### PR TITLE
fix(worktree): detect canonically equivalent checked-out refs

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -55,6 +55,11 @@ import type {
   RemoteFetchResult,
   RemoteTrackingBase
 } from '../runtime/orca-runtime'
+import {
+  hasLocalGitOptions,
+  isLocalBranchCheckedOut,
+  normalizeLocalBranchName
+} from '../runtime/runtime-worktree-selection'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-lookup'
 import { getEffectiveHooks, loadHooks, parseOrcaYaml } from '../hooks'
 import { buildPosixRunnerScript, buildWindowsRunnerScript } from '../setup-runner-script-text'
@@ -714,10 +719,6 @@ async function resolveCreateBranchNameSsh(
   return branchNameOverride
 }
 
-function normalizeLocalBranchName(branchName: string | undefined): string {
-  return branchName?.replace(/^refs\/heads\//, '') ?? ''
-}
-
 async function canCheckoutExistingLocalBranch(
   repoPath: string,
   branchName: string,
@@ -754,11 +755,11 @@ async function canCheckoutExistingLocalBranch(
     }
   }
   const worktrees = await listWorktrees(repoPath, gitOptions)
-  return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
-}
-
-function hasLocalGitOptions(gitOptions: { wslDistro?: string }): boolean {
-  return Object.keys(gitOptions).length > 0
+  return !(await isLocalBranchCheckedOut(
+    branchName,
+    worktrees.map((worktree) => worktree.branch),
+    (args) => gitExecFileAsync(args, { cwd: repoPath, ...gitOptions })
+  ))
 }
 
 function getLocalGitHubPrForBranch(
@@ -845,7 +846,11 @@ async function canCheckoutExistingLocalBranchSsh(
     }
   }
   const worktrees = await provider.listWorktrees(repoPath)
-  return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
+  return !(await isLocalBranchCheckedOut(
+    branchName,
+    worktrees.map((worktree) => worktree.branch),
+    (args) => provider.exec(args, repoPath)
+  ))
 }
 
 type SshGitExecutor = Pick<SshGitProvider, 'exec'>

--- a/src/main/runtime/runtime-worktree-create-git.ts
+++ b/src/main/runtime/runtime-worktree-create-git.ts
@@ -11,7 +11,11 @@ import {
   getSelectedReviewLookupHints,
   type SelectedReviewBranchInput
 } from './selected-review-branch'
-import { hasLocalGitOptions, normalizeLocalBranchName } from './runtime-worktree-selection'
+import {
+  hasLocalGitOptions,
+  isLocalBranchCheckedOut,
+  normalizeLocalBranchName
+} from './runtime-worktree-selection'
 import type { HostedReviewExecutionOptions } from '../source-control/hosted-review-git-options'
 
 export async function resolveCreateBranchName(
@@ -72,7 +76,11 @@ export async function canCheckoutExistingLocalBranch(
     }
   }
   const worktrees = await listWorktrees(repoPath, gitOptions)
-  return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
+  return !(await isLocalBranchCheckedOut(
+    branchName,
+    worktrees.map((worktree) => worktree.branch),
+    (args) => gitExecFileAsync(args, { cwd: repoPath, ...gitOptions })
+  ))
 }
 
 export function getLocalGitHubPrForBranch(

--- a/src/main/runtime/runtime-worktree-selection.test.ts
+++ b/src/main/runtime/runtime-worktree-selection.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it } from 'vitest'
-import { runtimeRepoMatchesExecutionHost } from './runtime-worktree-selection'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isLocalBranchCheckedOut,
+  runtimeRepoMatchesExecutionHost
+} from './runtime-worktree-selection'
+
+describe('isLocalBranchCheckedOut', () => {
+  it('asks Git to disambiguate canonically equivalent Linear branch names', async () => {
+    const branchName = 'feature/수신-기반'
+    const nfcRef = `refs/heads/${branchName.normalize('NFC')}`
+    const nfdRef = `refs/heads/${branchName.normalize('NFD')}`
+    const runGit = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: `abc123 ${nfcRef}\n` })
+      .mockResolvedValueOnce({ stdout: `abc123 ${nfdRef}\n` })
+
+    await expect(
+      isLocalBranchCheckedOut(branchName.normalize('NFD'), [nfcRef], runGit)
+    ).resolves.toBe(true)
+    await expect(
+      isLocalBranchCheckedOut(branchName.normalize('NFD'), [nfcRef], runGit)
+    ).resolves.toBe(false)
+    expect(runGit).toHaveBeenNthCalledWith(1, ['show-ref', '--verify', '--', nfdRef])
+  })
+})
 
 describe('runtimeRepoMatchesExecutionHost', () => {
   it('matches an unstamped SSH repo against its own host (#11163)', () => {

--- a/src/main/runtime/runtime-worktree-selection.ts
+++ b/src/main/runtime/runtime-worktree-selection.ts
@@ -73,6 +73,33 @@ export function normalizeLocalBranchName(branchName: string | undefined): string
   return branchName?.replace(/^refs\/heads\//, '') ?? ''
 }
 
+export async function isLocalBranchCheckedOut(
+  branchName: string,
+  worktreeBranches: readonly string[],
+  runGit: (args: string[]) => Promise<{ stdout: string }>
+): Promise<boolean> {
+  const requestedRef = `refs/heads/${normalizeLocalBranchName(branchName)}`
+  const checkedOutRefs = worktreeBranches.map(
+    (branch) => `refs/heads/${normalizeLocalBranchName(branch)}`
+  )
+  if (checkedOutRefs.includes(requestedRef)) {
+    return true
+  }
+  if (!checkedOutRefs.some((ref) => ref.normalize('NFC') === requestedRef.normalize('NFC'))) {
+    return false
+  }
+  try {
+    // Why: macOS Git may resolve NFD input to an NFC on-disk ref, while Linux can store both.
+    const { stdout } = await runGit(['show-ref', '--verify', '--', requestedRef])
+    const separator = stdout.indexOf(' ')
+    const resolvedRef = separator === -1 ? '' : stdout.slice(separator + 1).trim()
+    return !resolvedRef || checkedOutRefs.includes(resolvedRef)
+  } catch {
+    // Why: a failed probe cannot prove that reusing the branch is safe.
+    return true
+  }
+}
+
 export function getExplicitWorktreeIdSelector(selector: string | undefined): string | null {
   if (!selector?.startsWith('id:')) {
     return null


### PR DESCRIPTION
## ELI5

Linear and Git can represent the same Korean branch name using different Unicode bytes. Orca previously treated those spellings as different and tried to check out a branch that another worktree was already using. Orca now asks Git which ref the name actually resolves to before reusing it.

## What Changed

- Added a shared checked-out branch identity check.
- Ask `git show-ref --verify` to disambiguate canonically equivalent refs.
- Preserve distinct NFC and NFD refs on filesystems where Git treats them separately.
- Applied the check to local, WSL, and SSH worktree creation.
- Added a regression test covering macOS resolution and distinct-ref behavior.

## Why

JavaScript string equality does not reflect Git ref identity on macOS when `core.precomposeunicode=true`. Normalizing every branch name globally would incorrectly merge refs that can remain distinct on Linux, so Git remains the source of truth.

## Linked Issue

Fixes #18447

## Visual Proof

N/A — no visual change. This prevents the existing Create Worktree dialog from issuing an invalid Git command.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Related Vitest suites on the final rebased commit: 28/28 passed
- `pnpm typecheck`: passed
- `pnpm lint`: passed
- `pnpm build`: passed
- Earlier full parallel test run: 71,302 tests passed; five Electron network-egress tests timed out under parallel load and all five passed when rerun individually

The native app Linear flow was reproduced from installed Orca logs and with Apple Git 2.50.1. The patched app UI flow has not yet been rerun from a development build.

## AI Disclosure

OpenAI Codex was used for investigation and implementation. Claude Code and Grok 4.6 performed independent read-only reviews.

## Review

- Cross-platform: avoids global Unicode normalization, preserving distinct refs on Linux and Windows.
- Local/WSL/SSH: each path runs the identity probe using Git on its owning execution host.
- Integrations: the bug is exposed by Linear branch names, but the fix remains provider-neutral.
- Performance: the extra Git process runs only when a checked-out ref is canonically equivalent but not byte-equal.
- Security: Git arguments are passed as an argv array with `--`; no shell interpolation was added.
- UI: no visual or layout changes.
- Agent compatibility: no agent-specific behavior changed.

## Agent skill upstream boundary

- [x] Not applicable.

## Author

X (Twitter): @highcontrast_

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is marked N/A with a reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [ ] `pnpm test` is fully green on the final commit, or CI will cover
