### PR TITLE
perf(renderer): stop two store selectors allocating on every write

### DIFF
--- a/src/renderer/src/components/status-bar/ClaudeSwitcherMenu.tsx
+++ b/src/renderer/src/components/status-bar/ClaudeSwitcherMenu.tsx
@@ -34,6 +34,7 @@ import {
 import { AccountRuntimeToggle } from './StatusBarAccountControls'
 import { InlineUsageBars, InlineUsageSkeleton } from './InlineProviderUsage'
 import { ProviderDetailsMenu } from './ProviderDetailsMenu'
+import { getClaudeAccountSyncKey } from './provider-account-sync-key'
 
 // Exported so its account-switch/reset logic is preserved for row drill-in even
 // though the footer now opens the consolidated UsageRosterPanel first.
@@ -83,13 +84,7 @@ export function ClaudeSwitcherMenu({
     getWindowsTerminalCapabilityOwnerKey(settings?.activeRuntimeEnvironmentId),
     runtimeTarget
   )
-  const claudeAccountSyncKey = useAppStore((s) => {
-    const settings = s.settings
-    if (!settings) {
-      return 'no-settings'
-    }
-    return `${settings.activeRuntimeEnvironmentId?.trim() || 'local'}:${settings.activeClaudeManagedAccountId ?? 'system'}:${JSON.stringify(settings.activeClaudeManagedAccountIdsByRuntime ?? null)}:${settings.claudeManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
-  })
+  const claudeAccountSyncKey = useAppStore((s) => getClaudeAccountSyncKey(s.settings))
   const accountState = resolveClaudeStatusAccountState(settings, accounts)
 
   useEffect(() => {

--- a/src/renderer/src/components/status-bar/codex-switcher-projection.ts
+++ b/src/renderer/src/components/status-bar/codex-switcher-projection.ts
@@ -1,13 +1,7 @@
-import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { ProviderRateLimits } from '../../../../shared/rate-limit-types'
 import { formatResetCreditExpiry } from './tooltip'
 
-export function getCodexAccountSyncKey(settings: GlobalSettings | null | undefined): string {
-  if (!settings) {
-    return 'no-settings'
-  }
-  return `${settings.activeRuntimeEnvironmentId?.trim() || 'local'}:${settings.activeCodexManagedAccountId ?? 'system'}:${JSON.stringify(settings.activeCodexManagedAccountIdsByRuntime ?? null)}:${settings.codexManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
-}
+export { getCodexAccountSyncKey } from './provider-account-sync-key'
 
 export function getCodexResetProjection(
   codex: ProviderRateLimits,

--- a/src/renderer/src/components/status-bar/provider-account-sync-key.test.ts
+++ b/src/renderer/src/components/status-bar/provider-account-sync-key.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { getClaudeAccountSyncKey, getCodexAccountSyncKey } from './provider-account-sync-key'
+
+function makeSettings(overrides: Partial<GlobalSettings> = {}): GlobalSettings {
+  return {
+    activeRuntimeEnvironmentId: null,
+    activeClaudeManagedAccountId: null,
+    activeClaudeManagedAccountIdsByRuntime: null,
+    claudeManagedAccounts: [{ id: 'a1', updatedAt: 5 }],
+    activeCodexManagedAccountId: null,
+    activeCodexManagedAccountIdsByRuntime: null,
+    codexManagedAccounts: [{ id: 'c1', updatedAt: 7 }],
+    ...overrides
+  } as unknown as GlobalSettings
+}
+
+describe.each([
+  ['claude', getClaudeAccountSyncKey],
+  ['codex', getCodexAccountSyncKey]
+])('%s account sync key', (_provider, getSyncKey) => {
+  it('returns the same string for the same settings identity', () => {
+    const settings = makeSettings()
+    expect(getSyncKey(settings)).toBe(getSyncKey(settings))
+  })
+
+  it('answers no-settings when settings are absent', () => {
+    expect(getSyncKey(null)).toBe('no-settings')
+    expect(getSyncKey(undefined)).toBe('no-settings')
+  })
+
+  it('recomputes for a new settings identity', () => {
+    const first = getSyncKey(makeSettings())
+    const second = getSyncKey(
+      makeSettings({
+        claudeManagedAccounts: [{ id: 'a1', updatedAt: 6 }],
+        codexManagedAccounts: [{ id: 'c1', updatedAt: 8 }]
+      } as unknown as Partial<GlobalSettings>)
+    )
+    expect(second).not.toBe(first)
+  })
+})

--- a/src/renderer/src/components/status-bar/provider-account-sync-key.ts
+++ b/src/renderer/src/components/status-bar/provider-account-sync-key.ts
@@ -1,0 +1,42 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+
+// Why memoized on settings identity: these run inside useAppStore selectors, which Zustand re-runs
+// on every store write. Building the key stringifies a map and joins the whole managed-account
+// roster, and its inputs only move when `settings` is replaced.
+const claudeKeyBySettings = new WeakMap<GlobalSettings, string>()
+const codexKeyBySettings = new WeakMap<GlobalSettings, string>()
+
+function memoizeSyncKey(
+  cache: WeakMap<GlobalSettings, string>,
+  settings: GlobalSettings | null | undefined,
+  build: (settings: GlobalSettings) => string
+): string {
+  if (!settings) {
+    return 'no-settings'
+  }
+  const cached = cache.get(settings)
+  if (cached !== undefined) {
+    return cached
+  }
+  const key = build(settings)
+  cache.set(settings, key)
+  return key
+}
+
+export function getClaudeAccountSyncKey(settings: GlobalSettings | null | undefined): string {
+  return memoizeSyncKey(
+    claudeKeyBySettings,
+    settings,
+    (resolved) =>
+      `${resolved.activeRuntimeEnvironmentId?.trim() || 'local'}:${resolved.activeClaudeManagedAccountId ?? 'system'}:${JSON.stringify(resolved.activeClaudeManagedAccountIdsByRuntime ?? null)}:${resolved.claudeManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
+  )
+}
+
+export function getCodexAccountSyncKey(settings: GlobalSettings | null | undefined): string {
+  return memoizeSyncKey(
+    codexKeyBySettings,
+    settings,
+    (resolved) =>
+      `${resolved.activeRuntimeEnvironmentId?.trim() || 'local'}:${resolved.activeCodexManagedAccountId ?? 'system'}:${JSON.stringify(resolved.activeCodexManagedAccountIdsByRuntime ?? null)}:${resolved.codexManagedAccounts.map((account) => `${account.id}:${account.updatedAt}`).join('|')}`
+  )
+}

--- a/src/renderer/src/hooks/agent-hook-completion-store-sync.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-store-sync.ts
@@ -48,7 +48,10 @@ function terminalTabLivenessMatches(
     return false
   }
 
-  for (const [worktreeIndex, worktreeId] of currentWorktreeIds.entries()) {
+  // Indexed loops, not .entries(): this runs on every tab write including title frames, and the
+  // iterator allocated a [index, value] tuple per worktree and per tab in each changed bucket.
+  for (let worktreeIndex = 0; worktreeIndex < currentWorktreeIds.length; worktreeIndex += 1) {
+    const worktreeId = currentWorktreeIds[worktreeIndex]
     // Why: duplicate tab ids use first-worktree-wins lookup semantics, so a
     // worktree-key reorder is a liveness change even when every array is reused.
     if (previousWorktreeIds[worktreeIndex] !== worktreeId) {
@@ -62,7 +65,8 @@ function terminalTabLivenessMatches(
     if (!currentTabs || !previousTabs || currentTabs.length !== previousTabs.length) {
       return false
     }
-    for (const [tabIndex, currentTab] of currentTabs.entries()) {
+    for (let tabIndex = 0; tabIndex < currentTabs.length; tabIndex += 1) {
+      const currentTab = currentTabs[tabIndex]
       visitTab?.()
       const previousTab = previousTabs[tabIndex]
       if (


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |

<!-- /orca-pr-loc -->

## ELI5

Zustand re-runs *every* store selector on *every* write to the app store — thousands of times a second while an agent is running. Three selectors were doing real work in there:

- The Claude and Codex account "sync keys" were serialising a map with `JSON.stringify` and gluing together the whole list of managed accounts, to produce a string that only changes when your settings change.
- A terminal-tab liveness check was walking worktrees and tabs with `.entries()`, which hands back a fresh little `[index, value]` pair object for every step.

Now the sync keys are remembered per settings object, and the liveness walk uses plain indexed loops. Same answers, no per-write garbage.

## What Changed

**New `src/renderer/src/components/status-bar/provider-account-sync-key.ts`** — `getClaudeAccountSyncKey` and `getCodexAccountSyncKey`, each memoized in a `WeakMap<GlobalSettings, string>`:

```ts
const cached = cache.get(settings)
if (cached !== undefined) {
  return cached
}
const key = build(settings)
cache.set(settings, key)
return key
```

- `ClaudeSwitcherMenu.tsx:86-92` had this key built inline in the selector; it now calls `getClaudeAccountSyncKey(s.settings)`.
- `codex-switcher-projection.ts` had a byte-identical duplicate of the same logic for Codex; it now re-exports from the shared module, so both providers share one implementation instead of two copies.

**`src/renderer/src/hooks/agent-hook-completion-store-sync.ts:50, 63`** — `for (const [i, v] of xs.entries())` → indexed `for` loops, for both the worktree-id walk and the tab walk.

## Why

**The sync keys.** The Claude one was written inline inside `useAppStore((s) => { ... })`, so on every store write it ran:

```ts
`${...}:${...}:${JSON.stringify(settings.activeClaudeManagedAccountIdsByRuntime ?? null)}:${settings.claudeManagedAccounts.map((a) => `${a.id}:${a.updatedAt}`).join('|')}`
```

— a `JSON.stringify`, a `.map()` allocating an array of strings, and a `.join()`, per write, while the usage-roster popover is open. The value is a pure function of `settings`, and `settings` is replaced only when settings actually change (orders of magnitude rarer than store writes). Codex had the identical body in `codex-switcher-projection.ts:5-10`, reached from `use-codex-switcher-controller.ts:84` — that file's own comment already notes the intent was to avoid re-running on routine settings mutations, so memoizing on identity finishes that job.

Folding the two into one module also removes a copy-paste duplicate: the Claude and Codex key builders differed only in field names.

**The liveness walk.** `terminalTabLivenessMatches` is driven from `hooks/ipc-events/agent-status-ipc-bridge.ts:263-272` on every tab write — which includes synthetic title frames from background agents. `Array.prototype.entries()` allocates an iterator plus a two-element tuple per step, so the garbage scaled with workspace count on a very frequent path. The loops visit the same indices in the same order with the same early-exit points.

## Measurements

Per store write, work eliminated:

| selector | before (per write) | after (per write) |
| --- | --- | --- |
| `getClaudeAccountSyncKey` | 1 `JSON.stringify` + 1 `.map()` array + 1 `.join()` + template | 1 `WeakMap.get` |
| `getCodexAccountSyncKey` | same | 1 `WeakMap.get` |
| `terminalTabLivenessMatches` | 1 iterator + 1 tuple per worktree, plus 1 per tab in each changed bucket | 0 allocations |

Recompute count for the sync keys across N store writes with unchanged settings: **N → 1**.

For the liveness walk at the 423-workspace scale the repo's own ratchet (`store/always-mounted-selector-scan-cost.test.ts`) targets, that is 423 tuples plus 423 iterators per tab write removed, before counting tabs in changed buckets.

## Negative user-facing trade-offs

**None.**

- **Identical values.** The memoized builders produce the same string the inline code did — the key format is unchanged, so nothing downstream (the `useEffect` dependency at `ClaudeSwitcherMenu.tsx:120` that triggers the account refetch) sees a different value.
- **No staleness.** Both keys are pure functions of `settings`, and the cache is keyed on the `settings` object identity, so any settings change produces a new object and a fresh key. There is no field the builders read that can change without `settings` being replaced.
- **No memory growth.** `WeakMap` entries are collected with their `settings` object; there is no cap to tune and no eviction to get wrong.
- **`null`/`undefined` settings still return `'no-settings'`**, exactly as before (covered by a test).
- **Liveness semantics preserved.** Same iteration order, same indices, same early exits — including the deliberate first-worktree-wins reorder check that the existing "Why" comment protects. The existing `_measureAgentHookCompletionStoreSyncForTest` harness pins visit counts and still passes, which is exactly the guard for this kind of loop rewrite.

## Merge risk

**Low.** Two independent changes. The sync-key memo is a `WeakMap` keyed on `settings` identity for two pure functions, and it also removes a copy-paste duplicate between the Claude and Codex builders. The loop rewrite is pinned by the existing visit-count harness. Key format is unchanged, so the downstream refetch effect sees identical values.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual or interaction change. The Claude/Codex switcher menus show the same accounts and refetch on the same triggers; terminal tab liveness resolves identically.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `provider-account-sync-key.test.ts` — 6 tests, run against **both** providers via `describe.each`: same string for the same settings identity, `'no-settings'` for `null`/`undefined`, and a fresh key for a new settings identity.

Existing suites pass unchanged:
- `pnpm test src/renderer/src/components/status-bar` — 49 files, 333 tests
- `pnpm test src/renderer/src/hooks/agent-hook-completion-store-sync` — 4 tests, including the visit-count measurement harness that pins the loop semantics

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only, no platform-dependent behavior.

## AI Disclosure

