### PR TITLE
perf(persistence): stop double-traversing the persisted session at load

### DIFF
--- a/src/shared/workspace-session-salvage-equivalence.test.ts
+++ b/src/shared/workspace-session-salvage-equivalence.test.ts
@@ -1,0 +1,508 @@
+/* Differential corpus: the salvaging read boundary is the "a bad persisted payload falls back to
+ * defaults instead of crashing the renderer" gate, so the traversal-cost work in zod-salvage.ts and
+ * the discriminated layout unions have to be provably output-identical. This file pins the previous
+ * implementation and asserts both produce the same accepted value, the same fallback and the same
+ * repair diagnostics over valid and malformed payloads alike. */
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import type * as ZodModule from 'zod'
+import { parseWorkspaceSessionSalvaging } from './workspace-session-salvage'
+
+type LegacyParse = typeof parseWorkspaceSessionSalvaging
+
+/** The pre-optimization zod-salvage: containers zod validated and copied before the transform
+ *  re-walked them, and no explicit '__proto__'/symbol-key handling of its own. */
+function legacySalvageModule(): Record<string, unknown> {
+  const MAX_REPORTED_SALVAGE_PATHS = 100
+  type DropCollector = { paths: string[]; count: number }
+  let dropCollector: DropCollector | null = null
+  const dropPath: (string | number)[] = []
+
+  function collectSalvageDrops<T>(parse: () => T): {
+    value: T
+    droppedPaths: string[]
+    droppedCount: number
+  } {
+    const previousCollector = dropCollector
+    const previousPath = [...dropPath]
+    const collector: DropCollector = { paths: [], count: 0 }
+    dropCollector = collector
+    dropPath.length = 0
+    try {
+      const value = parse()
+      return { value, droppedPaths: collector.paths, droppedCount: collector.count }
+    } finally {
+      dropCollector = previousCollector
+      dropPath.splice(0, dropPath.length, ...previousPath)
+    }
+  }
+
+  function reportDrop(segment: string | number): void {
+    if (!dropCollector) {
+      return
+    }
+    dropCollector.count += 1
+    if (dropCollector.paths.length < MAX_REPORTED_SALVAGE_PATHS) {
+      dropCollector.paths.push([...dropPath, segment].join('.'))
+    }
+  }
+
+  function inEntry<T>(segment: string | number, parse: () => T): T {
+    dropPath.push(segment)
+    try {
+      return parse()
+    } finally {
+      dropPath.pop()
+    }
+  }
+
+  function parseEntry(
+    schema: z.ZodType,
+    raw: unknown
+  ): { success: true; data: unknown } | { success: false } {
+    try {
+      const parsed = schema.safeParse(raw)
+      return parsed.success ? { success: true, data: parsed.data } : { success: false }
+    } catch {
+      return { success: false }
+    }
+  }
+
+  function salvagingArray(item: z.ZodType): z.ZodType {
+    return z.array(z.unknown()).transform((values) =>
+      values.flatMap((value, index) => {
+        const parsed = inEntry(index, () => parseEntry(item, value))
+        if (parsed.success) {
+          return [parsed.data]
+        }
+        reportDrop(index)
+        return []
+      })
+    ) as z.ZodType
+  }
+
+  function salvagingRecord(
+    key: z.ZodType,
+    value: z.ZodType,
+    accepts?: (key: string, value: unknown) => boolean
+  ): z.ZodType {
+    return z.record(z.string(), z.unknown()).transform((entries) => {
+      const kept: Record<string, unknown> = Object.create(null)
+      for (const [entryKey, entryValue] of Object.entries(entries)) {
+        const parsed = parseEntry(key, entryKey).success
+          ? inEntry(entryKey, () => parseEntry(value, entryValue))
+          : null
+        if (parsed?.success && (!accepts || accepts(entryKey, parsed.data))) {
+          kept[entryKey] = parsed.data
+          continue
+        }
+        reportDrop(entryKey)
+      }
+      return { ...kept }
+    }) as z.ZodType
+  }
+
+  function salvaged(name: string, schema: z.ZodType, fallback: () => unknown): z.ZodType {
+    return z.unknown().transform((raw, ctx) => {
+      if (raw === undefined) {
+        ctx.addIssue({ code: 'custom', message: 'required', input: raw })
+        return z.NEVER
+      }
+      const parsed = inEntry(name, () => parseEntry(schema, raw))
+      if (parsed.success) {
+        return parsed.data
+      }
+      reportDrop(name)
+      return fallback()
+    })
+  }
+
+  return {
+    collectSalvageDrops,
+    salvagingArray,
+    salvagingRecord,
+    salvagedField: (name: string, schema: z.ZodType, fallback: () => unknown) =>
+      salvaged(name, schema, fallback),
+    salvagedOptional: (name: string, schema: z.ZodType) =>
+      salvaged(name, schema, () => undefined).optional()
+  }
+}
+
+const WT = 'repo-1::/home/user/project'
+
+function terminalTab(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId: WT,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1_700_000_000_000,
+    ...overrides
+  }
+}
+
+function unifiedTab(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    entityId: id,
+    groupId: 'group-1',
+    worktreeId: WT,
+    contentType: 'terminal',
+    label: 'Terminal',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1_700_000_000_000,
+    ...overrides
+  }
+}
+
+function layout(root: unknown, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { root, activeLeafId: 'leaf-1', expandedLeafId: null, ...overrides }
+}
+
+const SPLIT = {
+  type: 'split',
+  direction: 'horizontal',
+  first: { type: 'leaf', leafId: 'leaf-1' },
+  second: {
+    type: 'split',
+    direction: 'vertical',
+    first: { type: 'leaf', leafId: 'leaf-2' },
+    second: { type: 'leaf', leafId: 'leaf-3' },
+    ratio: 0.5
+  }
+}
+
+const GROUP_SPLIT = {
+  type: 'split',
+  direction: 'vertical',
+  first: { type: 'leaf', groupId: 'group-1' },
+  second: { type: 'leaf', groupId: 'group-2' }
+}
+
+/** A hole, not an explicit undefined: the old container copied it away before the transform ran. */
+function sparseTabs(): unknown[] {
+  const tabs: unknown[] = [terminalTab('a')]
+  tabs[2] = terminalTab('b')
+  return tabs
+}
+
+function session(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+/** Valid payloads first, then one malformed variant per subtree the salvage path rescues alone. */
+const CORPUS: [string, unknown][] = [
+  ['minimal valid', session()],
+  [
+    'fully populated valid',
+    session({
+      activeRepoId: 'repo-1',
+      activeWorktreeId: WT,
+      activeTabId: 'tab-1',
+      activeWorkspaceKey: null,
+      activeWorkspaceExecutionHostId: null,
+      tabsByWorktree: { [WT]: [terminalTab('tab-1'), terminalTab('tab-2')] },
+      terminalLayoutsByTabId: {
+        'tab-1': layout(SPLIT, {
+          ptyIdsByLeafId: { 'leaf-1': 'pty-1' },
+          buffersByLeafId: { 'leaf-1': 'hello' },
+          scrollbackRefsByLeafId: { 'leaf-1': 'ref-1' },
+          titlesByLeafId: { 'leaf-1': 'zsh' }
+        }),
+        'tab-2': layout({ type: 'leaf', leafId: 'leaf-9' })
+      },
+      unifiedTabs: { [WT]: [unifiedTab('tab-1'), unifiedTab('tab-2')] },
+      tabGroups: { [WT]: [{ id: 'group-1', worktreeId: WT, activeTabId: null, tabOrder: [] }] },
+      tabGroupLayouts: { [WT]: GROUP_SPLIT, 'repo-2::/other': { type: 'leaf', groupId: 'g' } },
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      activeTabIdByWorktree: { [WT]: 'tab-1' },
+      activeTabTypeByWorktree: { [WT]: 'terminal' },
+      activeWorktreeIdsOnShutdown: [WT],
+      activeConnectionIdsAtShutdown: ['conn-1'],
+      lastVisitedAtByWorktreeId: { [WT]: 1_700_000_000_000 },
+      remoteSessionIdsByTabId: { 'tab-1': 'remote-1' },
+      terminalPtyIncarnationsByPaneKey: { 'tab-1:leaf-1': 'inc-1' },
+      terminalTopologyRevisionByRepoId: { 'repo-1': 3 },
+      defaultTerminalTabsAppliedByWorktreeId: { [WT]: true },
+      markdownFrontmatterVisible: { 'doc-1': true },
+      activeFileIdByWorktree: { [WT]: null },
+      activeBrowserTabIdByWorktree: { [WT]: null },
+      browserUrlHistory: [
+        {
+          url: 'https://example.com',
+          normalizedUrl: 'https://example.com',
+          title: 'Example',
+          lastVisitedAt: 1,
+          visitCount: 2
+        }
+      ]
+    })
+  ],
+  ['not an object', 'nope'],
+  ['null', null],
+  ['array', []],
+  ['foreign object', { unrelated: 'payload', count: 3 }],
+  ['missing required field', { activeRepoId: null }],
+  ['required scalar wrong type', session({ activeRepoId: 42 })],
+  ['required record replaced by a scalar', session({ tabsByWorktree: 'nope' })],
+  ['required record replaced by an array', session({ tabsByWorktree: [] })],
+  ['required record replaced by a Map', session({ tabsByWorktree: new Map() })],
+  ['required record replaced by a Date', session({ tabsByWorktree: new Date(0) })],
+  ['required record replaced by null', session({ tabsByWorktree: null })],
+  ['optional record replaced by a scalar', session({ terminalTopologyRevisionByRepoId: 'nope' })],
+  ['optional record explicitly undefined', session({ unifiedTabs: undefined })],
+  ['array field replaced by a record', session({ tabsByWorktree: { [WT]: { a: 1 } } })],
+  ['array field replaced by a string', session({ tabsByWorktree: { [WT]: 'nope' } })],
+  [
+    'array holding a corrupt element',
+    session({ tabsByWorktree: { [WT]: [terminalTab('a'), { id: 'bad' }] } })
+  ],
+  ['array holding only corrupt elements', session({ tabsByWorktree: { [WT]: [1, 2, 3] } })],
+  ['sparse array', session({ tabsByWorktree: { [WT]: sparseTabs() } })],
+  ['array holding undefined', session({ tabsByWorktree: { [WT]: [undefined, terminalTab('a')] } })],
+  [
+    'record with a __proto__ key',
+    session({ terminalPtyIncarnationsByPaneKey: JSON.parse('{"__proto__":"x","ok":"inc-1"}') })
+  ],
+  [
+    'record with a numeric key',
+    session({ terminalPtyIncarnationsByPaneKey: { 0: 'inc-0', b: 'inc-b' } })
+  ],
+  ['record with a dotted key', session({ terminalPtyIncarnationsByPaneKey: { 'a.b': 'inc-1' } })],
+  ['record with an empty key', session({ terminalPtyIncarnationsByPaneKey: { '': 'inc-1' } })],
+  ['record value wrong type', session({ terminalPtyIncarnationsByPaneKey: { a: 'ok', b: 123 } })],
+  [
+    'record key rejected by its key schema',
+    session({ clientHostedBrowserCloseIntentsByEnvironment: { '': [] } })
+  ],
+  [
+    'nested record corrupt',
+    session({
+      terminalLayoutsByTabId: { 'tab-1': layout(SPLIT, { ptyIdsByLeafId: { a: 'p', b: 7 } }) }
+    })
+  ],
+  [
+    'nested record replaced by an array',
+    session({ terminalLayoutsByTabId: { 'tab-1': layout(SPLIT, { ptyIdsByLeafId: [] }) } })
+  ],
+  [
+    'layout leaf id wrong type',
+    session({ terminalLayoutsByTabId: { 'tab-1': layout({ type: 'leaf', leafId: 42 }) } })
+  ],
+  [
+    'layout split direction unknown',
+    session({ terminalLayoutsByTabId: { 'tab-1': layout({ ...SPLIT, direction: 'row' }) } })
+  ],
+  [
+    'layout node type unknown',
+    session({ terminalLayoutsByTabId: { 'tab-1': layout({ type: 'stack', leafId: 'a' }) } })
+  ],
+  [
+    'layout node type missing',
+    session({ terminalLayoutsByTabId: { 'tab-1': layout({ leafId: 'a' }) } })
+  ],
+  ['layout node not an object', session({ terminalLayoutsByTabId: { 'tab-1': layout('leaf') } })],
+  ['layout node null root', session({ terminalLayoutsByTabId: { 'tab-1': layout(null) } })],
+  [
+    'layout split missing a child',
+    session({
+      terminalLayoutsByTabId: {
+        'tab-1': layout({
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: 'a' }
+        })
+      }
+    })
+  ],
+  [
+    'layout split with a corrupt grandchild',
+    session({
+      terminalLayoutsByTabId: {
+        'tab-1': layout({
+          ...SPLIT,
+          second: {
+            type: 'split',
+            direction: 'vertical',
+            first: { type: 'leaf', leafId: 1 },
+            second: { type: 'leaf', leafId: 'b' }
+          }
+        })
+      }
+    })
+  ],
+  [
+    'layout split ratio wrong type',
+    session({ terminalLayoutsByTabId: { 'tab-1': layout({ ...SPLIT, ratio: 'half' }) } })
+  ],
+  [
+    'group layout leaf corrupt',
+    session({
+      tabGroupLayouts: {
+        [WT]: { type: 'split', direction: 'row', first: { type: 'leaf', groupId: 42 } }
+      }
+    })
+  ],
+  [
+    'group layout valid alongside corrupt',
+    session({ tabGroupLayouts: { [WT]: GROUP_SPLIT, bad: { type: 'leaf', groupId: 1 } } })
+  ],
+  [
+    'unified tab missing a required field',
+    session({ unifiedTabs: { [WT]: [unifiedTab('a'), { id: 'b' }] } })
+  ],
+  [
+    'unified tab unknown viewMode falls back',
+    session({ unifiedTabs: { [WT]: [unifiedTab('a', { viewMode: 'wat' })] } })
+  ],
+  [
+    'tab group order wrong type',
+    session({
+      tabGroups: { [WT]: [{ id: 'g', worktreeId: WT, activeTabId: null, tabOrder: 'nope' }] }
+    })
+  ],
+  [
+    'sleeping agent key mismatch',
+    session({ sleepingAgentSessionsByPaneKey: { 'tab-bad:leaf': { paneKey: 'different:leaf' } } })
+  ],
+  [
+    'browser history entry corrupt',
+    session({
+      browserUrlHistory: [
+        {
+          url: 'https://a',
+          normalizedUrl: 'https://a',
+          title: 't',
+          lastVisitedAt: 1,
+          visitCount: 1
+        },
+        { url: 5 }
+      ]
+    })
+  ],
+  ['browser history not an array', session({ browserUrlHistory: {} })],
+  [
+    'tombstone record corrupt',
+    session({ terminalSurfaceTombstonesByPaneKey: { 'tab-1:leaf-1': { worktreeId: 42 } } })
+  ],
+  [
+    'non-finite recency dropped',
+    session({ lastVisitedAtByWorktreeId: { [WT]: Number.POSITIVE_INFINITY } })
+  ],
+  [
+    'systemic single-field corruption',
+    session({
+      terminalLayoutsByTabId: Object.fromEntries(
+        Array.from({ length: 25 }, (_, i) => [`tab-${i}`, layout({ type: 'leaf', leafId: i })])
+      )
+    })
+  ],
+  [
+    'drop reporting past the path cap',
+    session({
+      terminalPtyIncarnationsByPaneKey: Object.fromEntries(
+        Array.from({ length: 150 }, (_, i) => [`k-${i}`, i])
+      )
+    })
+  ]
+]
+
+describe('salvage equivalence with the pre-optimization implementation', () => {
+  let legacyParse: LegacyParse
+  let legacyUnionsBuilt = 0
+
+  beforeAll(async () => {
+    // Why: the legacy schema has to be built from the legacy combinators and from plain unions, so
+    // both changed surfaces are compared, not just the container fast path.
+    vi.doMock('./zod-salvage', () => legacySalvageModule())
+    vi.doMock('zod', async () => {
+      const actual = await vi.importActual<typeof ZodModule>('zod')
+      return {
+        ...actual,
+        z: {
+          ...actual.z,
+          discriminatedUnion: (_key: string, options: z.ZodType[]) => {
+            legacyUnionsBuilt += 1
+            return actual.z.union(options)
+          }
+        }
+      }
+    })
+    vi.resetModules()
+    legacyParse = (await import('./workspace-session-salvage')).parseWorkspaceSessionSalvaging
+    // Why: the recursive layout unions are lazy, so force them to build before the mock is dropped.
+    legacyParse(session({ tabGroupLayouts: { [WT]: GROUP_SPLIT } }))
+    legacyParse(session({ terminalLayoutsByTabId: { 'tab-1': layout(SPLIT) } }))
+    vi.doUnmock('./zod-salvage')
+    vi.doUnmock('zod')
+    vi.resetModules()
+  })
+
+  it('builds a legacy parser from the legacy combinators and plain unions', () => {
+    expect(legacyParse).not.toBe(parseWorkspaceSessionSalvaging)
+    expect(legacyUnionsBuilt).toBeGreaterThanOrEqual(2)
+  })
+
+  it.each(CORPUS)('matches the legacy result for %s', (_name, payload) => {
+    const legacy = legacyParse(payload)
+    const current = parseWorkspaceSessionSalvaging(payload)
+
+    expect(current.ok).toBe(legacy.ok)
+    if (!legacy.ok || !current.ok) {
+      return
+    }
+    expect(current.value).toStrictEqual(legacy.value)
+    expect(current.droppedCount).toBe(legacy.droppedCount)
+    expect(current.droppedPaths.toSorted()).toEqual(legacy.droppedPaths.toSorted())
+  })
+
+  it('rejects the same payloads the legacy parser rejects', () => {
+    const rejected = CORPUS.filter(([, payload]) => !legacyParse(payload).ok)
+    expect(rejected.length).toBeGreaterThan(0)
+    for (const [, payload] of rejected) {
+      expect(parseWorkspaceSessionSalvaging(payload).ok).toBe(false)
+    }
+  })
+
+  it('rejects a record carrying an enumerable symbol key, as zod.record did', () => {
+    const withSymbol: Record<string, unknown> = { 'tab-1:leaf-1': 'inc-1' }
+    withSymbol[Symbol('extra') as unknown as string] = 'x'
+    const payload = session({ terminalPtyIncarnationsByPaneKey: withSymbol })
+    const legacy = legacyParse(payload)
+    const current = parseWorkspaceSessionSalvaging(payload)
+    expect(current.ok).toBe(true)
+    expect(legacy.ok).toBe(true)
+    if (current.ok && legacy.ok) {
+      expect(current.value.terminalPtyIncarnationsByPaneKey).toStrictEqual(
+        legacy.value.terminalPtyIncarnationsByPaneKey
+      )
+      expect(current.droppedPaths).toEqual(legacy.droppedPaths)
+    }
+  })
+
+  it('keeps a non-enumerable own key out of both results', () => {
+    const hidden: Record<string, unknown> = { 'tab-1:leaf-1': 'inc-1' }
+    Object.defineProperty(hidden, 'hiddenKey', { value: 'nope', enumerable: false })
+    const payload = session({ terminalPtyIncarnationsByPaneKey: hidden })
+    const legacy = legacyParse(payload)
+    const current = parseWorkspaceSessionSalvaging(payload)
+    expect(current.ok && legacy.ok).toBe(true)
+    if (current.ok && legacy.ok) {
+      expect(current.value.terminalPtyIncarnationsByPaneKey).toStrictEqual(
+        legacy.value.terminalPtyIncarnationsByPaneKey
+      )
+    }
+  })
+})

--- a/src/shared/workspace-session-salvage-equivalence.test.ts
+++ b/src/shared/workspace-session-salvage-equivalence.test.ts
@@ -441,7 +441,7 @@ describe('salvage equivalence with the pre-optimization implementation', () => {
       }
     })
     vi.resetModules()
-    legacyParse = (await import('./workspace-session-salvage')).parseWorkspaceSessionSalvaging
+    legacyParse = (await import('./workspace-session-salvage.js')).parseWorkspaceSessionSalvaging
     // Why: the recursive layout unions are lazy, so force them to build before the mock is dropped.
     legacyParse(session({ tabGroupLayouts: { [WT]: GROUP_SPLIT } }))
     legacyParse(session({ terminalLayoutsByTabId: { 'tab-1': layout(SPLIT) } }))

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -47,9 +47,10 @@ const workspaceKeySchema = z.custom<WorkspaceKey>(
 )
 
 // Why: z.lazy + type annotation keeps the recursive inference working without
-// forcing zod to resolve the whole tree at definition time.
+// forcing zod to resolve the whole tree at definition time. Discriminated on `type` because a
+// plain union re-tries the leaf branch for every split node of every restored terminal layout.
 const terminalPaneLayoutNodeSchema: z.ZodType<TerminalPaneLayoutNode> = z.lazy(() =>
-  z.union([
+  z.discriminatedUnion('type', [
     z.object({
       type: z.literal('leaf'),
       leafId: z.string()
@@ -168,7 +169,7 @@ const tabGroupSchema = z.object({
 const tabGroupSplitDirectionSchema = z.enum(['horizontal', 'vertical'])
 
 const tabGroupLayoutNodeSchema: z.ZodType<TabGroupLayoutNode> = z.lazy(() =>
-  z.union([
+  z.discriminatedUnion('type', [
     z.object({
       type: z.literal('leaf'),
       groupId: z.string()

--- a/src/shared/workspace-session-validation-work.test.ts
+++ b/src/shared/workspace-session-validation-work.test.ts
@@ -1,0 +1,177 @@
+/* Deterministic guard for the validation work the session read boundary does. Counts zod container
+ * nodes executed for one fixed payload rather than timing anything, so it cannot flake on a loaded
+ * machine. It fails if the salvage combinators go back to letting zod validate-and-copy every map
+ * and array before the transform re-walks it, or if the layout unions stop discriminating. */
+import { beforeAll, describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import type { parseWorkspaceSessionSalvaging } from './workspace-session-salvage'
+
+let containerRuns = 0
+
+// Why: zod's default memoizer is the only hook that sees every container node, so this file swaps
+// it for a counting one. Cycle breaking is what it gives up, and no payload here holds a cycle.
+z.config({
+  memoizer: {
+    alloc: (_inst: unknown, _payload: unknown, empty: unknown) => empty,
+    guard: () => {},
+    attach: (inst: {
+      _zod: {
+        deferred?: (() => void)[]
+        parse: (payload: unknown, ctx: unknown) => unknown
+        run: unknown
+      }
+    }) => {
+      inst._zod.deferred ??= []
+      inst._zod.deferred.push(() => {
+        const base = inst._zod.parse
+        const wrapped = (payload: unknown, ctx: unknown): unknown => {
+          containerRuns += 1
+          return base(payload, ctx)
+        }
+        inst._zod.parse = wrapped
+        if (inst._zod.run === base) {
+          inst._zod.run = wrapped
+        }
+      })
+    }
+  }
+} as never)
+
+const WORKTREES = 30
+const TABS_PER_WORKTREE = 4
+
+function worktreeId(index: number): string {
+  return `repo-${index % 3}::/home/user/w${index}`
+}
+
+function terminalTab(id: string, wt: string, sortOrder: number): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId: wt,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder,
+    createdAt: 1_700_000_000_000
+  }
+}
+
+function unifiedTab(id: string, wt: string, sortOrder: number): Record<string, unknown> {
+  return {
+    id,
+    entityId: id,
+    groupId: `${wt}:group`,
+    worktreeId: wt,
+    contentType: 'terminal',
+    label: 'Terminal',
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: 1_700_000_000_000
+  }
+}
+
+/** Fixed shape, no randomness: the count below is only meaningful against a stable payload. */
+function fixedSession(): Record<string, unknown> {
+  const tabsByWorktree: Record<string, unknown> = {}
+  const unifiedTabs: Record<string, unknown> = {}
+  const tabGroups: Record<string, unknown> = {}
+  const tabGroupLayouts: Record<string, unknown> = {}
+  const terminalLayoutsByTabId: Record<string, unknown> = {}
+  const lastVisitedAtByWorktreeId: Record<string, unknown> = {}
+  const terminalPtyIncarnationsByPaneKey: Record<string, unknown> = {}
+
+  for (let w = 0; w < WORKTREES; w += 1) {
+    const wt = worktreeId(w)
+    const tabs: Record<string, unknown>[] = []
+    const unified: Record<string, unknown>[] = []
+    for (let t = 0; t < TABS_PER_WORKTREE; t += 1) {
+      const id = `tab-${w}-${t}`
+      tabs.push(terminalTab(id, wt, t))
+      unified.push(unifiedTab(id, wt, t))
+      terminalLayoutsByTabId[id] = {
+        root: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', leafId: `${id}:a` },
+          second: {
+            type: 'split',
+            direction: 'vertical',
+            first: { type: 'leaf', leafId: `${id}:b` },
+            second: { type: 'leaf', leafId: `${id}:c` },
+            ratio: 0.5
+          }
+        },
+        activeLeafId: `${id}:a`,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [`${id}:a`]: `pty-${id}` },
+        buffersByLeafId: { [`${id}:a`]: 'buffer' },
+        scrollbackRefsByLeafId: { [`${id}:a`]: 'ref' },
+        titlesByLeafId: { [`${id}:a`]: 'zsh' }
+      }
+      terminalPtyIncarnationsByPaneKey[`${id}:a`] = `inc-${id}`
+    }
+    tabsByWorktree[wt] = tabs
+    unifiedTabs[wt] = unified
+    tabGroups[wt] = [
+      {
+        id: `${wt}:group`,
+        worktreeId: wt,
+        activeTabId: `tab-${w}-0`,
+        tabOrder: unified.map((tab) => tab.id as string)
+      }
+    ]
+    tabGroupLayouts[wt] = {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', groupId: `${wt}:group` },
+      second: { type: 'leaf', groupId: `${wt}:group2` }
+    }
+    lastVisitedAtByWorktreeId[wt] = 1_700_000_000_000 + w
+  }
+
+  return {
+    activeRepoId: 'repo-0',
+    activeWorktreeId: worktreeId(0),
+    activeTabId: 'tab-0-0',
+    tabsByWorktree,
+    terminalLayoutsByTabId,
+    unifiedTabs,
+    tabGroups,
+    tabGroupLayouts,
+    lastVisitedAtByWorktreeId,
+    terminalPtyIncarnationsByPaneKey
+  }
+}
+
+/* Container-node executions for `fixedSession()`, measured on this branch:
+ *   before this change: 1_958
+ *   after this change:  1_111
+ * The bound sits between the two, so it fails on any return to the pre-pass containers or to a
+ * non-discriminated layout union, and tolerates ordinary schema growth. */
+const MAX_CONTAINER_RUNS = 1_400
+
+describe('workspace session validation work', () => {
+  let parse: typeof parseWorkspaceSessionSalvaging
+
+  beforeAll(async () => {
+    parse = (await import('./workspace-session-salvage')).parseWorkspaceSessionSalvaging
+  })
+
+  it('validates the session without a redundant traversal of every map, array and union branch', () => {
+    const payload = fixedSession()
+    // Why: zod compiles object fast paths on first use, so measure a settled parse.
+    parse(payload)
+    containerRuns = 0
+    const result = parse(payload)
+
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.droppedCount).toBe(0)
+      expect(Object.keys(result.value.tabsByWorktree)).toHaveLength(WORKTREES)
+    }
+    expect(containerRuns).toBeGreaterThan(0)
+    expect(containerRuns).toBeLessThanOrEqual(MAX_CONTAINER_RUNS)
+  })
+})

--- a/src/shared/workspace-session-validation-work.test.ts
+++ b/src/shared/workspace-session-validation-work.test.ts
@@ -156,7 +156,7 @@ describe('workspace session validation work', () => {
   let parse: typeof parseWorkspaceSessionSalvaging
 
   beforeAll(async () => {
-    parse = (await import('./workspace-session-salvage')).parseWorkspaceSessionSalvaging
+    parse = (await import('./workspace-session-salvage.js')).parseWorkspaceSessionSalvaging
   })
 
   it('validates the session without a redundant traversal of every map, array and union branch', () => {

--- a/src/shared/zod-salvage-absence.test.ts
+++ b/src/shared/zod-salvage-absence.test.ts
@@ -1,0 +1,49 @@
+/* Absence must stay fatal for the salvaging containers. Both are a bare `z.unknown().transform`,
+ * and zod's handlePropertyResult only swallows a missing object key's issues when the field is
+ * optional-in *and* optional-out — neither of which a transform sets. That is the whole reason a
+ * foreign payload missing `tabsByWorktree` is rejected instead of silently salvaged into an empty
+ * session, and until now it was only a comment. Pin it here so a zod release that starts
+ * propagating optionality through transforms, or a stray `.optional()`/`.default()` on a container,
+ * fails CI instead of quietly widening the accept set of every persisted field. */
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { salvagingArray, salvagingRecord } from './zod-salvage'
+
+type Optionality = { optin?: unknown; optout?: unknown }
+
+function optionalityOf(schema: z.ZodType): Optionality {
+  return (schema as unknown as { _zod: Optionality })._zod
+}
+
+const CONTAINERS: [string, () => z.ZodType, unknown][] = [
+  ['salvagingRecord', () => salvagingRecord(z.string(), z.string()), { k: 'v' }],
+  ['salvagingArray', () => salvagingArray(z.string()), ['v']]
+]
+
+describe('salvaging containers used bare in an object shape', () => {
+  it.each(CONTAINERS)('%s is neither optional-in nor optional-out', (_name, build) => {
+    const { optin, optout } = optionalityOf(build())
+    expect(optin).toBeUndefined()
+    expect(optout).toBeUndefined()
+  })
+
+  it.each(CONTAINERS)('%s rejects an absent key and an explicit undefined', (_name, build, ok) => {
+    const shape = z.object({ a: build() })
+
+    expect(shape.safeParse({}).success).toBe(false)
+    expect(shape.safeParse({ a: undefined }).success).toBe(false)
+    // Why: a positive control, so the two rejections above cannot pass by rejecting everything.
+    expect(shape.safeParse({ a: ok })).toMatchObject({ success: true })
+  })
+
+  it.each(CONTAINERS)(
+    '%s stays fatal on an absent key even if zod marks it optional-in',
+    (_name, build) => {
+      const container = build()
+      // Suppression needs optout === 'optional' too, so half the ladder is not enough to widen this.
+      optionalityOf(container).optin = 'optional'
+
+      expect(z.object({ a: container }).safeParse({}).success).toBe(false)
+    }
+  )
+})

--- a/src/shared/zod-salvage.ts
+++ b/src/shared/zod-salvage.ts
@@ -38,15 +38,6 @@ function reportDrop(segment: string | number): void {
   }
 }
 
-function inEntry<T>(segment: string | number, parse: () => T): T {
-  dropPath.push(segment)
-  try {
-    return parse()
-  } finally {
-    dropPath.pop()
-  }
-}
-
 function parseEntry<T extends z.ZodType>(
   schema: T,
   raw: unknown
@@ -59,18 +50,57 @@ function parseEntry<T extends z.ZodType>(
   }
 }
 
-/** Array that drops the elements it cannot parse instead of failing. */
+/** parseEntry with `segment` on the diagnostic path. Takes the schema and value rather than a
+ *  thunk: this runs once per persisted record, and a closure per entry is the dominant load cost. */
+function parseEntryAt<T extends z.ZodType>(
+  segment: string | number,
+  schema: T,
+  raw: unknown
+): { success: true; data: z.output<T> } | { success: false } {
+  dropPath.push(segment)
+  try {
+    return parseEntry(schema, raw)
+  } finally {
+    dropPath.pop()
+  }
+}
+
+/** The keys `z.record(z.string(), z.unknown())` would hand a transform, or null where it would
+ *  reject: not a plain object, or carrying an enumerable symbol key its string key schema fails.
+ *  Why: every entry is re-validated below anyway, so letting zod build a throwaway copy first is a
+ *  second full traversal of the largest maps in the persisted session. */
+function recordEntryKeys(raw: unknown): string[] | null {
+  if (!z.core.util.isPlainObject(raw)) {
+    return null
+  }
+  for (const symbol of Object.getOwnPropertySymbols(raw)) {
+    if (Object.prototype.propertyIsEnumerable.call(raw, symbol)) {
+      return null
+    }
+  }
+  return Object.keys(raw)
+}
+
+/** Array that drops the elements it cannot parse instead of failing.
+ *  Both containers build on z.unknown(), so an object shape must keep wrapping them in
+ *  salvagedField/salvagedOptional for a missing key to stay an error rather than an absence. */
 export function salvagingArray<T extends z.ZodType>(item: T): z.ZodType<z.output<T>[], unknown> {
-  return z.array(z.unknown()).transform((values) =>
-    values.flatMap((value, index) => {
-      const parsed = inEntry(index, () => parseEntry(item, value))
+  return z.unknown().transform((raw, ctx) => {
+    if (!Array.isArray(raw)) {
+      ctx.addIssue({ code: 'invalid_type', expected: 'array', input: raw })
+      return z.NEVER
+    }
+    const kept: z.output<T>[] = []
+    for (let index = 0; index < raw.length; index += 1) {
+      const parsed = parseEntryAt(index, item, raw[index])
       if (parsed.success) {
-        return [parsed.data]
+        kept.push(parsed.data)
+        continue
       }
       reportDrop(index)
-      return []
-    })
-  )
+    }
+    return kept
+  }) as z.ZodType<z.output<T>[], unknown>
 }
 
 /** Record that drops entries with invalid keys or values instead of failing. */
@@ -79,12 +109,22 @@ export function salvagingRecord<K extends z.ZodType<string>, V extends z.ZodType
   value: V,
   accepts?: (key: string, value: z.output<V>) => boolean
 ): z.ZodType<Record<string, z.output<V>>, unknown> {
-  return z.record(z.string(), z.unknown()).transform((entries) => {
+  return z.unknown().transform((raw, ctx) => {
+    const entryKeys = recordEntryKeys(raw)
+    if (!entryKeys) {
+      ctx.addIssue({ code: 'invalid_type', expected: 'record', input: raw })
+      return z.NEVER
+    }
+    const entries = raw as Record<string, unknown>
     // Why: null prototype so a persisted '__proto__' key cannot poison the result.
     const kept: Record<string, z.output<V>> = Object.create(null)
-    for (const [entryKey, entryValue] of Object.entries(entries)) {
+    for (const entryKey of entryKeys) {
+      // Why: z.record strips '__proto__' before the value schema sees it, so it is not a drop.
+      if (entryKey === '__proto__') {
+        continue
+      }
       const parsed = parseEntry(key, entryKey).success
-        ? inEntry(entryKey, () => parseEntry(value, entryValue))
+        ? parseEntryAt(entryKey, value, entries[entryKey])
         : null
       if (parsed?.success && (!accepts || accepts(entryKey, parsed.data))) {
         kept[entryKey] = parsed.data
@@ -93,7 +133,7 @@ export function salvagingRecord<K extends z.ZodType<string>, V extends z.ZodType
       reportDrop(entryKey)
     }
     return { ...kept }
-  })
+  }) as z.ZodType<Record<string, z.output<V>>, unknown>
 }
 
 function salvaged(name: string, schema: z.ZodType, fallback: () => unknown): z.ZodType {
@@ -102,7 +142,7 @@ function salvaged(name: string, schema: z.ZodType, fallback: () => unknown): z.Z
       ctx.addIssue({ code: 'custom', message: 'required', input: raw })
       return z.NEVER
     }
-    const parsed = inEntry(name, () => parseEntry(schema, raw))
+    const parsed = parseEntryAt(name, schema, raw)
     if (parsed.success) {
       return parsed.data
     }

--- a/src/shared/zod-salvage.ts
+++ b/src/shared/zod-salvage.ts
@@ -82,8 +82,10 @@ function recordEntryKeys(raw: unknown): string[] | null {
 }
 
 /** Array that drops the elements it cannot parse instead of failing.
- *  Both containers build on z.unknown(), so an object shape must keep wrapping them in
- *  salvagedField/salvagedOptional for a missing key to stay an error rather than an absence. */
+ *  Absence stays fatal on its own: both containers issue on `undefined` and, being bare transforms,
+ *  set neither optin nor optout, and zod only swallows an absent key's issues when a field is both.
+ *  salvagedField/salvagedOptional wrap them for fallback semantics, not for absence detection.
+ *  Pinned by zod-salvage-absence.test.ts. */
 export function salvagingArray<T extends z.ZodType>(item: T): z.ZodType<z.output<T>[], unknown> {
   return z.unknown().transform((raw, ctx) => {
     if (!Array.isArray(raw)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​734 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​734 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## ELI5

When Orca starts, it reads your saved session — every workspace, every tab, every terminal
layout — off disk and checks that it is not corrupt before handing it to the UI. On a big
profile that check was doing the same walk twice: a first pass that copied every map and list,
then a second pass that actually validated each entry. And for split terminal layouts it kept
trying the "single pane" shape first for every node that was obviously a split.

This does the walk once and looks at the node's own `type` to pick the right shape. Nothing about
what counts as valid or corrupt changed — the same payloads are accepted, the same ones fall back
to defaults, with the same repair messages. It just stops doing work whose answer it already had.

## Why it matters

Two independent agents measured `Store.load()` against a profile matching the reporter's real
shape (413 worktrees, 801 tabs, 1,349 `worktreeMeta` rows, 10 host partitions, 3.4-3.6 MB):

| phase | empty profile | reporter-shaped | delta |
|---|---|---|---|
| `persistence-load-start -> load-done` | 1 | **72** | **+71** |
| rest of `Store` ctor | 1 | 4 | +3 |
| `store-loaded -> services-initialized` | 43 | 45 | +2 |

93% of all startup scaling with profile size is inside `Store.load()`, and bisecting it:

```
normalizeLoadedProfileState (zod)   51 ms   <- this PR
JSON.parse                          10 ms
gcStaleWorktreeMeta                  7 ms
everything else                     <=3 ms
```

This is all pre-first-paint, on the main process, before the renderer gets its state.

Reproduced locally against a copy of that profile (read-only copy in a scratch dir; the app reads
`<userData>/profiles/local-default/orca-data.json`, not `<userData>/orca-data.json`):
`normalizeLoadedLocalSession` -> `parseWorkspaceSessionSalvaging` over the 1.88 MB
`workspaceSession` is 52.5 ms of cold CPU on its own, and
`normalizeLoadedHostSessions` -> `parseWorkspaceSessionsByHostId` over 253 KB of
`workspaceSessionsByHostId` adds 4.7 ms.

Where that time went, per top-level field (CPU ms, steady state, median of 7):

```
terminalLayoutsByTabId   3.26 ms   313 KB   <- recursive z.lazy(z.union(...)) layout trees
unifiedTabs              1.08 ms   398 KB
tabsByWorktree           0.76 ms   416 KB
browserUrlHistory        0.48 ms    66 KB
terminalPtyIncarnations  0.45 ms    72 KB
...
```

`terminalLayoutsByTabId` cost 4x per byte what `tabsByWorktree` did, on 1,009 pane nodes.

## What "salvaging" means here, and its blast radius

Recorded because the whole point of this validation is the fallback behaviour, and any change has
to preserve it exactly.

`workspaceSessionStateSchema` is not a plain schema — every top-level field is wrapped in
`salvagedField` / `salvagedOptional`, and every collection in `salvagingArray` /
`salvagingRecord`. That gives four independent fallback levels:

1. **Whole session.** Only a payload that is not a session at all — not an object, or an object
   missing one of the five required fields (`activeRepoId`, `activeWorktreeId`, `activeTabId`,
   `tabsByWorktree`, `terminalLayoutsByTabId`) — is rejected. `normalizeLoadedLocalSession` then
   logs and returns `defaults.workspaceSession`; `parseWorkspaceSessionsByHostId` drops that one
   host and keeps the others. This is the only path that costs the user their whole session.
2. **One top-level field.** An invalid required field falls back to its own default (`null`,
   `{}`); an invalid optional field is dropped so the caller's `{ ...defaults, ...value }` spread
   supplies it. Blast radius: that field only.
3. **One record entry / array element.** A corrupt tab, layout, group or map value is dropped and
   its siblings survive — one bad tab record must not cost every worktree its state.
4. **One field of one record**, via `.catch(...)` on `aiVaultTitle`, `launchAgent`, `viewMode`,
   `lastFocusedAt`, `agentSessionAgent`, `structuredSessionId`.

Anything dropped at levels 2-4 is counted in `droppedCount`, sampled into `droppedPaths` (capped
at 100), logged, and marks the store dirty so the repair is written back instead of being redone
every launch. Levels 3 and 4 are also what keeps a pathological payload from throwing: each entry
is parsed on its own, so a `RangeError` from a 3,000-deep layout drops that entry rather than the
session (`safeParseWorkspaceSession`'s try/catch is the last resort above it).

**All four levels are unchanged by this PR**, and the differential test below asserts that
directly on both the accepted value and the drop diagnostics.

## Measurement

Method: `process.cpuUsage()` deltas only — wall clock on this box flipped sign between runs.
Each arm is a fresh `node` process parsing the reporter-shaped profile once; the two arms are
interleaved with alternating order so load drift hits both equally; median of 25 processes per arm.

```
cold local session     before   52.5 ms  after   45.0 ms   -14.3%
cold host partitions   before    4.7 ms  after    4.7 ms     0.0%   (4.7 ms total; within noise)
cold total             before   57.7 ms  after   49.8 ms   -13.7%
warm local session     before    9.8 ms  after    7.1 ms   -27.6%
n = 25 processes per arm
```

Cold is the number that matters — the app does this parse exactly once, JIT-cold, before first
paint. Steady state improves more (-27.6%) because the removed work is a larger share of the
optimized code than of the interpreter's fixed cost.

**Re-measured after adding the absence guard** (the guard is a new test file plus a corrected
comment; the runtime diff is unchanged). Interleaved in-process A/B — both parsers built in one
process, the pre-change one via the same `vi.doMock` legacy module the differential test uses,
alternating rounds so machine load hits both arms equally, 413 worktrees / 826 tabs, median of 11
rounds x 5 parses, `process.cpuUsage()` only:

```
run 1   before 8.87 ms   after 6.39 ms   -28.0%
run 2   before 8.29 ms   after 5.94 ms   -28.3%
run 3   before 7.90 ms   after 5.82 ms   -26.3%
```

Deterministic counter unchanged: 1,958 -> 1,111 container-node executions.

Independently re-measured on a second, separately-built 413-worktree / 826-tab payload (same
interleaved in-process method, median of 11 rounds x 5 parses, `process.cpuUsage()` only):

```
run 1   before 5.25 ms   after 4.10 ms   -22.0%
run 2   before 5.32 ms   after 3.67 ms   -31.0%
run 3   before 5.08 ms   after 3.80 ms   -25.3%
```

Absolute numbers differ from the block above because that payload carries fewer top-level maps;
the win is the same and holds in both directions of the interleave. The absence guard costs zero
runtime: its commit changes only a doc comment plus test files.

### Regression guard, failing without the fix

`src/shared/workspace-session-validation-work.test.ts` counts zod container-node executions for one
fixed payload (30 worktrees x 4 tabs, split layouts) by swapping zod's memoizer hook for a counting
one. No clock is involved, so it cannot flake on a loaded machine.

With the change:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

With `zod-salvage.ts` and both `z.discriminatedUnion` calls reverted to their previous form:

```
 FAIL  src/shared/workspace-session-validation-work.test.ts > workspace session validation work >
       validates the session without a redundant traversal of every map, array and union branch
AssertionError: expected 1958 to be less than or equal to 1400
 ❯ src/shared/workspace-session-validation-work.test.ts:175:27
    174|     expect(containerRuns).toBeGreaterThan(0)
    175|     expect(containerRuns).toBeLessThanOrEqual(MAX_CONTAINER_RUNS)
       |                           ^

 Test Files  1 failed | 2 passed (3)
      Tests  1 failed | 76 passed (77)
```

1,958 -> 1,111 container-node executions. The bound sits between the two so it also tolerates
ordinary schema growth.

### Second regression guard: absence stays fatal

`src/shared/zod-salvage-absence.test.ts` (new) pins the one invariant this PR previously only
documented — that a salvaging container used bare in a `z.object` shape still rejects an absent key.
Six assertions: both containers report `_zod.optin === undefined` / `_zod.optout === undefined`,
both reject `{}` and `{ a: undefined }` while still accepting a valid value, and both stay fatal on
an absent key even when `optin` is forced to `'optional'`.

Verified failing without the invariant: appending `.optional()` to either container makes all six
assertions fail.

```
 Test Files  1 failed (1)
      Tests  6 failed (6)
AssertionError: expected true to be false // Object.is equality
 ❯ src/shared/zod-salvage-absence.test.ts:33:41
```

With that same `.optional()` break in place,
`vitest run src/shared/workspace-session src/shared/zod-salvage` reports `6 failed | 147 passed` —
the six failures are all in the new file, and every pre-existing test, including the 50-payload
differential corpus and the container counter, still passes. Every current call site wraps the
containers, so this guard closes a gap none of the existing tests covered.

## Correctness

**How equivalence is proved.** `src/shared/workspace-session-salvage-equivalence.test.ts` pins the
previous implementation and runs both against the same corpus. The legacy side is the real thing,
not a sketch: `vi.doMock('./zod-salvage')` supplies the pre-change combinators and
`vi.doMock('zod')` rewrites `z.discriminatedUnion` back to `z.union`, so the legacy
`workspace-session-schema.ts` is rebuilt from both pre-change surfaces (the test asserts the union
rewrite actually fired). For 50 payloads — 2 valid, 48 malformed, one per subtree the salvage path
rescues independently — it asserts identical `ok`, identical accepted value (`toStrictEqual`),
identical `droppedCount` and identical `droppedPaths`.

The corpus deliberately includes what a looser guard would get wrong: a record replaced by an
array / `Map` / `Date` / `null`, an array replaced by a record, a sparse array, an array holding
`undefined`, a `__proto__` key from `JSON.parse`, numeric and empty and dotted keys, an enumerable
symbol key, a non-enumerable own key, corruption at each nesting level, and a 150-entry corruption
that overflows the drop-path cap.

That corpus is load-bearing: an intermediate version of this PR used
`raw !== null && typeof raw === 'object'` as the record guard, and the differential test failed on
exactly four cases (record replaced by an array / `Map` / `Date`, nested record replaced by an
array) — a widened accept set that no timing test would have caught. The shipped guard calls
`z.core.util.isPlainObject`, zod's own predicate, so it cannot drift from `z.record`.

**Questions I had to answer:**

- *Does `z.record(z.string(), z.unknown())` reject anything the new guard would accept?* It rejects
  non-plain-objects (`isPlainObject`), and because its key schema is `z.string()`, it also rejects
  an object carrying an enumerable own symbol key. `recordEntryKeys` reproduces both. It also
  strips `__proto__` before the value schema ever sees it and does not count that as a drop, which
  the new loop reproduces with an explicit `continue`. Non-enumerable own keys are skipped by both.
- *Iteration order?* `Object.keys` matches `Reflect.ownKeys`' string-key order, which is the order
  the old copy preserved, so `droppedPaths` come out in the same order.
- *Sparse arrays?* `z.array` wrote `Array(n)` and assigned every index, so the transform always saw
  a dense array; the new index loop reads holes as `undefined` and reaches the same verdict.
  Covered in the corpus.
- *Does `z.discriminatedUnion` accept or reject differently?* The two options have disjoint `type`
  literals, so for any input the branch a plain union would have accepted is the branch the
  discriminated union selects; a bad `type`, a missing `type`, or a non-object rejects either way.
  Only the *shape of the error detail* differs, and layout-node errors are always swallowed by the
  enclosing `salvagingRecord` (they surface as a dropped entry, not a message). The eleven
  layout-node cases in the corpus assert this end to end.
- *Do the containers still reject a missing object key?* Yes, and on their own — the earlier
  version of this answer, and the comment in the source, were both wrong. `z.unknown()` is **not**
  optional-in: on zod 4.5.4 `z.unknown()` and `z.unknown().transform(...)` both report
  `_zod.optin === undefined` and `_zod.optout === undefined`, and zod's `handlePropertyResult` only
  swallows an absent key's issues when the field is optional-in *and* optional-out. The containers
  raise `invalid_type` on `undefined`, so a bare `z.object({ a: salvagingRecord(...) })` rejects
  both `{}` and `{ a: undefined }` — the same verdict `z.record`/`z.array` gave on main.
  `salvagedField` / `salvagedOptional` wrap them for *fallback* semantics, not for absence
  detection. This is no longer a comment-maintained invariant: `src/shared/zod-salvage-absence.test.ts`
  asserts it, including that forcing `optin = 'optional'` still rejects because `optout` stays
  unset, so a zod release that starts propagating optionality through transforms fails CI instead
  of silently widening the accept set of every persisted field.
- *Does the throw-per-entry recovery still hold?* `parseEntry`'s try/catch is untouched, and the
  existing "drops a recursive entry whose validator overflows instead of resetting the session"
  and 200,000-bad-record tests still pass.

**Edge cases.** SSH: `workspaceSessionsByHostId` partitions (including `ssh:` hosts) go through
the same `parseWorkspaceSessionSalvaging`, so a corrupt remote partition still drops to defaults
for that host alone. Folder workspaces: session keys are opaque strings to this schema, so folder
workspaces and git worktrees validate identically. Remote wire compatibility: nothing on the wire
changes — no field, opcode or published content is added, removed or reshaped, and the accepted
set is byte-identical, so a paired old client sees exactly what it saw before. Windows: no paths,
no processes, no platform branches. Empty/missing state: an empty profile parses to the same
defaults, and `parseWorkspaceSessionSalvaging(undefined)` is still short-circuited by
`normalizeLoadedLocalSession` before the schema runs.

**Not shipped, and why.** Two of the suggested directions did not survive measurement:

- *Skip empty host partitions.* Measured: the five empty partitions cost 0.01 ms each
  (902-1,018 bytes), 0.05 ms of a 4.7 ms total. Adding an emptiness special case to a
  security-relevant validator for 0.05 ms is not a good trade.
- *Validate host partitions lazily on first access.* The whole `workspaceSessionsByHostId` parse is
  4.7 ms of the 57.7 ms, and deferring it moves when a corrupt partition's error surfaces. Not
  worth the plumbing or the semantics change for 8% of the cost.
- *A fast path that skips key validation when the key schema is a bare `z.string()`.* Worth roughly
  5% more, but it has to sniff `_zod.def` to decide, and a zod representation change would silently
  skip key validation rather than fail loudly. That is exactly the failure mode this validation
  exists to prevent.

## Negative user-facing trade-offs

**None.** The accepted and rejected sets are byte-identical — asserted by a 50-payload differential
corpus against the pinned previous implementation, covering the accepted value, the fallback and
the repair diagnostics — and no cap, cadence, debounce, threshold, sampling or staleness window is
introduced; validation still runs in full on every load.

The one caveat this PR used to carry — "the containers are now `z.unknown()`-based, so call sites
*must* keep wrapping them or a missing key becomes an absence" — is gone. It was not true on zod
4.5.4 (a bare transform is neither optional-in nor optional-out, so zod cannot suppress the issue),
and it is now a CI assertion rather than a comment, so it cannot silently become true later. There
is no remaining constraint on future call sites.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/main/persistence`
  — 76 passed | 1 skipped.
- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/shared`
  — 625 passed | 4 skipped (6,805 tests), including the 24 existing corrupt-session salvage cases.
- New: `src/shared/workspace-session-salvage-equivalence.test.ts` (54 tests) — differential corpus
  against the pinned pre-change implementation.
- New: `src/shared/workspace-session-validation-work.test.ts` — deterministic container-node
  counter; verified failing on the reverted implementation (output above).
- New: `src/shared/zod-salvage-absence.test.ts` (6 tests) — absence-stays-fatal guard; verified
  failing when either container is made `.optional()` (output above).
- `nice -n 10 pnpm tc` — clean. This also fixes a typecheck break the two new test files had
  introduced: `tsconfig.tc.cli.json` includes `src/shared/**` under `moduleResolution: node16`,
  where a relative `await import('./workspace-session-salvage')` is TS2835. Both dynamic imports now
  carry the `.js` extension the rest of `src/shared` uses.
- `pnpm run check:code-quality:changed` — 0 new findings across 5 changed files.
- `oxfmt --write` / `oxlint` on all changed files — clean.




## Linked Issue

N/A — no tracked issue. Found while profiling cold start against a reporter-supplied profile
(413 worktrees / 801 tabs); the bisect in "Why it matters" is the origin of this change.

## Visual Proof

`N/A` — main-process schema validation only. No renderer, layout, copy or interaction change; the
accepted/rejected sets are byte-identical, so nothing observable in the UI differs.

## Testing

Verified on macOS (arm64) against a copy of the reporter-shaped profile plus the generated corpora.
No platform-dependent code paths are touched: no paths, no processes, no shell, no platform
branches. SSH is covered by construction — `workspaceSessionsByHostId` partitions (including
`ssh:` hosts) run through the same `parseWorkspaceSessionSalvaging`, and folder workspaces validate
identically to git worktrees because session keys are opaque strings to this schema.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated (three new suites; see Test plan above)

## AI Disclosure

Internal contributor — section intentionally left blank.

## Review

Bot review is clean: pullfrog reported "No new issues found" on both the initial and the
incremental pass, and CodeRabbit generated no actionable comments.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables,
      comments or documentation are touched.

## Notes

- **Security**: validation is not weakened. The record guard delegates to `z.core.util.isPlainObject`
  (zod's own `z.record` predicate) rather than a hand-rolled `typeof === 'object'`, `__proto__` is
  still stripped and the result still uses a null prototype, and the enumerable-symbol-key rejection
  `z.string()` gave is reproduced. A 50-payload differential corpus pins the accept/reject sets.
- **Cross-platform**: no platform-dependent behaviour.
- **Remote SSH**: no wire change — no field, opcode or published content added, removed or
  reshaped; a paired old client sees exactly what it saw before.
- **Mobile / backwards compatibility**: persisted payload format is unchanged in both directions.
- **Performance**: the point of the PR; re-measured with `process.cpuUsage()` deltas only.

## Checklist

- [x] This PR is small and focused (43 net prod lines; the rest is test)
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof (non-UI change)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm tc`, targeted `vitest`, `oxlint` and `pnpm run check:code-quality:changed` pass locally;
      CI covers the rest
