### PR TITLE
fix(crash-reporting): stop claiming kills that never landed, and leave proof when the own-Chromium pid set is unreadable

### DIFF
--- a/src/main/codex/codex-app-server-process-teardown.test.ts
+++ b/src/main/codex/codex-app-server-process-teardown.test.ts
@@ -1,6 +1,13 @@
 import type { ChildProcess } from 'node:child_process'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  findSelfInitiatedTreeKills,
+  resetSelfInitiatedTreeKillLogForTest
+} from '../crash-reporting/self-initiated-tree-kill-log'
 import { terminateCodexAppServerProcessTree } from './codex-app-server-process-teardown'
+
+/** Above pid_max on every supported POSIX host, so the group signal is a real ESRCH. */
+const UNREACHABLE_PGID = 2_147_483_647
 
 function child() {
   return {
@@ -10,6 +17,10 @@ function child() {
 }
 
 describe('terminateCodexAppServerProcessTree', () => {
+  beforeEach(() => {
+    resetSelfInitiatedTreeKillLogForTest()
+  })
+
   it('waits for the Windows tree kill before releasing the wrapper', async () => {
     const target = child()
     const release = Promise.withResolvers<void>()
@@ -118,6 +129,55 @@ describe('terminateCodexAppServerProcessTree', () => {
     ).resolves.toBe(false)
 
     expect(target.kill).not.toHaveBeenCalled()
+  })
+
+  /**
+   * `selfInitiatedTreeKillCount` decides whether a `render-process-gone` was
+   * ours. A group that had already exited was killed by nobody, so crediting it
+   * puts a suspect in the five-second window that Orca never issued. Exercised
+   * through the real `process.kill(-pgid)` because the swallow being tested
+   * lives in the production default, not in an injectable seam.
+   */
+  it('does not claim a snapshot group that was already gone', async () => {
+    const target = { pid: UNREACHABLE_PGID, kill: vi.fn(() => true) as ChildProcess['kill'] }
+
+    await expect(
+      terminateCodexAppServerProcessTree(target, undefined, {
+        platform: 'darwin',
+        captureDescendants: async () => ({
+          rootPgid: UNREACHABLE_PGID,
+          descendants: [],
+          capturedAtMs: 1
+        }),
+        terminateDescendants: async () => true
+      })
+    ).resolves.toBe(true)
+
+    expect(target.kill).toHaveBeenLastCalledWith('SIGKILL')
+    expect(findSelfInitiatedTreeKills(Date.now())).toEqual([])
+  })
+
+  it('claims a snapshot group the signal actually reached', async () => {
+    const target = child()
+    const signalProcessGroup = vi.fn()
+
+    await expect(
+      terminateCodexAppServerProcessTree(target, undefined, {
+        platform: 'darwin',
+        captureDescendants: async () => ({ rootPgid: 1234, descendants: [], capturedAtMs: 1 }),
+        terminateDescendants: async () => true,
+        signalProcessGroup
+      })
+    ).resolves.toBe(true)
+
+    expect(signalProcessGroup).toHaveBeenCalledWith(1234, 'SIGKILL')
+    expect(findSelfInitiatedTreeKills(Date.now())).toEqual([
+      expect.objectContaining({
+        pid: 1234,
+        site: 'codex-app-server-teardown',
+        scope: 'posix-process-group'
+      })
+    ])
   })
 
   it('tears down 40 dedicated groups without process-table scans or cross-group fanout', async () => {

--- a/src/main/codex/codex-app-server-process-teardown.ts
+++ b/src/main/codex/codex-app-server-process-teardown.ts
@@ -134,12 +134,11 @@ async function terminatePosixTree(
       signalGroup(snapshot.rootPgid, 'SIGKILL')
       groupSignalled = true
     } catch {
-      // Group already exited: still the desired outcome, but nothing here
-      // killed it, and a breadcrumb for a kill we never landed is a false
-      // suspect in the render-process-gone window.
+      // Already-gone is still the desired outcome, but nothing here killed it,
+      // and a crumb for a kill we never landed is a false render-process-gone suspect.
     }
     if (groupSignalled) {
-      // Outside the try, like terminateDedicatedPosixGroup: that catch is the
+      // Outside the try, as in terminateDedicatedPosixGroup: that catch is the
       // already-gone contract, not a breadcrumb handler.
       recordSelfInitiatedTreeKill({
         pid: snapshot.rootPgid,

--- a/src/main/codex/codex-app-server-process-teardown.ts
+++ b/src/main/codex/codex-app-server-process-teardown.ts
@@ -128,19 +128,25 @@ async function terminatePosixTree(
   if (descendantsExited && snapshot.rootPgid === rootPid) {
     const signalGroup =
       deps.signalProcessGroup ??
-      ((pgid: number, signal: NodeJS.Signals) => {
-        try {
-          process.kill(-pgid, signal)
-        } catch {
-          // Group already exited.
-        }
+      ((pgid: number, signal: NodeJS.Signals) => process.kill(-pgid, signal))
+    let groupSignalled = false
+    try {
+      signalGroup(snapshot.rootPgid, 'SIGKILL')
+      groupSignalled = true
+    } catch {
+      // Group already exited: still the desired outcome, but nothing here
+      // killed it, and a breadcrumb for a kill we never landed is a false
+      // suspect in the render-process-gone window.
+    }
+    if (groupSignalled) {
+      // Outside the try, like terminateDedicatedPosixGroup: that catch is the
+      // already-gone contract, not a breadcrumb handler.
+      recordSelfInitiatedTreeKill({
+        pid: snapshot.rootPgid,
+        site: 'codex-app-server-teardown',
+        scope: 'posix-process-group'
       })
-    signalGroup(snapshot.rootPgid, 'SIGKILL')
-    recordSelfInitiatedTreeKill({
-      pid: snapshot.rootPgid,
-      site: 'codex-app-server-teardown',
-      scope: 'posix-process-group'
-    })
+    }
   }
   if (!descendantsExited) {
     child.kill('SIGCONT')

--- a/src/main/orca-chromium-process-pids.ts
+++ b/src/main/orca-chromium-process-pids.ts
@@ -1,4 +1,5 @@
 import { getAppEnvironment, hasAppEnvironment } from '../shared/app-environment'
+import { recordCoalescedDurableCrashBreadcrumb } from './crash-reporting/durable-crash-breadcrumb'
 
 /**
  * PIDs of Orca's own Chromium processes — browser, renderers, GPU, utilities.
@@ -10,6 +11,14 @@ import { getAppEnvironment, hasAppEnvironment } from '../shared/app-environment'
  *
  * Empty on a Node host and empty on failure: that is "no refusal proven", never
  * "safe to kill" — callers must keep every other guard they already have.
+ *
+ * Why failure stays open rather than refusing everything: a refusal is not free.
+ * `terminateWindowsProcessTree` resolves without killing, and
+ * `killSourceControlAgentProcess` returns that straight to a caller that then
+ * releases the managed-home lock, so failing closed would trade one unreadable
+ * metrics table for every PTY, git, codex and notebook tree in main leaking at
+ * once. The `own_chromium_pids_unreadable` crumb is the price of that choice:
+ * without it a throw is byte-identical to "no Chromium on this host".
  *
  * Host coverage: only Electron main installs a Chromium-backed AppEnvironment
  * (main-process-preflight). The standalone daemon installs none and `orcad`
@@ -30,7 +39,26 @@ export function readOrcaChromiumProcessPids(): ReadonlySet<number> {
       .map((metric) => metric.pid)
       .filter((pid) => Number.isInteger(pid) && pid > 0)
     return new Set(pids)
-  } catch {
+  } catch (error) {
+    recordUnreadableOwnChromiumMetrics(error)
     return new Set()
+  }
+}
+
+// Why coalesced: the gate reads this set on every tree kill, so a persistently
+// broken metrics table would otherwise flood the 30-slot ring it shares.
+const UNREADABLE_METRICS_COALESCE_MS = 60_000
+
+function recordUnreadableOwnChromiumMetrics(error: unknown): void {
+  try {
+    recordCoalescedDurableCrashBreadcrumb({
+      name: 'own_chromium_pids_unreadable',
+      data: { cause: error instanceof Error ? error.message : String(error) },
+      coalesceKey: 'own-chromium-pids-unreadable',
+      minIntervalMs: UNREADABLE_METRICS_COALESCE_MS
+    })
+  } catch {
+    // Diagnostics must never turn an admitted kill into a thrown one: callers
+    // read this set outside their own try.
   }
 }

--- a/src/main/own-chromium-tree-kill-guard.test.ts
+++ b/src/main/own-chromium-tree-kill-guard.test.ts
@@ -143,6 +143,40 @@ describe('refusing to tree-kill our own Chromium processes', () => {
     )
   })
 
+  /**
+   * Fail-open is the deliberate choice — see `orca-chromium-process-pids.ts` for
+   * why refusing everything is worse — so the crumb is the only thing that keeps
+   * an unreadable metrics table distinguishable from a host that has no Chromium.
+   */
+  it('leaves proof, and still admits the kill, when the Chromium metrics cannot be read', () => {
+    appMetricsMock.mockImplementation(() => {
+      throw new Error('getAppMetrics unavailable')
+    })
+
+    expect([...readOrcaChromiumProcessPids()]).toEqual([])
+    // Coalesced: the gate reads this set on every kill, so a broken table must
+    // not evict the ring it shares with the refusal crumb.
+    expect([...readOrcaChromiumProcessPids()]).toEqual([])
+    expect(
+      admitSelfInitiatedTreeKill({
+        pid: RENDERER_PID,
+        site: 'pty-descendant-sweep',
+        scope: 'win-taskkill-tree'
+      })
+    ).toBe(true)
+
+    expect(
+      getCrashBreadcrumbSnapshot().filter(
+        (breadcrumb) => breadcrumb.name === 'own_chromium_pids_unreadable'
+      )
+    ).toEqual([
+      expect.objectContaining({
+        name: 'own_chromium_pids_unreadable',
+        data: expect.objectContaining({ cause: 'getAppMetrics unavailable' })
+      })
+    ])
+  })
+
   it('refuses an own-Chromium pid at the gate the account teardowns share', () => {
     expect(
       admitSelfInitiatedTreeKill({


### PR DESCRIPTION
## What

Two CodeRabbit findings from #18367 that are **live on `main`** and are **not** addressed by #18459. #18367 merged early (as `7b530f1eb56`) before its own remediation round; #18459 carries the choke-point work, but neither of these two.

**1. `terminatePosixTree` claimed a group kill that never landed.** The codex app-server teardown's snapshot path recorded a `self_tree_kill` breadcrumb even when the group signal proved the group was already gone. Its default `signalGroup` swallowed every `process.kill(-pgid, 'SIGKILL')` error and the `recordSelfInitiatedTreeKill` call sat unconditionally below it, so an `ESRCH` — positive proof that this teardown killed nothing — still credited Orca with a group kill inside the five-second `render-process-gone` attribution window that #18367 exists to make decidable.

**2. An unreadable Chromium pid set was indistinguishable from "no Chromium here".** `readOrcaChromiumProcessPids` returns an empty set when `getAppMetrics()` throws. That decision is kept (see Trade-offs — failing closed is much worse), but the empty set was byte-identical to the legitimate Node-host case, so the fail-open left no trace in a field bundle. Now it emits a coalesced durable `own_chromium_pids_unreadable` crumb.

**Two other CodeRabbit findings on #18367 are REFUTED here, not fixed** — `own-chromium-tree-kill-guard.ts:35` / `process-tree-termination.ts:89` ("record accepted kills only after `taskkill` succeeds") and the "fail closed" half of `orca-chromium-process-pids.ts:34`. Both are declined on evidence, and complying with either would introduce a worse bug than the one it fixes. Reasoning and numbers are in **Refuted findings** below. Do not read this PR as "all bot comments addressed".

Finding 1 is the one member of the "record before the kill is proven" family that is both wrong and cheaply fixable: the signal is synchronous, so success is knowable at zero cost, and three siblings already do it correctly.

## Fix evidence

Finding 1 is not a new convention — it makes the outlier match the three group-kill sites that already record only on a proven signal:

| Site | Records on proven signal? |
|---|---|
| `terminateDedicatedPosixGroup` (**same file**, `codex-app-server-process-teardown.ts:29`) | yes — `catch` returns before the record, commented "Outside the try: that catch is the ESRCH contract, not a breadcrumb handler" |
| `forceKillPosixPtyProcessGroups` (`pty/posix-pty-process-groups.ts:130`) | yes — `isProcessAlreadyGone` skips the record |
| `claude-login-process-termination.ts:79` | yes — guarded by a `signaledGroup` flag |
| `terminatePosixTree` (`codex-app-server-process-teardown.ts:139`) | **no** — this PR |

`does not claim a snapshot group that was already gone` drives the **production default**, not an injected seam — the swallow being tested lives in the default lambda, so an injected throwing dep would not reach it. It uses pgid `2_147_483_647` (above `pid_max` on every supported POSIX host) so `process.kill(-pgid)` raises a real `ESRCH`.

**RED without the production hunk.** Run in a throwaway detached worktree with only `src/main/codex/codex-app-server-process-teardown.ts` restored to its `origin/main` content, so nothing else could perturb the result:

```
 FAIL  src/main/codex/codex-app-server-process-teardown.test.ts > terminateCodexAppServerProcessTree > does not claim a snapshot group that was already gone
AssertionError: expected [ { pid: 2147483647, …(3) } ] to deeply equal []

- Expected
+ Received

- []
+ [
+   {
+     "at": 1788499221650,
+     "pid": 2147483647,
+     "scope": "posix-process-group",
+     "site": "codex-app-server-teardown",
+   },
+ ]

 ❯ src/main/codex/codex-app-server-process-teardown.test.ts:157:52
 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

**RED without the finding-2 hunk**, same method on `src/main/orca-chromium-process-pids.ts`:

```
- ObjectContaining {
-     "data": ObjectContaining { "cause": "getAppMetrics unavailable" },
-     "name": "own_chromium_pids_unreadable",
-   },
- ]
+ []
 ❯ src/main/own-chromium-tree-kill-guard.test.ts:172:7
 Test Files  1 failed (1)
      Tests  1 failed | 9 passed (10)
```

**GREEN with both**, plus the surrounding suites:

```
vitest run --config config/vitest.config.ts src/main/codex/ src/main/crash-reporting/ \
  src/shared/child-process/ src/main/own-chromium-tree-kill-guard.test.ts \
  src/main/windows-process-tree-kill.test.ts src/main/pty/posix-pty-process-groups.test.ts \
  src/main/windows/windows-pty-job.test.ts src/main/claude-accounts/ src/main/codex-accounts/ \
  src/main/text-generation/ src/main/windows-pty-root-identity.test.ts
 Test Files  217 passed | 3 skipped (220)
      Tests  2208 passed | 36 skipped (2244)

tsc -p config/tsconfig.node.json --noEmit   -> exit 0
oxlint <all four touched files>             -> exit 0
oxfmt --check <all four touched files>      -> "All matched files use the correct format."
```

## ELI5

When Orca force-kills a group of processes it writes a note: "I did this." If a renderer dies right after, those notes are the list of suspects the crash report prints.

Finding 1: this path wrote the note even when the group had *already exited* and Orca's signal bounced off nothing — a suspect that was never at the scene. Now the note is only written when the signal actually reached something.

Finding 2: before killing anything, Orca asks Electron "which processes are my own windows?" so it never kills one by accident. If that question *fails*, Orca gets back an empty answer — which looks exactly like the honest answer on a machine that has no windows at all. Orca still proceeds (refusing everything would strand real processes), but it now writes down that the question failed, so nobody later reads "no windows here" and believes it.

**Honest scope on finding 1:** this is a POSIX *group* kill, so it lands in `selfInitiatedGroupKillCount` and the `selfInitiatedKills` string, not in `selfInitiatedTreeKillCount` — the pid-addressed, Windows-only field that actually decides whether a `render-process-gone` was Orca's. A process group cannot contain a Chromium process Orca did not put there, so this can never have caused a *wrong verdict*; it added a phantom entry to the evidence list a human reads next to it. Worth fixing because the list is the artifact, and because three sibling call sites already get this right — not because it was masking a crash.

## Refuted findings

**"Record accepted kills only after `taskkill` succeeds"** (coderabbit `own-chromium-tree-kill-guard.ts:35`, `process-tree-termination.ts:89`) — **refuted.**

The record is read at `render-process-gone` time by `findSelfInitiatedTreeKills`, over `[-SELF_TREE_KILL_LOOKBACK_MS, +SELF_TREE_KILL_LOOKAHEAD_MS]` = `[-5000ms, +250ms]`. The kill *causes* the death, so the death arrives before `taskkill.exe` exits. `terminateWindowsProcessTree` tolerates that exit for `WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS` = **5000 ms** by design. Recording on the success callback therefore stamps `at` up to 5000 ms *after* `goneAt` — outside a 250 ms lookahead — so the crash report would say "no self-initiated kill" for a kill Orca definitely issued.

That is a **false negative in exactly the #10680 scenario the feature was built for**, which is strictly worse than the bounded false positive being guarded against. The bot is optimising the cheap error at the cost of the expensive one. Additionally, "each caller's confirmed-success path" does not exist for several gated sites — `codex-accounts/service.ts` (`execFileSync`), the browser-route probes (`spawnSync`), and the fire-and-forget `spawn` arms in `precheck-runner.ts` / `ipc/notebook.ts` / `git/command-runner` — so complying would mean restructuring five teardowns to buy a worse signal.

POSIX is the exception, and that is the whole of finding 1 above: `process.kill(-pgid)` is synchronous, so there is no latency to lose and no reason to record early.

**"Fail closed when Chromium metrics cannot be read"** (coderabbit `orca-chromium-process-pids.ts:34`) — **refuted; the epistemic half taken.**

A refusal is not free. `terminateWindowsProcessTree` resolves *without killing* on refusal, and `killSourceControlAgentProcess` (`text-generation/source-control-local-process.ts:32-34` on `main`) returns that straight to a caller that then runs `markProcessClosed` and releases the managed-home lock with the agent still alive. Failing closed would convert one transient `getAppMetrics()` throw into refusing **every** pid-addressed tree kill in main — orphaning every PTY, git, codex and notebook tree on Windows and tripping that lock bug — to prevent a hypothetical. `getAppMetrics()` is a synchronous in-process Electron call; a throw means main is already broken.

What the bot was actually right about is that the failure was *invisible*: an empty set from a throw was byte-identical to the legitimate "no Chromium on this host". That half is fixed (finding 2).

**Still open, pre-existing, not regressions:** identity-bound termination (Job Object / handle) instead of a pid — coderabbit `own-chromium-tree-kill-guard.ts:34` and `process-tree-termination.ts:38`. Accurate, unfixed on `main` and unfixed in #18459. The PID check-to-use window predates #18367, which narrows rather than closes it. Tracked as the non-Chromium half of #10680; out of scope for a diagnostics fix.

## Trade-offs

- **Finding 2 stays fail-open, deliberately.** CodeRabbit asked to fail *closed* on a `getAppMetrics()` throw. That is worse, and concretely so: a refusal is not free. `terminateWindowsProcessTree` resolves *without killing* on refusal, and `killSourceControlAgentProcess` (`text-generation/source-control-local-process.ts:32-34`) returns that straight to a caller that then runs `markProcessClosed` and releases the managed-home lock with the agent still alive. Failing closed would trade one unreadable metrics table for every PTY, git, codex and notebook tree in main leaking at once, plus that lock bug — to prevent a hypothetical. `getAppMetrics()` is a synchronous in-process Electron call; a throw there means main is already broken. The crumb answers the reviewer's real complaint (we could not tell) without buying the leak.
- **Record-before-attempt on the Windows arms is correct and is left alone.** `taskkill.exe` is an out-of-process spawn whose exit can trail the renderer's death by more than `SELF_TREE_KILL_LOOKAHEAD_MS` (250 ms) — routinely so under EDR, and by design up to `WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS` (5 s) when it wedges. Recording on the success callback would move the crumb *outside* the window for the kills that did land, converting a bounded false-positive into a false-negative in exactly the scenario the feature was built for. Several gated sites (`codex-accounts/service.ts` `execFileSync`, the browser-route `spawnSync` probes, the fire-and-forget `spawn` arms) have no confirmed-success path to move it to without restructuring five teardowns. POSIX is different only because the signal is synchronous.
- **No error-code discrimination on finding 1.** Any throw skips the record, not just `ESRCH`. `terminateDedicatedPosixGroup` distinguishes `ESRCH` because it uses it as a *return value*; here the value is only "did we kill something", and an `EPERM` is equally not-a-kill. This also keeps the arm safe if it ever runs on a host where `process.kill(-pgid)` is unsupported.
- **Termination behaviour is unchanged** by both hunks. The throw is still swallowed; the wrapper still gets `SIGKILL` and the function still resolves `true`. Only the breadcrumb moved. Confirmed by the adjacent assertions in the new tests (`target.kill` last called with `SIGKILL`, resolves `true`).
- Diagnostics-only in blast radius: finding 1 can only *remove* a false suspect, never suppress a true one; finding 2 only *adds* a crumb and changes no decision.

## Adversarial review

- *Does skipping the record hide a kill we really made?* No. The record is skipped only on a throw, and a throw means `process.kill` delivered no signal to any process — the group either did not exist or we lacked permission. Neither is a kill.
- *Could the group have been killed by the descendant sweep just above, making the crumb legitimate?* The descendant sweep records nothing and signals individual pids, not the group. The crumb's `scope` is `posix-process-group` and its `pid` is `snapshot.rootPgid`; claiming that specific mechanism when it did not fire is the defect.
- *Does the impossible-pgid test flake?* `2_147_483_647` exceeds `pid_max` on Linux (2^22 ceiling) and macOS (99998), so `ESRCH` is structural, not probabilistic. This spec is not in the `package (windows)` lane's list, so that arm is Linux/macOS-verified only; the fix intentionally does not branch on the error code, so any throw on any host takes the same path.
- *Can the finding-2 crumb itself break a kill?* No. `readOrcaChromiumProcessPids()` is called by `admitSelfInitiatedTreeKill` **outside** its own `try`, so a throw from the breadcrumb path would propagate into the caller and turn an admitted kill into a thrown one. The recorder is therefore wrapped in its own `try`/`catch`, matching the existing "diagnostics must never fail a termination" rule in `process-tree-kill-observer.ts`.
- *Does the finding-2 crumb flood the ring?* The gate reads the pid set on **every** tree kill, so a persistently broken metrics table would otherwise evict the 30-slot breadcrumb ring it shares with the refusal crumb. It is coalesced on a fixed key at 60 s, the same shape the refusal and group-kill crumbs already use.
- *New import cycle or bundle edge?* No. `own-chromium-tree-kill-guard.ts` already imports both `orca-chromium-process-pids` and (transitively, via `self-initiated-tree-kill-log`) `durable-crash-breadcrumb`, so the daemon/`orcad` paths already carry it. `tsc -p config/tsconfig.node.json` is clean.
- *Ratchet interaction:* no new `node:child_process` import, no new raw recursive `rm`, no `max-lines` change, and no breadcrumb-name registry exists that would need updating.
- *Wire/SSH/folder-workspace:* none — this is main-process-local diagnostics state. No RPC params, stream opcodes, or published content change, so no remote wire-compatibility surface.

## Follow-ups

- The same "gate records before the POSIX signal" shape exists in `signalProcessTree` (`src/shared/child-process/process-tree-termination.ts`), where the admit-and-record seam necessarily fires before `process.kill(-pid)`. Splitting admit from record there is a larger change to the shared gate and belongs with #18459, not here.
- #18459 remains the vehicle for the choke-point work (gating the six ungated `taskkill /pid` sites, the refusal→`killRoot` fallback, and scope-aware ring eviction).
- Still open everywhere after this PR, and consciously so: identity-bound termination (Job Object / handle) to close the PID check-to-use window — CodeRabbit's `process-tree-termination.ts:38` and `own-chromium-tree-kill-guard.ts:34`. Pre-existing, tracked as the non-Chromium half of #10680.
