### PR TITLE
fix(orchestration): preserve spawn lineage and reconcile prompt delivery

### DIFF
--- a/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
+++ b/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
@@ -10,8 +10,40 @@ import type { ProjectExecutionRuntimeResolution } from '../../shared/project-exe
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
 import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 import { resolveTerminalOrchestrationCliCommand } from './orchestration/cli-command'
+import { resolveOrchestrationPromptDeliveryEvidence } from './orchestration-prompt-delivery-evidence'
 
 export class OrcaRuntimeWithGetOrchestrationDispatchAuthority extends OrcaRuntimeWithVerifyOrchestrationCompatibilityCaller {
+  getOrchestrationPromptDeliveryEvidence(args: {
+    terminalHandle: string
+    taskId: string
+    dispatchId: string
+    processIncarnation: string
+    submittedAt: number
+  }): 'input_delivered' | 'worker_running' | null {
+    let ptyId: string | null = null
+    try {
+      ptyId = this.resolveLiveLeafForHandle(args.terminalHandle)?.ptyId ?? null
+    } catch {
+      return null
+    }
+    if (!ptyId) {
+      return null
+    }
+    const snapshot = this.getTerminalAgentStatusSnapshot(args.terminalHandle, ptyId)
+    const paneKey = this.getPaneKeyForTerminalHandle(args.terminalHandle)
+    return resolveOrchestrationPromptDeliveryEvidence({
+      taskId: args.taskId,
+      dispatchId: args.dispatchId,
+      expectedProcessIncarnation: args.processIncarnation,
+      currentProcessIncarnation: this.getTerminalProcessIncarnation(args.terminalHandle),
+      submittedAt: args.submittedAt,
+      terminalOutputAt: this.ptysById.get(ptyId)?.lastOutputAt ?? null,
+      terminalStatus: snapshot.titleStatus,
+      waitText: snapshot.waitText,
+      hooks: (this.getAgentStatusSnapshotFn?.() ?? []).filter((entry) => entry.paneKey === paneKey)
+    })
+  }
+
   /** Every pane key this PTY could be addressed by, including restored receipts. */
   protected collectPaneKeysForPty(ptyId: string): Set<string> {
     const paneKeys = new Set<string>()

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -13,6 +13,7 @@ import {
 import { getAgentLaunchPlatformForRepo } from './runtime-agent-launch-resolution'
 import { resolveRepoWorktreeRows, resolveScopedWorktreeIdRow } from './repo-worktree-row-resolution'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
+import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import type { RepoWorktreeRowDeps } from './repo-worktree-row-resolution'
 import { listRuntimeFolderWorkspaces } from './runtime-worktree-filesystem'
 import type { ExecutionHostId } from '../../shared/execution-host'
@@ -105,8 +106,18 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
     )
     const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
     const workspaceLineageByChildKey = this.store?.getAllWorkspaceLineage?.() ?? {}
+    const fleetWorkspaceInstances = Object.fromEntries(
+      perRepoWorktrees.flatMap((rows) =>
+        rows.map((worktree) => [worktreeWorkspaceKey(worktree.id), worktree.instanceId])
+      )
+    )
     const worktrees = perRepoWorktrees.flatMap((rows) =>
-      projectResolvedWorktreeLineage(rows, lineageById, workspaceLineageByChildKey)
+      projectResolvedWorktreeLineage(
+        rows,
+        lineageById,
+        workspaceLineageByChildKey,
+        fleetWorkspaceInstances
+      )
     )
     return { worktrees, platformByRepoId }
   }

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -12,8 +12,7 @@ import {
 } from '../project-runtime-git-options'
 import { getAgentLaunchPlatformForRepo } from './runtime-agent-launch-resolution'
 import { resolveRepoWorktreeRows, resolveScopedWorktreeIdRow } from './repo-worktree-row-resolution'
-import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
-import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { projectCurrentHostWorktreeLineage } from './runtime-worktree-lineage-projection'
 import type { RepoWorktreeRowDeps } from './repo-worktree-row-resolution'
 import { listRuntimeFolderWorkspaces } from './runtime-worktree-filesystem'
 import type { ExecutionHostId } from '../../shared/execution-host'
@@ -104,22 +103,14 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
         async (repo) => await resolveRepoWorktreeRows(deps, repo, metaById, projectRuntimeByRepoId)
       )
     )
-    const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
-    const workspaceLineageByChildKey = this.store?.getAllWorkspaceLineage?.() ?? {}
-    const fleetWorkspaceInstances = perRepoWorktrees
-      .flat()
-      .reduce<Record<string, (string | undefined)[]>>((instances, worktree) => {
-        const key = worktreeWorkspaceKey(worktree.id)
-        ;(instances[key] ??= []).push(worktree.instanceId)
-        return instances
-      }, {})
-    const worktrees = perRepoWorktrees.flatMap((rows) =>
-      projectResolvedWorktreeLineage(
-        rows,
-        lineageById,
-        workspaceLineageByChildKey,
-        fleetWorkspaceInstances
-      )
+    const currentFleet = perRepoWorktrees.flat()
+    const worktrees = perRepoWorktrees.flatMap((rows, index) =>
+      projectCurrentHostWorktreeLineage({
+        worktrees: rows,
+        currentFleet,
+        store: this.store!,
+        executionHostId: getRepoExecutionHostId(repos[index])
+      })
     )
     return { worktrees, platformByRepoId }
   }

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -106,11 +106,13 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
     )
     const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
     const workspaceLineageByChildKey = this.store?.getAllWorkspaceLineage?.() ?? {}
-    const fleetWorkspaceInstances = Object.fromEntries(
-      perRepoWorktrees.flatMap((rows) =>
-        rows.map((worktree) => [worktreeWorkspaceKey(worktree.id), worktree.instanceId])
-      )
-    )
+    const fleetWorkspaceInstances = perRepoWorktrees
+      .flat()
+      .reduce<Record<string, (string | undefined)[]>>((instances, worktree) => {
+        const key = worktreeWorkspaceKey(worktree.id)
+        ;(instances[key] ??= []).push(worktree.instanceId)
+        return instances
+      }, {})
     const worktrees = perRepoWorktrees.flatMap((rows) =>
       projectResolvedWorktreeLineage(
         rows,

--- a/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
+++ b/src/main/runtime/orca-runtime-list-known-resolved-worktrees-for-explicit-target.ts
@@ -104,8 +104,9 @@ export class OrcaRuntimeWithListKnownResolvedWorktreesForExplicitTarget extends 
       )
     )
     const lineageById = this.store?.getAllWorktreeLineage?.() ?? {}
+    const workspaceLineageByChildKey = this.store?.getAllWorkspaceLineage?.() ?? {}
     const worktrees = perRepoWorktrees.flatMap((rows) =>
-      projectResolvedWorktreeLineage(rows, lineageById)
+      projectResolvedWorktreeLineage(rows, lineageById, workspaceLineageByChildKey)
     )
     return { worktrees, platformByRepoId }
   }

--- a/src/main/runtime/orca-runtime-stop-requested-pty-ids.ts
+++ b/src/main/runtime/orca-runtime-stop-requested-pty-ids.ts
@@ -136,7 +136,8 @@ export class OrcaRuntimeWithStopRequestedPtyIds extends OrcaRuntimeWithRuntimeId
     listResolved: () => this.listResolvedWorktrees(),
     resolveRepo: (selector) => this.resolveRepoSelector(selector),
     selectRepos: (selector) => this.selectReposBySelector(selector),
-    scanRepo: (repo) => this.listRepoWorktreesForResolution(repo)
+    scanRepo: (repo) => this.listRepoWorktreesForResolution(repo),
+    invalidateRepoScan: (repoId) => this.invalidateWorktreeScanCacheForRepo(repoId)
   })
 
   protected readonly ptyForegroundAgent = new RuntimePtyForegroundAgent({

--- a/src/main/runtime/orchestration-prompt-delivery-evidence.test.ts
+++ b/src/main/runtime/orchestration-prompt-delivery-evidence.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { buildOrchestrationPromptMarker } from '../../shared/orchestration-prompt-marker'
+import { resolveOrchestrationPromptDeliveryEvidence } from './orchestration-prompt-delivery-evidence'
+
+const marker = buildOrchestrationPromptMarker('task_exact', 'dispatch_exact')
+const baseline = {
+  taskId: 'task_exact',
+  dispatchId: 'dispatch_exact',
+  expectedProcessIncarnation: 'runtime:terminal:1',
+  currentProcessIncarnation: 'runtime:terminal:1',
+  submittedAt: 100,
+  terminalOutputAt: 110,
+  terminalStatus: 'working',
+  waitText: marker,
+  hooks: []
+}
+
+describe('resolveOrchestrationPromptDeliveryEvidence', () => {
+  it('accepts an exact post-submit rendered marker', () => {
+    expect(resolveOrchestrationPromptDeliveryEvidence(baseline)).toBe('input_delivered')
+  })
+
+  it.each([
+    ['wrong dispatch', buildOrchestrationPromptMarker('task_exact', 'dispatch_old'), 110],
+    ['stale render', marker, 99]
+  ])('rejects %s evidence', (_label, waitText, terminalOutputAt) => {
+    expect(
+      resolveOrchestrationPromptDeliveryEvidence({ ...baseline, waitText, terminalOutputAt })
+    ).toBeNull()
+  })
+
+  it('rejects exact evidence from a replaced terminal incarnation', () => {
+    expect(
+      resolveOrchestrationPromptDeliveryEvidence({
+        ...baseline,
+        currentProcessIncarnation: 'runtime:terminal:2'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps exact activity authoritative when a concurrent SessionStart has no prompt', () => {
+    expect(
+      resolveOrchestrationPromptDeliveryEvidence({
+        ...baseline,
+        waitText: '',
+        hooks: [
+          { prompt: '', state: 'done', receivedAt: 120 },
+          { prompt: marker, state: 'working', receivedAt: 110 }
+        ]
+      })
+    ).toBe('worker_running')
+  })
+})

--- a/src/main/runtime/orchestration-prompt-delivery-evidence.ts
+++ b/src/main/runtime/orchestration-prompt-delivery-evidence.ts
@@ -1,0 +1,34 @@
+import { buildOrchestrationPromptMarker } from '../../shared/orchestration-prompt-marker'
+
+export type OrchestrationPromptEvidenceInput = {
+  taskId: string
+  dispatchId: string
+  expectedProcessIncarnation: string
+  currentProcessIncarnation: string | null
+  submittedAt: number
+  terminalOutputAt: number | null
+  terminalStatus: string | null
+  waitText: string
+  hooks: readonly { prompt: string; state: string; receivedAt: number }[]
+}
+
+export function resolveOrchestrationPromptDeliveryEvidence(
+  input: OrchestrationPromptEvidenceInput
+): 'input_delivered' | 'worker_running' | null {
+  if (input.currentProcessIncarnation !== input.expectedProcessIncarnation) {
+    return null
+  }
+  const marker = buildOrchestrationPromptMarker(input.taskId, input.dispatchId)
+  const exactHook = input.hooks.find(
+    (hook) => hook.receivedAt >= input.submittedAt && hook.prompt.includes(marker)
+  )
+  if (exactHook?.state === 'working') {
+    return 'worker_running'
+  }
+  return input.terminalOutputAt !== null &&
+    input.terminalOutputAt >= input.submittedAt &&
+    input.terminalStatus === 'working' &&
+    input.waitText.includes(marker)
+    ? 'input_delivered'
+    : null
+}

--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -1,7 +1,8 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`buildDispatchPreamble > renders a stable snapshot of the full preamble 1`] = `
-"You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+"[orca-dispatch-prompt:task_SNAP:ctx_SNAP]
+You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
 Your coordinator's terminal handle is: term_COORD
 Your task ID is: task_SNAP
 

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
@@ -5,7 +5,8 @@ import type { OrchestrationDb } from '../orchestration-db'
 export function markWorkerDispatchReady(
   this: OrchestrationDb,
   dispatchId: string,
-  effects?: unknown[]
+  effects?: unknown[],
+  stage = 'input_accepted'
 ): WorkerDispatchRow {
   this.db.exec('BEGIN IMMEDIATE')
   try {
@@ -20,11 +21,11 @@ export function markWorkerDispatchReady(
     this.db
       .prepare(
         `UPDATE worker_dispatches
-         SET state = 'ready', stage = 'input_accepted',
+         SET state = 'ready', stage = ?,
              effects = COALESCE(?, effects), updated_at = datetime('now')
          WHERE dispatch_id = ?`
       )
-      .run(effects ? JSON.stringify(effects) : null, dispatchId)
+      .run(stage, effects ? JSON.stringify(effects) : null, dispatchId)
     this.db.exec('COMMIT')
     return this.getWorkerDispatch(dispatchId) as WorkerDispatchRow
   } catch (error) {

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -1,4 +1,5 @@
 import type { OrchestrationCliCommand } from './cli-command'
+import { buildOrchestrationPromptMarker } from '../../../shared/orchestration-prompt-marker'
 
 export type PreambleParams = {
   taskId: string
@@ -59,7 +60,8 @@ export function buildDispatchPreamble(params: PreambleParams): string {
     ? ` --dispatch-capability ${params.dispatchCapability}`
     : ''
 
-  const header = `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
+  const header = `${buildOrchestrationPromptMarker(params.taskId, params.dispatchId)}
+You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
 Your coordinator's terminal handle is: ${params.coordinatorHandle}
 Your task ID is: ${params.taskId}
 

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -10,8 +10,7 @@ import {
   writeWorktreeMetaForHost
 } from '../persistence/host-qualified-worktree-meta'
 import { isFolderRepo } from '../../shared/repo-kind'
-import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
-import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { projectCurrentHostWorktreeLineage } from './runtime-worktree-lineage-projection'
 import { withTimeout } from '../../shared/promise-timeout-fallback'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import type { WorktreeLineage } from '../../shared/worktree/lineage-types'
@@ -24,6 +23,7 @@ import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning
 import { getRepoOwnedWorktreeMeta } from '../worktree-metadata-ownership'
 import { resolveLocalProjectRuntimesForRepos } from '../project-runtime-git-options'
 import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
+import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 
 /**
  * Per-repo budget for one resolution pass. Why: mobile startup shares this path, so one slow repo
@@ -209,17 +209,42 @@ export async function resolveScopedWorktreeIdRow(
     store.getAllWorktreeMeta() ?? {},
     resolveLocalProjectRuntimesForRepos(store, [repo])
   )
-  const projected = projectResolvedWorktreeLineage(
-    rows,
-    store.getAllWorktreeLineage?.() ?? {},
-    store.getAllWorkspaceLineage?.() ?? {},
-    Object.fromEntries(
-      Object.entries(store.getAllWorktreeMeta() ?? {}).map(([id, meta]) => [
-        worktreeWorkspaceKey(id),
-        meta.instanceId
-      ])
+  const allMeta = store.getAllWorktreeMeta() ?? {}
+  const parentRepoIds = new Set<string>()
+  for (const row of rows) {
+    const ancestry = store.getAllWorkspaceLineage?.()[worktreeWorkspaceKey(row.id)]
+    const parent = ancestry ? parseWorkspaceKey(ancestry.parentWorkspaceKey) : null
+    if (parent?.type === 'worktree') {
+      const parsedParent = splitWorktreeIdForFilesystem(parent.worktreeId)
+      if (parsedParent?.repoId && parsedParent.repoId !== repo.id) {
+        parentRepoIds.add(parsedParent.repoId)
+      }
+    }
+  }
+  const parentRepos = store
+    .getRepos()
+    .filter(
+      (candidate) =>
+        parentRepoIds.has(candidate.id) &&
+        getRepoExecutionHostId(candidate) === getRepoExecutionHostId(repo)
     )
-  )
+  const projectRuntimes = resolveLocalProjectRuntimesForRepos(store, parentRepos)
+  const currentFleet = [
+    ...rows,
+    ...(
+      await Promise.all(
+        parentRepos.map((candidate) =>
+          resolveRepoWorktreeRows(deps, candidate, allMeta, projectRuntimes)
+        )
+      )
+    ).flat()
+  ]
+  const projected = projectCurrentHostWorktreeLineage({
+    worktrees: rows,
+    currentFleet,
+    store,
+    executionHostId: getRepoExecutionHostId(repo)
+  })
   const exact = projected.find((worktree) => worktree.id === worktreeId)
   if (exact) {
     return exact

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -208,7 +208,11 @@ export async function resolveScopedWorktreeIdRow(
     store.getAllWorktreeMeta() ?? {},
     resolveLocalProjectRuntimesForRepos(store, [repo])
   )
-  const projected = projectResolvedWorktreeLineage(rows, store.getAllWorktreeLineage?.() ?? {})
+  const projected = projectResolvedWorktreeLineage(
+    rows,
+    store.getAllWorktreeLineage?.() ?? {},
+    store.getAllWorkspaceLineage?.() ?? {}
+  )
   const exact = projected.find((worktree) => worktree.id === worktreeId)
   if (exact) {
     return exact

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -11,6 +11,7 @@ import {
 } from '../persistence/host-qualified-worktree-meta'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
+import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import { withTimeout } from '../../shared/promise-timeout-fallback'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import type { WorktreeLineage } from '../../shared/worktree/lineage-types'
@@ -211,7 +212,13 @@ export async function resolveScopedWorktreeIdRow(
   const projected = projectResolvedWorktreeLineage(
     rows,
     store.getAllWorktreeLineage?.() ?? {},
-    store.getAllWorkspaceLineage?.() ?? {}
+    store.getAllWorkspaceLineage?.() ?? {},
+    Object.fromEntries(
+      Object.entries(store.getAllWorktreeMeta() ?? {}).map(([id, meta]) => [
+        worktreeWorkspaceKey(id),
+        meta.instanceId
+      ])
+    )
   )
   const exact = projected.find((worktree) => worktree.id === worktreeId)
   if (exact) {

--- a/src/main/runtime/rpc/methods/orchestration-worker-ancestry.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-ancestry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+import type { WorkspaceLineage } from '../../../../shared/worktree/lineage-types'
+import { assertCreatedWorkerAncestry } from './orchestration-worker-ancestry'
+import type { WorkerEffect } from './orchestration-worker-topology'
+
+const validAncestry: WorkspaceLineage = {
+  childWorkspaceKey: 'worktree:target::created',
+  parentWorkspaceKey: 'worktree:repo::parent',
+  origin: 'orchestration' as const,
+  capture: { source: 'orchestration-context' as const, confidence: 'inferred' as const },
+  createdAt: 1,
+  taskId: 'task_1',
+  orchestrationRunId: 'run_1',
+  coordinatorHandle: 'term_coord'
+}
+
+function check(workspaceLineage: typeof validAncestry | null) {
+  const effects: WorkerEffect[] = []
+  const recordWorkerStage = vi.fn()
+  const invoke = () =>
+    assertCreatedWorkerAncestry({
+      db: { recordWorkerStage } as never,
+      dispatchId: 'dispatch_1',
+      runId: 'run_1',
+      taskId: 'task_1',
+      coordinatorHandle: 'term_coord',
+      childWorktreeId: 'target::created',
+      parentWorktreeId: 'repo::parent',
+      workspaceLineage,
+      effects
+    })
+  return { effects, invoke, recordWorkerStage }
+}
+
+describe('created worker ancestry', () => {
+  it('accepts authoritative cross-repository orchestration ancestry', () => {
+    const result = check(validAncestry)
+    expect(result.invoke).not.toThrow()
+    expect(result.effects).toEqual([])
+    expect(result.recordWorkerStage).not.toHaveBeenCalled()
+  })
+
+  it('rejects absent ancestry and durably retains the created resource', () => {
+    const result = check(null)
+    expect(result.invoke).toThrowError(OrchestrationError)
+    expect(result.effects).toEqual([
+      { kind: 'worktree', action: 'created_unlinked_child', id: 'target::created' }
+    ])
+    expect(result.recordWorkerStage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dispatchId: 'dispatch_1',
+        stage: 'worktree_created',
+        worktreeId: 'target::created',
+        residualResources: result.effects
+      })
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-ancestry.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-ancestry.ts
@@ -1,0 +1,46 @@
+import { worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { WorkspaceLineage } from '../../../../shared/worktree/lineage-types'
+import type { OrchestrationDb } from '../../orchestration/db'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+import type { WorkerEffect } from './orchestration-worker-topology'
+
+/** Fail closed when a newly created child cannot prove its requested orchestration ancestry. */
+export function assertCreatedWorkerAncestry(args: {
+  db: OrchestrationDb
+  dispatchId: string
+  runId: string
+  taskId: string
+  coordinatorHandle: string
+  childWorktreeId: string
+  parentWorktreeId: string
+  workspaceLineage?: WorkspaceLineage | null
+  effects: WorkerEffect[]
+}): void {
+  const ancestry = args.workspaceLineage
+  if (
+    ancestry?.origin === 'orchestration' &&
+    ancestry.childWorkspaceKey === worktreeWorkspaceKey(args.childWorktreeId) &&
+    ancestry.parentWorkspaceKey === worktreeWorkspaceKey(args.parentWorktreeId) &&
+    ancestry.taskId === args.taskId &&
+    ancestry.orchestrationRunId === args.runId &&
+    ancestry.coordinatorHandle === args.coordinatorHandle
+  ) {
+    return
+  }
+  args.effects.push({
+    kind: 'worktree',
+    action: 'created_unlinked_child',
+    id: args.childWorktreeId
+  })
+  args.db.recordWorkerStage({
+    dispatchId: args.dispatchId,
+    stage: 'worktree_created',
+    worktreeId: args.childWorktreeId,
+    effects: args.effects,
+    residualResources: args.effects
+  })
+  throw new OrchestrationError(
+    'created_unlinked_child',
+    'Created child worktree is missing authoritative orchestration ancestry.'
+  )
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-prompt-recovery.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-prompt-recovery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest'
+import { finishReadyWorkerStart } from './orchestration-worker-prompt-recovery'
+import type { WorkerEffect, WorkerSetupReceipt } from './orchestration-worker-topology'
+
+describe('recovered worker prompt finalization', () => {
+  it('preserves reveal warnings and starts the same post-ready setup monitor', () => {
+    const waitForSetupTerminalCompletion = vi.fn(() => new Promise(() => undefined))
+    const effects: WorkerEffect[] = [
+      { kind: 'terminal', role: 'setup', id: 'term_setup' },
+      { kind: 'setup', state: 'running' }
+    ]
+    const setup: WorkerSetupReceipt = {
+      requested: 'run',
+      effective: 'run',
+      source: 'orchestration_default',
+      hookFound: true,
+      startupPolicy: 'start-immediately',
+      state: 'running'
+    }
+
+    const receipt = finishReadyWorkerStart({
+      runtime: { waitForSetupTerminalCompletion } as never,
+      db: {} as never,
+      runId: 'run_1',
+      taskId: 'task_1',
+      dispatchId: 'dispatch_1',
+      worker: { state: 'ready', stage: 'worker_running' },
+      setup,
+      launch: { requested: {}, effective: {} },
+      timeoutMs: 1_000,
+      effects,
+      warning: 'terminal was created in the background'
+    })
+
+    expect(receipt).toMatchObject({
+      state: 'ready',
+      stage: 'worker_running',
+      warning: 'terminal was created in the background'
+    })
+    expect(waitForSetupTerminalCompletion).toHaveBeenCalledWith('term_setup')
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-prompt-recovery.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-prompt-recovery.ts
@@ -1,0 +1,84 @@
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { OrchestrationDb } from '../../orchestration/db'
+import { isAgentPromptStalledError } from '../../agent-prompt-submission-verification'
+import {
+  monitorWorkerSetup,
+  type WorkerEffect,
+  type WorkerSetupReceipt
+} from './orchestration-worker-topology'
+
+/** Reconcile a timed-out prompt only from evidence correlated to this exact worker attempt. */
+export function recoverStalledWorkerPrompt(args: {
+  error: unknown
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  terminalHandle?: string
+  taskId: string
+  dispatchId: string
+  processIncarnation?: string
+  submittedAt?: number
+  effects: WorkerEffect[]
+}) {
+  if (
+    !isAgentPromptStalledError(args.error) ||
+    !args.terminalHandle ||
+    !args.processIncarnation ||
+    !args.submittedAt
+  ) {
+    return null
+  }
+  const evidence = args.runtime.getOrchestrationPromptDeliveryEvidence({
+    terminalHandle: args.terminalHandle,
+    taskId: args.taskId,
+    dispatchId: args.dispatchId,
+    processIncarnation: args.processIncarnation,
+    submittedAt: args.submittedAt
+  })
+  if (!evidence) {
+    return null
+  }
+  args.effects.push({
+    kind: 'dispatch_input',
+    role: 'agent',
+    id: args.terminalHandle,
+    state: evidence
+  })
+  return args.db.markWorkerDispatchReady(args.dispatchId, args.effects, evidence)
+}
+
+/** Apply the common post-ready setup observer and build the successful worker-start receipt. */
+export function finishReadyWorkerStart(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  taskId: string
+  dispatchId: string
+  worker: { state: string; stage: string }
+  setup: WorkerSetupReceipt
+  launch: unknown
+  timeoutMs: number
+  effects: WorkerEffect[]
+  warning?: string
+}) {
+  monitorWorkerSetup({
+    runtime: args.runtime,
+    db: args.db,
+    runId: args.runId,
+    dispatchId: args.dispatchId,
+    setupReceipt: args.setup,
+    effects: args.effects
+  })
+  return {
+    runId: args.runId,
+    taskId: args.taskId,
+    dispatchId: args.dispatchId,
+    state: args.worker.state,
+    stage: args.worker.stage,
+    setup: args.setup,
+    launch: args.launch,
+    timeoutMs: args.timeoutMs,
+    effects: args.effects,
+    residualResources: [],
+    ...(args.warning ? { warning: args.warning } : {})
+  }
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-options.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-options.ts
@@ -1,0 +1,59 @@
+import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
+
+/** Validate that an explicitly reused terminal belongs to and is active in the selected worktree. */
+export async function validateExplicitWorkerTerminal(args: {
+  runtime: OrcaRuntimeService
+  terminalHandle: string
+  worktreeId?: string
+}) {
+  const terminal = await args.runtime.showTerminal(args.terminalHandle)
+  if (terminal.worktreeId !== args.worktreeId) {
+    throw new OrchestrationError(
+      'terminal_worktree_mismatch',
+      `Terminal ${args.terminalHandle} does not belong to worktree ${args.worktreeId}.`
+    )
+  }
+  if (!(await args.runtime.isTerminalRunningAgent(args.terminalHandle))) {
+    throw new OrchestrationError(
+      'agent_unconfigured',
+      `Terminal ${args.terminalHandle} is not running a recognized agent.`
+    )
+  }
+  return terminal
+}
+
+/** Persist the normalized placement and setup request that makes a start attempt replayable. */
+export function buildWorkerStartOptions(args: {
+  requestedWorktree: string
+  resolvedWorktreeId?: string
+  creationRepoId?: string
+  name?: string
+  repo?: string
+  baseBranch?: string
+  terminal?: string
+  agent?: string
+  launch: OrchestrationWorkerLaunchReceipt
+  timeoutMs: number
+  setup?: 'run' | 'skip' | 'inherit'
+  createsWorktree: boolean
+}) {
+  return {
+    worktree: args.requestedWorktree,
+    resolvedWorktreeId: args.resolvedWorktreeId ?? null,
+    name: args.name ?? null,
+    repo: args.repo ?? args.creationRepoId ?? null,
+    baseBranch: args.baseBranch ?? null,
+    terminal: args.terminal ?? null,
+    agent: args.agent ?? null,
+    launch: args.launch,
+    timeoutMs: args.timeoutMs,
+    setup: args.createsWorktree ? (args.setup ?? 'run') : 'not_applicable',
+    setupSource: args.createsWorktree
+      ? args.setup
+        ? 'explicit_request'
+        : 'orchestration_default'
+      : 'existing_worktree'
+  }
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-outcome-classification.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-outcome-classification.test.ts
@@ -14,6 +14,7 @@ describe('worker start outcome classification', () => {
     expect(isUnknownWorkerStartOutcome(new Error('request timed out'), 'worktree_create')).toBe(
       true
     )
+    expect(isUnknownWorkerStartOutcome(new Error('timeout'), 'worktree_create')).toBe(true)
   })
 
   it('keeps a definite failure definite', () => {

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-outcome.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-outcome.ts
@@ -1,0 +1,15 @@
+/** Classify worker-start failures whose external effect may have succeeded despite the error. */
+export function isUnknownWorkerStartOutcome(error: unknown, stage: string): boolean {
+  const code =
+    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
+      ? (error as { code: string }).code
+      : ''
+  if (code === 'operation_unknown') {
+    return true
+  }
+  if (stage !== 'worktree_create') {
+    return false
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return /connection|disconnect|timed?\s*out|runtime changed|outcome unknown/i.test(message)
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-outcome.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-outcome.ts
@@ -11,5 +11,7 @@ export function isUnknownWorkerStartOutcome(error: unknown, stage: string): bool
     return false
   }
   const message = error instanceof Error ? error.message : String(error)
-  return /connection|disconnect|timed?\s*out|runtime changed|outcome unknown/i.test(message)
+  return /connection|disconnect|\btimeout\b|timed?\s*out|runtime changed|outcome unknown/i.test(
+    message
+  )
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
@@ -113,10 +113,23 @@ async function createPromptContractHarness(
     worktreeId: 'repo::parent',
     status: 'running'
   } as never)
-  vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
-    id: 'repo::parent',
-    repoId: 'repo-1'
-  } as never)
+  vi.spyOn(runtime, 'showManagedWorktree').mockImplementation(async (selector) => {
+    if (selector === `id:${AGENT_PROMPT_TEST_WORKTREE_ID}`) {
+      return {
+        id: AGENT_PROMPT_TEST_WORKTREE_ID,
+        repoId: 'repo-1',
+        workspaceLineage: {
+          childWorkspaceKey: `worktree:${AGENT_PROMPT_TEST_WORKTREE_ID}`,
+          parentWorkspaceKey: 'worktree:repo::parent',
+          origin: 'orchestration',
+          taskId: task.id,
+          orchestrationRunId: run.id,
+          coordinatorHandle: 'term_coord'
+        }
+      } as never
+    }
+    return { id: 'repo::parent', repoId: 'repo-1' } as never
+  })
   vi.spyOn(runtime, 'showRepo').mockResolvedValue({ id: 'repo-1', kind: 'git' } as never)
   vi.spyOn(runtime, 'createManagedWorktree').mockResolvedValue({
     worktree: { id: AGENT_PROMPT_TEST_WORKTREE_ID, repoId: 'repo-1' },

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-receipt.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-receipt.ts
@@ -7,6 +7,7 @@ import {
 import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
 import { isAgentSessionPtyWriteRefusedError } from '../../../../shared/agent-session-pty-write-admission'
 import { structuredChatPtyWriteRefusalCopy } from '../../../../shared/agent-session-pty-write-refusal-copy'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
 
 export function failWorkerStartWithReceipt(args: {
   db: OrchestrationDb
@@ -41,6 +42,7 @@ export function failWorkerStartWithReceipt(args: {
     stage: worker.stage,
     failedStage: args.failedStage,
     lastError: reason,
+    ...(args.error instanceof OrchestrationError ? { errorCode: args.error.code } : {}),
     setup: args.setup,
     launch: args.launch,
     effects: JSON.parse(worker.effects) as unknown[],

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -2,6 +2,8 @@ import type { AgentLaunchPreferences } from '../../../../shared/agent-session-ho
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
+import { worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+import { OrchestrationError } from '../../orchestration/orchestration-error'
 
 export type WorkerEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
@@ -108,6 +110,8 @@ export async function createWorkerWorktree(args: {
   runtime: OrcaRuntimeService
   db: OrchestrationDb
   dispatchId: string
+  runId: string
+  taskId: string
   requestedWorktree: string
   coordinatorWorktree: Awaited<ReturnType<OrcaRuntimeService['showManagedWorktree']>>
   params: {
@@ -147,12 +151,53 @@ export async function createWorkerWorktree(args: {
     ...(args.launchPreferences ? { startupLaunchPreferences: args.launchPreferences } : {}),
     activate: false,
     lineage: {
-      parentWorktree: requestedWorktree === 'new-child' ? coordinatorWorktree.id : undefined,
+      parentWorktree: undefined,
+      orchestrationContext:
+        requestedWorktree === 'new-child'
+          ? {
+              parentWorktreeId: coordinatorWorktree.id,
+              orchestrationRunId: args.runId,
+              taskId: args.taskId,
+              coordinatorHandle: params.from
+            }
+          : undefined,
       noParent: requestedWorktree === 'new-top-level',
       callerTerminalHandle: params.from
     }
   })
   const terminalHandle = created.startupTerminal?.handle
+  const authoritative =
+    requestedWorktree === 'new-child'
+      ? await runtime.showManagedWorktree(`id:${created.worktree.id}`)
+      : (created.worktree as Awaited<ReturnType<OrcaRuntimeService['showManagedWorktree']>>)
+  if (requestedWorktree === 'new-child') {
+    const ancestry = authoritative.workspaceLineage
+    if (
+      ancestry?.origin !== 'orchestration' ||
+      ancestry.childWorkspaceKey !== worktreeWorkspaceKey(created.worktree.id) ||
+      ancestry.parentWorkspaceKey !== worktreeWorkspaceKey(coordinatorWorktree.id) ||
+      ancestry.taskId !== args.taskId ||
+      ancestry.orchestrationRunId !== args.runId ||
+      ancestry.coordinatorHandle !== params.from
+    ) {
+      effects.push({
+        kind: 'worktree',
+        action: 'created_unlinked_child',
+        id: created.worktree.id
+      })
+      db.recordWorkerStage({
+        dispatchId,
+        stage: 'worktree_created',
+        worktreeId: created.worktree.id,
+        effects,
+        residualResources: effects
+      })
+      throw new OrchestrationError(
+        'created_unlinked_child',
+        'Created child worktree is missing authoritative orchestration ancestry.'
+      )
+    }
+  }
   effects.push({
     kind: 'worktree',
     action: requestedWorktree === 'new-child' ? 'created_child' : 'created_top_level',
@@ -210,7 +255,7 @@ export async function createWorkerWorktree(args: {
     terminalId: setupTerminalHandle ?? setupTerminal?.id
   })
   return {
-    worktree: created.worktree as Awaited<ReturnType<OrcaRuntimeService['showManagedWorktree']>>,
+    worktree: authoritative,
     terminalHandle,
     setupReceipt
   }
@@ -281,3 +326,4 @@ export function isUnknownWorkerStartOutcome(error: unknown, stage: string): bool
   const message = error instanceof Error ? error.message : String(error)
   return /connection|disconnect|timed?\s*out|runtime changed|outcome unknown/i.test(message)
 }
+/* eslint-disable max-lines -- Why: worker worktree, setup-terminal, and ancestry validation form one auditable resource-creation transaction. */

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -2,8 +2,8 @@ import type { AgentLaunchPreferences } from '../../../../shared/agent-session-ho
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
-import { worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
-import { OrchestrationError } from '../../orchestration/orchestration-error'
+import { assertCreatedWorkerAncestry } from './orchestration-worker-ancestry'
+export { isUnknownWorkerStartOutcome } from './orchestration-worker-start-outcome'
 
 export type WorkerEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
@@ -171,32 +171,17 @@ export async function createWorkerWorktree(args: {
       ? await runtime.showManagedWorktree(`id:${created.worktree.id}`)
       : (created.worktree as Awaited<ReturnType<OrcaRuntimeService['showManagedWorktree']>>)
   if (requestedWorktree === 'new-child') {
-    const ancestry = authoritative.workspaceLineage
-    if (
-      ancestry?.origin !== 'orchestration' ||
-      ancestry.childWorkspaceKey !== worktreeWorkspaceKey(created.worktree.id) ||
-      ancestry.parentWorkspaceKey !== worktreeWorkspaceKey(coordinatorWorktree.id) ||
-      ancestry.taskId !== args.taskId ||
-      ancestry.orchestrationRunId !== args.runId ||
-      ancestry.coordinatorHandle !== params.from
-    ) {
-      effects.push({
-        kind: 'worktree',
-        action: 'created_unlinked_child',
-        id: created.worktree.id
-      })
-      db.recordWorkerStage({
-        dispatchId,
-        stage: 'worktree_created',
-        worktreeId: created.worktree.id,
-        effects,
-        residualResources: effects
-      })
-      throw new OrchestrationError(
-        'created_unlinked_child',
-        'Created child worktree is missing authoritative orchestration ancestry.'
-      )
-    }
+    assertCreatedWorkerAncestry({
+      db,
+      dispatchId,
+      runId: args.runId,
+      taskId: args.taskId,
+      coordinatorHandle: params.from,
+      childWorktreeId: created.worktree.id,
+      parentWorktreeId: coordinatorWorktree.id,
+      workspaceLineage: authoritative.workspaceLineage,
+      effects
+    })
   }
   effects.push({
     kind: 'worktree',
@@ -311,19 +296,3 @@ export function monitorWorkerSetup(args: {
     })
     .catch(() => undefined)
 }
-
-export function isUnknownWorkerStartOutcome(error: unknown, stage: string): boolean {
-  const code =
-    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
-      ? (error as { code: string }).code
-      : ''
-  if (code === 'operation_unknown') {
-    return true
-  }
-  if (stage !== 'worktree_create') {
-    return false
-  }
-  const message = error instanceof Error ? error.message : String(error)
-  return /connection|disconnect|timed?\s*out|runtime changed|outcome unknown/i.test(message)
-}
-/* eslint-disable max-lines -- Why: worker worktree, setup-terminal, and ancestry validation form one auditable resource-creation transaction. */

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -42,10 +42,24 @@ describe('orchestration new-worktree workers', () => {
       worktreeId: 'repo::parent',
       status: 'running'
     } as never)
-    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
-      id: 'repo::parent',
-      repoId: 'repo'
-    } as never)
+    vi.spyOn(runtime, 'showManagedWorktree').mockImplementation(async (selector) => {
+      if (selector !== 'id:repo::created') {
+        return { id: 'repo::parent', repoId: 'repo' } as never
+      }
+      const task = db.listTasks().at(-1)
+      return {
+        id: 'repo::created',
+        repoId: 'repo',
+        workspaceLineage: {
+          childWorkspaceKey: 'worktree:repo::created',
+          parentWorkspaceKey: 'worktree:repo::parent',
+          origin: 'orchestration',
+          taskId: task?.id,
+          orchestrationRunId: runId,
+          coordinatorHandle: 'term_coord'
+        }
+      } as never
+    })
     vi.spyOn(runtime, 'showRepo').mockResolvedValue({
       id: 'repo',
       kind: 'git'
@@ -123,6 +137,29 @@ describe('orchestration new-worktree workers', () => {
           options?.terminals?.find((terminal) => terminal.title === 'Setup')?.handle
       }
     } as never)
+    vi.mocked(runtime.showManagedWorktree).mockImplementation(async (selector) => {
+      if (selector !== 'id:repo::created') {
+        return { id: 'repo::parent', repoId: 'repo' } as never
+      }
+      const task = db.listTasks().at(-1)
+      return {
+        id: 'repo::created',
+        repoId: 'repo',
+        workspaceLineage: {
+          childWorkspaceKey: 'worktree:repo::created',
+          childInstanceId: 'child-instance',
+          parentWorkspaceKey: 'worktree:repo::parent',
+          parentInstanceId: 'parent-instance',
+          origin: 'orchestration',
+          capture: { source: 'orchestration-context', confidence: 'inferred' },
+          taskId: task?.id,
+          orchestrationRunId: runId,
+          coordinatorHandle: 'term_coord',
+          createdByTerminalHandle: 'term_coord',
+          createdAt: 1
+        }
+      } as never
+    })
     if (options?.terminals) {
       vi.mocked(runtime.listTerminals).mockResolvedValue({
         terminals: options.terminals,
@@ -163,6 +200,78 @@ describe('orchestration new-worktree workers', () => {
       ])
     )
     expect(runtime.createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('accepts a cross-repo child only after authoritative spawn ancestry is visible', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.createManagedWorktree).mockResolvedValue({
+      worktree: { id: 'target::created', repoId: 'target' },
+      startupTerminal: { spawned: true, handle: 'term_worker' }
+    } as never)
+    vi.mocked(runtime.showManagedWorktree).mockImplementation(async (selector) => {
+      if (selector === 'id:target::created') {
+        const task = db.listTasks().at(-1)!
+        return {
+          id: 'target::created',
+          repoId: 'target',
+          parentWorktreeId: null,
+          lineage: null,
+          workspaceLineage: {
+            childWorkspaceKey: 'worktree:target::created',
+            parentWorkspaceKey: 'worktree:repo::parent',
+            origin: 'orchestration',
+            taskId: task.id,
+            orchestrationRunId: runId,
+            coordinatorHandle: 'term_coord'
+          }
+        } as never
+      }
+      return { id: 'repo::parent', repoId: 'repo' } as never
+    })
+
+    const { result } = await startWorker({ repo: 'target' })
+
+    expect(result).toMatchObject({
+      state: 'ready',
+      effects: expect.arrayContaining([
+        expect.objectContaining({ action: 'created_child', id: 'target::created' })
+      ])
+    })
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lineage: expect.objectContaining({
+          parentWorktree: undefined,
+          orchestrationContext: expect.objectContaining({
+            parentWorktreeId: 'repo::parent',
+            orchestrationRunId: runId
+          })
+        })
+      })
+    )
+  })
+
+  it('rejects a child whose authoritative spawn ancestry is absent and retains the resource', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.showManagedWorktree).mockResolvedValue({
+      id: 'repo::created',
+      repoId: 'repo',
+      workspaceLineage: null
+    } as never)
+
+    const { result } = await startWorker()
+
+    expect(result).toMatchObject({
+      state: 'failed',
+      failedStage: 'worktree_create',
+      errorCode: 'created_unlinked_child',
+      residualResources: [
+        expect.objectContaining({ action: 'created_unlinked_child', id: 'repo::created' })
+      ]
+    })
+    expect(result).not.toHaveProperty(
+      'effects',
+      expect.arrayContaining([expect.objectContaining({ action: 'created_child' })])
+    )
   })
 
   it('passes launch preferences into agent-first worktree creation', async () => {
@@ -678,6 +787,30 @@ describe('orchestration new-worktree workers', () => {
     expect(reinjectPrompt).not.toHaveBeenCalled()
   })
 
+  it('reconciles a stalled prompt from exact correlated worker activity', async () => {
+    mockCreatedWorktree({ hookFound: false })
+    vi.mocked(runtime.sendTerminalAgentPrompt).mockRejectedValueOnce(
+      new Error('agent_prompt_stalled')
+    )
+    vi.spyOn(runtime, 'getOrchestrationPromptDeliveryEvidence').mockReturnValue('worker_running')
+
+    const { result, task } = await startWorker()
+
+    expect(result).toMatchObject({
+      state: 'ready',
+      stage: 'worker_running',
+      effects: expect.arrayContaining([
+        expect.objectContaining({ kind: 'dispatch_input', state: 'worker_running' })
+      ])
+    })
+    const dispatch = db.getDispatchContext(task.id)!
+    expect(dispatch).toMatchObject({ status: 'dispatched', capability_revoked_at: null })
+    expect(db.getWorkerDispatch(dispatch.id)).toMatchObject({
+      state: 'ready',
+      stage: 'worker_running'
+    })
+  })
+
   it('persists pre-effect, post-effect, and post-input stages in order', async () => {
     mockCreatedWorktree({ hookFound: false })
     let finishWait:
@@ -739,3 +872,4 @@ describe('orchestration new-worktree workers', () => {
     })
   })
 })
+/* eslint-disable max-lines -- Why: this single worker-start contract matrix shares stateful runtime and database fixtures across topology and prompt-delivery cases. */

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -202,78 +202,6 @@ describe('orchestration new-worktree workers', () => {
     expect(runtime.createTerminal).not.toHaveBeenCalled()
   })
 
-  it('accepts a cross-repo child only after authoritative spawn ancestry is visible', async () => {
-    mockCreatedWorktree()
-    vi.mocked(runtime.createManagedWorktree).mockResolvedValue({
-      worktree: { id: 'target::created', repoId: 'target' },
-      startupTerminal: { spawned: true, handle: 'term_worker' }
-    } as never)
-    vi.mocked(runtime.showManagedWorktree).mockImplementation(async (selector) => {
-      if (selector === 'id:target::created') {
-        const task = db.listTasks().at(-1)!
-        return {
-          id: 'target::created',
-          repoId: 'target',
-          parentWorktreeId: null,
-          lineage: null,
-          workspaceLineage: {
-            childWorkspaceKey: 'worktree:target::created',
-            parentWorkspaceKey: 'worktree:repo::parent',
-            origin: 'orchestration',
-            taskId: task.id,
-            orchestrationRunId: runId,
-            coordinatorHandle: 'term_coord'
-          }
-        } as never
-      }
-      return { id: 'repo::parent', repoId: 'repo' } as never
-    })
-
-    const { result } = await startWorker({ repo: 'target' })
-
-    expect(result).toMatchObject({
-      state: 'ready',
-      effects: expect.arrayContaining([
-        expect.objectContaining({ action: 'created_child', id: 'target::created' })
-      ])
-    })
-    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({
-        lineage: expect.objectContaining({
-          parentWorktree: undefined,
-          orchestrationContext: expect.objectContaining({
-            parentWorktreeId: 'repo::parent',
-            orchestrationRunId: runId
-          })
-        })
-      })
-    )
-  })
-
-  it('rejects a child whose authoritative spawn ancestry is absent and retains the resource', async () => {
-    mockCreatedWorktree()
-    vi.mocked(runtime.showManagedWorktree).mockResolvedValue({
-      id: 'repo::created',
-      repoId: 'repo',
-      workspaceLineage: null
-    } as never)
-
-    const { result } = await startWorker()
-
-    expect(result).toMatchObject({
-      state: 'failed',
-      failedStage: 'worktree_create',
-      errorCode: 'created_unlinked_child',
-      residualResources: [
-        expect.objectContaining({ action: 'created_unlinked_child', id: 'repo::created' })
-      ]
-    })
-    expect(result).not.toHaveProperty(
-      'effects',
-      expect.arrayContaining([expect.objectContaining({ action: 'created_child' })])
-    )
-  })
-
   it('passes launch preferences into agent-first worktree creation', async () => {
     mockCreatedWorktree()
 
@@ -872,4 +800,3 @@ describe('orchestration new-worktree workers', () => {
     })
   })
 })
-/* eslint-disable max-lines -- Why: this single worker-start contract matrix shares stateful runtime and database fixtures across topology and prompt-delivery cases. */

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -8,7 +8,6 @@ import { WorkerStartParams } from './orchestration-worker-start-schema'
 import {
   createExistingWorktreeWorkerTerminal,
   createWorkerWorktree,
-  monitorWorkerSetup,
   requireWorkerAuthority,
   type WorkerEffect,
   type WorkerSetupReceipt
@@ -26,7 +25,14 @@ import {
   isWorkerStartTimeoutWithinTimerLimit,
   resolveWorkerStartReadinessTimeoutMs
 } from '../../../../shared/orchestration-timing-budgets'
-import { isAgentPromptStalledError } from '../../agent-prompt-submission-verification'
+import {
+  finishReadyWorkerStart,
+  recoverStalledWorkerPrompt
+} from './orchestration-worker-prompt-recovery'
+import {
+  buildWorkerStartOptions,
+  validateExplicitWorkerTerminal
+} from './orchestration-worker-start-options'
 
 export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
   defineMethod({
@@ -97,40 +103,28 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         : requestedWorktree === 'current'
           ? await runtime.showManagedTerminalWorkspace(`id:${coordinatorTerminal.worktreeId}`)
           : await runtime.showManagedTerminalWorkspace(requestedWorktree)
-      let explicitTerminal
       if (params.terminal) {
-        explicitTerminal = await runtime.showTerminal(params.terminal)
-        if (explicitTerminal.worktreeId !== resolvedWorktree?.id) {
-          throw new OrchestrationError(
-            'terminal_worktree_mismatch',
-            `Terminal ${params.terminal} does not belong to worktree ${resolvedWorktree?.id}.`
-          )
-        }
-        if (!(await runtime.isTerminalRunningAgent(params.terminal))) {
-          throw new OrchestrationError(
-            'agent_unconfigured',
-            `Terminal ${params.terminal} is not running a recognized agent.`
-          )
-        }
+        await validateExplicitWorkerTerminal({
+          runtime,
+          terminalHandle: params.terminal,
+          worktreeId: resolvedWorktree?.id
+        })
       }
 
-      const startOptions = {
-        worktree: requestedWorktree,
-        resolvedWorktreeId: resolvedWorktree?.id ?? null,
-        name: params.name ?? null,
-        repo: params.repo ?? creationWorktree?.repoId ?? null,
-        baseBranch: params.baseBranch ?? null,
-        terminal: params.terminal ?? null,
-        agent: agent ?? null,
+      const startOptions = buildWorkerStartOptions({
+        requestedWorktree,
+        resolvedWorktreeId: resolvedWorktree?.id,
+        creationRepoId: creationWorktree?.repoId,
+        name: params.name,
+        repo: params.repo,
+        baseBranch: params.baseBranch,
+        terminal: params.terminal,
+        agent,
         launch: launch.receipt,
         timeoutMs: readinessTimeoutMs,
-        setup: createsWorktree ? (params.setup ?? 'run') : 'not_applicable',
-        setupSource: createsWorktree
-          ? params.setup
-            ? 'explicit_request'
-            : 'orchestration_default'
-          : 'existing_worktree'
-      }
+        setup: params.setup,
+        createsWorktree
+      })
       const started = db.createStartingWorkerDispatch({
         creator: resolveDispatchCreator(runtime, params.from),
         maxDepth: runtime.getNestedWorkerMaxDepth(),
@@ -148,9 +142,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         )
       }
       let terminalHandle = params.terminal
-      let terminalRevealWarning: string | undefined
-      let workerProcessIncarnation: string | undefined
-      let dispatchInputSubmittedAt: number | undefined
+      const deliveryState: { warning?: string; incarnation?: string; submittedAt?: number } = {}
       let failedStage = 'terminal_create'
       let setupReceipt: WorkerSetupReceipt = {
         requested: 'not_applicable',
@@ -160,6 +152,20 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         startupPolicy: 'start-immediately',
         state: 'not_applicable'
       }
+      const finishReady = (worker: { state: string; stage: string }) =>
+        finishReadyWorkerStart({
+          runtime,
+          db,
+          runId: run.id,
+          taskId: task.id,
+          dispatchId: started.dispatch.id,
+          worker,
+          setup: setupReceipt,
+          launch: launch.receipt,
+          timeoutMs: readinessTimeoutMs,
+          effects,
+          warning: deliveryState.warning
+        })
       try {
         if (creationWorktree) {
           failedStage = 'worktree_create'
@@ -195,7 +201,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             effects
           })
           terminalHandle = terminal.handle
-          terminalRevealWarning = terminal.warning
+          deliveryState.warning = terminal.warning
         } else {
           effects.push({
             kind: 'terminal',
@@ -238,7 +244,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           )
         }
         const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
-        workerProcessIncarnation = terminalAuthority.processIncarnation
+        deliveryState.incarnation = terminalAuthority.processIncarnation
         const capability = db.prepareStartingWorkerAuthority({
           dispatchId: started.dispatch.id,
           handle: terminalHandle,
@@ -261,7 +267,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           devMode: params.devMode,
           cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)
         })
-        dispatchInputSubmittedAt = Date.now()
+        deliveryState.submittedAt = Date.now()
         await runtime.sendTerminalAgentPrompt(terminalHandle, preamble)
         effects.push({
           kind: 'dispatch_input',
@@ -270,60 +276,21 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           state: 'accepted'
         })
         const worker = db.markWorkerDispatchReady(started.dispatch.id, effects)
-        monitorWorkerSetup({
+        return finishReady(worker)
+      } catch (error) {
+        const recovered = recoverStalledWorkerPrompt({
+          error,
           runtime,
           db,
-          runId: run.id,
-          dispatchId: started.dispatch.id,
-          setupReceipt,
-          effects
-        })
-        return {
-          runId: run.id,
+          terminalHandle,
           taskId: task.id,
           dispatchId: started.dispatch.id,
-          state: worker.state,
-          stage: worker.stage,
-          setup: setupReceipt,
-          launch: launch.receipt,
-          timeoutMs: readinessTimeoutMs,
-          effects,
-          residualResources: [],
-          ...(terminalRevealWarning ? { warning: terminalRevealWarning } : {})
-        }
-      } catch (error) {
-        if (isAgentPromptStalledError(error) && terminalHandle) {
-          const evidence =
-            workerProcessIncarnation && dispatchInputSubmittedAt
-              ? runtime.getOrchestrationPromptDeliveryEvidence({
-                  terminalHandle,
-                  taskId: task.id,
-                  dispatchId: started.dispatch.id,
-                  processIncarnation: workerProcessIncarnation,
-                  submittedAt: dispatchInputSubmittedAt
-                })
-              : null
-          if (evidence) {
-            effects.push({
-              kind: 'dispatch_input',
-              role: 'agent',
-              id: terminalHandle,
-              state: evidence
-            })
-            const worker = db.markWorkerDispatchReady(started.dispatch.id, effects, evidence)
-            return {
-              runId: run.id,
-              taskId: task.id,
-              dispatchId: started.dispatch.id,
-              state: worker.state,
-              stage: worker.stage,
-              setup: setupReceipt,
-              launch: launch.receipt,
-              timeoutMs: readinessTimeoutMs,
-              effects,
-              residualResources: []
-            }
-          }
+          processIncarnation: deliveryState.incarnation,
+          submittedAt: deliveryState.submittedAt,
+          effects
+        })
+        if (recovered) {
+          return finishReady(recovered)
         }
         return failWorkerStartWithReceipt({
           db,
@@ -339,4 +306,3 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
     }
   })
 ]
-/* eslint-disable max-lines -- Why: worker-start receipt transitions and correlated prompt recovery must remain auditable in one transaction handler. */

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -26,6 +26,7 @@ import {
   isWorkerStartTimeoutWithinTimerLimit,
   resolveWorkerStartReadinessTimeoutMs
 } from '../../../../shared/orchestration-timing-budgets'
+import { isAgentPromptStalledError } from '../../agent-prompt-submission-verification'
 
 export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
   defineMethod({
@@ -148,6 +149,8 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
       }
       let terminalHandle = params.terminal
       let terminalRevealWarning: string | undefined
+      let workerProcessIncarnation: string | undefined
+      let dispatchInputSubmittedAt: number | undefined
       let failedStage = 'terminal_create'
       let setupReceipt: WorkerSetupReceipt = {
         requested: 'not_applicable',
@@ -164,6 +167,8 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             runtime,
             db,
             dispatchId: started.dispatch.id,
+            runId: run.id,
+            taskId: task.id,
             requestedWorktree,
             coordinatorWorktree: creationWorktree,
             params,
@@ -233,6 +238,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           )
         }
         const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
+        workerProcessIncarnation = terminalAuthority.processIncarnation
         const capability = db.prepareStartingWorkerAuthority({
           dispatchId: started.dispatch.id,
           handle: terminalHandle,
@@ -255,6 +261,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           devMode: params.devMode,
           cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)
         })
+        dispatchInputSubmittedAt = Date.now()
         await runtime.sendTerminalAgentPrompt(terminalHandle, preamble)
         effects.push({
           kind: 'dispatch_input',
@@ -285,6 +292,39 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           ...(terminalRevealWarning ? { warning: terminalRevealWarning } : {})
         }
       } catch (error) {
+        if (isAgentPromptStalledError(error) && terminalHandle) {
+          const evidence =
+            workerProcessIncarnation && dispatchInputSubmittedAt
+              ? runtime.getOrchestrationPromptDeliveryEvidence({
+                  terminalHandle,
+                  taskId: task.id,
+                  dispatchId: started.dispatch.id,
+                  processIncarnation: workerProcessIncarnation,
+                  submittedAt: dispatchInputSubmittedAt
+                })
+              : null
+          if (evidence) {
+            effects.push({
+              kind: 'dispatch_input',
+              role: 'agent',
+              id: terminalHandle,
+              state: evidence
+            })
+            const worker = db.markWorkerDispatchReady(started.dispatch.id, effects, evidence)
+            return {
+              runId: run.id,
+              taskId: task.id,
+              dispatchId: started.dispatch.id,
+              state: worker.state,
+              stage: worker.stage,
+              setup: setupReceipt,
+              launch: launch.receipt,
+              timeoutMs: readinessTimeoutMs,
+              effects,
+              residualResources: []
+            }
+          }
+        }
         return failWorkerStartWithReceipt({
           db,
           runId: run.id,
@@ -299,3 +339,4 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
     }
   })
 ]
+/* eslint-disable max-lines -- Why: worker-start receipt transitions and correlated prompt recovery must remain auditable in one transaction handler. */

--- a/src/main/runtime/runtime-managed-worktree-queries.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.test.ts
@@ -51,6 +51,94 @@ function queries(store: RuntimeStore): RuntimeManagedWorktreeQueries {
 }
 
 describe('RuntimeManagedWorktreeQueries.listDetected', () => {
+  it('revalidates a referenced cross-repo parent instead of trusting a warm stale fleet', async () => {
+    const childRepo = { ...folderRepo({ id: 'child-repo', path: '/child' }), kind: 'git' as const }
+    const parentRepo = {
+      ...folderRepo({ id: 'parent-repo', path: '/parent' }),
+      kind: 'git' as const
+    }
+    const childId = 'child-repo::/child/worktree'
+    const parentId = 'parent-repo::/parent/deleted'
+    const childMeta = metadata({ hostId: 'local', instanceId: 'child-instance' })
+    const staleParentMeta = metadata({ hostId: 'local', instanceId: 'parent-instance' })
+    const workspaceLineage = {
+      childWorkspaceKey: `worktree:${childId}`,
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: `worktree:${parentId}`,
+      parentInstanceId: 'parent-instance',
+      origin: 'orchestration' as const,
+      capture: { source: 'orchestration-context' as const, confidence: 'inferred' as const },
+      createdAt: 1
+    }
+    const store = {
+      getRepos: () => [childRepo, parentRepo],
+      getRepo: (id: string) => (id === parentRepo.id ? parentRepo : childRepo),
+      getFolderWorkspaces: () => [],
+      getProjectGroups: () => [],
+      getAllWorktreeMeta: () => ({ [childId]: childMeta, [parentId]: staleParentMeta }),
+      getWorktreeMeta: (id: string) => ({ [childId]: childMeta, [parentId]: staleParentMeta })[id],
+      setWorktreeMeta: vi.fn((_id, updates) => metadata(updates)),
+      getAllWorktreeLineage: () => ({}),
+      getAllWorkspaceLineage: () => ({ [workspaceLineage.childWorkspaceKey]: workspaceLineage }),
+      getSettings: () => settings
+    } as unknown as RuntimeStore
+    const listResolved = vi.fn(
+      async () =>
+        [
+          { id: parentId, repoId: parentRepo.id, hostId: 'local', instanceId: 'parent-instance' }
+        ] as never
+    )
+    let parentScanCacheWarm = true
+    const invalidateRepoScan = vi.fn((repoId: string) => {
+      if (repoId === parentRepo.id) {
+        parentScanCacheWarm = false
+      }
+    })
+    const scanRepo = vi.fn(async (repo: Repo) => ({
+      ok: true as const,
+      worktrees:
+        repo.id === childRepo.id
+          ? [
+              {
+                path: '/child/worktree',
+                head: 'abc',
+                branch: 'feature',
+                isBare: false,
+                isMainWorktree: false
+              }
+            ]
+          : parentScanCacheWarm
+            ? [
+                {
+                  path: '/parent/deleted',
+                  head: 'stale',
+                  branch: 'deleted',
+                  isBare: false,
+                  isMainWorktree: false
+                }
+              ]
+            : []
+    }))
+    const subject = new RuntimeManagedWorktreeQueries({
+      getStore: () => store,
+      listResolved,
+      resolveRepo: async () => childRepo,
+      selectRepos: () => [childRepo],
+      scanRepo,
+      invalidateRepoScan
+    })
+
+    const result = await subject.listDetected(childRepo)
+
+    expect(
+      (result.worktrees[0] as (typeof result.worktrees)[0] & { workspaceLineage: unknown })
+        .workspaceLineage
+    ).toBeNull()
+    expect(scanRepo.mock.calls.map(([repo]) => repo.id)).toEqual(['child-repo', 'parent-repo'])
+    expect(invalidateRepoScan).toHaveBeenCalledExactlyOnceWith('parent-repo')
+    expect(listResolved).not.toHaveBeenCalled()
+  })
+
   it("does not project another host's folder metadata", async () => {
     const local = folderRepo()
     const remote = folderRepo({ connectionId: 'build-box', displayName: 'Remote app' })

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -13,6 +13,7 @@ import {
   toDetectedWorktree
 } from '../../shared/worktree/ownership'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
+import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import {
   createWorktreeVisibilitySourceMatcher,
   resolveCustomWorktreeVisibilitySources,
@@ -158,7 +159,13 @@ export class RuntimeManagedWorktreeQueries {
         worktrees: projectResolvedWorktreeLineage(
           detected,
           store.getAllWorktreeLineage?.() ?? {},
-          store.getAllWorkspaceLineage?.() ?? {}
+          store.getAllWorkspaceLineage?.() ?? {},
+          Object.fromEntries(
+            Object.entries(metaById).map(([id, meta]) => [
+              worktreeWorkspaceKey(id),
+              meta.instanceId
+            ])
+          )
         )
       }
     }
@@ -220,7 +227,10 @@ export class RuntimeManagedWorktreeQueries {
       worktrees: projectResolvedWorktreeLineage(
         detected,
         store.getAllWorktreeLineage?.() ?? {},
-        store.getAllWorkspaceLineage?.() ?? {}
+        store.getAllWorkspaceLineage?.() ?? {},
+        Object.fromEntries(
+          Object.entries(metaById).map(([id, meta]) => [worktreeWorkspaceKey(id), meta.instanceId])
+        )
       )
     }
   }

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -12,8 +12,7 @@ import {
   isLegacyRepoForExternalWorktreeVisibility,
   toDetectedWorktree
 } from '../../shared/worktree/ownership'
-import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
-import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { projectCurrentHostWorktreeLineage } from './runtime-worktree-lineage-projection'
 import {
   createWorktreeVisibilitySourceMatcher,
   resolveCustomWorktreeVisibilitySources,
@@ -31,7 +30,11 @@ import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
 import { listRuntimeFolderWorkspaces } from './runtime-worktree-filesystem'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
 import { resolveConfiguredWorktreeBasePaths } from '../../shared/worktree/configured-worktree-base-path'
-import { getRetiredNameRegistryForRepo } from '../worktree-name-retirement'
+import {
+  listRuntimeRetiredWorktreeNames,
+  buildRuntimeVisibilityMatchers,
+  resolveRuntimeVisibilityDefaults
+} from './runtime-retired-worktree-name-query'
 
 type Dependencies = {
   getStore(): RuntimeStore | null
@@ -134,6 +137,7 @@ export class RuntimeManagedWorktreeQueries {
     const visibilityDefaults = this.visibilityDefaults(sourceDefaultsSupported)
     const visibilitySettings = { ...settings, worktreeVisibilityDefaults: visibilityDefaults }
     if (isFolderRepo(repo)) {
+      const currentFleet = await this.deps.listResolved()
       const worktrees = listRuntimeFolderWorkspaces(store, repo)
       const metaById = store.getAllWorktreeMeta()
       const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
@@ -156,17 +160,12 @@ export class RuntimeManagedWorktreeQueries {
         repoId: repo.id,
         authoritative: true,
         source: 'git',
-        worktrees: projectResolvedWorktreeLineage(
-          detected,
-          store.getAllWorktreeLineage?.() ?? {},
-          store.getAllWorkspaceLineage?.() ?? {},
-          Object.fromEntries(
-            Object.entries(metaById).map(([id, meta]) => [
-              worktreeWorkspaceKey(id),
-              meta.instanceId
-            ])
-          )
-        )
+        worktrees: projectCurrentHostWorktreeLineage({
+          worktrees: detected,
+          currentFleet,
+          store,
+          executionHostId: getRepoExecutionHostId(repo)
+        })
       }
     }
     // Why capture before the scan: listing can mutate metadata synchronously before its first
@@ -220,18 +219,17 @@ export class RuntimeManagedWorktreeQueries {
       )
       return scan.ok ? result : applyMetadataFallbackVisibility(result)
     })
+    const currentFleet = await this.deps.listResolved()
     return {
       repoId: repo.id,
       authoritative: scan.ok,
       source: scan.ok ? 'git' : 'metadata-fallback',
-      worktrees: projectResolvedWorktreeLineage(
-        detected,
-        store.getAllWorktreeLineage?.() ?? {},
-        store.getAllWorkspaceLineage?.() ?? {},
-        Object.fromEntries(
-          Object.entries(metaById).map(([id, meta]) => [worktreeWorkspaceKey(id), meta.instanceId])
-        )
-      )
+      worktrees: projectCurrentHostWorktreeLineage({
+        worktrees: detected,
+        currentFleet,
+        store,
+        executionHostId: expectedHostId
+      })
     }
   }
 
@@ -252,25 +250,12 @@ export class RuntimeManagedWorktreeQueries {
     sourceDefaultsSupported = true,
     providedSettings?: ReturnType<RuntimeStore['getSettings']>
   ): Map<string, WorktreeVisibilitySourceMatcher> {
-    const checkoutPathsByRepoId = new Map<string, string[]>()
-    for (const worktree of worktrees) {
-      const checkoutPaths = checkoutPathsByRepoId.get(worktree.repoId) ?? []
-      checkoutPaths.push(worktree.path)
-      checkoutPathsByRepoId.set(worktree.repoId, checkoutPaths)
-    }
     const visibilityDefaults = this.visibilityDefaults(sourceDefaultsSupported, providedSettings)
-    return new Map(
-      (this.deps.getStore()?.getRepos() ?? [])
-        .filter((repo) => checkoutPathsByRepoId.has(repo.id))
-        .map((repo) => [
-          repo.id,
-          createWorktreeVisibilitySourceMatcher(
-            [repo.path, ...(checkoutPathsByRepoId.get(repo.id) ?? [])],
-            resolveCustomWorktreeVisibilitySources(repo, visibilityDefaults),
-            resolveConfiguredWorktreeBasePaths(repo)
-          )
-        ])
-    )
+    return buildRuntimeVisibilityMatchers({
+      store: this.deps.getStore(),
+      worktrees,
+      visibilityDefaults
+    })
   }
 
   private toDetected(
@@ -310,33 +295,21 @@ export class RuntimeManagedWorktreeQueries {
     retiredNamesByRepo: Record<string, readonly string[]>
     retiredNameTiersByRepo: Record<string, number>
   }> {
-    const store = this.deps.getStore()
-    if (!store?.getRetiredWorktreeNameRegistry || !store.mergeRetiredWorktreeNames) {
-      return { retiredNamesByRepo: {}, retiredNameTiersByRepo: {} }
-    }
-    const repo = await this.deps.resolveRepo(repoSelector)
-    const settings = store.getSettings()
-    const registry = await getRetiredNameRegistryForRepo(
-      store as never,
-      repo,
-      store.getRepos(),
-      settings
+    return listRuntimeRetiredWorktreeNames(
+      this.deps.getStore(),
+      this.deps.resolveRepo,
+      repoSelector
     )
-    return {
-      retiredNamesByRepo: { [repo.id]: registry.names },
-      retiredNameTiersByRepo: { [repo.id]: registry.exhaustedTiers }
-    }
   }
 
   private visibilityDefaults(
     sourceDefaultsSupported: boolean,
     providedSettings?: ReturnType<RuntimeStore['getSettings']>
   ) {
-    const defaults =
-      providedSettings !== undefined
-        ? providedSettings.worktreeVisibilityDefaults
-        : this.deps.getStore()?.getSettings().worktreeVisibilityDefaults
-    return sourceDefaultsSupported || !defaults ? defaults : { external: defaults.external }
+    return resolveRuntimeVisibilityDefaults(
+      this.deps.getStore(),
+      sourceDefaultsSupported,
+      providedSettings
+    )
   }
 }
-/* eslint-disable max-lines -- Why: the authoritative and fallback managed-worktree query paths must share one projection boundary; splitting them would risk lineage drift. */

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -155,7 +155,11 @@ export class RuntimeManagedWorktreeQueries {
         repoId: repo.id,
         authoritative: true,
         source: 'git',
-        worktrees: projectResolvedWorktreeLineage(detected, store.getAllWorktreeLineage?.() ?? {})
+        worktrees: projectResolvedWorktreeLineage(
+          detected,
+          store.getAllWorktreeLineage?.() ?? {},
+          store.getAllWorkspaceLineage?.() ?? {}
+        )
       }
     }
     // Why capture before the scan: listing can mutate metadata synchronously before its first
@@ -213,7 +217,11 @@ export class RuntimeManagedWorktreeQueries {
       repoId: repo.id,
       authoritative: scan.ok,
       source: scan.ok ? 'git' : 'metadata-fallback',
-      worktrees: projectResolvedWorktreeLineage(detected, store.getAllWorktreeLineage?.() ?? {})
+      worktrees: projectResolvedWorktreeLineage(
+        detected,
+        store.getAllWorktreeLineage?.() ?? {},
+        store.getAllWorkspaceLineage?.() ?? {}
+      )
     }
   }
 
@@ -321,3 +329,4 @@ export class RuntimeManagedWorktreeQueries {
     return sourceDefaultsSupported || !defaults ? defaults : { external: defaults.external }
   }
 }
+/* eslint-disable max-lines -- Why: the authoritative and fallback managed-worktree query paths must share one projection boundary; splitting them would risk lineage drift. */

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -12,7 +12,7 @@ import {
   isLegacyRepoForExternalWorktreeVisibility,
   toDetectedWorktree
 } from '../../shared/worktree/ownership'
-import { projectCurrentHostWorktreeLineage } from './runtime-worktree-lineage-projection'
+import { projectWithCurrentReferencedParents } from './runtime-worktree-lineage-projection'
 import {
   createWorktreeVisibilitySourceMatcher,
   resolveCustomWorktreeVisibilitySources,
@@ -42,6 +42,7 @@ type Dependencies = {
   resolveRepo(selector: string): Promise<Repo>
   selectRepos(selector: string): Repo[]
   scanRepo(repo: Repo): Promise<RuntimeWorktreeScanResult>
+  invalidateRepoScan?(repoId: string): void
 }
 
 /**
@@ -137,7 +138,6 @@ export class RuntimeManagedWorktreeQueries {
     const visibilityDefaults = this.visibilityDefaults(sourceDefaultsSupported)
     const visibilitySettings = { ...settings, worktreeVisibilityDefaults: visibilityDefaults }
     if (isFolderRepo(repo)) {
-      const currentFleet = await this.deps.listResolved()
       const worktrees = listRuntimeFolderWorkspaces(store, repo)
       const metaById = store.getAllWorktreeMeta()
       const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
@@ -160,11 +160,13 @@ export class RuntimeManagedWorktreeQueries {
         repoId: repo.id,
         authoritative: true,
         source: 'git',
-        worktrees: projectCurrentHostWorktreeLineage({
+        worktrees: await projectWithCurrentReferencedParents({
           worktrees: detected,
-          currentFleet,
+          childRepoId: repo.id,
           store,
-          executionHostId: getRepoExecutionHostId(repo)
+          executionHostId: getRepoExecutionHostId(repo),
+          scanRepo: this.deps.scanRepo,
+          invalidateRepoScan: this.deps.invalidateRepoScan
         })
       }
     }
@@ -219,16 +221,17 @@ export class RuntimeManagedWorktreeQueries {
       )
       return scan.ok ? result : applyMetadataFallbackVisibility(result)
     })
-    const currentFleet = await this.deps.listResolved()
     return {
       repoId: repo.id,
       authoritative: scan.ok,
       source: scan.ok ? 'git' : 'metadata-fallback',
-      worktrees: projectCurrentHostWorktreeLineage({
+      worktrees: await projectWithCurrentReferencedParents({
         worktrees: detected,
-        currentFleet,
+        childRepoId: repo.id,
         store,
-        executionHostId: expectedHostId
+        executionHostId: expectedHostId,
+        scanRepo: this.deps.scanRepo,
+        invalidateRepoScan: this.deps.invalidateRepoScan
       })
     }
   }

--- a/src/main/runtime/runtime-retired-worktree-name-query.ts
+++ b/src/main/runtime/runtime-retired-worktree-name-query.ts
@@ -1,0 +1,71 @@
+import { getRetiredNameRegistryForRepo } from '../worktree-name-retirement'
+import type { RuntimeStore } from './runtime-store-contract'
+import type { Worktree } from '../../shared/worktree/types'
+import {
+  createWorktreeVisibilitySourceMatcher,
+  resolveCustomWorktreeVisibilitySources
+} from '../../shared/worktree/visibility-sources'
+import { resolveConfiguredWorktreeBasePaths } from '../../shared/worktree/configured-worktree-base-path'
+
+/** Build visibility matchers only for repositories represented in the resolved result. */
+export function buildRuntimeVisibilityMatchers(args: {
+  store: RuntimeStore | null
+  worktrees: readonly Worktree[]
+  visibilityDefaults: ReturnType<RuntimeStore['getSettings']>['worktreeVisibilityDefaults']
+}) {
+  const pathsByRepo = new Map<string, string[]>()
+  for (const worktree of args.worktrees) {
+    const paths = pathsByRepo.get(worktree.repoId) ?? []
+    paths.push(worktree.path)
+    pathsByRepo.set(worktree.repoId, paths)
+  }
+  return new Map(
+    (args.store?.getRepos() ?? [])
+      .filter((repo) => pathsByRepo.has(repo.id))
+      .map((repo) => [
+        repo.id,
+        createWorktreeVisibilitySourceMatcher(
+          [repo.path, ...(pathsByRepo.get(repo.id) ?? [])],
+          resolveCustomWorktreeVisibilitySources(repo, args.visibilityDefaults),
+          resolveConfiguredWorktreeBasePaths(repo)
+        )
+      ])
+  )
+}
+
+/** Respect clients that predate source-specific worktree visibility defaults. */
+export function resolveRuntimeVisibilityDefaults(
+  store: RuntimeStore | null,
+  sourceDefaultsSupported: boolean,
+  providedSettings?: ReturnType<RuntimeStore['getSettings']>
+) {
+  const defaults =
+    providedSettings?.worktreeVisibilityDefaults ?? store?.getSettings().worktreeVisibilityDefaults
+  return sourceDefaultsSupported || !defaults ? defaults : { external: defaults.external }
+}
+
+/** Resolve the retired-name registry without expanding the managed-worktree query coordinator. */
+export async function listRuntimeRetiredWorktreeNames(
+  store: RuntimeStore | null,
+  resolveRepo: (selector: string) => Promise<{ id: string }>,
+  repoSelector: string
+): Promise<{
+  retiredNamesByRepo: Record<string, readonly string[]>
+  retiredNameTiersByRepo: Record<string, number>
+}> {
+  if (!store?.getRetiredWorktreeNameRegistry || !store.mergeRetiredWorktreeNames) {
+    return { retiredNamesByRepo: {}, retiredNameTiersByRepo: {} }
+  }
+  const repo = await resolveRepo(repoSelector)
+  const settings = store.getSettings()
+  const registry = await getRetiredNameRegistryForRepo(
+    store as never,
+    repo as never,
+    store.getRepos(),
+    settings
+  )
+  return {
+    retiredNamesByRepo: { [repo.id]: registry.names },
+    retiredNameTiersByRepo: { [repo.id]: registry.exhaustedTiers }
+  }
+}

--- a/src/main/runtime/runtime-worktree-lineage-projection.test.ts
+++ b/src/main/runtime/runtime-worktree-lineage-projection.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import { projectCurrentHostWorktreeLineage } from './runtime-worktree-lineage-projection'
+import type { WorkspaceLineage } from '../../shared/worktree/lineage-types'
+import type { Worktree } from '../../shared/worktree/types'
+
+const child = {
+  id: 'target::/child',
+  repoId: 'target',
+  hostId: 'local',
+  instanceId: 'child-instance'
+} as Worktree
+const parentId = 'source::/deleted-parent'
+const ancestry: WorkspaceLineage = {
+  childWorkspaceKey: `worktree:${child.id}`,
+  childInstanceId: child.instanceId,
+  parentWorkspaceKey: `worktree:${parentId}`,
+  parentInstanceId: 'stale-parent-instance',
+  origin: 'orchestration',
+  capture: { source: 'orchestration-context', confidence: 'inferred' },
+  createdAt: 1
+}
+
+function store() {
+  const metadata = {
+    [child.id]: { hostId: 'local', instanceId: child.instanceId },
+    [parentId]: { hostId: 'local', instanceId: 'stale-parent-instance' }
+  }
+  return {
+    getRepos: () => [
+      { id: 'target', path: '/target', executionHostId: 'local' },
+      { id: 'source', path: '/source', executionHostId: 'local' }
+    ],
+    getFolderWorkspaces: () => [],
+    getProjectGroups: () => [],
+    getWorktreeMeta: (id: string) => metadata[id as keyof typeof metadata],
+    getAllWorktreeLineage: () => ({}),
+    getAllWorkspaceLineage: () => ({ [ancestry.childWorkspaceKey]: ancestry })
+  }
+}
+
+describe('current-host worktree lineage projection', () => {
+  it('rejects stale parent metadata when the current parent repository scan has no row', () => {
+    const [projected] = projectCurrentHostWorktreeLineage({
+      worktrees: [child],
+      currentFleet: [child],
+      store: store() as never,
+      executionHostId: 'local'
+    })
+
+    expect(projected.workspaceLineage).toBeNull()
+  })
+
+  it('accepts ancestry when the current parent repository row proves the same instance', () => {
+    const [projected] = projectCurrentHostWorktreeLineage({
+      worktrees: [child],
+      currentFleet: [
+        child,
+        {
+          id: parentId,
+          repoId: 'source',
+          hostId: 'local',
+          instanceId: 'stale-parent-instance'
+        } as Worktree
+      ],
+      store: store() as never,
+      executionHostId: 'local'
+    })
+
+    expect(projected.workspaceLineage).toEqual(ancestry)
+  })
+})

--- a/src/main/runtime/runtime-worktree-lineage-projection.test.ts
+++ b/src/main/runtime/runtime-worktree-lineage-projection.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { projectCurrentHostWorktreeLineage } from './runtime-worktree-lineage-projection'
+import {
+  projectCurrentHostWorktreeLineage,
+  projectWithCurrentReferencedParents
+} from './runtime-worktree-lineage-projection'
 import type { WorkspaceLineage } from '../../shared/worktree/lineage-types'
 import type { Worktree } from '../../shared/worktree/types'
 
@@ -67,5 +70,20 @@ describe('current-host worktree lineage projection', () => {
     })
 
     expect(projected.workspaceLineage).toEqual(ancestry)
+  })
+
+  it('keeps the child usable and removes stale lineage when the parent scan rejects', async () => {
+    const [projected] = await projectWithCurrentReferencedParents({
+      worktrees: [child],
+      childRepoId: child.repoId,
+      executionHostId: 'local',
+      store: store() as never,
+      scanRepo: async () => {
+        throw new Error('parent host unavailable')
+      }
+    })
+
+    expect(projected.id).toBe(child.id)
+    expect(projected.workspaceLineage).toBeNull()
   })
 })

--- a/src/main/runtime/runtime-worktree-lineage-projection.ts
+++ b/src/main/runtime/runtime-worktree-lineage-projection.ts
@@ -1,0 +1,43 @@
+import { filterLineageForHost } from '../ipc/worktrees/metadata/workspace-lineage-filtering'
+import type { Store } from '../persistence'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
+import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import type { Worktree } from '../../shared/worktree/types'
+import type { RuntimeStore } from './runtime-store-contract'
+
+/** Project lineage using host-owned edges and live scan rows, never stale metadata instances. */
+export function projectCurrentHostWorktreeLineage<T extends Worktree>(args: {
+  worktrees: readonly T[]
+  currentFleet: readonly Worktree[]
+  store: RuntimeStore
+  executionHostId: ExecutionHostId
+}) {
+  const filterStore = args.store as unknown as Store
+  const lineage =
+    typeof filterStore.getFolderWorkspaces === 'function' &&
+    typeof filterStore.getProjectGroups === 'function'
+      ? filterLineageForHost(filterStore, args.executionHostId)
+      : {
+          worktreeLineageById: args.store.getAllWorktreeLineage?.() ?? {},
+          workspaceLineageByChildKey: args.store.getAllWorkspaceLineage?.() ?? {}
+        }
+  if (!lineage) {
+    return projectResolvedWorktreeLineage(args.worktrees, {}, {})
+  }
+  const currentInstances = args.currentFleet.reduce<Record<string, (string | undefined)[]>>(
+    (instances, worktree) => {
+      if (worktree.hostId === args.executionHostId) {
+        ;(instances[worktreeWorkspaceKey(worktree.id)] ??= []).push(worktree.instanceId)
+      }
+      return instances
+    },
+    {}
+  )
+  return projectResolvedWorktreeLineage(
+    args.worktrees,
+    lineage.worktreeLineageById,
+    lineage.workspaceLineageByChildKey,
+    currentInstances
+  )
+}

--- a/src/main/runtime/runtime-worktree-lineage-projection.ts
+++ b/src/main/runtime/runtime-worktree-lineage-projection.ts
@@ -45,7 +45,11 @@ export async function scanCurrentReferencedParentWorktrees(args: {
   const scanned = await Promise.all(
     parents.map(async (repo) => {
       args.invalidateRepoScan?.(repo.id)
-      return { repo, scan: await args.scanRepo(repo) }
+      try {
+        return { repo, scan: await args.scanRepo(repo) }
+      } catch {
+        return { repo, scan: { ok: false as const, worktrees: [] } }
+      }
     })
   )
   return scanned.flatMap(({ repo, scan }) =>

--- a/src/main/runtime/runtime-worktree-lineage-projection.ts
+++ b/src/main/runtime/runtime-worktree-lineage-projection.ts
@@ -1,10 +1,97 @@
 import { filterLineageForHost } from '../ipc/worktrees/metadata/workspace-lineage-filtering'
 import type { Store } from '../persistence'
-import type { ExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
 import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { parseWorkspaceKey } from '../../shared/workspace-scope'
+import { splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
+import type { Repo } from '../../shared/repo-types'
 import type { Worktree } from '../../shared/worktree/types'
 import type { RuntimeStore } from './runtime-store-contract'
+import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
+import { readWorktreeMetaForHost } from '../persistence/host-qualified-worktree-meta'
+
+/** Scan only cross-repository parents referenced by these children, bypassing warm fleet caches. */
+export async function scanCurrentReferencedParentWorktrees(args: {
+  children: readonly Worktree[]
+  childRepoId: string
+  executionHostId: ExecutionHostId
+  store: RuntimeStore
+  scanRepo(repo: Repo): Promise<RuntimeWorktreeScanResult>
+  invalidateRepoScan?(repoId: string): void
+}): Promise<Worktree[]> {
+  const lineage = args.store.getAllWorkspaceLineage?.() ?? {}
+  const parentRepoIds = new Set<string>()
+  for (const child of args.children) {
+    const parent = parseWorkspaceKey(
+      lineage[worktreeWorkspaceKey(child.id)]?.parentWorkspaceKey ?? ''
+    )
+    if (parent?.type !== 'worktree') {
+      continue
+    }
+    const parentId = splitWorktreeIdForFilesystem(parent.worktreeId)
+    if (parentId?.repoId && parentId.repoId !== args.childRepoId) {
+      parentRepoIds.add(parentId.repoId)
+    }
+  }
+  const parents = args.store
+    .getRepos()
+    .filter(
+      (repo) =>
+        parentRepoIds.has(repo.id) &&
+        repo.id !== args.childRepoId &&
+        getRepoExecutionHostId(repo) === args.executionHostId
+    )
+  const scanned = await Promise.all(
+    parents.map(async (repo) => {
+      args.invalidateRepoScan?.(repo.id)
+      return { repo, scan: await args.scanRepo(repo) }
+    })
+  )
+  return scanned.flatMap(({ repo, scan }) =>
+    scan.ok
+      ? scan.worktrees.map((worktree) => {
+          const id = `${repo.id}::${worktree.path}`
+          const meta = readWorktreeMetaForHost(
+            args.store as unknown as Store,
+            id,
+            args.executionHostId
+          )
+          return {
+            id,
+            repoId: repo.id,
+            hostId: args.executionHostId,
+            instanceId: meta?.instanceId
+          } as Worktree
+        })
+      : []
+  )
+}
+
+/** Revalidate referenced parents and project lineage as one authoritative query operation. */
+export async function projectWithCurrentReferencedParents<T extends Worktree>(args: {
+  worktrees: readonly T[]
+  childRepoId: string
+  executionHostId: ExecutionHostId
+  store: RuntimeStore
+  scanRepo(repo: Repo): Promise<RuntimeWorktreeScanResult>
+  invalidateRepoScan?(repoId: string): void
+}) {
+  const parents = await scanCurrentReferencedParentWorktrees({
+    children: args.worktrees,
+    childRepoId: args.childRepoId,
+    executionHostId: args.executionHostId,
+    store: args.store,
+    scanRepo: args.scanRepo,
+    invalidateRepoScan: args.invalidateRepoScan
+  })
+  return projectCurrentHostWorktreeLineage({
+    worktrees: args.worktrees,
+    currentFleet: [...args.worktrees, ...parents],
+    store: args.store,
+    executionHostId: args.executionHostId
+  })
+}
 
 /** Project lineage using host-owned edges and live scan rows, never stale metadata instances. */
 export function projectCurrentHostWorktreeLineage<T extends Worktree>(args: {

--- a/src/main/runtime/runtime-worktree-lineage-recording.test.ts
+++ b/src/main/runtime/runtime-worktree-lineage-recording.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { recordCreatedWorktreeLineage } from './runtime-worktree-lineage-recording'
+
+describe('recordCreatedWorktreeLineage orchestration ancestry', () => {
+  it('persists a cross-repo spawn only as workspace lineage', () => {
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn((lineage) => lineage)
+
+    const result = recordCreatedWorktreeLineage(
+      { setWorktreeLineage, setWorkspaceLineage } as never,
+      { id: 'target::/child', instanceId: 'child-instance' },
+      {
+        kind: 'lineage',
+        parent: {
+          type: 'worktree',
+          workspaceKey: worktreeWorkspaceKey('source::/parent'),
+          worktree: { id: 'source::/parent' },
+          instanceId: 'parent-instance'
+        },
+        origin: 'orchestration',
+        capture: { source: 'orchestration-context', confidence: 'inferred' },
+        orchestrationRunId: 'run_1',
+        taskId: 'task_1',
+        coordinatorHandle: 'term_coord',
+        createdByTerminalHandle: 'term_coord'
+      }
+    )
+
+    expect(setWorktreeLineage).not.toHaveBeenCalled()
+    expect(result.lineage).toBeNull()
+    expect(result.workspaceLineage).toMatchObject({
+      childWorkspaceKey: worktreeWorkspaceKey('target::/child'),
+      parentWorkspaceKey: worktreeWorkspaceKey('source::/parent'),
+      origin: 'orchestration',
+      taskId: 'task_1',
+      orchestrationRunId: 'run_1'
+    })
+  })
+})

--- a/src/main/runtime/runtime-worktree-lineage-recording.ts
+++ b/src/main/runtime/runtime-worktree-lineage-recording.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceLineage
 } from '../../shared/worktree/lineage-types'
 import { worktreeWorkspaceKey } from '../../shared/workspace-scope'
+import { splitWorktreeId } from '../../shared/worktree/id'
 import type { RuntimeStore } from './runtime-store-contract'
 
 type LineageParent =
@@ -54,8 +55,14 @@ export function recordCreatedWorktreeLineage(
   const childInstanceId = worktree.instanceId
   const parentInstanceId = resolution.parent.instanceId
   const createdAt = Date.now()
+  const sharesRepository =
+    resolution.parent.type === 'worktree'
+      ? splitWorktreeId(worktree.id)?.repoId ===
+        splitWorktreeId(resolution.parent.worktree.id)?.repoId
+      : false
   if (
     resolution.parent.type === 'worktree' &&
+    sharesRepository &&
     childInstanceId &&
     parentInstanceId &&
     store?.setWorktreeLineage
@@ -77,7 +84,7 @@ export function recordCreatedWorktreeLineage(
         : {}),
       createdAt
     })
-  } else if (resolution.parent.type === 'worktree') {
+  } else if (sharesRepository) {
     warnings.push({
       code: 'LINEAGE_PARENT_CONTEXT_MISSING',
       message:

--- a/src/shared/orchestration-prompt-marker.ts
+++ b/src/shared/orchestration-prompt-marker.ts
@@ -1,0 +1,5 @@
+const ORCHESTRATION_PROMPT_MARKER_PREFIX = '[orca-dispatch-prompt:'
+
+export function buildOrchestrationPromptMarker(taskId: string, dispatchId: string): string {
+  return `${ORCHESTRATION_PROMPT_MARKER_PREFIX}${taskId}:${dispatchId}]`
+}

--- a/src/shared/resolved-worktree-lineage.test.ts
+++ b/src/shared/resolved-worktree-lineage.test.ts
@@ -110,7 +110,8 @@ describe('projectResolvedWorktreeLineage', () => {
     const [projected] = projectResolvedWorktreeLineage(
       [crossRepoChild],
       {},
-      { [spawnLineage.childWorkspaceKey]: spawnLineage }
+      { [spawnLineage.childWorkspaceKey]: spawnLineage },
+      { [spawnLineage.parentWorkspaceKey]: 'parent-instance' }
     )
 
     expect(projected).toMatchObject({
@@ -118,6 +119,33 @@ describe('projectResolvedWorktreeLineage', () => {
       lineage: null,
       workspaceLineage: spawnLineage
     })
+  })
+
+  it('rejects cross-repo ancestry after the parent instance is recreated', () => {
+    const crossRepoChild = worktree('target::child', 'child-instance', { repoId: 'target' })
+    const childKey = worktreeWorkspaceKey(crossRepoChild.id)
+    const parentKey = worktreeWorkspaceKey('source::parent')
+    const [projected] = projectResolvedWorktreeLineage(
+      [crossRepoChild],
+      {},
+      {
+        [childKey]: {
+          childWorkspaceKey: childKey,
+          childInstanceId: 'child-instance',
+          parentWorkspaceKey: parentKey,
+          parentInstanceId: 'deleted-parent-instance',
+          origin: 'orchestration' as const,
+          capture: {
+            source: 'orchestration-context' as const,
+            confidence: 'inferred' as const
+          },
+          createdAt: 1
+        }
+      },
+      { [parentKey]: 'recreated-parent-instance' }
+    )
+
+    expect(projected.workspaceLineage).toBeNull()
   })
 
   it.each([

--- a/src/shared/resolved-worktree-lineage.test.ts
+++ b/src/shared/resolved-worktree-lineage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { join } from 'node:path'
 import type { WorktreeLineage } from './worktree/lineage-types'
+import { worktreeWorkspaceKey } from './workspace-scope'
 import type { Worktree } from './worktree/types'
 import type { WorktreeLineageBoundary } from './resolved-worktree-lineage'
 import {
@@ -91,6 +92,32 @@ describe('projectResolvedWorktreeLineage', () => {
       { id: 'child', parentWorktreeId: 'parent', childWorktreeIds: [], lineage: lineage() },
       { id: 'parent', parentWorktreeId: null, childWorktreeIds: ['child'], lineage: null }
     ])
+  })
+
+  it('projects cross-repo orchestration ancestry without creating ordinary nesting', () => {
+    const crossRepoChild = worktree('target::child', 'child-instance', { repoId: 'target' })
+    const spawnLineage = {
+      childWorkspaceKey: worktreeWorkspaceKey(crossRepoChild.id),
+      childInstanceId: crossRepoChild.instanceId,
+      parentWorkspaceKey: worktreeWorkspaceKey('source::parent'),
+      parentInstanceId: 'parent-instance',
+      origin: 'orchestration' as const,
+      capture: { source: 'orchestration-context' as const, confidence: 'inferred' as const },
+      taskId: 'task_1',
+      createdAt: 1
+    }
+
+    const [projected] = projectResolvedWorktreeLineage(
+      [crossRepoChild],
+      {},
+      { [spawnLineage.childWorkspaceKey]: spawnLineage }
+    )
+
+    expect(projected).toMatchObject({
+      parentWorktreeId: null,
+      lineage: null,
+      workspaceLineage: spawnLineage
+    })
   })
 
   it.each([

--- a/src/shared/resolved-worktree-lineage.test.ts
+++ b/src/shared/resolved-worktree-lineage.test.ts
@@ -148,6 +148,29 @@ describe('projectResolvedWorktreeLineage', () => {
     expect(projected.workspaceLineage).toBeNull()
   })
 
+  it('accepts the matching parent instance when the workspace key exists on multiple hosts', () => {
+    const crossRepoChild = worktree('target::child', 'child-instance', { repoId: 'target' })
+    const childKey = worktreeWorkspaceKey(crossRepoChild.id)
+    const parentKey = worktreeWorkspaceKey('source::parent')
+    const spawnLineage = {
+      childWorkspaceKey: childKey,
+      childInstanceId: 'child-instance',
+      parentWorkspaceKey: parentKey,
+      parentInstanceId: 'parent-on-first-host',
+      origin: 'orchestration' as const,
+      capture: { source: 'orchestration-context' as const, confidence: 'inferred' as const },
+      createdAt: 1
+    }
+    const [projected] = projectResolvedWorktreeLineage(
+      [crossRepoChild],
+      {},
+      { [childKey]: spawnLineage },
+      { [parentKey]: ['parent-on-first-host', 'parent-on-second-host'] }
+    )
+
+    expect(projected.workspaceLineage).toEqual(spawnLineage)
+  })
+
   it.each([
     ['stale child instance', lineage({ worktreeInstanceId: 'old-child' })],
     ['stale parent instance', lineage({ parentWorktreeInstanceId: 'old-parent' })],

--- a/src/shared/resolved-worktree-lineage.ts
+++ b/src/shared/resolved-worktree-lineage.ts
@@ -1,10 +1,13 @@
-import type { WorktreeLineage } from './worktree/lineage-types'
+import type { WorkspaceKey } from './folder-workspace-types'
+import type { WorkspaceLineage, WorktreeLineage } from './worktree/lineage-types'
+import { worktreeWorkspaceKey } from './workspace-scope'
 import type { Worktree } from './worktree/types'
 
 export type WorktreeWithResolvedLineage<T extends Worktree = Worktree> = T & {
   parentWorktreeId: string | null
   childWorktreeIds: string[]
   lineage: WorktreeLineage | null
+  workspaceLineage?: WorkspaceLineage | null
 }
 
 /** The fields a lineage edge is scoped by. Split out so create-time callers — which have a
@@ -78,7 +81,8 @@ export function getCyclicWorktreeLineageChildIds(
 
 export function projectResolvedWorktreeLineage<T extends Worktree>(
   worktrees: readonly T[],
-  lineageById: Readonly<Record<string, WorktreeLineage>>
+  lineageById: Readonly<Record<string, WorktreeLineage>>,
+  workspaceLineageByChildKey: Readonly<Record<WorkspaceKey, WorkspaceLineage>> = {}
 ): WorktreeWithResolvedLineage<T>[] {
   const worktreeById = new Map(worktrees.map((worktree) => [worktree.id, worktree]))
   const validLineageByChildId = new Map<string, WorktreeLineage>()
@@ -110,11 +114,19 @@ export function projectResolvedWorktreeLineage<T extends Worktree>(
 
   return worktrees.map((worktree) => {
     const lineage = validLineageByChildId.get(worktree.id) ?? null
+    const workspaceLineage = workspaceLineageByChildKey[worktreeWorkspaceKey(worktree.id)]
+    const validWorkspaceLineage =
+      workspaceLineage &&
+      (workspaceLineage.childInstanceId == null ||
+        workspaceLineage.childInstanceId === worktree.instanceId)
+        ? workspaceLineage
+        : null
     return {
       ...worktree,
       parentWorktreeId: lineage?.parentWorktreeId ?? null,
       childWorktreeIds: childIdsByParentId.get(worktree.id) ?? [],
-      lineage
+      lineage,
+      workspaceLineage: validWorkspaceLineage
     }
   })
 }

--- a/src/shared/resolved-worktree-lineage.ts
+++ b/src/shared/resolved-worktree-lineage.ts
@@ -83,14 +83,26 @@ export function projectResolvedWorktreeLineage<T extends Worktree>(
   worktrees: readonly T[],
   lineageById: Readonly<Record<string, WorktreeLineage>>,
   workspaceLineageByChildKey: Readonly<Record<WorkspaceKey, WorkspaceLineage>> = {},
-  externalWorkspaceInstances: Readonly<Record<WorkspaceKey, string | undefined>> = {}
+  externalWorkspaceInstances: Readonly<
+    Record<WorkspaceKey, string | readonly (string | undefined)[] | undefined>
+  > = {}
 ): WorktreeWithResolvedLineage<T>[] {
   const worktreeById = new Map(worktrees.map((worktree) => [worktree.id, worktree]))
-  const workspaceInstances = new Map<WorkspaceKey, string | undefined>(
-    Object.entries(externalWorkspaceInstances) as [WorkspaceKey, string | undefined][]
-  )
+  const workspaceInstances = new Map<WorkspaceKey, Set<string>>()
+  for (const [workspaceKey, values] of Object.entries(externalWorkspaceInstances)) {
+    const instances = Array.isArray(values) ? values : [values]
+    workspaceInstances.set(
+      workspaceKey as WorkspaceKey,
+      new Set(instances.filter((instance): instance is string => Boolean(instance)))
+    )
+  }
   for (const worktree of worktrees) {
-    workspaceInstances.set(worktreeWorkspaceKey(worktree.id), worktree.instanceId)
+    if (worktree.instanceId) {
+      const key = worktreeWorkspaceKey(worktree.id)
+      const instances = workspaceInstances.get(key) ?? new Set<string>()
+      instances.add(worktree.instanceId)
+      workspaceInstances.set(key, instances)
+    }
   }
   const validLineageByChildId = new Map<string, WorktreeLineage>()
   const childIdsByParentId = new Map<string, string[]>()
@@ -127,8 +139,9 @@ export function projectResolvedWorktreeLineage<T extends Worktree>(
       (workspaceLineage.childInstanceId == null ||
         workspaceLineage.childInstanceId === worktree.instanceId) &&
       (workspaceLineage.parentInstanceId == null ||
-        workspaceInstances.get(workspaceLineage.parentWorkspaceKey) ===
-          workspaceLineage.parentInstanceId)
+        workspaceInstances
+          .get(workspaceLineage.parentWorkspaceKey)
+          ?.has(workspaceLineage.parentInstanceId) === true)
         ? workspaceLineage
         : null
     return {

--- a/src/shared/resolved-worktree-lineage.ts
+++ b/src/shared/resolved-worktree-lineage.ts
@@ -82,9 +82,16 @@ export function getCyclicWorktreeLineageChildIds(
 export function projectResolvedWorktreeLineage<T extends Worktree>(
   worktrees: readonly T[],
   lineageById: Readonly<Record<string, WorktreeLineage>>,
-  workspaceLineageByChildKey: Readonly<Record<WorkspaceKey, WorkspaceLineage>> = {}
+  workspaceLineageByChildKey: Readonly<Record<WorkspaceKey, WorkspaceLineage>> = {},
+  externalWorkspaceInstances: Readonly<Record<WorkspaceKey, string | undefined>> = {}
 ): WorktreeWithResolvedLineage<T>[] {
   const worktreeById = new Map(worktrees.map((worktree) => [worktree.id, worktree]))
+  const workspaceInstances = new Map<WorkspaceKey, string | undefined>(
+    Object.entries(externalWorkspaceInstances) as [WorkspaceKey, string | undefined][]
+  )
+  for (const worktree of worktrees) {
+    workspaceInstances.set(worktreeWorkspaceKey(worktree.id), worktree.instanceId)
+  }
   const validLineageByChildId = new Map<string, WorktreeLineage>()
   const childIdsByParentId = new Map<string, string[]>()
 
@@ -118,7 +125,10 @@ export function projectResolvedWorktreeLineage<T extends Worktree>(
     const validWorkspaceLineage =
       workspaceLineage &&
       (workspaceLineage.childInstanceId == null ||
-        workspaceLineage.childInstanceId === worktree.instanceId)
+        workspaceLineage.childInstanceId === worktree.instanceId) &&
+      (workspaceLineage.parentInstanceId == null ||
+        workspaceInstances.get(workspaceLineage.parentWorkspaceKey) ===
+          workspaceLineage.parentInstanceId)
         ? workspaceLineage
         : null
     return {


### PR DESCRIPTION
## ELI5

When an Orca worker creates another worker, the child now remembers the exact live worktree that spawned it. If prompt submission reports a stall but Orca can prove the prompt arrived, startup resumes through the normal monitoring path instead of falsely failing or skipping setup state.

## What Changed

- Preserve and project provider-neutral workspace ancestry for same- and cross-repository child worktrees.
- Reload authoritative ancestry before reporting a child as created, with a typed residual-resource failure when linkage is missing.
- Reject stale parent links using current, host-scoped worktree instance evidence.
- Reconcile `agent_prompt_stalled` only from exact task/dispatch, post-submit, same-incarnation evidence.
- Route recovered delivery through the common setup-monitoring and warning finalization path.
- Split the touched runtime modules structurally, without adding `max-lines` suppressions.

## Why

Nested orchestration must anchor a spawned worker to the spawner's worktree, not an unrelated repository root or a deleted/recreated parent instance. Delivery recovery must also preserve the same observable setup lifecycle as an ordinary successful prompt submission.

## Linked Issue

External OpenLoop tracking: `openloop-i0lrpa.3083` and `openloop-pt8pm6.3004.3028.3011`.

No upstream GitHub issue was created; this PR is the upstream submission for the externally tracked defects.

## Visual Proof

N/A — runtime orchestration, lineage persistence, and recovery behavior only; no UI layout or visual styling changes.

## Testing

- [x] I manually tested these changes locally on macOS through focused runtime test execution.
- [x] Automated tests added/updated.

Commands run:

- `pnpm vitest run src/main/runtime/runtime-worktree-lineage-projection.test.ts src/main/runtime/rpc/methods/orchestration-worker-ancestry.test.ts src/main/runtime/rpc/methods/orchestration-worker-prompt-recovery.test.ts src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts` — 26 passed.
- Canonical aggregate runtime harness for lineage update/boundary cases — 6 passed.
- `pnpm tc:node` — passed.
- `pnpm check:max-lines-ratchet` — passed.
- Pre-commit oxlint, React Doctor lint, and formatting hooks — passed.

Remote SSH and multi-host behavior are covered by unit tests; no live Windows, Linux, or SSH host was manually exercised.

## AI Disclosure

Implemented and reviewed with OpenAI Codex agents under human direction.

## Review

Independent focused agent reviews were run after implementation; automated Pullfrog and CodeRabbit findings were incorporated into the latest commit.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, cross-platform path ownership, multi-host identity, Remote SSH lineage, mobile/runtime projection, backwards compatibility, and scan performance were considered. Current-instance evidence is host-scoped so a same-key worktree on another host cannot validate a stale parent locally.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why (including ELI5).
- [x] Visual proof is N/A with reason.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered.
- [ ] Full `pnpm lint`, `pnpm test`, and `pnpm build` are delegated to CI; focused tests, Node typecheck, ratchet, and pre-commit checks pass locally.
