### PR TITLE
fix(remote): stop a disclosure list latching the mirror completeness gate

### DIFF
--- a/src/main/ipc/pty/runtime/queried-host-kinds.test.ts
+++ b/src/main/ipc/pty/runtime/queried-host-kinds.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { parseExecutionHostId } from '../../../../shared/execution-host'
+import { sshProviders } from '../provider/registry'
+import { listProcessesWithHostScopeFromRuntimeController } from './inventory-operations'
+import type { PtyRuntimeControllerDeps } from './controller-deps'
+
+/**
+ * `hostScopeCensusIsComplete` treats a `runtime:` host in `omittedHostIds` as disclosure rather
+ * than a gap, on the strength of one fact about this process: it has no paired-runtime PTY
+ * provider, so it never queried that host and never owed it coverage.
+ *
+ * That fact is asserted at the client, about the host, which is exactly the kind of assumption
+ * that rots silently. The consolidation moving the SSH path onto `orcad` is the change most
+ * likely to introduce a runtime-backed PTY provider — at which point a runtime host really could
+ * answer an inventory, `hostScopeCensusIsComplete` would start calling a genuine gap complete,
+ * and nothing downstream would say so. Break here instead, at the source of the invariant.
+ */
+describe('the hosts a PTY inventory can report having queried', () => {
+  afterEach(() => {
+    sshProviders.clear()
+  })
+
+  it('never names a paired-runtime host, which is what lets the scope gate discount one', async () => {
+    const listProcesses = vi.fn(async () => [])
+    sshProviders.set('box-1', { listProcesses } as never)
+    sshProviders.set('box-2', { listProcesses } as never)
+
+    const { hostIds } = await listProcessesWithHostScopeFromRuntimeController({
+      runtime: null
+    } as unknown as PtyRuntimeControllerDeps)
+
+    expect(hostIds.length).toBeGreaterThan(0)
+    expect(hostIds.map((hostId) => parseExecutionHostId(hostId)?.kind)).not.toContain('runtime')
+    expect(new Set(hostIds.map((hostId) => parseExecutionHostId(hostId)?.kind))).toEqual(
+      new Set(['local', 'ssh'])
+    )
+  })
+
+  it('drops a provider that threw rather than reporting its host as queried', async () => {
+    sshProviders.set('box-live', { listProcesses: vi.fn(async () => []) } as never)
+    sshProviders.set('box-down', {
+      listProcesses: vi.fn(async () => {
+        throw new Error('relay unavailable')
+      })
+    } as never)
+
+    const { hostIds } = await listProcessesWithHostScopeFromRuntimeController({
+      runtime: { markPtyLivenessUnverifiable: vi.fn() }
+    } as unknown as PtyRuntimeControllerDeps)
+
+    expect(hostIds).toContain('ssh:box-live')
+    expect(hostIds).not.toContain('ssh:box-down')
+  })
+})

--- a/src/main/ipc/pty/runtime/queried-host-kinds.test.ts
+++ b/src/main/ipc/pty/runtime/queried-host-kinds.test.ts
@@ -5,32 +5,38 @@ import { listProcessesWithHostScopeFromRuntimeController } from './inventory-ope
 import type { PtyRuntimeControllerDeps } from './controller-deps'
 
 /**
- * `hostScopeCensusIsComplete` treats a `runtime:` host in `omittedHostIds` as disclosure rather
- * than a gap, on the strength of one fact about this process: it has no paired-runtime PTY
- * provider, so it never queried that host and never owed it coverage.
+ * `hostScopeCensusIsComplete` discounts a `runtime:` host in `omittedHostIds` on the strength of
+ * one fact about this process: it has no paired-runtime PTY provider, so it never queried that
+ * host and never owed it coverage. This file pins the producer side of that fact.
  *
- * That fact is asserted at the client, about the host, which is exactly the kind of assumption
- * that rots silently. The consolidation moving the SSH path onto `orcad` is the change most
- * likely to introduce a runtime-backed PTY provider — at which point a runtime host really could
- * answer an inventory, `hostScopeCensusIsComplete` would start calling a genuine gap complete,
- * and nothing downstream would say so. Break here instead, at the source of the invariant.
+ * What it catches: a new branch here that spells a queried host `runtime:`. Every id this
+ * function emits is built by `toSshExecutionHostId` or is `LOCAL_EXECUTION_HOST_ID`, so a third
+ * shape is the observable form of "a runtime host can now answer an inventory" — at which point
+ * the client predicate would start calling a genuine gap complete.
+ *
+ * What it does NOT catch, so do not lean on it: a runtime-backed transport registered under an
+ * SSH connection id still reports as `ssh:` and passes, which is fine — the predicate only
+ * discounts the `runtime:` spelling. The consolidation moving the SSH path onto orcad is expected
+ * to look exactly like that. The other route into `queriedHostIds` is separately fenced to
+ * `kind === 'ssh'` in `orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts`.
  */
 describe('the hosts a PTY inventory can report having queried', () => {
   afterEach(() => {
     sshProviders.clear()
   })
 
-  it('never names a paired-runtime host, which is what lets the scope gate discount one', async () => {
+  it('emits only local and ssh spellings, never a paired-runtime one', async () => {
     const listProcesses = vi.fn(async () => [])
     sshProviders.set('box-1', { listProcesses } as never)
-    sshProviders.set('box-2', { listProcesses } as never)
+    // A connection id shaped like an environment uuid still has to come back `ssh:`; the spelling
+    // is what the gate keys on, so a `runtime:` id appearing here is the breakage that matters.
+    sshProviders.set('a2478221-1d5c-4603-b8bf-b6b728eac9df', { listProcesses } as never)
 
     const { hostIds } = await listProcessesWithHostScopeFromRuntimeController({
       runtime: null
     } as unknown as PtyRuntimeControllerDeps)
 
-    expect(hostIds.length).toBeGreaterThan(0)
-    expect(hostIds.map((hostId) => parseExecutionHostId(hostId)?.kind)).not.toContain('runtime')
+    expect(hostIds).toContain('ssh:a2478221-1d5c-4603-b8bf-b6b728eac9df')
     expect(new Set(hostIds.map((hostId) => parseExecutionHostId(hostId)?.kind))).toEqual(
       new Set(['local', 'ssh'])
     )

--- a/src/renderer/src/runtime/__fixtures__/web-session-terminal-orphan-recovery-regression-fixtures.ts
+++ b/src/renderer/src/runtime/__fixtures__/web-session-terminal-orphan-recovery-regression-fixtures.ts
@@ -96,7 +96,9 @@ export function listResult(
     totalCount: terminals.length,
     truncated: options.truncated ?? false,
     ...(options.hostScope === undefined
-      ? { hostScope: { hostIds: [ENVIRONMENT_ID], omittedHostIds: [] } }
+      ? // A host names the execution hosts it covered, not its own environment id: answering
+        // `terminal.list` on a paired runtime reports `local` (verified against a live runtime).
+        { hostScope: { hostIds: ['local'], omittedHostIds: [] } }
       : { hostScope: options.hostScope })
   }
 }

--- a/src/renderer/src/runtime/host-live-terminal-probe.ts
+++ b/src/renderer/src/runtime/host-live-terminal-probe.ts
@@ -1,5 +1,6 @@
 import type { RuntimeTerminalListResult } from '../../../shared/runtime-types'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { hostScopeCensusIsComplete } from '../../../shared/runtime-listing-host-scope'
 
 /**
  * Asks the host whether ANY terminal is live in an environment, for the one
@@ -74,10 +75,12 @@ async function probeHost(
   if (response.ok === false || !isTerminalListResult(response.result)) {
     return 'unverifiable'
   }
-  // An omitted execution host is an incomplete census. In particular, a relay
-  // can list its local PTYs while an SSH child host is still starting up.
+  // A host this listing owed coverage for and did not deliver leaves an incomplete census — a
+  // relay can list its local PTYs while an SSH child host is still starting up. A peer runtime
+  // is not such a host: it answers `--environment` for itself, and reading its disclosure entry
+  // as a gap latched this probe forever (#18595).
   const hostScope = response.result.hostScope
-  if (hostScope && hostScope.omittedHostIds.length > 0) {
+  if (hostScope && !hostScopeCensusIsComplete(hostScope)) {
     return 'unverifiable'
   }
   const { terminals, totalCount } = response.result

--- a/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
+++ b/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
@@ -335,6 +335,89 @@ describe('empty host inventory settling the session mirror', () => {
     expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(true)
   })
 
+  // #18595, the reporter's shape: the answering host holds a mirrored row for a peer runtime, so
+  // that peer is named in `omittedHostIds` for every listing it will ever give. Reading the
+  // disclosure list as the gate made this probe permanently `unverifiable`, the mirror never
+  // hydrated, and every remote pane parked forever.
+  it('settles on a peer runtime it disclosed but never owed coverage for', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-peer-disclosed',
+      vi.fn(async () => ({
+        id: 'peer-disclosed',
+        ok: true as const,
+        result: {
+          terminals: [],
+          totalCount: 0,
+          truncated: false,
+          hostScope: { hostIds: ['local'], omittedHostIds: ['runtime:env-peer'] }
+        },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('none')
+  })
+
+  it('reports a live terminal through a peer-runtime disclosure', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-peer-live',
+      vi.fn(async () => ({
+        id: 'peer-live',
+        ok: true as const,
+        result: {
+          terminals: [{ handle: 'terminal-1' }],
+          totalCount: 1,
+          truncated: false,
+          hostScope: { hostIds: ['local'], omittedHostIds: ['runtime:env-peer'] }
+        },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('live')
+  })
+
+  it('stays unverifiable for an SSH host the answering runtime did owe coverage for', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-ssh-gap',
+      vi.fn(async () => ({
+        id: 'ssh-gap',
+        ok: true as const,
+        result: {
+          terminals: [],
+          totalCount: 0,
+          truncated: false,
+          hostScope: { hostIds: ['local'], omittedHostIds: ['ssh:box-1'] }
+        },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('unverifiable')
+  })
+
+  // A worktree-scoped listing whose target is a runtime host covers nothing and names `local`
+  // among its omissions. `local` is what keeps this unverifiable — the point is that the
+  // runtime-only rule does not rescue a listing that answered for nothing.
+  it('stays unverifiable when the listing covered no host at all', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-covered-nothing',
+      vi.fn(async () => ({
+        id: 'covered-nothing',
+        ok: true as const,
+        result: {
+          terminals: [],
+          totalCount: 0,
+          truncated: false,
+          hostScope: { hostIds: [], omittedHostIds: ['local', 'runtime:env-peer'] }
+        },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('unverifiable')
+  })
+
   it('rejects a present malformed host scope as unverifiable', async () => {
     const result = await probeHostLiveTerminals(
       'env-malformed-scope',

--- a/src/renderer/src/runtime/web-session-terminal-orphan-recovery-host-scope-gate.test.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-recovery-host-scope-gate.test.ts
@@ -57,7 +57,7 @@ describe('orphan recovery reads the host scope as coverage owed, not as disclosu
 
   it('prunes a twice-absent binding when the only omission is a peer runtime', async () => {
     const settled = await recoverTwice('repo::peer-disclosed', {
-      hostIds: [ENVIRONMENT_ID],
+      hostIds: ['local'],
       omittedHostIds: ['runtime:env-peer']
     })
 
@@ -66,7 +66,7 @@ describe('orphan recovery reads the host scope as coverage owed, not as disclosu
 
   it('retains the binding when an SSH host this runtime does query went unanswered', async () => {
     const settled = await recoverTwice('repo::ssh-gap', {
-      hostIds: [ENVIRONMENT_ID],
+      hostIds: ['local'],
       omittedHostIds: ['ssh:box-1']
     })
 

--- a/src/renderer/src/runtime/web-session-terminal-orphan-recovery-host-scope-gate.test.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-recovery-host-scope-gate.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ENVIRONMENT_ID,
+  listResult,
+  makeSnapshot,
+  makeState
+} from './__fixtures__/web-session-terminal-orphan-recovery-regression-fixtures'
+import {
+  clearWebSessionTerminalOrphanRecoveryForTests,
+  recoverWebSessionTerminalOrphansBeforeApply
+} from './web-session-terminal-orphan-recovery'
+
+/**
+ * The second consumer of `hostScopeCensusIsComplete`. Pruning here needs two consecutive
+ * authoritative inventories that omit the surface, so an incomplete census must hold the binding
+ * open indefinitely — and a peer runtime named in `omittedHostIds` must not be read as one, or
+ * the ghost binding is retained forever (#18595).
+ */
+const LEAVES = [{ leafId: 'leaf-1', handle: 'term-ghost' }]
+
+/**
+ * `listResult` substitutes a default scope when handed `undefined`, so the absent-scope case has
+ * to drop the key itself — passing `undefined` through the fixture silently tests the default.
+ */
+async function recoverTwice(worktree: string, hostScope: Record<string, unknown> | null) {
+  const state = makeState(worktree, LEAVES)
+  const call = vi.fn(async ({ method }: { method: string }) => {
+    if (method === 'terminal.list') {
+      const listed = listResult(worktree, [])
+      if (hostScope === null) {
+        delete (listed as { hostScope?: unknown }).hostScope
+      } else {
+        listed.hostScope = hostScope as never
+      }
+      return { ok: true as const, result: listed }
+    }
+    return { ok: false as const, error: { code: 'conflict', message: 'unexpected' } }
+  })
+  await recoverWebSessionTerminalOrphansBeforeApply(
+    state,
+    makeSnapshot(worktree, 'epoch-1', LEAVES),
+    ENVIRONMENT_ID,
+    { call: call as never }
+  )
+  return recoverWebSessionTerminalOrphansBeforeApply(
+    state,
+    makeSnapshot(worktree, 'epoch-2', LEAVES),
+    ENVIRONMENT_ID,
+    { call: call as never }
+  )
+}
+
+describe('orphan recovery reads the host scope as coverage owed, not as disclosure', () => {
+  beforeEach(() => {
+    clearWebSessionTerminalOrphanRecoveryForTests()
+  })
+
+  it('prunes a twice-absent binding when the only omission is a peer runtime', async () => {
+    const settled = await recoverTwice('repo::peer-disclosed', {
+      hostIds: [ENVIRONMENT_ID],
+      omittedHostIds: ['runtime:env-peer']
+    })
+
+    expect(settled?.tabs).toEqual([])
+  })
+
+  it('retains the binding when an SSH host this runtime does query went unanswered', async () => {
+    const settled = await recoverTwice('repo::ssh-gap', {
+      hostIds: [ENVIRONMENT_ID],
+      omittedHostIds: ['ssh:box-1']
+    })
+
+    expect(settled?.tabs).toEqual([
+      expect.objectContaining({ leafId: 'leaf-1', terminal: 'term-ghost' })
+    ])
+  })
+
+  it('retains the binding when the listing covered no host at all', async () => {
+    const settled = await recoverTwice('repo::covered-nothing', {
+      hostIds: [],
+      omittedHostIds: ['local', 'runtime:env-peer']
+    })
+
+    expect(settled?.tabs).toEqual([
+      expect.objectContaining({ leafId: 'leaf-1', terminal: 'term-ghost' })
+    ])
+  })
+
+  // Why: a host predating `hostScope` (v1.4.187) cannot say what it covered, and absence of the
+  // claim is never the claim.
+  it('retains the binding when the host is too old to publish a scope', async () => {
+    const settled = await recoverTwice('repo::no-scope', null)
+
+    expect(settled?.tabs).toEqual([
+      expect.objectContaining({ leafId: 'leaf-1', terminal: 'term-ghost' })
+    ])
+  })
+})

--- a/src/renderer/src/runtime/web-session-terminal-orphan-recovery-inventory.ts
+++ b/src/renderer/src/runtime/web-session-terminal-orphan-recovery-inventory.ts
@@ -18,6 +18,7 @@ import {
   type RecoverySurface
 } from './web-session-terminal-orphan-recovery-surface'
 import { runInTerminalRecoveryRpcLane } from './web-session-terminal-orphan-recovery-rpc-lane'
+import { hostScopeCensusIsComplete } from '../../../shared/runtime-listing-host-scope'
 
 type RuntimeCall = (args: {
   selector: string
@@ -163,9 +164,9 @@ export async function resolveTerminalOrphanInventory(args: {
       listedByHandle.set(terminal.handle, terminal)
     }
   }
-  // Older hosts omit hostScope entirely; an unscoped absence cannot prove a PTY exited.
-  const hostScopeUnverifiable =
-    listed.hostScope === undefined || listed.hostScope.omittedHostIds.length > 0
+  // Older hosts omit hostScope entirely; an unscoped absence cannot prove a PTY exited. A peer
+  // runtime named in `omittedHostIds` is disclosure rather than a gap this host owed (#18595).
+  const hostScopeUnverifiable = !hostScopeCensusIsComplete(listed.hostScope)
   const dispositions = new Map<string, RecoveryDisposition>()
   const claims: RuntimeTerminalOrphanAdoptionClaim[] = []
   for (const surface of inventorySurfaces) {

--- a/src/renderer/src/runtime/web-session-terminal-pending-handle-recovery.test.ts
+++ b/src/renderer/src/runtime/web-session-terminal-pending-handle-recovery.test.ts
@@ -145,7 +145,7 @@ describe('web session pending terminal handle recovery', () => {
             topologyRevisions: { [WORKTREE_ID]: 4 },
             totalCount: 1,
             truncated: false,
-            hostScope: { hostIds: [ENVIRONMENT_ID], omittedHostIds: [] }
+            hostScope: { hostIds: ['local'], omittedHostIds: [] }
           }
         }
       }
@@ -316,7 +316,7 @@ describe('web session pending terminal handle recovery', () => {
             topologyRevisions: { [WORKTREE_ID]: 4 },
             totalCount: 1,
             truncated: false,
-            hostScope: { hostIds: [ENVIRONMENT_ID], omittedHostIds: [] }
+            hostScope: { hostIds: ['local'], omittedHostIds: [] }
           }
         }
       }
@@ -394,7 +394,7 @@ describe('web session pending terminal handle recovery', () => {
             topologyRevisions: { [WORKTREE_ID]: 4 },
             totalCount: 1,
             truncated: false,
-            hostScope: { hostIds: [ENVIRONMENT_ID], omittedHostIds: [] }
+            hostScope: { hostIds: ['local'], omittedHostIds: [] }
           }
         }
       }
@@ -459,7 +459,7 @@ describe('web session pending terminal handle recovery', () => {
         terminals: [],
         totalCount: 0,
         truncated: false,
-        hostScope: { hostIds: [ENVIRONMENT_ID], omittedHostIds: [] }
+        hostScope: { hostIds: ['local'], omittedHostIds: [] }
       }
     }))
 
@@ -655,7 +655,7 @@ describe('web session pending terminal handle recovery', () => {
         terminals: [],
         totalCount: 0,
         truncated: false,
-        hostScope: { hostIds: [ENVIRONMENT_ID], omittedHostIds: [] }
+        hostScope: { hostIds: ['local'], omittedHostIds: [] }
       }
     }))
 

--- a/src/shared/runtime-listing-host-scope.test.ts
+++ b/src/shared/runtime-listing-host-scope.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { hostScopeCensusIsComplete } from './runtime-listing-host-scope'
+
+/**
+ * The gate and the disclosure list answer different questions off the same field. These pin the
+ * cases where they disagree — which is every case that mattered in #18595.
+ */
+describe('hostScopeCensusIsComplete', () => {
+  it('reads a peer runtime as disclosure, not as coverage this host owed', () => {
+    expect(
+      hostScopeCensusIsComplete({ hostIds: ['local'], omittedHostIds: ['runtime:env-7'] })
+    ).toBe(true)
+  })
+
+  it('still reads an SSH host as a gap, because this runtime does query those', () => {
+    expect(hostScopeCensusIsComplete({ hostIds: ['local'], omittedHostIds: ['ssh:box-1'] })).toBe(
+      false
+    )
+  })
+
+  it('reads a mixed omission as incomplete on the strength of the SSH host alone', () => {
+    expect(
+      hostScopeCensusIsComplete({
+        hostIds: ['local'],
+        omittedHostIds: ['runtime:env-7', 'ssh:box-1']
+      })
+    ).toBe(false)
+  })
+
+  it('calls a clean census complete', () => {
+    expect(hostScopeCensusIsComplete({ hostIds: ['local', 'ssh:box-1'], omittedHostIds: [] })).toBe(
+      true
+    )
+  })
+
+  // Defence in depth: `listKnownExecutionHostIds` always seeds `local`, so a real scope that
+  // covered nothing also omits `local` and is refused by the runtime-only rule anyway. This
+  // branch is what stops a scope that answered for no host from ever reading complete if that
+  // ever stops holding.
+  it('refuses a listing that covered no host at all', () => {
+    expect(hostScopeCensusIsComplete({ hostIds: [], omittedHostIds: ['runtime:env-7'] })).toBe(
+      false
+    )
+    expect(hostScopeCensusIsComplete({ hostIds: [], omittedHostIds: [] })).toBe(false)
+  })
+
+  // Why: `hostScope` shipped in v1.4.187. An older host cannot say what it covered, and absence
+  // of the claim is never the claim — this must stay the first branch.
+  it('refuses a host too old to publish a scope', () => {
+    expect(hostScopeCensusIsComplete(undefined)).toBe(false)
+  })
+
+  it('refuses an unparseable host id rather than discounting it', () => {
+    expect(
+      hostScopeCensusIsComplete({
+        hostIds: ['local'],
+        omittedHostIds: ['runtime:' as never]
+      })
+    ).toBe(false)
+  })
+})

--- a/src/shared/runtime-listing-host-scope.test.ts
+++ b/src/shared/runtime-listing-host-scope.test.ts
@@ -50,6 +50,26 @@ describe('hostScopeCensusIsComplete', () => {
     expect(hostScopeCensusIsComplete(undefined)).toBe(false)
   })
 
+  // Why: without this the runtime-only rule trusts a coverage claim it cannot read — the shape
+  // `{hostIds: ['runtime:'], omittedHostIds: ['runtime:env-7']}` was `unverifiable` before the
+  // gate changed and must not become `complete` on the strength of an unparseable id.
+  it('refuses a coverage claim with no legible host in it', () => {
+    expect(
+      hostScopeCensusIsComplete({
+        hostIds: ['runtime:' as never],
+        omittedHostIds: ['runtime:env-7']
+      })
+    ).toBe(false)
+  })
+
+  // Why "at least one legible" and not "all legible": a host that later gains a kind this client
+  // cannot parse must not report an incomplete census forever — that is this bug in a new coat.
+  it('accepts a coverage claim carrying one legible host beside an unreadable one', () => {
+    expect(
+      hostScopeCensusIsComplete({ hostIds: ['local', 'newkind:x' as never], omittedHostIds: [] })
+    ).toBe(true)
+  })
+
   it('refuses an unparseable host id rather than discounting it', () => {
     expect(
       hostScopeCensusIsComplete({

--- a/src/shared/runtime-listing-host-scope.ts
+++ b/src/shared/runtime-listing-host-scope.ts
@@ -29,8 +29,12 @@ export function hostScopeCensusIsComplete(scope: RuntimeListingHostScope | undef
   if (scope === undefined) {
     return false
   }
-  // A listing that covered no host at all proves nothing, whatever it omitted.
-  if (scope.hostIds.length === 0) {
+  // A listing that covered no host proves nothing, and an unreadable coverage claim is not a
+  // claim: `isTerminalListResult` checks only that `hostIds` is an array, so at least one covered
+  // id has to be legible before the claim can be believed. Deliberately "at least one" rather than
+  // "all": a host that later gains a kind this client cannot parse would otherwise report an
+  // incomplete census forever, which is the bug this predicate exists to stop.
+  if (!scope.hostIds.some((hostId) => parseExecutionHostId(hostId))) {
     return false
   }
   return scope.omittedHostIds.every((hostId) => parseExecutionHostId(hostId)?.kind === 'runtime')

--- a/src/shared/runtime-listing-host-scope.ts
+++ b/src/shared/runtime-listing-host-scope.ts
@@ -1,4 +1,4 @@
-import type { ExecutionHostId } from './execution-host'
+import { parseExecutionHostId, type ExecutionHostId } from './execution-host'
 
 /**
  * What a bounded listing did and did not cover, by execution host. An absent scope means the
@@ -9,4 +9,29 @@ import type { ExecutionHostId } from './execution-host'
 export type RuntimeListingHostScope = {
   hostIds: ExecutionHostId[]
   omittedHostIds: ExecutionHostId[]
+}
+
+/**
+ * Whether the answering runtime enumerated every host its listing owed coverage for.
+ *
+ * `omittedHostIds` is a disclosure list and deliberately over-names — `omitted-host-scope-selectors.ts`
+ * keeps ids for servers that are no longer paired so a caller can still see the gap. That makes it the
+ * wrong input for a completeness gate, which needs "coverage owed and not delivered". The two jobs pull
+ * in opposite directions, and reading the disclosure list as the gate latched every remote pane on any
+ * client that had ever paired outward (#18595).
+ *
+ * A `runtime:` host is never owed coverage by the runtime answering: a paired runtime is a peer with its
+ * own control plane, reached with `--environment`, and this runtime has no paired-runtime PTY provider to
+ * have queried. Its terminals are its own answer to give, so its presence here is disclosure, not a gap.
+ */
+export function hostScopeCensusIsComplete(scope: RuntimeListingHostScope | undefined): boolean {
+  // A host too old to publish a scope cannot claim one; absence is never completeness.
+  if (scope === undefined) {
+    return false
+  }
+  // A listing that covered no host at all proves nothing, whatever it omitted.
+  if (scope.hostIds.length === 0) {
+    return false
+  }
+  return scope.omittedHostIds.every((hostId) => parseExecutionHostId(hostId)?.kind === 'runtime')
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​330 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​324 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |

<!-- /orca-pr-loc -->

Fixes #18595.

> Replaces an earlier version of this PR that filtered `runtime:` hosts out of `listKnownExecutionHostIds`. That approach was sound but **did not reach the reporter's own configuration** — their peer runtime is named in `omittedHostIds` by a mirrored row, not by a session partition, so the filter left it in place. The branch was reset to base and rebuilt.

## Root cause: one field, two jobs, opposite requirements

`hostScope.omittedHostIds` serves two purposes that pull in opposite directions.

As **disclosure**, it must over-name. `src/cli/omitted-host-scope-selectors.ts:33-42` deliberately keeps ids for servers that are no longer paired, because `docs/reference/ssh-execution-boundary.md` requires a listing to name its gaps, and an agent completing a partial listing needs to see them.

As a **completeness gate**, it must name only coverage that was *owed and not delivered* — otherwise it latches.

It latched. Two sources put a peer runtime in that list permanently:

- `workspaceSessionsByHostId` keeps a partition for every runtime a machine has ever paired with, and nothing prunes it (`session-host-partitions.ts:70-80`).
- A mirrored `remote:<env>@@handle` row contributes `terminal.executionHostId` (`orca-runtime-get-runtime-id.ts:133-137`).

Neither can ever be `covered`, because a `runtime:` host can never enter `queriedHostIds` — there is no paired-runtime PTY provider (`src/main/ipc/pty/provider/registry.ts:18-23`, `src/main/ipc/pty/runtime/inventory-operations.ts:24-52`). So any client that has ever paired outward publishes a permanently non-empty `omittedHostIds`, `probeHostLiveTerminals` returns `unverifiable` forever, `markHostSessionMirrorHydrated` never fires, and panes parked on `parkUntilHostSessionMirrorHydrates` never drain. Blank remote tabs.

## The change

`hostScopeCensusIsComplete()` in `src/shared/runtime-listing-host-scope.ts` gives the gate its own answer and leaves the disclosure list untouched. Three branches, all load-bearing:

1. `scope === undefined` → not complete. A host too old to publish a scope cannot claim one; absence of the claim is never the claim. **This stays first.**
2. `hostIds.length === 0` → not complete. A listing that answered for no host proves nothing.
3. `hostIds` carries no id `parseExecutionHostId` can read → not complete. An unreadable coverage claim is not a claim.
4. Otherwise, complete iff every omitted host is `kind === 'runtime'`.

Branch 3 is the fix. A paired runtime is a peer with its own control plane, reached with `--environment`; this runtime never queried it and never owed it coverage, so its presence in the list is disclosure rather than a gap. This mirrors a rule the host already applies to itself — `isCompleteSessionTabsPtyCensus` discounts `runtime` kinds identically (`orca-runtime-collect-mobile-visible-graph-changed-worktrees.ts:188-197`).

Applied at the two gates: `host-live-terminal-probe.ts` and `web-session-terminal-orphan-recovery-inventory.ts`. Deliberately **not** applied at `worktree-live-terminal-surface-owners.ts:118` — that is a worktree-scoped listing where every other host including `ssh:` is omitted by design, so the predicate would null its owner index permanently on any machine with an SSH target.

Branch 2 is defence in depth, not a live path: `listKnownExecutionHostIds` always seeds `local`, so a real scope with `hostIds: []` also omits `local` and is refused by branch 3 anyway. It exists so a scope that covered nothing can never read complete if that stops holding.

## Review finding: covered ids were trusted without being read

CodeRabbit found a real asymmetry introduced by the first version of this gate. The predicate refused an *omitted* id it could not parse, but accepted an unparseable *covered* id as proof of coverage — `isTerminalListResult` validates only that `hostIds` is an array. So `{hostIds: ['runtime:'], omittedHostIds: ['runtime:env-7']}` was `unverifiable` before this PR and would have become `complete` after it. Narrow, but a new exposure created by the fix.

Taken as **at least one legible covered host**, not the suggested "every id parses". The strict form is a forward-compatibility trap: a host that later gains a host kind this client cannot parse would report an incomplete census forever — which is this bug in a new coat, and exactly the failure mode the predicate exists to prevent. A test pins that distinction.

### Why four pre-existing tests changed

Adding the check turned four tests red, and they are corrected rather than accommodated. They published `hostScope: { hostIds: ['remote-runtime'] }` — a bare environment id that `parseExecutionHostId` rejects.

**No host emits that shape.** A runtime answering `terminal.list` names the execution hosts it covered, which is `local`; verified against a live paired runtime (see the hardware section above, where the real wire answer is `hostIds: ["local"]`). The fixtures asserted a wire shape that does not exist, which is why the assertions move.

"I changed pre-existing tests so my change would pass" deserves scrutiny, so the reasoning is stated here rather than left implicit. Two of the four resolved from one line in the shared fixture (`web-session-terminal-orphan-recovery-regression-fixtures.ts`); the other two were inline literals in `web-session-terminal-pending-handle-recovery.test.ts`.

## Wire compatibility: no wire change

Rules 1, 2 and 3 of `docs/reference/remote-wire-compatibility.md` are not engaged. No `src/main` production file is touched; the host publishes byte-identical content and only the client's reading moves.

| | behaviour |
| --- | --- |
| new client + pre-v1.4.187 host (no `hostScope`) | unchanged — probe skips the gate on `hostScope &&`, recovery reads it as unverifiable |
| new client + v1.4.187+ host | fixed |
| old client + any host | unchanged, still latches |

Being client-side is the point: it reaches the reporter by updating **their M1 alone**, without waiting for their remote to update. Mixed versions are the normal state. It also avoids a new field's fallback rule, where "absent means complete" would recreate this bug with the polarity flipped.

## Hardware verification, on the reporter's shape

The real headless runtime (`out/orcad/orcad.js`) built from this branch, seeded with the reporter's own environment id from the issue, paired to the real CLI over the real RPC path:

```
LIVE terminal.list hostScope:
  {"hostIds":["local"],
   "omittedHostIds":["runtime:77ab217c-d04f-41bc-919d-709185f60308"],
   "omittedHostSelectors":[{"hostId":"runtime:77ab217c-...","selector":null}]}
```

That is the shape reported in the issue. Feeding that live wire answer to the real `probeHostLiveTerminals` from each tree — the host output is identical either side, so this isolates exactly what moved:

```
BASE  637dc30a321: unverifiable  -> mirror never settles, panes park
SPLIT this branch: none          -> mirror settles
```

Also measured: this defect does **not** require a stale pairing or an aged profile. A brand-new client profile has its paired runtimes in `workspaceSessionsByHostId` after the *first* connect, so it fires on first use.

## Version check on the reporter's host

Worth recording, because it decides whether this reaches them. `hostScope` on `terminal.list` — the field this gate reads — shipped in **v1.4.187**; the reporter runs 1.4.197, and a 1.4.195 remote here publishes it. Confirmed on hardware.

`hostScope` on `worktree.list` is a different, **unreleased** path (#18417, added 2026-09-03, in no release tag). A 1.4.195 remote correctly omits it, which is why `orca worktree list --environment <remote>` returns no `hostScope` today. That is not a defect and not what the gate reads.

## Testing

| test | with the fix removed |
| --- | --- |
| `reads a peer runtime as disclosure, not as coverage this host owed` | **FAILS** |
| `settles on a peer runtime it disclosed but never owed coverage for` | **FAILS** |
| `reports a live terminal through a peer-runtime disclosure` | **FAILS** |
| `prunes a twice-absent binding when the only omission is a peer runtime` | **FAILS** (gate 2) |
| `refuses a listing that covered no host at all` | **FAILS** (branch 2 only) |
| SSH-gap, covered-nothing and absent-scope cases at both gates | guards |

Reverting each branch independently: branch 3 → 3 failures; branch 2 → 1 failure; **gate 2 alone → 1 failure**. That last one matters: a readiness review caught that the first version of this PR left gate 2 unpinned — reverting it alone kept the entire renderer suite green, because every pre-existing fixture passes `omittedHostIds: []`. The commit claimed two gates and proved one.

One fixture trap worth naming: `listResult` substitutes its default scope when handed `undefined`, so the absent-scope case deletes the key instead. Routing through the fixture there silently tests the default.

- `pnpm tc` clean
- `src/renderer` + `src/cli` + `src/shared` — 4273 files, **37279 passed**
- `src/main` — 3093 passed; 5 failures under full-suite load (`node-pty-master-fd-retirement`, `ssh-remote-commands`) that **pass 26/26 in isolation**, plus `structured-tui-transcript-catchup` which is known-broken on main. None touch this change.
- `oxlint` exit 0 on all changed files, `oxfmt` applied, no `max-lines` disable

## Deliberately not addressed

CodeRabbit's pre-merge checks pass 4 of 5. The failure is **Docstring Coverage at 50% against an 80% threshold**, over four analyzed functions. Overridden: the production function (`hostScopeCensusIsComplete`) carries a full docstring, the remainder are test helpers, and `AGENTS.md` asks for concise non-obvious comments rather than blanket ones. Meeting the threshold would mean adding boilerplate that violates the repo's own style rule to satisfy a bot heuristic.

## Not covered

- **Nothing prunes `workspaceSessionsByHostId` on unpair.** This makes the entry harmless rather than absent. Separate follow-up.
- **A configured-but-unreachable SSH target still latches the probe**, correctly: that host *was* owed coverage. Pre-existing and out of scope, but the same blank-tab symptom will persist for that topology.
- **`worktree list` returning `[]` on a pure-remote client** was investigated separately and is not a second defect: four independent guards prevent a `runtime:`-hosted repo from entering a client store, and the symptom reproduces exactly on a fresh client with zero runtime repos. It is this bug plus having no locally registered repos.
- The reporter's blank *metadata* is addressed by their own PR #18602, which is complementary to this one.

