### PR TITLE
fix(ssh): stop pane adoption certifying a death from the relay's not-found union

### DIFF
--- a/docs/reference/ssh-execution-boundary.md
+++ b/docs/reference/ssh-execution-boundary.md
@@ -66,6 +66,8 @@ A verdict needs evidence from the host that owns the process. Apply these tests 
 
 **Does the termination event match the current identity?** A host-delivered exit for the live PTY incarnation and provider generation, while its siblings still report, establishes `exited`. A stale event, an event for a superseded incarnation, or one quiet terminal with no host evidence does not.
 
+**Did the answer carry its evidence, or only the same wording?** `pty.attach` refuses with `PTY "<id>" not found` both for a pid the relay probed and found gone and for an id its session map never had — which is every id minted before a relay restart, since ids carry a per-start mint epoch. Only the probed refusal carries `PTY_ATTACH_PROVEN_EXITED_MARKER` (`src/shared/pty-attach-absence-evidence.ts`) and reaches the client as `SshPtyProvenExitedOnRelayError`; the unmarked union arrives as `SshPtyAbsentFromRelayError`, which licenses retiring the client's own route to the PTY and nothing more. A missing marker is never evidence — an older relay omits it too.
+
 **Is a returned status actually a claim of success?** An operation that reports failure may have succeeded, and one that reports success may not have run — check the durable state it should have changed rather than trusting the return.
 
 Anything short of positive host evidence is `unverifiable`. Reporting it as `exited` is the error this document exists to prevent: it orphans live work and can cold-start a duplicate over the same worktree.

--- a/src/main/ipc/pty-dead-owner-respawn.test.ts
+++ b/src/main/ipc/pty-dead-owner-respawn.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
+import { SessionNotFoundError } from '../daemon/daemon-errors'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { registerPtyHandlers, setLocalPtyProvider } from './pty'
 
@@ -59,7 +60,7 @@ describe('registerPtyHandlers', () => {
     const providerSpawn = vi.fn(
       async (options: { attachOnly?: boolean; command?: string; sessionId?: string }) => {
         if (options.attachOnly) {
-          throw new Error('Session not found: pty-proven-absent-owner')
+          throw new SessionNotFoundError('pty-proven-absent-owner')
         }
         return { id: 'pty-fresh-proven', incarnationId: 'inc-fresh-proven' }
       }
@@ -161,10 +162,13 @@ describe('registerPtyHandlers', () => {
     expect(providerSpawn.mock.calls[1]?.[0]).toMatchObject({
       command: 'codex resume proven-absent-session'
     })
+    // The registry that owns the PTY answered, so this exit is confirmed — but the code stays the
+    // -1 sentinel; a synthesized zero would be indistinguishable from a clean shell exit.
     expect(runtime.onPtyExit).toHaveBeenCalledWith(
       'pty-proven-absent-owner',
-      0,
-      'inc-proven-absent-owner'
+      -1,
+      'inc-proven-absent-owner',
+      { hostExitConfirmed: true }
     )
     expect(store.setWorkspaceSession).toHaveBeenCalledOnce()
     expect(store.flushOrThrow).toHaveBeenCalledOnce()
@@ -178,7 +182,7 @@ describe('registerPtyHandlers', () => {
     const providerSpawn = vi.fn(
       async (options: { attachOnly?: boolean; command?: string; sessionId?: string }) => {
         if (options.attachOnly) {
-          throw new Error('Session not found: pty-probe-blip-owner')
+          throw new SessionNotFoundError('pty-probe-blip-owner')
         }
         return { id: 'pty-fresh-probe-blip', incarnationId: 'inc-fresh-probe-blip' }
       }
@@ -282,8 +286,9 @@ describe('registerPtyHandlers', () => {
     expect(providerSpawn).toHaveBeenCalledTimes(2)
     expect(runtime.onPtyExit).toHaveBeenCalledWith(
       'pty-probe-blip-owner',
-      0,
-      'inc-probe-blip-owner'
+      -1,
+      'inc-probe-blip-owner',
+      { hostExitConfirmed: true }
     )
   })
   // Why: a parked pane (stopped with keepHistory) leaves the runtime holding the binding while
@@ -299,7 +304,7 @@ describe('registerPtyHandlers', () => {
     const providerSpawn = vi.fn(
       async (options: { attachOnly?: boolean; command?: string; sessionId?: string }) => {
         if (options.attachOnly) {
-          throw new Error('Session not found: pty-already-retired-owner')
+          throw new SessionNotFoundError('pty-already-retired-owner')
         }
         return { id: 'pty-fresh-already-retired', incarnationId: 'inc-fresh-already-retired' }
       }
@@ -420,6 +425,8 @@ describe('registerPtyHandlers', () => {
     expect(providerSpawn.mock.calls[1]?.[0]).toMatchObject({
       command: 'codex resume already-retired-session'
     })
-    expect(runtime.onPtyExit).toHaveBeenCalledWith('pty-already-retired-owner', 0, undefined)
+    expect(runtime.onPtyExit).toHaveBeenCalledWith('pty-already-retired-owner', -1, undefined, {
+      hostExitConfirmed: true
+    })
   })
 })

--- a/src/main/ipc/pty-pane-reservation-settlement.test.ts
+++ b/src/main/ipc/pty-pane-reservation-settlement.test.ts
@@ -3,6 +3,10 @@ import { spawnMock, registerPtyMock } from './pty-ipc-mock-registry'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import {
+  SSH_SESSION_EXPIRED_ERROR,
+  SshPtyProvenExitedOnRelayError
+} from '../providers/ssh-pty-errors'
+import {
   registerPtyHandlers,
   registerSshPtyProvider,
   setLocalPtyProvider,
@@ -67,7 +71,9 @@ describe('registerPtyHandlers', () => {
     const freshPtyId = `ssh:${connectionId}@@fresh-relay-pty`
     const remoteSpawn = vi.fn(async (options: { attachOnly?: boolean; command?: string }) => {
       if (options.attachOnly) {
-        throw new Error('PTY "dead-relay-pty" not found')
+        // The relay's raw wire text never reaches a pane untyped; the SSH reattach path mints the
+        // proven-exit class for the one refusal the relay backed with a pid probe.
+        throw new SshPtyProvenExitedOnRelayError(`${SSH_SESSION_EXPIRED_ERROR}: dead-relay-pty`)
       }
       return { id: freshPtyId, incarnationId: 'inc-fresh-ssh-owner' }
     })

--- a/src/main/ipc/pty-persisted-incarnation-repair.test.ts
+++ b/src/main/ipc/pty-persisted-incarnation-repair.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { statSyncMock } from './pty-ipc-mock-registry'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
-import { TerminalSessionOwnerUnverifiedError } from '../daemon/daemon-errors'
+import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from '../daemon/daemon-errors'
 import { makePaneKey } from '../../shared/stable-pane-id'
 import { registerPtyHandlers, clearProviderPtyState, setLocalPtyProvider } from './pty'
 
@@ -230,7 +230,7 @@ describe('registerPtyHandlers', () => {
       const providerSpawn = vi.fn(
         async (options: { attachOnly?: boolean; command?: string; sessionId?: string }) => {
           if (options.attachOnly) {
-            throw new Error('Session not found: pty-dead-persisted-owner')
+            throw new SessionNotFoundError('pty-dead-persisted-owner')
           }
           return { id: 'pty-fresh-recovery', incarnationId: 'inc-fresh-recovery' }
         }
@@ -352,8 +352,9 @@ describe('registerPtyHandlers', () => {
         expect(store.setWorkspaceSession).toHaveBeenCalledOnce()
         expect(runtime.onPtyExit).toHaveBeenCalledWith(
           'pty-dead-persisted-owner',
-          0,
-          'inc-dead-persisted-owner'
+          -1,
+          'inc-dead-persisted-owner',
+          { hostExitConfirmed: true }
         )
         return
       }
@@ -376,8 +377,9 @@ describe('registerPtyHandlers', () => {
       expect(store.flushOrThrow).toHaveBeenCalledOnce()
       expect(runtime.onPtyExit).toHaveBeenCalledWith(
         'pty-dead-persisted-owner',
-        0,
-        'inc-dead-persisted-owner'
+        -1,
+        'inc-dead-persisted-owner',
+        { hostExitConfirmed: true }
       )
     }
   )

--- a/src/main/ipc/pty/pane/stable-owner.ts
+++ b/src/main/ipc/pty/pane/stable-owner.ts
@@ -1,5 +1,6 @@
 import { toSshExecutionHostId } from '../../../../shared/execution-host'
 import { makePaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+import { UNVERIFIED_PROCESS_EXIT_CODE } from '../../../../shared/terminal-exit-cause'
 import type { Store } from '../../../persistence'
 import { retireTerminalSurfaceFromPersistence } from '../../../runtime/mobile-session-terminal-persistence-retirement'
 import type { OrcaRuntimeService } from '../../../runtime/orca-runtime'
@@ -11,7 +12,7 @@ import {
   TerminalSessionOwnerUnverifiedError
 } from '../../../daemon/daemon-errors'
 import { ptyIncarnationById, ptyOwnership } from '../provider/ownership-state'
-import { isPtyAlreadyGoneError } from '../provider/liveness'
+import { isHostReportedPtyAbsenceError, isObservedPtyExitEvidence } from '../provider/liveness'
 import { clearProviderPtyState } from '../provider/state-cleanup'
 
 export type StablePaneOwner = {
@@ -239,7 +240,7 @@ export async function attachStablePaneOwner(
     if (isDaemonEndpointGoneError(error)) {
       throw new TerminalHostGoneError()
     }
-    if (!isPtyAlreadyGoneError(error)) {
+    if (!isHostReportedPtyAbsenceError(error)) {
       throw error
     }
     const ownerBeforeRetire = args.resolveOwner?.()
@@ -252,7 +253,17 @@ export async function attachStablePaneOwner(
     ) {
       throw new Error('terminal_pane_owner_changed')
     }
-    runtime?.onPtyExit(owner.ptyId, 0, owner.incarnationId)
+    // `pty.attach` answers absent both for a pid the relay probed and found gone and for an id its
+    // session map never had — every id minted before a relay restart, checked against nothing. Only
+    // the marked half observed the process, so only it may certify a death; the rest publishes the
+    // stop sentinel its sibling handlePtyReattachFailure publishes, which every reader resolves to
+    // `stop_unverified` (docs/reference/ssh-execution-boundary.md).
+    runtime?.onPtyExit(
+      owner.ptyId,
+      UNVERIFIED_PROCESS_EXIT_CODE,
+      owner.incarnationId,
+      isObservedPtyExitEvidence(error) ? { hostExitConfirmed: true } : {}
+    )
     clearProviderPtyState(owner.ptyId)
     ptyOwnership.delete(owner.ptyId)
     if (

--- a/src/main/ipc/pty/pane/stable-pane-absence-death-certificate.test.ts
+++ b/src/main/ipc/pty/pane/stable-pane-absence-death-certificate.test.ts
@@ -1,0 +1,185 @@
+// `attachStablePaneOwner` is the last reader that synthesised a runtime exit from a reattach
+// refusal, and it published code 0 — which `orca-runtime-on-pty-exit` records as a death
+// certificate. The refusal it acts on is a union: `pty.attach` answers absent both for a pid the
+// relay probed and found gone, and for an id its session map never had, which is every id minted
+// before a relay restart. Certifying the union orphans a live remote shell and cold-starts a second
+// agent onto its transcript (docs/reference/ssh-execution-boundary.md).
+//
+// The sibling handlePtyReattachFailure has always refused to certify from that union. These pin the
+// same rule here, and pin that the marked half — the one refusal the relay backed with a pid probe
+// — still earns the certificate, so a genuinely dead PTY is not left `unverifiable` forever.
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../../../shared/constants'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { SSH_EXIT_UNCONFIRMED_REASON } from '../../../../shared/pty-liveness-verdict'
+import type { WorkspaceSessionState } from '../../../../shared/workspace-session-state-types'
+import { SessionNotFoundError } from '../../../daemon/daemon-errors'
+import type { Store } from '../../../persistence'
+import {
+  SSH_SESSION_EXPIRED_ERROR,
+  SshPtyAbsentFromRelayError,
+  SshPtyProvenExitedOnRelayError
+} from '../../../providers/ssh-pty-errors'
+import type { IPtyProvider } from '../../../providers/types'
+import { OrcaRuntimeService } from '../../../runtime/orca-runtime'
+import { resolvePersistedStablePaneOwner, spawnForStablePane } from './stable-owner'
+
+const CONNECTION = 'conn-1'
+const WORKTREE = 'repo-1::/tmp/pane-absence'
+const TAB = 'tab-1'
+const LEAF = '1b3f2c4d-5e6a-4b7c-8d9e-0f1a2b3c4d5e'
+const SIBLING_LEAF = '2c4d3e5f-6a7b-4c8d-9e0f-1a2b3c4d5e6f'
+// Ids carry the relay's per-start mint epoch, so this one names a PTY the CURRENT relay never minted.
+const PTY_ID = 'ssh:conn-1@@pty2:epoch-a:1'
+const OWNER = { tabId: TAB, leafId: LEAF, ptyId: PTY_ID, hasPersistedBinding: true as const }
+
+function paneStore(): { store: Store; read: () => WorkspaceSessionState } {
+  let session = {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [WORKTREE]: [{ id: TAB, type: 'terminal', worktreeId: WORKTREE, ptyId: PTY_ID }]
+    },
+    terminalLayoutsByTabId: {
+      [TAB]: {
+        root: {
+          type: 'split',
+          direction: 'row',
+          first: { type: 'leaf', leafId: LEAF },
+          second: { type: 'leaf', leafId: SIBLING_LEAF }
+        },
+        activeLeafId: LEAF,
+        ptyIdsByLeafId: { [LEAF]: PTY_ID, [SIBLING_LEAF]: 'ssh:conn-1@@pty2:epoch-a:2' }
+      }
+    }
+  } as unknown as WorkspaceSessionState
+  return {
+    read: () => session,
+    store: {
+      getWorkspaceSession: () => session,
+      setWorkspaceSession: (next: WorkspaceSessionState) => {
+        session = next
+      },
+      flushOrThrow: () => {},
+      getRepos: () => [
+        {
+          id: 'repo-1',
+          path: '/tmp/pane-absence',
+          displayName: 'pane-absence',
+          badgeColor: '#000000',
+          addedAt: 0
+        }
+      ],
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined,
+      setWorktreeMeta: () => {},
+      removeWorktreeMeta: () => {},
+      getSettings: () => ({ workspaceDir: '/tmp/workspaces' }),
+      getProjects: () => []
+    } as unknown as Store
+  }
+}
+
+function runtimeOwning(store: Store): OrcaRuntimeService {
+  const runtime = new OrcaRuntimeService(store as never)
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    hasPty: () => null,
+    listProcesses: async () => [],
+    getForegroundProcess: async () => null
+  } as never)
+  runtime.attachWindow(1)
+  runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+  runtime.registerPty(PTY_ID, WORKTREE, CONNECTION)
+  return runtime
+}
+
+async function adoptAfterAttachRefusal(error: unknown): Promise<{
+  runtime: OrcaRuntimeService
+  store: Store
+  read: () => WorkspaceSessionState
+  spawn: ReturnType<typeof vi.fn>
+}> {
+  const { store, read } = paneStore()
+  const runtime = runtimeOwning(store)
+  const spawn = vi
+    .fn()
+    .mockRejectedValueOnce(error)
+    .mockResolvedValueOnce({ id: 'ssh:conn-1@@pty2:epoch-b:1', isReattach: false })
+  await spawnForStablePane({
+    runtime,
+    store,
+    provider: { spawn } as unknown as IPtyProvider,
+    spawnOptions: { cols: 80, rows: 24 },
+    owner: OWNER,
+    worktreeId: WORKTREE,
+    connectionId: CONNECTION,
+    resolveOwner: () => null
+  })
+  return { runtime, store, read, spawn }
+}
+
+describe('a stable pane whose reattach was refused', () => {
+  it('records no death certificate when the relay merely does not know the id', async () => {
+    const { runtime, spawn } = await adoptAfterAttachRefusal(
+      new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty2:epoch-a:1`)
+    )
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    // The shell may well still be running under the previous daemon's orphaned process tree, so the
+    // register must keep saying "we could not observe it" — not "it ended".
+    expect(runtime.getPtyLivenessVerdict(PTY_ID)).toEqual({
+      status: 'unverifiable',
+      reason: SSH_EXIT_UNCONFIRMED_REASON
+    })
+  })
+
+  it('still certifies the death the relay proved with a pid probe', async () => {
+    const { runtime, store, spawn } = await adoptAfterAttachRefusal(
+      new SshPtyProvenExitedOnRelayError(`${SSH_SESSION_EXPIRED_ERROR}: pty2:epoch-a:1`)
+    )
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(runtime.getPtyLivenessVerdict(PTY_ID)).toEqual({ status: 'exited' })
+    // If nothing ever retired, a proven-dead pane would reattach to a corpse on every adoption.
+    expect(
+      resolvePersistedStablePaneOwner(store, makePaneKey(TAB, LEAF), WORKTREE, CONNECTION)
+    ).toBeNull()
+  })
+
+  it('certifies an absence reported by the process registry that owns the PTY', async () => {
+    // The daemon (or the in-process map) answering here is the owner of the process, and an
+    // endpoint that had gone raises TerminalHostGoneError above, so this absence is an observation
+    // rather than a lost route.
+    const { runtime } = await adoptAfterAttachRefusal(new SessionNotFoundError(PTY_ID))
+
+    expect(runtime.getPtyLivenessVerdict(PTY_ID)).toEqual({ status: 'exited' })
+  })
+
+  it('refuses to abandon the binding on an untyped "not found" string', async () => {
+    // The relay's raw wire wording. The SSH reattach path types it before any pane sees it, so an
+    // untyped one reached this gate having lost every distinction the type carries — including
+    // whether the answer came from the host that owns the process at all.
+    const { store, read } = paneStore()
+    const before = JSON.stringify(read())
+    const runtime = runtimeOwning(store)
+    const spawn = vi.fn().mockRejectedValue(new Error(`PTY "pty2:epoch-a:1" not found`))
+
+    await expect(
+      spawnForStablePane({
+        runtime,
+        store,
+        provider: { spawn } as unknown as IPtyProvider,
+        spawnOptions: { cols: 80, rows: 24 },
+        owner: OWNER,
+        worktreeId: WORKTREE,
+        connectionId: CONNECTION,
+        resolveOwner: () => null
+      })
+    ).rejects.toThrow('not found')
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(runtime.getPtyLivenessVerdict(PTY_ID)).toBeNull()
+    expect(JSON.stringify(read())).toBe(before)
+  })
+})

--- a/src/main/ipc/pty/provider/liveness.ts
+++ b/src/main/ipc/pty/provider/liveness.ts
@@ -2,10 +2,12 @@ import { isRemoteAgentHooksEnabled } from '../../../../shared/agent-hook-relay'
 import type { AgentSessionOwnerBinding } from '../../../../shared/agent-session-host-authority'
 import { agentSessionOwnerBindingsEqual } from '../../../../shared/claimed-agent-pty-owner'
 import { addNodePtyRecoveryHint } from '../../../daemon/node-pty-error-hints'
+import { SessionNotFoundError } from '../../../daemon/daemon-errors'
 import type { Store } from '../../../persistence'
 import {
   isSshPtyAbsentFromRelayError,
-  isSshPtyNotFoundError
+  isSshPtyNotFoundError,
+  isSshPtyProvenExitedOnRelayError
 } from '../../../providers/ssh-pty-errors'
 import type { IPtyProvider } from '../../../providers/types'
 import { markClaudePtyExited } from '../../../claude-accounts/live-pty-gate'
@@ -64,6 +66,33 @@ export function isPtyAlreadyGoneError(err: unknown): boolean {
     isSshPtyAbsentFromRelayError(err) ||
     /Session not found/i.test(message)
   )
+}
+
+/**
+ * Narrower than {@link isPtyAlreadyGoneError}, for the one caller that retires a durable pane
+ * binding rather than just releasing in-memory state: only a typed answer from the host that owns
+ * the process may authorise that. The bare `PTY ".+" not found` text is the relay's raw wire
+ * wording, which the SSH reattach path always types before it reaches a pane; matching the text
+ * instead would let any untyped string carrying that phrase unbind a live pane
+ * (docs/reference/ssh-execution-boundary.md).
+ */
+export function isHostReportedPtyAbsenceError(err: unknown): boolean {
+  return isSshPtyAbsentFromRelayError(err) || err instanceof SessionNotFoundError
+}
+
+/**
+ * The half of {@link isHostReportedPtyAbsenceError} that actually observed the process, and so the
+ * only half that may certify an exit.
+ *
+ * The relay's plain absence answer is excluded because `pty.attach` gives it for an id its session
+ * map never had as readily as for a pid it probed — after a relay restart, every id the previous
+ * one minted. `SessionNotFoundError` is included because the process answering is the one that owns
+ * the PTY: the in-process registry itself, or a daemon whose endpoint is live (a gone endpoint
+ * raises `isDaemonEndpointGoneError` instead), so its absence is an observation rather than a lost
+ * route (docs/reference/ssh-execution-boundary.md).
+ */
+export function isObservedPtyExitEvidence(err: unknown): boolean {
+  return isSshPtyProvenExitedOnRelayError(err) || err instanceof SessionNotFoundError
 }
 
 export function delay(ms: number): Promise<void> {

--- a/src/main/providers/ssh-pty-errors.ts
+++ b/src/main/providers/ssh-pty-errors.ts
@@ -20,12 +20,16 @@ export function isSshPtyIdentityMismatchError(error: unknown): boolean {
 }
 
 /**
- * A reachable relay answered for this exact PTY id and reported it absent — positive evidence of
- * absence from the execution host, so `exited` rather than `unverifiable`
- * (docs/reference/ssh-execution-boundary.md). Deliberately NOT raised for a transport failure, a
- * request timeout, a disposed multiplexer, an identity mismatch (the id names a live PTY belonging
- * to another pane), or `restoreRequired` (the PTY is live, only its source stream is not) — none of
- * those observe the process, and treating them as absence orphans live remote work.
+ * A reachable relay answered for this exact PTY id and reported it absent, so the client may retire
+ * its own route to it. Deliberately NOT raised for a transport failure, a request timeout, a
+ * disposed multiplexer, an identity mismatch (the id names a live PTY belonging to another pane),
+ * or `restoreRequired` (the PTY is live, only its source stream is not) — none of those observe the
+ * process, and treating them as absence orphans live remote work.
+ *
+ * This is NOT itself a death certificate. `pty.attach` answers absent for an id its session map
+ * never had as readily as for a pid it probed — and after a relay restart that is every id the
+ * previous one minted. Certifying `exited` needs {@link SshPtyProvenExitedOnRelayError}
+ * (docs/reference/ssh-execution-boundary.md).
  *
  * Carries the same `SSH_SESSION_EXPIRED` message so message-based consumers are unaffected; only
  * callers that can act on the stronger verdict test the class.
@@ -39,4 +43,25 @@ export class SshPtyAbsentFromRelayError extends Error {
 
 export function isSshPtyAbsentFromRelayError(error: unknown): boolean {
   return error instanceof SshPtyAbsentFromRelayError
+}
+
+/**
+ * The narrow half of {@link SshPtyAbsentFromRelayError}: the relay probed the pid and found it gone
+ * before answering absent, so this is the one attach refusal that observed the process and the only
+ * one that may certify a death.
+ *
+ * The parent class is raised for the whole union, which also contains "this session map has no such
+ * id" — every id minted before a relay restart, checked against nothing. Callers that only release
+ * client-side bookkeeping keep testing the parent; a caller about to record `exited` must test this
+ * (docs/reference/ssh-execution-boundary.md).
+ */
+export class SshPtyProvenExitedOnRelayError extends SshPtyAbsentFromRelayError {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SshPtyProvenExitedOnRelayError'
+  }
+}
+
+export function isSshPtyProvenExitedOnRelayError(error: unknown): boolean {
+  return error instanceof SshPtyProvenExitedOnRelayError
 }

--- a/src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts
+++ b/src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts
@@ -14,9 +14,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   isSshPtyAbsentFromRelayError,
+  isSshPtyProvenExitedOnRelayError,
   SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR,
   SSH_SESSION_EXPIRED_ERROR
 } from './ssh-pty-errors'
+import { PTY_ATTACH_PROVEN_EXITED_MARKER } from '../../shared/pty-attach-absence-evidence'
 import { reattachSshPtySessionForSpawn } from './ssh-pty-session-reattach'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 
@@ -55,6 +57,20 @@ describe('an SSH reattach refusal says whether the host observed the PTY', () =>
 
     expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
     expect(isSshPtyAbsentFromRelayError(error)).toBe(true)
+    // ...but absence from the relay is a union. An unmarked answer is also what a restarted relay
+    // gives for every id the previous one minted, checked against nothing, so it may not certify a
+    // death (docs/reference/ssh-execution-boundary.md).
+    expect(isSshPtyProvenExitedOnRelayError(error)).toBe(false)
+  })
+
+  it('separates the refusal the relay backed with a pid probe', async () => {
+    const error = await refusalFrom(async () => {
+      throw new Error(`PTY "${SESSION}" not found (${PTY_ATTACH_PROVEN_EXITED_MARKER})`)
+    })
+
+    expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
+    expect(isSshPtyAbsentFromRelayError(error)).toBe(true)
+    expect(isSshPtyProvenExitedOnRelayError(error)).toBe(true)
   })
 
   it('gives a restoreRequired refusal its own token instead of the expiry text', async () => {
@@ -79,5 +95,6 @@ describe('an SSH reattach refusal says whether the host observed the PTY', () =>
 
     expect(error.message).toContain(SSH_SESSION_EXPIRED_ERROR)
     expect(isSshPtyAbsentFromRelayError(error)).toBe(false)
+    expect(isSshPtyProvenExitedOnRelayError(error)).toBe(false)
   })
 })

--- a/src/main/providers/ssh-pty-session-reattach.ts
+++ b/src/main/providers/ssh-pty-session-reattach.ts
@@ -5,9 +5,11 @@ import {
   SSH_PTY_SOURCE_RESTORE_REQUIRED_ERROR,
   SSH_SESSION_EXPIRED_ERROR,
   SshPtyAbsentFromRelayError,
+  SshPtyProvenExitedOnRelayError,
   isSshPtyIdentityMismatchError,
   isSshPtyNotFoundError
 } from './ssh-pty-errors'
+import { isProvenExitedPtyAttachRefusal } from '../../shared/pty-attach-absence-evidence'
 import { toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
 import type { PtySpawnOptions, PtySpawnResult } from './types'
 import type { SshPtySpawnExitRaceTracker } from './ssh-pty-spawn-exit-race'
@@ -238,6 +240,13 @@ export async function reattachSshPtySession(args: {
       // Why the class: the relay answered for this exact id, so callers holding a pane binding may
       // retire it and spawn fresh. Plain `SSH_SESSION_EXPIRED` cannot say that — a restarted relay
       // renumbers from pty-1, so the message alone is indistinguishable from a lost link.
+      //
+      // Why the subclass: the relay marks the one refusal it backed with a pid probe. Without the
+      // marker the answer is the "no such id" union, which is not evidence the shell ended, so the
+      // narrow class is minted only when the relay said so (docs/reference/ssh-execution-boundary.md).
+      if (isProvenExitedPtyAttachRefusal(error)) {
+        throw new SshPtyProvenExitedOnRelayError(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}`)
+      }
       throw new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: ${relaySessionId}`)
     }
     throw error

--- a/src/main/ssh-expired-lease-pane-readoption.test.ts
+++ b/src/main/ssh-expired-lease-pane-readoption.test.ts
@@ -7,6 +7,7 @@ import { resolvePersistedStablePaneOwner } from './ipc/pty/pane/stable-owner'
 import { adoptStablePane } from './ipc/pty/pane/adopt-stable'
 import { sshProviders } from './ipc/pty/provider/registry'
 import type { IPtyProvider } from './providers/types'
+import { SSH_SESSION_EXPIRED_ERROR, SshPtyAbsentFromRelayError } from './providers/ssh-pty-errors'
 import { testState, createStore, makeTerminalTab } from './persistence-test-harness'
 import { TEST_LEAF_1 } from './persistence-session-fixtures'
 
@@ -141,11 +142,13 @@ describe('recovery through createTerminal reattaches before it respawns', () => 
     expect(adopted?.owner).toMatchObject({ ptyId: APP_PTY_ID, hasPersistedBinding: true })
   })
 
+  // The typed refusal is what the SSH reattach path raises; the raw `PTY "…" not found` wire text
+  // never reaches a pane untyped, and an untyped one no longer authorises abandoning the binding.
   it('falls through to a fresh spawn once the host answers that the PTY is absent', async () => {
     const store = storeWithBoundRemotePane()
     store.markSshRemotePtyLease(TARGET, APP_PTY_ID, 'expired')
     const spawn = vi.fn(async () => {
-      throw new Error('PTY "remote-pty" not found')
+      throw new SshPtyAbsentFromRelayError(`${SSH_SESSION_EXPIRED_ERROR}: remote-pty`)
     })
     sshProviders.set(TARGET, { spawn } as unknown as IPtyProvider)
 

--- a/src/relay/pty-handler-attach-replay.test.ts
+++ b/src/relay/pty-handler-attach-replay.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import * as ptyShellUtils from './pty-shell-utils'
+import {
+  PTY_ATTACH_PROVEN_EXITED_MARKER,
+  isProvenExitedPtyAttachRefusal
+} from '../shared/pty-attach-absence-evidence'
 
 const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
   mockPtySpawn: vi.fn(),
@@ -87,7 +91,7 @@ describe('PtyHandler', () => {
     try {
       await expect(
         dispatcher.callRequest('pty.attach', { id: PTY_1, suppressReplayNotification: true })
-      ).rejects.toThrow(`PTY "${PTY_1}" not found`)
+      ).rejects.toThrow(`PTY "${PTY_1}" not found (${PTY_ATTACH_PROVEN_EXITED_MARKER})`)
     } finally {
       aliveSpy.mockRestore()
     }
@@ -96,9 +100,18 @@ describe('PtyHandler', () => {
     // is freed so a later attach also cleanly reports not-found.
     expect(exits).toEqual([{ id: PTY_1, paneKey: 'tab-dead:0' }])
     expect(handler.activePtyCount).toBe(0)
-    await expect(
-      dispatcher.callRequest('pty.attach', { id: PTY_1, suppressReplayNotification: true })
-    ).rejects.toThrow(`PTY "${PTY_1}" not found`)
+    const unknownId = await dispatcher
+      .callRequest('pty.attach', { id: PTY_1, suppressReplayNotification: true })
+      .then(
+        () => new Error('expected the attach to be refused'),
+        (error: Error) => error
+      )
+
+    // The second refusal is the shape a restarted relay gives for every id the previous one minted:
+    // same words, no liveness check behind them. Only the probed one may be read as a death
+    // (docs/reference/ssh-execution-boundary.md).
+    expect(unknownId.message).toContain(`PTY "${PTY_1}" not found`)
+    expect(isProvenExitedPtyAttachRefusal(unknownId)).toBe(false)
   })
 
   it('settles concurrent immediate shutdown when attach proves the shell exited', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -35,6 +35,7 @@ import {
   type RelaySpawnCwdResolution
 } from './pty-spawn-cwd'
 import { PhysicalExitTracker } from '../shared/physical-exit-tracker'
+import { PTY_ATTACH_PROVEN_EXITED_MARKER } from '../shared/pty-attach-absence-evidence'
 import { SHELL_READY_MARKER_PREFIX } from '../main/shell-ready-marker-scanner'
 import {
   createShellStartupOutputScanState,
@@ -2055,7 +2056,11 @@ export class PtyHandler {
 
     // Why: verify liveness because shells can exit without node-pty onExit.
     if (this.reapPtyProvenExited(managed)) {
-      throw new Error(`PTY "${id}" not found`)
+      // Why the marker: this is the ONLY not-found answer backed by a liveness check. The unmarked
+      // one above is also thrown for an id this session map never had — every id minted before a
+      // relay restart — so a client that cannot tell them apart certifies deaths it never observed
+      // (docs/reference/ssh-execution-boundary.md).
+      throw new Error(`PTY "${id}" not found (${PTY_ATTACH_PROVEN_EXITED_MARKER})`)
     }
 
     // Why: legacy `pty-N` ids repeated across relay generations; reject conflicting identities.

--- a/src/shared/pty-attach-absence-evidence.ts
+++ b/src/shared/pty-attach-absence-evidence.ts
@@ -1,0 +1,17 @@
+/**
+ * `pty.attach` refuses with `PTY "<id>" not found` for two unrelated situations: a pid the relay
+ * probed and found gone, and an id its session map simply never had — which is every id minted
+ * before a relay restart, since ids carry a per-start mint epoch. Only the first observes the
+ * process, so only the first carries this marker.
+ *
+ * The marker is additive on purpose: an answer without it means "ambiguous", which is also what an
+ * older relay's unmarked answer means, so a client may never read a missing marker as evidence of
+ * anything (docs/reference/ssh-execution-boundary.md).
+ */
+export const PTY_ATTACH_PROVEN_EXITED_MARKER = 'process exited'
+
+const PROVEN_EXITED_ATTACH_REFUSAL = /PTY ".+" not found \(process exited\)/i
+
+export function isProvenExitedPtyAttachRefusal(error: unknown): boolean {
+  return PROVEN_EXITED_ATTACH_REFUSAL.test(error instanceof Error ? error.message : String(error))
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​233 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 |

<!-- /orca-pr-loc -->

## The defect

`attachStablePaneOwner` (`src/main/ipc/pty/pane/stable-owner.ts`) was the last reader that synthesised a runtime exit out of a reattach refusal, and it published exit code **`0`**:

```ts
runtime?.onPtyExit(owner.ptyId, 0, owner.incarnationId)
```

`orca-runtime-on-pty-exit.ts` reads `exitCode >= 0` as `rememberPtyLivenessVerdict(ptyId, { status: 'exited' })` — a death certificate whose own doc comment says *"Its only writer is a host-delivered exit frame; nothing weaker may reach it."*

**The refusal it acts on is a union.** `src/relay/pty-handler.ts` `attach` throws `PTY "<id>" not found` for two unrelated situations:

1. a pid it probed with `isProcessAlive` and found gone (`reapPtyProvenExited`) — `exited` is correct;
2. an id its session map simply never had, with **no liveness check on that path at all** — which, because ids are `pty2:<ptyIdMintEpoch>:<n>`, is *every previously minted id after a relay restart*.

So: relay restarts → user reconnects → pane adoption runs `attachOnly` for a lease whose shell is still alive under the old daemon's orphaned process tree → `exited` is recorded → `retirePersistedStablePaneOwner` clears the binding → fresh spawn → **duplicate agent on one transcript**.

The codebase already knew this. `handlePtyReattachFailure` (`ssh-relay-session.ts`) carries a paragraph explaining exactly this union and **deliberately does not call `onPtyExit`**, publishing `-1` instead. `stable-owner.ts` was the one remaining path that did — with `0`.

Blame is `3bc13f7b8cb` (Aug 24); pre-existing, not from today's sweep. The existing test (`ssh-expired-lease-pane-readoption.test.ts`) passed `runtime: undefined`, so `onPtyExit` was never observable.

## The fix

The two relay situations were genuinely indistinguishable at the client — the same string produced both, and `SshPtyAbsentFromRelayError` was minted for the whole union. Following the `restoreRequired` precedent from #17951, the narrow case now gets its own token:

- **Relay** (`pty-handler.ts`): the `reapPtyProvenExited` refusal carries `PTY_ATTACH_PROVEN_EXITED_MARKER`. Additive on purpose — an unmarked answer, *including an older relay's*, stays ambiguous, so a missing marker is never evidence.
- **Client** (`ssh-pty-errors.ts`, `ssh-pty-session-reattach.ts`): that half is minted as `SshPtyProvenExitedOnRelayError`, a **subclass** of `SshPtyAbsentFromRelayError`, so every existing `isSshPtyAbsentFromRelayError` consumer (`spawn-execute.ts` ×2 lease bookkeeping) is unchanged.
- **`stable-owner.ts`**: publishes `UNVERIFIED_PROCESS_EXIT_CODE` (`-1`), the sentinel its sibling publishes, and passes `hostExitConfirmed: true` only for evidence that observed the process — the marked relay refusal, or `SessionNotFoundError` from the registry that *owns* the PTY. The ambiguous half now records `unverifiable`, not `exited`.
- **Discriminate by type, not text**: the gone-branch keys on `isHostReportedPtyAbsenceError` (classes) instead of `isPtyAlreadyGoneError`, whose bare `/PTY ".+" not found/` match let an untyped string abandon a binding. This is the discriminator `pty-connect-limits.ts` already documented on the renderer side.

`isPtyAlreadyGoneError` is untouched for the kill/teardown callers, where leniency is correct.

## What is deliberately *not* changed

The ambiguous case still retires the client's pane binding and falls through to a fresh spawn. That is client routing bookkeeping, not a claim about the process: after a relay change the old id is genuinely unroutable, and `docs/reference/ssh-execution-boundary.md` already documents that fallback. Refusing to retire would also strand the pane — `resolveStablePaneOwner` throws `terminal_pane_owner_conflict` once the runtime's pane→pty and persistence disagree. The destructive artifact was the **certificate**, and that is what is removed: the orphan now stays `unverifiable`, so the sweep, stop verdicts and `getPtyLivenessVerdict` keep failing closed over it.

## Tests

- `src/main/ipc/pty/pane/stable-pane-absence-death-certificate.test.ts` (new) — a **real `OrcaRuntimeService`**, so `onPtyExit` and the verdict register are observable. Covers the relay-restart case (`unverifiable`, no certificate), the pid-probed case (`exited`, binding retired — a genuinely dead PTY must still retire), the owning-registry case, and an untyped `not found` string (no verdict, persistence untouched).
- `src/relay/pty-handler-attach-replay.test.ts` — the same spec now asserts the probed refusal carries the marker and the "id the map never had" refusal does not.
- `src/main/providers/ssh-pty-reattach-absence-discrimination.test.ts` — the reattach path maps only the marked refusal to the proven class.
- `ssh-expired-lease-pane-readoption.test.ts` now throws the typed error the real SSH provider raises rather than raw wire text.

Failing before the fix (verified by reverting each half in place):

```
× records no death certificate when the relay merely does not know the id
    expected { status: 'exited' } to deeply equal { status: 'unverifiable', … }
× refuses to abandon the binding on an untyped "not found" string
× reports not-found and reaps a reattach whose backing shell is dead   (relay marker)
```

## Verification

- `pnpm tc` ✅
- `pnpm run check:code-quality:changed` ✅ (0 new findings across 10 files; `max-lines` proved live with a 320-line positive control)
- `oxfmt --check` ✅
- `pnpm test src` — see comment below
