### PR TITLE
fix(dashboard): hide agents without live local panes

### DIFF
--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -473,7 +473,7 @@ describe('buildDashboardSnapshot', () => {
     expect(snapshot.repoIconsByRepoId).toEqual({ r1: null })
   })
 
-  it('nulls ptyId when the layout entry points at a dead pty', () => {
+  it('omits a local agent when the layout points at a dead pty', () => {
     const snapshot = buildDashboardSnapshot(
       baseState({
         agentStatusByPaneKey: { [PANE_KEY]: entry({}) },
@@ -483,7 +483,30 @@ describe('buildDashboardSnapshot', () => {
       }),
       NOW
     )
-    expect(snapshot.cards[0].ptyId).toBeNull()
+
+    expect(snapshot.cards).toEqual([])
+  })
+
+  it('keeps a remote agent visible when terminal liveness is unverifiable', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        repos: [
+          {
+            id: 'r1',
+            path: '/r1',
+            displayName: 'Repo One',
+            badgeColor: '#000',
+            executionHostId: 'ssh:host-1'
+          }
+        ],
+        agentStatusByPaneKey: { [PANE_KEY]: entry({}) },
+        ptyIdsByTabId: { [TAB_ID]: [] }
+      } as unknown as Partial<DashboardSnapshotState>),
+      NOW
+    )
+
+    expect(snapshot.cards).toHaveLength(1)
+    expect(snapshot.cards[0]).toMatchObject({ ptyId: null, hostKind: 'ssh' })
   })
 
   it('moves an acknowledged completion to idle while retaining its raw done state', () => {
@@ -549,7 +572,7 @@ describe('buildDashboardSnapshot', () => {
     expect(snapshot.cards[0].dotState).toBe('idle')
   })
 
-  it('routes retained done agents to the done bucket', () => {
+  it('omits retained done agents whose local pane is gone', () => {
     const donePaneKey = makePaneKey(TAB_ID, GONE_LEAF_ID)
     const snapshot = buildDashboardSnapshot(
       baseState({
@@ -565,9 +588,8 @@ describe('buildDashboardSnapshot', () => {
       }),
       NOW
     )
-    const done = snapshot.cards.find((c) => c.dotState === 'done')
-    expect(done).toBeDefined()
-    expect(done?.bucket).toBe('done')
+
+    expect(snapshot.cards).toEqual([])
   })
 
   it('includes collapsed subagents and workspace status metadata on the parent card', () => {

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -572,7 +572,7 @@ describe('buildDashboardSnapshot', () => {
     expect(snapshot.cards[0].dotState).toBe('idle')
   })
 
-  it('omits retained done agents whose local pane is gone', () => {
+  it('keeps retained done agents after their local pane is gone', () => {
     const donePaneKey = makePaneKey(TAB_ID, GONE_LEAF_ID)
     const snapshot = buildDashboardSnapshot(
       baseState({
@@ -589,7 +589,13 @@ describe('buildDashboardSnapshot', () => {
       NOW
     )
 
-    expect(snapshot.cards).toEqual([])
+    expect(snapshot.cards).toHaveLength(1)
+    expect(snapshot.cards[0]).toMatchObject({
+      paneKey: donePaneKey,
+      ptyId: null,
+      bucket: 'done',
+      dotState: 'done'
+    })
   })
 
   it('includes collapsed subagents and workspace status metadata on the parent card', () => {

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -182,6 +182,11 @@ export function buildDashboardSnapshot(
         layoutPtyId && (state.ptyIdsByTabId?.[tabId] ?? []).includes(layoutPtyId)
           ? layoutPtyId
           : null
+      // A local row without a live PTY cannot be opened or focused. Do not
+      // publish dead cards; remote absence is only unverifiable and stays visible.
+      if (includeCardDetails && !ptyId && workspace.remoteHostKind === null) {
+        continue
+      }
       // Why: only a live pty can open a preview terminal, and only a
       // card-rendering caller can open one — the sidebar's bucket counts must
       // not pay host resolution on every agent-status tick.

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -182,9 +182,14 @@ export function buildDashboardSnapshot(
         layoutPtyId && (state.ptyIdsByTabId?.[tabId] ?? []).includes(layoutPtyId)
           ? layoutPtyId
           : null
-      // A local row without a live PTY cannot be opened or focused. Do not
-      // publish dead cards; remote absence is only unverifiable and stays visible.
-      if (includeCardDetails && !ptyId && workspace.remoteHostKind === null) {
+      // A live local row without a PTY cannot be opened or focused. Retained rows
+      // intentionally outlive their completed terminal; remote absence is unverifiable.
+      if (
+        includeCardDetails &&
+        !ptyId &&
+        row.rowSource !== 'retained' &&
+        workspace.remoteHostKind === null
+      ) {
         continue
       }
       // Why: only a live pty can open a preview terminal, and only a


### PR DESCRIPTION
## ELI5

Agent Dashboard no longer shows local agent cards whose terminal pane is already gone.

## What Changed

- Skip local dashboard cards when their remembered pane has no live PTY.
- Keep SSH/remote cards visible because missing client-side PTY state does not prove remote process exit.
- Update snapshot tests for dead local panes, retained completed agents, and unverifiable remote sessions.

## Why

After restart/reboot, restored local pane metadata can outlive its PTY. Those cards cannot open or focus anything and only lead to the “pane has closed” dialog.

## Linked Issue

Fixes #10669

## Visual Proof

N/A — stale cards are removed at snapshot generation; regression is covered with deterministic snapshot tests because reproducing the source state requires reboot/session restoration.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Executed on Linux:

- `pnpm test src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts` — 29 passed
- `pnpm tc:web` — passed
- `pnpm run check:code-quality:changed` — 0 findings

SSH boundary: remote cards remain visible when PTY liveness is unverifiable.

## AI Disclosure

Implemented with OpenAI Codex GPT-5.6 assistance; changes and verification were reviewed locally.

## Review

Please verify restored local sessions after reboot no longer produce dead dashboard cards, while SSH cards remain available to open their workspace.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No wire contract changes. Filtering happens only for detailed dashboard snapshots, preserving lightweight sidebar bucket-count behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with explanation