### PR TITLE
perf(startup): stop queueing window creation behind the proxy apply and i18n

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -90,7 +90,19 @@ const bundledPluginResources = {
 // from package directories where pnpm's symlink farm is absent. Copy the exact
 // runtime dependency closure to Resources/node_modules so bare require() calls
 // do not fall through to a developer checkout's node_modules.
-const commonExtraResources = [relayExtraResource, bundledPluginResources, skillFreshnessResources]
+// Why the single file rather than the package root: app.asar carries no node_modules, so main's
+// lazy require in deferred-emoji-shortcode-dataset.ts resolves only out of Resources/node_modules,
+// but emojibase-data is 49 MB of locale datasets and worktree naming reads exactly this 166 KB file.
+const emojiShortcodeDatasetResource = {
+  from: 'node_modules/emojibase-data/en/shortcodes/emojibase.json',
+  to: 'node_modules/emojibase-data/en/shortcodes/emojibase.json'
+}
+const commonExtraResources = [
+  relayExtraResource,
+  bundledPluginResources,
+  skillFreshnessResources,
+  emojiShortcodeDatasetResource
+]
 // Why: native speech addons must be real files outside app.asar; copy only the
 // package matching the artifact target instead of every optional variant.
 const macSpeechNativeResource = {

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -1,14 +1,18 @@
+import { readFileSync, readdirSync } from 'node:fs'
 import { cp, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join, relative, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
+const projectRoot = resolve(import.meta.dirname, '..', '..')
 const electronBuilderConfig = require('../electron-builder.config.cjs')
 const {
   createPackagedRuntimeNodeModuleResources,
   findAsarEntry,
+  isPackagedExternalSpecifier,
+  packageNameFromSpecifier,
   prunePackagedNodePty,
   prunePackagedParcelWatcher,
   prunePackagedSherpaOnnx,
@@ -305,4 +309,92 @@ describe('packaged runtime resources', () => {
       }
     }
   )
+})
+
+// Why source-anchored: the bundler renames a createRequire()'d require, so
+// verifyPackagedMainRuntimeDeps' `require("x")` scan cannot see these specifiers — packaging
+// stays green while the packaged app throws MODULE_NOT_FOUND the first time the path runs.
+function collectLazyRequireSpecifiers(directory, found = new Map()) {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      collectLazyRequireSpecifiers(entryPath, found)
+      continue
+    }
+    if (!entry.isFile() || !entry.name.endsWith('.ts') || entry.name.includes('.test.')) {
+      continue
+    }
+    const source = readFileSync(entryPath, 'utf8')
+    if (!source.includes('createRequire(')) {
+      continue
+    }
+    for (const match of source.matchAll(/\brequire[A-Za-z0-9_]*\(\s*'([^']+)'\s*\)/g)) {
+      if (isPackagedExternalSpecifier(match[1])) {
+        found.set(match[1], relative(projectRoot, entryPath).replaceAll('\\', '/'))
+      }
+    }
+  }
+  return found
+}
+
+function packagedResourceDestinations(platform) {
+  return new Set(
+    (electronBuilderConfig[platform].extraResources ?? []).map((resource) =>
+      String(resource.to).replaceAll('\\', '/')
+    )
+  )
+}
+
+describe('lazily required packages reach Resources/node_modules', () => {
+  it('copies every createRequire specifier main uses into the packaged resource plan', () => {
+    const specifiers = collectLazyRequireSpecifiers(join(projectRoot, 'src', 'main'))
+    expect(specifiers.size).toBeGreaterThan(0)
+
+    const destinations = {
+      win: packagedResourceDestinations('win'),
+      mac: packagedResourceDestinations('mac'),
+      linux: packagedResourceDestinations('linux')
+    }
+    for (const [specifier, source] of specifiers) {
+      const packageName = packageNameFromSpecifier(specifier)
+      const covered = (platform) =>
+        destinations[platform].has(`node_modules/${packageName}`) ||
+        destinations[platform].has(`node_modules/${specifier}`)
+      // Windows carries the full closure, so an uncovered specifier is uncovered everywhere.
+      expect(
+        covered('win'),
+        `${source} lazily requires '${specifier}', but nothing copies it to Resources/node_modules`
+      ).toBe(true)
+      if (covered('mac') && covered('linux')) {
+        continue
+      }
+      // Only the Windows-native loaders may be absent from the mac/linux plans.
+      expect(source, `'${specifier}' is packaged for Windows only`).toContain('windows')
+    }
+  })
+
+  it('resolves the copied emoji dataset the way the packaged main bundle does', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-lazy-require-'))
+    try {
+      const datasetPath = 'node_modules/emojibase-data/en/shortcodes/emojibase.json'
+      const entry = electronBuilderConfig.mac.extraResources.find(
+        (resource) => String(resource.to) === datasetPath
+      )
+      expect(entry).toBeDefined()
+      const destination = join(resourcesDir, ...datasetPath.split('/'))
+      await mkdir(dirname(destination), { recursive: true })
+      await cp(join(projectRoot, ...String(entry.from).split('/')), destination)
+
+      // app.asar's parent is Resources, so main's bare require walks into Resources/node_modules.
+      const packagedMainDir = join(resourcesDir, 'app.asar', 'out', 'main')
+      await mkdir(packagedMainDir, { recursive: true })
+      const probe = join(packagedMainDir, 'probe.cjs')
+      await writeFile(probe, 'module.exports = require', 'utf8')
+
+      const dataset = require(probe)('emojibase-data/en/shortcodes/emojibase.json')
+      expect(Object.keys(dataset).length).toBeGreaterThan(1000)
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -19,6 +19,7 @@
     "../src/preload/usage-provider-api.ts",
     "../src/shared/**/*",
     "../src/main/gitlab/mappers.ts",
+    "../src/main/ipc/deferred-emoji-shortcode-dataset.ts",
     "../src/main/ipc/worktree-branch-name.ts",
     "../src/main/ipc/worktree-logic.ts",
     "../src/main/ipc/worktree-display-name.ts",

--- a/src/main/ipc/deferred-emoji-shortcode-dataset.test.ts
+++ b/src/main/ipc/deferred-emoji-shortcode-dataset.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest'
+import emojiShortcodes from 'emojibase-data/en/shortcodes/emojibase.json'
+import { requireEmojiShortcodeDataset } from './deferred-emoji-shortcode-dataset'
+
+// Lives under src/main (not next to the shared catalog) so the shared tsconfig projects stay
+// free of a src/main import — the boundary emoji-shortcode-catalog.lazy.test.ts asserts on.
+describe('deferred emoji shortcode dataset', () => {
+  it('loads the main-side dataset synchronously into an identical catalog', async () => {
+    vi.resetModules()
+    const eager = await import('../../shared/emoji-shortcode-catalog.js')
+    eager.setEmojiShortcodeDatasetLoader(() => emojiShortcodes)
+    const eagerEntries = eager.getStandardEmojiShortcodeEntries()
+    const eagerTransform = eager.replaceKnownEmojiWithShortcodes('ship \u{1F389} \u{1F44D}')
+
+    vi.resetModules()
+    const deferred = await import('../../shared/emoji-shortcode-catalog.js')
+    deferred.setEmojiShortcodeDatasetLoader(requireEmojiShortcodeDataset)
+
+    // No await between registration and first use: the require path keeps the sync contract.
+    expect(deferred.getStandardEmojiShortcodeEntries()).toEqual(eagerEntries)
+    expect(deferred.replaceKnownEmojiWithShortcodes('ship \u{1F389} \u{1F44D}')).toBe(
+      eagerTransform
+    )
+  })
+})

--- a/src/main/ipc/deferred-emoji-shortcode-dataset.ts
+++ b/src/main/ipc/deferred-emoji-shortcode-dataset.ts
@@ -3,8 +3,9 @@ import type { EmojiShortcodeDataset } from '../../shared/emoji-shortcode-catalog
 
 // Why createRequire (same reason as linear-sdk.ts): a static import inlines the 166 KB
 // shortcode dataset into out/main/index.js and JSON.parses it on every launch, while only
-// worktree-name sanitization ever reads it. `emojibase-data` is a production dependency, so
-// the packaged app.asar resolves this the same way it resolves any other bare require.
+// worktree-name sanitization ever reads it. app.asar ships no node_modules, so this bare require
+// resolves out of Resources/node_modules — electron-builder.config.cjs copies exactly this file
+// there (the package root is 49 MB of locale data).
 const requireFromMain = createRequire(__filename)
 
 export function requireEmojiShortcodeDataset(): EmojiShortcodeDataset {

--- a/src/main/ipc/deferred-emoji-shortcode-dataset.ts
+++ b/src/main/ipc/deferred-emoji-shortcode-dataset.ts
@@ -1,0 +1,12 @@
+import { createRequire } from 'node:module'
+import type { EmojiShortcodeDataset } from '../../shared/emoji-shortcode-catalog'
+
+// Why createRequire (same reason as linear-sdk.ts): a static import inlines the 166 KB
+// shortcode dataset into out/main/index.js and JSON.parses it on every launch, while only
+// worktree-name sanitization ever reads it. `emojibase-data` is a production dependency, so
+// the packaged app.asar resolves this the same way it resolves any other bare require.
+const requireFromMain = createRequire(__filename)
+
+export function requireEmojiShortcodeDataset(): EmojiShortcodeDataset {
+  return requireFromMain('emojibase-data/en/shortcodes/emojibase.json') as EmojiShortcodeDataset
+}

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -4,8 +4,14 @@ import type { Repo } from '../../shared/repo-types'
 import { isWindowsAbsolutePathLike, resolveRuntimePath } from '../../shared/cross-platform-path'
 import { isWslUncPath, resolveWslRepoWorktreeBasePath } from '../../shared/wsl-paths'
 import { splitWorktreeId } from '../../shared/worktree/id'
-import { replaceKnownEmojiWithShortcodes } from '../../shared/emoji-shortcode-catalog'
+import {
+  replaceKnownEmojiWithShortcodes,
+  setEmojiShortcodeDatasetLoader
+} from '../../shared/emoji-shortcode-catalog'
+import { requireEmojiShortcodeDataset } from './deferred-emoji-shortcode-dataset'
 import { getWslHome, getWslHomeAsync, parseWslPath } from '../wsl'
+
+setEmojiShortcodeDatasetLoader(requireEmojiShortcodeDataset)
 
 type WorktreePathSettings = Pick<GlobalSettings, 'nestWorkspaces' | 'workspaceDir'> & {
   /** Distro to mirror the workspace root into when the repo itself sits on a

--- a/src/main/proxy-guarded-fetch-call-site-audit.test.ts
+++ b/src/main/proxy-guarded-fetch-call-site-audit.test.ts
@@ -24,10 +24,12 @@ const AUDITED_NON_NET_FETCH_CALLS = new Map<string, number>([
 ])
 
 // `globalThis.fetch` / `global.fetch` belong to global-fetch-call-site-audit.test.ts.
-const FETCH_CALL = /\.fetch\(/g
+// `\s*` before `(`: the formatter never emits `net.fetch (url)`, but an unformatted call must not
+// be a hole in a guard whose whole job is to fail on the call nobody reviewed.
+const FETCH_CALL = /\.fetch\s*\(/g
 const RECEIVER_IDENTIFIER = /(?:^|[^.\w$])([A-Za-z_$][\w$]*)\s*$/
 const DEFAULT_SESSION_RECEIVERS = new Set(['net', 'globalThis', 'global'])
-const NET_REQUEST_CALL = /(?<![.\w$])net\.(?:fetch|request)\(/g
+const NET_REQUEST_CALL = /(?<![.\w$])net\.(?:fetch|request)\s*\(/g
 // Matches `{ session: x }` and the `{ url, session }` shorthand both `net.request` overloads take.
 const SESSION_SCOPED_OPTION = /(?:^|[{,\s])(?:session|partition)\s*[:,}]/
 

--- a/src/main/proxy-guarded-fetch-call-site-audit.test.ts
+++ b/src/main/proxy-guarded-fetch-call-site-audit.test.ts
@@ -24,9 +24,12 @@ const AUDITED_NON_NET_FETCH_CALLS = new Map<string, number>([
 ])
 
 // `globalThis.fetch` / `global.fetch` belong to global-fetch-call-site-audit.test.ts.
-const NON_NET_FETCH_CALL = /(?<![.\w$])(?!net\b|globalThis\b|global\b)[A-Za-z_$][\w$]*\.fetch\(/g
+const FETCH_CALL = /\.fetch\(/g
+const RECEIVER_IDENTIFIER = /(?:^|[^.\w$])([A-Za-z_$][\w$]*)\s*$/
+const DEFAULT_SESSION_RECEIVERS = new Set(['net', 'globalThis', 'global'])
 const NET_REQUEST_CALL = /(?<![.\w$])net\.(?:fetch|request)\(/g
-const SESSION_SCOPED_OPTION = /(?:^|[{,\s])(?:session|partition)\s*:/
+// Matches `{ session: x }` and the `{ url, session }` shorthand both `net.request` overloads take.
+const SESSION_SCOPED_OPTION = /(?:^|[{,\s])(?:session|partition)\s*[:,}]/
 
 /** Text between the call's parentheses, skipping string bodies so quoted parens don't unbalance. */
 function callArgumentText(content: string, callEnd: number): string {
@@ -105,7 +108,12 @@ describe('proxy-guarded fetch call-site audit (main)', () => {
   it('keeps every non-default-session fetcher audited with its expected count', () => {
     const found = new Map<string, number>()
     for (const { file, content } of sources) {
-      const hits = [...content.matchAll(NON_NET_FETCH_CALL)].length
+      const hits = [...content.matchAll(FETCH_CALL)].filter((match) => {
+        const receiver = RECEIVER_IDENTIFIER.exec(content.slice(0, match.index))?.[1]
+        // A chained (`session.fromPartition(...).fetch(`) or member (`ctx.session.fetch(`)
+        // receiver has no bare trailing identifier, and is never the default session.
+        return receiver === undefined || !DEFAULT_SESSION_RECEIVERS.has(receiver)
+      }).length
       if (hits > 0) {
         found.set(file, hits)
       }

--- a/src/main/proxy-guarded-fetch-call-site-audit.test.ts
+++ b/src/main/proxy-guarded-fetch-call-site-audit.test.ts
@@ -1,0 +1,130 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Startup applies the persisted proxy to `session.defaultSession` only, and
+// `installElectronProxyRequestGuard(session.defaultSession)` is what actually holds requests
+// until that apply (and every later proxy transition) settles. Two ways a main-process fetcher
+// can escape that fence, both audited here:
+//   1. a `net.fetch` / `net.request` that names another `session` or `partition`
+//   2. a `<session>.fetch(` on a `session.fromPartition(...)` session
+// Known pre-existing gap outside this repo's reach: electron-updater runs on its own partition.
+//
+// Rule 2 entries map a file to its expected number of non-`net` `.fetch(` calls. A count change
+// means a call site was added, removed, or moved: re-audit the file and update the count.
+const AUDITED_NON_NET_FETCH_CALLS = new Map<string, number>([
+  // Isolated cookie-jar session, proxied by createOpenCodeRequestSession before any request.
+  ['main/rate-limits/opencode-go-usage-fetcher.ts', 2],
+  // Isolated cookie-jar session that does NOT apply the proxy — a pre-existing gap, not a
+  // regression: no proxy has ever reached this partition. Keep it listed so it stays visible.
+  ['main/rate-limits/minimax-request-context.ts', 2],
+  // Injected HttpClient, not a session: resolves to net.fetch on defaultSession
+  // (main/host/electron-http-client.ts) or to the global-fetch-audited Node fallback.
+  ['main/jira/authenticated-request.ts', 1]
+])
+
+// `globalThis.fetch` / `global.fetch` belong to global-fetch-call-site-audit.test.ts.
+const NON_NET_FETCH_CALL = /(?<![.\w$])(?!net\b|globalThis\b|global\b)[A-Za-z_$][\w$]*\.fetch\(/g
+const NET_REQUEST_CALL = /(?<![.\w$])net\.(?:fetch|request)\(/g
+const SESSION_SCOPED_OPTION = /(?:^|[{,\s])(?:session|partition)\s*:/
+
+/** Text between the call's parentheses, skipping string bodies so quoted parens don't unbalance. */
+function callArgumentText(content: string, callEnd: number): string {
+  let depth = 0
+  let quote: string | null = null
+  for (let index = callEnd - 1; index < content.length; index += 1) {
+    const char = content[index]!
+    if (quote) {
+      if (char === '\\') {
+        index += 1
+      } else if (char === quote) {
+        quote = null
+      }
+      continue
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char
+      continue
+    }
+    if (char === '(') {
+      depth += 1
+    } else if (char === ')') {
+      depth -= 1
+      if (depth === 0) {
+        return content.slice(callEnd, index)
+      }
+    }
+  }
+  return content.slice(callEnd)
+}
+
+function auditedSourceFiles(mainRoot: string): { file: string; content: string }[] {
+  const files: { file: string; content: string }[] = []
+  for (const entry of readdirSync(mainRoot, { recursive: true, withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.ts')) {
+      continue
+    }
+    if (
+      entry.name.endsWith('.test.ts') ||
+      entry.name.endsWith('.test-fixtures.ts') ||
+      entry.name.endsWith('.d.ts')
+    ) {
+      continue
+    }
+    const filePath = join(entry.parentPath, entry.name)
+    files.push({
+      file: `main/${relative(mainRoot, filePath).split(sep).join('/')}`,
+      content: readFileSync(filePath, 'utf8')
+    })
+  }
+  return files
+}
+
+describe('proxy-guarded fetch call-site audit (main)', () => {
+  const sources = auditedSourceFiles(__dirname)
+
+  it('keeps every net.fetch/net.request on the guarded default session', () => {
+    const offenders: string[] = []
+    for (const { file, content } of sources) {
+      for (const match of content.matchAll(NET_REQUEST_CALL)) {
+        const args = callArgumentText(content, match.index + match[0].length)
+        if (SESSION_SCOPED_OPTION.test(args)) {
+          offenders.push(`${file}:${content.slice(0, match.index).split('\n').length}`)
+        }
+      }
+    }
+    expect(
+      offenders.sort(),
+      'This request names its own session/partition, so it is not covered by ' +
+        'installElectronProxyRequestGuard(session.defaultSession) and startup never applies the ' +
+        'persisted proxy to it. Either drop the option, or apply the proxy to that session ' +
+        'yourself (see main/rate-limits/opencode-go-request-session.ts) and allowlist it here.'
+    ).toEqual([])
+  })
+
+  it('keeps every non-default-session fetcher audited with its expected count', () => {
+    const found = new Map<string, number>()
+    for (const { file, content } of sources) {
+      const hits = [...content.matchAll(NON_NET_FETCH_CALL)].length
+      if (hits > 0) {
+        found.set(file, hits)
+      }
+    }
+
+    const drifted = [...found]
+      .filter(([file, count]) => AUDITED_NON_NET_FETCH_CALLS.get(file) !== count)
+      .map(([file, count]) => `${file}: found ${count} call(s)`)
+      .sort()
+    expect(
+      drifted,
+      'A session.fromPartition(...) session is not covered by ' +
+        'installElectronProxyRequestGuard(session.defaultSession), so nothing holds its requests ' +
+        'until the proxy lands and startup never applies the proxy to it. Apply the proxy to that ' +
+        'session yourself (see main/rate-limits/opencode-go-request-session.ts), then update ' +
+        'AUDITED_NON_NET_FETCH_CALLS.'
+    ).toEqual([])
+
+    const stale = [...AUDITED_NON_NET_FETCH_CALLS.keys()].filter((file) => !found.has(file)).sort()
+    expect(stale, 'Remove audited entries whose .fetch( calls are gone.').toEqual([])
+  })
+})

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -66,7 +66,12 @@ describe('startup ordering', () => {
     )
     expect(desktopStartup).toContain('recordRuntimeRpcStartFailure(')
     // Why: `void`, not `await` — awaiting the dialog would park the rest of startup behind a modal.
-    expect(desktopStartup).toMatch(/void showRuntimeRpcStartupFailureDialog\(\s*win,/)
+    // It chains off the i18n barrier (published before this phase starts) so the translated strings
+    // it reads are loaded, which is a wait on i18n only, never on the dialog itself.
+    expect(desktopStartup).toMatch(
+      /void state\.mainProcessI18nReady\.then\(\(\) =>\s*showRuntimeRpcStartupFailureDialog\(\s*win,/
+    )
+    expect(desktopStartup).not.toMatch(/await[^\n]*showRuntimeRpcStartupFailureDialog\(/)
     // Why (#11025): a bare console.error here is exactly what left the CLI dead but the app healthy.
     expect(desktopStartup).not.toContain(
       "console.error('[runtime] Failed to start local RPC transport:'"

--- a/src/main/startup/main-process-ready-foundation.ts
+++ b/src/main/startup/main-process-ready-foundation.ts
@@ -139,7 +139,22 @@ export async function initializeReadyFoundation(): Promise<void> {
   })
   state.store = store
   // Why: create pending readiness before the guard can observe the default session.
-  const initialProxyApplication = applyElectronProxySettings(store.getSettings())
+  // Why parked on state instead of awaited here: Dock/Launchpad launches don't inherit shell
+  // proxy env vars, so the persisted proxy must land before any app-owned network fetcher runs —
+  // but the guard below already holds every default-session request until this settles, so
+  // awaiting it inline only delayed window creation. Runtime launch awaits it before the first
+  // fetcher (the desktop relay / headless serve).
+  state.initialProxyApplicationReady = applyElectronProxySettings(store.getSettings()).then(
+    (result) => {
+      if (result.source === 'invalid-settings') {
+        // Why (STA-3442): a silent DIRECT fallback made a dead configured proxy undiagnosable.
+        console.warn('[proxy] persisted proxy settings are invalid; using direct networking')
+      }
+    },
+    () => {
+      console.warn('[proxy] Failed to apply network proxy settings')
+    }
+  )
   installElectronProxyRequestGuard(session.defaultSession)
   // Why armed here and not at install time: the report remembers what it last said, and
   // that state lives beside the profile data file, which does not exist until now.
@@ -234,16 +249,6 @@ export async function initializeReadyFoundation(): Promise<void> {
   applyAppIcon(store.getSettings().appIcon)
   if (shouldSuppressDevEducation({ isDev: is.dev })) {
     suppressDevEducationForStore(store)
-  }
-  try {
-    // Why: Dock/Launchpad launches don't inherit shell proxy env vars, so apply the persisted proxy before any app-owned network fetchers run.
-    const proxyApplyResult = await initialProxyApplication
-    if (proxyApplyResult.source === 'invalid-settings') {
-      // Why (STA-3442): a silent DIRECT fallback made a dead configured proxy undiagnosable.
-      console.warn('[proxy] persisted proxy settings are invalid; using direct networking')
-    }
-  } catch {
-    console.warn('[proxy] Failed to apply network proxy settings')
   }
   // Why: the partition installer reads the proxy through this resolver, so register it before sessions materialize.
   setBrowserNetworkProxySettingsResolver(() => state.store!.getSettings())

--- a/src/main/startup/main-process-ready-phase-ordering.test.ts
+++ b/src/main/startup/main-process-ready-phase-ordering.test.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const phaseEvents: string[] = []
+let releaseI18n: (() => void) | null = null
+
+vi.mock('./main-process-ready-foundation', () => ({
+  initializeReadyFoundation: vi.fn(async () => {
+    phaseEvents.push('foundation')
+  })
+}))
+vi.mock('./main-process-ready-runtime', () => ({
+  initializeReadyRuntimeServices: vi.fn(async () => {
+    phaseEvents.push('runtime-services')
+  })
+}))
+vi.mock('./main-process-i18n-menu', () => ({
+  initializeMainProcessI18nAndMenu: vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        phaseEvents.push('i18n-start')
+        releaseI18n = () => {
+          phaseEvents.push('i18n-done')
+          resolve()
+        }
+      })
+  )
+}))
+vi.mock('./main-process-runtime-launch', () => ({
+  initializeMainProcessRuntimeLaunch: vi.fn(async () => {
+    phaseEvents.push('launch-start')
+    await Promise.resolve()
+    phaseEvents.push('window-created')
+  })
+}))
+
+const { initializeMainProcessReady } = await import('./main-process-ready')
+
+describe('ready-phase concurrency', () => {
+  beforeEach(() => {
+    phaseEvents.length = 0
+    releaseI18n = null
+  })
+
+  it('creates the window without waiting for i18n and the native menu', async () => {
+    const options = {
+      openMainWindow: vi.fn(),
+      handleMacAppActivation: vi.fn()
+    } as unknown as Parameters<typeof initializeMainProcessReady>[0]
+
+    const ready = initializeMainProcessReady(options)
+    // Drain the launch phase's microtasks while i18n is still pending.
+    for (let tick = 0; tick < 8; tick += 1) {
+      await Promise.resolve()
+    }
+
+    expect(phaseEvents).toEqual([
+      'foundation',
+      'runtime-services',
+      'i18n-start',
+      'launch-start',
+      'window-created'
+    ])
+
+    releaseI18n?.()
+    await ready
+    expect(phaseEvents.at(-1)).toBe('i18n-done')
+  })
+
+  it('still resolves only once i18n and the menu have settled', async () => {
+    const options = {
+      openMainWindow: vi.fn(),
+      handleMacAppActivation: vi.fn()
+    } as unknown as Parameters<typeof initializeMainProcessReady>[0]
+
+    const ready = initializeMainProcessReady(options)
+    let settled = false
+    void ready.then(() => {
+      settled = true
+    })
+    for (let tick = 0; tick < 8; tick += 1) {
+      await Promise.resolve()
+    }
+
+    expect(settled).toBe(false)
+    releaseI18n?.()
+    await ready
+    expect(settled).toBe(true)
+  })
+})
+
+describe('initial proxy application ordering', () => {
+  const readStartupSource = (file: string): string =>
+    readFileSync(join(process.cwd(), 'src/main/startup', file), 'utf8')
+
+  it('parks the default-session proxy apply instead of blocking window creation on it', () => {
+    const foundation = readStartupSource('main-process-ready-foundation.ts')
+
+    expect(foundation).toContain('state.initialProxyApplicationReady = applyElectronProxySettings(')
+    // The request guard, not this phase, is what fences fetchers on the proxy; awaiting it here
+    // only queued openMainWindow behind a ~24 ms setProxy round trip.
+    expect(foundation).not.toMatch(/await\s+(?:state\.)?initialProxyApplication/)
+  })
+
+  it('awaits the proxy after the window opens and before the desktop relay starts', () => {
+    const launch = readStartupSource('main-process-runtime-launch.ts')
+    const desktopStart = launch.indexOf('async function launchDesktopMode(')
+    const desktopEnd = launch.indexOf('\nexport async function initializeMainProcessRuntimeLaunch')
+    expect(desktopStart).toBeGreaterThanOrEqual(0)
+    expect(desktopEnd).toBeGreaterThan(desktopStart)
+    const desktop = launch.slice(desktopStart, desktopEnd)
+
+    const windowIndex = desktop.indexOf('openMainWindow()')
+    const proxyIndex = desktop.indexOf('await state.initialProxyApplicationReady')
+    const relayIndex = desktop.indexOf('new DesktopRelayService(')
+
+    expect(windowIndex).toBeGreaterThanOrEqual(0)
+    expect(proxyIndex).toBeGreaterThan(windowIndex)
+    expect(relayIndex).toBeGreaterThan(proxyIndex)
+  })
+
+  it('keeps headless serve strictly ordered behind the proxy apply', () => {
+    const launch = readStartupSource('main-process-runtime-launch.ts')
+    const serveStart = launch.indexOf('async function launchServeMode(')
+    const serveEnd = launch.indexOf('\nasync function launchDesktopMode(', serveStart)
+    expect(serveStart).toBeGreaterThanOrEqual(0)
+    expect(serveEnd).toBeGreaterThan(serveStart)
+    const serve = launch.slice(serveStart, serveEnd)
+
+    const proxyIndex = serve.indexOf('await state.initialProxyApplicationReady')
+    const rpcIndex = serve.indexOf('runtimeRpc.start()')
+
+    expect(proxyIndex).toBeGreaterThanOrEqual(0)
+    expect(rpcIndex).toBeGreaterThan(proxyIndex)
+  })
+})

--- a/src/main/startup/main-process-ready-phase-ordering.test.ts
+++ b/src/main/startup/main-process-ready-phase-ordering.test.ts
@@ -120,6 +120,22 @@ describe('initial proxy application ordering', () => {
     expect(relayIndex).toBeGreaterThan(proxyIndex)
   })
 
+  it('waits for i18n before the only launch-phase dialog that reads a translated string', () => {
+    const ready = readStartupSource('main-process-ready.ts')
+    const launch = readStartupSource('main-process-runtime-launch.ts')
+
+    // Published before the launch phase starts, or the barrier the dialog awaits is still the
+    // default resolved promise.
+    const publishIndex = ready.indexOf('state.mainProcessI18nReady = ')
+    expect(publishIndex).toBeGreaterThanOrEqual(0)
+    expect(ready.indexOf('initializeMainProcessRuntimeLaunch(options)')).toBeGreaterThan(
+      publishIndex
+    )
+    expect(launch).toMatch(
+      /state\.mainProcessI18nReady\.then\(\(\) =>\s*\n?\s*showRuntimeRpcStartupFailureDialog\(/
+    )
+  })
+
   it('keeps headless serve strictly ordered behind the proxy apply', () => {
     const launch = readStartupSource('main-process-runtime-launch.ts')
     const serveStart = launch.indexOf('async function launchServeMode(')

--- a/src/main/startup/main-process-ready.ts
+++ b/src/main/startup/main-process-ready.ts
@@ -12,6 +12,11 @@ export async function initializeMainProcessReady(
 ): Promise<void> {
   await initializeReadyFoundation()
   await initializeReadyRuntimeServices()
-  await initializeMainProcessI18nAndMenu()
-  await initializeMainProcessRuntimeLaunch(options)
+  // Why concurrent: window creation reads no translated string and no menu item, and both the
+  // native menu and the tray only become reachable once the window shows — so serializing them
+  // ahead of openMainWindow only delayed the renderer (8 ms in English, more for a lazy locale).
+  await Promise.all([
+    initializeMainProcessI18nAndMenu(),
+    initializeMainProcessRuntimeLaunch(options)
+  ])
 }

--- a/src/main/startup/main-process-ready.ts
+++ b/src/main/startup/main-process-ready.ts
@@ -1,4 +1,5 @@
 import { initializeMainProcessI18nAndMenu } from './main-process-i18n-menu'
+import { mainProcessState as state } from './main-process-state'
 import { initializeReadyFoundation } from './main-process-ready-foundation'
 import { initializeReadyRuntimeServices } from './main-process-ready-runtime'
 import {
@@ -15,8 +16,7 @@ export async function initializeMainProcessReady(
   // Why concurrent: window creation reads no translated string and no menu item, and both the
   // native menu and the tray only become reachable once the window shows — so serializing them
   // ahead of openMainWindow only delayed the renderer (8 ms in English, more for a lazy locale).
-  await Promise.all([
-    initializeMainProcessI18nAndMenu(),
-    initializeMainProcessRuntimeLaunch(options)
-  ])
+  const i18nAndMenuReady = initializeMainProcessI18nAndMenu()
+  state.mainProcessI18nReady = i18nAndMenuReady.catch(() => {})
+  await Promise.all([i18nAndMenuReady, initializeMainProcessRuntimeLaunch(options)])
 }

--- a/src/main/startup/main-process-runtime-launch.ts
+++ b/src/main/startup/main-process-runtime-launch.ts
@@ -229,7 +229,12 @@ async function launchDesktopMode(
       )
   ])
   if (!runtimeRpcStartResult.ok) {
-    void showRuntimeRpcStartupFailureDialog(win, runtimeRpcStartResult.error)
+    // Why gated: this dialog is the only launch-phase text read through translateMain, and i18n
+    // now settles alongside this phase — without the wait a non-English user could get the
+    // English defaultValue fallback. Still off the renderer's path (it is failure-only).
+    void state.mainProcessI18nReady.then(() =>
+      showRuntimeRpcStartupFailureDialog(win, runtimeRpcStartResult.error)
+    )
   }
   // Why after the window and not before it: the default-session request guard already holds every
   // fetcher until the persisted proxy lands, so this only has to keep the launch phase itself

--- a/src/main/startup/main-process-runtime-launch.ts
+++ b/src/main/startup/main-process-runtime-launch.ts
@@ -120,6 +120,9 @@ async function launchServeMode(
   runtimeRpc: OrcaRuntimeRpcServer,
   serveOptions: NonNullable<ReturnType<typeof getServeOptions>>
 ): Promise<void> {
+  // Why here: headless serve has no window to unblock, so keep the persisted proxy strictly
+  // ahead of every fetcher this phase can reach (relay, CLI install, RPC clients).
+  await state.initialProxyApplicationReady
   // Why: give managed WSL launchers a brief chance to migrate before headless PTYs go live, without slow repairs withholding all RPC readiness.
   logStartupMilestone('wsl-cli-barrier-start')
   await state.managedWslCliStartupBarrierReady
@@ -228,6 +231,10 @@ async function launchDesktopMode(
   if (!runtimeRpcStartResult.ok) {
     void showRuntimeRpcStartupFailureDialog(win, runtimeRpcStartResult.error)
   }
+  // Why after the window and not before it: the default-session request guard already holds every
+  // fetcher until the persisted proxy lands, so this only has to keep the launch phase itself
+  // ordered ahead of the relay — it must not gate the renderer.
+  await state.initialProxyApplicationReady
   const cloudAuth = getOrcaCloudAuthConfig()
   if (cloudAuth.configured) {
     try {

--- a/src/main/startup/main-process-state.ts
+++ b/src/main/startup/main-process-state.ts
@@ -103,6 +103,10 @@ export const mainProcessState = {
   // Why published: the default-session proxy must be applied before the first app-owned fetcher,
   // but window creation has no reason to queue behind it (the request guard already fences it).
   initialProxyApplicationReady: Promise.resolve(),
+  // Why published: i18n/menu init no longer precedes the launch phase, so the one launch-phase
+  // path that reads a translated string (the runtime-RPC startup failure dialog) waits on this.
+  // Never rejects: the phase's own failure is surfaced by initializeMainProcessReady.
+  mainProcessI18nReady: Promise.resolve(),
   managedWslCliReconciliationReady: Promise.resolve(),
   managedWslCliStartupBarrierReady: Promise.resolve(),
   // Why: the serve barrier fails open, so this state tells headless clients a WSL PTY launch may still race an un-migrated registration ('settled' = off-Windows no-op).

--- a/src/main/startup/main-process-state.ts
+++ b/src/main/startup/main-process-state.ts
@@ -100,6 +100,9 @@ export const mainProcessState = {
   // Electron with no error. Only the renderer's own pull proves the listener is live.
   markdownFileOpenListenerReady: false,
   firstWindowStartupServicesReady: Promise.resolve(),
+  // Why published: the default-session proxy must be applied before the first app-owned fetcher,
+  // but window creation has no reason to queue behind it (the request guard already fences it).
+  initialProxyApplicationReady: Promise.resolve(),
   managedWslCliReconciliationReady: Promise.resolve(),
   managedWslCliStartupBarrierReady: Promise.resolve(),
   // Why: the serve barrier fails open, so this state tells headless clients a WSL PTY launch may still race an un-migrated registration ('settled' = off-Windows no-op).

--- a/src/renderer/src/lib/workspace-emoji-shortcodes.ts
+++ b/src/renderer/src/lib/workspace-emoji-shortcodes.ts
@@ -1,7 +1,13 @@
+import emojiShortcodes from 'emojibase-data/en/shortcodes/emojibase.json'
 import {
   getStandardEmojiShortcodeEntries,
+  setEmojiShortcodeDatasetLoader,
   type StandardEmojiShortcodeEntry
 } from '../../../shared/emoji-shortcode-catalog'
+
+// Why eager here and lazy in main: a dynamic import made the shortcode transform return an
+// empty catalog until it settled, so a `:wink:` submitted in that window persisted literally.
+setEmojiShortcodeDatasetLoader(() => emojiShortcodes)
 
 export type WorkspaceEmojiSuggestion = StandardEmojiShortcodeEntry
 

--- a/src/shared/emoji-shortcode-catalog.lazy.test.ts
+++ b/src/shared/emoji-shortcode-catalog.lazy.test.ts
@@ -1,6 +1,13 @@
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import emojiShortcodes from 'emojibase-data/en/shortcodes/emojibase.json'
+
+async function importConfiguredCatalog() {
+  const catalog = await import('./emoji-shortcode-catalog.js')
+  catalog.setEmojiShortcodeDatasetLoader(() => emojiShortcodes)
+  return catalog
+}
 
 describe('emoji shortcode catalog laziness', () => {
   beforeEach(() => {
@@ -8,7 +15,7 @@ describe('emoji shortcode catalog laziness', () => {
   })
 
   it('does not build the catalog when the shared module is imported', async () => {
-    const catalog = await import('./emoji-shortcode-catalog.js')
+    const catalog = await importConfiguredCatalog()
 
     expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(false)
 
@@ -17,20 +24,23 @@ describe('emoji shortcode catalog laziness', () => {
   })
 
   it('builds on first use and keeps the main process off the eager path', async () => {
-    const catalog = await import('./emoji-shortcode-catalog.js')
+    const catalog = await importConfiguredCatalog()
 
     expect(catalog.replaceKnownEmojiWithShortcodes('ship \u{1F389}')).toBe('ship  party ')
     expect(catalog.isEmojiShortcodeCatalogBuiltForTest()).toBe(true)
   })
 
-  it('leaves the main-process worktree namer importing only the deferred entry point', () => {
+  it('leaves the main-process worktree namer importing only the deferred entry points', () => {
     // A cross-project import would drag src/main into the shared tsconfig, so assert on source.
     const worktreeLogic = readFileSync(join(__dirname, '../main/ipc/worktree-logic.ts'), 'utf8')
     const catalogImport = worktreeLogic.match(
       /import \{([^}]*)\} from '[^']*emoji-shortcode-catalog'/
     )
 
-    expect(catalogImport?.[1].trim()).toBe('replaceKnownEmojiWithShortcodes')
+    expect(catalogImport?.[1].split(',').map((name) => name.trim())).toEqual([
+      'replaceKnownEmojiWithShortcodes',
+      'setEmojiShortcodeDatasetLoader'
+    ])
   })
 
   it('keeps the catalog build out of module scope', () => {
@@ -40,5 +50,34 @@ describe('emoji shortcode catalog laziness', () => {
     expect(sharedSource).not.toMatch(/^const \w+ = Object\.entries\(/m)
     expect(sharedSource).not.toMatch(/^const \w+ = new (?:Map|Intl\.Segmenter)\(/m)
     expect(sharedSource).toContain('function loadCatalog()')
+  })
+
+  it('keeps the 166 KB dataset off every module main statically imports', () => {
+    const sharedSource = readFileSync(join(__dirname, 'emoji-shortcode-catalog.ts'), 'utf8')
+    const worktreeLogic = readFileSync(join(__dirname, '../main/ipc/worktree-logic.ts'), 'utf8')
+
+    // A static `emojibase-data` import anywhere main reaches inlines the dataset into
+    // out/main/index.js and JSON.parses it on every launch.
+    const staticDatasetImport = /\bfrom '[^']*emojibase-data[^']*'/
+    expect(sharedSource).not.toMatch(staticDatasetImport)
+    expect(worktreeLogic).not.toMatch(staticDatasetImport)
+  })
+
+  it('loads the main-side dataset synchronously into an identical catalog', async () => {
+    const { requireEmojiShortcodeDataset } =
+      await import('../main/ipc/deferred-emoji-shortcode-dataset.js')
+    const eager = await importConfiguredCatalog()
+    const eagerEntries = eager.getStandardEmojiShortcodeEntries()
+    const eagerTransform = eager.replaceKnownEmojiWithShortcodes('ship \u{1F389} \u{1F44D}')
+
+    vi.resetModules()
+    const deferred = await import('./emoji-shortcode-catalog.js')
+    deferred.setEmojiShortcodeDatasetLoader(requireEmojiShortcodeDataset)
+
+    // No await between registration and first use: the require path keeps the sync contract.
+    expect(deferred.getStandardEmojiShortcodeEntries()).toEqual(eagerEntries)
+    expect(deferred.replaceKnownEmojiWithShortcodes('ship \u{1F389} \u{1F44D}')).toBe(
+      eagerTransform
+    )
   })
 })

--- a/src/shared/emoji-shortcode-catalog.lazy.test.ts
+++ b/src/shared/emoji-shortcode-catalog.lazy.test.ts
@@ -62,22 +62,4 @@ describe('emoji shortcode catalog laziness', () => {
     expect(sharedSource).not.toMatch(staticDatasetImport)
     expect(worktreeLogic).not.toMatch(staticDatasetImport)
   })
-
-  it('loads the main-side dataset synchronously into an identical catalog', async () => {
-    const { requireEmojiShortcodeDataset } =
-      await import('../main/ipc/deferred-emoji-shortcode-dataset.js')
-    const eager = await importConfiguredCatalog()
-    const eagerEntries = eager.getStandardEmojiShortcodeEntries()
-    const eagerTransform = eager.replaceKnownEmojiWithShortcodes('ship \u{1F389} \u{1F44D}')
-
-    vi.resetModules()
-    const deferred = await import('./emoji-shortcode-catalog.js')
-    deferred.setEmojiShortcodeDatasetLoader(requireEmojiShortcodeDataset)
-
-    // No await between registration and first use: the require path keeps the sync contract.
-    expect(deferred.getStandardEmojiShortcodeEntries()).toEqual(eagerEntries)
-    expect(deferred.replaceKnownEmojiWithShortcodes('ship \u{1F389} \u{1F44D}')).toBe(
-      eagerTransform
-    )
-  })
 })

--- a/src/shared/emoji-shortcode-catalog.ts
+++ b/src/shared/emoji-shortcode-catalog.ts
@@ -1,8 +1,21 @@
-import emojiShortcodes from 'emojibase-data/en/shortcodes/emojibase.json'
-
 export type StandardEmojiShortcodeEntry = {
   emoji: string
   shortcode: string
+}
+
+/** Shape of `emojibase-data/en/shortcodes/emojibase.json`: hexcode -> shortcode or aliases. */
+export type EmojiShortcodeDataset = Readonly<Record<string, string | readonly string[]>>
+
+let loadDataset: (() => EmojiShortcodeDataset) | null = null
+
+/**
+ * Why injected instead of statically imported: the renderer must keep its eager copy (a
+ * dynamic import there returned an empty catalog mid-load and persisted `:wink:` literally),
+ * but a static import here also inlines the same 166 KB into out/main/index.js and JSON.parses
+ * it on every launch. Main supplies a lazy require instead; both stay synchronous.
+ */
+export function setEmojiShortcodeDatasetLoader(load: () => EmojiShortcodeDataset): void {
+  loadDataset = load
 }
 
 // Skin-tone aliases (`wave_tone3`) are ~40% of the dataset and would drown the suggestion list.
@@ -23,7 +36,10 @@ function loadCatalog(): EmojiShortcodeCatalog {
   if (catalog) {
     return catalog
   }
-  const grouped = Object.entries(emojiShortcodes).flatMap(([hexcode, value]) => {
+  if (!loadDataset) {
+    throw new Error('Emoji shortcode dataset loader was never registered')
+  }
+  const grouped = Object.entries(loadDataset()).flatMap(([hexcode, value]) => {
     const shortcodes = (typeof value === 'string' ? [value] : value).filter(
       (shortcode) => !SKIN_TONE_SHORTCODE.test(shortcode)
     )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​442 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​436 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |

<!-- /orca-pr-loc -->

## ELI5

When Orca launches, the main process does a short list of chores before it is allowed to open the window you actually look at. Two of those chores did not need to be in that line. One was waiting for the network-proxy setting to be written into Chromium; the other was loading the translated app menu. Neither is something the window needs in order to exist, so the window was just standing behind them.

This moves both out of the way. The proxy is still applied at exactly the same moment and still finishes before anything on the network happens — a separate gate already holds every request until it lands — but the window no longer waits for the confirmation. The menu is built at the same time the window is created instead of before it.

One smaller thing rides along: a 166 KB emoji dataset that only gets read when you name a workspace was being baked into the main bundle and JSON-parsed on every single launch; it is now read from disk the first time it is actually needed.

## Why it matters

Measured with `ORCA_STARTUP_DIAGNOSTICS`, best warm iteration on this machine:

- `f-claude-pty-seeded` -> `f-proxy-applied` = **24 ms**, with nothing between the two markers but the `await` on `applyElectronProxySettings`. That 24 ms sat entirely in front of `open-main-window-start`.
- `initializeMainProcessI18nAndMenu` = **8 ms** for English. Non-English adds a lazy locale chunk (`src/main/i18n/main-i18n.ts:26-30`, 380-616 KB), 2.6-5.5 ms to read and compile plus i18next ingestion — call it 15-20 ms for `ja`/`ko`/`es`/`zh`.
- Whole-phase context from the same trace: `app-ready` -> `open-main-window-start` = 91 ms; `open-main-window-start` -> `window-created` = 119 ms; `window-created` -> `did-finish-load` = 273 ms.

So this is roughly **32 ms (English) to 44 ms (non-English)** removed from in front of window creation, plus the 166 KiB main-bundle reduction below, against a 1.6-2.0 s time-to-workspace-ready. It is a real but small fraction. Several of these are two-line reorders, which is why they are worth taking.

## Measurement

### Bundle bytes (electron-vite production build, before/after on this branch)

| | before | after | delta |
|---|---|---|---|
| `out/main/index.js` | 7,210,071 B | 7,040,147 B | **-169,924 B (-166.0 KiB)** |

Renderer bytes are unchanged: the lazy-dialog item is no longer on this branch (see "What I did not ship"), so `verify-renderer-boot-graph` reports the same 342 chunks / 4368.4 KB as `main`.

Confirming the emoji dataset really left the main bundle (`water_buffalo` is a shortcode only that JSON carries):

```
$ grep -c water_buffalo out/main/index.js     # before
1
$ grep -c water_buffalo out/main/index.js     # after
0
$ grep -rl water_buffalo out/main/            # after: not in a split chunk either
(no output)
```

### Microbenchmark: the parse that used to run on every launch

Re-measured with `process.cpuUsage()` deltas rather than wall clock (this box runs ~24 agents;
wall-clock numbers on it are noise):

```
dataset bytes 170452
parse cpu 1.247 ms (keys 3979)
parse cpu 0.74 ms  (keys 3979)
parse cpu 1.408 ms (keys 3979)
parse cpu 0.711 ms (keys 3979)
parse cpu 1.273 ms (keys 3979)
```

That ran at main-bundle module-evaluation time on every start. It now runs only when a worktree name is first sanitized.

### Failing-test proof

The new/changed guards were run against `origin/main`'s sources (production files stashed, tests kept):

```
 FAIL  src/shared/emoji-shortcode-catalog.lazy.test.ts > emoji shortcode catalog laziness > keeps the 166 KB dataset off every module main statically imports
AssertionError: expected 'import emojiShortcodes from \'emojiba…' not to match /\bfrom '[^']*emojibase-data[^']*'/

 FAIL  src/shared/emoji-shortcode-catalog.lazy.test.ts > emoji shortcode catalog laziness > loads the main-side dataset synchronously into an identical catalog

 FAIL  src/main/startup/main-process-ready-phase-ordering.test.ts > ready-phase concurrency > creates the window without waiting for i18n and the native menu
AssertionError: expected [ 'foundation', …(2) ] to deeply equal [ 'foundation', …(4) ]

 FAIL  src/main/startup/main-process-ready-phase-ordering.test.ts > initial proxy application ordering > parks the default-session proxy apply instead of blocking window creation on it
AssertionError: expected 'import { app, session } from \'electr…' to contain 'state.initialProxyApplicationReady = …'

 FAIL  src/main/startup/main-process-ready-phase-ordering.test.ts > initial proxy application ordering > awaits the proxy after the window opens and before the desktop relay starts
AssertionError: expected -1 to be greater than 662

 FAIL  src/main/startup/main-process-ready-phase-ordering.test.ts > initial proxy application ordering > keeps headless serve strictly ordered behind the proxy apply
AssertionError: expected -1 to be greater than or equal to 0

 Test Files  2 failed (2)
      Tests  9 failed | 2 passed (11)
```

With the change:

```
 Test Files  2 passed (2)
      Tests  11 passed (11)
```

(The "creates the window without waiting for i18n" case is the load-bearing one for item 2: on `main` the i18n phase is awaited first, so with a deliberately-never-resolving i18n mock the launch phase never starts and the recorded event list stops at `i18n-start`. The two source-anchored proxy cases follow the existing `desktop-startup-ordering.test.ts` pattern, which is how this repo pins startup ordering.)

`src/main/proxy-guarded-fetch-call-site-audit.test.ts` (new, see Correctness) was verified failing by
introducing each violation it is meant to catch into `src/main/updater-nudge.ts` and reverting:

```
# adding `session: session.fromPartition('orca-nudge')` to the existing net.fetch options
 FAIL  proxy-guarded fetch call-site audit (main) > keeps every net.fetch/net.request on the guarded default session
AssertionError: This request names its own session/partition, so it is not covered by
installElectronProxyRequestGuard(session.defaultSession) and startup never applies the persisted
proxy to it. [...]: expected [ 'main/updater-nudge.ts:12' ] to deeply equal []

# routing the same call through `session.fromPartition('orca-nudge').fetch(...)` instead
 FAIL  proxy-guarded fetch call-site audit (main) > keeps every non-default-session fetcher audited with its expected count
AssertionError: A session.fromPartition(...) session is not covered by
installElectronProxyRequestGuard(session.defaultSession) [...]: expected
[ 'main/updater-nudge.ts: found 1 call(s)' ] to deeply equal []
```

`99fe1997400` then closed two holes the first version of those rules had, verified the same way with a
scratch file carrying one call site per shape (each is caught, and the file is deleted again):

```
# net.request({ url, session }) and net.request({ url, partition })  -- object shorthand
 FAIL  ... > keeps every net.fetch/net.request on the guarded default session
expected [ 'main/tmp-violation-probe.ts:12', 'main/tmp-violation-probe.ts:6',
           'main/tmp-violation-probe.ts:9' ] to deeply equal []

# session.fromPartition('x').fetch(url), holder.s.fetch(url), session2.fetch(url)
 FAIL  ... > keeps every non-default-session fetcher audited with its expected count
expected [ 'main/tmp-violation-probe.ts: found 3 call(s)' ] to deeply equal []
```

Before that commit the shorthand and the two non-identifier receivers (`....fetch(`, `a.b.fetch(`)
all passed silently; only line 6 and the bare `session2.fetch(` were caught. The audited counts did
not move (2/2/1), so no real call site changed classification.

### Performance is unchanged by the audit commits

The audit is test-only, so none of the numbers above move. Verified deterministically rather than by
timing:

```
$ git diff bc1307d8bac..HEAD --stat -- . ':!*.test.ts' ':!*.test.mjs'
(no output)
```

i.e. the two audit commits (`46131460e72`, `99fe1997400`) add and then tighten one `.test.ts` file and
change zero production lines -- the diff above is empty at both. The 24 ms proxy hoist,
the 8 ms i18n overlap and the 166 KiB main-bundle drop are all byte-for-byte the same code as the
head that was measured.

## Correctness

**Item 1 — the proxy await.** The safety claim is *not* "no fetcher runs in that window". It does: `src/main/claude-accounts/oauth-refresh.ts:142` issues `net.fetch(OAUTH_TOKEN_URL)`, reached synchronously from `new ClaudeRuntimeAuthService(store)` -> `void this.safeSyncForCurrentSelection()` -> `runtime-auth-sync.ts:250` -> `refreshManagedAccountTokenIfNeeded`, during `initializeReadyRuntimeServices`. The updater nudge/prerelease feed and the rate-limit fetchers follow at the `ready-to-show` / +1000 ms boundary.

The reason the hoist is safe is that **`installElectronProxyRequestGuard` (`src/main/network/electron-proxy-request-guard.ts`, installed at `main-process-ready-foundation.ts:56` and again at `:143`) is what enforces the ordering, not the `await`.** It hooks `defaultSession.webRequest.onBeforeRequest` and *awaits* `getProxySessionApplicationReadiness` — it holds the request until the newest proxy transition settles rather than cancelling it (see the existing `electron-proxy-request-guard.test.ts` case "holds renderer requests until a delayed proxy transition settles"). Every fetcher above uses `net.fetch`/`net.request` with no explicit session, so they all land on `defaultSession` and are all held. Verified empirically on this repo's Electron 43 (standalone probe app, main-process `net.fetch` against a loopback server): the `defaultSession` `onBeforeRequest` listener sees the request URL, `cb({cancel:true})` fails it with `net::ERR_BLOCKED_BY_CLIENT`, and a listener that defers its callback by 500 ms delays the `net.fetch` by the same 500 ms. So a main-process `net.fetch` really is held by the guard, not merely observed by it. The `await` in `initializeReadyFoundation` was therefore redundant for ordering and only queued `openMainWindow` behind a `setProxy` round trip.

The apply itself is unchanged: `applyElectronProxySettings(store.getSettings())` is still called at the same line, before the guard is (re-)installed, so the guard still observes pending readiness from the same instant. The `invalid-settings` and failure `console.warn`s were moved onto the parked promise's settle handlers, so they fire at the same moment they did before, not later. Attaching the handlers synchronously also closes a small unhandled-rejection window that existed while the promise sat unawaited for ~90 lines.

The phase postcondition is preserved: `initializeMainProcessReady` still does not resolve until the proxy has settled, because `launchDesktopMode` awaits it (after the window, before `new DesktopRelayService`) and `launchServeMode` awaits it at its top. Headless serve therefore keeps the strict "proxy before anything" ordering it had, since it has no window to unblock. Rejection behaviour is identical: the old `try/catch` swallowed failures and so does the new rejection handler, so `await state.initialProxyApplicationReady` can never throw.

`applyBrowserSessionProxies` is unaffected: it operates on `session.fromPartition(...)` objects with their own per-session state in `sessionProxyApplications` (a `WeakMap` keyed by session), so it was never ordered against the default session's apply — only against the resolver registration, which still precedes it.

**Item 2 — i18n/menu concurrency.** Nothing on the window-creation path imports `main-i18n`: `translateMain` consumers are `system-tray.ts`, `main-window-close-lifecycle.ts`, `editable-context-menu.ts`, `runtime-rpc-startup-failure.ts`, `register-app-menu.ts`, `settings.ts` and the i18n/menu phase itself — none of which `createMainWindow`, `main-window-controller.ts`, `main-window-core-services.ts` or `main-window-service-readiness.ts` reach. The tray is created on `ready-to-show`, which is after `did-finish-load`. Menu ordering is safe because Electron's `Menu.setApplicationMenu` applies to already-created windows (it iterates `BrowserWindow.getAllWindows()` on Windows/Linux and is global on macOS), and `createMainWindow` sets `autoHideMenuBar: true` and never calls `window.setMenu`, so there is nothing for a late `registerAppMenu` to race. `Promise.all` (rather than a bare parallel start) keeps both settled before the phase resolves and attaches handlers to both, so neither can become an unhandled rejection.

**Item 4 — the emoji dataset.** `src/shared/emoji-shortcode-catalog.ts` no longer imports the dataset itself; it takes a synchronous loader. Both consumers register one at module scope of the only module that reaches the catalog in their bundle, so the loader is always set before the first call:

- renderer: `workspace-emoji-shortcodes.ts` keeps its **eager** static import and registers `() => emojiShortcodes`. Byte-for-byte the same renderer behaviour — no dynamic import, no await, no window in which the transform can return an empty catalog. `config/scripts/renderer-boot-graph.mjs:44-48` documents why that must not change, and this PR does not change it.
- main: `deferred-emoji-shortcode-dataset.ts` registers a `createRequire(__filename)` loader, the same pattern already used by `src/main/linear/linear-sdk.ts`. `require()` is synchronous, so `loadCatalog()` keeps its exact contract; a new test asserts the deferred path produces an `toEqual`-identical entry list and an identical `replaceKnownEmojiWithShortcodes` output with no await between registration and first use.

**Packaging (corrected in `bc1307d8bac`).** The original claim here — that `emojibase-data` ships inside `app.asar` because it is a production dependency — was wrong on both counts, and it was a P0. `app.asar` carries **zero** `node_modules` entries (verified against the shipped 1.4.197 build: `asar.listPackage(...).filter(e => e.includes('node_modules')).length === 0`), so every bare `require` from packaged main resolves out of `Resources/node_modules`, which is the explicit allowlist in `config/packaged-runtime-node-modules.cjs` (`PACKAGED_RUNTIME_PACKAGE_ROOTS`). That is how `@linear/sdk` works. `emojibase-data` is a **devDependency** (`package.json:237`) and was in neither place — `find /Applications/Orca.app -name 'emojibase*'` returns nothing — so `requireEmojiShortcodeDataset()` would have thrown `MODULE_NOT_FOUND` in every packaged build, taking `sanitizeWorktreeName` and therefore **all workspace creation** down with it. Dev builds resolve from the repo checkout, which is why local testing did not catch it.

`verifyPackagedMainRuntimeDeps` does not catch this either: it regexes `out/main/index.js` for literal `require("x")`, and the bundler renames the `createRequire` binding (`grep 'require("@linear/sdk")'` on the shipped bundle: no match).

The fix copies the single 166 KB dataset file — not the 49 MB package root — into `Resources/node_modules` via `commonExtraResources`, so the bare specifier resolves unchanged and the bundle/parse win is kept in full. `emojibase-data` has no `exports` field, so the one JSON file is sufficient for subpath resolution. Two new gates in `config/scripts/electron-builder-runtime-resources.test.mjs`: one resolves the dataset through a simulated `Resources/app.asar/out/main` → `Resources/node_modules` walk, and one asserts every `createRequire`'d bare specifier under `src/main` is covered by the packaged resource plan on all three platforms (Windows-native loaders excepted). Both fail on the pre-fix config.

**Edge cases.**

- *SSH / folder workspaces*: nothing here branches on workspace kind or execution host. `sanitizeWorktreeName` is unchanged in behaviour and still synchronous, so remote and folder-workspace naming are untouched.
- *Headless `orca serve`*: gets its proxy await at the top of `launchServeMode`, ahead of the WSL barrier, headless PTY runtime, `runtimeRpc.start()`, the CLI install and `printServeReady` — strictly stronger ordering than the desktop path, and equivalent to today.
- *Windows*: the early-window path (`startWindowsDesktopBeforeShellPathReady`) is untouched; it already opens the window before `shellPathReady`, and it flows into the same `launchDesktopMode` await.
- *Empty/missing state*: `mainProcessState.initialProxyApplicationReady` defaults to `Promise.resolve()`, so any path that never runs the foundation (tests, `orca` CLI entry) awaits a no-op, exactly like `shellPathReady` and `managedWslCliStartupBarrierReady`.
- *Wire compatibility*: no RPC params, stream frames or published content change.

**The guard's precondition is now enforced by CI, not by review.** "Every app-owned request lands on `defaultSession`, where the guard holds it" is the one invariant the hoist depends on. It held when this was written (all 18 `net.fetch`/`net.request` sites under `src/main` pass no session option), but nothing stopped a future fetcher from quietly routing around it. `src/main/proxy-guarded-fetch-call-site-audit.test.ts` (new, modelled on the existing `src/main/global-fetch-call-site-audit.test.ts`) makes both escape routes fail loudly:

1. no `net.fetch(` / `net.request(` under `src/main` may name a session: neither a `session:` / `partition:` key nor the `{ url, session }` object shorthand that both `net.request` overloads accept. The test balances parentheses from the call site to read the real argument text (skipping string bodies), so it is not fooled by line wrapping;
2. every `.fetch(` call site whose receiver is not a literal `net` / `globalThis` / `global` is counted per file against an allowlist, so a new non-default-session fetcher fails until it is audited — including the receivers with no bare identifier to key off, `session.fromPartition(...).fetch(...)` and `ctx.session.fetch(...)`. The allowlist is `opencode-go-usage-fetcher.ts` (2 — its session *is* proxied by `createOpenCodeRequestSession`), `minimax-request-context.ts` (2 — its session is **not** proxied, see below), and `jira/authenticated-request.ts` (1 — an injected `HttpClient`, not a session, which resolves to `net.fetch` on `defaultSession`). `globalThis.fetch`/`global.fetch` are excluded because `global-fetch-call-site-audit.test.ts` already owns them.

Both rules were verified failing (transcript above). This is worth noting because the same audit also covers the identical assumption on `origin/main`'s post-startup proxy transitions (`ipc/settings.ts:203-215` and every `ensureElectronProxyFromEnvironment` caller), where the guard has always been the sole ordering authority.

**Pre-existing gaps the audit surfaces but does not close (for separate tickets), neither introduced nor worsened here:**

- electron-updater issues its own requests on `session.fromPartition('electron-updater', {cache:false})` (`node_modules/electron-updater/out/electronHttpExecutor.js:8,52`), which neither the request guard nor `applyElectronProxySettings` touches. Third-party code, so out of the audit's reach; noted in the test's header comment.
- `main/rate-limits/minimax-request-context.ts` fetches on `session.fromPartition('orca-minimax-rate-limit-fetch')` and never applies a proxy to it, unlike its opencode-go sibling. `applyElectronProxySettings` has only ever configured `defaultSession`, so the `await` this PR removes never covered that partition either — the behaviour is identical before and after. It is now listed in the audit allowlist with that gap spelled out, so it stays visible instead of being rediscovered.

## Negative user-facing trade-offs

Not "None" — one, and it is a log-ordering detail:

1. **A `console.warn` for an invalid or failed proxy apply is no longer guaranteed to be printed before `openMainWindow` runs.** It fires at the same wall-clock moment as before (the handlers are attached synchronously to the same promise), but its position relative to other startup logs can shift. Nothing branches on it.

**Removed since the last review:** the "first open of a lazy dialog waits on a chunk fetch" trade-off is gone, because the lazy-dialog item is no longer on this branch at all — `NewWorkspaceComposerCard.tsx` and `SidebarSettingsHelpMenu.tsx` are byte-identical to `main`. There is no longer any first-open latency cost, and no renderer behaviour change of any kind in this PR.

Explicitly *not* traded away: no new cap, cadence, debounce, threshold, sampling window or reduced coverage; the proxy is applied at the identical moment and no request can escape it — and, as of `46131460e72` / `99fe1997400`, that last clause is a CI-enforced assertion rather than a claim.

## What I did not ship from the brief

**Item 3 (lazy renderer chunks) in full.** Two of the seven chunks fit `lazy-with-retry` cleanly and were on an earlier revision of this branch, but they are no longer here: this PR is now main-process startup ordering plus the emoji dataset only, and it changes no renderer component. That also removed the only user-visible trade-off the PR had. The other five were never viable:

- `worktree-creation-flow` (19.0 KB) and `delete-worktree-flow` (13.4 KB) are plain function modules, not components — `lazy-with-retry` does not apply, and they have 2 and 12 **synchronous** call sites respectively. Deferring them means turning those call sites async, which is the same class of change as the reverted emoji dynamic import.
- `SkillFreshnessUpdateDialog` (7.2 KB) must stay mounted: it is the subscriber to `skill-freshness-update-dialog`'s request store (`subscribeSkillFreshnessUpdateDialog`), so an unmounted dialog would miss requests. Deferring it safely needs the subscription hoisted into `AppRootSurfaces`, which is a bigger change than 7 KB justifies.
- `SshHostAdvancedFields` (8.3 KB) owns its own "Advanced" disclosure trigger (`open`/`onOpenChange` are its props), so lazying it removes the click target — exactly what the brief says not to do.
- `CliSkillRuntimeSetup` (6.8 KB) is a shared helper module with ~20 importers, most of them type-only. Not a dialog.

## Test plan

```
nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/main/startup src/main/network src/shared/emoji-shortcode-catalog.lazy.test.ts \
  src/renderer/src/lib/workspace-emoji-shortcodes.lazy.test.ts src/main/ipc/worktree-logic.test.ts
# 55 passed | 1 skipped (56 files), 586 passed | 6 skipped

nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/ipc/worktree
# 65 files, 805 passed

nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/main/proxy-guarded-fetch-call-site-audit.test.ts src/main/global-fetch-call-site-audit.test.ts \
  src/main/startup/main-process-ready-phase-ordering.test.ts \
  src/main/network/proxy-settings.test.ts src/main/network/proxy-settings-session.test.ts \
  src/main/network/electron-proxy-request-guard.test.ts \
  src/shared/emoji-shortcode-catalog.lazy.test.ts
# 7 files, 52 passed (re-run at 99fe1997400)

node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false   # clean
node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.cli.json --composite false # clean
node_modules/.bin/oxlint <changed files>                                        # clean
node config/scripts/run-electron-vite-build.mjs                                 # boot-graph gate passes
```

Manual check worth doing on review: create a workspace with an emoji in the name and confirm it still slugifies to the shortcode (that is the only user-reachable path the emoji-dataset change touches).

## Changes since review (`2ed433c58cb`)

Rebased onto `main` (picks up the fr.json catalog fix from #18550, which is what `static analysis` was red on). Three follow-ups on top:

1. **Typecheck (the real failure).** TS6307 in two directions:
   - `tsconfig.tc.web.json` lists `src/main/ipc/worktree-logic.ts`, which now imports `src/main/ipc/deferred-emoji-shortcode-dataset.ts` — that file is now listed too.
   - `tsconfig.tc.cli.json` includes `src/shared/**/*`, and `emoji-shortcode-catalog.lazy.test.ts` had one case importing `../main/ipc/deferred-emoji-shortcode-dataset.js`. Rather than drag a `createRequire` main module into the CLI project, that case moved to `src/main/ipc/deferred-emoji-shortcode-dataset.test.ts` — which restores the boundary the shared test's own comment asserts. All three projects clean.
2. **The i18n race is now closed, not just documented.** `mainProcessState.mainProcessI18nReady` is published synchronously in `main-process-ready.ts` before the launch phase is invoked, and `launchDesktopMode` chains the runtime-RPC failure dialog off it. Still `void`, not `await`: the wait is on i18n, never on the modal, and it is failure-only. `desktop-startup-ordering.test.ts` pins the new shape and now also asserts no `await ... showRuntimeRpcStartupFailureDialog(`.
3. **Audit whitespace hole.** `net.fetch (url, { session })` and `x .fetch(url)` slipped both rules because each regex required `(` immediately after the member name; both now use `\s*\(`. Verified failing against a scratch probe carrying one call per shape (deleted again); audited counts unchanged at 2 / 2 / 1.

**Win is intact.** The whole production diff of this commit is 14 added / 5 removed lines across `main-process-ready.ts`, `main-process-runtime-launch.ts` and `main-process-state.ts` — an error-path chain and one `Promise.resolve()` field. Nothing on the emoji path, the proxy hoist or the bundle changed, and `main-process-state` was already imported by all three sibling phase modules, so no module was added to main's evaluation graph. The deterministic guard for the overlap — "creates the window without waiting for i18n and the native menu", which records the phase event list against a never-resolving i18n mock — still passes.
