### PR TITLE
fix(relay): stop self-closing the control socket on unknown messages

### DIFF
--- a/src/main/runtime/relay/relay-control-client.test.ts
+++ b/src/main/runtime/relay/relay-control-client.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
 import { WebSocketServer, type WebSocket } from 'ws'
 import type { E2EEKeypair } from '../e2ee-keypair'
+import { MOBILE_RELAY_CLOSE_CODE } from '../../../shared/mobile-relay-close-codes'
 import { RelayControlClient } from './relay-control-client'
 
 const encoder = new TextEncoder()
@@ -549,5 +550,49 @@ describe('RelayControlClient scripted-socket lifecycle', () => {
 
     vi.advanceTimersByTime(91_000)
     expect(client.isLive()).toBe(false)
+  })
+
+  it('ignores an unrecognized control message without closing the active control', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { client, socket, onClose } = scriptedControl()
+    await client.connect()
+    expect(client.isLive()).toBe(true)
+
+    // A newer relay opcode the desktop schema does not know. Rule 2 of
+    // remote-wire-compatibility: an unknown-but-well-formed frame is dropped,
+    // never fatal to a live control.
+    socket.deliver({ type: 'relay-hint', v: 2, hint: 'future-feature' })
+
+    expect(client.isLive()).toBe(true)
+    expect(socket.readyState).toBe(1)
+    expect(onClose).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('ignores a reply whose request already timed out instead of self-closing', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const { client, socket, onClose } = scriptedControl()
+    await client.connect()
+
+    // A relay control-error carrying a reqId with no live waiter — e.g. a late
+    // reply that arrived after the desktop's request deadline deleted it, or the
+    // relay's no-op error for a command it could not route. Must not be fatal.
+    socket.deliver({ type: 'control-error', reqId: 'expired-req', code: 'unknown_control_message' })
+
+    expect(client.isLive()).toBe(true)
+    expect(socket.readyState).toBe(1)
+    expect(onClose).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('still tears down a malformed (non-JSON) control frame', async () => {
+    const { client, socket, onClose } = scriptedControl()
+    await client.connect()
+
+    socket.emit('message', 'not-json{', false)
+
+    expect(client.isLive()).toBe(false)
+    expect(socket.readyState).toBe(3)
+    expect(onClose).toHaveBeenCalledWith(MOBILE_RELAY_CLOSE_CODE.BAD_OUTER_CREDENTIAL)
   })
 })

--- a/src/main/runtime/relay/relay-control-client.ts
+++ b/src/main/runtime/relay/relay-control-client.ts
@@ -234,14 +234,16 @@ export class RelayControlClient {
     if (this.requests.resolveMessage(message)) {
       return
     }
-    // Wire-compat (docs/reference/remote-wire-compatibility.md, Rule 2): a
-    // well-formed control message we do not recognize must be dropped, never
-    // fatal. It is either a newer relay's opcode this build predates, or a reply
-    // whose request already timed out and has no waiter (relay control ops run DB
-    // transactions that can exceed the request deadline under load). Self-closing
-    // here forced an orphaned relay session that answered the phone with
-    // HOST_OFFLINE for the orphan-grace window plus the director's reconnect
-    // throttle — minutes of outage from a message that could simply be ignored.
+    // Drop a well-formed control message we do not recognize, matching how every
+    // other Orca decoder treats an unknown frame (see the silent-drop convention
+    // in docs/reference/remote-wire-compatibility.md). The control channel has no
+    // opcode negotiation step, so this reaches either a newer relay's message
+    // this build predates, or a reply whose request already timed out and has no
+    // waiter (relay control ops run DB transactions that can exceed the request
+    // deadline under load). Self-closing here was strictly worse than ignoring:
+    // it orphaned the relay session, which answered the phone with HOST_OFFLINE
+    // for the orphan-grace window plus the director's reconnect throttle — minutes
+    // of outage from a single stray frame.
     const messageType = typeof message.type === 'string' ? message.type : 'unknown'
     console.warn(`[relay] ignoring unrecognized control message type=${messageType}`)
   }

--- a/src/main/runtime/relay/relay-control-client.ts
+++ b/src/main/runtime/relay/relay-control-client.ts
@@ -234,7 +234,16 @@ export class RelayControlClient {
     if (this.requests.resolveMessage(message)) {
       return
     }
-    this.failProtocol('unknown control message')
+    // Wire-compat (docs/reference/remote-wire-compatibility.md, Rule 2): a
+    // well-formed control message we do not recognize must be dropped, never
+    // fatal. It is either a newer relay's opcode this build predates, or a reply
+    // whose request already timed out and has no waiter (relay control ops run DB
+    // transactions that can exceed the request deadline under load). Self-closing
+    // here forced an orphaned relay session that answered the phone with
+    // HOST_OFFLINE for the orphan-grace window plus the director's reconnect
+    // throttle — minutes of outage from a message that could simply be ignored.
+    const messageType = typeof message.type === 'string' ? message.type : 'unknown'
+    console.warn(`[relay] ignoring unrecognized control message type=${messageType}`)
   }
 
   private handleProofMessage(message: Record<string, unknown>): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## Problem

Observed 2026-09-03 on a Samsung phone + macOS desktop (v1.4.197-adhoc): the desktop closed its own relay **control** WebSocket with code `4401 "unknown control message"` after ~29 min active, then the phone could not reach the desktop for minutes — every dial ended in `replacement session authentication timed out` or `relay_outer_4404` (HOST_OFFLINE), even after the director re-assigned the host 5s later.

```
control closed host=666077865f2e gen=1 state=active ageMs=1756183 code=4401 reason="unknown control message"
```

This is **not branch-specific**: relay telemetry shows ~15 of these `4401 "unknown control message"` closes per day across app versions `1.4.175..1.4.197`.

## Root cause

`RelayControlClient.handleMessage()` (`src/main/runtime/relay/relay-control-client.ts`) routed every control frame that was not `ping` / `conn-open` / `drain` / a tracked request reply into `failProtocol('unknown control message')`, which **closes the socket (4401) and tears down the origin**.

Three well-formed frames reach that branch during a healthy `active` control:

1. **A reply that arrives after the desktop's 10s request deadline** already deleted the pending entry. Relay control ops (`confirmResume`, `installCredential`, …) run DB transactions that can exceed 10s under load, so `RelayControlRequests.resolveMessage()` finds no waiter and returns `false`.
2. **A `control-error` with no/unknown `reqId`** — including the relay's own `sendControlError(session, undefined, 'unknown_control_message')` reply to a host command it could not route (`orca-cloud` `host-session-registry.ts`).
3. **A newer relay opcode** this build predates (forward-compat).

### Why the phone stayed down for minutes

The 4401 self-close is far more costly than the frame that triggers it. On the relay the session drops to `orphaned` and, for the 30s orphan-grace window, `acceptClient` rejects the phone with `HOST_OFFLINE (4404)`. The desktop's recovery (`onClose → handleDrain(recovery: 'resolve-director')`) then has to re-register through the director's 503 reconnect throttle, so a single stray frame becomes minutes of mobile downtime. Not self-closing removes the orphan window and the re-registration entirely.

## Fix

A well-formed control frame the desktop does not recognize is now **dropped and logged**, not treated as fatal — matching how every other Orca decoder already handles an unknown frame. The relay control channel has no opcode-negotiation step, so the frame is either a newer relay message this build predates or a reply whose request already timed out. The justification is the cost asymmetry: self-closing orphaned the relay session and caused minutes of `HOST_OFFLINE`, whereas ignoring the frame costs nothing. Malformed JSON, binary frames, and messages before activation still close as genuine protocol violations.

_(Note: an earlier revision cited `remote-wire-compatibility.md` Rule 2 as the mandate here. Rule 2 actually governs the sender of a new terminal-stream opcode and frames the receiver-side silent drop as a hazard, so that citation was dropped — thanks @pullfrog.)_

## Tests

- `ignores an unrecognized control message without closing the active control`
- `ignores a reply whose request already timed out instead of self-closing`
- `still tears down a malformed (non-JSON) control frame` (guard preserved)

## Verification

- `pnpm test relay-control-client.test.ts` — 11/11
- `pnpm test relay-session-broker.test.ts` — 8/8 (recovery path)
- `pnpm tc:node` clean
- `pnpm run check:code-quality:changed` — 0 findings

## Compatibility

Desktop-only decoder change; nothing on the wire changes. Old relays (which already send these frames) and SSH/remote hosts are unaffected — the desktop simply stops overreacting to them.
