### PR TITLE
perf(renderer): narrow the App-root badge and terminal pty-set subscriptions

### DIFF
--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-bound-pty-ids.test.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-bound-pty-ids.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as SnapshotCapabilityModule from './terminal-provider-snapshot-capability'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import { makeTab, makeWorktree } from '@/store/slices/store-test-helpers'
+
+const { collectPtyIds } = vi.hoisted(() => ({ collectPtyIds: vi.fn() }))
+
+vi.mock('./terminal-provider-snapshot-capability', async (importOriginal) => {
+  const actual = await importOriginal<typeof SnapshotCapabilityModule>()
+  collectPtyIds.mockImplementation(actual.collectTerminalProviderSnapshotPtyIds)
+  return { ...actual, collectTerminalProviderSnapshotPtyIds: collectPtyIds }
+})
+
+import { useAppStore } from '@/store'
+import { createTerminalProviderSnapshotBoundPtyIdsSelector } from './terminal-provider-snapshot-bound-pty-ids'
+
+const initialState = useAppStore.getInitialState()
+const TAB_COUNT = 40
+const WORKTREE_ID = 'repo::worktree-0'
+
+function tabId(index: number): string {
+  return `tab-${index}`
+}
+
+function leafLayout(index: number, activeLeafId: string): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split' as const,
+      direction: 'vertical' as const,
+      first: { type: 'leaf' as const, leafId: `leaf-a-${index}` },
+      second: { type: 'leaf' as const, leafId: `leaf-b-${index}` }
+    },
+    activeLeafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: {
+      [`leaf-a-${index}`]: `pty-${index}-a`,
+      [`leaf-b-${index}`]: `pty-${index}-b`
+    }
+  }
+}
+
+function seedWorkspace(): void {
+  const worktrees = Array.from({ length: 8 }, (_, index) =>
+    makeWorktree({ id: `repo::worktree-${index}`, repoId: 'repo' })
+  )
+  const tabs = Array.from({ length: TAB_COUNT }, (_, index) =>
+    makeTab({ id: tabId(index), worktreeId: WORKTREE_ID, ptyId: `pty-${index}` })
+  )
+  useAppStore.setState({
+    worktreesByRepo: { repo: worktrees },
+    tabsByWorktree: { [WORKTREE_ID]: tabs },
+    ptyIdsByTabId: Object.fromEntries(tabs.map((tab, index) => [tab.id, [`pty-${index}`]])),
+    terminalLayoutsByTabId: Object.fromEntries(
+      tabs.map((tab, index) => [tab.id, leafLayout(index, `leaf-a-${index}`)])
+    )
+  })
+}
+
+describe('createTerminalProviderSnapshotBoundPtyIdsSelector', () => {
+  let select: ReturnType<typeof createTerminalProviderSnapshotBoundPtyIdsSelector>
+  let boundPtyIds: string[]
+  let unsubscribe: () => void
+
+  beforeEach(() => {
+    useAppStore.setState(initialState, true)
+    seedWorkspace()
+    collectPtyIds.mockClear()
+    select = createTerminalProviderSnapshotBoundPtyIdsSelector()
+    boundPtyIds = select(useAppStore.getState())
+    // Why subscribe: this mirrors how zustand drives the selector — once per store write.
+    unsubscribe = useAppStore.subscribe((state) => {
+      boundPtyIds = select(state)
+    })
+  })
+
+  afterEach(() => {
+    unsubscribe()
+    useAppStore.setState(initialState, true)
+  })
+
+  // Why: the collector walks every tab and every layout leaf, and both of these rewrite the maps it
+  // reads without being able to change the pty set.
+  it('never re-collects for agent title frames or active-leaf moves', () => {
+    expect(collectPtyIds).toHaveBeenCalledTimes(1)
+    const initialBoundPtyIds = boundPtyIds
+
+    for (let index = 0; index < TAB_COUNT; index += 1) {
+      useAppStore.getState().updateTabTitle(tabId(index), `agent frame ${index}`)
+    }
+    for (let index = 0; index < TAB_COUNT; index += 1) {
+      useAppStore.getState().setTabLayout(tabId(index), leafLayout(index, `leaf-b-${index}`))
+    }
+
+    expect(useAppStore.getState().tabsByWorktree).not.toBe(initialState.tabsByWorktree)
+    expect(useAppStore.getState().terminalLayoutsByTabId[tabId(0)]?.activeLeafId).toBe('leaf-b-0')
+    expect(collectPtyIds).toHaveBeenCalledTimes(1)
+    expect(boundPtyIds).toBe(initialBoundPtyIds)
+  })
+
+  it('re-collects and republishes when the pty set actually changes', () => {
+    const expectRecollect = (label: string, mutate: () => void): string[] => {
+      const before = collectPtyIds.mock.calls.length
+      const previousBoundPtyIds = boundPtyIds
+      mutate()
+      expect(collectPtyIds.mock.calls.length, label).toBeGreaterThan(before)
+      expect(boundPtyIds, label).not.toBe(previousBoundPtyIds)
+      return boundPtyIds
+    }
+
+    expectRecollect('pty bound to a leaf', () => {
+      useAppStore.getState().replaceTerminalLayoutPanePtyId(tabId(0), 'leaf-b-0', 'pty-0-b-next')
+    })
+    expect(boundPtyIds).toContain('pty-0-b-next')
+
+    expectRecollect('split pty bound to a tab', () => {
+      useAppStore.setState((state) => ({
+        ptyIdsByTabId: { ...state.ptyIdsByTabId, [tabId(1)]: ['pty-1', 'pty-1-split'] }
+      }))
+    })
+    expect(boundPtyIds).toContain('pty-1-split')
+
+    expectRecollect('split pty unbound from a tab', () => {
+      useAppStore.setState((state) => ({
+        ptyIdsByTabId: { ...state.ptyIdsByTabId, [tabId(1)]: ['pty-1'] }
+      }))
+    })
+    expect(boundPtyIds).not.toContain('pty-1-split')
+
+    expectRecollect('pending reconnect pty appears', () => {
+      useAppStore.setState({ pendingReconnectPtyIdByTabId: { [tabId(2)]: 'pty-2-reconnect' } })
+    })
+    expect(boundPtyIds).toContain('pty-2-reconnect')
+
+    expectRecollect('leaf added', () => {
+      useAppStore.getState().setTabLayout(tabId(3), {
+        ...leafLayout(3, 'leaf-a-3'),
+        root: {
+          type: 'split',
+          direction: 'vertical',
+          first: { type: 'leaf', leafId: 'leaf-a-3' },
+          second: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf-b-3' },
+            second: { type: 'leaf', leafId: 'leaf-c-3' }
+          }
+        },
+        ptyIdsByLeafId: {
+          'leaf-a-3': 'pty-3-a',
+          'leaf-b-3': 'pty-3-b',
+          'leaf-c-3': 'pty-3-c'
+        }
+      })
+    })
+    expect(boundPtyIds).toContain('pty-3-c')
+
+    expectRecollect('leaf removed', () => {
+      useAppStore.getState().setTabLayout(tabId(3), leafLayout(3, 'leaf-a-3'))
+    })
+    expect(boundPtyIds).not.toContain('pty-3-c')
+
+    expectRecollect('tab added', () => {
+      useAppStore.setState((state) => ({
+        tabsByWorktree: {
+          ...state.tabsByWorktree,
+          [WORKTREE_ID]: [
+            ...(state.tabsByWorktree[WORKTREE_ID] ?? []),
+            makeTab({ id: 'tab-new', worktreeId: WORKTREE_ID, ptyId: 'pty-new' })
+          ]
+        }
+      }))
+    })
+    expect(boundPtyIds).toContain('pty-new')
+
+    expectRecollect('tab removed', () => {
+      useAppStore.setState((state) => ({
+        tabsByWorktree: {
+          ...state.tabsByWorktree,
+          [WORKTREE_ID]: (state.tabsByWorktree[WORKTREE_ID] ?? []).filter(
+            (tab) => tab.id !== 'tab-new'
+          )
+        }
+      }))
+    })
+    expect(boundPtyIds).not.toContain('pty-new')
+  })
+
+  // Why: the id array identity is the synchronization loop's restart trigger, so a rebuild that
+  // lands on the same set must reuse the previous array rather than restart the loop.
+  it('keeps the array identity when a rebuild lands on the same id set', () => {
+    const initialBoundPtyIds = boundPtyIds
+
+    useAppStore.setState((state) => ({
+      tabsByWorktree: {
+        ...state.tabsByWorktree,
+        [WORKTREE_ID]: (state.tabsByWorktree[WORKTREE_ID] ?? []).toReversed()
+      }
+    }))
+
+    expect(collectPtyIds).toHaveBeenCalledTimes(2)
+    expect(boundPtyIds).toBe(initialBoundPtyIds)
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-bound-pty-ids.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-bound-pty-ids.ts
@@ -1,0 +1,88 @@
+import { reuseArrayIfEqual } from '@/components/sidebar/worktree-agent-row-selectors'
+import { sameBucketRecords } from '@/lib/bucket-record-equality'
+import { sameStringRecord } from '@/lib/terminal-layout-equality'
+import {
+  type SnapshotCapabilityBindingState,
+  type SnapshotCapabilityTab,
+  collectTerminalProviderSnapshotPtyIds
+} from './terminal-provider-snapshot-capability'
+
+type TabsByWorktree = SnapshotCapabilityBindingState['tabsByWorktree']
+type LayoutsByTabId = NonNullable<SnapshotCapabilityBindingState['terminalLayoutsByTabId']>
+
+const EMPTY_TABS: TabsByWorktree = Object.freeze({})
+const EMPTY_LAYOUTS: LayoutsByTabId = Object.freeze({})
+
+function sameBoundTab(previous: SnapshotCapabilityTab, next: SnapshotCapabilityTab): boolean {
+  return previous.id === next.id && previous.ptyId === next.ptyId
+}
+
+/** Leaf pty bindings are the only layout field the collector reads; active-leaf moves, pane titles
+ *  and buffer captures all replace the layout object without touching them. */
+function sameLayoutLeafPtyIds(previous: LayoutsByTabId, next: LayoutsByTabId): boolean {
+  if (previous === next) {
+    return true
+  }
+  const tabIds = Object.keys(next)
+  if (tabIds.length !== Object.keys(previous).length) {
+    return false
+  }
+  for (const tabId of tabIds) {
+    const nextLayout = next[tabId]
+    const previousLayout = previous[tabId]
+    if (previousLayout === nextLayout) {
+      continue
+    }
+    if (
+      !previousLayout ||
+      !sameStringRecord(previousLayout.ptyIdsByLeafId, nextLayout?.ptyIdsByLeafId)
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Why: the collector walks every tab and every layout leaf, and the maps it reads are rewritten by
+ * agent title frames and active-leaf moves that cannot alter the pty set. Gating it on the fields it
+ * actually reads — `tab.id`, `tab.ptyId`, `ptyIdsByTabId`, `pendingReconnectPtyIdByTabId`,
+ * `layout.ptyIdsByLeafId` — keeps those frames free, and reusing the prior array when a real rebuild
+ * lands on the same set keeps the synchronization effect asleep.
+ *
+ * Why chaining against the immediately preceding state is enough: equality over those fields is
+ * transitive, so a run of unchanged states is equivalent to comparing against the state that
+ * produced the cached array.
+ */
+export function createTerminalProviderSnapshotBoundPtyIdsSelector(): (
+  state: SnapshotCapabilityBindingState
+) => string[] {
+  let previousTabsByWorktree: TabsByWorktree = EMPTY_TABS
+  let previousLayoutsByTabId: LayoutsByTabId = EMPTY_LAYOUTS
+  let previousPtyIdsByTabId: SnapshotCapabilityBindingState['ptyIdsByTabId'] | undefined
+  let previousPendingReconnectPtyIdByTabId: SnapshotCapabilityBindingState['pendingReconnectPtyIdByTabId']
+  let boundPtyIds: string[] = []
+  let collected = false
+
+  return (state) => {
+    const layoutsByTabId = state.terminalLayoutsByTabId ?? EMPTY_LAYOUTS
+    const unchanged =
+      collected &&
+      previousPtyIdsByTabId === state.ptyIdsByTabId &&
+      previousPendingReconnectPtyIdByTabId === state.pendingReconnectPtyIdByTabId &&
+      sameBucketRecords(previousTabsByWorktree, state.tabsByWorktree, sameBoundTab) &&
+      sameLayoutLeafPtyIds(previousLayoutsByTabId, layoutsByTabId)
+    if (!unchanged) {
+      boundPtyIds = reuseArrayIfEqual(
+        boundPtyIds,
+        collectTerminalProviderSnapshotPtyIds(state).sort()
+      )
+      previousPtyIdsByTabId = state.ptyIdsByTabId
+      previousPendingReconnectPtyIdByTabId = state.pendingReconnectPtyIdByTabId
+      collected = true
+    }
+    previousTabsByWorktree = state.tabsByWorktree
+    previousLayoutsByTabId = layoutsByTabId
+    return boundPtyIds
+  }
+}

--- a/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts
@@ -1,7 +1,7 @@
 type SnapshotCapability = { id: string; authoritative: boolean | null }
 type SnapshotCapabilityResolver = (ids: string[]) => Promise<SnapshotCapability[]>
-type SnapshotCapabilityTab = { id: string; ptyId?: string | null }
-type SnapshotCapabilityBindingState = {
+export type SnapshotCapabilityTab = { id: string; ptyId?: string | null }
+export type SnapshotCapabilityBindingState = {
   tabsByWorktree: Readonly<Record<string, readonly SnapshotCapabilityTab[]>>
   ptyIdsByTabId: Readonly<Record<string, readonly string[]>>
   pendingReconnectPtyIdByTabId?: Readonly<Record<string, string>>

--- a/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
+++ b/src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts
@@ -1,38 +1,22 @@
 import { useEffect, useMemo, useSyncExternalStore } from 'react'
 import { useAppStore } from '@/store'
+import { createTerminalProviderSnapshotBoundPtyIdsSelector } from './terminal-provider-snapshot-bound-pty-ids'
 import {
-  collectTerminalProviderSnapshotPtyIds,
   getTerminalProviderSnapshotCapabilityRevision,
   subscribeTerminalProviderSnapshotCapability,
   startTerminalProviderSnapshotCapabilitySynchronization
 } from './terminal-provider-snapshot-capability'
 
 export function useTerminalProviderSnapshotCapability(enabled: boolean): number {
-  const tabsByWorktree = useAppStore((state) => state.tabsByWorktree)
-  const ptyIdsByTabId = useAppStore((state) => state.ptyIdsByTabId)
-  const pendingReconnectPtyIdByTabId = useAppStore((state) => state.pendingReconnectPtyIdByTabId)
-  const terminalLayoutsByTabId = useAppStore((state) => state.terminalLayoutsByTabId)
   // Why the full field set: synchronization PRUNES cached verdicts outside the
   // collected ids, so a collector narrower than startup's (App.tsx refresh
   // passes full state) would evict valid answers for split-leaf and
   // pending-reconnect ptys back into the exempt-by-default unknown state.
-  // Why keyed: layouts change without changing the pty set (active-leaf churn);
-  // the synchronization loop must restart only on genuine id-set changes.
-  // Why memoized on the map identities: this runs at Terminal's render cadence,
-  // and only a change to one of the four collected maps can alter the id set.
-  const boundPtyIdsKey = useMemo(
-    () =>
-      JSON.stringify(
-        collectTerminalProviderSnapshotPtyIds({
-          tabsByWorktree,
-          ptyIdsByTabId,
-          pendingReconnectPtyIdByTabId,
-          terminalLayoutsByTabId
-        }).sort()
-      ),
-    [tabsByWorktree, ptyIdsByTabId, pendingReconnectPtyIdByTabId, terminalLayoutsByTabId]
-  )
-  const boundPtyIds = useMemo(() => JSON.parse(boundPtyIdsKey) as string[], [boundPtyIdsKey])
+  // Why a selector: it returns an identity-stable id set, so the
+  // synchronization loop restarts only on genuine id-set changes and title
+  // frames and active-leaf moves never reach the collector at all.
+  const selectBoundPtyIds = useMemo(() => createTerminalProviderSnapshotBoundPtyIdsSelector(), [])
+  const boundPtyIds = useAppStore(selectBoundPtyIds)
   const capabilityRevision = useSyncExternalStore(
     subscribeTerminalProviderSnapshotCapability,
     getTerminalProviderSnapshotCapabilityRevision,

--- a/src/renderer/src/hooks/useUnreadDockBadge.test.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.test.ts
@@ -123,4 +123,58 @@ describe('useUnreadDockBadge', () => {
     expect(getUnreadBadgeCount).toHaveBeenCalledTimes(5)
     expect(setUnreadDockBadgeCount).toHaveBeenLastCalledWith(0)
   })
+
+  // Why render-counted: this hook is mounted on the App root, so anything that wakes its
+  // subscription re-renders the whole shell — the chrome layout, both providers and every
+  // non-memoised overlay — for a badge integer that did not move.
+  it('leaves the App root asleep through title frames and wakes it only on a badge change', () => {
+    const worktrees = Array.from({ length: 20 }, (_, index) =>
+      makeWorktree({ id: `repo::worktree-${index}`, repoId: 'repo' })
+    )
+    const tabsByWorktree = Object.fromEntries(
+      worktrees.map((worktree, index) => [
+        worktree.id,
+        [makeTab({ id: `tab-${index}`, worktreeId: worktree.id })]
+      ])
+    )
+    useAppStore.setState({
+      worktreesByRepo: { repo: worktrees },
+      tabsByWorktree,
+      unreadTerminalTabs: { 'tab-19': true }
+    })
+    let renders = 0
+    renderHook(() => {
+      renders += 1
+      return useUnreadDockBadge()
+    })
+    const rendersAfterMount = renders
+
+    // Separate acts: title frames arrive as individual store writes, not one batch.
+    for (let index = 0; index < 20; index += 1) {
+      act(() => useAppStore.getState().updateTabTitle(`tab-${index}`, `agent frame ${index}`))
+    }
+
+    expect(useAppStore.getState().tabsByWorktree).not.toBe(tabsByWorktree)
+    expect(renders).toBe(rendersAfterMount)
+
+    // A tab becomes unread.
+    act(() => useAppStore.setState({ unreadTerminalTabs: { 'tab-19': true, 'tab-0': true } }))
+    expect(renders).toBe(rendersAfterMount + 1)
+    expect(setUnreadDockBadgeCount).toHaveBeenLastCalledWith(2)
+
+    // A tab is read.
+    act(() => useAppStore.setState({ unreadTerminalTabs: { 'tab-19': true } }))
+    expect(renders).toBe(rendersAfterMount + 2)
+    expect(setUnreadDockBadgeCount).toHaveBeenLastCalledWith(1)
+
+    // A tab holding unread state closes.
+    act(() =>
+      useAppStore.setState({
+        tabsByWorktree: { ...useAppStore.getState().tabsByWorktree, 'repo::worktree-19': [] },
+        unreadTerminalTabs: {}
+      })
+    )
+    expect(renders).toBe(rendersAfterMount + 3)
+    expect(setUnreadDockBadgeCount).toHaveBeenLastCalledWith(0)
+  })
 })

--- a/src/renderer/src/hooks/useUnreadDockBadge.ts
+++ b/src/renderer/src/hooks/useUnreadDockBadge.ts
@@ -1,6 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { useShallow } from 'zustand/react/shallow'
-import { getUnreadBadgeCount } from '@/lib/unread-badge-count'
+import { createUnreadBadgeCountSelector } from '@/lib/unread-badge-count-selector'
 import { useAppStore } from '@/store'
 
 function setUnreadDockBadgeCountBestEffort(count: number): void {
@@ -18,18 +17,11 @@ export function clearUnreadDockBadgeCount(): void {
 }
 
 export function useUnreadDockBadge(): typeof clearUnreadDockBadgeCount {
-  const { worktreesByRepo, tabsByWorktree, unreadTerminalTabs } = useAppStore(
-    useShallow((state) => ({
-      worktreesByRepo: state.worktreesByRepo,
-      tabsByWorktree: state.tabsByWorktree,
-      unreadTerminalTabs: state.unreadTerminalTabs
-    }))
-  )
-  // Why: this hook is always mounted; unrelated remote writes must not rescan every workspace.
-  const unreadCount = useMemo(
-    () => getUnreadBadgeCount({ worktreesByRepo, tabsByWorktree, unreadTerminalTabs }),
-    [tabsByWorktree, unreadTerminalTabs, worktreesByRepo]
-  )
+  // Why a selector and not the raw maps: this hook is mounted on the App root, so subscribing to
+  // `tabsByWorktree` re-rendered the entire shell on every title frame. The selector both skips the
+  // rescan and keeps the subscription quiet unless the badge integer itself changes.
+  const selectUnreadBadgeCount = useMemo(() => createUnreadBadgeCountSelector(), [])
+  const unreadCount = useAppStore(selectUnreadBadgeCount)
 
   // oxlint-disable-next-line react-doctor/no-derived-state-effect -- Why: this syncs an external OS dock badge, not React render state.
   useEffect(() => {

--- a/src/renderer/src/lib/bucket-record-equality.ts
+++ b/src/renderer/src/lib/bucket-record-equality.ts
@@ -1,0 +1,42 @@
+/**
+ * Identity-first equality over a `Record<string, readonly T[]>` under a projection of each item.
+ *
+ * Why not `createWorktreeTabBucketProjection`: that builds a projected record so callers can hold
+ * it; a subscriber that only needs "did my fields change?" pays for an allocation per store write.
+ * This answers the same question by comparing in place.
+ */
+export function sameBucketRecords<T>(
+  previous: Readonly<Record<string, readonly T[]>>,
+  next: Readonly<Record<string, readonly T[]>>,
+  isSameItem: (previous: T, next: T) => boolean
+): boolean {
+  if (previous === next) {
+    return true
+  }
+  const keys = Object.keys(next)
+  if (keys.length !== Object.keys(previous).length) {
+    return false
+  }
+  for (const key of keys) {
+    const nextItems = next[key]
+    const previousItems = previous[key]
+    if (previousItems === nextItems) {
+      continue
+    }
+    if (!previousItems || !nextItems || previousItems.length !== nextItems.length) {
+      return false
+    }
+    for (let index = 0; index < nextItems.length; index += 1) {
+      const previousItem = previousItems[index]
+      const nextItem = nextItems[index]
+      if (
+        previousItem === undefined ||
+        nextItem === undefined ||
+        !isSameItem(previousItem, nextItem)
+      ) {
+        return false
+      }
+    }
+  }
+  return true
+}

--- a/src/renderer/src/lib/terminal-layout-equality.ts
+++ b/src/renderer/src/lib/terminal-layout-equality.ts
@@ -3,7 +3,8 @@ import type {
   TerminalPaneLayoutNode
 } from '../../../shared/terminal-tab-types'
 
-function sameStringRecord(
+/** Exported so pty-topology gates can reuse the leaf-map comparison this equality already defines. */
+export function sameStringRecord(
   a: Readonly<Record<string, string>> | undefined,
   b: Readonly<Record<string, string>> | undefined
 ): boolean {

--- a/src/renderer/src/lib/unread-badge-count-selector.ts
+++ b/src/renderer/src/lib/unread-badge-count-selector.ts
@@ -1,0 +1,50 @@
+import { sameBucketRecords } from './bucket-record-equality'
+import {
+  type UnreadBadgeCountSources,
+  type UnreadBadgeTab,
+  type UnreadBadgeWorktree,
+  getUnreadBadgeCount
+} from './unread-badge-count'
+
+const EMPTY_BUCKETS = Object.freeze({})
+
+function sameBadgeWorktree(previous: UnreadBadgeWorktree, next: UnreadBadgeWorktree): boolean {
+  return previous.id === next.id && previous.isUnread === next.isUnread
+}
+
+function sameBadgeTab(previous: UnreadBadgeTab, next: UnreadBadgeTab): boolean {
+  return previous.id === next.id
+}
+
+/**
+ * Why: the App root holds this subscription for a single integer. Returning the raw maps re-rendered
+ * the whole shell on every agent title frame; selecting the count instead means the subscription
+ * only notifies when the badge value can actually have moved.
+ *
+ * Why chaining against the immediately preceding state is enough: equality over the count's read set
+ * — worktree `id`/`isUnread`, tab `id`, and the unread map identity — is transitive, so a run of
+ * unchanged states is equivalent to comparing against the state that produced the cached count.
+ */
+export function createUnreadBadgeCountSelector(): (state: UnreadBadgeCountSources) => number {
+  let previousWorktreesByRepo: UnreadBadgeCountSources['worktreesByRepo'] = EMPTY_BUCKETS
+  let previousTabsByWorktree: UnreadBadgeCountSources['tabsByWorktree'] = EMPTY_BUCKETS
+  let previousUnreadTerminalTabs: UnreadBadgeCountSources['unreadTerminalTabs'] | undefined
+  let unreadCount = 0
+  let counted = false
+
+  return (state) => {
+    const unchanged =
+      counted &&
+      previousUnreadTerminalTabs === state.unreadTerminalTabs &&
+      sameBucketRecords(previousWorktreesByRepo, state.worktreesByRepo, sameBadgeWorktree) &&
+      sameBucketRecords(previousTabsByWorktree, state.tabsByWorktree, sameBadgeTab)
+    if (!unchanged) {
+      unreadCount = getUnreadBadgeCount(state)
+      previousUnreadTerminalTabs = state.unreadTerminalTabs
+      counted = true
+    }
+    previousWorktreesByRepo = state.worktreesByRepo
+    previousTabsByWorktree = state.tabsByWorktree
+    return unreadCount
+  }
+}

--- a/src/renderer/src/lib/unread-badge-count.ts
+++ b/src/renderer/src/lib/unread-badge-count.ts
@@ -1,15 +1,21 @@
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { Worktree } from '../../../shared/worktree/types'
 
+/** The only fields the count reads, so a projection over them is a sound cache key. */
+export type UnreadBadgeWorktree = Pick<Worktree, 'id' | 'isUnread'>
+export type UnreadBadgeTab = Pick<TerminalTab, 'id'>
+
+export type UnreadBadgeCountSources = {
+  worktreesByRepo: Readonly<Record<string, readonly UnreadBadgeWorktree[]>>
+  tabsByWorktree: Readonly<Record<string, readonly UnreadBadgeTab[]>>
+  unreadTerminalTabs: Readonly<Record<string, true>>
+}
+
 export function getUnreadBadgeCount({
   worktreesByRepo,
   tabsByWorktree,
   unreadTerminalTabs
-}: {
-  worktreesByRepo: Record<string, Worktree[]>
-  tabsByWorktree: Record<string, TerminalTab[]>
-  unreadTerminalTabs: Record<string, true>
-}): number {
+}: UnreadBadgeCountSources): number {
   const unreadWorktreeIds = new Set<string>()
 
   for (const worktrees of Object.values(worktreesByRepo)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​258 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​258 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​207 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​44 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 |

<!-- /orca-pr-loc -->

## ELI5

Two parts of the app were listening to far more than they needed.

The first is the little red number on the Dock icon. To keep that one number up to date, the app was watching the entire list of every terminal tab in every workspace. Agents rewrite their tab titles constantly while they work, and every one of those title updates counted as "the tab list changed" — so the app redrew its whole outer shell, thousands of times, to recompute a number that had not changed. Now it watches the number itself, so the shell only redraws when the badge actually moves.

The second is a background check that asks each terminal process whether it can hand back a saved copy of its scrollback. To know which processes to ask, the app rebuilt the full list of process IDs from scratch. It rebuilt that list on every title update and every time you clicked into a different pane — neither of which can change which processes exist. It then compared the rebuilt list to the old one, found them identical, and threw the work away. Now it checks the cheap question first ("did the set of processes change?") and only rebuilds when the answer is yes.

## What Changed

Two always-mounted renderer subscriptions were narrowed from raw store maps to the value each
consumer actually needs. No behaviour, no cadence, no threshold changed.

- `src/renderer/src/hooks/useUnreadDockBadge.ts` — drops the `useShallow` subscription over
  `worktreesByRepo` / `tabsByWorktree` / `unreadTerminalTabs` and selects the badge integer through
  the new `createUnreadBadgeCountSelector`, so the App root re-renders only when the count moves.
- `src/renderer/src/lib/unread-badge-count-selector.ts` (new) — stateful selector gating
  `getUnreadBadgeCount` on exactly its read set.
- `src/renderer/src/lib/unread-badge-count.ts` — read set expressed as types
  (`UnreadBadgeCountSources`, `UnreadBadgeWorktree`, `UnreadBadgeTab`); logic unchanged.
- `src/renderer/src/components/terminal/use-terminal-provider-snapshot-capability.ts` — replaces the
  `collect` + `sort` + `JSON.stringify` + `JSON.parse` memo key with
  `createTerminalProviderSnapshotBoundPtyIdsSelector`.
- `src/renderer/src/components/terminal/terminal-provider-snapshot-bound-pty-ids.ts` (new) —
  topology gate over `tab.id` / `tab.ptyId`, `ptyIdsByTabId`, `pendingReconnectPtyIdByTabId` and
  `layout.ptyIdsByLeafId`; reuses the prior id array via `reuseArrayIfEqual` when a real rebuild
  lands on the same set, preserving the identity the synchronizer's early-out depends on.
- `src/renderer/src/lib/bucket-record-equality.ts` (new) — `sameBucketRecords`, shared by both gates.
- `src/renderer/src/lib/terminal-layout-equality.ts` — exports the existing `sameStringRecord`.
- `src/renderer/src/components/terminal/terminal-provider-snapshot-capability.ts` — exports two
  existing types. Collector untouched, still receives full state.

## Why

Both land on the React render/commit line measured at **2.07% of wall time** on the live packaged app (renderer audit, 413 worktrees / 801 tabs / 905 layout leaves).

- Finding 1 — `useUnreadDockBadge` bound the **App root** to `tabsByWorktree` (422 KB) via `useShallow` over three raw maps. Every title frame re-rendered `App`, which recreates `layout` from `useAppChromeLayout` and re-renders `AppWorkspaceShell`, `AppRootSurfaces`, `AppBackgroundServices`, both providers, and every non-memoised overlay under `AppRootSurfaces` (`StarNagCard`, `StarNagToastHost`, `TelemetryFirstLaunchSurface`, `ZoomOverlay`, `StructuredAgentSessionStatusBridge`). Commit `d15a554f62c` gated the *scan*; the *subscription* was left broad.
- Finding 2 — `use-terminal-provider-snapshot-capability.ts` memoised its collector key on raw `tabsByWorktree` + `terminalLayoutsByTabId` (317 KB, 905 leaves). The file's own comment already said "layouts change without changing the pty set", yet both title frames and active-leaf moves re-ran `collectTerminalProviderSnapshotPtyIds` (a `Set` over every tab *and* every layout), `.sort()`, `JSON.stringify`, `JSON.parse`. `boundPtyIdsKey` correctly stopped the *effect* from restarting, so **100% of that work was discarded**.

**On the trigger rate:** the brief asked for a live counter. I could not get one — the running packaged Orca exposes only a Node inspector on 9229 (main process); there is no renderer CDP port, and launching a second instance would not reproduce the 801-tab / 905-leaf session that makes the number interesting. So instead of quoting a range I am quoting the two things I *can* measure exactly: the cost per trigger (below), and the trigger *count* per user-visible event, which the regression test pins at **exactly 1 rebuild per agent title frame and 1 per active-leaf move, now 0**. Multiply by your own frame rate.

## Linked Issue

N/A — no tracking issue; this came out of the renderer render/commit audit described above.

## Visual Proof

`N/A` — pure renderer subscription plumbing. Nothing rendered changes: the dock badge shows the same
integer at the same moment, and the terminal snapshot-capability set is byte-identical. The only
difference is how many times React re-renders to produce it, which has no visual form.

## Measurement

### Microbenchmark — Finding 2 (801 tabs / 905 leaves / 413 worktrees, 1706 pty ids, 2000 alternating title-frame + active-leaf-move triggers, 200-iteration warmup)

| | µs / trigger |
|---|---|
| before: `collect` + `sort` + `JSON.stringify` + `JSON.parse` | **270.4** |
| after: topology gate (collector never runs) | **46.7** |

Three consecutive runs, before / after: `272.1 / 46.7`, `271.4 / 47.1`, `269.8 / 46.2` µs. **5.8× reduction, ~224 µs saved per trigger.** (Machine is heavily loaded; the audit's 0.302 ms for the same "before" path on the packaged app is the same order.)

### Failing-test output without the change

**Finding 1** — reverted `useUnreadDockBadge.ts` to the `useShallow` version:

```
 × leaves the App root asleep through title frames and wakes it only on a badge change
AssertionError: expected 21 to be 1 // Object.is equality
 Test Files  1 failed (1)
      Tests  1 failed | 5 passed (6)
```

20 real `updateTabTitle` calls ⇒ 20 extra App-root renders. With the change: `6 passed (6)`.

**Finding 2** — replaced the topology gate with the pre-change raw-map identity comparison:

```
 × never re-collects for agent title frames or active-leaf moves
AssertionError: expected "vi.fn()" to be called 1 times, but got 81 times
 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

40 real `updateTabTitle` + 40 real `setTabLayout` active-leaf moves ⇒ 80 extra collector runs. With the change: `3 passed (3)`.

## Correctness

**Finding 2 — read-set claim, verified by reading `collectTerminalProviderSnapshotPtyIds` myself.** It reads exactly: `tab.ptyId` and `tab.id` from each `tabsByWorktree` bucket, `ptyIdsByTabId[tab.id]`, the values of `pendingReconnectPtyIdByTabId`, and `layout.ptyIdsByLeafId` from each `terminalLayoutsByTabId` entry. Nothing else. The gate compares a strict superset: whole-object identity for `ptyIdsByTabId` and `pendingReconnectPtyIdByTabId`, per-bucket identity then element-wise `{id, ptyId}` for tabs, and per-tab identity then `sameStringRecord` over `ptyIdsByLeafId` for layouts. A gate hit therefore implies the collector's inputs are value-identical, so its output is identical.

**Why chaining against the previous state is sound.** Both selectors compare each new state against the *immediately preceding* one and advance their stored references even on a hit. Equality over each read set is an equivalence relation, so a run of pairwise-unchanged states is equivalent to comparing against the state that produced the cached value.

**The synchronizer's identity contract is preserved.** `synchronizeTerminalProviderSnapshotCapabilities` early-outs on `livePtyIds === lastSynchronizedLivePtyIds`, and `startTerminalProviderSnapshotCapabilitySynchronization` is re-armed by the effect's `[boundPtyIds]` dep — so array *identity* is load-bearing. The `JSON.stringify` → `JSON.parse` round-trip existed solely as a value-equality gate that preserved that identity across content-equal rebuilds (e.g. a tab reorder). **I removed it** and replaced it with the already-exported `reuseArrayIfEqual`, which is the same value gate with no string allocation: for a `string[]`, JSON-string equality and element-wise equality are the same predicate. A dedicated test pins this (`keeps the array identity when a rebuild lands on the same id set` — a tab reorder still re-collects but returns the prior array). The existing `preserves newline-bearing folder-workspace pty ids in the memo key` test also still passes: element-wise comparison has no escaping hazard at all, where JSON did.

**Pruning coverage is unchanged.** The synchronizer *prunes* cached verdicts outside the collected set, so a narrower collector would evict valid split-leaf and pending-reconnect answers back into exempt-by-default unknown. The collector itself is untouched and still receives full state; only the decision to *call* it changed.

**Finding 1 — read set.** `getUnreadBadgeCount` reads `worktree.id` / `worktree.isUnread`, `tab.id`, and every key of `unreadTerminalTabs`. The gate compares exactly those (identity for `unreadTerminalTabs`, element-wise `{id, isUnread}` / `{id}` for the two bucket maps). Its `unreadTabIds.size + unreadWorktreeIds.size` hydration-race branch is unaffected — that branch is a function of the same three inputs.

**No new subscription cost on unrelated writes.** Both selectors now run once per store write instead of once per component render. In the common case (an unrelated write, e.g. agent status or usage) every map identity matches and the comparators short-circuit on `previous === next` — 3 or 4 reference compares, no allocation. The existing `does not rescan workspaces for unrelated remote activity or parent renders` test (100 unrelated store writes ⇒ 1 scan) still passes unchanged.

**In-place state mutation.** The selectors deliberately store the four/three *field* references rather than the state object, because the existing hook test mocks `@/store` with a single mutable object. Zustand never mutates state in place, but holding the state object would have made the gate silently stale under that mock — I hit exactly that and fixed the production code rather than the test.

**Reuse note (measured, not assumed).** The brief suggested `createWorktreeTabBucketProjection`. I implemented it that way first and benchmarked it: because it materialises a projected record per call, it cost **~108 µs/trigger** — barely better than just letting the collector run, and *slower* than the before path in some runs. The final version answers the same question by comparing in place (`sameBucketRecords`, new, shared by both findings) at **46.7 µs**. `sameStringRecord` (already in `terminal-layout-equality.ts`, the same predicate the store's own `setTabLayout` bailout uses) and `reuseArrayIfEqual` (already exported for reuse) are reused as-is.

**Edge cases.** Empty/missing state: `terminalLayoutsByTabId` and `pendingReconnectPtyIdByTabId` are optional and normalise to a frozen empty record, matching the collector's own `?? {}`. Key add/remove (tab closed, layout dropped) is caught by the key-count check before any per-item compare, and a same-count key *swap* is caught because the removed key's previous value is absent. SSH / remote: pty ids are opaque strings throughout; the ids compared here include `ssh:` and relay ids, and the existing SSH-flavoured tests in `use-terminal-provider-snapshot-capability.test.tsx` are unchanged and passing. Folder workspaces: nothing here assumes a git worktree — keys are workspace ids, and the newline-bearing folder-workspace id test still passes. Windows: pure in-memory renderer logic, no paths, no platform branches. Remote wire: nothing crosses the wire; no RPC params, stream frames or published content changed.

## Negative user-facing trade-offs

**None.** No cap, cadence, debounce, threshold, sampling or staleness window was introduced: both gates are exact equality over each consumer's full read set, so every input change that could alter the output still produces the same output at the same moment — the app just stops recomputing when the inputs are provably unchanged.

## Testing

- `src/renderer/src/components/terminal/terminal-provider-snapshot-bound-pty-ids.test.ts` (new, 3 cases) drives the **real** app store through the selector via `useAppStore.subscribe`, exactly as zustand does:
  - 40 real `updateTabTitle` + 40 real `setTabLayout` active-leaf moves ⇒ collector runs **0** additional times and the id array keeps its identity.
  - Collector **does** re-run, and the array identity **does** change, for: a leaf pty rebound (`replaceTerminalLayoutPanePtyId`), a split pty bound to a tab, a split pty unbound, a pending-reconnect pty appearing, a leaf added, a leaf removed, a tab added, a tab removed — each asserted to contain / not contain the specific pty id.
  - A tab reorder re-collects but reuses the prior array, so the synchronization loop does not restart.
- `src/renderer/src/hooks/useUnreadDockBadge.test.ts` (new case) counts renders of the hook's host: 20 real `updateTabTitle` calls ⇒ **0** additional renders; then exactly one render each for a tab becoming unread (badge 1→2), a tab being read (2→1), and a tab holding unread state closing (1→0), with the dock badge value asserted at each step. The four pre-existing cases are unchanged.
- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/hooks/useUnreadDockBadge.test.ts src/renderer/src/lib src/renderer/src/components/terminal` → **979 files, 9314 passed**.
- `src/renderer/src/app-shell` + `src/renderer/src/components/terminal` + `session-write-subscriber` → **477 files, 4512 passed**.
- `src/renderer/src/components/sidebar` → 4 timeouts at 15–30 s under load; all pass in isolation (unrelated, load-induced).
- `nice -n 10 node_modules/.bin/tsc --noEmit -p config/tsconfig.tc.web.json --composite false` clean; `oxfmt` + `oxlint` clean on all changed files.

Platforms: macOS locally (renderer-only, in-memory logic — no path, shell or platform branches, so
Linux/Windows/SSH behaviour is identical by construction; SSH-flavoured pty ids are covered by the
existing unchanged tests in `use-terminal-provider-snapshot-capability.test.tsx`).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- Internal contributor: section intentionally left blank. -->

## Review

Both bot reviews are clean: pullfrog `✅ No new issues found` (it independently verified the read-set
and transitive-chaining claims against `collectTerminalProviderSnapshotPtyIds` and
`getUnreadBadgeCount`), CodeRabbit `No actionable comments were generated`, merge risk `Minimal`.

CodeRabbit's remaining pre-merge warnings: the description-template warning is addressed by this
rewrite; the 80% docstring-coverage warning is declined — `AGENTS.md` mandates "Concise/Brief
Non-obvious Comments ONLY", and the non-obvious parts here (why chaining against the immediately
preceding state is sound, why the collector still gets full state, why not
`createWorktreeTabBucketProjection`) already carry comments.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — no new inputs, no IO, no serialization; the removed `JSON.stringify`/`JSON.parse`
  round-trip strictly reduces parsing surface.
- **Cross-platform** — in-memory renderer logic only; no paths, no shortcuts, no platform branches.
- **Remote SSH** — pty ids are opaque strings throughout; `ssh:` and relay ids compare like any
  other. Nothing here reports on, stops or lists remote work, so the `live`/`unverifiable`/`exited`
  boundary is untouched.
- **Folder workspaces** — keys are workspace ids, not worktree paths; the newline-bearing
  folder-workspace pty id test still passes (element-wise comparison has no escaping hazard where
  JSON did).
- **Mobile / backwards compatibility / remote wire** — nothing crosses the wire; no RPC params,
  stream frames or published content changed.
- **Performance** — see Measurement.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
