### PR TITLE
fix(cloud): retry the committed-winner collision codes in relay schema startup

### DIFF
--- a/cloud/.gitleaks.toml
+++ b/cloud/.gitleaks.toml
@@ -13,3 +13,10 @@ description = "Cloud SQL rollout lease holder keys in the action's unit tests"
 regexTarget = "secret"
 paths = ['''\.github/actions/cloud-sql-rollout-lease/[a-z-]+\.test\.mjs$''']
 regexes = ['''^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/[0-9]+$''']
+
+# RFC 6455 §1.3 example handshake nonce ("the sample nonce" in base64), sent by the raw-socket
+# upgrade tests; the generic key rule reads any base64 header value as a secret.
+[[allowlists]]
+description = "RFC 6455 example Sec-WebSocket-Key in upgrade tests"
+regexTarget = "secret"
+regexes = ['''^dGhlIHNhbXBsZSBub25jZQ==$''']

--- a/cloud/apps/relay/src/database-postgres-timeout.test.ts
+++ b/cloud/apps/relay/src/database-postgres-timeout.test.ts
@@ -119,6 +119,39 @@ describe('PostgreSQL schema startup', () => {
   })
 
   it.each([
+    ['42710', 'CREATE TABLE IF NOT EXISTS test'],
+    ['42P07', 'CREATE TABLE IF NOT EXISTS test'],
+    ['42P07', 'CREATE INDEX IF NOT EXISTS test_index ON test(id)'],
+    ['42P07', 'CREATE UNIQUE INDEX IF NOT EXISTS test_index ON test(id)']
+  ])('retries the committed-winner %s collision for %s', async (code, statement) => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const collision = Object.assign(new Error('already exists'), { code })
+    const query = vi
+      .fn<(statement: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(collision)
+      .mockResolvedValue(undefined)
+
+    await applyPostgresSchema([statement], query, { wait: async () => undefined })
+
+    expect(query).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    ['42710', 'CREATE INDEX IF NOT EXISTS test_index ON test(id)'],
+    ['42710', 'CREATE TABLE test'],
+    ['42P07', 'CREATE TABLE test'],
+    ['42P07', 'CREATE INDEX test_index ON test(id)']
+  ])('does not retry %s for %s', async (code, statement) => {
+    const error = Object.assign(new Error('already exists'), { code })
+    const query = vi.fn<(statement: string) => Promise<unknown>>().mockRejectedValue(error)
+    const pause = vi.fn(async () => undefined)
+
+    await expect(applyPostgresSchema([statement], query, { wait: pause })).rejects.toBe(error)
+
+    expect(pause).not.toHaveBeenCalled()
+  })
+
+  it.each([
     ['pg_type_typname_nsp_index', 'CREATE TABLE test'],
     ['pg_class_relname_nsp_index', 'CREATE INDEX test_index ON test(id)']
   ])('does not retry %s for non-idempotent DDL', async (constraint, statement) => {

--- a/cloud/apps/relay/src/postgres-schema-concurrency-postgres.test.ts
+++ b/cloud/apps/relay/src/postgres-schema-concurrency-postgres.test.ts
@@ -34,22 +34,28 @@ describePostgres('PostgreSQL schema concurrency', () => {
   })
 
   it('opens five directors when one new table is absent', async () => {
-    const initial = await openRelayDatabase({ databaseUrl: scopedUrl, dataDir: '' })
-    await initial.query(`DROP TABLE relay_cell_legacy_fence_adoptions`)
-    await initial.close()
+    // Which catalog step the race loser fails on depends on scheduling, so run several rounds and
+    // keep the loser's SQLSTATE in the failure instead of a bare boolean.
+    for (let round = 0; round < 10; round += 1) {
+      const initial = await openRelayDatabase({ databaseUrl: scopedUrl, dataDir: '' })
+      await initial.query(`DROP TABLE relay_cell_legacy_fence_adoptions`)
+      await initial.close()
 
-    const results = await Promise.allSettled(
-      Array.from({ length: 5 }, async (): Promise<RelayDatabase> =>
-        await openRelayDatabase({ databaseUrl: scopedUrl, dataDir: '' })
+      const results = await Promise.allSettled(
+        Array.from({ length: 5 }, async (): Promise<RelayDatabase> =>
+          await openRelayDatabase({ databaseUrl: scopedUrl, dataDir: '' })
+        )
       )
-    )
-    const databases = results.flatMap((result) =>
-      result.status === 'fulfilled' ? [result.value] : []
-    )
-    try {
-      expect(results.every((result) => result.status === 'fulfilled')).toBe(true)
-    } finally {
+      const databases = results.flatMap((result) =>
+        result.status === 'fulfilled' ? [result.value] : []
+      )
       await Promise.all(databases.map(async (database) => await database.close()))
+      const rejections = results.flatMap((result) =>
+        result.status === 'rejected'
+          ? [{ round, code: (result.reason as { code?: unknown }).code, message: String(result.reason) }]
+          : []
+      )
+      expect(rejections).toEqual([])
     }
-  })
+  }, 60_000)
 })

--- a/cloud/apps/relay/src/postgres-schema-startup.ts
+++ b/cloud/apps/relay/src/postgres-schema-startup.ts
@@ -22,15 +22,37 @@ function wait(delayMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs))
 }
 
+const CREATE_TABLE_IF_NOT_EXISTS = /^\s*CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\b/i
+const CREATE_INDEX_IF_NOT_EXISTS = /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+IF\s+NOT\s+EXISTS\b/i
+
+// `IF NOT EXISTS` only checks the name before the catalog inserts, so the loser of a concurrent
+// CREATE can fail on the catalog unique index (23505) or, when the winner has already committed by
+// the time the loser reaches TypeCreate/heap_create_with_catalog, on the name check those routines
+// repeat (42710 duplicate type, 42P07 duplicate relation). Each is a no-op on the next attempt.
+function concurrentCreateCollision(
+  value: { code?: unknown; constraint?: unknown },
+  statement: string
+): boolean {
+  if (CREATE_TABLE_IF_NOT_EXISTS.test(statement)) {
+    return (
+      (value.code === '23505' && value.constraint === 'pg_type_typname_nsp_index') ||
+      value.code === '42710' ||
+      value.code === '42P07'
+    )
+  }
+  if (CREATE_INDEX_IF_NOT_EXISTS.test(statement)) {
+    return (
+      (value.code === '23505' && value.constraint === 'pg_class_relname_nsp_index') ||
+      value.code === '42P07'
+    )
+  }
+  return false
+}
+
 function retryableSchemaError(error: unknown, statement: string): boolean {
   const value = error as { code?: unknown; constraint?: unknown }
   return (
-    RETRYABLE_SCHEMA_CODES.has(String(value.code)) ||
-    (value.code === '23505' &&
-      ((value.constraint === 'pg_type_typname_nsp_index' &&
-        /^\s*CREATE\s+TABLE\s+IF\s+NOT\s+EXISTS\b/i.test(statement)) ||
-        (value.constraint === 'pg_class_relname_nsp_index' &&
-          /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+IF\s+NOT\s+EXISTS\b/i.test(statement))))
+    RETRYABLE_SCHEMA_CODES.has(String(value.code)) || concurrentCreateCollision(value, statement)
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## Why

`postgres-schema-concurrency-postgres.test.ts` is red on `main` (since #18537's run) and on every relay PR (#18547 twice). It is not a flake.

`CREATE TABLE IF NOT EXISTS` only checks the name before the catalog inserts. The loser of a concurrent CREATE therefore fails in one of two ways depending on timing:

- on the catalog unique index: `23505` on `pg_type_typname_nsp_index` (already retried), or
- when the winner has committed by the time the loser reaches `TypeCreate` / `heap_create_with_catalog`, on the repeated name check: `42710` (duplicate type) / `42P07` (duplicate relation).

The startup retry predicate treated the second shape as fatal, so a director could fail startup on a table it was about to find present. A throwaway diagnostic run in CI (#18552, closed) reported exactly those two codes as the only rejection reasons.

## What

- `postgres-schema-startup.ts`: `42710`/`42P07` retryable for `CREATE TABLE IF NOT EXISTS`, `42P07` for `CREATE [UNIQUE] INDEX IF NOT EXISTS`. Every other statement shape still fails fast.
- `database-postgres-timeout.test.ts`: retry / no-retry cases for each new code × statement shape.
- `postgres-schema-concurrency-postgres.test.ts`: ten rounds, and the failure now carries the loser's SQLSTATE instead of `expected false to be true`.

## Verified

- Local Postgres 16 on 127.0.0.1:55440 pinned to 0.2 CPU to make the race lose: unfixed predicate fails (`42P07`), fixed predicate passes 18/18 runs.
- `tsc` clean for `apps/relay`.

Production impact: startup only; a director that lost this race would have crashed and been restarted by Cloud Run / the MIG. No wire or data change.

## Also carried

`cloud/.gitleaks.toml`: the RFC 6455 example `Sec-WebSocket-Key` allowlist from #18547. Cloud Verify's Secret scan runs gitleaks over `--all` refs, so #18547's test nonce fails every cloud PR's scan until the allowlist is on `main`. Landing it here first; #18547 rebases onto it.