### PR TITLE
fix(settings): disambiguate setups by repoId for multiple checkouts on same host (#18493)

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -48,7 +48,8 @@ function setupsByOwnedExecutionHost(
     const key = JSON.stringify([
       setup.hostId,
       setup.executionHostId ?? setup.hostId,
-      setup.runtimeOwnerEnvironmentId ?? null
+      setup.runtimeOwnerEnvironmentId ?? null,
+      setup.repoId ?? null
     ])
     if (!byHost.has(key) || setup.id === selectedSetupId) {
       byHost.set(key, setup)


### PR DESCRIPTION
## Summary

Fixes #18493

### Problem
When an Orca Project contains multiple checkouts on the same host (e.g. an upstream clone and a separate fork checkout), `setupsByOwnedExecutionHost` collapsed setups solely by host tuple `[hostId, executionHostId, runtimeOwnerEnvironmentId]`. Since both checkouts share `hostId: "local"`, they collapsed into a single setup and the setup switcher was omitted, causing Project Settings edits to unintentionally target the representative repo.

### Solution
- Keyed `setupsByOwnedExecutionHost` by `[hostId, executionHostId, runtimeOwnerEnvironmentId, repoId]`, preserving distinct entries for distinct repo checkouts on the same execution host.
