### PR TITLE
[CI CONTROL — do not merge] baseline SSH e2e at 79d5fb4

### DIFF
--- a/src/main/ssh/ssh-relay-endpoint-incumbent.ts
+++ b/src/main/ssh/ssh-relay-endpoint-incumbent.ts
@@ -24,6 +24,7 @@ import { execCommand, isUnconfirmedSshCommandTermination } from './ssh-relay-dep
 import { isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
 
 // CI control experiment: comment-only edit to select the SSH e2e lane. No behavior change.
+// Re-pushed after marking the PR ready: pr.yml gates the e2e lane on draft != true.
 export type RelayEndpointVerdict = 'live' | 'unverifiable' | 'exited'
 
 export type RelayEndpointEvidence =

--- a/src/main/ssh/ssh-relay-endpoint-incumbent.ts
+++ b/src/main/ssh/ssh-relay-endpoint-incumbent.ts
@@ -23,6 +23,7 @@ import { shellEscape } from './ssh-connection-utils'
 import { execCommand, isUnconfirmedSshCommandTermination } from './ssh-relay-deploy-helpers'
 import { isWindowsRemoteHost, type RemoteHostPlatform } from './ssh-remote-platform'
 
+// CI control experiment: comment-only edit to select the SSH e2e lane. No behavior change.
 export type RelayEndpointVerdict = 'live' | 'unverifiable' | 'exited'
 
 export type RelayEndpointEvidence =


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

Control experiment for #18586. Comment-only edit to `src/main/ssh/ssh-relay-endpoint-incumbent.ts`, based on exactly `79d5fb469a31` — the same base as #18586 — so the changed-e2e detector selects the identical SSH docker lane with zero behavior change.

Purpose: determine whether `ssh-cold-activation-restore.spec.ts:40`, `:212` and `ssh-port-forward-lifecycle.spec.ts:52` fail on this base independently of #18586.

**Do not merge. Close once the e2e lane reports.**