### PR TITLE
perf(terminal): gate the Command Code banner scan before building its scan windows

### DIFF
--- a/src/shared/command-code-output-status.test.ts
+++ b/src/shared/command-code-output-status.test.ts
@@ -49,6 +49,22 @@ describe('createCommandCodeOutputStatusDetector', () => {
     expect(onWorking).toHaveBeenCalledWith('')
   })
 
+  it('detects the banner after chunks that carry no banner characters at all', () => {
+    const onWorking = vi.fn()
+    const detector = createCommandCodeOutputStatusDetector({
+      startupCommand: null,
+      onWorking
+    })
+
+    // Ordinary agent output with no '#': the raw prefilter skips these without building a window.
+    expect(detector.observe('Codex is editing the file and rendering a diff\r\n')).toBe(false)
+    expect(detector.observe('Codex wrote 12 lines\r\n')).toBe(false)
+    expect(detector.observe('# Command Code v0.27.2\r\n')).toBe(false)
+    expect(detector.observe('⌘ Parsing...')).toBe(true)
+
+    expect(onWorking).toHaveBeenCalledWith('')
+  })
+
   it('detects the Command Code banner when ANSI styling splits the words', () => {
     const onWorking = vi.fn()
     const detector = createCommandCodeOutputStatusDetector({

--- a/src/shared/command-code-output-status.ts
+++ b/src/shared/command-code-output-status.ts
@@ -142,6 +142,21 @@ function rawTextMayContainCommandCodeBanner(rawText: string): boolean {
   return rawText.includes('C') && rawText.includes('o') && rawText.includes('d')
 }
 
+// COMMAND_CODE_BANNER_RE requires a literal '#', and stripTerminalControl only ever removes
+// characters, so raw bytes without one cannot produce a banner match.
+const BANNER_REQUIRED_RAW_CHAR = '#'
+
+/**
+ * Prefilter run against the raw chunk before the scan windows are built. Testing the whole carry
+ * plus chunk over-admits relative to the window test (the windows drop middle content), so it can
+ * never turn a match into a miss.
+ */
+function rawChunkMayContainCommandCodeBanner(previousRawText: string, data: string): boolean {
+  return (
+    data.includes(BANNER_REQUIRED_RAW_CHAR) || previousRawText.includes(BANNER_REQUIRED_RAW_CHAR)
+  )
+}
+
 function appendRecentRawText(previousRawText: string, data: string): string {
   if (data.length >= RECENT_TEXT_LIMIT) {
     return data.slice(-RECENT_TEXT_LIMIT)
@@ -233,6 +248,11 @@ export function createCommandCodeOutputStatusDetector(args: {
     observe(data: string): boolean {
       const previousRawText = recentRawText
       recentRawText = appendRecentRawText(previousRawText, data)
+      // Why before the windows: a non-Command-Code pane pays two ~4KB string builds per chunk
+      // otherwise, only to fail the same prefilter a few lines later.
+      if (!hasSeenCommandCodeUi && !rawChunkMayContainCommandCodeBanner(previousRawText, data)) {
+        return false
+      }
       const scanRawText = buildStatusScanRawText(previousRawText, data)
       const scanRawTextWithChunkBoundary = previousRawText
         ? buildStatusScanRawText(`${previousRawText}\n`, data)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

Orca watches terminal output for the Command Code startup banner, which looks like `# Command Code v1.2.3`. To do that it was assembling two ~4 KB windows of recent output for *every* chunk of output from *every* terminal — and then, for panes that hadn't shown a banner yet, stripping colour codes out of those windows three times over, before finally checking whether a banner was there.

There was already a cheap "is this worth looking at?" test, but it ran *after* all that work, and all it asked was "does this text contain the letters C, o and d?" — which basically any coding agent's output does.

The banner must contain a `#`. Colour-code stripping only ever deletes characters, so if there's no `#` in the raw bytes there cannot be a banner. Now that one check runs first, before any of the windows get built.

## What Changed

`src/shared/command-code-output-status.ts`, inside `observe()`:

```diff
   const previousRawText = recentRawText
   recentRawText = appendRecentRawText(previousRawText, data)
+  if (!hasSeenCommandCodeUi && !rawChunkMayContainCommandCodeBanner(previousRawText, data)) {
+    return false
+  }
   const scanRawText = buildStatusScanRawText(previousRawText, data)
   const scanRawTextWithChunkBoundary = previousRawText
     ? buildStatusScanRawText(`${previousRawText}\n`, data)
     : scanRawText
```

`rawChunkMayContainCommandCodeBanner` tests the carry and the chunk for `#`. The existing window-level prefilter (`rawTextMayContainCommandCodeBanner`, the C/o/d test) is left exactly as it was.

## Why

The detector is created for every PTY (`orca-runtime-apply-tracked-pty-title.ts:186`) and driven from `orca-runtime-on-pty-data.ts:226`, on the **main process** — the thread every pane's output queues behind, shared with the headless emulator. So per-chunk cost here is multiplied by every pane on the machine.

For a pane that is not a Command Code pane (the overwhelming majority), the old order was:

1. `buildStatusScanRawText(previousRawText, data)` — build a ~4 KB window
2. `buildStatusScanRawText(previousRawText + '\n', data)` — build a second ~4 KB window
3. C/o/d prefilter on window 1 — passes for almost any agent output
4. `stripTerminalControl` × 3 over those windows
5. two `COMMAND_CODE_BANNER_RE` tests — fail
6. return false

Steps 1–5 are all discardable if the raw bytes contain no `#`.

Why `#` is a sound gate: `COMMAND_CODE_BANNER_RE` (line 115) requires a literal `#` in the *stripped* text, and `stripTerminalControl` only removes characters — it never synthesizes one. So `#` absent from the raw bytes ⇒ `#` absent from the stripped text ⇒ the regex cannot match. Testing `previousRawText || data` (rather than the built windows) deliberately over-admits, because the windows drop middle content when they overflow their budget — so the gate is strictly looser than what it replaces on that axis, and cannot turn a match into a miss.

I deliberately did **not** add `#` to the existing window-level C/o/d prefilter. That one gates only on `scanRawText`, while the banner is also tested against a second, differently-truncated window; tightening it could in principle reject a case the second window would have matched. Leaving it alone keeps this change provably one-directional.

## Measurements

Node/Vitest, Apple Silicon, 20,000 × ~4 KB agent-style chunks through one detector on a non-Command-Code pane, best of 3 runs:

| chunk shape | before | after | |
| --- | --- | --- | --- |
| agent output with no `#` (gate applies) | **452.7 ms** (22.6 µs/chunk) | **2.4 ms** (0.12 µs/chunk) | **~190x faster** |
| agent output containing `#` (gate does not apply) | 448.1 ms | 451.5 ms | within run-to-run noise (~0.7%) |

To put the first row in scale: at 30 chunks/sec on 4 active panes, the old path burned ~2.7 ms of main-process time *per second* on this detector alone, and that is main-process time every other pane's output waits behind.

## Negative user-facing trade-offs

**None.** Specifically:

- **Detection is unchanged.** The gate is a necessary condition derived from the regex itself, not a heuristic — no false negatives are possible. The banner is still detected when it is split across chunks, when ANSI styling splits the words, and when it follows arbitrary `#`-free output (all three are covered by tests).
- **No change for Command Code panes.** Once `hasSeenCommandCodeUi` is true the gate is bypassed entirely, so the arming path, the working/done callbacks, and the prompt scraping are untouched.
- **`recentRawText` is still updated first**, so the carry advances identically whether the gate passes or not — a chunk skipped by the gate still contributes its bytes to the next chunk's context.
- **No cost regression.** The `#`-present case measured within noise (one `String.includes` scan that exits at the first `#`).
- **No cap, window, or limit changed.** `RECENT_TEXT_LIMIT` and `STATUS_SCAN_TEXT_LIMIT` are untouched.

## Merge risk

**Low.** Adds a gate ahead of existing work on a main-process per-chunk path; the gate is derived from the banner regex itself (`#` is required, and control-stripping only deletes characters). I deliberately left the existing window-level C/o/d prefilter untouched so the change is provably one-directional. 106 tests pass and the new one covers `#`-free chunks preceding the banner.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual or interaction change. The Command Code working/done status behaves identically; the detector just stops doing discardable work first.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm test src/shared/command-code-output-status` — 106 tests (105 existing + 1 new), all passing.

The new test, `detects the banner after chunks that carry no banner characters at all`, feeds two `#`-free agent-output chunks (which now take the gated path) before the banner chunk and asserts the banner is still detected and `onWorking` still fires. The existing `detects the Command Code banner across PTY chunk boundaries` and `...when ANSI styling splits the words` tests already cover the carry and ANSI-interleaved cases and pass unchanged.

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: `src/shared` string handling, no platform branches. The win is per-PTY on the main process, so it applies equally to local, WSL, and SSH-backed panes.

## AI Disclosure

