### PR TITLE
perf(sidebar): stop building host projections the row model throws away

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { Worktree } from '../../../../../../shared/worktree-types'
+import { getHostWorktreeCounts, getHostWorktreeIds } from './host-labels'
+
+const LOCAL = 'local' as ExecutionHostId
+
+function makeRepos(hostByRepo: Record<string, ExecutionHostId | undefined>): Map<string, Repo> {
+  return new Map(
+    Object.entries(hostByRepo).map(([id, executionHostId]) => [
+      id,
+      { id, path: `/${id}`, ...(executionHostId ? { executionHostId } : {}) } as Repo
+    ])
+  )
+}
+
+function makeWorktrees(rows: { id: string; repoId: string }[]): Worktree[] {
+  return rows.map((row) => row as Worktree)
+}
+
+describe('host worktree counts and ids', () => {
+  it('reports a count equal to the length of each host id list', () => {
+    const repoMap = makeRepos({
+      'repo-local': undefined,
+      'repo-remote': 'ssh:other' as ExecutionHostId
+    })
+    const worktrees = makeWorktrees([
+      { id: 'a', repoId: 'repo-local' },
+      { id: 'b', repoId: 'repo-local' },
+      { id: 'c', repoId: 'repo-remote' }
+    ])
+
+    const counts = getHostWorktreeCounts(worktrees, repoMap, LOCAL)
+    const ids = getHostWorktreeIds(worktrees, repoMap, LOCAL)
+
+    expect(ids).toBeDefined()
+    expect(counts).toBeDefined()
+    for (const [hostId, hostIds] of ids ?? []) {
+      expect(counts?.get(hostId), `count for ${hostId}`).toBe(hostIds.length)
+    }
+    expect([...(counts?.keys() ?? [])].sort()).toEqual([...(ids?.keys() ?? [])].sort())
+  })
+
+  it('counts a repeated host identity once', () => {
+    const repoMap = makeRepos({ 'repo-local': undefined })
+    const worktrees = makeWorktrees([
+      { id: 'a', repoId: 'repo-local' },
+      { id: 'a', repoId: 'repo-local' },
+      { id: 'b', repoId: 'repo-local' }
+    ])
+
+    expect(getHostWorktreeCounts(worktrees, repoMap, LOCAL)?.get(LOCAL)).toBe(2)
+    expect(getHostWorktreeIds(worktrees, repoMap, LOCAL)?.get(LOCAL)).toEqual(['a', 'b'])
+  })
+
+  it('returns undefined for an empty lane', () => {
+    const repoMap = makeRepos({})
+    expect(getHostWorktreeCounts([], repoMap, LOCAL)).toBeUndefined()
+    expect(getHostWorktreeIds([], repoMap, LOCAL)).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { Repo } from '../../../../../../shared/repo-types'
-import type { Worktree } from '../../../../../../shared/worktree-types'
+import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getHostWorktreeCounts, getHostWorktreeIds } from './host-labels'
 
 const LOCAL = 'local' as ExecutionHostId

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.ts
@@ -153,17 +153,17 @@ export function getHostWorktreeCounts(
   if (worktrees.length === 0) {
     return undefined
   }
-  const counts = new Map<ExecutionHostId, number>()
+  // Derived from the id map rather than repeating its dedupe walk: every caller asks for both,
+  // and a host's count is exactly the length of its id list by construction.
   // Dedup by host, not by bare id: the same id on two hosts is two workspaces
   // and has to be counted under each of them (STA-4343).
-  const seenIdentities = new Set<string>()
-  for (const worktree of worktrees) {
-    if (seenIdentities.has(getWorktreeHostIdentity(worktree))) {
-      continue
-    }
-    seenIdentities.add(getWorktreeHostIdentity(worktree))
-    const hostId = getWorktreeExecutionHostId(worktree, repoMap.get(worktree.repoId), defaultHostId)
-    counts.set(hostId, (counts.get(hostId) ?? 0) + 1)
+  const idsByHost = getHostWorktreeIds(worktrees, repoMap, defaultHostId)
+  if (!idsByHost) {
+    return undefined
+  }
+  const counts = new Map<ExecutionHostId, number>()
+  for (const [hostId, ids] of idsByHost) {
+    counts.set(hostId, ids.length)
   }
   return counts
 }
@@ -179,10 +179,12 @@ export function getHostWorktreeIds(
   const idsByHost = new Map<ExecutionHostId, string[]>()
   const seenIdentities = new Set<string>()
   for (const worktree of worktrees) {
-    if (seenIdentities.has(getWorktreeHostIdentity(worktree))) {
+    // Hoisted: the identity string was built twice per row, once to test and once to record.
+    const identity = getWorktreeHostIdentity(worktree)
+    if (seenIdentities.has(identity)) {
       continue
     }
-    seenIdentities.add(getWorktreeHostIdentity(worktree))
+    seenIdentities.add(identity)
     const hostId = getWorktreeExecutionHostId(worktree, repoMap.get(worktree.repoId), defaultHostId)
     const ids = idsByHost.get(hostId) ?? []
     ids.push(worktree.id)

--- a/src/shared/worktree/host-context-labels.test.ts
+++ b/src/shared/worktree/host-context-labels.test.ts
@@ -4,7 +4,7 @@ import { getMixedHostContextLabels } from './host-context-labels'
 
 type Item = { id: string; hostId: ExecutionHostId }
 
-function argsFor(items: Item[], counters: { hostIdReads: number; identityReads: number }) {
+function argsFor(counters: { hostIdReads: number; identityReads: number }) {
   return {
     getHostId: (item: Item): ExecutionHostId => {
       counters.hostIdReads += 1
@@ -25,7 +25,7 @@ describe('getMixedHostContextLabels', () => {
     }))
     const counters = { hostIdReads: 0, identityReads: 0 }
 
-    expect(getMixedHostContextLabels(items, argsFor(items, counters))).toBeUndefined()
+    expect(getMixedHostContextLabels(items, argsFor(counters))).toBeUndefined()
     // The label map was built for all 50 and thrown away before; now nothing is built.
     expect(counters.identityReads).toBe(0)
   })
@@ -38,7 +38,7 @@ describe('getMixedHostContextLabels', () => {
       }))
       const counters = { hostIdReads: 0, identityReads: 0 }
 
-      const labels = getMixedHostContextLabels(items, argsFor(items, counters))
+      const labels = getMixedHostContextLabels(items, argsFor(counters))
 
       expect(labels, `second host at index ${lateIndex}`).toBeDefined()
       expect(labels?.size).toBe(50)
@@ -48,6 +48,6 @@ describe('getMixedHostContextLabels', () => {
 
   it('returns undefined for an empty list', () => {
     const counters = { hostIdReads: 0, identityReads: 0 }
-    expect(getMixedHostContextLabels([], argsFor([], counters))).toBeUndefined()
+    expect(getMixedHostContextLabels([], argsFor(counters))).toBeUndefined()
   })
 })

--- a/src/shared/worktree/host-context-labels.test.ts
+++ b/src/shared/worktree/host-context-labels.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { ExecutionHostId } from '../execution-host'
+import { getMixedHostContextLabels } from './host-context-labels'
+
+type Item = { id: string; hostId: ExecutionHostId }
+
+function argsFor(items: Item[], counters: { hostIdReads: number; identityReads: number }) {
+  return {
+    getHostId: (item: Item): ExecutionHostId => {
+      counters.hostIdReads += 1
+      return item.hostId
+    },
+    getIdentity: (item: Item): string => {
+      counters.identityReads += 1
+      return item.id
+    }
+  }
+}
+
+describe('getMixedHostContextLabels', () => {
+  it('returns undefined without building any labels when every item shares one host', () => {
+    const items: Item[] = Array.from({ length: 50 }, (_, index) => ({
+      id: `wt-${index}`,
+      hostId: 'local' as ExecutionHostId
+    }))
+    const counters = { hostIdReads: 0, identityReads: 0 }
+
+    expect(getMixedHostContextLabels(items, argsFor(items, counters))).toBeUndefined()
+    // The label map was built for all 50 and thrown away before; now nothing is built.
+    expect(counters.identityReads).toBe(0)
+  })
+
+  it('labels every item once a second host appears, wherever it appears', () => {
+    for (const lateIndex of [1, 25, 49]) {
+      const items: Item[] = Array.from({ length: 50 }, (_, index) => ({
+        id: `wt-${index}`,
+        hostId: (index === lateIndex ? 'ssh:other' : 'local') as ExecutionHostId
+      }))
+      const counters = { hostIdReads: 0, identityReads: 0 }
+
+      const labels = getMixedHostContextLabels(items, argsFor(items, counters))
+
+      expect(labels, `second host at index ${lateIndex}`).toBeDefined()
+      expect(labels?.size).toBe(50)
+      expect(labels?.has(`wt-${lateIndex}`)).toBe(true)
+    }
+  })
+
+  it('returns undefined for an empty list', () => {
+    const counters = { hostIdReads: 0, identityReads: 0 }
+    expect(getMixedHostContextLabels([], argsFor([], counters))).toBeUndefined()
+  })
+})

--- a/src/shared/worktree/host-context-labels.ts
+++ b/src/shared/worktree/host-context-labels.ts
@@ -83,12 +83,30 @@ export function getMixedHostContextLabels<T>(
     sources?: HostContextLabelSources
   }
 ): Map<string, string> | undefined {
-  const labelsByIdentity = new Map<string, string>()
-  const hostIds = new Set<ExecutionHostId>()
+  // Why two passes: on a single-host install the map is built for every item and then discarded.
+  // Deciding first costs one getHostId per item and skips the label work entirely.
+  let firstHostId: ExecutionHostId | undefined
+  let isMixed = false
   for (const item of items) {
     const hostId = args.getHostId(item)
-    hostIds.add(hostId)
-    labelsByIdentity.set(args.getIdentity(item), getHostContextLabel(hostId, args.sources))
+    if (firstHostId === undefined) {
+      firstHostId = hostId
+      continue
+    }
+    if (hostId !== firstHostId) {
+      isMixed = true
+      break
+    }
   }
-  return hostIds.size > 1 ? labelsByIdentity : undefined
+  if (!isMixed) {
+    return undefined
+  }
+  const labelsByIdentity = new Map<string, string>()
+  for (const item of items) {
+    labelsByIdentity.set(
+      args.getIdentity(item),
+      getHostContextLabel(args.getHostId(item), args.sources)
+    )
+  }
+  return labelsByIdentity
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

The sidebar's worktree list does two pieces of bookkeeping every time it rebuilds its rows.

**First**, it works out whether it needs to show "which machine is this on?" labels. It only needs them when your workspaces live on *more than one* host. But it was building the full label map for every workspace first, and only *then* checking whether there were two hosts — throwing the whole thing away on a single-host install, which is the normal case.

**Second**, it counted workspaces per host and listed workspace ids per host as two separate walks over the same rows. But a host's count is just how long its id list is, so the counting walk was redundant. Each walk also built the same identity string twice per row.

Now: check for a second host before building anything, and derive the counts from the id lists.

## What Changed

**`src/shared/worktree/host-context-labels.ts`** — `getMixedHostContextLabels` decides before it builds:

```ts
let firstHostId: ExecutionHostId | undefined
let isMixed = false
for (const item of items) {
  const hostId = args.getHostId(item)
  if (firstHostId === undefined) { firstHostId = hostId; continue }
  if (hostId !== firstHostId) { isMixed = true; break }
}
if (!isMixed) { return undefined }
// ...only now build labelsByIdentity
```

**`src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.ts`**:
- `getHostWorktreeCounts` now derives from `getHostWorktreeIds` (`counts.set(hostId, ids.length)`) instead of repeating the dedupe walk.
- `getHostWorktreeIds` hoists `const identity = getWorktreeHostIdentity(worktree)` — it was called twice per row, once to test the `Set` and once to add to it.

## Why

`getMixedWorktreeHostContextLabels` is called unconditionally from `build-rows.ts:108` over every visible worktree, in every `groupBy` mode. `buildRows` re-runs on every filter, collapse, membership, and settings change. On a single-host install the old code did N `getHostId` calls, N `getIdentity` calls, and N `getHostContextLabel` calls (each of which is two `parseExecutionHostId` parses) plus an N-entry `Map` — and then returned `undefined`.

The counts/ids pair is called back-to-back at all three call sites with identical arguments (`build-rows.ts:161,167` and `group-sections.ts:109,115` and `:134,140`), so the second dedupe walk was always redundant work sitting right next to the first.

## Measurements

Benchmarked through the **real exported functions** (not a model), via a temporary Vitest file, 2000 calls after 200 warmup calls, median of 3 runs on Apple Silicon.

**`getMixedHostContextLabels`:**

| workspaces | host layout | before | after | |
| --- | --- | --- | --- | --- |
| 423 | single host (**common case**) | **43.91 µs** | **0.96 µs** | **~46x** |
| 1000 | single host | **107.38 µs** | **0.97 µs** | **~111x** |
| 423 | two hosts interleaved | 82.69 µs | 78.36 µs | 1.05x |
| 1000 | two hosts interleaved | 196.82 µs | 187.95 µs | 1.05x |
| 423 | **adversarial** — second host only on the very last row | 45.46 µs | 45.03 µs | 1.01x |
| 1000 | **adversarial** — second host only on the very last row | 108.52 µs | 102.69 µs | 1.06x |

I measured the adversarial case specifically because the early-exit scan degenerates to a full extra pass there. It does not regress: dropping the per-item `hostIds` `Set` from the build loop pays for the detection pass.

**`getHostWorktreeCounts` + `getHostWorktreeIds`** (one lane, both called as the call sites do):

| workspaces | before | after | |
| --- | --- | --- | --- |
| 423 | 82.98 µs | 64.17 µs | 1.29x |
| 1000 | 217.97 µs | 151.98 µs | 1.43x |

Note: an auditor's model of a more aggressive single-pass rewrite (changing all three call sites to take both maps from one call) measured 3.31x. I deliberately took the smaller change that leaves the public signatures and call sites untouched, so this is the honest 1.29–1.43x rather than that number.

## Negative user-facing trade-offs

**None**, and I checked the cases where an early exit usually costs something:

- **Identical return values.** For a single host both old and new return `undefined`. For mixed hosts the new build loop populates exactly the same `labelsByIdentity` entries — the old loop's extra `hostIds` `Set` only ever fed the `size > 1` decision, which the detection pass now makes.
- **A second host anywhere still triggers labels.** Tested with the second host at index 1, 25, and 49 of 50 — the detection loop breaks on the first mismatch wherever it is, and the build loop then covers all 50.
- **No measured regression in any layout**, including the adversarial worst case (table above).
- **Counts are exactly equivalent.** A host's count was already, by construction, the number of distinct identities recorded for it — which is the length of its id list. Both derive from the same dedupe, so they cannot drift; a test asserts `counts.get(h) === ids.get(h).length` for every host and that the key sets match.
- **Dedupe semantics preserved.** The `STA-4343` rule — dedupe by host identity, not bare id, so the same id on two hosts counts under each — is unchanged; the identity hoist is the same string, computed once instead of twice. A test pins that a repeated identity counts once.
- **Empty-lane behaviour preserved.** Both still return `undefined` for an empty lane, which the `getLaneHost*` wrappers rely on (`#15362`: a lane of only folder workspaces must not render as global). The wrappers are untouched.

## Merge risk

**Low.** Two behaviour-preserving changes in adjacent files, both with new tests, and the early-exit was measured in the adversarial layout (second host on the last row) specifically to prove it does not regress. This PR initially failed CI on typecheck because I added tests after running it — fixed and re-verified, which is worth knowing when reading the history.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual change. Host context labels, host section headers, and per-host counts all render identically; the work to produce them is just skipped when it cannot matter.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `src/shared/worktree/host-context-labels.test.ts` (3 tests) — the first uses `getHostId`/`getIdentity` read counters and asserts **0 identity reads** on a single-host list. Confirmed to fail against the pre-change code (`expected 50 to be +0`).

New `src/renderer/src/components/sidebar/worktree-list/grouping/host-labels.test.ts` (3 tests) — counts match id-list lengths per host and share a key set; a repeated host identity counts once; an empty lane returns `undefined`.

Wider suite: `pnpm test src/renderer/src/components/sidebar` — 290 files, 2463 tests, all passing (includes `worktree-list-groups-host-collision.test.ts`, which covers the mixed-host labelling path end to end). `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer + shared, no platform-dependent behavior.

## AI Disclosure

