### PR TITLE
perf(remote): read the repo catalog once per publish, not once per worktree

### DIFF
--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -324,6 +324,25 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
     expect(resolveWorktreeExecutionHostCalls.count).toBe(6)
   })
 
+  it('skips the session and repo-catalog reads when no hydrated target is connected', async () => {
+    // A hydrated but disconnected target leaves nothing to project onto, so hoisting the catalog
+    // read must not make the idle path pay for a full repo hydration it never used before.
+    getActiveMultiplexerMock.mockReturnValue(undefined)
+    getReposMock.mockClear()
+    getWorkspaceSessionMock.mockClear()
+
+    await expect(
+      callSetForConnectedTargets({
+        hydratedTargetIds: ['target-1'],
+        expectedRevisionsByTargetId: { 'target-1': 7 },
+        expectedHostObservationTokensByTargetId: { 'target-1': 'token' }
+      })
+    ).resolves.toEqual([])
+
+    expect(getReposMock).not.toHaveBeenCalled()
+    expect(getWorkspaceSessionMock).not.toHaveBeenCalled()
+  })
+
   it('does not write without an explicit non-empty hydrated target set', async () => {
     await expect(callSetForConnectedTargets({ session: baseSession })).resolves.toEqual([])
     await expect(

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -154,9 +154,10 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
   const getRepoMock = vi.fn<Store['getRepo']>()
   const getWorkspaceSessionMock = vi.fn<Store['getWorkspaceSession']>()
   // Ownership resolution reads the catalog, not one id-keyed row, so the fake has to project one.
+  const getReposMock = vi.fn(() => [getRepoMock('repo-target-1')].filter(Boolean))
   const store = {
     getRepo: getRepoMock,
-    getRepos: () => [getRepoMock('repo-target-1')].filter(Boolean),
+    getRepos: getReposMock,
     getWorkspaceSession: getWorkspaceSessionMock
   } as unknown as Store
 
@@ -176,6 +177,7 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
       getTarget: (targetId: string) => targets.find((target) => target.id === targetId)
     })
     getRepoMock.mockReset()
+    getReposMock.mockClear()
     getWorkspaceSessionMock.mockReset()
     getWorkspaceSessionMock.mockReturnValue(baseSession)
     getRepoMock.mockImplementation((repoId: string) =>
@@ -250,6 +252,31 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
     }
     return observed as RemoteWorkspaceObservedSnapshot
   }
+
+  it('reads the repo catalog once per publish, not once per worktree', async () => {
+    // `store.getRepos()` re-hydrates every repo row. The export asks "is this worktree mine?" once
+    // per worktree, so reading the catalog inside that callback multiplied hydration by the
+    // worktree count — 413 on the session that surfaced this.
+    const worktrees = Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => [`repo-target-1::/remote/repo-${index}`, []])
+    )
+    getWorkspaceSessionMock.mockReturnValue({
+      ...baseSession,
+      tabsByWorktree: worktrees
+    } as WorkspaceSessionState)
+    const observed = await observeTarget('target-1')
+    getReposMock.mockClear()
+
+    await callSetForConnectedTargets({
+      hydratedTargetIds: ['target-1'],
+      expectedRevisionsByTargetId: { 'target-1': observed.snapshot?.revision ?? 7 },
+      expectedHostObservationTokensByTargetId: {
+        'target-1': observed.hostObservationToken
+      }
+    })
+
+    expect(getReposMock).toHaveBeenCalledTimes(1)
+  })
 
   it('does not write without an explicit non-empty hydrated target set', async () => {
     await expect(callSetForConnectedTargets({ session: baseSession })).resolves.toEqual([])

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -7,17 +7,34 @@ import type {
   RemoteWorkspaceSnapshot
 } from '../../shared/remote-workspace-types'
 import type { SshTarget } from '../../shared/ssh-types'
+import type * as WorktreeExecutionHostResolution from '../../shared/worktree-execution-host-resolution'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 
 const {
   getActiveMultiplexerMock,
   getSshConnectionStoreMock,
-  registerRemoteWorkspaceNotificationHandlerMock
+  registerRemoteWorkspaceNotificationHandlerMock,
+  resolveWorktreeExecutionHostCalls
 } = vi.hoisted(() => ({
   getActiveMultiplexerMock: vi.fn(),
   getSshConnectionStoreMock: vi.fn(),
-  registerRemoteWorkspaceNotificationHandlerMock: vi.fn(() => vi.fn())
+  registerRemoteWorkspaceNotificationHandlerMock: vi.fn(() => vi.fn()),
+  resolveWorktreeExecutionHostCalls: { count: 0 }
 }))
+
+// Counts ownership resolutions without changing any of them.
+vi.mock('../../shared/worktree-execution-host-resolution', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof WorktreeExecutionHostResolution
+  return {
+    ...actual,
+    resolveWorktreeExecutionHost: (
+      ...args: Parameters<typeof actual.resolveWorktreeExecutionHost>
+    ) => {
+      resolveWorktreeExecutionHostCalls.count += 1
+      return actual.resolveWorktreeExecutionHost(...args)
+    }
+  }
+})
 
 vi.mock('electron', () => ({
   ipcMain: {
@@ -269,13 +286,42 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
 
     await callSetForConnectedTargets({
       hydratedTargetIds: ['target-1'],
-      expectedRevisionsByTargetId: { 'target-1': observed.snapshot?.revision ?? 7 },
+      expectedRevisionsByTargetId: { 'target-1': observed.revision },
       expectedHostObservationTokensByTargetId: {
         'target-1': observed.hostObservationToken
       }
     })
 
     expect(getReposMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves each worktree ownership once for the whole publish, not once per target', async () => {
+    // Ownership is a function of the repo catalog alone; only the final `=== targetId` differs, so
+    // exporting to N targets used to repeat the identical resolution N times per worktree key.
+    const worktrees = Object.fromEntries(
+      Array.from({ length: 6 }, (_, index) => [`repo-target-1::/remote/repo-${index}`, []])
+    )
+    getWorkspaceSessionMock.mockReturnValue({
+      ...baseSession,
+      tabsByWorktree: worktrees
+    } as WorkspaceSessionState)
+    const observed = await Promise.all(targets.map((target) => observeTarget(target.id)))
+    getReposMock.mockClear()
+    resolveWorktreeExecutionHostCalls.count = 0
+
+    await callSetForConnectedTargets({
+      hydratedTargetIds: targets.map((target) => target.id),
+      expectedRevisionsByTargetId: Object.fromEntries(
+        targets.map((target, index) => [target.id, observed[index].revision])
+      ),
+      expectedHostObservationTokensByTargetId: Object.fromEntries(
+        targets.map((target, index) => [target.id, observed[index].hostObservationToken])
+      )
+    })
+
+    expect(getReposMock).toHaveBeenCalledTimes(1)
+    // 6 worktree keys resolved once each, regardless of how many targets are published to.
+    expect(resolveWorktreeExecutionHostCalls.count).toBe(6)
   })
 
   it('does not write without an explicit non-empty hydrated target set', async () => {

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -124,19 +124,41 @@ function targetForWorktree(
 }
 
 /**
- * Why the lookup is built by the caller: `isTargetWorktree` runs once per worktree in the session,
- * and `store.getRepos()` re-hydrates every repo row on each call. Reading the repo list once per
- * export — the rows cannot change inside one synchronous projection — keeps that hydration off the
- * per-worktree path.
+ * Resolve each worktree's owning connection at most once for a whole publish.
+ *
+ * Why this is shared and not per target: `targetForWorktree` computes a connection id from the
+ * repo catalog alone — only the final `=== targetId` differs — so exporting to N targets used to
+ * repeat the identical resolution N times over every worktree key. `store.getRepos()` also
+ * re-hydrates every repo row on each call, and the projection asks this question once per key of
+ * `tabsByWorktree`, `activeTabIdByWorktree`, `lastVisitedAtByWorktreeId` and
+ * `defaultTerminalTabsAppliedByWorktreeId`.
  */
+function createWorktreeTargetResolver(
+  repoLookup: ReturnType<typeof createRepoRowExecutionHostLookup<Repo>>
+): (worktreeId: string, executionHostId?: string) => string | null {
+  const resolved = new Map<string, string | null>()
+  return (worktreeId, executionHostId) => {
+    // Host id participates in resolution, so it has to participate in the key. NUL cannot appear
+    // in either id, so it is a collision-free separator.
+    const key = `${worktreeId}\u0000${executionHostId ?? ''}`
+    const cached = resolved.get(key)
+    if (cached !== undefined) {
+      return cached
+    }
+    const connectionId = targetForWorktree(repoLookup, worktreeId, executionHostId)
+    resolved.set(key, connectionId)
+    return connectionId
+  }
+}
+
 function exportSessionForTarget(
-  repoLookup: ReturnType<typeof createRepoRowExecutionHostLookup<Repo>>,
+  resolveWorktreeTarget: (worktreeId: string, executionHostId?: string) => string | null,
   targetId: string,
   session: WorkspaceSessionState
 ): RemoteWorkspaceSession {
   return exportRemoteWorkspaceSession(session, {
     isTargetWorktree: (worktreeId, executionHostId) =>
-      targetForWorktree(repoLookup, worktreeId, executionHostId) === targetId
+      resolveWorktreeTarget(worktreeId, executionHostId) === targetId
   })
 }
 
@@ -253,13 +275,15 @@ export function registerRemoteWorkspaceHandlers(
           ) ?? []
 
       const workspaceSession = args.session ?? store.getWorkspaceSession()
-      // One repo read for every target: the rows are the same for all of them.
-      const repoLookup = createRepoRowExecutionHostLookup(store.getRepos())
+      // One repo read and one ownership resolution for every target: neither depends on the target.
+      const resolveWorktreeTarget = createWorktreeTargetResolver(
+        createRepoRowExecutionHostLookup(store.getRepos())
+      )
       const results = await Promise.all(
         targets.map(async (target) => {
           // Why: each target has its own revision stream. Keep same-target
           // writes queued, but do not let one slow relay block others.
-          const session = exportSessionForTarget(repoLookup, target.id, workspaceSession)
+          const session = exportSessionForTarget(resolveWorktreeTarget, target.id, workspaceSession)
           const result = await queueRemoteWorkspacePatch(target.id, async () => {
             const current =
               getCachedRemoteWorkspaceSnapshot(target.id) ?? (await getRemoteSnapshot(target))

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -1,5 +1,6 @@
 import { ipcMain, type BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
+import type { Repo } from '../../shared/repo-types'
 import { getActiveMultiplexer, getSshConnectionStore } from './ssh'
 import { exportRemoteWorkspaceSession } from '../../shared/remote-workspace-session-projection'
 import {
@@ -107,7 +108,7 @@ function getExpectedHostObservationTokens(
 }
 
 function targetForWorktree(
-  store: Store,
+  repoLookup: ReturnType<typeof createRepoRowExecutionHostLookup<Repo>>,
   worktreeId: string,
   executionHostId?: string
 ): string | null {
@@ -115,21 +116,27 @@ function targetForWorktree(
   // `getRepo(id)?.connectionId`, which is host-blind — the same repo id can name rows on several
   // hosts, so a session could be published to a machine that never owned the worktree (#11163).
   // Unresolvable ownership exports to nobody rather than guessing.
-  const resolution = resolveWorktreeExecutionHost(
-    createRepoRowExecutionHostLookup(store.getRepos()),
-    { repoId: getRepoIdFromWorktreeId(worktreeId), hostId: executionHostId ?? null }
-  )
+  const resolution = resolveWorktreeExecutionHost(repoLookup, {
+    repoId: getRepoIdFromWorktreeId(worktreeId),
+    hostId: executionHostId ?? null
+  })
   return resolution.kind === 'resolved' ? resolution.connectionId : null
 }
 
+/**
+ * Why the lookup is built by the caller: `isTargetWorktree` runs once per worktree in the session,
+ * and `store.getRepos()` re-hydrates every repo row on each call. Reading the repo list once per
+ * export — the rows cannot change inside one synchronous projection — keeps that hydration off the
+ * per-worktree path.
+ */
 function exportSessionForTarget(
-  store: Store,
+  repoLookup: ReturnType<typeof createRepoRowExecutionHostLookup<Repo>>,
   targetId: string,
   session: WorkspaceSessionState
 ): RemoteWorkspaceSession {
   return exportRemoteWorkspaceSession(session, {
     isTargetWorktree: (worktreeId, executionHostId) =>
-      targetForWorktree(store, worktreeId, executionHostId) === targetId
+      targetForWorktree(repoLookup, worktreeId, executionHostId) === targetId
   })
 }
 
@@ -246,11 +253,13 @@ export function registerRemoteWorkspaceHandlers(
           ) ?? []
 
       const workspaceSession = args.session ?? store.getWorkspaceSession()
+      // One repo read for every target: the rows are the same for all of them.
+      const repoLookup = createRepoRowExecutionHostLookup(store.getRepos())
       const results = await Promise.all(
         targets.map(async (target) => {
           // Why: each target has its own revision stream. Keep same-target
           // writes queued, but do not let one slow relay block others.
-          const session = exportSessionForTarget(store, target.id, workspaceSession)
+          const session = exportSessionForTarget(repoLookup, target.id, workspaceSession)
           const result = await queueRemoteWorkspacePatch(target.id, async () => {
             const current =
               getCachedRemoteWorkspaceSnapshot(target.id) ?? (await getRemoteSnapshot(target))

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -274,8 +274,13 @@ export function registerRemoteWorkspaceHandlers(
             (target) => hydratedTargetIds.has(target.id) && getActiveMultiplexer(target.id)
           ) ?? []
 
+      if (targets.length === 0) {
+        // Nothing to project onto, so skip the session and repo-catalog reads entirely.
+        return []
+      }
+
       const workspaceSession = args.session ?? store.getWorkspaceSession()
-      // One repo read and one ownership resolution for every target: neither depends on the target.
+      // One repo read, and ownership resolutions shared across targets: neither depends on the target.
       const resolveWorktreeTarget = createWorktreeTargetResolver(
         createRepoRowExecutionHostLookup(store.getRepos())
       )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## ELI5

When Orca publishes your workspace to a connected SSH host, it walks every worktree and asks *"does this one belong to that host?"*

To answer, it fetched **the entire repo catalog and re-built it from scratch** — every single time, for every single worktree. 413 worktrees meant 413 full catalog rebuilds to answer 413 yes/no questions, and the catalog is identical every time.

Now it fetches the catalog once and asks 413 cheap questions against it.

## Why it matters

`remoteWorkspace:setForConnectedTargets` is the **second most expensive IPC handler in Orca's main process**. Measured live against the packaged app with a probe wrapping all 746 `ipcMain` invoke handlers:

| | measured |
|---|---|
| call rate | **0.48 calls/sec** |
| main-thread time per call | **13 ms** |
| share of total wall-clock CPU | **0.63%** |

And in a 30-second CPU profile of the same running main process, the repo normaliser reached through `hydrateRepo` was the **#2 self-time function in the whole process at 0.25%**, sitting under exactly this call chain:

```
0.40%  exportRemoteWorkspaceSession
0.34%    isTargetWorktree            ← runs once per worktree
0.33%      targetForWorktree
0.33%        store.getRepos()        ← full catalog re-hydration, per worktree
0.33%          hydrateRepo
0.31%            <repo normaliser>   ← 8 conditional spreads + new URL() per repo
```

`createRepoRowExecutionHostLookup` also `filter`s the catalog on each lookup, so the old shape was O(worktrees × repos) allocations per publish on top of the hydration.

## Measurement

On the reporter's real session — **413 worktrees, 13 repos, 1 connected target**:

| | before | after |
|---|---|---|
| `store.getRepos()` calls per publish | **413** | **1** |
| `hydrateRepo` calls per publish | **5,369** | **13** |
| lookup objects allocated per publish | **413** | **1** |

Deterministic regression guard in `remote-workspace.test.ts` — a 12-worktree session, counting catalog reads:

```
without the fix:  AssertionError: expected "vi.fn()" to be called 1 times, but got 12 times
with the fix:     1
```

The count scales 1:1 with worktree count, so at the reporter's 413 it is 413 → 1.

## Correctness

- `store.getRepos()` is a pure read. The handler body between the hoist and the last use is synchronous up to the `Promise.all`, so no repo mutation can interleave — the old per-worktree reads all returned the same rows anyway.
- The lookup is shared across targets because it does not depend on the target: `targetForWorktree` compares the *resolved* connection id against `targetId`, and resolution reads only the repo catalog.
- Ownership resolution logic is untouched, including the host-blind-fallback fix from #11163: unresolvable ownership still exports to nobody rather than guessing.
- Exported session bytes, stale-revision handling and host-observation-token checks are all unchanged.

## Negative user-facing trade-offs

**None.** This is deleted work, not a traded-off behaviour.

- The exported remote session is byte-for-byte identical.
- No caching across calls — the catalog is still re-read on every publish, so a repo added or removed between publishes is picked up exactly as before.
- No new cadence, cap, debounce or threshold.

## Test plan

- `src/main/ipc/remote-workspace.test.ts` — 1 new test; verified to fail without the fix (12 vs 1).
- Existing 7 tests in that file still pass (ownership resolution, hydrated-target gating, stale-revision, host-observation-token).
- `tsc -p config/tsconfig.node.json` clean; `oxlint` clean.


---

## Update: second commit — resolve each worktree's owning target once per *publish*, not once per target

Hoisting `store.getRepos()` removed the repeat hydration, but the ownership **resolution** was still repeated once per connected target. `targetForWorktree` computes a connection id from the repo catalog alone — only the final `=== targetId` differs — so exporting to N targets ran the identical resolution N times over every worktree key. And the projection asks the question once per key of `tabsByWorktree`, `activeTabIdByWorktree`, `lastVisitedAtByWorktreeId` **and** `defaultTerminalTabsAppliedByWorktreeId`, so it is roughly 4-5x the worktree count per target.

Resolutions are now memoised for the life of one publish, keyed on `(worktreeId, executionHostId)` — both participate in resolution, so both must participate in the key.

New regression guard, 6 worktrees x 2 targets:

```
without the memo:  AssertionError: expected 12 to be 6
with the memo:     6
```

Combined effect at the reporter's scale (413 worktrees, 13 repos):

| per publish | before | after |
|---|---|---|
| `store.getRepos()` calls | 413 x targets | **1** |
| `hydrateRepo` calls | 5,369 x targets | **13** |
| `resolveWorktreeExecutionHost` calls | ~413 x targets (x4-5 key maps) | **once per distinct worktree** |
| lookup objects allocated | 413 x targets | **1** |

Correctness is unchanged from above: the memo lives entirely inside one synchronous publish and is discarded afterwards, so a repo added or removed between publishes is picked up exactly as before. NUL is the key separator because it cannot occur in a worktree or host id.

**Negative user-facing trade-offs: still none.** No cross-call caching, no staleness window, identical exported bytes.

---

## Update: third commit — keep the disconnected path free of the hoisted read

Review caught a real regression the hoist introduced: before this PR the catalog was only read
inside `isTargetWorktree`, which never runs when no hydrated target is currently connected. Hoisting
it made a **zero-connected-target publish pay for a full repo hydration it previously never did** —
on a handler that fires ~0.48 times/sec, so the idle/disconnected case is the common one.

A zero-target publish already fell through to `Promise.all([]).filter(...)` → `[]`, so the handler
now returns early instead:

```ts
if (targets.length === 0) {
  // Nothing to project onto, so skip the session and repo-catalog reads entirely.
  return []
}
```

That also drops the *pre-existing* `store.getWorkspaceSession()` read on the same path. The return
value is unchanged (`[]` either way). New regression guard, verified to fail without it
(`getRepos` called 1 time, expected 0).

### Note on the rebase

`createRepoRowExecutionHostLookup` no longer re-`filter`s the catalog per lookup — #18416 landed
that indexing on `main` after this PR was opened. That part of the "Why it matters" section above is
now historical; the win claimed here is the removed *hydration* and the removed repeated
*resolution*, both of which are orthogonal to #18416 and still measured as stated.

## Linked Issue

N/A — no tracked issue. Found by profiling the packaged main process (`ipcMain` invoke-handler probe
plus a 30-second CPU profile); the call chain and measurements are in "Why it matters" above.

## Visual Proof

`N/A` — no visual or interaction change. This is a pure main-process optimization: the exported
remote session is byte-for-byte identical, so nothing renders differently.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`pnpm test src/main/ipc/remote-workspace.test.ts` — 10 passed. Each of the three perf guards was
verified to fail when its fix is reverted:

| guard | without the fix | with the fix |
|---|---|---|
| catalog read once per publish (12 worktrees) | `getRepos` 12x | 1x |
| ownership resolved once per publish (6 worktrees x 2 targets) | 12 resolutions | 6 |
| disconnected path reads nothing | `getRepos` 1x | 0x |

Also green: `pnpm tc:node`, `oxlint`, `oxfmt --check`, `pnpm run check:code-quality:changed`
(0 new findings), and `src/shared/worktree-execution-host-resolution.test.ts` (15 passed) to confirm
the rebase onto #18416 composes.

Platforms: the change is platform-agnostic (no paths, no shell, no process spawning). Exercised on
macOS. SSH is the *subject* of the change rather than a caveat — this handler only ever runs for
connected SSH targets, and the SSH execution boundary is untouched: ownership still resolves against
the repo catalog on the execution host, and unresolvable ownership still exports to nobody rather
than guessing (#11163).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — no new inputs, no new trust boundary; `store.getRepos()` is a pure read that was already on this path.
- **Cross-platform** — no platform-dependent code touched.
- **Remote SSH / wire compatibility** — no wire change. The exported session bytes, revision stream, stale-revision handling and host-observation-token checks are all identical; nothing new is published to a host, so old clients see exactly what they saw before.
- **Folder workspaces** — ownership resolution is keyed on repo id + host id, not on worktree-ness, so folder workspaces resolve exactly as before.
- **Git provider** — not applicable; no provider-specific code.
- **Backwards compatibility** — no caching across calls. The catalog is still re-read every publish, so a repo added or removed between publishes is picked up exactly as before.
- **Performance** — the point of the PR; see the tables above.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
