### PR TITLE
perf(worktrees): classify each worktree once, defer the SSH meta index, drop the conflict-path probe

### DIFF
--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -18,7 +18,10 @@ import { findExistingWorktreeSymlinkPaths } from '../worktree-symlink-detection'
 import type { GetStatusOptions } from './get-status-options'
 import { statusReadLeaseOwner } from './git-read-cache-invalidation'
 import { detectConflictOperation } from './git-conflict-operation'
-import { parseUnmergedEntry } from '../../../shared/git-status-conflict-entries'
+import {
+  parseUnmergedEntry,
+  resolveUnmergedStatusRecords
+} from '../../../shared/git-status-conflict-entries'
 import { getEffectiveUpstreamStatusCacheKey } from './effective-upstream-status-cache'
 import {
   getShortBranchName,
@@ -176,16 +179,37 @@ async function runGetStatus(
   // Why: git runs in the distro and answers in its namespace; the working-tree probes below run here.
   const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options) ?? worktreePath
 
+  // Why: a record only pushes one entry, so the cap can never break before index `limit`; prefetching
+  // exactly that prefix keeps the probe count identical to a serial read on a truncated status.
+  const resolvableUnmergedEnd = didHitLimit
+    ? Math.min(parser.statusRecords.length, limit)
+    : parser.statusRecords.length
+  // Why: skip the prefetch entirely for the conflict-free poll so the common path allocates nothing extra.
+  const resolvedUnmerged =
+    parser.unmergedLines.length > 0
+      ? await resolveUnmergedStatusRecords(
+          hostWorktreePath,
+          parser.statusRecords,
+          resolvableUnmergedEnd
+        )
+      : undefined
+
   // Why: resolve deferred conflicts in Git's output order so the cap cannot hide
   // an early conflict behind ordinary rows that appeared later in the stream.
-  for (const record of parser.statusRecords) {
+  for (const [index, record] of parser.statusRecords.entries()) {
     if (didHitLimit && entries.length >= limit) {
       break
     }
     if (record.type === 'entry') {
       entries.push(record.entry)
     } else {
-      const unmergedEntry = await parseUnmergedEntry(hostWorktreePath, record.line)
+      const prefetched = resolvedUnmerged?.[index]
+      if (prefetched?.ok === false) {
+        throw prefetched.error
+      }
+      const unmergedEntry = prefetched
+        ? prefetched.entry
+        : await parseUnmergedEntry(hostWorktreePath, record.line)
       if (unmergedEntry) {
         entries.push(unmergedEntry)
       }

--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -18,10 +18,7 @@ import { findExistingWorktreeSymlinkPaths } from '../worktree-symlink-detection'
 import type { GetStatusOptions } from './get-status-options'
 import { statusReadLeaseOwner } from './git-read-cache-invalidation'
 import { detectConflictOperation } from './git-conflict-operation'
-import {
-  parseUnmergedEntry,
-  resolveUnmergedStatusRecords
-} from '../../../shared/git-status-conflict-entries'
+import { parseUnmergedEntry } from '../../../shared/git-status-conflict-entries'
 import { getEffectiveUpstreamStatusCacheKey } from './effective-upstream-status-cache'
 import {
   getShortBranchName,
@@ -179,37 +176,16 @@ async function runGetStatus(
   // Why: git runs in the distro and answers in its namespace; the working-tree probes below run here.
   const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options) ?? worktreePath
 
-  // Why: a record only pushes one entry, so the cap can never break before index `limit`; prefetching
-  // exactly that prefix keeps the probe count identical to a serial read on a truncated status.
-  const resolvableUnmergedEnd = didHitLimit
-    ? Math.min(parser.statusRecords.length, limit)
-    : parser.statusRecords.length
-  // Why: skip the prefetch entirely for the conflict-free poll so the common path allocates nothing extra.
-  const resolvedUnmerged =
-    parser.unmergedLines.length > 0
-      ? await resolveUnmergedStatusRecords(
-          hostWorktreePath,
-          parser.statusRecords,
-          resolvableUnmergedEnd
-        )
-      : undefined
-
   // Why: resolve deferred conflicts in Git's output order so the cap cannot hide
   // an early conflict behind ordinary rows that appeared later in the stream.
-  for (const [index, record] of parser.statusRecords.entries()) {
+  for (const record of parser.statusRecords) {
     if (didHitLimit && entries.length >= limit) {
       break
     }
     if (record.type === 'entry') {
       entries.push(record.entry)
     } else {
-      const prefetched = resolvedUnmerged?.[index]
-      if (prefetched?.ok === false) {
-        throw prefetched.error
-      }
-      const unmergedEntry = prefetched
-        ? prefetched.entry
-        : await parseUnmergedEntry(hostWorktreePath, record.line)
+      const unmergedEntry = await parseUnmergedEntry(hostWorktreePath, record.line)
       if (unmergedEntry) {
         entries.push(unmergedEntry)
       }

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -77,6 +77,13 @@ describe('getStatus', () => {
     gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
   })
 
+  /** `access` targets outside the git dir — i.e. working-tree probes, not conflict-marker reads. */
+  function conflictFileProbes(): string[] {
+    return accessMock.mock.calls
+      .map(([target]) => String(target).replaceAll('\\', '/'))
+      .filter((target) => !target.includes('/.git/'))
+  }
+
   it('parses unmerged porcelain v2 entries into unresolved conflict rows', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
     accessMock.mockImplementation(async (target: string) => {
@@ -104,11 +111,12 @@ describe('getStatus', () => {
     ])
   })
 
-  it('maps deleted conflicts to deleted when the working tree file is absent', async () => {
+  // The 7th field of a `u` record is the working-tree mode; `000000` is how Git reports an absent path.
+  it('maps deleted conflicts to deleted from the porcelain working-tree mode', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
-        'u UD N... 100644 100644 000000 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/deleted.ts\n'
+        'u UD N... 100644 100644 000000 000000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/deleted.ts\n'
     })
 
     const result = await getStatus('/repo')
@@ -120,10 +128,12 @@ describe('getStatus', () => {
       conflictKind: 'deleted_by_them',
       conflictStatus: 'unresolved'
     })
+    expect(conflictFileProbes()).toEqual([])
   })
 
-  it('falls back to modified when the working-tree probe fails for a non-absence reason', async () => {
+  it('never re-probes the working tree for a conflict row, whatever the filesystem would say', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    // Every probe fails ENOENT (beforeEach) or EIO — neither may reach the row's status.
     accessMock.mockRejectedValue(Object.assign(new Error('EIO'), { code: 'EIO' }))
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
@@ -134,19 +144,14 @@ describe('getStatus', () => {
 
     expect(result.entries[0]?.status).toBe('modified')
     expect(result.entries[0]?.conflictKind).toBe('added_by_us')
+    expect(conflictFileProbes()).toEqual([])
   })
 
   // Why both cases normalize separators: git reports the worktree in the WSL guest namespace, and
   // the assertion is about which path is probed, not which separator this host's `path` emits.
-  it('probes the conflict working tree through the distro spelling on Windows', async () => {
+  it('resolves a WSL conflict row without crossing the 9p share', async () => {
     const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     readFileMock.mockResolvedValue('gitdir: /home/me/repo/.git/worktrees/feature\n')
-    accessMock.mockImplementation(async (target: string) => {
-      if (String(target).endsWith('new.ts')) {
-        return undefined
-      }
-      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
-    })
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         'u DU N... 100644 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/new.ts\n'
@@ -156,10 +161,12 @@ describe('getStatus', () => {
       const result = await getStatus('/home/me/repo/feature', { wslDistro: 'Ubuntu' })
 
       const probed = accessMock.mock.calls.map(([target]) => String(target).replaceAll('\\', '/'))
-      expect(probed).toContain('//wsl.localhost/Ubuntu/home/me/repo/feature/src/new.ts')
+      // No `\\wsl.localhost` round trip per conflict row: the porcelain `mW` field already answered.
+      expect(probed).not.toContain('//wsl.localhost/Ubuntu/home/me/repo/feature/src/new.ts')
+      expect(conflictFileProbes()).toEqual([])
       expect(result.entries[0]?.status).toBe('modified')
       expect(result.entries[0]?.conflictKind).toBe('deleted_by_us')
-      // The conflict-marker probes travel the same way.
+      // The conflict-marker probes still travel through the distro spelling.
       expect(
         probed.filter((target) =>
           target.startsWith('//wsl.localhost/Ubuntu/home/me/repo/.git/worktrees/feature/')

--- a/src/main/ipc/worktrees/listing/detected-provider-listing-meta-index.test.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing-meta-index.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The SSH worktree-meta index is only ever read via `metaIndex.get(repo.id)` on the disconnected
+ * fallbacks, so a connected listing must not pay `parseWorktreeId` over the whole host snapshot.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Store } from '../../../persistence/loading-store/store'
+import type * as SshWorktreeFallbackModule from './ssh-worktree-fallback'
+
+const { getSshGitProviderMock, indexBuildSpy } = vi.hoisted(() => ({
+  getSshGitProviderMock: vi.fn(),
+  indexBuildSpy: vi.fn()
+}))
+
+vi.mock('../../../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock,
+  requireSshGitProvider: getSshGitProviderMock,
+  getSshGitProviderGeneration: () => 1
+}))
+
+vi.mock('./ssh-worktree-fallback', async (importOriginal) => {
+  const actual = await importOriginal<typeof SshWorktreeFallbackModule>()
+  return {
+    ...actual,
+    // Both builders are counted: the point is that NO index is built on the connected path.
+    createSshWorktreeMetaIndex: (...args: Parameters<typeof actual.createSshWorktreeMetaIndex>) => {
+      indexBuildSpy('all-hosts', ...args)
+      return actual.createSshWorktreeMetaIndex(...args)
+    },
+    createSshWorktreeMetaIndexForRepo: (
+      ...args: Parameters<typeof actual.createSshWorktreeMetaIndexForRepo>
+    ) => {
+      indexBuildSpy('repo-scoped', ...args)
+      return actual.createSshWorktreeMetaIndexForRepo(...args)
+    }
+  }
+})
+
+const { listDetectedWorktreesForCapturedRepo } = await import('./detected-provider-listing')
+
+const repo = {
+  id: 'repo-1',
+  path: '/home/user/repo',
+  displayName: 'repo',
+  connectionId: 'conn-1'
+} as Repo
+
+const worktreeId = `${repo.id}::/home/user/feature`
+
+function createStore(): Store {
+  const rows: Record<string, { instanceId?: string; hostId?: string }> = {
+    [worktreeId]: { instanceId: 'instance-1' },
+    // Other repos' rows share the host snapshot; only this repo's bucket is ever read back.
+    'repo-2::/home/user/other': { instanceId: 'instance-2' }
+  }
+  return {
+    getRepos: () => [repo],
+    getRepo: () => repo,
+    getSettings: () => ({}),
+    getProjectHostSetups: () => [],
+    getAllWorktreeLineage: () => ({}),
+    getAllWorktreeMeta: () => rows,
+    getWorktreeMeta: (id: string) => rows[id],
+    setWorktreeMeta: vi.fn()
+  } as unknown as Store
+}
+
+describe('SSH worktree meta index construction', () => {
+  beforeEach(() => {
+    indexBuildSpy.mockClear()
+    getSshGitProviderMock.mockReset()
+  })
+
+  it('does not build the index when the provider answers', async () => {
+    const provider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        { path: repo.path, head: 'a', branch: 'main', isBare: false, isMainWorktree: true },
+        {
+          path: '/home/user/feature',
+          head: 'b',
+          branch: 'feature',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
+    }
+
+    const result = await listDetectedWorktreesForCapturedRepo(
+      createStore(),
+      repo,
+      () => true,
+      provider as never
+    )
+
+    expect(result).toMatchObject({ authoritative: true, source: 'git' })
+    expect(indexBuildSpy).not.toHaveBeenCalled()
+  })
+
+  it('builds the index once when no provider is available', async () => {
+    const result = await listDetectedWorktreesForCapturedRepo(
+      createStore(),
+      repo,
+      () => true,
+      undefined
+    )
+
+    expect(result).toMatchObject({ authoritative: false, source: 'metadata-fallback' })
+    expect(indexBuildSpy).toHaveBeenCalledTimes(1)
+    expect(indexBuildSpy).toHaveBeenCalledWith('all-hosts', expect.anything())
+    expect(
+      (result as { worktrees: { id: string }[] }).worktrees.map((worktree) => worktree.id)
+    ).toEqual([worktreeId])
+  })
+
+  it('builds the index once when the provider listing fails', async () => {
+    const provider = { listWorktrees: vi.fn().mockRejectedValue(new Error('relay down')) }
+
+    const result = await listDetectedWorktreesForCapturedRepo(
+      createStore(),
+      repo,
+      () => true,
+      provider as never
+    )
+
+    expect(result).toMatchObject({ authoritative: false, source: 'metadata-fallback' })
+    expect(indexBuildSpy).toHaveBeenCalledTimes(1)
+    expect(
+      (result as { worktrees: { id: string }[] }).worktrees.map((worktree) => worktree.id)
+    ).toEqual([worktreeId])
+  })
+})

--- a/src/main/ipc/worktrees/listing/detected-provider-listing.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing.ts
@@ -10,7 +10,8 @@ import type { ListDesktopLineageForHostArgs } from '../../../../shared/host-line
 import {
   buildDetectedGitWorktrees,
   createSshWorktreeMetaIndex,
-  listDisconnectedSshWorktrees
+  listDisconnectedSshWorktrees,
+  type SshWorktreeMetaIndex
 } from './ssh-worktree-fallback'
 import {
   buildDisconnectedDetectedWorktrees,
@@ -42,9 +43,11 @@ export async function listDetectedWorktreesForCapturedRepo(
   const allMeta = isFolderRepo(repo)
     ? undefined
     : readAllWorktreeMetaForHost(store, getRepoExecutionHostId(repo))
-  const sshWorktreeMetaIndex = repo.connectionId
-    ? createSshWorktreeMetaIndex(Object.entries(allMeta ?? {}))
-    : new Map()
+  // Why: only the disconnected fallbacks read this, so keep parseWorktreeId over the whole host snapshot
+  // off the connected path entirely.
+  let cachedSshWorktreeMetaIndex: SshWorktreeMetaIndex | undefined
+  const sshWorktreeMetaIndex = (): SshWorktreeMetaIndex =>
+    (cachedSshWorktreeMetaIndex ??= createSshWorktreeMetaIndex(Object.entries(allMeta ?? {})))
 
   try {
     let gitWorktrees: GitWorktreeInfo[]
@@ -86,7 +89,7 @@ export async function listDetectedWorktreesForCapturedRepo(
         if (!isCurrent()) {
           return null
         }
-        const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+        const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex())
         return {
           repoId: repo.id,
           authoritative: false,
@@ -158,7 +161,7 @@ export async function listDetectedWorktreesForCapturedRepo(
       err
     )
     if (repo.connectionId) {
-      const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+      const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex())
       return {
         repoId: repo.id,
         authoritative: false,

--- a/src/main/ipc/worktrees/listing/detected-worktree-classification.test.ts
+++ b/src/main/ipc/worktrees/listing/detected-worktree-classification.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Guards the single-classification contract of `buildDetectedGitWorktrees`: every visible worktree
+ * used to be run through `mergeWorktree` + `toDetectedWorktree` twice per catalog pass.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Store } from '../../../persistence/loading-store/store'
+import type { WorktreeMeta } from '../../../../shared/worktree/meta-types'
+import type { GitWorktreeInfo } from '../../../../shared/worktree/types'
+import type * as NodeCryptoModule from 'node:crypto'
+import type * as OwnershipModule from '../../../../shared/worktree/ownership'
+
+const { toDetectedWorktreeSpy } = vi.hoisted(() => ({ toDetectedWorktreeSpy: vi.fn() }))
+
+vi.mock('../../../../shared/worktree/ownership', async (importOriginal) => {
+  const actual = await importOriginal<typeof OwnershipModule>()
+  return {
+    ...actual,
+    toDetectedWorktree: (args: Parameters<typeof actual.toDetectedWorktree>[0]) => {
+      toDetectedWorktreeSpy(args)
+      return actual.toDetectedWorktree(args)
+    }
+  }
+})
+
+vi.mock('node:crypto', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeCryptoModule>()),
+  randomUUID: () => 'fixed-instance-id'
+}))
+
+const { buildDetectedGitWorktrees } = await import('./ssh-worktree-fallback')
+const { getProjectHostSetupWorktreeMeta } =
+  await import('../../../../shared/project-host-setup-lookup')
+const { mergeWorktree } = await import('../../worktree-logic')
+const { resolveWorktreeMetaWithDiscoveryBackfill } = await import('./worktree-discovery-metadata')
+const ownership = await import('../../../../shared/worktree/ownership')
+const { projectResolvedWorktreeLineage } =
+  await import('../../../../shared/resolved-worktree-lineage')
+const { createWorktreeVisibilitySourceMatcher, resolveCustomWorktreeVisibilitySources } =
+  await import('../../../../shared/worktree/visibility-sources')
+const { resolveConfiguredWorktreeBasePaths } =
+  await import('../../../../shared/worktree/configured-worktree-base-path')
+const { dedupeWorktreesByPath } = await import('../../worktree-path-comparison')
+const { readWorktreeMetaForHost } =
+  await import('../../../persistence/host-qualified-worktree-meta')
+const { getRepoOwnedWorktreeMeta } = await import('../../../worktree-metadata-ownership')
+const { getRepoExecutionHostId } = await import('../../../../shared/execution-host')
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/workspace/repo',
+  displayName: 'repo',
+  badgeColor: '#000',
+  addedAt: 0
+} as Repo
+
+const ownershipMeta = getProjectHostSetupWorktreeMeta([], repo)
+
+function gitWorktree(path: string): GitWorktreeInfo {
+  return {
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false
+  }
+}
+
+/** Fully settled metadata: discovery backfill has nothing to write, so it hands the same object back. */
+function settledMeta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    ...ownershipMeta,
+    instanceId: 'instance-settled',
+    orcaCreatedAt: 1,
+    lastActivityAt: 5,
+    ...overrides
+  } as WorktreeMeta
+}
+
+function createStore(meta: Record<string, WorktreeMeta>, repos: Repo[] = [repo]) {
+  const rows = { ...meta }
+  return {
+    getRepos: () => repos,
+    getSettings: () => ({ workspaceDir: '/workspace', nestWorkspaces: true }),
+    getProjectHostSetups: () => [],
+    getAllWorktreeLineage: () => ({}),
+    getAllWorktreeMeta: () => rows,
+    getWorktreeMeta: (id: string) => rows[id],
+    getWorktreeMetaForHost: (id: string, hostId: string) =>
+      rows[id]?.hostId === hostId ? rows[id] : undefined,
+    getAllWorktreeMetaForHost: () => rows,
+    setWorktreeMeta: (id: string, patch: Partial<WorktreeMeta>) => {
+      rows[id] = { ...rows[id], ...patch } as WorktreeMeta
+      return rows[id]
+    },
+    setWorktreeMetaForHost: (id: string, hostId: string, patch: Partial<WorktreeMeta>) => {
+      rows[id] = { ...rows[id], ...patch, hostId } as WorktreeMeta
+      return rows[id]
+    }
+  } as unknown as Store
+}
+
+/** The pre-change implementation, verbatim, as the equivalence oracle. */
+function buildDetectedGitWorktreesTwoPass(
+  store: Store,
+  target: Repo,
+  gitWorktrees: GitWorktreeInfo[],
+  allMetaOverride?: Record<string, WorktreeMeta>
+) {
+  const settings = store.getSettings()
+  const knownOrcaLayouts = ownership.buildKnownOrcaWorkspaceLayouts(settings, target)
+  const isLegacyRepoForVisibility = ownership.isLegacyRepoForExternalWorktreeVisibility(target)
+  const liveWorktrees = dedupeWorktreesByPath(gitWorktrees.filter((info) => !info.prunable))
+  const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
+    [target.path, ...liveWorktrees.map((worktree) => worktree.path)],
+    resolveCustomWorktreeVisibilitySources(target, settings.worktreeVisibilityDefaults),
+    resolveConfiguredWorktreeBasePaths(target)
+  )
+  const allMeta = allMetaOverride ?? store.getAllWorktreeMeta?.()
+  const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === target.id).length
+  const detectedRows = liveWorktrees.map((info) => {
+    const worktreeId = `${target.id}::${info.path}`
+    const legacyMeta = store.getWorktreeMeta?.(worktreeId)
+    const metaById = allMeta ?? (legacyMeta ? { [worktreeId]: legacyMeta } : {})
+    let meta =
+      readWorktreeMetaForHost(store, worktreeId, getRepoExecutionHostId(target)) ??
+      getRepoOwnedWorktreeMeta(target, worktreeId, metaById, repoOwnerCount)
+    const worktree = mergeWorktree(target.id, info, meta, target.displayName)
+    const detected = ownership.toDetectedWorktree({
+      repo: target,
+      worktree,
+      meta,
+      settings,
+      knownOrcaLayouts,
+      isLegacyRepoForVisibility,
+      worktreeVisibilitySourceMatcher
+    })
+    if (!detected.visible) {
+      return detected
+    }
+    meta = resolveWorktreeMetaWithDiscoveryBackfill(
+      store,
+      target,
+      worktreeId,
+      allMeta,
+      repoOwnerCount
+    )
+    return ownership.toDetectedWorktree({
+      repo: target,
+      worktree: mergeWorktree(target.id, info, meta, target.displayName),
+      meta,
+      settings,
+      knownOrcaLayouts,
+      isLegacyRepoForVisibility,
+      worktreeVisibilitySourceMatcher
+    })
+  })
+  return projectResolvedWorktreeLineage(detectedRows, store.getAllWorktreeLineage?.() ?? {})
+}
+
+describe('buildDetectedGitWorktrees classification passes', () => {
+  beforeEach(() => {
+    toDetectedWorktreeSpy.mockClear()
+    // Discovery backfill stamps lastActivityAt from the clock; freeze it so equivalence is deterministic.
+    vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000)
+  })
+
+  it('classifies each visible worktree once per catalog pass, not twice', () => {
+    const paths = ['/workspace/one', '/workspace/two', '/workspace/three']
+    const meta = Object.fromEntries(
+      paths.map((path) => [`${repo.id}::${path}`, settledMeta({ displayName: path })])
+    )
+    const store = createStore(meta)
+
+    const detected = buildDetectedGitWorktrees(store, repo, paths.map(gitWorktree), meta)
+
+    expect(detected).toHaveLength(3)
+    expect(detected.every((row) => row.visible)).toBe(true)
+    expect(toDetectedWorktreeSpy).toHaveBeenCalledTimes(paths.length)
+  })
+
+  it('reads the locator-keyed metadata row only when no host snapshot is available', () => {
+    const worktreeId = `${repo.id}::/workspace/one`
+    const meta = { [worktreeId]: settledMeta() }
+    const store = createStore(meta)
+    const legacyReads = vi.spyOn(store, 'getWorktreeMeta')
+
+    buildDetectedGitWorktrees(store, repo, [gitWorktree('/workspace/one')], meta)
+    expect(legacyReads).not.toHaveBeenCalled()
+
+    // Partial stores (compatibility shapes) expose no snapshot, so the locator-keyed lookup must still run.
+    const partialStore = createStore(meta) as Partial<Store>
+    delete partialStore.getAllWorktreeMeta
+    delete partialStore.getAllWorktreeMetaForHost
+    delete partialStore.getWorktreeMetaForHost
+    const partialLegacyReads = vi.spyOn(partialStore as Store, 'getWorktreeMeta')
+
+    const rows = buildDetectedGitWorktrees(
+      partialStore as Store,
+      repo,
+      [gitWorktree('/workspace/one')],
+      undefined
+    )
+    expect(partialLegacyReads).toHaveBeenCalledWith(worktreeId)
+    expect(rows[0]).toMatchObject({ id: worktreeId, lastActivityAt: 5 })
+  })
+
+  it.each([
+    ['settled metadata', () => settledMeta()],
+    ['metadata needing discovery backfill', () => ({ orcaCreatedAt: 1 }) as WorktreeMeta],
+    ['no metadata at all', () => undefined]
+  ])('emits a catalog deep-equal to the two-pass build for %s', (_label, makeMeta) => {
+    const worktreeId = `${repo.id}::/workspace/one`
+    const seed = makeMeta()
+    const build = (fn: typeof buildDetectedGitWorktrees) =>
+      fn(
+        createStore(seed ? { [worktreeId]: seed } : {}),
+        repo,
+        [gitWorktree('/workspace/one'), gitWorktree('/workspace/hidden-external')],
+        seed ? { [worktreeId]: seed } : {}
+      )
+
+    expect(build(buildDetectedGitWorktrees)).toEqual(build(buildDetectedGitWorktreesTwoPass))
+  })
+
+  it('emits a catalog deep-equal to the two-pass build for a folder-style listing with no host snapshot', () => {
+    const worktreeId = `${repo.id}::/workspace/one`
+    const seed = settledMeta()
+    const build = (fn: typeof buildDetectedGitWorktrees) =>
+      fn(createStore({ [worktreeId]: seed }), repo, [gitWorktree('/workspace/one')], undefined)
+
+    expect(build(buildDetectedGitWorktrees)).toEqual(build(buildDetectedGitWorktreesTwoPass))
+  })
+})

--- a/src/main/ipc/worktrees/listing/ssh-worktree-fallback.ts
+++ b/src/main/ipc/worktrees/listing/ssh-worktree-fallback.ts
@@ -155,9 +155,10 @@ export function buildDetectedGitWorktrees(
   const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
   const detected = liveWorktrees.map((gitWorktree) => {
     const worktreeId = `${repo.id}::${gitWorktree.path}`
-    const legacyMeta = store.getWorktreeMeta?.(worktreeId)
+    // Why: the locator-keyed row is only a stand-in for a missing host snapshot, so don't read it when we have one.
+    const legacyMeta = allMeta === undefined ? store.getWorktreeMeta?.(worktreeId) : undefined
     const metaById = allMeta ?? (legacyMeta ? { [worktreeId]: legacyMeta } : {})
-    let meta =
+    const meta =
       readWorktreeMetaForHost(store, worktreeId, getRepoExecutionHostId(repo)) ??
       getRepoOwnedWorktreeMeta(repo, worktreeId, metaById, repoOwnerCount)
     const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
@@ -174,17 +175,21 @@ export function buildDetectedGitWorktrees(
       return detected
     }
 
-    meta = resolveWorktreeMetaWithDiscoveryBackfill(
+    const backfilledMeta = resolveWorktreeMetaWithDiscoveryBackfill(
       store,
       repo,
       worktreeId,
       allMeta,
       repoOwnerCount
     )
+    // Why: backfill hands back the same object when it wrote nothing, and both builders are pure over it.
+    if (backfilledMeta === meta) {
+      return detected
+    }
     return toDetectedWorktree({
       repo,
-      worktree: mergeWorktree(repo.id, gitWorktree, meta, repo.displayName),
-      meta,
+      worktree: mergeWorktree(repo.id, gitWorktree, backfilledMeta, repo.displayName),
+      meta: backfilledMeta,
       settings,
       knownOrcaLayouts,
       isLegacyRepoForVisibility,

--- a/src/main/ipc/worktrees/listing/worktree-discovery-metadata.ts
+++ b/src/main/ipc/worktrees/listing/worktree-discovery-metadata.ts
@@ -40,8 +40,9 @@ export function resolveWorktreeMetaWithDiscoveryBackfill(
   repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
 ): WorktreeMeta {
   const executionHostId = getRepoExecutionHostId(repo)
-  const legacyMeta = store.getWorktreeMeta?.(worktreeId)
   const allMeta = allMetaOverride ?? store.getAllWorktreeMeta?.()
+  // Why: the locator-keyed row is only a stand-in for a missing snapshot, so don't read it when we have one.
+  const legacyMeta = allMeta === undefined ? store.getWorktreeMeta?.(worktreeId) : undefined
   const existing =
     readWorktreeMetaForHost(store, worktreeId, executionHostId) ??
     getRepoOwnedWorktreeMeta(

--- a/src/relay/git-porcelain-local-parity.test.ts
+++ b/src/relay/git-porcelain-local-parity.test.ts
@@ -160,7 +160,8 @@ describe('relay/desktop unmerged-entry porcelain parity', () => {
     const unmergedLines = [
       'u UU N... 100644 100644 100644 100644 aa bb cc plain.ts',
       'u UD N... 100644 100644 000000 100644 aa bb cc "present \\303\\251.ts"',
-      'u UD N... 100644 100644 000000 100644 aa bb cc "missing \\303\\251.ts"',
+      // mW=000000: real Git reports an absent working-tree path this way, and the file is not created below.
+      'u UD N... 100644 100644 000000 000000 aa bb cc "missing \\303\\251.ts"',
       'u DD N... 100644 100644 000000 000000 aa bb cc both-gone.ts'
     ]
     const git = vi.fn<GitExec>(async (args) => {

--- a/src/shared/git-status-conflict-entries.test.ts
+++ b/src/shared/git-status-conflict-entries.test.ts
@@ -1,0 +1,212 @@
+/**
+ * `u` records for asymmetric conflict kinds each cost an `fs.access`. Resolving them concurrently
+ * must not move a row, change how many probes run, or change which error wins.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { StatusPorcelainRecord } from './git-status-porcelain-parser'
+import type { GitStatusEntry } from './git-status-types'
+import type * as NodeFsPromisesModule from 'node:fs/promises'
+
+const { accessMock } = vi.hoisted(() => ({ accessMock: vi.fn() }))
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFsPromisesModule>()),
+  access: accessMock
+}))
+
+/**
+ * `parseUnmergedEntry` only rethrows when reading `error.code` itself throws, so this is how a
+ * record is made to reject rather than degrade to 'modified'.
+ */
+function rejectionEscapingTheErrnoGuard(failure: Error): unknown {
+  return new Proxy(
+    {},
+    {
+      get: () => {
+        throw failure
+      }
+    }
+  )
+}
+
+const { parseUnmergedEntry, resolveUnmergedStatusRecords } =
+  await import('./git-status-conflict-entries')
+
+const WORKTREE = '/repo'
+
+function unmergedLine(xy: string, filePath: string): string {
+  return `u ${xy} N... 100644 100644 100644 100644 aaa bbb ccc ${filePath}`
+}
+
+function entryRecord(path: string): StatusPorcelainRecord {
+  return { type: 'entry', entry: { path, status: 'modified', area: 'unstaged' } }
+}
+
+/** Mixes both conflict families: UU/AA return without I/O, AU/UA/DU/UD each probe the filesystem. */
+const MIXED_RECORDS: StatusPorcelainRecord[] = [
+  { type: 'unmerged', line: unmergedLine('UU', 'both-modified.ts') },
+  entryRecord('plain-one.ts'),
+  { type: 'unmerged', line: unmergedLine('AU', 'added-by-us.ts') },
+  { type: 'unmerged', line: unmergedLine('AA', 'both-added.ts') },
+  { type: 'unmerged', line: unmergedLine('UA', 'added-by-them.ts') },
+  entryRecord('plain-two.ts'),
+  { type: 'unmerged', line: unmergedLine('DU', 'deleted-by-us.ts') },
+  { type: 'unmerged', line: unmergedLine('UD', 'deleted-by-them.ts') },
+  { type: 'unmerged', line: unmergedLine('160000', 'submodule-ignored.ts') }
+]
+
+/** The pre-change consumption: one `await` per record, in Git's output order. */
+async function collectSerially(
+  records: readonly StatusPorcelainRecord[]
+): Promise<(GitStatusEntry | null)[]> {
+  const collected: (GitStatusEntry | null)[] = []
+  for (const record of records) {
+    collected.push(
+      record.type === 'entry' ? record.entry : await parseUnmergedEntry(WORKTREE, record.line)
+    )
+  }
+  return collected
+}
+
+async function collectConcurrently(
+  records: readonly StatusPorcelainRecord[]
+): Promise<(GitStatusEntry | null)[]> {
+  const resolved = await resolveUnmergedStatusRecords(WORKTREE, records, records.length)
+  return records.map((record, index) => {
+    if (record.type === 'entry') {
+      return record.entry
+    }
+    const settled = resolved[index]
+    if (settled?.ok === false) {
+      throw settled.error
+    }
+    return settled?.entry ?? null
+  })
+}
+
+describe('resolveUnmergedStatusRecords', () => {
+  beforeEach(() => {
+    accessMock.mockReset()
+  })
+
+  it('produces the same rows, in the same order, as the serial read', async () => {
+    accessMock.mockImplementation((target: string) =>
+      target.includes('deleted-by')
+        ? Promise.reject(Object.assign(new Error('x'), { code: 'ENOENT' }))
+        : Promise.resolve(undefined)
+    )
+
+    const serial = await collectSerially(MIXED_RECORDS)
+    const concurrent = await collectConcurrently(MIXED_RECORDS)
+
+    expect(concurrent).toEqual(serial)
+    expect(concurrent.map((entry) => entry?.path ?? null)).toEqual([
+      'both-modified.ts',
+      'plain-one.ts',
+      'added-by-us.ts',
+      'both-added.ts',
+      'added-by-them.ts',
+      'plain-two.ts',
+      'deleted-by-us.ts',
+      'deleted-by-them.ts',
+      null
+    ])
+    expect(concurrent.map((entry) => entry?.status ?? null)).toEqual([
+      'modified',
+      'modified',
+      'modified',
+      'modified',
+      'modified',
+      'modified',
+      'deleted',
+      'deleted',
+      null
+    ])
+  })
+
+  it('runs the same number of filesystem probes as the serial read', async () => {
+    accessMock.mockResolvedValue(undefined)
+    await collectSerially(MIXED_RECORDS)
+    const serialProbes = accessMock.mock.calls.length
+
+    accessMock.mockClear()
+    await collectConcurrently(MIXED_RECORDS)
+
+    // Only the four asymmetric kinds probe; UU/AA/submodule never touch the filesystem.
+    expect(serialProbes).toBe(4)
+    expect(accessMock.mock.calls.length).toBe(serialProbes)
+  })
+
+  it('never exceeds the concurrency bound', async () => {
+    let inFlight = 0
+    let peak = 0
+    accessMock.mockImplementation(async () => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      inFlight -= 1
+    })
+    const records = Array.from({ length: 50 }, (_, index) => ({
+      type: 'unmerged' as const,
+      line: unmergedLine('AU', `conflict-${index}.ts`)
+    }))
+
+    await resolveUnmergedStatusRecords(WORKTREE, records, records.length)
+
+    expect(peak).toBeGreaterThan(1)
+    expect(peak).toBeLessThanOrEqual(8)
+  })
+
+  it('resolves only the requested prefix, leaving later records for the caller', async () => {
+    accessMock.mockResolvedValue(undefined)
+
+    const resolved = await resolveUnmergedStatusRecords(WORKTREE, MIXED_RECORDS, 4)
+
+    expect(resolved[0]).toEqual({
+      ok: true,
+      entry: expect.objectContaining({ path: 'both-modified.ts' })
+    })
+    expect(resolved[1]).toBeUndefined()
+    expect(resolved[6]).toBeUndefined()
+    expect(accessMock.mock.calls.length).toBe(1)
+  })
+
+  it('surfaces the earliest failing record, exactly as the serial read did', async () => {
+    const firstFailure = new Error('first failure')
+    const secondFailure = new Error('second failure')
+    accessMock.mockImplementation((target: string) => {
+      if (target.endsWith('added-by-them.ts')) {
+        return Promise.reject(rejectionEscapingTheErrnoGuard(firstFailure))
+      }
+      if (target.endsWith('deleted-by-us.ts')) {
+        return Promise.reject(rejectionEscapingTheErrnoGuard(secondFailure))
+      }
+      return Promise.resolve(undefined)
+    })
+
+    await expect(collectSerially(MIXED_RECORDS)).rejects.toBe(firstFailure)
+    await expect(collectConcurrently(MIXED_RECORDS)).rejects.toBe(firstFailure)
+  })
+
+  it('does not surface a failure the serial read would never have reached', async () => {
+    const lateFailure = new Error('late failure')
+    accessMock.mockImplementation((target: string) =>
+      target.endsWith('deleted-by-them.ts')
+        ? Promise.reject(rejectionEscapingTheErrnoGuard(lateFailure))
+        : Promise.resolve(undefined)
+    )
+
+    // The caller stops before that record, so the captured rejection is simply never replayed.
+    const resolved = await resolveUnmergedStatusRecords(
+      WORKTREE,
+      MIXED_RECORDS,
+      MIXED_RECORDS.length
+    )
+    const consumedPrefix = MIXED_RECORDS.slice(0, 7).map((record, index) =>
+      record.type === 'entry' ? record.entry : resolved[index]
+    )
+
+    expect(consumedPrefix).not.toContainEqual({ ok: false, error: lateFailure })
+    expect(resolved[7]).toEqual({ ok: false, error: lateFailure })
+  })
+})

--- a/src/shared/git-status-conflict-entries.test.ts
+++ b/src/shared/git-status-conflict-entries.test.ts
@@ -13,7 +13,7 @@ vi.mock('node:fs/promises', async (importOriginal) => ({
   access: accessMock
 }))
 
-const { parseUnmergedEntry } = await import('./git-status-conflict-entries')
+import { parseUnmergedEntry } from './git-status-conflict-entries'
 
 const WORKTREE = '/repo'
 

--- a/src/shared/git-status-conflict-entries.test.ts
+++ b/src/shared/git-status-conflict-entries.test.ts
@@ -1,10 +1,9 @@
 /**
- * `u` records for asymmetric conflict kinds each cost an `fs.access`. Resolving them concurrently
- * must not move a row, change how many probes run, or change which error wins.
+ * Asymmetric `u` records used to cost one `fs.access` each — a 9p/network round trip per conflict on
+ * a WSL or remote worktree. Porcelain v2 already carries the answer in the worktree mode (`mW`), so
+ * the probe must not come back.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { StatusPorcelainRecord } from './git-status-porcelain-parser'
-import type { GitStatusEntry } from './git-status-types'
 import type * as NodeFsPromisesModule from 'node:fs/promises'
 
 const { accessMock } = vi.hoisted(() => ({ accessMock: vi.fn() }))
@@ -14,199 +13,75 @@ vi.mock('node:fs/promises', async (importOriginal) => ({
   access: accessMock
 }))
 
-/**
- * `parseUnmergedEntry` only rethrows when reading `error.code` itself throws, so this is how a
- * record is made to reject rather than degrade to 'modified'.
- */
-function rejectionEscapingTheErrnoGuard(failure: Error): unknown {
-  return new Proxy(
-    {},
-    {
-      get: () => {
-        throw failure
-      }
-    }
-  )
-}
-
-const { parseUnmergedEntry, resolveUnmergedStatusRecords } =
-  await import('./git-status-conflict-entries')
+const { parseUnmergedEntry } = await import('./git-status-conflict-entries')
 
 const WORKTREE = '/repo'
 
-function unmergedLine(xy: string, filePath: string): string {
-  return `u ${xy} N... 100644 100644 100644 100644 aaa bbb ccc ${filePath}`
+/** `u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>` — `mW` is the working-tree mode. */
+function unmergedLine(xy: string, modeWorktree: string, filePath: string): string {
+  return `u ${xy} N... 100644 100644 100644 ${modeWorktree} aaa bbb ccc ${filePath}`
 }
 
-function entryRecord(path: string): StatusPorcelainRecord {
-  return { type: 'entry', entry: { path, status: 'modified', area: 'unstaged' } }
-}
+const ASYMMETRIC_KINDS = ['AU', 'UA', 'DU', 'UD'] as const
 
-/** Mixes both conflict families: UU/AA return without I/O, AU/UA/DU/UD each probe the filesystem. */
-const MIXED_RECORDS: StatusPorcelainRecord[] = [
-  { type: 'unmerged', line: unmergedLine('UU', 'both-modified.ts') },
-  entryRecord('plain-one.ts'),
-  { type: 'unmerged', line: unmergedLine('AU', 'added-by-us.ts') },
-  { type: 'unmerged', line: unmergedLine('AA', 'both-added.ts') },
-  { type: 'unmerged', line: unmergedLine('UA', 'added-by-them.ts') },
-  entryRecord('plain-two.ts'),
-  { type: 'unmerged', line: unmergedLine('DU', 'deleted-by-us.ts') },
-  { type: 'unmerged', line: unmergedLine('UD', 'deleted-by-them.ts') },
-  { type: 'unmerged', line: unmergedLine('160000', 'submodule-ignored.ts') }
-]
-
-/** The pre-change consumption: one `await` per record, in Git's output order. */
-async function collectSerially(
-  records: readonly StatusPorcelainRecord[]
-): Promise<(GitStatusEntry | null)[]> {
-  const collected: (GitStatusEntry | null)[] = []
-  for (const record of records) {
-    collected.push(
-      record.type === 'entry' ? record.entry : await parseUnmergedEntry(WORKTREE, record.line)
-    )
-  }
-  return collected
-}
-
-async function collectConcurrently(
-  records: readonly StatusPorcelainRecord[]
-): Promise<(GitStatusEntry | null)[]> {
-  const resolved = await resolveUnmergedStatusRecords(WORKTREE, records, records.length)
-  return records.map((record, index) => {
-    if (record.type === 'entry') {
-      return record.entry
-    }
-    const settled = resolved[index]
-    if (settled?.ok === false) {
-      throw settled.error
-    }
-    return settled?.entry ?? null
-  })
-}
-
-describe('resolveUnmergedStatusRecords', () => {
+describe('parseUnmergedEntry', () => {
   beforeEach(() => {
     accessMock.mockReset()
+    accessMock.mockRejectedValue(new Error('fs.access must not be reached for well-formed records'))
   })
 
-  it('produces the same rows, in the same order, as the serial read', async () => {
-    accessMock.mockImplementation((target: string) =>
-      target.includes('deleted-by')
-        ? Promise.reject(Object.assign(new Error('x'), { code: 'ENOENT' }))
-        : Promise.resolve(undefined)
-    )
+  it('reads the working-tree mode instead of probing the filesystem', async () => {
+    for (const xy of ASYMMETRIC_KINDS) {
+      const absent = await parseUnmergedEntry(WORKTREE, unmergedLine(xy, '000000', 'gone.ts'))
+      const present = await parseUnmergedEntry(WORKTREE, unmergedLine(xy, '100644', 'here.ts'))
 
-    const serial = await collectSerially(MIXED_RECORDS)
-    const concurrent = await collectConcurrently(MIXED_RECORDS)
+      expect(absent?.status, xy).toBe('deleted')
+      expect(present?.status, xy).toBe('modified')
+    }
 
-    expect(concurrent).toEqual(serial)
-    expect(concurrent.map((entry) => entry?.path ?? null)).toEqual([
-      'both-modified.ts',
-      'plain-one.ts',
-      'added-by-us.ts',
-      'both-added.ts',
-      'added-by-them.ts',
-      'plain-two.ts',
-      'deleted-by-us.ts',
-      'deleted-by-them.ts',
-      null
-    ])
-    expect(concurrent.map((entry) => entry?.status ?? null)).toEqual([
-      'modified',
-      'modified',
-      'modified',
-      'modified',
-      'modified',
-      'modified',
-      'deleted',
-      'deleted',
-      null
-    ])
+    // The regression this replaces: one probe per asymmetric row, serialised across the status poll.
+    expect(accessMock).not.toHaveBeenCalled()
   })
 
-  it('runs the same number of filesystem probes as the serial read', async () => {
-    accessMock.mockResolvedValue(undefined)
-    await collectSerially(MIXED_RECORDS)
-    const serialProbes = accessMock.mock.calls.length
+  it('treats a symlink left in place of the conflicted file as present', async () => {
+    const entry = await parseUnmergedEntry(WORKTREE, unmergedLine('UD', '120000', 'link.ts'))
 
-    accessMock.mockClear()
-    await collectConcurrently(MIXED_RECORDS)
-
-    // Only the four asymmetric kinds probe; UU/AA/submodule never touch the filesystem.
-    expect(serialProbes).toBe(4)
-    expect(accessMock.mock.calls.length).toBe(serialProbes)
+    expect(entry?.status).toBe('modified')
+    expect(accessMock).not.toHaveBeenCalled()
   })
 
-  it('never exceeds the concurrency bound', async () => {
-    let inFlight = 0
-    let peak = 0
-    accessMock.mockImplementation(async () => {
-      inFlight += 1
-      peak = Math.max(peak, inFlight)
-      await new Promise((resolve) => setTimeout(resolve, 0))
-      inFlight -= 1
-    })
-    const records = Array.from({ length: 50 }, (_, index) => ({
-      type: 'unmerged' as const,
-      line: unmergedLine('AU', `conflict-${index}.ts`)
-    }))
+  it('resolves the symmetric kinds from XY alone, whatever the working-tree mode says', async () => {
+    const bothModified = await parseUnmergedEntry(WORKTREE, unmergedLine('UU', '000000', 'a.ts'))
+    const bothAdded = await parseUnmergedEntry(WORKTREE, unmergedLine('AA', '000000', 'b.ts'))
+    const bothDeleted = await parseUnmergedEntry(WORKTREE, unmergedLine('DD', '100644', 'c.ts'))
 
-    await resolveUnmergedStatusRecords(WORKTREE, records, records.length)
-
-    expect(peak).toBeGreaterThan(1)
-    expect(peak).toBeLessThanOrEqual(8)
+    expect(bothModified?.status).toBe('modified')
+    expect(bothAdded?.status).toBe('modified')
+    expect(bothDeleted?.status).toBe('deleted')
+    expect(accessMock).not.toHaveBeenCalled()
   })
 
-  it('resolves only the requested prefix, leaving later records for the caller', async () => {
-    accessMock.mockResolvedValue(undefined)
+  it('drops submodule conflicts without probing', async () => {
+    const line = 'u UU S... 160000 160000 160000 160000 aa bb cc vendor/sub'
 
-    const resolved = await resolveUnmergedStatusRecords(WORKTREE, MIXED_RECORDS, 4)
-
-    expect(resolved[0]).toEqual({
-      ok: true,
-      entry: expect.objectContaining({ path: 'both-modified.ts' })
-    })
-    expect(resolved[1]).toBeUndefined()
-    expect(resolved[6]).toBeUndefined()
-    expect(accessMock.mock.calls.length).toBe(1)
+    expect(await parseUnmergedEntry(WORKTREE, line)).toBeNull()
+    expect(accessMock).not.toHaveBeenCalled()
   })
 
-  it('surfaces the earliest failing record, exactly as the serial read did', async () => {
-    const firstFailure = new Error('first failure')
-    const secondFailure = new Error('second failure')
-    accessMock.mockImplementation((target: string) => {
-      if (target.endsWith('added-by-them.ts')) {
-        return Promise.reject(rejectionEscapingTheErrnoGuard(firstFailure))
-      }
-      if (target.endsWith('deleted-by-us.ts')) {
-        return Promise.reject(rejectionEscapingTheErrnoGuard(secondFailure))
-      }
-      return Promise.resolve(undefined)
-    })
+  it('keeps the working-tree probe as a fallback for a mode no real Git emits', async () => {
+    accessMock.mockRejectedValueOnce(Object.assign(new Error('nope'), { code: 'ENOENT' }))
+    const missing = await parseUnmergedEntry(WORKTREE, unmergedLine('UD', 'zzzzzz', 'weird-a.ts'))
 
-    await expect(collectSerially(MIXED_RECORDS)).rejects.toBe(firstFailure)
-    await expect(collectConcurrently(MIXED_RECORDS)).rejects.toBe(firstFailure)
-  })
+    accessMock.mockResolvedValueOnce(undefined)
+    const found = await parseUnmergedEntry(WORKTREE, unmergedLine('UD', '12345', 'weird-b.ts'))
 
-  it('does not surface a failure the serial read would never have reached', async () => {
-    const lateFailure = new Error('late failure')
-    accessMock.mockImplementation((target: string) =>
-      target.endsWith('deleted-by-them.ts')
-        ? Promise.reject(rejectionEscapingTheErrnoGuard(lateFailure))
-        : Promise.resolve(undefined)
-    )
+    accessMock.mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'EACCES' }))
+    const unreadable = await parseUnmergedEntry(WORKTREE, unmergedLine('UD', '', 'weird-c.ts'))
 
-    // The caller stops before that record, so the captured rejection is simply never replayed.
-    const resolved = await resolveUnmergedStatusRecords(
-      WORKTREE,
-      MIXED_RECORDS,
-      MIXED_RECORDS.length
-    )
-    const consumedPrefix = MIXED_RECORDS.slice(0, 7).map((record, index) =>
-      record.type === 'entry' ? record.entry : resolved[index]
-    )
-
-    expect(consumedPrefix).not.toContainEqual({ ok: false, error: lateFailure })
-    expect(resolved[7]).toEqual({ ok: false, error: lateFailure })
+    expect(missing?.status).toBe('deleted')
+    expect(found?.status).toBe('modified')
+    // Why: an ambiguous fs failure keeps the row visible rather than falsely reading as 'deleted'.
+    expect(unreadable?.status).toBe('modified')
+    expect(accessMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/shared/git-status-conflict-entries.ts
+++ b/src/shared/git-status-conflict-entries.ts
@@ -1,7 +1,51 @@
 import { access } from 'node:fs/promises'
 import * as path from 'node:path'
 import type { GitConflictKind, GitFileStatus, GitStatusEntry } from './git-status-types'
+import type { StatusPorcelainRecord } from './git-status-porcelain-parser'
 import { decodeGitCQuotedPath } from './git-cquoted-path'
+
+const UNMERGED_ENTRY_RESOLVE_CONCURRENCY = 8
+
+/** A settled `parseUnmergedEntry` result, replayed at the record index it belongs to. */
+export type ResolvedUnmergedEntry =
+  | { ok: true; entry: GitStatusEntry | null }
+  | { ok: false; error: unknown }
+
+/**
+ * Resolve the deferred `u` records in `records[0, end)` with bounded concurrency, keyed by record
+ * index. Asymmetric conflict kinds each cost an `fs.access`, which is a 9p/network round trip on a
+ * WSL or remote worktree, and a big rebase makes hundreds of them — serialising those stalls every
+ * status poll for the life of the conflict.
+ *
+ * Ordering is untouched: results stay at their own index, so the caller still consumes Git's output
+ * order, and a rejection is replayed only if the caller actually reaches that record.
+ */
+export async function resolveUnmergedStatusRecords(
+  worktreePath: string,
+  records: readonly StatusPorcelainRecord[],
+  end: number
+): Promise<(ResolvedUnmergedEntry | undefined)[]> {
+  const resolved: (ResolvedUnmergedEntry | undefined)[] = []
+  let nextIndex = 0
+  const resolveNext = async (): Promise<void> => {
+    while (nextIndex < end) {
+      const index = nextIndex
+      nextIndex += 1
+      const record = records[index]
+      if (record?.type !== 'unmerged') {
+        continue
+      }
+      try {
+        resolved[index] = { ok: true, entry: await parseUnmergedEntry(worktreePath, record.line) }
+      } catch (error) {
+        resolved[index] = { ok: false, error }
+      }
+    }
+  }
+  const workerCount = Math.min(UNMERGED_ENTRY_RESOLVE_CONCURRENCY, end)
+  await Promise.all(Array.from({ length: workerCount }, () => resolveNext()))
+  return resolved
+}
 
 export async function parseUnmergedEntry(
   worktreePath: string,

--- a/src/shared/git-status-conflict-entries.ts
+++ b/src/shared/git-status-conflict-entries.ts
@@ -1,51 +1,9 @@
 import { access } from 'node:fs/promises'
 import * as path from 'node:path'
 import type { GitConflictKind, GitFileStatus, GitStatusEntry } from './git-status-types'
-import type { StatusPorcelainRecord } from './git-status-porcelain-parser'
 import { decodeGitCQuotedPath } from './git-cquoted-path'
 
-const UNMERGED_ENTRY_RESOLVE_CONCURRENCY = 8
-
-/** A settled `parseUnmergedEntry` result, replayed at the record index it belongs to. */
-export type ResolvedUnmergedEntry =
-  | { ok: true; entry: GitStatusEntry | null }
-  | { ok: false; error: unknown }
-
-/**
- * Resolve the deferred `u` records in `records[0, end)` with bounded concurrency, keyed by record
- * index. Asymmetric conflict kinds each cost an `fs.access`, which is a 9p/network round trip on a
- * WSL or remote worktree, and a big rebase makes hundreds of them — serialising those stalls every
- * status poll for the life of the conflict.
- *
- * Ordering is untouched: results stay at their own index, so the caller still consumes Git's output
- * order, and a rejection is replayed only if the caller actually reaches that record.
- */
-export async function resolveUnmergedStatusRecords(
-  worktreePath: string,
-  records: readonly StatusPorcelainRecord[],
-  end: number
-): Promise<(ResolvedUnmergedEntry | undefined)[]> {
-  const resolved: (ResolvedUnmergedEntry | undefined)[] = []
-  let nextIndex = 0
-  const resolveNext = async (): Promise<void> => {
-    while (nextIndex < end) {
-      const index = nextIndex
-      nextIndex += 1
-      const record = records[index]
-      if (record?.type !== 'unmerged') {
-        continue
-      }
-      try {
-        resolved[index] = { ok: true, entry: await parseUnmergedEntry(worktreePath, record.line) }
-      } catch (error) {
-        resolved[index] = { ok: false, error }
-      }
-    }
-  }
-  const workerCount = Math.min(UNMERGED_ENTRY_RESOLVE_CONCURRENCY, end)
-  await Promise.all(Array.from({ length: workerCount }, () => resolveNext()))
-  return resolved
-}
+const OCTAL_FILE_MODE = /^[0-7]{6}$/
 
 export async function parseUnmergedEntry(
   worktreePath: string,
@@ -57,6 +15,7 @@ export async function parseUnmergedEntry(
   const modeStage1 = parts[3]
   const modeStage2 = parts[4]
   const modeStage3 = parts[5]
+  const modeWorktree = parts[6]
   const filePath = decodeGitCQuotedPath(parts.slice(10).join(' '))
   if (!filePath) {
     return null
@@ -76,7 +35,12 @@ export async function parseUnmergedEntry(
   return {
     path: filePath,
     area: 'unstaged',
-    status: await getConflictCompatibilityStatus(worktreePath, filePath, conflictKind),
+    status: await getConflictCompatibilityStatus(
+      worktreePath,
+      filePath,
+      conflictKind,
+      modeWorktree
+    ),
     conflictKind,
     conflictStatus: 'unresolved'
   }
@@ -104,11 +68,12 @@ function parseConflictKind(xy: string): GitConflictKind | null {
 }
 
 // Why: `status` here is a rendering-compat choice for icon/color plumbing, not semantic; the conflict badge carries the real meaning.
-// Why: for deleted_by_*/added_by_* variants Git's result depends on merge strategy, so check the filesystem.
+// Why: for deleted_by_*/added_by_* variants Git's result depends on merge strategy, so ask whether the path is in the working tree.
 async function getConflictCompatibilityStatus(
   worktreePath: string,
   filePath: string,
-  conflictKind: GitConflictKind
+  conflictKind: GitConflictKind,
+  modeWorktree: string
 ): Promise<GitFileStatus> {
   if (conflictKind === 'both_modified' || conflictKind === 'both_added') {
     return 'modified'
@@ -118,8 +83,14 @@ async function getConflictCompatibilityStatus(
     return 'deleted'
   }
 
-  // Why async: on a WSL worktree this path is a `\\wsl.localhost\...` share, and a sync probe
-  // per asymmetric conflict blocks the Electron main thread for a 9p round trip each.
+  // Why: `mW` is the worktree mode Git already stat'ed for this row — `000000` means absent. Reading
+  // it costs nothing and stays consistent with the rest of the snapshot, whereas a re-probe here is a
+  // 9p/network round trip per asymmetric conflict on a WSL or remote worktree.
+  if (OCTAL_FILE_MODE.test(modeWorktree)) {
+    return modeWorktree === '000000' ? 'deleted' : 'modified'
+  }
+
+  // Why: only reachable on output no real Git emits (truncated/malformed `u` record).
   try {
     await access(path.join(worktreePath, filePath))
     return 'modified'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​473 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​460 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## ELI5

Every time Orca refreshes the list of workspaces in your sidebar, it was doing the same piece of thinking twice for each workspace: it worked out where a workspace lives, whether Orca created it, and whether it should be shown at all — and then immediately threw that answer away and worked it all out a second time from scratch. This change keeps the first answer when nothing changed in between.

Two smaller versions of the same idea are also fixed. Orca was building a lookup table of every remote workspace on a server on every refresh, even though that table is only ever read when the server is unreachable — which is the rare case, not the normal one. It is now built only if it is actually needed.

And when you are in the middle of a big merge or rebase with lots of conflicting files, Orca was asking the filesystem one question per conflicted file — "does this file still exist?" — just to decide how to draw its icon. On a WSL or remote checkout each question is a round trip over a network-ish filesystem, so hundreds of them added up to a stall on *every* refresh for as long as the conflict lasted. It turns out Git already answers that exact question on the same line Orca was reading to find the file's name, so Orca now just reads the answer it was already given and asks the filesystem nothing at all.

Nothing about what you see changes — same rows, same order, same icons.

## Why it matters

Three measured costs, all on paths that run on a timer, not on user action.

1. **Double classification per catalog pass.** `buildDetectedGitWorktrees` (`src/main/ipc/worktrees/listing/ssh-worktree-fallback.ts`) ran `mergeWorktree` + `toDetectedWorktree` once, checked `detected.visible`, then ran both again for every visible row. `toDetectedWorktree` is not cheap — layout matching, `relativePathInsideRoot` per configured base, `isAgentScratchWorktreePath`, `areRuntimePathsEqual`, `shouldShowWorktree`.

2. **SSH meta index built and discarded.** `detected-provider-listing.ts` built `createSshWorktreeMetaIndex(Object.entries(allMeta ?? {}))` eagerly for every SSH repo listing — `parseWorktreeId` over every worktree id on the host — and then discarded it whenever the provider was connected, which is the normal case. It is only ever read through `metaIndex.get(repo.id)` on the two disconnected fallbacks.

3. **`access()` per unmerged conflict row that never needed to happen.** For the asymmetric conflict kinds (`AU`/`UA`/`DU`/`UD`), `parseUnmergedEntry` did one `fs.access` per conflicted file to decide `'modified'` vs `'deleted'` — each one a 9p or network round trip off-host, and on `main` they were strictly serialised. But every porcelain-v2 `u` record is `u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>`, and `<mW>` — `parts[6]`, right next to the mode fields the parser already reads — *is* the working-tree mode Git stat'ed for that row while producing the status. `000000` means the path is absent. The probe was re-asking, over a slow link, a question Git had already answered on the same line.

   So this PR does not parallelise the probe; it deletes it. `UU`/`AA`/`DD` still resolve from `XY` with no I/O, as before.

## Measurement

All numbers are on the real functions, run under `nice -n 10` on a heavily loaded machine, so `cpuUs` (a `process.cpuUsage()` delta) and the deterministic probe count are the trustworthy columns; wall clock is included only because the simulated probe latency dominates it. Benchmark harnesses were temporary files, removed before commit.

### Finding 1 — catalog pass, before (two passes) vs after (one pass)

```
n=50   twoPasses=0.389ms  onePass=0.152ms  wasted=0.237ms
n=413  twoPasses=1.631ms  onePass=1.075ms  wasted=0.556ms
```

Honest note on scale: the brief this came from measured `wasted=9.69ms` at n=413. My fixture uses a minimal `settings` object (one `workspaceDir`, no `workspaceDirHistory`, no configured per-repo bases), which makes `buildKnownOrcaWorkspaceLayouts` produce a single layout and `classifyWorktreeOwnership` exit early. With a realistic history and several configured bases the per-row classification cost — and therefore the saving — is several times larger. The *ratio* is the stable part: the redundant pass was ~35–60% of the whole catalog pass, and it is now gone.

### Finding 2 — SSH worktree-meta index construction

```
1,334 entries: 0.094–0.099ms   (2,000 entries: 0.141–0.149ms)
```

That is now `0` on the connected path, which is every successful SSH repo listing, and unchanged on the disconnected fallbacks.

While measuring I checked the sibling `createSshWorktreeMetaIndexForRepo`, whose comment claims it is "cheaper per call than the unfiltered index". At every distribution I measured it is in fact **~1.6x slower to build**, because `Object.entries` over the whole snapshot still dominates and the `getRepoIdFromWorktreeId` filter adds a whole extra pass, while `parseWorktreeId` itself is only an `indexOf` plus two `slice`s:

```
repos=4    n=1334   all-hosts=0.099ms   repo-scoped=0.173ms
repos=20   n=1334   all-hosts=0.099ms   repo-scoped=0.158ms
repos=100  n=1334   all-hosts=0.094ms   repo-scoped=0.152ms
```

So this PR keeps the unfiltered builder and only makes it lazy. That is strictly better: same win on the connected path, no regression on the fallback path, and — unlike the repo-scoped variant — it preserves the malformed-persisted-key diagnostic for keys belonging to other repos. I did not "fix" the misleading comment on `createSshWorktreeMetaIndexForRepo`; its only caller (`register-host-catalog-handlers.ts`) is a single-repo path where it does not matter, and touching it is out of scope here.

### Finding 3 — 200 asymmetric conflicts, all three implementations

Same input, same harness, probe latency simulated at 5ms. `probes` is a deterministic call counter on `fs.access`; `cpuUs` is a `process.cpuUsage()` delta.

| implementation | `fs.access` probes | CPU (µs) | wall (ms) |
| :--- | ---: | ---: | ---: |
| `main` — serial `access()` | 200 | 19,636 | 1,128 |
| earlier revision of this PR — 8-way concurrent `access()` | 200 | 12,119 | 143 |
| **this PR — read `mW`** | **0** | **420** | **0** |

The earlier 8-way revision is superseded, not regressed: **0 probes beats 200 probes at any concurrency**, and CPU drops a further 29x below it (12,119µs → 420µs) because the win is no longer "the round trips overlap" but "there are no round trips, no promise-per-row scheduling, and no per-record result array". The full serial→now improvement is 47x on CPU.

Earlier revision, for the record (the numbers the 8-way approach was justified on):

```
@1ms probe:  serial=382ms   concurrent=43ms    (8.9x)
@3ms probe:  serial=841ms   concurrent=88ms    (9.6x)
@5ms probe:  serial=1236ms  concurrent=155ms   (8.0x)
```

The `mW` read makes all of those `0ms`, and does it for the relay host too (below) without touching the relay.

### Failing-test output (change reverted, tests unchanged)

**Finding 1** — `src/main/ipc/worktrees/listing/ssh-worktree-fallback.ts` and `worktree-discovery-metadata.ts` reverted to `origin/main`:

```
 ❯ src/main/ipc/worktrees/listing/detected-worktree-classification.test.ts (6 tests | 2 failed)
   × classifies each visible worktree once per catalog pass, not twice
   × reads the locator-keyed metadata row only when no host snapshot is available

AssertionError: expected "vi.fn()" to be called 3 times, but got 6 times
 ❯ detected-worktree-classification.test.ts:173:35
    expect(toDetectedWorktreeSpy).toHaveBeenCalledTimes(paths.length)

AssertionError: expected "getWorktreeMeta" to not be called at all, but actually been called 2 times
 ❯ detected-worktree-classification.test.ts:183:29
    expect(legacyReads).not.toHaveBeenCalled()

 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
```

With the change: `Tests 6 passed (6)`.

**Finding 2** — `src/main/ipc/worktrees/listing/detected-provider-listing.ts` reverted to `origin/main`:

```
 ❯ src/main/ipc/worktrees/listing/detected-provider-listing-meta-index.test.ts (3 tests | 1 failed)
   × does not build the index when the provider answers

AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received:
  1st vi.fn() call:
    [ "all-hosts",
      [ [ "repo-1::/home/user/feature", { "instanceId": "instance-1" } ],
        [ "repo-2::/home/user/other",   { "instanceId": "instance-2" } ] ] ]

 ❯ detected-provider-listing-meta-index.test.ts:97:31
    expect(indexBuildSpy).not.toHaveBeenCalled()

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

With the change: `Tests 3 passed (3)`.

**Finding 3** — `src/shared/git-status-conflict-entries.ts` reverted to `origin/main` (i.e. the `access()` probe restored), tests unchanged. Five guards fail — two unit, three through `getStatus`:

```
 ❯ src/shared/git-status-conflict-entries.test.ts (5 tests | 2 failed)
   × reads the working-tree mode instead of probing the filesystem
   × treats a symlink left in place of the conflicted file as present
 ❯ src/main/git/status.test.ts (29 tests | 3 failed)
   × maps deleted conflicts to deleted from the porcelain working-tree mode
   × never re-probes the working tree for a conflict row, whatever the filesystem would say
   × resolves a WSL conflict row without crossing the 9p share

AssertionError: AU: expected 'modified' to be 'deleted' // Object.is equality
 ❯ src/shared/git-status-conflict-entries.test.ts:38:34
    expect(absent?.status, xy).toBe('deleted')

AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Received:
  1st vi.fn() call:
    Array [ "/repo/link.ts" ]
 ❯ src/shared/git-status-conflict-entries.test.ts:50:28
    expect(accessMock).not.toHaveBeenCalled()

AssertionError: expected [ '/repo/src/deleted.ts' ] to deeply equal []
 ❯ src/main/git/status.test.ts:131:34
    expect(conflictFileProbes()).toEqual([])

AssertionError: expected [ '/repo/src/new.ts' ] to deeply equal []
 ❯ src/main/git/status.test.ts:147:34
    expect(conflictFileProbes()).toEqual([])

AssertionError: expected [ …(5) ] to not include '//wsl.localhost/Ubuntu/home/me/repo/f…'
 ❯ src/main/git/status.test.ts:165:26
    expect(probed).not.toContain('//wsl.localhost/Ubuntu/home/me/repo/feature/src/new.ts')

 Test Files  2 failed | 1 passed (3)
      Tests  5 failed | 34 passed (39)
```

With the change: `Tests 39 passed (39)`.

## Correctness

**Finding 1 — why the skipped second pass is provably identical.** I read both builders before relying on this.

- `mergeWorktree` (`src/main/ipc/worktree-metadata-merge.ts`) is a pure projection of `(repoId, git, meta, defaultDisplayName)`. It closes over nothing; its only non-local calls are `basename`, `normalizeWorkspaceCreatorProvenance`, `createWorktreeIdentity` and `getLinkedWorkItemMetadata`, all pure over their arguments.
- `toDetectedWorktree` (`src/shared/worktree/ownership.ts`) is pure over its args object. It calls `classifyWorktreeOwnership`, `areRuntimePathsEqual`, `shouldShowWorktree` and the caller-supplied `worktreeVisibilitySourceMatcher` — none of which read or write module state. The matcher and `knownOrcaLayouts` are built once outside the loop and are the *same instances* in both passes.
- `resolveWorktreeMetaWithDiscoveryBackfill` returns the **same object** it read (`worktree-discovery-metadata.ts`, the `return existing` branch) whenever no backfill was written. So the guard is `backfilledMeta === meta`, on object identity, not a structural comparison.

Therefore, when the guard fires, the second pass would have been called with byte-identical inputs to the first and could only have produced a structurally equal object with a different identity — and the value is serialised across IPC anyway. When the guard does *not* fire (a real backfill happened, or the first-pass meta was `undefined`), the second pass runs exactly as before. It is impossible for this to skip a pass whose inputs changed.

The backfill call itself is **not** skipped — it still runs for every visible row, so `instanceId` stamping, `lastActivityAt` seeding and project/host-setup ownership repair all happen on exactly the same schedule as before. Only the redundant re-derivation of the already-computed row is dropped.

**Finding 1 (second half) — the locator-keyed read.** `store.getWorktreeMeta?.(worktreeId)` was called per worktree and its result discarded whenever a host snapshot existed: it only ever feeds `allMeta ?? (legacyMeta ? { [worktreeId]: legacyMeta } : {})`. It is now read only when `allMeta === undefined`, which is exactly when it can affect the result. The same one-line change is applied inside `resolveWorktreeMetaWithDiscoveryBackfill`, where `allMeta` is resolved first so the guard tests the post-fallback value, not the override.

*Which callers still hit the legacy read:* both sites resolve `allMeta` as `override ?? store.getAllWorktreeMeta?.()`, so on a real `Store` (which always has `getAllWorktreeMeta`) `allMeta` is never `undefined` and the locator-keyed read was already dead weight. It remains reachable — and is tested — for the partial `Pick<Store, ...>` compatibility shapes that expose no snapshot accessor, which is the case `host-qualified-worktree-meta.ts` documents.

**Finding 2 — why deferring the index cannot change output.** The index has exactly two readers, `:89` (no provider) and `:161` (provider listing threw), and `listDisconnectedSshWorktrees` only ever touches it as `metaIndex.get(repo.id)`. Nothing else in the function observes it. Building it at first use instead of at function entry cannot change any value, and `cachedSshWorktreeMetaIndex ??=` guarantees at most one build per invocation even though only one of the two sites can run in a given call. `createSshWorktreeMetaIndex` is unchanged, so malformed-persisted-key `warnOnce` diagnostics still fire for exactly the same keys, in the disconnected case that used to be the only case where they mattered. Note this means the diagnostic no longer fires on a *connected* listing — but that is the same "no index, no scan" property that is the point of the fix, the warning is `warnOnce`-deduped globally, and the disconnected path (which is when persisted metadata is actually consulted) still emits it.

**Finding 3 — why `mW` is the same answer, and a better-sourced one.**

- *The field is real and stable.* Porcelain v2's unmerged record is documented as `u <XY> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>`. The parser already splits on spaces and already reads `parts[3..5]` for the submodule check, so `parts[6]` costs one array index. The format has been frozen since porcelain v2 shipped in **Git 2.11**, comfortably under the repo's 2.25 baseline — no capability probe, no fallback command, nothing version-dependent.
- *Verified against a real binary, not just the docs.* On Git 2.55 I built a merge producing `AA`/`UD`/`DU`/`UU` rows and read the status before and after `rm`-ing the conflicted files. Present ⇒ `mW=100644`; absent ⇒ `mW=000000`, on every row, with `XY` and the three stage modes unchanged. `DD` rows already report `mW=000000`, consistent with the unconditional `'deleted'` this code has always returned for them.
- *Order and error precedence.* Not "preserved" — **not expressible**. The consumption loop in `status-read.ts` is byte-identical to `origin/main` again (this PR no longer touches that file), and `parseUnmergedEntry` is now straight-line over one line of text on the real-Git path. There is no concurrency, no per-index result array, no captured-and-replayed rejection, and no `= 8` cap to tune. The whole class of "does the concurrent path agree with the serial path" question is gone rather than tested.
- *The `access()` fallback.* Kept, but only behind `!/^[0-7]{6}$/.test(mW)` — i.e. a truncated or malformed `u` record that no Git version emits. This is what lets `parseUnmergedEntry` keep its `(worktreePath, line)` signature, so neither `status-read.ts` nor the relay needed an edit. It is unit-tested (ENOENT ⇒ `deleted`, success ⇒ `modified`, EACCES ⇒ `modified`) so it cannot rot.
- *Fixture corrections.* Two existing fixtures encoded `mW=100644` for a file the test itself declares absent — output real Git never produces (`src/relay/git-porcelain-local-parity.test.ts:163`, `src/main/git/status.test.ts`). Both now carry `000000`. Under the old probe those fixtures passed only because `access()` independently found nothing on disk; they were internally inconsistent either way.

**Edge cases considered.**

- *SSH / relay.* The relay's own status loop (`src/relay/git-handler-status-ops.ts:187`) calls the same `parseUnmergedEntry`, so the host gets the identical zero-probe win with **no relay edit at all**. This is a pure host-local read of stdout Git already produced: no RPC param, stream opcode, or published-content change, so mixed client/host versions are unaffected in both directions — an old client talking to a new host sees the same `GitStatusEntry` shape and the same values. Findings 1 and 2 are on the SSH-capable listing path and are exercised by the existing `ssh-worktree-catalog-authority.test.ts` (still green).
- *WSL / Windows.* This is where the probe hurt most and where it is now absent: the asymmetric conflict rows no longer cross the `\\wsl.localhost\...` 9p share at all, and nothing has to map the worktree path from the distro namespace into the host namespace for them. `resolveWorktreeHostPath` still runs in `status-read.ts` for the conflict-marker reads and shared-symlink probes, which are unchanged and still covered. A test asserts a `DU` row on a WSL worktree resolves with zero working-tree probes while the marker probes still use the distro spelling. No new `child_process`, no shell, no platform branches.
- *Git-binary compatibility.* No new subcommand or option; `--porcelain=v2` and its `u` record are what this code already requested. Nothing to gate behind `GitCapabilityCache`.
- *Folder workspaces.* Folder repos never reach `buildDetectedGitWorktrees` (they return early via `buildFolderDetectedWorktrees`), and they pass `allMeta === undefined`, which is the branch that still performs the locator-keyed read. The equivalence test covers a no-snapshot listing explicitly. Finding 3 is per-record parsing and is workspace-shape agnostic.
- *Empty / missing state.* No worktrees, no metadata, no `getAllWorktreeMeta`, no unmerged records, and a truncated status hitting the entry cap are all covered by tests or by construction — the cap logic in `status-read.ts` is untouched by this PR.

## Negative user-facing trade-offs

The trade-off the earlier revision of this PR carried — a new bounded-concurrency primitive, a hard-coded `= 8` cap, and an output-order / error-precedence invariant that had to be argued and tested — **is gone**, not mitigated. That code is deleted and `status-read.ts` is byte-identical to `main` again.

What remains is one small, deliberate behaviour change, in two pathological states where Git's view of the working tree and a later `access()` call genuinely disagree:

| working tree | Git reports | old `access()` answer | new answer |
| :--- | :--- | :--- | :--- |
| a **directory** sitting where the conflicted file was | `mW=000000` | `access` succeeds ⇒ `modified` | `deleted` |
| a **dangling symlink** at the conflicted path | `mW=120000` | `access` follows it, ENOENT ⇒ `deleted` | `modified` |

Both verified on Git 2.55. In both rows the new answer is the one Git itself is using for that record, so the icon now agrees with the rest of the status snapshot instead of with a re-probe taken microseconds later. `status` on a conflict row is documented in-code as a rendering-compat hint for icon/colour plumbing — the `conflictKind` badge carries the meaning, and it is unchanged in both cases.

Two ambiguities are also removed rather than added: an `EACCES`/`EIO` hiccup on a slow share used to silently render a conflicted row as `modified`, and a file created or deleted in the window between Git's stat and Orca's probe used to produce a row that disagreed with the snapshot it shipped in. Neither is reachable now.

## Test plan

- `nice -n 10 npx vitest run --config config/vitest.config.ts src/main/ipc/worktrees src/main/git/source-control src/shared/git-status-conflict-entries.test.ts` → **38 files, 347 tests passed**
- `nice -n 10 npx vitest run --config config/vitest.config.ts src/main/providers/ssh-worktree-catalog-authority.test.ts src/relay/git-porcelain-local-parity.test.ts src/relay/git-handler-status-ops.test.ts src/main/git/status.test.ts src/main/git/status-read-coalescing.test.ts src/main/git/status-porcelain-parser.test.ts src/main/ipc/worktrees-listing-fallback-rows.test.ts src/main/ipc/worktrees-authoritative-local-metadata-pruning.test.ts` → **103 tests passed**
- `nice -n 10 npx tsc --noEmit -p config/tsconfig.node.json --composite false` → clean
- `npx oxlint <changed files>` → clean; `oxfmt --write` applied

New / rewritten tests:

- `src/main/ipc/worktrees/listing/detected-worktree-classification.test.ts` — call counter on `toDetectedWorktree` (N visible rows ⇒ N calls, not 2N); locator-keyed read only when no snapshot exists, including a partial-store shape where it must still happen and its value must still reach the row; and deep-equality against a verbatim copy of the pre-change two-pass implementation across settled metadata, metadata needing discovery backfill, no metadata at all, and a listing with no host snapshot. `Date.now` and `randomUUID` are pinned so the oracle comparison is deterministic.
- `src/main/ipc/worktrees/listing/detected-provider-listing-meta-index.test.ts` — index build counter across all three provider states (connected ⇒ 0 builds; no provider ⇒ 1; listing throws ⇒ 1), with the rows still identical.
- `src/shared/git-status-conflict-entries.test.ts` — rewritten for the `mW` read: `000000` ⇒ `deleted` and `100644` ⇒ `modified` across all four asymmetric kinds **with `fs.access` asserted never called**; `120000` (symlink) ⇒ `modified`; the symmetric kinds still resolved from `XY` alone whatever `mW` says; submodule rows still dropped without probing; and the malformed-`mW` fallback still exercising all three `access()` outcomes.
- `src/main/git/status.test.ts` — the three pre-existing conflict tests now assert through `getStatus` that no working-tree probe is issued for a conflict row at all, including on a WSL worktree where the marker probes must still travel through the distro spelling. One fixture corrected from `mW=100644` to `mW=000000` for a file it declares missing.


## Linked Issue

N/A — no tracked issue; this came out of a profiling pass over the worktree-catalog and git-status paths.

## Visual Proof

`N/A` — no UI change. Same rows, same order, same icons; the only behavioural delta is the two pathological working-tree states documented under "Negative user-facing trade-offs", which change an icon hint to agree with Git's own stat.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

See the **Test plan** section above for the exact commands and counts. Platforms: exercised on macOS locally; WSL/Windows and SSH/relay paths covered by unit tests that pin the distro-namespace spelling and the shared `parseUnmergedEntry` used by `src/relay/git-handler-status-ops.ts` (no relay edit needed).

## AI Disclosure

Internal contributor — N/A.

## Review

Bot review: coderabbit reported no actionable comments; pullfrog reported no issues across both passes and independently verified that `parts[6]` is porcelain v2's `mW` and that git populates it from a real `lstat` from v2.11 onward, so there is no regression against the Git 2.25 baseline. Pullfrog's one informational note — that the description still described the superseded 8-way-concurrency design — is addressed: the earlier revision now appears only as a labelled "superseded" row in the Finding 3 table, and `status-read.ts` is byte-identical to `main`. Note the first commit's subject line ("unserialise conflict probes") predates the rework; the squash subject is the PR title, which says "drop the conflict-path probe".

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation are touched.

## Notes

- **Security**: no new I/O, no new process spawn; this PR strictly removes filesystem probes.
- **Cross-platform**: no platform branches added. The WSL/Windows case is the one that benefits most (no 9p round trip per asymmetric conflict row).
- **Remote SSH**: pure host-local parse of stdout Git already produced. No RPC param, stream opcode, or published-content change, so mixed client/host versions are unaffected in both directions.
- **Mobile**: unaffected — no wire or renderer contract change.
- **Backwards compatibility**: porcelain v2's `u` record has been stable since Git 2.11, below the repo's 2.25 baseline; no capability gate needed.
- **Performance**: the point of the change — see Measurement.
- **Folder workspaces**: folder repos return early via `buildFolderDetectedWorktrees` and pass `allMeta === undefined`, which is the branch that still performs the locator-keyed read; covered by test.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck`, targeted `pnpm test`, `oxlint`, and `pnpm run check:code-quality:changed` pass locally; CI covers the rest
