### PR TITLE
fix(runtime): keep WSL browser CLI RPCs alive

### DIFF
--- a/src/main/runtime/runtime-rpc-long-poll-transport.test.ts
+++ b/src/main/runtime/runtime-rpc-long-poll-transport.test.ts
@@ -63,6 +63,34 @@ describe('OrcaRuntimeRpcServer', () => {
     ).toBeNull()
   })
 
+  it.each(['browser.snapshot', 'browser.screenshot', 'browser.wait'])(
+    'keeps %s alive while browser automation is pending',
+    (method) => {
+      expect(
+        classifyRuntimeLongPoll({
+          id: `req_${method.replaceAll('.', '_')}`,
+          authToken: 'token',
+          method,
+          params: {}
+        })
+      ).toBe('wait')
+    }
+  )
+
+  it.each(['browser.eval', 'browser.click', 'browser.tabSwitch'])(
+    'keeps %s on the short RPC path',
+    (method) => {
+      expect(
+        classifyRuntimeLongPoll({
+          id: `req_${method.replaceAll('.', '_')}`,
+          authToken: 'token',
+          method,
+          params: {}
+        })
+      ).toBeNull()
+    }
+  )
+
   it('rejects oversized RPC frames instead of buffering them indefinitely', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
     const runtime = new OrcaRuntimeService()
@@ -131,6 +159,45 @@ describe('OrcaRuntimeRpcServer', () => {
           authToken: metadata!.authToken,
           method: 'orchestration.workerStart',
           params: { task: 'task_1', timeoutMs: 60_000 }
+        })
+        await session.done
+
+        expect(
+          session.frames.filter((frame) => frame._keepalive === true).length
+        ).toBeGreaterThanOrEqual(2)
+        expect(session.frames.filter((frame) => frame.ok !== undefined)).toHaveLength(1)
+      } finally {
+        await server.stop()
+      }
+    })
+
+    it('emits keepalives while a browser snapshot helper blocks', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 30
+      })
+      const dispatch = server['dispatcher']
+      vi.spyOn(dispatch, 'dispatch').mockImplementation(async (request) => {
+        await sleep(120)
+        return {
+          id: request.id,
+          ok: true,
+          result: { browserPageId: 'page-1', snapshot: 'tree' },
+          _meta: { runtimeId: runtime.getRuntimeId() }
+        }
+      })
+      await server.start()
+
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const session = openFramedSession(metadata!.transports[0]!.endpoint, {
+          id: 'req_browser_snapshot',
+          authToken: metadata!.authToken,
+          method: 'browser.snapshot',
+          params: { worktree: 'id:wt-1' }
         })
         await session.done
 

--- a/src/main/runtime/runtime-rpc/runtime-rpc-long-poll.ts
+++ b/src/main/runtime/runtime-rpc/runtime-rpc-long-poll.ts
@@ -29,6 +29,16 @@ export function classifyRuntimeLongPoll(request: RpcRequest): RuntimeLongPollCla
   if (request.method === 'browser.clientHost.attach') {
     return 'browser-host'
   }
+  // Browser automation can spend longer than the socket idle budget starting
+  // the helper, painting a frame, or waiting on a page condition. Keep the
+  // local socket (including Windows named pipes used by the WSL CLI) alive.
+  if (
+    request.method === 'browser.snapshot' ||
+    request.method === 'browser.screenshot' ||
+    request.method === 'browser.wait'
+  ) {
+    return 'wait'
+  }
   if (request.method === 'terminal.wait') {
     return 'wait'
   }


### PR DESCRIPTION
## Summary

The WSL CLI reaches a Windows Orca host through the local runtime RPC transport (a Windows named pipe). `browser.snapshot`, `browser.screenshot`, and `browser.wait` can block in agent-browser startup/paint/condition waits, but the runtime long-poll classifier treated them as short RPCs. The 30s socket/named-pipe idle timer could therefore close a healthy request before the browser helper replied; the CLI surfaced `runtime_unavailable`. `eval`, `click`, and tab commands remain on the short path.

This patch classifies those three browser methods as the existing `wait` long-poll class. That enables the existing keepalive frames and abort/slot accounting for both Unix sockets and Windows named pipes. No new wire fields, opcodes, retries, polling, or fallback routing are introduced.

## Deterministic evidence

- Oracle: `src/main/runtime/runtime-rpc-long-poll-transport.test.ts`
- Classifier assertions cover the affected methods (`browser.snapshot`, `browser.screenshot`, `browser.wait`) and controls (`browser.eval`, `browser.click`, `browser.tabSwitch`). On the base revision those new assertions are red because the methods classify as short RPCs.
- A real newline-framed local RPC session delays `browser.snapshot` for 120ms, observes >=2 keepalives, and receives exactly one terminal response on the candidate.
- Focused result: `pnpm test src/main/runtime/runtime-rpc-long-poll-transport.test.ts src/cli/browser.test.ts` — 57 passed.
- Additional result: 49 tests passed across local long-poll, WebSocket long-poll, remote client, and envelope suites; 38 browser bridge/lifecycle tests passed.
- `pnpm tc:node` passed.
- `pnpm run check:code-quality:changed` passed with 0 new findings.

## Compatibility and limits

The keepalive frame is already part of the existing RPC envelope and is understood by current/legacy clients; this changes only host-side classification. The existing long-poll cap still bounds concurrency and returns `runtime_busy` under saturation.

This workspace is macOS. Windows 2, WSL2, ConPTY, and the physical Windows named-pipe path were not available, so no physical Windows/WSL reproduction is claimed. The oracle exercises the same classifier and real local framed transport used by that path, but it does not prove WSL interop, PowerShell argv forwarding, or Windows kernel named-pipe behavior. A >30s end-to-end timeout was not run in CI because it would make the regression suite unnecessarily slow; the causal boundary is the host idle timer plus the missing classifier entry.

Linear was not mutated; the session's `orca-ide` Linear CLI was unavailable.
