### PR TITLE
perf(terminals): spend one inspection start on a whole cadence round

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -101,6 +101,9 @@ export function createAgentCompletionProcessMonitor({
     enqueueAgentProcessInspection({
       priority,
       canRun: () => !state.disposed,
+      // Local reads all resolve out of one process-table capture; remote ones each cost their
+      // own execution-host round trip and stay admitted one at a time.
+      sharesHostObservation: options.isRemotePtyId?.(ptyId) !== true,
       run: async () => {
         let inspectedRecognizedAgent = false
         let inspectionSucceeded = false

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts
@@ -4,27 +4,54 @@ type InspectionTask = {
   priority: InspectionPriority
   canRun: () => boolean
   run: () => Promise<void>
+  /**
+   * Reads served by one shared host observation. Every local pane's inspection resolves out of
+   * the same TTL-and-in-flight-deduped process-table snapshot, so a whole round of them costs
+   * the host one capture however many panes ride it.
+   */
+  sharesHostObservation?: boolean
 }
 
 const MAX_CONCURRENT_INSPECTIONS = 4
 const MAX_INSPECTION_STARTS_PER_SECOND = 8
 
 let activeInspections = 0
+let inspectionPumpQueued = false
 let inspectionPumpTimer: ReturnType<typeof setTimeout> | null = null
 const inspectionStarts: number[] = []
 const inspectionQueue: InspectionTask[] = []
 
-function canStartInspection(now: number): boolean {
+/**
+ * Host observations still admissible right now. A start is one observation, not one pane: a
+ * shared-observation round costs one however many panes ride it, an unshared task costs one each.
+ */
+function availableInspectionStarts(now: number): number {
   if (inspectionStarts.length > 0 && now < inspectionStarts[0]!) {
     inspectionStarts.length = 0
   }
   while (inspectionStarts.length > 0 && now - inspectionStarts[0]! >= 1_000) {
     inspectionStarts.shift()
   }
-  return (
-    activeInspections < MAX_CONCURRENT_INSPECTIONS &&
-    inspectionStarts.length < MAX_INSPECTION_STARTS_PER_SECOND
+  return Math.min(
+    MAX_CONCURRENT_INSPECTIONS - activeInspections,
+    MAX_INSPECTION_STARTS_PER_SECOND - inspectionStarts.length
   )
+}
+
+/**
+ * Pump on a microtask, so a synchronous burst of enqueues forms one round. Pumping inline
+ * spent a start per pane until the concurrency slots filled and then parked the rest of the
+ * burst on the 100ms retry.
+ */
+function queueInspectionPump(): void {
+  if (inspectionPumpQueued) {
+    return
+  }
+  inspectionPumpQueued = true
+  queueMicrotask(() => {
+    inspectionPumpQueued = false
+    pumpInspectionQueue()
+  })
 }
 
 function scheduleInspectionPump(delayMs = 0): void {
@@ -37,44 +64,92 @@ function scheduleInspectionPump(delayMs = 0): void {
   }, delayMs)
 }
 
-function pumpInspectionQueue(): void {
-  // Drop disposed tasks before slot/rate accounting.
-  for (let index = inspectionQueue.length - 1; index >= 0; index -= 1) {
-    const task = inspectionQueue[index]
-    if (task && !task.canRun()) {
-      inspectionQueue.splice(index, 1)
+/** Compact disposed tasks out in one pass; a splice per drop is quadratic at pane scale. */
+function dropDisposedInspections(): void {
+  let write = 0
+  for (let read = 0; read < inspectionQueue.length; read += 1) {
+    const task = inspectionQueue[read]!
+    if (task.canRun()) {
+      inspectionQueue[write] = task
+      write += 1
     }
   }
+  inspectionQueue.length = write
+}
+
+function startInspectionRound(tasks: InspectionTask[], now: number): void {
+  activeInspections += 1
+  inspectionStarts.push(now)
+  let outstanding = tasks.length
+  const settleOne = (): void => {
+    outstanding -= 1
+    if (outstanding > 0) {
+      return
+    }
+    activeInspections = Math.max(0, activeInspections - 1)
+    if (inspectionQueue.length > 0) {
+      scheduleInspectionPump()
+    }
+  }
+  for (const task of tasks) {
+    // Started synchronously so every read in the round lands in the same tick, hitting one
+    // process-table capture instead of serializing one capture window apart.
+    // Why the catch before finally: an unreachable runtime rejects the inspection on a cadence, and a
+    // bare `.finally()` chain re-raises it as a renderer-global unhandledrejection. Coordinators own
+    // their own failure/backoff state, so the queue only has to keep its accounting running.
+    void task
+      .run()
+      .catch(() => {})
+      .finally(settleOne)
+  }
+}
+
+/** Take every shared-observation task, in order, leaving the rest queued. */
+function takeSharedObservationRound(): InspectionTask[] {
+  const round: InspectionTask[] = []
+  let write = 0
+  for (let read = 0; read < inspectionQueue.length; read += 1) {
+    const task = inspectionQueue[read]!
+    if (task.sharesHostObservation === true) {
+      round.push(task)
+    } else {
+      inspectionQueue[write] = task
+      write += 1
+    }
+  }
+  inspectionQueue.length = write
+  return round
+}
+
+function pumpInspectionQueue(): void {
+  // Drop disposed tasks before slot/rate accounting.
+  dropDisposedInspections()
   if (inspectionQueue.length === 0) {
     return
   }
   const now = Date.now()
-  if (!canStartInspection(now)) {
+  let starts = availableInspectionStarts(now)
+  if (starts <= 0) {
     scheduleInspectionPump(100)
     return
   }
-
-  const priorityIndex = inspectionQueue.findIndex((task) => task.priority === 'pending-title')
-  const next =
-    priorityIndex !== -1 ? inspectionQueue.splice(priorityIndex, 1)[0] : inspectionQueue.shift()
-  if (!next) {
-    return
+  // The whole shared-observation backlog goes on one start, so a pane's wait is bounded by the
+  // observation budget rather than by how many other panes are also due.
+  const sharedRound = takeSharedObservationRound()
+  if (sharedRound.length > 0) {
+    startInspectionRound(sharedRound, now)
+    starts -= 1
   }
-
-  activeInspections += 1
-  inspectionStarts.push(now)
-  // Why the catch before finally: an unreachable runtime rejects the inspection on a cadence, and a
-  // bare `.finally()` chain re-raises it as a renderer-global unhandledrejection. Coordinators own
-  // their own failure/backoff state, so the queue only has to keep its accounting running.
-  void next
-    .run()
-    .catch(() => {})
-    .finally(() => {
-      activeInspections = Math.max(0, activeInspections - 1)
-      if (inspectionQueue.length > 0) {
-        scheduleInspectionPump()
-      }
-    })
+  while (starts > 0 && inspectionQueue.length > 0) {
+    const priorityIndex = inspectionQueue.findIndex((task) => task.priority === 'pending-title')
+    const next =
+      priorityIndex !== -1 ? inspectionQueue.splice(priorityIndex, 1)[0] : inspectionQueue.shift()
+    if (!next) {
+      break
+    }
+    startInspectionRound([next], now)
+    starts -= 1
+  }
 
   if (inspectionQueue.length > 0) {
     scheduleInspectionPump()
@@ -83,7 +158,7 @@ function pumpInspectionQueue(): void {
 
 export function enqueueAgentProcessInspection(task: InspectionTask): void {
   inspectionQueue.push(task)
-  pumpInspectionQueue()
+  queueInspectionPump()
 }
 
 export function resetAgentProcessInspectionQueueForTests(): void {
@@ -91,6 +166,7 @@ export function resetAgentProcessInspectionQueueForTests(): void {
     clearTimeout(inspectionPumpTimer)
     inspectionPumpTimer = null
   }
+  inspectionPumpQueued = false
   activeInspections = 0
   inspectionStarts.length = 0
   inspectionQueue.length = 0

--- a/src/renderer/src/components/terminal-pane/agent-process-inspection-round.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-process-inspection-round.test.ts
@@ -1,0 +1,149 @@
+// Regression guard for the inspection admission budget. The cadence tiers
+// (active 750ms / idle 2000 / hidden 3000 / no-evidence 15000) were a per-pane
+// promise the queue could not keep: the budget of 8 starts per second was spent
+// one pane at a time, so N due panes meant roughly N/8 seconds between
+// inspections for each of them and agent-completion latency degraded as the
+// user added panes. Local inspections all resolve out of one TTL-and-in-flight-
+// deduped process-table capture, so a whole round of them is one host
+// observation and rides one start, launched in a single tick. The budget itself
+// is unchanged — it just buys the whole round instead of one pane.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  enqueueAgentProcessInspection,
+  resetAgentProcessInspectionQueueForTests
+} from './agent-process-inspection-queue'
+
+const PANES = 300
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  resetAgentProcessInspectionQueueForTests()
+})
+
+describe('agent process inspection rounds', () => {
+  it('inspects every pane of a 300-pane round inside the same admission budget', async () => {
+    const inspected = new Set<string>()
+
+    for (let index = 0; index < PANES; index += 1) {
+      const ptyId = `pty-${index}`
+      enqueueAgentProcessInspection({
+        priority: 'cadence',
+        canRun: () => true,
+        sharesHostObservation: true,
+        run: async () => {
+          await Promise.resolve()
+          inspected.add(ptyId)
+        }
+      })
+    }
+    // Well inside one 1s rate-limiter window: pre-fix only the 8 starts that window
+    // allows are spent, so only 8 of the 300 panes are ever inspected.
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(inspected.size).toBe(PANES)
+  })
+
+  it('launches the whole round in one tick on one start', async () => {
+    const launchesPerTick = new Map<number, number>()
+    let unshared = 0
+
+    for (let index = 0; index < PANES; index += 1) {
+      enqueueAgentProcessInspection({
+        priority: 'cadence',
+        canRun: () => true,
+        sharesHostObservation: true,
+        run: async () => {
+          // Fake timers freeze the clock inside a tick, so a shared timestamp is a shared burst.
+          const tick = Date.now()
+          launchesPerTick.set(tick, (launchesPerTick.get(tick) ?? 0) + 1)
+        }
+      })
+    }
+    // Seven unshared panes still fit, which is what proves the round cost exactly one of
+    // the eight starts rather than one per pane until the concurrency slots filled.
+    for (let index = 0; index < 7; index += 1) {
+      enqueueAgentProcessInspection({
+        priority: 'cadence',
+        canRun: () => true,
+        sharesHostObservation: false,
+        run: async () => {
+          unshared += 1
+        }
+      })
+    }
+    await vi.advanceTimersByTimeAsync(200)
+
+    // One synchronous burst carries every pane, so they hit one process-table capture
+    // rather than serializing across the limiter.
+    expect([...launchesPerTick.values()]).toEqual([PANES])
+    expect(unshared).toBe(7)
+  })
+
+  it('keeps a pane whose read is not shared admitted one round trip at a time', async () => {
+    const started: string[] = []
+
+    for (let index = 0; index < PANES; index += 1) {
+      enqueueAgentProcessInspection({
+        priority: 'cadence',
+        canRun: () => true,
+        // Remote panes: each costs its own execution-host round trip, so no round shares them.
+        sharesHostObservation: false,
+        run: async () => {
+          started.push(`ssh-${index}`)
+        }
+      })
+    }
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(started.length).toBeLessThanOrEqual(8)
+  })
+
+  it('still serves a pending-title read ahead of the queued cadence backlog', async () => {
+    const order: string[] = []
+
+    for (let index = 0; index < 20; index += 1) {
+      enqueueAgentProcessInspection({
+        priority: 'cadence',
+        canRun: () => true,
+        sharesHostObservation: false,
+        run: async () => {
+          order.push(`cadence-${index}`)
+        }
+      })
+    }
+    enqueueAgentProcessInspection({
+      priority: 'pending-title',
+      canRun: () => true,
+      sharesHostObservation: false,
+      run: async () => {
+        order.push('pending-title')
+      }
+    })
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(order.length).toBeLessThanOrEqual(8)
+    expect(order).toContain('pending-title')
+  })
+
+  it('drops disposed panes out of the round instead of inspecting them', async () => {
+    const inspected: number[] = []
+
+    for (let index = 0; index < PANES; index += 1) {
+      enqueueAgentProcessInspection({
+        priority: 'cadence',
+        canRun: () => index % 2 === 0,
+        sharesHostObservation: true,
+        run: async () => {
+          inspected.push(index)
+        }
+      })
+    }
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(inspected).toEqual(Array.from({ length: PANES / 2 }, (_unused, index) => index * 2))
+  })
+})


### PR DESCRIPTION
## ELI5

Orca watches the programs running in your terminals so it can tell you when an agent
finishes. To avoid hammering the app it only allows itself 8 of those checks per second,
across every pane you have open — and it spent them one pane at a time.

That works fine with a handful of panes. With three hundred, 8 checks a second means each
individual pane gets looked at about once every forty seconds, even though the code believes
it is checking that pane every three quarters of a second. So the more agents you run, the
longer Orca takes to notice one has finished — exactly backwards from what you want.

But those checks were never eight *separate* things. Every local pane's answer is read out of
one snapshot of the machine's process list, which Orca already captures at most twice a
second no matter how many panes ask. Eight panes asking is one look at the process list; three
hundred panes asking is also one look at the process list.

So the allowance was counting the wrong thing. It now counts looks at the process list instead
of panes. The number stays at 8 per second; it just buys three hundred panes now instead of
eight.

## Why it matters

The budget is a hard global cap:

- `MAX_INSPECTION_STARTS_PER_SECOND = 8` in
  `src/renderer/src/components/terminal-pane/agent-process-inspection-queue.ts`, shared by
  every pane in the app.
- The tiers it is supposed to serve are active `750ms` / idle `2000` / hidden `3000` /
  no-evidence `15000` (`agent-completion-poll-cadence.ts`).

A pane re-enqueues once per tier interval, and the queue was FIFO one-at-a-time, so the
effective per-pane period was `max(tier, N/8 seconds)`. Every pane past the eighth was served
at the cap's rate, not its tier's. The reporting session had **905 terminal leaves**; at a few
hundred panes holding agent evidence the effective period is tens of seconds for a pane the
code polls at 750ms–3000ms. That is user-visible as "Orca didn't tell me my agent finished",
and it gets worse monotonically as panes are added.

Note on what this is *not*: it is not a subprocess-churn fix. `getProcessTableSnapshot()`
already sits behind a 500ms TTL plus in-flight dedupe (`src/shared/process-table-snapshot-reader.ts`),
on Windows too (`readWindowsProcessTable`), so the `ps`/process-table capture rate is ~2/s
app-wide regardless of pane count. That TTL is exactly what makes a whole round of local reads
one host observation, and it is what the limiter should have been counting all along.

## What changed

Three renderer files. **No IPC, preload, wire, or main-process change** — each pane keeps its
existing per-pane `pty:inspectProcess` invoke.

- `agent-process-inspection-queue.ts` — `canStartInspection` becomes `availableInspectionStarts`,
  the pump drains every `sharesHostObservation` task as one round on one start, and starts the
  round's tasks synchronously so they all land in the same tick (and therefore the same
  process-table capture window). `enqueueAgentProcessInspection` now pumps on a deduplicated
  microtask instead of inline, so a synchronous burst of enqueues forms *one* round — pumping
  inline spent a start per pane until the concurrency slots filled and then parked the rest of
  the burst on the 100ms retry. Unshared tasks keep the old one-start-each admission and the
  old `pending-title` priority. Disposed tasks are compacted out in one pass instead of a
  splice per drop, so the per-round predicate cost is linear rather than quadratic at pane scale.
- `agent-completion-process-monitor.ts` — sets `sharesHostObservation` from `isRemotePtyId`.
- `agent-process-inspection-round.test.ts` — new guard.

An earlier revision of this PR also added a `pty:inspectProcessBatch` IPC channel, a preload
method, a renderer coalescer, a batch entry type and a 256-entry chunk limit. That is dropped.
It carried all of the merge risk (new wire surface, per-entry guard threading, positional
short-reply semantics, capability fallback) and a failure mode that does not exist today — one
hung entry inside a `Promise.all` chunk withholding up to 255 sibling results — while main's
batch handler was itself only `Promise.all` over the identical per-entry inspection. It saved
invoke framing and nothing else. The measurement section below prices that framing.

## Measurement

Deterministic counter guard, no wall-clock assertion. 300 panes enqueue a cadence
inspection; advance fake timers 200ms (well inside one rate-limiter window) and count how
many panes were actually inspected.

**Before** (queue file reverted to `origin/main`, everything else this branch):

```
 FAIL  src/renderer/.../agent-process-inspection-round.test.ts
   × inspects every pane of a 300-pane round inside the same admission budget
   × launches the round in one tick instead of one pane per admission
   × drops disposed panes out of the round instead of inspecting them

AssertionError: expected 8 to be 300 // Object.is equality
     47|     expect(inspected.size).toBe(PANES)
AssertionError: expected [ 4, 1, 1, 1, 1 ] to deeply equal [ 300 ]
     83|     expect([...launchesPerTick.values()]).toEqual([PANES])

 Tests  3 failed | 2 passed (5)
```

**After:** `Test Files  1 passed (1) / Tests  5 passed (5)`

Starts spent, same 200ms window, same 300 panes:

| | starts | panes inspected | per-pane period at N=300 |
| --- | ---: | ---: | ---: |
| before | 8 | 8 | ~37.5s (N/8) |
| after | 1 | 300 | tier + one admission slot |

Verified at 50 / 300 / 800 panes: `inspected=50 bursts=[50]`, `inspected=300 bursts=[300]`,
`inspected=800 bursts=[800]` — one start, one tick, full coverage, at every scale.

### What dropping the batch IPC costs

The one thing the batch bought was invoke framing, so it was priced directly rather than
argued about. Real Electron 43 IPC, hidden `BrowserWindow`, `process.cpuUsage()` deltas
sampled in **both** the renderer and the main process (this machine is loaded, so wall clock
is reported but not relied on), 60 rounds per measurement × 2 interleaved passes, 15 warmup
rounds. Both shapes run the identical per-entry host work behind a shared TTL'd snapshot, so
the only variable is framing. Harness: `/tmp/orcaperf/ipc-bench-18438`.

| panes | shape | invokes/round | renderer µs CPU/round | main µs CPU/round | total µs CPU/round | µs CPU/pane | sync launch burst p95 | round latency median |
| ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 50 | **per-pane (shipped)** | 50 | 827 | 1088 | 1915 | 38.3 | 0.15 ms | 0.60 ms |
| 50 | batch | 1 | 126 | 123 | 250 | 5.0 | 0.10 ms | 0.20 ms |
| 300 | **per-pane (shipped)** | 300 | 3957 | 5504 | 9462 | 31.5 | 0.40 ms | 3.00 ms |
| 300 | batch | 2 | 476 | 466 | 942 | 3.1 | 0.10 ms | 0.60 ms |
| 800 | **per-pane (shipped)** | 800 | 10255 | 13741 | 23996 | 30.0 | 0.85 ms | 7.70 ms |
| 800 | batch | 4 | 1122 | 1462 | 2584 | 3.2 | 0.20 ms | 1.00 ms |

So the batch was worth ~10x on framing: ~30µs of aggregate CPU per pane-inspection versus
~3µs. Converted to steady state — inspections/s is `N / tier`, identical under both shapes,
because both inspect the whole round inside one window:

| panes | tier | inspections/s | per-pane CPU/s | batch CPU/s | delta |
| ---: | --- | ---: | ---: | ---: | ---: |
| 300 | active 750ms | 400 | 12.6 ms/s (1.3% of one core) | 1.3 ms/s | +11.4 ms/s |
| 300 | hidden 3000ms | 100 | 3.2 ms/s (0.3%) | 0.3 ms/s | +2.8 ms/s |
| 800 | active 750ms | 1067 | 32.0 ms/s (3.2% of one core) | 3.5 ms/s | +28.6 ms/s |
| 800 | hidden 3000ms | 267 | 8.0 ms/s (0.8%) | 0.9 ms/s | +7.1 ms/s |

Three things put that in scale:

1. **It does not touch the frame budget.** The queue starts a round in one synchronous burst,
   so the jank-relevant number is how long that burst holds the renderer main thread. It is
   **0.85 ms at p95 even when all 800 panes ride a single round** — 5% of a 16.7 ms frame. The
   batch's is 0.20 ms. No frame is dropped at any tested pane count; the rest of the cost is
   completion handling spread across later ticks.
2. **It is small against the capture the feature already pays for.** One
   `ps -axo pid=,ppid=,pgid=,tpgid=,stat=,tty=,lstart=,command=` on this machine (1814
   processes, 453 KB) costs 254 ms CPU (30 ms user + 224 ms sys) in the forked `ps`, plus
   2.3 ms in the main process to drain the pipe. The 500 ms TTL caps that at 2/s app-wide, so
   the feature already spends ~510 ms CPU/s there **at any pane count, on `main` today**. The
   framing delta is 2.2% of that at 300 active panes and 5.6% at 800. (Both the numerator and
   that denominator are inflated on this box — 1814 processes is ~3x a normal machine — and
   they inflate together.)
3. **Neither shape changes the win.** Coverage and latency are identical: 300/300 and 800/800
   panes inspected inside one rate-limiter window either way. The batch only ever made the
   mechanism cheaper, never faster.

Against that, the batch cost a new IPC channel, a preload method with a capability fallback,
per-entry incarnation-guard threading, positional short-reply semantics, and a `Promise.all`
chunk in which one hung entry withholds up to 255 sibling results — a head-of-line stall that
does not exist when each pane owns its own invoke. Trading a few percent of one core for that
surface is the wrong side of the trade, so it is dropped. If the CPU ever becomes the binding
constraint, the batch is a self-contained follow-up that needs none of this PR undone.

For reference, `main` spends only ~0.24 ms CPU/s on inspection round trips at any N — because
it only ever performs 8 of them per second, which is the bug.

## Correctness

**No wire, IPC, preload or main-process surface changes.** `git diff origin/main --stat` is
three files, all under `src/renderer/src/components/terminal-pane/`. Every pane still calls
the same `pty:inspectProcess` with the same arguments and gets the same reply; nothing about
what is computed, by whom, or how it is transported changes. Only *when* the renderer is
allowed to issue the call changes.

**Verdict integrity** (`docs/reference/ssh-execution-boundary.md`). Untouched. Each pane's
inspection is its own promise, its own rejection, and its own
`classifyTerminalProcessInspectionFailure`. There is no shared reply, no positional decoding,
and no path by which one pane's outcome is derived from a sibling's. The vocabulary stays
`live` / `unverifiable` / `exited`.

**Per-pane incarnation guard.** `expectedIncarnationId` is captured per request and rechecked
after the await (`getExpectedIncarnationId() === expectedIncarnationIdAtRequest` in
`agent-completion-process-monitor.ts`), exactly as before. The queue never inspects, reorders
or merges a task's arguments — it only decides which tick a task's `run()` is invoked on, and
`run()` closes over its own pane's state.

**Remote wire compatibility** (`docs/reference/remote-wire-compatibility.md`). No wire change
and no behavior change for remote panes. `shouldRunCadenceInspection()` already returns `false`
for remote PTY ids, so SSH and paired-runtime panes never cadence-poll; their only inspections
are pending-title ones, they are flagged `sharesHostObservation: false`, and they keep the
existing one-start-each admission and the existing `pending-title` priority. Old and new
clients are indistinguishable on the wire. The remote plan stays the one already recorded in
`agent-process-inspection-cost.ts` — consume the batched foreground evidence hosts already
publish on the `pty.listProcesses` inventory (#17525) — which this PR does not pre-empt.
`src/main/providers/ssh-pty-provider-rpc-operations.ts` is untouched.

**Does the 8/s cap still need to exist?** Yes, and it is numerically unchanged. What was wrong
was its *unit*: it counted panes when it should have counted host observations. A start is now
one observation — a shared round costs one however many panes ride it, an unshared (remote)
task costs one each. `MAX_CONCURRENT_INSPECTIONS = 4` is likewise unchanged and now bounds
concurrent rounds. A round holds its concurrency slot until its *last* task settles, so a slow
pane cannot let the next round overlap it.

**Priority ordering.** The shared round drains before the unshared `pending-title` scan within
the same pump. This is not starvation: a *local* pending-title read is itself
`sharesHostObservation: true` and rides that very round, and a *remote* pending-title read is
served in the same pump from the 7 remaining starts. Raised (non-blocking) by pullfrog; the
split does not change the ordering it reviewed, and the reasoning still holds.

**Edge cases.** SSH and paired-runtime panes: unchanged path, unchanged admission, still
`hidden`/no-cadence. Folder workspaces: this path keys on PTY id only and never touches
worktree state. Windows: `isAgentProcessInspectionCostly` and the `no-evidence` 15s tier are
untouched, `readWindowsProcessTable` has the same TTL+dedupe that makes the round shared, and
the existing `agent-completion-no-evidence-cadence.test.ts` guard still passes. Empty queue,
all-disposed queue, and clock-jump-backwards (`now < inspectionStarts[0]`) all keep their
existing handling.

## Negative user-facing trade-offs

**None user-facing.** Every pane still gets the same inspection, computed by the same code,
transported the same way, with the same guard; both the admission budget and the cadence tiers
are numerically unchanged, and no pane waits on a window its own cadence did not already
contain.

**One measured non-user-facing cost, stated plainly:** because each pane keeps its own invoke,
this spends ~10x the IPC framing CPU that the dropped batch revision would have — ~30µs of
aggregate renderer+main CPU per pane-inspection instead of ~3µs. In absolute terms that is
**+11.4 ms CPU/s at 300 panes all holding a live agent, and +28.6 ms/s at an adversarial 800**
(1.3% and 3.2% of one core, split across two processes). It does not cost a frame — the
synchronous launch burst is 0.85 ms at p95 with all 800 panes in one round — and it is a few
percent of the ~510 ms CPU/s the process-table captures behind this feature already cost on
`main` at any pane count. It is a real number and it is the price of not adding the batch's
wire surface and head-of-line-stall failure mode. Table and method above.

## Linked Issue

N/A — no tracking issue. This came out of a performance session on a report with **905 terminal
leaves**, where the per-pane cadence tiers were silently degrading to `max(tier, N/8 seconds)`.

## Visual Proof

`N/A` — nothing rendered changes. There is no new UI, no layout, color, typography or component
change, and no new interaction: the same inspection runs for the same panes with the same tiers
and the same global budget. The only observable difference is *when* an existing completion
signal fires at high pane counts, which is not screenshottable at 300 panes; it is pinned instead
by the deterministic counters in `agent-process-inspection-round.test.ts`
(`inspected=300`, `bursts=[300]`, red on `origin/main` with `expected 8 to be 300`) and by the
CPU-delta table under **Measurement**.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane src/renderer/src/runtime` — 596 files / 5474 tests pass (and 667 files / 6141 with `src/main/ipc/pty` added).
- `... src/main/ipc/pty-session-liveness-and-ownership.test.ts src/main/providers` — 85 files / 868 tests pass.
- New `agent-process-inspection-round.test.ts`: 300-pane coverage guard (red proof above),
  single-tick round launch on a single start (with 7 unshared panes still fitting in the same
  window, which is what proves the round cost one start), remote panes still admitted one start
  at a time at N=300,
  `pending-title` still prioritized, disposed panes dropped out of the round.
- `tsc --noEmit -p config/tsconfig.node.json` and `-p config/tsconfig.tc.web.json` both clean.
- `pnpm run check:code-quality:changed` — 0 new findings across 3 changed files.
- `oxfmt --write` + `oxlint` clean on all changed files.

