### PR TITLE
perf(source-control): sort branch entries before filtering, gate projections by view mode

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control-file-filter.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-file-filter.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   SOURCE_CONTROL_FILE_FILTER_QUERY_MAX_BYTES,
-  filterAndSortSourceControlPathEntries,
   filterSourceControlGroupedPathEntries,
   filterSourceControlPathEntries,
   getSourceControlFileFilterState,
@@ -10,26 +9,6 @@ import {
 } from './source-control/listing/file-filter'
 
 describe('source-control-file-filter', () => {
-  it('naturally orders committed branch rows without mutating store input', () => {
-    const entries = [
-      { path: 'migrations/100.sql' },
-      { path: 'migrations/9.sql' },
-      { path: 'migrations/99.sql' }
-    ]
-
-    expect(
-      filterAndSortSourceControlPathEntries(entries, {
-        normalizedFilter: '',
-        tooLarge: false
-      }).map((entry) => entry.path)
-    ).toEqual(['migrations/9.sql', 'migrations/99.sql', 'migrations/100.sql'])
-    expect(entries.map((entry) => entry.path)).toEqual([
-      'migrations/100.sql',
-      'migrations/9.sql',
-      'migrations/99.sql'
-    ])
-  })
-
   it('normalizes bounded queries and filters entries by path', () => {
     const filter = getSourceControlFileFilterState('  SRC/button  ')
 

--- a/src/renderer/src/components/right-sidebar/source-control-tree.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-tree.ts
@@ -165,7 +165,7 @@ export function buildGitStatusSourceControlTree(
 }
 
 export function flattenSourceControlTree<Entry extends SourceControlTreeEntry, Area extends string>(
-  nodes: SourceControlTreeNode<Entry, Area>[],
+  nodes: readonly SourceControlTreeNode<Entry, Area>[],
   collapsedDirectoryKeys: ReadonlySet<string>
 ): SourceControlTreeNode<Entry, Area>[] {
   const result: SourceControlTreeNode<Entry, Area>[] = []

--- a/src/renderer/src/components/right-sidebar/source-control/listing/branch-section.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/branch-section.tsx
@@ -39,7 +39,7 @@ export function SourceControlBranchSection({
   collapsedSections: Set<string>
   toggleSection: (section: string) => void
   sourceControlViewMode: SourceControlViewMode
-  visibleBranchTreeRows: SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[]
+  visibleBranchTreeRows: readonly SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[]
   fileListScrollElement: HTMLDivElement | null
   collapsedTreeDirs: Set<string>
   toggleTreeDir: (key: string) => void

--- a/src/renderer/src/components/right-sidebar/source-control/listing/file-filter.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/file-filter.ts
@@ -1,5 +1,4 @@
 import { isClipboardTextByteLengthOverLimit } from '../../../../../../shared/clipboard-text'
-import { compareFileNames } from '../../../../../../shared/file-name-sort'
 
 export const SOURCE_CONTROL_FILE_FILTER_QUERY_MAX_BYTES = 2 * 1024
 
@@ -47,15 +46,6 @@ export function filterSourceControlPathEntries<T extends SourceControlPathEntry>
     return entries
   }
   return entries.filter((entry) => entry.path.toLowerCase().includes(filter.normalizedFilter))
-}
-
-export function filterAndSortSourceControlPathEntries<T extends SourceControlPathEntry>(
-  entries: T[],
-  filter: SourceControlFileFilterState
-): T[] {
-  return [...filterSourceControlPathEntries(entries, filter)].sort((a, b) =>
-    compareFileNames(a.path, b.path)
-  )
 }
 
 export function filterSourceControlGroupedPathEntries<T extends SourceControlPathEntry>(

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection-work.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection-work.test.tsx
@@ -1,0 +1,275 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
+import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
+import type { SourceControlViewMode } from '../../../../../../shared/ui-chrome-types'
+import type * as FileNameSortModule from '../../../../../../shared/file-name-sort'
+import type * as SourceControlTreeModule from '../../source-control-tree'
+import type * as SubmoduleExpansionModule from './submodule-expansion'
+
+const counters = vi.hoisted(() => ({
+  compareFileNames: 0,
+  buildGitStatusSourceControlTree: 0,
+  buildSourceControlTree: 0,
+  flattenSourceControlTree: 0,
+  injectExpandedSubmoduleRows: 0,
+  injectExpandedSubmoduleEntries: 0
+}))
+
+vi.mock('../../../../../../shared/file-name-sort', async (importOriginal) => {
+  const actual = await importOriginal<typeof FileNameSortModule>()
+  return {
+    ...actual,
+    compareFileNames: (a: string, b: string) => {
+      counters.compareFileNames += 1
+      return actual.compareFileNames(a, b)
+    }
+  }
+})
+
+vi.mock('../../source-control-tree', async (importOriginal) => {
+  const actual = await importOriginal<typeof SourceControlTreeModule>()
+  return {
+    ...actual,
+    buildGitStatusSourceControlTree: (
+      ...args: Parameters<typeof actual.buildGitStatusSourceControlTree>
+    ) => {
+      counters.buildGitStatusSourceControlTree += 1
+      return actual.buildGitStatusSourceControlTree(...args)
+    },
+    buildSourceControlTree: ((...args: unknown[]) => {
+      counters.buildSourceControlTree += 1
+      return (actual.buildSourceControlTree as (...a: unknown[]) => unknown)(...args)
+    }) as typeof actual.buildSourceControlTree,
+    flattenSourceControlTree: ((...args: unknown[]) => {
+      counters.flattenSourceControlTree += 1
+      return (actual.flattenSourceControlTree as (...a: unknown[]) => unknown)(...args)
+    }) as typeof actual.flattenSourceControlTree
+  }
+})
+
+vi.mock('./submodule-expansion', async (importOriginal) => {
+  const actual = await importOriginal<typeof SubmoduleExpansionModule>()
+  return {
+    ...actual,
+    injectExpandedSubmoduleRows: ((...args: unknown[]) => {
+      counters.injectExpandedSubmoduleRows += 1
+      return (actual.injectExpandedSubmoduleRows as (...a: unknown[]) => unknown)(...args)
+    }) as typeof actual.injectExpandedSubmoduleRows,
+    injectExpandedSubmoduleEntries: ((...args: unknown[]) => {
+      counters.injectExpandedSubmoduleEntries += 1
+      return (actual.injectExpandedSubmoduleEntries as (...a: unknown[]) => unknown)(...args)
+    }) as typeof actual.injectExpandedSubmoduleEntries
+  }
+})
+
+const { compareFileNames } = await import('../../../../../../shared/file-name-sort')
+const { getSourceControlFileFilterState, filterSourceControlPathEntries } =
+  await import('./file-filter')
+const { useSourceControlFileProjection } = await import('./use-file-projection')
+
+const NO_ENTRIES: GitStatusEntry[] = []
+const NO_COLLAPSED_TREE_DIRS = new Set<string>()
+const NO_EXPANDED_SUBMODULES = new Set<string>()
+const NO_COLLAPSED_SECTIONS = new Set<string>()
+const NO_SUBMODULE_STATUS = {}
+const GROUP_ORDER = ['unstaged', 'staged', 'untracked'] as const
+
+type ProjectionProps = {
+  entries: GitStatusEntry[]
+  branchEntries: GitBranchChangeEntry[]
+  filterQuery: string
+  sourceControlViewMode: SourceControlViewMode
+}
+
+function renderProjection(initialProps: ProjectionProps) {
+  return renderHook(
+    (props: ProjectionProps) =>
+      useSourceControlFileProjection({
+        entries: props.entries,
+        branchEntries: props.branchEntries,
+        filterQuery: props.filterQuery,
+        sourceControlGroupOrder: GROUP_ORDER,
+        activeWorktreeId: 'wt-1',
+        worktreePath: '/repo',
+        isFolder: false,
+        collapsedTreeDirs: NO_COLLAPSED_TREE_DIRS,
+        expandedSubmoduleKeys: NO_EXPANDED_SUBMODULES,
+        submoduleStatusByKey: NO_SUBMODULE_STATUS,
+        sourceControlViewMode: props.sourceControlViewMode,
+        collapsedSections: NO_COLLAPSED_SECTIONS
+      }),
+    { initialProps }
+  )
+}
+
+function makeBranchEntries(count: number): GitBranchChangeEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `src/area-${index % 7}/nested/deep-${index % 13}/file-${index}.ts`,
+    status: 'modified' as const
+  }))
+}
+
+/** Numeric collation, case variants, unicode, collator ties, and an exact duplicate path. */
+const ORDERING_FIXTURE: GitBranchChangeEntry[] = [
+  { path: 'migrations/100.sql', status: 'modified' },
+  { path: 'migrations/9.sql', status: 'modified' },
+  { path: 'migrations/99.sql', status: 'added' },
+  { path: 'migrations/02.sql', status: 'modified' },
+  { path: 'migrations/2.sql', status: 'deleted' },
+  { path: 'src/Button.tsx', status: 'modified' },
+  { path: 'src/button.tsx', status: 'added' },
+  { path: 'src/éclair.ts', status: 'modified' },
+  { path: 'src/eclair.ts', status: 'deleted' },
+  { path: 'src/Éclair.ts', status: 'modified' },
+  { path: 'src/日本語.ts', status: 'added' },
+  { path: 'src/dup.ts', status: 'modified' },
+  { path: 'src/dup.ts', status: 'added' }
+]
+
+/** The pre-change implementation: filter, then copy-and-sort. */
+function legacyFilterThenSort(
+  entries: GitBranchChangeEntry[],
+  filterQuery: string
+): GitBranchChangeEntry[] {
+  const state = getSourceControlFileFilterState(filterQuery)
+  return [...filterSourceControlPathEntries(entries, state)].sort((a, b) =>
+    compareFileNames(a.path, b.path)
+  )
+}
+
+function makeStatusEntries(count: number): GitStatusEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `src/area-${index % 7}/nested/deep-${index % 13}/file-${index}.ts`,
+    status: 'modified' as const,
+    area: (['unstaged', 'staged', 'untracked'] as const)[index % 3]
+  }))
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(counters) as (keyof typeof counters)[]) {
+    counters[key] = 0
+  }
+})
+
+describe('useSourceControlFileProjection branch entry ordering', () => {
+  it('sorts committed branch entries once across many filter changes', () => {
+    const branchEntries = makeBranchEntries(400)
+    const { rerender } = renderProjection({
+      entries: NO_ENTRIES,
+      branchEntries,
+      filterQuery: '',
+      sourceControlViewMode: 'list'
+    })
+
+    const comparesForInitialSort = counters.compareFileNames
+    expect(comparesForInitialSort).toBeGreaterThan(0)
+
+    for (const filterQuery of ['f', 'fi', 'fil', 'file', 'file-', 'file-1']) {
+      rerender({ entries: NO_ENTRIES, branchEntries, filterQuery, sourceControlViewMode: 'list' })
+    }
+
+    expect(counters.compareFileNames).toBe(comparesForInitialSort)
+  })
+
+  it('produces the same order as the previous filter-then-sort for every filter', () => {
+    const { result, rerender } = renderProjection({
+      entries: NO_ENTRIES,
+      branchEntries: ORDERING_FIXTURE,
+      filterQuery: '',
+      sourceControlViewMode: 'list'
+    })
+
+    for (const filterQuery of ['', 'src', 'MIGRATIONS', 'é', '9', 'dup', 'no-match']) {
+      rerender({
+        entries: NO_ENTRIES,
+        branchEntries: ORDERING_FIXTURE,
+        filterQuery,
+        sourceControlViewMode: 'list'
+      })
+      expect(result.current.filteredBranchEntries).toEqual(
+        legacyFilterThenSort(ORDERING_FIXTURE, filterQuery)
+      )
+    }
+  })
+
+  it('does not mutate the store-owned branch entry array', () => {
+    const branchEntries = [...ORDERING_FIXTURE]
+    renderProjection({
+      entries: NO_ENTRIES,
+      branchEntries,
+      filterQuery: '',
+      sourceControlViewMode: 'list'
+    })
+
+    expect(branchEntries).toEqual(ORDERING_FIXTURE)
+  })
+})
+
+describe('useSourceControlFileProjection view-mode gating', () => {
+  const entries = makeStatusEntries(120)
+  const branchEntries = makeBranchEntries(120)
+
+  it('builds no tree projection in list mode', () => {
+    const { result } = renderProjection({
+      entries,
+      branchEntries,
+      filterQuery: '',
+      sourceControlViewMode: 'list'
+    })
+
+    expect(counters.buildGitStatusSourceControlTree).toBe(0)
+    expect(counters.buildSourceControlTree).toBe(0)
+    expect(counters.flattenSourceControlTree).toBe(0)
+    expect(counters.injectExpandedSubmoduleRows).toBe(0)
+    expect(counters.injectExpandedSubmoduleEntries).toBeGreaterThan(0)
+    expect(result.current.visibleTreeRowsBySection).toEqual({})
+    expect(result.current.visibleBranchTreeRows).toEqual([])
+  })
+
+  it('builds no list projection in tree mode', () => {
+    const { result } = renderProjection({
+      entries,
+      branchEntries,
+      filterQuery: '',
+      sourceControlViewMode: 'tree'
+    })
+
+    expect(counters.injectExpandedSubmoduleEntries).toBe(0)
+    expect(counters.buildGitStatusSourceControlTree).toBeGreaterThan(0)
+    expect(counters.buildSourceControlTree).toBeGreaterThan(0)
+    expect(result.current.visibleListRowsBySection).toEqual({})
+  })
+
+  it('has the other mode fully projected on the first render after a switch', () => {
+    const { result, rerender } = renderProjection({
+      entries,
+      branchEntries,
+      filterQuery: '',
+      sourceControlViewMode: 'list'
+    })
+    const listRows = result.current.visibleListRowsBySection
+    const listSelectionCount = result.current.visibleSelectionEntries.length
+    expect(listSelectionCount).toBe(entries.length)
+
+    rerender({ entries, branchEntries, filterQuery: '', sourceControlViewMode: 'tree' })
+
+    expect(result.current.visibleListRowsBySection).toEqual({})
+    expect(result.current.visibleBranchTreeRows.length).toBeGreaterThan(0)
+    expect(
+      Object.values(result.current.visibleTreeRowsBySection).reduce(
+        (total, rows) => total + rows.length,
+        0
+      )
+    ).toBeGreaterThan(0)
+    expect(result.current.visibleSelectionEntries.length).toBe(listSelectionCount)
+
+    rerender({ entries, branchEntries, filterQuery: '', sourceControlViewMode: 'list' })
+
+    expect(result.current.visibleTreeRowsBySection).toEqual({})
+    expect(result.current.visibleBranchTreeRows).toEqual([])
+    expect(result.current.visibleListRowsBySection).toEqual(listRows)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection-work.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection-work.test.tsx
@@ -18,13 +18,20 @@ const counters = vi.hoisted(() => ({
   injectExpandedSubmoduleEntries: 0
 }))
 
+/** Lets a test swap in a comparator that is deliberately not a total order. */
+const comparatorOverride = vi.hoisted(() => ({
+  current: null as ((a: string, b: string) => number) | null
+}))
+
 vi.mock('../../../../../../shared/file-name-sort', async (importOriginal) => {
   const actual = await importOriginal<typeof FileNameSortModule>()
   return {
     ...actual,
     compareFileNames: (a: string, b: string) => {
       counters.compareFileNames += 1
-      return actual.compareFileNames(a, b)
+      return comparatorOverride.current
+        ? comparatorOverride.current(a, b)
+        : actual.compareFileNames(a, b)
     }
   }
 })
@@ -148,7 +155,27 @@ function makeStatusEntries(count: number): GitStatusEntry[] {
   }))
 }
 
+/**
+ * Deliberately not a total order: every path under the same top-level directory compares equal, so
+ * distinct paths tie. Sort-before-filter must still match filter-before-sort under it.
+ */
+function compareTopLevelDirOnly(a: string, b: string): number {
+  const dirA = a.slice(0, a.indexOf('/'))
+  const dirB = b.slice(0, b.indexOf('/'))
+  return dirA < dirB ? -1 : dirA > dirB ? 1 : 0
+}
+
+/** Big enough that V8 leaves binary insertion sort for TimSort, where instability would show. */
+function makeTieHeavyEntries(count: number): GitBranchChangeEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    // Scrambled so the tie order is not already the sorted order.
+    path: `dir-${(index * 7) % 3}/file-${(index * 31) % count}.ts`,
+    status: 'modified' as const
+  }))
+}
+
 beforeEach(() => {
+  comparatorOverride.current = null
   for (const key of Object.keys(counters) as (keyof typeof counters)[]) {
     counters[key] = 0
   }
@@ -191,6 +218,27 @@ describe('useSourceControlFileProjection branch entry ordering', () => {
       })
       expect(result.current.filteredBranchEntries).toEqual(
         legacyFilterThenSort(ORDERING_FIXTURE, filterQuery)
+      )
+    }
+  })
+
+  // Guards the invariant the sort-before-filter swap actually rests on: a stable sort, not a total
+  // order. If sortedBranchEntries ever stops preserving the original order of tied paths, this
+  // diverges from filter-then-sort even though every total-order fixture above still passes.
+  it('matches filter-then-sort under a comparator that is not a total order', () => {
+    comparatorOverride.current = compareTopLevelDirOnly
+    const branchEntries = makeTieHeavyEntries(300)
+    const { result, rerender } = renderProjection({
+      entries: NO_ENTRIES,
+      branchEntries,
+      filterQuery: '',
+      sourceControlViewMode: 'list'
+    })
+
+    for (const filterQuery of ['', 'dir-1', 'file-1', 'file-12', '7.ts', 'no-match']) {
+      rerender({ entries: NO_ENTRIES, branchEntries, filterQuery, sourceControlViewMode: 'list' })
+      expect(result.current.filteredBranchEntries.map((entry) => entry.path)).toEqual(
+        legacyFilterThenSort(branchEntries, filterQuery).map((entry) => entry.path)
       )
     }
   })

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts
@@ -63,6 +63,10 @@ export type SourceControlFileProjection = {
 
 // Why: only one view mode is ever rendered, so building the other mode's projection is pure dead
 // work (precedent: the combined-diff file tree short-circuits the same way while collapsed).
+// The gates below and both branching consumers (section-file-list.tsx, branch-section.tsx) read the
+// same sourceControlViewMode prop within one synchronous render, so a mode switch can never show
+// these. Keep that single source: deriving the mode from a separate store read would let a consumer
+// switch a render before the memos do, and only then could one of these reach the screen.
 const EMPTY_TREE_ROOTS_BY_SECTION: Readonly<
   Partial<Record<SourceControlDisplaySectionId, GitStatusSourceControlTreeNode[]>>
 > = Object.freeze({})
@@ -141,8 +145,11 @@ export function useSourceControlFileProjection({
     [unfilteredDisplaySections]
   )
 
-  // Why: sorting before filtering keeps the collator off the keystroke path; Array#filter preserves
-  // order and compareFileNames is a total order, so filter(sort(x)) === sort(filter(x)).
+  // Why: sorting before filtering keeps the collator off the keystroke path, and is order-identical
+  // to the old filter-then-sort for any self-consistent comparator (a total order is not required):
+  // a stable sort fixes each element's position by (comparator result, original index), and
+  // Array#filter drops elements without disturbing either, so re-sorting the survivors would
+  // reproduce the same relative order. filter(sort(x)) === sort(filter(x)).
   const sortedBranchEntries = useMemo(
     () => [...branchEntries].sort((a, b) => compareFileNames(a.path, b.path)),
     [branchEntries]

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts
@@ -2,10 +2,11 @@ import { useMemo } from 'react'
 import type { GitBranchChangeEntry } from '../../../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
 import type { SourceControlViewMode } from '../../../../../../shared/ui-chrome-types'
+import { compareFileNames } from '../../../../../../shared/file-name-sort'
 import { compareGitStatusEntries } from '../../source-control-status-sort'
 import {
-  filterAndSortSourceControlPathEntries,
   filterSourceControlGroupedPathEntries,
+  filterSourceControlPathEntries,
   getSourceControlFileFilterState,
   type SourceControlFileFilterState
 } from './file-filter'
@@ -59,6 +60,19 @@ export type SourceControlFileProjection = {
   visibleBranchTreeRows: SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[]
   visibleSelectionEntries: FlatEntry[]
 }
+
+// Why: only one view mode is ever rendered, so building the other mode's projection is pure dead
+// work (precedent: the combined-diff file tree short-circuits the same way while collapsed).
+const EMPTY_TREE_ROOTS_BY_SECTION: Readonly<
+  Partial<Record<SourceControlDisplaySectionId, GitStatusSourceControlTreeNode[]>>
+> = Object.freeze({})
+const EMPTY_TREE_ROWS_BY_SECTION: Readonly<
+  Partial<Record<SourceControlDisplaySectionId, RenderableSourceControlNode[]>>
+> = Object.freeze({})
+const EMPTY_LIST_ROWS_BY_SECTION: Readonly<
+  Partial<Record<SourceControlDisplaySectionId, RenderableSubmoduleListItem[]>>
+> = Object.freeze({})
+const EMPTY_BRANCH_TREE_NODES: SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[] = []
 
 export function useSourceControlFileProjection({
   entries,
@@ -127,12 +141,21 @@ export function useSourceControlFileProjection({
     [unfilteredDisplaySections]
   )
 
+  // Why: sorting before filtering keeps the collator off the keystroke path; Array#filter preserves
+  // order and compareFileNames is a total order, so filter(sort(x)) === sort(filter(x)).
+  const sortedBranchEntries = useMemo(
+    () => [...branchEntries].sort((a, b) => compareFileNames(a.path, b.path)),
+    [branchEntries]
+  )
   const filteredBranchEntries = useMemo(
-    () => filterAndSortSourceControlPathEntries(branchEntries, fileFilterState),
-    [branchEntries, fileFilterState]
+    () => filterSourceControlPathEntries(sortedBranchEntries, fileFilterState),
+    [fileFilterState, sortedBranchEntries]
   )
 
   const treeRootsBySection = useMemo(() => {
+    if (sourceControlViewMode !== 'tree') {
+      return EMPTY_TREE_ROOTS_BY_SECTION
+    }
     const roots: Partial<Record<SourceControlDisplaySectionId, GitStatusSourceControlTreeNode[]>> =
       {}
     for (const section of displaySections) {
@@ -148,9 +171,12 @@ export function useSourceControlFileProjection({
           : sectionRoots
     }
     return roots
-  }, [displaySections])
+  }, [displaySections, sourceControlViewMode])
 
   const visibleTreeRowsBySection = useMemo(() => {
+    if (sourceControlViewMode !== 'tree') {
+      return EMPTY_TREE_ROWS_BY_SECTION
+    }
     const rows: Partial<Record<SourceControlDisplaySectionId, RenderableSourceControlNode[]>> = {}
     for (const section of displaySections) {
       rows[section.id] = injectExpandedSubmoduleRows(
@@ -167,11 +193,15 @@ export function useSourceControlFileProjection({
     displaySections,
     treeRootsBySection,
     expandedSubmoduleKeys,
+    sourceControlViewMode,
     submoduleStatusByKey
   ])
 
   // List view needs the same lazy submodule expansion as tree view, spliced into the flat entry list.
   const visibleListRowsBySection = useMemo(() => {
+    if (sourceControlViewMode !== 'list') {
+      return EMPTY_LIST_ROWS_BY_SECTION
+    }
     const rows: Partial<Record<SourceControlDisplaySectionId, RenderableSubmoduleListItem[]>> = {}
     for (const section of displaySections) {
       rows[section.id] = injectExpandedSubmoduleEntries(
@@ -183,15 +213,21 @@ export function useSourceControlFileProjection({
       )
     }
     return rows
-  }, [displaySections, expandedSubmoduleKeys, submoduleStatusByKey])
+  }, [displaySections, expandedSubmoduleKeys, sourceControlViewMode, submoduleStatusByKey])
 
   const branchTreeRoots = useMemo(
-    () => compactSourceControlTree(buildSourceControlTree('branch', filteredBranchEntries)),
-    [filteredBranchEntries]
+    () =>
+      sourceControlViewMode === 'tree'
+        ? compactSourceControlTree(buildSourceControlTree('branch', filteredBranchEntries))
+        : EMPTY_BRANCH_TREE_NODES,
+    [filteredBranchEntries, sourceControlViewMode]
   )
   const visibleBranchTreeRows = useMemo(
-    () => flattenSourceControlTree(branchTreeRoots, collapsedTreeDirs),
-    [branchTreeRoots, collapsedTreeDirs]
+    () =>
+      sourceControlViewMode === 'tree'
+        ? flattenSourceControlTree(branchTreeRoots, collapsedTreeDirs)
+        : EMPTY_BRANCH_TREE_NODES,
+    [branchTreeRoots, collapsedTreeDirs, sourceControlViewMode]
   )
 
   const visibleSelectionEntries = useMemo(() => {

--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts
@@ -57,7 +57,7 @@ export type SourceControlFileProjection = {
   visibleListRowsBySection: Partial<
     Record<SourceControlDisplaySectionId, RenderableSubmoduleListItem[]>
   >
-  visibleBranchTreeRows: SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[]
+  visibleBranchTreeRows: readonly SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[]
   visibleSelectionEntries: FlatEntry[]
 }
 
@@ -76,7 +76,8 @@ const EMPTY_TREE_ROWS_BY_SECTION: Readonly<
 const EMPTY_LIST_ROWS_BY_SECTION: Readonly<
   Partial<Record<SourceControlDisplaySectionId, RenderableSubmoduleListItem[]>>
 > = Object.freeze({})
-const EMPTY_BRANCH_TREE_NODES: SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[] = []
+const EMPTY_BRANCH_TREE_NODES: readonly SourceControlTreeNode<GitBranchChangeEntry, 'branch'>[] =
+  Object.freeze([])
 
 export function useSourceControlFileProjection({
   entries,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​323 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​302 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

Two bits of work in the Source Control sidebar were being done and then thrown away.

First: every time you type a character into the file filter, the panel re-alphabetised the whole "Committed on Branch" list from scratch — even though the list itself hadn't changed, only which rows you wanted to see. Alphabetising with natural ordering ("file9" before "file10") is expensive; narrowing a list is cheap. Now the list is alphabetised once when it arrives and each keystroke only narrows it. The result you see on screen is exactly the same order as before.

Second: the sidebar can show your changed files either as a flat list or as a folder tree. It was building *both* every time, then rendering one and discarding the other. Since the flat list is the default, everyone who never opens the tree view was paying for a folder tree nobody looked at. Now each shape is built only when it is the one on screen.

## What Changed

`src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection.ts`
- Split the branch-entry pipeline into a `sortedBranchEntries` memo keyed only on `branchEntries`, and a `filteredBranchEntries` memo keyed on the filter. The natural-order collator now runs once per data change instead of once per keystroke.
- Gated `treeRootsBySection`, `visibleTreeRowsBySection`, `branchTreeRoots` and `visibleBranchTreeRows` on `sourceControlViewMode === 'tree'`, and `visibleListRowsBySection` on `=== 'list'`. The inactive mode returns a module-level frozen empty singleton instead of being built and discarded.

`src/renderer/src/components/right-sidebar/source-control/listing/file-filter.ts`
- Deleted `filterAndSortSourceControlPathEntries`; its only caller is gone.

`src/renderer/src/components/right-sidebar/source-control-tree.ts`
- `flattenSourceControlTree` takes `readonly SourceControlTreeNode<Entry, Area>[]` (it only iterates). Return type unchanged, so all callers are unaffected.

`src/renderer/src/components/right-sidebar/source-control/listing/branch-section.tsx`
- `visibleBranchTreeRows` prop is `readonly`, matching `SourceControlVirtualFileList`, which already declared `rows: readonly TRow[]`.

Tests
- New `use-file-projection-work.test.tsx`: deterministic call-counting guards for both findings, plus ordering, non-mutation, and mode-switch coverage.
- Removed the `filterAndSortSourceControlPathEntries` unit test from `source-control-file-filter.test.ts`; both properties it covered are re-asserted at the hook level.

No IPC, wire format, persisted state, or main-process change. Renderer-only.

## Why it matters

Both numbers were measured, then reproduced on this branch.

**Finding 1 — re-sorting on every keystroke.** `filterAndSortSourceControlPathEntries` copied the array and re-ran `Intl.Collator('en', {numeric: true})` on every `fileFilterState` change. Unlike uncommitted rows (capped at `DEFAULT_GIT_STATUS_LIMIT = 1000`), `branchEntries` is **uncapped** — `loadBranchChanges` (`src/main/git/source-control/branch-change-entries.ts:27`) applies no limit, so a long-lived branch can put several thousand rows through this path.

Same collator config, realistic deep paths, typing at ~8 chars/sec (`node /tmp/bench-sc2.mjs`, 30 runs):

```
n=2000: per-keystroke before=14.66ms  after=0.23ms  | 8 keystrokes/s: 117.3ms -> 1.8ms
n=5000: per-keystroke before=34.07ms  after=1.47ms  | 8 keystrokes/s: 272.5ms -> 11.8ms
```

That is 117–273 ms of pure sorting per second of typing, on the renderer's main thread, versus a filter pass that costs ~0.2–1.5 ms and is the only part that actually has to be redone. Symptom: input lag typing in the Source Control filter, plus a hitch when switching onto a worktree with a large "Committed on Branch" list.

**Finding 2 — building the projection for the mode you are not in.** `SourceControlSectionFileList` (`listing/section-file-list.tsx:73`) renders `treeRows` **or** `listRows` by `sourceControlViewMode`; `SourceControlBranchSection` (`listing/branch-section.tsx:107`) does the same. The default is `'list'` (`src/shared/default-global-settings.ts:133`), so the entire tree pipeline — path splitting, per-directory `Map`s, per-directory collator sorts, compaction, flatten — was built, retained by the memo, and never rendered.

Tree pass vs list pass over the same entries, 3 sections (`node /tmp/bench-sc3.mjs`, 30 runs):

```
n=200:  treePass(3 sections)=0.78ms   listPass=0.007ms
n=1000: treePass(3 sections)=3.99ms   listPass=0.115ms
n=5000: treePass(3 sections)=26.11ms  listPass=0.156ms
```

This runs on every filter keystroke and every git-status refresh, and it compounds with finding 1: because `branchTreeRoots` depends on `filteredBranchEntries`, a keystroke in list mode rebuilt the branch *tree* too.

## Measurement

### Before/after (microbenchmarks above)

| | before | after |
|---|---|---|
| Branch-list sort, per keystroke, n=5000 | 34.07 ms | 1.47 ms |
| Branch-list sort, 8 keystrokes/s, n=5000 | 272.5 ms | 11.8 ms |
| Off-mode projection, per rebuild, n=5000 | 26.11 ms | 0 ms (not built) |

### Deterministic re-measure of the win

Re-measured on a heavily loaded box where wall clock is unusable, so this counts **work units, not milliseconds**: the same mocked-module counters the regression guard uses, driving the real hook with n=2000 branch entries + n=2000 status entries in list mode, first render then 8 filter keystrokes.

| per full interaction (first render + 8 keystrokes), list mode, n=2000 | `origin/main` | this branch |
|---|---:|---:|
| `compareFileNames` calls | 163 783 | **34 685** |
| `compareFileNames` calls attributable to the 8 keystrokes | 125 102 | **0** |
| `buildGitStatusSourceControlTree` calls | 27 | **0** |
| `buildSourceControlTree` (branch tree) calls | 9 | **0** |
| `flattenSourceControlTree` calls | 36 | **0** |
| `injectExpandedSubmoduleRows` (tree-only) calls | 27 | **0** |

The last commit on this branch is comments and one added test; the counters are byte-identical before and after it (34 685 / 0 / 0 / 0 / 0 in both), so the win is unchanged.

### Regression guard fails without the change

File: `src/renderer/src/components/right-sidebar/source-control/listing/use-file-projection-work.test.tsx`. It is a deterministic call counter, not a wall-clock assertion — the mocked modules count `compareFileNames`, `buildSourceControlTree`, `buildGitStatusSourceControlTree`, `flattenSourceControlTree`, `injectExpandedSubmoduleRows` and `injectExpandedSubmoduleEntries` calls and delegate to the real implementations.

**With `use-file-projection.ts` and `file-filter.ts` reverted to `origin/main` (test file unchanged):**

```
 × sorts committed branch entries once across many filter changes 20ms
 × builds no tree projection in list mode 2ms
 × builds no list projection in tree mode 1ms
 × has the other mode fully projected on the first render after a switch 5ms
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected 20569 to be 3309 // Object.is equality
AssertionError: expected 3 to be +0 // Object.is equality
AssertionError: expected 3 to be +0 // Object.is equality
AssertionError: expected { unstaged: [ { …(2) }, …(39) ], …(2) } to deeply equal {}
```

6 filter changes over 400 fixed branch entries cost **20 569** `compareFileNames` calls on `main` versus **3 309** here — one sort, then filtering only.

Reverting each finding on its own also fails, so neither test passes by accident:

- finding 1 reverted only: `AssertionError: expected 18065 to be 2910`
- finding 2 reverted only: 4 failures, including `expected 3 to be +0` for both build counters and `expected 5414 to be 3309` for the sort counter (the branch tree was still rebuilt per keystroke in list mode)

### Guard for the one premise that is actually load-bearing

`matches filter-then-sort under a comparator that is not a total order` swaps `compareFileNames` for one that ties every path sharing a top-level directory (~100-way ties over 300 entries, past the size where V8 leaves binary insertion sort for TimSort) and asserts the hook still returns exactly what filter-then-sort returns, for six filters.

Verified failing: replacing `[...branchEntries].sort(cmp)` with a correct-but-**unstable** sort makes it fail with `expected [ 'dir-0/file-207.ts', …(299) ] to deeply equal [ 'dir-0/file-0.ts', …(299) ]`. It is not redundant with the existing fixture test: with the duplicate-path rows removed from `ORDERING_FIXTURE`, the pre-existing `produces the same order as the previous filter-then-sort` test **passes** under that same unstable sort (a total-order comparator ties nothing else), and only the new test fails. The old fixture's coverage of stability rested entirely on one 2-element tie.

**On this branch:**

```
 Test Files  1 passed (1)
      Tests  7 passed (7)
```

## Correctness

**Finding 1 — is `filter(sort(x))` really `sort(filter(x))`?** Yes, and it does not depend on any property of `compareFileNames` beyond self-consistency.

- `Array.prototype.sort` is **stable** (required since ES2019; always true in V8, so on every Electron we ship). A stable sort places each element by the pair *(comparator result, original index)*. `Array#filter` removes elements without changing the comparator result for any surviving pair and without changing their relative original-index order — so re-sorting the survivors would reproduce the order they already have. That argument holds for **any** comparator that returns the same sign for the same pair, which the old filter-then-sort already required. It needs no total order, no assumption that ties happen only for identical strings, and nothing about the code-unit tie-break in `src/shared/file-name-sort.ts`.
- Earlier revisions of this PR argued the equivalence from `compareFileNames` being a total order, with an 83 521-pair brute force as evidence. That premise is true but unnecessary, and asserting it made a property of a *shared* module load-bearing for this hook — anyone relaxing `compareFileNames` later would silently be changing this code's correctness argument. The claim is dropped from the code comment and from here; the weaker, structurally guaranteed invariant is what the comment now states and what the tests pin.
- Pinned by tests two ways: against an inlined copy of the old filter-then-sort over a fixture with numeric filenames, case variants, unicode, collator ties (`2` vs `02`, `éclair` vs `eclair` vs `Éclair`) and an exact duplicate path; and — the load-bearing one — against a deliberately non-total, tie-heavy comparator, which fails if the sort ever stops being stable (see the guard section above).
- Not mutating the store array: `[...branchEntries].sort(...)` copies first, same as before. Asserted by a test.
- `filterSourceControlPathEntries` returns its input array by reference when the filter is empty, so with no filter `filteredBranchEntries === sortedBranchEntries`. That array is our own copy, never the store's, and no consumer mutates it (`branch-section.tsx` reads `.length` and renders; `panel-content.tsx` reads `.length`).

**Finding 2 — can a mode switch render one frame with the empty projection?** No, and not because the code is careful — because there is only one place the mode can come from. `sourceControlViewMode` is read once in `use-panel-state`, threaded through `use-panel-foundation` into both the projection hook (`use-file-listing` → `use-file-projection`) and, on the same object, into the two components that branch on it (`section-file-list.tsx:73`, `branch-section.tsx:107`). `use-file-listing` does not re-export it, so there is no second value to diverge. Within one synchronous render, `useMemo` recomputes before children are committed, and there is no effect or async step between the gate and the consumers. The `EMPTY_*` comment now records that constraint, so a future reader does not reintroduce a separate store read for the mode. Asserted directly too: the test switches list → tree and checks the tree rows and branch tree rows are non-empty on `result.current` immediately after the switch, then switches back and checks the list rows are byte-identical to what they were before.

Other invalidation questions I had to answer:

- `visibleSelectionEntries` branches on the same `sourceControlViewMode` and reads whichever projection is live, so selection/range bookkeeping never sees the empty object. The test asserts the selection entry count is unchanged across a mode switch (120 entries before and after).
- Every downstream consumer reads `[id] ?? []` (`uncommitted-sections.tsx:194-195`), so an absent section key behaves exactly as an empty array did.
- `filteredBranchEntries` is **not** gated — the "Committed on Branch" heading count and the list-mode rows both read it in either mode. Only the branch *tree* is gated.
- The empty projections are module-level frozen singletons, so their identity is stable and gating does not add memo churn downstream.
- Sorting stays in the renderer on purpose. Moving it into `loadBranchChanges` or the `setGitBranchCompare` reducer would save nothing further — the reducer's `entriesUnchanged` guard already keeps `branchEntries` identity stable, so the memo runs once per real data change — while changing the order `CombinedDiffViewer` / `use-combined-diff-entry-set` see (currently `git -M -C` order), touching the relay/SSH publish path, and altering the index-based `entriesUnchanged` diff.

Edge cases:

- Renderer-only change; no IPC, no wire format, no persisted state. SSH, WSL and remote hosts are unaffected — the main process still returns the same entries.
- Folder workspaces: no assumption that the workspace is a git worktree; the branch section is only rendered when a branch summary exists, and that gating is untouched.
- Windows/Linux/macOS: no platform-dependent code. The collator is still the shared `'en'`-pinned one, so ordering stays identical across hosts.
- Empty/missing state: `branchEntries: []` sorts to `[]`; an oversized filter query still short-circuits to `[]` via `filter.tooLarge` before any path is read (that path is unchanged and still covered by `source-control-file-filter.test.ts`).

Cleanup: `filterAndSortSourceControlPathEntries` had exactly one caller and is deleted. Its unit test in `source-control-file-filter.test.ts` (natural ordering + no mutation of store input) is deleted with it and both properties are re-asserted at the hook level in the new test file, where they now actually live.

## Negative user-facing trade-offs

**None.** Rendered order and row contents are identical to before by construction, not by measurement: stable sort and `filter` commute for any self-consistent comparator, which is a property of the language, not of our comparator. Mode switching projects fully on its first render because the hook and both branching consumers read one `sourceControlViewMode` value in one synchronous render. There is no cap, debounce, threshold or lazy-render behaviour a user could perceive.

Two risks were named against earlier revisions of this PR and are gone as premises, not merely argued down:

- *"Depends on `compareFileNames` being a total order."* It does not; nothing here reads the code-unit tie-break in `file-name-sort.ts`. The only requirement is a stable `Array#sort`, which the spec guarantees, plus a self-consistent comparator, which the pre-change filter-then-sort already required. New test covers it.
- *"A mode switch could render one frame with the empty projection."* Unreachable: there is a single source for the mode and no async step between the gate and the consumers, so no ordering exists in which a consumer is in the new mode while the memos are in the old one.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/source-control src/shared/file-name-sort.test.ts` — 43 files, 403 tests passed
- `nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json --composite false` — clean
- `oxlint` + `oxfmt` on all changed files — clean
- Regression guard verified failing on `origin/main` (output above), failing when either finding is reverted on its own, and the new non-total-comparator guard verified failing against an unstable sort

## Linked Issue

N/A — self-directed performance work found by profiling the Source Control panel, not filed as an issue first. Both findings are reproduced by the microbenchmarks and pinned by the deterministic guards above.

## Visual Proof

`N/A` — no visual or interaction change. Rendered row order and row contents are identical by construction (see Correctness): a stable `Array#sort` and `Array#filter` commute for any self-consistent comparator, and the gated projections are the ones the active view mode never reads. There is no new cap, debounce, threshold, or lazy-render behaviour to show a before/after of.

## Testing

Verified on macOS (arm64). Renderer-only change with no platform-dependent code and no main-process, IPC, or wire surface, so Linux / Windows / SSH behaviour is unchanged by construction — the main process returns the same entries and the collator is the shared `'en'`-pinned one, so ordering is host-independent.

- `pnpm test src/renderer/src/components/right-sidebar/` — 226 files, 1955 tests passed
- `pnpm tc:web` — clean
- `oxlint` + `pnpm format` on changed files — clean
- Regression guard verified failing on `origin/main`, failing when either finding is reverted alone, and the non-total-comparator guard verified failing against an unstable sort

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor — section not applicable.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** none — no new input handling, no new surface. The oversized-filter short-circuit (`filter.tooLarge`) is untouched.
- **Cross-platform:** no platform branches added; the collator is the shared `'en'`-pinned one, so ordering is identical on macOS / Linux / Windows.
- **Remote SSH:** renderer-only. The execution host still computes and returns the same entries; nothing about how remote work is reported, listed, or stopped changed.
- **Mobile:** not reached — this is desktop renderer code.
- **Backwards compatibility:** no IPC params, stream frames, or published content changed, so mixed client/host versions are unaffected.
- **Performance:** the point of the PR; measured both by microbenchmark and by deterministic work-unit counters.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm typecheck`, `pnpm test` (scoped), `oxlint` and `pnpm format` pass locally; CI covers the rest
