### PR TITLE
docs(relay): correct why the ConPTY teardown asset diverges from the desktop patch

### DIFF
--- a/config/relay-assets/node-pty-1.1.0-windows-pty-teardown-patch.cjs
+++ b/config/relay-assets/node-pty-1.1.0-windows-pty-teardown-patch.cjs
@@ -12,14 +12,15 @@ const { join, resolve } = require('node:path')
  * `_inSocket`, and it wraps a real Windows named-pipe handle from `fs.openSync(term.conin, 'w')`.
  * Every terminal leaks one File handle for the life of the host process.
  *
- * The obvious fix -- and the one the desktop patch ships -- releases it at the TOP of the branch,
- * before `_getConsoleProcessList()` forks and before the native kill. That is measurably worse than
- * leaving the leak alone: teardown aborts partway, the forked console-list agent is never reaped,
- * and both pipe handles stay alive instead of one. This asset releases it at the END of the branch
- * instead, after the fork and the kill have already happened.
+ * The obvious fix -- and the placement `config/patches/node-pty@1.1.0.patch` uses -- releases it at
+ * the TOP of the branch, before `_getConsoleProcessList()` forks and before the native kill. That is
+ * measurably worse than leaving the leak alone: teardown aborts partway, the forked console-list
+ * agent is never reaped, and both pipe handles stay alive instead of one. This asset releases it at
+ * the END of the branch instead, after the fork and the kill have already happened.
  *
  * Measured on a Windows SSH host, 20 spawn/kill cycles, handles bucketed by NT object type
- * (identical numbers standalone and through a real relay):
+ * (identical numbers standalone and through a real relay). Every row is the NON-DLL branch, which
+ * is the branch a relay runs -- see the divergence note below for why that matters:
  *
  *   published node-pty        File +1/terminal,  Process flat
  *   desktop patch placement   File +2/terminal,  Process +1/terminal   <-- 3x WORSE
@@ -34,18 +35,64 @@ const { join, resolve } = require('node:path')
  * Why this ships as a relay asset rather than only in config/patches/node-pty@1.1.0.patch: pnpm
  * patches do not cross the SSH boundary -- a relay host runs the tree `npm install` put there.
  *
- * DELIBERATE DIVERGENCE FROM THE DESKTOP: the desktop patch has the early placement and therefore
- * the +2 File / +1 Process regression, measured against its exact installed tree. Correcting it
- * there is a separate change with its own verification, so the two trees differ on this one hunk on
- * purpose, and the test pins that so a future "sync the patches" does not copy the bug back.
+ * DELIBERATE DIVERGENCE FROM THE DESKTOP, AND WHY IT IS NOT A DESKTOP-TERMINAL BUG: the two hosts
+ * do not run the same branch of `kill()`. node-pty defaults `_useConptyDll` to false
+ * (`windowsPtyAgent.js`). Every desktop site that opens a terminal pane sets it true --
+ * `local-pty-utils.ts` (two) and `native-pty-spawn.ts` -- as does the `windows-conpty-warmup.ts`
+ * warm-up, so all of those take the `else` branch, where UPSTREAM ALREADY destroys the input
+ * socket. The relay passes no such option (`src/relay/pty-handler.ts`), so it takes the
+ * `!useConptyDll` branch -- the one this asset and the desktop patch both edit.
  *
- * NOT ADDRESSED, AND A SEPARATE DEFECT THAT IS STILL OPEN: a terminal that exits on its own is
- * still torn down through `kill()` -- both hosts call `destroy()` on natural exit and
- * `WindowsTerminal.destroy()` is `kill()` -- but the shell is already gone by then, and the
- * ordering this patch relies on does not hold. Measured over 20 self-exit cycles with that
- * `destroy()` issued: published +3 File/+1 Process per terminal, desktop-patched +2/+1, this tree
- * +2/+1. So this patch does not close it and the desktop patch does not either. It is reachable
- * for every Windows user, local and relay, on every terminal closed by typing `exit`.
+ * THE DESKTOP IS NOT ENTIRELY OFF THAT BRANCH. Two desktop sites omit the option and so run it
+ * too: the hidden rate-limit probes in `src/main/rate-limits/claude-pty.ts` and
+ * `codex-pty-rate-limit-probe.ts`. Both recur -- their fetchers poll -- and both tear down through
+ * `kill()`, so this hunk is live on the desktop, just never for a pane a user can see. Do not
+ * restate this as "the desktop never executes that branch": that sentence stood here for two
+ * revisions and is false.
+ *
+ * What the numbers above therefore do NOT cover: they were measured on relay-style spawn/kill
+ * cycles. Whether the early placement costs the same +2 File / +1 Process across a probe's
+ * lifecycle is UNMEASURED -- plausible, not established, and worth measuring before anyone quotes
+ * a desktop figure. What IS settled is the claim this comment replaced: that the desktop patch made
+ * every Windows user worse off ON EVERY TERMINAL. Terminals take the DLL branch, and the harness
+ * that produced that claim defaulted into the branch it was not trying to measure.
+ *
+ * The divergence is therefore about which branch each host runs for the workload that matters, not
+ * about a regression in the terminals users open. The test still pins it, because a future "sync
+ * the patches" would put the early placement onto the relay's branch, where it does cost +2 File
+ * and +1 Process per terminal.
+ *
+ * If you extend this enumeration, grep for `node-pty` rather than for a static import: those two
+ * probes were missed three times because they use `await import('node-pty')`.
+ *
+ * THE SELF-EXIT LEAK: FIXED FOR THE DESKTOP BY #18635, STILL LIVE ON A RELAY. A terminal that exits
+ * on its own is also torn down through `kill()` -- both hosts call `destroy()` on natural exit and
+ * `WindowsTerminal.destroy()` is `kill()` -- but the shell is already gone by then, so the ordering
+ * this asset relies on does not hold. Measured over 20 self-exit cycles on the NON-DLL branch:
+ * published +3 File/+1 Process per terminal, desktop patch placement +2/+1, this tree +2/+1. This
+ * asset does not close it.
+ *
+ * #18635 does, in `config/patches/node-pty@1.1.0.patch`: the baton outlives the shell so `PtyKill`
+ * still reaches `ClosePseudoConsole`, plus an unconditional conout dispose on the DLL branch. That
+ * fix does not reach a Windows relay, and no hunk in THIS file can carry it, because it is mostly
+ * NATIVE (`src/win/conpty.cc`) and this asset only rewrites `lib/*.js`. Three delivery paths exist
+ * and none currently covers Windows:
+ *
+ *   - the pnpm patch does not cross the SSH boundary -- the remote `npm install` yields upstream's
+ *     unpatched node-pty;
+ *   - the orcad prebuild matrix has no win32 entry (`MATRIX_SLOTS`,
+ *     `config/scripts/build-orcad-prebuilds.mjs`), so no Windows binary is ever compiled from
+ *     patched source to ship;
+ *   - a relay asset CAN patch native source and rebuild on the host -- that is exactly what
+ *     `node-pty-1.1.0-master-cloexec-patch.cjs` does -- but it returns
+ *     `skipped:unsupported-platform` for anything but linux/darwin. Extending it to win32 means
+ *     requiring an MSVC toolchain on the relay host, a far heavier precondition than on Linux,
+ *     where node-gyp already runs at install time.
+ *
+ * So a Windows SSH relay still leaks a pseudoconsole per self-exiting terminal, and closing it is a
+ * DELIVERY problem, not another hunk here. Do not read #18635's flat self-exit relay numbers as
+ * covering deployed relays: they were measured against a locally rebuilt binary, so they describe
+ * the relay CODE PATH on a patched tree, not the tree a relay host actually installs.
  */
 
 const EXPECTED_NODE_PTY_VERSION = '1.1.0'

--- a/config/scripts/node-pty-windows-pty-teardown-patch.test.mjs
+++ b/config/scripts/node-pty-windows-pty-teardown-patch.test.mjs
@@ -1,11 +1,18 @@
-// The relay's copy of the ConPTY teardown release, and the guard that keeps it in lockstep with the
-// desktop's own node-pty patch. pnpm patches do not cross the SSH boundary, so a relay runs the tree
-// `npm install` put there; the desktop had this fix and the relay did not, and every terminal on a
-// Windows SSH host leaked one File handle for the life of the relay process.
+// The relay's copy of the ConPTY teardown release, and the guard that keeps it in lockstep with
+// `config/patches/node-pty@1.1.0.patch`. pnpm patches do not cross the SSH boundary, so a relay runs
+// the tree `npm install` put there, and every terminal on a Windows SSH host leaked one File handle
+// for the life of the relay process.
 //
-// The ORDER of the conin release is the fix. Releasing it at the top of the branch -- what the
-// desktop patch does -- was measured at 3x WORSE than shipping nothing (File +2/terminal and a new
-// Process +1/terminal); releasing it after the console-list fork and the native kill is flat.
+// The ORDER of the conin release is the fix. Releasing it at the top of the branch -- the placement
+// the desktop patch uses -- was measured at 3x WORSE than shipping nothing (File +2/terminal and a
+// new Process +1/terminal); releasing it after the console-list fork and the native kill is flat.
+//
+// Those numbers are the `!useConptyDll` branch, which is the branch a RELAY runs. Every desktop
+// site that opens a terminal pane sets `useConptyDll: true` and takes the other branch, where
+// upstream already destroys the input socket. Two hidden rate-limit probes
+// (`src/main/rate-limits/claude-pty.ts`, `codex-pty-rate-limit-probe.ts`) do omit the option and so
+// do run this hunk, but no user-visible pane does. The divergence pinned below is about which
+// branch each host runs for terminals -- not about a regression in the panes users open.
 import { createRequire } from 'node:module'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
@@ -90,9 +97,11 @@ describe('Windows SSH relay node-pty ConPTY teardown patch', () => {
     )
   })
 
-  // The one hunk that must NOT match the desktop, and the reason is measured, not stylistic:
-  // releasing conin before `_getConsoleProcessList()` forks aborts teardown partway.
-  it('releases conin after the console-list fork, not before it like the desktop patch', () => {
+  // The one hunk that must NOT match the desktop patch, and the reason is measured, not stylistic:
+  // on the branch a relay runs, releasing conin before `_getConsoleProcessList()` forks aborts
+  // teardown partway. Desktop terminal panes take the other branch, so no pane is affected either
+  // way; what this guards is a patch sync putting the early placement onto the relay's branch.
+  it('releases conin after the console-list fork, unlike the desktop patch placement', () => {
     const fixture = writeNodePtyFixture('1.1.0')
     patchNodePtyWindowsTeardown(fixture.root)
     const patched = readFileSync(join(fixture.libDir, 'windowsPtyAgent.js'), 'utf8')
@@ -108,7 +117,8 @@ describe('Windows SSH relay node-pty ConPTY teardown patch', () => {
     expect(branch.indexOf('this._inSocket.destroy();')).toBeGreaterThan(
       branch.indexOf('this._getConsoleProcessList()')
     )
-    // Pinned so a future "sync the relay asset to config/patches" cannot copy the regression back.
+    // Pinned so a future "sync the relay asset to config/patches" cannot copy the early placement
+    // onto the relay's branch, where it costs +2 File and +1 Process per terminal.
     expect(patched).not.toBe(readFileSync(desktopPath('windowsPtyAgent.js'), 'utf8'))
   })
 


### PR DESCRIPTION
## ELI5

A comment in the relay's node-pty patch explained *why* it deliberately differs from the desktop's patch, and the explanation was wrong: it said the shipped Windows desktop app leaks handles because of its own leak fix. It doesn't — the two hosts simply run different branches of the same function. The rule the comment guards is correct and unchanged; only the reason is rewritten. While in there, the self-exit paragraph is refreshed, because #18635 just made it stale.

## What Changed

Comment-only, plus one test **name**. Every assertion, hash and patch hunk is byte-identical — verifiable directly:

```
$ git diff main HEAD -- config/scripts/node-pty-windows-pty-teardown-patch.test.mjs \
    | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-]\s*//' | grep -vE '^[+-]\s*$'
-  it('releases conin after the console-list fork, not before it like the desktop patch', () => {
+  it('releases conin after the console-list fork, unlike the desktop patch placement', () => {

$ git diff main HEAD -- config/relay-assets/node-pty-1.1.0-windows-pty-teardown-patch.cjs \
    | grep -E '^[+-]' | grep -v '^[+-][+-]' | grep -vE '^[+-] \*' | grep -vE '^[+-]\s*$'
(no output)
```

## Why

**1. The divergence rationale was wrong.** #18601's comment said:

> the desktop patch has the early placement and therefore the +2 File / +1 Process regression, measured against its exact installed tree

`node-pty` defaults `_useConptyDll` to `false` (`windowsPtyAgent.js:31`), and `kill()` branches on it:

Here is the **complete** enumeration of Windows-reachable `pty.spawn` sites — see the enumeration note below for why I'm claiming completeness this time:

| site | `useConptyDll` | branch |
|---|---|---|
| `local-pty-utils.ts:193,243` (user terminal panes) | **true** | `else` (DLL) |
| `native-pty-spawn.ts:43` (daemon subprocess) | **true** | `else` (DLL) |
| `windows-conpty-warmup.ts:28` (ConPTY warm-up) | **true** | `else` (DLL) |
| `rate-limits/claude-pty.ts:118` (hidden probe) | **absent** | **`!useConptyDll`** |
| `rate-limits/codex-pty-rate-limit-probe.ts:46` (hidden probe) | **absent** | **`!useConptyDll`** |
| `spawn-preflight.ts:163` | — | unreachable: `preflightPtySpawnHealth` returns `false` on win32 |
| `zsh-startup-hook-pty-harness.ts:97` | — | unreachable: `hasZsh` requires `platform !== 'win32'` |
| `relay/pty-handler.ts:617` (the relay) | absent | `!useConptyDll` |

So the original claim was wrong in the way that matters — **user terminal panes take the DLL branch**, so the desktop patch does not cost every Windows user a handle per terminal. But "the desktop never executes that hunk" is *also* wrong: the two hidden rate-limit probes do, they recur (their fetchers poll), and they tear down through `kill()`. The docblock now says both, and explicitly warns against restating the "never executes" form.

**What I did not do is trade one overstatement for another.** Whether the early placement costs the same +2 File / +1 Process across a probe's lifecycle is **unmeasured** — those numbers were taken on relay-style spawn/kill cycles. The comment records it as plausible and unestablished rather than asserting a desktop leak I haven't seen.

The pin stays either way: a "sync the patches" would put the early placement onto the relay's branch, where it does cost +2 File and +1 Process per terminal.

### Why the enumeration was wrong three times

`claude-pty.ts` and `codex-pty-rate-limit-probe.ts` acquire node-pty with `await import('node-pty')`. Every enumeration so far grepped for static imports (`from 'node-pty'` / `require('node-pty')`), which cannot see a dynamic import — so all three passes missed exactly these two files. The fix is to grep for `node-pty` in any form and filter, which is what produced the table above. The docblock carries that instruction for the next reader.

**2. #18635 made the self-exit paragraph stale.** It said that leak was "still open" and "tracked separately". #18635 closed it for the desktop. The refreshed note records the part that is easy to get wrong — **the fix cannot reach a Windows relay**, structurally:

- it is mostly **native** (`src/win/conpty.cc`) and this asset only rewrites `lib/*.js`, so no hunk here can carry it;
- pnpm patches do not cross the SSH boundary, so the remote `npm install` yields upstream's unpatched node-pty;
- the orcad prebuild matrix has **no win32 entry** (`MATRIX_SLOTS`, `config/scripts/build-orcad-prebuilds.mjs:37` — four Linux, two macOS), so no Windows binary is ever compiled from patched source;
- and the one relay asset that *does* patch native source and rebuild on the host, `node-pty-1.1.0-master-cloexec-patch.cjs`, returns `skipped:unsupported-platform` for anything but linux/darwin.

**I had this last bullet wrong first.** My initial draft said a relay asset "cannot express a native change at all." The cloexec asset disproves that — the mechanism exists, it just stops at linux/darwin, and extending it to win32 means requiring an MSVC toolchain on the relay host (far heavier than Linux, where node-gyp already runs at install time). Corrected before pushing. Noting it because it is the identical failure mode this PR exists to fix: a confident structural claim that one grep would have falsified.

The note also says explicitly that #18635's flat self-exit *relay* numbers were measured against a locally rebuilt binary — they describe the relay **code path on a patched tree**, not the tree a relay host installs. Left implicit, that is a straightforward misread, and it is the kind of conflation this whole PR exists to correct.

## Linked Issue

No `Fixes #` — this corrects the justification for a rule landed in #18601 and refreshes it against #18635. No behavior changes, so there is no defect to close.

## Visual Proof

`N/A` — comments and one test name. No runtime code, no UI surface.

## Testing

`config/scripts/node-pty-windows-pty-teardown-patch.test.mjs` passes (5/5) on the rebased tree — the run that matters, since #18635 added a `DESKTOP_HUNKS` entry to the same file and un-applying the desktop hunks must still reconstruct published node-pty.

`oxlint` and `check:code-quality:changed` clean (0 new findings across 2 changed files).

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated

**No revert test, and deliberately so.** This PR adds no assertion; the whole point is that the pin from #18601 is correct and untouched. A revert test would be theatre here — the two greps above are the real evidence, and they show the assertions are byte-identical.

**Not re-measured on hardware.** No numbers changed; the claims are re-derived from source that I re-read on current `main` after the rebase (the DLL-branch `_inSocket.destroy()`, the `useConptyDll` default, all four desktop spawn sites, the absent win32 slot). Prior hardware measurements are cited as-is from #18601 and #18635.

## AI Disclosure

Internal contributor — section not applicable.

## Review

Rebased onto `main` after #18635 merged, and **the rebase was checked rather than assumed**: #18635 added a `DESKTOP_HUNKS` entry and two further commits including a `DuplicateHandle` hardening fix, so the text being replaced could have moved. It had not — but two claims did need updating, and both are in this diff: the spawn-site enumeration (`windows-conpty-warmup.ts` was missing) and the self-exit paragraph.

**Wire:** not applicable. No RPC, no stream frame, no published content — the relay asset's patch bytes are unchanged, so an already-deployed relay is bit-identical before and after.

Cross-platform: Windows-only subject matter, no code executed. SSH: the asymmetry note is the SSH-facing content. Mobile: no surface touched.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Follow-up this documents but does not fix: a Windows SSH relay still leaks a pseudoconsole per self-exiting terminal after #18635. Closing it needs a win32 prebuild slot or another native delivery path — not another hunk in this asset. Worth its own issue; flagging rather than filing so the lead can decide where it sits.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof (comments only)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `oxlint` and the affected `pnpm test` suite pass locally; CI covers the rest
