### PR TITLE
chore(cloud): close the Workload Identity cutover onto stablyai/orca

### DIFF
--- a/cloud/dev/scripts/relay-repository.mjs
+++ b/cloud/dev/scripts/relay-repository.mjs
@@ -15,9 +15,16 @@ export function relayWorkflowFile(name) {
   return `${RELAY_WORKFLOW_FILE_PREFIX}${name}`
 }
 
+// Repository-relative path for a repository that renames its copies with `prefix`. Terraform's
+// trusted prefix is a variable and need not be this checkout's, so callers rendering a
+// workflow_ref from Terraform pass it in rather than assuming the local one.
+export function prefixedRelayWorkflowPath(prefix, name) {
+  return `.github/workflows/${prefix}${name}`
+}
+
 // Repository-relative path, the shape GitHub reports in workflow_ref and evidence payloads.
 export function relayWorkflowPath(name) {
-  return `.github/workflows/${relayWorkflowFile(name)}`
+  return prefixedRelayWorkflowPath(RELAY_WORKFLOW_FILE_PREFIX, name)
 }
 
 export function relayWorkflowUrl(name) {

--- a/cloud/dev/scripts/relay-repository.test.mjs
+++ b/cloud/dev/scripts/relay-repository.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import {
   RELAY_GITHUB_REPOSITORY,
   RELAY_WORKFLOW_FILE_PREFIX,
+  prefixedRelayWorkflowPath,
   readRelayWorkflow,
   relayWorkflowFile,
   relayWorkflowPath,
@@ -21,6 +22,8 @@ test('workflow identity is derived, never restated', () => {
   assert.equal(relayWorkflowFile('deploy-relay-staging.yml'), `${RELAY_WORKFLOW_FILE_PREFIX}deploy-relay-staging.yml`)
   assert.equal(relayWorkflowPath('deploy-relay-staging.yml'), `.github/workflows/${relayWorkflowFile('deploy-relay-staging.yml')}`)
   assert.ok(relayWorkflowUrl('deploy-relay-staging.yml').pathname.endsWith(relayWorkflowPath('deploy-relay-staging.yml')))
+  // A caller rendering Terraform's trusted ref supplies that prefix instead of this checkout's.
+  assert.equal(prefixedRelayWorkflowPath('cloud-', 'deploy-relay-staging.yml'), '.github/workflows/cloud-deploy-relay-staging.yml')
   assert.match(readRelayWorkflow('deploy-relay-staging.yml'), /^name:/m)
   assert.match(RELAY_GITHUB_REPOSITORY, /^[\w.-]+\/[\w.-]+$/)
 })

--- a/cloud/dev/scripts/relay-staging-deploy-identity.test.mjs
+++ b/cloud/dev/scripts/relay-staging-deploy-identity.test.mjs
@@ -2,11 +2,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import test from 'node:test'
 import { readWorkflow, workflowFiles } from './cloud-sql-rollout-lock-census.mjs'
-import {
-  RELAY_WORKFLOW_FILE_PREFIX,
-  relayWorkflowFile,
-  relayWorkflowPath
-} from './relay-repository.mjs'
+import { prefixedRelayWorkflowPath, relayWorkflowFile } from './relay-repository.mjs'
 
 const identity = readFileSync(
   new URL('../../infra/terraform/relay-staging-deploy-iam.tf', import.meta.url),
@@ -128,8 +124,11 @@ test('the rendered attribute condition stays inside the provider limit', () => {
     `assertion.repository_id == '${variableDefault('github_repo_id')}'`,
     `assertion.repository_owner_id == '${variableDefault('github_owner_id')}'`
   ]
+  // The prefix is the Terraform variable, not this checkout's own workflow filenames: the
+  // condition names the files as the trusted repository carries them.
+  const prefix = variableDefault('github_workflow_file_prefix')
   const workflowRefs = providerWorkflowFiles().map(
-    (file) => `${repository}/${relayWorkflowPath(file)}@refs/heads/main`
+    (file) => `${repository}/${prefixedRelayWorkflowPath(prefix, file)}@refs/heads/main`
   )
   const rendered = [
     ...claims,
@@ -138,9 +137,7 @@ test('the rendered attribute condition stays inside the provider limit', () => {
     `(${workflowRefs.map((ref) => `assertion.workflow_ref == '${ref}'`).join(' || ')})`
   ].join(' && ')
   assert.ok(rendered.length < 4096, `rendered condition is ${rendered.length} characters`)
-  // 797 is the private repository's rendered length. This copy prefixes every workflow filename,
-  // which is the only difference, so the pin still moves the moment a workflow is added or dropped.
-  assert.equal(rendered.length, 797 + workflowRefs.length * RELAY_WORKFLOW_FILE_PREFIX.length)
+  assert.equal(rendered.length, 791)
 })
 
 // Why: the census is the point. A binding added here without a workflow step behind it, or one

--- a/cloud/dev/scripts/workload-identity-attribute-conditions.test.mjs
+++ b/cloud/dev/scripts/workload-identity-attribute-conditions.test.mjs
@@ -13,13 +13,13 @@ const EXPECTED_CONDITIONS = {
   staging: {
     relay: {
       github_staging_relay_capacity:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && (assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/bootstrap-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/prove-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/recover-relay-staging-c4-image.yml@refs/heads/main')) || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-bootstrap-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-prove-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-recover-relay-staging-c4-image.yml@refs/heads/main')))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-bootstrap-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-prove-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-recover-relay-staging-c4-image.yml@refs/heads/main')",
       github_staging_relay_deploy:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && (assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/bootstrap-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-staging-gce-candidate.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-staging.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/operate-relay-asia-admission.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/power-relay-staging.yml@refs/heads/main')) || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-bootstrap-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-staging-gce-candidate.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-staging.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-asia-admission.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-power-relay-staging.yml@refs/heads/main')))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-bootstrap-relay-staging-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-staging-gce-candidate.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-staging.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-asia-admission.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-power-relay-staging.yml@refs/heads/main')",
       github_relay_asia_topology:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && assertion.event_name == 'workflow_dispatch' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-asia-topology.yml@refs/heads/main') || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-asia-topology.yml@refs/heads/main'))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && assertion.event_name == 'workflow_dispatch' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-asia-topology.yml@refs/heads/main'",
       github_relay_asia_proof:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && assertion.event_name == 'workflow_dispatch' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/prove-relay-asia-staging.yml@refs/heads/main') || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-prove-relay-asia-staging.yml@refs/heads/main'))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'staging' && assertion.event_name == 'workflow_dispatch' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-prove-relay-asia-staging.yml@refs/heads/main'",
     },
     // The relay root creates this provider only in production, so staging has exactly one
     // definition and it lives here.
@@ -31,15 +31,15 @@ const EXPECTED_CONDITIONS = {
   production: {
     relay: {
       github:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && ((assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-fence-broker.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-director.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-multi-target.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/operate-relay-asia-admission.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/publish-relay-production.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/operate-relay-production-rehome.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/operate-relay-production-rehome-job.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-same-cap.yml@refs/heads/main' && (assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-same-cap-job.yml@refs/heads/main' || assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-same-cap.yml@refs/heads/main')))) || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && ((assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-fence-broker.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-director.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-multi-target.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-asia-admission.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-publish-relay-production.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-production-rehome.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-production-rehome-job.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap.yml@refs/heads/main' && (assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml@refs/heads/main' || assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap.yml@refs/heads/main')))))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && ((assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-fence-broker.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-capacity.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-director.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-multi-target.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-asia-admission.yml@refs/heads/main' || assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-publish-relay-production.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-production-rehome.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-operate-relay-production-rehome-job.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap.yml@refs/heads/main' && (assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml@refs/heads/main' || assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap.yml@refs/heads/main')))",
       github_monitor:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/monitor-relay-production.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/monitor-relay-production-job.yml@refs/heads/main') || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-monitor-relay-production.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-monitor-relay-production-job.yml@refs/heads/main'))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-monitor-relay-production.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-monitor-relay-production-job.yml@refs/heads/main'",
       github_fence:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-multi-target.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-multi-target.yml@refs/heads/main') || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-multi-target.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-multi-target.yml@refs/heads/main'))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-multi-target.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-multi-target.yml@refs/heads/main'",
       github_production_relay_capacity:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && ((assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-capacity.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-capacity-job.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-same-cap.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-production-same-cap-job.yml@refs/heads/main'))) || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && ((assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-capacity.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-capacity-job.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml@refs/heads/main'))))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && ((assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-capacity.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-capacity-job.yml@refs/heads/main') || (assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap.yml@refs/heads/main' && assertion.job_workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml@refs/heads/main'))",
       github_relay_asia_topology:
-        "assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && assertion.event_name == 'workflow_dispatch' && ((assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca-cloud/.github/workflows/deploy-relay-asia-topology.yml@refs/heads/main') || (assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-asia-topology.yml@refs/heads/main'))",
+        "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420' && assertion.ref == 'refs/heads/main' && assertion.environment == 'production' && assertion.event_name == 'workflow_dispatch' && assertion.workflow_ref == 'stablyai/orca/.github/workflows/cloud-deploy-relay-asia-topology.yml@refs/heads/main'",
     },
     apps: {
       github_production_app_deploy:
@@ -48,20 +48,21 @@ const EXPECTED_CONDITIONS = {
   },
 }
 
-// Every repository the relay root accepts while the public extraction runs, with the workflow-ref
-// head each one contributes. The apps root is not part of the dual accept.
-const ACCEPTED_REPOSITORIES = [
-  {
-    claims:
-      "assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420'",
-    workflowHead: 'stablyai/orca-cloud/.github/workflows/'
-  },
-  {
+// The one repository each root trusts, with the workflow-ref head it contributes. The relay root
+// moved to the public repository, where the workflow files carry the `cloud-` prefix; the apps
+// root still deploys from the private one.
+const ROOT_REPOSITORIES = {
+  relay: {
     claims:
       "assertion.repository == 'stablyai/orca' && assertion.repository_id == '1183888342' && assertion.repository_owner_id == '127256420'",
     workflowHead: 'stablyai/orca/.github/workflows/cloud-'
+  },
+  apps: {
+    claims:
+      "assertion.repository == 'stablyai/orca-cloud' && assertion.repository_id == '1273841466' && assertion.repository_owner_id == '127256420'",
+    workflowHead: 'stablyai/orca-cloud/.github/workflows/'
   }
-]
+}
 
 // [root, provider, condition] for every provider the environment creates, across all roots.
 async function flatten(environment) {
@@ -103,9 +104,7 @@ for (const environment of Object.keys(EXPECTED_CONDITIONS)) {
   test(`${environment} pins repository, branch, and environment on every provider`, async () => {
     for (const [root, provider, condition] of await flatten(environment)) {
       for (const pin of [
-        "assertion.repository == 'stablyai/orca-cloud'",
-        "assertion.repository_id == '1273841466'",
-        "assertion.repository_owner_id == '127256420'",
+        ROOT_REPOSITORIES[root].claims,
         "assertion.ref == 'refs/heads/main'",
         `assertion.environment == '${environment}'`
       ]) {
@@ -131,27 +130,23 @@ for (const environment of Object.keys(EXPECTED_CONDITIONS)) {
   })
 }
 
-// Why: the dual accept is only safe if each OR arm carries its own repository claims. An arm that
-// inherited them, or a workflow ref that named the other repository, would let one repository's
-// workflows run under the other's proof.
+// Why: the cutover left one arm per relay provider. A leftover `stablyai/orca-cloud` claim or
+// workflow ref would keep trusting a repository whose relay workflows are retired, and an unprefixed
+// ref would name a file the public repository does not have.
 for (const environment of Object.keys(EXPECTED_CONDITIONS)) {
-  test(`${environment} admits both repositories through every relay provider`, async () => {
+  test(`${environment} admits only the public repository through every relay provider`, async () => {
+    const { claims, workflowHead } = ROOT_REPOSITORIES.relay
     const rendered = await renderAttributeConditions(environment)
     for (const [provider, condition] of Object.entries(rendered.relay)) {
-      assert.ok(
-        condition.startsWith("assertion.ref == 'refs/heads/main' && "),
-        `${provider} does not lead with the repository-independent claims`
-      )
+      assert.ok(condition.startsWith(`${claims} && `), `${provider} does not lead with the claims`)
+      assert.doesNotMatch(condition, /stablyai\/orca-cloud|1273841466/, `${provider} keeps an old arm`)
       const refs = [...condition.matchAll(/(?:job_)?workflow_ref == '([^']+)'/g)].map(
         (match) => match[1]
       )
-      const perRepository = ACCEPTED_REPOSITORIES.map((repository) => {
-        assert.ok(condition.includes(`(${repository.claims} && `), `${provider} misses an arm`)
-        return refs.filter((ref) => ref.startsWith(repository.workflowHead)).length
-      })
-      assert.equal(refs.length, perRepository[0] + perRepository[1], `${provider} names a stray ref`)
-      assert.equal(perRepository[0], perRepository[1], `${provider} arms are not the same size`)
-      assert.ok(perRepository[0] > 0, `${provider} names no workflow`)
+      assert.ok(refs.length > 0, `${provider} names no workflow`)
+      for (const ref of refs) {
+        assert.ok(ref.startsWith(workflowHead), `${provider} names a stray ref ${ref}`)
+      }
     }
   })
 }

--- a/cloud/infra/terraform/README.md
+++ b/cloud/infra/terraform/README.md
@@ -37,35 +37,26 @@ identity (`google_service_account.github_deploy`, its provider, and its bindings
 with production-only counts; staging's copies are declared by `infra/terraform-apps`. An untargeted
 plan is orderable again; the `Plan:` line still reflects the standing cell-template drift backlog.
 
-### Dual-accept Workload Identity during the public extraction
+### Workload Identity trusts the public repository
 
-While the relay source moves to the public `stablyai/orca` repository, every relay Workload
-Identity provider accepts the same workflows from both repositories. `github_accepted_repositories`
-lists the extra repositories; `relay-github-workflow-trust.tf` renders one parenthesised OR arm per
-accepted repository, each arm carrying that repository's own `repository`, `repository_id`, and
-`repository_owner_id` claims plus its exact workflow refs. `ref`, `environment`, and `event_name`
-stay outside the OR. Workflow files keep their names in the private repo and take the
-`workflow_file_prefix` (`cloud-`) in the public one.
+The cutover closed on 2026-09-03. Every relay Workload Identity provider now accepts exactly one
+repository, `stablyai/orca` (`1183888342`, owner `127256420`), and every workflow ref it names is
+built from `github_workflow_file_prefix` (`cloud-`), which is the rename the public repo applies to
+the workflow files it carries. `github_repo`, `github_repo_id`, and that prefix are set in both
+`environments/*.tfvars` as well as defaulted here, and `github_accepted_repositories` is empty.
+Nothing in this root trusts `stablyai/orca-cloud` any more; the apps and foundation roots still do,
+because the app workflows still live there.
 
-Adding a repository is a tfvars edit: no provider block changes, and the rendered strings are
-pinned by `dev/scripts/workload-identity-attribute-conditions.test.mjs`. An empty list renders
-byte-identically to the single-repository form, which is what makes the arms reviewable against
-the pre-extraction condition.
+`github_accepted_repositories` stays available for the next repository move. Each entry renders its
+own parenthesised OR arm in `relay-github-workflow-trust.tf`, carrying that repository's own
+`repository`, `repository_id`, and `repository_owner_id` claims plus its exact workflow refs, while
+`ref`, `environment`, and `event_name` stay outside the OR. An empty list renders byte-identically
+to the single-repository form, so adding and removing a repository is a tfvars edit with no provider
+block change. The rendered strings are pinned by
+`dev/scripts/workload-identity-attribute-conditions.test.mjs`.
 
-Closing the cutover is an owner step, in this order:
-
-1. Retire the private workflows, so nothing runs from `stablyai/orca-cloud` any more.
-2. Point `github_owner`, `github_repo`, `github_repo_id`, and `github_owner_id` at
-   `stablyai/orca` (`1183888342`, owner `127256420`), and set `workflow_file_prefix` for it by
-   moving the surviving entry's prefix onto the primary: the public files keep the `cloud-` names,
-   so the primary prefix becomes `cloud-` unless the files are renamed back.
-3. Empty `github_accepted_repositories` in both `environments/*.tfvars`.
-4. Re-render and update the pinned conditions, then apply. Each provider goes back to a single
-   arm, and `google_service_account_iam_member.github_accepted_repository_workload_identity_user`
-   is destroyed as the primary `attribute.repository` binding takes over.
-
-Step 2 and step 3 must land in the same apply: dropping the accepted entry before repointing the
-primary would revoke the public repository mid-flight.
+Repointing the primary and emptying the list must land in the same apply: dropping the accepted
+entry before repointing the primary would revoke the surviving repository mid-flight.
 
 ### `ORCA_RELAY_IMAGE_DIGEST` is not Terraform-owned
 

--- a/cloud/infra/terraform/environments/production.tfvars
+++ b/cloud/infra/terraform/environments/production.tfvars
@@ -5,19 +5,11 @@ region      = "us-central1"
 
 artifact_repository_id = "orca-cloud"
 
-# Dual accept while the relay source moves to the public stablyai/orca repository: the same
-# workflows are trusted from both repos, and the public copies carry a `cloud-` file prefix.
-# Remove this entry once the private workflows are retired and point github_owner/github_repo,
-# github_repo_id, and github_owner_id at the surviving repository.
-github_accepted_repositories = [
-  {
-    owner                = "stablyai"
-    repo                 = "orca"
-    repo_id              = "1183888342"
-    owner_id             = "127256420"
-    workflow_file_prefix = "cloud-"
-  }
-]
+# The relay source lives in the public stablyai/orca repository, where the workflows carry a
+# `cloud-` file prefix. github_owner and github_owner_id keep their defaults.
+github_repo                 = "orca"
+github_repo_id              = "1183888342"
+github_workflow_file_prefix = "cloud-"
 
 # Our first-party auth service. auth.onorca.dev is PropelAuth's prod domain, so
 # our service lives at login.onorca.dev (desktop points ORCA_CLOUD_API_URL here).

--- a/cloud/infra/terraform/environments/staging.tfvars
+++ b/cloud/infra/terraform/environments/staging.tfvars
@@ -5,19 +5,11 @@ region      = "us-central1"
 
 artifact_repository_id = "orca-cloud"
 
-# Dual accept while the relay source moves to the public stablyai/orca repository: the same
-# workflows are trusted from both repos, and the public copies carry a `cloud-` file prefix.
-# Remove this entry once the private workflows are retired and point github_owner/github_repo,
-# github_repo_id, and github_owner_id at the surviving repository.
-github_accepted_repositories = [
-  {
-    owner                = "stablyai"
-    repo                 = "orca"
-    repo_id              = "1183888342"
-    owner_id             = "127256420"
-    workflow_file_prefix = "cloud-"
-  }
-]
+# The relay source lives in the public stablyai/orca repository, where the workflows carry a
+# `cloud-` file prefix. github_owner and github_owner_id keep their defaults.
+github_repo                 = "orca"
+github_repo_id              = "1183888342"
+github_workflow_file_prefix = "cloud-"
 
 auth_base_url = "https://auth-staging.onorca.dev"
 

--- a/cloud/infra/terraform/relay-shared.tf
+++ b/cloud/infra/terraform/relay-shared.tf
@@ -14,16 +14,16 @@ locals {
     "assertion.repository_owner_id == '${var.github_owner_id}'",
   ]
 
-  # Dual accept during the public extraction: the primary repository first, then every repository
-  # var.github_accepted_repositories adds. Each one renders its own OR arm in every provider
-  # condition, so both repos can run the same workflows through the same identities. A repository
-  # that imports these workflows may rename the files, hence the per-repository prefix.
+  # The primary repository first, then every repository var.github_accepted_repositories adds.
+  # Each one renders its own OR arm in every provider condition, so a repository move can trust
+  # both repos at once. A repository that imports these workflows may rename the files, hence the
+  # per-repository prefix; the primary's is var.github_workflow_file_prefix.
   relay_github_accepted_repositories = concat([{
     owner                = var.github_owner
     repo                 = var.github_repo
     repo_id              = var.github_repo_id
     owner_id             = var.github_owner_id
-    workflow_file_prefix = ""
+    workflow_file_prefix = var.github_workflow_file_prefix
   }], var.github_accepted_repositories)
 
   relay_github_single_repository = length(local.relay_github_accepted_repositories) == 1

--- a/cloud/infra/terraform/variables.tf
+++ b/cloud/infra/terraform/variables.tf
@@ -22,14 +22,14 @@ variable "github_owner" {
 variable "github_repo" {
   type        = string
   description = "GitHub repo allowed to deploy through Workload Identity Federation."
-  default     = "orca-cloud"
+  default     = "orca"
 }
 
 # Numeric IDs survive a rename or transfer of the repository; every provider pins them next to the name.
 variable "github_repo_id" {
   type        = string
   description = "Numeric GitHub repository ID of github_owner/github_repo."
-  default     = "1273841466"
+  default     = "1183888342"
 
   validation {
     condition     = can(regex("^[0-9]+$", var.github_repo_id))
@@ -48,12 +48,24 @@ variable "github_owner_id" {
   }
 }
 
-# Additional repositories whose identical workflows the same identities must accept while the
-# public extraction runs. Each entry renders its own OR arm in every provider condition, so the
-# private repo keeps working while the public one takes over. `workflow_file_prefix` is the rename
-# the importing repository applies to the workflow files it copies. Empty is the steady state:
-# the final step of the cutover is to empty this list again and point github_owner/github_repo,
-# github_repo_id, and github_owner_id at the surviving repository.
+# The rename the relay repository applies to the workflow files it carries. The public repo keeps
+# the workflows under `cloud-` names, so every relay workflow_ref is built from this head.
+variable "github_workflow_file_prefix" {
+  type        = string
+  description = "Filename prefix on github_owner/github_repo's copies of the relay workflows."
+  default     = "cloud-"
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]*$", var.github_workflow_file_prefix))
+    error_message = "github_workflow_file_prefix must be lowercase letters, digits, or hyphens."
+  }
+}
+
+# Additional repositories whose identical workflows the same identities must accept during a
+# repository move. Each entry renders its own OR arm in every provider condition, so both repos
+# can run the same workflows through the same identities. `workflow_file_prefix` is the rename the
+# importing repository applies to the workflow files it copies. Empty is the steady state, and is
+# where the public extraction left it: stablyai/orca is now the primary and only repository.
 variable "github_accepted_repositories" {
   type = list(object({
     owner                = string


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​69 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 |

<!-- /orca-pr-loc -->

Public mirror of stablyai/orca-cloud#470, which closes the relay Workload Identity cutover. Every relay provider now trusts exactly one repository, this one.

The private relay workflows were retired, so the dual accept has had one live arm since. This drops the other.

## What changed

- New relay-root variable `github_workflow_file_prefix` (default `cloud-`, validated like the accepted-repo prefix). `relay-shared.tf` uses it for the primary entry's `workflow_file_prefix`, which was hardcoded to `""`.
- `github_repo` defaults to `orca` and `github_repo_id` to `1183888342`. Owner and owner id are unchanged.
- Both `environments/*.tfvars` set `github_repo`, `github_repo_id`, and `github_workflow_file_prefix` explicitly, and no longer carry `github_accepted_repositories`.
- `github_accepted_repositories` itself stays. It is the mechanism for the next repository move, and an empty list renders byte-identically to the single-repository form.

`cloud/infra/terraform` is byte-identical to the private branch, verified by a recursive diff of the whole directory.

Every rendered `attribute_condition` is re-pinned in `workload-identity-attribute-conditions.test.mjs`. The dual-accept structural test became a single-arm test that also asserts no relay condition mentions `stablyai/orca-cloud` or `1273841466`, and the repository pins are now per root so the apps root's expectations, which sit unused here, keep their own.

The two identity tests already diverged from the private originals, so they take the same change rather than the same bytes. Both rendered the trusted ref head from this checkout's own workflow filenames, which stopped matching Terraform once the prefix became a variable. They now read the variable through a new `prefixedRelayWorkflowPath` helper, which keeps the `relay-repository.mjs` ratchet intact. That is also what lets the length pin be the same 791 characters in either repository, replacing the `797 + refs x prefix` expression this copy carried.

## Plans

The private PR carries the read-only plans for both environments, A/B'd against `origin/main` so the standing backlog is separated out. The cutover-attributable changes are an in-place `attribute_condition` update on four staging and five production providers, plus, in production only, a replace of `google_service_account_iam_member.github_workload_identity_user[0]` onto `attribute.repository/stablyai/orca` and the destroy of `github_accepted_repository_workload_identity_user["stablyai/orca"]`. Nothing else differs from baseline in either environment.

The private PR also flags an apply-ordering hazard on those last two production resources, which manage the identical IAM member. Read it before anyone applies production.

## Tests

`cd cloud && CI=true pnpm install --frozen-lockfile --offline && pnpm test`: 148 pretest and 495 test assertions, 0 failures. `terraform -chdir=cloud/infra/terraform fmt -check -recursive` clean and `validate` succeeds.
