### PR TITLE
fix(terminal): remove split panes the host retired from a remote-server tab

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   isHostAuthoritativeLayout,
-  planTerminalLiveLayoutInsertions
+  planTerminalLiveLayoutInsertions,
+  planTerminalLiveLayoutRemovals
 } from './terminal-live-layout-reconciliation'
 import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
 
@@ -230,5 +231,33 @@ describe('planTerminalLiveLayoutInsertions', () => {
     }
 
     expect(planTerminalLiveLayoutInsertions(layout, [])).toEqual([])
+  })
+})
+
+describe('planTerminalLiveLayoutRemovals', () => {
+  it('plans the mounted leaf a host-retired layout no longer names', () => {
+    // Why: closing one pane of a remote-server split kills its PTY on the host,
+    // which retires the leaf and republishes a one-leaf layout; the pane mounted
+    // for the retired leaf must go too, or it lingers as a blank ghost.
+    const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
+
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'])).toEqual(['leaf-b'])
+  })
+
+  it('plans nothing when every mounted leaf is still in the layout', () => {
+    const layout: TerminalPaneLayoutNode = {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: 'leaf-a' },
+      second: { type: 'leaf', leafId: 'leaf-b' }
+    }
+
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'])).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a'])).toEqual([])
+  })
+
+  it('plans nothing for an empty layout', () => {
+    expect(planTerminalLiveLayoutRemovals(null, ['leaf-a'])).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(undefined, ['leaf-a'])).toEqual([])
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
@@ -3,7 +3,8 @@ import {
   isHostAuthoritativeLayout,
   planTerminalLiveLayoutInsertions,
   planTerminalLiveLayoutRemovals,
-  selectRetiredPaneIds
+  selectRetiredPaneIds,
+  trackRetiredLeafIds
 } from './terminal-live-layout-reconciliation'
 import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
 
@@ -236,6 +237,7 @@ describe('planTerminalLiveLayoutInsertions', () => {
 })
 
 describe('planTerminalLiveLayoutRemovals', () => {
+  // Every mounted leaf counted as retired: the layout alone must veto removals.
   const BOTH = new Set(['leaf-a', 'leaf-b'])
 
   it('plans the mounted leaf a host-retired layout no longer names', () => {
@@ -244,7 +246,9 @@ describe('planTerminalLiveLayoutRemovals', () => {
     // for the retired leaf must go too, or it lingers as a blank ghost.
     const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
 
-    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'], BOTH)).toEqual(['leaf-b'])
+    expect(
+      planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'], new Set(['leaf-b']))
+    ).toEqual(['leaf-b'])
   })
 
   it('plans nothing when every mounted leaf is still in the layout', () => {
@@ -304,5 +308,98 @@ describe('selectRetiredPaneIds', () => {
 
   it('skips a leaf that has no mounted pane', () => {
     expect(selectRetiredPaneIds(['leaf-x'], view({ 1: 'pty-a', 2: null }))).toEqual([])
+  })
+})
+
+describe('trackRetiredLeafIds', () => {
+  it('retires a mounted leaf the host dropped from its layout', () => {
+    expect(
+      trackRetiredLeafIds({
+        retiredLeafIds: new Set(),
+        previousLayoutLeafIds: new Set(['leaf-a', 'leaf-b']),
+        layoutLeafIds: new Set(['leaf-a']),
+        mountedLeafIds: ['leaf-a', 'leaf-b']
+      })
+    ).toEqual(new Set(['leaf-b']))
+  })
+
+  it('keeps a retired leaf until its pane is gone', () => {
+    // Why: the removal may have been skipped while the transport still held its
+    // PTY; the next reconciliation must still see the leaf as retired.
+    const args = {
+      retiredLeafIds: new Set(['leaf-b']),
+      previousLayoutLeafIds: new Set(['leaf-a']),
+      layoutLeafIds: new Set(['leaf-a'])
+    }
+    expect(trackRetiredLeafIds({ ...args, mountedLeafIds: ['leaf-a', 'leaf-b'] })).toEqual(
+      new Set(['leaf-b'])
+    )
+    expect(trackRetiredLeafIds({ ...args, mountedLeafIds: ['leaf-a'] })).toEqual(new Set())
+  })
+
+  it('forgets a retired leaf the host names again', () => {
+    expect(
+      trackRetiredLeafIds({
+        retiredLeafIds: new Set(['leaf-b']),
+        previousLayoutLeafIds: new Set(['leaf-a']),
+        layoutLeafIds: new Set(['leaf-a', 'leaf-b']),
+        mountedLeafIds: ['leaf-a', 'leaf-b']
+      })
+    ).toEqual(new Set())
+  })
+
+  it('never retires a leaf the host has not named', () => {
+    expect(
+      trackRetiredLeafIds({
+        retiredLeafIds: new Set(),
+        previousLayoutLeafIds: new Set(['leaf-a']),
+        layoutLeafIds: new Set(['leaf-a']),
+        mountedLeafIds: ['leaf-a', 'leaf-new']
+      })
+    ).toEqual(new Set())
+  })
+})
+
+describe('host retirement that lands before the transport teardown', () => {
+  it('removes the pane on the reconciliation after its PTY clears', () => {
+    // Why: the host drops the leaf and ends its PTY in one step, but the two
+    // reach the client separately. If the layout arrives first the pane still
+    // holds its PTY and must not be closed yet; once the exit lands and rewrites
+    // the layout bindings, the effect runs again and must close it then.
+    const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
+    const mounted = ['leaf-a', 'leaf-b']
+    const paneIdForLeaf = (leafId: string) =>
+      leafId === 'leaf-a' ? 1 : leafId === 'leaf-b' ? 2 : null
+
+    let retired = trackRetiredLeafIds({
+      retiredLeafIds: new Set(),
+      previousLayoutLeafIds: new Set(mounted),
+      layoutLeafIds: new Set(['leaf-a']),
+      mountedLeafIds: mounted
+    })
+    let removals = planTerminalLiveLayoutRemovals(layout, mounted, retired)
+    expect(removals).toEqual(['leaf-b'])
+    expect(
+      selectRetiredPaneIds(removals, {
+        paneCount: 2,
+        paneIdForLeaf,
+        ptyIdForPane: (paneId) => (paneId === 2 ? 'pty-b' : 'pty-a')
+      })
+    ).toEqual([])
+
+    retired = trackRetiredLeafIds({
+      retiredLeafIds: retired,
+      previousLayoutLeafIds: new Set(['leaf-a']),
+      layoutLeafIds: new Set(['leaf-a']),
+      mountedLeafIds: mounted
+    })
+    removals = planTerminalLiveLayoutRemovals(layout, mounted, retired)
+    expect(
+      selectRetiredPaneIds(removals, {
+        paneCount: 2,
+        paneIdForLeaf,
+        ptyIdForPane: (paneId) => (paneId === 2 ? null : 'pty-a')
+      })
+    ).toEqual([2])
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   isHostAuthoritativeLayout,
   planTerminalLiveLayoutInsertions,
-  planTerminalLiveLayoutRemovals
+  planTerminalLiveLayoutRemovals,
+  selectRetiredPaneIds
 } from './terminal-live-layout-reconciliation'
 import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
 
@@ -259,5 +260,35 @@ describe('planTerminalLiveLayoutRemovals', () => {
   it('plans nothing for an empty layout', () => {
     expect(planTerminalLiveLayoutRemovals(null, ['leaf-a'])).toEqual([])
     expect(planTerminalLiveLayoutRemovals(undefined, ['leaf-a'])).toEqual([])
+  })
+})
+
+describe('selectRetiredPaneIds', () => {
+  const view = (ptyIdsByPane: Record<number, string | null | undefined>) => ({
+    paneCount: Object.keys(ptyIdsByPane).length,
+    paneIdForLeaf: (leafId: string) => (leafId === 'leaf-b' ? 2 : leafId === 'leaf-c' ? 3 : null),
+    ptyIdForPane: (paneId: number) => ptyIdsByPane[paneId]
+  })
+
+  it('closes the pane whose transport lost its PTY', () => {
+    // Why: the host retired the leaf because its PTY ended, so a pane that no
+    // longer has one is exactly the blank ghost the layout stopped naming.
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 1: 'pty-a', 2: null }))).toEqual([2])
+  })
+
+  it('keeps a pane still bound to a PTY or not yet attached to a transport', () => {
+    // A stale snapshot may simply not name a live pane yet; a pane with no
+    // transport is still mounting. Neither is evidence of a retired leaf.
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 1: 'pty-a', 2: 'pty-b' }))).toEqual([])
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 1: 'pty-a', 2: undefined }))).toEqual([])
+  })
+
+  it('never removes the last pane on the tab', () => {
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 2: null }))).toEqual([])
+    expect(selectRetiredPaneIds(['leaf-b', 'leaf-c'], view({ 2: null, 3: null }))).toEqual([2])
+  })
+
+  it('skips a leaf that has no mounted pane', () => {
+    expect(selectRetiredPaneIds(['leaf-x'], view({ 1: 'pty-a', 2: null }))).toEqual([])
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
@@ -236,13 +236,15 @@ describe('planTerminalLiveLayoutInsertions', () => {
 })
 
 describe('planTerminalLiveLayoutRemovals', () => {
+  const BOTH = new Set(['leaf-a', 'leaf-b'])
+
   it('plans the mounted leaf a host-retired layout no longer names', () => {
     // Why: closing one pane of a remote-server split kills its PTY on the host,
     // which retires the leaf and republishes a one-leaf layout; the pane mounted
     // for the retired leaf must go too, or it lingers as a blank ghost.
     const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
 
-    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'])).toEqual(['leaf-b'])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'], BOTH)).toEqual(['leaf-b'])
   })
 
   it('plans nothing when every mounted leaf is still in the layout', () => {
@@ -253,13 +255,25 @@ describe('planTerminalLiveLayoutRemovals', () => {
       second: { type: 'leaf', leafId: 'leaf-b' }
     }
 
-    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'])).toEqual([])
-    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a'])).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'], BOTH)).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a'], BOTH)).toEqual([])
   })
 
   it('plans nothing for an empty layout', () => {
-    expect(planTerminalLiveLayoutRemovals(null, ['leaf-a'])).toEqual([])
-    expect(planTerminalLiveLayoutRemovals(undefined, ['leaf-a'])).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(null, ['leaf-a'], BOTH)).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(undefined, ['leaf-a'], BOTH)).toEqual([])
+  })
+
+  it('leaves a mounted leaf the host has never named alone', () => {
+    // Why: a pane the client just split is still spawning, so its transport has
+    // no PTY yet, and a host snapshot that lands mid-spawn does not name it.
+    // Only a leaf the host named before can be one the host retired.
+    const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
+
+    expect(
+      planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-new'], new Set(['leaf-a']))
+    ).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-new'], new Set())).toEqual([])
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
@@ -85,6 +85,33 @@ function mountedLeafIdsIn(
   ]
 }
 
+function collectLeafIds(node: TerminalPaneLayoutNode, leafIds: Set<string>): void {
+  if (node.type === 'leaf') {
+    leafIds.add(node.leafId)
+    return
+  }
+  collectLeafIds(node.first, leafIds)
+  collectLeafIds(node.second, leafIds)
+}
+
+/**
+ * Mounted leaves the host layout no longer names. The host retires a leaf when
+ * its PTY ends, so a pane still mounted for it is a ghost: it renders nothing
+ * and, once it is the only pane left, absorbs the tab's next close. An empty
+ * layout plans nothing — absence of a tree is not evidence about any pane.
+ */
+export function planTerminalLiveLayoutRemovals(
+  root: TerminalPaneLayoutNode | null | undefined,
+  currentLeafIds: Iterable<string>
+): string[] {
+  if (!root) {
+    return []
+  }
+  const layoutLeafIds = new Set<string>()
+  collectLeafIds(root, layoutLeafIds)
+  return [...currentLeafIds].filter((leafId) => !layoutLeafIds.has(leafId))
+}
+
 export function planTerminalLiveLayoutInsertions(
   root: TerminalPaneLayoutNode | null | undefined,
   currentLeafIds: Iterable<string>

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
@@ -3,6 +3,7 @@ import type {
   TerminalPaneSplitDirection
 } from '../../../../shared/terminal-tab-types'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import { collectLeafIds } from './terminal-pane-layout-tree'
 
 /**
  * Whether a tab's split layout is owned by a host (web/mobile clients, or a
@@ -85,15 +86,6 @@ function mountedLeafIdsIn(
   ]
 }
 
-function collectLeafIds(node: TerminalPaneLayoutNode, leafIds: Set<string>): void {
-  if (node.type === 'leaf') {
-    leafIds.add(node.leafId)
-    return
-  }
-  collectLeafIds(node.first, leafIds)
-  collectLeafIds(node.second, leafIds)
-}
-
 /**
  * Mounted leaves the host layout no longer names. The host retires a leaf when
  * its PTY ends, so a pane still mounted for it is a ghost: it renders nothing
@@ -107,8 +99,7 @@ export function planTerminalLiveLayoutRemovals(
   if (!root) {
     return []
   }
-  const layoutLeafIds = new Set<string>()
-  collectLeafIds(root, layoutLeafIds)
+  const layoutLeafIds = new Set(collectLeafIds(root))
   return [...currentLeafIds].filter((leafId) => !layoutLeafIds.has(leafId))
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
@@ -95,17 +95,17 @@ function mountedLeafIdsIn(
 export function planTerminalLiveLayoutRemovals(
   root: TerminalPaneLayoutNode | null | undefined,
   currentLeafIds: Iterable<string>,
-  previousLayoutLeafIds: ReadonlySet<string>
+  retiredLeafIds: ReadonlySet<string>
 ): string[] {
   if (!root) {
     return []
   }
   const layoutLeafIds = new Set(collectLeafIds(root))
-  // Why: only a leaf the host named before can be one it retired. A leaf it has
-  // never named is a pane the client is still starting; its transport has no PTY
-  // yet either, so a snapshot that lands mid-spawn must not read as a retirement.
+  // Why: a mounted leaf the layout stopped naming is a removal only once the
+  // host is known to have retired it (trackRetiredLeafIds). A snapshot landing
+  // while the client is still starting a pane must not read as a retirement.
   return [...currentLeafIds].filter(
-    (leafId) => !layoutLeafIds.has(leafId) && previousLayoutLeafIds.has(leafId)
+    (leafId) => !layoutLeafIds.has(leafId) && retiredLeafIds.has(leafId)
   )
 }
 
@@ -205,4 +205,27 @@ export function selectRetiredPaneIds(
     paneIds.push(paneId)
   }
   return paneIds
+}
+
+/**
+ * Leaves the host dropped from its layout whose panes are still mounted. Only a
+ * leaf the host named before can be retired: a leaf it has never named belongs
+ * to a pane the client is still starting. A retired leaf stays retired until
+ * its pane is gone or the host names it again, so a removal skipped while the
+ * transport still held its PTY is planned again once that PTY clears.
+ */
+export function trackRetiredLeafIds(args: {
+  retiredLeafIds: ReadonlySet<string>
+  previousLayoutLeafIds: ReadonlySet<string>
+  layoutLeafIds: ReadonlySet<string>
+  mountedLeafIds: Iterable<string>
+}): ReadonlySet<string> {
+  const mounted = new Set(args.mountedLeafIds)
+  const next = new Set<string>()
+  for (const leafId of [...args.retiredLeafIds, ...args.previousLayoutLeafIds]) {
+    if (mounted.has(leafId) && !args.layoutLeafIds.has(leafId)) {
+      next.add(leafId)
+    }
+  }
+  return next
 }

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
@@ -183,3 +183,29 @@ export function planTerminalLiveLayoutInsertions(
   ensureSubtree(root)
   return insertions
 }
+
+/** Panes to close for leaves the host retired. Only a pane whose transport has
+ *  no PTY any more is a ghost; a pane with no transport yet, or still bound to
+ *  a PTY, may simply not be named by a stale snapshot. The last pane on the tab
+ *  is never removed. */
+export function selectRetiredPaneIds(
+  retiredLeafIds: readonly string[],
+  view: {
+    paneCount: number
+    paneIdForLeaf: (leafId: string) => number | null
+    ptyIdForPane: (paneId: number) => string | null | undefined
+  }
+): number[] {
+  const paneIds: number[] = []
+  for (const leafId of retiredLeafIds) {
+    if (view.paneCount - paneIds.length <= 1) {
+      break
+    }
+    const paneId = view.paneIdForLeaf(leafId)
+    if (paneId === null || view.ptyIdForPane(paneId) !== null) {
+      continue
+    }
+    paneIds.push(paneId)
+  }
+  return paneIds
+}

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
@@ -94,13 +94,19 @@ function mountedLeafIdsIn(
  */
 export function planTerminalLiveLayoutRemovals(
   root: TerminalPaneLayoutNode | null | undefined,
-  currentLeafIds: Iterable<string>
+  currentLeafIds: Iterable<string>,
+  previousLayoutLeafIds: ReadonlySet<string>
 ): string[] {
   if (!root) {
     return []
   }
   const layoutLeafIds = new Set(collectLeafIds(root))
-  return [...currentLeafIds].filter((leafId) => !layoutLeafIds.has(leafId))
+  // Why: only a leaf the host named before can be one it retired. A leaf it has
+  // never named is a pane the client is still starting; its transport has no PTY
+  // yet either, so a snapshot that lands mid-spawn must not read as a retirement.
+  return [...currentLeafIds].filter(
+    (leafId) => !layoutLeafIds.has(leafId) && previousLayoutLeafIds.has(leafId)
+  )
 }
 
 export function planTerminalLiveLayoutInsertions(

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
@@ -10,7 +10,8 @@ import {
   isHostAuthoritativeLayout,
   planTerminalLiveLayoutInsertions,
   planTerminalLiveLayoutRemovals,
-  selectRetiredPaneIds
+  selectRetiredPaneIds,
+  trackRetiredLeafIds
 } from './terminal-live-layout-reconciliation'
 import { collectLeafIds } from './terminal-pane-layout-tree'
 import { useTerminalPaneProcessExitActions } from './use-terminal-pane-process-exit-actions'
@@ -34,9 +35,11 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     restoredLayout,
     tabId
   } = controller
-  // Leaves the last host-authoritative layout named; a removal needs the host to
-  // have named the leaf before it dropped it.
+  // Leaves the last host-authoritative layout named, and the ones it has since
+  // dropped whose panes are still mounted; a removal needs the host to have
+  // named the leaf before it dropped it, and may have to wait for the PTY exit.
   const hostLayoutLeafIdsRef = useRef<ReadonlySet<string>>(new Set())
+  const retiredLeafIdsRef = useRef<ReadonlySet<string>>(new Set())
 
   useEffect(() => {
     closeTerminalLinkActions()
@@ -55,14 +58,21 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     ) {
       return
     }
-    const previousHostLayoutLeafIds = hostLayoutLeafIdsRef.current
-    hostLayoutLeafIdsRef.current = new Set(collectLeafIds(restoredLayout.root))
+    const layoutLeafIds = new Set(collectLeafIds(restoredLayout.root))
     const mountedLeafIds = manager.getPanes().map((pane) => pane.leafId)
+    const retiredLeafIds = trackRetiredLeafIds({
+      retiredLeafIds: retiredLeafIdsRef.current,
+      previousLayoutLeafIds: hostLayoutLeafIdsRef.current,
+      layoutLeafIds,
+      mountedLeafIds
+    })
+    hostLayoutLeafIdsRef.current = layoutLeafIds
+    retiredLeafIdsRef.current = retiredLeafIds
     const insertions = planTerminalLiveLayoutInsertions(restoredLayout.root, mountedLeafIds)
     const removals = planTerminalLiveLayoutRemovals(
       restoredLayout.root,
       mountedLeafIds,
-      previousHostLayoutLeafIds
+      retiredLeafIds
     )
     if (insertions.length === 0 && removals.length === 0) {
       return

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import {
   applyExpandedLayoutTo,
   cancelPendingPaneSizeRefreshFrames,
@@ -12,6 +12,7 @@ import {
   planTerminalLiveLayoutRemovals,
   selectRetiredPaneIds
 } from './terminal-live-layout-reconciliation'
+import { collectLeafIds } from './terminal-pane-layout-tree'
 import { useTerminalPaneProcessExitActions } from './use-terminal-pane-process-exit-actions'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
 
@@ -33,6 +34,9 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     restoredLayout,
     tabId
   } = controller
+  // Leaves the last host-authoritative layout named; a removal needs the host to
+  // have named the leaf before it dropped it.
+  const hostLayoutLeafIdsRef = useRef<ReadonlySet<string>>(new Set())
 
   useEffect(() => {
     closeTerminalLinkActions()
@@ -51,9 +55,15 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     ) {
       return
     }
+    const previousHostLayoutLeafIds = hostLayoutLeafIdsRef.current
+    hostLayoutLeafIdsRef.current = new Set(collectLeafIds(restoredLayout.root))
     const mountedLeafIds = manager.getPanes().map((pane) => pane.leafId)
     const insertions = planTerminalLiveLayoutInsertions(restoredLayout.root, mountedLeafIds)
-    const removals = planTerminalLiveLayoutRemovals(restoredLayout.root, mountedLeafIds)
+    const removals = planTerminalLiveLayoutRemovals(
+      restoredLayout.root,
+      mountedLeafIds,
+      previousHostLayoutLeafIds
+    )
     if (insertions.length === 0 && removals.length === 0) {
       return
     }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
@@ -9,7 +9,8 @@ import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution
 import {
   isHostAuthoritativeLayout,
   planTerminalLiveLayoutInsertions,
-  planTerminalLiveLayoutRemovals
+  planTerminalLiveLayoutRemovals,
+  selectRetiredPaneIds
 } from './terminal-live-layout-reconciliation'
 import { useTerminalPaneProcessExitActions } from './use-terminal-pane-process-exit-actions'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
@@ -19,6 +20,7 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     activityIsolationSnapshotRef,
     closeTerminalLinkActions,
     containerRef,
+    executeClosePane,
     isActive,
     isRendererVisible,
     isolatedPaneKey,
@@ -85,18 +87,16 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     }
     // Why: the host retired these leaves (its PTY for them ended), so their panes
     // would otherwise outlive the layout as blank ghosts and take the tab's next
-    // close for themselves. A pane still bound to a PTY is not a ghost — a stale
-    // snapshot may simply not name it yet — and the last pane is never removed.
-    for (const leafId of removals) {
-      const paneId = manager.getNumericIdForLeaf(leafId)
-      if (paneId === null || manager.getPanes().length <= 1) {
-        continue
-      }
-      const transport = paneTransportsRef.current.get(paneId)
-      if (!transport || transport.getPtyId() !== null) {
-        continue
-      }
-      manager.closePane(paneId)
+    // close for themselves. Closing through executeClosePane runs the same
+    // cleanup a user close does: cache timer, agent status, terminal error,
+    // restored-session banner and the leaf's pty binding.
+    const retiredPaneIds = selectRetiredPaneIds(removals, {
+      paneCount: manager.getPanes().length,
+      paneIdForLeaf: (leafId) => manager.getNumericIdForLeaf(leafId),
+      ptyIdForPane: (paneId) => paneTransportsRef.current.get(paneId)?.getPtyId()
+    })
+    for (const paneId of retiredPaneIds) {
+      executeClosePane(paneId)
     }
     if (appliedInsertion) {
       persistLayoutSnapshot()
@@ -110,7 +110,7 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
       manager.setActivePane(nextActivePaneId, { focus: isActive })
     }
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- Preserve the pre-split dependency contract.
-  }, [isActive, paneCount, persistLayoutSnapshot, restoredLayout])
+  }, [executeClosePane, isActive, paneCount, persistLayoutSnapshot, restoredLayout])
 
   useLayoutEffect(() => {
     const snapshots = activityIsolationSnapshotRef.current

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
@@ -8,7 +8,8 @@ import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import {
   isHostAuthoritativeLayout,
-  planTerminalLiveLayoutInsertions
+  planTerminalLiveLayoutInsertions,
+  planTerminalLiveLayoutRemovals
 } from './terminal-live-layout-reconciliation'
 import { useTerminalPaneProcessExitActions } from './use-terminal-pane-process-exit-actions'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
@@ -24,6 +25,7 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     managerRef,
     paneCount,
     paneLayoutRevision,
+    paneTransportsRef,
     pendingPaneSizeRefreshFrameIdsRef,
     persistLayoutSnapshot,
     restoredLayout,
@@ -47,11 +49,10 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     ) {
       return
     }
-    const insertions = planTerminalLiveLayoutInsertions(
-      restoredLayout.root,
-      manager.getPanes().map((pane) => pane.leafId)
-    )
-    if (insertions.length === 0) {
+    const mountedLeafIds = manager.getPanes().map((pane) => pane.leafId)
+    const insertions = planTerminalLiveLayoutInsertions(restoredLayout.root, mountedLeafIds)
+    const removals = planTerminalLiveLayoutRemovals(restoredLayout.root, mountedLeafIds)
+    if (insertions.length === 0 && removals.length === 0) {
       return
     }
     let appliedInsertion = false
@@ -81,6 +82,21 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
       if (createdPane) {
         appliedInsertion = true
       }
+    }
+    // Why: the host retired these leaves (its PTY for them ended), so their panes
+    // would otherwise outlive the layout as blank ghosts and take the tab's next
+    // close for themselves. A pane still bound to a PTY is not a ghost — a stale
+    // snapshot may simply not name it yet — and the last pane is never removed.
+    for (const leafId of removals) {
+      const paneId = manager.getNumericIdForLeaf(leafId)
+      if (paneId === null || manager.getPanes().length <= 1) {
+        continue
+      }
+      const transport = paneTransportsRef.current.get(paneId)
+      if (!transport || transport.getPtyId() !== null) {
+        continue
+      }
+      manager.closePane(paneId)
     }
     if (appliedInsertion) {
       persistLayoutSnapshot()


### PR DESCRIPTION
## ELI5

In a tab that runs on a paired remote Orca runtime, closing one half of a split terminal left an empty pane behind, and closing that empty pane killed the terminal that was still alive. Now the empty pane goes away on its own and the surviving terminal stays.

## What Changed

- `terminal-live-layout-reconciliation.ts`: `trackRetiredLeafIds` remembers the leaves the host named and then dropped while their panes are still mounted (a leaf the host never named belongs to a pane the client is still starting; a retired leaf stays pending until its pane is gone, so a removal skipped while the transport still held its PTY is retried after the exit). `planTerminalLiveLayoutRemovals` turns those into removals, and `selectRetiredPaneIds` decides which panes to close: only a pane whose transport has no PTY, never the last pane on the tab.
- `use-terminal-pane-reconciliation.ts`: the host-authoritative branch applies those removals after insertions, through `executeClosePane`, so a retired pane gets the same cleanup a user close does (cache timer, agent status, terminal error, restored-session banner, pty binding).
- Tests for both planners.

## Why

The client sends `terminal.close` for the pane and drops the leaf from its layout, but the host still sees two live surfaces at that moment, so `rebaseLayout` refuses the membership change and republishes the two-leaf layout, and the live-layout reconciler faithfully re-inserts a pane for the retired leaf. When the host's `onPtyExit` then retires the leaf and publishes a one-leaf layout, the store shrinks, but the reconciler only planned insertions, so the pane stayed mounted with no PTY and no close control. Its next close request resolved to the live sibling.

Planning removals alongside insertions closes that gap. Guarding on "transport has no PTY" and "never the last pane" keeps a stale snapshot from tearing down a live split.

## Linked Issue

Fixes #17770

## Visual Proof

Before, split then one pane closed: a blank ghost pane stays and the next close takes the live terminal with it.

![before: split](https://raw.githubusercontent.com/ylcn91/orca/0f054aea46dddb135404869a1bf9f589e5407731/17770/before-1-split.png)
![before: ghost pane after closing one side](https://raw.githubusercontent.com/ylcn91/orca/0f054aea46dddb135404869a1bf9f589e5407731/17770/before-2-ghost.png)

After, same steps: the closed pane disappears and the other terminal keeps running.

![after: split](https://raw.githubusercontent.com/ylcn91/orca/0f054aea46dddb135404869a1bf9f589e5407731/17770/after-1-split.png)
![after: one pane left after closing one side](https://raw.githubusercontent.com/ylcn91/orca/0f054aea46dddb135404869a1bf9f589e5407731/17770/after-2-closed.png)

## Testing

Reproduced against a headless `orca serve` (Linux AppImage) on Ubuntu 24.04, paired over an SSH tunnel ("Add remote server" with the printed pairing URL and the SSH-tunnel option); client on macOS.

1. Open a terminal tab in the remote-server workspace and split it; run a process in each half.
2. Close one pane. Before: a blank pane stayed, the DOM had two `.pane` nodes while the store held one leaf and `orca terminal list` on the host listed one terminal; closing the blank pane closed the surviving terminal too. After: one pane, one leaf, one terminal, and only the closed pane's process ended.
3. The same steps over an "Add SSH host" connection were already correct on v1.4.193 and main; that path is not touched.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`vitest` for `terminal-live-layout-reconciliation.test.ts`, `pnpm tc:web`, `oxlint`, `oxfmt --check` and `check:code-quality:changed` pass; the CI workflow's lint, typecheck and test jobs were run locally on this branch. Platforms: macOS client, Linux remote runtime.

## AI Disclosure

Claude Code (Fable 5.1) drafted the diagnosis, the patch and the tests. I set up the remote runtime, reproduced the bug, reviewed the change and verified it live against the running app and the host.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Only the remote-server (paired runtime) reconciliation path changes; local and "Add SSH host" tabs never take the host-authoritative branch with a retired leaf.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
