### PR TITLE
fix(explorer): focus the confirm action so Del + Enter deletes

### DIFF
--- a/src/renderer/src/components/confirmation-dialog.test.tsx
+++ b/src/renderer/src/components/confirmation-dialog.test.tsx
@@ -83,6 +83,22 @@ describe('ConfirmationDialogProvider', () => {
     await waitFor(() => expect(onSettled).toHaveBeenCalledWith(false))
   })
 
+  it('focuses the confirm action so Enter runs it instead of dismissing the prompt', async () => {
+    const { onSettled } = renderDialog({
+      title: 'Delete artifact?',
+      confirmLabel: 'Delete',
+      confirmVariant: 'destructive'
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: 'ask' }))
+    const confirmButton = await screen.findByRole('button', { name: 'Delete' })
+    await waitFor(() => expect(confirmButton).toHaveFocus())
+
+    await userEvent.keyboard('{Enter}')
+
+    await waitFor(() => expect(onSettled).toHaveBeenCalledWith(true))
+  })
+
   it('does not carry a checked box into the next prompt', async () => {
     const onConfirmed = vi.fn()
     renderDialog({

--- a/src/renderer/src/components/confirmation-dialog.tsx
+++ b/src/renderer/src/components/confirmation-dialog.tsx
@@ -32,6 +32,7 @@ export function ConfirmationDialogProvider({
   children: React.ReactNode
 }): React.JSX.Element {
   const nextIdRef = useRef(0)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
   const [queue, setQueue] = useState<ConfirmationDialogRequest[]>([])
   const [dontAskAgain, setDontAskAgain] = useState(false)
   const activeRequest = queue[0] ?? null
@@ -96,7 +97,19 @@ export function ConfirmationDialogProvider({
         open={activeRequest !== null}
         onOpenChange={(open) => !open && settleActiveRequest(false)}
       >
-        <DialogContent showCloseButton={false} className="sm:max-w-md">
+        <DialogContent
+          showCloseButton={false}
+          className="sm:max-w-md"
+          onOpenAutoFocus={(event) => {
+            if (!confirmButtonRef.current) {
+              return
+            }
+            // Why: Radix otherwise focuses Cancel first, so Enter dismisses the prompt
+            // instead of running the action the user was just asked to confirm.
+            event.preventDefault()
+            confirmButtonRef.current.focus()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{displayedRequest?.options.title}</DialogTitle>
             {displayedRequest?.options.description ? (
@@ -130,8 +143,10 @@ export function ConfirmationDialogProvider({
                 translate('auto.components.confirmation.dialog.56f5c60e0c', 'Cancel')}
             </Button>
             <Button
+              ref={confirmButtonRef}
               type="button"
               variant={displayedRequest?.options.confirmVariant ?? 'default'}
+              autoFocus
               onClick={() => settleActiveRequest(true)}
             >
               {displayedRequest?.options.confirmLabel ??


### PR DESCRIPTION
## ELI5

When you hit `Del` on a file in the tree, Orca asks "are you sure?" — but it puts the cursor on the **Cancel** button. So the next thing everyone presses, `Enter`, cancels the prompt instead of deleting. The file survives, nothing is said, and it looks like `Del` is broken. This moves the cursor onto the **Delete** button, so `Del` then `Enter` deletes and `Esc` still backs out.

## What Changed

`ConfirmationDialogProvider` now focuses its confirm button when the dialog opens:

- `onOpenAutoFocus` on `DialogContent` preventing the default and focusing the confirm button
- `autoFocus` + a `ref` on the confirm `Button`

This mirrors `SourceControlDiscardDialog`, which already does exactly this (`focusDiscardDialogConfirmButton`), comment and all. Nothing else changed — no new props, no caller changes, no new copy or i18n keys.

## Why

Radix's `FocusScope` autofocuses the first tabbable candidate inside the content, which in this footer is Cancel. So `Enter` right after `Del` resolved the confirm promise with `false`: `useFileDeletion` returned early and never issued the delete, with no toast to explain it.

Because every `useConfirmationDialog()` caller goes through this one provider, fixing it here fixes the dead `Enter` on all confirm prompts (file/folder delete, artifacts, skills, hosted review actions) rather than patching the delete path alone.

It is also the rule `docs/STYLEGUIDE.md` states directly:

> **Default focus:** dialogs, popovers, and command surfaces should focus the field or primary action the user is most likely to use. If Enter submits, focus must land where Enter triggers the intended primary action.

On focusing a destructive default: the repo has already settled this in `SourceControlDiscardDialog`, whose test asserts Cancel is *not* autofocused and destructive `Discard` *is*. The prompt is itself the guard — a bare `Del` never reaches it, and `Esc` and the overlay still cancel.

## Linked Issue

Fixes #18391

## Visual Proof

No screenshot attached — the change is not a repaint, and I could not run the Electron app in the environment I prepared this in. Precisely and completely, the visible difference is **which footer button carries the focus ring when the prompt opens**: before, the outline `Cancel` button; after, the `Delete` / `Confirm` button. Layout, size, copy, colors, and animation are untouched. The behavioral difference is that `Enter` on open now resolves the prompt `true` instead of `false`.

This is covered by an automated test rather than an image (see Testing) — the test fails on `main` and passes with the change, which is the same claim a before/after pair would make. Happy to add a capture if a maintainer would still like one.

## Testing

Automated, in `src/renderer/src/components/confirmation-dialog.test.tsx`:

```
it('focuses the confirm action so Enter runs it instead of dismissing the prompt')
```

It opens a destructive prompt, asserts the confirm button holds focus, presses `Enter`, and asserts the prompt settled `true`. Verified it is a real regression test — with the `confirmation-dialog.tsx` change reverted it fails on the focus assertion (`expect(confirmButton).toHaveFocus()`), and passes with it.

Commands run locally on Linux (Node 24, pnpm 12):

- `vitest run src/renderer/src/components/confirmation-dialog.test.tsx` — 5 passed
- the existing suites that mount this provider or the delete path — `confirmation-dialog-refresh-boundary`, `SourceControl.preview-open`, `use-hosted-review-actions`, `ArtifactsPage`, `SkillsPage`, `remote-host-file-delete-repro`, `file-explorer-delete-owner-provenance`, `source-control-discard-dialog` — 8 files, 66 passed
- `pnpm typecheck` — clean
- `oxlint`, `oxfmt --check`, `pnpm check:max-lines-ratchet`, `pnpm verify:localization-catalog` — clean
- `pnpm exec lint-staged` via the pre-commit hook — clean

I did not run `pnpm build`, and I did not exercise the dialog by hand in the running app on any platform — flagging that plainly rather than checking the box below. The change is renderer-only, uses no platform or path APIs, and has no macOS/Windows/Linux or local/SSH/remote branch, so I would not expect platform-specific behavior; a maintainer spot-check on macOS would still be worth it.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). A human reported the symptom ("`Del` then `Enter` doesn't delete"); the root cause, patch, and test were produced by the agent and are reflected in the commit's `Co-Authored-By` trailer.

## Review

Reviewed against the areas in Notes:

- **Security:** none. No IPC, filesystem, network, or shell surface; focus target is an internal ref, never caller-supplied.
- **Cross-platform:** no platform check added or needed — no keybinding, accelerator, or path code is touched. `Esc`/overlay dismissal is unchanged on all three platforms.
- **Remote SSH:** this is the path that actually benefits, since the delete prompt only appears for non-local operation owners. No latency-sensitive work added; focus is set once on mount, before any remote call.
- **Mobile:** the provider is desktop-renderer only, and a touch confirm taps the button directly, so a focused default button changes nothing there.
- **Backwards compatibility:** `ConfirmationDialogOptions` is unchanged, so no caller has to opt in or migrate.
- **Performance:** one ref and one mount-time handler; it replaces Radix's own autofocus pass rather than adding to it. No hot path.
- **UI quality:** the focus ring is the existing `ring` token on the existing button, so light/dark are inherited. Tab order, `dontAskAgain` checkbox, and the queued-prompt behavior are untouched.

One deliberate non-change: `focusDiscardDialogConfirmButton` in `source-control/commit/discard-dialog.tsx` now does the same thing as the handler added here. I left it duplicated rather than extracting a shared helper, since hoisting it would mean either importing a source-control module into the global provider or adding a new file — both wider than this fix. Happy to extract it if you would prefer one helper.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Scope is one file plus its test. The behavior change reaches every confirm prompt by design — that is the root-cause fix rather than a per-caller patch — and the `Esc` / Cancel / overlay escape routes are all unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — described in words under Visual Proof; no capture attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — typecheck, oxlint/oxfmt, ratchets and the touched suites pass locally; `pnpm build` and the full suite left to CI
