### PR TITLE
fix(remote): close terminal after confirmed exit

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-end-verdict.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-end-verdict.test.ts
@@ -82,4 +82,28 @@ describe('remote runtime PTY stream end verdict', () => {
     expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-1')
     expect(runtimeSubscribe).toHaveBeenCalledTimes(1)
   })
+  it('retires a remote workspace terminal after an owning-host exit verdict', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const onExit = vi.fn()
+    const onDisconnect = vi.fn()
+    const onPtyExit = vi.fn()
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'wt-1',
+      tabId: 'web-terminal-host-tab-1',
+      leafId: 'pane:1',
+      onPtyExit
+    })
+
+    await transport.connect({ url: '', callbacks: { onExit, onDisconnect } })
+    const { streamId } = latestSubscribePayload()
+    subscriptionCallbacks?.onResponse({
+      ok: true,
+      result: { type: 'end', streamId, verdict: 'exited' }
+    })
+
+    expect(onExit).toHaveBeenCalledWith(0)
+    expect(onDisconnect).toHaveBeenCalledOnce()
+    expect(onPtyExit).toHaveBeenCalledWith('remote:env-1@@terminal-1')
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -2049,7 +2049,7 @@ export function createRemoteRuntimePtyTransport(
             return
           }
           outputProcessor.clearAccumulatedState()
-          if (verdict === 'unverifiable' || (tabId && isWebTerminalSurfaceTabId(tabId))) {
+          if (verdict === 'unverifiable') {
             setAttachmentReady(false)
             multiplexedStream = null
             multiplexedStreamHandle = null


### PR DESCRIPTION
## Summary
- honor authoritative remote terminal `exited` verdicts for mirrored workspace tabs
- keep bounded reconnect behavior for `unverifiable` stream endings
- cover Ctrl-D-style remote shell exit with a regression test

## Root cause
The renderer treated every `web-terminal-*` stream end as transport loss, even when the owning runtime explicitly reported `verdict: 'exited'`. A normal shell exit therefore entered the one-minute remote-runtime reconnect flow instead of retiring the terminal.

## Test plan
- `pnpm test src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-end-verdict.test.ts`
- `pnpm tc:web`
- `pnpm exec oxlint src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-end-verdict.test.ts`