### PR TITLE
fix(ssh): close the macOS relay's per-terminal pty fd leak

### DIFF
--- a/config/relay-assets/node-pty-1.1.0-master-cloexec-patch.cjs
+++ b/config/relay-assets/node-pty-1.1.0-master-cloexec-patch.cjs
@@ -1,16 +1,34 @@
 /**
- * Relay-side pty-master close-on-exec patch for node-pty 1.1.0 (#17915).
+ * Relay-side pty fd-leak patch for node-pty 1.1.0 (#17915).
  *
  * The app gets this through pnpm `patchedDependencies`; the relay installs stock
- * node-pty from npm onto the host, where no pnpm patch reaches. Without it every
- * later child of the relay -- pty children, git helpers, probes, agent CLIs --
- * inherits each live master fd and keeps its /dev/pts device alive for the life
- * of the relay (#8362).
+ * node-pty from npm onto the host, where no pnpm patch reaches. Stock 1.1.0 leaks
+ * a pty fd on both Unix relay platforms, by two unrelated bugs on two code paths.
  *
- * Linux only, deliberately: it is the only relay platform that takes forkpty()'s
- * no-atomic-O_CLOEXEC path, and the only one that already compiles node-pty at
- * install time, so the rebuild costs a second compile rather than a first one.
- * macOS re-opens the tty through uv_tty_init's cloexec dup and Windows has no fds.
+ * Linux takes forkpty(), which has no atomic O_CLOEXEC, so every later child of
+ * the relay -- pty children, git helpers, probes, agent CLIs -- inherits each live
+ * master and keeps its /dev/pts device alive for the life of the relay (#8362).
+ *
+ * macOS takes pty_posix_spawn(), which opens up to three throwaway ptys to push
+ * the real master off fds 0-2 and then never closes them: the cleanup loop is
+ * `for (; count > 0; count--)`, but in any running process the first posix_openpt()
+ * already returns >= 2, so the loop breaks with count == 0 and its body never runs
+ * -- and where it does run it closes low_fds[count], never low_fds[0]. Measured on
+ * darwin-arm64: one orphaned /dev/ptmx fd per terminal, never returned.
+ *
+ * macOS does not inherit the master into spawned children today, but not because it
+ * is marked: FD_CLOEXEC is not set on it (`lsof +fg` shows R,W,NB, no CX). What
+ * closes it is POSIX_SPAWN_CLOEXEC_DEFAULT in pty_posix_spawn's spawn flags, an
+ * Apple-only flag that closes every fd in the child. That is one option away from
+ * gone -- setting uid/gid drops libuv back to fork()/exec(), which honors nothing
+ * but FD_CLOEXEC -- so the master is marked on the Apple path too, exactly as the
+ * app's pnpm patch marks it. Windows has no fds and is excluded.
+ *
+ * The compile it buys differs by platform. Linux relays already run node-gyp at
+ * install time (1.1.0 ships no linux prebuild), so this is a second compile on a
+ * path that already compiles. macOS runs the shipped darwin prebuild and has no
+ * build/ at all, so this is its first compile -- the price of the only fix there
+ * is, since the bug is in the source that prebuild was built from.
  *
  * Non-fatal by construction: the working build is moved aside before anything is
  * touched and moved back on any failure, and a failed attempt drops a skip marker
@@ -31,7 +49,7 @@ const { dirname, join, resolve } = require('node:path')
 
 const EXPECTED_NODE_PTY_VERSION = '1.1.0'
 const ORIGINAL_SOURCE_SHA256 = '5e1005d6bdcfbe97b486ee415419fe7adae99035047f07340fbad36419e0bae6'
-const PATCHED_SOURCE_SHA256 = '97dea52199216c01b62070758f0f38621ae53adc16c221271dd35ae2d8ee3482'
+const PATCHED_SOURCE_SHA256 = '3e6bc1a688aae187d231687130cfc0a11781c672f5f616d73183d471ee8ee65c'
 
 const STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
 const SKIP_MARKER_FILENAME = '.node-pty-cloexec-skip'
@@ -97,7 +115,56 @@ const FORKPTY_CALL_SITE = [
 `
 ]
 
-const REPLACEMENTS = [FORWARD_DECLARATION, DEFINITION, FORKPTY_CALL_SITE]
+// Apple never reaches FORKPTY_CALL_SITE: `default:` sits in the `#else` arm of PtyFork's
+// `#if defined(__APPLE__)`, so before this pair the asset patched nothing macOS executes.
+const POSIX_SPAWN_CALL_SITE = [
+  `  if (pty_nonblock(master) == -1) {
+    throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+  }
+#else
+`,
+  `  if (pty_nonblock(master) == -1) {
+    throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+  }
+  if (pty_cloexec(master) == -1) {
+    throw Napi::Error::New(napiEnv, "Could not set master fd to close-on-exec.");
+  }
+#else
+`
+]
+
+// The throwaway ptys pty_posix_spawn opens to keep the real master off fds 0-2. Byte-identical to
+// the app's pnpm patch, so both trees compile the same cleanup.
+const LOW_FDS_DECLARATION = [
+  `  int low_fds[3];
+  size_t count = 0;
+`,
+  `  int low_fds[3] = {-1, -1, -1};
+  size_t count = 0;
+`
+]
+
+const LOW_FDS_CLEANUP = [
+  `  for (; count > 0; count--) {
+    close(low_fds[count]);
+  }
+`,
+  `  for (size_t i = 0; i <= count && i < 3; i++) {
+    if (low_fds[i] != -1) {
+      close(low_fds[i]);
+    }
+  }
+`
+]
+
+const REPLACEMENTS = [
+  FORWARD_DECLARATION,
+  DEFINITION,
+  POSIX_SPAWN_CALL_SITE,
+  FORKPTY_CALL_SITE,
+  LOW_FDS_DECLARATION,
+  LOW_FDS_CLEANUP
+]
 
 function sourceSha256(source) {
   return createHash('sha256').update(source).digest('hex')
@@ -188,10 +255,12 @@ function rebuildNodePty(relayDir) {
   }
 }
 
-// Why a child: a bad build can abort the process on require, which would strand the
-// moved-aside working build. Why the reachability check: a host without /proc cannot
-// show inheritance, and an unobservable flag is not evidence the rebuild was wrong.
-const VERIFY_SCRIPT = `
+// Why a child, for both scripts below: a bad build can abort the process on require, which would
+// strand the moved-aside working build. Why each ends in a reachability check: a host that cannot
+// show its fds says nothing, and an unobservable flag is not evidence the rebuild was wrong.
+//
+// Linux's leak is inheritance, so the observation is a later plain child's /proc/self/fd.
+const VERIFY_INHERITANCE_SCRIPT = `
 const pty = require(process.argv[1]);
 const term = pty.spawn('/bin/sh', ['-c', 'exit 0'], {
   name: 'xterm-256color', cols: 80, rows: 24, cwd: process.cwd(), env: process.env
@@ -200,13 +269,39 @@ const probe = require('node:child_process').spawnSync('/bin/sh', ['-c', 'ls -l /
 try { term.kill() } catch {}
 const listing = probe.stdout || '';
 if (probe.status !== 0 || !listing.includes('->')) { console.log('UNVERIFIED'); process.exit(0) }
-console.log(listing.includes('ptmx') ? 'INHERITED' : 'ISOLATED');
+console.log(listing.includes('ptmx') ? 'LEAKED' : 'ISOLATED');
 process.exit(0);
 `
 
-/** 'isolated' when a later plain child no longer inherits the master, 'unverified' when /proc cannot say. */
-function verifyMasterNotInheritedByLaterChild(relayDir) {
-  const result = spawnSync(process.execPath, ['-e', VERIFY_SCRIPT, nodePtyDir(relayDir)], {
+// Apple's leak is self-held, not inherited, so the observation is this process's own fd table:
+// N live ptys must account for exactly N /dev/ptmx rows. A stock build shows 2N -- the master plus
+// the throwaway pty_posix_spawn opened and never closed. lsof, not /proc, because macOS has no
+// /proc; a host without lsof cannot say, which is 'unverified', not a failed patch.
+const VERIFY_SELF_FDS_SCRIPT = `
+const pty = require(process.argv[1]);
+const terms = [];
+for (let i = 0; i < 3; i++) {
+  terms.push(pty.spawn('/bin/sh', ['-c', 'sleep 30'], {
+    name: 'xterm-256color', cols: 80, rows: 24, cwd: process.cwd(), env: process.env
+  }));
+}
+const probe = require('node:child_process').spawnSync('/bin/sh', ['-c', 'lsof -p ' + process.pid], { encoding: 'utf8', maxBuffer: 1 << 24 });
+for (const term of terms) { try { term.kill() } catch {} }
+const rows = (probe.stdout || '').split('\\n').filter((line) => line.includes('/dev/ptmx'));
+if (probe.status !== 0 || rows.length < terms.length) { console.log('UNVERIFIED'); process.exit(0) }
+console.log(rows.length > terms.length ? 'LEAKED' : 'ISOLATED');
+process.exit(0);
+`
+
+const LEAK_MESSAGE = {
+  darwin: 'rebuilt node-pty still leaks a throwaway pty fd per spawn',
+  linux: 'rebuilt node-pty still leaks the pty master into later children'
+}
+
+/** 'isolated' when the platform's leak is gone, 'unverified' when the host cannot show it. */
+function verifyNoPtyFdLeak(relayDir, platform) {
+  const script = platform === 'darwin' ? VERIFY_SELF_FDS_SCRIPT : VERIFY_INHERITANCE_SCRIPT
+  const result = spawnSync(process.execPath, ['-e', script, nodePtyDir(relayDir)], {
     cwd: relayDir,
     encoding: 'utf8',
     timeout: VERIFY_TIMEOUT_MS,
@@ -219,22 +314,53 @@ function verifyMasterNotInheritedByLaterChild(relayDir) {
       `rebuilt node-pty did not load: ${tail || result.error?.message || result.signal}`
     )
   }
-  if (output.includes('INHERITED')) {
-    throw new Error('rebuilt node-pty still leaks the pty master into later children')
+  if (output.includes('LEAKED')) {
+    throw new Error(LEAK_MESSAGE[platform] || LEAK_MESSAGE.linux)
   }
   return output.includes('ISOLATED') ? 'isolated' : 'unverified'
 }
 
-function rollback(relayDir, releaseDir, backupDir) {
-  rmSync(releaseDir, { recursive: true, force: true })
+/**
+ * What gets moved aside before the compile, and where the compile writes.
+ *
+ * Linux ships no prebuild, so `build/Release` is both the working build and the compile's output,
+ * and moving it aside only arms the rollback. macOS runs `prebuilds/darwin-<arch>` and has no
+ * `build/` at all, so the compile writes a new `build/Release` -- which node-pty's loader checks
+ * ahead of `prebuilds`. Moving `prebuilds` aside does double duty there: it arms the rollback and
+ * it is what makes node-pty's install script fall through from "prebuild found" to `node-gyp
+ * rebuild`. Deliberately not `npm_config_build_from_source`, which deletes the prebuilds outright
+ * and would leave nothing to roll back to.
+ */
+function buildLayout(relayDir, platform, arch) {
+  const ptyDir = nodePtyDir(relayDir)
+  const compiledDir = join(ptyDir, 'build', 'Release')
+  if (platform === 'darwin') {
+    const prebuildsDir = join(ptyDir, 'prebuilds')
+    return {
+      compiledDir,
+      movedDir: prebuildsDir,
+      workingBuildPath: join(prebuildsDir, `darwin-${arch}`, 'pty.node'),
+      missingStatus: 'skipped:no-prebuild'
+    }
+  }
+  return {
+    compiledDir,
+    movedDir: compiledDir,
+    workingBuildPath: join(compiledDir, 'pty.node'),
+    missingStatus: 'skipped:no-compiled-build'
+  }
+}
+
+function rollback(relayDir, layout, backupDir) {
+  rmSync(layout.compiledDir, { recursive: true, force: true })
   try {
     revertNodePtyMasterCloexecSource(relayDir)
   } catch {
     // The build that is about to be restored predates the patch either way.
   }
   if (existsSync(backupDir)) {
-    mkdirSync(dirname(releaseDir), { recursive: true })
-    renameSync(backupDir, releaseDir)
+    mkdirSync(dirname(layout.movedDir), { recursive: true })
+    renameSync(backupDir, layout.movedDir)
   }
 }
 
@@ -244,16 +370,17 @@ function rollback(relayDir, releaseDir, backupDir) {
  */
 function applyNodePtyMasterCloexecPatch(relayDir = process.cwd(), options = {}) {
   const platform = options.platform || process.platform
+  const arch = options.arch || process.arch
   const rebuild = options.rebuild || rebuildNodePty
-  const verify = options.verify || verifyMasterNotInheritedByLaterChild
-  if (platform !== 'linux') {
-    return 'skipped:not-linux'
+  const verify = options.verify || verifyNoPtyFdLeak
+  if (platform !== 'linux' && platform !== 'darwin') {
+    return 'skipped:unsupported-platform'
   }
   const skipMarkerPath = join(relayDir, SKIP_MARKER_FILENAME)
   if (existsSync(skipMarkerPath)) {
     return 'skipped:earlier-attempt-failed'
   }
-  const releaseDir = join(nodePtyDir(relayDir), 'build', 'Release')
+  const layout = buildLayout(relayDir, platform, arch)
   const backupDir = join(nodePtyDir(relayDir), BACKUP_DIRNAME)
   // A backup stranded by a connection that died mid-rebuild is stale by definition:
   // whatever repaired node-pty since built from the source now on disk.
@@ -272,25 +399,28 @@ function applyNodePtyMasterCloexecPatch(relayDir = process.cwd(), options = {}) 
   if (hash !== ORIGINAL_SOURCE_SHA256) {
     return 'skipped:unexpected-source'
   }
-  // No compiled build means the host runs a prebuild or nothing at all; rebuilding
-  // could only take away the artifact the probe just proved loadable.
-  if (!existsSync(join(releaseDir, 'pty.node'))) {
-    return 'skipped:no-compiled-build'
+  // Nothing to fall back on means the host runs neither a compile nor the prebuild
+  // this platform expects; rebuilding could only take away the artifact the probe
+  // just proved loadable.
+  if (!existsSync(layout.workingBuildPath)) {
+    return layout.missingStatus
   }
 
   try {
-    renameSync(releaseDir, backupDir)
+    renameSync(layout.movedDir, backupDir)
   } catch (err) {
     return `skipped:${err.message}`
   }
   try {
     patchNodePtyMasterCloexecSource(relayDir)
     rebuild(relayDir)
-    const verdict = verify(relayDir)
+    const verdict = verify(relayDir, platform)
+    // Discarded, not restored: a tree that gets published must hold no unpatched binary the
+    // loader could still fall back to. A later repair recompiles from the patched source.
     rmSync(backupDir, { recursive: true, force: true })
     return verdict === 'isolated' ? 'patched' : 'patched-unverified'
   } catch (err) {
-    rollback(relayDir, releaseDir, backupDir)
+    rollback(relayDir, layout, backupDir)
     // Bounded on purpose: one compile attempt per relay directory, never a retry loop.
     try {
       writeFileSync(skipMarkerPath, `${new Date().toISOString()} ${err.message}\n`)

--- a/config/scripts/node-pty-master-cloexec-patch.test.mjs
+++ b/config/scripts/node-pty-master-cloexec-patch.test.mjs
@@ -27,7 +27,7 @@ afterEach(() => {
   }
 })
 
-describe('SSH relay node-pty pty-master close-on-exec patch', () => {
+describe('SSH relay node-pty pty fd-leak patch', () => {
   it('adds the forkpty close-on-exec call and reverts to the published bytes', () => {
     const fixture = writeRelayFixture()
 
@@ -42,6 +42,27 @@ describe('SSH relay node-pty pty-master close-on-exec patch', () => {
 
     expect(revertNodePtyMasterCloexecSource(fixture.root)).toBe(true)
     expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+  })
+
+  it('rewrites the Apple branch, which is the only one macOS executes', () => {
+    const fixture = writeRelayFixture()
+    patchNodePtyMasterCloexecSource(fixture.root)
+    const patched = readFileSync(fixture.sourcePath, 'utf8')
+
+    // Stock's cleanup never runs: the first posix_openpt() already returns >= 2, so the loop
+    // breaks with count == 0 -- and where it does run it closes low_fds[count], never low_fds[0].
+    expect(STOCK_SOURCE).toContain('for (; count > 0; count--) {')
+    expect(patched).not.toContain('for (; count > 0; count--) {')
+    expect(patched).toContain('int low_fds[3] = {-1, -1, -1};')
+    expect(patched).toContain('for (size_t i = 0; i <= count && i < 3; i++) {')
+
+    // `default:` sits in the `#else` arm of PtyFork's `#if defined(__APPLE__)`, so marking only
+    // the forkpty call site left the master macOS actually opens unmarked.
+    expect(patched).toContain(
+      '  if (pty_cloexec(master) == -1) {\n' +
+        '    throw Napi::Error::New(napiEnv, "Could not set master fd to close-on-exec.");\n' +
+        '  }\n#else\n'
+    )
   })
 
   it('refuses a different node-pty version or an unrecognized source', () => {
@@ -139,19 +160,81 @@ describe('SSH relay node-pty pty-master close-on-exec patch', () => {
     expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
   })
 
-  it('never compiles on a platform that does not leak', () => {
-    for (const platform of ['darwin', 'win32']) {
-      const fixture = writeRelayFixture()
-      const calls = []
-      const status = applyNodePtyMasterCloexecPatch(fixture.root, {
-        platform,
-        rebuild: () => calls.push('rebuild'),
-        verify: () => 'isolated'
-      })
-      expect(status).toBe('skipped:not-linux')
-      expect(calls).toEqual([])
-      expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
-    }
+  it('never compiles on a platform with no pty fds to leak', () => {
+    const fixture = writeRelayFixture()
+    const calls = []
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'win32',
+      rebuild: () => calls.push('rebuild'),
+      verify: () => 'isolated'
+    })
+    expect(status).toBe('skipped:unsupported-platform')
+    expect(calls).toEqual([])
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+  })
+
+  it('compiles a macOS install out from under its shipped prebuild', () => {
+    // macOS has no build/ at all: node-pty runs `prebuilds/darwin-<arch>`, built from the leaky
+    // source. Moving `prebuilds` aside is what both arms the rollback and makes node-pty's own
+    // install script fall through from "prebuild found" to node-gyp.
+    const fixture = writeRelayFixture({ platform: 'darwin' })
+    const prebuildsPresentDuringRebuild = []
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'darwin',
+      arch: fixture.arch,
+      rebuild: () => {
+        prebuildsPresentDuringRebuild.push(existsSync(fixture.prebuildsDir))
+        writeCompiledBuild(fixture, 'patched-build')
+      },
+      verify: () => 'isolated'
+    })
+
+    expect(status).toBe('patched')
+    expect(prebuildsPresentDuringRebuild).toEqual([false])
+    expect(readFileSync(fixture.compiledPath, 'utf8')).toBe('patched-build')
+    // The published tree must hold no unpatched binary: node-pty's loader checks build/Release
+    // first, but falls back to a prebuild if that ever fails to load.
+    expect(existsSync(fixture.prebuildsDir)).toBe(false)
+    expect(existsSync(fixture.backupDir)).toBe(false)
+  })
+
+  it('restores the macOS prebuild when the first compile fails', () => {
+    // A macOS host has no toolchain guarantee at all, so this is the common failure, not the rare
+    // one -- and the relay has to come back on the prebuild exactly as it was installed.
+    const fixture = writeRelayFixture({ platform: 'darwin' })
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'darwin',
+      arch: fixture.arch,
+      rebuild: () => {
+        writeCompiledBuild(fixture, 'half-built')
+        throw new Error('npm rebuild node-pty exited 1: no C++ toolchain')
+      },
+      verify: () => 'isolated'
+    })
+
+    expect(status).toContain('failed:')
+    expect(readFileSync(fixture.buildPath, 'utf8')).toBe('stock-build')
+    expect(existsSync(fixture.compiledPath)).toBe(false)
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
+    expect(existsSync(fixture.skipMarkerPath)).toBe(true)
+  })
+
+  it('will not rebuild a macOS install that has no prebuild to fall back on', () => {
+    const fixture = writeRelayFixture({ platform: 'darwin', build: false })
+    const calls = []
+
+    const status = applyNodePtyMasterCloexecPatch(fixture.root, {
+      platform: 'darwin',
+      arch: fixture.arch,
+      rebuild: () => calls.push('rebuild'),
+      verify: () => 'isolated'
+    })
+
+    expect(status).toBe('skipped:no-prebuild')
+    expect(calls).toEqual([])
+    expect(readFileSync(fixture.sourcePath, 'utf8')).toBe(STOCK_SOURCE)
   })
 
   it('leaves an already patched install alone', () => {
@@ -201,19 +284,35 @@ describe('SSH relay node-pty pty-master close-on-exec patch', () => {
   })
 })
 
-function writeRelayFixture({ version = '1.1.0', source = STOCK_SOURCE, build = true } = {}) {
+/**
+ * `buildPath` is the working build the patch has to be able to fall back on, which differs by
+ * platform: Linux compiles into build/Release at install time, macOS runs a shipped prebuild and
+ * has no build/ at all. `compiledPath` is where the rebuild writes on either.
+ */
+function writeRelayFixture({
+  version = '1.1.0',
+  source = STOCK_SOURCE,
+  build = true,
+  platform = 'linux',
+  arch = 'arm64'
+} = {}) {
   const root = mkdtempSync(join(projectDir, '.node-pty-cloexec-patch-test-'))
   cleanupDirs.push(root)
   const nodePtyDir = join(root, 'node_modules', 'node-pty')
   const sourcePath = join(nodePtyDir, 'src', 'unix', 'pty.cc')
-  const buildPath = join(nodePtyDir, 'build', 'Release', 'pty.node')
+  const compiledPath = join(nodePtyDir, 'build', 'Release', 'pty.node')
+  const prebuildsDir = join(nodePtyDir, 'prebuilds')
   mkdirSync(join(nodePtyDir, 'src', 'unix'), { recursive: true })
   writeFileSync(join(nodePtyDir, 'package.json'), JSON.stringify({ version }))
   writeFileSync(sourcePath, source)
   const fixture = {
     root,
+    arch,
     sourcePath,
-    buildPath,
+    compiledPath,
+    prebuildsDir,
+    buildPath:
+      platform === 'darwin' ? join(prebuildsDir, `darwin-${arch}`, 'pty.node') : compiledPath,
     backupDir: join(nodePtyDir, '.orca-cloexec-prepatch-release'),
     skipMarkerPath: join(root, SKIP_MARKER_FILENAME)
   }
@@ -226,4 +325,9 @@ function writeRelayFixture({ version = '1.1.0', source = STOCK_SOURCE, build = t
 function writeBuild(fixture, contents) {
   mkdirSync(resolve(fixture.buildPath, '..'), { recursive: true })
   writeFileSync(fixture.buildPath, contents)
+}
+
+function writeCompiledBuild(fixture, contents) {
+  mkdirSync(resolve(fixture.compiledPath, '..'), { recursive: true })
+  writeFileSync(fixture.compiledPath, contents)
 }

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -52,6 +52,7 @@ import {
   RELAY_DEPLOY_TIMEOUT_MS
 } from './ssh-relay-deploy-timing'
 import { createSshOperationAbortError, shellEscape } from './ssh-connection-utils'
+import { isWindowsRelayPlatform } from '../../shared/relay-artifacts'
 import {
   probeBuildToolchain,
   formatMissingToolchainError,
@@ -745,27 +746,29 @@ const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-
 const NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME = 'node-pty-1.1.0-master-cloexec-patch.cjs'
 const NODE_PTY_CLOEXEC_STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
 /**
- * Whether the tree the patch left behind still leaks the pty master into every later child.
- * `fixed` is the only outcome a shared cache entry may be published from.
+ * Whether the tree the patch left behind still leaks a pty fd -- the master into every later child
+ * on Linux, a throwaway /dev/ptmx per spawn on macOS. `fixed` is the only outcome a shared cache
+ * entry may be published from.
  */
 type NodePtyMasterCloexecOutcome = 'fixed' | 'unfixed'
 /**
  * The statuses that leave a non-leaking tree. Deliberately an allowlist, not a `failed:` denylist:
- * the script's `skipped:` family is mixed. `skipped:not-linux` is a platform that never leaks, but
- * `skipped:earlier-attempt-failed`, `skipped:no-compiled-build`, `skipped:unexpected-source` and
- * the two `skipped:<errno>` forms all mean the patch was refused and the leaky build is still on
- * disk -- indistinguishable from `failed:` as far as what gets published.
+ * the script's `skipped:` family is mixed. `skipped:unsupported-platform` is a platform that never
+ * leaks, but `skipped:earlier-attempt-failed`, `skipped:no-compiled-build`, `skipped:no-prebuild`,
+ * `skipped:unexpected-source` and the two `skipped:<errno>` forms all mean the patch was refused
+ * and the leaky build is still on disk -- indistinguishable from `failed:` as far as what gets
+ * published.
  */
 const NODE_PTY_CLOEXEC_FIXED_STATUSES: ReadonlySet<string> = new Set([
   'patched',
-  // The rebuild ran from patched source; only the isolation check could not observe the result.
-  // An unobservable check is not a failed patch, and treating it as one would disable the shared
-  // cache on every host without `lsof`.
+  // The rebuild ran from patched source; only the leak check could not observe the result. An
+  // unobservable check is not a failed patch, and treating it as one would disable the shared
+  // cache on every host without `/proc` or `lsof`.
   'patched-unverified',
   'already-patched',
-  // Unreachable while the platform gate below short-circuits first, but it is the one `skipped:`
-  // that means "nothing to fix" rather than "would not fix it".
-  'skipped:not-linux'
+  // Unreachable while the platform gate below short-circuits Windows first, but it is the one
+  // `skipped:` that means "nothing to fix" rather than "would not fix it".
+  'skipped:unsupported-platform'
 ])
 // Exported for the relay-native-dependency-coverage test, which asserts every
 // native addon the relay bundle imports is either installed here or explicitly
@@ -1300,7 +1303,7 @@ async function installNativeDeps(
 }
 
 /**
- * Re-apply the pty-master FD_CLOEXEC patch the app gets from pnpm to the host's npm copy (#17915).
+ * Re-apply the pty fd-leak patch the app gets from pnpm to the host's npm copy (#17915).
  *
  * Why it is safe to rebuild under a live relay: this only runs from installNativeDeps, so only on a
  * freshly created directory or a locked repair, and a relay already serving PTYs has pty.node mapped
@@ -1324,9 +1327,11 @@ async function applyNodePtyMasterCloexecPatch(
   nodePath: string,
   signal?: AbortSignal
 ): Promise<NodePtyMasterCloexecOutcome> {
-  // Linux is the only relay platform that takes forkpty()'s no-O_CLOEXEC path; macOS and Windows
-  // ship prebuilds, so forcing a rebuild there would add a first compile to fix nothing.
-  if (isWindowsRemoteHost(hostPlatform) || !platform.startsWith('linux')) {
+  // Both Unix relay platforms leak, by different bugs: Linux inherits the master through forkpty()'s
+  // no-O_CLOEXEC path, macOS orphans one throwaway /dev/ptmx fd per spawn in pty_posix_spawn. Only
+  // Windows, which has no fds, is short-circuited -- and answering 'fixed' from a gate that ran
+  // nothing is exactly how a leaking darwin tree got published to the shared cache.
+  if (isWindowsRemoteHost(hostPlatform) || isWindowsRelayPlatform(platform)) {
     return 'fixed'
   }
   try {

--- a/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
+++ b/src/main/ssh/ssh-relay-pty-master-cloexec-install.test.ts
@@ -88,11 +88,12 @@ import {
 const PATCH_ASSET = 'node-pty-1.1.0-master-cloexec-patch.cjs'
 
 /**
- * The relay installs stock node-pty from npm, so the app's pnpm patch never reaches it and every
- * later child of the relay inherits a live pty master (#17915). The compile that closes it sits on
+ * The relay installs stock node-pty from npm, so the app's pnpm patch never reaches it and the
+ * relay leaks a pty fd per terminal (#17915) -- the master into every later child on Linux, an
+ * orphaned /dev/ptmx throwaway in `pty_posix_spawn` on macOS. The compile that closes both sits on
  * the connect path, so what these specs pin is the blast radius, not the patch itself.
  */
-describe('relay pty-master close-on-exec patch on the install path', () => {
+describe('relay pty fd-leak patch on the install path', () => {
   const sftpCapture: SftpWriteCapture = {
     paths: [],
     contents: {},
@@ -211,9 +212,9 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
   })
 
   it('does not publish a tree the patch refused to touch', async () => {
-    // `skipped:` is not one verdict. Every form except `skipped:not-linux` means the patch was
-    // declined and the leaky build is still on disk, which is indistinguishable from `failed:`
-    // as far as what would get published.
+    // `skipped:` is not one verdict. Every form except `skipped:unsupported-platform` means the
+    // patch was declined and the leaky build is still on disk, which is indistinguishable from
+    // `failed:` as far as what would get published.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     try {
       const conn = makeMockConnection(sftpCapture)
@@ -281,25 +282,39 @@ describe('relay pty-master close-on-exec patch on the install path', () => {
     expect(patchCommands()).toEqual([])
   })
 
-  it('never adds a compile to a macOS relay, which does not leak the master', async () => {
+  it('runs the patch on a macOS relay, which orphans a /dev/ptmx fd per spawn', async () => {
+    // macOS takes `pty_posix_spawn`, not forkpty, so the asset's original replacements rewrote
+    // nothing macOS executes -- and this gate answered 'fixed' without running anything, which is
+    // exactly what publishes to the shared cache. Every later host on the machine then linked a
+    // tree that leaks one /dev/ptmx fd per terminal, measured +1 per open/close cycle on
+    // darwin-arm64. macOS pays a first compile here, unlike Linux's second, and that is the price.
     vi.mocked(parseUnameToRelayPlatform).mockReturnValue('darwin-arm64')
     const conn = makeMockConnection(sftpCapture)
-    feed([
-      ...makeStagedFirstInstallExecPrefix(),
-      '', // npm install native deps
-      '', // chmod prebuilds
-      'ORCA-NPTY-PROBE-OK\n',
-      '', // rm probe stderr
-      '', // promote into the shared native-deps cache
-      '', // clean stage root
-      'DEAD',
-      '', // publish the per-launch credential
-      'READY'
-    ])
+    feed(makeExecResponses({ npmInstall: 'ok', probe: 'ok' }))
 
     await deployAndLaunchRelay(conn)
 
-    expect(patchCommands()).toEqual([])
+    expect(patchCommands()).toHaveLength(1)
+    expect(promoted()).toBe(true)
+  })
+
+  it('does not publish a macOS tree whose compile failed', async () => {
+    // The darwin rollback restores the shipped prebuild, so the relay still works -- and that is
+    // precisely why the status, not the exit code, has to decide publishability: a rolled-back
+    // macOS tree probes loadable and still leaks.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      vi.mocked(parseUnameToRelayPlatform).mockReturnValue('darwin-arm64')
+      const conn = makeMockConnection(sftpCapture)
+      feed(firstInstallReporting('failed:npm rebuild node-pty exited 1: gyp ERR! not ok'))
+
+      await deployAndLaunchRelay(conn)
+
+      expect(patchCommands()).toHaveLength(1)
+      expect(promoted()).toBe(false)
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('connects anyway when the patch command fails outright', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​156 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​187 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​52 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​135 |

<!-- /orca-pr-loc -->

Closes the half of #17915 that #17920 could not have found: **macOS relay hosts leak one `/dev/ptmx` fd per terminal**, and the gate that decides publishability answered `fixed` for them without running anything.

## Two bugs, one gate

**1. The asset patched nothing macOS executes.** `FORKPTY_CALL_SITE` targets `default:`, which sits in the `#else` arm of `PtyFork`'s `#if defined(__APPLE__)` (`pty.cc:378`). macOS takes `pty_posix_spawn`. `grep -c low_fds config/relay-assets/node-pty-1.1.0-master-cloexec-patch.cjs` returned 0.

**2. The platform gate short-circuited before the script.** `applyNodePtyMasterCloexecPatch` returned `'fixed'` for any non-Linux/Windows host, and `'fixed'` is what gates `promoteRelayNativeDepsCache`. A `darwin-arm64-<hash>` entry was therefore published to `~/.orca-remote/native/` as non-leaking, so every later host on that machine links a tree that leaks an fd per terminal.

The leak itself is in stock `pty_posix_spawn`, which opens up to three throwaway ptys to push the real master off fds 0-2 and never closes them:

```c
for (; count > 0; count--) {
  close(low_fds[count]);
}
```

In any running process the first `posix_openpt()` already returns >= 2, so the loop breaks with `count == 0` and **the body never runs** — and where it does run it closes `low_fds[count]`, never `low_fds[0]`. Linux takes `forkpty()` and has no `low_fds` block at all, which is why Linux and Docker testing could never surface this.

## Measured on real darwin-arm64 hardware

A relay-shaped directory running `installNativeDeps`' own commands (relay `package.json` with `allowScripts`, `npm install --ignore-scripts=false --omit=dev --no-audit --no-fund node-pty@1.1.0 @parcel/watcher@2.5.6`, the `find … -name spawn-helper -exec chmod +x` line, the native-deps probe, then `node node-pty-1.1.0-master-cloexec-patch.cjs`). One PTY per open/close cycle:

```
== native deps probe ==      ORCA-NPTY-PROBE-OK
== BEFORE ==
cycle:ptmx  1:1  2:2  3:3  4:4  5:5  6:6  7:7  8:8  9:9  10:10
after 3s settle: ptmx=10
== cloexec patch ==          ORCA-NPTY-CLOEXEC:patched
== AFTER ==
cycle:ptmx  1:0  2:0  3:0  4:0  5:0  6:0  7:0  8:0  9:0  10:0
after 3s settle: ptmx=0
```

**Flat where it grew +1 per cycle, and 0 retained rather than 10.** Total patch + compile time: **8.5s**. Second run: `already-patched`.

The SSH transport itself was not exercised on a Mac — Remote Login is off on the machine available to me and enabling it needs a password I do not have. What is reproduced is the entire host-side half, which is all the SSH channel carries: the command in, the `ORCA-NPTY-CLOEXEC:` status line out.

## Correcting a false comment, with the measurement

The asset claimed *"macOS re-opens the tty through uv_tty_init's cloexec dup."* Measured false — `lsof +fg` on a stock build shows `R,W,NB`, **no `CX`**. What actually closes the master in children is `POSIX_SPAWN_CLOEXEC_DEFAULT` in `pty_posix_spawn`'s spawn flags, an Apple-only flag closing every fd in the spawned child. That is one option away from gone: setting `uid`/`gid` drops libuv back to `fork()`/`exec()`, which honors nothing but `FD_CLOEXEC`. So this also ports the app patch's Apple-branch `pty_cloexec(master)` call. After:

```
node  39744  nwparker  12u  CHR  R,W,NB;CX  15,161  0t0  605  /dev/ptmx
```

Both new C hunks are byte-identical to `config/patches/node-pty@1.1.0.patch`, so the desktop and the relay compile the same cleanup.

## macOS needs a different build layout, not a wider gate

Flipping the gate alone would have done nothing. node-pty 1.1.0 ships `prebuilds/darwin-{x64,arm64}` and **no `build/` at all** on macOS, so the existing `skipped:no-compiled-build` guard would have refused, and `npm rebuild` would no-op (`scripts/prebuild.js` exits 0 when the prebuild is present).

`buildLayout()` splits it:

| | fallback moved aside | compile writes | guard |
|---|---|---|---|
| linux | `build/Release` | `build/Release` | `skipped:no-compiled-build` |
| darwin | `prebuilds` | `build/Release` | `skipped:no-prebuild` |

Moving `prebuilds` aside does double duty on darwin: it arms the rollback **and** it is what makes node-pty's install script fall through from "prebuild found" to `node-gyp rebuild`. Deliberately not `npm_config_build_from_source`, which deletes the prebuilds outright and would leave nothing to roll back to. `loadNativeModule` checks `build/Release` before `prebuilds`, so the compiled artifact wins; on success the prebuild is **discarded**, matching Linux, so no unpatched binary survives in a tree that gets published.

Verification is per-platform too, because the leaks differ in kind: Linux's is inheritance (a later plain child's `/proc/self/fd`), macOS's is self-held (this process's own `lsof`, N live ptys must account for exactly N `/dev/ptmx` rows). Either returns `patched-unverified` rather than failing when the host cannot show its fds.

## Failure behaviour, verified on the same Mac

macOS has no toolchain guarantee, so a failed compile is the common case, not the rare one. With `binding.gyp` corrupted:

```
STATUS: failed:npm rebuild node-pty exited 1: gyp ERR! ...
source reverted:      true      prebuilds restored:  true
build/Release removed:true      backup discarded:    true
skip marker written:  true      node-pty still loads: yes
SECOND ATTEMPT:       skipped:earlier-attempt-failed
```

`failed:` is not in `NODE_PTY_CLOEXEC_FIXED_STATUSES`, so the rolled-back tree is **not published** — which matters more on darwin than on Linux, because the rollback restores a working prebuild and the tree therefore probes loadable while still leaking. #17920's promotion gate is exactly what catches that.

## Linux is unaffected

`pty_posix_spawn` is inside `#if defined(__APPLE__)`; Linux never compiles it. Re-verified in `docker node:22` against a real npm install:

```
BEFORE  later child sees ptmx: true
patch   ORCA-NPTY-CLOEXEC:patched
AFTER   later child sees ptmx: false
2nd run ORCA-NPTY-CLOEXEC:already-patched
```

`build/Release` present, `prebuilds` untouched (node-pty ships no linux prebuild). The `default:` call site, the `pty_cloexec` definition and the forward declaration are unchanged; the only Linux-visible change is the verify script's token (`INHERITED` → `LEAKED`, shared with the darwin script), same verdict logic.

## Cache keys

**The key changes with the patch bytes** — `computeRelayNativeDepsCacheKey` hashes each patch artifact's contents (`ssh-relay-native-deps-cache.ts:90`), and `RELAY_NATIVE_DEPS_PATCH_ARTIFACT_PATTERN` matches this asset. Already-published leaky `darwin-*` entries are therefore **naturally orphaned**: a patched build mints a new key and can never link the old one. No eviction is needed — once their relay dirs are GC'd they are unreferenced and `gcRelayNativeDepsCache` reclaims them under its existing tombstone protocol. Same for the relay directory itself, which is content-hashed over the manifest the asset is part of.

## Cost

macOS pays a **first** compile, where Linux pays a second on a path that already compiles. Measured 8.5s end to end on darwin-arm64, once per relay directory ever, bounded by the skip marker, behind the probe that already proved node-pty loadable. That is the price of the only fix there is: the bug is in the source the prebuild was built from.

## Verification

- `pnpm tc` clean; `pnpm test src/main/ssh` 2070 passed / 16 skipped; `config/scripts/node-pty-master-cloexec-patch.test.mjs` 14 passed; `pnpm run check:code-quality:changed` 0 new findings.
- New specs: the Apple-branch rewrite (anchors + the stock loop's absence), the darwin prebuild layout, darwin rollback, `skipped:no-prebuild`, and — inverting the old `never adds a compile to a macOS relay` case — that a darwin relay now runs the patch and promotes, and that a failed darwin compile does not.

Refs #17915
Refs #8362


---

### Note: `static analysis` is red for a reason that predates this PR

`Verify runtime-required localization catalog` fails on this branch and on **every** PR based on `main` since `c79e1c097b7` ("fix(i18n): localize remaining onboarding UI", landed on `main` today). That commit added 35 keys to `src/renderer/src/i18n/locales/en.json` and never regenerated `src/renderer/src/i18n/en-runtime-required.json`, whose last change is the unrelated #18326. The four keys the gate names are `components.onboarding.integrations.capabilities.{browseIssues,managePullRequests,reviewStatus,startWorkspaceFromIssue}` — no file in this PR touches i18n or onboarding. The fix is one command on `main`, `pnpm run sync:localization-runtime-catalog`, and is deliberately not bundled into a relay fd-leak PR. `verify` is red only because it aggregates that job.

All 8 `test` shards, `typecheck`, `package` and `package (windows)` pass.
