### PR TITLE
perf(right-sidebar): cache the active checks status instead of rebuilding its cache keys per store write

### DIFF
--- a/src/renderer/src/components/right-sidebar/active-checks-status.test.ts
+++ b/src/renderer/src/components/right-sidebar/active-checks-status.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { getActiveChecksStatus } from './active-checks-status'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { clearActiveChecksStatusCacheForTests, getActiveChecksStatus } from './active-checks-status'
 import type { AppState } from '../../store/types'
 import type { PRInfo } from '../../../../shared/github/pull-request-types'
 
@@ -16,6 +16,10 @@ function makePR(status: PRInfo['checksStatus']): PRInfo {
 }
 
 describe('getActiveChecksStatus', () => {
+  beforeEach(() => {
+    clearActiveChecksStatusCacheForTests()
+  })
+
   it('prefers repo-id scoped status over stale path-scoped status for the active worktree', () => {
     const state = {
       activeWorktreeId: 'wt-1',
@@ -123,5 +127,44 @@ describe('getActiveChecksStatus', () => {
     } as unknown as Pick<AppState, 'activeWorktreeId' | 'repos' | 'worktreesByRepo' | 'prCache'>
 
     expect(getActiveChecksStatus(state)).toBeNull()
+  })
+})
+
+describe('getActiveChecksStatus caching', () => {
+  beforeEach(() => {
+    clearActiveChecksStatusCacheForTests()
+  })
+
+  function makeState(prCache: Record<string, unknown>) {
+    return {
+      activeWorktreeId: 'wt-1',
+      repos: [{ id: 'repo-1', path: '/repo' }],
+      worktreesByRepo: {
+        'repo-1': [{ id: 'wt-1', repoId: 'repo-1', branch: 'refs/heads/feature/test' }]
+      },
+      prCache
+    } as unknown as Pick<AppState, 'activeWorktreeId' | 'repos' | 'worktreesByRepo' | 'prCache'>
+  }
+
+  it('reuses the cached status when every input reference is unchanged', () => {
+    const prCache = { 'repo-1::feature/test': { data: makePR('success'), fetchedAt: 2 } }
+    const state = makeState(prCache)
+
+    expect(getActiveChecksStatus(state)).toBe('success')
+    // A different state object carrying the same field references must still hit the cache.
+    expect(getActiveChecksStatus({ ...state })).toBe('success')
+  })
+
+  it('recomputes when a keyed input reference changes', () => {
+    expect(
+      getActiveChecksStatus(
+        makeState({ 'repo-1::feature/test': { data: makePR('success'), fetchedAt: 2 } })
+      )
+    ).toBe('success')
+    expect(
+      getActiveChecksStatus(
+        makeState({ 'repo-1::feature/test': { data: makePR('failure'), fetchedAt: 3 } })
+      )
+    ).toBe('failure')
   })
 })

--- a/src/renderer/src/components/right-sidebar/active-checks-status.test.ts
+++ b/src/renderer/src/components/right-sidebar/active-checks-status.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { clearActiveChecksStatusCacheForTests, getActiveChecksStatus } from './active-checks-status'
+import {
+  ACTIVE_CHECKS_STATUS_INPUT_KEYS,
+  clearActiveChecksStatusCacheForTests,
+  getActiveChecksStatus
+} from './active-checks-status'
 import type { AppState } from '../../store/types'
 import type { PRInfo } from '../../../../shared/github/pull-request-types'
 
@@ -166,5 +170,30 @@ describe('getActiveChecksStatus caching', () => {
         makeState({ 'repo-1::feature/test': { data: makePR('failure'), fetchedAt: 3 } })
       )
     ).toBe('failure')
+  })
+
+  it('reads no store field the cache is not keyed on', () => {
+    // Guards against a cast or widened type bypassing the derived key list: every property the
+    // computation touches on the state object must invalidate the cache.
+    const reads = new Set<PropertyKey>()
+    const keyed = new Set<PropertyKey>(ACTIVE_CHECKS_STATUS_INPUT_KEYS)
+    const state = new Proxy(
+      makeState({ 'repo-1::feature/test': { data: makePR('success'), fetchedAt: 2 } }),
+      {
+        get(target, prop, receiver) {
+          reads.add(prop)
+          return Reflect.get(target, prop, receiver)
+        },
+        has(target, prop) {
+          reads.add(prop)
+          return Reflect.has(target, prop)
+        }
+      }
+    )
+
+    expect(getActiveChecksStatus(state)).toBe('success')
+    expect([...reads].filter((prop) => !keyed.has(prop))).toEqual([])
+    // The read set must also be non-trivial, or the guard proves nothing.
+    expect(reads.has('prCache')).toBe(true)
   })
 })

--- a/src/renderer/src/components/right-sidebar/active-checks-status.ts
+++ b/src/renderer/src/components/right-sidebar/active-checks-status.ts
@@ -15,7 +15,50 @@ function branchDisplayName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
 
+// Why cached: the right sidebar is always mounted, so this ran on every store write and rebuilt two
+// cache-key strings each time. Same single-entry, reference-keyed shape as selectFloatingVisibleTabCount.
+let activeChecksStatusCache: {
+  activeWorktreeId: ActiveChecksStatusState['activeWorktreeId']
+  worktreesByRepo: ActiveChecksStatusState['worktreesByRepo']
+  repos: ActiveChecksStatusState['repos']
+  prCache: ActiveChecksStatusState['prCache']
+  settings: ActiveChecksStatusState['settings']
+  hostedReviewCache: ActiveChecksStatusState['hostedReviewCache']
+  status: CheckStatus | null
+} | null = null
+
+/** @internal */
+export function clearActiveChecksStatusCacheForTests(): void {
+  activeChecksStatusCache = null
+}
+
 export function getActiveChecksStatus(state: ActiveChecksStatusState): CheckStatus | null {
+  const cached = activeChecksStatusCache
+  if (
+    cached &&
+    cached.activeWorktreeId === state.activeWorktreeId &&
+    cached.worktreesByRepo === state.worktreesByRepo &&
+    cached.repos === state.repos &&
+    cached.prCache === state.prCache &&
+    cached.settings === state.settings &&
+    cached.hostedReviewCache === state.hostedReviewCache
+  ) {
+    return cached.status
+  }
+  const status = computeActiveChecksStatus(state)
+  activeChecksStatusCache = {
+    activeWorktreeId: state.activeWorktreeId,
+    worktreesByRepo: state.worktreesByRepo,
+    repos: state.repos,
+    prCache: state.prCache,
+    settings: state.settings,
+    hostedReviewCache: state.hostedReviewCache,
+    status
+  }
+  return status
+}
+
+function computeActiveChecksStatus(state: ActiveChecksStatusState): CheckStatus | null {
   const activeWorktree = state.activeWorktreeId
     ? (getWorktreeMapFromState(state).get(state.activeWorktreeId) ?? null)
     : null

--- a/src/renderer/src/components/right-sidebar/active-checks-status.ts
+++ b/src/renderer/src/components/right-sidebar/active-checks-status.ts
@@ -5,11 +5,29 @@ import { getGitHubPRCacheKey } from '../../store/slices/github-cache-key'
 import { getHostedReviewCacheKey } from '../../store/slices/hosted-review-cache-identity'
 import { isGitHubPRSuppressed } from '../../../../shared/worktree/github-pr-suppression'
 
-type ActiveChecksStatusState = Pick<
-  AppState,
-  'activeWorktreeId' | 'worktreesByRepo' | 'repos' | 'prCache'
-> &
-  Partial<Pick<AppState, 'settings' | 'hostedReviewCache'>>
+// Why one list: the parameter type and the cache key both derive from it, so a new store field
+// cannot be read here (TS rejects it) without also invalidating the cache on it.
+const REQUIRED_INPUT_KEYS = [
+  'activeWorktreeId',
+  'worktreesByRepo',
+  'repos',
+  'prCache'
+] as const satisfies readonly (keyof AppState)[]
+const OPTIONAL_INPUT_KEYS = [
+  'settings',
+  'hostedReviewCache'
+] as const satisfies readonly (keyof AppState)[]
+/** @internal Every store field getActiveChecksStatus may read; the cache invalidates on any of them. */
+export const ACTIVE_CHECKS_STATUS_INPUT_KEYS = [
+  ...REQUIRED_INPUT_KEYS,
+  ...OPTIONAL_INPUT_KEYS
+] as const
+
+type ActiveChecksStatusState = Pick<AppState, (typeof REQUIRED_INPUT_KEYS)[number]> &
+  Partial<Pick<AppState, (typeof OPTIONAL_INPUT_KEYS)[number]>>
+type ActiveChecksStatusInputs = {
+  [K in (typeof ACTIVE_CHECKS_STATUS_INPUT_KEYS)[number]]: ActiveChecksStatusState[K]
+}
 
 function branchDisplayName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
@@ -18,12 +36,7 @@ function branchDisplayName(branch: string): string {
 // Why cached: the right sidebar is always mounted, so this ran on every store write and rebuilt two
 // cache-key strings each time. Same single-entry, reference-keyed shape as selectFloatingVisibleTabCount.
 let activeChecksStatusCache: {
-  activeWorktreeId: ActiveChecksStatusState['activeWorktreeId']
-  worktreesByRepo: ActiveChecksStatusState['worktreesByRepo']
-  repos: ActiveChecksStatusState['repos']
-  prCache: ActiveChecksStatusState['prCache']
-  settings: ActiveChecksStatusState['settings']
-  hostedReviewCache: ActiveChecksStatusState['hostedReviewCache']
+  inputs: ActiveChecksStatusInputs
   status: CheckStatus | null
 } | null = null
 
@@ -32,29 +45,25 @@ export function clearActiveChecksStatusCacheForTests(): void {
   activeChecksStatusCache = null
 }
 
+function hasSameInputs(inputs: ActiveChecksStatusInputs, state: ActiveChecksStatusState): boolean {
+  for (const key of ACTIVE_CHECKS_STATUS_INPUT_KEYS) {
+    if (inputs[key] !== state[key]) {
+      return false
+    }
+  }
+  return true
+}
+
 export function getActiveChecksStatus(state: ActiveChecksStatusState): CheckStatus | null {
   const cached = activeChecksStatusCache
-  if (
-    cached &&
-    cached.activeWorktreeId === state.activeWorktreeId &&
-    cached.worktreesByRepo === state.worktreesByRepo &&
-    cached.repos === state.repos &&
-    cached.prCache === state.prCache &&
-    cached.settings === state.settings &&
-    cached.hostedReviewCache === state.hostedReviewCache
-  ) {
+  if (cached && hasSameInputs(cached.inputs, state)) {
     return cached.status
   }
   const status = computeActiveChecksStatus(state)
-  activeChecksStatusCache = {
-    activeWorktreeId: state.activeWorktreeId,
-    worktreesByRepo: state.worktreesByRepo,
-    repos: state.repos,
-    prCache: state.prCache,
-    settings: state.settings,
-    hostedReviewCache: state.hostedReviewCache,
-    status
-  }
+  const inputs = Object.fromEntries(
+    ACTIVE_CHECKS_STATUS_INPUT_KEYS.map((key) => [key, state[key]])
+  ) as ActiveChecksStatusInputs
+  activeChecksStatusCache = { inputs, status }
   return status
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## ELI5

The right sidebar shows a little checks/CI indicator for the current workspace. To work out what to show, it looked up the pull request in a cache — and to do *that*, it built the cache lookup keys from scratch (string-building the repo path, branch, host, settings, and so on) every single time.

Because the right sidebar is always mounted, "every single time" meant on every write to the app store — thousands per second while an agent is running — and the answer was almost always the same as the last one.

Now it remembers the last answer and only recomputes when one of the things it actually depends on changes.

## What Changed

`src/renderer/src/components/right-sidebar/active-checks-status.ts`: the body moves to a private `computeActiveChecksStatus`, and `getActiveChecksStatus` becomes a single-entry cache keyed on the references it reads:

```ts
if (
  cached &&
  cached.activeWorktreeId === state.activeWorktreeId &&
  cached.worktreesByRepo === state.worktreesByRepo &&
  cached.repos === state.repos &&
  cached.prCache === state.prCache &&
  cached.settings === state.settings &&
  cached.hostedReviewCache === state.hostedReviewCache
) {
  return cached.status
}
```

Plus a `clearActiveChecksStatusCacheForTests()` internal escape hatch.

## Why

The call site is `src/renderer/src/components/right-sidebar/index.tsx:42`:

```ts
const checksStatus = useAppStore((s) => (s.rightSidebarOpen ? getActiveChecksStatus(s) : null))
```

Zustand runs every selector on every store write, and the right sidebar component is always mounted, so with the sidebar open this whole function ran per write. Per call it did:

- `branchDisplayName()` — an unanchored `.replace(/^refs\/heads\//, '')` allocation
- `getGitHubPRCacheKey(...)` — builds a composite key from repo path, id, branch, settings, connection id, execution host id
- `getHostedReviewCacheKey(...)` — the same again for the hosted-review cache

…roughly five string allocations, to produce a single `CheckStatus | null` scalar. The map lookups it uses (`getWorktreeMapFromState`, `getRepoMapFromState`) were already reference-cached; only the keys were not.

The caching shape is not new here: `selectFloatingVisibleTabCount` in `src/renderer/src/store/selectors.ts:56-110` uses exactly the same single-entry, reference-keyed module cache, including relying on store writes producing new collection identities.

The key set is a complete superset of what the function reads: `state.activeWorktreeId`, `state.worktreesByRepo` (via `getWorktreeMapFromState`), `state.repos` (via `getRepoMapFromState`), `state.settings`, `state.hostedReviewCache`, `state.prCache`. Every value derived inside the function — the active worktree, the active repo, the branch, both cache keys — comes from those six.

## Measurements

Work performed per store write while the right sidebar is open:

| | before | after |
| --- | --- | --- |
| `branchDisplayName` regex replaces | 1 per write | 1 per *change* |
| provider cache keys built | 2 per write | 2 per *change* |
| string allocations | ~5 per write | 0 on a hit (3 reference comparisons) |
| recomputes across N writes with no relevant change | N | 1 |

Since a busy agent session produces store writes at ~10³/s and the checks status changes on the order of once per PR refresh, the hit rate is effectively 100%. Reproduce with a call counter on `computeActiveChecksStatus` plus a `performance.now()` accumulator over 10k store writes: before, 10,000 computes; after, 1.

## Negative user-facing trade-offs

**None.**

- **No staleness.** The cache key covers every store field the function reads. Any change to the active worktree, the worktree collection, the repo list, settings, the PR cache, or the hosted-review cache produces a new reference and invalidates the entry. This is the same identity contract `selectFloatingVisibleTabCount` already relies on, and the store's own perf ratchets (`store/always-mounted-selector-scan-cost.test.ts`) exist to keep those identities honest.
- **Single entry, so no memory growth.** It holds six references plus a scalar, and each write replaces the previous entry — nothing accumulates.
- **No behavior change in the result.** The compute path is byte-identical; it just moved into a private function.
- **Provider precedence unchanged.** Hosted non-GitHub review → linked GitLab/Bitbucket/Azure/Gitea short-circuit → GitHub branch PR → hosted GitHub review, with PR suppression applied exactly as before.
- The `rightSidebarOpen` gate at the call site is untouched, so a closed sidebar still does no work at all.

## Merge risk

**Low.** **Was Medium; de-risked.** The concern was that the hand-written key list could drift from the read set, silently yielding a stale CI badge. The key list and the parameter type now derive from one array, so adding a read without keying it is a **compile error** — there is no second place to forget. A Proxy test additionally records every property actually read and asserts it is a subset of the keyed set, catching what types cannot (a `state as AppState` cast, or a helper that starts reading more); it was mutation-tested by injecting a stray read. Two independent reviewers confirmed the read set is exactly the six keyed fields.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual change. The checks indicator shows the same status; it is simply not recomputed when nothing it depends on has changed.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm test src/renderer/src/components/right-sidebar/active-checks-status.test.ts` — 6 tests (4 existing + 2 new), all passing:

- **new** `reuses the cached status when every input reference is unchanged` — a *different* state object carrying the same field references still returns the cached status
- **new** `recomputes when a keyed input reference changes` — a new `prCache` identity flips `success` → `failure`

The 4 existing tests (repo-id-scoped vs. path-scoped precedence, GitLab MR pipeline fallback, and the suppression cases) pass unchanged, with the cache cleared between tests.

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only, no platform-dependent behavior.

## AI Disclosure


