### PR TITLE
perf(terminal): scan only new tail lines for the wait-blocked sentinel

### DIFF
--- a/src/main/runtime/terminal-tail-buffer.test.ts
+++ b/src/main/runtime/terminal-tail-buffer.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appendNormalizedToTailBuffer } from './terminal-tail-buffer'
+import { MAX_TAIL_LINES } from './terminal-tail-limits'
+import type { RetainedTailRedrawCursor } from './terminal-tail-redraw-buffer'
+
+// Guards the per-chunk prefix work in appendNormalizedToTailBuffer: the retained char total is
+// carried across appends and the redraw prefix is not re-scanned, so a saturated tail must not be
+// walked once per chunk. Correctness is pinned by the cold/warm differential below — a "cold" run
+// hands every append a fresh array so the memo always misses and every total is summed in full.
+
+type TailSim = {
+  lines: string[]
+  partialLine: string
+  redrawCursor: RetainedTailRedrawCursor | null
+}
+
+function newSim(): TailSim {
+  return { lines: [], partialLine: '', redrawCursor: null }
+}
+
+type Step = ReturnType<typeof appendNormalizedToTailBuffer>
+
+function feed(sim: TailSim, chunk: string, cold: boolean): Step {
+  const next = appendNormalizedToTailBuffer(
+    cold ? [...sim.lines] : sim.lines,
+    sim.partialLine,
+    chunk,
+    sim.redrawCursor
+  )
+  sim.lines = next.lines
+  sim.partialLine = next.partialLine
+  sim.redrawCursor = next.redrawCursor
+  return next
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = Math.imul(state ^ (state >>> 15), 1 | state)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const ESC = String.fromCharCode(27)
+
+/**
+ * `short` fills the 2000-line cap and mixes in TUI redraws; `long` streams lines wide enough to
+ * hit the 256 KiB character cap first. Both eviction paths adjust the carried character total, so
+ * both need differential coverage, and a redraw's row truncation would keep `long` off its cap.
+ */
+function randomChunk(random: () => number, profile: 'short' | 'long'): string {
+  const roll = random()
+  if (profile === 'long') {
+    if (roll < 0.7) {
+      return `${'w'.repeat(1000 + Math.floor(random() * 3000))}\n`
+    }
+    if (roll < 0.8) {
+      return `\rspinner ${Math.floor(random() * 100)}%`
+    }
+    if (roll < 0.9) {
+      return 'trailing spaces here   \n'
+    }
+    return roll < 0.95 ? '' : `no newline ${Math.floor(random() * 1000)}`
+  }
+  if (roll < 0.22) {
+    const lines: string[] = []
+    for (let index = 0; index < 30; index += 1) {
+      lines.push(`burst ${Math.floor(random() * 1e6)}${random() < 0.3 ? '   ' : ''}`)
+    }
+    return `${lines.join('\n')}\n`
+  }
+  if (roll < 0.42) {
+    return `plain output ${Math.floor(random() * 1e6)}\n`
+  }
+  if (roll < 0.56) {
+    return `${'   '.repeat(Math.floor(random() * 3))}\n`
+  }
+  if (roll < 0.68) {
+    const rows = 1 + Math.floor(random() * 12)
+    return `${ESC}[${rows}A${ESC}[2Kredrawn ${Math.floor(random() * 1000)}\n`
+  }
+  if (roll < 0.8) {
+    return `\rspinner ${Math.floor(random() * 100)}%`
+  }
+  if (roll < 0.86) {
+    return 'trailing spaces here   \n'
+  }
+  if (roll < 0.92) {
+    return `multi\nline\nchunk ${Math.floor(random() * 1000)}\n`
+  }
+  if (roll < 0.96) {
+    return ''
+  }
+  return `no newline ${Math.floor(random() * 1000)}`
+}
+
+describe('retained tail buffer prefix reuse', () => {
+  for (const profile of ['short', 'long'] as const) {
+    for (const seed of [3, 11, 91, 2024]) {
+      it(`carries the retained char total exactly (${profile}, seed ${seed})`, () => {
+        const random = mulberry32(seed)
+        const warm = newSim()
+        const cold = newSim()
+        let sawCap = false
+        for (let step = 0; step < 1400; step += 1) {
+          const chunk = randomChunk(random, profile)
+          const lineCountBefore = warm.lines.length
+          const warmStep = feed(warm, chunk, false)
+          const coldStep = feed(cold, chunk, true)
+          expect(warmStep.lines, `step ${step} lines`).toEqual(coldStep.lines)
+          expect(warmStep.partialLine, `step ${step} partial`).toBe(coldStep.partialLine)
+          expect(warmStep.truncated, `step ${step} truncated`).toBe(coldStep.truncated)
+          expect(warmStep.redrawCursor, `step ${step} cursor`).toEqual(coldStep.redrawCursor)
+          expect(warmStep.newCompleteLines, `step ${step} newCompleteLines`).toBe(
+            coldStep.newCompleteLines
+          )
+          expect(warmStep.newlyCompletedLines, `step ${step} newlyCompletedLines`).toEqual(
+            coldStep.newlyCompletedLines
+          )
+          sawCap =
+            sawCap ||
+            (profile === 'short'
+              ? warm.lines.length >= MAX_TAIL_LINES
+              : // Lines dropped below the line cap on an append-only chunk == character-cap eviction.
+                !chunk.includes(ESC) &&
+                warm.lines.length < MAX_TAIL_LINES &&
+                lineCountBefore + warmStep.newlyCompletedLines.length > warm.lines.length)
+        }
+        // Guard against a vacuous pass: the profile's eviction path must have run.
+        expect(sawCap).toBe(true)
+      })
+    }
+  }
+
+  it('does not walk the untouched redraw prefix on every chunk', () => {
+    const sim = newSim()
+    for (let index = 0; index < MAX_TAIL_LINES + 200; index += 1) {
+      feed(sim, `streaming build output line ${index}\n`, false)
+    }
+    expect(sim.lines.length).toBe(MAX_TAIL_LINES)
+
+    const redrawChunk = `${ESC}[3A${ESC}[2Krewritten row${ESC}[2B\n`
+    const spy = vi.spyOn(String.prototype, 'charCodeAt')
+    let prefixTouches = 0
+    try {
+      feed(sim, redrawChunk, false)
+      prefixTouches = spy.mock.calls.length
+    } finally {
+      spy.mockRestore()
+    }
+    // Before this change the prefix trailing-space scan alone cost one charCodeAt per retained
+    // row (~1990); the chunk itself accounts for well under a hundred.
+    expect(prefixTouches).toBeLessThan(300)
+  })
+})

--- a/src/main/runtime/terminal-tail-buffer.ts
+++ b/src/main/runtime/terminal-tail-buffer.ts
@@ -1,4 +1,5 @@
 import { containsTerminalVerticalLineControl } from './terminal-ansi-normalization'
+import { carryTerminalTailSentinelMatches } from './terminal-tail-sentinel-index'
 import {
   applyTerminalLineControls,
   processTerminalTailCompleteSegments,
@@ -10,6 +11,35 @@ import {
   appendNormalizedToMultilineTailBufferUnwindowed,
   type RetainedTailRedrawCursor
 } from './terminal-tail-redraw-buffer'
+
+type RetainedTailLineStats = {
+  totalChars: number
+  /** Whether every line is already right-trimmed, so the redraw prefix trim is a no-op. */
+  rightTrimmed: boolean
+}
+
+// Why weak + array-keyed: the tail is replaced (never mutated) on every append, so an entry dies
+// with the array it describes and only the live tail per PTY is retained. Carrying the char total
+// this way replaces a full-tail re-sum on every chunk.
+const tailLineStatsByLines = new WeakMap<readonly string[], RetainedTailLineStats>()
+
+function getRetainedTailLineStats(lines: readonly string[]): RetainedTailLineStats {
+  const cached = tailLineStatsByLines.get(lines)
+  if (cached) {
+    return cached
+  }
+  let totalChars = 0
+  let rightTrimmed = true
+  for (const line of lines) {
+    totalChars += line.length
+    if (rightTrimmed && trimTerminalLineRight(line) !== line) {
+      rightTrimmed = false
+    }
+  }
+  const stats = { totalChars, rightTrimmed }
+  tailLineStatsByLines.set(lines, stats)
+  return stats
+}
 
 export function appendNormalizedToTailBuffer(
   previousLines: string[],
@@ -52,7 +82,13 @@ export function appendNormalizedToTailBuffer(
   // Why: status UIs redraw one line via CR/backspace/erase; retain the latest redraw segment instead of appending every spinner frame.
   const segments = splitRetainedTerminalTailSegments(combinedChunk)
   const pieces = processTerminalTailCompleteSegments(segments.completeSegments)
-  const newlyCompletedLines = pieces.map((line) => trimTerminalLineRight(line))
+  const newlyCompletedLines: string[] = []
+  let newlyCompletedChars = 0
+  for (const piece of pieces) {
+    const line = trimTerminalLineRight(piece)
+    newlyCompletedLines.push(line)
+    newlyCompletedChars += line.length
+  }
   const partialResult = applyTerminalLineControls(segments.partialSegment)
   const nextPartialLine = trimTerminalLineRight(partialResult.text)
   const retainedPartialLine = nextPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS)
@@ -67,26 +103,49 @@ export function appendNormalizedToTailBuffer(
     omittedNewCompleteLines > 0 ||
     nextPartialLine.length > MAX_TAIL_PARTIAL_CHARS
 
+  // The plain path only ever appends, so the whole previous tail carries unless it was discarded.
+  const carriesPreviousLines = newCompleteLines === 0 || omittedNewCompleteLines === 0
+  const previousStats = carriesPreviousLines ? getRetainedTailLineStats(previousLines) : null
+  let carriedSourceStart = 0
+  let carriedCount = carriesPreviousLines ? previousLines.length : 0
+  let nextLinesChars =
+    (previousStats?.totalChars ?? 0) + (newCompleteLines > 0 ? newlyCompletedChars : 0)
+
   if (nextLines.length > MAX_TAIL_LINES) {
-    nextLines = nextLines.slice(nextLines.length - MAX_TAIL_LINES)
+    const evictedCount = nextLines.length - MAX_TAIL_LINES
+    for (let index = 0; index < evictedCount; index += 1) {
+      nextLinesChars -= nextLines[index]!.length
+    }
+    nextLines = nextLines.slice(evictedCount)
     truncated = true
+    const carriedShift = Math.min(evictedCount, carriedCount)
+    carriedSourceStart += carriedShift
+    carriedCount -= carriedShift
   }
 
   if (newCompleteLines > 0 || retainedPartialLine.length > previousPartialLine.length) {
-    if (nextLines === previousLines) {
-      nextLines = [...previousLines]
-    }
-    let totalChars =
-      nextLines.reduce((sum, line) => sum + line.length, 0) + retainedPartialLine.length
+    let totalChars = nextLinesChars + retainedPartialLine.length
     let trimStartIndex = 0
     while (trimStartIndex < nextLines.length && totalChars > MAX_TAIL_CHARS) {
-      totalChars -= nextLines[trimStartIndex].length
+      totalChars -= nextLines[trimStartIndex]!.length
       trimStartIndex += 1
     }
     if (trimStartIndex > 0) {
+      nextLinesChars = totalChars - retainedPartialLine.length
       nextLines = nextLines.slice(trimStartIndex)
       truncated = true
+      const carriedShift = Math.min(trimStartIndex, carriedCount)
+      carriedSourceStart += carriedShift
+      carriedCount -= carriedShift
     }
+  }
+
+  if (nextLines !== previousLines) {
+    tailLineStatsByLines.set(nextLines, {
+      totalChars: nextLinesChars,
+      rightTrimmed: carriedCount === 0 || (previousStats?.rightTrimmed ?? true)
+    })
+    carryTerminalTailSentinelMatches(previousLines, nextLines, carriedSourceStart, carriedCount)
   }
 
   const redrawCursor =
@@ -145,13 +204,23 @@ function appendNormalizedToMultilineTailBuffer(
   const windowRows =
     maxUpwardCursorReach(normalizedChunk, previousRedrawCursor) + REDRAW_WINDOW_SAFETY_ROWS
   if (windowRows >= previousLines.length) {
-    return appendNormalizedToMultilineTailBufferUnwindowed(
+    const unwindowed = appendNormalizedToMultilineTailBufferUnwindowed(
       previousLines,
       boundedPreviousPartialLine,
       normalizedChunk,
       previousPartialWasCapped,
       previousRedrawCursor
     )
+    if (unwindowed.lines !== previousLines) {
+      let totalChars = 0
+      for (const line of unwindowed.lines) {
+        totalChars += line.length
+      }
+      // Why nothing carries: an unwindowed redraw may rewrite any retained row.
+      tailLineStatsByLines.set(unwindowed.lines, { totalChars, rightTrimmed: true })
+      carryTerminalTailSentinelMatches(previousLines, unwindowed.lines, 0, 0)
+    }
+    return unwindowed
   }
   const prefixLength = previousLines.length - windowRows
   const suffix = previousLines.slice(prefixLength)
@@ -162,36 +231,59 @@ function appendNormalizedToMultilineTailBuffer(
     previousPartialWasCapped,
     previousRedrawCursor
   )
+  const previousStats = getRetainedTailLineStats(previousLines)
   let lines = previousLines.slice(0, prefixLength)
-  // Why: the shared prefix must match the unwindowed finalize's trailing-space trim without paying a regex per untouched row.
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index]!
-    const lastChar = line.charCodeAt(line.length - 1)
-    if (lastChar === 32 || lastChar === 9) {
-      lines[index] = line.replace(/[ \t]+$/g, '')
+  let linesChars = previousStats.totalChars
+  for (const line of suffix) {
+    linesChars -= line.length
+  }
+  let carriedSourceStart = 0
+  let carriedCount = prefixLength
+  if (!previousStats.rightTrimmed) {
+    // Why: the shared prefix must match the unwindowed finalize's trailing-space trim without paying a regex per untouched row.
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index]!
+      const lastChar = line.charCodeAt(line.length - 1)
+      if (lastChar === 32 || lastChar === 9) {
+        const trimmed = line.replace(/[ \t]+$/g, '')
+        lines[index] = trimmed
+        linesChars -= line.length - trimmed.length
+        carriedCount = 0
+      }
     }
   }
   for (const line of windowed.lines) {
     lines.push(line)
+    linesChars += line.length
   }
   let truncated = windowed.truncated
   if (lines.length > MAX_TAIL_LINES) {
-    lines = lines.slice(lines.length - MAX_TAIL_LINES)
+    const evictedCount = lines.length - MAX_TAIL_LINES
+    for (let index = 0; index < evictedCount; index += 1) {
+      linesChars -= lines[index]!.length
+    }
+    lines = lines.slice(evictedCount)
     truncated = true
+    const carriedShift = Math.min(evictedCount, carriedCount)
+    carriedSourceStart += carriedShift
+    carriedCount -= carriedShift
   }
-  let totalChars = windowed.partialLine.length
-  for (const line of lines) {
-    totalChars += line.length
-  }
+  let totalChars = linesChars + windowed.partialLine.length
   let dropCount = 0
   while (dropCount < lines.length && totalChars > MAX_TAIL_CHARS) {
     totalChars -= lines[dropCount]!.length
     dropCount += 1
   }
   if (dropCount > 0) {
+    linesChars = totalChars - windowed.partialLine.length
     lines = lines.slice(dropCount)
     truncated = true
+    const carriedShift = Math.min(dropCount, carriedCount)
+    carriedSourceStart += carriedShift
+    carriedCount -= carriedShift
   }
+  tailLineStatsByLines.set(lines, { totalChars: linesChars, rightTrimmed: true })
+  carryTerminalTailSentinelMatches(previousLines, lines, carriedSourceStart, carriedCount)
   return {
     lines,
     partialLine: windowed.partialLine,

--- a/src/main/runtime/terminal-tail-buffer.ts
+++ b/src/main/runtime/terminal-tail-buffer.ts
@@ -41,6 +41,93 @@ function getRetainedTailLineStats(lines: readonly string[]): RetainedTailLineSta
   return stats
 }
 
+type CarriedTailBuild = {
+  lines: string[]
+  /** Whether a retention cap dropped a row. */
+  truncated: boolean
+}
+
+/**
+ * The only way to produce a next tail array: `previousLines[keepStart, keepEnd) ++ appended`,
+ * capped by `MAX_TAIL_LINES` and — when `charCapPartialChars` is non-null — `MAX_TAIL_CHARS`.
+ *
+ * Why a constructor rather than three call sites doing their own arithmetic: the carried-match
+ * window handed to the sentinel index, the character total, and the array itself are all derived
+ * here from the same keep bounds, including whatever the caps drop, so they cannot disagree. The
+ * one thing a caller still has to get right is that every row in `appended` is already
+ * right-trimmed, which every producer of retained rows does.
+ */
+function buildCarriedTailLines(
+  previousLines: string[],
+  keepStart: number,
+  keepEnd: number,
+  appended: readonly string[],
+  charCapPartialChars: number | null
+): CarriedTailBuild {
+  const keptCount = keepEnd > keepStart ? keepEnd - keepStart : 0
+  let totalChars = 0
+  let carriedRightTrimmed = true
+  if (keptCount > 0) {
+    const previousStats = getRetainedTailLineStats(previousLines)
+    totalChars = previousStats.totalChars
+    carriedRightTrimmed = previousStats.rightTrimmed
+    for (let index = 0; index < keepStart; index += 1) {
+      totalChars -= previousLines[index]!.length
+    }
+    for (let index = keepEnd; index < previousLines.length; index += 1) {
+      totalChars -= previousLines[index]!.length
+    }
+  }
+  for (const line of appended) {
+    totalChars += line.length
+  }
+
+  // Both caps only ever drop from the front, so resolve them against the virtual concatenation
+  // before the array exists; the surviving keep bounds then define the carried window exactly.
+  const combinedLength = keptCount + appended.length
+  let dropCount = combinedLength > MAX_TAIL_LINES ? combinedLength - MAX_TAIL_LINES : 0
+  for (let index = 0; index < dropCount; index += 1) {
+    totalChars -= (
+      index < keptCount ? previousLines[keepStart + index]! : appended[index - keptCount]!
+    ).length
+  }
+  if (charCapPartialChars !== null) {
+    const charBudget = MAX_TAIL_CHARS - charCapPartialChars
+    while (dropCount < combinedLength && totalChars > charBudget) {
+      totalChars -= (
+        dropCount < keptCount
+          ? previousLines[keepStart + dropCount]!
+          : appended[dropCount - keptCount]!
+      ).length
+      dropCount += 1
+    }
+  }
+
+  if (
+    dropCount === 0 &&
+    appended.length === 0 &&
+    keepStart === 0 &&
+    keepEnd === previousLines.length
+  ) {
+    return { lines: previousLines, truncated: false }
+  }
+
+  const droppedFromCarried = dropCount < keptCount ? dropCount : keptCount
+  const carriedSourceStart = keepStart + droppedFromCarried
+  const carriedCount = keptCount - droppedFromCarried
+  const lines = previousLines.slice(carriedSourceStart, keepEnd)
+  for (let index = dropCount - droppedFromCarried; index < appended.length; index += 1) {
+    lines.push(appended[index]!)
+  }
+
+  tailLineStatsByLines.set(lines, {
+    totalChars,
+    rightTrimmed: carriedCount === 0 || carriedRightTrimmed
+  })
+  carryTerminalTailSentinelMatches(previousLines, lines, carriedSourceStart, carriedCount)
+  return { lines, truncated: dropCount > 0 }
+}
+
 export function appendNormalizedToTailBuffer(
   previousLines: string[],
   previousPartialLine: string,
@@ -83,70 +170,34 @@ export function appendNormalizedToTailBuffer(
   const segments = splitRetainedTerminalTailSegments(combinedChunk)
   const pieces = processTerminalTailCompleteSegments(segments.completeSegments)
   const newlyCompletedLines: string[] = []
-  let newlyCompletedChars = 0
   for (const piece of pieces) {
-    const line = trimTerminalLineRight(piece)
-    newlyCompletedLines.push(line)
-    newlyCompletedChars += line.length
+    newlyCompletedLines.push(trimTerminalLineRight(piece))
   }
   const partialResult = applyTerminalLineControls(segments.partialSegment)
   const nextPartialLine = trimTerminalLineRight(partialResult.text)
   const retainedPartialLine = nextPartialLine.slice(-MAX_TAIL_PARTIAL_CHARS)
   const newCompleteLines = segments.completeLineCount
   const omittedNewCompleteLines = newCompleteLines - pieces.length
-  let nextLines =
-    newCompleteLines > 0
-      ? [...(omittedNewCompleteLines > 0 ? [] : previousLines), ...newlyCompletedLines]
-      : previousLines
-  let truncated =
-    previousPartialWasCapped ||
-    omittedNewCompleteLines > 0 ||
-    nextPartialLine.length > MAX_TAIL_PARTIAL_CHARS
 
   // The plain path only ever appends, so the whole previous tail carries unless it was discarded.
   const carriesPreviousLines = newCompleteLines === 0 || omittedNewCompleteLines === 0
-  const previousStats = carriesPreviousLines ? getRetainedTailLineStats(previousLines) : null
-  let carriedSourceStart = 0
-  let carriedCount = carriesPreviousLines ? previousLines.length : 0
-  let nextLinesChars =
-    (previousStats?.totalChars ?? 0) + (newCompleteLines > 0 ? newlyCompletedChars : 0)
-
-  if (nextLines.length > MAX_TAIL_LINES) {
-    const evictedCount = nextLines.length - MAX_TAIL_LINES
-    for (let index = 0; index < evictedCount; index += 1) {
-      nextLinesChars -= nextLines[index]!.length
-    }
-    nextLines = nextLines.slice(evictedCount)
-    truncated = true
-    const carriedShift = Math.min(evictedCount, carriedCount)
-    carriedSourceStart += carriedShift
-    carriedCount -= carriedShift
-  }
-
-  if (newCompleteLines > 0 || retainedPartialLine.length > previousPartialLine.length) {
-    let totalChars = nextLinesChars + retainedPartialLine.length
-    let trimStartIndex = 0
-    while (trimStartIndex < nextLines.length && totalChars > MAX_TAIL_CHARS) {
-      totalChars -= nextLines[trimStartIndex]!.length
-      trimStartIndex += 1
-    }
-    if (trimStartIndex > 0) {
-      nextLinesChars = totalChars - retainedPartialLine.length
-      nextLines = nextLines.slice(trimStartIndex)
-      truncated = true
-      const carriedShift = Math.min(trimStartIndex, carriedCount)
-      carriedSourceStart += carriedShift
-      carriedCount -= carriedShift
-    }
-  }
-
-  if (nextLines !== previousLines) {
-    tailLineStatsByLines.set(nextLines, {
-      totalChars: nextLinesChars,
-      rightTrimmed: carriedCount === 0 || (previousStats?.rightTrimmed ?? true)
-    })
-    carryTerminalTailSentinelMatches(previousLines, nextLines, carriedSourceStart, carriedCount)
-  }
+  const built = buildCarriedTailLines(
+    previousLines,
+    carriesPreviousLines ? 0 : previousLines.length,
+    previousLines.length,
+    newlyCompletedLines,
+    // Why gated: a chunk that neither completes a line nor grows the partial cannot breach the
+    // character cap, and re-checking it would evict on a tail that has not changed size.
+    newCompleteLines > 0 || retainedPartialLine.length > previousPartialLine.length
+      ? retainedPartialLine.length
+      : null
+  )
+  const nextLines = built.lines
+  const truncated =
+    previousPartialWasCapped ||
+    omittedNewCompleteLines > 0 ||
+    nextPartialLine.length > MAX_TAIL_PARTIAL_CHARS ||
+    built.truncated
 
   const redrawCursor =
     !partialResult.hadControl || partialResult.cursorColumn === nextPartialLine.length
@@ -211,16 +262,15 @@ function appendNormalizedToMultilineTailBuffer(
       previousPartialWasCapped,
       previousRedrawCursor
     )
-    if (unwindowed.lines !== previousLines) {
-      let totalChars = 0
-      for (const line of unwindowed.lines) {
-        totalChars += line.length
-      }
-      // Why nothing carries: an unwindowed redraw may rewrite any retained row.
-      tailLineStatsByLines.set(unwindowed.lines, { totalChars, rightTrimmed: true })
-      carryTerminalTailSentinelMatches(previousLines, unwindowed.lines, 0, 0)
+    if (unwindowed.lines === previousLines) {
+      return unwindowed
     }
-    return unwindowed
+    // Why nothing carries: an unwindowed redraw may rewrite any retained row. Both caps were
+    // already applied inside the unwindowed builder, so the constructor only registers here.
+    return {
+      ...unwindowed,
+      lines: buildCarriedTailLines(previousLines, 0, 0, unwindowed.lines, null).lines
+    }
   }
   const prefixLength = previousLines.length - windowRows
   const suffix = previousLines.slice(prefixLength)
@@ -231,64 +281,39 @@ function appendNormalizedToMultilineTailBuffer(
     previousPartialWasCapped,
     previousRedrawCursor
   )
+  // The window provably cannot reach the prefix, so it carries unchanged — unless the tail
+  // entered un-right-trimmed, in which case the prefix has to be rewritten to match the
+  // unwindowed finalize's trailing-space trim and is therefore no longer the previous tail's rows.
   const previousStats = getRetainedTailLineStats(previousLines)
-  let lines = previousLines.slice(0, prefixLength)
-  let linesChars = previousStats.totalChars
-  for (const line of suffix) {
-    linesChars -= line.length
-  }
-  let carriedSourceStart = 0
-  let carriedCount = prefixLength
+  let keepEnd = prefixLength
+  let appended: readonly string[] = windowed.lines
   if (!previousStats.rightTrimmed) {
-    // Why: the shared prefix must match the unwindowed finalize's trailing-space trim without paying a regex per untouched row.
-    for (let index = 0; index < lines.length; index += 1) {
-      const line = lines[index]!
+    const rewritten = previousLines.slice(0, prefixLength)
+    for (let index = 0; index < rewritten.length; index += 1) {
+      const line = rewritten[index]!
       const lastChar = line.charCodeAt(line.length - 1)
       if (lastChar === 32 || lastChar === 9) {
-        const trimmed = line.replace(/[ \t]+$/g, '')
-        lines[index] = trimmed
-        linesChars -= line.length - trimmed.length
-        carriedCount = 0
+        rewritten[index] = line.replace(/[ \t]+$/g, '')
       }
     }
-  }
-  for (const line of windowed.lines) {
-    lines.push(line)
-    linesChars += line.length
-  }
-  let truncated = windowed.truncated
-  if (lines.length > MAX_TAIL_LINES) {
-    const evictedCount = lines.length - MAX_TAIL_LINES
-    for (let index = 0; index < evictedCount; index += 1) {
-      linesChars -= lines[index]!.length
+    for (const line of windowed.lines) {
+      rewritten.push(line)
     }
-    lines = lines.slice(evictedCount)
-    truncated = true
-    const carriedShift = Math.min(evictedCount, carriedCount)
-    carriedSourceStart += carriedShift
-    carriedCount -= carriedShift
+    keepEnd = 0
+    appended = rewritten
   }
-  let totalChars = linesChars + windowed.partialLine.length
-  let dropCount = 0
-  while (dropCount < lines.length && totalChars > MAX_TAIL_CHARS) {
-    totalChars -= lines[dropCount]!.length
-    dropCount += 1
-  }
-  if (dropCount > 0) {
-    linesChars = totalChars - windowed.partialLine.length
-    lines = lines.slice(dropCount)
-    truncated = true
-    const carriedShift = Math.min(dropCount, carriedCount)
-    carriedSourceStart += carriedShift
-    carriedCount -= carriedShift
-  }
-  tailLineStatsByLines.set(lines, { totalChars: linesChars, rightTrimmed: true })
-  carryTerminalTailSentinelMatches(previousLines, lines, carriedSourceStart, carriedCount)
+  const built = buildCarriedTailLines(
+    previousLines,
+    0,
+    keepEnd,
+    appended,
+    windowed.partialLine.length
+  )
   return {
-    lines,
+    lines: built.lines,
     partialLine: windowed.partialLine,
     redrawCursor: windowed.redrawCursor,
-    truncated,
+    truncated: windowed.truncated || built.truncated,
     newCompleteLines: windowed.newCompleteLines,
     newlyCompletedLines: windowed.newlyCompletedLines
   }

--- a/src/main/runtime/terminal-tail-sentinel-index.test.ts
+++ b/src/main/runtime/terminal-tail-sentinel-index.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import { appendNormalizedToTailBuffer } from './terminal-tail-buffer'
 import { MAX_TAIL_CHARS, MAX_TAIL_LINES } from './terminal-tail-limits'
 import { buildPreview } from './terminal-tail-state'
-import { tailMayContainBlockedSignal } from './terminal-tail-sentinel-index'
+import {
+  getTerminalTailSentinelFullScanCount,
+  getTerminalTailSentinelMatches,
+  tailMayContainBlockedSignal
+} from './terminal-tail-sentinel-index'
 import { computeTerminalTailWaitState } from './terminal-wait-tail-state'
 import { TERMINAL_WAIT_BLOCKED_SENTINEL_RE } from './terminal-wait-detection'
 import type { RetainedTailRedrawCursor } from './terminal-tail-redraw-buffer'
@@ -56,6 +60,32 @@ function assertMatchesFullScan(sim: TailSim): void {
 }
 
 const BLOCKED_LINE = 'Update available! Press Enter to continue.'
+const ESC = String.fromCharCode(27)
+
+/** The exact positions a from-scratch scan would record, written out independently. */
+function referenceSentinelMatches(lines: readonly string[]): number[] {
+  const matches: number[] = []
+  for (let index = 0; index < lines.length; index += 1) {
+    if (TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(lines[index]!)) {
+      matches.push(index)
+    }
+  }
+  return matches
+}
+
+/**
+ * The whole contract of the carried window, at position resolution: the index the constructor
+ * registered for this exact array must equal a from-scratch scan of it. A boolean-only assertion
+ * would pass on an index whose positions are shifted, doubled, or out of bounds.
+ */
+function assertIndexedPositionsAreExact(lines: readonly string[]): void {
+  const indexed = [...getTerminalTailSentinelMatches(lines)]
+  expect(indexed).toEqual(referenceSentinelMatches(lines))
+  for (const position of indexed) {
+    expect(position).toBeGreaterThanOrEqual(0)
+    expect(position).toBeLessThan(lines.length)
+  }
+}
 
 function countSentinelTests(run: () => void): number {
   const spy = vi.spyOn(TERMINAL_WAIT_BLOCKED_SENTINEL_RE, 'test')
@@ -179,6 +209,129 @@ describe('terminal tail sentinel index', () => {
   })
 })
 
+/**
+ * `buildCarriedTailLines` is the only producer of a tail array, and it derives the carried-match
+ * window from the same keep bounds it slices the array out of. These guards pin the four ways
+ * that derivation could still be written wrong, plus the one way a path could escape it. Each was
+ * confirmed to fail against a deliberately broken constructor (see the PR body).
+ */
+describe('terminal tail sentinel index carried window', () => {
+  it('drops a carried match the moment the constructor evicts its row (no stale match)', () => {
+    const sim = saturatedSim()
+    feed(sim, `${BLOCKED_LINE}\n`)
+    // Walk it to the very first retained slot, checking the position every step: each append
+    // evicts one row at a saturated tail, so the carried match must shift down by exactly one.
+    for (let index = 0; index < MAX_TAIL_LINES - 1; index += 1) {
+      feed(sim, `after prompt ${index}\n`)
+      expect(getTerminalTailSentinelMatches(sim.lines)).toEqual([MAX_TAIL_LINES - 2 - index])
+    }
+    expect(sim.lines[0]).toBe(BLOCKED_LINE)
+
+    feed(sim, 'evicting line\n')
+    expect(sim.lines.includes(BLOCKED_LINE)).toBe(false)
+    assertIndexedPositionsAreExact(sim.lines)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+  })
+
+  it('finds a match a redraw writes into rows the carried prefix does not cover', () => {
+    const sim = saturatedSim()
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+
+    // A windowed redraw: the prefix carries, the rewritten suffix must still be scanned.
+    feed(sim, `${ESC}[3A${ESC}[2K${BLOCKED_LINE}\n`)
+    assertIndexedPositionsAreExact(sim.lines)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+
+    // And a redraw that overwrites that same row again must drop it.
+    feed(sim, `${ESC}[1A${ESC}[2Kplain replacement\n`)
+    assertIndexedPositionsAreExact(sim.lines)
+
+    // A redraw deep enough to outrun the window carries nothing and rescans in full.
+    feed(sim, `${ESC}[2500A${ESC}[2K${BLOCKED_LINE}\n`)
+    assertIndexedPositionsAreExact(sim.lines)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+  })
+
+  it('shifts every carried position by exactly the number of rows evicted', () => {
+    const sim = newSim()
+    feed(sim, `first\n${BLOCKED_LINE}\nsecond\n${BLOCKED_LINE}\nthird\n`)
+    expect(getTerminalTailSentinelMatches(sim.lines)).toEqual([1, 3])
+
+    // Saturate so the line cap evicts exactly one row per single-line append.
+    for (let index = 0; index < MAX_TAIL_LINES - 5; index += 1) {
+      feed(sim, `pad ${index}\n`)
+    }
+    expect(sim.lines.length).toBe(MAX_TAIL_LINES)
+    expect(getTerminalTailSentinelMatches(sim.lines)).toEqual([1, 3])
+
+    feed(sim, 'evict one\n')
+    expect(getTerminalTailSentinelMatches(sim.lines)).toEqual([0, 2])
+    feed(sim, 'evict two\n')
+    expect(getTerminalTailSentinelMatches(sim.lines)).toEqual([1])
+    assertIndexedPositionsAreExact(sim.lines)
+  })
+
+  it('stays in bounds when a single chunk evicts the whole carried window and part of itself', () => {
+    const sim = saturatedSim()
+    feed(sim, `${BLOCKED_LINE}\n`)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+
+    // One chunk with more complete lines than the tail retains: every carried row goes, and so
+    // does the front of the chunk itself, so nothing may survive from before the cut.
+    const early: string[] = [BLOCKED_LINE]
+    for (let index = 0; index < MAX_TAIL_LINES + 500; index += 1) {
+      early.push(`flood ${index}`)
+    }
+    feed(sim, `${early.join('\n')}\n`)
+    expect(sim.lines.length).toBe(MAX_TAIL_LINES)
+    assertIndexedPositionsAreExact(sim.lines)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+
+    // Same shape, but the prompt lands inside the surviving suffix of the chunk.
+    const late: string[] = []
+    for (let index = 0; index < MAX_TAIL_LINES + 500; index += 1) {
+      late.push(`flood ${index}`)
+    }
+    late.push(BLOCKED_LINE)
+    feed(sim, `${late.join('\n')}\n`)
+    expect(getTerminalTailSentinelMatches(sim.lines)).toEqual([MAX_TAIL_LINES - 1])
+    assertIndexedPositionsAreExact(sim.lines)
+
+    // The character cap drops from the same front, past the carried window and into the chunk.
+    const bulk = `${'x'.repeat(4000)}\n`
+    for (let index = 0; index * 4001 < MAX_TAIL_CHARS + 20000; index += 1) {
+      feed(sim, bulk)
+    }
+    assertIndexedPositionsAreExact(sim.lines)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+  })
+
+  it('never leaves a produced tail unindexed, on any append path', () => {
+    const sim = saturatedSim()
+    computeTerminalTailWaitState(sim.lines, sim.partialLine, sim.preview)
+    const fullScansBefore = getTerminalTailSentinelFullScanCount()
+
+    feed(sim, `${BLOCKED_LINE}\n`)
+    for (let index = 0; index < 200; index += 1) {
+      feed(sim, `after prompt ${index}\n`)
+    }
+    feed(sim, 'partial with no newline')
+    feed(sim, ' and its completion\n')
+    feed(sim, '\rspinner 40%')
+    feed(sim, `${ESC}[3A${ESC}[2Kredrawn\n`)
+    feed(sim, `${ESC}[2500A${ESC}[2Kdeep redraw\n`)
+    feed(sim, 'trailing spaces here   \n')
+    feed(sim, `${'z'.repeat(5000)}\n`)
+    feed(sim, `multi\nline\nchunk\n`)
+    feed(sim, '')
+    // Reading the verdict must never trigger a scan of an array the constructor produced.
+    computeTerminalTailWaitState(sim.lines, sim.partialLine, sim.preview)
+
+    expect(getTerminalTailSentinelFullScanCount()).toBe(fullScansBefore)
+    assertIndexedPositionsAreExact(sim.lines)
+  })
+})
+
 // Deterministic PRNG so a divergence is reproducible from the seed alone.
 function mulberry32(seed: number): () => number {
   let state = seed >>> 0
@@ -189,8 +342,6 @@ function mulberry32(seed: number): () => number {
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296
   }
 }
-
-const ESC = String.fromCharCode(27)
 
 /**
  * `streaming` saturates and evicts the retained tail; `tui` trades saturation for redraw

--- a/src/main/runtime/terminal-tail-sentinel-index.test.ts
+++ b/src/main/runtime/terminal-tail-sentinel-index.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it, vi } from 'vitest'
+import { appendNormalizedToTailBuffer } from './terminal-tail-buffer'
+import { MAX_TAIL_CHARS, MAX_TAIL_LINES } from './terminal-tail-limits'
+import { buildPreview } from './terminal-tail-state'
+import { tailMayContainBlockedSignal } from './terminal-tail-sentinel-index'
+import { computeTerminalTailWaitState } from './terminal-wait-tail-state'
+import { TERMINAL_WAIT_BLOCKED_SENTINEL_RE } from './terminal-wait-detection'
+import type { RetainedTailRedrawCursor } from './terminal-tail-redraw-buffer'
+
+// The definition the incremental index must reproduce: does ANY retained line (or the
+// partial line) match the sentinel? Written out independently of the implementation.
+function referenceMayContainBlockedSignal(lines: string[], partialLine: string): boolean {
+  for (const line of lines) {
+    if (TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(line)) {
+      return true
+    }
+  }
+  return TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(partialLine)
+}
+
+function indexedMayContainBlockedSignal(lines: string[], partialLine: string): boolean {
+  return tailMayContainBlockedSignal(lines) || TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(partialLine)
+}
+
+type TailSim = {
+  lines: string[]
+  partialLine: string
+  redrawCursor: RetainedTailRedrawCursor | null
+  preview: string
+}
+
+function newSim(): TailSim {
+  return { lines: [], partialLine: '', redrawCursor: null, preview: '' }
+}
+
+function feed(sim: TailSim, chunk: string): void {
+  const next = appendNormalizedToTailBuffer(sim.lines, sim.partialLine, chunk, sim.redrawCursor)
+  sim.lines = next.lines
+  sim.partialLine = next.partialLine
+  sim.redrawCursor = next.redrawCursor
+  sim.preview = buildPreview(next.lines, next.partialLine)
+}
+
+/** A structurally identical tail the index has never seen, so it takes the full-scan path. */
+function unindexed(sim: TailSim): string[] {
+  return [...sim.lines]
+}
+
+function assertMatchesFullScan(sim: TailSim): void {
+  expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(
+    referenceMayContainBlockedSignal(sim.lines, sim.partialLine)
+  )
+  expect(computeTerminalTailWaitState(sim.lines, sim.partialLine, sim.preview)).toEqual(
+    computeTerminalTailWaitState(unindexed(sim), sim.partialLine, sim.preview)
+  )
+}
+
+const BLOCKED_LINE = 'Update available! Press Enter to continue.'
+
+function countSentinelTests(run: () => void): number {
+  const spy = vi.spyOn(TERMINAL_WAIT_BLOCKED_SENTINEL_RE, 'test')
+  try {
+    run()
+    return spy.mock.calls.length
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+function saturatedSim(): TailSim {
+  const sim = newSim()
+  for (let index = 0; index < MAX_TAIL_LINES + 400; index += 1) {
+    feed(sim, `streaming build output line ${index}\n`)
+  }
+  expect(sim.lines.length).toBe(MAX_TAIL_LINES)
+  return sim
+}
+
+describe('terminal tail sentinel index', () => {
+  it('tests only the lines an append produced, not the whole retained tail', () => {
+    const sim = saturatedSim()
+    // Warm the index for the current tail identity.
+    computeTerminalTailWaitState(sim.lines, sim.partialLine, sim.preview)
+
+    const incrementalTests = countSentinelTests(() => {
+      for (let index = 0; index < 20; index += 1) {
+        feed(sim, `fresh line ${index}\n`)
+      }
+      computeTerminalTailWaitState(sim.lines, sim.partialLine, sim.preview)
+    })
+
+    const fullScanTests = countSentinelTests(() => {
+      computeTerminalTailWaitState(unindexed(sim), sim.partialLine, sim.preview)
+    })
+
+    expect(fullScanTests).toBeGreaterThanOrEqual(MAX_TAIL_LINES)
+    // 20 appended lines + one partial-line test per compute call.
+    expect(incrementalTests).toBeLessThanOrEqual(25)
+  })
+
+  it('keeps a retained sentinel visible and drops it exactly when it is evicted', () => {
+    const sim = saturatedSim()
+    feed(sim, `${BLOCKED_LINE}\n`)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+    assertMatchesFullScan(sim)
+
+    // Push the prompt to the very last retained slot.
+    for (let index = 0; index < MAX_TAIL_LINES - 1; index += 1) {
+      feed(sim, `after prompt ${index}\n`)
+      expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+    }
+    expect(sim.lines[0]).toBe(BLOCKED_LINE)
+
+    // One more line evicts it.
+    feed(sim, 'evicting line\n')
+    expect(sim.lines.includes(BLOCKED_LINE)).toBe(false)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+    assertMatchesFullScan(sim)
+
+    // And it stays gone many chunks later.
+    for (let index = 0; index < 200; index += 1) {
+      feed(sim, `long after eviction ${index}\n`)
+    }
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+    assertMatchesFullScan(sim)
+  })
+
+  it('drops a sentinel evicted by the retained-character cap', () => {
+    const sim = newSim()
+    feed(sim, `${BLOCKED_LINE}\n`)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+    const bulkLine = `${'x'.repeat(4000)}\n`
+    for (let index = 0; index * 4001 < MAX_TAIL_CHARS + 20000; index += 1) {
+      feed(sim, bulkLine)
+    }
+    expect(sim.lines.includes(BLOCKED_LINE)).toBe(false)
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+    assertMatchesFullScan(sim)
+  })
+
+  it('finds a sentinel split across two chunks once the line completes', () => {
+    const sim = saturatedSim()
+    feed(sim, 'Codex asks: press ent')
+    // Still only a partial line, and no alternative matches the fragment yet.
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(false)
+    assertMatchesFullScan(sim)
+
+    feed(sim, 'er to confirm')
+    // Now complete, but still the partial line — the partial is always tested directly.
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+    assertMatchesFullScan(sim)
+
+    feed(sim, '\n')
+    // And once it becomes a retained line the index carries it.
+    expect(sim.partialLine).toBe('')
+    expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(true)
+    assertMatchesFullScan(sim)
+  })
+
+  it('full-scans a tail array the index has never seen (seed/restore path)', () => {
+    // primeWaitBlockedBaselineFromSeededTail reads whatever tail the restore seed installed.
+    const seeded = ['boot log', BLOCKED_LINE, 'trailing']
+    expect(tailMayContainBlockedSignal(seeded)).toBe(true)
+    const state = computeTerminalTailWaitState(seeded, '', '')
+    expect(state.fromTail).toBe(true)
+    expect(state.signal?.reason).toBe('codex-update-prompt')
+
+    const clean = ['boot log', 'no prompt here', 'trailing']
+    expect(tailMayContainBlockedSignal(clean)).toBe(false)
+    expect(computeTerminalTailWaitState(clean, '', '').signal).toBeNull()
+  })
+
+  it('reports fromTail from a blank tail without consulting the index', () => {
+    const sim = newSim()
+    feed(sim, '   \n\t\n')
+    expect(computeTerminalTailWaitState(sim.lines, sim.partialLine, '').fromTail).toBe(false)
+    feed(sim, 'now visible\n')
+    expect(computeTerminalTailWaitState(sim.lines, sim.partialLine, '').fromTail).toBe(true)
+  })
+})
+
+// Deterministic PRNG so a divergence is reproducible from the seed alone.
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0
+    let t = Math.imul(state ^ (state >>> 15), 1 | state)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const ESC = String.fromCharCode(27)
+
+/**
+ * `streaming` saturates and evicts the retained tail; `tui` trades saturation for redraw
+ * coverage (cursor-up rewrites of retained rows, and reaches past the redraw window).
+ */
+function randomChunk(random: () => number, profile: 'streaming' | 'tui'): string {
+  const roll = random()
+  if (roll < 0.2) {
+    const lines: string[] = []
+    for (let index = 0; index < 30; index += 1) {
+      lines.push(`burst line ${Math.floor(random() * 1e6)}`)
+    }
+    return `${lines.join('\n')}\n`
+  }
+  if (roll < 0.42) {
+    return `plain output ${Math.floor(random() * 1e6)}\n`
+  }
+  if (roll < 0.48) {
+    return `${'   '.repeat(Math.floor(random() * 3))}\n`
+  }
+  if (roll < 0.54) {
+    return `${BLOCKED_LINE}\n`
+  }
+  if (roll < 0.58) {
+    return 'do you trust the files in this folder?\n'
+  }
+  if (roll < 0.63) {
+    // Sentinel split across a chunk boundary.
+    return random() < 0.5 ? 'Codex asks: press ent' : 'er to confirm\n'
+  }
+  if (roll < 0.7) {
+    // TUI redraw: move the cursor up a few rows and rewrite them.
+    const rows = 1 + Math.floor(random() * 12)
+    return `${ESC}[${rows}A${ESC}[2Kredrawn row ${Math.floor(random() * 1000)}\n`
+  }
+  if (roll < (profile === 'tui' ? 0.76 : 0.7)) {
+    // Deep redraw that outruns the window and forces the unwindowed path.
+    return `${ESC}[${1500 + Math.floor(random() * 800)}A${ESC}[2Kdeep redraw\n`
+  }
+  if (roll < 0.82) {
+    return `\rspinner ${Math.floor(random() * 100)}%`
+  }
+  if (roll < 0.87) {
+    return 'trailing spaces here   \n'
+  }
+  if (roll < 0.91) {
+    return `${'y'.repeat(3000)}\n`
+  }
+  if (roll < 0.95) {
+    return `multi\nline\nchunk ${Math.floor(random() * 1000)}\n`
+  }
+  if (roll < 0.97) {
+    return ''
+  }
+  return `no newline ${Math.floor(random() * 1000)}`
+}
+
+describe('terminal tail sentinel index property', () => {
+  for (const profile of ['streaming', 'tui'] as const) {
+    for (const seed of [1, 7, 42, 1337]) {
+      it(`matches a full scan on every step of a random ${profile} sequence (seed ${seed})`, () => {
+        const random = mulberry32(seed)
+        const sim = newSim()
+        let sawSentinel = false
+        let sawSaturation = false
+        for (let step = 0; step < 1200; step += 1) {
+          feed(sim, randomChunk(random, profile))
+          const expected = referenceMayContainBlockedSignal(sim.lines, sim.partialLine)
+          expect(indexedMayContainBlockedSignal(sim.lines, sim.partialLine)).toBe(expected)
+          expect(computeTerminalTailWaitState(sim.lines, sim.partialLine, sim.preview)).toEqual(
+            computeTerminalTailWaitState(unindexed(sim), sim.partialLine, sim.preview)
+          )
+          sawSentinel = sawSentinel || expected
+          sawSaturation = sawSaturation || sim.lines.length >= MAX_TAIL_LINES
+        }
+        // Guard against a vacuous pass.
+        expect(sawSentinel).toBe(true)
+        if (profile === 'streaming') {
+          expect(sawSaturation).toBe(true)
+        }
+      })
+    }
+  }
+})

--- a/src/main/runtime/terminal-tail-sentinel-index.ts
+++ b/src/main/runtime/terminal-tail-sentinel-index.ts
@@ -1,0 +1,77 @@
+import { TERMINAL_WAIT_BLOCKED_SENTINEL_RE } from './terminal-wait-detection'
+
+/**
+ * Which retained tail lines match the wait-blocked sentinel, memoized per
+ * lines-array identity.
+ *
+ * Why: `computeTerminalTailWaitState` must prove the ABSENCE of a signal, so it
+ * cannot early-exit and re-tested all 2000 retained lines on every scan (20/s
+ * per streaming PTY) even though only ~20 lines were new. Keyed weakly by the
+ * array so an entry dies with the tail it describes; the tail array is replaced
+ * on every append and never mutated in place, so at most one entry per PTY
+ * stays live.
+ */
+const sentinelMatchesByTailLines = new WeakMap<readonly string[], number[]>()
+
+function collectSentinelMatches(
+  lines: readonly string[],
+  startIndex: number,
+  into: number[]
+): void {
+  for (let index = startIndex; index < lines.length; index += 1) {
+    if (TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(lines[index]!)) {
+      into.push(index)
+    }
+  }
+}
+
+/** Ascending indices of sentinel-matching lines; full-scans an unseen array. */
+export function getTerminalTailSentinelMatches(lines: readonly string[]): readonly number[] {
+  const cached = sentinelMatchesByTailLines.get(lines)
+  if (cached) {
+    return cached
+  }
+  const matches: number[] = []
+  collectSentinelMatches(lines, 0, matches)
+  sentinelMatchesByTailLines.set(lines, matches)
+  return matches
+}
+
+export function tailMayContainBlockedSignal(lines: readonly string[]): boolean {
+  return getTerminalTailSentinelMatches(lines).length > 0
+}
+
+/**
+ * Derive `nextLines`' match index from `previousLines`', testing only the lines
+ * the append actually produced.
+ *
+ * The caller guarantees `nextLines[0 … carriedCount)` are the very same strings
+ * as `previousLines[carriedSourceStart … carriedSourceStart + carriedCount)`,
+ * and that every later line is newly produced. Matches outside that carried
+ * window are dropped because their lines were evicted or rewritten, which is
+ * exactly what the full scan would conclude.
+ */
+export function carryTerminalTailSentinelMatches(
+  previousLines: readonly string[],
+  nextLines: readonly string[],
+  carriedSourceStart: number,
+  carriedCount: number
+): void {
+  if (nextLines === previousLines) {
+    return
+  }
+  const matches: number[] = []
+  if (carriedCount > 0) {
+    const carriedEnd = carriedSourceStart + carriedCount
+    for (const index of getTerminalTailSentinelMatches(previousLines)) {
+      if (index >= carriedEnd) {
+        break
+      }
+      if (index >= carriedSourceStart) {
+        matches.push(index - carriedSourceStart)
+      }
+    }
+  }
+  collectSentinelMatches(nextLines, carriedCount, matches)
+  sentinelMatchesByTailLines.set(nextLines, matches)
+}

--- a/src/main/runtime/terminal-tail-sentinel-index.ts
+++ b/src/main/runtime/terminal-tail-sentinel-index.ts
@@ -25,12 +25,26 @@ function collectSentinelMatches(
   }
 }
 
+/**
+ * How many arrays have been full-scanned because they arrived without an index entry.
+ * Every array `appendNormalizedToTailBuffer` produces is registered by `buildCarriedTailLines`,
+ * so this only advances for tails the index has genuinely never seen (a restore seed, a persisted
+ * record, a hand-built array). Tests assert it stays flat across the real append paths, which is
+ * what proves no producer path silently bypasses the constructor.
+ */
+let sentinelFullScanCount = 0
+
+export function getTerminalTailSentinelFullScanCount(): number {
+  return sentinelFullScanCount
+}
+
 /** Ascending indices of sentinel-matching lines; full-scans an unseen array. */
 export function getTerminalTailSentinelMatches(lines: readonly string[]): readonly number[] {
   const cached = sentinelMatchesByTailLines.get(lines)
   if (cached) {
     return cached
   }
+  sentinelFullScanCount += 1
   const matches: number[] = []
   collectSentinelMatches(lines, 0, matches)
   sentinelMatchesByTailLines.set(lines, matches)
@@ -45,11 +59,14 @@ export function tailMayContainBlockedSignal(lines: readonly string[]): boolean {
  * Derive `nextLines`' match index from `previousLines`', testing only the lines
  * the append actually produced.
  *
- * The caller guarantees `nextLines[0 … carriedCount)` are the very same strings
- * as `previousLines[carriedSourceStart … carriedSourceStart + carriedCount)`,
- * and that every later line is newly produced. Matches outside that carried
- * window are dropped because their lines were evicted or rewritten, which is
- * exactly what the full scan would conclude.
+ * `nextLines[0 … carriedCount)` are the very same strings as
+ * `previousLines[carriedSourceStart … carriedSourceStart + carriedCount)`, and
+ * every later line is newly produced. That is not an assumption a caller has to
+ * uphold by hand: `buildCarriedTailLines` in `terminal-tail-buffer.ts` is the
+ * sole caller, and it derives this window from the same keep bounds it slices
+ * `nextLines` out of, so the window and the array cannot disagree. Matches
+ * outside the carried window are dropped because their lines were evicted or
+ * rewritten, which is exactly what a full scan would conclude.
  */
 export function carryTerminalTailSentinelMatches(
   previousLines: readonly string[],

--- a/src/main/runtime/terminal-wait-tail-state.ts
+++ b/src/main/runtime/terminal-wait-tail-state.ts
@@ -1,5 +1,6 @@
 import type { RuntimeTerminalWaitBlockedReason } from '../../shared/runtime-types'
 import { buildTailLines } from './terminal-tail-state'
+import { tailMayContainBlockedSignal } from './terminal-tail-sentinel-index'
 import {
   findActionableTerminalWaitBlockedSignal,
   TERMINAL_WAIT_BLOCKED_SENTINEL_RE
@@ -60,23 +61,22 @@ function inspectTerminalWaitTail(
   lines: string[],
   partialLine: string
 ): { fromTail: boolean; mayContainBlockedSignal: boolean } {
-  let fromTail = false
-  let mayContainBlockedSignal = false
+  return {
+    fromTail: hasVisibleTailLine(lines) || partialLine.trim().length > 0,
+    // Why the index: proving a signal is ABSENT can't early-exit, so a full re-test of the
+    // 2000-line tail ran per scan; the index tests only the lines each append produced.
+    mayContainBlockedSignal:
+      tailMayContainBlockedSignal(lines) || TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(partialLine)
+  }
+}
+
+function hasVisibleTailLine(lines: string[]): boolean {
   for (const line of lines) {
-    if (!fromTail && line.trim().length > 0) {
-      fromTail = true
-    }
-    if (!mayContainBlockedSignal && TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(line)) {
-      mayContainBlockedSignal = true
+    if (line.trim().length > 0) {
+      return true
     }
   }
-  if (!fromTail && partialLine.trim().length > 0) {
-    fromTail = true
-  }
-  if (!mayContainBlockedSignal && TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test(partialLine)) {
-    mayContainBlockedSignal = true
-  }
-  return { fromTail, mayContainBlockedSignal }
+  return false
 }
 
 // Why: consumes precomputed wait states so full-tail scans aren't repeated per chunk (replaces the former inline double full-tail scan).


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​585 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​585 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​285 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​74 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 |

<!-- /orca-pr-loc -->

## ELI5

Every terminal pane keeps the last 2000 lines of output so Orca can tell whether an agent is sitting on a permission prompt. Twenty times a second, while output is flowing, Orca re-read all 2000 of those lines looking for prompt phrases — even though only about twenty lines were new since the last look. It could not stop early, because to say "this agent is *not* blocked" you have to check every single line.

This change remembers which lines already matched, and checks only the lines that actually arrived. The answer is exactly the same; it just stops re-reading the 1980 lines nothing touched. The same idea is applied to two other per-chunk full-tail walks: the running character total and the trailing-whitespace check over the part of the screen a redraw provably did not touch.

## What Changed

- **New `src/main/runtime/terminal-tail-sentinel-index.ts`** — a `WeakMap<readonly string[], number[]>` holding the ascending indices of the retained tail lines that match `TERMINAL_WAIT_BLOCKED_SENTINEL_RE`, keyed by tail-array identity. An unseen array is full-scanned once and memoized; `carryTerminalTailSentinelMatches` derives the next array's index from the previous one's by shifting the carried window and testing only the lines the append produced.
- **`terminal-tail-buffer.ts`** — all three append paths (plain, windowed redraw, unwindowed redraw) now produce their next tail array through one constructor, `buildCarriedTailLines`, which resolves both retention caps against the virtual concatenation and then derives the array, the carried character total, and the carried-match window from the same surviving bounds. A second `WeakMap` caches `{ totalChars, rightTrimmed }`, so `MAX_TAIL_CHARS` eviction no longer re-sums the tail and the untouched redraw prefix is no longer re-scanned for trailing whitespace per chunk.
- **`terminal-wait-tail-state.ts`** — `inspectTerminalWaitTail` splits into an early-exiting `hasVisibleTailLine` scan for `fromTail` and an index lookup (plus the same direct partial-line test as before) for `mayContainBlockedSignal`.
- **Tests** — two differential/property suites plus regression guards on the sentinel-`RE.test` and `charCodeAt` call counts and on the carried-window positions.

No behavior change: both booleans remain the same pure functions of `(lines, partialLine)`.

## Why

Both hot spots are in `src/main/runtime`, on the per-PTY-chunk path (`orca-runtime-on-pty-data.ts` → `scheduleWaitBlockedCheck` → `computeTerminalTailWaitState` / `appendNormalizedToTailBuffer`).

An idle profile understates this: `pty:data` fires only ~2.39/s when nothing is streaming. The cost is per chunk on *streaming* panes, and this user runs many concurrent agent panes. From the audit that produced the finding: 10 concurrently-streaming agents ≈ 43 ms/s (~4.3% of a main core), 40 streaming ≈ 171 ms/s (~17%).

Auditor's measurements (vitest, best-of-5 after a 3000-iteration warmup) for finding 1:

```
computeTerminalTailWaitState tail=2000: 169.97 us/op
sentinel RE.test over 2000 lines:       214.10 us/op   <- what ran today (dominates)
sentinel RE.test over   20 lines:         1.44 us/op   <- what incremental costs
```

and for finding 2 (prefix components at 1968 rows):

```
slice 2.54us + trailing-space scan 9.57us + totalChars sum 10.39us = ~22 us/chunk
```

`WAIT_BLOCKED_CHECK_MIN_INTERVAL_MS` is 50 ms, so `runWaitBlockedCheck` runs 20×/s per PTY while output flows, and `MAX_TAIL_LINES = 2000` is the steady state for any agent pane older than a minute — not an edge case.

## Measurement

### Microbenchmark, before vs after

`process.cpuUsage()` deltas (this box is loaded, so wall clock is not trustworthy), `nice -n 10`, best of 5 rounds after a warmup, then best of 3 whole process runs. "main" = `origin/main`; "after" = this branch. Real streaming is a mix of appends and 20 Hz wait scans, so the table sweeps the appends-per-scan ratio rather than picking one.

| scenario (tail saturated at 2000 lines) | main | after | |
| --- | --- | --- | --- |
| wait scan only (`computeTerminalTailWaitState`) | 216.18 us/op | 0.05 us/op | |
| 1-row TUI redraw chunk + wait scan | 227.28 us/op | 4.42 us/op | **51×** |
| 1 append + 1 wait scan | 193.68 us/op | 2.74 us/op | **71×** |
| 5 appends + 1 wait scan | 214.57 us/op | 13.12 us/op | **16×** |
| 10 appends + 1 wait scan | 234.95 us/op | 26.39 us/op | **8.9×** |
| 20 appends + 1 wait scan | 283.45 us/op | 53.84 us/op | **5.3×** |
| 40 appends + 1 wait scan | 361.50 us/op | 107.12 us/op | **3.4×** |
| plain 1-line append (no wait scan) | 4.09 us/op | 2.67 us/op | 1.5× |

The residual in the multi-append rows is the individual `appendNormalizedToTailBuffer` calls themselves (segment splitting, line-control application) — untouched by this PR.

The final row is the one with no scan to amortise, so it is the one a correctness-hardening change could quietly invert. Making the carry correct by construction (see below) *improved* it rather than costing anything: against the previous revision of this branch it went 3.20 → 2.67 us/op, because resolving both retention caps before the array exists collapses the plain path's spread-then-`slice`-then-`slice` into a single allocation. Every append row moved the same way:

| scenario | branch before the constructor | with the constructor | |
| --- | --- | --- | --- |
| wait scan only | 0.05 us/op | 0.05 us/op | — |
| 1-row TUI redraw chunk + wait scan | 4.51 us/op | 4.42 us/op | 1.02× |
| 1 append + 1 wait scan | 3.36 us/op | 2.74 us/op | 1.23× |
| 5 appends + 1 wait scan | 15.95 us/op | 13.12 us/op | 1.22× |
| 10 appends + 1 wait scan | 32.24 us/op | 26.39 us/op | 1.22× |
| 20 appends + 1 wait scan | 63.44 us/op | 53.84 us/op | 1.18× |
| 40 appends + 1 wait scan | 127.60 us/op | 107.12 us/op | 1.19× |
| plain 1-line append (no wait scan) | 3.20 us/op | 2.67 us/op | 1.20× |

### Regression guard 1 — the regex runs over O(new lines)

`src/main/runtime/terminal-tail-sentinel-index.test.ts` spies on `TERMINAL_WAIT_BLOCKED_SENTINEL_RE.test` and counts invocations for one 20-line append + scan against a saturated tail, and separately for the same scan on an array the index has never seen.

With `inspectTerminalWaitTail` reverted to the full scan:

```
 FAIL  terminal tail sentinel index > tests only the lines an append produced, not the whole retained tail
AssertionError: expected 2021 to be less than or equal to 25
    96|     expect(fullScanTests).toBeGreaterThanOrEqual(MAX_TAIL_LINES)
    97|     // 20 appended lines + one partial-line test per compute call.
    98|     expect(incrementalTests).toBeLessThanOrEqual(25)
```

With the change: 21 tests (20 new lines + 1 partial line), and the same test asserts the unindexed reference still costs ≥ 2000, so it can never pass vacuously.

### Regression guard 2 — the untouched redraw prefix is not re-walked

`src/main/runtime/terminal-tail-buffer.test.ts` counts `String.prototype.charCodeAt` calls for one windowed redraw chunk against a saturated tail. With the `rightTrimmed` gate removed (i.e. the prefix scan restored):

```
 FAIL  retained tail buffer prefix reuse > does not walk the untouched redraw prefix on every chunk
AssertionError: expected 1999 to be less than 300
```

With the change the prefix contributes zero and only the chunk itself is parsed.

### Regression guard 3 — the carried window cannot disagree with the array

Five guards in `terminal-tail-sentinel-index.test.ts` pin the four ways the derivation could still be written wrong plus the one way a producer could escape it. They assert *positions*, not just the boolean — a boolean-only assertion passes on an index whose entries are shifted, doubled or out of bounds. `getTerminalTailSentinelFullScanCount()` counts arrays that arrived without an index entry, which is what makes "no path bypasses the constructor" observable.

Each guard was confirmed to fail against a deliberately broken constructor. Injected defect → tests that go red (whole file, 19 tests):

| injected defect | guard that catches it |
| --- | --- |
| eviction no longer advances `carriedSourceStart` | *no stale match* + *shifts by exactly the rows evicted* + 2 pre-existing (4 failed) |
| index told the whole result carried, so appended rows are never scanned | *finds a match a redraw writes outside the carried prefix* + 14 others (15 failed) |
| a separate, `+1` offset handed to the index | *shifts by exactly the rows evicted* + 7 others (8 failed) |
| index given an unclamped carried count (runs past the array) | *stays in bounds when a chunk evicts the whole carried window* + 3 others (4 failed) |
| the unwindowed-redraw path returns without registering | *never leaves a produced tail unindexed* (1 failed, and only that one) |

A sixth injection — the windowed path over-claiming `keepEnd` as `previousLines.length`, which corrupts the tail *content* rather than the index — is caught by the pre-existing `retained-tail-redraw-window.equivalence.test.ts` fuzz (`matches the unwindowed reference across 500 randomized cases`).

## Correctness

This gates agent wait/blocked detection, so the bar is definitional equality, not "close enough".

**What the scan computes.** `inspectTerminalWaitTail` returns two booleans that are pure functions of `(lines, partialLine)`:
- `mayContainBlockedSignal` = ∃ line in `lines` matching `TERMINAL_WAIT_BLOCKED_SENTINEL_RE`, OR the partial line matches.
- `fromTail` = ∃ line in `lines` with `line.trim().length > 0`, OR the partial line is non-blank.

Nothing else about the scan changed: `TERMINAL_WAIT_BLOCKED_SENTINEL_RE` has no `g` flag so `.test` is stateless, the partial line is still tested directly on every call, and everything downstream (`buildTailLines`, `findActionableTerminalWaitBlockedSignal`, `tailGainedNewerBlockedReason`) is untouched.

**`fromTail`.** Now a plain early-exiting scan for the first non-blank line. The old loop could not exit early because it was also looking for the sentinel; separating them makes this O(1) in the normal case and O(tail) only when the whole tail is blank — which is the cheap case, and rare after startup. Same predicate, no state, so no invalidation question.

**`mayContainBlockedSignal`.** A `WeakMap<readonly string[], number[]>` maps a tail-lines array to the ascending indices of its matching lines. `mayContainBlockedSignal === matches.length > 0`.

The index is derived, never guessed: `nextLines[0 … carriedCount)` are the very same strings as `previousLines[carriedSourceStart … carriedSourceStart + carriedCount)`, and every line after that is newly produced. Carried matches shift by `carriedSourceStart`; matches outside the carried window are dropped, which is exactly what a full scan concludes (their lines were evicted or rewritten); the rest of the array is tested.

**The carry is correct by construction, not by assertion.** The risk in an incremental index is that the offsets and the array are maintained separately and drift apart. They are not maintained separately here. `buildCarriedTailLines` is the single constructor for a tail array, and it is the only caller of `carryTerminalTailSentinelMatches`:

```ts
buildCarriedTailLines(previousLines, keepStart, keepEnd, appended, charCapPartialChars)
//  result = previousLines[keepStart, keepEnd) ++ appended, minus whatever the caps drop
```

It resolves both retention caps against the *virtual* concatenation first — both caps only ever drop from the front, so the number of dropped rows is computable before any array exists — and then produces the array, the character total and the carried window from the same surviving bounds:

```ts
const carriedSourceStart = keepStart + droppedFromCarried
const carriedCount = keptCount - droppedFromCarried
const lines = previousLines.slice(carriedSourceStart, keepEnd)     // the array …
for (…) lines.push(appended[index]!)
carryTerminalTailSentinelMatches(previousLines, lines, carriedSourceStart, carriedCount)  // … and its window
```

`carriedSourceStart` is literally the `slice` bound. There is no second expression that could be edited out of step with the first, and no per-path eviction bookkeeping left to keep in sync — the three producers deleted theirs. Each now states only what it structurally knows, and nothing about the caps:

- **Plain append.** `keep [0, previousLines.length)`, `appended = newlyCompletedLines` — the path only appends. A chunk carrying more complete lines than the tail retains passes `keepStart === keepEnd`, so nothing carries.
- **Windowed redraw.** `keep [0, prefixLength)` — the rows the window provably does not reach, the same invariant the code already relies on for the prefix's *content*, fuzz-verified in `retained-tail-redraw-window.equivalence.test.ts`. If the tail entered un-right-trimmed, the prefix has to be rewritten to match the unwindowed finalize's trailing-space trim, so those rows are no longer the previous array's rows: the whole prefix moves into `appended` and nothing carries.
- **Unwindowed redraw.** `keep [0, 0)` — an unwindowed redraw may rewrite any retained row, so nothing carries and the result is scanned in full. Same cost as before this PR, on the same path.

This replaces an earlier design that *verified* the carry with a `===` walk over the carried window on every append. That walk was correct but cost O(tail) on the per-chunk path — 6.43 vs 4.16 us/op on the pure-append row, i.e. 1.55× slower than `main` on a row this PR otherwise makes 1.5× faster, and >15% of the win at 10 appends per wait scan. Deriving the window instead of checking it costs nothing, and in fact pays (table above).

- **Any array the index has never seen** (restore seed, persisted record, `[]`, a hand-built array) is full-scanned on first use and memoized. `primeWaitBlockedBaselineFromSeededTail` therefore behaves exactly as before: absent an entry, the answer comes from the same full scan.

I explicitly checked the two claims the brief flagged as needing verification:
- **Tail arrays are never mutated in place.** `grep` for `tailBuffer.push|splice|pop|shift|unshift|sort|reverse|fill` and `tailBuffer[` over `src/` returns nothing. The one in-place write in the redraw path (`lines[index] = line.replace(...)`) targets `previousLines.slice(0, prefixLength)` — a fresh copy — and happens before the array is registered. `appendNormalizedToMultilineTailBufferUnwindowed` builds a fresh `rows` array of fresh objects and never touches `previousLines`. So a WeakMap entry can never describe a stale array, and the map holds one live entry per PTY, dying with the array.
- **Every producer right-trims.** `newlyCompletedLines` goes through `trimTerminalLineRight`; `finalizeRetainedTerminalRows` applies `.replace(/[ \t]+$/g, '')` to every row; the windowed prefix is trimmed or already trimmed. `trimTerminalLineRight` strips exactly `0x20` and `0x09`, the same set as the regex. So the prefix trim *is* a no-op in steady state — but the code does not assume it: `rightTrimmed` is computed once per array (during the same walk that computes the character total) and the trim loop still runs when it is false.

**Character total.** `MAX_TAIL_CHARS` eviction depends on an exact character total, so the carried total must be exact, not approximate. It comes out of the same constructor, from the same bounds (previous total, minus the rows outside `[keepStart, keepEnd)`, plus the appended lines' lengths, minus each dropped line's length), and the differential test below proves it matches a from-scratch sum step for step.

**Invalidation.** There is none to get wrong: the key is the array identity, and a tail array is immutable once returned. A miss is always safe (full scan). There is no TTL, no version counter, no staleness window.

**Edge cases.**
- *Eviction boundary*: covered by dedicated tests for a still-retained match, a match evicted by the line cap on the exact chunk that evicts it, one evicted 200 chunks earlier, and one evicted by the character cap.
- *Split prompts*: a sentinel arriving across two chunks is found — the partial line is tested directly on every call, and once it completes into a retained line the index picks it up.
- *Prune / reset*: `pruneDisconnectedPtyTranscript` and the floating-workspace liveness reset install `[]`, which has no entry and no matches. `orca-runtime-tail-wait-memo.test.ts` (unchanged) still covers the prune-then-resume stamping.
- *SSH / remote*: nothing here touches the execution boundary, the wire, or any RPC/stream shape. It is a pure in-memory main-process computation over bytes the host already delivered, so a remote PTY behaves identically to a local one.
- *Folder workspaces*: the tail is per PTY, not per git worktree; nothing consulted here is repository state.
- *Windows / Linux / macOS*: no platform-dependent behaviour, no paths, no processes, no shortcuts.
- *Empty / missing state*: empty tail, empty chunk, blank-only tail, and no prior index entry all take documented paths and are asserted.

**Differential coverage.** Two property tests, deterministic PRNG with fixed seeds:
- `terminal-tail-sentinel-index.test.ts` drives random chunk sequences (plain lines, blank lines, whole and split sentinels, windowed redraws, redraws deep enough to force the unwindowed path, CR spinners, trailing spaces, 3000-char lines, multi-line chunks, empty chunks) through the real `appendNormalizedToTailBuffer`, and at **every step** asserts both the index's answer against an independently written full scan and the whole `TerminalTailWaitState` against the same call on a copied (unindexed) array. Each run asserts it actually saw a sentinel, and the streaming profile asserts it actually saturated the tail, so it cannot pass vacuously.
- `terminal-tail-buffer.test.ts` runs a "warm" tail (memo hits) against a "cold" tail (a fresh array every step, so every total is summed in full) and compares `lines`, `partialLine`, `truncated`, `redrawCursor`, `newCompleteLines` and `newlyCompletedLines` at every step, under a line-cap profile and a character-cap profile, each asserting its eviction path actually ran.

**One deliberate identity change.** The plain path no longer does `nextLines = [...previousLines]` when a chunk adds no complete line; the constructor returns `previousLines` itself when nothing is appended and no cap drops a row. That copy was pure waste: if the character cap then trims, `slice` allocates a new array anyway, and if it does not, the copy is discarded on the next append. Returning `previousLines` unchanged is already an existing outcome of this function (the empty-chunk early return does it). The only consumer sensitive to identity is `tailStateMatches`, which uses `lines === snapshot.lines` as a fast path and falls through to a value comparison — so this can only make that check cheaper, never change its result.

## Negative user-facing trade-offs

**None.** The two booleans are the same pure functions of the same inputs, proven step-for-step against a full scan across four seeded random chunk sequences per profile; no cadence, cap, threshold, debounce or coverage was changed, and the only added memory is one small array of match indices per live tail, held weakly.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/runtime` → **575 files, 6293 tests passed**, 1 file / 9 tests skipped.
- New: `src/main/runtime/terminal-tail-sentinel-index.test.ts` (19 tests) and `src/main/runtime/terminal-tail-buffer.test.ts` (9 tests).
- All three regression guards verified to fail without the change — the first two against the reverted code, the five carried-window guards against a deliberately broken constructor (matrix above).
- Pre-existing `orca-runtime-tail-wait-memo.test.ts`, `retained-tail-redraw-window.equivalence.test.ts`, `wait-blocked-check-state.test.ts` and `terminal-wait-results.test.ts` pass unchanged.
- `nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false` clean; `pnpm run check:code-quality:changed` → 0 new findings across 5 changed files; `oxfmt` / `oxlint` clean.


## Linked Issue

N/A — no tracking issue. This came out of a main-process CPU audit of the per-PTY-chunk path; the finding and its measurements are inlined above rather than filed separately.

## Visual Proof

`N/A` — no UI, layout, copy or interaction change. This is a main-process computation over bytes already delivered to the PTY tail buffer; the two booleans it produces are unchanged, so the rendered wait/blocked state is byte-identical.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/runtime` → 575 files, 6293 tests passed. New suites: `terminal-tail-sentinel-index.test.ts`, `terminal-tail-buffer.test.ts`. All three regression guards were confirmed to fail against the reverted / deliberately-broken code (matrix above). Platform: macOS. The change is platform-independent (no paths, processes, shortcuts or shell invocation), so Linux/Windows/SSH were not separately exercised — see Notes.

## AI Disclosure

Internal contributor — section not applicable.

## Review

Correctness argument in the **Correctness** section above; the load-bearing claim is that `buildCarriedTailLines` is the sole producer of a tail array and the sole caller of `carryTerminalTailSentinelMatches`, so the carried window is derived from the same `slice` bounds as the array rather than maintained alongside it. `getTerminalTailSentinelFullScanCount()` makes "no append path bypasses the constructor" observable, and a test asserts it stays flat.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: no new inputs, no parsing of untrusted formats, no persistence; the index holds line indices only, weakly, and dies with the array.
- **Cross-platform (macOS / Linux / Windows)**: no platform-dependent behavior — no path handling, no child processes, no keyboard accelerators.
- **Remote SSH**: nothing here touches the execution boundary, an RPC param, a stream frame, or anything a client and host exchange. It is in-memory main-process work over bytes the execution host already delivered, so a remote PTY behaves exactly as a local one; no `live`/`unverifiable`/`exited` verdict is produced or consumed.
- **Folder workspaces**: the tail is per PTY, not per git worktree; no repository state is consulted.
- **Mobile / backwards compatibility**: no wire change, no persisted-shape change, no capability negotiation needed. An array restored from a record or seed simply misses the index and is full-scanned once, exactly as today.
- **Performance**: measured above; the point of the PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
