### PR TITLE
fix(hosts): resolve a folder workspace's SSH host from the repo's host, not its raw connectionId

### DIFF
--- a/src/main/ipc/worktrees/listing/detected-provider-listing.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing.ts
@@ -26,8 +26,7 @@ import {
   type DetectedWorktreeSideEffectToken
 } from './detected-worktree-scan-cache'
 import { loggedWorktreeListFailures, warnOnce } from './worktree-listing-diagnostics'
-import { readAllWorktreeMetaForHost } from '../../../persistence/host-qualified-worktree-meta'
-import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { readAllWorktreeMetaForRepo } from '../../../persistence/host-qualified-worktree-meta'
 
 export async function listDetectedWorktreesForCapturedRepo(
   store: Store,
@@ -40,9 +39,7 @@ export async function listDetectedWorktreesForCapturedRepo(
     providerAbort?.signal.aborted
       ? ({ providerAbortStatus: providerAbort.status() } as const)
       : undefined
-  const allMeta = isFolderRepo(repo)
-    ? undefined
-    : readAllWorktreeMetaForHost(store, getRepoExecutionHostId(repo))
+  const allMeta = isFolderRepo(repo) ? undefined : readAllWorktreeMetaForRepo(store, repo)
   // Why: only the disconnected fallbacks read this, so keep parseWorktreeId over the whole host snapshot
   // off the connected path entirely.
   let cachedSshWorktreeMetaIndex: SshWorktreeMetaIndex | undefined

--- a/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
+++ b/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
@@ -23,7 +23,10 @@ import {
   warnOnce
 } from './worktree-listing-diagnostics'
 import type { WorktreeIpcContext } from '../worktree-ipc-context'
-import { readAllWorktreeMetaForHost } from '../../../persistence/host-qualified-worktree-meta'
+import {
+  readAllWorktreeMetaForHost,
+  readAllWorktreeMetaForRepo
+} from '../../../persistence/host-qualified-worktree-meta'
 import type { WorktreeMeta } from '../../../../shared/worktree/meta-types'
 
 const WORKTREE_LIST_ALL_CONCURRENCY = 8
@@ -174,9 +177,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
     if (!repo) {
       return []
     }
-    const allMeta = repo.connectionId
-      ? readAllWorktreeMetaForHost(store, getRepoExecutionHostId(repo))
-      : undefined
+    const allMeta = repo.connectionId ? readAllWorktreeMetaForRepo(store, repo) : undefined
     const sshWorktreeMetaIndex = repo.connectionId
       ? createSshWorktreeMetaIndex(Object.entries(allMeta ?? {}))
       : new Map()
@@ -226,7 +227,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
         })
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-      const metadata = allMeta ?? readAllWorktreeMetaForHost(store, getRepoExecutionHostId(repo))
+      const metadata = allMeta ?? readAllWorktreeMetaForRepo(store, repo)
       return buildDetectedGitWorktrees(store, repo, gitWorktrees, metadata)
         .filter((worktree) => worktree.visible)
         .map((worktree) => stampAndMergeVisibleDetectedWorktree(store, repo, worktree, metadata))

--- a/src/main/ipc/worktrees/listing/ssh-worktree-fallback.ts
+++ b/src/main/ipc/worktrees/listing/ssh-worktree-fallback.ts
@@ -9,7 +9,7 @@ import type { GitWorktreeInfo, DetectedWorktree, Worktree } from '../../../../sh
 import type { Store } from '../../../persistence/loading-store/store'
 import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
-  readWorktreeMetaForHost,
+  readWorktreeMetaForRepo,
   writeWorktreeMetaForHost
 } from '../../../persistence/host-qualified-worktree-meta'
 import { getRepoOwnedWorktreeMeta } from '../../../worktree-metadata-ownership'
@@ -159,7 +159,7 @@ export function buildDetectedGitWorktrees(
     const legacyMeta = allMeta === undefined ? store.getWorktreeMeta?.(worktreeId) : undefined
     const metaById = allMeta ?? (legacyMeta ? { [worktreeId]: legacyMeta } : {})
     const meta =
-      readWorktreeMetaForHost(store, worktreeId, getRepoExecutionHostId(repo)) ??
+      readWorktreeMetaForRepo(store, worktreeId, repo) ??
       getRepoOwnedWorktreeMeta(repo, worktreeId, metaById, repoOwnerCount)
     const worktree = mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
     const detected = toDetectedWorktree({

--- a/src/main/ipc/worktrees/listing/worktree-discovery-metadata.ts
+++ b/src/main/ipc/worktrees/listing/worktree-discovery-metadata.ts
@@ -4,7 +4,7 @@ import type { WorktreeMeta } from '../../../../shared/worktree/meta-types'
 import { getProjectHostSetupWorktreeMeta } from '../../../../shared/project-host-setup-lookup'
 import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
-  readWorktreeMetaForHost,
+  readWorktreeMetaForRepo,
   writeWorktreeMetaForHost
 } from '../../../persistence/host-qualified-worktree-meta'
 import { getRepoOwnedWorktreeMeta } from '../../../worktree-metadata-ownership'
@@ -44,7 +44,7 @@ export function resolveWorktreeMetaWithDiscoveryBackfill(
   // Why: the locator-keyed row is only a stand-in for a missing snapshot, so don't read it when we have one.
   const legacyMeta = allMeta === undefined ? store.getWorktreeMeta?.(worktreeId) : undefined
   const existing =
-    readWorktreeMetaForHost(store, worktreeId, executionHostId) ??
+    readWorktreeMetaForRepo(store, worktreeId, repo) ??
     getRepoOwnedWorktreeMeta(
       repo,
       worktreeId,

--- a/src/main/persistence/host-qualified-worktree-meta.ts
+++ b/src/main/persistence/host-qualified-worktree-meta.ts
@@ -1,4 +1,5 @@
-import type { ExecutionHostId } from '../../shared/execution-host'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 
 /**
@@ -50,6 +51,26 @@ export function readWorktreeMetaForHost(
   executionHostId: ExecutionHostId
 ): WorktreeMeta | undefined {
   return store.getWorktreeMetaForHost?.(worktreeId, executionHostId)
+}
+
+/**
+ * The same two reads keyed off a repo row, so the resolve-then-read pair lives in one place. Four
+ * call sites had open-coded it identically, which is the shape that lets one copy drift from the
+ * rest (F7/F8).
+ */
+export function readAllWorktreeMetaForRepo(
+  store: Pick<HostQualifiedWorktreeMetaStore, 'getAllWorktreeMeta' | 'getAllWorktreeMetaForHost'>,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): Record<string, WorktreeMeta> {
+  return readAllWorktreeMetaForHost(store, getRepoExecutionHostId(repo))
+}
+
+export function readWorktreeMetaForRepo(
+  store: Pick<HostQualifiedWorktreeMetaStore, 'getWorktreeMetaForHost'>,
+  worktreeId: string,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): WorktreeMeta | undefined {
+  return readWorktreeMetaForHost(store, worktreeId, getRepoExecutionHostId(repo))
 }
 
 export function writeWorktreeMetaForHost(

--- a/src/main/runtime/worktree-launch-host-repo.ts
+++ b/src/main/runtime/worktree-launch-host-repo.ts
@@ -17,7 +17,10 @@ export type WorktreeHostRouting<T extends LaunchHostRepo> =
   | { kind: 'resolved'; hostId: ExecutionHostId; repo: T | null }
   /** No row carries this repo id and the worktree names no host — nothing ever named a host. */
   | { kind: 'unowned' }
-  /** Rival rows disagree about the host; guessing one is the cross-host leak. */
+  /**
+   * No single trustworthy host: rival rows disagree, or the resolved row named one that cannot be
+   * parsed. Guessing is the cross-host leak in both cases.
+   */
   | { kind: 'ambiguous' }
 
 /**
@@ -33,7 +36,10 @@ export function resolveWorktreeHostRouting<T extends LaunchHostRepo & ExecutionH
 ): WorktreeHostRouting<T> {
   const resolution = resolveWorktreeExecutionHost(createRepoRowExecutionHostLookup(repos), worktree)
   if (resolution.kind === 'unresolved') {
-    return resolution.reason === 'ambiguous' ? { kind: 'ambiguous' } : { kind: 'unowned' }
+    // Only `unknown` — nothing anywhere carries the id — becomes `unowned`, which callers dispose of
+    // as a plain local folder. `malformed` is a row that declared a host and named an unparseable
+    // one, so it joins `ambiguous`: guessing is the cross-host leak either way.
+    return resolution.reason === 'unknown' ? { kind: 'unowned' } : { kind: 'ambiguous' }
   }
   return { kind: 'resolved', hostId: resolution.hostId, repo: resolution.owner }
 }

--- a/src/shared/execution-host.test.ts
+++ b/src/shared/execution-host.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   LOCAL_EXECUTION_HOST_ID,
+  getExecutionHostLabel,
   getLocalExecutionHostLabel,
   getRepoExecutionHostId,
   getRepoSshConnectionId,
@@ -168,5 +169,17 @@ describe('execution host id delimiter invariant', () => {
       id: 'ssh:a%7Cb',
       targetId: 'a|b'
     })
+  })
+
+  // "All hosts" is the everything-scope. Answering with it for an id that names no host shows one
+  // unroutable row as though it were on every host, which is the opposite of what it is.
+  it('labels an id that names no host as one unknown host, not as every host', () => {
+    for (const id of ['ssh:', 'ssh:a|b', 'ssh:%zz', 'runtime:', 'quantum:box'] as const) {
+      expect(getExecutionHostLabel(id as never)).toBe('Unknown host')
+    }
+    expect(getExecutionHostLabel(null)).toBe('Unknown host')
+    expect(getExecutionHostLabel(ALL_EXECUTION_HOSTS_SCOPE)).toBe('All hosts')
+    expect(getExecutionHostLabel('ssh:box')).toBe('box')
+    expect(getExecutionHostLabel('runtime:env-1')).toBe('env-1')
   })
 })

--- a/src/shared/execution-host.ts
+++ b/src/shared/execution-host.ts
@@ -226,13 +226,18 @@ export function getSettingsFocusedExecutionHostId(
     : LOCAL_EXECUTION_HOST_ID
 }
 
-export function getExecutionHostLabel(id: ExecutionHostScope): string {
+export function getExecutionHostLabel(id: ExecutionHostScope | null | undefined): string {
   if (id === ALL_EXECUTION_HOSTS_SCOPE) {
     return 'All hosts'
   }
   const parsed = parseExecutionHostId(id)
   if (!parsed) {
-    return 'All hosts'
+    // Not "All hosts": an id that names no host is one *unknown* host, and answering with the
+    // everything-scope label shows an unroutable row as though it were on every host.
+    // Plain English like every other label in this module (`Local Mac`, `This computer`,
+    // `All hosts`) — none of them resolve through the renderer's i18n catalog, so a lone
+    // translated string here would read inconsistently.
+    return 'Unknown host'
   }
   switch (parsed.kind) {
     case 'local':

--- a/src/shared/folder-workspace-execution-host.test.ts
+++ b/src/shared/folder-workspace-execution-host.test.ts
@@ -284,6 +284,84 @@ describe('folder workspace execution host', () => {
     expect(resolved).toEqual({ kind: 'local' })
   })
 
+  // The candidate FILTER decides which rows reach the resolver, and it read `repo.connectionId` raw
+  // too — so an SSH-only repo outside the project-group subtree was dropped before any of the above
+  // could classify it. Every test before this one uses a repo inside the subtree, which is never
+  // filtered, so none of them could have caught it (found in review by CodeRabbit).
+  describe('a repo matched only by path, outside the project-group subtree', () => {
+    const sshOnlyPathRepo = repo({
+      id: 'repo-path',
+      path: '/work/app/nested',
+      executionHostId: 'ssh:box'
+    })
+
+    it('survives the scope-connection filter instead of being dropped as connectionless', () => {
+      const scoped = state({
+        folderWorkspaces: [workspace({ connectionId: 'box' })],
+        repos: [sshOnlyPathRepo]
+      })
+
+      expect(findFolderWorkspaceCandidateRepos(scoped, 'fw-1')).toEqual([sshOnlyPathRepo])
+      expect(resolveFolderWorkspaceHost(scoped, 'fw-1')).toEqual({ kind: 'ssh', targetId: 'box' })
+    })
+
+    // Pins the resolver, not the filter: under the old raw read BOTH rows came back connectionless,
+    // so they matched each other by accident and this case survived the filter either way. The
+    // legacy-vs-unified pairing below is the one that discriminates.
+    it('survives the group-connection filter when the group is on that same SSH host', () => {
+      const scoped = state({
+        repos: [
+          repo({
+            id: 'repo-group',
+            path: '/work/app/group',
+            projectGroupId: 'group-1',
+            executionHostId: 'ssh:box'
+          }),
+          sshOnlyPathRepo
+        ]
+      })
+
+      expect(findFolderWorkspaceCandidateRepos(scoped, 'fw-1')).toHaveLength(2)
+      expect(resolveFolderWorkspaceHost(scoped, 'fw-1')).toEqual({ kind: 'ssh', targetId: 'box' })
+    })
+
+    // Both sides of the group comparison are resolved, so the legacy spelling on one side and the
+    // unified spelling on the other still match.
+    it('matches a legacy-spelled group repo against a unified-spelled path repo', () => {
+      const scoped = state({
+        repos: [
+          repo({
+            id: 'repo-group',
+            path: '/work/app/group',
+            projectGroupId: 'group-1',
+            connectionId: 'box'
+          }),
+          sshOnlyPathRepo
+        ]
+      })
+
+      expect(findFolderWorkspaceCandidateRepos(scoped, 'fw-1')).toHaveLength(2)
+      expect(resolveFolderWorkspaceHost(scoped, 'fw-1')).toEqual({ kind: 'ssh', targetId: 'box' })
+    })
+
+    // A `runtime:` row's nested target is still read from the raw field, so it matches a scope
+    // connection exactly as it does today. Pinned so the carve-out stays a decision.
+    it('leaves a runtime row matching the scope connection through its nested target', () => {
+      const runtimePathRepo = repo({
+        id: 'repo-path',
+        path: '/work/app/nested',
+        executionHostId: 'runtime:env-1',
+        connectionId: 'box'
+      })
+      const scoped = state({
+        folderWorkspaces: [workspace({ connectionId: 'box' })],
+        repos: [runtimePathRepo]
+      })
+
+      expect(findFolderWorkspaceCandidateRepos(scoped, 'fw-1')).toEqual([runtimePathRepo])
+    })
+  })
+
   it('reads each repository membership once while collecting candidates', () => {
     let membershipReads = 0
     const repos = Array.from({ length: 32 }, (_, index) => {

--- a/src/shared/folder-workspace-execution-host.test.ts
+++ b/src/shared/folder-workspace-execution-host.test.ts
@@ -174,6 +174,116 @@ describe('folder workspace execution host', () => {
     expect(resolveFolderWorkspaceHost(state({ repos: [] }), 'fw-1')).toEqual({ kind: 'local' })
   })
 
+  // SSH ownership has two spellings on a repo row. A row carrying only `executionHostId: 'ssh:*'`
+  // has no `connectionId`, and reading the raw field counted it as a local repo — so a workspace
+  // whose files live on an SSH host resolved `local`, which is an execute-here answer for a remote
+  // path. These fire on well-formed rows; nothing malformed is involved.
+  it('resolves a repo that names its SSH host only through executionHostId', () => {
+    const resolved = resolveFolderWorkspaceHost(
+      state({
+        repos: [
+          repo({
+            id: 'repo-1',
+            path: '/work/app/a',
+            projectGroupId: 'group-1',
+            executionHostId: 'ssh:box'
+          })
+        ]
+      }),
+      'fw-1'
+    )
+
+    expect(resolved).toEqual({ kind: 'ssh', targetId: 'box' })
+  })
+
+  it('mixes such a repo with a local one as ambiguous rather than local', () => {
+    const resolved = resolveFolderWorkspaceHost(
+      state({
+        repos: [
+          repo({ id: 'repo-1', path: '/work/app/a', projectGroupId: 'group-1' }),
+          repo({
+            id: 'repo-2',
+            path: '/work/app/b',
+            projectGroupId: 'group-1',
+            executionHostId: 'ssh:box'
+          })
+        ]
+      }),
+      'fw-1'
+    )
+
+    expect(resolved).toEqual({ kind: 'ambiguous' })
+  })
+
+  it('matches a scope connection against such a repo instead of calling it ambiguous', () => {
+    const resolved = resolveFolderWorkspaceHost(
+      state({
+        folderWorkspaces: [workspace({ connectionId: 'box' })],
+        repos: [
+          repo({
+            id: 'repo-1',
+            path: '/work/app/a',
+            projectGroupId: 'group-1',
+            executionHostId: 'ssh:box'
+          })
+        ]
+      }),
+      'fw-1'
+    )
+
+    expect(resolved).toEqual({ kind: 'ssh', targetId: 'box' })
+  })
+
+  it('reads the target off the host, so a percent-encoded id decodes', () => {
+    const resolved = resolveFolderWorkspaceHost(
+      state({
+        repos: [
+          repo({
+            id: 'repo-1',
+            path: '/work/app/a',
+            projectGroupId: 'group-1',
+            executionHostId: `ssh:${encodeURIComponent('box 1')}`
+          })
+        ]
+      }),
+      'fw-1'
+    )
+
+    expect(resolved).toEqual({ kind: 'ssh', targetId: 'box 1' })
+  })
+
+  // Deliberately unchanged: a `runtime:` row's nested SSH target is not this client's to dial, but
+  // narrowing that here would be a second behaviour change riding on the SSH fix.
+  it('leaves a runtime row contributing its nested connection exactly as before', () => {
+    const resolved = resolveFolderWorkspaceHost(
+      state({
+        repos: [
+          repo({
+            id: 'repo-1',
+            path: '/work/app/a',
+            projectGroupId: 'group-1',
+            executionHostId: 'runtime:env-1',
+            connectionId: 'nested-box'
+          })
+        ]
+      }),
+      'fw-1'
+    )
+
+    expect(resolved).toEqual({ kind: 'ssh', targetId: 'nested-box' })
+  })
+
+  it('still answers local for a runtime pin, which the type cannot express otherwise', () => {
+    const resolved = resolveFolderWorkspaceHost(
+      state({
+        folderWorkspaces: [workspace({ executionHostId: 'runtime:env-1' })]
+      }),
+      'fw-1'
+    )
+
+    expect(resolved).toEqual({ kind: 'local' })
+  })
+
   it('reads each repository membership once while collecting candidates', () => {
     let membershipReads = 0
     const repos = Array.from({ length: 32 }, (_, index) => {

--- a/src/shared/folder-workspace-execution-host.ts
+++ b/src/shared/folder-workspace-execution-host.ts
@@ -17,7 +17,7 @@ import type { ProjectGroup } from './project-group-types'
 import type { Repo } from './repo-types'
 import { isPathInsideOrEqual } from './cross-platform-path'
 import { getProjectGroupSubtreeIds } from './project-groups'
-import { parseExecutionHostId } from './execution-host'
+import { getRepoExecutionHostId, parseExecutionHostId } from './execution-host'
 
 export type FolderWorkspaceHostState = {
   folderWorkspaces: readonly FolderWorkspace[]
@@ -102,6 +102,12 @@ export function resolveFolderWorkspaceHost(
   }
   const explicitHost = parseExecutionHostId(workspace.executionHostId)
   if (explicitHost) {
+    // A `runtime:` workspace deliberately answers `local`, and `FolderWorkspaceHost` has no runtime
+    // variant to answer with instead. That omission is known: a runtime environment's own server
+    // normalizes its work to `local`, and the nested SSH target on such a row is addressable only as
+    // the pair (environmentId, targetId) — handing it to this client's SSH table would dial a
+    // same-named box in the wrong namespace. Widening the type is its own change, not an oversight
+    // here.
     return explicitHost.kind === 'ssh'
       ? { kind: 'ssh', targetId: explicitHost.targetId }
       : { kind: 'local' }
@@ -114,7 +120,17 @@ export function resolveFolderWorkspaceHost(
   let hasLocalRepo = false
   const connectionIds = new Set<string>()
   for (const repo of candidateRepos) {
-    const connectionId = normalizeConnectionId(repo.connectionId)
+    // Why not `repo.connectionId` alone: SSH ownership has two spellings on a repo row, and a row
+    // carrying only `executionHostId: 'ssh:<target>'` has no `connectionId` to read. Reading the raw
+    // field counted it as a local repo, so a folder workspace whose files live on an SSH host
+    // resolved `local` — an execute-here answer for a remote path (#11163).
+    //
+    // Resolve the host first, then read the target off it. Every other row keeps its existing
+    // contribution, including a `runtime:` row's nested target: that is not this client's to dial,
+    // but narrowing it here would be a second behaviour change riding on this one.
+    const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+    const connectionId =
+      host?.kind === 'ssh' ? host.targetId : normalizeConnectionId(repo.connectionId)
     if (connectionId) {
       connectionIds.add(connectionId)
     } else {

--- a/src/shared/folder-workspace-execution-host.ts
+++ b/src/shared/folder-workspace-execution-host.ts
@@ -36,6 +36,24 @@ export function normalizeConnectionId(value: string | null | undefined): string 
   return value?.trim() || null
 }
 
+/**
+ * The SSH target whose filesystem holds this repo's files, or `null` for anything else.
+ *
+ * SSH ownership has two spellings on a repo row — the legacy `connectionId` field and the unified
+ * `executionHostId` — so reading the raw field sees only one of them and a row carrying only
+ * `executionHostId: 'ssh:<target>'` reads as if it had no connection at all. Every comparison in
+ * this file goes through here: the candidate filters decide which rows reach the resolver, so
+ * reading raw in either place drops the row before the resolver can classify it.
+ *
+ * A non-SSH host falls back to the raw field so a `runtime:` row keeps contributing its nested
+ * target exactly as it does today. That target is not this client's to dial, but changing it is a
+ * separate defect with its own reasoning — see the note in `resolveFolderWorkspaceHost`.
+ */
+function getRepoScopeConnectionId(repo: Repo): string | null {
+  const host = parseExecutionHostId(getRepoExecutionHostId(repo))
+  return host?.kind === 'ssh' ? host.targetId : normalizeConnectionId(repo.connectionId)
+}
+
 function getFolderScopeCandidateRepos(args: {
   folderPath: string
   projectGroupId: string
@@ -59,18 +77,18 @@ function getFolderScopeCandidateRepos(args: {
   if (args.connectionId) {
     return [
       ...groupRepos,
-      ...pathRepos.filter((repo) => normalizeConnectionId(repo.connectionId) === args.connectionId)
+      ...pathRepos.filter((repo) => getRepoScopeConnectionId(repo) === args.connectionId)
     ]
   }
   if (groupRepos.length === 0) {
     return pathRepos
   }
-  const groupConnectionIds = new Set(
-    groupRepos.map((repo) => normalizeConnectionId(repo.connectionId))
-  )
+  // Both sides resolved: comparing a resolved path repo against a raw group read would reintroduce
+  // the same mismatch from the other direction.
+  const groupConnectionIds = new Set(groupRepos.map(getRepoScopeConnectionId))
   return [
     ...groupRepos,
-    ...pathRepos.filter((repo) => groupConnectionIds.has(normalizeConnectionId(repo.connectionId)))
+    ...pathRepos.filter((repo) => groupConnectionIds.has(getRepoScopeConnectionId(repo)))
   ]
 }
 
@@ -120,17 +138,7 @@ export function resolveFolderWorkspaceHost(
   let hasLocalRepo = false
   const connectionIds = new Set<string>()
   for (const repo of candidateRepos) {
-    // Why not `repo.connectionId` alone: SSH ownership has two spellings on a repo row, and a row
-    // carrying only `executionHostId: 'ssh:<target>'` has no `connectionId` to read. Reading the raw
-    // field counted it as a local repo, so a folder workspace whose files live on an SSH host
-    // resolved `local` — an execute-here answer for a remote path (#11163).
-    //
-    // Resolve the host first, then read the target off it. Every other row keeps its existing
-    // contribution, including a `runtime:` row's nested target: that is not this client's to dial,
-    // but narrowing it here would be a second behaviour change riding on this one.
-    const host = parseExecutionHostId(getRepoExecutionHostId(repo))
-    const connectionId =
-      host?.kind === 'ssh' ? host.targetId : normalizeConnectionId(repo.connectionId)
+    const connectionId = getRepoScopeConnectionId(repo)
     if (connectionId) {
       connectionIds.add(connectionId)
     } else {

--- a/src/shared/worktree-execution-host-resolution.test.ts
+++ b/src/shared/worktree-execution-host-resolution.test.ts
@@ -156,6 +156,40 @@ describe('resolveWorktreeExecutionHost', () => {
     it('reports an unknown owner distinctly from a conflicting one', () => {
       expect(resolve([], { repoId: 'r' })).toEqual({ kind: 'unresolved', reason: 'unknown' })
     })
+
+    // `unknown` is a verdict the launch path disposes of as a plain local folder, so a row that
+    // declared a host and named an unparseable one must not share the word — it has to fail closed.
+    it('reports a row naming an unparseable host distinctly from an unknown one', () => {
+      for (const executionHostId of ['ssh:', 'ssh:a|b', 'ssh:%zz', 'runtime:', 'quantum:box']) {
+        expect(resolve([{ id: 'r', executionHostId }], { repoId: 'r' })).toEqual({
+          kind: 'unresolved',
+          reason: 'malformed'
+        })
+      }
+    })
+
+    it('does not recover a host from the connectionId such a row overrode', () => {
+      expect(
+        resolve([{ id: 'r', executionHostId: 'ssh:a|b', connectionId: 'openclaw' }], {
+          repoId: 'r'
+        })
+      ).toEqual({ kind: 'unresolved', reason: 'malformed' })
+    })
+
+    it('still resolves every row that names a parseable host', () => {
+      expect(resolve([{ id: 'r', executionHostId: 'ssh:box' }], { repoId: 'r' })).toMatchObject({
+        kind: 'resolved',
+        hostId: 'ssh:box'
+      })
+      expect(resolve([{ id: 'r', connectionId: 'box' }], { repoId: 'r' })).toMatchObject({
+        kind: 'resolved',
+        hostId: 'ssh:box'
+      })
+      expect(resolve([{ id: 'r' }], { repoId: 'r' })).toMatchObject({
+        kind: 'resolved',
+        hostId: 'local'
+      })
+    })
   })
 
   it('ignores an unparseable host id rather than treating it as a host', () => {

--- a/src/shared/worktree-execution-host-resolution.ts
+++ b/src/shared/worktree-execution-host-resolution.ts
@@ -54,7 +54,29 @@ export type WorktreeExecutionHostResolution<T extends ExecutionHostOwnerRow> =
       /** Display metadata only. The decisions are `hostId` / `connectionId`. */
       owner: T | null
     }
-  | { kind: 'unresolved'; reason: 'ambiguous' | 'unknown' }
+  /**
+   * Three reasons, not two, and deliberately not collapsed. `unknown` (nothing carries the id) is a
+   * verdict the launch path may legitimately dispose of as a plain local folder; `malformed` (the
+   * row named a host that cannot be parsed) must fail closed. A vocabulary that cannot express the
+   * difference guarantees it is lost at the first caller that switches on it — the same shape as
+   * #18006, where one word had to stand for two liveness situations.
+   */
+  | { kind: 'unresolved'; reason: 'ambiguous' | 'unknown' | 'malformed' }
+
+/**
+ * The owner row's host, or `null` when the row names one that cannot be parsed.
+ *
+ * Module-private and deliberately not a second exported reading of a repo row: only this resolution
+ * needs the distinction, because only this resolution is routing. `getRepoExecutionHostId` stays the
+ * answer everywhere else — its fall-through to `local` is harmless for the grouping, label and index
+ * callers that make up nearly all of its ~340 call sites, and is wrong only when the value decides
+ * where work runs.
+ */
+function resolveOwnerRowHostId(row: ExecutionHostOwnerRow): ExecutionHostId | null {
+  return row.executionHostId?.trim()
+    ? normalizeExecutionHostId(row.executionHostId)
+    : getRepoExecutionHostId(row)
+}
 
 export function resolveWorktreeExecutionHost<T extends ExecutionHostOwnerRow>(
   lookup: ExecutionHostOwnerLookup<T>,
@@ -80,9 +102,13 @@ export function resolveWorktreeExecutionHost<T extends ExecutionHostOwnerRow>(
   if (match.kind !== 'resolved') {
     return { kind: 'unresolved', reason: match.kind === 'ambiguous' ? 'ambiguous' : 'unknown' }
   }
+  const hostId = resolveOwnerRowHostId(match.owner)
+  if (!hostId) {
+    return { kind: 'unresolved', reason: 'malformed' }
+  }
   return {
     kind: 'resolved',
-    hostId: getRepoExecutionHostId(match.owner),
+    hostId,
     connectionId: getRepoSshConnectionId(match.owner),
     owner: match.owner
   }
@@ -115,12 +141,14 @@ export function createRepoRowExecutionHostLookup<T extends ExecutionHostOwnerRow
       if (!owner) {
         return { kind: 'missing' }
       }
-      const ownerHostId = getRepoExecutionHostId(owner)
-      return rows.some((repo) => getRepoExecutionHostId(repo) !== ownerHostId)
+      const ownerHostId = resolveOwnerRowHostId(owner)
+      return rows.some((repo) => resolveOwnerRowHostId(repo) !== ownerHostId)
         ? { kind: 'ambiguous' }
         : { kind: 'resolved', owner }
     },
+    // A row naming an unparseable host matches no host, which is what stops a worktree on a real
+    // host from adopting it.
     byHost: (repoId, hostId) =>
-      rowsFor(repoId).find((repo) => getRepoExecutionHostId(repo) === hostId) ?? null
+      rowsFor(repoId).find((repo) => resolveOwnerRowHostId(repo) === hostId) ?? null
   }
 }


### PR DESCRIPTION
## The defect

`resolveFolderWorkspaceHost` inferred a folder workspace's host by reading `repo.connectionId` **directly**:

```ts
const connectionId = normalizeConnectionId(repo.connectionId)
if (connectionId) { connectionIds.add(connectionId) } else { hasLocalRepo = true }
```

SSH ownership has two spellings on a repo row — the legacy `connectionId` field and the unified `executionHostId`. A row carrying only `executionHostId: 'ssh:<target>'` has no `connectionId`, so it fell into the `else` and counted as a **local** repo. A folder workspace whose files live on an SSH host therefore resolved `{ kind: 'local' }`, or `ambiguous` when mixed with a genuinely local repo.

`local` means "execute on this machine", so this is the #11163 execute-here class — and unlike the rest of that workstream **it fires on a perfectly well-formed row**. Nothing malformed is involved; it is live today.

The fix resolves the host first, then reads the target off it.

## A second, separate defect this PR deliberately does NOT fix

While fixing the above I identified another live bug in the same loop, and I am leaving it alone on purpose. Stating it plainly rather than as a style choice:

**A folder workspace over a `runtime:` repo row can resolve `{ kind: 'ssh', targetId: nestedTarget }`, and that is arguably wrong.** A `runtime:` row's `connectionId` holds the SSH target *nested inside that runtime environment*, addressable only as the pair `(environmentId, targetId)`. Handing it to this client's SSH table dials a same-named box in **our** namespace — the wrong-host answer this codebase warns about in `execution-host-provider-dispatch`, `host-repo-catalog-snapshot` and `host-qualified-worktree-listing`, all of which reject runtime hosts for exactly this reason. It is live today, independent of this PR.

**Why it is not fixed here.** The tidy-looking change — route `runtime:` rows to `hasLocalRepo` so the inference matches the explicit-pin branch — is a second behaviour change riding on an unrelated targeted fix. "Consistent" is how regressions get smuggled into a narrow PR, and this one would alter how every runtime-hosted folder workspace resolves, which deserves its own change, its own reasoning about what `FolderWorkspaceHost` should answer for a runtime host, and its own review. It is tracked as a separate finding.

So non-`ssh:` rows fall back to the raw `connectionId` read and every runtime row keeps its current contribution byte for byte. **`leaves a runtime row contributing its nested connection exactly as before` pins that**, so the omission is a recorded decision rather than something a future reader has to guess at.

## Otherwise unchanged

- **The explicit `runtime:` pin still answers `local`**, and now carries a comment saying why: `FolderWorkspaceHost` has no runtime variant, a runtime environment's own server normalizes its work to `local`, and the nested target is addressable only as the pair above. Widening the type is a separate change with its own blast radius — recorded so the next reader doesn't take it for an oversight.
- Every other row keeps its existing contribution: a legacy `connectionId`-only row, a contradictory `local` + `connectionId` row, and a blank connection id all resolve exactly as they did.

## Three smaller items, each justified independently of the above

1. **`resolveWorktreeExecutionHost` gains a `malformed` reason distinct from `unknown`.** `unknown` (nothing carries the id) is a verdict the launch path may legitimately dispose of as a plain local folder; `malformed` (the row named a host that cannot be parsed) must fail closed. A vocabulary that cannot express the difference guarantees it is lost at the first caller that switches on it — the same shape as #18006, where `SshRemotePtyLeaseState` had no `unverifiable` member and two situations shared one word. The strict read is **private to that module**: `getRepoExecutionHostId` stays the answer everywhere else, because its fall-through to `local` is harmless for the grouping, label, index-key and set-membership callers that make up nearly all of its ~340 call sites.
2. **`readAllWorktreeMetaForRepo` / `readWorktreeMetaForRepo`** replace four open-coded copies of the same host-qualified read — the lockstep-copy shape behind F7/F8.
3. **`getExecutionHostLabel` answers `'Unknown host'`** rather than `'All hosts'` for an id that names no host. Reading one unroutable row as the everything-scope is wrong on its own terms. Plain English like every other label in that module (`'Local Mac'`, `'This computer'`, `'All hosts'`) — I checked, none resolve through the renderer's i18n catalog, so no key was added and `sync:localization-runtime-catalog` was not run. *Pre-existing gap flagged, not fixed here:* that module's labels are rendered raw at ~8 call sites and ship English to all six locales; routing all five through the catalog is its own change.

## Recorded: no producer of a malformed `executionHostId` exists

Verbatim, so nobody re-derives it. This is why the wide `getRepoExecutionHostId` migration (#18588) was **closed unmerged** and why nothing here depends on a malformed row existing.

**Every writer of `Repo.executionHostId` encodes.** All nine go through `toSshExecutionHostId` / `toRuntimeExecutionHostId` — both `encodeURIComponent`, so no bare `|`, and `parseExecutionHostId` round-trips them — or the `LOCAL_EXECUTION_HOST_ID` constant, each behind a truthiness/`trim()` guard so none can emit a bare `ssh:`:
`add-repo-store-upsert.ts:19,25` · `owner-routing.ts:27` · `web-runtime-calls.ts:98` · `remote-repo-registration.ts:87,100` · `local-repo-registration.ts:80` · `repo-clone-lifecycle.ts:264` · `repo-creation-handlers.ts:270` · `nested-repo-import-handler.ts:126`.

About a dozen places build `` `ssh:${…}` `` / `` `runtime:${…}` `` unencoded; each was checked and all are cache keys, comparison keys, or `expectedExecutionHostId` arguments. None writes a repo row.

| Vector | Finding |
|---|---|
| Persisted-state migration | **None writes the field.** The only persistence module that mentions it reads it for a cache key. |
| Wire, newer or older client | **Closed.** The runtime RPC `repo.update` schema (`repo-update-schema.ts`) does not list `executionHostId`, and zod strips unknown keys, so a peer cannot write one. A peer's served catalog is a clone of its own store, carrying only what that host's writers produced. |
| Truncated / partial write | **Closed.** State writes are temp-file + `rename` (`write-flush-barriers.ts:196-207,250-257`). A crash yields the old file or a complete new one; a torn file fails `JSON.parse` and goes to backup recovery. It cannot yield well-formed JSON with a mangled field. |
| `mobile/` | **No writer** — four read sites only. |
| Hand-edited config / a non-Orca peer | The one remaining path. |

The invariant is nonetheless enforced nowhere on ingress — `loaded-state-parsing.ts:99` is `JSON.parse(raw) as PersistedState`, an unchecked cast, and `hydrateRepo` sanitizes eight fields but not this one; `direct-ssh-host-hydration.ts:62` splices a peer's `snapshot.repos` into `state.repos` with no per-row validation. That is tracked separately as an ingress-validation item, not addressed here: rejecting a row on the wire merge is defensible, but silently dropping a user's project on persistence load is not, and there is no safe value to clamp to. It needs a product decision, not type surgery.

## Candidate selection had the same defect (found in review)

CodeRabbit caught that fixing the resolver was not enough: `findFolderWorkspaceCandidateRepos` decides which rows reach it, and it read `repo.connectionId` raw too — so an SSH-only repo **outside the project-group subtree** was dropped before the new logic ran, and the execute-here bug survived for exactly the population this PR is for.

The audit found **three** repo-row reads with this root cause, not one:

| Line | Read | Effect |
|---|---|---|
| 62 | `pathRepos.filter(raw === args.connectionId)` | an `executionHostId: 'ssh:*'`-only path repo is dropped against a scope connection |
| 69 | `groupConnectionIds` built from group repos' raw field | a group repo on `ssh:box` via the unified spelling contributes `null` |
| 73 | that set tested against path repos' raw field | the other half of the same comparison |

**Fixing exactly what the review named would have left the class intact.** 69 and 73 are one comparison with the mismatch on either side: resolving only the path repos — the literal reading of the comment — would have reintroduced the identical bug from the group side, where a group repo on `ssh:box` via the unified spelling contributes `null` and so matches nothing. The review found one instance of a class; the fix has to be the class.

All three reads, plus the resolution loop, now go through a single `getRepoScopeConnectionId` helper, so there is one place to change if this rule ever moves — the four lockstep copies were the shape behind F7 and F8.

The regression tests use a repo matched **only by path, outside the subtree** — the population every pre-existing test missed, which is why the original four passing revert-tests did not catch this.

### One more instance, flagged and not fixed

`findFolderWorkspaceCandidateRepos` (line 89) derives its scope connection from `workspace.connectionId ?? group?.connectionId` and never consults `workspace.executionHostId`. A folder workspace pinned to `ssh:box` with no `connectionId` therefore scopes its candidates as if it had no connection. `resolveFolderWorkspaceHost` is unaffected — its explicit-pin branch returns first — but the exported function's other callers (the renderer's owner resolution, AI-vault resume targeting, direct-SSH target scope) do see it. Same defect class on the *workspace* row rather than a repo row; changing it alters that function's contract for independent consumers, so it belongs in its own change.

## Verification

- `pnpm tc` clean. `mobile/` typechecked separately (`npx tsc --noEmit`, exit 0) — the root projects do not cover it — plus its 4,064 tests.
- `src/renderer` 29,272 · `src/shared`/`src/relay`/`src/cli` 9,687 · `mobile` 4,064 all green. `src/main` (31,414) has two failing files, neither in this diff: `ssh-remote-commands.test.ts` (load-sensitive, green in isolation) and `structured-tui-transcript-catchup.test.ts`, which **fails on clean `origin/main`** — verified in a separate worktree at the merge base, three runs, failing every time. Reported separately; not caused here.
- `oxlint` clean on every changed file. `max-lines` proven live with a positive control: a temporary 320-line file was linted, the rule fired (`File has too many lines (320)`), and the file was removed. A clean lint on this diff therefore means the rule ran.
- `pnpm run check:code-quality:changed`: 0 new findings across 12 files. Formatted with `oxfmt` scoped to the changed files, and staged file-by-file — `pnpm format` runs `oxfmt --write .` repo-wide, which previously swept six unrelated reformats including a CI workflow into a commit.

**Per-test revert results.** Every new test was run with its production change reverted:

- Restoring the raw `repo.connectionId` read fails **4 of 4** new folder-workspace tests (`executionHostId`-only resolves SSH; mixed with a local repo is ambiguous; a scope connection matches such a repo; a percent-encoded target decodes).
- The two "deliberately unchanged" tests — the runtime row's nested contribution and the runtime pin answering `local` — pass **both ways by design**; they are regression guards pinning the non-change.
- Reverting the private strict read to the total reading fails both new `malformed` tests.
- Reverting the label branch fails the `'Unknown host'` test.
- `readAllWorktreeMetaForRepo` / `readWorktreeMetaForRepo` are a pure de-duplication with no behaviour change, so they carry no new test; the existing tests over the four call sites cover them. Called out rather than papered over with a tautological assertion.