### PR TITLE
fix(i18n): ship the onboarding integration capability strings in the boot catalog

### DIFF
--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -3717,6 +3717,16 @@
           "readyOneOne": "1 workspace found, with 1 cleanup suggestion."
         }
       }
+    },
+    "onboarding": {
+      "integrations": {
+        "capabilities": {
+          "browseIssues": "Browse GitHub issues and pull requests in the Tasks view without leaving Orca",
+          "managePullRequests": "Read, comment on, and merge pull requests without leaving Orca",
+          "reviewStatus": "See issue state, review status, and CI checks on every worktree",
+          "startWorkspaceFromIssue": "Start a workspace from any GitHub issue or pull request, prefilled with its title and context"
+        }
+      }
     }
   },
   "dashboard": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## Why

c79e1c097b (`fix(i18n): localize remaining onboarding UI`) added four `components.onboarding.integrations.capabilities.*` strings to `en.json` without regenerating `en-runtime-required.json`. `verify:localization-runtime-catalog` now fails in the static analysis job of every PR whose merge commit includes that change (seen on #18051).

## What

Adds exactly the four entries the generator reports as missing. The 921 stale entries it also mentions are documented as harmless and are left for a dedicated sync so this stays a minimal, reviewable unbreak.

## Verification

```
node config/scripts/generate-runtime-required-english-catalog.mjs
en-runtime-required.json covers en.json: 1667 of 14001 English entries must ship in the boot bundle
```