### PR TITLE
feat(settings): add integration removal controls

### DIFF
--- a/src/renderer/src/components/settings/RemoveIntegrationButton.tsx
+++ b/src/renderer/src/components/settings/RemoveIntegrationButton.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react'
+import { Loader2, Unlink } from 'lucide-react'
+import { toast } from 'sonner'
+import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
+import { Button } from '@/components/ui/button'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { translate } from '@/i18n/i18n'
+
+const REMOVE_PENDING_FEEDBACK_DELAY_MS = 200
+
+type RemoveIntegrationButtonProps = {
+  integrationName: string
+  scopeLabel: string
+  onRemove: () => Promise<void>
+}
+
+export function RemoveIntegrationButton({
+  integrationName,
+  scopeLabel,
+  onRemove
+}: RemoveIntegrationButtonProps): React.JSX.Element {
+  const confirm = useConfirmationDialog()
+  const mountedRef = useMountedRef()
+  const requestPendingRef = useRef(false)
+  const [removing, setRemoving] = useState(false)
+  const [showPendingFeedback, setShowPendingFeedback] = useState(false)
+
+  useEffect(() => {
+    if (!removing) {
+      setShowPendingFeedback(false)
+      return
+    }
+    const timer = window.setTimeout(
+      () => setShowPendingFeedback(true),
+      REMOVE_PENDING_FEEDBACK_DELAY_MS
+    )
+    return () => window.clearTimeout(timer)
+  }, [removing])
+
+  const handleRemove = async (): Promise<void> => {
+    if (requestPendingRef.current) {
+      return
+    }
+    requestPendingRef.current = true
+    const confirmed = await confirm({
+      title: translate(
+        'auto.components.settings.RemoveIntegrationButton.title',
+        'Remove {{value0}} integration?',
+        { value0: integrationName }
+      ),
+      description: translate(
+        'auto.components.settings.RemoveIntegrationButton.description',
+        'Orca will delete its saved credentials for this integration from {{value0}}. Credentials issued by {{value1}} will not be revoked.',
+        { value0: scopeLabel, value1: integrationName }
+      ),
+      confirmLabel: translate('auto.components.settings.RemoveIntegrationButton.confirm', 'Remove'),
+      confirmVariant: 'destructive'
+    })
+    if (!confirmed || !mountedRef.current) {
+      requestPendingRef.current = false
+      return
+    }
+
+    setRemoving(true)
+    try {
+      await onRemove()
+      toast.success(
+        translate(
+          'auto.components.settings.RemoveIntegrationButton.success',
+          '{{value0}} integration removed.',
+          { value0: integrationName }
+        )
+      )
+    } catch (error) {
+      toast.error(
+        translate(
+          'auto.components.settings.RemoveIntegrationButton.failure',
+          'Could not remove the {{value0}} integration.',
+          { value0: integrationName }
+        ),
+        error instanceof Error ? { description: error.message } : undefined
+      )
+    } finally {
+      requestPendingRef.current = false
+      if (mountedRef.current) {
+        setRemoving(false)
+      }
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="destructive"
+      size="sm"
+      disabled={removing}
+      aria-busy={removing}
+      onClick={() => void handleRemove()}
+    >
+      {showPendingFeedback ? <Loader2 className="animate-spin" /> : <Unlink />}
+      {translate('auto.components.settings.RemoveIntegrationButton.action', 'Remove')}
+    </Button>
+  )
+}

--- a/src/renderer/src/components/settings/bitbucket-integration-card.test.tsx
+++ b/src/renderer/src/components/settings/bitbucket-integration-card.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
+import type { BitbucketConnectionStatus } from '../../../../shared/bitbucket-credentials'
+import { BitbucketIntegrationCard } from './bitbucket-integration-card'
+
+const storedConnection: BitbucketConnectionStatus = {
+  configured: true,
+  source: 'stored',
+  account: 'bitbucket-user',
+  authMode: 'token',
+  email: null,
+  baseUrl: null
+}
+
+const disconnectedConnection: BitbucketConnectionStatus = {
+  configured: false,
+  source: 'none',
+  account: null,
+  authMode: null,
+  email: null,
+  baseUrl: null
+}
+
+const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(async () => true),
+  disconnect: vi.fn(async () => {}),
+  refresh: vi.fn(),
+  status: vi.fn<() => Promise<BitbucketConnectionStatus>>(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn()
+}))
+
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => mocks.confirm
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError, success: mocks.toastSuccess }
+}))
+
+vi.mock('./bitbucket-credentials-dialog', () => ({
+  BitbucketCredentialsDialog: () => null
+}))
+
+vi.mock('./source-control-preflight-card-status', () => ({
+  usePreflightCardStatuses: () => ({
+    statuses: {
+      bitbucketStatus: 'connected',
+      bitbucketAccount: 'bitbucket-user'
+    },
+    unavailable: false,
+    refresh: mocks.refresh
+  })
+}))
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+async function renderCard(): Promise<HTMLDivElement> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<BitbucketIntegrationCard />)
+  })
+  return container
+}
+
+describe('BitbucketIntegrationCard removal', () => {
+  beforeEach(() => {
+    mocks.status.mockResolvedValueOnce(storedConnection).mockResolvedValue(disconnectedConnection)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        bitbucket: {
+          disconnect: mocks.disconnect,
+          status: mocks.status
+        },
+        shell: { openUrl: vi.fn() }
+      }
+    })
+  })
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root?.unmount()
+      })
+    }
+    root = null
+    container?.remove()
+    container = null
+    mocks.confirm.mockClear()
+    mocks.disconnect.mockClear()
+    mocks.refresh.mockClear()
+    mocks.toastError.mockClear()
+    mocks.toastSuccess.mockClear()
+    mocks.status.mockReset()
+    Reflect.deleteProperty(window, 'api')
+  })
+
+  it('removes the stored credential after destructive confirmation', async () => {
+    const rendered = await renderCard()
+    expect(rendered.textContent).toContain('Edit credentials')
+    expect(rendered.textContent).toContain('Remove')
+
+    await act(async () => {
+      Array.from(rendered.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Remove')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.confirm).toHaveBeenCalledWith({
+      title: 'Remove Bitbucket integration?',
+      description: `Orca will delete its saved credentials for this integration from ${getLocalExecutionHostLabel()}. Credentials issued by Bitbucket will not be revoked.`,
+      confirmLabel: 'Remove',
+      confirmVariant: 'destructive'
+    })
+    expect(mocks.disconnect).toHaveBeenCalledTimes(1)
+    expect(mocks.refresh).toHaveBeenCalledTimes(1)
+    expect(rendered.textContent).not.toContain('Remove')
+  })
+
+  it('reports credential removal failures and keeps the integration connected', async () => {
+    mocks.disconnect.mockRejectedValueOnce(new Error('Keychain is locked'))
+    const rendered = await renderCard()
+
+    await act(async () => {
+      Array.from(rendered.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Remove')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Could not remove the Bitbucket integration.', {
+      description: 'Keychain is locked'
+    })
+    expect(mocks.refresh).not.toHaveBeenCalled()
+    expect(rendered.textContent).toContain('Remove')
+  })
+})

--- a/src/renderer/src/components/settings/bitbucket-integration-card.tsx
+++ b/src/renderer/src/components/settings/bitbucket-integration-card.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useState } from 'react'
-import { ExternalLink, GitPullRequestArrow, LoaderCircle, Unlink } from 'lucide-react'
+import { ExternalLink, GitPullRequestArrow } from 'lucide-react'
 import type { BitbucketConnectionStatus } from '../../../../shared/bitbucket-credentials'
+import { getLocalExecutionHostLabel } from '../../../../shared/execution-host'
 import { Button } from '@/components/ui/button'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
+import { RemoveIntegrationButton } from './RemoveIntegrationButton'
 import { useIntegrationSubordinateRowClass } from './integration-card-presentation'
 import type { BitbucketStatus } from './integrations-pane-status'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
@@ -22,8 +24,6 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
   const subordinateRowClass = useIntegrationSubordinateRowClass('flex items-center gap-3')
   const [connection, setConnection] = useState<BitbucketConnectionStatus | null>(null)
   const [dialogOpen, setDialogOpen] = useState(false)
-  const [disconnecting, setDisconnecting] = useState(false)
-  const [disconnectError, setDisconnectError] = useState<string | null>(null)
 
   // Reads plaintext metadata only — never the encrypted secret — so mounting the
   // pane cannot trigger a keychain prompt.
@@ -66,33 +66,6 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
     refresh()
   }
 
-  const handleDisconnect = async (): Promise<void> => {
-    setDisconnecting(true)
-    setDisconnectError(null)
-    try {
-      await window.api.bitbucket.disconnect()
-    } catch (error) {
-      // Why: disconnect rethrows when a credential file cannot be deleted.
-      // Unhandled, the card silently re-renders as still connected.
-      if (mountedRef.current) {
-        setDisconnectError(
-          error instanceof Error
-            ? error.message
-            : translate(
-                'auto.components.settings.bitbucket.integration.card.disconnectFailed',
-                'Could not remove the saved Bitbucket credential.'
-              )
-        )
-      }
-    } finally {
-      if (mountedRef.current) {
-        setDisconnecting(false)
-      }
-      void loadConnection()
-      refresh()
-    }
-  }
-
   return (
     <IntegrationCardShell
       icon={<GitPullRequestArrow className="size-5" />}
@@ -119,18 +92,34 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
       statusLabel={tokenProviderStatusLabel({ configured: connected, status })}
       actions={
         status !== 'checking' && !envManaged ? (
-          <Button
-            variant={storedCredential ? 'outline' : 'default'}
-            size="sm"
-            onClick={() => setDialogOpen(true)}
-          >
-            {storedCredential
-              ? translate(
-                  'auto.components.settings.bitbucket.integration.card.edit',
-                  'Edit credentials'
-                )
-              : translate('auto.components.settings.bitbucket.integration.card.connect', 'Connect')}
-          </Button>
+          <>
+            <Button
+              variant={storedCredential ? 'outline' : 'default'}
+              size="sm"
+              onClick={() => setDialogOpen(true)}
+            >
+              {storedCredential
+                ? translate(
+                    'auto.components.settings.bitbucket.integration.card.edit',
+                    'Edit credentials'
+                  )
+                : translate(
+                    'auto.components.settings.bitbucket.integration.card.connect',
+                    'Connect'
+                  )}
+            </Button>
+            {storedCredential ? (
+              <RemoveIntegrationButton
+                integrationName="Bitbucket"
+                scopeLabel={getLocalExecutionHostLabel()}
+                onRemove={async () => {
+                  await window.api.bitbucket.disconnect()
+                  await loadConnection()
+                  refresh()
+                }}
+              />
+            ) : null}
+          </>
         ) : null
       }
     >
@@ -150,26 +139,8 @@ export function BitbucketIntegrationCard(): React.JSX.Element {
                   <p className="truncate text-xs text-muted-foreground">{credentialSummary}</p>
                 ) : null}
               </div>
-              {storedCredential ? (
-                <button
-                  onClick={() => void handleDisconnect()}
-                  disabled={disconnecting}
-                  aria-label={translate(
-                    'auto.components.settings.bitbucket.integration.card.disconnect',
-                    'Disconnect Bitbucket'
-                  )}
-                  className="rounded-md p-1 text-muted-foreground/50 transition-colors hover:text-destructive"
-                >
-                  {disconnecting ? (
-                    <LoaderCircle className="size-3.5 animate-spin" />
-                  ) : (
-                    <Unlink className="size-3.5" />
-                  )}
-                </button>
-              ) : null}
             </div>
           ) : null}
-          {disconnectError ? <p className="text-xs text-destructive">{disconnectError}</p> : null}
           <BitbucketCardNote
             envManaged={envManaged}
             status={status}

--- a/src/renderer/src/components/settings/jira-integration-card.test.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.test.tsx
@@ -22,6 +22,7 @@ type StoreState = {
 }
 
 const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(async () => true),
   store: { current: null as StoreState | null }
 }))
 
@@ -32,6 +33,13 @@ vi.mock('@/store', () => ({
     }
     return selector(mocks.store.current)
   }
+}))
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => mocks.confirm
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
 }))
 
 vi.mock('@/components/jira-connect-dialog', () => ({
@@ -92,6 +100,7 @@ describe('JiraIntegrationCard account scope', () => {
     container?.remove()
     container = null
     mocks.store.current = null
+    mocks.confirm.mockClear()
   })
 
   it('shows remote-server account ownership and opens Hosts settings', async () => {
@@ -116,5 +125,25 @@ describe('JiraIntegrationCard account scope', () => {
       repoId: null,
       sectionId: 'default-runtime'
     })
+  })
+
+  it('removes all Jira access after destructive confirmation', async () => {
+    const state = installStore({ activeRuntimeEnvironmentId: 'runtime-1' })
+    const rendered = await renderCard()
+
+    await act(async () => {
+      Array.from(rendered.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Remove')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.confirm).toHaveBeenCalledWith({
+      title: 'Remove Jira integration?',
+      description:
+        'Orca will delete its saved credentials for this integration from Remote server: runtime-1. Credentials issued by Jira will not be revoked.',
+      confirmLabel: 'Remove',
+      confirmVariant: 'destructive'
+    })
+    expect(state.disconnectJira).toHaveBeenCalledWith(undefined)
   })
 })

--- a/src/renderer/src/components/settings/jira-integration-card.tsx
+++ b/src/renderer/src/components/settings/jira-integration-card.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/provider-runtime-context'
 import { useAppStore } from '@/store'
 import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
+import { RemoveIntegrationButton } from './RemoveIntegrationButton'
 import { useIntegrationSubordinateRowClass } from './integration-card-presentation'
 import { getProviderAccountScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
@@ -109,21 +110,30 @@ export function JiraIntegrationCard(): React.JSX.Element {
       }
       actions={
         !checking ? (
-          <Button
-            variant={connected ? 'outline' : 'default'}
-            size="sm"
-            onClick={() => setDialogOpen(true)}
-          >
-            {connected
-              ? translate(
-                  'auto.components.settings.task.tracker.integration.cards.60996beda6',
-                  'Add Jira site'
-                )
-              : translate(
-                  'auto.components.settings.task.tracker.integration.cards.e2ff968276',
-                  'Connect Jira'
-                )}
-          </Button>
+          <>
+            <Button
+              variant={connected ? 'outline' : 'default'}
+              size="sm"
+              onClick={() => setDialogOpen(true)}
+            >
+              {connected
+                ? translate(
+                    'auto.components.settings.task.tracker.integration.cards.60996beda6',
+                    'Add Jira site'
+                  )
+                : translate(
+                    'auto.components.settings.task.tracker.integration.cards.e2ff968276',
+                    'Connect Jira'
+                  )}
+            </Button>
+            {connected ? (
+              <RemoveIntegrationButton
+                integrationName="Jira"
+                scopeLabel={accountScope.label}
+                onRemove={() => handleDisconnect()}
+              />
+            ) : null}
+          </>
         ) : null
       }
     >
@@ -217,20 +227,12 @@ export function JiraIntegrationCard(): React.JSX.Element {
                 'Jira is connected for this runtime. Re-check if the connected site list looks stale.'
               )}
             </p>
-            <div className="flex items-center gap-2">
-              <Button variant="ghost" size="sm" onClick={() => void checkJiraConnection()}>
-                {translate(
-                  'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
-                  'Re-check'
-                )}
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => void handleDisconnect()}>
-                {translate(
-                  'auto.components.settings.task.tracker.integration.cards.disconnect_all',
-                  'Disconnect'
-                )}
-              </Button>
-            </div>
+            <Button variant="ghost" size="sm" onClick={() => void checkJiraConnection()}>
+              {translate(
+                'auto.components.settings.task.tracker.integration.cards.c90f2ef419',
+                'Re-check'
+              )}
+            </Button>
           </>
         ) : !checking ? (
           <>

--- a/src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx
+++ b/src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx
@@ -27,6 +27,7 @@ type StoreState = {
 }
 
 const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(async () => true),
   store: { current: null as StoreState | null }
 }))
 
@@ -37,6 +38,13 @@ vi.mock('@/store', () => ({
     }
     return selector(mocks.store.current)
   }
+}))
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => mocks.confirm
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
 }))
 
 vi.mock('@/components/linear-api-key-dialog', () => ({
@@ -118,6 +126,7 @@ describe('LinearIntegrationCard account scope', () => {
     container?.remove()
     container = null
     mocks.store.current = null
+    mocks.confirm.mockClear()
     Reflect.deleteProperty(window, 'api')
   })
 
@@ -173,6 +182,40 @@ describe('LinearIntegrationCard account scope', () => {
     })
 
     expect(state.testLinearConnection).toHaveBeenCalledWith('workspace-1')
+  })
+
+  it('removes all Linear access after destructive confirmation', async () => {
+    const state = installStore(true, { activeRuntimeEnvironmentId: 'runtime-1' })
+    const rendered = await renderCard()
+
+    await act(async () => {
+      Array.from(rendered.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Remove')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(mocks.confirm).toHaveBeenCalledWith({
+      title: 'Remove Linear integration?',
+      description:
+        'Orca will delete its saved credentials for this integration from Remote server: runtime-1. Credentials issued by Linear will not be revoked.',
+      confirmLabel: 'Remove',
+      confirmVariant: 'destructive'
+    })
+    expect(state.disconnectLinear).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps Linear access when removal is canceled', async () => {
+    const state = installStore(true)
+    mocks.confirm.mockResolvedValueOnce(false)
+    const rendered = await renderCard()
+
+    await act(async () => {
+      Array.from(rendered.querySelectorAll('button'))
+        .find((button) => button.textContent === 'Remove')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(state.disconnectLinear).not.toHaveBeenCalled()
   })
 
   it('clears verification state after adding another Linear workspace', async () => {

--- a/src/renderer/src/components/settings/task-tracker-integration-cards.tsx
+++ b/src/renderer/src/components/settings/task-tracker-integration-cards.tsx
@@ -7,6 +7,7 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import { getProviderRuntimeContextKey } from '@/lib/provider-runtime-context'
 import { useAppStore } from '@/store'
 import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
+import { RemoveIntegrationButton } from './RemoveIntegrationButton'
 import { useIntegrationSubordinateRowClass } from './integration-card-presentation'
 import { LinearAgentSkillInstallCta } from './linear-agent-skill-install-cta'
 import { getProviderAccountScope } from './provider-account-scope'
@@ -104,21 +105,30 @@ export function LinearIntegrationCard(): React.JSX.Element {
       }
       actions={
         !checking ? (
-          <Button
-            variant={connected ? 'outline' : 'default'}
-            size="sm"
-            onClick={() => setDialogOpen(true)}
-          >
-            {connected
-              ? translate(
-                  'auto.components.settings.task.tracker.integration.cards.622c224082',
-                  'Add workspace access'
-                )
-              : translate(
-                  'auto.components.settings.task.tracker.integration.cards.1a12e33fe5',
-                  'Add Linear access'
-                )}
-          </Button>
+          <>
+            <Button
+              variant={connected ? 'outline' : 'default'}
+              size="sm"
+              onClick={() => setDialogOpen(true)}
+            >
+              {connected
+                ? translate(
+                    'auto.components.settings.task.tracker.integration.cards.622c224082',
+                    'Add workspace access'
+                  )
+                : translate(
+                    'auto.components.settings.task.tracker.integration.cards.1a12e33fe5',
+                    'Add Linear access'
+                  )}
+            </Button>
+            {connected ? (
+              <RemoveIntegrationButton
+                integrationName="Linear"
+                scopeLabel={accountScope.label}
+                onRemove={() => handleDisconnect()}
+              />
+            ) : null}
+          </>
         ) : null
       }
     >

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11739,6 +11739,14 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "RemoveIntegrationButton": {
+          "title": "Remove {{value0}} integration?",
+          "description": "Orca will delete its saved credentials for this integration from {{value0}}. Credentials issued by {{value1}} will not be revoked.",
+          "confirm": "Remove",
+          "success": "{{value0}} integration removed.",
+          "failure": "Could not remove the {{value0}} integration.",
+          "action": "Remove"
         }
       },
       "right": {


### PR DESCRIPTION
## ELI5

Connected integrations now have a clear **Remove** button. Orca asks for confirmation, says where the credential is stored, and warns that removing it from Orca does not revoke the provider-issued token.

## What Changed

- Added a shared destructive removal action with duplicate-request protection, delayed progress feedback, success/error toasts, and scope-aware confirmation copy.
- Added card-level removal for every integration whose credentials Orca stores: Linear, Jira, and Bitbucket.
- Linear and Jira remove all credentials from the currently selected local or remote runtime through their existing runtime-aware store actions.
- Bitbucket removes its locally stored credential through the existing credential API, then refreshes both credential metadata and preflight status.
- Preserved granular per-workspace/per-site disconnect actions and environment-owned credential behavior.
- Added focused tests for confirmation, cancellation, successful removal, refresh, and error reporting; synchronized the English localization catalog.

## Why

The Integrations pane made connection prominent but hid removal in low-visibility row icons or provider-specific controls. A consistent card-level action makes full disconnection discoverable without violating credential ownership: Orca removes only credentials it stores. CLI-owned GitHub/GitLab auth and environment-owned Azure DevOps/Gitea/Bitbucket configuration remain under their owning tools.

## Linked Issue

Fixes #18536

## Visual Proof

**Before — no card-level removal action:**

![Before: connected Linear integration without a card-level Remove action](https://github.com/user-attachments/assets/70367ac5-0e0d-41c0-b5fb-6925a9cc85ab)

**After — explicit destructive Remove action:**

![After: connected Linear integration with a visible red Remove action](https://github.com/user-attachments/assets/ed2020b9-84f4-4b2b-a8d8-f91cf1d69f76)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS:

- `pnpm test src/renderer/src/components/settings/task-tracker-integration-cards.test.tsx src/renderer/src/components/settings/jira-integration-card.test.tsx src/renderer/src/components/settings/bitbucket-integration-card.test.tsx` — 9 tests passed.
- `pnpm tc:web` — passed.
- `pnpm run check:code-quality:changed` — no new code-quality, type-aware, or React Doctor findings.
- Localization catalog, extraction, and coverage verification — passed.
- Electron Playwright smoke — built and rendered the connected Linear card, opened the destructive confirmation dialog, verified the scope/non-revocation copy, canceled, and confirmed the dialog closed.
- Electron Playwright before/after capture — both baseline and changed builds passed.

Linux, Windows, SSH, and mobile were not executed locally.

## AI Disclosure

AI-assisted with OpenAI Codex (`openai-codex/gpt-5.6-sol`) for repository exploration, implementation, focused tests, verification, and PR preparation. All reported checks were executed locally.

Contributor: @erdenizko  
X handle: N/A — no X handle is listed on the contributor's GitHub profile.

## Review

### Agent review summary

- Correctness: the shared action confirms before deletion, prevents duplicate requests, refreshes provider state, and retains the connected UI when deletion fails.
- Security: deletion stays on existing credential-owner paths; no secrets cross new boundaries or appear in logs/UI.
- Compatibility: no RPC, storage schema, Git command, filesystem path, shortcut, or mobile contract changed.
- Residual risk: Linux, Windows, SSH, and mobile were reasoned through but not executed locally; CI covers the full matrix.

### Security

Removal calls the existing credential deletion APIs and never reads, logs, or renders secret values. Confirmation explicitly states that provider-issued credentials are not revoked.

### Cross-platform, remote, compatibility, and performance

- Linear/Jira reuse the existing runtime-aware disconnect paths, so the selected local or paired remote runtime remains the credential owner. The confirmation names that runtime.
- Bitbucket's existing credential API is client-local; the confirmation uses the platform-specific local host label.
- No RPC, stream opcode, persistence schema, path handling, shortcut, Git, provider-wire, or mobile behavior changed.
- Environment- and CLI-owned integrations are intentionally unchanged; Orca does not delete credentials it does not own.
- No background polling or new provider calls were added. Loading feedback starts only for a user-triggered removal that lasts over 200 ms.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The existing per-workspace Linear and per-site Jira actions remain available for granular removal. The new card action removes the integration's complete Orca-managed credential set from the displayed account scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted checks and the Electron build passed locally; CI will cover the full matrix)