### PR TITLE
fix(relay): release the ConPTY conin handle after teardown, not before it

### DIFF
--- a/config/relay-assets/node-pty-1.1.0-windows-pty-teardown-patch.cjs
+++ b/config/relay-assets/node-pty-1.1.0-windows-pty-teardown-patch.cjs
@@ -1,0 +1,158 @@
+const { createHash } = require('node:crypto')
+const { readFileSync, renameSync, rmSync, writeFileSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+
+/**
+ * Release the ConPTY teardown handles a relay's npm-installed node-pty never releases.
+ *
+ * Two files, and the ORDER of one of the edits is the whole fix.
+ *
+ * `windowsPtyAgent.js` -- `kill()` flips `readable` on both sockets and destroys neither.
+ * `_cleanUpProcess` destroys `_outSocket`, so the conout handle comes back; nothing ever destroys
+ * `_inSocket`, and it wraps a real Windows named-pipe handle from `fs.openSync(term.conin, 'w')`.
+ * Every terminal leaks one File handle for the life of the host process.
+ *
+ * The obvious fix -- and the one the desktop patch ships -- releases it at the TOP of the branch,
+ * before `_getConsoleProcessList()` forks and before the native kill. That is measurably worse than
+ * leaving the leak alone: teardown aborts partway, the forked console-list agent is never reaped,
+ * and both pipe handles stay alive instead of one. This asset releases it at the END of the branch
+ * instead, after the fork and the kill have already happened.
+ *
+ * Measured on a Windows SSH host, 20 spawn/kill cycles, handles bucketed by NT object type
+ * (identical numbers standalone and through a real relay):
+ *
+ *   published node-pty        File +1/terminal,  Process flat
+ *   desktop patch placement   File +2/terminal,  Process +1/terminal   <-- 3x WORSE
+ *   released last (here)      File flat,         Process flat
+ *
+ * `windowsTerminal.js` carries the desktop's error-listener hunks verbatim. The conin listener is
+ * what keeps a pipe error retiring one terminal instead of the host -- its own comment names the
+ * failure mode: "Without a listener, Node promotes errors such as write EAGAIN to uncaughtException".
+ * It is not what fixes the leak (adding it changed nothing on its own), but it is the guard that
+ * makes destroying conin safe at all.
+ *
+ * Why this ships as a relay asset rather than only in config/patches/node-pty@1.1.0.patch: pnpm
+ * patches do not cross the SSH boundary -- a relay host runs the tree `npm install` put there.
+ *
+ * DELIBERATE DIVERGENCE FROM THE DESKTOP: the desktop patch has the early placement and therefore
+ * the +2 File / +1 Process regression, measured against its exact installed tree. Correcting it
+ * there is a separate change with its own verification, so the two trees differ on this one hunk on
+ * purpose, and the test pins that so a future "sync the patches" does not copy the bug back.
+ *
+ * NOT ADDRESSED, AND A SEPARATE DEFECT THAT IS STILL OPEN: a terminal that exits on its own is
+ * still torn down through `kill()` -- both hosts call `destroy()` on natural exit and
+ * `WindowsTerminal.destroy()` is `kill()` -- but the shell is already gone by then, and the
+ * ordering this patch relies on does not hold. Measured over 20 self-exit cycles with that
+ * `destroy()` issued: published +3 File/+1 Process per terminal, desktop-patched +2/+1, this tree
+ * +2/+1. So this patch does not close it and the desktop patch does not either. It is reachable
+ * for every Windows user, local and relay, on every terminal closed by typing `exit`.
+ */
+
+const EXPECTED_NODE_PTY_VERSION = '1.1.0'
+
+/** Each entry is one published file, its patched form, and the edits between them. */
+const PATCH_TARGETS = [
+  {
+    relativePath: ['lib', 'windowsPtyAgent.js'],
+    originalSha256: '8636d16b38266112204061a22b135734177c242837982fd3a4055be726efa64a',
+    patchedSha256: '1e23ef480569e73706e3ab4f5482c7e553c76f51414ae8e7b0bdcc2fd75f7280',
+    replacements: [
+      [
+        '                this._ptyNative.kill(this._pty, this._useConptyDll);\n                this._conoutSocketWorker.dispose();\n',
+        '                this._ptyNative.kill(this._pty, this._useConptyDll);\n                this._conoutSocketWorker.dispose();\n                // Orca: released AFTER the console-list fork and the native kill, not before them.\n                // Destroying conin first aborts teardown partway -- measured on a Windows SSH relay\n                // as +2 File and +1 Process handles per terminal, against +1 File unpatched.\n                this._inSocket.destroy();\n'
+      ]
+    ]
+  },
+  {
+    relativePath: ['lib', 'windowsTerminal.js'],
+    originalSha256: 'c3a65716f53fed0135a8a633373d5f9c2ab092544d651f27ef0a67096dd3bcd9',
+    patchedSha256: '8247ecd69be8b18257050fb026b290024612c5ffc6d492ff1d46f81e613be2cf',
+    replacements: [
+      [
+        '        _this._agent = new windowsPtyAgent_1.WindowsPtyAgent(file, args, parsedEnv, cwd, _this._cols, _this._rows, false, opt.useConpty, opt.useConptyDll, opt.conptyInheritCursor);\n        _this._socket = _this._agent.outSocket;\n        // Not available until `ready` event emitted.\n        _this._pid = _this._agent.innerPid;',
+        "        _this._agent = new windowsPtyAgent_1.WindowsPtyAgent(file, args, parsedEnv, cwd, _this._cols, _this._rows, false, opt.useConpty, opt.useConptyDll, opt.conptyInheritCursor);\n        _this._socket = _this._agent.outSocket;\n        // Attach before readiness so a broken ConPTY output pipe cannot be unhandled.\n        _this._socket.on('error', function (err) {\n            var code = err && err.code;\n            // PTY output can report EPIPE before `_close()` wins the race.\n            _this._close();\n            if (code === 'EPIPE' || code === 'ERR_STREAM_PUSH_AFTER_EOF' || code === 'ERR_STREAM_DESTROYED') {\n                return;\n            }\n            // EIO, happens when someone closes our child process: the only process\n            // in the terminal.\n            // node < 0.6.14: errno 5\n            // node >= 0.6.14: read EIO\n            if (typeof code === 'string') {\n                if (~code.indexOf('errno 5') || ~code.indexOf('EIO'))\n                    return;\n            }\n            // Throw anything else.\n            if (_this.listeners('error').length < 2) {\n                throw err;\n            }\n        });\n        // Not available until `ready` event emitted.\n        _this._pid = _this._agent.innerPid;"
+      ],
+      [
+        "                }\n            });\n            // Shutdown if `error` event is emitted.\n            _this._socket.on('error', function (err) {\n                // Close terminal session.\n                _this._close();\n                // EIO, happens when someone closes our child process: the only process\n                // in the terminal.\n                // node < 0.6.14: errno 5\n                // node >= 0.6.14: read EIO\n                if (err.code) {\n                    if (~err.code.indexOf('errno 5') || ~err.code.indexOf('EIO'))\n                        return;\n                }\n                // Throw anything else.\n                if (_this.listeners('error').length < 2) {\n                    throw err;\n                }\n            });\n            // Cleanup after the socket is closed.\n            _this._socket.on('close', function () {",
+        "                }\n            });\n            // Cleanup after the socket is closed.\n            _this._socket.on('close', function () {"
+      ],
+      [
+        '        _this._readable = true;\n        _this._writable = true;\n        _this._forwardEvents();\n        return _this;',
+        "        _this._readable = true;\n        _this._writable = true;\n        // A ConPTY input-pipe error must retire only this terminal. Without a listener, Node promotes\n        // errors such as write EAGAIN to uncaughtException and kills every PTY in the daemon.\n        _this._agent.inSocket.on('error', function () {\n            if (!_this._writable) {\n                return;\n            }\n            _this._close();\n            try {\n                _this._agent.kill();\n            }\n            catch (_a) {\n                // The failing pipe may have raced process exit; the terminal is already unwritable.\n            }\n        });\n        _this._forwardEvents();\n        return _this;"
+      ],
+      [
+        'exports.WindowsTerminal = WindowsTerminal;\n//# sourceMappingURL=windowsTerminal.js.map',
+        'exports.WindowsTerminal = WindowsTerminal;\n//# sourceMappingURL=windowsTerminal.js.map\n'
+      ]
+    ]
+  }
+]
+
+function inspectTarget(relayDir, target) {
+  const nodePtyDir = resolve(relayDir, 'node_modules', 'node-pty')
+  const packageJson = JSON.parse(readFileSync(join(nodePtyDir, 'package.json'), 'utf8'))
+  if (packageJson.version !== EXPECTED_NODE_PTY_VERSION) {
+    throw new Error(
+      `Refusing to patch node-pty ${packageJson.version}; expected ${EXPECTED_NODE_PTY_VERSION}`
+    )
+  }
+  const filePath = join(nodePtyDir, ...target.relativePath)
+  return { filePath, source: readFileSync(filePath, 'utf8') }
+}
+
+function assertPatchedNodePtyWindowsTeardown(relayDir = process.cwd()) {
+  for (const target of PATCH_TARGETS) {
+    const inspected = inspectTarget(relayDir, target)
+    if (sourceSha256(inspected.source) !== target.patchedSha256) {
+      throw new Error(
+        `node-pty ConPTY teardown release is not installed in ${target.relativePath.join('/')}`
+      )
+    }
+  }
+}
+
+function patchNodePtyWindowsTeardown(relayDir = process.cwd()) {
+  for (const target of PATCH_TARGETS) {
+    const inspected = inspectTarget(relayDir, target)
+    const sourceHash = sourceSha256(inspected.source)
+    if (sourceHash === target.patchedSha256) {
+      continue
+    }
+    if (sourceHash !== target.originalSha256) {
+      throw new Error(
+        `Refusing to patch unexpected node-pty source in ${target.relativePath.join('/')}`
+      )
+    }
+    let patchedSource = inspected.source
+    for (const [from, to] of target.replacements) {
+      // Why the count check: an anchor that matched twice would patch the wrong site silently, and
+      // the hash below would then reject a tree this script had already rewritten.
+      if (patchedSource.split(from).length - 1 !== 1) {
+        throw new Error(`Refusing to patch ${target.relativePath.join('/')}; anchor is not unique`)
+      }
+      patchedSource = patchedSource.replace(from, to)
+    }
+    const temporaryPath = `${inspected.filePath}.orca-patch-${process.pid}`
+    // Why: a terminated remote install must leave either known source version recoverable on reconnect.
+    try {
+      writeFileSync(temporaryPath, patchedSource)
+      renameSync(temporaryPath, inspected.filePath)
+    } finally {
+      rmSync(temporaryPath, { force: true })
+    }
+  }
+  assertPatchedNodePtyWindowsTeardown(relayDir)
+}
+
+function sourceSha256(source) {
+  return createHash('sha256').update(source).digest('hex')
+}
+
+if (require.main === module) {
+  patchNodePtyWindowsTeardown()
+}
+
+module.exports = {
+  assertPatchedNodePtyWindowsTeardown,
+  patchNodePtyWindowsTeardown
+}

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -57,6 +57,13 @@ const NODE_PTY_CONSOLE_LIST_PATCH_SOURCE = join(
   'relay-assets',
   NODE_PTY_CONSOLE_LIST_PATCH_FILENAME
 )
+const NODE_PTY_WINDOWS_TEARDOWN_PATCH_FILENAME = 'node-pty-1.1.0-windows-pty-teardown-patch.cjs'
+const NODE_PTY_WINDOWS_TEARDOWN_PATCH_SOURCE = join(
+  ROOT,
+  'config',
+  'relay-assets',
+  NODE_PTY_WINDOWS_TEARDOWN_PATCH_FILENAME
+)
 const NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME = 'node-pty-1.1.0-master-cloexec-patch.cjs'
 const NODE_PTY_MASTER_CLOEXEC_PATCH_SOURCE = join(
   ROOT,
@@ -131,6 +138,10 @@ for (const platform of RELAY_BUILD_PLATFORMS) {
     copyFileSync(
       NODE_PTY_CONSOLE_LIST_PATCH_SOURCE,
       join(outDir, NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)
+    )
+    copyFileSync(
+      NODE_PTY_WINDOWS_TEARDOWN_PATCH_SOURCE,
+      join(outDir, NODE_PTY_WINDOWS_TEARDOWN_PATCH_FILENAME)
     )
   }
   copyFileSync(

--- a/config/scripts/node-pty-windows-pty-teardown-patch.test.mjs
+++ b/config/scripts/node-pty-windows-pty-teardown-patch.test.mjs
@@ -1,0 +1,195 @@
+// The relay's copy of the ConPTY teardown release, and the guard that keeps it in lockstep with the
+// desktop's own node-pty patch. pnpm patches do not cross the SSH boundary, so a relay runs the tree
+// `npm install` put there; the desktop had this fix and the relay did not, and every terminal on a
+// Windows SSH host leaked one File handle for the life of the relay process.
+//
+// The ORDER of the conin release is the fix. Releasing it at the top of the branch -- what the
+// desktop patch does -- was measured at 3x WORSE than shipping nothing (File +2/terminal and a new
+// Process +1/terminal); releasing it after the console-list fork and the native kill is flat.
+import { createRequire } from 'node:module'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  assertPatchedNodePtyWindowsTeardown,
+  patchNodePtyWindowsTeardown
+} = require('../relay-assets/node-pty-1.1.0-windows-pty-teardown-patch.cjs')
+const projectDir = resolve(import.meta.dirname, '..', '..')
+const cleanupDirs = []
+
+const PATCHED_FILES = ['windowsPtyAgent.js', 'windowsTerminal.js']
+
+/** The hunks config/patches/node-pty@1.1.0.patch adds to the installed desktop tree. */
+const DESKTOP_HUNKS = {
+  'windowsPtyAgent.js': [
+    [
+      [
+        '                this._inSocket.readable = false;',
+        '                // The non-DLL path previously only flipped `readable`, leaving the',
+        '                // conin PipeWrap alive until the host exited (#947).',
+        '                this._inSocket.destroy();',
+        '                this._outSocket.readable = false;',
+        ''
+      ].join('\n'),
+      [
+        '                this._inSocket.readable = false;',
+        '                this._outSocket.readable = false;',
+        ''
+      ].join('\n')
+    ]
+  ],
+  'windowsTerminal.js': [
+    [
+      '        // Attach before readiness so a broken ConPTY output pipe cannot be unhandled.',
+      null
+    ],
+    ['        // A ConPTY input-pipe error must retire only this terminal.', null]
+  ]
+}
+
+function desktopPath(file) {
+  return join(projectDir, 'node_modules', 'node-pty', 'lib', file)
+}
+
+afterEach(() => {
+  for (const dir of cleanupDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('Windows SSH relay node-pty ConPTY teardown patch', () => {
+  // Why reconstruct rather than vendor upstream: the installed tree IS the published file plus the
+  // desktop's hunks, so un-applying them yields upstream exactly -- and pinning that against this
+  // asset's own hashes is what fails loudly if either side of the pair moves.
+  it('takes the desktop error listeners verbatim', () => {
+    const fixture = writeNodePtyFixture('1.1.0')
+    patchNodePtyWindowsTeardown(fixture.root)
+
+    expect(readFileSync(join(fixture.libDir, 'windowsTerminal.js'), 'utf8')).toBe(
+      readFileSync(desktopPath('windowsTerminal.js'), 'utf8')
+    )
+  })
+
+  // The one hunk that must NOT match the desktop, and the reason is measured, not stylistic:
+  // releasing conin before `_getConsoleProcessList()` forks aborts teardown partway.
+  it('releases conin after the console-list fork, not before it like the desktop patch', () => {
+    const fixture = writeNodePtyFixture('1.1.0')
+    patchNodePtyWindowsTeardown(fixture.root)
+    const patched = readFileSync(join(fixture.libDir, 'windowsPtyAgent.js'), 'utf8')
+
+    const branch = patched.slice(
+      patched.indexOf('if (!this._useConptyDll) {'),
+      patched.indexOf('else {', patched.indexOf('if (!this._useConptyDll) {'))
+    )
+    expect(branch).toContain('this._inSocket.destroy();')
+    expect(branch.indexOf('this._inSocket.destroy();')).toBeGreaterThan(
+      branch.indexOf('this._conoutSocketWorker.dispose();')
+    )
+    expect(branch.indexOf('this._inSocket.destroy();')).toBeGreaterThan(
+      branch.indexOf('this._getConsoleProcessList()')
+    )
+    // Pinned so a future "sync the relay asset to config/patches" cannot copy the regression back.
+    expect(patched).not.toBe(readFileSync(desktopPath('windowsPtyAgent.js'), 'utf8'))
+  })
+
+  it('installs and verifies idempotently', () => {
+    const fixture = writeNodePtyFixture('1.1.0')
+
+    patchNodePtyWindowsTeardown(fixture.root)
+    const once = PATCHED_FILES.map((file) => readFileSync(join(fixture.libDir, file), 'utf8'))
+    for (const file of PATCHED_FILES) {
+      expect(existsSync(`${join(fixture.libDir, file)}.orca-patch-${process.pid}`)).toBe(false)
+    }
+    expect(() => assertPatchedNodePtyWindowsTeardown(fixture.root)).not.toThrow()
+
+    patchNodePtyWindowsTeardown(fixture.root)
+    expect(PATCHED_FILES.map((file) => readFileSync(join(fixture.libDir, file), 'utf8'))).toEqual(
+      once
+    )
+  })
+
+  it('refuses a different package version or unexpected source', () => {
+    const wrongVersion = writeNodePtyFixture('1.2.0-beta.11')
+    expect(() => patchNodePtyWindowsTeardown(wrongVersion.root)).toThrow('expected 1.1.0')
+
+    for (const file of PATCHED_FILES) {
+      const drifted = writeNodePtyFixture('1.1.0')
+      const path = join(drifted.libDir, file)
+      writeFileSync(path, `${readFileSync(path, 'utf8')}\n// drift`)
+      expect(() => patchNodePtyWindowsTeardown(drifted.root)).toThrow('unexpected node-pty')
+    }
+  })
+
+  it('refuses a half-applied tree, so one file cannot pass for both', () => {
+    for (const file of PATCHED_FILES) {
+      const partial = writeNodePtyFixture('1.1.0')
+      const fixture = writeNodePtyFixture('1.1.0')
+      patchNodePtyWindowsTeardown(fixture.root)
+      writeFileSync(join(partial.libDir, file), readFileSync(join(fixture.libDir, file), 'utf8'))
+      expect(() => assertPatchedNodePtyWindowsTeardown(partial.root)).toThrow('is not installed')
+    }
+  })
+})
+
+/** A published node-pty tree, rebuilt by un-applying the desktop hunks from the installed one. */
+function writeNodePtyFixture(version) {
+  const root = mkdtempSync(join(projectDir, '.node-pty-teardown-patch-test-'))
+  cleanupDirs.push(root)
+  const libDir = join(root, 'node_modules', 'node-pty', 'lib')
+  mkdirSync(libDir, { recursive: true })
+  writeFileSync(join(root, 'node_modules', 'node-pty', 'package.json'), JSON.stringify({ version }))
+  for (const file of PATCHED_FILES) {
+    const desktop = readFileSync(desktopPath(file), 'utf8')
+    for (const [marker] of DESKTOP_HUNKS[file]) {
+      expect(desktop).toContain(marker)
+    }
+    writeFileSync(join(libDir, file), unapplyDesktopHunks(file, desktop))
+  }
+  return { root, libDir }
+}
+
+/**
+ * Reverse of the published-to-desktop transform.
+ *
+ * `windowsTerminal.js` is taken verbatim from the desktop, so the asset's own replacement table is
+ * the transform and reversing it is exact. `windowsPtyAgent.js` deliberately diverges, so its
+ * published form is rebuilt from the desktop hunk instead -- which is also what makes this file the
+ * place that notices if the desktop hunk itself ever moves.
+ */
+function unapplyDesktopHunks(file, desktop) {
+  if (file === 'windowsPtyAgent.js') {
+    let published = desktop
+    for (const [patched, original] of DESKTOP_HUNKS[file]) {
+      expect(published.split(patched).length - 1).toBe(1)
+      published = published.replace(patched, original)
+    }
+    return published
+  }
+  const asset = readFileSync(
+    join(projectDir, 'config', 'relay-assets', 'node-pty-1.1.0-windows-pty-teardown-patch.cjs'),
+    'utf8'
+  )
+  const { PATCH_TARGETS } = loadPatchTargets(asset)
+  const target = PATCH_TARGETS.find((entry) => entry.relativePath.at(-1) === file)
+  expect(target).toBeDefined()
+  let published = desktop
+  for (const [from, to] of target.replacements.toReversed()) {
+    expect(published.split(to).length - 1).toBe(1)
+    published = published.replace(to, from)
+  }
+  return published
+}
+
+function loadPatchTargets(assetSource) {
+  const module = { exports: {} }
+  const factory = new Function(
+    'module',
+    'exports',
+    'require',
+    `${assetSource}\nmodule.exports.PATCH_TARGETS = PATCH_TARGETS`
+  )
+  factory(module, module.exports, require)
+  return module.exports
+}

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -743,6 +743,7 @@ function uploadStageNamespaceIfSupported(
 
 const NODE_PTY_VERSION = '1.1.0'
 const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
+const NODE_PTY_WINDOWS_TEARDOWN_PATCH_FILENAME = 'node-pty-1.1.0-windows-pty-teardown-patch.cjs'
 const NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME = 'node-pty-1.1.0-master-cloexec-patch.cjs'
 const NODE_PTY_CLOEXEC_STATUS_PREFIX = 'ORCA-NPTY-CLOEXEC:'
 /**
@@ -791,7 +792,8 @@ function nativeDepsProbeJs(successToken: string): string {
   // Why: node-pty's Windows wrapper defers conpty.node until first spawn, so require("node-pty") alone can't prove the binding is healthy.
   const loadNodePty =
     'require("node-pty"); require("node-pty/lib/utils").loadNativeModule(process.platform==="win32"&&Number(require("os").release().split(".")[2])>=18309?"conpty":"pty");' +
-    `if(process.platform==="win32"){require("./${NODE_PTY_CONSOLE_LIST_PATCH_FILENAME}").assertPatchedNodePtyConsoleListAgent(process.cwd())}`
+    `if(process.platform==="win32"){require("./${NODE_PTY_CONSOLE_LIST_PATCH_FILENAME}").assertPatchedNodePtyConsoleListAgent(process.cwd());` +
+    `require("./${NODE_PTY_WINDOWS_TEARDOWN_PATCH_FILENAME}").assertPatchedNodePtyWindowsTeardown(process.cwd())}`
   return `(()=>{const missing=[];try{${loadNodePty}}catch{missing.push("node-pty")}try{require("@parcel/watcher")}catch{missing.push("@parcel/watcher")}if(missing.length){console.log("${NATIVE_DEPS_MISSING_PREFIX}"+missing.join(","));process.exitCode=1}else{console.log(${JSON.stringify(successToken)})}})()`
 }
 
@@ -1327,10 +1329,16 @@ async function applyNodePtyMasterCloexecPatch(
   nodePath: string,
   signal?: AbortSignal
 ): Promise<NodePtyMasterCloexecOutcome> {
-  // Both Unix relay platforms leak, by different bugs: Linux inherits the master through forkpty()'s
-  // no-O_CLOEXEC path, macOS orphans one throwaway /dev/ptmx fd per spawn in pty_posix_spawn. Only
-  // Windows, which has no fds, is short-circuited -- and answering 'fixed' from a gate that ran
-  // nothing is exactly how a leaking darwin tree got published to the shared cache.
+  // Both Unix relay platforms leak the pty master, by different bugs: Linux inherits it through
+  // forkpty()'s no-O_CLOEXEC path, macOS orphans one throwaway /dev/ptmx fd per spawn in
+  // pty_posix_spawn. Windows is short-circuited because it has no fds for a master to leak into --
+  // and answering 'fixed' from a gate that ran nothing is exactly how a leaking darwin tree got
+  // published to the shared cache.
+  //
+  // What 'fixed' means here is exactly "this tree does not leak the pty MASTER", which is the only
+  // thing the shared native-deps cache keys on. It is NOT a statement that a Windows relay leaks
+  // nothing: it leaked one Windows File handle per terminal until the ConPTY teardown patch above,
+  // by a mechanism that has nothing to do with fds. Read this gate as scoped to its own question.
   if (isWindowsRemoteHost(hostPlatform) || isWindowsRelayPlatform(platform)) {
     return 'fixed'
   }
@@ -1530,8 +1538,11 @@ async function rebuildNativeDeps(
 }
 
 function windowsNodePtyPatchCommand(nodePath: string): string {
-  // Why: pnpm patches do not cross the SSH boundary; apply the version-checked fallback to the remote npm package.
-  return `& ${powerShellLiteral(nodePath)} ${powerShellLiteral(NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`
+  // Why: pnpm patches do not cross the SSH boundary; apply the version-checked fallbacks to the remote npm package.
+  return [
+    `& ${powerShellLiteral(nodePath)} ${powerShellLiteral(NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`,
+    `& ${powerShellLiteral(nodePath)} ${powerShellLiteral(NODE_PTY_WINDOWS_TEARDOWN_PATCH_FILENAME)}; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }`
+  ].join('; ')
 }
 
 async function makeNodePtySpawnHelperExecutable(

--- a/src/shared/relay-artifacts.ts
+++ b/src/shared/relay-artifacts.ts
@@ -57,6 +57,10 @@ export const RELAY_ARTIFACTS: readonly RelayArtifact[] = [
   // title request with no title and no error.
   { filename: 'wsl-transcript-fs-process-entry.js' },
   { filename: 'node-pty-1.1.0-console-list-agent-patch.cjs', windowsOnly: true },
+  // The ConPTY teardown release the desktop's own node-pty patch already carries; pnpm patches do
+  // not cross the SSH boundary, so a relay ran the unpatched npm tree and leaked one Windows File
+  // handle per terminal for the life of the relay process.
+  { filename: 'node-pty-1.1.0-windows-pty-teardown-patch.cjs', windowsOnly: true },
   // Only Linux relays run it, but it ships everywhere: the manifest's only
   // platform axis is Windows, and a second one would buy nothing but a fork in
   // the hash. Its presence is what moves a host to a fresh relay directory, and


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​184 |

<!-- /orca-pr-loc -->

## What

A Windows SSH relay leaked one Windows **File** handle per terminal, for the life of the relay
process, **across reconnects**. node-pty's `kill()` flips `readable` on the conin and conout sockets
and destroys neither. `_cleanUpProcess` destroys `_outSocket`, so the conout handle comes back;
nothing ever destroys `_inSocket`, and it wraps a real named-pipe handle from
`fs.openSync(term.conin, 'w')`.

## The fix is where, not what

The obvious fix — and the one `config/patches/node-pty@1.1.0.patch` already ships for the desktop —
releases conin at the **top** of the branch, before `_getConsoleProcessList()` forks and before the
native kill. Measured against a real Windows SSH host, that is **three times worse than leaving the
leak alone**. Releasing it at the **end** of the branch, after the fork and the kill, is flat.

20 spawn/kill cycles, handles bucketed by NT object type via
`NtQuerySystemInformation(SystemExtendedHandleInformation)`. Identical numbers standalone and
through a real relay:

| tree | File (type 42) | Process (type 8) | per terminal |
|---|---|---|---|
| published node-pty 1.1.0 | 43 → 63 | 0 → 0 | +1 File |
| desktop patch placement | 44 → 82 | 1 → 20 | **+2 File, +1 Process** |
| released last (this PR) | 42 → 42 | 0 → 0 | **flat** |

Through the relay on `awin`, this PR's build: `total 250 → 250`, `File 56 → 56`, Process absent
throughout. Every other bucket flat.

The Process handle is what identified the mechanism. It is **absent in published node-pty** and
appears only with the early placement: destroying conin before the fork aborts teardown partway, so
the forked console-list agent is never reaped (+1 Process) and both pipe handles stay alive instead
of one (+2 File).

## Why both files

`windowsTerminal.js` takes the desktop's error-listener hunks verbatim. The conin listener is **not**
what fixes the leak — adding it alone changed nothing, measured — but it is what keeps a pipe error
retiring one terminal instead of the host. Its own comment names the failure mode: *"Without a
listener, Node promotes errors such as write EAGAIN to uncaughtException."*

## Deliberate divergence from the desktop patch

The desktop has the early placement and therefore the +2 File / +1 Process regression — measured
against its exact installed tree, in a plain node process with no relay involved. **Orca's Windows
desktop app leaks ~3 handles per terminal because of a fix intended to reduce leaks.** Correcting it
there needs its own verification on a Windows desktop build, which I could not do here, so the two
trees diverge on this one hunk on purpose and a test pins that so a future "sync the patches" cannot
copy the regression back. That correction should be its own PR.

## Separate defect, still open, and reachable by every Windows user

A terminal that **exits on its own** is still torn down through `kill()` — both hosts call
`destroy()` on natural exit (`local-pty-session-activation.ts` -> `destroyPtyProcess`; the relay's
`disposeManagedPty`) and `WindowsTerminal.destroy()` is `kill()`. But the shell is already gone by
then, so the ordering this patch depends on does not hold.

20 self-exit cycles **with that `destroy()` issued**, which is what Orca actually does:

| tree | File (42) | Process (8) | Thread (9) |
|---|---|---|---|
| published | 46 → 106 (+3/term) | 1 → 21 (+1/term) | flat |
| desktop-patched | 45 → 85 (+2/term) | 1 → 21 (+1/term) | flat |
| this PR | 45 → 85 (+2/term) | 1 → 21 (+1/term) | flat |

**This patch does not close it, and neither does the desktop patch** — they behave identically here.
Not dead code: it is live for every Windows user, local and relay, on every terminal closed by
typing `exit`.

Correcting my own earlier figure: I first measured this at +8 File / +2 Thread / +1 Process, from a
probe that let node-pty exit with nobody calling `destroy()`. Orca always calls it, so that probe
overstated the exposure — `destroy()` removes the Thread leak entirely and most of the File leak.
The numbers above are the ones that describe what ships.

## The durable lesson

My first port of this shipped a 3× regression and my standalone harness said it was flat. The
harness drove node-pty directly with no relay-side error surface, and on that box the **unpatched**
`conpty_console_list_agent.js` was already throwing visibly — so its fork behaved differently from
the relay's, where that agent **is** patched. The standalone harness and the relay are not the same
host. Totals hid it for a round; only bucketing by object type showed that one leak had become two.

## Revert-tested

- Replacement table set back to the desktop's early placement → `releases conin after the
  console-list fork, not before it like the desktop patch` fails.
- Half-applied tree (either file patched alone) → `assertPatchedNodePtyWindowsTeardown` throws.
- Drift in either file, or a wrong package version → refuses to patch.

The test reconstructs the published sources by un-applying the desktop hunks from the installed tree
and asserts every hash in the asset, so it fails loudly if either side of the pair moves.

## Checks

`pnpm tc`, `oxlint`, `check:code-quality:changed` (0 findings), `check:max-lines-ratchet` all clean.
4047 test files / 41094 tests pass across `src/main`, `src/relay`, `src/shared`, `config/scripts`.
Rebased onto current `origin/main` (`cc9e9ed`) and the acceptance measurement re-run on that build.