### PR TITLE
perf(main): take the idle ownership poll off the main thread and batch pending marker probes

### DIFF
--- a/src/main/ipc/worktree-base-directory-marker-poller.ts
+++ b/src/main/ipc/worktree-base-directory-marker-poller.ts
@@ -28,7 +28,7 @@ const PENDING_MARKER_MAX_TICKS = 300
 // Why: matches the git-common poller's fan-out bound (#17828) — bounded
 // concurrency turns hundreds of serial round trips into a handful of batches
 // without dumping every candidate onto libuv's 4-thread pool at once.
-const MARKER_PROBE_CONCURRENCY = 8
+export const MARKER_PROBE_CONCURRENCY = 8
 
 function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
   return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
@@ -186,7 +186,7 @@ export async function startBasePoller(
   }
 
   const checkPendingMarkers = async (): Promise<void> => {
-    const events: WorktreeBasePollEvent[] = []
+    const dueDirs: string[] = []
     for (const [dir, firstSeenTick] of markerProbeStartedAt) {
       if (firstSeenTick === null) {
         continue
@@ -195,13 +195,19 @@ export async function startBasePoller(
         markerProbeStartedAt.set(dir, null)
         continue
       }
+      dueDirs.push(dir)
+    }
+    const events: WorktreeBasePollEvent[] = []
+    // Same bound as the full scan's fan-out: serial probes cost D x latency per tick,
+    // which a WSL- or network-backed base directory pays for up to `pendingMarkerMaxTicks`.
+    await forEachWithConcurrency(dueDirs, MARKER_PROBE_CONCURRENCY, async (dir) => {
       options.onPendingMarkerProbe?.(join(dir, '.git'))
       if (await hasGitMarker(dir)) {
         markerProbeStartedAt.delete(dir)
         snapshot.markers.set(dir, true)
         events.push({ type: 'create', path: join(dir, '.git') })
       }
-    }
+    })
     if (!disposed && events.length > 0) {
       onEvents(events)
     }

--- a/src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { MARKER_PROBE_CONCURRENCY } from './worktree-base-directory-marker-poller'
 import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
 import type {
   WorktreeBaseRepoWatchConfig,
@@ -12,7 +13,11 @@ import type {
 // Why: the backstop full scan stats a `.git` marker per candidate dir; an
 // unbounded fan-out at hundreds of worktrees would queue thousands of `stat`
 // calls on libuv's 4-thread pool (#17828).
-const { concurrency } = vi.hoisted(() => ({ concurrency: { current: 0, peak: 0 } }))
+const { concurrency, markerStatGate } = vi.hoisted(() => ({
+  concurrency: { current: 0, peak: 0 },
+  // Parks `.git` stats so a batch's launched-at-once width is observable without wall clocks.
+  markerStatGate: { hold: false, parked: [] as (() => void)[] }
+}))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof NodeFsPromises>()
@@ -22,6 +27,9 @@ vi.mock('node:fs/promises', async (importOriginal) => {
       concurrency.current += 1
       concurrency.peak = Math.max(concurrency.peak, concurrency.current)
       try {
+        if (markerStatGate.hold && String(args[0]).endsWith('.git')) {
+          await new Promise<void>((resolve) => markerStatGate.parked.push(resolve))
+        }
         return await actual.stat(...args)
       } finally {
         concurrency.current -= 1
@@ -50,11 +58,26 @@ describe('worktree base directory poller marker fan-out (#17828)', () => {
   beforeEach(() => {
     concurrency.current = 0
     concurrency.peak = 0
+    markerStatGate.hold = false
+    markerStatGate.parked.length = 0
   })
 
   afterEach(async () => {
+    markerStatGate.hold = false
+    for (const resume of markerStatGate.parked.splice(0)) {
+      resume()
+    }
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
   })
+
+  async function waitUntil(predicate: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 2_000 && !predicate(); attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    }
+    if (!predicate()) {
+      throw new Error('timed out waiting for the poller')
+    }
+  }
 
   it('bounds concurrent `.git`-marker stats regardless of candidate count', async () => {
     const root = await realpath(await mkdtemp(join(tmpdir(), 'orca-base-poller-fanout-')))
@@ -80,5 +103,48 @@ describe('worktree base directory poller marker fan-out (#17828)', () => {
     // while still overlapping requests (not serialized one-at-a-time).
     expect(concurrency.peak).toBeGreaterThan(1)
     expect(concurrency.peak).toBeLessThan(20)
+  })
+
+  it('probes pending `.git` markers in bounded batches instead of one at a time', async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'orca-base-poller-pending-')))
+    cleanups.push(() => rm(root, { recursive: true, force: true }))
+    const pendingCount = MARKER_PROBE_CONCURRENCY * 4
+    for (let i = 0; i < pendingCount; i++) {
+      // No `.git`: every dir stays a pending-marker candidate for the whole test.
+      await mkdir(join(root, `pending-${i}`))
+    }
+
+    const probed: string[] = []
+    let parkFirstBatch = true
+    const target = makeTarget(root)
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      () => {},
+      {
+        pollIntervalMs: 1,
+        onPendingMarkerProbe: (path) => {
+          probed.push(path)
+          // Park from the first probe onward, so the count below is the batch width.
+          markerStatGate.hold = parkFirstBatch
+        }
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    await waitUntil(() => markerStatGate.parked.length > 0)
+
+    // Serial probing parks after one; the batch launches exactly the bound at once.
+    expect(probed.length).toBe(MARKER_PROBE_CONCURRENCY)
+
+    parkFirstBatch = false
+    markerStatGate.hold = false
+    for (const resume of markerStatGate.parked.splice(0)) {
+      resume()
+    }
+    await waitUntil(() => probed.length >= pendingCount)
+
+    // The first tick still probes every due dir exactly once.
+    expect(new Set(probed.slice(0, pendingCount)).size).toBe(pendingCount)
   })
 })

--- a/src/main/runtime/runtime-metadata-ownership-watch.test.ts
+++ b/src/main/runtime/runtime-metadata-ownership-watch.test.ts
@@ -1,4 +1,6 @@
 import { mkdtempSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -9,6 +11,82 @@ import {
   watchRuntimeMetadataOwnership,
   type RuntimeMetadataOwnershipWatch
 } from './runtime-metadata-ownership-watch'
+
+// Counts blocking fs calls against orca-runtime.json so the poll tick's I/O stays off the main thread.
+const metadataSyncCalls = vi.hoisted(() => {
+  const state = { recording: false, calls: [] as string[] }
+  return {
+    state,
+    record(fn: string, target: unknown): void {
+      if (state.recording && typeof target === 'string' && target.endsWith('orca-runtime.json')) {
+        state.calls.push(fn)
+      }
+    }
+  }
+})
+
+// Lets a test park the tick's async read so overlapping ticks are observable without wall clocks.
+const metadataReadGate = vi.hoisted(() => {
+  const gate = {
+    hold: false,
+    reads: 0,
+    parked: [] as (() => void)[],
+    /** Reads handed to the real fs; parked ones are excluded so `whenIdle` stays answerable. */
+    active: 0,
+    idle: [] as (() => void)[],
+    whenIdle(): Promise<void> {
+      return gate.active === 0
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => gate.idle.push(resolve))
+    }
+  }
+  return gate
+})
+
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+  return {
+    ...actual,
+    default: actual,
+    readFile: (async (target: unknown, options: never) => {
+      const call = (): unknown =>
+        (actual.readFile as (...args: never[]) => unknown)(target as never, options)
+      if (typeof target !== 'string' || !target.endsWith('orca-runtime.json')) {
+        return call()
+      }
+      metadataReadGate.reads += 1
+      if (metadataReadGate.hold) {
+        await new Promise<void>((resolve) => metadataReadGate.parked.push(resolve))
+      }
+      metadataReadGate.active += 1
+      try {
+        return await call()
+      } finally {
+        metadataReadGate.active -= 1
+        if (metadataReadGate.active === 0) {
+          for (const resolve of metadataReadGate.idle.splice(0)) {
+            resolve()
+          }
+        }
+      }
+    }) as typeof actual.readFile
+  }
+})
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    existsSync: (target: NodeFs.PathLike) => {
+      metadataSyncCalls.record('existsSync', target)
+      return actual.existsSync(target)
+    },
+    readFileSync: ((target: never, options: never) => {
+      metadataSyncCalls.record('readFileSync', target)
+      return actual.readFileSync(target, options)
+    }) as typeof actual.readFileSync
+  }
+})
 
 const OWNED_PID = 4242
 const OWNED_RUNTIME_ID = 'rt_owner'
@@ -81,6 +159,14 @@ describe('watchRuntimeMetadataOwnership', () => {
   const userDataPaths: string[] = []
 
   afterEach(() => {
+    metadataSyncCalls.state.recording = false
+    metadataSyncCalls.state.calls.length = 0
+    metadataReadGate.hold = false
+    metadataReadGate.reads = 0
+    for (const resume of metadataReadGate.parked.splice(0)) {
+      resume()
+    }
+    metadataReadGate.idle.splice(0)
     for (const watch of watches.splice(0)) {
       watch.stop()
     }
@@ -103,13 +189,32 @@ describe('watchRuntimeMetadataOwnership', () => {
     return watch
   }
 
+  function usePolledTimers(): void {
+    vi.useFakeTimers({ toFake: ['setInterval', 'clearInterval'] })
+  }
+
+  /** Waits out the tick's real read; everything after it resolves as microtasks. */
+  async function settleReads(): Promise<void> {
+    await new Promise((resolve) => setImmediate(resolve))
+    await metadataReadGate.whenIdle()
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+
+  /** Fires one interval at a time so each tick's async read settles before the next. */
+  async function advancePolls(ms: number, stepMs = 1_000): Promise<void> {
+    for (let elapsed = 0; elapsed < ms; elapsed += stepMs) {
+      await vi.advanceTimersByTimeAsync(stepMs)
+      await settleReads()
+    }
+  }
+
   function makeUserDataPath(): string {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-ownership-'))
     userDataPaths.push(userDataPath)
     return userDataPath
   }
 
-  it('republishes after a second instance clobbers the record and exits', () => {
+  it('republishes after a second instance clobbers the record and exits', async () => {
     const userDataPath = makeUserDataPath()
     writeRuntimeMetadata(userDataPath, record())
     const watch = armWatch(userDataPath)
@@ -118,7 +223,7 @@ describe('watchRuntimeMetadataOwnership', () => {
       userDataPath,
       record({ pid: FOREIGN_DEAD_PID, runtimeId: 'rt_second_instance' })
     )
-    watch.check()
+    await watch.check()
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({
       pid: OWNED_PID,
@@ -126,28 +231,28 @@ describe('watchRuntimeMetadataOwnership', () => {
     })
   })
 
-  it('republishes a record that was deleted underneath the runtime', () => {
+  it('republishes a record that was deleted underneath the runtime', async () => {
     const userDataPath = makeUserDataPath()
     writeRuntimeMetadata(userDataPath, record())
     const watch = armWatch(userDataPath)
 
     clearRuntimeMetadata(userDataPath)
-    watch.check()
+    await watch.check()
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: OWNED_PID })
   })
 
-  it('replaces an unreadable record', () => {
+  it('replaces an unreadable record', async () => {
     const userDataPath = makeUserDataPath()
     const watch = armWatch(userDataPath)
     writeFileSync(getRuntimeMetadataPath(userDataPath), '{ truncated')
 
-    watch.check()
+    await watch.check()
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: OWNED_PID })
   })
 
-  it('leaves a live sibling runtime in place', () => {
+  it('leaves a live sibling runtime in place', async () => {
     const userDataPath = makeUserDataPath()
     const watch = armWatch(userDataPath)
     writeRuntimeMetadata(
@@ -155,13 +260,13 @@ describe('watchRuntimeMetadataOwnership', () => {
       record({ pid: FOREIGN_LIVE_PID, runtimeId: 'rt_second_instance' })
     )
 
-    watch.check()
+    await watch.check()
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: FOREIGN_LIVE_PID })
   })
 
-  it('reclaims on the poll interval without an explicit check', () => {
-    vi.useFakeTimers()
+  it('reclaims on the poll interval without an explicit check', async () => {
+    usePolledTimers()
     const userDataPath = makeUserDataPath()
     armWatch(userDataPath, 1_000)
     writeRuntimeMetadata(
@@ -169,13 +274,13 @@ describe('watchRuntimeMetadataOwnership', () => {
       record({ pid: FOREIGN_DEAD_PID, runtimeId: 'rt_second_instance' })
     )
 
-    vi.advanceTimersByTime(1_000)
+    await advancePolls(1_000)
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: OWNED_PID })
   })
 
-  it('stops reclaiming once the watch is stopped', () => {
-    vi.useFakeTimers()
+  it('stops reclaiming once the watch is stopped', async () => {
+    usePolledTimers()
     const userDataPath = makeUserDataPath()
     const watch = armWatch(userDataPath, 1_000)
 
@@ -184,13 +289,59 @@ describe('watchRuntimeMetadataOwnership', () => {
       userDataPath,
       record({ pid: FOREIGN_DEAD_PID, runtimeId: 'rt_second_instance' })
     )
-    vi.advanceTimersByTime(5_000)
+    await advancePolls(5_000)
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: FOREIGN_DEAD_PID })
   })
 
-  it('keeps polling after a republish failure', () => {
-    vi.useFakeTimers()
+  it('reads the record off-thread, so the poll tick never blocks the main thread', async () => {
+    const userDataPath = makeUserDataPath()
+    writeRuntimeMetadata(userDataPath, record())
+    const watch = armWatch(userDataPath)
+
+    metadataSyncCalls.state.recording = true
+    await watch.check()
+    await watch.check()
+    metadataSyncCalls.state.recording = false
+
+    expect(metadataSyncCalls.state.calls).toEqual([])
+  })
+
+  it('treats a missing record as reclaimable without a pre-existence check', async () => {
+    const userDataPath = makeUserDataPath()
+    const watch = armWatch(userDataPath)
+
+    metadataSyncCalls.state.recording = true
+    await watch.check()
+    metadataSyncCalls.state.recording = false
+
+    expect(metadataSyncCalls.state.calls).toEqual([])
+    expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: OWNED_PID })
+  })
+
+  it('never runs two overlapping ownership checks', async () => {
+    usePolledTimers()
+    const userDataPath = makeUserDataPath()
+    writeRuntimeMetadata(userDataPath, record())
+    armWatch(userDataPath, 1_000)
+
+    metadataReadGate.hold = true
+    await advancePolls(3_000)
+
+    expect(metadataReadGate.reads).toBe(1)
+
+    metadataReadGate.hold = false
+    for (const resume of metadataReadGate.parked.splice(0)) {
+      resume()
+    }
+    await settleReads()
+    await advancePolls(1_000)
+
+    expect(metadataReadGate.reads).toBe(2)
+  })
+
+  it('keeps polling after a republish failure', async () => {
+    usePolledTimers()
     const userDataPath = makeUserDataPath()
     const republish = vi
       .fn()
@@ -209,7 +360,7 @@ describe('watchRuntimeMetadataOwnership', () => {
     })
     watches.push(watch)
 
-    vi.advanceTimersByTime(2_000)
+    await advancePolls(2_000)
 
     expect(republish).toHaveBeenCalledTimes(2)
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ pid: OWNED_PID })

--- a/src/main/runtime/runtime-metadata-ownership-watch.ts
+++ b/src/main/runtime/runtime-metadata-ownership-watch.ts
@@ -1,5 +1,5 @@
 import { getRuntimeMetadataPath, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
-import { readRuntimeMetadata } from './runtime-metadata'
+import { readRuntimeMetadataAsync } from './runtime-metadata'
 
 /**
  * Why: `orca-runtime.json` is the CLI's only pointer at a live runtime, and it
@@ -18,7 +18,7 @@ export const RUNTIME_METADATA_OWNERSHIP_POLL_MS = 10_000
 
 export type RuntimeMetadataOwnershipWatch = {
   /** Runs one ownership check immediately; exposed for tests and eager repair. */
-  check: () => void
+  check: () => Promise<void>
   stop: () => void
 }
 
@@ -56,8 +56,9 @@ export function watchRuntimeMetadataOwnership(
   options: RuntimeMetadataOwnershipWatchOptions
 ): RuntimeMetadataOwnershipWatch {
   const isProcessRunning = options.isProcessRunning ?? isPidRunning
-  const check = (): void => {
-    const current = tryReadRuntimeMetadata(options.userDataPath)
+  let inFlight: Promise<void> | null = null
+  const runCheck = async (): Promise<void> => {
+    const current = await tryReadRuntimeMetadata(options.userDataPath)
     if (
       !shouldReclaimRuntimeMetadata(
         current,
@@ -77,8 +78,18 @@ export function watchRuntimeMetadataOwnership(
     }
     options.onReclaim?.(current)
   }
+  // Why: the read is off-thread now, so a slow volume could otherwise stack ticks on one file.
+  const check = (): Promise<void> => {
+    inFlight ??= runCheck().finally(() => {
+      inFlight = null
+    })
+    return inFlight
+  }
 
-  const timer = setInterval(check, options.pollIntervalMs ?? RUNTIME_METADATA_OWNERSHIP_POLL_MS)
+  const timer = setInterval(
+    () => void check(),
+    options.pollIntervalMs ?? RUNTIME_METADATA_OWNERSHIP_POLL_MS
+  )
   // Why: discovery bookkeeping must never be the reason the process stays alive.
   timer.unref?.()
   return {
@@ -87,9 +98,9 @@ export function watchRuntimeMetadataOwnership(
   }
 }
 
-function tryReadRuntimeMetadata(userDataPath: string): RuntimeMetadata | null {
+async function tryReadRuntimeMetadata(userDataPath: string): Promise<RuntimeMetadata | null> {
   try {
-    return readRuntimeMetadata(userDataPath)
+    return await readRuntimeMetadataAsync(userDataPath)
   } catch (error) {
     // Why: an unparseable record is as useless to the CLI as a missing one, so treat it as reclaimable.
     console.warn(

--- a/src/main/runtime/runtime-metadata.ts
+++ b/src/main/runtime/runtime-metadata.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
 import { getRuntimeMetadataPath, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import { writeSecureJsonFile } from '../../shared/secure-file'
 
@@ -13,6 +14,22 @@ export function readRuntimeMetadata(userDataPath: string): RuntimeMetadata | nul
     return null
   }
   return JSON.parse(readFileSync(metadataPath, 'utf-8')) as RuntimeMetadata
+}
+
+/** Off-thread twin of {@link readRuntimeMetadata} for pollers; a missing file is not an error. */
+export async function readRuntimeMetadataAsync(
+  userDataPath: string
+): Promise<RuntimeMetadata | null> {
+  let raw: string
+  try {
+    raw = await readFile(getRuntimeMetadataPath(userDataPath), 'utf-8')
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+  return JSON.parse(raw) as RuntimeMetadata
 }
 
 export function clearRuntimeMetadata(userDataPath: string): void {

--- a/src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts
+++ b/src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts
@@ -7,6 +7,7 @@ import * as runtimeMetadataModule from './runtime-metadata'
 import { readRuntimeMetadata, writeRuntimeMetadata } from './runtime-metadata'
 import { createRuntimeTransportMetadata, OrcaRuntimeRpcServer } from './runtime-rpc'
 import type { DeviceRegistry } from './device-registry'
+import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
 
 vi.mock('../git/worktree', () => {
   const worktrees = [
@@ -116,6 +117,39 @@ describe('OrcaRuntimeRpcServer', () => {
 
     expect(watchStop).toHaveBeenCalledTimes(1)
     expect(server['metadataOwnershipWatch']).toBeNull()
+    expect(readRuntimeMetadata(userDataPath)).toMatchObject({ runtimeId: 'rt_second_instance' })
+  })
+
+  it('drops a republish from an ownership read that lands after the server stopped', async () => {
+    // Why: the read is off-thread now, so a tick can outlive stop(); the cleared
+    // activeTransports guard — not the interval teardown — is what stops it republishing.
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const server = new OrcaRuntimeRpcServer({ runtime, userDataPath, pid: 1001 })
+    await server.start()
+
+    let releaseRead: (record: RuntimeMetadata | null) => void = () => {}
+    vi.spyOn(runtimeMetadataModule, 'readRuntimeMetadataAsync').mockImplementationOnce(
+      () =>
+        new Promise<RuntimeMetadata | null>((resolve) => {
+          releaseRead = resolve
+        })
+    )
+    const heldCheck = server.checkRuntimeMetadataOwnership()
+
+    await server.stop()
+    writeRuntimeMetadata(userDataPath, {
+      runtimeId: 'rt_second_instance',
+      pid: 99999999,
+      transports: [],
+      authToken: 'second-instance-token',
+      startedAt: 1
+    })
+    // A missing record is the most reclaimable verdict there is, so an unguarded
+    // resume would rewrite the file the second instance just published.
+    releaseRead(null)
+    await heldCheck
+
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ runtimeId: 'rt_second_instance' })
   })
 

--- a/src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts
+++ b/src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts
@@ -61,7 +61,7 @@ describe('OrcaRuntimeRpcServer', () => {
       authToken: 'second-instance-token',
       startedAt: 1
     })
-    server.checkRuntimeMetadataOwnership()
+    await server.checkRuntimeMetadataOwnership()
 
     expect(readRuntimeMetadata(userDataPath)).toEqual(published)
 
@@ -86,7 +86,7 @@ describe('OrcaRuntimeRpcServer', () => {
       authToken: 'sibling-token',
       startedAt: 1
     })
-    server.checkRuntimeMetadataOwnership()
+    await server.checkRuntimeMetadataOwnership()
 
     expect(readRuntimeMetadata(userDataPath)).toMatchObject({ runtimeId: 'rt_live_sibling' })
 
@@ -112,7 +112,7 @@ describe('OrcaRuntimeRpcServer', () => {
       authToken: 'second-instance-token',
       startedAt: 1
     })
-    server.checkRuntimeMetadataOwnership()
+    await server.checkRuntimeMetadataOwnership()
 
     expect(watchStop).toHaveBeenCalledTimes(1)
     expect(server['metadataOwnershipWatch']).toBeNull()

--- a/src/main/runtime/runtime-rpc/runtime-rpc-shutdown.ts
+++ b/src/main/runtime/runtime-rpc/runtime-rpc-shutdown.ts
@@ -2,8 +2,8 @@ import { RuntimeRpcMobilePairing } from './runtime-rpc-mobile-pairing'
 
 export class RuntimeRpcShutdown extends RuntimeRpcMobilePairing {
   /** Why: test-only seam — runs one ownership check instead of waiting out the poll interval. */
-  checkRuntimeMetadataOwnership(): void {
-    this.metadataOwnershipWatch?.check()
+  checkRuntimeMetadataOwnership(): Promise<void> {
+    return this.metadataOwnershipWatch?.check() ?? Promise.resolve()
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​251 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

Two background chores run forever while the app sits idle doing nothing.

The first one checks, six times a minute, that a small bookkeeping file still says "this app owns
this session". It reads that file in the blocking way — the whole app freezes for a fraction of a
millisecond each time, over half a million times in a week-long run. It now reads the file the
non-blocking way, so nothing waits on it.

The second one watches a folder for new worktrees appearing. When some folders are still "half
created", it re-checks them one at a time, waiting for each answer before starting the next. Every
other check in that same file already asks eight at once. Now this one does too. On a local SSD
that's a rounding error; on a WSL or network-mounted folder each check has real latency, and they
were being paid back to back.

## Why it matters

**Finding 1 (main-thread block).** `watchRuntimeMetadataOwnership` ran
`existsSync` + `readFileSync` + `JSON.parse` on the main thread every 10s, un-gated by window
visibility (`src/main/runtime/runtime-metadata-ownership-watch.ts:81`,
`src/main/runtime/runtime-metadata.ts:10-16`). That is 6 blocking file reads a minute, ~518,000 over
a week-long session, for the life of the process. It is exactly the class of perfectly-periodic
main-thread stall the repo's own probe (`src/main/startup/event-loop-stall-probe.ts:8`) exists to
catch. The syscall count on the tick path goes from 2 blocking calls to 0 (measured below).

**Finding 2 (serial fan-out).** `checkPendingMarkers` probed pending `.git` markers with a plain
`for ... await`, so a tick with D pending dirs cost `D x latency` instead of
`ceil(D / 8) x latency`, repeated for up to `PENDING_MARKER_MAX_TICKS = 300` ticks at 2s. The full
scan in the same file already runs its marker probes through
`forEachWithConcurrency(candidates, MARKER_PROBE_CONCURRENCY, ...)` with a comment explaining why
(#17828); the pending path just never got the same treatment. Measured batch width goes from **1 to
8** (the existing constant).

## Measurement

### Finding 1 — blocking syscalls on the tick path

New test counts `existsSync` / `readFileSync` calls against `orca-runtime.json` during two ticks.

Before (reverted to the sync implementation, signature kept async so only the I/O shape differs):

```
 ❯ src/main/runtime/runtime-metadata-ownership-watch.test.ts (15 tests | 3 failed)
     × reads the record off-thread, so the poll tick never blocks the main thread
     × treats a missing record as reclaimable without a pre-existence check
     × never runs two overlapping ownership checks

 FAIL  ... > reads the record off-thread, so the poll tick never blocks the main thread
AssertionError: expected [ 'existsSync', 'readFileSync', …(2) ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "existsSync",
+   "readFileSync",
+   "existsSync",
+   "readFileSync",
+ ]

 FAIL  ... > treats a missing record as reclaimable without a pre-existence check
AssertionError: expected [ 'existsSync' ] to deeply equal []

- Expected
+ Received

- []
+ [
+   "existsSync",
+ ]

 FAIL  ... > never runs two overlapping ownership checks
AssertionError: expected +0 to be 1 // Object.is equality
```

After:

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

So: **4 blocking fs calls over 2 ticks → 0**, and the missing-file case drops its `existsSync`
probe entirely while still returning the reclaimable verdict.

### Finding 2 — pending-marker batch width

New test parks every `.git` stat from the first probe onward and counts how many probes were
launched before any could complete. That number *is* the batch width, with no wall clock involved.

Before (reverted `checkPendingMarkers` to the serial loop):

```
 FAIL  src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts > worktree base directory
       poller marker fan-out (#17828) > probes pending `.git` markers in bounded batches instead of
       one at a time
AssertionError: expected 1 to be 8 // Object.is equality

- Expected
+ Received

- 8
+ 1
```

After:

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

Batch width **1 → 8**, i.e. a tick over D pending dirs costs `ceil(D / 8)` round trips instead of
`D`. The same test then asserts the first tick still probes every due dir exactly once
(`new Set(probed.slice(0, 32)).size === 32`), so nothing is dropped or duplicated.

## Correctness

**Ownership watch — output is identical.**

- `readRuntimeMetadataAsync` returns `null` on `ENOENT` and rethrows everything else, exactly like
  `existsSync`-then-`readFileSync` did. Any other error (EACCES, EIO) still reaches
  `tryReadRuntimeMetadata`, which logs and returns `null` — unchanged.
- Dropping the `existsSync` pre-check removes a TOCTOU race rather than adding one: the old code
  could see the file exist and then throw ENOENT from `readFileSync` if it vanished in between,
  which the `catch` already swallowed into `null`. The new code reaches the same `null` in one
  syscall.
- `shouldReclaimRuntimeMetadata` already treats `null` as reclaimable, so a missing or unreadable
  record still republishes. A live foreign pid still wins (no ping-pong); a foreign `runtimeId` on
  our own pid is still reclaimed.
- Republish failures still log and wait for the next tick.
- The `inFlight` guard is the same shape the worktree pollers use (`ticking` in
  `worktree-base-directory-marker-poller.ts`). It can only drop a tick that fires while the previous
  read is still outstanding — at a 10s interval against a single small local file that never happens
  in practice; if a volume ever did stall that long, the old code would have blocked the main thread
  for the same duration instead. `check()` returns the in-flight promise, so an eager caller joins
  the running check rather than racing a second one.
- The sole non-test caller is the interval itself; `checkRuntimeMetadataOwnership()` is a documented
  test-only seam and now returns the promise so tests can await it.

**Marker poller — output is identical.**

- The expiry bookkeeping (`markerProbeStartedAt.set(dir, null)` past `pendingMarkerMaxTicks`) stays
  serial and still runs before any probe. It is pure: `tickCount` is fixed for the call and the loop
  only writes the key it is visiting, so hoisting it into its own pass cannot change which dirs are
  retired.
- Probes are independent. `snapshot.markers.set(dir, true)` and `markerProbeStartedAt.delete(dir)`
  are per-dir and non-overlapping, so concurrent workers never touch the same key.
- `onPendingMarkerProbe` still fires exactly once per probed dir, immediately before that dir's own
  `hasGitMarker` — the existing "retires stale marker probes" test in
  `worktree-base-directory-poller.test.ts` writes the marker from inside that callback and still
  passes, which pins the per-dir ordering.
- Event ordering within a batch is not load-bearing: `diffBase` already emits unordered batches from
  a `Map` iteration, and the consumer treats a batch as a set.
- `poll()` is serialized by the poller's `ticking` flag, so `snapshot` cannot be reassigned by a
  full scan while a batch is in flight.
- Concurrency is the already-imported `MARKER_PROBE_CONCURRENCY = 8`, the same bound the full scan
  uses — no new cap, and no new pressure on libuv's 4-thread pool.

**Edge cases.** Both paths are host-local main-process bookkeeping. Nothing crosses the SSH
execution boundary, no RPC params or stream frames change, so there is no wire-compatibility
question. The marker poller is already folder-workspace-aware (it watches a base directory and only
infers worktree-ness from a `.git` marker); this change does not touch that inference. Paths keep
going through `path.join`, so Windows is unaffected, and the ENOENT code is what Windows reports for
a missing file too. Empty state: zero pending dirs means `forEachWithConcurrency([])` resolves
immediately, same as the old empty loop; a missing metadata file yields `null` and republishes.

## Negative user-facing trade-offs

**None.** No cadence, cap, threshold, or staleness window changed: the ownership watch still polls
every 10s and reclaims on exactly the same verdicts, and the marker poller still probes exactly the
same dirs on exactly the same ticks — only the thread the read happens on and the number of probes
in flight changed.

## Test plan

```
nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/main/runtime/runtime-metadata-ownership-watch.test.ts \
  src/main/runtime/runtime-rpc-metadata-lifecycle.test.ts \
  src/main/ipc/worktree-base-directory-poller-marker-fanout.test.ts \
  src/main/ipc/worktree-base-directory-poller.test.ts \
  src/main/ipc/worktree-base-directory-watcher.test.ts \
  src/main/ipc/worktree-base-directory-change-collector.test.ts \
  src/main/ipc/worktree-base-directory-event-filter.test.ts \
  src/main/ipc/worktree-base-directory-watch-targets.test.ts
# 8 files, 99 tests passed

nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false   # clean
pnpm run check:code-quality:changed                                                        # 0 findings
```

Both new guards were verified to fail against the pre-change implementation (output pasted above)
and pass after.

## Not shipped in this PR: the structured agent-session lease renewer

A third idle timer was in scope and is **deliberately not changed**, because the obvious fix is not
free.

`StructuredAgentSessionLeaseRenewer.renewNow()`
(`src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts:36,63,101`)
unconditionally calls `store.renewLeases(renewals)` every 10s even when `renewals` is empty. That
runs a full durable transaction (`src/main/runtime/agent-session-store-transaction-queue.ts:91-150`):
`mkdir` + `chmod`, a `proper-lockfile` acquire, `readFile(store)` + `readFile(store.bak)` +
`JSON.parse`, a SHA-256 over the fully re-serialised state, four Map/Set clones, then release. Only
the final `saveAgentSessionStore` is skipped when nothing changed.

Measured on this machine against a real store via `AgentSessionRecordStore.open` (200 iterations
after a 20-iteration warm-up, 10 records): **5.079 ms per no-op call**, i.e. ~30 ms/min of
main-thread work and ~360 lock create/delete cycles an hour, including for users with zero
structured agent sessions. (Repeat runs under load ranged 12–27 ms/call; the machine is heavily
loaded, so treat 5 ms as the floor. The brief's independent measurement was 3.599 ms.)

**Why the early-return was not shipped.** The transaction is also the only *periodic* cross-process
refresh of the store. `transact()` calls `refreshExternallyChangedState()` before `apply()`, and the
lease renewer is the only recurring transactor in the process — every other agent-session
transaction is event-driven. So for a host with no renewable leases, that 10s tick is the sole
mechanism by which its in-memory `store.state` learns about a record another Orca process on the
same profile wrote.

That refresh has a real consumer: `src/main/ai-vault/structured-session-ownership.ts:116` reads
`host.deps.store.listRecords()` to refuse a terminal `--resume` that would collide with a structured
session. Today that guard converges within 10s across processes; with the naive early-return it
would never converge for a host holding no leases of its own, and the guard would fail open. That is
a cross-process correctness property, not a perf detail, so it is not worth 5 ms.

The suggested fallback — a stat/mtime-gated reload instead of the lock+hash — was considered and
rejected for this PR: it is a probabilistic equality test (mtime granularity, inode reuse), not an
exact one, so it would introduce exactly the kind of silent staleness window this PR's bar forbids.
An exact version is possible (cache the raw bytes last read and short-circuit the parse + SHA-256 on
a byte-identical read), but it changes shared transaction-queue code on the durable lease path and
deserves its own reviewed PR rather than riding along with two unrelated one-liners.
