### PR TITLE
fix(settings): target the right checkout for same-host repo clones

### DIFF
--- a/src/renderer/src/components/settings/settings-project-list.test.ts
+++ b/src/renderer/src/components/settings/settings-project-list.test.ts
@@ -153,11 +153,43 @@ describe('deep-link resolution', () => {
     expect(map.get('local-1')).toBe('local-1')
   })
 
-  it('maps a repoId to its owning project + host for selection', () => {
+  it('maps a repoId to its owning project + host + setup for selection', () => {
     const map = buildRepoIdToHostSelection(projects)
     expect(map.get('remote-9')).toEqual({
       projectId: projects[0].projectId,
-      hostId: 'runtime:home-mac'
+      hostId: 'runtime:home-mac',
+      setupId: 'remote-9'
+    })
+  })
+
+  it('splits same-host clones of one project into a settings entry per checkout (#18493)', () => {
+    // Two local clones of the same remote: one merged project, two distinct `local` checkouts.
+    const cloneRepos: Repo[] = [
+      makeRepo({ id: 'ios', gitRemoteIdentity: gitRemote, path: '/repos/ios' }),
+      makeRepo({ id: 'ios2', gitRemoteIdentity: gitRemote, path: '/repos/ios2' })
+    ]
+    const cloneProjects = buildSettingsProjectList(cloneRepos)
+    // One settings entry per checkout, mirroring the sidebar's per-checkout rows.
+    expect(cloneProjects).toHaveLength(2)
+    const byRepo = new Map(cloneProjects.map((entry) => [entry.representativeRepoId, entry]))
+    expect([...byRepo.keys()].sort()).toEqual(['ios', 'ios2'])
+    // Each entry renders/edits its own checkout even with no explicit selection.
+    expect(getSettingsProjectHostRepo(byRepo.get('ios')!, cloneRepos, undefined)?.path).toBe(
+      '/repos/ios'
+    )
+    expect(getSettingsProjectHostRepo(byRepo.get('ios2')!, cloneRepos, undefined)?.path).toBe(
+      '/repos/ios2'
+    )
+    // Deep-link maps resolve each clone to its own section, not a shared representative.
+    const rep = buildRepoIdToRepresentative(cloneProjects)
+    expect(rep.get('ios')).toBe('ios')
+    expect(rep.get('ios2')).toBe('ios2')
+    // Each checkout still carries its own setupId for precise deep-link selection.
+    const hostSelection = buildRepoIdToHostSelection(cloneProjects)
+    expect(hostSelection.get('ios2')).toEqual({
+      projectId: byRepo.get('ios2')!.projectId,
+      hostId: 'local',
+      setupId: 'ios2'
     })
   })
 
@@ -234,7 +266,7 @@ describe('deep-link resolution', () => {
     ).toBe('/remote/repo')
   })
 
-  it('selects a same-transport setup by setup id', () => {
+  it('splits distinct checkouts sharing one runtime host into an entry per checkout', () => {
     const directRepo = makeRepo({
       id: 'direct-repo',
       gitRemoteIdentity: gitRemote,
@@ -248,16 +280,23 @@ describe('deep-link resolution', () => {
       path: '/jump/repo'
     })
     const sameHubProjects = buildSettingsProjectList([directRepo, jumpRepo])
-    const jumpSetup = sameHubProjects[0].setups.find((setup) => setup.repoId === 'jump-repo')
+    expect(sameHubProjects).toHaveLength(2)
+    const byRepo = new Map(sameHubProjects.map((entry) => [entry.representativeRepoId, entry]))
 
     expect(
       getSettingsProjectHostRepo(
-        sameHubProjects[0],
+        byRepo.get('jump-repo')!,
         [directRepo, jumpRepo],
-        'runtime:home-mac',
-        jumpSetup?.id
+        'runtime:home-mac'
       )?.path
     ).toBe('/jump/repo')
+    expect(
+      getSettingsProjectHostRepo(
+        byRepo.get('direct-repo')!,
+        [directRepo, jumpRepo],
+        'runtime:home-mac'
+      )?.path
+    ).toBe('/direct/repo')
   })
 })
 

--- a/src/renderer/src/components/settings/settings-project-list.ts
+++ b/src/renderer/src/components/settings/settings-project-list.ts
@@ -6,6 +6,10 @@ import {
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../../../shared/project-host-setup-projection'
+import {
+  buildProjectGroupingIndex,
+  getProjectGroupingForRepo
+} from '../sidebar/worktree-list/grouping/project-grouping'
 
 export type SettingsProject = {
   projectId: string
@@ -40,25 +44,42 @@ export function getSettingsProjectRepresentativeRepoId(
 }
 
 /**
- * Collapses repo rows into one entry per project so Settings renders per
- * project, matching the rest of the app. Derived from repos alone (not the
- * persisted projects/setups) so the nav and pane lists agree exactly.
+ * One Settings entry per checkout group: a project on multiple hosts collapses to
+ * one entry, but a project with 2+ distinct checkouts sharing a host splits into one
+ * entry per checkout — mirroring the sidebar's per-checkout rows so both stay in sync
+ * and each clone gets its own nav row + editable pane (#18493). Grouping reuses the
+ * sidebar's `getProjectGroupingForRepo`; `projectId` stays the merged project id (split
+ * siblings self-scope via their singleton `setups`, so shared selection state is benign).
+ * Derived from repos alone so the nav and pane lists agree exactly.
  */
 export function buildSettingsProjectList(repos: readonly Repo[]): SettingsProject[] {
   const projection = projectHostSetupProjectionFromRepos(repos)
-  const setupsByProjectId = new Map<string, ProjectHostSetup[]>()
+  const repoMap = new Map(repos.map((repo) => [repo.id, repo]))
+  const projectById = new Map(projection.projects.map((project) => [project.id, project]))
+  const groupingIndex = buildProjectGroupingIndex({
+    projects: projection.projects,
+    projectHostSetups: projection.setups
+  })
+  const groups = new Map<string, { project: Project; setups: ProjectHostSetup[] }>()
+  const order: string[] = []
   for (const setup of projection.setups) {
-    const projectSetups = setupsByProjectId.get(setup.projectId)
-    if (projectSetups) {
-      projectSetups.push(setup)
+    const project = projectById.get(setup.projectId)
+    if (!project) {
+      continue
+    }
+    // Same grouping decision the sidebar makes, so a checkout that gets its own
+    // sidebar row also gets its own Settings entry (and vice versa).
+    const groupKey = getProjectGroupingForRepo(setup.repoId, repoMap, groupingIndex).key
+    const existing = groups.get(groupKey)
+    if (existing) {
+      existing.setups.push(setup)
     } else {
-      setupsByProjectId.set(setup.projectId, [setup])
+      groups.set(groupKey, { project, setups: [setup] })
+      order.push(groupKey)
     }
   }
-  return projection.projects.map((project) => {
-    // Why: Settings metadata is rebuilt as repos refresh across hosts; index
-    // setups once so many projects do not turn each refresh into an O(n²) scan.
-    const setups = setupsByProjectId.get(project.id) ?? []
+  return order.map((groupKey) => {
+    const { project, setups } = groups.get(groupKey)!
     return {
       projectId: project.id,
       project,
@@ -108,16 +129,21 @@ export function buildRepoIdToRepresentative(
   return map
 }
 
-/** Maps each host's repoId to its owning project + host, so a deep link can
- *  select that host in the pane's "Available Hosts" switcher. */
+/** Maps each host's repoId to its owning project + host + setup, so a deep link
+ *  selects that exact checkout — critical when 2+ checkouts share one host, where
+ *  hostId alone would collapse to the first setup and target the wrong repo (#18493). */
 export function buildRepoIdToHostSelection(
   projects: readonly SettingsProject[]
-): Map<string, { projectId: string; hostId: ExecutionHostId }> {
-  const map = new Map<string, { projectId: string; hostId: ExecutionHostId }>()
+): Map<string, { projectId: string; hostId: ExecutionHostId; setupId: string }> {
+  const map = new Map<string, { projectId: string; hostId: ExecutionHostId; setupId: string }>()
   for (const settingsProject of projects) {
     for (const setup of settingsProject.setups) {
       if (setup.repoId.trim().length > 0 && !map.has(setup.repoId)) {
-        map.set(setup.repoId, { projectId: settingsProject.projectId, hostId: setup.hostId })
+        map.set(setup.repoId, {
+          projectId: settingsProject.projectId,
+          hostId: setup.hostId,
+          setupId: setup.id
+        })
       }
     }
   }

--- a/src/renderer/src/components/settings/settings-project-section-renderer.tsx
+++ b/src/renderer/src/components/settings/settings-project-section-renderer.tsx
@@ -31,7 +31,9 @@ export function renderProjectSettingsSections(context: SettingsRenderContext): R
         title={translate(
           'auto.components.settings.Settings.3bf149e873',
           'Project Settings > {{value0}}',
-          { value0: project.displayName }
+          // Why: follow the selected checkout's name (repo), not the merged project's, so the
+          // title matches the pane's Display Name/path when 2+ checkouts share one project (#18493).
+          { value0: repo.displayName }
         )}
         description={repo.path}
         searchEntries={navigation.getSectionSearchEntries(repoSectionId)}

--- a/src/renderer/src/hooks/settings-navigation-remote-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-remote-sections.ts
@@ -167,7 +167,10 @@ export function buildRemoteSettingsSections(
           : (setups[0]?.path ?? representativeRepo.path)
       return {
         id: `repo-${representativeRepoId}`,
-        title: project.displayName,
+        // Why: name the checkout (representative repo), not the merged project, so split
+        // same-host clones get distinct nav labels ("ios" vs "ios2") instead of both reading
+        // the merged project's name (#18493).
+        title: representativeRepo.displayName,
         description: `${getRepoKindLabel(project)} • ${hostSummary}`,
         icon: SlidersHorizontal,
         searchEntries: getRepositoryPaneSearchEntries(representativeRepo, {

--- a/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
+++ b/src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts
@@ -401,6 +401,42 @@ describe('settings navigation metadata', () => {
     expect(repoSections[0].id).toBe('repo-local-1')
   })
 
+  it('renders a distinctly-titled nav section per checkout for same-host clones (#18493)', () => {
+    const gitRemote = {
+      canonicalKey: 'gitlab.com/acme/app',
+      remoteName: 'origin',
+      remoteUrl: 'git@gitlab.com:acme/app.git'
+    }
+    const sections = buildSettingsNavigationMetadata({
+      isMac: false,
+      isWindows: false,
+      isWebClient: false,
+      repos: [
+        {
+          id: 'ios',
+          path: '/Users/dev/ios',
+          displayName: 'ios',
+          badgeColor: '#000',
+          addedAt: 0,
+          gitRemoteIdentity: gitRemote
+        },
+        {
+          id: 'ios2',
+          path: '/Users/dev/ios2',
+          displayName: 'ios2',
+          badgeColor: '#000',
+          addedAt: 0,
+          gitRemoteIdentity: gitRemote
+        }
+      ]
+    })
+
+    const repoSections = sections.filter((section) => section.id.startsWith('repo-'))
+    expect(repoSections.map((section) => section.id)).toEqual(['repo-ios', 'repo-ios2'])
+    // Each row names its own checkout, not the shared merged-project name.
+    expect(repoSections.map((section) => section.title)).toEqual(['ios', 'ios2'])
+  })
+
   it('keeps macOS permissions mac-only', () => {
     expect(ids({ isMac: false })).not.toContain('developer-permissions')
     expect(ids({ isMac: true })).toContain('developer-permissions')


### PR DESCRIPTION
## ELI5

<!-- Simple high-level explanation -->

If you clone the same repo into two folders (ios and ios2), Orca treats them as one project because they share a Git remote. Opening "Project Settings" from either sidebar row always opened the first clone's settings — and edits saved there, silently overwriting it. This makes each clone reachable and editable on its own.

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

- Deep-link targeting: `buildRepoIdToHostSelection `now carries each checkout's setupId, so opening Project Settings from a sidebar row selects that checkout instead of falling back to the first setup on the host.
- Per-checkout settings entries: `buildSettingsProjectList` now splits distinct same-host checkouts into one entry per checkout, reusing the sidebar's existing grouping helper so the settings list and the sidebar stay in sync. Genuine multi-host projects still collapse to a single entry.
- Titles: the pane header and nav row now name the selected checkout's repo instead of the merged project, so the two clones read ios / ios2 rather than both showing ios.

projectId stays the merged project id — split siblings self-scope via their singleton setups, so the (renderer-only, non-persisted) selection state stays correct and the host switcher is untouched.

## Why

<!-- What problem does this solve, and why is this approach right? -->

Project identity is deliberately keyed on the Git remote (so one repo across local/SSH/WSL, or a fork and its parent, collapse to one project). But the settings layer collapsed two same-host checkouts to a single "representative," so the sidebar showed two rows while settings could only reach one — landing on the wrong checkout and silently saving edits to it (data loss). The sidebar already distinguishes these checkouts; this change makes settings do the same, by reusing that same grouping logic rather than inventing a parallel one.

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #18493

## Visual Proof

<!-- REQUIRED for UI / behavior changes. Please attach a BEFORE and AFTER that can easily tabbed/switched. Use videos for when appropriate over screenshots -->
<!-- If there is truly no visual or interaction change, write exactly: `N/A` and briefly say why. -->
<!-- For attachments NEVER add directly to the PR files (do not commit to files), use `gh image` extension or drag + drop (works for any attachment) -->

Before:

https://github.com/user-attachments/assets/ba1deb4c-e078-43c5-af60-b35d2bbb1e22

After:

https://github.com/user-attachments/assets/1387004c-f7d3-45fd-86a9-4c1e0dd2e808

## Testing

<!-- How did you verify this? Steps a reviewer can follow. Which platforms did you actually test (macOS / Linux / Windows / SSH)? -->

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Tested on macOS

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

Claude Opus 4.8

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
