### PR TITLE
fix(terminal): keep an invalid search regex from crashing the workbench

### DIFF
--- a/src/renderer/src/components/terminal-search-safe-find.test.ts
+++ b/src/renderer/src/components/terminal-search-safe-find.test.ts
@@ -57,3 +57,49 @@ describe('safeFind (TerminalSearch decoration crash guard)', () => {
     expect(() => safeFind(find, 'q')).toThrow('something genuinely broken')
   })
 })
+
+/**
+ * Regression for STA-6256 (reproduced live on main 573537ecd4, crash report
+ * 812e673e-3a47-438f-9755-9e9e36279205, boundary_id terminal.workbench):
+ * typing an invalid pattern with the Regex toggle on crashed the whole
+ * workspace workbench with "SyntaxError: Invalid regular expression: /[/gi:
+ * Unterminated character class".
+ *
+ * The addon compiles the raw query as `RegExp(term, caseSensitive ? 'g' : 'gi')`
+ * with no guard, so these tests throw the real compile error rather than a
+ * hand-written lookalike — a message-only fixture would still pass if the addon
+ * changed which error it raises.
+ */
+describe('safeFind (invalid regex crash guard)', () => {
+  // Exactly how @xterm/addon-search builds the matcher in regex mode.
+  const compileLikeAddon = (term: string, caseSensitive = false): boolean =>
+    RegExp(term, caseSensitive ? 'g' : 'gi').test('haystack')
+
+  // Every one of these is a prefix of a pattern a user is part-way through typing.
+  it.each(['[', '(', '*', '\\', '[a-', '(?<'])(
+    'contains the real SyntaxError from partially-typed pattern %j instead of crashing the surface',
+    (term) => {
+      const find = vi.fn((t: string) => compileLikeAddon(t))
+      // Guard the premise: this pattern really is uncompilable, so the test is
+      // exercising the throw path rather than passing vacuously.
+      expect(() => RegExp(term, 'gi')).toThrow(SyntaxError)
+      expect(() => safeFind(find, term)).not.toThrow()
+      expect(safeFind(find, term)).toBe(false)
+      expect(find).toHaveBeenCalledWith(term, undefined)
+    }
+  )
+
+  it('still finds matches once the pattern becomes valid', () => {
+    const find = vi.fn((t: string) => compileLikeAddon(t))
+    expect(safeFind(find, '[')).toBe(false)
+    // The completed pattern must search normally - the guard must not latch.
+    expect(safeFind(find, '[abc]')).toBe(true)
+  })
+
+  it('re-throws a SyntaxError that is not a regex compile failure', () => {
+    const find = vi.fn(() => {
+      throw new SyntaxError('Unexpected token } in JSON at position 4')
+    })
+    expect(() => safeFind(find, 'q')).toThrow('Unexpected token }')
+  })
+})

--- a/src/renderer/src/components/terminal-search-safe-find.ts
+++ b/src/renderer/src/components/terminal-search-safe-find.ts
@@ -17,6 +17,13 @@ type SearchOptions = Parameters<SearchAddon['findNext']>[1]
  * specific decoration failure keeps search functional and merely drops the
  * highlight on the pathological frame instead of taking down the terminal. The
  * next find (after a reflow/fit widens the viewport) highlights normally.
+ *
+ * Why (invalid regex): in regex mode the addon compiles the raw query with
+ * `RegExp(term, ...)` and no guard, so every keystroke on the way to a complete
+ * pattern — `[` before `[abc]`, `(` before `(a|b)` — throws SyntaxError straight
+ * out of findNext into the same boundary and kills the terminal surface
+ * (STA-6256). A pattern the user has not finished typing is not an app fault, so
+ * it is reported as "no match" until it compiles.
  */
 export function safeFind(
   search: (term: string, options?: SearchOptions) => boolean,
@@ -26,7 +33,7 @@ export function safeFind(
   try {
     return search(term, options)
   } catch (error) {
-    if (isDecorationPositiveIntegerError(error)) {
+    if (isDecorationPositiveIntegerError(error) || isInvalidRegexError(error)) {
       return false
     }
     throw error
@@ -35,4 +42,8 @@ export function safeFind(
 
 function isDecorationPositiveIntegerError(error: unknown): boolean {
   return error instanceof Error && /only accepts positive integers/i.test(error.message)
+}
+
+function isInvalidRegexError(error: unknown): boolean {
+  return error instanceof SyntaxError && /invalid regular expression/i.test(error.message)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## Problem

With the **Regex** toggle on, terminal search compiles the raw query through `@xterm/addon-search`:

```js
RegExp(term, caseSensitive ? 'g' : 'gi')
```

There is no guard around it, so every keystroke on the way to a complete pattern — `[` before `[abc]`, `(` before `(a|b)` — throws `SyntaxError` synchronously out of `findNext`. `safeFind` only swallowed the xterm decoration error and rethrew everything else, so the throw reached `RecoverableRenderErrorBoundary` and took down the entire terminal workbench.

Fixes STA-6256.

## Reproduced live

macOS, dev build of `main` at `573537ecd4`, isolated profile, real user path (open terminal → ⌘F → Regex → type `[`):

- Crash report `812e673e-3a47-438f-9755-9e9e36279205`
- `boundary_id: terminal.workbench`, `surface: terminal-workbench`
- `SyntaxError: Invalid regular expression: /[/gi: Unterminated character class`
- Stack: `RegExp` → `_findInLine` → `findNextWithSelection` → `findNext` → `safeFind` → `TerminalSearch`

The workbench replaced the terminal with "The workspace workbench hit an error."

## Fix

Treat an uncompilable pattern as "no match" until it compiles. Both entry points — the `TerminalSearch` effect and the ⌘G / ⌘⇧G keyboard path in `terminal-keyboard-shortcut-matching.ts` — already route through `safeFind`, so the single guard covers both.

The predicate is deliberately narrow: a `SyntaxError` that is **not** a regex compile failure still propagates, so genuine bugs stay visible.

## Tests

7 new cases in `terminal-search-safe-find.test.ts`. They throw the **real** compile error via `RegExp(term, 'gi')` rather than a hand-written lookalike, and each parametrised case asserts the pattern really is uncompilable first, so it cannot pass vacuously. Coverage: 6 partially-typed patterns, "still finds matches once the pattern becomes valid" (the guard must not latch), and a non-regex `SyntaxError` that must still throw.

- `vitest run terminal-search-safe-find.test.ts` → **11 passed**
- Ablation (invalid-regex arm removed): **7 failed / 4 passed** — the new tests fail without the fix
- `tsc -p config/tsconfig.tc.web.json` → clean
- `oxlint` + `oxfmt --check` → clean

## Live QA

Same rig, differential on one running instance:

| Build | Result |
|---|---|
| `main` (pre-fix) | crash, report `812e673e` |
| fix ablated in place | crash returns, report `8596fc57`, stack through `safeFind` |
| fix restored | no crash, no new crash report, search stays mounted |

With the fix, `[` leaves the search bar mounted and the terminal alive, and completing it to `[a-z]+` highlights matches normally.

## Compatibility

Renderer-only, no platform branches, no wire/IPC/Git surface touched — behaviour is identical on macOS, Windows, Linux, SSH/remote-runtime, and folder workspaces.