### PR TITLE
feat(checks-panel): open-in-browser button on PR comments

### DIFF
--- a/src/renderer/src/components/right-sidebar/checks-panel/comment-controls.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/comment-controls.tsx
@@ -3,7 +3,6 @@ import {
   Bot,
   Check,
   Copy,
-  ExternalLink,
   MoreHorizontal,
   LoaderCircle,
   Pencil,
@@ -185,11 +184,10 @@ export function CommentMoreMenu({
   // Why: the override is an escape hatch for bots the heuristics miss, so hide
   // the action when the author is already detected as a bot without it.
   const hasMarkAsBot = authorLogin.length > 0 && (isOverriddenBot || !isBotPRComment(comment))
-  const hasGoToComment = Boolean(comment.url)
   const hasEdit = Boolean(onStartEdit)
   const hasDelete = Boolean(onDelete)
   const hasQueue = Boolean(onQueueForAgent)
-  if (!hasGoToComment && !hasEdit && !hasDelete && !hasQueue && !hasMarkAsBot) {
+  if (!hasEdit && !hasDelete && !hasQueue && !hasMarkAsBot) {
     return null
   }
 
@@ -219,17 +217,7 @@ export function CommentMoreMenu({
             )}
           </DropdownMenuItem>
         ) : null}
-        {hasQueue && (hasGoToComment || hasEdit || hasDelete) ? <DropdownMenuSeparator /> : null}
-        {hasGoToComment && (
-          <DropdownMenuItem onSelect={() => window.api.shell.openUrl(comment.url)}>
-            <ExternalLink />
-            {translate(
-              'auto.components.right.sidebar.checks.panel.content.d3923d18fe',
-              'Go to comment'
-            )}
-          </DropdownMenuItem>
-        )}
-        {hasGoToComment && (hasEdit || hasDelete) ? <DropdownMenuSeparator /> : null}
+        {hasQueue && (hasEdit || hasDelete) ? <DropdownMenuSeparator /> : null}
         {hasEdit ? (
           <DropdownMenuItem
             onSelect={(event) => {
@@ -249,7 +237,7 @@ export function CommentMoreMenu({
         ) : null}
         {hasMarkAsBot ? (
           <>
-            {(hasQueue || hasGoToComment || hasEdit || hasDelete) && <DropdownMenuSeparator />}
+            {(hasQueue || hasEdit || hasDelete) && <DropdownMenuSeparator />}
             <DropdownMenuItem
               onSelect={() => setPRBotAuthorOverride(comment.author, !isOverriddenBot)}
             >

--- a/src/renderer/src/components/right-sidebar/checks-panel/comment-row.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/comment-row.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
+import { ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
@@ -167,6 +168,22 @@ export function CommentRow({
         </button>
       )}
       <CopyButton text={buildCopyText(comment)} />
+      {comment.url ? (
+        <button
+          type="button"
+          className="shrink-0 rounded p-1 text-muted-foreground/40 transition-colors hover:bg-accent hover:text-foreground"
+          title={translate(
+            'auto.components.right.sidebar.checks.panel.content.d3923d18fe',
+            'Go to comment'
+          )}
+          onClick={(event) => {
+            event.stopPropagation()
+            void window.api.shell.openUrl(comment.url)
+          }}
+        >
+          <ExternalLink className="size-3" />
+        </button>
+      ) : null}
       <CommentMoreMenu
         comment={comment}
         botAuthorOverrides={botAuthorOverrides}

--- a/src/renderer/src/components/right-sidebar/checks-panel/comment-row.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/comment-row.tsx
@@ -168,6 +168,21 @@ export function CommentRow({
         </button>
       )}
       <CopyButton text={buildCopyText(comment)} />
+      <CommentMoreMenu
+        comment={comment}
+        botAuthorOverrides={botAuthorOverrides}
+        onStartEdit={canMutateComment && onEditComment ? handleStartEdit : undefined}
+        onDelete={canMutateComment && onDeleteComment ? handleDelete : undefined}
+        onQueueForAgent={!isReply ? onQueueForAgent : undefined}
+      />
+    </div>
+  ) : null
+
+  const commentActions = !editing ? (
+    <div className="flex shrink-0 items-center gap-0.5">
+      {presentation.useCardLayout ? null : queueButton}
+      {hoverActions}
+      {/* Why: outside hoverActions so the link stays visible (and focusable) without hover. */}
       {comment.url ? (
         <button
           type="button"
@@ -184,20 +199,6 @@ export function CommentRow({
           <ExternalLink className="size-3" />
         </button>
       ) : null}
-      <CommentMoreMenu
-        comment={comment}
-        botAuthorOverrides={botAuthorOverrides}
-        onStartEdit={canMutateComment && onEditComment ? handleStartEdit : undefined}
-        onDelete={canMutateComment && onDeleteComment ? handleDelete : undefined}
-        onQueueForAgent={!isReply ? onQueueForAgent : undefined}
-      />
-    </div>
-  ) : null
-
-  const commentActions = !editing ? (
-    <div className="flex shrink-0 items-center gap-0.5">
-      {presentation.useCardLayout ? null : queueButton}
-      {hoverActions}
     </div>
   ) : null
 


### PR DESCRIPTION
Adds an always-visible external-link icon button beside the copy button on each PR/MR comment row that opens the comment in the browser. Reuses the existing "Go to comment" label and `shell.openUrl` path from the ... menu; hidden when the comment has no URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9yZ828Fji1sT6C4u8ULgk