### PR TITLE
fix(remote-terminal): keep live output flowing during resync

### DIFF
--- a/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
@@ -95,11 +95,6 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
         frame.opcode === TerminalStreamOpcode.OutputSpan && typeof span?.rawLength === 'number'
           ? span.rawLength
           : data.length
-      // Why: a resync snapshot is authoritative; discard live output while
-      // it is in flight, but still return transport credit in finally.
-      if (stream.resyncInFlight) {
-        return
-      }
       const seq = typeof frame.seq === 'number' && frame.seq > 0 ? frame.seq : undefined
       // Why: older servers replay snapshot-covered buffered chunks after a
       // requested recovery; rendering them would duplicate the recovered tail.
@@ -110,11 +105,18 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
       ) {
         return
       }
-      if (this.detectOutputGap(stream, seq, rawLength)) {
+      const resyncInFlight = stream.resyncInFlight
+      // Why: recovery is corrective, not a renderer backpressure gate. Keep
+      // painting live output while the authoritative snapshot travels over a
+      // jittery link; leave expectedSeq anchored so a failed/expired recovery
+      // still exposes the gap and retries on a later frame. Discard the frame
+      // that exposes the gap because it follows missing bytes and cannot be
+      // parsed safely against the prior terminal state.
+      if (!resyncInFlight && this.detectOutputGap(stream, seq, rawLength)) {
         this.requestResyncSnapshot(stream)
         return
       }
-      if (typeof seq === 'number') {
+      if (typeof seq === 'number' && !resyncInFlight) {
         stream.expectedSeq = seq
         stream.commandProbeBaselineSeq = undefined
       }

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -44,6 +44,7 @@ class FakeMultiplexServer {
   holdNextRecoverySnapshot = false
   snapshotRequests: (number | undefined)[] = []
   private heldManualRequestId: number | null = null
+  private heldRecoverySnapshot = false
   private snapshotData = 'INITIAL'
 
   constructor(
@@ -77,6 +78,7 @@ class FakeMultiplexServer {
       if (typeof payload?.requestId !== 'number' && this.holdNextRecoverySnapshot) {
         // The reply's binary frames were all dropped under backpressure.
         this.holdNextRecoverySnapshot = false
+        this.heldRecoverySnapshot = true
         return
       }
       if (typeof payload?.requestId !== 'number' && this.truncateNextRecoverySnapshot) {
@@ -167,6 +169,14 @@ class FakeMultiplexServer {
     this.snapshotData = 'MANUAL'
     this.sendSnapshot(requestId)
   }
+
+  flushHeldRecoverySnapshot(): void {
+    if (!this.heldRecoverySnapshot) {
+      throw new Error('No recovery snapshot is held')
+    }
+    this.heldRecoverySnapshot = false
+    this.sendSnapshot()
+  }
 }
 
 describe('remote terminal frame-drop resync', () => {
@@ -239,7 +249,8 @@ describe('remote terminal frame-drop resync', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    // The corrupt tail ('ccc', which followed a gap) is NOT rendered as live data.
+    // The immediate snapshot covers the corrupt tail ('ccc'), so it is not
+    // rendered separately or duplicated after the recovery reset.
     expect(data).toEqual(['aaa'])
     expect(server.droppedFrames).toBe(1)
     // Instead, a fresh authoritative snapshot recovers the terminal.
@@ -250,7 +261,7 @@ describe('remote terminal frame-drop resync', () => {
     expect(data).toEqual(['aaa', 'ddd'])
   })
 
-  it('retries a truncated recovery on a backoff without accepting output across the gap', async () => {
+  it('retries a truncated recovery on a backoff while keeping live output flowing', async () => {
     vi.useFakeTimers()
     try {
       const { data, snapshots } = await subscribeClient()
@@ -260,8 +271,8 @@ describe('remote terminal frame-drop resync', () => {
       server.dropNextOutput = true
       server.output('bbb')
       server.output('ccc')
-      // The gate stays shut across the backoff: the post-gap tail is corrupt,
-      // and retrying once per chunk would stampede a flooded server.
+      // Recovery retries are backoff-limited, but the live path stays open;
+      // output must not freeze while a jittery host serializes the snapshot.
       server.output('ddd')
       expect(server.snapshotRequests).toEqual([undefined])
 
@@ -271,9 +282,56 @@ describe('remote terminal frame-drop resync', () => {
 
       server.output('eee')
       expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
-      expect(data).toEqual(['aaa', 'eee'])
+      expect(data).toEqual(['aaa', 'ddd', 'eee'])
     } finally {
       vi.useRealTimers()
+    }
+  })
+
+  it('keeps painting live output while a recovery snapshot is delayed', async () => {
+    const { data, snapshots, stream } = await subscribeClient()
+    try {
+      server.holdNextRecoverySnapshot = true
+
+      server.output('aaa')
+      server.dropNextOutput = true
+      server.output('bbb')
+      server.output('ccc') // exposes the gap and starts the delayed recovery
+      server.output('ddd')
+      server.output('eee')
+
+      // A slow snapshot must not become a renderer backpressure gate.
+      expect(data).toEqual(['aaa', 'ddd', 'eee'])
+      expect(snapshots).toEqual(['INITIAL'])
+    } finally {
+      stream.close()
+    }
+  })
+
+  it('reconciles painted output when a delayed recovery snapshot arrives', async () => {
+    const { data, snapshots, stream } = await subscribeClient()
+    try {
+      server.holdNextRecoverySnapshot = true
+
+      server.output('aaa')
+      server.dropNextOutput = true
+      server.output('bbb')
+      server.output('ccc')
+      server.output('ddd')
+      server.output('eee')
+
+      expect(data).toEqual(['aaa', 'ddd', 'eee'])
+      expect(snapshots).toEqual(['INITIAL'])
+
+      server.flushHeldRecoverySnapshot()
+      expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
+
+      // A replay covered by the authoritative snapshot must not duplicate.
+      server.replaySnapshotCoveredOutput('eee')
+      server.output('fff')
+      expect(data).toEqual(['aaa', 'ddd', 'eee', 'fff'])
+    } finally {
+      stream.close()
     }
   })
 

--- a/src/renderer/src/runtime/remote-runtime-terminal-snapshot-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-snapshot-controller.ts
@@ -38,10 +38,9 @@ export abstract class RemoteRuntimeTerminalSnapshotController extends RemoteRunt
     return startSeq > stream.expectedSeq
   }
 
-  // Why: on a detected gap, discard the corrupt tail and pull a fresh
-  // authoritative snapshot. The request carries no requestId so the server
-  // reply renders through the initial-snapshot path (full reset), self-healing
-  // without surfacing an error to the user.
+  // Why: on a detected gap, pull a fresh authoritative snapshot. The request
+  // carries no requestId so the server reply uses the recovery path (full
+  // reset), self-healing without surfacing an error to the user.
   protected requestResyncSnapshot(stream: RemoteRuntimeMultiplexedTerminalState): void {
     if (stream.resyncInFlight) {
       return
@@ -51,7 +50,7 @@ export abstract class RemoteRuntimeTerminalSnapshotController extends RemoteRunt
       // Why: snapshot frame groups are not multiplexed; wait for the manual
       // snapshot to finish so its response cannot be mistaken for recovery.
       // Arm the watchdog now so a dispatch path that consumes the pending
-      // request without re-dispatching cannot hold the gate shut forever.
+      // request without re-dispatching cannot leave recovery pending forever.
       stream.resyncPendingSend = true
       this.startResyncTimer(stream)
       return
@@ -81,8 +80,8 @@ export abstract class RemoteRuntimeTerminalSnapshotController extends RemoteRunt
     }
   }
 
-  // Why: keep the gate shut across the backoff — the post-gap tail is corrupt
-  // either way — and heal even if the flood ends with no further output.
+  // Why: keep recovery pending across the backoff and heal even if the flood
+  // ends with no further output.
   protected scheduleResyncRetry(stream: RemoteRuntimeMultiplexedTerminalState): void {
     stream.resyncAttempts += 1
     const delay = Math.min(


### PR DESCRIPTION
## Summary

Fixes #18488.

Remote terminal output could repaint on a fixed ~10-second cadence when a sequence-gap recovery snapshot was delayed. While recovery was in flight, the renderer discarded every live output frame until the watchdog expired.

This change makes recovery soft:

- Drop only the first frame that exposes a sequence gap.
- Keep rendering later live output while the authoritative snapshot is in flight.
- Keep sequence tracking anchored so failed recovery retries still detect the original gap.
- Apply the recovery snapshot as the authoritative terminal state and deduplicate replayed output it already covers.
- Preserve the existing wire protocol and recovery/backoff behavior.

## ELI5

When a remote terminal misses a chunk of text, Orca used to stop showing everything for 10 seconds while asking the server to repair the screen. Now it keeps showing new text immediately, then quietly replaces the screen with the server's correct version when the repair arrives. The terminal stays responsive without sacrificing correctness.

## Verification

- Remote terminal suites: 49 tests
- Cross-version wire tests: 10 tests
- Main terminal characterization: 6 tests
- Related pane replay/recovery tests: 60 tests
- `pnpm tc`
- Changed-code quality checks, Oxlint, formatting, and diff checks
- Electron CDP validation
