### PR TITLE
fix(release): restore version and harden staging confirmation

### DIFF
--- a/.github/workflows/cloud-prove-relay-asia-staging.yml
+++ b/.github/workflows/cloud-prove-relay-asia-staging.yml
@@ -55,9 +55,11 @@ jobs:
 
       - name: Validate the exact staging proof request
         shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
         run: |
           set -euo pipefail
-          test "${{ inputs.confirmation }}" = PROVE_ASIA_STAGING
+          test "${CONFIRMATION}" = PROVE_ASIA_STAGING
           [[ "${IMAGE_DIGEST}" =~ ^sha256:[0-9a-f]{64}$ ]]
           [[ "${INITIAL_SELECTOR_GENERATION}" =~ ^[1-9][0-9]*$ ]]
           [[ "${PROMOTE_ATTEMPT_ID}" =~ ^[A-Za-z0-9_-]{8,128}$ ]]

--- a/config/scripts/release-blocker-fixes.test.mjs
+++ b/config/scripts/release-blocker-fixes.test.mjs
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+describe('release blocker safeguards', () => {
+  it('keeps the root package version on the current stable release line', () => {
+    const packageJson = JSON.parse(readFileSync(resolve(projectDir, 'package.json'), 'utf8'))
+    const match = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(packageJson.version)
+    expect(match).not.toBeNull()
+    const version = match.slice(1, 4).map(Number)
+    const isAtLeastStable =
+      version[0] > 1 ||
+      (version[0] === 1 && (version[1] > 4 || (version[1] === 4 && version[2] >= 196)))
+    expect(isAtLeastStable).toBe(true)
+  })
+
+  it('passes the staging confirmation through the step environment', () => {
+    const workflow = parse(
+      readFileSync(
+        resolve(projectDir, '.github/workflows/cloud-prove-relay-asia-staging.yml'),
+        'utf8'
+      )
+    )
+    const step = workflow.jobs.prove.steps.find(
+      ({ name }) => name === 'Validate the exact staging proof request'
+    )
+
+    expect(step.env.CONFIRMATION).toBe('${{ inputs.confirmation }}')
+    expect(step.run).toContain('test "${CONFIRMATION}" = PROVE_ASIA_STAGING')
+    expect(step.run).not.toContain('${{ inputs.confirmation }}')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orca",
-  "version": "1.4.178-rc.2",
+  "version": "1.4.197",
   "description": "Next-gen IDE for parallel agentic development",
   "homepage": "https://github.com/stablyai/orca",
   "author": "stablyai",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## Summary
- restore root package metadata to the current release line (`1.4.197`)
- pass the staging proof confirmation through the step environment instead of interpolating it into shell
- add focused contract tests for both release safeguards

## Validation
- `pnpm test config/scripts/release-blocker-fixes.test.mjs --run`
- `pnpm tc`
- `pnpm exec oxfmt --check package.json config/scripts/release-blocker-fixes.test.mjs`
- `pnpm exec oxlint --config config/oxlint-code-quality-native-plugins.json config/scripts/release-blocker-fixes.test.mjs --deny-warnings`

Fixes the release-scan findings STA-6611 and STA-6612.
