### PR TITLE
fix(runtime): fence terminal topology and pane identity

### DIFF
--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -26,7 +26,7 @@ export function formatTerminalList(result: RuntimeTerminalListResult): string {
   const body = result.terminals
     .map(
       (terminal) =>
-        `${terminal.handle}  ${terminal.title ?? '(untitled)'}  ${terminal.connected ? 'connected' : 'disconnected'}  host=${terminal.executionHostId ?? 'unverifiable'}  ${terminal.worktreePath}\n${terminal.preview ? `preview: ${terminal.preview}` : 'preview: <empty>'}`
+        `${terminal.handle}  ${terminal.title ?? '(untitled)'}  ${terminal.connected ? 'connected' : 'disconnected'}  visual=${terminal.visualTopologyState ?? 'unverifiable'}  host=${terminal.executionHostId ?? 'unverifiable'}  ${terminal.worktreePath}\n${terminal.preview ? `preview: ${terminal.preview}` : 'preview: <empty>'}`
     )
     .join('\n\n')
   const visualLayout = formatTerminalVisualLayouts(result.visualLayouts)
@@ -114,6 +114,7 @@ export function formatTerminalShow(result: { terminal: RuntimeTerminalShow }): s
     `ptyId: ${terminal.ptyId ?? 'none'}`,
     `connected: ${terminal.connected}`,
     `writable: ${terminal.writable}`,
+    `visualTopologyState: ${terminal.visualTopologyState ?? 'unverifiable'}`,
     // Why listed above the preview: the preview is where a reader would otherwise have to
     // spot the prompt by eye, which is the work this line exists to remove.
     `agentWait: ${formatAgentWait(terminal.agentWait)}`,

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -125,11 +125,15 @@ describe('createPtySubprocess', () => {
     const saved = {
       ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
       ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+      ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+      ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE,
+      ORCA_AGENT_LAUNCH_TOKEN: process.env.ORCA_AGENT_LAUNCH_TOKEN
     }
     process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
     process.env.ORCA_TAB_ID = 'parent-tab'
     process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+    process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+    process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
     try {
       await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
@@ -147,6 +151,8 @@ describe('createPtySubprocess', () => {
     expect(env.ORCA_PANE_KEY).toBeUndefined()
     expect(env.ORCA_TAB_ID).toBeUndefined()
     expect(env.ORCA_WORKTREE_ID).toBeUndefined()
+    expect(env.ORCA_TERMINAL_HANDLE).toBeUndefined()
+    expect(env.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
   })
 
   it('preserves explicit child Orca pane identity over parent env', async () => {

--- a/src/main/daemon/pty-subprocess/spawn-environment.ts
+++ b/src/main/daemon/pty-subprocess/spawn-environment.ts
@@ -16,15 +16,10 @@ import {
   expandWindowsEnvironmentVariables,
   expandWindowsPathEnvironmentVariables
 } from '../../../shared/windows-environment-expansion'
+import { removeUnspecifiedPaneIdentityEnv } from '../../../shared/pane-identity-env'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { PtySubprocessOptions } from '../pty-subprocess'
 
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
 const WINDOWS_PATH_ENV_KEY_RE = /^path$/i
 
 function composeGuardedDaemonGitConfigEnv(
@@ -55,17 +50,6 @@ function deleteRequestedDaemonEnvKeys(
   }
   if (deleteOrcaOwnedCodexHome) {
     delete env.CODEX_HOME
-  }
-}
-
-function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
   }
 }
 

--- a/src/main/providers/local-pty-launch-helpers.ts
+++ b/src/main/providers/local-pty-launch-helpers.ts
@@ -4,27 +4,10 @@ import { parseWslPath } from '../wsl'
 import { resolvePathEnvKey } from '../pty/windows-environment-path'
 import { expandWindowsEnvironmentVariables } from '../../shared/windows-environment-expansion'
 import { resolveSafePtyDefaultCwd } from './pty-default-cwd'
-
-const PANE_IDENTITY_ENV_KEYS = [
-  'ORCA_PANE_KEY',
-  'ORCA_TAB_ID',
-  'ORCA_WORKTREE_ID',
-  'ORCA_AGENT_LAUNCH_TOKEN'
-] as const
+export { removeUnspecifiedPaneIdentityEnv } from '../../shared/pane-identity-env'
 
 export function getDefaultCwd(): string {
   return resolveSafePtyDefaultCwd()
-}
-
-export function removeUnspecifiedPaneIdentityEnv(
-  env: Record<string, string>,
-  explicitEnv: Record<string, string> | undefined
-): void {
-  for (const key of PANE_IDENTITY_ENV_KEYS) {
-    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
-      delete env[key]
-    }
-  }
 }
 
 export function promoteAgentTeamsShimPath(

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -563,11 +563,15 @@ describe('LocalPtyProvider', () => {
       const saved = {
         ORCA_PANE_KEY: process.env.ORCA_PANE_KEY,
         ORCA_TAB_ID: process.env.ORCA_TAB_ID,
-        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID
+        ORCA_WORKTREE_ID: process.env.ORCA_WORKTREE_ID,
+        ORCA_TERMINAL_HANDLE: process.env.ORCA_TERMINAL_HANDLE,
+        ORCA_AGENT_LAUNCH_TOKEN: process.env.ORCA_AGENT_LAUNCH_TOKEN
       }
       process.env.ORCA_PANE_KEY = 'parent-tab:parent-leaf'
       process.env.ORCA_TAB_ID = 'parent-tab'
       process.env.ORCA_WORKTREE_ID = 'parent-worktree'
+      process.env.ORCA_TERMINAL_HANDLE = 'term_parent'
+      process.env.ORCA_AGENT_LAUNCH_TOKEN = 'parent-launch-token'
 
       try {
         await provider.spawn({ cols: 80, rows: 24 })
@@ -585,6 +589,8 @@ describe('LocalPtyProvider', () => {
       expect(spawnCall[2].env.ORCA_PANE_KEY).toBeUndefined()
       expect(spawnCall[2].env.ORCA_TAB_ID).toBeUndefined()
       expect(spawnCall[2].env.ORCA_WORKTREE_ID).toBeUndefined()
+      expect(spawnCall[2].env.ORCA_TERMINAL_HANDLE).toBeUndefined()
+      expect(spawnCall[2].env.ORCA_AGENT_LAUNCH_TOKEN).toBeUndefined()
     })
 
     it('preserves explicit child Orca pane identity over parent env', async () => {

--- a/src/main/runtime/mobile-session-terminal-projection.ts
+++ b/src/main/runtime/mobile-session-terminal-projection.ts
@@ -23,6 +23,7 @@ export function buildHeadlessMobileSessionTerminalTabs(
       }
       return leafIds.flatMap((leafId) => {
         const ptyId = layout?.ptyIdsByLeafId?.[leafId] ?? (leafIds.length === 1 ? tab.ptyId : null)
+        const incarnationId = session.terminalPtyIncarnationsByPaneKey?.[`${tab.id}:${leafId}`]
         const title =
           tab.customTitle?.trim() ||
           tab.generatedTitle?.trim() ||
@@ -37,6 +38,7 @@ export function buildHeadlessMobileSessionTerminalTabs(
             leafId,
             title,
             ...(ptyId ? { ptyId } : {}),
+            ...(incarnationId ? { incarnationId } : {}),
             ...(tab.startupCwd ? { startupCwd: tab.startupCwd } : {}),
             ...(tab.launchAgent ? { launchAgent: tab.launchAgent } : {}),
             ...(layout ? { parentLayout: cloneTerminalLayoutSnapshot(layout) } : {}),

--- a/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
+++ b/src/main/runtime/orca-runtime-resolve-terminal-pane.ts
@@ -13,6 +13,8 @@ import {
   readTerminalTail
 } from './terminal-tail-read'
 import { getTerminalState } from './terminal-wait-results'
+import { buildRuntimeTerminalVisualLayouts } from './runtime-terminal-visual-layout'
+import { annotateRuntimeTerminalVisualTopology } from './runtime-terminal-visual-topology-state'
 
 export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTerminalInteractiveWait {
   resolveTerminalPane(paneKey: string, expectedWorktreeId?: string): RuntimeTerminalResolvePane {
@@ -142,16 +144,21 @@ export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTermin
       const preview = await this.visibleSnapshotPreview(pty.pty.ptyId, summary.preview)
       this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
       const agentWait = await this.getTerminalInteractiveWait(handle)
-      return {
-        ...summary,
-        preview,
-        tabId: pty.pty.tabId ?? pty.record.tabId,
-        leafId: parsePaneKey(pty.pty.paneKey ?? '')?.leafId ?? pty.record.leafId,
-        paneRuntimeId: -1,
-        ptyId: pty.pty.ptyId,
-        rendererGraphEpoch: this.rendererGraphEpoch,
-        ...(agentWait !== undefined ? { agentWait } : {})
-      }
+      const result = this.withVisualTopologyState(
+        {
+          ...summary,
+          preview,
+          tabId: pty.pty.tabId ?? pty.record.tabId,
+          leafId: parsePaneKey(pty.pty.paneKey ?? '')?.leafId ?? pty.record.leafId,
+          paneRuntimeId: -1,
+          ptyId: pty.pty.ptyId,
+          rendererGraphEpoch: this.rendererGraphEpoch,
+          ...(agentWait !== undefined ? { agentWait } : {})
+        },
+        worktreesById
+      )
+      this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
+      return result
     }
     const graphEpoch = this.captureReadyGraphEpoch()
     const worktreesById = await this.getResolvedWorktreeMap()
@@ -166,14 +173,36 @@ export class OrcaRuntimeWithResolveTerminalPane extends OrcaRuntimeWithGetTermin
       this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
     }
     const agentWait = await this.getTerminalInteractiveWait(handle)
-    return {
-      ...summary,
-      preview,
-      paneRuntimeId: leaf.paneRuntimeId,
-      ptyId: leaf.ptyId,
-      rendererGraphEpoch: this.rendererGraphEpoch,
-      ...(agentWait !== undefined ? { agentWait } : {})
+    const result = this.withVisualTopologyState(
+      {
+        ...summary,
+        preview,
+        paneRuntimeId: leaf.paneRuntimeId,
+        ptyId: leaf.ptyId,
+        rendererGraphEpoch: this.rendererGraphEpoch,
+        ...(agentWait !== undefined ? { agentWait } : {})
+      },
+      worktreesById
+    )
+    if (leaf.ptyId) {
+      this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
     }
+    return result
+  }
+
+  protected withVisualTopologyState(
+    terminal: RuntimeTerminalShow,
+    worktreesById: Map<string, { path: string }>
+  ): RuntimeTerminalShow {
+    const snapshot = this.mobileSessionTabsByWorktree.get(terminal.worktreeId)
+    const snapshots = snapshot ? [snapshot] : []
+    const layouts = buildRuntimeTerminalVisualLayouts({
+      terminals: [terminal],
+      worktreesById,
+      snapshots,
+      getTabTitle: (tabId) => this.tabs.get(tabId)?.title ?? null
+    })
+    return annotateRuntimeTerminalVisualTopology([terminal], layouts, snapshots)[0]
   }
 
   async readTerminal(

--- a/src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts
@@ -6,6 +6,7 @@ import {
   listWorktrees
 } from '../orca-runtime-test-mocks.spec'
 import {
+  HEADLESS_LEAF_ID,
   TEST_FOLDER_WORKSPACE_PATH,
   TEST_REPO_ID,
   TEST_WORKTREE_ID,
@@ -14,8 +15,94 @@ import {
   makeWorktreeMeta,
   store
 } from '../orca-runtime-test-fixtures.spec'
+import { buildRuntimeTerminalVisualLayouts } from '../runtime-terminal-visual-layout'
 
 describe('OrcaRuntimeService', () => {
+  it('does not project a replacement PTY through a stale restart snapshot', () => {
+    const layouts = buildRuntimeTerminalVisualLayouts({
+      terminals: [
+        {
+          handle: 'term-replacement',
+          ptyId: 'pty-replacement',
+          incarnationId: 'incarnation-new',
+          worktreeId: TEST_WORKTREE_ID,
+          worktreePath: TEST_WORKTREE_PATH,
+          branch: 'main',
+          tabId: 'tab-restarted',
+          leafId: HEADLESS_LEAF_ID,
+          title: 'Replacement',
+          connected: true,
+          writable: true,
+          lastOutputAt: null,
+          preview: ''
+        }
+      ],
+      worktreesById: new Map([[TEST_WORKTREE_ID, { path: TEST_WORKTREE_PATH }]]),
+      snapshots: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch: 'renderer:after-restart:1',
+          snapshotVersion: 1,
+          activeGroupId: null,
+          activeTabId: `tab-restarted::${HEADLESS_LEAF_ID}`,
+          activeTabType: 'terminal',
+          tabs: [
+            {
+              type: 'terminal',
+              id: `tab-restarted::${HEADLESS_LEAF_ID}`,
+              parentTabId: 'tab-restarted',
+              leafId: HEADLESS_LEAF_ID,
+              ptyId: 'pty-old',
+              incarnationId: 'incarnation-old',
+              title: 'Persisted',
+              isActive: true
+            }
+          ]
+        }
+      ],
+      getTabTitle: () => null
+    })
+
+    expect(layouts).toEqual([])
+  })
+
+  it('reports a live terminal as detached when its persisted tab is absent', async () => {
+    const runtime = createRuntime()
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (
+        ptyId: string,
+        worktreeId: string,
+        state?: Record<string, unknown>
+      ) => void
+      mobileSessionTabsByWorktree: Map<string, unknown>
+    }
+    internals.recordPtyWorktree('pty-detached', TEST_WORKTREE_ID, {
+      connected: true,
+      incarnationId: 'incarnation-live',
+      tabId: 'missing-tab',
+      paneKey: `missing-tab:${HEADLESS_LEAF_ID}`
+    })
+    internals.mobileSessionTabsByWorktree.set(TEST_WORKTREE_ID, {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer:after-restart:1',
+      snapshotVersion: 1,
+      activeGroupId: null,
+      activeTabId: null,
+      activeTabType: null,
+      tabs: []
+    })
+
+    const listed = await runtime.listTerminals(`id:${TEST_WORKTREE_ID}`, 10, {
+      includeVisualLayouts: true
+    })
+    expect(listed.terminals[0]).toMatchObject({
+      ptyId: 'pty-detached',
+      connected: true,
+      visualTopologyState: 'detached'
+    })
+    expect(listed.visualLayouts).toBeUndefined()
+  })
+
   it('emits one mobile session terminal tab per live PTY even if two tabs resolve to it', () => {
     const runtime = createRuntime()
     const internals = runtime as unknown as {

--- a/src/main/runtime/runtime-terminal-list.ts
+++ b/src/main/runtime/runtime-terminal-list.ts
@@ -8,6 +8,7 @@ import type { PtyControllerInventory } from './runtime-pty-controller-contract'
 import type { ResolvedWorktreeSnapshot } from './runtime-resolved-worktree-cache'
 import type { RuntimeLeafRecord, RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 import { buildRuntimeTerminalVisualLayouts } from './runtime-terminal-visual-layout'
+import { annotateRuntimeTerminalVisualTopology } from './runtime-terminal-visual-topology-state'
 import {
   includeTargetResolvedWorktree,
   type ResolvedWorktree
@@ -163,8 +164,12 @@ export class RuntimeTerminalList {
               : snapshots.values(),
             getTabTitle: (tabId) => this.deps.getTabTitle(tabId)
           })
+    const listedWithVisualState =
+      opts.includeVisualLayouts === false
+        ? listed
+        : annotateRuntimeTerminalVisualTopology(listed, visualLayouts, snapshots.values())
     return {
-      terminals: listed,
+      terminals: listedWithVisualState,
       hostScope: this.deps.buildHostScope(
         targetId,
         matching,

--- a/src/main/runtime/runtime-terminal-visual-layout.ts
+++ b/src/main/runtime/runtime-terminal-visual-layout.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../shared/runtime-types'
 import type { TabGroupLayoutNode } from '../../shared/tab-types'
 import type { TerminalPaneLayoutNode } from '../../shared/terminal-tab-types'
+import { getPtyBindings } from './runtime-terminal-visual-topology-state'
 
 type RuntimeTerminalVisualLayoutArgs = {
   terminals: RuntimeTerminalSummary[]
@@ -138,7 +139,13 @@ function buildTab(
     type: 'leaf' as const,
     leafId: firstSurface.leafId
   }
-  const visibleLeafIds = collectVisibleLeafIds(root, parentTabId, summariesByLeafKey)
+  const visibleLeafIds = collectVisibleLeafIds(
+    root,
+    parentTabId,
+    surfaces,
+    firstSurface.parentLayout,
+    summariesByLeafKey
+  )
   if (visibleLeafIds.length === 0) {
     return null
   }
@@ -147,7 +154,14 @@ function buildTab(
       ? requestedActiveLeafId
       : surfaces.find((surface) => surface.isActive && visibleLeafIds.includes(surface.leafId))
           ?.leafId) ?? visibleLeafIds[0]!
-  const panes = buildPane(root, parentTabId, activeLeafId, summariesByLeafKey)
+  const panes = buildPane(
+    root,
+    parentTabId,
+    activeLeafId,
+    surfaces,
+    firstSurface.parentLayout,
+    summariesByLeafKey
+  )
   if (!panes) {
     return null
   }
@@ -162,14 +176,18 @@ function buildTab(
 function collectVisibleLeafIds(
   node: TerminalPaneLayoutNode,
   tabId: string,
+  surfaces: readonly RuntimeMobileSessionTerminalTab[],
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'],
   summariesByLeafKey: ReadonlyMap<string, RuntimeTerminalSummary>
 ): string[] {
   if (node.type === 'leaf') {
-    return summariesByLeafKey.has(leafKey(tabId, node.leafId)) ? [node.leafId] : []
+    return getVisuallyBoundSummary(tabId, node.leafId, surfaces, parentLayout, summariesByLeafKey)
+      ? [node.leafId]
+      : []
   }
   return [
-    ...collectVisibleLeafIds(node.first, tabId, summariesByLeafKey),
-    ...collectVisibleLeafIds(node.second, tabId, summariesByLeafKey)
+    ...collectVisibleLeafIds(node.first, tabId, surfaces, parentLayout, summariesByLeafKey),
+    ...collectVisibleLeafIds(node.second, tabId, surfaces, parentLayout, summariesByLeafKey)
   ]
 }
 
@@ -177,10 +195,18 @@ function buildPane(
   node: TerminalPaneLayoutNode,
   tabId: string,
   activeLeafId: string | null,
+  surfaces: readonly RuntimeMobileSessionTerminalTab[],
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'],
   summariesByLeafKey: ReadonlyMap<string, RuntimeTerminalSummary>
 ): RuntimeTerminalVisualPaneNode | null {
   if (node.type === 'leaf') {
-    const summary = summariesByLeafKey.get(leafKey(tabId, node.leafId))
+    const summary = getVisuallyBoundSummary(
+      tabId,
+      node.leafId,
+      surfaces,
+      parentLayout,
+      summariesByLeafKey
+    )
     if (!summary) {
       return null
     }
@@ -194,12 +220,52 @@ function buildPane(
       active: summary.leafId === activeLeafId
     }
   }
-  const first = buildPane(node.first, tabId, activeLeafId, summariesByLeafKey)
-  const second = buildPane(node.second, tabId, activeLeafId, summariesByLeafKey)
+  const first = buildPane(
+    node.first,
+    tabId,
+    activeLeafId,
+    surfaces,
+    parentLayout,
+    summariesByLeafKey
+  )
+  const second = buildPane(
+    node.second,
+    tabId,
+    activeLeafId,
+    surfaces,
+    parentLayout,
+    summariesByLeafKey
+  )
   if (first && second) {
     return { type: 'pane-split', direction: node.direction, first, second }
   }
   return first ?? second
+}
+
+function getVisuallyBoundSummary(
+  tabId: string,
+  leafId: string,
+  surfaces: readonly RuntimeMobileSessionTerminalTab[],
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'],
+  summariesByLeafKey: ReadonlyMap<string, RuntimeTerminalSummary>
+): RuntimeTerminalSummary | null {
+  const summary = summariesByLeafKey.get(leafKey(tabId, leafId))
+  const surface = surfaces.find((candidate) => candidate.leafId === leafId)
+  if (!summary || !surface) {
+    return null
+  }
+  const ptyBindings = getPtyBindings(surface, parentLayout)
+  if (
+    !summary.ptyId ||
+    ptyBindings.length === 0 ||
+    ptyBindings.some((ptyId) => ptyId !== summary.ptyId)
+  ) {
+    return null
+  }
+  if (surface.incarnationId && surface.incarnationId !== summary.incarnationId) {
+    return null
+  }
+  return summary
 }
 
 function buildGroupLayout(

--- a/src/main/runtime/runtime-terminal-visual-topology-state.ts
+++ b/src/main/runtime/runtime-terminal-visual-topology-state.ts
@@ -1,0 +1,94 @@
+import type {
+  RuntimeMobileSessionTabsSnapshot,
+  RuntimeMobileSessionTerminalTab,
+  RuntimeTerminalSummary,
+  RuntimeTerminalVisualLayout,
+  RuntimeTerminalVisualLayoutNode,
+  RuntimeTerminalVisualPaneNode
+} from '../../shared/runtime-types'
+import { UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH } from '../../shared/runtime-types'
+
+export function annotateRuntimeTerminalVisualTopology(
+  terminals: readonly RuntimeTerminalSummary[],
+  layouts: readonly RuntimeTerminalVisualLayout[],
+  snapshots: Iterable<RuntimeMobileSessionTabsSnapshot>
+): RuntimeTerminalSummary[] {
+  const projectedHandles = new Set<string>()
+  for (const layout of layouts) {
+    collectProjectedHandles(layout.root, projectedHandles)
+  }
+  const snapshotsByWorktree = new Map(
+    [...snapshots].map((snapshot) => [snapshot.worktree, snapshot])
+  )
+  return terminals.map((terminal) => {
+    const snapshot = snapshotsByWorktree.get(terminal.worktreeId)
+    if (!snapshot) {
+      return terminal
+    }
+    const surface = snapshot.tabs.find(
+      (candidate): candidate is RuntimeMobileSessionTerminalTab =>
+        candidate.type === 'terminal' &&
+        candidate.parentTabId === terminal.tabId &&
+        candidate.leafId === terminal.leafId
+    )
+    if (!surface) {
+      if (
+        snapshot.publicationEpoch === UNPUBLISHED_WORKTREE_PUBLICATION_EPOCH &&
+        snapshot.snapshotVersion === 0
+      ) {
+        return terminal
+      }
+      return { ...terminal, visualTopologyState: 'detached' }
+    }
+    const parentSurface = snapshot.tabs.find(
+      (candidate): candidate is RuntimeMobileSessionTerminalTab =>
+        candidate.type === 'terminal' && candidate.parentTabId === terminal.tabId
+    )
+    const ptyBindings = getPtyBindings(surface, parentSurface?.parentLayout)
+    if (!terminal.ptyId || ptyBindings.length === 0) {
+      return terminal
+    }
+    if (ptyBindings.some((ptyId) => ptyId !== terminal.ptyId)) {
+      return { ...terminal, visualTopologyState: 'detached' }
+    }
+    if (!surface.incarnationId || !terminal.incarnationId) {
+      return terminal
+    }
+    if (surface.incarnationId !== terminal.incarnationId) {
+      return { ...terminal, visualTopologyState: 'detached' }
+    }
+    return {
+      ...terminal,
+      visualTopologyState: projectedHandles.has(terminal.handle) ? 'projected' : 'detached'
+    }
+  })
+}
+
+export function getPtyBindings(
+  surface: RuntimeMobileSessionTerminalTab,
+  parentLayout: RuntimeMobileSessionTerminalTab['parentLayout'] = surface.parentLayout
+): string[] {
+  return [
+    surface.ptyId,
+    surface.parentLayout?.ptyIdsByLeafId?.[surface.leafId],
+    parentLayout?.ptyIdsByLeafId?.[surface.leafId]
+  ].filter((ptyId): ptyId is string => typeof ptyId === 'string' && ptyId.length > 0)
+}
+
+function collectProjectedHandles(
+  node: RuntimeTerminalVisualLayoutNode | RuntimeTerminalVisualPaneNode,
+  handles: Set<string>
+): void {
+  if (node.type === 'terminal') {
+    handles.add(node.handle)
+    return
+  }
+  if (node.type === 'group') {
+    for (const tab of node.tabs) {
+      collectProjectedHandles(tab.panes, handles)
+    }
+    return
+  }
+  collectProjectedHandles(node.first, handles)
+  collectProjectedHandles(node.second, handles)
+}

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -93,6 +93,42 @@ describe('PtyHandler', () => {
     expect(spawnOptions.env.PATH).toBe(expectedEnv.PATH)
   })
 
+  it('scrubs inherited pane identity from relay spawns', async () => {
+    const keys = [
+      'ORCA_PANE_KEY',
+      'ORCA_TAB_ID',
+      'ORCA_WORKTREE_ID',
+      'ORCA_TERMINAL_HANDLE',
+      'ORCA_AGENT_LAUNCH_TOKEN'
+    ] as const
+    const saved = new Map(keys.map((key) => [key, process.env[key]]))
+    Object.assign(process.env, {
+      ORCA_PANE_KEY: 'parent-tab:parent-leaf',
+      ORCA_TAB_ID: 'parent-tab',
+      ORCA_WORKTREE_ID: 'parent-worktree',
+      ORCA_TERMINAL_HANDLE: 'term-parent',
+      ORCA_AGENT_LAUNCH_TOKEN: 'launch-parent'
+    })
+    try {
+      await dispatcher.callRequest('pty.spawn', {})
+    } finally {
+      for (const [key, value] of saved) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+    const spawnCall = mockPtySpawn.mock.calls[0]
+    const env = (spawnCall?.[2] as { env: Record<string, string> } | undefined)?.env
+    expect(env).toBeDefined()
+    const spawnedEnv = env as Record<string, string>
+    for (const key of keys) {
+      expect(spawnedEnv[key]).toBeUndefined()
+    }
+  })
+
   describe('half-activated conda env (#14195)', () => {
     const CONDA_KEYS = [
       'CONDA_SHLVL',

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -4,6 +4,7 @@ import type * as NodePty from 'node-pty'
 import { existsSync } from 'node:fs'
 import { basename, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
+import { removeUnspecifiedPaneIdentityEnv } from '../shared/pane-identity-env'
 import { resolveWindowsGitBashShellPath } from '../main/git-bash'
 import { WINDOWS_GIT_BASH_SHELL } from '../shared/windows-terminal-shell'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
@@ -833,6 +834,8 @@ export class PtyHandler {
     // pane to another worktree's history file — and wrapping a zsh pane that
     // nothing asked to wrap, since `history` is selected on its presence.
     delete result.ORCA_HISTFILE
+    // Relay processes are often launched from an Orca pane; inherited identity names the parent.
+    removeUnspecifiedPaneIdentityEnv(result, rendererEnv)
     // Why: match local/daemon precedence so defaults/augmenters can't resurrect explicitly-removed values.
     for (const key of envToDelete) {
       delete result[key]

--- a/src/shared/pane-identity-env.ts
+++ b/src/shared/pane-identity-env.ts
@@ -1,0 +1,20 @@
+/** Identity Orca stamps into one PTY; inherited values name the parent process's pane. */
+export const PANE_IDENTITY_ENV_KEYS = [
+  'ORCA_PANE_KEY',
+  'ORCA_TAB_ID',
+  'ORCA_WORKTREE_ID',
+  'ORCA_TERMINAL_HANDLE',
+  'ORCA_AGENT_LAUNCH_TOKEN'
+] as const
+
+/** Drops identity not explicitly supplied for this spawn. */
+export function removeUnspecifiedPaneIdentityEnv(
+  env: Record<string, string>,
+  explicitEnv: Record<string, string> | undefined
+): void {
+  for (const key of PANE_IDENTITY_ENV_KEYS) {
+    if (!explicitEnv || !Object.hasOwn(explicitEnv, key)) {
+      delete env[key]
+    }
+  }
+}

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -33,6 +33,8 @@ export type RuntimeTerminalSummary = {
   exitCause?: TerminalExitCause
   /** Absent when the host predates the field or could not name the execution host. */
   executionHostId?: ExecutionHostId
+  /** Visual-layout membership; detached is live but not currently projected. */
+  visualTopologyState?: 'projected' | 'detached'
 }
 
 export type RuntimeTerminalVisualTerminalNode = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​251 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​62 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​189 |

<!-- /orca-pr-loc -->

## Summary

Fixes STA-6458 / #18201 by making live-but-unprojected terminals explicit and enforcing PTY identity at visual projection and child-spawn boundaries.

- Visual layouts now require persisted PTY binding and, when present, incarnation identity to match the live summary.
- `terminal.list` and `terminal.show` report optional `visualTopologyState: projected|detached`; detached remains live and writable.
- Daemon, local provider, and relay spawn/revive environments scrub inherited `ORCA_*` pane/worktree/tab/terminal/launch-token identity while preserving explicit child values.

## Reproduction and validation

Current main deterministically projected a replacement PTY through a stale persisted restart snapshot. The focused regression is `does not project a replacement PTY through a stale restart snapshot` in `src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts`.

Passed:

- `pnpm test src/main/runtime/orca-runtime.test.ts src/cli/format.test.ts src/cli/terminal-list-host-scope-format.test.ts`
- `pnpm test src/main/daemon/pty-subprocess-env-inheritance.test.ts src/main/providers/local-pty-provider-spawn-env.test.ts src/relay/pty-handler-spawn-environment.test.ts`
- `pnpm tc:node`
- `pnpm run check:code-quality:changed`

The paired/relay boundary was reviewed against existing PR #18171 and relay/daemon provider contracts; no production or Linear state was changed.

## Review notes

This is intentionally additive and optional for mixed-version clients/hosts. No renderer state wiring, polling, transport opcode, path, shortcut, Git, or SSH execution semantics were added. A `show` response computes the same topology annotation as `list` from the authoritative runtime snapshot.
