### PR TITLE
fix(dashboard): open remote sessions from every agent reveal path

### DIFF
--- a/src/renderer/src/components/activity/activity-thread-actions.test.ts
+++ b/src/renderer/src/components/activity/activity-thread-actions.test.ts
@@ -49,12 +49,23 @@ describe('activity thread host routing', () => {
   const setActiveWorktree = vi.fn()
   const acknowledgeAgents = vi.fn()
   const setSelectedPaneKey = vi.fn()
+  let state: Record<string, unknown>
+
+  function makeActions(): ReturnType<typeof createActivityThreadActions> {
+    return createActivityThreadActions({
+      getMarkAllReadThreads: () => [thread],
+      acknowledgeAgents,
+      unacknowledgeAgents: vi.fn(),
+      setSelectedPaneKey
+    })
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.activateStructuredAgentSessionTab.mockReturnValue(false)
+    mocks.activateAndRevealWorkspace.mockReturnValue({ primaryTabId: null })
     getKnownWorktreeById.mockReturnValue(thread.worktree)
-    mocks.getState.mockReturnValue({
+    state = {
       getKnownWorktreeById,
       worktreesByRepo: { [thread.worktree.repoId]: [thread.worktree] },
       detectedWorktreesByRepo: {},
@@ -77,21 +88,19 @@ describe('activity thread host routing', () => {
       setActiveRepo: vi.fn(),
       setActiveWorktree,
       setActiveTabType: vi.fn()
-    })
+    }
+    mocks.getState.mockImplementation(() => state)
   })
 
-  it('selects the matching host when the same workspace id is active elsewhere', () => {
-    const actions = createActivityThreadActions({
-      getMarkAllReadThreads: () => [thread],
-      acknowledgeAgents,
-      unacknowledgeAgents: vi.fn(),
-      setSelectedPaneKey
+  it('routes the row click through the full activation sequence for the matching host', () => {
+    makeActions().selectThread(thread)
+
+    // Bare setActiveWorktree skips setActiveView('terminal'), initial-terminal seeding and
+    // sleeping-session resume — the workspace dispatcher is the only path that runs them.
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith(thread.worktree.id, {
+      executionHostId: REMOTE_HOST
     })
-
-    actions.selectThread(thread)
-
-    expect(getKnownWorktreeById).toHaveBeenCalledWith(thread.worktree.id, REMOTE_HOST)
-    expect(setActiveWorktree).toHaveBeenCalledWith(thread.worktree.id, REMOTE_HOST)
+    expect(setActiveWorktree).not.toHaveBeenCalled()
     expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(
       thread.tab.id,
       '11111111-1111-4111-8111-111111111111',
@@ -99,23 +108,56 @@ describe('activity thread host routing', () => {
     )
   })
 
-  it('activates a structured agent session instead of looking for a terminal pane', () => {
-    mocks.activateStructuredAgentSessionTab.mockReturnValue(true)
-    mocks.getState.mockReturnValue({
-      ...mocks.getState(),
-      tabsByWorktree: { [thread.worktree.id]: [] },
-      unifiedTabsByWorktree: {
-        [thread.worktree.id]: [{ id: thread.tab.id, contentType: 'agent-session' }]
-      }
-    })
-    const actions = createActivityThreadActions({
-      getMarkAllReadThreads: () => [thread],
-      acknowledgeAgents,
-      unacknowledgeAgents: vi.fn(),
-      setSelectedPaneKey
+  it('opens a cold-parked remote thread whose tab activation revives', () => {
+    // The reported SSH symptom: the tab is not resident because the session was never
+    // revived, so a residency probe before activation made the click a silent no-op.
+    state.tabsByWorktree = {}
+    mocks.activateAndRevealWorkspace.mockImplementation(() => {
+      state.tabsByWorktree = { [thread.worktree.id]: [thread.tab] }
+      return { primaryTabId: thread.tab.id }
     })
 
-    actions.selectThread(thread)
+    makeActions().selectThread(thread)
+
+    expect(setSelectedPaneKey).toHaveBeenCalledWith(thread.paneKey)
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith(thread.worktree.id, {
+      executionHostId: REMOTE_HOST
+    })
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith(
+      thread.tab.id,
+      '11111111-1111-4111-8111-111111111111',
+      { flashFocusedPane: true, scrollToBottomIfOutputSinceLastView: true }
+    )
+  })
+
+  it('still activates the workspace when a retained thread has no tab to focus', () => {
+    state.tabsByWorktree = {}
+
+    makeActions().selectThread(thread)
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith(thread.worktree.id, {
+      executionHostId: REMOTE_HOST
+    })
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+  })
+
+  it('focuses nothing when the workspace itself is gone', () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue(false)
+
+    makeActions().selectThread(thread)
+
+    expect(mocks.activateStructuredAgentSessionTab).not.toHaveBeenCalled()
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+  })
+
+  it('activates a structured agent session instead of looking for a terminal pane', () => {
+    mocks.activateStructuredAgentSessionTab.mockReturnValue(true)
+    state.tabsByWorktree = { [thread.worktree.id]: [] }
+    state.unifiedTabsByWorktree = {
+      [thread.worktree.id]: [{ id: thread.tab.id, contentType: 'agent-session' }]
+    }
+
+    makeActions().selectThread(thread)
 
     expect(mocks.activateStructuredAgentSessionTab).toHaveBeenCalledWith({
       worktreeId: thread.worktree.id,
@@ -126,14 +168,8 @@ describe('activity thread host routing', () => {
 
   it('jumps to and probes the matching host-qualified workspace', () => {
     expect(hasActivityThreadWorkspace(thread)).toBe(true)
-    const actions = createActivityThreadActions({
-      getMarkAllReadThreads: () => [thread],
-      acknowledgeAgents,
-      unacknowledgeAgents: vi.fn(),
-      setSelectedPaneKey
-    })
 
-    actions.jumpToWorkspace(thread)
+    makeActions().jumpToWorkspace(thread)
 
     expect(acknowledgeAgents).toHaveBeenCalledWith([thread.paneKey])
     expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith(thread.worktree.id, {

--- a/src/renderer/src/components/activity/activity-thread-actions.ts
+++ b/src/renderer/src/components/activity/activity-thread-actions.ts
@@ -1,5 +1,6 @@
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import { activateStructuredAgentSessionTab } from '@/lib/structured-agent-session-tab-activation'
+import { activateAndRevealWorkspace } from '@/lib/worktree-activation'
 import { jumpToWorktreeFromSidebar } from '@/lib/worktree-jump-navigation'
 import { useAppStore } from '@/store'
 import {
@@ -74,38 +75,31 @@ export function createActivityThreadActions({
   }
 
   const activateThreadTarget = (thread: AgentPaneThread): void => {
-    const state = useAppStore.getState()
     const executionHostId = getActivityThreadExecutionHostId(
       thread,
-      getSettingsFocusedExecutionHostId(state.settings)
+      getSettingsFocusedExecutionHostId(useAppStore.getState().settings)
     )
-    const worktree = state.getKnownWorktreeById(thread.worktree.id, executionHostId)
-    if (!worktree) {
+    // Why the full sequence (not bare setActiveWorktree): a cold-parked thread — the normal
+    // state of an SSH session that was never revived — has no resident tab until
+    // resumeSleepingAgentSessionsForWorktree/ensureWorktreeHasInitialTerminal run inside here.
+    // Probing tab residency first is what made a remote row click a silent no-op (#16731).
+    if (activateAndRevealWorkspace(thread.worktree.id, { executionHostId }) === false) {
       return
-    }
-    const liveTabs = state.tabsByWorktree[worktree.id] ?? []
-    const hasLiveTerminal = liveTabs.some((tab) => tab.id === thread.tab.id)
-    const hasLiveAgentSession = (state.unifiedTabsByWorktree?.[worktree.id] ?? []).some(
-      (tab) => tab.id === thread.tab.id && tab.contentType === 'agent-session'
-    )
-    // Why: retained threads can outlive their target; reorienting the workspace for a
-    // dead terminal or structured session would just confuse the user.
-    if (!hasLiveTerminal && !hasLiveAgentSession) {
-      return
-    }
-    if (state.activeRepoId !== worktree.repoId) {
-      state.setActiveRepo(worktree.repoId)
     }
     if (
-      state.activeWorktreeId !== worktree.id ||
-      state.activeWorkspaceExecutionHostId !== executionHostId
+      activateStructuredAgentSessionTab({ worktreeId: thread.worktree.id, tabId: thread.tab.id })
     ) {
-      state.setActiveWorktree(worktree.id, executionHostId)
-    }
-    if (activateStructuredAgentSessionTab({ worktreeId: worktree.id, tabId: thread.tab.id })) {
       return
     }
-    state.setActiveTabType('terminal')
+    // Read post-activation: the tab this thread points at may have only just been revived.
+    const activated = useAppStore.getState()
+    const liveTabs = activated.tabsByWorktree[thread.worktree.id] ?? []
+    if (!liveTabs.some((tab) => tab.id === thread.tab.id)) {
+      // Retained threads outlive their tab; the workspace is still activated, but there is
+      // no pane to focus and focusing a sibling would be worse than focusing nothing.
+      return
+    }
+    activated.setActiveTabType('terminal')
     const parsed = parsePaneKey(thread.paneKey)
     activateTabAndFocusPane(
       thread.tab.id,

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.test.tsx
@@ -91,6 +91,32 @@ describe('AgentTerminalDialog', () => {
     expect(screen.getByTestId('preview')).toHaveAttribute('data-terminal-input', 'null')
   })
 
+  it('does not claim a remote pane closed when the card carries no live pty', () => {
+    render(
+      <AgentTerminalDialog
+        card={card({ ptyId: null, hostKind: 'ssh' })}
+        onOpenChange={() => {}}
+        onReveal={() => {}}
+      />
+    )
+
+    // Loss of contact with an SSH host is `unverifiable`, never `exited`.
+    expect(screen.getByText(/remote session/)).toBeInTheDocument()
+    expect(screen.queryByText(/pane has closed/)).not.toBeInTheDocument()
+  })
+
+  it('still reports a closed pane for a local card with no live pty', () => {
+    render(
+      <AgentTerminalDialog
+        card={card({ ptyId: null, hostKind: 'local' })}
+        onOpenChange={() => {}}
+        onReveal={() => {}}
+      />
+    )
+
+    expect(screen.getByText(/pane has closed/)).toBeInTheDocument()
+  })
+
   it('labels acknowledged completions idle without review or pin controls', () => {
     render(
       <AgentTerminalDialog

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalDialog.tsx
@@ -11,6 +11,7 @@ import {
   type DashboardRevealAgentArgs
 } from '../../../../shared/dashboard-snapshot'
 import { AgentTerminalPreview } from './AgentTerminalPreview'
+import { terminalPreviewUnavailableMessage } from './terminal-preview-unavailable-message'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
 
@@ -80,10 +81,7 @@ function AgentTerminalFrame({
         />
       ) : (
         <div className="min-h-0 flex-1 px-2.5 pb-2 text-[11px] text-muted-foreground">
-          {translate(
-            'dashboardPopout.terminal.closed',
-            "No live terminal — this agent's pane has closed."
-          )}
+          {terminalPreviewUnavailableMessage({ hostKind: card.hostKind })}
         </div>
       )}
       <div className="flex shrink-0 items-center gap-1.5 px-2.5 py-1.5">

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -612,6 +612,14 @@ describe('AgentTerminalPreview', () => {
     expect(unsubscribe).toHaveBeenCalledWith('pty-1')
   })
 
+  it('does not claim a remote pane closed when no snapshot can exist for it', async () => {
+    connect.mockResolvedValueOnce({ snapshot: null, replay: [] })
+    const view = render(<AgentTerminalPreview ptyId="ssh:devbox@@pty-3" />)
+
+    await waitFor(() => expect(view.getByText(/remote session/)).toBeInTheDocument())
+    expect(view.queryByText(/pane has closed/)).not.toBeInTheDocument()
+  })
+
   it('connects a replacement pty after the previous pty was gone', async () => {
     connect.mockResolvedValueOnce({ snapshot: null, replay: [] }).mockResolvedValueOnce({
       snapshot: { data: 'replacement', cols: 80, rows: 24, seq: 1 },

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -17,7 +17,7 @@ import { installPreviewTerminalCompatibility } from './preview-terminal-compatib
 import { createPreviewClipboardPaster } from './preview-terminal-paste'
 import { installPreviewImeBridge, type PreviewImeBridge } from './preview-terminal-ime-bridge'
 import type { DashboardCardTerminalInput } from '../../../../shared/dashboard-snapshot'
-import { translate } from '@/i18n/i18n'
+import { terminalPreviewUnavailableMessage } from './terminal-preview-unavailable-message'
 import { getBuiltinTheme, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
@@ -430,10 +430,7 @@ export function AgentTerminalPreview({
     >
       {ptyGone ? (
         <div className="absolute inset-0 flex items-center justify-center px-2.5 py-8 text-center text-[11px] text-muted-foreground">
-          {translate(
-            'dashboardPopout.terminal.closed',
-            "No live terminal — this agent's pane has closed."
-          )}
+          {terminalPreviewUnavailableMessage({ ptyId })}
         </div>
       ) : null}
       <div

--- a/src/renderer/src/components/dashboard-popout/terminal-preview-unavailable-message.test.ts
+++ b/src/renderer/src/components/dashboard-popout/terminal-preview-unavailable-message.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { terminalPreviewUnavailableMessage } from './terminal-preview-unavailable-message'
+
+describe('terminalPreviewUnavailableMessage', () => {
+  it('claims the pane closed only for a pty the client could have observed', () => {
+    expect(terminalPreviewUnavailableMessage({ ptyId: 'pty-1' })).toMatch(/pane has closed/)
+    expect(terminalPreviewUnavailableMessage({ hostKind: 'local' })).toMatch(/pane has closed/)
+  })
+
+  it('reports an unobservable remote preview instead of asserting the pane exited', () => {
+    // SshPtyProvider provides no authoritative buffer snapshot and the relay has no snapshot
+    // RPC, so a null snapshot is loss of contact. See docs/reference/ssh-execution-boundary.md.
+    const fromPtyId = terminalPreviewUnavailableMessage({ ptyId: 'ssh:devbox@@pty-3' })
+    expect(fromPtyId).toMatch(/remote session/)
+    expect(fromPtyId).not.toMatch(/pane has closed/)
+    expect(terminalPreviewUnavailableMessage({ hostKind: 'ssh' })).toBe(fromPtyId)
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/terminal-preview-unavailable-message.ts
+++ b/src/renderer/src/components/dashboard-popout/terminal-preview-unavailable-message.ts
@@ -1,0 +1,27 @@
+import { translate } from '@/i18n/i18n'
+import type { DashboardCardHostKind } from '../../../../shared/dashboard-snapshot'
+import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
+
+/**
+ * A missing buffer snapshot only proves the pane exited when the client could have
+ * observed it. `SshPtyProvider` reports no authoritative buffer snapshot and the relay
+ * exposes no snapshot RPC, so for a remote pty the absence is loss of contact —
+ * `unverifiable`, never `exited`. See docs/reference/ssh-execution-boundary.md.
+ */
+export function terminalPreviewUnavailableMessage(source: {
+  ptyId?: string | null
+  hostKind?: DashboardCardHostKind
+}): string {
+  const isRemote =
+    source.hostKind === 'ssh' ||
+    (typeof source.ptyId === 'string' && parseAppSshPtyId(source.ptyId) !== null)
+  return isRemote
+    ? translate(
+        'dashboardPopout.terminal.remotePreviewUnavailable',
+        'No preview for this remote session — open the workspace to view the terminal.'
+      )
+    : translate(
+        'dashboardPopout.terminal.closed',
+        "No live terminal — this agent's pane has closed."
+      )
+}

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.test.tsx
@@ -8,11 +8,16 @@ const mocks = vi.hoisted(() => ({
   useLiveDashboardSnapshot: vi.fn(() => ({ generatedAt: 1, cards: [] })),
   blockingOverlay: false,
   boardProps: null as Record<string, unknown> | null,
-  activateTabAndFocusPane: vi.fn()
+  activateTabAndFocusPane: vi.fn(),
+  activateAndRevealWorkspace: vi.fn(() => ({ primaryTabId: null }) as unknown)
 }))
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
   activateTabAndFocusPane: mocks.activateTabAndFocusPane
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
 }))
 
 vi.mock('./useLiveDashboardSnapshot', () => ({
@@ -49,6 +54,9 @@ beforeEach(() => {
     false
   )
   mocks.useLiveDashboardSnapshot.mockClear()
+  mocks.activateTabAndFocusPane.mockClear()
+  mocks.activateAndRevealWorkspace.mockClear()
+  mocks.activateAndRevealWorkspace.mockReturnValue({ primaryTabId: null })
   mocks.blockingOverlay = false
   mocks.boardProps = null
   ;(window as unknown as { api: unknown }).api = {
@@ -95,34 +103,63 @@ describe('AgentDashboardDrawer', () => {
     expect(mocks.boardProps?.initialView).toBeUndefined()
   })
 
-  it('reveals a colliding worktree on the card execution host', () => {
-    const setActiveWorktree = vi.spyOn(useAppStore.getState(), 'setActiveWorktree')
+  type RevealAgent = (args: {
+    repoId: string
+    worktreeId: string
+    executionHostId?: string
+    tabId: string
+    leafId: string | null
+  }) => void
+
+  function revealFromBoard(executionHostId: string): void {
     render(<AgentDashboardDrawer statusBarVisible />)
     act(() => useAppStore.setState({ agentDashboardDrawerOpen: true }))
     const onRevealAgent = mocks.boardProps?.onRevealAgent
     expect(onRevealAgent).toBeTypeOf('function')
-
     act(() => {
-      ;(
-        onRevealAgent as (args: {
-          repoId: string
-          worktreeId: string
-          executionHostId?: string
-          tabId: string
-          leafId: string | null
-        }) => void
-      )({
+      ;(onRevealAgent as RevealAgent)({
         repoId: 'repo-1',
         worktreeId: 'shared-worktree',
-        executionHostId: 'runtime:env-1',
+        executionHostId,
         tabId: 'tab-1',
         leafId: 'leaf-1'
       })
     })
+  }
 
-    expect(setActiveWorktree).toHaveBeenCalledWith('shared-worktree', 'runtime:env-1')
+  it('reveals a colliding worktree on the card execution host', () => {
+    const setActiveWorktree = vi.spyOn(useAppStore.getState(), 'setActiveWorktree')
+
+    revealFromBoard('runtime:env-1')
+
+    // Bare setActiveWorktree skips the terminal view switch, initial-terminal seeding and
+    // sleeping-session resume the shared dispatcher runs.
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('shared-worktree', {
+      executionHostId: 'runtime:env-1'
+    })
+    expect(setActiveWorktree).not.toHaveBeenCalled()
     expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {
       flashFocusedPane: true
     })
+  })
+
+  it('activates a parked SSH workspace before reaching for its pane', () => {
+    revealFromBoard('ssh:devbox')
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('shared-worktree', {
+      executionHostId: 'ssh:devbox'
+    })
+    // Ordering is the fix: a parked remote tab only exists after activation revives it.
+    expect(mocks.activateAndRevealWorkspace.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.activateTabAndFocusPane.mock.invocationCallOrder[0] as number
+    )
+  })
+
+  it('skips pane focus when the revealed workspace is gone', () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue(false)
+
+    revealFromBoard('ssh:devbox')
+
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
+++ b/src/renderer/src/components/dashboard/AgentDashboardDrawer.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
 import { Sheet, SheetContent, SheetTitle } from '@/components/ui/sheet'
-import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { revealDashboardAgent } from './reveal-dashboard-agent'
 import { AgentKanbanBoard } from '../dashboard-popout/AgentKanbanBoard'
 import type { AgentRevealArgs } from '../dashboard-popout/AgentTerminalDialog'
 import {
@@ -47,8 +47,7 @@ function AgentDashboardDrawerBody({
   }, [])
   const handleRevealAgent = useCallback(
     (args: AgentRevealArgs) => {
-      useAppStore.getState().setActiveWorktree(args.worktreeId, args.executionHostId)
-      activateTabAndFocusPane(args.tabId, args.leafId, { flashFocusedPane: true })
+      revealDashboardAgent(args)
       onClose()
     },
     [onClose]

--- a/src/renderer/src/components/dashboard/reveal-dashboard-agent.ts
+++ b/src/renderer/src/components/dashboard/reveal-dashboard-agent.ts
@@ -1,0 +1,23 @@
+import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { activateAndRevealWorkspace } from '@/lib/worktree-activation'
+import type { DashboardRevealAgentArgs } from '../../../../shared/dashboard-snapshot'
+
+/**
+ * Click-to-focus from either Agent Dashboard surface (pop-out relay or in-window drawer).
+ *
+ * Why the workspace dispatcher rather than a bare `setActiveWorktree`: only the shared
+ * sequence switches the view back to terminal, resumes sleeping agent sessions, and seeds a
+ * terminal surface. A parked SSH workspace has no resident tab until those run, so the bare
+ * call revealed a workspace with nothing in it (#16731).
+ */
+export function revealDashboardAgent(args: DashboardRevealAgentArgs): boolean {
+  const activated = activateAndRevealWorkspace(
+    args.worktreeId,
+    args.executionHostId ? { executionHostId: args.executionHostId } : undefined
+  )
+  if (activated === false) {
+    return false
+  }
+  activateTabAndFocusPane(args.tabId, args.leafId, { flashFocusedPane: true })
+  return true
+}

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
@@ -21,7 +21,9 @@ const mocks = vi.hoisted(() => ({
   offRevealAgent: vi.fn(),
   offAckAgent: vi.fn(),
   offPopoutOpenChanged: vi.fn(),
-  offSnapshotRequested: vi.fn()
+  offSnapshotRequested: vi.fn(),
+  activateTabAndFocusPane: vi.fn(),
+  activateAndRevealWorkspace: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
@@ -35,7 +37,11 @@ vi.mock('@/store', () => ({
 }))
 
 vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
-  activateTabAndFocusPane: vi.fn()
+  activateTabAndFocusPane: mocks.activateTabAndFocusPane
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
 }))
 
 vi.mock('./build-dashboard-snapshot', () => ({
@@ -159,7 +165,8 @@ describe('useDashboardPopoutBridge', () => {
     expect(mocks.buildDashboardSnapshot).toHaveBeenCalledTimes(1)
   })
 
-  it('reveals the agent on its exact execution host', async () => {
+  it('reveals the agent on its exact execution host through the full activation', async () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue({ primaryTabId: null })
     await act(async () => root.render(<Harness enabled />))
 
     await act(async () =>
@@ -172,7 +179,53 @@ describe('useDashboardPopoutBridge', () => {
       })
     )
 
-    expect(mocks.setActiveWorktree).toHaveBeenCalledWith('shared-worktree', 'runtime:env-1')
+    // Bare setActiveWorktree skips the terminal view switch, initial-terminal seeding and
+    // sleeping-session resume, so a parked pane is never revived (#16731).
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('shared-worktree', {
+      executionHostId: 'runtime:env-1'
+    })
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {
+      flashFocusedPane: true
+    })
+  })
+
+  it('activates a parked SSH workspace before reaching for its pane', async () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue({ primaryTabId: 'tab-1' })
+    await act(async () => root.render(<Harness enabled />))
+
+    await act(async () =>
+      mocks.onRevealAgent.mock.calls[0][0]({
+        repoId: 'repo-1',
+        worktreeId: 'remote-worktree',
+        executionHostId: 'ssh:devbox',
+        tabId: 'tab-1',
+        leafId: 'leaf-1'
+      })
+    )
+
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('remote-worktree', {
+      executionHostId: 'ssh:devbox'
+    })
+    expect(mocks.activateAndRevealWorkspace.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.activateTabAndFocusPane.mock.invocationCallOrder[0] as number
+    )
+  })
+
+  it('skips pane focus when the revealed workspace is gone', async () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue(false)
+    await act(async () => root.render(<Harness enabled />))
+
+    await act(async () =>
+      mocks.onRevealAgent.mock.calls[0][0]({
+        repoId: 'repo-1',
+        worktreeId: 'deleted-worktree',
+        tabId: 'tab-1',
+        leafId: 'leaf-1'
+      })
+    )
+
+    expect(mocks.activateTabAndFocusPane).not.toHaveBeenCalled()
   })
 
   it('ignores unrelated store writes while retaining every snapshot input', () => {

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { useAppStore, type AppState } from '@/store'
-import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import { revealDashboardAgent } from './reveal-dashboard-agent'
 import { runSleepWorktree } from '../sidebar/sleep-worktree-flow'
 import type { RepoIcon } from '../../../../shared/repo-icon'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
@@ -133,8 +133,7 @@ export function useDashboardPopoutBridge(enabled: boolean): void {
       return
     }
     return window.api.dashboard.onRevealAgent((args) => {
-      useAppStore.getState().setActiveWorktree(args.worktreeId, args.executionHostId)
-      activateTabAndFocusPane(args.tabId, args.leafId, { flashFocusedPane: true })
+      revealDashboardAgent(args)
     })
   }, [enabled])
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17230,6 +17230,7 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
+      "remotePreviewUnavailable": "No preview for this remote session — open the workspace to view the terminal.",
       "focusWorktree": "Open worktree",
       "close": "Close"
     },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​50 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​178 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## Summary

Fixes #16731. Clicking an agent could not open a **remote (SSH)** session: the reveal landed on a workspace with no terminal, the Activity row-click was a silent no-op, and the preview claimed the pane had closed.

Three reveal paths called bare `setActiveWorktree` + `activateTabAndFocusPane`, skipping `setActiveView('terminal')`, `ensureWorktreeHasInitialTerminal` and `resumeSleepingAgentSessionsForWorktree`:

| surface | site |
|---|---|
| pop-out bridge | `useDashboardPopoutBridge.ts` |
| in-window drawer | `AgentDashboardDrawer.tsx` |
| Activity row-click | `activity-thread-actions.ts` (added by #18222) |

All three now route through the incumbent `activateAndRevealWorkspace` — the same dispatcher the sidebar (`WorktreeCardAgents`, `active-worktree-focus-after-delete`, `use-worktree-context-menu-commands`) and the row's own "Jump to workspace" affordance already use. No new activation helper; the two dashboard surfaces share one small `revealDashboardAgent` wrapper. The workspace dispatcher (not `activateAndRevealWorktree` directly) so a folder-workspace card keeps its path-status gate.

**The Activity early-return is removed.** It probed `tabsByWorktree`/`unifiedTabsByWorktree` *before* activating, so a cold-parked remote thread — the normal state of an SSH session that was never revived — produced a silent no-op click. Residency is now probed *after* activation, matching `WorktreeCardAgents.handleActivateAgentTab`: a revived tab gets focused, and a genuinely retained thread whose tab never returns still activates its workspace instead of doing nothing.

**Message honesty.** `SshPtyProvider.canProvideAuthoritativeBufferSnapshot` returns `false` and the relay's `RecentPtyOutputBuffer` has no snapshot RPC, so `serializeTerminalBufferFromAvailableState` has nothing to fall through to for SSH. A null snapshot for a remote pty is loss of contact, and per `docs/reference/ssh-execution-boundary.md` that is `unverifiable`, never `exited`. The preview and the no-pty dialog branch now render a host-aware string instead of asserting the pane closed. Adding the relay snapshot RPC is **out of scope** — a new stream opcode needs capability negotiation (`docs/reference/remote-wire-compatibility.md`).

Renderer-only. Nothing crosses the remote wire: `hostKind` is already on `DashboardCard`, and no snapshot field was added.

## Not fixed here (deliberate)

`activate-tab-and-focus-pane.ts` dispatches `FOCUS_TERMINAL_PANE_EVENT` inside a single `requestAnimationFrame`, and its only consumer is a bare `window.addEventListener`, so a pane mounting after the dispatch never sees it. All four surfaces share this. It is a real gap, but it is a *focus flash*, not the reported symptom — with activation routed correctly the workspace opens and the terminal is there. Building a TTL'd pending-focus registry for it speculatively is a larger change than the bug being fixed, so it is left alone and noted.

## Testing

- `pnpm tc` — clean
- `pnpm test src` (whole tree) — 69,614 passed. The only 2 failures are in `src/main/native-chat/agent-session-wire/structured-tui-transcript-catchup.test.ts`, which **fails identically on a clean tree** (verified by stashing) and is unrelated main-process transcript-watcher work.
- `pnpm run check:code-quality:changed` — 0 new findings (code quality, type-aware, React Doctor)
- `oxlint` over the three touched directories — clean, with `max-lines` proven to fire there via a 320-line positive control
- Docker SSH e2e lane

**Failed-first: 12 of the 66 assertions in the touched suites fail against the pre-fix source.** The important one is `activity-thread-actions.test.ts`, which previously *pinned the bug*: it asserted the bare `setActiveWorktree(thread.worktree.id, REMOTE_HOST)` call for a remote host. That assertion is now inverted (`setActiveWorktree` must **not** be called; the dispatcher must be), and a **cold-parked remote thread whose tab is not resident until activation revives it** is covered directly — the reported symptom and the early-return case.

## Notes

Supersedes #16732, which attempted this before the defect spread to Activity. That PR routes through `activateAndRevealWorktree` (missing the folder-workspace dispatcher), does not touch the Activity surface or its early-return, does not update the test that pins the bug, and copies the new English string into `es`/`ja`/`ko`/`zh`. Its one piece of unique work is the pending-focus registry described above. Recommend closing it in favour of this PR and tracking the focus registry separately if it proves load-bearing.
