### PR TITLE
fix(ui): prevent sidebar agent send labels from wrapping

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -186,6 +186,7 @@ describe('DashboardAgentRow', () => {
     expect(tokens).toContain('absolute')
     expect(tokens).toContain('h-5')
     expect(tokens).toContain('w-12')
+    expect(tokens).toContain('whitespace-nowrap')
     expect(markup).toContain('lucide-send')
     expect(markup).not.toContain('aria-label="Dismiss agent"')
   })

--- a/src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
@@ -74,7 +74,7 @@ export function DashboardAgentRowTrailingControls({
           onKeyDown={stopKeyDown}
           disabled={sendTargetStatus === 'sending'}
           className={cn(
-            'worktree-agent-send-target-button absolute right-0 top-1/2 z-10 inline-flex h-5 -translate-y-1/2 items-center gap-1 rounded-md border px-1.5 text-[10px] font-medium leading-none transition-[background-color,border-color,color,opacity]',
+            'worktree-agent-send-target-button absolute right-0 top-1/2 z-10 inline-flex h-5 -translate-y-1/2 items-center gap-1 rounded-md border px-1.5 text-[10px] font-medium leading-none transition-[background-color,border-color,color,opacity] whitespace-nowrap',
             sendTargetStatus === 'sending' && 'cursor-progress opacity-75'
           )}
           aria-label={translate(


### PR DESCRIPTION
## ELI5

When a Diff note is ready to send to an agent, Orca shows a small Send button beside each eligible agent in the sidebar. Some translated labels could split across multiple lines inside that fixed-height button. This change keeps the label on one line in every supported locale.

## What Changed

- Added whitespace-nowrap to the sidebar agent send-target button.
- Added a regression assertion to the existing DashboardAgentRow test.
- Kept the existing 48 px trailing slot, intrinsic button width, absolute positioning, row height, icon sizing, and event behavior unchanged.

The change is limited to:

- src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
- src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx

No locale catalog, main-process, RPC, SSH, or remote-wire code was changed.

## Why

The absolutely positioned button uses automatic width inside a fixed trailing slot. Without whitespace-nowrap, browsers may break Korean, Chinese, and Japanese labels between characters, creating multiple lines inside the fixed h-5 control. Longer Latin labels follow a different min-content path.

Preventing whitespace wrapping directly expresses the required UI invariant while avoiding wider reserved slots or changes to the normal trailing controls.

## Linked Issue

Fixes #18473

## Visual Proof

| State | Before | After |
|---|---|---|
| Korean 보내기 | Characters wrap vertically and overflow | Label remains on one line |
| Chinese 发送 | Vulnerable to per-character wrapping | Label remains on one line |
| Japanese 送信 | Vulnerable to per-character wrapping | Label remains on one line |
| Spanish Enviar | Width behavior differs from CJK labels | Label remains readable on one line |

| Before screenshot | After screenshot |
|---|---|
|<img width="402" height="324" alt="image" src="https://github.com/user-attachments/assets/17e4d35b-f002-4852-86f5-5d4ae7beeadc" />|<img width="752" height="211" alt="image" src="https://github.com/user-attachments/assets/d27477ee-ab47-4d8c-ac97-001ad24212e2" />|

The red circle highlights the before-and-after states of the fix, while the red rectangle shows a composite image tested across different languages.

## Testing

- [x] Manually verified the localized labels in the development build at narrow/default sidebar widths
- [x] pnpm test src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx — 20 tests passed
- [x] pnpm tc:web — passed
- [x] pnpm run check:code-quality:changed — 0 new findings across 2 changed files
- [x] Targeted oxfmt check — passed
- [x] git diff --check — passed

## AI Disclosure

Developed and validated with OpenAI Codex. The final localized layout was manually reviewed in Orca's development build.

## Review

- Cross-platform: renderer-only utility-class change consumed identically on macOS, Linux, and Windows.
- SSH / Remote / Local: no execution, transport, RPC, or remote-wire behavior changed.
- Folder workspaces / Git worktrees: no workspace-model assumptions or behavior changed.
- Accessibility: existing button semantics, accessible name, title, focus styling, and keyboard handling are unchanged.
- Security and performance: no new runtime logic, data handling, command execution, IPC, or measurable rendering work.
- Localization: existing translations are reused; no locale catalogs or translation keys changed.

## Agent skill upstream boundary

- [x] Not applicable. This change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including an ELI5 summary
- [x] Before/after screenshots are attached
- [x] Self-reviewed for correctness, security, accessibility, and performance
- [x] Cross-platform, SSH/remote, folder-workspace, and wire-compatibility impact considered
- [x] Targeted tests, web typecheck, formatting, and changed-code quality checks pass; full-suite and build coverage can run in CI
