### PR TITLE
fix(terminal): keep bracketed paste after interrupt for single-line payloads

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-interrupt-inference.test.ts
@@ -413,7 +413,7 @@ describe('connectPanePty', () => {
     })
   })
 
-  it('marks bracketed paste as stale after acknowledged Ctrl+C input', async () => {
+  it('keeps bracketed paste for single-line text after acknowledged Ctrl+C input', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const { pasteTerminalText } = await import('./terminal-bracketed-paste')
     const transport = createMockTransport()
@@ -438,7 +438,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
     pasteTerminalText(pane.terminal as never, 'a69ce28e1d092e0c8825cd1a109ac36409962bc1')
 
-    expect(observedIgnoreValues).toEqual([true])
+    expect(observedIgnoreValues).toEqual([false])
     expect(pane.terminal.options.ignoreBracketedPasteMode).toBe(false)
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -21,7 +21,7 @@ function createTerminal(bracketedPasteMode = true) {
 }
 
 describe('terminal bracketed paste policy', () => {
-  it('temporarily ignores bracketed paste wrappers for single-line paste after Ctrl+C', () => {
+  it('keeps bracketed paste wrappers for single-line paste after Ctrl+C', () => {
     const terminal = createTerminal(true)
     const observedIgnoreValues: (boolean | undefined)[] = []
     terminal.paste.mockImplementation(() => {
@@ -32,7 +32,7 @@ describe('terminal bracketed paste policy', () => {
     pasteTerminalText(terminal, 'a69ce28e1d092e0c8825cd1a109ac36409962bc1')
 
     expect(terminal.paste).toHaveBeenCalledWith('a69ce28e1d092e0c8825cd1a109ac36409962bc1')
-    expect(observedIgnoreValues).toEqual([true])
+    expect(observedIgnoreValues).toEqual([false])
     expect(terminal.options.ignoreBracketedPasteMode).toBe(false)
   })
 
@@ -192,7 +192,7 @@ describe('terminal bracketed paste policy', () => {
     observeTerminalBracketedPasteModeOutput(terminal, '04h')
     pasteTerminalText(terminal, 'commit')
 
-    expect(observedIgnoreValues).toEqual([true])
+    expect(observedIgnoreValues).toEqual([false])
   })
 
   it('detects split compound bracketed paste mode output', () => {
@@ -226,13 +226,18 @@ describe('terminal bracketed paste policy', () => {
     expect(observedIgnoreValues).toEqual([false, false])
   })
 
-  it('renders embedded escape bytes inert when forcing plain single-line paste', () => {
+  it('keeps bracketed paste for single-line payloads that contain escape bytes after Ctrl+C', () => {
     const terminal = createTerminal(true)
+    const observedIgnoreValues: (boolean | undefined)[] = []
+    terminal.paste.mockImplementation(() => {
+      observedIgnoreValues.push(terminal.options.ignoreBracketedPasteMode)
+    })
 
     markTerminalBracketedPasteInterrupted(terminal)
     pasteTerminalText(terminal, 'before\x1b[201~after')
 
-    expect(terminal.paste).toHaveBeenCalledWith('before\u241b[201~after')
+    expect(terminal.paste).toHaveBeenCalledWith('before\x1b[201~after')
+    expect(observedIgnoreValues).toEqual([false])
   })
 
   it('sanitizes escape-heavy paste text without split arrays', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -236,7 +236,7 @@ describe('terminal bracketed paste policy', () => {
     markTerminalBracketedPasteInterrupted(terminal)
     pasteTerminalText(terminal, 'before\x1b[201~after')
 
-    expect(terminal.paste).toHaveBeenCalledWith('before\x1b[201~after')
+    expect(terminal.paste).toHaveBeenCalledWith('before\u241b[201~after')
     expect(observedIgnoreValues).toEqual([false])
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts
@@ -226,7 +226,7 @@ describe('terminal bracketed paste policy', () => {
     expect(observedIgnoreValues).toEqual([false, false])
   })
 
-  it('keeps bracketed paste for single-line payloads that contain escape bytes after Ctrl+C', () => {
+  it('forwards interrupted single-line paste to xterm native sanitization', () => {
     const terminal = createTerminal(true)
     const observedIgnoreValues: (boolean | undefined)[] = []
     terminal.paste.mockImplementation(() => {
@@ -236,7 +236,7 @@ describe('terminal bracketed paste policy', () => {
     markTerminalBracketedPasteInterrupted(terminal)
     pasteTerminalText(terminal, 'before\x1b[201~after')
 
-    expect(terminal.paste).toHaveBeenCalledWith('before\u241b[201~after')
+    expect(terminal.paste).toHaveBeenCalledWith('before\x1b[201~after')
     expect(observedIgnoreValues).toEqual([false])
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -26,7 +26,6 @@ export const BRACKETED_PASTE_END = `${ESCAPE}[201~`
 const BRACKETED_PASTE_MODE_SEQUENCE_RE = /^\[\?(?:\d+;)*2004(?:;\d+)*[hl]/
 const BRACKETED_PASTE_MODE_TAIL_MAX = 128
 const BRACKETED_PASTE_MODE_SEQUENCE_SCAN_MAX = BRACKETED_PASTE_MODE_TAIL_MAX
-const LINE_BREAK_RE = /[\r\n]/
 
 function hasBracketedPasteModeSequence(data: string): boolean {
   let escapeIndex = data.indexOf(ESCAPE)
@@ -142,7 +141,7 @@ export function pasteTerminalText(
   }
   if (options?.forceBracketedPaste) {
     // Why: generated image paths are paste payloads, even when they are a
-    // single line, so they must bypass stale Ctrl+C plain-text suppression.
+    // single line or bracketed-paste mode is off.
     forceBracketedPaste(terminal, text)
     return
   }
@@ -156,18 +155,7 @@ export function pasteTerminalText(
     terminal.paste(text)
     return
   }
-  if (LINE_BREAK_RE.test(text)) {
-    terminal.paste(text)
-    return
-  }
-
-  const previousIgnoreBracketedPasteMode = terminal.options.ignoreBracketedPasteMode
-  // Why: Ctrl+C can leave xterm's bracketed-paste bit stale after the foreground
-  // process dies. Single-line paste does not need wrappers, so avoid leaking them.
-  terminal.options.ignoreBracketedPasteMode = true
-  try {
-    terminal.paste(sanitizeTerminalPasteText(text))
-  } finally {
-    terminal.options.ignoreBracketedPasteMode = previousIgnoreBracketedPasteMode
-  }
+  // Why: TUI agents treat paste vs keystrokes by bracketing, not line count.
+  // Stripping wrappers after Ctrl+C truncates long single-line pastes.
+  terminal.paste(text)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -157,6 +157,6 @@ export function pasteTerminalText(
   }
   // Why: TUI agents treat paste vs keystrokes by bracketing, not line count.
   // Stripping wrappers after Ctrl+C truncates long single-line pastes.
-  // Why: xterm's native paste wrapper must not let pasted escape bytes close the frame early.
-  terminal.paste(sanitizeTerminalPasteText(text))
+  // Why: xterm owns the wrapper and ESC sanitization for the native paste path.
+  terminal.paste(text)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-bracketed-paste.ts
@@ -157,5 +157,6 @@ export function pasteTerminalText(
   }
   // Why: TUI agents treat paste vs keystrokes by bracketing, not line count.
   // Stripping wrappers after Ctrl+C truncates long single-line pastes.
-  terminal.paste(text)
+  // Why: xterm's native paste wrapper must not let pasted escape bytes close the frame early.
+  terminal.paste(sanitizeTerminalPasteText(text))
 }

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -363,7 +363,7 @@ describe('terminal clipboard paste', () => {
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
   })
 
-  it('keeps normal single-line text paste on the stale Ctrl+C protection path', async () => {
+  it('keeps bracketed paste for single-line text after Ctrl+C', async () => {
     const observedIgnoreBracketedPasteMode: boolean[] = []
     const terminal = {
       modes: { bracketedPasteMode: true },
@@ -385,7 +385,7 @@ describe('terminal clipboard paste', () => {
     })
 
     expect(terminal.paste).toHaveBeenCalledWith('a69ce28e1d092e0c8825cd1a109ac36409962bc1')
-    expect(observedIgnoreBracketedPasteMode).toEqual([true])
+    expect(observedIgnoreBracketedPasteMode).toEqual([false])
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Description
After Ctrl+C, a latched agent pane no longer strips bracketed paste from single-line clipboard payloads. TUI agents that enable `?2004h` (Claude Code and similar) keep one paste frame instead of keystrokes that silently truncate long lines.

## Focused fix
- In scope: drop the interrupted-pane single-line exemption in `pasteTerminalText` so single-line and multi-line pastes both keep bracketing.
- Out of scope (explicit): toasts/diagnostics, clearing the latch on agent heartbeat, gating on foreground-agent evidence, #15502 multi-line remote execution, #13332 mobile chunk truncation.

## Preserves
- Multi-line pastes already used `terminal.paste` after interrupt.
- Non-interrupted panes still take the ordinary paste path.
- Forced image-path bracketing, Windows input-record newlines, and SSH clipboard image routing are unchanged.
- The interrupt latch still clears on a fresh `?2004h`/`?2004l` sequence or when mode is already off.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-bracketed-paste.test.ts src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts src/renderer/src/components/terminal-pane/pty-connection-interrupt-inference.test.ts src/renderer/src/components/terminal-pane/terminal-agent-paste-bracketing.test.ts`
- Result: 64 passed.
- Before: after `markTerminalBracketedPasteInterrupted`, a single-line paste set `ignoreBracketedPasteMode` to `true`.
- After: the same paste leaves `ignoreBracketedPasteMode` false so xterm keeps native bracketing.

## User-regression-tradeoffs
- If Ctrl+C actually killed a process that left xterm's mode bit stale, a single-line paste may now emit `\x1b[200~` wrappers into a shell. Multi-line pastes already took that path without reported problems; TUI agents that survive Ctrl+C (the reported case) need the wrappers.

Fixes #18380
