### PR TITLE
feat(rate-limits): add hardened Z.AI Coding Plan usage

### DIFF
--- a/docs/site/content/docs/agents/usage-tracking.mdx
+++ b/docs/site/content/docs/agents/usage-tracking.mdx
@@ -2,7 +2,7 @@
 title: Usage & rate-limit tracking
 ---
 
-Orca reads local usage state for Claude Code, Codex, Gemini, OpenCode, Kimi Code, and MiniMax and surfaces it in the status bar, so you know how close you are to a rate limit before an agent stalls.
+Orca reads local usage state for Claude Code, Codex, Gemini, OpenCode, Kimi Code, MiniMax, Grok, and the Z.AI Coding Plan and surfaces it in the status bar, so you know how close you are to a rate limit before an agent stalls.
 
 ## What's shown
 
@@ -12,7 +12,11 @@ Orca reads local usage state for Claude Code, Codex, Gemini, OpenCode, Kimi Code
 
 ## How it works
 
-Orca reads the local usage state each agent maintains on disk (under `~/.claude`, `~/.codex`, and the Gemini/OpenCode equivalents). No API calls, no extra auth. This means the readout is only as fresh as the agent's own bookkeeping — numbers update when the agent writes, not in real time.
+For most providers, Orca reads usage state that the agent maintains locally (under `~/.claude`, `~/.codex`, and provider equivalents). Those readouts update when the agent writes its bookkeeping.
+
+For **Z.AI Coding Plan**, Orca reads only the explicit `zai-coding-plan` API-key record that OpenCode stores on the execution host. Set it up with `opencode auth login`, choose **Z.AI Coding Plan**, and enter your plan key. Orca never rewrites that credential or publishes it to the UI. It sends one read-only quota request to Z.AI's monitor endpoint at the configured global (`api.z.ai`) or China (`open.bigmodel.cn`) origin; it does not call a model or billing endpoint and does not try the other region. The 5-hour and weekly limits are shared by every supported tool using the same GLM Coding Plan.
+
+Z.AI's official usage plugin uses this monitor endpoint, but it is not a documented stable public API. If Z.AI rejects the key or the quota is unavailable, repeat the OpenCode login flow and confirm that the account has a Coding Plan. Orca treats missing or unfamiliar quota data as unknown rather than showing 0%.
 
 ## Multi-account accounting
 

--- a/mobile/src/components/accounts-snapshot.ts
+++ b/mobile/src/components/accounts-snapshot.ts
@@ -39,7 +39,8 @@ export const ProviderRateLimitsSchema = z
       'kimi',
       'minimax',
       'grok',
-      'antigravity'
+      'antigravity',
+      'zai'
     ]),
     session: RateLimitWindowSchema.nullable(),
     weekly: RateLimitWindowSchema.nullable(),

--- a/src/main/opencode/opencode-auth-store.test.ts
+++ b/src/main/opencode/opencode-auth-store.test.ts
@@ -1,0 +1,159 @@
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsState = vi.hoisted<{ files: Map<string, string | Error> }>(() => ({
+  files: new Map()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => {
+    const entry = fsState.files.get(String(path))
+    if (entry === undefined) {
+      const error = new Error(
+        `ENOENT: no such file or directory, open ${path}`
+      ) as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    }
+    if (entry instanceof Error) {
+      throw entry
+    }
+    return entry
+  }
+}))
+
+vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
+
+import {
+  getOpenCodeApiKeyRecord,
+  getOpenCodeAuthJsonCandidates,
+  readOpenCodeAuthJson
+} from './opencode-auth-store'
+
+// Built with `join` so expectations match the separator emitted on this platform.
+function expectedPath(...segments: string[]): string {
+  return join(...segments)
+}
+
+describe('getOpenCodeAuthJsonCandidates', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('lists APPDATA, XDG, Linux default, macOS default in precedence order', () => {
+    const candidates = getOpenCodeAuthJsonCandidates(
+      { APPDATA: 'C:\\Users\\u\\AppData\\Roaming', XDG_DATA_HOME: '/xdg' },
+      '/home/test'
+    )
+    expect(candidates).toEqual([
+      expectedPath('C:\\Users\\u\\AppData\\Roaming', 'opencode', 'auth.json'),
+      expectedPath('/xdg', 'opencode', 'auth.json'),
+      expectedPath('/home/test', '.local', 'share', 'opencode', 'auth.json'),
+      expectedPath('/home/test', 'Library', 'Application Support', 'opencode', 'auth.json')
+    ])
+  })
+
+  it('skips unset environment variables', () => {
+    const candidates = getOpenCodeAuthJsonCandidates({}, '/home/test')
+    expect(candidates).toEqual([
+      expectedPath('/home/test', '.local', 'share', 'opencode', 'auth.json'),
+      expectedPath('/home/test', 'Library', 'Application Support', 'opencode', 'auth.json')
+    ])
+  })
+
+  it('dedupes candidates that resolve to the same path, keeping the first', () => {
+    const candidates = getOpenCodeAuthJsonCandidates(
+      { APPDATA: '/shared', XDG_DATA_HOME: '/shared' },
+      '/home/test'
+    )
+    expect(candidates).toEqual([
+      expectedPath('/shared', 'opencode', 'auth.json'),
+      expectedPath('/home/test', '.local', 'share', 'opencode', 'auth.json'),
+      expectedPath('/home/test', 'Library', 'Application Support', 'opencode', 'auth.json')
+    ])
+  })
+})
+
+describe('readOpenCodeAuthJson', () => {
+  beforeEach(() => {
+    fsState.files.clear()
+  })
+
+  it('prefers the first readable candidate', async () => {
+    fsState.files.set(
+      expectedPath('/appdata', 'opencode', 'auth.json'),
+      JSON.stringify({ source: 'appdata' })
+    )
+    fsState.files.set(
+      expectedPath('/home/test', '.local', 'share', 'opencode', 'auth.json'),
+      JSON.stringify({ source: 'linux-default' })
+    )
+    const result = await readOpenCodeAuthJson({ APPDATA: '/appdata' }, '/home/test')
+    expect(result).toEqual({ status: 'ok', auth: { source: 'appdata' } })
+  })
+
+  it('returns missing when no candidate exists', async () => {
+    const result = await readOpenCodeAuthJson({}, '/home/test')
+    expect(result).toEqual({ status: 'missing' })
+  })
+
+  it('continues past ENOTDIR to the next candidate', async () => {
+    const notDir = new Error('ENOTDIR: not a directory') as NodeJS.ErrnoException
+    notDir.code = 'ENOTDIR'
+    fsState.files.set(expectedPath('/appdata', 'opencode', 'auth.json'), notDir)
+    fsState.files.set(
+      expectedPath('/home/test', '.local', 'share', 'opencode', 'auth.json'),
+      JSON.stringify({ source: 'linux-default' })
+    )
+    const result = await readOpenCodeAuthJson({ APPDATA: '/appdata' }, '/home/test')
+    expect(result).toEqual({ status: 'ok', auth: { source: 'linux-default' } })
+  })
+
+  it('reports a sanitized error without the path for unreadable files', async () => {
+    const accessError = new Error('EACCES: permission denied') as NodeJS.ErrnoException
+    accessError.code = 'EACCES'
+    fsState.files.set(expectedPath('/appdata', 'opencode', 'auth.json'), accessError)
+    const result = await readOpenCodeAuthJson({ APPDATA: '/appdata' }, '/home/test')
+    expect(result).toEqual({ status: 'error', error: 'Failed to read OpenCode auth.json (EACCES)' })
+  })
+
+  it('reports invalid JSON without echoing file contents', async () => {
+    fsState.files.set(
+      expectedPath('/appdata', 'opencode', 'auth.json'),
+      '{"secret-key-value": trun'
+    )
+    const result = await readOpenCodeAuthJson({ APPDATA: '/appdata' }, '/home/test')
+    expect(result).toEqual({ status: 'error', error: 'OpenCode auth.json is not valid JSON' })
+  })
+
+  it('rejects non-object JSON documents', async () => {
+    fsState.files.set(expectedPath('/appdata', 'opencode', 'auth.json'), '["not-a-record"]')
+    const result = await readOpenCodeAuthJson({ APPDATA: '/appdata' }, '/home/test')
+    expect(result).toEqual({ status: 'error', error: 'OpenCode auth.json is invalid' })
+  })
+})
+
+describe('getOpenCodeApiKeyRecord', () => {
+  it('accepts an explicit api record with a nonempty key', () => {
+    expect(
+      getOpenCodeApiKeyRecord(
+        { 'zai-coding-plan': { type: 'api', key: ' key-1 ' } },
+        'zai-coding-plan'
+      )
+    ).toEqual({ type: 'api', key: ' key-1 ' })
+  })
+
+  it('rejects other auth entry shapes', () => {
+    const auth = {
+      wellknown: { type: 'wellknown', key: 'k' },
+      empty: { type: 'api', key: '   ' },
+      missingKey: { type: 'api' },
+      nonStringKey: { type: 'api', key: 42 },
+      arrayEntry: ['api'],
+      nullEntry: null
+    }
+    for (const [providerId] of Object.entries(auth)) {
+      expect(getOpenCodeApiKeyRecord(auth, providerId)).toBeNull()
+    }
+  })
+})

--- a/src/main/opencode/opencode-auth-store.ts
+++ b/src/main/opencode/opencode-auth-store.ts
@@ -1,0 +1,105 @@
+import { readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+export type OpenCodeAuthRecord = Record<string, unknown>
+
+/** One provider credential: `"<provider-id>": { "type": "api", "key": "..." }`. */
+export type OpenCodeApiKeyRecord = { type: 'api'; key: string }
+
+export type OpenCodeAuthReadResult =
+  | { status: 'missing' }
+  | { status: 'error'; error: string }
+  | { status: 'ok'; auth: OpenCodeAuthRecord }
+
+/**
+ * auth.json locations in OpenCode's own search order: Windows APPDATA, then
+ * XDG_DATA_HOME, then the Linux and macOS defaults. Duplicates of an earlier
+ * path (e.g. XDG_DATA_HOME pointing at ~/.local/share) are dropped so the
+ * first occurrence always wins.
+ */
+export function getOpenCodeAuthJsonCandidates(
+  environment: NodeJS.ProcessEnv = process.env,
+  homeDirectory = homedir()
+): string[] {
+  const candidates = [
+    environment.APPDATA ? join(environment.APPDATA, 'opencode', 'auth.json') : null,
+    environment.XDG_DATA_HOME ? join(environment.XDG_DATA_HOME, 'opencode', 'auth.json') : null,
+    join(homeDirectory, '.local', 'share', 'opencode', 'auth.json'),
+    join(homeDirectory, 'Library', 'Application Support', 'opencode', 'auth.json')
+  ].filter((candidate): candidate is string => candidate !== null)
+  const seen = new Set<string>()
+  const unique: string[] = []
+  for (const candidate of candidates) {
+    const key = resolve(candidate)
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    unique.push(candidate)
+  }
+  return unique
+}
+
+function isMissingPathError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}
+
+// Why: never echo file contents or raw OS messages into user-visible errors;
+// a partially-written auth.json can carry credential fragments.
+function describeReadError(error: unknown): string {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code ? `Failed to read OpenCode auth.json (${code})` : 'Failed to read OpenCode auth.json'
+}
+
+/**
+ * Read-only read of the first existing OpenCode auth.json. Never writes and
+ * never throws: parse or filesystem failures surface as a sanitized error.
+ */
+export async function readOpenCodeAuthJson(
+  environment: NodeJS.ProcessEnv = process.env,
+  homeDirectory = homedir()
+): Promise<OpenCodeAuthReadResult> {
+  for (const candidate of getOpenCodeAuthJsonCandidates(environment, homeDirectory)) {
+    let raw: string
+    try {
+      raw = await readFile(candidate, 'utf-8')
+    } catch (error) {
+      if (isMissingPathError(error)) {
+        continue
+      }
+      return { status: 'error', error: describeReadError(error) }
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { status: 'error', error: 'OpenCode auth.json is invalid' }
+      }
+      return { status: 'ok', auth: parsed as OpenCodeAuthRecord }
+    } catch {
+      return { status: 'error', error: 'OpenCode auth.json is not valid JSON' }
+    }
+  }
+  return { status: 'missing' }
+}
+
+/**
+ * Strict `{ type: 'api', key }` record lookup. The key must be nonempty after
+ * trimming and the type must match exactly — anything else reads as "not
+ * configured" instead of feeding a partial record downstream.
+ */
+export function getOpenCodeApiKeyRecord(
+  auth: OpenCodeAuthRecord,
+  providerId: string
+): OpenCodeApiKeyRecord | null {
+  const entry: unknown = auth[providerId]
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+    return null
+  }
+  const record = entry as Record<string, unknown>
+  if (record.type !== 'api' || typeof record.key !== 'string' || record.key.trim().length === 0) {
+    return null
+  }
+  return { type: 'api', key: record.key }
+}

--- a/src/main/rate-limits/gemini-oauth-sources.ts
+++ b/src/main/rate-limits/gemini-oauth-sources.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, rename } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net } from 'electron'
+import { readOpenCodeAuthJson } from '../opencode/opencode-auth-store'
 import { extractOAuthClientCredentials } from './gemini-cli-oauth-extractor'
 
 const API_TIMEOUT_MS = 10_000
@@ -28,27 +29,15 @@ type AuthJson = {
 }
 
 export async function readAuthJson(): Promise<AuthJson | null> {
-  const candidates = [
-    process.env.APPDATA ? path.join(process.env.APPDATA, 'opencode', 'auth.json') : null,
-    process.env.XDG_DATA_HOME
-      ? path.join(process.env.XDG_DATA_HOME, 'opencode', 'auth.json')
-      : null,
-    path.join(homedir(), '.local', 'share', 'opencode', 'auth.json'),
-    path.join(homedir(), 'Library', 'Application Support', 'opencode', 'auth.json')
-  ].filter((candidate): candidate is string => candidate !== null)
-
-  for (const candidate of candidates) {
-    try {
-      const raw = await readFile(candidate, 'utf-8')
-      return JSON.parse(raw) as AuthJson
-    } catch (err) {
-      if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
-        continue
-      }
-      throw err
-    }
+  // Why: candidate discovery/parse policy is shared with the Z.AI Coding Plan
+  // reader; this wrapper preserves the historical throw-on-error contract.
+  const result = await readOpenCodeAuthJson()
+  if (result.status === 'ok') {
+    return result.auth as AuthJson
   }
-
+  if (result.status === 'error') {
+    throw new Error(result.error)
+  }
   return null
 }
 

--- a/src/main/rate-limits/rate-limit-service-test-harness.ts
+++ b/src/main/rate-limits/rate-limit-service-test-harness.ts
@@ -9,6 +9,7 @@ import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
+import { fetchZaiRateLimits } from './zai-fetcher'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 
 export type Deferred<T> = {
@@ -89,6 +90,7 @@ export function mockFreshBackgroundProviderFetches(): void {
   vi.mocked(fetchKimiRateLimits).mockImplementation(async () => okProvider('kimi', 0))
   vi.mocked(fetchMiniMaxRateLimits).mockImplementation(async () => okProvider('minimax', 0))
   vi.mocked(fetchGrokRateLimits).mockImplementation(async () => unavailableProvider('grok'))
+  vi.mocked(fetchZaiRateLimits).mockImplementation(async () => unavailableProvider('zai'))
 }
 
 /** Shared `beforeEach` body: healthy stubs for every provider the service polls. */
@@ -105,6 +107,15 @@ export function resetRateLimitProviderMocks(): void {
     updatedAt: Date.now(),
     error: null,
     status: 'unavailable'
+  })
+  vi.mocked(fetchZaiRateLimits).mockResolvedValue({
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error: null,
+    status: 'unavailable',
+    usageMetadata: { failureKind: 'missing-credentials' }
   })
   vi.mocked(hasMiniMaxSessionCookie).mockReturnValue(false)
   vi.mocked(readGrokAuthSession).mockReturnValue({ status: 'missing' })

--- a/src/main/rate-limits/service-account-target-selection.test.ts
+++ b/src/main/rate-limits/service-account-target-selection.test.ts
@@ -40,6 +40,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-antigravity-usage.test.ts
+++ b/src/main/rate-limits/service-antigravity-usage.test.ts
@@ -39,6 +39,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-inactive-account-previews.test.ts
+++ b/src/main/rate-limits/service-inactive-account-previews.test.ts
@@ -47,6 +47,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-live-claude-usage.test.ts
+++ b/src/main/rate-limits/service-live-claude-usage.test.ts
@@ -44,6 +44,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-minimax-usage.test.ts
+++ b/src/main/rate-limits/service-minimax-usage.test.ts
@@ -41,6 +41,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -48,6 +48,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-window-activation.test.ts
+++ b/src/main/rate-limits/service-window-activation.test.ts
@@ -49,6 +49,10 @@ vi.mock('./grok-fetcher', () => ({
   fetchGrokRateLimits: vi.fn()
 }))
 
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
 vi.mock('./grok-auth', () => ({
   readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
 }))

--- a/src/main/rate-limits/service-zai-usage.test.ts
+++ b/src/main/rate-limits/service-zai-usage.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RateLimitService } from './service'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { fetchZaiRateLimits } from './zai-fetcher'
+import {
+  errorProvider,
+  okProvider,
+  resetRateLimitProviderMocks,
+  unavailableProvider
+} from './rate-limit-service-test-harness'
+
+vi.mock('./claude-fetcher', () => ({
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
+}))
+
+vi.mock('./codex-fetcher', () => ({
+  consumeCodexRateLimitResetCredit: vi.fn(),
+  fetchCodexRateLimits: vi.fn()
+}))
+
+vi.mock('./gemini-usage-fetcher', () => ({
+  fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./kimi-fetcher', () => ({
+  fetchKimiRateLimits: vi.fn()
+}))
+
+vi.mock('./opencode-go-usage-fetcher', () => ({
+  fetchOpenCodeGoRateLimits: vi.fn()
+}))
+
+vi.mock('./minimax-fetcher', () => ({
+  fetchMiniMaxRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-fetcher', () => ({
+  fetchGrokRateLimits: vi.fn()
+}))
+
+vi.mock('./zai-fetcher', () => ({
+  fetchZaiRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-auth', () => ({
+  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+}))
+
+vi.mock('../minimax/minimax-cookie-store', () => ({
+  hasMiniMaxSessionCookie: vi.fn(() => false)
+}))
+
+function zaiOk(usedPercent: number, updatedAt = Date.now()) {
+  return { ...okProvider('zai', usedPercent, updatedAt), usageMetadata: { source: 'web' as const } }
+}
+
+function zaiMissingCredentials() {
+  return {
+    ...unavailableProvider('zai'),
+    usageMetadata: { failureKind: 'missing-credentials' as const }
+  }
+}
+
+describe('RateLimitService Z.AI usage', () => {
+  beforeEach(() => {
+    resetRateLimitProviderMocks()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
+  })
+
+  it('fetches Z.AI concurrently with the other providers and passes the cycle signal', async () => {
+    const service = new RateLimitService()
+    vi.mocked(fetchZaiRateLimits).mockResolvedValue(zaiOk(42))
+
+    const state = await service.refresh()
+
+    expect(fetchZaiRateLimits).toHaveBeenCalledTimes(1)
+    const [options] = vi.mocked(fetchZaiRateLimits).mock.calls[0]
+    expect(options?.signal).toBeInstanceOf(AbortSignal)
+    expect(state.zai).toMatchObject({ provider: 'zai', status: 'ok' })
+    expect(state.zai?.session?.usedPercent).toBe(42)
+    // Why: a settled quota answer implies the fetcher's own auth read found a key.
+    expect(state.zaiAuthConfigured).toBe(true)
+  })
+
+  it('reports zaiAuthConfigured false when the settled result lacks credentials', async () => {
+    const service = new RateLimitService()
+    vi.mocked(fetchZaiRateLimits).mockResolvedValue(zaiMissingCredentials())
+
+    const state = await service.refresh()
+
+    expect(state.zai).toMatchObject({ provider: 'zai', status: 'unavailable' })
+    expect(state.zaiAuthConfigured).toBe(false)
+  })
+
+  it('keeps zaiAuthConfigured true through a transient error so the bar does not drop', async () => {
+    const service = new RateLimitService()
+    vi.mocked(fetchZaiRateLimits).mockResolvedValueOnce(zaiOk(10))
+    await service.refresh()
+
+    vi.mocked(fetchZaiRateLimits).mockResolvedValue(errorProvider('zai', 'network down'))
+    const state = await service.refresh()
+
+    expect(state.zaiAuthConfigured).toBe(true)
+    expect(state.zai?.status).toBe('error')
+  })
+
+  it('keeps a recent snapshot through a failed cycle instead of flapping to empty', async () => {
+    const service = new RateLimitService()
+    vi.mocked(fetchZaiRateLimits).mockResolvedValue(zaiOk(33))
+    await service.refresh()
+
+    vi.mocked(fetchZaiRateLimits).mockResolvedValue(errorProvider('zai', 'usage unavailable'))
+    const state = await service.refresh()
+
+    expect(state.zai).toMatchObject({
+      provider: 'zai',
+      status: 'error',
+      session: { usedPercent: 33 }
+    })
+  })
+
+  it('drops a stale snapshot once it ages past the stale threshold', async () => {
+    vi.useFakeTimers()
+    try {
+      const service = new RateLimitService()
+      vi.mocked(fetchZaiRateLimits).mockResolvedValue(zaiOk(33))
+      await service.refresh()
+
+      vi.advanceTimersByTime(31 * 60 * 1000)
+      vi.mocked(fetchZaiRateLimits).mockResolvedValue(errorProvider('zai', 'usage unavailable'))
+      const state = await service.refresh()
+
+      expect(state.zai).toMatchObject({ provider: 'zai', status: 'error', session: null })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('settles a rejected fetch as a zai error result instead of crashing the cycle', async () => {
+    const service = new RateLimitService()
+    vi.mocked(fetchZaiRateLimits).mockRejectedValueOnce(new Error('socket hang up'))
+
+    const state = await service.refresh()
+
+    expect(state.zai).toMatchObject({
+      provider: 'zai',
+      status: 'error',
+      error: 'Z.ai usage request failed unexpectedly'
+    })
+    expect(state.zai?.error).not.toContain('socket hang up')
+    // Why: only an explicit missing-credentials answer may flip the durable flag off.
+    expect(state.zaiAuthConfigured).toBe(true)
+  })
+})

--- a/src/main/rate-limits/service/service-configuration.ts
+++ b/src/main/rate-limits/service/service-configuration.ts
@@ -124,6 +124,7 @@ export abstract class RateLimitServiceConfiguration extends RateLimitServiceAcco
       // Why: the cookie lives on the filesystem, not GlobalSettings; surface its presence so the renderer keeps the MiniMax bar across reloads.
       minimaxCookieConfigured: hasMiniMaxSessionCookie(),
       grokAuthConfigured: this.grokAuthConfigured,
+      zaiAuthConfigured: this.zaiAuthConfigured,
       claudeTarget: this.claudeFetchTarget,
       codexTarget: this.codexFetchTarget,
       inactiveClaudeAccounts: this.buildInactiveArray(

--- a/src/main/rate-limits/service/service-full-cycle-application.ts
+++ b/src/main/rate-limits/service/service-full-cycle-application.ts
@@ -1,5 +1,6 @@
 import { RateLimitServiceFullCyclePreparation } from './service-full-cycle-preparation'
 import { deriveAntigravityRateLimits } from '../antigravity-usage-mirror'
+import { deriveZaiAuthConfigured } from '../zai-auth-configured'
 import type { ProviderRateLimits } from './service-types'
 
 export abstract class RateLimitServiceFullCycleApplication extends RateLimitServiceFullCyclePreparation {
@@ -32,7 +33,8 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
         geminiResult,
         opencodeGoResult,
         kimiResult,
-        miniMaxResult
+        miniMaxResult,
+        zaiResult
       ],
       grokResultPromise
     } = prepared
@@ -125,6 +127,18 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
             status: 'error'
           } satisfies ProviderRateLimits)
 
+    const zai =
+      zaiResult.status === 'fulfilled'
+        ? zaiResult.value
+        : ({
+            provider: 'zai',
+            session: null,
+            weekly: null,
+            updatedAt: Date.now(),
+            error: 'Z.ai usage request failed unexpectedly',
+            status: 'error'
+          } satisfies ProviderRateLimits)
+
     const latestCodexHome = this.resolveCodexHome(codexTarget)
     const latestClaudeAuthPreparation = await this.claudeAuthPreparationResolver?.(claudeTarget)
     if (signal.aborted) {
@@ -164,6 +178,9 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
     if (shouldApplyMiniMax) {
       this.trackActiveFailureStreak('minimax', miniMax)
     }
+    this.trackActiveFailureStreak('zai', zai)
+    // Why: the fetcher owns the auth read, so the durable flag derives from its settled result — no duplicate auth probe.
+    this.zaiAuthConfigured = deriveZaiAuthConfigured(zai)
 
     // Why: apply a Codex result only when provenance and generation still match, else a raced in-flight fetch overwrites the new account.
     this.updateState({
@@ -188,7 +205,8 @@ export abstract class RateLimitServiceFullCycleApplication extends RateLimitServ
         ? miniMaxConfigChanged
           ? miniMax
           : this.applyStalePolicy(miniMax, previousState.minimax)
-        : this.state.minimax
+        : this.state.minimax,
+      zai: this.applyStalePolicy(zai, previousState.zai)
     })
 
     const grokResult = await grokResultPromise

--- a/src/main/rate-limits/service/service-full-cycle-preparation.ts
+++ b/src/main/rate-limits/service/service-full-cycle-preparation.ts
@@ -5,6 +5,7 @@ import { fetchGrokRateLimits } from '../grok-fetcher'
 import { readGrokAuthSession } from '../grok-auth'
 import { fetchMiniMaxRateLimits } from '../minimax-fetcher'
 import { fetchOpenCodeGoRateLimits } from '../opencode-go-usage-fetcher'
+import { fetchZaiRateLimits } from '../zai-fetcher'
 import { RateLimitServiceFetchPolicy } from './service-fetch-policy'
 import type {
   ClaudeRuntimeAuthPreparation,
@@ -31,6 +32,7 @@ export type FetchAllCyclePrepared = {
   miniMaxGeneration: number
   claudeFetchGated: boolean
   results: [
+    PromiseSettledResult<ProviderRateLimits>,
     PromiseSettledResult<ProviderRateLimits>,
     PromiseSettledResult<ProviderRateLimits>,
     PromiseSettledResult<ProviderRateLimits>,
@@ -119,7 +121,8 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
       minimax: miniMaxConfigChanged
         ? this.withFetchingStatus(null, 'minimax')
         : this.withFetchingStatus(previousState.minimax, 'minimax'),
-      grok: this.withFetchingStatus(previousState.grok, 'grok')
+      grok: this.withFetchingStatus(previousState.grok, 'grok'),
+      zai: this.withFetchingStatus(previousState.zai, 'zai')
     })
 
     const missingWslCodexHome =
@@ -136,40 +139,49 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
 
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
-      await Promise.allSettled([
-        claudeFetchGated
-          ? Promise.resolve(previousState.claude as ProviderRateLimits)
-          : fetchClaudeRateLimits({
-              authPreparation: claudeAuthPreparation,
-              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-              networkProxySettings: this.networkProxySettingsResolver?.(),
-              signal
-            }),
-        codexFetchGated
-          ? Promise.resolve(previousState.codex as ProviderRateLimits)
-          : (missingWslCodexHome ??
-            fetchCodexRateLimits({
-              codexHomePath,
-              allowPtyFallback: this.shouldAllowCodexPtyFallback(),
-              signal
-            })),
-        fetchGeminiRateLimits(geminiCliOAuthEnabled),
-        fetchOpenCodeGoRateLimits(
-          cookie,
-          workspaceIdOverride || undefined,
-          this.networkProxySettingsResolver?.()
-        ),
-        this.fetchKimiWithResolvedHome(),
-        miniMaxConfigResult.error
-          ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
-          : fetchMiniMaxRateLimits({
-              cookie: miniMaxCookie,
-              groupId: miniMaxGroupId,
-              models: miniMaxModels
-            })
-      ])
+    const [
+      claudeResult,
+      codexResult,
+      geminiResult,
+      opencodeGoResult,
+      kimiResult,
+      miniMaxResult,
+      zaiResult
+    ] = await Promise.allSettled([
+      claudeFetchGated
+        ? Promise.resolve(previousState.claude as ProviderRateLimits)
+        : fetchClaudeRateLimits({
+            authPreparation: claudeAuthPreparation,
+            allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+            allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
+            signal
+          }),
+      codexFetchGated
+        ? Promise.resolve(previousState.codex as ProviderRateLimits)
+        : (missingWslCodexHome ??
+          fetchCodexRateLimits({
+            codexHomePath,
+            allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            signal
+          })),
+      fetchGeminiRateLimits(geminiCliOAuthEnabled),
+      fetchOpenCodeGoRateLimits(
+        cookie,
+        workspaceIdOverride || undefined,
+        this.networkProxySettingsResolver?.()
+      ),
+      this.fetchKimiWithResolvedHome(),
+      miniMaxConfigResult.error
+        ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
+        : fetchMiniMaxRateLimits({
+            cookie: miniMaxCookie,
+            groupId: miniMaxGroupId,
+            models: miniMaxModels
+          }),
+      // Why: concurrent with the other providers; aborts with the shared cycle signal.
+      fetchZaiRateLimits({ signal })
+    ])
 
     if (signal.aborted) {
       return null
@@ -196,7 +208,8 @@ export abstract class RateLimitServiceFullCyclePreparation extends RateLimitServ
         geminiResult,
         opencodeGoResult,
         kimiResult,
-        miniMaxResult
+        miniMaxResult,
+        zaiResult
       ],
       grokResultPromise
     }

--- a/src/main/rate-limits/service/service-polling.ts
+++ b/src/main/rate-limits/service/service-polling.ts
@@ -78,7 +78,8 @@ export abstract class RateLimitServicePolling extends RateLimitServiceFetchQueue
       kimi: this.state.kimi,
       minimax: this.state.minimax,
       grok: this.state.grok,
-      antigravity: this.state.antigravity
+      antigravity: this.state.antigravity,
+      zai: this.state.zai
     }
     return Object.entries(byProvider).map(([provider, limits]) => ({
       provider: provider as ActiveRateLimitProvider,

--- a/src/main/rate-limits/service/service-result-policy.ts
+++ b/src/main/rate-limits/service/service-result-policy.ts
@@ -92,6 +92,7 @@ export abstract class RateLimitServiceResultPolicy extends RateLimitServiceFetch
       | 'minimax'
       | 'grok'
       | 'antigravity'
+      | 'zai'
   ): ProviderRateLimits {
     if (!current) {
       return {

--- a/src/main/rate-limits/service/service-state.ts
+++ b/src/main/rate-limits/service/service-state.ts
@@ -31,9 +31,12 @@ export abstract class RateLimitServiceState {
     kimi: null,
     antigravity: null,
     minimax: null,
-    grok: null
+    grok: null,
+    zai: null
   }
   protected grokAuthConfigured = readGrokAuthSession().status === 'ok'
+  // Why: derived from each settled Z.AI fetch result; no separate auth-file probe per getState().
+  protected zaiAuthConfigured = false
   protected pollInterval: number = DEFAULT_POLL_MS
   protected timer: ReturnType<typeof setInterval> | null = null
   protected deferredStartupRefreshTimer: ReturnType<typeof setTimeout> | null = null
@@ -46,7 +49,8 @@ export abstract class RateLimitServiceState {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    zai: 0
   }
   // Why: consecutive failures drive exponential backoff of the fast activation-retry lane; reset on any success/unavailable result.
   protected activeFailureStreakByProvider: Record<ActiveRateLimitProvider, number> = {
@@ -57,7 +61,8 @@ export abstract class RateLimitServiceState {
     kimi: 0,
     minimax: 0,
     grok: 0,
-    antigravity: 0
+    antigravity: 0,
+    zai: 0
   }
   protected mainWindow: BrowserWindow | null = null
   protected detachWindowListeners: (() => void) | null = null

--- a/src/main/rate-limits/service/service-types.ts
+++ b/src/main/rate-limits/service/service-types.ts
@@ -105,6 +105,7 @@ export type InternalRateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  zai: ProviderRateLimits | null
 }
 
 export function normalizePollingInterval(ms: number): number {

--- a/src/main/rate-limits/zai-auth-configured.test.ts
+++ b/src/main/rate-limits/zai-auth-configured.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { deriveZaiAuthConfigured } from './zai-auth-configured'
+import type { ProviderRateLimits } from '../../shared/rate-limit-types'
+
+function zai(overrides: Partial<ProviderRateLimits>): ProviderRateLimits {
+  return {
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok',
+    ...overrides
+  }
+}
+
+describe('deriveZaiAuthConfigured', () => {
+  it('is false before any Z.AI fetch has settled', () => {
+    expect(deriveZaiAuthConfigured(null)).toBe(false)
+  })
+
+  it('is true for a settled quota answer', () => {
+    expect(deriveZaiAuthConfigured(zai({ status: 'ok' }))).toBe(true)
+  })
+
+  it('is false for the explicit missing-credentials answer', () => {
+    expect(
+      deriveZaiAuthConfigured(
+        zai({
+          status: 'unavailable',
+          usageMetadata: { failureKind: 'missing-credentials' }
+        })
+      )
+    ).toBe(false)
+  })
+
+  it('stays true through transient errors so the bar does not drop', () => {
+    expect(deriveZaiAuthConfigured(zai({ status: 'error', error: 'network' }))).toBe(true)
+  })
+
+  it('is false for an unavailable answer without credential evidence', () => {
+    expect(deriveZaiAuthConfigured(zai({ status: 'unavailable' }))).toBe(false)
+  })
+})

--- a/src/main/rate-limits/zai-auth-configured.ts
+++ b/src/main/rate-limits/zai-auth-configured.ts
@@ -1,0 +1,18 @@
+import type { ProviderRateLimits } from '../../shared/rate-limit-types'
+
+/**
+ * Derive the durable `zaiAuthConfigured` flag from a settled Z.AI fetch result
+ * instead of re-reading opencode's auth store — the fetcher already read it,
+ * so a second probe per cycle would duplicate the auth-file read.
+ */
+export function deriveZaiAuthConfigured(limits: ProviderRateLimits | null): boolean {
+  if (!limits) {
+    return false
+  }
+  // Why: only definitive absence hides the row; auth-store read failures keep it
+  // discoverable because they do not prove the Coding Plan key is unconfigured.
+  if (limits.usageMetadata?.failureKind === 'missing-credentials') {
+    return false
+  }
+  return limits.status !== 'unavailable'
+}

--- a/src/main/rate-limits/zai-credentials.test.ts
+++ b/src/main/rate-limits/zai-credentials.test.ts
@@ -1,0 +1,154 @@
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsState = vi.hoisted<{ files: Map<string, string | Error> }>(() => ({
+  files: new Map()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => {
+    const entry = fsState.files.get(String(path))
+    if (entry === undefined) {
+      const error = new Error(
+        `ENOENT: no such file or directory, open ${path}`
+      ) as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    }
+    if (entry instanceof Error) {
+      throw entry
+    }
+    return entry
+  }
+}))
+
+vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
+
+import {
+  DEFAULT_ZAI_ORIGIN,
+  isZaiAuthConfigured,
+  readZaiCredentials,
+  resolveZaiOrigin
+} from './zai-credentials'
+
+const AUTH_PATH = join('/home/test', '.local', 'share', 'opencode', 'auth.json')
+
+function writeAuthJson(value: unknown): void {
+  fsState.files.set(AUTH_PATH, JSON.stringify(value))
+}
+
+describe('resolveZaiOrigin', () => {
+  it('defaults to api.z.ai without a record', () => {
+    expect(resolveZaiOrigin(null)).toBe(DEFAULT_ZAI_ORIGIN)
+    expect(resolveZaiOrigin({})).toBe(DEFAULT_ZAI_ORIGIN)
+  })
+
+  it('accepts the record baseURL when it is an allowed origin', () => {
+    expect(resolveZaiOrigin({ baseURL: 'https://open.bigmodel.cn/api/anthropic' })).toBe(
+      'https://open.bigmodel.cn'
+    )
+  })
+
+  it('reads nested metadata and config base URLs', () => {
+    expect(resolveZaiOrigin({ metadata: { baseURL: 'https://open.bigmodel.cn' } })).toBe(
+      'https://open.bigmodel.cn'
+    )
+    expect(resolveZaiOrigin({ config: { apiBase: 'https://api.z.ai/api/anthropic' } })).toBe(
+      DEFAULT_ZAI_ORIGIN
+    )
+  })
+
+  it('falls back to the default for disallowed or malformed URLs', () => {
+    expect(resolveZaiOrigin({ baseURL: 'https://evil.example.com/api/anthropic' })).toBe(
+      DEFAULT_ZAI_ORIGIN
+    )
+    expect(resolveZaiOrigin({ baseURL: '::::not-a-url' })).toBe(DEFAULT_ZAI_ORIGIN)
+    expect(resolveZaiOrigin({ baseURL: 42 })).toBe(DEFAULT_ZAI_ORIGIN)
+  })
+})
+
+describe('readZaiCredentials', () => {
+  beforeEach(() => {
+    fsState.files.clear()
+  })
+
+  it('is missing when no auth.json exists', async () => {
+    const result = await readZaiCredentials()
+    expect(result).toEqual({ status: 'missing' })
+  })
+
+  it('is missing when auth.json has no zai-coding-plan entry', async () => {
+    writeAuthJson({ google: { type: 'oauth', access: 'a', expires: 1, refresh: 'r' } })
+    const result = await readZaiCredentials()
+    expect(result).toEqual({ status: 'missing' })
+  })
+
+  it('ignores environment-only credentials', async () => {
+    vi.stubEnv('ZAI_API_KEY', 'wallet-key')
+    vi.stubEnv('ZAI_CODING_API_KEY', 'coding-key')
+    vi.stubEnv('ANTHROPIC_AUTH_TOKEN', 'anthropic-key')
+    try {
+      await expect(readZaiCredentials()).resolves.toEqual({ status: 'missing' })
+    } finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it('is missing for a nonempty-key record with the wrong type', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'wellknown', key: 'key-1' } })
+    const result = await readZaiCredentials()
+    expect(result).toEqual({ status: 'missing' })
+  })
+
+  it('returns the trimmed key and default origin', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: '  key-1 \n' } })
+    const result = await readZaiCredentials()
+    expect(result).toEqual({ status: 'ok', key: 'key-1', origin: DEFAULT_ZAI_ORIGIN })
+  })
+
+  it('uses the record base URL origin when recognizable', async () => {
+    writeAuthJson({
+      'zai-coding-plan': {
+        type: 'api',
+        key: 'key-1',
+        metadata: { baseURL: 'https://open.bigmodel.cn/api/anthropic' }
+      }
+    })
+    const result = await readZaiCredentials()
+    expect(result).toEqual({ status: 'ok', key: 'key-1', origin: 'https://open.bigmodel.cn' })
+  })
+
+  it('surfaces sanitized store errors unchanged', async () => {
+    const accessError = new Error('EACCES: permission denied') as NodeJS.ErrnoException
+    accessError.code = 'EACCES'
+    fsState.files.set(AUTH_PATH, accessError)
+    const result = await readZaiCredentials()
+    expect(result).toEqual({
+      status: 'error',
+      error: 'Failed to read OpenCode auth.json (EACCES)'
+    })
+  })
+})
+
+describe('isZaiAuthConfigured', () => {
+  beforeEach(() => {
+    fsState.files.clear()
+  })
+
+  it('is true only for an explicit api record with a nonempty key', async () => {
+    expect(await isZaiAuthConfigured()).toBe(false)
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: '' } })
+    expect(await isZaiAuthConfigured()).toBe(false)
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-1' } })
+    expect(await isZaiAuthConfigured()).toBe(true)
+  })
+
+  it('is false when the auth store is unreadable', async () => {
+    const parseError = new Error(
+      'EISDIR: illegal operation on a directory'
+    ) as NodeJS.ErrnoException
+    parseError.code = 'EISDIR'
+    fsState.files.set(AUTH_PATH, parseError)
+    expect(await isZaiAuthConfigured()).toBe(false)
+  })
+})

--- a/src/main/rate-limits/zai-credentials.ts
+++ b/src/main/rate-limits/zai-credentials.ts
@@ -1,0 +1,96 @@
+import {
+  getOpenCodeApiKeyRecord,
+  readOpenCodeAuthJson,
+  type OpenCodeAuthRecord
+} from '../opencode/opencode-auth-store'
+
+export const ZAI_CODING_PLAN_PROVIDER_ID = 'zai-coding-plan'
+
+export const DEFAULT_ZAI_ORIGIN = 'https://api.z.ai'
+
+// Why: the quota monitor only answers on the two GLM Coding Plan hosts; a
+// payload field pointing anywhere else must never redirect the key elsewhere.
+const ALLOWED_ZAI_ORIGINS: readonly string[] = [DEFAULT_ZAI_ORIGIN, 'https://open.bigmodel.cn']
+
+// Where a custom base URL may hide inside a provider record: the record body
+// itself or its metadata/config sub-objects.
+const ORIGIN_FIELDS: readonly string[] = ['baseURL', 'base_url', 'baseUrl', 'apiBase']
+const ORIGIN_CONTAINERS: readonly string[] = ['metadata', 'config']
+
+export type ZaiCredentialsResult =
+  | { status: 'missing' }
+  | { status: 'error'; error: string }
+  | { status: 'ok'; key: string; origin: string }
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function allowedOriginFromValue(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return null
+  }
+  try {
+    const url = new URL(value.trim())
+    return ALLOWED_ZAI_ORIGINS.includes(url.origin) ? url.origin : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Infer which GLM Coding Plan host a record belongs to from its
+ * metadata/config when recognizable; otherwise the global default.
+ */
+export function resolveZaiOrigin(record: OpenCodeAuthRecord | null): string {
+  if (!record) {
+    return DEFAULT_ZAI_ORIGIN
+  }
+  const containers = [record]
+  for (const key of ORIGIN_CONTAINERS) {
+    const nested = asRecord(record[key])
+    if (nested) {
+      containers.push(nested)
+    }
+  }
+  for (const container of containers) {
+    for (const field of ORIGIN_FIELDS) {
+      const origin = allowedOriginFromValue(container[field])
+      if (origin) {
+        return origin
+      }
+    }
+  }
+  return DEFAULT_ZAI_ORIGIN
+}
+
+/**
+ * Read-only Z.AI Coding Plan credentials from OpenCode's auth.json. The key
+ * lifecycle is owned by `opencode auth login`; Orca never writes that file.
+ */
+export async function readZaiCredentials(): Promise<ZaiCredentialsResult> {
+  const auth = await readOpenCodeAuthJson()
+  if (auth.status !== 'ok') {
+    return auth
+  }
+  const record = getOpenCodeApiKeyRecord(auth.auth, ZAI_CODING_PLAN_PROVIDER_ID)
+  if (!record) {
+    return { status: 'missing' }
+  }
+  // Why: origin hints live on the raw record; strict extraction drops extras.
+  return {
+    status: 'ok',
+    key: record.key.trim(),
+    origin: resolveZaiOrigin(asRecord(auth.auth[ZAI_CODING_PLAN_PROVIDER_ID]))
+  }
+}
+
+/** Durable `zaiAuthConfigured` signal: a nonempty Coding Plan key is on disk. */
+export async function isZaiAuthConfigured(): Promise<boolean> {
+  const auth = await readOpenCodeAuthJson()
+  return (
+    auth.status === 'ok' && getOpenCodeApiKeyRecord(auth.auth, ZAI_CODING_PLAN_PROVIDER_ID) !== null
+  )
+}

--- a/src/main/rate-limits/zai-fetcher.test.ts
+++ b/src/main/rate-limits/zai-fetcher.test.ts
@@ -1,0 +1,337 @@
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const netFetchMock = vi.hoisted(() => vi.fn())
+const fsState = vi.hoisted<{ files: Map<string, string | Error> }>(() => ({
+  files: new Map()
+}))
+
+vi.mock('electron', () => ({
+  net: { fetch: netFetchMock }
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: async (path: string) => {
+    const entry = fsState.files.get(String(path))
+    if (entry === undefined) {
+      const error = new Error(
+        `ENOENT: no such file or directory, open ${path}`
+      ) as NodeJS.ErrnoException
+      error.code = 'ENOENT'
+      throw error
+    }
+    if (entry instanceof Error) {
+      throw entry
+    }
+    return entry
+  }
+}))
+
+vi.mock('node:os', () => ({ homedir: () => '/home/test' }))
+
+import { fetchZaiRateLimits } from './zai-fetcher'
+
+const AUTH_PATH = join('/home/test', '.local', 'share', 'opencode', 'auth.json')
+const QUOTA_URL = 'https://api.z.ai/api/monitor/usage/quota/limit'
+
+function writeAuthJson(value: unknown): void {
+  fsState.files.set(AUTH_PATH, JSON.stringify(value))
+}
+
+function jsonResponse(
+  body: unknown,
+  { status = 200, headers = {} }: { status?: number; headers?: Record<string, string> } = {}
+): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
+    json: async () => body
+  } as Response
+}
+
+// Real shape from GET https://api.z.ai/api/monitor/usage/quota/limit: a 5h
+// window (unit 3 × 5) plus a weekly window (unit 6 × 1), percentage quotas
+// with epoch-ms reset times.
+const WRAPPED_QUOTA = {
+  success: true,
+  data: {
+    limits: [
+      {
+        type: 'CREDIT_LIMIT',
+        percentage: 62.5,
+        unit: 3,
+        number: 5,
+        nextResetTime: 1770648402389
+      },
+      {
+        type: 'CREDIT_LIMIT',
+        percentage: 10,
+        unit: 6,
+        number: 1,
+        nextResetTime: 1771000000000
+      }
+    ]
+  }
+}
+
+describe('fetchZaiRateLimits', () => {
+  beforeEach(() => {
+    netFetchMock.mockReset()
+    fsState.files.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns unavailable and never fetches without a key', async () => {
+    const result = await fetchZaiRateLimits()
+    expect(result.provider).toBe('zai')
+    expect(result.status).toBe('unavailable')
+    expect(result.usageMetadata?.source).toBe('web')
+    expect(result.usageMetadata?.failureKind).toBe('missing-credentials')
+    expect(netFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('maps the wrapped payload to exact 300/10080 windows with raw-key headers', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(jsonResponse(WRAPPED_QUOTA))
+
+    const result = await fetchZaiRateLimits()
+
+    expect(result.status).toBe('ok')
+    expect(result.usageMetadata?.source).toBe('web')
+    expect(result.session?.windowMinutes).toBe(300)
+    expect(result.session?.usedPercent).toBeCloseTo(62.5)
+    expect(result.session?.resetsAt).toBe(1770648402389)
+    expect(result.weekly?.windowMinutes).toBe(10080)
+    expect(result.weekly?.usedPercent).toBeCloseTo(10)
+
+    // Why: exactly one usage request per fetch — no retries, no extra probes.
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = netFetchMock.mock.calls[0]
+    expect(url).toBe(QUOTA_URL)
+    expect(init.method).toBe('GET')
+    expect(init.headers).toEqual({
+      Authorization: 'key-abc',
+      'Accept-Language': 'en-US,en',
+      'Content-Type': 'application/json'
+    })
+    expect(init.signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('combines an optional caller signal with the bounded timeout', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    let captured: AbortSignal | undefined
+    netFetchMock.mockImplementationOnce(async (_url: string, init: { signal: AbortSignal }) => {
+      captured = init.signal
+      return jsonResponse(WRAPPED_QUOTA)
+    })
+
+    const controller = new AbortController()
+    const result = await fetchZaiRateLimits({ signal: controller.signal })
+
+    expect(result.status).toBe('ok')
+    expect(captured).toBeInstanceOf(AbortSignal)
+    expect(captured?.aborted).toBe(false)
+    // Why: the composite signal must propagate caller cancellation.
+    controller.abort()
+    expect(captured?.aborted).toBe(true)
+  })
+
+  it('parses the unwrapped payload with legacy TOKENS_LIMIT name field', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        limits: [{ name: 'TOKENS_LIMIT', percentage: '41', unit: 3, number: 5 }]
+      })
+    )
+
+    const result = await fetchZaiRateLimits()
+
+    expect(result.status).toBe('ok')
+    expect(result.session?.usedPercent).toBeCloseTo(41)
+    expect(result.weekly).toBeNull()
+  })
+
+  it('converts epoch-second resets and clamps percentages', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        limits: [
+          { type: 'CREDIT_LIMIT', percentage: 150, unit: 3, number: 5, nextResetTime: 1770648402 },
+          { type: 'CREDIT_LIMIT', percentage: -4, unit: 6, number: 1 }
+        ]
+      })
+    )
+
+    const result = await fetchZaiRateLimits()
+
+    expect(result.session?.usedPercent).toBe(100)
+    expect(result.session?.resetsAt).toBe(1770648402000)
+    expect(result.weekly?.usedPercent).toBe(0)
+    expect(result.weekly?.resetsAt).toBeNull()
+  })
+
+  it('accepts only exact 5-hour and 7-day windows', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        limits: [
+          { type: 'CREDIT_LIMIT', percentage: 80, unit: 4, number: 3 },
+          { type: 'CREDIT_LIMIT', percentage: 20, unit: 3, number: 5 },
+          { type: 'CREDIT_LIMIT', percentage: 5, unit: 4, number: 10 },
+          { type: 'CREDIT_LIMIT', percentage: 40, unit: 4, number: 7 }
+        ]
+      })
+    )
+
+    const result = await fetchZaiRateLimits()
+
+    expect(result.session?.usedPercent).toBeCloseTo(20)
+    expect(result.session?.windowMinutes).toBe(300)
+    expect(result.weekly?.usedPercent).toBeCloseTo(40)
+    expect(result.weekly?.windowMinutes).toBe(10080)
+  })
+
+  it('ignores unrelated and unusable entries', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        limits: [
+          { type: 'TIME_LIMIT', percentage: 50, currentValue: 1, usage: 100 },
+          { type: 'CREDIT_LIMIT', unit: 3, number: 5 }, // no percentage
+          { type: 'CREDIT_LIMIT', percentage: 30, unit: 9, number: 5 }, // unknown unit
+          'garbage'
+        ]
+      })
+    )
+
+    const result = await fetchZaiRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.source).toBe('web')
+    expect(result.usageMetadata?.failureKind).toBe('usage-unavailable')
+  })
+
+  it('uses the record-provided origin only when it is allowed', async () => {
+    writeAuthJson({
+      'zai-coding-plan': {
+        type: 'api',
+        key: 'key-abc',
+        metadata: { baseURL: 'https://open.bigmodel.cn/api/anthropic' }
+      }
+    })
+    netFetchMock.mockResolvedValueOnce(jsonResponse(WRAPPED_QUOTA))
+    await fetchZaiRateLimits()
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+    expect(netFetchMock.mock.calls[0][0]).toBe(
+      'https://open.bigmodel.cn/api/monitor/usage/quota/limit'
+    )
+
+    writeAuthJson({
+      'zai-coding-plan': {
+        type: 'api',
+        key: 'key-abc',
+        metadata: { baseURL: 'https://evil.example.com/api/anthropic' }
+      }
+    })
+    netFetchMock.mockResolvedValueOnce(jsonResponse(WRAPPED_QUOTA))
+    await fetchZaiRateLimits()
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+    expect(netFetchMock.mock.calls[1][0]).toBe(QUOTA_URL)
+  })
+
+  it('classifies 401/403 as stale credentials without leaking the key', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'secret-key-abc' } })
+    for (const status of [401, 403]) {
+      netFetchMock.mockResolvedValueOnce(jsonResponse({}, { status }))
+      const result = await fetchZaiRateLimits()
+      expect(result.status).toBe('error')
+      expect(result.usageMetadata?.failureKind).toBe('stale-token')
+      expect(result.error).toContain(`HTTP ${status}`)
+      expect(result.error).not.toContain('secret-key-abc')
+    }
+  })
+
+  it('captures a numeric Retry-After on 429', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({}, { status: 429, headers: { 'retry-after': '3000' } })
+    )
+    const before = Date.now()
+    const result = await fetchZaiRateLimits()
+    expect(result.usageMetadata?.failureKind).toBe('rate-limited')
+    expect(result.usageMetadata?.retryAtMs).toBeGreaterThanOrEqual(before + 3000 * 1000)
+    expect(result.usageMetadata?.retryAtMs).toBeLessThanOrEqual(Date.now() + 3000 * 1000)
+  })
+
+  it('omits retryAtMs for missing, invalid, and non-positive Retry-After', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    for (const header of [null, 'soon', '0']) {
+      netFetchMock.mockResolvedValueOnce(
+        jsonResponse({}, { status: 429, headers: header ? { 'retry-after': header } : {} })
+      )
+      const result = await fetchZaiRateLimits()
+      expect(result.usageMetadata?.failureKind).toBe('rate-limited')
+      expect(result.usageMetadata?.retryAtMs).toBeUndefined()
+    }
+  })
+
+  it('classifies 5xx as a server failure', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce(jsonResponse({}, { status: 503 }))
+    const result = await fetchZaiRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('server')
+  })
+
+  it('classifies malformed JSON bodies as a parse failure', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    netFetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => {
+        throw new SyntaxError('Unexpected token < in JSON')
+      }
+    } as unknown as Response)
+    const result = await fetchZaiRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('parse')
+  })
+
+  it('classifies payload shape problems as usage-unavailable', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    for (const body of ['not-an-object', {}, { limits: 'nope' }, { data: {} }]) {
+      netFetchMock.mockResolvedValueOnce(jsonResponse(body))
+      const result = await fetchZaiRateLimits()
+      expect(result.status).toBe('error')
+      expect(result.usageMetadata?.failureKind).toBe('usage-unavailable')
+    }
+  })
+
+  it('reports request failures as a generic sanitized network error', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'secret-key-abc' } })
+    netFetchMock.mockRejectedValueOnce(
+      new Error('fetch failed: https://api.z.ai/... internal ECONNRESET detail')
+    )
+    const result = await fetchZaiRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('network')
+    expect(result.error).toBe('Z.ai usage request failed — check your network connection')
+    expect(result.error).not.toContain('secret-key-abc')
+    expect(result.error).not.toContain('ECONNRESET')
+  })
+
+  it('reports timeout aborts as bounded network errors', async () => {
+    writeAuthJson({ 'zai-coding-plan': { type: 'api', key: 'key-abc' } })
+    const timeout = new Error('The operation was aborted due to timeout')
+    timeout.name = 'TimeoutError'
+    netFetchMock.mockRejectedValueOnce(timeout)
+    const result = await fetchZaiRateLimits()
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('network')
+    expect(result.error).toContain('timed out')
+  })
+})

--- a/src/main/rate-limits/zai-fetcher.ts
+++ b/src/main/rate-limits/zai-fetcher.ts
@@ -1,0 +1,318 @@
+import { net } from 'electron'
+import type {
+  ProviderRateLimits,
+  RateLimitWindow,
+  UsageRateLimitFailureKind
+} from '../../shared/rate-limit-types'
+import { readZaiCredentials } from './zai-credentials'
+
+const API_TIMEOUT_MS = 10_000
+const QUOTA_LIMIT_PATH = '/api/monitor/usage/quota/limit'
+
+// Why: the status contract exposes only the two contracted windows (5h/7d),
+// mirroring how Codex and MiniMax always report 300/10080 minutes regardless
+// of what the payload's duration metadata drifts to.
+const SESSION_WINDOW_MINUTES = 300
+const WEEKLY_WINDOW_MINUTES = 10080
+
+// Why: identical to the official glm-plan-usage plugin — raw key (no Bearer
+// prefix) plus locale headers; the monitor endpoint authenticates by key only.
+const ACCEPT_LANGUAGE = 'en-US,en'
+
+// Z.ai duration metadata is a `(unit, number)` pair: 3=hour, 4=day, 5=month
+// (30d), 6=week. Unknown units are ignored so a future window cannot hide
+// meters that still parse.
+const ZAI_UNIT_MS: Partial<Record<number, number>> = {
+  3: 3_600_000,
+  4: 86_400_000,
+  5: 30 * 86_400_000,
+  6: 7 * 86_400_000
+}
+
+// Why: a corrupt/hostile Retry-After must not gate usage refreshes for days.
+const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000
+
+// Why: raw provider/network error text can embed URLs or infrastructure
+// details; the user only needs to know the request did not go through.
+const GENERIC_NETWORK_ERROR = 'Z.ai usage request failed — check your network connection'
+
+export type FetchZaiRateLimitsOptions = {
+  /** Optional caller cancellation; combined with the bounded timeout. */
+  signal?: AbortSignal
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function clampPercent(value: number): number {
+  return Math.min(100, Math.max(0, value))
+}
+
+// Why: current payloads send epoch milliseconds but older revisions sent epoch
+// seconds; a magnitude check tells the two apart.
+function toEpochMs(value: unknown): number | null {
+  const raw = asNumber(value)
+  if (raw === null) {
+    return null
+  }
+  if (raw >= 1e12) {
+    return raw
+  }
+  if (raw >= 1e9) {
+    return raw * 1000
+  }
+  return null
+}
+
+function limitEntryMinutes(entry: Record<string, unknown>): number | null {
+  const unit = asNumber(entry.unit)
+  const count = asNumber(entry.number)
+  if (unit === null || count === null || count <= 0) {
+    return null
+  }
+  const unitMs = ZAI_UNIT_MS[unit]
+  return unitMs === undefined ? null : (unitMs * count) / 60_000
+}
+
+function contractedWindowMinutes(minutes: number): number | null {
+  if (minutes === SESSION_WINDOW_MINUTES || minutes === WEEKLY_WINDOW_MINUTES) {
+    return minutes
+  }
+  return null
+}
+
+type ZaiUsageWindow = RateLimitWindow
+
+function mapQuotaEntry(entry: unknown): ZaiUsageWindow | null {
+  const record = asObject(entry)
+  if (!record) {
+    return null
+  }
+  // Z.ai has matched entries by `type` or `name` across payload revisions.
+  const kind = typeof record.type === 'string' ? record.type : record.name
+  // Why: only percentage quota windows meter Coding Plan usage; TIME_LIMIT
+  // (monthly web-search counts) and future kinds are not rate-limit data.
+  if (kind !== 'CREDIT_LIMIT' && kind !== 'TOKENS_LIMIT') {
+    return null
+  }
+  const percentage = asNumber(record.percentage)
+  const minutes = limitEntryMinutes(record)
+  const windowMinutes = minutes === null ? null : contractedWindowMinutes(minutes)
+  if (percentage === null || windowMinutes === null) {
+    return null
+  }
+  return {
+    usedPercent: clampPercent(percentage),
+    windowMinutes,
+    resetsAt: toEpochMs(record.nextResetTime),
+    resetDescription: null
+  }
+}
+
+function unwrapQuotaLimits(data: unknown): unknown[] | null {
+  const body = asObject(data)
+  if (!body) {
+    return null
+  }
+  // Wrapped payloads nest under `data` ({ success, data: { limits } }); older
+  // ones expose `limits` at the top level.
+  const limits = asObject(body.data)?.limits ?? body.limits
+  return Array.isArray(limits) ? limits : null
+}
+
+function toRateLimitWindow(entry: ZaiUsageWindow): RateLimitWindow {
+  return {
+    usedPercent: entry.usedPercent,
+    windowMinutes: entry.windowMinutes,
+    resetsAt: entry.resetsAt,
+    resetDescription: entry.resetDescription
+  }
+}
+
+function mapQuotaResponse(
+  data: unknown
+): { session: RateLimitWindow | null; weekly: RateLimitWindow | null } | null {
+  const limits = unwrapQuotaLimits(data)
+  if (limits === null) {
+    return null
+  }
+  let session: ZaiUsageWindow | null = null
+  let weekly: ZaiUsageWindow | null = null
+  for (const entry of limits) {
+    const mapped = mapQuotaEntry(entry)
+    if (!mapped) {
+      continue
+    }
+    if (mapped.windowMinutes === SESSION_WINDOW_MINUTES) {
+      session ??= mapped
+    } else {
+      weekly ??= mapped
+    }
+  }
+  if (!session && !weekly) {
+    return null
+  }
+  return {
+    session: session ? toRateLimitWindow(session) : null,
+    weekly: weekly ? toRateLimitWindow(weekly) : null
+  }
+}
+
+// Mirrors the Claude usage parser: seconds or an HTTP-date (RFC 9110).
+function parseRetryAfterMs(header: string | null): number | null {
+  if (!header) {
+    return null
+  }
+  const seconds = Number(header)
+  if (Number.isFinite(seconds)) {
+    return seconds > 0 ? Math.min(seconds * 1000, MAX_RETRY_AFTER_MS) : null
+  }
+  const dateMs = Date.parse(header)
+  if (!Number.isFinite(dateMs)) {
+    return null
+  }
+  const delta = dateMs - Date.now()
+  return delta > 0 ? Math.min(delta, MAX_RETRY_AFTER_MS) : null
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (error as { name?: unknown } | null)?.name === 'TimeoutError'
+}
+
+function usageMetadata(
+  failureKind?: UsageRateLimitFailureKind,
+  retryAtMs?: number
+): ProviderRateLimits['usageMetadata'] {
+  return {
+    source: 'web',
+    ...(failureKind ? { failureKind } : {}),
+    ...(retryAtMs !== undefined ? { retryAtMs } : {})
+  }
+}
+
+function makeUnavailable(error: string): ProviderRateLimits {
+  return {
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error,
+    status: 'unavailable',
+    usageMetadata: usageMetadata('missing-credentials')
+  }
+}
+
+function makeError(
+  error: string,
+  failureKind: UsageRateLimitFailureKind,
+  retryAtMs?: number
+): ProviderRateLimits {
+  return {
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error,
+    status: 'error',
+    usageMetadata: usageMetadata(failureKind, retryAtMs)
+  }
+}
+
+/**
+ * Read-only usage for the OpenCode Z.AI Coding Plan (`zai-coding-plan` in
+ * OpenCode's auth.json). Orca never refreshes or rewrites that key — it is
+ * owned by `opencode auth login`. The quota endpoint is the same monitor API
+ * the official glm-plan-usage plugin calls.
+ */
+export async function fetchZaiRateLimits(
+  options?: FetchZaiRateLimitsOptions
+): Promise<ProviderRateLimits> {
+  const credentials = await readZaiCredentials()
+  if (credentials.status === 'missing') {
+    return makeUnavailable(
+      'Z.ai Coding Plan key not found — run "opencode auth login" and add Z.ai'
+    )
+  }
+  if (credentials.status === 'error') {
+    return makeError(credentials.error, 'unknown')
+  }
+  const { key, origin } = credentials
+  // Why: same combination shape as the codex/claude fetchers — caller
+  // cancellation plus one bounded timeout, whichever fires first.
+  const timeoutSignal = AbortSignal.timeout(API_TIMEOUT_MS)
+  const signal = options?.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal
+  try {
+    const response = await net.fetch(`${origin.replace(/\/$/, '')}${QUOTA_LIMIT_PATH}`, {
+      method: 'GET',
+      headers: {
+        Authorization: key,
+        'Accept-Language': ACCEPT_LANGUAGE,
+        'Content-Type': 'application/json'
+      },
+      signal
+    })
+    if (response.status === 401 || response.status === 403) {
+      return makeError(
+        `Z.ai rejected the Coding Plan key (HTTP ${response.status}) — run "opencode auth login" to refresh it`,
+        'stale-token'
+      )
+    }
+    if (response.status === 429) {
+      // Why: activation refreshes honor Retry-After; the metadata contract wants
+      // an absolute timestamp, so convert the parsed delta.
+      const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'))
+      return makeError(
+        'Z.ai usage is rate limited right now',
+        'rate-limited',
+        retryAfterMs === null ? undefined : Date.now() + retryAfterMs
+      )
+    }
+    if (!response.ok) {
+      return makeError(
+        `Z.ai usage request failed (HTTP ${response.status})`,
+        response.status >= 500 ? 'server' : 'unknown'
+      )
+    }
+    let data: unknown
+    try {
+      data = await response.json()
+    } catch {
+      return makeError('Z.ai usage response is not valid JSON', 'parse')
+    }
+    const windows = mapQuotaResponse(data)
+    if (!windows) {
+      return makeError(
+        'Z.ai usage response did not include recognized quota windows',
+        'usage-unavailable'
+      )
+    }
+    return {
+      provider: 'zai',
+      session: windows.session,
+      weekly: windows.weekly,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok',
+      usageMetadata: usageMetadata()
+    }
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      return makeError(`Z.ai usage request timed out after ${API_TIMEOUT_MS / 1000}s`, 'network')
+    }
+    return makeError(GENERIC_NETWORK_ERROR, 'network')
+  }
+}

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -54,6 +54,7 @@ const AgentActivityDisplayMode = z.enum(['compact', 'full'])
 const StatusBarItem = z.enum([
   'claude',
   'codex',
+  'zai',
   'gemini',
   'antigravity',
   'opencode-go',
@@ -166,6 +167,7 @@ const UiUpdateFields = z
     _minimaxStatusBarDefaultAdded: z.boolean().optional(),
     _antigravityStatusBarDefaultAdded: z.boolean().optional(),
     _grokStatusBarDefaultAdded: z.boolean().optional(),
+    _zaiStatusBarDefaultAdded: z.boolean().optional(),
     statusBarVisible: z.boolean().optional(),
     usagePercentageDisplay: z.enum(['used', 'remaining']).optional(),
     statusBarUsageMode: z.enum(['verbose', 'compact']).optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -615,7 +615,9 @@ describe('client UI RPC methods', () => {
     ['browserImportHintHidden', { browserImportHintHidden: true }],
     ['mobileEmulatorTabIntroDismissed', { mobileEmulatorTabIntroDismissed: true }],
     ['mobileEmulatorAgentSetupDismissed', { mobileEmulatorAgentSetupDismissed: true }],
-    ['alwaysShowDefaultBranchWorkspace', { alwaysShowDefaultBranchWorkspace: false }]
+    ['alwaysShowDefaultBranchWorkspace', { alwaysShowDefaultBranchWorkspace: false }],
+    ['statusBarItems.zai', { statusBarItems: ['claude', 'codex', 'zai'] }],
+    ['_zaiStatusBarDefaultAdded', { _zaiStatusBarDefaultAdded: true }]
   ])('accepts %s, which the renderer persists through ui.set', async (_label, payload) => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/renderer/src/components/settings/appearance-status-bar-minimax-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-minimax-toggle-search.ts
@@ -1,0 +1,41 @@
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getMiniMaxStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'minimax',
+    title: translate('auto.components.settings.appearance.search.0f08f6b483', 'MiniMax Usage'),
+    description: translate(
+      'auto.components.settings.appearance.search.e46178eb1b',
+      'Show MiniMax subscription usage in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.d16378a88f', 'minimax'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.de586def95',
+        'subscription'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.d9e7cef86f', 'cookie'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.25e51b62ee',
+        'rate limit'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.minimaxToggleDescription',
+      'Show MiniMax subscription usage for the active workspace.'
+    )
+  }
+}

--- a/src/renderer/src/components/settings/appearance-status-bar-search.test.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.test.ts
@@ -43,4 +43,17 @@ describe('getStatusBarToggles', () => {
       expect.arrayContaining(['status bar', 'minimax', 'usage', 'subscription', 'cookie'])
     )
   })
+
+  it('includes Z.AI usage so Appearance can toggle the status item unconditionally', () => {
+    const zaiToggle = getStatusBarToggles().find((entry) => entry.id === 'zai')
+
+    expect(zaiToggle).toMatchObject({
+      title: 'Z.AI Usage',
+      description: 'Show Z.AI Coding Plan usage in the status bar.',
+      toggleDescription: 'Show Z.AI Coding Plan usage when signed in through opencode auth.'
+    })
+    expect(zaiToggle?.keywords).toEqual(
+      expect.arrayContaining(['status bar', 'z.ai', 'glm', 'usage', 'subscription', 'opencode'])
+    )
+  })
 })

--- a/src/renderer/src/components/settings/appearance-status-bar-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-search.ts
@@ -4,6 +4,8 @@ import { translate } from '@/i18n/i18n'
 import { translateSearchKeyword } from './settings-search-keywords'
 import { getAntigravityStatusBarToggleSearchEntry } from './appearance-status-bar-antigravity-toggle-search'
 import { getGrokStatusBarToggleSearchEntry } from './appearance-status-bar-grok-toggle-search'
+import { getMiniMaxStatusBarToggleSearchEntry } from './appearance-status-bar-minimax-toggle-search'
+import { getZaiStatusBarToggleSearchEntry } from './appearance-status-bar-zai-toggle-search'
 
 export const getStatusBarToggles = createLocalizedCatalog(
   (): readonly {
@@ -71,6 +73,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show Codex token and cost usage for the active workspace.'
       )
     },
+    getZaiStatusBarToggleSearchEntry(),
     {
       id: 'gemini',
       title: translate('auto.components.settings.appearance.search.5bfb874d05', 'Gemini Usage'),
@@ -164,41 +167,7 @@ export const getStatusBarToggles = createLocalizedCatalog(
         'Show Kimi subscription usage for the active workspace.'
       )
     },
-    {
-      id: 'minimax',
-      title: translate('auto.components.settings.appearance.search.0f08f6b483', 'MiniMax Usage'),
-      description: translate(
-        'auto.components.settings.appearance.search.e46178eb1b',
-        'Show MiniMax subscription usage in the status bar.'
-      ),
-      keywords: [
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.896eb53fd4',
-          'status bar'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.d16378a88f',
-          'minimax'
-        ),
-        ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.de586def95',
-          'subscription'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.d9e7cef86f',
-          'cookie'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.appearance.search.25e51b62ee',
-          'rate limit'
-        )
-      ],
-      toggleDescription: translate(
-        'settings.appearance.statusBar.minimaxToggleDescription',
-        'Show MiniMax subscription usage for the active workspace.'
-      )
-    },
+    getMiniMaxStatusBarToggleSearchEntry(),
     getGrokStatusBarToggleSearchEntry(),
     {
       id: 'ssh',

--- a/src/renderer/src/components/settings/appearance-status-bar-zai-toggle-search.ts
+++ b/src/renderer/src/components/settings/appearance-status-bar-zai-toggle-search.ts
@@ -1,0 +1,41 @@
+import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
+import { translate } from '@/i18n/i18n'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+export function getZaiStatusBarToggleSearchEntry(): {
+  id: StatusBarItem
+  title: string
+  description: string
+  keywords: string[]
+  toggleDescription: string
+} {
+  return {
+    id: 'zai',
+    title: translate('auto.components.settings.appearance.search.zaiUsageTitle', 'Z.AI Usage'),
+    description: translate(
+      'auto.components.settings.appearance.search.zaiUsageDescription',
+      'Show Z.AI Coding Plan usage in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.896eb53fd4',
+        'status bar'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.zaiKeyword', 'z.ai'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.zaiGlmKeyword', 'glm'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.00a028f25f', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.de586def95',
+        'subscription'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.zaiOpencodeKeyword',
+        'opencode'
+      )
+    ],
+    toggleDescription: translate(
+      'settings.appearance.statusBar.zaiToggleDescription',
+      'Show Z.AI Coding Plan usage when signed in through opencode auth.'
+    )
+  }
+}

--- a/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarProviderSegment.tsx
@@ -82,6 +82,8 @@ function getProviderLetter(provider: ProviderRateLimits['provider']): string {
       return 'M'
     case 'grok':
       return 'R'
+    case 'zai':
+      return 'Z'
     case 'codex':
       return 'X'
   }

--- a/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import type { StatusBarController } from './use-status-bar-controller'
@@ -62,6 +62,17 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.c0909c686e', 'Codex Usage')}
           </DropdownMenuCheckboxItem>
         )}
+        {/* Why: Z.AI auth is opencode-store-based, not a CLI on PATH, so its toggle has no agent gate. */}
+        <DropdownMenuCheckboxItem
+          checked={statusBarItems.includes('zai')}
+          onCheckedChange={() => {
+            recordFeatureInteraction('usage-tracking')
+            toggleStatusBarItem('zai')
+          }}
+        >
+          <ZaiIcon size={14} />
+          {translate('auto.components.status.bar.StatusBar.zaiUsageMenu', 'Z.AI Usage')}
+        </DropdownMenuCheckboxItem>
         {isStatusBarItemAvailable('gemini', detectedAgentIds) && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('gemini')}

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -171,6 +171,50 @@ describe('UsageRow', () => {
     expect(markup).not.toContain('Resets in')
   })
 
+  it('renders Z.AI session and weekly windows in verbose and compact modes', () => {
+    const zai: ProviderRateLimits = {
+      provider: 'zai',
+      session: {
+        usedPercent: 25,
+        windowMinutes: 300,
+        resetsAt: null,
+        resetDescription: null
+      },
+      weekly: {
+        usedPercent: 60,
+        windowMinutes: 10_080,
+        resetsAt: null,
+        resetDescription: null
+      },
+      updatedAt: 0,
+      status: 'ok',
+      error: null
+    }
+    const render = (mode: 'verbose' | 'compact') =>
+      renderToStaticMarkup(
+        <UsageRow
+          p={zai}
+          display="used"
+          mode={mode}
+          state={{ kind: 'usage', statusLabel: null }}
+          showSignInAction={false}
+          now={mocks.now}
+        />
+      )
+
+    const verbose = render('verbose')
+    expect(verbose.match(/data-usage-window=/g)).toHaveLength(2)
+    expect(verbose).toContain('5h')
+    expect(verbose).toContain('25%')
+    expect(verbose).toContain('wk')
+    expect(verbose).toContain('60%')
+
+    const compact = render('compact')
+    expect(compact.match(/data-usage-window=/g)).toHaveLength(1)
+    expect(compact).toContain('60%')
+    expect(compact).not.toContain('25%')
+  })
+
   it('uses the same compact selection for Claude subscription windows', () => {
     const markup = renderToStaticMarkup(
       <UsageRow

--- a/src/renderer/src/components/status-bar/icons.test.tsx
+++ b/src/renderer/src/components/status-bar/icons.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { MiniMaxIcon } from './icons'
+import { MiniMaxIcon, ZaiIcon } from './icons'
 
 describe('MiniMaxIcon', () => {
   it('renders the official MiniMax mark as an image', () => {
@@ -20,5 +20,23 @@ describe('MiniMaxIcon', () => {
   it('does not render the legacy "M" placeholder text', () => {
     const markup = renderToStaticMarkup(<MiniMaxIcon size={14} />)
     expect(markup).not.toContain('>M<')
+  })
+})
+
+describe('ZaiIcon', () => {
+  it('renders a monochrome currentColor SVG Z glyph', () => {
+    const markup = renderToStaticMarkup(<ZaiIcon size={13} />)
+    expect(markup.startsWith('<svg')).toBe(true)
+    expect(markup).toContain('fill="currentColor"')
+    expect(markup).toContain('width="13"')
+    expect(markup).toContain('height="13"')
+    // A letter-Z silhouette: top bar, diagonal, bottom bar.
+    expect(markup).toContain('d="M5 4h14v3l-9.5 10H19v3H5v-3l9.5-10H5V4z"')
+  })
+
+  it('honors a custom size prop', () => {
+    const markup = renderToStaticMarkup(<ZaiIcon size={20} />)
+    expect(markup).toContain('width="20"')
+    expect(markup).toContain('height="20"')
   })
 })

--- a/src/renderer/src/components/status-bar/icons.tsx
+++ b/src/renderer/src/components/status-bar/icons.tsx
@@ -343,3 +343,20 @@ export function DroidIcon({ size = 14 }: { size?: number }): React.JSX.Element {
     </svg>
   )
 }
+
+// Why: a token-compliant monochrome Z keeps the icon on the text color in both
+// themes; Z.AI's gradient brand mark would fight the status-bar chrome.
+export function ZaiIcon({ size = 14 }: { size?: number }): React.JSX.Element {
+  return (
+    <svg
+      fill="currentColor"
+      height={size}
+      width={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path d="M5 4h14v3l-9.5 10H19v3H5v-3l9.5-10H5V4z" />
+    </svg>
+  )
+}

--- a/src/renderer/src/components/status-bar/provider-segment-letter-badge.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-letter-badge.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import { ProviderLetterBadge } from './StatusBarProviderSegment'
+
+function zaiLimits(status: ProviderRateLimits['status']): ProviderRateLimits {
+  return {
+    provider: 'zai',
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status
+  }
+}
+
+describe('ProviderLetterBadge for Z.AI', () => {
+  it('renders the single-letter Z badge for zai', () => {
+    const markup = renderToStaticMarkup(<ProviderLetterBadge p={zaiLimits('ok')} />)
+    expect(markup).toContain('>Z<')
+  })
+
+  it('keeps the has-data dot logic for zai snapshots', () => {
+    const empty = renderToStaticMarkup(<ProviderLetterBadge p={zaiLimits('ok')} />)
+    const withData = renderToStaticMarkup(
+      <ProviderLetterBadge
+        p={{
+          ...zaiLimits('ok'),
+          weekly: { usedPercent: 10, windowMinutes: 10080, resetsAt: null, resetDescription: null }
+        }}
+      />
+    )
+    // The dot carries the has-data state; the letter stays constant.
+    expect(empty).not.toEqual(withData)
+    expect(withData).toContain('>Z<')
+  })
+})

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -10,6 +10,11 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('resource-usage', [])).toBe(true)
     expect(isStatusBarItemAvailable('ports', [])).toBe(true)
     expect(isStatusBarItemAvailable('opencode-go', [])).toBe(true)
+    // Why: Z.AI auth lives in opencode's auth store, not a CLI on PATH, so it
+    // must never be hidden by agent detection.
+    expect(isStatusBarItemAvailable('zai', null)).toBe(true)
+    expect(isStatusBarItemAvailable('zai', [])).toBe(true)
+    expect(isStatusBarItemAvailable('zai', ['claude', 'codex'])).toBe(true)
   })
 
   it('keeps CLI items visible while detection is in flight', () => {

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -74,6 +74,7 @@ function usageSettings(overrides: Partial<UsageProviderSettings> = {}): UsagePro
     antigravityUsageConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
+    zaiAuthConfigured: false,
     ...overrides
   }
 }
@@ -128,6 +129,7 @@ describe('hasUsageProviderSettings', () => {
     )
     expect(hasUsageProviderSettings(usageSettings({ minimaxCookieConfigured: true }))).toBe(true)
     expect(hasUsageProviderSettings(usageSettings({ grokAuthConfigured: true }))).toBe(true)
+    expect(hasUsageProviderSettings(usageSettings({ zaiAuthConfigured: true }))).toBe(true)
   })
 
   it('does not treat empty or unloaded settings as configured', () => {
@@ -202,6 +204,14 @@ describe('hasUsageProviderSettingsForProvider', () => {
     ).toBe(true)
     expect(hasUsageProviderSettingsForProvider('grok', usageSettings())).toBe(false)
     expect(hasUsageProviderSettingsForProvider('grok', null)).toBe(false)
+  })
+
+  it('treats zaiAuthConfigured as the durable signal for Z.AI', () => {
+    expect(
+      hasUsageProviderSettingsForProvider('zai', usageSettings({ zaiAuthConfigured: true }))
+    ).toBe(true)
+    expect(hasUsageProviderSettingsForProvider('zai', usageSettings())).toBe(false)
+    expect(hasUsageProviderSettingsForProvider('zai', null)).toBe(false)
   })
 })
 
@@ -359,6 +369,35 @@ describe('getVisibleUsageProvider', () => {
       )
     ).toBe(null)
   })
+
+  it('keeps Z.AI visible while the snapshot is pending when auth is configured', () => {
+    const visible = getVisibleUsageProvider('zai', null, usageSettings({ zaiAuthConfigured: true }))
+    expect(visible).toMatchObject({
+      provider: 'zai',
+      status: 'fetching',
+      session: null,
+      weekly: null
+    })
+  })
+
+  it('keeps a configured Z.AI failure visible instead of flapping the bar', () => {
+    // Why: an auth hiccup on a configured provider is a *configured* provider
+    // failing, so the error state stays visible with its recovery copy.
+    const failing = provider('error', {
+      provider: 'zai',
+      error: 'Z.AI usage could not be refreshed: not logged in'
+    })
+    expect(
+      getVisibleUsageProvider('zai', failing, usageSettings({ zaiAuthConfigured: true }))
+    ).toBe(failing)
+  })
+
+  it('hides Z.AI when auth is not configured and the snapshot is unavailable', () => {
+    expect(getVisibleUsageProvider('zai', null, usageSettings())).toBe(null)
+    expect(
+      getVisibleUsageProvider('zai', provider('unavailable', { provider: 'zai' }), usageSettings())
+    ).toBe(null)
+  })
 })
 
 describe('isUsageEmptyState', () => {
@@ -373,7 +412,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          zai: null
         },
         usageSettings()
       )
@@ -391,7 +431,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: undefined,
           minimax: undefined,
-          grok: undefined
+          grok: undefined,
+          zai: undefined
         },
         usageSettings()
       )
@@ -409,7 +450,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: provider('unavailable', { provider: 'antigravity' }),
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings()
       )
@@ -427,7 +469,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: provider('unavailable', { provider: 'antigravity' }),
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings({
           codexManagedAccounts: [
@@ -456,7 +499,8 @@ describe('isUsageEmptyState', () => {
           kimi: null,
           antigravity: null,
           minimax: null,
-          grok: null
+          grok: null,
+          zai: null
         },
         null
       )
@@ -474,7 +518,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           minimax: provider('unavailable', { provider: 'minimax' }),
-          grok: provider('unavailable', { provider: 'grok' })
+          grok: provider('unavailable', { provider: 'grok' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings()
       )
@@ -492,7 +537,8 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           grok: provider('unavailable', { provider: 'grok' }),
-          minimax: provider('unavailable', { provider: 'minimax' })
+          minimax: provider('unavailable', { provider: 'minimax' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings({ antigravityUsageConfigured: true, geminiCliOAuthEnabled: true })
       )
@@ -512,10 +558,30 @@ describe('isUsageEmptyState', () => {
           kimi: provider('unavailable', { provider: 'kimi' }),
           antigravity: null,
           grok: provider('unavailable', { provider: 'grok' }),
-          minimax: provider('unavailable', { provider: 'minimax' })
+          minimax: provider('unavailable', { provider: 'minimax' }),
+          zai: provider('unavailable', { provider: 'zai' })
         },
         usageSettings({ antigravityUsageConfigured: true })
       )
     ).toBe(true)
+  })
+
+  it('does not show the setup CTA while a configured Z.AI snapshot is still pending', () => {
+    expect(
+      isUsageEmptyState(
+        {
+          claude: provider('unavailable', { provider: 'claude' }),
+          codex: provider('unavailable', { provider: 'codex' }),
+          gemini: provider('unavailable'),
+          opencodeGo: provider('unavailable', { provider: 'opencode-go' }),
+          kimi: provider('unavailable', { provider: 'kimi' }),
+          antigravity: null,
+          grok: provider('unavailable', { provider: 'grok' }),
+          minimax: provider('unavailable', { provider: 'minimax' }),
+          zai: null
+        },
+        usageSettings({ zaiAuthConfigured: true })
+      )
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -17,6 +17,8 @@ export type UsageProviderSettings = Pick<
   // Why: MiniMax/Grok sign-in live on disk, not in settings; main sets these each poll.
   minimaxCookieConfigured: boolean
   grokAuthConfigured: boolean
+  // Why: Z.AI sign-in lives in opencode's auth store, not in Orca settings; main sets this each poll.
+  zaiAuthConfigured?: boolean
 }
 
 type UsageProviderSnapshots = {
@@ -28,6 +30,7 @@ type UsageProviderSnapshots = {
   antigravity: ProviderRateLimits | null | undefined
   minimax: ProviderRateLimits | null | undefined
   grok: ProviderRateLimits | null | undefined
+  zai: ProviderRateLimits | null | undefined
 }
 
 type UsageProviderId = ProviderRateLimits['provider']
@@ -77,7 +80,8 @@ export function hasUsageProviderSettings(
     // Antigravity's durable signal requires geminiCliOAuthEnabled, so it is
     // already covered by the gemini term above.
     settings?.minimaxCookieConfigured === true ||
-    settings?.grokAuthConfigured === true
+    settings?.grokAuthConfigured === true ||
+    settings?.zaiAuthConfigured === true
   )
 }
 
@@ -111,6 +115,10 @@ export function hasUsageProviderSettingsForProvider(
   }
   if (providerId === 'grok') {
     return settings.grokAuthConfigured === true
+  }
+  if (providerId === 'zai') {
+    // Why: Z.AI credentials live in opencode's auth store; main reports them per poll.
+    return settings.zaiAuthConfigured === true
   }
   return false
 }
@@ -165,7 +173,8 @@ export function isUsageEmptyState(
     isProviderSnapshotPending(providers.kimi) ||
     antigravitySnapshotPending ||
     isProviderSnapshotPending(providers.minimax) ||
-    isProviderSnapshotPending(providers.grok)
+    isProviderSnapshotPending(providers.grok) ||
+    isProviderSnapshotPending(providers.zai)
   ) {
     return false
   }
@@ -178,6 +187,7 @@ export function isUsageEmptyState(
     !isProviderConfigured(providers.kimi) &&
     !isProviderConfigured(providers.antigravity) &&
     !isProviderConfigured(providers.minimax) &&
-    !isProviderConfigured(providers.grok)
+    !isProviderConfigured(providers.grok) &&
+    !isProviderConfigured(providers.zai)
   )
 }

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -4,7 +4,7 @@ import {
   formatResetDuration
 } from '../../../../shared/rate-limit-reset-format'
 import { AgentIcon } from '@/lib/agent-catalog'
-import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from './icons'
+import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon, ZaiIcon } from './icons'
 import { translate } from '@/i18n/i18n'
 import {
   getProviderDisplayName,
@@ -96,6 +96,9 @@ export function ProviderIcon({ provider }: { provider: string }): React.JSX.Elem
   }
   if (provider === 'grok') {
     return <AgentIcon agent="grok" size={13} />
+  }
+  if (provider === 'zai') {
+    return <ZaiIcon size={13} />
   }
   return <ClaudeIcon size={13} />
 }

--- a/src/renderer/src/components/status-bar/usage-error-copy.test.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.test.ts
@@ -4,7 +4,8 @@ vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
-import { getProviderDisplayName } from './usage-error-copy'
+import { getProviderDisplayName, getProviderUsageErrorMessage } from './usage-error-copy'
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 
 describe('getProviderDisplayName', () => {
   it('returns the Antigravity brand name', () => {
@@ -13,6 +14,10 @@ describe('getProviderDisplayName', () => {
 
   it('returns the MiniMax brand name', () => {
     expect(getProviderDisplayName('minimax')).toBe('MiniMax')
+  })
+
+  it('returns the Z.AI brand name', () => {
+    expect(getProviderDisplayName('zai')).toBe('Z.AI')
   })
 
   it('returns the existing provider brand names', () => {
@@ -28,5 +33,36 @@ describe('getProviderDisplayName', () => {
     // Why: provider id is a closed union, but TypeScript may not enforce
     // exhaustiveness on dynamic callers. Fallback keeps logging safe.
     expect(getProviderDisplayName('unknown-provider' as never)).toBe('unknown-provider')
+  })
+})
+
+describe('getProviderUsageErrorMessage for Z.AI', () => {
+  function zaiSnapshot(
+    error: string | null,
+    failureKind?: NonNullable<ProviderRateLimits['usageMetadata']>['failureKind']
+  ): ProviderRateLimits {
+    return {
+      provider: 'zai',
+      session: null,
+      weekly: null,
+      updatedAt: 0,
+      error,
+      status: 'error',
+      ...(failureKind ? { usageMetadata: { source: 'web', failureKind } } : {})
+    }
+  }
+
+  it('instructs opencode auth login with the Z.AI Coding Plan on auth failures', () => {
+    // Why: typed failure metadata must drive recovery even if backend copy changes.
+    const message = getProviderUsageErrorMessage(zaiSnapshot('Credential rejected', 'stale-token'))
+
+    expect(message).toContain('opencode auth login')
+    expect(message).toContain('Z.AI Coding Plan')
+  })
+
+  it('passes non-auth Z.AI failures through untouched', () => {
+    expect(getProviderUsageErrorMessage(zaiSnapshot('network request failed', 'network'))).toBe(
+      'network request failed'
+    )
   })
 })

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -26,6 +26,9 @@ export function getProviderDisplayName(provider: ProviderRateLimits['provider'])
   if (provider === 'grok') {
     return 'Grok'
   }
+  if (provider === 'zai') {
+    return 'Z.AI'
+  }
   return provider
 }
 
@@ -181,6 +184,17 @@ export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
   }
   if (isUsageRateLimitError(p.error)) {
     return p.error
+  }
+  if (
+    p.provider === 'zai' &&
+    (p.usageMetadata?.failureKind === 'stale-token' ||
+      p.usageMetadata?.failureKind === 'missing-credentials')
+  ) {
+    // Why: Z.AI usage reads opencode's credential store; re-auth happens in the opencode CLI, not Orca.
+    return translate(
+      'auto.components.status.bar.tooltip.zaiAuthRecovery',
+      'Run opencode auth login in a terminal, choose Z.AI Coding Plan, and complete sign-in, then retry usage.'
+    )
   }
   if (isUsageAuthError(p.error)) {
     const name = getProviderDisplayName(p.provider)

--- a/src/renderer/src/components/status-bar/usage-provider-settings-target.test.ts
+++ b/src/renderer/src/components/status-bar/usage-provider-settings-target.test.ts
@@ -15,4 +15,10 @@ describe('getUsageProviderAccountsSectionId', () => {
   it('does not invent an Accounts section for CLI-owned Kimi credentials', () => {
     expect(getUsageProviderAccountsSectionId('kimi')).toBeNull()
   })
+
+  it('does not invent an Accounts section for Z.AI because opencode auth owns it', () => {
+    // Why: Z.AI re-auth happens via `opencode auth login`, so there is no Orca
+    // Accounts section to open for it.
+    expect(getUsageProviderAccountsSectionId('zai')).toBeNull()
+  })
 })

--- a/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
+++ b/src/renderer/src/components/status-bar/usage-provider-settings-target.ts
@@ -19,7 +19,8 @@ export function getUsageProviderAccountsSectionId(
     case 'grok':
       return 'accounts-grok'
     case 'kimi':
-      // Why: Orca must not mutate Kimi's CLI-owned credential lifecycle.
+    case 'zai':
+      // Why: credentials are CLI-owned (Kimi CLI, opencode auth) — Orca must not mutate them.
       return null
   }
 }

--- a/src/renderer/src/components/status-bar/usage-roster-order.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-order.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  ProviderRateLimits,
+  ProviderRateLimitStatus
+} from '../../../../shared/rate-limit-types'
+import { buildUsageRosterProviders } from './usage-roster-order'
+
+function snapshot(provider: ProviderRateLimits['provider']): ProviderRateLimits {
+  const status: ProviderRateLimitStatus = 'ok'
+  return {
+    provider,
+    session: null,
+    weekly: null,
+    updatedAt: 0,
+    error: null,
+    status
+  }
+}
+
+describe('buildUsageRosterProviders', () => {
+  it('orders the roster Claude, Codex, Z.AI, then the existing providers', () => {
+    const roster = buildUsageRosterProviders({
+      claude: snapshot('claude'),
+      codex: snapshot('codex'),
+      zai: snapshot('zai'),
+      gemini: snapshot('gemini'),
+      antigravity: snapshot('antigravity'),
+      opencodeGo: snapshot('opencode-go'),
+      kimi: snapshot('kimi'),
+      minimax: snapshot('minimax'),
+      grok: snapshot('grok')
+    })
+
+    expect(roster.map((p) => p.provider)).toEqual([
+      'claude',
+      'codex',
+      'zai',
+      'gemini',
+      'antigravity',
+      'opencode-go',
+      'kimi',
+      'minimax',
+      'grok'
+    ])
+  })
+
+  it('keeps Z.AI ahead of the remaining providers and drops hidden slots', () => {
+    const roster = buildUsageRosterProviders({
+      claude: null,
+      codex: snapshot('codex'),
+      zai: snapshot('zai'),
+      gemini: null,
+      antigravity: null,
+      opencodeGo: snapshot('opencode-go'),
+      kimi: null,
+      minimax: null,
+      grok: null
+    })
+
+    expect(roster.map((p) => p.provider)).toEqual(['codex', 'zai', 'opencode-go'])
+  })
+
+  it('returns an empty roster when every slot is hidden', () => {
+    const roster = buildUsageRosterProviders({
+      claude: null,
+      codex: null,
+      zai: null,
+      gemini: null,
+      antigravity: null,
+      opencodeGo: null,
+      kimi: null,
+      minimax: null,
+      grok: null
+    })
+
+    expect(roster).toEqual([])
+  })
+})

--- a/src/renderer/src/components/status-bar/usage-roster-order.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-order.ts
@@ -1,0 +1,29 @@
+import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+
+export type UsageRosterSlots = {
+  claude: ProviderRateLimits | null
+  codex: ProviderRateLimits | null
+  zai: ProviderRateLimits | null
+  gemini: ProviderRateLimits | null
+  antigravity: ProviderRateLimits | null
+  opencodeGo: ProviderRateLimits | null
+  kimi: ProviderRateLimits | null
+  minimax: ProviderRateLimits | null
+  grok: ProviderRateLimits | null
+}
+
+// Why: the footer roster's provider order is a product decision (Claude, Codex,
+// Z.AI, then the remaining providers), so it lives in one testable place.
+export function buildUsageRosterProviders(slots: UsageRosterSlots): ProviderRateLimits[] {
+  return [
+    slots.claude,
+    slots.codex,
+    slots.zai,
+    slots.gemini,
+    slots.antigravity,
+    slots.opencodeGo,
+    slots.kimi,
+    slots.minimax,
+    slots.grok
+  ].filter((p): p is ProviderRateLimits => p !== null)
+}

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { useAppStore } from '../../store'
 import { selectFloatingWorkspaceHasUnread } from '../../store/selectors'
-import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
+import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
 import { normalizeUsagePercentageDisplay } from '../../../../shared/usage-percentage-display'
 import { normalizeStatusBarUsageMode } from '../../../../shared/status-bar-usage-mode'
 import { isStatusBarItemAvailable } from './status-bar-agent-gating'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
+import { buildUsageRosterProviders } from './usage-roster-order'
 import { CLOSE_ALL_CONTEXT_MENUS_EVENT, useStatusBarMenuFocusHandoff } from './ProviderDetailsMenu'
 import { observeStatusBarContainer } from './status-bar-container-observer'
 
@@ -100,6 +101,13 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   }
 
   const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  // Why: Z.AI's snapshot and auth flag arrive from main's RateLimitState; read them
+  // defensively so an older process without the keys stays unconfigured, matching
+  // the renderer-HMR tolerance used for the other provider snapshots.
+  const { zai, zaiAuthConfigured } = rateLimits as RateLimitState & {
+    zai?: ProviderRateLimits | null
+    zaiAuthConfigured?: boolean
+  }
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -112,7 +120,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     ...settings,
     antigravityUsageConfigured,
     minimaxCookieConfigured: rateLimits.minimaxCookieConfigured,
-    grokAuthConfigured: rateLimits.grokAuthConfigured
+    grokAuthConfigured: rateLimits.grokAuthConfigured,
+    zaiAuthConfigured: zaiAuthConfigured === true
   }
   const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
   const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)
@@ -121,6 +130,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const visibleAntigravity = getVisibleUsageProvider('antigravity', antigravity, usageSettings)
   const visibleMiniMax = getVisibleUsageProvider('minimax', minimax, usageSettings)
   const visibleGrok = getVisibleUsageProvider('grok', grok, usageSettings)
+  const visibleZai = getVisibleUsageProvider('zai', zai, usageSettings)
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
@@ -150,6 +160,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
   const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
+  // Why: Z.AI reads opencode's auth store, not a CLI on PATH, so detection-gating doesn't apply.
+  const showZai = visibleZai !== null && statusBarItems.includes('zai')
   const showSsh = statusBarItems.includes('ssh')
   const showResourceUsage = statusBarItems.includes('resource-usage')
   const showPorts = statusBarItems.includes('ports')
@@ -159,6 +171,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const hasVisibleUsageMeters =
     showClaude ||
     showCodex ||
+    showZai ||
     showGemini ||
     showOpencodeGo ||
     showKimi ||
@@ -168,7 +181,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: include Settings so durable managed accounts count — a configured user isn't shown the empty state while snapshots hydrate.
   const isEmptyUsageState = isUsageEmptyState(
-    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
+    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok, zai },
     usageSettings
   )
   // Why: one-time nudge — once dismissed, stays hidden even if providers reconnect later.
@@ -176,6 +189,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const anyFetching =
     claude?.status === 'fetching' ||
     codex?.status === 'fetching' ||
+    zai?.status === 'fetching' ||
     gemini?.status === 'fetching' ||
     opencodeGo?.status === 'fetching' ||
     kimi?.status === 'fetching' ||
@@ -192,16 +206,17 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
 
   // Why: the roster must contain only status items the user left visible;
   // otherwise an empty trigger would bypass those visibility controls.
-  const rosterProviders = [
-    showClaude ? visibleClaude : null,
-    showCodex ? visibleCodex : null,
-    showGemini ? visibleGemini : null,
-    showAntigravity ? visibleAntigravity : null,
-    showOpencodeGo ? visibleOpencodeGo : null,
-    showKimi ? visibleKimi : null,
-    showMiniMax ? visibleMiniMax : null,
-    showGrok ? visibleGrok : null
-  ].filter((p): p is ProviderRateLimits => p !== null)
+  const rosterProviders = buildUsageRosterProviders({
+    claude: showClaude ? visibleClaude : null,
+    codex: showCodex ? visibleCodex : null,
+    zai: showZai ? visibleZai : null,
+    gemini: showGemini ? visibleGemini : null,
+    antigravity: showAntigravity ? visibleAntigravity : null,
+    opencodeGo: showOpencodeGo ? visibleOpencodeGo : null,
+    kimi: showKimi ? visibleKimi : null,
+    minimax: showMiniMax ? visibleMiniMax : null,
+    grok: showGrok ? visibleGrok : null
+  })
 
   const handleManageAccounts = (): void => {
     setUsageMenuOpen(false)

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -3265,7 +3265,8 @@
             "d79c3362c4": "5h",
             "d7a0668acc": "opencode-go",
             "fda8146810": "Open Kimi usage details",
-            "grokUsageAria": "Open Grok usage details"
+            "grokUsageAria": "Open Grok usage details",
+            "zaiUsageAria": "Open Z.AI usage details"
           },
           "WorkspaceSpaceCompactPanel": {
             "2837dc7c72": "cancelling",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -133,7 +133,8 @@
         "resourceUsageToggleDescription": "Show the Resource Manager. Click it for CPU, memory, sessions, daemon controls, and workspace disk scans.",
         "portsToggleDescription": "Show live workspace ports. Click it for workspace-scoped ports and external listeners.",
         "antigravityToggleDescription": "Show Antigravity subscription usage for the active workspace.",
-        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI."
+        "grokToggleDescription": "Show Grok subscription credit usage when signed in via Grok CLI.",
+        "zaiToggleDescription": "Show Z.AI Coding Plan usage when signed in through opencode auth."
       },
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
@@ -3687,6 +3688,8 @@
             "antigravityUsageDetails": "Open Antigravity usage details",
             "grokUsageAria": "Open Grok usage details",
             "grokUsageMenu": "Grok Usage",
+            "zaiUsageAria": "Open Z.AI usage details",
+            "zaiUsageMenu": "Z.AI Usage",
             "floatingTerminalNewActivity": "{{label}}, new activity",
             "codexSignInSuccess": "Signed in to Codex",
             "codexSignInError": "Codex sign-in failed. Please try again."
@@ -3865,6 +3868,7 @@
             "c06c1d215d": "Claude usage could not be refreshed because the network request failed.",
             "cabdc2a9e0": "Claude sign-in credentials could not be read.",
             "a7517cccb6": "Claude usage is unavailable right now.",
+            "zaiAuthRecovery": "Run opencode auth login in a terminal, choose Z.AI Coding Plan, and complete sign-in, then retry usage.",
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
@@ -9042,6 +9046,8 @@
             "antigravityKeyword": "antigravity",
             "f8e2a1c4b6": "Grok Usage",
             "e7d1b0f3a5": "Show Grok weekly credit usage from Grok CLI OAuth.",
+            "zaiUsageTitle": "Z.AI Usage",
+            "zaiUsageDescription": "Show Z.AI Coding Plan usage in the status bar.",
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
@@ -9053,7 +9059,10 @@
               "close": "close",
               "notification": "notification area",
               "background": "background"
-            }
+            },
+            "zaiKeyword": "z.ai",
+            "zaiGlmKeyword": "glm",
+            "zaiOpencodeKeyword": "opencode"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -34,7 +34,8 @@
         "resourceUsageToggleDescription": "Muestra el Administrador de recursos. Haz clic para ver CPU, memoria, sesiones, controles del daemon y análisis de disco de los espacios de trabajo.",
         "portsToggleDescription": "Muestra los puertos activos de los espacios de trabajo. Haz clic para ver los puertos de cada espacio de trabajo y los puertos externos.",
         "antigravityToggleDescription": "Muestra el uso de suscripción de Antigravity para el espacio de trabajo activo.",
-        "grokToggleDescription": "Muestra el uso de créditos de suscripción de Grok cuando has iniciado sesión con Grok CLI."
+        "grokToggleDescription": "Muestra el uso de créditos de suscripción de Grok cuando has iniciado sesión con Grok CLI.",
+        "zaiToggleDescription": "Muestra el uso del plan Z.AI Coding Plan cuando inicias sesión mediante la autenticación de opencode."
       },
       "menuBarIcon": {
         "title": "Mostrar icono en la barra de menús",
@@ -3297,6 +3298,8 @@
             "antigravityUsageDetails": "Abrir detalles de uso de Antigravity",
             "grokUsageAria": "Abrir detalles de uso de Grok",
             "grokUsageMenu": "Uso de Grok",
+            "zaiUsageAria": "Abrir detalles de uso de Z.AI",
+            "zaiUsageMenu": "Uso de Z.AI",
             "floatingTerminalNewActivity": "{{label}}, nueva actividad",
             "codexSignInSuccess": "Sesión iniciada en Codex",
             "codexSignInError": "No se pudo iniciar sesión en Codex. Inténtalo de nuevo."
@@ -3459,6 +3462,7 @@
             "c06c1d215d": "No se pudo actualizar el uso de Claude porque falló la solicitud de red.",
             "cabdc2a9e0": "No se pudieron leer las credenciales de inicio de sesión de Claude.",
             "a7517cccb6": "El uso de Claude no está disponible ahora.",
+            "zaiAuthRecovery": "Ejecuta opencode auth login en una terminal, elige Z.AI Coding Plan, completa el inicio de sesión y vuelve a intentar consultar el uso.",
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
@@ -7935,10 +7939,15 @@
             "antigravityKeyword": "antigravity",
             "f8e2a1c4b6": "Uso de Grok",
             "e7d1b0f3a5": "Muestra el uso semanal de créditos de Grok desde OAuth de Grok CLI.",
+            "zaiUsageTitle": "Uso de Z.AI",
+            "zaiUsageDescription": "Muestra el uso del plan Z.AI Coding Plan en la barra de estado.",
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Porcentajes de uso",
-            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante."
+            "usagePercentageDisplayDescription": "Elige si los límites del proveedor muestran el porcentaje usado o restante.",
+            "zaiKeyword": "z.ai",
+            "zaiGlmKeyword": "glm",
+            "zaiOpencodeKeyword": "opencode"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -34,7 +34,8 @@
         "resourceUsageToggleDescription": "リソースマネージャーを表示します。クリックすると、CPU、メモリ、セッション、デーモンコントロール、ワークスペースディスクスキャンの情報を確認できます。",
         "portsToggleDescription": "ライブワークスペースポートを表示します。ワークスペーススコープのポートと外部リスナーの場合はこれをクリックします。",
         "antigravityToggleDescription": "アクティブなワークスペースの Antigravity サブスクリプション使用量を表示します。",
-        "grokToggleDescription": "Grok CLI でサインインしている場合に Grok サブスクリプションのクレジット使用量を表示します。"
+        "grokToggleDescription": "Grok CLI でサインインしている場合に Grok サブスクリプションのクレジット使用量を表示します。",
+        "zaiToggleDescription": "opencode 認証でサインインしているときに、Z.AI Coding Plan の使用状況を表示します。"
       },
       "menuBarIcon": {
         "title": "メニューバーアイコンを表示",
@@ -3297,6 +3298,8 @@
             "antigravityUsageDetails": "Antigravity の使用状況詳細を開く",
             "grokUsageAria": "Grok の使用状況詳細を開く",
             "grokUsageMenu": "Grok の使用状況",
+            "zaiUsageAria": "Z.AI の使用状況詳細を開く",
+            "zaiUsageMenu": "Z.AI の使用状況",
             "floatingTerminalNewActivity": "{{label}}、新規アクティビティ",
             "codexSignInSuccess": "Codex にサインインしました",
             "codexSignInError": "Codex のサインインに失敗しました。もう一度お試しください。"
@@ -3459,6 +3462,7 @@
             "c06c1d215d": "ネットワークリクエストに失敗したため、Claude 使用量を更新できませんでした。",
             "cabdc2a9e0": "Claude サインイン認証情報を読み取れませんでした。",
             "a7517cccb6": "Claude 使用量は現在利用できません。",
+            "zaiAuthRecovery": "ターミナルで opencode auth login を実行し、Z.AI Coding Plan を選択してサインインを完了してから、使用状況を再試行してください。",
             "e2c6a4f917": "Grok を実行して更新",
             "d1b7f509ac": "Orca を実行しているコンピュータのターミナルで grok を実行し、起動するまで待ってください。サインインを求められた場合は完了してから、使用状況を再取得してください。チャットメッセージを送る必要はありません。",
             "f90b3d7a16": "Kimi を実行して更新",
@@ -7957,10 +7961,15 @@
             "antigravityKeyword": "antigravity",
             "f8e2a1c4b6": "Grok の使用状況",
             "e7d1b0f3a5": "Grok CLI OAuth から Grok の週次クレジット使用量を表示します。",
+            "zaiUsageTitle": "Z.AI の使用状況",
+            "zaiUsageDescription": "ステータスバーに Z.AI Coding Plan の使用状況を表示します。",
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "使用率",
-            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。"
+            "usagePercentageDisplayDescription": "プロバイダーの制限を使用済みまたは残りの割合で表示するかを選択します。",
+            "zaiKeyword": "z.ai",
+            "zaiGlmKeyword": "glm",
+            "zaiOpencodeKeyword": "opencode"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -34,7 +34,8 @@
         "resourceUsageToggleDescription": "리소스 관리자를 표시합니다. 클릭하면 CPU, 메모리, 세션, 데몬 제어, 워크스페이스 디스크 스캔을 볼 수 있습니다.",
         "portsToggleDescription": "라이브 워크스페이스 포트를 표시합니다. 워크스페이스 범위 포트 및 외부 수신기를 보려면 클릭하세요.",
         "antigravityToggleDescription": "활성 워크스페이스에 대한 Antigravity 구독 사용량을 표시합니다.",
-        "grokToggleDescription": "Grok CLI로 로그인한 경우 Grok 구독 크레딧 사용량을 표시합니다."
+        "grokToggleDescription": "Grok CLI로 로그인한 경우 Grok 구독 크레딧 사용량을 표시합니다.",
+        "zaiToggleDescription": "opencode 인증으로 로그인한 경우 Z.AI Coding Plan 사용량을 표시합니다."
       },
       "menuBarIcon": {
         "title": "메뉴 바 아이콘 표시",
@@ -3302,6 +3303,8 @@
             "antigravityUsageDetails": "Antigravity 사용량 세부 정보 열기",
             "grokUsageAria": "Grok 사용량 세부 정보 열기",
             "grokUsageMenu": "Grok 사용량",
+            "zaiUsageAria": "Z.AI 사용량 세부 정보 열기",
+            "zaiUsageMenu": "Z.AI 사용량",
             "floatingTerminalNewActivity": "{{label}}, 새 활동",
             "codexSignInSuccess": "Codex에 로그인했습니다",
             "codexSignInError": "Codex 로그인에 실패했습니다. 다시 시도해 주세요."
@@ -3464,6 +3467,7 @@
             "c06c1d215d": "네트워크 요청 실패로 Claude 사용량을 새로 고칠 수 없습니다.",
             "cabdc2a9e0": "Claude 로그인 자격 증명을 읽을 수 없습니다.",
             "a7517cccb6": "현재 Claude 사용량을 사용할 수 없습니다.",
+            "zaiAuthRecovery": "터미널에서 opencode auth login을 실행하고 Z.AI Coding Plan을 선택하여 로그인을 완료한 후 사용량 조회를 다시 시도하세요.",
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
@@ -7925,10 +7929,15 @@
             "antigravityKeyword": "antigravity",
             "f8e2a1c4b6": "Grok 사용량",
             "e7d1b0f3a5": "Grok CLI OAuth에서 Grok 주간 크레딧 사용량을 표시합니다.",
+            "zaiUsageTitle": "Z.AI 사용량",
+            "zaiUsageDescription": "상태 표시줄에 Z.AI Coding Plan 사용량을 표시합니다.",
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "사용량 백분율",
-            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다."
+            "usagePercentageDisplayDescription": "공급자 한도를 사용한 비율 또는 남은 비율로 표시할지 선택합니다.",
+            "zaiKeyword": "z.ai",
+            "zaiGlmKeyword": "glm",
+            "zaiOpencodeKeyword": "opencode"
           }
         },
         "auto": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -34,7 +34,8 @@
         "resourceUsageToggleDescription": "显示资源管理器。点击可查看 CPU、内存、会话、守护进程控制和工作区磁盘扫描。",
         "portsToggleDescription": "显示实时工作区端口。点击可查看工作区范围的端口和外部监听器。",
         "antigravityToggleDescription": "显示当前工作区的 Antigravity 订阅使用情况。",
-        "grokToggleDescription": "通过 Grok CLI 登录后显示 Grok 订阅额度使用情况。"
+        "grokToggleDescription": "通过 Grok CLI 登录后显示 Grok 订阅额度使用情况。",
+        "zaiToggleDescription": "通过 opencode 认证登录后，显示 Z.AI Coding Plan 的使用情况。"
       },
       "menuBarIcon": {
         "title": "显示菜单栏图标",
@@ -3312,6 +3313,8 @@
             "antigravityUsageDetails": "打开 Antigravity 使用详情",
             "grokUsageAria": "打开 Grok 使用详情",
             "grokUsageMenu": "Grok 使用情况",
+            "zaiUsageAria": "打开 Z.AI 使用详情",
+            "zaiUsageMenu": "Z.AI 使用情况",
             "floatingTerminalNewActivity": "{{label}}，有新活动",
             "codexSignInSuccess": "已登录 Codex",
             "codexSignInError": "Codex 登录失败，请重试。"
@@ -3474,6 +3477,7 @@
             "c06c1d215d": "由于网络请求失败，无法刷新 Claude 用量。",
             "cabdc2a9e0": "无法读取 Claude 登录凭据。",
             "a7517cccb6": "Claude 用量目前不可用。",
+            "zaiAuthRecovery": "在终端中运行 opencode auth login，选择 Z.AI Coding Plan 并完成登录，然后重试用量查询。",
             "e2c6a4f917": "运行 Grok 以刷新",
             "d1b7f509ac": "在运行 Orca 的电脑上的终端中运行 grok，并等待其启动。如有提示，请完成登录，然后重试用量检查。您无需发送聊天消息。",
             "f90b3d7a16": "运行 Kimi 以刷新",
@@ -7968,10 +7972,15 @@
             "antigravityKeyword": "antigravity",
             "f8e2a1c4b6": "Grok 使用情况",
             "e7d1b0f3a5": "显示来自 Grok CLI OAuth 的 Grok 每周额度使用情况。",
+            "zaiUsageTitle": "Z.AI 使用情况",
+            "zaiUsageDescription": "在状态栏中显示 Z.AI Coding Plan 的使用情况。",
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "用量百分比",
-            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。"
+            "usagePercentageDisplayDescription": "选择以已用或剩余百分比显示提供商限额。",
+            "zaiKeyword": "z.ai",
+            "zaiGlmKeyword": "glm",
+            "zaiOpencodeKeyword": "opencode"
           }
         },
         "auto": {

--- a/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
+++ b/src/renderer/src/runtime/runtime-provider-accounts-client.test.ts
@@ -262,6 +262,46 @@ describe('watchProviderAccounts', () => {
     expect(snapshots).toHaveLength(2)
   })
 
+  it('preserves unknown Z.AI state when an old host omits additive fields', async () => {
+    const snapshots: ProviderAccountsSnapshot[] = []
+    watchProviderAccounts(REMOTE, {
+      onSnapshot: (snapshot) => snapshots.push(snapshot),
+      onError: () => {
+        throw new Error('unexpected error')
+      }
+    })
+    await flushMicrotasks()
+
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: {
+        type: 'ready',
+        snapshot: {
+          ...snapshotFixture('old-host'),
+          rateLimits: {
+            claude: null,
+            codex: null,
+            gemini: null,
+            opencodeGo: null,
+            kimi: null,
+            antigravity: null,
+            minimax: null,
+            grok: null,
+            minimaxCookieConfigured: false,
+            grokAuthConfigured: false,
+            claudeTarget: { runtime: 'host', wslDistro: null },
+            codexTarget: { runtime: 'host', wslDistro: null },
+            inactiveClaudeAccounts: [],
+            inactiveCodexAccounts: []
+          }
+        }
+      }
+    })
+
+    expect(snapshots[0]?.rateLimits?.zai).toBeUndefined()
+    expect(snapshots[0]?.rateLimits?.zaiAuthConfigured).toBeUndefined()
+  })
+
   it('surfaces remote subscription failures as errors', async () => {
     const errors: unknown[] = []
     watchProviderAccounts(REMOTE, {

--- a/src/renderer/src/store/slices/rate-limits.test.ts
+++ b/src/renderer/src/store/slices/rate-limits.test.ts
@@ -2,6 +2,7 @@ import { createStore, type StoreApi } from 'zustand/vanilla'
 import { describe, expect, it } from 'vitest'
 import { createRateLimitSlice } from './rate-limits'
 import type { AppState } from '../types'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
 
 function createRateLimitStore(): StoreApi<AppState> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -15,5 +16,57 @@ describe('createRateLimitSlice', () => {
     const store = createRateLimitStore()
 
     expect(store.getState().rateLimits.antigravity).toBeNull()
+  })
+
+  it('initializes the Z.AI snapshot and auth flag as unconfigured', () => {
+    const store = createRateLimitStore()
+
+    expect(store.getState().rateLimits.zai).toBeNull()
+    expect(store.getState().rateLimits.zaiAuthConfigured).toBe(false)
+  })
+
+  it('keeps Z.AI defaults when an old host pushes a payload without the keys', () => {
+    const store = createRateLimitStore()
+    const oldHostPush = {
+      claude: null,
+      codex: null,
+      gemini: null,
+      opencodeGo: null,
+      kimi: null,
+      antigravity: null,
+      minimax: null,
+      grok: null,
+      minimaxCookieConfigured: false,
+      grokAuthConfigured: true,
+      claudeTarget: { runtime: 'host', wslDistro: null },
+      codexTarget: { runtime: 'host', wslDistro: null },
+      inactiveClaudeAccounts: [],
+      inactiveCodexAccounts: []
+    } satisfies RateLimitState
+
+    store.getState().setRateLimitsFromPush(oldHostPush)
+
+    const rateLimits = store.getState().rateLimits
+    expect(rateLimits.zai).toBeNull()
+    expect(rateLimits.zaiAuthConfigured).toBe(false)
+    expect(rateLimits.grokAuthConfigured).toBe(true)
+  })
+
+  it('preserves a new host Z.AI payload through the push path', () => {
+    const store = createRateLimitStore()
+    const zaiSnapshot = {
+      provider: 'zai' as const,
+      session: { usedPercent: 12, windowMinutes: 300, resetsAt: null, resetDescription: null },
+      weekly: null,
+      updatedAt: 1,
+      error: null,
+      status: 'ok' as const
+    }
+
+    store.getState().setRateLimitsFromPush({ zai: zaiSnapshot, zaiAuthConfigured: true } as never)
+
+    const rateLimits = store.getState().rateLimits
+    expect(rateLimits.zai).toMatchObject({ provider: 'zai', status: 'ok' })
+    expect(rateLimits.zaiAuthConfigured).toBe(true)
   })
 })

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -25,6 +25,8 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     antigravity: null,
     minimax: null,
     grok: null,
+    zai: null,
+    zaiAuthConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },
@@ -147,6 +149,13 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
   },
 
   setRateLimitsFromPush: (state) => {
-    set({ rateLimits: state })
+    set({
+      rateLimits: {
+        ...state,
+        // Why: an older paired host's push predates the Z.AI keys; fill the defaults so selectors never see undefined.
+        zai: state.zai ?? null,
+        zaiAuthConfigured: state.zaiAuthConfigured === true
+      }
+    })
   }
 })

--- a/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
+++ b/src/renderer/src/store/slices/ui-hydration-workspace-preferences.test.ts
@@ -139,7 +139,8 @@ describe('createUISlice hydratePersistedUI', () => {
       'kimi',
       'minimax',
       'antigravity',
-      'grok'
+      'grok',
+      'zai'
     ])
     expect(setUI).toHaveBeenCalledWith({
       statusBarItems: [
@@ -149,13 +150,15 @@ describe('createUISlice hydratePersistedUI', () => {
         'kimi',
         'minimax',
         'antigravity',
-        'grok'
+        'grok',
+        'zai'
       ],
       _portsStatusBarDefaultAdded: true,
       _kimiStatusBarDefaultAdded: true,
       _minimaxStatusBarDefaultAdded: true,
       _antigravityStatusBarDefaultAdded: true,
-      _grokStatusBarDefaultAdded: true
+      _grokStatusBarDefaultAdded: true,
+      _zaiStatusBarDefaultAdded: true
     })
   })
 
@@ -171,11 +174,58 @@ describe('createUISlice hydratePersistedUI', () => {
         _kimiStatusBarDefaultAdded: true,
         _minimaxStatusBarDefaultAdded: true,
         _antigravityStatusBarDefaultAdded: true,
-        _grokStatusBarDefaultAdded: true
+        _grokStatusBarDefaultAdded: true,
+        _zaiStatusBarDefaultAdded: true
       })
     )
 
     expect(store.getState().statusBarItems).toEqual(['claude', 'resource-usage'])
+    expect(setUI).not.toHaveBeenCalled()
+  })
+
+  it('inserts the Z.AI status item after Codex in one shot', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        statusBarItems: ['claude', 'codex', 'gemini', 'ports'],
+        _portsStatusBarDefaultAdded: true,
+        _kimiStatusBarDefaultAdded: true,
+        _minimaxStatusBarDefaultAdded: true,
+        _antigravityStatusBarDefaultAdded: true,
+        _grokStatusBarDefaultAdded: true
+      })
+    )
+
+    expect(store.getState().statusBarItems).toEqual(['claude', 'codex', 'zai', 'gemini', 'ports'])
+    expect(setUI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusBarItems: ['claude', 'codex', 'zai', 'gemini', 'ports'],
+        _zaiStatusBarDefaultAdded: true
+      })
+    )
+  })
+
+  it('does not re-insert Z.AI once its one-shot migration has run', () => {
+    const setUI = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+
+    store.getState().hydratePersistedUI(
+      makePersistedUI({
+        statusBarItems: ['claude', 'codex'],
+        _portsStatusBarDefaultAdded: true,
+        _kimiStatusBarDefaultAdded: true,
+        _minimaxStatusBarDefaultAdded: true,
+        _antigravityStatusBarDefaultAdded: true,
+        _grokStatusBarDefaultAdded: true,
+        _zaiStatusBarDefaultAdded: true
+      })
+    )
+
+    expect(store.getState().statusBarItems).toEqual(['claude', 'codex'])
     expect(setUI).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/store/slices/ui/status-bar-default-hydration.ts
+++ b/src/renderer/src/store/slices/ui/status-bar-default-hydration.ts
@@ -1,0 +1,42 @@
+import type { PersistedUIState } from '../../../../../shared/persisted-ui-state-types'
+import type { StatusBarItem } from '../../../../../shared/ui-chrome-types'
+import { migrateStatusBarItems } from './ui-slice-hydration-sanitizers'
+
+const DEFAULT_ON_STATUS_BAR_ITEMS = [
+  ['_portsStatusBarDefaultAdded', 'ports'],
+  ['_kimiStatusBarDefaultAdded', 'kimi'],
+  ['_minimaxStatusBarDefaultAdded', 'minimax'],
+  ['_antigravityStatusBarDefaultAdded', 'antigravity'],
+  ['_grokStatusBarDefaultAdded', 'grok']
+] as const
+
+export function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
+  let items = migrateStatusBarItems(ui.statusBarItems)
+  for (const [flag, item] of DEFAULT_ON_STATUS_BAR_ITEMS) {
+    if (!ui[flag] && !items.includes(item)) {
+      items = [...items, item]
+    }
+  }
+  // Why: Z.AI's roster slot sits after Codex, so its one-shot migration inserts
+  // in place instead of appending like later providers.
+  if (!ui._zaiStatusBarDefaultAdded && !items.includes('zai')) {
+    const codexIndex = items.indexOf('codex')
+    items =
+      codexIndex !== -1
+        ? [...items.slice(0, codexIndex + 1), 'zai', ...items.slice(codexIndex + 1)]
+        : [...items, 'zai']
+  }
+  if (
+    typeof window !== 'undefined' &&
+    (DEFAULT_ON_STATUS_BAR_ITEMS.some(([flag]) => !ui[flag]) || !ui._zaiStatusBarDefaultAdded)
+  ) {
+    window.api.ui
+      .set({
+        statusBarItems: items,
+        ...Object.fromEntries(DEFAULT_ON_STATUS_BAR_ITEMS.map(([flag]) => [flag, true])),
+        _zaiStatusBarDefaultAdded: true
+      })
+      .catch(console.error)
+  }
+  return items
+}

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-actions.ts
@@ -1,6 +1,5 @@
 import type { UISlice, UISliceGet, UISliceSet } from './ui-slice-contract'
 import type { AppState } from '../../types'
-import type { PersistedUIState } from '../../../../../shared/persisted-ui-state-types'
 import { normalizeRightSidebarRoute } from '../../right-sidebar-route'
 import {
   applyManualRepoOrder,
@@ -38,12 +37,10 @@ import { normalizeStatusBarUsageMode } from '../../../../../shared/status-bar-us
 import { normalizeBrowserPageZoomLevel } from '../../../../../shared/browser-page-zoom'
 import { normalizeKagiSessionLink } from '../../../../../shared/browser-url'
 import { isReleaseChannel } from '../../../../../shared/release-channel'
-import type { StatusBarItem } from '../../../../../shared/ui-chrome-types'
 import {
   filterSetupScriptPromptDismissalsToValidRepos,
   sanitizeSetupScriptPromptDismissals
 } from '../../../lib/setup-script-prompt'
-import { isBundledPetId, DEFAULT_PET_ID } from '../../../components/pet/pet-models'
 import { getRepoHostIdentity } from '../repo-host-identity'
 import type { PersistedUIWriteBaseline } from '../persisted-ui-write-baseline'
 import {
@@ -60,40 +57,17 @@ import {
   sanitizeWorkspaceCleanupDismissals,
   sanitizePersistedSidebarWidth,
   hydratedUIPartialMatchesState,
-  migrateStatusBarItems,
   clampPetSize
 } from './ui-slice-hydration-sanitizers'
-import { hydrateAgentReadState, sanitizeTaskResumeState } from './ui-slice-hydration-values'
+import { hydrateStatusBarItems } from './status-bar-default-hydration'
+import {
+  hydrateAgentReadState,
+  hydratePetSelection,
+  sanitizeTaskResumeState
+} from './ui-slice-hydration-values'
 
 const MAX_LEFT_SIDEBAR_WIDTH = 500
 const MAX_RIGHT_SIDEBAR_WIDTH = 4000
-const DEFAULT_ON_PORTS_STATUS_BAR_ITEM: StatusBarItem = 'ports'
-const DEFAULT_ON_KIMI_STATUS_BAR_ITEM: StatusBarItem = 'kimi'
-const DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM: StatusBarItem = 'minimax'
-const DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM: StatusBarItem = 'antigravity'
-const DEFAULT_ON_GROK_STATUS_BAR_ITEM: StatusBarItem = 'grok'
-
-function hydrateStatusBarItems(ui: PersistedUIState): StatusBarItem[] {
-  let items = migrateStatusBarItems(ui.statusBarItems)
-  const defaults = [
-    ['_portsStatusBarDefaultAdded', DEFAULT_ON_PORTS_STATUS_BAR_ITEM],
-    ['_kimiStatusBarDefaultAdded', DEFAULT_ON_KIMI_STATUS_BAR_ITEM],
-    ['_minimaxStatusBarDefaultAdded', DEFAULT_ON_MINIMAX_STATUS_BAR_ITEM],
-    ['_antigravityStatusBarDefaultAdded', DEFAULT_ON_ANTIGRAVITY_STATUS_BAR_ITEM],
-    ['_grokStatusBarDefaultAdded', DEFAULT_ON_GROK_STATUS_BAR_ITEM]
-  ] as const
-  for (const [flag, item] of defaults) {
-    if (!ui[flag] && !items.includes(item)) {
-      items = [...items, item]
-    }
-  }
-  if (typeof window !== 'undefined' && defaults.some(([flag]) => !ui[flag])) {
-    window.api.ui
-      .set({ statusBarItems: items, ...Object.fromEntries(defaults.map(([flag]) => [flag, true])) })
-      .catch(console.error)
-  }
-  return items
-}
 
 export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Partial<UISlice> {
   return {
@@ -105,13 +79,7 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
         const validRepoHostIdentities = new Set(s.repos.map(getRepoHostIdentity))
         const persistedFilterRepoIds = sanitizePersistedRepoIds(ui.filterRepoIds)
         const persistedAgentsFilterRepoIds = sanitizePersistedRepoIds(ui.agentsFilterRepoIds)
-        // Why: pre-rename builds used sidekick* keys; read as fallback only so new pet* writes win after upgrade.
-        const customPets = Array.isArray(ui.customPets)
-          ? ui.customPets
-          : Array.isArray(ui.customSidekicks)
-            ? ui.customSidekicks
-            : []
-        const petId = ui.petId ?? ui.sidekickId
+        const { customPets, petId } = hydratePetSelection(ui)
         // Migration: one-shot old-'recent'→'smart' runs in main (_sortBySmartMigrated), not here, so a deliberate 'recent' choice survives restart.
         const sortBy = ui.sortBy
         const statusBarItemsWithGrok = hydrateStatusBarItems(ui)
@@ -210,20 +178,7 @@ export function createUiHydrationActions(set: UISliceSet, _get: UISliceGet): Par
             fallback: PET_SIZE_DEFAULT
           }),
           customPets,
-          // Why: fall back to default when the persisted id is unknown (e.g. custom pet removed elsewhere) so the overlay renders.
-          petId: ((): string => {
-            const id = petId
-            if (typeof id !== 'string') {
-              return DEFAULT_PET_ID
-            }
-            if (isBundledPetId(id)) {
-              return id
-            }
-            if (customPets.some((m) => m.id === id)) {
-              return id
-            }
-            return DEFAULT_PET_ID
-          })(),
+          petId,
           dismissedUpdateVersion: ui.dismissedUpdateVersion ?? null,
           // Why: a persisted value from a build that knew a different channel set
           // would otherwise survive as-is; activeChannel only falls back on null,

--- a/src/renderer/src/store/slices/ui/ui-slice-hydration-values.ts
+++ b/src/renderer/src/store/slices/ui/ui-slice-hydration-values.ts
@@ -2,6 +2,7 @@ import type { PersistedUIState } from '../../../../../shared/persisted-ui-state-
 import type { TaskResumeState, TaskViewPresetId } from '../../../../../shared/ui-chrome-types'
 import type { FeatureInteractionState } from '../../../../../shared/feature-interactions'
 import type { ContextualTourId } from '../../../../../shared/contextual-tours'
+import { isBundledPetId, DEFAULT_PET_ID } from '../../../components/pet/pet-models'
 import { normalizeFeatureInteractions } from '../../../../../shared/feature-interactions'
 import { normalizeContextualTourIds } from '../../../../../shared/contextual-tours'
 import type { UISlice } from './ui-slice-contract'
@@ -10,6 +11,25 @@ import {
   sanitizeActivityClearedAtByPaneKey,
   sanitizePaneKeyTimestampRecord
 } from './ui-slice-hydration-sanitizers'
+
+export function hydratePetSelection(ui: PersistedUIState): {
+  customPets: NonNullable<PersistedUIState['customPets']>
+  petId: string
+} {
+  // Why: pre-rename builds used sidekick* keys; new pet* writes win after upgrade.
+  const customPets = Array.isArray(ui.customPets)
+    ? ui.customPets
+    : Array.isArray(ui.customSidekicks)
+      ? ui.customSidekicks
+      : []
+  const candidate = ui.petId ?? ui.sidekickId
+  const petId =
+    typeof candidate === 'string' &&
+    (isBundledPetId(candidate) || customPets.some((pet) => pet.id === candidate))
+      ? candidate
+      : DEFAULT_PET_ID
+  return { customPets, petId }
+}
 
 const VALID_TASK_PRESETS = new Set<TaskViewPresetId>([
   'all',

--- a/src/renderer/src/web/preload-api/web-rate-limits-api.ts
+++ b/src/renderer/src/web/preload-api/web-rate-limits-api.ts
@@ -12,6 +12,8 @@ export function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimi
     antigravity: null,
     minimax: null,
     grok: null,
+    zai: null,
+    zaiAuthConfigured: false,
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/shared/persisted-ui-state-types.ts
+++ b/src/shared/persisted-ui-state-types.ts
@@ -116,6 +116,8 @@ export type PersistedUIState = {
   _antigravityStatusBarDefaultAdded?: boolean
   /** One-shot migration flag for adding the default-on Grok status item. */
   _grokStatusBarDefaultAdded?: boolean
+  /** One-shot migration flag for inserting the default-on Z.AI status item after Codex. */
+  _zaiStatusBarDefaultAdded?: boolean
   statusBarItems: StatusBarItem[]
   statusBarVisible: boolean
   /** Why: this is client-side presentation, not a provider/account or execution-host setting. */

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -55,6 +55,7 @@ export type ProviderRateLimits = {
     | 'minimax'
     | 'grok'
     | 'antigravity'
+    | 'zai'
   /** 5-hour session window, null if not available. */
   session: RateLimitWindow | null
   /** 7-day weekly window, null if not available. */
@@ -124,6 +125,17 @@ export type RateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  /**
+   * Z.AI Coding Plan snapshot. Optional on the wire: hosts from before the
+   * Z.AI integration omit it, so consumers must treat a missing key as
+   * "unconfigured" rather than a settled null snapshot.
+   */
+  zai?: ProviderRateLimits | null
+  /**
+   * True when main found a Z.AI Coding Plan key in opencode's auth store.
+   * Optional on the wire for the same old-host reason as `zai`.
+   */
+  zaiAuthConfigured?: boolean
   /**
    * True when a MiniMax session cookie is persisted on disk. The cookie lives
    * outside GlobalSettings, so this flag is the durable signal that the

--- a/src/shared/status-bar-defaults.ts
+++ b/src/shared/status-bar-defaults.ts
@@ -3,6 +3,7 @@ import type { StatusBarItem } from './ui-chrome-types'
 export const DEFAULT_STATUS_BAR_ITEMS: StatusBarItem[] = [
   'claude',
   'codex',
+  'zai',
   'gemini',
   'antigravity',
   'opencode-go',

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -56,6 +56,7 @@ export type { ActivityGroupBy, ThreadReadFilter } from './agents-view-thread-fil
 export type StatusBarItem =
   | 'claude'
   | 'codex'
+  | 'zai'
   | 'gemini'
   | 'antigravity'
   | 'opencode-go'

--- a/tests/e2e/status-bar-caffeinate.spec.ts
+++ b/tests/e2e/status-bar-caffeinate.spec.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { ElectronApplication } from '@stablyai/playwright-test'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
 import { readHookEndpoint } from './helpers/agent-hook-endpoint'
@@ -26,6 +26,39 @@ async function postCodexHookEvent(
     })
   })
   expect(response.status).toBe(204)
+}
+
+// Why: only 'zai' is checked, so every usage meter in the status bar belongs to
+// the synthetic snapshot and percentage assertions cannot collide with real CLIs.
+async function seedZaiUsage(orcaPage: Page): Promise<void> {
+  await orcaPage.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    store.setState({
+      statusBarItems: ['zai'],
+      statusBarUsageMode: 'verbose',
+      usagePercentageDisplay: 'used',
+      rateLimits: {
+        ...store.getState().rateLimits,
+        zai: {
+          provider: 'zai',
+          session: {
+            usedPercent: 37,
+            windowMinutes: 300,
+            resetsAt: null,
+            resetDescription: null
+          },
+          weekly: null,
+          updatedAt: Date.now(),
+          error: null,
+          status: 'ok'
+        },
+        zaiAuthConfigured: true
+      }
+    })
+  })
 }
 
 test('shows keep-awake mode and Agent activity in the status bar', async ({
@@ -69,4 +102,60 @@ test('shows keep-awake mode and Agent activity in the status bar', async ({
 
   await postCodexHookEvent(electronApp, paneKey, 'Stop')
   await expect(agentInactiveStatus).toBeVisible()
+})
+
+test('renders synthetic Z.AI usage across status bar modes', async ({ orcaPage }) => {
+  await waitForSessionReady(orcaPage)
+  await seedZaiUsage(orcaPage)
+
+  const usageTrigger = orcaPage.getByRole('button', { name: 'Usage', exact: true })
+
+  // Normal: verbose density with used-percentage display.
+  await expect(usageTrigger).toBeVisible()
+  await expect(usageTrigger).toContainText('37%')
+
+  // Remaining: the same window flips to % remaining.
+  await orcaPage.evaluate(() => {
+    window.__store?.setState({ usagePercentageDisplay: 'remaining' })
+  })
+  await expect(usageTrigger).toContainText('63%')
+  await expect(usageTrigger).not.toContainText('37%')
+  await orcaPage.evaluate(() => {
+    window.__store?.setState({ usagePercentageDisplay: 'used' })
+  })
+  await expect(usageTrigger).toContainText('37%')
+
+  // Detailed: the roster popover lists the Z.AI row with both its identity and windows.
+  await usageTrigger.click()
+  const rosterRow = orcaPage.locator('[data-usage-mode="verbose"]', { hasText: 'Z.AI' })
+  await expect(rosterRow).toBeVisible()
+
+  // Compact: roster density collapses to the tightest window only.
+  await orcaPage.evaluate(() => {
+    window.__store?.setState({ statusBarUsageMode: 'compact' })
+  })
+  await expect(orcaPage.locator('[data-usage-mode="compact"]', { hasText: 'Z.AI' })).toBeVisible()
+  await orcaPage.keyboard.press('Escape')
+  await expect(usageTrigger).toContainText('37%')
+
+  // Icon-only: a narrow window swaps meters for the single-letter Z badge.
+  await orcaPage.setViewportSize({ width: 420, height: 800 })
+  const zaiBadge = orcaPage.getByTitle('Z.AI')
+  await expect(zaiBadge).toBeVisible()
+  await expect(zaiBadge).toContainText('Z')
+  await orcaPage.setViewportSize({ width: 1280, height: 800 })
+  await expect(usageTrigger).toContainText('37%')
+
+  // Toggle: the visibility menu item must be focused explicitly before Enter —
+  // Radix checkbox items do not reliably activate from a pointerless click.
+  await usageTrigger.click({ button: 'right' })
+  const zaiToggle = orcaPage.getByRole('menuitemcheckbox', { name: 'Z.AI Usage' })
+  await expect(zaiToggle).toBeVisible()
+  await expect(zaiToggle).toBeChecked()
+  await zaiToggle.focus()
+  await orcaPage.keyboard.press('Enter')
+  await expect(zaiToggle).not.toBeChecked()
+  await orcaPage.keyboard.press('Escape')
+  // Why: zai was the only checked provider, so unchecking it unmounts the usage trigger entirely.
+  await expect(usageTrigger).toBeHidden()
 })


### PR DESCRIPTION
## What Changed

- Adds first-class Z.AI GLM Coding Plan quota monitoring through Orca’s shared rate-limit pipeline.
- Reads only the explicit `zai-coding-plan` API-key record from OpenCode `auth.json` and sends one read-only quota request to the configured global or China origin.
- Displays Z.AI after Claude and Codex in the footer with 5-hour and weekly windows, compact/detailed modes, visibility controls, localized recovery guidance, and a one-shot default-on migration.
- Adds mixed-version, credential-safety, parser, stale/backoff, service-isolation, persistence, renderer, and Electron E2E coverage.

## Why

GLM Coding Plan users currently need to leave Orca to check quota. This reuses the existing usage roster while preserving OpenCode credential ownership and treating missing or unfamiliar quota data as unknown rather than falsely showing 0%.

## Linked Issue

Fixes #18506

## Visual Proof

Validated by the deterministic Electron status-bar E2E at normal, compact, and icon-only widths, and with a signed local macOS build manually tested by the requester. The E2E asserts the visible Z.AI row, 5-hour and weekly windows, compact meter, icon badge, keyboard focus, and visibility toggle.

## Testing

- [x] I manually tested these changes locally on macOS
- [x] Automated tests added/updated

- `pnpm tc` — passed on current upstream `main`
- 222 focused tests — passed on current upstream `main`
- `pnpm run check:code-quality:changed` — feature branch passed with 0 findings before rebasing; after rebasing, the repo-wide baseline comparison reports one unrelated pre-existing finding in `mobile/src/session/use-mobile-session-terminal-create-actions.test.ts`
- Electron status-bar E2E — 2/2 passed
- `pnpm build:mac` — signed arm64 and x64 DMG/ZIP artifacts produced

## Review

- Independent plan-compliance and adversarial security/UX reviews found no critical/high issues.
- Keys remain main-process-only; there are no auth-file writes, inference calls, region probes, environment-key fallbacks, or secret-bearing errors.
- `RateLimitState` additions are optional for old-host compatibility.
- Z.AI visibility is credential/snapshot based and deliberately not PATH gated.

## Parallel implementation

PR #18507 addresses the same issue. This PR is an independently developed, hardened alternative with explicit OpenCode credential ownership, a strict global/CN origin allowlist, no in-app key-entry/account surface, stale/backoff integration, additive old-host compatibility, one-shot migration behavior, and broader regression coverage. Maintainers may prefer or combine either approach.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Z.AI’s official usage plugin uses the monitor endpoint, but it is not a documented stable public REST contract. Parsing is isolated and fails unknown instead of displaying false zero usage.
- OpenCode credentials are read on the execution host; no unbounded WSL/UNC or remote credential scans are performed.

## Checklist

- [x] This PR is focused on Z.AI quota monitoring
- [x] I explained what changed and why
- [x] Visual behavior validated through deterministic Electron E2E and a local macOS build
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, mobile, and backwards-compatibility impact considered
- [x] Typecheck, focused tests, pre-commit lint/format, and macOS build pass
