### PR TITLE
perf(ipc): index worktree owners instead of rescanning the repo list per lookup

### DIFF
--- a/src/main/ipc/local-worktree-runtime-options.test.ts
+++ b/src/main/ipc/local-worktree-runtime-options.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { WORKTREE_ID_SEPARATOR, type ParsedWorktreeId } from '../../shared/worktree/id'
+import type * as WorktreeIdModule from '../../shared/worktree/id'
+
+const counter = vi.hoisted(() => ({ splitCalls: 0 }))
+
+// Why: `splitWorktreeId` (and the `Object.keys` snapshot around it) is the per-row work the repo
+// loop used to repeat once per repo. Counting it makes the O(repos x rows) regression observable.
+vi.mock('../../shared/worktree/id', async (importOriginal) => {
+  const actual = await importOriginal<typeof WorktreeIdModule>()
+  return {
+    ...actual,
+    splitWorktreeId: (worktreeId: string): ParsedWorktreeId | null => {
+      counter.splitCalls += 1
+      return actual.splitWorktreeId(worktreeId)
+    }
+  }
+})
+
+const { getLocalRepoForRegisteredWorktree } = await import('./local-worktree-runtime-options')
+
+type TestRepo = { id: string; path: string; connectionId?: string }
+
+const makeStore = (
+  repos: readonly TestRepo[],
+  worktreeIds: readonly string[]
+): { store: never; metaScans: () => number } => {
+  let metaScans = 0
+  const meta = Object.fromEntries(worktreeIds.map((id) => [id, {}]))
+  const store = {
+    getRepos: () => repos,
+    getAllWorktreeMeta: () => {
+      metaScans += 1
+      return meta
+    }
+  }
+  return { store: store as never, metaScans: () => metaScans }
+}
+
+const worktreeId = (repoId: string, path: string): string =>
+  `${repoId}${WORKTREE_ID_SEPARATOR}${path}`
+
+beforeEach(() => {
+  counter.splitCalls = 0
+})
+
+describe('getLocalRepoForRegisteredWorktree', () => {
+  it('walks the worktree meta table once, not once per repo', () => {
+    // Worst case: the owning repo is last, so every earlier repo used to force a full rescan.
+    const repoCount = 10
+    const rowCount = 200
+    const repos = Array.from({ length: repoCount }, (_, i) => ({
+      id: `repo-${i}`,
+      path: `/repos/repo-${i}`
+    }))
+    const target = '/repos/repo-9/wt-last'
+    const worktreeIds = Array.from({ length: rowCount }, (_, i) =>
+      worktreeId(`repo-${i % repoCount}`, `/repos/wt-${i}`)
+    )
+    worktreeIds[rowCount - 1] = worktreeId(`repo-${repoCount - 1}`, target)
+    const { store, metaScans } = makeStore(repos, worktreeIds)
+
+    expect(getLocalRepoForRegisteredWorktree(store, target, target)?.id).toBe('repo-9')
+    expect(metaScans()).toBe(1)
+    expect(counter.splitCalls).toBe(rowCount)
+  })
+
+  it('never touches the meta table when a repo path matches directly', () => {
+    const { store, metaScans } = makeStore([{ id: 'repo-a', path: '/repos/a' }], [])
+    expect(getLocalRepoForRegisteredWorktree(store, '/repos/a', '/repos/a')?.id).toBe('repo-a')
+    expect(metaScans()).toBe(0)
+  })
+
+  describe('equivalence with the per-repo scan', () => {
+    const repos: TestRepo[] = [
+      { id: 'first', path: '/repos/first' },
+      { id: 'middle', path: '/repos/middle' },
+      { id: 'last', path: '/repos/last' }
+    ]
+
+    it('finds a worktree owned by the first repo', () => {
+      const { store } = makeStore(repos, [worktreeId('first', '/wt/one')])
+      expect(getLocalRepoForRegisteredWorktree(store, '/wt/one', '/wt/one')?.id).toBe('first')
+    })
+
+    it('finds a worktree owned by the last repo', () => {
+      const { store } = makeStore(repos, [worktreeId('last', '/wt/one')])
+      expect(getLocalRepoForRegisteredWorktree(store, '/wt/one', '/wt/one')?.id).toBe('last')
+    })
+
+    it('returns undefined when no repo owns the worktree', () => {
+      const { store } = makeStore(repos, [worktreeId('other', '/wt/elsewhere')])
+      expect(getLocalRepoForRegisteredWorktree(store, '/wt/one', '/wt/one')).toBeUndefined()
+    })
+
+    it('keeps getRepos precedence when two repos both own the path', () => {
+      const { store } = makeStore(repos, [
+        worktreeId('last', '/wt/shared'),
+        worktreeId('middle', '/wt/shared')
+      ])
+      // getRepos order decides, not the meta table's insertion order.
+      expect(getLocalRepoForRegisteredWorktree(store, '/wt/shared', '/wt/shared')?.id).toBe(
+        'middle'
+      )
+    })
+
+    it('excludes an SSH repo even when it owns the registered worktree', () => {
+      const { store } = makeStore(
+        [{ id: 'remote', path: '/repos/remote', connectionId: 'm4air' }, ...repos],
+        [worktreeId('remote', '/wt/one'), worktreeId('middle', '/wt/one')]
+      )
+      expect(getLocalRepoForRegisteredWorktree(store, '/wt/one', '/wt/one')?.id).toBe('middle')
+
+      const onlyRemote = makeStore(
+        [{ id: 'remote', path: '/repos/remote', connectionId: 'm4air' }],
+        [worktreeId('remote', '/wt/one')]
+      )
+      expect(
+        getLocalRepoForRegisteredWorktree(onlyRemote.store, '/wt/one', '/wt/one')
+      ).toBeUndefined()
+    })
+
+    it('matches the resolved path spelling as well as the raw one', () => {
+      const { store } = makeStore(repos, [worktreeId('middle', '/wt/one')])
+      expect(getLocalRepoForRegisteredWorktree(store, '/wt/other', '/wt/one')?.id).toBe('middle')
+    })
+
+    it('returns undefined for a folder workspace that is not a registered worktree', () => {
+      const { store } = makeStore(repos, [worktreeId('middle', '/wt/one')])
+      expect(
+        getLocalRepoForRegisteredWorktree(store, '/folders/notes', '/folders/notes')
+      ).toBeUndefined()
+    })
+
+    it('tolerates a store without getRepos or getAllWorktreeMeta', () => {
+      expect(getLocalRepoForRegisteredWorktree({} as never, '/wt/one', '/wt/one')).toBeUndefined()
+      expect(
+        getLocalRepoForRegisteredWorktree({ getRepos: () => repos } as never, '/wt/one', '/wt/one')
+      ).toBeUndefined()
+    })
+  })
+})

--- a/src/main/ipc/local-worktree-runtime-options.ts
+++ b/src/main/ipc/local-worktree-runtime-options.ts
@@ -19,20 +19,21 @@ function getCandidateLocalWorktreePaths(
   return new Set([worktreePath, resolvedWorktreePath].map(comparableLocalPath))
 }
 
-function hasRegisteredWorktreeMetaForRepo(
+/** Repos owning a registered worktree at one of `candidatePaths`, in one pass over the meta table. */
+function collectRepoIdsWithRegisteredWorktreeMeta(
   store: Store,
-  repoId: string,
   candidatePaths: Set<string>
-): boolean {
+): Set<string> {
   const worktreeMeta =
     typeof store.getAllWorktreeMeta === 'function' ? store.getAllWorktreeMeta() : {}
+  const repoIds = new Set<string>()
   for (const worktreeId of Object.keys(worktreeMeta)) {
     const parsed = splitWorktreeId(worktreeId)
-    if (parsed?.repoId === repoId && candidatePaths.has(comparableLocalPath(parsed.worktreePath))) {
-      return true
+    if (parsed && candidatePaths.has(comparableLocalPath(parsed.worktreePath))) {
+      repoIds.add(parsed.repoId)
     }
   }
-  return false
+  return repoIds
 }
 
 export function getLocalRepoForRegisteredWorktree(
@@ -45,13 +46,18 @@ export function getLocalRepoForRegisteredWorktree(
   }
 
   const candidatePaths = getCandidateLocalWorktreePaths(worktreePath, resolvedWorktreePath)
+  // Built at most once, and only when a repo actually needs it, so the meta table is never
+  // rescanned per repo — 59 IPC call sites hit this, some per keystroke.
+  let repoIdsWithMeta: Set<string> | undefined
   return store
     .getRepos()
     .find(
       (repo) =>
         !repo.connectionId &&
         (candidatePaths.has(comparableLocalPath(repo.path)) ||
-          hasRegisteredWorktreeMetaForRepo(store, repo.id, candidatePaths))
+          (repoIdsWithMeta ??= collectRepoIdsWithRegisteredWorktreeMeta(store, candidatePaths)).has(
+            repo.id
+          ))
     )
 }
 

--- a/src/shared/worktree-execution-host-resolution.test.ts
+++ b/src/shared/worktree-execution-host-resolution.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   createRepoRowExecutionHostLookup,
-  resolveWorktreeExecutionHost
+  resolveWorktreeExecutionHost,
+  type ExecutionHostOwnerRow
 } from './worktree-execution-host-resolution'
 
 // Why (#11163, #17799): main's terminal launch scope and the renderer's owner index both answer
@@ -163,5 +164,69 @@ describe('resolveWorktreeExecutionHost', () => {
       kind: 'resolved',
       connectionId: 'openclaw'
     })
+  })
+})
+
+describe('createRepoRowExecutionHostLookup', () => {
+  /** Rows whose `id` reads are counted, so a rescan of the repo list is observable. */
+  const countingRepos = (
+    rows: readonly ExecutionHostOwnerRow[]
+  ): { repos: ExecutionHostOwnerRow[]; idReads: () => number } => {
+    let idReads = 0
+    const repos = rows.map(({ id, ...rest }) => ({
+      ...rest,
+      get id(): string {
+        idReads += 1
+        return id
+      }
+    }))
+    return { repos, idReads: () => idReads }
+  }
+
+  it('scans the repo list once for the factory, never again per lookup', () => {
+    const { repos, idReads } = countingRepos([
+      { id: 'a' },
+      { id: 'b', connectionId: 'm4air' },
+      { id: 'c' }
+    ])
+    const lookup = createRepoRowExecutionHostLookup(repos)
+    // One grouping pass over the list — a Map get plus a set per row — and then never again.
+    const afterBuild = idReads()
+    expect(afterBuild).toBeLessThanOrEqual(repos.length * 2)
+
+    for (let i = 0; i < 50; i++) {
+      lookup.byId('a')
+      lookup.byId('missing')
+      lookup.byHost('b', 'ssh:m4air')
+    }
+    expect(idReads()).toBe(afterBuild)
+  })
+
+  it('answers missing, ambiguous and resolved exactly as a per-call scan would', () => {
+    expect(createRepoRowExecutionHostLookup([]).byId('r')).toEqual({ kind: 'missing' })
+
+    const openclaw = { id: 'r', connectionId: 'openclaw' }
+    const m4air = { id: 'r', connectionId: 'm4air' }
+    expect(createRepoRowExecutionHostLookup([openclaw, m4air]).byId('r')).toEqual({
+      kind: 'ambiguous'
+    })
+
+    // Two rows agreeing on one host still resolve to the first in repo-list order.
+    const first: ExecutionHostOwnerRow = { id: 'r', connectionId: 'm4air' }
+    const second: ExecutionHostOwnerRow = { id: 'r', executionHostId: 'ssh:m4air' }
+    expect(createRepoRowExecutionHostLookup([first, second]).byId('r')).toEqual({
+      kind: 'resolved',
+      owner: first
+    })
+  })
+
+  it('keeps byHost hits, misses and repo-list order', () => {
+    const openclaw = { id: 'r', connectionId: 'openclaw' }
+    const m4air = { id: 'r', connectionId: 'm4air' }
+    const lookup = createRepoRowExecutionHostLookup([openclaw, m4air])
+    expect(lookup.byHost('r', 'ssh:m4air')).toBe(m4air)
+    expect(lookup.byHost('r', 'ssh:openclaw')).toBe(openclaw)
+    expect(lookup.byHost('r', 'local')).toBeNull()
+    expect(lookup.byHost('other', 'local')).toBeNull()
   })
 })

--- a/src/shared/worktree-execution-host-resolution.ts
+++ b/src/shared/worktree-execution-host-resolution.ts
@@ -88,20 +88,37 @@ export function resolveWorktreeExecutionHost<T extends ExecutionHostOwnerRow>(
   }
 }
 
-/** Array-backed lookup for callers holding the whole repo list (main's store). */
+const EMPTY_ROWS: readonly never[] = []
+
+/**
+ * Array-backed lookup for callers holding the whole repo list (main's store). Grouped once at
+ * construction — a lookup is hit once per worktree key per target, so a per-call `filter` was an
+ * O(repos) rescan each time. Rows keep repo-list order, which `byId` depends on for `rows[0]`.
+ */
 export function createRepoRowExecutionHostLookup<T extends ExecutionHostOwnerRow>(
   repos: readonly T[]
 ): ExecutionHostOwnerLookup<T> {
-  const rowsFor = (repoId: string): T[] => repos.filter((repo) => repo.id === repoId)
+  const rowsById = new Map<string, T[]>()
+  for (const repo of repos) {
+    const rows = rowsById.get(repo.id)
+    if (rows) {
+      rows.push(repo)
+    } else {
+      rowsById.set(repo.id, [repo])
+    }
+  }
+  const rowsFor = (repoId: string): readonly T[] => rowsById.get(repoId) ?? EMPTY_ROWS
   return {
     byId: (repoId) => {
       const rows = rowsFor(repoId)
-      if (rows.length === 0) {
+      const owner = rows[0]
+      if (!owner) {
         return { kind: 'missing' }
       }
-      const hostIds = new Set(rows.map((repo) => getRepoExecutionHostId(repo)))
-      const owner = rows[0]
-      return hostIds.size > 1 || !owner ? { kind: 'ambiguous' } : { kind: 'resolved', owner }
+      const ownerHostId = getRepoExecutionHostId(owner)
+      return rows.some((repo) => getRepoExecutionHostId(repo) !== ownerHostId)
+        ? { kind: 'ambiguous' }
+        : { kind: 'resolved', owner }
     },
     byHost: (repoId, hostId) =>
       rowsFor(repoId).find((repo) => getRepoExecutionHostId(repo) === hostId) ?? null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​208 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## ELI5

Two little "who owns this folder?" questions had a bad habit. Instead of reading the address book once and remembering it, they re-read the whole book from the start for every single name they checked. With one address book of 1,334 entries and 20 names to check, that's 20 full readings of the book — for one question the app asks on every keystroke in Quick Open and every time you expand a folder in the File Explorer.

This PR reads the book once. Same answers, same order of preference, just not re-read 20 times.

## Why it matters

**Finding 1 — `getLocalRepoForRegisteredWorktree`** (`src/main/ipc/local-worktree-runtime-options.ts`)

`hasRegisteredWorktreeMetaForRepo` ran *per repo* inside `repos.find(...)`, and each run did `Object.keys(store.getAllWorktreeMeta())` — a fresh array allocation over the whole table — plus a `splitWorktreeId` (two substring allocations + an object) *per row*. That is R full table walks per call.

There are 59 call sites, including `src/main/ipc/filesystem-search-file-paths.ts:49` (once per Quick Open keystroke) and `src/main/ipc/filesystem-list-files.ts:41` (every File Explorer expand), plus `git:status` / `git:diff` / `git:index`.

At the reported real scale (1,334 metadata rows, 20 repos, worst case = worktree owned by the last repo), on this machine under load:

```
current (O(R*M)) : 8.739 ms/call
indexed (O(M+R)) : 1.697 ms/call   (5.1x)
```

**Correction to the original report:** the brief attributed the R x M term to `path.resolve`. It isn't — the original short-circuits on `parsed?.repoId === repoId` *before* calling `comparableLocalPath`, so `path.resolve` was already ~O(M) in total. The genuine R x M terms are the per-repo `Object.keys()` snapshot and the R x M `splitWorktreeId` calls (26,680 vs 1,334 at the reported scale). The regression guard counts those instead, which is why it is a real guard rather than one that passes either way.

**Finding 2 — `createRepoRowExecutionHostLookup`** (`src/shared/worktree-execution-host-resolution.ts`)

`rowsFor` was `repos.filter(...)`: a fresh O(repos) scan plus an array allocation on *every* `byId`/`byHost` call, plus a `Set` allocation inside `byId`. It is called once per worktree key per target by the remote-workspace export path, and by the renderer's copy of the same resolution.

```
filter-per-call  : 0.2593 ms per 200-key pass   (20 repos)
grouped-once     : 0.0792 ms per 200-key pass   (3.3x)
```

## Measurement

Benchmarks: `nice -n 10 node` on a loaded machine, 2,000 iterations after a 200-iteration warmup (finding 1) and 5,000 iterations after 500 (finding 2). Absolute numbers run high because the box is loaded; the ratio is the signal and it reproduced across runs (5.1x / 6.1x, 3.3x / 11.8x).

### Regression guards fail without the change

Both source files reverted (`git stash`), tests kept:

```
 FAIL  src/shared/worktree-execution-host-resolution.test.ts > createRepoRowExecutionHostLookup > scans the repo list once for the factory, never again per lookup
AssertionError: expected 450 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 450

 ❯ src/shared/worktree-execution-host-resolution.test.ts:202:23
    200|       lookup.byHost('b', 'ssh:m4air')
    201|     }
    202|     expect(idReads()).toBe(afterBuild)
       |                       ^
    203|   })

 FAIL  src/main/ipc/local-worktree-runtime-options.test.ts > getLocalRepoForRegisteredWorktree > walks the worktree meta table once, not once per repo
AssertionError: expected 10 to be 1 // Object.is equality

- Expected
+ Received

- 1
+ 10

 ❯ src/main/ipc/local-worktree-runtime-options.test.ts:63:25
     61|
     62|     expect(getLocalRepoForRegisteredWorktree(store, target, target)?.i…
     63|     expect(metaScans()).toBe(1)
       |                         ^
     64|     expect(counter.splitCalls).toBe(rowCount)
     65|   })

 Test Files  2 failed (2)
      Tests  2 failed | 23 passed (25)
```

The 23 passing tests in that run are the equivalence cases — **they pass against the original implementation too**, which is the point: they pin behaviour, the two counters pin the complexity.

After the change:

```
 Test Files  2 passed (2)
      Tests  25 passed (25)
```

## Correctness

**Finding 1.** The predicate is unchanged and side-effect free; only evaluation order moves. `hasRegisteredWorktreeMetaForRepo(store, repo.id, paths)` asked "is there a row with this repoId whose path is a candidate?"; `collectRepoIdsWithRegisteredWorktreeMeta(store, paths).has(repo.id)` asks the same question of a set built from exactly the rows satisfying the path half. Iteration is still `Object.keys` (own enumerable keys only — not `for...in`, which would also walk the prototype chain).

- **`getRepos()` precedence is preserved.** The original short-circuits on the first matching repo in `getRepos()` order, and so does this one — `repos.find(...)` is untouched; only the body of the second disjunct changed. Explicitly tested with two repos that both own the path: `middle` wins over `last` because `middle` comes first in `getRepos()`, regardless of meta-table insertion order.
- **Laziness is preserved exactly.** The set is built on first need via `??=`, so a store where every candidate repo matches by path still never calls `getAllWorktreeMeta` — same trigger condition as before, just memoised. Tested (`metaScans() === 0`).
- **Invalidation:** the set is a local, built and discarded inside one call. There is no cache across calls, so no staleness window and nothing to invalidate. A `getRepos()`/`getAllWorktreeMeta()` change between two IPC calls is seen immediately, as before.
- **SSH:** `!repo.connectionId` still gates the whole predicate, so an SSH repo is excluded even when it owns the registered worktree. Tested both ways — with a local rival present (local repo wins) and alone (`undefined`, not the SSH repo).
- **Folder workspaces:** unchanged. A folder workspace that is not a registered worktree still resolves to `undefined`; the meta table is the same table, keyed the same way, and `splitWorktreeId` is unchanged (in particular the `::workspace:<uuid>` suffix is still *not* stripped here, exactly as before).
- **Windows:** path comparison still goes through the same `comparableLocalPath` (`resolve` + `toLowerCase` on `win32`). Nothing was moved out of that helper.
- **Empty/missing state:** the `typeof store.getRepos !== 'function'` and `typeof store.getAllWorktreeMeta !== 'function'` guards are both preserved and tested.

**Finding 2.** `Map` preserves insertion order and the groups are built by iterating `repos` in order and pushing, so each group is the same array `repos.filter(...)` produced — same members, same order. `rows[0]` therefore selects the same owner.

- `rows.length === 0 -> missing` becomes `!rows[0] -> missing`. These differ only if index 0 of a non-empty group were nullish, which cannot happen: building the group already dereferenced `repo.id`.
- `new Set(rows.map(hostId)).size > 1` becomes `rows.some(hostId !== rows[0].hostId)`. Identical predicate (a set of size > 1 means some element differs from the first), one fewer array and one fewer Set allocated, and it short-circuits.
- The `|| !owner -> ambiguous` arm of the original was unreachable for a non-empty group; it is now folded into `missing`. Same observable outcomes.
- `ambiguous` / `missing` / `resolved` and `byHost` hit/miss are all covered by new tests, and the 14 existing `resolveWorktreeExecutionHost` tests — which drive the real cross-host leak cases from #11163 / #6648 / #17799 — pass unchanged.
- The grouped arrays are private to the factory; `byId` uses `some` and `byHost` uses `find`, neither mutates, so sharing them across calls is safe.
- **Remote wire:** nothing crosses the wire here. This is a local index over an already-fetched repo list; no RPC params, stream frames, or published content change.

**Scope:** `src/main/ipc/remote-workspace.ts` is deliberately untouched — this is the complementary fix *inside* the factory and stacks cleanly on #18410.

## Negative user-facing trade-offs

**None.** No cap, cadence, debounce, threshold, sampling, or staleness window was introduced; both indexes are built and discarded within a single call/factory lifetime, so every lookup still sees the current store state and returns the identical repo.

## Test plan

```
nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/shared/worktree-execution-host-resolution.test.ts \
  src/main/ipc/local-worktree-runtime-options.test.ts \
  src/main/runtime/worktree-launch-host-repo.test.ts \
  src/main/ipc/filesystem-list-files.test.ts \
  src/main/ipc/filesystem-search-file-paths.test.ts
# Test Files 5 passed (5) | Tests 63 passed (63)

nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false   # clean
nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json --composite false # clean (finding 2 is shared code the renderer imports)
node_modules/.bin/oxlint <changed files>                                                   # clean
```

New tests:

- `src/main/ipc/local-worktree-runtime-options.test.ts` (new file) — counter guard (200 meta rows, 10 repos, owner is the last repo: exactly 1 `getAllWorktreeMeta` call and exactly 200 `splitWorktreeId` calls), a "never touches the meta table when a repo path matches" guard, and equivalence for: owner is the first repo, owner is the last repo, no owner, two repos owning the same path (`getRepos` precedence), an SSH repo that owns the worktree (excluded, with and without a local rival), the resolved-path spelling, a folder workspace that is not a registered worktree, and a store missing `getRepos` / `getAllWorktreeMeta`.
- `src/shared/worktree-execution-host-resolution.test.ts` — counter guard (150 lookups against one factory read the repo rows zero additional times), plus `missing` / `ambiguous` / `resolved`-with-agreeing-rows (still `rows[0]`) and `byHost` hit/miss/order.


## Linked Issue

No tracked issue — this came out of a performance audit of the IPC hot paths (Quick Open keystrokes, File Explorer expand, `git:status`/`git:diff`/`git:index`), not a filed bug.

## Visual Proof

`N/A` — no UI, layout, or interaction change. Both edits are pure lookup-internals in main/shared code; every call returns the identical repo it returned before, so there is nothing to show a before/after of.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Verified locally (see the Test plan section above for the exact commands): 5 test files / 63 tests pass, `tsc --noEmit` clean for both the node and web projects, `oxlint` clean on the changed files. Both regression guards were confirmed to fail against the pre-change implementations. Platform: macOS; the changed code is platform-independent apart from `comparableLocalPath`, which is untouched and still applies the `win32` `toLowerCase` branch.

## Review

Two behaviour-preserving index builds, both scoped to a single call/factory lifetime. The equivalence argument for each is spelled out in the Correctness section: the `Set` membership predicate is the same question the old per-repo path check asked, and `rows.some(hostId !== rows[0].hostId)` is the same predicate as `new Set(hostIds).size > 1`. `getRepos()` precedence, laziness, SSH exclusion, and folder-workspace behaviour are each pinned by a test.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation is copied or translated here.

## Notes

- **Security:** no new input surface; both indexes are built from data the callers already hold.
- **Cross-platform:** path comparison still goes through the unchanged `comparableLocalPath` (`resolve` + `toLowerCase` on `win32`); no separator assumptions were added.
- **Remote SSH:** `!repo.connectionId` still gates the whole predicate, so an SSH repo is never returned as the local owner — tested with and without a competing local repo. Nothing here reports on, stops, or lists remote work, so the `live`/`unverifiable`/`exited` vocabulary does not apply.
- **Mobile:** untouched.
- **Backwards compatibility / remote wire:** nothing crosses the wire; no RPC params, stream frames, or published content change, so a mixed-version client/host pair sees exactly what it saw before.
- **Folder workspaces:** a folder workspace that is not a registered worktree still resolves to `undefined`; the `::workspace:<uuid>` suffix is still not stripped here, exactly as before.
- **Git provider:** no provider-specific code paths involved.
- **Performance:** the point of the PR — O(R*M) to O(M+R) for finding 1, and O(repos) per lookup to O(1) for finding 2.

## Checklist

- [x] This PR is small and focused (2 prod files, +36/-13)
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof — no UI or interaction change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Typecheck, targeted tests, and lint pass locally; CI covers the rest
