### PR TITLE
feat(sidebar): show unresolved PR/MR comment count on the workspace card

### DIFF
--- a/mobile/src/session/github-pr-parsers.ts
+++ b/mobile/src/session/github-pr-parsers.ts
@@ -71,7 +71,8 @@ export function readForBranch(value: unknown): HostedReviewInfo | null {
     autoMergeAllowed:
       value.autoMergeAllowed === null ? null : (readBoolean(value.autoMergeAllowed) ?? undefined),
     mergeStateStatus: value.mergeStateStatus === null ? null : readString(value.mergeStateStatus),
-    headSha: readString(value.headSha)
+    headSha: readString(value.headSha),
+    unresolvedReviewCommentCount: readNumber(value.unresolvedReviewCommentCount)
   }
 }
 
@@ -105,7 +106,8 @@ export function readPRForBranch(value: unknown): PRInfo | null {
     // prRepo identifies a fork PR's head repo; checks/merge are keyed on it.
     prRepo: readRepoIdentity(value.prRepo),
     // mergeMethodSettings drives which merge methods the picker may offer.
-    mergeMethodSettings: readMergeMethodSettings(value.mergeMethodSettings)
+    mergeMethodSettings: readMergeMethodSettings(value.mergeMethodSettings),
+    unresolvedReviewCommentCount: readNumber(value.unresolvedReviewCommentCount)
   }
 }
 

--- a/src/main/github/client-pr-branch-discovery.test.ts
+++ b/src/main/github/client-pr-branch-discovery.test.ts
@@ -26,7 +26,7 @@ vi.mock('./github-api-repository', async (importOriginal) =>
   )
 )
 
-import { getPRForBranch } from './client'
+import { getPRForBranch, getPRForBranchOutcome } from './client'
 import { resetPRForBranchMocks } from './client-test-harness'
 
 const {
@@ -203,5 +203,83 @@ describe('getPRForBranch', () => {
     const pr = await getPRForBranch('/repo-root', 'no-pr-branch')
 
     expect(pr).toBeNull()
+  })
+})
+
+describe('getPRForBranchOutcome unresolved review comment count', () => {
+  beforeEach(() => {
+    resetPRForBranchMocks(clientMocks)
+  })
+
+  const exactLookup = {
+    number: 42,
+    title: 'Fix PR discovery',
+    state: 'OPEN',
+    url: 'https://github.com/acme/widgets/pull/42',
+    statusCheckRollup: [],
+    updatedAt: '2026-03-28T00:00:00Z',
+    isDraft: false,
+    mergeable: 'MERGEABLE',
+    reviewDecision: null,
+    mergeStateStatus: 'CLEAN',
+    autoMergeRequest: null,
+    baseRefName: 'main',
+    headRefName: 'feature/test',
+    baseRefOid: 'base-oid',
+    headRefOid: 'head-oid'
+  }
+  const thread = (isResolved: boolean, login: string, typename = 'User') => ({
+    isResolved,
+    comments: { nodes: [{ author: { __typename: typename, login } }] }
+  })
+
+  function primeGhExec(): void {
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'api' && args[1]?.includes('pulls?head=')) {
+        return {
+          stdout: JSON.stringify([
+            {
+              number: 42,
+              title: 'Fix PR discovery',
+              state: 'open',
+              html_url: exactLookup.url,
+              updated_at: exactLookup.updatedAt,
+              base: { ref: 'main', sha: 'base-oid' },
+              head: { ref: 'feature/test', sha: 'head-oid' }
+            }
+          ])
+        }
+      }
+      if (args[0] === 'pr' && args[1] === 'view') {
+        return { stdout: JSON.stringify(exactLookup) }
+      }
+      if (args.includes('graphql') && args.some((arg) => arg.includes('reviewThreads'))) {
+        const nodes = [thread(false, 'alice'), thread(true, 'alice'), thread(false, 'ci', 'Bot')]
+        return {
+          stdout: JSON.stringify({
+            data: { repository: { pullRequest: { reviewThreads: { nodes } } } }
+          })
+        }
+      }
+      return { stdout: '{}' }
+    })
+  }
+
+  it('counts unresolved human review threads only when the hosted-review path opts in', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    primeGhExec()
+
+    const outcome = await getPRForBranchOutcome('/repo-root', 'feature/test', null, null, null, {
+      includeUnresolvedReviewCommentCount: true
+    })
+    expect(outcome.kind === 'found' && outcome.pr.unresolvedReviewCommentCount).toBe(1)
+
+    ghExecFileAsyncMock.mockClear()
+    const plain = await getPRForBranchOutcome('/repo-root', 'feature/test')
+    expect(plain.kind === 'found' && plain.pr.unresolvedReviewCommentCount).toBeUndefined()
+    const askedForThreads = ghExecFileAsyncMock.mock.calls.some((call) =>
+      call[0].some((arg: string) => arg.includes('reviewThreads'))
+    )
+    expect(askedForThreads).toBe(false)
   })
 })

--- a/src/main/github/client/lookup/branch-lookup-derived-data.ts
+++ b/src/main/github/client/lookup/branch-lookup-derived-data.ts
@@ -4,6 +4,7 @@ import { hydrateGitHubPRStack } from '../../github-pr-stack'
 import { detectRepositoryMergeMetadata } from './../detect/repository-merge-metadata'
 import { derivePullRequestMergeable, type PullRequestLookupData } from './pull-request-lookup-data'
 import { getCachedGitHubPRStackSummary } from './pr-stack-summary-cache'
+import { fetchUnresolvedReviewCommentCount } from './pr-unresolved-review-threads'
 
 export async function derivePRRefreshData(args: {
   data: PullRequestLookupData
@@ -14,11 +15,13 @@ export async function derivePRRefreshData(args: {
   ghOptions: ReturnType<typeof ghRepoExecOptions>
   executionScope: string
   usedExactNumberLookup: boolean
+  includeUnresolvedReviewCommentCount?: boolean
 }): Promise<{
   mergeable: ReturnType<typeof derivePullRequestMergeable>
   stack: PullRequestLookupData['stack']
   stackMergeQueueRequired: boolean | null | undefined
   conflictSummary: Awaited<ReturnType<typeof getPRConflictSummary>>
+  unresolvedReviewCommentCount: number | undefined
 }> {
   const { data, dataRepo, repoPath, connectionId, localGitOptions, ghOptions, executionScope } =
     args
@@ -72,5 +75,16 @@ export async function derivePRRefreshData(args: {
           localGitOptions
         )
       : undefined
-  return { mergeable, stack, stackMergeQueueRequired, conflictSummary }
+  // Why: last in the sequence so the extra GraphQL call never delays merge/stack state.
+  const unresolvedReviewCommentCount =
+    args.includeUnresolvedReviewCommentCount && dataRepo
+      ? await fetchUnresolvedReviewCommentCount(dataRepo, data, ghOptions)
+      : undefined
+  return {
+    mergeable,
+    stack,
+    stackMergeQueueRequired,
+    conflictSummary,
+    unresolvedReviewCommentCount
+  }
 }

--- a/src/main/github/client/lookup/branch-lookup-resolution.ts
+++ b/src/main/github/client/lookup/branch-lookup-resolution.ts
@@ -269,7 +269,13 @@ export async function resolvePRForBranchOutcome(input: {
     return { kind: 'no-pr', fetchedAt: Date.now() }
   }
 
-  const { mergeable, stack, stackMergeQueueRequired, conflictSummary } = await derivePRRefreshData({
+  const {
+    mergeable,
+    stack,
+    stackMergeQueueRequired,
+    conflictSummary,
+    unresolvedReviewCommentCount
+  } = await derivePRRefreshData({
     data,
     dataRepo,
     repoPath,
@@ -277,7 +283,8 @@ export async function resolvePRForBranchOutcome(input: {
     localGitOptions,
     ghOptions,
     executionScope,
-    usedExactNumberLookup
+    usedExactNumberLookup,
+    includeUnresolvedReviewCommentCount: options.includeUnresolvedReviewCommentCount === true
   })
 
   return assemblePRRefreshFoundOutcome({
@@ -289,6 +296,7 @@ export async function resolvePRForBranchOutcome(input: {
     stackMergeQueueRequired,
     confirmedContainedHeadOid,
     headDivergedFromMergedPRAtOid,
-    conflictSummary
+    conflictSummary,
+    unresolvedReviewCommentCount
   })
 }

--- a/src/main/github/client/lookup/pr-refresh-outcome-assembly.ts
+++ b/src/main/github/client/lookup/pr-refresh-outcome-assembly.ts
@@ -18,6 +18,7 @@ export function assemblePRRefreshFoundOutcome(args: {
   confirmedContainedHeadOid: string | null
   headDivergedFromMergedPRAtOid: string | null
   conflictSummary: PRConflictSummary | undefined
+  unresolvedReviewCommentCount?: number
 }): PRRefreshOutcome {
   const {
     data,
@@ -28,7 +29,8 @@ export function assemblePRRefreshFoundOutcome(args: {
     stackMergeQueueRequired,
     confirmedContainedHeadOid,
     headDivergedFromMergedPRAtOid,
-    conflictSummary
+    conflictSummary,
+    unresolvedReviewCommentCount
   } = args
   return {
     kind: 'found',
@@ -64,7 +66,8 @@ export function assemblePRRefreshFoundOutcome(args: {
       ...(data.headRefName ? { headRefName: data.headRefName } : {}),
       prRepo: dataRepo ?? undefined,
       headRepo: dataHeadRepo ?? undefined,
-      conflictSummary
+      conflictSummary,
+      ...(unresolvedReviewCommentCount !== undefined ? { unresolvedReviewCommentCount } : {})
     }
   }
 }

--- a/src/main/github/client/lookup/pr-unresolved-review-threads.test.ts
+++ b/src/main/github/client/lookup/pr-unresolved-review-threads.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { countUnresolvedReviewThreads } from './pr-unresolved-review-threads'
+
+const thread = (isResolved: boolean, login: string, typename = 'User') => ({
+  isResolved,
+  comments: { nodes: [{ author: { __typename: typename, login } }] }
+})
+
+describe('countUnresolvedReviewThreads', () => {
+  it('counts unresolved human threads and skips resolved and bot ones', () => {
+    expect(
+      countUnresolvedReviewThreads([
+        thread(false, 'alice'),
+        thread(true, 'alice'),
+        thread(false, 'github-actions', 'Bot'),
+        thread(false, 'coderabbitai'),
+        null,
+        { isResolved: false }
+      ])
+    ).toBe(2)
+  })
+})

--- a/src/main/github/client/lookup/pr-unresolved-review-threads.test.ts
+++ b/src/main/github/client/lookup/pr-unresolved-review-threads.test.ts
@@ -1,15 +1,18 @@
-import { describe, expect, it } from 'vitest'
-import { countUnresolvedReviewThreads } from './pr-unresolved-review-threads'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  countUnresolvedReviewThreadNodes,
+  fetchUnresolvedReviewCommentCount
+} from './pr-unresolved-review-threads'
 
 const thread = (isResolved: boolean, login: string, typename = 'User') => ({
   isResolved,
   comments: { nodes: [{ author: { __typename: typename, login } }] }
 })
 
-describe('countUnresolvedReviewThreads', () => {
+describe('countUnresolvedReviewThreadNodes', () => {
   it('counts unresolved human threads and skips resolved and bot ones', () => {
     expect(
-      countUnresolvedReviewThreads([
+      countUnresolvedReviewThreadNodes([
         thread(false, 'alice'),
         thread(true, 'alice'),
         thread(false, 'github-actions', 'Bot'),
@@ -18,5 +21,86 @@ describe('countUnresolvedReviewThreads', () => {
         { isResolved: false }
       ])
     ).toBe(2)
+  })
+})
+
+const { exec, guard, spend } = vi.hoisted(() => ({
+  exec: vi.fn(),
+  guard: vi.fn(),
+  spend: vi.fn()
+}))
+vi.mock('../../gh-utils', () => ({ ghExecFileAsync: exec }))
+vi.mock('../../rate-limit', () => ({
+  repositoryRateLimitGuard: guard,
+  noteRepositoryRateLimitSpend: spend
+}))
+
+const ownerRepo = { owner: 'org', repo: 'repo', host: 'github.example.com' }
+const options = { cwd: '/workspace' }
+const data = {
+  number: 12,
+  title: '',
+  state: 'OPEN',
+  url: '',
+  statusCheckRollup: [],
+  updatedAt: '',
+  mergeable: 'UNKNOWN'
+}
+const page = (nodes: unknown[], hasNextPage = false, endCursor: string | null = null) => ({
+  stdout: JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          reviewThreads: { nodes, pageInfo: { hasNextPage, endCursor } }
+        }
+      }
+    }
+  })
+})
+
+describe('fetchUnresolvedReviewCommentCount', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    guard.mockReturnValue({ blocked: false })
+  })
+
+  it('counts page two and guards/accounts for each host-scoped request', async () => {
+    exec
+      .mockResolvedValueOnce(
+        page(
+          Array.from({ length: 100 }, () => thread(true, 'alice')),
+          true,
+          'next'
+        )
+      )
+      .mockResolvedValueOnce(page([thread(false, 'bob')]))
+    expect(await fetchUnresolvedReviewCommentCount(ownerRepo, data, options)).toBe(1)
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(exec.mock.calls[1][0]).toContain('cursor=next')
+    expect(exec.mock.calls[1][1]).toMatchObject(options)
+    expect(guard).toHaveBeenCalledTimes(2)
+    expect(guard).toHaveBeenLastCalledWith(ownerRepo, 'graphql', options)
+    expect(spend).toHaveBeenCalledTimes(2)
+    expect(spend).toHaveBeenLastCalledWith(ownerRepo, 'graphql', 1, options)
+  })
+
+  it('does not publish a partial count when the next page is blocked', async () => {
+    exec.mockResolvedValueOnce(page([thread(false, 'alice')], true, 'next'))
+    guard.mockReturnValueOnce({ blocked: false }).mockReturnValueOnce({ blocked: true })
+    expect(await fetchUnresolvedReviewCommentCount(ownerRepo, data, options)).toBeUndefined()
+    expect(exec).toHaveBeenCalledTimes(1)
+    expect(spend).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not publish a partial count when a later request fails', async () => {
+    exec
+      .mockResolvedValueOnce(page([thread(false, 'alice')], true, 'next'))
+      .mockRejectedValueOnce(new Error('offline'))
+    expect(await fetchUnresolvedReviewCommentCount(ownerRepo, data, options)).toBeUndefined()
+  })
+
+  it('rejects incomplete pagination metadata', async () => {
+    exec.mockResolvedValueOnce(page([thread(false, 'alice')], true))
+    expect(await fetchUnresolvedReviewCommentCount(ownerRepo, data, options)).toBeUndefined()
   })
 })

--- a/src/main/github/client/lookup/pr-unresolved-review-threads.ts
+++ b/src/main/github/client/lookup/pr-unresolved-review-threads.ts
@@ -1,0 +1,95 @@
+import { isBotPRCommentAuthor } from '../../../../shared/pr-comment-audience'
+import { ghExecFileAsync, type OwnerRepo } from '../../gh-utils'
+import { githubHostExecOptions } from '../../github-api-repository'
+import { mapPRState } from '../../mappers'
+import { noteRepositoryRateLimitSpend, repositoryRateLimitGuard } from '../../rate-limit'
+import type { GhExecOptions } from './../github-exec-scope'
+import type { PullRequestLookupData } from './pull-request-lookup-data'
+
+// Why: thread resolution is GraphQL-only; `gh pr view --json` has no field for it.
+const UNRESOLVED_REVIEW_THREADS_QUERY = `
+query($owner: String!, $repo: String!, $pr: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 1) { nodes { author { __typename login } } }
+        }
+      }
+    }
+  }
+}`
+
+export type ReviewThreadResolutionNode = {
+  isResolved?: boolean
+  comments?: {
+    nodes?: ({
+      author?: { __typename?: string; login?: string } | null
+    } | null)[]
+  }
+}
+
+export function countUnresolvedReviewThreads(
+  nodes: readonly (ReviewThreadResolutionNode | null)[]
+): number {
+  let count = 0
+  for (const node of nodes) {
+    if (!node || node.isResolved === true) {
+      continue
+    }
+    const author = node.comments?.nodes?.[0]?.author
+    // Why: match the PR-comments panel's bot filter so a noisy CI bot doesn't light up every card.
+    if (author && isBotPRCommentAuthor(author.login ?? '', author.__typename === 'Bot')) {
+      continue
+    }
+    count += 1
+  }
+  return count
+}
+
+/** Best-effort: undefined when the PR is not open, the GraphQL budget is low, or the call fails. */
+export async function fetchUnresolvedReviewCommentCount(
+  ownerRepo: OwnerRepo,
+  data: PullRequestLookupData,
+  ghOptions: GhExecOptions
+): Promise<number | undefined> {
+  const state = mapPRState(data.state, data.isDraft)
+  if (state !== 'open' && state !== 'draft') {
+    return undefined
+  }
+  try {
+    if (repositoryRateLimitGuard(ownerRepo, 'graphql', ghOptions).blocked) {
+      return undefined
+    }
+    noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
+    const { stdout } = await ghExecFileAsync(
+      [
+        'api',
+        'graphql',
+        '-f',
+        `query=${UNRESOLVED_REVIEW_THREADS_QUERY}`,
+        '-f',
+        `owner=${ownerRepo.owner}`,
+        '-f',
+        `repo=${ownerRepo.repo}`,
+        '-F',
+        `pr=${data.number}`
+      ],
+      { ...ghOptions, ...githubHostExecOptions(ownerRepo) }
+    )
+    const parsed = JSON.parse(stdout) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            reviewThreads?: { nodes?: (ReviewThreadResolutionNode | null)[] }
+          }
+        }
+      }
+    }
+    const nodes = parsed.data?.repository?.pullRequest?.reviewThreads?.nodes
+    return Array.isArray(nodes) ? countUnresolvedReviewThreads(nodes) : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/src/main/github/client/lookup/pr-unresolved-review-threads.ts
+++ b/src/main/github/client/lookup/pr-unresolved-review-threads.ts
@@ -8,10 +8,11 @@ import type { PullRequestLookupData } from './pull-request-lookup-data'
 
 // Why: thread resolution is GraphQL-only; `gh pr view --json` has no field for it.
 const UNRESOLVED_REVIEW_THREADS_QUERY = `
-query($owner: String!, $repo: String!, $pr: Int!) {
+query($owner: String!, $repo: String!, $pr: Int!, $cursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           isResolved
           comments(first: 1) { nodes { author { __typename login } } }
@@ -30,7 +31,7 @@ export type ReviewThreadResolutionNode = {
   }
 }
 
-export function countUnresolvedReviewThreads(
+export function countUnresolvedReviewThreadNodes(
   nodes: readonly (ReviewThreadResolutionNode | null)[]
 ): number {
   let count = 0
@@ -59,36 +60,55 @@ export async function fetchUnresolvedReviewCommentCount(
     return undefined
   }
   try {
-    if (repositoryRateLimitGuard(ownerRepo, 'graphql', ghOptions).blocked) {
-      return undefined
-    }
-    noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
-    const { stdout } = await ghExecFileAsync(
-      [
-        'api',
-        'graphql',
-        '-f',
-        `query=${UNRESOLVED_REVIEW_THREADS_QUERY}`,
-        '-f',
-        `owner=${ownerRepo.owner}`,
-        '-f',
-        `repo=${ownerRepo.repo}`,
-        '-F',
-        `pr=${data.number}`
-      ],
-      { ...ghOptions, ...githubHostExecOptions(ownerRepo) }
-    )
-    const parsed = JSON.parse(stdout) as {
-      data?: {
-        repository?: {
-          pullRequest?: {
-            reviewThreads?: { nodes?: (ReviewThreadResolutionNode | null)[] }
+    let count = 0
+    let cursor: string | undefined
+    while (true) {
+      if (repositoryRateLimitGuard(ownerRepo, 'graphql', ghOptions).blocked) {
+        return undefined
+      }
+      noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
+      const { stdout } = await ghExecFileAsync(
+        [
+          'api',
+          'graphql',
+          '-f',
+          `query=${UNRESOLVED_REVIEW_THREADS_QUERY}`,
+          '-f',
+          `owner=${ownerRepo.owner}`,
+          '-f',
+          `repo=${ownerRepo.repo}`,
+          '-F',
+          `pr=${data.number}`,
+          ...(cursor ? ['-f', `cursor=${cursor}`] : [])
+        ],
+        { ...ghOptions, ...githubHostExecOptions(ownerRepo) }
+      )
+      const parsed = JSON.parse(stdout) as {
+        data?: {
+          repository?: {
+            pullRequest?: {
+              reviewThreads?: {
+                nodes?: (ReviewThreadResolutionNode | null)[]
+                pageInfo?: { hasNextPage: boolean; endCursor?: string | null }
+              }
+            }
           }
         }
       }
+      const threads = parsed.data?.repository?.pullRequest?.reviewThreads
+      if (!Array.isArray(threads?.nodes) || !threads.pageInfo) {
+        return undefined
+      }
+      count += countUnresolvedReviewThreadNodes(threads.nodes)
+      if (!threads.pageInfo.hasNextPage) {
+        return count
+      }
+      const nextCursor = threads.pageInfo.endCursor
+      if (!nextCursor || nextCursor === cursor) {
+        return undefined
+      }
+      cursor = nextCursor
     }
-    const nodes = parsed.data?.repository?.pullRequest?.reviewThreads?.nodes
-    return Array.isArray(nodes) ? countUnresolvedReviewThreads(nodes) : undefined
   } catch {
     return undefined
   }

--- a/src/main/github/client/lookup/pull-request-lookup-data.ts
+++ b/src/main/github/client/lookup/pull-request-lookup-data.ts
@@ -72,6 +72,8 @@ export type GitHubPRBranchLookupOptions = HostedReviewExecutionOptions & {
   acceptMergedFallbackPR?: boolean
   // Why: compare merged implicit PRs against the worktree HEAD, not main repo HEAD, without a worktree-scoped git call.
   currentHeadOid?: string | null
+  // Why: one extra GraphQL call per open PR; only the sidebar's hosted-review path opts in.
+  includeUnresolvedReviewCommentCount?: boolean
 }
 
 export function mapRestPRMergeable(pr: RestPullRequest): PRMergeableState {

--- a/src/main/gitlab/client-mr-branch-lookup.test.ts
+++ b/src/main/gitlab/client-mr-branch-lookup.test.ts
@@ -106,6 +106,41 @@ describe('gitlab client — MR operations', () => {
       )
     })
 
+    it('counts unresolved non-bot discussions when the open MR has user notes', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify({ iid: 10, title: 't', state: 'opened', user_notes_count: 3 })
+        })
+        .mockResolvedValueOnce({
+          stdout: JSON.stringify([
+            { notes: [{ resolvable: true, resolved: false, author: { username: 'alice' } }] },
+            { notes: [{ resolvable: true, resolved: true, author: { username: 'alice' } }] },
+            {
+              notes: [
+                { resolvable: true, resolved: false, author: { username: 'ci', state: 'bot' } }
+              ]
+            }
+          ])
+        })
+      const mr = await getMergeRequest('/repo', 10)
+      expect(mr?.unresolvedReviewCommentCount).toBe(1)
+      expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
+        ['api', 'projects/g%2Fp/merge_requests/10/discussions?per_page=100'],
+        { cwd: '/repo' }
+      )
+    })
+
+    it('reports zero without fetching discussions when the MR has no user notes', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify({ iid: 10, title: 't', state: 'opened', user_notes_count: 0 })
+      })
+      const mr = await getMergeRequest('/repo', 10)
+      expect(mr?.unresolvedReviewCommentCount).toBe(0)
+      expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    })
+
     it('falls back to `glab mr view` when project ref is unresolved', async () => {
       getProjectRefMock.mockResolvedValueOnce(null)
       glabExecFileAsyncMock.mockResolvedValueOnce({

--- a/src/main/gitlab/merge-request-lookup.ts
+++ b/src/main/gitlab/merge-request-lookup.ts
@@ -8,9 +8,11 @@ import {
   glabRepoExecOptions,
   glabExecFileAsync,
   release,
+  type LocalGitExecOptions,
   type ProjectRef
 } from './gl-utils'
 import { encodedProject } from './project-path-encoding'
+import { countUnresolvedDiscussions, fetchDiscussions } from './mr-discussion-notes'
 import {
   hasHostedReviewLocalGitOptions,
   getHostedReviewLocalGitOptions,
@@ -34,6 +36,45 @@ export async function getProjectSlug(
   const localGitArgs = hostedReviewLocalGitOptionArgs(options)
   const knownHosts = await getGlabKnownHosts(connectionId, localGitArgs[0])
   return getProjectRef(repoPath, knownHosts, connectionId, ...localGitArgs)
+}
+
+type GitLabMRPipelineRaw = Parameters<typeof mapMRInfo>[0] & {
+  head_pipeline?: { status?: string } | null
+  pipeline?: { status?: string } | null
+  user_notes_count?: number
+}
+
+/**
+ * Attach the unresolved-discussion count for an open MR. `user_notes_count` comes free on the
+ * list/detail payload, so the extra `/discussions` call only happens when there is something to count.
+ */
+async function withUnresolvedCommentCount(
+  info: MRInfo,
+  raw: GitLabMRPipelineRaw,
+  repoPath: string,
+  projectRef: ProjectRef | null,
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): Promise<MRInfo> {
+  if (!projectRef || raw.state !== 'opened' || typeof raw.user_notes_count !== 'number') {
+    return info
+  }
+  if (raw.user_notes_count === 0) {
+    return { ...info, unresolvedReviewCommentCount: 0 }
+  }
+  try {
+    const discussions = await fetchDiscussions(
+      repoPath,
+      projectRef,
+      'mr',
+      info.number,
+      connectionId,
+      localGitOptions
+    )
+    return { ...info, unresolvedReviewCommentCount: countUnresolvedDiscussions(discussions) }
+  } catch {
+    return info
+  }
 }
 
 /**
@@ -63,13 +104,17 @@ export async function getMergeRequest(
       args,
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = JSON.parse(stdout) as Parameters<typeof mapMRInfo>[0] & {
-      head_pipeline?: { status?: string } | null
-      pipeline?: { status?: string } | null
-    }
+    const data = JSON.parse(stdout) as GitLabMRPipelineRaw
     // Why: older GitLab instances expose `pipeline` instead of `head_pipeline`; try both.
     const pipelineStatus = derivePipelineStatus(data.head_pipeline ?? data.pipeline ?? null)
-    return mapMRInfo(data, pipelineStatus)
+    return withUnresolvedCommentCount(
+      mapMRInfo(data, pipelineStatus),
+      data,
+      repoPath,
+      projectRef,
+      connectionId,
+      localGitOptions
+    )
   } catch {
     return null
   } finally {
@@ -112,12 +157,16 @@ export async function getMergeRequestForBranch(
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
-      const raw = JSON.parse(stdout) as Parameters<typeof mapMRInfo>[0] & {
-        head_pipeline?: { status?: string } | null
-        pipeline?: { status?: string } | null
-      }
+      const raw = JSON.parse(stdout) as GitLabMRPipelineRaw
       const pipelineStatus = derivePipelineStatus(raw.head_pipeline ?? raw.pipeline ?? null)
-      return mapMRInfo(raw, pipelineStatus)
+      return withUnresolvedCommentCount(
+        mapMRInfo(raw, pipelineStatus),
+        raw,
+        repoPath,
+        projectRef,
+        connectionId,
+        localGitOptions
+      )
     }
     if (branchName) {
       const { stdout } = await glabExecFileAsync(
@@ -132,10 +181,7 @@ export async function getMergeRequestForBranch(
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
-      const data = JSON.parse(stdout) as (Parameters<typeof mapMRInfo>[0] & {
-        head_pipeline?: { status?: string } | null
-        pipeline?: { status?: string } | null
-      })[]
+      const data = JSON.parse(stdout) as GitLabMRPipelineRaw[]
       if (Array.isArray(data) && data.length > 0) {
         const raw = data[0]
         // Why: older GitLab list payloads expose `pipeline` instead of `head_pipeline`.
@@ -151,7 +197,14 @@ export async function getMergeRequestForBranch(
           localGitOptions
         })
         if (!hideOnDefaultBranch) {
-          return info
+          return withUnresolvedCommentCount(
+            info,
+            raw,
+            repoPath,
+            projectRef,
+            connectionId,
+            localGitOptions
+          )
         }
       }
     }

--- a/src/main/gitlab/merge-request-lookup.ts
+++ b/src/main/gitlab/merge-request-lookup.ts
@@ -12,7 +12,7 @@ import {
   type ProjectRef
 } from './gl-utils'
 import { encodedProject } from './project-path-encoding'
-import { countUnresolvedDiscussions, fetchDiscussions } from './mr-discussion-notes'
+import { fetchUnresolvedDiscussionCount } from './mr-discussion-notes'
 import {
   hasHostedReviewLocalGitOptions,
   getHostedReviewLocalGitOptions,
@@ -63,15 +63,14 @@ async function withUnresolvedCommentCount(
     return { ...info, unresolvedReviewCommentCount: 0 }
   }
   try {
-    const discussions = await fetchDiscussions(
+    const count = await fetchUnresolvedDiscussionCount(
       repoPath,
       projectRef,
-      'mr',
       info.number,
       connectionId,
       localGitOptions
     )
-    return { ...info, unresolvedReviewCommentCount: countUnresolvedDiscussions(discussions) }
+    return { ...info, unresolvedReviewCommentCount: count }
   } catch {
     return info
   }

--- a/src/main/gitlab/mr-discussion-notes.test.ts
+++ b/src/main/gitlab/mr-discussion-notes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { countUnresolvedDiscussions } from './mr-discussion-notes'
+
+describe('countUnresolvedDiscussions', () => {
+  it('counts discussions whose root note is unresolved and human-authored', () => {
+    expect(
+      countUnresolvedDiscussions([
+        {
+          notes: [
+            {
+              resolvable: true,
+              resolved: false,
+              author: { username: 'alice' }
+            }
+          ]
+        },
+        {
+          notes: [{ resolvable: true, resolved: true, author: { username: 'alice' } }]
+        },
+        // Why: non-resolvable notes (plain comments) never block review.
+        { notes: [{ resolvable: false, author: { username: 'alice' } }] },
+        {
+          notes: [
+            {
+              resolvable: true,
+              resolved: false,
+              author: { username: 'ci', state: 'bot' }
+            }
+          ]
+        },
+        {
+          notes: [
+            { system: true, body: 'changed the description' },
+            { resolvable: true, resolved: false, author: { username: 'bob' } }
+          ]
+        }
+      ])
+    ).toBe(2)
+  })
+})

--- a/src/main/gitlab/mr-discussion-notes.test.ts
+++ b/src/main/gitlab/mr-discussion-notes.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { countUnresolvedDiscussions } from './mr-discussion-notes'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { countUnresolvedDiscussions, fetchUnresolvedDiscussionCount } from './mr-discussion-notes'
 
 describe('countUnresolvedDiscussions', () => {
   it('counts discussions whose root note is unresolved and human-authored', () => {
@@ -36,5 +36,69 @@ describe('countUnresolvedDiscussions', () => {
         }
       ])
     ).toBe(2)
+  })
+})
+
+const { exec, repoOptions, hostnameArgs } = vi.hoisted(() => ({
+  exec: vi.fn(),
+  repoOptions: vi.fn(),
+  hostnameArgs: vi.fn()
+}))
+vi.mock('./gl-utils', () => ({
+  glabExecFileAsync: exec,
+  glabRepoExecOptions: repoOptions,
+  glabHostnameArgs: hostnameArgs
+}))
+
+describe('fetchUnresolvedDiscussionCount', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    hostnameArgs.mockReturnValue(['--hostname', 'gitlab.example.com'])
+    repoOptions.mockReturnValue({ cwd: '/workspace' })
+  })
+
+  it('includes unresolved discussions on page two and preserves execution options', async () => {
+    exec
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(
+          Array.from({ length: 100 }, () => ({
+            notes: [{ resolvable: true, resolved: true }]
+          }))
+        )
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          { notes: [{ resolvable: true, resolved: false, author: { username: 'alice' } }] }
+        ])
+      })
+    const project = { host: 'gitlab.example.com', path: 'g/p' }
+    const options = { wslDistro: 'Ubuntu' }
+    expect(await fetchUnresolvedDiscussionCount('/workspace', project, 12, 'ssh-id', options)).toBe(
+      1
+    )
+    expect(exec).toHaveBeenCalledTimes(2)
+    expect(exec.mock.calls[1][0]).toEqual([
+      'api',
+      '--hostname',
+      'gitlab.example.com',
+      'projects/g%2Fp/merge_requests/12/discussions?per_page=100&page=2'
+    ])
+    expect(repoOptions).toHaveBeenLastCalledWith('/workspace', 'ssh-id', options)
+    expect(hostnameArgs).toHaveBeenLastCalledWith(project, 'ssh-id')
+  })
+
+  it('rejects a later page failure instead of returning a partial count', async () => {
+    exec
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify(
+          Array.from({ length: 100 }, () => ({
+            notes: [{ resolvable: true, resolved: false }]
+          }))
+        )
+      })
+      .mockRejectedValueOnce(new Error('offline'))
+    await expect(
+      fetchUnresolvedDiscussionCount('/workspace', { host: 'gitlab.com', path: 'g/p' }, 12)
+    ).rejects.toThrow('offline')
   })
 })

--- a/src/main/gitlab/mr-discussion-notes.ts
+++ b/src/main/gitlab/mr-discussion-notes.ts
@@ -1,4 +1,5 @@
 import type { MRComment } from '../../shared/gitlab-types'
+import { isBotPRCommentAuthor } from '../../shared/pr-comment-audience'
 import { encodedProject } from './project-path-encoding'
 import {
   glabHostnameArgs,
@@ -58,6 +59,22 @@ export function flattenDiscussions(discussions: GitLabRawDiscussion[]): MRCommen
   // Why: oldest-first matches gitlab.com's conversation rendering and
   // makes "what's new" intuitive when polling for updates later.
   return out.sort((a, b) => (a.createdAt ?? '').localeCompare(b.createdAt ?? ''))
+}
+
+/** Discussions whose root note is resolvable, unresolved, and not bot-authored. */
+export function countUnresolvedDiscussions(discussions: readonly GitLabRawDiscussion[]): number {
+  let count = 0
+  for (const discussion of discussions) {
+    const root = discussion.notes?.find((note) => note.system !== true)
+    if (!root || root.resolvable !== true || root.resolved === true) {
+      continue
+    }
+    if (isBotPRCommentAuthor(root.author?.username ?? '', root.author?.state === 'bot')) {
+      continue
+    }
+    count += 1
+  }
+  return count
 }
 
 export async function fetchDiscussions(

--- a/src/main/gitlab/mr-discussion-notes.ts
+++ b/src/main/gitlab/mr-discussion-notes.ts
@@ -83,7 +83,8 @@ export async function fetchDiscussions(
   type: 'issue' | 'mr',
   iid: number,
   connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
+  localGitOptions: LocalGitExecOptions = {},
+  page?: number
 ): Promise<GitLabRawDiscussion[]> {
   const resource = type === 'mr' ? 'merge_requests' : 'issues'
   const { stdout } = await glabExecFileAsync(
@@ -92,9 +93,35 @@ export async function fetchDiscussions(
       ...glabHostnameArgs(projectRef, connectionId),
       // Why: detail drawers need a bounded recent conversation snapshot.
       // Walking every historic discussion can retain and render huge note sets.
-      `projects/${encodedProject(projectRef.path)}/${resource}/${iid}/discussions?per_page=100`
+      `projects/${encodedProject(projectRef.path)}/${resource}/${iid}/discussions?per_page=100${page ? `&page=${page}` : ''}`
     ],
     glabRepoExecOptions(repoPath, connectionId, localGitOptions)
   )
   return JSON.parse(stdout) as GitLabRawDiscussion[]
+}
+
+/** Count all pages without retaining the full conversation. */
+export async function fetchUnresolvedDiscussionCount(
+  repoPath: string,
+  projectRef: ProjectRef,
+  iid: number,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<number> {
+  let count = 0
+  for (let page = 1; ; page += 1) {
+    const discussions = await fetchDiscussions(
+      repoPath,
+      projectRef,
+      'mr',
+      iid,
+      connectionId,
+      localGitOptions,
+      page > 1 ? page : undefined
+    )
+    count += countUnresolvedDiscussions(discussions)
+    if (discussions.length < 100) {
+      return count
+    }
+  }
 }

--- a/src/main/source-control/forge-provider.test.ts
+++ b/src/main/source-control/forge-provider.test.ts
@@ -392,7 +392,8 @@ describe('forge provider interface', () => {
     })
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', '', null, 'ssh-1', 7, {
       acceptMergedFallbackPR: true,
-      currentHeadOid: null
+      currentHeadOid: null,
+      includeUnresolvedReviewCommentCount: true
     })
   })
 
@@ -407,7 +408,8 @@ describe('forge provider interface', () => {
     })
 
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', 'feature/x', null, null, null, {
-      currentHeadOid: 'abc1234'
+      currentHeadOid: 'abc1234',
+      includeUnresolvedReviewCommentCount: true
     })
   })
 

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -189,7 +189,8 @@ const gitHubForgeProvider = {
       {
         ...executionArgs[0],
         ...(fallbackReviewNumber !== null ? { acceptMergedFallbackPR: true } : {}),
-        currentHeadOid: input.githubCurrentHeadOid ?? null
+        currentHeadOid: input.githubCurrentHeadOid ?? null,
+        includeUnresolvedReviewCommentCount: true
       }
     )
     return unwrapGitHubPRForBranchOutcome(outcome)
@@ -197,17 +198,14 @@ const gitHubForgeProvider = {
   async getReviewByNumber(input) {
     await assertGitHubReviewRateLimitBudget(input)
     const executionArgs = hostedReviewExecutionArgs(input)
-    const outcome =
-      executionArgs.length > 0
-        ? await getPRForBranchOutcome(
-            input.repoPath,
-            '',
-            input.number,
-            forgeConnectionId(input),
-            null,
-            ...executionArgs
-          )
-        : await getPRForBranchOutcome(input.repoPath, '', input.number, forgeConnectionId(input))
+    const outcome = await getPRForBranchOutcome(
+      input.repoPath,
+      '',
+      input.number,
+      forgeConnectionId(input),
+      null,
+      { ...executionArgs[0], includeUnresolvedReviewCommentCount: true }
+    )
     return unwrapGitHubPRForBranchOutcome(outcome)
   },
   createReview: createGitHubPullRequest

--- a/src/main/source-control/forge-review-mappers.ts
+++ b/src/main/source-control/forge-review-mappers.ts
@@ -29,7 +29,10 @@ export function mapGitLabReview(mr: MRInfo): HostedReviewInfo {
     mergeable: mr.mergeable,
     ...(mr.mergeStateStatus !== undefined ? { mergeStateStatus: mr.mergeStateStatus } : {}),
     ...(mr.headSha ? { headSha: mr.headSha } : {}),
-    ...(mr.conflictSummary ? { conflictSummary: mr.conflictSummary } : {})
+    ...(mr.conflictSummary ? { conflictSummary: mr.conflictSummary } : {}),
+    ...(mr.unresolvedReviewCommentCount !== undefined
+      ? { unresolvedReviewCommentCount: mr.unresolvedReviewCommentCount }
+      : {})
   }
 }
 

--- a/src/main/source-control/hosted-review.test.ts
+++ b/src/main/source-control/hosted-review.test.ts
@@ -149,7 +149,8 @@ describe('getHostedReviewForBranch', () => {
       status: 'pending'
     })
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', 'feature', 3, null, null, {
-      currentHeadOid: null
+      currentHeadOid: null,
+      includeUnresolvedReviewCommentCount: true
     })
   })
 
@@ -225,7 +226,8 @@ describe('getHostedReviewForBranch', () => {
     })
     expect(getPRForBranchOutcomeMock).toHaveBeenCalledWith('/repo', '', null, null, 42, {
       acceptMergedFallbackPR: true,
-      currentHeadOid: null
+      currentHeadOid: null,
+      includeUnresolvedReviewCommentCount: true
     })
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -381,3 +381,54 @@ describe('WorktreeCardDetailsHover', () => {
     expect(markup).toContain('View on Linear')
   })
 })
+
+describe('WorktreeCardMetaBadges unresolved comment count', () => {
+  const review = {
+    provider: 'github' as const,
+    number: 12,
+    title: 'Add badges',
+    state: 'open' as const,
+    url: 'https://github.com/acme/orca/pull/12',
+    status: 'success' as const
+  }
+
+  it('shows a count badge with a tooltip label next to the review glyph', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardMetaBadges
+        issue={null}
+        linearIssue={null}
+        review={review}
+        unresolvedReviewCommentCount={3}
+        comment={null}
+      />
+    )
+    expect(markup).toContain('data-testid="review-comment-count"')
+    expect(markup).toContain('3 unresolved comments')
+  })
+
+  it('keeps the count when the new card style moves the review glyph to the status lane', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardMetaBadges
+        issue={null}
+        linearIssue={null}
+        review={null}
+        unresolvedReviewCommentCount={3}
+        comment={null}
+      />
+    )
+    expect(markup).toContain('data-testid="review-comment-count"')
+  })
+
+  it('renders nothing for the count at zero', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardMetaBadges
+        issue={null}
+        linearIssue={null}
+        review={review}
+        unresolvedReviewCommentCount={0}
+        comment={null}
+      />
+    )
+    expect(markup).not.toContain('review-comment-count')
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 import { LinearIcon } from '@/components/icons/LinearIcon'
 import { JiraIcon } from '@/components/icons/JiraIcon'
 import { MetaIconBadge } from './WorktreeCardMetadataControls'
-import { getReviewLabel, ReviewIcon } from './worktree-review-helpers'
+import { getReviewLabel, ReviewCommentCountBadge, ReviewIcon } from './worktree-review-helpers'
 import type {
   WorktreeCardMetaBadgesProps,
   WorktreeCardMetaBadgesRootProps
@@ -44,6 +44,7 @@ export const WorktreeCardMetaBadges = React.forwardRef<
     linearIssue,
     jiraIssue,
     review,
+    unresolvedReviewCommentCount = 0,
     comment,
     automationProvenance,
     cliProvenance,
@@ -52,7 +53,9 @@ export const WorktreeCardMetaBadges = React.forwardRef<
   },
   ref
 ): React.JSX.Element | null {
+  // Why: the new card style passes review=null here and only the count, so the count alone keeps the row.
   if (
+    unresolvedReviewCommentCount <= 0 &&
     !hasWorktreeCardDetails({
       issue,
       linearIssue,
@@ -151,6 +154,9 @@ export const WorktreeCardMetaBadges = React.forwardRef<
         >
           <ReviewIcon review={review} />
         </MetaIconBadge>
+      )}
+      {unresolvedReviewCommentCount > 0 && (
+        <ReviewCommentCountBadge count={unresolvedReviewCommentCount} />
       )}
     </div>
   )

--- a/src/renderer/src/components/sidebar/worktree-card-meta-types.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-meta-types.ts
@@ -35,6 +35,8 @@ export type WorktreeCardMetaBadgesProps = {
   linearIssue: WorktreeCardLinearIssueDisplay | null
   jiraIssue?: WorktreeCardJiraIssueDisplay | null
   review: WorktreeCardPrDisplay | null
+  /** Passed separately from `review` because the new card style moves the glyph to the status lane. */
+  unresolvedReviewCommentCount?: number
   comment: string | null
   automationProvenance?: AutomationWorkspaceProvenance | null
   cliProvenance?: CliWorkspaceProvenance | null

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -10,6 +10,7 @@ import {
   WorktreeCardMetaBadges
 } from './WorktreeCardMeta'
 import { WorktreeCardPortsDetails, WorktreeCardPortsTrigger } from './WorktreeCardPorts'
+import { getUnresolvedReviewCommentCount } from './worktree-review-helpers'
 import type { WorktreeCardController } from './use-worktree-card-controller'
 
 export function buildWorktreeCardPresentation(card: WorktreeCardController) {
@@ -212,6 +213,7 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
             linearIssue={metaLinearIssue}
             jiraIssue={metaJiraIssue}
             review={newCardStyle ? null : metaReview}
+            unresolvedReviewCommentCount={getUnresolvedReviewCommentCount(metaReview)}
             comment={metaComment}
             automationProvenance={metaAutomationProvenance}
             cliProvenance={metaCliProvenance}

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -1,6 +1,8 @@
 import { createElement } from 'react'
-import { GitMerge } from 'lucide-react'
+import { GitMerge, MessageSquare } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
 import { getReviewStateIcon } from '@/components/github/review-state-presentation'
 import { PullRequestIcon } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
@@ -77,4 +79,42 @@ export function ReviewIcon({
   return createElement(Icon, {
     className: cn(className, getCheckTone(review) ?? getStateTone(review.state))
   })
+}
+
+export function getUnresolvedReviewCommentCount(review: WorktreeCardPrDisplay | null): number {
+  return review && 'unresolvedReviewCommentCount' in review
+    ? (review.unresolvedReviewCommentCount ?? 0)
+    : 0
+}
+
+/** Speech-bubble count beside the review glyph; callers hide it at zero. */
+export function ReviewCommentCountBadge({ count }: { count: number }): React.JSX.Element {
+  const label =
+    count === 1
+      ? translate(
+          'auto.components.sidebar.WorktreeCardMeta.unresolvedCommentOne',
+          '1 unresolved comment'
+        )
+      : translate(
+          'auto.components.sidebar.WorktreeCardMeta.unresolvedCommentOther',
+          '{{count}} unresolved comments',
+          { count }
+        )
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="inline-flex h-3.5 shrink-0 items-center gap-0.5 text-[10px] font-medium tabular-nums leading-none text-muted-foreground/70 hover:text-foreground"
+          data-testid="review-comment-count"
+        >
+          <MessageSquare className="size-3" aria-hidden="true" />
+          {count}
+          <span className="sr-only">{label}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5503,7 +5503,9 @@
           "cliCreated": "Created by Orca CLI",
           "jiraIssue": "Jira {{value0}}",
           "viewOnJira": "View on Jira",
-          "linkedJira": "Linked Jira {{value0}}"
+          "linkedJira": "Linked Jira {{value0}}",
+          "unresolvedCommentOne": "1 unresolved comment",
+          "unresolvedCommentOther": "{{count}} unresolved comments"
         },
         "WorktreeCardMetadataStatusBadges": {
           "fe188062a1": "State: Open",

--- a/src/shared/github/pull-request-types.ts
+++ b/src/shared/github/pull-request-types.ts
@@ -87,6 +87,8 @@ export type PRInfo = {
   prRepo?: GitHubRepositoryIdentity
   headRepo?: GitHubRepositoryIdentity
   conflictSummary?: PRConflictSummary
+  /** Unresolved, non-bot review threads. Absent when the lookup could not report it. */
+  unresolvedReviewCommentCount?: number
 }
 
 export type IssueInfo = {

--- a/src/shared/gitlab-types.ts
+++ b/src/shared/gitlab-types.ts
@@ -54,6 +54,8 @@ export type MRInfo = {
   /** Target branch name for review-created worktree compare-base repair. */
   baseRefName?: string
   conflictSummary?: PRConflictSummary
+  /** Unresolved, non-bot discussions. Absent when the lookup could not report it. */
+  unresolvedReviewCommentCount?: number
 }
 
 // Why: GitLab emoji awards are open-ended, so we carry the raw award name and let the renderer decide.

--- a/src/shared/hosted-review-github.test.ts
+++ b/src/shared/hosted-review-github.test.ts
@@ -29,4 +29,12 @@ describe('hostedReviewInfoFromGitHubPRInfo', () => {
       githubRepository
     })
   })
+
+  it('passes the unresolved review comment count through only when present', () => {
+    expect(hostedReviewInfoFromGitHubPRInfo(pr)).not.toHaveProperty('unresolvedReviewCommentCount')
+    expect(
+      hostedReviewInfoFromGitHubPRInfo({ ...pr, unresolvedReviewCommentCount: 3 })
+        .unresolvedReviewCommentCount
+    ).toBe(3)
+  })
 })

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -21,6 +21,9 @@ export function hostedReviewInfoFromGitHubPRInfo(pr: PRInfo): HostedReviewInfo {
     ...(pr.confirmedContainedHeadOid
       ? { confirmedContainedHeadOid: pr.confirmedContainedHeadOid }
       : {}),
-    ...(pr.conflictSummary ? { conflictSummary: pr.conflictSummary } : {})
+    ...(pr.conflictSummary ? { conflictSummary: pr.conflictSummary } : {}),
+    ...(pr.unresolvedReviewCommentCount !== undefined
+      ? { unresolvedReviewCommentCount: pr.unresolvedReviewCommentCount }
+      : {})
   }
 }

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -50,6 +50,8 @@ export type HostedReviewInfo = {
   /** Target branch name for review-created worktree compare-base repair. */
   baseRefName?: string
   conflictSummary?: PRConflictSummary
+  /** Unresolved, non-bot review threads. Absent when the provider could not report it. */
+  unresolvedReviewCommentCount?: number
 }
 
 export type HostedReviewForBranchArgs = {

--- a/src/shared/pr-comment-audience.ts
+++ b/src/shared/pr-comment-audience.ts
@@ -37,9 +37,17 @@ export function isBotPRComment(
   comment: PRComment,
   botAuthorOverrides?: ReadonlySet<string>
 ): boolean {
-  const author = comment.author.trim()
+  return isBotPRCommentAuthor(comment.author, comment.isBot, botAuthorOverrides)
+}
+
+export function isBotPRCommentAuthor(
+  rawAuthor: string,
+  isBot?: boolean,
+  botAuthorOverrides?: ReadonlySet<string>
+): boolean {
+  const author = rawAuthor.trim()
   const normalized = normalizePRCommentAuthorLogin(author)
-  if (botAuthorOverrides?.has(normalized) || comment.isBot === true) {
+  if (botAuthorOverrides?.has(normalized) || isBot === true) {
     return true
   }
   if (normalized.endsWith(BOT_LOGIN_SUFFIX)) {


### PR DESCRIPTION
Closes #18485

## What

Shows a small speech-bubble badge with the unresolved review-comment count next to the PR/MR glyph on the sidebar workspace card. Hidden at zero, tooltip `N unresolved comments`. Works in both the legacy meta row and the new card style (where the glyph lives in the status lane and the count sits in the title-row indicators).

## How

- `HostedReviewInfo`, `PRInfo`, `MRInfo` gain an optional `unresolvedReviewCommentCount`; both review mappers and the mobile runtime parsers pass it through (a new optional field, so wire-compatible with older hosts and clients).
- **GitHub**: `gh pr view --json` has no thread-resolution field, so the hosted-review lookup opts in (`includeUnresolvedReviewCommentCount`) to one extra GraphQL call per open PR: `reviewThreads(first: 100) { isResolved, root author }`. The plain PR-refresh poll is unchanged. Guarded by the GraphQL rate-limit budget; any failure leaves the field absent.
- **GitLab**: `user_notes_count` already comes back on the list/detail payload and gates a bounded `/discussions?per_page=100` fetch. MRs with zero notes cost nothing extra. `blocking_discussions_resolved` was not used because it reports `true` whenever the project does not require resolution before merge.
- Both providers count only unresolved threads whose root author is not a bot, using the same built-in bot detection as the PR-comments panel (`isBotPRCommentAuthor`, extracted from `isBotPRComment`).

## Known limits

- User-configured bot-author overrides (renderer settings) are not applied to the count; built-in detection is.
- GitLab fetches discussions whenever the MR has any user notes, including MRs whose notes are all plain comments.
- The count only lands on the hosted-review cache, not the `prCache` fallback. Absence hides the badge; it never renders `0`.
- No rendered Electron UI check was performed. In the legacy card style the badge's tooltip sits inside the metadata hover-card trigger, so both may open on hover; if that stacks badly, drop the tooltip and keep the `sr-only` label.

## Verification

- `pnpm tc` clean
- `pnpm run check:code-quality:changed` clean
- `pnpm test src/main/github src/main/gitlab src/main/source-control src/renderer/src/components/sidebar mobile/src/session src/shared`: 1014 files / 10325 tests passing
- New tests: GitHub thread counting and option gating, GitLab discussion counting and the `user_notes_count` gate, mapper passthrough, badge render at N>0 (both card styles) and hidden at 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MUZ7hbomhVSDNjYfyp8tE
