### PR TITLE
perf(startup): overlap the runtime capability refresh with the session-tabs inventory

### DIFF
--- a/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts
@@ -307,6 +307,43 @@ describe('local structured session tab projection', () => {
     }
   })
 
+  it('starts the session-tabs inventory without waiting for the capability refresh', async () => {
+    const priorApi = window.api
+    let releaseStatus = (): void => undefined
+    const statusGate = new Promise<void>((resolve) => {
+      releaseStatus = resolve
+    })
+    const getStatus = vi.fn(async () => {
+      await statusGate
+      return { capabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY] }
+    })
+    const call = vi.fn().mockResolvedValue({ ok: true, result: { snapshots: [] } })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { runtime: { getStatus, call } }
+    })
+    try {
+      vi.resetModules()
+      const { restoreLocalStructuredSessionTabsOnce } =
+        await import('./local-structured-session-tabs-sync')
+      let settled = false
+      const restored = restoreLocalStructuredSessionTabsOnce().finally(() => {
+        settled = true
+      })
+      expect(getStatus).toHaveBeenCalledOnce()
+      // The inventory RPC must already be in flight while the capability refresh is pending.
+      expect(call).toHaveBeenCalledWith({ method: 'session.tabs.listAll', params: {} })
+      // ...and overlapping must not let the restore open the gate before capabilities land.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(settled).toBe(false)
+      releaseStatus()
+      await restored
+      expect(call).toHaveBeenCalledOnce()
+    } finally {
+      Object.defineProperty(window, 'api', { configurable: true, value: priorApi })
+    }
+  })
+
   it('accepts a newer session after merged content returns to the base epoch', () => {
     const state = createSnapshot()
     const base = {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/inventory-refresh.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/inventory-refresh.ts
@@ -10,10 +10,14 @@ import { applyStructuredSessionTabSnapshots } from './snapshot-apply'
 export function restoreLocalStructuredSessionTabsOnce(
   expectedGeneration = localStructuredSessionGeneration()
 ): Promise<void> {
+  // Why concurrent: the capability refresh only seeds the module cache that later launch
+  // flows read; the inventory fetch never reads it, so chaining them only paid a second
+  // serial IPC round-trip on the startup gate.
   return latchLocalStructuredSessionRestore(() =>
-    refreshLocalRuntimeCapabilities()
-      .then(() => refreshLocalStructuredSessionTabs(expectedGeneration))
-      .then(() => undefined)
+    Promise.all([
+      refreshLocalRuntimeCapabilities(),
+      refreshLocalStructuredSessionTabs(expectedGeneration)
+    ]).then(() => undefined)
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## ELI5

When Orca finishes drawing its window, it still has a short list of chores to do before your
workspace is actually usable — read your settings, find your repos, restore your tabs, reattach your
terminals. The very last chore was doing two independent errands one after the other: asking the app
for a list of what it can do, and then asking it for the list of your agent chat tabs. The first
answer was never used by the second question, so waiting for it was pure dead time.

Now both errands are sent at the same time. Nothing new is skipped, delayed, or approximated — the
chore still finishes only when both answers are back, it just stops standing in its own queue.

## Why it matters

On a profile shaped like the reporter's (413 worktrees, 801 tabs, 1,349 `worktreeMeta` rows, 10 host
partitions, ~3.0 MB persisted state), the `did-finish-load -> renderer-startup-hydration-done` window
is **1,683 ms median (n=26)** versus **146 ms median (n=9)** on an empty profile. That window sits
after first paint but before the workspace is usable.

Bisecting it with temporary phase markers, the last step — `project-structured-session-tabs` — is the
third largest scaling term in the window, and just over a quarter of it was one serial IPC leg:

| leg of `restoreLocalStructuredSessionTabsOnce` | empty profile | reporter-shaped |
|---|---|---|
| `runtime:getStatus` (capability refresh) | 2 ms | **109 ms** (mean 106, n=26) |
| `session.tabs.listAll` (inventory) | 16 ms | 299 ms |

The capability refresh's return value is discarded at that call site — it exists only to seed the
module cache that later launch flows read — so its 109 ms was spent purely waiting.

## Measurement

All numbers are median-of-N with the two builds **interleaved** (a prebuilt `out/renderer` tree is
swapped between iterations, arm order alternating per pair) because this box drifts enough between
blocks to flip a sign. Fixture: the reporter's real persisted state, remapped onto 13 synthetic git
repos and 1,377 real `git worktree add` checkouts inside the fixture, with SSH targets and
`activeConnectionIdsAtShutdown` cleared so no run touches the network.

### Before/after — paired, 26 interleaved pairs

```
n pairs = 26
window base                        median= 1683  mean= 1693
window after                       median= 1635  mean= 1572
paired dWindow (base-after)        median=  111  mean=  121   improved=18/26
step base                          median=  426  mean=  379
step after                         median=  415  mean=  287
paired dStep (base-after)          median=   63  mean=   92   improved=15/26
base capability leg                median=  109  mean=  106   <- the serial leg removed
after capability leg               median=   98  mean=   90   <- now overlapped
```

The deterministic quantity is the capability leg: it no longer sits in series. End-to-end the paired
median improvement is 111 ms on the window; the run-to-run spread on this loaded box is large (the
step is bimodal at ~110 ms / ~450 ms in *both* arms), which is why the paired sign counts are 18/26
and 15/26 rather than 26/26.

### Full phase attribution of the window (median, wall / main-process CPU ms)

`cpu` is `process.cpuUsage().user + .system` in the main process, sampled at each milestone.

| step | empty wall | empty cpu | shaped wall | shaped cpu |
|---|---|---|---|---|
| did-finish-load -> startup-chain-start | 44 | 31 | 49 | 50 |
| fetch-settings | 30 | 7 | 34 | 56 |
| ui-get | 11 | 9 | 16 | 23 |
| hydrate-persisted-ui | 0 | 0 | 2 | 1 |
| fetch-repos-local | 18 | 39 | 40 | 59 |
| fetch-project-groups-local | 3 | 13 | 3 | 10 |
| session-get | 0 | 0 | 19 | 35 |
| fetch-folder-workspaces-local | 2 | 2 | 1 | 6 |
| git-environment-barrier-await | 0 | 0 | 0 | 1 |
| **fetch-hydration-worktrees** | 0 | 0 | **540** | **1069** |
| repo-catalog-final-settlement | 0 | 0 | 0 | 0 |
| hydrate-session-stores | 2 | 5 | 10 | 11 |
| prepare-terminal-startup-restoration | 9 | 19 | 22 | 37 |
| visit-timestamp-prune | 0 | 1 | 1 | 2 |
| **recover-legacy-worker-terminals (pre-reconnect)** | 4 | 4 | **309** | **670** |
| terminal-provider-snapshot-capabilities | 1 | 1 | 13 | 11 |
| reconnect-terminals | 2 | 4 | 21 | 35 |
| **recover-legacy-worker-terminals (post-reconnect)** | 1 | 5 | **224** | **275** |
| project-structured-session-tabs: capability leg | 2 | 5 | **127** | 162 |
| project-structured-session-tabs: inventory leg | 16 | 28 | **252** | 213 |
| **TOTAL window** | **146** | **175** | **1683** | **2726** |

### Failing-test output (change temporarily reverted)

```
 ❯ src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts (13 tests | 1 failed) 68ms
     × starts the session-tabs inventory without waiting for the capability refresh 55ms

 FAIL  ... > starts the session-tabs inventory without waiting for the capability refresh
AssertionError: expected "vi.fn()" to be called with arguments: [ { …(2) } ]

Number of calls: 0

 ❯ src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts:243:20
    241|       expect(getStatus).toHaveBeenCalledOnce()
    242|       // The inventory RPC must already be in flight while the capabil…
    243|       expect(call).toHaveBeenCalledWith({ method: 'session.tabs.listAl…

 Test Files  1 failed (1)
      Tests  1 failed | 12 passed (13)
```

With the change:

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

The guard is a call-ordering assertion (the inventory RPC must already be dispatched while the
capability promise is still pending), not a wall-clock assertion.

## Correctness

**Why the output is identical.** `refreshLocalRuntimeCapabilities()`'s resolved value is discarded at
this call site; its only effect is assigning the module-level cache that `readLocalRuntimeCapabilities()`
returns. `Promise.all` still resolves only after both settle, so that cache is populated no later than
before `restoreLocalStructuredSessionTabsOnce()` resolves, and every downstream observer
(`startLocalStructuredSessionTabsSync`, `use-app-startup-hydration`) sees the same post-conditions.

**Does anything between the two calls read the capability cache?** No. The readers of
`readLocalRuntimeCapabilities()` are `folder-workspace-composer-submit`, `quick-creation-execution`,
`full-creation-execution`, `onboarding-folder-agent-startup`, `launch-agent-in-new-tab`, and
`launch-work-item-direct-route-preparation` — all user-initiated launch flows, none of which can run
between the two calls. `refreshLocalStructuredSessionTabs()` and `applyStructuredSessionTabSnapshots()`
never read it.

**Rejection semantics.** `refreshLocalRuntimeCapabilities()` catches internally and resolves to `[]`,
so it cannot reject; the only rejection path is still the inventory fetch, and it still lands in the
existing `.catch` that clears the memo so a later caller retries. The previously-unreachable branch
where a capability rejection skipped the inventory fetch stays unreachable.

**Store ordering.** The capability refresh performs no store writes, so applying the inventory
snapshots earlier cannot race with it.

**SSH.** Both calls target the local desktop runtime (`runtime:getStatus` and `runtime:call` on the
main process); nothing about remote execution hosts changes.
`applyLocalStructuredSessionTabSnapshots` still skips any worktree whose execution host is not
`local`, so SSH- and runtime-owned panes are untouched. Terminal reconnect is upstream of this step
and is not reordered.

**Folder workspaces.** Unchanged — the snapshot application path, including the
`folderWorkspaceKey` cursor pruning, is not touched.

**Remote wire compatibility.** No RPC method, param, stream opcode, or published payload changes —
only the order in which the client issues two calls it already made.

**Windows / Linux.** Pure renderer promise ordering; no platform-dependent code.

**Empty / missing state.** With no structured sessions the inventory returns `{ snapshots: [] }` and
both legs cost 2 ms + 16 ms; the change is a measured no-op there.

## Negative user-facing trade-offs

**None.** No cap, cadence, debounce, threshold, sampling rate, staleness window, or coverage changes,
and both calls still complete before the startup gate opens — so nothing renders earlier in a
partially-hydrated state and no agent-session tab pops in late.

## Test plan

- `nice -n 10 node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/app-shell src/main/startup src/renderer/src/runtime/local-structured-session-tabs-sync.test.ts src/renderer/src/runtime/local-runtime-capabilities.test.ts` — 58 files passed, 494 tests passed, 6 skipped.
- New guard verified failing with the change reverted (output above).
- `tsc --noEmit -p config/tsconfig.tc.web.json` — clean.
- `tsc --noEmit -p config/tsconfig.node.json --composite false` — clean.
- `oxfmt --write` + `oxlint` on both changed files — clean.
- `pnpm run check:code-quality:changed` — 0 new findings.
- 52 real app launches (26 interleaved A/B pairs) against the reporter-shaped fixture, plus 9 on an
  empty profile.
