### PR TITLE
perf(source-control): stop reconciling selection on every panel render

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control/listing/use-selection.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/use-selection.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, type RefObject } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef, type RefObject } from 'react'
 import type { GitStatusEntry } from '../../../../../../shared/git-status-types'
 import type { SourceControlRowOpenEvent } from './split-open'
 
@@ -34,6 +34,10 @@ export function reconcileSourceControlSelectionState(args: {
   flatEntries: FlatEntry[]
 }): { selectedKeys: ReadonlySet<string>; anchorKey: string | null } {
   const { anchorKey, flatEntries, selectedKeys } = args
+  // Nothing to prune and no anchor to invalidate: skip building the key set over every visible row.
+  if (selectedKeys.size === 0 && anchorKey === null) {
+    return { selectedKeys, anchorKey }
+  }
   const validKeys = new Set(flatEntries.map((e) => e.key))
   const nextSelected = new Set<string>()
   let selectedChanged = false
@@ -111,11 +115,12 @@ export function useSourceControlSelection({
     shouldOpenAsSplitRef.current = shouldOpenAsSplit
   }, [shouldOpenAsSplit])
 
-  const reconciledSelection = reconcileSourceControlSelectionState({
-    selectedKeys,
-    anchorKey,
-    flatEntries
-  })
+  // Memoized: this hook re-runs on every Source Control panel render (commit-message keystrokes,
+  // status polls), but the reconciliation only moves when one of these three references does.
+  const reconciledSelection = useMemo(
+    () => reconcileSourceControlSelectionState({ selectedKeys, anchorKey, flatEntries }),
+    [selectedKeys, anchorKey, flatEntries]
+  )
   if (reconciledSelection.selectedKeys !== selectedKeys) {
     // Why: visible source-control rows can disappear after filtering, staging,
     // or status refresh; prune stale bulk-action keys before children see them.

--- a/src/renderer/src/components/right-sidebar/useSourceControlSelection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useSourceControlSelection.test.ts
@@ -38,6 +38,41 @@ describe('reconcileSelectionKeys', () => {
 })
 
 describe('reconcileSourceControlSelectionState', () => {
+  it('returns the same references without scanning rows when nothing is selected', () => {
+    const selectedKeys: ReadonlySet<string> = new Set()
+    let keyReads = 0
+    const flatEntries = Array.from({ length: 50 }, (_, index) => ({
+      get key() {
+        keyReads += 1
+        return `file-${index}.ts`
+      }
+    })) as unknown as Parameters<typeof reconcileSourceControlSelectionState>[0]['flatEntries']
+
+    const result = reconcileSourceControlSelectionState({
+      selectedKeys,
+      anchorKey: null,
+      flatEntries
+    })
+
+    expect(keyReads).toBe(0)
+    expect(result.selectedKeys).toBe(selectedKeys)
+    expect(result.anchorKey).toBeNull()
+  })
+
+  it('still drops an anchor that is no longer visible when nothing is selected', () => {
+    const selectedKeys: ReadonlySet<string> = new Set()
+    const result = reconcileSourceControlSelectionState({
+      selectedKeys,
+      anchorKey: 'gone.ts',
+      flatEntries: [{ key: 'kept.ts' }] as unknown as Parameters<
+        typeof reconcileSourceControlSelectionState
+      >[0]['flatEntries']
+    })
+
+    expect(result.anchorKey).toBeNull()
+    expect(result.selectedKeys).toBe(selectedKeys)
+  })
+
   it('keeps selected keys and anchor identity when all keys are still visible', () => {
     const flatEntries = [
       makeEntry('unstaged::a.ts', 'unstaged', 'a.ts'),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

The Source Control panel keeps track of which files you've selected. Every time the panel re-rendered, it re-checked that selection against the current file list — building a lookup set containing every visible file, then walking your selection to prune anything that had disappeared.

The catch: it did this on *every* render, including ones that had nothing to do with the file list — every character you type in the commit message box, and every git-status poll tick. And it did the full check even when you had **nothing selected at all**, which is most of the time.

Now it returns immediately when there's nothing to prune, and otherwise only redoes the work when the selection or the file list actually changes.

## What Changed

`src/renderer/src/components/right-sidebar/source-control/listing/use-selection.ts`, two independent guards:

**1. Early return in `reconcileSourceControlSelectionState`** — no selection and no anchor means there is nothing to prune and nothing to invalidate, so the row scan is skipped entirely:

```ts
if (selectedKeys.size === 0 && anchorKey === null) {
  return { selectedKeys, anchorKey }
}
const validKeys = new Set(flatEntries.map((e) => e.key))
```

**2. Memoize the call site**, which previously ran straight from the hook body:

```diff
-const reconciledSelection = reconcileSourceControlSelectionState({
-  selectedKeys, anchorKey, flatEntries
-})
+const reconciledSelection = useMemo(
+  () => reconcileSourceControlSelectionState({ selectedKeys, anchorKey, flatEntries }),
+  [selectedKeys, anchorKey, flatEntries]
+)
```

## Why

`useSourceControlSelection` is called from `useSourceControlFileListing`, which is called inline from the single top-level `useSourceControlPanelModel` hook tree — not from a separately memoized component. So it re-runs on *any* re-render of the whole Source Control panel. Two of those triggers fire constantly:

- **Commit-message keystrokes.** `panel/commit-surface.tsx:163` wires `onCommitMessageChange` straight to `updateCommitDrafts` with no debounce, so every character re-renders the panel.
- **Git-status / upstream / hosted-review poll ticks**, which re-render the panel whether or not the file list changed.

On each of those the function allocated `new Set(flatEntries.map((e) => e.key))` — an intermediate array plus a Set sized to every visible row — and then walked the selection. At 500 changed files that is a 500-element array and a 500-entry Set built to answer "has anything I selected gone away?" when usually nothing is selected.

The two guards are complementary rather than redundant: the early return kills the common case even on a genuine input change, and the memo kills the rest (a non-empty selection re-checked on an unrelated render).

## Measurements

Node, Apple Silicon, 500 flat entries, 20,000 calls per case, asserting identical `selectedKeys`/`anchorKey` output on both paths:

| case | before | after | |
| --- | --- | --- | --- |
| **nothing selected** (the common case) | **13.10 µs/call** | **0.03 µs/call** | **~437x** |
| 3 files selected | 11.58 µs/call | 10.93 µs/call | ~1.06x (early return does not apply; the memo is what helps here) |
| all 500 selected | 29.79 µs/call | 24.70 µs/call | ~1.21x |

Separately, the memo removes the call entirely on renders where none of the three inputs changed — which is what a commit-message keystroke and a poll tick both are. Across 2,000 unrelated re-renders that is 2,000 calls → 1.

**Honest scoping:** at 500 files this is ~13 µs per wasted render. That is real and free, but it is not on its own a perceptible win — it is low-hanging fruit, not a headline fix. I am not going to claim otherwise.

## Negative user-facing trade-offs

**None.**

- **The early return is exactly equivalent.** With an empty `selectedKeys`, the loop adds nothing and `selectedChanged` stays `false`, so the original returned `selectedKeys` by identity — same as the early return. With `anchorKey === null`, the original's `anchorKey && !validKeys.has(anchorKey) ? null : anchorKey` short-circuits to `null` without consulting `validKeys`. So the skipped `validKeys` set could not have changed either result. A test pins this by counting property reads on the entries.
- **Anchor invalidation still works when nothing is selected.** The guard requires `anchorKey === null` too, so an empty selection with a stale anchor still takes the full path and still drops the anchor. Covered by a dedicated test.
- **The memo cannot go stale.** Its dependencies are the complete input set of a pure function. `selectedKeys` and `anchorKey` are React state in this hook, and `flatEntries` is reference-stable upstream, so any real change produces a new reference.
- **Render-phase convergence is unchanged.** The `setSelectedKeys` / `setAnchorKey` calls that consume the result still run in the same place; when they fire, `selectedKeys` changes identity, the memo recomputes, and it converges exactly as before.

## Merge risk

**Low.** Two guards on one hook, both argued from the original code's own control flow (an empty selection returns the input by identity; a null anchor short-circuits before touching the key set). The read-counter test fails on the old code. Smallest measured absolute win of the set, so low reward as well as low risk.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual or interaction change. Selection, range-select, and pruning of rows that disappear after staging/filtering all behave identically.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm test src/renderer/src/components/right-sidebar/useSourceControlSelection.test.ts` — 7 tests (5 existing + 2 new):

- **new** `returns the same references without scanning rows when nothing is selected` — uses a `get key()` read counter on the entries and asserts **0 reads**. Confirmed to fail against the pre-change code (`expected 50 to be +0`).
- **new** `still drops an anchor that is no longer visible when nothing is selected` — pins that the guard does not swallow anchor invalidation.

Wider suite: `pnpm test src/renderer/src/components/right-sidebar/source-control` — 42 files, 399 tests, all passing. `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only, no platform-dependent behavior.

## AI Disclosure

