### PR TITLE
perf(agent-hooks): find spool newlines with Buffer.indexOf, not a per-byte loop

### DIFF
--- a/src/shared/agent-hook-spool-read.test.ts
+++ b/src/shared/agent-hook-spool-read.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { readSpoolFile } from './agent-hook-spool'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'orca-spool-read-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+function write(contents: string): string {
+  const file = join(dir, 'spool.jsonl')
+  writeFileSync(file, contents)
+  return file
+}
+
+function record(paneKey: string): string {
+  return JSON.stringify({ paneKey, source: 'PreToolUse', payload: {}, receivedAt: Date.now() })
+}
+
+describe('readSpoolFile', () => {
+  it('leaves a trailing line without its newline unconsumed', () => {
+    const complete = `${record('a')}\n`
+    const result = readSpoolFile(write(`${complete}${record('b')}`))
+
+    expect(result.records.map((entry) => entry.paneKey)).toEqual(['a'])
+    // The in-flight final record must stay replayable: consumed stops at the last newline.
+    expect(result.consumed).toBe(Buffer.byteLength(complete))
+  })
+
+  it('consumes through the final newline when every line is complete', () => {
+    const contents = `${record('a')}\n${record('b')}\n`
+    const result = readSpoolFile(write(contents))
+
+    expect(result.records.map((entry) => entry.paneKey)).toEqual(['a', 'b'])
+    expect(result.consumed).toBe(Buffer.byteLength(contents))
+  })
+
+  it('skips blank lines without consuming less than the bytes they occupy', () => {
+    const contents = `${record('a')}\n\n\n${record('b')}\n`
+    const result = readSpoolFile(write(contents))
+
+    expect(result.records.map((entry) => entry.paneKey)).toEqual(['a', 'b'])
+    expect(result.consumed).toBe(Buffer.byteLength(contents))
+  })
+
+  it('returns nothing for an empty file', () => {
+    expect(readSpoolFile(write(''))).toEqual({ records: [], consumed: 0 })
+  })
+
+  it('returns nothing for a file that is one torn line', () => {
+    expect(readSpoolFile(write(record('a'))).records).toEqual([])
+    expect(readSpoolFile(write(record('a'))).consumed).toBe(0)
+  })
+
+  it('returns nothing for a missing file', () => {
+    expect(readSpoolFile(join(dir, 'absent.jsonl'))).toEqual({ records: [], consumed: 0 })
+  })
+})

--- a/src/shared/agent-hook-spool.ts
+++ b/src/shared/agent-hook-spool.ts
@@ -67,19 +67,17 @@ export function readSpoolFile(
   const records: SpoolRecord[] = []
   let consumed = 0
   let start = 0
-  for (let end = 0; end <= bytes.length; end += 1) {
-    if (end !== bytes.length && bytes[end] !== 0x0a) {
-      continue
-    }
+  // indexOf, not a per-byte loop: this runs over every spooled file before the hook listener binds,
+  // and Buffer.indexOf finds the newline with memchr instead of an interpreted scan.
+  for (;;) {
+    const end = bytes.indexOf(0x0a, start)
     // A final line without its newline may still be in flight from a hook writer.
     // Leave it untouched until the writer terminates the record explicitly.
-    if (end === bytes.length && (end === 0 || bytes[end - 1] !== 0x0a)) {
+    if (end === -1) {
       break
     }
     const lineBytes = bytes.subarray(start, end)
-    if (end !== bytes.length) {
-      consumed = end + 1
-    }
+    consumed = end + 1
     start = end + 1
     if (lineBytes.length === 0) {
       continue


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When an agent hook can't reach Orca (the app is starting, or was closed), the hook writes its event to a "spool" file on disk — one JSON record per line. On the next launch, Orca reads those files back and replays them.

To split a file into lines, it looked at **every single byte**, one at a time, in JavaScript, asking "is this a newline?" Node can do that with a single native call that uses the CPU's memory-scanning instruction instead.

Same lines, same records, same handling of a half-written final line — just found the fast way.

## What Changed

`readSpoolFile` in `src/shared/agent-hook-spool.ts`:

```diff
-for (let end = 0; end <= bytes.length; end += 1) {
-  if (end !== bytes.length && bytes[end] !== 0x0a) { continue }
-  if (end === bytes.length && (end === 0 || bytes[end - 1] !== 0x0a)) { break }
-  const lineBytes = bytes.subarray(start, end)
-  if (end !== bytes.length) { consumed = end + 1 }
+for (;;) {
+  const end = bytes.indexOf(0x0a, start)
+  if (end === -1) { break }
+  const lineBytes = bytes.subarray(start, end)
+  consumed = end + 1
   start = end + 1
```

The JSON parse, the record validation, the age filter, and the `{ records, consumed }` shape are all untouched.

## Why

`drainAgentHookSpool` is called from inside `start()` **before `createServer`** — i.e. it runs on the startup path, ahead of the hook listener binding. It walks up to `AGENT_HOOK_SPOOL_MAX_FILES = 1024` files, each up to the spool's size cap.

The old loop ran one interpreted iteration per byte: roughly 5 million loop iterations, array index reads, and comparisons for a 5 MB file. `Buffer.prototype.indexOf` delegates to a native `memchr`-style scan, so it moves the same distance in a fraction of the instructions.

The awkward shape of the old loop existed to handle the terminal case (`end === bytes.length`) so that a final line with no trailing newline could be detected and left alone. With `indexOf` that case is free: a torn final line simply has no newline to find, so the loop ends without touching it — which is exactly the old `break`.

## Measurements

Benchmarked through the **real exported `readSpoolFile`** via a temporary Vitest file, 60 reads after 20 warmup reads, on Apple Silicon:

| spool file | before | after | |
| --- | --- | --- | --- |
| 44 KB (200 records) | 0.276 ms/read | 0.201 ms/read | **1.37x** |
| 5.3 MB (4000 records) | **32.50 ms/read** | **9.26 ms/read** | **3.51x** |

That is ~23 ms saved per large spool file, on a path that runs before the hook listener is accepting connections, and can repeat across up to 1024 files.

## Negative user-facing trade-offs

**None.** The rewrite is behaviour-identical, and I verified that rather than assuming it:

- **Torn trailing line still unconsumed.** A final line without a newline is not replayed and `consumed` stops at the last newline, so a hook writer still finishing that record is never truncated away. This is the contract the old loop's terminal branch existed for.
- **`consumed` byte offset is exact.** The old code set `consumed = end + 1` only for non-terminal newlines; `indexOf` only ever returns non-terminal newline positions, so the value is identical in every case.
- **Blank lines still skipped**, and still counted toward `consumed`.
- **Empty file, missing file, and single-torn-line file** all still return `{ records: [], consumed: 0 }`.
- **Record validation unchanged** — same `paneKey`/`source`/`payload`/`receivedAt` checks and the same `AGENT_HOOK_SPOOL_MAX_AGE_MS` age filter.
- **Parse failures still isolated** — a torn or invalid line is discarded while later complete lines remain replayable.

## Merge risk

**Low.** Byte-level rewrite of a scanner on the startup path, which sounds worse than it is: `indexOf` cannot return a terminal position, so the awkward end-of-buffer branch the old loop needed simply disappears. Be aware the six tests are *characterization* tests — they pass against both implementations by design, so they pin the contract rather than fail without the change.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no UI change. Spooled hook events replay identically; the file is just scanned faster.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `src/shared/agent-hook-spool-read.test.ts` (6 tests) pinning the exact contract: torn trailing line left unconsumed with an exact `consumed` offset; full consumption when every line is complete; blank lines skipped without under-counting `consumed`; empty file; single-torn-line file; missing file.

**Note on what these tests are:** they pass against **both** the old and the new implementation. That is deliberate — this is a pure rewrite, so the right guard is a characterization test proving equivalence, not a test that fails without the change. I ran them against the pre-change code specifically to confirm that (6/6 pass both ways).

Wider suite: `pnpm test src/main/agent-hooks` — 78 files, 772 tests (6 skipped), all passing, including `spool.test.ts`'s existing "drops torn lines while retaining complete records" case. `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: `src/shared` Buffer handling, no platform-dependent behavior. `Buffer.indexOf` is Node core, available on every supported platform.

## AI Disclosure

