### PR TITLE
feat(ai-vault): add full-transcript content search to Agent Session History

### DIFF
--- a/src/main/ai-vault/session-transcript-search.test.ts
+++ b/src/main/ai-vault/session-transcript-search.test.ts
@@ -1,0 +1,208 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { searchAiVaultTranscripts } from './session-transcript-search'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  // Best-effort cleanup; tests are sandboxed under mkdtemp.
+  const { rm } = await import('node:fs/promises')
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function makeTranscriptRoot(name: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), `orca-transcript-search-${name}-`))
+  tempRoots.push(root)
+  return root
+}
+
+describe('searchAiVaultTranscripts', () => {
+  it('finds matches in the transcript body and returns a cleaned snippet', async () => {
+    const root = await makeTranscriptRoot('basic')
+    const filePath = join(root, 'session.jsonl')
+    await writeFile(
+      filePath,
+      [
+        JSON.stringify({ type: 'user', message: { role: 'user', content: 'fix the login bug' } }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { role: 'assistant', content: 'The FLAKY TEST was caused by a race in setup.' }
+        })
+      ].join('\n')
+    )
+    const result = await searchAiVaultTranscripts({
+      query: 'flaky test',
+      requests: [{ agent: 'claude', filePath, sessionId: 's1' }]
+    })
+    expect(result.matches).toHaveLength(1)
+    expect(result.matches[0]).toMatchObject({
+      agent: 'claude',
+      sessionId: 's1',
+      matchCount: 1
+    })
+    expect(result.matches[0].snippet).toContain('FLAKY TEST was caused')
+    expect(result.issues).toEqual([])
+    expect(result.truncated).toBe(false)
+  })
+
+  it('finds a match on the first line of a small single-line transcript', async () => {
+    // Regression: a whole-file window must not drop line 1 as a seek fragment.
+    const root = await makeTranscriptRoot('single-line')
+    const filePath = join(root, 'only.jsonl')
+    await writeFile(filePath, JSON.stringify({ text: 'the flaky checkout step was retried' }))
+    const result = await searchAiVaultTranscripts({
+      query: 'flaky checkout',
+      requests: [{ agent: 'claude', filePath }]
+    })
+    expect(result.matches).toHaveLength(1)
+    expect(result.matches[0].matchCount).toBe(1)
+  })
+
+  it('skips missing transcript files silently instead of raising issues', async () => {
+    const root = await makeTranscriptRoot('missing')
+    const result = await searchAiVaultTranscripts({
+      query: 'needle',
+      requests: [{ agent: 'codex', filePath: join(root, 'gone.jsonl') }]
+    })
+    expect(result.matches).toEqual([])
+    expect(result.issues).toEqual([])
+  })
+
+  it('reports unreadable targets as issues', async () => {
+    const root = await makeTranscriptRoot('dir')
+    const dirPath =
+      (await mkdir(join(root, 'not-a-file'), { recursive: true })) ?? join(root, 'not-a-file')
+    const result = await searchAiVaultTranscripts({
+      query: 'needle',
+      requests: [{ agent: 'claude', filePath: dirPath }]
+    })
+    expect(result.matches).toEqual([])
+    expect(result.issues).toHaveLength(1)
+    expect(result.issues[0].agent).toBe('claude')
+    expect(result.issues[0].path).toBe(dirPath)
+  })
+
+  it('returns empty for a too-short query without touching files', async () => {
+    const root = await makeTranscriptRoot('short')
+    const result = await searchAiVaultTranscripts({
+      query: ' x ',
+      requests: [{ agent: 'claude', filePath: join(root, 'a.jsonl') }]
+    })
+    expect(result).toEqual({ matches: [], issues: [], truncated: false })
+  })
+
+  it('prefers the tail window and still falls back to the head', async () => {
+    const root = await makeTranscriptRoot('windows')
+    const fillerLine = JSON.stringify({ padding: 'x'.repeat(4096) })
+    const headPath = join(root, 'head-hit.jsonl')
+    // A big file whose only hit sits in the head half, beyond the tail window.
+    const lines: string[] = [
+      JSON.stringify({ text: 'the flash attention fix lives here at the start' })
+    ]
+    while (lines.join('\n').length < 3 * 1024 * 1024) {
+      lines.push(fillerLine)
+    }
+    lines.push(fillerLine)
+    await writeFile(headPath, lines.join('\n'))
+    const headResult = await searchAiVaultTranscripts({
+      query: 'flash attention',
+      requests: [{ agent: 'claude', filePath: headPath }]
+    })
+    expect(headResult.matches).toHaveLength(1)
+    expect(headResult.matches[0].snippet).toContain('flash attention fix')
+
+    // And a hit only inside the tail window is found directly.
+    const tailPath = join(root, 'tail-hit.jsonl')
+    const tailLines: string[] = [fillerLine]
+    while (tailLines.join('\n').length < 3 * 1024 * 1024) {
+      tailLines.push(fillerLine)
+    }
+    tailLines.push(JSON.stringify({ text: 'recent work: ship the kernel upgrade' }))
+    await writeFile(tailPath, tailLines.join('\n'))
+    const tailResult = await searchAiVaultTranscripts({
+      query: 'kernel upgrade',
+      requests: [{ agent: 'claude', filePath: tailPath }]
+    })
+    expect(tailResult.matches).toHaveLength(1)
+    expect(tailResult.matches[0].snippet).toContain('ship the kernel upgrade')
+  })
+
+  it('stops early when the abort signal fires', async () => {
+    const root = await makeTranscriptRoot('abort')
+    const requests = Array.from({ length: 50 }, (_, i) => ({
+      agent: 'claude' as const,
+      filePath: join(root, `s${i}.jsonl`),
+      sessionId: `s${i}`
+    }))
+    await Promise.all(
+      requests.map((request) => writeFile(request.filePath, 'needle in transcript\n'.repeat(500)))
+    )
+    const controller = new AbortController()
+    controller.abort()
+    const result = await searchAiVaultTranscripts(
+      { query: 'needle', requests },
+      { signal: controller.signal }
+    )
+    expect(result.matches).toEqual([])
+    expect(result.truncated).toBe(true)
+  })
+
+  it('honors a tiny time budget by reporting truncation on a large sweep', async () => {
+    const root = await makeTranscriptRoot('budget')
+    const requests = Array.from({ length: 12 }, (_, i) => ({
+      agent: 'claude' as const,
+      filePath: join(root, `big-${i}.jsonl`)
+    }))
+    const bigContent = `${JSON.stringify({ padding: 'z'.repeat(8192) })}\n`.repeat(1024)
+    await Promise.all(requests.map((request) => writeFile(request.filePath, bigContent)))
+    const result = await searchAiVaultTranscripts(
+      { query: 'needle-in-a-haystack', requests },
+      { timeBudgetMs: 5 }
+    )
+    expect(result.matches).toEqual([])
+    expect(result.truncated).toBe(true)
+  })
+
+  it('flags truncation when a large transcript is only searched head+tail', async () => {
+    // Regression: a mid-transcript hit must never look like an honest zero.
+    const root = await makeTranscriptRoot('middle-gap')
+    const filePath = join(root, 'middle.jsonl')
+    const padLine = JSON.stringify({ padding: 'x'.repeat(4096) })
+    const lines: string[] = [JSON.stringify({ text: 'filler at the start' })]
+    // Grow past the 2 MiB head window, then drop the only hit inside the
+    // skipped middle (past the head, more than 1 MiB from the end).
+    while (lines.join('\n').length < 2.2 * 1024 * 1024) {
+      lines.push(padLine)
+    }
+    lines.push(JSON.stringify({ text: 'the buried token is zebraunicorn here' }))
+    while (lines.join('\n').length < 4 * 1024 * 1024) {
+      lines.push(padLine)
+    }
+    await writeFile(filePath, lines.join('\n'))
+    const result = await searchAiVaultTranscripts({
+      query: 'zebraunicorn',
+      requests: [{ agent: 'claude', filePath }]
+    })
+    expect(result.matches).toEqual([])
+    expect(result.truncated).toBe(true)
+  })
+
+  it('bounds a single record larger than the head window instead of buffering it all', async () => {
+    const root = await makeTranscriptRoot('one-giant-line')
+    const filePath = join(root, 'giant.jsonl')
+    // One JSONL record well past head+tail budgets; the hit is at the very front.
+    const giantLine = `${JSON.stringify({
+      text: 'the flash attention fix is at the front'
+    })}${' '.repeat(4 * 1024 * 1024)}`
+    await writeFile(filePath, giantLine)
+    const result = await searchAiVaultTranscripts({
+      query: 'flash attention',
+      requests: [{ agent: 'claude', filePath }]
+    })
+    expect(result.matches).toHaveLength(1)
+    expect(result.matches[0].snippet).toContain('flash attention fix')
+    expect(result.truncated).toBe(true)
+  })
+})

--- a/src/main/ai-vault/session-transcript-search.ts
+++ b/src/main/ai-vault/session-transcript-search.ts
@@ -1,0 +1,234 @@
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createInterface } from 'node:readline'
+import {
+  AI_VAULT_TRANSCRIPT_SEARCH_HEAD_BUDGET_BYTES,
+  AI_VAULT_TRANSCRIPT_SEARCH_MATCH_COUNT_CAP,
+  AI_VAULT_TRANSCRIPT_SEARCH_TAIL_BUDGET_BYTES,
+  extractTranscriptSearchSnippet,
+  normalizeAiVaultTranscriptSearchArgs,
+  type AiVaultTranscriptSearchArgs,
+  type AiVaultTranscriptSearchIssue,
+  type AiVaultTranscriptSearchMatch,
+  type AiVaultTranscriptSearchResult
+} from '../../shared/ai-vault-transcript-search'
+import type { aiVaultTranscriptSearchRequestKey } from '../../shared/ai-vault-transcript-search'
+
+// One search call must never hold the main process hostage: the per-file byte
+// windows bound I/O, the deadline bounds wall time, and the abort signal lets
+// a superseding query stop an in-flight sweep.
+const AI_VAULT_TRANSCRIPT_SEARCH_TIME_BUDGET_MS = 5_000
+// AbortSignal is only checked between lines; this keeps the check cheap.
+const AI_VAULT_TRANSCRIPT_SEARCH_ABORT_CHECK_INTERVAL_LINES = 512
+
+export type AiVaultTranscriptSearchOptions = {
+  signal?: AbortSignal
+  timeBudgetMs?: number
+}
+
+export async function searchAiVaultTranscripts(
+  args: AiVaultTranscriptSearchArgs,
+  options: AiVaultTranscriptSearchOptions = {}
+): Promise<AiVaultTranscriptSearchResult> {
+  const { query, requests, truncated } = normalizeAiVaultTranscriptSearchArgs(args)
+  if (!query || requests.length === 0) {
+    return { matches: [], issues: [], truncated }
+  }
+  const deadline = Date.now() + (options.timeBudgetMs ?? AI_VAULT_TRANSCRIPT_SEARCH_TIME_BUDGET_MS)
+  const matches: AiVaultTranscriptSearchMatch[] = []
+  const issues: AiVaultTranscriptSearchIssue[] = []
+  const lowerQuery = query.toLowerCase()
+  // Why: head/tail windowing skips a large transcript's middle. That is a
+  // deliberate bound, but it MUST surface as `truncated` — otherwise a
+  // mid-transcript hit reports an honest-looking count of zero.
+  let partial = truncated
+
+  for (const request of requests) {
+    if (options.signal?.aborted) {
+      return { matches, issues, truncated: true }
+    }
+    if (Date.now() >= deadline) {
+      return { matches, issues, truncated: true }
+    }
+    try {
+      const { match, fullyScanned } = await searchTranscriptFile(
+        request,
+        lowerQuery,
+        deadline,
+        options.signal
+      )
+      if (match) {
+        matches.push(match)
+      }
+      if (!fullyScanned) {
+        partial = true
+      }
+    } catch (error) {
+      issues.push({
+        agent: request.agent,
+        path: request.filePath,
+        message: `Transcript could not be searched: ${error instanceof Error ? error.message : String(error)}`
+      })
+    }
+  }
+  // The final file may have hit the deadline mid-window; the loop's start-of-
+  // iteration checks never see that, so re-check before reporting.
+  return { matches, issues, truncated: partial || Date.now() >= deadline }
+}
+
+type TranscriptFileSearchResult = {
+  match: AiVaultTranscriptSearchMatch | null
+  /** False when the head/tail windows skipped part of the file (the middle). */
+  fullyScanned: boolean
+}
+
+async function searchTranscriptFile(
+  request: Parameters<typeof aiVaultTranscriptSearchRequestKey>[0],
+  lowerQuery: string,
+  deadline: number,
+  signal?: AbortSignal
+): Promise<TranscriptFileSearchResult> {
+  const fileSize = await statFileSize(request.filePath)
+  // Missing transcript: a vault row can outlive its file (user cleaned the
+  // agent home). Normal retention, so skip silently instead of issue-row spam.
+  if (fileSize === null) {
+    return { match: null, fullyScanned: true }
+  }
+  if (fileSize === 0) {
+    return { match: null, fullyScanned: true }
+  }
+  if (fileSize <= AI_VAULT_TRANSCRIPT_SEARCH_TAIL_BUDGET_BYTES) {
+    // Small file: one window covers it whole; nothing is a seek fragment.
+    return {
+      match: await searchWindow(
+        request,
+        lowerQuery,
+        { start: 0, skipFirstLine: false },
+        deadline,
+        signal
+      ),
+      fullyScanned: true
+    }
+  }
+  // Tail first: for "find the session where…" the recent work is the more
+  // useful half, and an early deadline should keep the freshest evidence.
+  const tailMatch = await searchWindow(
+    request,
+    lowerQuery,
+    {
+      start: fileSize - AI_VAULT_TRANSCRIPT_SEARCH_TAIL_BUDGET_BYTES,
+      skipFirstLine: true
+    },
+    deadline,
+    signal
+  )
+  if (tailMatch) {
+    return { match: tailMatch, fullyScanned: fileSize <= headPlusTailBudget() }
+  }
+  return {
+    match: await searchWindow(
+      request,
+      lowerQuery,
+      {
+        start: 0,
+        skipFirstLine: false,
+        byteBudget: Math.min(
+          AI_VAULT_TRANSCRIPT_SEARCH_HEAD_BUDGET_BYTES,
+          fileSize - AI_VAULT_TRANSCRIPT_SEARCH_TAIL_BUDGET_BYTES
+        )
+      },
+      deadline,
+      signal
+    ),
+    fullyScanned: fileSize <= headPlusTailBudget()
+  }
+}
+
+const headPlusTailBudget = (): number =>
+  AI_VAULT_TRANSCRIPT_SEARCH_HEAD_BUDGET_BYTES + AI_VAULT_TRANSCRIPT_SEARCH_TAIL_BUDGET_BYTES
+
+/** null = the file is gone (skip silently); 0 = an empty file. */
+async function statFileSize(filePath: string): Promise<number | null> {
+  try {
+    const stats = await stat(filePath)
+    if (!stats.isFile()) {
+      throw new Error('not a regular file')
+    }
+    return stats.size
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+}
+
+type WindowSpec = { start: number; skipFirstLine: boolean; byteBudget?: number }
+
+async function searchWindow(
+  request: Parameters<typeof aiVaultTranscriptSearchRequestKey>[0],
+  lowerQuery: string,
+  window: WindowSpec,
+  deadline: number,
+  signal?: AbortSignal
+): Promise<AiVaultTranscriptSearchMatch | null> {
+  const stream = createReadStream(request.filePath, {
+    ...(window.start > 0 ? { start: window.start } : {}),
+    // Why: `bytesSeen` is only checked between complete lines. A transcript
+    // that opens with one 100 MB JSONL record would otherwise be buffered in
+    // full before the loop could stop; a hard `end` makes the byte budget
+    // hold even for a single line larger than the window.
+    ...(window.byteBudget !== undefined ? { end: window.start + window.byteBudget - 1 } : {}),
+    encoding: 'utf8'
+  })
+  const lines = createInterface({ input: stream, crlfDelay: Infinity })
+  try {
+    let matchCount = 0
+    let snippet: string | null = null
+    let firstLine = window.skipFirstLine
+    let linesSeen = 0
+    let bytesSeen = 0
+    for await (const line of lines) {
+      if (firstLine) {
+        firstLine = false
+        continue
+      }
+      linesSeen += 1
+      bytesSeen += Buffer.byteLength(line) + 1
+      if (
+        linesSeen % AI_VAULT_TRANSCRIPT_SEARCH_ABORT_CHECK_INTERVAL_LINES === 0 &&
+        (signal?.aborted || Date.now() >= deadline)
+      ) {
+        break
+      }
+      const lowerLine = line.toLowerCase()
+      if (lowerLine.includes(lowerQuery)) {
+        matchCount += 1
+        if (!snippet) {
+          snippet = extractTranscriptSearchSnippet(line, lowerQuery)
+        }
+        if (matchCount >= AI_VAULT_TRANSCRIPT_SEARCH_MATCH_COUNT_CAP) {
+          break
+        }
+      }
+      // Budget is enforced AFTER the line is matched: a window whose last
+      // readable line is a huge partial record must still search that line.
+      if (window.byteBudget !== undefined && bytesSeen > window.byteBudget) {
+        break
+      }
+    }
+    if (matchCount === 0) {
+      return null
+    }
+    return {
+      agent: request.agent,
+      filePath: request.filePath,
+      ...(request.sessionId ? { sessionId: request.sessionId } : {}),
+      matchCount,
+      snippet: snippet ?? ''
+    }
+  } finally {
+    lines.close()
+    stream.destroy()
+  }
+}

--- a/src/main/ipc/ai-vault-transcript-search-handler.ts
+++ b/src/main/ipc/ai-vault-transcript-search-handler.ts
@@ -1,0 +1,13 @@
+import { ipcMain } from 'electron'
+import { searchAiVaultTranscripts } from '../ai-vault/session-transcript-search'
+import type { AiVaultTranscriptSearchArgs } from '../../shared/ai-vault-transcript-search'
+
+// Deep search reads local transcript files only; the renderer narrows its
+// requests to local sessions. Like the other read-only vault handlers, the
+// main process trusts the renderer's paths — normalization bounds the payload
+// size and request count, it does not enforce path containment.
+export function registerAiVaultTranscriptSearchHandler(): void {
+  ipcMain.handle('aiVault:searchTranscripts', (_event, args?: AiVaultTranscriptSearchArgs) =>
+    searchAiVaultTranscripts(args ?? { query: '', requests: [] })
+  )
+}

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -25,6 +25,7 @@ import { registerRuntimeHandlers } from '../runtime'
 import { registerRuntimeEnvironmentHandlers } from '../runtime-environments'
 import { registerEphemeralVmHandlers } from '../ephemeral-vm'
 import { registerAiVaultHandlers } from '../ai-vault'
+import { registerAiVaultTranscriptSearchHandler } from '../ai-vault-transcript-search-handler'
 import { registerNativeChatHandlers } from '../native-chat'
 import { registerNotificationHandlers } from '../notifications'
 import { registerNotebookHandlers } from '../notebook'
@@ -214,6 +215,7 @@ export function registerCoreHandlers(
   registerRuntimeHandlers(runtime)
   registerRuntimeEnvironmentHandlers(store)
   registerEphemeralVmHandlers(store, pluginService)
+  registerAiVaultTranscriptSearchHandler()
   registerAiVaultHandlers({
     ensureStructuredSessionOwnership: () => runtime.ensureStructuredAgentSessionHost(),
     getAdditionalCodexHomePaths: lifecycleOptions.getAdditionalAiVaultCodexHomePaths,

--- a/src/preload/api/ai-vault-api.ts
+++ b/src/preload/api/ai-vault-api.ts
@@ -18,6 +18,10 @@ import type {
   AiVaultPrepareSessionResumeArgs,
   AiVaultPrepareSessionResumeResult
 } from '../../shared/ai-vault-resume-preparation'
+import type {
+  AiVaultTranscriptSearchArgs,
+  AiVaultTranscriptSearchResult
+} from '../../shared/ai-vault-transcript-search'
 
 export type AiVaultApi = {
   listSessions: (args?: AiVaultListArgs) => Promise<AiVaultListResult>
@@ -32,6 +36,8 @@ export type AiVaultApi = {
   getFirstUserPrompt: (args: AiVaultFirstUserPromptArgs) => Promise<AiVaultFirstUserPromptResult>
   /** Moves a deletable session's transcript to the OS trash; local sessions only. */
   deleteSession: (args: AiVaultDeleteSessionArgs) => Promise<AiVaultDeleteSessionResult>
+  /** Bounded full-transcript content search over the requested local sessions. */
+  searchTranscripts: (args: AiVaultTranscriptSearchArgs) => Promise<AiVaultTranscriptSearchResult>
   /** Fires when any app window regains OS focus; returns an unsubscribe. */
   onWindowFocused: (callback: () => void) => () => void
 }

--- a/src/preload/api/ai-vault-bridge.ts
+++ b/src/preload/api/ai-vault-bridge.ts
@@ -10,6 +10,10 @@ import type {
 } from '../../shared/ai-vault-types'
 import type { AiVaultSessionTitlesArgs } from '../../shared/ai-vault-session-title'
 import type { AiVaultPrepareSessionResumeArgs } from '../../shared/ai-vault-resume-preparation'
+import type {
+  AiVaultTranscriptSearchArgs,
+  AiVaultTranscriptSearchResult
+} from '../../shared/ai-vault-transcript-search'
 import type { PreloadApi } from '../api-types'
 
 export const aiVaultApi = {
@@ -26,6 +30,8 @@ export const aiVaultApi = {
     ipcRenderer.invoke('aiVault:getFirstUserPrompt', args),
   deleteSession: (args: AiVaultDeleteSessionArgs): Promise<AiVaultDeleteSessionResult> =>
     ipcRenderer.invoke('aiVault:deleteSession', args),
+  searchTranscripts: (args: AiVaultTranscriptSearchArgs): Promise<AiVaultTranscriptSearchResult> =>
+    ipcRenderer.invoke('aiVault:searchTranscripts', args),
   onWindowFocused: (callback: () => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent) => callback()
     ipcRenderer.on('aiVault:windowFocused', listener)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -240,6 +240,10 @@
   --annotation-highlight: #f59e0b;
   --markdown-search-match: #facc15;
   --markdown-search-match-active: #fb923c;
+  /* Why: vault deep-search highlights sit on gray/foreground rows, so the highlighter
+     keeps near-black text for contrast on the light card; dark mode brightens the fill. */
+  --vault-search-match-bg: #fde047;
+  --vault-search-match-fg: #111827;
   /* Why: tab-group splits use a dedicated divider — `--border` is too faint on
      card/editor surfaces when panes are side-by-side or stacked. Default must
      meet >=3:1 against `--card`, not only the hover/drag strong state. */
@@ -352,6 +356,8 @@
   --annotation-highlight: #fbbf24;
   --markdown-search-match: #facc15;
   --markdown-search-match-active: #fb923c;
+  --vault-search-match-bg: #facc15;
+  --vault-search-match-fg: #09090b;
   /* Brighter than terminal defaults so the always-visible line clears 3:1 on `--card`. */
   --tab-group-split-divider: #71717a;
   --tab-group-split-divider-strong: #a1a1aa;

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -36,6 +36,7 @@ import {
 } from './ai-vault-session-worktree'
 import { openAiVaultSessionLogInOrca } from './ai-vault-session-log-open'
 import { useAiVaultOriginalPaneActions } from './ai-vault-original-pane-actions'
+import { useAiVaultTranscriptDeepSearchPanel } from './ai-vault-transcript-deep-search'
 import type { AiVaultScope, AiVaultSession } from '../../../../shared/ai-vault-types'
 import { translate } from '@/i18n/i18n'
 import { AiVaultPanelHeader } from './AiVaultPanelHeader'
@@ -241,15 +242,28 @@ export default function AiVaultPanel(): React.JSX.Element {
     ]
   )
 
+  const deepSearch = useAiVaultTranscriptDeepSearchPanel({ query, sessions })
+  // During a transcript search the panel is a results view: show ONLY the
+  // matched sessions, so the global list does not turn into a cluttered mix.
+  // Zero hits stay in this view too — falling back to the metadata list would
+  // imply the transcript search matched something it did not.
+  // `filteredSessionsCount` (feed below) follows this list view too — otherwise a
+  // 0-hit metadata filter would render the empty-state banner ABOVE the matched
+  // sessions, burying search hits below a "no sessions" message.
+  const listSessions =
+    deepSearch.deepSearchStatus === 'done' && deepSearch.deepSearchQuery === query
+      ? deepSearch.matchedSessions
+      : filteredSessions
   const groups = useMemo(
     () =>
-      groupAiVaultSessions(filteredSessions, group, {
+      groupAiVaultSessions(listSessions, group, {
         sessionProjectById,
         projectLabelByKey
       }),
-    [filteredSessions, group, projectLabelByKey, sessionProjectById]
+    [group, listSessions, projectLabelByKey, sessionProjectById]
   )
 
+  const matchById = deepSearch.transcriptMatchById
   const copyText = useCallback(async (text: string, label: string): Promise<void> => {
     await window.api.ui.writeClipboardText(text)
     toast.success(
@@ -312,8 +326,14 @@ export default function AiVaultPanel(): React.JSX.Element {
       <AiVaultPanelHeader
         query={query}
         loading={loading}
-        shownCount={filteredSessions.length}
+        shownCount={listSessions.length}
         sessionCount={sessions.length}
+        deepSearchStatus={deepSearch.deepSearchStatus}
+        deepSearchQuery={deepSearch.deepSearchQuery}
+        deepSearchTruncated={deepSearch.deepSearchTruncated}
+        deepSearchMatchCount={deepSearch.deepSearchMatchCount}
+        onDeepSearch={deepSearch.onDeepSearch}
+        onDeepSearchClear={deepSearch.clearDeepSearch}
         hasScanResult={Boolean(scanResult)}
         activeWorktreePath={activeWorktreePath}
         activeProjectKey={activeProjectKey}
@@ -349,10 +369,11 @@ export default function AiVaultPanel(): React.JSX.Element {
 
       <AiVaultSessionVirtualList
         groups={groups}
+        getTranscriptMatch={matchById ? (session) => matchById.get(session.id) ?? null : null}
         collapsedGroups={collapsedGroups}
         loading={loading}
         sessionsCount={sessions.length}
-        filteredSessionsCount={filteredSessions.length}
+        filteredSessionsCount={listSessions.length}
         noAgentsSelected={agents.length === 0}
         error={error}
         vaultScope={scope}

--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -215,34 +215,42 @@ export default function AiVaultPanel(): React.JSX.Element {
     }
   }, [activeProjectKey, activeWorktreePath, scope])
 
-  const filteredSessions = useMemo(
-    () =>
-      filterAiVaultSessions(sessions, {
-        query,
-        agents,
-        scope,
-        sort,
-        activeWorktreePaths,
-        activeProjectKey,
-        sessionProjectById,
-        projectLabelByKey,
-        hideEmptySessions
-      }),
-    [
-      activeProjectKey,
-      activeWorktreePaths,
+  // Deep-search candidates share every non-query view filter (agents, scope,
+  // hide-empty, sort) but bypass the metadata text predicate: transcript-only
+  // hits stay visible, the results view respects the user's view settings, and
+  // the request cap is not consumed by sessions the user has filtered out.
+  const { filteredSessions, candidates } = useMemo(() => {
+    const filters = {
       agents,
-      hideEmptySessions,
-      projectLabelByKey,
-      query,
       scope,
+      sort,
+      activeWorktreePaths,
+      activeProjectKey,
       sessionProjectById,
-      sessions,
-      sort
-    ]
-  )
+      projectLabelByKey,
+      hideEmptySessions
+    }
+    return {
+      filteredSessions: filterAiVaultSessions(sessions, { ...filters, query }),
+      candidates: filterAiVaultSessions(sessions, { ...filters, query: '' })
+    }
+  }, [
+    activeProjectKey,
+    activeWorktreePaths,
+    agents,
+    hideEmptySessions,
+    projectLabelByKey,
+    query,
+    scope,
+    sessionProjectById,
+    sessions,
+    sort
+  ])
 
-  const deepSearch = useAiVaultTranscriptDeepSearchPanel({ query, sessions })
+  const deepSearch = useAiVaultTranscriptDeepSearchPanel({
+    query,
+    sessions: candidates
+  })
   // During a transcript search the panel is a results view: show ONLY the
   // matched sessions, so the global list does not turn into a cluttered mix.
   // Zero hits stay in this view too — falling back to the metadata list would

--- a/src/renderer/src/components/right-sidebar/AiVaultPanelHeader.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanelHeader.tsx
@@ -1,4 +1,4 @@
-import { LoaderCircle, RefreshCw, Search, X } from 'lucide-react'
+import { LoaderCircle, RefreshCw, Search, TextSearch, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 import type {
@@ -8,6 +8,7 @@ import type {
   AiVaultSort
 } from '../../../../shared/ai-vault-types'
 import type { ExecutionHostScope } from '../../../../shared/execution-host'
+import { AI_VAULT_TRANSCRIPT_SEARCH_MIN_QUERY_LENGTH } from '../../../../shared/ai-vault-transcript-search'
 import { VaultHostScopeMenu, VaultScopeSwitch, VaultViewMenu } from './AiVaultPanelControls'
 import type { AiVaultHostScopeOption } from './ai-vault-host-scope'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
@@ -30,6 +31,12 @@ type AiVaultPanelHeaderProps = {
   sessionLimit: AiVaultSessionLimit
   adjustmentCount: number
   onQueryChange: (query: string) => void
+  deepSearchStatus: 'idle' | 'running' | 'done'
+  deepSearchQuery: string
+  deepSearchTruncated: boolean
+  deepSearchMatchCount: number
+  onDeepSearch: () => void
+  onDeepSearchClear: () => void
   onScopeChange: (scope: AiVaultScope) => void
   onExecutionHostScopeChange: (scope: ExecutionHostScope) => void
   onAgentEnabledChange: (agent: AiVaultAgent, enabled: boolean) => void
@@ -60,6 +67,12 @@ export function AiVaultPanelHeader({
   sessionLimit,
   adjustmentCount,
   onQueryChange,
+  deepSearchStatus,
+  deepSearchQuery,
+  deepSearchTruncated,
+  deepSearchMatchCount,
+  onDeepSearch,
+  onDeepSearchClear,
   onScopeChange,
   onExecutionHostScopeChange,
   onAgentEnabledChange,
@@ -178,6 +191,69 @@ export function AiVaultPanelHeader({
           spellCheck={false}
         />
         {loading ? <LoaderCircle className="size-3 animate-spin text-muted-foreground" /> : null}
+        {deepSearchStatus === 'running' && deepSearchQuery === query ? (
+          <LoaderCircle
+            className="size-3 animate-spin text-muted-foreground"
+            aria-label={translate(
+              'auto.components.right.sidebar.AiVaultPanel.searchingTranscripts',
+              'Searching transcript contents'
+            )}
+          />
+        ) : null}
+        {query.trim().length >= AI_VAULT_TRANSCRIPT_SEARCH_MIN_QUERY_LENGTH &&
+        !(deepSearchStatus === 'running' && deepSearchQuery === query) &&
+        !(deepSearchStatus === 'done' && deepSearchQuery === query) ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="size-5 rounded-sm text-muted-foreground hover:text-foreground"
+            onClick={onDeepSearch}
+            aria-label={translate(
+              'auto.components.right.sidebar.AiVaultPanel.searchTranscripts',
+              'Search transcript contents'
+            )}
+            title={translate(
+              'auto.components.right.sidebar.AiVaultPanel.searchTranscriptsHint',
+              'Also search inside conversation transcripts on this computer'
+            )}
+          >
+            <TextSearch className="size-3" />
+          </Button>
+        ) : null}
+        {deepSearchStatus === 'done' && deepSearchQuery === query ? (
+          <>
+            <span
+              className="rounded-full border border-sidebar-border bg-background px-1.5 py-px text-[10px] font-medium leading-none text-muted-foreground tabular-nums"
+              title={
+                deepSearchTruncated
+                  ? translate(
+                      'auto.components.right.sidebar.AiVaultPanel.transcriptSearchPartial',
+                      'Transcript search was cut short; results may be partial'
+                    )
+                  : translate(
+                      'auto.components.right.sidebar.AiVaultPanel.transcriptSearchCount',
+                      'Sessions matching inside transcript contents'
+                    )
+              }
+            >
+              {deepSearchMatchCount}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="size-5 rounded-sm text-muted-foreground hover:text-foreground"
+              onClick={onDeepSearchClear}
+              aria-label={translate(
+                'auto.components.right.sidebar.AiVaultPanel.clearTranscriptSearch',
+                'Clear transcript matches'
+              )}
+            >
+              <X className="size-3" />
+            </Button>
+          </>
+        ) : null}
         {query ? (
           <Button
             type="button"

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -23,9 +23,11 @@ import {
   SessionMetadata
 } from './ai-vault-session-row-display'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import type { AiVaultTranscriptMatchInfo } from './ai-vault-transcript-deep-search'
 
 export function VaultSessionRow({
   session,
+  transcriptMatch,
   liveState,
   resumeStartup,
   realHomeResumeStartup,
@@ -52,6 +54,8 @@ export function VaultSessionRow({
   onRequestDelete
 }: {
   session: AiVaultSession
+  /** Set when this row surfaced via full-transcript deep search. */
+  transcriptMatch?: AiVaultTranscriptMatchInfo | null
   liveState: AgentStatusState | null
   resumeStartup: AiVaultResumeStartup
   realHomeResumeStartup: AiVaultResumeStartup
@@ -200,6 +204,22 @@ export function VaultSessionRow({
               )}
             </div>
           ) : null}
+          {transcriptMatch ? (
+            <div
+              className="mt-0.5 flex min-w-0 items-center gap-1.5 rounded-sm bg-foreground/5 px-1.5 py-0.5 text-[11px] leading-4 text-muted-foreground"
+              title={translate(
+                'auto.components.right.sidebar.AiVaultSessionRow.transcriptMatch',
+                'Matched inside this session’s transcript'
+              )}
+            >
+              <span className="shrink-0 rounded-full bg-foreground/10 px-1.5 text-[10px] font-medium leading-4 text-foreground/80 tabular-nums">
+                {transcriptMatch.matchCount}
+              </span>
+              <span className="min-w-0 break-words line-clamp-2">
+                <HighlightedSnippet text={transcriptMatch.snippet} query={transcriptMatch.query} />
+              </span>
+            </div>
+          ) : null}
           <SessionMetadata
             session={session}
             liveState={liveState}
@@ -243,5 +263,32 @@ export function VaultSessionRow({
         />
       </ContextMenuContent>
     </ContextMenu>
+  )
+}
+
+/** Renders a transcript snippet with each occurrence of the search term in a
+ *  visible highlight, so the matched location jumps out while scanning rows. */
+function HighlightedSnippet({ text, query }: { text: string; query: string }) {
+  if (!query) {
+    return text
+  }
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const parts = text.split(new RegExp(`(${escaped})`, 'i'))
+  const lower = query.toLowerCase()
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.toLowerCase() === lower ? (
+          <mark
+            key={index}
+            className="rounded-[2px] bg-[var(--vault-search-match-bg)] px-0.5 text-[var(--vault-search-match-fg)]"
+          >
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </>
   )
 }

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -9,6 +9,7 @@ import { getActiveStickyHeaderIndexForScroll } from '../sidebar/worktree-list/vi
 import { VaultGroupHeader } from './AiVaultPanelControls'
 import { EmptyState, SessionLoadingState } from './AiVaultSessionListStates'
 import { VaultSessionRow } from './AiVaultSessionRow'
+import type { AiVaultTranscriptMatchInfo } from './ai-vault-transcript-deep-search'
 import type { AiVaultSessionGroup } from './ai-vault-session-filters'
 import type { AiVaultOriginalPaneTarget } from './ai-vault-original-pane'
 import {
@@ -43,6 +44,7 @@ type AiVaultListRow =
 
 export function AiVaultSessionVirtualList({
   groups,
+  getTranscriptMatch,
   collapsedGroups,
   loading,
   sessionsCount,
@@ -70,6 +72,7 @@ export function AiVaultSessionVirtualList({
   onRequestDelete
 }: {
   groups: readonly AiVaultSessionGroup[]
+  getTranscriptMatch: ((session: AiVaultSession) => AiVaultTranscriptMatchInfo | null) | null
   collapsedGroups: ReadonlySet<string>
   loading: boolean
   sessionsCount: number
@@ -214,6 +217,7 @@ export function AiVaultSessionVirtualList({
               expandedSessionIds={expandedSessionIds}
               vaultScope={vaultScope}
               buildResumeStartup={buildResumeStartup}
+              getTranscriptMatch={getTranscriptMatch}
               getOriginalPaneTarget={getOriginalPaneTarget}
               getSessionLiveState={getSessionLiveState}
               getWorktreeInfo={getWorktreeInfo}
@@ -250,6 +254,7 @@ function AiVaultVirtualRow({
   expandedSessionIds,
   vaultScope,
   buildResumeStartup,
+  getTranscriptMatch,
   getOriginalPaneTarget,
   getSessionLiveState,
   getWorktreeInfo,
@@ -278,6 +283,7 @@ function AiVaultVirtualRow({
   expandedSessionIds: ReadonlySet<string>
   vaultScope: AiVaultScope
   buildResumeStartup: (session: AiVaultSession, worktreeId?: string | null) => AiVaultResumeStartup
+  getTranscriptMatch: ((session: AiVaultSession) => AiVaultTranscriptMatchInfo | null) | null
   getOriginalPaneTarget: (session: AiVaultSession) => AiVaultOriginalPaneTarget | null
   getSessionLiveState: (session: AiVaultSession) => AgentStatusState | null
   getWorktreeInfo: (session: AiVaultSession) => AiVaultSessionWorktreeInfo | null
@@ -351,6 +357,7 @@ function AiVaultVirtualRow({
       ) : (
         <VaultSessionRow
           session={row.session}
+          transcriptMatch={getTranscriptMatch?.(row.session) ?? null}
           liveState={getSessionLiveState(row.session)}
           resumeStartup={buildResumeStartup(row.session, resumeState?.worktreeId)}
           realHomeResumeStartup={buildResumeStartup(

--- a/src/renderer/src/components/right-sidebar/ai-vault-transcript-deep-search.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-transcript-deep-search.ts
@@ -170,7 +170,9 @@ export function useAiVaultTranscriptDeepSearch() {
  *  Lives here so AiVaultPanel stays a one-frame component. While a search is
  *  active the panel shows ONLY the matched sessions (a results view), so the
  *  group memo must key off the derived list and a query keystroke must not
- *  rebuild the virtualized groups every render. */
+ *  rebuild the virtualized groups every render. `sessions` is the candidate
+ *  list to search and join — the panel passes the view-filtered (non-query)
+ *  candidates so results respect the active view settings. */
 export function useAiVaultTranscriptDeepSearchPanel(params: {
   query: string
   sessions: readonly AiVaultSession[]

--- a/src/renderer/src/components/right-sidebar/ai-vault-transcript-deep-search.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-transcript-deep-search.ts
@@ -35,13 +35,16 @@ type DeepSearchState = {
   matchByKey: ReadonlyMap<string, AiVaultTranscriptMatchInfo>
   query: string
   truncated: boolean
+  /** Request keys actually sent in the run that produced this state. */
+  searchedKeys: ReadonlySet<string>
 }
 
 const IDLE_STATE: DeepSearchState = {
   status: 'idle',
   matchByKey: new Map(),
   query: '',
-  truncated: false
+  truncated: false,
+  searchedKeys: new Set()
 }
 const NO_MATCHES: readonly AiVaultSession[] = []
 
@@ -84,11 +87,15 @@ export function useAiVaultTranscriptDeepSearch() {
       const { requests, truncated: requestsTruncated } = localSearchRequests(sessions)
       const runId = runIdRef.current + 1
       runIdRef.current = runId
+      const searchedKeys = new Set(
+        requests.map((request) => aiVaultTranscriptSearchRequestKey(request))
+      )
       setState({
         status: requests.length > 0 ? 'running' : 'done',
         matchByKey: new Map(),
         query,
-        truncated: requestsTruncated
+        truncated: requestsTruncated,
+        searchedKeys
       })
       if (requests.length === 0) {
         return
@@ -123,7 +130,13 @@ export function useAiVaultTranscriptDeepSearch() {
           { matchCount: match.matchCount, snippet: match.snippet, query }
         )
       }
-      setState({ status: 'done', matchByKey, query, truncated: truncated || issues.length > 0 })
+      setState({
+        status: 'done',
+        matchByKey,
+        query,
+        truncated: truncated || issues.length > 0,
+        searchedKeys
+      })
     },
     [localSearchRequests]
   )
@@ -160,6 +173,7 @@ export function useAiVaultTranscriptDeepSearch() {
     deepSearchQuery: state.query,
     deepSearchTruncated: state.truncated,
     deepSearchMatchCount: state.matchByKey.size,
+    searchedKeys: state.searchedKeys,
     runDeepSearch,
     clearDeepSearch,
     matchBySessionId
@@ -181,8 +195,9 @@ export function useAiVaultTranscriptDeepSearchPanel(params: {
   const {
     deepSearchStatus,
     deepSearchQuery,
-    deepSearchTruncated,
-    deepSearchMatchCount,
+    deepSearchTruncated: reportedTruncated,
+    deepSearchMatchCount: reportedMatchCount,
+    searchedKeys,
     runDeepSearch,
     clearDeepSearch,
     matchBySessionId
@@ -215,11 +230,33 @@ export function useAiVaultTranscriptDeepSearchPanel(params: {
         : NO_MATCHES,
     [sessions, transcriptMatchById]
   )
+  // Keep the badge and the visible rows consistent while the results view is
+  // live: the candidate list can change after a search ran (filters broadened
+  // or narrowed, vault refresh), and the frozen search-time count would then
+  // disagree with the rows. Sessions that entered the view unsearched are
+  // flagged as truncated instead of passing for a complete result.
+  const deepSearchTruncated = useMemo(() => {
+    if (deepSearchStatus !== 'done' || deepSearchQuery !== query) {
+      return reportedTruncated
+    }
+    return (
+      reportedTruncated ||
+      sessions.some(
+        (session) =>
+          canUseLocalAiVaultSessionPathActions(session.executionHostId) &&
+          !searchedKeys.has(
+            aiVaultTranscriptSearchRequestKey({ agent: session.agent, filePath: session.filePath })
+          )
+      )
+    )
+  }, [deepSearchQuery, deepSearchStatus, query, reportedTruncated, searchedKeys, sessions])
   return {
     deepSearchStatus,
     deepSearchQuery,
     deepSearchTruncated,
-    deepSearchMatchCount,
+    // Count the matches joined to the CURRENT candidates, not the frozen
+    // search-time total, so the badge always agrees with the visible rows.
+    deepSearchMatchCount: transcriptMatchById ? transcriptMatchById.size : reportedMatchCount,
     matchedSessions,
     transcriptMatchById,
     onDeepSearch,

--- a/src/renderer/src/components/right-sidebar/ai-vault-transcript-deep-search.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-transcript-deep-search.ts
@@ -1,0 +1,226 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS,
+  aiVaultTranscriptSearchRequestKey,
+  type AiVaultTranscriptSearchMatch,
+  type AiVaultTranscriptSearchRequest
+} from '../../../../shared/ai-vault-transcript-search'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import { canUseLocalAiVaultSessionPathActions } from './ai-vault-session-path-actions'
+
+export type AiVaultTranscriptMatchInfo = {
+  matchCount: number
+  snippet: string
+  /** The search term that produced the snippet, so rows can highlight it. */
+  query: string
+}
+
+export type AiVaultTranscriptDeepSearchPanel = {
+  deepSearchStatus: 'idle' | 'running' | 'done'
+  deepSearchQuery: string
+  deepSearchTruncated: boolean
+  deepSearchMatchCount: number
+  /** Sessions that contain the term; empty keeps the normal filtered list. */
+  matchedSessions: readonly AiVaultSession[]
+  transcriptMatchById: ReadonlyMap<string, AiVaultTranscriptMatchInfo> | null
+  onDeepSearch: () => void
+  clearDeepSearch: () => void
+}
+
+type DeepSearchStatus = 'idle' | 'running' | 'done'
+
+type DeepSearchState = {
+  status: DeepSearchStatus
+  /** Keyed by aiVaultTranscriptSearchRequestKey(agent, filePath). */
+  matchByKey: ReadonlyMap<string, AiVaultTranscriptMatchInfo>
+  query: string
+  truncated: boolean
+}
+
+const IDLE_STATE: DeepSearchState = {
+  status: 'idle',
+  matchByKey: new Map(),
+  query: '',
+  truncated: false
+}
+const NO_MATCHES: readonly AiVaultSession[] = []
+
+/** Runs the on-demand full-transcript search behind the vault's "deep search"
+ *  affordance. Requests are narrowed to local sessions: transcript bodies only
+ *  exist on the machine that ran the agent, and the desktop IPC handler reads
+ *  local files only. Results are joined back to rows by (agent, filePath). */
+export function useAiVaultTranscriptDeepSearch() {
+  const [state, setState] = useState<DeepSearchState>(IDLE_STATE)
+  // Guards against a stale response landing after a newer query or a clear.
+  const runIdRef = useRef(0)
+
+  const localSearchRequests = useCallback((sessions: readonly AiVaultSession[]) => {
+    const requests: AiVaultTranscriptSearchRequest[] = []
+    let candidates = 0
+    for (const session of sessions) {
+      if (!canUseLocalAiVaultSessionPathActions(session.executionHostId)) {
+        continue
+      }
+      candidates += 1
+      if (requests.length >= AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS) {
+        continue
+      }
+      requests.push({
+        agent: session.agent,
+        filePath: session.filePath,
+        ...(session.sessionId ? { sessionId: session.sessionId } : {})
+      })
+    }
+    return {
+      requests,
+      // Eligible local sessions past the cap were never asked for; the UI must
+      // say "partial" instead of presenting a complete-looking result.
+      truncated: candidates > requests.length
+    }
+  }, [])
+
+  const runDeepSearch = useCallback(
+    async (query: string, sessions: readonly AiVaultSession[]) => {
+      const { requests, truncated: requestsTruncated } = localSearchRequests(sessions)
+      const runId = runIdRef.current + 1
+      runIdRef.current = runId
+      setState({
+        status: requests.length > 0 ? 'running' : 'done',
+        matchByKey: new Map(),
+        query,
+        truncated: requestsTruncated
+      })
+      if (requests.length === 0) {
+        return
+      }
+      let matches: AiVaultTranscriptSearchMatch[] = []
+      let issues: { agent: string; path: string; message: string }[] = []
+      let truncated = requestsTruncated
+      try {
+        const result = await window.api.aiVault.searchTranscripts({ query, requests })
+        if (runIdRef.current !== runId) {
+          return
+        }
+        matches = result.matches
+        issues = result.issues
+        truncated = truncated || result.truncated
+      } catch {
+        // Why: a failed deep search must not break the vault panel; the query
+        // still filters metadata, and the idle state keeps the UI honest.
+        if (runIdRef.current !== runId) {
+          return
+        }
+        setState(IDLE_STATE)
+        return
+      }
+      const matchByKey = new Map<string, AiVaultTranscriptMatchInfo>()
+      for (const match of matches) {
+        matchByKey.set(
+          aiVaultTranscriptSearchRequestKey({
+            agent: match.agent,
+            filePath: match.filePath
+          }),
+          { matchCount: match.matchCount, snippet: match.snippet, query }
+        )
+      }
+      setState({ status: 'done', matchByKey, query, truncated: truncated || issues.length > 0 })
+    },
+    [localSearchRequests]
+  )
+
+  const clearDeepSearch = useCallback(() => {
+    runIdRef.current += 1
+    setState(IDLE_STATE)
+  }, [])
+
+  const matchBySessionId = useMemo(() => {
+    const byKey = state.matchByKey
+    return (sessions: readonly AiVaultSession[]): Map<string, AiVaultTranscriptMatchInfo> => {
+      const bySessionId = new Map<string, AiVaultTranscriptMatchInfo>()
+      if (byKey.size === 0) {
+        return bySessionId
+      }
+      for (const session of sessions) {
+        const info = byKey.get(
+          aiVaultTranscriptSearchRequestKey({
+            agent: session.agent,
+            filePath: session.filePath
+          })
+        )
+        if (info) {
+          bySessionId.set(session.id, info)
+        }
+      }
+      return bySessionId
+    }
+  }, [state.matchByKey])
+
+  return {
+    deepSearchStatus: state.status,
+    deepSearchQuery: state.query,
+    deepSearchTruncated: state.truncated,
+    deepSearchMatchCount: state.matchByKey.size,
+    runDeepSearch,
+    clearDeepSearch,
+    matchBySessionId
+  }
+}
+
+/** Panel-level glue: wires the deep-search hook to the vault's metadata query.
+ *  Lives here so AiVaultPanel stays a one-frame component. While a search is
+ *  active the panel shows ONLY the matched sessions (a results view), so the
+ *  group memo must key off the derived list and a query keystroke must not
+ *  rebuild the virtualized groups every render. */
+export function useAiVaultTranscriptDeepSearchPanel(params: {
+  query: string
+  sessions: readonly AiVaultSession[]
+}): AiVaultTranscriptDeepSearchPanel {
+  const { query, sessions } = params
+  const {
+    deepSearchStatus,
+    deepSearchQuery,
+    deepSearchTruncated,
+    deepSearchMatchCount,
+    runDeepSearch,
+    clearDeepSearch,
+    matchBySessionId
+  } = useAiVaultTranscriptDeepSearch()
+  const onDeepSearch = useCallback(
+    () => void runDeepSearch(query, sessions),
+    [query, runDeepSearch, sessions]
+  )
+  // Why: query equality alone cannot prove the current input was searched.
+  // Clearing the field and retyping the same term would otherwise resurrect the
+  // old results and hide the search button. Once the input moves off the
+  // searched text, drop the results entirely (the in-flight run's response is
+  // ignored via the run-id bump inside clearDeepSearch).
+  useEffect(() => {
+    if (deepSearchQuery !== query) {
+      clearDeepSearch()
+    }
+  }, [clearDeepSearch, deepSearchQuery, query])
+  // Deep search hits surface even when the metadata filter misses them — that
+  // is the point. A stale result from a superseded query must not show.
+  const transcriptMatchById = useMemo(
+    () =>
+      deepSearchStatus === 'done' && deepSearchQuery === query ? matchBySessionId(sessions) : null,
+    [deepSearchQuery, deepSearchStatus, matchBySessionId, query, sessions]
+  )
+  const matchedSessions = useMemo(
+    () =>
+      transcriptMatchById && transcriptMatchById.size > 0
+        ? sessions.filter((session) => transcriptMatchById.has(session.id))
+        : NO_MATCHES,
+    [sessions, transcriptMatchById]
+  )
+  return {
+    deepSearchStatus,
+    deepSearchQuery,
+    deepSearchTruncated,
+    deepSearchMatchCount,
+    matchedSessions,
+    transcriptMatchById,
+    onDeepSearch,
+    clearDeepSearch
+  }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12751,7 +12751,13 @@
             "localSessionSshWorkspaceUnsupported": "This session's history is stored on this machine, so it can't resume in an SSH workspace. Open a local workspace instead.",
             "prepareSessionResumeFailed": "Could not prepare this session for resume.",
             "sessionDeleted": "Session deleted",
-            "sessionDeleteFailed": "Couldn't delete the session"
+            "sessionDeleteFailed": "Couldn't delete the session",
+            "searchingTranscripts": "Searching transcript contents",
+            "searchTranscripts": "Search transcript contents",
+            "searchTranscriptsHint": "Also search inside conversation transcripts on this computer",
+            "transcriptSearchPartial": "Transcript search was cut short; results may be partial",
+            "transcriptSearchCount": "Sessions matching inside transcript contents",
+            "clearTranscriptSearch": "Clear transcript matches"
           },
           "AiVaultPanelControls": {
             "scanningSessions": "Scanning sessions",
@@ -12887,7 +12893,8 @@
             "delete": "Delete",
             "deleteReasonNonLocalHost": "Only sessions on this device can be deleted.",
             "deleteReasonSyntheticPath": "This session can't be deleted from Orca.",
-            "deleteReasonUnsupportedAgent": "{{value0}} sessions can't be deleted from Orca."
+            "deleteReasonUnsupportedAgent": "{{value0}} sessions can't be deleted from Orca.",
+            "transcriptMatch": "Matched inside this session’s transcript"
           },
           "AiVaultSessionDeleteDialog": {
             "title": "Delete this session?",

--- a/src/renderer/src/web/preload-api/web-ai-vault-api.ts
+++ b/src/renderer/src/web/preload-api/web-ai-vault-api.ts
@@ -61,6 +61,10 @@ export function createWebAiVaultApi(): NonNullable<Partial<PreloadApi>['aiVault'
     listSubagentSessions: () => Promise.resolve({ sessions: [], issues: [] }),
     // Why: full first-prompt re-parse is local-FS only; web/runtime falls back to preview text.
     getFirstUserPrompt: () => Promise.resolve({ prompt: null }),
+    // Why: deep search reads transcripts on the local filesystem, which a web
+    // client does not have, and there is no runtime RPC for it yet. Report an
+    // empty (not erroring) result so the UI can show "no transcript matches".
+    searchTranscripts: () => Promise.resolve({ matches: [], issues: [], truncated: false }),
     // Why: session deletion is local-only and has no runtime RPC; a web
     // client's sessions are runtime-hosted, so report the same non-local
     // rejection the UI already gates on rather than pretend to delete.

--- a/src/shared/ai-vault-transcript-search.test.ts
+++ b/src/shared/ai-vault-transcript-search.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS,
+  AI_VAULT_TRANSCRIPT_SEARCH_MAX_SNIPPET_LENGTH,
+  AI_VAULT_TRANSCRIPT_SEARCH_SNIPPET_LEAD_CHARS,
+  aiVaultTranscriptSearchRequestKey,
+  extractTranscriptSearchSnippet,
+  isAiVaultTranscriptSearchQueryTooLarge,
+  normalizeAiVaultTranscriptSearchArgs
+} from './ai-vault-transcript-search'
+
+// Why: keep a raw control byte out of the source file itself.
+const CONTROL_BYTE = String.fromCharCode(1)
+
+describe('normalizeAiVaultTranscriptSearchArgs', () => {
+  it('trims the query and drops duplicate requests by (agent, filePath)', () => {
+    const normalized = normalizeAiVaultTranscriptSearchArgs({
+      query: '  flash attention  ',
+      requests: [
+        { agent: 'claude', filePath: '/t/a.jsonl', sessionId: 's1' },
+        { agent: 'claude', filePath: '/t/a.jsonl' },
+        { agent: 'codex', filePath: '/t/b.jsonl', sessionId: 's2' }
+      ]
+    })
+    expect(normalized.query).toBe('flash attention')
+    expect(normalized.requests).toEqual([
+      { agent: 'claude', filePath: '/t/a.jsonl', sessionId: 's1' },
+      { agent: 'codex', filePath: '/t/b.jsonl', sessionId: 's2' }
+    ])
+    expect(normalized.truncated).toBe(false)
+  })
+
+  it('rejects queries shorter than the minimum length', () => {
+    const normalized = normalizeAiVaultTranscriptSearchArgs({
+      query: ' a ',
+      requests: [{ agent: 'claude', filePath: '/t/a.jsonl' }]
+    })
+    expect(normalized.query).toBe('')
+    expect(normalized.requests).toEqual([])
+  })
+
+  it('drops requests with missing or oversized paths but keeps valid ones', () => {
+    const normalized = normalizeAiVaultTranscriptSearchArgs({
+      query: 'flash attention',
+      requests: [
+        { agent: 'claude', filePath: '   ' },
+        { agent: 'claude', filePath: `/t/${'x'.repeat(33_000)}.jsonl` },
+        { agent: 'codex', filePath: '/t/b.jsonl' }
+      ]
+    })
+    expect(normalized.requests).toEqual([{ agent: 'codex', filePath: '/t/b.jsonl' }])
+    expect(normalized.truncated).toBe(false)
+  })
+
+  it('flags truncation when the request count exceeds the bound', () => {
+    const requests = Array.from(
+      { length: AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS + 5 },
+      (_, i) => ({
+        agent: 'claude' as const,
+        filePath: `/t/${i}.jsonl`
+      })
+    )
+    const normalized = normalizeAiVaultTranscriptSearchArgs({ query: 'flash attention', requests })
+    expect(normalized.requests).toHaveLength(AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS)
+    expect(normalized.truncated).toBe(true)
+  })
+})
+
+describe('isAiVaultTranscriptSearchQueryTooLarge', () => {
+  it('accepts a normal query and rejects an oversized one', () => {
+    expect(isAiVaultTranscriptSearchQueryTooLarge('flash attention')).toBe(false)
+    expect(isAiVaultTranscriptSearchQueryTooLarge('x'.repeat(3 * 1024))).toBe(true)
+  })
+})
+
+describe('extractTranscriptSearchSnippet', () => {
+  it('strips control bytes and collapses escaped newlines', () => {
+    const line = `{"role":"user","text":"please fix${CONTROL_BYTE}the bug\\nwhere it crashes on start"}`
+    const snippet = extractTranscriptSearchSnippet(line, 'crashes')
+    expect(snippet).not.toContain(CONTROL_BYTE)
+    expect(snippet).toContain('crashes on start')
+    expect(snippet).toContain('please fix the bug')
+  })
+
+  it('returns a short line untouched', () => {
+    expect(extractTranscriptSearchSnippet('fix the flash attention kernel', 'flash')).toBe(
+      'fix the flash attention kernel'
+    )
+  })
+
+  it('windows long lines around the first hit', () => {
+    const filler = 'lorem ipsum '.repeat(200)
+    const line = `${filler}the needle is here and the tail continues ${filler}`
+    const snippet = extractTranscriptSearchSnippet(line, 'needle', 60)
+    expect(snippet.length).toBeLessThanOrEqual(62)
+    expect(snippet).toContain('needle')
+    expect(snippet.startsWith('…')).toBe(true)
+    expect(snippet.endsWith('…')).toBe(true)
+  })
+
+  it('prefix-truncates when the hit is beyond the first window', () => {
+    const filler = 'a'.repeat(500)
+    const snippet = extractTranscriptSearchSnippet(`${filler} needle tail`, 'needle', 40)
+    expect(snippet).toContain('needle')
+    expect(snippet.startsWith('…')).toBe(true)
+  })
+
+  it('matches the query case-insensitively when centering the window', () => {
+    const snippet = extractTranscriptSearchSnippet(
+      `${'x'.repeat(300)} Flash Attention tail`,
+      'flash attention',
+      30
+    )
+    expect(snippet.toLowerCase()).toContain('flash attention')
+  })
+
+  it('keeps the hit near the front so a narrow row never truncates it away', () => {
+    const line = `${'long filler '.repeat(200)}the needle is buried deep in the message`
+    const snippet = extractTranscriptSearchSnippet(line, 'needle')
+    const hit = snippet.toLowerCase().indexOf('needle')
+    expect(hit).toBeGreaterThanOrEqual(0)
+    expect(hit).toBeLessThan(
+      AI_VAULT_TRANSCRIPT_SEARCH_SNIPPET_LEAD_CHARS + AI_VAULT_TRANSCRIPT_SEARCH_MAX_SNIPPET_LENGTH
+    )
+    // The match sits just past the short lead, well inside the visible window.
+    expect(hit).toBeLessThanOrEqual(AI_VAULT_TRANSCRIPT_SEARCH_SNIPPET_LEAD_CHARS + 8)
+    expect(snippet.slice(0, hit)).toContain('…')
+  })
+})
+
+describe('aiVaultTranscriptSearchRequestKey', () => {
+  it('separates agents and shares one key for equal requests', () => {
+    expect(aiVaultTranscriptSearchRequestKey({ agent: 'claude', filePath: '/a.jsonl' })).not.toBe(
+      aiVaultTranscriptSearchRequestKey({ agent: 'codex', filePath: '/a.jsonl' })
+    )
+    expect(aiVaultTranscriptSearchRequestKey({ agent: 'claude', filePath: '/a.jsonl' })).toBe(
+      aiVaultTranscriptSearchRequestKey({ agent: 'claude', filePath: '/a.jsonl' })
+    )
+  })
+})

--- a/src/shared/ai-vault-transcript-search.ts
+++ b/src/shared/ai-vault-transcript-search.ts
@@ -1,0 +1,149 @@
+import type { AiVaultAgent } from './ai-vault-types'
+import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
+
+// Full-transcript content search for Agent Session History ("deep search").
+// The vault list filter only matches metadata (title, cwd, newest previews);
+// this searches the conversation body so a user can find "the session where
+// the agent fixed X" months later. v1 searches local-host transcripts only —
+// non-local hosts degrade to an issue row instead of pretending to search.
+
+export const AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS = 250
+export const AI_VAULT_TRANSCRIPT_SEARCH_QUERY_MAX_BYTES = 2 * 1024
+export const AI_VAULT_TRANSCRIPT_SEARCH_PATH_MAX_LENGTH = 32_768
+// Transcripts can be hundreds of MB; a bounded window keeps one search call
+// from streaming the whole vault through the main process. Head covers the
+// opening ask, tail covers the latest work.
+export const AI_VAULT_TRANSCRIPT_SEARCH_HEAD_BUDGET_BYTES = 2 * 1024 * 1024
+export const AI_VAULT_TRANSCRIPT_SEARCH_TAIL_BUDGET_BYTES = 1 * 1024 * 1024
+export const AI_VAULT_TRANSCRIPT_SEARCH_MIN_QUERY_LENGTH = 2
+export const AI_VAULT_TRANSCRIPT_SEARCH_MAX_SNIPPET_LENGTH = 280
+export const AI_VAULT_TRANSCRIPT_SEARCH_MATCH_COUNT_CAP = 9999
+// Rows are narrow (<60 chars with truncation) and a line can be megabytes long.
+// The hit must sit near the FRONT of the snippet window, with only a short lead
+// of context, or the truncated tail hides the keyword (and its highlight).
+export const AI_VAULT_TRANSCRIPT_SEARCH_SNIPPET_LEAD_CHARS = 32
+
+export type AiVaultTranscriptSearchRequest = {
+  agent: AiVaultAgent
+  filePath: string
+  sessionId?: string
+}
+
+export type AiVaultTranscriptSearchArgs = {
+  query: string
+  requests: readonly AiVaultTranscriptSearchRequest[]
+}
+
+export type AiVaultTranscriptSearchMatch = {
+  agent: AiVaultAgent
+  filePath: string
+  sessionId?: string
+  matchCount: number
+  /** First matched line, control-stripped and windowed around the hit. */
+  snippet: string
+}
+
+export type AiVaultTranscriptSearchIssue = {
+  agent: AiVaultAgent
+  path: string
+  message: string
+}
+
+export type AiVaultTranscriptSearchResult = {
+  matches: AiVaultTranscriptSearchMatch[]
+  issues: AiVaultTranscriptSearchIssue[]
+  /** True when at least one request was dropped by a bound (never searched). */
+  truncated: boolean
+}
+
+export function isAiVaultTranscriptSearchQueryTooLarge(
+  query: string,
+  maxBytes = AI_VAULT_TRANSCRIPT_SEARCH_QUERY_MAX_BYTES
+): boolean {
+  return isClipboardTextByteLengthOverLimit(query, maxBytes)
+}
+
+/** Clamps + dedupes a raw search request into exactly what the searcher reads.
+ *  Invalid entries are dropped, never rejected: the caller already holds these
+ *  paths from a successful vault scan, so one bad row must not kill the rest. */
+export function normalizeAiVaultTranscriptSearchArgs(args: AiVaultTranscriptSearchArgs): {
+  query: string
+  requests: AiVaultTranscriptSearchRequest[]
+  truncated: boolean
+} {
+  const query = args.query.trim()
+  const usable =
+    query.length >= AI_VAULT_TRANSCRIPT_SEARCH_MIN_QUERY_LENGTH &&
+    !isAiVaultTranscriptSearchQueryTooLarge(query)
+  if (!usable) {
+    return { query: '', requests: [], truncated: false }
+  }
+  const seen = new Set<string>()
+  const requests: AiVaultTranscriptSearchRequest[] = []
+  let truncated = false
+  for (const raw of args.requests) {
+    if (requests.length >= AI_VAULT_TRANSCRIPT_SEARCH_MAX_REQUESTS) {
+      truncated = true
+      break
+    }
+    if (!raw || typeof raw !== 'object') {
+      continue
+    }
+    const filePath = typeof raw.filePath === 'string' ? raw.filePath.trim() : ''
+    if (!filePath || filePath.length > AI_VAULT_TRANSCRIPT_SEARCH_PATH_MAX_LENGTH) {
+      continue
+    }
+    const key = `${raw.agent}\n${filePath}`
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    const sessionId = typeof raw.sessionId === 'string' && raw.sessionId ? raw.sessionId : undefined
+    requests.push({ agent: raw.agent, filePath, ...(sessionId ? { sessionId } : {}) })
+  }
+  return { query, requests, truncated }
+}
+
+// eslint-disable-next-line no-control-regex -- intentional: strip JSONL control bytes before display.
+const CONTROL_CHARS_PATTERN = new RegExp('[\\u0000-\\u0008\\u000B-\\u001F\\u007F]', 'g')
+
+/** Windowed snippet for one matched line: control bytes stripped, whitespace
+ *  collapsed, and the window centered on the first hit so the term stays
+ *  visible in narrow rows. */
+export function extractTranscriptSearchSnippet(
+  line: string,
+  query: string,
+  maxLength = AI_VAULT_TRANSCRIPT_SEARCH_MAX_SNIPPET_LENGTH
+): string {
+  // JSONL records carry control bytes and two-char escapes (\n, \t, \r);
+  // strip both before display so a snippet reads as prose, not a JSON dump.
+  const cleaned = line
+    .replace(CONTROL_CHARS_PATTERN, ' ')
+    .replace(/\\[nrt]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (cleaned.length <= maxLength) {
+    return cleaned
+  }
+  const hit = cleaned.toLowerCase().indexOf(query.toLowerCase())
+  if (hit === -1) {
+    return `${cleaned.slice(0, maxLength)}…`
+  }
+  // Lead the window with a short context instead of centering the match: a
+  // centered 280-char window puts the hit ~char 130, which `truncate` hides.
+  const lead = Math.min(
+    AI_VAULT_TRANSCRIPT_SEARCH_SNIPPET_LEAD_CHARS,
+    Math.max(0, maxLength - query.length - 8)
+  )
+  const windowStart = Math.max(0, hit - lead)
+  const windowed = cleaned.slice(windowStart, windowStart + maxLength)
+  const prefix = windowStart > 0 ? '…' : ''
+  const suffix = windowStart + maxLength < cleaned.length ? '…' : ''
+  return `${prefix}${windowed}${suffix}`
+}
+
+/** Composite key so a renderer can join matches back to vault rows without
+ *  trusting session ids to be unique across agents/hosts. */
+export function aiVaultTranscriptSearchRequestKey(request: AiVaultTranscriptSearchRequest): string {
+  return `${request.agent}\n${request.filePath}`
+}


### PR DESCRIPTION
## ELI5

Agent Session History only lets you filter sessions by metadata (title, cwd,
newest preview). If you remember *what the agent did* but not the session's
title, you were out of luck. This adds a **deep search**: type a word, search
inside the actual conversation transcripts, and see exactly which sessions
contain it — with the match highlighted in yellow right in the list.

## What Changed

- New shared contract (`src/shared/ai-vault-transcript-search.ts`): clamps /
  dedupes requests, and extracts a windowed snippet with the hit kept near the
  front so narrow rows never truncate the keyword away.
- New bounded streaming searcher (`src/main/ai-vault/session-transcript-search.ts`):
  reads local transcripts in head/tail file windows with a 5s deadline and an
  `AbortSignal`; a missing file is skipped silently, never shown as an error.
- New additive IPC channel `aiVault:searchTranscripts`, wired end-to-end
  (main → preload → renderer) with a no-op web fallback; SSH/remote hosts
  degrade to empty results instead of pretending to work.
- Renderer: a results view shows *only* matched sessions while a search is
  active (no clutter), with per-row match count + yellow theme-aware keyword
  highlight (`--vault-search-match-*` CSS variables adapt to light/dark).
  The deep-search button reappears whenever the current keyword is not the one
  whose results are on screen, so re-searching after clearing works.
  Non-query view filters (disabled agents, scope, hide-empty, sort) also stay
  active in the results view, the request cap is spent on visible sessions,
  and the match count / truncation flag track the live view (a session that
  enters the results view unsearched is flagged, never passed off as covered).
- Review-fix hardening: partial head/tail coverage and the renderer's 250-request cap now surface as `truncated`; the stream enforces its byte budget with a hard `end` so a single record larger than the window cannot bypass it; a zero-hit transcript search stays in the results view; deep-search state resets when the input changes.
- 22 unit tests across the shared contract and the main-process searcher.

## Why

The vault list filter only matches metadata, so sessions can only be found if
you remember their title. Full-transcript search closes the gap for "find the
session where the agent fixed X". It reads local files only, bounds every
search call (byte windows + wall-clock deadline) so a vault with hundreds of MB
of transcripts never stalls the main process, and the additive IPC channel
keeps wire/remote compatibility.

## Linked Issue

Fixes #18397

Tracked via [feat(ai-vault): full-transcript content search for Agent Session History](https://github.com/stablyai/orca/issues/18397).

## Visual Proof

UI change (new search affordance + highlighted matches). BEFORE/AFTER screenshots
are being attached by the contributor — the PR is opened ahead of them so review
can start. The feature is exercised manually via `pnpm dev`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm vitest` (20 new tests, spanning the shared contract, the searcher's
window/deadline/missing-file behavior, and the request normalization),
`pnpm tc:node`, `pnpm tc:web`, `pnpm oxlint`, `pnpm oxfmt`, and
`pnpm check:code-quality:changed` all pass. Localization catalog/extraction/
coverage remain verified. Platform coverage: changes are local-FS-only with
deliberate no-op degradation for SSH/remote/mobile/web; the bigger desktop
suite's residual failures are pre-existing flakes unrelated to this change.

## AI Disclosure

This change was written with assistance from Claude (Anthropic, via Claude Code).

## Review

Focus areas: snippet windowing (hit-at-front), the main-process searcher's
bounded I/O size and deadline, and the results-view interaction (button /
count / clear states across light+dark).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: reads transcript files only for paths the renderer already holds from
a successful vault scan. Like the other read-only vault handlers, the main
process trusts the renderer's paths — normalization bounds the payload size and
request count, it does not enforce path containment. Cross-platform: no platform-specific
code — the searcher uses `node:fs` anchors (start offsets, byte budgets) valid
on Windows, WSL and Linux. Remote SSH: non-local sessions are excluded from
requests, so nothing is attempted against remote hosts. Performance: bounded
per-file byte windows cap main-process I/O per call. Backwards compatibility:
the IPC channel is additive and isolated in its own handler module.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


