### PR TITLE
fix(pty): close the pseudoconsole and dispose the conout worker on Windows self-exit (F24)

### DIFF
--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -603,7 +603,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..2ae787c5bd4f3eba470584dc658a01a5
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a6a4082ce 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d3f275fb7 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -614,7 +614,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
  #include <vector>
  #include <Windows.h>
  #include <strsafe.h>
-@@ -44,12 +45,29 @@ struct pty_baton {
+@@ -44,12 +45,38 @@ struct pty_baton {
    HANDLE hOut;
    HPCON hpc;
  
@@ -630,6 +630,15 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
 +  // refused to create or assign one (an outer job without breakaway rights),
 +  // in which case callers fall back to their pre-job behaviour.
 +  HANDLE hJob = nullptr;
++
++  // Orca: teardown needs BOTH the shell's death and an explicit kill() before
++  // the baton can be freed, so each side records that it has run. Whichever
++  // arrives second frees it. Freeing on the shell's death alone -- what this
++  // file did before -- destroyed the only record of `hpc` while
++  // ClosePseudoConsole was still owed, which is why a self-exiting shell
++  // leaked its pseudoconsole and the console host it reaps (#18601 / F24).
++  bool shellExited = false;
++  bool consoleClosed = false;
  
    pty_baton(int _id, HANDLE _hIn, HANDLE _hOut, HPCON _hpc) : id(_id), hIn(_hIn), hOut(_hOut), hpc(_hpc) {};
  };
@@ -645,7 +654,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
  static volatile LONG ptyCounter;
  
  static pty_baton* get_pty_baton(int id) {
-@@ -102,8 +120,27 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+@@ -102,8 +129,31 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
      // Get process exit code.
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
@@ -665,9 +674,13 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
 +      // Why inside the lock: erasing frees the baton the job accessors hold a
 +      // pointer to. Note remove_pty_baton must not be an assert() argument --
 +      // NDEBUG would compile the call away and leak every baton.
-+      const bool removed = remove_pty_baton(baton->id);
-+      assert(removed);
-+      (void)removed;
++      baton->shellExited = true;
++      if (baton->consoleClosed) {
++        const bool removed = remove_pty_baton(baton->id);
++        assert(removed);
++        (void)removed;
++      }
++      // Else PtyKill has not run yet and still owns hpc. It frees the baton.
 +    }
 +    // Why the lock ends here: BlockingCall below waits on the JS thread, and the
 +    // JS thread can be waiting on ptyJobMutex inside PtyTerminateJob. Holding
@@ -675,7 +688,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -409,6 +446,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -409,6 +459,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "UpdateProcThreadAttribute failed");
    }
  
@@ -691,7 +704,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
    PROCESS_INFORMATION piClient{};
    fSuccess = !!CreateProcessW(
        nullptr,
-@@ -416,7 +462,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -416,7 +475,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -703,7 +716,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,8 +475,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,8 +488,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -753,7 +766,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
    if (useConptyDll && fLoadedDll)
    {
      PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
-@@ -440,6 +528,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +541,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -762,7 +775,65 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -567,6 +657,143 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -544,9 +647,40 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+   int id = info[0].As<Napi::Number>().Int32Value();
+   const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
+ 
+-  const pty_baton* handle = get_pty_baton(id);
++  // Orca: the baton now outlives the shell, so this runs on a self-exited pty
++  // too -- that is the whole point. Take what we need under the lock: the
++  // watcher thread nulls hShell the moment the shell dies, and TerminateProcess
++  // on a handle it just closed is an invalid-handle operation. Duplicating
++  // rather than reordering keeps upstream's close-then-terminate sequence.
++  HPCON hpc = nullptr;
++  HANDLE hShellDup = nullptr;
++  bool owed = false;
++  {
++    std::lock_guard<std::mutex> guard(ptyJobMutex);
++    pty_baton* handle = get_pty_baton(id);
++    // Why the consoleClosed check: a second kill() would otherwise close the
++    // same pseudoconsole twice. Upstream relied on the baton being gone.
++    if (handle != nullptr && !handle->consoleClosed) {
++      hpc = handle->hpc;
++      owed = true;
++      handle->consoleClosed = true;
++      // Null on a self-exited pty, where there is nothing left to terminate.
++      if (useConptyDll && handle->hShell != nullptr) {
++        DuplicateHandle(GetCurrentProcess(), handle->hShell, GetCurrentProcess(),
++                        &hShellDup, 0, FALSE, DUPLICATE_SAME_ACCESS);
++      }
++      if (handle->shellExited) {
++        const bool removed = remove_pty_baton(id);
++        assert(removed);
++        (void)removed;
++      }
++      // Else the shell is still running and the watcher frees the baton.
++    }
++  }
+ 
+-  if (handle != nullptr) {
++  // Why outside the lock: ClosePseudoConsole blocks until the conout side has
++  // drained, and the watcher must be able to take the lock while it does.
++  if (owed) {
+     HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+     bool fLoadedDll = hLibrary != nullptr;
+     if (fLoadedDll)
+@@ -556,17 +690,155 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+         useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
+       if (pfnClosePseudoConsole)
+       {
+-        pfnClosePseudoConsole(handle->hpc);
++        pfnClosePseudoConsole(hpc);
+       }
+     }
+-    if (useConptyDll) {
+-      TerminateProcess(handle->hShell, 1);
++    if (hShellDup != nullptr) {
++      TerminateProcess(hShellDup, 1);
++      CloseHandle(hShellDup);
+     }
+   }
+ 
    return env.Undefined();
  }
  
@@ -906,7 +977,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ec6bf3932c65b89c013ff133dc6bf46a
  /**
  * Init
  */
-@@ -577,6 +804,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +849,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -988,7 +988,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
  };
  
 diff --git a/lib/windowsPtyAgent.js b/lib/windowsPtyAgent.js
-index a358ffb..fb3a96f 100644
+index a358ffb177357e177661033c1b092f9c9d0e5f5a..26c2a4c58799ce649f5113131e4c52f7ed2d87ad 100644
 --- a/lib/windowsPtyAgent.js
 +++ b/lib/windowsPtyAgent.js
 @@ -136,6 +136,9 @@ var WindowsPtyAgent = /** @class */ (function () {
@@ -1001,6 +1001,20 @@ index a358ffb..fb3a96f 100644
                  this._outSocket.readable = false;
                  this._getConsoleProcessList().then(function (consoleProcessList) {
                      consoleProcessList.forEach(function (pid) {
+@@ -154,9 +157,10 @@ var WindowsPtyAgent = /** @class */ (function () {
+                 // Close the input write handle to signal the end of session.
+                 this._inSocket.destroy();
+                 this._ptyNative.kill(this._pty, this._useConptyDll);
+-                this._outSocket.on('data', function () {
+-                    _this._conoutSocketWorker.dispose();
+-                });
++                // Orca: dispose unconditionally, as the non-DLL branch above does.
++                // Waiting for another 'data' event leaks the conout worker on every
++                // self-exiting shell, because no more data ever arrives (F24).
++                this._conoutSocketWorker.dispose();
+             }
+         }
+         else {
 diff --git a/lib/windowsTerminal.js b/lib/windowsTerminal.js
 index 3c38f89..e20b3e6 100644
 --- a/lib/windowsTerminal.js
@@ -1086,7 +1100,7 @@ index 3c38f89..e20b3e6 100644
 \ No newline at end of file
 +//# sourceMappingURL=windowsTerminal.js.map
 diff --git a/src/windowsPtyAgent.ts b/src/windowsPtyAgent.ts
-index d705444..ce611b8 100644
+index d7054449516f0c9a62af351c2caa17331206d530..0c28a32e2e1db2b3f208ddde8443cd4e67bb1ad6 100644
 --- a/src/windowsPtyAgent.ts
 +++ b/src/windowsPtyAgent.ts
 @@ -143,6 +143,9 @@ export class WindowsPtyAgent {
@@ -1099,6 +1113,20 @@ index d705444..ce611b8 100644
          this._outSocket.readable = false;
          this._getConsoleProcessList().then(consoleProcessList => {
            consoleProcessList.forEach((pid: number) => {
+@@ -159,9 +162,10 @@ export class WindowsPtyAgent {
+         // Close the input write handle to signal the end of session.
+         this._inSocket.destroy();
+         (this._ptyNative as IConptyNative).kill(this._pty, this._useConptyDll);
+-        this._outSocket.on('data', () => {
+-          this._conoutSocketWorker.dispose();
+-        });
++        // Orca: dispose unconditionally, as the non-DLL branch above does.
++        // Waiting for another 'data' event leaks the conout worker on every
++        // self-exiting shell, because no more data ever arrives (F24).
++        this._conoutSocketWorker.dispose();
+       }
+     } else {
+       // Because pty.kill closes the handle, it will kill most processes by itself.
 diff --git a/src/windowsTerminal.ts b/src/windowsTerminal.ts
 index 13f6c6d..eda63c8 100644
 --- a/src/windowsTerminal.ts

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -603,7 +603,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..2ae787c5bd4f3eba470584dc658a01a5
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d3f275fb7 100644
+index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c97209248e 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -614,7 +614,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
  #include <vector>
  #include <Windows.h>
  #include <strsafe.h>
-@@ -44,12 +45,38 @@ struct pty_baton {
+@@ -44,12 +45,39 @@ struct pty_baton {
    HANDLE hOut;
    HPCON hpc;
  
@@ -644,17 +644,18 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
  };
  
  static std::vector<std::unique_ptr<pty_baton>> ptyHandles;
-+// Orca: guards the job accessors below against the exit watcher thread. It does
-+// NOT make the whole table safe -- PtyResize/PtyClear/PtyKill read it unlocked,
-+// as they always have -- but it closes the window this patch opened, where the
-+// watcher can close hShell/hJob and free the baton between a lookup and its use.
++// Orca: guards the job accessors below, and PtyKill, against the exit watcher
++// thread. It does NOT make the whole table safe -- PtyResize and PtyClear still
++// read it unlocked, as they always have -- but it closes the window this patch
++// opened, where the watcher can close hShell/hJob and free the baton between a
++// lookup and its use.
 +// Handle VALUES are recycled aggressively, so an unguarded read could pass the
 +// shell-pid check against an unrelated process and terminate the wrong job.
 +static std::mutex ptyJobMutex;
  static volatile LONG ptyCounter;
  
  static pty_baton* get_pty_baton(int id) {
-@@ -102,8 +129,31 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+@@ -102,8 +130,31 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
      // Get process exit code.
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
@@ -688,7 +689,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -409,6 +459,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -409,6 +460,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "UpdateProcThreadAttribute failed");
    }
  
@@ -704,7 +705,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
    PROCESS_INFORMATION piClient{};
    fSuccess = !!CreateProcessW(
        nullptr,
-@@ -416,7 +475,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -416,7 +476,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -716,7 +717,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,8 +488,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,8 +489,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -766,7 +767,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
    if (useConptyDll && fLoadedDll)
    {
      PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
-@@ -440,6 +541,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +542,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -775,11 +776,36 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -544,9 +647,40 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -544,29 +648,215 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    int id = info[0].As<Napi::Number>().Int32Value();
    const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
  
 -  const pty_baton* handle = get_pty_baton(id);
++  // Orca: resolve the DLL BEFORE touching any baton state, for the same reason
++  // PtyConnect does it before creating anything. LoadConptyDll throws when
++  // conpty.dll is missing, and a throw after consoleClosed was set would strand
++  // the pseudoconsole permanently: the retry would find the work already
++  // claimed and do nothing. Only the useConptyDll path can throw here; the
++  // other returns kernel32.
++  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
++  PFNCLOSEPSEUDOCONSOLE pfnClosePseudoConsole = nullptr;
++  if (hLibrary != nullptr) {
++    pfnClosePseudoConsole = (PFNCLOSEPSEUDOCONSOLE)GetProcAddress(
++      (HMODULE)hLibrary,
++      useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
++  }
+ 
+-  if (handle != nullptr) {
+-    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+-    bool fLoadedDll = hLibrary != nullptr;
+-    if (fLoadedDll)
+-    {
+-      PFNCLOSEPSEUDOCONSOLE const pfnClosePseudoConsole = (PFNCLOSEPSEUDOCONSOLE)GetProcAddress(
+-        (HMODULE)hLibrary,
+-        useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
+-      if (pfnClosePseudoConsole)
+-      {
+-        pfnClosePseudoConsole(handle->hpc);
 +  // Orca: the baton now outlives the shell, so this runs on a self-exited pty
 +  // too -- that is the whole point. Take what we need under the lock: the
 +  // watcher thread nulls hShell the moment the shell dies, and TerminateProcess
@@ -797,37 +823,38 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
 +      hpc = handle->hpc;
 +      owed = true;
 +      handle->consoleClosed = true;
-+      // Null on a self-exited pty, where there is nothing left to terminate.
++      // Null hShell means a self-exited pty, where there is nothing to kill.
 +      if (useConptyDll && handle->hShell != nullptr) {
-+        DuplicateHandle(GetCurrentProcess(), handle->hShell, GetCurrentProcess(),
-+                        &hShellDup, 0, FALSE, DUPLICATE_SAME_ACCESS);
++        if (!DuplicateHandle(GetCurrentProcess(), handle->hShell, GetCurrentProcess(),
++                             &hShellDup, 0, FALSE, DUPLICATE_SAME_ACCESS)) {
++          // Why terminate here instead of skipping: a failed duplication leaves
++          // hShellDup null, which is indistinguishable from the self-exit case,
++          // and skipping would leave the shell RUNNING after its pane closed --
++          // a worse outcome than the leak this all exists to fix. hShell is
++          // valid under this lock and TerminateProcess does not block, so the
++          // only cost is that this rare path kills before the console closes.
++          hShellDup = nullptr;
++          TerminateProcess(handle->hShell, 1);
++        }
 +      }
 +      if (handle->shellExited) {
 +        const bool removed = remove_pty_baton(id);
 +        assert(removed);
 +        (void)removed;
-+      }
-+      // Else the shell is still running and the watcher frees the baton.
-+    }
-+  }
- 
--  if (handle != nullptr) {
-+  // Why outside the lock: ClosePseudoConsole blocks until the conout side has
-+  // drained, and the watcher must be able to take the lock while it does.
-+  if (owed) {
-     HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
-     bool fLoadedDll = hLibrary != nullptr;
-     if (fLoadedDll)
-@@ -556,17 +690,155 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
-         useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
-       if (pfnClosePseudoConsole)
-       {
--        pfnClosePseudoConsole(handle->hpc);
-+        pfnClosePseudoConsole(hpc);
        }
++      // Else the shell is still running and the watcher frees the baton.
      }
 -    if (useConptyDll) {
 -      TerminateProcess(handle->hShell, 1);
++  }
++
++  // Why outside the lock: ClosePseudoConsole blocks until the conout side has
++  // drained, and the watcher must be able to take the lock while it does.
++  if (owed) {
++    if (pfnClosePseudoConsole)
++    {
++      pfnClosePseudoConsole(hpc);
++    }
 +    if (hShellDup != nullptr) {
 +      TerminateProcess(hShellDup, 1);
 +      CloseHandle(hShellDup);
@@ -879,9 +906,11 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
 + * Orca: the pids still alive in this pty's tree, straight from the kernel.
 + *
 + * Descendant liveness for a tree that is still tracked, including children that
-+ * detached from the console. Once the shell exits the baton is gone, so this
-+ * returns null rather than an empty list -- null means "no answer", never
-+ * "they died". Also returns null when no job was assigned.
++ * detached from the console. Once the shell exits the watcher nulls hJob, which
++ * ownsShell rejects, so this returns null rather than an empty list -- null
++ * means "no answer", never "they died". (The baton itself now outlives the
++ * shell, until kill() runs; hJob is what makes the answer null.) Also returns
++ * null when no job was assigned.
 + *
 + * Does not include the ConPTY console host: CreatePseudoConsole spawns it
 + * before this job exists, so it is not a member and ClosePseudoConsole is what
@@ -977,7 +1006,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..ab7706780a2dfa9b355b2d398749d40d
  /**
  * Init
  */
-@@ -577,6 +849,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +867,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/scripts/node-pty-windows-pty-teardown-patch.test.mjs
+++ b/config/scripts/node-pty-windows-pty-teardown-patch.test.mjs
@@ -38,6 +38,24 @@ const DESKTOP_HUNKS = {
         '                this._outSocket.readable = false;',
         ''
       ].join('\n')
+    ],
+    // The useConptyDll branch, which only the DESKTOP runs -- the relay takes the
+    // non-DLL branch above, where the dispose is already unconditional. Listed here
+    // so un-applying still yields published; the relay asset needs no counterpart.
+    [
+      [
+        '                // Orca: dispose unconditionally, as the non-DLL branch above does.',
+        "                // Waiting for another 'data' event leaks the conout worker on every",
+        '                // self-exiting shell, because no more data ever arrives (F24).',
+        '                this._conoutSocketWorker.dispose();',
+        ''
+      ].join('\n'),
+      [
+        "                this._outSocket.on('data', function () {",
+        '                    _this._conoutSocketWorker.dispose();',
+        '                });',
+        ''
+      ].join('\n')
     ]
   ],
   'windowsTerminal.js': [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: e262847f57a1d4d3f2287a843822f7dcf3c9d8655892b07a69eba464e1317eaa
+  node-pty@1.1.0: addd223bbac133dfe211bdc6a3d000a4b967d661ff729f45f95b9b24d252218c
 
 importers:
 
@@ -157,7 +157,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=e262847f57a1d4d3f2287a843822f7dcf3c9d8655892b07a69eba464e1317eaa)
+        version: 1.1.0(patch_hash=addd223bbac133dfe211bdc6a3d000a4b967d661ff729f45f95b9b24d252218c)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12195,7 +12195,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=e262847f57a1d4d3f2287a843822f7dcf3c9d8655892b07a69eba464e1317eaa):
+  node-pty@1.1.0(patch_hash=addd223bbac133dfe211bdc6a3d000a4b967d661ff729f45f95b9b24d252218c):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: 0d8c22c3a03903fa7bd1c340682e79b4b9b2fa109b6adb36eaacec2bdeba9c9e
+  node-pty@1.1.0: 7cc9d45f3d2c38f142490d0805e75db55f0eef5174ad41c4b52abc5fbe079ad1
 
 importers:
 
@@ -157,7 +157,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=0d8c22c3a03903fa7bd1c340682e79b4b9b2fa109b6adb36eaacec2bdeba9c9e)
+        version: 1.1.0(patch_hash=7cc9d45f3d2c38f142490d0805e75db55f0eef5174ad41c4b52abc5fbe079ad1)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12195,7 +12195,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=0d8c22c3a03903fa7bd1c340682e79b4b9b2fa109b6adb36eaacec2bdeba9c9e):
+  node-pty@1.1.0(patch_hash=7cc9d45f3d2c38f142490d0805e75db55f0eef5174ad41c4b52abc5fbe079ad1):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: addd223bbac133dfe211bdc6a3d000a4b967d661ff729f45f95b9b24d252218c
+  node-pty@1.1.0: 0d8c22c3a03903fa7bd1c340682e79b4b9b2fa109b6adb36eaacec2bdeba9c9e
 
 importers:
 
@@ -157,7 +157,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=addd223bbac133dfe211bdc6a3d000a4b967d661ff729f45f95b9b24d252218c)
+        version: 1.1.0(patch_hash=0d8c22c3a03903fa7bd1c340682e79b4b9b2fa109b6adb36eaacec2bdeba9c9e)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12195,7 +12195,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=addd223bbac133dfe211bdc6a3d000a4b967d661ff729f45f95b9b24d252218c):
+  node-pty@1.1.0(patch_hash=0d8c22c3a03903fa7bd1c340682e79b4b9b2fa109b6adb36eaacec2bdeba9c9e):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
+++ b/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
@@ -66,13 +66,50 @@ describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
   it('closes the pseudoconsole from PtyKill even after the shell has exited', () => {
     // hpc is copied out under the lock, so the close survives the baton's removal.
     expect(PATCH).toContain('+      hpc = handle->hpc;')
-    expect(PATCH).toContain('+        pfnClosePseudoConsole(hpc);')
+    expect(PATCH).toContain('+      pfnClosePseudoConsole(hpc);')
   })
 
-  it('never terminates through a shell handle the watcher may have closed', () => {
-    // The watcher nulls hShell on exit; upstream dereferenced it unconditionally.
-    expect(PATCH).toContain('+      if (useConptyDll && handle->hShell != nullptr) {')
-    expect(PATCH).not.toMatch(/^\+\s*TerminateProcess\(handle->hShell, 1\);/m)
+  it('resolves the ConPTY DLL before it claims the close', () => {
+    // LoadConptyDll throws when conpty.dll is missing. Throwing after
+    // consoleClosed was set would strand the pseudoconsole for good: the retry
+    // finds the work claimed and does nothing.
+    const dllResolve = PATCH.indexOf('+  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);')
+    const claim = PATCH.indexOf('+      handle->consoleClosed = true;')
+    expect(dllResolve).toBeGreaterThan(-1)
+    expect(claim).toBeGreaterThan(-1)
+    expect(dllResolve).toBeLessThan(claim)
+  })
+
+  it('reaches hShell only under the null check the watcher can trip', () => {
+    // Pinned as one block. The watcher nulls hShell on exit, and upstream
+    // dereferenced it unconditionally; every remaining use — the duplication and
+    // the failure fallback below it — must stay inside this guard.
+    const guarded = PATCH.slice(
+      PATCH.indexOf('+      if (useConptyDll && handle->hShell != nullptr) {'),
+      PATCH.indexOf('+      if (handle->shellExited) {')
+    )
+    expect(guarded).not.toBe('')
+    expect(guarded).toContain('DuplicateHandle(GetCurrentProcess(), handle->hShell')
+    expect(guarded).toContain('TerminateProcess(handle->hShell, 1);')
+    // No ADDED line outside that guard may terminate through hShell. Removed
+    // (`-`) lines still carry upstream's unguarded call, which is the point.
+    const strayAdds = PATCH.replace(guarded, '')
+      .split('\n')
+      .filter((line) => line.startsWith('+') && line.includes('TerminateProcess(handle->hShell'))
+    expect(strayAdds).toEqual([])
+  })
+
+  it('still kills the shell when DuplicateHandle fails', () => {
+    // A null hShellDup is indistinguishable from the self-exit case, so a
+    // swallowed failure would leave the shell running after its pane closed —
+    // a worse outcome than the leak this patch exists to fix.
+    expect(PATCH).toContain(
+      [
+        '+          hShellDup = nullptr;',
+        '+          TerminateProcess(handle->hShell, 1);',
+        '+        }'
+      ].join('\n')
+    )
   })
 
   it('keeps the close idempotent so a second kill cannot double-close', () => {

--- a/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
+++ b/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * A shell that exits by itself must still close its pseudoconsole.
+ *
+ * `ClosePseudoConsole` is the only thing that reaps a ConPTY's console host —
+ * Orca's own job-ownership patch says so, because `CreatePseudoConsole` spawns
+ * that host before the per-pty job exists and it is therefore not a job member.
+ * Upstream node-pty calls it from exactly one place, `PtyKill`, which begins by
+ * looking the baton up by id — and the exit watcher in `SetupExitCallback`
+ * erased the baton the moment the shell died. So on the self-exit path (typing
+ * `exit`, which is how panes usually close) that lookup missed, `PtyKill` did
+ * nothing at all, and the pseudoconsole was never closed.
+ *
+ * Measured on Windows 11 / awin, 20 self-exit cycles, handles bucketed by NT
+ * object type, per terminal:
+ *
+ *   relay spawn (no useConptyDll)   before  +1 Process +2 File   after  FLAT
+ *   desktop spawn (useConptyDll)    before  +1 Process +5 File   after  +4 File
+ *
+ * The desktop residue is a *separate* defect in the `useConptyDll` branch of
+ * `WindowsPtyAgent.kill()`, which disposes the conout worker only from an
+ * `_outSocket.on('data')` handler — and no more data arrives after the shell has
+ * gone. That one is tracked with F23; both are needed for the desktop to be flat.
+ *
+ * WHY THIS IS A PATCH-CONTENT PIN AND NOT A BEHAVIOURAL TEST: the defect is
+ * only observable as a per-NT-type handle count, which needs
+ * `NtQuerySystemInformation(SystemExtendedHandleInformation)`. Nothing in the
+ * repo can read that, and the cheaper Windows-observable proxies do not
+ * discriminate — the console host process is reaped either way (the leak is a
+ * handle to an already-exited object, not an orphaned process), and the
+ * `\\.\pipe\conpty-*` entries disappear either way. Both were measured and
+ * rejected as assertions rather than assumed. So this pins the mechanism
+ * instead, which is the real risk: a future resync of the vendored patch
+ * silently dropping the hunk.
+ */
+
+const PATCH = readFileSync(join(__dirname, '../../../config/patches/node-pty@1.1.0.patch'), 'utf8')
+
+describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
+  it('does not let the exit watcher free the baton while the close is still owed', () => {
+    // Pinned as one block: the erase must stay INSIDE the consoleClosed guard.
+    // Upstream ran it unconditionally, which is the line that caused the leak,
+    // and a resync that re-flattens this is the failure mode worth catching.
+    expect(PATCH).toContain(
+      [
+        '+      baton->shellExited = true;',
+        '+      if (baton->consoleClosed) {',
+        '+        const bool removed = remove_pty_baton(baton->id);',
+        '+        assert(removed);',
+        '+        (void)removed;',
+        '+      }'
+      ].join('\n')
+    )
+  })
+
+  it('closes the pseudoconsole from PtyKill even after the shell has exited', () => {
+    // hpc is copied out under the lock, so the close survives the baton's removal.
+    expect(PATCH).toContain('+      hpc = handle->hpc;')
+    expect(PATCH).toContain('+        pfnClosePseudoConsole(hpc);')
+  })
+
+  it('never terminates through a shell handle the watcher may have closed', () => {
+    // The watcher nulls hShell on exit; upstream dereferenced it unconditionally.
+    expect(PATCH).toContain('+      if (useConptyDll && handle->hShell != nullptr) {')
+    expect(PATCH).not.toMatch(/^\+\s*TerminateProcess\(handle->hShell, 1\);/m)
+  })
+
+  it('keeps the close idempotent so a second kill cannot double-close', () => {
+    expect(PATCH).toContain('+    if (handle != nullptr && !handle->consoleClosed) {')
+    expect(PATCH).toContain('+      handle->consoleClosed = true;')
+  })
+})

--- a/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
+++ b/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
@@ -14,16 +14,23 @@ import { describe, expect, it } from 'vitest'
  * `exit`, which is how panes usually close) that lookup missed, `PtyKill` did
  * nothing at all, and the pseudoconsole was never closed.
  *
- * Measured on Windows 11 / awin, 20 self-exit cycles, handles bucketed by NT
- * object type, per terminal:
+ * There is a SECOND, independent defect on the same path: the `useConptyDll`
+ * branch of `WindowsPtyAgent.kill()` disposed the conout worker only from an
+ * `_outSocket.on('data')` handler, and no more data arrives once the shell has
+ * gone — so that worker leaked too. The non-DLL branch beside it already
+ * disposed unconditionally. The desktop always sets `useConptyDll`, so it hit
+ * both; the relay sets neither and hit only the first.
  *
- *   relay spawn (no useConptyDll)   before  +1 Process +2 File   after  FLAT
- *   desktop spawn (useConptyDll)    before  +1 Process +5 File   after  +4 File
+ * Measured on Windows 11 / awin, 20 cycles, handles bucketed by NT object type,
+ * totals before -> after:
  *
- * The desktop residue is a *separate* defect in the `useConptyDll` branch of
- * `WindowsPtyAgent.kill()`, which disposes the conout worker only from an
- * `_outSocket.on('data')` handler — and no more data arrives after the shell has
- * gone. That one is tracked with F23; both are needed for the desktop to be flat.
+ *   self-exit,     relay spawn     225 -> 285   becomes  219 -> 219  FLAT
+ *   self-exit,     desktop spawn   239 -> 439   becomes  222 -> 222  FLAT
+ *   explicit kill, relay spawn     225 -> 285   becomes  219 -> 219  FLAT
+ *   explicit kill, desktop spawn   235 -> 395   becomes  219 -> 219  FLAT
+ *
+ * Neither fix alone is enough on the desktop: the pseudoconsole close is worth
+ * +1 Process +1 File per terminal, the dispose +2 Thread +4 File.
  *
  * WHY THIS IS A PATCH-CONTENT PIN AND NOT A BEHAVIOURAL TEST: the defect is
  * only observable as a per-NT-type handle count, which needs
@@ -71,5 +78,20 @@ describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
   it('keeps the close idempotent so a second kill cannot double-close', () => {
     expect(PATCH).toContain('+    if (handle != nullptr && !handle->consoleClosed) {')
     expect(PATCH).toContain('+      handle->consoleClosed = true;')
+  })
+})
+
+describe('node-pty patch: conout worker disposal on the self-exit path', () => {
+  // The desktop's larger half: 8 of its 10 leaked handles per terminal.
+  it('disposes the conout worker unconditionally in the useConptyDll branch', () => {
+    expect(PATCH).toContain('+                this._conoutSocketWorker.dispose();')
+    // The data handler is what never fired once the shell had gone.
+    expect(PATCH).toContain("-                this._outSocket.on('data', function () {")
+    expect(PATCH).toContain('-                    _this._conoutSocketWorker.dispose();')
+  })
+
+  it('applies the same change to the TypeScript source the patch also carries', () => {
+    expect(PATCH).toContain('+        this._conoutSocketWorker.dispose();')
+    expect(PATCH).toContain("-        this._outSocket.on('data', () => {")
   })
 })

--- a/src/main/windows/windows-pty-job.ts
+++ b/src/main/windows/windows-pty-job.ts
@@ -118,8 +118,10 @@ export function terminatePtyJob(proc: IPty): JobTerminationOutcome {
 /**
  * Pids still alive in a PTY's tree, or null when there is no answer.
  *
- * Measured on Windows 11: once the shell exits, node-pty drops its handle
- * record and closes the job, so a terminated tree reports **null**, not `[]`.
+ * Measured on Windows 11: once the shell exits, node-pty closes the job, so a
+ * terminated tree reports **null**, not `[]`. (Its handle record now outlives
+ * the shell until `kill()` runs — see config/patches/node-pty@1.1.0.patch — but
+ * the nulled job handle is what makes the answer null either way.)
  * Null therefore means "unverifiable" in the sense of
  * docs/reference/ssh-execution-boundary.md — this build has no job support,
  * the terminal is not a ConPTY, or it is no longer tracked. It is never


### PR DESCRIPTION
Closes **F24**: on Windows, a shell that exits by itself left handles behind on every terminal. **Two distinct defects** on the same teardown path — both are here, and all four paths measure flat.

## Defect 1 — the pseudoconsole was never closed (`src/win/conpty.cc`)

Affects **both** spawn configurations, on the self-exit path.

`ClosePseudoConsole` is the only thing that reaps a ConPTY's console host. Orca's own job-ownership patch already says so, in a comment written for another purpose:

> Does not include the ConPTY console host: `CreatePseudoConsole` spawns it before this job exists, so it is not a member and **`ClosePseudoConsole` is what reaps it**.

node-pty calls it from exactly one place, `PtyKill`, which begins with `get_pty_baton(id)`. The exit watcher in `SetupExitCallback` erased that baton the moment the shell died:

```cpp
CloseHandle(baton->hShell);
assert(remove_pty_baton(baton->id));   // destroys the only record of hpc
```

So on the self-exit path — typing `exit`, how panes usually close — the lookup missed and **`PtyKill` did nothing at all**. This is in published node-pty 1.1.0, which is why no previous Orca patch variant moved it.

The baton now survives until **both** the shell has exited and `kill()` has run; whichever arrives second frees it. `PtyKill` copies `hpc` out under `ptyJobMutex` and closes it *outside* the lock (the close can block until conout drains, and the watcher must be able to take the lock meanwhile), and **duplicates** the shell handle rather than reordering, so upstream's close-then-terminate sequence is unchanged.

Two hardening fixes from review are folded in (`808711570e1`): `DuplicateHandle`'s result is checked, and on failure the shell is terminated through `handle->hShell` under the lock — a swallowed failure would otherwise have left the shell *running* after its pane closed, worse than the leak this fixes. And `LoadConptyDll` is now resolved **before** any baton state is touched, because it throws when `conpty.dll` is missing and a throw after `consoleClosed` was set would have stranded the pseudoconsole permanently.

**Contribution: +1 Process, +1 File per terminal.**

## Defect 2 — the conout worker was never disposed (`lib/windowsPtyAgent.js`, `src/windowsPtyAgent.ts`)

Affects the **DLL branch only**, so the desktop only. This is the larger half.

```js
} else {                                  // useConptyDll — the branch the DESKTOP takes
    this._inSocket.destroy();
    this._ptyNative.kill(this._pty, this._useConptyDll);
    this._outSocket.on('data', function () {
        _this._conoutSocketWorker.dispose();   // never fires once the shell has gone
    });
}
```

The non-DLL branch three lines above already disposes unconditionally. **These two hunks are easy to confuse — the sibling above is the non-DLL one**, and that confusion is what mis-scoped F23.

**Contribution: +2 Thread, +4 File, and one type-24 and one type-40 per terminal.**

**The relay is unaffected by this change** — `grep -rn useConptyDll src/relay/` returns nothing and there is exactly one `pty.spawn(` in `src/relay` (`pty-handler.ts:1928`), so a relay host cannot reach the DLL branch, and the branch it does reach already disposes. That is precisely **why the relay went flat on defect 1 alone**. If anyone later adds `useConptyDll` to the relay spawn to pick up the DLL backend, that assumption dies silently — grep for `useConptyDll` before doing so.

## Measurements

Windows 11 on `awin`, real hardware. **Protocol, stated because it is the difference between these numbers and the ones that had to be retracted:** I shipped the tree `git apply` produces from *this* patch, compiled `conpty.node` from it, asserted both changes were present in the built tree, and only then measured. The final row is a direct measurement with both fixes in place, not the two earlier numbers composed.

20 cycles each, 8s settle, handles bucketed by NT object type via `NtQuerySystemInformation(SystemExtendedHandleInformation)`. Every run sanity-gated: each cycle must have run a real shell that exited 0 with non-empty output and no spawn errors, because a failed spawn also leaks and would read as a leak.

| path | spawn config | before | after |
| --- | --- | --- | --- |
| self-exit | relay (no `useConptyDll`) | 225 → 285 | **219 → 219 FLAT** |
| self-exit | desktop (`useConptyDll`) | 239 → 439 | **222 → 222 FLAT** |
| explicit kill of a live shell | relay | 225 → 285 | **219 → 219 FLAT** |
| explicit kill of a live shell | desktop | 235 → 395 | **219 → 219 FLAT** |

Desktop per-terminal decomposition — the two defects are additive and **neither alone is sufficient**:

| tree | 8 Process | 9 Thread | 24 | 40 | 42 File | total |
| --- | --- | --- | --- | --- | --- | --- |
| before | +1 | +2 | +1 | +1 | +5 | +10 |
| defect 1 only | 0 | +2 | +1 | +1 | +4 | +8 |
| defect 2 only | +1 | 0 | 0 | 0 | +1 | +2 |
| **both** | **0** | **0** | **0** | **0** | **0** | **0** |

**Do not read defect 2 as "the JS half is just the worker".** The explicit-kill desktop row (235 → 395) was left *byte-identical* by defect 1's fix and is closed entirely by defect 2 — the JS line is load-bearing on a path the native change never touches.

Type indices were **calibrated empirically**, not assumed: opening N files moved `42`, spawning N children moved `8`, a `fork()` with an IPC channel moved `8/21/41/42` and returned to zero when reaped. So **42 = File, 8 = Process**. That calibration also falsifies the "unreaped `_getConsoleProcessList()` fork" mechanism this finding was originally recorded with — the leak never moves 21 or 41. Types 24 and 40 are counted but not named; both are flat after the fix.

**Causality control.** A tree byte-identical to the baseline in every file **except** `conpty.node` — same `lib/*.js`, same `node_modules`, same prebuilds — measures flat. Only the compiled binary differs.

## Known tradeoff

If a consumer self-exits a pty and then **never calls `kill()`**, the baton now persists (~50 bytes) where it used to be freed. The pseudoconsole leaked in that case both before *and* after — that is the whole bug — so this is strictly fewer leaking cases, never more. What is genuinely new is the struct, and the linear `get_pty_baton` scan over a vector that such a caller would grow without bound. Orca always calls `kill()` (on Windows `destroy()` **is** `kill()`), so Orca is bounded; a readiness review walked both hosts' skip-conditions and confirmed each is reachable only once `kill()` has already run.

The alternative — closing the pseudoconsole from the exit watcher so no `kill()` is needed — was rejected deliberately: `ClosePseudoConsole` on the non-DLL path can block until conout drains, so doing it on the watcher thread risks hanging that thread and truncating trailing output. There are measurements showing this design works and none showing that one is safe.

## Reach, and one asymmetry

`src/main/orcad/node-pty-prebuilt-slot.ts` documents that orcad prebuilds are built from the patched source, and `config/scripts/build-orcad-prebuilds.mjs` **refuses to build** without the patch. So a deployment served a prebuilt slot receives the native fix; an npm-installed relay tree does not, because pnpm patches do not cross the SSH boundary.

Precisely, though: that guard asserts only the *Linux glibc* markers (`binding.gyp`'s `--no-as-needed,-l:libutil.so.1` and `src/unix/pty.cc`'s `.symver` pins). A wholly-unapplied patch trips it, but a partially-applied one missing only the Windows hunks would not be caught. The guard does what it says; it just says less than "the patch is applied".

## Tests

`src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts` is a **patch-content pin, not a behavioural test**.

The reason, so a reviewer meeting a content pin does not have to ask: the defect is observable only as a per-NT-object-type handle count, which requires `NtQuerySystemInformation(SystemExtendedHandleInformation)`. Nothing in the repo can read that, and `AGENTS.md` forbids forking PowerShell for process work. I measured the two cheaper Windows-observable proxies and **rejected both because they do not discriminate**: the console host is reaped either way (the leak is a handle to an already-exited object, not an orphaned process), and `\\.\pipe\conpty-*` entries disappear either way — delta 0 on both trees. I wrote a console-host behavioural test, found it passed *without* the fix, and deleted it rather than ship decoration.

So it pins the mechanism, which is the real ongoing risk: a resync of the vendored patch silently dropping a hunk. All 6 assertions revert-tested individually against `origin/main`'s patch — **6 failed reverted, 6 passed restored.**

`config/scripts/node-pty-windows-pty-teardown-patch.test.mjs` needed one mechanical change: it reconstructs published node-pty by un-applying a known hunk list from the installed tree, so a new hunk in `lib/windowsPtyAgent.js` broke the reconstruction (4 of 5 red with *"Refusing to patch unexpected node-pty source"*). Added the hunk to `DESKTOP_HUNKS`. Its ordering assertion slices the `!useConptyDll` branch and is untouched, as is its header prose (#18636 owns that and will rebase onto this).

## Checks

- `pnpm tc` clean
- `npx oxlint` clean on both changed test files, with a positive control (injected `no-unused-vars` + `no-debugger` → exit 1, both reported; exit 0 restored) confirming oxlint actually lints them
- `pnpm test src/main/pty src/main/providers src/relay/pty-handler config/scripts` — 2760 passed, 20 skipped
- Full suite: 71853 passed, 1 failed — `tests/e2e/cross-version-wire/release-checkout.unit.test.ts` on temp-dir lock contention, which passes 10/10 in isolation on this branch. Across three full-suite runs it failed 4, then 3, then 1 test in that same file: a parallel-load flake, not a break.
- **CI: 27 pass, 2 fail — both pre-existing on `main`.** The failures are the CJK/Hangul IME suite. The scheduled Terminal IME E2E run on `main` at `637dc30a321`, which is this branch's exact base commit, fails with the **byte-identical two steps** (`Run deterministic terminal IME boundary tests`, `Run native IBus Hangul exact-byte tests`). Same commit, none of these changes, same failure. `package (windows)` — the only job that rebuilds the native module — **passes**.
- `pnpm-lock.yaml` carries the new `patch_hash`, which also invalidates the Windows CI native-module cache so the patch is genuinely rebuilt there.

Known flake, pre-existing and not introduced: the relay-config harness occasionally throws one uncaught `EPIPE` from node-pty's conout forwarding during teardown (~1 run in 3). I first hit it on the **unmodified baseline** tree; handle counts were flat in both the run that flaked and the clean repeat.

Refs F24. F23 closed as void — it was scoped around the non-DLL branch, which the desktop never executes.
