### PR TITLE
fix(cloud): stop asking setup-node to cache the pnpm store in the relay workflows

### DIFF
--- a/.github/workflows/cloud-deploy-relay-production-capacity-job.yml
+++ b/.github/workflows/cloud-deploy-relay-production-capacity-job.yml
@@ -164,8 +164,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: cloud/pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/cloud-deploy-relay-production-capacity.yml
+++ b/.github/workflows/cloud-deploy-relay-production-capacity.yml
@@ -136,8 +136,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: cloud/pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/cloud-deploy-relay-production-multi-target.yml
+++ b/.github/workflows/cloud-deploy-relay-production-multi-target.yml
@@ -193,8 +193,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: cloud/pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
+++ b/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
@@ -99,8 +99,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: cloud/pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/cloud-deploy-relay-production.yml
+++ b/.github/workflows/cloud-deploy-relay-production.yml
@@ -90,8 +90,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: cloud/pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/cloud-monitor-relay-production-job.yml
+++ b/.github/workflows/cloud-monitor-relay-production-job.yml
@@ -64,8 +64,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: cloud/pnpm-lock.yaml
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 6 | 0 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 |

<!-- /orca-pr-loc -->

First public run of `cloud-monitor-relay-production` (33746931085) died in `actions/setup-node` before auth: `cache: pnpm` runs `pnpm store path` from the repository root, where `packageManager` pins pnpm 12, and the downloaded shim fails with a shell syntax error on the runner. Cloud Verify never used the cache and is green. Drops `cache: pnpm` + `cache-dependency-path` from the six `cloud-*` workflows that copied it from orca-cloud (whose root is pnpm 10). `cloud-monitor-relay-clock-skew` already passed on the public repo.