### PR TITLE
fix(skills): orchestration stub fallback uses run-list, which works with no Run bound

### DIFF
--- a/skill-stubs/orchestration.md
+++ b/skill-stubs/orchestration.md
@@ -57,7 +57,7 @@ read-only bootstrap to orient. Do not dead-end and do not invent commands:
 
 ```text
 ORCA status --json
-ORCA orchestration task-list --json
+ORCA orchestration run-list --json
 ORCA terminal list --json
 ```
 

--- a/skills/orchestration/SKILL.md
+++ b/skills/orchestration/SKILL.md
@@ -76,7 +76,7 @@ read-only bootstrap to orient. Do not dead-end and do not invent commands:
 
 ```text
 ORCA status --json
-ORCA orchestration task-list --json
+ORCA orchestration run-list --json
 ORCA terminal list --json
 ```
 


### PR DESCRIPTION
## ELI5

When an agent's Orca is too old to serve the full guide, the orchestration stub hands it three commands to get its bearings. One of the three can't work yet, so the agent hits an error inside the block that tells it not to get stuck.

## What Changed

One command in the pre-guide fallback block of `skill-stubs/orchestration.md`:

```diff
-ORCA orchestration task-list --json
+ORCA orchestration run-list --json
```

`skills/orchestration/SKILL.md` is the generated projection, regenerated with `node config/scripts/generate-bundled-skill-guides.mjs --write`. No other file changes.

## Why

`task-list` needs a bound Run. With nothing bound it returns `run_required` ("No Run is bound. Use orchestration run-create or run-use first."), which is the state an agent is in when it reaches that block. The prose above the block says "use only this bounded, read-only bootstrap to orient. Do not dead-end and do not invent commands", so the agent has no sanctioned move left and stops.

`run-list` is the read-only orchestration call that answers with no Run bound, so it keeps the block's intent without asking the agent for state it doesn't have yet.

`task-list` stays as it is everywhere else. In `skill-guides/orchestration.md` and the CLI docs it appears after a Run has been created or adopted, which is correct.

## Linked Issue

Fixes #18384 

## Visual Proof

N/A. Documentation content inside a skill stub, no UI or interaction change.

## Testing

Against Orca 1.4.196 on Linux, in a shell outside an Orca-managed terminal:

```bash
orca-ide orchestration task-list --json   # "ok": false, "code": "run_required"
orca-ide orchestration run-list --json    # "ok": true
orca-ide status --json                    # "ok": true
orca-ide terminal list --json             # "ok": true
```

`node config/scripts/generate-bundled-skill-guides.mjs --check` passes, so the stub and its projection are in sync.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No new test. The existing `verify:bundled-skill-guides` gate already covers the invariant this change could break, which is the stub and its projection drifting apart. A test asserting that the commands in a fallback block run without prior state would be worth having, but it needs a live runtime and belongs in its own PR.

## AI Disclosure

Claude Opus 5, used to audit both stubs against the running 1.4.196 CLI, find the failing command, and apply the change. I ran every command above against the live binary rather than inferring the output.

## Review

Two things worth a reviewer's eye. The first is whether `run-list` is the call you want in that block at all, or whether the block should drop to `status` and `terminal list` and say plainly that orchestration state needs a Run first. The second is the sibling stub: `skill-stubs/orca-cli.md` uses `worktree ps` and `terminal list` there, and both answer with no state, so it needs no change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: none, the change removes no guard and adds no capability. Cross-platform: the stub text is platform-neutral and the command exists on all three. Remote SSH and mobile: not touched. Backwards compatibility: `run-list` predates this change and the block is advisory text for older binaries, so nothing breaks for anyone already following it. Performance: not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)