### PR TITLE
fix(openloop-i0lrpa.3082): reconcile terminal close outcome

### DIFF
--- a/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
+++ b/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
@@ -7,6 +7,27 @@ import { countTerminalLayoutLeaves } from './headless-terminal-split-layout'
 import type { RuntimePtyTabCloseAuthority } from './runtime-terminal-state-records'
 
 export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithFocusTerminal {
+  /** Resolves a close target from the handle-indexed runtime state without host I/O. */
+  getTerminalCloseTarget(handle: string): { tabId: string } | null {
+    const pty = this.getLivePtyForHandle(handle)
+    if (pty) {
+      const authority: RuntimePtyTabCloseAuthority = {
+        handle,
+        ptyId: pty.pty.ptyId,
+        incarnationId: pty.pty.incarnationId,
+        worktreeId: pty.pty.worktreeId
+      }
+      const tabId =
+        this.resolvePtyTabCloseSurfaceAuthority(authority)?.surface.tab.parentTabId ?? pty.pty.tabId
+      return tabId ? { tabId } : null
+    }
+    try {
+      return { tabId: this.getLiveLeafForHandle(handle).leaf.tabId }
+    } catch {
+      return null
+    }
+  }
+
   protected async stopExplicitlyClosedTabPtys(
     ptyIds: readonly string[],
     addressedPtyId: string

--- a/src/main/runtime/rpc/runtime-close-attribution.test.ts
+++ b/src/main/runtime/rpc/runtime-close-attribution.test.ts
@@ -70,6 +70,7 @@ describe('runtime close attribution', () => {
       const close = vi.fn().mockResolvedValue({ handle: 'term-1', ptyKilled: true })
       const runtime = {
         getRuntimeId: () => 'test-runtime',
+        getTerminalCloseTarget: vi.fn().mockReturnValue(null),
         listTerminals: vi.fn().mockResolvedValue({
           terminals: [],
           hostScope: { hostIds: [], omittedHostIds: [] }
@@ -92,6 +93,7 @@ describe('runtime close attribution', () => {
 
       expect(JSON.parse(replies[0]!)).toMatchObject({ ok: true })
       expect(close).toHaveBeenCalledWith('term-1')
+      expect(runtime.listTerminals).not.toHaveBeenCalled()
       expect(sink.records).toEqual([
         expect.objectContaining({
           type: 'effect-span',
@@ -157,15 +159,16 @@ describe('runtime close attribution', () => {
     }
   )
 
-  it('reports a listed terminal as closed when retirement wins a tab_not_found race', async () => {
+  it('preserves closeTab result and telemetry when retirement wins a tab_not_found race', async () => {
     let terminals = [{ handle: 'term-race', tabId: 'tab-race' }]
     const runtime = {
       getRuntimeId: () => 'test-runtime',
+      getTerminalCloseTarget: vi.fn().mockReturnValue({ tabId: 'tab-race' }),
       listTerminals: vi.fn(async () => ({
         terminals,
         hostScope: { hostIds: ['local'], omittedHostIds: [] }
       })),
-      closeTerminal: vi.fn(async () => {
+      closeTerminalTab: vi.fn(async () => {
         terminals = []
         throw new Error('tab_not_found')
       })
@@ -174,7 +177,7 @@ describe('runtime close attribution', () => {
     const replies: string[] = []
 
     await dispatcher.dispatchStreaming(
-      request('terminal.close', { terminal: 'term-race' }),
+      request('terminal.closeTab', { terminal: 'term-race' }),
       (reply) => replies.push(reply)
     )
 
@@ -185,17 +188,30 @@ describe('runtime close attribution', () => {
           handle: 'term-race',
           tabId: 'tab-race',
           outcome: 'closed',
+          closeMode: 'tab',
           ptyKilled: false
         }
       }
     })
-    expect((await runtime.listTerminals()).terminals).toEqual([])
+    expect(runtime.listTerminals).toHaveBeenCalledTimes(1)
+    expect(sink.records).toEqual([
+      expect.objectContaining({
+        name: 'terminal.closeTab',
+        attributes: expect.objectContaining({
+          outcome: 'succeeded-after-retirement',
+          tabId: 'tab-race',
+          closeMode: 'tab',
+          ptyKilled: false
+        })
+      })
+    ])
   })
 
   it('does not reinterpret tab_not_found without an attested state transition', async () => {
     const listed = [{ handle: 'term-live', tabId: 'tab-live' }]
     const runtime = {
       getRuntimeId: () => 'test-runtime',
+      getTerminalCloseTarget: vi.fn().mockReturnValue({ tabId: 'tab-live' }),
       listTerminals: vi.fn(async () => ({
         terminals: listed,
         hostScope: { hostIds: ['local'], omittedHostIds: [] }
@@ -211,12 +227,13 @@ describe('runtime close attribution', () => {
     )
 
     expect(JSON.parse(replies[0]!)).toMatchObject({ ok: false })
-    expect((await runtime.listTerminals()).terminals).toEqual(listed)
+    expect(runtime.listTerminals).toHaveBeenCalledTimes(1)
   })
 
-  it('reports already_absent only when both inventories attest absence', async () => {
+  it('reports already_absent only when targeted state and complete inventory attest absence', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
+      getTerminalCloseTarget: vi.fn().mockReturnValue(null),
       listTerminals: vi.fn(async () => ({
         terminals: [],
         hostScope: { hostIds: ['local'], omittedHostIds: [] }
@@ -235,12 +252,13 @@ describe('runtime close attribution', () => {
       ok: true,
       result: { close: { handle: 'term-absent', outcome: 'already_absent' } }
     })
-    expect(runtime.listTerminals).toHaveBeenCalledTimes(2)
+    expect(runtime.listTerminals).toHaveBeenCalledTimes(1)
   })
 
   it('preserves tab_not_found when inventory cannot attest absence', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
+      getTerminalCloseTarget: vi.fn().mockReturnValue(null),
       listTerminals: vi.fn(async () => ({
         terminals: [],
         hostScope: { hostIds: [], omittedHostIds: ['ssh:offline'] }

--- a/src/main/runtime/rpc/runtime-close-attribution.test.ts
+++ b/src/main/runtime/rpc/runtime-close-attribution.test.ts
@@ -70,6 +70,10 @@ describe('runtime close attribution', () => {
       const close = vi.fn().mockResolvedValue({ handle: 'term-1', ptyKilled: true })
       const runtime = {
         getRuntimeId: () => 'test-runtime',
+        listTerminals: vi.fn().mockResolvedValue({
+          terminals: [],
+          hostScope: { hostIds: [], omittedHostIds: [] }
+        }),
         [call]: close
       } as unknown as OrcaRuntimeService
       const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
@@ -152,4 +156,105 @@ describe('runtime close attribution', () => {
       expect(JSON.stringify(sink.records)).not.toContain(BEARER_CLIENT_ID)
     }
   )
+
+  it('reports a listed terminal as closed when retirement wins a tab_not_found race', async () => {
+    let terminals = [{ handle: 'term-race', tabId: 'tab-race' }]
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listTerminals: vi.fn(async () => ({
+        terminals,
+        hostScope: { hostIds: ['local'], omittedHostIds: [] }
+      })),
+      closeTerminal: vi.fn(async () => {
+        terminals = []
+        throw new Error('tab_not_found')
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      request('terminal.close', { terminal: 'term-race' }),
+      (reply) => replies.push(reply)
+    )
+
+    expect(JSON.parse(replies[0]!)).toMatchObject({
+      ok: true,
+      result: {
+        close: {
+          handle: 'term-race',
+          tabId: 'tab-race',
+          outcome: 'closed',
+          ptyKilled: false
+        }
+      }
+    })
+    expect((await runtime.listTerminals()).terminals).toEqual([])
+  })
+
+  it('does not reinterpret tab_not_found without an attested state transition', async () => {
+    const listed = [{ handle: 'term-live', tabId: 'tab-live' }]
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listTerminals: vi.fn(async () => ({
+        terminals: listed,
+        hostScope: { hostIds: ['local'], omittedHostIds: [] }
+      })),
+      closeTerminal: vi.fn().mockRejectedValue(new Error('tab_not_found'))
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      request('terminal.close', { terminal: 'term-live' }),
+      (reply) => replies.push(reply)
+    )
+
+    expect(JSON.parse(replies[0]!)).toMatchObject({ ok: false })
+    expect((await runtime.listTerminals()).terminals).toEqual(listed)
+  })
+
+  it('reports already_absent only when both inventories attest absence', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listTerminals: vi.fn(async () => ({
+        terminals: [],
+        hostScope: { hostIds: ['local'], omittedHostIds: [] }
+      })),
+      closeTerminal: vi.fn().mockRejectedValue(new Error('tab_not_found'))
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      request('terminal.close', { terminal: 'term-absent' }),
+      (reply) => replies.push(reply)
+    )
+
+    expect(JSON.parse(replies[0]!)).toMatchObject({
+      ok: true,
+      result: { close: { handle: 'term-absent', outcome: 'already_absent' } }
+    })
+    expect(runtime.listTerminals).toHaveBeenCalledTimes(2)
+  })
+
+  it('preserves tab_not_found when inventory cannot attest absence', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      listTerminals: vi.fn(async () => ({
+        terminals: [],
+        hostScope: { hostIds: [], omittedHostIds: ['ssh:offline'] }
+      })),
+      closeTerminal: vi.fn().mockRejectedValue(new Error('tab_not_found'))
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: TERMINAL_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      request('terminal.close', { terminal: 'term-unverifiable' }),
+      (reply) => replies.push(reply)
+    )
+
+    expect(JSON.parse(replies[0]!)).toMatchObject({ ok: false })
+  })
 })

--- a/src/main/runtime/rpc/terminal-close-attribution.ts
+++ b/src/main/runtime/rpc/terminal-close-attribution.ts
@@ -5,6 +5,34 @@ import type { RpcContext } from './core'
 type TerminalCloseMethod = 'terminal.close' | 'terminal.closeTab'
 type TerminalCloseTargetKind = 'terminal' | 'terminal-tab'
 
+type TerminalPresence =
+  | { state: 'present'; tabId: string }
+  | { state: 'absent' }
+  | { state: 'unknown' }
+
+async function attestTerminalPresence(
+  context: Pick<RpcContext, 'runtime'>,
+  terminal: string
+): Promise<TerminalPresence> {
+  try {
+    const listed = await context.runtime.listTerminals(undefined, 1, {
+      handles: [terminal],
+      includeVisualLayouts: false
+    })
+    if (!listed.hostScope || listed.hostScope.omittedHostIds.length > 0) {
+      return { state: 'unknown' }
+    }
+    const match = listed.terminals.find((candidate) => candidate.handle === terminal)
+    return match ? { state: 'present', tabId: match.tabId } : { state: 'absent' }
+  } catch {
+    return { state: 'unknown' }
+  }
+}
+
+function isTabNotFound(error: unknown): boolean {
+  return error instanceof Error && error.message === 'tab_not_found'
+}
+
 export function withTerminalCloseAttribution(
   method: TerminalCloseMethod,
   context: Pick<
@@ -19,6 +47,7 @@ export function withTerminalCloseAttribution(
     method,
     async (span) => {
       span.setAttribute('decision', 'allowed')
+      const before = await attestTerminalPresence(context, terminal)
       try {
         const result = await close()
         span.setAttribute('outcome', 'succeeded')
@@ -27,8 +56,28 @@ export function withTerminalCloseAttribution(
         if (result.closeMode) {
           span.setAttribute('closeMode', result.closeMode)
         }
-        return result
+        return { ...result, outcome: 'closed' }
       } catch (error) {
+        if (isTabNotFound(error)) {
+          const after = await attestTerminalPresence(context, terminal)
+          if (before.state === 'present' && after.state === 'absent') {
+            span.setAttribute('outcome', 'succeeded-after-retirement')
+            return {
+              handle: terminal,
+              tabId: before.tabId,
+              outcome: 'closed',
+              ptyKilled: false
+            }
+          }
+          if (before.state === 'absent' && after.state === 'absent') {
+            span.setAttribute('outcome', 'already-absent')
+            return {
+              handle: terminal,
+              outcome: 'already_absent',
+              ptyKilled: false
+            }
+          }
+        }
         span.setAttribute('outcome', 'failed')
         throw error
       }

--- a/src/main/runtime/rpc/terminal-close-attribution.ts
+++ b/src/main/runtime/rpc/terminal-close-attribution.ts
@@ -10,6 +10,9 @@ type TerminalPresence =
   | { state: 'absent' }
   | { state: 'unknown' }
 
+/**
+ * Resolves exact-handle terminal presence from the authoritative runtime inventory.
+ */
 async function attestTerminalPresence(
   context: Pick<RpcContext, 'runtime'>,
   terminal: string
@@ -29,10 +32,16 @@ async function attestTerminalPresence(
   }
 }
 
+/**
+ * Identifies the runtime close race where the terminal surface has already retired.
+ */
 function isTabNotFound(error: unknown): boolean {
   return error instanceof Error && error.message === 'tab_not_found'
 }
 
+/**
+ * Wraps terminal close RPCs with attribution and reconciles tab_not_found races against inventory.
+ */
 export function withTerminalCloseAttribution(
   method: TerminalCloseMethod,
   context: Pick<

--- a/src/main/runtime/rpc/terminal-close-attribution.ts
+++ b/src/main/runtime/rpc/terminal-close-attribution.ts
@@ -10,6 +10,8 @@ type TerminalPresence =
   | { state: 'absent' }
   | { state: 'unknown' }
 
+type TerminalCloseTarget = { tabId: string } | null
+
 /**
  * Resolves exact-handle terminal presence from the authoritative runtime inventory.
  */
@@ -39,6 +41,23 @@ function isTabNotFound(error: unknown): boolean {
   return error instanceof Error && error.message === 'tab_not_found'
 }
 
+/** Records result fields shared by ordinary and reconciled terminal closes. */
+function recordCloseResult(
+  span: { setAttribute(key: string, value: string | number | boolean): void },
+  result: RuntimeTerminalClose,
+  outcome: string
+): RuntimeTerminalClose {
+  span.setAttribute('outcome', outcome)
+  if (result.tabId) {
+    span.setAttribute('tabId', result.tabId)
+  }
+  span.setAttribute('ptyKilled', result.ptyKilled)
+  if (result.closeMode) {
+    span.setAttribute('closeMode', result.closeMode)
+  }
+  return result
+}
+
 /**
  * Wraps terminal close RPCs with attribution and reconciles tab_not_found races against inventory.
  */
@@ -56,35 +75,29 @@ export function withTerminalCloseAttribution(
     method,
     async (span) => {
       span.setAttribute('decision', 'allowed')
-      const before = await attestTerminalPresence(context, terminal)
+      const before: TerminalCloseTarget = context.runtime.getTerminalCloseTarget(terminal)
       try {
         const result = await close()
-        span.setAttribute('outcome', 'succeeded')
-        span.setAttribute('tabId', result.tabId)
-        span.setAttribute('ptyKilled', result.ptyKilled)
-        if (result.closeMode) {
-          span.setAttribute('closeMode', result.closeMode)
-        }
-        return { ...result, outcome: 'closed' }
+        return recordCloseResult(span, { ...result, outcome: 'closed' }, 'succeeded')
       } catch (error) {
         if (isTabNotFound(error)) {
           const after = await attestTerminalPresence(context, terminal)
-          if (before.state === 'present' && after.state === 'absent') {
-            span.setAttribute('outcome', 'succeeded-after-retirement')
-            return {
+          if (before && after.state === 'absent') {
+            const result: RuntimeTerminalClose = {
               handle: terminal,
               tabId: before.tabId,
               outcome: 'closed',
+              ...(method === 'terminal.closeTab' ? { closeMode: 'tab' as const } : {}),
               ptyKilled: false
             }
+            return recordCloseResult(span, result, 'succeeded-after-retirement')
           }
-          if (before.state === 'absent' && after.state === 'absent') {
-            span.setAttribute('outcome', 'already-absent')
-            return {
-              handle: terminal,
-              outcome: 'already_absent',
-              ptyKilled: false
-            }
+          if (!before && after.state === 'absent') {
+            return recordCloseResult(
+              span,
+              { handle: terminal, outcome: 'already_absent', ptyKilled: false },
+              'already-absent'
+            )
           }
         }
         span.setAttribute('outcome', 'failed')

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -305,7 +305,8 @@ export type RuntimeTerminalFocus = {
 
 export type RuntimeTerminalClose = {
   handle: string
-  tabId: string
+  tabId?: string
+  outcome?: 'closed' | 'already_absent'
   closeMode?: 'tab'
   ptyKilled: boolean
   ptyStopVerdict?: 'live' | 'unverifiable'


### PR DESCRIPTION
## ELI5

Closing a terminal can race with worker retirement: the terminal may disappear after the close starts but before the close handler finishes. This change recognizes that proven race as a successful close instead of returning a misleading `tab_not_found` error.

## What Changed

- Capture the target tab from handle-indexed runtime state before closing, without listing terminals across the fleet on the successful path.
- After a `tab_not_found`, inventory the authoritative host scope and distinguish a proven close race, a terminal that was already absent, and an unverified failure.
- Preserve `closeMode: 'tab'` and close telemetry on the recovered `terminal.closeTab` path.
- Extend the shared close result with `outcome: 'closed' | 'already_absent'` and add regression coverage.

## Why

`orca terminal close` could remove the requested terminal successfully while reporting `ok: false`, `runtime_error`, and `tab_not_found`. The RPC attribution boundary now reports success only when exact before/after evidence proves the requested handle disappeared, while preserving errors when the handle is still live or host coverage is incomplete.

The adjacent stronger rule—turn every `tab_not_found` into success—is wrong because it would hide wrong-handle requests and unreachable-host failures.

## Linked Issue

Tracked externally as `openloop-i0lrpa.3082`; no upstream GitHub issue exists to auto-close.

## Visual Proof

N/A — this changes CLI/RPC outcome attribution and has no UI rendering change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/runtime-close-attribution.test.ts src/main/runtime/rpc/runtime-close-attribution-topology.test.ts` (35 tests passed)
- final focused regression suite (8 tests passed)
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 pnpm run test:e2e tests/e2e/completed-worker-retirement-resume.spec.ts --grep terminal-close-cli` reached an unrelated recovery precondition failure before the close assertion: expected `working`, observed `done`. Tracked as `openloop-i0lrpa.3084`.

## AI Disclosure

Implemented and reviewed with OpenAI Codex (`gpt-5.6-sol`) under an orchestrated OpenLoop workflow.

## Review

The Pullfrog findings on successful-path fleet fan-out and lost `closeMode`/telemetry were addressed in `de50d2d5423bb55b02de2c15bdcd237a8fdc53a9`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, shortcut, mobile, or filesystem-path behavior changes. Remote/SSH failure semantics remain fail-closed when authoritative host coverage is incomplete. The successful close path no longer performs fleet-wide inventory.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Relevant typecheck, quality, focused tests, and build pass; full CI will cover the repository-wide suite
