### PR TITLE
fix(ssh): measure pane idleness in the unit the sweep's kill operates on

### DIFF
--- a/docs/reference/ssh-execution-boundary.md
+++ b/docs/reference/ssh-execution-boundary.md
@@ -70,6 +70,21 @@ A verdict needs evidence from the host that owns the process. Apply these tests 
 
 Anything short of positive host evidence is `unverifiable`. Reporting it as `exited` is the error this document exists to prevent: it orphans live work and can cold-start a duplicate over the same worktree.
 
+## Deciding a remote pane is idle
+
+The orphan-PTY sweep is the one flow that turns an observation into a SIGKILL, so its idleness evidence has to be measured against the same thing the signal reaches. It is not the terminal.
+
+`forceKillPosixPtyProcessGroups` (`src/main/pty/posix-pty-process-groups.ts`) collects every process group on the pane's tty and `killpg`s each one. The blast radius is therefore _(process groups on the tty) × (members of those groups, wherever they are)_, and the second factor is not bounded by the terminal at all. Two facts make that gap reachable:
+
+- **Job control can be off.** With `set +m` a background job does not get its own process group — it keeps the shell's. `ps` then shows one process group on the tty, running a build. Nothing in a tty-shaped predicate can see it.
+- **A group member can leave the terminal.** `ioctl(TIOCNOTTY)` without `setsid` drops the controlling terminal but keeps the pgid, so the process reports `tpgid == -1`, never appears in `ps -t <tty>`, and is still killed by `killpg(shellPgid)`. A double-forked grandchild similarly keeps the pgid while reparenting to pid 1, so no walk by `ppid` from the PTY root can name it either.
+
+So `shellOwnsEveryTtyProcessGroup` (`src/main/providers/agent-foreground-process-batch.ts`) requires both measurements: every process group on the tty is the shell's own with none stopped, **and** the shell's own process group has no other member anywhere in the host's process table. The name is tty-shaped for wire-compatibility reasons only.
+
+Two residuals remain, and neither is removable here. The capture is a snapshot, so work started between the `ps` and the signal is invisible — bounded by `RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS` on the reading side, not eliminated. And a process the host's own `ps` cannot enumerate (another PID namespace, `hidepid=2`, a table truncated by a permission boundary) is unobservable while `killpg` still reaches it.
+
+The general rule this instantiates: **evidence must be measured in the unit the destructive action operates on.** Evidence in a different unit is `unverifiable` no matter how precise it looks.
+
 ## Reading artifacts instead of process state
 
 Artifacts are stronger evidence than liveness signals, but they answer a narrower question than they appear to.

--- a/src/main/providers/agent-foreground-process-batch.ts
+++ b/src/main/providers/agent-foreground-process-batch.ts
@@ -29,7 +29,10 @@ export type BatchedForegroundProcessResult = {
   processName: string | null
   reason?: string
   /** Set only when the table was readable: every process group attached to this PTY's terminal is
-   *  the shell's own, and none of them is stopped. Left absent when we could not observe it. */
+   *  the shell's own, none of them is stopped, AND that group's only member is the shell itself.
+   *  Left absent when we could not observe it. Keeps the tty-shaped name because it is on the wire
+   *  (`ForegroundProcessEvidence`); the value only ever got stricter, so an old client reading it
+   *  skips more, never less. */
   shellOwnsEveryTtyProcessGroup?: boolean
 }
 
@@ -62,30 +65,45 @@ export type BatchedForegroundProcessOptions = {
   stats?: ProcessTableIndexStats
 }
 
-/** Which process groups occupy each controlling terminal, and which terminals hold a stopped
- *  process. */
-type TtyOccupancy = {
+/** The two units a forced stop can reach, indexed from one capture: which process groups occupy
+ *  each controlling terminal (which terminals hold a stopped process), and how many rows belong to
+ *  each process group anywhere on the host. */
+type PaneOccupancy = {
   processGroupsByTty: ReadonlyMap<number, ReadonlySet<number>>
   stoppedTtys: ReadonlySet<number>
+  /** Rows per `pgid`, counted over the WHOLE table with no tty filter — that is the point of it.
+   *  A member that shares the shell's group but has no controlling terminal is reachable by
+   *  `killpg` and invisible to every tty-shaped index. */
+  rowsByProcessGroup: ReadonlyMap<number, number>
+  /** True when some row carried no `pgid`, so the group counts are incomplete and cannot support
+   *  an idleness claim. */
+  processGroupsIncomplete: boolean
 }
 
-const ttyOccupancyByCapture = new WeakMap<readonly ProcessTableRow[], TtyOccupancy>()
+const paneOccupancyByCapture = new WeakMap<readonly ProcessTableRow[], PaneOccupancy>()
 
-/** Index the capture by controlling terminal.
+/** Index the capture by controlling terminal and by process group.
  *
- *  Keyed on `tpgid` because the snapshot carries no tty column and does not need one: a process
- *  group belongs to exactly one session, a session to at most one controlling terminal, so two
- *  rows reporting the same live `tpgid` are on the same tty. Memoized per capture, since the
- *  per-pane cadence poll and `pty.listProcesses` share one TTL-cached table. */
-function getTtyOccupancy(rows: readonly ProcessTableRow[]): TtyOccupancy {
-  const cached = ttyOccupancyByCapture.get(rows)
+ *  The tty half is keyed on `tpgid` because the snapshot carries no tty column and does not need
+ *  one: a process group belongs to exactly one session, a session to at most one controlling
+ *  terminal, so two rows reporting the same live `tpgid` are on the same tty. Memoized per capture,
+ *  since the per-pane cadence poll and `pty.listProcesses` share one TTL-cached table. */
+function getPaneOccupancy(rows: readonly ProcessTableRow[]): PaneOccupancy {
+  const cached = paneOccupancyByCapture.get(rows)
   if (cached) {
     return cached
   }
   const processGroupsByTty = new Map<number, Set<number>>()
   const stoppedTtys = new Set<number>()
+  const rowsByProcessGroup = new Map<number, number>()
+  let processGroupsIncomplete = false
   for (const row of rows) {
-    if (row.pgid === undefined || row.tpgid === undefined || row.tpgid <= 0) {
+    if (row.pgid === undefined) {
+      processGroupsIncomplete = true
+      continue
+    }
+    rowsByProcessGroup.set(row.pgid, (rowsByProcessGroup.get(row.pgid) ?? 0) + 1)
+    if (row.tpgid === undefined || row.tpgid <= 0) {
       continue
     }
     let groups = processGroupsByTty.get(row.tpgid)
@@ -99,8 +117,13 @@ function getTtyOccupancy(rows: readonly ProcessTableRow[]): TtyOccupancy {
       stoppedTtys.add(row.tpgid)
     }
   }
-  const occupancy: TtyOccupancy = { processGroupsByTty, stoppedTtys }
-  ttyOccupancyByCapture.set(rows, occupancy)
+  const occupancy: PaneOccupancy = {
+    processGroupsByTty,
+    stoppedTtys,
+    rowsByProcessGroup,
+    processGroupsIncomplete
+  }
+  paneOccupancyByCapture.set(rows, occupancy)
   return occupancy
 }
 
@@ -161,7 +184,7 @@ export function resolveAgentForegroundProcessesFromIndex(
     }
   }
 
-  const occupancy = getTtyOccupancy(index.rows)
+  const occupancy = getPaneOccupancy(index.rows)
   return requests.map((request) => {
     const root = lookupProcessTableIndex(index, (value) => value.byPid.get(request.rootPid))
     if (!root) {
@@ -185,20 +208,40 @@ export function resolveAgentForegroundProcessesFromIndex(
         reason: 'no_controlling_tty'
       }
     }
-    // The only host-observable "nothing is running here" signal, and it has to be read off the
-    // whole tty rather than off `tpgid === pgid`. A backgrounded `pnpm build &` and a Ctrl-Z'd
-    // editor both leave the shell owning the foreground group, byte-identical to an idle prompt;
-    // what separates them is a second process group attached to the pane's terminal. That is also
-    // exactly the blast radius of the stop this attests to — `forceKillPosixPtyProcessGroups`
-    // SIGKILLs every process group on the tty — so the evidence and the kill now measure the same
-    // thing. A reader may treat `false` as "busy" and must never treat absence as "idle".
+    // The only host-observable "nothing is running here" signal, and it takes TWO measurements
+    // because the stop it authorizes has two units. `forceKillPosixPtyProcessGroups` collects every
+    // process group on the pane's tty and then `killpg`s each one, so the blast radius is
+    // (groups on the tty) x (members of those groups, wherever they are). Neither half implies the
+    // other, so both are required:
+    //
+    //   tty:   a backgrounded `pnpm build &` and a Ctrl-Z'd editor both hand the terminal back, so
+    //          the shell's row is byte-identical to an idle prompt. What separates them is a second
+    //          process group attached to the pane's terminal.
+    //   group: with job control off (`set +m`, common in non-interactive and dumb-terminal shells,
+    //          and settable by the user at the prompt) a background job KEEPS the shell's pgid, so
+    //          the tty shows one group and that group is running a build. Same for a child that
+    //          drops the controlling terminal without `setsid` (`tpgid == -1`, absent from every
+    //          tty index, still reachable by `killpg`) and for a double-forked grandchild that
+    //          reparents to pid 1 and so never appears in the ppid walk below.
+    //
+    // Residual after both, written down because the predicate cannot see it: the capture is a
+    // snapshot, so work started between the `ps` and the signal is invisible — bounded, not
+    // removed, by RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS on the reading side; and a process the host's
+    // own `ps` cannot enumerate (another PID namespace, `hidepid=2`, a table truncated by a
+    // permission boundary) is unobservable here while `killpg` still reaches it.
+    //
+    // A reader may treat `false` as "busy" and must never treat absence as "idle".
     const ttyProcessGroups = occupancy.processGroupsByTty.get(root.tpgid)
     const shellOwnsEveryTtyProcessGroup =
       root.tpgid === root.pgid &&
       ttyProcessGroups !== undefined &&
       ttyProcessGroups.size === 1 &&
       ttyProcessGroups.has(root.pgid) &&
-      !occupancy.stoppedTtys.has(root.tpgid)
+      !occupancy.stoppedTtys.has(root.tpgid) &&
+      !occupancy.processGroupsIncomplete &&
+      // The root always counts itself, so exactly one row in its group means the group IS the
+      // shell — no separate leader check, and no set of pids retained per capture.
+      occupancy.rowsByProcessGroup.get(root.pgid) === 1
     const allCandidates = rowsByOwner.get(root.pid) ?? []
     const foregroundCandidates = allCandidates.filter((row) => row.pgid === root.tpgid)
     const fallbackProcess = request.fallbackProcess

--- a/src/main/ssh/ssh-orphan-sweep-pane-state-verdicts.test.ts
+++ b/src/main/ssh/ssh-orphan-sweep-pane-state-verdicts.test.ts
@@ -68,6 +68,44 @@ const CAPTURES = {
       ' 3159  3158  3159  3158 T    sleep 300',
       ' 3160     1     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
     ]
+  },
+  /** `set +m; sleep 300 &`. With job control OFF the job does not get its own process group — it
+   *  keeps the SHELL's pgid. So the tty carries exactly one process group, and that group is
+   *  running a build. Reproduced independently on a real Ubuntu host through an Orca pane. */
+  setMinusMBackground: {
+    rootPid: 12,
+    table: [
+      '    1     0     1    -1 Ss   /bin/bash /work/run.sh',
+      '   11     1     1    -1 S    python3 /work/pty-scenario.py setm_background',
+      '   12    11    12    12 Ss+  bash -i',
+      '   13    12    12    12 S+   sleep 300',
+      '   14    11     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
+  },
+  /** A `set +m` job that drops its controlling terminal (`ioctl(TIOCNOTTY)` with no `setsid`). It
+   *  keeps the shell's pgid, reports `tpgid == -1`, and is absent from `ps -t <tty>` and from every
+   *  tty-keyed index — while `killpg(shellPgid)` still reaches it. */
+  nottyGroupMember: {
+    rootPid: 16,
+    table: [
+      '    1     0     1    -1 Ss   /bin/bash /work/run.sh',
+      '   15     1     1    -1 S    python3 /work/pty-scenario.py notty_member',
+      '   16    15    16    16 Ss+  bash -i',
+      '   17    16    16    -1 S    python3 -c import fcntl,os,time;fd=os.open("/dev/tty",os.O_RDWR);fcntl.ioctl(fd,0x5422);os.close(fd);time.sleep(300)',
+      '   18    15     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
+  },
+  /** A `set +m` job that double-forks. pid 22 keeps the shell's pgid and tty but reparented to pid
+   *  1, so the ppid walk from `rootPid` never reaches it and it can never be named. */
+  doubleForkedGroupMember: {
+    rootPid: 20,
+    table: [
+      '    1     0     1    -1 Ss   /bin/bash /work/run.sh',
+      '   19     1     1    -1 S    python3 /work/pty-scenario.py double_fork',
+      '   20    19    20    20 Ss+  bash -i',
+      '   22     1    20    20 S+   python3 -c import os,sys,time;p=os.fork() if p:     print("GRANDCHILD:%d"%p);sys.stdout.flush();os._exit(0) time.sleep(300)',
+      '   23    19     1    -1 R    ps -axo pid=,ppid=,pgid=,tpgid=,stat=,command='
+    ]
   }
 } as const
 
@@ -147,6 +185,15 @@ describe('what the host publishes about a pane, read by the sweep', () => {
     expect(shellShape(CAPTURES.background)).toBe(shellShape(CAPTURES.idle))
     expect(shellShape(CAPTURES.ctrlz)).toBe(shellShape(CAPTURES.idle))
     expect(shellShape(CAPTURES.foreground)).not.toBe(shellShape(CAPTURES.idle))
+
+    // Same premise for the `set +m` captures, minus `ppid`: their harness keeps its parent alive
+    // rather than reparenting the shell to init, and the ppid is the one field of the shape the
+    // predicate never reads.
+    const paneShape = (capture: { rootPid: number; table: readonly string[] }): string =>
+      shellShape(capture).split(' ').slice(1).join(' ')
+    expect(paneShape(CAPTURES.setMinusMBackground)).toBe(paneShape(CAPTURES.idle))
+    expect(paneShape(CAPTURES.nottyGroupMember)).toBe(paneShape(CAPTURES.idle))
+    expect(paneShape(CAPTURES.doubleForkedGroupMember)).toBe(paneShape(CAPTURES.idle))
   })
 
   it('sweeps an idle shell', async () => {
@@ -187,6 +234,58 @@ describe('what the host publishes about a pane, read by the sweep', () => {
     expect(evidence).toMatchObject({ shellOwnsEveryTtyProcessGroup: false })
 
     const plan = await planFor(CAPTURES.ctrlz)
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host does not attest an idle shell')
+  })
+
+  // The tty is not the unit the stop operates on. `forceKillPosixPtyProcessGroups` collects the
+  // groups on the tty and then `killpg`s each one, so anything sharing the shell's pgid dies with
+  // it — including members the tty index cannot see at all. All three captures below reproduce on
+  // real Linux: before the group-membership half of the predicate they published
+  // `shellOwnsEveryTtyProcessGroup: true`, planned a SWEEP, and the planted pid was GONE after the
+  // real `forceKillPosixPtyProcessGroups` call.
+  it('never sweeps a pane whose background job shares the shell pgid under `set +m`', async () => {
+    // pid 13 is `sleep 300` — stand in `pnpm build`. Its pgid IS the shell's, so the tty carries
+    // exactly one process group and the tty half of the predicate reads the pane as idle.
+    const rows = parseStrictProcessTableRows(CAPTURES.setMinusMBackground.table.join('\n'))
+    const tty = rows.filter((row) => row.tpgid === CAPTURES.setMinusMBackground.rootPid)
+    expect(new Set(tty.map((row) => row.pgid))).toEqual(new Set([12]))
+    expect(tty.map((row) => row.pid)).toEqual([12, 13])
+
+    const evidence = await publish(CAPTURES.setMinusMBackground)
+    expect(evidence).toMatchObject({ shellOwnsEveryTtyProcessGroup: false })
+
+    const plan = await planFor(CAPTURES.setMinusMBackground)
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host does not attest an idle shell')
+  })
+
+  it('never sweeps a pane whose group member dropped the controlling terminal', async () => {
+    // pid 17 kept the shell's pgid and called `ioctl(TIOCNOTTY)`, so it reports `tpgid == -1`,
+    // never appears in `ps -t <tty>`, and no tty-shaped index — not process groups, not pids —
+    // can observe it. `killpg(16)` reaches it regardless.
+    const rows = parseStrictProcessTableRows(CAPTURES.nottyGroupMember.table.join('\n'))
+    expect(rows.filter((row) => row.tpgid === 16).map((row) => row.pid)).toEqual([16])
+    expect(rows.filter((row) => row.pgid === 16).map((row) => row.pid)).toEqual([16, 17])
+
+    const evidence = await publish(CAPTURES.nottyGroupMember)
+    expect(evidence).toMatchObject({ shellOwnsEveryTtyProcessGroup: false })
+
+    const plan = await planFor(CAPTURES.nottyGroupMember)
+    expect(plan.sweep).toEqual([])
+    expect(skipReason(plan)).toBe('host does not attest an idle shell')
+  })
+
+  it('never sweeps a pane whose group member double-forked away from the shell', async () => {
+    // pid 22 reparented to pid 1, so the ppid walk from rootPid cannot reach it and the named-
+    // process backstop can never fire. It still holds the shell's pgid.
+    const rows = parseStrictProcessTableRows(CAPTURES.doubleForkedGroupMember.table.join('\n'))
+    expect(rows.find((row) => row.pid === 22)).toMatchObject({ ppid: 1, pgid: 20, tpgid: 20 })
+
+    const evidence = await publish(CAPTURES.doubleForkedGroupMember)
+    expect(evidence).toMatchObject({ processName: null, shellOwnsEveryTtyProcessGroup: false })
+
+    const plan = await planFor(CAPTURES.doubleForkedGroupMember)
     expect(plan.sweep).toEqual([])
     expect(skipReason(plan)).toBe('host does not attest an idle shell')
   })

--- a/src/shared/foreground-process-evidence.ts
+++ b/src/shared/foreground-process-evidence.ts
@@ -17,14 +17,20 @@ export type ForegroundProcessEvidence =
   | ({
       verdict: 'live'
       processName: string | null
-      /** True only when the host observed every process group attached to this PTY's terminal to be
-       *  the shell's own, with none of them stopped — i.e. nothing is running in the pane, in the
-       *  foreground OR the background, and nothing sits suspended.
+      /** True only when the host observed BOTH units a forced stop can reach to hold nothing but
+       *  the shell: every process group attached to this PTY's terminal is the shell's own with
+       *  none of them stopped, AND the shell's own process group has no other member anywhere on
+       *  the host. I.e. nothing is running in the pane, in the foreground OR the background, and
+       *  nothing sits suspended.
        *
        *  Deliberately not `tpgid === pgid`: a job the user backgrounded with `&` and a job the user
        *  suspended with Ctrl-Z both hand the terminal back to the shell, so a foreground-only
-       *  predicate reads them as idle. This one is measured against the same set of process groups
-       *  a forced stop would SIGKILL.
+       *  predicate reads them as idle. Deliberately not the tty alone either: with job control off
+       *  (`set +m`) a background job keeps the shell's pgid, and a child that drops the controlling
+       *  terminal leaves every tty index entirely — both are still inside `killpg`'s reach.
+       *
+       *  The name is tty-shaped for wire reasons only. It shipped that way and old clients read it;
+       *  the value has only ever become stricter, which makes an old client skip more, never less.
        *
        *  False means something IS running, named or not. Absent from a host that predates the
        *  field, which is neither: a reader deciding whether the pane is idle must require `true`

--- a/src/shared/ssh-relay-pty-ownership-proof.test.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.test.ts
@@ -146,6 +146,58 @@ describe('planRelayPtySweep', () => {
     expect(reasonFor(plan, 'pty-1')).toBe('host attests another client created it')
   })
 
+  // The age gate is the one comparison in the file that a malformed field defaults toward the
+  // kill: the sum goes `NaN`, and `NaN > budget` is FALSE, so the entry PASSES the freshness gate
+  // and proceeds toward the stop. Nothing validated this record on the sweep path —
+  // `mapSshPtyProcessList` checks the ownership fields and spreads the rest through.
+  it.each([
+    ['missing', undefined],
+    ['a string', '0' as unknown],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['negative', -1],
+    ['fractional', 1.5]
+  ])('never sweeps when the host stamped capturedAgeMs %s', (_label, capturedAgeMs) => {
+    const plan = planRelayPtySweep(
+      [
+        orphan({
+          foregroundProcessEvidence: {
+            ...idleShell(),
+            capturedAgeMs
+          } as unknown as ForegroundProcessEvidence
+        })
+      ],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host foreground observation is malformed')
+  })
+
+  it('never sweeps on an evidence record whose other host stamps are malformed', () => {
+    const plan = planRelayPtySweep(
+      [
+        orphan({
+          foregroundProcessEvidence: {
+            ...idleShell(),
+            authorityGeneration: ''
+          } as ForegroundProcessEvidence
+        })
+      ],
+      context()
+    )
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('host foreground observation is malformed')
+  })
+
+  it('never sweeps when this client cannot compute an age budget', () => {
+    const plan = planRelayPtySweep([orphan()], context({ evidenceAgeSinceListingMs: Number.NaN }))
+
+    expect(plan.sweep).toEqual([])
+    expect(reasonFor(plan, 'pty-1')).toBe('sweep has no usable evidence-age budget')
+  })
+
   it('never sweeps a PTY younger than the floor', () => {
     const plan = planRelayPtySweep(
       [orphan({ hostAgeMs: RELAY_PTY_SWEEP_MIN_AGE_MS - 1 })],

--- a/src/shared/ssh-relay-pty-ownership-proof.ts
+++ b/src/shared/ssh-relay-pty-ownership-proof.ts
@@ -1,4 +1,7 @@
-import type { ForegroundProcessEvidence } from './foreground-process-evidence'
+import {
+  isForegroundProcessEvidence,
+  type ForegroundProcessEvidence
+} from './foreground-process-evidence'
 
 /** Which relay PTYs a client may prove it orphaned, and therefore may stop (#9819).
  *
@@ -104,9 +107,10 @@ export const RELAY_PTY_SWEEP_MAX_PER_PASS = 8
 export const RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS = 5_000
 
 /** The host's own answer to "is anything running in this pane?". Only a positive "no" clears the
- *  sweep; every other shape — an older host, an unreadable process table, an observation too old to
- *  describe now, a named foreground process, any other process group on the pane's terminal — is a
- *  reason to leave the process alone. */
+ *  sweep; every other shape — an older host, a malformed record, an unreadable process table, an
+ *  observation too old to describe now, a named foreground process, any other process group on the
+ *  pane's terminal, any other member of the shell's own process group — is a reason to leave the
+ *  process alone. */
 function foregroundSkipReason(
   evidence: ForegroundProcessEvidence | undefined,
   context: RelayPtySweepContext
@@ -115,6 +119,20 @@ function foregroundSkipReason(
     // A host that never published it, or a Windows host where it is not collected. Absence of the
     // observation is not the observation of absence.
     return 'host published no foreground-process observation'
+  }
+  // The record reaches this decision straight off the wire — `mapSshPtyProcessList` validates the
+  // ownership fields and spreads the rest through, and `PtyProcessListAdmission` is not on the
+  // sweep path. Shape-check it here, because the age gate below is the one comparison in this file
+  // that a malformed field defaults toward the kill: a non-numeric `capturedAgeMs` makes the sum
+  // `NaN`, and `NaN > budget` is FALSE, so the entry would pass the freshness gate.
+  if (!isForegroundProcessEvidence(evidence)) {
+    return 'host foreground observation is malformed'
+  }
+  if (
+    !Number.isFinite(context.evidenceAgeSinceListingMs) ||
+    !Number.isFinite(context.maximumEvidenceAgeMs)
+  ) {
+    return 'sweep has no usable evidence-age budget'
   }
   // Before anything is read out of it: an observation is only a claim about the instant it was
   // taken. Age is checked on both verdicts because a stale `unverifiable` is no better.
@@ -130,9 +148,11 @@ function foregroundSkipReason(
     return 'host observes a named foreground process'
   }
   if (evidence.shellOwnsEveryTtyProcessGroup !== true) {
-    // Something other than the shell's own process group is attached to the pane's terminal — a
-    // foreground command, a job backgrounded with `&`, a Ctrl-Z'd editor — or this host predates
-    // the field. The stop would SIGKILL that group, so none of those is a pane to reclaim.
+    // The host saw work inside the stop's blast radius: another process group on the pane's
+    // terminal (a foreground command, a job backgrounded with `&`, a Ctrl-Z'd editor), or another
+    // member of the shell's OWN process group (a `set +m` background job, a child that dropped the
+    // controlling terminal) — or this host predates the field. `killpg` reaches all of it, so none
+    // of those is a pane to reclaim.
     return 'host does not attest an idle shell'
   }
   return null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​84 |

<!-- /orca-pr-loc -->

## The defect

The orphan-relay-PTY sweep is the one flow that turns an observation into a SIGKILL. It authorizes `pty.shutdown { immediate: true }`, which on the relay runs `forceKillPosixPtyProcessGroups` (`src/main/pty/posix-pty-process-groups.ts`): collect every process group on the pane's tty, then `process.kill(-pgid, 'SIGKILL')` each one.

**The unit of the kill is the process group. The evidence measured the tty.** A group is not a subset of a tty, so the comment claiming "the evidence and the kill now measure the same thing" was false. Three shapes read as idle and were destroyed:

| | how it hides | who can see it |
|---|---|---|
| **A** `set +m; pnpm build &` | job control off, so the job keeps the **shell's pgid**; the tty carries exactly one group and that group is running the build | pgid count, or a pids-per-tty set |
| **B** `ioctl(TIOCNOTTY)` without `setsid` | keeps the pgid, reports `tpgid == -1`, **never appears in `ps -t <tty>`** | **pgid count only** |
| **C** `set +m` child that double-forks | grandchild keeps pgid **and** tty but reparents to pid 1, so the `ppid` walk cannot reach it and it can never be named | pgid count, or a pids-per-tty set |

The named-process backstop does not help: `selectForegroundProcessCandidate` returns `null` unless `recognizeAgentProcessFromCommandLine` matches, so `sleep`, `pnpm build`, and `vim` are never named.

**Why the pgid-wide count rather than the cheaper pids-per-tty set:** a pids-per-tty set covers A and C but not B, whose whole signature is that it left the terminal. Since the kill's unit is the group, anything in the group the evidence cannot see is a process we may destroy. The count costs one extra `Map<number, number>` increment inside the loop `getTtyOccupancy` already ran — no second pass, and cheaper per entry than the `Set` the tty half already keeps.

## The fix

`shellOwnsEveryTtyProcessGroup` now requires **both** units to be clean: every process group on the tty is the shell's own with none stopped, **and** the shell's own process group has no other member anywhere in the table. The root always counts itself, so `rowsByProcessGroup.get(root.pgid) === 1` means the group *is* the shell — no separate leader check and no per-capture pid sets. A row with no `pgid` marks the index incomplete and refuses the attestation, so an unanswerable table is `unverifiable`, never "idle".

The wire field keeps its tty-shaped name deliberately. This is a Rule 3 change under `remote-wire-compatibility.md` — the host publishes different content with no codec change — but the value only ever became **stricter**, so an old client reading it skips more, never less. Renaming would instead make idle shells unsweepable in both skew directions.

## Second finding, same audit

`foregroundSkipReason` computed `evidence.capturedAgeMs + context.evidenceAgeSinceListingMs > context.maximumEvidenceAgeMs` with nothing validated. If `capturedAgeMs` is `undefined` or non-numeric the sum is `NaN`, and **`NaN > 5000` is false** — the entry *passes* the freshness gate and proceeds toward the stop. That was the one place in the file where a malformed field defaulted toward kill.

It was unvalidated on this path: `ssh-pty-provider.listProcesses` → `mapSshPtyProcessList` validates only `agentSessionOwners`/`incarnationId` and spreads the rest through; `sweepOrphanedRelayPtys` passes it straight into the plan. `PtyProcessListAdmission` (which does call `isForegroundProcessEvidence`) is on the daemon-inventory and IPC-inspect paths, not this one. It now runs `isForegroundProcessEvidence` and fails closed, and a non-finite client-side age budget gets its own skip reason.

## Verification — real evidence, not only mocks

A Docker container drives a real `bash -i` on a real pty, builds each construction, runs the **real** publisher (`resolveAgentForegroundProcessesBatch` → `toForegroundProcessEvidence`) and the **real** planner (`planRelayPtySweep`), then calls the **real** `forceKillPosixPtyProcessGroups`. `ps` by pid before and after.

**Before (`main`):**

```
=== scenario setm_background: shell pid 22, planted pids [23]
--- ps BEFORE      PID PPID PGID TPGID STAT COMMAND
    22    21    22    22 Ss+  bash -i
    23    12    22    22 S+   sleep 300
--- host publishes: {... "shellOwnsEveryTtyProcessGroup": true}
--- client plans: SWEEP
--- executing forceKillPosixPtyProcessGroups (the real SIGKILL path)
--- ps AFTER, by pid
    pid 22: ALIVE  22    21    22    -1 Zs   [bash] <defunct>
    pid 23: GONE                                   <-- the user's build

=== scenario notty_member: shell pid 36, planted pids [37]
    37    36    36    -1 S    python3 -c ... ioctl(fd,0x5422) ... time.sleep(300)
--- client plans: SWEEP  ->  pid 37: GONE

=== scenario double_fork: shell pid 50, planted pids [51, 52]
    52     1    50    50 S+   python3 -c ... os.fork() ... time.sleep(300)
--- client plans: SWEEP  ->  pid 52: GONE
```

**After (this branch):**

```
=== scenario idle          -> SWEEP, shell pid 9 => Zs [bash] <defunct>   (still reclaimed)
=== scenario setm_background -> SKIP (host does not attest an idle shell)
    pid 22: ALIVE  22 21 22 22 Ss+ bash -i     pid 23: ALIVE  sleep 300
=== scenario notty_member    -> SKIP (host does not attest an idle shell)
    pid 34: ALIVE                              pid 35: ALIVE  python3 ... TIOCNOTTY
=== scenario double_fork     -> SKIP (host does not attest an idle shell)
    pid 46: ALIVE                              pid 48: ALIVE  python3 ... double-forked
```

The `idle` scenario is the control: if nothing is ever swept the feature is a no-op, and that is also a failure. It still sweeps.

- 11 new unit tests, **all 11 verified failing on `main`** before the fix. The three pane-state fixtures are verbatim `ps` transcripts from those container runs, added to `ssh-orphan-sweep-pane-state-verdicts.test.ts` — the file that runs the real publisher against the real client reader, which is precisely how a foreground-only predicate survived review the first time.
- `pnpm tc` clean; `pnpm run check:code-quality:changed` 0 findings (`max-lines` proven to fire with a 320-line positive control, since `npx oxlint <file>` can exit 0 without running it).

## Documentation

The `set +m` limitation was recorded nowhere a reader of this predicate would find it. It is now at the predicate, on the wire field, and in a new **"Deciding a remote pane is idle"** section of `docs/reference/ssh-execution-boundary.md`, along with the two residuals that remain:

- the capture is a snapshot, so work started between the `ps` and the signal is invisible — bounded by `RELAY_PTY_SWEEP_MAX_EVIDENCE_AGE_MS`, not removed;
- a process the host's own `ps` cannot enumerate (another PID namespace, `hidepid=2`, a table truncated by a permission boundary) is unobservable while `killpg` still reaches it.

The general rule the section states: **evidence must be measured in the unit the destructive action operates on.** Evidence in a different unit is `unverifiable` however precise it looks.

## Independent confirmation

A QA pass reproduced construction A on a real Ubuntu host through an actual Orca pane (`set +m; sleep 900 &` → `pid=2105299 pgid=2100210`, the job sitting in the shell's own pgid). No disagreement with this fix; the only difference was a proposed cheaper pids-per-tty variant, which the container run above shows does not cover construction B.
