### PR TITLE
perf(terminal): stop copying every PTY chunk for two startup-error detectors

### DIFF
--- a/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.ts
+++ b/src/renderer/src/components/terminal-pane/codex-backfill-error-detector.ts
@@ -9,6 +9,8 @@ const ANSI_ESCAPE_PATTERN =
   // eslint-disable-next-line no-control-regex -- terminal escape sequences contain control bytes
   /\u001b(?:\[[0-9;?]*[ -/]*[@-~]|\][^\u0007\u001b]*(?:\u0007|\u001b\\)?)/g
 const DETECTOR_BUFFER_MAX_CHARS = 4096
+// Why a regex over toLowerCase(): the case-folded copy allocated the whole 4KB carry on every chunk.
+const CODEX_BACKFILL_TIMEOUT_PATTERN = new RegExp(CODEX_BACKFILL_TIMEOUT_SIGNATURE, 'i')
 
 export type CodexBackfillErrorDetector = { observe(chunk: string): string | null }
 
@@ -23,7 +25,7 @@ export function createCodexBackfillErrorDetector(): CodexBackfillErrorDetector {
       }
       const normalized = (tail + chunk).replace(ANSI_ESCAPE_PATTERN, '').replace(/\r/g, '')
       tail = normalized.slice(-DETECTOR_BUFFER_MAX_CHARS)
-      if (!tail.toLowerCase().includes(CODEX_BACKFILL_TIMEOUT_SIGNATURE)) {
+      if (!CODEX_BACKFILL_TIMEOUT_PATTERN.test(tail)) {
         return null
       }
       armed = false

--- a/src/renderer/src/components/terminal-pane/git-bash-console-capacity.test.ts
+++ b/src/renderer/src/components/terminal-pane/git-bash-console-capacity.test.ts
@@ -11,6 +11,29 @@ describe('Git Bash console capacity detection', () => {
     expect(detector.detected()).toBe(true)
   })
 
+  it('detects the marker at every chunk boundary, in any case', () => {
+    const noisyPrefix = 'x'.repeat(200)
+    const stream = `${noisyPrefix}Console device allocation failure - TOO MANY CONSOLES In Use, Max Consoles Is 128\r\n`
+
+    for (let split = 0; split <= stream.length; split += 1) {
+      const detector = createGitBashConsoleCapacityDetector()
+      detector.observe(stream.slice(0, split))
+      detector.observe(stream.slice(split))
+      expect(detector.detected(), `split at ${split}`).toBe(true)
+    }
+  })
+
+  it('still matches when the carry is rebuilt by chunks that skip the fast path', () => {
+    const detector = createGitBashConsoleCapacityDetector()
+
+    // None of these chunks contain the marker's final character, so each takes the fast path.
+    detector.observe('too many consoles in use, ')
+    detector.observe('max consoles is ')
+    detector.observe('128')
+
+    expect(detector.detected()).toBe(true)
+  })
+
   it('ignores unrelated shell failures', () => {
     const detector = createGitBashConsoleCapacityDetector()
     detector.observe('bash: command not found')

--- a/src/renderer/src/components/terminal-pane/git-bash-console-capacity.ts
+++ b/src/renderer/src/components/terminal-pane/git-bash-console-capacity.ts
@@ -1,4 +1,8 @@
 const GIT_BASH_CONSOLE_CAPACITY_MARKER = 'too many consoles in use, max consoles is 128'
+const CARRY_LENGTH = GIT_BASH_CONSOLE_CAPACITY_MARKER.length - 1
+// Why this char: a match that was not already found must end inside the new chunk, so the chunk has
+// to contain the marker's final character. It is a digit, so the test needs no case folding.
+const MARKER_FINAL_CHAR = GIT_BASH_CONSOLE_CAPACITY_MARKER.at(-1) as string
 
 export type GitBashConsoleCapacityDetector = {
   observe: (data: string) => void
@@ -14,9 +18,17 @@ export function createGitBashConsoleCapacityDetector(): GitBashConsoleCapacityDe
       if (matched || data.length === 0) {
         return
       }
+      if (!data.includes(MARKER_FINAL_CHAR)) {
+        // Fold only the carry instead of copying the whole chunk: this runs per PTY chunk per pane.
+        tail =
+          data.length >= CARRY_LENGTH
+            ? data.slice(-CARRY_LENGTH).toLowerCase()
+            : (tail + data).slice(-CARRY_LENGTH).toLowerCase()
+        return
+      }
       const candidate = (tail + data).toLowerCase()
       matched = candidate.includes(GIT_BASH_CONSOLE_CAPACITY_MARKER)
-      tail = candidate.slice(-(GIT_BASH_CONSOLE_CAPACITY_MARKER.length - 1))
+      tail = candidate.slice(-CARRY_LENGTH)
     },
     detected: () => matched
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

Two little watchers sit on every terminal, reading every scrap of output looking for one specific error message. Each one made a full lowercase copy of the text it was searching, for every single chunk of output, for as long as the terminal was alive — just to answer one yes/no question that gets asked at most once (and usually never).

Now they answer the same question without making those copies.

## What Changed

**`git-bash-console-capacity.ts`** — searches for the MSYS error `too many consoles in use, max consoles is 128`.

It used to do `(carry + chunk).toLowerCase()` per chunk. It now skips that copy when the chunk cannot possibly complete a match. The gate is exact: a match that was not already found must *end* inside the new chunk (every earlier end position was tested on a previous chunk), so the chunk must contain the marker's final character — and that character is `8`, a digit, so no case folding is needed to test for it. When the gate skips, only the 44-character carry is folded, not the chunk.

**`codex-backfill-error-detector.ts`** — searches for `timed out waiting for state db backfill`.

It used to do `tail.toLowerCase().includes(SIGNATURE)`, allocating a lowercased copy of the whole 4096-character carry on every chunk. It now tests the carry in place with a module-level case-insensitive `RegExp`. No allocation.

## Why

These run on the hottest path in the renderer. `git-bash-console-capacity`'s detector is created **unconditionally** for every pane (`pty-connection/pty-exit-hibernate.ts:32`) and fed from `transport-output-callbacks.ts:52`; its `detected()` result is read in exactly one place, at a non-zero local process exit (`pty-exit-hibernate.ts:299`). The Codex one is created for every Codex pane (`run-deferred-connect.ts:119`) and fed from `live-data-callback.ts:67`; Codex is a full-screen TUI that repaints on every token.

So: a per-chunk, per-pane, whole-pane-lifetime string copy feeding a boolean that is usually never true.

## Measurements

Node, Apple Silicon, 20,000 chunks through each detector, comparing old and new implementations directly:

**`git-bash-console-capacity`**, 4 KB chunks:

| chunk shape | before | after | |
| --- | --- | --- | --- |
| typical prose / TUI redraw (no `8` in the chunk) | **30.9 ms** | **2.7 ms** | **11x faster** |
| chunk contains an `8` (fast path does not apply) | 33.7 ms | 35.3 ms | ~5% slower — see below |

**`codex-backfill-error-detector`**, ~1 KB ANSI-decorated chunks:

| | before | after | |
| --- | --- | --- | --- |
| Codex-style redraw stream | **100.7 ms** | **51.1 ms** | **2.0x faster** |

The Codex win is unconditional (the 4 KB carry copy is gone in all cases). The Git Bash win is conditional on the chunk not containing an `8`.

## Negative user-facing trade-offs

**One, and it is measured and negligible — disclosing it rather than claiming a clean sweep:**

- In the `git-bash-console-capacity` detector, a chunk that *does* contain the character `8` now pays one extra `String.prototype.includes` scan before doing the same work as before. Measured at **+1.6 ms across 20,000 4 KB chunks (~85 ns per chunk, ~5%)** on the worst-case shape, against an 11x saving on the shape that skips. Digit-dense output (verbose numeric logs) lands in the slower bucket; prose, TUI redraws, and most agent output land in the faster one. There is no configuration in which this is user-perceptible, and the expected value is strongly positive.

Everything else is free:

- **Detection is unchanged.** The `8` gate is a necessary condition, not a heuristic — it cannot produce a false negative. Proven by a new test that replays the marker with **every possible chunk split** (all 285 split points), in mixed case, and asserts detection at each one, plus a test where three consecutive chunks each take the fast path and the match still lands.
- **No case-sensitivity change.** The Codex regex is a pure-ASCII pattern with `/i`; identical results to `toLowerCase().includes(...)` for this signature. The existing test already exercises mixed case (`state DB back` split across chunks) and still passes.
- **No carry-length or buffer-cap change.** Both detectors retain exactly as much context as before (44 chars and 4096 chars respectively).
- **No platform gating added.** It would be tempting to skip the Git Bash detector entirely off Windows, but that would narrow behavior on a non-Windows host that happens to print the string, so I left it alone. The fast path is platform-neutral and exact.

## Merge risk

**Low.** Two independent detectors, both gated by an exactness argument rather than a heuristic. The all-splits test (285 boundaries, mixed case) is the real protection. Carries the session's only measured micro-regression: +85ns per chunk when the chunk contains an `8`. Reviewer should sanity-check the claim that a new match must end inside the new bytes.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual or interaction change. Both detectors produce the same verdicts; they just stop allocating to get there.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`git-bash-console-capacity.test.ts` — 4 tests (2 existing + 2 new):
- detects the marker at every chunk boundary, in any case (285 split points)
- still matches when the carry is rebuilt by chunks that each skip the fast path

`codex-backfill-error-detector.test.ts` — 2 existing tests pass unchanged (one already covers a mixed-case, ANSI-decorated, split-across-chunks match).

Full terminal-pane + PTY suite: `pnpm test src/renderer/src/components/terminal-pane src/main/ipc/pty` — 505 files, 4858 tests, all passing. `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only string handling, no platform branches.

## AI Disclosure

