### PR TITLE
perf(editor): build the closing-fence pattern once per fence, not once per line

### DIFF
--- a/src/renderer/src/components/editor/details-markdown-html.ts
+++ b/src/renderer/src/components/editor/details-markdown-html.ts
@@ -94,7 +94,7 @@ export function renderDetailsAttributes(attrs: Record<string, unknown> | undefin
 function markdownFenceRanges(content: string): MarkdownFenceRanges {
   const ranges: [number, number][] = []
   let offset = 0
-  let openFence: { marker: '`' | '~'; length: number; start: number } | null = null
+  let openFence: { closingPattern: RegExp; start: number } | null = null
 
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|\n|\r|$)/g)) {
     const line = lineMatch[0]
@@ -104,11 +104,8 @@ function markdownFenceRanges(content: string): MarkdownFenceRanges {
 
     const lineText = line.replace(/(?:\r\n|\n|\r)$/u, '')
     if (openFence) {
-      const closingFencePattern =
-        openFence.marker === '`'
-          ? new RegExp(`^ {0,3}\`{${openFence.length},}\\s*$`)
-          : new RegExp(`^ {0,3}~{${openFence.length},}\\s*$`)
-      if (closingFencePattern.test(lineText)) {
+      // Built once per fence: rebuilding it per line recompiled the same regex for every fenced line.
+      if (openFence.closingPattern.test(lineText)) {
         ranges.push([openFence.start, offset + line.length])
         openFence = null
       }
@@ -116,8 +113,9 @@ function markdownFenceRanges(content: string): MarkdownFenceRanges {
       const openingFenceMatch = lineText.match(/^ {0,3}(`{3,}|~{3,})/u)
       if (openingFenceMatch?.[1]) {
         openFence = {
-          marker: openingFenceMatch[1][0] as '`' | '~',
-          length: openingFenceMatch[1].length,
+          closingPattern: new RegExp(
+            `^ {0,3}${openingFenceMatch[1][0]}{${openingFenceMatch[1].length},}\\s*$`
+          ),
           start: offset
         }
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When Orca scans a Markdown document to find its fenced code blocks (the ```` ``` ```` bits), it needs a pattern to recognise the *closing* fence. That pattern depends only on which fence character opened the block and how many of them there were — it can't change while the block is open.

It was being rebuilt from scratch for every single line inside the block. Now it's built once when the fence opens and reused until it closes.

## What Changed

`markdownFenceRanges` in `src/renderer/src/components/editor/details-markdown-html.ts` stores the compiled closing pattern on the open-fence record instead of recompiling it per line:

```diff
-let openFence: { marker: '`' | '~'; length: number; start: number } | null = null
+let openFence: { closingPattern: RegExp; start: number } | null = null
 ...
 if (openFence) {
-  const closingFencePattern =
-    openFence.marker === '`'
-      ? new RegExp(`^ {0,3}\`{${openFence.length},}\\s*$`)
-      : new RegExp(`^ {0,3}~{${openFence.length},}\\s*$`)
-  if (closingFencePattern.test(lineText)) {
+  if (openFence.closingPattern.test(lineText)) {
 ...
 if (openingFenceMatch?.[1]) {
   openFence = {
-    marker: openingFenceMatch[1][0] as '`' | '~',
-    length: openingFenceMatch[1].length,
+    closingPattern: new RegExp(
+      `^ {0,3}${openingFenceMatch[1][0]}{${openingFenceMatch[1].length},}\\s*$`
+    ),
     start: offset
   }
 }
```

The two hard-coded branches collapse into one because both fence characters (`` ` `` and `~`) are regex-safe in that position, so the matched character can be interpolated directly.

## Why

`markdownFenceRanges` exists so `matchDetailsHtmlBlock` can ignore `<details>` tags that appear *inside* code fences. It runs whenever a `<details>` block is encountered at a line start in `raw-markdown-html.ts:133` and in `rich-markdown-details-extension.ts:233` — i.e. on the rich-markdown editor open path, and again on reconcile/programmatic sync.

The old code allocated and compiled a `RegExp` per line for the entire body of every fenced block. A `<details>` block wrapping a large pasted diff or log dump — a very ordinary shape in PR descriptions, task notes, and agent output — is exactly where that adds up. This is a constant-factor fix, not a complexity-class one; the scan was and remains O(lines).

## Measurements

Node, Apple Silicon, one 100,000-line fenced block, asserting the two implementations return identical range arrays:

| | before | after | |
| --- | --- | --- | --- |
| `markdownFenceRanges` over 100k fenced lines | **16.6 ms** | **5.8 ms** | **2.9x faster** |

Output verified byte-identical (`JSON.stringify(before) === JSON.stringify(after)`).

For context on scale: I also measured the enclosing `encodeRawMarkdownHtmlForRichEditor` path across document sizes (500 → 8000 paragraphs, 21 KB → 343 KB) and it is comfortably linear (1.4 ms → 8.0 ms), so this fence scan is the per-line hot spot rather than the surrounding loop.

## Negative user-facing trade-offs

**None.**

- **Identical matching.** The generated pattern source is character-for-character the same as before. The old code escaped the backtick only because it was inside a template literal; in a regex the backtick is not special, so interpolating the matched character produces the same pattern. Verified directly: `` ^ {0,3}`{3,}\s*$ `` still matches ```` ``` ````, still rejects ```` `` ````, still matches `~~~~  ` for a 3-tilde fence, and a 4-backtick fence still rejects a 3-backtick line.
- **Same fence semantics.** A closing fence still has to be at least as long as the opener and use the same character; up to 3 leading spaces and trailing whitespace are still allowed; an unclosed fence still runs to end-of-document.
- **No caching across calls.** The pattern lives on the per-fence record inside a single `markdownFenceRanges` call, so there is no cross-document or cross-call state to go stale.
- No change to `matchDetailsHtmlBlock`, `isInsideRange`, or any caller.

## Merge risk

**Low.** Pure loop-invariant hoist producing a character-identical pattern. The only subtlety is that the original escaped the backtick for the *template literal*, not for the regex — verified the generated source is unchanged. Existing 8 tests cover the behaviour; no new test because there is no new behaviour to pin.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual or interaction change. Fence ranges are identical, so `<details>` blocks inside and outside code fences render exactly as before.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated (existing coverage; see below)

`pnpm test src/renderer/src/components/editor/details-markdown-html.test.ts` — 8 existing tests pass unchanged. These already cover the behaviour this touches (fenced vs. unfenced `<details>`, nested blocks, fence-length matching), and since the change is a pure hoist producing an identical pattern, a new test would only re-assert what they already pin.

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only string/regex handling, no platform branches.

## AI Disclosure

