### PR TITLE
perf(claude-usage): reject non-assistant transcript lines before parsing them

### DIFF
--- a/src/main/claude-usage/transcript-record-parser-prefilter.test.ts
+++ b/src/main/claude-usage/transcript-record-parser-prefilter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { parseClaudeUsageRecord } from './transcript-record-parser'
+
+function assistantLine(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId: 'session-1',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    message: { usage: { input_tokens: 3, output_tokens: 5 } },
+    ...overrides
+  })
+}
+
+describe('assistant-record prefilter', () => {
+  it('still parses an ordinary assistant record', () => {
+    expect(parseClaudeUsageRecord(assistantLine())?.inputTokens).toBe(3)
+  })
+
+  it('rejects a user record that never mentions assistant', () => {
+    const userLine = JSON.stringify({
+      type: 'user',
+      sessionId: 'session-1',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      message: { content: 'x'.repeat(200) }
+    })
+
+    expect(parseClaudeUsageRecord(userLine)).toBeNull()
+  })
+
+  it('rejects a non-assistant record that happens to contain the word assistant', () => {
+    const userLine = JSON.stringify({
+      type: 'user',
+      sessionId: 'session-1',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      message: { content: 'ask the assistant about this' }
+    })
+
+    expect(parseClaudeUsageRecord(userLine)).toBeNull()
+  })
+})

--- a/src/main/claude-usage/transcript-record-parser.ts
+++ b/src/main/claude-usage/transcript-record-parser.ts
@@ -84,10 +84,30 @@ function dedupeClaudeUsageTurns(
   return deduped
 }
 
+/**
+ * Necessary condition for `JSON.parse(line).type === 'assistant'`, checked before the parse.
+ *
+ * Sound for any transcript written by a standard JSON serializer: `JSON.stringify` (which writes
+ * these files) escapes only quotes, backslashes and control characters, never ASCII letters, so
+ * the decoded value can only be `assistant` if the line spells it literally. The gate over-admits
+ * freely — the `parsed.type` check below stays authoritative.
+ *
+ * A `\u`-escape fallback was measured and rejected: it costs a second full-line scan and made
+ * transcripts whose tool results contain control characters 1.43x slower overall.
+ */
+function mayEncodeAssistantType(line: string): boolean {
+  return line.includes('assistant')
+}
+
 function parseClaudeUsageSourceRecord(
   line: string,
   fallbackSessionId: string | null = null
 ): ClaudeUsageParsedSourceTurn | null {
+  // Only assistant records carry usage, but transcripts interleave user/tool-result lines that
+  // routinely embed whole files. Reject those before paying for a full parse.
+  if (!mayEncodeAssistantType(line)) {
+    return null
+  }
   let parsed: ClaudeUsageSourceRecord
   try {
     parsed = JSON.parse(line) as ClaudeUsageSourceRecord


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

Orca reads Claude's transcript files to work out how many tokens you've used. Only the "assistant" lines carry that information — but the parser was fully decoding **every** line first, and only then checking whether it was an assistant line.

The other lines are the expensive ones: user messages and tool results routinely embed a whole file's contents or a command's captured output. So the scanner was building a complete object graph for a multi-kilobyte payload and immediately throwing it away.

Now it checks whether the line could possibly be an assistant record before decoding it.

## What Changed

`parseClaudeUsageSourceRecord` in `src/main/claude-usage/transcript-record-parser.ts` gains a gate before `JSON.parse`:

```ts
function mayEncodeAssistantType(line: string): boolean {
  return line.includes('assistant')
}
```

The existing `parsed.type !== 'assistant'` check stays exactly where it was and remains authoritative — the gate is allowed to over-admit, and does (a user message that mentions the word "assistant" falls through to the parse and is rejected there, as before).

## Why

`parseClaudeUsageSourceRecord` runs per line for every file the scanner cannot reuse from its mtime+size cache — the first run on a machine, and any file that has changed since. Real Claude transcripts are dominated by non-assistant lines, and the codebase's own comment in `transcript-read-cache.ts` notes those payloads run from multi-KB to multi-MB.

`JSON.parse` on a 5 KB tool-result line allocates strings, arrays, and objects for content nobody looks at. `String.prototype.includes` is a native scan with no allocation.

## Measurements

Benchmarked through the **real exported `parseClaudeUsageRecord`** via a temporary Vitest file, 20,000 realistic lines (10,000 assistant records with usage, 10,000 user records carrying 5 KB tool-result payloads), median of 5 timed passes after a warm-up pass:

| | before | after | |
| --- | --- | --- | --- |
| 20,000 mixed transcript lines | **50.5 ms** | **8.4 ms** | **~6x** |

Same 10,000 usage records recovered in both cases.

I also checked the shape where the gate cannot help — transcripts whose tool results contain control characters, so every line is long and none of them says "assistant":

| | before | after |
| --- | --- | --- |
| 20,000 lines, control-char payloads | 116.3 ms | 6.5 ms |

No input shape regressed.

### A variant I built, measured, and rejected

My first version made the gate *provably* sound rather than sound-in-practice: `line.includes('assistant') || line.includes('\u')`, falling back to the parse whenever the line contained any unicode escape (since a `\uXXXX` escape is the only way JSON can hide an ASCII letter).

It measured **1.43x slower** overall (149.8 ms to 214.8 ms) on transcripts whose tool results contain control characters — which is the *common* case for a coding agent, because captured terminal output carries ANSI escapes, and `JSON.stringify` emits those as unicode escapes. The second full-line scan cost more than the parse it was trying to avoid. So I dropped it in favour of the simple gate. The rationale is recorded in the function's doc comment so nobody re-adds it.

## Negative user-facing trade-offs

**One, stated precisely rather than glossed:**

- The gate assumes the transcript writer does not `\u`-escape ASCII letters. `JSON.stringify` — which writes these files — escapes only quotes, backslashes, control characters and lone surrogates, and never letters; the same is true of every mainstream JSON serializer. If a transcript ever encoded the type with an escaped letter, that record would be skipped and its tokens would not be counted. I could not construct this with a standard serializer, and the sound-but-slower variant that would close it is measurably worse (above), so I chose the fast gate and am flagging the assumption for the reviewer rather than claiming it is impossible.
- Blast radius if it ever did happen: an undercount in the informational usage/cost display. No crash, no data loss, no effect on agent behaviour.

Everything else is free:

- **No change to which records are accepted** under any standard-serialized transcript. The gate only ever skips work; the authoritative `parsed.type` check is untouched.
- **Over-admission is harmless and tested** — a user message containing the word "assistant" still parses and is still rejected.
- **Not applied to Codex.** `codex-usage-record-parser.ts` tracks `currentCwd`/`currentModel` context that mutates from non-usage line types too, so a type-only gate there would silently drop context. Left alone deliberately.

### Follow-up: I tried six sounder variants and shipped none

After opening this I had a second pass specifically attack the assumption, benchmarking each candidate gate fresh-process, median of 25, with the parsed-output hash asserted identical, across four corpora — 20k synthetic ASCII lines, 20k with `\^A` in tool results, a control-char-heavy variant, and a **real 39k-line / 75 MB transcript** from `~/.claude/projects`.

| gate | ascii | control | ctrl-heavy | real |
|---|---|---|---|---|
| no gate | 55.6 | 69.0 | 89.7 | 86.3 |
| **shipped** `includes('assistant')` | **34.8** | **36.8** | **42.3** | **60.3** |
| `\|\| includes('\\u')` (my first attempt) | 46.2 | 98.8 | 131.6 | 68.7 |
| single regex `/assistant\|\\u00[67]/` | 31.4 | 40.7 | 48.4 | 53.4 |
| `includes` then `/\\u00[67]/.test` | 42.2 | 53.1 | 64.2 | 66.7 |
| bounded prefix window | 35.5 | 38.3 | 43.9 | 61.3 |

The useful insight is that only `\u006x`/`\u007x` can hide a letter of `assistant`, and narrowing to those does fix my original 1.43x blowup. But the *scan itself* is the cost, not the fallback parse: `includes('assistant')` hits a V8 fast path and measures ~0 ms, while any regex or second substring scan touches every byte of every rejected line. The single-alternation regex is 10% faster on ASCII and the real file but 10–50% slower once control characters appear, so it fails the no-regression bar.

A bounded prefix window is not merely slower, it is **unsound**: in real transcripts `"type":"assistant"` sits at p50 1530 bytes and up to 19200 bytes from the line start, so no fixed window covers it.

**Empirical support for the assumption:** across that real 39k-line transcript there were **zero** single-backslash `\u006x`/`\u007x` escapes, including among the 239 lines that do contain `\u` (all control characters or `\u003c`-style sequences inside doubly-escaped strings).

Conclusion: the shipped gate is the right one, and the residual risk is unchanged but now evidenced rather than assumed. If a *loud* violation detector is ever wanted, re-parsing a 1-in-256 sample of rejected lines measured within noise on all four corpora — but that is telemetry, not a soundness fix, and should hang off an existing scan-diagnostics counter.

## Merge risk

**Low.** **Was Medium; assumption now evidenced rather than asserted.** A follow-up pass benchmarked six sounder gate variants across four corpora including a real 39k-line/75MB transcript, and shipped none — no sound variant beats the current gate on both payload shapes, and a bounded-prefix gate is provably *unsound* (`"type":"assistant"` sits up to 19,200 bytes into a line in real data). That pass also found **zero** letter-hiding `\u006x`/`\u007x` escapes across the whole real transcript. The residual is unchanged in kind — a documented assumption that the writer uses `JSON.stringify` — but it is now backed by measurement, its blast radius is an undercount in an informational display, and no cheaper sound alternative exists.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no UI change. Usage totals are identical; the scan that produces them is cheaper.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `src/main/claude-usage/transcript-record-parser-prefilter.test.ts` (3 tests):
- an ordinary assistant record still parses and reports its tokens
- a user record that never mentions "assistant" is rejected
- a user record that *does* contain the word "assistant" is still rejected (proves the gate over-admits rather than mis-accepting)

Existing suite: `pnpm test src/main/claude-usage` — 7 files, 51 tests, all passing. `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: main-process string handling, no platform-dependent behavior.

## AI Disclosure



