### PR TITLE
Add localization for activity view and sidebar

### DIFF
--- a/src/renderer/src/components/activity/activity-thread-presentation.ts
+++ b/src/renderer/src/components/activity/activity-thread-presentation.ts
@@ -1,4 +1,4 @@
-import { agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import type { AgentDotState } from '@/components/AgentStateDot'
 import { formatAgentTypeLabel } from '@/lib/agent-status'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { showsAgentToolPreview } from '@/lib/agent-row-tool-preview'
@@ -112,21 +112,42 @@ export function threadAgentStateLabel(thread: AgentPaneThread): string {
   if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
     return translate('auto.components.activity.ActivityPrototypePage.interrupted', 'Interrupted')
   }
-  const labels: Partial<Record<AgentDotState, [string, string]>> = {
-    working: ['working', 'Working'],
-    monitoring: ['monitoring', 'Monitoring background tasks'],
-    blocked: ['blocked', 'Blocked'],
-    waiting: ['waiting', 'Waiting for input'],
-    failed: ['failed', 'Failed'],
-    done: ['done', 'Done'],
-    idle: ['idle', 'Idle'],
-    unverifiable: ['unverifiable', 'No recent update'],
-    permission: ['permission', 'Needs permission']
+  // Literal keys with literal fallbacks: a dynamic key registers no catalog reference
+  // and forces every state string into the boot bundle.
+  switch (state) {
+    case 'working':
+      return translate('auto.components.activity.ActivityPrototypePage.state.working', 'Working')
+    case 'monitoring':
+      return translate(
+        'auto.components.activity.ActivityPrototypePage.state.monitoring',
+        'Monitoring background tasks'
+      )
+    case 'blocked':
+      return translate('auto.components.activity.ActivityPrototypePage.state.blocked', 'Blocked')
+    case 'waiting':
+      return translate(
+        'auto.components.activity.ActivityPrototypePage.state.waiting',
+        'Waiting for input'
+      )
+    case 'interrupted':
+      return translate('auto.components.activity.ActivityPrototypePage.interrupted', 'Interrupted')
+    case 'failed':
+      return translate('auto.components.activity.ActivityPrototypePage.state.failed', 'Failed')
+    case 'done':
+      return translate('auto.components.activity.ActivityPrototypePage.state.done', 'Done')
+    case 'idle':
+      return translate('auto.components.activity.ActivityPrototypePage.state.idle', 'Idle')
+    case 'unverifiable':
+      return translate(
+        'auto.components.activity.ActivityPrototypePage.state.unverifiable',
+        'No recent update'
+      )
+    case 'permission':
+      return translate(
+        'auto.components.activity.ActivityPrototypePage.state.permission',
+        'Needs permission'
+      )
   }
-  const entry = labels[state]
-  return entry
-    ? translate(`auto.components.activity.ActivityPrototypePage.state.${entry[0]}`, entry[1])
-    : agentStateLabel(state)
 }
 
 export type ActivityThreadStatusKind = 'tool' | 'message' | 'state' | 'none'

--- a/src/renderer/src/components/activity/activity-thread-presentation.ts
+++ b/src/renderer/src/components/activity/activity-thread-presentation.ts
@@ -8,6 +8,7 @@ import {
   resolveActivityThreadStatusPreview
 } from '@/lib/activity-thread-display'
 import { formatUiRelativeTime } from '@/i18n/relative-time-format'
+import { translate } from '@/i18n/i18n'
 import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { ActivityEvent, AgentPaneThread } from './activity-thread-types'
@@ -109,9 +110,23 @@ export function threadAgentState(thread: AgentPaneThread): AgentDotState {
 export function threadAgentStateLabel(thread: AgentPaneThread): string {
   const state = threadAgentState(thread)
   if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
-    return 'Interrupted'
+    return translate('auto.components.activity.ActivityPrototypePage.interrupted', 'Interrupted')
   }
-  return agentStateLabel(state)
+  const labels: Partial<Record<AgentDotState, [string, string]>> = {
+    working: ['working', 'Working'],
+    monitoring: ['monitoring', 'Monitoring background tasks'],
+    blocked: ['blocked', 'Blocked'],
+    waiting: ['waiting', 'Waiting for input'],
+    failed: ['failed', 'Failed'],
+    done: ['done', 'Done'],
+    idle: ['idle', 'Idle'],
+    unverifiable: ['unverifiable', 'No recent update'],
+    permission: ['permission', 'Needs permission']
+  }
+  const entry = labels[state]
+  return entry
+    ? translate(`auto.components.activity.ActivityPrototypePage.state.${entry[0]}`, entry[1])
+    : agentStateLabel(state)
 }
 
 export type ActivityThreadStatusKind = 'tool' | 'message' | 'state' | 'none'

--- a/src/renderer/src/components/activity/activity-thread-presentation.ts
+++ b/src/renderer/src/components/activity/activity-thread-presentation.ts
@@ -145,7 +145,7 @@ export function threadAgentStateLabel(thread: AgentPaneThread): string {
     case 'permission':
       return translate(
         'auto.components.activity.ActivityPrototypePage.state.permission',
-        'Needs permission'
+        'Needs attention'
       )
   }
 }

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -36,10 +36,10 @@ const SidebarHeader = React.memo(function SidebarHeader({
   const acknowledgeIntro = React.useCallback(() => {
     void updateSettings?.({ agentsSidebarIntroShown: true })
   }, [updateSettings])
-  const sidebarTitle = translate(
-    groupBy === 'repo' ? 'dashboard.sidebar.projects' : 'dashboard.sidebar.workspaces',
-    groupBy === 'repo' ? 'Projects' : 'Workspaces'
-  )
+  const sidebarTitle =
+    groupBy === 'repo'
+      ? translate('dashboard.sidebar.projects', 'Projects')
+      : translate('dashboard.sidebar.workspaces', 'Workspaces')
   const activityLabel = translate(
     agentsViewActive ? 'dashboard.sidebar.closeActivity' : 'dashboard.sidebar.openActivity',
     agentsViewActive ? 'Turn off activity view' : 'View activity'

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -36,7 +36,10 @@ const SidebarHeader = React.memo(function SidebarHeader({
   const acknowledgeIntro = React.useCallback(() => {
     void updateSettings?.({ agentsSidebarIntroShown: true })
   }, [updateSettings])
-  const sidebarTitle = groupBy === 'repo' ? 'Projects' : 'Workspaces'
+  const sidebarTitle = translate(
+    groupBy === 'repo' ? 'dashboard.sidebar.projects' : 'dashboard.sidebar.workspaces',
+    groupBy === 'repo' ? 'Projects' : 'Workspaces'
+  )
   const activityLabel = translate(
     agentsViewActive ? 'dashboard.sidebar.closeActivity' : 'dashboard.sidebar.openActivity',
     agentsViewActive ? 'Turn off activity view' : 'View activity'

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -195,7 +195,18 @@
         "ActivityPrototypePage": {
           "770d458144": "Group by",
           "a472a14700": "More options",
-          "beb2c19173": "Unread"
+          "beb2c19173": "Unread",
+          "state": {
+            "blocked": "Blocked",
+            "done": "Done",
+            "failed": "Failed",
+            "idle": "Idle",
+            "monitoring": "Monitoring background tasks",
+            "permission": "Needs permission",
+            "unverifiable": "No recent update",
+            "waiting": "Waiting for input",
+            "working": "Working"
+          }
         },
         "ActivityScopeFilterControls": {
           "hiddenCount": "{{value0}} hidden"
@@ -2701,7 +2712,9 @@
     "sidebar": {
       "closeActivity": "Turn off activity view",
       "label": "Agents",
-      "openActivity": "View activity"
+      "openActivity": "View activity",
+      "projects": "Projects",
+      "workspaces": "Workspaces"
     }
   },
   "dashboardPopout": {

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -195,18 +195,7 @@
         "ActivityPrototypePage": {
           "770d458144": "Group by",
           "a472a14700": "More options",
-          "beb2c19173": "Unread",
-          "state": {
-            "blocked": "Blocked",
-            "done": "Done",
-            "failed": "Failed",
-            "idle": "Idle",
-            "monitoring": "Monitoring background tasks",
-            "permission": "Needs permission",
-            "unverifiable": "No recent update",
-            "waiting": "Waiting for input",
-            "working": "Working"
-          }
+          "beb2c19173": "Unread"
         },
         "ActivityScopeFilterControls": {
           "hiddenCount": "{{value0}} hidden"
@@ -2712,9 +2701,7 @@
     "sidebar": {
       "closeActivity": "Turn off activity view",
       "label": "Agents",
-      "openActivity": "View activity",
-      "projects": "Projects",
-      "workspaces": "Workspaces"
+      "openActivity": "View activity"
     }
   },
   "dashboardPopout": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16218,7 +16218,19 @@
           "showUnreadOnly": "Show unread only",
           "showChildAgents": "Show child agents",
           "activityOptions": "Activity options",
-          "threadListOptionsFiltered": "Thread list options, filters active"
+          "threadListOptionsFiltered": "Thread list options, filters active",
+          "interrupted": "Interrupted",
+          "state": {
+            "working": "Working",
+            "monitoring": "Monitoring background tasks",
+            "blocked": "Blocked",
+            "waiting": "Waiting for input",
+            "failed": "Failed",
+            "done": "Done",
+            "idle": "Idle",
+            "unverifiable": "No recent update",
+            "permission": "Needs permission"
+          }
         },
         "clearCompleted": {
           "clearedOne": "Cleared 1 completed agent",
@@ -17610,7 +17622,9 @@
       "label": "Agents",
       "dashboardLabel": "Agent Dashboard",
       "openActivity": "View activity",
-      "closeActivity": "Turn off activity view"
+      "closeActivity": "Turn off activity view",
+      "projects": "Projects",
+      "workspaces": "Workspaces"
     }
   },
   "runtimeRpc": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16229,7 +16229,7 @@
             "done": "Done",
             "idle": "Idle",
             "unverifiable": "No recent update",
-            "permission": "Needs permission"
+            "permission": "Needs attention"
           }
         },
         "clearCompleted": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14186,7 +14186,27 @@
           "beb2c19173": "No leído",
           "5651b216c6": "Proyecto desconocido",
           "22b22034bc": "Terminal independiente no disponible en Actividad.",
-          "afdc2139a8": "Terminal de Agent cerrada. Abre una nueva terminal en este workspace para continuar."
+          "afdc2139a8": "Terminal de Agent cerrada. Abre una nueva terminal en este workspace para continuar.",
+          "compactModeDescription": "Muestra filas de hilo más cortas con títulos de una línea y mensajes de estado de dos líneas.",
+          "unreadOnlyDescription": "Filtra la lista de actividad para mostrar solo hilos con actualizaciones sin leer.",
+          "clearCompleted": "Borrar completados",
+          "none": "Ninguno",
+          "search": "Buscar",
+          "showUnreadOnly": "Mostrar solo no leídos",
+          "showChildAgents": "Mostrar agentes secundarios",
+          "activityOptions": "Opciones de actividad",
+          "interrupted": "Interrumpido",
+          "state": {
+            "working": "Trabajando",
+            "monitoring": "Supervisando tareas en segundo plano",
+            "blocked": "Bloqueado",
+            "waiting": "Esperando entrada",
+            "failed": "Fallido",
+            "done": "Completado",
+            "idle": "Inactivo",
+            "unverifiable": "Sin actualizaciones recientes",
+            "permission": "Se necesita permiso"
+          }
         },
         "ActivityScopeFilterControls": {
           "resetScope": "Mostrar todos los hosts y proyectos"
@@ -14842,7 +14862,11 @@
   "dashboard": {
     "sidebar": {
       "label": "Agentes",
-      "dashboardLabel": "Panel de agentes"
+      "dashboardLabel": "Panel de agentes",
+      "openActivity": "Ver actividad",
+      "closeActivity": "Cerrar vista de actividad",
+      "projects": "Proyectos",
+      "workspaces": "Espacios de trabajo"
     }
   },
   "browser": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14205,7 +14205,7 @@
             "done": "Completado",
             "idle": "Inactivo",
             "unverifiable": "Sin actualizaciones recientes",
-            "permission": "Se necesita permiso"
+            "permission": "Requiere atención"
           }
         },
         "ActivityScopeFilterControls": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14205,7 +14205,7 @@
             "done": "完了",
             "idle": "アイドル",
             "unverifiable": "最近の更新なし",
-            "permission": "権限が必要"
+            "permission": "要対応"
           }
         },
         "ActivityScopeFilterControls": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14186,7 +14186,27 @@
           "beb2c19173": "未読",
           "5651b216c6": "不明なプロジェクト",
           "22b22034bc": "スタンドアロンターミナルはアクティビティでは使用できません。",
-          "afdc2139a8": "Agent ターミナルが閉じられました。続行するには、このワークスペースで新規ターミナルを開いてください。"
+          "afdc2139a8": "Agent ターミナルが閉じられました。続行するには、このワークスペースで新規ターミナルを開いてください。",
+          "compactModeDescription": "1 行のタイトルと 2 行のステータスメッセージで短いスレッド行を表示します。",
+          "unreadOnlyDescription": "未読の更新があるスレッドのみをアクティビティ一覧に表示します。",
+          "clearCompleted": "完了済みをクリア",
+          "none": "なし",
+          "search": "検索",
+          "showUnreadOnly": "未読のみ表示",
+          "showChildAgents": "子 Agent を表示",
+          "activityOptions": "アクティビティのオプション",
+          "interrupted": "中断",
+          "state": {
+            "working": "作業中",
+            "monitoring": "バックグラウンドタスクを監視中",
+            "blocked": "ブロック",
+            "waiting": "入力待ち",
+            "failed": "失敗",
+            "done": "完了",
+            "idle": "アイドル",
+            "unverifiable": "最近の更新なし",
+            "permission": "権限が必要"
+          }
         },
         "ActivityScopeFilterControls": {
           "resetScope": "すべてのホストとプロジェクトを表示"
@@ -14877,7 +14897,11 @@
   "dashboard": {
     "sidebar": {
       "label": "Agent",
-      "dashboardLabel": "Agent ダッシュボード"
+      "dashboardLabel": "Agent ダッシュボード",
+      "openActivity": "アクティビティを表示",
+      "closeActivity": "アクティビティビューを閉じる",
+      "projects": "プロジェクト",
+      "workspaces": "ワークスペース"
     }
   },
   "browser": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14264,7 +14264,27 @@
           "beb2c19173": "읽지 않음",
           "5651b216c6": "알 수 없는 프로젝트",
           "22b22034bc": "활동에서는 독립형 terminal을 사용할 수 없습니다.",
-          "afdc2139a8": "Agent terminal이 닫혔습니다. 계속하려면 이 워크스페이스에서 새 terminal을 여세요."
+          "afdc2139a8": "Agent terminal이 닫혔습니다. 계속하려면 이 워크스페이스에서 새 terminal을 여세요.",
+          "compactModeDescription": "한 줄 제목과 두 줄 상태 메시지로 더 짧은 스레드 행을 표시합니다.",
+          "unreadOnlyDescription": "읽지 않은 업데이트가 있는 스레드만 활동 목록에 표시합니다.",
+          "clearCompleted": "완료된 항목 지우기",
+          "none": "없음",
+          "search": "검색",
+          "showUnreadOnly": "읽지 않은 항목만 표시",
+          "showChildAgents": "하위 에이전트 표시",
+          "activityOptions": "활동 옵션",
+          "interrupted": "중단됨",
+          "state": {
+            "working": "작업 중",
+            "monitoring": "백그라운드 작업 모니터링 중",
+            "blocked": "차단됨",
+            "waiting": "입력 대기 중",
+            "failed": "실패",
+            "done": "완료",
+            "idle": "유휴",
+            "unverifiable": "최근 업데이트 없음",
+            "permission": "권한 필요"
+          }
         },
         "ActivityScopeFilterControls": {
           "resetScope": "모든 호스트 및 프로젝트 표시"
@@ -15016,7 +15036,11 @@
   "dashboard": {
     "sidebar": {
       "label": "에이전트",
-      "dashboardLabel": "에이전트 대시보드"
+      "dashboardLabel": "에이전트 대시보드",
+      "openActivity": "활동 보기",
+      "closeActivity": "활동 보기 닫기",
+      "projects": "프로젝트",
+      "workspaces": "워크스페이스"
     }
   },
   "browser": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14283,7 +14283,7 @@
             "done": "완료",
             "idle": "유휴",
             "unverifiable": "최근 업데이트 없음",
-            "permission": "권한 필요"
+            "permission": "주의 필요"
           }
         },
         "ActivityScopeFilterControls": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14283,7 +14283,7 @@
             "done": "完成",
             "idle": "空闲",
             "unverifiable": "暂无近期更新",
-            "permission": "需要权限"
+            "permission": "需注意"
           }
         },
         "ActivityScopeFilterControls": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14264,7 +14264,27 @@
           "beb2c19173": "未读",
           "5651b216c6": "未知项目",
           "22b22034bc": "独立终端在活动中不可用。",
-          "afdc2139a8": "智能体终端关闭。在此工作区中打开一个新终端以继续。"
+          "afdc2139a8": "智能体终端关闭。在此工作区中打开一个新终端以继续。",
+          "compactModeDescription": "以单行标题和两行状态消息显示更短的线程行。",
+          "unreadOnlyDescription": "将活动列表筛选为仅显示有未读更新的线程。",
+          "clearCompleted": "清除已完成",
+          "none": "无",
+          "search": "搜索",
+          "showUnreadOnly": "仅显示未读",
+          "showChildAgents": "显示子智能体",
+          "activityOptions": "活动选项",
+          "interrupted": "已中断",
+          "state": {
+            "working": "工作中",
+            "monitoring": "监控后台任务",
+            "blocked": "受阻",
+            "waiting": "等待输入",
+            "failed": "失败",
+            "done": "完成",
+            "idle": "空闲",
+            "unverifiable": "暂无近期更新",
+            "permission": "需要权限"
+          }
         },
         "ActivityScopeFilterControls": {
           "resetScope": "显示所有主机和项目"
@@ -14981,7 +15001,11 @@
   "dashboard": {
     "sidebar": {
       "label": "智能体",
-      "dashboardLabel": "智能体仪表盘"
+      "dashboardLabel": "智能体仪表盘",
+      "openActivity": "查看活动",
+      "closeActivity": "关闭活动视图",
+      "projects": "项目",
+      "workspaces": "工作区"
     }
   },
   "browser": {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​149 |

<!-- /orca-pr-loc -->

## Problem

The activity view and sidebar contain hard-coded English strings for agent state labels and sidebar titles, which prevents localization for non-English users.

## Solution

Wrapped user-facing strings in `translate()` calls and added corresponding i18n keys to all locale files:
- Agent state labels (working, monitoring, blocked, waiting, failed, done, idle, unverifiable, permission, interrupted) in activity-thread-presentation.ts
- Sidebar titles (Projects/Workspaces) in SidebarHeader.tsx
- Updated all five locale catalogs (en, es, ja, ko, zh) with translations

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)