### PR TITLE
docs(ssh): document keep-alive-until-reset as the default grace

### DIFF
--- a/docs/site/content/docs/ssh.mdx
+++ b/docs/site/content/docs/ssh.mdx
@@ -49,7 +49,7 @@ Remote worktrees show a chip with live SSH status — green connected, yellow re
 
 ## Sessions across app close
 
-Closing the desktop app no longer kills your remote PTY sessions. Remote terminal sessions are leased through the relay running on the remote host, so they survive Orca closing on your laptop. When you reopen the app and reconnect to the target, leased PTYs are restored to their tabs in the **attached** state, with their scrollback intact. A short grace period (5 minutes by default, configurable per target) gives the relay time to ride out a quick reconnect before tearing down detached sessions.
+Closing the desktop app no longer kills your remote PTY sessions. Remote terminal sessions are leased through the relay running on the remote host, so they survive Orca closing on your laptop. When you reopen the app and reconnect to the target, leased PTYs are restored to their tabs in the **attached** state, with their scrollback intact. By default there is no countdown at all: **Keep terminals alive until reset** is on for every target, so detached sessions keep running until you end them explicitly — **End Remote Terminals**, **Reset Relay**, removing the target, or closing the tab. Turn that switch off under **Advanced Connection** to set a bounded **Timeout after disconnect** for that target instead; the form starts at 24 hours and accepts 60 seconds to 7 days, after which the relay tears down detached sessions. Losing contact with a host is not evidence that its work stopped, so a remote session you cannot currently reach should not be assumed dead — check the host before starting a second agent on the same worktree.
 
 ## Downloading remote files and folders
 


### PR DESCRIPTION
Closes #18277.

## What

`docs/site/content/docs/ssh.mdx` told users that detached remote PTYs get "a short grace period (5 minutes by default, configurable per target)" before the relay tears them down. Five minutes matches **none** of the shipped constants in `src/shared/ssh-types.ts` — not `MIN` (60s), not the bounded form default (24h), not the legacy default (3h), and not the actual default:

```ts
export const DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS = 0
```

The paragraph now documents the real behavior: keep-alive-until-reset by default, with the bounded opt-out described in the app's own words.

## Why it matters

This is the exact failure `docs/reference/ssh-execution-boundary.md` exists to prevent. A user or agent following `/docs/ssh` would compute "disconnected 20 minutes ago > 5 minutes, therefore dead," treat a still-`live` remote PTY as `exited`, and start a second agent on the same worktree. **Loss of contact is never evidence of process death** — the docs page was actively teaching people to infer death from elapsed time.

## Verified: the default really is keep-alive, not a long timeout

Before writing docs that promise "until reset," I traced the value through the relay rather than trusting the constant's name:

- `PtyHandler.startGraceTimer` (`src/relay/pty-handler.ts:3024`) returns early on `timeoutMs === 0` — **no timer is ever armed**, so there is no elapsed-time path to teardown while PTYs are pooled.
- `decideRelayGrace` (`src/relay/relay-grace-branch.ts`) reaches its bounded `idle-no-ptys` branch only when `relayIdle` is true, which requires zero pooled PTYs *and* zero admitted-but-unpooled creations. A relay with nothing to preserve is capped at 15 minutes; a relay holding live work is not.
- `RelayGraceLifecycle.start` records `graceDeadlineAt = null` for a zero decision — deadline-less, not long-deadline.

So nothing is reclaimed on elapsed time under the shipped default. That is consistent with the precedent this area follows elsewhere: tmux never destroys a session on client loss (`destroy-unattached` defaults off), mosh defaults `MOSH_SERVER_NETWORK_TMOUT` to 0, and VS Code uses client-side evidence only to *shorten* a grace, never to kill. Only the explicit, user-unchecked bounded mode (60s–7d, form default 24h) tears down on time, and that stays unchanged here.

## Upgrade / behavior notes

- **No behavior change.** No constant, relay path, or UI value moved; this is prose only. Users are not being switched to a new default — they were already on it and the page misdescribed it.
- Existing targets are unaffected for the same reason. Worth noting for reviewers that `normalizeSshTarget` (`src/main/persistence/leasing-ssh-ptys/ssh-normalization.ts:37-43`) already strips a persisted legacy `10800`, so targets carrying the old 3h form default also resolve to `0` at load — the page is now correct for legacy targets too, not just fresh ones.
- **Nothing crosses the wire.** No RPC param, stream frame, or published host content is touched, so `docs/reference/remote-wire-compatibility.md` has no bearing.
- UI labels quoted in the new copy (**Keep terminals alive until reset**, **Timeout after disconnect**, **Advanced Connection**, **End Remote Terminals**, **Reset Relay**) were checked against `src/renderer/src/i18n/locales/en.json` — all verbatim, so the docs name controls that actually exist.

## Tests

**No test added, and none is warranted — stated plainly rather than padded.** The change has no code path: it is a documented value that already had full coverage on the code side. There is no assertion that would fail before this diff and pass after it, and the docs package (`docs/site/tests/*.test.mjs`) has no existing constant-assertion pattern that imports from `src/` — inventing a markdown parser to enforce prose was explicitly out of scope. Behavior-change-to-test ratio: 0 changes, 0 tests. Intended no-op: everything under `src/`.

## Verification

| Check | Result |
|---|---|
| `rg -n "5 minute" docs/site/content/docs/ssh.mdx` | empty |
| `rg -n "5 minute\|5-minute\|cinco minutos\|5 分钟\|5分" docs/site` | empty (docs site is English-only; no locale copies of this page exist) |
| `rg "5 minute" docs/site docs/reference/ssh-execution-boundary.md` | empty |
| `docs/site` tests (`node --test tests/*.test.mjs`) | 13/13 pass |
| `pnpm tc` | exit 0 |
| `pnpm test src` (whole tree) | 69,581 passed / 5 failed — all 5 are parallel-load flakes, each re-verified passing in isolation (see below) |
| `pnpm run check:code-quality:changed` | exit 0 (no changed JS/TS) |

The 5 full-run failures were `remote-runtime-shared-control-connection` (socket timing), `terminal-output-frame-chunks-equivalence` (800-payload fuzz), `orchestration-creator-authority-performance` (a wall-clock perf bound), `codex-tui-resume-real-binary.integration`, and `browser-route-h3-egress.electron`. Re-run in isolation on this branch: 3 files / 53 tests passed, then 2 files / 2 tests passed — 5 for 5 green. None of them can be reached by a one-line MDX prose edit; they are timing and environment sensitivity under a fully parallel local run.

Docker SSH lane not run: no relay or lifecycle code is touched.

`docs/reference/ssh-execution-boundary.md` was left alone — its Survival section already states default `0`, unchecked 60s–7d, form default 24h, and carried no 5-minute figure to fix. Per the issue, no files under `plans/` are committed (the directory does not exist in this repo).
