### PR TITLE
fix(terminal): flush xterm's parked renderer resize when releasing the pause latch

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release-parked-resize.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release-parked-resize.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  forceFullViewportPresent,
+  forceRepaintThroughRenderPause,
+  requestFullViewportPresent
+} from './terminal-render-pause-release'
+
+// Why a separate file: the parked-resize contract is one hazard shared by all
+// three helpers, and the main spec is already at the max-lines budget.
+
+type FakeRenderService = {
+  _isPaused: boolean
+  _needsFullRefresh: boolean
+  _pausedResizeTask?: { flush: ReturnType<typeof vi.fn> } | null
+  refreshRows: ReturnType<typeof vi.fn>
+  _renderer?: { value?: { renderRows?: ReturnType<typeof vi.fn> } }
+}
+
+function createPausedTerminal(options: {
+  synchronizedOutput?: boolean
+  withoutTask?: boolean
+  flushThrows?: boolean
+}): { terminal: unknown; service: FakeRenderService; order: string[] } {
+  const order: string[] = []
+  const flush = vi.fn(() => {
+    order.push('flush')
+    if (options.flushThrows) {
+      throw new Error('renderer disposed')
+    }
+  })
+  const service: FakeRenderService = {
+    _isPaused: true,
+    _needsFullRefresh: true,
+    _pausedResizeTask: options.withoutTask ? null : { flush },
+    refreshRows: vi.fn(() => order.push('refreshRows')),
+    _renderer: { value: { renderRows: vi.fn(() => order.push('renderRows')) } }
+  }
+  const terminal = {
+    rows: 24,
+    _core: {
+      _renderService: service,
+      coreService: { decPrivateModes: { synchronizedOutput: options.synchronizedOutput === true } }
+    }
+  }
+  return { terminal, service, order }
+}
+
+const helpers = [
+  ['forceRepaintThroughRenderPause', forceRepaintThroughRenderPause],
+  ['requestFullViewportPresent', requestFullViewportPresent],
+  ['forceFullViewportPresent', forceFullViewportPresent]
+] as const
+
+describe.each(helpers)('%s parked renderer resize', (_name, present) => {
+  it('flushes the resize xterm parked while paused before presenting', () => {
+    // A resize that lands under _isPaused only parks WebglRenderer.handleResize;
+    // xterm flushes it solely from the observer callback we are pre-empting.
+    const { terminal, service, order } = createPausedTerminal({})
+
+    expect(present(terminal)).toBe(true)
+    expect(service._pausedResizeTask?.flush).toHaveBeenCalledTimes(1)
+    expect(order[0]).toBe('flush')
+    expect(order).toHaveLength(2)
+    expect(service._isPaused).toBe(false)
+    expect(service._needsFullRefresh).toBe(false)
+  })
+
+  it('flushes before a DEC 2026 present too', () => {
+    const { terminal, service, order } = createPausedTerminal({ synchronizedOutput: true })
+
+    expect(present(terminal)).toBe(true)
+    expect(service._pausedResizeTask?.flush).toHaveBeenCalledTimes(1)
+    expect(order[0]).toBe('flush')
+  })
+
+  it('still presents when the parked-task internal is unavailable', () => {
+    const { terminal, service } = createPausedTerminal({ withoutTask: true })
+
+    expect(present(terminal)).toBe(true)
+    expect(service._isPaused).toBe(false)
+  })
+
+  it('still presents when the parked resize throws', () => {
+    const { terminal, order } = createPausedTerminal({ flushThrows: true })
+
+    expect(present(terminal)).toBe(true)
+    expect(order).toEqual(['flush', expect.any(String)])
+  })
+})
+
+describe('parked renderer resize on an unpaused terminal', () => {
+  it('is left to xterm when the pause latch is not set', () => {
+    const flush = vi.fn()
+    const service = {
+      _isPaused: false,
+      _needsFullRefresh: false,
+      _pausedResizeTask: { flush },
+      refreshRows: vi.fn()
+    }
+    const terminal = {
+      rows: 24,
+      _core: {
+        _renderService: service,
+        coreService: { decPrivateModes: { synchronizedOutput: true } }
+      }
+    }
+
+    expect(requestFullViewportPresent(terminal)).toBe(true)
+    expect(forceFullViewportPresent(terminal)).toBe(true)
+    expect(forceRepaintThroughRenderPause(terminal)).toBe(false)
+    expect(flush).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
@@ -24,6 +24,7 @@ type MaybeWebglRenderer = {
 type MaybePausableRenderService = {
   _isPaused?: boolean
   _needsFullRefresh?: boolean
+  _pausedResizeTask?: { flush?: () => void } | null
   refreshRows?: (start: number, end: number, sync?: boolean) => void
   _renderer?: { value?: MaybeWebglRenderer | null } | MaybeWebglRenderer | null
 }
@@ -38,6 +39,29 @@ type TerminalWithRenderService = {
     _renderService?: MaybePausableRenderService
     coreService?: { decPrivateModes?: { synchronizedOutput?: boolean } }
     _coreService?: { decPrivateModes?: { synchronizedOutput?: boolean } }
+  }
+}
+
+/**
+ * Clears xterm's observer-pause latches and runs the renderer resize xterm parked
+ * while paused.
+ *
+ * Why the flush: `RenderService.handleResize` under `_isPaused` only parks the
+ * WebGL renderer's own resize on an idle task, and xterm flushes that task solely
+ * from the observer callback gated on `_needsFullRefresh`. Clearing the latch
+ * without flushing lets the present below paint the new grid through the old
+ * canvas/model geometry (misplaced fragments, stray bars until a user resize).
+ */
+function releaseRenderPause(service: PausableRenderService): void {
+  // Why: leave the latch as if the pending full refresh was serviced — we are
+  // about to service it — so the observer's next callback doesn't queue a
+  // redundant second full repaint.
+  service._isPaused = false
+  service._needsFullRefresh = false
+  try {
+    service._pausedResizeTask?.flush?.()
+  } catch {
+    // Why: a resize that throws mid-dispose must not block the present.
   }
 }
 
@@ -66,11 +90,7 @@ export function forceRepaintThroughRenderPause(terminal: unknown): boolean {
     return false
   }
 
-  // Why: leave the latch as if the pending full refresh was serviced — we are
-  // about to service it — so the observer's next callback doesn't queue a
-  // redundant second full repaint.
-  service._isPaused = false
-  service._needsFullRefresh = false
+  releaseRenderPause(service)
   try {
     service.refreshRows(0, rows - 1, true)
     return true
@@ -102,8 +122,7 @@ export function requestFullViewportPresent(terminal: unknown): boolean {
   }
 
   if (paused) {
-    service._isPaused = false
-    service._needsFullRefresh = false
+    releaseRenderPause(service)
   }
 
   try {
@@ -160,8 +179,7 @@ export function forceFullViewportPresent(terminal: unknown): boolean {
   }
 
   if (paused) {
-    service._isPaused = false
-    service._needsFullRefresh = false
+    releaseRenderPause(service)
   }
 
   const renderer = getRenderer(service)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## Summary
- Root cause of the garbled OpenCode TUI after workspace switch / Settings / minimize (Slack C0AK2T3JEF4, GH #18178; same family as #14320, #9115). Not the xterm 287→303 bump: the renderer tree, RenderService, viewport and DEC 2026 handling are byte-identical across it.
- When a pane's box changes while hidden, the reveal fit calls `terminal.resize` while xterm's IntersectionObserver still has RenderService paused. xterm then only **parks** `WebglRenderer.handleResize` on a `requestIdleCallback` task and flushes it solely from the observer callback, gated on `_needsFullRefresh`. Orca's three pause-release helpers cleared both latches and presented without flushing, so the first frame painted the new grid through the old canvas/model geometry: content at wrong column offsets, previous-frame fragments, stray bars. Any real resize (Cmd+L) runs the renderer resize directly and heals it, matching the reported workaround.
- Fix: a shared `releaseRenderPause` that clears the latches and flushes `_pausedResizeTask`, used by all three helpers.

## Evidence
Dev build at 67e22345da, real OpenCode 1.18.27 streaming, cycle = hide worktree → toggle right sidebar → reveal, renderer geometry read on the first present (before any heal):

| Build | Cycles with wrong-geometry frame | Renderer model cells vs grid |
|---|---|---|
| Unfixed | 8 of 8 | 32400 vs 42960 |
| Fixed | 0 of 8 | equal |

On an idle machine the parked task ran 130–270 ms later and self-healed; with idle callbacks starved for 5 s the bad frame persisted the whole time and healed only when the flush ran, which is why loaded field machines see it stick.

## Test plan
- [x] `terminal-render-pause-release-parked-resize.test.ts` (new, 13 tests: flush ordering for all three helpers, DEC 2026 path, missing internal, throwing flush, unpaused no-op)
- [x] existing `terminal-render-pause-release.test.ts` (14)
- [x] `pnpm run check:code-quality:changed`, `pnpm tc:web`
- [x] Live repro with real OpenCode before/after (table above)