### PR TITLE
perf(agent-hooks): stop cloning the whole status roster on every hook event

### DIFF
--- a/src/main/agent-awake-service-platform-assertions.test.ts
+++ b/src/main/agent-awake-service-platform-assertions.test.ts
@@ -22,6 +22,20 @@ function workingStatus(): AgentAwakeStatus {
   }
 }
 
+describe('AgentAwakeService status array ownership', () => {
+  it('does not observe rows appended to the caller array after setStatuses', () => {
+    const service = new AgentAwakeService()
+    service.setMode('auto')
+    const statuses: AgentAwakeStatus[] = [workingStatus()]
+
+    service.setStatuses(statuses)
+    const before = service.getWorkingAgentCount()
+    statuses.push(workingStatus(), workingStatus())
+
+    expect(service.getWorkingAgentCount()).toBe(before)
+  })
+})
+
 function createBlocker() {
   const startedIds = new Set<number>()
   let nextId = 1

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -105,7 +105,8 @@ export class AgentAwakeService {
   }
 
   setStatuses(statuses: AgentAwakeStatus[]): void {
-    this.statuses = statuses.map((status) => ({ ...status }))
+    // Copy the array, not every row: the hook server allocates each row fresh per event.
+    this.statuses = [...statuses]
     this.refresh('status-change')
   }
 
@@ -171,7 +172,8 @@ export class AgentAwakeService {
 
   private getEligibleRunningStatusCount(): number {
     const now = this.now()
-    return this.statuses.filter((status) => this.isWakeEligible(status, now)).length
+    // Counted in place: the filtered array was only ever measured, and this runs per hook event.
+    return this.statuses.reduce((count, s) => count + (this.isWakeEligible(s, now) ? 1 : 0), 0)
   }
 
   private isWakeEligible(status: AgentAwakeStatus, now: number): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Every time an agent does anything — starts a turn, calls a tool, finishes — the hook server tells the rest of the app about it. Part of that notification is the current status of every pane Orca has an agent status cached for (up to 500).

The service that decides "should I keep the computer awake?" received that list and immediately made a **copy of every single row**, even though the hook server had just built each of those rows fresh a microsecond earlier and nobody else was going to touch them. Then, to count how many agents were working, it built *another* array just to ask how long it was.

So the cost of one pane's event scaled with how many panes you'd ever run an agent in. Now it copies the list without copying each row, and counts without building anything.

## What Changed

`src/main/agent-awake-service.ts`, two lines:

```diff
-this.statuses = statuses.map((status) => ({ ...status }))
+this.statuses = [...statuses]
```

```diff
-return this.statuses.filter((status) => this.isWakeEligible(status, now)).length
+return this.statuses.reduce((count, s) => count + (this.isWakeEligible(s, now) ? 1 : 0), 0)
```

## Why

`setStatuses` is wired to `agentHookServer.subscribeStatusChanges` in `src/main/startup/main-process-observers.ts:59`, which fires on every applied hook status. The array it receives is built by `buildStatusChangeNotification` (`server/server-listeners.ts:160`), which allocates a **fresh object literal per pane on every call**:

```ts
statuses.push({
  state: enriched.payload.state,
  receivedAt: enriched.receivedAt,
  observedInCurrentRuntime: this.runtimeObservedStatusPaneKeys.has(paneKey)
})
```

So the `.map(status => ({ ...status }))` was cloning objects that had no other owner, to protect against mutation that cannot happen. `AgentAwakeService` only ever reads `state`, `receivedAt`, and `observedInCurrentRuntime`.

`getEligibleRunningStatusCount` runs on the same path via `refresh()` / `getStatus()`, and `.filter(...).length` allocates a result array whose only use is `.length`. `reduce` walks the same rows in one pass with no allocation.

## Measurements

Benchmarked through the **real `AgentAwakeService`** via a temporary Vitest file: 2000 `setStatuses` calls per timed pass (each with a distinct pre-built frame, so nothing is trivially cached) after 200 warm-up calls, median of 5 passes.

| cached panes | before | after | |
| --- | --- | --- | --- |
| 50 | 1.01 µs/event | 0.60 µs/event | **1.7x** |
| 200 | 3.59 µs/event | 1.18 µs/event | **3.0x** |
| 500 (the cache cap) | **5.34 µs/event** | **1.78 µs/event** | **3.0x** |

The shape is the point: the old cost grew with total cached panes, so the app got measurably slower per agent event the longer you used it. The remaining cost is the unavoidable single walk.

I used `reduce` rather than a plain `for` loop because the loop pushed the file past the repo's 300-line `max-lines` gate, and `AGENTS.md` forbids bumping or disabling that. `reduce` is allocation-free and measured within noise of the loop version (1.78 vs 1.93 µs at N=500).

## Negative user-facing trade-offs

**None.**

- **Array isolation is preserved.** `[...statuses]` still copies the array, so the service cannot observe rows the caller appends or removes afterwards. A new test pins exactly that.
- **Row aliasing cannot bite.** The only two production callers are `setStatuses([])` (a fresh literal) and `setStatuses(statuses)` from the hook subscription, whose rows are freshly allocated per event by `buildStatusChangeNotification` and never retained or mutated by the producer. `AgentAwakeService` treats them as read-only.
- **Counting is exactly equivalent.** `reduce` applies the same `isWakeEligible` predicate to the same rows in the same order and returns the same number; only the intermediate array is gone.
- **No behaviour change to wake decisions** — the mode logic, staleness window (`AGENT_AWAKE_STATUS_STALE_AFTER_MS`), and `observedInCurrentRuntime` gate are untouched.
- **No cap or retention change** — the hook server's 500-pane status cache is unchanged; this only stops re-copying it.

## Merge risk

**Low.** Drops a per-row clone of an array whose rows are freshly allocated per event by the hook server and never retained elsewhere; the array copy itself is kept, so caller isolation is unchanged. Only two production call sites. The `reduce` shape was chosen over a `for` loop solely to stay under the repo's 300-line `max-lines` gate rather than bump it.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no UI change. The keep-awake behaviour and the working-agent count are identical; producing them just costs less per agent event.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New case in `src/main/agent-awake-service-platform-assertions.test.ts`: `does not observe rows appended to the caller array after setStatuses` — pins the array-copy contract that `[...statuses]` keeps.

**Note on what that test is:** it passes against both the old and new code, deliberately. The old `.map()` also produced a new array, so the contract is unchanged — the test exists to stop a future "just assign it" simplification from silently removing the isolation, not to fail without this diff.

Existing suites: `pnpm test src/main/agent-awake-service.test.ts src/main/agent-awake-service-platform-assertions.test.ts` — 22 tests, all passing. `pnpm tc`, `oxlint` (including the `max-lines` gate), and `pnpm run check:code-quality:changed` all clean.

Platforms: main-process logic; the power-save-blocker calls it feeds are already platform-guarded and untouched.

## AI Disclosure

