### PR TITLE
perf(persistence): stop dead SSH leases pinning metadata, retire unreachable tombstones

### DIFF
--- a/src/main/persistence-ssh-lease-reattach-reclaim.test.ts
+++ b/src/main/persistence-ssh-lease-reattach-reclaim.test.ts
@@ -49,14 +49,16 @@ describe('ssh remote pty lease reclaim after a proven reattach', () => {
     expect(sshRemotePtyLeaseAllowsReattach(lease)).toBe(true)
   })
 
-  it('leaves a terminated lease absorbing even when the id appears in a reattach batch', async () => {
+  it('never lets a reattach batch revive an operator-closed id', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'pty-1', state: 'attached' })
     store.markSshRemotePtyLease('ssh-1', 'pty-1', 'terminated')
 
     await store.markSshRemotePtyLeasesAttachedAsync('ssh-1', ['pty-1'])
 
-    expect(store.getSshRemotePtyLeases('ssh-1')[0]).toMatchObject({ state: 'terminated' })
+    // The unbound tombstone is retired at close, and the batch only ever updates existing rows —
+    // so the id stays out of the reattach set either way.
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
   })
 
   it('does not revive an expired lease from an unqualified bulk attach', async () => {

--- a/src/main/persistence-ssh-lease-tombstone-retention.test.ts
+++ b/src/main/persistence-ssh-lease-tombstone-retention.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createStore, testState } from './persistence-test-harness'
+import { TEST_LEAF_1 } from './persistence-session-fixtures'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: () => ({}) }))
+
+describe('operator-closed SSH lease tombstones', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  /** A pane whose lease froze `tab-old` before `detachTerminalPaneToTab` moved it to `tab-new`.
+   *  The binding scrub matches tab-qualified, so it cannot reach this row's binding. */
+  async function storeWithDetachedPaneBinding(): Promise<Awaited<ReturnType<typeof createStore>>> {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty',
+      worktreeId: 'wt1',
+      tabId: 'tab-old',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    store.setWorkspaceSession({
+      activeRepoId: 'r1',
+      activeWorktreeId: 'wt1',
+      activeTabId: 'tab-new',
+      tabsByWorktree: {
+        wt1: [
+          {
+            id: 'tab-new',
+            worktreeId: 'wt1',
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1,
+            ptyId: null
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-new': {
+          root: { type: 'leaf', leafId: TEST_LEAF_1 },
+          activeLeafId: TEST_LEAF_1,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty' }
+        }
+      }
+    })
+    return store
+  }
+
+  it('keeps the tombstone while a binding the scrub could not reach still names the pty', async () => {
+    const store = await storeWithDetachedPaneBinding()
+
+    store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'terminated')
+
+    // `isRestorablePtyBinding` still consults this row to refuse replaying that binding.
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({ ptyId: 'remote-pty', state: 'terminated' })
+    ])
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId['tab-new'].ptyIdsByLeafId).toEqual({
+      [TEST_LEAF_1]: 'ssh:ssh-1@@remote-pty'
+    })
+  })
+
+  it('keeps an operator-closed lease that still owes an undelivered stop', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'remote-pty', state: 'attached' })
+    store.recordSshRemotePtyKillIntent('ssh-1', 'remote-pty', {
+      incarnationId: 'inc-1',
+      requestedAt: 1,
+      attempts: 0
+    })
+
+    store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'terminated')
+
+    expect(store.getSshRemotePtyKillIntents('ssh-1', 2)).toHaveLength(1)
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({ ptyId: 'remote-pty', state: 'terminated' })
+    ])
+  })
+
+  // `expired` is never evidence the shell died, and `sweepOrphanedRelayPtys` reads these ids as its
+  // leave-alone list, so dropping one would authorize stopping a process left running on purpose.
+  it('keeps a superseded expired lease when a sibling pane is closed', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-1',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'ssh-1',
+      ptyId: 'remote-pty-2',
+      worktreeId: 'wt1',
+      tabId: 'tab1',
+      leafId: TEST_LEAF_1,
+      state: 'attached'
+    })
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId: 'remote-pty-3', state: 'attached' })
+
+    store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty-3', 'terminated')
+
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
+      expect.objectContaining({
+        ptyId: 'remote-pty-1',
+        state: 'expired',
+        supersededBy: 'remote-pty-2'
+      }),
+      expect.objectContaining({ ptyId: 'remote-pty-2', state: 'attached' })
+    ])
+  })
+
+  it('retires every unreachable tombstone for the target, not only the one just closed', async () => {
+    const store = await createStore()
+    for (const ptyId of ['remote-pty-1', 'remote-pty-2', 'remote-pty-3']) {
+      store.upsertSshRemotePtyLease({ targetId: 'ssh-1', ptyId, state: 'terminated' })
+    }
+    store.upsertSshRemotePtyLease({ targetId: 'ssh-2', ptyId: 'other-pty', state: 'terminated' })
+    expect(store.getSshRemotePtyLeases()).toHaveLength(4)
+
+    store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty-1', 'terminated')
+
+    // Other targets are untouched: the pass is scoped to the one whose bindings were just scrubbed.
+    expect(store.getSshRemotePtyLeases()).toEqual([
+      expect.objectContaining({ targetId: 'ssh-2', ptyId: 'other-pty' })
+    ])
+  })
+})

--- a/src/main/persistence-ssh-remote-pty-leases.test.ts
+++ b/src/main/persistence-ssh-remote-pty-leases.test.ts
@@ -526,12 +526,9 @@ describe('Store', () => {
     store.markSshRemotePtyLeases('ssh-1', 'terminated')
 
     const session = store.getWorkspaceSession()
-    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
-      expect.objectContaining({
-        ptyId: 'remote-pty',
-        state: 'terminated'
-      })
-    ])
+    // The scrub is what retires the row: with no binding left naming the id, the tombstone routes
+    // nothing and is dropped in the same write.
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
     expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
     expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
   })
@@ -622,12 +619,8 @@ describe('Store', () => {
 
     store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'terminated')
 
-    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
-      expect.objectContaining({
-        ptyId: 'remote-pty',
-        state: 'terminated'
-      })
-    ])
+    // An unresolved id would have left the lease `attached`; this unbound row is retired instead.
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
   })
 
   // `expired` never means the shell exited — every writer records that the CLIENT lost its route
@@ -658,12 +651,7 @@ describe('Store', () => {
     store.markSshRemotePtyLease('ssh-1', 'ssh:ssh-1@@remote-pty', 'terminated')
 
     const session = store.getWorkspaceSession()
-    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([
-      expect.objectContaining({
-        ptyId: 'remote-pty',
-        state: 'terminated'
-      })
-    ])
+    expect(store.getSshRemotePtyLeases('ssh-1')).toEqual([])
     expect(session.tabsByWorktree.wt1[0].ptyId).toBeNull()
     expect(session.terminalLayoutsByTabId.tab1.ptyIdsByLeafId).toEqual({})
   })

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -2,6 +2,7 @@ import type { PersistedState } from '../../../shared/persisted-state-types'
 import type { SshRemotePtyLease } from '../../../shared/ssh-types'
 import { isTerminalLeafId } from '../../../shared/stable-pane-id'
 import { invalidateLocalWorktreeMetadataPruneInputs } from '../../local-worktree-metadata-prune-gate'
+import { pruneRetiredSshRemotePtyLeaseTombstones } from './ssh-pty-lease-tombstone-retention'
 import { supersedeSiblingLeasesForPane } from './ssh-pty-pane-supersession'
 
 export type SshPtyLeaseOperations = {
@@ -145,7 +146,11 @@ function updateSshRemotePtyLeaseStates(
   const bindingsChanged = shouldClearBindings
     ? operations.clearBindingsForLeases(targetId, leasesToClear)
     : false
-  return changed || bindingsChanged
+  // Why after the scrub: it is the scrub that makes the tombstones unreachable.
+  const tombstonesPruned = shouldClearBindings
+    ? pruneRetiredSshRemotePtyLeaseTombstones(operations, targetId)
+    : false
+  return changed || bindingsChanged || tombstonesPruned
 }
 
 export function markSshRemotePtyLeases(
@@ -215,10 +220,11 @@ export function markSshRemotePtyLease(
   }
   const shouldClearBindings = leaseStateWithdrawsBinding(state)
   if (lease.state === state) {
-    if (
-      (shouldClearBindings && operations.clearBindingsForLeases(targetId, [lease])) ||
-      recycledChanged
-    ) {
+    const bindingsCleared =
+      shouldClearBindings && operations.clearBindingsForLeases(targetId, [lease])
+    const tombstonesPruned =
+      shouldClearBindings && pruneRetiredSshRemotePtyLeaseTombstones(operations, targetId)
+    if (bindingsCleared || tombstonesPruned || recycledChanged) {
       operations.flush()
     }
     return
@@ -233,6 +239,7 @@ export function markSshRemotePtyLease(
   }
   if (shouldClearBindings) {
     operations.clearBindingsForLeases(targetId, [lease])
+    pruneRetiredSshRemotePtyLeaseTombstones(operations, targetId)
   }
   operations.flush()
 }

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-tombstone-retention.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-tombstone-retention.ts
@@ -1,0 +1,89 @@
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import type { SshRemotePtyLease } from '../../../shared/ssh-types'
+
+export type SshPtyLeaseTombstoneRetentionOperations = {
+  state: PersistedState
+  toComparablePtyId: (targetId: string, ptyId: string) => string
+}
+
+/** A routing tombstone with nothing left to route: the operator closed this PTY and no stop is
+ *  still owed for it. `expired` is deliberately not here — it says only that the CLIENT lost its
+ *  route (docs/reference/ssh-execution-boundary.md), and `sweepOrphanedRelayPtys` reads those ids
+ *  as its leave-alone list, so deleting one would authorize stopping a remote shell that
+ *  supersession left running on purpose. */
+function isRetiredRoutingTombstone(lease: SshRemotePtyLease, targetId: string): boolean {
+  return (
+    lease.targetId === targetId && lease.state === 'terminated' && lease.pendingKill === undefined
+  )
+}
+
+/** Every stored-form relay pty id some persisted pane binding still names for this target.
+ *
+ *  Reads all partitions, not only the two `clearSshRemotePtyBindingsForLeases` scrubs: this answer
+ *  authorizes a delete, so a partition left unscanned would be a binding whose tombstone we dropped.
+ */
+function boundRelayPtyIds(
+  operations: SshPtyLeaseTombstoneRetentionOperations,
+  targetId: string
+): Set<string> {
+  const bound = new Set<string>()
+  const sessions = [
+    operations.state.workspaceSession,
+    ...Object.values(operations.state.workspaceSessionsByHostId ?? {})
+  ]
+  for (const session of sessions) {
+    if (!session) {
+      continue
+    }
+    for (const tabs of Object.values(session.tabsByWorktree ?? {})) {
+      for (const tab of tabs) {
+        if (tab.ptyId) {
+          bound.add(operations.toComparablePtyId(targetId, tab.ptyId))
+        }
+      }
+    }
+    for (const layout of Object.values(session.terminalLayoutsByTabId ?? {})) {
+      for (const ptyId of Object.values(layout?.ptyIdsByLeafId ?? {})) {
+        bound.add(operations.toComparablePtyId(targetId, ptyId))
+      }
+    }
+  }
+  return bound
+}
+
+/**
+ * Deletes the `terminated` rows nothing can reach, bounding an array that otherwise only grew.
+ *
+ * `terminated` is written with a binding scrub in the same call, so once no persisted binding names
+ * the id the row answers no question any reader asks. Reattach refuses it
+ * (`sshRemotePtyLeaseAllowsReattach`), pane recovery matches on `expired` only, the orphan sweep
+ * already classes it neither routed nor expired, and `ssh:reset` / `ssh:terminateSessions` skip it
+ * outright — every one of those behaves identically on an absent row. The one reader that can still
+ * observe it is `isRestorablePtyBinding`, and only through a binding whose pty id matches, which is
+ * exactly what the reachability test rules out. A `pendingKill` is an undelivered stop, so those
+ * rows stay until the replay retires them.
+ *
+ * The reachability test is not redundant with the scrub: a lease freezes its `tabId`, so a pane
+ * broken out into a new tab leaves a binding the scrub's tab-qualified match no longer reaches.
+ *
+ * Does not re-arm the local-worktree-metadata prune gate: a `terminated` lease no longer counts as
+ * a persisted workspace owner, so dropping one cannot make any metadata row more removable.
+ */
+export function pruneRetiredSshRemotePtyLeaseTombstones(
+  operations: SshPtyLeaseTombstoneRetentionOperations,
+  targetId: string
+): boolean {
+  const leases = operations.state.sshRemotePtyLeases ?? []
+  if (!leases.some((lease) => isRetiredRoutingTombstone(lease, targetId))) {
+    return false
+  }
+  const bound = boundRelayPtyIds(operations, targetId)
+  const retained = leases.filter(
+    (lease) => !isRetiredRoutingTombstone(lease, targetId) || bound.has(lease.ptyId)
+  )
+  if (retained.length === leases.length) {
+    return false
+  }
+  operations.state.sshRemotePtyLeases = retained
+  return true
+}

--- a/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.test.ts
+++ b/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.test.ts
@@ -287,6 +287,64 @@ describe('pruneSessionlessMissingLocalWorktreeMetadataForRepo', () => {
     }
   })
 
+  // A route-retired lease is a tombstone, not a claim: counting one pinned its worktree's metadata
+  // row for good, so the prune could never make progress on it (#17775).
+  it('does not let route-retired SSH leases pin a metadata row', () => {
+    const state = makeState()
+    const liveIds = Array.from({ length: 3 }, (_, i) => `${REPO_ID}::/workspace/live-${i}`)
+    const terminatedIds = Array.from({ length: 5 }, (_, i) => `${REPO_ID}::/workspace/closed-${i}`)
+    const supersededIds = Array.from({ length: 4 }, (_, i) => `${REPO_ID}::/workspace/lost-${i}`)
+    const recycledIds = [`${REPO_ID}::/workspace/recycled`]
+    const allIds = [...liveIds, ...terminatedIds, ...supersededIds, ...recycledIds]
+    for (const worktreeId of allIds) {
+      state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    }
+    const lease = (worktreeId: string, index: number, extra: object) => ({
+      targetId: 'builder',
+      ptyId: `pty-${index}`,
+      worktreeId,
+      createdAt: 1,
+      updatedAt: 1,
+      ...extra
+    })
+    state.sshRemotePtyLeases = [
+      ...liveIds.map((id, i) => lease(id, i, { state: 'detached' })),
+      ...terminatedIds.map((id, i) => lease(id, 100 + i, { state: 'terminated' })),
+      ...supersededIds.map((id, i) =>
+        lease(id, 200 + i, { state: 'expired', supersededBy: 'pty-9' })
+      ),
+      ...recycledIds.map((id, i) => lease(id, 300 + i, { state: 'expired', relayIdRecycled: true }))
+    ] as never
+
+    const scan = capture(state)
+
+    expect(pruneCaptured(state, scan, allIds).sort()).toEqual(
+      [...terminatedIds, ...supersededIds, ...recycledIds].sort()
+    )
+    expect(Object.keys(state.worktreeMeta).sort()).toEqual([...liveIds].sort())
+  })
+
+  // A plain `expired` lease says only that the CLIENT lost its route, so its pane is still
+  // recoverable and its metadata row is still owned (docs/reference/ssh-execution-boundary.md).
+  it('keeps a metadata row pinned by an unmarked expired lease', () => {
+    const state = makeState()
+    const worktreeId = `${REPO_ID}::/workspace/orphaned`
+    state.worktreeMeta[worktreeId] = makeMeta(worktreeId)
+    const scan = capture(state)
+    state.sshRemotePtyLeases = [
+      {
+        targetId: 'builder',
+        ptyId: 'pty',
+        worktreeId,
+        state: 'expired',
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+
+    expect(pruneCaptured(state, scan, [worktreeId])).toEqual([])
+  })
+
   it('preserves canonically equivalent session and top-level owners', () => {
     const candidateId = `${REPO_ID}::/workspace/Café`.normalize('NFC')
     const ownerId = candidateId.normalize('NFD')

--- a/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.ts
+++ b/src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.ts
@@ -2,6 +2,7 @@ import { isWindowsAbsolutePathLike } from '../../../shared/cross-platform-path'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import type { PersistedState } from '../../../shared/persisted-state-types'
 import { getRepoKind } from '../../../shared/repo-kind'
+import { sshRemotePtyLeaseAllowsReattach } from '../../../shared/ssh-types'
 import { worktreeWorkspaceKey } from '../../../shared/workspace-scope'
 import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR, splitWorktreeId } from '../../../shared/worktree/id'
 import { isWslUncPath } from '../../../shared/wsl-paths'
@@ -40,6 +41,13 @@ function collectPersistedWorkspaceOwners(
     }
   }
   for (const lease of state.sshRemotePtyLeases) {
+    // A lease that can never be reattached is a routing tombstone, not a claim on a workspace:
+    // `terminated` is the operator close, and an `expired` row marked `supersededBy` /
+    // `relayIdRecycled` already lost its pane to a newer lease. Counting them as owners pinned
+    // their worktree's metadata row permanently, so the prune could never make progress (#17775).
+    if (!sshRemotePtyLeaseAllowsReattach(lease)) {
+      continue
+    }
     add(lease.worktreeId)
   }
   for (const entry of state.migrationUnsupportedPtyEntries) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 |

<!-- /orca-pr-loc -->

## ELI5

Every few seconds while you work, Orca writes its whole memory of your projects to disk in one go. Two of the things it remembers were never cleaned up, so that write kept getting slower forever.

The first is a list of remote terminals you opened over SSH. When you close one, Orca leaves behind a little note saying "this one is closed". Nothing ever threw those notes away — one machine had 138 of them, 137 already dead, adding about 38 new ones a day. This change throws a note away once nothing can possibly refer to it any more.

The second is subtler. Orca has a separate cleanup job for records of folders that no longer exist. That job skips any folder something is still using — and it counted those dead "this one is closed" notes as something still using it. So a dead note could keep a folder's record alive forever, and the cleanup could never finish its work.

Neither change touches a terminal you might still get back.

## Why it matters

Measured on the reported live profile (`~/Library/Application Support/orca/profiles/local-default/orca-data.json`, 3,637,526 bytes), which is re-serialised in full on every save:

```
sshRemotePtyLeases: 138 rows / 57,357 bytes
  terminated 101  (0 carrying pendingKill)
  expired     37  (0 carrying supersededBy, 0 carrying relayIdRecycled)
  max age 3.6 days, all from a single targetId
```

There is no pruning path for that array. Removal happens in exactly three places, all explicit and none age- or state-based: `removeSshRemotePtyLease`, `removeSshRemotePtyLeases` (target deletion only) and `ssh-target-reassignment.ts:144`. `normalize-loaded-profile-state.ts:90` only maps and drops nulls. `terminated` and `expired` are *states*, not deletions. Sibling structures in the same subsystem do have caps (`MAX_CLAUDE_LIVE_PTY_SESSION_IDS = 200`, `MAX_REMOVED_SSH_TARGET_TOMBSTONES = 50`), so this is a gap, not a policy.

At the observed rate of ~38 leases/day from one target, that is ~450 KB/month and ~5.5 MB/year — the array would eventually outweigh the rest of the store.

The owner-set bug is named by the prune gate's own doc comment (`src/main/local-worktree-metadata-prune-gate.ts:8`):

> Rows pinned by a persisted session are never removable, so the repetition cannot even make progress.

## Measurement

### Before/after on the real profile

Replaying the shipped predicate over the live `orca-data.json`:

```
leases before: 138 rows, 57,357 bytes
leases after :  38 rows, 16,292 bytes
reclaimed    : 100 rows, 41,065 bytes (1.13% of the 3,637,526-byte file)

serialise the leases array: 0.130 ms -> 0.038 ms
```

100 of the 101 `terminated` rows are unreachable and retired. The one that stays is genuinely load-bearing: two persisted layout bindings in `workspaceSession` still name `ssh:ssh-1777360569033-yvz2mp@@pty-1`, under tab ids the lease's frozen `tabId` no longer matches — so the tab-qualified binding scrub never reached them, and `isRestorablePtyBinding` still consults that row. This is the case the reachability gate exists for, and it is not hypothetical.

### Honest scope note on the metadata prune

The brief I was given framed this as unblocking ~921 dangling `worktreeMeta` rows. **That framing is wrong and I am not claiming it.** Re-measured:

```
worktreeMeta rows                    1,339
  hostId local                       1,311   (of which 1,291 paths still exist on disk, 23 gone)
  hostId ssh:...yvz2mp                  26
  unqualified                            2
worktreeIds pinned ONLY by a dead lease: 0 local candidates
```

96% of rows are `hostId: local` and 98% of those point at a live directory — this user genuinely has ~1,291 checkouts. The 26 SSH rows "dangle" only because the existence check runs on the wrong machine, which is exactly why `isLocallyRemovableWorktreeMetadataRow` refuses them.

So the owner-set filter reclaims **0 rows on this particular profile**: every dead lease's `worktreeId` names the SSH repo (`a0fe26b4::/home/neil/...`), and the local prune only ever considers candidates whose `repoId` is a local git repo. It is shipped as a correctness fix for a latent pin, not as a size win, and it makes **no** additional metadata row prunable beyond the ~21 genuinely-dead ones. No `worktreeMeta` pruning of any kind is added here.

### Failing-test output (guards verified against a temporarily reverted change)

**1. Owner-set filter reverted** (`if (!sshRemotePtyLeaseAllowsReattach(lease)) continue` removed):

```
FAIL src/main/persistence/tracking-repos/missing-local-worktree-metadata-pruning.test.ts
   > does not let route-retired SSH leases pin a metadata row
AssertionError: expected [] to deeply equal [ 'repo-1::/workspace/closed-0', ... ]

- [
-   "repo-1::/workspace/closed-0",  "repo-1::/workspace/closed-1",
-   "repo-1::/workspace/closed-2",  "repo-1::/workspace/closed-3",
-   "repo-1::/workspace/closed-4",  "repo-1::/workspace/lost-0",
-   "repo-1::/workspace/lost-1",    "repo-1::/workspace/lost-2",
-   "repo-1::/workspace/lost-3",    "repo-1::/workspace/recycled",
- ]
+ []

 Tests  1 failed | 28 skipped (29)
```

**2. Tombstone retirement reverted** (`pruneRetiredSshRemotePtyLeaseTombstones` made a no-op):

```
 × clears workspace bindings when marking all SSH remote PTY leases for a target terminated
 × updates SSH remote PTY leases when callers pass scoped app ids
 × clears workspace bindings when marking an SSH remote PTY lease terminated
 × keeps a superseded expired lease when a sibling pane is closed
 × retires every unreachable tombstone for the target, not only the one just closed
 Tests  5 failed | 19 passed (24)
```

**3. The reachability gate alone reverted** (`|| bound.has(lease.ptyId)` removed — i.e. delete every terminated row regardless of bindings):

```
 × keeps the tombstone while a binding the scrub could not reach still names the pty
 Tests  1 failed | 23 passed (24)
```

That third one is the important guard: it proves the gate is doing real work and that an ungated delete would drop a tombstone a binding still depends on.

**With the change, all green:**

```
Test Files  98 passed | 1 skipped (99)
     Tests  1023 passed | 1 skipped (1024)
```

## Correctness

This deletes persisted state, so both changes are argued from an enumeration of every reader.

### Change 1 — the owner set

`collectPersistedWorkspaceOwners` had no state filter on `state.sshRemotePtyLeases`, so every lease registered its `worktreeId` as a live persisted owner. It now skips leases that `sshRemotePtyLeaseAllowsReattach` rejects — reusing the predicate that already decides which leases still name a route, rather than reimplementing the state test.

- A `terminated` lease is the operator-close tombstone. `ssh-pty-lease-operations.ts:105` documents that only `terminated` unbinds a pane; it is written *after* the user closed the PTY. It cannot be a live workspace owner.
- An `expired` lease carrying `supersededBy` has already lost its pane to a newer lease for the same `(targetId, worktreeId, leafId)`.
- An `expired` lease carrying `relayIdRecycled` has had its id handed to a different shell by the relay, so it no longer names the workspace it describes.
- A plain `expired` lease with **neither** mark is deliberately still an owner: it means the client lost its route while the remote shell may still live, which is the SSH pane-recovery affordance. Covered by a dedicated test.

The prune this feeds is already evidence-gated and re-checks everything authoritatively (`pruneSessionlessMissingLocalWorktreeMetadataForRepo`), so a disagreement here can only cost a wasted `stat`, never widen a delete.

### Change 2 — retiring unreachable tombstones

A `terminated` lease is written with a binding scrub in the same call (`clearBindingsForLeases`). Once no persisted binding names the id, the row routes nothing. Every reader of the lease array, checked individually:

| Reader | On a `terminated` row | On an absent row |
| --- | --- | --- |
| `sshRemotePtyLeaseAllowsReattach` (`ssh-relay-session.ts:2038`, `:2330`) | `false` — excluded from reattach | excluded |
| `clientClaims` (`ssh-orphan-relay-pty-sweep.ts:61`) | neither `routed` nor `expired` | neither |
| `ssh:reset` loop (`ssh-connection-handlers.ts:83`) | `state !== 'terminated'` guard skips it | skipped |
| `ssh:terminateSessions` (`ssh-connection-handlers.ts:140`) | `continue` | not seen |
| `getRecentExpiredSshLease` | requires `state === 'expired'` | not found |
| `updateSshRemotePtyLeaseStates` bulk-attach guard | `continue` — never revived | never created |
| `hasRestorableSshRemotePtyLease` | `false` (withdraws binding) | `false` (no match) |
| `isRestorablePtyBinding` | **`false`** — refuses the replay | **`true`** |
| `remapSshRemotePtyLeaseLeafIds`, `ssh-target-reassignment`, `clearSshRemotePtyBindingsForTarget` | per-row rewrite/scrub | one fewer row to rewrite |
| `getSshRemotePtyKillIntents` / replay / cap | `pendingKill`-scoped | those rows are retained |

`isRestorablePtyBinding` is the one reader that can tell the difference, and it can only ever be reached through a persisted binding: both its matchers require `lease.ptyId === toComparablePtyId(targetId, binding.ptyId)` before anything else, and its two call sites (`workspace-session-terminal-binding-replay.ts:119`, `:167`) source their pty ids exclusively from `prior` — the session main already holds, which is precisely what the gate scans. That is why the delete is gated on reachability rather than on the scrub alone: **a lease freezes its `tabId`, so `detachTerminalPaneToTab` leaves a binding under a tab id the scrub's tab-qualified match cannot reach.** The live profile contains exactly that case, and the gate retains that row.

**`expired` is deliberately untouched, superseded rows included.** I did not ship the "drop `expired` rows with `supersededBy`" half of the plan, because it is not safe: `sweepOrphanedRelayPtys` passes those ids to `planRelayPtySweep` as `expiredLeasePtyIds`, its leave-alone list (`ssh-relay-pty-ownership-proof.ts:179` → `'this client expired its lease without ordering a stop'`). Deleting such a row puts the ptyId in neither `routed` nor `expired`, which turns a remote shell that supersession left running **on purpose** into a sweep candidate. That is a process kill, not a byte saving. It would also have reclaimed nothing: 0 of the 37 `expired` rows on the reported profile carry either mark.

`pendingKill` rows are retained unconditionally — an undelivered stop is replayed on the next handshake, and the existing `isDisposableKillOnlyLease` path already owns their retirement.

The prune does **not** re-arm `invalidateLocalWorktreeMetadataPruneInputs`. With change 1 in place a `terminated` lease no longer counts as an owner, so dropping one cannot make any metadata row more removable, and a spurious bump would cost a full O(all rows) pass the gate exists to avoid.

### Edge cases

- **SSH**: the whole change is SSH. Verdict vocabulary respected — nothing here reads loss of contact as death, and no `expired` row is deleted.
- **Folder workspaces**: untouched. `getPersistedWorktreeOwnerId` already returns `null` for folder scopes, and the tombstone prune reads only pty ids.
- **Windows / Linux**: no path handling, no platform branch, no process spawning.
- **Empty/missing state**: `sshRemotePtyLeases ?? []` and `workspaceSessionsByHostId ?? {}` throughout; a store with no leases short-circuits before the session scan.
- **Remote wire compatibility**: nothing here crosses the wire. `pendingKill` is explicitly client-local, and leases are not published to a host.
- **Cost**: the session scan runs only on the paths that already scrub bindings (`terminated` writes), and short-circuits unless a candidate row exists.

## Negative user-facing trade-offs

**None** for any state a user can still reach — no `expired` lease is deleted, no lease with an undelivered stop is deleted, and no lease a persisted binding still names is deleted, so every recoverable SSH pane keeps the row that recovers it.

One behavioural difference worth naming honestly, since it is not literally byte-identical: three existing tests asserted that an *unbound* `terminated` row survives its own close, and they now assert it is retired. Each was verified equivalent through the table above — the row they were keeping answers no question any reader asks. One genuine side effect falls out: `upsertSshRemotePtyLease` can no longer merge a recycled relay id onto a dead pane's frozen identity, which is the hazard its own `NOTE`/STA-3077 comment describes. That is a fix, not a regression, but it is a change.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/persistence src/main/persistence-ssh-lease-tombstone-retention.test.ts src/main/local-worktree-metadata-prune-gate.test.ts src/main/orca-profiles` — 98 files, 1023 passed, 1 skipped.
- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/ssh src/main/ssh-expired-lease-pane-readoption.test.ts src/main/ssh-reattach-pane-cardinality.test.ts` — 151 files, 2065 passed. (One unrelated flake under load, `ssh-remote-commands.test.ts > bounds real POSIX GC output…`; passes in isolation, file untouched by this branch.)
- `nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false` — clean.
- `oxfmt --write` + `oxlint` on all changed files — clean. New tests live in their own file rather than bumping `max-lines` on `persistence-ssh-remote-pty-leases.test.ts`.
- Each guard verified failing against a temporarily reverted change (three separate reverts, output above).

New coverage:
- owner set contains only reattachable leases' worktreeIds; `terminated`, superseded-`expired` and `relayIdRecycled` rows do not pin (counter-style: 3 live vs 5+4+1 dead);
- a plain `expired` lease still pins its metadata row;
- a tombstone is kept while an out-of-tab binding still names its pty;
- a tombstone with a `pendingKill` is kept, and its intent still replays;
- a superseded `expired` lease survives a sibling pane's close;
- the pass retires the whole target's unreachable backlog and leaves other targets alone.

## Not shipped, and why

The brief also asked for deleting emptied `workspaceSessionsByHostId` partitions, on the stated grounds that "absent and empty are already equivalent to every reader". **I verified that claim and it does not hold**, so I did not ship it.

`getWorkspaceSessionHostIds()` enumerates the partition *keys*, and `workspace-session-snapshot-publication.ts:91` feeds that set to `remapSshRemotePtyLeaseLeafIds` as `hostIdsWithWorkspaceSessions`. That set gates the legacy-local fallback at `workspace-pane-normalization.ts:124`: with the partition present the remap resolves against that host, and with it absent the lease falls back to the **local** remap — which can rewrite or `delete` a lease's `leafId`, i.e. its durable pane identity. `hasPersistedWorkspaceSession` also branches on presence. The payoff was ~4.7 KB (0.13% of one save) against a real risk of mangling SSH pane identity, so it is not worth taking. If it is still wanted, it needs `getWorkspaceSessionHostIds` to keep reporting a deleted-but-known host, which is a different change.
