### PR TITLE
fix(cloud): recalibrate the relay monitor's exhausted-retry freeze to a measured bar

### DIFF
--- a/cloud/apps/relay-ops/src/incident-monitor.test.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.test.ts
@@ -123,15 +123,20 @@ describe('incident monitor evaluator', () => {
     })
   })
 
-  // Why: sweeps no longer reach the retry wrapper, so any exhaustion left in this
-  // counter is a request path that terminally failed. It must still freeze.
-  it('freezes on a single exhausted request-path transaction', () => {
-    const sample = healthySample()
-    sample.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(1)
-    expect(evaluateIncidentSample(sample, startedAt)).toMatchObject({
+  // Why: since #18521 the request path fails fast on the cell-inventory lock, so
+  // exhaustion is a steady contention rate (post-#18521 p90 147/5min, max 220),
+  // not an anomaly. The bar bounds it below the 2026-08-23 incident peak of 467.
+  it('tolerates the measured healthy exhaustion rate and freezes above the bar', () => {
+    const healthy = healthySample()
+    healthy.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(220)
+    expect(evaluateIncidentSample(healthy, startedAt).status).toBe('green')
+
+    const incident = healthySample()
+    incident.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(301)
+    expect(evaluateIncidentSample(incident, startedAt)).toMatchObject({
       status: 'freeze',
       failures: [
-        expect.objectContaining({ signal: 'relay.postgres_retry_exhausted', threshold: 0 })
+        expect.objectContaining({ signal: 'relay.postgres_retry_exhausted', threshold: 300 })
       ]
     })
   })

--- a/cloud/apps/relay-ops/src/incident-monitor.test.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.test.ts
@@ -131,6 +131,10 @@ describe('incident monitor evaluator', () => {
     healthy.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(220)
     expect(evaluateIncidentSample(healthy, startedAt).status).toBe('green')
 
+    const atLimit = healthySample()
+    atLimit.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(300)
+    expect(evaluateIncidentSample(atLimit, startedAt).status).toBe('green')
+
     const incident = healthySample()
     incident.sources['relay-logs']!.signals['relay.postgres_retry_exhausted'] = signal(301)
     expect(evaluateIncidentSample(incident, startedAt)).toMatchObject({

--- a/cloud/apps/relay-ops/src/incident-monitor.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.ts
@@ -15,8 +15,8 @@ export const INCIDENT_MONITOR_THRESHOLDS = {
   // Why: healthy latest-sum backends idle near 100 but spike to 216 in 1-minute
   // bursts (~10 min/day exceeded the old bar of 160 on 2026-08-26, freezing a
   // pre-drain gate on baseline noise). 250 clears measured healthy peaks while
-  // firing well before the verified 400-connection ceiling; pool-wait and
-  // exhausted-retry signals keep their strict thresholds.
+  // firing well before the verified 400-connection ceiling; the retry signals
+  // below discriminate incident-class contention.
   cloudSqlBackends: 250,
   // Bound the observed recovery load; deadlocks remain zero-tolerance.
   cloudSqlLockWaits: 20,
@@ -35,24 +35,23 @@ export const INCIDENT_MONITOR_THRESHOLDS = {
   // Healthy 2026-08-26 baseline bursts to 234/5min (26% of windows crossed the old
   // bar of 20, set unmeasured at the monitor's 2026-07-28 birth); the 2026-08-23
   // incident ran ~2,200-3,000/5min. 300 clears healthy bursts with ~10x incident
-  // margin; relayPostgresRetryExhausted below stays at zero tolerance, so any
-  // transaction that terminally fails still freezes the gate.
+  // margin; relayPostgresRetryExhausted below bounds the terminally failed share.
   relayPostgresRetries: 300,
-  // Why: this bar stays at zero. Cell-inventory contention reaches the retry
-  // wrapper from exactly two kinds of caller, and neither is a sweep tick that
-  // can shrug the failure off:
-  //   - request paths, which take a wait bounded at CELL_INVENTORY_LOCK_TIMEOUT_MS
-  //     (assignment, control activation, activity, admin drain/evacuate/supersede);
-  //   - sweep-reachable code that a request also enters, which keeps the pool
-  //     lock_timeout so it cannot fail faster than before this change: the
-  //     completeEvacuation site that waits, reconcileReservationAccounting, and
-  //     placement re-entered from evacuateDeadCells.
-  // Sweep-only sites take the inventory NOWAIT, so their contention becomes
-  // database_lock_unavailable, which is not a retryable abort and never reaches
-  // this counter. The relay's cell-inventory-lock census test holds that split.
-  // Splitting the metric by the phase label PR #423 put on the log payload would
-  // need a labelled log-based metric, which this signal's counter does not carry.
-  relayPostgresRetryExhausted: 0,
+  // Why: 300 per five minutes, recalibrated 2026-09-04 from a bar of zero that no
+  // production window has cleared since #18521 shipped to the director. That
+  // change cut the request-path cell-inventory wait from the 1 s pool lock_timeout
+  // to 500 ms, so a contended waiter now fails fast (one /v1/assign 503 with
+  // Retry-After, which the client retries) instead of succeeding slowly, and the
+  // exhaustion count became a steady-state contention rate rather than an
+  // anomaly. Measured fleet-wide (director + cells) per five minutes over
+  // 2026-09-03T03Z..2026-09-04T02Z: every one of 236 windows was non-zero;
+  // quiet hours p50 2 / max 36; pre-#18521 daytime p50 10 / p90 25 / max 87;
+  // post-#18521 p50 42 / p90 147 / max 220. The 2026-08-23 lock incident peaked
+  // at 467. 300 clears every measured healthy window and still sits below the
+  // incident shape; relayPostgresRetries above stays the ~10x discriminator.
+  // User-facing /v1/assign 503 share did not move with #18521 (13.9% old image
+  // vs 12.3% new, same evening), so exhaustion is not a proxy for user harm.
+  relayPostgresRetryExhausted: 300,
   // Why: public admission is a per-instance semaphore, so fleet assignment capacity is
   // concurrency x instances. A floor of 1 let the 2026-08-04 collapse from five instances
   // to two pass unnoticed, which is the exact failure this monitor exists to catch. Keep in

--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -337,8 +337,8 @@ export type CellInventoryLockMode =
   // Never queue: the caller handles database_lock_unavailable and moves on.
   | 'nowait'
   // A sweep can enter here, so keep the pool default. Failing sooner would turn
-  // ordinary contention into a 55P03 the retry wrapper reports as terminal, and
-  // one terminal failure freezes the incident gate.
+  // ordinary contention into a 55P03 the retry wrapper reports as terminal, which
+  // spends the incident gate's bounded exhausted-retry budget (300 per 5 min).
   | 'pool-default'
 // Why: stranded detection (issue #225) needs a grant old enough that a real
 // attach would have registered (the 90s activity lease covers dial +

--- a/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
@@ -170,8 +170,8 @@ describe('cell inventory lock call-site census', () => {
   })
 
   // Why: this is the whole point of the classification. A shorter wait on a
-  // sweep-reachable site turns contention into a terminal transaction failure,
-  // and relayPostgresRetryExhausted freezes the incident gate at zero.
+  // sweep-reachable site turns contention into a terminal transaction failure
+  // that counts against the incident gate's relayPostgresRetryExhausted bar.
   // Why: the hold distribution is what the 500ms bound will be tuned against, so
   // a mode that stops asking for it goes unmeasured in exactly the lane that
   // matters. Nothing else in the suite reads the pool-default branch.

--- a/cloud/apps/relay/src/cell-inventory-lock-contention.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-lock-contention.test.ts
@@ -300,8 +300,8 @@ describe('bounded cell-inventory lock wait', () => {
   })
 })
 
-// Why: the incident monitor freezes at zero exhausted transactions. A sweep that
-// steps aside must not spend the retry budget or report a terminal failure.
+// Why: exhausted transactions count against the incident monitor's bounded bar.
+// A sweep that steps aside must not spend the retry budget or report a terminal failure.
 describe('sweep lock skips stay off the transaction retry counters', () => {
   it('reports neither a retry nor an exhaustion when NOWAIT finds the lock held', async () => {
     const database = await openFakePostgres()

--- a/cloud/docs/relay-incident-monitor.md
+++ b/cloud/docs/relay-incident-monitor.md
@@ -100,7 +100,7 @@ durably marked consumed before mutation and cannot authorize another run.
 | Relay pool waiters | over 800 |
 | Relay pool wait | over 2,500 ms |
 | PostgreSQL retries in five minutes | over 300 |
-| Exhausted PostgreSQL retries | over 0 |
+| Exhausted PostgreSQL retries in five minutes | over 300 |
 | Director instances | outside 5–6 |
 | Director CPU or memory | over 80% |
 | Director concurrency | over 64 |
@@ -132,15 +132,25 @@ heartbeats, and matching live admission.
   10 minutes over the old bar of 160 — enough to freeze roughly one in ten
   15-minute pre-drain gates on baseline noise. 250 clears measured healthy
   peaks and still fires well before the verified 400-connection ceiling;
-  pool waiters, pool wait latency, and exhausted retries keep their strict
-  thresholds.
+  pool waiters and pool wait latency keep their strict thresholds.
 - Recalibrated the PostgreSQL-retry freeze from 20 to 300 per five minutes
   (2026-08-26). Basis, measured from
   `jsonPayload.event="orca_relay_postgres_transaction_retry"` in production
   logs: healthy-day bursts reach 234/5min with zero exhausted retries and 26%
   of five-minute windows over 20, while the 2026-08-23 lock-contention
-  incident ran roughly 2,200–3,000/5min. Exhausted retries stay at zero
-  tolerance.
+  incident ran roughly 2,200–3,000/5min.
+- Recalibrated the exhausted-PostgreSQL-retry freeze from 0 to 300 per five
+  minutes (2026-09-04). Basis: #18521 cut the request-path cell-inventory
+  lock wait from the 1 s pool `lock_timeout` to 500 ms, so contended waiters
+  now fail fast (one `/v1/assign` 503 with `Retry-After`) instead of
+  succeeding slowly, and `orca_relay_postgres_transaction_exhausted` became
+  a steady contention rate. Measured fleet-wide per five minutes over
+  2026-09-03T03Z..2026-09-04T02Z: 236 of 236 windows non-zero; quiet hours
+  p50 2 / max 36; pre-#18521 daytime p50 10 / p90 25 / max 87; post-#18521
+  p50 42 / p90 147 / max 220; the 2026-08-23 incident peaked at 467. Every
+  pre-drain dry-run since the director deploy froze at minute one on this
+  bar, which blocked the cell roll that carries the same fix to the 23 GCE
+  cells. `/v1/assign` 503 share was unchanged by #18521 (13.9% vs 12.3%).
 - Added a fail-closed state machine with latched threshold freezes,
   generation-scoped checkpoint boundaries, continuity-reset evidence, cadence
   accounting, restart-gap recovery, and the 15-minute pre-drain gate.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Before any production cell roll, a 15-minute health check has to pass. One of its rules says "zero database lock give-ups allowed". Since #18521 made the relay give up on a contended lock quickly instead of waiting a full second, the fleet always has a few dozen give-ups per five minutes, so the health check fails at minute one every time and nobody can roll the cells. This PR sets that rule to a number the healthy fleet actually stays under while still catching the real incident.

## What Changed

- `cloud/apps/relay-ops/src/incident-monitor.ts`: `relayPostgresRetryExhausted` 0 → 300 per five minutes, with the measurement basis in the comment; adjacent comments that referred to the zero bar updated.
- `cloud/apps/relay-ops/src/incident-monitor.test.ts`: the "freezes on signal(1) with threshold 0" test becomes "220 is green, 301 freezes with threshold 300". Reverting the constant to 0 fails it.
- `cloud/docs/relay-incident-monitor.md`: threshold table row and an implementation-log entry with the basis.

## Why

Every `cloud-monitor-relay-production` dry-run since the director deploy at 22:12Z on 2026-09-03 froze on this bar (runs 33746931085, 33747826907, 33812032190). `cloud-deploy-relay-production-same-cap` requires a fresh green dry-run, so the 23 GCE cells are stuck on the pre-#18521 image with the 1 s lock wait, which is exactly what keeps `sqlLatencyMsMax` pinned at 1.0–1.2 s on every cell (see #18565).

Measured from `jsonPayload.event="orca_relay_postgres_transaction_exhausted"` fleet-wide (director + cells), summed per five minutes, 2026-09-03T03Z to 2026-09-04T02Z:

| window | five-minute windows | p50 | p90 | max |
|---|---|---|---|---|
| all | 236 (236 non-zero) | 15 | 98 | 220 |
| quiet hours 03Z–08Z | 17 | 2 | 9 | 36 |
| pre-#18521 daytime | 167 | 10 | 25 | 87 |
| post-#18521 (director) | 68 | 42 | 147 | 220 |
| 2026-08-23 incident peak | | | | 467 |

300 clears every healthy window measured and stays below the incident shape. `relayPostgresRetries: 300` remains the ~10x discriminator for incident-class contention and is unchanged. User-facing `/v1/assign` 503 share did not move with #18521 (13.9% old image vs 12.3% new, same evening), so exhaustion is not a proxy for user harm.

Post-roll the cells will also fail fast, so the fleet-wide exhausted count will rise further while retries fall; the bar leaves room for that (roughly 2.5x the current p90).

## Not in this PR

`cloud/infra/terraform/relay-observability.tf` has `google_monitoring_alert_policy.relay_postgres_retry_exhausted` with the same `> 0` threshold on both the Cloud Run and GCE conditions, so that alert has been firing continuously since #18521. It should be recalibrated to the same 300 per 300 s, but that is a Terraform apply on the observability root and belongs in its own change.

## Linked Issue

Fixes # (none filed; unblocks the cell roll described in the #18565 report)

## Visual Proof

N/A: threshold constant, test, and docs only.

## Testing

- [x] `cloud/apps/relay-ops`: `vitest run` 12 files / 76 passed; `tsc --noEmit` clean; mutation check (bar back to 0) fails the new test.
- [ ] Real verification is the next dry-run dispatch: it should now run the full 15 minutes instead of freezing at minute one.

## Agent skill upstream boundary

- [x] Not applicable

## Checklist

- [x] Small and focused
- [x] ELI5 and why included
- [x] N/A visual proof with reason
- [x] Self-reviewed
- [x] Cross-platform / SSH: N/A (cloud ops tooling)
- [x] Local lint/typecheck/test pass for the touched package
