### PR TITLE
fix(crash-reporting): bound replay-guard wedge bursts in the ring without losing their spans

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
@@ -49,6 +49,7 @@ function recordRendererBreadcrumbTrace(
 const DUPLICATE_TAB_OWNER_BREADCRUMB = 'terminal_tab_id_owned_by_multiple_worktrees'
 const PARK_VERDICT_CHURN_BREADCRUMB = 'terminal_park_verdict_churn'
 const REACT_COMMIT_CASCADE_BREADCRUMB = 'react_commit_cascade'
+const REPLAY_GUARD_WEDGED_BREADCRUMB = 'terminal_replay_guard_wedged_release'
 const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'renderer_error',
   'renderer_unhandled_rejection',
@@ -56,6 +57,7 @@ const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   DUPLICATE_TAB_OWNER_BREADCRUMB,
   PARK_VERDICT_CHURN_BREADCRUMB,
   REACT_COMMIT_CASCADE_BREADCRUMB,
+  REPLAY_GUARD_WEDGED_BREADCRUMB,
   TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB
 ])
 const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
@@ -69,6 +71,11 @@ const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
 // 30-entry ring to two such bursts. `suppressedSinceLast` keeps the pane count
 // — the only signal these carry — in one slot.
 const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set(['terminal_safe_fit_retry_exhausted'])
+// Why: the 30-slot ring is the scarce sink; the durable span stream is not. For
+// bounded-rate pane telemetry whose multiplicity is the whole signal, spans are the
+// only place a burst survives the restart that clears the ring, so coalesce the ring
+// but keep every event's span.
+const PER_EVENT_TRACED_COALESCED_BREADCRUMB_NAMES = new Set([REPLAY_GUARD_WEDGED_BREADCRUMB])
 
 function rendererBreadcrumbCoalesceKey(
   name: string,
@@ -76,6 +83,13 @@ function rendererBreadcrumbCoalesceKey(
 ): string | undefined {
   if (NAME_ONLY_COALESCED_BREADCRUMB_NAMES.has(name)) {
     return name
+  }
+  // Why presence and not value: `ptyId`/`tabIdHash` are absent on the restore call
+  // site (layout-serialization restoreScrollbackBuffers) and present on reattach, so
+  // their presence is the call-site identity a mixed burst would otherwise lose. Four
+  // slots per storm at most, regardless of pane count.
+  if (name === REPLAY_GUARD_WEDGED_BREADCRUMB) {
+    return `${name}:${data?.ptyId ? 'pty' : ''}:${data?.tabIdHash ? 'tab' : ''}`
   }
   // Why trigger and not name alone: `burst` means damping engaged a commit
   // short of React #185, `window` means slow benign churn. Collapsing them
@@ -191,9 +205,13 @@ export function recordRendererBreadcrumbFromRenderer(
       minIntervalMs: RENDERER_BREADCRUMB_COALESCE_MS,
       ...(origin ? { origin } : {})
     })
-    // Why: tracing every suppressed duplicate would preserve the same
-    // serialization and disk churn that breadcrumb coalescing removes.
-    if (coalesceResult) {
+    if (PER_EVENT_TRACED_COALESCED_BREADCRUMB_NAMES.has(args.name)) {
+      // Why the raw data: every event already gets its own span, so folding the ring's
+      // running count in here would double-count in any span-stream total.
+      recordRendererBreadcrumbTrace(args.name, data)
+    } else if (coalesceResult) {
+      // Why gated: tracing every suppressed duplicate would preserve the same
+      // serialization and disk churn that breadcrumb coalescing removes.
       recordRendererBreadcrumbTrace(
         args.name,
         coalesceResult.suppressedSinceLast > 0

--- a/src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts
+++ b/src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot,
+  recordCrashBreadcrumb
+} from '../crash-reporting/crash-breadcrumb-store'
+import { recordRendererBreadcrumbFromRenderer } from './crash-reporting-renderer-breadcrumbs'
+
+type SpanOptions = { attributes: Record<string, unknown> }
+const startSpanMock = vi.fn((_name: string, _options: SpanOptions) => ({ end: () => {} }))
+vi.mock('../observability/tracer', () => ({
+  startSpan: (name: string, options: SpanOptions) => startSpanMock(name, options)
+}))
+
+const WEDGE_BREADCRUMB = 'terminal_replay_guard_wedged_release'
+
+/** Reattach-path shape: identity-bearing (`tabIdHash`, optionally `ptyId`). */
+function emitReattachWedge(pane: number, withPtyId = false): void {
+  recordRendererBreadcrumbFromRenderer({
+    name: WEDGE_BREADCRUMB,
+    data: {
+      paneId: pane,
+      leafIdHash: `leaf${String(pane).padStart(5, '0')}`,
+      tabIdHash: `tab${String(pane).padStart(6, '0')}`,
+      worktreeIdHash: 'caa15fa9',
+      ...(withPtyId ? { ptyId: `…@@pty-${pane}` } : {})
+    }
+  })
+}
+
+/** Restore-path shape (restoreScrollbackBuffers): no tabIdHash, no ptyId. */
+function emitRestoreWedge(pane: number): void {
+  recordRendererBreadcrumbFromRenderer({
+    name: WEDGE_BREADCRUMB,
+    data: { paneId: pane, leafIdHash: `leaf${String(pane).padStart(5, '0')}` }
+  })
+}
+
+function wedgeCrumbs(): ReturnType<typeof getCrashBreadcrumbSnapshot> {
+  return getCrashBreadcrumbSnapshot().filter((entry) => entry.name === WEDGE_BREADCRUMB)
+}
+
+function wedgeSpanCount(): number {
+  return startSpanMock.mock.calls.filter(
+    (call) => call[1].attributes['breadcrumb.name'] === WEDGE_BREADCRUMB
+  ).length
+}
+
+beforeEach(() => {
+  startSpanMock.mockClear()
+})
+
+afterEach(() => {
+  clearCrashBreadcrumbsForTest()
+})
+
+// One mount/reveal/wake transition expires every in-flight replay write at once, so
+// the burst reaches the 30-slot ring as N distinct entries. Field span streams measure
+// bursts of 26 in 0.96s and 62 over 85s. No captured report in the 09-02 corpus shows
+// a ring that actually drained — all nine bursts predate their report's ring window —
+// so this bounds a demonstrated hazard, not an observed loss, and must not cost the
+// durable span evidence that did carry those bursts.
+describe('replay-guard wedge burst against the fixed-size breadcrumb ring', () => {
+  it('costs one ring slot per call site and preserves the pre-crash trail', () => {
+    for (let index = 0; index < 10; index += 1) {
+      recordCrashBreadcrumb(`pre_crash_evidence_${index}`, { index })
+    }
+
+    for (let pane = 0; pane < 26; pane += 1) {
+      emitReattachWedge(pane)
+    }
+
+    const snapshot = getCrashBreadcrumbSnapshot()
+    expect(snapshot.filter((entry) => entry.name.startsWith('pre_crash_evidence_'))).toHaveLength(
+      10
+    )
+    expect(wedgeCrumbs()).toHaveLength(1)
+  })
+
+  it('carries the burst multiplicity into the ring as suppressedSinceLast', () => {
+    for (let pane = 0; pane < 26; pane += 1) {
+      emitReattachWedge(pane)
+    }
+
+    // 26 emissions: one owns the slot, 25 fold into it.
+    expect(wedgeCrumbs()[0]?.data?.suppressedSinceLast).toBe(25)
+  })
+
+  // The 121-event field corpus lives entirely in the renderer.breadcrumb span stream,
+  // and the ring is cleared by the restart that usually precedes the crash report, so
+  // ring coalescing must not suppress the per-event spans.
+  it('still emits one durable span per wedge event', () => {
+    for (let pane = 0; pane < 26; pane += 1) {
+      emitReattachWedge(pane)
+    }
+
+    expect(wedgeSpanCount()).toBe(26)
+    // Why no count on the span: one span per event already carries the multiplicity.
+    expect(
+      startSpanMock.mock.calls.some((call) =>
+        JSON.stringify(call[1]).includes('suppressedSinceLast')
+      )
+    ).toBe(false)
+  })
+
+  // Bundle 8907a508 mixes restore-path (identity-less) and reattach-path crumbs in one
+  // window; name-only keying would report only the last one's shape.
+  it('keeps restore-path and reattach-path call sites in separate slots', () => {
+    emitRestoreWedge(1)
+    emitRestoreWedge(2)
+    emitReattachWedge(3)
+    emitReattachWedge(4, true)
+
+    const crumbs = wedgeCrumbs()
+    expect(crumbs).toHaveLength(3)
+    expect(crumbs.map((crumb) => Boolean(crumb.data?.tabIdHash))).toEqual([false, true, true])
+    expect(crumbs.map((crumb) => Boolean(crumb.data?.ptyId))).toEqual([false, false, true])
+  })
+
+  it('bounds a many-pane burst to one slot within a call site', () => {
+    for (let pane = 0; pane < 40; pane += 1) {
+      emitReattachWedge(pane, pane % 2 === 0)
+    }
+
+    expect(wedgeCrumbs()).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## What

`terminal_replay_guard_wedged_release` was missing from `COALESCED_RENDERER_BREADCRUMB_NAMES` in `src/main/ipc/crash-reporting-renderer-breadcrumbs.ts:52`, and the payload built by `replayGuardBreadcrumbData` (`src/renderer/src/components/terminal-pane/replay-guard.ts:50-69` — `paneId`, `leafIdHash`, `tabIdHash`, `worktreeIdHash`, `ptyId`) gives every emission a unique ring identity. The crumb is emitted from the `'wedged'` arm of `release()` at `src/renderer/src/components/terminal-pane/replay-guard.ts:121`. One mount/reveal/wake transition expires every in-flight replay write at once, so a burst arrives as N distinct entries against the fixed 30-slot FIFO in `src/main/crash-reporting/crash-breadcrumb-store.ts` (`MAX_BREADCRUMBS = 30` at `:8`, `breadcrumbs.shift()` at `:87-88`).

**Measured field evidence** (09-02 corpus, 121 `renderer.breadcrumb` spans across 9 of 55 diagnostic bundles, spanning 5 clusters):

- bundle `26461769`: 26 wedge events in 0.958 s
- `murlock1000`: 62 events over 85.0 s
- bundle `8907a508`: two call sites mixed in one window — 2 crumbs carry `tabIdHash`, 2 do not
- replaying the real corpus timestamps through the new coalesce key with the existing 30 s window: **121 events → 14 ring writes**

**Field impact — correcting the number this PR was scoped against.** An earlier draft of this change (and the handoff that produced it) asserted "destroys 87–100 % of the 30-entry ring in affected reports". That figure **did not reproduce** and is not claimed here. See *Fix evidence* for the refutation. What is claimed is narrower and verified: the crumb is unbounded per burst against a 30-slot ring, and this PR bounds it at 4 slots per 30-second coalescing window regardless of pane count, while keeping every event's durable span. ("Per storm" is the right description for the field shapes measured here — 26 events in 0.958 s collapses 26 slots to 1 — but a storm sustained beyond 30 s opens a new window, so a multi-hour storm can still fill the ring. Verified by an 8-hour simulation.)

The fix has two halves:

1. The name joins `COALESCED_RENDERER_BREADCRUMB_NAMES`, with a coalesce key of `ptyId`/`tabIdHash` **presence** (`crash-reporting-renderer-breadcrumbs.ts:92`) rather than name alone — those fields are absent on the restore call site (`layout-serialization` → `restoreScrollbackBuffers`) and present on reattach, so name-only keying would collapse `8907a508`'s two call sites into whichever crumb landed last. This matches the bounded-discriminator precedents already in the file (webgl keys on `kind`, duplicate-tab on `resolvedToActiveWorktree`).
2. A new `PER_EVENT_TRACED_COALESCED_BREADCRUMB_NAMES` set keeps **one `renderer.breadcrumb` span per wedge event**, because the normal coalesce path emits no span for suppressed repeats (the repo's own `crash-reporting-renderer-breadcrumbs.test.ts` proves 1000 emissions → 1 span). Without this half, coalescing alone would have cut the 121-event corpus to 13 spans with the multiplicity recorded nowhere. Span volume is unchanged at 121, and the per-event span deliberately carries no count so a span-stream total cannot double-count what the ring already claims.

Diff: 2 files, +149/−3 — one production file (+24/−3) and one new regression test.

## Fix evidence

All commands run from inside `/tmp/fix-wedge-breadcrumb-flood` at the pushed commit `5664d588ad4`, working tree clean.

**RED** — production hunk reverted to the `origin/main` version of `src/main/ipc/crash-reporting-renderer-breadcrumbs.ts`, test file unchanged:

```
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts

 RUN  v4.1.11 /private/tmp/fix-wedge-breadcrumb-flood

 ❯ src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts (5 tests | 4 failed) 15ms
     × costs one ring slot per call site and preserves the pre-crash trail 11ms
     × carries the burst multiplicity into the ring as suppressedSinceLast 1ms
     × keeps restore-path and reattach-path call sites in separate slots 1ms
     × bounds a many-pane burst to one slot within a call site 1ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 4 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  ... > costs one ring slot per call site and preserves the pre-crash trail
AssertionError: expected [ { …(3) }, { …(3) }, { …(3) }, …(1) ] to have a length of 10 but got 4

- Expected
+ Received

- 10
+ 4

 FAIL  ... > carries the burst multiplicity into the ring as suppressedSinceLast
AssertionError: expected undefined to be 25 // Object.is equality

- Expected:
25

+ Received:
undefined

 FAIL  ... > keeps restore-path and reattach-path call sites in separate slots
AssertionError: expected [ { …(3) }, { …(3) }, { …(3) }, …(1) ] to have a length of 3 but got 4

- Expected
+ Received

- 3
+ 4

 FAIL  ... > bounds a many-pane burst to one slot within a call site
AssertionError: expected [ { …(3) }, { …(3) }, { …(3) }, …(27) ] to have a length of 2 but got 30

- Expected
+ Received

- 2
+ 30

 Test Files  1 failed (1)
      Tests  4 failed | 1 passed (5)
```

The RED numbers are the mechanism, stated as a unit-test model and not as a field measurement: 10 pre-crash crumbs + 26 wedge crumbs = 36 into a 30-slot ring, so only 4 of the 10 pre-crash entries survive; a 30-pane burst fills all 30 slots.

**GREEN** — production hunk restored (`git checkout --` back to the committed tree, `git status --short` empty):

```
$ ./node_modules/.bin/vitest run --config config/vitest.config.ts src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts

 RUN  v4.1.11 /private/tmp/fix-wedge-breadcrumb-flood

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

**Related suites, typecheck, lint, ratchet** (committed tree, unmodified):

```
$ ./node_modules/.bin/tsc -p config/tsconfig.node.json --noEmit
TSC_EXIT=0

$ ./node_modules/.bin/oxlint src/main/ipc/crash-reporting-renderer-breadcrumbs.ts src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts
OXLINT_EXIT=0

$ node config/scripts/check-max-lines-ratchet.mjs
max-lines ratchet OK — 12 grandfathered suppression(s), no new bypasses.

$ ./node_modules/.bin/vitest run --config config/vitest.config.ts \
    src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts \
    src/main/ipc/crash-reporting-replay-guard-wedge-burst.test.ts \
    src/main/crash-reporting/ \
    src/renderer/src/components/terminal-pane/replay-guard.test.ts

 Test Files  29 passed (29)
      Tests  324 passed (324)
```

### Claims that are NOT proven — stated explicitly

- **"Destroys 87–100 % of the ring in affected reports" is refuted, not proven.** Parsing the `Recent activity:` ring of every `.txt` in the corpus: **zero of the 57 crash reports contain a single `terminal_replay_guard_wedged_release` breadcrumb**. In all 9 bundles that have wedge events, the burst window precedes the report's ring window entirely. For the headline bundle `26461769` the wedges span `13:36:03.784Z–13:36:04.742Z` while the report header records `mainProcessStartedAt=2026-09-02T13:43:44.380Z` — the main process that owns the in-memory ring started **7 m 40 s after** the burst ended, so those crumbs lived in a previous process's ring and evicted nothing from the captured report. This PR therefore bounds a **demonstrated hazard**, not an **observed loss**. The commit message says so in the same words.
- **No live CDP reproduction output is included in this PR.** The wedge mechanism was reproduced live during the investigation (one replay + one dispose produces the exact field crumb), but that repro belongs to the follow-up behaviour fix (#1 below), not to this diagnostics change. Nothing here rests on it.
- **This does not fix "can't type."** It does not stop panes wedging and does not explain this round's `can't type` reports. `kkotamraju_yahoo`'s bundle has 2075 crumbs and zero of this class; `chao605`'s has zero (concurrent GPU + Network Service sibling kill instead); `murlock1000`'s 62 wedges are all on the pre-update session.
- **One of the five new tests is not a discriminator.** `still emits one durable span per wedge event` passes unchanged against `origin/main`, because a non-coalesced name already traces every event. It is a guard against a future naive name-only fix, not evidence for this one. The other four go RED without the production hunk, as shown above.

## ELI5

When Orca crashes it mails home a little flight recorder: the last 30 things that happened, newest wins, oldest falls off the end. Thirty slots, no more.

One of those "things" is a note the terminal writes when a pane's replay gets stuck — and panes get stuck in herds. Waking a laptop, revealing a hidden window, or restoring a saved layout can stick two dozen panes in the same second, and each one wrote its own note with its own pane number. Two dozen near-identical notes go into a 30-slot notebook, and everything that actually happened before the crash gets pushed off the page.

To be clear about what we saw: we have not caught a real crash report with its notebook wiped this way — in the reports we collected, the herd happened minutes before the recorder that shipped even started. So this is closing a hole we can demonstrate, not repairing damage we can point at.

The fix is: when the same kind of note repeats, keep **one** note and write "and 25 more like this" next to it. Two shapes of the note are kept apart, because they come from two different places in the code and telling them apart is the whole point of reading them later. Separately, the full blow-by-blow still goes into the bigger log file that has no 30-slot limit, so in almost every report the per-pane detail is still there — only the tiny notebook gets the summary. A small number of reports arrive without that bigger log attached; for those, the summary and its count are all we get.

Nothing about using Orca changes. No pane behaves differently, nothing gets faster or slower for the user. This only changes what the crash report looks like to us.

## Trade-offs

- **Fidelity loss in the ring, by construction.** After this change a wedge storm occupies at most 4 ring slots (one per `ptyId`/`tabIdHash` presence combination) carrying the newest payload plus `suppressedSinceLast`. Per-pane identity for the suppressed events is gone **from the ring**. Mitigated for almost all reports by the per-event span stream (see next bullet). This is the same trade the existing `terminal_safe_fit_retry_exhausted` precedent already made.
- **Two of the 57 corpus reports have no diagnostic bundle** (57 `.txt` vs 55 `.ndjson`). For those, the ring is the only channel and the span-stream mitigation does not apply: a wedge storm would be recorded as 1–4 crumbs plus a count, with per-pane identity unrecoverable. Accepted knowingly — zero of the 57 reports contain this crumb at all today.
- **Downstream analysis step change with no schema change.** Any dashboard or triage script that counts `terminal_replay_guard_wedged_release` *ring entries* in crash reports will see a step down for the same underlying wedge rate; it must now add `suppressedSinceLast`. Scripts counting *spans* in `.diag.ndjson` are unaffected — span volume is deliberately unchanged at 121 for the corpus. Affects Orca crash triage only, no user-facing surface.
- **The `ptyId` dimension of the coalesce key is speculative.** Across all 9 corpus bundles `ptyId` presence is constant within every window; only the `tabIdHash` dimension has field support. Kept because the two fields are populated by independent branches in `replayGuardBreadcrumbData` and a future call site could vary either. Cost is bounded at 4 slots instead of 2. Disclosed rather than removed.
- **`PER_EVENT_TRACED_COALESCED_BREADCRUMB_NAMES` is not enforced as a subset** of `COALESCED_RENDERER_BREADCRUMB_NAMES` by type or test. A name added only to the former would be silently inert — the branch is reachable only inside the coalesced path. No current defect; noted so the next editor knows.
- **No user-facing regression, no added latency, no newly-swallowed error.** Main-process only; no timers, async, nulls, or new catch blocks. The renderer still emits every event on an unchanged IPC payload, so this is not a wire change: old and new main processes remain interchangeable for any renderer, and remote clients see no difference. Nothing platform-, SSH-execution-host-, folder-workspace-, or Git-version-dependent. The coalesce key is computed from already-sanitized data (`hashReplayIdentity` / `redactPtyIdForDiagnostics`), so no new PII reaches the key. `MAX_COALESCE_KEYS` pressure *increases* slightly, and does not decrease as an earlier draft of this section claimed: before this PR the name was not coalesced at all and contributed **0** keys, so the delta is 0 → up to 4 per renderer origin. The 128-key cap is unchanged and an evicted key still materializes its count into the ring via `preservePendingCoalescedBreadcrumb`, so there is no memory or data-loss consequence — measured worst case is ~2.0 MB retained at the cap, of which ~1.5 MB is attributable to this PR.

## Adversarial review

**2 round(s), converged clean = true.**

**Round 1 — BLOCK, 3 blocking findings. All three were accepted and the implementation was rewritten; none were rebutted.**

1. *The headline field number was a model presented as a measurement.* The reviewer parsed the `Recent activity:` ring of all 57 `.txt` reports and found zero wedge crumbs, and showed that for `26461769` the ring-owning main process started 7 m 40 s **after** the burst ended. **Resolved by correction, not defence:** the "26 of 30 slots / 87 % of the pre-crash trail" claim was deleted from the code comment and from the commit message, and the commit now carries an explicit `Not measured:` paragraph plus a retraction of the earlier draft. The PR body above repeats the retraction rather than quietly dropping it.
2. *Naive coalescing would have destroyed the evidence stream the investigation actually used.* All 121 wedge events came from `renderer.breadcrumb` effect-spans in the `.diag.ndjson` bundles, and suppressed repeats emit no span (the repo's own 1000-emissions → 1-span test). The first draft would have cut 121 spans to 13 with `suppressedSinceLast` reaching nowhere, since it only materializes in the ring. **Resolved by design change:** added `PER_EVENT_TRACED_COALESCED_BREADCRUMB_NAMES` so every wedge event still emits its own span; span volume is unchanged at 121. The span carries no count, so span totals cannot double-count the ring's.
3. *Name-only keying would erase the one discriminator the analysis depended on.* `ptyId`/`tabIdHash` **presence** distinguishes the restore call site from reattach, and bundle `8907a508` mixes both in one window. **Resolved by design change:** the coalesce key is now presence-based, bounded at 4 slots per storm, matching the webgl `kind` and duplicate-tab `resolvedToActiveWorktree` precedents in the same file.

Round 1 also raised, and the rewrite fixed, that the test never asserted `suppressedSinceLast` (now a dedicated test) and that fake timers were decorative (the suite now has five tests exercising both call-site shapes, the count, the many-pane bound, and span preservation).

**Round 2 — APPROVE, clean, no blocking findings.** The reviewer independently re-derived every field number from the corpus and reproduced each exactly (121 spans across 9 of 55 bundles; `26461769` = 26 in 0.958 s; `murlock1000` = 62 over 85.0 s; `8907a508` = 2 with `tabIdHash` + 2 without; zero of 57 `.txt` reports carrying the crumb; 121 → 14 ring writes replaying real timestamps). It re-ran the revert-and-retest gate itself and confirmed 4 of 5 tests go RED on the `origin/main` file.

**Accepted as disclosed limitations** (round 2 non-blocking, each surfaced in *Trade-offs* above with its residual risk): the `ptyId` key dimension has no field support (residual risk: one unnecessary key dimension, bounded at 4 slots); `PER_EVENT_TRACED_...` is not enforced as a subset (residual risk: a future name added to the wrong set is silently inert); the 2 bundle-less reports get no span-stream mitigation (residual risk: per-pane identity unrecoverable for a wedge storm in those reports); the span-preservation test passes on `origin/main` too (residual risk: none — it is a guard, and the other four discriminate).

**Rebutted:** nothing. Round 2's one substantive complaint — that the handoff prose was stale and still carried the retracted 87 % figure — is a defect in the handoff text, not the code, and this PR body is written from the commit message rather than that text precisely so the retracted number is not resurrected.

## Follow-ups

1. **Dispose is not a wedge** (highest remaining value — removes most of the 121 field events at source). `probeForStall` (`src/renderer/src/components/terminal-pane/replay-guard.ts:140`) and `armWedgeDeadline` (`:127`) should check `isXtermInstanceDisposed(terminal)` — the predicate already exists at `src/renderer/src/lib/pane-manager/xterm-instance-disposed.ts:10` and is already used at `layout-serialization.ts:166` — and release with a distinct `'disposed'` reason: no wedge crumb, no `notifyUndeliverableWrite`. A torn-down pane needs no obituary and no recovery. Mechanism was proved two ways during investigation (a headless-xterm experiment showing a disposed instance silently swallows both the write callback and the FIFO probe with no throw, and a live CDP repro producing the exact field crumb from one replay + one dispose), and the corpus agrees: 121 wedges with zero `lost_completion` and zero throw-guard crumbs.
2. **Cancel engaged guards at unmount.** `replayIntoTerminal` returns `void` and keeps its timers in a closure, so `src/renderer/src/lib/pane-manager/session-reconcile-dispose.ts:203-204` — which meticulously cancels ~30 other timers — cannot cancel this one. Measured in the repro: the guard drops every keystroke on the pane for the full 2 × `stallCheckMs` (20 s in production) even after the pane is gone. Return a `{ cancel() }` handle (or register releases in a per-terminal set) and call it alongside `terminalRecoveryInstance.unregister()`. Needs SSH/remote-host consideration across the pane lifecycle.
3. **Never certify dead without an owner.** `src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts:91-103` — skip certification when `handlersByTerminal.get(terminal)` is undefined. Today a replay that wedges before `installPtyInputRecovery` runs (`connect-pane-pty.ts:211`) — the identity-less `restoreScrollbackBuffers` path visible in bundles `621d50aa` and `8907a508` — poisons the terminal permanently, after which `pane-terminal-output-writer.ts:53` drops every byte the PTY sends. Requires care around re-entrancy: the `certifiedDeadTerminals.add(terminal)` before the handler call is re-entrancy protection, not an ordering bug, and it interacts with `armTerminalWritePipelineWatch`'s early return at `:126`. Own PR, own tests.
4. **Close the silent-decline holes in `terminal-pane-recovery.ts`** (`:216` stale request, `:222` `viewMode === 'chat'`, `:225` budget, plus the throw in `discardTerminalOutput` swallowed by the catch at `terminal-write-pipeline-health.ts:96-102`). Record a coalesced `terminal_pane_recovery_declined` crumb carrying the reason. This is why the corpus shows 121 certifications with 0 remounts and no way to distinguish a decline from "never asked". Cheap, and it makes the next round's data conclusive.
5. **Enforce `PER_EVENT_TRACED_COALESCED_BREADCRUMB_NAMES ⊆ COALESCED_RENDERER_BREADCRUMB_NAMES`** with a type or a one-line test, so a name added only to the former is not silently inert.
6. **Consider coalescing `terminal_replay_guard_lost_completion`** for symmetry. Same burst geometry from the same `release()` switch (`replay-guard.ts:116`), but zero events across all 55 bundles, so no action now.
7. **Re-read the affected bundles after this ships.** Reports from the affected clusters should start arriving with an intact 30-entry trail even when a wedge storm precedes the crash in the same process. If they do not, the hazard model in this PR is wrong and should be reverted rather than extended.

