### PR TITLE
feat(editor): current-line git blame, including git diff views

### DIFF
--- a/src/main/git/blame.real-git.test.ts
+++ b/src/main/git/blame.real-git.test.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { isUncommittedBlameOid } from '../../shared/git-blame'
+import { getFileBlame } from './blame'
+
+const tempRoots: string[] = []
+
+function git(repo: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repo,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim()
+}
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('getFileBlame real git', () => {
+  it('returns the committing author for a tracked line and marks an uncommitted edit', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'orca-blame-'))
+    tempRoots.push(root)
+    git(root, ['init', '-q'])
+    git(root, ['config', 'user.email', 'ada@example.com'])
+    git(root, ['config', 'user.name', 'Ada Lovelace'])
+    git(root, ['config', 'commit.gpgSign', 'false'])
+    await writeFile(path.join(root, 'note.txt'), 'hello\n', 'utf8')
+    git(root, ['add', 'note.txt'])
+    git(root, ['commit', '-q', '-m', 'Add note'])
+    const committedOid = git(root, ['rev-parse', 'HEAD'])
+
+    await writeFile(path.join(root, 'note.txt'), 'hello\nworld\n', 'utf8')
+    const result = await getFileBlame(root, 'note.txt')
+
+    expect(result.status).toBe('ready')
+    expect(result.lines[0]).toMatchObject({
+      line: 1,
+      commitOid: committedOid,
+      author: 'Ada Lovelace',
+      summary: 'Add note'
+    })
+    expect(isUncommittedBlameOid(result.lines[1]?.commitOid ?? '')).toBe(true)
+  })
+
+  it('returns unavailable for a path git cannot blame', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'orca-blame-missing-'))
+    tempRoots.push(root)
+    git(root, ['init', '-q'])
+    git(root, ['config', 'user.email', 'ada@example.com'])
+    git(root, ['config', 'user.name', 'Ada Lovelace'])
+    git(root, ['config', 'commit.gpgSign', 'false'])
+    git(root, ['commit', '--allow-empty', '-q', '-m', 'empty'])
+
+    await expect(getFileBlame(root, 'missing.txt')).resolves.toEqual({
+      status: 'unavailable',
+      lines: []
+    })
+  })
+
+  it('blames a historical revision instead of the working tree', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'orca-blame-rev-'))
+    tempRoots.push(root)
+    git(root, ['init', '-q'])
+    git(root, ['config', 'user.email', 'ada@example.com'])
+    git(root, ['config', 'user.name', 'Ada Lovelace'])
+    git(root, ['config', 'commit.gpgSign', 'false'])
+    await writeFile(path.join(root, 'note.txt'), 'hello\n', 'utf8')
+    git(root, ['add', 'note.txt'])
+    git(root, ['commit', '-q', '-m', 'Add note'])
+    const firstOid = git(root, ['rev-parse', 'HEAD'])
+    await writeFile(path.join(root, 'note.txt'), 'hello\nworld\n', 'utf8')
+    git(root, ['add', 'note.txt'])
+    git(root, ['commit', '-q', '-m', 'Expand note'])
+
+    const result = await getFileBlame(root, 'note.txt', {}, firstOid)
+    expect(result.status).toBe('ready')
+    expect(result.lines).toHaveLength(1)
+    expect(result.lines[0]).toMatchObject({
+      line: 1,
+      commitOid: firstOid,
+      summary: 'Add note'
+    })
+  })
+})

--- a/src/main/git/blame.real-git.test.ts
+++ b/src/main/git/blame.real-git.test.ts
@@ -85,4 +85,32 @@ describe('getFileBlame real git', () => {
       summary: 'Add note'
     })
   })
+
+  it('blames staged index contents when they differ from the working tree', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'orca-blame-index-'))
+    tempRoots.push(root)
+    git(root, ['init', '-q'])
+    git(root, ['config', 'user.email', 'ada@example.com'])
+    git(root, ['config', 'user.name', 'Ada Lovelace'])
+    git(root, ['config', 'commit.gpgSign', 'false'])
+    await writeFile(path.join(root, 'note.txt'), 'hello\n', 'utf8')
+    git(root, ['add', 'note.txt'])
+    git(root, ['commit', '-q', '-m', 'Add note'])
+    const committedOid = git(root, ['rev-parse', 'HEAD'])
+
+    await writeFile(path.join(root, 'note.txt'), 'hello\nstaged\n', 'utf8')
+    git(root, ['add', 'note.txt'])
+    await writeFile(path.join(root, 'note.txt'), 'hello\nstaged\nworktree\n', 'utf8')
+
+    const workingTree = await getFileBlame(root, 'note.txt')
+    expect(workingTree.status).toBe('ready')
+    expect(workingTree.lines).toHaveLength(3)
+    expect(isUncommittedBlameOid(workingTree.lines[2]?.commitOid ?? '')).toBe(true)
+
+    const index = await getFileBlame(root, 'note.txt', {}, undefined, 'index')
+    expect(index.status).toBe('ready')
+    expect(index.lines).toHaveLength(2)
+    expect(index.lines[0]?.commitOid).toBe(committedOid)
+    expect(isUncommittedBlameOid(index.lines[1]?.commitOid ?? '')).toBe(true)
+  })
 })

--- a/src/main/git/blame.ts
+++ b/src/main/git/blame.ts
@@ -1,5 +1,10 @@
-import type { GitBlameResult } from '../../shared/git-blame'
-import { buildGitBlameArgv, parseBlamePorcelain } from '../../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../../shared/git-blame'
+import {
+  buildGitBlameArgv,
+  buildGitShowIndexArgv,
+  GIT_BLAME_INDEX_CONTENTS,
+  parseBlamePorcelain
+} from '../../shared/git-blame'
 import { gitReadOptionsForWorktree, type GitRuntimeOptions } from './git-runtime-options'
 import { gitExecFileAsync } from './runner'
 
@@ -10,17 +15,28 @@ export async function getFileBlame(
   worktreePath: string,
   filePath: string,
   options: GitRuntimeOptions = {},
-  revision?: string
+  revision?: string,
+  contentsSource?: GitBlameContentsSource
 ): Promise<GitBlameResult> {
   try {
-    const { stdout } = await gitExecFileAsync(buildGitBlameArgv(filePath, revision), {
-      ...gitReadOptionsForWorktree(worktreePath, {
-        ...options,
-        admissionTier: options.admissionTier ?? 'interactive'
-      }),
+    const readOptions = gitReadOptionsForWorktree(worktreePath, {
+      ...options,
+      admissionTier: options.admissionTier ?? 'interactive'
+    })
+    const execOptions = {
+      ...readOptions,
       maxBuffer: BLAME_MAX_BUFFER_BYTES,
       timeout: BLAME_TIMEOUT_MS
-    })
+    }
+    let stdin: string | undefined
+    if (contentsSource === GIT_BLAME_INDEX_CONTENTS) {
+      const shown = await gitExecFileAsync(buildGitShowIndexArgv(filePath), execOptions)
+      stdin = shown.stdout
+    }
+    const { stdout } = await gitExecFileAsync(
+      buildGitBlameArgv(filePath, revision, contentsSource),
+      stdin === undefined ? execOptions : { ...execOptions, stdin }
+    )
     return { status: 'ready', lines: parseBlamePorcelain(stdout) }
   } catch {
     return { status: 'unavailable', lines: [] }

--- a/src/main/git/blame.ts
+++ b/src/main/git/blame.ts
@@ -1,0 +1,28 @@
+import type { GitBlameResult } from '../../shared/git-blame'
+import { buildGitBlameArgv, parseBlamePorcelain } from '../../shared/git-blame'
+import { gitReadOptionsForWorktree, type GitRuntimeOptions } from './git-runtime-options'
+import { gitExecFileAsync } from './runner'
+
+const BLAME_MAX_BUFFER_BYTES = 16 * 1024 * 1024
+const BLAME_TIMEOUT_MS = 15_000
+
+export async function getFileBlame(
+  worktreePath: string,
+  filePath: string,
+  options: GitRuntimeOptions = {},
+  revision?: string
+): Promise<GitBlameResult> {
+  try {
+    const { stdout } = await gitExecFileAsync(buildGitBlameArgv(filePath, revision), {
+      ...gitReadOptionsForWorktree(worktreePath, {
+        ...options,
+        admissionTier: options.admissionTier ?? 'interactive'
+      }),
+      maxBuffer: BLAME_MAX_BUFFER_BYTES,
+      timeout: BLAME_TIMEOUT_MS
+    })
+    return { status: 'ready', lines: parseBlamePorcelain(stdout) }
+  } catch {
+    return { status: 'unavailable', lines: [] }
+  }
+}

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -17,6 +17,7 @@ import { registerFilesystemGitModelDiscoveryHandlers } from './filesystem/filesy
 import { registerFilesystemGitPullRequestGenerationHandlers } from './filesystem/filesystem-git-pull-request-generation-handlers'
 import { registerFilesystemGitRemoteHandlers } from './filesystem/filesystem-git-remote-handlers'
 import { registerFilesystemGitDiffHandlers } from './filesystem/filesystem-git-diff-handlers'
+import { registerFilesystemGitBlameHandlers } from './filesystem/filesystem-git-blame-handlers'
 import { registerFilesystemGitIndexHandlers } from './filesystem/filesystem-git-index-handlers'
 import { registerFilesystemGitUrlHandlers } from './filesystem/filesystem-git-url-handlers'
 
@@ -42,6 +43,7 @@ export function registerFilesystemHandlers(
   registerFilesystemGitPullRequestGenerationHandlers(context)
   registerFilesystemGitRemoteHandlers(context)
   registerFilesystemGitDiffHandlers(context)
+  registerFilesystemGitBlameHandlers(context)
   registerFilesystemGitIndexHandlers(context)
   registerFilesystemGitUrlHandlers(context)
   registerLocalLogTailHandlers(store)

--- a/src/main/ipc/filesystem/filesystem-git-blame-handlers.ts
+++ b/src/main/ipc/filesystem/filesystem-git-blame-handlers.ts
@@ -1,0 +1,45 @@
+import { ipcMain } from 'electron'
+import type { GitBlameResult } from '../../../shared/git-blame'
+import { getFileBlame } from '../../git/blame'
+import {
+  getSshGitProvider,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE
+} from '../../providers/ssh-git-dispatch'
+import { resolveRegisteredWorktreePath } from '../registered-worktree-roots-cache'
+import { getLocalGitOptionsForRegisteredWorktree } from '../local-worktree-runtime-options'
+import {
+  validateFullGitObjectId,
+  validateGitRelativeFilePath
+} from '../filesystem-path-containment'
+import type { FilesystemHandlerContext } from './filesystem-handler-context'
+
+export function registerFilesystemGitBlameHandlers(context: FilesystemHandlerContext): void {
+  const { store } = context
+  ipcMain.handle(
+    'git:blame',
+    async (
+      _event,
+      args: { worktreePath: string; filePath: string; connectionId?: string; revision?: string }
+    ): Promise<GitBlameResult> => {
+      const revision =
+        args.revision && args.revision !== 'HEAD'
+          ? validateFullGitObjectId(args.revision, 'revision')
+          : args.revision
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.getBlame(args.worktreePath, args.filePath, revision)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      return getFileBlame(worktreePath, filePath, gitOptions, revision)
+    }
+  )
+}

--- a/src/main/ipc/filesystem/filesystem-git-blame-handlers.ts
+++ b/src/main/ipc/filesystem/filesystem-git-blame-handlers.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import type { GitBlameResult } from '../../../shared/git-blame'
+import { GIT_BLAME_INDEX_CONTENTS, type GitBlameResult } from '../../../shared/git-blame'
 import { getFileBlame } from '../../git/blame'
 import {
   getSshGitProvider,
@@ -13,24 +13,40 @@ import {
 } from '../filesystem-path-containment'
 import type { FilesystemHandlerContext } from './filesystem-handler-context'
 
+function resolveBlameContentsSource(
+  contentsSource: string | undefined
+): typeof GIT_BLAME_INDEX_CONTENTS | undefined {
+  return contentsSource === GIT_BLAME_INDEX_CONTENTS ? GIT_BLAME_INDEX_CONTENTS : undefined
+}
+
 export function registerFilesystemGitBlameHandlers(context: FilesystemHandlerContext): void {
   const { store } = context
   ipcMain.handle(
     'git:blame',
     async (
       _event,
-      args: { worktreePath: string; filePath: string; connectionId?: string; revision?: string }
+      args: {
+        worktreePath: string
+        filePath: string
+        connectionId?: string
+        revision?: string
+        contentsSource?: string
+      }
     ): Promise<GitBlameResult> => {
       const revision =
         args.revision && args.revision !== 'HEAD'
           ? validateFullGitObjectId(args.revision, 'revision')
           : args.revision
+      const contentsSource = resolveBlameContentsSource(args.contentsSource)
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {
           throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
         }
-        return provider.getBlame(args.worktreePath, args.filePath, revision)
+        // Why: same relative-path containment as local git:blame; worktree
+        // ownership stays on the relay, matching git.diff / git.history.
+        const filePath = validateGitRelativeFilePath(args.worktreePath, args.filePath)
+        return provider.getBlame(args.worktreePath, filePath, revision, contentsSource)
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
       const filePath = validateGitRelativeFilePath(worktreePath, args.filePath)
@@ -39,7 +55,7 @@ export function registerFilesystemGitBlameHandlers(context: FilesystemHandlerCon
         args.worktreePath,
         worktreePath
       )
-      return getFileBlame(worktreePath, filePath, gitOptions, revision)
+      return getFileBlame(worktreePath, filePath, gitOptions, revision, contentsSource)
     }
   )
 }

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -1,4 +1,4 @@
-import type { GitBlameResult } from '../../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../../shared/git-blame'
 import type {
   GitBranchCompareResult,
   GitCommitCompareResult,
@@ -54,7 +54,12 @@ export type IGitProvider = {
     options?: { admissionTier?: GitAdmissionTier }
   ): Promise<GitBranchCompareResult>
   getCommitCompare(worktreePath: string, commitId: string): Promise<GitCommitCompareResult>
-  getBlame(worktreePath: string, filePath: string, revision?: string): Promise<GitBlameResult>
+  getBlame(
+    worktreePath: string,
+    filePath: string,
+    revision?: string,
+    contentsSource?: GitBlameContentsSource
+  ): Promise<GitBlameResult>
   getUpstreamStatus(worktreePath: string, pushTarget?: GitPushTarget): Promise<GitUpstreamStatus>
   pushBranch(
     worktreePath: string,

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -1,3 +1,4 @@
+import type { GitBlameResult } from '../../shared/git-blame'
 import type {
   GitBranchCompareResult,
   GitCommitCompareResult,
@@ -53,6 +54,7 @@ export type IGitProvider = {
     options?: { admissionTier?: GitAdmissionTier }
   ): Promise<GitBranchCompareResult>
   getCommitCompare(worktreePath: string, commitId: string): Promise<GitCommitCompareResult>
+  getBlame(worktreePath: string, filePath: string, revision?: string): Promise<GitBlameResult>
   getUpstreamStatus(worktreePath: string, pushTarget?: GitPushTarget): Promise<GitUpstreamStatus>
   pushBranch(
     worktreePath: string,

--- a/src/main/providers/ssh-git-provider-api.test.ts
+++ b/src/main/providers/ssh-git-provider-api.test.ts
@@ -36,6 +36,7 @@ describe('SshGitProvider public API parity', () => {
       'listLocalBranches',
       'getBranchCompare',
       'getCommitCompare',
+      'getBlame',
       'getUpstreamStatus',
       'pushBranch',
       'pullBranch',
@@ -64,7 +65,7 @@ describe('SshGitProvider public API parity', () => {
       'getRemoteCommitUrl'
     ] as const
 
-    expect(methods).toHaveLength(52)
+    expect(methods).toHaveLength(53)
     for (const method of methods) {
       expect(provider[method], method).toBeTypeOf('function')
     }

--- a/src/main/providers/ssh-git-working-tree-provider.ts
+++ b/src/main/providers/ssh-git-working-tree-provider.ts
@@ -1,4 +1,4 @@
-import type { GitBlameResult } from '../../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../../shared/git-blame'
 import type {
   GitBranchCompareResult,
   GitCommitCompareResult
@@ -130,12 +130,14 @@ export class SshGitWorkingTreeProvider extends SshGitNoninteractiveProvider {
   async getBlame(
     worktreePath: string,
     filePath: string,
-    revision?: string
+    revision?: string,
+    contentsSource?: GitBlameContentsSource
   ): Promise<GitBlameResult> {
     return (await this.mux.request('git.blame', {
       worktreePath,
       filePath,
-      ...(revision ? { revision } : {})
+      ...(revision ? { revision } : {}),
+      ...(contentsSource ? { contentsSource } : {})
     })) as GitBlameResult
   }
 }

--- a/src/main/providers/ssh-git-working-tree-provider.ts
+++ b/src/main/providers/ssh-git-working-tree-provider.ts
@@ -1,3 +1,4 @@
+import type { GitBlameResult } from '../../shared/git-blame'
 import type {
   GitBranchCompareResult,
   GitCommitCompareResult
@@ -124,5 +125,17 @@ export class SshGitWorkingTreeProvider extends SshGitNoninteractiveProvider {
       worktreePath,
       commitId
     })) as GitCommitCompareResult
+  }
+
+  async getBlame(
+    worktreePath: string,
+    filePath: string,
+    revision?: string
+  ): Promise<GitBlameResult> {
+    return (await this.mux.request('git.blame', {
+      worktreePath,
+      filePath,
+      ...(revision ? { revision } : {})
+    })) as GitBlameResult
   }
 }

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -21,6 +21,7 @@ export class RuntimeGitCommands {
   readonly getRuntimeGitDiff: RuntimeGitDiffCommands['getRuntimeGitDiff']
   readonly getRuntimeGitBranchCompare: RuntimeGitDiffCommands['getRuntimeGitBranchCompare']
   readonly getRuntimeGitCommitCompare: RuntimeGitDiffCommands['getRuntimeGitCommitCompare']
+  readonly getRuntimeGitBlame: RuntimeGitDiffCommands['getRuntimeGitBlame']
   readonly getRuntimeGitBranchDiff: RuntimeGitDiffCommands['getRuntimeGitBranchDiff']
   readonly getRuntimeGitCommitDiff: RuntimeGitDiffCommands['getRuntimeGitCommitDiff']
   readonly getRuntimeGitRemoteFileUrl: RuntimeGitDiffCommands['getRuntimeGitRemoteFileUrl']
@@ -64,6 +65,7 @@ export class RuntimeGitCommands {
     this.getRuntimeGitDiff = diff.getRuntimeGitDiff.bind(diff)
     this.getRuntimeGitBranchCompare = diff.getRuntimeGitBranchCompare.bind(diff)
     this.getRuntimeGitCommitCompare = diff.getRuntimeGitCommitCompare.bind(diff)
+    this.getRuntimeGitBlame = diff.getRuntimeGitBlame.bind(diff)
     this.getRuntimeGitBranchDiff = diff.getRuntimeGitBranchDiff.bind(diff)
     this.getRuntimeGitCommitDiff = diff.getRuntimeGitCommitDiff.bind(diff)
     this.getRuntimeGitRemoteFileUrl = diff.getRuntimeGitRemoteFileUrl.bind(diff)

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -96,7 +96,8 @@ export const GitCommitDiff = GitFilePath.extend({
 })
 
 export const GitBlame = GitFilePath.extend({
-  revision: z.union([z.literal('HEAD'), FullGitObjectId]).optional()
+  revision: z.union([z.literal('HEAD'), FullGitObjectId]).optional(),
+  contentsSource: z.literal('index').optional()
 })
 
 export const GitCommit = WorktreeSelector.extend({

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -95,6 +95,10 @@ export const GitCommitDiff = GitFilePath.extend({
   oldPath: z.string().optional()
 })
 
+export const GitBlame = GitFilePath.extend({
+  revision: z.union([z.literal('HEAD'), FullGitObjectId]).optional()
+})
+
 export const GitCommit = WorktreeSelector.extend({
   message: z
     .unknown()

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -148,7 +148,12 @@ describe('git RPC methods', () => {
       makeRequest('git.blame', { worktree: 'id:wt-1', filePath: 'src/index.ts' })
     )
 
-    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith('id:wt-1', 'src/index.ts', undefined)
+    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith(
+      'id:wt-1',
+      'src/index.ts',
+      undefined,
+      undefined
+    )
     expect(response).toMatchObject({
       ok: true,
       result: { status: 'ready', lines: [expect.objectContaining({ author: 'Ada' })] }
@@ -171,7 +176,36 @@ describe('git RPC methods', () => {
       })
     )
 
-    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith('id:wt-1', 'src/index.ts', commitId)
+    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith(
+      'id:wt-1',
+      'src/index.ts',
+      commitId,
+      undefined
+    )
+  })
+
+  it('forwards index blame contents', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitBlame: vi.fn().mockResolvedValue({ status: 'ready', lines: [] })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('git.blame', {
+        worktree: 'id:wt-1',
+        filePath: 'src/index.ts',
+        revision: 'HEAD',
+        contentsSource: 'index'
+      })
+    )
+
+    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith(
+      'id:wt-1',
+      'src/index.ts',
+      'HEAD',
+      'index'
+    )
   })
 
   it('returns ignored paths for selected explorer rows', async () => {

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -126,6 +126,54 @@ describe('git RPC methods', () => {
     })
   })
 
+  it('returns blame lines for a selected file', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitBlame: vi.fn().mockResolvedValue({
+        status: 'ready',
+        lines: [
+          {
+            line: 1,
+            commitOid: 'a'.repeat(40),
+            author: 'Ada',
+            authorTime: 1,
+            summary: 'Add'
+          }
+        ]
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('git.blame', { worktree: 'id:wt-1', filePath: 'src/index.ts' })
+    )
+
+    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith('id:wt-1', 'src/index.ts', undefined)
+    expect(response).toMatchObject({
+      ok: true,
+      result: { status: 'ready', lines: [expect.objectContaining({ author: 'Ada' })] }
+    })
+  })
+
+  it('forwards an optional blame revision', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getRuntimeGitBlame: vi.fn().mockResolvedValue({ status: 'ready', lines: [] })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: GIT_METHODS })
+    const commitId = 'a'.repeat(40)
+
+    await dispatcher.dispatch(
+      makeRequest('git.blame', {
+        worktree: 'id:wt-1',
+        filePath: 'src/index.ts',
+        revision: commitId
+      })
+    )
+
+    expect(runtime.getRuntimeGitBlame).toHaveBeenCalledWith('id:wt-1', 'src/index.ts', commitId)
+  })
+
   it('returns ignored paths for selected explorer rows', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -2,6 +2,7 @@ import { defineMethod, type RpcMethod } from '../core'
 import { GIT_COMMIT_MESSAGE_GENERATION_METHODS } from './git-commit-message-generation-methods'
 import { GIT_DIFF_METHODS } from './git-diff-methods'
 import {
+  GitBlame,
   GitBranchCompare,
   GitBulkPaths,
   GitCheckIgnored,
@@ -116,6 +117,12 @@ export const GIT_METHODS: RpcMethod[] = [
     params: GitCommitCompare,
     handler: async (params, { runtime }) =>
       runtime.getRuntimeGitCommitCompare(params.worktree, params.commitId)
+  }),
+  defineMethod({
+    name: 'git.blame',
+    params: GitBlame,
+    handler: async (params, { runtime }) =>
+      runtime.getRuntimeGitBlame(params.worktree, params.filePath, params.revision)
   }),
   defineMethod({
     name: 'git.upstreamStatus',

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -122,7 +122,12 @@ export const GIT_METHODS: RpcMethod[] = [
     name: 'git.blame',
     params: GitBlame,
     handler: async (params, { runtime }) =>
-      runtime.getRuntimeGitBlame(params.worktree, params.filePath, params.revision)
+      runtime.getRuntimeGitBlame(
+        params.worktree,
+        params.filePath,
+        params.revision,
+        params.contentsSource
+      )
   }),
   defineMethod({
     name: 'git.upstreamStatus',

--- a/src/main/runtime/runtime-git-api-contract.test.ts
+++ b/src/main/runtime/runtime-git-api-contract.test.ts
@@ -18,6 +18,7 @@ const RPC_TO_RUNTIME_COMMAND = {
   'git.commitDiff': 'getRuntimeGitCommitDiff',
   'git.branchCompare': 'getRuntimeGitBranchCompare',
   'git.commitCompare': 'getRuntimeGitCommitCompare',
+  'git.blame': 'getRuntimeGitBlame',
   'git.upstreamStatus': 'getRuntimeGitUpstreamStatus',
   'git.fetch': 'fetchRuntimeGit',
   'git.forkSync': 'syncRuntimeGitForkDefaultBranch',

--- a/src/main/runtime/runtime-git-command-surface.ts
+++ b/src/main/runtime/runtime-git-command-surface.ts
@@ -13,6 +13,7 @@ type RuntimeGitCommandName =
   | 'getRuntimeGitDiff'
   | 'getRuntimeGitBranchCompare'
   | 'getRuntimeGitCommitCompare'
+  | 'getRuntimeGitBlame'
   | 'getRuntimeGitUpstreamStatus'
   | 'fetchRuntimeGit'
   | 'syncRuntimeGitForkDefaultBranch'
@@ -56,6 +57,7 @@ export function installRuntimeGitCommandSurface(
     getRuntimeGitDiff: commands.getRuntimeGitDiff.bind(commands),
     getRuntimeGitBranchCompare: commands.getRuntimeGitBranchCompare.bind(commands),
     getRuntimeGitCommitCompare: commands.getRuntimeGitCommitCompare.bind(commands),
+    getRuntimeGitBlame: commands.getRuntimeGitBlame.bind(commands),
     getRuntimeGitUpstreamStatus: commands.getRuntimeGitUpstreamStatus.bind(commands),
     fetchRuntimeGit: commands.fetchRuntimeGit.bind(commands),
     syncRuntimeGitForkDefaultBranch: commands.syncRuntimeGitForkDefaultBranch.bind(commands),

--- a/src/main/runtime/runtime-git-diff-commands.ts
+++ b/src/main/runtime/runtime-git-diff-commands.ts
@@ -1,4 +1,4 @@
-import type { GitBlameResult } from '../../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../../shared/git-blame'
 import type {
   GitBranchCompareResult,
   GitCommitCompareResult,
@@ -87,19 +87,21 @@ export class RuntimeGitDiffCommands {
   async getRuntimeGitBlame(
     worktreeSelector: string,
     filePath: string,
-    revision?: string
+    revision?: string,
+    contentsSource?: GitBlameContentsSource
   ): Promise<GitBlameResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const relativePath = normalizeRuntimeGitRelativePath(filePath)
     const provider = requireRuntimeGitProvider(target)
     if (provider) {
-      return provider.getBlame(target.worktree.path, relativePath, revision)
+      return provider.getBlame(target.worktree.path, relativePath, revision, contentsSource)
     }
     return getFileBlame(
       target.worktree.path,
       relativePath,
       { ...localGitOptionsForTarget(target), admissionTier: 'interactive' },
-      revision
+      revision,
+      contentsSource
     )
   }
 

--- a/src/main/runtime/runtime-git-diff-commands.ts
+++ b/src/main/runtime/runtime-git-diff-commands.ts
@@ -1,3 +1,4 @@
+import type { GitBlameResult } from '../../shared/git-blame'
 import type {
   GitBranchCompareResult,
   GitCommitCompareResult,
@@ -12,6 +13,7 @@ import {
   getCommitDiff,
   getDiff
 } from '../git/status'
+import { getFileBlame } from '../git/blame'
 import { awaitWindowsHostGitEnvironmentReady } from '../git/runner'
 import type { GitAdmissionTier } from '../git/command-runner/git-exec-options'
 import { normalizeRuntimeRelativePath } from './runtime-relative-paths'
@@ -80,6 +82,25 @@ export class RuntimeGitDiffCommands {
       ...localGitOptionsForTarget(target),
       admissionTier: 'interactive'
     })
+  }
+
+  async getRuntimeGitBlame(
+    worktreeSelector: string,
+    filePath: string,
+    revision?: string
+  ): Promise<GitBlameResult> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const relativePath = normalizeRuntimeGitRelativePath(filePath)
+    const provider = requireRuntimeGitProvider(target)
+    if (provider) {
+      return provider.getBlame(target.worktree.path, relativePath, revision)
+    }
+    return getFileBlame(
+      target.worktree.path,
+      relativePath,
+      { ...localGitOptionsForTarget(target), admissionTier: 'interactive' },
+      revision
+    )
   }
 
   async getRuntimeGitBranchDiff(

--- a/src/main/runtime/runtime-rpc/runtime-rpc-mobile-method-allowlist.ts
+++ b/src/main/runtime/runtime-rpc/runtime-rpc-mobile-method-allowlist.ts
@@ -59,6 +59,7 @@ export const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'git.checkout',
   'git.commit',
   'git.commitCompare',
+  'git.blame',
   'git.commitDiff',
   'git.discard',
   'git.discoverCommitMessageModels',

--- a/src/preload/api/git-bridge.ts
+++ b/src/preload/api/git-bridge.ts
@@ -3,6 +3,7 @@ import type { GitForkSyncExpectedUpstream, GitForkSyncResult } from '../../share
 import type { GitStagingArea, GitUpstreamStatus } from '../../shared/git-status-types'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import type { GitBlameContentsSource } from '../../shared/git-blame'
 import type { PreloadApi } from '../api-types'
 
 export const gitApi = {
@@ -64,6 +65,7 @@ export const gitApi = {
     worktreePath: string
     filePath: string
     revision?: string
+    contentsSource?: GitBlameContentsSource
     connectionId?: string
   }) => ipcRenderer.invoke('git:blame', args),
   upstreamStatus: (args: {

--- a/src/preload/api/git-bridge.ts
+++ b/src/preload/api/git-bridge.ts
@@ -60,6 +60,12 @@ export const gitApi = {
     ipcRenderer.invoke('git:branchCompare', args),
   commitCompare: (args: { worktreePath: string; commitId: string; connectionId?: string }) =>
     ipcRenderer.invoke('git:commitCompare', args),
+  blame: (args: {
+    worktreePath: string
+    filePath: string
+    revision?: string
+    connectionId?: string
+  }) => ipcRenderer.invoke('git:blame', args),
   upstreamStatus: (args: {
     worktreePath: string
     connectionId?: string

--- a/src/preload/api/git-inspection-api.ts
+++ b/src/preload/api/git-inspection-api.ts
@@ -11,7 +11,7 @@ import type {
 } from '../../shared/git-status-types'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
-import type { GitBlameResult } from '../../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../../shared/git-blame'
 import type {
   CommitMessageAgentCapability,
   CommitMessageModelCapability
@@ -80,6 +80,7 @@ export type GitInspectionApi = {
     worktreePath: string
     filePath: string
     revision?: string
+    contentsSource?: GitBlameContentsSource
     connectionId?: string
   }) => Promise<GitBlameResult>
   upstreamStatus: (args: {

--- a/src/preload/api/git-inspection-api.ts
+++ b/src/preload/api/git-inspection-api.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../shared/git-status-types'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import type { GitBlameResult } from '../../shared/git-blame'
 import type {
   CommitMessageAgentCapability,
   CommitMessageModelCapability
@@ -75,6 +76,12 @@ export type GitInspectionApi = {
     commitId: string
     connectionId?: string
   }) => Promise<GitCommitCompareResult>
+  blame: (args: {
+    worktreePath: string
+    filePath: string
+    revision?: string
+    connectionId?: string
+  }) => Promise<GitBlameResult>
   upstreamStatus: (args: {
     worktreePath: string
     connectionId?: string

--- a/src/relay/git-handler-blame-ops.ts
+++ b/src/relay/git-handler-blame-ops.ts
@@ -1,15 +1,33 @@
-import type { GitBlameResult } from '../shared/git-blame'
-import { buildGitBlameArgv, parseBlamePorcelain } from '../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../shared/git-blame'
+import {
+  buildGitBlameArgv,
+  buildGitShowIndexArgv,
+  GIT_BLAME_INDEX_CONTENTS,
+  parseBlamePorcelain
+} from '../shared/git-blame'
 import type { GitExec } from './git-handler-ops'
+import { assertGitPathInsideWorktree } from './git-handler-utils'
 
 export async function blameFile(
   git: GitExec,
   worktreePath: string,
   filePath: string,
-  revision?: string
+  revision?: string,
+  contentsSource?: GitBlameContentsSource
 ): Promise<GitBlameResult> {
+  // Why: match git.diff — reject traversal before git sees the path.
+  assertGitPathInsideWorktree(worktreePath, filePath)
   try {
-    const { stdout } = await git(buildGitBlameArgv(filePath, revision), worktreePath)
+    let stdin: string | undefined
+    if (contentsSource === GIT_BLAME_INDEX_CONTENTS) {
+      const shown = await git(buildGitShowIndexArgv(filePath), worktreePath)
+      stdin = shown.stdout
+    }
+    const { stdout } = await git(
+      buildGitBlameArgv(filePath, revision, contentsSource),
+      worktreePath,
+      stdin === undefined ? undefined : { stdin }
+    )
     return { status: 'ready', lines: parseBlamePorcelain(stdout) }
   } catch {
     return { status: 'unavailable', lines: [] }

--- a/src/relay/git-handler-blame-ops.ts
+++ b/src/relay/git-handler-blame-ops.ts
@@ -3,7 +3,8 @@ import {
   buildGitBlameArgv,
   buildGitShowIndexArgv,
   GIT_BLAME_INDEX_CONTENTS,
-  parseBlamePorcelain
+  parseBlamePorcelain,
+  parseGitBlameRevision
 } from '../shared/git-blame'
 import type { GitExec } from './git-handler-ops'
 import { assertGitPathInsideWorktree } from './git-handler-utils'
@@ -17,6 +18,9 @@ export async function blameFile(
 ): Promise<GitBlameResult> {
   // Why: match git.diff — reject traversal before git sees the path.
   assertGitPathInsideWorktree(worktreePath, filePath)
+  // Why: revision sits before --end-of-options, so a flag-like value would be
+  // parsed as a git option. Reject anything that is not HEAD or a full oid.
+  const blameRevision = parseGitBlameRevision(revision)
   try {
     let stdin: string | undefined
     if (contentsSource === GIT_BLAME_INDEX_CONTENTS) {
@@ -24,7 +28,7 @@ export async function blameFile(
       stdin = shown.stdout
     }
     const { stdout } = await git(
-      buildGitBlameArgv(filePath, revision, contentsSource),
+      buildGitBlameArgv(filePath, blameRevision, contentsSource),
       worktreePath,
       stdin === undefined ? undefined : { stdin }
     )

--- a/src/relay/git-handler-blame-ops.ts
+++ b/src/relay/git-handler-blame-ops.ts
@@ -1,0 +1,17 @@
+import type { GitBlameResult } from '../shared/git-blame'
+import { buildGitBlameArgv, parseBlamePorcelain } from '../shared/git-blame'
+import type { GitExec } from './git-handler-ops'
+
+export async function blameFile(
+  git: GitExec,
+  worktreePath: string,
+  filePath: string,
+  revision?: string
+): Promise<GitBlameResult> {
+  try {
+    const { stdout } = await git(buildGitBlameArgv(filePath, revision), worktreePath)
+    return { status: 'ready', lines: parseBlamePorcelain(stdout) }
+  } catch {
+    return { status: 'unavailable', lines: [] }
+  }
+}

--- a/src/relay/git-handler-blame.test.ts
+++ b/src/relay/git-handler-blame.test.ts
@@ -33,6 +33,18 @@ describe('GitHandler blame', () => {
     ).rejects.toThrow('outside the worktree')
   })
 
+  it('rejects a flag-like blame revision before git runs', async () => {
+    gitInit(tmpDir)
+
+    await expect(
+      dispatcher.callRequest('git.blame', {
+        worktreePath: tmpDir,
+        filePath: 'note.txt',
+        revision: '--output=/tmp/pwned'
+      })
+    ).rejects.toThrow('revision must be a full git object id')
+  })
+
   it('blames staged index contents when they differ from the working tree', async () => {
     gitInit(tmpDir)
     writeFileSync(`${tmpDir}/note.txt`, 'hello\n')

--- a/src/relay/git-handler-blame.test.ts
+++ b/src/relay/git-handler-blame.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import { gitInit, gitCommit, type MockDispatcher } from './git-handler-test-setup'
+import {
+  createGitHandlerRelay,
+  createGitTempDir,
+  removeGitTempDir
+} from './git-handler-test-harness'
+import { GIT_BLAME_INDEX_CONTENTS, isUncommittedBlameOid } from '../shared/git-blame'
+
+describe('GitHandler blame', () => {
+  let dispatcher: MockDispatcher
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = createGitTempDir()
+    ;({ dispatcher } = createGitHandlerRelay())
+  })
+
+  afterEach(async () => {
+    await removeGitTempDir(tmpDir)
+  })
+
+  it('rejects blame paths that traverse outside the worktree', async () => {
+    gitInit(tmpDir)
+
+    await expect(
+      dispatcher.callRequest('git.blame', {
+        worktreePath: tmpDir,
+        filePath: '../outside.txt'
+      })
+    ).rejects.toThrow('outside the worktree')
+  })
+
+  it('blames staged index contents when they differ from the working tree', async () => {
+    gitInit(tmpDir)
+    writeFileSync(`${tmpDir}/note.txt`, 'hello\n')
+    gitCommit(tmpDir, 'Add note')
+    writeFileSync(`${tmpDir}/note.txt`, 'hello\nstaged\n')
+    execFileSync('git', ['add', 'note.txt'], { cwd: tmpDir, stdio: 'pipe' })
+    writeFileSync(`${tmpDir}/note.txt`, 'hello\nstaged\nworktree\n')
+
+    const workingTree = (await dispatcher.callRequest('git.blame', {
+      worktreePath: tmpDir,
+      filePath: 'note.txt'
+    })) as { status: string; lines: { commitOid: string }[] }
+    expect(workingTree.status).toBe('ready')
+    expect(workingTree.lines).toHaveLength(3)
+    expect(isUncommittedBlameOid(workingTree.lines[2]?.commitOid ?? '')).toBe(true)
+
+    const index = (await dispatcher.callRequest('git.blame', {
+      worktreePath: tmpDir,
+      filePath: 'note.txt',
+      contentsSource: GIT_BLAME_INDEX_CONTENTS
+    })) as { status: string; lines: { commitOid: string }[] }
+    expect(index.status).toBe('ready')
+    expect(index.lines).toHaveLength(2)
+    expect(isUncommittedBlameOid(index.lines[1]?.commitOid ?? '')).toBe(true)
+  })
+})

--- a/src/relay/git-handler-read-operations.ts
+++ b/src/relay/git-handler-read-operations.ts
@@ -1,9 +1,11 @@
-import * as path from 'node:path'
 import type { RequestContext } from './dispatcher'
 import { GitHandlerOperationContext } from './git-handler-operation-context'
 import { getStatusOp } from './git-handler-status-ops'
 import { streamRelayGitStdout } from './git-stdout-stream'
+import { GIT_BLAME_INDEX_CONTENTS } from '../shared/git-blame'
+import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import { capGitStatusEntries, resolveGitStatusLimit } from '../shared/git-status-limit'
+import { stableInFlightKey } from '../shared/in-flight-promise-dedupe'
 import {
   buildSubmoduleInnerCommitRangeDiff,
   computeSubmodulePointerDiff,
@@ -15,9 +17,8 @@ import {
 } from './git-handler-submodule-ops'
 import { computeDiff, type GitExec } from './git-handler-ops'
 import { checkIgnoredPathsOp } from './git-handler-check-ignore'
-import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import { blameFile } from './git-handler-blame-ops'
-import { stableInFlightKey } from '../shared/in-flight-promise-dedupe'
+import { assertGitPathInsideWorktree } from './git-handler-utils'
 
 function resolveSubmoduleStatusArea(
   params: Record<string, unknown>
@@ -103,18 +104,16 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
     const revision = typeof params.revision === 'string' ? params.revision : undefined
-    return blameFile(this.git.bind(this), worktreePath, filePath, revision)
+    const contentsSource =
+      params.contentsSource === GIT_BLAME_INDEX_CONTENTS ? GIT_BLAME_INDEX_CONTENTS : undefined
+    return blameFile(this.git.bind(this), worktreePath, filePath, revision, contentsSource)
   }
 
   async getDiff(params: Record<string, unknown>, context?: RequestContext) {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
     // Why: validate relative paths to prevent traversal outside the worktree.
-    const resolved = path.resolve(worktreePath, filePath)
-    const rel = path.relative(path.resolve(worktreePath), resolved)
-    if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
-      throw new Error(`Path "${filePath}" resolves outside the worktree`)
-    }
+    assertGitPathInsideWorktree(worktreePath, filePath)
     const staged = params.staged as boolean
     const compareAgainstHead = params.compareAgainstHead as boolean | undefined
     // Why: register dedupe before awaiting so identical reads coalesce.

--- a/src/relay/git-handler-read-operations.ts
+++ b/src/relay/git-handler-read-operations.ts
@@ -16,6 +16,7 @@ import {
 import { computeDiff, type GitExec } from './git-handler-ops'
 import { checkIgnoredPathsOp } from './git-handler-check-ignore'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
+import { blameFile } from './git-handler-blame-ops'
 import { stableInFlightKey } from '../shared/in-flight-promise-dedupe'
 
 function resolveSubmoduleStatusArea(
@@ -96,6 +97,13 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
       limit: typeof params.limit === 'number' ? params.limit : undefined,
       baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
     })
+  }
+
+  async blame(params: Record<string, unknown>) {
+    const worktreePath = params.worktreePath as string
+    const filePath = params.filePath as string
+    const revision = typeof params.revision === 'string' ? params.revision : undefined
+    return blameFile(this.git.bind(this), worktreePath, filePath, revision)
   }
 
   async getDiff(params: Record<string, unknown>, context?: RequestContext) {

--- a/src/relay/git-handler-read-operations.ts
+++ b/src/relay/git-handler-read-operations.ts
@@ -2,7 +2,7 @@ import type { RequestContext } from './dispatcher'
 import { GitHandlerOperationContext } from './git-handler-operation-context'
 import { getStatusOp } from './git-handler-status-ops'
 import { streamRelayGitStdout } from './git-stdout-stream'
-import { GIT_BLAME_INDEX_CONTENTS } from '../shared/git-blame'
+import { GIT_BLAME_INDEX_CONTENTS, parseGitBlameRevision } from '../shared/git-blame'
 import { loadGitHistoryFromExecutor } from '../shared/git-history'
 import { capGitStatusEntries, resolveGitStatusLimit } from '../shared/git-status-limit'
 import { stableInFlightKey } from '../shared/in-flight-promise-dedupe'
@@ -103,7 +103,7 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
   async blame(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
     const filePath = params.filePath as string
-    const revision = typeof params.revision === 'string' ? params.revision : undefined
+    const revision = parseGitBlameRevision(params.revision)
     const contentsSource =
       params.contentsSource === GIT_BLAME_INDEX_CONTENTS ? GIT_BLAME_INDEX_CONTENTS : undefined
     return blameFile(this.git.bind(this), worktreePath, filePath, revision, contentsSource)

--- a/src/relay/git-handler-registration.ts
+++ b/src/relay/git-handler-registration.ts
@@ -13,6 +13,7 @@ export function registerGitHandlers(
   )
   dispatcher.onRequest('git.checkIgnored', (p) => handlers.read.checkIgnored(p))
   dispatcher.onRequest('git.history', (p) => handlers.read.history(p))
+  dispatcher.onRequest('git.blame', (p) => handlers.read.blame(p))
   dispatcher.onRequest('git.commit', (p) => handlers.changes.commit(p))
   dispatcher.onRequest('git.diff', (p, context) => handlers.read.getDiff(p, context))
   dispatcher.onRequest('git.stage', (p) => handlers.changes.stage(p))

--- a/src/relay/git-handler-utils.test.ts
+++ b/src/relay/git-handler-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isUnsupportedWorktreeListZError, parseWorktreeList } from './git-handler-utils'
+import {
+  assertGitPathInsideWorktree,
+  isUnsupportedWorktreeListZError,
+  parseWorktreeList
+} from './git-handler-utils'
 
 describe('parseWorktreeList', () => {
   it('preserves SSH worktree lock metadata from porcelain output', () => {
@@ -102,5 +106,17 @@ describe('isUnsupportedWorktreeListZError', () => {
       stderr: 'fatal: unable to read tree\n'
     })
     expect(isUnsupportedWorktreeListZError(error)).toBe(false)
+  })
+})
+
+describe('assertGitPathInsideWorktree', () => {
+  it('allows a relative file inside the worktree', () => {
+    expect(() => assertGitPathInsideWorktree('/repo', 'src/a.ts')).not.toThrow()
+  })
+
+  it('rejects a path that escapes the worktree', () => {
+    expect(() => assertGitPathInsideWorktree('/repo', '../outside.txt')).toThrow(
+      'outside the worktree'
+    )
   })
 })

--- a/src/relay/git-handler-utils.ts
+++ b/src/relay/git-handler-utils.ts
@@ -12,6 +12,14 @@ import { isBinaryBuffer } from '../shared/binary-buffer'
 import type { GitLineStats } from '../shared/git-uncommitted-line-stats'
 export { isUnsupportedWorktreeListZError } from '../shared/git-worktree-command-capabilities'
 
+export function assertGitPathInsideWorktree(worktreePath: string, filePath: string): void {
+  const resolved = path.resolve(worktreePath, filePath)
+  const rel = path.relative(path.resolve(worktreePath), resolved)
+  if (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel)) {
+    throw new Error(`Path "${filePath}" resolves outside the worktree`)
+  }
+}
+
 export function parseBranchStatusChar(char: string): string {
   switch (char) {
     case 'M':

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -42,6 +42,7 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.status')
     expect(methods).toContain('git.checkIgnored')
     expect(methods).toContain('git.history')
+    expect(methods).toContain('git.blame')
     expect(methods).toContain('git.commit')
     expect(methods).toContain('git.diff')
     expect(methods).toContain('git.stage')

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2229,6 +2229,27 @@ html.native-shell .app-layout {
   opacity: 0.92;
 }
 
+.monaco-editor .orca-git-line-blame {
+  box-sizing: border-box;
+  max-width: 60ch;
+  padding-left: 2ch;
+  color: var(--muted-foreground, #8b949e);
+  cursor: pointer;
+  font-style: italic;
+  font-weight: 400;
+  opacity: 0.55;
+  overflow: hidden;
+  pointer-events: auto;
+  text-overflow: ellipsis;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.monaco-editor .orca-git-line-blame:hover {
+  opacity: 0.9;
+  text-decoration: underline;
+}
+
 /* Why: Monaco's find-widget button tooltips (Close, Find in Selection, etc.)
    render inside a `.context-view` wrapper → `.workbench-hover-container` →
    `.workbench-hover.compact`, positioned above the target button. The wrapper's

--- a/src/renderer/src/components/editor/ChangesModeView.tsx
+++ b/src/renderer/src/components/editor/ChangesModeView.tsx
@@ -5,6 +5,7 @@ import type { GitDiffResult } from '../../../../shared/git-diff-compare-types'
 import type { GitStatusEntry } from '../../../../shared/git-status-types'
 import { ConflictBanner } from './ConflictComponents'
 import { getDiffContentSignature } from './diff-content-signature'
+import { GIT_BLAME_HEAD_REVISION } from '../../../../shared/git-blame'
 import { translate } from '@/i18n/i18n'
 
 const DiffViewer = lazy(() => import('./DiffViewer'))
@@ -98,6 +99,7 @@ export function ChangesModeView({
           sideBySide={sideBySide}
           editable={true}
           worktreeId={activeFile.worktreeId}
+          originalBlameRevision={GIT_BLAME_HEAD_REVISION}
           onContentChange={onContentChange}
           onSave={onSave}
         />

--- a/src/renderer/src/components/editor/ChangesModeView.tsx
+++ b/src/renderer/src/components/editor/ChangesModeView.tsx
@@ -100,6 +100,7 @@ export function ChangesModeView({
           editable={true}
           worktreeId={activeFile.worktreeId}
           originalBlameRevision={GIT_BLAME_HEAD_REVISION}
+          modifiedBufferDirty={activeFile.isDirty}
           onContentChange={onContentChange}
           onSave={onSave}
         />

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -7,10 +7,7 @@ import { useAppStore } from '@/store'
 import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
-import {
-  getDiffCommentPopoverLeft,
-  getDiffCommentPopoverTop
-} from '../diff-comments/diff-comment-popover-position'
+import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import { DiffSectionHeader } from './DiffSectionHeader'
 import type { DiffComment } from '../../../../shared/diff-comment-types'
@@ -21,6 +18,8 @@ import { useDiffSectionLayoutMetrics } from './useDiffSectionLayoutMetrics'
 import { getLiveDiffSectionRenderLimit } from './diff-section-live-render-limit'
 import { useDiffSectionFallbackCleanup } from './useDiffSectionFallbackCleanup'
 import { submitDiffSectionComment } from './diff-section-comment-submit'
+import { useDiffCommentPopoverLayout } from './useDiffCommentPopoverLayout'
+import { useDiffPaneGitLineBlame } from './useDiffPaneGitLineBlame'
 import type { DiffSectionItemProps } from './diff-section-item-props'
 import { useDiffSectionModelLifecycle } from './use-diff-section-model-lifecycle'
 
@@ -33,6 +32,9 @@ export function DiffSectionItem({
   settings,
   sectionHeight,
   worktreeId,
+  originalBlamePath,
+  originalBlameRevision,
+  modifiedBlameRevision,
   loadSection,
   loadDeferredSection,
   retrySection,
@@ -80,7 +82,15 @@ export function DiffSectionItem({
     editorFontZoomLevel
   )
 
-  const [modifiedEditor, setModifiedEditor] = useState<monacoEditor.ICodeEditor | null>(null)
+  const { modifiedEditor, setOriginalEditor, setModifiedEditor } = useDiffPaneGitLineBlame({
+    worktreeId,
+    relativePath: section.path,
+    originalBlamePath,
+    originalBlameRevision,
+    modifiedBlameRevision,
+    widgetKeyPrefix: `diff:${section.key}`,
+    extraEnabled: !section.collapsed
+  })
   const diffEditorRef = useRef<monacoEditor.IStandaloneDiffEditor | null>(null)
   const sectionBodyRef = useRef<HTMLDivElement | null>(null)
   const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
@@ -135,35 +145,12 @@ export function DiffSectionItem({
     onPendingScrollConsumed: () => setScrollToDiffCommentId(null)
   })
 
-  useEffect(() => {
-    if (!modifiedEditor || !popover) {
-      return
-    }
-    const update = (): void => {
-      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
-      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
-      if (top == null) {
-        setPopover(null)
-        return
-      }
-      const left = getDiffCommentPopoverLeft(modifiedEditor, sectionBodyRef.current)
-      setPopover((prev) =>
-        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
-      )
-    }
-    const scrollSub = modifiedEditor.onDidScrollChange(update)
-    const contentSub = modifiedEditor.onDidContentSizeChange(update)
-    const layoutSub = modifiedEditor.onDidLayoutChange(update)
-    return () => {
-      scrollSub.dispose()
-      contentSub.dispose()
-      layoutSub.dispose()
-    }
-    // Why: depend on popover.lineNumber (not the whole popover object) so the
-    // effect doesn't re-subscribe on every top update it dispatches. The guard
-    // on `popover` above handles the popover-closed case.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modifiedEditor, popover?.lineNumber])
+  useDiffCommentPopoverLayout({
+    editor: modifiedEditor,
+    popover,
+    containerRef: sectionBodyRef,
+    setPopover
+  })
 
   useEffect(() => {
     const diffEditor = diffEditorRef.current
@@ -213,6 +200,7 @@ export function DiffSectionItem({
     lineNumberOptionsSubRef.current?.dispose()
     lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(editor, sideBySide)
     const modified = editor.getModifiedEditor()
+    const original = editor.getOriginalEditor()
 
     // Why: measuring before Monaco computes hidden unchanged regions records
     // full-file height, making virtualized combined diffs jump as rows remount.
@@ -250,6 +238,7 @@ export function DiffSectionItem({
       markDiffLayoutReady()
     }
 
+    setOriginalEditor(original)
     setModifiedEditor(modified)
     // Why: Monaco disposes inner editors when the DiffEditor container is
     // unmounted (e.g. section collapse, tab change). Clearing the state
@@ -270,6 +259,7 @@ export function DiffSectionItem({
         modifiedEditorsRef.current.delete(index)
       }
       setModifiedEditor(null)
+      setOriginalEditor(null)
       setPopover(null)
     })
 
@@ -278,7 +268,6 @@ export function DiffSectionItem({
     }
 
     modifiedEditorsRef.current.set(index, modified)
-    const original = editor.getOriginalEditor()
     const cleanupSaveShortcut = installEditorSaveShortcut(modified.getContainerDomNode(), () =>
       handleSectionSaveRef.current(index)
     )

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -34,7 +34,10 @@ export function DiffSectionItem({
   worktreeId,
   originalBlamePath,
   originalBlameRevision,
+  originalContentsSource,
   modifiedBlameRevision,
+  modifiedContentsSource,
+  modifiedBufferDirty,
   loadSection,
   loadDeferredSection,
   retrySection,
@@ -87,7 +90,10 @@ export function DiffSectionItem({
     relativePath: section.path,
     originalBlamePath,
     originalBlameRevision,
+    originalContentsSource,
     modifiedBlameRevision,
+    modifiedContentsSource,
+    modifiedBufferDirty,
     widgetKeyPrefix: `diff:${section.key}`,
     extraEnabled: !section.collapsed
   })

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -51,7 +51,10 @@ export default function DiffViewer({
   largeDiffSaveContentAvailable,
   originalBlamePath,
   originalBlameRevision,
-  modifiedBlameRevision
+  originalContentsSource,
+  modifiedBlameRevision,
+  modifiedContentsSource,
+  modifiedBufferDirty
 }: DiffViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
@@ -95,7 +98,10 @@ export default function DiffViewer({
     relativePath,
     originalBlamePath,
     originalBlameRevision,
+    originalContentsSource,
     modifiedBlameRevision,
+    modifiedContentsSource,
+    modifiedBufferDirty,
     widgetKeyPrefix: 'diff',
     extraEnabled: renderLimit.limited !== true
   })

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -9,10 +9,7 @@ import { useContextualCopySetup } from './useContextualCopySetup'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
 import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import { DiffCommentPopover } from '../diff-comments/DiffCommentPopover'
-import {
-  getDiffCommentPopoverLeft,
-  getDiffCommentPopoverTop
-} from '../diff-comments/diff-comment-popover-position'
+import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import type { DiffComment } from '../../../../shared/diff-comment-types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
@@ -28,6 +25,9 @@ import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
 import { monacoFindOptions } from './monaco-find-options'
+import { submitDiffViewerComment } from './diff-viewer-comment-submit'
+import { useDiffCommentPopoverLayout } from './useDiffCommentPopoverLayout'
+import { useDiffPaneGitLineBlame } from './useDiffPaneGitLineBlame'
 
 export default function DiffViewer({
   modelKey,
@@ -48,7 +48,10 @@ export default function DiffViewer({
   onContentChange,
   onSave,
   largeDiffRenderLimit,
-  largeDiffSaveContentAvailable
+  largeDiffSaveContentAvailable,
+  originalBlamePath,
+  originalBlameRevision,
+  modifiedBlameRevision
 }: DiffViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
@@ -75,7 +78,6 @@ export default function DiffViewer({
   const { registerDiffEditor, unregisterDiffEditor } = useDiffEditorRegistration()
   const diffBodyRef = useRef<HTMLDivElement | null>(null)
   const lineNumberOptionsSubRef = useRef<{ dispose: () => void } | null>(null)
-  const [modifiedEditor, setModifiedEditor] = useState<editor.ICodeEditor | null>(null)
   const [popover, setPopover] = useState<{
     lineNumber: number
     startLine?: number
@@ -88,6 +90,15 @@ export default function DiffViewer({
     () => largeDiffRenderLimit ?? getLargeDiffRenderLimit({ originalContent, modifiedContent }),
     [largeDiffRenderLimit, originalContent, modifiedContent]
   )
+  const { modifiedEditor, setOriginalEditor, setModifiedEditor } = useDiffPaneGitLineBlame({
+    worktreeId,
+    relativePath,
+    originalBlamePath,
+    originalBlameRevision,
+    modifiedBlameRevision,
+    widgetKeyPrefix: 'diff',
+    extraEnabled: renderLimit.limited !== true
+  })
   const hasLineCommentAction = Boolean(worktreeId || onAddLineComment)
 
   // Why: only forward the pending scroll id when this viewer owns the comment, else unrelated viewers race to ack it.
@@ -127,33 +138,12 @@ export default function DiffViewer({
     onPendingScrollConsumed: () => setScrollToDiffCommentId(null)
   })
 
-  useEffect(() => {
-    if (!modifiedEditor || !popover) {
-      return
-    }
-    const update = (): void => {
-      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
-      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
-      if (top == null) {
-        setPopover(null)
-        return
-      }
-      const left = getDiffCommentPopoverLeft(modifiedEditor, diffBodyRef.current)
-      setPopover((prev) =>
-        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
-      )
-    }
-    const scrollSub = modifiedEditor.onDidScrollChange(update)
-    const contentSub = modifiedEditor.onDidContentSizeChange(update)
-    const layoutSub = modifiedEditor.onDidLayoutChange(update)
-    return () => {
-      scrollSub.dispose()
-      contentSub.dispose()
-      layoutSub.dispose()
-    }
-    // Why: depend on popover.lineNumber (not the whole object) so the effect doesn't re-subscribe on every top update.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [modifiedEditor, popover?.lineNumber])
+  useDiffCommentPopoverLayout({
+    editor: modifiedEditor,
+    popover,
+    containerRef: diffBodyRef,
+    setPopover
+  })
 
   // Why: center the first diff from a dedicated effect (not handleMount) so it runs after the decorator's view zones, which would otherwise shift content downward.
   const didAutoScrollFirstDiffRef = useRef(false)
@@ -228,42 +218,25 @@ export default function DiffViewer({
     if (fallenBackEditor) {
       unregisterDiffEditor(fallenBackEditor)
     }
+    setOriginalEditor(null)
     setModifiedEditor(null)
     setPopover(null)
-  }, [unregisterDiffEditor])
+  }, [setModifiedEditor, setOriginalEditor, unregisterDiffEditor])
 
   const handleSubmitComment = async (body: string): Promise<void> => {
     if (!popover) {
       return
     }
-    if (onAddLineComment) {
-      const ok = await onAddLineComment({
-        lineNumber: popover.lineNumber,
-        startLine: popover.startLine,
-        body
-      })
-      if (ok) {
-        setPopover(null)
-      }
-      return
-    }
-    if (!worktreeId) {
-      return
-    }
-    // Why: await persistence — a null result (failed save) keeps the popover open for retry instead of losing the draft.
-    const result = await addDiffComment({
-      worktreeId,
-      filePath: relativePath,
-      source: 'diff',
-      startLine: popover.startLine,
-      lineNumber: popover.lineNumber,
+    const submitted = await submitDiffViewerComment({
+      addDiffComment,
       body,
-      side: 'modified'
+      onAddLineComment,
+      popover,
+      relativePath,
+      worktreeId
     })
-    if (result) {
+    if (submitted) {
       setPopover(null)
-    } else {
-      console.error('Failed to add diff comment — draft preserved')
     }
   }
 
@@ -299,6 +272,7 @@ export default function DiffViewer({
 
       setupCopy(originalEditor, monaco, filePath, propsRef)
       setupCopy(modifiedEditor, monaco, filePath, propsRef)
+      setOriginalEditor(originalEditor)
       setModifiedEditor(modifiedEditor)
 
       // Why: restore full diff view state (not just scrollTop) so cursor/selection stay consistent across both panes.
@@ -341,11 +315,22 @@ export default function DiffViewer({
         lineNumberOptionsSubRef.current = null
         diffEditorRef.current = null
         unregisterDiffEditor(diffEditor)
+        setOriginalEditor(null)
         setModifiedEditor(null)
         setPopover(null)
       })
     },
-    [editable, setupCopy, modelKey, filePath, sideBySide, registerDiffEditor, unregisterDiffEditor]
+    [
+      editable,
+      setupCopy,
+      modelKey,
+      filePath,
+      sideBySide,
+      registerDiffEditor,
+      unregisterDiffEditor,
+      setOriginalEditor,
+      setModifiedEditor
+    ]
   )
 
   // Why: snapshot view state on deactivation (layoutEffect cleanup fires before unmount), not on scroll.

--- a/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
@@ -2,6 +2,7 @@ import { translate } from '@/i18n/i18n'
 import type { OpenFile } from '@/store/slices/editor'
 import type { GitDiffResult } from '../../../../shared/git-diff-compare-types'
 import { getDiffContentSignature } from './diff-content-signature'
+import { getFileDiffBlameRevisions } from './diff-blame-revisions'
 import { DiffViewer, ImageDiffViewer, MarkdownPreview } from './editor-lazy-views'
 import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 import type { useMarkdownDocuments } from './useMarkdownDocuments'
@@ -138,6 +139,7 @@ export function EditorDiffFileSurface({
   const diffReloadNonce = activeFile.diffContentReloadNonce ?? 0
   const originalModelKey = `${diffViewStateKey}:original:${getDiffContentSignature(diffContent.originalContent)}`
   const modifiedModelKey = `${diffViewStateKey}:modified:${getDiffContentSignature(diffContent.modifiedContent)}:${diffReloadNonce}`
+  const blameRevisions = getFileDiffBlameRevisions(activeFile)
   const diffViewer = (
     <DiffViewer
       // Why: content refreshes via modifiedModelKey; keying off content too would remount Monaco and flash on every save.
@@ -152,6 +154,9 @@ export function EditorDiffFileSurface({
       language={resolvedLanguage}
       filePath={activeFile.filePath}
       relativePath={activeFile.relativePath}
+      originalBlamePath={activeFile.branchOldPath}
+      originalBlameRevision={blameRevisions.originalRevision}
+      modifiedBlameRevision={blameRevisions.modifiedRevision}
       sideBySide={sideBySide}
       editable={isEditable}
       worktreeId={activeFile.worktreeId}

--- a/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
@@ -156,7 +156,10 @@ export function EditorDiffFileSurface({
       relativePath={activeFile.relativePath}
       originalBlamePath={activeFile.branchOldPath}
       originalBlameRevision={blameRevisions.originalRevision}
+      originalContentsSource={blameRevisions.originalContentsSource}
       modifiedBlameRevision={blameRevisions.modifiedRevision}
+      modifiedContentsSource={blameRevisions.modifiedContentsSource}
+      modifiedBufferDirty={activeFile.isDirty}
       sideBySide={sideBySide}
       editable={isEditable}
       worktreeId={activeFile.worktreeId}

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -87,11 +87,15 @@ export default function MonacoEditor({
 
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  const fileIsDirty = useAppStore(
+    (s) => s.openFiles.find((file) => file.id === fileId)?.isDirty === true
+  )
   useGitLineBlame({
     editor: mountedEditor,
     enabled:
       !autoHeight &&
       !liveTail &&
+      !fileIsDirty &&
       Boolean(worktreeId) &&
       settings?.editorGitLineBlameEnabled !== false,
     worktreeId,

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -13,6 +13,7 @@ import { isLinuxUserAgent } from '../terminal-pane/pane-helpers'
 import { buildFileEditorWordWrapOptions } from './file-editor-word-wrap-options'
 import { getMonacoAutoHeightForContent, isMonacoAutoHeightCapped } from './monaco-auto-height'
 import { monacoFindOptions } from './monaco-find-options'
+import { useGitLineBlame } from './useGitLineBlame'
 import { useMonacoRevealScheduler } from './use-monaco-reveal-scheduler'
 import type { MonacoContentSyncMode } from './monaco-content-sync'
 import { useMonacoContentSyncBridge } from './use-monaco-content-sync-bridge'
@@ -86,6 +87,16 @@ export default function MonacoEditor({
 
   const settings = useAppStore((s) => s.settings)
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
+  useGitLineBlame({
+    editor: mountedEditor,
+    enabled:
+      !autoHeight &&
+      !liveTail &&
+      Boolean(worktreeId) &&
+      settings?.editorGitLineBlameEnabled !== false,
+    worktreeId,
+    relativePath
+  })
   const setPendingEditorReveal = useAppStore((s) => s.setPendingEditorReveal)
   const setEditorCursorLine = useAppStore((s) => s.setEditorCursorLine)
   const editorFontSize = computeEditorFontSize(

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
@@ -114,7 +114,10 @@ export function CombinedDiffSectionList({
                   worktreeId={file.worktreeId}
                   originalBlamePath={section.oldPath}
                   originalBlameRevision={blameRevisions.originalRevision}
+                  originalContentsSource={blameRevisions.originalContentsSource}
                   modifiedBlameRevision={blameRevisions.modifiedRevision}
+                  modifiedContentsSource={blameRevisions.modifiedContentsSource}
+                  modifiedBufferDirty={file.isDirty && section.area === 'unstaged'}
                   loadSection={loadSection}
                   loadDeferredSection={loadDeferredSection}
                   retrySection={retrySection}

--- a/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
+++ b/src/renderer/src/components/editor/combined-diff/scroll-viewport/combined-diff-section-list.tsx
@@ -4,6 +4,7 @@ import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
 import type { DiffComment } from '../../../../../../shared/diff-comment-types'
 import { DiffSectionItem } from '../../DiffSectionItem'
+import { getCombinedSectionBlameRevisions } from '../../diff-blame-revisions'
 import type { DiffSectionItemProps } from '../../diff-section-item-props'
 import { DiffNotesSendMenu } from '../../DiffNotesSendMenu'
 import { canOpenDiffSectionPreviewToSide } from '../../diff-section-preview'
@@ -84,6 +85,12 @@ export function CombinedDiffSectionList({
             if (!section) {
               return null
             }
+            const blameRevisions = getCombinedSectionBlameRevisions({
+              diffSource: file.diffSource,
+              sectionArea: section.area,
+              commitCompare: file.commitCompare,
+              branchCompare: file.branchCompare
+            })
 
             return (
               <div
@@ -105,6 +112,9 @@ export function CombinedDiffSectionList({
                   settings={settings}
                   sectionHeight={sectionHeights[virtualItem.index]}
                   worktreeId={file.worktreeId}
+                  originalBlamePath={section.oldPath}
+                  originalBlameRevision={blameRevisions.originalRevision}
+                  modifiedBlameRevision={blameRevisions.modifiedRevision}
                   loadSection={loadSection}
                   loadDeferredSection={loadDeferredSection}
                   retrySection={retrySection}

--- a/src/renderer/src/components/editor/diff-blame-revisions.test.ts
+++ b/src/renderer/src/components/editor/diff-blame-revisions.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { GIT_BLAME_HEAD_REVISION } from '../../../../shared/git-blame'
+import { getCombinedSectionBlameRevisions, getFileDiffBlameRevisions } from './diff-blame-revisions'
+
+const COMMIT = 'a'.repeat(40)
+const PARENT = 'b'.repeat(40)
+const HEAD = 'c'.repeat(40)
+const BASE = 'd'.repeat(40)
+
+describe('getFileDiffBlameRevisions', () => {
+  it('blames HEAD vs the working tree for uncommitted diffs', () => {
+    expect(getFileDiffBlameRevisions({ diffSource: 'unstaged' })).toEqual({
+      originalRevision: GIT_BLAME_HEAD_REVISION,
+      modifiedRevision: undefined
+    })
+    expect(getFileDiffBlameRevisions({ diffSource: 'staged' })).toEqual({
+      originalRevision: GIT_BLAME_HEAD_REVISION,
+      modifiedRevision: undefined
+    })
+  })
+
+  it('blames the parent and commit for a commit diff', () => {
+    expect(
+      getFileDiffBlameRevisions({
+        diffSource: 'commit',
+        commitCompare: { commitOid: COMMIT, parentOid: PARENT }
+      })
+    ).toEqual({ originalRevision: PARENT, modifiedRevision: COMMIT })
+  })
+
+  it('skips the original side when a commit has no parent', () => {
+    expect(
+      getFileDiffBlameRevisions({
+        diffSource: 'commit',
+        commitCompare: { commitOid: COMMIT, parentOid: null }
+      })
+    ).toEqual({ originalRevision: undefined, modifiedRevision: COMMIT })
+  })
+
+  it('blames the merge base and head for a branch diff', () => {
+    expect(
+      getFileDiffBlameRevisions({
+        diffSource: 'branch',
+        branchCompare: { mergeBase: BASE, baseOid: BASE, headOid: HEAD }
+      })
+    ).toEqual({ originalRevision: BASE, modifiedRevision: HEAD })
+  })
+})
+
+describe('getCombinedSectionBlameRevisions', () => {
+  it('treats combined-all rows without an area as branch entries', () => {
+    expect(
+      getCombinedSectionBlameRevisions({
+        diffSource: 'combined-all',
+        branchCompare: { mergeBase: BASE, baseOid: BASE, headOid: HEAD }
+      })
+    ).toEqual({ originalRevision: BASE, modifiedRevision: HEAD })
+  })
+
+  it('treats combined-all rows with an area as uncommitted', () => {
+    expect(
+      getCombinedSectionBlameRevisions({
+        diffSource: 'combined-all',
+        sectionArea: 'unstaged',
+        branchCompare: { mergeBase: BASE, baseOid: BASE, headOid: HEAD }
+      })
+    ).toEqual({ originalRevision: GIT_BLAME_HEAD_REVISION, modifiedRevision: undefined })
+  })
+})

--- a/src/renderer/src/components/editor/diff-blame-revisions.test.ts
+++ b/src/renderer/src/components/editor/diff-blame-revisions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { GIT_BLAME_HEAD_REVISION } from '../../../../shared/git-blame'
+import { GIT_BLAME_HEAD_REVISION, GIT_BLAME_INDEX_CONTENTS } from '../../../../shared/git-blame'
 import { getCombinedSectionBlameRevisions, getFileDiffBlameRevisions } from './diff-blame-revisions'
 
 const COMMIT = 'a'.repeat(40)
@@ -8,14 +8,19 @@ const HEAD = 'c'.repeat(40)
 const BASE = 'd'.repeat(40)
 
 describe('getFileDiffBlameRevisions', () => {
-  it('blames HEAD vs the working tree for uncommitted diffs', () => {
+  it('blames index contents on the unstaged original pane and the working tree on the right', () => {
     expect(getFileDiffBlameRevisions({ diffSource: 'unstaged' })).toEqual({
       originalRevision: GIT_BLAME_HEAD_REVISION,
+      originalContentsSource: GIT_BLAME_INDEX_CONTENTS,
       modifiedRevision: undefined
     })
+  })
+
+  it('blames HEAD on the staged original pane and index contents on the right', () => {
     expect(getFileDiffBlameRevisions({ diffSource: 'staged' })).toEqual({
       originalRevision: GIT_BLAME_HEAD_REVISION,
-      modifiedRevision: undefined
+      modifiedRevision: GIT_BLAME_HEAD_REVISION,
+      modifiedContentsSource: GIT_BLAME_INDEX_CONTENTS
     })
   })
 
@@ -57,13 +62,31 @@ describe('getCombinedSectionBlameRevisions', () => {
     ).toEqual({ originalRevision: BASE, modifiedRevision: HEAD })
   })
 
-  it('treats combined-all rows with an area as uncommitted', () => {
+  it('treats combined-all unstaged rows as index vs working tree', () => {
     expect(
       getCombinedSectionBlameRevisions({
         diffSource: 'combined-all',
         sectionArea: 'unstaged',
         branchCompare: { mergeBase: BASE, baseOid: BASE, headOid: HEAD }
       })
-    ).toEqual({ originalRevision: GIT_BLAME_HEAD_REVISION, modifiedRevision: undefined })
+    ).toEqual({
+      originalRevision: GIT_BLAME_HEAD_REVISION,
+      originalContentsSource: GIT_BLAME_INDEX_CONTENTS,
+      modifiedRevision: undefined
+    })
+  })
+
+  it('treats combined-all staged rows as HEAD vs index contents', () => {
+    expect(
+      getCombinedSectionBlameRevisions({
+        diffSource: 'combined-all',
+        sectionArea: 'staged',
+        branchCompare: { mergeBase: BASE, baseOid: BASE, headOid: HEAD }
+      })
+    ).toEqual({
+      originalRevision: GIT_BLAME_HEAD_REVISION,
+      modifiedRevision: GIT_BLAME_HEAD_REVISION,
+      modifiedContentsSource: GIT_BLAME_INDEX_CONTENTS
+    })
   })
 })

--- a/src/renderer/src/components/editor/diff-blame-revisions.ts
+++ b/src/renderer/src/components/editor/diff-blame-revisions.ts
@@ -1,0 +1,54 @@
+import { GIT_BLAME_HEAD_REVISION } from '../../../../shared/git-blame'
+import type { DiffSource } from '@/store/slices/editor/types/open-file'
+
+export type DiffBlameRevisionPair = {
+  originalRevision?: string
+  modifiedRevision?: string
+}
+
+export function getFileDiffBlameRevisions(file: {
+  diffSource?: DiffSource
+  commitCompare?: { commitOid: string; parentOid: string | null } | null
+  branchCompare?: {
+    mergeBase: string | null
+    baseOid: string | null
+    headOid: string | null
+  } | null
+}): DiffBlameRevisionPair {
+  if (file.diffSource === 'commit' || file.diffSource === 'combined-commit') {
+    return {
+      originalRevision: file.commitCompare?.parentOid ?? undefined,
+      modifiedRevision: file.commitCompare?.commitOid
+    }
+  }
+  if (file.diffSource === 'branch' || file.diffSource === 'combined-branch') {
+    return {
+      originalRevision: file.branchCompare?.mergeBase ?? file.branchCompare?.baseOid ?? undefined,
+      modifiedRevision: file.branchCompare?.headOid ?? undefined
+    }
+  }
+  return { originalRevision: GIT_BLAME_HEAD_REVISION, modifiedRevision: undefined }
+}
+
+export function getCombinedSectionBlameRevisions(args: {
+  diffSource?: DiffSource
+  sectionArea?: string
+  commitCompare?: { commitOid: string; parentOid: string | null } | null
+  branchCompare?: {
+    mergeBase: string | null
+    baseOid: string | null
+    headOid: string | null
+  } | null
+}): DiffBlameRevisionPair {
+  if (args.diffSource === 'combined-all' && args.sectionArea === undefined) {
+    return getFileDiffBlameRevisions({
+      diffSource: 'combined-branch',
+      branchCompare: args.branchCompare
+    })
+  }
+  return getFileDiffBlameRevisions({
+    diffSource: args.diffSource,
+    commitCompare: args.commitCompare,
+    branchCompare: args.branchCompare
+  })
+}

--- a/src/renderer/src/components/editor/diff-blame-revisions.ts
+++ b/src/renderer/src/components/editor/diff-blame-revisions.ts
@@ -1,9 +1,31 @@
-import { GIT_BLAME_HEAD_REVISION } from '../../../../shared/git-blame'
+import {
+  GIT_BLAME_HEAD_REVISION,
+  GIT_BLAME_INDEX_CONTENTS,
+  type GitBlameContentsSource
+} from '../../../../shared/git-blame'
 import type { DiffSource } from '@/store/slices/editor/types/open-file'
 
 export type DiffBlameRevisionPair = {
   originalRevision?: string
   modifiedRevision?: string
+  originalContentsSource?: GitBlameContentsSource
+  modifiedContentsSource?: GitBlameContentsSource
+}
+
+function getStagedBlameRevisions(): DiffBlameRevisionPair {
+  return {
+    originalRevision: GIT_BLAME_HEAD_REVISION,
+    modifiedRevision: GIT_BLAME_HEAD_REVISION,
+    modifiedContentsSource: GIT_BLAME_INDEX_CONTENTS
+  }
+}
+
+function getUnstagedBlameRevisions(): DiffBlameRevisionPair {
+  return {
+    originalRevision: GIT_BLAME_HEAD_REVISION,
+    originalContentsSource: GIT_BLAME_INDEX_CONTENTS,
+    modifiedRevision: undefined
+  }
 }
 
 export function getFileDiffBlameRevisions(file: {
@@ -27,7 +49,10 @@ export function getFileDiffBlameRevisions(file: {
       modifiedRevision: file.branchCompare?.headOid ?? undefined
     }
   }
-  return { originalRevision: GIT_BLAME_HEAD_REVISION, modifiedRevision: undefined }
+  if (file.diffSource === 'staged') {
+    return getStagedBlameRevisions()
+  }
+  return getUnstagedBlameRevisions()
 }
 
 export function getCombinedSectionBlameRevisions(args: {
@@ -45,6 +70,12 @@ export function getCombinedSectionBlameRevisions(args: {
       diffSource: 'combined-branch',
       branchCompare: args.branchCompare
     })
+  }
+  if (args.sectionArea === 'staged') {
+    return getStagedBlameRevisions()
+  }
+  if (args.sectionArea === 'unstaged') {
+    return getUnstagedBlameRevisions()
   }
   return getFileDiffBlameRevisions({
     diffSource: args.diffSource,

--- a/src/renderer/src/components/editor/diff-section-item-props.ts
+++ b/src/renderer/src/components/editor/diff-section-item-props.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, MutableRefObject, ReactNode, SetStateAction } from 'react'
 import type { editor as monacoEditor } from 'monaco-editor'
+import type { GitBlameContentsSource } from '../../../../shared/git-blame'
 import type { DecoratedDiffComment } from '../diff-comments/decorated-diff-comment'
 import type { DiffSection } from './diff-section-types'
 
@@ -19,7 +20,10 @@ export type DiffSectionItemProps = {
   worktreeId?: string
   originalBlamePath?: string
   originalBlameRevision?: string
+  originalContentsSource?: GitBlameContentsSource
   modifiedBlameRevision?: string
+  modifiedContentsSource?: GitBlameContentsSource
+  modifiedBufferDirty?: boolean
   loadSection: (index: number) => void
   loadDeferredSection?: (index: number) => void
   retrySection: (index: number) => void

--- a/src/renderer/src/components/editor/diff-section-item-props.ts
+++ b/src/renderer/src/components/editor/diff-section-item-props.ts
@@ -17,6 +17,9 @@ export type DiffSectionItemProps = {
   } | null
   sectionHeight: number | undefined
   worktreeId?: string
+  originalBlamePath?: string
+  originalBlameRevision?: string
+  modifiedBlameRevision?: string
   loadSection: (index: number) => void
   loadDeferredSection?: (index: number) => void
   retrySection: (index: number) => void

--- a/src/renderer/src/components/editor/diff-viewer-comment-submit.ts
+++ b/src/renderer/src/components/editor/diff-viewer-comment-submit.ts
@@ -1,0 +1,60 @@
+type DiffViewerPopoverTarget = {
+  lineNumber: number
+  startLine?: number
+}
+
+type AddDiffComment = (args: {
+  worktreeId: string
+  filePath: string
+  source: 'diff'
+  startLine?: number
+  lineNumber: number
+  body: string
+  side: 'modified'
+}) => Promise<unknown>
+
+export async function submitDiffViewerComment({
+  addDiffComment,
+  body,
+  onAddLineComment,
+  popover,
+  relativePath,
+  worktreeId
+}: {
+  addDiffComment: AddDiffComment
+  body: string
+  onAddLineComment?: (args: {
+    lineNumber: number
+    startLine?: number
+    body: string
+  }) => Promise<boolean>
+  popover: DiffViewerPopoverTarget
+  relativePath: string
+  worktreeId?: string
+}): Promise<boolean> {
+  if (onAddLineComment) {
+    return onAddLineComment({
+      lineNumber: popover.lineNumber,
+      startLine: popover.startLine,
+      body
+    })
+  }
+  if (!worktreeId) {
+    return false
+  }
+  // Why: await persistence before closing the popover. If the store rolls back
+  // the optimistic insert, keep the user's draft open so they can retry.
+  const result = await addDiffComment({
+    worktreeId,
+    filePath: relativePath,
+    source: 'diff',
+    startLine: popover.startLine,
+    lineNumber: popover.lineNumber,
+    body,
+    side: 'modified'
+  })
+  if (!result) {
+    console.error('Failed to add diff comment — draft preserved')
+  }
+  return Boolean(result)
+}

--- a/src/renderer/src/components/editor/diff-viewer-props.ts
+++ b/src/renderer/src/components/editor/diff-viewer-props.ts
@@ -28,4 +28,7 @@ export type DiffViewerProps = {
   // Why: main-process limited diffs intentionally blank text bodies before IPC;
   // the fallback must not treat that placeholder as a saveable draft.
   largeDiffSaveContentAvailable?: boolean
+  originalBlamePath?: string
+  originalBlameRevision?: string
+  modifiedBlameRevision?: string
 }

--- a/src/renderer/src/components/editor/diff-viewer-props.ts
+++ b/src/renderer/src/components/editor/diff-viewer-props.ts
@@ -1,4 +1,5 @@
 import type { LargeDiffRenderLimit } from './large-diff-render-limit'
+import type { GitBlameContentsSource } from '../../../../shared/git-blame'
 
 export type DiffViewerProps = {
   modelKey: string
@@ -30,5 +31,8 @@ export type DiffViewerProps = {
   largeDiffSaveContentAvailable?: boolean
   originalBlamePath?: string
   originalBlameRevision?: string
+  originalContentsSource?: GitBlameContentsSource
   modifiedBlameRevision?: string
+  modifiedContentsSource?: GitBlameContentsSource
+  modifiedBufferDirty?: boolean
 }

--- a/src/renderer/src/components/editor/git-line-blame-decorations.test.ts
+++ b/src/renderer/src/components/editor/git-line-blame-decorations.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { buildGitLineBlameWidgetModel } from './git-line-blame-decorations'
+
+describe('buildGitLineBlameWidgetModel', () => {
+  it('skips lines outside the model', () => {
+    expect(
+      buildGitLineBlameWidgetModel(
+        {
+          line: 9,
+          commitOid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          author: 'Ada',
+          authorTime: 1,
+          summary: 'Add'
+        },
+        2,
+        { uncommittedLabel: 'Not Committed Yet', endColumn: 1 }
+      )
+    ).toBeNull()
+  })
+
+  it('places the annotation at the end of the current line', () => {
+    const model = buildGitLineBlameWidgetModel(
+      {
+        line: 1,
+        commitOid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        author: 'Ada',
+        authorTime: 1_700_000_000,
+        summary: 'Add parser'
+      },
+      3,
+      { uncommittedLabel: 'Not Committed Yet', nowMs: 1_700_000_000 * 1000, endColumn: 12 }
+    )
+    expect(model).toMatchObject({
+      lineNumber: 1,
+      column: 12,
+      text: expect.stringContaining('Ada')
+    })
+    expect(model?.text).toContain('Add parser')
+  })
+})

--- a/src/renderer/src/components/editor/git-line-blame-decorations.ts
+++ b/src/renderer/src/components/editor/git-line-blame-decorations.ts
@@ -1,0 +1,18 @@
+import { formatBlameAnnotation, type GitBlameLine } from '../../../../shared/git-blame'
+
+export const GIT_LINE_BLAME_INLINE_CLASS = 'orca-git-line-blame'
+
+export function buildGitLineBlameWidgetModel(
+  line: GitBlameLine,
+  modelLineCount: number,
+  options: { uncommittedLabel: string; nowMs?: number; endColumn: number }
+): { text: string; lineNumber: number; column: number } | null {
+  if (line.line < 1 || line.line > modelLineCount || options.endColumn < 1) {
+    return null
+  }
+  return {
+    text: formatBlameAnnotation(line, options),
+    lineNumber: line.line,
+    column: options.endColumn
+  }
+}

--- a/src/renderer/src/components/editor/useDiffCommentPopoverLayout.ts
+++ b/src/renderer/src/components/editor/useDiffCommentPopoverLayout.ts
@@ -1,0 +1,51 @@
+import { useEffect, type Dispatch, type SetStateAction } from 'react'
+import type { editor } from 'monaco-editor'
+import { monaco } from '@/lib/monaco-setup'
+import {
+  getDiffCommentPopoverLeft,
+  getDiffCommentPopoverTop
+} from '../diff-comments/diff-comment-popover-position'
+
+export type DiffCommentPopoverLayoutState = {
+  lineNumber: number
+  startLine?: number
+  top: number
+  left?: number
+  lineHeight: number
+}
+
+export function useDiffCommentPopoverLayout(args: {
+  editor: editor.ICodeEditor | null
+  popover: DiffCommentPopoverLayoutState | null
+  containerRef: { current: HTMLDivElement | null }
+  setPopover: Dispatch<SetStateAction<DiffCommentPopoverLayoutState | null>>
+}): void {
+  const { editor: modifiedEditor, popover, containerRef, setPopover } = args
+  useEffect(() => {
+    if (!modifiedEditor || !popover) {
+      return
+    }
+    const update = (): void => {
+      const lineHeight = modifiedEditor.getOption(monaco.editor.EditorOption.lineHeight)
+      const top = getDiffCommentPopoverTop(modifiedEditor, popover.lineNumber, lineHeight)
+      if (top == null) {
+        setPopover(null)
+        return
+      }
+      const left = getDiffCommentPopoverLeft(modifiedEditor, containerRef.current)
+      setPopover((prev) =>
+        prev ? { ...prev, top, left: left == null ? prev.left : left, lineHeight } : prev
+      )
+    }
+    const scrollSub = modifiedEditor.onDidScrollChange(update)
+    const contentSub = modifiedEditor.onDidContentSizeChange(update)
+    const layoutSub = modifiedEditor.onDidLayoutChange(update)
+    return () => {
+      scrollSub.dispose()
+      contentSub.dispose()
+      layoutSub.dispose()
+    }
+    // Why: depend on popover.lineNumber (not the whole object) so the effect doesn't re-subscribe on every top update.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modifiedEditor, popover?.lineNumber])
+}

--- a/src/renderer/src/components/editor/useDiffPaneGitLineBlame.ts
+++ b/src/renderer/src/components/editor/useDiffPaneGitLineBlame.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { editor } from 'monaco-editor'
+import type { GitBlameContentsSource } from '../../../../shared/git-blame'
 import { useAppStore } from '@/store'
 import { useGitLineBlame } from './useGitLineBlame'
 
@@ -8,7 +9,10 @@ export function useDiffPaneGitLineBlame(args: {
   relativePath: string
   originalBlamePath?: string
   originalBlameRevision?: string
+  originalContentsSource?: GitBlameContentsSource
   modifiedBlameRevision?: string
+  modifiedContentsSource?: GitBlameContentsSource
+  modifiedBufferDirty?: boolean
   widgetKeyPrefix: string
   extraEnabled?: boolean
 }): {
@@ -34,14 +38,16 @@ export function useDiffPaneGitLineBlame(args: {
     worktreeId: args.worktreeId,
     relativePath: originalPath,
     revision: args.originalBlameRevision,
+    contentsSource: args.originalContentsSource,
     widgetKey: `${args.widgetKeyPrefix}-original`
   })
   useGitLineBlame({
     editor: modifiedEditor,
-    enabled,
+    enabled: enabled && args.modifiedBufferDirty !== true,
     worktreeId: args.worktreeId,
     relativePath: args.relativePath,
     revision: args.modifiedBlameRevision,
+    contentsSource: args.modifiedContentsSource,
     widgetKey: `${args.widgetKeyPrefix}-modified`
   })
 

--- a/src/renderer/src/components/editor/useDiffPaneGitLineBlame.ts
+++ b/src/renderer/src/components/editor/useDiffPaneGitLineBlame.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react'
+import type { editor } from 'monaco-editor'
+import { useAppStore } from '@/store'
+import { useGitLineBlame } from './useGitLineBlame'
+
+export function useDiffPaneGitLineBlame(args: {
+  worktreeId?: string
+  relativePath: string
+  originalBlamePath?: string
+  originalBlameRevision?: string
+  modifiedBlameRevision?: string
+  widgetKeyPrefix: string
+  extraEnabled?: boolean
+}): {
+  modifiedEditor: editor.ICodeEditor | null
+  setOriginalEditor: (next: editor.ICodeEditor | null) => void
+  setModifiedEditor: (next: editor.ICodeEditor | null) => void
+} {
+  const [originalEditor, setOriginalEditor] = useState<editor.ICodeEditor | null>(null)
+  const [modifiedEditor, setModifiedEditor] = useState<editor.ICodeEditor | null>(null)
+  const editorGitLineBlameEnabled = useAppStore(
+    (state) => state.settings?.editorGitLineBlameEnabled
+  )
+  const enabled =
+    Boolean(args.worktreeId) && editorGitLineBlameEnabled !== false && args.extraEnabled !== false
+  const originalPath =
+    args.originalBlamePath && args.originalBlamePath.length > 0
+      ? args.originalBlamePath
+      : args.relativePath
+
+  useGitLineBlame({
+    editor: originalEditor,
+    enabled: enabled && Boolean(args.originalBlameRevision),
+    worktreeId: args.worktreeId,
+    relativePath: originalPath,
+    revision: args.originalBlameRevision,
+    widgetKey: `${args.widgetKeyPrefix}-original`
+  })
+  useGitLineBlame({
+    editor: modifiedEditor,
+    enabled,
+    worktreeId: args.worktreeId,
+    relativePath: args.relativePath,
+    revision: args.modifiedBlameRevision,
+    widgetKey: `${args.widgetKeyPrefix}-modified`
+  })
+
+  return { modifiedEditor, setOriginalEditor, setModifiedEditor }
+}

--- a/src/renderer/src/components/editor/useGitLineBlame.ts
+++ b/src/renderer/src/components/editor/useGitLineBlame.ts
@@ -12,7 +12,11 @@ import {
   getRepoIdFromWorktreeId,
   splitWorktreeIdForFilesystem
 } from '../../../../shared/worktree/id'
-import { blameLineByNumber, type GitBlameResult } from '../../../../shared/git-blame'
+import {
+  blameLineByNumber,
+  type GitBlameContentsSource,
+  type GitBlameResult
+} from '../../../../shared/git-blame'
 import {
   buildGitLineBlameWidgetModel,
   GIT_LINE_BLAME_INLINE_CLASS
@@ -26,6 +30,7 @@ export function useGitLineBlame(args: {
   worktreeId?: string
   relativePath: string
   revision?: string
+  contentsSource?: GitBlameContentsSource
   widgetKey?: string
 }): void {
   const {
@@ -34,6 +39,7 @@ export function useGitLineBlame(args: {
     worktreeId,
     relativePath,
     revision,
+    contentsSource,
     widgetKey = 'file'
   } = args
   const head = useAppStore((state) =>
@@ -112,6 +118,7 @@ export function useGitLineBlame(args: {
     }
 
     let cancelled = false
+    let fetchGeneration = 0
     let debounce: ReturnType<typeof setTimeout> | null = null
     const load = (): void => {
       if (debounce) {
@@ -127,6 +134,8 @@ export function useGitLineBlame(args: {
         }
         const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
         const repo = state.repos.find((entry) => entry.id === repoId) ?? null
+        const generation = ++fetchGeneration
+        const modelVersion = editorInstance.getModel()?.getAlternativeVersionId()
         void getRuntimeGitBlame(
           {
             settings: getRepoOwnerRoutedSettings(state.settings, repo),
@@ -135,17 +144,22 @@ export function useGitLineBlame(args: {
             connectionId: getConnectionId(worktreeId) ?? undefined
           },
           relativePath,
-          revision
+          revision,
+          contentsSource
         )
           .then((result) => {
-            if (cancelled) {
+            if (
+              cancelled ||
+              generation !== fetchGeneration ||
+              editorInstance.getModel()?.getAlternativeVersionId() !== modelVersion
+            ) {
               return
             }
             blameRef.current = result
             renderLine(lineRef.current)
           })
           .catch(() => {
-            if (cancelled) {
+            if (cancelled || generation !== fetchGeneration) {
               return
             }
             blameRef.current = { status: 'unavailable', lines: [] }
@@ -170,6 +184,13 @@ export function useGitLineBlame(args: {
       renderLine(event.position.lineNumber)
     })
     const contentSub = editorInstance.onDidChangeModelContent(() => {
+      if (!editorInstance.getOption(monaco.editor.EditorOption.readOnly)) {
+        // Why: disk blame line numbers no longer match an unsaved buffer.
+        fetchGeneration += 1
+        blameRef.current = null
+        hide()
+        return
+      }
       renderLine(lineRef.current)
     })
     const configSub = editorInstance.onDidChangeConfiguration(() => {
@@ -187,5 +208,5 @@ export function useGitLineBlame(args: {
       configSub.dispose()
       editorInstance.removeContentWidget(widget)
     }
-  }, [editorInstance, enabled, head, relativePath, revision, widgetKey, worktreeId])
+  }, [contentsSource, editorInstance, enabled, head, relativePath, revision, widgetKey, worktreeId])
 }

--- a/src/renderer/src/components/editor/useGitLineBlame.ts
+++ b/src/renderer/src/components/editor/useGitLineBlame.ts
@@ -1,0 +1,191 @@
+import { useEffect, useRef } from 'react'
+import type { editor } from 'monaco-editor'
+import { translate } from '@/i18n/i18n'
+import { getConnectionId } from '@/lib/connection-context'
+import { monaco } from '@/lib/monaco-setup'
+import { openGitBlameCommitDiff } from '@/lib/open-git-blame-commit-diff'
+import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
+import { getRuntimeGitBlame } from '@/runtime/runtime-git-client'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import {
+  getRepoIdFromWorktreeId,
+  splitWorktreeIdForFilesystem
+} from '../../../../shared/worktree/id'
+import { blameLineByNumber, type GitBlameResult } from '../../../../shared/git-blame'
+import {
+  buildGitLineBlameWidgetModel,
+  GIT_LINE_BLAME_INLINE_CLASS
+} from './git-line-blame-decorations'
+
+const BLAME_FETCH_DEBOUNCE_MS = 80
+
+export function useGitLineBlame(args: {
+  editor: editor.ICodeEditor | editor.IStandaloneCodeEditor | null
+  enabled: boolean
+  worktreeId?: string
+  relativePath: string
+  revision?: string
+  widgetKey?: string
+}): void {
+  const {
+    editor: editorInstance,
+    enabled,
+    worktreeId,
+    relativePath,
+    revision,
+    widgetKey = 'file'
+  } = args
+  const head = useAppStore((state) =>
+    worktreeId ? (state.gitStatusHeadByWorktree[worktreeId] ?? null) : null
+  )
+  const blameRef = useRef<GitBlameResult | null>(null)
+  const lineRef = useRef(1)
+
+  useEffect(() => {
+    if (!editorInstance || !enabled || !worktreeId || relativePath.length === 0) {
+      blameRef.current = null
+      return
+    }
+
+    const uncommittedLabel = translate(
+      'auto.components.editor.gitLineBlame.uncommittedLabel',
+      'Not Committed Yet'
+    )
+    const node = document.createElement('div')
+    node.className = GIT_LINE_BLAME_INLINE_CLASS
+    node.style.display = 'none'
+    let widgetPosition: editor.IContentWidgetPosition | null = null
+    const widget: editor.IContentWidget = {
+      // Why: overflow widgets are clamped into the viewport, which slides a
+      // long annotation to the editor's left edge instead of keeping it at EOL.
+      allowEditorOverflow: false,
+      suppressMouseDown: true,
+      getId: () => `orca.git-line-blame.${widgetKey}.${worktreeId}.${relativePath}`,
+      getDomNode: () => node,
+      getPosition: () => widgetPosition
+    }
+    editorInstance.addContentWidget(widget)
+
+    const hide = (): void => {
+      node.style.display = 'none'
+      node.textContent = ''
+      widgetPosition = null
+      editorInstance.layoutContentWidget(widget)
+    }
+
+    const renderLine = (lineNumber: number): void => {
+      lineRef.current = lineNumber
+      const blameLine = blameLineByNumber(blameRef.current?.lines ?? [], lineNumber)
+      const model = editorInstance.getModel()
+      if (!blameLine || !model) {
+        hide()
+        return
+      }
+      const widgetModel = buildGitLineBlameWidgetModel(blameLine, model.getLineCount(), {
+        uncommittedLabel,
+        endColumn: model.getLineMaxColumn(lineNumber)
+      })
+      if (!widgetModel) {
+        hide()
+        return
+      }
+      const fontInfo = editorInstance.getOption(monaco.editor.EditorOption.fontInfo)
+      const lineHeight = editorInstance.getOption(monaco.editor.EditorOption.lineHeight)
+      node.textContent = widgetModel.text
+      node.style.display = 'block'
+      node.style.height = `${lineHeight}px`
+      node.style.fontFamily = fontInfo.fontFamily
+      node.style.fontSize = `${Math.max(11, fontInfo.fontSize - 1)}px`
+      node.style.lineHeight = `${lineHeight}px`
+      widgetPosition = {
+        position: { lineNumber, column: widgetModel.column },
+        preference: [monaco.editor.ContentWidgetPositionPreference.EXACT],
+        positionAffinity: monaco.editor.PositionAffinity.Right
+      }
+      editorInstance.layoutContentWidget(widget)
+    }
+
+    const position = editorInstance.getPosition()
+    if (position) {
+      lineRef.current = position.lineNumber
+    }
+
+    let cancelled = false
+    let debounce: ReturnType<typeof setTimeout> | null = null
+    const load = (): void => {
+      if (debounce) {
+        clearTimeout(debounce)
+      }
+      debounce = setTimeout(() => {
+        const state = useAppStore.getState()
+        const worktree = findWorktreeById(state.worktreesByRepo, worktreeId)
+        const worktreePath =
+          worktree?.path ?? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath ?? null
+        if (!worktreePath) {
+          return
+        }
+        const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+        const repo = state.repos.find((entry) => entry.id === repoId) ?? null
+        void getRuntimeGitBlame(
+          {
+            settings: getRepoOwnerRoutedSettings(state.settings, repo),
+            worktreeId,
+            worktreePath,
+            connectionId: getConnectionId(worktreeId) ?? undefined
+          },
+          relativePath,
+          revision
+        )
+          .then((result) => {
+            if (cancelled) {
+              return
+            }
+            blameRef.current = result
+            renderLine(lineRef.current)
+          })
+          .catch(() => {
+            if (cancelled) {
+              return
+            }
+            blameRef.current = { status: 'unavailable', lines: [] }
+            hide()
+          })
+      }, BLAME_FETCH_DEBOUNCE_MS)
+    }
+
+    const onAnnotationMouseDown = (event: MouseEvent): void => {
+      event.preventDefault()
+      event.stopPropagation()
+      const blameLine = blameLineByNumber(blameRef.current?.lines ?? [], lineRef.current)
+      if (!blameLine) {
+        return
+      }
+      void openGitBlameCommitDiff(worktreeId, blameLine)
+    }
+    node.addEventListener('mousedown', onAnnotationMouseDown)
+
+    load()
+    const cursorSub = editorInstance.onDidChangeCursorPosition((event) => {
+      renderLine(event.position.lineNumber)
+    })
+    const contentSub = editorInstance.onDidChangeModelContent(() => {
+      renderLine(lineRef.current)
+    })
+    const configSub = editorInstance.onDidChangeConfiguration(() => {
+      renderLine(lineRef.current)
+    })
+
+    return () => {
+      cancelled = true
+      if (debounce) {
+        clearTimeout(debounce)
+      }
+      node.removeEventListener('mousedown', onAnnotationMouseDown)
+      cursorSub.dispose()
+      contentSub.dispose()
+      configSub.dispose()
+      editorInstance.removeContentWidget(widget)
+    }
+  }, [editorInstance, enabled, head, relativePath, revision, widgetKey, worktreeId])
+}

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -20,6 +20,7 @@ import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
 import { DiffShowWhitespaceSetting } from './DiffShowWhitespaceSetting'
 import { EditorWordWrapSetting } from './EditorWordWrapSetting'
 import { EditorFontFamilySetting } from './EditorFontFamilySetting'
+import { GitLineBlameSetting } from './GitLineBlameSetting'
 import {
   createAutoSaveDelayDraftState,
   resolveAutoSaveDelayDraftState,
@@ -365,6 +366,8 @@ export function GeneralEditorSettingsSection({
           onChange={() => updateSettings({ editorMinimapEnabled: !settings.editorMinimapEnabled })}
         />
       </SearchableSetting>
+
+      <GitLineBlameSetting settings={settings} updateSettings={updateSettings} />
 
       <RichMarkdownSpellcheckSetting settings={settings} updateSettings={updateSettings} />
 

--- a/src/renderer/src/components/settings/GitLineBlameSetting.tsx
+++ b/src/renderer/src/components/settings/GitLineBlameSetting.tsx
@@ -1,0 +1,45 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+
+type GitLineBlameSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function GitLineBlameSetting({
+  settings,
+  updateSettings
+}: GitLineBlameSettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.gitLineBlame',
+        'Git Line Blame'
+      )}
+      description={translate(
+        'auto.components.settings.GeneralEditorSettingsSection.gitLineBlameDesc',
+        'Show who last changed the current line. Click the annotation to open that commit’s diff.'
+      )}
+      keywords={['git', 'blame', 'gitlens', 'author', 'commit']}
+    >
+      <SettingsSwitchRow
+        label={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.gitLineBlame',
+          'Git Line Blame'
+        )}
+        description={translate(
+          'auto.components.settings.GeneralEditorSettingsSection.gitLineBlameDesc',
+          'Show who last changed the current line. Click the annotation to open that commit’s diff.'
+        )}
+        checked={settings.editorGitLineBlameEnabled !== false}
+        onChange={() =>
+          updateSettings({
+            editorGitLineBlameEnabled: settings.editorGitLineBlameEnabled === false
+          })
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/general-editor-search.ts
+++ b/src/renderer/src/components/settings/general-editor-search.ts
@@ -106,6 +106,20 @@ export const getGeneralEditorSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate('auto.components.settings.general.search.gitLineBlame', 'Git Line Blame'),
+    description: translate(
+      'auto.components.settings.general.search.gitLineBlameDesc',
+      'Show who last changed the current line. Click the annotation to open that commit’s diff.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.general.search.gitKw', 'git'),
+      ...translateSearchKeyword('auto.components.settings.general.search.blameKw', 'blame'),
+      ...translateSearchKeyword('auto.components.settings.general.search.gitlensKw', 'gitlens'),
+      ...translateSearchKeyword('auto.components.settings.general.search.authorKw', 'author'),
+      ...translateSearchKeyword('auto.components.settings.general.search.commitKw', 'commit')
+    ]
+  },
+  {
     title: translate(
       'auto.components.settings.general.search.d2d2d929c0',
       'Rich Markdown Spellcheck'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6990,6 +6990,8 @@
           "80c454e8a6": "Match this to your provider's cache TTL."
         },
         "GeneralEditorSettingsSection": {
+          "gitLineBlame": "Git Line Blame",
+          "gitLineBlameDesc": "Show who last changed the current line. Click the annotation to open that commit’s diff.",
           "f80603d293": "Show local markdown note controls in rich editor mode and agent handoff actions.",
           "4edc104f0f": "Markdown Review Notes",
           "5f02e6fb21": "Show local markdown review note controls in rich editor mode.",
@@ -9410,6 +9412,13 @@
             "e3919429c0": "overview",
             "9c72990db8": "minimap",
             "716a4dfb1f": "Show the minimap overview when editing a file.",
+            "gitLineBlame": "Git Line Blame",
+            "gitLineBlameDesc": "Show who last changed the current line. Click the annotation to open that commit’s diff.",
+            "gitKw": "git",
+            "blameKw": "blame",
+            "gitlensKw": "gitlens",
+            "authorKw": "author",
+            "commitKw": "commit",
             "6f584fcb48": "Minimap",
             "19baae651b": "sidebar",
             "973ed6bfbf": "combined diff",
@@ -14259,6 +14268,11 @@
         }
       },
       "editor": {
+        "gitLineBlame": {
+          "uncommittedLabel": "Not Committed Yet",
+          "uncommittedToast": "This line is not committed yet.",
+          "openFailed": "Failed to open commit diff"
+        },
         "ChangesModeView": {
           "ef25ae2d09": "No uncommitted changes.",
           "052c184f24": "Text diff is unavailable for this file.",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5991,6 +5991,8 @@
           "80c454e8a6": "이를 공급자의 캐시 TTL과 일치시킵니다."
         },
         "GeneralEditorSettingsSection": {
+          "gitLineBlame": "Git 줄 Blame",
+          "gitLineBlameDesc": "현재 줄을 마지막으로 바꾼 사람과 커밋을 보여 줍니다. 주석을 클릭하면 해당 커밋 diff가 열립니다.",
           "f80603d293": "리치 에디터 모드 및 agent 전달 작업에서 로컬 markdown 메모 컨트롤을 표시합니다.",
           "4edc104f0f": "Markdown 리뷰 노트",
           "5f02e6fb21": "리치 에디터 모드에서 로컬 markdown 리뷰 노트 컨트롤을 표시합니다.",
@@ -8321,6 +8323,13 @@
             "e3919429c0": "개요",
             "9c72990db8": "미니맵",
             "716a4dfb1f": "파일을 편집할 때 미니맵 개요를 표시합니다.",
+            "gitLineBlame": "Git 줄 Blame",
+            "gitLineBlameDesc": "현재 줄을 마지막으로 바꾼 사람과 커밋을 보여 줍니다. 주석을 클릭하면 해당 커밋 diff가 열립니다.",
+            "gitKw": "git",
+            "blameKw": "blame",
+            "gitlensKw": "gitlens",
+            "authorKw": "작성자",
+            "commitKw": "커밋",
             "6f584fcb48": "미니맵",
             "19baae651b": "사이드바",
             "973ed6bfbf": "결합된 차이",
@@ -12781,6 +12790,11 @@
         }
       },
       "editor": {
+        "gitLineBlame": {
+          "uncommittedLabel": "아직 커밋되지 않음",
+          "uncommittedToast": "이 줄은 아직 커밋되지 않았습니다.",
+          "openFailed": "커밋 diff를 열지 못했습니다"
+        },
         "ChangesModeView": {
           "ef25ae2d09": "commit 되지 않은 변경 사항이 없습니다.",
           "052c184f24": "이 파일에는 텍스트 비교를 사용할 수 없습니다.",

--- a/src/renderer/src/lib/open-git-blame-commit-diff.ts
+++ b/src/renderer/src/lib/open-git-blame-commit-diff.ts
@@ -1,0 +1,69 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { getConnectionId } from '@/lib/connection-context'
+import { getRepoOwnerRoutedSettings } from '@/lib/repo-runtime-owner'
+import { getRuntimeGitCommitCompare } from '@/runtime/runtime-git-client'
+import { useAppStore } from '@/store'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { isUncommittedBlameOid, type GitBlameLine } from '../../../shared/git-blame'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree/id'
+
+export async function openGitBlameCommitDiff(
+  worktreeId: string,
+  line: GitBlameLine
+): Promise<void> {
+  if (isUncommittedBlameOid(line.commitOid)) {
+    toast.info(
+      translate(
+        'auto.components.editor.gitLineBlame.uncommittedToast',
+        'This line is not committed yet.'
+      )
+    )
+    return
+  }
+
+  const state = useAppStore.getState()
+  const worktree = findWorktreeById(state.worktreesByRepo, worktreeId)
+  const worktreePath =
+    worktree?.path ?? splitWorktreeIdForFilesystem(worktreeId)?.worktreePath ?? null
+  if (!worktreePath) {
+    toast.error(
+      translate('auto.components.editor.gitLineBlame.openFailed', 'Failed to open commit diff')
+    )
+    return
+  }
+  const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
+  const repo = state.repos.find((entry) => entry.id === repoId) ?? null
+  const settings = getRepoOwnerRoutedSettings(state.settings, repo)
+  try {
+    const result = await getRuntimeGitCommitCompare(
+      {
+        settings,
+        worktreeId,
+        worktreePath,
+        connectionId: getConnectionId(worktreeId) ?? undefined
+      },
+      line.commitOid
+    )
+    if (result.summary.status !== 'ready') {
+      throw new Error(
+        result.summary.errorMessage ??
+          translate('auto.components.editor.gitLineBlame.openFailed', 'Failed to open commit diff')
+      )
+    }
+    state.openCommitAllDiffs(
+      worktreeId,
+      worktreePath,
+      result.summary,
+      result.entries,
+      line.summary,
+      line.summary
+    )
+  } catch (error) {
+    toast.error(
+      error instanceof Error
+        ? error.message
+        : translate('auto.components.editor.gitLineBlame.openFailed', 'Failed to open commit diff')
+    )
+  }
+}

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -4,6 +4,7 @@ import {
   getRuntimeGitBranchDiff as getRuntimeGitBranchDiffImplementation,
   getRuntimeGitCommitCompare as getRuntimeGitCommitCompareImplementation,
   getRuntimeGitCommitDiff as getRuntimeGitCommitDiffImplementation,
+  getRuntimeGitBlame as getRuntimeGitBlameImplementation,
   getRuntimeGitDiff as getRuntimeGitDiffImplementation
 } from './runtime-git-diff-client'
 import {
@@ -74,6 +75,7 @@ export const rebaseRuntimeGitFromBase = rebaseRuntimeGitFromBaseImplementation
 export const pushRuntimeGit = pushRuntimeGitImplementation
 export const getRuntimeGitBranchDiff = getRuntimeGitBranchDiffImplementation
 export const getRuntimeGitCommitDiff = getRuntimeGitCommitDiffImplementation
+export const getRuntimeGitBlame = getRuntimeGitBlameImplementation
 export const commitRuntimeGit = commitRuntimeGitImplementation
 export const generateRuntimeCommitMessage = generateRuntimeCommitMessageImplementation
 export const discoverRuntimeCommitMessageModels = discoverRuntimeCommitMessageModelsImplementation

--- a/src/renderer/src/runtime/runtime-git-diff-client.ts
+++ b/src/renderer/src/runtime/runtime-git-diff-client.ts
@@ -3,6 +3,7 @@ import type {
   GitCommitCompareResult,
   GitDiffResult
 } from '../../../shared/git-diff-compare-types'
+import type { GitBlameResult } from '../../../shared/git-blame'
 import { resolveLocalWorktreePath, type RuntimeGitContext } from './runtime-git-client-context'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
@@ -121,6 +122,32 @@ export async function getRuntimeGitCommitDiff(
     target,
     'git.commitDiff',
     { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...args },
+    { timeoutMs: 15_000 }
+  )
+}
+
+export async function getRuntimeGitBlame(
+  context: RuntimeGitContext,
+  filePath: string,
+  revision?: string
+): Promise<GitBlameResult> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    return window.api.git.blame({
+      worktreePath: resolveLocalWorktreePath(context),
+      filePath,
+      revision,
+      connectionId: context.connectionId
+    })
+  }
+  return callRuntimeRpc<GitBlameResult>(
+    target,
+    'git.blame',
+    {
+      worktree: toRuntimeWorktreeSelector(context.worktreeId),
+      filePath,
+      ...(revision ? { revision } : {})
+    },
     { timeoutMs: 15_000 }
   )
 }

--- a/src/renderer/src/runtime/runtime-git-diff-client.ts
+++ b/src/renderer/src/runtime/runtime-git-diff-client.ts
@@ -3,7 +3,7 @@ import type {
   GitCommitCompareResult,
   GitDiffResult
 } from '../../../shared/git-diff-compare-types'
-import type { GitBlameResult } from '../../../shared/git-blame'
+import type { GitBlameContentsSource, GitBlameResult } from '../../../shared/git-blame'
 import { resolveLocalWorktreePath, type RuntimeGitContext } from './runtime-git-client-context'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
@@ -129,7 +129,8 @@ export async function getRuntimeGitCommitDiff(
 export async function getRuntimeGitBlame(
   context: RuntimeGitContext,
   filePath: string,
-  revision?: string
+  revision?: string,
+  contentsSource?: GitBlameContentsSource
 ): Promise<GitBlameResult> {
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
@@ -137,6 +138,7 @@ export async function getRuntimeGitBlame(
       worktreePath: resolveLocalWorktreePath(context),
       filePath,
       revision,
+      contentsSource,
       connectionId: context.connectionId
     })
   }
@@ -146,7 +148,8 @@ export async function getRuntimeGitBlame(
     {
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       filePath,
-      ...(revision ? { revision } : {})
+      ...(revision ? { revision } : {}),
+      ...(contentsSource ? { contentsSource } : {})
     },
     { timeoutMs: 15_000 }
   )

--- a/src/renderer/src/web/preload-api/web-git-api.ts
+++ b/src/renderer/src/web/preload-api/web-git-api.ts
@@ -137,6 +137,14 @@ export function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
         commitId
       })
     },
+    blame: async ({ worktreePath, filePath, revision }) => {
+      const file = await resolveRuntimeFilePath(filePath, worktreePath)
+      return callRuntimeResult('git.blame', {
+        worktree: toRuntimeWorktreeSelector(file.worktree.id),
+        filePath: file.relativePath,
+        ...(revision ? { revision } : {})
+      })
+    },
     upstreamStatus: async ({ worktreePath, pushTarget }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
       return callRuntimeResult('git.upstreamStatus', {

--- a/src/renderer/src/web/preload-api/web-git-api.ts
+++ b/src/renderer/src/web/preload-api/web-git-api.ts
@@ -137,12 +137,13 @@ export function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
         commitId
       })
     },
-    blame: async ({ worktreePath, filePath, revision }) => {
+    blame: async ({ worktreePath, filePath, revision, contentsSource }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
       return callRuntimeResult('git.blame', {
         worktree: toRuntimeWorktreeSelector(file.worktree.id),
         filePath: file.relativePath,
-        ...(revision ? { revision } : {})
+        ...(revision ? { revision } : {}),
+        ...(contentsSource ? { contentsSource } : {})
       })
     },
     upstreamStatus: async ({ worktreePath, pushTarget }) => {

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -81,6 +81,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').editorWordWrap).toBe(true)
   })
 
+  it('keeps editor git line blame enabled by default', () => {
+    expect(getDefaultSettings('/tmp').editorGitLineBlameEnabled).toBe(true)
+  })
+
   it('keeps rich Markdown spellcheck enabled by default', () => {
     expect(getDefaultSettings('/tmp').richMarkdownSpellcheckEnabled).toBe(true)
   })

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -50,6 +50,7 @@ export function buildDefaultSettings(args: {
     editorAutoSave: false,
     editorAutoSaveDelayMs: args.editorAutoSaveDelayMs,
     editorMinimapEnabled: false,
+    editorGitLineBlameEnabled: true,
     // Why empty: the editor keeps following the terminal font unless the user opts in.
     editorFontFamily: '',
     editorWordWrap: true,

--- a/src/shared/git-blame.test.ts
+++ b/src/shared/git-blame.test.ts
@@ -8,7 +8,8 @@ import {
   GIT_BLAME_HEAD_REVISION,
   GIT_BLAME_INDEX_CONTENTS,
   isUncommittedBlameOid,
-  parseBlamePorcelain
+  parseBlamePorcelain,
+  parseGitBlameRevision
 } from './git-blame'
 
 const SAMPLE = [
@@ -138,5 +139,20 @@ describe('buildGitBlameArgv', () => {
       '--',
       'src/a.ts'
     ])
+  })
+})
+
+describe('parseGitBlameRevision', () => {
+  it('allows HEAD and a full object id', () => {
+    expect(parseGitBlameRevision(undefined)).toBeUndefined()
+    expect(parseGitBlameRevision(GIT_BLAME_HEAD_REVISION)).toBe(GIT_BLAME_HEAD_REVISION)
+    expect(parseGitBlameRevision('a'.repeat(40))).toBe('a'.repeat(40))
+  })
+
+  it('rejects a flag-like revision that would sit before end-of-options', () => {
+    expect(() => parseGitBlameRevision('--output=/tmp/pwned')).toThrow(
+      'revision must be a full git object id'
+    )
+    expect(() => parseGitBlameRevision('HEAD~1')).toThrow('revision must be a full git object id')
   })
 })

--- a/src/shared/git-blame.test.ts
+++ b/src/shared/git-blame.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   blameLineByNumber,
   buildGitBlameArgv,
+  buildGitShowIndexArgv,
   formatBlameAnnotation,
   formatBlameRelativeTime,
   GIT_BLAME_HEAD_REVISION,
+  GIT_BLAME_INDEX_CONTENTS,
   isUncommittedBlameOid,
   parseBlamePorcelain
 } from './git-blame'
@@ -120,5 +122,21 @@ describe('buildGitBlameArgv', () => {
     ).toBeLessThan(
       buildGitBlameArgv('src/a.ts', GIT_BLAME_HEAD_REVISION).indexOf('--end-of-options')
     )
+  })
+
+  it('blames stdin contents against HEAD for the index', () => {
+    expect(buildGitShowIndexArgv('src\\a.ts')).toEqual(['show', '--end-of-options', ':src/a.ts'])
+    expect(buildGitBlameArgv('src/a.ts', undefined, GIT_BLAME_INDEX_CONTENTS)).toEqual([
+      'blame',
+      '--encoding=UTF-8',
+      '--line-porcelain',
+      '-w',
+      '--contents',
+      '-',
+      GIT_BLAME_HEAD_REVISION,
+      '--end-of-options',
+      '--',
+      'src/a.ts'
+    ])
   })
 })

--- a/src/shared/git-blame.test.ts
+++ b/src/shared/git-blame.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import {
+  blameLineByNumber,
+  buildGitBlameArgv,
+  formatBlameAnnotation,
+  formatBlameRelativeTime,
+  GIT_BLAME_HEAD_REVISION,
+  isUncommittedBlameOid,
+  parseBlamePorcelain
+} from './git-blame'
+
+const SAMPLE = [
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1 1 2',
+  'author Ada Lovelace',
+  'author-mail <ada@example.com>',
+  'author-time 1700000000',
+  'author-tz +0000',
+  'summary Add parser',
+  'filename src/git-blame.ts',
+  '\texport function parse() {',
+  'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 2 2',
+  'filename src/git-blame.ts',
+  '\t  return []',
+  '0000000000000000000000000000000000000000 3 3 1',
+  'author Not Committed Yet',
+  'author-mail <not.committed.yet>',
+  'author-time 1700000060',
+  'summary uncommitted',
+  'filename src/git-blame.ts',
+  '\t}'
+].join('\n')
+
+describe('parseBlamePorcelain', () => {
+  it('keeps author metadata across grouped lines and marks the zero oid', () => {
+    const lines = parseBlamePorcelain(SAMPLE)
+    expect(lines).toEqual([
+      {
+        line: 1,
+        commitOid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        author: 'Ada Lovelace',
+        authorTime: 1700000000,
+        summary: 'Add parser'
+      },
+      {
+        line: 2,
+        commitOid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        author: 'Ada Lovelace',
+        authorTime: 1700000000,
+        summary: 'Add parser'
+      },
+      {
+        line: 3,
+        commitOid: '0000000000000000000000000000000000000000',
+        author: 'Not Committed Yet',
+        authorTime: 1700000060,
+        summary: 'uncommitted'
+      }
+    ])
+    expect(isUncommittedBlameOid(lines[2]?.commitOid ?? '')).toBe(true)
+    expect(blameLineByNumber(lines, 2)?.author).toBe('Ada Lovelace')
+    expect(blameLineByNumber(lines, 99)).toBeNull()
+  })
+})
+
+describe('formatBlameAnnotation', () => {
+  it('uses the uncommitted label for a zero oid', () => {
+    expect(
+      formatBlameAnnotation({
+        line: 1,
+        commitOid: '0000000000000000000000000000000000000000',
+        author: 'Not Committed Yet',
+        authorTime: 1,
+        summary: 'wip'
+      })
+    ).toBe('Not Committed Yet')
+  })
+
+  it('joins author, relative time, and a clipped summary', () => {
+    const annotation = formatBlameAnnotation(
+      {
+        line: 1,
+        commitOid: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        author: 'Ada',
+        authorTime: 1_700_000_000,
+        summary: 'x'.repeat(60)
+      },
+      { uncommittedLabel: 'Not Committed Yet', nowMs: 1_700_000_000 * 1000 + 3_600_000 }
+    )
+    expect(annotation.startsWith('Ada, ')).toBe(true)
+    expect(annotation).toContain('• ')
+    expect(annotation.endsWith('…')).toBe(true)
+  })
+})
+
+describe('formatBlameRelativeTime', () => {
+  it('returns an empty string for a missing timestamp', () => {
+    expect(formatBlameRelativeTime(0)).toBe('')
+  })
+})
+
+describe('buildGitBlameArgv', () => {
+  it('blames the working tree when no revision is given', () => {
+    expect(buildGitBlameArgv('src/a.ts')).toEqual([
+      'blame',
+      '--encoding=UTF-8',
+      '--line-porcelain',
+      '-w',
+      '--end-of-options',
+      '--',
+      'src/a.ts'
+    ])
+  })
+
+  it('places a revision before end-of-options', () => {
+    expect(buildGitBlameArgv('src/a.ts', GIT_BLAME_HEAD_REVISION)).toContain(
+      GIT_BLAME_HEAD_REVISION
+    )
+    expect(
+      buildGitBlameArgv('src/a.ts', GIT_BLAME_HEAD_REVISION).indexOf(GIT_BLAME_HEAD_REVISION)
+    ).toBeLessThan(
+      buildGitBlameArgv('src/a.ts', GIT_BLAME_HEAD_REVISION).indexOf('--end-of-options')
+    )
+  })
+})

--- a/src/shared/git-blame.ts
+++ b/src/shared/git-blame.ts
@@ -16,18 +16,32 @@ export type GitBlameResult = {
 const HEADER_LINE_RE = /^([0-9a-fA-F]+)\s+\d+\s+(\d+)(?:\s+\d+)?$/
 
 export const GIT_BLAME_HEAD_REVISION = 'HEAD'
+export const GIT_BLAME_INDEX_CONTENTS = 'index' as const
+
+export type GitBlameContentsSource = typeof GIT_BLAME_INDEX_CONTENTS
 
 export function isUncommittedBlameOid(oid: string): boolean {
   return oid.length > 0 && GIT_BLAME_ZERO_OID_RE.test(oid)
 }
 
-export function buildGitBlameArgv(filePath: string, revision?: string): string[] {
+export function buildGitShowIndexArgv(filePath: string): string[] {
+  return ['show', '--end-of-options', `:${filePath.replace(/\\/g, '/')}`]
+}
+
+export function buildGitBlameArgv(
+  filePath: string,
+  revision?: string,
+  contentsSource?: GitBlameContentsSource
+): string[] {
+  const blameRevision =
+    revision ?? (contentsSource === GIT_BLAME_INDEX_CONTENTS ? GIT_BLAME_HEAD_REVISION : undefined)
   return [
     'blame',
     '--encoding=UTF-8',
     '--line-porcelain',
     '-w',
-    ...(revision ? [revision] : []),
+    ...(contentsSource === GIT_BLAME_INDEX_CONTENTS ? ['--contents', '-'] : []),
+    ...(blameRevision ? [blameRevision] : []),
     '--end-of-options',
     '--',
     filePath

--- a/src/shared/git-blame.ts
+++ b/src/shared/git-blame.ts
@@ -1,0 +1,133 @@
+export const GIT_BLAME_ZERO_OID_RE = /^0+$/
+
+export type GitBlameLine = {
+  line: number
+  commitOid: string
+  author: string
+  authorTime: number
+  summary: string
+}
+
+export type GitBlameResult = {
+  status: 'ready' | 'unavailable'
+  lines: GitBlameLine[]
+}
+
+const HEADER_LINE_RE = /^([0-9a-fA-F]+)\s+\d+\s+(\d+)(?:\s+\d+)?$/
+
+export const GIT_BLAME_HEAD_REVISION = 'HEAD'
+
+export function isUncommittedBlameOid(oid: string): boolean {
+  return oid.length > 0 && GIT_BLAME_ZERO_OID_RE.test(oid)
+}
+
+export function buildGitBlameArgv(filePath: string, revision?: string): string[] {
+  return [
+    'blame',
+    '--encoding=UTF-8',
+    '--line-porcelain',
+    '-w',
+    ...(revision ? [revision] : []),
+    '--end-of-options',
+    '--',
+    filePath
+  ]
+}
+
+export function parseBlamePorcelain(stdout: string): GitBlameLine[] {
+  const lines: GitBlameLine[] = []
+  let pendingOid = ''
+  let pendingLine = 0
+  let author = ''
+  let authorTime = 0
+  let summary = ''
+
+  for (const raw of stdout.split('\n')) {
+    if (raw.startsWith('\t')) {
+      if (pendingLine > 0 && pendingOid) {
+        lines.push({
+          line: pendingLine,
+          commitOid: pendingOid,
+          author,
+          authorTime,
+          summary
+        })
+      }
+      pendingOid = ''
+      pendingLine = 0
+      continue
+    }
+
+    const header = HEADER_LINE_RE.exec(raw)
+    if (header) {
+      pendingOid = header[1] ?? ''
+      pendingLine = Number(header[2])
+      continue
+    }
+
+    if (raw.startsWith('author ')) {
+      author = raw.slice('author '.length)
+      continue
+    }
+    if (raw.startsWith('author-time ')) {
+      const parsed = Number(raw.slice('author-time '.length))
+      authorTime = Number.isFinite(parsed) ? parsed : 0
+      continue
+    }
+    if (raw.startsWith('summary ')) {
+      summary = raw.slice('summary '.length)
+    }
+  }
+
+  return lines
+}
+
+export function blameLineByNumber(
+  lines: readonly GitBlameLine[],
+  lineNumber: number
+): GitBlameLine | null {
+  return lines.find((line) => line.line === lineNumber) ?? null
+}
+
+export function formatBlameRelativeTime(epochSeconds: number, nowMs: number = Date.now()): string {
+  if (!Number.isFinite(epochSeconds) || epochSeconds <= 0) {
+    return ''
+  }
+  const deltaSeconds = Math.round(nowMs / 1000 - epochSeconds)
+  const abs = Math.abs(deltaSeconds)
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  if (abs < 60) {
+    return formatter.format(-deltaSeconds, 'second')
+  }
+  if (abs < 3600) {
+    return formatter.format(-Math.round(deltaSeconds / 60), 'minute')
+  }
+  if (abs < 86400) {
+    return formatter.format(-Math.round(deltaSeconds / 3600), 'hour')
+  }
+  if (abs < 2_592_000) {
+    return formatter.format(-Math.round(deltaSeconds / 86400), 'day')
+  }
+  if (abs < 31_536_000) {
+    return formatter.format(-Math.round(deltaSeconds / 2_592_000), 'month')
+  }
+  return formatter.format(-Math.round(deltaSeconds / 31_536_000), 'year')
+}
+
+export function formatBlameAnnotation(
+  line: GitBlameLine,
+  options: { uncommittedLabel: string; nowMs?: number } = { uncommittedLabel: 'Not Committed Yet' }
+): string {
+  if (isUncommittedBlameOid(line.commitOid)) {
+    return options.uncommittedLabel
+  }
+  const relative = formatBlameRelativeTime(line.authorTime, options.nowMs)
+  const summary = line.summary.trim()
+  const parts = [line.author.trim() || 'Unknown', relative].filter((part) => part.length > 0)
+  const prefix = parts.join(', ')
+  if (!summary) {
+    return prefix
+  }
+  const clipped = summary.length > 50 ? `${summary.slice(0, 49)}…` : summary
+  return `${prefix} • ${clipped}`
+}

--- a/src/shared/git-blame.ts
+++ b/src/shared/git-blame.ts
@@ -20,6 +20,21 @@ export const GIT_BLAME_INDEX_CONTENTS = 'index' as const
 
 export type GitBlameContentsSource = typeof GIT_BLAME_INDEX_CONTENTS
 
+const FULL_GIT_OBJECT_ID_RE = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/
+
+export function parseGitBlameRevision(revision: unknown): string | undefined {
+  if (revision == null || revision === '') {
+    return undefined
+  }
+  if (revision === GIT_BLAME_HEAD_REVISION) {
+    return GIT_BLAME_HEAD_REVISION
+  }
+  if (typeof revision !== 'string' || !FULL_GIT_OBJECT_ID_RE.test(revision)) {
+    throw new Error('revision must be a full git object id')
+  }
+  return revision
+}
+
 export function isUncommittedBlameOid(oid: string): boolean {
   return oid.length > 0 && GIT_BLAME_ZERO_OID_RE.test(oid)
 }

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -84,6 +84,8 @@ export type GlobalSettings = {
   editorAutoSave: boolean
   editorAutoSaveDelayMs: number
   editorMinimapEnabled: boolean
+  /** Current-line git blame annotation. Absent on older profiles; treated as on. */
+  editorGitLineBlameEnabled?: boolean
   /** Opt-in code-editor font; empty (the default) keeps following `terminalFontFamily`. */
   editorFontFamily?: string
   /** Defaults on for profiles saved before file-editor wrapping became configurable. */


### PR DESCRIPTION
## ELI5

When the cursor sits on a line, Orca now shows who last changed it at the end of that line — in the file editor and in git diff views. Click the annotation to open that commit’s diff.

## What Changed

- Current-line GitLens-style annotation (`author, relative time • summary`) at EOL via a Monaco content widget.
- Same annotation in file diffs, Changes mode, and combined/source-control diffs. Each pane blames the revision that pane actually shows (`HEAD`/parent vs working tree or commit/branch oid).
- Toggle under Settings → General → Git Line Blame (default on).
- `git.blame` through local IPC, runtime RPC, SSH provider, and relay.

## Why

#9948 asks for inline authorship while reviewing code. Existing work in #13321 covers the file-editor / status-bar surface and is the more complete take on caching, dirty buffers, and remote capability gating. This PR is meant as a complement: **diff windows**, which #13321 currently skips on purpose (read-only tabs).

The editor plumbing is included only because `main` has no blame API yet. If #13321 lands first, I am happy to rebase this down to the diff-view pieces (or close it and re-open that slice on top of theirs).

## Linked Issue

Related to #9948
Related to #13321
Related to #8947

## Visual Proof

Not attached in this upload — I can add screenshots of the file editor and a side-by-side diff after the first review pass. The annotation is dim italic text after the last character of the cursor line; long summaries ellipsis at 60ch and stay anchored at EOL (`allowEditorOverflow: false`).

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Targeted vitest: parser, real-git blame, RPC `git.blame`, SSH method list, relay handler, widget model, diff revision helper (9 files / 97 tests). Pre-commit oxlint + oxfmt on the touched files passed. Full `pnpm lint` / `typecheck` / `test` / `build` not run locally — relying on CI.

Reviewer steps: open a tracked file, click a line, confirm the annotation sits at EOL; open an unstaged diff and a commit diff and click lines on both panes.

Platforms exercised: macOS local git. Linux / Windows / SSH not manually verified in this pass.

## AI Disclosure

Implemented with Cursor (Grok 4.6).

## Review

AI review (cross-platform, SSH, performance, security):

- **Cross-platform:** blame argv is a fixed array through the central git runner (no shell). Porcelain parse splits on `\n`; Windows CRLF on header values is not specially normalized beyond that.
- **SSH/remote:** `IGitProvider.getBlame`, relay `blame` op, and `git.blame` on the mobile RPC allowlist. Older relays without the method should fail closed (no annotation) rather than crash the editor. No advertised capability gate like #13321’s `git.blame.v1` — if that is required, I will add it.
- **Performance:** one whole-file `git blame --line-porcelain` per file (debounced 80ms). No in-memory file cache / TTL; cursor moves only re-render. Large files can hitch; this is weaker than #13321’s cache.
- **Security:** path is `validateGitRelativeFilePath`; revision is `HEAD` or a full object id only. No `--contents` / `-S`.
- **UI:** content widget at EOL, not injected text, so it should not reflow source. Dirty buffers are not hidden — unsaved edits can misattribute lines (known gap vs #13321).

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Not trying to replace #13321. Distinctive slice is blame inside git diff views. Happy to trim or close if maintainers would rather take #13321 and have diff views as a later follow-up.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)