### PR TITLE
docs(cloud): reconcile the 2026-08-23 retry figure with the gate metric

### DIFF
--- a/cloud/docs/relay-incident-monitor.md
+++ b/cloud/docs/relay-incident-monitor.md
@@ -138,7 +138,9 @@ heartbeats, and matching live admission.
   `jsonPayload.event="orca_relay_postgres_transaction_retry"` in production
   logs: healthy-day bursts reach 234/5min with zero exhausted retries and 26%
   of five-minute windows over 20, while the 2026-08-23 lock-contention
-  incident ran roughly 2,200–3,000/5min.
+  incident ran roughly 2,200–3,000/5min by raw log-line count (the gate's
+  own `orca_relay_postgres_retries` metric read 1,510 for that window; see the
+  2026-09-04 entry).
 - Recalibrated the PostgreSQL-retry freeze from 300 to 2,000 per five minutes
   (2026-09-04). Basis: the global `relay_cells FOR UPDATE` lock made
   successful retries a steady-state rate. Measured fleet-wide (director +


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

Follow-up to #18580. The implementation log recorded the 2026-08-23 incident as 2,200–3,000 retries per five minutes (raw log-line count) and the new entry as 1,510 (the gate's own log-based metric). Notes the scoping difference so the two entries do not contradict each other. Doc only.