### PR TITLE
fix: recognize the kimi-code process as the kimi agent

### DIFF
--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -178,6 +178,19 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('vibe')).toBe(true)
   })
 
+  it('recognizes Kimi Code by the kimi-code process its launcher becomes', () => {
+    expect(recognizeAgentProcess('/home/dev/.kimi-code/bin/kimi')).toEqual({
+      agent: 'kimi',
+      processName: 'kimi'
+    })
+    expect(recognizeAgentProcess('kimi-code')).toEqual({
+      agent: 'kimi',
+      processName: 'kimi-code'
+    })
+    expect(isExpectedAgentProcess('/home/dev/.kimi-code/bin/kimi', 'kimi')).toBe(true)
+    expect(isRecognizedAgentType('kimi-code')).toBe(true)
+  })
+
   it('recognizes Qwen Code by its installed qwen executable', () => {
     expect(recognizeAgentProcess('/home/dev/.local/bin/qwen')).toEqual({
       agent: 'qwen-code',

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -233,7 +233,10 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     ctrlEnterEncoding: 'csi-u'
   },
   kimi: {
+    // Why: the `kimi` launcher runs as `kimi-code`, so foreground-process recognition never
+    // matches the agent without the alias — terminal reuse and `dispatch --inject` fail.
     detectCmd: 'kimi',
+    detectCmdAliases: ['kimi-code'],
     promptInjectionMode: 'stdin-after-start'
   },
   'mistral-vibe': {


### PR DESCRIPTION
Fixes #18633.

### The bug

`worker-start --terminal <handle>` on a terminal running Kimi Code always fails with
`agent_unconfigured: Terminal … is not running a recognized agent`, so a kimi worker's
terminal can never be handed to a follow-up task — regardless of whether it was retained or
released. The same lifecycle with `claude` reuses fine.

### Cause

`PROCESS_TO_AGENT` is built from each agent's `expectedProcess`, its detect commands and the
first token of `launchCmd`. The kimi entry only carried `detectCmd: 'kimi'`, and
`launchCmd` / `expectedProcess` default to it, so `kimi` was the only accepted name. The
process the launcher actually becomes is `kimi-code`:

```
$ ps -o pid,ppid,comm -p 415842
    PID    PPID COMMAND
 415842  415751 kimi-code     # parent is the shell of the Orca terminal
```

so `recognizeAgentProcess` returned null and `isTerminalRunningAgent` was false.

### The change

One line in the kimi entry, using the mechanism already used for `mistral-vibe` (`vibe`) and
`claude-agent-teams` (`orca-dev`, `orca-ide`):

```ts
detectCmdAliases: ['kimi-code'],
```

plus a test in `agent-process-recognition.test.ts` modelled on the existing Mistral Vibe and
Qwen Code cases.

### Verification

- `vitest run src/shared/agent-process-recognition.test.ts src/shared/tui-agent-config.test.ts`
  — 29 passed.
- Mutation check: removing `detectCmdAliases` again makes the new test fail
  (`recognizes Kimi Code by the kimi-code process its launcher becomes`), and restoring it
  makes it pass, so the test guards the property rather than the surrounding code.
- `oxlint` on both changed files: clean.
- `pnpm typecheck` exited 0, but in ~2s with no output on this machine, so I would not treat
  that as strong evidence.
- Not run: the full `pnpm test` suite and `pnpm build` (Electron). Deps were installed with
  `--ignore-scripts`, so the native runtime was not built here. CI covers both.

### One thing left for maintainers

Recognition is not the only place a kimi process name is compared, and the rest of them do not
go through `PROCESS_TO_AGENT`. `isExpectedAgentProcess`
(`src/shared/agent-process-recognition.ts:257`) matches on the single `expectedProcess` string:

```ts
normalizedProcess === normalizedExpected ||
normalizedProcess.startsWith(`${normalizedExpected}.`)
```

It never consults `detectCmdAliases` — those reach only `getTuiAgentDetectCommands`, which is
used solely to build the recognition map. The kimi entry sets no `expectedProcess`, so
`resolveTuiAgentConfig` defaults it to `detectCmd` (`tui-agent-config.ts:64`), and
`isExpectedAgentProcess('kimi-code', 'kimi')` is false on both arms.

Five call sites pass a config-derived `expectedProcess` and are therefore affected:
`agent-ready-wait`, `agent-followup-delivery`, `agent-paste-draft`,
`runtime-worktree-startup-readiness` and `pane-serializer-settle`. The other users of the
function pass a wrapper name (`fallbackProcess`) or the literal `'claude'` and are unrelated.

To be precise about the impact, since an earlier revision of this description overstated it:
this is a degraded path, not a hard failure. `waitForAgentReady`
(`agent-ready-wait.ts:84`) and `waitForWorktreeStartupFollowup`
(`runtime-worktree-startup-readiness.ts:68`) both fall back to "foreground is not a shell and
the pty has child processes" from the fourth poll onward, and `kimi-code` is not a shell — so
readiness is usually still reached, just via the weakest signal and several polls later, and it
times out when kimi-code happens to have no children at that moment.

Setting `expectedProcess: 'kimi-code'` would cover those paths and would also add the name to
the recognition map, but `normalizeProcessName` strips `.cmd`, so a Windows `kimi.cmd` shim
would then stop matching. Making `isExpectedAgentProcess` alias-aware looks like the right
shape, but it touches every agent, so I left it out of this fix rather than guess across
platforms.
