### PR TITLE
fix(markdown): refresh Mermaid after a syntax error is fixed

### DIFF
--- a/src/renderer/src/components/editor/MermaidBlock.test.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mermaidApi = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  render: vi.fn()
+}))
+
+vi.mock('mermaid', () => ({
+  default: mermaidApi
+}))
+
+vi.mock('dompurify', () => ({
+  default: {
+    sanitize: (html: string) => html
+  }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+import MermaidBlock from './MermaidBlock'
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+beforeEach(() => {
+  mermaidApi.initialize.mockReset()
+  mermaidApi.render.mockReset()
+})
+
+function mockMermaidSource(content: string): Promise<{ svg: string }> {
+  if (content.includes('TDD')) {
+    return Promise.reject(new Error('Syntax error in text'))
+  }
+  return Promise.resolve({ svg: `<svg data-source="${content}"></svg>` })
+}
+
+describe('MermaidBlock', () => {
+  it('shows a diagram error for invalid syntax and keeps the source visible', async () => {
+    mermaidApi.render.mockImplementation((_id: string, content: string) =>
+      mockMermaidSource(content)
+    )
+
+    const { container } = render(<MermaidBlock content="graph TDD; A-->B" isDark={false} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.mermaid-error')).not.toBeNull()
+    })
+    expect(container.textContent).toContain('Diagram error:')
+    expect(container.textContent).toContain('Syntax error in text')
+    expect(container.querySelector('code')?.textContent).toBe('graph TDD; A-->B')
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('re-renders the diagram after a syntax error is fixed without remounting', async () => {
+    mermaidApi.render.mockImplementation((_id: string, content: string) =>
+      mockMermaidSource(content)
+    )
+
+    const { container, rerender } = render(
+      <MermaidBlock content="graph TDD; A-->B" isDark={false} />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('.mermaid-error')).not.toBeNull()
+    })
+
+    rerender(<MermaidBlock content="graph TD; A-->B" isDark={false} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.mermaid-error')).toBeNull()
+      expect(container.querySelector('svg')?.getAttribute('data-source')).toBe('graph TD; A-->B')
+    })
+  })
+
+  it('shows a diagram error again if the source becomes invalid after a successful render', async () => {
+    mermaidApi.render.mockImplementation((_id: string, content: string) =>
+      mockMermaidSource(content)
+    )
+
+    const { container, rerender } = render(
+      <MermaidBlock content="graph TD; A-->B" isDark={false} />
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull()
+    })
+
+    rerender(<MermaidBlock content="graph TDD; A-->B" isDark={false} />)
+
+    await waitFor(() => {
+      expect(container.querySelector('.mermaid-error')).not.toBeNull()
+      expect(container.querySelector('svg')).toBeNull()
+    })
+    expect(container.querySelector('code')?.textContent).toBe('graph TDD; A-->B')
+  })
+})

--- a/src/renderer/src/components/editor/MermaidBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.tsx
@@ -72,21 +72,30 @@ export default function MermaidBlock({
         // broken foreignObject label path again.
         mermaid.initialize(getMermaidConfig(isDark, htmlLabels))
         const { svg } = await mermaid.render(`mermaid-${id}`, content)
-        if (!cancelled && containerRef.current) {
-          // Why: although mermaid uses DOMPurify internally, we add an explicit
-          // sanitization pass as defense-in-depth against XSS in case upstream
-          // behaviour changes or a mermaid version ships without sanitization.
-          containerRef.current.innerHTML = DOMPurify.sanitize(svg, {
-            USE_PROFILES: { svg: true }
-          })
-          setError(null)
+        if (cancelled) {
+          return
         }
+        // Why: although mermaid uses DOMPurify internally, we add an explicit
+        // sanitization pass as defense-in-depth against XSS in case upstream
+        // behaviour changes or a mermaid version ships without sanitization.
+        const sanitized = DOMPurify.sanitize(svg, {
+          USE_PROFILES: { svg: true }
+        })
+        if (containerRef.current) {
+          containerRef.current.innerHTML = sanitized
+        }
+        setError(null)
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Invalid mermaid syntax')
           // Mermaid leaves an error element in the DOM on failure — clean it up.
           const errorEl = document.getElementById(`d${`mermaid-${id}`}`)
           errorEl?.remove()
+          // Why: the SVG host stays mounted (hidden) during error; clear it so
+          // the previous diagram cannot linger in the DOM.
+          if (containerRef.current) {
+            containerRef.current.innerHTML = ''
+          }
         }
       }
     }
@@ -99,18 +108,21 @@ export default function MermaidBlock({
     }
   }, [content, htmlLabels, isDark, id])
 
-  if (error) {
-    return (
-      <div className="mermaid-block">
-        <div className="mermaid-error">
-          {translate('auto.components.editor.MermaidBlock.dcc132e691', 'Diagram error:')} {error}
-        </div>
-        <pre>
-          <code>{content}</code>
-        </pre>
-      </div>
-    )
-  }
-
-  return <div className="mermaid-block" ref={containerRef} />
+  return (
+    <div className="mermaid-block">
+      {error ? (
+        <>
+          <div className="mermaid-error">
+            {translate('auto.components.editor.MermaidBlock.dcc132e691', 'Diagram error:')} {error}
+          </div>
+          <pre>
+            <code>{content}</code>
+          </pre>
+        </>
+      ) : null}
+      {/* Why: keep the SVG host mounted during error so a later successful
+          parse can write the diagram and clear the stale error (#18370). */}
+      <div ref={containerRef} hidden={error !== null} />
+    </div>
+  )
 }


### PR DESCRIPTION
## Description
Fixing a Mermaid syntax error in floating-window markdown now re-renders the diagram without toggling code/edit mode.

After a parse failure the error UI replaced the SVG host, so a later successful `mermaid.render()` found a null ref and never cleared the stale error.

## Focused fix
- In scope: keep the Mermaid SVG host mounted (hidden) during a syntax error so a subsequent successful parse can write the diagram and clear the error.
- Out of scope (explicit): mermaid engine/parser changes; preview vs code/edit chrome; SSH/remote diagram execution (preview is renderer-local).

## Preserves
- Error banner and source remain visible while the diagram is invalid.
- Preview vs code/edit mode behavior is unchanged.
- Sanitized SVG path, serialized render queue, and theme/`htmlLabels` initialization are unchanged.
- Mermaid rendering stays in the local renderer; SSH is not on this path.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/MermaidBlock.test.tsx`
- Without the fix: invalid source shows the error, then valid source leaves that error on screen until the block remounts (mode toggle).
- With the fix: valid source after an error shows the diagram and clears the error; a later invalid source shows the error again and drops the previous SVG.

## User-regression-tradeoffs
- None intended. Invalid diagrams still show the error; recovery no longer requires a mode toggle.

Fixes #18370
