### PR TITLE
fix: run archive hook for SSH CLI worktree removal

### DIFF
--- a/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
+++ b/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
@@ -848,27 +848,32 @@ Include the manifest path/schema, exact provider commands, Codex managed-home re
 After the `/srv/script` copy and focused tests pass, refresh the live managed
 scripts through the supported CLI. `agent hooks on` alone does not guarantee a
 refresh: `src/cli/handlers/agent-hooks.ts:setAgentHooksEnabled()` calls
-`updateRunningRuntime()`, which sends `settings.update` with
-`agentStatusHooksEnabled: true`; when a reachable runtime already has that
-setting `true`, `src/main/ipc/settings.ts`'s `hookSettingChanged` guard is
-false, `applyAgentStatusHooksEnabled()`/`installManagedAgentHooks()` is never
-called, and the CLI falls through to `getManagedAgentHookStatuses()`, a
-read-only status probe. Since hooks are already enabled in the normal
-operator flow, this is the common case, not an edge case. Force the actual
-state transition instead: run `agent hooks off` immediately followed by
-`agent hooks on`. Both calls change `agentStatusHooksEnabled`, so
-`hookSettingChanged` is true both times, `applyAgentStatusHooksEnabled(true, …)`
-runs, and `installManagedAgentHooks()`'s unconditional
-`refreshExistingManagedScripts()` regenerates the Claude/Codex managed
-scripts from the amended source before the presence-gated install step. When
-the runtime is unreachable, the CLI's offline `setAgentHooksEnabled()` path
-calls `applyAgentStatusHooksEnabled()` directly on every invocation and does
-not need the off/on toggle. The raw OMP recovery extension is not installed
-by this managed-hook refresh; the live setup hook installs it under the OMP
-agent directory's `extensions` child and selects it through
-`ORCA_OMP_STATUS_EXTENSION`. Do not treat `agent hooks status` or a single
-`agent hooks on` against an already-enabled reachable runtime as deployment
-or refresh.
+`updateRunningRuntime()`, which sends the `settings.update` RPC with
+`agentStatusHooksEnabled: true` through
+`src/main/runtime/rpc/methods/client-ui.ts`'s `settings.update` method into
+`runtime.updateClientSettings()`. That resolves to
+`src/main/runtime/runtime-client-settings.ts:RuntimeClientSettings.update()`,
+which reconciles managed hooks only when
+`before !== updates.agentStatusHooksEnabled` (or the disabled-agent set
+changes); when a reachable runtime already has that setting `true`, this gate
+is false, `reconcileManagedAgentHooks()`/`applyAgentStatusHooksEnabled()`/
+`installManagedAgentHooks()` is never called, and the CLI falls through to
+`getManagedAgentHookStatuses()`, a read-only status probe. Since hooks are
+already enabled in the normal operator flow, this is the common case, not an
+edge case. Force the actual state transition instead: run `agent hooks off`
+immediately followed by `agent hooks on`. Both calls change
+`agentStatusHooksEnabled`, so the gate is true both times,
+`applyAgentStatusHooksEnabled(true, …)` runs, and
+`installManagedAgentHooks()`'s unconditional `refreshExistingManagedScripts()`
+regenerates the Claude/Codex managed scripts from the amended source before
+the presence-gated install step. When the runtime is unreachable, the CLI's
+offline `setAgentHooksEnabled()` path calls `applyAgentStatusHooksEnabled()`
+directly on every invocation and does not need the off/on toggle. The raw OMP
+recovery extension is not installed by this managed-hook refresh; the live
+setup hook installs it under the OMP agent directory's `extensions` child and
+selects it through `ORCA_OMP_STATUS_EXTENSION`. Do not treat `agent hooks
+status` or a single `agent hooks on` against an already-enabled reachable
+runtime as deployment or refresh.
 
 Verify the resulting artifacts and returned statuses before updating the live setup hook:
 

--- a/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
+++ b/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
@@ -4,11 +4,11 @@
 
 **Goal:** Make every local OCI Git worktree recoverable after an OCI/tmux restart by having the setup hook create one deterministic four-window tmux session (`codex`, `claude`, `omp`, `bash`) and having the coordinator resume each provider exactly once from provider-native session locators persisted in a path-bound manifest.
 
-**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and OMP hook installation. Claude/Codex raw recorders run only after their provider-specific exclusion guards, may pass captured provider payloads to a host-local writer, and the writer mutates the manifest only for `SessionStart`. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch.
+**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and explicit OMP extension selection. Claude/Codex raw recorders run only after their provider-specific exclusion guards, may pass captured provider payloads to a host-local writer, and the writer mutates the manifest only for `SessionStart`. The OMP recovery extension rereads its native session identity on each context-bearing lifecycle callback and records only a durable session ID. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch.
 
 **Tech Stack:** Bash, tmux, jq, `realpath`, `sha256sum`, `flock`, TypeScript-generated POSIX hook scripts, Bun OMP hooks, the existing `/srv/script/orca-coordinator.sh` JSON CLI integration, Vitest, ShellCheck.
 
-**Review basis:** The approved design is recorded in `docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md`. The final standalone web GPT contract review returned `APPROVE` / `NONE` from the revised summary; it was a contract review, not independent repository inspection. The implementation must therefore retain the local source facts below, especially Codex's redirected `CODEX_HOME`, OMP's native `sessionManager` APIs, and the existing setup-hook source-of-truth boundary.
+**Review basis:** The design is recorded in `docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md`. Follow-up source review confirmed the linked-worktree identity rules, provider hook order, Codex artifact split, Claude parser probe, OMP extension installation path, OMP lifecycle behavior, provider ID trust boundary, OMP ID-based resume contract, and the supported managed-hook reconciliation entrypoints recorded below. The implementation must retain the local source facts for Codex's redirected `CODEX_HOME`, OMP's `sessionManager` APIs, the existing OMP extension wrapper, and the setup-hook source-of-truth boundary.
 
 ---
 
@@ -31,7 +31,7 @@
   - `src/main/claude/hook-service.test.ts`
   - `src/main/codex/codex-hook-script.ts`
   - `src/main/codex/hook-service-managed-install.test.ts`
-- Keep the approved design specification unchanged unless implementation evidence exposes a real contract error; update the plan or spec before coding if that happens.
+- Keep the design specification and this plan synchronized; source evidence from the follow-up review is incorporated below before coding.
 - Do not change Dashboard, AgentMap, managed-worker registration, terminal ownership, IPC, RPC, stream frames, or remote wire contracts. A raw tmux pane is never an Orca-managed worker.
 - Do not auto-migrate an existing one-window or otherwise legacy session. Existing sessions are left untouched; the documented operator action is archive and recreate once.
 - Do not infer provider locators from terminal text, pane order, mtimes, recent-session pickers, `--last`, `--continue`, or a fresh provider launch.
@@ -54,17 +54,17 @@
 
 - `/srv/script/orca-worktree-session-manifest.sh` — host-local `record` command. Validates canonical worktree/root identity, including linked-worktree `--git-common-dir` ownership and exact manifest path, extracts native Claude/Codex JSON identifiers or accepts OMP's native identifier arguments, serializes concurrent updates with `flock`, and publishes mode-0600 JSON through temp-file plus atomic rename.
 - `/srv/script/orca-worktree-session-manifest.test.sh` — isolated manifest writer, path-binding, linked-worktree identity, permissions, concurrency, malformed-input, and moved-worktree tests.
-- `/srv/script/orca-omp-worktree-session-hook.ts` — OMP auto-discovered `session_start` hook. Reads `ctx.sessionManager.getSessionId()` and optional `ctx.sessionManager.getSessionFile()`, then invokes the manifest writer with the tmux session's exact environment context.
-- `/srv/script/orca-omp-worktree-session-hook.test.sh` — Bun harness that registers the hook with a fake HookAPI and verifies the native OMP callback arguments sent to a fake writer.
+- `/srv/script/orca-omp-worktree-session-hook.ts` — OMP recovery extension loaded through the existing explicit `ORCA_OMP_STATUS_EXTENSION`/`omp --extension` path. It rereads `ctx.sessionManager.getSessionId()` and uses `getSessionFile()` only to distinguish durable sessions; it records the current native ID on each supported lifecycle callback.
+- `/srv/script/orca-omp-worktree-session-hook.test.sh` — Bun harness that registers the extension's lifecycle callbacks with a fake HookAPI and verifies repeated native OMP IDs sent to a fake writer.
 - `src/main/agent-hooks/oci-worktree-session-event.ts` — shared POSIX shell-line generator for guarded raw-tmux provider-payload recording; no endpoint, pane key, or UI relay dependency.
 - `src/main/agent-hooks/oci-worktree-session-event.test.ts` — exact generated-line contract, provider-exclusion ordering, ordinary-event no-op, and platform guard tests.
 
 ### Modify
 
-- `/srv/script/orca-tmux-hook.sh` — create and validate the four-window layout, install the OMP hook, set session-scoped raw recovery environment, and remove partially created sessions on layout failure.
-- `/srv/script/orca-tmux-hook.test.sh` — assert exact ordered windows, session/pane paths, env values, idempotency, mismatch fail-closed behavior, and partial-layout cleanup.
+- `/srv/script/orca-tmux-hook.sh` — create and validate the four-window layout, install/select the OMP recovery extension, set session-scoped raw recovery environment, and remove partially created sessions on layout failure.
+- `/srv/script/orca-tmux-hook.test.sh` — assert exact ordered windows, session/pane paths, env values including `ORCA_OMP_STATUS_EXTENSION`, idempotency, mismatch fail-closed behavior, and partial-layout cleanup.
 - `/srv/script/orca-coordinator.sh` — preserve current coordinator/hpv2 behavior while replacing worktree's old single Codex `--last` bootstrap with observed-new-session provider recovery and exact preflighted commands.
-- `/srv/script/orca-coordinator.test.sh` — add fake provider binaries, manifests, flag preflight, one-shot, failure, and `RESUME_AGENTS=0` cases without weakening current liveness checks.
+- `/srv/script/orca-coordinator.test.sh` — add fake provider binaries, manifests, flag preflight, one-shot, failure, invalid-ID, and `RESUME_AGENTS=0` cases without weakening current liveness checks.
 - `/srv/script/projects/orca.md` — document the OCI recovery contract, operational backup/hashes, manifest location, provider flags, `RECOVERY_REQUIRED`, and archive/recreate procedure.
 - `src/main/claude/hook-service.ts` — add the shared raw-tmux recorder after the existing Devin/`CLAUDE_JOB_DIR` exclusions and before endpoint-dependent logic, while preserving the neutral JSON output, endpoint refresh, and normal Orca spool/post path.
 - `src/main/claude/hook-service.test.ts` — verify the shared POSIX managed script at `~/.orca/agent-hooks/claude-hook.sh` contains the recorder after exclusions and executes the raw native SessionStart branch without changing existing user settings behavior.
@@ -73,8 +73,7 @@
 
 ### Do not modify
 
-- `src/shared/agent-session-resume.ts` and `src/shared/tui-agent-resume-startup.ts`; their already verified provider argv mapping is the command contract this feature consumes.
-- `src/main/agent-hooks/managed-agent-hook-registry.ts`; raw OMP installation is host-local auto-discovery, not a managed Orca worker hook.
+- `src/main/agent-hooks/managed-agent-hook-registry.ts`; the raw OMP extension is a host-local explicit `ORCA_OMP_STATUS_EXTENSION` selection, not a managed Orca worker hook.
 - `src/renderer/src/**`; there is no UI change.
 - `/srv/script/AGENTS.md` and `/home/ai/.codex/AGENTS.md`; they remain host/project policy.
 
@@ -143,6 +142,7 @@ ORCA_OCI_SESSION_MANIFEST=canonical manifest path
 ORCA_OCI_WORKTREE_PATH=canonical worktree path
 ORCA_OCI_REPO_ROOT=canonical repository root
 ORCA_OCI_PROVIDER_EVENT_WRITER=/srv/script/orca-worktree-session-manifest.sh
+ORCA_OMP_STATUS_EXTENSION=canonical OMP extension path
 ```
 
 The setup hook also sets `CODEX_HOME` and `ORCA_CODEX_HOME` to the Orca-managed runtime home `${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home` unless the coordinator's test-only `ORCA_COORDINATOR_CODEX_HOME` override is present. This closes the existing Codex split where Orca installs `hooks.json` in its redirected runtime home while a raw shell would otherwise invoke the user's `~/.codex`. The executable managed POSIX launcher remains the shared `~/.orca/agent-hooks/codex-hook.sh`; the runtime `hooks.json` registration and shared launcher are separate installation artifacts and must be preflighted separately.
@@ -157,7 +157,7 @@ The persisted schema is exactly:
   "providers": {
     "codex": { "key": "session_id", "id": "codex-session-id" },
     "claude": { "key": "session_id", "id": "claude-session-id" },
-    "omp": { "key": "session_id", "id": "omp-session-id", "resumeFilePath": "/canonical/omp-session.jsonl" }
+    "omp": { "key": "session_id", "id": "omp-session-id" }
   }
 }
 ```
@@ -167,10 +167,12 @@ Provider resume commands are fixed and must not be generalized through an enviro
 ```bash
 codex resume "$CODEX_SESSION_ID" --dangerously-bypass-approvals-and-sandbox
 claude --resume "$CLAUDE_SESSION_ID" --dangerously-skip-permissions
-omp --resume "$OMP_RESUME_TARGET" --auto-approve --approval-mode=yolo
+omp --extension "$ORCA_OMP_STATUS_EXTENSION" --resume "$OMP_SESSION_ID" --auto-approve --approval-mode=yolo
 ```
 
-The coordinator may override provider binary paths, writer, OMP source, and Codex home only for isolated tests. Tests set `XDG_STATE_HOME` to a temporary directory instead of overriding the manifest-root formula. The coordinator must not override provider argv or approval flags in production.
+OMP's recorded `session_id` is the authoritative resume locator. `getSessionFile()` is read by the recovery extension only as the same persistence gate used by Orca's OMP status integration; it is not stored as `resumeFilePath` and is not passed to `omp --resume` in this OCI path. The explicit `--extension "$ORCA_OMP_STATUS_EXTENSION"` argument is the recovery command's confirmed OMP integration path; the coordinator must validate that it is the exact readable session extension selected by setup.
+
+The coordinator may override provider binary paths, writer, OMP source, OMP agent directory, and Codex home only for isolated tests. Tests set `XDG_STATE_HOME` to a temporary directory instead of overriding the manifest-root formula. The coordinator must not override provider argv or approval flags in production.
 
 ## Implementation tasks
 
@@ -278,10 +280,9 @@ Require exactly one locator source:
 ```text
 --payload-stdin                  # only codex/claude
 --session-id ID                  # only omp
---resume-file PATH               # optional omp field, only with --session-id
 ```
 
-Reject unknown flags, missing values, duplicate flags, empty IDs, control characters, and provider/locator combinations that do not match the table above. Do not echo the native payload or locator into diagnostics.
+Reject unknown flags, missing values, duplicate flags, empty IDs, and provider/locator combinations that do not match the table above. Implement one `normalize_provider_session_id` helper and use it for both JSON-extracted IDs and `--session-id`: trim surrounding whitespace, reject empty values, values over the shared 512 string-length limit, values beginning with `-`, and values containing a character with code `<= 0x1f` or `0x7f`. Do not echo the native payload or locator into diagnostics.
 
 Resolve `worktree` and `repo-root` with `realpath -e`. Verify both are
 non-bare worktree paths and that they belong to the same Git repository:
@@ -327,12 +328,13 @@ For Claude and Codex, read all stdin once and use `jq -er` to require the native
 ```bash
 event_name="$(printf '%s' "$payload" | jq -er '.hook_event_name // empty')"
 [ "$event_name" = SessionStart ] || exit 0
-session_id="$(printf '%s' "$payload" | jq -er '.session_id | strings | select(length > 0)')"
+raw_session_id="$(printf '%s' "$payload" | jq -er '.session_id | strings')"
+session_id="$(normalize_provider_session_id "$raw_session_id")" || exit 1
 ```
 
-Do not accept an event with a missing/empty `session_id`; return non-zero without changing the manifest. Do not parse a transcript filename, terminal output, or current directory from the payload.
+`normalize_provider_session_id` must apply the exact shared boundary described in Step 1 before any manifest write: trim surrounding whitespace, require a non-empty value of at most 512 characters, reject a leading `-`, and reject every control character. A missing, malformed, overlong, leading-dash, or unsafe ID returns non-zero without changing the manifest. Do not parse a transcript filename, terminal output, or current directory from the payload.
 
-For OMP, accept the exact `--session-id` from `ctx.sessionManager.getSessionId()` and preserve a non-empty `--resume-file` from `ctx.sessionManager.getSessionFile()` as `resumeFilePath`. Do not derive either value from a path basename, mtime, or recent picker.
+For OMP, accept `--session-id` only from `ctx.sessionManager.getSessionId()` after the same normalization. The extension reads `ctx.sessionManager.getSessionFile()` only to suppress records for non-persistent/ephemeral sessions; it never turns that path into a manifest locator. Do not derive either value from a path basename, mtime, or recent picker.
 
 - [ ] **Step 3: Publish one provider field atomically and serialize writers**
 
@@ -347,7 +349,7 @@ and .repoRoot == $repo_root
 and (.providers | type == "object")
 ```
 
-For a missing manifest, start with the exact version/path/root/provider object. Replace only the selected provider field. Preserve the other provider fields and preserve all existing `omp.resumeFilePath` data when the incoming OMP event has no resume file.
+For a missing manifest, start with the exact version/path/root/provider object. Replace only the selected provider field. The OMP field contains only the normalized native `session_id`; never create or preserve an OMP `resumeFilePath` field.
 
 Write JSON to `mktemp "$manifest.tmp.XXXXXX"`, `chmod 600` the temp file, then `mv -f` it over the manifest. Remove the temp file on every failure. Never write directly to the final path and never leave a mode-0644 intermediate file.
 
@@ -356,9 +358,9 @@ Write JSON to `mktemp "$manifest.tmp.XXXXXX"`, `chmod 600` the temp file, then `
 The shell test must create a temporary Git root and worktree and verify:
 
 ```text
-Claude SessionStart JSON -> providers.claude.key=session_id and exact id
-Codex SessionStart JSON  -> providers.codex.key=session_id and exact id
-OMP session-id + file    -> providers.omp.id and resumeFilePath
+Claude SessionStart JSON -> providers.claude.key=session_id and exact normalized id
+Codex SessionStart JSON  -> providers.codex.key=session_id and exact normalized id
+OMP persistent session-id -> providers.omp.key=session_id and exact normalized id
 second provider record   -> previous provider fields preserved
 concurrent codex/claude records -> both fields survive
 manifest mode            -> 600; parent directory -> 700
@@ -368,11 +370,14 @@ moved/missing worktree   -> non-zero and no write
 malformed existing JSON  -> non-zero and file unchanged
 ordinary provider event  -> zero and no provider field
 missing native id        -> non-zero and no provider field
+overlong/leading-dash/control-character/whitespace-only id -> non-zero and no write
 ```
+
+The same invalid-ID cases must run for Claude, Codex, and OMP. Whitespace surrounding an otherwise valid ID is trimmed before persistence and resume; no rejected input may alter an existing provider field.
 
 Also assert the writer has no code path reading `tmux capture-pane`, `pane_current_path`, file mtimes, or recent session listings. Run the actual script; do not make a source-text-only test the sole proof.
 
-### Task 3: Add the native OMP `session_start` adapter and installation
+### Task 3: Add the native OMP recovery extension and installation
 
 **Files:**
 
@@ -380,99 +385,87 @@ Also assert the writer has no code path reading `tmux capture-pane`, `pane_curre
 - Create `/srv/script/orca-omp-worktree-session-hook.test.sh`.
 - Modify `/srv/script/orca-tmux-hook.sh` and its test.
 
-- [ ] **Step 1: Implement the OMP hook against the installed API**
+- [ ] **Step 1: Implement the OMP extension against the installed API**
 
-Export a default function that subscribes only to `session_start`:
+Export a default function that registers the raw recorder on every context-bearing lifecycle event already used by Orca's OMP status extension:
 
-```ts
-import { spawnSync } from 'node:child_process'
-
-type OmpHookContext = {
-  cwd: string
-  sessionManager: {
-    getSessionId(): string
-    getSessionFile(): string | null
-  }
-}
-
-export default function registerOciWorktreeHook(pi: {
-  on(
-    event: 'session_start',
-    handler: (event: unknown, ctx: OmpHookContext) => unknown
-  ): void
-}): void {
-  pi.on('session_start', async (_event, ctx) => {
-    const manifest = process.env.ORCA_OCI_SESSION_MANIFEST?.trim()
-    const worktree = process.env.ORCA_OCI_WORKTREE_PATH?.trim()
-    const repoRoot = process.env.ORCA_OCI_REPO_ROOT?.trim()
-    const writer = process.env.ORCA_OCI_PROVIDER_EVENT_WRITER?.trim()
-    const sessionId = ctx.sessionManager.getSessionId().trim()
-    const resumeFilePath = ctx.sessionManager.getSessionFile()?.trim() ?? ''
-    if (!manifest || !worktree || !repoRoot || !writer || !sessionId) return
-
-    const args = [
-      'record',
-      '--manifest',
-      manifest,
-      '--provider',
-      'omp',
-      '--worktree',
-      worktree,
-      '--repo-root',
-      repoRoot,
-      '--session-id',
-      sessionId
-    ]
-    if (resumeFilePath) args.push('--resume-file', resumeFilePath)
-    try {
-      spawnSync(writer, args, { stdio: 'ignore' })
-    } catch {
-      // A missing writer must not make the OMP session unusable.
-    }
-  })
-}
+```text
+before_agent_start
+agent_start
+tool_call
+tool_execution_start
+tool_execution_end
+tool_approval_requested
+tool_approval_resolved
+message_end
+agent_settled
+agent_end
 ```
 
-Use the actual `HookContext` shape verified in the installed OMP package: `cwd`, readonly `sessionManager`, `getSessionId()`, and `getSessionFile()`. Catch spawn errors so the OMP session itself remains usable; the coordinator's missing manifest/provider field is the recovery signal. Do not subscribe to session switch/branch events.
+Do not make `session_start` the recording contract: the current OMP status
+source intentionally leaves its `session_start` handler unregistered. Use the
+installed OMP `HookContext` shape (`cwd`, readonly `sessionManager`,
+`getSessionId()`, and `getSessionFile()`). Each registered callback must reread
+both session-manager values. Treat a non-empty `getSessionFile()` as the
+persistence gate, but store and send only the normalized `getSessionId()`:
+
+
+```ts
+const sessionId = normalizeProviderSessionId(ctx.sessionManager.getSessionId())
+const sessionFile = ctx.sessionManager.getSessionFile()?.trim() ?? ''
+if (!sessionId || !sessionFile) return
+spawnSync(writer, [
+  'record',
+  '--manifest', manifest,
+  '--provider', 'omp',
+  '--worktree', worktree,
+  '--repo-root', repoRoot,
+  '--session-id', sessionId
+], { stdio: 'ignore' })
+```
+
+The shell writer remains the final validation boundary; the extension-side normalization only prevents needless invalid invocations. Catch spawn errors so the OMP session itself remains usable. Do not use `getSessionFile()` as a resume target, do not pass `--resume-file`, and do not subscribe to unverified event names outside the installed event set above. The callback set is required because Orca's existing OMP status source documents in-process session switching and refreshes identity on each lifecycle event.
 
 The runtime script must not hardcode a different writer path; the setup hook's environment is authoritative. The test may set `ORCA_OCI_PROVIDER_EVENT_WRITER` to a temporary fake executable.
 
-- [ ] **Step 2: Install the hook idempotently from the setup hook**
+- [ ] **Step 2: Install and select the extension through OMP's existing mechanism**
+
+OMP's confirmed integration writes managed extensions under the selected agent directory's `extensions` child (`src/main/pi/titlebar-extension-service.ts#installManagedExtensions`). The existing wrapper's source-backed native invocation is `omp --extension <path>` (`src/main/pty/omp-shell-wrapper.ts#__orca_omp_invoke`). Raw recovery must pass that argument directly; it must not depend on an arbitrary tmux pane having Orca's shell-startup wrapper installed. Do not use or describe `~/.omp/agent/hooks` as an auto-discovery directory.
 
 Before creating a new tmux session, the setup hook must:
 
 ```bash
-omp_hook_dir="$HOME/.omp/agent/hooks"
-mkdir -p "$omp_hook_dir"
-tmp_hook="$(mktemp "$omp_hook_dir/orca-oci-worktree-session-hook.ts.XXXXXX")"
+omp_agent_dir="${ORCA_OCI_OMP_AGENT_DIR:-$HOME/.omp/agent}"
+omp_extension_dir="$omp_agent_dir/extensions"
+omp_extension_path="$omp_extension_dir/orca-oci-worktree-session-hook.ts"
+mkdir -p "$omp_extension_dir"
+if [ -e "$omp_extension_path" ] && ! grep -Fq '@orca-managed-oci-worktree-extension' "$omp_extension_path"; then
+  printf '%s\n' 'OMP extension path is user-owned' >&2
+  exit 1
+fi
+tmp_hook="$(mktemp "$omp_extension_dir/orca-oci-worktree-session-hook.ts.XXXXXX")"
 cp "$omp_hook_source" "$tmp_hook"
 chmod 600 "$tmp_hook"
-mv -f "$tmp_hook" "$omp_hook_dir/orca-oci-worktree-session-hook.ts"
+mv -f "$tmp_hook" "$omp_extension_path"
 ```
 
-Use `/srv/script/orca-omp-worktree-session-hook.ts` by default and `ORCA_OCI_OMP_HOOK_SOURCE` only as an isolated test override. If the source is absent or cannot be copied, fail before creating a session. Do not overwrite any other user hook.
+The source file must carry the `@orca-managed-oci-worktree-extension` marker. Use `/srv/script/orca-omp-worktree-session-hook.ts` by default and `ORCA_OCI_OMP_HOOK_SOURCE` only as an isolated test override. Set the new session's `ORCA_OMP_STATUS_EXTENSION` to the exact `omp_extension_path`; the coordinator reads that value and passes it directly with `omp --extension`, while interactive shells may use the existing wrapper when present. If the source is absent, the extension cannot be installed, or the existing path is user-owned, fail before creating a session. Do not overwrite any other user extension.
 
-The live hook body must carry this same installation logic. Re-running setup for an existing session must return after session path validation without changing the OMP hook or any session environment.
+The live hook body must carry this same installation and selection logic. Re-running setup for an existing session must return after session path validation without changing the OMP extension or any session environment.
 
-- [ ] **Step 3: Test the OMP adapter through a real callback**
+- [ ] **Step 3: Test the OMP extension through repeated real callbacks**
 
-The shell test must generate a Bun harness that imports the new `.ts` file, captures the `session_start` handler, supplies:
+The shell test must generate a Bun harness that imports the new `.ts` file, captures handlers for the event set above, and supplies a mutable context:
 
 ```text
-getSessionId()  -> omp-native-id
+getSessionId() -> omp-native-id-1, then omp-native-id-2
 getSessionFile() -> /tmp/omp-native-session.jsonl
 cwd -> /srv/worktree
 ```
 
-Set the four `ORCA_OCI_*` environment variables and invoke the handler. The fake writer must log argv and assert:
+Set the four `ORCA_OCI_*` environment variables and invoke `agent_start`, then mutate the native ID and invoke `before_agent_start` or another listed lifecycle callback. The fake writer must receive two records with the two IDs, proving a session switch is reflected in the manifest. Assert that neither record contains `--resume-file` and that the OMP recovery command selects the extension with `--extension`.
 
-```text
-record --manifest /tmp/oci-manifest.json --provider omp --worktree /srv/worktree
-      --repo-root /srv/repository --session-id omp-native-id
-      --resume-file /tmp/omp-native-session.jsonl
-```
-
-Repeat with `getSessionFile() -> null` and assert no `--resume-file` argument. Repeat with missing context and assert no writer invocation.
+Repeat with `getSessionFile() -> null` and assert no writer invocation for the ephemeral session. Repeat with missing context and assert no writer invocation. Verify the setup test installs the file under `$HOME/.omp/agent/extensions`, sets `ORCA_OMP_STATUS_EXTENSION` to that file, and the coordinator's OMP argv passes that exact path with `--extension`.
 
 ### Task 4: Make the setup hook own the deterministic four-window layout
 
@@ -533,10 +526,12 @@ manifest_dir="$(realpath -m "${XDG_STATE_HOME:-$HOME/.local/state}/orca/oci-work
 manifest="${manifest_dir}/$(printf '%s' "$worktree" | sha256sum | cut -d' ' -f1).json"
 writer="${ORCA_OCI_PROVIDER_EVENT_WRITER:-/srv/script/orca-worktree-session-manifest.sh}"
 omp_hook_source="${ORCA_OCI_OMP_HOOK_SOURCE:-/srv/script/orca-omp-worktree-session-hook.ts}"
+omp_agent_dir="${ORCA_OCI_OMP_AGENT_DIR:-$HOME/.omp/agent}"
+omp_extension_path="$omp_agent_dir/extensions/orca-oci-worktree-session-hook.ts"
 codex_home="${ORCA_COORDINATOR_CODEX_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home}"
 ```
 
-Require `tmux`, `git`, `realpath`, `sha256sum`, `jq`, and the writer. Require the OMP source for a new session. These checks are setup dependencies, not a reason to modify an existing session.
+Require `tmux`, `git`, `realpath`, `sha256sum`, `jq`, and the writer. Require the OMP source for a new session. The extension directory may be created by the installation step. These checks are setup dependencies, not a reason to modify an existing session.
 
 - [ ] **Step 3: Leave existing sessions untouched**
 
@@ -552,6 +547,7 @@ tmux -L "$socket" new-session -d -s "$session" -n codex -c "$worktree" \
   -e "ORCA_OCI_WORKTREE_PATH=$worktree" \
   -e "ORCA_OCI_REPO_ROOT=$root" \
   -e "ORCA_OCI_PROVIDER_EVENT_WRITER=$writer" \
+  -e "ORCA_OMP_STATUS_EXTENSION=$omp_extension_path" \
   -e "CODEX_HOME=$codex_home" \
   -e "ORCA_CODEX_HOME=$codex_home"
 tmux -L "$socket" new-window -d -t "$session:1" -n claude -c "$worktree"
@@ -569,7 +565,8 @@ Use the test socket and shell's arguments exactly as existing code does; do not 
 2:omp
 3:bash
 all four #{pane_current_path} == canonical worktree
-show-environment contains all four ORCA_OCI_* values and CODEX_HOME/ORCA_CODEX_HOME
+all four ORCA_OCI_* values, CODEX_HOME/ORCA_CODEX_HOME, and ORCA_OMP_STATUS_EXTENSION
+OMP recovery argv selects the exact extension path with --extension
 ```
 
 - [ ] **Step 5: Remove partial new sessions on any layout failure**
@@ -588,6 +585,8 @@ all four pane cwds == worktree
 session_path == worktree even after a pane cd /tmp
 all four ORCA_OCI_* env values exact
 CODEX_HOME and ORCA_CODEX_HOME exact
+ORCA_OMP_STATUS_EXTENSION == $omp_extension_path
+OMP recovery argv receives --extension "$omp_extension_path"
 second setup -> no extra window/no env rewrite/no hook rewrite
 same-name wrong path -> non-zero
 missing worktree -> non-zero
@@ -596,7 +595,8 @@ partial new layout -> session removed
 archive -> exact session only; missing/deleted path archive is zero
 ```
 
-Run the live UI setup hook manually against a disposable local worktree only after this test passes. Observe the newly created session, four windows, session path, pane paths, and env; archive that disposable session through the existing archive hook. Do not use a real project worktree for the probe.
+Run the live UI setup hook manually against a disposable local worktree only after this test passes. Observe the newly created session, four windows, session path, pane paths, env, and OMP extension selection; archive that disposable session through the existing archive hook. Do not use a real project worktree for the probe.
+
 
 ### Task 5: Replace worktree `--last` bootstrap with one-shot provider recovery
 
@@ -612,7 +612,8 @@ Do not change `ensure_session()`'s coordinator keeper logic. Add these configura
 ```bash
 manifest_root="${XDG_STATE_HOME:-$HOME/.local/state}/orca/oci-worktree-sessions"
 provider_event_writer="${ORCA_COORDINATOR_PROVIDER_EVENT_WRITER:-/srv/script/orca-worktree-session-manifest.sh}"
-omp_hook_source="${ORCA_COORDINATOR_OMP_HOOK_SOURCE:-/srv/script/orca-omp-worktree-session-hook.ts}"
+omp_agent_dir="${ORCA_COORDINATOR_OMP_AGENT_DIR:-$HOME/.omp/agent}"
+omp_extension_path="$omp_agent_dir/extensions/orca-oci-worktree-session-hook.ts"
 codex_home="${ORCA_COORDINATOR_CODEX_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home}"
 ```
 
@@ -639,7 +640,7 @@ Use the observed `created` name as the only target. Do not calculate a session n
 
 - [ ] **Step 3: Add exact manifest and layout reads**
 
-For a newly created session, read `ORCA_OCI_SESSION_MANIFEST`, `ORCA_OCI_WORKTREE_PATH`, and `ORCA_OCI_REPO_ROOT` from the session environment and compare the latter two values to the canonical `$path` and `$root` arguments from the inventory loop. Reject the session for provider recovery if any is missing, if the manifest path is not the exact sha256 path under `manifest_root`, or if manifest `worktreePath`/`repoRoot` do not exactly match the setup context. Log `RECOVERY_REQUIRED` and leave all panes as shells when the binding fails.
+For a newly created session, read `ORCA_OCI_SESSION_MANIFEST`, `ORCA_OCI_WORKTREE_PATH`, `ORCA_OCI_REPO_ROOT`, and `ORCA_OMP_STATUS_EXTENSION` from the session environment. Compare `ORCA_OCI_WORKTREE_PATH` and `ORCA_OCI_REPO_ROOT` to the canonical `$path` and `$root` arguments from the inventory loop, and require the OMP extension value to equal the expected readable file under the selected agent directory's `extensions` child. Reject the session for provider recovery if any is missing, if the manifest path is not the exact sha256 path under `manifest_root`, or if manifest `worktreePath`/`repoRoot` do not exactly match the setup context. Log `RECOVERY_REQUIRED` and leave all panes as shells when the binding fails.
 Read provider fields only through `jq -er` selectors equivalent to:
 
 ```jq
@@ -648,16 +649,19 @@ Read provider fields only through `jq -er` selectors equivalent to:
 .providers.omp.key == "session_id" and (.providers.omp.id | strings | length > 0)
 ```
 
-For OMP, use `.resumeFilePath` when it is a non-empty string; otherwise use the exact `.id`. Missing/malformed fields are provider-local `RECOVERY_REQUIRED`, not a fresh start and not a reason to touch another provider.
+After each selector, pass the extracted value through the same provider-ID normalizer as the manifest writer. Trim surrounding whitespace, reject empty or over-512-character values, reject leading `-`, and reject control characters (`<= 0x1f` or `0x7f`) before constructing any command. A rejected ID is provider-local `RECOVERY_REQUIRED`; it must not alter the manifest or reach `send-keys`.
 
+For OMP, use `.providers.omp.id` only. Do not inspect or synthesize `resumeFilePath`; the recorded native session ID is the OCI locator. Read `ORCA_OMP_STATUS_EXTENSION` from the new session environment and require it to equal the expected extension path under the selected agent directory's `extensions` child. Missing/malformed fields are provider-local `RECOVERY_REQUIRED`, not a fresh start and not a reason to touch another provider.
 Before sending a provider command, verify the binary exists and the exact
-resume selector and approval options are accepted without starting a provider:
+resume selector, extension, and approval options are accepted without starting
+a provider:
 
 ```text
 codex: CODEX_HOME=$codex_home codex --help contains --dangerously-bypass-approvals-and-sandbox;
        CODEX_HOME=$codex_home codex resume --help is callable
 claude: claude --resume "__orca_capability_probe__" --dangerously-skip-permissions --help exits zero
-omp:    omp --help contains --resume, --auto-approve, --approval-mode, and yolo
+omp:    omp --extension "$omp_extension_path" --help is callable and
+       omp --help contains --resume, --auto-approve, --approval-mode, and yolo
 ```
 
 The Claude line is a parser-acceptance probe: it must pass the exact
@@ -666,31 +670,30 @@ conversation is resumed or provider session is launched. Do not require those
 flags to appear in `claude --help` output. A failed probe is
 `RECOVERY_REQUIRED`.
 
-The installation artifacts must be checked independently:
+The installation artifacts and OMP extension route must be checked independently:
 
 ```text
 codex: $codex_home/hooks.json exists; its SessionStart managed command points to
-       $HOME/.orca/agent-hooks/codex-hook.sh; that shared script contains the
-       raw adapter
+       $HOME/.orca/agent-hooks/codex-hook.sh; that shared script contains
+       the raw adapter
 claude: $HOME/.orca/agent-hooks/claude-hook.sh exists and contains the raw adapter
-omp:    $HOME/.omp/agent/hooks/orca-oci-worktree-session-hook.ts exists and is readable
+omp:    $omp_extension_path exists under the agent directory's extensions child,
+       is readable, and session environment ORCA_OMP_STATUS_EXTENSION points to it;
+       recovery argv passes --extension "$omp_extension_path"
 writer: provider_event_writer is executable
 ```
 
-Do not treat the Codex runtime `hooks.json` and shared executable launcher as
-the same file. If any check fails, print `RECOVERY_REQUIRED` in that provider's
-pane and log the precise preflight reason. Never silently remove a flag,
-substitute a different resume selector, or use a provider's recent-session
-option.
+Do not treat the Codex runtime `hooks.json` and shared executable launcher as the same file. If any check fails, print `RECOVERY_REQUIRED` in that provider's pane and log the precise preflight reason. Never silently remove a flag, substitute a different resume selector, or use a provider's recent-session option.
+
 
 - [ ] **Step 5: Send one exact command per provider window**
 
-Use fixed window names/indexes from the hook's new-session contract and shell-quote every manifest-derived locator with Bash `printf '%q'`. Send only these commands:
+Use fixed window names/indexes from the hook's new-session contract and shell-quote every manifest-derived locator plus the session's OMP extension path with Bash `printf '%q'`. Send only these commands:
 
 ```bash
 codex resume "$codex_id" --dangerously-bypass-approvals-and-sandbox
 claude --resume "$claude_id" --dangerously-skip-permissions
-omp --resume "$omp_resume_target" --auto-approve --approval-mode=yolo
+omp --extension "$omp_extension_path" --resume "$omp_id" --auto-approve --approval-mode=yolo
 ```
 
 Wrap each command so a non-zero provider exit leaves the shell alive and prints a literal sentinel:
@@ -715,8 +718,9 @@ missing manifest -> shells + RECOVERY_REQUIRED; zero provider invocations
 wrong manifest binding -> shells + RECOVERY_REQUIRED; zero provider invocations
 missing provider field -> only that provider RECOVERY_REQUIRED
 missing help flag or failed Claude parser probe -> provider RECOVERY_REQUIRED; no downgraded invocation
-provider exits non-zero -> shell remains and RECOVERY_REQUIRED is visible
-ordinary provider event -> writer may run; manifest remains unchanged
+overlong/leading-dash/control-character provider ID -> provider RECOVERY_REQUIRED; zero invocation
+provider ID with surrounding whitespace -> trimmed ID is the only argv value
+OMP manifest ID -> omp --extension receives the selected extension path and --resume receives only that ID, never a file path
 second ensure after provider failure -> no retry/invocation
 pre-existing legacy one-window session -> untouched, no auto-migration
 Windows inventory path -> no local session
@@ -734,45 +738,48 @@ Keep all current coordinator tests for coordinator reuse, bare coordinator start
 
 - [ ] **Step 1: Add the operational contract**
 
-Document this exact flow:
-
 ```text
 1. Coordinator enumerates local OCI Git worktrees only.
 2. Setup hook creates/reuses the deterministic session and, for a new session, four windows.
 3. Coordinator observes before/after session names.
 4. Only newly created sessions are eligible for provider resume.
-5. Provider-native SessionStart hooks populate the path-bound manifest.
+5. Provider-native SessionStart/lifecycle adapters populate the path-bound manifest.
 6. Missing/malformed/mismatched locator or unsupported flags produce RECOVERY_REQUIRED.
 7. Existing sessions are never restarted or migrated.
 8. Archive the exact old session and rerun setup once to migrate a legacy layout.
 ```
 
-Include the manifest path/schema, exact provider commands, Codex managed-home requirement, OMP hook path, `ORCA_OCI_*` variables, `ORCA_COORDINATOR_RESUME_AGENTS=0` meaning, and the warning that `RECOVERY_REQUIRED` is not evidence that a provider has no upstream session; it means this recovery path is intentionally fail-closed.
+Include the manifest path/schema, exact provider commands, Codex managed-home requirement, OMP extension path and `ORCA_OMP_STATUS_EXTENSION` wrapper selection, `ORCA_OCI_*` variables, `ORCA_COORDINATOR_RESUME_AGENTS=0` meaning, and the warning that `RECOVERY_REQUIRED` is not evidence that a provider has no upstream session; it means this recovery path is intentionally fail-closed.
 
-After the `/srv/script` copy and focused test pass, load the amended Orca source in the supported OCI runtime and invoke the existing managed-agent hook install/reconciliation operation for Claude and Codex. This is the path backed by `installManagedAgentHooks` and its existing `ClaudeHookService.refreshManagedScripts()` / `CodexHookService.refreshManagedScripts()` refreshers; do not manually copy generated managed scripts. If the live OCI runtime cannot run the amended source, stop and do not claim managed-hook deployment.
+After the `/srv/script` copy and focused tests pass, use the supported `agent hooks on` path for the live OCI runtime. When the runtime is reachable, the settings update path (`src/main/ipc/settings.ts`) calls `applyAgentStatusHooksEnabled()`, which calls `installManagedAgentHooks()` and refreshes the existing Claude/Codex managed scripts. When the runtime is unavailable, the CLI's offline `setAgentHooksEnabled()` path calls the same `applyAgentStatusHooksEnabled()` operation directly. The raw OMP recovery extension is not installed by this managed-hook refresh; the live setup hook installs it under the OMP agent directory's `extensions` child and selects it through `ORCA_OMP_STATUS_EXTENSION`. Do not treat `agent hooks status` alone as deployment or refresh. Do not manually copy generated managed scripts.
 
-Verify the resulting artifacts before updating the live setup hook:
+Verify the resulting artifacts and returned statuses before updating the live setup hook:
 
 ```text
 Claude: ~/.orca/agent-hooks/claude-hook.sh contains the recorder after the Devin/CLAUDE_JOB_DIR guards
 Codex: redirected CODEX_HOME/hooks.json SessionStart entry points to ~/.orca/agent-hooks/codex-hook.sh
        ~/.orca/agent-hooks/codex-hook.sh contains the recorder
+OMP:   ~/.omp/agent/extensions/orca-oci-worktree-session-hook.ts is the
+       explicit extension source selected by ORCA_OMP_STATUS_EXTENSION
 ```
 
-Then update the live OCI setup hook setting and probe a disposable worktree. Record:
+If neither supported `agent hooks on` route can run the amended source and refresh the artifacts, stop and do not claim managed-hook deployment. Then update the live OCI setup hook setting and probe a disposable worktree. Record:
 
 ```text
+agent hooks on route (runtime settings or offline CLI fallback)
+returned managed-hook statuses
 observed new session name
 session_path
 0:codex, 1:claude, 2:omp, 3:bash
 all pane_current_path values
-ORCA_OCI_* values, CODEX_HOME, and ORCA_CODEX_HOME
-OMP hook installation path
+ORCA_OCI_* values, CODEX_HOME, ORCA_CODEX_HOME, and ORCA_OMP_STATUS_EXTENSION
+OMP extension installation path and wrapper --extension argument
 Claude/Codex installed-script probe result
 archive result for the disposable session
 ```
 
 Do not restart `orca-tmux.service`, kill the tmux server, or touch a real project session for this probe.
+
 
 ### Task 7: Run focused OCI verification and preserve operational evidence
 
@@ -880,15 +887,15 @@ Re-run the four OCI shell suites and `git diff --check` after any final source c
 - [ ] The setup hook is idempotent for an existing exact-path session and fail-closed for a name/path mismatch; it does not auto-migrate old layouts.
 - [ ] A partial new layout is removed without touching any pre-existing session or the coordinator keeper.
 - [ ] A linked worktree passes when its canonical `show-toplevel` equals the worktree and its canonical `--git-common-dir` matches the repository root; a different repository is rejected.
-- [ ] Session environment contains the four exact `ORCA_OCI_*` variables and routes raw Codex to the same redirected `CODEX_HOME` where Orca registers its hook.
+- [ ] Session environment contains the four exact `ORCA_OCI_*` variables, the exact `ORCA_OMP_STATUS_EXTENSION` extension path, and routes raw Codex to the same redirected `CODEX_HOME` where Orca registers its hook.
 - [ ] Claude and Codex raw recorders run after required provider exclusions, pass native payloads to the writer, and the manifest changes only for native `SessionStart.session_id`; ordinary events leave it unchanged.
 - [ ] Claude's shared `~/.orca/agent-hooks/claude-hook.sh` and Codex's shared `~/.orca/agent-hooks/codex-hook.sh` contain the recorder; Codex's redirected `CODEX_HOME/hooks.json` independently registers the shared launcher.
-- [ ] OMP records `getSessionId()` and optional `getSessionFile()` through the auto-discovered hook.
-- [ ] The manifest is keyed by canonical worktree path, validates canonical root/worktree identity and shared Git common directory, is mode 0600 under mode-0700 directories, serializes concurrent writers, and publishes atomically.
-- [ ] The coordinator sends fixed provider resume commands with exact dangerous approval flags only to sessions observed as newly created in the current invocation.
+- [ ] OMP records the current durable `getSessionId()` on every supported context-bearing lifecycle callback (not `session_start`, which the current OMP status source intentionally does not register), using `getSessionFile()` only as a persistence gate; the extension is installed under the agent directory's `extensions` child, selected through `ORCA_OMP_STATUS_EXTENSION`, and passed explicitly with `omp --extension` during recovery.
+- [ ] Every Claude, Codex, and OMP provider ID is normalized with the shared trim/empty/512-character/leading-dash/control-character boundary; rejected IDs cannot mutate the manifest or reach resume argv.
+- [ ] The coordinator sends fixed provider resume commands with exact dangerous approval flags only to sessions observed as newly created in the current invocation; OMP receives only its recorded `session_id`.
 - [ ] Claude capability preflight uses a non-launching parser-acceptance probe; unsupported flags, missing artifacts, and failed launches leave shells plus `RECOVERY_REQUIRED` with no fallback.
 - [ ] A second coordinator invocation sends no duplicate provider command to an existing session, including after a provider failure.
 - [ ] `ORCA_COORDINATOR_RESUME_AGENTS=0` suppresses provider sends without suppressing the four-window layout.
 - [ ] Windows/hpv2 inventory entries remain excluded and hpv2/runtime failures do not destroy OCI sessions.
 - [ ] Raw tmux remains outside Orca's managed worker/UI contract.
-- [ ] The supported OCI managed-hook deployment and live installed-script probe are recorded separately from hpv2 source validation; focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.
+- [ ] The supported OCI managed-hook deployment and live installed-script probe are recorded separately from hpv2 source validation; the exact `agent hooks on` runtime/offline route, returned statuses, focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.

--- a/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
+++ b/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make every local OCI Git worktree recoverable after an OCI/tmux restart by having the setup hook create one deterministic four-window tmux session (`codex`, `claude`, `omp`, `bash`) and having the coordinator resume each provider exactly once from provider-native session locators persisted in a path-bound manifest.
 
-**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and OMP hook installation. Provider hooks record native `SessionStart` identifiers through a host-local atomic manifest writer. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch.
+**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and OMP hook installation. Claude/Codex raw recorders run only after their provider-specific exclusion guards, may pass captured provider payloads to a host-local writer, and the writer mutates the manifest only for `SessionStart`. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch.
 
 **Tech Stack:** Bash, tmux, jq, `realpath`, `sha256sum`, `flock`, TypeScript-generated POSIX hook scripts, Bun OMP hooks, the existing `/srv/script/orca-coordinator.sh` JSON CLI integration, Vitest, ShellCheck.
 
@@ -52,12 +52,12 @@
 
 ### Create
 
-- `/srv/script/orca-worktree-session-manifest.sh` — host-local `record` command. Validates canonical worktree/root identity and exact manifest path, extracts native Claude/Codex JSON identifiers or accepts OMP's native identifier arguments, serializes concurrent updates with `flock`, and publishes mode-0600 JSON through temp-file plus atomic rename.
-- `/srv/script/orca-worktree-session-manifest.test.sh` — isolated manifest writer, path-binding, permissions, concurrency, malformed-input, and moved-worktree tests.
+- `/srv/script/orca-worktree-session-manifest.sh` — host-local `record` command. Validates canonical worktree/root identity, including linked-worktree `--git-common-dir` ownership and exact manifest path, extracts native Claude/Codex JSON identifiers or accepts OMP's native identifier arguments, serializes concurrent updates with `flock`, and publishes mode-0600 JSON through temp-file plus atomic rename.
+- `/srv/script/orca-worktree-session-manifest.test.sh` — isolated manifest writer, path-binding, linked-worktree identity, permissions, concurrency, malformed-input, and moved-worktree tests.
 - `/srv/script/orca-omp-worktree-session-hook.ts` — OMP auto-discovered `session_start` hook. Reads `ctx.sessionManager.getSessionId()` and optional `ctx.sessionManager.getSessionFile()`, then invokes the manifest writer with the tmux session's exact environment context.
 - `/srv/script/orca-omp-worktree-session-hook.test.sh` — Bun harness that registers the hook with a fake HookAPI and verifies the native OMP callback arguments sent to a fake writer.
-- `src/main/agent-hooks/oci-worktree-session-event.ts` — shared POSIX shell-line generator for guarded raw-tmux native `SessionStart` recording; no endpoint, pane key, or UI relay dependency.
-- `src/main/agent-hooks/oci-worktree-session-event.test.ts` — exact generated-line contract and platform guard tests.
+- `src/main/agent-hooks/oci-worktree-session-event.ts` — shared POSIX shell-line generator for guarded raw-tmux provider-payload recording; no endpoint, pane key, or UI relay dependency.
+- `src/main/agent-hooks/oci-worktree-session-event.test.ts` — exact generated-line contract, provider-exclusion ordering, ordinary-event no-op, and platform guard tests.
 
 ### Modify
 
@@ -66,10 +66,10 @@
 - `/srv/script/orca-coordinator.sh` — preserve current coordinator/hpv2 behavior while replacing worktree's old single Codex `--last` bootstrap with observed-new-session provider recovery and exact preflighted commands.
 - `/srv/script/orca-coordinator.test.sh` — add fake provider binaries, manifests, flag preflight, one-shot, failure, and `RESUME_AGENTS=0` cases without weakening current liveness checks.
 - `/srv/script/projects/orca.md` — document the OCI recovery contract, operational backup/hashes, manifest location, provider flags, `RECOVERY_REQUIRED`, and archive/recreate procedure.
-- `src/main/claude/hook-service.ts` — add the shared raw-tmux recorder to the generated POSIX script while preserving the neutral JSON output, Devin guard, endpoint refresh, and normal Orca spool/post path.
-- `src/main/claude/hook-service.test.ts` — verify the installed POSIX managed script contains and executes the raw native SessionStart branch without changing existing user settings behavior.
-- `src/main/codex/codex-hook-script.ts` — add the same shared raw-tmux recorder to the generated POSIX script while preserving endpoint refresh, WSL curl fallback, and normal spool/post behavior.
-- `src/main/codex/hook-service-managed-install.test.ts` — verify the managed script installed under the redirected runtime `CODEX_HOME` records raw native SessionStart payloads and still posts ordinary events.
+- `src/main/claude/hook-service.ts` — add the shared raw-tmux recorder after the existing Devin/`CLAUDE_JOB_DIR` exclusions and before endpoint-dependent logic, while preserving the neutral JSON output, endpoint refresh, and normal Orca spool/post path.
+- `src/main/claude/hook-service.test.ts` — verify the shared POSIX managed script at `~/.orca/agent-hooks/claude-hook.sh` contains the recorder after exclusions and executes the raw native SessionStart branch without changing existing user settings behavior.
+- `src/main/codex/codex-hook-script.ts` — add the same shared raw-tmux recorder after payload/spool setup and before endpoint loading, while preserving the endpoint loader and WSL curl fallback.
+- `src/main/codex/hook-service-managed-install.test.ts` — verify redirected runtime `CODEX_HOME/hooks.json` registers SessionStart through the shared `~/.orca/agent-hooks/codex-hook.sh` launcher, that launcher records raw native SessionStart payloads, and ordinary events leave the manifest unchanged.
 
 ### Do not modify
 
@@ -145,7 +145,7 @@ ORCA_OCI_REPO_ROOT=canonical repository root
 ORCA_OCI_PROVIDER_EVENT_WRITER=/srv/script/orca-worktree-session-manifest.sh
 ```
 
-The setup hook also sets `CODEX_HOME` and `ORCA_CODEX_HOME` to the Orca-managed runtime home `${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home` unless the coordinator's test-only `ORCA_COORDINATOR_CODEX_HOME` override is present. This closes the existing Codex split where Orca installs hooks in its redirected runtime home while a raw shell would otherwise invoke the user's `~/.codex`.
+The setup hook also sets `CODEX_HOME` and `ORCA_CODEX_HOME` to the Orca-managed runtime home `${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home` unless the coordinator's test-only `ORCA_COORDINATOR_CODEX_HOME` override is present. This closes the existing Codex split where Orca installs `hooks.json` in its redirected runtime home while a raw shell would otherwise invoke the user's `~/.codex`. The executable managed POSIX launcher remains the shared `~/.orca/agent-hooks/codex-hook.sh`; the runtime `hooks.json` registration and shared launcher are separate installation artifacts and must be preflighted separately.
 
 The persisted schema is exactly:
 
@@ -196,12 +196,12 @@ export function buildPosixOciWorktreeSessionRecordLines(
 ```
 
 The returned shell lines must:
-
 1. Require all four `ORCA_OCI_*` variables before doing anything.
 2. Pipe the already captured native `payload` variable to the configured writer's `record` command.
 3. Pass `--manifest`, `--provider`, `--worktree`, `--repo-root`, and `--payload-stdin` as separate shell arguments.
 4. Redirect writer output and errors away from the provider hook protocol and fail open for the provider process (`|| :`).
 5. Never inspect terminal output, `PWD`, mtimes, endpoint variables, pane keys, or UI relay state.
+6. The generator does not need to parse the event type. The writer reads `hook_event_name` and mutates the manifest only for `SessionStart`; ordinary events may invoke the writer but must be a no-op.
 
 Generated line shape:
 
@@ -221,11 +221,9 @@ fi
 
 The Claude generator emits `--provider claude`; the Codex generator emits the same line with the compile-time literal `--provider codex`. No generated script accepts a provider value from payload text.
 
-- [ ] **Step 2: Add the adapter before normal spool/post code**
+In Claude's POSIX `getManagedScript()` return array, keep `buildPosixHookPayloadCapture()` and `buildPosixHookSpoolLines('claude')` in their existing order, then keep the existing Devin exclusion and `CLAUDE_JOB_DIR` guard before inserting the generated raw-recorder lines. The recorder must therefore run after both provider-specific exclusions and before the `ORCA_AGENT_HOOK_ENDPOINT` refresh/validation path. Preserve the existing initial `printf "{}\\n"` and neutral exit paths. Do not add this branch to the Windows `.cmd` output; this recovery surface is Linux POSIX tmux.
 
-In Claude's POSIX `getManagedScript()` return array, place the generated lines immediately after `buildPosixHookPayloadCapture()` and before `buildPosixHookSpoolLines('claude')`. Preserve the existing initial `printf "{}\\n"`, Devin skip, `CLAUDE_JOB_DIR` exit, endpoint refresh, and neutral exit paths. Do not add this branch to the Windows `.cmd` output; this recovery surface is Linux POSIX tmux.
-
-In Codex's POSIX `getManagedScript()` return array, place the generated lines immediately after `buildPosixHookPayloadCapture()` and before `buildPosixHookSpoolLines('codex')`. Preserve the existing endpoint loader and WSL curl fallback. Do not make the raw branch depend on a successfully loaded `ORCA_AGENT_HOOK_ENDPOINT`.
+In Codex's POSIX `getManagedScript()` return array, keep `buildPosixHookPayloadCapture()` and `buildPosixHookSpoolLines('codex')` in their existing order, then insert the generated raw-recorder lines before `load_hook_endpoint()` and all endpoint-dependent logic. Preserve the existing endpoint loader and WSL curl fallback. Do not make the raw branch depend on a successfully loaded `ORCA_AGENT_HOOK_ENDPOINT`.
 
 - [ ] **Step 3: Test generated contract and normal-path isolation**
 
@@ -243,7 +241,9 @@ expect(lines.join('\n')).not.toContain('ORCA_AGENT_HOOK_ENDPOINT')
 expect(lines.join('\n')).not.toContain('ORCA_PANE_KEY')
 ```
 
-Use the existing provider install tests to read the actual installed scripts and run each script on a temporary POSIX host with a fake executable writer. Send a native `SessionStart` JSON payload containing a provider `session_id`; assert the writer receives the exact payload on stdin and the provider script exits zero. Send an ordinary event and assert the raw writer is not invoked. Leave the existing ordinary Orca endpoint/post assertions intact.
+Use the existing provider install tests to read the actual installed POSIX scripts and run each script on a temporary host with a fake executable writer. For Claude, assert that the raw recorder appears after the Devin/`CLAUDE_JOB_DIR` exclusions. Send a native `SessionStart` JSON payload containing a provider `session_id`; assert the writer receives the exact payload on stdin and the provider script exits zero. Send an ordinary event; the fake writer may be invoked, but the actual manifest writer must leave the manifest unchanged. Keep the existing ordinary Orca endpoint/post assertions intact.
+
+The Claude test must inspect the shared `~/.orca/agent-hooks/claude-hook.sh` path produced by `getManagedScriptPath()`. The Codex test must inspect both the redirected runtime `CODEX_HOME/hooks.json` SessionStart entry and the shared `~/.orca/agent-hooks/codex-hook.sh` content it invokes; do not assert that the executable launcher lives under `CODEX_HOME`.
 
 - [ ] **Step 4: Run the focused source tests through hpv2**
 
@@ -283,13 +283,32 @@ Require exactly one locator source:
 
 Reject unknown flags, missing values, duplicate flags, empty IDs, control characters, and provider/locator combinations that do not match the table above. Do not echo the native payload or locator into diagnostics.
 
-Resolve `worktree` and `repo-root` with `realpath -e`. Verify:
+Resolve `worktree` and `repo-root` with `realpath -e`. Verify both are
+non-bare worktree paths and that they belong to the same Git repository:
 
 ```bash
-git -C "$worktree" rev-parse --show-toplevel
+canonical_git_common_dir() {
+  local path="$1" common
+  common="$(git -C "$path" rev-parse --git-common-dir)"
+  case "$common" in
+    /*) realpath -e "$common" ;;
+    *) realpath -e "$path/$common" ;;
+  esac
+}
+
+worktree_top="$(realpath -e "$(git -C "$worktree" rev-parse --show-toplevel)")"
+repo_top="$(realpath -e "$(git -C "$repo_root" rev-parse --show-toplevel)")"
+[ "$worktree_top" = "$worktree" ]
+[ "$repo_top" = "$repo_root" ]
+worktree_common="$(canonical_git_common_dir "$worktree")"
+repo_common="$(canonical_git_common_dir "$repo_root")"
+[ "$worktree_common" = "$repo_common" ]
 ```
 
-resolves to exactly `repo-root`. Compute the expected manifest path from the canonical worktree:
+The `show-toplevel` checks are intentionally against each canonical path, not
+against each other: a linked worktree has its own top-level path while sharing
+the repository's canonical common Git directory with the main worktree. Compute
+the expected manifest path from the canonical worktree:
 
 ```bash
 state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
@@ -299,6 +318,7 @@ expected="$(realpath -m "$state_home/orca/oci-worktree-sessions")/$(
 ```
 
 Reject if the supplied `--manifest` is not exactly `expected`. This prevents a stale pane or a caller with another worktree's path from writing that worktree's file.
+
 
 - [ ] **Step 2: Extract only native provider locators**
 
@@ -466,16 +486,43 @@ Repeat with `getSessionFile() -> null` and assert no `--resume-file` argument. R
 
 Keep the existing `setup|archive` interface, `ORCA_TMUX_SOCKET`, `ORCA_TMUX_UNIT`, and `ORCA_TMUX_KEEPER` test overrides, realpath-based root/worktree validation, slugification, root-to-`main` naming, exact session path check, keeper/server check, and exact archive target. Do not replace `session_path` validation with `pane_current_path`; a pane may `cd` away while session ownership remains correct.
 
-Keep these invariants:
+Keep these identity invariants:
+
+The shared setup/archive prelude must keep missing-path tolerance:
 
 ```bash
-root="$(realpath -e "${ORCA_ROOT_PATH:?ORCA_ROOT_PATH missing}")"
-worktree="$(realpath -e "${ORCA_WORKTREE_PATH:?ORCA_WORKTREE_PATH missing}")"
-toplevel="$(git -C "$worktree" rev-parse --show-toplevel)"
-[ "$(realpath -e "$toplevel")" = "$root" ]
+root="$(realpath -m "${ORCA_ROOT_PATH:?ORCA_ROOT_PATH missing}")"
+worktree="$(realpath -m "${ORCA_WORKTREE_PATH:?ORCA_WORKTREE_PATH missing}")"
 ```
 
-A missing worktree is an error for setup and remains archive-tolerated when the directory has already been removed.
+For `setup`, after checking that both paths are directories, canonicalize them
+with `realpath -e` and enforce these identity invariants:
+
+```bash
+root="$(realpath -e "$root")"
+worktree="$(realpath -e "$worktree")"
+worktree_top="$(realpath -e "$(git -C "$worktree" rev-parse --show-toplevel)")"
+[ "$worktree_top" = "$worktree" ]
+
+canonical_git_common_dir() {
+  local path="$1" common
+  common="$(git -C "$path" rev-parse --git-common-dir)"
+  case "$common" in
+    /*) realpath -e "$common" ;;
+    *) realpath -e "$path/$common" ;;
+  esac
+}
+
+root_top="$(realpath -e "$(git -C "$root" rev-parse --show-toplevel)")"
+[ "$root_top" = "$root" ]
+[ "$(canonical_git_common_dir "$worktree")" = "$(canonical_git_common_dir "$root")" ]
+```
+
+The root/worktree comparison uses the shared Git common directory because
+`root` is the main repository worktree for a linked worktree, while
+`worktree_top` must still equal the selected worktree itself. `archive` must not
+run these setup-only `realpath -e` or Git checks; a missing worktree remains
+archive-tolerated.
 
 - [ ] **Step 2: Compute exact session metadata and dependencies**
 
@@ -603,26 +650,38 @@ Read provider fields only through `jq -er` selectors equivalent to:
 
 For OMP, use `.resumeFilePath` when it is a non-empty string; otherwise use the exact `.id`. Missing/malformed fields are provider-local `RECOVERY_REQUIRED`, not a fresh start and not a reason to touch another provider.
 
-- [ ] **Step 4: Add provider command/flag preflight**
-
-Before sending a provider command, verify the binary exists and its help output contains the exact selector and approval options:
+Before sending a provider command, verify the binary exists and the exact
+resume selector and approval options are accepted without starting a provider:
 
 ```text
 codex: CODEX_HOME=$codex_home codex --help contains --dangerously-bypass-approvals-and-sandbox;
        CODEX_HOME=$codex_home codex resume --help is callable
-claude: claude --help contains --resume and --dangerously-skip-permissions
+claude: claude --resume "__orca_capability_probe__" --dangerously-skip-permissions --help exits zero
 omp:    omp --help contains --resume, --auto-approve, --approval-mode, and yolo
 ```
 
+The Claude line is a parser-acceptance probe: it must pass the exact
+`--resume` and `--dangerously-skip-permissions` arguments with `--help` so no
+conversation is resumed or provider session is launched. Do not require those
+flags to appear in `claude --help` output. A failed probe is
+`RECOVERY_REQUIRED`.
+
+The installation artifacts must be checked independently:
 
 ```text
-codex: $codex_home/hooks.json exists and contains the managed SessionStart adapter
-claude: the installed managed Claude hook script exists and contains the raw adapter
-omp: $HOME/.omp/agent/hooks/orca-oci-worktree-session-hook.ts exists and is readable
+codex: $codex_home/hooks.json exists; its SessionStart managed command points to
+       $HOME/.orca/agent-hooks/codex-hook.sh; that shared script contains the
+       raw adapter
+claude: $HOME/.orca/agent-hooks/claude-hook.sh exists and contains the raw adapter
+omp:    $HOME/.omp/agent/hooks/orca-oci-worktree-session-hook.ts exists and is readable
 writer: provider_event_writer is executable
 ```
 
-If any check fails, print `RECOVERY_REQUIRED` in that provider's pane and log the precise preflight reason. Never silently remove a flag, substitute a different resume selector, or use a provider's recent-session option.
+Do not treat the Codex runtime `hooks.json` and shared executable launcher as
+the same file. If any check fails, print `RECOVERY_REQUIRED` in that provider's
+pane and log the precise preflight reason. Never silently remove a flag,
+substitute a different resume selector, or use a provider's recent-session
+option.
 
 - [ ] **Step 5: Send one exact command per provider window**
 
@@ -648,13 +707,16 @@ Extend the coordinator shell test with temporary fake `codex`, `claude`, and `om
 
 ```text
 new session + complete manifest + valid help -> exactly three exact invocations
+new linked-worktree session + matching common dir -> provider recovery allowed
+different repo common dir -> shells + RECOVERY_REQUIRED; zero provider invocations
 new session + ORCA_COORDINATOR_RESUME_AGENTS=0 -> zero provider invocations
 second ensure with existing four-window sessions -> zero duplicate invocations
 missing manifest -> shells + RECOVERY_REQUIRED; zero provider invocations
 wrong manifest binding -> shells + RECOVERY_REQUIRED; zero provider invocations
 missing provider field -> only that provider RECOVERY_REQUIRED
-missing help flag -> provider RECOVERY_REQUIRED; no downgraded invocation
+missing help flag or failed Claude parser probe -> provider RECOVERY_REQUIRED; no downgraded invocation
 provider exits non-zero -> shell remains and RECOVERY_REQUIRED is visible
+ordinary provider event -> writer may run; manifest remains unchanged
 second ensure after provider failure -> no retry/invocation
 pre-existing legacy one-window session -> untouched, no auto-migration
 Windows inventory path -> no local session
@@ -687,17 +749,26 @@ Document this exact flow:
 
 Include the manifest path/schema, exact provider commands, Codex managed-home requirement, OMP hook path, `ORCA_OCI_*` variables, `ORCA_COORDINATOR_RESUME_AGENTS=0` meaning, and the warning that `RECOVERY_REQUIRED` is not evidence that a provider has no upstream session; it means this recovery path is intentionally fail-closed.
 
-- [ ] **Step 2: Record live-hook deployment evidence**
+After the `/srv/script` copy and focused test pass, load the amended Orca source in the supported OCI runtime and invoke the existing managed-agent hook install/reconciliation operation for Claude and Codex. This is the path backed by `installManagedAgentHooks` and its existing `ClaudeHookService.refreshManagedScripts()` / `CodexHookService.refreshManagedScripts()` refreshers; do not manually copy generated managed scripts. If the live OCI runtime cannot run the amended source, stop and do not claim managed-hook deployment.
 
-After the `/srv/script` copy and focused test pass, update the live hook setting and probe a disposable worktree. Record:
+Verify the resulting artifacts before updating the live setup hook:
+
+```text
+Claude: ~/.orca/agent-hooks/claude-hook.sh contains the recorder after the Devin/CLAUDE_JOB_DIR guards
+Codex: redirected CODEX_HOME/hooks.json SessionStart entry points to ~/.orca/agent-hooks/codex-hook.sh
+       ~/.orca/agent-hooks/codex-hook.sh contains the recorder
+```
+
+Then update the live OCI setup hook setting and probe a disposable worktree. Record:
 
 ```text
 observed new session name
 session_path
 0:codex, 1:claude, 2:omp, 3:bash
 all pane_current_path values
-ORCA_OCI_* values and CODEX_HOME
+ORCA_OCI_* values, CODEX_HOME, and ORCA_CODEX_HOME
 OMP hook installation path
+Claude/Codex installed-script probe result
 archive result for the disposable session
 ```
 
@@ -767,9 +838,7 @@ After the tests pass, write `SHA256SUMS.after` in the backup directory from the 
 
 **Files:** repository TypeScript files and tests from Task 1; operational files remain outside Git.
 
-- [ ] **Step 1: Synchronize the OCI commit to hpv2**
-
-Commit only tracked Orca repository changes after the source-focused review. Do not stage the unrelated untracked files. Push the OCI commit, then use `/srv/script/orca-coordinator.sh` to fetch/fast-forward hpv2 and verify the exact commit SHA before running any project command. If hpv2 is unavailable, stop project validation rather than running pnpm on OCI.
+Commit only tracked Orca repository changes after the source-focused review. Do not stage the unrelated untracked files. Push the OCI commit, then use `/srv/script/orca-coordinator.sh` to fetch/fast-forward hpv2 and verify the exact commit SHA before running any project command. If hpv2 is unavailable, stop project validation rather than running pnpm on OCI. This source synchronization and hpv2 validation do not deploy live OCI managed scripts; Task 6 Step 2's supported managed-hook install/reconciliation and installed-script probe remain mandatory before claiming the raw provider path is live.
 
 - [ ] **Step 2: Run focused source tests through hpv2**
 
@@ -810,13 +879,16 @@ Re-run the four OCI shell suites and `git diff --check` after any final source c
 - [ ] A new local OCI worktree setup creates exactly four ordered windows named `codex`, `claude`, `omp`, `bash`, all with the canonical worktree pane CWD and exact session path.
 - [ ] The setup hook is idempotent for an existing exact-path session and fail-closed for a name/path mismatch; it does not auto-migrate old layouts.
 - [ ] A partial new layout is removed without touching any pre-existing session or the coordinator keeper.
-- [ ] Session environment contains the four exact `ORCA_OCI_*` variables and routes raw Codex to the same redirected `CODEX_HOME` where Orca installs its managed hook.
-- [ ] Claude and Codex record native `SessionStart.session_id` through the shared generated POSIX adapter; OMP records `getSessionId()` and optional `getSessionFile()` through the auto-discovered hook.
-- [ ] The manifest is keyed by canonical worktree path, validates canonical root/worktree identity, is mode 0600 under mode-0700 directories, serializes concurrent writers, and publishes atomically.
+- [ ] A linked worktree passes when its canonical `show-toplevel` equals the worktree and its canonical `--git-common-dir` matches the repository root; a different repository is rejected.
+- [ ] Session environment contains the four exact `ORCA_OCI_*` variables and routes raw Codex to the same redirected `CODEX_HOME` where Orca registers its hook.
+- [ ] Claude and Codex raw recorders run after required provider exclusions, pass native payloads to the writer, and the manifest changes only for native `SessionStart.session_id`; ordinary events leave it unchanged.
+- [ ] Claude's shared `~/.orca/agent-hooks/claude-hook.sh` and Codex's shared `~/.orca/agent-hooks/codex-hook.sh` contain the recorder; Codex's redirected `CODEX_HOME/hooks.json` independently registers the shared launcher.
+- [ ] OMP records `getSessionId()` and optional `getSessionFile()` through the auto-discovered hook.
+- [ ] The manifest is keyed by canonical worktree path, validates canonical root/worktree identity and shared Git common directory, is mode 0600 under mode-0700 directories, serializes concurrent writers, and publishes atomically.
 - [ ] The coordinator sends fixed provider resume commands with exact dangerous approval flags only to sessions observed as newly created in the current invocation.
-- [ ] Missing/malformed/mismatched locators, missing hook dependencies, unsupported help flags, and failed provider launches leave shells plus `RECOVERY_REQUIRED`; no fallback starts.
+- [ ] Claude capability preflight uses a non-launching parser-acceptance probe; unsupported flags, missing artifacts, and failed launches leave shells plus `RECOVERY_REQUIRED` with no fallback.
 - [ ] A second coordinator invocation sends no duplicate provider command to an existing session, including after a provider failure.
 - [ ] `ORCA_COORDINATOR_RESUME_AGENTS=0` suppresses provider sends without suppressing the four-window layout.
 - [ ] Windows/hpv2 inventory entries remain excluded and hpv2/runtime failures do not destroy OCI sessions.
 - [ ] Raw tmux remains outside Orca's managed worker/UI contract.
-- [ ] Focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.
+- [ ] The supported OCI managed-hook deployment and live installed-script probe are recorded separately from hpv2 source validation; focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.

--- a/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
+++ b/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
@@ -1,0 +1,822 @@
+# OCI Worktree tmux Agent Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every local OCI Git worktree recoverable after an OCI/tmux restart by having the setup hook create one deterministic four-window tmux session (`codex`, `claude`, `omp`, `bash`) and having the coordinator resume each provider exactly once from provider-native session locators persisted in a path-bound manifest.
+
+**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and OMP hook installation. Provider hooks record native `SessionStart` identifiers through a host-local atomic manifest writer. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch.
+
+**Tech Stack:** Bash, tmux, jq, `realpath`, `sha256sum`, `flock`, TypeScript-generated POSIX hook scripts, Bun OMP hooks, the existing `/srv/script/orca-coordinator.sh` JSON CLI integration, Vitest, ShellCheck.
+
+**Review basis:** The approved design is recorded in `docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md`. The final standalone web GPT contract review returned `APPROVE` / `NONE` from the revised summary; it was a contract review, not independent repository inspection. The implementation must therefore retain the local source facts below, especially Codex's redirected `CODEX_HOME`, OMP's native `sessionManager` APIs, and the existing setup-hook source-of-truth boundary.
+
+---
+
+## Scope and non-goals
+
+- Modify the OCI host recovery scripts and their focused shell tests:
+  - `/srv/script/orca-tmux-hook.sh`
+  - `/srv/script/orca-tmux-hook.test.sh`
+  - `/srv/script/orca-worktree-session-manifest.sh` (new)
+  - `/srv/script/orca-worktree-session-manifest.test.sh` (new)
+  - `/srv/script/orca-omp-worktree-session-hook.ts` (new)
+  - `/srv/script/orca-omp-worktree-session-hook.test.sh` (new)
+  - `/srv/script/orca-coordinator.sh`
+  - `/srv/script/orca-coordinator.test.sh`
+  - `/srv/script/projects/orca.md`
+- Modify Orca's POSIX provider hook generators so raw tmux provider processes use the same native event adapters as Orca-managed providers:
+  - `src/main/agent-hooks/oci-worktree-session-event.ts` (new shared generator)
+  - `src/main/agent-hooks/oci-worktree-session-event.test.ts` (new)
+  - `src/main/claude/hook-service.ts`
+  - `src/main/claude/hook-service.test.ts`
+  - `src/main/codex/codex-hook-script.ts`
+  - `src/main/codex/hook-service-managed-install.test.ts`
+- Keep the approved design specification unchanged unless implementation evidence exposes a real contract error; update the plan or spec before coding if that happens.
+- Do not change Dashboard, AgentMap, managed-worker registration, terminal ownership, IPC, RPC, stream frames, or remote wire contracts. A raw tmux pane is never an Orca-managed worker.
+- Do not auto-migrate an existing one-window or otherwise legacy session. Existing sessions are left untouched; the documented operator action is archive and recreate once.
+- Do not infer provider locators from terminal text, pane order, mtimes, recent-session pickers, `--last`, `--continue`, or a fresh provider launch.
+- Do not make hpv2 or Windows part of this recovery path. The coordinator must continue filtering non-local paths and must not destroy OCI sessions when hpv2 is unavailable.
+- Do not run project pnpm tests, typechecks, lint, builds, packaging, or Electron on OCI. Run those through the hpv2 coordinator after the OCI commit is pushed and the exact SHA is synchronized.
+- Do not touch `/srv/workspace/scouter` or the unrelated untracked files `ISSUE-archive-hook-cli-remote.md` and `ORPHAN-PTY-FINDINGS.md`.
+
+## Host and ownership contract
+
+- OCI source/control plane: `/srv/workspace/orca`, selector `cd90eb16-48b5-4735-aeb5-74a0a15e511c`, current contribution session `orca-wt-main`.
+- hpv2 validation plane: selector `bdf5ef9b-3d40-45b1-9b84-3ce9e3630cd4`, canonical path `C:/Users/ljhlj/workspace/orca`, environment `hp_v2`.
+- `/srv/script` is the coordinator host's operational directory, not a Git worktree. Before changing any `/srv/script` file, create a dated backup and `SHA256SUMS.before`; after verification write `SHA256SUMS.after`. Never run `git add` or `git commit` in `/srv/script`.
+- The Orca UI's local project hook setting remains the live setup/archive source of truth. `/srv/script/orca-tmux-hook.sh` is the focused test/deployment copy. After changing the copy, update the existing live OCI setup hook body with the identical layout, environment, OMP installation, and partial-cleanup logic through the normal Orca UI operation; the CLI cannot edit this setting. Do not claim deployment until the live hook has been manually updated and probed.
+- The current coordinator unit and live sessions are not to be restarted, killed, archived, or recreated during implementation. Use throwaway tmux sockets for tests. A real OCI reboot/recovery trial is a separate coordinator/host-owner operation after all static and focused checks pass.
+- The coordinator process itself continues to own only the `coordinator` keeper session. Its existing single-pane startup behavior and `ORCA_COORDINATOR_AGENT_RESUME_CMD`/`ORCA_COORDINATOR_AGENT_START_CMD` test overrides remain isolated from per-worktree provider recovery.
+
+## File structure and responsibilities
+
+### Create
+
+- `/srv/script/orca-worktree-session-manifest.sh` — host-local `record` command. Validates canonical worktree/root identity and exact manifest path, extracts native Claude/Codex JSON identifiers or accepts OMP's native identifier arguments, serializes concurrent updates with `flock`, and publishes mode-0600 JSON through temp-file plus atomic rename.
+- `/srv/script/orca-worktree-session-manifest.test.sh` — isolated manifest writer, path-binding, permissions, concurrency, malformed-input, and moved-worktree tests.
+- `/srv/script/orca-omp-worktree-session-hook.ts` — OMP auto-discovered `session_start` hook. Reads `ctx.sessionManager.getSessionId()` and optional `ctx.sessionManager.getSessionFile()`, then invokes the manifest writer with the tmux session's exact environment context.
+- `/srv/script/orca-omp-worktree-session-hook.test.sh` — Bun harness that registers the hook with a fake HookAPI and verifies the native OMP callback arguments sent to a fake writer.
+- `src/main/agent-hooks/oci-worktree-session-event.ts` — shared POSIX shell-line generator for guarded raw-tmux native `SessionStart` recording; no endpoint, pane key, or UI relay dependency.
+- `src/main/agent-hooks/oci-worktree-session-event.test.ts` — exact generated-line contract and platform guard tests.
+
+### Modify
+
+- `/srv/script/orca-tmux-hook.sh` — create and validate the four-window layout, install the OMP hook, set session-scoped raw recovery environment, and remove partially created sessions on layout failure.
+- `/srv/script/orca-tmux-hook.test.sh` — assert exact ordered windows, session/pane paths, env values, idempotency, mismatch fail-closed behavior, and partial-layout cleanup.
+- `/srv/script/orca-coordinator.sh` — preserve current coordinator/hpv2 behavior while replacing worktree's old single Codex `--last` bootstrap with observed-new-session provider recovery and exact preflighted commands.
+- `/srv/script/orca-coordinator.test.sh` — add fake provider binaries, manifests, flag preflight, one-shot, failure, and `RESUME_AGENTS=0` cases without weakening current liveness checks.
+- `/srv/script/projects/orca.md` — document the OCI recovery contract, operational backup/hashes, manifest location, provider flags, `RECOVERY_REQUIRED`, and archive/recreate procedure.
+- `src/main/claude/hook-service.ts` — add the shared raw-tmux recorder to the generated POSIX script while preserving the neutral JSON output, Devin guard, endpoint refresh, and normal Orca spool/post path.
+- `src/main/claude/hook-service.test.ts` — verify the installed POSIX managed script contains and executes the raw native SessionStart branch without changing existing user settings behavior.
+- `src/main/codex/codex-hook-script.ts` — add the same shared raw-tmux recorder to the generated POSIX script while preserving endpoint refresh, WSL curl fallback, and normal spool/post behavior.
+- `src/main/codex/hook-service-managed-install.test.ts` — verify the managed script installed under the redirected runtime `CODEX_HOME` records raw native SessionStart payloads and still posts ordinary events.
+
+### Do not modify
+
+- `src/shared/agent-session-resume.ts` and `src/shared/tui-agent-resume-startup.ts`; their already verified provider argv mapping is the command contract this feature consumes.
+- `src/main/agent-hooks/managed-agent-hook-registry.ts`; raw OMP installation is host-local auto-discovery, not a managed Orca worker hook.
+- `src/renderer/src/**`; there is no UI change.
+- `/srv/script/AGENTS.md` and `/home/ai/.codex/AGENTS.md`; they remain host/project policy.
+
+## Operational backup before `/srv/script` edits
+
+Run this once immediately before the first operational edit, on OCI:
+
+```bash
+stamp="$(date +%Y%m%dT%H%M%S)"
+backup="/srv/script/.backup/$stamp"
+mkdir -p "$backup"
+cp /srv/script/orca-tmux-hook.sh \
+  /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/orca-coordinator.sh \
+  /srv/script/orca-coordinator.test.sh \
+  /srv/script/projects/orca.md \
+  "$backup/"
+sha256sum \
+  /srv/script/orca-tmux-hook.sh \
+  /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/orca-coordinator.sh \
+  /srv/script/orca-coordinator.test.sh \
+  /srv/script/projects/orca.md \
+  >"$backup/SHA256SUMS.before"
+printf '%s\n' "$backup"
+```
+
+Record the new files separately after creation and write the matching `SHA256SUMS.after` only after focused checks pass:
+
+```bash
+sha256sum \
+  /srv/script/orca-tmux-hook.sh \
+  /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/orca-worktree-session-manifest.sh \
+  /srv/script/orca-worktree-session-manifest.test.sh \
+  /srv/script/orca-omp-worktree-session-hook.ts \
+  /srv/script/orca-omp-worktree-session-hook.test.sh \
+  /srv/script/orca-coordinator.sh \
+  /srv/script/orca-coordinator.test.sh \
+  /srv/script/projects/orca.md \
+  >"$backup/SHA256SUMS.after"
+```
+
+## Contract constants
+
+Use these exact values in production; only the explicitly named test environment overrides may vary them:
+
+```text
+session name       repo-root-basename-wt-worktree-basename
+root worktree slug main
+window 0           codex
+window 1           claude
+window 2           omp
+window 3           bash
+manifest root      ${XDG_STATE_HOME:-$HOME/.local/state}/orca/oci-worktree-sessions
+manifest file      sha256(realpath(worktree)).json
+manifest mode      0600; parent directories 0700
+writer             /srv/script/orca-worktree-session-manifest.sh
+OMP hook source    /srv/script/orca-omp-worktree-session-hook.ts
+```
+
+The setup hook passes these per-session variables, exactly as named:
+
+```text
+ORCA_OCI_SESSION_MANIFEST=canonical manifest path
+ORCA_OCI_WORKTREE_PATH=canonical worktree path
+ORCA_OCI_REPO_ROOT=canonical repository root
+ORCA_OCI_PROVIDER_EVENT_WRITER=/srv/script/orca-worktree-session-manifest.sh
+```
+
+The setup hook also sets `CODEX_HOME` and `ORCA_CODEX_HOME` to the Orca-managed runtime home `${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home` unless the coordinator's test-only `ORCA_COORDINATOR_CODEX_HOME` override is present. This closes the existing Codex split where Orca installs hooks in its redirected runtime home while a raw shell would otherwise invoke the user's `~/.codex`.
+
+The persisted schema is exactly:
+
+```json
+{
+  "version": 1,
+  "worktreePath": "/canonical/worktree",
+  "repoRoot": "/canonical/repository",
+  "providers": {
+    "codex": { "key": "session_id", "id": "codex-session-id" },
+    "claude": { "key": "session_id", "id": "claude-session-id" },
+    "omp": { "key": "session_id", "id": "omp-session-id", "resumeFilePath": "/canonical/omp-session.jsonl" }
+  }
+}
+```
+
+Provider resume commands are fixed and must not be generalized through an environment override:
+
+```bash
+codex resume "$CODEX_SESSION_ID" --dangerously-bypass-approvals-and-sandbox
+claude --resume "$CLAUDE_SESSION_ID" --dangerously-skip-permissions
+omp --resume "$OMP_RESUME_TARGET" --auto-approve --approval-mode=yolo
+```
+
+The coordinator may override provider binary paths, writer, OMP source, and Codex home only for isolated tests. Tests set `XDG_STATE_HOME` to a temporary directory instead of overriding the manifest-root formula. The coordinator must not override provider argv or approval flags in production.
+
+## Implementation tasks
+
+### Task 1: Add the native raw-tmux event adapter generator
+
+**Files:**
+
+- Create `src/main/agent-hooks/oci-worktree-session-event.ts`.
+- Create `src/main/agent-hooks/oci-worktree-session-event.test.ts`.
+- Modify `src/main/claude/hook-service.ts`.
+- Modify `src/main/codex/codex-hook-script.ts`.
+
+- [ ] **Step 1: Define the shared generator contract**
+
+Export one concrete function:
+
+```ts
+export type OciWorktreeProvider = 'claude' | 'codex'
+
+export function buildPosixOciWorktreeSessionRecordLines(
+  provider: OciWorktreeProvider
+): string[]
+```
+
+The returned shell lines must:
+
+1. Require all four `ORCA_OCI_*` variables before doing anything.
+2. Pipe the already captured native `payload` variable to the configured writer's `record` command.
+3. Pass `--manifest`, `--provider`, `--worktree`, `--repo-root`, and `--payload-stdin` as separate shell arguments.
+4. Redirect writer output and errors away from the provider hook protocol and fail open for the provider process (`|| :`).
+5. Never inspect terminal output, `PWD`, mtimes, endpoint variables, pane keys, or UI relay state.
+
+Generated line shape:
+
+```sh
+if [ -n "${ORCA_OCI_SESSION_MANIFEST:-}" ] && \
+   [ -n "${ORCA_OCI_WORKTREE_PATH:-}" ] && \
+   [ -n "${ORCA_OCI_REPO_ROOT:-}" ] && \
+   [ -x "${ORCA_OCI_PROVIDER_EVENT_WRITER:-}" ]; then
+  printf '%s' "$payload" | "$ORCA_OCI_PROVIDER_EVENT_WRITER" record \
+    --manifest "$ORCA_OCI_SESSION_MANIFEST" \
+    --provider claude \
+    --worktree "$ORCA_OCI_WORKTREE_PATH" \
+    --repo-root "$ORCA_OCI_REPO_ROOT" \
+    --payload-stdin >/dev/null 2>&1 || :
+fi
+```
+
+The Claude generator emits `--provider claude`; the Codex generator emits the same line with the compile-time literal `--provider codex`. No generated script accepts a provider value from payload text.
+
+- [ ] **Step 2: Add the adapter before normal spool/post code**
+
+In Claude's POSIX `getManagedScript()` return array, place the generated lines immediately after `buildPosixHookPayloadCapture()` and before `buildPosixHookSpoolLines('claude')`. Preserve the existing initial `printf "{}\\n"`, Devin skip, `CLAUDE_JOB_DIR` exit, endpoint refresh, and neutral exit paths. Do not add this branch to the Windows `.cmd` output; this recovery surface is Linux POSIX tmux.
+
+In Codex's POSIX `getManagedScript()` return array, place the generated lines immediately after `buildPosixHookPayloadCapture()` and before `buildPosixHookSpoolLines('codex')`. Preserve the existing endpoint loader and WSL curl fallback. Do not make the raw branch depend on a successfully loaded `ORCA_AGENT_HOOK_ENDPOINT`.
+
+- [ ] **Step 3: Test generated contract and normal-path isolation**
+
+Add tests that assert:
+
+```ts
+expect(buildPosixOciWorktreeSessionRecordLines('claude').join('\n')).toContain(
+  '--provider claude'
+)
+expect(buildPosixOciWorktreeSessionRecordLines('codex').join('\n')).toContain(
+  '--provider codex'
+)
+expect(lines.join('\n')).toContain('ORCA_OCI_SESSION_MANIFEST')
+expect(lines.join('\n')).not.toContain('ORCA_AGENT_HOOK_ENDPOINT')
+expect(lines.join('\n')).not.toContain('ORCA_PANE_KEY')
+```
+
+Use the existing provider install tests to read the actual installed scripts and run each script on a temporary POSIX host with a fake executable writer. Send a native `SessionStart` JSON payload containing a provider `session_id`; assert the writer receives the exact payload on stdin and the provider script exits zero. Send an ordinary event and assert the raw writer is not invoked. Leave the existing ordinary Orca endpoint/post assertions intact.
+
+- [ ] **Step 4: Run the focused source tests through hpv2**
+
+Do not run pnpm on OCI. After the source edits are made, use the hpv2 routing procedure in Task 8 for:
+
+```bash
+pnpm test src/main/agent-hooks/oci-worktree-session-event.test.ts \
+  src/main/claude/hook-service.test.ts \
+  src/main/codex/hook-service-managed-install.test.ts
+```
+
+### Task 2: Implement the atomic, path-bound manifest writer
+
+**Files:**
+
+- Create `/srv/script/orca-worktree-session-manifest.sh`.
+- Create `/srv/script/orca-worktree-session-manifest.test.sh`.
+
+- [ ] **Step 1: Implement strict argument parsing and canonical identity checks**
+
+Use `set -euo pipefail`, `umask 077`, and a single `record` subcommand. Require these arguments:
+
+```text
+--manifest PATH
+--provider codex|claude|omp
+--worktree PATH
+--repo-root PATH
+```
+
+Require exactly one locator source:
+
+```text
+--payload-stdin                  # only codex/claude
+--session-id ID                  # only omp
+--resume-file PATH               # optional omp field, only with --session-id
+```
+
+Reject unknown flags, missing values, duplicate flags, empty IDs, control characters, and provider/locator combinations that do not match the table above. Do not echo the native payload or locator into diagnostics.
+
+Resolve `worktree` and `repo-root` with `realpath -e`. Verify:
+
+```bash
+git -C "$worktree" rev-parse --show-toplevel
+```
+
+resolves to exactly `repo-root`. Compute the expected manifest path from the canonical worktree:
+
+```bash
+state_home="${XDG_STATE_HOME:-$HOME/.local/state}"
+expected="$(realpath -m "$state_home/orca/oci-worktree-sessions")/$(
+  printf '%s' "$worktree" | sha256sum | cut -d' ' -f1
+).json"
+```
+
+Reject if the supplied `--manifest` is not exactly `expected`. This prevents a stale pane or a caller with another worktree's path from writing that worktree's file.
+
+- [ ] **Step 2: Extract only native provider locators**
+
+For Claude and Codex, read all stdin once and use `jq -er` to require the native event and identifier:
+
+```bash
+event_name="$(printf '%s' "$payload" | jq -er '.hook_event_name // empty')"
+[ "$event_name" = SessionStart ] || exit 0
+session_id="$(printf '%s' "$payload" | jq -er '.session_id | strings | select(length > 0)')"
+```
+
+Do not accept an event with a missing/empty `session_id`; return non-zero without changing the manifest. Do not parse a transcript filename, terminal output, or current directory from the payload.
+
+For OMP, accept the exact `--session-id` from `ctx.sessionManager.getSessionId()` and preserve a non-empty `--resume-file` from `ctx.sessionManager.getSessionFile()` as `resumeFilePath`. Do not derive either value from a path basename, mtime, or recent picker.
+
+- [ ] **Step 3: Publish one provider field atomically and serialize writers**
+
+Create the parent directory with mode 0700, open a stable `manifest.lock` file with mode 0600, and acquire an exclusive `flock` before reading or writing. A stale lock file is harmless because `flock` is released by process exit.
+
+If the manifest exists, reject it unless it is valid JSON with:
+
+```jq
+.version == 1
+and .worktreePath == $worktree
+and .repoRoot == $repo_root
+and (.providers | type == "object")
+```
+
+For a missing manifest, start with the exact version/path/root/provider object. Replace only the selected provider field. Preserve the other provider fields and preserve all existing `omp.resumeFilePath` data when the incoming OMP event has no resume file.
+
+Write JSON to `mktemp "$manifest.tmp.XXXXXX"`, `chmod 600` the temp file, then `mv -f` it over the manifest. Remove the temp file on every failure. Never write directly to the final path and never leave a mode-0644 intermediate file.
+
+- [ ] **Step 4: Test writer behavior and security boundaries**
+
+The shell test must create a temporary Git root and worktree and verify:
+
+```text
+Claude SessionStart JSON -> providers.claude.key=session_id and exact id
+Codex SessionStart JSON  -> providers.codex.key=session_id and exact id
+OMP session-id + file    -> providers.omp.id and resumeFilePath
+second provider record   -> previous provider fields preserved
+concurrent codex/claude records -> both fields survive
+manifest mode            -> 600; parent directory -> 700
+wrong manifest hash      -> non-zero and no write
+wrong repo root          -> non-zero and no write
+moved/missing worktree   -> non-zero and no write
+malformed existing JSON  -> non-zero and file unchanged
+ordinary provider event  -> zero and no provider field
+missing native id        -> non-zero and no provider field
+```
+
+Also assert the writer has no code path reading `tmux capture-pane`, `pane_current_path`, file mtimes, or recent session listings. Run the actual script; do not make a source-text-only test the sole proof.
+
+### Task 3: Add the native OMP `session_start` adapter and installation
+
+**Files:**
+
+- Create `/srv/script/orca-omp-worktree-session-hook.ts`.
+- Create `/srv/script/orca-omp-worktree-session-hook.test.sh`.
+- Modify `/srv/script/orca-tmux-hook.sh` and its test.
+
+- [ ] **Step 1: Implement the OMP hook against the installed API**
+
+Export a default function that subscribes only to `session_start`:
+
+```ts
+import { spawnSync } from 'node:child_process'
+
+type OmpHookContext = {
+  cwd: string
+  sessionManager: {
+    getSessionId(): string
+    getSessionFile(): string | null
+  }
+}
+
+export default function registerOciWorktreeHook(pi: {
+  on(
+    event: 'session_start',
+    handler: (event: unknown, ctx: OmpHookContext) => unknown
+  ): void
+}): void {
+  pi.on('session_start', async (_event, ctx) => {
+    const manifest = process.env.ORCA_OCI_SESSION_MANIFEST?.trim()
+    const worktree = process.env.ORCA_OCI_WORKTREE_PATH?.trim()
+    const repoRoot = process.env.ORCA_OCI_REPO_ROOT?.trim()
+    const writer = process.env.ORCA_OCI_PROVIDER_EVENT_WRITER?.trim()
+    const sessionId = ctx.sessionManager.getSessionId().trim()
+    const resumeFilePath = ctx.sessionManager.getSessionFile()?.trim() ?? ''
+    if (!manifest || !worktree || !repoRoot || !writer || !sessionId) return
+
+    const args = [
+      'record',
+      '--manifest',
+      manifest,
+      '--provider',
+      'omp',
+      '--worktree',
+      worktree,
+      '--repo-root',
+      repoRoot,
+      '--session-id',
+      sessionId
+    ]
+    if (resumeFilePath) args.push('--resume-file', resumeFilePath)
+    try {
+      spawnSync(writer, args, { stdio: 'ignore' })
+    } catch {
+      // A missing writer must not make the OMP session unusable.
+    }
+  })
+}
+```
+
+Use the actual `HookContext` shape verified in the installed OMP package: `cwd`, readonly `sessionManager`, `getSessionId()`, and `getSessionFile()`. Catch spawn errors so the OMP session itself remains usable; the coordinator's missing manifest/provider field is the recovery signal. Do not subscribe to session switch/branch events.
+
+The runtime script must not hardcode a different writer path; the setup hook's environment is authoritative. The test may set `ORCA_OCI_PROVIDER_EVENT_WRITER` to a temporary fake executable.
+
+- [ ] **Step 2: Install the hook idempotently from the setup hook**
+
+Before creating a new tmux session, the setup hook must:
+
+```bash
+omp_hook_dir="$HOME/.omp/agent/hooks"
+mkdir -p "$omp_hook_dir"
+tmp_hook="$(mktemp "$omp_hook_dir/orca-oci-worktree-session-hook.ts.XXXXXX")"
+cp "$omp_hook_source" "$tmp_hook"
+chmod 600 "$tmp_hook"
+mv -f "$tmp_hook" "$omp_hook_dir/orca-oci-worktree-session-hook.ts"
+```
+
+Use `/srv/script/orca-omp-worktree-session-hook.ts` by default and `ORCA_OCI_OMP_HOOK_SOURCE` only as an isolated test override. If the source is absent or cannot be copied, fail before creating a session. Do not overwrite any other user hook.
+
+The live hook body must carry this same installation logic. Re-running setup for an existing session must return after session path validation without changing the OMP hook or any session environment.
+
+- [ ] **Step 3: Test the OMP adapter through a real callback**
+
+The shell test must generate a Bun harness that imports the new `.ts` file, captures the `session_start` handler, supplies:
+
+```text
+getSessionId()  -> omp-native-id
+getSessionFile() -> /tmp/omp-native-session.jsonl
+cwd -> /srv/worktree
+```
+
+Set the four `ORCA_OCI_*` environment variables and invoke the handler. The fake writer must log argv and assert:
+
+```text
+record --manifest /tmp/oci-manifest.json --provider omp --worktree /srv/worktree
+      --repo-root /srv/repository --session-id omp-native-id
+      --resume-file /tmp/omp-native-session.jsonl
+```
+
+Repeat with `getSessionFile() -> null` and assert no `--resume-file` argument. Repeat with missing context and assert no writer invocation.
+
+### Task 4: Make the setup hook own the deterministic four-window layout
+
+**Files:**
+
+- Modify `/srv/script/orca-tmux-hook.sh`.
+- Modify `/srv/script/orca-tmux-hook.test.sh`.
+- Update the live OCI setup hook setting with the same body after the copy passes.
+
+- [ ] **Step 1: Preserve current identity and archive behavior**
+
+Keep the existing `setup|archive` interface, `ORCA_TMUX_SOCKET`, `ORCA_TMUX_UNIT`, and `ORCA_TMUX_KEEPER` test overrides, realpath-based root/worktree validation, slugification, root-to-`main` naming, exact session path check, keeper/server check, and exact archive target. Do not replace `session_path` validation with `pane_current_path`; a pane may `cd` away while session ownership remains correct.
+
+Keep these invariants:
+
+```bash
+root="$(realpath -e "${ORCA_ROOT_PATH:?ORCA_ROOT_PATH missing}")"
+worktree="$(realpath -e "${ORCA_WORKTREE_PATH:?ORCA_WORKTREE_PATH missing}")"
+toplevel="$(git -C "$worktree" rev-parse --show-toplevel)"
+[ "$(realpath -e "$toplevel")" = "$root" ]
+```
+
+A missing worktree is an error for setup and remains archive-tolerated when the directory has already been removed.
+
+- [ ] **Step 2: Compute exact session metadata and dependencies**
+
+Compute:
+
+```bash
+manifest_dir="$(realpath -m "${XDG_STATE_HOME:-$HOME/.local/state}/orca/oci-worktree-sessions")"
+manifest="${manifest_dir}/$(printf '%s' "$worktree" | sha256sum | cut -d' ' -f1).json"
+writer="${ORCA_OCI_PROVIDER_EVENT_WRITER:-/srv/script/orca-worktree-session-manifest.sh}"
+omp_hook_source="${ORCA_OCI_OMP_HOOK_SOURCE:-/srv/script/orca-omp-worktree-session-hook.ts}"
+codex_home="${ORCA_COORDINATOR_CODEX_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home}"
+```
+
+Require `tmux`, `git`, `realpath`, `sha256sum`, `jq`, and the writer. Require the OMP source for a new session. These checks are setup dependencies, not a reason to modify an existing session.
+
+- [ ] **Step 3: Leave existing sessions untouched**
+
+After exact-name `has-session`, compare `#{session_path}` to the canonical worktree. If it matches, print the existing ready message and exit successfully before installing hooks, setting env, adding windows, or touching any file. If it differs, fail closed. Do not inspect or mutate the existing window count; this is what makes old one-window sessions an explicit archive/recreate operation.
+
+- [ ] **Step 4: Create the session with four ordered windows and session-scoped env**
+
+For a new session, create window 0 with the exact name and environment, then create windows 1–3 with the exact names and `-c "$worktree"`:
+
+```bash
+tmux -L "$socket" new-session -d -s "$session" -n codex -c "$worktree" \
+  -e "ORCA_OCI_SESSION_MANIFEST=$manifest" \
+  -e "ORCA_OCI_WORKTREE_PATH=$worktree" \
+  -e "ORCA_OCI_REPO_ROOT=$root" \
+  -e "ORCA_OCI_PROVIDER_EVENT_WRITER=$writer" \
+  -e "CODEX_HOME=$codex_home" \
+  -e "ORCA_CODEX_HOME=$codex_home"
+tmux -L "$socket" new-window -d -t "$session:1" -n claude -c "$worktree"
+tmux -L "$socket" new-window -d -t "$session:2" -n omp -c "$worktree"
+tmux -L "$socket" new-window -d -t "$session:3" -n bash -c "$worktree"
+tmux -L "$socket" select-window -t "$session:0"
+```
+
+Use the test socket and shell's arguments exactly as existing code does; do not start a provider from the hook. Validate after creation:
+
+```text
+#{session_path} == canonical worktree
+0:codex
+1:claude
+2:omp
+3:bash
+all four #{pane_current_path} == canonical worktree
+show-environment contains all four ORCA_OCI_* values and CODEX_HOME/ORCA_CODEX_HOME
+```
+
+- [ ] **Step 5: Remove partial new sessions on any layout failure**
+
+Set a `created_session=1` flag immediately after `new-session` succeeds and install an `EXIT` trap that kills only `=$session` when `layout_ready` is still false. Clear the trap only after all windows, environment, path, and ordered-layout checks pass. Never kill the keeper or any pre-existing session. The test must force a delegated `tmux new-window` failure through a temporary PATH wrapper and assert no session remains.
+
+- [ ] **Step 6: Test setup idempotency and non-mutation**
+
+Extend the existing throwaway-socket test to assert:
+
+```text
+root name -> repoa-wt-main
+feature name -> repoa-wt-feature
+exactly four ordered windows
+all four pane cwds == worktree
+session_path == worktree even after a pane cd /tmp
+all four ORCA_OCI_* env values exact
+CODEX_HOME and ORCA_CODEX_HOME exact
+second setup -> no extra window/no env rewrite/no hook rewrite
+same-name wrong path -> non-zero
+missing worktree -> non-zero
+non-git directory -> non-zero
+partial new layout -> session removed
+archive -> exact session only; missing/deleted path archive is zero
+```
+
+Run the live UI setup hook manually against a disposable local worktree only after this test passes. Observe the newly created session, four windows, session path, pane paths, and env; archive that disposable session through the existing archive hook. Do not use a real project worktree for the probe.
+
+### Task 5: Replace worktree `--last` bootstrap with one-shot provider recovery
+
+**Files:**
+
+- Modify `/srv/script/orca-coordinator.sh`.
+- Modify `/srv/script/orca-coordinator.test.sh`.
+
+- [ ] **Step 1: Keep coordinator startup separate and add recovery configuration**
+
+Do not change `ensure_session()`'s coordinator keeper logic. Add these configuration values for the worktree path only:
+
+```bash
+manifest_root="${XDG_STATE_HOME:-$HOME/.local/state}/orca/oci-worktree-sessions"
+provider_event_writer="${ORCA_COORDINATOR_PROVIDER_EVENT_WRITER:-/srv/script/orca-worktree-session-manifest.sh}"
+omp_hook_source="${ORCA_COORDINATOR_OMP_HOOK_SOURCE:-/srv/script/orca-omp-worktree-session-hook.ts}"
+codex_home="${ORCA_COORDINATOR_CODEX_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}/orca/codex-runtime-home/home}"
+```
+
+Retain `ORCA_COORDINATOR_RESUME_AGENTS` as the sole switch for whether provider commands are sent to newly created sessions. It must not cause commands to be sent to existing worktree sessions.
+
+- [ ] **Step 2: Keep observed-new-session ownership**
+
+In `restore_worktree_sessions()` retain the current local inventory pairing and Windows-path filter. For each local worktree:
+
+```bash
+before="$(session_names)"
+run_setup_hook_with_oci_context
+if setup succeeds; then
+  after="$(session_names)"
+  created="$(comm -13 <(printf '%s\n' "$before") <(printf '%s\n' "$after"))"
+  while IFS= read -r session; do
+    [ -n "$session" ] || continue
+    recover_new_worktree_session "$session" "$root" "$path"
+  done <<<"$created"
+fi
+```
+
+Use the observed `created` name as the only target. Do not calculate a session name in the coordinator, do not use a prefix target, and do not recover any session absent from the before/after delta. If the hook fails, log it and continue; do not remove sessions or fail the coordinator keeper.
+
+- [ ] **Step 3: Add exact manifest and layout reads**
+
+For a newly created session, read `ORCA_OCI_SESSION_MANIFEST`, `ORCA_OCI_WORKTREE_PATH`, and `ORCA_OCI_REPO_ROOT` from the session environment and compare the latter two values to the canonical `$path` and `$root` arguments from the inventory loop. Reject the session for provider recovery if any is missing, if the manifest path is not the exact sha256 path under `manifest_root`, or if manifest `worktreePath`/`repoRoot` do not exactly match the setup context. Log `RECOVERY_REQUIRED` and leave all panes as shells when the binding fails.
+Read provider fields only through `jq -er` selectors equivalent to:
+
+```jq
+.providers.codex.key == "session_id" and (.providers.codex.id | strings | length > 0)
+.providers.claude.key == "session_id" and (.providers.claude.id | strings | length > 0)
+.providers.omp.key == "session_id" and (.providers.omp.id | strings | length > 0)
+```
+
+For OMP, use `.resumeFilePath` when it is a non-empty string; otherwise use the exact `.id`. Missing/malformed fields are provider-local `RECOVERY_REQUIRED`, not a fresh start and not a reason to touch another provider.
+
+- [ ] **Step 4: Add provider command/flag preflight**
+
+Before sending a provider command, verify the binary exists and its help output contains the exact selector and approval options:
+
+```text
+codex: CODEX_HOME=$codex_home codex --help contains --dangerously-bypass-approvals-and-sandbox;
+       CODEX_HOME=$codex_home codex resume --help is callable
+claude: claude --help contains --resume and --dangerously-skip-permissions
+omp:    omp --help contains --resume, --auto-approve, --approval-mode, and yolo
+```
+
+
+```text
+codex: $codex_home/hooks.json exists and contains the managed SessionStart adapter
+claude: the installed managed Claude hook script exists and contains the raw adapter
+omp: $HOME/.omp/agent/hooks/orca-oci-worktree-session-hook.ts exists and is readable
+writer: provider_event_writer is executable
+```
+
+If any check fails, print `RECOVERY_REQUIRED` in that provider's pane and log the precise preflight reason. Never silently remove a flag, substitute a different resume selector, or use a provider's recent-session option.
+
+- [ ] **Step 5: Send one exact command per provider window**
+
+Use fixed window names/indexes from the hook's new-session contract and shell-quote every manifest-derived locator with Bash `printf '%q'`. Send only these commands:
+
+```bash
+codex resume "$codex_id" --dangerously-bypass-approvals-and-sandbox
+claude --resume "$claude_id" --dangerously-skip-permissions
+omp --resume "$omp_resume_target" --auto-approve --approval-mode=yolo
+```
+
+Wrap each command so a non-zero provider exit leaves the shell alive and prints a literal sentinel:
+
+```bash
+if codex resume "$codex_id" --dangerously-bypass-approvals-and-sandbox; then :; else printf '%s\n' RECOVERY_REQUIRED; fi
+```
+
+Send no provider command and no sentinel when `ORCA_COORDINATOR_RESUME_AGENTS=0`; the four-window shell layout is still created. Do not add a second command on a later reconcile: only the current setup invocation's `created` set can enter this function.
+
+- [ ] **Step 6: Test recovery, idempotency, and failure behavior**
+
+Extend the coordinator shell test with temporary fake `codex`, `claude`, and `omp` binaries plus a fake writer/source. Cover:
+
+```text
+new session + complete manifest + valid help -> exactly three exact invocations
+new session + ORCA_COORDINATOR_RESUME_AGENTS=0 -> zero provider invocations
+second ensure with existing four-window sessions -> zero duplicate invocations
+missing manifest -> shells + RECOVERY_REQUIRED; zero provider invocations
+wrong manifest binding -> shells + RECOVERY_REQUIRED; zero provider invocations
+missing provider field -> only that provider RECOVERY_REQUIRED
+missing help flag -> provider RECOVERY_REQUIRED; no downgraded invocation
+provider exits non-zero -> shell remains and RECOVERY_REQUIRED is visible
+second ensure after provider failure -> no retry/invocation
+pre-existing legacy one-window session -> untouched, no auto-migration
+Windows inventory path -> no local session
+runtime CLI failure -> coordinator keeper and existing OCI sessions survive
+```
+
+Keep all current coordinator tests for coordinator reuse, bare coordinator startup, exact worktree path, and hpv2 terminal liveness. Ensure the existing fake `ORCA_COORDINATOR_AGENT_RESUME_CMD` test remains scoped to the coordinator keeper and does not accidentally become the provider command source.
+
+### Task 6: Document operator recovery and live-hook deployment
+
+**Files:**
+
+- Modify `/srv/script/projects/orca.md`.
+- Update the live OCI project setup hook setting through the UI; no source file in this repository owns that setting.
+
+- [ ] **Step 1: Add the operational contract**
+
+Document this exact flow:
+
+```text
+1. Coordinator enumerates local OCI Git worktrees only.
+2. Setup hook creates/reuses the deterministic session and, for a new session, four windows.
+3. Coordinator observes before/after session names.
+4. Only newly created sessions are eligible for provider resume.
+5. Provider-native SessionStart hooks populate the path-bound manifest.
+6. Missing/malformed/mismatched locator or unsupported flags produce RECOVERY_REQUIRED.
+7. Existing sessions are never restarted or migrated.
+8. Archive the exact old session and rerun setup once to migrate a legacy layout.
+```
+
+Include the manifest path/schema, exact provider commands, Codex managed-home requirement, OMP hook path, `ORCA_OCI_*` variables, `ORCA_COORDINATOR_RESUME_AGENTS=0` meaning, and the warning that `RECOVERY_REQUIRED` is not evidence that a provider has no upstream session; it means this recovery path is intentionally fail-closed.
+
+- [ ] **Step 2: Record live-hook deployment evidence**
+
+After the `/srv/script` copy and focused test pass, update the live hook setting and probe a disposable worktree. Record:
+
+```text
+observed new session name
+session_path
+0:codex, 1:claude, 2:omp, 3:bash
+all pane_current_path values
+ORCA_OCI_* values and CODEX_HOME
+OMP hook installation path
+archive result for the disposable session
+```
+
+Do not restart `orca-tmux.service`, kill the tmux server, or touch a real project session for this probe.
+
+### Task 7: Run focused OCI verification and preserve operational evidence
+
+**Files:** all changed files from Tasks 1–6.
+
+- [ ] **Step 1: Run the four OCI shell suites**
+
+Run on OCI:
+
+```bash
+bash /srv/script/orca-worktree-session-manifest.test.sh
+bash /srv/script/orca-omp-worktree-session-hook.test.sh
+bash /srv/script/orca-tmux-hook.test.sh
+bash /srv/script/orca-coordinator.test.sh
+```
+
+These must use throwaway tmux sockets and temporary directories only. A passing test must demonstrate behavior, not only source-text matching.
+
+- [ ] **Step 2: Run ShellCheck**
+
+Run on OCI:
+
+```bash
+shellcheck \
+  /srv/script/orca-worktree-session-manifest.sh \
+  /srv/script/orca-worktree-session-manifest.test.sh \
+  /srv/script/orca-omp-worktree-session-hook.test.sh \
+  /srv/script/orca-tmux-hook.sh \
+  /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/orca-coordinator.sh \
+  /srv/script/orca-coordinator.test.sh
+```
+
+ShellCheck must be clean. Do not add a max-lines suppression or disable a reliability rule.
+
+- [ ] **Step 3: Check repository source formatting and diff safety**
+
+On OCI, run only the read-only Git check:
+
+```bash
+git diff --check
+```
+
+Run the formatter check through hpv2 with the same target-safe preflight used by Task 8:
+
+```bash
+pnpm exec oxfmt --check \
+  src/main/agent-hooks/oci-worktree-session-event.ts \
+  src/main/agent-hooks/oci-worktree-session-event.test.ts \
+  src/main/claude/hook-service.ts \
+  src/main/claude/hook-service.test.ts \
+  src/main/codex/codex-hook-script.ts \
+  src/main/codex/hook-service-managed-install.test.ts
+```
+
+Inspect the diff for accidental changes to UI, managed-worker, remote-wire, or unrelated user files.
+
+- [ ] **Step 4: Write operational after-hashes**
+
+After the tests pass, write `SHA256SUMS.after` in the backup directory from the exact command in the backup section. Report the before/after hash files and changed operational paths; do not commit `/srv/script`.
+
+### Task 8: Validate the project source on hpv2 and commit only the Orca repository changes
+
+**Files:** repository TypeScript files and tests from Task 1; operational files remain outside Git.
+
+- [ ] **Step 1: Synchronize the OCI commit to hpv2**
+
+Commit only tracked Orca repository changes after the source-focused review. Do not stage the unrelated untracked files. Push the OCI commit, then use `/srv/script/orca-coordinator.sh` to fetch/fast-forward hpv2 and verify the exact commit SHA before running any project command. If hpv2 is unavailable, stop project validation rather than running pnpm on OCI.
+
+- [ ] **Step 2: Run focused source tests through hpv2**
+
+After `hpv2-check`, exact worktree/terminal/shell/idle preflight, and SHA verification, run:
+
+```bash
+pnpm test src/main/agent-hooks/oci-worktree-session-event.test.ts \
+  src/main/claude/hook-service.test.ts \
+  src/main/codex/hook-service-managed-install.test.ts
+```
+
+The result must exercise the generated scripts and preserve existing provider hook installation behavior.
+
+- [ ] **Step 3: Run node typecheck and changed-file quality checks through hpv2**
+
+Run through the same target-safe coordinator flow:
+
+```bash
+pnpm exec oxfmt --check \
+  src/main/agent-hooks/oci-worktree-session-event.ts \
+  src/main/agent-hooks/oci-worktree-session-event.test.ts \
+  src/main/claude/hook-service.ts \
+  src/main/claude/hook-service.test.ts \
+  src/main/codex/codex-hook-script.ts \
+  src/main/codex/hook-service-managed-install.test.ts
+pnpm tc:node
+pnpm run check:code-quality:changed
+```
+
+Use the repository's required changed-file quality command; do not substitute a local lint run on OCI. If the typecheck or quality command exposes an implementation mismatch, fix the source on OCI, commit/push again, re-sync hpv2, and rerun the exact command.
+
+- [ ] **Step 4: Run final source and operational verification**
+
+Re-run the four OCI shell suites and `git diff --check` after any final source correction. Confirm the repository commit SHA and changed paths. Confirm the `/srv/script` after-hash file. Only then report the feature as implemented; a passing source test does not imply that the live UI hook setting was deployed or that a real reboot trial occurred.
+
+## Acceptance checklist
+
+- [ ] A new local OCI worktree setup creates exactly four ordered windows named `codex`, `claude`, `omp`, `bash`, all with the canonical worktree pane CWD and exact session path.
+- [ ] The setup hook is idempotent for an existing exact-path session and fail-closed for a name/path mismatch; it does not auto-migrate old layouts.
+- [ ] A partial new layout is removed without touching any pre-existing session or the coordinator keeper.
+- [ ] Session environment contains the four exact `ORCA_OCI_*` variables and routes raw Codex to the same redirected `CODEX_HOME` where Orca installs its managed hook.
+- [ ] Claude and Codex record native `SessionStart.session_id` through the shared generated POSIX adapter; OMP records `getSessionId()` and optional `getSessionFile()` through the auto-discovered hook.
+- [ ] The manifest is keyed by canonical worktree path, validates canonical root/worktree identity, is mode 0600 under mode-0700 directories, serializes concurrent writers, and publishes atomically.
+- [ ] The coordinator sends fixed provider resume commands with exact dangerous approval flags only to sessions observed as newly created in the current invocation.
+- [ ] Missing/malformed/mismatched locators, missing hook dependencies, unsupported help flags, and failed provider launches leave shells plus `RECOVERY_REQUIRED`; no fallback starts.
+- [ ] A second coordinator invocation sends no duplicate provider command to an existing session, including after a provider failure.
+- [ ] `ORCA_COORDINATOR_RESUME_AGENTS=0` suppresses provider sends without suppressing the four-window layout.
+- [ ] Windows/hpv2 inventory entries remain excluded and hpv2/runtime failures do not destroy OCI sessions.
+- [ ] Raw tmux remains outside Orca's managed worker/UI contract.
+- [ ] Focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.

--- a/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
+++ b/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make every local OCI Git worktree recoverable after an OCI/tmux restart by having the setup hook create one deterministic four-window tmux session (`codex`, `claude`, `omp`, `bash`) and having the coordinator resume each provider exactly once from provider-native session locators persisted in a path-bound manifest.
 
-**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and explicit OMP extension selection. Claude/Codex raw recorders run only after their provider-specific exclusion guards, may pass captured provider payloads to a host-local writer, and the writer mutates the manifest only for `SessionStart`. The OMP recovery extension rereads its native session identity on each context-bearing lifecycle callback and records only a durable session ID. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch.
+**Architecture:** Keep raw tmux as a host recovery surface, not an Orca-managed worker. The setup hook remains the sole owner of session naming, session path, window layout, session environment, and explicit OMP extension selection. Claude/Codex raw recorders run only after their provider-specific exclusion guards, may pass captured provider payloads to a host-local writer, and the writer mutates the manifest only for `SessionStart`. The OMP recovery extension rereads its native session identity on each context-bearing lifecycle callback and records only a durable session ID. The coordinator observes sessions created by the current setup invocation, validates the exact provider command and approval flags, and sends at most one provider resume command to each newly created pane; existing sessions, missing locators, failed preflights, and failed resumes remain shell-only with `RECOVERY_REQUIRED` and never fall back to a fresh or recent-session launch. The separate coordinator-only `oci-omp-run` fallback is a direct non-interactive subprocess path with its own origin-keyed state; it must not be folded into tmux recovery or launched from a worker pane.
 
 **Tech Stack:** Bash, tmux, jq, `realpath`, `sha256sum`, `flock`, TypeScript-generated POSIX hook scripts, Bun OMP hooks, the existing `/srv/script/orca-coordinator.sh` JSON CLI integration, Vitest, ShellCheck.
 
@@ -34,8 +34,8 @@
 - Keep the design specification and this plan synchronized; source evidence from the follow-up review is incorporated below before coding.
 - Do not change Dashboard, AgentMap, managed-worker registration, terminal ownership, IPC, RPC, stream frames, or remote wire contracts. A raw tmux pane is never an Orca-managed worker.
 - Do not auto-migrate an existing one-window or otherwise legacy session. Existing sessions are left untouched; the documented operator action is archive and recreate once.
-- Do not infer provider locators from terminal text, pane order, mtimes, recent-session pickers, `--last`, `--continue`, or a fresh provider launch.
-- Do not make hpv2 or Windows part of this recovery path. The coordinator must continue filtering non-local paths and must not destroy OCI sessions when hpv2 is unavailable.
+- For per-worktree tmux recovery, do not infer provider locators from terminal text, pane order, mtimes, recent-session pickers, `--last`, `--continue`, or a fresh provider launch. The separate coordinator-only fallback may perform a bounded latest-JSONL scan inside its stable origin-keyed `sessionDir` only to identify the persistent session just returned by that subprocess; that fallback state is never manifest input.
+- Do not make hpv2 or Windows part of the per-worktree tmux recovery path. The separate coordinator-only fallback is OCI-local and explicit; hpv2 orchestration remains preferred when available. The coordinator must continue filtering non-local paths and must not destroy OCI sessions when hpv2 is unavailable.
 - Do not run project pnpm tests, typechecks, lint, builds, packaging, or Electron on OCI. Run those through the hpv2 coordinator after the OCI commit is pushed and the exact SHA is synchronized.
 - Do not touch `/srv/workspace/scouter` or the unrelated untracked files `ISSUE-archive-hook-cli-remote.md` and `ORPHAN-PTY-FINDINGS.md`.
 
@@ -46,7 +46,56 @@
 - `/srv/script` is the coordinator host's operational directory, not a Git worktree. Before changing any `/srv/script` file, create a dated backup and `SHA256SUMS.before`; after verification write `SHA256SUMS.after`. Never run `git add` or `git commit` in `/srv/script`.
 - The Orca UI's local project hook setting remains the live setup/archive source of truth. `/srv/script/orca-tmux-hook.sh` is the focused test/deployment copy. After changing the copy, update the existing live OCI setup hook body with the identical layout, environment, OMP installation, and partial-cleanup logic through the normal Orca UI operation; the CLI cannot edit this setting. Do not claim deployment until the live hook has been manually updated and probed.
 - The current coordinator unit and live sessions are not to be restarted, killed, archived, or recreated during implementation. Use throwaway tmux sockets for tests. A real OCI reboot/recovery trial is a separate coordinator/host-owner operation after all static and focused checks pass.
-- The coordinator process itself continues to own only the `coordinator` keeper session. Its existing single-pane startup behavior and `ORCA_COORDINATOR_AGENT_RESUME_CMD`/`ORCA_COORDINATOR_AGENT_START_CMD` test overrides remain isolated from per-worktree provider recovery.
+- The coordinator process itself continues to own only the `coordinator` keeper session. Its existing single-pane startup behavior and `ORCA_COORDINATOR_AGENT_RESUME_CMD`/`ORCA_COORDINATOR_AGENT_START_CMD` test overrides remain isolated from per-worktree provider recovery. The explicit `oci-omp-run` command is coordinator-only and must remain available as the direct OCI fallback when hpv2 orchestration is unavailable; it is not a tmux child or a managed worker.
+
+## Coordinator-only OCI OMP fallback boundary
+
+The existing `/srv/script/oci-omp-fallback.sh` route is a separate control-plane
+fallback, not another implementation of the four-window tmux recovery surface:
+
+```text
+hpv2 runtime ready       -> existing Orca/hpv2 orchestration remains preferred
+explicit oci-omp-run    -> orca-coordinator.sh -> oci-omp-fallback.sh
+                         -> direct OMP subprocess -> stdout relay to caller
+```
+
+The fallback may be invoked only through `orca-coordinator.sh oci-omp-run`.
+The current `orca-wt-main` work session and hpv2/managed worker panes must not
+invoke it or launch a direct child agent; the worker preamble enforces that
+boundary. The helper creates no child tmux session and no PTY, never
+passes `--no-session`, and invokes OMP with stable `--profile`, origin-scoped
+`--session-dir`, `--cwd`, `--no-pty`, and `-p`. The first request has no
+`--resume`; later requests validate the origin-keyed state and pass the saved
+`sessionId` with `--resume`. The helper relays captured stdout unchanged.
+
+The fallback's stable state file is separate from the per-worktree recovery
+manifest:
+
+```json
+{
+  "origin": "<stable coordinator origin>",
+  "workerId": "oci-omp-<sha256(origin)>",
+  "sessionId": "<native OMP session id>",
+  "sessionFile": "<session JSONL evidence path>",
+  "profile": "<stable OMP profile>",
+  "sessionDir": "<stable origin session directory>",
+  "cwd": "<requested working directory>",
+  "updatedAt": "<UTC timestamp>"
+}
+```
+
+`sessionId` is the only resume value. `sessionFile` is evidence/storage
+metadata for this fallback and must not be confused with the tmux manifest's
+removed OMP `resumeFilePath` contract. `workerId` is an opaque coordinator
+state identifier, not an Orca managed-worker identity or AgentMap edge.
+The fallback's native session ID must use the same trim/empty/512-character/
+leading-dash/control-character trust boundary before state persistence and
+before `--resume`; invalid state must fail closed without invoking OMP.
+The currently deployed fallback files are compatibility inputs for this plan:
+`/srv/script/oci-omp-fallback.sh`, its `.conf` and focused test,
+`/srv/script/orca-coordinator.sh`, and `/srv/script/worker-preamble.md`.
+Preserve their coordinator-only boundary while implementing tmux recovery; do
+not replace the fallback with a child tmux/PTY or make worker panes invoke it.
 
 ## File structure and responsibilities
 
@@ -87,6 +136,9 @@ backup="/srv/script/.backup/$stamp"
 mkdir -p "$backup"
 cp /srv/script/orca-tmux-hook.sh \
   /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/oci-omp-fallback.sh \
+  /srv/script/oci-omp-fallback.conf \
+  /srv/script/oci-omp-fallback.test.sh \
   /srv/script/orca-coordinator.sh \
   /srv/script/orca-coordinator.test.sh \
   /srv/script/projects/orca.md \
@@ -94,6 +146,9 @@ cp /srv/script/orca-tmux-hook.sh \
 sha256sum \
   /srv/script/orca-tmux-hook.sh \
   /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/oci-omp-fallback.sh \
+  /srv/script/oci-omp-fallback.conf \
+  /srv/script/oci-omp-fallback.test.sh \
   /srv/script/orca-coordinator.sh \
   /srv/script/orca-coordinator.test.sh \
   /srv/script/projects/orca.md \
@@ -107,6 +162,9 @@ Record the new files separately after creation and write the matching `SHA256SUM
 sha256sum \
   /srv/script/orca-tmux-hook.sh \
   /srv/script/orca-tmux-hook.test.sh \
+  /srv/script/oci-omp-fallback.sh \
+  /srv/script/oci-omp-fallback.conf \
+  /srv/script/oci-omp-fallback.test.sh \
   /srv/script/orca-worktree-session-manifest.sh \
   /srv/script/orca-worktree-session-manifest.test.sh \
   /srv/script/orca-omp-worktree-session-hook.ts \
@@ -604,6 +662,10 @@ Run the live UI setup hook manually against a disposable local worktree only aft
 
 - Modify `/srv/script/orca-coordinator.sh`.
 - Modify `/srv/script/orca-coordinator.test.sh`.
+- Preserve the coordinator-only contract in `/srv/script/oci-omp-fallback.sh`,
+  `/srv/script/oci-omp-fallback.conf`, and
+  `/srv/script/oci-omp-fallback.test.sh`; add only the shared provider-ID
+  trust-boundary hardening and focused coverage required below.
 
 - [ ] **Step 1: Keep coordinator startup separate and add recovery configuration**
 
@@ -728,6 +790,23 @@ runtime CLI failure -> coordinator keeper and existing OCI sessions survive
 ```
 
 Keep all current coordinator tests for coordinator reuse, bare coordinator startup, exact worktree path, and hpv2 terminal liveness. Ensure the existing fake `ORCA_COORDINATOR_AGENT_RESUME_CMD` test remains scoped to the coordinator keeper and does not accidentally become the provider command source.
+The coordinator test must also retain the already-deployed `oci-omp-run` dispatch: an explicit `oci-omp-run run --origin ... --cwd ... --prompt ...` reaches the direct fallback, never a tmux/PTY child, while `hpv2-run` remains the preferred route whenever hpv2 is ready. Keep this fallback test separate from the per-worktree `created`-session delta and OMP tmux-window recovery assertions.
+- [ ] **Step 7: Align fallback state IDs with the shared trust boundary**
+
+In `/srv/script/oci-omp-fallback.sh`, apply the same provider-ID normalizer
+used by the tmux manifest writer to the native ID found in a persistent OMP
+JSONL session record and to the ID loaded from an existing origin state file.
+Trim before storing or resuming; reject empty, over-512-character,
+leading-dash, and control-character IDs before writing state or invoking OMP.
+An invalid existing state must fail closed without `--resume`; an invalid new
+session record must not publish state. Do not change the direct
+`--no-pty -p`, stable profile/session directory, stdout relay, or
+coordinator-caller gate.
+
+Extend `/srv/script/oci-omp-fallback.test.sh` with overlong, leading-dash,
+control-character, and whitespace-boundary IDs. Assert rejected IDs do not
+reach the fake OMP or alter the prior state file, while a valid surrounding-
+whitespace ID is trimmed before `--resume`.
 
 ### Task 6: Document operator recovery and live-hook deployment
 
@@ -748,6 +827,21 @@ Keep all current coordinator tests for coordinator reuse, bare coordinator start
 7. Existing sessions are never restarted or migrated.
 8. Archive the exact old session and rerun setup once to migrate a legacy layout.
 ```
+Document the separate coordinator-only fallback contract in `/srv/script/projects/orca.md` without conflating its state with the tmux manifest:
+
+```text
+oci-omp-run -> oci-omp-fallback.sh -> direct OMP --no-pty -p
+first request -> stable --profile/--session-dir, no --resume
+follow-up   -> same origin state, saved session ID, --resume
+stdout      -> coordinator relays the subprocess output unchanged
+worker pane -> never invokes the helper directly
+```
+
+Record the configured `oci-omp-fallback.conf` profile/session/state roots,
+origin-keyed state file, opaque coordinator `workerId`, native `sessionId`, and
+the fact that `sessionFile` is evidence only. Do not document the fallback as
+an Orca managed worker, as a tmux recovery window, or as an alternative
+provider locator for the path-bound manifest.
 
 Include the manifest path/schema, exact provider commands, Codex managed-home requirement, OMP extension path and `ORCA_OMP_STATUS_EXTENSION` wrapper selection, `ORCA_OCI_*` variables, `ORCA_COORDINATOR_RESUME_AGENTS=0` meaning, and the warning that `RECOVERY_REQUIRED` is not evidence that a provider has no upstream session; it means this recovery path is intentionally fail-closed.
 
@@ -785,25 +879,36 @@ Do not restart `orca-tmux.service`, kill the tmux server, or touch a real projec
 
 **Files:** all changed files from Tasks 1–6.
 
-- [ ] **Step 1: Run the four OCI shell suites**
+- [ ] **Step 1: Run the five OCI shell suites**
 
 Run on OCI:
 
 ```bash
+bash /srv/script/oci-omp-fallback.test.sh
 bash /srv/script/orca-worktree-session-manifest.test.sh
 bash /srv/script/orca-omp-worktree-session-hook.test.sh
 bash /srv/script/orca-tmux-hook.test.sh
 bash /srv/script/orca-coordinator.test.sh
 ```
 
-These must use throwaway tmux sockets and temporary directories only. A passing test must demonstrate behavior, not only source-text matching.
+These must use throwaway tmux sockets and temporary directories only. The
+fallback suite must additionally prove direct non-PTY execution, persistent
+session storage, follow-up `--resume`, stdout relay, coordinator-only caller
+gating, no `tmux`/`nohup`/`setsid` launcher, and the shared provider-ID
+boundary for newly discovered and saved IDs. A passing test must demonstrate
+behavior, not only source-text matching.
+
 
 - [ ] **Step 2: Run ShellCheck**
+
 
 Run on OCI:
 
 ```bash
-shellcheck \
+shellcheck -x \
+  /srv/script/oci-omp-fallback.conf \
+  /srv/script/oci-omp-fallback.sh \
+  /srv/script/oci-omp-fallback.test.sh \
   /srv/script/orca-worktree-session-manifest.sh \
   /srv/script/orca-worktree-session-manifest.test.sh \
   /srv/script/orca-omp-worktree-session-hook.test.sh \
@@ -879,7 +984,7 @@ Use the repository's required changed-file quality command; do not substitute a 
 
 - [ ] **Step 4: Run final source and operational verification**
 
-Re-run the four OCI shell suites and `git diff --check` after any final source correction. Confirm the repository commit SHA and changed paths. Confirm the `/srv/script` after-hash file. Only then report the feature as implemented; a passing source test does not imply that the live UI hook setting was deployed or that a real reboot trial occurred.
+Re-run the five OCI shell suites and `git diff --check` after any final source correction. Confirm the repository commit SHA and changed paths. Confirm the `/srv/script` after-hash file. Only then report the feature as implemented; a passing source test does not imply that the live UI hook setting was deployed or that a real reboot trial occurred.
 
 ## Acceptance checklist
 
@@ -891,11 +996,12 @@ Re-run the four OCI shell suites and `git diff --check` after any final source c
 - [ ] Claude and Codex raw recorders run after required provider exclusions, pass native payloads to the writer, and the manifest changes only for native `SessionStart.session_id`; ordinary events leave it unchanged.
 - [ ] Claude's shared `~/.orca/agent-hooks/claude-hook.sh` and Codex's shared `~/.orca/agent-hooks/codex-hook.sh` contain the recorder; Codex's redirected `CODEX_HOME/hooks.json` independently registers the shared launcher.
 - [ ] OMP records the current durable `getSessionId()` on every supported context-bearing lifecycle callback (not `session_start`, which the current OMP status source intentionally does not register), using `getSessionFile()` only as a persistence gate; the extension is installed under the agent directory's `extensions` child, selected through `ORCA_OMP_STATUS_EXTENSION`, and passed explicitly with `omp --extension` during recovery.
-- [ ] Every Claude, Codex, and OMP provider ID is normalized with the shared trim/empty/512-character/leading-dash/control-character boundary; rejected IDs cannot mutate the manifest or reach resume argv.
+- [ ] Every Claude, Codex, OMP manifest, and coordinator-fallback provider ID is normalized with the shared trim/empty/512-character/leading-dash/control-character boundary; rejected IDs cannot mutate state or reach resume argv.
 - [ ] The coordinator sends fixed provider resume commands with exact dangerous approval flags only to sessions observed as newly created in the current invocation; OMP receives only its recorded `session_id`.
 - [ ] Claude capability preflight uses a non-launching parser-acceptance probe; unsupported flags, missing artifacts, and failed launches leave shells plus `RECOVERY_REQUIRED` with no fallback.
 - [ ] A second coordinator invocation sends no duplicate provider command to an existing session, including after a provider failure.
 - [ ] `ORCA_COORDINATOR_RESUME_AGENTS=0` suppresses provider sends without suppressing the four-window layout.
 - [ ] Windows/hpv2 inventory entries remain excluded and hpv2/runtime failures do not destroy OCI sessions.
 - [ ] Raw tmux remains outside Orca's managed worker/UI contract.
+- [ ] The coordinator-only `oci-omp-run` fallback uses direct persistent non-PTY OMP execution with stable origin/profile/session storage, resumes follow-up requests from its saved `sessionId`, relays stdout, and remains inaccessible to worker panes.
 - [ ] The supported OCI managed-hook deployment and live installed-script probe are recorded separately from hpv2 source validation; the exact `agent hooks on` runtime/offline route, returned statuses, focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.

--- a/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
+++ b/docs/superpowers/plans/2026-09-03-oci-worktree-tmux-agent-recovery.md
@@ -228,7 +228,7 @@ claude --resume "$CLAUDE_SESSION_ID" --dangerously-skip-permissions
 omp --extension "$ORCA_OMP_STATUS_EXTENSION" --resume "$OMP_SESSION_ID" --auto-approve --approval-mode=yolo
 ```
 
-OMP's recorded `session_id` is the authoritative resume locator. `getSessionFile()` is read by the recovery extension only as the same persistence gate used by Orca's OMP status integration; it is not stored as `resumeFilePath` and is not passed to `omp --resume` in this OCI path. The explicit `--extension "$ORCA_OMP_STATUS_EXTENSION"` argument is the recovery command's confirmed OMP integration path; the coordinator must validate that it is the exact readable session extension selected by setup.
+OMP's recorded `session_id` is the authoritative resume locator. `getSessionFile()` is read by the recovery extension only as the same persistence gate used by Orca's OMP status integration; it is not stored as `resumeFilePath` and is not passed to `omp --resume` in this OCI path. The explicit `--extension "$ORCA_OMP_STATUS_EXTENSION"` argument is the recovery command's confirmed OMP integration path; the coordinator must validate that it is the exact readable session extension selected by setup. This `omp --extension … --resume "$OMP_SESSION_ID" …` line is a literal bash argument list built directly in `orca-coordinator.sh`; it never calls `src/shared/agent-session-resume.ts:getAgentResumeArgv()`, whose separate OMP case (`['omp', '--resume', ompResumeFilePath?.trim() || id]`) belongs to Orca's own managed-worker resume flow and its own `ompResumeFilePath` argument. This OCI path never constructs that argument, so that function's file-priority branch is structurally unreachable here, not merely untested.
 
 The coordinator may override provider binary paths, writer, OMP source, OMP agent directory, and Codex home only for isolated tests. Tests set `XDG_STATE_HOME` to a temporary directory instead of overriding the manifest-root formula. The coordinator must not override provider argv or approval flags in production.
 
@@ -845,7 +845,30 @@ provider locator for the path-bound manifest.
 
 Include the manifest path/schema, exact provider commands, Codex managed-home requirement, OMP extension path and `ORCA_OMP_STATUS_EXTENSION` wrapper selection, `ORCA_OCI_*` variables, `ORCA_COORDINATOR_RESUME_AGENTS=0` meaning, and the warning that `RECOVERY_REQUIRED` is not evidence that a provider has no upstream session; it means this recovery path is intentionally fail-closed.
 
-After the `/srv/script` copy and focused tests pass, use the supported `agent hooks on` path for the live OCI runtime. When the runtime is reachable, the settings update path (`src/main/ipc/settings.ts`) calls `applyAgentStatusHooksEnabled()`, which calls `installManagedAgentHooks()` and refreshes the existing Claude/Codex managed scripts. When the runtime is unavailable, the CLI's offline `setAgentHooksEnabled()` path calls the same `applyAgentStatusHooksEnabled()` operation directly. The raw OMP recovery extension is not installed by this managed-hook refresh; the live setup hook installs it under the OMP agent directory's `extensions` child and selects it through `ORCA_OMP_STATUS_EXTENSION`. Do not treat `agent hooks status` alone as deployment or refresh. Do not manually copy generated managed scripts.
+After the `/srv/script` copy and focused tests pass, refresh the live managed
+scripts through the supported CLI. `agent hooks on` alone does not guarantee a
+refresh: `src/cli/handlers/agent-hooks.ts:setAgentHooksEnabled()` calls
+`updateRunningRuntime()`, which sends `settings.update` with
+`agentStatusHooksEnabled: true`; when a reachable runtime already has that
+setting `true`, `src/main/ipc/settings.ts`'s `hookSettingChanged` guard is
+false, `applyAgentStatusHooksEnabled()`/`installManagedAgentHooks()` is never
+called, and the CLI falls through to `getManagedAgentHookStatuses()`, a
+read-only status probe. Since hooks are already enabled in the normal
+operator flow, this is the common case, not an edge case. Force the actual
+state transition instead: run `agent hooks off` immediately followed by
+`agent hooks on`. Both calls change `agentStatusHooksEnabled`, so
+`hookSettingChanged` is true both times, `applyAgentStatusHooksEnabled(true, …)`
+runs, and `installManagedAgentHooks()`'s unconditional
+`refreshExistingManagedScripts()` regenerates the Claude/Codex managed
+scripts from the amended source before the presence-gated install step. When
+the runtime is unreachable, the CLI's offline `setAgentHooksEnabled()` path
+calls `applyAgentStatusHooksEnabled()` directly on every invocation and does
+not need the off/on toggle. The raw OMP recovery extension is not installed
+by this managed-hook refresh; the live setup hook installs it under the OMP
+agent directory's `extensions` child and selects it through
+`ORCA_OMP_STATUS_EXTENSION`. Do not treat `agent hooks status` or a single
+`agent hooks on` against an already-enabled reachable runtime as deployment
+or refresh.
 
 Verify the resulting artifacts and returned statuses before updating the live setup hook:
 
@@ -857,10 +880,13 @@ OMP:   ~/.omp/agent/extensions/orca-oci-worktree-session-hook.ts is the
        explicit extension source selected by ORCA_OMP_STATUS_EXTENSION
 ```
 
-If neither supported `agent hooks on` route can run the amended source and refresh the artifacts, stop and do not claim managed-hook deployment. Then update the live OCI setup hook setting and probe a disposable worktree. Record:
+If neither the reachable-runtime off/on toggle nor the offline CLI fallback
+can run the amended source and refresh the artifacts, stop and do not claim
+managed-hook deployment. Then update the live OCI setup hook setting and
+probe a disposable worktree. Record:
 
 ```text
-agent hooks on route (runtime settings or offline CLI fallback)
+agent hooks route (reachable-runtime off/on toggle or offline CLI fallback)
 returned managed-hook statuses
 observed new session name
 session_path
@@ -1004,4 +1030,4 @@ Re-run the five OCI shell suites and `git diff --check` after any final source c
 - [ ] Windows/hpv2 inventory entries remain excluded and hpv2/runtime failures do not destroy OCI sessions.
 - [ ] Raw tmux remains outside Orca's managed worker/UI contract.
 - [ ] The coordinator-only `oci-omp-run` fallback uses direct persistent non-PTY OMP execution with stable origin/profile/session storage, resumes follow-up requests from its saved `sessionId`, relays stdout, and remains inaccessible to worker panes.
-- [ ] The supported OCI managed-hook deployment and live installed-script probe are recorded separately from hpv2 source validation; the exact `agent hooks on` runtime/offline route, returned statuses, focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded.
+- [ ] The supported OCI managed-hook deployment and live installed-script probe are recorded separately from hpv2 source validation; the exact `agent hooks off`/`agent hooks on` reachable-runtime toggle (or offline CLI fallback), returned statuses, focused shell tests, ShellCheck, hpv2 provider-hook tests, node typecheck, changed-file quality, exact SHA sync, and operational before/after hashes are recorded. A single `agent hooks on` against an already-enabled reachable runtime is not accepted as deployment evidence.

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -23,10 +23,12 @@ with four windows:
 3. `omp`
 4. `bash`
 
-When OCI recovery creates a new session, resume the provider's most recent
-session in windows 1–3 with the provider-specific permission-bypass flags. Do
-not create a fresh provider session when resume is unavailable or fails. Keep
-OCI session recovery independent from hp_v2 availability and keep UI-visible
+When OCI recovery creates a new session, load each provider's exact saved
+session locator from the worktree's host-local provider-session manifest and
+resume windows 1–3 with provider-specific permission-bypass flags. Do not use
+provider-wide "most recent" selection for recovery. Do not create a fresh
+provider session when the manifest locator is absent or resume fails. Keep OCI
+session recovery independent from hp_v2 availability and keep UI-visible
 managed workers outside these tmux sessions.
 
 ## Non-goals
@@ -39,7 +41,7 @@ managed workers outside these tmux sessions.
 - No hp_v2 worker tmux sessions. hp_v2 remains a pinned remote shell terminal.
 - No restoration of reboot-time child processes, running commands, tests, or
   PTY scrollback.
-- No change to Orca application source or Dashboard/AgentMap data contracts.
+- No change to Dashboard/AgentMap data contracts or UI rendering.
 - No automatic fresh provider startup after a failed or missing resume session.
 
 ## Chosen approach
@@ -49,16 +51,18 @@ cleanup behavior is outside this design and is not changed here. The OCI
 systemd-owned tmux server owns server persistence. The coordinator owns only
 boot-time reconciliation of missing OCI worktree sessions and remote hp_v2
 routing; it does not continuously supervise healthy OCI sessions.
-
-The setup hook and its OCI test copy must produce the same four-window layout.
-The live Orca inline hook remains authoritative; `/srv/script/orca-tmux-hook.sh`
-must be kept byte-compatible with its session-name and layout behavior for local
-recovery tests.
+The setup hook is the single owner of the four-window layout. The live Orca
+inline hook remains authoritative; `/srv/script/orca-tmux-hook.sh` must be kept
+compatible with its session-name and layout behavior for local recovery tests.
+The coordinator never independently creates or orders provider windows; its
+restore path calls the setup hook and only starts providers in a session that
+the hook created during that invocation.
 
 `restore_worktree_sessions()` continues to enumerate Orca's worktree inventory,
 skip non-local paths, call the setup hook, observe which session name was newly
-created, and start provider recovery only for that newly created session. An
-existing session is never modified or sent a resume command.
+created, load the matching host-local provider-session manifest, and start
+provider recovery only for that newly created session. An existing session is
+never modified or sent a resume command.
 
 ## Session layout
 
@@ -72,41 +76,80 @@ The root worktree uses `main` as its worktree slug. Every new session is created
 with the exact worktree as its session path and each window's initial pane CWD.
 The four windows are ordered as follows:
 
-| tmux index | name | startup behavior |
-| --- | --- | --- |
-| 0 | `codex` | Codex resume command |
-| 1 | `claude` | Claude continue command |
-| 2 | `omp` | OMP continue command |
+| 0 | `codex` | Codex exact-locator resume command |
+| 1 | `claude` | Claude exact-locator resume command |
+| 2 | `omp` | OMP exact-locator resume command |
 | 3 | `bash` | idle shell |
 
 If the session already exists, setup validates its session path and returns
 without adding, deleting, or respawning windows.
 
-## Provider recovery commands
-
 Provider commands are sent only after the session was created during the
-current recovery invocation and its pane CWD matches the exact worktree.
+current recovery invocation, its pane CWD matches the exact worktree, and the
+provider manifest entry matches that same worktree.
 
 | window | command |
 | --- | --- |
-| `codex` | `codex resume --last --dangerously-bypass-approvals-and-sandbox` |
-| `claude` | `claude --continue --dangerously-skip-permissions` |
-| `omp` | `omp --continue --auto-approve --approval-mode=yolo` |
+| `codex` | `codex resume <session-id> --dangerously-bypass-approvals-and-sandbox` |
+| `claude` | `claude --resume <session-id> --dangerously-skip-permissions` |
+| `omp` | `omp --resume <resume-file-or-session-id> --auto-approve --approval-mode=yolo` |
 
-The Codex `--last` selection uses Codex's default CWD-filtered candidate set;
-`--all` is not used. Claude `--continue` and OMP `--continue` likewise run from
-the exact worktree CWD. Provider session stores remain provider-specific and
-are not keyed by tmux session name or shared across Codex, Claude, and OMP.
+The provider locator is not selected by tmux session name or a global recent
+session picker. The Codex locator is the recorded `session_id`; the Claude
+locator is its recorded `session_id`; the OMP locator is its recorded
+`resumeFilePath` when present, otherwise its recorded `session_id`. This
+matches the provider-specific mapping in
+`src/shared/agent-session-resume.ts:getAgentResumeArgv()` and the startup plan
+in `src/shared/tui-agent-resume-startup.ts:buildAgentResumeStartupPlan()`.
 
 The permission-bypass flags are an explicit OCI-only policy. They are not sent
 to hp_v2. OMP has no `dangerously-skip-permissions` flag; `--auto-approve` plus
-`--approval-mode=yolo` is its corresponding non-interactive approval policy.
+`--approval-mode=yolo` is its installed CLI approval policy and must remain a
+provider-specific command contract.
 
-A provider resume failure, including no saved session, returns the window to an
-ordinary shell and records `RECOVERY_REQUIRED`. It must not be converted into a
-fresh provider launch. The recovery code must not use an unconditional
-`resume || fresh` fallback that hides authentication, lock, CWD, or corrupt
-session errors.
+A provider resume failure, including a missing or mismatched manifest locator,
+returns the window to an ordinary shell and records `RECOVERY_REQUIRED`. It
+must not be converted into a fresh provider launch. The recovery code must not
+use an unconditional `resume || fresh` fallback that hides authentication,
+lock, CWD, unsupported-flag, or corrupt-session errors.
+
+## Provider session manifest
+
+Each OCI worktree has one host-local manifest outside the worktree:
+
+```text
+${XDG_STATE_HOME:-$HOME/.local/state}/orca/oci-worktree-sessions/<sha256(realpath(worktree))>.json
+```
+
+The manifest is mode `0600`, written through a temporary file and atomic rename,
+and never committed to the worktree. Its minimum schema is:
+
+```json
+{
+  "version": 1,
+  "worktreePath": "/srv/workspace/project-feature",
+  "repoRoot": "/srv/workspace/project",
+  "providers": {
+    "codex": { "key": "session_id", "id": "..." },
+    "claude": { "key": "session_id", "id": "..." },
+    "omp": { "key": "session_id", "id": "...", "resumeFilePath": "..." }
+  }
+}
+```
+
+Entries are updated only from the provider's authoritative session-start
+identity event or the existing Orca provider-session relay; the implementation
+must not infer an ID from terminal text, file mtime, or a global recent-session
+picker. A manifest is consumed only when its recorded `worktreePath` and
+`repoRoot` match the canonical realpaths of the target session. A moved or
+renamed worktree does not reuse the old manifest automatically.
+
+If the provider hook/relay cannot publish an exact locator, that provider stays
+at `RECOVERY_REQUIRED` after reboot. The system does not downgrade to
+`--last`, `--continue`, or a fresh session.
+
+The manifest stores provider locators only; it stores no API credentials,
+approval tokens, or conversation content.
 
 ## Writer and ownership policy
 
@@ -138,9 +181,8 @@ expected for the separate managed terminal path.
 | --- | --- |
 | hp_v2 reboot while OCI is running | OCI tmux sessions and provider processes are untouched; hp_v2 state is separate |
 | OCI reboot | coordinator session is ensured; missing local worktree sessions are recreated with four windows |
-| existing worktree session | validate path and leave session/windows/processes untouched |
-| newly created worktree session | send one provider-specific resume command per provider window |
-| no saved provider session | leave that window as shell and record `RECOVERY_REQUIRED` |
+| newly created worktree session | load the matching manifest and send one exact-locator resume command per provider window |
+| no matching provider locator | leave that window as shell and record `RECOVERY_REQUIRED` |
 | provider resume error | leave that window as shell and record `RECOVERY_REQUIRED`; no fresh launch |
 | wrong session path or pane CWD | fail the recovery for that session; do not start a provider |
 | non-local/Windows worktree path | skip it; do not create an OCI tmux session |
@@ -149,21 +191,22 @@ expected for the separate managed terminal path.
 A resume restores provider conversation context only. It does not claim that a
 previous command, test, child process, or terminal output was restored.
 
-## Implementation boundaries
-
 The operational change is limited to:
 
 - the authoritative Orca local setup hook and its `/srv/script` test copy, for
   creating the four-window layout;
-- `/srv/script/orca-coordinator.sh`, for provider-specific recovery on newly
-  created sessions and strict failure handling;
-- focused shell tests for hook layout and coordinator recovery behavior;
+- a host-local provider-session manifest writer/reader and focused tests;
+- `/srv/script/orca-coordinator.sh`, for provider-specific exact-locator
+  recovery on newly created sessions and strict failure handling;
+- focused shell tests for hook layout, manifest matching, and coordinator
+  recovery behavior;
 - operational project facts documenting the OCI session and provider policy.
 
 The existing Codex invocation must use
 `--dangerously-bypass-approvals-and-sandbox`, not Claude's
-`--dangerously-skip-permissions`. Claude and OMP require their own command
-contracts; provider flags must not be substituted across tools.
+`--dangerously-skip-permissions`. Claude and OMP require their own exact
+resume and approval contracts; provider flags must not be substituted across
+tools.
 
 ## Tests
 
@@ -179,12 +222,23 @@ The setup-hook test must assert:
 - an existing session is reused without window mutation;
 - path mismatch fails closed.
 
+The manifest tests must assert:
+
+- one manifest is selected only for the exact canonical worktree path and repo
+  root;
+- Codex, Claude, and OMP locators are persisted with their provider-specific
+  fields;
+- manifest writes are private and atomic;
+- a moved worktree, missing provider entry, malformed locator, or provider
+  mismatch yields `RECOVERY_REQUIRED`;
+- no provider ID is inferred from recent-session ordering or terminal text.
+
 The coordinator test must assert:
 
 - `ensure-session` restores missing local worktree sessions;
 - Windows/hp_v2 paths are skipped;
 - only sessions created during the current invocation receive provider commands;
-- the exact Codex, Claude, and OMP command strings are sent to the matching
+- the exact provider-specific locator commands are sent to the matching
   windows;
 - `ORCA_COORDINATOR_RESUME_AGENTS=0` restores sessions without provider starts;
 - provider resume failure produces `RECOVERY_REQUIRED` and no fresh command;
@@ -192,9 +246,10 @@ The coordinator test must assert:
 - an unreachable hp_v2 runtime does not destroy the OCI keeper or local session
   inventory.
 
-Run CLI help probes for the installed Codex, Claude, and OMP versions before
-locking command assertions. Do not infer a provider's resume syntax from another
-provider.
+Run CLI help probes for the installed Codex, Claude, and OMP versions and keep
+the exact-resume assertions aligned with
+`getAgentResumeArgv()`/`buildAgentResumeStartupPlan()`. Do not infer a
+provider's resume syntax from another provider.
 
 The UI-visible managed-worker acceptance remains a separate Orca UI/AgentMap
 smoke check. It must verify a managed worker has its own terminal and managed

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -242,11 +242,18 @@ session picker. The Codex locator is the recorded `session_id`; the Claude
 locator is its recorded `session_id`; the OMP locator is its recorded
 `session_id` only. The OMP command also receives the exact extension path from
 `ORCA_OMP_STATUS_EXTENSION`; this is extension selection, not a session
-locator. The locator mapping matches
-`src/shared/agent-session-resume.ts:getAgentResumeArgv()` for the default OMP
-case. That function supports an explicit caller-supplied `ompResumeFilePath`
-override, but this OCI manifest does not populate that separate override from
-native `getSessionFile()`.
+locator. The OCI recovery command in the table above is a literal bash
+argument list built directly by `orca-coordinator.sh`; it never calls
+`src/shared/agent-session-resume.ts:getAgentResumeArgv()`. That shared
+function's OMP case is `['omp', '--resume', ompResumeFilePath?.trim() || id]`
+(confirmed at `agent-session-resume.ts:282-285`) and is reachable only through
+Orca's own managed-worker resume flow, which supplies its own
+`ompResumeFilePath` argument from a different code path than this OCI
+manifest. Because this raw path never constructs or passes an
+`ompResumeFilePath` value, the file-priority branch of that function is
+structurally unreachable here, not merely untested; this OCI path's own
+`--resume "$OMP_SESSION_ID"` argument is always the manifest's normalized
+`session_id`.
 
 The permission-bypass flags are an explicit OCI-only policy. They are not sent
 to hp_v2. OMP has no `dangerously-skip-permissions` flag; `--auto-approve` plus
@@ -515,15 +522,23 @@ only by the coordinator/host owner.
 
 Before claiming recovery support, record the focused test output and verify
 that provider resume is attempted only for newly created sessions. For live
-managed-hook deployment, use the supported `agent hooks on` entrypoint: a
-reachable runtime routes the settings update through
-`src/main/ipc/settings.ts` to `applyAgentStatusHooksEnabled()` and
-`installManagedAgentHooks()`, while the CLI's offline path calls the same
-installation operation directly. This refreshes the managed Claude/Codex
-artifacts; it does not install the raw OMP recovery extension. The live setup
-hook installs that extension under `~/.omp/agent/extensions/`, sets
-`ORCA_OMP_STATUS_EXTENSION`, and the disposable-session probe verifies the
-explicit `omp --extension` route. `agent hooks status` alone is not a refresh
-operation. Record the returned statuses and verify all artifacts before
-updating the live setup hook. Keep the provider resume policy independent from
-hp_v2 terminal handles, SHA gates, and remote wire fields.
+managed-hook deployment, `src/main/ipc/settings.ts`'s `hookSettingChanged`
+guard skips `applyAgentStatusHooksEnabled()`/`installManagedAgentHooks()`
+whenever a reachable runtime already has the requested
+`agentStatusHooksEnabled` value, so a single `agent hooks on` against an
+already-enabled runtime falls through
+`src/cli/handlers/agent-hooks.ts:setAgentHooksEnabled()` to the read-only
+`getManagedAgentHookStatuses()` path and refreshes nothing. Use `agent hooks
+off` immediately followed by `agent hooks on` to force the state transition
+that runs `installManagedAgentHooks()`'s unconditional
+`refreshExistingManagedScripts()`; the CLI's offline path calls
+`applyAgentStatusHooksEnabled()` directly on every invocation and needs no
+toggle. This refreshes the managed Claude/Codex artifacts; it does not
+install the raw OMP recovery extension. The live setup hook installs that
+extension under `~/.omp/agent/extensions/`, sets `ORCA_OMP_STATUS_EXTENSION`,
+and the disposable-session probe verifies the explicit `omp --extension`
+route. `agent hooks status` alone is not a refresh operation, and neither is
+`agent hooks on` alone against an already-enabled reachable runtime. Record
+the returned statuses and verify all artifacts before updating the live setup
+hook. Keep the provider resume policy independent from hp_v2 terminal
+handles, SHA gates, and remote wire fields.

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -170,6 +170,42 @@ skip non-local paths, call the setup hook, observe which session name was newly
 created, load the matching host-local provider-session manifest, and start
 provider recovery only for that newly created session. An existing session is
 never modified or sent a resume command.
+## Coordinator-only OCI OMP fallback
+
+The existing `orca-coordinator.sh oci-omp-run` route is an explicit
+coordinator-only fallback, not a second implementation of the four-window tmux
+recovery surface:
+
+```text
+hp_v2 ready          -> existing Orca/hp_v2 orchestration remains preferred
+explicit oci-omp-run -> direct OMP subprocess -> stdout relay to caller
+```
+This contract is carried by
+`/srv/script/oci-omp-fallback.sh` and
+`/srv/script/oci-omp-fallback.conf`, dispatched only by
+`/srv/script/orca-coordinator.sh`, with focused coverage in
+`/srv/script/oci-omp-fallback.test.sh`. `/srv/script/worker-preamble.md`
+continues to prohibit worker-side direct invocation.
+
+
+The fallback creates no child tmux session and no PTY. It never passes
+`--no-session`; it invokes OMP with a stable `--profile`, origin-scoped
+`--session-dir`, `--cwd`, `--no-pty`, and `-p`. The first request omits
+`--resume`. A later request for the same stable origin validates its state and
+passes the saved native `sessionId` with `--resume`.
+
+Its origin-keyed state is separate from the per-worktree manifest and contains
+the stable origin, opaque coordinator `workerId`, native `sessionId`,
+`sessionFile` evidence path, profile, session directory, cwd, and update time.
+Only `sessionId` reaches `--resume`; `sessionFile` is not a locator for the
+tmux manifest and does not create an OMP `resumeFilePath` field. The fallback's
+session ID uses the same trim/empty/512-character/leading-dash/control-character
+boundary before state persistence and before `--resume`; invalid state fails
+closed without invoking OMP.
+
+The worker preamble forbids direct fallback invocation and direct child-agent
+launch. The fallback is a control-plane relay only and never creates an Orca
+managed-worker identity or AgentMap edge.
 
 ## Session layout
 
@@ -257,13 +293,16 @@ path defined in the chosen approach. The generated Claude/Codex recorder may
 pass each captured payload to the writer, but the writer accepts only a
 `SessionStart` payload for a manifest mutation. An ordinary provider event
 therefore may invoke the writer but must produce no manifest change. The
-implementation must not infer an ID from terminal text, file mtime, a global
-recent-session picker, or a relay event that lacks the raw session's
-`ORCA_OCI_*` context. The writer receives a normalized provider locator from
-the adapter, realpaths and validates the worktree/root pair, then atomically
-updates the matching manifest. OMP's `getSessionFile()` is a persistence gate
-only; it is never serialized as `resumeFilePath` or used as the OCI resume
-target.
+For the tmux manifest, the implementation must not infer an ID from terminal
+text, file mtime, a global recent-session picker, or a relay event that lacks
+the raw session's `ORCA_OCI_*` context. The separate coordinator-only fallback
+may scan its stable origin-keyed session directory only to identify the
+persistent session record produced by its own direct subprocess; that state
+never feeds this manifest. The writer receives a normalized provider locator
+from the adapter, realpaths and validates the worktree/root pair, then
+atomically updates the matching manifest. OMP's `getSessionFile()` is a
+persistence gate only; it is never serialized as `resumeFilePath` or used as
+the OCI resume target.
 
 All Claude, Codex, and OMP IDs use the same trust boundary as
 `normalizeAgentProviderSession` in `src/shared/agent-session-resume.ts`: trim
@@ -302,7 +341,9 @@ A UI-visible worker is created through Orca managed orchestration and receives
 its own managed terminal/worktree identity. It is not placed into one of the
 four existing tmux windows. The current `/srv/workspace/orca` OMP work session
 must not directly start, stop, resume, or kill that worker; the permitted
-coordinator/control-plane dispatch path owns the lifecycle.
+coordinator/control-plane dispatch path owns the lifecycle. The explicit
+coordinator-only `oci-omp-run` fallback is allowed only on that control-plane
+path and remains outside managed-worker lifecycle.
 
 Raw `tmux send-keys` provider startup is therefore intentionally invisible to
 managed orchestration lineage. Dashboard cards and AgentMap edges are only
@@ -320,6 +361,7 @@ expected for the separate managed terminal path.
 | wrong session path or pane CWD | fail the recovery for that session; do not start a provider |
 | non-local/Windows worktree path | skip it; do not create an OCI tmux session |
 | managed worker request | create a separate Orca managed terminal/worktree, never a tmux child |
+| explicit coordinator `oci-omp-run` fallback | run direct persistent non-PTY OMP; relay stdout; save state and resume later requests by origin |
 
 Recovery is deliberately one-shot per created tmux session. If a provider
 start or preflight partially fails, the coordinator leaves the session and
@@ -345,6 +387,9 @@ The operational change is limited to:
 - focused shell tests for hook layout, manifest matching, and coordinator
   recovery behavior;
 - operational project facts documenting the OCI session and provider policy.
+- the existing coordinator-only `oci-omp-run` fallback and its
+  origin/profile/session state, which must remain separate from tmux recovery
+  and inaccessible to worker panes;
 
 The existing Codex invocation must use
 `--dangerously-bypass-approvals-and-sandbox`, not Claude's
@@ -423,6 +468,18 @@ The coordinator test must assert:
 - an existing session is not resumed again;
 - an unreachable hp_v2 runtime does not destroy the OCI keeper or local session
   inventory.
+The coordinator-only fallback test must assert:
+
+- `oci-omp-run` is callable only through the coordinator wrapper;
+- hp_v2 orchestration remains preferred when its runtime is ready;
+- the helper uses direct `--no-pty -p` execution with stable `--profile`,
+  `--session-dir`, and `--cwd`, without tmux/PTY/`--no-session` launchers;
+- the first request has no `--resume`, a follow-up uses the same origin state
+  and saved native `sessionId` with `--resume`, and stdout is relayed unchanged;
+- the saved state preserves the same opaque `workerId` and origin while its
+  `sessionFile` remains evidence rather than a resume locator;
+- overlong, leading-dash, control-character, or malformed saved IDs fail
+  closed before OMP invocation.
 
 
 Run CLI help probes for the installed Codex, Claude, and OMP versions and keep
@@ -448,11 +505,13 @@ The UI-visible managed-worker acceptance remains a separate Orca UI/AgentMap
 smoke check. It must verify a managed worker has its own terminal and managed
 lineage; it must not expect a raw tmux window to become a card.
 
-Read-only source inspection, ShellCheck, and focused shell tests run on OCI.
-Project pnpm gates, builds, packaging, and Electron validation remain hp_v2-only
-through the coordinator. No hp_v2 reboot is required for normal OCI session
-recovery verification; a controlled OCI tmux-service restart or host reboot
-scenario must be performed only by the coordinator/host owner.
+Read-only source inspection, ShellCheck, and focused shell tests run on OCI;
+the focused set includes `/srv/script/oci-omp-fallback.test.sh` for the
+coordinator-only persistent direct-OMP route. Project pnpm gates, builds,
+packaging, and Electron validation remain hp_v2-only through the coordinator.
+No hp_v2 reboot is required for normal OCI session recovery verification; a
+controlled OCI tmux-service restart or host reboot scenario must be performed
+only by the coordinator/host owner.
 
 Before claiming recovery support, record the focused test output and verify
 that provider resume is attempted only for newly created sessions. For live

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -522,15 +522,18 @@ only by the coordinator/host owner.
 
 Before claiming recovery support, record the focused test output and verify
 that provider resume is attempted only for newly created sessions. For live
-managed-hook deployment, `src/main/ipc/settings.ts`'s `hookSettingChanged`
-guard skips `applyAgentStatusHooksEnabled()`/`installManagedAgentHooks()`
-whenever a reachable runtime already has the requested
-`agentStatusHooksEnabled` value, so a single `agent hooks on` against an
-already-enabled runtime falls through
-`src/cli/handlers/agent-hooks.ts:setAgentHooksEnabled()` to the read-only
-`getManagedAgentHookStatuses()` path and refreshes nothing. Use `agent hooks
-off` immediately followed by `agent hooks on` to force the state transition
-that runs `installManagedAgentHooks()`'s unconditional
+managed-hook deployment, the reachable-runtime `agent hooks on/off` CLI path
+sends the `settings.update` RPC (`src/main/runtime/rpc/methods/client-ui.ts`)
+into `runtime.updateClientSettings()`, which resolves to
+`src/main/runtime/runtime-client-settings.ts:RuntimeClientSettings.update()`.
+That method reconciles managed hooks only when
+`before !== updates.agentStatusHooksEnabled` (or the disabled-agent set
+changes); a single `agent hooks on` against an already-enabled reachable
+runtime leaves that gate false, so
+`src/cli/handlers/agent-hooks.ts:setAgentHooksEnabled()` falls through to the
+read-only `getManagedAgentHookStatuses()` path and refreshes nothing. Use
+`agent hooks off` immediately followed by `agent hooks on` to force the state
+transition that runs `installManagedAgentHooks()`'s unconditional
 `refreshExistingManagedScripts()`; the CLI's offline path calls
 `applyAgentStatusHooksEnabled()` directly on every invocation and needs no
 toggle. This refreshes the managed Claude/Codex artifacts; it does not

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -57,6 +57,81 @@ compatible with its session-name and layout behavior for local recovery tests.
 The coordinator never independently creates or orders provider windows; its
 restore path calls the setup hook and only starts providers in a session that
 the hook created during that invocation.
+Raw tmux provider events do not use the Orca provider-session relay as their
+manifest source. On newly created sessions, the setup hook sets these
+session-scoped tmux environment values before any provider is started:
+
+```text
+ORCA_OCI_SESSION_MANIFEST=<manifest path>
+ORCA_OCI_WORKTREE_PATH=<canonical worktree path>
+ORCA_OCI_REPO_ROOT=<canonical repository root>
+ORCA_OCI_PROVIDER_EVENT_WRITER=/srv/script/orca-worktree-session-manifest.sh
+```
+
+The writer path is host-local and may be overridden only by focused tests.
+
+
+The provider-native SessionStart adapters then have one explicit path:
+
+- Claude and Codex use the generated managed hook scripts in
+  `src/main/claude/hook-service.ts#getManagedScript` and
+  `src/main/codex/codex-hook-script.ts#getManagedScript`. When
+  `ORCA_OCI_SESSION_MANIFEST` and `ORCA_OCI_PROVIDER_EVENT_WRITER` are set,
+  their guarded `SessionStart` branch sends the native JSON hook payload to:
+
+  ```text
+  "$ORCA_OCI_PROVIDER_EVENT_WRITER" record \
+    --manifest "$ORCA_OCI_SESSION_MANIFEST" \
+    --provider <provider> \
+    --worktree "$ORCA_OCI_WORKTREE_PATH" \
+    --repo-root "$ORCA_OCI_REPO_ROOT" \
+    --payload-stdin
+  ```
+
+  The adapter extracts only the provider's native `session_id`; it never
+  parses terminal output. The normal Orca status-hook path remains separate.
+- OMP loads `/srv/script/orca-omp-worktree-session-hook.ts`, installed as the
+  host-local auto-discovered hook extension under `~/.omp/agent/hooks/`. Its
+  `session_start` handler reads `ctx.sessionManager.getSessionId()` and
+  `ctx.sessionManager.getSessionFile()`, then invokes the same writer with the
+  exact ID and optional resume file path. It is a provider hook event, never
+  terminal-output parsing.
+
+The writer realpaths and validates `ORCA_OCI_WORKTREE_PATH`, verifies that
+`git -C` reports the same `ORCA_OCI_REPO_ROOT`, rejects a mismatched manifest
+argument, and atomically updates only that provider's field. Missing provider
+hook configuration means no locator is published; recovery remains
+`RECOVERY_REQUIRED`. Managed Orca panes do not set `ORCA_OCI_*` and therefore
+do not write this manifest.
+
+The setup implementation must treat provider-hook adapter installation and the
+writer's executable path as a preflight dependency. It may not silently rely
+on a running Orca UI, a stale `ORCA_AGENT_HOOK_*` endpoint, or an implicit
+relay association.
+
+The setup hook must remove a partially created session if four-window creation
+fails. Existing sessions remain untouched.
+
+Initial rollout does not mutate legacy sessions that predate the four-window
+layout. The operator must archive and recreate each such session once; only
+new sessions receive the layout automatically.
+
+Provider command dispatch is additionally gated by a non-mutating binary/flag
+preflight on the new session's target host. The preflight checks the exact
+resume subcommand/selector and permission flags for that provider. An
+unsupported binary or flag records `RECOVERY_REQUIRED` and sends no provider
+command; it never substitutes another flag or selector.
+
+Recovery is deliberately one-shot per created tmux session. If a provider
+start or preflight partially fails, the coordinator leaves the session and
+window as shell plus `RECOVERY_REQUIRED`; a later reconciliation sees the
+existing session and sends no second provider command. Manual archive and
+recreate is required after correcting the failure, preventing duplicate
+provider processes or concurrent writers.
+
+The setup hook's single-owner contract is the only layout definition. The
+coordinator must not duplicate or reinterpret it.
+
 
 `restore_worktree_sessions()` continues to enumerate Orca's worktree inventory,
 skip non-local paths, call the setup hook, observe which session name was newly
@@ -106,6 +181,11 @@ The permission-bypass flags are an explicit OCI-only policy. They are not sent
 to hp_v2. OMP has no `dangerously-skip-permissions` flag; `--auto-approve` plus
 `--approval-mode=yolo` is its installed CLI approval policy and must remain a
 provider-specific command contract.
+The command rows above are the recovery argv after the provider preflight. The
+preflight must verify the installed provider help output exposes every
+selector and permission flag used by that row. A preflight failure is a
+provider-local `RECOVERY_REQUIRED`, not a downgrade to another approval mode.
+
 
 A provider resume failure, including a missing or mismatched manifest locator,
 returns the window to an ordinary shell and records `RECOVERY_REQUIRED`. It
@@ -137,16 +217,23 @@ and never committed to the worktree. Its minimum schema is:
 }
 ```
 
-Entries are updated only from the provider's authoritative session-start
-identity event or the existing Orca provider-session relay; the implementation
-must not infer an ID from terminal text, file mtime, or a global recent-session
-picker. A manifest is consumed only when its recorded `worktreePath` and
-`repoRoot` match the canonical realpaths of the target session. A moved or
-renamed worktree does not reuse the old manifest automatically.
+Entries are updated only by the explicit provider-native SessionStart adapter
+path defined in the chosen approach. The implementation must not infer an ID
+from terminal text, file mtime, a global recent-session picker, or a relay
+event that lacks the raw session's `ORCA_OCI_*` context. The writer receives a
+normalized provider locator from the adapter, realpaths and validates the
+worktree/root pair, then atomically updates the matching manifest. For OMP,
+`resumeFilePath` is stored only when
+`ctx.sessionManager.getSessionFile()` supplies the authoritative path;
+otherwise the exact OMP session ID remains the locator.
 
-If the provider hook/relay cannot publish an exact locator, that provider stays
-at `RECOVERY_REQUIRED` after reboot. The system does not downgrade to
+A manifest is consumed only when its recorded `worktreePath` and `repoRoot`
+match the canonical realpaths of the target session. A moved or renamed
+worktree does not reuse the old manifest automatically. A missing adapter,
+missing locator, malformed locator, or failed path/root validation leaves that
+provider at `RECOVERY_REQUIRED` after reboot. The system does not downgrade to
 `--last`, `--continue`, or a fresh session.
+
 
 The manifest stores provider locators only; it stores no API credentials,
 approval tokens, or conversation content.
@@ -188,6 +275,14 @@ expected for the separate managed terminal path.
 | non-local/Windows worktree path | skip it; do not create an OCI tmux session |
 | managed worker request | create a separate Orca managed terminal/worktree, never a tmux child |
 
+Recovery is deliberately one-shot per created tmux session. If a provider
+start or preflight partially fails, the coordinator leaves the session and
+window as shell plus `RECOVERY_REQUIRED`; a later reconciliation sees the
+existing session and sends no second provider command. Manual archive and
+recreate is required after correcting the failure, preventing duplicate
+provider processes or concurrent writers.
+
+
 A resume restores provider conversation context only. It does not claim that a
 previous command, test, child process, or terminal output was restored.
 
@@ -195,6 +290,9 @@ The operational change is limited to:
 
 - the authoritative Orca local setup hook and its `/srv/script` test copy, for
   creating the four-window layout;
+- the provider-native raw-session event adapters and OMP hook extension that
+  feed the manifest writer without using the Orca managed relay;
+
 - a host-local provider-session manifest writer/reader and focused tests;
 - `/srv/script/orca-coordinator.sh`, for provider-specific exact-locator
   recovery on newly created sessions and strict failure handling;
@@ -233,6 +331,17 @@ The manifest tests must assert:
   mismatch yields `RECOVERY_REQUIRED`;
 - no provider ID is inferred from recent-session ordering or terminal text.
 
+The event-path tests must assert:
+
+- Claude/Codex SessionStart payloads reach the writer with the native
+  `session_id`;
+- OMP `session_start` reaches the writer with
+  `ctx.sessionManager.getSessionId()` and its optional session file;
+- absent or mismatched `ORCA_OCI_*` context cannot write another worktree's
+  manifest;
+- no manifest update depends on terminal text, mtime, or recent-session order.
+
+
 The coordinator test must assert:
 
 - `ensure-session` restores missing local worktree sessions;
@@ -250,6 +359,15 @@ Run CLI help probes for the installed Codex, Claude, and OMP versions and keep
 the exact-resume assertions aligned with
 `getAgentResumeArgv()`/`buildAgentResumeStartupPlan()`. Do not infer a
 provider's resume syntax from another provider.
+
+Provider preflight tests must cover the installed Codex, Claude, and OMP
+selector/permission flags, with unsupported flags producing
+`RECOVERY_REQUIRED` and no downgrade.
+
+Recovery idempotency tests must cover a second coordinator invocation after
+each provider preflight/start failure: it must leave the existing session
+untouched and send no duplicate provider command. A failed partial layout must
+be removed by setup so a later setup can retry creation.
 
 The UI-visible managed-worker acceptance remains a separate Orca UI/AgentMap
 smoke check. It must verify a managed worker has its own terminal and managed

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -66,6 +66,7 @@ ORCA_OCI_SESSION_MANIFEST=<manifest path>
 ORCA_OCI_WORKTREE_PATH=<canonical worktree path>
 ORCA_OCI_REPO_ROOT=<canonical repository root>
 ORCA_OCI_PROVIDER_EVENT_WRITER=/srv/script/orca-worktree-session-manifest.sh
+ORCA_OMP_STATUS_EXTENSION=<installed OMP extension path>
 ```
 
 The writer path is host-local and may be overridden only by focused tests.
@@ -99,12 +100,26 @@ The provider-native raw event adapters then have one explicit path:
   `SessionStart`. Ordinary events must leave the manifest unchanged.
   The adapter extracts only the provider's native `session_id`; it never
   parses terminal output. The normal Orca status-hook path remains separate.
-- OMP loads `/srv/script/orca-omp-worktree-session-hook.ts`, installed as the
-  host-local auto-discovered hook extension under `~/.omp/agent/hooks/`. Its
-  `session_start` handler reads `ctx.sessionManager.getSessionId()` and
-  `ctx.sessionManager.getSessionFile()`, then invokes the same writer with the
-  exact ID and optional resume file path. It is a provider hook event, never
-  terminal-output parsing.
+- OMP uses `/srv/script/orca-omp-worktree-session-hook.ts`, installed under the
+  selected OMP agent directory's `extensions` child (normally
+  `~/.omp/agent/extensions/`). The setup hook sets
+  `ORCA_OMP_STATUS_EXTENSION` to that exact file. The existing
+  `src/main/pty/omp-shell-wrapper.ts` is the source-backed proof that OMP's
+  supported explicit invocation is `omp --extension <path>`; raw recovery
+  passes that argument directly and does not depend on an arbitrary tmux pane
+  having Orca's shell-startup wrapper. `~/.omp/agent/hooks/` is not an
+  auto-discovery contract.
+  The extension registers the context-bearing lifecycle callbacks
+  `before_agent_start`, `agent_start`, `tool_call`, `tool_execution_start`,
+  `tool_execution_end`, `tool_approval_requested`,
+  `tool_approval_resolved`, `message_end`, `agent_settled`, and `agent_end`.
+  The current OMP status source intentionally has no `session_start` handler.
+  Each callback rereads `ctx.sessionManager.getSessionId()` and
+  `getSessionFile()`, uses a non-empty session file only as the persistence
+  gate, and invokes the same writer with only the normalized native session ID.
+  OMP can switch sessions in-process, so the callback set must refresh the ID
+  rather than rely on a single initial callback. It is a provider hook event,
+  never terminal-output parsing.
 
 The writer realpaths both `ORCA_OCI_WORKTREE_PATH` and
 `ORCA_OCI_REPO_ROOT`. It requires
@@ -184,15 +199,18 @@ provider manifest entry matches that same worktree.
 | --- | --- |
 | `codex` | `codex resume <session-id> --dangerously-bypass-approvals-and-sandbox` |
 | `claude` | `claude --resume <session-id> --dangerously-skip-permissions` |
-| `omp` | `omp --resume <resume-file-or-session-id> --auto-approve --approval-mode=yolo` |
+| `omp` | `omp --extension <extension-path> --resume <session-id> --auto-approve --approval-mode=yolo` |
 
 The provider locator is not selected by tmux session name or a global recent
 session picker. The Codex locator is the recorded `session_id`; the Claude
 locator is its recorded `session_id`; the OMP locator is its recorded
-`resumeFilePath` when present, otherwise its recorded `session_id`. This
-matches the provider-specific mapping in
-`src/shared/agent-session-resume.ts:getAgentResumeArgv()` and the startup plan
-in `src/shared/tui-agent-resume-startup.ts:buildAgentResumeStartupPlan()`.
+`session_id` only. The OMP command also receives the exact extension path from
+`ORCA_OMP_STATUS_EXTENSION`; this is extension selection, not a session
+locator. The locator mapping matches
+`src/shared/agent-session-resume.ts:getAgentResumeArgv()` for the default OMP
+case. That function supports an explicit caller-supplied `ompResumeFilePath`
+override, but this OCI manifest does not populate that separate override from
+native `getSessionFile()`.
 
 The permission-bypass flags are an explicit OCI-only policy. They are not sent
 to hp_v2. OMP has no `dangerously-skip-permissions` flag; `--auto-approve` plus
@@ -229,7 +247,7 @@ and never committed to the worktree. Its minimum schema is:
   "providers": {
     "codex": { "key": "session_id", "id": "..." },
     "claude": { "key": "session_id", "id": "..." },
-    "omp": { "key": "session_id", "id": "...", "resumeFilePath": "..." }
+    "omp": { "key": "session_id", "id": "..." }
   }
 }
 ```
@@ -243,9 +261,16 @@ implementation must not infer an ID from terminal text, file mtime, a global
 recent-session picker, or a relay event that lacks the raw session's
 `ORCA_OCI_*` context. The writer receives a normalized provider locator from
 the adapter, realpaths and validates the worktree/root pair, then atomically
-updates the matching manifest. For OMP, `resumeFilePath` is stored only when
-`ctx.sessionManager.getSessionFile()` supplies the authoritative path;
-otherwise the exact OMP session ID remains the locator.
+updates the matching manifest. OMP's `getSessionFile()` is a persistence gate
+only; it is never serialized as `resumeFilePath` or used as the OCI resume
+target.
+
+All Claude, Codex, and OMP IDs use the same trust boundary as
+`normalizeAgentProviderSession` in `src/shared/agent-session-resume.ts`: trim
+surrounding whitespace, reject empty values, reject values over the shared
+512 string-length limit, reject a leading `-`, and reject control characters
+with code `<= 0x1f` or `0x7f`. Rejected values cannot mutate a manifest or reach
+resume argv.
 
 
 A manifest is consumed only when its recorded `worktreePath` and `repoRoot`
@@ -338,7 +363,10 @@ The setup-hook test must assert:
 - branch worktree name derivation;
 - exactly four windows in the documented order;
 - every window's session path and initial pane CWD match the worktree;
-- an existing session is reused without window mutation;
+- `ORCA_OMP_STATUS_EXTENSION` points to the installed extension under the
+  agent directory's `extensions` child and the coordinator's recovery argv
+  passes that exact path with `omp --extension`;
+- an existing session is reused without window or extension mutation;
 - path mismatch fails closed.
 
 The manifest tests must assert:
@@ -351,6 +379,10 @@ The manifest tests must assert:
   `--git-common-dir`, including a real linked-worktree fixture;
 - Codex, Claude, and OMP locators are persisted with their provider-specific
   fields;
+- surrounding whitespace is trimmed before persistence;
+- empty, overlong, leading-dash, or control-character IDs from all three
+  providers return non-zero, leave the prior manifest field unchanged, and
+  never reach a resume command;
 - manifest writes are private and atomic;
 - a moved worktree, missing provider entry, malformed locator, or provider
   mismatch yields `RECOVERY_REQUIRED`;
@@ -369,8 +401,10 @@ The event-path tests must assert:
 - Codex's redirected runtime `CODEX_HOME/hooks.json` `SessionStart`
   registration points to the shared `~/.orca/agent-hooks/codex-hook.sh`
   launcher, and that launcher contains the recorder;
-- OMP `session_start` reaches the writer with
-  `ctx.sessionManager.getSessionId()` and its optional session file;
+- OMP registers the confirmed lifecycle event set, rereads a mutable
+  `ctx.sessionManager` ID after a session switch, and records both native IDs;
+- OMP with a missing `getSessionFile()` does not invoke the writer, and no OMP
+  event passes `--resume-file`;
 - absent or mismatched `ORCA_OCI_*` context cannot write another worktree's
   manifest;
 - no manifest update depends on terminal text, mtime, or recent-session order.
@@ -382,12 +416,14 @@ The coordinator test must assert:
 - only sessions created during the current invocation receive provider
   commands;
 - the exact provider-specific locator commands are sent to the matching
-  windows;
+  windows, with OMP receiving only its recorded `session_id`;
+- invalid provider IDs are rejected before `send-keys`;
 - `ORCA_COORDINATOR_RESUME_AGENTS=0` restores sessions without provider starts;
 - provider resume failure produces `RECOVERY_REQUIRED` and no fresh command;
 - an existing session is not resumed again;
 - an unreachable hp_v2 runtime does not destroy the OCI keeper or local session
   inventory.
+
 
 Run CLI help probes for the installed Codex, Claude, and OMP versions and keep
 the exact-resume assertions aligned with
@@ -399,7 +435,9 @@ provider's resume syntax from another provider.
 
 Provider preflight tests must cover the installed Codex, Claude, and OMP
 selector/permission flags, with unsupported flags producing
-`RECOVERY_REQUIRED` and no downgrade.
+`RECOVERY_REQUIRED` and no downgrade. The OMP preflight and recovery command
+must use the manifest's ID, never a native session-file path.
+
 
 Recovery idempotency tests must cover a second coordinator invocation after
 each provider preflight/start failure: it must leave the existing session
@@ -410,15 +448,23 @@ The UI-visible managed-worker acceptance remains a separate Orca UI/AgentMap
 smoke check. It must verify a managed worker has its own terminal and managed
 lineage; it must not expect a raw tmux window to become a card.
 
-## Verification and delivery
-
 Read-only source inspection, ShellCheck, and focused shell tests run on OCI.
 Project pnpm gates, builds, packaging, and Electron validation remain hp_v2-only
 through the coordinator. No hp_v2 reboot is required for normal OCI session
 recovery verification; a controlled OCI tmux-service restart or host reboot
 scenario must be performed only by the coordinator/host owner.
 
-Before claiming recovery support, record the focused test output and verify that
-provider resume is attempted only for newly created sessions. Keep the provider
-resume policy independent from hp_v2 terminal handles, SHA gates, and remote
-wire fields.
+Before claiming recovery support, record the focused test output and verify
+that provider resume is attempted only for newly created sessions. For live
+managed-hook deployment, use the supported `agent hooks on` entrypoint: a
+reachable runtime routes the settings update through
+`src/main/ipc/settings.ts` to `applyAgentStatusHooksEnabled()` and
+`installManagedAgentHooks()`, while the CLI's offline path calls the same
+installation operation directly. This refreshes the managed Claude/Codex
+artifacts; it does not install the raw OMP recovery extension. The live setup
+hook installs that extension under `~/.omp/agent/extensions/`, sets
+`ORCA_OMP_STATUS_EXTENSION`, and the disposable-session probe verifies the
+explicit `omp --extension` route. `agent hooks status` alone is not a refresh
+operation. Record the returned statuses and verify all artifacts before
+updating the live setup hook. Keep the provider resume policy independent from
+hp_v2 terminal handles, SHA gates, and remote wire fields.

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -71,13 +71,14 @@ ORCA_OCI_PROVIDER_EVENT_WRITER=/srv/script/orca-worktree-session-manifest.sh
 The writer path is host-local and may be overridden only by focused tests.
 
 
-The provider-native SessionStart adapters then have one explicit path:
+The provider-native raw event adapters then have one explicit path:
 
 - Claude and Codex use the generated managed hook scripts in
   `src/main/claude/hook-service.ts#getManagedScript` and
   `src/main/codex/codex-hook-script.ts#getManagedScript`. When
-  `ORCA_OCI_SESSION_MANIFEST` and `ORCA_OCI_PROVIDER_EVENT_WRITER` are set,
-  their guarded `SessionStart` branch sends the native JSON hook payload to:
+  `ORCA_OCI_SESSION_MANIFEST`, `ORCA_OCI_WORKTREE_PATH`,
+  `ORCA_OCI_REPO_ROOT`, and `ORCA_OCI_PROVIDER_EVENT_WRITER` are set,
+  their raw recorder passes the captured native JSON payload to:
 
   ```text
   "$ORCA_OCI_PROVIDER_EVENT_WRITER" record \
@@ -88,6 +89,14 @@ The provider-native SessionStart adapters then have one explicit path:
     --payload-stdin
   ```
 
+  The Claude recorder is emitted after the existing Devin and
+  `CLAUDE_JOB_DIR` exclusion guards and before endpoint-dependent logic.
+  The Codex recorder is emitted after payload capture and the spool helper
+  definition but before endpoint loading. Neither recorder depends on an
+  `ORCA_AGENT_HOOK_*` endpoint or adds a Windows `.cmd` branch.
+  The generated recorder may invoke the writer for ordinary provider events;
+  the writer alone parses `hook_event_name` and mutates the manifest only for
+  `SessionStart`. Ordinary events must leave the manifest unchanged.
   The adapter extracts only the provider's native `session_id`; it never
   parses terminal output. The normal Orca status-hook path remains separate.
 - OMP loads `/srv/script/orca-omp-worktree-session-hook.ts`, installed as the
@@ -97,12 +106,19 @@ The provider-native SessionStart adapters then have one explicit path:
   exact ID and optional resume file path. It is a provider hook event, never
   terminal-output parsing.
 
-The writer realpaths and validates `ORCA_OCI_WORKTREE_PATH`, verifies that
-`git -C` reports the same `ORCA_OCI_REPO_ROOT`, rejects a mismatched manifest
-argument, and atomically updates only that provider's field. Missing provider
-hook configuration means no locator is published; recovery remains
-`RECOVERY_REQUIRED`. Managed Orca panes do not set `ORCA_OCI_*` and therefore
-do not write this manifest.
+The writer realpaths both `ORCA_OCI_WORKTREE_PATH` and
+`ORCA_OCI_REPO_ROOT`. It requires
+`git -C "$worktree" rev-parse --show-toplevel` to resolve to the canonical
+worktree itself and the corresponding command for `repo-root` to resolve to
+that canonical root. It then canonicalizes `git -C "$worktree" rev-parse
+--git-common-dir` and the corresponding value from `repo-root` (resolving
+relative output against the command's path). Those common directories must
+match. This supports a linked worktree whose path differs from the main
+repository worktree while rejecting a different repository. The writer
+rejects a mismatched manifest argument and atomically updates only that
+provider's field. Missing provider hook configuration means no locator is
+published; recovery remains `RECOVERY_REQUIRED`. Managed Orca panes do not set
+`ORCA_OCI_*` and therefore do not write this manifest.
 
 The setup implementation must treat provider-hook adapter installation and the
 writer's executable path as a preflight dependency. It may not silently rely
@@ -111,6 +127,7 @@ relay association.
 
 The setup hook must remove a partially created session if four-window creation
 fails. Existing sessions remain untouched.
+
 
 Initial rollout does not mutate legacy sessions that predate the four-window
 layout. The operator must archive and recreate each such session once; only
@@ -217,15 +234,19 @@ and never committed to the worktree. Its minimum schema is:
 }
 ```
 
-Entries are updated only by the explicit provider-native SessionStart adapter
-path defined in the chosen approach. The implementation must not infer an ID
-from terminal text, file mtime, a global recent-session picker, or a relay
-event that lacks the raw session's `ORCA_OCI_*` context. The writer receives a
-normalized provider locator from the adapter, realpaths and validates the
-worktree/root pair, then atomically updates the matching manifest. For OMP,
-`resumeFilePath` is stored only when
+Entries are updated only by the explicit provider-native raw-event adapter
+path defined in the chosen approach. The generated Claude/Codex recorder may
+pass each captured payload to the writer, but the writer accepts only a
+`SessionStart` payload for a manifest mutation. An ordinary provider event
+therefore may invoke the writer but must produce no manifest change. The
+implementation must not infer an ID from terminal text, file mtime, a global
+recent-session picker, or a relay event that lacks the raw session's
+`ORCA_OCI_*` context. The writer receives a normalized provider locator from
+the adapter, realpaths and validates the worktree/root pair, then atomically
+updates the matching manifest. For OMP, `resumeFilePath` is stored only when
 `ctx.sessionManager.getSessionFile()` supplies the authoritative path;
 otherwise the exact OMP session ID remains the locator.
+
 
 A manifest is consumed only when its recorded `worktreePath` and `repoRoot`
 match the canonical realpaths of the target session. A moved or renamed
@@ -322,8 +343,12 @@ The setup-hook test must assert:
 
 The manifest tests must assert:
 
-- one manifest is selected only for the exact canonical worktree path and repo
-  root;
+- one manifest is selected only for the exact canonical worktree path and
+  repository root;
+- the worktree's canonical `git rev-parse --show-toplevel` equals the
+  worktree path itself;
+- the worktree and repository root resolve to the same canonical
+  `--git-common-dir`, including a real linked-worktree fixture;
 - Codex, Claude, and OMP locators are persisted with their provider-specific
   fields;
 - manifest writes are private and atomic;
@@ -333,20 +358,29 @@ The manifest tests must assert:
 
 The event-path tests must assert:
 
-- Claude/Codex SessionStart payloads reach the writer with the native
+- the Claude recorder appears after the Devin/`CLAUDE_JOB_DIR` exclusions and
+  before endpoint-dependent code;
+- Claude/Codex `SessionStart` payloads reach the writer with the native
   `session_id`;
+- an ordinary Claude/Codex payload may reach the writer but leaves the
+  manifest unchanged;
+- the installed Claude POSIX script is the shared
+  `~/.orca/agent-hooks/claude-hook.sh` path and contains the recorder;
+- Codex's redirected runtime `CODEX_HOME/hooks.json` `SessionStart`
+  registration points to the shared `~/.orca/agent-hooks/codex-hook.sh`
+  launcher, and that launcher contains the recorder;
 - OMP `session_start` reaches the writer with
   `ctx.sessionManager.getSessionId()` and its optional session file;
 - absent or mismatched `ORCA_OCI_*` context cannot write another worktree's
   manifest;
 - no manifest update depends on terminal text, mtime, or recent-session order.
 
-
 The coordinator test must assert:
 
 - `ensure-session` restores missing local worktree sessions;
 - Windows/hp_v2 paths are skipped;
-- only sessions created during the current invocation receive provider commands;
+- only sessions created during the current invocation receive provider
+  commands;
 - the exact provider-specific locator commands are sent to the matching
   windows;
 - `ORCA_COORDINATOR_RESUME_AGENTS=0` restores sessions without provider starts;
@@ -357,7 +391,10 @@ The coordinator test must assert:
 
 Run CLI help probes for the installed Codex, Claude, and OMP versions and keep
 the exact-resume assertions aligned with
-`getAgentResumeArgv()`/`buildAgentResumeStartupPlan()`. Do not infer a
+`getAgentResumeArgv()`/`buildAgentResumeStartupPlan()`. Claude capability
+preflight must use a non-launching parser-acceptance invocation that includes
+the exact `--resume` and `--dangerously-skip-permissions` arguments; it must
+not require those strings to appear in `claude --help` output. Do not infer a
 provider's resume syntax from another provider.
 
 Provider preflight tests must cover the installed Codex, Claude, and OMP

--- a/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
+++ b/docs/superpowers/specs/2026-09-03-oci-worktree-tmux-agent-recovery-design.md
@@ -1,0 +1,214 @@
+# OCI Worktree tmux Provider Recovery
+
+## Problem
+
+OCI worktree sessions are created by the Orca setup hook and are independent of
+the hp_v2 host. A full OCI reboot destroys the tmux server, its worktree
+sessions, and the provider processes inside them. The existing recovery path can
+recreate missing worktree sessions and has a Codex-only resume bootstrap, but it
+does not define a stable four-window layout or provider-specific recovery for
+Claude and OMP.
+
+A raw provider process inside an OCI tmux window is also not an Orca managed
+worker. Creating a process with `tmux send-keys` does not create a managed
+terminal identity, parent lineage, or AgentMap orchestration edge.
+
+## Goal
+
+For every local OCI Git worktree, maintain a deterministic detached tmux session
+with four windows:
+
+1. `codex`
+2. `claude`
+3. `omp`
+4. `bash`
+
+When OCI recovery creates a new session, resume the provider's most recent
+session in windows 1–3 with the provider-specific permission-bypass flags. Do
+not create a fresh provider session when resume is unavailable or fails. Keep
+OCI session recovery independent from hp_v2 availability and keep UI-visible
+managed workers outside these tmux sessions.
+
+## Non-goals
+
+- No nested Orca managed worker inside an existing tmux window.
+- No conversion of raw tmux processes into synthetic managed identities.
+- No automatic Claude/OMP task dispatch after resume.
+- No shared cross-provider writer-lock implementation in this first version;
+  manual operation is single-provider-at-a-time.
+- No hp_v2 worker tmux sessions. hp_v2 remains a pinned remote shell terminal.
+- No restoration of reboot-time child processes, running commands, tests, or
+  PTY scrollback.
+- No change to Orca application source or Dashboard/AgentMap data contracts.
+- No automatic fresh provider startup after a failed or missing resume session.
+
+## Chosen approach
+
+The setup hook owns normal worktree session creation. Existing archive-hook
+cleanup behavior is outside this design and is not changed here. The OCI
+systemd-owned tmux server owns server persistence. The coordinator owns only
+boot-time reconciliation of missing OCI worktree sessions and remote hp_v2
+routing; it does not continuously supervise healthy OCI sessions.
+
+The setup hook and its OCI test copy must produce the same four-window layout.
+The live Orca inline hook remains authoritative; `/srv/script/orca-tmux-hook.sh`
+must be kept byte-compatible with its session-name and layout behavior for local
+recovery tests.
+
+`restore_worktree_sessions()` continues to enumerate Orca's worktree inventory,
+skip non-local paths, call the setup hook, observe which session name was newly
+created, and start provider recovery only for that newly created session. An
+existing session is never modified or sent a resume command.
+
+## Session layout
+
+Session names retain the existing derivation:
+
+```text
+<repository-root-basename>-wt-<worktree-basename>
+```
+
+The root worktree uses `main` as its worktree slug. Every new session is created
+with the exact worktree as its session path and each window's initial pane CWD.
+The four windows are ordered as follows:
+
+| tmux index | name | startup behavior |
+| --- | --- | --- |
+| 0 | `codex` | Codex resume command |
+| 1 | `claude` | Claude continue command |
+| 2 | `omp` | OMP continue command |
+| 3 | `bash` | idle shell |
+
+If the session already exists, setup validates its session path and returns
+without adding, deleting, or respawning windows.
+
+## Provider recovery commands
+
+Provider commands are sent only after the session was created during the
+current recovery invocation and its pane CWD matches the exact worktree.
+
+| window | command |
+| --- | --- |
+| `codex` | `codex resume --last --dangerously-bypass-approvals-and-sandbox` |
+| `claude` | `claude --continue --dangerously-skip-permissions` |
+| `omp` | `omp --continue --auto-approve --approval-mode=yolo` |
+
+The Codex `--last` selection uses Codex's default CWD-filtered candidate set;
+`--all` is not used. Claude `--continue` and OMP `--continue` likewise run from
+the exact worktree CWD. Provider session stores remain provider-specific and
+are not keyed by tmux session name or shared across Codex, Claude, and OMP.
+
+The permission-bypass flags are an explicit OCI-only policy. They are not sent
+to hp_v2. OMP has no `dangerously-skip-permissions` flag; `--auto-approve` plus
+`--approval-mode=yolo` is its corresponding non-interactive approval policy.
+
+A provider resume failure, including no saved session, returns the window to an
+ordinary shell and records `RECOVERY_REQUIRED`. It must not be converted into a
+fresh provider launch. The recovery code must not use an unconditional
+`resume || fresh` fallback that hides authentication, lock, CWD, or corrupt
+session errors.
+
+## Writer and ownership policy
+
+Codex, Claude, and OMP sessions are separate provider conversations, but their
+windows share the same worktree filesystem. This version relies on the
+operator's explicit invariant that only one provider is actively used for
+write-capable work at a time.
+
+The coordinator must not automatically dispatch work to more than one provider
+in the same worktree. A future automated or UI-visible worker must use a
+separate worktree; introducing automation is the trigger for a shared writer
+lock or equivalent preflight, not normal tmux session recovery.
+
+## Managed UI boundary
+
+A UI-visible worker is created through Orca managed orchestration and receives
+its own managed terminal/worktree identity. It is not placed into one of the
+four existing tmux windows. The current `/srv/workspace/orca` OMP work session
+must not directly start, stop, resume, or kill that worker; the permitted
+coordinator/control-plane dispatch path owns the lifecycle.
+
+Raw `tmux send-keys` provider startup is therefore intentionally invisible to
+managed orchestration lineage. Dashboard cards and AgentMap edges are only
+expected for the separate managed terminal path.
+
+## Recovery behavior
+
+| condition | expected behavior |
+| --- | --- |
+| hp_v2 reboot while OCI is running | OCI tmux sessions and provider processes are untouched; hp_v2 state is separate |
+| OCI reboot | coordinator session is ensured; missing local worktree sessions are recreated with four windows |
+| existing worktree session | validate path and leave session/windows/processes untouched |
+| newly created worktree session | send one provider-specific resume command per provider window |
+| no saved provider session | leave that window as shell and record `RECOVERY_REQUIRED` |
+| provider resume error | leave that window as shell and record `RECOVERY_REQUIRED`; no fresh launch |
+| wrong session path or pane CWD | fail the recovery for that session; do not start a provider |
+| non-local/Windows worktree path | skip it; do not create an OCI tmux session |
+| managed worker request | create a separate Orca managed terminal/worktree, never a tmux child |
+
+A resume restores provider conversation context only. It does not claim that a
+previous command, test, child process, or terminal output was restored.
+
+## Implementation boundaries
+
+The operational change is limited to:
+
+- the authoritative Orca local setup hook and its `/srv/script` test copy, for
+  creating the four-window layout;
+- `/srv/script/orca-coordinator.sh`, for provider-specific recovery on newly
+  created sessions and strict failure handling;
+- focused shell tests for hook layout and coordinator recovery behavior;
+- operational project facts documenting the OCI session and provider policy.
+
+The existing Codex invocation must use
+`--dangerously-bypass-approvals-and-sandbox`, not Claude's
+`--dangerously-skip-permissions`. Claude and OMP require their own command
+contracts; provider flags must not be substituted across tools.
+
+## Tests
+
+Extend the existing focused shell tests without creating a real reboot or
+modifying the live `orca` tmux socket.
+
+The setup-hook test must assert:
+
+- root worktree name normalization to `*-wt-main`;
+- branch worktree name derivation;
+- exactly four windows in the documented order;
+- every window's session path and initial pane CWD match the worktree;
+- an existing session is reused without window mutation;
+- path mismatch fails closed.
+
+The coordinator test must assert:
+
+- `ensure-session` restores missing local worktree sessions;
+- Windows/hp_v2 paths are skipped;
+- only sessions created during the current invocation receive provider commands;
+- the exact Codex, Claude, and OMP command strings are sent to the matching
+  windows;
+- `ORCA_COORDINATOR_RESUME_AGENTS=0` restores sessions without provider starts;
+- provider resume failure produces `RECOVERY_REQUIRED` and no fresh command;
+- an existing session is not resumed again;
+- an unreachable hp_v2 runtime does not destroy the OCI keeper or local session
+  inventory.
+
+Run CLI help probes for the installed Codex, Claude, and OMP versions before
+locking command assertions. Do not infer a provider's resume syntax from another
+provider.
+
+The UI-visible managed-worker acceptance remains a separate Orca UI/AgentMap
+smoke check. It must verify a managed worker has its own terminal and managed
+lineage; it must not expect a raw tmux window to become a card.
+
+## Verification and delivery
+
+Read-only source inspection, ShellCheck, and focused shell tests run on OCI.
+Project pnpm gates, builds, packaging, and Electron validation remain hp_v2-only
+through the coordinator. No hp_v2 reboot is required for normal OCI session
+recovery verification; a controlled OCI tmux-service restart or host reboot
+scenario must be performed only by the coordinator/host owner.
+
+Before claiming recovery support, record the focused test output and verify that
+provider resume is attempted only for newly created sessions. Keep the provider
+resume policy independent from hp_v2 terminal handles, SHA gates, and remote
+wire fields.

--- a/src/main/agent-hooks/oci-worktree-session-event.test.ts
+++ b/src/main/agent-hooks/oci-worktree-session-event.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { buildPosixOciWorktreeSessionRecordLines } from './oci-worktree-session-event'
+
+const expectedLines = (provider: 'claude' | 'codex'): string[] => [
+  'if [ -n "${ORCA_OCI_SESSION_MANIFEST:-}" ] && \\',
+  '   [ -n "${ORCA_OCI_WORKTREE_PATH:-}" ] && \\',
+  '   [ -n "${ORCA_OCI_REPO_ROOT:-}" ] && \\',
+  '   [ -x "${ORCA_OCI_PROVIDER_EVENT_WRITER:-}" ]; then',
+  '  printf \'%s\' "$payload" | "$ORCA_OCI_PROVIDER_EVENT_WRITER" record \\',
+  '    --manifest "$ORCA_OCI_SESSION_MANIFEST" \\',
+  `    --provider ${provider} \\`,
+  '    --worktree "$ORCA_OCI_WORKTREE_PATH" \\',
+  '    --repo-root "$ORCA_OCI_REPO_ROOT" \\',
+  '    --payload-stdin >/dev/null 2>&1 || :',
+  'fi'
+]
+
+describe('buildPosixOciWorktreeSessionRecordLines', () => {
+  it('emits the guarded Claude recorder contract', () => {
+    const lines = buildPosixOciWorktreeSessionRecordLines('claude')
+    const output = lines.join('\n')
+
+    expect(lines).toEqual(expectedLines('claude'))
+    expect(output).toContain('--provider claude')
+    expect(output).toContain('ORCA_OCI_SESSION_MANIFEST')
+    expect(output).not.toContain('ORCA_AGENT_HOOK_ENDPOINT')
+    expect(output).not.toContain('ORCA_PANE_KEY')
+  })
+
+  it('bakes the Codex provider into the recorder contract', () => {
+    const lines = buildPosixOciWorktreeSessionRecordLines('codex')
+    const output = lines.join('\n')
+
+    expect(lines).toEqual(expectedLines('codex'))
+    expect(output).toContain('--provider codex')
+    expect(output).toContain('ORCA_OCI_SESSION_MANIFEST')
+    expect(output).not.toContain('ORCA_AGENT_HOOK_ENDPOINT')
+    expect(output).not.toContain('ORCA_PANE_KEY')
+  })
+})

--- a/src/main/agent-hooks/oci-worktree-session-event.ts
+++ b/src/main/agent-hooks/oci-worktree-session-event.ts
@@ -1,0 +1,17 @@
+export type OciWorktreeProvider = 'claude' | 'codex'
+
+export function buildPosixOciWorktreeSessionRecordLines(provider: OciWorktreeProvider): string[] {
+  return [
+    'if [ -n "${ORCA_OCI_SESSION_MANIFEST:-}" ] && \\',
+    '   [ -n "${ORCA_OCI_WORKTREE_PATH:-}" ] && \\',
+    '   [ -n "${ORCA_OCI_REPO_ROOT:-}" ] && \\',
+    '   [ -x "${ORCA_OCI_PROVIDER_EVENT_WRITER:-}" ]; then',
+    '  printf \'%s\' "$payload" | "$ORCA_OCI_PROVIDER_EVENT_WRITER" record \\',
+    '    --manifest "$ORCA_OCI_SESSION_MANIFEST" \\',
+    `    --provider ${provider} \\`,
+    '    --worktree "$ORCA_OCI_WORKTREE_PATH" \\',
+    '    --repo-root "$ORCA_OCI_REPO_ROOT" \\',
+    '    --payload-stdin >/dev/null 2>&1 || :',
+    'fi'
+  ]
+}

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -3,7 +3,16 @@
 // or the script body that lands on the remote box. Local install behavior
 // is exercised through `installer-utils.test.ts` and the per-CLI status
 // audit; this file covers ONLY the SFTP-backed path added in commit #8.
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { vi, describe, expect, it } from 'vitest'
@@ -32,6 +41,28 @@ type TestHook = { command: string; args?: string[] }
 
 function hasManagedCommand(hook: TestHook, matcher: (command: string | undefined) => boolean) {
   return matcher(hook.command) || hook.args?.some(matcher) === true
+}
+
+function createFakeOciProviderEventWriter(dir: string): {
+  writerPath: string
+  argsPath: string
+  payloadPath: string
+} {
+  const writerPath = join(dir, 'fake-oci-provider-event-writer.sh')
+  const argsPath = join(dir, 'writer-args.txt')
+  const payloadPath = join(dir, 'writer-payload.json')
+  writeFileSync(
+    writerPath,
+    `#!/bin/sh
+printf '%s\\n' "$@" > "$ORCA_TEST_WRITER_ARGS"
+payload=$(cat)
+case "$payload" in
+  *'"hook_event_name":"SessionStart"'*) printf '%s' "$payload" > "$ORCA_TEST_WRITER_PAYLOAD" ;;
+esac
+`
+  )
+  chmodSync(writerPath, 0o755)
+  return { writerPath, argsPath, payloadPath }
 }
 
 describe('getWindowsManagedLifecycleHook', () => {
@@ -363,6 +394,88 @@ describe('ClaudeHookService.install', () => {
       rmSync(tmpHome, { recursive: true, force: true })
     }
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'records OCI Claude SessionStart payloads before endpoint handling',
+    () => {
+      const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-oci-session-'))
+      vi.stubEnv('HOME', tmpHome)
+      vi.stubEnv('USERPROFILE', tmpHome)
+      try {
+        expect(new ClaudeHookService().install().state).toBe('installed')
+
+        const scriptPath = join(tmpHome, '.orca', 'agent-hooks', 'claude-hook.sh')
+        const script = readFileSync(scriptPath, 'utf-8')
+        const recorder = 'if [ -n "${ORCA_OCI_SESSION_MANIFEST:-}" ]'
+        expect(script.indexOf('if [ -n "$DEVIN_PROJECT_DIR" ]')).toBeLessThan(
+          script.indexOf(recorder)
+        )
+        expect(script.indexOf('if [ -n "$CLAUDE_JOB_DIR" ]')).toBeLessThan(script.indexOf(recorder))
+        expect(script.indexOf(recorder)).toBeLessThan(
+          script.indexOf('if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ]')
+        )
+        expect(script).toContain('printf \'%s\' "$payload" | curl')
+        expect(script).toContain('/hook/claude')
+
+        const writer = createFakeOciProviderEventWriter(tmpHome)
+        const cleanEnv: NodeJS.ProcessEnv = {}
+        for (const [key, value] of Object.entries(process.env)) {
+          if (!key.startsWith('ORCA_')) {
+            cleanEnv[key] = value
+          }
+        }
+        const env = {
+          ...cleanEnv,
+          ORCA_OCI_SESSION_MANIFEST: join(tmpHome, 'manifest.json'),
+          ORCA_OCI_WORKTREE_PATH: tmpHome,
+          ORCA_OCI_REPO_ROOT: tmpHome,
+          ORCA_OCI_PROVIDER_EVENT_WRITER: writer.writerPath,
+          ORCA_TEST_WRITER_ARGS: writer.argsPath,
+          ORCA_TEST_WRITER_PAYLOAD: writer.payloadPath
+        }
+        const runHook = (payload: string) =>
+          spawnSync('/bin/sh', [scriptPath], {
+            input: payload,
+            env,
+            encoding: 'utf-8',
+            timeout: 5000
+          })
+
+        const sessionPayload = JSON.stringify({
+          hook_event_name: 'SessionStart',
+          session_id: 'claude-session-id'
+        })
+        const sessionResult = runHook(sessionPayload)
+        expect(sessionResult.error).toBeUndefined()
+        expect(sessionResult.status).toBe(0)
+        expect(sessionResult.stdout).toBe('{}\n')
+        expect(readFileSync(writer.payloadPath, 'utf-8')).toBe(sessionPayload)
+        expect(readFileSync(writer.argsPath, 'utf-8').trim().split('\n')).toEqual([
+          'record',
+          '--manifest',
+          join(tmpHome, 'manifest.json'),
+          '--provider',
+          'claude',
+          '--worktree',
+          tmpHome,
+          '--repo-root',
+          tmpHome,
+          '--payload-stdin'
+        ])
+
+        const ordinaryResult = runHook(
+          JSON.stringify({ hook_event_name: 'UserPromptSubmit', prompt: 'ordinary' })
+        )
+        expect(ordinaryResult.error).toBeUndefined()
+        expect(ordinaryResult.status).toBe(0)
+        expect(readFileSync(writer.payloadPath, 'utf-8')).toBe(sessionPayload)
+        expect(ordinaryResult.stdout).toBe('{}\n')
+      } finally {
+        vi.unstubAllEnvs()
+        rmSync(tmpHome, { recursive: true, force: true })
+      }
+    }
+  )
 
   it.skipIf(process.platform !== 'win32')(
     'runs portable managed hooks through a single headless command string',

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -16,6 +16,7 @@ import {
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
+import { buildPosixOciWorktreeSessionRecordLines } from '../agent-hooks/oci-worktree-session-event'
 import {
   buildPosixHookPayloadCapture,
   buildPosixHookSpoolLines,
@@ -112,6 +113,7 @@ function getManagedScript(
     'if [ -n "$CLAUDE_JOB_DIR" ]; then',
     '  exit 0',
     'fi',
+    ...buildPosixOciWorktreeSessionRecordLines('claude'),
     // Why: refresh endpoint coordinates for PTYs surviving an Orca restart.
     // Why: suppress parse errors so they neither leak nor trip outer set -e.
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',

--- a/src/main/codex/codex-hook-script.ts
+++ b/src/main/codex/codex-hook-script.ts
@@ -1,4 +1,5 @@
 import { buildPosixAgentHookPostCommand } from '../agent-hooks/hook-post-command'
+import { buildPosixOciWorktreeSessionRecordLines } from '../agent-hooks/oci-worktree-session-event'
 import {
   buildPosixHookPayloadCapture,
   buildPosixHookSpoolLines,
@@ -26,6 +27,7 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
     ...buildPosixHookSpoolLines('codex'),
+    ...buildPosixOciWorktreeSessionRecordLines('codex'),
     // Why: sourcing refreshes PORT/TOKEN/ENV/VERSION from the current Orca so a surviving PTY keeps reporting after a restart (see claude/hook-service.ts).
     'load_hook_endpoint() {',
     '  endpoint_path="$1"',

--- a/src/main/codex/hook-service-managed-install.test.ts
+++ b/src/main/codex/hook-service-managed-install.test.ts
@@ -1,9 +1,17 @@
 import { describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { createServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { isCodexManagedCommand, setupCodexHookHomes } from './hook-service-test-harness'
@@ -46,6 +54,28 @@ function localManagedCodexEvents(): string[] {
     'SubagentStop',
     'UserPromptSubmit'
   ]
+}
+
+function createFakeOciProviderEventWriter(dir: string): {
+  writerPath: string
+  argsPath: string
+  payloadPath: string
+} {
+  const writerPath = join(dir, 'fake-oci-provider-event-writer.sh')
+  const argsPath = join(dir, 'writer-args.txt')
+  const payloadPath = join(dir, 'writer-payload.json')
+  writeFileSync(
+    writerPath,
+    `#!/bin/sh
+printf '%s\\n' "$@" > "$ORCA_TEST_WRITER_ARGS"
+payload=$(cat)
+case "$payload" in
+  *'"hook_event_name":"SessionStart"'*) printf '%s' "$payload" > "$ORCA_TEST_WRITER_PAYLOAD" ;;
+esac
+`
+  )
+  chmodSync(writerPath, 0o755)
+  return { writerPath, argsPath, payloadPath }
 }
 
 describe('CodexHookService', () => {
@@ -128,6 +158,83 @@ describe('CodexHookService', () => {
     expect(trustConfig).toContain('approval_policy = "on-request"')
     expect(trustConfig).toContain(':permission_request:0:0')
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'registers and executes the shared Codex OCI SessionStart recorder',
+    async () => {
+      expect((await new CodexHookService().install()).state).toBe('installed')
+
+      const managedCodexHome = join(homes.userDataDir, 'codex-runtime-home', 'home')
+      const hooksConfig = JSON.parse(
+        readFileSync(join(managedCodexHome, 'hooks.json'), 'utf-8')
+      ) as {
+        hooks: Record<string, { hooks?: { command?: string }[] }[]>
+      }
+      const sessionStartCommand = hooksConfig.hooks.SessionStart?.[0]?.hooks?.[0]?.command ?? ''
+      const scriptPath = join(homes.tmpHome, '.orca', 'agent-hooks', 'codex-hook.sh')
+      expect(sessionStartCommand).toContain(scriptPath)
+
+      const script = readFileSync(scriptPath, 'utf-8')
+      const recorder = 'if [ -n "${ORCA_OCI_SESSION_MANIFEST:-}" ]'
+      expect(script.indexOf(recorder)).toBeGreaterThanOrEqual(0)
+      expect(script.indexOf(recorder)).toBeLessThan(script.indexOf('load_hook_endpoint() {'))
+      expect(script).toContain('printf \'%s\' "$payload" | curl')
+      expect(script).toContain('/hook/codex')
+
+      const writer = createFakeOciProviderEventWriter(homes.tmpHome)
+      const cleanEnv: NodeJS.ProcessEnv = {}
+      for (const [key, value] of Object.entries(process.env)) {
+        if (!key.startsWith('ORCA_')) {
+          cleanEnv[key] = value
+        }
+      }
+      const env = {
+        ...cleanEnv,
+        HOME: homes.tmpHome,
+        ORCA_OCI_SESSION_MANIFEST: join(homes.tmpHome, 'manifest.json'),
+        ORCA_OCI_WORKTREE_PATH: homes.tmpHome,
+        ORCA_OCI_REPO_ROOT: homes.tmpHome,
+        ORCA_OCI_PROVIDER_EVENT_WRITER: writer.writerPath,
+        ORCA_TEST_WRITER_ARGS: writer.argsPath,
+        ORCA_TEST_WRITER_PAYLOAD: writer.payloadPath
+      }
+      const runHook = (payload: string) =>
+        spawnSync('/bin/sh', [scriptPath], {
+          input: payload,
+          env,
+          encoding: 'utf-8',
+          timeout: 5000
+        })
+
+      const sessionPayload = JSON.stringify({
+        hook_event_name: 'SessionStart',
+        session_id: 'codex-session-id'
+      })
+      const sessionResult = runHook(sessionPayload)
+      expect(sessionResult.error).toBeUndefined()
+      expect(sessionResult.status).toBe(0)
+      expect(readFileSync(writer.payloadPath, 'utf-8')).toBe(sessionPayload)
+      expect(readFileSync(writer.argsPath, 'utf-8').trim().split('\n')).toEqual([
+        'record',
+        '--manifest',
+        join(homes.tmpHome, 'manifest.json'),
+        '--provider',
+        'codex',
+        '--worktree',
+        homes.tmpHome,
+        '--repo-root',
+        homes.tmpHome,
+        '--payload-stdin'
+      ])
+
+      const ordinaryResult = runHook(
+        JSON.stringify({ hook_event_name: 'UserPromptSubmit', prompt: 'ordinary' })
+      )
+      expect(ordinaryResult.error).toBeUndefined()
+      expect(ordinaryResult.status).toBe(0)
+      expect(readFileSync(writer.payloadPath, 'utf-8')).toBe(sessionPayload)
+    }
+  )
 
   it('installs managed hooks + trust into a per-account self-contained home, not the shared mirror', async () => {
     const systemCodexHome = join(homes.tmpHome, '.codex')

--- a/src/main/runtime/orca-runtime-remove-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-remove-managed-worktree.ts
@@ -191,6 +191,7 @@ export class OrcaRuntimeWithRemoveManagedWorktree extends OrcaRuntimeWithCreateM
             store,
             provider: provider!,
             force,
+            runHooks,
             allowUnverifiedPtyStop,
             deleteBranch,
             acquireWatcherRemoval: this.acquireFileWatcherRemoval,

--- a/src/main/runtime/orca-runtime-tests/ssh-worktree-lifecycle-part-02.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/ssh-worktree-lifecycle-part-02.spec.ts
@@ -461,7 +461,14 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({
       scripts: { archive: 'pnpm worktree:archive' }
     })
-    const runtime = new OrcaRuntimeService(remoteStore as never)
+    const ptyProvider = {
+      listProcesses: vi.fn().mockResolvedValue([]),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      deleteWorktreeHistory: vi.fn().mockResolvedValue(undefined)
+    }
+    const runtime = new OrcaRuntimeService(remoteStore as never, undefined, {
+      getSshProvider: () => ptyProvider as never
+    })
 
     try {
       await runtime.removeManagedWorktree('path:/remote/feature', true, true)
@@ -522,7 +529,14 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({
       scripts: { archive: 'pnpm worktree:archive' }
     })
-    const runtime = new OrcaRuntimeService(remoteStore as never)
+    const ptyProvider = {
+      listProcesses: vi.fn().mockResolvedValue([]),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      deleteWorktreeHistory: vi.fn().mockResolvedValue(undefined)
+    }
+    const runtime = new OrcaRuntimeService(remoteStore as never, undefined, {
+      getSshProvider: () => ptyProvider as never
+    })
 
     let result: RemoveWorktreeResult & { warning?: string }
     try {

--- a/src/main/runtime/orca-runtime-tests/ssh-worktree-lifecycle-part-02.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/ssh-worktree-lifecycle-part-02.spec.ts
@@ -21,6 +21,7 @@ import {
   unregisterSshGitProvider
 } from '../orca-runtime-test-mocks.spec'
 import type { WorktreeMeta } from '../orca-runtime-test-mocks.spec'
+import type { RemoveWorktreeResult } from '../../../shared/worktree/create-types'
 import {
   TEST_REPO_ID,
   TEST_REPO_PATH,
@@ -419,6 +420,122 @@ describe('OrcaRuntimeService', () => {
     expect(removeWorktree).not.toHaveBeenCalled()
     expect(listWorktrees).not.toHaveBeenCalled()
     expect(deleteWorktreeHistoryDirMock).toHaveBeenCalledWith(`${TEST_REPO_ID}::/remote/feature`)
+  })
+
+  it('runs archive hooks for CLI SSH worktree removal when hooks are explicitly enabled', async () => {
+    const remoteRepo = {
+      id: TEST_REPO_ID,
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const remoteStore = { ...store, getRepos: () => [remoteRepo], getRepo: () => remoteRepo }
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo',
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/remote/feature',
+          head: 'abc',
+          branch: 'feature/foo',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      execNonInteractive: vi.fn().mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false
+      })
+    }
+    registerSshGitProvider('ssh-1', gitProvider as never)
+    vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({
+      scripts: { archive: 'pnpm worktree:archive' }
+    })
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    try {
+      await runtime.removeManagedWorktree('path:/remote/feature', true, true)
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+
+    expect(gitProvider.execNonInteractive).toHaveBeenCalledWith(
+      '/bin/bash',
+      ['-lc', 'pnpm worktree:archive'],
+      '/remote/feature',
+      expect.any(Number),
+      undefined,
+      expect.anything()
+    )
+    expect(gitProvider.execNonInteractive.mock.invocationCallOrder[0]).toBeLessThan(
+      gitProvider.removeWorktree.mock.invocationCallOrder[0]
+    )
+    expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
+  })
+
+  it('warns instead of running the archive hook for CLI SSH removal without --run-hooks', async () => {
+    const remoteRepo = {
+      id: TEST_REPO_ID,
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: 'blue',
+      addedAt: 1,
+      connectionId: 'ssh-1'
+    }
+    const remoteStore = { ...store, getRepos: () => [remoteRepo], getRepo: () => remoteRepo }
+    const gitProvider = {
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo',
+          head: 'main',
+          branch: 'refs/heads/main',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/remote/feature',
+          head: 'abc',
+          branch: 'feature/foo',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue(undefined),
+      execNonInteractive: vi.fn().mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false
+      })
+    }
+    registerSshGitProvider('ssh-1', gitProvider as never)
+    vi.mocked(getEffectiveHooksFromConfig).mockReturnValue({
+      scripts: { archive: 'pnpm worktree:archive' }
+    })
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    let result: RemoveWorktreeResult & { warning?: string }
+    try {
+      result = await runtime.removeManagedWorktree('path:/remote/feature', true, false)
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+
+    expect(gitProvider.execNonInteractive).not.toHaveBeenCalled()
+    expect(gitProvider.removeWorktree).toHaveBeenCalledWith('/remote/feature', true)
+    expect(result.warning).toBe(
+      'orca.yaml archive hook skipped for /remote/feature; pass --run-hooks to run it.'
+    )
   })
 
   // Regression: `repoId::path` ids repeat across hosts, so the SSH delete's runtime sweep used to

--- a/src/main/runtime/runtime-registered-remote-worktree-removal.ts
+++ b/src/main/runtime/runtime-registered-remote-worktree-removal.ts
@@ -3,9 +3,12 @@ import type { RemoveWorktreeResult } from '../../shared/worktree/create-types'
 import type { Repo } from '../../shared/repo-types'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
 import { cleanupUnusedWorktreePushTargetRemoteSsh } from '../ipc/worktree-remote'
+import {
+  getArchiveHooksForRemoval,
+  runRemoteArchiveHook
+} from '../ipc/worktrees/removal/worktree-archive-hook'
 import type { RuntimeStore } from './runtime-store-contract'
 import type { RuntimeWorktreeRemovalTarget } from './runtime-worktree-selection'
-
 export async function removeRuntimeRegisteredRemoteWorktree(args: {
   repo: Repo
   target: RuntimeWorktreeRemovalTarget
@@ -14,6 +17,7 @@ export async function removeRuntimeRegisteredRemoteWorktree(args: {
   store: RuntimeStore
   provider: SshGitProvider
   force: boolean
+  runHooks: boolean
   allowUnverifiedPtyStop: boolean
   deleteBranch: boolean
   acquireWatcherRemoval: (
@@ -27,9 +31,21 @@ export async function removeRuntimeRegisteredRemoteWorktree(args: {
     fallbackHead: string | undefined
   ) => RemoveWorktreeResult
   finishRemoval: (result: RemoveWorktreeResult) => void
-}): Promise<RemoveWorktreeResult> {
+}): Promise<RemoveWorktreeResult & { warning?: string }> {
   const { repo, target, registeredWorktree, provider } = args
   const connectionId = repo.connectionId!
+  const canonicalPath = registeredWorktree.path
+  const hooks = await getArchiveHooksForRemoval(repo)
+  let warning: string | undefined
+  if (hooks?.scripts.archive && args.runHooks) {
+    const hookResult = await runRemoteArchiveHook(repo, canonicalPath, hooks.scripts.archive)
+    if (!hookResult.success) {
+      console.error(`[hooks] archive hook failed for ${canonicalPath}:`, hookResult.output)
+    }
+  } else if (hooks?.scripts.archive) {
+    warning = `orca.yaml archive hook skipped for ${canonicalPath}; pass --run-hooks to run it.`
+    console.warn(`[hooks] ${warning}`)
+  }
   const removeOptions = !args.deleteBranch ? { deleteBranch: args.deleteBranch } : {}
   const gate = await args.acquireWatcherRemoval(registeredWorktree.path, connectionId)
   let rawResult: RemoveWorktreeResult | undefined
@@ -53,5 +69,5 @@ export async function removeRuntimeRegisteredRemoteWorktree(args: {
   )
   await args.deleteHistory()
   args.finishRemoval(result)
-  return result
+  return { ...result, ...(warning ? { warning } : {}) }
 }


### PR DESCRIPTION
Fixes #18558.

## Problem
`orca worktree rm --run-hooks` removed SSH-backed worktrees without running their configured archive hook. The app UI removal path already ran it correctly via `getArchiveHooksForRemoval`/`runRemoteArchiveHook` (`src/main/ipc/worktrees/removal/worktree-archive-hook.ts`).

## Root cause
Local removal (`runtime-registered-local-worktree-removal.ts`) already ran the archive hook. SSH removal (`runtime-registered-remote-worktree-removal.ts`) never called it.

## Fix
`removeRuntimeRegisteredRemoteWorktree` now threads a `runHooks` flag from `orca-runtime-remove-managed-worktree.ts` and, before tearing down PTYs and removing the worktree, runs the archive hook over the SSH connection via the same `getArchiveHooksForRemoval`/`runRemoteArchiveHook` helpers the UI removal path uses. When `--run-hooks` is not passed and an archive hook is configured, it returns the same skipped-hook warning the local path already returns, matching UI behavior end to end.

## Testing
- `pnpm tc:node` — clean
- `pnpm vitest run src/main/runtime/orca-runtime.test.ts` — 1222 passed, 1 pre-existing unrelated `/tmp` mkdtemp flake on Windows (not touched by this change)
- `pnpm exec oxlint` on changed files — 0 warnings, 0 errors
- Added two focused tests in `ssh-worktree-lifecycle-part-02.spec.ts` covering the hook running under `--run-hooks` and the skipped-hook warning without it.