### PR TITLE
chore: CI control at current main (do not merge)

### DIFF
--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -108,6 +108,8 @@ import {
   MIN_SSH_RELAY_GRACE_PERIOD_SECONDS
 } from '../../shared/ssh-types'
 
+// CI control (temporary, see the ssh-docker-transport-drop-recovery:337 investigation): a
+// comment-only diff at current main, the A/B partner of the cc9e9ed control.
 export type RelayDeployResult = {
   transport: MultiplexerTransport
   serverBuildId?: string


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

Temporary CI control, A/B partner of #18615. **Do not merge — I will close both once the lane answers.**

A `+2/−0` comment-only diff at current `main` (`637dc30a321`), which **contains** #18591 and #18601. #18615 is the identical diff at `cc9e9ed`, which does **not**.

`pr.yml:929` passes `ref: github.event.pull_request.head.sha`, so each runs its own head rather than a merge ref — the two differ only in whether the merged changes are present.

Question: does `ssh-docker-transport-drop-recovery.spec.ts:337` fail at the same rate on both? If yes, it is base-independent flake. If it fails here and not on #18615, the merged changes are implicated.