### PR TITLE
perf(orchestration): bound the worker terminal archive in linear time

### DIFF
--- a/src/main/runtime/orchestration/worker-output-archive-bounding.test.ts
+++ b/src/main/runtime/orchestration/worker-output-archive-bounding.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { boundArchiveLines } from './worker-output-archive'
+
+const TERMINAL_ARCHIVE_MAX_CHARS = 262_144
+
+function totalCost(lines: string[]): number {
+  return lines.reduce((sum, line) => sum + line.length + 1, 0)
+}
+
+describe('boundArchiveLines', () => {
+  it('returns the original array untouched when the tail already fits', () => {
+    const lines = ['one', 'two', 'three']
+    const bounded = boundArchiveLines(lines)
+    expect(bounded.truncated).toBe(false)
+    expect(bounded.lines).toBe(lines)
+  })
+
+  it('keeps the newest lines in order and reports truncation', () => {
+    const lines = Array.from({ length: 40_000 }, (_, index) => `line ${index}`)
+    const bounded = boundArchiveLines(lines)
+    expect(bounded.truncated).toBe(true)
+    expect(totalCost(bounded.lines)).toBeLessThanOrEqual(TERMINAL_ARCHIVE_MAX_CHARS)
+    expect(bounded.lines.at(-1)).toBe(lines.at(-1))
+    expect(bounded.lines).toEqual(lines.slice(lines.length - bounded.lines.length))
+  })
+
+  it('truncates a single oversized line from its tail', () => {
+    const bounded = boundArchiveLines(['x'.repeat(TERMINAL_ARCHIVE_MAX_CHARS * 2)])
+    expect(bounded.truncated).toBe(true)
+    expect(bounded.lines).toHaveLength(1)
+    expect(bounded.lines[0]).toHaveLength(TERMINAL_ARCHIVE_MAX_CHARS - 1)
+  })
+
+  it('bounds a blank-line flood in linear time', () => {
+    // The char budget admits ~262k blank lines; an unshift-per-line build was ~4.3s here.
+    const startedAt = performance.now()
+    const bounded = boundArchiveLines(Array.from({ length: 300_000 }, () => ''))
+    expect(bounded.lines).toHaveLength(TERMINAL_ARCHIVE_MAX_CHARS)
+    expect(performance.now() - startedAt).toBeLessThan(500)
+  })
+})

--- a/src/main/runtime/orchestration/worker-output-archive.ts
+++ b/src/main/runtime/orchestration/worker-output-archive.ts
@@ -114,7 +114,7 @@ export async function captureWorkerOutputArchive(args: {
   }
 }
 
-function boundArchiveLines(lines: string[]): { lines: string[]; truncated: boolean } {
+export function boundArchiveLines(lines: string[]): { lines: string[]; truncated: boolean } {
   let total = 0
   for (const line of lines) {
     total += line.length + 1
@@ -122,18 +122,21 @@ function boundArchiveLines(lines: string[]): { lines: string[]; truncated: boole
   if (total <= TERMINAL_ARCHIVE_MAX_CHARS) {
     return { lines, truncated: false }
   }
-  const kept: string[] = []
+  // Collected newest-first and reversed once: unshift per line is O(n^2) and the
+  // char budget admits ~260k blank lines.
+  const keptReversed: string[] = []
   let budget = TERMINAL_ARCHIVE_MAX_CHARS
   for (let index = lines.length - 1; index >= 0; index -= 1) {
     const cost = lines[index].length + 1
     if (cost > budget) {
-      if (kept.length === 0 && budget > 1) {
-        kept.unshift(lines[index].slice(-(budget - 1)))
+      if (keptReversed.length === 0 && budget > 1) {
+        keptReversed.push(lines[index].slice(-(budget - 1)))
       }
       break
     }
-    kept.unshift(lines[index])
+    keptReversed.push(lines[index])
     budget -= cost
   }
-  return { lines: kept, truncated: true }
+  keptReversed.reverse()
+  return { lines: keptReversed, truncated: true }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

When an orchestration worker is released, Orca saves the tail of its terminal output as evidence. If the output is too big it trims it, keeping the newest 256 KB.

The trimming worked by walking backwards through the lines and inserting each one at the *front* of a list. Inserting at the front means shuffling everything already in the list along by one — so with a lot of lines, the work grows with the square of the line count.

Now it collects the lines back-to-front and flips the list once at the end. Same output, same trim point, but the work grows in a straight line instead.

## What Changed

`boundArchiveLines` in `src/main/runtime/orchestration/worker-output-archive.ts` now `push`es into a reversed accumulator and calls `.reverse()` once, instead of `unshift`ing per line. `boundArchiveLines` is exported so it can be unit-tested directly.

## Why

The budget is a **character** budget, not a line budget:

```ts
const TERMINAL_ARCHIVE_MAX_CHARS = 262_144
```

Each line costs `line.length + 1`, so a blank line costs 1. That means the kept-line count is bounded by ~262,144, not by anything small. Terminal output with many short or blank lines — agent spinners, `\n`-padded log output, TUI redraws, blank-line-separated prompts — reaches that bound easily.

`Array.prototype.unshift` is O(current length), so building 262k entries that way is ~3.4×10¹⁰ element moves. This runs synchronously on the main process during worker release, so it presents as the app freezing at the moment a worker finishes.

## Measurements

Node, Apple Silicon, comparing the old and new implementations directly and asserting byte-identical output:

| input | before (`unshift`) | after (`push` + `reverse`) | speedup |
| --- | --- | --- | --- |
| 300,000 blank lines (worst case, hits the 262k line bound) | **4322 ms** | **6 ms** | **~720x** |
| 120,000 short lines `"line N"` (22k kept) | 25 ms | 3 ms | ~8x |

Both cases verified to produce identical `{ lines, truncated }` results.

The new test `bounds a blank-line flood in linear time` fails on the old implementation (4.3 s against a 500 ms bound) and passes on the new one, so it is a real regression guard, not a smoke test.

## Negative user-facing trade-offs

**None.** The archive content is bit-for-bit identical:

- Same lines kept, same order, same `truncated` flag.
- Same tail-truncation of a single oversized line (`slice(-(budget - 1))`).
- Same early-return identity when the whole tail fits (still returns the original array, so no extra allocation on the common path).
- No cap was lowered and no output is dropped — this only changes *how* the same array is constructed.

## Merge risk

**Low.** Self-contained pure function, no callers changed, output asserted identical against the old implementation. The perf guard fails on the old code (4.3s against a 500ms bound), so a regression cannot land quietly. Only new API surface is exporting the function for the test.

## Linked Issue

Fixes #

## Visual Proof

N/A — no UI change. The only observable difference is that worker release stops blocking the main process; the archived output is identical.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `src/main/runtime/orchestration/worker-output-archive-bounding.test.ts` (4 tests):
- returns the original array untouched when the tail already fits (identity preserved)
- keeps the newest lines in order and reports truncation
- truncates a single oversized line from its tail
- bounds a blank-line flood in linear time (the perf guard; fails on the old code)

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: pure JavaScript array manipulation, no platform-dependent behavior.

## AI Disclosure

