### PR TITLE
test(renderer): pin the runtime-target selector identity stability that #18685 fixed

### DIFF
--- a/src/renderer/src/runtime/use-worktree-runtime-target.test.ts
+++ b/src/renderer/src/runtime/use-worktree-runtime-target.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { useWorktreeRuntimeTarget } from './use-worktree-runtime-target'
+
+const initialState = useAppStore.getInitialState()
+
+afterEach(() => {
+  cleanup()
+  useAppStore.setState(initialState, true)
+})
+
+it('keeps the runtime target identity stable across unrelated store writes', () => {
+  let renders = 0
+  const { result } = renderHook(() => {
+    renders += 1
+    return useWorktreeRuntimeTarget('worktree-1')
+  })
+
+  const first = result.current
+  const rendersAfterMount = renders
+
+  act(() => {
+    for (let index = 0; index < 50; index += 1) {
+      useAppStore.setState({ activeRepoId: `repo-${index}` })
+    }
+  })
+
+  // A selector that built the target object inline re-rendered on every write.
+  expect(renders).toBe(rendersAfterMount)
+  expect(result.current).toBe(first)
+})


### PR DESCRIPTION
## ELI5

A hook that tells the ports UI which machine owns a workspace was building its answer object fresh inside the store subscription. React compares by identity, so a brand-new object always looks "changed" — and the always-mounted status-bar Ports segment re-rendered on **every single write to the app store**.

That fix has since landed on `main` via #18685. It landed without a test. This PR is that test.

## What Changed

Test only. `src/renderer/src/runtime/use-worktree-runtime-target.test.ts` renders the hook, drives 50 unrelated store writes, and asserts two things: the consumer renders exactly once, and the returned target keeps its referential identity.

No production code — `main` already has the fix.

## Why

I found and fixed this independently while auditing renderer render-churn; #18685 shipped the same change first (`useAppStore(state => getExecutionHostIdForWorktree(...))` then `useMemo`), so I dropped my duplicate implementation and rebased this branch down to the regression guard.

Worth keeping, because the bug is invisible without one: the hook returns a *structurally correct* value either way. Only the identity differs, so nothing fails, nothing looks wrong, and the cost shows up as unexplained baseline render churn that scales with store traffic. A future refactor could reintroduce it silently. This test fails loudly instead — verified at **51 renders vs 1** against the pre-#18685 hook.

## Measurements

| | before #18685 | after |
| --- | --- | --- |
| renders of a consumer across 50 unrelated store writes | **51** (1 mount + 50) | **1** (mount only) |
| returned target identity stable across those writes | no | yes |

## Negative user-facing trade-offs

**None** — this PR contains no production code. It adds one test file.

## Merge risk

**Very low.** Test-only, on the current `main`, covering a fix that is already merged. The worst case is a flaky test, and it is not timing-based: it counts renders and compares object identity.

## Linked Issue

No tracked issue — found by a repository-wide performance audit. Related: #18685.

## Visual Proof

N/A — no production change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm test src/renderer/src/runtime/use-worktree-runtime-target.test.ts` passes on current `main`, and was confirmed to fail against the pre-#18685 hook.

Platforms: renderer-only, no platform-dependent behavior.

## AI Disclosure
