### PR TITLE
fix(ports): stabilize worktree runtime target snapshot

### DIFF
--- a/src/renderer/src/runtime/use-worktree-runtime-target.react185.test.tsx
+++ b/src/renderer/src/runtime/use-worktree-runtime-target.react185.test.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment happy-dom */
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@/store', async () => {
+  const { create } = await import('zustand')
+  return { useAppStore: create(() => ({})) }
+})
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getExecutionHostIdForWorktree: () => 'local'
+}))
+
+import { useWorktreeRuntimeTarget } from './use-worktree-runtime-target'
+
+const mounted: { container: HTMLDivElement; root: ReturnType<typeof createRoot> }[] = []
+
+afterEach(() => {
+  for (const { container, root } of mounted) {
+    act(() => root.unmount())
+    container.remove()
+  }
+  mounted.length = 0
+})
+
+function TargetProbe(): React.JSX.Element {
+  const target = useWorktreeRuntimeTarget(null)
+  return <span>{target?.kind}</span>
+}
+
+class CaptureBoundary extends React.Component<
+  { children: React.ReactNode; errors: Error[] },
+  { failed: boolean }
+> {
+  state = { failed: false }
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: Error): void {
+    this.props.errors.push(error)
+  }
+
+  render(): React.ReactNode {
+    return this.state.failed ? null : this.props.children
+  }
+}
+
+describe('useWorktreeRuntimeTarget React snapshot identity', () => {
+  it('mounts without a maximum-update-depth loop when the owner is unchanged', () => {
+    const errors: Error[] = []
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container, { onCaughtError: () => undefined })
+    mounted.push({ container, root })
+
+    act(() => {
+      root.render(
+        <CaptureBoundary errors={errors}>
+          <TargetProbe />
+        </CaptureBoundary>
+      )
+    })
+
+    expect(errors).toEqual([])
+    expect(container.textContent).toBe('local')
+  })
+})

--- a/src/renderer/src/runtime/use-worktree-runtime-target.ts
+++ b/src/renderer/src/runtime/use-worktree-runtime-target.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { runtimeTargetForExecutionHostId, type RuntimeClientTarget } from './runtime-client-target'
@@ -10,7 +11,6 @@ import { runtimeTargetForExecutionHostId, type RuntimeClientTarget } from './run
 export function useWorktreeRuntimeTarget(
   worktreeId: string | null | undefined
 ): RuntimeClientTarget | null {
-  return useAppStore((state) =>
-    runtimeTargetForExecutionHostId(getExecutionHostIdForWorktree(state, worktreeId))
-  )
+  const executionHostId = useAppStore((state) => getExecutionHostIdForWorktree(state, worktreeId))
+  return useMemo(() => runtimeTargetForExecutionHostId(executionHostId), [executionHostId])
 }


### PR DESCRIPTION
## ELI5

The ports UI was asking the app store for a runtime target object. Even when the target had not changed, that lookup created a new object, so React thought the store changed continuously and eventually stopped the render loop with error #185. This change subscribes to the stable host ID first and derives the target afterward.

## What Changed

- Subscribe `useWorktreeRuntimeTarget` to the primitive `ExecutionHostId` snapshot.
- Memoize the derived `RuntimeClientTarget` by host ID.
- Add a real Zustand and React-root regression test that reproduces the startup loop.

## Why

Zustand uses `useSyncExternalStore`, whose selector snapshot must be reference-stable when the store has not changed. Calling `runtimeTargetForExecutionHostId` inside the selector returned a fresh object on every read. `PortsStatusSegment` mounts this hook during startup, making the failure surface as `Maximum update depth exceeded` before user interaction.

## Linked Issue

Fixes #18611

## Visual Proof

N/A — there is no visual change; this prevents the renderer from entering a startup update loop.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally:

- `node_modules/.bin/vitest run --config config/vitest.config.ts src/renderer/src/runtime/use-worktree-runtime-target.react185.test.tsx src/renderer/src/components/status-bar/PortsStatusSegment.host-routing.test.tsx src/renderer/src/components/sidebar/WorktreeCardPorts.test.tsx src/renderer/src/components/right-sidebar/PortsPanel.test.tsx src/renderer/src/components/status-bar/ports-status-popover-rows.test.tsx` — 5 files, 36 tests
- `pnpm tc`
- `ORCA_CODE_QUALITY_BASE=main node config/scripts/check-changed-code-quality.mjs`
- `git diff --check`

The full platform matrix is left to CI.

## AI Disclosure

OpenAI Codex (GPT-5) was used for diagnosis, implementation, regression testing, and review.

## Review

- Security: no trust boundary, input, credential, or filesystem behavior changes.
- Cross-platform: the change is React/Zustand-only and contains no platform-specific API.
- Remote/SSH/local: target resolution is unchanged; local, runtime-environment, and direct-SSH results retain their existing semantics.
- Agents/integrations/git providers: not affected.
- Performance: removes an infinite render loop; the only added work is one memoized derivation when the host ID changes.
- UI quality: N/A; no visual or interaction change.

## Agent skill upstream boundary

- [x] Not applicable; this PR changes no skills or skill installation code.

## Notes

X handle: N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] Full `pnpm lint`, `pnpm test`, and `pnpm build` were not run locally; CI will cover them