### PR TITLE
fix(cloud): run the rehome control job under pipefail

### DIFF
--- a/.github/workflows/cloud-operate-relay-production-rehome-job.yml
+++ b/.github/workflows/cloud-operate-relay-production-rehome-job.yml
@@ -26,6 +26,9 @@ permissions:
 
 defaults:
   run:
+    # `shell: bash` adds pipefail; without it `node ... | tee` reports tee's exit code and a
+    # thrown inspect/apply passed green (Aug 28-29 and Sep 3 2026 runs).
+    shell: bash
     working-directory: cloud
 
 jobs:

--- a/cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs
+++ b/cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs
@@ -191,3 +191,10 @@ test('director rollout has a strict one-time identity bootstrap', () => {
   assert.ok(candidateProof > 0 && candidateProof < trafficMove)
   assert.equal(script.indexOf('verifyRehomeDisabled', trafficMove), -1)
 })
+
+test('rehome job pipes every control result through tee under pipefail', () => {
+  const job = workflow('operate-relay-production-rehome-job.yml')
+  // Without `shell: bash` the step exit code is tee's, so a thrown inspect/apply passes green.
+  assert.match(job, /defaults:\n  run:\n(?:    #.*\n)*    shell: bash\n/)
+  assert.ok((job.match(/\| tee "\$\{RUNNER_TEMP\}/g) ?? []).length >= 5)
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

The five `node ... | tee` steps in `cloud-operate-relay-production-rehome-job.yml` reported tee's exit code, so a thrown inspect or apply passed green. The Aug 28 21:25Z and Aug 29 inspect runs and today's first inspect (33810752689) all printed `director returned an invalid regional rehome control` and still succeeded; the durable control had moved to generation 12 when the Aug 28 rehome aborted.

`shell: bash` on the job defaults adds `-o pipefail`. `relay-regional-rehome-workflow.test.mjs` pins the default and the tee count (mutation-checked: dropping the shell line fails the test).

No behavior change for successful runs.