### PR TITLE
fix(source-control): route hosted reviews by resolved execution host

### DIFF
--- a/src/main/azure-devops/pull-request-creation.test.ts
+++ b/src/main/azure-devops/pull-request-creation.test.ts
@@ -84,14 +84,18 @@ describe('Azure DevOps pull request creation', () => {
     globalThis.fetch = fetchMock as never
 
     await expect(
-      createAzureDevOpsPullRequest('/repo', {
-        provider: 'azure-devops',
-        base: 'origin/main',
-        head: 'refs/heads/feature/azure',
-        title: 'Add Azure create',
-        body: 'Body',
-        draft: true
-      })
+      createAzureDevOpsPullRequest(
+        '/repo',
+        {
+          provider: 'azure-devops',
+          base: 'origin/main',
+          head: 'refs/heads/feature/azure',
+          title: 'Add Azure create',
+          body: 'Body',
+          draft: true
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 37,
@@ -136,13 +140,17 @@ describe('Azure DevOps pull request creation', () => {
     globalThis.fetch = fetchMock as never
 
     await expect(
-      createAzureDevOpsPullRequest('/repo', {
-        provider: 'azure-devops',
-        base: 'main',
-        head: 'feature/server',
-        title: 'Server create',
-        body: 'Body'
-      })
+      createAzureDevOpsPullRequest(
+        '/repo',
+        {
+          provider: 'azure-devops',
+          base: 'main',
+          head: 'feature/server',
+          title: 'Server create',
+          body: 'Body'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 51,
@@ -161,12 +169,16 @@ describe('Azure DevOps pull request creation', () => {
     globalThis.fetch = fetchMock as never
 
     await expect(
-      createAzureDevOpsPullRequest('/repo', {
-        provider: 'azure-devops',
-        base: 'main',
-        head: 'feature/azure',
-        title: 'Do not retry'
-      })
+      createAzureDevOpsPullRequest(
+        '/repo',
+        {
+          provider: 'azure-devops',
+          base: 'main',
+          head: 'feature/azure',
+          title: 'Do not retry'
+        },
+        'local'
+      )
     ).resolves.toMatchObject({ ok: false, code: 'validation' })
     expect(fetchMock).toHaveBeenCalledOnce()
   })
@@ -197,7 +209,7 @@ describe('Azure DevOps pull request creation', () => {
           head: 'feature/azure',
           title: 'Remote Azure create'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toMatchObject({
       ok: true,
@@ -215,12 +227,16 @@ describe('Azure DevOps pull request creation', () => {
     ) as never
 
     await expect(
-      createAzureDevOpsPullRequest('/repo', {
-        provider: 'azure-devops',
-        base: 'main',
-        head: 'feature/azure',
-        title: 'Add Azure create'
-      })
+      createAzureDevOpsPullRequest(
+        '/repo',
+        {
+          provider: 'azure-devops',
+          base: 'main',
+          head: 'feature/azure',
+          title: 'Add Azure create'
+        },
+        'local'
+      )
     ).resolves.toMatchObject({
       ok: false,
       code: 'auth_required'

--- a/src/main/azure-devops/pull-request-creation.ts
+++ b/src/main/azure-devops/pull-request-creation.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
 import { Buffer } from 'node:buffer'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
@@ -169,7 +171,7 @@ async function findExistingPullRequest(
 export async function createAzureDevOpsPullRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
-  connectionId?: string | null
+  executionHostId: ExecutionHostId
 ): Promise<CreateHostedReviewResult> {
   if (input.provider !== 'azure-devops') {
     return {
@@ -178,6 +180,9 @@ export async function createAzureDevOpsPullRequest(
       error: 'Creating reviews for this provider is not supported yet.'
     }
   }
+
+  // The Azure DevOps REST calls run on this client; only the git reads under them are routed.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
 
   const repo = await getAzureDevOpsRepoRef(repoPath, connectionId)
   if (!repo) {

--- a/src/main/bitbucket/pull-request-creation.test.ts
+++ b/src/main/bitbucket/pull-request-creation.test.ts
@@ -81,7 +81,7 @@ describe('Bitbucket pull request creation', () => {
     })
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
-    await expect(createBitbucketPullRequest('/repo', CREATE_INPUT)).resolves.toEqual({
+    await expect(createBitbucketPullRequest('/repo', CREATE_INPUT, 'local')).resolves.toEqual({
       ok: true,
       number: 42,
       url: 'https://bitbucket.org/team/repo/pull-requests/42'
@@ -94,7 +94,7 @@ describe('Bitbucket pull request creation', () => {
     const fetchMock = vi.fn(async () => createdPullRequestResponse())
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
-    const result = await createBitbucketPullRequest('/repo', CREATE_INPUT)
+    const result = await createBitbucketPullRequest('/repo', CREATE_INPUT, 'local')
 
     // No env var and no stored credential: fail closed rather than POST anonymously.
     expect(result).toMatchObject({ ok: false, code: 'auth_required' })
@@ -108,7 +108,7 @@ describe('Bitbucket pull request creation', () => {
     // Why: the composer hides the Draft toggle for Bitbucket, so a `true` here
     // is an unreachable persisted default the user cannot clear.
     await expect(
-      createBitbucketPullRequest('/repo', { ...CREATE_INPUT, draft: true })
+      createBitbucketPullRequest('/repo', { ...CREATE_INPUT, draft: true }, 'local')
     ).resolves.toMatchObject({ ok: true, number: 42 })
     expect(JSON.parse(String((fetchMock.mock.calls[0] as never[])[1]['body']))).not.toHaveProperty(
       'draft'
@@ -147,7 +147,7 @@ describe('Bitbucket pull request creation', () => {
     })
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
-    expect(await createBitbucketPullRequest('/repo', CREATE_INPUT)).toMatchObject({
+    expect(await createBitbucketPullRequest('/repo', CREATE_INPUT, 'local')).toMatchObject({
       ok: false,
       code: 'already_exists',
       existingReview: { number: 7, url: 'https://bitbucket.org/team/repo/pull-requests/7' }
@@ -159,7 +159,7 @@ describe('Bitbucket pull request creation', () => {
       Response.json({ error: { message: 'Unauthorized' } }, { status: 401 })
     ) as unknown as typeof fetch
 
-    const result = await createBitbucketPullRequest('/repo', CREATE_INPUT)
+    const result = await createBitbucketPullRequest('/repo', CREATE_INPUT, 'local')
 
     expect(result).toMatchObject({ ok: false, code: 'auth_required' })
     expect(!result.ok && result.error).toContain('Settings')
@@ -172,9 +172,11 @@ describe('Bitbucket pull request creation', () => {
     })
     globalThis.fetch = vi.fn() as unknown as typeof fetch
 
-    await expect(createBitbucketPullRequest('/repo', CREATE_INPUT)).resolves.toMatchObject({
-      ok: false,
-      code: 'unsupported_provider'
-    })
+    await expect(createBitbucketPullRequest('/repo', CREATE_INPUT, 'local')).resolves.toMatchObject(
+      {
+        ok: false,
+        code: 'unsupported_provider'
+      }
+    )
   })
 })

--- a/src/main/bitbucket/pull-request-creation.ts
+++ b/src/main/bitbucket/pull-request-creation.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
   normalizeHostedReviewBaseRef,
@@ -108,7 +110,7 @@ async function findExistingPullRequest(
 export async function createBitbucketPullRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateHostedReviewResult> {
   if (input.provider !== 'bitbucket') {
@@ -118,6 +120,9 @@ export async function createBitbucketPullRequest(
       error: 'Creating reviews for this provider is not supported yet.'
     }
   }
+
+  // The Bitbucket REST calls run on this client; only the git reads under them are routed.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
 
   const config = resolveBitbucketAuthConfig()
   if (!hasAuth(config)) {

--- a/src/main/gitea/pull-request-creation.test.ts
+++ b/src/main/gitea/pull-request-creation.test.ts
@@ -82,14 +82,18 @@ describe('Gitea pull request creation', () => {
     globalThis.fetch = fetchMock as never
 
     await expect(
-      createGiteaPullRequest('/repo', {
-        provider: 'gitea',
-        base: 'origin/main',
-        head: 'refs/heads/feature/gitea',
-        title: 'Add Gitea create',
-        body: 'Body',
-        draft: true
-      })
+      createGiteaPullRequest(
+        '/repo',
+        {
+          provider: 'gitea',
+          base: 'origin/main',
+          head: 'refs/heads/feature/gitea',
+          title: 'Add Gitea create',
+          body: 'Body',
+          draft: true
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 13,
@@ -126,7 +130,7 @@ describe('Gitea pull request creation', () => {
           head: 'feature/gitea',
           title: 'Remote Gitea create'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toMatchObject({
       ok: true,
@@ -144,12 +148,16 @@ describe('Gitea pull request creation', () => {
     ) as never
 
     await expect(
-      createGiteaPullRequest('/repo', {
-        provider: 'gitea',
-        base: 'main',
-        head: 'feature/gitea',
-        title: 'Add Gitea create'
-      })
+      createGiteaPullRequest(
+        '/repo',
+        {
+          provider: 'gitea',
+          base: 'main',
+          head: 'feature/gitea',
+          title: 'Add Gitea create'
+        },
+        'local'
+      )
     ).resolves.toMatchObject({
       ok: false,
       code: 'validation'

--- a/src/main/gitea/pull-request-creation.ts
+++ b/src/main/gitea/pull-request-creation.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
   normalizeHostedReviewBaseRef,
@@ -118,7 +120,7 @@ async function findExistingPullRequest(
 export async function createGiteaPullRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
-  connectionId?: string | null
+  executionHostId: ExecutionHostId
 ): Promise<CreateHostedReviewResult> {
   if (input.provider !== 'gitea') {
     return {
@@ -127,6 +129,9 @@ export async function createGiteaPullRequest(
       error: 'Creating reviews for this provider is not supported yet.'
     }
   }
+
+  // The Gitea REST calls run on this client; only the git reads under them are routed.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
 
   const repo = await getGiteaRepoRef(repoPath, connectionId)
   if (!repo) {

--- a/src/main/github/client-create-pr.test.ts
+++ b/src/main/github/client-create-pr.test.ts
@@ -102,14 +102,18 @@ describe('createGitHubPullRequest', () => {
     })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'origin/main',
-        head: 'refs/heads/feature/create-pr',
-        title: '  Create PR UI  ',
-        body: 'Body text',
-        draft: true
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'origin/main',
+          head: 'refs/heads/feature/create-pr',
+          title: '  Create PR UI  ',
+          body: 'Body text',
+          draft: true
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 42,
@@ -159,12 +163,16 @@ describe('createGitHubPullRequest', () => {
     })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'main',
-        head: 'my-branch',
-        title: 'Fork PR'
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'my-branch',
+          title: 'Fork PR'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 5,
@@ -191,12 +199,16 @@ describe('createGitHubPullRequest', () => {
     })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature/create-pr',
-        title: 'GHES PR'
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature/create-pr',
+          title: 'GHES PR'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 7,
@@ -232,12 +244,16 @@ describe('createGitHubPullRequest', () => {
       })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature/create-pr',
-        title: 'GHES PR'
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature/create-pr',
+          title: 'GHES PR'
+        },
+        'local'
+      )
     ).resolves.toMatchObject({
       ok: false,
       code: 'already_exists',
@@ -268,7 +284,7 @@ describe('createGitHubPullRequest', () => {
           head: 'feature/wsl-create-pr',
           title: 'WSL Create PR'
         },
-        null,
+        'local',
         { localGitExecOptions: { wslDistro: 'Ubuntu' } }
       )
     ).resolves.toEqual({
@@ -304,7 +320,7 @@ describe('createGitHubPullRequest', () => {
           head: 'feature/ssh-create-pr',
           title: 'SSH Create PR'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -393,7 +409,7 @@ describe('createGitHubPullRequest', () => {
             body: '',
             useTemplate: true
           },
-          'ssh-1'
+          'ssh:ssh-1'
         )
       ).resolves.toEqual({
         ok: true,
@@ -415,12 +431,16 @@ describe('createGitHubPullRequest', () => {
     })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature/url-output',
-        title: 'URL output'
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature/url-output',
+          title: 'URL output'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 43,
@@ -442,12 +462,16 @@ describe('createGitHubPullRequest', () => {
       })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'main',
-        head: 'refs/remotes/origin/feature/existing',
-        title: 'Existing'
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'refs/remotes/origin/feature/existing',
+          title: 'Existing'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'already_exists',
@@ -485,12 +509,16 @@ describe('createGitHubPullRequest', () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
 
     await expect(
-      createGitHubPullRequest('/repo-root', {
-        provider: 'github',
-        base: 'refs/heads/feature',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createGitHubPullRequest(
+        '/repo-root',
+        {
+          provider: 'github',
+          base: 'refs/heads/feature',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'validation',

--- a/src/main/github/client/create/create-github-pull-request.ts
+++ b/src/main/github/client/create/create-github-pull-request.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../../../source-control/hosted-review-execution-host'
 import type {
   CreateHostedReviewInput,
   CreateHostedReviewResult
@@ -26,7 +28,7 @@ import { findOpenPRByHeadBase, readPullRequestTemplate } from './pull-request-te
 export async function createGitHubPullRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateHostedReviewResult> {
   if (input.provider !== 'github') {
@@ -36,6 +38,9 @@ export async function createGitHubPullRequest(
       error: 'Creating reviews for this provider is not supported yet.'
     }
   }
+
+  // `gh` runs on this client whatever the host; only the git reads under it are routed.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
 
   // Why: creation targets the origin owning the unqualified head branch; the shared resolver preserves its host (#7331, #8312).
   const ownerRepo = await getOriginGitHubApiRepository(

--- a/src/main/github/stacked-pr-creation.test.ts
+++ b/src/main/github/stacked-pr-creation.test.ts
@@ -65,12 +65,16 @@ describe('prepareGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: JSON.stringify([stack(50, [40, 41])]) })
       .mockResolvedValueOnce({ stdout: '[]' })
 
-    const result = await prepareGitHubStackedPullRequest('/repo', {
-      provider: 'github',
-      base: 'origin/stack/parent',
-      head: 'refs/heads/stack/child',
-      title: 'Child'
-    })
+    const result = await prepareGitHubStackedPullRequest(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'origin/stack/parent',
+        head: 'refs/heads/stack/child',
+        title: 'Child'
+      },
+      'local'
+    )
 
     expect(result).toMatchObject({
       ok: true,
@@ -96,12 +100,16 @@ describe('prepareGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: JSON.stringify([stack(50, [41, 42])]) })
       .mockResolvedValueOnce({ stdout: JSON.stringify([stack(50, [41, 42])]) })
 
-    const result = await prepareGitHubStackedPullRequest('/repo', {
-      provider: 'github',
-      base: 'stack/parent',
-      head: 'stack/child',
-      title: 'Child'
-    })
+    const result = await prepareGitHubStackedPullRequest(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'stack/parent',
+        head: 'stack/child',
+        title: 'Child'
+      },
+      'local'
+    )
 
     expect(result).toMatchObject({ ok: true, currentReview: { number: 42 } })
   })
@@ -111,12 +119,16 @@ describe('prepareGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: '[]' })
       .mockResolvedValueOnce({ stdout: '[]' })
 
-    const result = await prepareGitHubStackedPullRequest('/repo', {
-      provider: 'github',
-      base: 'feature/parent',
-      head: 'feature/child',
-      title: 'Child'
-    })
+    const result = await prepareGitHubStackedPullRequest(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'feature/parent',
+        head: 'feature/child',
+        title: 'Child'
+      },
+      'local'
+    )
 
     expect(result).toMatchObject({ ok: false, code: 'validation' })
     if (!result.ok) {
@@ -130,12 +142,16 @@ describe('prepareGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: '[]' })
       .mockResolvedValueOnce({ stdout: JSON.stringify([stack(50, [41, 45])]) })
 
-    const result = await prepareGitHubStackedPullRequest('/repo', {
-      provider: 'github',
-      base: 'stack/parent',
-      head: 'stack/child',
-      title: 'Child'
-    })
+    const result = await prepareGitHubStackedPullRequest(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'stack/parent',
+        head: 'stack/child',
+        title: 'Child'
+      },
+      'local'
+    )
 
     expect(result).toMatchObject({ ok: false, code: 'validation' })
     if (!result.ok) {
@@ -150,12 +166,16 @@ describe('prepareGitHubStackedPullRequest', () => {
       host: 'github.acme.test'
     })
 
-    const result = await prepareGitHubStackedPullRequest('/repo', {
-      provider: 'github',
-      base: 'stack/parent',
-      head: 'stack/child',
-      title: 'Child'
-    })
+    const result = await prepareGitHubStackedPullRequest(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'stack/parent',
+        head: 'stack/child',
+        title: 'Child'
+      },
+      'local'
+    )
 
     expect(result).toMatchObject({ ok: false, code: 'validation' })
     expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
@@ -170,6 +190,7 @@ describe('registerGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: JSON.stringify({ number: 50 }) })
 
     const result = await registerGitHubStackedPullRequest({
+      executionHostId: 'local',
       repoPath: '/repo',
       repository,
       parentReview,
@@ -200,7 +221,7 @@ describe('registerGitHubStackedPullRequest', () => {
       repository,
       parentReview,
       currentReview,
-      connectionId: 'ssh-1'
+      executionHostId: 'ssh:ssh-1'
     })
 
     expect(result).toMatchObject({ ok: true, stackNumber: 50 })
@@ -221,6 +242,7 @@ describe('registerGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: JSON.stringify([stack(50, [41, 42])]) })
 
     const result = await registerGitHubStackedPullRequest({
+      executionHostId: 'local',
       repoPath: '/repo',
       repository,
       parentReview,
@@ -239,6 +261,7 @@ describe('registerGitHubStackedPullRequest', () => {
       .mockResolvedValueOnce({ stdout: JSON.stringify([stack(50, [42])]) })
 
     const result = await registerGitHubStackedPullRequest({
+      executionHostId: 'local',
       repoPath: '/repo',
       repository,
       parentReview,
@@ -259,6 +282,7 @@ describe('registerGitHubStackedPullRequest', () => {
       .mockRejectedValueOnce(new Error('HTTP 422'))
 
     const result = await registerGitHubStackedPullRequest({
+      executionHostId: 'local',
       repoPath: '/repo',
       repository,
       parentReview,

--- a/src/main/github/stacked-pr-creation.ts
+++ b/src/main/github/stacked-pr-creation.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
 import type {
   CreateStackedHostedReviewInput,
   CreateStackedHostedReviewResult
@@ -116,12 +118,14 @@ function validateParentStack(
 export async function prepareGitHubStackedPullRequest(
   repoPath: string,
   input: CreateStackedHostedReviewInput,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<StackedPullRequestPlan> {
   if (input.provider !== 'github') {
     return creationError('Stacked pull request creation is available only for GitHub repositories.')
   }
+  // `gh` runs on this client whatever the host; only the git reads under it are routed.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
   const repository = await getOriginGitHubApiRepository(
     repoPath,
     connectionId,
@@ -222,10 +226,11 @@ export async function registerGitHubStackedPullRequest(args: {
   repository: GitHubApiRepository
   parentReview: NumberedHostedReviewSummary
   currentReview: NumberedHostedReviewSummary
-  connectionId?: string | null
+  executionHostId: ExecutionHostId
   options?: HostedReviewExecutionOptions
 }): Promise<CreateStackedHostedReviewResult> {
   const options = args.options ?? {}
+  const connectionId = hostedReviewSshConnectionId(args.executionHostId)
   await acquire()
   try {
     const [parentStacks, currentStacks] = await Promise.all([
@@ -233,14 +238,14 @@ export async function registerGitHubStackedPullRequest(args: {
         args.repoPath,
         args.repository,
         args.parentReview.number,
-        args.connectionId,
+        connectionId,
         options
       ),
       getStacksForPullRequest(
         args.repoPath,
         args.repository,
         args.currentReview.number,
-        args.connectionId,
+        connectionId,
         options
       )
     ])
@@ -281,7 +286,7 @@ export async function registerGitHubStackedPullRequest(args: {
       command.push('-F', `pull_requests[]=${pullRequest}`)
     }
     const { stdout } = await ghExecFileAsync(command, {
-      ...ghOptions(args.repoPath, args.repository, args.connectionId, options),
+      ...ghOptions(args.repoPath, args.repository, connectionId, options),
       idempotent: false
     })
     const stackNumber = Number((JSON.parse(stdout) as { number?: unknown }).number)

--- a/src/main/gitlab/merge-request-creation.test.ts
+++ b/src/main/gitlab/merge-request-creation.test.ts
@@ -58,14 +58,18 @@ describe('createGitLabMergeRequest', () => {
     })
 
     await expect(
-      createGitLabMergeRequest('/repo-root', {
-        provider: 'gitlab',
-        base: 'origin/main',
-        head: 'refs/heads/feature/create-mr',
-        title: '  Create MR UI  ',
-        body: 'Body text',
-        draft: true
-      })
+      createGitLabMergeRequest(
+        '/repo-root',
+        {
+          provider: 'gitlab',
+          base: 'origin/main',
+          head: 'refs/heads/feature/create-mr',
+          title: '  Create MR UI  ',
+          body: 'Body text',
+          draft: true
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 42,
@@ -115,7 +119,7 @@ describe('createGitLabMergeRequest', () => {
           head: 'feature/wsl-create-mr',
           title: 'WSL Create MR'
         },
-        null,
+        'local',
         { localGitExecOptions: { wslDistro: 'Ubuntu' } }
       )
     ).resolves.toEqual({
@@ -151,7 +155,7 @@ describe('createGitLabMergeRequest', () => {
           head: 'feature/ssh-create-mr',
           title: 'SSH Create MR'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -204,7 +208,7 @@ describe('createGitLabMergeRequest', () => {
           body: '',
           useTemplate: true
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -233,12 +237,16 @@ describe('createGitLabMergeRequest', () => {
       })
 
     await expect(
-      createGitLabMergeRequest('/repo-root', {
-        provider: 'gitlab',
-        base: 'main',
-        head: 'feature/existing',
-        title: 'Existing MR'
-      })
+      createGitLabMergeRequest(
+        '/repo-root',
+        {
+          provider: 'gitlab',
+          base: 'main',
+          head: 'feature/existing',
+          title: 'Existing MR'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'already_exists',

--- a/src/main/gitlab/merge-request-creation.ts
+++ b/src/main/gitlab/merge-request-creation.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { hostedReviewSshConnectionId } from '../source-control/hosted-review-execution-host'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
@@ -124,7 +126,7 @@ async function readMergeRequestTemplate(
 export async function createGitLabMergeRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateHostedReviewResult> {
   if (input.provider !== 'gitlab') {
@@ -134,6 +136,9 @@ export async function createGitLabMergeRequest(
       error: 'Creating reviews for this provider is not supported yet.'
     }
   }
+
+  // `glab` runs on this client whatever the host; only the git reads under it are routed.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
 
   const projectRef = await getProjectSlug(
     repoPath,

--- a/src/main/ipc/hosted-review.test.ts
+++ b/src/main/ipc/hosted-review.test.ts
@@ -170,7 +170,7 @@ describe('registerHostedReviewHandlers', () => {
         head: 'feature/pr',
         title: 'Feature PR'
       }),
-      null,
+      'local',
       { localGitExecOptions: { wslDistro: 'Ubuntu', admissionTier: 'interactive' } }
     )
   })
@@ -211,7 +211,7 @@ describe('registerHostedReviewHandlers', () => {
     expect(createHostedReviewMock).toHaveBeenCalledWith(
       resolvedWorktreePath,
       expect.anything(),
-      null,
+      'local',
       {
         localGitExecOptions: { admissionTier: 'interactive' },
         sharedLinkPaths: ['node_modules']
@@ -239,9 +239,14 @@ describe('registerHostedReviewHandlers', () => {
       title: 'Feature PR'
     })
 
-    expect(createHostedReviewMock).toHaveBeenCalledWith(worktreePath, expect.anything(), 'ssh-1', {
-      localGitExecOptions: { admissionTier: 'interactive' }
-    })
+    expect(createHostedReviewMock).toHaveBeenCalledWith(
+      worktreePath,
+      expect.anything(),
+      'ssh:ssh-1',
+      {
+        localGitExecOptions: { admissionTier: 'interactive' }
+      }
+    )
   })
 
   it('routes local WSL project review status through main-process runtime options', async () => {
@@ -291,7 +296,7 @@ describe('registerHostedReviewHandlers', () => {
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         repoPath: localRepo.path,
-        connectionId: undefined,
+        executionHostId: 'local',
         branch: 'feature/wsl',
         linkedGitHubPR: 42,
         localGitExecOptions: { wslDistro: 'Ubuntu', admissionTier: 'background' }
@@ -352,7 +357,7 @@ describe('registerHostedReviewHandlers', () => {
     })
 
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ connectionId: 'ssh-1', branch: 'feature/owner' })
+      expect.objectContaining({ executionHostId: 'ssh:ssh-1', branch: 'feature/owner' })
     )
   })
 
@@ -396,7 +401,7 @@ describe('registerHostedReviewHandlers', () => {
     expect(getHostedReviewCreationEligibilityMock).toHaveBeenCalledWith(
       expect.objectContaining({
         repoPath: worktreePath,
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'feature/pr',
         base: 'main'
       })
@@ -435,7 +440,7 @@ describe('registerHostedReviewHandlers', () => {
         body: null,
         draft: false
       },
-      'ssh-1',
+      'ssh:ssh-1',
       { localGitExecOptions: { admissionTier: 'interactive' } }
     )
     expect(resolveRegisteredWorktreePathMock).not.toHaveBeenCalled()
@@ -471,7 +476,7 @@ describe('registerHostedReviewHandlers', () => {
     expect(createStackedHostedReviewMock).toHaveBeenCalledWith(
       worktreePath,
       expect.objectContaining({ base: 'stack/parent', head: 'stack/child' }),
-      'ssh-1',
+      'ssh:ssh-1',
       { localGitExecOptions: { admissionTier: 'interactive' } }
     )
     expect(createHostedReviewMock).not.toHaveBeenCalled()

--- a/src/main/ipc/hosted-review.ts
+++ b/src/main/ipc/hosted-review.ts
@@ -19,7 +19,8 @@ import { resolveRegisteredWorktreePath } from './registered-worktree-roots-cache
 import { listRepoWorktreeGraph } from '../repo-worktrees'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
 import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
-import { getRepoExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, getRepoSshConnectionId } from '../../shared/execution-host'
+import { getRepoHostedReviewExecutionHostId } from '../source-control/hosted-review-execution-host'
 
 function assertRegisteredRepo(repoPath: string, store: Store, repoId?: string): Repo {
   if (repoId) {
@@ -42,7 +43,9 @@ function assertRegisteredRepoForBranch(args: HostedReviewForBranchArgs, store: S
     return assertRegisteredRepo(args.repoPath, store, args.repoId)
   }
   const matches = store.getRepos().filter((candidate) => {
-    const samePath = candidate.connectionId
+    // Which host holds the files, not which this client may dial: a remote path is POSIX and
+    // `resolve()` would rewrite it, and a row can name its SSH owner in either spelling.
+    const samePath = getRepoSshConnectionId(candidate)
       ? normalizeRemoteHostedReviewPath(candidate.path) ===
         normalizeRemoteHostedReviewPath(args.repoPath)
       : resolve(candidate.path) === resolve(args.repoPath)
@@ -66,7 +69,7 @@ async function resolveHostedReviewWorktreePath(
   if (!worktreePath) {
     return repo.path
   }
-  if (repo.connectionId) {
+  if (getRepoSshConnectionId(repo)) {
     const remoteWorktreePath = normalizeRemoteHostedReviewPath(worktreePath)
     const repoWorktrees = await listRepoWorktreeGraph(repo)
     if (
@@ -109,7 +112,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
     }
     const review = await getHostedReviewForBranch({
       repoPath: repo.path,
-      connectionId: repo.connectionId,
+      executionHostId: getRepoHostedReviewExecutionHostId(repo),
       branch: args.branch,
       linkedGitHubPR: args.linkedGitHubPR ?? null,
       fallbackGitHubPR: args.linkedGitHubPR == null ? (args.fallbackGitHubPR ?? null) : null,
@@ -141,7 +144,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       return getHostedReviewCreationEligibility({
         ...args,
         repoPath: worktreePath,
-        connectionId: repo.connectionId ?? null,
+        executionHostId: getRepoHostedReviewExecutionHostId(repo),
         localGitExecOptions: { ...localGitOptions, admissionTier: 'interactive' as const }
       })
     }
@@ -158,7 +161,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
     // Remote creation never materializes them, and `repo.path` is a path on the
     // remote host — reading it locally would resolve an unrelated `orca.yaml`.
     // Not dead code: SSH ignores these, so this only prevents that read and a poisoned cache entry.
-    const sharedLinkPaths = repo.connectionId ? [] : getWorktreeSharedLinkPaths(repo)
+    const sharedLinkPaths = getRepoSshConnectionId(repo) ? [] : getWorktreeSharedLinkPaths(repo)
     const executionOptions =
       Object.keys(localGitOptions).length > 0 || sharedLinkPaths.length > 0
         ? {
@@ -177,9 +180,10 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       draft: args.draft,
       ...(args.useTemplate !== undefined ? { useTemplate: args.useTemplate } : {})
     }
+    const executionHostId = getRepoHostedReviewExecutionHostId(repo)
     const result = executionOptions
-      ? await createHostedReview(worktreePath, input, repo.connectionId ?? null, executionOptions)
-      : await createHostedReview(worktreePath, input, repo.connectionId ?? null)
+      ? await createHostedReview(worktreePath, input, executionHostId, executionOptions)
+      : await createHostedReview(worktreePath, input, executionHostId)
     if (result.ok && !stats.hasCountedPR(result.url)) {
       stats.record({
         type: 'pr_created',
@@ -200,7 +204,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
         ...getLocalProjectWorktreeGitOptions(store, repo),
         admissionTier: 'interactive' as const
       }
-      const sharedLinkPaths = repo.connectionId ? [] : getWorktreeSharedLinkPaths(repo)
+      const sharedLinkPaths = getRepoSshConnectionId(repo) ? [] : getWorktreeSharedLinkPaths(repo)
       const executionOptions = {
         ...(Object.keys(localGitOptions).length > 0
           ? { localGitExecOptions: localGitOptions }
@@ -219,7 +223,7 @@ export function registerHostedReviewHandlers(store: Store, stats: StatsCollector
       const result = await createStackedHostedReview(
         worktreePath,
         input,
-        repo.connectionId ?? null,
+        getRepoHostedReviewExecutionHostId(repo),
         executionOptions
       )
       if (result.ok && !stats.hasCountedPR(result.url)) {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 // Why: worktree create helpers (local + remote) split out of worktrees.ts; the cohesive create flow runs this file just over the per-file line limit.
 
+import { getRepoHostedReviewExecutionHostId } from '../source-control/hosted-review-execution-host'
 import type { BrowserWindow } from 'electron'
 import { posix, win32 } from 'node:path'
 import { existsSync } from 'node:fs'
@@ -955,7 +956,7 @@ function getSelectedReviewLookupHints(args: SelectedReviewBranchInput): {
 }
 
 async function getSelectedHostedReviewForBranch(
-  repo: Pick<Repo, 'path' | 'connectionId'>,
+  repo: Pick<Repo, 'path' | 'connectionId' | 'executionHostId'>,
   branchName: string,
   args: SelectedReviewBranchInput
 ): Promise<{ matchesSelected: boolean; number: number } | null> {
@@ -965,7 +966,7 @@ async function getSelectedHostedReviewForBranch(
   }
   const review = await getHostedReviewForBranch({
     repoPath: repo.path,
-    connectionId: repo.connectionId ?? null,
+    executionHostId: getRepoHostedReviewExecutionHostId(repo),
     branch: branchName,
     ...getSelectedReviewLookupHints(args)
   })

--- a/src/main/runtime/orca-runtime-tests/hooks-and-hosted-review-part-02.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/hooks-and-hosted-review-part-02.spec.ts
@@ -433,7 +433,7 @@ describe('OrcaRuntimeService', () => {
     expect(getHostedReviewCreationEligibilityMock).toHaveBeenCalledWith(
       expect.objectContaining({
         repoPath: '/remote/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'feature/ssh'
       })
     )
@@ -444,7 +444,7 @@ describe('OrcaRuntimeService', () => {
         head: 'feature/ssh',
         title: 'Feature SSH'
       }),
-      'ssh-1',
+      'ssh:ssh-1',
       { localGitExecOptions: { admissionTier: 'interactive' } }
     )
     expect(createStackedHostedReviewMock).toHaveBeenCalledWith(
@@ -454,7 +454,7 @@ describe('OrcaRuntimeService', () => {
         base: 'stack/parent',
         head: 'feature/ssh'
       }),
-      'ssh-1',
+      'ssh:ssh-1',
       { localGitExecOptions: { admissionTier: 'interactive' } }
     )
   })
@@ -532,7 +532,7 @@ describe('OrcaRuntimeService', () => {
     expect(getHostedReviewCreationEligibilityMock).toHaveBeenCalledWith(
       expect.objectContaining({
         repoPath: TEST_REPO_PATH,
-        connectionId: null,
+        executionHostId: 'local',
         branch: 'feature/wsl',
         localGitExecOptions: { wslDistro: 'Ubuntu', admissionTier: 'interactive' }
       })
@@ -540,7 +540,7 @@ describe('OrcaRuntimeService', () => {
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
       expect.objectContaining({
         repoPath: TEST_REPO_PATH,
-        connectionId: null,
+        executionHostId: 'local',
         branch: 'feature/wsl',
         linkedGitHubPR: 76,
         localGitExecOptions: { wslDistro: 'Ubuntu', admissionTier: 'background' }
@@ -553,7 +553,7 @@ describe('OrcaRuntimeService', () => {
         head: 'feature/wsl',
         title: 'Feature WSL'
       }),
-      null,
+      'local',
       { localGitExecOptions: { wslDistro: 'Ubuntu', admissionTier: 'interactive' } }
     )
     expect(createStackedHostedReviewMock).toHaveBeenCalledWith(
@@ -563,7 +563,7 @@ describe('OrcaRuntimeService', () => {
         base: 'stack/parent',
         head: 'feature/wsl'
       }),
-      null,
+      'local',
       { localGitExecOptions: { wslDistro: 'Ubuntu', admissionTier: 'interactive' } }
     )
   })

--- a/src/main/runtime/runtime-hosted-review-commands.ts
+++ b/src/main/runtime/runtime-hosted-review-commands.ts
@@ -23,6 +23,10 @@ import { admissionTierForRefreshReason } from '../github/pr-refresh-candidate-po
 import type { GitAdmissionTier } from '../git/command-runner/git-exec-options'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
 import {
+  getRepoHostedReviewExecutionHostId,
+  hostedReviewSshConnectionId
+} from '../source-control/hosted-review-execution-host'
+import {
   createHostedReview,
   getHostedReviewCreationEligibility
 } from '../source-control/hosted-review-creation'
@@ -47,17 +51,19 @@ export class RuntimeHostedReviewCommands {
   async getRepoSlug(repoSelector: string): Promise<GitHubOwnerRepo | null> {
     const repo = await this.deps.resolveRepo(repoSelector)
     const options = this.deps.getExecutionOptions(repo)
+    const connectionId = hostedReviewSshConnectionId(getRepoHostedReviewExecutionHostId(repo))
     return options
-      ? getRepoSlug(repo.path, repo.connectionId ?? null, options)
-      : getRepoSlug(repo.path, repo.connectionId ?? null)
+      ? getRepoSlug(repo.path, connectionId, options)
+      : getRepoSlug(repo.path, connectionId)
   }
 
   async getRepoUpstream(repoSelector: string): Promise<GitHubOwnerRepo | null> {
     const repo = await this.deps.resolveRepo(repoSelector)
     const options = this.deps.getExecutionOptions(repo)
+    const connectionId = hostedReviewSshConnectionId(getRepoHostedReviewExecutionHostId(repo))
     return options
-      ? getRepoUpstream(repo.path, repo.connectionId ?? null, options)
-      : getRepoUpstream(repo.path, repo.connectionId ?? null)
+      ? getRepoUpstream(repo.path, connectionId, options)
+      : getRepoUpstream(repo.path, connectionId)
   }
 
   async getRepoPRForBranch(
@@ -88,7 +94,7 @@ export class RuntimeHostedReviewCommands {
       repo.path,
       branch,
       linkedPRNumber ?? null,
-      repo.connectionId ?? null,
+      hostedReviewSshConnectionId(getRepoHostedReviewExecutionHostId(repo)),
       linkedPRNumber == null ? (fallbackPRNumber ?? null) : null,
       ...lookupOptionArgs
     )
@@ -111,7 +117,7 @@ export class RuntimeHostedReviewCommands {
     const executionOptions = this.deps.getExecutionOptions(repo, args.admissionTier ?? 'background')
     const review = await getHostedReviewForBranch({
       repoPath: repo.path,
-      connectionId: repo.connectionId ?? null,
+      executionHostId: getRepoHostedReviewExecutionHostId(repo),
       branch: args.branch,
       currentHeadOid: args.currentHeadOid ?? null,
       ...(args.active === true ? { active: true } : {}),
@@ -136,7 +142,7 @@ export class RuntimeHostedReviewCommands {
     const executionOptions = this.deps.getExecutionOptions(repo, 'interactive')
     return getHostedReviewCreationEligibility({
       repoPath,
-      connectionId: repo.connectionId ?? null,
+      executionHostId: getRepoHostedReviewExecutionHostId(repo),
       branch: args.branch,
       base: args.base ?? null,
       hasUncommittedChanges: args.hasUncommittedChanges,
@@ -167,9 +173,10 @@ export class RuntimeHostedReviewCommands {
       draft: args.draft,
       ...(args.useTemplate !== undefined ? { useTemplate: args.useTemplate } : {})
     }
+    const executionHostId = getRepoHostedReviewExecutionHostId(repo)
     const result = executionOptions
-      ? await createHostedReview(repoPath, input, repo.connectionId ?? null, executionOptions)
-      : await createHostedReview(repoPath, input, repo.connectionId ?? null)
+      ? await createHostedReview(repoPath, input, executionHostId, executionOptions)
+      : await createHostedReview(repoPath, input, executionHostId)
     if (result.ok) {
       this.deps.recordCreated(repo.id, result.number, result.url)
     }
@@ -192,7 +199,7 @@ export class RuntimeHostedReviewCommands {
         draft: args.draft,
         ...(args.useTemplate !== undefined ? { useTemplate: args.useTemplate } : {})
       },
-      repo.connectionId ?? null,
+      getRepoHostedReviewExecutionHostId(repo),
       executionOptions ?? {}
     )
     if (result.ok) {

--- a/src/main/runtime/runtime-worktree-create-git.ts
+++ b/src/main/runtime/runtime-worktree-create-git.ts
@@ -1,3 +1,4 @@
+import { getRepoHostedReviewExecutionHostId } from '../source-control/hosted-review-execution-host'
 import type { BranchPrefixStrategy } from '../../shared/ui-chrome-types'
 import type { Repo } from '../../shared/repo-types'
 import { getPRForBranch } from '../github/client'
@@ -87,7 +88,7 @@ export function getLocalGitHubPrForBranch(
 }
 
 export async function getSelectedHostedReviewForBranch(
-  repo: Pick<Repo, 'path' | 'connectionId'>,
+  repo: Pick<Repo, 'path' | 'connectionId' | 'executionHostId'>,
   branchName: string,
   args: SelectedReviewBranchInput,
   executionOptions: HostedReviewExecutionOptions = {}
@@ -98,7 +99,7 @@ export async function getSelectedHostedReviewForBranch(
   }
   const review = await getHostedReviewForBranch({
     repoPath: repo.path,
-    connectionId: repo.connectionId ?? null,
+    executionHostId: getRepoHostedReviewExecutionHostId(repo),
     branch: branchName,
     ...executionOptions,
     ...getSelectedReviewLookupHints(args)

--- a/src/main/source-control/forge-provider.test.ts
+++ b/src/main/source-control/forge-provider.test.ts
@@ -125,8 +125,12 @@ describe('forge provider interface', () => {
     getProjectSlugMock.mockResolvedValue({ host: 'gitlab.com', path: 'team/orca' })
     getRepoSlugMock.mockResolvedValue({ owner: 'team', repo: 'orca' })
 
-    await expect(detectHostedReviewProvider({ repoPath: '/repo' })).resolves.toBe('gitlab')
-    await expect(getForgeProviderForRepository({ repoPath: '/repo' })).resolves.toMatchObject({
+    await expect(
+      detectHostedReviewProvider({ executionHostId: 'local', repoPath: '/repo' })
+    ).resolves.toBe('gitlab')
+    await expect(
+      getForgeProviderForRepository({ executionHostId: 'local', repoPath: '/repo' })
+    ).resolves.toMatchObject({
       id: 'gitlab'
     })
     expect(getRepoSlugMock).not.toHaveBeenCalled()
@@ -145,8 +149,12 @@ describe('forge provider interface', () => {
       host: 'github.acme-corp.com'
     })
 
-    await expect(detectHostedReviewProvider({ repoPath: '/repo' })).resolves.toBe('github')
-    await expect(getForgeProviderForRepository({ repoPath: '/repo' })).resolves.toMatchObject({
+    await expect(
+      detectHostedReviewProvider({ executionHostId: 'local', repoPath: '/repo' })
+    ).resolves.toBe('github')
+    await expect(
+      getForgeProviderForRepository({ executionHostId: 'local', repoPath: '/repo' })
+    ).resolves.toMatchObject({
       id: 'github'
     })
     // Gitea must never be consulted once GitHub claims the enterprise host.
@@ -169,7 +177,9 @@ describe('forge provider interface', () => {
       webBaseUrl: 'https://gitea.example.com'
     })
 
-    await expect(detectHostedReviewProvider({ repoPath: '/repo' })).resolves.toBe('gitea')
+    await expect(
+      detectHostedReviewProvider({ executionHostId: 'local', repoPath: '/repo' })
+    ).resolves.toBe('gitea')
   })
 
   it('keeps review creation capability scoped to providers with creation support', async () => {
@@ -196,23 +206,31 @@ describe('forge provider interface', () => {
 
     const provider = getForgeProviderById('github')
     await expect(
-      provider.createReview?.('/repo', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature/provider-interface',
-        title: 'Add provider interface'
-      })
+      provider.createReview?.(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature/provider-interface',
+          title: 'Add provider interface'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 12,
       url: 'https://github.com/team/orca/pull/12'
     })
-    expect(createGitHubPullRequestMock).toHaveBeenCalledWith('/repo', {
-      provider: 'github',
-      base: 'main',
-      head: 'feature/provider-interface',
-      title: 'Add provider interface'
-    })
+    expect(createGitHubPullRequestMock).toHaveBeenCalledWith(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/provider-interface',
+        title: 'Add provider interface'
+      },
+      'local'
+    )
   })
 
   it('routes Bitbucket review creation through the shared provider contract', async () => {
@@ -229,12 +247,12 @@ describe('forge provider interface', () => {
       head: 'feature/provider-interface',
       title: 'Add provider interface'
     }
-    await expect(provider.createReview?.('/repo', input)).resolves.toEqual({
+    await expect(provider.createReview?.('/repo', input, 'local')).resolves.toEqual({
       ok: true,
       number: 23,
       url: 'https://bitbucket.org/team/orca/pull-requests/23'
     })
-    expect(createBitbucketPullRequestMock).toHaveBeenCalledWith('/repo', input)
+    expect(createBitbucketPullRequestMock).toHaveBeenCalledWith('/repo', input, 'local')
   })
 
   it('routes GitLab review creation through the shared provider contract', async () => {
@@ -254,7 +272,7 @@ describe('forge provider interface', () => {
           head: 'feature/provider-interface',
           title: 'Add provider interface'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -269,7 +287,7 @@ describe('forge provider interface', () => {
         head: 'feature/provider-interface',
         title: 'Add provider interface'
       },
-      'ssh-1'
+      'ssh:ssh-1'
     )
   })
 
@@ -290,7 +308,7 @@ describe('forge provider interface', () => {
           head: 'feature/provider-interface',
           title: 'Add provider interface'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -305,7 +323,7 @@ describe('forge provider interface', () => {
         head: 'feature/provider-interface',
         title: 'Add provider interface'
       },
-      'ssh-1'
+      'ssh:ssh-1'
     )
   })
 
@@ -326,7 +344,7 @@ describe('forge provider interface', () => {
           head: 'feature/provider-interface',
           title: 'Add provider interface'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -341,7 +359,7 @@ describe('forge provider interface', () => {
         head: 'feature/provider-interface',
         title: 'Add provider interface'
       },
-      'ssh-1'
+      'ssh:ssh-1'
     )
   })
 
@@ -363,7 +381,7 @@ describe('forge provider interface', () => {
     await expect(
       getForgeProviderById('github').getReviewForBranch({
         repoPath: '/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: '',
         fallbackReviewNumber: 7
       })
@@ -383,7 +401,7 @@ describe('forge provider interface', () => {
 
     await getForgeProviderById('github').getReviewForBranch({
       repoPath: '/repo',
-      connectionId: null,
+      executionHostId: 'local',
       branch: 'feature/x',
       githubCurrentHeadOid: 'abc1234'
     })
@@ -399,7 +417,7 @@ describe('forge provider interface', () => {
     await expect(
       getForgeProviderById('github').getReviewForBranch({
         repoPath: '/repo',
-        connectionId: null,
+        executionHostId: 'local',
         branch: 'feature/x'
       })
     ).resolves.toBeNull()
@@ -416,7 +434,7 @@ describe('forge provider interface', () => {
     await expect(
       getForgeProviderById('github').getReviewForBranch({
         repoPath: '/repo',
-        connectionId: null,
+        executionHostId: 'local',
         branch: 'feature/x'
       })
     ).rejects.toThrow(/network/)
@@ -430,7 +448,7 @@ describe('forge provider interface', () => {
     await expect(
       getForgeProviderById('github').getReviewForBranch({
         repoPath: '/repo',
-        connectionId: null,
+        executionHostId: 'local',
         branch: 'feature/x'
       })
       // Throwing (not null) keeps a low budget from reading as "no pull request".
@@ -446,7 +464,7 @@ describe('forge provider interface', () => {
     await expect(
       getForgeProviderById('github').getReviewByNumber({
         repoPath: '/repo',
-        connectionId: null,
+        executionHostId: 'local',
         number: 42
       })
     ).rejects.toThrow(/rate_limited/)
@@ -460,7 +478,7 @@ describe('forge provider interface', () => {
     await expect(
       getForgeProviderById('gitlab').getReviewForBranch({
         repoPath: '/repo',
-        connectionId: null,
+        executionHostId: 'local',
         branch: 'feature/x'
       })
     ).resolves.toBeNull()

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -1,3 +1,4 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type {
   CreateHostedReviewInput,
   CreateHostedReviewResult,
@@ -37,6 +38,7 @@ import {
   mapGitHubReview,
   mapGitLabReview
 } from './forge-review-mappers'
+import { hostedReviewSshConnectionId } from './hosted-review-execution-host'
 import {
   hasHostedReviewLocalGitOptions,
   getHostedReviewLocalGitOptions,
@@ -47,7 +49,8 @@ export type ForgeProviderId = Exclude<HostedReviewProvider, 'unsupported'>
 
 export type ForgeProviderRepositoryContext = HostedReviewExecutionOptions & {
   repoPath: string
-  connectionId?: string | null
+  /** Resolved, never null: `local` and "unresolved" are no longer the same value. */
+  executionHostId: ExecutionHostId
 }
 
 export type ForgeReviewForBranchInput = ForgeProviderRepositoryContext & {
@@ -72,9 +75,14 @@ export type ForgeProvider = {
   createReview?(
     repoPath: string,
     input: CreateHostedReviewInput,
-    connectionId?: string | null,
+    executionHostId: ExecutionHostId,
     options?: HostedReviewExecutionOptions
   ): Promise<CreateHostedReviewResult>
+}
+
+/** The forge CLIs (`gh`, `glab`, the REST clients) run here; only their git reads are host-routed. */
+function forgeConnectionId(context: ForgeProviderRepositoryContext): string | null {
+  return hostedReviewSshConnectionId(context.executionHostId)
 }
 
 function hostedReviewExecutionArgs(
@@ -89,7 +97,11 @@ const gitLabForgeProvider = {
   id: 'gitlab',
   supportsReviewCreation: true,
   resolveRepository: (context) =>
-    getProjectSlug(context.repoPath, context.connectionId, ...hostedReviewExecutionArgs(context)),
+    getProjectSlug(
+      context.repoPath,
+      forgeConnectionId(context),
+      ...hostedReviewExecutionArgs(context)
+    ),
   async getReviewForBranch(input) {
     // Why: throw (not null) on a real lookup failure so eligibility records
     // `unavailable`, never a false "No merge request found" — same contract the
@@ -98,7 +110,7 @@ const gitLabForgeProvider = {
       input.repoPath,
       input.branch,
       input.linkedReviewNumber ?? null,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return mr ? mapGitLabReview(mr) : null
@@ -107,7 +119,7 @@ const gitLabForgeProvider = {
     const mr = await getMergeRequest(
       input.repoPath,
       input.number,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return mr ? mapGitLabReview(mr) : null
@@ -139,7 +151,7 @@ async function assertGitHubReviewRateLimitBudget(
 ): Promise<void> {
   const block = await getGitHubPRLookupRateLimitBlock(
     input.repoPath,
-    input.connectionId,
+    forgeConnectionId(input),
     getHostedReviewLocalGitOptions(input)
   )
   if (block) {
@@ -158,7 +170,11 @@ const gitHubForgeProvider = {
   // gh is authenticated to their host (the same signal GitLab uses for
   // self-hosted instances), so detection never falls through to Gitea (#8312).
   resolveRepository: async (context) =>
-    getRepoSlug(context.repoPath, context.connectionId, ...hostedReviewExecutionArgs(context)),
+    getRepoSlug(
+      context.repoPath,
+      forgeConnectionId(context),
+      ...hostedReviewExecutionArgs(context)
+    ),
   async getReviewForBranch(input) {
     await assertGitHubReviewRateLimitBudget(input)
     const fallbackReviewNumber =
@@ -168,7 +184,7 @@ const gitHubForgeProvider = {
       input.repoPath,
       input.branch,
       input.linkedReviewNumber ?? null,
-      input.connectionId,
+      forgeConnectionId(input),
       fallbackReviewNumber,
       {
         ...executionArgs[0],
@@ -187,11 +203,11 @@ const gitHubForgeProvider = {
             input.repoPath,
             '',
             input.number,
-            input.connectionId,
+            forgeConnectionId(input),
             null,
             ...executionArgs
           )
-        : await getPRForBranchOutcome(input.repoPath, '', input.number, input.connectionId)
+        : await getPRForBranchOutcome(input.repoPath, '', input.number, forgeConnectionId(input))
     return unwrapGitHubPRForBranchOutcome(outcome)
   },
   createReview: createGitHubPullRequest
@@ -203,7 +219,7 @@ const bitbucketForgeProvider = {
   resolveRepository: (context) =>
     getBitbucketRepoSlug(
       context.repoPath,
-      context.connectionId,
+      forgeConnectionId(context),
       ...hostedReviewExecutionArgs(context)
     ),
   async getReviewForBranch(input) {
@@ -213,7 +229,7 @@ const bitbucketForgeProvider = {
       input.repoPath,
       input.branch,
       input.linkedReviewNumber ?? null,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return pr ? mapBitbucketReview(pr) : null
@@ -222,7 +238,7 @@ const bitbucketForgeProvider = {
     const pr = await getBitbucketPullRequest(
       input.repoPath,
       input.number,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return pr ? mapBitbucketReview(pr) : null
@@ -236,7 +252,7 @@ const azureDevOpsForgeProvider = {
   resolveRepository: (context) =>
     getAzureDevOpsRepoSlug(
       context.repoPath,
-      context.connectionId,
+      forgeConnectionId(context),
       ...hostedReviewExecutionArgs(context)
     ),
   async getReviewForBranch(input) {
@@ -246,7 +262,7 @@ const azureDevOpsForgeProvider = {
       input.repoPath,
       input.branch,
       input.linkedReviewNumber ?? null,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return pr ? mapAzureDevOpsReview(pr) : null
@@ -255,7 +271,7 @@ const azureDevOpsForgeProvider = {
     const pr = await getAzureDevOpsPullRequest(
       input.repoPath,
       input.number,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return pr ? mapAzureDevOpsReview(pr) : null
@@ -267,7 +283,11 @@ const giteaForgeProvider = {
   id: 'gitea',
   supportsReviewCreation: true,
   resolveRepository: (context) =>
-    getGiteaRepoSlug(context.repoPath, context.connectionId, ...hostedReviewExecutionArgs(context)),
+    getGiteaRepoSlug(
+      context.repoPath,
+      forgeConnectionId(context),
+      ...hostedReviewExecutionArgs(context)
+    ),
   async getReviewForBranch(input) {
     // Why: surface a real lookup failure so eligibility records `unavailable`
     // instead of a false "No pull request found".
@@ -275,7 +295,7 @@ const giteaForgeProvider = {
       input.repoPath,
       input.branch,
       input.linkedReviewNumber ?? null,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return pr ? mapGiteaReview(pr) : null
@@ -284,7 +304,7 @@ const giteaForgeProvider = {
     const pr = await getGiteaPullRequest(
       input.repoPath,
       input.number,
-      input.connectionId,
+      forgeConnectionId(input),
       ...hostedReviewExecutionArgs(input)
     )
     return pr ? mapGiteaReview(pr) : null

--- a/src/main/source-control/hosted-review-azure-devops.integration.test.ts
+++ b/src/main/source-control/hosted-review-azure-devops.integration.test.ts
@@ -99,7 +99,11 @@ describe('Azure DevOps hosted review integration', () => {
       )
 
       await expect(
-        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/azure' })
+        getHostedReviewForBranch({
+          executionHostId: 'local',
+          repoPath,
+          branch: 'refs/heads/feature/azure'
+        })
       ).resolves.toEqual({
         provider: 'azure-devops',
         number: 31,
@@ -204,7 +208,11 @@ describe('Azure DevOps hosted review integration', () => {
       )
 
       await expect(
-        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/azure' })
+        getHostedReviewForBranch({
+          executionHostId: 'local',
+          repoPath,
+          branch: 'refs/heads/feature/azure'
+        })
       ).resolves.toMatchObject({
         provider: 'azure-devops',
         number: 41,

--- a/src/main/source-control/hosted-review-base-ref-suffix.test.ts
+++ b/src/main/source-control/hosted-review-base-ref-suffix.test.ts
@@ -38,7 +38,7 @@ describe('baseRefExistsOnRemote suffix fallback', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(false)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(false)
   })
 
   it('still resolves a stale single-segment remote through the suffix fallback', async () => {
@@ -55,7 +55,7 @@ describe('baseRefExistsOnRemote suffix fallback', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(true)
   })
 
   it('treats a suffix lookup that never ran as inconclusive', async () => {
@@ -72,6 +72,6 @@ describe('baseRefExistsOnRemote suffix fallback', () => {
       })
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(true)
   })
 })

--- a/src/main/source-control/hosted-review-bitbucket.integration.test.ts
+++ b/src/main/source-control/hosted-review-bitbucket.integration.test.ts
@@ -94,7 +94,11 @@ describe('Bitbucket hosted review integration', () => {
       })
 
       await expect(
-        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/bitbucket' })
+        getHostedReviewForBranch({
+          executionHostId: 'local',
+          repoPath,
+          branch: 'refs/heads/feature/bitbucket'
+        })
       ).resolves.toEqual({
         provider: 'bitbucket',
         number: 12,
@@ -176,12 +180,20 @@ describe('Bitbucket hosted review integration', () => {
       })
 
       await expect(
-        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/recovery' })
+        getHostedReviewForBranch({
+          executionHostId: 'local',
+          repoPath,
+          branch: 'refs/heads/feature/recovery'
+        })
       ).rejects.toThrow('HTTP 503')
 
       vi.advanceTimersByTime(60_001)
       await expect(
-        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/recovery' })
+        getHostedReviewForBranch({
+          executionHostId: 'local',
+          repoPath,
+          branch: 'refs/heads/feature/recovery'
+        })
       ).resolves.toMatchObject({
         provider: 'bitbucket',
         number: 13,

--- a/src/main/source-control/hosted-review-branch-cache.test.ts
+++ b/src/main/source-control/hosted-review-branch-cache.test.ts
@@ -15,7 +15,7 @@ import {
   MAX_UNSETTLED_LOOKUPS_PER_KEY
 } from './hosted-review-refresh-pacing'
 
-const identity = { repoPath: '/repo', connectionId: null, branch: 'feature/x' }
+const identity = { repoPath: '/repo', executionHostId: 'local' as const, branch: 'feature/x' }
 const START = 1_000_000
 
 /** A lookup that never settles — the wedged provider this file's deadline exists for. */
@@ -248,7 +248,7 @@ describe('hosted review branch cache (#11532)', () => {
       .mockResolvedValueOnce(openReview)
 
     await withHostedReviewBranchCache(identity, { headOid: null }, lookup)
-    invalidateHostedReviewBranchCache('/repo', null)
+    invalidateHostedReviewBranchCache('/repo', 'local')
 
     await expect(withHostedReviewBranchCache(identity, { headOid: null }, lookup)).resolves.toEqual(
       openReview
@@ -269,7 +269,7 @@ describe('hosted review branch cache (#11532)', () => {
       .mockResolvedValue(openReview)
 
     const inflight = withHostedReviewBranchCache(identity, { headOid: null }, lookup)
-    invalidateHostedReviewBranchCache('/repo', null)
+    invalidateHostedReviewBranchCache('/repo', 'local')
     // The poll started before the review existed, so its "no review" answer is
     // older than the invalidation and must not be cached back over it.
     resolveLookup(null)
@@ -292,7 +292,7 @@ describe('hosted review branch cache (#11532)', () => {
     )
 
     const inflight = withHostedReviewBranchCache(other, { headOid: null }, lookup)
-    invalidateHostedReviewBranchCache('/repo', null)
+    invalidateHostedReviewBranchCache('/repo', 'local')
     resolveLookup(null)
     await inflight
 
@@ -311,7 +311,7 @@ describe('hosted review branch cache (#11532)', () => {
     )
     expect(lookup).toHaveBeenCalledTimes(2)
 
-    invalidateHostedReviewBranchCache('/other', null)
+    invalidateHostedReviewBranchCache('/other', 'local')
 
     await withHostedReviewBranchCache(identity, { headOid: null }, lookup)
     expect(lookup).toHaveBeenCalledTimes(2)
@@ -328,7 +328,7 @@ describe('hosted review branch cache (#11532)', () => {
 
     await withHostedReviewBranchCache(identity, { headOid: null }, lookup)
     await withHostedReviewBranchCache(
-      { ...identity, connectionId: 'ssh-1' },
+      { ...identity, executionHostId: 'ssh:ssh-1' as const },
       { headOid: null },
       lookup
     )
@@ -891,11 +891,11 @@ describe('hosted review branch cache (#11532)', () => {
       const stale = stuckLookup()
       const inflight = withHostedReviewBranchCache(identity, { headOid: null }, stale.lookup)
 
-      invalidateHostedReviewBranchCache('/repo', null)
+      invalidateHostedReviewBranchCache('/repo', 'local')
       // Fill the generation map so the repo's own generation is evicted: read back
       // as zero it would match what this lookup captured before the invalidation.
       for (let index = 0; index < MAX_BRANCH_MAP_ENTRIES; index += 1) {
-        invalidateHostedReviewBranchCache(`/filler/${index}`, null)
+        invalidateHostedReviewBranchCache(`/filler/${index}`, 'local')
       }
 
       stale.resolve(null)

--- a/src/main/source-control/hosted-review-branch-cache.ts
+++ b/src/main/source-control/hosted-review-branch-cache.ts
@@ -1,3 +1,4 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type { HostedReviewInfo } from '../../shared/hosted-review'
 import {
   __resetHostedReviewActiveClaimsForTests,
@@ -76,7 +77,7 @@ const KEY_SEPARATOR = '\0'
 
 export type HostedReviewBranchCacheIdentity = {
   repoPath: string
-  connectionId?: string | null
+  executionHostId: ExecutionHostId
   branch: string
   linkedGitHubPR?: number | null
   fallbackGitHubPR?: number | null
@@ -94,14 +95,16 @@ export type HostedReviewBranchCacheOptions = {
   active?: boolean
 }
 
-/** Repo-scoped prefix so a single repo's entries can be dropped without a full flush. */
-function repoScope(repoPath: string, connectionId?: string | null): string {
-  return `${connectionId ?? ''}${KEY_SEPARATOR}${repoPath}`
+/** Repo-scoped prefix so a single repo's entries can be dropped without a full flush.
+ *  Keyed on the resolved host, not a raw connection id: two rows at one path on different hosts
+ *  are different repositories, and collapsing them serves one host's answer for the other. */
+function repoScope(repoPath: string, executionHostId: ExecutionHostId): string {
+  return `${executionHostId}${KEY_SEPARATOR}${repoPath}`
 }
 
 export function hostedReviewBranchCacheKey(identity: HostedReviewBranchCacheIdentity): string {
   return [
-    repoScope(identity.repoPath, identity.connectionId),
+    repoScope(identity.repoPath, identity.executionHostId),
     identity.branch,
     // Each linked id selects a different lookup, so it belongs in the identity.
     identity.linkedGitHubPR ?? '',
@@ -203,9 +206,9 @@ function trackInflight(key: string, record: InflightRecord): void {
  */
 export function invalidateHostedReviewBranchCache(
   repoPath: string,
-  connectionId?: string | null
+  executionHostId: ExecutionHostId
 ): void {
-  const scope = repoScope(repoPath, connectionId)
+  const scope = repoScope(repoPath, executionHostId)
   bumpScopeGeneration(scope)
   const prefix = `${scope}${KEY_SEPARATOR}`
   for (const key of entries.keys()) {
@@ -424,5 +427,5 @@ export async function withHostedReviewBranchCache(
     throw new Error(unavailable)
   }
 
-  return startLookup(key, repoScope(identity.repoPath, identity.connectionId), headOid, lookup)
+  return startLookup(key, repoScope(identity.repoPath, identity.executionHostId), headOid, lookup)
 }

--- a/src/main/source-control/hosted-review-creation-eligibility.test.ts
+++ b/src/main/source-control/hosted-review-creation-eligibility.test.ts
@@ -103,22 +103,19 @@ vi.mock('../gitlab/gl-utils', () => ({
     connectionId ? {} : { cwd: repoPath }
 }))
 
-vi.mock('../git/upstream', () => ({
-  getUpstreamStatus: getUpstreamStatusMock
-}))
+vi.mock('../git/upstream', () => ({ getUpstreamStatus: getUpstreamStatusMock }))
 
-vi.mock('../providers/ssh-git-dispatch', () => ({
-  getSshGitProvider: getSshGitProviderMock
-}))
+vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: getSshGitProviderMock }))
 
-vi.mock('./hosted-review', () => ({
-  getHostedReviewForBranch: getHostedReviewForBranchMock
-}))
+vi.mock('./hosted-review', () => ({ getHostedReviewForBranch: getHostedReviewForBranchMock }))
 
 import { createHostedReview, getHostedReviewCreationEligibility } from './hosted-review-creation'
 import { baseRefExistsOnRemote } from './hosted-review-creation-git-state'
 
 import { _resetOriginGitHubApiRepositoryCache } from '../github/github-api-repository'
+
+// Every eligibility case below is one local repo at the same path.
+const LOCAL_REPO_ARGS = { executionHostId: 'local' as const, repoPath: '/repo' }
 
 // The origin-repository cache is module-level state; reset it so slugs
 // resolved by one test cannot leak into the next.
@@ -243,7 +240,7 @@ describe('getHostedReviewCreationEligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'main',
         base: 'origin/main',
         hasUncommittedChanges: false,
@@ -271,7 +268,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw Object.assign(new Error('missing ref'), { code: 1 })
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(true)
     expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
       'show-ref',
       '--verify',
@@ -299,7 +296,7 @@ describe('getHostedReviewCreationEligibility', () => {
         throw Object.assign(new Error('missing ref'), { code: 1 })
       })
 
-      await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(false)
+      await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(false)
       expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
         'show-ref',
         '--',
@@ -321,7 +318,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw Object.assign(new Error('missing ref'), { code: 1 })
     })
 
-    await expect(baseRefExistsOnRemote('orphan/main', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('orphan/main', '/repo', 'local')).resolves.toBe(true)
     expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
       'show-ref',
       '--verify',
@@ -343,7 +340,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw Object.assign(new Error('missing ref'), { code: 1 })
     })
 
-    await expect(baseRefExistsOnRemote('orphan/main', '/repo')).resolves.toBe(false)
+    await expect(baseRefExistsOnRemote('orphan/main', '/repo', 'local')).resolves.toBe(false)
     expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
       'show-ref',
       '--',
@@ -366,7 +363,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('feature/fix', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('feature/fix', '/repo', 'local')).resolves.toBe(true)
   })
 
   it('finds a unique bare suffix on an unconfigured stale remote', async () => {
@@ -384,7 +381,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(true)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['show-ref', '--', 'main'],
       expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 })
@@ -406,7 +403,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('HEAD', '/repo')).resolves.toBe(false)
+    await expect(baseRefExistsOnRemote('HEAD', '/repo', 'local')).resolves.toBe(false)
   })
 
   it('keeps a bare suffix present when stale refs are ambiguous across remotes', async () => {
@@ -425,7 +422,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(true)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(true)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['show-ref', '--', 'main'],
       expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 })
@@ -443,7 +440,7 @@ describe('getHostedReviewCreationEligibility', () => {
       throw new Error(`unexpected git command: ${args.join(' ')}`)
     })
 
-    await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(false)
+    await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(false)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['show-ref', '--', 'main'],
       expect.objectContaining({ maxBuffer: 10 * 1024 * 1024 })
@@ -466,12 +463,12 @@ describe('getHostedReviewCreationEligibility', () => {
         throw new Error(`unexpected git command: ${args.join(' ')}`)
       })
 
-      await expect(baseRefExistsOnRemote('main', '/repo')).resolves.toBe(true)
+      await expect(baseRefExistsOnRemote('main', '/repo', 'local')).resolves.toBe(true)
     }
   )
 
   it('fails closed for malformed base input without invoking Git', async () => {
-    await expect(baseRefExistsOnRemote('main*', '/repo')).resolves.toBe(false)
+    await expect(baseRefExistsOnRemote('main*', '/repo', 'local')).resolves.toBe(false)
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
 
@@ -479,7 +476,7 @@ describe('getHostedReviewCreationEligibility', () => {
     getHostedReviewForBranchMock.mockResolvedValue({ number: 7, url: 'https://x/pull/7' })
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/x',
         hasUncommittedChanges: false,
         hasUpstream: true,
@@ -493,7 +490,7 @@ describe('getHostedReviewCreationEligibility', () => {
     getHostedReviewForBranchMock.mockResolvedValue(null)
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/x',
         hasUncommittedChanges: false,
         hasUpstream: true,
@@ -507,7 +504,7 @@ describe('getHostedReviewCreationEligibility', () => {
     getHostedReviewForBranchMock.mockRejectedValue(new Error('ssh: connection refused'))
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/x',
         hasUncommittedChanges: false,
         hasUpstream: false,
@@ -524,7 +521,7 @@ describe('getHostedReviewCreationEligibility', () => {
     getHostedReviewForBranchMock.mockRejectedValue(new Error('gh: could not connect to github.com'))
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/x',
         base: 'origin/main',
         hasUncommittedChanges: false,
@@ -553,12 +550,16 @@ describe('getHostedReviewCreationEligibility', () => {
       return { stdout: 'refs/remotes/origin/main\n', stderr: '' }
     })
 
-    const result = await createHostedReview('/repo', {
-      provider: 'github',
-      base: 'main',
-      head: 'feature/x',
-      title: 'Add feature'
-    })
+    const result = await createHostedReview(
+      '/repo',
+      {
+        provider: 'github',
+        base: 'main',
+        head: 'feature/x',
+        title: 'Add feature'
+      },
+      'local'
+    )
 
     expect(result).toMatchObject({ ok: false, code: 'validation' })
     // The provider create API must never run on an inconclusive lookup.
@@ -570,7 +571,7 @@ describe('getHostedReviewCreationEligibility', () => {
   const stackedArgs = (
     overrides: Partial<Parameters<typeof getHostedReviewCreationEligibility>[0]> = {}
   ): Parameters<typeof getHostedReviewCreationEligibility>[0] => ({
-    repoPath: '/repo',
+    ...LOCAL_REPO_ARGS,
     branch: 'feature/stacked',
     base: 'stacked-parent',
     hasUncommittedChanges: false,
@@ -658,7 +659,7 @@ describe('getHostedReviewCreationEligibility', () => {
   it('blocks dirty tracked GitHub branches before PR creation', async () => {
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/create-pr',
         base: 'main',
         hasUncommittedChanges: true,
@@ -680,7 +681,7 @@ describe('getHostedReviewCreationEligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/create-pr',
         base: 'main',
         hasUncommittedChanges: true,
@@ -710,7 +711,7 @@ describe('getHostedReviewCreationEligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'refs/heads/feature/create-pr',
         base: 'origin/main',
         hasUncommittedChanges: false,
@@ -733,7 +734,7 @@ describe('getHostedReviewCreationEligibility', () => {
     mockGitHubEnterpriseProvider()
 
     const result = await getHostedReviewCreationEligibility({
-      repoPath: '/repo',
+      ...LOCAL_REPO_ARGS,
       branch: 'feature/create-pr',
       base: 'origin/main',
       hasUncommittedChanges: false,
@@ -772,7 +773,7 @@ describe('getHostedReviewCreationEligibility', () => {
     await expect(
       getHostedReviewCreationEligibility({
         repoPath: '/remote/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'feature/create-pr',
         base: 'origin/main',
         hasUncommittedChanges: false,
@@ -789,7 +790,7 @@ describe('getHostedReviewCreationEligibility', () => {
     expect(getProjectSlugMock).toHaveBeenCalledWith('/remote/repo', 'ssh-1')
     expect(getRepoSlugMock).toHaveBeenCalledWith('/remote/repo', 'ssh-1')
     expect(getHostedReviewForBranchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ repoPath: '/remote/repo', connectionId: 'ssh-1' })
+      expect.objectContaining({ repoPath: '/remote/repo', executionHostId: 'ssh:ssh-1' })
     )
     // Why: the base-on-remote probe must run on the SSH host that will execute
     // the provider create, so it flows through the relay exec, not local git.
@@ -803,7 +804,7 @@ describe('getHostedReviewCreationEligibility', () => {
   it('offers push as the next action for authenticated branches with local-only commits', async () => {
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/create-pr',
         base: 'main',
         hasUncommittedChanges: false,
@@ -823,7 +824,7 @@ describe('getHostedReviewCreationEligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/gitlab',
         base: 'main',
         hasUncommittedChanges: false,
@@ -850,7 +851,7 @@ describe('getHostedReviewCreationEligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/azure',
         base: 'main',
         hasUncommittedChanges: false,
@@ -875,7 +876,7 @@ describe('getHostedReviewCreationEligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
-        repoPath: '/repo',
+        ...LOCAL_REPO_ARGS,
         branch: 'feature/gitea',
         base: 'main',
         hasUncommittedChanges: false,

--- a/src/main/source-control/hosted-review-creation-git-state.ts
+++ b/src/main/source-control/hosted-review-creation-git-state.ts
@@ -13,7 +13,12 @@ import { parsePorcelainV1Records, type PorcelainV1Record } from '../git/porcelai
 import { resolveDefaultBaseRefViaExec } from '../git/repo'
 import { getUpstreamStatus } from '../git/upstream'
 import { findExistingWorktreeSymlinkPaths } from '../git/worktree-symlink-detection'
-import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import {
+  ExecutionHostNotDispatchableError,
+  resolveGitRouteForHost,
+  type ExecutionHostGitRoute
+} from '../providers/execution-host-provider-dispatch'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
@@ -117,20 +122,38 @@ async function listSuffixRemoteBaseRefs(
   }
 }
 
+/**
+ * Why not a `connectionId` check: `null` used to mean "local", "runtime host" and "unresolved"
+ * alike, so a worktree whose owner is named only by `executionHostId` had its preflight git run
+ * against this machine's copy of a remote path. `runtime:` is a routing mistake here rather than a
+ * fallback — that environment's server runs its own git.
+ */
+function requireHostedReviewGitRoute(executionHostId: ExecutionHostId): ExecutionHostGitRoute {
+  const route = resolveGitRouteForHost(executionHostId)
+  if (route.kind === 'runtime') {
+    throw new ExecutionHostNotDispatchableError(route.hostId)
+  }
+  return route
+}
+
+/** Loss of contact is not locality: an SSH host with no provider refuses, it does not run here. */
+function requireHostedReviewSshProvider(route: ExecutionHostGitRoute) {
+  if (route.kind !== 'ssh' || !route.provider) {
+    throw new Error('Remote connection dropped. Click Reconnect on the SSH target before retrying.')
+  }
+  return route.provider
+}
+
 async function runGitForHostedReview(
   repoPath: string,
   args: string[],
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {},
   commandOptions: HostedReviewGitRunOptions = {}
 ): Promise<{ stdout: string; stderr?: string }> {
-  if (connectionId) {
-    const provider = getSshGitProvider(connectionId)
-    if (!provider) {
-      throw new Error(
-        'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
-      )
-    }
+  const route = requireHostedReviewGitRoute(executionHostId)
+  if (route.kind === 'ssh') {
+    const provider = requireHostedReviewSshProvider(route)
     return commandOptions.timeoutMs === undefined
       ? provider.exec(args, repoPath)
       : provider.exec(args, repoPath, { timeoutMs: commandOptions.timeoutMs })
@@ -145,11 +168,11 @@ async function runGitForHostedReview(
 
 export async function getDefaultBaseRef(
   repoPath: string,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<string | null> {
   return resolveDefaultBaseRefViaExec((argv) =>
-    runGitForHostedReview(repoPath, argv, connectionId, options)
+    runGitForHostedReview(repoPath, argv, executionHostId, options)
   )
 }
 
@@ -162,7 +185,7 @@ export async function getDefaultBaseRef(
 export async function baseRefExistsOnRemote(
   candidate: string,
   repoPath: string,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
   const base = normalizeHostedReviewBaseRef(candidate).trim()
@@ -170,7 +193,7 @@ export async function baseRefExistsOnRemote(
     return false
   }
   const run: HostedReviewGitRun = (argv, commandOptions) =>
-    runGitForHostedReview(repoPath, argv, connectionId, options, commandOptions)
+    runGitForHostedReview(repoPath, argv, executionHostId, options, commandOptions)
 
   // Validate the complete tracking ref before interpolating user/repo metadata
   // into Git arguments. In particular, never let `*`, `?`, or control bytes
@@ -227,13 +250,13 @@ export async function baseRefExistsOnRemote(
 
 export async function getCurrentBranch(
   repoPath: string,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<string> {
   const { stdout } = await runGitForHostedReview(
     repoPath,
     ['rev-parse', '--abbrev-ref', 'HEAD'],
-    connectionId,
+    executionHostId,
     options
   )
   return stripRefPrefix(stdout.trim())
@@ -241,20 +264,15 @@ export async function getCurrentBranch(
 
 export async function hasUncommittedChanges(
   repoPath: string,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
-  if (connectionId) {
-    const provider = getSshGitProvider(connectionId)
-    if (!provider) {
-      throw new Error(
-        'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
-      )
-    }
+  const route = requireHostedReviewGitRoute(executionHostId)
+  if (route.kind === 'ssh') {
     // Why: the relay restricts generic git.exec, so use the structured status RPC for SSH dirty checks.
     // No shared-link exclusion here: remote worktree creation skips the symlink
     // and shared-directory passes entirely, so a remote worktree never has one.
-    return (await provider.getStatus(repoPath)).entries.length > 0
+    return (await requireHostedReviewSshProvider(route).getStatus(repoPath)).entries.length > 0
   }
   // Why: `-z` keeps paths raw so the shared-link comparison below can't be
   // defeated by Git quoting a path with spaces or non-ASCII bytes.
@@ -300,16 +318,14 @@ async function anyRecordIsUserDirt(
 
 export async function getHostedReviewUpstreamStatus(
   repoPath: string,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<GitUpstreamStatus> {
-  if (!connectionId) {
+  const route = requireHostedReviewGitRoute(executionHostId)
+  if (route.kind !== 'ssh') {
     return getUpstreamStatus(repoPath, undefined, getHostedReviewLocalGitOptions(options))
   }
-  const provider = getSshGitProvider(connectionId)
-  if (!provider) {
-    throw new Error('Remote connection dropped. Click Reconnect on the SSH target before retrying.')
-  }
+  const provider = requireHostedReviewSshProvider(route)
   try {
     // Why: the relay blocks generic git.exec, so use its dedicated upstream RPC for SSH divergence.
     return await provider.getUpstreamStatus(repoPath)

--- a/src/main/source-control/hosted-review-creation-gitlab-self-hosted.test.ts
+++ b/src/main/source-control/hosted-review-creation-gitlab-self-hosted.test.ts
@@ -125,6 +125,7 @@ describe('GitLab self-hosted hosted review creation eligibility', () => {
 
     await expect(
       getHostedReviewCreationEligibility({
+        executionHostId: 'local',
         repoPath: '/repo',
         branch: 'feature/self-hosted-mr',
         base: 'main',
@@ -180,6 +181,7 @@ gitlab.internal
     })
 
     const result = await getHostedReviewCreationEligibility({
+      executionHostId: 'local',
       repoPath: '/repo',
       branch: 'feature/self-hosted-mr',
       base: 'main',
@@ -231,6 +233,7 @@ gitlab.internal
     })
 
     const eligibilityInput = {
+      executionHostId: 'local' as const,
       repoPath: '/repo',
       branch: 'feature/self-hosted-mr',
       base: 'main',

--- a/src/main/source-control/hosted-review-creation-provider.ts
+++ b/src/main/source-control/hosted-review-creation-provider.ts
@@ -1,3 +1,4 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type { HostedReviewProvider } from '../../shared/hosted-review'
 import type { HostedReviewCreationProvider } from '../../shared/hosted-review-creation-providers'
 import { isAzureDevOpsReviewCreationAuthenticated } from '../azure-devops/pull-request-creation'
@@ -12,6 +13,7 @@ import {
   glabRepoExecOptions,
   release as releaseGlab
 } from '../gitlab/gl-utils'
+import { hostedReviewSshConnectionId } from './hosted-review-execution-host'
 import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
@@ -19,7 +21,7 @@ import {
 
 async function isGitHubAuthenticated(
   repoPath: string,
-  connectionId?: string | null,
+  connectionId: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
   // Why: a non-null enterprise slug already means gh is authenticated there, so skip a redundant probe (#8312).
@@ -46,7 +48,7 @@ async function isGitHubAuthenticated(
 
 async function isGitLabAuthenticated(
   repoPath: string,
-  connectionId?: string | null,
+  connectionId: string | null,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
   const projectRef = await getProjectSlug(repoPath, connectionId, options)
@@ -116,12 +118,9 @@ export function reviewCopy(provider: HostedReviewProvider): {
 export async function isProviderAuthenticated(
   provider: HostedReviewCreationProvider,
   repoPath: string,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<boolean> {
-  if (provider === 'gitlab') {
-    return isGitLabAuthenticated(repoPath, connectionId, options)
-  }
   if (provider === 'azure-devops') {
     return isAzureDevOpsReviewCreationAuthenticated()
   }
@@ -132,6 +131,12 @@ export async function isProviderAuthenticated(
     // Why: falling through to the GitHub check made Create PR unusable for
     // anyone with Bitbucket connected but no `gh auth login`.
     return isBitbucketReviewCreationAuthenticated()
+  }
+  // Only the CLI-backed probes read a host: `gh` and `glab` run here, and the SSH target only
+  // routes the git reads under them. The token-backed forges never touch the repository at all.
+  const connectionId = hostedReviewSshConnectionId(executionHostId)
+  if (provider === 'gitlab') {
+    return isGitLabAuthenticated(repoPath, connectionId, options)
   }
   return isGitHubAuthenticated(repoPath, connectionId, options)
 }

--- a/src/main/source-control/hosted-review-creation-shared-symlinks.test.ts
+++ b/src/main/source-control/hosted-review-creation-shared-symlinks.test.ts
@@ -100,7 +100,7 @@ describe('createHostedReview with shared symlinks', () => {
     createHostedReview(
       worktree,
       { provider: 'github', base: 'main', head: 'feature', title: 'Feature' },
-      null,
+      'local',
       sharedLinkPaths ? { sharedLinkPaths } : {}
     )
 

--- a/src/main/source-control/hosted-review-creation.test.ts
+++ b/src/main/source-control/hosted-review-creation.test.ts
@@ -285,12 +285,16 @@ describe('createHostedReview', () => {
     })
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'validation',
@@ -308,12 +312,16 @@ describe('createHostedReview', () => {
     })
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'validation',
@@ -335,12 +343,16 @@ describe('createHostedReview', () => {
     })
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'github',
-        base: 'stacked-parent',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'stacked-parent',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'validation',
@@ -352,12 +364,16 @@ describe('createHostedReview', () => {
 
   it('creates the pull request after fresh main-process validation passes', async () => {
     await expect(
-      createHostedReview('/repo', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 12,
@@ -376,7 +392,7 @@ describe('createHostedReview', () => {
           head: 'feature',
           title: 'Feature'
         },
-        null,
+        'local',
         { localGitExecOptions: { wslDistro: 'Ubuntu' } }
       )
     ).resolves.toEqual({
@@ -419,7 +435,7 @@ describe('createHostedReview', () => {
     expect(createGitHubPullRequestMock).toHaveBeenCalledWith(
       '/repo',
       expect.objectContaining({ provider: 'github', head: 'feature' }),
-      null,
+      'local',
       { localGitExecOptions: { wslDistro: 'Ubuntu' } }
     )
   })
@@ -428,12 +444,16 @@ describe('createHostedReview', () => {
     mockGitHubEnterpriseProvider()
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 12,
@@ -451,12 +471,16 @@ describe('createHostedReview', () => {
     mockGitLabProvider()
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'gitlab',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'gitlab',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 44,
@@ -475,7 +499,7 @@ describe('createHostedReview', () => {
         head: 'feature',
         title: 'Feature'
       },
-      undefined
+      'local'
     )
     expect(createGitHubPullRequestMock).not.toHaveBeenCalled()
   })
@@ -484,12 +508,16 @@ describe('createHostedReview', () => {
     mockAzureDevOpsProvider()
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'azure-devops',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'azure-devops',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 88,
@@ -504,7 +532,7 @@ describe('createHostedReview', () => {
         head: 'feature',
         title: 'Feature'
       },
-      undefined
+      'local'
     )
     expect(createGitHubPullRequestMock).not.toHaveBeenCalled()
     expect(createGitLabMergeRequestMock).not.toHaveBeenCalled()
@@ -514,12 +542,16 @@ describe('createHostedReview', () => {
     mockGiteaProvider()
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'gitea',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'gitea',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: true,
       number: 19,
@@ -534,7 +566,7 @@ describe('createHostedReview', () => {
         head: 'feature',
         title: 'Feature'
       },
-      undefined
+      'local'
     )
     expect(createGitHubPullRequestMock).not.toHaveBeenCalled()
     expect(createGitLabMergeRequestMock).not.toHaveBeenCalled()
@@ -579,7 +611,7 @@ describe('createHostedReview', () => {
           head: 'feature',
           title: 'Feature'
         },
-        'ssh-1'
+        'ssh:ssh-1'
       )
     ).resolves.toEqual({
       ok: true,
@@ -611,7 +643,7 @@ describe('createHostedReview', () => {
         head: 'feature',
         title: 'Feature'
       },
-      'ssh-1'
+      'ssh:ssh-1'
     )
   })
 
@@ -628,12 +660,16 @@ describe('createHostedReview', () => {
     })
 
     await expect(
-      createHostedReview('/repo', {
-        provider: 'github',
-        base: 'main',
-        head: 'feature',
-        title: 'Feature'
-      })
+      createHostedReview(
+        '/repo',
+        {
+          provider: 'github',
+          base: 'main',
+          head: 'feature',
+          title: 'Feature'
+        },
+        'local'
+      )
     ).resolves.toEqual({
       ok: false,
       code: 'already_exists',

--- a/src/main/source-control/hosted-review-creation.ts
+++ b/src/main/source-control/hosted-review-creation.ts
@@ -1,3 +1,4 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type {
   CreateHostedReviewInput,
   CreateHostedReviewResult,
@@ -23,25 +24,31 @@ import {
   stripRefPrefix
 } from './hosted-review-creation-git-state'
 import { isProviderAuthenticated, reviewCopy } from './hosted-review-creation-provider'
+import { hostedReviewSshConnectionId } from './hosted-review-execution-host'
 import {
   getHostedReviewLocalGitOptions,
   type HostedReviewExecutionOptions
 } from './hosted-review-git-options'
 
-type HostedReviewCreationEligibilityInput = HostedReviewCreationEligibilityArgs & {
-  connectionId?: string | null
+// `connectionId` is dropped rather than carried: the wire arg still declares it for older peers,
+// but nothing on this side may read it — the resolved host is the only routing answer here.
+type HostedReviewCreationEligibilityInput = Omit<
+  HostedReviewCreationEligibilityArgs,
+  'connectionId'
+> & {
+  executionHostId: ExecutionHostId
   // Why: only the create-time preflight sets this; the renderer's probe leaves it unset to auto-correct a local-only parent.
   enforceBaseOnRemote?: boolean
 } & HostedReviewExecutionOptions
 
 async function validateCurrentBranchCanCreateReview(
   repoPath: string,
-  connectionId: string | null | undefined,
+  executionHostId: ExecutionHostId,
   input: CreateHostedReviewInput,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateHostedReviewResult | null> {
   const requestedHead = input.head ? stripRefPrefix(input.head).trim() : ''
-  const currentBranch = await getCurrentBranch(repoPath, connectionId, options)
+  const currentBranch = await getCurrentBranch(repoPath, executionHostId, options)
   const copy = reviewCopy(input.provider)
   if (requestedHead && requestedHead !== currentBranch) {
     return {
@@ -53,8 +60,8 @@ async function validateCurrentBranchCanCreateReview(
 
   try {
     const [dirty, upstreamStatus] = await Promise.all([
-      hasUncommittedChanges(repoPath, connectionId, options),
-      getHostedReviewUpstreamStatus(repoPath, connectionId, options)
+      hasUncommittedChanges(repoPath, executionHostId, options),
+      getHostedReviewUpstreamStatus(repoPath, executionHostId, options)
     ])
     const submittedBase = normalizeHostedReviewBaseRef(input.base)
     const eligibility = await getHostedReviewCreationEligibility({
@@ -65,7 +72,7 @@ async function validateCurrentBranchCanCreateReview(
       hasUpstream: upstreamStatus.hasUpstream,
       ahead: upstreamStatus.ahead,
       behind: upstreamStatus.behind,
-      connectionId,
+      executionHostId,
       // Why: last gate before the create, which targets the submitted base verbatim — enforce it exists on the remote.
       enforceBaseOnRemote: true,
       ...options
@@ -96,19 +103,19 @@ export async function getHostedReviewCreationEligibility(
   const branch = stripRefPrefix(args.branch).trim()
   const provider = await detectHostedReviewProvider({
     repoPath: args.repoPath,
-    connectionId: args.connectionId,
+    executionHostId: args.executionHostId,
     ...hostedReviewExecutionContext(args)
   })
   // Why: the base is only a candidate; fall back to repo default so a local-only parent targets a remote-resolvable ref.
   const candidateBase = args.base?.trim() || null
   const candidateBaseOnRemote =
     candidateBase != null &&
-    (await baseRefExistsOnRemote(candidateBase, args.repoPath, args.connectionId, args))
+    (await baseRefExistsOnRemote(candidateBase, args.repoPath, args.executionHostId, args))
   let defaultBaseRef: string | null
   if (candidateBase && candidateBaseOnRemote) {
     defaultBaseRef = candidateBase
   } else {
-    const repoDefaultBaseRef = await getDefaultBaseRef(args.repoPath, args.connectionId, args)
+    const repoDefaultBaseRef = await getDefaultBaseRef(args.repoPath, args.executionHostId, args)
     defaultBaseRef = repoDefaultBaseRef ?? candidateBase
   }
   const baseBranch = defaultBaseRef ? normalizeHostedReviewBaseRef(defaultBaseRef) : null
@@ -125,7 +132,7 @@ export async function getHostedReviewCreationEligibility(
       linkedBitbucketPR: args.linkedBitbucketPR ?? null,
       linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
       linkedGiteaPR: args.linkedGiteaPR ?? null,
-      connectionId: args.connectionId ?? null,
+      executionHostId: args.executionHostId,
       // Why: eligibility is only ever asked for the worktree the user is acting
       // on, so it earns the fast tier. Without it a review opened outside Orca
       // in the last no-review interval would leave Create enabled (#11532).
@@ -145,7 +152,11 @@ export async function getHostedReviewCreationEligibility(
       : 'not_found'
   const githubRepository =
     provider === 'github'
-      ? await getRepoSlug(args.repoPath, args.connectionId, args).catch(() => null)
+      ? await getRepoSlug(
+          args.repoPath,
+          hostedReviewSshConnectionId(args.executionHostId),
+          args
+        ).catch(() => null)
       : null
   const baseResult = {
     provider,
@@ -195,7 +206,7 @@ export async function getHostedReviewCreationEligibility(
   const authenticated = await isProviderAuthenticated(
     provider,
     args.repoPath,
-    args.connectionId,
+    args.executionHostId,
     args
   )
   if (!authenticated) {
@@ -230,7 +241,7 @@ export async function getHostedReviewCreationEligibility(
 export async function createHostedReview(
   repoPath: string,
   input: CreateHostedReviewInput,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateHostedReviewResult> {
   if (!supportsHostedReviewCreation(input.provider)) {
@@ -242,7 +253,7 @@ export async function createHostedReview(
   }
   const provider = await getForgeProviderForRepository({
     repoPath,
-    connectionId,
+    executionHostId,
     ...hostedReviewExecutionContext(options)
   })
   if (provider?.id !== input.provider || !provider.createReview) {
@@ -253,19 +264,24 @@ export async function createHostedReview(
       error: `Creating ${copy.reviewLabel}s requires a ${copy.providerName} remote.`
     }
   }
-  const blocked = await validateCurrentBranchCanCreateReview(repoPath, connectionId, input, options)
+  const blocked = await validateCurrentBranchCanCreateReview(
+    repoPath,
+    executionHostId,
+    input,
+    options
+  )
   if (blocked) {
     return blocked
   }
   const localGitOptions = getHostedReviewLocalGitOptions(options)
   const result =
     Object.keys(localGitOptions).length > 0
-      ? await provider.createReview(repoPath, input, connectionId, options)
-      : await provider.createReview(repoPath, input, connectionId)
+      ? await provider.createReview(repoPath, input, executionHostId, options)
+      : await provider.createReview(repoPath, input, executionHostId)
   if (result.ok) {
     // Why (#11532): the branch cache holds a "no review" answer for far longer
     // than a poll interval, so Orca's own creation must retire it at once.
-    invalidateHostedReviewBranchCache(repoPath, connectionId)
+    invalidateHostedReviewBranchCache(repoPath, executionHostId)
   }
   return result
 }

--- a/src/main/source-control/hosted-review-dirty-preflight-wsl-paths.test.ts
+++ b/src/main/source-control/hosted-review-dirty-preflight-wsl-paths.test.ts
@@ -30,7 +30,7 @@ describe('hasUncommittedChanges shared-symlink probe', () => {
 
   it('passes the configured distro through to the probe', async () => {
     await expect(
-      hasUncommittedChanges('/home/me/repo/feature', null, {
+      hasUncommittedChanges('/home/me/repo/feature', 'local', {
         localGitExecOptions: { wslDistro: 'Ubuntu' },
         sharedLinkPaths: ['node_modules']
       })

--- a/src/main/source-control/hosted-review-execution-host-routing.test.ts
+++ b/src/main/source-control/hosted-review-execution-host-routing.test.ts
@@ -1,0 +1,469 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../shared/repo-types'
+
+/**
+ * Routing cases for the hosted-review contract.
+ *
+ * Two SSH targets are registered at once in every case on purpose: routing that answers with
+ * "some connected host" rather than *this row's* host only shows up once a second one exists,
+ * and the `runtime:` cases reuse one of those names so a nested target cannot be told apart
+ * from a client-dialable one by its spelling.
+ */
+
+const {
+  getSshGitProviderMock,
+  gitExecFileAsyncMock,
+  ghExecFileAsyncMock,
+  glabExecFileAsyncMock,
+  getUpstreamStatusMock,
+  getProjectSlugMock,
+  getMergeRequestForBranchOrThrowMock,
+  getRepoSlugMock,
+  getPRForBranchOutcomeMock,
+  getRepoUpstreamMock,
+  getBitbucketRepoSlugMock,
+  getBitbucketPullRequestForBranchOrThrowMock,
+  getAzureDevOpsRepoSlugMock,
+  getGiteaRepoSlugMock,
+  createGitLabMergeRequestMock,
+  createGitHubPullRequestMock,
+  createBitbucketPullRequestMock,
+  createAzureDevOpsPullRequestMock,
+  createGiteaPullRequestMock,
+  getEnterpriseGitHubRepoSlugMock,
+  isBitbucketReviewCreationAuthenticatedMock,
+  resolveDefaultBaseRefViaExecMock,
+  probeAnyExactRefMock,
+  assertRemoteUrlReadableMock
+} = vi.hoisted(() => ({
+  getSshGitProviderMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  ghExecFileAsyncMock: vi.fn(),
+  glabExecFileAsyncMock: vi.fn(),
+  getUpstreamStatusMock: vi.fn(),
+  getProjectSlugMock: vi.fn(),
+  getMergeRequestForBranchOrThrowMock: vi.fn(),
+  getRepoSlugMock: vi.fn(),
+  getPRForBranchOutcomeMock: vi.fn(),
+  getRepoUpstreamMock: vi.fn(),
+  getBitbucketRepoSlugMock: vi.fn(),
+  getBitbucketPullRequestForBranchOrThrowMock: vi.fn(),
+  getAzureDevOpsRepoSlugMock: vi.fn(),
+  getGiteaRepoSlugMock: vi.fn(),
+  createGitLabMergeRequestMock: vi.fn(),
+  createGitHubPullRequestMock: vi.fn(),
+  createBitbucketPullRequestMock: vi.fn(),
+  createAzureDevOpsPullRequestMock: vi.fn(),
+  createGiteaPullRequestMock: vi.fn(),
+  getEnterpriseGitHubRepoSlugMock: vi.fn(),
+  isBitbucketReviewCreationAuthenticatedMock: vi.fn(),
+  resolveDefaultBaseRefViaExecMock: vi.fn(),
+  probeAnyExactRefMock: vi.fn(),
+  assertRemoteUrlReadableMock: vi.fn()
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'SSH git provider unavailable'
+}))
+
+vi.mock('../github/gh-utils', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  ghExecFileAsync: ghExecFileAsyncMock,
+  acquire: vi.fn(async () => {}),
+  release: vi.fn()
+}))
+
+vi.mock('../gitlab/gl-utils', () => ({
+  acquire: vi.fn(async () => {}),
+  release: vi.fn(),
+  glabExecFileAsync: glabExecFileAsyncMock,
+  glabRepoExecOptions: vi.fn(() => ({}))
+}))
+
+vi.mock('../git/runner', () => ({
+  gitOptionalLocksDisabledEnv: vi.fn(() => ({}))
+}))
+
+vi.mock('../git/upstream', () => ({ getUpstreamStatus: getUpstreamStatusMock }))
+
+vi.mock('../git/repo', () => ({
+  resolveDefaultBaseRefViaExec: resolveDefaultBaseRefViaExecMock
+}))
+
+vi.mock('../git/exact-ref-probe', () => ({
+  probeAnyExactRef: probeAnyExactRefMock,
+  isShowRefNoMatchError: vi.fn(() => false)
+}))
+
+vi.mock('../git/worktree-symlink-detection', () => ({
+  findExistingWorktreeSymlinkPaths: vi.fn(async () => [])
+}))
+
+vi.mock('../git/remote-url-probe', () => ({
+  assertRemoteUrlReadable: assertRemoteUrlReadableMock
+}))
+
+vi.mock('../gitlab/client', () => ({
+  getProjectSlug: getProjectSlugMock,
+  getMergeRequest: vi.fn(async () => null),
+  getMergeRequestForBranchOrThrow: getMergeRequestForBranchOrThrowMock
+}))
+
+vi.mock('../gitlab/merge-request-creation', () => ({
+  createGitLabMergeRequest: createGitLabMergeRequestMock
+}))
+
+vi.mock('../github/client', () => ({
+  getRepoSlug: getRepoSlugMock,
+  getRepoUpstream: getRepoUpstreamMock,
+  getPRForBranchOutcome: getPRForBranchOutcomeMock,
+  getGitHubPRLookupRateLimitBlock: vi.fn(async () => null),
+  createGitHubPullRequest: createGitHubPullRequestMock
+}))
+
+vi.mock('../github/github-enterprise-repository', () => ({
+  getEnterpriseGitHubRepoSlug: getEnterpriseGitHubRepoSlugMock
+}))
+
+vi.mock('../bitbucket/client', () => ({
+  getBitbucketRepoSlug: getBitbucketRepoSlugMock,
+  getBitbucketPullRequest: vi.fn(async () => null),
+  getBitbucketPullRequestForBranchOrThrow: getBitbucketPullRequestForBranchOrThrowMock
+}))
+
+vi.mock('../bitbucket/pull-request-creation', () => ({
+  createBitbucketPullRequest: createBitbucketPullRequestMock,
+  isBitbucketReviewCreationAuthenticated: isBitbucketReviewCreationAuthenticatedMock
+}))
+
+vi.mock('../azure-devops/client', () => ({
+  getAzureDevOpsRepoSlug: getAzureDevOpsRepoSlugMock,
+  getAzureDevOpsPullRequest: vi.fn(async () => null),
+  getAzureDevOpsPullRequestForBranchOrThrow: vi.fn(async () => null)
+}))
+
+vi.mock('../azure-devops/pull-request-creation', () => ({
+  createAzureDevOpsPullRequest: createAzureDevOpsPullRequestMock,
+  isAzureDevOpsReviewCreationAuthenticated: vi.fn(async () => true)
+}))
+
+vi.mock('../gitea/client', () => ({
+  getGiteaRepoSlug: getGiteaRepoSlugMock,
+  getGiteaPullRequest: vi.fn(async () => null),
+  getGiteaPullRequestForBranchOrThrow: vi.fn(async () => null)
+}))
+
+vi.mock('../gitea/pull-request-creation', () => ({
+  createGiteaPullRequest: createGiteaPullRequestMock,
+  isGiteaReviewCreationAuthenticated: vi.fn(async () => true)
+}))
+
+import { __resetHostedReviewBranchCacheForTests } from './hosted-review-branch-cache'
+import {
+  getRepoHostedReviewExecutionHostId,
+  hostedReviewSshConnectionId
+} from './hosted-review-execution-host'
+import { RuntimeHostedReviewCommands } from '../runtime/runtime-hosted-review-commands'
+
+const REPO_PATH = '/remote/workspace/repo'
+
+type SshProviderStub = {
+  exec: ReturnType<typeof vi.fn>
+  getStatus: ReturnType<typeof vi.fn>
+  getUpstreamStatus: ReturnType<typeof vi.fn>
+}
+
+const sshProviders = new Map<string, SshProviderStub>()
+
+function makeSshProvider(): SshProviderStub {
+  return {
+    exec: vi.fn(async () => ({ stdout: 'feature\n', stderr: '' })),
+    getStatus: vi.fn(async () => ({ entries: [] })),
+    getUpstreamStatus: vi.fn(async () => ({ hasUpstream: true, ahead: 0, behind: 0 }))
+  }
+}
+
+function makeRepo(overrides: Partial<Repo>): Repo {
+  return {
+    id: 'repo-1',
+    path: REPO_PATH,
+    displayName: 'repo',
+    badgeColor: '#000',
+    addedAt: 0,
+    kind: 'git',
+    ...overrides
+  } as Repo
+}
+
+function makeCommands(repo: Repo): RuntimeHostedReviewCommands {
+  return new RuntimeHostedReviewCommands({
+    resolveRepo: async () => repo,
+    resolveTarget: async () => ({ repo, repoPath: repo.path }),
+    getExecutionOptions: () => undefined,
+    recordCreated: () => {}
+  })
+}
+
+/** Which SSH target the git-state layer actually ran the preflight on, or null for local. */
+function sshTargetThatRanGit(): string | null {
+  for (const [id, provider] of sshProviders) {
+    if (provider.exec.mock.calls.length > 0 || provider.getStatus.mock.calls.length > 0) {
+      return id
+    }
+  }
+  return null
+}
+
+const CREATE_INPUT = {
+  base: 'main',
+  head: 'feature',
+  title: 'Add a thing',
+  body: '',
+  draft: false
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  __resetHostedReviewBranchCacheForTests()
+  sshProviders.clear()
+  sshProviders.set('ssh-a', makeSshProvider())
+  sshProviders.set('ssh-b', makeSshProvider())
+  getSshGitProviderMock.mockImplementation((id: string) => sshProviders.get(id) ?? null)
+
+  gitExecFileAsyncMock.mockImplementation(async (argv: string[]) => ({
+    stdout: argv[0] === 'status' ? '' : 'feature\n',
+    stderr: ''
+  }))
+  ghExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+  glabExecFileAsyncMock.mockResolvedValue({ stdout: '{}', stderr: '' })
+  getUpstreamStatusMock.mockResolvedValue({ hasUpstream: true, ahead: 0, behind: 0 })
+  resolveDefaultBaseRefViaExecMock.mockImplementation(
+    async (run: (argv: string[]) => Promise<{ stdout: string }>) => {
+      await run(['rev-parse', '--abbrev-ref', 'origin/HEAD'])
+      return 'main'
+    }
+  )
+  probeAnyExactRefMock.mockResolvedValue({ found: true, unknown: false })
+  assertRemoteUrlReadableMock.mockResolvedValue(undefined)
+
+  // No forge claims the remote unless a case says so; each test opts its provider in.
+  getProjectSlugMock.mockResolvedValue(null)
+  getRepoSlugMock.mockResolvedValue(null)
+  getRepoUpstreamMock.mockResolvedValue(null)
+  getBitbucketRepoSlugMock.mockResolvedValue(null)
+  getAzureDevOpsRepoSlugMock.mockResolvedValue(null)
+  getGiteaRepoSlugMock.mockResolvedValue(null)
+  getPRForBranchOutcomeMock.mockResolvedValue({ kind: 'not_found' })
+  getMergeRequestForBranchOrThrowMock.mockResolvedValue(null)
+  getBitbucketPullRequestForBranchOrThrowMock.mockResolvedValue(null)
+  getEnterpriseGitHubRepoSlugMock.mockResolvedValue({ host: 'github.com', owner: 'a', repo: 'b' })
+  isBitbucketReviewCreationAuthenticatedMock.mockResolvedValue(true)
+  createGitHubPullRequestMock.mockResolvedValue({ ok: true, number: 7, url: 'https://pr/7' })
+  createGitLabMergeRequestMock.mockResolvedValue({ ok: true, number: 7, url: 'https://mr/7' })
+  createBitbucketPullRequestMock.mockResolvedValue({ ok: true, number: 7, url: 'https://pr/7' })
+  createAzureDevOpsPullRequestMock.mockResolvedValue({ ok: true, number: 7, url: 'https://pr/7' })
+  createGiteaPullRequestMock.mockResolvedValue({ ok: true, number: 7, url: 'https://pr/7' })
+})
+
+describe('hosted-review lookups route on the resolved execution host', () => {
+  it('reads a GitHub review on the SSH host a row names only in executionHostId', async () => {
+    getRepoSlugMock.mockResolvedValue({ host: 'github.com', owner: 'a', repo: 'b' })
+    const commands = makeCommands(makeRepo({ executionHostId: 'ssh:ssh-a' }))
+
+    await commands.getHostedReviewForBranch({ repoSelector: 'repo-1', branch: 'feature' })
+
+    expect(getRepoSlugMock).toHaveBeenCalledWith(REPO_PATH, 'ssh-a')
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith(
+      REPO_PATH,
+      'feature',
+      null,
+      'ssh-a',
+      null,
+      expect.anything()
+    )
+  })
+
+  it('reads a GitLab review on the executionHostId host when connectionId names a different one', async () => {
+    getProjectSlugMock.mockResolvedValue({ host: 'gitlab.com', path: 'acme/widgets' })
+    const commands = makeCommands(makeRepo({ connectionId: 'ssh-b', executionHostId: 'ssh:ssh-a' }))
+
+    await commands.getHostedReviewForBranch({ repoSelector: 'repo-1', branch: 'feature' })
+
+    expect(getProjectSlugMock).toHaveBeenCalledWith(REPO_PATH, 'ssh-a')
+    expect(getMergeRequestForBranchOrThrowMock).toHaveBeenCalledWith(
+      REPO_PATH,
+      'feature',
+      null,
+      'ssh-a'
+    )
+    expect(getProjectSlugMock).not.toHaveBeenCalledWith(REPO_PATH, 'ssh-b')
+  })
+
+  it('does not dial this client for a runtime row whose nested target shares a local name', async () => {
+    getBitbucketRepoSlugMock.mockResolvedValue({ workspace: 'acme', repo: 'widgets' })
+    const commands = makeCommands(
+      makeRepo({ connectionId: 'ssh-b', executionHostId: 'runtime:env-1' })
+    )
+
+    await commands.getHostedReviewForBranch({ repoSelector: 'repo-1', branch: 'feature' })
+
+    expect(getBitbucketRepoSlugMock).toHaveBeenCalledWith(REPO_PATH, null)
+    expect(getSshGitProviderMock).not.toHaveBeenCalledWith('ssh-b')
+  })
+
+  it('keeps a runtime row with no nested target on this process (self-addressed stamp)', async () => {
+    getGiteaRepoSlugMock.mockResolvedValue({ host: 'gitea.example', owner: 'a', repo: 'b' })
+    const commands = makeCommands(makeRepo({ executionHostId: 'runtime:env-1' }))
+
+    await commands.getHostedReviewForBranch({ repoSelector: 'repo-1', branch: 'feature' })
+
+    expect(getGiteaRepoSlugMock).toHaveBeenCalledWith(REPO_PATH, null)
+  })
+
+  it('keeps a legacy connectionId-only SSH row on its target', async () => {
+    getRepoSlugMock.mockResolvedValue({ host: 'github.com', owner: 'a', repo: 'b' })
+    const commands = makeCommands(makeRepo({ connectionId: 'ssh-b' }))
+
+    await commands.getHostedReviewForBranch({ repoSelector: 'repo-1', branch: 'feature' })
+
+    expect(getRepoSlugMock).toHaveBeenCalledWith(REPO_PATH, 'ssh-b')
+  })
+
+  it('does not share a cached answer between two rows at one path on different hosts', async () => {
+    getRepoSlugMock.mockResolvedValue({ host: 'github.com', owner: 'a', repo: 'b' })
+    await makeCommands(makeRepo({ executionHostId: 'ssh:ssh-a' })).getHostedReviewForBranch({
+      repoSelector: 'repo-1',
+      branch: 'feature'
+    })
+    getPRForBranchOutcomeMock.mockClear()
+
+    await makeCommands(
+      makeRepo({ id: 'repo-2', executionHostId: 'local' })
+    ).getHostedReviewForBranch({ repoSelector: 'repo-2', branch: 'feature' })
+
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith(
+      REPO_PATH,
+      'feature',
+      null,
+      null,
+      null,
+      expect.anything()
+    )
+  })
+})
+
+describe('hosted-review creation routes on the resolved execution host', () => {
+  it('runs the GitLab preflight and create on the executionHostId-only SSH host', async () => {
+    getProjectSlugMock.mockResolvedValue({ host: 'gitlab.com', path: 'acme/widgets' })
+    const commands = makeCommands(makeRepo({ executionHostId: 'ssh:ssh-a' }))
+
+    const result = await commands.createHostedReview({
+      repoSelector: 'repo-1',
+      provider: 'gitlab',
+      ...CREATE_INPUT
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sshTargetThatRanGit()).toBe('ssh-a')
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(createGitLabMergeRequestMock).toHaveBeenCalledWith(
+      REPO_PATH,
+      expect.objectContaining({ provider: 'gitlab' }),
+      'ssh:ssh-a'
+    )
+  })
+
+  it('runs the GitHub preflight on the executionHostId host, not the connectionId one', async () => {
+    getRepoSlugMock.mockResolvedValue({ host: 'github.com', owner: 'a', repo: 'b' })
+    const commands = makeCommands(makeRepo({ connectionId: 'ssh-b', executionHostId: 'ssh:ssh-a' }))
+
+    const result = await commands.createHostedReview({
+      repoSelector: 'repo-1',
+      provider: 'github',
+      ...CREATE_INPUT
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sshTargetThatRanGit()).toBe('ssh-a')
+    expect(createGitHubPullRequestMock).toHaveBeenCalledWith(
+      REPO_PATH,
+      expect.objectContaining({ provider: 'github' }),
+      'ssh:ssh-a'
+    )
+  })
+
+  it('creates a Bitbucket review locally for a runtime row rather than dialing its nested target', async () => {
+    getBitbucketRepoSlugMock.mockResolvedValue({ workspace: 'acme', repo: 'widgets' })
+    const commands = makeCommands(
+      makeRepo({ connectionId: 'ssh-b', executionHostId: 'runtime:env-1' })
+    )
+
+    const result = await commands.createHostedReview({
+      repoSelector: 'repo-1',
+      provider: 'bitbucket',
+      ...CREATE_INPUT
+    })
+
+    expect(result.ok).toBe(true)
+    expect(sshTargetThatRanGit()).toBeNull()
+    expect(createBitbucketPullRequestMock).toHaveBeenCalledWith(
+      REPO_PATH,
+      expect.objectContaining({ provider: 'bitbucket' }),
+      'local'
+    )
+  })
+
+  it('reports creation eligibility from the executionHostId-only SSH host', async () => {
+    getAzureDevOpsRepoSlugMock.mockResolvedValue({ organization: 'acme', project: 'p', repo: 'r' })
+    const commands = makeCommands(makeRepo({ executionHostId: 'ssh:ssh-a' }))
+
+    await commands.getHostedReviewCreationEligibility({
+      repoSelector: 'repo-1',
+      branch: 'feature',
+      base: 'main',
+      hasUpstream: true,
+      ahead: 0,
+      behind: 0
+    })
+
+    expect(getAzureDevOpsRepoSlugMock).toHaveBeenCalledWith(REPO_PATH, 'ssh-a')
+    expect(sshTargetThatRanGit()).toBe('ssh-a')
+  })
+
+  it('resolves the GitHub slug for a repo listing on the row it is asked about', async () => {
+    getRepoSlugMock.mockResolvedValue({ host: 'github.com', owner: 'a', repo: 'b' })
+    const commands = makeCommands(makeRepo({ executionHostId: 'ssh:ssh-a' }))
+
+    await commands.getRepoSlug('repo-1')
+
+    expect(getRepoSlugMock).toHaveBeenCalledWith(REPO_PATH, 'ssh-a')
+  })
+})
+
+describe('hosted-review host resolution', () => {
+  it('refuses to dial a runtime host from this process', () => {
+    expect(() => hostedReviewSshConnectionId('runtime:env-1')).toThrow(
+      'is not dispatched by this process'
+    )
+  })
+
+  it('answers with the SSH target for both spellings and local otherwise', () => {
+    expect(hostedReviewSshConnectionId('ssh:ssh-a')).toBe('ssh-a')
+    expect(hostedReviewSshConnectionId('local')).toBeNull()
+    expect(getRepoHostedReviewExecutionHostId({ executionHostId: 'ssh:ssh-a' })).toBe('ssh:ssh-a')
+    expect(getRepoHostedReviewExecutionHostId({ connectionId: 'ssh-b' })).toBe('ssh:ssh-b')
+  })
+
+  it('reads a runtime stamp on a row in this store as self-addressing, not a second machine', () => {
+    // The registration controller only adopts `runtime:` onto a row with no connectionId, so the
+    // checkout is here; a nested target belongs to that server's namespace and is never dialed.
+    expect(getRepoHostedReviewExecutionHostId({ executionHostId: 'runtime:env-1' })).toBe('local')
+    expect(
+      getRepoHostedReviewExecutionHostId({
+        executionHostId: 'runtime:env-1',
+        connectionId: 'ssh-b'
+      })
+    ).toBe('local')
+  })
+})

--- a/src/main/source-control/hosted-review-execution-host.ts
+++ b/src/main/source-control/hosted-review-execution-host.ts
@@ -1,0 +1,49 @@
+import {
+  getRepoExecutionHostId,
+  getSshTargetIdForExecutionHost,
+  LOCAL_EXECUTION_HOST_ID,
+  type ExecutionHostId
+} from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+import {
+  ExecutionHostNotDispatchableError,
+  resolveGitRouteForHost
+} from '../providers/execution-host-provider-dispatch'
+
+/**
+ * The SSH target *this* process may dial for a hosted review, or `null` when the work runs here.
+ *
+ * The hosted-review contract used to carry `connectionId: string | null`, where `null` spelled
+ * "genuinely local", "runtime host" and "could not resolve" alike — so a row naming its owner only
+ * as `executionHostId: ssh:<target>` ran `git status`, `git rev-parse` and the forge CLI against
+ * this machine's copy of a remote path (#11163). Resolving the host first removes that collapse.
+ *
+ * `runtime:` throws rather than degrading: that environment's server runs its own git, and the SSH
+ * target on its repo row is nested in that server's namespace, so dialing it here reaches a
+ * same-named box of ours. Store-backed callers ask `getRepoHostedReviewExecutionHostId` first,
+ * which is the "what may this client dial" question and never hands a `runtime:` id down.
+ */
+export function hostedReviewSshConnectionId(executionHostId: ExecutionHostId): string | null {
+  const route = resolveGitRouteForHost(executionHostId)
+  if (route.kind === 'runtime') {
+    throw new ExecutionHostNotDispatchableError(route.hostId)
+  }
+  return route.kind === 'ssh' ? route.connectionId : null
+}
+
+/**
+ * The host this process may run a hosted review on for a row in *its own* store.
+ *
+ * `getSshTargetIdForExecutionHost` and not `getRepoSshConnectionId`: a `runtime:` stamp on a row in
+ * this store is how a paired client addresses it, not a second machine holding the files. The
+ * runtime registration controller only adopts that stamp onto a row with no `connectionId`
+ * (`runtimeRepoMatchesExecutionHost` refuses to match an SSH row), so the checkout really is here
+ * and this keeps the review that has always been created for it. A row whose files sit on an SSH
+ * host keeps its own target — including one that carries only `executionHostId: ssh:…`.
+ */
+export function getRepoHostedReviewExecutionHostId(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): ExecutionHostId {
+  const hostId = getRepoExecutionHostId(repo)
+  return getSshTargetIdForExecutionHost(hostId) ? hostId : LOCAL_EXECUTION_HOST_ID
+}

--- a/src/main/source-control/hosted-review-gitea.integration.test.ts
+++ b/src/main/source-control/hosted-review-gitea.integration.test.ts
@@ -84,7 +84,11 @@ describe('Gitea hosted review integration', () => {
       )
 
       await expect(
-        getHostedReviewForBranch({ repoPath, branch: 'refs/heads/feature/gitea' })
+        getHostedReviewForBranch({
+          executionHostId: 'local',
+          repoPath,
+          branch: 'refs/heads/feature/gitea'
+        })
       ).resolves.toEqual({
         provider: 'gitea',
         number: 9,

--- a/src/main/source-control/hosted-review.test.ts
+++ b/src/main/source-control/hosted-review.test.ts
@@ -101,7 +101,7 @@ describe('getHostedReviewForBranch', () => {
     await expect(
       getHostedReviewForBranch({
         repoPath: '/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'refs/heads/feature'
       })
     ).resolves.toEqual({
@@ -138,6 +138,7 @@ describe('getHostedReviewForBranch', () => {
 
     await expect(
       getHostedReviewForBranch({
+        executionHostId: 'local',
         repoPath: '/repo',
         branch: 'feature',
         linkedGitHubPR: 3
@@ -147,7 +148,7 @@ describe('getHostedReviewForBranch', () => {
       number: 3,
       status: 'pending'
     })
-    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', 'feature', 3, undefined, null, {
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', 'feature', 3, null, null, {
       currentHeadOid: null
     })
   })
@@ -168,6 +169,7 @@ describe('getHostedReviewForBranch', () => {
 
     await expect(
       getHostedReviewForBranch({
+        executionHostId: 'local',
         repoPath: '/repo',
         branch: 'feature/wsl',
         linkedBitbucketPR: 22,
@@ -180,14 +182,14 @@ describe('getHostedReviewForBranch', () => {
     })
 
     const executionOptions = { localGitExecOptions: { wslDistro: 'Ubuntu' } }
-    expect(getProjectSlugMock).toHaveBeenCalledWith('/repo', undefined, executionOptions)
-    expect(getRepoSlugMock).toHaveBeenCalledWith('/repo', undefined, executionOptions)
-    expect(getBitbucketRepoSlugMock).toHaveBeenCalledWith('/repo', undefined, executionOptions)
+    expect(getProjectSlugMock).toHaveBeenCalledWith('/repo', null, executionOptions)
+    expect(getRepoSlugMock).toHaveBeenCalledWith('/repo', null, executionOptions)
+    expect(getBitbucketRepoSlugMock).toHaveBeenCalledWith('/repo', null, executionOptions)
     expect(getBitbucketPullRequestForBranchMock).toHaveBeenCalledWith(
       '/repo',
       'feature/wsl',
       22,
-      undefined,
+      null,
       executionOptions
     )
   })
@@ -211,6 +213,7 @@ describe('getHostedReviewForBranch', () => {
 
     await expect(
       getHostedReviewForBranch({
+        executionHostId: 'local',
         repoPath: '/repo',
         branch: '',
         fallbackGitHubPR: 42
@@ -220,7 +223,7 @@ describe('getHostedReviewForBranch', () => {
       number: 42,
       status: 'success'
     })
-    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', '', null, undefined, 42, {
+    expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', '', null, null, 42, {
       acceptMergedFallbackPR: true,
       currentHeadOid: null
     })
@@ -244,7 +247,7 @@ describe('getHostedReviewForBranch', () => {
     await expect(
       getHostedReviewForBranch({
         repoPath: '/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'feature/bitbucket',
         linkedBitbucketPR: 11
       })
@@ -292,7 +295,7 @@ describe('getHostedReviewForBranch', () => {
     await expect(
       getHostedReviewForBranch({
         repoPath: '/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'feature/gitea',
         linkedGiteaPR: 14
       })
@@ -340,7 +343,7 @@ describe('getHostedReviewForBranch', () => {
     await expect(
       getHostedReviewForBranch({
         repoPath: '/repo',
-        connectionId: 'ssh-1',
+        executionHostId: 'ssh:ssh-1',
         branch: 'feature/azure',
         linkedAzureDevOpsPR: 21
       })

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -1,6 +1,8 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type { HostedReviewInfo } from '../../shared/hosted-review'
 import { assertRemoteUrlReadable } from '../git/remote-url-probe'
 import { getForgeProviderForRepository, type ForgeProviderId } from './forge-provider'
+import { hostedReviewSshConnectionId } from './hosted-review-execution-host'
 import { withHostedReviewBranchCache } from './hosted-review-branch-cache'
 import {
   getHostedReviewLocalGitOptions,
@@ -31,7 +33,7 @@ function reviewLinkForProvider(
 export async function getHostedReviewForBranch(
   input: {
     repoPath: string
-    connectionId?: string | null
+    executionHostId: ExecutionHostId
     branch: string
     linkedGitHubPR?: number | null
     fallbackGitHubPR?: number | null
@@ -71,7 +73,7 @@ export async function getHostedReviewForBranch(
     async () => {
       const provider = await getForgeProviderForRepository({
         repoPath: input.repoPath,
-        connectionId: input.connectionId,
+        executionHostId: input.executionHostId,
         ...(input.localGitExecOptions ? { localGitExecOptions: input.localGitExecOptions } : {})
       })
       if (!provider) {
@@ -81,14 +83,15 @@ export async function getHostedReviewForBranch(
         // Throwing keeps it on the cache's failure path instead (P1-D).
         await assertRemoteUrlReadable({
           repoPath: input.repoPath,
-          connectionId: input.connectionId,
+          // The probe is the leaf that still dials: it takes the SSH target, not the host id.
+          connectionId: hostedReviewSshConnectionId(input.executionHostId),
           ...getHostedReviewLocalGitOptions(input)
         })
         return null
       }
       return provider.getReviewForBranch({
         repoPath: input.repoPath,
-        connectionId: input.connectionId,
+        executionHostId: input.executionHostId,
         branch: branchName,
         ...(input.localGitExecOptions ? { localGitExecOptions: input.localGitExecOptions } : {}),
         githubCurrentHeadOid: headOid,

--- a/src/main/source-control/stacked-hosted-review-creation.test.ts
+++ b/src/main/source-control/stacked-hosted-review-creation.test.ts
@@ -47,12 +47,12 @@ describe('createStackedHostedReview', () => {
       stackNumber: 50
     })
 
-    const result = await createStackedHostedReview('/repo', input, 'ssh-1')
+    const result = await createStackedHostedReview('/repo', input, 'ssh:ssh-1')
 
     expect(result).toMatchObject({ ok: true, stackNumber: 50 })
-    expect(createMock).toHaveBeenCalledWith('/repo', input, 'ssh-1', {})
+    expect(createMock).toHaveBeenCalledWith('/repo', input, 'ssh:ssh-1', {})
     expect(registerMock).toHaveBeenCalledWith(
-      expect.objectContaining({ parentReview, currentReview, connectionId: 'ssh-1' })
+      expect.objectContaining({ parentReview, currentReview, executionHostId: 'ssh:ssh-1' })
     )
   })
 
@@ -70,7 +70,7 @@ describe('createStackedHostedReview', () => {
       stackNumber: 50
     })
 
-    await createStackedHostedReview('/repo', input)
+    await createStackedHostedReview('/repo', input, 'local')
 
     expect(createMock).not.toHaveBeenCalled()
     expect(registerMock).toHaveBeenCalledOnce()
@@ -83,7 +83,7 @@ describe('createStackedHostedReview', () => {
       error: 'Choose the top pull request.'
     })
 
-    const result = await createStackedHostedReview('/repo', input)
+    const result = await createStackedHostedReview('/repo', input, 'local')
 
     expect(result).toMatchObject({ ok: false, code: 'validation' })
     expect(createMock).not.toHaveBeenCalled()

--- a/src/main/source-control/stacked-hosted-review-creation.ts
+++ b/src/main/source-control/stacked-hosted-review-creation.ts
@@ -1,3 +1,4 @@
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type {
   CreateStackedHostedReviewInput,
   CreateStackedHostedReviewResult,
@@ -13,17 +14,17 @@ import type { HostedReviewExecutionOptions } from './hosted-review-git-options'
 export async function createStackedHostedReview(
   repoPath: string,
   input: CreateStackedHostedReviewInput,
-  connectionId?: string | null,
+  executionHostId: ExecutionHostId,
   options: HostedReviewExecutionOptions = {}
 ): Promise<CreateStackedHostedReviewResult> {
-  const plan = await prepareGitHubStackedPullRequest(repoPath, input, connectionId, options)
+  const plan = await prepareGitHubStackedPullRequest(repoPath, input, executionHostId, options)
   if (!plan.ok) {
     return plan
   }
 
   let currentReview: (HostedReviewSummary & { number: number }) | null = plan.currentReview
   if (!currentReview) {
-    const created = await createHostedReview(repoPath, input, connectionId, options)
+    const created = await createHostedReview(repoPath, input, executionHostId, options)
     if (!created.ok) {
       if (!created.existingReview?.number) {
         return created
@@ -54,7 +55,7 @@ export async function createStackedHostedReview(
     repository: plan.repository,
     parentReview: plan.parentReview,
     currentReview,
-    connectionId,
+    executionHostId,
     options
   })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​978 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​333 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​645 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​280 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​124 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 |

<!-- /orca-pr-loc -->

Follow-up scoped out of #18377. Sixth in the series after #18296, #18307, #18325, #18358, #18377.

## The defect

`ForgeProvider.createReview(repoPath, input, connectionId, options)` and the `connectionId` on `ForgeProviderRepositoryContext` carried the same collapse the five prior migrations closed: `string | null` spells **"genuinely local"**, **"runtime host"** and **"could not resolve"** with one value.

The value was decided two layers up — `repo.connectionId ?? null` at the `hostedReview:*` IPC handlers and in `RuntimeHostedReviewCommands` — and from there it fanned out through `getProjectSlug`, `getCurrentBranch`, `hasUncommittedChanges`, `getDefaultBaseRef`, `baseRefExistsOnRemote`, `getHostedReviewUpstreamStatus`, `isProviderAuthenticated` and `getHostedReviewForBranch`. So a repo row naming its owner only as `executionHostId: ssh:<target>` ran the **entire** review path against this machine's copy of a remote path (#11163): `git rev-parse --abbrev-ref HEAD`, `git status --porcelain`, the base-on-remote ref probe, the upstream divergence read, and `gh`/`glab` with no host flags. A `runtime:` row handed its *nested* SSH target to this client's dispatch table — a same-named box of ours.

Fixed at the decision point, not at the leaf: `getRepoHostedReviewExecutionHostId(repo)` resolves the host where `repo.connectionId ?? null` used to be read, and a required `ExecutionHostId` is threaded through the contract. The forge clients themselves (`src/main/gitlab/`, `src/main/github/`, …) keep taking a connection id — the conversion happens once, at the contract boundary, through #18296's `resolveGitRouteForHost`.

## Removed, not added beside

The parameter is **removed**, so all five implementations — GitLab, GitHub, Bitbucket, Azure DevOps, Gitea — and every caller became a compile error. This mattered more than usual: `ExecutionHostId` is a subtype of `string`, so leaving an implementation on `connectionId?: string | null` would still have satisfied a widened `createReview` signature and silently received `'ssh:host-a'` as a connection id. Each of the five now takes `executionHostId: ExecutionHostId` and resolves it itself.

**`@ts-nocheck` check (per #18325):** none of `src/main/source-control/`, `src/main/gitlab/`, `src/main/github/`, `src/main/bitbucket/`, `src/main/gitea/`, `src/main/azure-devops/`, `src/main/ipc/hosted-review.ts` or `src/main/runtime/runtime-hosted-review-commands.ts` carries one, so the compile-error guarantee is real — the #18358 case, not the #18325 one. (`src/main/runtime/orca-runtime-file-commands.ts` does carry `@ts-nocheck`, but it only constructs `RuntimeHostedReviewCommands` with deps this PR does not change.)

## Also fixed at the sites

- **The branch cache scoped entries on `connectionId ?? ''`.** Two rows at one path on different hosts shared one cached review, one backoff deadline and one invalidation. Now keyed on the resolved host, the same collapse #18377 fixed for its probe location key.
- **`hostedReview:create` read the raw field for file-holder questions.** An `executionHostId`-only SSH row resolved shared symlink paths locally (reading an unrelated `orca.yaml`, the exact thing the existing comment warns about) and `resolve()`d a remote POSIX worktree path. Those ask `getRepoSshConnectionId` — "which host holds the files" — not the dialable one.
- **An unreachable SSH host no longer falls through to the local branch** in the git-state layer. `provider: null` is "remote and currently unreachable", which is not "local" (docs/reference/ssh-execution-boundary.md).

## The `runtime:` exception

`hostedReviewSshConnectionId` **throws** for `runtime:` — that environment's server runs its own git, and the SSH target on its repo row is nested in that server's namespace.

But store-backed callers ask `getRepoHostedReviewExecutionHostId` first, which is the *"what may this client dial"* question and answers `local` for a `runtime:` row. That is deliberate and matches #18377's exception: `RuntimeRepositoryRegistrationController.add` only adopts a `runtime:` stamp onto a row with **no** `connectionId` (`runtimeRepoMatchesExecutionHost` refuses to match a row that already names an SSH owner), so the checkout really is in this process. Refusing would have regressed a runtime server creating reviews for its own rows — the same shape as #18377's `git clone` finding. Both branches are covered by tests.

## Wire compatibility

**No wire change.** `connectionId` on `CreateHostedReviewArgs`, `CreateStackedHostedReviewArgs` and `HostedReviewCreationEligibilityArgs` in `src/shared/hosted-review.ts` is untouched. Every host already ignores it in favour of the repo row it looked up, so it is inert request content; removing it from the request types would only churn a schema older clients still populate, with nothing gained. The main-side eligibility input `Omit`s it instead, so nothing on this side can read the ambiguous field again. Nothing this PR touches is *published* content — no result field carries a host id.

## Verification

- `pnpm tc` — clean.
- `pnpm test src` — whole tree. 7467 files pass. One unrelated file (`src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts`, an 800-iteration fuzz) hit the 30s vitest timeout under full-tree load and passes in 11.3s on its own; it touches no hosted-review code.
- `pnpm run check:code-quality:changed` — 0 new findings across 40 changed files.
- `oxlint` — clean. `max-lines` was proven to fire first with a 400-line positive control (it caught `hosted-review-creation-eligibility.test.ts` crossing 800 and was resolved by collapsing a repeated fixture, **not** by a disable or a bump).
- `oxfmt --check` — clean.
- Docker SSH lane (`pnpm test:e2e:ssh-docker`).

### Failed-first: 9 of 14

`src/main/source-control/hosted-review-execution-host-routing.test.ts` drives the two decision points through their unchanged public entry points (`RuntimeHostedReviewCommands`), so it runs against the pre-change tree. **9 failed / 5 passed** before the change.

Two SSH targets (`ssh-a`, `ssh-b`) are registered simultaneously in every case, and the `runtime:` cases reuse `ssh-b` as the nested target so a wrong-namespace dial cannot hide behind a matching name. Four forge providers are exercised — GitHub, GitLab, Bitbucket, Azure DevOps, plus Gitea in the runtime-stamp case — since this is a shared contract.

Failed first (9):
- GitHub review lookup on an `executionHostId`-only SSH row
- GitLab review lookup where `connectionId` names a *different* registered target
- Bitbucket lookup on a `runtime:` row must not dial this client's same-named `ssh-b`
- branch cache must not serve one host's answer to a row at the same path on another host
- GitLab create: preflight git and the create must both land on `ssh-a`, never local
- GitHub create: preflight must follow `executionHostId`, not `connectionId`
- Bitbucket create on a `runtime:` row must stay local rather than dial the nested target
- Azure DevOps creation eligibility on an `executionHostId`-only SSH row
- `getRepoSlug` on an `executionHostId`-only SSH row

Passed before and after — intended no-ops (5):
- **Gitea lookup on a `runtime:` row with no nested target.** `connectionId ?? null` already answered `null`; the test pins the self-addressed-stamp exception so a future "refuse runtime" change has to confront it.
- **Legacy `connectionId`-only SSH row keeps its target.** Regression guard for the incumbent spelling.
- **Three unit tests on the new module's refusal contract** (`runtime:` throws; both SSH spellings resolve; a `runtime:` row in this store reads as `local` with and without a nested target). They exercise a module this PR adds, so they cannot fail against a tree that lacks it — they exist to keep the exception from being silently widened.
