### PR TITLE
fix(native-chat): fill the model picker from Claude's startup frame

### DIFF
--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.test.ts
@@ -295,6 +295,20 @@ describe('Claude terminal session option detection', () => {
     })
   })
 
+  it('reads a Claude header drawn with cursor-forward moves instead of spaces', () => {
+    // Main-buffer snapshot of a `claude --model opus` start on Claude Code
+    // 2.1.258: every gap between words is an `ESC[nC` move, not a space.
+    const screen =
+      '\u001b[38;2;215;119;87m ▐\u001b[48;2;0;0;0m▛███▛█\u001b[0m\u001b[3C\u001b[1mClaude\u001b[1CCode\u001b[1C\u001b[38;2;153;153;153;22mv2.1.258\r\n' +
+      '\u001b[38;2;215;119;87m▝▜\u001b[48;2;0;0;0m█████\u001b[49m█▀\u001b[2C\u001b[38;2;153;153;153mOpus\u001b[1C5\u001b[1Cwith\u001b[1Cxhigh\u001b[1Ceffort\u001b[1C·\u001b[1CClaude\u001b[1CMax\r\n' +
+      '\u001b[38;2;215;119;87m \u001b[1C▝▝\u001b[1C▝▝\u001b[4C\u001b[38;2;153;153;153m~/github/agents/orca'
+
+    expect(readClaudeSessionOptionsFromTerminalScreen(screen)).toEqual({
+      model: 'opus',
+      effort: 'xhigh'
+    })
+  })
+
   it('does not mistake old conversation output for the current model', () => {
     const screen =
       'Set model to Opus 4.8 and saved as your default\r\n' +

--- a/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
+++ b/src/renderer/src/components/native-chat/claude-terminal-session-options.ts
@@ -24,12 +24,24 @@ const CLAUDE_MODEL_EFFORT =
 const FRAME_TOP = '╭'
 const FRAME_BOTTOM = '╰'
 const FRAME_COLUMN = '│'
+const ESC = String.fromCharCode(27)
+// Cursor-forward (`ESC[nC`); the count defaults to 1 when omitted.
+const CURSOR_FORWARD_PATTERN = new RegExp(`${ESC}\\[(\\d*)C`, 'g')
 
 /** Rows of the visible screen, ANSI-stripped and whitespace-collapsed. */
 function normalizedScreenLines(screen: string): string[] {
-  return stripScrollbackAnsi(screen)
+  return stripScrollbackAnsi(widenCursorForwardGaps(screen))
     .split('\n')
     .map((line) => line.replace(/\s+/g, ' ').trim())
+}
+
+// Claude Code 2.1.258 draws the header with cursor-forward moves instead of
+// spaces (`Claude\x1b[1CCode`, `Opus\x1b[1C5\x1b[1Cwith`). Stripping them with
+// the rest of the ANSI fuses the words, so turn each move into the gap it spans.
+function widenCursorForwardGaps(screen: string): string {
+  return screen.replace(CURSOR_FORWARD_PATTERN, (_match, count: string) =>
+    ' '.repeat(Math.max(1, Number(count || '1')))
+  )
 }
 
 function isClaudeHeaderRow(line: string): boolean {

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
@@ -119,6 +119,59 @@ describe('useNativeChatSessionOptions model reporting', () => {
     expect(selectedValue(result.current.snapshot, 'model')).toBe('sonnet')
   })
 
+  it('does not let a retry already in flight overwrite a pick made meanwhile', async () => {
+    // The retry checks for a pick before it starts, but the snapshot read is
+    // async; a pick that lands while that read is in flight must still win.
+    vi.useFakeTimers()
+    discoverModels.mockResolvedValue(null)
+    let resolveLateSnapshot: (snapshot: { data: string; alternateScreen: false }) => void = () => {}
+    const getMainBufferSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce({ data: '', alternateScreen: false })
+      .mockReturnValueOnce(
+        new Promise<{ data: string; alternateScreen: false }>((resolve) => {
+          resolveLateSnapshot = resolve
+        })
+      )
+      .mockReturnValue(new Promise(() => {}))
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { pty: { getMainBufferSnapshot } }
+    })
+    const dispatchCommand = vi.fn().mockResolvedValue(undefined)
+    // Stable, as the pane's real reader is: an inline arrow would restart the
+    // read effect on every render and cancel the very retry under test.
+    const readTerminalScreen = (): string | null => null
+
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptions({
+        agent: 'claude',
+        terminalTabId: 'tab-inflight-pick',
+        targetPtyId: 'pty-inflight-pick',
+        dispatchCommand,
+        readTerminalScreen
+      })
+    )
+
+    // The blank first read schedules a retry, whose read is now in flight.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(getMainBufferSnapshot).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await result.current.surface?.setOption('model', 'sonnet')
+    })
+    expect(selectedValue(result.current.snapshot, 'model')).toBe('sonnet')
+
+    await act(async () => {
+      resolveLateSnapshot({ data: CLAUDE_SCREEN_HAIKU, alternateScreen: false })
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(selectedValue(result.current.snapshot, 'model')).toBe('sonnet')
+  })
+
   it('re-resolves the reported model against models discovered after the read', async () => {
     // Why: discovery is async, so the first scrape can only reach the seed. If
     // the reported id were left at the family the picker would show a row it

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
-import { renderHook, waitFor } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CatalogModel } from '../../../../shared/agent-session-option-catalog'
 import { clearNativeChatModelEnrichmentForTests } from './native-chat-session-option-enrichment'
 
@@ -25,6 +25,9 @@ import { useNativeChatSessionOptions } from './use-native-chat-session-options'
 const CLAUDE_SCREEN =
   'Claude Code v2.1.220\r\nOpus 5 (1M context) with high effort · API Usage Billing\r\n~/repo'
 
+// The frame Claude paints for a session that started on a different model.
+const CLAUDE_SCREEN_HAIKU = 'Claude Code v2.1.220\r\nHaiku 4.5 · API Usage Billing\r\n~/repo'
+
 const DISCOVERED: CatalogModel[] = [
   { id: 'opus[1m]', label: 'Opus (1M context)', options: [] },
   { id: 'haiku', label: 'Haiku', options: [] }
@@ -38,11 +41,82 @@ function modelDescriptor(snapshot: { id: string; kind: unknown }[]): {
   return model?.kind as { currentValue?: string; choices: { value: string }[] }
 }
 
+function selectedValue(snapshot: { id: string; kind: unknown }[], id: string): string | undefined {
+  const descriptor = snapshot.find((entry) => entry.id === id)
+  return (descriptor?.kind as { currentValue?: string } | undefined)?.currentValue
+}
+
 describe('useNativeChatSessionOptions model reporting', () => {
   beforeEach(() => {
     clearNativeChatModelEnrichmentForTests()
     discoverModels.mockReset()
     Object.defineProperty(window, 'api', { configurable: true, value: undefined })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps reading until Claude paints its startup frame', async () => {
+    // The pane mounts as soon as the pty exists, seconds before the CLI paints its
+    // frame, so the read at mount finds a blank screen. Without a retry the picker
+    // never learns the model and the model-scoped effort row never appears at all.
+    vi.useFakeTimers()
+    discoverModels.mockResolvedValue(null)
+    let screen: string | null = null
+    const readTerminalScreen = (): string | null => screen
+    const dispatchCommand = vi.fn()
+
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptions({
+        agent: 'claude',
+        terminalTabId: 'tab-late-frame',
+        targetPtyId: 'pty-late-frame',
+        dispatchCommand,
+        readTerminalScreen
+      })
+    )
+
+    expect(selectedValue(result.current.snapshot, 'model')).toBeUndefined()
+
+    screen = CLAUDE_SCREEN
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    expect(selectedValue(result.current.snapshot, 'model')).toBe('opus')
+    expect(selectedValue(result.current.snapshot, 'effort')).toBe('high')
+  })
+
+  it('lets a pick made before the frame lands survive a later read', async () => {
+    // The startup frame names the model the session began with, so a read that
+    // outlives the user's own switch would silently repaint the stale one.
+    vi.useFakeTimers()
+    discoverModels.mockResolvedValue(null)
+    let screen: string | null = null
+    const dispatchCommand = vi.fn().mockResolvedValue(undefined)
+
+    const { result } = renderHook(() =>
+      useNativeChatSessionOptions({
+        agent: 'claude',
+        terminalTabId: 'tab-early-pick',
+        targetPtyId: 'pty-early-pick',
+        dispatchCommand,
+        readTerminalScreen: () => screen
+      })
+    )
+
+    await act(async () => {
+      await result.current.surface?.setOption('model', 'sonnet')
+    })
+    expect(selectedValue(result.current.snapshot, 'model')).toBe('sonnet')
+
+    screen = CLAUDE_SCREEN_HAIKU
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+    })
+
+    expect(selectedValue(result.current.snapshot, 'model')).toBe('sonnet')
   })
 
   it('re-resolves the reported model against models discovered after the read', async () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -202,6 +202,11 @@ export function useNativeChatSessionOptions(args: {
         if (cancelled) {
           return
         }
+        // Why: the snapshot read is async. A pick that landed while a retry's
+        // read was in flight already names the model; the frame is stale by then.
+        if (attempt > 0 && modelIsKnown()) {
+          return
+        }
         reportedScreenRef.current = screen
         surface.reportSessionOptions(reportedValues)
         return

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -28,6 +28,11 @@ import {
   resolveNativeChatModelDiscoveryContext
 } from './native-chat-session-option-discovery'
 import { readClaudeSessionOptionsFromTerminalScreen } from './claude-terminal-session-options'
+import { createNativeChatReadRetryTimer } from './native-chat-read-retry-timer'
+
+/** How long to keep looking for Claude's startup frame. Covers a cold CLI start
+ *  behind SSH latency, after which the frame has likely scrolled out anyway. */
+const CLAUDE_FRAME_READ_WINDOW_MS = 60_000
 
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
 const subscribeEmpty = (): (() => void) => () => {}
@@ -160,7 +165,13 @@ export function useNativeChatSessionOptions(args: {
     }
     let cancelled = false
     reportedScreenRef.current = null
-    const reportCurrentValues = async (): Promise<void> => {
+    const retryTimer = createNativeChatReadRetryTimer()
+    const startedAt = Date.now()
+    const modelIsKnown = (): boolean =>
+      surface
+        .getSnapshot()
+        .some((descriptor) => descriptor.id === 'model' && descriptor.valueSource !== 'unknown')
+    const reportCurrentValues = async (attempt: number): Promise<void> => {
       let authoritativeScreen: string | null = null
       if (targetPtyId && window.api?.pty?.getMainBufferSnapshot) {
         try {
@@ -195,10 +206,22 @@ export function useNativeChatSessionOptions(args: {
         surface.reportSessionOptions(reportedValues)
         return
       }
+      // Why: the pane mounts on the spawned pty, well before the CLI paints the
+      // frame carrying the model, so a single read at mount usually finds nothing.
+      if (cancelled || Date.now() - startedAt >= CLAUDE_FRAME_READ_WINDOW_MS) {
+        return
+      }
+      retryTimer.schedule(attempt, () => {
+        // A pick or typed /model already named the model; the startup frame is stale by then.
+        if (!modelIsKnown()) {
+          void reportCurrentValues(attempt + 1)
+        }
+      })
     }
-    void reportCurrentValues()
+    void reportCurrentValues(0)
     return () => {
       cancelled = true
+      retryTimer.cancel()
     }
   }, [agent, discoveryContext, readTerminalScreen, surface, targetPtyId])
 


### PR DESCRIPTION
## ELI5

Opening a Claude session in Native Chat left the model and effort pills in the composer on the placeholder "Model", even though the terminal showed which model was running. Orca now keeps looking at Claude's startup screen until it has been painted, and it can read the layout current Claude Code draws.

## What Changed

Two commits:

1. `use-native-chat-session-options.ts`: instead of reading the Claude startup frame once, the hook retries on a short timer until the model is known or a 60 s window ends (`createNativeChatReadRetryTimer`, `CLAUDE_FRAME_READ_WINDOW_MS`, `modelIsKnown()`). A retry re-checks the model right before applying its result, so a pick made while its snapshot read was in flight is kept.
2. `claude-terminal-session-options.ts`: before ANSI is stripped, cursor-forward moves (`ESC[nC`) are widened into the spaces they stand for, so a header drawn as `Claude<ESC>[1CCode` reads as `Claude Code`.

Tests for both.

## Why

Two independent failures produced the same empty pill. The single read happened a beat before `claude` finished painting, so the frame had no header yet and nothing ever re-read it. Separately, Claude Code 2.1.258 draws its startup frame with cursor-forward moves between words instead of spaces; `stripScrollbackAnsi` removed them with the colours, `Claude Code` became `ClaudeCode`, and the header regex never matched, so even a well-timed read returned nothing. Fixing only the timing still left the pill empty on current Claude Code, which is how the second bug surfaced.

## Linked Issue

Fixes #18330

## Visual Proof

Same flow in both: new terminal tab, `claude --model opus`, switch the tab to Chat view.

Before, the composer keeps the placeholder:

![before: composer shows "Model"](https://raw.githubusercontent.com/ylcn91/orca/0f054aea46dddb135404869a1bf9f589e5407731/18330/before-1-model-empty.png)

After, the pills fill in from the startup frame:

![after: composer shows "Opus" and "Extra high"](https://raw.githubusercontent.com/ylcn91/orca/0f054aea46dddb135404869a1bf9f589e5407731/18330/after-2-model-filled.png)

## Testing

1. Enable Native Chat, open a terminal tab, run `claude --model opus`, switch the tab to Chat view.
2. Before: the composer shows "Model" with no value and never updates. After: "Opus" and "Extra high" appear once Claude has painted its header (Claude Code 2.1.258, macOS).
3. `vitest` for `use-native-chat-session-options.test.ts`, `claude-terminal-session-options.test.ts` and `native-chat-scrape-fallback.test.ts`; `pnpm tc:web`, `oxlint`, `oxfmt --check`, `check:code-quality:changed`. The parser regression test fails on the previous commit and passes here. The CI workflow's lint, typecheck and test jobs were run locally on this branch.

Platform: macOS. The hook reads the local PTY snapshot; no SSH/remote path is involved.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Code was used: Opus 5 drafted the first commit (the retry), Fable 5.1 the parser fix. I reviewed both, drove the live verification and took the screenshots.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

The retry stops as soon as the model is known or after 60 s, so an idle tab does not keep polling. Widening cursor-forward moves only touches the parser's own screen normalisation; the transcript scraper is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
