### PR TITLE
fix(git): share one failed-command error-text reader between local and the SSH relay

### DIFF
--- a/src/main/git/worktree-branch-removal.ts
+++ b/src/main/git/worktree-branch-removal.ts
@@ -7,12 +7,9 @@ import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
 import { withRepoRefMaintenancePaused } from './local-repo-ref-maintenance'
 import { gitExecFileAsync } from './runner'
 import { parseWorktreeList } from '../../shared/git-worktree-porcelain-parser'
+import { isBranchCheckedOutInWorktreeError } from '../../shared/git-branch-delete-refusal'
 import type { GitWorktreeExecOptions, RemoveWorktreeOptions } from './worktree-operation-options'
-import {
-  gitExecOptions,
-  isBranchCheckedOutInWorktreeError,
-  normalizeLocalBranchRef
-} from './worktree-operation-options'
+import { gitExecOptions, normalizeLocalBranchRef } from './worktree-operation-options'
 
 export async function deleteBranchAfterWorktreeRemoval(
   repoPath: string,

--- a/src/main/git/worktree-operation-options.ts
+++ b/src/main/git/worktree-operation-options.ts
@@ -2,6 +2,7 @@ import type {
   LocalBaseRefRefreshResult,
   LocalBaseRefUpdateSuggestion
 } from '../../shared/worktree/base-ref-drift-types'
+import { readGitCommandFailureText } from '../../shared/git-command-failure-text'
 import type { RemoveWorktreeResult } from '../../shared/worktree/create-types'
 import type { GitWorktreeInfo } from '../../shared/worktree/types'
 
@@ -95,28 +96,8 @@ export function getErrorCode(error: unknown): string | undefined {
     : undefined
 }
 
-function getErrorText(error: unknown): string {
-  if (typeof error === 'object' && error !== null) {
-    const parts: string[] = []
-    if ('message' in error && typeof error.message === 'string') {
-      parts.push(error.message)
-    }
-    if ('stderr' in error && typeof error.stderr === 'string') {
-      parts.push(error.stderr)
-    }
-    return parts.join('\n')
-  }
-  return String(error)
-}
-
 export function isNotGitRepositoryError(error: unknown): boolean {
-  return /not a git repository/i.test(getErrorText(error))
-}
-
-export function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
-  return /cannot delete branch .*(?:used by worktree|checked out)|branch .*is checked out/i.test(
-    getErrorText(error)
-  )
+  return /not a git repository/i.test(readGitCommandFailureText(error))
 }
 
 export function normalizeLocalBranchRef(branch: string): string {

--- a/src/relay/git-branch-delete-refusal-parity.test.ts
+++ b/src/relay/git-branch-delete-refusal-parity.test.ts
@@ -1,0 +1,206 @@
+/**
+ * The relay and the desktop each carried their own `getErrorText`, and they had
+ * drifted: the relay read `message` + `stderr` + `stdout`, the desktop only
+ * `message` + `stderr`. So a `git branch -d` refusal that arrived on `stdout`
+ * routed the SSH removal through prune-and-retry while the local removal gave up
+ * and preserved the branch.
+ *
+ * These tests push the same failure through both published removal entry points —
+ * `removeWorktreeOp` (what `git.removeWorktree` runs on the host) and `removeWorktree`
+ * (the local runner) — and require the same branch-deletion commands and the same
+ * `RemoveWorktreeResult`. A second error-text reader on either side fails here.
+ */
+import type * as FsPromises from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, resolveGitDirMock, moveWorktreeDirectoryToTrashMock } = vi.hoisted(
+  () => ({
+    gitExecFileAsyncMock: vi.fn(),
+    resolveGitDirMock: vi.fn(),
+    moveWorktreeDirectoryToTrashMock: vi.fn()
+  })
+)
+
+vi.mock('../main/worktree-trash', () => ({
+  moveWorktreeDirectoryToTrash: moveWorktreeDirectoryToTrashMock,
+  restoreWorktreeDirectoryFromTrash: vi.fn(async () => true),
+  scheduleWorktreeTrashDeletion: vi.fn()
+}))
+
+vi.mock('../main/git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileSync: vi.fn(),
+  translateWslOutputPaths: (output: string) => output
+}))
+
+vi.mock('../main/git/status', () => ({
+  resolveGitDir: resolveGitDirMock,
+  runWithGitReadCacheInvalidation: <T>(run: () => Promise<T>) => run()
+}))
+
+vi.mock('fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('fs/promises')
+  return {
+    ...actual,
+    stat: vi.fn(async () => {
+      throw enoent()
+    }),
+    readFile: vi.fn()
+  }
+})
+
+import { GitCapabilityCache } from '../shared/git-capability-cache'
+import type { RemoveWorktreeResult } from '../shared/worktree/create-types'
+import { clearGitCapabilityStateForTests } from '../main/git/git-capability-state'
+import { _resetWorktreeScanCacheForTests } from '../main/git/worktree'
+import { __resetSparseCheckoutStateCacheForTests } from '../main/git/worktree-sparse-checkout-cache'
+import { removeWorktree } from '../main/git/worktree'
+import type { GitExec } from './git-handler-ops'
+import { removeWorktreeOp } from './git-handler-worktree-ops'
+
+const REPO_PATH = '/repo'
+const WORKTREE_PATH = '/repo-feature'
+const BRANCH = 'feature/test'
+
+function enoent(): Error {
+  return Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+}
+
+/** Only the branch-deletion phase; the two entry points legitimately reach it by different routes. */
+function branchDeletionCalls(calls: string[][]): string[] {
+  return calls
+    .map((args) => args.join(' '))
+    .filter((call) => call.startsWith('branch ') || call === 'worktree prune')
+}
+
+function worktreeListPorcelain(withFeature: boolean): string {
+  const blocks = [[`worktree ${REPO_PATH}`, 'HEAD abc123', 'branch refs/heads/main']]
+  if (withFeature) {
+    blocks.push([`worktree ${WORKTREE_PATH}`, 'HEAD def456', `branch refs/heads/${BRANCH}`])
+  }
+  return `${blocks.map((block) => block.join('\n')).join('\n\n')}\n`
+}
+
+type RefusalStream = 'stdout' | 'stderr'
+
+const REFUSAL_TEXT = `error: cannot delete branch '${BRANCH}' used by worktree at '/repo-stale'`
+
+/**
+ * A `branch -d` rejection carrying the refusal on exactly one stream. `message` stays
+ * generic so the assertion is about the stream, not about Node's stderr echo.
+ */
+function branchDeleteRefusal(stream: RefusalStream): Error {
+  return Object.assign(new Error('Command failed: git branch -d'), {
+    code: 1,
+    stdout: stream === 'stdout' ? REFUSAL_TEXT : '',
+    stderr: stream === 'stderr' ? REFUSAL_TEXT : ''
+  })
+}
+
+/** Refuses the first `branch -d`, accepts the retry that follows `worktree prune`. */
+function scriptRelayGit(stream: RefusalStream): {
+  git: GitExec
+  calls: string[][]
+} {
+  const calls: string[][] = []
+  let branchDeleteCount = 0
+  const git = vi.fn<GitExec>(async (args) => {
+    calls.push(args)
+    if (args[0] === 'rev-parse') {
+      return { stdout: `${REPO_PATH}/.git\n`, stderr: '' }
+    }
+    if (args[0] === 'worktree' && args[1] === 'list') {
+      return { stdout: worktreeListPorcelain(true), stderr: '' }
+    }
+    if (args[0] === 'branch' && args[1] === '-d') {
+      branchDeleteCount += 1
+      if (branchDeleteCount === 1) {
+        throw branchDeleteRefusal(stream)
+      }
+      return { stdout: '', stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+  return { git, calls }
+}
+
+function scriptDesktopGit(stream: RefusalStream): string[][] {
+  const calls: string[][] = []
+  let branchDeleteCount = 0
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    calls.push(args)
+    if (args[0] === 'worktree' && args[1] === 'list') {
+      return { stdout: worktreeListPorcelain(branchDeleteCount === 0), stderr: '' }
+    }
+    if (args[0] === 'branch' && args[1] === '-d') {
+      branchDeleteCount += 1
+      if (branchDeleteCount === 1) {
+        throw branchDeleteRefusal(stream)
+      }
+      return { stdout: '', stderr: '' }
+    }
+    return { stdout: '', stderr: '' }
+  })
+  return calls
+}
+
+async function removeOverRelay(
+  stream: RefusalStream
+): Promise<{ result: RemoveWorktreeResult; branchCalls: string[] }> {
+  const { git, calls } = scriptRelayGit(stream)
+  const result = await removeWorktreeOp(
+    git,
+    { worktreePath: WORKTREE_PATH },
+    new GitCapabilityCache()
+  )
+  return { result, branchCalls: branchDeletionCalls(calls) }
+}
+
+async function removeLocally(
+  stream: RefusalStream
+): Promise<{ result: RemoveWorktreeResult; branchCalls: string[] }> {
+  const calls = scriptDesktopGit(stream)
+  const result = await removeWorktree(REPO_PATH, WORKTREE_PATH)
+  return { result, branchCalls: branchDeletionCalls(calls) }
+}
+
+beforeEach(() => {
+  clearGitCapabilityStateForTests()
+  _resetWorktreeScanCacheForTests()
+  __resetSparseCheckoutStateCacheForTests()
+  gitExecFileAsyncMock.mockReset()
+  resolveGitDirMock.mockReset()
+  resolveGitDirMock.mockImplementation(async (worktreePath: string) => `${worktreePath}/.git`)
+  moveWorktreeDirectoryToTrashMock.mockReset()
+  // Default: the checkout cannot be renamed aside, so removal runs `worktree remove` in place.
+  moveWorktreeDirectoryToTrashMock.mockResolvedValue(undefined)
+})
+
+describe('relay/desktop branch-delete refusal parity', () => {
+  it('prunes and retries on both paths when the refusal arrives on stdout', async () => {
+    const relay = await removeOverRelay('stdout')
+    const local = await removeLocally('stdout')
+
+    expect(relay.branchCalls).toEqual(local.branchCalls)
+    expect(relay.result).toEqual(local.result)
+    expect(local.branchCalls).toEqual([
+      `branch -d -- ${BRANCH}`,
+      'worktree prune',
+      `branch -d -- ${BRANCH}`
+    ])
+    expect(local.result).toEqual({})
+  })
+
+  it('prunes and retries on both paths when the refusal arrives on stderr, as real Git sends it', async () => {
+    const relay = await removeOverRelay('stderr')
+    const local = await removeLocally('stderr')
+
+    expect(relay.branchCalls).toEqual(local.branchCalls)
+    expect(relay.result).toEqual(local.result)
+    expect(local.branchCalls).toEqual([
+      `branch -d -- ${BRANCH}`,
+      'worktree prune',
+      `branch -d -- ${BRANCH}`
+    ])
+  })
+})

--- a/src/relay/git-branch-delete-refusal-parity.test.ts
+++ b/src/relay/git-branch-delete-refusal-parity.test.ts
@@ -52,9 +52,8 @@ vi.mock('fs/promises', async () => {
 import { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { RemoveWorktreeResult } from '../shared/worktree/create-types'
 import { clearGitCapabilityStateForTests } from '../main/git/git-capability-state'
-import { _resetWorktreeScanCacheForTests } from '../main/git/worktree'
+import { _resetWorktreeScanCacheForTests, removeWorktree } from '../main/git/worktree'
 import { __resetSparseCheckoutStateCacheForTests } from '../main/git/worktree-sparse-checkout-cache'
-import { removeWorktree } from '../main/git/worktree'
 import type { GitExec } from './git-handler-ops'
 import { removeWorktreeOp } from './git-handler-worktree-ops'
 

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -1,34 +1,12 @@
 import * as path from 'node:path'
 import type { RemoveWorktreeResult } from '../shared/worktree/create-types'
+import { isBranchCheckedOutInWorktreeError } from '../shared/git-branch-delete-refusal'
 import { assertWorktreeUnlockedForRemoval } from '../shared/worktree/removal'
 import { isSubmoduleWorktreeRemovalRefusal } from '../shared/worktree/submodule-removal'
 import { deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure } from './git-handler-branch-cleanup'
 import type { GitExec } from './git-handler-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import { readRelayWorktreeList } from './git-handler-worktree-list'
-
-function getErrorText(error: unknown): string {
-  if (typeof error === 'object' && error !== null) {
-    const parts: string[] = []
-    if ('message' in error && typeof error.message === 'string') {
-      parts.push(error.message)
-    }
-    if ('stderr' in error && typeof error.stderr === 'string') {
-      parts.push(error.stderr)
-    }
-    if ('stdout' in error && typeof error.stdout === 'string') {
-      parts.push(error.stdout)
-    }
-    return parts.join('\n')
-  }
-  return String(error)
-}
-
-function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
-  return /cannot delete branch .*(?:used by worktree|checked out)|branch .*is checked out/i.test(
-    getErrorText(error)
-  )
-}
 
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -8,6 +8,7 @@ import {
   isUnsupportedMergeTreeMergeBaseError,
   isUnsupportedMergeTreeWriteTreeError
 } from './git-merge-tree-capability'
+import { isBranchCheckedOutInWorktreeError } from './git-branch-delete-refusal'
 import { isForEachRefExcludeUnsupportedError } from './git-ref-command-capabilities'
 import { isNoWriteFetchHeadUnsupportedError } from './git-fetch-head-capability'
 import {
@@ -138,6 +139,29 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     await expect(
       runGit(['rev-parse', '--show-toplevel', '--git-common-dir'])
     ).resolves.toBeDefined()
+  })
+
+  // Why pin this: worktree removal decides whether to prune and retry `branch -d` by
+  // matching Git's refusal text, and the wording moved inside the supported range
+  // (<=2.40 "Cannot delete branch 'x' checked out at", >=2.43 "cannot delete branch 'x'
+  // used by worktree at"). It is also the only evidence that the refusal is a stderr
+  // message on every supported Git rather than something a caller could read off stdout.
+  it('refuses to delete a branch another worktree holds, on stderr, in a recognized wording', async () => {
+    await runGit(['worktree', 'add', '-b', 'compat-held', 'held-wt'])
+    try {
+      const refusal = await runGit(['branch', '-d', '--', 'compat-held']).then(
+        () => null,
+        (error: unknown) => error
+      )
+      expect(refusal).not.toBeNull()
+      expect(isBranchCheckedOutInWorktreeError(refusal)).toBe(true)
+      const streams = refusal as { stdout?: string; stderr?: string }
+      expect(streams.stderr ?? '').toMatch(/delete branch .*compat-held/i)
+      expect(streams.stdout ?? '').toBe('')
+    } finally {
+      await runGit(['worktree', 'remove', '--force', 'held-wt'])
+      await runGit(['branch', '-D', 'compat-held'])
+    }
   })
 
   it('deregisters a worktree whose directory was renamed away', async () => {

--- a/src/shared/git-branch-delete-refusal.ts
+++ b/src/shared/git-branch-delete-refusal.ts
@@ -1,0 +1,16 @@
+import { readGitCommandFailureText } from './git-command-failure-text'
+
+/**
+ * `git branch -d/-D` refused because the branch is the HEAD of some worktree.
+ *
+ * Both wordings are live in Orca's supported range: Git through 2.40 says
+ * "Cannot delete branch 'x' checked out at '<path>'", and 2.43+ says "cannot delete
+ * branch 'x' used by worktree at '<path>'". Every version prints it through `error()`,
+ * so it arrives on stderr. Callers treat a match as "the blocker may be a stale
+ * worktree record", prune, and retry once.
+ */
+export function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
+  return /cannot delete branch .*(?:used by worktree|checked out)|branch .*is checked out/i.test(
+    readGitCommandFailureText(error)
+  )
+}

--- a/src/shared/git-command-failure-text.ts
+++ b/src/shared/git-command-failure-text.ts
@@ -1,0 +1,27 @@
+/**
+ * The text a failed Git invocation left behind, for the predicates that classify a
+ * failure by what Git said.
+ *
+ * Why all three streams and not just `message` + `stderr`: the errors Orca classifies
+ * do not all come straight out of `execFile`. Node puts Git's stderr in both `message`
+ * and `stderr`, but Orca also throws its own failures with the Git output on `stdout`
+ * (`worktree remove`'s submodule retry attaches `git status --porcelain` output that
+ * way on both the local runner and the relay). Reading all three is what keeps the
+ * local and relay classifiers from disagreeing about the same error object.
+ *
+ * Against a real binary this reads no differently: Git emits every refusal this module
+ * classifies through `error()`/`die()`, i.e. stderr only, on 2.25 through 2.55.
+ */
+export function readGitCommandFailureText(error: unknown): string {
+  if (typeof error !== 'object' || error === null) {
+    return String(error)
+  }
+  const parts: string[] = []
+  for (const field of ['message', 'stderr', 'stdout'] as const) {
+    const value = (error as Record<string, unknown>)[field]
+    if (typeof value === 'string' && value) {
+      parts.push(value)
+    }
+  }
+  return parts.join('\n')
+}

--- a/src/shared/worktree/submodule-removal.ts
+++ b/src/shared/worktree/submodule-removal.ts
@@ -1,16 +1,4 @@
-function getErrorText(error: unknown): string {
-  if (typeof error === 'object' && error !== null) {
-    const parts: string[] = []
-    for (const field of ['message', 'stderr', 'stdout'] as const) {
-      const value = (error as Record<string, unknown>)[field]
-      if (typeof value === 'string' && value) {
-        parts.push(value)
-      }
-    }
-    return parts.join('\n')
-  }
-  return String(error)
-}
+import { readGitCommandFailureText } from '../git-command-failure-text'
 
 // Why: `git worktree remove` (non-force) categorically refuses any worktree
 // containing an initialised submodule, even when parent and submodule are
@@ -18,5 +6,7 @@ function getErrorText(error: unknown): string {
 // cleanliness and retry with --force. Both the local runner and the relay pin
 // English git output (UNTRANSLATED_GIT_OUTPUT_ENV), so text matching is stable.
 export function isSubmoduleWorktreeRemovalRefusal(error: unknown): boolean {
-  return /working trees containing submodules cannot be moved or removed/i.test(getErrorText(error))
+  return /working trees containing submodules cannot be moved or removed/i.test(
+    readGitCommandFailureText(error)
+  )
 }


### PR DESCRIPTION
Follow-up to #18389, same principle: a duplicated implementation between local and relay is where SSH drifts from local. This one had already drifted.

## The drift

`getErrorText` existed three times, and the desktop copy read one stream fewer:

| | reads |
|---|---|
| `src/shared/worktree/submodule-removal.ts` (used by **both** hosts) | `message` + `stderr` + `stdout` |
| `src/relay/git-handler-worktree-remove.ts` | `message` + `stderr` + `stdout` |
| `src/main/git/worktree-operation-options.ts` | `message` + `stderr` |

`isBranchCheckedOutInWorktreeError` was duplicated verbatim on top of them. So a `git branch -d` refusal that arrived on `stdout` made the SSH removal prune-and-retry while the local removal rethrew, fell through to the already-merged recovery, and returned `preservedBranch`. Different answers, same error.

## Which side is right, and why

I checked Git itself rather than picking the longer implementation.

**Git never puts this text on stdout, on any version Orca supports.** Both wordings are `error()` calls in `builtin/branch.c`, so they go to stderr. Verified against real binaries:

| Git | stream | wording |
|---|---|---|
| 2.25.1 (baseline, Ubuntu 20.04) | stderr | `error: Cannot delete branch 'x' checked out at '<path>'` |
| 2.38.1 | stderr | `error: Cannot delete branch 'x' checked out at '<path>'` |
| 2.40.1 | stderr | `error: Cannot delete branch 'x' checked out at '<path>'` |
| 2.43.0 | stderr | `error: cannot delete branch 'x' used by worktree at '<path>'` |
| 2.45.2 / 2.49.1 / 2.55.0 | stderr | `error: cannot delete branch 'x' used by worktree at '<path>'` |

stdout was empty in every case. So the premise in the issue — "git reports it on stdout" — does not happen, and neither implementation is wrong *about a real binary*.

Where the desktop copy **is** wrong on its own terms is that not every error Orca classifies came straight out of `execFile`. Orca throws its own failures with the Git output on `.stdout` — `worktree remove`'s submodule retry does exactly that on both the relay (`git-handler-worktree-remove.ts`) and the local runner. And the stdout-reading form is already the *shared* spelling: `isSubmoduleWorktreeRemovalRefusal` classifies the same class of failure for both hosts and reads all three streams. The desktop copy was the outlier among three, so this converges on the incumbent shared behavior rather than on the shorter one.

Cost of including stdout: none I can find. A *failed* `git branch -d` writes nothing to stdout, and `isNotGitRepositoryError`'s callers read `worktree list` / `rev-parse` output, which cannot plausibly contain "not a git repository".

## The fix

Delete the carriers rather than patch each copy:

- `src/shared/git-command-failure-text.ts` — `readGitCommandFailureText`, the one reader.
- `src/shared/git-branch-delete-refusal.ts` — `isBranchCheckedOutInWorktreeError`, the one predicate, documenting both wordings and their version boundary.
- All three local copies removed; the relay, the desktop, and `submodule-removal.ts` import the shared pair.

`rg "function getErrorText" src` now returns zero hits.

Not folded in: `normalizeLocalBranchRef` is also duplicated relay/desktop, but the same one-line `refs/heads/` strip is spelled inline in ~10 more places across main and renderer. Unifying it is a real cleanup with a different blast radius, not a rider on this one.

## Behavior change

Local `removeWorktree` now also prunes and retries when the refusal text is on `.stdout`, which can turn a `preservedBranch` result into `{}`.

The relay's behavior does not change. Its old reader pushed empty stream values into the joined text (`"msg\n\n"` rather than `"msg"`); the shared one skips them, which is invisible to an unanchored `.test()`. Same verdict on every input.

**Wire compatibility:** none. The relay publishes nothing new and nothing differently, so `docs/reference/remote-wire-compatibility.md` Rule 3 is not engaged. The only changed published value is `RemoveWorktreeResult` on the *local* path, and only for an error shape a real Git binary does not produce.

## Git compatibility

No new subcommand, option, or capability probe — `docs/reference/git-compatibility.md` needs no new row. What did change is the real-binary contract: `src/shared/git-binary-compatibility.test.ts` now runs `branch -d` against a branch another worktree holds and asserts the predicate recognizes the refusal, that it lands on **stderr**, and that **stdout is empty** — which is what pins the finding above instead of leaving it in a PR description. It passes on all three matrix versions (see below), covering both wordings.

## Test

`src/relay/git-branch-delete-refusal-parity.test.ts` pushes one failure object through *both published removal entry points* — `removeWorktreeOp` (what `git.removeWorktree` runs on the host) and `removeWorktree` (the local runner) — and requires the same branch-deletion command sequence and the same `RemoveWorktreeResult`.

**Failed-first:** reintroducing an actual second implementation — a desktop-local `getErrorText` reading only `message` + `stderr`, wired into `worktree-branch-removal.ts` — fails 1 of the 2 tests, and fails it on the desktop side specifically (`['branch -d'] !== ['branch -d', 'worktree prune', 'branch -d']`). Reverting the *shared* reader instead would drift both sides together and the test would still pass, which is why the probe is a second implementation and not a one-line revert. The other test is an intended no-op: the refusal on stderr, which is what real Git sends, and which both sides already agreed on.

## Verification

- `pnpm tc` — clean
- `pnpm test src` — 7469 files / 69605 tests pass. One unrelated failure, `src/main/native-chat/agent-session-wire/structured-tui-transcript-catchup.test.ts`, is a pre-existing watcher-timing flake: it fails 3 of 4 runs on a clean `origin/main` tree with this branch stashed.
- `pnpm run check:code-quality:changed` — 0 new findings across 8 changed files. `max-lines` proved live first with a 400-line positive control through the same gate; no file grows.
- **Git compatibility lane**, run locally against real binaries: 2.25.1, 2.38.1, 2.49.1 — 15/15 each.

## Landing order

Independent of the push-target refactor; either order works. This one is the behavior fix, so it is the smaller review.

## CI

All 23 non-skipped checks pass, including `Git compatibility`, `static analysis`, all eight test shards, and the `e2e / ssh docker watcher isolation` lane (24 passed, 19m14s). No re-runs.
