### PR TITLE
Keep mirrored remote terminal metadata

### DIFF
--- a/src/main/runtime/orca-runtime-write-orchestration-pointer-pty.ts
+++ b/src/main/runtime/orca-runtime-write-orchestration-pointer-pty.ts
@@ -10,10 +10,14 @@ import { isTuiAgent } from '../../shared/tui-agent-config'
 import { resolvePublishedPaneAgentIdentity } from '../../shared/published-pane-agent-identity'
 import type { RuntimeTerminalSummary, RuntimeWorktreePsSummary } from '../../shared/runtime-types'
 import type { RuntimeWorktreeSummaryPathIndex } from './runtime-worktree-summary-paths'
-import { parseRuntimeWorktreeId } from './runtime-worktree-path-identity'
 import { findRuntimeWorktreeSummaryByPath } from './runtime-worktree-summary-paths'
 import type { ResolvedWorktree } from './runtime-worktree-path-identity'
-import { getLatestLeafTitle } from './runtime-worktree-status-projection'
+import { parseRuntimeWorktreeId } from './runtime-worktree-path-identity'
+import {
+  getLatestLeafTitle,
+  getLatestPtyTitle,
+  maxTimestamp
+} from './runtime-worktree-status-projection'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
 import { isTerminalLeafId, makePaneKey } from '../../shared/stable-pane-id'
 
@@ -124,7 +128,22 @@ export class OrcaRuntimeWithWriteOrchestrationPointerPty extends OrcaRuntimeWith
     const tab = this.tabs.get(leaf.tabId) ?? null
 
     const pty = leaf.ptyId ? this.ptysById.get(leaf.ptyId) : undefined
-    const title = getLatestLeafTitle(leaf, tab?.title ?? null)
+    const mobileTerminalTab = this.mobileSessionTabsByWorktree
+      .get(leaf.worktreeId)
+      ?.tabs.find(
+        (candidate) =>
+          candidate.type === 'terminal' &&
+          candidate.parentTabId === leaf.tabId &&
+          candidate.leafId === leaf.leafId
+      )
+    const title =
+      getLatestLeafTitle(leaf, tab?.title ?? null) ??
+      (pty ? (getLatestPtyTitle(pty) ?? pty.controllerTitle) : null) ??
+      mobileTerminalTab?.title ??
+      null
+    const parsedWorktree = parseRuntimeWorktreeId(leaf.worktreeId)
+    const lastOutputAt = maxTimestamp(leaf.lastOutputAt, pty?.lastOutputAt ?? null)
+    const preview = leaf.preview || pty?.preview || ''
     // Why: leaf.connected mirrors the renderer graph (`ptyId !== null`), so a
     // restored surface whose PTY died with a prior run still reads connected.
     // Demote only on a controller-proven absence, and only for locally-scoped
@@ -146,15 +165,15 @@ export class OrcaRuntimeWithWriteOrchestrationPointerPty extends OrcaRuntimeWith
       incarnationId: pty?.incarnationId ?? null,
       orphaned: false,
       worktreeId: leaf.worktreeId,
-      worktreePath: worktree?.path ?? '',
+      worktreePath: worktree?.path ?? parsedWorktree?.worktreePath ?? '',
       branch: worktree?.branch ?? '',
       tabId: leaf.tabId,
       leafId: leaf.leafId,
       title,
       connected: provenAbsent ? false : leaf.connected,
       writable: provenAbsent ? false : leaf.writable,
-      lastOutputAt: leaf.lastOutputAt,
-      preview: leaf.preview,
+      lastOutputAt,
+      preview,
       ...(leaf.lastExitCause ? { exitCause: leaf.lastExitCause } : {}),
       ...this.terminalExecutionHostField(leaf.ptyId, leaf.worktreeId),
       ...this.resolvePaneAgentIdentityField(

--- a/src/main/runtime/terminal-list-execution-host-scope.test.ts
+++ b/src/main/runtime/terminal-list-execution-host-scope.test.ts
@@ -142,6 +142,79 @@ describe('listTerminals execution-host identity', () => {
     expect(terminals[0]?.executionHostId).toBe('runtime:env-7')
   })
 
+  it('keeps mirrored paired-runtime terminal metadata when the local profile lacks that repo', async () => {
+    const worktreeId = 'repo-runtime::/Users/me/remote/project'
+    const ptyId = 'remote:env-7@@handle-1'
+    const runtime = makeRuntime([], {
+      ...makeStore(),
+      getRepos: vi.fn(() => []),
+      getRepo: vi.fn(() => undefined),
+      getWorkspaceSessionHostIds: vi.fn(() => ['local', 'runtime:env-7'])
+    })
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (
+        ptyId: string,
+        worktreeId: string,
+        state?: Record<string, unknown>
+      ) => void
+      mobileSessionTabsByWorktree: Map<string, unknown>
+    }
+    internals.recordPtyWorktree(ptyId, worktreeId, { connected: true })
+    runtime.seedTerminalRestoreTail(ptyId, { text: 'remote restored output\r\n' })
+    internals.mobileSessionTabsByWorktree.set(worktreeId, {
+      worktree: worktreeId,
+      publicationEpoch: 'renderer:test',
+      snapshotVersion: 1,
+      activeGroupId: null,
+      activeTabId: 'tab-remote::leaf-remote',
+      activeTabType: 'terminal',
+      tabs: [
+        {
+          type: 'terminal',
+          id: 'tab-remote::leaf-remote',
+          parentTabId: 'tab-remote',
+          leafId: 'leaf-remote',
+          ptyId,
+          title: 'Remote snapshot title',
+          isActive: true
+        }
+      ]
+    })
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-remote',
+          worktreeId,
+          title: '',
+          activeLeafId: 'leaf-remote',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-remote',
+          worktreeId,
+          leafId: 'leaf-remote',
+          paneRuntimeId: 1,
+          ptyId,
+          paneTitle: null,
+          title: ''
+        }
+      ]
+    })
+
+    const result = await runtime.listTerminals()
+
+    expect(result.hostScope?.hostIds).toEqual(['local'])
+    expect(result.hostScope?.omittedHostIds).toEqual(['runtime:env-7'])
+    expect(result.terminals[0]).toMatchObject({
+      executionHostId: 'runtime:env-7',
+      worktreePath: '/Users/me/remote/project',
+      title: 'Remote snapshot title',
+      preview: 'remote restored output'
+    })
+  })
+
   it('leaves the host unset — never local — for a paired PTY that names no environment', async () => {
     const runtime = makeRuntime([
       { worktreeId: LOCAL_WORKTREE_ID, leafId: REMOTE_LEAF_ID, ptyId: 'remote:handle-1' }


### PR DESCRIPTION
## ELI5

When a paired remote Orca tab is mirrored locally, the local runtime can know that a terminal exists without having the remote repo registered locally. In that case `terminal list` should still show the useful tab title, worktree path, and restored preview instead of a blank row.

## What Changed

- Added fallback metadata for terminal summaries from the PTY record and mirrored mobile-session terminal snapshot.
- Falls back to the parsed worktree path embedded in the worktree id when the local profile has no matching repo/worktree record.
- Added a regression test for paired-runtime terminals where the local profile lacks the remote repo.

## Why

This addresses a paired M1/Intel failure where direct remote inventory returned full terminal metadata, but the default local/federated terminal list showed remote rows with blank title/path/branch/preview. The fix keeps the existing host-scope semantics intact: mirrored runtime rows still do not claim authoritative host inventory coverage.

## Linked Issue

Fixes #18595

## Visual Proof

N/A. This is a runtime/CLI metadata fix covered by a regression test; no visual asset was changed.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands run on macOS:

```sh
npm exec --yes pnpm@12.0.0 -- vitest run src/main/runtime/terminal-list-execution-host-scope.test.ts
npm exec --yes pnpm@12.0.0 -- run typecheck:node
npm exec --yes pnpm@12.0.0 -- run check:code-quality:changed
git diff --check
```

Note: the global `pnpm` shim on this machine is currently corrupted for the pinned `pnpm@12.0.0` path, so I used `npm exec --yes pnpm@12.0.0` for the local validation commands.

## AI Disclosure

AI assistance was used to diagnose the issue, implement the patch, and draft this PR.

## Review

Self-reviewed for scope, host-scope truthfulness, and regression coverage.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cross-platform impact should be low: the path fallback only parses the existing runtime worktree id format and is used only when no resolved worktree metadata exists.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
