### PR TITLE
perf(startup): stop the persistence startup milestone from timing its own details closure

### DIFF
--- a/src/main/persistence-loading-store-extraction.test.ts
+++ b/src/main/persistence-loading-store-extraction.test.ts
@@ -116,6 +116,47 @@ describe('loading Store extraction seams', () => {
     })
   })
 
+  it('timestamps persistence-load-done before resolving its details closure', () => {
+    const sentinel = 'startup-diagnostics-workspace-session-sentinel-ordering'
+    vi.stubEnv('ORCA_STARTUP_DIAGNOSTICS', '1')
+    const state = getDefaultPersistedState(testState.dir)
+    state.workspaceSession = { ...state.workspaceSession, activeTabId: sentinel }
+    writeDataFile(state)
+
+    // Fake clock only the details closure advances, so a post-closure timestamp is unambiguous.
+    let clock = 0
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => clock)
+    const realStringify = JSON.stringify
+    const stringifySpy = vi.spyOn(JSON, 'stringify').mockImplementation(((
+      value: unknown,
+      ...rest: unknown[]
+    ) => {
+      if (
+        value &&
+        typeof value === 'object' &&
+        (value as { activeTabId?: unknown }).activeTabId === sentinel
+      ) {
+        clock += 1000
+      }
+      return (realStringify as (...args: unknown[]) => string)(value, ...rest)
+    }) as typeof JSON.stringify)
+
+    try {
+      const store = createStore()
+      store.freezeWrites()
+    } finally {
+      stringifySpy.mockRestore()
+      nowSpy.mockRestore()
+    }
+
+    const loadDoneCall = logStartupDiagnosticMock.mock.calls.find(
+      ([event]) => event === 'persistence-load-done'
+    )
+    const details = loadDoneCall?.[1] as Record<string, unknown> | undefined
+    expect(details?.workspaceSessionBytes).toEqual(expect.any(Number))
+    expect(details?.t).toBe(0)
+  })
+
   it('accepts the first JSON-parseable backup even when an older backup has richer state', async () => {
     mkdirSync(testState.dir, { recursive: true })
     writeFileSync(dataFile(), '{{corrupt-primary', 'utf-8')

--- a/src/main/persistence/loading-store/loaded-state-parsing.ts
+++ b/src/main/persistence/loading-store/loaded-state-parsing.ts
@@ -51,8 +51,10 @@ function logPersistenceStartupMilestone(
   if (!isStartupDiagnosticsEnabled()) {
     return
   }
+  // Why: snapshot `t` before resolving lazy details — otherwise an expensive details closure is billed to the milestone it measures.
+  const t = Math.round(performance.now())
   const resolvedDetails = typeof details === 'function' ? details() : details
-  logStartupDiagnostic(event, { t: Math.round(performance.now()), ...resolvedDetails })
+  logStartupDiagnostic(event, { t, ...resolvedDetails })
 }
 
 import type { StoreRuntimeState } from './store-runtime-state'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Orca has a stopwatch that records how long startup takes. One of the stopwatch's own steps was doing real work — squashing the entire saved session into a string just to report how big it is — and it was doing that work *before* pressing the stopwatch button. So the stopwatch was timing itself. This moves the button press to before the work, so the number it reports is the number it claims to report.

Nothing users can see changes. The same diagnostic line comes out, with the same fields and the same byte count. Only the recorded timestamp moves.

Along the way I went looking for the 145 ms "tab-scaling gap" this PR was originally supposed to fix. It isn't where the report said it was, and there is no free win to take. The measurements are below; I shipped only the correctness fix.

## Why it matters

`src/main/persistence/loading-store/loaded-state-parsing.ts` resolved the lazy `details` closure *before* reading the clock:

```ts
const resolvedDetails = typeof details === 'function' ? details() : details
logStartupDiagnostic(event, { t: Math.round(performance.now()), ...resolvedDetails })
```

The only closure call site is `persistence-load-done`, whose details do `Buffer.byteLength(JSON.stringify(migrated.workspaceSession))` — a full serialization of the whole workspace session.

Measured cost of that serialization, `process.cpuUsage()` median of 25 runs on a 1.61 MB workspace session (the synthetic profile below, shaped to match the reporter's real one):

```
workspaceSession bytes: 1607843
Buffer.byteLength(JSON.stringify(workspaceSession)) median CPU ms: 2.73
```

The reporter measured 3.19 ms on their real 1.88 MB session. Consistent.

### Which previously-reported numbers this invalidates

`derivePhases` in `tests/tools/benchmarks/startup-time-bench.mjs` computes
`startupStoreLoadMs = t(persistence-load-done) − t(persistence-load-start)`.
That delta ended *after* the stringify, so **every previously reported `startupStoreLoadMs` is inflated by the serialization cost of that profile's workspace session** — ~2.7 ms on a 1.6 MB session, ~3.2 ms on the reporter's 1.88 MB one. Any per-profile `startupStoreLoadMs` comparison in this investigation should have that subtracted. The same applies to any hand-computed delta anchored on `persistence-load-done`.

**What this does NOT fix, and I want to be explicit about it:** `appReadyToServices` is `t(services-initialized) − t(app-ready)`. The stringify still *executes* when `ORCA_STARTUP_DIAGNOSTICS=1`, it just no longer lands inside the `persistence-load-done` timestamp. So `appReadyToServices` (and anything else measured past the Store constructor) keeps that ~3 ms. Diagnostics-enabled totals remain an upper bound on production, by roughly the size of that one serialization. Fixing that would mean either dropping `workspaceSessionBytes` from the diagnostic or deferring it to a later tick, both of which change what the instrument reports — out of scope for a correctness fix.

### Audit of the other call sites

Every other `logStartupDiagnostic` / `logStartupMilestone` / `logDaemonMilestone` call site passes an **eagerly evaluated object literal**, so its details are computed before the function is even entered and the ordering inside the function cannot help them. I checked each for an expensive expression:

- `persistence-read-done` — `Buffer.byteLength(raw)` on the raw file string. O(n) but sub-millisecond; measured at 0–1 ms CPU for the whole `load-start → read-done` span on a 3.43 MB file.
- `main-process-plugins.ts:125` — `getDiscovered().length`, O(installed plugins).
- `main-process-preflight.ts`, `daemon-provider-init.ts`, `daemon-process-identity-query.ts`, `event-loop-stall-probe.ts`, `main-window-controller.ts`, `main-process-pty-startup.ts`, `main-process-i18n-menu.ts`, `main-window-updater.ts`, `windows-install-dir-acl-recovery.ts`, `main-process-ipc-bootstrap.ts` — booleans, paths, counters, pre-computed durations. None allocate or traverse state.

`persistence-load-done` is the only closure and the only expensive one.

## Measurement

### Regression test fails without the change

The test drives a real `Store` load with `performance.now()` stubbed to a clock that **only the details closure advances** (via a `JSON.stringify` spy keyed on a sentinel), so the assertion is deterministic — no wall-clock threshold.

Without the fix (ordering reverted, test unchanged):

```
 FAIL  src/main/persistence-loading-store-extraction.test.ts > loading Store extraction seams > timestamps persistence-load-done before resolving its details closure
AssertionError: expected 1000 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1000

 ❯ src/main/persistence-loading-store-extraction.test.ts:156:24
    154|     const details = loadDoneCall?.[1] as Record<string, unknown> | und…
    155|     expect(details?.workspaceSessionBytes).toEqual(expect.any(Number))
    156|     expect(details?.t).toBe(0)
       |                        ^

 Test Files  1 failed (1)
      Tests  1 failed | 9 skipped (10)
```

With the fix:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

`workspaceSessionBytes` is still asserted present in the same call, so the fix cannot be "passed" by deleting the closure.

### Microbenchmark

`Buffer.byteLength(JSON.stringify(workspaceSession))`, `process.cpuUsage()` median of 25, 1.61 MB session: **2.73 ms CPU**. That is the amount removed from `startupStoreLoadMs`.

---

## Part B: the 145 ms `appReadyToServices` tab-scaling gap — investigated, no fix shipped

The brief's premise was that `appReadyToServices` grows 97 ms → 242 ms with 801 session tabs, that the `Store` load is only ~37 ms, and therefore **the gap must be downstream of persistence**. I could not reproduce that. The gap is not downstream of persistence; it *is* persistence, and the 37 ms figure understates the packaged-app cost by about 2x.

### Method

Temporary `cpu: Math.round((process.cpuUsage().user + process.cpuUsage().system) / 1000)` was added to every startup milestone, plus temporary phase markers inside `Store.load()` and the `Store` constructor. Packaged app, `tests/tools/benchmarks/startup-time-bench.mjs`, medians over 5–7 iterations. **All instrumentation has been removed** — the diff in this PR is 2 files, and `git status --porcelain` is clean apart from them.

Wall clock on this box is unusable, exactly as warned: across two 3-iteration runs in the same session, wall-clock `appReadyToServices` came out **195 ms for the empty profile and 90 ms for the 801-tab profile** — the sign of the "gap" flipped. CPU deltas reproduced to within ~5% across independent runs. Everything below is CPU.

### Fixture

The bench fixture generates one worktree, so `--session-tabs 801` gives 801 tabs in a single worktree and no `worktreeMeta` — it cannot produce the reporter's profile shape. Rather than report a number the fixture cannot produce, I built the missing shape by hand on top of a bench-created fixture:

| | reporter's real profile | fixture used here |
|---|---|---|
| total `orca-data.json` | 3.64 MB | 3.43 MB |
| `workspaceSession` | 1.88 MB | 1.56 MB |
| `workspaceSessionsByHostId` | 253 KB, 10 partitions, 5 empty | 481 KB, 10 partitions, 5 empty |
| worktree tab-groups | 413 | 413 |
| session tabs | 801 | 801 |
| `worktreeMeta` rows | 1,349 | 1,349 |

(One trap worth recording: the app reads `<userData>/profiles/local-default/orca-data.json`, not `<userData>/orca-data.json`. A fixture directory that has already been benched once will silently keep serving the old profile copy. My first two attempts measured the wrong state because of this.)

### Result — CPU ms, median of 7 iterations

| phase | empty profile | reporter-shaped profile | delta |
|---|---|---|---|
| `app-ready → persistence-load-start` | 26 | 27 | +1 |
| **`persistence-load-start → persistence-load-done`** | **1** | **72** | **+71** |
| `persistence-load-done → store-loaded` (rest of `Store` ctor) | 1 | 4 | +3 |
| **`store-loaded → services-initialized`** | **43** | **45** | **+2** |
| **`app-ready → services-initialized`** | **71** | **147** | **+76** |
| `services-initialized → window-created` | 70 | 69 | −1 |
| `window-created → did-finish-load` | 218 | 239 | +21 |
| **`did-finish-load → renderer-startup-hydration-done`** | **118** | **272** | **+154** |

**93% of the `appReadyToServices` scaling is inside `Store.load()`. Downstream of the `Store` constructor it is +2 ms — i.e. nothing.**

### Bisection inside `Store.load()` (temporary markers, CPU ms, median of 5, reporter-shaped profile)

```
 27  app-ready                     -> persistence-load-start      (profile setup; 26 on empty too)
 10  persistence-load-start        -> json-parse-done             (readFileSync + JSON.parse, 3.43 MB)
  1  json-parse-done               -> prepare-done
 51  prepare-done                  -> normalizeLoadedProfileState  <-- 65% of the whole load
  1  normalize-done                -> prune-done                  (scrollback buffers + browser history)
  0  prune-done                    -> scrollback-snapshot-done
  1  scrollback-done               -> automigrations-done         (project groups, host setup, automations, folder scope)
  3  automigrations-done           -> normalizeWorktreeLinkedItemMetadata
  7  worktreemeta-normalize-done   -> gcStaleWorktreeMeta          (existsSync fan-out over 1,349 rows)
  0  gc-done                       -> cohorts + github sidecar
  1  cohorts-done                  -> persistence-load-done       (the diagnostics stringify, Part A)
  0  persistence-load-done         -> load() returns
  0  load returns                  -> normalizePersistedPaneIdentityState
  0                                -> activeViewPreference
  0                                -> adaptFlatFolderScanProjectGroups + hydrateFolderWorkspaceDiffComments
  2                                -> sweepDeregisteredRepoResidue
  1                                -> store-loaded
 43  store-loaded                  -> services-initialized        (43 on the empty profile too — zero scaling)
```

### Conclusions

1. **The premise is wrong.** There is no 145 ms tab-scaling cost downstream of persistence. `store-loaded → services-initialized` is 43 ms CPU on an empty profile and 45 ms CPU on a profile with 801 tabs, 413 worktrees, 1,349 `worktreeMeta` rows and 10 host partitions. Observers, runtime construction, automations, plugins, star-nag, browser bridge, emulator bridge and the worktree-trash sweep collectively contribute ~0 tab scaling.
2. **The ~37 ms `loader.load()` figure from vitest understates the packaged app by ~2x.** In the real main process, on a comparable profile, `loader.load()` is **72 ms CPU**. It runs exactly once, cold, with no JIT warm-up — the opposite of the "less in the packaged app" assumption that led the investigation to look downstream.
3. **The single dominant cost is `normalizeLoadedProfileState` at 51 ms CPU** — the zod validation of the workspace session and each host partition. The brief explicitly rules this out ("must run every load by design, NOT yours") and another agent owns `normalize-loaded-profile-state.ts`, so I did not touch it.
4. **Nothing else in the load is a free win.** `gcStaleWorktreeMeta` (7 ms) is the runner-up; it already checks the 30-day grace *before* the `existsSync` fan-out, and the only ways to cut it further are a cache, a cadence, or skipping rows — all disqualified by the free-win bar. `JSON.parse` (10 ms) is irreducible. Everything else is ≤3 ms.
5. **The real tab-scaling hot spot is somewhere else entirely: renderer startup hydration.** `did-finish-load → renderer-startup-hydration-done` goes **118 → 272 ms CPU (+154 ms)** with the same profile — larger than the whole `appReadyToServices` window and outside it. That is where a 145 ms-scale win actually lives, and it is a separate investigation (and other agents own the renderer store).

Per the brief — "if the gap turns out to be irreducible, say so with the breakdown and ship Part A alone" — that is what this PR does.

## Correctness

- **Output is provably identical.** The only change is that `t` is read from `performance.now()` one statement earlier. `details()` is still called exactly once, its result is still spread into the same object in the same order, and `t` is still the first key. Same event name, same fields, same `workspaceSessionBytes` value, same stderr line format.
- **Is `t` still meaningful?** Yes — more so. `t` is documented as "ms since process start" and is meant to mark *when the milestone was reached*, not when the diagnostic line was formatted. Taking it before the closure is what the field already claims to be.
- **Could moving `t` earlier hide real work?** No. The closure is diagnostics-only work that does not exist when `ORCA_STARTUP_DIAGNOSTICS` is unset, so excluding it makes the diagnostics-enabled timeline closer to production, not further.
- **Gating unchanged.** The `isStartupDiagnosticsEnabled()` early return still precedes everything, so with diagnostics off the closure is still never resolved and the workspace session is still never serialized. The existing test asserting zero `JSON.stringify` calls on the session when diagnostics are off still passes.
- **Ordering vs. other milestones.** `t` values remain monotonic: the new `t` is strictly earlier than the old one, and `persistence-load-done` is the last milestone in `load()`, so no earlier milestone can now appear to come after it.
- **SSH / remote hosts:** no wire surface. This is a stderr diagnostic line in the desktop main process; nothing is exchanged with a remote Orca server, no RPC params, stream frames or published content change.
- **Folder workspaces:** the closure reads `migrated.workspaceSession` and `migrated.repos.length`, neither of which assumes a git worktree. Unchanged either way.
- **Windows / Linux / macOS:** no platform-dependent code touched; `performance.now()` and `process.cpuUsage()` behave identically across all three, and the shipped diff does not use `cpuUsage` at all.
- **Empty / missing state:** on a fresh profile `load()` returns defaults and the closure serializes the default session — same before and after; the existing empty-profile bench run exercises this path and emits the milestone normally.
- **Corrupt state / backup recovery:** `load(false)` recursion after a backup restore re-enters the same helper; ordering is per-call, so the recursive call is unaffected.

## Negative user-facing trade-offs

**None.** The changed code only runs when `ORCA_STARTUP_DIAGNOSTICS=1`, which is a benchmark/debug opt-in; with it off, control flow is byte-for-byte identical, and with it on the emitted line is identical apart from a `t` value that is now ~3 ms smaller and more accurate.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/persistence src/main/startup` — 122 files passed, 2 skipped; 1303 tests passed, 7 skipped.
- Verified the new test fails on the unfixed code (`expected 1000 to be +0`) and passes with the fix — both outputs above.
- `nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.node.json --composite false` — exit 0.
- `node_modules/.bin/oxfmt --write` and `node_modules/.bin/oxlint` on both changed files — clean.
- Packaged-app benchmark (`tests/tools/benchmarks/startup-time-bench.mjs`) run against an empty profile and a 3.43 MB reporter-shaped profile, 7 iterations each, before and after the change; no phase regressed and `startupStoreLoadMs` no longer contains the serialization.
- All temporary instrumentation removed and confirmed with `git status --porcelain`; no bench result files left behind.


## Linked Issue

No tracked issue — this came out of the startup-diagnostics/tab-scaling perf investigation described above, not a filed bug.

## Visual Proof

`N/A` — main-process diagnostics timestamp only. Nothing renders; the only observable output is a stderr line emitted under `ORCA_STARTUP_DIAGNOSTICS=1`, and its fields are unchanged.

## Testing

See the Test plan above. Verified on macOS (packaged app + vitest). No platform-dependent code is touched, so Linux/Windows/SSH behave identically — `performance.now()` and the diagnostics gate are platform-neutral and there is no remote wire surface.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Reviewed by `coderabbitai` (no actionable comments) and `pullfrog` (no new issues; ran the test file locally, 10/10). Self-reviewed the ordering change against every `logStartupDiagnostic` call site — see the "Audit of the other call sites" section.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: none — no new input, no new surface. Cross-platform: no platform branches touched. Remote SSH: no wire change; this is a desktop main-process stderr diagnostic. Mobile: unaffected. Backwards compatibility: the diagnostic event name and fields are unchanged. Performance: strictly non-negative — one statement reordered, no extra work.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
