### PR TITLE
perf(ipc): build the filesystem allowed-root list once per authorization

### DIFF
--- a/src/main/ipc/filesystem-allowed-roots.test.ts
+++ b/src/main/ipc/filesystem-allowed-roots.test.ts
@@ -1,0 +1,344 @@
+import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type * as RepoWorktrees from '../repo-worktrees'
+import { listRepoWorktreeGraph } from '../repo-worktrees'
+import type * as ProjectGroupsModule from '../../shared/project-groups'
+import { buildProjectGroupChildIndex, getProjectGroupSubtreeIds } from '../../shared/project-groups'
+import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
+import { getWorktreeMirrorDistro } from '../project-runtime-git-options'
+import type { FolderWorkspace } from '../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../shared/project-group-types'
+import type { Project } from '../../shared/project-types'
+import type { Repo } from '../../shared/repo-types'
+import { getAllowedRoots } from './filesystem-allowed-roots'
+import { resolveAuthorizedPath } from './filesystem-auth'
+import { invalidateAuthorizedRootsCache } from './registered-worktree-roots-cache'
+import { computeWorkspaceRoot, getWorktreePathSettings } from './worktree-logic'
+
+vi.mock('../repo-worktrees', async () => {
+  const actual = await vi.importActual<typeof RepoWorktrees>('../repo-worktrees')
+  return { ...actual, listRepoWorktreeGraph: vi.fn(async () => []) }
+})
+
+vi.mock('../../shared/project-groups', async () => {
+  const actual = await vi.importActual<typeof ProjectGroupsModule>('../../shared/project-groups')
+  return {
+    ...actual,
+    buildProjectGroupChildIndex: vi.fn(actual.buildProjectGroupChildIndex),
+    getProjectGroupSubtreeIds: vi.fn(actual.getProjectGroupSubtreeIds)
+  }
+})
+
+type StoreFixture = {
+  repos: Repo[]
+  projects: Project[]
+  projectGroups: ProjectGroup[]
+  folderWorkspaces: FolderWorkspace[]
+  workspaceDir?: string
+}
+
+type StoreCallCounts = {
+  getRepos: number
+  getProjects: number
+  getProjectGroups: number
+  getFolderWorkspaces: number
+}
+
+function makeCountingStore(fixture: StoreFixture): { store: Store; counts: StoreCallCounts } {
+  const counts: StoreCallCounts = {
+    getRepos: 0,
+    getProjects: 0,
+    getProjectGroups: 0,
+    getFolderWorkspaces: 0
+  }
+  const store = {
+    getRepos: () => {
+      counts.getRepos += 1
+      // Match the real store, which rehydrates fresh repo objects on every read.
+      return fixture.repos.map((repo) => ({ ...repo }))
+    },
+    getProjects: () => {
+      counts.getProjects += 1
+      return fixture.projects.map((project) => ({ ...project }))
+    },
+    getProjectGroups: () => {
+      counts.getProjectGroups += 1
+      return fixture.projectGroups.map((group) => ({ ...group }))
+    },
+    getFolderWorkspaces: () => {
+      counts.getFolderWorkspaces += 1
+      return fixture.folderWorkspaces.map((workspace) => ({ ...workspace }))
+    },
+    getSettings: () => ({ nestWorkspaces: false, workspaceDir: fixture.workspaceDir ?? '' })
+  } as unknown as Store
+  return { store, counts }
+}
+
+/**
+ * The pre-change `getAllowedRoots` algorithm, kept verbatim so the equivalence test compares the
+ * new root list against the old one rather than against a hand-written expectation.
+ */
+function referenceAllowedRoots(store: Store): string[] {
+  const scopeStore = store as unknown as {
+    getRepos: () => Repo[]
+    getProjectGroups?: () => ProjectGroup[]
+    getFolderWorkspaces?: () => FolderWorkspace[]
+    getSettings: () => { workspaceDir?: string; nestWorkspaces?: boolean }
+  }
+  const localRepos = scopeStore.getRepos().filter((repo) => !repo.connectionId)
+  const settings = scopeStore.getSettings()
+
+  const scopeRepos = scopeStore.getRepos()
+  const projectGroups = scopeStore.getProjectGroups?.() ?? []
+  const isRemoteOnly = (
+    folderPath: string,
+    projectGroupId: string,
+    connectionId: string | null | undefined
+  ): boolean => {
+    if (connectionId) {
+      return true
+    }
+    const groupIds = getProjectGroupSubtreeIds(projectGroups, projectGroupId)
+    const candidates = scopeRepos.filter(
+      (repo) =>
+        (typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) ||
+        isPathInsideOrEqual(folderPath, repo.path)
+    )
+    return candidates.length > 0 && candidates.every((repo) => Boolean(repo.connectionId))
+  }
+  const folderScopeRoots: string[] = []
+  for (const group of projectGroups) {
+    if (group.parentPath && !isRemoteOnly(group.parentPath, group.id, group.connectionId)) {
+      folderScopeRoots.push(resolve(group.parentPath))
+    }
+  }
+  for (const workspace of scopeStore.getFolderWorkspaces?.() ?? []) {
+    const connectionId =
+      workspace.connectionId ??
+      projectGroups.find((group) => group.id === workspace.projectGroupId)?.connectionId ??
+      null
+    if (!isRemoteOnly(workspace.folderPath, workspace.projectGroupId, connectionId)) {
+      folderScopeRoots.push(resolve(workspace.folderPath))
+    }
+  }
+
+  const roots = [...localRepos.map((repo) => resolve(repo.path)), ...folderScopeRoots]
+  if (settings.workspaceDir) {
+    if (localRepos.length === 0) {
+      roots.push(resolve(settings.workspaceDir))
+    } else {
+      for (const repo of localRepos) {
+        roots.push(
+          resolve(
+            computeWorkspaceRoot(
+              repo.path,
+              getWorktreePathSettings(repo, settings as never, getWorktreeMirrorDistro(store, repo))
+            )
+          )
+        )
+      }
+    }
+  }
+  return roots
+}
+
+function makeRepo(overrides: Partial<Repo> & Pick<Repo, 'id' | 'path'>): Repo {
+  return {
+    displayName: overrides.id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    kind: 'git',
+    ...overrides
+  }
+}
+
+function makeGroup(overrides: Partial<ProjectGroup> & Pick<ProjectGroup, 'id'>): ProjectGroup {
+  return {
+    name: overrides.id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeWorkspace(
+  overrides: Partial<FolderWorkspace> & Pick<FolderWorkspace, 'id' | 'folderPath'>
+): FolderWorkspace {
+  return {
+    projectGroupId: 'group-root',
+    name: overrides.id,
+    comment: '',
+    linkedTask: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+/** Repos, nested groups, folder workspaces (one not a git worktree), and an SSH repo. */
+function makeMixedFixture(): StoreFixture {
+  const repos = [
+    makeRepo({ id: 'repo-local', path: '/repos/app', projectGroupId: 'group-root' }),
+    makeRepo({ id: 'repo-nested', path: '/repos/nested', projectGroupId: 'group-child' }),
+    makeRepo({ id: 'repo-folder', path: '/folders/plain', kind: 'folder' }),
+    makeRepo({
+      id: 'repo-ssh',
+      path: '/remote/app',
+      connectionId: 'ssh-1',
+      projectGroupId: 'group-remote'
+    })
+  ]
+  const projectGroups = [
+    makeGroup({ id: 'group-root', parentPath: '/folders/root' }),
+    makeGroup({ id: 'group-child', parentGroupId: 'group-root', parentPath: '/folders/child' }),
+    makeGroup({ id: 'group-grandchild', parentGroupId: 'group-child' }),
+    makeGroup({ id: 'group-remote', parentPath: '/remote/scope' }),
+    makeGroup({ id: 'group-connection', parentPath: '/remote/via-group', connectionId: 'ssh-1' })
+  ]
+  const folderWorkspaces = [
+    makeWorkspace({ id: 'ws-git', folderPath: '/folders/root/feature' }),
+    // Not a git worktree: a plain folder workspace under a folder-kind repo.
+    makeWorkspace({
+      id: 'ws-plain',
+      folderPath: '/folders/plain/scratch',
+      projectGroupId: 'group-child'
+    }),
+    makeWorkspace({ id: 'ws-remote', folderPath: '/remote/ws', projectGroupId: 'group-remote' }),
+    makeWorkspace({
+      id: 'ws-connection',
+      folderPath: '/remote/direct',
+      projectGroupId: 'group-connection'
+    }),
+    makeWorkspace({
+      id: 'ws-unlinked',
+      folderPath: '/folders/unlinked',
+      projectGroupId: 'group-orphan'
+    })
+  ]
+  const projects: Project[] = [
+    {
+      id: 'project-1',
+      displayName: 'App',
+      badgeColor: '#000000',
+      sourceRepoIds: ['repo-local', 'repo-nested'],
+      createdAt: 1,
+      updatedAt: 1
+    },
+    {
+      id: 'project-2',
+      displayName: 'Folder',
+      badgeColor: '#000000',
+      sourceRepoIds: ['repo-folder'],
+      createdAt: 1,
+      updatedAt: 1
+    }
+  ]
+  return { repos, projects, projectGroups, folderWorkspaces, workspaceDir: '/workspaces' }
+}
+
+beforeEach(() => {
+  invalidateAuthorizedRootsCache()
+  vi.mocked(buildProjectGroupChildIndex).mockClear()
+  vi.mocked(getProjectGroupSubtreeIds).mockClear()
+})
+
+describe('getAllowedRoots', () => {
+  it('produces the same roots as the pre-change implementation', () => {
+    const { store } = makeCountingStore(makeMixedFixture())
+
+    expect(getAllowedRoots(store)).toEqual(referenceAllowedRoots(store))
+  })
+
+  it('reads the store once and indexes project groups once per build', () => {
+    const fixture = makeMixedFixture()
+    const { store, counts } = makeCountingStore(fixture)
+
+    getAllowedRoots(store)
+
+    expect.soft(counts.getRepos).toBe(1)
+    expect.soft(counts.getProjectGroups).toBe(1)
+    expect.soft(counts.getFolderWorkspaces).toBe(1)
+    // Batched runtime resolution scans the project list once, not once per local repo.
+    expect.soft(counts.getProjects).toBe(1)
+    // The per-scope subtree walk no longer rebuilds the parent->children index.
+    expect.soft(vi.mocked(buildProjectGroupChildIndex)).toHaveBeenCalledTimes(1)
+    expect.soft(vi.mocked(getProjectGroupSubtreeIds)).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveAuthorizedPath allowed-root reuse', () => {
+  let repoRoot: string
+  let outsideRoot: string
+  let store: Store
+  let counts: StoreCallCounts
+
+  beforeEach(async () => {
+    repoRoot = await mkdtemp(join(await realpath(tmpdir()), 'orca-allowed-roots-'))
+    outsideRoot = await mkdtemp(join(await realpath(tmpdir()), 'orca-outside-'))
+    const fixture = makeMixedFixture()
+    fixture.repos = [makeRepo({ id: 'repo-local', path: repoRoot }), ...fixture.repos]
+    fixture.projects[0]!.sourceRepoIds = ['repo-local']
+    ;({ store, counts } = makeCountingStore(fixture))
+  })
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true })
+    await rm(outsideRoot, { recursive: true, force: true })
+  })
+
+  it('builds the allowed-root list once per call across repeated reads', async () => {
+    const dirPath = join(repoRoot, 'src')
+    await mkdir(dirPath)
+    await writeFile(join(dirPath, 'index.ts'), 'export {}\n')
+    const callCount = 5
+
+    for (let index = 0; index < callCount; index += 1) {
+      await resolveAuthorizedPath(dirPath, store)
+      await resolveAuthorizedPath(join(dirPath, 'index.ts'), store)
+    }
+
+    const buildCount = callCount * 2
+    // One build per authorization, not one per raw-path check plus one per realpath check.
+    expect.soft(counts.getFolderWorkspaces).toBe(buildCount)
+    expect.soft(counts.getRepos).toBe(buildCount)
+    expect.soft(counts.getProjects).toBe(buildCount)
+    expect.soft(vi.mocked(buildProjectGroupChildIndex)).toHaveBeenCalledTimes(buildCount)
+    expect.soft(vi.mocked(getProjectGroupSubtreeIds)).not.toHaveBeenCalled()
+  })
+
+  it('still refuses a symlink that escapes every allowed root', async () => {
+    const secret = join(outsideRoot, 'secret.txt')
+    await writeFile(secret, 'secret\n')
+    const escape = join(repoRoot, 'escape.txt')
+    await symlink(secret, escape)
+
+    await expect(resolveAuthorizedPath(escape, store)).rejects.toThrow('Access denied')
+    expect(vi.mocked(listRepoWorktreeGraph)).toHaveBeenCalled()
+  })
+
+  it('still refuses a directory symlink that escapes every allowed root', async () => {
+    const outsideDir = join(outsideRoot, 'nested')
+    await mkdir(outsideDir)
+    await writeFile(join(outsideDir, 'file.txt'), 'secret\n')
+    const escape = join(repoRoot, 'escape-dir')
+    await symlink(outsideDir, escape)
+
+    await expect(resolveAuthorizedPath(join(escape, 'file.txt'), store)).rejects.toThrow(
+      'Access denied'
+    )
+  })
+})

--- a/src/main/ipc/filesystem-allowed-roots.test.ts
+++ b/src/main/ipc/filesystem-allowed-roots.test.ts
@@ -14,7 +14,7 @@ import type { ProjectGroup } from '../../shared/project-group-types'
 import type { Project } from '../../shared/project-types'
 import type { Repo } from '../../shared/repo-types'
 import { getAllowedRoots } from './filesystem-allowed-roots'
-import { resolveAuthorizedPath } from './filesystem-auth'
+import { authorizeExternalPath, resolveAuthorizedPath } from './filesystem-auth'
 import { invalidateAuthorizedRootsCache } from './registered-worktree-roots-cache'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './worktree-logic'
 
@@ -328,6 +328,25 @@ describe('resolveAuthorizedPath allowed-root reuse', () => {
 
     await expect(resolveAuthorizedPath(escape, store)).rejects.toThrow('Access denied')
     expect(vi.mocked(listRepoWorktreeGraph)).toHaveBeenCalled()
+  })
+
+  it('builds no allowed-root list at all for a granted external path', async () => {
+    const external = join(outsideRoot, 'external.md')
+    await writeFile(external, 'notes\n')
+    authorizeExternalPath(external)
+    counts.getRepos = 0
+    counts.getProjects = 0
+    counts.getFolderWorkspaces = 0
+
+    for (let index = 0; index < 5; index += 1) {
+      await expect(resolveAuthorizedPath(external, store)).resolves.toBe(external)
+    }
+
+    // The grant answers on its own; hoisting the snapshot must not turn zero builds into one per read.
+    expect.soft(counts.getRepos).toBe(0)
+    expect.soft(counts.getProjects).toBe(0)
+    expect.soft(counts.getFolderWorkspaces).toBe(0)
+    expect.soft(vi.mocked(buildProjectGroupChildIndex)).not.toHaveBeenCalled()
   })
 
   it('still refuses a directory symlink that escapes every allowed root', async () => {

--- a/src/main/ipc/filesystem-allowed-roots.test.ts
+++ b/src/main/ipc/filesystem-allowed-roots.test.ts
@@ -320,15 +320,21 @@ describe('resolveAuthorizedPath allowed-root reuse', () => {
     expect.soft(vi.mocked(getProjectGroupSubtreeIds)).not.toHaveBeenCalled()
   })
 
-  it('still refuses a symlink that escapes every allowed root', async () => {
-    const secret = join(outsideRoot, 'secret.txt')
-    await writeFile(secret, 'secret\n')
-    const escape = join(repoRoot, 'escape.txt')
-    await symlink(secret, escape)
+  // Why (both symlink cases): creating a symlink on Windows needs elevation or
+  // Developer Mode, so these would fail EPERM in setup rather than exercise the
+  // escape check. Every non-symlink case still runs there.
+  it.skipIf(process.platform === 'win32')(
+    'still refuses a symlink that escapes every allowed root',
+    async () => {
+      const secret = join(outsideRoot, 'secret.txt')
+      await writeFile(secret, 'secret\n')
+      const escape = join(repoRoot, 'escape.txt')
+      await symlink(secret, escape)
 
-    await expect(resolveAuthorizedPath(escape, store)).rejects.toThrow('Access denied')
-    expect(vi.mocked(listRepoWorktreeGraph)).toHaveBeenCalled()
-  })
+      await expect(resolveAuthorizedPath(escape, store)).rejects.toThrow('Access denied')
+      expect(vi.mocked(listRepoWorktreeGraph)).toHaveBeenCalled()
+    }
+  )
 
   it('builds no allowed-root list at all for a granted external path', async () => {
     const external = join(outsideRoot, 'external.md')
@@ -349,15 +355,18 @@ describe('resolveAuthorizedPath allowed-root reuse', () => {
     expect.soft(vi.mocked(buildProjectGroupChildIndex)).not.toHaveBeenCalled()
   })
 
-  it('still refuses a directory symlink that escapes every allowed root', async () => {
-    const outsideDir = join(outsideRoot, 'nested')
-    await mkdir(outsideDir)
-    await writeFile(join(outsideDir, 'file.txt'), 'secret\n')
-    const escape = join(repoRoot, 'escape-dir')
-    await symlink(outsideDir, escape)
+  it.skipIf(process.platform === 'win32')(
+    'still refuses a directory symlink that escapes every allowed root',
+    async () => {
+      const outsideDir = join(outsideRoot, 'nested')
+      await mkdir(outsideDir)
+      await writeFile(join(outsideDir, 'file.txt'), 'secret\n')
+      const escape = join(repoRoot, 'escape-dir')
+      await symlink(outsideDir, escape)
 
-    await expect(resolveAuthorizedPath(join(escape, 'file.txt'), store)).rejects.toThrow(
-      'Access denied'
-    )
-  })
+      await expect(resolveAuthorizedPath(join(escape, 'file.txt'), store)).rejects.toThrow(
+        'Access denied'
+      )
+    }
+  )
 })

--- a/src/main/ipc/filesystem-allowed-roots.ts
+++ b/src/main/ipc/filesystem-allowed-roots.ts
@@ -1,9 +1,16 @@
 import { resolve } from 'node:path'
 import type { Store } from '../persistence'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './worktree-logic'
-import { getWorktreeMirrorDistro } from '../project-runtime-git-options'
+import {
+  getWorktreeMirrorDistroForRuntime,
+  resolveLocalProjectRuntimesForRepos
+} from '../project-runtime-git-options'
 import { isPathInsideOrEqual } from '../../shared/cross-platform-path'
-import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
+import {
+  buildProjectGroupChildIndex,
+  collectProjectGroupSubtreeIds,
+  type ProjectGroupChildIndex
+} from '../../shared/project-groups'
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../shared/project-group-types'
 import type { Repo } from '../../shared/repo-types'
@@ -11,18 +18,22 @@ import type { Repo } from '../../shared/repo-types'
 type FolderScopeStore = Pick<Store, 'getRepos'> &
   Partial<Pick<Store, 'getProjectGroups' | 'getFolderWorkspaces'>>
 
+// Why: SSH repo paths are remote-host paths; treating them as local roots could authorize unrelated local folders or probe SSH-only paths.
+function filterLocalRepos(repos: readonly Repo[]): Repo[] {
+  return repos.filter((repo) => !repo.connectionId)
+}
+
 export function getLocalRepos(store: Store) {
-  // Why: SSH repo paths are remote-host paths; treating them as local roots could authorize unrelated local folders or probe SSH-only paths.
-  return store.getRepos().filter((repo) => !repo.connectionId)
+  return filterLocalRepos(store.getRepos())
 }
 
 function getFolderScopeCandidateRepos(
   folderPath: string,
   projectGroupId: string,
-  projectGroups: readonly ProjectGroup[],
+  childGroupIndex: ProjectGroupChildIndex,
   repos: readonly Repo[]
 ): Repo[] {
-  const groupIds = getProjectGroupSubtreeIds(projectGroups, projectGroupId)
+  const groupIds = collectProjectGroupSubtreeIds(childGroupIndex, projectGroupId)
   return repos.filter(
     (repo) =>
       (typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) ||
@@ -34,13 +45,18 @@ function isRemoteOnlyFolderScope(
   folderPath: string,
   projectGroupId: string,
   connectionId: string | null | undefined,
-  projectGroups: readonly ProjectGroup[],
+  childGroupIndex: ProjectGroupChildIndex,
   repos: readonly Repo[]
 ): boolean {
   if (connectionId) {
     return true
   }
-  const candidates = getFolderScopeCandidateRepos(folderPath, projectGroupId, projectGroups, repos)
+  const candidates = getFolderScopeCandidateRepos(
+    folderPath,
+    projectGroupId,
+    childGroupIndex,
+    repos
+  )
   return candidates.length > 0 && candidates.every((repo) => Boolean(repo.connectionId))
 }
 
@@ -55,16 +71,22 @@ function getFolderWorkspaceConnectionId(
   )
 }
 
-function getLocalFolderScopeRoots(store: Store): string[] {
+function getLocalFolderScopeRoots(store: Store, repos: readonly Repo[]): string[] {
   const scopeStore = store as FolderScopeStore
-  const repos = scopeStore.getRepos()
   // Why: many filesystem tests use narrow Store doubles; folder scopes are additive.
   const projectGroups = scopeStore.getProjectGroups?.() ?? []
+  const childGroupIndex = buildProjectGroupChildIndex(projectGroups)
   const roots: string[] = []
   for (const group of projectGroups) {
     if (
       group.parentPath &&
-      !isRemoteOnlyFolderScope(group.parentPath, group.id, group.connectionId, projectGroups, repos)
+      !isRemoteOnlyFolderScope(
+        group.parentPath,
+        group.id,
+        group.connectionId,
+        childGroupIndex,
+        repos
+      )
     ) {
       roots.push(resolve(group.parentPath))
     }
@@ -75,7 +97,7 @@ function getLocalFolderScopeRoots(store: Store): string[] {
         workspace.folderPath,
         workspace.projectGroupId,
         getFolderWorkspaceConnectionId(workspace, projectGroups),
-        projectGroups,
+        childGroupIndex,
         repos
       )
     ) {
@@ -86,16 +108,19 @@ function getLocalFolderScopeRoots(store: Store): string[] {
 }
 
 export function getAllowedRoots(store: Store): string[] {
-  const localRepos = getLocalRepos(store)
+  // Why one read: `getRepos` rehydrates every repo, and this runs twice per filesystem IPC.
+  const repos = store.getRepos()
+  const localRepos = filterLocalRepos(repos)
   const settings = store.getSettings()
   const roots = [
     ...localRepos.map((repo) => resolve(repo.path)),
-    ...getLocalFolderScopeRoots(store)
+    ...getLocalFolderScopeRoots(store, repos)
   ]
   if (settings.workspaceDir) {
     if (localRepos.length === 0) {
       roots.push(resolve(settings.workspaceDir))
     } else {
+      const projectRuntimeByRepoId = resolveLocalProjectRuntimesForRepos(store, localRepos)
       for (const repo of localRepos) {
         roots.push(
           resolve(
@@ -104,7 +129,11 @@ export function getAllowedRoots(store: Store): string[] {
               // Why enriched here too: placement has to agree with the create
               // flow, or renderer file access is denied for a worktree Orca
               // just put on the WSL side.
-              getWorktreePathSettings(repo, settings, getWorktreeMirrorDistro(store, repo))
+              getWorktreePathSettings(
+                repo,
+                settings,
+                getWorktreeMirrorDistroForRuntime(projectRuntimeByRepoId.get(repo.id))
+              )
             )
           )
         )

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -43,10 +43,23 @@ export function authorizeExternalPath(targetPath: string): void {
   } catch {}
 }
 
+/**
+ * One allowed-root list shared by every check in a single authorization.
+ *
+ * Lazy so a path already covered by an external grant still builds nothing at all, the way it did
+ * before the list was hoisted out of the individual checks.
+ */
+type AllowedRootsSnapshot = { get: () => readonly string[] }
+
+function createAllowedRootsSnapshot(store: Store): AllowedRootsSnapshot {
+  let roots: readonly string[] | undefined
+  return { get: () => (roots ??= getAllowedRoots(store)) }
+}
+
 export function isPathAllowed(
   targetPath: string,
   store: Store,
-  allowedRoots?: readonly string[]
+  allowedRoots?: AllowedRootsSnapshot
 ): boolean {
   const resolvedTarget = resolve(targetPath)
   if (authorizedExternalPaths.has(resolvedTarget)) {
@@ -57,7 +70,7 @@ export function isPathAllowed(
       return true
     }
   }
-  return (allowedRoots ?? getAllowedRoots(store)).some((root) =>
+  return (allowedRoots?.get() ?? getAllowedRoots(store)).some((root) =>
     isDescendantOrEqual(resolvedTarget, root)
   )
 }
@@ -77,7 +90,7 @@ export async function resolveAuthorizedPath(
   const resolvedTarget = resolve(targetPath)
   // Why: the roots depend only on store state, not on the candidate path, so one snapshot serves
   // every authorization below; each candidate is still checked against it in full.
-  const allowedRoots = getAllowedRoots(store)
+  const allowedRoots = createAllowedRootsSnapshot(store)
   if (!(await isPathAllowedIncludingRegisteredWorktrees(resolvedTarget, store, { allowedRoots }))) {
     throw new Error(PATH_ACCESS_DENIED_MESSAGE)
   }
@@ -128,7 +141,7 @@ export async function resolveAuthorizedPath(
 async function resolveAuthorizedMissingPath(
   resolvedTarget: string,
   store: Store,
-  allowedRoots: readonly string[]
+  allowedRoots: AllowedRootsSnapshot
 ): Promise<string> {
   let existingAncestor = resolvedTarget
   const missingSegments: string[] = []
@@ -164,7 +177,7 @@ async function resolveAuthorizedMissingPath(
 async function isPathAllowedIncludingRegisteredWorktrees(
   targetPath: string,
   store: Store,
-  options: { canonicalSourcePath?: string; allowedRoots?: readonly string[] } = {}
+  options: { canonicalSourcePath?: string; allowedRoots?: AllowedRootsSnapshot } = {}
 ): Promise<boolean> {
   if (isPathAllowed(targetPath, store, options.allowedRoots)) {
     return true
@@ -202,12 +215,12 @@ async function isPathAllowedByCanonicalAllowedRoot(
   targetPath: string,
   sourcePath: string | undefined,
   store: Store,
-  allowedRoots?: readonly string[]
+  allowedRoots?: AllowedRootsSnapshot
 ): Promise<boolean> {
   if (!sourcePath) {
     return false
   }
-  for (const root of allowedRoots ?? getAllowedRoots(store)) {
+  for (const root of allowedRoots?.get() ?? getAllowedRoots(store)) {
     const resolvedRoot = resolve(root)
     if (!isDescendantOrEqual(sourcePath, resolvedRoot)) {
       continue

--- a/src/main/ipc/filesystem-auth.ts
+++ b/src/main/ipc/filesystem-auth.ts
@@ -43,7 +43,11 @@ export function authorizeExternalPath(targetPath: string): void {
   } catch {}
 }
 
-export function isPathAllowed(targetPath: string, store: Store): boolean {
+export function isPathAllowed(
+  targetPath: string,
+  store: Store,
+  allowedRoots?: readonly string[]
+): boolean {
   const resolvedTarget = resolve(targetPath)
   if (authorizedExternalPaths.has(resolvedTarget)) {
     return true
@@ -53,7 +57,9 @@ export function isPathAllowed(targetPath: string, store: Store): boolean {
       return true
     }
   }
-  return getAllowedRoots(store).some((root) => isDescendantOrEqual(resolvedTarget, root))
+  return (allowedRoots ?? getAllowedRoots(store)).some((root) =>
+    isDescendantOrEqual(resolvedTarget, root)
+  )
 }
 
 export type ResolveAuthorizedPathOptions = {
@@ -69,7 +75,10 @@ export async function resolveAuthorizedPath(
   options: ResolveAuthorizedPathOptions = {}
 ): Promise<string> {
   const resolvedTarget = resolve(targetPath)
-  if (!(await isPathAllowedIncludingRegisteredWorktrees(resolvedTarget, store))) {
+  // Why: the roots depend only on store state, not on the candidate path, so one snapshot serves
+  // every authorization below; each candidate is still checked against it in full.
+  const allowedRoots = getAllowedRoots(store)
+  if (!(await isPathAllowedIncludingRegisteredWorktrees(resolvedTarget, store, { allowedRoots }))) {
     throw new Error(PATH_ACCESS_DENIED_MESSAGE)
   }
 
@@ -80,14 +89,15 @@ export async function resolveAuthorizedPath(
       realParent = await realpath(dirname(resolvedTarget))
     } catch (error) {
       if (isENOENT(error)) {
-        return resolveAuthorizedMissingPath(resolvedTarget, store)
+        return resolveAuthorizedMissingPath(resolvedTarget, store, allowedRoots)
       }
       throw error
     }
     const candidateTarget = resolve(realParent, basename(resolvedTarget))
     if (
       !(await isPathAllowedIncludingRegisteredWorktrees(candidateTarget, store, {
-        canonicalSourcePath: resolvedTarget
+        canonicalSourcePath: resolvedTarget,
+        allowedRoots
       }))
     ) {
       throw new Error(PATH_ACCESS_DENIED_MESSAGE)
@@ -100,7 +110,8 @@ export async function resolveAuthorizedPath(
     const realTarget = resolve(await realpath(resolvedTarget))
     if (
       !(await isPathAllowedIncludingRegisteredWorktrees(realTarget, store, {
-        canonicalSourcePath: resolvedTarget
+        canonicalSourcePath: resolvedTarget,
+        allowedRoots
       }))
     ) {
       throw new Error(PATH_ACCESS_DENIED_MESSAGE)
@@ -110,11 +121,15 @@ export async function resolveAuthorizedPath(
     if (!isENOENT(error)) {
       throw error
     }
-    return resolveAuthorizedMissingPath(resolvedTarget, store)
+    return resolveAuthorizedMissingPath(resolvedTarget, store, allowedRoots)
   }
 }
 
-async function resolveAuthorizedMissingPath(resolvedTarget: string, store: Store): Promise<string> {
+async function resolveAuthorizedMissingPath(
+  resolvedTarget: string,
+  store: Store,
+  allowedRoots: readonly string[]
+): Promise<string> {
   let existingAncestor = resolvedTarget
   const missingSegments: string[] = []
 
@@ -124,7 +139,8 @@ async function resolveAuthorizedMissingPath(resolvedTarget: string, store: Store
       const candidateTarget = resolve(realAncestor, ...missingSegments)
       if (
         !(await isPathAllowedIncludingRegisteredWorktrees(candidateTarget, store, {
-          canonicalSourcePath: resolvedTarget
+          canonicalSourcePath: resolvedTarget,
+          allowedRoots
         }))
       ) {
         throw new Error(PATH_ACCESS_DENIED_MESSAGE)
@@ -148,9 +164,9 @@ async function resolveAuthorizedMissingPath(resolvedTarget: string, store: Store
 async function isPathAllowedIncludingRegisteredWorktrees(
   targetPath: string,
   store: Store,
-  options: { canonicalSourcePath?: string } = {}
+  options: { canonicalSourcePath?: string; allowedRoots?: readonly string[] } = {}
 ): Promise<boolean> {
-  if (isPathAllowed(targetPath, store)) {
+  if (isPathAllowed(targetPath, store, options.allowedRoots)) {
     return true
   }
 
@@ -158,7 +174,14 @@ async function isPathAllowedIncludingRegisteredWorktrees(
     return true
   }
 
-  if (await isPathAllowedByCanonicalAllowedRoot(targetPath, options.canonicalSourcePath, store)) {
+  if (
+    await isPathAllowedByCanonicalAllowedRoot(
+      targetPath,
+      options.canonicalSourcePath,
+      store,
+      options.allowedRoots
+    )
+  ) {
     return true
   }
 
@@ -178,12 +201,13 @@ async function isPathAllowedIncludingRegisteredWorktrees(
 async function isPathAllowedByCanonicalAllowedRoot(
   targetPath: string,
   sourcePath: string | undefined,
-  store: Store
+  store: Store,
+  allowedRoots?: readonly string[]
 ): Promise<boolean> {
   if (!sourcePath) {
     return false
   }
-  for (const root of getAllowedRoots(store)) {
+  for (const root of allowedRoots ?? getAllowedRoots(store)) {
     const resolvedRoot = resolve(root)
     if (!isDescendantOrEqual(sourcePath, resolvedRoot)) {
       continue

--- a/src/main/project-runtime-git-options.ts
+++ b/src/main/project-runtime-git-options.ts
@@ -102,7 +102,12 @@ export function getWorktreeMirrorDistro(
   store: ProjectRuntimeResolutionStore,
   repo: Repo
 ): string | undefined {
-  const projectRuntime = resolveLocalProjectRuntimeForRepo(store, repo)
+  return getWorktreeMirrorDistroForRuntime(resolveLocalProjectRuntimeForRepo(store, repo))
+}
+
+export function getWorktreeMirrorDistroForRuntime(
+  projectRuntime: ProjectExecutionRuntimeResolution | undefined
+): string | undefined {
   if (!projectRuntime || projectRuntime.status !== 'resolved') {
     return undefined
   }

--- a/src/shared/project-groups.ts
+++ b/src/shared/project-groups.ts
@@ -109,10 +109,12 @@ export function clearMissingProjectGroupMemberships(repos: Repo[], groups: Proje
   )
 }
 
-export function getProjectGroupSubtreeIds(
-  groups: readonly Pick<ProjectGroup, 'id' | 'parentGroupId'>[],
-  rootGroupId: string
-): Set<string> {
+export type ProjectGroupChildIndex = ReadonlyMap<string, string[]>
+
+/** Build once and reuse when collecting subtrees for more than one root. */
+export function buildProjectGroupChildIndex(
+  groups: readonly Pick<ProjectGroup, 'id' | 'parentGroupId'>[]
+): ProjectGroupChildIndex {
   const childGroupsByParentId = new Map<string, string[]>()
   for (const group of groups) {
     if (!group.parentGroupId) {
@@ -122,7 +124,20 @@ export function getProjectGroupSubtreeIds(
     children.push(group.id)
     childGroupsByParentId.set(group.parentGroupId, children)
   }
+  return childGroupsByParentId
+}
 
+export function getProjectGroupSubtreeIds(
+  groups: readonly Pick<ProjectGroup, 'id' | 'parentGroupId'>[],
+  rootGroupId: string
+): Set<string> {
+  return collectProjectGroupSubtreeIds(buildProjectGroupChildIndex(groups), rootGroupId)
+}
+
+export function collectProjectGroupSubtreeIds(
+  childGroupsByParentId: ProjectGroupChildIndex,
+  rootGroupId: string
+): Set<string> {
   const subtreeIds = new Set<string>()
   const pending = [rootGroupId]
   while (pending.length > 0) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​372 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​372 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |

<!-- /orca-pr-loc -->

## ELI5

Every time the app reads a file or lists a folder, it first has to answer "is the renderer allowed
to touch this path?" To answer that, it rebuilds the whole list of folders you're allowed to read —
walking all your repos, all your project groups and all your folder workspaces — from scratch.

It did that rebuild **twice for every single read**: once for the path as typed, and again after
resolving symlinks. And inside each rebuild it re-read your repo list twice, re-scanned your project
list once per repo, and re-built the same project-group parent/child index once per folder scope.

This builds the list once per read and reuses it for both checks, and stops the three redundant
inner rebuilds. Same list, same answers, same security decisions — just computed once instead of
over and over. The File Explorer, which re-reads every expanded directory on a refresh, pays this
cost once per directory.

## Why it matters

`getAllowedRoots()` is rebuilt from scratch **at least twice on every filesystem IPC**, on the main
thread, so it also delays PTY chunk forwarding in the same tick. From the audit that found this:

> A full File Explorer refresh re-reads root plus every expanded directory
> (`src/renderer/src/hooks/useFileExplorerTree.ts:216-242`) — 150 expanded dirs is roughly
> **170 ms of pure authorisation before a single `readdir` syscall**.

The finding's own cost breakdown, all now addressed:

- `store.getRepos()` called **twice** per build (`filesystem-allowed-roots.ts:89` and `:60`), and
  `getRepos()` runs `hydrateRepo` — 8 sanitize/normalize passes plus an object rebuild — per repo.
- `getProjectGroupSubtreeIds` called once per project group **and** once per folder workspace, each
  rebuilding its whole parent->children index (`src/shared/project-groups.ts:116-124`).
- `resolveLocalProjectRuntimeForRepo` called per repo, which does
  `getProjects().find(p => p.sourceRepoIds.includes(repo.id))` — O(repos x projects)
  (`src/main/local-project-runtime-resolution.ts:78`).

## Measurement

### Microbenchmark — µs per `getAllowedRoots` call

Measured in **separate processes** for before and after (running both implementations in one
process cross-pollutes V8's inline caches and produced impossible results like a strictly-less-work
path measuring 1.8x slower). Min of 300 adaptive ~2ms blocks after warm-up, `nice -n 10`, on a
heavily loaded machine. The bench store models the real store faithfully: `getRepos()` runs the real
`hydrateRepo` per read, `getProjects()`/`getProjectGroups()`/`getFolderWorkspaces()` return fresh
objects per read.

`before` = `origin/main`, `after` = this branch, same bench file, same fixtures.

| repos | projects | groups | folder workspaces | roots produced | before µs | after µs | per build | **per filesystem IPC** |
|---|---|---|---|---|---|---|---|---|
| 3 | 3 | 0 | 0 | 6 | 4.1 | 3.0 | 1.37x | **2.7x** (8.2 → 3.0) |
| 8 | 8 | 2 | 0 | 18 | 13.4 | 9.5 | 1.41x | **2.8x** (26.8 → 9.5) |
| 8 | 8 | 2 | 3 | 21 | 15.8 | 11.8 | 1.34x | **2.7x** (31.6 → 11.8) |
| 20 | 20 | 5 | 5 | 50 | 63.2 | 50.0 | 1.26x | **2.5x** (126.4 → 50.0) |
| 30 | 25 | 10 | 10 | 80 | 155.3 | 126.6 | 1.23x | **2.5x** (310.6 → 126.6) |

The `roots produced` column is identical on both sides at every size — the bench asserts the root
count, and the equivalence test below asserts the exact list.

"Per filesystem IPC" is `2 x before` vs `1 x after`, because `resolveAuthorizedPath` performed two
independent builds and now performs one. Headline: **~2.5x less main-thread authorization work per
`fs:readDir` / `fs:readFile`.**

Honest scoping note: the per-build speedup is a modest 1.2-1.4x rather than the superlinear collapse
you might expect, because the dominant superlinear term — `repos.filter(isPathInsideOrEqual)` once
per folder scope — is genuinely per-scope work that this PR does **not** touch. The large win is the
2x from building once per IPC instead of twice.

The per-IPC snapshot is built lazily. A path already covered by an external grant answers inside
`isPathAllowed` before it ever looks at the roots, so those reads build **zero** root lists, exactly
as they did before the hoist; an eager snapshot would have turned that into one build per read.
`builds no allowed-root list at all for a granted external path` guards it.

### Regression guard — deterministic call counters

`src/main/ipc/filesystem-allowed-roots.test.ts` counts store reads and index builds. No wall-clock
assertions (the machine is loaded and timing tests flake).

**With the change — 5 passed:**

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Without the change** (reverted `filesystem-allowed-roots.ts` and `filesystem-auth.ts` to
`origin/main`, left everything else) — 2 tests fail with 9 soft-assertion failures:

```
 ❯ src/main/ipc/filesystem-allowed-roots.test.ts (5 tests | 2 failed) 136ms
     × reads the store once and indexes project groups once per build 5ms
     × builds the allowed-root list once per call across repeated reads 77ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  > getAllowedRoots > reads the store once and indexes project groups once per build
AssertionError: expected 2 to be 1            ❯ :272  expect.soft(counts.getRepos).toBe(1)
AssertionError: expected 3 to be 1            ❯ :276  expect.soft(counts.getProjects).toBe(1)
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
                                              ❯ :278  buildProjectGroupChildIndex
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 7 times
                                              ❯ :279  getProjectGroupSubtreeIds

 FAIL  > resolveAuthorizedPath allowed-root reuse > builds the allowed-root list once per call
AssertionError: expected 20 to be 10          ❯ :316  expect.soft(counts.getFolderWorkspaces)
AssertionError: expected 40 to be 10          ❯ :317  expect.soft(counts.getRepos)
AssertionError: expected 80 to be 10          ❯ :318  expect.soft(counts.getProjects)
AssertionError: expected "vi.fn()" to be called 10 times, but got 0 times
                                              ❯ :319  buildProjectGroupChildIndex
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 140 times
                                              ❯ :320  getProjectGroupSubtreeIds

 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)
```

Read across 10 `resolveAuthorizedPath` calls (the second test), that is:

| counter | before | after |
|---|---|---|
| root-list builds (`getFolderWorkspaces`) | 20 | 10 |
| `store.getRepos()` | 40 | 10 |
| `store.getProjects()` | 80 | 10 |
| project-group child index builds | 140 | 10 |

## Correctness

**Why the output is provably identical.** The test `produces the same roots as the pre-change
implementation` keeps a verbatim copy of the old `getAllowedRoots` algorithm in the test file and
asserts `toEqual` against the new one, over a fixture containing repos, a project group with a
nested child and grandchild, folder workspaces, an SSH repo (`connectionId` set), an SSH-scoped
group, a folder workspace whose group carries the `connectionId`, a folder workspace pointing at an
unknown group, and a folder workspace that is **not** a git worktree (a plain folder under a
`kind: 'folder'` repo). The microbenchmark independently asserts the root count matches at all five
sizes.

The three changes and their invalidation questions:

1. **One root snapshot per `resolveAuthorizedPath`.** The roots depend only on store state, never on
   the candidate path, so they were being recomputed for a value that cannot have changed as a
   function of the input. The symlink-escape check is **fully preserved**: the second authorization
   call still runs, still against the full root list, still on the `realpath`-ed target. What is
   hoisted is the roots, not the check. Two tests assert this directly — a file symlink and a
   directory symlink both pointing outside every allowed root are still refused with `Access denied`.
   *Staleness question I had to answer:* could the store mutate between the raw-path check and the
   realpath check (there is an `await realpath` between them), making the reused snapshot differ from
   a fresh read? Yes, in principle — but only in a window of microseconds, and the raw path was
   already authorized against that very snapshot a moment earlier. Taking one snapshot at the start
   of the call is the conventional TOCTOU semantics for an authorization check and is strictly more
   self-consistent than the old behaviour, which mixed two different snapshots within one decision.
   No memoisation across calls is introduced, so there is nothing to invalidate: every
   `resolveAuthorizedPath` still reads the store fresh.

2. **Project-group child index built once per root build.** `getProjectGroupSubtreeIds` is split into
   `buildProjectGroupChildIndex(groups)` + `collectProjectGroupSubtreeIds(index, rootId)`, and
   `getProjectGroupSubtreeIds` is **kept as a wrapper with its unchanged signature**, so none of its
   ~10 other call sites change at all. The traversal body — including the deliberate non-spread
   `pending.push` for very wide imported trees — is byte-identical. `getLocalFolderScopeRoots` now
   builds the index once instead of once per group plus once per folder workspace. Pure hoist of a
   pure function of an input that does not vary inside the loop.

3. **Batched project-runtime resolution.** `resolveLocalProjectRuntimesForRepos` already existed and
   is already used by two other call sites. Equivalence with the per-repo `resolveLocalProjectRuntimeForRepo`:
   both skip non-local-host repos; both bail identically when the store lacks `getProjects`/`getSettings`
   (`canResolveProjectRuntimeForRepo` is the same guard, so narrow test doubles behave the same, and
   the map's `.get()` returning `undefined` maps onto the old `undefined` return); for a repo listed in
   several projects, the batched version's `!runtimeByRepoId.has(repoId)` makes the first project in
   `getProjects()` order win, exactly like the old `.find()`; a repo in no project yields no entry,
   exactly like the old `undefined`. Introduced `getWorktreeMirrorDistroForRuntime` alongside the
   existing `getWorktreeMirrorDistro`, mirroring the existing
   `getLocalProjectWorktreeGitOptionsForRuntime` precedent in the same file; `getWorktreeMirrorDistro`
   is now a one-line delegate so its 5 other call sites are untouched.

**Not shipped: memoising the root list on a store revision.** The brief flagged it as tempting.
It needs invalidation reasoning across every store mutation path (repo add/remove/move,
project-group create/reparent/delete, folder-workspace create/delete, `workspaceDir` and
`nestWorkspaces` settings changes, WSL distro cache warm-up, project runtime-preference edits) and a
stale entry here means *widening an authorization allowlist*. Items 1-3 need no invalidation
reasoning at all and get the same headline number, so per the brief I shipped those and stopped.

**Edge cases.**
- *SSH*: the SSH-repo filter (`!repo.connectionId`) and the remote-only folder-scope logic are
  moved into `filterLocalRepos` / threaded through unchanged, with the original "why" comment kept
  on the filter. The fixture covers an SSH repo, an SSH-only project group, and a folder workspace
  inheriting `connectionId` from its group; all three still yield no local root. SSH-served
  `fs:readDir`/`fs:readFile` return before `resolveAuthorizedPath` and are untouched.
- *Folder workspaces that are not git worktrees*: covered explicitly in the equivalence fixture
  (`ws-plain` under a `kind: 'folder'` repo). Folder-scope roots are computed from `folderPath` and
  group membership, never from worktree state; nothing here assumes a git worktree.
- *Windows*: no new path handling. All path work still goes through `node:path` `resolve` and the
  existing `isPathInsideOrEqual` / `isDescendantOrEqual` helpers. The `realpath` UNC re-`resolve`
  comment and behaviour are unchanged.
- *Empty/missing state*: `getProjectGroups`/`getFolderWorkspaces` remain optional with the same
  `?? []` fallbacks and the same "narrow Store doubles" comment, so `buildProjectGroupChildIndex([])`
  returns an empty index and the loops do not run. The `localRepos.length === 0` branch is unchanged,
  and the batched runtime resolution is only reached inside the `workspaceDir && localRepos.length > 0`
  branch, so no store reads were added to the empty case.
- *#18348 (`fix(ipc): stop renderer grants from widening the FS allowlist`)*: read before touching
  this file. That PR's contract lives in the renderer-facing grant IPCs and the
  `authorizedExternalPaths` set. This PR does not touch grant validation, the grant set, or any
  renderer IPC; the `authorizedExternalPaths` short-circuits in `isPathAllowed` are byte-identical and
  still run before the root check.

## Negative user-facing trade-offs

**None.** The allowed-root list is provably identical (asserted against a verbatim copy of the old
algorithm), no cache, TTL, debounce, cadence, threshold or staleness window is introduced, and the
symlink-escape re-check on the resolved path still runs in full — with two new tests proving an
escape outside every allowed root is still refused.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/ipc/filesystem src/main/ipc/registered-worktree-roots-cache src/shared/project-groups.test.ts src/main/local-project-runtime-resolution.test.ts src/main/worktree-root-preparation.test.ts src/main/worktree-name-retirement.test.ts` — 46 files, 445 passed, 2 skipped.
- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/shared/folder-workspace-execution-host src/main/persistence/tracking-repos src/main/project-groups src/main/ipc/worktrees/metadata src/main/persistence/restoring-sessions` (the other `getProjectGroupSubtreeIds` consumers) — 16 files, 182 passed.
- New `src/main/ipc/filesystem-allowed-roots.test.ts` — 5 tests: old-vs-new root-list equivalence over the mixed fixture, two deterministic call-counter guards, and two symlink-escape refusals (file and directory).
- Verified both counter tests fail on `origin/main` (output pasted above) and pass with the change.
- `nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false` — clean.
- `node_modules/.bin/oxlint` on all changed files — clean. `node_modules/.bin/oxfmt --write` applied.
- The temporary benchmark file used for the table above was deleted and is not part of this PR.

Platforms exercised by tests: macOS. No platform-specific code paths were added or changed.

