### PR TITLE
fix(serve): pin Ozone to X11 for Linux headless serve

### DIFF
--- a/src/main/startup/ensure-virtual-display.test.ts
+++ b/src/main/startup/ensure-virtual-display.test.ts
@@ -9,7 +9,7 @@ const { spawnMock, existsSyncMock, readFileSyncMock, rmSyncMock, statSyncMock, a
     statSyncMock: vi.fn(),
     appMock: {
       disableHardwareAcceleration: vi.fn(),
-      commandLine: { appendSwitch: vi.fn(), getSwitchValue: vi.fn() },
+      commandLine: { appendSwitch: vi.fn(), getSwitchValue: vi.fn(), removeSwitch: vi.fn() },
       once: vi.fn()
     }
   }))
@@ -62,6 +62,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     statSyncMock.mockReset()
     appMock.disableHardwareAcceleration.mockReset()
     appMock.commandLine.appendSwitch.mockReset()
+    appMock.commandLine.removeSwitch.mockReset()
     appMock.commandLine.getSwitchValue.mockReset().mockReturnValue('')
     appMock.once.mockReset()
     delete process.env.DISPLAY
@@ -110,6 +111,36 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     expect(appMock.disableHardwareAcceleration).toHaveBeenCalled()
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-dev-shm-usage')
     expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('disable-gpu')
+  })
+
+  it('pins Ozone to X11 so offscreen serve windows keep compositing', async () => {
+    setPlatform('linux')
+    process.env.DISPLAY = ':0'
+    mockLiveXDisplay()
+    const { ensureVirtualDisplayForHeadlessServe } = await import('./ensure-virtual-display')
+
+    expect(ensureVirtualDisplayForHeadlessServe({ isServeMode: true })).toBe(true)
+    // Electron has already resolved its hint into --ozone-platform, so appending alone is a
+    // no-op: the value must be dropped first or Ozone stays on Wayland and never paints.
+    expect(appMock.commandLine.removeSwitch).toHaveBeenCalledWith('ozone-platform')
+    expect(appMock.commandLine.appendSwitch).toHaveBeenCalledWith('ozone-platform', 'x11')
+  })
+
+  it('leaves an explicitly selected ozone platform alone', async () => {
+    setPlatform('linux')
+    process.env.DISPLAY = ':0'
+    const originalArgv = process.argv
+    process.argv = [...originalArgv, '--ozone-platform=wayland']
+    mockLiveXDisplay()
+    const { ensureVirtualDisplayForHeadlessServe } = await import('./ensure-virtual-display')
+
+    try {
+      ensureVirtualDisplayForHeadlessServe({ isServeMode: true })
+    } finally {
+      process.argv = originalArgv
+    }
+    expect(appMock.commandLine.removeSwitch).not.toHaveBeenCalled()
+    expect(appMock.commandLine.appendSwitch).not.toHaveBeenCalledWith('ozone-platform', 'x11')
   })
 
   it('reports unsupported when Xvfb cannot be launched', async () => {

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -26,6 +26,19 @@ function configureHeadlessServeChromiumFlags(): void {
   // Why: externally managed displays are commonly Xvfb too; a GPU-process fork can trap before serve readiness.
   app.disableHardwareAcceleration()
   app.commandLine.appendSwitch('disable-gpu')
+  pinOzonePlatformToX11()
+}
+
+// Why: Electron has already resolved its platform hint into --ozone-platform by now, so on a
+// desktop session (a `systemctl --user` serve unit inherits one) it reads Wayland, where a hidden
+// BrowserWindow with the GPU disabled above never paints and browser panes stay blank. Overriding
+// the resolved value is the only way to reach X11; an explicit command-line choice still wins.
+function pinOzonePlatformToX11(): void {
+  if (process.argv.some((arg) => arg.startsWith('--ozone-platform'))) {
+    return
+  }
+  app.commandLine.removeSwitch('ozone-platform')
+  app.commandLine.appendSwitch('ozone-platform', 'x11')
 }
 
 function xvfbSocketPath(displayNumber: number): string {


### PR DESCRIPTION
## ELI5

On Linux, `orca serve` renders remote browser pages into an invisible window with the GPU turned off. That combination only produces frames on X11 — but the serve path never said "use X11", so on a host with a desktop session logged in Chromium ran on Wayland instead, the invisible window never painted, and every remote browser pane stayed blank forever. This pins the platform to X11, which is what the serve path already assumed.

## What Changed

`configureHeadlessServeChromiumFlags()` now pins `--ozone-platform=x11` for Linux headless serve. Electron has already resolved its platform hint into that switch by the time this runs, and `appendSwitch` does not override a switch that already carries a value, so the resolved value is dropped with `removeSwitch` first. An explicit `--ozone-platform` on `process.argv` is left alone.

## Why

`ensureVirtualDisplayForHeadlessServe()` disables the GPU unconditionally, and the offscreen browser backend renders into a hidden `BrowserWindow`. On Wayland that pair never paints: `Page.startScreencast` emits no frames and `capturePage()` hangs, so remote browser panes sit on *"This pane is rendered from the active runtime server"* while navigation, page titles, DOM and `orca snapshot` all keep working — nothing that needs pixels succeeds.

A `systemctl --user` serve unit inherits the desktop session's `WAYLAND_DISPLAY` / `XDG_SESSION_TYPE=wayland`, so Ozone selected Wayland. The function already starts Xvfb (X11) when `DISPLAY` is unset and documents *"Offscreen serve windows require X11"*; the gap was the early return when `DISPLAY` **is** set, which accepted the inherited display without pinning the platform.

Measured with a standalone Electron harness on the affected host — same page, hidden `BrowserWindow`, `Page.startScreencast` observed for 10s:

| ozone platform | GPU | frames |
| --- | --- | --- |
| wayland | disabled | **0** |
| wayland | default | 3 |
| x11 (Xvfb) | disabled | 3 |
| x11 (inherited `DISPLAY=:0` via Xwayland) | disabled | 3 |

Only that one combination fails, and it is what `orca serve` produced. `--use-gl=swiftshader` does not help (0 frames); a visible window does (3 frames), which is why the desktop app was never affected.

No behaviour change for hosts that already worked: with `DISPLAY` unset Orca starts its own Xvfb (X11) exactly as before. `hasUsableLinuxDisplay()` — the only other reader of the switch — is called solely on the non-serve path and earlier in startup, so its result cannot shift.

## Linked Issue

None filed — the full root cause, the measurements and the repro steps are in this PR, so a separate issue looked redundant. Happy to open one if you would rather track it separately.

The closest existing report is #11492 (macOS, visible window, compositor parked by display sleep): same symptom family, different cause and platform.

## Visual Proof

N/A — no UI or interaction change; this is a Chromium startup switch. The observable difference is that pages in a headless serve runtime produce frames at all, captured here against a real serve instance on Ubuntu 25.04 (GNOME/Wayland, Xwayland `:0`):

**Before**
```
$ orca screenshot --format png
CDP error (Page.captureScreenshot): Screenshot timed out — the browser tab may not be
visible or the window may not have focus.
```

**After**
```
$ orca screenshot --format png
Screenshot captured (png, 87450 bytes)
```

## Testing

Host: Ubuntu 25.04, GNOME/Wayland session with Xwayland on `:0`, `orca serve` run as a `systemctl --user` unit — the configuration that reproduces the bug.

End-to-end, against a real runtime rather than only unit tests:

- Applied the equivalent change to a copy of the installed 1.4.195 app and ran that copy as a second serve instance on `:6769` with an isolated `HOME`, inheriting the same `DISPLAY` / `WAYLAND_DISPLAY` / `XDG_SESSION_TYPE` as the live unit. Created a page against it and captured: timeout before, 87450-byte PNG after (see Visual Proof).
- That run is also what showed a plain `appendSwitch` is not enough: with the guard that skipped when the switch already had a value, the GPU process still came up `--ozone-platform=wayland` and the capture still timed out. Dropping the resolved value first is what actually reaches X11.
- Characterised the failure with a standalone Electron harness (hidden `BrowserWindow` + `Page.startScreencast`, 10s) to fill in the matrix above.

Automated:

- `pnpm test src/main/startup/ensure-virtual-display.test.ts` — 35 passed.
- Same tests against the unmodified upstream source file — 1 failed / 34 passed, so the new regression test does fail without the change.
- `oxlint` and `oxfmt --check` clean on both files; `tsc --noEmit -p config/tsconfig.node.json` clean.

Platforms actually tested: Linux (serve host). Not tested on macOS or Windows; the changed branch is Linux-and-serve-only and returns early elsewhere.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Two tests added: one asserting the x11 pin (including the `removeSwitch` that makes it effective), one asserting an explicit `--ozone-platform` is respected.

## AI Disclosure

Investigated and drafted with Claude Opus 5 (Claude Code): root-cause analysis, the measurement harness, the patch and the tests, then verified end-to-end on the affected host.
