### PR TITLE
feat(ipynb): read-only preview with sandboxed outputs

### DIFF
--- a/src/renderer/src/components/editor/IpynbCellEditor.tsx
+++ b/src/renderer/src/components/editor/IpynbCellEditor.tsx
@@ -1,9 +1,7 @@
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react'
 import Editor, { type OnMount } from '@monaco-editor/react'
-import Markdown from 'react-markdown'
-import rehypeRaw from 'rehype-raw'
-import rehypeSanitize from 'rehype-sanitize'
-import remarkGfm from 'remark-gfm'
+import type { Components } from 'react-markdown'
+import { MarkdownPreviewBody } from './MarkdownPreviewBody'
 import { monaco } from '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
@@ -13,13 +11,50 @@ import { getIpynbCodeCellEditorHeight, getIpynbCodeCellPreviewLines } from './ip
 import type { IpynbCell } from './ipynb-parse'
 import MonacoCodeExcerpt from './MonacoCodeExcerpt'
 
+// Shared frozen instance: react-markdown treats it as read-only config.
+const EMPTY_MARKDOWN_COMPONENTS: Components = Object.freeze({})
+
 export function IpynbMarkdownCell({ source }: { source: string }): React.JSX.Element {
   return (
     <div className="markdown-preview-body px-4 py-3 text-sm">
-      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw, rehypeSanitize]}>
-        {source || '\u00a0'}
-      </Markdown>
+      <MarkdownPreviewBody content={source || '\u00a0'} components={EMPTY_MARKDOWN_COMPONENTS} />
     </div>
+  )
+}
+
+export function IpynbMarkdownCellEditor({
+  source,
+  active,
+  onActivate,
+  onChange
+}: {
+  source: string
+  active: boolean
+  onActivate: () => void
+  onChange: (source: string) => void
+}): React.JSX.Element {
+  if (active) {
+    return (
+      <div data-ipynb-cell-editor="true" className="grid gap-0 lg:grid-cols-2">
+        <IpynbEditableTextCell source={source} onChange={onChange} />
+        <div className="border-t border-border/50 lg:border-l lg:border-t-0">
+          <IpynbMarkdownCell source={source} />
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="block w-full cursor-text text-left" onDoubleClick={onActivate}>
+      <IpynbMarkdownCell source={source} />
+    </div>
+  )
+}
+
+export function IpynbRawCell({ source }: { source: string }): React.JSX.Element {
+  return (
+    <pre className="overflow-auto whitespace-pre-wrap px-4 py-3 font-mono text-xs leading-5 text-foreground scrollbar-editor">
+      {source || '\u00a0'}
+    </pre>
   )
 }
 
@@ -51,7 +86,7 @@ function IpynbCodeCellEditor({
   cell: IpynbCell
   source: string
   active: boolean
-  onActivate: () => void
+  onActivate?: () => void
   onDeactivate: () => void
   onChange: (source: string) => void
   onSaveRequest: () => Promise<void>
@@ -97,13 +132,13 @@ function IpynbCodeCellEditor({
   if (!active) {
     return (
       <div
-        role="button"
-        tabIndex={0}
-        className="block w-full cursor-text bg-editor-surface text-left"
+        role={onActivate ? 'button' : undefined}
+        tabIndex={onActivate ? 0 : undefined}
+        className={`block w-full bg-editor-surface text-left ${onActivate ? 'cursor-text' : ''}`}
         onClick={onActivate}
         onKeyDown={(event) => {
           if (event.key === 'Enter') {
-            onActivate()
+            onActivate?.()
           }
         }}
       >

--- a/src/renderer/src/components/editor/IpynbCellHeader.tsx
+++ b/src/renderer/src/components/editor/IpynbCellHeader.tsx
@@ -1,0 +1,30 @@
+import { Braces, FileCode2, Play } from 'lucide-react'
+import type { IpynbCell, IpynbCellKind } from './ipynb-parse'
+
+export function getIpynbCellExecutionLabel(cell: IpynbCell): string {
+  return cell.kind === 'code' ? `In [${cell.executionCount ?? ' '}]:` : cell.kind
+}
+
+export function IpynbCellKindIcon({ kind }: { kind: IpynbCellKind }): React.JSX.Element {
+  const Icon = kind === 'code' ? Play : kind === 'markdown' ? FileCode2 : Braces
+  return <Icon className="size-3.5" aria-hidden="true" />
+}
+
+export function IpynbCellHeader({
+  cell,
+  index
+}: {
+  cell: IpynbCell
+  index: number
+}): React.JSX.Element {
+  return (
+    <div
+      data-testid="ipynb-cell-header"
+      className="flex items-center gap-2 border-b border-border/50 bg-muted/20 px-3 py-1.5 text-xs text-muted-foreground"
+    >
+      <IpynbCellKindIcon kind={cell.kind} />
+      <span className="font-mono">{getIpynbCellExecutionLabel(cell)}</span>
+      <span className="ml-auto font-mono">#{index + 1}</span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/IpynbCellOutputs.tsx
+++ b/src/renderer/src/components/editor/IpynbCellOutputs.tsx
@@ -34,6 +34,21 @@ function sanitizeSvgImage(value: string): string | null {
   return new XMLSerializer().serializeToString(root)
 }
 
+// Strict shape check so corrupt payloads fall back to text instead of a broken <img>.
+const STRICT_BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/
+
+function isDecodableBase64(value: string): boolean {
+  if (!STRICT_BASE64_PATTERN.test(value)) {
+    return false
+  }
+  try {
+    atob(value)
+  } catch {
+    return false
+  }
+  return true
+}
+
 function dataUriForImage(item: IpynbOutputItem): string | null {
   const value = valueToText(item.value).replace(/\s/g, '')
   if (!value) {
@@ -42,6 +57,9 @@ function dataUriForImage(item: IpynbOutputItem): string | null {
   if (item.mime === 'image/svg+xml') {
     const sanitized = sanitizeSvgImage(valueToText(item.value))
     return sanitized ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sanitized)}` : null
+  }
+  if (!isDecodableBase64(value)) {
+    return null
   }
   return `data:${item.mime};base64,${value}`
 }

--- a/src/renderer/src/components/editor/IpynbCellOutputs.tsx
+++ b/src/renderer/src/components/editor/IpynbCellOutputs.tsx
@@ -1,8 +1,10 @@
 import DOMPurify from 'dompurify'
 import { cn } from '@/lib/utils'
-import { translate } from '@/i18n/i18n'
 import { IpynbMarkdownCell } from './IpynbCellEditor'
+import { IpynbHtmlOutput } from './IpynbHtmlOutput'
 import type { IpynbCell, IpynbOutputItem } from './ipynb-parse'
+
+const MAX_ALT_LEN = 140
 
 function valueToText(value: unknown): string {
   if (Array.isArray(value)) {
@@ -17,13 +19,29 @@ function valueToText(value: unknown): string {
   return typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)
 }
 
+const SVG_VISUAL_CONTENT =
+  'circle, ellipse, foreignObject, image, line, path, polygon, polyline, rect, text, use'
+
+function sanitizeSvgImage(value: string): string | null {
+  const sanitized = DOMPurify.sanitize(value, {
+    USE_PROFILES: { svg: true, svgFilters: true }
+  })
+  const parsed = new DOMParser().parseFromString(sanitized, 'image/svg+xml')
+  const root = parsed.documentElement
+  if (root.localName !== 'svg' || !root.querySelector(SVG_VISUAL_CONTENT)) {
+    return null
+  }
+  return new XMLSerializer().serializeToString(root)
+}
+
 function dataUriForImage(item: IpynbOutputItem): string | null {
   const value = valueToText(item.value).replace(/\s/g, '')
   if (!value) {
     return null
   }
   if (item.mime === 'image/svg+xml') {
-    return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(valueToText(item.value))}`
+    const sanitized = sanitizeSvgImage(valueToText(item.value))
+    return sanitized ? `data:image/svg+xml;charset=utf-8,${encodeURIComponent(sanitized)}` : null
   }
   return `data:${item.mime};base64,${value}`
 }
@@ -47,30 +65,36 @@ function PreformattedOutput({
   )
 }
 
-function OutputItem({ item }: { item: IpynbOutputItem }): React.JSX.Element | null {
+function OutputItem({
+  item,
+  imageAlt
+}: {
+  item: IpynbOutputItem
+  imageAlt?: string
+}): React.JSX.Element | null {
   if (item.mime === 'text/html') {
-    const html = DOMPurify.sanitize(valueToText(item.value), {
-      USE_PROFILES: { html: true, svg: true, svgFilters: true }
-    })
-    return (
-      <iframe
-        title={translate('auto.components.editor.IpynbViewer.66a3f7d330', 'Notebook HTML output')}
-        sandbox=""
-        referrerPolicy="no-referrer"
-        loading="lazy"
-        className="block h-80 w-full border-0 bg-background"
-        srcDoc={html}
-      />
-    )
+    return <IpynbHtmlOutput value={valueToText(item.value)} />
   }
 
   if (item.mime.startsWith('image/')) {
     const uri = dataUriForImage(item)
-    return uri ? (
+    if (!uri) {
+      return null
+    }
+    // Keep long text/plain out of layout; full text stays in title.
+    const fullAlt = imageAlt?.trim() ?? ''
+    const alt =
+      fullAlt.length > MAX_ALT_LEN ? `${fullAlt.slice(0, MAX_ALT_LEN - 1)}\u2026` : fullAlt
+    return (
       <div className="flex max-w-full overflow-auto p-3 scrollbar-editor">
-        <img src={uri} alt={item.mime} className="max-h-[520px] max-w-full object-contain" />
+        <img
+          src={uri}
+          alt={alt}
+          title={fullAlt.length > MAX_ALT_LEN ? fullAlt : undefined}
+          className="max-h-[520px] max-w-full object-contain"
+        />
       </div>
-    ) : null
+    )
   }
 
   if (item.mime === 'application/json' || item.mime.endsWith('+json')) {
@@ -85,6 +109,21 @@ function OutputItem({ item }: { item: IpynbOutputItem }): React.JSX.Element | nu
     return <PreformattedOutput text={valueToText(item.value)} />
   }
   return null
+}
+
+function isRenderableItem(item: IpynbOutputItem): boolean {
+  if (item.mime.startsWith('image/')) {
+    return dataUriForImage(item) !== null
+  }
+  if (
+    item.mime === 'text/html' ||
+    item.mime === 'text/markdown' ||
+    item.mime.startsWith('text/') ||
+    item.mime === 'application/javascript'
+  ) {
+    return valueToText(item.value).trim().length > 0
+  }
+  return item.mime === 'application/json' || item.mime.endsWith('+json')
 }
 
 export function IpynbCellOutputs({ cell }: { cell: IpynbCell }): React.JSX.Element | null {
@@ -107,12 +146,13 @@ export function IpynbCellOutputs({ cell }: { cell: IpynbCell }): React.JSX.Eleme
             </div>
           )
         }
-        const renderedItems = output.items
-          .map((item, itemIndex) => <OutputItem key={`${item.mime}-${itemIndex}`} item={item} />)
-          .filter(Boolean)
-        return renderedItems.length > 0 ? (
+        const item = output.items.find(isRenderableItem)
+        const imageAlt = valueToText(
+          output.items.find((candidate) => candidate.mime === 'text/plain')?.value
+        )
+        return item ? (
           <div key={index} className="border-b border-border/40 last:border-b-0">
-            {renderedItems}
+            <OutputItem item={item} imageAlt={imageAlt} />
           </div>
         ) : null
       })}

--- a/src/renderer/src/components/editor/IpynbCellToolbar.tsx
+++ b/src/renderer/src/components/editor/IpynbCellToolbar.tsx
@@ -2,11 +2,11 @@ import type { ReactNode } from 'react'
 import {
   ArrowDownToLine,
   ArrowUpToLine,
-  Braces,
   FileCode2,
   Loader2,
   MoveDown,
   MoveUp,
+  Pencil,
   Play,
   Trash2
 } from 'lucide-react'
@@ -59,11 +59,11 @@ export function IpynbToolbarButton({
 
 export function IpynbCellToolbar({
   cell,
-  index,
   running,
   canMoveUp,
   canMoveDown,
   onRun,
+  onEdit,
   onKindChange,
   onInsertAbove,
   onInsertBelow,
@@ -72,11 +72,11 @@ export function IpynbCellToolbar({
   onDelete
 }: {
   cell: IpynbCell
-  index: number
   running: boolean
   canMoveUp: boolean
   canMoveDown: boolean
   onRun: () => void
+  onEdit: () => void
   onKindChange: (kind: IpynbCellKind) => void
   onInsertAbove: (kind: IpynbCellKind) => void
   onInsertBelow: (kind: IpynbCellKind) => void
@@ -84,12 +84,8 @@ export function IpynbCellToolbar({
   onMoveDown: () => void
   onDelete: () => void
 }): React.JSX.Element {
-  const Icon = cell.kind === 'code' ? Play : cell.kind === 'markdown' ? FileCode2 : Braces
-  const executionLabel = cell.kind === 'code' ? `In [${cell.executionCount ?? ' '}]:` : cell.kind
   return (
     <div className="flex items-center gap-2 border-b border-border/50 bg-muted/20 px-3 py-1.5 text-xs text-muted-foreground">
-      <Icon className="size-3.5" />
-      <span className="font-mono">{executionLabel}</span>
       <select
         value={cell.kind}
         onChange={(event) => onKindChange(event.target.value as IpynbCellKind)}
@@ -112,6 +108,13 @@ export function IpynbCellToolbar({
           onClick={onRun}
         >
           {running ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+        </IpynbToolbarButton>
+      ) : cell.kind === 'markdown' ? (
+        <IpynbToolbarButton
+          label={translate('auto.components.editor.EditorViewToggle.ac3bb87913', 'Edit')}
+          onClick={onEdit}
+        >
+          <Pencil className="size-3.5" />
         </IpynbToolbarButton>
       ) : null}
       <IpynbToolbarButton
@@ -170,7 +173,6 @@ export function IpynbCellToolbar({
       >
         <Trash2 className="size-3.5" />
       </IpynbToolbarButton>
-      <span className="ml-auto font-mono">#{index + 1}</span>
     </div>
   )
 }

--- a/src/renderer/src/components/editor/IpynbHtmlOutput.tsx
+++ b/src/renderer/src/components/editor/IpynbHtmlOutput.tsx
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import DOMPurify from 'dompurify'
+import { translate } from '@/i18n/i18n'
+import { resolveDocumentTheme } from '@/lib/document-theme'
+import { useAppStore } from '@/store'
+
+function outputDocumentPrefix(colorScheme: 'light' | 'dark'): string {
+  return `<!doctype html>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'">
+<style>
+  :root { color-scheme: ${colorScheme}; }
+  html, body { margin: 0; padding: 0; background: transparent; color: CanvasText; }
+  body { padding: 12px; font: 13px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  table { border-collapse: collapse; max-width: 100%; }
+  th, td { border: 1px solid color-mix(in srgb, currentColor 20%, transparent); padding: 4px 8px; text-align: left; }
+  img, svg { max-width: 100%; height: auto; }
+  pre { overflow: auto; white-space: pre-wrap; }
+</style>`
+}
+
+const MIN_HEIGHT_PX = 72
+const MAX_HEIGHT_PX = 960
+
+function sanitizeOutputHtml(value: string): string {
+  const sanitized = DOMPurify.sanitize(value, {
+    USE_PROFILES: { html: true, svg: true, svgFilters: true },
+    FORBID_TAGS: ['button', 'form', 'input', 'select', 'textarea'],
+    FORBID_ATTR: ['autofocus', 'formaction']
+  })
+  const parsed = new DOMParser().parseFromString(sanitized, 'text/html')
+  // Defense-in-depth: DOMPurify already strips handlers, drop any survivors.
+  for (const element of parsed.querySelectorAll('*')) {
+    for (const attr of Array.from(element.attributes)) {
+      if (attr.name.toLowerCase().startsWith('on')) {
+        element.removeAttribute(attr.name)
+      }
+    }
+  }
+  for (const element of parsed.querySelectorAll('[href], [xlink\\:href]')) {
+    const href = element.getAttribute('href') ?? element.getAttribute('xlink:href') ?? ''
+    // Keep in-output fragment links only; block javascript:/external navigation.
+    if (!href.trim().startsWith('#')) {
+      element.removeAttribute('href')
+      element.removeAttribute('xlink:href')
+    }
+  }
+  return parsed.body.innerHTML
+}
+
+export function IpynbHtmlOutput({ value }: { value: string }): React.JSX.Element {
+  const settings = useAppStore((state) => state.settings)
+  const colorScheme = resolveDocumentTheme(settings?.theme ?? 'system') ? 'dark' : 'light'
+  const frameRef = useRef<HTMLIFrameElement>(null)
+  const [height, setHeight] = useState(MIN_HEIGHT_PX)
+  const [loadVersion, setLoadVersion] = useState(0)
+  const srcDoc = useMemo(
+    () => `${outputDocumentPrefix(colorScheme)}${sanitizeOutputHtml(value)}`,
+    [colorScheme, value]
+  )
+  const resizeToContent = useCallback((): void => {
+    const body = frameRef.current?.contentDocument?.body
+    if (!body) {
+      return
+    }
+    const contentHeight = Math.ceil(body.getBoundingClientRect().height)
+    setHeight(Math.min(MAX_HEIGHT_PX, Math.max(MIN_HEIGHT_PX, contentHeight + 2)))
+  }, [])
+  useEffect(() => {
+    if (loadVersion === 0) {
+      return
+    }
+    resizeToContent()
+    const frameDocument = frameRef.current?.contentDocument
+    if (!frameDocument || typeof ResizeObserver === 'undefined') {
+      return
+    }
+    const observer = new ResizeObserver(resizeToContent)
+    observer.observe(frameDocument.body)
+    return () => observer.disconnect()
+  }, [srcDoc, loadVersion, resizeToContent])
+
+  // allow-same-origin enables size measurement via contentDocument; no
+  // allow-scripts, so output stays inert under CSP default-src 'none'.
+  return (
+    <iframe
+      ref={frameRef}
+      title={translate('auto.components.editor.IpynbViewer.66a3f7d330', 'Notebook HTML output')}
+      sandbox="allow-same-origin"
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      className="block w-full border-0 bg-background"
+      style={{ height }}
+      srcDoc={srcDoc}
+      onLoad={() => setLoadVersion((current) => current + 1)}
+    />
+  )
+}

--- a/src/renderer/src/components/editor/IpynbRendering.test.tsx
+++ b/src/renderer/src/components/editor/IpynbRendering.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment happy-dom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IpynbCellOutputs } from './IpynbCellOutputs'
+import { IpynbMarkdownCell, IpynbMarkdownCellEditor } from './IpynbCellEditor'
+import type { IpynbCell } from './ipynb-parse'
+
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) => selector({ settings: { theme: 'dark' } })
+}))
+
+function codeCell(outputs: IpynbCell['outputs']): IpynbCell {
+  return {
+    id: 'cell-1',
+    kind: 'code',
+    language: 'python',
+    source: 'value',
+    executionCount: 1,
+    outputs
+  }
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('notebook rendering', () => {
+  it('uses the full Markdown pipeline for GFM and math', () => {
+    render(<IpynbMarkdownCell source={'| A | B |\n| - | - |\n| 1 | 2 |\n\n$x^2$'} />)
+
+    expect(document.querySelector('table')).not.toBeNull()
+    expect(document.querySelector('.katex')).not.toBeNull()
+  })
+
+  it('renders Markdown as a document until editing is explicitly activated', () => {
+    const onActivate = vi.fn()
+    const onChange = vi.fn()
+    const { container, rerender } = render(
+      <IpynbMarkdownCellEditor
+        source="# Report"
+        active={false}
+        onActivate={onActivate}
+        onChange={onChange}
+      />
+    )
+
+    expect(screen.queryByRole('textbox')).toBeNull()
+    const preview = container.firstElementChild
+    expect(preview?.getAttribute('role')).toBeNull()
+    fireEvent.doubleClick(preview as Element)
+    expect(onActivate).toHaveBeenCalledOnce()
+
+    rerender(
+      <IpynbMarkdownCellEditor
+        source="# Report"
+        active
+        onActivate={onActivate}
+        onChange={onChange}
+      />
+    )
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '# Updated' } })
+    expect(onChange).toHaveBeenCalledWith('# Updated')
+  })
+
+  it('renders only the preferred representation from a display MIME bundle', () => {
+    render(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'execute_result',
+            executionCount: 1,
+            items: [
+              { mime: 'text/html', value: '<table><tr><td>rich</td></tr></table>' },
+              { mime: 'text/plain', value: 'plain fallback' }
+            ]
+          }
+        ])}
+      />
+    )
+
+    const frame = screen.getByTitle('Notebook HTML output')
+    expect(frame.getAttribute('srcdoc')).toContain('rich')
+    expect(screen.queryByText('plain fallback')).toBeNull()
+  })
+
+  it('falls back from an empty preferred image and preserves image alternatives', () => {
+    const { rerender } = render(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'display_data',
+            executionCount: null,
+            items: [
+              { mime: 'image/png', value: '' },
+              { mime: 'text/plain', value: 'fallback value' }
+            ]
+          }
+        ])}
+      />
+    )
+    expect(screen.getByText('fallback value')).toBeTruthy()
+
+    rerender(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'display_data',
+            executionCount: null,
+            items: [
+              { mime: 'image/png', value: 'aW1hZ2U=' },
+              { mime: 'text/plain', value: 'Chart of monthly totals' }
+            ]
+          }
+        ])}
+      />
+    )
+    expect(screen.getByAltText('Chart of monthly totals')).toBeTruthy()
+  })
+
+  it('rejects SVG output that sanitizes to empty content', () => {
+    render(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'display_data',
+            executionCount: null,
+            items: [
+              {
+                mime: 'image/svg+xml',
+                value: '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+              },
+              { mime: 'text/plain', value: 'SVG output unavailable' }
+            ]
+          }
+        ])}
+      />
+    )
+    expect(screen.getByText('SVG output unavailable')).toBeTruthy()
+  })
+
+  it('sanitizes HTML outputs and blocks scripts, links, and remote resources', () => {
+    render(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'display_data',
+            executionCount: null,
+            items: [
+              {
+                mime: 'text/html',
+                value:
+                  '<script>alert(1)</script><a href="https://example.com">leave</a><img src="https://example.com/track.png"><b>safe</b>'
+              }
+            ]
+          }
+        ])}
+      />
+    )
+
+    const source = screen.getByTitle('Notebook HTML output').getAttribute('srcdoc') ?? ''
+    expect(source).not.toContain('<script')
+    expect(source).toContain("default-src 'none'; img-src data:")
+    expect(source).not.toContain('href=')
+    expect(source).toContain('color-scheme: dark')
+    expect(source).toContain('<b>safe</b>')
+  })
+
+  it('tracks stable HTML content height and disconnects its observer', () => {
+    const observe = vi.fn()
+    const disconnect = vi.fn()
+    let resizeCallback: ResizeObserverCallback | null = null
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback
+        }
+        observe = observe
+        disconnect = disconnect
+      }
+    )
+    const { unmount } = render(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'display_data',
+            executionCount: null,
+            items: [{ mime: 'text/html', value: '<details><summary>More</summary>Text</details>' }]
+          }
+        ])}
+      />
+    )
+    const frame = screen.getByTitle('Notebook HTML output') as HTMLIFrameElement
+    const body = frame.contentDocument?.body
+    expect(body).toBeTruthy()
+    vi.spyOn(body as HTMLElement, 'getBoundingClientRect').mockReturnValue({
+      height: 120
+    } as DOMRect)
+    observe.mockClear()
+
+    fireEvent.load(frame)
+    expect(observe).toHaveBeenCalledOnce()
+    expect(observe).toHaveBeenCalledWith(body)
+    expect(frame.style.height).toBe('122px')
+
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+    expect(frame.style.height).toBe('122px')
+    unmount()
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/IpynbRendering.test.tsx
+++ b/src/renderer/src/components/editor/IpynbRendering.test.tsx
@@ -3,7 +3,7 @@ import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IpynbCellOutputs } from './IpynbCellOutputs'
 import { IpynbMarkdownCell, IpynbMarkdownCellEditor } from './IpynbCellEditor'
-import type { IpynbCell } from './ipynb-parse'
+import { parseIpynb, type IpynbCell } from './ipynb-parse'
 
 vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
 vi.mock('@/store', () => ({
@@ -120,6 +120,39 @@ describe('notebook rendering', () => {
       />
     )
     expect(screen.getByAltText('Chart of monthly totals')).toBeTruthy()
+  })
+
+  it('prefers gif/webp/bmp/tiff images over a text/plain fallback', () => {
+    const notebook = parseIpynb(
+      JSON.stringify({
+        nbformat: 4,
+        nbformat_minor: 5,
+        metadata: { language_info: { name: 'python' } },
+        cells: [
+          {
+            id: 'img-1',
+            cell_type: 'code',
+            metadata: {},
+            execution_count: 1,
+            source: ['plot()'],
+            outputs: [
+              {
+                output_type: 'display_data',
+                data: {
+                  'text/plain': 'fallback',
+                  'image/gif': 'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs='
+                },
+                metadata: {}
+              }
+            ]
+          }
+        ]
+      })
+    )
+    expect(notebook.cells[0].outputs[0]).toMatchObject({ kind: 'display' })
+    render(<IpynbCellOutputs cell={notebook.cells[0]} />)
+    expect(screen.getByRole('img')).toBeTruthy()
+    expect(screen.queryByText('fallback')).toBeNull()
   })
 
   it('rejects SVG output that sanitizes to empty content', () => {

--- a/src/renderer/src/components/editor/IpynbRendering.test.tsx
+++ b/src/renderer/src/components/editor/IpynbRendering.test.tsx
@@ -177,6 +177,26 @@ describe('notebook rendering', () => {
     expect(screen.getByText('SVG output unavailable')).toBeTruthy()
   })
 
+  it('falls back to text when an image payload is malformed Base64', () => {
+    render(
+      <IpynbCellOutputs
+        cell={codeCell([
+          {
+            kind: 'display',
+            outputType: 'display_data',
+            executionCount: null,
+            items: [
+              { mime: 'image/png', value: '!!!not-base64!!!' },
+              { mime: 'text/plain', value: 'fallback text' }
+            ]
+          }
+        ])}
+      />
+    )
+    expect(screen.getByText('fallback text')).toBeTruthy()
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+
   it('sanitizes HTML outputs and blocks scripts, links, and remote resources', () => {
     render(
       <IpynbCellOutputs

--- a/src/renderer/src/components/editor/IpynbRendering.test.tsx
+++ b/src/renderer/src/components/editor/IpynbRendering.test.tsx
@@ -122,7 +122,13 @@ describe('notebook rendering', () => {
     expect(screen.getByAltText('Chart of monthly totals')).toBeTruthy()
   })
 
-  it('prefers gif/webp/bmp/tiff images over a text/plain fallback', () => {
+  it.each([
+    { mime: 'image/gif', showsImage: true },
+    { mime: 'image/webp', showsImage: true },
+    { mime: 'image/bmp', showsImage: true },
+    // Chromium/Electron cannot decode TIFF, so the legible text/plain fallback must win.
+    { mime: 'image/tiff', showsImage: false }
+  ])('ranks $mime against a text/plain fallback', ({ mime, showsImage }) => {
     const notebook = parseIpynb(
       JSON.stringify({
         nbformat: 4,
@@ -140,7 +146,7 @@ describe('notebook rendering', () => {
                 output_type: 'display_data',
                 data: {
                   'text/plain': 'fallback',
-                  'image/gif': 'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs='
+                  [mime]: 'R0lGODdhAQABAIAAAP///////ywAAAAAAQABAAACAkQBADs='
                 },
                 metadata: {}
               }
@@ -151,8 +157,13 @@ describe('notebook rendering', () => {
     )
     expect(notebook.cells[0].outputs[0]).toMatchObject({ kind: 'display' })
     render(<IpynbCellOutputs cell={notebook.cells[0]} />)
-    expect(screen.getByRole('img')).toBeTruthy()
-    expect(screen.queryByText('fallback')).toBeNull()
+    if (showsImage) {
+      expect(screen.getByRole('img')).toBeTruthy()
+      expect(screen.queryByText('fallback')).toBeNull()
+    } else {
+      expect(screen.getByText('fallback')).toBeTruthy()
+      expect(screen.queryByRole('img')).toBeNull()
+    }
   })
 
   it('rejects SVG output that sanitizes to empty content', () => {

--- a/src/renderer/src/components/editor/IpynbViewer.preview-mode.test.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.preview-mode.test.tsx
@@ -43,6 +43,7 @@ vi.mock('./IpynbCellEditor', () => ({
   IpynbRawCell: () => <div data-testid="raw-preview" />
 }))
 vi.mock('./IpynbCellOutputs', () => ({ IpynbCellOutputs: () => null }))
+vi.mock('./editor-shortcuts', () => ({ editorShortcutMatches: () => true }))
 vi.mock('./IpynbCellToolbar', () => ({
   IpynbCellToolbar: () => <div data-testid="cell-toolbar" />,
   IpynbToolbarButton: ({
@@ -135,5 +136,28 @@ describe('IpynbViewer preview mode', () => {
     expect(screen.getByText('In [3]:')).toBeTruthy()
     expect(screen.getByText('#1')).toBeTruthy()
     expect(screen.queryByTestId('cell-toolbar')).toBeNull()
+  })
+
+  it('ignores the save shortcut while in preview and honors it once editing', () => {
+    const onSave = vi.fn(async () => true)
+    const { container } = render(
+      <IpynbViewer
+        content={CONTENT}
+        fileId="notebook.ipynb"
+        filePath="/repo/notebook.ipynb"
+        worktreeId="wt-1"
+        scrollCacheKey="notebook-save-guard"
+        onContentChange={() => {}}
+        onDirtyStateHint={() => {}}
+        onSave={onSave}
+      />
+    )
+    const root = container.firstElementChild as Element
+    fireEvent.keyDown(root, { key: 's', ctrlKey: true })
+    expect(onSave).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByLabelText('Edit'))
+    fireEvent.keyDown(root, { key: 's', ctrlKey: true })
+    expect(onSave).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/editor/IpynbViewer.preview-mode.test.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.preview-mode.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({ settings: {}, editorFontZoomLevel: 0 })
+}))
+vi.mock('@/hooks/useShortcutLabel', () => ({ useShortcutKeyDetails: () => undefined }))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('./useIpynbScrollRestoration', () => ({ useIpynbScrollRestoration: () => {} }))
+vi.mock('./useIpynbDocumentEditing', () => ({
+  getIpynbCellKey: (_cell: unknown, index: number) => `cell-${index}`,
+  hasIpynbSourceDraft: () => false,
+  useIpynbDocumentEditing: () => ({
+    rootRef: null,
+    setRootRef: () => {},
+    sourceDrafts: {},
+    flushSourceDrafts: () => '{}',
+    applyContent: () => {},
+    updateCellSource: () => {},
+    updateCellKind: () => {},
+    insertCell: () => {},
+    moveCell: () => {},
+    deleteCell: () => {}
+  })
+}))
+vi.mock('./useIpynbCellExecution', () => ({
+  useIpynbCellExecution: () => ({
+    runError: null,
+    runningCellIndex: null,
+    pendingRunCellIndex: null,
+    runCell: () => {},
+    cancelPendingRun: () => {},
+    confirmPendingRun: () => {}
+  })
+}))
+vi.mock('./IpynbCellEditor', () => ({
+  IpynbCodeCell: () => <div data-testid="code-cell" />,
+  IpynbEditableTextCell: () => <div data-testid="raw-editor" />,
+  IpynbMarkdownCell: () => <div data-testid="markdown-preview" />,
+  IpynbMarkdownCellEditor: () => <div data-testid="markdown-editor" />,
+  IpynbRawCell: () => <div data-testid="raw-preview" />
+}))
+vi.mock('./IpynbCellOutputs', () => ({ IpynbCellOutputs: () => null }))
+vi.mock('./IpynbCellToolbar', () => ({
+  IpynbCellToolbar: () => <div data-testid="cell-toolbar" />,
+  IpynbToolbarButton: ({
+    label,
+    onClick,
+    children
+  }: {
+    label: string
+    onClick: () => void
+    children: React.ReactNode
+  }) => (
+    <button aria-label={label} onClick={onClick}>
+      {children}
+    </button>
+  )
+}))
+
+import IpynbViewer from './IpynbViewer'
+
+const CONTENT = JSON.stringify({
+  nbformat: 4,
+  nbformat_minor: 5,
+  metadata: { language_info: { name: 'python' } },
+  cells: [{ id: 'intro', cell_type: 'markdown', metadata: {}, source: ['# Report'] }]
+})
+
+afterEach(() => cleanup())
+
+describe('IpynbViewer preview mode', () => {
+  it('opens as a clean rendered notebook and reveals editing controls on demand', () => {
+    render(
+      <IpynbViewer
+        content={CONTENT}
+        fileId="notebook.ipynb"
+        filePath="/repo/notebook.ipynb"
+        worktreeId="wt-1"
+        scrollCacheKey="notebook"
+        onContentChange={() => {}}
+        onDirtyStateHint={() => {}}
+        onSave={async () => true}
+      />
+    )
+
+    expect(screen.getByTestId('markdown-preview')).toBeTruthy()
+    expect(screen.queryByTestId('markdown-editor')).toBeNull()
+    expect(screen.queryByTestId('cell-toolbar')).toBeNull()
+    expect(screen.queryByLabelText('Save notebook')).toBeNull()
+    expect(screen.getByTestId('ipynb-cell-header')).toBeTruthy()
+    expect(screen.getByText('#1')).toBeTruthy()
+
+    fireEvent.click(screen.getByLabelText('Edit'))
+
+    expect(screen.getByTestId('markdown-editor')).toBeTruthy()
+    expect(screen.getByTestId('cell-toolbar')).toBeTruthy()
+    expect(screen.getByTestId('ipynb-cell-header')).toBeTruthy()
+    expect(screen.getByLabelText('Save notebook')).toBeTruthy()
+    expect(screen.getByLabelText('Preview')).toBeTruthy()
+  })
+
+  it('shows the execution count and cell number for code cells in preview', () => {
+    const codeContent = JSON.stringify({
+      nbformat: 4,
+      nbformat_minor: 5,
+      metadata: { language_info: { name: 'python' } },
+      cells: [
+        {
+          id: 'code-1',
+          cell_type: 'code',
+          metadata: {},
+          execution_count: 3,
+          source: ['print(1)'],
+          outputs: []
+        }
+      ]
+    })
+    render(
+      <IpynbViewer
+        content={codeContent}
+        fileId="notebook.ipynb"
+        filePath="/repo/notebook.ipynb"
+        worktreeId="wt-1"
+        scrollCacheKey="notebook-code"
+        onContentChange={() => {}}
+        onDirtyStateHint={() => {}}
+        onSave={async () => true}
+      />
+    )
+
+    expect(screen.getByTestId('ipynb-cell-header')).toBeTruthy()
+    expect(screen.getByText('In [3]:')).toBeTruthy()
+    expect(screen.getByText('#1')).toBeTruthy()
+    expect(screen.queryByTestId('cell-toolbar')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from 'react'
-import { AlertCircle, Save } from 'lucide-react'
+import { AlertCircle, Eye, Pencil, Save } from 'lucide-react'
 import { computeEditorFontSize, resolveEditorFontFamilyOrInherit } from '@/lib/editor-font-zoom'
 import { useAppStore } from '@/store'
 import { Button } from '@/components/ui/button'
@@ -14,8 +14,15 @@ import {
 import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import { editorShortcutMatches } from './editor-shortcuts'
+import { IpynbCellHeader } from './IpynbCellHeader'
 import { IpynbCellToolbar, IpynbToolbarButton } from './IpynbCellToolbar'
-import { IpynbCodeCell, IpynbEditableTextCell, IpynbMarkdownCell } from './IpynbCellEditor'
+import {
+  IpynbCodeCell,
+  IpynbEditableTextCell,
+  IpynbMarkdownCell,
+  IpynbMarkdownCellEditor,
+  IpynbRawCell
+} from './IpynbCellEditor'
 import { IpynbCellOutputs } from './IpynbCellOutputs'
 import { parseIpynb } from './ipynb-parse'
 import {
@@ -49,6 +56,7 @@ export default function IpynbViewer({
 }: IpynbViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  const [editingEnabled, setEditingEnabled] = useState(false)
   const [editingCellKey, setEditingCellKey] = useState<string | null>(null)
   const parsed = useMemo(() => {
     try {
@@ -114,7 +122,7 @@ export default function IpynbViewer({
         return
       }
       const target = event.target instanceof Element ? event.target : null
-      if (!target?.closest('.monaco-editor')) {
+      if (!target?.closest('.monaco-editor, [data-ipynb-cell-editor="true"]')) {
         setEditingCellKey(null)
       }
     },
@@ -160,12 +168,27 @@ export default function IpynbViewer({
         {execution.runError ? <span className="text-destructive">{execution.runError}</span> : null}
         <div className="ml-auto flex items-center gap-2">
           <IpynbToolbarButton
-            label={translate('auto.components.editor.IpynbViewer.15ec40a735', 'Save notebook')}
-            shortcut={saveShortcut}
-            onClick={() => void saveNotebook()}
+            label={
+              editingEnabled
+                ? translate('auto.components.editor.EditorViewToggle.0d193dc03c', 'Preview')
+                : translate('auto.components.editor.EditorViewToggle.ac3bb87913', 'Edit')
+            }
+            onClick={() => {
+              setEditingEnabled((current) => !current)
+              setEditingCellKey(null)
+            }}
           >
-            <Save className="size-3.5" />
+            {editingEnabled ? <Eye className="size-3.5" /> : <Pencil className="size-3.5" />}
           </IpynbToolbarButton>
+          {editingEnabled ? (
+            <IpynbToolbarButton
+              label={translate('auto.components.editor.IpynbViewer.15ec40a735', 'Save notebook')}
+              shortcut={saveShortcut}
+              onClick={() => void saveNotebook()}
+            >
+              <Save className="size-3.5" />
+            </IpynbToolbarButton>
+          ) : null}
           <span className="rounded-sm border border-border bg-muted px-1.5 py-0.5 font-medium text-muted-foreground">
             {translate('auto.components.editor.IpynbViewer.329764e9fc', 'BETA')}
           </span>
@@ -191,47 +214,53 @@ export default function IpynbViewer({
                 key={cellKey}
                 className="overflow-hidden rounded-md border border-border bg-background"
               >
-                <IpynbCellToolbar
-                  cell={cell}
-                  index={index}
-                  running={execution.runningCellIndex === index}
-                  canMoveUp={index > 0}
-                  canMoveDown={index < notebook.cells.length - 1}
-                  onRun={() => void execution.runCell(index)}
-                  onKindChange={(kind) => updateCellKind(index, kind)}
-                  onInsertAbove={(kind) => insertCell(index, kind)}
-                  onInsertBelow={(kind) => insertCell(index + 1, kind)}
-                  onMoveUp={() => moveCell(index, -1)}
-                  onMoveDown={() => moveCell(index, 1)}
-                  onDelete={() => deleteCell(index)}
-                />
+                <IpynbCellHeader cell={cell} index={index} />
+                {editingEnabled ? (
+                  <IpynbCellToolbar
+                    cell={cell}
+                    running={execution.runningCellIndex === index}
+                    canMoveUp={index > 0}
+                    canMoveDown={index < notebook.cells.length - 1}
+                    onRun={() => void execution.runCell(index)}
+                    onEdit={() => setEditingCellKey(cellKey)}
+                    onKindChange={(kind) => updateCellKind(index, kind)}
+                    onInsertAbove={(kind) => insertCell(index, kind)}
+                    onInsertBelow={(kind) => insertCell(index + 1, kind)}
+                    onMoveUp={() => moveCell(index, -1)}
+                    onMoveDown={() => moveCell(index, 1)}
+                    onDelete={() => deleteCell(index)}
+                  />
+                ) : null}
                 {cell.kind === 'markdown' ? (
-                  <div className="grid gap-0 lg:grid-cols-2">
-                    <IpynbEditableTextCell
+                  editingEnabled ? (
+                    <IpynbMarkdownCellEditor
                       source={source}
+                      active={editingCellKey === cellKey}
+                      onActivate={() => setEditingCellKey(cellKey)}
                       onChange={(nextSource) => updateCellSource(index, nextSource)}
                     />
-                    <div className="border-t border-border/50 lg:border-l lg:border-t-0">
-                      <IpynbMarkdownCell source={source} />
-                    </div>
-                  </div>
+                  ) : (
+                    <IpynbMarkdownCell source={source} />
+                  )
                 ) : cell.kind === 'code' ? (
                   <IpynbCodeCell
                     cell={cell}
                     source={source}
-                    active={editingCellKey === cellKey}
-                    onActivate={() => setEditingCellKey(cellKey)}
+                    active={editingEnabled && editingCellKey === cellKey}
+                    onActivate={editingEnabled ? () => setEditingCellKey(cellKey) : undefined}
                     onDeactivate={() =>
                       setEditingCellKey((current) => (current === cellKey ? null : current))
                     }
                     onChange={(nextSource) => updateCellSource(index, nextSource)}
                     onSaveRequest={saveNotebook}
                   />
-                ) : (
+                ) : editingEnabled ? (
                   <IpynbEditableTextCell
                     source={source}
                     onChange={(nextSource) => updateCellSource(index, nextSource)}
                   />
+                ) : (
+                  <IpynbRawCell source={source} />
                 )}
                 <IpynbCellOutputs cell={cell} />
               </section>

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -109,11 +109,15 @@ export default function IpynbViewer({
       if (event.repeat || !editorShortcutMatches('editor.save', event)) {
         return
       }
+      // Preview is read-only: ignore the save shortcut until editing is enabled.
+      if (!editingEnabled) {
+        return
+      }
       event.preventDefault()
       event.stopPropagation()
       void saveNotebook()
     },
-    [saveNotebook]
+    [editingEnabled, saveNotebook]
   )
 
   const handleNotebookPointerDownCapture = useCallback(

--- a/src/renderer/src/components/editor/ipynb-parse.ts
+++ b/src/renderer/src/components/editor/ipynb-parse.ts
@@ -29,6 +29,10 @@ export type ParsedIpynb = {
 const DISPLAY_MIME_ORDER = [
   'text/html',
   'image/png',
+  'image/gif',
+  'image/webp',
+  'image/bmp',
+  'image/tiff',
   'image/jpeg',
   'image/jpg',
   'image/svg+xml',

--- a/src/renderer/src/components/editor/ipynb-parse.ts
+++ b/src/renderer/src/components/editor/ipynb-parse.ts
@@ -32,13 +32,14 @@ const DISPLAY_MIME_ORDER = [
   'image/gif',
   'image/webp',
   'image/bmp',
-  'image/tiff',
   'image/jpeg',
   'image/jpg',
   'image/svg+xml',
   'application/json',
   'text/markdown',
-  'text/plain'
+  'text/plain',
+  // Last resort: Chromium/Electron has no TIFF decoder, so a legible text/plain fallback must win.
+  'image/tiff'
 ] as const
 
 const JUPYTER_LANGUAGE_TO_MONACO_LANGUAGE: Record<string, string> = {


### PR DESCRIPTION
## ELI5

Opening a `.ipynb` file used to drop you straight into an editable notebook. Now it opens in a calm read-only Preview — like opening a PDF — and you flip into Edit mode only when you want to change or run cells.

## What Changed

- Notebooks open in **Preview mode by default**: markdown, code, and raw cells render without editable surfaces, cell toolbars, or the save button.
- New **Preview/Edit toggle** in the notebook header (Pencil/Eye icons, reuses existing `EditorViewToggle` strings). Edit mode restores per-cell toolbars, Monaco/markdown editors, and Save.
- New persistent **`IpynbCellHeader`**: kind icon, `In [n]:` execution label, and `#position` now show in both modes (previously lived inside the edit toolbar).
- Markdown cells show a rendered preview you **double-click to edit**; in Edit mode an inactive markdown cell shows preview-only until activated, then the side-by-side editor appears.
- Rich `text/html` outputs render in a dedicated sandboxed iframe (`IpynbHtmlOutput`): DOMPurify sanitization, strict CSP (`default-src 'none'`), no scripts, content-based auto-resize (72–960px).
- Inline SVG outputs are sanitized and validated (must contain real visual content); empty/unrenderable payloads render nothing instead of broken frames.
- Each output renders its **single richest MIME type**; full `text/plain` is exposed as the image accessible name (truncated at 140 chars with full text in `title`).
- Markdown rendering is unified on the shared `MarkdownPreviewBody` instead of a second local `react-markdown` setup.

## Why

`#17075` tracks making the notebook viewer safe to open and pleasant to read: previously every open was an editing session, and rich outputs rendered in a fixed-height unsanitized frame. Preview-first matches how people actually use notebooks most of the time (read/review), while keeping full editing one click away.

## Linked Issue

Fixes #17075

## Visual Proof

**BEFORE** (editable on open, fixed-height HTML frame):

<img width="800" alt="ipynb before 1 — notebook opens directly editable" src="https://github.com/user-attachments/assets/4aa21734-ed35-4086-8e30-8c3f33751dea">

<img width="800" alt="ipynb before 2 — rich output in fixed-height frame" src="https://github.com/user-attachments/assets/5ef45768-d82f-4e80-874d-01fce3b28674">

**AFTER** (read-only preview with Edit toggle, sandboxed auto-sizing outputs):

<img width="800" alt="ipynb after 1 — notebook opens in preview mode" src="https://github.com/user-attachments/assets/d2cd10ef-e186-4112-9fbc-11710e05403d">

<img width="800" alt="ipynb after 2 — edit mode with toolbar and editors" src="https://github.com/user-attachments/assets/df2005c0-23cf-4d71-9b3c-a5e21668306e">

## Testing

- [x] I manually tested these changes locally (open/edit/toggle flow verified before handoff; screenshots above)
- [x] Automated tests added/updated, or explained why not below

New suites (9 tests, all passing):

- `IpynbViewer.preview-mode.test.tsx` — opens read-only by default, toggles into edit mode, hides save until editing.
- `IpynbRendering.test.tsx` — sandboxed HTML output, sanitized SVG, MIME selection, markdown/raw rendering.

Verification on branch `feat/ipynb-readonly-preview` (base `origin/main` @ `7d27c841b4`):

- `pnpm tc:web` — PASS (clean)
- `pnpm test <both suites>` — 2 files passed, 9 tests passed
- `pnpm run check:code-quality:changed` — 0 new findings, gate passed

Tested on macOS. No platform-specific code paths touched (pure renderer components + iframe sandbox).

## AI Disclosure

Assisted by Muse Spark (subagent session) for implementation; screenshots captured via Electron CDP and attached manually via drag + drop.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: HTML/SVG outputs go through DOMPurify plus a second defense-in-depth pass (event-handler attributes, non-fragment links stripped); iframe sandbox is `allow-same-origin` only (size measurement) with no `allow-scripts`, under a `default-src 'none'` CSP.
- **Cross-platform**: no path/shortcut/OS branches touched; renderer-only change, safe on Linux/Windows/Mac.
- **SSH/remote**: no execution-host or process behavior changed; cell-run path untouched.
- **Backwards compatibility**: default view changes from edit to preview, but all editing capability is preserved behind the toggle; no file-format or settings changes.
- **Performance**: single richest MIME per output (was: render all items); iframe lazy-loads and caps at 960px; markdown shares the existing preview component instead of a second pipeline.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint-changed/typecheck/tests run locally, build covered by CI

