### PR TITLE
fix(ci): preserve the next stable release version

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -484,12 +484,27 @@ jobs:
           fi
 
           package_stable="$(current_package_stable)"
+          package_floor_candidate=""
           if [[ -n "$package_stable" ]]; then
             # Why: if a stable release is deleted after its version-bump commit
             # reached main, GitHub's release list regresses. package.json is the
             # floor for the current ref so the next cut cannot reuse an older
             # stable number just because the public release was nuked.
             if semver_gt "$package_stable" "$latest_stable"; then
+              # A stable package floor one patch above the latest published
+              # release is the release waiting to be cut. Treating it as the
+              # new baseline and bumping again silently skipped that version
+              # (for example, 1.4.197 -> 1.4.198). Preserve the floor as the
+              # patch candidate instead; refuse larger gaps so an operator
+              # must resolve the version history explicitly rather than
+              # strand clients on an unshipped number.
+              expected_patch="$(bump "$latest_stable" patch)"
+              if [[ "$package_stable" == "$expected_patch" ]]; then
+                package_floor_candidate="$package_stable"
+              elif [[ "$KIND" == "patch" ]]; then
+                echo "::error::package.json stable floor $package_stable is not the next patch after published stable $latest_stable; refusing to auto-skip stable versions." >&2
+                exit 1
+              fi
               # Skip floor-tag recovery when an explicit version is requested:
               # recover_unpublished_tag can exit 0, which would recover the
               # package-floor tag instead of cutting the requested version —
@@ -522,6 +537,10 @@ jobs:
           # human assert the exact target (e.g. leapfrog to 1.4.155); the
           # updater-safety gate and tag-collision recovery below still apply.
           new=""
+          if [[ -n "$package_floor_candidate" && ( "$KIND" == "patch" || -n "${EXPLICIT_VERSION:-}" ) ]]; then
+            new="$package_floor_candidate"
+            echo "Using package.json release floor as the next stable patch: $new"
+          fi
           if [[ -n "${EXPLICIT_VERSION:-}" ]]; then
             explicit="${EXPLICIT_VERSION#v}"
             # Why the optional trailing identifier: it lets an operator name a
@@ -555,7 +574,7 @@ jobs:
             # Same updater-safety gate the kind path enforces: stable line must
             # strictly increase over the latest published stable (prerelease
             # identifiers ignored for the comparison).
-            if ! semver_gt "$explicit" "$latest_stable"; then
+            if ! semver_gt "$explicit" "$latest_stable" && [[ "$explicit" != "$package_floor_candidate" ]]; then
               echo "::error::Refusing explicit version $explicit: not greater than latest stable $latest_stable." >&2
               exit 1
             fi

--- a/config/scripts/release-cut-version-floor.test.mjs
+++ b/config/scripts/release-cut-version-floor.test.mjs
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+describe('release-cut stable version floor', () => {
+  it('uses the package floor for the next patch instead of bumping past it', () => {
+    const workflow = parse(
+      readFileSync(resolve(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+    )
+    const step = workflow.jobs.cut.steps.find(({ name }) => name === 'Compute next version')
+
+    expect(step.run).toContain('package_floor_candidate')
+    expect(step.run).toContain('expected_patch="$(bump "$latest_stable" patch)"')
+    expect(step.run).toContain('Using package.json release floor as the next stable patch')
+    expect(step.run).toContain('refusing to auto-skip stable versions')
+    expect(step.run).toContain('"$explicit" != "$package_floor_candidate"')
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## Summary
- use a one-patch package.json floor as the stable patch candidate
- fail closed on unexplained multi-version package floors instead of skipping releases
- cover the release-cut contract and explicit-version path

Fixes the 1.4.197 -> 1.4.198 skip observed while cutting from the verified Sep 3 candidate.