### PR TITLE
test(cloud): derive both reachability directions for the relay inventory census

### DIFF
--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -7969,7 +7969,7 @@ function isDatabaseLockUnavailable(error: unknown): boolean {
   return error instanceof Error && error.message === 'database_lock_unavailable'
 }
 
-function cellInventoryLockOptions(mode: CellInventoryLockMode): RelayLockOptions {
+export function cellInventoryLockOptions(mode: CellInventoryLockMode): RelayLockOptions {
   if (mode === 'nowait') return { failIfUnavailable: true, measureHoldMs: true }
   if (mode === 'pool-default') return { measureHoldMs: true }
   return { lockTimeoutMs: CELL_INVENTORY_LOCK_TIMEOUT_MS, measureHoldMs: true }

--- a/cloud/apps/relay/src/cell-inventory-hold-samples.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-hold-samples.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CellInventoryHoldSamples,
+  emptyCellInventoryHoldCounts
+} from './cell-inventory-hold-samples.js'
+
+// Nearest rank, computed in integer arithmetic so it cannot inherit the float
+// error the implementation's `0.95 * n` could in principle carry.
+function nearestRankP95(sorted: number[]): number {
+  return sorted[Math.ceil((95 * sorted.length) / 100) - 1]!
+}
+
+function samplesOf(values: number[]): CellInventoryHoldSamples {
+  const samples = new CellInventoryHoldSamples()
+  for (const value of values) samples.record(value)
+  return samples
+}
+
+describe('cell inventory hold samples', () => {
+  it('reports nothing before the first hold', () => {
+    expect(new CellInventoryHoldSamples().readCounts()).toEqual(
+      emptyCellInventoryHoldCounts()
+    )
+  })
+
+  // Why: the 500ms bound will be tuned against this percentile, so an off-by-one
+  // here reads as a hold the fleet never had.
+  it('places p95 at the nearest rank for every window size', () => {
+    for (let size = 1; size <= 400; size++) {
+      const values = Array.from({ length: size }, (_, index) => index + 1)
+      const shuffled = [...values].reverse()
+
+      const counts = samplesOf(shuffled).readCounts()
+
+      expect(counts.cellInventoryHoldMsP95).toBe(nearestRankP95(values))
+      expect(counts.cellInventoryHoldMsMax).toBe(size)
+      expect(counts.cellInventoryHolds).toBe(size)
+    }
+  })
+
+  it('never reports a p95 above the max', () => {
+    for (let size = 1; size <= 200; size++) {
+      const counts = samplesOf(Array.from({ length: size }, (_, i) => i + 1)).readCounts()
+
+      expect(counts.cellInventoryHoldMsP95).toBeLessThanOrEqual(counts.cellInventoryHoldMsMax)
+    }
+  })
+
+  it('ignores a hold that is not a finite, non-negative duration', () => {
+    const samples = samplesOf([Number.NaN, Number.POSITIVE_INFINITY, -1])
+
+    expect(samples.readCounts()).toEqual(emptyCellInventoryHoldCounts())
+  })
+
+  // Why: the reservoir is bounded, so a heavy flush interval keeps the most
+  // recent holds rather than growing without limit or freezing on the oldest.
+  it('keeps the most recent holds once the reservoir is full', () => {
+    const counts = samplesOf(Array.from({ length: 2_100 }, (_, index) => index + 1)).readCounts()
+
+    expect(counts.cellInventoryHolds).toBe(2_048)
+    expect(counts.cellInventoryHoldMsMax).toBe(2_100)
+  })
+
+  it('resets the window on consume so each flush reports its own holds', () => {
+    const samples = samplesOf([5, 10])
+
+    expect(samples.consumeCounts().cellInventoryHolds).toBe(2)
+    expect(samples.consumeCounts()).toEqual(emptyCellInventoryHoldCounts())
+  })
+})

--- a/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
@@ -1,11 +1,11 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import type { CellInventoryLockMode } from './assignment-store.js'
+import { cellInventoryLockOptions, type CellInventoryLockMode } from './assignment-store.js'
 
 // Which entry points can reach a call site. A site a sweep can enter must never
 // take the bounded wait: its 55P03 becomes a terminal transaction failure, and
 // the incident monitor freezes on a single one.
-type Reachability = 'request' | 'sweep' | 'both'
+type Reachability = 'request' | 'sweep' | 'both' | 'orphan'
 
 // 'caller' is not a CellInventoryLockMode: those sites take the mode threaded
 // from `assign`, which is 'request' for a client and 'pool-default' for the
@@ -25,7 +25,8 @@ const CENSUS: CensusEntry[] = [
   { method: 'assignOnce', mode: 'nowait', reach: 'both' },
   { method: 'assignOnce', mode: 'nowait', reach: 'both' },
   { method: 'refreshDrainMigrationLeasesOnce', mode: 'request', reach: 'request' },
-  { method: 'changeActivity', mode: 'request', reach: 'request' },
+  // Reachable from neither: changeActivity has no production callers, only tests.
+  { method: 'changeActivity', mode: 'request', reach: 'orphan' },
   { method: 'acquireActivity', mode: 'request', reach: 'request' },
   { method: 'activateControl', mode: 'request', reach: 'request' },
   { method: 'startEvacuation', mode: 'request', reach: 'request' },
@@ -52,20 +53,15 @@ const CENSUS: CensusEntry[] = [
 ]
 
 // The background sweeps, and nothing else. A method reachable from one of these
-// can be entered by a sweep tick, whatever else can also enter it.
-const SWEEP_ROOTS = [
-  'refreshRegionalRehomeLeases',
-  'completeReadyEvacuations',
-  'completeReadyRegionalRehomes',
-  'abortExpiredEvacuations',
-  'abortExpiredRegionalRehomes',
-  'reapRegionalRehomeAttempts',
-  'releaseExpiredActivityLeases',
-  'releaseExpiredActivity',
-  'releaseExpiredRegionPreferences',
-  'evacuateDeadCells',
-  'claimRegionalRehome',
-  'recordRegionalRehomeDispatchFailure'
+// can be entered by a sweep tick, whatever else can also enter it. Both lists are
+// read from source, so a new sweep step or a new route widens the derivation here
+// instead of silently widening what a bounded wait can be entered from.
+const SWEEP_ENTRY_FILES = ['./assignment-cleanup-steps.ts', './regional-rehome-worker.ts']
+const REQUEST_ENTRY_FILES = [
+  './app.ts',
+  './relay-server.ts',
+  './host-session-registry.ts',
+  './cell-admission-startup.ts'
 ]
 
 const DECLARATION = /^ {2}(?:private |public )?(?:static )?(?:async )?([A-Za-z_][\w]*)[(<]/
@@ -74,9 +70,18 @@ function storeSource(): string[] {
   return readFileSync(new URL('./assignment-store.ts', import.meta.url), 'utf8').split('\n')
 }
 
-// Why: a hand-written reachability column is a claim, not a check. Derive it, so
-// a new sweep edge into a bounded site fails here instead of in production.
-function sweepReachableMethods(lines: string[]): Set<string> {
+function entryPoints(files: string[]): string[] {
+  return files.flatMap((file) =>
+    [
+      ...readFileSync(new URL(file, import.meta.url), 'utf8').matchAll(
+        /assignments\.([A-Za-z_][\w]*)\(/g
+      )
+    ].map((call) => call[1]!)
+  )
+}
+
+// Same-class call graph: store methods only ever reach each other through `this.`.
+function storeCallGraph(lines: string[]): Map<string, Set<string>> {
   const bounds: { name: string; start: number }[] = []
   lines.forEach((line, index) => {
     const declaration = DECLARATION.exec(line)
@@ -93,8 +98,12 @@ function sweepReachableMethods(lines: string[]): Set<string> {
     }
     callees.set(method.name, names)
   })
+  return callees
+}
+
+function closure(callees: Map<string, Set<string>>, roots: string[]): Set<string> {
   const reached = new Set<string>()
-  const pending = [...SWEEP_ROOTS]
+  const pending = [...roots]
   while (pending.length > 0) {
     const name = pending.pop()!
     if (reached.has(name)) continue
@@ -102,6 +111,23 @@ function sweepReachableMethods(lines: string[]): Set<string> {
     for (const callee of callees.get(name) ?? []) if (!reached.has(callee)) pending.push(callee)
   }
   return reached
+}
+
+// Why: a hand-written reachability column is a claim, not a check. Derive both
+// directions, so a new sweep edge into a bounded site fails here instead of in
+// production, and so 'sweep' and 'both' stop being asserted by hand.
+function derivedReachability(lines: string[]): (method: string) => Reachability {
+  const callees = storeCallGraph(lines)
+  const sweep = closure(callees, entryPoints(SWEEP_ENTRY_FILES))
+  const request = closure(callees, entryPoints(REQUEST_ENTRY_FILES))
+  return (method) =>
+    sweep.has(method)
+      ? request.has(method)
+        ? 'both'
+        : 'sweep'
+      : request.has(method)
+        ? 'request'
+        : 'orphan'
 }
 
 function readCallSites(): { method: string; mode: CensusMode }[] {
@@ -136,27 +162,42 @@ describe('cell inventory lock call-site census', () => {
   })
 
   it('derives the same reachability the census claims', () => {
-    const reached = sweepReachableMethods(storeSource())
-    const derived = readCallSites().map(({ method }) => reached.has(method))
+    const reachOf = derivedReachability(storeSource())
 
-    expect(derived).toEqual(CENSUS.map((entry) => entry.reach !== 'request'))
+    expect(readCallSites().map(({ method }) => reachOf(method))).toEqual(
+      CENSUS.map((entry) => entry.reach)
+    )
   })
 
   // Why: this is the whole point of the classification. A shorter wait on a
   // sweep-reachable site turns contention into a terminal transaction failure,
   // and relayPostgresRetryExhausted freezes the incident gate at zero.
+  // Why: the hold distribution is what the 500ms bound will be tuned against, so
+  // a mode that stops asking for it goes unmeasured in exactly the lane that
+  // matters. Nothing else in the suite reads the pool-default branch.
+  it('measures the hold in every lock mode', () => {
+    const modes: CellInventoryLockMode[] = ['request', 'nowait', 'pool-default']
+
+    expect(modes.map((mode) => cellInventoryLockOptions(mode).measureHoldMs)).toEqual([
+      true,
+      true,
+      true
+    ])
+  })
+
   it('never puts a sweep-reachable site on the bounded wait', () => {
-    const reached = sweepReachableMethods(storeSource())
+    const reachOf = derivedReachability(storeSource())
     const bounded = readCallSites().filter(
-      (site) => site.mode === 'request' && reached.has(site.method)
+      (site) => site.mode === 'request' && ['sweep', 'both'].includes(reachOf(site.method))
     )
 
     expect(bounded).toEqual([])
   })
 
   it('routes every sweep-only site to NOWAIT so it can skip the tick', () => {
-    const queueing = CENSUS.filter(
-      (entry) => entry.reach === 'sweep' && entry.mode !== 'nowait'
+    const reachOf = derivedReachability(storeSource())
+    const queueing = readCallSites().filter(
+      (site) => reachOf(site.method) === 'sweep' && site.mode !== 'nowait'
     )
 
     expect(queueing).toEqual([])

--- a/cloud/apps/relay/src/regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-store.test.ts
@@ -626,7 +626,7 @@ describe('regional rehome assignment state', () => {
       await context.store.releaseActivity(identity, sourceControl)
     }
     probe.reset()
-    probe.failNoWaitOnce = true
+    probe.failNoWaitTimes = 1
     const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
 
     let completed: number
@@ -642,6 +642,57 @@ describe('regional rehome assignment state', () => {
         event: 'orca_relay_sweep_cell_inventory_busy',
         sweep: 'complete-ready-regional-rehomes',
         skipped: 1
+      }
+    ])
+    await context.database.close()
+  })
+
+  // Why: with `continue` replaced by `break` a single contended candidate drops
+  // the rest of the page. Two in a row prove the sweep resumes, not just that it
+  // survived one, and that the summary counts both.
+  it('completes a candidate behind two contended ones', async () => {
+    const probe = new CellInventoryLockProbe()
+    const context = await setup({ wrap: (database) => probe.wrap(database) })
+    const identities = [
+      { userId: 'user-1', relayHostId: 'abcdefghijklmnop' },
+      { userId: 'user-2', relayHostId: 'ponmlkjihgfedcba' },
+      { userId: 'user-3', relayHostId: 'aaaabbbbccccdddd' }
+    ]
+    for (const identity of identities) {
+      // Dispatch is rate limited, so each claim needs its own interval.
+      context.advance(60_000)
+      await freshHeartbeats(context)
+      const sourceControl = await activatePreferredSource(context, identity)
+      const attempt = await context.store.claimRegionalRehome()
+      await context.store.recordRegionalRehomeDrainReceipt(attempt!.attemptId, 'accepted')
+      await context.store.activateControl(identity, {
+        cellId: target.id,
+        assignmentEpoch: 2,
+        generation: 1
+      })
+      await context.store.markMigrationTargetRegistered(identity, {
+        cellId: target.id,
+        assignmentEpoch: 2
+      })
+      await context.store.releaseActivity(identity, sourceControl)
+    }
+    probe.reset()
+    probe.failNoWaitTimes = 2
+    const busy = collectEventWarnings('orca_relay_sweep_cell_inventory_busy')
+
+    let completed: number
+    try {
+      completed = await context.store.completeReadyRegionalRehomes()
+    } finally {
+      busy.restore()
+    }
+
+    expect(completed).toBe(1)
+    expect(busy.entries).toEqual([
+      {
+        event: 'orca_relay_sweep_cell_inventory_busy',
+        sweep: 'complete-ready-regional-rehomes',
+        skipped: 2
       }
     ])
     await context.database.close()
@@ -1692,8 +1743,8 @@ async function heartbeat(
 class CellInventoryLockProbe {
   readonly locks: (RelayLockOptions | undefined)[] = []
   failNoWait = false
-  // Contends one candidate only, so the sweep must carry on to the next.
-  failNoWaitOnce = false
+  // Contends the first N candidates only, so the sweep must carry on past them.
+  failNoWaitTimes = 0
   failWith: Error | null = null
 
   reset(): void {
@@ -1708,8 +1759,8 @@ class CellInventoryLockProbe {
         if (sql.trim() === 'SELECT * FROM relay_cells ORDER BY cell_id ASC') {
           probe.locks.push(options)
           if (probe.failWith) throw probe.failWith
-          if (options?.failIfUnavailable && probe.failNoWaitOnce) {
-            probe.failNoWaitOnce = false
+          if (options?.failIfUnavailable && probe.failNoWaitTimes > 0) {
+            probe.failNoWaitTimes--
             throw new Error('database_lock_unavailable')
           }
           if (probe.failNoWait && options?.failIfUnavailable) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​162 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

Mirrors stablyai/orca-cloud#472 (byte-identical under `cloud/`). Test-only apart from exporting `cellInventoryLockOptions`: the census now derives request-reachability from the store methods app.ts / relay-server.ts / host-session-registry.ts / cell-admission-startup.ts call, records `changeActivity` as orphan, asserts `measureHoldMs` on all three lock modes, adds a two-contended-candidate sweep test, and pins the hold reservoir's nearest-rank p95.