### PR TITLE
chore: CI control at cc9e9ed (do not merge)

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -108,6 +108,8 @@ import {
   MIN_SSH_RELAY_GRACE_PERIOD_SECONDS
 } from '../../shared/ssh-types'
 
+// CI control (temporary, see the ssh-docker-transport-drop-recovery:337 investigation): a
+// comment-only diff that still selects the SSH e2e lane, so the lane's failures can be attributed.
 export type RelayDeployResult = {
   transport: MultiplexerTransport
   serverBuildId?: string


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

Temporary CI control. **Do not merge — I will close this once the lane answers.**

A `+2/−0` comment-only diff based on `cc9e9ed65fc`, the same base as #18591 and #18601, touching a non-test file under `src/main/ssh/` so the `changed e2e specs` lane selects.

Purpose: `ssh-docker-transport-drop-recovery.spec.ts:337` failed on both of those PRs and passed on the older `+2/−0` control at `79d5fb4`. This separates base drift from those diffs — a failure here is attributable to the base, not to a change.