### PR TITLE
fix(gitlab): re-fetch branch-matched MRs so CI status is not lost

### DIFF
--- a/src/main/gitlab/client-mr-branch-lookup.test.ts
+++ b/src/main/gitlab/client-mr-branch-lookup.test.ts
@@ -197,6 +197,48 @@ describe('gitlab client — MR operations', () => {
       expect(mr?.pipelineStatus).toBe('failure')
     })
 
+    // Why (#18484): GitLab's list endpoint omits `head_pipeline`/`pipeline` entirely, so a failed
+    // pipeline read as neutral and the card painted the MR open-green. Re-fetch the single MR.
+    it('re-fetches the MR by iid when the list row carries no pipeline field', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            { iid: 5049, title: 'odin-log-api', state: 'opened', sha: 'abc' }
+          ])
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({
+            iid: 5049,
+            title: 'odin-log-api',
+            state: 'opened',
+            sha: 'abc',
+            head_pipeline: { status: 'failed' }
+          })
+        })
+
+      const mr = await getMergeRequestForBranch('/repo', 'odin-log-api')
+      expect(mr?.number).toBe(5049)
+      expect(mr?.pipelineStatus).toBe('failure')
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
+      expect(glabExecFileAsyncMock).toHaveBeenLastCalledWith(
+        ['api', 'projects/g%2Fp/merge_requests/5049?with_merge_status_recheck=true'],
+        { cwd: '/repo' }
+      )
+    })
+
+    it('keeps the list row when the pipeline re-fetch fails', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([{ iid: 6, title: 'Flaky', state: 'opened', sha: 'abc' }])
+        })
+        .mockRejectedValueOnce(new Error('glab: 502'))
+
+      const mr = await getMergeRequestForBranchOrThrow('/repo', 'flaky')
+      expect(mr).toMatchObject({ number: 6, pipelineStatus: 'neutral' })
+    })
+
     it('strips refs/heads/ prefix from the branch arg', async () => {
       getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
       glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })

--- a/src/main/gitlab/client-mr-branch-lookup.test.ts
+++ b/src/main/gitlab/client-mr-branch-lookup.test.ts
@@ -237,6 +237,7 @@ describe('gitlab client — MR operations', () => {
 
       const mr = await getMergeRequestForBranchOrThrow('/repo', 'flaky')
       expect(mr).toMatchObject({ number: 6, pipelineStatus: 'neutral' })
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
     })
 
     it('strips refs/heads/ prefix from the branch arg', async () => {

--- a/src/main/gitlab/merge-request-lookup.ts
+++ b/src/main/gitlab/merge-request-lookup.ts
@@ -20,6 +20,11 @@ import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-d
 
 type HostedReviewLocalGitOptions = ReturnType<typeof getHostedReviewLocalGitOptions>
 
+type RawMergeRequest = Parameters<typeof mapMRInfo>[0] & {
+  head_pipeline?: { status?: string } | null
+  pipeline?: { status?: string } | null
+}
+
 function hostedReviewLocalGitOptionArgs(
   options: HostedReviewExecutionOptions = {}
 ): [] | [HostedReviewLocalGitOptions] {
@@ -63,10 +68,7 @@ export async function getMergeRequest(
       args,
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = JSON.parse(stdout) as Parameters<typeof mapMRInfo>[0] & {
-      head_pipeline?: { status?: string } | null
-      pipeline?: { status?: string } | null
-    }
+    const data = JSON.parse(stdout) as RawMergeRequest
     // Why: older GitLab instances expose `pipeline` instead of `head_pipeline`; try both.
     const pipelineStatus = derivePipelineStatus(data.head_pipeline ?? data.pipeline ?? null)
     return mapMRInfo(data, pipelineStatus)
@@ -103,21 +105,20 @@ export async function getMergeRequestForBranch(
   }
   await acquire()
   try {
-    if (typeof linkedMRIid === 'number') {
+    const fetchByIid = async (iid: number): Promise<MRInfo> => {
       const { stdout } = await glabExecFileAsync(
         [
           'api',
           ...glabHostnameArgs(projectRef, connectionId),
-          `projects/${encodedProject(projectRef.path)}/merge_requests/${linkedMRIid}?with_merge_status_recheck=true`
+          `projects/${encodedProject(projectRef.path)}/merge_requests/${iid}?with_merge_status_recheck=true`
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
-      const raw = JSON.parse(stdout) as Parameters<typeof mapMRInfo>[0] & {
-        head_pipeline?: { status?: string } | null
-        pipeline?: { status?: string } | null
-      }
-      const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null)
-      return mapMRInfo(raw, pipelineStatus)
+      const raw = JSON.parse(stdout) as RawMergeRequest
+      return mapMRInfo(raw, derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null))
+    }
+    if (typeof linkedMRIid === 'number') {
+      return fetchByIid(linkedMRIid)
     }
     if (branchName) {
       const { stdout } = await glabExecFileAsync(
@@ -132,15 +133,12 @@ export async function getMergeRequestForBranch(
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
-      const data = JSON.parse(stdout) as (Parameters<typeof mapMRInfo>[0] & {
-        head_pipeline?: { status?: string } | null
-        pipeline?: { status?: string } | null
-      })[]
+      const data = JSON.parse(stdout) as RawMergeRequest[]
       if (Array.isArray(data) && data.length > 0) {
         const raw = data[0]
         // Why: older GitLab list payloads expose `pipeline` instead of `head_pipeline`.
         const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null)
-        const info = mapMRInfo(raw, pipelineStatus)
+        let info = mapMRInfo(raw, pipelineStatus)
         // Why (#9171): discard a non-open implicit branch match on the repo default branch.
         const hideOnDefaultBranch = await shouldHideNonOpenReviewOnDefaultBranch({
           state: info.state,
@@ -151,6 +149,16 @@ export async function getMergeRequestForBranch(
           localGitOptions
         })
         if (!hideOnDefaultBranch) {
+          // Why (#18484): the list endpoint omits `head_pipeline`/`pipeline` entirely, so a failed
+          // pipeline read as neutral and the card painted the MR open-green. Re-fetch the single
+          // MR for its pipeline; keep the list row if that call fails, since the MR does exist.
+          if (!('head_pipeline' in raw) && !('pipeline' in raw)) {
+            try {
+              info = await fetchByIid(info.number)
+            } catch {
+              // ponytail: list row stays authoritative; pipeline just reads neutral this poll
+            }
+          }
           return info
         }
       }

--- a/src/main/gitlab/merge-request-lookup.ts
+++ b/src/main/gitlab/merge-request-lookup.ts
@@ -105,6 +105,7 @@ export async function getMergeRequestForBranch(
   }
   await acquire()
   try {
+    /** Fetch one MR by iid with merge-status recheck and pipeline status rolled up. */
     const fetchByIid = async (iid: number): Promise<MRInfo> => {
       const { stdout } = await glabExecFileAsync(
         [
@@ -156,7 +157,8 @@ export async function getMergeRequestForBranch(
             try {
               info = await fetchByIid(info.number)
             } catch {
-              // ponytail: list row stays authoritative; pipeline just reads neutral this poll
+              // Why: the list row already proves the MR exists; a transient re-fetch failure
+              // must not turn it into "unavailable", so the pipeline just reads neutral this poll.
             }
           }
           return info


### PR DESCRIPTION
## ELI5

When Orca found a GitLab merge request by branch name, GitLab's answer never included the CI result, so the sidebar card painted a failed pipeline with the same green as a passing one. Orca now asks GitLab for the full MR after finding it, so the card shows the real CI status.

## What Changed

- `getMergeRequestForBranch` re-fetches the single MR by iid (the same `merge_requests/:iid?with_merge_status_recheck=true` call the linked-iid path already makes) when the list row carries neither `head_pipeline` nor `pipeline`.
- If that re-fetch fails, the list row is kept so an MR that exists never collapses to `unavailable`.
- The linked-iid fetch is extracted into `fetchByIid` and shared; the raw payload type is hoisted to `RawMergeRequest`.
- Two tests: the re-fetch recovers a `failed` pipeline as `failure`, and a failing re-fetch falls back to the list row with `neutral` after actually attempting the second call.

## Why

GitLab's merge request **list** endpoint omits `head_pipeline`/`pipeline` (verified on gitlab.com against thorchain/thornode!5049). `derivePipelineStatus(null)` returns `neutral`, and the card's check tone returns null for neutral, so the open-state emerald wins. The single-MR endpoint is the documented source of `head_pipeline`, and the linked-iid path already used it, so reusing that call is the smallest correct fix.

Deliberately not changed:
- The card's open-state emerald for a `neutral` status is documented as intentional in `worktree-review-helpers.tsx` and its test. Muting it would recolour every open review in a repo with no CI (GitHub included) and diverge from the right-sidebar header. Separate product call.
- The re-fetch gate is `'head_pipeline' in raw` (key absent), not a null check. A self-hosted instance that emits `head_pipeline: null` on list rows while a pipeline exists would still read neutral; flip the gate to `!(raw.head_pipeline ?? raw.pipeline)` if that shape turns out to be real.
- The GitHub REST fallback hardcoding `statusCheckRollup: []` is a separate path with a separate fix (a check-runs call on the head sha).

## Linked Issue

Fixes #18484

## Visual Proof

N/A — no UI code changes. The card already renders `text-rose-500/85` for `failure`; this PR only fixes the data so that status arrives. Rendering behaviour is covered by the existing `worktree-review-helpers.test.tsx`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Tested on macOS (darwin arm64). No platform-specific code touched; the change is a second `glab api` call through the existing `glabExecFileAsync` path, which already handles native, WSL, and SSH hosts.

- The first new test fails against the original source (`pipelineStatus` is `neutral`, 1 glab call) and passes with the fix.
- `vitest src/main/gitlab src/main/source-control/hosted-review.test.ts src/main/source-control/forge-provider.test.ts` — 302 passed
- `pnpm tc:node`, `pnpm run check:code-quality:changed` — clean

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1); root cause was traced and reported by the issue author.

## Review

Request volume: on instances that omit the pipeline keys (gitlab.com), a branch-matched lookup now costs two `glab api` calls instead of one. Both run inside the same `acquire()` slot (MAX_CONCURRENT = 4), so concurrency is unchanged; only the per-poll call count doubles for branch-matched MRs. The linked-iid path already cost one call of this shape.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: no new inputs; iid comes from GitLab's own list response. Cross-platform: no path or shell changes. Remote SSH: goes through the existing `glabRepoExecOptions` host routing. Mobile: N/A. Backwards compatibility: no wire or IPC change. Performance: one extra bounded API call per branch-matched poll on gitlab.com, see Review.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019u8JM6QjCAG2asmvgUh8Ry
