### PR TITLE
perf(orchestration): project task columns so task reads hit the statement cache

### DIFF
--- a/src/main/runtime/orchestration/db/hot-path-statement-compilation.test.ts
+++ b/src/main/runtime/orchestration/db/hot-path-statement-compilation.test.ts
@@ -131,6 +131,32 @@ describe('orchestration hot-path statement compilation', () => {
     }
   })
 
+  // Why: getTask sits on the dispatch/lifecycle path and listTasks runs several times per
+  // coordinator tick, so a wildcard there recompiles on every call the same way the publish did.
+  it('compiles the task lookup and listing SQL exactly once across repeated calls', () => {
+    const db = openDatabase(':memory:')
+    seedDispatchedWorker(db)
+    const seeded = db.listTasks()
+    expect(seeded.length).toBeGreaterThan(0)
+    const taskId = seeded[0].id
+
+    const compiled = trackCompiledSql(db)
+    for (let call = 0; call < 5; call += 1) {
+      db.getTask(taskId)
+      db.listTasks()
+      db.listTasks({ ready: true })
+      db.listTasks({ status: 'pending' })
+      db.listTasks({ runId: seeded[0].run_id })
+    }
+
+    const compilationsPerSql = new Map<string, number>()
+    for (const sql of compiled) {
+      compilationsPerSql.set(sql, (compilationsPerSql.get(sql) ?? 0) + 1)
+    }
+    expect([...compilationsPerSql].filter(([, count]) => count > 1)).toEqual([])
+    expect(compiled.filter((sql) => WILDCARD_PROJECTION.test(sql))).toEqual([])
+  })
+
   // Why: `SELECT *` is what made these statements uncacheable, and a retained wildcard is the only
   // way node:sqlite could build a row from stale column names after another connection's ALTER.
   // Seeds on one connection and publishes on a second so every compilation here is hot-path SQL.

--- a/src/main/runtime/orchestration/db/tasks/task-store.ts
+++ b/src/main/runtime/orchestration/db/tasks/task-store.ts
@@ -79,8 +79,12 @@ export function createTask(
       runId,
       depsJson
     )
-  return this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow
+  return this.db.prepare(`SELECT ${TASK_COLUMN_LIST} FROM tasks WHERE id = ?`).get(id) as TaskRow
 }
+
+// Why wildcard-free: SyncDatabase refuses to cache any statement containing `*`, so a `SELECT *`
+// here recompiles on every call — including the hot dispatch lookups and the coordinator poll.
+const TASK_COLUMN_LIST = selectColumns(TASK_COLUMNS)
 
 // Why: hoisted and wildcard-free so the per-publish lineage lookup hits the SyncDatabase statement cache.
 const TASK_RUNTIME_LINEAGE_SQL = `SELECT ${selectColumns(TASK_COLUMNS, 't')},
@@ -113,7 +117,9 @@ export function getTask(
   dispatchRunId?: string
 ): TaskRow | TaskRuntimeLineageRow | undefined {
   if (dispatchRunId === undefined) {
-    return this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined
+    return this.db.prepare(`SELECT ${TASK_COLUMN_LIST} FROM tasks WHERE id = ?`).get(id) as
+      | TaskRow
+      | undefined
   }
   return this.db.prepare(TASK_RUNTIME_LINEAGE_SQL).get(dispatchRunId, id) as
     | TaskRuntimeLineageRow
@@ -128,20 +134,26 @@ export function listTasks(
   const runParams: Database.BindValue[] = filter?.runId ? [filter.runId] : []
   if (filter?.ready) {
     return this.db
-      .prepare(`SELECT * FROM tasks WHERE ${runWhere}status = 'ready' ORDER BY created_at`)
+      .prepare(
+        `SELECT ${TASK_COLUMN_LIST} FROM tasks WHERE ${runWhere}status = 'ready' ORDER BY created_at`
+      )
       .all(...runParams) as TaskRow[]
   }
   if (filter?.status) {
     return this.db
-      .prepare(`SELECT * FROM tasks WHERE ${runWhere}status = ? ORDER BY created_at`)
+      .prepare(
+        `SELECT ${TASK_COLUMN_LIST} FROM tasks WHERE ${runWhere}status = ? ORDER BY created_at`
+      )
       .all(...runParams, filter.status) as TaskRow[]
   }
   if (filter?.runId) {
     return this.db
-      .prepare('SELECT * FROM tasks WHERE run_id = ? ORDER BY created_at')
+      .prepare(`SELECT ${TASK_COLUMN_LIST} FROM tasks WHERE run_id = ? ORDER BY created_at`)
       .all(filter.runId) as TaskRow[]
   }
-  return this.db.prepare('SELECT * FROM tasks ORDER BY created_at').all() as TaskRow[]
+  return this.db
+    .prepare(`SELECT ${TASK_COLUMN_LIST} FROM tasks ORDER BY created_at`)
+    .all() as TaskRow[]
 }
 
 // Why: the correlated indexed lookup avoids materializing every retained Dispatch before filtering Tasks.
@@ -195,7 +207,7 @@ export function listTasksWithDispatch(
 // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.
 export function promoteReadyTasks(this: OrchestrationDb, completedTaskId: string): void {
   const candidates = this.db
-    .prepare("SELECT * FROM tasks WHERE status = 'pending'")
+    .prepare(`SELECT ${TASK_COLUMN_LIST} FROM tasks WHERE status = 'pending'`)
     .all() as TaskRow[]
 
   for (const task of candidates) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Orca stores orchestration tasks in SQLite. Preparing a query is expensive, so it keeps a cache of prepared queries and reuses them.

But the cache deliberately refuses to store any query containing `SELECT *`. (Good reason: after a schema change, SQLite can build a row from stale column names, so a reused wildcard query could silently drop a newly added column.)

Every task read in this file was written as `SELECT * FROM tasks ...` — so none of them could ever be cached, and each one recompiled its SQL from scratch on every single call.

Now they list their columns explicitly, so the cache can do its job.

## What Changed

`src/main/runtime/orchestration/db/tasks/task-store.ts` — one hoisted constant:

```ts
const TASK_COLUMN_LIST = selectColumns(TASK_COLUMNS)
```

and six `SELECT *` queries rewritten to use it, across `createTask`'s read-back, `getTask`, all four `listTasks` variants, and `promoteReadyTasks`.

`selectColumns` and `TASK_COLUMNS` were **already imported in this file** (line 8) and already used two lines above for `TASK_RUNTIME_LINEAGE_SQL`, whose comment says it is *"hoisted and wildcard-free so the per-publish lineage lookup hits the SyncDatabase statement cache."* This applies that same treatment to the rest of the file.

## Why

`src/main/sqlite/sync-database.ts:26` gates the cache:

```ts
function isStatementCacheable(sql: string): boolean {
  return !PRAGMA_STATEMENT.test(sql) && !sql.replace(AGGREGATE_STAR, '').includes('*')
}
```

So each of these queries took the `db.prepare()` compile path on every call. And they are called constantly:

- **`getTask(id)`** is on the hot dispatch/lifecycle path — `worker-dispatch-start.ts`, `dispatch-context-store.ts`, `worker-report-settlement.ts`, `decision-gate-store.ts`, `lifecycle-reconciliation.ts`, `coordinator-escalation-triage.ts`, twice per `updateTaskStatus` transition, plus a loop in `promoteReadyTasks`/`createTask`.
- **`listTasks()`** runs several times per coordinator tick (`coordinator.ts`, `coordinator-dag-convergence.ts`) on the 2-second autonomous-coordinator poll, for as long as a run is active.

`#18420` (`perf(orchestration): project explicit columns so the graph publish stops recompiling SQL`) fixed exactly this shape for the graph publish. The task-store reads were not covered by it.

## Measurements

Benchmarked through the **real `OrchestrationDb`** against an in-memory database seeded with 40 tasks and a root dispatch, via a temporary Vitest file: 3000 calls per timed pass after 500 warm-up calls, median of 5 passes.

| call | before | after | |
| --- | --- | --- | --- |
| **`getTask(id)`** | **7.88 µs** | **2.18 µs** | **3.6x** |
| `listTasks()` (40 rows) | 51.56 µs | 43.80 µs | 1.18x |

`getTask` is where the win lands, because the compile dominates a single-row lookup. For `listTasks` the row materialisation dominates at this size, so removing the compile is a smaller slice — still free.

The new test measures the same thing deterministically rather than by timing: it counts real `node:sqlite` compilations across 5 rounds of `getTask` + all four `listTasks` variants and asserts each SQL compiles **exactly once**. It fails against the pre-change code (`expected [ [ …(2) ], [ …(2) ], [ …(2) ], …(2) ] to deeply equal []` — five distinct statements each recompiling).

## Negative user-facing trade-offs

**None.**

- **No risk of a dropped column** — which is the reason the wildcard ban exists in the first place. `TASK_COLUMNS` is guarded at compile time by `type UnprojectedTaskColumn = Exclude<keyof TaskRow, (typeof TASK_COLUMNS)[number]>` plus an `extends never` assertion in `row-column-lists.ts:64-72`, so a column added to `TaskRow` without being added to the list is a **type error**, not a silent data loss. `row-column-lists.test.ts` additionally pins the list against the live schema. This change makes these reads *safer* than `SELECT *`, not riskier.
- **Identical rows returned.** Same columns, same order, same `WHERE`/`ORDER BY` clauses, same bind parameters. Only the projection text changed.
- **No new cache pressure.** The cache is a bounded LRU (256 entries) and these are six statements; it also clears itself on schema-changing SQL, so a migration cannot leave a stale entry behind.
- **Scope deliberately limited to `tasks`.** `dispatch_contexts` and `messages` have the same wildcard shape elsewhere in this directory, but `messages` has no column list yet and adding one needs its own schema-drift assertion. I did not fold that in — it belongs in its own change with its own test.

## Merge risk

**Low.** Projection-string change only. The safety that matters is already in the repo: `TASK_COLUMNS` carries a compile-time `extends never` assertion, so a column added to `TaskRow` without being listed is a type error rather than silent data loss — which makes these reads safer than the `SELECT *` they replace. The new test counts real `node:sqlite` compilations and fails on the old code.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no UI change. Task rows, orchestration behaviour, and the coordinator loop are unchanged; the SQL behind them is just prepared once instead of every call.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New case in `src/main/runtime/orchestration/db/hot-path-statement-compilation.test.ts`: `compiles the task lookup and listing SQL exactly once across repeated calls`. It reuses that file's existing `trackCompiledSql` harness (which wraps the raw `node:sqlite` handle, so it counts *real* compilations, not cache hits) and also asserts no wildcard projection is compiled at all. Confirmed to fail before the change.

Existing suite: `pnpm test src/main/runtime/orchestration` — 70 files, 578 tests (4 skipped), all passing, including `row-column-lists.test.ts` and the two pre-existing hot-path cases. `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: main-process SQLite, no platform-dependent behavior.

## AI Disclosure

