### PR TITLE
fix(cloud): bound and yield the relay's global cell-inventory lock

### DIFF
--- a/cloud/apps/relay-ops/src/incident-monitor.test.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.test.ts
@@ -123,6 +123,19 @@ describe('incident monitor evaluator', () => {
     })
   })
 
+  // Why: sweeps no longer reach the retry wrapper, so any exhaustion left in this
+  // counter is a request path that terminally failed. It must still freeze.
+  it('freezes on a single exhausted request-path transaction', () => {
+    const sample = healthySample()
+    sample.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(1)
+    expect(evaluateIncidentSample(sample, startedAt)).toMatchObject({
+      status: 'freeze',
+      failures: [
+        expect.objectContaining({ signal: 'relay.postgres_retry_exhausted', threshold: 0 })
+      ]
+    })
+  })
+
   it('allows missing auth readiness and legacy existing-only connections', () => {
     const sample = healthySample()
     const legacySelector = {

--- a/cloud/apps/relay-ops/src/incident-monitor.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.ts
@@ -38,6 +38,20 @@ export const INCIDENT_MONITOR_THRESHOLDS = {
   // margin; relayPostgresRetryExhausted below stays at zero tolerance, so any
   // transaction that terminally fails still freezes the gate.
   relayPostgresRetries: 300,
+  // Why: this bar stays at zero. Cell-inventory contention reaches the retry
+  // wrapper from exactly two kinds of caller, and neither is a sweep tick that
+  // can shrug the failure off:
+  //   - request paths, which take a wait bounded at CELL_INVENTORY_LOCK_TIMEOUT_MS
+  //     (assignment, control activation, activity, admin drain/evacuate/supersede);
+  //   - sweep-reachable code that a request also enters, which keeps the pool
+  //     lock_timeout so it cannot fail faster than before this change: the
+  //     completeEvacuation site that waits, reconcileReservationAccounting, and
+  //     placement re-entered from evacuateDeadCells.
+  // Sweep-only sites take the inventory NOWAIT, so their contention becomes
+  // database_lock_unavailable, which is not a retryable abort and never reaches
+  // this counter. The relay's cell-inventory-lock census test holds that split.
+  // Splitting the metric by the phase label PR #423 put on the log payload would
+  // need a labelled log-based metric, which this signal's counter does not carry.
   relayPostgresRetryExhausted: 0,
   // Why: public admission is a per-instance semaphore, so fleet assignment capacity is
   // concurrency x instances. A floor of 1 let the 2026-08-04 collapse from five instances

--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -31,7 +31,12 @@ import {
 } from './assignment-connection-headroom-query.js'
 import { AssignmentIdentityQueue } from './assignment-identity-queue.js'
 import type { RelayCellConfig } from './config.js'
-import type { RelayDatabase, RelayTransactionOptions, SqlRow } from './database.js'
+import type {
+  RelayDatabase,
+  RelayLockOptions,
+  RelayTransactionOptions,
+  SqlRow
+} from './database.js'
 import type { RegionalRehomeSafetySnapshot } from './relay-observability.js'
 import {
   combineRegionalRehomeSafety,
@@ -316,6 +321,25 @@ const ACTIVITY_REQUEST_UNITS: Record<AssignmentActivityKind, number> = {
 }
 
 const ASSIGNMENT_LOCK_RETRY_DEADLINE_MS = 15_000
+// Why: one global FOR UPDATE over a 23-row table serialises every director and
+// cell. At the 1s pool lock_timeout each blocked waiter also holds a pooled
+// client for a full second, so the queue converts contention into pool
+// exhaustion. The lock is held to COMMIT and the assignment path runs many
+// statements after taking it, and no hold-time telemetry existed before this
+// change, so 500ms is a first value to tune once cellInventoryHoldMsMax lands.
+export const CELL_INVENTORY_LOCK_TIMEOUT_MS = 500
+
+// The same inventory lock is taken by live requests and by background sweeps,
+// and the right failure mode differs per caller.
+export type CellInventoryLockMode =
+  // Bound the wait so a blocked request stops occupying a pooled client.
+  | 'request'
+  // Never queue: the caller handles database_lock_unavailable and moves on.
+  | 'nowait'
+  // A sweep can enter here, so keep the pool default. Failing sooner would turn
+  // ordinary contention into a 55P03 the retry wrapper reports as terminal, and
+  // one terminal failure freezes the incident gate.
+  | 'pool-default'
 // Why: stranded detection (issue #225) needs a grant old enough that a real
 // attach would have registered (the 90s activity lease covers dial +
 // activation), yet recent enough to prove an active retry loop rather than
@@ -536,29 +560,35 @@ export class RelayAssignmentStore {
   async assign(
     identity: AssignmentIdentity,
     preferredRegion?: RelayRegion,
-    placementRegion: RelayRegion = preferredRegion ?? RELAY_DEFAULT_REGION
+    placementRegion: RelayRegion = preferredRegion ?? RELAY_DEFAULT_REGION,
+    // evacuateDeadCells re-enters placement from a sweep; it must not take the
+    // bounded wait, whose 55P03 would surface as a terminal sweep failure.
+    lockMode: CellInventoryLockMode = 'request'
   ): Promise<RelayAssignment> {
-    const sticky = await this.assignStickyWithLockRetry(identity, preferredRegion)
+    const sticky = await this.assignStickyWithLockRetry(identity, lockMode, preferredRegion)
     if (sticky) return sticky
     // Only placement needs the global inventory critical section; queueing those
     // attempts locally avoids turning true placement bursts into NOWAIT storms.
     return await this.serializeAssignment(
-      async () => await this.assignWithLockRetry(identity, preferredRegion, placementRegion)
+      async () =>
+        await this.assignWithLockRetry(identity, lockMode, preferredRegion, placementRegion)
     )
   }
 
   private async assignStickyWithLockRetry(
     identity: AssignmentIdentity,
+    lockMode: CellInventoryLockMode,
     preferredRegion?: RelayRegion
   ): Promise<RelayAssignment | null> {
     return await this.withAssignmentLockRetry(
       async (inventoryFirst) =>
-        await this.assignStickyOnce(identity, inventoryFirst, preferredRegion)
+        await this.assignStickyOnce(identity, inventoryFirst, lockMode, preferredRegion)
     )
   }
 
   private async assignWithLockRetry(
     identity: AssignmentIdentity,
+    lockMode: CellInventoryLockMode,
     preferredRegion?: RelayRegion,
     placementRegion: RelayRegion = preferredRegion ?? RELAY_DEFAULT_REGION
   ): Promise<RelayAssignment> {
@@ -566,7 +596,13 @@ export class RelayAssignmentStore {
     let inventoryScope: AssignmentInventoryScope = 'none'
     while (true) {
       try {
-        return await this.assignOnce(identity, inventoryScope, preferredRegion, placementRegion)
+        return await this.assignOnce(
+          identity,
+          inventoryScope,
+          lockMode,
+          preferredRegion,
+          placementRegion
+        )
       } catch (error) {
         if (error instanceof AssignmentInventoryScopeChanged) {
           inventoryScope = 'all'
@@ -604,12 +640,13 @@ export class RelayAssignmentStore {
   private async assignStickyOnce(
     identity: AssignmentIdentity,
     inventoryFirst: boolean,
+    lockMode: CellInventoryLockMode,
     preferredRegion?: RelayRegion
   ): Promise<RelayAssignment | null> {
     const now = this.now()
     return await this.database.transaction(async (transaction) => {
       const lockedCells = inventoryFirst
-        ? await this.lockCellInventory(transaction)
+        ? await this.lockCellInventory(transaction, lockMode)
         : undefined
       const existing = await this.assignmentRow(transaction, identity, inventoryFirst)
       if (!existing) return null
@@ -751,6 +788,7 @@ export class RelayAssignmentStore {
   private async assignOnce(
     identity: AssignmentIdentity,
     inventoryScope: AssignmentInventoryScope,
+    lockMode: CellInventoryLockMode,
     preferredRegion?: RelayRegion,
     placementRegion: RelayRegion = preferredRegion ?? RELAY_DEFAULT_REGION
   ): Promise<RelayAssignment> {
@@ -760,9 +798,9 @@ export class RelayAssignmentStore {
     return await this.database.transaction(async (transaction) => {
       let lockedCells =
         inventoryScope === 'all'
-          ? await this.lockCellInventory(transaction)
+          ? await this.lockCellInventory(transaction, lockMode)
           : inventoryScope === 'general'
-            ? await this.lockGeneralCellInventory(transaction)
+            ? await this.lockGeneralCellInventory(transaction, lockMode)
             : undefined
       const existing = await this.assignmentRow(
         transaction,
@@ -779,7 +817,7 @@ export class RelayAssignmentStore {
       let connectionHeadroomReassignment = false
       let strandedReassignment = false
       if (existing && !mayNormallyReassign(activity(existing), now)) {
-        lockedCells ??= await this.lockCellInventory(transaction, true)
+        lockedCells ??= await this.lockCellInventory(transaction, 'nowait')
         const admission = await cellAdmissionStates(transaction)
         const currentRow = lockedCells.find(
           (row) => text(row, 'cell_id') === text(existing, 'cell_id')
@@ -859,8 +897,8 @@ export class RelayAssignmentStore {
       }
 
       lockedCells ??= existing
-        ? await this.lockCellInventory(transaction, true)
-        : await this.lockGeneralCellInventory(transaction, true)
+        ? await this.lockCellInventory(transaction, 'nowait')
+        : await this.lockGeneralCellInventory(transaction, 'nowait')
       const target = await this.leastLoadedCell(
         transaction,
         lockedCells,
@@ -2114,7 +2152,7 @@ export class RelayAssignmentStore {
          ORDER BY migration.user_id, migration.relay_host_id`,
         [input.cellId]
       )
-      const cells = await this.lockCellInventory(transaction)
+      const cells = await this.lockCellInventory(transaction, 'request')
       for (const migrationRow of migrations) {
         const identity = {
           userId: text(migrationRow, 'user_id'),
@@ -2608,10 +2646,12 @@ export class RelayAssignmentStore {
     let moved = 0
     for (const row of rows) {
       try {
-        const assignment = await this.assign({
-          userId: text(row, 'user_id'),
-          relayHostId: text(row, 'relay_host_id')
-        })
+        const assignment = await this.assign(
+          { userId: text(row, 'user_id'), relayHostId: text(row, 'relay_host_id') },
+          undefined,
+          undefined,
+          'pool-default'
+        )
         if (assignment.cellId !== text(row, 'cell_id')) moved++
       } catch (error) {
         if (!(error instanceof Error && error.message === 'relay_capacity_exhausted')) throw error
@@ -3162,7 +3202,7 @@ export class RelayAssignmentStore {
         )
         const requestDelta = ACTIVITY_REQUEST_UNITS[kind] * (after - before)
         if (requestDelta !== 0) {
-          await this.lockCellInventory(transaction)
+          await this.lockCellInventory(transaction, 'request')
           await this.adjustCellReservation(transaction, text(row, 'cell_id'), requestDelta)
         }
       })
@@ -3223,7 +3263,7 @@ export class RelayAssignmentStore {
         }
         const units = ACTIVITY_REQUEST_UNITS[input.kind]
         if (existing) {
-          await this.lockCellInventory(transaction)
+          await this.lockCellInventory(transaction, 'request')
           await this.removeActivityLease(transaction, identity, existing, now)
           await this.adjustCellReservation(transaction, input.cellId, units)
         }
@@ -3540,7 +3580,7 @@ export class RelayAssignmentStore {
             )
             await this.touchAssignment(transaction, identity, expiresAt, now)
           } else {
-            await this.lockCellInventory(transaction)
+            await this.lockCellInventory(transaction, 'request')
             await this.adjustCellReservation(transaction, input.cellId, 1)
             await this.adjustActivityCount(transaction, identity, 'control', 1, expiresAt, now)
             await transaction.query(
@@ -3614,7 +3654,7 @@ export class RelayAssignmentStore {
       }
       if (sourceCellId === targetCellId) throw new Error('target_matches_source')
       await this.lockAssignmentActivities(transaction, identity)
-      const cells = await this.lockCellInventory(transaction)
+      const cells = await this.lockCellInventory(transaction, 'request')
       const target = cells.find((row) => text(row, 'cell_id') === targetCellId)
       if (!target || integer(target, 'enabled') !== 1) throw new Error('target_cell_unavailable')
       if (!(await this.cellIsLive(transaction, targetCellId, now))) {
@@ -3822,7 +3862,7 @@ export class RelayAssignmentStore {
       let lockedCells: SqlRow[] | undefined
       if (inventoryFirst) {
         try {
-          lockedCells = await this.lockCellInventory(transaction)
+          lockedCells = await this.lockCellInventory(transaction, 'request')
         } catch (error) {
           if (isDatabaseLockTimeout(error)) {
             throw new Error('database_lock_unavailable')
@@ -3863,7 +3903,7 @@ export class RelayAssignmentStore {
       if (activityUnitsForCell(activityLeases, input.sourceCellId) > 0) {
         throw new Error('migration_source_still_active')
       }
-      const cells = lockedCells ?? (await this.lockCellInventory(transaction, true))
+      const cells = lockedCells ?? (await this.lockCellInventory(transaction, 'nowait'))
       const source = cells.find((cell) => text(cell, 'cell_id') === input.sourceCellId)
       const target = cells.find((cell) => text(cell, 'cell_id') === input.targetCellId)
       if (!source || integer(source, 'enabled') !== 0) {
@@ -3967,7 +4007,7 @@ export class RelayAssignmentStore {
     const now = this.now()
     return await this.database.transaction(async (transaction) => {
       const lockedCells = inventoryFirst
-        ? await this.lockCellInventory(transaction)
+        ? await this.lockCellInventory(transaction, 'request')
         : undefined
       const assignment = await this.assignmentRow(transaction, identity, inventoryFirst)
       const existing = (
@@ -4041,7 +4081,7 @@ export class RelayAssignmentStore {
       ) {
         throw new Error('migration_activity_topology_mismatch')
       }
-      const cells = lockedCells ?? (await this.lockCellInventory(transaction, true))
+      const cells = lockedCells ?? (await this.lockCellInventory(transaction, 'nowait'))
       const source = cells.find((cell) => text(cell, 'cell_id') === input.sourceCellId)
       const currentTarget = cells.find(
         (cell) => text(cell, 'cell_id') === input.currentTargetCellId
@@ -4458,7 +4498,7 @@ export class RelayAssignmentStore {
             throw new Error('migration_activity_topology_mismatch')
           }
         }
-        if (obsoleteLeases.length > 0) await this.lockCellInventory(transaction)
+        if (obsoleteLeases.length > 0) await this.lockCellInventory(transaction, 'request')
         for (const lease of obsoleteLeases) {
           await this.removeActivityLease(transaction, identity, lease, now)
         }
@@ -4634,7 +4674,7 @@ export class RelayAssignmentStore {
       ) {
         throw new Error('migration_activity_lease_shape_mismatch')
       }
-      await this.lockCellInventory(transaction)
+      await this.lockCellInventory(transaction, 'request')
       await this.adjustCellReservation(
         transaction,
         input.currentTargetCellId,
@@ -4723,7 +4763,7 @@ export class RelayAssignmentStore {
       if (this.requireLiveCells) {
         let cells: SqlRow[]
         try {
-          cells = await this.lockCellInventory(transaction, true)
+          cells = await this.lockCellInventory(transaction, 'nowait')
         } catch (error) {
           if (isDatabaseLockUnavailable(error)) {
             // Mixed-version workers may still hold a cell-first lock; defer
@@ -4779,7 +4819,7 @@ export class RelayAssignmentStore {
       )
       if (!targetIsActive) throw new Error('migration_target_not_active')
       const lease = activityLeaseById(activityLeases, migrationActivityId(assignmentEpoch))
-      if (lease && !cellsLocked) await this.lockCellInventory(transaction)
+      if (lease && !cellsLocked) await this.lockCellInventory(transaction, 'pool-default')
       if (lease) await this.removeActivityLease(transaction, identity, lease, now)
       await transaction.query(
         `UPDATE relay_assignment_migrations SET completed_at = ?, updated_at = ?
@@ -4801,7 +4841,7 @@ export class RelayAssignmentStore {
       const sourceCellId = text(assignment, 'cell_id')
       if (sourceCellId === targetCellId) throw new Error('target_matches_source')
       await this.lockAssignmentActivities(transaction, identity)
-      const cells = await this.lockCellInventory(transaction)
+      const cells = await this.lockCellInventory(transaction, 'request')
       const admission = await cellAdmissionStates(transaction)
       const targetRow = cells.find(
         (row) =>
@@ -5051,7 +5091,13 @@ export class RelayAssignmentStore {
     }
     this.pendingRegionalRehomeDisableLog = null
     const candidateSkips: RegionalRehomeCandidateSkip[] = []
+    // A Postgres transaction is unusable after a NOWAIT abort, so a contended
+    // tick abandons the candidate it stopped on plus every one behind it.
+    let candidatesTotal = 0
+    let candidatesFinished = 0
     const claimResult = await this.database.transaction(async (transaction) => {
+      candidatesTotal = 0
+      candidatesFinished = 0
       candidateSkips.length = 0
       await this.initializeRegionalRehomeControl(transaction, now)
       const control = (
@@ -5122,6 +5168,7 @@ export class RelayAssignmentStore {
         )
       )[0]
       if (retry) {
+        candidatesTotal = 1
         const fleetSafety = await this.lockedRegionalRehomeFleetSafety(transaction, now)
         if (
           !(await this.regionalRehomeSafetyAllowsClaim(
@@ -5190,6 +5237,7 @@ export class RelayAssignmentStore {
         )
       )[0]
       if (redrain) {
+        candidatesTotal = 1
         const fleetSafety = await this.lockedRegionalRehomeFleetSafety(transaction, now)
         if (
           !(await this.regionalRehomeSafetyAllowsClaim(
@@ -5253,6 +5301,7 @@ export class RelayAssignmentStore {
          LIMIT 10`,
         [preferenceCutoff, now - this.heartbeatTtlMs, now]
       )
+      candidatesTotal = candidates.length
       for (const candidate of candidates) {
         const claimed = await this.startRegionalRehomeCandidate(transaction, {
           identity: {
@@ -5268,6 +5317,7 @@ export class RelayAssignmentStore {
           now,
           skips: candidateSkips
         })
+        candidatesFinished++
         if (!claimed) continue
         await this.markRegionalRehomeDispatchClaimed(
           transaction,
@@ -5282,6 +5332,21 @@ export class RelayAssignmentStore {
         // charge the dispatch interval so skips are rate-limited like claims.
         await this.markRegionalRehomeTickSkipped(transaction, now, intervalMs)
       }
+      return null
+    }).catch((error: unknown): RegionalRehomeAttempt | null => {
+      // Only inventory contention is swallowed here; every other failure keeps
+      // its existing propagation and its dispatch-failure accounting.
+      if (!isDatabaseLockUnavailable(error)) throw error
+      // The dispatch tick runs every second; losing one to inventory contention
+      // costs a second of latency and never loses durable rehome state. The
+      // rolled-back transaction never disabled anything, so its pending disable
+      // log would describe a decision that did not happen.
+      candidateSkips.length = 0
+      this.pendingRegionalRehomeDisableLog = null
+      warnSweepCellInventoryBusy(
+        'claim-regional-rehome',
+        Math.max(1, candidatesTotal - candidatesFinished)
+      )
       return null
     })
     const pendingDisableLog = this.pendingRegionalRehomeDisableLog
@@ -5343,7 +5408,7 @@ export class RelayAssignmentStore {
     }
     const activityLeases = await this.lockAssignmentActivities(transaction, input.identity)
     assertAssignmentActivityCounts(assignment, activityLeases, 0)
-    const cells = await this.lockCellInventory(transaction)
+    const cells = await this.lockCellInventory(transaction, 'nowait')
     const admission = await cellAdmissionStates(transaction)
     const regions = new Map(
       (await transaction.query(`SELECT cell_id, region FROM relay_cell_regions`)).map((row) => [
@@ -5630,7 +5695,7 @@ export class RelayAssignmentStore {
     transaction: RelayDatabase,
     now: number
   ): Promise<RegionalRehomeFleetSafety> {
-    const cells = await this.lockCellInventory(transaction)
+    const cells = await this.lockCellInventory(transaction, 'nowait')
     const admission = await cellAdmissionStates(transaction)
     const regions = new Map(
       (await transaction.query(`SELECT cell_id, region FROM relay_cell_regions`)).map((row) => [
@@ -5874,6 +5939,7 @@ export class RelayAssignmentStore {
       [...quarantined, limit]
     )
     let completed = 0
+    let inventoryBusy = 0
     for (const candidate of candidates) {
       // One poisoned row must not stall every later candidate: an invariant
       // throw here blocked fleet completions head-of-line in production.
@@ -5890,9 +5956,14 @@ export class RelayAssignmentStore {
         if (changed) completed++
         this.regionalRehomeCandidateQuarantine.delete(attemptId)
       } catch (error) {
+        if (isDatabaseLockUnavailable(error)) {
+          inventoryBusy++
+          continue
+        }
         this.recordRegionalRehomeCandidateFailure('complete', attemptId, now, error)
       }
     }
+    warnSweepCellInventoryBusy('complete-ready-regional-rehomes', inventoryBusy)
     return completed
   }
 
@@ -6112,7 +6183,7 @@ export class RelayAssignmentStore {
         leases,
         migration
       )
-      const cells = await this.lockCellInventory(transaction)
+      const cells = await this.lockCellInventory(transaction, 'nowait')
       const target = cells.find((cell) => text(cell, 'cell_id') === targetCellId)
       const admission = await cellAdmissionStates(transaction)
       if (
@@ -6261,6 +6332,7 @@ export class RelayAssignmentStore {
       [now - REGIONAL_REHOME_MAX_REFRESH_MS, ...quarantined, limit]
     )
     let aborted = 0
+    let inventoryBusy = 0
     for (const candidate of candidates) {
       const identity = {
         userId: text(candidate, 'user_id'),
@@ -6318,7 +6390,7 @@ export class RelayAssignmentStore {
             integer(lease, 'expires_at') > now
         )
         if (targetActive) return false
-        const cells = await this.lockCellInventory(transaction)
+        const cells = await this.lockCellInventory(transaction, 'nowait')
         const source = cells.find((cell) => text(cell, 'cell_id') === sourceCellId)
         const admission = await cellAdmissionStates(transaction)
         if (
@@ -6376,10 +6448,12 @@ export class RelayAssignmentStore {
         })
         this.regionalRehomeCandidateQuarantine.delete(attemptId)
       } catch (error) {
-        this.recordRegionalRehomeCandidateFailure('abort', attemptId, now, error)
+        if (isDatabaseLockUnavailable(error)) inventoryBusy++
+        else this.recordRegionalRehomeCandidateFailure('abort', attemptId, now, error)
       }
       if (changed) aborted++
     }
+    warnSweepCellInventoryBusy('abort-expired-regional-rehomes', inventoryBusy)
     return aborted
   }
 
@@ -6396,6 +6470,7 @@ export class RelayAssignmentStore {
       [now, now, abandonedBefore, abandonedBefore]
     )
     let aborted = 0
+    let inventoryBusy = 0
     for (const candidate of candidates) {
       const didAbort = await this.database.transaction(async (transaction) => {
         const identity = {
@@ -6480,7 +6555,7 @@ export class RelayAssignmentStore {
           ]
             .map((activityId) => activityLeaseById(activityLeases, activityId))
             .filter((lease): lease is SqlRow => lease !== undefined)
-          if (obsoleteLeases.length > 0) await this.lockCellInventory(transaction)
+          if (obsoleteLeases.length > 0) await this.lockCellInventory(transaction, 'nowait')
           for (const lease of obsoleteLeases) {
             await this.removeActivityLease(transaction, identity, lease, now)
           }
@@ -6498,7 +6573,7 @@ export class RelayAssignmentStore {
           )
           return true
         }
-        const cells = await this.lockCellInventory(transaction)
+        const cells = await this.lockCellInventory(transaction, 'nowait')
         const sourceCellId = text(row, 'source_cell_id')
         const admissionRows = await transaction.query(
           `SELECT cell_id, admission_state, updated_at FROM relay_cell_admission
@@ -6595,9 +6670,15 @@ export class RelayAssignmentStore {
           [now, now, identity.userId, identity.relayHostId, assignmentEpoch]
         )
         return true
+      }).catch((error: unknown): boolean => {
+        // Expiry is durable; another director settling this row is not a failure.
+        if (!isDatabaseLockUnavailable(error)) throw error
+        inventoryBusy++
+        return false
       })
       if (didAbort) aborted++
     }
+    warnSweepCellInventoryBusy('abort-expired-evacuations', inventoryBusy)
     return aborted
   }
 
@@ -6665,7 +6746,7 @@ export class RelayAssignmentStore {
           const activityLeases = await this.lockAssignmentActivities(transaction, identity, true)
           const lease = activityLeaseById(activityLeases, text(candidate, 'activity_id'))
           if (!lease || integer(lease, 'expires_at') > now) return false
-          await this.lockCellInventory(transaction, true)
+          await this.lockCellInventory(transaction, 'nowait')
           await this.removeActivityLease(transaction, identity, lease, now)
           return true
         })
@@ -6709,7 +6790,7 @@ export class RelayAssignmentStore {
           [now],
           { failIfUnavailable: true }
         )
-        if (expired.length > 0) await this.lockCellInventory(transaction, true)
+        if (expired.length > 0) await this.lockCellInventory(transaction, 'nowait')
         for (const row of expired) {
           await this.adjustCellReservation(transaction, text(row, 'cell_id'), -requestUnits(row))
           await transaction.query(
@@ -6782,7 +6863,7 @@ export class RelayAssignmentStore {
           targetCellId
         ]
       )
-      const cells = await this.lockCellInventory(transaction)
+      const cells = await this.lockCellInventory(transaction, 'pool-default')
       const assignmentKeys = new Set(
         assignments.map((row) =>
           assignmentKey(text(row, 'user_id'), text(row, 'relay_host_id'))
@@ -6861,30 +6942,32 @@ export class RelayAssignmentStore {
 
   private async lockCellInventory(
     database: RelayDatabase,
-    failIfUnavailable = false
+    mode: CellInventoryLockMode
   ): Promise<SqlRow[]> {
     // Every capacity-changing assignment takes the tiny cell inventory in one
     // order; dynamically locking only the selected target allowed cross-cell cycles.
-    return await database.queryLocked(
+    const rows = await database.queryLocked(
       `SELECT * FROM relay_cells ORDER BY cell_id ASC`,
       [],
-      { failIfUnavailable }
+      cellInventoryLockOptions(mode)
     )
+    return rows
   }
 
   private async lockGeneralCellInventory(
     database: RelayDatabase,
-    failIfUnavailable = false
+    mode: CellInventoryLockMode
   ): Promise<SqlRow[]> {
-    return await database.queryLocked(
+    const rows = await database.queryLocked(
       `SELECT * FROM relay_cells
        WHERE cell_id IN (
          SELECT cell_id FROM relay_cell_admission WHERE admission_state = 'general'
        )
        ORDER BY cell_id ASC`,
       [],
-      { failIfUnavailable }
+      cellInventoryLockOptions(mode)
     )
+    return rows
   }
 
   private async leastLoadedCell(
@@ -6892,7 +6975,7 @@ export class RelayAssignmentStore {
     lockedCells: SqlRow[] | undefined,
     preferredRegion: RelayRegion
   ): Promise<CellRow | null> {
-    const rows = lockedCells ?? (await this.lockCellInventory(database))
+    const rows = lockedCells ?? (await this.lockCellInventory(database, 'pool-default'))
     const regions = new Map(
       (await database.query(`SELECT cell_id, region FROM relay_cell_regions`)).map((row) => [
         text(row, 'cell_id'),
@@ -7507,7 +7590,7 @@ export class RelayAssignmentStore {
     ) {
       throw new Error('activity_lease_shape_mismatch')
     }
-    const cells = await this.lockCellInventory(database)
+    const cells = await this.lockCellInventory(database, 'request')
     await database.query(
       `DELETE FROM relay_assignment_activity_leases
        WHERE user_id = ? AND relay_host_id = ? AND activity_kind = 'control'
@@ -7884,6 +7967,23 @@ function isMissingMigration(error: unknown): boolean {
 
 function isDatabaseLockUnavailable(error: unknown): boolean {
   return error instanceof Error && error.message === 'database_lock_unavailable'
+}
+
+function cellInventoryLockOptions(mode: CellInventoryLockMode): RelayLockOptions {
+  if (mode === 'nowait') return { failIfUnavailable: true, measureHoldMs: true }
+  if (mode === 'pool-default') return { measureHoldMs: true }
+  return { lockTimeoutMs: CELL_INVENTORY_LOCK_TIMEOUT_MS, measureHoldMs: true }
+}
+
+// Background sweeps take the cell inventory NOWAIT so they never queue ahead of
+// assignment traffic. A skipped candidate is re-derived from durable state on
+// the next tick, so it is ordinary contention, not a sweep failure: one summary
+// line per tick, never an error and never a quarantine.
+function warnSweepCellInventoryBusy(sweep: string, skipped: number): void {
+  if (skipped === 0) return
+  console.warn(
+    JSON.stringify({ event: 'orca_relay_sweep_cell_inventory_busy', sweep, skipped })
+  )
 }
 
 function isDatabaseLockTimeout(error: unknown): boolean {

--- a/cloud/apps/relay/src/cell-inventory-hold-samples.ts
+++ b/cloud/apps/relay/src/cell-inventory-hold-samples.ts
@@ -1,0 +1,46 @@
+// Why: the cell inventory lock is held to COMMIT, and the assignment path runs
+// many statements after taking it. Tuning the request-path wait bound needs the
+// hold distribution, and no runtime metric carried it before this change.
+export type CellInventoryHoldCounts = {
+  cellInventoryHoldMsMax: number
+  cellInventoryHoldMsP95: number
+  cellInventoryHolds: number
+}
+
+// Bounded so a flush interval with heavy assignment traffic cannot grow the array
+// without limit; the reservoir keeps the most recent holds.
+const MAX_SAMPLES = 2_048
+
+export function emptyCellInventoryHoldCounts(): CellInventoryHoldCounts {
+  return { cellInventoryHoldMsMax: 0, cellInventoryHoldMsP95: 0, cellInventoryHolds: 0 }
+}
+
+export class CellInventoryHoldSamples {
+  private samples: number[] = []
+
+  record(holdMs: number): void {
+    if (!Number.isFinite(holdMs) || holdMs < 0) return
+    if (this.samples.length === MAX_SAMPLES) this.samples.shift()
+    this.samples.push(holdMs)
+  }
+
+  consumeCounts(): CellInventoryHoldCounts {
+    const counts = this.readCounts()
+    this.samples = []
+    return counts
+  }
+
+  readCounts(): CellInventoryHoldCounts {
+    if (this.samples.length === 0) return emptyCellInventoryHoldCounts()
+    const sorted = [...this.samples].sort((left, right) => left - right)
+    return {
+      cellInventoryHoldMsMax: round(sorted[sorted.length - 1]!),
+      cellInventoryHoldMsP95: round(sorted[Math.ceil(0.95 * sorted.length) - 1] ?? 0),
+      cellInventoryHolds: sorted.length
+    }
+  }
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(3))
+}

--- a/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import type { CellInventoryLockMode } from './assignment-store.js'
+
+// Which entry points can reach a call site. A site a sweep can enter must never
+// take the bounded wait: its 55P03 becomes a terminal transaction failure, and
+// the incident monitor freezes on a single one.
+type Reachability = 'request' | 'sweep' | 'both'
+
+// 'caller' is not a CellInventoryLockMode: those sites take the mode threaded
+// from `assign`, which is 'request' for a client and 'pool-default' for the
+// evacuateDeadCells sweep.
+type CensusMode = CellInventoryLockMode | 'caller'
+
+type CensusEntry = { method: string; mode: CensusMode; reach: Reachability }
+
+// Every lockCellInventory / lockGeneralCellInventory call site in
+// assignment-store.ts, in source order. A new site fails this test until it is
+// classified here, which is the point.
+const CENSUS: CensusEntry[] = [
+  { method: 'assignStickyOnce', mode: 'caller', reach: 'both' },
+  { method: 'assignOnce', mode: 'caller', reach: 'both' },
+  { method: 'assignOnce', mode: 'caller', reach: 'both' },
+  { method: 'assignOnce', mode: 'nowait', reach: 'both' },
+  { method: 'assignOnce', mode: 'nowait', reach: 'both' },
+  { method: 'assignOnce', mode: 'nowait', reach: 'both' },
+  { method: 'refreshDrainMigrationLeasesOnce', mode: 'request', reach: 'request' },
+  { method: 'changeActivity', mode: 'request', reach: 'request' },
+  { method: 'acquireActivity', mode: 'request', reach: 'request' },
+  { method: 'activateControl', mode: 'request', reach: 'request' },
+  { method: 'startEvacuation', mode: 'request', reach: 'request' },
+  { method: 'completeEvacuationFromDeadSourceOnce', mode: 'request', reach: 'request' },
+  { method: 'completeEvacuationFromDeadSourceOnce', mode: 'nowait', reach: 'request' },
+  { method: 'supersedeRegisteredEvacuationOnce', mode: 'request', reach: 'request' },
+  { method: 'supersedeRegisteredEvacuationOnce', mode: 'nowait', reach: 'request' },
+  { method: 'prepareRegisteredCellSupersession', mode: 'request', reach: 'request' },
+  { method: 'prepareRegisteredCellSupersession', mode: 'request', reach: 'request' },
+  { method: 'completeEvacuation', mode: 'nowait', reach: 'both' },
+  { method: 'completeEvacuation', mode: 'pool-default', reach: 'both' },
+  { method: 'rebalanceDormant', mode: 'request', reach: 'request' },
+  { method: 'startRegionalRehomeCandidate', mode: 'nowait', reach: 'sweep' },
+  { method: 'lockedRegionalRehomeFleetSafety', mode: 'nowait', reach: 'sweep' },
+  { method: 'completeRegionalRehomeCandidate', mode: 'nowait', reach: 'sweep' },
+  { method: 'abortExpiredRegionalRehomes', mode: 'nowait', reach: 'sweep' },
+  { method: 'abortExpiredEvacuations', mode: 'nowait', reach: 'sweep' },
+  { method: 'abortExpiredEvacuations', mode: 'nowait', reach: 'sweep' },
+  { method: 'releaseExpiredActivityLeases', mode: 'nowait', reach: 'sweep' },
+  { method: 'releaseExpiredActivity', mode: 'nowait', reach: 'sweep' },
+  { method: 'reconcileReservationAccounting', mode: 'pool-default', reach: 'both' },
+  { method: 'leastLoadedCell', mode: 'pool-default', reach: 'both' },
+  { method: 'removeSupersededSameCellControls', mode: 'request', reach: 'request' }
+]
+
+// The background sweeps, and nothing else. A method reachable from one of these
+// can be entered by a sweep tick, whatever else can also enter it.
+const SWEEP_ROOTS = [
+  'refreshRegionalRehomeLeases',
+  'completeReadyEvacuations',
+  'completeReadyRegionalRehomes',
+  'abortExpiredEvacuations',
+  'abortExpiredRegionalRehomes',
+  'reapRegionalRehomeAttempts',
+  'releaseExpiredActivityLeases',
+  'releaseExpiredActivity',
+  'releaseExpiredRegionPreferences',
+  'evacuateDeadCells',
+  'claimRegionalRehome',
+  'recordRegionalRehomeDispatchFailure'
+]
+
+const DECLARATION = /^ {2}(?:private |public )?(?:static )?(?:async )?([A-Za-z_][\w]*)[(<]/
+
+function storeSource(): string[] {
+  return readFileSync(new URL('./assignment-store.ts', import.meta.url), 'utf8').split('\n')
+}
+
+// Why: a hand-written reachability column is a claim, not a check. Derive it, so
+// a new sweep edge into a bounded site fails here instead of in production.
+function sweepReachableMethods(lines: string[]): Set<string> {
+  const bounds: { name: string; start: number }[] = []
+  lines.forEach((line, index) => {
+    const declaration = DECLARATION.exec(line)
+    if (declaration) bounds.push({ name: declaration[1]!, start: index })
+  })
+  const callees = new Map<string, Set<string>>()
+  bounds.forEach((method, index) => {
+    const end = bounds[index + 1]?.start ?? lines.length
+    const names = callees.get(method.name) ?? new Set<string>()
+    for (const call of lines.slice(method.start, end).join('\n').matchAll(
+      /this\.([A-Za-z_][\w]*)\s*\(/g
+    )) {
+      names.add(call[1]!)
+    }
+    callees.set(method.name, names)
+  })
+  const reached = new Set<string>()
+  const pending = [...SWEEP_ROOTS]
+  while (pending.length > 0) {
+    const name = pending.pop()!
+    if (reached.has(name)) continue
+    reached.add(name)
+    for (const callee of callees.get(name) ?? []) if (!reached.has(callee)) pending.push(callee)
+  }
+  return reached
+}
+
+function readCallSites(): { method: string; mode: CensusMode }[] {
+  const sites: { method: string; mode: CensusMode }[] = []
+  let method = '<module>'
+  for (const line of storeSource()) {
+    const declaration = DECLARATION.exec(line)
+    if (declaration) method = declaration[1]!
+    if (/private async lock(General)?CellInventory\(/.test(line)) continue
+    const call = /lock(?:General)?CellInventory\(\s*\w+\s*,\s*(?:'([a-z-]+)'|(\w+))\s*\)/.exec(line)
+    if (!call) continue
+    sites.push({ method, mode: (call[1] ?? 'caller') as CensusMode })
+  }
+  return sites
+}
+
+describe('cell inventory lock call-site census', () => {
+  it('classifies every call site exactly as recorded', () => {
+    expect(readCallSites()).toEqual(
+      CENSUS.map(({ method, mode }) => ({ method, mode }))
+    )
+  })
+
+  it('leaves no call site taking the inventory without naming a mode', () => {
+    const source = readFileSync(new URL('./assignment-store.ts', import.meta.url), 'utf8')
+    const unclassified = source
+      .split('\n')
+      .filter((line) => /lock(?:General)?CellInventory\(\s*\w+\s*\)/.test(line))
+      .filter((line) => !line.includes('private async'))
+
+    expect(unclassified).toEqual([])
+  })
+
+  it('derives the same reachability the census claims', () => {
+    const reached = sweepReachableMethods(storeSource())
+    const derived = readCallSites().map(({ method }) => reached.has(method))
+
+    expect(derived).toEqual(CENSUS.map((entry) => entry.reach !== 'request'))
+  })
+
+  // Why: this is the whole point of the classification. A shorter wait on a
+  // sweep-reachable site turns contention into a terminal transaction failure,
+  // and relayPostgresRetryExhausted freezes the incident gate at zero.
+  it('never puts a sweep-reachable site on the bounded wait', () => {
+    const reached = sweepReachableMethods(storeSource())
+    const bounded = readCallSites().filter(
+      (site) => site.mode === 'request' && reached.has(site.method)
+    )
+
+    expect(bounded).toEqual([])
+  })
+
+  it('routes every sweep-only site to NOWAIT so it can skip the tick', () => {
+    const queueing = CENSUS.filter(
+      (entry) => entry.reach === 'sweep' && entry.mode !== 'nowait'
+    )
+
+    expect(queueing).toEqual([])
+  })
+})

--- a/cloud/apps/relay/src/cell-inventory-lock-contention.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-lock-contention.test.ts
@@ -1,0 +1,541 @@
+import { readFileSync } from 'node:fs'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const fakes = vi.hoisted(() => ({
+  statements: [] as string[],
+  query: vi.fn(async (sql: string) => {
+    fakes.statements.push(sql)
+    return { rows: [], rowCount: 0 }
+  }),
+  release: vi.fn(),
+  end: vi.fn(async () => undefined)
+}))
+
+vi.mock('pg', () => ({
+  default: {
+    Pool: class {
+      totalCount = 1
+      idleCount = 1
+      waitingCount = 0
+      end = fakes.end
+      on = vi.fn()
+      connect = vi.fn(async () => ({ query: fakes.query, release: fakes.release }))
+    }
+  }
+}))
+
+const { CELL_INVENTORY_LOCK_TIMEOUT_MS, RelayAssignmentStore } = await import(
+  './assignment-store.js'
+)
+const { consumeRelayCellInventoryHold, openInMemoryRelayDatabase, openRelayDatabase, POSTGRES_LOCK_TIMEOUT_MS } =
+  await import('./database.js')
+const RESTORE = `SET LOCAL lock_timeout = '${POSTGRES_LOCK_TIMEOUT_MS}ms'`
+type RelayDatabase = import('./database.js').RelayDatabase
+type RelayLockOptions = import('./database.js').RelayLockOptions
+type RelayTransactionOptions = import('./database.js').RelayTransactionOptions
+type SqlRow = import('./database.js').SqlRow
+
+const CELL_INVENTORY_SQL = 'SELECT * FROM relay_cells ORDER BY cell_id ASC'
+
+// The assignment path locks the general-admission subset; both forms are the
+// same ordered scan of the same 23-row table and share its lock queue.
+function locksCellInventory(sql: string): boolean {
+  return sql.trim().startsWith('SELECT * FROM relay_cells') && sql.includes('ORDER BY cell_id ASC')
+}
+const CELLS = [
+  { id: 'cell-a', url: 'https://relay-a.example.com', capacityRequests: 10 },
+  { id: 'cell-b', url: 'https://relay-b.example.com', capacityRequests: 10 }
+]
+const identity = { userId: 'user-a', relayHostId: 'host000000000001' }
+
+async function openFakePostgres(): Promise<RelayDatabase> {
+  const database = await openRelayDatabase({
+    databaseUrl: 'postgresql://relay:secret@127.0.0.1:5432/relay',
+    dataDir: './unused'
+  })
+  fakes.statements.length = 0
+  return database
+}
+
+afterEach(() => {
+  fakes.statements.length = 0
+  fakes.query.mockReset()
+  fakes.query.mockImplementation(async (sql: string) => {
+    fakes.statements.push(sql)
+    return { rows: [], rowCount: 0 }
+  })
+})
+
+describe('bounded cell-inventory lock wait', () => {
+  // Why: a bound at or above the pool default would fence nothing, and one far
+  // below the hold time would convert ordinary contention into terminal failures.
+  it('keeps the request bound strictly inside the pool default', () => {
+    expect(CELL_INVENTORY_LOCK_TIMEOUT_MS).toBe(500)
+    expect(CELL_INVENTORY_LOCK_TIMEOUT_MS).toBeLessThan(POSTGRES_LOCK_TIMEOUT_MS)
+  })
+
+  // Why: SET LOCAL lasts to COMMIT. Left in place it would govern every later
+  // locked statement in the transaction and misattribute their 55P03s.
+  it('restores the pool default before the next statement in the transaction', async () => {
+    const database = await openFakePostgres()
+
+    await database.transaction(async (transaction) => {
+      await transaction.queryLocked(CELL_INVENTORY_SQL, [], { lockTimeoutMs: 150 })
+      await transaction.queryLocked('SELECT * FROM relay_assignments', [])
+    })
+
+    expect(fakes.statements).toEqual([
+      'BEGIN',
+      "SET LOCAL lock_timeout = '150ms'",
+      `${CELL_INVENTORY_SQL} FOR UPDATE`,
+      RESTORE,
+      'SELECT * FROM relay_assignments FOR UPDATE',
+      'COMMIT'
+    ])
+    await database.close()
+  })
+
+  it('restores the pool default when the bounded lock itself times out', async () => {
+    const database = await openFakePostgres()
+    fakes.query.mockImplementation(async (sql: string) => {
+      fakes.statements.push(sql)
+      if (sql.includes('FOR UPDATE')) {
+        throw Object.assign(new Error('lock timeout'), { code: '55P03' })
+      }
+      return { rows: [], rowCount: 0 }
+    })
+
+    await expect(
+      database.transaction(async (transaction) => {
+        await transaction.queryLocked(CELL_INVENTORY_SQL, [], { lockTimeoutMs: 150 })
+      })
+    ).rejects.toMatchObject({ code: '55P03' })
+
+    // The retry wrapper makes three attempts; each one must leave the default back.
+    expect(fakes.statements.filter((sql) => sql.startsWith('SET LOCAL'))).toEqual(
+      Array.from({ length: 3 }, () => ["SET LOCAL lock_timeout = '150ms'", RESTORE]).flat()
+    )
+    await database.close()
+  })
+
+  it('rejects a lock bound that is not a positive whole number of milliseconds', async () => {
+    const database = await openFakePostgres()
+
+    for (const lockTimeoutMs of [0, -1, 1.5, Number.NaN]) {
+      await expect(
+        database.transaction(
+          async (transaction) =>
+            await transaction.queryLocked(CELL_INVENTORY_SQL, [], { lockTimeoutMs })
+        )
+      ).rejects.toThrow('invalid_lock_timeout')
+    }
+    await database.close()
+  })
+
+  it('skips the timeout for a NOWAIT lock, which never queues', async () => {
+    const database = await openFakePostgres()
+
+    await database.transaction(async (transaction) => {
+      await transaction.queryLocked(CELL_INVENTORY_SQL, [], {
+        failIfUnavailable: true,
+        lockTimeoutMs: 150
+      })
+    })
+
+    expect(fakes.statements.filter((sql) => sql.startsWith('SET LOCAL'))).toEqual([])
+    await database.close()
+  })
+
+  it('skips the timeout outside a transaction, where SET LOCAL cannot survive', async () => {
+    const database = await openFakePostgres()
+
+    await database.queryLocked(CELL_INVENTORY_SQL, [], { lockTimeoutMs: 150 })
+
+    expect(fakes.statements).toEqual([`${CELL_INVENTORY_SQL} FOR UPDATE`])
+    await database.close()
+  })
+
+  it('ignores the timeout on SQLite, which has no SET LOCAL', async () => {
+    const database = await openInMemoryRelayDatabase()
+
+    const rows = await database.transaction(
+      async (transaction) =>
+        await transaction.queryLocked(CELL_INVENTORY_SQL, [], { lockTimeoutMs: 150 })
+    )
+
+    expect(rows).toEqual([])
+    await database.close()
+  })
+
+  // Why: testing the helper alone would pass with the store still queueing for
+  // the pool's one-second default.
+  // Why: testing the helper alone would pass with the request path still queueing
+  // for the pool's full second.
+  it('never lets a request path take the unbounded wait', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const probe = new InventoryLockProbe(database)
+    const store = new RelayAssignmentStore(probe, () => 1_000)
+    await store.reconcileCells(CELLS)
+    probe.inventoryLocks.length = 0
+
+    // Assignment takes the general-admission subset; evacuation takes them all.
+    await store.assign(identity)
+    const generalLocks = probe.inventoryLocks.length
+    await store.startEvacuation(identity, 'cell-b')
+
+    expect(generalLocks).toBeGreaterThan(0)
+    expect(probe.inventoryLocks.length).toBeGreaterThan(generalLocks)
+    for (const options of probe.inventoryLocks) {
+      const bounded = options?.lockTimeoutMs === CELL_INVENTORY_LOCK_TIMEOUT_MS
+      expect(bounded || options?.failIfUnavailable === true).toBe(true)
+    }
+    await database.close()
+  })
+
+  // Why: evacuateDeadCells re-enters placement from a sweep. A 55P03 there would
+  // be reported as a terminal sweep failure and freeze the incident gate.
+  it('keeps the pool default when a sweep re-enters placement', async () => {
+    const requestModes = await recordAssignInventoryModes(async (store) => {
+      await store.assign(identity)
+    })
+    const sweepModes = await recordAssignInventoryModes(async (store) => {
+      await store.assign(identity, undefined, undefined, 'pool-default')
+    })
+
+    // The inventory-first retry is the lane that carries the caller's mode.
+    expect(requestModes).toContain(CELL_INVENTORY_LOCK_TIMEOUT_MS)
+    expect(sweepModes).not.toContain(CELL_INVENTORY_LOCK_TIMEOUT_MS)
+    expect(sweepModes.filter((mode) => mode === 'nowait').length).toBe(
+      requestModes.filter((mode) => mode === 'nowait').length
+    )
+  })
+
+  it('sends the sweep that re-enters placement down the unbounded lane', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const probe = new InventoryLockProbe(database)
+    let now = 1_000
+    const store = new RelayAssignmentStore(probe, () => now, {
+      requireLiveCells: true,
+      heartbeatTtlMs: 45_000
+    })
+    await store.reconcileCells(CELLS)
+    for (const cell of CELLS) {
+      await store.recordCellHeartbeat({
+        cellId: cell.id,
+        cellUrl: cell.url,
+        cellIncarnation: `1111111${cell.id.slice(-1)}-1111-4111-8111-111111111111`,
+        startedAt: 50,
+        ready: true,
+        observedRequests: 0
+      })
+    }
+    await store.assign(identity)
+    // Let every heartbeat lapse so the sweep sees the assigned cell as dead.
+    now += 45_001
+    probe.inventoryLocks.length = 0
+    probe.failActivityLockOnce = true
+
+    await store.evacuateDeadCells()
+
+    expect(probe.inventoryLocks).not.toEqual([])
+    for (const options of probe.inventoryLocks) {
+      expect(options?.lockTimeoutMs).toBeUndefined()
+    }
+    await database.close()
+  })
+
+  // Why: the SQLite hold test cannot reach PostgresDatabase.transaction, which is
+  // the only path production ever takes.
+  it('records the hold on the PostgreSQL transaction path', async () => {
+    const database = await openFakePostgres()
+
+    await database.transaction(async (transaction) => {
+      await transaction.queryLocked(CELL_INVENTORY_SQL, [], {
+        lockTimeoutMs: 150,
+        measureHoldMs: true
+      })
+    })
+
+    expect(consumeRelayCellInventoryHold(database).cellInventoryHolds).toBe(1)
+    await database.close()
+  })
+
+  it('records no hold for a PostgreSQL transaction that took no measured lock', async () => {
+    const database = await openFakePostgres()
+
+    await database.transaction(async (transaction) => {
+      await transaction.queryLocked(CELL_INVENTORY_SQL, [], { lockTimeoutMs: 150 })
+    })
+
+    expect(consumeRelayCellInventoryHold(database).cellInventoryHolds).toBe(0)
+    await database.close()
+  })
+
+  // Why: index.ts boots a server on import, so its wiring can only be read. An
+  // unspread hold metric is invisible: the flush simply omits the fields.
+  it('spreads the hold counts into the runtime metrics flush', () => {
+    const source = readFileSync(new URL('./index.ts', import.meta.url), 'utf8')
+    const flush = /observability\.start\(\(\) => \(\{([^}]*)\}\)\)/.exec(source)
+
+    expect(flush?.[1]).toContain('...consumeRelayCellInventoryHold(database)')
+  })
+
+  // Why: 500ms is a first value, not a measurement. Tuning it needs the hold
+  // distribution, which no runtime metric carried.
+  it('reports how long the inventory lock was held to COMMIT', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const store = new RelayAssignmentStore(database, () => 1_000)
+    await store.reconcileCells(CELLS)
+    consumeRelayCellInventoryHold(database)
+
+    await store.assign(identity)
+
+    const counts = consumeRelayCellInventoryHold(database)
+    expect(counts.cellInventoryHolds).toBeGreaterThan(0)
+    expect(counts.cellInventoryHoldMsMax).toBeGreaterThanOrEqual(counts.cellInventoryHoldMsP95)
+    expect(counts.cellInventoryHoldMsMax).toBeGreaterThan(0)
+    // Consuming resets the window so the next flush reports its own holds.
+    expect(consumeRelayCellInventoryHold(database).cellInventoryHolds).toBe(0)
+    await database.close()
+  })
+})
+
+// Why: the incident monitor freezes at zero exhausted transactions. A sweep that
+// steps aside must not spend the retry budget or report a terminal failure.
+describe('sweep lock skips stay off the transaction retry counters', () => {
+  it('reports neither a retry nor an exhaustion when NOWAIT finds the lock held', async () => {
+    const database = await openFakePostgres()
+    fakes.query.mockImplementation(async (sql: string) => {
+      fakes.statements.push(sql)
+      if (sql.includes('FOR UPDATE NOWAIT')) {
+        throw Object.assign(new Error('could not obtain lock'), { code: '55P03' })
+      }
+      return { rows: [], rowCount: 0 }
+    })
+    const events: string[] = []
+    const warn = vi.spyOn(console, 'warn').mockImplementation((line: unknown) => {
+      try {
+        events.push(String((JSON.parse(line as string) as { event?: unknown }).event))
+      } catch {
+        // non-JSON lines are not transaction telemetry
+      }
+    })
+
+    try {
+      await expect(
+        database.transaction(async (transaction) => {
+          await transaction.queryLocked(CELL_INVENTORY_SQL, [], { failIfUnavailable: true })
+        })
+      ).rejects.toThrow('database_lock_unavailable')
+    } finally {
+      warn.mockRestore()
+    }
+
+    expect(events).not.toContain('orca_relay_postgres_transaction_retry')
+    expect(events).not.toContain('orca_relay_postgres_transaction_exhausted')
+    expect(fakes.statements.filter((sql) => sql === 'BEGIN')).toHaveLength(1)
+    await database.close()
+  })
+})
+
+describe('background sweeps skip a contended cell inventory', () => {
+  it('takes the inventory NOWAIT and skips the tick instead of queueing', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const probe = new InventoryLockProbe(database)
+    let now = 1_000
+    const store = new RelayAssignmentStore(probe, () => now)
+    await store.reconcileCells(CELLS)
+    const assignment = await store.assign(identity)
+    await store.activateControl(identity, {
+      cellId: assignment.cellId,
+      assignmentEpoch: assignment.assignmentEpoch,
+      generation: 1
+    })
+    await store.startEvacuation(identity, 'cell-b')
+    now += 24 * 60 * 60_000
+    probe.inventoryLocks.length = 0
+    probe.failNoWait = true
+    const warnings = collectWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    let aborted: number
+    try {
+      aborted = await store.abortExpiredEvacuations()
+    } finally {
+      warnings.restore()
+    }
+
+    expect(aborted).toBe(0)
+    expect(probe.inventoryLocks).not.toEqual([])
+    expect(probe.inventoryLocks.every((options) => options?.failIfUnavailable === true)).toBe(
+      true
+    )
+    expect(warnings.entries).toEqual([
+      { event: 'orca_relay_sweep_cell_inventory_busy', sweep: 'abort-expired-evacuations', skipped: 1 }
+    ])
+    await database.close()
+  })
+
+  // Why: a summary line on every quiet tick would bury the contended ones.
+  it('says nothing on a tick that skipped no candidate', async () => {
+    const database = await openInMemoryRelayDatabase()
+    let now = 1_000
+    const store = new RelayAssignmentStore(database, () => now)
+    await store.reconcileCells(CELLS)
+    const assignment = await store.assign(identity)
+    await store.activateControl(identity, {
+      cellId: assignment.cellId,
+      assignmentEpoch: assignment.assignmentEpoch,
+      generation: 1
+    })
+    await store.startEvacuation(identity, 'cell-b')
+    now += 24 * 60 * 60_000
+    const warnings = collectWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    let aborted: number
+    try {
+      aborted = await store.abortExpiredEvacuations()
+    } finally {
+      warnings.restore()
+    }
+
+    expect(aborted).toBe(1)
+    expect(warnings.entries).toEqual([])
+    await database.close()
+  })
+
+  it('still aborts the expired evacuation once the inventory is free', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const probe = new InventoryLockProbe(database)
+    let now = 1_000
+    const store = new RelayAssignmentStore(probe, () => now)
+    await store.reconcileCells(CELLS)
+    const assignment = await store.assign(identity)
+    await store.activateControl(identity, {
+      cellId: assignment.cellId,
+      assignmentEpoch: assignment.assignmentEpoch,
+      generation: 1
+    })
+    await store.startEvacuation(identity, 'cell-b')
+    now += 24 * 60 * 60_000
+
+    expect(await store.abortExpiredEvacuations()).toBe(1)
+    await database.close()
+  })
+})
+
+// Returns each inventory lock the run took, as its bound or 'nowait'.
+async function recordAssignInventoryModes(
+  drive: (store: InstanceType<typeof RelayAssignmentStore>) => Promise<void>
+): Promise<(number | 'nowait' | 'pool-default')[]> {
+  const database = await openInMemoryRelayDatabase()
+  const probe = new InventoryLockProbe(database)
+  const store = new RelayAssignmentStore(probe, () => 1_000)
+  await store.reconcileCells(CELLS)
+  probe.inventoryLocks.length = 0
+  probe.failActivityLockOnce = true
+  await drive(store)
+  await database.close()
+  return probe.inventoryLocks.map((options) =>
+    options?.failIfUnavailable ? 'nowait' : (options?.lockTimeoutMs ?? 'pool-default')
+  )
+}
+
+function collectWarnings(event: string) {
+  const entries: Record<string, unknown>[] = []
+  const original = console.warn
+  console.warn = (line: unknown, ...rest: unknown[]) => {
+    try {
+      const parsed = JSON.parse(line as string) as Record<string, unknown>
+      if (parsed.event === event) return void entries.push(parsed)
+    } catch {
+      // fall through to the real console for non-JSON lines
+    }
+    original(line, ...rest)
+  }
+  return { entries, restore: () => (console.warn = original) }
+}
+
+const ACTIVITY_LEASE_SQL = 'SELECT * FROM relay_assignment_activity_leases'
+
+class InventoryLockProbe implements RelayDatabase {
+  readonly inventoryLocks: (RelayLockOptions | undefined)[] = []
+  failNoWait = false
+  // Forces the next assign attempt down its inventory-first retry, the only lane
+  // that reaches the threaded lock mode.
+  failActivityLockOnce = false
+
+  constructor(private readonly delegate: RelayDatabase) {}
+
+  async query(sql: string, params?: unknown[]): Promise<SqlRow[]> {
+    return await this.delegate.query(sql, params)
+  }
+
+  async queryLocked(
+    sql: string,
+    params?: unknown[],
+    options?: RelayLockOptions
+  ): Promise<SqlRow[]> {
+    if (locksCellInventory(sql)) {
+      this.inventoryLocks.push(options)
+      if (this.failNoWait && options?.failIfUnavailable) {
+        throw new Error('database_lock_unavailable')
+      }
+    }
+    if (this.failActivityLockOnce && sql.trim().startsWith(ACTIVITY_LEASE_SQL) && options?.failIfUnavailable) {
+      this.failActivityLockOnce = false
+      throw new Error('database_lock_unavailable')
+    }
+    return await this.delegate.queryLocked(sql, params, options)
+  }
+
+  async transaction<T>(
+    operation: (transaction: RelayDatabase) => Promise<T>,
+    options?: RelayTransactionOptions
+  ): Promise<T> {
+    return await this.delegate.transaction(
+      async (transaction) => await operation(new InventoryLockProbeTransaction(transaction, this)),
+      options
+    )
+  }
+
+  async close(): Promise<void> {}
+}
+
+class InventoryLockProbeTransaction implements RelayDatabase {
+  constructor(
+    private readonly delegate: RelayDatabase,
+    private readonly probe: InventoryLockProbe
+  ) {}
+
+  async query(sql: string, params?: unknown[]): Promise<SqlRow[]> {
+    return await this.delegate.query(sql, params)
+  }
+
+  async queryLocked(
+    sql: string,
+    params?: unknown[],
+    options?: RelayLockOptions
+  ): Promise<SqlRow[]> {
+    if (locksCellInventory(sql)) {
+      this.probe.inventoryLocks.push(options)
+      if (this.probe.failNoWait && options?.failIfUnavailable) {
+        throw new Error('database_lock_unavailable')
+      }
+    }
+    if (
+      this.probe.failActivityLockOnce &&
+      sql.trim().startsWith(ACTIVITY_LEASE_SQL) &&
+      options?.failIfUnavailable
+    ) {
+      this.probe.failActivityLockOnce = false
+      throw new Error('database_lock_unavailable')
+    }
+    return await this.delegate.queryLocked(sql, params, options)
+  }
+
+  async transaction<T>(operation: (transaction: RelayDatabase) => Promise<T>): Promise<T> {
+    return await operation(this)
+  }
+
+  async close(): Promise<void> {}
+}

--- a/cloud/apps/relay/src/database.ts
+++ b/cloud/apps/relay/src/database.ts
@@ -1,4 +1,5 @@
 import { mkdirSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import pg from 'pg'
@@ -8,9 +9,37 @@ import {
   type PostgresPoolPressureCounts
 } from './postgres-pool-pressure.js'
 import { applyPostgresSchema } from './postgres-schema-startup.js'
+import {
+  CellInventoryHoldSamples,
+  emptyCellInventoryHoldCounts,
+  type CellInventoryHoldCounts
+} from './cell-inventory-hold-samples.js'
+
+export const POSTGRES_LOCK_TIMEOUT_MS = 1_000
+
+function setLocalLockTimeout(milliseconds: number): string {
+  if (!Number.isInteger(milliseconds) || milliseconds < 1) {
+    throw new Error('invalid_lock_timeout')
+  }
+  return `SET LOCAL lock_timeout = '${milliseconds}ms'`
+}
 
 export type SqlRow = Record<string, unknown>
-export type RelayLockOptions = { failIfUnavailable?: boolean }
+export type RelayLockOptions = {
+  failIfUnavailable?: boolean
+  // Only honoured inside a transaction: SET LOCAL is a no-op in autocommit.
+  lockTimeoutMs?: number
+  // Report how long this lock is held to COMMIT. The hold, not the wait, is what
+  // forms the queue, and nothing measured it before.
+  measureHoldMs?: boolean
+}
+
+// A transaction that can report how long it held a measured lock before COMMIT.
+type HoldMeasuringTransaction = { consumeHoldMs(): number | undefined }
+
+function measuredHoldMs(transaction: unknown): number | undefined {
+  return (transaction as HoldMeasuringTransaction).consumeHoldMs?.()
+}
 export type RelayTransactionOptions = { reportRetries?: boolean }
 
 export interface RelayDatabase {
@@ -612,8 +641,22 @@ function postgresTransactionErrorPhase(error: unknown): string {
 
 class SqliteTransaction implements RelayDatabase {
   readonly dialect = 'sqlite' as const
+  private heldFromMs: number | undefined
 
   constructor(protected readonly database: DatabaseSync) {}
+
+  consumeHoldMs(): number | undefined {
+    if (this.heldFromMs === undefined) return undefined
+    const holdMs = performance.now() - this.heldFromMs
+    this.heldFromMs = undefined
+    return holdMs
+  }
+
+  protected noteHeld(options: RelayLockOptions): void {
+    if (options.measureHoldMs && this.heldFromMs === undefined) {
+      this.heldFromMs = performance.now()
+    }
+  }
 
   async query(sql: string, params: unknown[] = []): Promise<SqlRow[]> {
     const statement = this.database.prepare(sql)
@@ -626,9 +669,11 @@ class SqliteTransaction implements RelayDatabase {
   async queryLocked(
     sql: string,
     params: unknown[] = [],
-    _options: RelayLockOptions = {}
+    options: RelayLockOptions = {}
   ): Promise<SqlRow[]> {
-    return await this.query(sql, params)
+    const rows = await this.query(sql, params)
+    this.noteHeld(options)
+    return rows
   }
 
   async transaction<T>(
@@ -643,6 +688,11 @@ class SqliteTransaction implements RelayDatabase {
 
 class SqliteDatabase extends SqliteTransaction {
   private tail: Promise<void> = Promise.resolve()
+  private readonly holds = new CellInventoryHoldSamples()
+
+  consumeHoldCounts(): CellInventoryHoldCounts {
+    return this.holds.consumeCounts()
+  }
 
   override async query(sql: string, params: unknown[] = []): Promise<SqlRow[]> {
     await this.tail
@@ -655,9 +705,11 @@ class SqliteDatabase extends SqliteTransaction {
     this.tail = new Promise((resolve) => (release = resolve))
     await previous
     this.database.exec('BEGIN IMMEDIATE')
+    const transaction = new SqliteTransaction(this.database)
     try {
-      const result = await operation(new SqliteTransaction(this.database))
+      const result = await operation(transaction)
       this.database.exec('COMMIT')
+      this.holds.record(measuredHoldMs(transaction) ?? Number.NaN)
       return result
     } catch (error) {
       this.database.exec('ROLLBACK')
@@ -675,8 +727,16 @@ class SqliteDatabase extends SqliteTransaction {
 
 class PostgresTransaction implements RelayDatabase {
   readonly dialect = 'postgres' as const
+  private heldFromMs: number | undefined
 
   constructor(protected readonly client: pg.PoolClient) {}
+
+  consumeHoldMs(): number | undefined {
+    if (this.heldFromMs === undefined) return undefined
+    const holdMs = performance.now() - this.heldFromMs
+    this.heldFromMs = undefined
+    return holdMs
+  }
 
   async query(sql: string, params: unknown[] = []): Promise<SqlRow[]> {
     try {
@@ -693,11 +753,21 @@ class PostgresTransaction implements RelayDatabase {
     params: unknown[] = [],
     options: RelayLockOptions = {}
   ): Promise<SqlRow[]> {
+    // SET LOCAL lasts to COMMIT, so a bound left in place would silently govern
+    // every later locked statement in the transaction and misattribute its 55P03s.
+    const bounded = options.lockTimeoutMs !== undefined && !options.failIfUnavailable
     try {
-      return await this.query(
+      // A blocked waiter holds its pooled client for the whole lock_timeout, so
+      // hot tiny-table locks bound their own wait well under the pool default.
+      if (bounded) await this.query(setLocalLockTimeout(options.lockTimeoutMs!))
+      const rows = await this.query(
         `${sql} FOR UPDATE${options.failIfUnavailable ? ' NOWAIT' : ''}`,
         params
       )
+      if (options.measureHoldMs && this.heldFromMs === undefined) {
+        this.heldFromMs = performance.now()
+      }
+      return rows
     } catch (error) {
       if (
         options.failIfUnavailable &&
@@ -706,6 +776,10 @@ class PostgresTransaction implements RelayDatabase {
         throw new Error('database_lock_unavailable')
       }
       throw error
+    } finally {
+      // Restore on the error path too: the transaction may still be retried or
+      // continue with unrelated locks after a caught lock failure.
+      if (bounded) await this.query(setLocalLockTimeout(POSTGRES_LOCK_TIMEOUT_MS)).catch(() => undefined)
     }
   }
 
@@ -723,7 +797,6 @@ const POSTGRES_TRANSACTION_ATTEMPTS = 3
 const POSTGRES_RETRY_MAX_DELAY_MS = 25
 const POSTGRES_CONNECTION_TIMEOUT_MS = 2_000
 const POSTGRES_STATEMENT_TIMEOUT_MS = 5_000
-const POSTGRES_LOCK_TIMEOUT_MS = 1_000
 const POSTGRES_IDLE_TRANSACTION_TIMEOUT_MS = 5_000
 
 function retryablePostgresTransactionError(error: unknown): boolean {
@@ -749,6 +822,11 @@ async function waitForPostgresRetry(random: () => number = Math.random): Promise
 class PostgresDatabase implements RelayDatabase {
   readonly dialect = 'postgres' as const
   private readonly pressure: PostgresPoolPressure
+  private readonly holds = new CellInventoryHoldSamples()
+
+  consumeHoldCounts(): CellInventoryHoldCounts {
+    return this.holds.consumeCounts()
+  }
 
   constructor(private readonly pool: pg.Pool) {
     this.pressure = new PostgresPoolPressure(pool)
@@ -770,6 +848,8 @@ class PostgresDatabase implements RelayDatabase {
     options: RelayLockOptions = {}
   ): Promise<SqlRow[]> {
     try {
+      // No transaction here, so options.lockTimeoutMs cannot apply: SET LOCAL
+      // would be discarded at the autocommit boundary before the lock is taken.
       return await this.query(
         `${sql} FOR UPDATE${options.failIfUnavailable ? ' NOWAIT' : ''}`,
         params
@@ -791,10 +871,12 @@ class PostgresDatabase implements RelayDatabase {
   ): Promise<T> {
     for (let attempt = 1; attempt <= POSTGRES_TRANSACTION_ATTEMPTS; attempt++) {
       const client = await this.pressure.connect()
+      const transaction = new PostgresTransaction(client)
       try {
         await client.query('BEGIN')
-        const result = await operation(new PostgresTransaction(client))
+        const result = await operation(transaction)
         await client.query('COMMIT')
+        this.holds.record(measuredHoldMs(transaction) ?? Number.NaN)
         return result
       } catch (error) {
         await client.query('ROLLBACK').catch(() => undefined)
@@ -850,6 +932,13 @@ export function consumeRelayDatabasePoolPressure(
   return database instanceof PostgresDatabase
     ? database.consumePoolPressure()
     : emptyPostgresPoolPressureCounts()
+}
+
+export function consumeRelayCellInventoryHold(
+  database: RelayDatabase
+): CellInventoryHoldCounts {
+  const holder = database as { consumeHoldCounts?: () => CellInventoryHoldCounts }
+  return holder.consumeHoldCounts?.() ?? emptyCellInventoryHoldCounts()
 }
 
 export function readRelayDatabasePoolPressure(

--- a/cloud/apps/relay/src/index.ts
+++ b/cloud/apps/relay/src/index.ts
@@ -10,12 +10,14 @@ import {
   roleOwnsAssignmentMaintenance
 } from './cell-admission-startup.js'
 import {
+  consumeRelayCellInventoryHold,
   consumeRelayDatabasePoolPressure,
   openRelayDatabase,
   readRelayDatabasePoolPressure
 } from './database.js'
 import { runAssignmentCleanup } from './assignment-cleanup-steps.js'
 import { runRelayBackgroundOperation } from './relay-background-operation.js'
+import { jitteredSweepIntervalMs } from './relay-sweep-schedule.js'
 import { observedRelayRequests } from './relay-observability.js'
 import { startRegionalRehomeWorker } from './regional-rehome-worker.js'
 import { createRelayServer } from './relay-server.js'
@@ -54,7 +56,7 @@ const cleanupTimer = setInterval(
 const assignmentCleanupTimer = roleOwnsAssignmentMaintenance(config.role)
   ? setInterval(() => {
       void runAssignmentCleanup(assignments)
-    }, 30_000)
+    }, jitteredSweepIntervalMs(30_000))
   : null
 const inventorySnapshotTimer = roleOwnsAssignmentMaintenance(config.role)
   ? setInterval(() => {
@@ -78,7 +80,8 @@ inventorySnapshotTimer?.unref()
 migrationInventoryTimer?.unref()
 observability.start(() => ({
   ...runtimeCounts(),
-  ...consumeRelayDatabasePoolPressure(database)
+  ...consumeRelayDatabasePoolPressure(database),
+  ...consumeRelayCellInventoryHold(database)
 }))
 const regionalRehomeWorker = startRegionalRehomeWorker(config, assignments, {
   safetySnapshot: () => ({

--- a/cloud/apps/relay/src/regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-store.test.ts
@@ -5,7 +5,12 @@ import {
   REGIONAL_REHOME_QUARANTINE_MS,
   REGIONAL_REHOME_REDRAIN_SEND_LIMIT
 } from './assignment-store.js'
-import { openInMemoryRelayDatabase, type RelayDatabase, type SqlRow } from './database.js'
+import {
+  openInMemoryRelayDatabase,
+  type RelayDatabase,
+  type RelayLockOptions,
+  type SqlRow
+} from './database.js'
 import {
   REGIONAL_REHOME_SQL_FAILURES_LIMIT,
   REGIONAL_REHOME_SQL_FAILURES_PER_CELL_LIMIT
@@ -553,6 +558,290 @@ describe('regional rehome assignment state', () => {
         [identity.userId, identity.relayHostId]
       )
     ).toEqual([{ cell_id: target.id, assignment_epoch: 2 }])
+    await context.database.close()
+  })
+
+  it('skips a rehome dispatch tick on a contended cell inventory', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    await activatePreferredSource(context, identity)
+    probe.reset()
+    probe.failNoWait = true
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    let attempt: unknown
+    try {
+      attempt = await context.store.claimRegionalRehome()
+    } finally {
+      busy.restore()
+    }
+
+    expect(attempt).toBeNull()
+    expect(probe.locks).not.toEqual([])
+    expect(probe.locks.every((options) => options?.failIfUnavailable === true)).toBe(true)
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'claim-regional-rehome',
+        skipped: 1
+      }
+    ])
+
+    probe.failNoWait = false
+    expect(await context.store.claimRegionalRehome()).toMatchObject({
+      sourceCellId: source.id,
+      targetCellId: target.id
+    })
+    await context.database.close()
+  })
+
+  // Why: the redrain lane reaches the inventory through the fleet-safety read
+  // rather than through candidate selection, so it needs its own coverage.
+  // Why: one contended candidate must cost its own tick, not the whole page. The
+  // sweeps are explicitly per-candidate isolated for exactly this reason.
+  it('completes the candidates behind a contended one', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    const identities = [
+      { userId: 'user-1', relayHostId: 'abcdefghijklmnop' },
+      { userId: 'user-2', relayHostId: 'ponmlkjihgfedcba' }
+    ]
+    for (const identity of identities) {
+      // Dispatch is rate limited, so each claim needs its own interval.
+      context.advance(60_000)
+      await freshHeartbeats(context)
+      const sourceControl = await activatePreferredSource(context, identity)
+      const attempt = await context.store.claimRegionalRehome()
+      await context.store.recordRegionalRehomeDrainReceipt(attempt!.attemptId, 'accepted')
+      await context.store.activateControl(identity, {
+        cellId: target.id,
+        assignmentEpoch: 2,
+        generation: 1
+      })
+      await context.store.markMigrationTargetRegistered(identity, {
+        cellId: target.id,
+        assignmentEpoch: 2
+      })
+      await context.store.releaseActivity(identity, sourceControl)
+    }
+    probe.reset()
+    probe.failNoWaitOnce = true
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    let completed: number
+    try {
+      completed = await context.store.completeReadyRegionalRehomes()
+    } finally {
+      busy.restore()
+    }
+
+    expect(completed).toBe(1)
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'complete-ready-regional-rehomes',
+        skipped: 1
+      }
+    ])
+    await context.database.close()
+  })
+
+  // Why: only inventory contention is ordinary. Every other failure must keep its
+  // existing propagation and its dispatch-failure accounting.
+  it('propagates a claim failure that is not inventory contention', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    await activatePreferredSource(context, { userId: 'user-1', relayHostId: 'abcdefghijklmnop' })
+    probe.reset()
+    probe.failWith = new Error('relay_capacity_exhausted')
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    try {
+      await expect(context.store.claimRegionalRehome()).rejects.toThrow(
+        'relay_capacity_exhausted'
+      )
+    } finally {
+      busy.restore()
+    }
+
+    expect(busy.entries).toEqual([])
+    await context.database.close()
+  })
+
+  // Why: the transaction dies at the first contended candidate, so every
+  // candidate behind it is abandoned too. Reporting one would understate the tick.
+  it('reports every candidate the contended tick abandoned', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    await activatePreferredSource(context, { userId: 'user-1', relayHostId: 'abcdefghijklmnop' })
+    await activatePreferredSource(context, { userId: 'user-2', relayHostId: 'ponmlkjihgfedcba' })
+    await activatePreferredSource(context, { userId: 'user-3', relayHostId: 'aaaabbbbccccdddd' })
+    probe.reset()
+    probe.failNoWait = true
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    try {
+      expect(await context.store.claimRegionalRehome()).toBeNull()
+    } finally {
+      busy.restore()
+    }
+
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'claim-regional-rehome',
+        skipped: 3
+      }
+    ])
+    await context.database.close()
+  })
+
+  it('skips a redrain tick on a contended cell inventory', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    await activatePreferredSource(context, identity)
+    const attempt = await context.store.claimRegionalRehome()
+    await context.store.recordRegionalRehomeDrainReceipt(attempt!.attemptId, 'accepted')
+    await context.store.activateControl(identity, {
+      cellId: target.id,
+      assignmentEpoch: 2,
+      generation: 1
+    })
+    await context.store.markMigrationTargetRegistered(identity, {
+      cellId: target.id,
+      assignmentEpoch: 2
+    })
+    context.advance(60 * 60_000 + 1)
+    await freshHeartbeats(context)
+    probe.reset()
+    probe.failNoWait = true
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    let redrain: unknown
+    try {
+      redrain = await context.store.claimRegionalRehome()
+    } finally {
+      busy.restore()
+    }
+
+    expect(redrain).toBeNull()
+    expect(probe.locks).not.toEqual([])
+    expect(probe.locks.every((options) => options?.failIfUnavailable === true)).toBe(true)
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'claim-regional-rehome',
+        skipped: 1
+      }
+    ])
+
+    probe.failNoWait = false
+    expect(await context.store.claimRegionalRehome()).toMatchObject({
+      attemptId: attempt!.attemptId,
+      sendAttempts: 2
+    })
+    await context.database.close()
+  })
+
+  it('skips a completion tick on a contended cell inventory without quarantining it', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    const sourceControl = await activatePreferredSource(context, identity)
+    const attempt = await context.store.claimRegionalRehome()
+    await context.store.recordRegionalRehomeDrainReceipt(attempt!.attemptId, 'accepted')
+    await context.store.activateControl(identity, {
+      cellId: target.id,
+      assignmentEpoch: 2,
+      generation: 1
+    })
+    await context.store.markMigrationTargetRegistered(identity, {
+      cellId: target.id,
+      assignmentEpoch: 2
+    })
+    await context.store.releaseActivity(identity, sourceControl)
+    probe.reset()
+    probe.failNoWait = true
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+    const failures = collectCandidateFailureWarnings()
+
+    let completed: number
+    try {
+      completed = await context.store.completeReadyRegionalRehomes()
+    } finally {
+      failures.restore()
+      busy.restore()
+    }
+
+    expect(completed).toBe(0)
+    expect(probe.locks).not.toEqual([])
+    expect(probe.locks.every((options) => options?.failIfUnavailable === true)).toBe(true)
+    expect(failures.entries).toEqual([])
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'complete-ready-regional-rehomes',
+        skipped: 1
+      }
+    ])
+
+    probe.failNoWait = false
+    expect(await context.store.completeReadyRegionalRehomes()).toBe(1)
+    await context.database.close()
+  })
+
+  // Why: a contended inventory is another director settling the same row, not a
+  // poisoned candidate. Quarantining on it would exclude a healthy attempt from
+  // the sweep's LIMIT pages for 15 minutes.
+  it('skips an abort tick on a contended cell inventory without quarantining it', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    const sourceControl = await activatePreferredSource(context, identity)
+    const attempt = await context.store.claimRegionalRehome()
+    await context.store.recordRegionalRehomeDrainReceipt(attempt!.attemptId, 'accepted')
+    const targetControl = await context.store.activateControl(identity, {
+      cellId: target.id,
+      assignmentEpoch: 2,
+      generation: 1
+    })
+    await context.store.markMigrationTargetRegistered(identity, {
+      cellId: target.id,
+      assignmentEpoch: 2
+    })
+    await context.store.releaseActivity(identity, sourceControl)
+    await context.store.releaseActivity(identity, targetControl)
+    context.advance(24 * 60 * 60_000)
+    await heartbeat(context.store, source, sourceIncarnation, 1, 2)
+    probe.reset()
+    probe.failNoWait = true
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+    const failures = collectCandidateFailureWarnings()
+
+    let aborted: number
+    try {
+      aborted = await context.store.abortExpiredRegionalRehomes()
+    } finally {
+      failures.restore()
+      busy.restore()
+    }
+
+    expect(aborted).toBe(0)
+    expect(probe.locks).not.toEqual([])
+    expect(probe.locks.every((options) => options?.failIfUnavailable === true)).toBe(true)
+    expect(failures.entries).toEqual([])
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'abort-expired-regional-rehomes',
+        skipped: 1
+      }
+    ])
+
+    probe.failNoWait = false
+    expect(await context.store.abortExpiredRegionalRehomes()).toBe(1)
     await context.database.close()
   })
 
@@ -1208,10 +1497,12 @@ function collectDisableWarnings() {
   }
 }
 
-async function setup(options: { sourceProtocol?: number } = {}) {
+async function setup(
+  options: { sourceProtocol?: number; wrap?: (database: RelayDatabase) => RelayDatabase } = {}
+) {
   let clock = 1_000_000
   const database = await openInMemoryRelayDatabase()
-  const store = new RelayAssignmentStore(database, () => clock, {
+  const store = new RelayAssignmentStore(options.wrap?.(database) ?? database, () => clock, {
     requireLiveCells: true,
     heartbeatTtlMs: 45_000
   })
@@ -1396,4 +1687,44 @@ async function heartbeat(
       databasePoolWaitMsMax: 0
     }
   })
+}
+
+class CellInventoryLockProbe {
+  readonly locks: (RelayLockOptions | undefined)[] = []
+  failNoWait = false
+  // Contends one candidate only, so the sweep must carry on to the next.
+  failNoWaitOnce = false
+  failWith: Error | null = null
+
+  reset(): void {
+    this.locks.length = 0
+  }
+
+  wrap(database: RelayDatabase): RelayDatabase {
+    const probe = this
+    const decorate = (delegate: RelayDatabase): RelayDatabase => ({
+      query: async (sql, params) => await delegate.query(sql, params),
+      queryLocked: async (sql, params, options) => {
+        if (sql.trim() === 'SELECT * FROM relay_cells ORDER BY cell_id ASC') {
+          probe.locks.push(options)
+          if (probe.failWith) throw probe.failWith
+          if (options?.failIfUnavailable && probe.failNoWaitOnce) {
+            probe.failNoWaitOnce = false
+            throw new Error('database_lock_unavailable')
+          }
+          if (probe.failNoWait && options?.failIfUnavailable) {
+            throw new Error('database_lock_unavailable')
+          }
+        }
+        return await delegate.queryLocked(sql, params, options)
+      },
+      transaction: async (operation, options) =>
+        await delegate.transaction(
+          async (transaction) => await operation(decorate(transaction)),
+          options
+        ),
+      close: async () => undefined
+    })
+    return decorate(database)
+  }
 }

--- a/cloud/apps/relay/src/regional-rehome-worker.ts
+++ b/cloud/apps/relay/src/regional-rehome-worker.ts
@@ -3,6 +3,7 @@ import type { RelayAssignmentStore } from './assignment-store.js'
 import type { RelayConfig } from './config.js'
 import { googleMetadataIdentityToken } from './google-metadata-identity-token.js'
 import type { RegionalRehomeSafetySnapshot } from './relay-observability.js'
+import { jitteredSweepIntervalMs } from './relay-sweep-schedule.js'
 
 type RegionalRehomeWorkerOptions = {
   fetch?: typeof fetch
@@ -10,6 +11,7 @@ type RegionalRehomeWorkerOptions = {
   now?: () => number
   intervalMs?: number
   requestTimeoutMs?: number
+  random?: () => number
   safetySnapshot?: () => RegionalRehomeSafetySnapshot
 }
 
@@ -109,7 +111,10 @@ export function startRegionalRehomeWorker(
       inFlight = false
     }
   }
-  const timer = setInterval(() => void run(), options.intervalMs ?? 1_000)
+  const timer = setInterval(
+    () => void run(),
+    options.intervalMs ?? jitteredSweepIntervalMs(1_000, options.random)
+  )
   timer.unref()
   void run()
   return {

--- a/cloud/apps/relay/src/relay-observability.ts
+++ b/cloud/apps/relay/src/relay-observability.ts
@@ -1,6 +1,7 @@
 import { monitorEventLoopDelay, performance } from 'node:perf_hooks'
 import type { RelayRegion } from '@orca-cloud/relay-contract'
 import type { ControlRenewalOutcome } from './assignment-store.js'
+import type { CellInventoryHoldCounts } from './cell-inventory-hold-samples.js'
 import type { PostgresPoolPressureCounts } from './postgres-pool-pressure.js'
 import type { RelayReadinessObservation } from './relay-readiness.js'
 
@@ -20,7 +21,9 @@ export function observedRelayRequests(counts: RelayRuntimeCounts): number {
   return counts.preAuthConnections + counts.controls + counts.splices + counts.pendingSplices
 }
 
-export type RelayProcessCounts = RelayRuntimeCounts & PostgresPoolPressureCounts
+export type RelayProcessCounts = RelayRuntimeCounts &
+  PostgresPoolPressureCounts &
+  Partial<CellInventoryHoldCounts>
 
 export type RegionalRehomeRuntimeSafety = {
   observedAt: number

--- a/cloud/apps/relay/src/relay-sweep-schedule.test.ts
+++ b/cloud/apps/relay/src/relay-sweep-schedule.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import { startRegionalRehomeWorker } from './regional-rehome-worker.js'
+import { jitteredSweepIntervalMs, SWEEP_JITTER_FRACTION } from './relay-sweep-schedule.js'
+
+describe('sweep schedule jitter', () => {
+  it('spreads instances across a bounded window above the base period', () => {
+    expect(jitteredSweepIntervalMs(30_000, () => 0)).toBe(30_000)
+    expect(jitteredSweepIntervalMs(30_000, () => 0.5)).toBe(33_000)
+    // Math.random() never returns 1, so the open bound is the real ceiling.
+    expect(jitteredSweepIntervalMs(30_000, () => 0.999)).toBeLessThan(36_000)
+  })
+
+  // Why: a shorter period would raise the very lock traffic the offset spreads.
+  it('never schedules a sweep sooner than its base period', () => {
+    for (const random of [0, 0.25, 0.5, 0.75, 0.999]) {
+      expect(jitteredSweepIntervalMs(1_000, () => random)).toBeGreaterThanOrEqual(1_000)
+    }
+    expect(SWEEP_JITTER_FRACTION).toBeGreaterThan(0)
+  })
+
+  it('jitters the regional rehome dispatch tick, which every director runs each second', () => {
+    const timers: number[] = []
+    const setIntervalSpy = vi
+      .spyOn(globalThis, 'setInterval')
+      .mockImplementation(((_handler: unknown, delayMs?: number) => {
+        timers.push(delayMs ?? 0)
+        return { unref: () => undefined, [Symbol.dispose]: () => undefined } as never
+      }) as never)
+
+    try {
+      startRegionalRehomeWorker(
+        {
+          role: 'director',
+          rehomeAudience: 'https://rehome.example.test',
+          rehomeDirectorServiceAccount: 'rehome@example.test'
+        } as never,
+        { claimRegionalRehome: async () => null } as never,
+        { random: () => 0.5, safetySnapshot: () => ({}) as never }
+      )
+    } finally {
+      setIntervalSpy.mockRestore()
+    }
+
+    expect(timers).toEqual([1_100])
+  })
+
+  // Why: index.ts boots a server on import, so its wiring can only be read.
+  it('jitters the director assignment cleanup tick', () => {
+    const source = readFileSync(new URL('./index.ts', import.meta.url), 'utf8')
+    const cleanup = /runAssignmentCleanup\(assignments\)\s*\},\s*([^\n]*?)\)\n/.exec(source)
+
+    expect(cleanup?.[1]).toBe('jitteredSweepIntervalMs(30_000)')
+  })
+})

--- a/cloud/apps/relay/src/relay-sweep-schedule.ts
+++ b/cloud/apps/relay/src/relay-sweep-schedule.ts
@@ -1,0 +1,13 @@
+// Why: every director instance boots from the same rollout, so its periodic
+// sweeps land on the same wall-clock second across instances and pile onto the
+// one global cell-inventory lock together. A per-process offset spreads the
+// arrivals; the sweeps are idempotent, so a slightly longer period is free.
+export const SWEEP_JITTER_FRACTION = 0.2
+
+export function jitteredSweepIntervalMs(
+  baseMs: number,
+  random: () => number = Math.random
+): number {
+  // Only ever longer: a shorter period would raise the very load being spread.
+  return baseMs + Math.floor(random() * baseMs * SWEEP_JITTER_FRACTION)
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1107 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1104 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​332 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​273 |

<!-- /orca-pr-loc -->

Mirrors stablyai/orca-cloud#471 (byte-identical under `cloud/`; verified per file against private main). Private PR body follows.

## The contention

`lockCellInventory` runs `SELECT * FROM relay_cells ORDER BY cell_id ASC FOR UPDATE`:
one global lock over a 23-row table, taken from 31 call sites including the
assignment hot path and the director sweeps. Five director instances plus 23
cells serialise on it against a single Cloud SQL primary.

The pool sets `lock_timeout = 1000ms`, so a blocked waiter also holds a pooled
client for a full second. Lock contention becomes pool exhaustion.

| Signal (production, 5-minute windows) | Observed |
| --- | --- |
| `orca_relay_postgres_transaction_retry` | ~690 |
| `orca_relay_postgres_transaction_exhausted` | ~12 |
| Director exhaustions in the `cell-inventory` phase | 540 of 541 |
| Deadlocks | 0 |
| Pool waiters, peak | 100 |
| Pool wait, peak | 2s |
| Cloud SQL CPU, peak | 77% |

Zero deadlocks with all exhaustion in one phase is the signature of a queue, not
a cycle.

## Bounded wait, scoped to one statement

`RelayLockOptions` gains `lockTimeoutMs`. The Postgres transaction path issues
`SET LOCAL lock_timeout` immediately before the locked select and restores
`POSTGRES_LOCK_TIMEOUT_MS` in a `finally`, on the error path too.

The restore is load-bearing. `SET LOCAL` lasts to COMMIT, so without it the bound
would govern every later locked statement in the transaction and misattribute
their `55P03`s. `rebalanceDormant`, `assignOnce`, `assignStickyOnce` and
`activateControl` all take further locks after the inventory.

The bound is `CELL_INVENTORY_LOCK_TIMEOUT_MS = 500`. Worst-case request queueing
becomes about 1.5s across the wrapper's three attempts, down from about 3s. An
invalid bound throws rather than reaching SQL. `SET LOCAL` is skipped for NOWAIT,
skipped in autocommit where it cannot survive, and absent on SQLite.

## Three-way classification, enforced by a census

The same lock is taken by live requests and by background sweeps, and the right
failure differs. `failIfUnavailable` is replaced by an explicit mode, so each of
the 31 sites states its intent:

| Mode | Sites | Behaviour |
| --- | --- | --- |
| `request` | 11 | bounded wait at 500ms |
| `nowait` | 14 | never queue; the caller skips and re-derives next tick |
| `pool-default` | 3 | unbounded wait at the pool `lock_timeout` |
| threaded from the caller | 3 | `assign`, per entry point |

`pool-default` exists because a sweep that fails sooner turns ordinary contention
into a terminal transaction failure, and one of those freezes the incident gate.
`evacuateDeadCells` re-enters placement, so `assign` threads the caller's mode:
clients keep the bound, that sweep does not.

`cell-inventory-lock-census.test.ts` scrapes every call site from source, derives
sweep reachability by walking the call graph from the ten cleanup steps plus
`claimRegionalRehome` and `recordRegionalRehomeDispatchFailure`, and fails if a
site is new, reclassified, unclassified, or sweep-reachable on the bounded wait.

## Sweeps yield instead of queueing

Six sweep sites take the inventory NOWAIT: regional rehome claim, fleet safety,
candidate start, completion, expiry abort, and expired-evacuation abort. Each
skips quietly and logs at most one `orca_relay_sweep_cell_inventory_busy` summary
per tick, reporting how many candidates the tick abandoned. Contention is never a
sweep failure and never quarantines a rehome attempt. A NOWAIT skip raises
`database_lock_unavailable`, which is not a retryable `55P03`, so sweeps also stop
spending the transaction retry budget.

Director sweep periods are now jittered per process. Instances boot from one
rollout, so their 30s cleanup and 1s rehome ticks land on the same wall-clock
second. The offset only ever lengthens a period.

## Hold-time measurement

500ms is a first value, not a measurement, and nothing measured the hold before.
The lock is held to COMMIT and the assignment path runs many statements after
taking it. Both dialects now time each inventory lock from acquisition to COMMIT
and report `cellInventoryHoldMsMax`, `cellInventoryHoldMsP95` and
`cellInventoryHolds` as additive runtime-metrics fields, so the bound can be tuned
after the first director deploy.

## Monitor

`relayPostgresRetries: 300` is unchanged; it is correctly detecting this
regression. `relayPostgresRetryExhausted` stays at 0, with a comment naming
exactly which callers can still reach the retry wrapper. Splitting the counter by
the phase label PR #423 put on the log payload would need a labelled log-based
metric, which this signal does not carry, and that is a terraform change this PR
is out of scope for.

## Rollout

This ships inside the relay image, so it needs a **director blue/green and a cell
roll** to take full effect. The pieces are safe partially deployed: the bound is
per-transaction, and the NOWAIT sweeps only ever do less work than before.

## Verification

- `pnpm --filter @orca-cloud/relay test` — 462 passed, 80 skipped
- `pnpm --filter @orca-cloud/relay-ops test` — 76 passed
- `typecheck`, which is also this repo's lint, clean for both packages
- Postgres 17, `--no-file-parallelism`: these suites are flaky on `origin/main`
  itself, so both sides were measured. Warmed, three consecutive full runs each:
  `origin/main` 10, 8, 10 failures of 510; this branch 10, 8, 8 of 540. Same
  failure count on 30 more tests, same clusters, differing sets run to run.
- Mutation: 39 mutants across four passes, 38 killed. The survivor inserts a clear
  of the pending rehome disable log above its rethrow, observable only through a
  later tick reading private state.

