### PR TITLE
perf(git): overlap the three independent submodule status reads

### DIFF
--- a/src/main/git/source-control/submodule-status.ts
+++ b/src/main/git/source-control/submodule-status.ts
@@ -26,17 +26,22 @@ export async function getSubmoduleStatus(
   const submoduleWorktreePath = resolveSubmoduleWorktreePath(worktreePath, submodulePath)
   const limit = resolveGitStatusLimit(options.limit)
   // Why: staged expansion only represents HEAD→index; scanning the submodule worktree is wasted work.
-  const workingResult = options.staged
-    ? ({ entries: [], conflictOperation: 'unknown' } satisfies GitStatusResult)
-    : await getStatus(submoduleWorktreePath, options)
-  // Why: a moved gitlink (clean worktree) has no status rows; surface the parent-commit→checkout range as inner rows.
-  const fromOid = options.staged
-    ? await readGitlinkOidFromTree(worktreePath, 'HEAD', submodulePath, options)
-    : (await readGitlinkOidFromIndex(worktreePath, submodulePath, options)) ||
-      (await readGitlinkOidFromTree(worktreePath, 'HEAD', submodulePath, options))
-  const toOid = options.staged
-    ? await readGitlinkOidFromIndex(worktreePath, submodulePath, options)
-    : await readWorkingSubmoduleHead(submoduleWorktreePath, options)
+  // These three reads are independent, so they run concurrently — on SSH/WSL each one is a real round trip.
+  const [workingResult, fromOid, toOid] = await Promise.all([
+    options.staged
+      ? Promise.resolve<GitStatusResult>({ entries: [], conflictOperation: 'unknown' })
+      : getStatus(submoduleWorktreePath, options),
+    // Why: a moved gitlink (clean worktree) has no status rows; surface the parent-commit→checkout range as inner rows.
+    options.staged
+      ? readGitlinkOidFromTree(worktreePath, 'HEAD', submodulePath, options)
+      : readGitlinkOidFromIndex(worktreePath, submodulePath, options).then(
+          (indexOid) =>
+            indexOid || readGitlinkOidFromTree(worktreePath, 'HEAD', submodulePath, options)
+        ),
+    options.staged
+      ? readGitlinkOidFromIndex(worktreePath, submodulePath, options)
+      : readWorkingSubmoduleHead(submoduleWorktreePath, options)
+  ])
   if (fromOid && toOid && fromOid !== toOid) {
     const rangeEntries = await computeSubmoduleRangeEntries(
       submoduleWorktreePath,

--- a/src/main/git/status-submodule.test.ts
+++ b/src/main/git/status-submodule.test.ts
@@ -395,4 +395,35 @@ describe('getSubmoduleStatus', () => {
     expect(result.didHitLimit).toBe(true)
     expect(result.statusLength).toBe(2)
   })
+
+  it('overlaps the inner status, index and HEAD reads instead of serializing them', async () => {
+    const OLD_OID = 'a'.repeat(40)
+    const NEW_OID = 'b'.repeat(40)
+    readFileMock.mockResolvedValue('gitdir: /repo/flutter_mine/.git\n')
+    existsSyncMock.mockReturnValue(false)
+    const events: string[] = []
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const name = args.includes('status') ? 'status' : args[0]
+      events.push(`start:${name}`)
+      if (name === 'status') {
+        // Hold the inner status open so a serialized caller could not have started the oid reads.
+        await new Promise((resolve) => setTimeout(resolve, 5))
+      }
+      events.push(`end:${name}`)
+      if (name === 'ls-files') {
+        return { stdout: `160000 ${OLD_OID} 0\tflutter_mine\n` }
+      }
+      if (name === 'rev-parse') {
+        return { stdout: `${NEW_OID}\n` }
+      }
+      return { stdout: '' }
+    })
+
+    await getSubmoduleStatus('/repo', 'flutter_mine')
+
+    // Serialized reads only start ls-files/rev-parse once the inner status has resolved.
+    expect(events.indexOf('start:ls-files')).toBeLessThan(events.indexOf('end:status'))
+    expect(events.indexOf('start:rev-parse')).toBeLessThan(events.indexOf('end:status'))
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

When you expand a submodule row in Source Control, Orca runs three separate `git` commands to work out what changed inside it. None of them needs the answer from any other, but they were being run one after another — command 1 finishes, then command 2 starts, then command 3 starts.

Now all three start at the same time. The panel waits for the slowest one instead of for all of them added together.

## What Changed

`getSubmoduleStatus` in `src/main/git/source-control/submodule-status.ts` now issues its three independent reads through a single `Promise.all`:

- the inner `git status` in the submodule worktree
- the parent gitlink oid (`git ls-files -s`, falling back to `git ls-tree HEAD`)
- the submodule's checked-out HEAD (`git rev-parse HEAD`)

The one genuine dependency — the `ls-tree` fallback that only runs when `ls-files` comes back empty — stays chained behind `ls-files`, but that chain now runs concurrently with the other two.

## Why

The old shape awaited each read in sequence:

```ts
const workingResult = options.staged ? {...} : await getStatus(submoduleWorktreePath, options)
const fromOid = options.staged
  ? await readGitlinkOidFromTree(...)
  : (await readGitlinkOidFromIndex(...)) || (await readGitlinkOidFromTree(...))
const toOid = options.staged ? await readGitlinkOidFromIndex(...) : await readWorkingSubmoduleHead(...)
```

This is not a one-off cost. `src/renderer/src/components/right-sidebar/source-control/listing/use-submodule-status.ts` refetches on every parent status poll — its own comment says it "re-runs when the parent status poll refreshes ... so expanded children stay fresh". So an expanded submodule row pays the full serialized latency on every poll for as long as it stays expanded.

It also matters far more than the local numbers suggest: `git.submoduleStatus` forwards to this same host-side function over the SSH relay (`src/relay/git-handler-read-operations.ts`) and through `ssh-git-read-provider.ts`. On SSH — or on WSL, where each Git invocation crosses the 9p/interop boundary — each of these is a real network/interop round trip.

## Measurements

The reads are latency-bound, not CPU-bound, so the right measurement is round-trip count on the critical path:

| | before | after |
| --- | --- | --- |
| git subprocesses spawned (unchanged) | 3 (4 on the `ls-tree` fallback) | 3 (4 on the fallback) |
| **sequential round trips on the critical path** | **3** (4 on the fallback) | **1** (2 on the fallback) |
| wall clock | ≈ `t_status + t_lsfiles + t_revparse` | ≈ `max(t_status, t_lsfiles, t_revparse)` |

So a submodule row over an SSH link with 60 ms RTT goes from ~180 ms per poll to ~60 ms per poll; locally it goes from the sum of three `git` process startups to the longest single one.

The new test proves the overlap deterministically rather than by timing: it holds the inner `git status` open and asserts that `ls-files` and `rev-parse` have already *started* before `status` resolves. It fails on the old code (`expected 2 to be less than 1`) and passes on the new code.

## Negative user-facing trade-offs

**None.** Specifically:

- **Same commands, same arguments, same results.** Only the await ordering changed; every branch (staged vs. unstaged, gitlink-moved vs. not, limit capping) produces identical output.
- **Error behaviour preserved.** `readGitlinkOidFromIndex` / `readGitlinkOidFromTree` / `readWorkingSubmoduleHead` all already swallow failures and return `''`. Only `getStatus` can reject, and `Promise.all` still rejects with exactly that error. The other two reads may now have been started when it rejects — that costs nothing user-visible, and they cannot reject.
- **No git-version risk.** No new subcommands or options; nothing here moves off the Git 2.25 baseline.
- **No index-lock contention.** All three already run with `GIT_OPTIONAL_LOCKS=0` (`gitOptionalLocksDisabledEnv()`), so running them together cannot race the user's terminal Git on `index.lock`.
- **Concurrency budget**: three concurrent reads instead of three serial ones, only while a submodule row is expanded. These go through the same admission-tiered runner as before.

## Merge risk

**Low.** Await reordering inside one function; no new Git subcommands or flags, so no version-baseline exposure. The thing to check is error precedence: only `getStatus` can reject, `Promise.all` still rejects with exactly that error, and the other two reads swallow failures by design. Reaches the SSH relay through the same function, so it wants a sanity check on a remote repo.

## Linked Issue

Fixes #

## Visual Proof

N/A — the Source Control submodule rows render exactly the same content, just sooner. No visual or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm test src/main/git/status-submodule.test.ts` — 14 pass (13 existing + 1 new). The new test, `overlaps the inner status, index and HEAD reads instead of serializing them`, was confirmed to fail against the pre-change implementation and pass after.

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: developed and tested on macOS. The change is platform-neutral, and the SSH/WSL paths go through the same function, which is where the win is largest.

## AI Disclosure

