### PR TITLE
feat(editor): zoom and pan standalone mermaid diagrams

### DIFF
--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -729,10 +729,18 @@
   width: 100%;
   height: auto;
 }
-/* Why: auto margins center the diagram without clipping its leading edge once
-   zoom makes it overflow, which justify-content: center would do, and flex: none
-   keeps the flex parent from shrinking a zoomed box back to the pane width. */
+/* Until the surface has measured the diagram, including a render that failed,
+   the box spans the canvas so the error banner and source keep the width they
+   had before this wrapper existed. */
 .mermaid-diagram-box {
+  align-self: flex-start;
+  width: 100%;
+}
+/* Why: once the box carries a pixel size, auto margins center it without
+   clipping its leading edge the way justify-content: center would, and
+   flex: none keeps the flex parent from shrinking it back to the pane width. */
+.mermaid-diagram-box[data-zoom-layout='true'] {
+  align-self: auto;
   flex: none;
   margin: auto;
 }

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -718,10 +718,9 @@
 }
 .mermaid-viewer-canvas {
   display: flex;
-  align-items: flex-start;
-  justify-content: center;
   min-height: 100%;
-  padding: 32px 24px;
+  /* Keep in sync with MERMAID_CANVAS_PADDING in MermaidZoomSurface.tsx. */
+  padding: 24px;
 }
 .mermaid-viewer-canvas .mermaid-block {
   width: 100%;
@@ -729,6 +728,24 @@
 .mermaid-viewer-canvas .mermaid-block svg {
   width: 100%;
   height: auto;
+}
+/* Why: auto margins center the diagram without clipping its leading edge once
+   zoom makes it overflow, which justify-content: center would do, and flex: none
+   keeps the flex parent from shrinking a zoomed box back to the pane width. */
+.mermaid-diagram-box {
+  flex: none;
+  margin: auto;
+}
+/* Once the zoom surface has measured the diagram it sizes this box in pixels,
+   so the SVG fills the box instead of the pane. */
+.mermaid-diagram-box[data-zoom-layout='true'] .mermaid-block,
+.mermaid-diagram-box[data-zoom-layout='true'] .mermaid-block svg {
+  width: 100%;
+  height: 100%;
+}
+/* Why: mermaid writes an inline max-width on the svg, which would cap the box. */
+.mermaid-diagram-box[data-zoom-layout='true'] .mermaid-block svg {
+  max-width: none !important;
 }
 
 .markdown-body ul,

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -5,20 +5,20 @@ import { cn } from '@/lib/utils'
 import ImageViewerPopup from './ImageViewerPopup'
 import PdfViewer from './PdfViewer'
 import {
-  type ApplyImageViewerZoomChange,
-  applyAnchoredImageViewerZoomChange,
-  applyImageSurfaceWheel,
+  type ApplySurfaceZoomChange,
+  applyAnchoredSurfaceZoomChange,
+  applySurfaceWheel,
   getElementSurfaceSize,
-  getImageLayoutStyle
-} from './image-viewer-dom-zoom'
+  getSurfaceLayoutStyle
+} from './surface-dom-zoom'
 import {
-  IMAGE_VIEWER_ZOOM_STEP,
-  MAX_IMAGE_VIEWER_ZOOM,
-  MIN_IMAGE_VIEWER_ZOOM,
-  type ImageViewerImageDimensions,
-  type ImageViewerSurfaceSize,
-  getZoomedImageLayoutSize
-} from './image-viewer-zoom'
+  SURFACE_ZOOM_STEP,
+  MAX_SURFACE_ZOOM,
+  MIN_SURFACE_ZOOM,
+  type SurfaceContentDimensions,
+  type SurfaceSize,
+  getZoomedSurfaceLayoutSize
+} from './surface-zoom'
 import { translate } from '@/i18n/i18n'
 import { buildImageDataUri } from '../../../../shared/image-data-uri'
 
@@ -46,9 +46,9 @@ export default function ImageViewer({
   const [popupZoom, setPopupZoom] = useState(1)
   const inlineSurfaceRef = useRef<HTMLDivElement | null>(null)
   const popupSurfaceRef = useRef<HTMLDivElement | null>(null)
-  const [inlineSurfaceSize, setInlineSurfaceSize] = useState<ImageViewerSurfaceSize | null>(null)
-  const [popupSurfaceSize, setPopupSurfaceSize] = useState<ImageViewerSurfaceSize | null>(null)
-  const [imageDimensions, setImageDimensions] = useState<ImageViewerImageDimensions | null>(null)
+  const [inlineSurfaceSize, setInlineSurfaceSize] = useState<SurfaceSize | null>(null)
+  const [popupSurfaceSize, setPopupSurfaceSize] = useState<SurfaceSize | null>(null)
+  const [imageDimensions, setImageDimensions] = useState<SurfaceContentDimensions | null>(null)
   const [failedPreviewSrc, setFailedPreviewSrc] = useState<string | null>(null)
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
@@ -85,8 +85,8 @@ export default function ImageViewer({
     () =>
       isIntrinsicLayout
         ? null
-        : getZoomedImageLayoutSize({
-            imageDimensions,
+        : getZoomedSurfaceLayoutSize({
+            contentDimensions: imageDimensions,
             surfaceSize: inlineSurfaceSize,
             zoom: inlineZoom
           }),
@@ -94,26 +94,26 @@ export default function ImageViewer({
   )
   const popupImageLayoutSize = useMemo(
     () =>
-      getZoomedImageLayoutSize({
-        imageDimensions,
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: imageDimensions,
         surfaceSize: popupSurfaceSize,
         zoom: popupZoom
       }),
     [imageDimensions, popupSurfaceSize, popupZoom]
   )
   const inlineImageLayoutStyle = useMemo(
-    () => getImageLayoutStyle(inlineImageLayoutSize),
+    () => getSurfaceLayoutStyle(inlineImageLayoutSize),
     [inlineImageLayoutSize]
   )
   const popupImageLayoutStyle = useMemo(
-    () => getImageLayoutStyle(popupImageLayoutSize),
+    () => getSurfaceLayoutStyle(popupImageLayoutSize),
     [popupImageLayoutSize]
   )
-  const applyInlineZoomChange = useCallback<ApplyImageViewerZoomChange>((getNextZoom, anchor) => {
-    applyAnchoredImageViewerZoomChange(inlineSurfaceRef.current, setInlineZoom, getNextZoom, anchor)
+  const applyInlineZoomChange = useCallback<ApplySurfaceZoomChange>((getNextZoom, anchor) => {
+    applyAnchoredSurfaceZoomChange(inlineSurfaceRef.current, setInlineZoom, getNextZoom, anchor)
   }, [])
-  const applyPopupZoomChange = useCallback<ApplyImageViewerZoomChange>((getNextZoom, anchor) => {
-    applyAnchoredImageViewerZoomChange(popupSurfaceRef.current, setPopupZoom, getNextZoom, anchor)
+  const applyPopupZoomChange = useCallback<ApplySurfaceZoomChange>((getNextZoom, anchor) => {
+    applyAnchoredSurfaceZoomChange(popupSurfaceRef.current, setPopupZoom, getNextZoom, anchor)
   }, [])
   const openPopup = useCallback(() => {
     setPopupZoom(inlineZoom)
@@ -130,13 +130,13 @@ export default function ImageViewer({
   )
   const handleInlineImageSurfaceWheel = useCallback(
     (event: WheelEvent) => {
-      applyImageSurfaceWheel(event, applyInlineZoomChange)
+      applySurfaceWheel(event, applyInlineZoomChange)
     },
     [applyInlineZoomChange]
   )
   const handlePopupImageSurfaceWheel = useCallback(
     (event: WheelEvent) => {
-      applyImageSurfaceWheel(event, applyPopupZoomChange)
+      applySurfaceWheel(event, applyPopupZoomChange)
     },
     [applyPopupZoomChange]
   )
@@ -313,9 +313,9 @@ export default function ImageViewer({
               type="button"
               className="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-50"
               onClick={() =>
-                applyInlineZoomChange((currentZoom) => currentZoom / IMAGE_VIEWER_ZOOM_STEP)
+                applyInlineZoomChange((currentZoom) => currentZoom / SURFACE_ZOOM_STEP)
               }
-              disabled={inlineZoom <= MIN_IMAGE_VIEWER_ZOOM}
+              disabled={inlineZoom <= MIN_SURFACE_ZOOM}
               title={translate('auto.components.editor.ImageViewer.be27304574', 'Zoom out')}
             >
               <ZoomOut size={14} />
@@ -333,9 +333,9 @@ export default function ImageViewer({
               type="button"
               className="rounded p-1 hover:bg-accent hover:text-foreground disabled:opacity-50"
               onClick={() =>
-                applyInlineZoomChange((currentZoom) => currentZoom * IMAGE_VIEWER_ZOOM_STEP)
+                applyInlineZoomChange((currentZoom) => currentZoom * SURFACE_ZOOM_STEP)
               }
-              disabled={inlineZoom >= MAX_IMAGE_VIEWER_ZOOM}
+              disabled={inlineZoom >= MAX_SURFACE_ZOOM}
               title={translate('auto.components.editor.ImageViewer.3c9217f5a6', 'Zoom in')}
             >
               <ZoomIn size={14} />

--- a/src/renderer/src/components/editor/ImageViewerPopup.tsx
+++ b/src/renderer/src/components/editor/ImageViewerPopup.tsx
@@ -2,7 +2,7 @@ import { X } from 'lucide-react'
 import type { CSSProperties, JSX } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
-import type { ImageViewerImageDimensions } from './image-viewer-zoom'
+import type { SurfaceContentDimensions } from './surface-zoom'
 import { translate } from '@/i18n/i18n'
 
 type ImageViewerPopupProps = {
@@ -10,7 +10,7 @@ type ImageViewerPopupProps = {
   isOpen: boolean
   previewUrl: string
   zoomPercent: number
-  imageLayoutSize: ImageViewerImageDimensions | null
+  imageLayoutSize: SurfaceContentDimensions | null
   imageLayoutStyle: CSSProperties | undefined
   onOpenChange: (open: boolean) => void
   setSurfaceRef: (surface: HTMLDivElement | null) => void

--- a/src/renderer/src/components/editor/MermaidBlock.tsx
+++ b/src/renderer/src/components/editor/MermaidBlock.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useId, useRef, useState } from 'react'
 import type mermaidNamespace from 'mermaid'
 import DOMPurify from 'dompurify'
 import { getMermaidConfig } from './mermaid-config'
+import { getRenderedDiagramSize } from './mermaid-diagram-size'
+import type { SurfaceContentDimensions } from './surface-zoom'
 import { translate } from '@/i18n/i18n'
 
 type MermaidApi = typeof mermaidNamespace
@@ -22,6 +24,9 @@ type MermaidBlockProps = {
   content: string
   isDark: boolean
   htmlLabels?: boolean
+  // Why: the rendered SVG is injected imperatively, so a zoom surface wrapping
+  // this block has no other way to learn the diagram's intrinsic size.
+  onRendered?: (size: SurfaceContentDimensions | null) => void
 }
 
 // Why: mermaid.render() manipulates global DOM state (element IDs, internal
@@ -50,7 +55,8 @@ function enqueueRender(fn: () => Promise<void>): void {
 export default function MermaidBlock({
   content,
   isDark,
-  htmlLabels = false
+  htmlLabels = false,
+  onRendered
 }: MermaidBlockProps): React.JSX.Element {
   const id = useId().replace(/:/g, '_')
   const containerRef = useRef<HTMLDivElement>(null)
@@ -80,10 +86,12 @@ export default function MermaidBlock({
             USE_PROFILES: { svg: true }
           })
           setError(null)
+          onRendered?.(getRenderedDiagramSize(containerRef.current))
         }
       } catch (err) {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : 'Invalid mermaid syntax')
+          onRendered?.(null)
           // Mermaid leaves an error element in the DOM on failure — clean it up.
           const errorEl = document.getElementById(`d${`mermaid-${id}`}`)
           errorEl?.remove()
@@ -97,7 +105,7 @@ export default function MermaidBlock({
     return () => {
       cancelled = true
     }
-  }, [content, htmlLabels, isDark, id])
+  }, [content, htmlLabels, isDark, id, onRendered])
 
   if (error) {
     return (

--- a/src/renderer/src/components/editor/MermaidViewer.tsx
+++ b/src/renderer/src/components/editor/MermaidViewer.tsx
@@ -1,7 +1,7 @@
 import React, { useLayoutEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { scrollTopCache, setWithLRU } from '@/lib/scroll-cache'
-import MermaidBlock from './MermaidBlock'
+import MermaidZoomSurface from './MermaidZoomSurface'
 
 type MermaidViewerProps = {
   content: string
@@ -92,13 +92,13 @@ export default function MermaidViewer({
   }, [scrollCacheKey, content])
 
   return (
-    <div ref={rootRef} className="mermaid-viewer h-full min-h-0 overflow-auto scrollbar-editor">
-      <div className="mermaid-viewer-canvas">
-        {/* Why: DOMPurify's SVG profile strips <foreignObject> elements that
-           mermaid uses for HTML labels. Force SVG-native <text> labels so
-           they survive sanitization — same fix as the markdown preview path. */}
-        <MermaidBlock content={content.trim()} isDark={isDark} htmlLabels={false} />
-      </div>
-    </div>
+    // Why: remounting per file gives each diagram its own zoom level without
+    // deriving state from props.
+    <MermaidZoomSurface
+      key={filePath}
+      content={content.trim()}
+      isDark={isDark}
+      surfaceRef={rootRef}
+    />
   )
 }

--- a/src/renderer/src/components/editor/MermaidZoomSurface.test.tsx
+++ b/src/renderer/src/components/editor/MermaidZoomSurface.test.tsx
@@ -1,0 +1,302 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import MermaidZoomSurface from './MermaidZoomSurface'
+import { MAX_SURFACE_ZOOM, MIN_SURFACE_ZOOM } from './surface-zoom'
+
+const DIAGRAM_WIDTH = 800
+const DIAGRAM_HEIGHT = 600
+const SURFACE_WIDTH = 400
+const SURFACE_HEIGHT = 400
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+// Why: the real block loads ~650KB of mermaid and renders asynchronously; the
+// surface only depends on the intrinsic size it reports back.
+vi.mock('./MermaidBlock', async () => {
+  const { createElement, useEffect } = await import('react')
+  function MermaidBlockStub({
+    onRendered
+  }: {
+    onRendered?: (size: { width: number; height: number } | null) => void
+  }) {
+    useEffect(() => {
+      onRendered?.({ width: DIAGRAM_WIDTH, height: DIAGRAM_HEIGHT })
+    }, [onRendered])
+    return createElement('div', { className: 'mermaid-block', 'data-testid': 'mermaid-block' })
+  }
+  return { default: MermaidBlockStub }
+})
+
+// Why: happy-dom reports every element as 0x0, so the surface would never get a
+// measurable size to fit the diagram into.
+const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get: () => SURFACE_WIDTH
+  })
+  Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+    configurable: true,
+    get: () => SURFACE_HEIGHT
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  if (originalClientWidth) {
+    Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth)
+  }
+  if (originalClientHeight) {
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', originalClientHeight)
+  }
+})
+
+function renderSurface(): HTMLElement {
+  const { container } = render(<MermaidZoomSurface content="graph TD; a-->b" isDark={false} />)
+  const surface = container.querySelector('.mermaid-viewer')
+  if (!(surface instanceof HTMLElement)) {
+    throw new Error('zoom surface not rendered')
+  }
+  return surface
+}
+
+function getDiagramBox(): HTMLElement {
+  const box = document.querySelector('.mermaid-diagram-box')
+  if (!(box instanceof HTMLElement)) {
+    throw new Error('diagram box not rendered')
+  }
+  return box
+}
+
+function getZoomPercent(): number {
+  const label = document.querySelector('.tabular-nums')?.textContent ?? ''
+  return Number.parseInt(label, 10)
+}
+
+function setScrollExtents(surface: HTMLElement, { horizontal }: { horizontal: boolean }): void {
+  // Why: happy-dom does not lay out, so a zoomed surface reports no overflow
+  // and the pan handler would refuse to start.
+  Object.defineProperty(surface, 'scrollWidth', {
+    configurable: true,
+    get: () => (horizontal ? SURFACE_WIDTH * 3 : SURFACE_WIDTH)
+  })
+  Object.defineProperty(surface, 'scrollHeight', {
+    configurable: true,
+    get: () => (horizontal ? SURFACE_HEIGHT : SURFACE_HEIGHT * 3)
+  })
+}
+
+function stubPointerCapture(surface: HTMLElement): {
+  setPointerCapture: ReturnType<typeof vi.fn>
+  releasePointerCapture: ReturnType<typeof vi.fn>
+} {
+  const setPointerCapture = vi.fn()
+  const releasePointerCapture = vi.fn()
+  Object.assign(surface, { setPointerCapture, releasePointerCapture })
+  return { setPointerCapture, releasePointerCapture }
+}
+
+function dispatchPointer(
+  surface: HTMLElement,
+  type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel',
+  {
+    clientX,
+    clientY,
+    pointerId = 1,
+    button = 0,
+    pointerType = 'mouse'
+  }: {
+    clientX: number
+    clientY: number
+    pointerId?: number
+    button?: number
+    pointerType?: string
+  }
+): void {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  Object.assign(event, { clientX, clientY, pointerId, button, pointerType })
+  fireEvent(surface, event)
+}
+
+function dispatchWheel(
+  surface: HTMLElement,
+  { deltaY, ctrlKey = false }: { deltaY: number; ctrlKey?: boolean }
+): WheelEvent {
+  const event = new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY })
+  // Why: happy-dom's WheelEvent leaves ctrlKey undefined, and ctrl-wheel is how
+  // Chromium reports a trackpad pinch.
+  Object.defineProperty(event, 'ctrlKey', { value: ctrlKey })
+  fireEvent(surface, event)
+  return event
+}
+
+describe('MermaidZoomSurface', () => {
+  it('sizes the diagram box in pixels once the diagram reports its size', () => {
+    renderSurface()
+
+    const box = getDiagramBox()
+    expect(box.dataset.zoomLayout).toBe('true')
+    // The 800x600 diagram is fitted into the 400x400 surface minus the 24px
+    // canvas padding on each side, keeping its aspect ratio.
+    expect(box.style.width).toBe('352px')
+    expect(box.style.height).toBe('264px')
+    expect(getZoomPercent()).toBe(100)
+  })
+
+  it('grows the layout box when zooming in so scroll extents can reach the diagram', () => {
+    renderSurface()
+    const widthBefore = Number.parseFloat(getDiagramBox().style.width)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+
+    expect(Number.parseFloat(getDiagramBox().style.width)).toBeGreaterThan(widthBefore)
+    expect(getZoomPercent()).toBe(125)
+  })
+
+  it('returns to a fitted diagram when resetting zoom', () => {
+    renderSurface()
+    const fittedWidth = getDiagramBox().style.width
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+    expect(getDiagramBox().style.width).not.toBe(fittedWidth)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fit diagram' }))
+    expect(getDiagramBox().style.width).toBe(fittedWidth)
+    expect(getZoomPercent()).toBe(100)
+  })
+
+  it('zooms on ctrl-wheel and leaves plain wheel to scroll the surface', () => {
+    const surface = renderSurface()
+
+    const plainWheel = dispatchWheel(surface, { deltaY: -120 })
+    expect(plainWheel.defaultPrevented).toBe(false)
+    expect(getZoomPercent()).toBe(100)
+
+    const zoomWheel = dispatchWheel(surface, { deltaY: -120, ctrlKey: true })
+    expect(zoomWheel.defaultPrevented).toBe(true)
+    expect(getZoomPercent()).toBeGreaterThan(100)
+  })
+
+  it('disables each control at its zoom bound', () => {
+    const surface = renderSurface()
+    const zoomIn = screen.getByRole('button', { name: 'Zoom in' }) as HTMLButtonElement
+    const zoomOut = screen.getByRole('button', { name: 'Zoom out' }) as HTMLButtonElement
+    const fit = screen.getByRole('button', { name: 'Fit diagram' }) as HTMLButtonElement
+
+    expect(fit.disabled).toBe(true)
+
+    // Why: a single event is deliberately capped, so reaching a bound takes
+    // several gestures rather than one huge delta.
+    for (let index = 0; index < 10; index += 1) {
+      dispatchWheel(surface, { deltaY: -1000, ctrlKey: true })
+    }
+    expect(getZoomPercent()).toBe(MAX_SURFACE_ZOOM * 100)
+    expect(zoomIn.disabled).toBe(true)
+
+    for (let index = 0; index < 10; index += 1) {
+      dispatchWheel(surface, { deltaY: 1000, ctrlKey: true })
+    }
+    expect(getZoomPercent()).toBe(MIN_SURFACE_ZOOM * 100)
+    expect(zoomOut.disabled).toBe(true)
+  })
+
+  it('pans the surface by dragging inside the diagram', () => {
+    const surface = renderSurface()
+    setScrollExtents(surface, { horizontal: true })
+    const { setPointerCapture, releasePointerCapture } = stubPointerCapture(surface)
+    surface.scrollLeft = 120
+    surface.scrollTop = 40
+
+    dispatchPointer(surface, 'pointerdown', { clientX: 300, clientY: 200 })
+    expect(setPointerCapture).toHaveBeenCalledWith(1)
+
+    dispatchPointer(surface, 'pointermove', { clientX: 260, clientY: 175 })
+    expect(surface.scrollLeft).toBe(160)
+    expect(surface.scrollTop).toBe(65)
+
+    // Each move is measured from the press, not from the previous move.
+    dispatchPointer(surface, 'pointermove', { clientX: 250, clientY: 170 })
+    expect(surface.scrollLeft).toBe(170)
+    expect(surface.scrollTop).toBe(70)
+
+    dispatchPointer(surface, 'pointerup', { clientX: 250, clientY: 170 })
+    expect(releasePointerCapture).toHaveBeenCalledWith(1)
+
+    dispatchPointer(surface, 'pointermove', { clientX: 100, clientY: 100 })
+    expect(surface.scrollLeft).toBe(170)
+  })
+
+  it('does not start a pan when the diagram already fits', () => {
+    const surface = renderSurface()
+    setScrollExtents(surface, { horizontal: false })
+    Object.defineProperty(surface, 'scrollHeight', {
+      configurable: true,
+      get: () => SURFACE_HEIGHT
+    })
+    const { setPointerCapture } = stubPointerCapture(surface)
+    surface.scrollLeft = 0
+
+    dispatchPointer(surface, 'pointerdown', { clientX: 300, clientY: 200 })
+    dispatchPointer(surface, 'pointermove', { clientX: 200, clientY: 200 })
+
+    expect(setPointerCapture).not.toHaveBeenCalled()
+    expect(surface.scrollLeft).toBe(0)
+  })
+
+  it('leaves touch drags to native scrolling', () => {
+    const surface = renderSurface()
+    setScrollExtents(surface, { horizontal: true })
+    const { setPointerCapture } = stubPointerCapture(surface)
+    surface.scrollLeft = 50
+
+    dispatchPointer(surface, 'pointerdown', { clientX: 300, clientY: 200, pointerType: 'touch' })
+    dispatchPointer(surface, 'pointermove', { clientX: 200, clientY: 200, pointerType: 'touch' })
+
+    expect(setPointerCapture).not.toHaveBeenCalled()
+    expect(surface.scrollLeft).toBe(50)
+  })
+
+  it('stops panning when the pointer capture is lost', () => {
+    const surface = renderSurface()
+    setScrollExtents(surface, { horizontal: true })
+    stubPointerCapture(surface)
+    surface.scrollLeft = 0
+
+    dispatchPointer(surface, 'pointerdown', { clientX: 300, clientY: 200 })
+    dispatchPointer(surface, 'pointercancel', { clientX: 300, clientY: 200 })
+    dispatchPointer(surface, 'pointermove', { clientX: 100, clientY: 200 })
+
+    expect(surface.scrollLeft).toBe(0)
+  })
+
+  it('advertises a grab cursor only once the diagram can be panned', () => {
+    const surface = renderSurface()
+    expect(surface.className).not.toContain('cursor-grab')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }))
+
+    const zoomedSurface = document.querySelector('.mermaid-viewer')
+    expect(zoomedSurface?.className).toContain('cursor-grab')
+  })
+
+  it('detaches the wheel listener when the surface unmounts', () => {
+    const { container, unmount } = render(
+      <MermaidZoomSurface content="graph TD; a-->b" isDark={false} />
+    )
+    const surface = container.querySelector('.mermaid-viewer')
+    if (!(surface instanceof HTMLElement)) {
+      throw new Error('zoom surface not rendered')
+    }
+    const removeEventListener = vi.spyOn(surface, 'removeEventListener')
+
+    unmount()
+
+    expect(removeEventListener).toHaveBeenCalledWith('wheel', expect.any(Function))
+  })
+})

--- a/src/renderer/src/components/editor/MermaidZoomSurface.test.tsx
+++ b/src/renderer/src/components/editor/MermaidZoomSurface.test.tsx
@@ -10,6 +10,11 @@ const DIAGRAM_HEIGHT = 600
 const SURFACE_WIDTH = 400
 const SURFACE_HEIGHT = 400
 
+// Why: the error path reports a null size, which must leave the box unmeasured.
+const renderedSize: { current: { width: number; height: number } | null } = {
+  current: { width: DIAGRAM_WIDTH, height: DIAGRAM_HEIGHT }
+}
+
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
@@ -24,7 +29,7 @@ vi.mock('./MermaidBlock', async () => {
     onRendered?: (size: { width: number; height: number } | null) => void
   }) {
     useEffect(() => {
-      onRendered?.({ width: DIAGRAM_WIDTH, height: DIAGRAM_HEIGHT })
+      onRendered?.(renderedSize.current)
     }, [onRendered])
     return createElement('div', { className: 'mermaid-block', 'data-testid': 'mermaid-block' })
   }
@@ -37,6 +42,7 @@ const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototyp
 const originalClientHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientHeight')
 
 beforeEach(() => {
+  renderedSize.current = { width: DIAGRAM_WIDTH, height: DIAGRAM_HEIGHT }
   Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
     configurable: true,
     get: () => SURFACE_WIDTH
@@ -283,6 +289,16 @@ describe('MermaidZoomSurface', () => {
 
     const zoomedSurface = document.querySelector('.mermaid-viewer')
     expect(zoomedSurface?.className).toContain('cursor-grab')
+  })
+
+  it('leaves the box unmeasured and hides the controls when the diagram fails to render', () => {
+    renderedSize.current = null
+    renderSurface()
+
+    const box = getDiagramBox()
+    expect(box.dataset.zoomLayout).toBe('false')
+    expect(box.style.width).toBe('')
+    expect(screen.queryByRole('button', { name: 'Zoom in' })).toBeNull()
   })
 
   it('detaches the wheel listener when the surface unmounts', () => {

--- a/src/renderer/src/components/editor/MermaidZoomSurface.tsx
+++ b/src/renderer/src/components/editor/MermaidZoomSurface.tsx
@@ -1,0 +1,233 @@
+import { RotateCcw, ZoomIn, ZoomOut } from 'lucide-react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import MermaidBlock from './MermaidBlock'
+import {
+  type SurfacePanOrigin,
+  getPannedScrollOffsets,
+  shouldStartSurfacePan
+} from './surface-drag-pan'
+import {
+  type ApplySurfaceZoomChange,
+  applyAnchoredSurfaceZoomChange,
+  applySurfaceWheel,
+  getElementSurfaceSize,
+  getSurfaceLayoutStyle
+} from './surface-dom-zoom'
+import {
+  MAX_SURFACE_ZOOM,
+  MIN_SURFACE_ZOOM,
+  SURFACE_ZOOM_STEP,
+  type SurfaceContentDimensions,
+  type SurfaceSize,
+  getZoomedSurfaceLayoutSize
+} from './surface-zoom'
+
+// Why: must match the .mermaid-viewer-canvas padding, or the fitted diagram
+// overflows the surface at 100% and reports itself as pannable.
+const MERMAID_CANVAS_PADDING = 24
+
+type MermaidZoomSurfaceProps = {
+  content: string
+  isDark: boolean
+  // Why: the caller owns scroll-position memory, so it needs the same element
+  // this surface scrolls and zooms.
+  surfaceRef?: React.RefObject<HTMLDivElement | null>
+}
+
+/**
+ * Scroll-and-zoom surface for a rendered mermaid diagram. Zoom resizes the
+ * diagram's layout box rather than transforming it, so scroll extents grow with
+ * zoom and panning reaches the whole diagram.
+ */
+export default function MermaidZoomSurface({
+  content,
+  isDark,
+  surfaceRef
+}: MermaidZoomSurfaceProps): React.JSX.Element {
+  const [zoom, setZoom] = useState(1)
+  const [surfaceSize, setSurfaceSize] = useState<SurfaceSize | null>(null)
+  const [diagramSize, setDiagramSize] = useState<SurfaceContentDimensions | null>(null)
+  const localSurfaceRef = useRef<HTMLDivElement | null>(null)
+  const panOriginRef = useRef<SurfacePanOrigin | null>(null)
+
+  const layoutSize = getZoomedSurfaceLayoutSize({
+    contentDimensions: diagramSize,
+    surfaceSize,
+    zoom,
+    padding: MERMAID_CANVAS_PADDING
+  })
+  const layoutStyle = getSurfaceLayoutStyle(layoutSize)
+
+  const applyZoomChange = useCallback<ApplySurfaceZoomChange>((getNextZoom, anchor) => {
+    applyAnchoredSurfaceZoomChange(localSurfaceRef.current, setZoom, getNextZoom, anchor)
+  }, [])
+  const handleSurfaceWheel = useCallback(
+    (event: WheelEvent) => {
+      applySurfaceWheel(event, applyZoomChange)
+    },
+    [applyZoomChange]
+  )
+  const setSurfaceRef = useCallback(
+    (surface: HTMLDivElement | null) => {
+      if (localSurfaceRef.current) {
+        localSurfaceRef.current.removeEventListener('wheel', handleSurfaceWheel)
+      }
+      localSurfaceRef.current = surface
+      if (surfaceRef) {
+        surfaceRef.current = surface
+      }
+      if (surface) {
+        setSurfaceSize(getElementSurfaceSize(surface))
+        // Why: Chromium exposes trackpad pinch as ctrl-wheel and requires a
+        // native non-passive listener to stop browser/app zoom.
+        surface.addEventListener('wheel', handleSurfaceWheel, { passive: false })
+      } else {
+        setSurfaceSize(null)
+      }
+    },
+    [handleSurfaceWheel, surfaceRef]
+  )
+
+  useEffect(() => {
+    const surface = localSurfaceRef.current
+    if (!surface || typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    const observer = new ResizeObserver(() => setSurfaceSize(getElementSurfaceSize(surface)))
+    observer.observe(surface)
+    return () => observer.disconnect()
+  }, [])
+
+  const endPan = useCallback((pointerId: number): boolean => {
+    if (panOriginRef.current?.pointerId !== pointerId) {
+      return false
+    }
+    panOriginRef.current = null
+    return true
+  }, [])
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const surface = localSurfaceRef.current
+    if (!surface || panOriginRef.current || !shouldStartSurfacePan(event)) {
+      return
+    }
+    const canPan =
+      surface.scrollWidth > surface.clientWidth || surface.scrollHeight > surface.clientHeight
+    if (!canPan) {
+      return
+    }
+
+    panOriginRef.current = {
+      pointerId: event.pointerId,
+      clientX: event.clientX,
+      clientY: event.clientY,
+      scrollLeft: surface.scrollLeft,
+      scrollTop: surface.scrollTop
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }, [])
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const origin = panOriginRef.current
+    const surface = localSurfaceRef.current
+    if (!origin || !surface || origin.pointerId !== event.pointerId) {
+      return
+    }
+
+    const { scrollLeft, scrollTop } = getPannedScrollOffsets(origin, event.clientX, event.clientY)
+    surface.scrollLeft = scrollLeft
+    surface.scrollTop = scrollTop
+  }, [])
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (endPan(event.pointerId)) {
+        event.currentTarget.releasePointerCapture(event.pointerId)
+      }
+    },
+    [endPan]
+  )
+  const handlePointerCancel = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      endPan(event.pointerId)
+    },
+    [endPan]
+  )
+
+  const zoomPercent = Math.round(zoom * 100)
+  const hasDiagram = diagramSize !== null
+  const isPannable = zoom > 1
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col">
+      <div
+        ref={setSurfaceRef}
+        className={cn(
+          'mermaid-viewer min-h-0 flex-1 overflow-auto scrollbar-editor',
+          isPannable && 'cursor-grab select-none active:cursor-grabbing'
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onLostPointerCapture={handlePointerCancel}
+      >
+        <div className="mermaid-viewer-canvas">
+          <div
+            className="mermaid-diagram-box"
+            data-zoom-layout={layoutSize ? 'true' : 'false'}
+            style={layoutStyle}
+          >
+            {/* Why: DOMPurify's SVG profile strips <foreignObject> elements that
+               mermaid uses for HTML labels. Force SVG-native <text> labels so
+               they survive sanitization — same fix as the markdown preview path. */}
+            <MermaidBlock
+              content={content}
+              isDark={isDark}
+              htmlLabels={false}
+              onRendered={setDiagramSize}
+            />
+          </div>
+        </div>
+      </div>
+      {hasDiagram && (
+        <div className="absolute bottom-3 left-3 flex items-center gap-0.5 rounded-md border border-border bg-card p-0.5 shadow-xs">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate('editor.mermaidDiagram.zoomOut', 'Zoom out')}
+            disabled={zoom <= MIN_SURFACE_ZOOM}
+            onClick={() => applyZoomChange((currentZoom) => currentZoom / SURFACE_ZOOM_STEP)}
+          >
+            <ZoomOut className="size-3" />
+          </Button>
+          <span className="min-w-12 text-center text-[10px] text-muted-foreground tabular-nums">
+            {zoomPercent}%
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate('editor.mermaidDiagram.zoomIn', 'Zoom in')}
+            disabled={zoom >= MAX_SURFACE_ZOOM}
+            onClick={() => applyZoomChange((currentZoom) => currentZoom * SURFACE_ZOOM_STEP)}
+          >
+            <ZoomIn className="size-3" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate('editor.mermaidDiagram.resetZoom', 'Fit diagram')}
+            disabled={zoom === 1}
+            onClick={() => applyZoomChange(() => 1)}
+          >
+            <RotateCcw className="size-3" />
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/mermaid-diagram-size.test.ts
+++ b/src/renderer/src/components/editor/mermaid-diagram-size.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { getRenderedDiagramSize, parseDiagramViewBoxSize } from './mermaid-diagram-size'
+
+function renderContainer(svgMarkup: string): HTMLDivElement {
+  const container = document.createElement('div')
+  container.innerHTML = svgMarkup
+  return container
+}
+
+describe('parseDiagramViewBoxSize', () => {
+  it('reads width and height from a viewBox', () => {
+    expect(parseDiagramViewBoxSize('0 0 640 480')).toEqual({ width: 640, height: 480 })
+  })
+
+  it('ignores the viewBox origin so offset diagrams keep their real size', () => {
+    expect(parseDiagramViewBoxSize('-8 -8 200 100')).toEqual({ width: 200, height: 100 })
+  })
+
+  it('accepts comma-separated values', () => {
+    expect(parseDiagramViewBoxSize('0,0,120,60')).toEqual({ width: 120, height: 60 })
+  })
+
+  it('rejects malformed, empty, and non-positive viewBoxes', () => {
+    expect(parseDiagramViewBoxSize(null)).toBeNull()
+    expect(parseDiagramViewBoxSize('')).toBeNull()
+    expect(parseDiagramViewBoxSize('0 0 640')).toBeNull()
+    expect(parseDiagramViewBoxSize('0 0 wide 480')).toBeNull()
+    expect(parseDiagramViewBoxSize('0 0 0 480')).toBeNull()
+    expect(parseDiagramViewBoxSize('0 0 -640 480')).toBeNull()
+  })
+})
+
+describe('getRenderedDiagramSize', () => {
+  it('prefers the viewBox over the percentage width mermaid emits by default', () => {
+    const container = renderContainer(
+      '<svg width="100%" style="max-width: 640px;" viewBox="0 0 640 480"></svg>'
+    )
+
+    expect(getRenderedDiagramSize(container)).toEqual({ width: 640, height: 480 })
+  })
+
+  it('falls back to px width and height attributes when useMaxWidth is off', () => {
+    const container = renderContainer('<svg width="320" height="240"></svg>')
+
+    expect(getRenderedDiagramSize(container)).toEqual({ width: 320, height: 240 })
+  })
+
+  it('returns null when only a percentage width is available', () => {
+    const container = renderContainer('<svg width="100%" height="100%"></svg>')
+
+    expect(getRenderedDiagramSize(container)).toBeNull()
+  })
+
+  it('returns null for a missing container or an unrendered diagram', () => {
+    expect(getRenderedDiagramSize(null)).toBeNull()
+    expect(getRenderedDiagramSize(renderContainer(''))).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/mermaid-diagram-size.ts
+++ b/src/renderer/src/components/editor/mermaid-diagram-size.ts
@@ -1,0 +1,52 @@
+import type { SurfaceContentDimensions } from './surface-zoom'
+
+// Why: with the default useMaxWidth, mermaid emits width="100%" plus an inline
+// max-width, so the viewBox is the only place the diagram's real size survives.
+export function parseDiagramViewBoxSize(viewBox: string | null): SurfaceContentDimensions | null {
+  if (!viewBox) {
+    return null
+  }
+
+  const parts = viewBox
+    .trim()
+    .split(/[\s,]+/)
+    .map(Number)
+  if (parts.length !== 4 || parts.some((part) => !Number.isFinite(part))) {
+    return null
+  }
+
+  const [, , width, height] = parts
+  if (width <= 0 || height <= 0) {
+    return null
+  }
+
+  return { width, height }
+}
+
+function parseDiagramLengthAttribute(value: string | null): number | null {
+  if (!value || value.endsWith('%')) {
+    return null
+  }
+
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+}
+
+export function getRenderedDiagramSize(
+  container: HTMLElement | null
+): SurfaceContentDimensions | null {
+  const svg = container?.querySelector('svg')
+  if (!svg) {
+    return null
+  }
+
+  const viewBoxSize = parseDiagramViewBoxSize(svg.getAttribute('viewBox'))
+  if (viewBoxSize) {
+    return viewBoxSize
+  }
+
+  // Why: useMaxWidth: false diagrams carry px width/height attributes instead.
+  const width = parseDiagramLengthAttribute(svg.getAttribute('width'))
+  const height = parseDiagramLengthAttribute(svg.getAttribute('height'))
+  return width !== null && height !== null ? { width, height } : null
+}

--- a/src/renderer/src/components/editor/surface-dom-zoom.ts
+++ b/src/renderer/src/components/editor/surface-dom-zoom.ts
@@ -1,29 +1,29 @@
 import type { CSSProperties, Dispatch, SetStateAction } from 'react'
 import { flushSync } from 'react-dom'
 import {
-  type ImageViewerImageDimensions,
-  type ImageViewerSurfaceSize,
-  type ImageViewerZoomAnchor,
-  clampImageViewerZoom,
-  getAnchoredImageViewerScrollOffset,
-  getNextWheelImageViewerZoom,
-  shouldHandleImageZoomWheel
-} from './image-viewer-zoom'
+  type SurfaceContentDimensions,
+  type SurfaceSize,
+  type SurfaceZoomAnchor,
+  clampSurfaceZoom,
+  getAnchoredSurfaceScrollOffset,
+  getNextWheelSurfaceZoom,
+  shouldHandleSurfaceZoomWheel
+} from './surface-zoom'
 
-export type ApplyImageViewerZoomChange = (
+export type ApplySurfaceZoomChange = (
   getNextZoom: (currentZoom: number) => number,
-  anchor?: ImageViewerZoomAnchor | null
+  anchor?: SurfaceZoomAnchor | null
 ) => void
 
-export function getElementSurfaceSize(element: HTMLElement): ImageViewerSurfaceSize {
+export function getElementSurfaceSize(element: HTMLElement): SurfaceSize {
   return {
     width: element.clientWidth,
     height: element.clientHeight
   }
 }
 
-export function getImageLayoutStyle(
-  size: ImageViewerImageDimensions | null
+export function getSurfaceLayoutStyle(
+  size: SurfaceContentDimensions | null
 ): CSSProperties | undefined {
   if (!size) {
     return undefined
@@ -35,11 +35,11 @@ export function getImageLayoutStyle(
   }
 }
 
-export function applyAnchoredImageViewerZoomChange(
+export function applyAnchoredSurfaceZoomChange(
   surface: HTMLDivElement | null,
   setZoom: Dispatch<SetStateAction<number>>,
   getNextZoom: (currentZoom: number) => number,
-  anchor?: ImageViewerZoomAnchor | null
+  anchor?: SurfaceZoomAnchor | null
 ): void {
   const resolvedAnchor = surface
     ? (anchor ?? { x: surface.clientWidth / 2, y: surface.clientHeight / 2 })
@@ -52,7 +52,7 @@ export function applyAnchoredImageViewerZoomChange(
   flushSync(() => {
     setZoom((current) => {
       currentZoom = current
-      nextZoom = clampImageViewerZoom(getNextZoom(current))
+      nextZoom = clampSurfaceZoom(getNextZoom(current))
       return nextZoom
     })
   })
@@ -61,13 +61,13 @@ export function applyAnchoredImageViewerZoomChange(
     return
   }
 
-  surface.scrollLeft = getAnchoredImageViewerScrollOffset({
+  surface.scrollLeft = getAnchoredSurfaceScrollOffset({
     scrollOffset: scrollLeft,
     anchorOffset: resolvedAnchor.x,
     currentZoom,
     nextZoom
   })
-  surface.scrollTop = getAnchoredImageViewerScrollOffset({
+  surface.scrollTop = getAnchoredSurfaceScrollOffset({
     scrollOffset: scrollTop,
     anchorOffset: resolvedAnchor.y,
     currentZoom,
@@ -75,11 +75,11 @@ export function applyAnchoredImageViewerZoomChange(
   })
 }
 
-export function applyImageSurfaceWheel(
+export function applySurfaceWheel(
   event: WheelEvent,
-  applyZoomChange: ApplyImageViewerZoomChange
+  applyZoomChange: ApplySurfaceZoomChange
 ): void {
-  if (!shouldHandleImageZoomWheel(event)) {
+  if (!shouldHandleSurfaceZoomWheel(event)) {
     return
   }
 
@@ -88,7 +88,7 @@ export function applyImageSurfaceWheel(
   const surface = event.currentTarget instanceof HTMLDivElement ? event.currentTarget : null
   const rect = surface?.getBoundingClientRect()
   applyZoomChange(
-    (currentZoom) => getNextWheelImageViewerZoom(currentZoom, event.deltaY, event.deltaMode),
+    (currentZoom) => getNextWheelSurfaceZoom(currentZoom, event.deltaY, event.deltaMode),
     rect ? { x: event.clientX - rect.left, y: event.clientY - rect.top } : null
   )
 }

--- a/src/renderer/src/components/editor/surface-drag-pan.test.ts
+++ b/src/renderer/src/components/editor/surface-drag-pan.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { getPannedScrollOffsets, shouldStartSurfacePan } from './surface-drag-pan'
+
+const origin = {
+  pointerId: 1,
+  clientX: 200,
+  clientY: 150,
+  scrollLeft: 400,
+  scrollTop: 300
+}
+
+describe('shouldStartSurfacePan', () => {
+  it('starts on a primary mouse or pen press', () => {
+    expect(shouldStartSurfacePan({ button: 0, pointerType: 'mouse' })).toBe(true)
+    expect(shouldStartSurfacePan({ button: 0, pointerType: 'pen' })).toBe(true)
+  })
+
+  it('ignores secondary buttons', () => {
+    expect(shouldStartSurfacePan({ button: 1, pointerType: 'mouse' })).toBe(false)
+    expect(shouldStartSurfacePan({ button: 2, pointerType: 'mouse' })).toBe(false)
+  })
+
+  it('leaves touch to native scrolling', () => {
+    expect(shouldStartSurfacePan({ button: 0, pointerType: 'touch' })).toBe(false)
+  })
+})
+
+describe('getPannedScrollOffsets', () => {
+  it('moves the content with the pointer, so scroll goes the opposite way', () => {
+    expect(getPannedScrollOffsets(origin, 250, 200)).toEqual({
+      scrollLeft: 350,
+      scrollTop: 250
+    })
+    expect(getPannedScrollOffsets(origin, 150, 100)).toEqual({
+      scrollLeft: 450,
+      scrollTop: 350
+    })
+  })
+
+  it('is anchored to the press, not to the previous move', () => {
+    const first = getPannedScrollOffsets(origin, 210, 160)
+    const second = getPannedScrollOffsets(origin, 220, 170)
+
+    expect(first).toEqual({ scrollLeft: 390, scrollTop: 290 })
+    expect(second).toEqual({ scrollLeft: 380, scrollTop: 280 })
+  })
+
+  it('keeps the offsets unchanged when the pointer has not moved', () => {
+    expect(getPannedScrollOffsets(origin, origin.clientX, origin.clientY)).toEqual({
+      scrollLeft: origin.scrollLeft,
+      scrollTop: origin.scrollTop
+    })
+  })
+})

--- a/src/renderer/src/components/editor/surface-drag-pan.ts
+++ b/src/renderer/src/components/editor/surface-drag-pan.ts
@@ -22,6 +22,9 @@ export function shouldStartSurfacePan(event: SurfacePanPointerEventLike): boolea
   return event.button === 0 && event.pointerType !== 'touch'
 }
 
+// Why: the content follows the pointer, so scroll moves against it, and both
+// offsets are measured from the press rather than the previous move so a drag
+// cannot accumulate rounding drift.
 export function getPannedScrollOffsets(
   origin: SurfacePanOrigin,
   clientX: number,

--- a/src/renderer/src/components/editor/surface-drag-pan.ts
+++ b/src/renderer/src/components/editor/surface-drag-pan.ts
@@ -1,0 +1,34 @@
+export type SurfacePanOrigin = {
+  pointerId: number
+  clientX: number
+  clientY: number
+  scrollLeft: number
+  scrollTop: number
+}
+
+type SurfacePanPointerEventLike = {
+  button: number
+  pointerType: string
+}
+
+export type SurfaceScrollOffsets = {
+  scrollLeft: number
+  scrollTop: number
+}
+
+// Why: touch already pans through native scrolling, and claiming the pointer
+// there would fight the browser's own gesture handling.
+export function shouldStartSurfacePan(event: SurfacePanPointerEventLike): boolean {
+  return event.button === 0 && event.pointerType !== 'touch'
+}
+
+export function getPannedScrollOffsets(
+  origin: SurfacePanOrigin,
+  clientX: number,
+  clientY: number
+): SurfaceScrollOffsets {
+  return {
+    scrollLeft: origin.scrollLeft - (clientX - origin.clientX),
+    scrollTop: origin.scrollTop - (clientY - origin.clientY)
+  }
+}

--- a/src/renderer/src/components/editor/surface-zoom.test.ts
+++ b/src/renderer/src/components/editor/surface-zoom.test.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import {
-  MAX_IMAGE_VIEWER_ZOOM,
-  MIN_IMAGE_VIEWER_ZOOM,
-  clampImageViewerZoom,
-  getAnchoredImageViewerScrollOffset,
-  getNextWheelImageViewerZoom,
+  MAX_SURFACE_ZOOM,
+  MIN_SURFACE_ZOOM,
+  clampSurfaceZoom,
+  getAnchoredSurfaceScrollOffset,
+  getNextWheelSurfaceZoom,
   getPinchZoomFactor,
-  getZoomedImageLayoutSize,
-  shouldHandleImageZoomWheel
-} from './image-viewer-zoom'
+  getZoomedSurfaceLayoutSize,
+  shouldHandleSurfaceZoomWheel
+} from './surface-zoom'
 
-describe('image viewer zoom helpers', () => {
+describe('surface zoom helpers', () => {
   it('clamps zoom to the viewer bounds', () => {
-    expect(clampImageViewerZoom(0.01)).toBe(MIN_IMAGE_VIEWER_ZOOM)
-    expect(clampImageViewerZoom(1)).toBe(1)
-    expect(clampImageViewerZoom(20)).toBe(MAX_IMAGE_VIEWER_ZOOM)
+    expect(clampSurfaceZoom(0.01)).toBe(MIN_SURFACE_ZOOM)
+    expect(clampSurfaceZoom(1)).toBe(1)
+    expect(clampSurfaceZoom(20)).toBe(MAX_SURFACE_ZOOM)
   })
 
   it('handles only ctrl-wheel input as image zoom', () => {
-    expect(shouldHandleImageZoomWheel({ ctrlKey: true })).toBe(true)
-    expect(shouldHandleImageZoomWheel({ ctrlKey: false })).toBe(false)
+    expect(shouldHandleSurfaceZoomWheel({ ctrlKey: true })).toBe(true)
+    expect(shouldHandleSurfaceZoomWheel({ ctrlKey: false })).toBe(false)
   })
 
   it('maps negative wheel deltas to zoom in and positive deltas to zoom out', () => {
-    expect(getNextWheelImageViewerZoom(1, -30, 0)).toBeGreaterThan(1)
-    expect(getNextWheelImageViewerZoom(1, 30, 0)).toBeLessThan(1)
+    expect(getNextWheelSurfaceZoom(1, -30, 0)).toBeGreaterThan(1)
+    expect(getNextWheelSurfaceZoom(1, 30, 0)).toBeLessThan(1)
   })
 
   it('keeps zero wheel delta from changing zoom while still being handleable', () => {
     expect(getPinchZoomFactor(0, 0)).toBe(1)
-    expect(getNextWheelImageViewerZoom(1.5, 0, 0)).toBe(1.5)
-    expect(shouldHandleImageZoomWheel({ ctrlKey: true })).toBe(true)
+    expect(getNextWheelSurfaceZoom(1.5, 0, 0)).toBe(1.5)
+    expect(shouldHandleSurfaceZoomWheel({ ctrlKey: true })).toBe(true)
   })
 
   it('normalizes line and page wheel delta modes', () => {
@@ -50,21 +50,21 @@ describe('image viewer zoom helpers', () => {
   })
 
   it('stays clamped at min and max zoom for pinch gestures', () => {
-    expect(getNextWheelImageViewerZoom(MIN_IMAGE_VIEWER_ZOOM, 100, 0)).toBe(MIN_IMAGE_VIEWER_ZOOM)
-    expect(getNextWheelImageViewerZoom(MAX_IMAGE_VIEWER_ZOOM, -100, 0)).toBe(MAX_IMAGE_VIEWER_ZOOM)
+    expect(getNextWheelSurfaceZoom(MIN_SURFACE_ZOOM, 100, 0)).toBe(MIN_SURFACE_ZOOM)
+    expect(getNextWheelSurfaceZoom(MAX_SURFACE_ZOOM, -100, 0)).toBe(MAX_SURFACE_ZOOM)
   })
 
   it('uses fitted image dimensions as the base layout size before zooming', () => {
     expect(
-      getZoomedImageLayoutSize({
-        imageDimensions: { width: 1000, height: 500 },
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: { width: 1000, height: 500 },
         surfaceSize: { width: 500, height: 500 },
         zoom: 1
       })
     ).toEqual({ width: 468, height: 234 })
     expect(
-      getZoomedImageLayoutSize({
-        imageDimensions: { width: 1000, height: 500 },
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: { width: 1000, height: 500 },
         surfaceSize: { width: 500, height: 500 },
         zoom: 2
       })
@@ -73,15 +73,15 @@ describe('image viewer zoom helpers', () => {
 
   it('does not upscale images at 100 percent before applying user zoom', () => {
     expect(
-      getZoomedImageLayoutSize({
-        imageDimensions: { width: 200, height: 100 },
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: { width: 200, height: 100 },
         surfaceSize: { width: 800, height: 600 },
         zoom: 1
       })
     ).toEqual({ width: 200, height: 100 })
     expect(
-      getZoomedImageLayoutSize({
-        imageDimensions: { width: 200, height: 100 },
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: { width: 200, height: 100 },
         surfaceSize: { width: 800, height: 600 },
         zoom: 2
       })
@@ -90,15 +90,15 @@ describe('image viewer zoom helpers', () => {
 
   it('returns no layout size until image and surface dimensions are available', () => {
     expect(
-      getZoomedImageLayoutSize({
-        imageDimensions: null,
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: null,
         surfaceSize: { width: 800, height: 600 },
         zoom: 1
       })
     ).toBeNull()
     expect(
-      getZoomedImageLayoutSize({
-        imageDimensions: { width: 200, height: 100 },
+      getZoomedSurfaceLayoutSize({
+        contentDimensions: { width: 200, height: 100 },
         surfaceSize: null,
         zoom: 1
       })
@@ -107,7 +107,7 @@ describe('image viewer zoom helpers', () => {
 
   it('keeps the zoom anchor stable by moving the scroll offset', () => {
     expect(
-      getAnchoredImageViewerScrollOffset({
+      getAnchoredSurfaceScrollOffset({
         scrollOffset: 100,
         anchorOffset: 200,
         currentZoom: 1,
@@ -115,7 +115,7 @@ describe('image viewer zoom helpers', () => {
       })
     ).toBe(400)
     expect(
-      getAnchoredImageViewerScrollOffset({
+      getAnchoredSurfaceScrollOffset({
         scrollOffset: 400,
         anchorOffset: 200,
         currentZoom: 2,
@@ -126,7 +126,7 @@ describe('image viewer zoom helpers', () => {
 
   it('leaves scroll unchanged when the current zoom is invalid', () => {
     expect(
-      getAnchoredImageViewerScrollOffset({
+      getAnchoredSurfaceScrollOffset({
         scrollOffset: 100,
         anchorOffset: 200,
         currentZoom: 0,

--- a/src/renderer/src/components/editor/surface-zoom.ts
+++ b/src/renderer/src/components/editor/surface-zoom.ts
@@ -1,7 +1,7 @@
-export const MIN_IMAGE_VIEWER_ZOOM = 0.25
-export const MAX_IMAGE_VIEWER_ZOOM = 8
-export const IMAGE_VIEWER_ZOOM_STEP = 1.25
-export const IMAGE_VIEWER_SURFACE_PADDING = 16
+export const MIN_SURFACE_ZOOM = 0.25
+export const MAX_SURFACE_ZOOM = 8
+export const SURFACE_ZOOM_STEP = 1.25
+export const SURFACE_ZOOM_PADDING = 16
 
 const DOM_DELTA_LINE = 1
 const DOM_DELTA_PAGE = 2
@@ -10,30 +10,30 @@ const PIXELS_PER_PAGE = 800
 const MAX_NORMALIZED_WHEEL_DELTA = 200
 const WHEEL_ZOOM_SENSITIVITY = 300
 
-type ImageZoomWheelEventLike = {
+type SurfaceZoomWheelEventLike = {
   ctrlKey: boolean
 }
 
-export type ImageViewerImageDimensions = {
+export type SurfaceContentDimensions = {
   width: number
   height: number
 }
 
-export type ImageViewerSurfaceSize = {
+export type SurfaceSize = {
   width: number
   height: number
 }
 
-export type ImageViewerZoomAnchor = {
+export type SurfaceZoomAnchor = {
   x: number
   y: number
 }
 
-export function clampImageViewerZoom(next: number): number {
-  return Math.min(MAX_IMAGE_VIEWER_ZOOM, Math.max(MIN_IMAGE_VIEWER_ZOOM, next))
+export function clampSurfaceZoom(next: number): number {
+  return Math.min(MAX_SURFACE_ZOOM, Math.max(MIN_SURFACE_ZOOM, next))
 }
 
-export function shouldHandleImageZoomWheel(event: ImageZoomWheelEventLike): boolean {
+export function shouldHandleSurfaceZoomWheel(event: SurfaceZoomWheelEventLike): boolean {
   return event.ctrlKey
 }
 
@@ -56,30 +56,30 @@ export function getPinchZoomFactor(deltaY: number, deltaMode: number): number {
   return Math.exp(-boundedDeltaY / WHEEL_ZOOM_SENSITIVITY)
 }
 
-export function getNextWheelImageViewerZoom(
+export function getNextWheelSurfaceZoom(
   currentZoom: number,
   deltaY: number,
   deltaMode: number
 ): number {
-  return clampImageViewerZoom(currentZoom * getPinchZoomFactor(deltaY, deltaMode))
+  return clampSurfaceZoom(currentZoom * getPinchZoomFactor(deltaY, deltaMode))
 }
 
-export function getZoomedImageLayoutSize({
-  imageDimensions,
+export function getZoomedSurfaceLayoutSize({
+  contentDimensions,
   surfaceSize,
   zoom,
-  padding = IMAGE_VIEWER_SURFACE_PADDING
+  padding = SURFACE_ZOOM_PADDING
 }: {
-  imageDimensions: ImageViewerImageDimensions | null
-  surfaceSize: ImageViewerSurfaceSize | null
+  contentDimensions: SurfaceContentDimensions | null
+  surfaceSize: SurfaceSize | null
   zoom: number
   padding?: number
-}): ImageViewerImageDimensions | null {
+}): SurfaceContentDimensions | null {
   if (
-    !imageDimensions ||
+    !contentDimensions ||
     !surfaceSize ||
-    imageDimensions.width <= 0 ||
-    imageDimensions.height <= 0 ||
+    contentDimensions.width <= 0 ||
+    contentDimensions.height <= 0 ||
     surfaceSize.width <= 0 ||
     surfaceSize.height <= 0
   ) {
@@ -94,20 +94,20 @@ export function getZoomedImageLayoutSize({
 
   const fitScale = Math.min(
     1,
-    availableWidth / imageDimensions.width,
-    availableHeight / imageDimensions.height
+    availableWidth / contentDimensions.width,
+    availableHeight / contentDimensions.height
   )
-  const boundedZoom = clampImageViewerZoom(zoom)
+  const boundedZoom = clampSurfaceZoom(zoom)
 
-  // Why: transformed images do not change scroll extents, so zoom must resize
-  // the layout box for popup panning to reach the full image.
+  // Why: transformed content does not change scroll extents, so zoom must resize
+  // the layout box for panning to reach the full image or diagram.
   return {
-    width: imageDimensions.width * fitScale * boundedZoom,
-    height: imageDimensions.height * fitScale * boundedZoom
+    width: contentDimensions.width * fitScale * boundedZoom,
+    height: contentDimensions.height * fitScale * boundedZoom
   }
 }
 
-export function getAnchoredImageViewerScrollOffset({
+export function getAnchoredSurfaceScrollOffset({
   scrollOffset,
   anchorOffset,
   currentZoom,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -104,6 +104,11 @@
     "richMarkdown": {
       "tooLarge": "File is larger than the {{limit}} rich editing limit. Showing source mode instead.",
       "openAnyway": "Open anyway"
+    },
+    "mermaidDiagram": {
+      "zoomIn": "Zoom in",
+      "zoomOut": "Zoom out",
+      "resetZoom": "Fit diagram"
     }
   },
   "githubChecks": {


### PR DESCRIPTION
## ELI5

Open a `.mmd` diagram in Orca today and it draws at exactly the width of the pane, forever. A wide flowchart comes out squashed until the labels are unreadable, and nothing you press changes that. `Cmd/Ctrl` `+` only grows the editor font, and the diagram itself carries no zoom control.

This adds zoom to the standalone diagram viewer. `Ctrl`-wheel or a trackpad pinch zooms toward the cursor, three buttons handle zoom in, zoom out, and fit, and once you are zoomed in you drag inside the diagram to move around it.

## What Changed

`MermaidZoomSurface` now owns the diagram's scroll box, a cursor-anchored wheel and pinch zoom, drag-to-pan, and a control cluster showing the current percentage.

Zoom resizes the diagram's layout box instead of applying a transform. `image-viewer-zoom.ts:102-107` already documents why: a CSS transform leaves scroll extents untouched, so a transform-based zoom looks correct but cannot pan to the edges.

The zoom engine is the image viewer's, generalized rather than copied, following the "Reuse Before Reimplementing" rule in `AGENTS.md`. `image-viewer-zoom.ts` and `image-viewer-dom-zoom.ts` become `surface-zoom.ts` and `surface-dom-zoom.ts` with surface-neutral names. The math inside was never image-specific. `ImageViewer` behavior does not change; only its import names moved.

`mermaid-diagram-size.ts` reads the diagram's intrinsic size from the SVG `viewBox`. Under mermaid's default `useMaxWidth`, `calculateSvgSizeAttrs` emits `width="100%"` plus an inline `style="max-width: …px"`, leaving the viewBox as the only place the real size survives.

`surface-drag-pan.ts` holds the panning math: whether a press should start a pan, and where the surface should scroll given a pointer position. Both are pure functions, so the drag behavior is testable without a layout engine.

`MermaidBlock` gains one optional `onRendered` prop so the surface can learn that size. The render queue, the DOMPurify SVG-profile pass, `securityLevel: 'strict'`, and `htmlLabels={false}` all stay as they were.

In CSS, the zoom surface overrides the two shrink-to-fit clamps only after it has measured the diagram, keyed on `[data-zoom-layout='true']`. Before measurement the rendering matches today's byte for byte.

## Why

`.mermaid-viewer-canvas .mermaid-block svg { width: 100% }` (`markdown-preview.css:729-732`) pins the SVG to the pane, so the `overflow-auto` container in `MermaidViewer` never has anything to scroll. Narrowing the pane shrinks the diagram rather than letting you inspect it at native size. `MermaidBlock` returns a bare `<div>` with no wheel handler, no transform state, and no controls. The app-level `Cmd/Ctrl` `+` is an editor font-size zoom (`zoom-ipc-bridge.ts:24-34` feeding `MarkdownPreviewSurface.tsx:53`), which mermaid's px-dimensioned geometry ignores. The diagram ends up as the one thing in the editor whose scale nothing can change.

Three decisions in this PR deserve their reasoning stated.

**Layout box over transform**, for the panning reason above.

**`flex: none` on the diagram box.** The box is a flex item inside `.mermaid-viewer-canvas`, and under the default `flex-shrink: 1` a zoomed box collapses straight back to the pane width. I found this only by rendering a real mermaid SVG in Chromium against these exact rules. happy-dom performs no layout, so no unit test could have caught it. Auto margins, rather than `justify-content: center`, keep the diagram centered without clipping its leading edge once it overflows.

**Canvas padding of 24px on every side.** The fit calculation and the CSS padding disagreed before this change (16px against 32/24px), which let a tall diagram overflow at 100%. Both now read 24, with a comment on each side pointing at the other.

### Relationship to existing work

#8731 asks for full-size viewing of Mermaid diagrams, scoped to Markdown preview. This PR covers the standalone `.mmd` and `.mermaid` viewer, which no open issue tracked before the linked one.

#11404 also builds a zoomable diagram surface for the `.mmd` viewer, but as part of a much larger change: editable Code, Split, and Chart modes across 17 files, declaring no closing issue. This PR deliberately carries only the zoom, on one surface, so it can land on its own. If you prefer #11404, close this one. If the narrow step is useful first, I can rebase around whatever lands.

#716 diagnosed this exact root cause in April ("mermaid emits many diagrams as fixed-size `<svg width=…>` elements … diagrams that already fit the pane appeared not to zoom at all") before it was closed unmerged.

Markdown preview, sidebar comments, and the rich editor share `MermaidBlock` and keep their current behavior. Those are separate surfaces and belong in separate PRs. Mobile disables zoom on purpose in three places and stays untouched.

## Linked Issue

Fixes #18467

## Visual Proof

The same `pipeline.mmd` in the same pane, on `main` and on this branch.

**Before**, on `main`: the diagram sits pinned to the pane width, labels unreadable, no controls, no scrollbar. Nothing moves it.

![before.png](https://github.com/user-attachments/assets/79e82c92-8889-4e9d-9929-5fb9e253306b)

**After**, fitted at 100%, with the control cluster at bottom left:

![after-100.png](https://github.com/user-attachments/assets/f1936f33-4a94-4c0d-80e8-e82593fc1a7a)

**After**, zoomed to 244%: readable labels and a horizontal scrollbar, because the layout box grew. Dragging inside the diagram pans it.

![after-zoomed.png](https://github.com/user-attachments/assets/d4cf22d8-5ec1-4bfc-89f4-2cdf06c2f882)

## Testing

- `pnpm tc`: pass
- `pnpm lint`: pass, including the four localization gates
- `pnpm build`: pass
- `pnpm run check:react-doctor:changed`: 0 issues
- `pnpm test`: 71162 passed, 10 failed, all 10 unrelated to this change and explained below

Tested by hand on macOS against a wide `flowchart LR` saved as a `.mmd` file: zoomed with the buttons, with `Ctrl`-wheel, and with a trackpad pinch; dragged inside the diagram to pan at high zoom; confirmed Fit returns to the fitted size; confirmed a plain wheel still scrolls.

Two diagrams cover both overflow directions. The wide `flowchart LR` in #18467 is the one in the screenshots above. This second one is large on both axes, so it also exercises vertical panning and the canvas-padding fix:

```mermaid
flowchart TB
    subgraph client[Client tier]
        web[Web app] --> bff[BFF gateway]
        mobile[Mobile app] --> bff
        cli[CLI] --> bff
    end
    subgraph core[Core services]
        bff --> auth[Auth service]
        bff --> catalog[Catalog service]
        bff --> orders[Order service]
        orders --> payments[Payment service]
        orders --> inventory[Inventory service]
        payments --> ledger[Ledger]
    end
    subgraph data[Data platform]
        catalog --> search[(Search index)]
        orders --> events[[Event bus]]
        events --> warehouse[(Warehouse)]
        events --> realtime[Realtime aggregator]
        warehouse --> bi[BI dashboards]
        realtime --> alerts[Alerting]
    end
    auth -.audit.-> events
    inventory -.stock deltas.-> events
```

Save it as `architecture.mmd` and open it in Orca; diagram mode picks up the extension on its own.

New tests:

- `mermaid-diagram-size.test.ts` covers viewBox parsing, the `width="100%"` case mermaid actually emits, the px fallback when `useMaxWidth` is off, and malformed input.
- `surface-drag-pan.test.ts` covers which presses start a pan and how pointer movement maps to scroll offsets, including that each move measures from the press rather than from the previous move.
- `MermaidZoomSurface.test.tsx` covers sizing the box in px once the diagram reports its size, growth of the layout box on zoom, Fit returning to the fitted size, `Ctrl`-wheel zooming while a plain wheel scrolls, each control disabling at its bound, dragging to pan, touch falling through to native scrolling, a lost pointer capture ending the pan, the grab cursor appearing only when panning is possible, and the wheel listener detaching on unmount.
- `surface-zoom.test.ts` is the existing image-viewer zoom suite, renamed with its module.

The 10 failures in the full run come from my local checkout, not from this branch. Seven are the `tests/e2e/cross-version-wire` suite, which needs release tags present locally; I cloned with `--depth 50`, so the working copy has zero tags and the harness reports `could not resolve ref "v1.4.190"`. The other three are `pty-connection` timeouts at the 30-second limit under a loaded parallel run. Run on their own, `pty-connection-pty-exit-teardown` and `pty-connection-terminal-input-gating` pass 44 of 44. Neither suite touches the editor.

One thing tests do not cover: the CSS cascade against a real mermaid SVG, since happy-dom has no layout engine. I verified that by hand in Chromium, which is how the `flex: none` bug surfaced.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Author

[@krus210](https://x.com/krus210)

## AI Disclosure

Written with Claude Opus 5 through Claude Code.

## Review

An AI review pass checked the following.

**Cross-platform.** The wheel gate reads `event.ctrlKey` on every platform, which is how Chromium reports a trackpad pinch (`ImageViewer.tsx:151-153` documents this). No `metaKey` appears anywhere, and the PR adds no keyboard binding, so no platform-specific shortcut labels are needed. Panning ignores touch pointers and leaves them to native scrolling. No paths, no shell, no child processes.

**SSH, remote, and local.** Renderer-local UI only. No IPC, no RPC parameters, no stream opcodes, so nothing touches wire compatibility. Mermaid rendering was already async and serialized, and the zoom setup does not assume the SVG exists on the first frame.

**Agents, integrations, and git providers.** Untouched.

**Performance.** No new dependency; `package.json` had no pan or zoom library and still has none. Zoom state stays local to the surface. The ResizeObserver disconnects on unmount, and the native wheel listener is removed both in the ref callback and on unmount. Panning writes `scrollLeft` and `scrollTop` directly rather than through React state, so a drag triggers no re-render. `MermaidBlock`'s render effect gains `onRendered` in its dependency list, and the caller passes a stable `setState` reference, so render frequency is unchanged.

**UI quality.** lucide icons at `size-3`, `Button variant="ghost" size="icon-xs"`, tokens only (`border`, `card`, `muted-foreground`), `tabular-nums` on the percentage with a fixed `min-w-12` so the control does not jitter, and `scrollbar-editor` on the overflow container per the styleguide's three-scrollbar rule. The control cluster mirrors `AgentMapViewportControls`, the nearest in-repo precedent, and stays hidden until a diagram has rendered. The grab cursor appears only above 100%, where panning does something. Checked in light and dark; mermaid's own theme already follows `isDark`.

**Security.** Sanitization does not change. `DOMPurify.sanitize(svg, { USE_PROFILES: { svg: true } })`, `securityLevel: 'strict'`, and `htmlLabels={false}` all stay. The new code reads the rendered SVG's `viewBox`, `width`, and `height` attributes and injects no markup.

**Backwards compatibility.** Before the surface measures a diagram, the DOM and CSS resolve exactly as they do today, so a pending or failed render looks unchanged.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

The one `!important` in the new CSS exists because mermaid writes `max-width` as an inline style on the `<svg>`, which a class selector cannot beat. It is scoped to `.mermaid-diagram-box[data-zoom-layout='true'] .mermaid-block svg`, so it applies only to a diagram this surface is actively sizing.

Panning inside the image viewer is tracked separately in #9337. This PR does not touch that surface, but `surface-drag-pan.ts` is written to be reusable if someone picks that up.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass


