### PR TITLE
perf(renderer): load the project-location and feedback dialogs on click

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.set-location-warm.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.set-location-warm.test.tsx
@@ -9,9 +9,13 @@ import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
 // so this only moves when the composer actually reaches for the chunk.
 const chunk = vi.hoisted(() => ({ loads: 0 }))
 
+// Renders a marker unconditionally so the "warming did not mount it" assertion below can
+// actually fail; a `() => null` stub would make that check vacuous.
 vi.mock('@/components/new-workspace/SetProjectLocationDialog', () => {
   chunk.loads += 1
-  return { SetProjectLocationDialog: () => null }
+  return {
+    SetProjectLocationDialog: () => <div data-testid="set-project-location-dialog" />
+  }
 })
 
 vi.mock('@/store', () => ({

--- a/src/renderer/src/components/NewWorkspaceComposerCard.set-location-warm.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.set-location-warm.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { hostOptions, renderCard } from './NewWorkspaceComposerCard.test-fixture'
+import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
+
+// Counts evaluations of the set-location chunk. A dynamic import evaluates a module once,
+// so this only moves when the composer actually reaches for the chunk.
+const chunk = vi.hoisted(() => ({ loads: 0 }))
+
+vi.mock('@/components/new-workspace/SetProjectLocationDialog', () => {
+  chunk.loads += 1
+  return { SetProjectLocationDialog: () => null }
+})
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        closeModal: vi.fn(),
+        openModal: vi.fn(),
+        openSettingsPage: vi.fn(),
+        openSettingsTarget: vi.fn(),
+        setRuntimeEnvironmentStatus: vi.fn(),
+        setupProjectExistingFolder: vi.fn(),
+        setupProjectClone: vi.fn(),
+        activeModal: 'new-workspace-composer',
+        settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
+        updateSettings: vi.fn(),
+        projects: [],
+        repos: []
+      }),
+    { getState: () => ({}) }
+  )
+}))
+
+vi.mock('@/components/contextual-tours/use-contextual-tour', () => ({
+  useContextualTour: vi.fn()
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/agent/AgentCombobox', () => ({
+  default: () => <button type="button">Agent picker</button>
+}))
+
+vi.mock('@/components/sidebar/AddRemoteHostDialog', () => ({
+  AddRemoteHostDialog: () => null
+}))
+
+vi.mock('@/components/sparse/SparseCheckoutPresetSelect', () => ({
+  default: () => null
+}))
+
+vi.mock('@/components/new-workspace/SmartWorkspaceNameField', () => ({
+  default: () => <input aria-label="workspace name" />
+}))
+
+vi.mock('@/components/new-workspace/ProjectCombobox', () => ({
+  default: () => <div data-testid="project-combobox" />
+}))
+
+const readyOnlyHostOptions = hostOptions.filter((option) => option.kind === 'ready')
+// A disconnected host is a needs-setup row with no "Set location" action, so it must not warm.
+const unavailableHostOptions: ProjectHostSetupOption[] = [
+  ...readyOnlyHostOptions,
+  {
+    kind: 'needs-setup',
+    id: 'needs-setup:ssh:offline',
+    projectId: 'project-group:platform',
+    hostId: 'ssh:offline',
+    label: 'Offline box',
+    detail: 'Not connected',
+    isAvailable: false,
+    attention: false,
+    canSetLocation: false
+  }
+]
+
+// Declaration order matters here and nowhere else: a module evaluates once, so the
+// no-warm cases have to observe the counter before anything warms it.
+describe('NewWorkspaceComposerCard set-location chunk warm', () => {
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    container?.remove()
+    container = null
+  })
+
+  it('does not warm the chunk when no host needs its location set', async () => {
+    container = await renderCard({ projectHostSetupOptions: readyOnlyHostOptions })
+
+    expect(
+      [...container.querySelectorAll('button')].some((button) =>
+        button.textContent?.includes('Set project location')
+      )
+    ).toBe(false)
+    expect(chunk.loads).toBe(0)
+  })
+
+  it('does not warm the chunk when the needs-setup host cannot take a location', async () => {
+    container = await renderCard({ projectHostSetupOptions: unavailableHostOptions })
+
+    expect(chunk.loads).toBe(0)
+  })
+
+  it('warms the chunk on mount for a needs-setup host, before Set project location is clicked', async () => {
+    container = await renderCard()
+
+    expect(chunk.loads).toBe(1)
+    // Warming must not mount the dialog; it still waits on an explicit click.
+    expect(document.body.querySelector('[data-testid="set-project-location-dialog"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx
@@ -1,11 +1,8 @@
 // @vitest-environment happy-dom
 
 import React, { act } from 'react'
-import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import NewWorkspaceComposerCard from './NewWorkspaceComposerCard'
-import type { NewWorkspaceProjectOption } from '@/lib/new-workspace-project-options'
-import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
+import { renderCard } from './NewWorkspaceComposerCard.test-fixture'
 
 const storeMocks = vi.hoisted(() => ({
   closeModal: vi.fn(),
@@ -99,118 +96,6 @@ vi.mock('@/components/new-workspace/SetProjectLocationDialog', () => ({
     ) : null
 }))
 
-const projectOptions: NewWorkspaceProjectOption[] = [
-  {
-    kind: 'project-group',
-    id: 'project-group:platform',
-    projectGroupId: 'platform',
-    displayName: 'Platform',
-    badgeColor: 'var(--muted-foreground)',
-    detail: '/workspace/platform',
-    parentPath: '/workspace/platform',
-    connectionId: null
-  }
-]
-
-const hostOptions: ProjectHostSetupOption[] = [
-  {
-    kind: 'ready',
-    id: 'setup-local',
-    projectId: 'project-group:platform',
-    hostId: 'local',
-    repoId: 'repo-a',
-    label: 'Local Mac',
-    detail: 'Orca',
-    path: '/Users/alice/orca'
-  },
-  {
-    kind: 'needs-setup',
-    id: 'needs-setup:ssh:devbox',
-    projectId: 'project-group:platform',
-    hostId: 'ssh:devbox',
-    label: 'Devbox',
-    detail: 'Project location not set',
-    isAvailable: true,
-    attention: false,
-    canSetLocation: true
-  }
-]
-
-function renderCard(
-  overrides: Partial<React.ComponentProps<typeof NewWorkspaceComposerCard>> = {}
-): HTMLDivElement {
-  const container = document.createElement('div')
-  document.body.appendChild(container)
-  const root = createRoot(container)
-  act(() => {
-    root.render(
-      <NewWorkspaceComposerCard
-        quickAgent={null}
-        onQuickAgentChange={() => {}}
-        eligibleRepos={[]}
-        repoId="repo-a"
-        projectOptions={projectOptions}
-        selectedProjectId="project-group:platform"
-        selectedRepoIsGit
-        onRepoChange={() => {}}
-        onProjectChange={() => {}}
-        primaryActionLabel="Create workspace"
-        name=""
-        onNameValueChange={() => {}}
-        onSmartGitHubItemSelect={() => {}}
-        onSmartGitLabItemSelect={() => {}}
-        onSmartBranchSelect={() => {}}
-        onSmartLinearIssueSelect={() => {}}
-        smartNameSelection={null}
-        onClearSmartNameSelection={() => {}}
-        canReuseSelectedBranch={false}
-        reuseSelectedBranch={false}
-        onReuseSelectedBranchChange={() => {}}
-        forkPushWarning={null}
-        detectedAgentIds={null}
-        onOpenAgentSettings={() => {}}
-        advancedOpen={false}
-        onToggleAdvanced={() => {}}
-        parentWorktreeId={null}
-        onParentWorktreeIdChange={() => {}}
-        createDisabled={false}
-        projectError={null}
-        creating={false}
-        onCreate={() => {}}
-        note=""
-        onNoteChange={() => {}}
-        setupConfig={null}
-        requiresExplicitSetupChoice={false}
-        setupDecision={null}
-        onSetupDecisionChange={() => {}}
-        setupAgentStartupPolicy="start-immediately"
-        onSetupAgentStartupPolicyChange={() => {}}
-        shouldWaitForSetupCheck={false}
-        resolvedSetupDecision={null}
-        createError={null}
-        selectedRepoConnectionId={null}
-        selectedRepoSshStatus={null}
-        selectedRepoRequiresConnection={false}
-        selectedRepoConnectInProgress={false}
-        onConnectSelectedRepo={async () => {}}
-        canUseSparseCheckout={false}
-        sparsePresets={[]}
-        sparseSelectedPresetId={null}
-        onSparseSelectPreset={() => {}}
-        branchNameOverride={undefined}
-        onBranchNameOverrideChange={() => {}}
-        branchesEnabled={false}
-        setupControlsEnabled={false}
-        sparseControlsEnabled={false}
-        projectHostSetupOptions={hostOptions}
-        selectedProjectHostSetupId="setup-local"
-        {...overrides}
-      />
-    )
-  })
-  return container
-}
-
 describe('NewWorkspaceComposerCard set location', () => {
   let container: HTMLDivElement | null = null
 
@@ -228,7 +113,7 @@ describe('NewWorkspaceComposerCard set location', () => {
   // Async because the dialog is a lazy chunk: the click mounts Suspense, the chunk resolves next tick.
   it('opens set-location over the composer without leaving the create dialog', async () => {
     const nestedOpenChanges: boolean[] = []
-    container = renderCard({
+    container = await renderCard({
       onNestedDialogOpenChange: (open) => nestedOpenChanges.push(open)
     })
 
@@ -256,7 +141,7 @@ describe('NewWorkspaceComposerCard set location', () => {
   it('closes the nested dialog before publishing the ready run target', async () => {
     const nestedOpenChanges: boolean[] = []
     const setupChanges: string[] = []
-    container = renderCard({
+    container = await renderCard({
       onNestedDialogOpenChange: (open) => nestedOpenChanges.push(open),
       onProjectHostSetupChange: (setupId) => setupChanges.push(setupId)
     })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx
@@ -251,7 +251,9 @@ describe('NewWorkspaceComposerCard set location', () => {
     expect(storeMocks.openSettingsPage).not.toHaveBeenCalled()
   })
 
-  it('closes the nested dialog before publishing the ready run target', () => {
+  // Async for the same reason: without the flush this only passes when an earlier
+  // test in this file already resolved the shared lazy chunk.
+  it('closes the nested dialog before publishing the ready run target', async () => {
     const nestedOpenChanges: boolean[] = []
     const setupChanges: string[] = []
     container = renderCard({
@@ -266,6 +268,7 @@ describe('NewWorkspaceComposerCard set location', () => {
       (button) => button.textContent?.includes('Set project location')
     )
     act(() => setLocation?.click())
+    await act(async () => {})
     const complete = [...document.body.querySelectorAll<HTMLButtonElement>('button')].find(
       (button) => button.textContent === 'Complete location'
     )

--- a/src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx
@@ -225,7 +225,8 @@ describe('NewWorkspaceComposerCard set location', () => {
     container = null
   })
 
-  it('opens set-location over the composer without leaving the create dialog', () => {
+  // Async because the dialog is a lazy chunk: the click mounts Suspense, the chunk resolves next tick.
+  it('opens set-location over the composer without leaving the create dialog', async () => {
     const nestedOpenChanges: boolean[] = []
     container = renderCard({
       onNestedDialogOpenChange: (open) => nestedOpenChanges.push(open)
@@ -239,6 +240,7 @@ describe('NewWorkspaceComposerCard set location', () => {
     )
     expect(setLocation).toBeTruthy()
     act(() => setLocation?.click())
+    await act(async () => {})
 
     const dialog = document.body.querySelector('[data-testid="set-project-location-dialog"]')
     expect(dialog?.getAttribute('data-host')).toBe('Devbox')

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test-fixture.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test-fixture.tsx
@@ -1,0 +1,120 @@
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import NewWorkspaceComposerCard from './NewWorkspaceComposerCard'
+import type { NewWorkspaceProjectOption } from '@/lib/new-workspace-project-options'
+import type { ProjectHostSetupOption } from '@/lib/project-host-setup-options'
+
+export const projectOptions: NewWorkspaceProjectOption[] = [
+  {
+    kind: 'project-group',
+    id: 'project-group:platform',
+    projectGroupId: 'platform',
+    displayName: 'Platform',
+    badgeColor: 'var(--muted-foreground)',
+    detail: '/workspace/platform',
+    parentPath: '/workspace/platform',
+    connectionId: null
+  }
+]
+
+export const hostOptions: ProjectHostSetupOption[] = [
+  {
+    kind: 'ready',
+    id: 'setup-local',
+    projectId: 'project-group:platform',
+    hostId: 'local',
+    repoId: 'repo-a',
+    label: 'Local Mac',
+    detail: 'Orca',
+    path: '/Users/alice/orca'
+  },
+  {
+    kind: 'needs-setup',
+    id: 'needs-setup:ssh:devbox',
+    projectId: 'project-group:platform',
+    hostId: 'ssh:devbox',
+    label: 'Devbox',
+    detail: 'Project location not set',
+    isAvailable: true,
+    attention: false,
+    canSetLocation: true
+  }
+]
+
+export async function renderCard(
+  overrides: Partial<React.ComponentProps<typeof NewWorkspaceComposerCard>> = {}
+): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(
+      <NewWorkspaceComposerCard
+        quickAgent={null}
+        onQuickAgentChange={() => {}}
+        eligibleRepos={[]}
+        repoId="repo-a"
+        projectOptions={projectOptions}
+        selectedProjectId="project-group:platform"
+        selectedRepoIsGit
+        onRepoChange={() => {}}
+        onProjectChange={() => {}}
+        primaryActionLabel="Create workspace"
+        name=""
+        onNameValueChange={() => {}}
+        onSmartGitHubItemSelect={() => {}}
+        onSmartGitLabItemSelect={() => {}}
+        onSmartBranchSelect={() => {}}
+        onSmartLinearIssueSelect={() => {}}
+        smartNameSelection={null}
+        onClearSmartNameSelection={() => {}}
+        canReuseSelectedBranch={false}
+        reuseSelectedBranch={false}
+        onReuseSelectedBranchChange={() => {}}
+        forkPushWarning={null}
+        detectedAgentIds={null}
+        onOpenAgentSettings={() => {}}
+        advancedOpen={false}
+        onToggleAdvanced={() => {}}
+        parentWorktreeId={null}
+        onParentWorktreeIdChange={() => {}}
+        createDisabled={false}
+        projectError={null}
+        creating={false}
+        onCreate={() => {}}
+        note=""
+        onNoteChange={() => {}}
+        setupConfig={null}
+        requiresExplicitSetupChoice={false}
+        setupDecision={null}
+        onSetupDecisionChange={() => {}}
+        setupAgentStartupPolicy="start-immediately"
+        onSetupAgentStartupPolicyChange={() => {}}
+        shouldWaitForSetupCheck={false}
+        resolvedSetupDecision={null}
+        createError={null}
+        selectedRepoConnectionId={null}
+        selectedRepoSshStatus={null}
+        selectedRepoRequiresConnection={false}
+        selectedRepoConnectInProgress={false}
+        onConnectSelectedRepo={async () => {}}
+        canUseSparseCheckout={false}
+        sparsePresets={[]}
+        sparseSelectedPresetId={null}
+        onSparseSelectPreset={() => {}}
+        branchNameOverride={undefined}
+        onBranchNameOverrideChange={() => {}}
+        branchesEnabled={false}
+        setupControlsEnabled={false}
+        sparseControlsEnabled={false}
+        projectHostSetupOptions={hostOptions}
+        selectedProjectHostSetupId="setup-local"
+        {...overrides}
+      />
+    )
+  })
+  // Settle the mount-time chunk warm before the click, so the click's import() is not
+  // overlapping an in-flight one (vitest's module runner serialises those; a browser does not).
+  await act(async () => {})
+  return container
+}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -100,10 +100,7 @@ export default function NewWorkspaceComposerCard(
   )
   // Why sticky: the dialog animates itself closed off its own `option` prop, so unmounting it
   // when the option clears would cut that animation short.
-  const setLocationDialogRequested = React.useRef(false)
-  if (setLocationOption !== null) {
-    setLocationDialogRequested.current = true
-  }
+  const [setLocationDialogMounted, setSetLocationDialogMounted] = React.useState(false)
 
   const selectedRepo = eligibleRepos.find((candidate) => candidate.id === repoId)
   const selectedRepoName = selectedRepo?.displayName ?? selectedRepo?.path ?? 'This project'
@@ -208,6 +205,7 @@ export default function NewWorkspaceComposerCard(
   }, [onAddProjectOverride, openModal])
   const handleSetLocation = React.useCallback(
     (option: NeedsProjectHostOption): void => {
+      setSetLocationDialogMounted(true)
       setSetLocationOption(option)
       onNestedDialogOpenChange?.(true)
     },
@@ -350,7 +348,7 @@ export default function NewWorkspaceComposerCard(
         submitShortcutModifierLabel={getScreenSubmitModifierLabel()}
       />
       <AddRemoteHostDialog mode={addRemoteHostMode} onOpenChange={setAddRemoteHostMode} />
-      {setLocationDialogRequested.current ? (
+      {setLocationDialogMounted ? (
         <React.Suspense fallback={null}>
           <SetProjectLocationDialog
             option={setLocationOption}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -12,6 +12,7 @@ import {
   type AddRemoteHostMode
 } from '@/components/sidebar/AddRemoteHostDialog'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
+import type * as SetProjectLocationDialogModule from '@/components/new-workspace/SetProjectLocationDialog'
 import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
 import { withUiConnectTimeout } from '@/ssh/ssh-connect-ui-timeout'
 import { isSshConnectInFlight, trackSshConnect } from '@/ssh/ssh-connect-in-flight'
@@ -38,10 +39,14 @@ import { getSshStatusLabel } from './new-workspace/new-workspace-composer-ssh-st
 import { useComposerFileDragOver } from './new-workspace/use-composer-file-drag-over'
 
 // Why lazy: this pulls the ~41 KB project-location browser onto the boot graph, and nothing
-// reaches it without an explicit "Set location" click.
+// reaches it without an explicit "Set location" click. Shared with the warm below so both hit
+// the same module-map entry.
+const loadSetProjectLocationDialog = (): Promise<typeof SetProjectLocationDialogModule> =>
+  import('@/components/new-workspace/SetProjectLocationDialog')
+
 const SetProjectLocationDialog = lazyWithRetry(
   () =>
-    import('@/components/new-workspace/SetProjectLocationDialog').then((module) => ({
+    loadSetProjectLocationDialog().then((module) => ({
       default: module.SetProjectLocationDialog
     })),
   { reloadKey: 'set-project-location-dialog' }
@@ -112,6 +117,16 @@ export default function NewWorkspaceComposerCard(
   const needsSetupProjectHostSetupOptions = projectHostSetupOptions.filter(
     (option) => option.kind === 'needs-setup'
   )
+  // Warm on the precursor: the "Set location" row only renders for a needs-setup host that can
+  // still take one, so the chunk resolves while the picker is being read rather than on the click.
+  const hasSetLocationOption = needsSetupProjectHostSetupOptions.some(
+    (option) => option.canSetLocation
+  )
+  React.useEffect(() => {
+    if (hasSetLocationOption) {
+      void loadSetProjectLocationDialog().catch(() => {})
+    }
+  }, [hasSetLocationOption])
   const shouldShowRunTargetPicker =
     readyProjectHostSetupOptions.length > 0 ||
     ephemeralVmRecipes.length > 0 ||

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -11,7 +11,7 @@ import {
   AddRemoteHostDialog,
   type AddRemoteHostMode
 } from '@/components/sidebar/AddRemoteHostDialog'
-import { SetProjectLocationDialog } from '@/components/new-workspace/SetProjectLocationDialog'
+import { lazyWithRetry } from '@/lib/lazy-with-retry'
 import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
 import { withUiConnectTimeout } from '@/ssh/ssh-connect-ui-timeout'
 import { isSshConnectInFlight, trackSshConnect } from '@/ssh/ssh-connect-in-flight'
@@ -36,6 +36,16 @@ import {
 } from './new-workspace/new-workspace-composer-card-props'
 import { getSshStatusLabel } from './new-workspace/new-workspace-composer-ssh-status'
 import { useComposerFileDragOver } from './new-workspace/use-composer-file-drag-over'
+
+// Why lazy: this pulls the ~41 KB project-location browser onto the boot graph, and nothing
+// reaches it without an explicit "Set location" click.
+const SetProjectLocationDialog = lazyWithRetry(
+  () =>
+    import('@/components/new-workspace/SetProjectLocationDialog').then((module) => ({
+      default: module.SetProjectLocationDialog
+    })),
+  { reloadKey: 'set-project-location-dialog' }
+)
 
 export default function NewWorkspaceComposerCard(
   props: NewWorkspaceComposerCardProps
@@ -83,6 +93,12 @@ export default function NewWorkspaceComposerCard(
   const [setLocationOption, setSetLocationOption] = React.useState<NeedsProjectHostOption | null>(
     null
   )
+  // Why sticky: the dialog animates itself closed off its own `option` prop, so unmounting it
+  // when the option clears would cut that animation short.
+  const setLocationDialogRequested = React.useRef(false)
+  if (setLocationOption !== null) {
+    setLocationDialogRequested.current = true
+  }
 
   const selectedRepo = eligibleRepos.find((candidate) => candidate.id === repoId)
   const selectedRepoName = selectedRepo?.displayName ?? selectedRepo?.path ?? 'This project'
@@ -319,14 +335,18 @@ export default function NewWorkspaceComposerCard(
         submitShortcutModifierLabel={getScreenSubmitModifierLabel()}
       />
       <AddRemoteHostDialog mode={addRemoteHostMode} onOpenChange={setAddRemoteHostMode} />
-      <SetProjectLocationDialog
-        option={setLocationOption}
-        projectName={selectedProjectName}
-        projectKind={selectedRepoIsGit ? 'git' : 'folder'}
-        defaultCloneUrl={defaultCloneUrl}
-        onClose={handleSetLocationClose}
-        onReady={handleSetLocationReady}
-      />
+      {setLocationDialogRequested.current ? (
+        <React.Suspense fallback={null}>
+          <SetProjectLocationDialog
+            option={setLocationOption}
+            projectName={selectedProjectName}
+            projectKind={selectedRepoIsGit ? 'git' : 'folder'}
+            defaultCloneUrl={defaultCloneUrl}
+            onClose={handleSetLocationClose}
+            onReady={handleSetLocationReady}
+          />
+        </React.Suspense>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   updaterCheck: vi.fn(),
   shellOpenUrl: vi.fn(),
   useShortcutKeyDetails: vi.fn(),
+  /** Counts evaluations of the feedback chunk; a dynamic import evaluates it exactly once. */
+  feedbackChunkLoads: 0,
   setupProgress: {
     ready: true,
     coreDoneCount: 2,
@@ -56,7 +58,18 @@ vi.mock('../setup-guide/SetupGuideProgressRing', () => ({
 }))
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
-  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenu: ({
+    children,
+    onOpenChange
+  }: {
+    children: ReactNode
+    onOpenChange?: (open: boolean) => void
+  }) => (
+    <>
+      <button data-testid="open-menu" onClick={() => onOpenChange?.(true)} />
+      {children}
+    </>
+  ),
   DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
   DropdownMenuItem: ({
     children,
@@ -114,9 +127,10 @@ vi.mock('sonner', () => ({
   }
 }))
 
-vi.mock('./SidebarFeedbackDialog', () => ({
-  SidebarFeedbackDialog: () => <div data-testid="feedback-dialog" />
-}))
+vi.mock('./SidebarFeedbackDialog', () => {
+  mocks.feedbackChunkLoads += 1
+  return { SidebarFeedbackDialog: () => <div data-testid="feedback-dialog" /> }
+})
 
 function installWindowApi(): void {
   Object.assign(window, {
@@ -310,6 +324,21 @@ describe('SidebarSettingsHelpMenu', () => {
       includePrerelease: false,
       includePerfPrerelease: false
     })
+  })
+
+  // No other test in this file opens the menu or selects Send Feedback, so the 0 -> 1
+  // transition below is this warm and nothing else, whatever order the tests run in.
+  it('warms the feedback chunk when the menu opens, before Send Feedback is selected', async () => {
+    const container = await renderMenu()
+    expect(mocks.feedbackChunkLoads).toBe(0)
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="open-menu"]')?.click()
+    })
+
+    expect(mocks.feedbackChunkLoads).toBe(1)
+    // Warming must not mount the dialog: it stays behind its own open state.
+    expect(document.body.querySelector('[data-testid="feedback-dialog"]')).toBeNull()
   })
 
   it('renders shortcut keys in the settings tooltip', () => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -108,10 +108,7 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const [menuOpen, setMenuOpen] = useState(false)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
   // Why sticky: the dialog animates itself closed off `open`, so unmounting on close cuts that short.
-  const feedbackDialogRequested = React.useRef(false)
-  if (feedbackOpen) {
-    feedbackDialogRequested.current = true
-  }
+  const [feedbackDialogMounted, setFeedbackDialogMounted] = useState(false)
   const [isRestartingOrca, setIsRestartingOrca] = useState(false)
   const lastShowOnboardingAtRef = React.useRef(0)
   const updateCheckModifiersRef = React.useRef(NO_UPDATE_CHECK_MODIFIERS)
@@ -129,6 +126,11 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
       // so the chunk is already in the module map by the time the item is selected.
       void loadSidebarFeedbackDialog().catch(() => {})
     }
+  }
+
+  const handleOpenFeedback = (): void => {
+    setFeedbackDialogMounted(true)
+    setFeedbackOpen(true)
   }
 
   const handleShowOnboarding = (): void => {
@@ -251,7 +253,7 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
               )}
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
+            <DropdownMenuItem onSelect={handleOpenFeedback}>
               <MessageSquareText className="size-3.5" />
               {translate(
                 'auto.components.sidebar.SidebarSettingsHelpMenu.4cf5b868d7',
@@ -352,7 +354,7 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      {feedbackDialogRequested.current ? (
+      {feedbackDialogMounted ? (
         <React.Suspense fallback={null}>
           <SidebarFeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
         </React.Suspense>

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -32,16 +32,18 @@ import { showOnboardingFromRenderer } from '../onboarding/show-onboarding-event'
 import { SetupGuideProgressRing } from '../setup-guide/SetupGuideProgressRing'
 import { useSetupGuideProgress } from '../setup-guide/use-setup-guide-progress'
 import { lazyWithRetry } from '@/lib/lazy-with-retry'
+import type * as SidebarFeedbackDialogModule from './SidebarFeedbackDialog'
 import { translate } from '@/i18n/i18n'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from '@/lib/update-check-click-options'
 
 // Why lazy: the feedback form is only reachable from this menu's own item, so it does not
-// belong on the renderer boot graph.
+// belong on the renderer boot graph. Shared with the menu-open warm below so both hit the
+// same module-map entry.
+const loadSidebarFeedbackDialog = (): Promise<typeof SidebarFeedbackDialogModule> =>
+  import('./SidebarFeedbackDialog')
+
 const SidebarFeedbackDialog = lazyWithRetry(
-  () =>
-    import('./SidebarFeedbackDialog').then((module) => ({
-      default: module.SidebarFeedbackDialog
-    })),
+  () => loadSidebarFeedbackDialog().then((module) => ({ default: module.SidebarFeedbackDialog })),
   { reloadKey: 'sidebar-feedback-dialog' }
 )
 
@@ -122,6 +124,11 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const handleMenuOpenChange = (open: boolean): void => {
     setMenuOpen(open)
     updateCheckModifiersRef.current = NO_UPDATE_CHECK_MODIFIERS
+    if (open) {
+      // Warm on the precursor: reading the menu and clicking Send Feedback takes hundreds of ms,
+      // so the chunk is already in the module map by the time the item is selected.
+      void loadSidebarFeedbackDialog().catch(() => {})
+    }
   }
 
   const handleShowOnboarding = (): void => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -31,9 +31,19 @@ import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { showOnboardingFromRenderer } from '../onboarding/show-onboarding-event'
 import { SetupGuideProgressRing } from '../setup-guide/SetupGuideProgressRing'
 import { useSetupGuideProgress } from '../setup-guide/use-setup-guide-progress'
-import { SidebarFeedbackDialog } from './SidebarFeedbackDialog'
+import { lazyWithRetry } from '@/lib/lazy-with-retry'
 import { translate } from '@/i18n/i18n'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from '@/lib/update-check-click-options'
+
+// Why lazy: the feedback form is only reachable from this menu's own item, so it does not
+// belong on the renderer boot graph.
+const SidebarFeedbackDialog = lazyWithRetry(
+  () =>
+    import('./SidebarFeedbackDialog').then((module) => ({
+      default: module.SidebarFeedbackDialog
+    })),
+  { reloadKey: 'sidebar-feedback-dialog' }
+)
 
 const DOCS_URL = 'https://www.onorca.dev/docs'
 const CHANGELOG_URL = 'https://onorca.dev/changelog'
@@ -95,6 +105,11 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const settingsShortcut = useShortcutKeyDetails('app.settings')
   const [menuOpen, setMenuOpen] = useState(false)
   const [feedbackOpen, setFeedbackOpen] = useState(false)
+  // Why sticky: the dialog animates itself closed off `open`, so unmounting on close cuts that short.
+  const feedbackDialogRequested = React.useRef(false)
+  if (feedbackOpen) {
+    feedbackDialogRequested.current = true
+  }
   const [isRestartingOrca, setIsRestartingOrca] = useState(false)
   const lastShowOnboardingAtRef = React.useRef(0)
   const updateCheckModifiersRef = React.useRef(NO_UPDATE_CHECK_MODIFIERS)
@@ -330,7 +345,11 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <SidebarFeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+      {feedbackDialogRequested.current ? (
+        <React.Suspense fallback={null}>
+          <SidebarFeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+        </React.Suspense>
+      ) : null}
     </>
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​124 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​193 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 |

<!-- /orca-pr-loc -->

## ELI5

Two dialogs in Orca can only appear after you click something: the "Set project location" dialog in the new-workspace composer, and the "Send Feedback" dialog in the sidebar help menu. Even so, the code for both was being downloaded and compiled as part of the very first screen, on every single launch, whether or not you ever opened them.

This makes them load on demand, the same way Settings, the task page and the image viewer already work — and then warms each one at the moment it first becomes *reachable* rather than waiting for the click: the composer starts fetching the location dialog when it renders a host that can actually take a location, and the help menu starts fetching the feedback dialog the moment you open the menu. By the time you click, the code is already in memory.

So the startup bytes go away and the click stays instant. The buttons that open them stay exactly where they are.

## Why it matters

The renderer boot graph is every chunk the main window fetches and evaluates before first paint (`config/scripts/renderer-boot-graph.mjs`). Anything on it is startup cost on every launch, used or not.

Measured on the production `electron-vite` build, all three points rebuilt back-to-back on the same machine:

| | boot graph | chunks | delta vs base |
|---|---|---|---|
| base (merge base `3eec77c11a2`) | 4,473,242 B | 342 | — |
| lazy only | 4,424,142 B | 342 | **-49,100 B** |
| **lazy + precursor warm (this PR)** | **4,424,284 B** | 342 | **-48,958 B (-47.8 KiB)** |

`verify-renderer-boot-graph`, which runs automatically at the end of `build:electron-vite`:

```
base:              Renderer boot graph: 342 chunks, 4368.4 KB minified.
lazy only:         Renderer boot graph: 342 chunks, 4320.5 KB minified.
lazy + warm (HEAD): Renderer boot graph: 342 chunks, 4320.6 KB minified.
```

All three points were rebuilt and re-measured independently after the warm landed, and reproduce byte-for-byte: 4,473,242 / 4,424,142 / 4,424,284 B. Note the base row is the branch's **merge base**, not today's `main` — `main` has since moved 36 commits and now builds to 4,473,866 B / 340 chunks, so a reviewer rebuilding against current `main` will see a slightly different absolute base (the delta is unaffected: -49,582 B against it).

The warm costs 142 B of the 49,100 B win (0.29%) — that is its own source text landing on an already-preloaded chunk. `import()` never enters the modulepreload set, so warming a chunk from a second call site does not put it back on the boot graph; the emitted chunk sets are byte-identical between the two after-builds.

`CreateProjectLocationField-*.js` was 42,122 B on the boot graph and is now off it. The net is a little more than that because `SidebarFeedbackDialog` also left its eager chunk, and a little less than the naive sum because dropping a preloaded chunk redistributes its shared dependencies.

For context on the size of this win: the whole boot graph is ~4.3 MB, so this is ~1.1% of it. It is not a headline number. It is bytes that were provably never needed on the first frame.

## Measurement

### First-open cost — moved off the click path, not merely accepted

The cost the deferral creates is reading every chunk the dialog's `import()` newly pulls (excluding chunks the boot graph already holds) and V8-parsing/compiling the exact shipped bytes. Measured with `vm.SourceTextModule` against the real build output, median of 11 runs, reported as `process.cpuUsage()` deltas rather than wall clock (this box is loaded enough that wall clock is noise):

```
SetProjectLocationDialog: 5 newly-fetched chunk(s), 38,015 B, read+compile CPU median 0.78 ms
  SetProjectLocationDialog-*.js CreateProjectLocationField-*.js
  house-*.js file-type-icons-*.js file-braces-*.js

SidebarFeedbackDialog: 2 newly-fetched chunk(s), 16,086 B, read+compile CPU median 0.24 ms
  SidebarFeedbackDialog-*.js client-environment-info-*.js
```

That work still happens — but it no longer happens on the click. Both dialogs have a guaranteed precursor that fires hundreds of milliseconds earlier and is itself off the boot path:

- **`SetProjectLocationDialog`** — the "Set location" row only renders for a `needs-setup` host whose `canSetLocation` is true (`RunTargetCombobox.tsx:311`). The composer warms the chunk in an effect gated on exactly that predicate, and the composer card itself only mounts when the composer modal is open (`NewWorkspaceComposerModal.tsx:63` returns `null` otherwise), so the warm cannot reach startup.
- **`SidebarFeedbackDialog`** — "Send Feedback" only exists inside an open help menu, so `handleMenuOpenChange(true)` warms it.

Both use the pattern already in the repo for `preloadCommentMarkdown` (`comment-markdown-lazy.tsx`): a swallowed `void import(...).catch(() => {})` sharing one loader function with the `lazyWithRetry` factory, so both hit the same module-map entry.

What remains on the click is one already-resolved-promise microtask and one `Suspense` commit with `fallback={null}` — the DOM at that instant is identical to what the pre-PR synchronous path rendered.

## Correctness

**The trigger stays eager.** Only the dialog body is deferred. In the composer, the "Set project location" button lives in `NewWorkspaceComposerProjectSection`, untouched; in the sidebar, the "Send Feedback" `DropdownMenuItem` is untouched. There is no window in which the click target is missing.

**Warming does not mount anything.** Both preloads are bare `import()` calls; they populate the module map and nothing else. Neither dialog element is rendered, no effect inside either dialog runs, and no DOM appears — asserted directly in both new guards (`expect(document.body.querySelector('[data-testid="feedback-dialog"]')).toBeNull()`). Both assertions are non-vacuous: each guard's mocked dialog renders its marker unconditionally, so forcing the lazy element to mount at the precursor fails them with `expected <div /> to be null`. This is deliberately *not* the "mount the dialog closed at the precursor" variant, which would remove the last microtask but would also make a corrupt chunk throw during a render the user never asked for, taking out the whole composer via `RecoverableRenderErrorBoundary` for users who never wanted set-location. Warming keeps the failure confined to the click the user actually made.

**The warm is scoped to reachability, not to "the composer is open".** Gating on `canSetLocation` rather than "any needs-setup host" matters: a disconnected or unavailable host is `canSetLocation: false` (`project-host-setup-options.ts:279`), renders a status line rather than a button, and must not pull 38 KB for a dialog nobody can open. Both no-warm cases are covered by guards.

**The mount is sticky, so the close animation is intact.** Both dialogs animate themselves closed off their own `option` / `open` prop (`SetProjectLocationDialog` deliberately retains `renderOption` "so the body doesn't blank out as the dialog slides away"). Unmounting them when the prop clears would cut that short. Each host therefore sets a one-way `useState` mount flag from the open handler and keeps the lazy element mounted afterwards — the same idiom `NewWorkspaceComposerModal.tsx:196` already uses for `addProjectMounted`:

```tsx
const [setLocationDialogMounted, setSetLocationDialogMounted] = React.useState(false)
// in handleSetLocation, batched with the option:
setSetLocationDialogMounted(true)
setSetLocationOption(option)
```

(An earlier revision latched a ref during render instead. React Doctor's `Bugs: Ref mutated during render` rule correctly rejected that in `static analysis`; the state flag is the repo's existing answer and is exactly equivalent here, since `handleSetLocation` / `handleOpenFeedback` are the only paths that open either dialog.)

Repeat opens are instant (the chunk and the component instance are already resolved) and behave exactly as before.

**Neither dialog does anything while closed.** `SetProjectLocationDialog` renders `<Dialog open={option !== null}>` with a `null` body when `activeOption` is null, and every effect that matters (the `abandoned` latch, the `exitHostBrowser` escape hook) lives in `SetProjectLocationDialogBody`, which only mounts with a non-null option. `SidebarFeedbackDialog` is likewise inert while `open` is false. So deferring the mount cannot drop work that used to happen in the background — this is specifically *not* the `SkillFreshnessUpdateDialog` situation (see rejected list below).

**Repeat warms are free.** `import()` memoises, so re-opening the help menu (or a re-render that flips `hasSetLocationOption` back on) returns the same resolved promise; there is no repeated fetch.

**`Suspense fallback={null}`** matches the surrounding convention (`AppRootSurfaces.tsx` uses `fallback={null}` for every lazy overlay). During the load the user sees what they saw before the click; nothing flashes.

**Edge cases.** Nothing here branches on workspace kind, execution host, or platform, so SSH targets, runtime environments and folder workspaces behave identically — `SetProjectLocationDialog` still receives the same `NeedsSetupProjectHostOption` and still routes SSH/runtime hosts into `CreateProjectParentBrowser`. No main-process, IPC, or remote-wire surface is touched. `lazy-with-retry` degrades safely when `window.sessionStorage` is unavailable (it preserves normal error reporting rather than containing a failure it never acted on).

## Negative user-facing trade-offs

**1. ~~The first open of each dialog per session waits on a local chunk fetch.~~ Gone.** This was the one real cost of the deferral and it is no longer on the click path: the 0.78 ms / 0.24 ms of read-plus-compile (and the `file://` round trips, and the cold-page-cache case I could not evict to measure) now happen at the precursor — while the run-target picker is being read, or while the help menu is open — hundreds of milliseconds before any click. The click retains one resolved-promise microtask and one `fallback={null}` Suspense commit that renders the same DOM as before. The only way to still hit the old cost is to click faster than the precursor's fetch completes, which requires opening the picker/menu and selecting an item within the same frame; in that case the behaviour is exactly the pre-warm one, never worse.

**2. A load failure has a different failure mode than before the PR.** Previously the dialog code was already in memory and could not fail to appear. Now a corrupt or truncated chunk surfaces as a `LazyChunkLoadError` through `RecoverableRenderErrorBoundary` after retries and one recovery reload, instead of being impossible. This is inherent to lazy loading and is already accepted for the ~20 other click-reachable surfaces in `AppRootSurfaces.tsx`; in practice it only happens when an update swaps assets under a running window, which is exactly the case `lazy-with-retry` exists to handle. The warm does not widen it: the prefetch's rejection is swallowed, so a failed warm produces no error-boundary noise and the click-time `lazyWithRetry` path still owns retry and recovery unchanged.

**3. One extra dynamic import per composer-open-with-a-settable-host and per help-menu-open.** Both are rare, user-driven, and off the boot path. Nothing else changed: no new cap, cadence, debounce, threshold, sampling window, or reduced coverage; no behaviour change once either dialog is open.

## Considered and rejected

Five other feature-dialog chunks on the boot graph were looked at and deliberately left alone, so nobody re-proposes them without reading this:

- **`worktree-creation-flow` (19.0 KB)** and **`delete-worktree-flow` (13.4 KB)** — plain function modules, not components, so `lazy-with-retry` does not apply. They have 2 and 12 **synchronous** call sites respectively (`use-worktree-card-workspace-actions.ts`, `worktree-context-menu-delete-intent.ts`, `hovered-workspace-delete.ts`, `TerminalSshReconnectOverlay.tsx`, `HostedReviewActions.tsx`, …). Deferring them means making those call sites async, which is the same class of change as the `emojibase-data` dynamic import this repo already tried and reverted (`config/scripts/renderer-boot-graph.mjs:44-48`).
- **`SkillFreshnessUpdateDialog` (7.2 KB)** — it *is* the subscriber to the `skill-freshness-update-dialog` request store (`subscribeSkillFreshnessUpdateDialog`), so it has to stay mounted to observe requests at all. Deferring it safely needs the subscription hoisted into `AppRootSurfaces` first, which is a larger change than 7 KB justifies.
- **`SshHostAdvancedFields` (8.3 KB)** — it renders its own "Advanced" disclosure trigger (`open` / `onOpenChange` are its props), so lazying it removes the click target rather than deferring what sits behind it.
- **`CliSkillRuntimeSetup` (6.8 KB)** — a shared helper module with ~20 importers, most of them type-only. Not a dialog and not a lazy boundary.

Also rejected: **mounting the lazy element closed at the precursor** (`hasSetLocationOption || setLocationOption !== null`, `menuOpen || feedbackOpen`). It would remove the last microtask and the Suspense commit, but it moves a possible chunk-load throw into a render the user never requested, breaking the whole composer for people who never wanted set-location. Trading one risk for another is not worth a microtask.

## Test plan

```
nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/renderer/src/components/NewWorkspaceComposerCard.set-location.test.tsx \
  src/renderer/src/components/NewWorkspaceComposerCard.set-location-warm.test.tsx \
  src/renderer/src/components/NewWorkspaceComposerCard.test.tsx \
  src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx \
  src/renderer/src/components/sidebar/SidebarFeedbackDialog.test.tsx \
  src/renderer/src/components/sidebar/SidebarToolbar.test.tsx \
  src/renderer/src/components/new-workspace
# 23 files, 229 passed

node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json --composite false  # clean
node_modules/.bin/oxlint <changed files>                                         # clean
node_modules/.bin/oxfmt <changed files>                                          # clean
node config/scripts/run-electron-vite-build.mjs                                  # boot-graph gate passes
```

**New guards for the warm** (each counts module *evaluations* of the mocked chunk, which a dynamic import performs exactly once, so the counter only moves when the host actually reaches for the chunk):

- `NewWorkspaceComposerCard.set-location-warm.test.tsx` — does not warm with ready-only hosts; does not warm with a `needs-setup` host whose `canSetLocation` is false; warms exactly once on mount for a settable host, without mounting the dialog.
- `SidebarSettingsHelpMenu.test.tsx` — warms on `onOpenChange(true)` before "Send Feedback" is selected, without mounting the dialog.

Verified failing without the production change: reverting only the two component files and re-running gives

```
FAIL … set-location-warm.test.tsx > warms the chunk on mount for a needs-setup host
FAIL … SidebarSettingsHelpMenu.test.tsx > warms the feedback chunk when the menu opens
AssertionError: expected +0 to be 1
```

Re-confirmed on the current head: reverting only `NewWorkspaceComposerCard.tsx` and `SidebarSettingsHelpMenu.tsx` to the pre-warm commit fails exactly those two tests with `expected +0 to be 1`, and nothing else in the 23-file run.

The composer guard's no-mount assertion was also tightened: its dialog mock previously stubbed to `() => null`, which made `expect(...toBeNull())` vacuously true. It now renders a marker unconditionally, matching the sidebar guard, and was checked by forcing the lazy element to mount eagerly (`expected <div /> to be null`).

`NewWorkspaceComposerCard.set-location.test.tsx` still needs `await act(async () => {})` after the click — the click still resolves through a microtask, it just no longer resolves through a fetch. Its render harness moved to `NewWorkspaceComposerCard.test-fixture.tsx` so the warm test can share it.

**Manual checks a reviewer should do:**
1. Open the new-workspace composer, pick a project whose host needs setup, click "Set project location". Confirm it opens with no perceptible delay, that the browse/clone views work, and that closing it still animates out rather than blanking.
2. Open it a second time — should be instant.
3. Sidebar help menu -> "Send Feedback"; same two checks.
4. Ideally on a packaged build rather than `pnpm dev`, since dev serves chunks over HTTP and packaged serves them from `file://` inside the asar.


