### PR TITLE
feat(status-bar): track Z.ai GLM Coding Plan usage

### DIFF
--- a/docs/site/content/docs/agents/usage-tracking.mdx
+++ b/docs/site/content/docs/agents/usage-tracking.mdx
@@ -12,7 +12,9 @@ Orca reads local usage state for Claude Code, Codex, Gemini, OpenCode, Kimi Code
 
 ## How it works
 
-Orca reads the local usage state each agent maintains on disk (under `~/.claude`, `~/.codex`, and the Gemini/OpenCode equivalents). No API calls, no extra auth. This means the readout is only as fresh as the agent's own bookkeeping — numbers update when the agent writes, not in real time.
+Orca reads the local usage state each agent maintains on disk (under `~/.claude`, `~/.codex`, and the Gemini/OpenCode equivalents) — no API calls, no extra auth for those. The readout is then only as fresh as the agent's own bookkeeping: numbers update when the agent writes, not in real time.
+
+Z.ai is the exception: there is no local state to read, so Orca calls the GLM Coding Plan quota API with the key you store under [Settings → Accounts](/docs/settings). Without a key the Z.ai row reads **Usage unavailable**.
 
 ## Multi-account accounting
 

--- a/docs/site/content/docs/agents/usage-tracking.mdx
+++ b/docs/site/content/docs/agents/usage-tracking.mdx
@@ -2,7 +2,7 @@
 title: Usage & rate-limit tracking
 ---
 
-Orca reads local usage state for Claude Code, Codex, Gemini, OpenCode, Kimi Code, and MiniMax and surfaces it in the status bar, so you know how close you are to a rate limit before an agent stalls.
+Orca reads local usage state for Claude Code, Codex, Gemini, OpenCode, Kimi Code, MiniMax, and Z.ai and surfaces it in the status bar, so you know how close you are to a rate limit before an agent stalls.
 
 ## What's shown
 

--- a/docs/site/content/docs/settings.mdx
+++ b/docs/site/content/docs/settings.mdx
@@ -91,6 +91,7 @@ Settings are grouped into panes. Everything here is searchable with `Cmd-,` then
 - Jira — Cloud (email + API token) or self-hosted Server/Data Center (PAT or username/password). See [Jira items drawer](/docs/review/jira).
 - Bitbucket Cloud — **Connect** with **Email & API token** (default) or an **Access token**. Orca verifies the credential before saving. `ORCA_BITBUCKET_*` environment variables take precedence and hide Connect / Disconnect. Saved credentials stay on this machine — on a [Remote Orca Server](/docs/remote-servers), set the env vars on the server instead. See [Hosted reviews](/docs/review/github).
 - MiniMax — paste a MiniMax session cookie (from `platform.minimax.io/console/usage`) to enable local usage and rate-limit tracking for the MiniMax CLI. Optional group ID and usage models fields override the defaults picked from the cookie.
+- Z.ai — paste a Z.ai API key to track GLM Coding Plan quota (5-hour and weekly windows) in the status bar. The key is stored encrypted and used only for Z.ai's quota endpoint; a Coding Plan subscription is required.
 - MCP servers.
 
 ## Notifications

--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -110,6 +110,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     defaultRepoSelection: null,
     defaultLinearTeamSelection: null,
     opencodeSessionCookie: '',
+    zaiApiKey: '',
     opencodeWorkspaceId: '',
     minimaxGroupId: '',
     minimaxUsageModels: 'general',

--- a/src/main/codex-accounts/service-reset-credit-test-fixtures.ts
+++ b/src/main/codex-accounts/service-reset-credit-test-fixtures.ts
@@ -35,6 +35,7 @@ export function createResetRateLimitState(
     antigravity: null,
     minimax: null,
     grok: null,
+    zai: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -131,6 +131,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     defaultRepoSelection: null,
     defaultLinearTeamSelection: null,
     opencodeSessionCookie: '',
+    zaiApiKey: '',
     opencodeWorkspaceId: '',
     minimaxGroupId: '',
     minimaxUsageModels: 'general',

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -61,6 +61,9 @@ export function updateSettings(
   if ('httpProxyUrl' in updates && !updates.httpProxyUrl) {
     operations.removeRetainedBlob(PROTECTED_SECRET_SLOT.httpProxyUrl)
   }
+  if ('zaiApiKey' in updates && !updates.zaiApiKey) {
+    operations.removeRetainedBlob(PROTECTED_SECRET_SLOT.zaiApiKey)
+  }
   // Why: coerce to boolean here (not the IPC edge) so every write path is covered and a truthy non-bool can't persist as "tray-minimize on".
   if ('minimizeToTrayOnClose' in updates) {
     sanitizedUpdates.minimizeToTrayOnClose = updates.minimizeToTrayOnClose === true

--- a/src/main/persistence/loading-store/loaded-state-parsing.ts
+++ b/src/main/persistence/loading-store/loaded-state-parsing.ts
@@ -105,6 +105,12 @@ export class LoadedStateParsingOperations {
             isLegacyOpenCodeSessionCookie
           )
         }
+        if (parsed.settings?.zaiApiKey) {
+          parsed.settings.zaiApiKey = this.runtime.protectedSecrets.decrypt(
+            PROTECTED_SECRET_SLOT.zaiApiKey,
+            parsed.settings.zaiApiKey
+          )
+        }
         if (parsed.settings?.httpProxyUrl) {
           const decryptedProxy = this.runtime.protectedSecrets.decryptWithStatus(
             PROTECTED_SECRET_SLOT.httpProxyUrl,

--- a/src/main/persistence/loading-store/state-serialization-secret-handling.ts
+++ b/src/main/persistence/loading-store/state-serialization-secret-handling.ts
@@ -118,6 +118,10 @@ export class StateSerializationSecretHandlingOperations {
         httpProxyUrl: encryptToSentinel(
           PROTECTED_SECRET_SLOT.httpProxyUrl,
           this.runtime.state.settings.httpProxyUrl ?? ''
+        ),
+        zaiApiKey: encryptToSentinel(
+          PROTECTED_SECRET_SLOT.zaiApiKey,
+          this.runtime.state.settings.zaiApiKey ?? ''
         )
       },
       ui: {

--- a/src/main/protected-secret-persistence.ts
+++ b/src/main/protected-secret-persistence.ts
@@ -2,6 +2,7 @@ import { getSecretStore } from '../shared/secret-store'
 
 export const PROTECTED_SECRET_SLOT = {
   opencodeSessionCookie: 'settings.opencodeSessionCookie',
+  zaiApiKey: 'settings.zaiApiKey',
   httpProxyUrl: 'settings.httpProxyUrl',
   browserKagiSessionLink: 'ui.browserKagiSessionLink'
 } as const

--- a/src/main/rate-limits/service/service-configuration.ts
+++ b/src/main/rate-limits/service/service-configuration.ts
@@ -9,6 +9,7 @@ import {
   type ClaudeAuthPreparationResolver,
   type OpenCodeGoRateLimitConfig,
   type MiniMaxRateLimitConfig,
+  type ZaiRateLimitConfig,
   type GeminiCliOAuthEnabledResolver,
   type InactiveCodexAccountInfo,
   type InactiveClaudeAccountInfo,
@@ -45,6 +46,10 @@ export abstract class RateLimitServiceConfiguration extends RateLimitServiceAcco
 
   setMiniMaxConfigResolver(resolver: () => MiniMaxRateLimitConfig): void {
     this.miniMaxConfigResolver = resolver
+  }
+
+  setZaiConfigResolver(resolver: () => ZaiRateLimitConfig): void {
+    this.zaiConfigResolver = resolver
   }
 
   setGeminiCliOAuthEnabledResolver(resolver: GeminiCliOAuthEnabledResolver): void {

--- a/src/main/rate-limits/service/service-full-cycle-application.ts
+++ b/src/main/rate-limits/service/service-full-cycle-application.ts
@@ -25,6 +25,8 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
       opencodeGeneration,
       miniMaxConfigChanged,
       miniMaxGeneration,
+      zaiConfigChanged,
+      zaiGeneration,
       claudeFetchGated,
       results: [
         claudeResult,
@@ -32,7 +34,8 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
         geminiResult,
         opencodeGoResult,
         kimiResult,
-        miniMaxResult
+        miniMaxResult,
+        zaiResult
       ],
       grokResultPromise
     } = prepared
@@ -125,6 +128,18 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
             status: 'error'
           } satisfies ProviderRateLimits)
 
+    const zai =
+      zaiResult.status === 'fulfilled'
+        ? zaiResult.value
+        : ({
+            provider: 'zai',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error: zaiResult.reason instanceof Error ? zaiResult.reason.message : 'Unknown error',
+            status: 'error'
+          } satisfies ProviderRateLimits)
+
     const latestCodexHome = this.resolveCodexHome(codexTarget)
     const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     if (signal.aborted) {
@@ -148,6 +163,7 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
       this.isSameClaudeTarget(claudeTarget, this.claudeFetchTarget)
     const shouldApplyOpencode = opencodeGeneration === this.opencodeFetchGeneration
     const shouldApplyMiniMax = miniMaxGeneration === this.minimaxFetchGeneration
+    const shouldApplyZai = zaiGeneration === this.zaiFetchGeneration
 
     if (shouldApplyClaude) {
       this.trackActiveFailureStreak('claude', claude)
@@ -163,6 +179,9 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
     this.trackActiveFailureStreak('kimi', kimi)
     if (shouldApplyMiniMax) {
       this.trackActiveFailureStreak('minimax', miniMax)
+    }
+    if (shouldApplyZai) {
+      this.trackActiveFailureStreak('zai', zai)
     }
 
     // Why: apply a Codex result only when provenance and generation still match, else a raced in-flight fetch overwrites the new account.
@@ -188,7 +207,12 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
         ? miniMaxConfigChanged
           ? miniMax
           : this.applyStalePolicy(miniMax, previousState.minimax)
-        : this.state.minimax
+        : this.state.minimax,
+      zai: shouldApplyZai
+        ? zaiConfigChanged
+          ? zai
+          : this.applyStalePolicy(zai, previousState.zai)
+        : this.state.zai
     })
 
     const grokResult = await grokResultPromise

--- a/src/main/rate-limits/service/service-full-cycle-preparation.ts
+++ b/src/main/rate-limits/service/service-full-cycle-preparation.ts
@@ -5,6 +5,7 @@ import { fetchGrokRateLimits } from '../grok-fetcher'
 import { readGrokAuthSession } from '../grok-auth'
 import { fetchMiniMaxRateLimits } from '../minimax-fetcher'
 import { fetchOpenCodeGoRateLimits } from '../opencode-go-usage-fetcher'
+import { fetchZaiRateLimits } from '../zai-fetcher'
 import { RateLimitServiceFetchPolicy } from './service-fetch-policy'
 import type {
   ClaudeRuntimeAuthPreparation,
@@ -29,8 +30,11 @@ export type FetchAllCyclePrepared = {
   opencodeGeneration: number
   miniMaxConfigChanged: boolean
   miniMaxGeneration: number
+  zaiConfigChanged: boolean
+  zaiGeneration: number
   claudeFetchGated: boolean
   results: [
+    PromiseSettledResult<ProviderRateLimits>,
     PromiseSettledResult<ProviderRateLimits>,
     PromiseSettledResult<ProviderRateLimits>,
     PromiseSettledResult<ProviderRateLimits>,
@@ -80,6 +84,7 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
     const miniMaxCookie = miniMaxConfigResult.config.sessionCookie
     const miniMaxGroupId = miniMaxConfigResult.config.groupId
     const miniMaxModels = miniMaxConfigResult.config.models
+    const zaiApiKey = this.zaiConfigResolver?.().apiKey ?? ''
     const geminiCliOAuthEnabled = this.geminiCliOAuthEnabledResolver?.() ?? false
     // Why: getState() is hot (renderer pushes + mobile snapshots); keep Grok's sync auth-file probe on fetch cycles instead.
     const grokAuthReadResult = readGrokAuthSession()
@@ -102,6 +107,13 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
     }
     const miniMaxGeneration = this.minimaxFetchGeneration
 
+    const zaiConfigChanged = zaiApiKey !== this.lastZaiConfigHash
+    if (zaiConfigChanged) {
+      this.lastZaiConfigHash = zaiApiKey
+      this.zaiFetchGeneration += 1
+    }
+    const zaiGeneration = this.zaiFetchGeneration
+
     // Mark all providers fetching while keeping previous data visible (Codex is cleared separately on account change).
     this.updateState({
       ...previousState,
@@ -119,7 +131,10 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
       minimax: miniMaxConfigChanged
         ? this.withFetchingStatus(null, 'minimax')
         : this.withFetchingStatus(previousState.minimax, 'minimax'),
-      grok: this.withFetchingStatus(previousState.grok, 'grok')
+      grok: this.withFetchingStatus(previousState.grok, 'grok'),
+      zai: zaiConfigChanged
+        ? this.withFetchingStatus(null, 'zai')
+        : this.withFetchingStatus(previousState.zai, 'zai')
     })
 
     const missingWslCodexHome =
@@ -136,40 +151,48 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
 
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
-      await Promise.allSettled([
-        claudeFetchGated
-          ? Promise.resolve(previousState.claude as ProviderRateLimits)
-          : fetchClaudeRateLimits({
-              authPreparation: claudeAuthPreparation,
-              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-              networkProxySettings: this.networkProxySettingsResolver?.(),
-              signal
-            }),
-        codexFetchGated
-          ? Promise.resolve(previousState.codex as ProviderRateLimits)
-          : (missingWslCodexHome ??
-            fetchCodexRateLimits({
-              codexHomePath,
-              allowPtyFallback: this.shouldAllowCodexPtyFallback(),
-              signal
-            })),
-        fetchGeminiRateLimits(geminiCliOAuthEnabled),
-        fetchOpenCodeGoRateLimits(
-          cookie,
-          workspaceIdOverride || undefined,
-          this.networkProxySettingsResolver?.()
-        ),
-        this.fetchKimiWithResolvedHome(),
-        miniMaxConfigResult.error
-          ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
-          : fetchMiniMaxRateLimits({
-              cookie: miniMaxCookie,
-              groupId: miniMaxGroupId,
-              models: miniMaxModels
-            })
-      ])
+    const [
+      claudeResult,
+      codexResult,
+      geminiResult,
+      opencodeGoResult,
+      kimiResult,
+      miniMaxResult,
+      zaiResult
+    ] = await Promise.allSettled([
+      claudeFetchGated
+        ? Promise.resolve(previousState.claude as ProviderRateLimits)
+        : fetchClaudeRateLimits({
+            authPreparation: claudeAuthPreparation,
+            allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+            allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
+            signal
+          }),
+      codexFetchGated
+        ? Promise.resolve(previousState.codex as ProviderRateLimits)
+        : (missingWslCodexHome ??
+          fetchCodexRateLimits({
+            codexHomePath,
+            allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            signal
+          })),
+      fetchGeminiRateLimits(geminiCliOAuthEnabled),
+      fetchOpenCodeGoRateLimits(
+        cookie,
+        workspaceIdOverride || undefined,
+        this.networkProxySettingsResolver?.()
+      ),
+      this.fetchKimiWithResolvedHome(),
+      miniMaxConfigResult.error
+        ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
+        : fetchMiniMaxRateLimits({
+            cookie: miniMaxCookie,
+            groupId: miniMaxGroupId,
+            models: miniMaxModels
+          }),
+      fetchZaiRateLimits({ apiKey: zaiApiKey })
+    ])
 
     if (signal.aborted) {
       return null
@@ -189,6 +212,8 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
       opencodeGeneration,
       miniMaxConfigChanged,
       miniMaxGeneration,
+      zaiConfigChanged,
+      zaiGeneration,
       claudeFetchGated,
       results: [
         claudeResult,
@@ -196,7 +221,8 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
         geminiResult,
         opencodeGoResult,
         kimiResult,
-        miniMaxResult
+        miniMaxResult,
+        zaiResult
       ],
       grokResultPromise
     }

--- a/src/main/rate-limits/service/service-full-cycle-preparation.ts
+++ b/src/main/rate-limits/service/service-full-cycle-preparation.ts
@@ -191,7 +191,7 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
             groupId: miniMaxGroupId,
             models: miniMaxModels
           }),
-      fetchZaiRateLimits({ apiKey: zaiApiKey })
+      fetchZaiRateLimits({ apiKey: zaiApiKey, signal })
     ])
 
     if (signal.aborted) {

--- a/src/main/rate-limits/service/service-polling.ts
+++ b/src/main/rate-limits/service/service-polling.ts
@@ -78,7 +78,8 @@ export abstract class RateLimitServicePolling extends RateLimitServiceFetchQueue
       kimi: this.state.kimi,
       minimax: this.state.minimax,
       grok: this.state.grok,
-      antigravity: this.state.antigravity
+      antigravity: this.state.antigravity,
+      zai: this.state.zai
     }
     return Object.entries(byProvider).map(([provider, limits]) => ({
       provider: provider as ActiveRateLimitProvider,

--- a/src/main/rate-limits/service/service-result-policy.ts
+++ b/src/main/rate-limits/service/service-result-policy.ts
@@ -92,6 +92,7 @@ export abstract class RateLimitServiceResultPolicy extends RateLimitServiceFetch
       | 'minimax'
       | 'grok'
       | 'antigravity'
+      | 'zai'
   ): ProviderRateLimits {
     if (!current) {
       return {

--- a/src/main/rate-limits/service/service-state.ts
+++ b/src/main/rate-limits/service/service-state.ts
@@ -13,6 +13,7 @@ import {
   type ClaudeAuthPreparationResolver,
   type OpenCodeGoRateLimitConfig,
   type MiniMaxRateLimitConfig,
+  type ZaiRateLimitConfig,
   type GeminiCliOAuthEnabledResolver,
   type NormalizedCodexAccountSelectionTarget,
   type NormalizedClaudeAccountSelectionTarget,
@@ -31,7 +32,8 @@ export abstract class RateLimitServiceState {
     kimi: null,
     antigravity: null,
     minimax: null,
-    grok: null
+    grok: null,
+    zai: null
   }
   protected grokAuthConfigured = readGrokAuthSession().status === 'ok'
   protected pollInterval: number = DEFAULT_POLL_MS
@@ -46,7 +48,8 @@ export abstract class RateLimitServiceState {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    zai: 0
   }
   // Why: consecutive failures drive exponential backoff of the fast activation-retry lane; reset on any success/unavailable result.
   protected activeFailureStreakByProvider: Record<ActiveRateLimitProvider, number> = {
@@ -57,7 +60,8 @@ export abstract class RateLimitServiceState {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    zai: 0
   }
   protected mainWindow: BrowserWindow | null = null
   protected detachWindowListeners: (() => void) | null = null
@@ -74,8 +78,10 @@ export abstract class RateLimitServiceState {
   protected lastClaudeAuthSnapshot: { configDir: string | null; provenance: string } | null = null
   protected opencodeFetchGeneration = 0
   protected minimaxFetchGeneration = 0
+  protected zaiFetchGeneration = 0
   protected lastOpencodeConfigHash = ''
   protected lastMiniMaxConfigHash = ''
+  protected lastZaiConfigHash = ''
   protected codexHomePathResolver: CodexHomePathResolver | null = null
   protected codexFetchTarget: NormalizedCodexAccountSelectionTarget = {
     runtime: 'host',
@@ -90,6 +96,7 @@ export abstract class RateLimitServiceState {
   }
   protected openCodeGoConfigResolver: (() => OpenCodeGoRateLimitConfig) | null = null
   protected miniMaxConfigResolver: (() => MiniMaxRateLimitConfig) | null = null
+  protected zaiConfigResolver: (() => ZaiRateLimitConfig) | null = null
   protected geminiCliOAuthEnabledResolver: GeminiCliOAuthEnabledResolver | null = null
   protected inactiveClaudeAccountsResolver: (() => InactiveClaudeAccountInfo[]) | null = null
   protected inactiveCodexAccountsResolver: (() => InactiveCodexAccountInfo[]) | null = null

--- a/src/main/rate-limits/service/service-types.ts
+++ b/src/main/rate-limits/service/service-types.ts
@@ -52,6 +52,10 @@ export type MiniMaxRateLimitConfig = {
   models: string
 }
 
+export type ZaiRateLimitConfig = {
+  apiKey: string
+}
+
 export type MiniMaxResolvedConfig = {
   config: MiniMaxRateLimitConfig
   error: string | null
@@ -105,6 +109,7 @@ export type InternalRateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  zai: ProviderRateLimits | null
 }
 
 export function normalizePollingInterval(ms: number): number {

--- a/src/main/rate-limits/zai-fetcher.test.ts
+++ b/src/main/rate-limits/zai-fetcher.test.ts
@@ -100,6 +100,16 @@ describe('fetchZaiRateLimits', () => {
     expect(result.usageMetadata?.failureKind).toBe('usage-unavailable')
   })
 
+  it('aborts with the caller signal instead of waiting out the request timeout', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse(QUOTA_RESPONSE))
+    const controller = new AbortController()
+    await fetchZaiRateLimits({ apiKey: 'key-6', signal: controller.signal })
+    const passedSignal = netFetchMock.mock.calls[0]?.[1]?.signal as AbortSignal
+    expect(passedSignal.aborted).toBe(false)
+    controller.abort()
+    expect(passedSignal.aborted).toBe(true)
+  })
+
   it('ignores windows whose unit code is unknown', async () => {
     netFetchMock.mockResolvedValue(
       jsonResponse({

--- a/src/main/rate-limits/zai-fetcher.test.ts
+++ b/src/main/rate-limits/zai-fetcher.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+import { fetchZaiRateLimits, ZAI_USAGE_ENDPOINT } from './zai-fetcher'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as Response
+}
+
+// Real shape captured from GET https://api.z.ai/api/monitor/usage/quota/limit
+// on a GLM Coding Plan "pro" subscription.
+const QUOTA_RESPONSE = {
+  code: 200,
+  msg: 'Operation successful',
+  success: true,
+  data: {
+    limits: [
+      {
+        type: 'CREDIT_LIMIT',
+        unit: 3,
+        number: 5,
+        usage: 12000,
+        currentValue: 839,
+        remaining: 11160,
+        percentage: 6,
+        nextResetTime: 1788469936870
+      },
+      {
+        type: 'CREDIT_LIMIT',
+        unit: 6,
+        number: 1,
+        usage: 60000,
+        currentValue: 44392,
+        remaining: 15607,
+        percentage: 73,
+        nextResetTime: 1788520473997
+      }
+    ],
+    level: 'pro'
+  }
+}
+
+describe('fetchZaiRateLimits', () => {
+  beforeEach(() => {
+    netFetchMock.mockReset()
+  })
+
+  it('maps the 5-hour and weekly quota windows', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse(QUOTA_RESPONSE))
+    const result = await fetchZaiRateLimits({ apiKey: 'key-1' })
+    expect(result.status).toBe('ok')
+    expect(result.planType).toBe('pro')
+    expect(result.session).toEqual({
+      usedPercent: 6,
+      windowMinutes: 300,
+      resetsAt: 1788469936870,
+      resetDescription: null
+    })
+    expect(result.weekly).toEqual({
+      usedPercent: 73,
+      windowMinutes: 10080,
+      resetsAt: 1788520473997,
+      resetDescription: null
+    })
+  })
+
+  it('sends the raw key — z.ai rejects a Bearer-prefixed Authorization header', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse(QUOTA_RESPONSE))
+    await fetchZaiRateLimits({ apiKey: '  key-2  ' })
+    expect(netFetchMock).toHaveBeenCalledWith(
+      ZAI_USAGE_ENDPOINT,
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'key-2' }) })
+    )
+  })
+
+  it('reports an unconfigured key as unavailable, not an error', async () => {
+    const result = await fetchZaiRateLimits({ apiKey: '   ' })
+    expect(result.status).toBe('unavailable')
+    expect(result.usageMetadata?.failureKind).toBe('missing-credentials')
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('treats a rejected key as a stale token', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse({}, 401))
+    const result = await fetchZaiRateLimits({ apiKey: 'key-3' })
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('stale-token')
+  })
+
+  it('surfaces a payload-level failure message', async () => {
+    netFetchMock.mockResolvedValue(jsonResponse({ success: false, msg: 'quota service down' }))
+    const result = await fetchZaiRateLimits({ apiKey: 'key-4' })
+    expect(result.status).toBe('error')
+    expect(result.error).toBe('quota service down')
+    expect(result.usageMetadata?.failureKind).toBe('usage-unavailable')
+  })
+
+  it('ignores windows whose unit code is unknown', async () => {
+    netFetchMock.mockResolvedValue(
+      jsonResponse({
+        success: true,
+        data: { level: 'lite', limits: [{ unit: 99, number: 5, percentage: 10 }] }
+      })
+    )
+    const result = await fetchZaiRateLimits({ apiKey: 'key-5' })
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('usage-unavailable')
+  })
+})

--- a/src/main/rate-limits/zai-fetcher.ts
+++ b/src/main/rate-limits/zai-fetcher.ts
@@ -1,0 +1,192 @@
+import { net } from 'electron'
+import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+
+export const ZAI_USAGE_ENDPOINT = 'https://api.z.ai/api/monitor/usage/quota/limit'
+export const ZAI_CN_USAGE_ENDPOINT = 'https://open.bigmodel.cn/api/monitor/usage/quota/limit'
+
+const API_TIMEOUT_MS = 15_000
+const SESSION_WINDOW_MINUTES = 300
+const WEEKLY_WINDOW_MINUTES = 10_080
+
+// Why: z.ai reports a window as {unit, number}; only these unit codes are
+// documented by the responses the GLM Coding Plan returns today, and an
+// unknown code is dropped rather than guessed into the wrong bucket.
+const UNIT_MINUTES: Record<number, number> = {
+  3: 60,
+  4: 60 * 24,
+  6: 60 * 24 * 7
+}
+
+type ZaiQuotaLimit = {
+  unit?: unknown
+  number?: unknown
+  percentage?: unknown
+  nextResetTime?: unknown
+}
+
+type ZaiQuotaResponse = {
+  code?: unknown
+  msg?: unknown
+  success?: unknown
+  data?: {
+    level?: unknown
+    limits?: ZaiQuotaLimit[]
+  }
+}
+
+export type FetchZaiRateLimitsOptions = {
+  apiKey: string
+  endpoint?: string
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function makeResult(
+  fields: Partial<ProviderRateLimits> & Pick<ProviderRateLimits, 'status'>
+): ProviderRateLimits {
+  return {
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error: null,
+    usageMetadata: { source: 'web' },
+    ...fields
+  }
+}
+
+function makeUnavailable(error: string): ProviderRateLimits {
+  return makeResult({
+    status: 'unavailable',
+    error,
+    usageMetadata: { failureKind: 'missing-credentials', source: 'web' }
+  })
+}
+
+function makeError(
+  error: string,
+  failureKind: NonNullable<ProviderRateLimits['usageMetadata']>['failureKind']
+): ProviderRateLimits {
+  return makeResult({ status: 'error', error, usageMetadata: { failureKind, source: 'web' } })
+}
+
+function parseWindow(limit: ZaiQuotaLimit): { minutes: number; window: RateLimitWindow } | null {
+  const unit = asNumber(limit.unit)
+  const count = asNumber(limit.number)
+  const percentage = asNumber(limit.percentage)
+  if (unit === null || count === null || percentage === null) {
+    return null
+  }
+  const unitMinutes = UNIT_MINUTES[unit]
+  if (!unitMinutes) {
+    return null
+  }
+  const minutes = unitMinutes * count
+  const resetsAt = asNumber(limit.nextResetTime)
+  return {
+    minutes,
+    window: {
+      usedPercent: clampPercent(percentage),
+      // Why: the status bar labels the two contracted buckets (5h / 7d); report
+      // those exact durations so a 295-minute drift doesn't relabel the bar.
+      windowMinutes:
+        minutes <= WEEKLY_WINDOW_MINUTES / 2 ? SESSION_WINDOW_MINUTES : WEEKLY_WINDOW_MINUTES,
+      resetsAt: resetsAt !== null && resetsAt > 0 ? resetsAt : null,
+      resetDescription: null
+    }
+  }
+}
+
+function selectWindows(limits: ZaiQuotaLimit[]): {
+  session: RateLimitWindow | null
+  weekly: RateLimitWindow | null
+} {
+  let session: { minutes: number; window: RateLimitWindow } | null = null
+  let weekly: { minutes: number; window: RateLimitWindow } | null = null
+  for (const limit of limits) {
+    const parsed = parseWindow(limit)
+    if (!parsed) {
+      continue
+    }
+    if (parsed.minutes <= WEEKLY_WINDOW_MINUTES / 2) {
+      // Why: keep the tightest short window — that's the one that stops work first.
+      if (!session || parsed.minutes < session.minutes) {
+        session = parsed
+      }
+      continue
+    }
+    if (!weekly || parsed.minutes < weekly.minutes) {
+      weekly = parsed
+    }
+  }
+  return { session: session?.window ?? null, weekly: weekly?.window ?? null }
+}
+
+function handleHttpError(status: number): ProviderRateLimits | null {
+  if (status === 401 || status === 403) {
+    return makeError('Z.ai rejected the API key. Replace it in Settings.', 'stale-token')
+  }
+  if (status === 429) {
+    return makeError('Z.ai rate-limited the usage request', 'rate-limited')
+  }
+  if (status >= 500) {
+    return makeError(`Z.ai usage fetch failed (${status})`, 'server')
+  }
+  return status === 200 ? null : makeError(`Z.ai usage fetch failed (${status})`, 'unknown')
+}
+
+export async function fetchZaiRateLimits(
+  options: FetchZaiRateLimitsOptions
+): Promise<ProviderRateLimits> {
+  const apiKey = options.apiKey.trim()
+  if (!apiKey) {
+    return makeUnavailable('Z.ai API key not configured')
+  }
+  try {
+    const response = await net.fetch(options.endpoint ?? ZAI_USAGE_ENDPOINT, {
+      // Why: z.ai's monitor API takes the raw key — a `Bearer ` prefix 401s.
+      headers: { Authorization: apiKey, 'Accept-Language': 'en-US,en' },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS)
+    })
+    const httpError = handleHttpError(response.status)
+    if (httpError) {
+      return httpError
+    }
+    let payload: ZaiQuotaResponse
+    try {
+      payload = (await response.json()) as ZaiQuotaResponse
+    } catch {
+      return makeError('Invalid Z.ai usage response', 'parse')
+    }
+    if (payload.success === false) {
+      const message = typeof payload.msg === 'string' ? payload.msg : 'Z.ai returned an error'
+      return makeError(message, 'usage-unavailable')
+    }
+    const { session, weekly } = selectWindows(payload.data?.limits ?? [])
+    if (!session && !weekly) {
+      return makeError('Z.ai returned no usage windows', 'usage-unavailable')
+    }
+    return makeResult({
+      status: 'ok',
+      session,
+      weekly,
+      planType: typeof payload.data?.level === 'string' ? payload.data.level : null
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown Z.ai usage error'
+    return makeError(message, 'network')
+  }
+}

--- a/src/main/rate-limits/zai-fetcher.ts
+++ b/src/main/rate-limits/zai-fetcher.ts
@@ -2,7 +2,6 @@ import { net } from 'electron'
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 
 export const ZAI_USAGE_ENDPOINT = 'https://api.z.ai/api/monitor/usage/quota/limit'
-export const ZAI_CN_USAGE_ENDPOINT = 'https://open.bigmodel.cn/api/monitor/usage/quota/limit'
 
 const API_TIMEOUT_MS = 15_000
 const SESSION_WINDOW_MINUTES = 300
@@ -36,7 +35,8 @@ type ZaiQuotaResponse = {
 
 export type FetchZaiRateLimitsOptions = {
   apiKey: string
-  endpoint?: string
+  /** Caller's fetch-cycle signal; combined with the request timeout so a cancelled cycle aborts immediately. */
+  signal?: AbortSignal
 }
 
 function clampPercent(value: number): number {
@@ -148,6 +148,10 @@ function handleHttpError(status: number): ProviderRateLimits | null {
   return status === 200 ? null : makeError(`Z.ai usage fetch failed (${status})`, 'unknown')
 }
 
+/**
+ * Reads the z.ai GLM Coding Plan quota (5-hour and weekly windows) from the
+ * monitor API and maps it onto the shared provider rate-limit shape.
+ */
 export async function fetchZaiRateLimits(
   options: FetchZaiRateLimitsOptions
 ): Promise<ProviderRateLimits> {
@@ -156,10 +160,13 @@ export async function fetchZaiRateLimits(
     return makeUnavailable('Z.ai API key not configured')
   }
   try {
-    const response = await net.fetch(options.endpoint ?? ZAI_USAGE_ENDPOINT, {
+    const timeoutSignal = AbortSignal.timeout(API_TIMEOUT_MS)
+    const response = await net.fetch(ZAI_USAGE_ENDPOINT, {
       // Why: z.ai's monitor API takes the raw key — a `Bearer ` prefix 401s.
       headers: { Authorization: apiKey, 'Accept-Language': 'en-US,en' },
-      signal: AbortSignal.timeout(API_TIMEOUT_MS)
+      // Why: without the caller's signal a cancelled fetch cycle stays pending in
+      // `Promise.allSettled` until the 15s timeout fires.
+      signal: options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal
     })
     const httpError = handleHttpError(response.status)
     if (httpError) {

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -60,6 +60,7 @@ const StatusBarItem = z.enum([
   'kimi',
   'minimax',
   'grok',
+  'zai',
   'ssh',
   'resource-usage',
   'ports'
@@ -166,6 +167,7 @@ const UiUpdateFields = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _zaiStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),

--- a/src/main/startup/main-process-account-services.ts
+++ b/src/main/startup/main-process-account-services.ts
@@ -108,6 +108,7 @@ export function initializeMainProcessAccountServices(): void {
       models: settings.minimaxUsageModels
     }
   })
+  state.rateLimits.setZaiConfigResolver(() => ({ apiKey: store.getSettings().zaiApiKey }))
   state.rateLimits.setGeminiCliOAuthEnabledResolver(() => store.getSettings().geminiCliOAuthEnabled)
   state.rateLimits.setNetworkProxySettingsResolver(() => store.getSettings())
   state.keybindings = new KeybindingService({

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -22,7 +22,8 @@ import {
   getAccountsLocationSearchEntries,
   getAccountsMiniMaxSearchEntries,
   getAccountsOpencodeSearchEntries,
-  getAccountsPaneSearchEntries
+  getAccountsPaneSearchEntries,
+  getAccountsZaiSearchEntries
 } from './accounts-search'
 import { getRemoteAccountsPaneScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
@@ -58,6 +59,7 @@ import {
   renderOpenCodeAccountsSection
 } from './accounts-pane-provider-setting-sections'
 import { renderMiniMaxAccountsSection } from './accounts-pane-minimax-section'
+import { renderZaiAccountsSection } from './accounts-pane-zai-section'
 import { renderAccountsRemovalDialogs } from './accounts-pane-removal-dialogs'
 
 export { getAccountsPaneSearchEntries }
@@ -365,7 +367,10 @@ export function AccountsPane({
       : null,
     matchesSettingsSearch(searchQuery, getAccountsGrokSearchEntries()) ? (
       <GrokAccountsSection key="grok" />
-    ) : null
+    ) : null,
+    matchesSettingsSearch(searchQuery, getAccountsZaiSearchEntries())
+      ? renderZaiAccountsSection(model)
+      : null
   ].filter(Boolean)
 
   return (

--- a/src/renderer/src/components/settings/accounts-pane-zai-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-zai-section.tsx
@@ -1,0 +1,76 @@
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { ZaiIcon } from '../status-bar/icons'
+import { SearchableSetting } from './SearchableSetting'
+import type { AccountsPaneSectionModel } from './accounts-pane-types'
+
+export function renderZaiAccountsSection(model: AccountsPaneSectionModel): React.JSX.Element {
+  const { recordFeatureInteraction, settings, updateSettings } = model
+  return (
+    <section key="zai" id="accounts-zai" className="space-y-4 scroll-mt-6">
+      <div className="space-y-1">
+        <h3 className="flex items-center gap-2 text-sm font-semibold">
+          <ZaiIcon size={16} />
+          {translate('auto.components.settings.AccountsPane.zaiTitle', 'Z.ai')}
+        </h3>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.AccountsPane.zaiSubtitle',
+            'Configure Z.ai GLM Coding Plan usage.'
+          )}
+        </p>
+      </div>
+
+      <SearchableSetting
+        title={translate('auto.components.settings.AccountsPane.zaiApiKeyTitle', 'Z.ai API Key')}
+        description={translate(
+          'auto.components.settings.AccountsPane.zaiApiKeyDescription',
+          'Paste your Z.ai API key to show GLM Coding Plan quota in the status bar.'
+        )}
+        keywords={['z.ai', 'zai', 'glm', 'api key', 'rate limit', 'status bar']}
+        className="space-y-2"
+      >
+        <Label>
+          {translate('auto.components.settings.AccountsPane.zaiApiKeyLabel', 'Z.ai API key')}
+        </Label>
+        <div className="flex gap-2">
+          <Input
+            type="password"
+            value={settings.zaiApiKey}
+            onChange={(e) => {
+              recordFeatureInteraction('usage-tracking')
+              updateSettings({ zaiApiKey: e.target.value })
+            }}
+            placeholder={translate(
+              'auto.components.settings.AccountsPane.zaiApiKeyPlaceholder',
+              'API key from z.ai → API Keys'
+            )}
+            spellCheck={false}
+            className="flex-1 text-xs"
+          />
+          {settings.zaiApiKey && (
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                recordFeatureInteraction('usage-tracking')
+                updateSettings({ zaiApiKey: '' })
+              }}
+              className="h-7 shrink-0 text-xs text-muted-foreground hover:text-foreground"
+            >
+              {translate('auto.components.settings.AccountsPane.b398b834c9', 'Clear')}
+            </Button>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.AccountsPane.zaiApiKeyHint',
+            'The key is stored encrypted and used only for the GLM Coding Plan quota endpoint. A Coding Plan subscription is required — pay-as-you-go keys report no quota windows.'
+          )}
+        </p>
+      </SearchableSetting>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/accounts-pane-zai-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-zai-section.tsx
@@ -6,6 +6,7 @@ import { ZaiIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import type { AccountsPaneSectionModel } from './accounts-pane-types'
 
+/** Renders the Accounts pane section that stores the Z.ai API key used for GLM Coding Plan usage. */
 export function renderZaiAccountsSection(model: AccountsPaneSectionModel): React.JSX.Element {
   const { recordFeatureInteraction, settings, updateSettings } = model
   return (

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -212,6 +212,29 @@ export const getAccountsGrokSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getAccountsZaiSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate('auto.components.settings.accounts.search.zaiUsageTitle', 'Z.ai Usage'),
+    description: translate(
+      'auto.components.settings.accounts.search.zaiUsageDescription',
+      'Paste your Z.ai API key to show GLM Coding Plan quota in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.zaiKeyword', 'z.ai'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.glmKeyword', 'glm'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.apiKeyKeyword',
+        'api key'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.e949b08ffb',
+        'rate limit'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.86edc96bc9', 'status bar')
+    ]
+  }
+])
+
 export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAccountsLocationSearchEntries(),
   ...getAccountsClaudeSearchEntries(),
@@ -219,5 +242,6 @@ export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsS
   ...getAccountsGeminiSearchEntries(),
   ...getAccountsOpencodeSearchEntries(),
   ...getAccountsMiniMaxSearchEntries(),
-  ...getAccountsGrokSearchEntries()
+  ...getAccountsGrokSearchEntries(),
+  ...getAccountsZaiSearchEntries()
 ])

--- a/src/renderer/src/components/settings/appearance-status-bar-minimax-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-minimax-toggle-search.ts
@@ -1,0 +1,41 @@
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getMiniMaxStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'minimax',
+    title: translate('auto.components.settings.appearance.search.0f08f6b483', 'MiniMax Usage'),
+    description: translate(
+      'auto.components.settings.appearance.search.e46178eb1b',
+      'Show MiniMax subscription usage in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.d16378a88f', 'minimax'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.de586def95',
+        'subscription'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.d9e7cef86f', 'cookie'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.25e51b62ee',
+        'rate limit'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.minimaxToggleDescription',
+      'Show MiniMax subscription usage for the active workspace.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-minimax-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-minimax-toggle-search.ts
@@ -2,6 +2,7 @@ import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
+/** Settings-search entry for the Appearance toggle that shows or hides the MiniMax status-bar segment. */
 export function getMiniMaxStatusBarToggleSearchEntry(): {
   id: StatusBarItem
   title: string

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -4,6 +4,8 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
 import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
+import { getMiniMaxStatusBarToggleSearchEntry } from './appearance-status-bar-minimax-toggle-search'
+import { getZaiStatusBarToggleSearchEntry } from './appearance-status-bar-zai-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -164,42 +166,9 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show Kimi subscription usage for the active workspace.'
       )
     },
-    {
-      id: 'minimax',
-      title: translate('auto.components.settings.appearance.search.0f08f6b483', 'MiniMax Usage'),
-      description: translate(
-        'auto.components.settings.appearance.search.e46178eb1b',
-        'Show MiniMax subscription usage in the status bar.'
-      ),
-      keywords: [
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.896eb53fd4',
-          'status bar'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.d16378a88f',
-          'minimax'
-        ),
-        ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.de586def95',
-          'subscription'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.d9e7cef86f',
-          'cookie'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.25e51b62ee',
-          'rate limit'
-        )
-      ],
-      toggleDescription: translate(
-        'settings.appearance.statusBar.minimaxToggleDescription',
-        'Show MiniMax subscription usage for the active workspace.'
-      )
-    },
+    getMiniMaxStatusBarToggleSearchEntry(),
     getGrokStatusBarToggleSearchEntry(),
+    getZaiStatusBarToggleSearchEntry(),
     {
       id: 'ssh',
       title: translate('auto.components.settings.appearance.search.57fb424c56', 'Remote Hosts'),

--- a/src/renderer/src/components/settings/appearance-status-bar-zai-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-zai-toggle-search.ts
@@ -1,0 +1,37 @@
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getZaiStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'zai',
+    title: translate('auto.components.settings.appearance.search.zaiUsageTitle', 'Z.ai Usage'),
+    description: translate(
+      'auto.components.settings.appearance.search.zaiUsageDescription',
+      'Show GLM Coding Plan quota from your Z.ai API key.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.zaiKeyword', 'z.ai'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.glmKeyword', 'glm'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.de586def95',
+        'subscription'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.zaiToggleDescription',
+      'Show Z.ai GLM Coding Plan quota when an API key is configured.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-zai-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-zai-toggle-search.ts
@@ -2,6 +2,7 @@ import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 
+/** Settings-search entry for the Appearance toggle that shows or hides the Z.ai status-bar segment. */
 export function getZaiStatusBarToggleSearchEntry(): {
   id: StatusBarItem
   title: string

--- a/src/renderer/src/components/stats/GrokUsagePane.test.tsx
+++ b/src/renderer/src/components/stats/GrokUsagePane.test.tsx
@@ -37,6 +37,7 @@ const mockStoreState = {
       error: null,
       status: 'ok'
     },
+    zai: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: true,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
@@ -84,6 +84,8 @@ function getProviderLetter(provider: ProviderRateLimits['provider']): string {
       return 'R'
     case 'codex':
       return 'X'
+    case 'zai':
+      return 'Z'
   }
 }
 

--- a/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import type { StatusBarController } from './use-status-bar-controller'
@@ -133,6 +133,16 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.grokUsageMenu', 'Grok Usage')}
           </DropdownMenuCheckboxItem>
         )}
+        <DropdownMenuCheckboxItem
+          checked={statusBarItems.includes('zai')}
+          onCheckedChange={() => {
+            recordFeatureInteraction('usage-tracking')
+            toggleStatusBarItem('zai')
+          }}
+        >
+          <ZaiIcon size={14} />
+          {translate('auto.components.status.bar.StatusBar.zaiUsageMenu', 'Z.ai Usage')}
+        </DropdownMenuCheckboxItem>
         <DropdownMenuCheckboxItem
           checked={statusBarItems.includes('ssh')}
           onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/icons.tsx
+++ b/src/renderer/src/components/status-bar/icons.tsx
@@ -34,6 +34,23 @@ export function MiniMaxIcon({ size = 14 }: { size?: number }): React.JSX.Element
   )
 }
 
+export function ZaiIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  // Why: a plain Z glyph, drawn in currentColor so it reads in both themes and
+  // carries no vendor artwork we would have to vendor and license.
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width={size}
+      height={size}
+      aria-hidden="true"
+      className="text-current block shrink-0"
+      fill="currentColor"
+    >
+      <path d="M3.6 2h8.8v1.9L6.7 12h5.9v2H3.4v-1.9L9.1 4H3.6V2z" />
+    </svg>
+  )
+}
+
 // Why: each instance needs unique filter/mask IDs — reusing the same ID across
 // multiple SVGs on the same page causes the browser to resolve to the first one,
 // breaking all subsequent instances.

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -70,6 +70,7 @@ function usageSettings(overrides: Partial<UsageProviderSettings> = {}): UsagePro
     codexManagedAccounts: [],
     claudeManagedAccounts: [],
     opencodeSessionCookie: '',
+    zaiApiKey: '',
     geminiCliOAuthEnabled: false,
     antigravityUsageConfigured: false,
     minimaxCookieConfigured: false,
@@ -373,7 +374,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          zai: null
         },
         usageSettings()
       )
@@ -391,7 +393,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: undefined,
           minimax: undefined,
-          grok: undefined
+          grok: undefined,
+          zai: null
         },
         usageSettings()
       )
@@ -409,7 +412,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: provider('unavailable', { provider: 'antigravity' }),
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings()
       )
@@ -427,7 +431,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: provider('unavailable', { provider: 'antigravity' }),
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings({
           codexManagedAccounts: [
@@ -456,7 +461,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          zai: null
         },
         null
       )
@@ -474,7 +480,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings()
       )
@@ -492,7 +499,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           grok: provider('unavailable', { provider: 'grok' }),
-          minimax: provider('unavailable', { provider: 'minimax' })
+          minimax: provider('unavailable', { provider: 'minimax' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings({ antigravityUsageConfigured: true, geminiCliOAuthEnabled: true })
       )
@@ -512,7 +520,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           grok: provider('unavailable', { provider: 'grok' }),
-          minimax: provider('unavailable', { provider: 'minimax' })
+          minimax: provider('unavailable', { provider: 'minimax' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings({ antigravityUsageConfigured: true })
       )

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -7,6 +7,7 @@ export type UsageProviderSettings = Pick<
   | 'claudeManagedAccounts'
   | 'opencodeSessionCookie'
   | 'geminiCliOAuthEnabled'
+  | 'zaiApiKey'
 > & {
   // Why: Antigravity has no separate persisted usage credential in Orca. The
   // checked status-bar item is the durable user signal; StatusBar only sets
@@ -28,6 +29,7 @@ type UsageProviderSnapshots = {
   antigravity: ProviderRateLimits | null | undefined
   minimax: ProviderRateLimits | null | undefined
   grok: ProviderRateLimits | null | undefined
+  zai: ProviderRateLimits | null | undefined
 }
 
 type UsageProviderId = ProviderRateLimits['provider']
@@ -77,7 +79,8 @@ export function hasUsageProviderSettings(
     // Antigravity's durable signal requires geminiCliOAuthEnabled, so it is
     // already covered by the gemini term above.
     settings?.minimaxCookieConfigured === true ||
-    settings?.grokAuthConfigured === true
+    settings?.grokAuthConfigured === true ||
+    Boolean(settings?.zaiApiKey?.trim())
   )
 }
 
@@ -111,6 +114,9 @@ export function hasUsageProviderSettingsForProvider(
   }
   if (providerId === 'grok') {
     return settings.grokAuthConfigured === true
+  }
+  if (providerId === 'zai') {
+    return Boolean(settings.zaiApiKey?.trim())
   }
   return false
 }
@@ -165,7 +171,8 @@ export function isUsageEmptyState(
     isProviderSnapshotPending(providers.kimi) ||
     antigravitySnapshotPending ||
     isProviderSnapshotPending(providers.minimax) ||
-    isProviderSnapshotPending(providers.grok)
+    isProviderSnapshotPending(providers.grok) ||
+    isProviderSnapshotPending(providers.zai)
   ) {
     return false
   }
@@ -178,6 +185,7 @@ export function isUsageEmptyState(
     !isProviderConfigured(providers.kimi) &&
     !isProviderConfigured(providers.antigravity) &&
     !isProviderConfigured(providers.minimax) &&
-    !isProviderConfigured(providers.grok)
+    !isProviderConfigured(providers.grok) &&
+    !isProviderConfigured(providers.zai)
   )
 }

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -4,7 +4,7 @@ import {
   formatResetDuration
 } from '../../../../shared/rate-limit-reset-format'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 import {
   getProviderDisplayName,
@@ -96,6 +96,9 @@ export function ProviderIcon({ provider }: { provider: string }): React.JSX.Elem
   }
   if (provider === 'grok') {
     return <AgentIcon agent="grok" size={13} />
+  }
+  if (provider === 'zai') {
+    return <ZaiIcon size={13} />
   }
   return <ClaudeIcon size={13} />
 }

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -26,6 +26,9 @@ export function getProviderDisplayName(provider: ProviderRateLimits['provider'])
   if (provider === 'grok') {
     return 'Grok'
   }
+  if (provider === 'zai') {
+    return 'Z.ai'
+  }
   return provider
 }
 

--- a/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
+++ b/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
@@ -18,6 +18,8 @@ export function getUsageProviderAccountsSectionId(
       return 'accounts-minimax'
     case 'grok':
       return 'accounts-grok'
+    case 'zai':
+      return 'accounts-zai'
     case 'kimi':
       // Why: Orca must not mutate Kimi's CLI-owned credential lifecycle.
       return null

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -99,7 +99,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, zai } = rateLimits
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -121,6 +121,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const visibleAntigravity = getVisibleUsageProvider('antigravity', antigravity, usageSettings)
   const visibleMiniMax = getVisibleUsageProvider('minimax', minimax, usageSettings)
   const visibleGrok = getVisibleUsageProvider('grok', grok, usageSettings)
+  const visibleZai = getVisibleUsageProvider('zai', zai, usageSettings)
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
@@ -147,6 +148,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     visibleGrok !== null &&
     statusBarItems.includes('grok') &&
     isStatusBarItemAvailable('grok', detectedAgentIds)
+  // Why: Z.ai usage is key-auth against the plan, not a CLI on PATH, so detection-gating doesn't apply.
+  const showZai = visibleZai !== null && statusBarItems.includes('zai')
   // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
   const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
@@ -164,11 +167,12 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     showKimi ||
     showAntigravity ||
     showMiniMax ||
-    showGrok
+    showGrok ||
+    showZai
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: include Settings so durable managed accounts count — a configured user isn't shown the empty state while snapshots hydrate.
   const isEmptyUsageState = isUsageEmptyState(
-    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
+    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, zai },
     usageSettings
   )
   // Why: one-time nudge — once dismissed, stays hidden even if providers reconnect later.
@@ -181,7 +185,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     kimi?.status === 'fetching' ||
     antigravity?.status === 'fetching' ||
     minimax?.status === 'fetching' ||
-    grok?.status === 'fetching'
+    grok?.status === 'fetching' ||
+    zai?.status === 'fetching'
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
@@ -200,7 +205,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     showOpencodeGo ? visibleOpencodeGo : null,
     showKimi ? visibleKimi : null,
     showMiniMax ? visibleMiniMax : null,
-    showGrok ? visibleGrok : null
+    showGrok ? visibleGrok : null,
+    showZai ? visibleZai : null
   ].filter((p): p is ProviderRateLimits => p !== null)
 
   const handleManageAccounts = (): void => {

--- a/src/renderer/src/hooks/settings-navigation-capability-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-capability-sections.ts
@@ -54,7 +54,7 @@ export function buildCapabilitySettingsSections({
       ),
       description: translate(
         'auto.hooks.useSettingsNavigationMetadata.b1c2f8b0ac',
-        'Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, and Grok.'
+        'Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, Grok, and Z.ai.'
       ),
       icon: UserCog,
       searchEntries: getAccountsPaneSearchEntries(),

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -3571,7 +3571,7 @@
       },
       "useSettingsNavigationMetadata": {
         "5235c215ca": "Choose which task providers appear in the Tasks page and sidebar.",
-        "b1c2f8b0ac": "Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, and Grok."
+        "b1c2f8b0ac": "Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, Grok, and Z.ai."
       }
     },
     "lib": {

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -3570,7 +3570,8 @@
         "f6300deb8b": "New Browser Tab"
       },
       "useSettingsNavigationMetadata": {
-        "5235c215ca": "Choose which task providers appear in the Tasks page and sidebar."
+        "5235c215ca": "Choose which task providers appear in the Tasks page and sidebar.",
+        "b1c2f8b0ac": "Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, and Grok."
       }
     },
     "lib": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -132,7 +132,8 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "zaiToggleDescription": "Show Z.ai GLM Coding Plan quota when an API key is configured."
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
@@ -3683,7 +3684,8 @@
             "grokUsageMenu": "Grok Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
-            "codexSignInError": "Codex sign-in failed. Please try again."
+            "codexSignInError": "Codex sign-in failed. Please try again.",
+            "zaiUsageMenu": "Z.ai Usage"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",
@@ -6417,7 +6419,14 @@
           "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
           "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
           "codexConfigSyncManagedHomeUnavailable": "Orca could not read this account’s Codex files just now, so settings may not be syncing. This usually clears on its own — antivirus or a backup tool briefly locks them.",
-          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+          "zaiTitle": "Z.ai",
+          "zaiSubtitle": "Configure Z.ai GLM Coding Plan usage.",
+          "zaiApiKeyTitle": "Z.ai API Key",
+          "zaiApiKeyDescription": "Paste your Z.ai API key to show GLM Coding Plan quota in the status bar.",
+          "zaiApiKeyLabel": "Z.ai API key",
+          "zaiApiKeyPlaceholder": "API key from z.ai → API Keys",
+          "zaiApiKeyHint": "The key is stored encrypted and used only for the GLM Coding Plan quota endpoint. A Coding Plan subscription is required — pay-as-you-go keys report no quota windows."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",
@@ -8790,7 +8799,9 @@
             "d2c6a0e8f1": "grok",
             "c1b5f9d7e0": "xai",
             "b0a4e8c6d9": "oauth",
-            "a9f3d7b5c8": "login"
+            "a9f3d7b5c8": "login",
+            "zaiUsageTitle": "Z.ai Usage",
+            "zaiUsageDescription": "Paste your Z.ai API key to show GLM Coding Plan quota in the status bar."
           }
         },
         "advanced": {
@@ -9017,7 +9028,9 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "zaiUsageTitle": "Z.ai Usage",
+            "zaiUsageDescription": "Show GLM Coding Plan quota from your Z.ai API key."
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1072,7 +1072,7 @@
         "cd50cec5d7": "Coordinate multiple coding agents through Orca.",
         "58a868e8e4": "Orchestration",
         "7c79d3b7bf": "Optional",
-        "b1c2f8b0ac": "Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, and Grok.",
+        "b1c2f8b0ac": "Optional account switching and usage setup for Claude, Codex, Gemini, OpenCode Go, MiniMax, Grok, and Z.ai.",
         "f70ac54d38": "AI Provider Accounts",
         "4121f7a0a2": "Manage AI agents, set a default, and customize commands.",
         "b49abbd2f7": "Agents",

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -25,6 +25,7 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     antigravity: null,
     minimax: null,
     grok: null,
+    zai: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -72,6 +72,7 @@ const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
 const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
 const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
 const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
+const DEFAULT_ON_ZAI_STATUS_BAR_ITEM: StatusBarItem = 'zai'
 
 function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
   let items = migrateStatusBarItems(ui.statusBarItems)
@@ -80,7 +81,8 @@ function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
     ['_kimiStatusBarDefaultAdded', DEFAULT_ON_KIMI_STATUS_BAR_ITEM],
     ['_minimaxStatusBarDefaultAdded', DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM],
     ['_antigravityStatusBarDefaultAdded', DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM],
-    ['_grokStatusBarDefaultAdded', DEFAULT_ON_GROK_STATUS_BAR_ITEM]
+    ['_grokStatusBarDefaultAdded', DEFAULT_ON_GROK_STATUS_BAR_ITEM],
+    ['_zaiStatusBarDefaultAdded', DEFAULT_ON_ZAI_STATUS_BAR_ITEM]
   ] as const
   for (const [flag, item] of defaults) {
     if (!ui[flag] && !items.includes(item)) {

--- a/src/renderer/src/web/preload-api/web-rate-limits-api.ts
+++ b/src/renderer/src/web/preload-api/web-rate-limits-api.ts
@@ -12,6 +12,7 @@ export function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimi
     antigravity: null,
     minimax: null,
     grok: null,
+    zai: null,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -199,6 +199,7 @@ export function buildDefaultSettings(args: {
     opencodeWorkspaceId: '',
     minimaxGroupId: '',
     minimaxUsageModels: 'general',
+    zaiApiKey: '',
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -360,6 +360,8 @@ export type GlobalSettings = {
   minimaxGroupId: string
   /** Comma-separated MiniMax model names to show in the status bar usage window. */
   minimaxUsageModels: string
+  /** Z.ai API key used for GLM Coding Plan quota fetching. Stored encrypted. */
+  zaiApiKey: string
   /** Extract OAuth credentials from the local Gemini CLI for rate-limit fetching. Off by default (explicit opt-in). */
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -116,6 +116,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for adding the default-on Z.ai status item. */
+  _zaiStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */

--- a/src/shared/rate-limit-types.test.ts
+++ b/src/shared/rate-limit-types.test.ts
@@ -16,6 +16,7 @@ describe('RateLimitState', () => {
       antigravity: null,
       minimax: null,
       grok: null,
+      zai: null,
       minimaxCookieConfigured: false,
       grokAuthConfigured: false,
       claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -55,6 +55,7 @@ export type ProviderRateLimits = {
     | 'minimax'
     | 'grok'
     | 'antigravity'
+    | 'zai'
   /** 5-hour session window, null if not available. */
   session: RateLimitWindow | null
   /** 7-day weekly window, null if not available. */
@@ -124,6 +125,7 @@ export type RateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  zai: ProviderRateLimits | null
   /**
    * True when a MiniMax session cookie is persisted on disk. The cookie lives
    * outside GlobalSettings, so this flag is the durable signal that the

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -9,6 +9,7 @@ export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'kimi',
   'minimax',
   'grok',
+  'zai',
   'ssh',
   'resource-usage',
   'ports'

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -62,6 +62,7 @@ export type StatusBarItem =
   | 'kimi'
   | 'minimax'
   | 'grok'
+  | 'zai'
   | 'ssh'
   | 'resource-usage'
   | 'ports'


### PR DESCRIPTION
## ELI5

Orca already shows how much of your Claude/Codex/Gemini/Kimi/MiniMax plan you have burned. This adds the same readout for Z.ai's GLM Coding Plan: paste your Z.ai API key in Settings → AI Provider Accounts, and the status bar gains a `Z` segment with the 5-hour and weekly windows.

## What Changed

- **New provider `zai`** end to end: `ProviderRateLimits['provider']`, `RateLimitState.zai`, the `zai` status-bar item (default-on, with the one-shot `_zaiStatusBarDefaultAdded` migration used by the other late-added items), visibility menu entry, appearance/accounts search entries, tooltip icon, and provider letter.
- **`src/main/rate-limits/zai-fetcher.ts`** — `net.fetch` against `https://api.z.ai/api/monitor/usage/quota/limit`. The endpoint takes the **raw** key in `Authorization` (a `Bearer` prefix 401s). Windows are mapped by their `{unit, number}` pair onto the contracted 300 / 10080-minute buckets so the bar labels them like every other provider; an undocumented unit code is dropped rather than guessed into the wrong bucket. `data.level` becomes `planType`.
- **Credential** — `zaiApiKey` in `GlobalSettings`, persisted through the existing `PROTECTED_SECRET_SLOT` machinery (encrypt on serialize, decrypt on load, retained blob dropped when cleared), i.e. the same path as the OpenCode Go cookie. It is never written to the runtime client settings.
- **Service wiring** — resolver + config-hash generation so a changed key discards stale data, a seventh slot in the full fetch cycle, and entries in the per-provider failure-streak/retry records (which are `Record<ActiveRateLimitProvider, …>`, so the compiler forced each one).
- **Housekeeping** — the MiniMax status-bar search entry moves into its own module (`appearance-status-bar-minimax-toggle-search.ts`), matching Grok/Antigravity, so the shared catalog stays under the `max-lines` ratchet.
- Docs: usage-tracking and settings pages mention Z.ai.

## Why

The provider roster is compiled in, so a GLM Coding Plan user has no way to see quota inside Orca even though they are already running GLM through Claude Code (`ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic`), OpenCode or Cline. The plan enforces a rolling 5-hour window and a weekly window — exactly the two buckets the status bar is built around — so it drops into the existing shape without new UI concepts.

## Linked Issue

Fixes #18506

## Visual Proof

Before: no Z.ai segment — the bar ends after Grok.

After (dev build, real `pro` plan, key pasted into Settings → AI Provider Accounts → Z.ai):

```
✳ 13% used 3h 39m · 60% used 4d 7h · 29% used Fable   ◎ 98% used 3d 13h   ✂ Run Grok to refresh   Z 7% used 1h 51m · 74% used 15h 53m
```

![Status bar with the new Z.ai segment](https://github.com/ArtemBozhenko/orca/releases/download/zai-usage-proof/zai-status-bar-after.png)

The `Z` segment is the new one: 5-hour window at 7%, weekly at 74%, each with its own reset countdown; the tooltip/roster row reads `Z.ai · pro`. The "before" is the same bar with that segment absent (nothing else changes), so only the after shot is attached.

## Review follow-ups (56712d6e)

- fetch-cycle `AbortSignal` now reaches `fetchZaiRateLimits` (combined with the 15s timeout via `AbortSignal.any`), so a cancelled poll cycle no longer lingers — new test covers it.
- dropped the unused CN endpoint constant and its `endpoint` override.
- usage-tracking doc no longer claims "no API calls" for Z.ai; it documents the key requirement and the `Usage unavailable` state.
- Z.ai added to the stale English accounts-section catalog string (`en-runtime-required.json` + `locales/en.json`).

## Testing

- `src/main/rate-limits/zai-fetcher.test.ts` (new, 6 cases): window mapping from a real captured payload, raw-key header contract, unconfigured key → `unavailable` (not an error), 401 → `stale-token`, payload-level failure, unknown unit code ignored.
- Updated the fixtures/tests that enumerate providers exhaustively.
- `pnpm lint` ✅, `pnpm typecheck` ✅ (node/cli/web), `pnpm test src/main/rate-limits src/renderer/src/components/status-bar src/shared/rate-limit-types.test.ts` ✅ — the 4 failures in `codex-fetcher-pty-settle.test.ts` reproduce on a clean checkout of `main` on this machine and are unrelated.
- Manual: macOS dev build, real Z.ai `pro` key — pasted the key in Settings, watched the bar populate, confirmed the fetched snapshot (`status: 'ok'`, both windows, `planType: 'pro'`), and confirmed an empty key hides the segment again. Not tested on Linux/Windows/SSH: the code is a plain `net.fetch` plus settings plumbing with no platform- or host-specific paths.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Opus 5), reviewed by me before pushing.

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- Security: the key is a protected secret, is not synced to runtime clients, and is only ever sent to `api.z.ai`.
- Cross-platform: no platform branches; no filesystem access.
- Remote/SSH: `zaiApiKey` is deliberately not part of `RuntimeClientSettings`, so a remote client shows no Z.ai bar rather than shipping the secret over the wire — same treatment as the OpenCode Go cookie.
- Backwards compatibility: `zai` is a new optional slot; the one-shot default-add flag keeps existing status-bar layouts intact. `StatusBarItem` gains a value in the client-UI RPC schema, so an older host rejects `'zai'` from a newer client the same way it did when `grok` was added.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after attached (PNG of the after state; before = same bar without the `Z` segment)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally (`pnpm build` not run: this machine's Xcode install is broken, CI covers it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNBmqKA9PvYQ7A8pYiW5GY
