### PR TITLE
fix(browser): isolate local HTML previews

### DIFF
--- a/src/main/browser/doc-preview-file-reader.test.ts
+++ b/src/main/browser/doc-preview-file-reader.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   callRuntimeEnvironment: vi.fn(),
+  readAuthorizedDocPreviewFile: vi.fn(),
   readDocPreviewFile: vi.fn(),
   requireSshFilesystemProvider: vi.fn()
 }))
@@ -10,6 +11,9 @@ vi.mock('../ipc/runtime-environment-transport-routing', () => ({
   callRuntimeEnvironment: mocks.callRuntimeEnvironment
 }))
 vi.mock('../persistence', () => ({ getCanonicalUserDataPath: () => '/user-data' }))
+vi.mock('../../shared/doc-preview-file-access', () => ({
+  readAuthorizedDocPreviewFile: mocks.readAuthorizedDocPreviewFile
+}))
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   requireSshFilesystemProvider: mocks.requireSshFilesystemProvider
 }))
@@ -50,6 +54,16 @@ function runtimeGrant(root = '/srv/repo/docs'): ReturnType<typeof mintDocPreview
   return grant
 }
 
+function localGrant(): ReturnType<typeof mintDocPreviewGrant> {
+  return mintDocPreviewGrant({
+    owner: { kind: 'local' },
+    requestBase: '/srv/repo',
+    root: '/srv/repo/docs',
+    entryRelativePath: 'docs/index.html',
+    browserPageId: 'page-1'
+  })
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
   revokeAllDocPreviewGrants()
@@ -64,6 +78,53 @@ describe('docPreviewContentType', () => {
     expect(docPreviewContentType('assets/app.CSS')).toBe('text/css; charset=utf-8')
     expect(docPreviewContentType('assets/logo.png')).toBe('image/png')
     expect(docPreviewContentType('data.bin')).toBe('application/octet-stream')
+  })
+})
+
+describe('readDocPreviewFile — local owner', () => {
+  it('uses the bounded canonical filesystem reader', async () => {
+    mocks.readAuthorizedDocPreviewFile.mockResolvedValue({
+      content: '<h1>local</h1>',
+      isBinary: false
+    })
+
+    const outcome = await readDocPreviewFile(localGrant(), 'docs/index.html')
+
+    expect(mocks.readAuthorizedDocPreviewFile).toHaveBeenCalledWith({
+      boundaryPath: '/srv/repo',
+      entryPath: '/srv/repo/docs/index.html',
+      implicitRootPath: '/srv/repo/docs',
+      authorizedRootPaths: [],
+      targetPath: '/srv/repo/docs/index.html',
+      maxTextBytes: 10 * 1024 * 1024,
+      maxBinaryBytes: 10 * 1024 * 1024
+    })
+    expect(outcome).toEqual({
+      ok: true,
+      bytes: Buffer.from('<h1>local</h1>', 'utf8'),
+      contentType: 'text/html; charset=utf-8'
+    })
+  })
+
+  it('requires directory approval before touching a sibling local path', async () => {
+    const outcome = await readDocPreviewFile(localGrant(), 'assets/app.js')
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      status: 403,
+      reason: 'authorization-required'
+    })
+    expect(mocks.readAuthorizedDocPreviewFile).not.toHaveBeenCalled()
+  })
+
+  it('reports a local file above the bounded reader cap as too large', async () => {
+    mocks.readAuthorizedDocPreviewFile.mockRejectedValue(new Error('file_too_large'))
+
+    await expect(readDocPreviewFile(localGrant(), 'docs/index.html')).resolves.toMatchObject({
+      ok: false,
+      status: 413,
+      reason: 'too-large'
+    })
   })
 })
 

--- a/src/main/browser/doc-preview-file-reader.ts
+++ b/src/main/browser/doc-preview-file-reader.ts
@@ -3,6 +3,7 @@ import type { RuntimeFilePreviewResult } from '../../shared/runtime-file-contrac
 import type { DocPreviewFileFailureReason } from '../../shared/doc-preview-scheme'
 import { callRuntimeEnvironment } from '../ipc/runtime-environment-transport-routing'
 import { FileReadCapExceededError } from '../ssh/ssh-filesystem-stream-reader'
+import { readAuthorizedDocPreviewFile } from '../../shared/doc-preview-file-access'
 import { getCanonicalUserDataPath } from '../persistence'
 import { requireSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
@@ -15,8 +16,8 @@ import {
 } from './doc-preview-grant-registry'
 
 const DOC_PREVIEW_READ_TIMEOUT_MS = 15_000
-const DIRECT_SSH_DOC_PREVIEW_TEXT_MAX_BYTES = 10 * 1024 * 1024
-const DIRECT_SSH_DOC_PREVIEW_BINARY_MAX_BYTES = 10 * 1024 * 1024
+const DIRECT_DOC_PREVIEW_TEXT_MAX_BYTES = 10 * 1024 * 1024
+const DIRECT_DOC_PREVIEW_BINARY_MAX_BYTES = 10 * 1024 * 1024
 
 /** Why not "needs a newer server": the SSH read path only ever serves images and PDFs as bytes, so
  *  a font is refused there by design, not by version. Name the file type, not the host's age. */
@@ -170,6 +171,24 @@ export async function readDocPreviewFile(
   }
   const contentType = docPreviewContentType(relativePath)
   try {
+    if (grant.owner.kind === 'local') {
+      const authority = resolveDocPreviewAuthorityPaths(grant)
+      if (!authority.entryPath) {
+        return notFoundOutcome()
+      }
+      return toOutcome(
+        await readAuthorizedDocPreviewFile({
+          boundaryPath: grant.requestBase,
+          entryPath: authority.entryPath,
+          implicitRootPath: authority.implicitRootPath,
+          authorizedRootPaths: authority.authorizedRootPaths,
+          targetPath: absolutePath,
+          maxTextBytes: DIRECT_DOC_PREVIEW_TEXT_MAX_BYTES,
+          maxBinaryBytes: DIRECT_DOC_PREVIEW_BINARY_MAX_BYTES
+        }),
+        contentType
+      )
+    }
     if (grant.owner.kind === 'ssh') {
       const provider = requireSshFilesystemProvider(grant.owner.connectionId)
       const authority = resolveDocPreviewAuthorityPaths(grant)
@@ -183,8 +202,8 @@ export async function readDocPreviewFile(
           implicitRootPath: authority.implicitRootPath,
           authorizedRootPaths: authority.authorizedRootPaths,
           targetPath: absolutePath,
-          maxTextBytes: DIRECT_SSH_DOC_PREVIEW_TEXT_MAX_BYTES,
-          maxBinaryBytes: DIRECT_SSH_DOC_PREVIEW_BINARY_MAX_BYTES
+          maxTextBytes: DIRECT_DOC_PREVIEW_TEXT_MAX_BYTES,
+          maxBinaryBytes: DIRECT_DOC_PREVIEW_BINARY_MAX_BYTES
         }),
         contentType
       )

--- a/src/main/browser/doc-preview-grant-registry.ts
+++ b/src/main/browser/doc-preview-grant-registry.ts
@@ -8,6 +8,7 @@ import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
  * subtree requests may resolve inside. No grant, no bytes.
  */
 export type DocPreviewOwner =
+  | { kind: 'local' }
   | { kind: 'ssh'; connectionId: string }
   | {
       kind: 'runtime'

--- a/src/main/ipc/doc-preview-grant-ipc.test.ts
+++ b/src/main/ipc/doc-preview-grant-ipc.test.ts
@@ -108,6 +108,12 @@ describe('document preview grant handlers', () => {
     expect(mocks.isTrustedBrowserRenderer).toHaveBeenCalledWith(sender)
   })
 
+  it('mints a local grant for the bounded main-process reader', () => {
+    const result = mint({ ...REQUEST, owner: { kind: 'local' } })
+
+    expect(getDocPreviewGrant(result.grantId)?.owner).toEqual({ kind: 'local' })
+  })
+
   it('revokes a grant it minted', () => {
     const result = mint()
 

--- a/src/main/ipc/doc-preview-grant-ipc.ts
+++ b/src/main/ipc/doc-preview-grant-ipc.ts
@@ -37,6 +37,9 @@ function isValidGrantRequest(request: DocPreviewGrantRequest): boolean {
   if (typeof request.browserPageId !== 'string' || !request.browserPageId.trim()) {
     return false
   }
+  if (request.owner.kind === 'local') {
+    return true
+  }
   if (request.owner.kind === 'ssh') {
     return Boolean(request.owner.connectionId.trim())
   }
@@ -48,9 +51,9 @@ function isValidGrantRequest(request: DocPreviewGrantRequest): boolean {
 }
 
 /**
- * Minting never widens what the renderer can already read: an SSH grant reads
- * through the same provider as `fs:readFile`, and a runtime grant through the
- * same worktree-scoped `files.read` RPC the renderer can call directly.
+ * Minting never widens what the renderer can already read: a local grant uses
+ * the bounded filesystem reader, an SSH grant its filesystem provider, and a
+ * runtime grant the same worktree-scoped `files.read` RPC.
  */
 export function registerDocPreviewGrantHandlers(): void {
   ipcMain.handle(

--- a/src/preload/api/doc-preview-api.ts
+++ b/src/preload/api/doc-preview-api.ts
@@ -1,6 +1,7 @@
 import type { DocPreviewFailure } from '../../shared/doc-preview-scheme'
 
 export type DocPreviewGrantOwner =
+  | { kind: 'local' }
   | { kind: 'ssh'; connectionId: string }
   | {
       kind: 'runtime'

--- a/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts
@@ -1,4 +1,3 @@
-import { absolutePathToFileUri } from '@/components/editor/markdown-internal-links'
 import { getWorkspaceFilePreviewPlan, openFileInBrowserTab } from '@/lib/file-preview'
 import { downloadAndOpenRemoteTerminalFile } from './terminal-remote-file-download-open'
 import { detectLanguage } from '@/lib/language-detect'
@@ -30,19 +29,6 @@ type TerminalFileOpenDeps = {
 
 export function isHtmlFilePath(filePath: string): boolean {
   return /\.html?$/i.test(filePath)
-}
-
-function openHtmlFileInBrowser(filePath: string, worktreeId: string): void {
-  const store = useAppStore.getState()
-  if (worktreeId) {
-    // Why: following an HTML file link changes which worktree is foregrounded,
-    // so it must record a history visit before opening the browser tab — but the
-    // browser tab is the surface, so an emptied workspace must not gain a shell.
-    activateAndRevealWorktree(worktreeId, { providesInitialSurface: true })
-  }
-  const fileUrl = absolutePathToFileUri(filePath)
-  const title = filePath.split(/[/\\]/).pop() ?? filePath
-  store.createBrowserTab(worktreeId, fileUrl, { title, activate: true })
 }
 
 export function getTerminalFileContext(
@@ -197,15 +183,9 @@ export function openDetectedFilePath(
       return
     }
 
-    // Why: local HTML files render in Orca's browser for ordinary Cmd/Ctrl-click,
-    // and remain the fallback if Shift+Cmd/Ctrl cannot launch the OS default.
+    // Why: every HTML file opened inside Orca uses the isolated document preview;
+    // Shift+Cmd/Ctrl still explicitly delegates to the OS default above.
     if (isHtmlFilePath(mappedFilePath)) {
-      if (shouldOpenTerminalFileWithSystemDefault(fileContext, mappedFilePath)) {
-        openHtmlFileInBrowser(mappedFilePath, worktreeId)
-        return
-      }
-      // Why: the same gesture renders remote HTML too, through the doc preview; only an
-      // unsupported plan (e.g. a paired doc outside the worktree) falls back to source.
       const plan = getWorkspaceFilePreviewPlan(useAppStore.getState(), worktreeId, mappedFilePath)
       if (plan.status === 'doc-preview') {
         activateAndRevealWorktree(worktreeId, { providesInitialSurface: true })

--- a/src/renderer/src/components/terminal-pane/terminal-link-click-fallback.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-click-fallback.test.ts
@@ -22,6 +22,10 @@ import {
 } from './terminal-link-handlers-test-harness'
 
 const doubles = createTerminalLinkTestDoubles()
+const filePreviewMocks = vi.hoisted(() => ({
+  getWorkspaceFilePreviewPlan: vi.fn(() => ({ status: 'doc-preview' as const })),
+  openFileInBrowserTab: vi.fn()
+}))
 const {
   storeState,
   openUrlMock,
@@ -50,6 +54,8 @@ vi.mock('@/lib/worktree-activation', () => ({
 vi.mock('@/lib/connection-context', () => ({
   getConnectionId: vi.fn(() => null)
 }))
+
+vi.mock('@/lib/file-preview', () => filePreviewMocks)
 
 installTerminalLinkTestEnvironment(doubles)
 
@@ -215,11 +221,11 @@ describe('createFilePathLinkProvider range bounds', () => {
     await flushAsyncWork()
 
     expect(opened).toBe(true)
-    expect(createBrowserTabMock).toHaveBeenCalledWith(
-      'wt-1',
-      'file:///tmp/mobile/mock-homepage.html',
-      expect.objectContaining({ title: 'mock-homepage.html', activate: true })
-    )
+    expect(filePreviewMocks.openFileInBrowserTab).toHaveBeenCalledWith({
+      filePath: '/tmp/mobile/mock-homepage.html',
+      worktreeId: 'wt-1'
+    })
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
     expect(openFilePathMock).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-link-file-open-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-file-open-routing.test.ts
@@ -11,13 +11,16 @@ import {
 } from './terminal-link-handlers-test-harness'
 
 const findWorkspaceFileRouteMock = vi.hoisted(() => vi.fn())
+const filePreviewMocks = vi.hoisted(() => ({
+  getWorkspaceFilePreviewPlan: vi.fn(() => ({ status: 'doc-preview' as const })),
+  openFileInBrowserTab: vi.fn()
+}))
 const doubles = createTerminalLinkTestDoubles()
 const {
   storeState,
   deps,
   openFileMock,
   openFilePathMock,
-  createBrowserTabMock,
   setPendingEditorRevealMock,
   setMarkdownViewModeMock,
   statMock
@@ -46,10 +49,12 @@ vi.mock('@/lib/runtime-workspace-file-route', () => ({
   findWorkspaceFileRoute: findWorkspaceFileRouteMock
 }))
 
+vi.mock('@/lib/file-preview', () => filePreviewMocks)
+
 installTerminalLinkTestEnvironment(doubles)
 
 describe('handleOscLink', () => {
-  it('opens local .html file paths in Orca browser tabs with the platform modifier', async () => {
+  it('opens local .html file paths in the isolated document preview', async () => {
     setPlatform('Macintosh')
 
     openDetectedFilePath('/tmp/report.html', null, null, deps)
@@ -59,11 +64,10 @@ describe('handleOscLink', () => {
 
     expect(openFileMock).not.toHaveBeenCalled()
     expect(setPendingEditorRevealMock).not.toHaveBeenCalled()
-    expect(createBrowserTabMock).toHaveBeenCalledWith(
-      'wt-1',
-      'file:///tmp/report.html',
-      expect.objectContaining({ title: 'report.html', activate: true })
-    )
+    expect(filePreviewMocks.openFileInBrowserTab).toHaveBeenCalledWith({
+      filePath: '/tmp/report.html',
+      worktreeId: 'wt-1'
+    })
     expect(openFilePathMock).not.toHaveBeenCalled()
     // Why: the browser tab is the surface — activation must not re-seed a shell into a
     // workspace whose last terminal the user closed.
@@ -72,7 +76,7 @@ describe('handleOscLink', () => {
     })
   })
 
-  it('also opens local .htm paths in Orca browser tabs with the platform modifier', async () => {
+  it('also opens local .htm paths in the isolated document preview', async () => {
     setPlatform('Macintosh')
 
     openDetectedFilePath('/tmp/legacy.HTM', null, null, deps)
@@ -80,11 +84,10 @@ describe('handleOscLink', () => {
 
     expect(openFileMock).not.toHaveBeenCalled()
     expect(setPendingEditorRevealMock).not.toHaveBeenCalled()
-    expect(createBrowserTabMock).toHaveBeenCalledWith(
-      'wt-1',
-      'file:///tmp/legacy.HTM',
-      expect.objectContaining({ title: 'legacy.HTM' })
-    )
+    expect(filePreviewMocks.openFileInBrowserTab).toHaveBeenCalledWith({
+      filePath: '/tmp/legacy.HTM',
+      worktreeId: 'wt-1'
+    })
     expect(openFilePathMock).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/doc-preview-grants.test.ts
+++ b/src/renderer/src/lib/doc-preview-grants.test.ts
@@ -33,6 +33,15 @@ beforeEach(() => {
 })
 
 describe('buildDocPreviewGrantRequest', () => {
+  it('scopes a local grant to the workspace and document directory', () => {
+    expect(buildDocPreviewGrantRequest(state, 'wt-1', '/srv/repo/docs/report.html')).toEqual({
+      owner: { kind: 'local' },
+      requestBase: '/srv/repo',
+      root: '/srv/repo/docs',
+      entryRelativePath: 'docs/report.html'
+    })
+  })
+
   // A document outside every workspace resolves and authorizes from its own directory.
   it('roots an SSH grant outside the workspace at the document directory', () => {
     mocks.connectionId = 'ssh-1'
@@ -79,8 +88,19 @@ describe('buildDocPreviewGrantRequest', () => {
     expect(buildDocPreviewGrantRequest(state, 'wt-1', '/var/tmp/report.html')).toBeNull()
   })
 
-  it('refuses a local workspace, which has no remote channel to read over', () => {
-    expect(buildDocPreviewGrantRequest(state, 'wt-1', '/tmp/report.html')).toBeNull()
+  it('makes an outside-workspace local grant entry-only in its document directory', () => {
+    expect(buildDocPreviewGrantRequest(state, 'wt-1', '/tmp/report.html')).toEqual({
+      owner: { kind: 'local' },
+      requestBase: '/tmp',
+      root: '/tmp',
+      entryRelativePath: 'report.html'
+    })
+  })
+
+  it('refuses to assume a local owner while workspace ownership is unresolved', () => {
+    mocks.connectionId = undefined
+
+    expect(buildDocPreviewGrantRequest(state, 'wt-1', '/srv/repo/docs/report.html')).toBeNull()
   })
 })
 

--- a/src/renderer/src/lib/doc-preview-grants.ts
+++ b/src/renderer/src/lib/doc-preview-grants.ts
@@ -31,14 +31,20 @@ export function buildDocPreviewGrantRequest(
     return null
   }
   const connectionId = getConnectionIdForFileFromState(state, worktreeId, filePath)
-  if (connectionId) {
+  if (connectionId === undefined) {
+    return null
+  }
+  if (connectionId !== null) {
     // Outside a workspace there is no broader request base: the document directory bounds
     // resolution, and main starts such a grant at the entry file alone — an out-of-workspace
     // directory is often a home directory, which is where secrets live.
     return { owner: { kind: 'ssh', connectionId }, requestBase, root, entryRelativePath }
   }
   const environmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
-  if (!environmentId || !worktreeRoot || !worktreeRelativePath) {
+  if (!environmentId) {
+    return { owner: { kind: 'local' }, requestBase, root, entryRelativePath }
+  }
+  if (!worktreeRoot || !worktreeRelativePath) {
     return null
   }
   return {

--- a/src/renderer/src/lib/file-preview.test.ts
+++ b/src/renderer/src/lib/file-preview.test.ts
@@ -92,7 +92,7 @@ beforeEach(() => {
 
 /**
  * What a preview open looks like now: a browser tab located by the document, never a URL.
- * `activate` is the caller's call — opening a file moves the reader to it, a side preview does not.
+ * `activate` preserves the focus behavior of the entry point that opened it.
  */
 function docPreviewCall(filePath: string, extra: Record<string, unknown> = {}): unknown[] {
   return [
@@ -110,16 +110,17 @@ function docPreviewCall(filePath: string, extra: Record<string, unknown> = {}): 
 }
 
 describe('openFileInBrowserTab', () => {
-  it('opens a local file URL in the Orca browser with the filename as title', () => {
-    openFileInBrowserTab({
+  it('isolates a local HTML file behind a scoped document grant instead of a file URL', () => {
+    const plan = openFileInBrowserTab({
       filePath: '/tmp/example file.html',
       worktreeId: 'wt-1'
     })
 
-    expect(mocks.createBrowserTab).toHaveBeenCalledWith('wt-1', 'file:///tmp/example%20file.html', {
-      title: 'example file.html',
-      activate: true
-    })
+    expect(plan).toEqual({ status: 'doc-preview' })
+    expect(mocks.createBrowserTab).toHaveBeenCalledWith(
+      ...docPreviewCall('/tmp/example file.html', { activate: true })
+    )
+    expect(mocks.createBrowserTab.mock.calls[0]?.[1]).not.toMatch(/^file:/)
   })
 
   it('renders a paired-runtime file as a local doc preview instead of a runtime browser tab', () => {
@@ -301,11 +302,9 @@ describe('openFileInBrowserTab', () => {
     })
 
     expect(mocks.createEmptySplitGroup).toHaveBeenCalledWith('wt-1', 'group-1', 'right')
-    expect(mocks.createBrowserTab).toHaveBeenCalledWith('wt-1', 'file:///tmp/example.html', {
-      title: 'example.html',
-      targetGroupId: 'group-2',
-      activate: true
-    })
+    expect(mocks.createBrowserTab).toHaveBeenCalledWith(
+      ...docPreviewCall('/tmp/example.html', { targetGroupId: 'group-2', activate: true })
+    )
   })
 
   it('rejects a local workspace whose managed browser is unavailable before creating a split', () => {

--- a/src/renderer/src/lib/file-preview.ts
+++ b/src/renderer/src/lib/file-preview.ts
@@ -34,14 +34,11 @@ function pairedOutsideWorktreeMessage(): string {
 /**
  * How a previewable document should be rendered.
  *
- * `browser-tab` keeps local workspaces on the pre-existing embedded browser tab.
- * `doc-preview` renders the document locally from the owning workspace's disk
- * over the `orca-preview` scheme, which is the only option for SSH and paired
- * workspaces: client-hosted browser guests refuse `file:` by design, and a
- * `file://` URL would resolve on the wrong machine anyway.
+ * `doc-preview` renders the document over the isolated `orca-preview` scheme.
+ * Local files use it too: a normal `file:` page receives broader filesystem and
+ * network access than a previewed workspace document should have.
  */
 export type WorkspaceFilePreviewPlan =
-  | { status: 'browser-tab'; url: string; title: string }
   | { status: 'doc-preview' }
   | { status: 'unsupported'; message: string; reason: 'no-channel' | 'outside-worktree' }
 
@@ -82,11 +79,7 @@ export function getWorkspaceFilePreviewPlan(
   if (availability.state !== 'enabled') {
     return { status: 'unsupported', message: availability.reason, reason: 'no-channel' }
   }
-  return {
-    status: 'browser-tab',
-    url: absolutePathToFileUri(filePath),
-    title: basename(filePath) || filePath
-  }
+  return { status: 'doc-preview' }
 }
 
 export function canShowWorkspaceFileBrowserAction(
@@ -194,8 +187,8 @@ function openDocPreviewTab(
     // Why explicitly client-local: the document is read through a grant this desktop mints, so the
     // page never belongs to a remote runtime even when the worktree does.
     browserRuntimeEnvironmentId: null,
-    // Why the caller decides: opening a file is a request to look at it, while a preview opened to
-    // the side belongs beside the source the reader is still working in.
+    // Why the caller decides: direct opens activate, while side previews preserve their existing
+    // local or remote focus behavior.
     activate: params.activate
   })
 }
@@ -209,15 +202,7 @@ export function openFileInBrowserTab(params: {
   if (plan.status === 'unsupported') {
     return plan
   }
-  if (plan.status === 'doc-preview') {
-    openDocPreviewTab(state, { ...params, activate: true })
-    return plan
-  }
-
-  state.createBrowserTab(params.worktreeId, plan.url, {
-    title: plan.title,
-    activate: true
-  })
+  openDocPreviewTab(state, { ...params, activate: true })
   return plan
 }
 
@@ -339,31 +324,25 @@ export function openFilePreviewToSide(params: {
 
   const layout = state.layoutByWorktree[worktreeId] ?? null
   const existingSibling = layout ? findSiblingGroupId(layout, sourceGroupId) : null
+  const runtimeEnvironmentId = getRuntimeEnvironmentIdForWorktree(state, worktreeId)
 
   // Why the unfocused split on a paired workspace: the preview opens in the background, and a host
   // snapshot reads an activated empty group as a terminal pane.
   const targetGroupId =
     existingSibling ??
-    (getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    (runtimeEnvironmentId
       ? state.createEmptySplitGroup(worktreeId, sourceGroupId, 'right', { activate: false })
       : state.createEmptySplitGroup(worktreeId, sourceGroupId, 'right'))
   if (!targetGroupId) {
     return
   }
 
-  if (plan.status === 'doc-preview') {
-    openDocPreviewTab(state, {
-      filePath: params.filePath,
-      worktreeId,
-      targetGroupId,
-      activate: false
-    })
-    return
-  }
-
-  state.createBrowserTab(worktreeId, plan.url, {
-    title: plan.title,
+  openDocPreviewTab(state, {
+    filePath: params.filePath,
+    worktreeId,
     targetGroupId,
-    activate: true
+    activate:
+      getConnectionIdForFileFromState(state, worktreeId, params.filePath) === null &&
+      !runtimeEnvironmentId
   })
 }

--- a/src/renderer/src/lib/workspace-doc-address-input.test.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.test.ts
@@ -5,7 +5,6 @@ import type { AppState } from '@/store/types'
 const plan = vi.hoisted(() => ({
   result: { status: 'doc-preview' } as
     | { status: 'doc-preview' }
-    | { status: 'browser-tab'; url: string; title: string }
     | { status: 'unsupported'; message: string; reason: 'no-channel' },
   calls: [] as { worktreeId: string; filePath: string }[]
 }))
@@ -133,12 +132,7 @@ describe('resolveWorkspaceDocAddressTarget', () => {
     expect(plan.calls).toEqual([])
   })
 
-  it('keeps a local file on the file:// pipeline and surfaces an unsupported plan as its message', () => {
-    plan.result = { status: 'browser-tab', url: 'file:///x', title: 'x' }
-    expect(
-      resolveWorkspaceDocAddressTarget(makeState(), CURRENT, '/home/alice/wt1/x.html')
-    ).toEqual({ status: 'not-a-workspace-doc' })
-
+  it('surfaces an unsupported preview plan as its message', () => {
     plan.result = { status: 'unsupported', message: 'no channel', reason: 'no-channel' }
     expect(
       resolveWorkspaceDocAddressTarget(makeState(), CURRENT, '/home/alice/wt1/x.html')

--- a/src/renderer/src/lib/workspace-doc-address-input.ts
+++ b/src/renderer/src/lib/workspace-doc-address-input.ts
@@ -43,17 +43,13 @@ function planToTarget(
   filePath: string
 ): WorkspaceDocAddressTarget {
   const plan = getWorkspaceFilePreviewPlan(state, worktreeId, filePath)
-  if (plan.status === 'doc-preview') {
-    return {
-      status: 'workspace-doc',
-      docLocation: { kind: 'workspace-doc', worktreeId, filePath }
-    }
-  }
   if (plan.status === 'unsupported') {
     return { status: 'unsupported', message: plan.message }
   }
-  // A local file keeps today's file:// tab; the URL pipeline handles it.
-  return { status: 'not-a-workspace-doc' }
+  return {
+    status: 'workspace-doc',
+    docLocation: { kind: 'workspace-doc', worktreeId, filePath }
+  }
 }
 
 /**


### PR DESCRIPTION
## ELI5
Opening a local HTML file inside Orca now uses the same restricted document-preview path as remote HTML instead of loading the file directly as a normal `file:` page. The preview still opens in an Orca browser tab, but it no longer receives the broader local-file and network access of a regular local page.

## What Changed
- Route local HTML/HTM opens, side previews, workspace address input, and terminal-link fallback through `orca-preview://`.
- Add a local preview grant owner that uses the existing canonical, authorization-scoped file reader.
- Cap direct local preview reads at 10 MiB and add regression coverage for routing, grant scope, directory approval, and read limits.

## Why
Local HTML previews previously used `file:`, bypassing the document preview's scoped file grants and outbound-request policy. Reusing the existing isolated preview session closes that privilege gap while preserving the current preview UI and explicit “open with system default” behavior.

## Linked Issue
N/A — no linked issue.

## Visual Proof
N/A — no visual change; the file opens in the same browser-tab UI with an isolated backing URL and session.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below
- [x] `node config/scripts/run-typecheck-projects-in-parallel.mjs` — passed
- [x] Relevant preview, grant, terminal-routing, and address-input tests — 8 files / 120 tests passed
- [x]`pnpm build` — passed
- [x] Changed-code quality check against `upstream/main` — passed with 0 findings
- [x] Full `pnpm lint` is currently blocked by an unchanged `upstream/main` runtime-localization catalog mismatch; CI will cover the full lint and test suites.
- [x] Local checks ran on macOS arm64. Linux and Windows were not run locally; SSH/runtime routing is covered by the targeted tests.

## AI Disclosure
Codex (GPT-5.6 Sol, Max reasoning effort) was used for implementation, tests, and final-diff review.

## Review
- **Security:** Local HTML now uses the non-persistent preview partition, its outbound-request policy, and grant-scoped canonical file reads. The local read is bounded at 10 MiB. Explicit OS-default opening remains unchanged.
- **Cross-platform:** No platform-specific branch was added; the change reuses the existing cross-platform path and grant helpers. Linux/Windows remain for CI coverage.
- **Remote SSH/local:** Local previews join the existing document-preview route. SSH and runtime ownership remain distinct, and the relevant routing tests pass.
- **Mobile, agents, integrations, and git providers:** Not affected.
- **Performance:** Preview reads remain bounded and no persistent browser session is introduced.
- **UI/backwards compatibility:** No visual change. Existing open, side-preview, address-input, and terminal-link entry points remain supported.

## Agent skill upstream boundary
- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes
The scope is intentionally limited to local HTML opened inside Orca's preview surface.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
