### PR TITLE
fix(runtime): let a scoped worktree listing report the host it could not cover

### DIFF
--- a/src/main/runtime/runtime-managed-worktree-queries.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.test.ts
@@ -40,14 +40,18 @@ function metadata(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
   }
 }
 
-function queries(store: RuntimeStore): RuntimeManagedWorktreeQueries {
+function queries(
+  store: RuntimeStore,
+  overrides: Partial<ConstructorParameters<typeof RuntimeManagedWorktreeQueries>[0]> = {}
+): RuntimeManagedWorktreeQueries {
   return new RuntimeManagedWorktreeQueries({
     getStore: () => store,
     listResolved: async () => [],
     resolveRepo: async () => store.getRepos()[0]!,
     selectRepos: () => store.getRepos(),
     scanRepo: async () => ({ ok: true, worktrees: [] }),
-    listKnownHostIds: () => []
+    listKnownHostIds: () => [],
+    ...overrides
   })
 }
 
@@ -103,5 +107,75 @@ describe('RuntimeManagedWorktreeQueries.listDetected', () => {
       visibilitySource: { kind: 'custom', id: 'host-source' }
     })
     expect(legacy.worktrees[0]).not.toHaveProperty('visibilitySource')
+  })
+})
+
+describe('RuntimeManagedWorktreeQueries.list host scope', () => {
+  // Measured on hardware before this fix, same runtime and same refusing SSH host in the same
+  // second: the UNSCOPED listing reported `omittedHostIds: ["local","ssh:ssh-scope-refused"]` with
+  // `--host` selectors, while the SCOPED listing reported `{"hostIds":[],"omittedHostIds":[]}`.
+  // A listing that covered nothing, reporting no gaps, is indistinguishable from a repo that
+  // genuinely has no worktrees -- the thing docs/reference/ssh-execution-boundary.md forbids.
+  function sshStore(): RuntimeStore {
+    const repo = folderRepo({
+      id: 'repo-ssh',
+      kind: 'git',
+      connectionId: 'conn-1',
+      path: '/home/dev/app'
+    })
+    return {
+      getRepos: () => [repo],
+      getRepo: () => repo,
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined,
+      setWorktreeMeta: vi.fn(),
+      getAllWorktreeLineage: () => ({}),
+      getSettings: () => settings
+    } as unknown as RuntimeStore
+  }
+
+  it('names the scoped repo host as omitted when the listing covered nothing', async () => {
+    const result = await queries(sshStore()).list('repo-ssh', 50)
+
+    expect(result.totalCount).toBe(0)
+    expect(result.hostScope).toEqual({
+      hostIds: [],
+      omittedHostIds: ['ssh:conn-1']
+    })
+  })
+
+  it('does not report the scoped host as omitted once it contributes rows', async () => {
+    const store = sshStore()
+    const result = await queries(store, {
+      listResolved: async () =>
+        [
+          {
+            id: 'repo-ssh::/home/dev/app',
+            repoId: 'repo-ssh',
+            path: '/home/dev/app',
+            hostId: 'ssh:conn-1'
+          }
+        ] as never
+    }).list('repo-ssh', 50)
+
+    expect(result.hostScope?.hostIds).toEqual(['ssh:conn-1'])
+    expect(result.hostScope?.omittedHostIds).toEqual([])
+  })
+
+  // The caller scoped the listing, so the hosts they excluded must not come back as gaps.
+  it('never names a host the caller scoped out', async () => {
+    const scoped = await queries(sshStore(), {
+      listKnownHostIds: () => ['local', 'ssh:other', 'runtime:elsewhere'] as never
+    }).list('repo-ssh', 50)
+
+    expect(scoped.hostScope?.omittedHostIds).toEqual(['ssh:conn-1'])
+  })
+
+  it('still reports every configured host when the listing is unscoped', async () => {
+    const unscoped = await queries(sshStore(), {
+      listKnownHostIds: () => ['local', 'ssh:conn-1'] as never
+    }).list(undefined, 50)
+
+    expect(unscoped.hostScope?.omittedHostIds).toEqual(['local', 'ssh:conn-1'])
   })
 })

--- a/src/main/runtime/runtime-managed-worktree-queries.test.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.test.ts
@@ -171,6 +171,48 @@ describe('RuntimeManagedWorktreeQueries.list host scope', () => {
     expect(scoped.hostScope?.omittedHostIds).toEqual(['ssh:conn-1'])
   })
 
+  // `getRepoExecutionHostId` derives the host from two spellings, and a scoped listing that named
+  // the wrong one would be worse than naming none. These pin both.
+  it('names the local host for a scoped local repo', async () => {
+    const repo = folderRepo({ id: 'repo-local', kind: 'git', path: '/workspace/local' })
+    const store = {
+      getRepos: () => [repo],
+      getRepo: () => repo,
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined,
+      setWorktreeMeta: vi.fn(),
+      getAllWorktreeLineage: () => ({}),
+      getSettings: () => settings
+    } as unknown as RuntimeStore
+
+    const result = await queries(store).list('repo-local', 50)
+
+    expect(result.hostScope?.omittedHostIds).toEqual(['local'])
+  })
+
+  it('prefers executionHostId over connectionId for the scoped host', async () => {
+    const repo = folderRepo({
+      id: 'repo-runtime',
+      kind: 'git',
+      connectionId: 'conn-legacy',
+      executionHostId: 'runtime:env-1',
+      path: '/workspace/runtime'
+    })
+    const store = {
+      getRepos: () => [repo],
+      getRepo: () => repo,
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined,
+      setWorktreeMeta: vi.fn(),
+      getAllWorktreeLineage: () => ({}),
+      getSettings: () => settings
+    } as unknown as RuntimeStore
+
+    const result = await queries(store).list('repo-runtime', 50)
+
+    expect(result.hostScope?.omittedHostIds).toEqual(['runtime:env-1'])
+  })
+
   it('still reports every configured host when the listing is unscoped', async () => {
     const unscoped = await queries(sshStore(), {
       listKnownHostIds: () => ['local', 'ssh:conn-1'] as never

--- a/src/main/runtime/runtime-managed-worktree-queries.ts
+++ b/src/main/runtime/runtime-managed-worktree-queries.ts
@@ -2,7 +2,7 @@ import type { DetectedWorktreeListResult, Worktree } from '../../shared/worktree
 import type { Repo } from '../../shared/repo-types'
 import type { RuntimeWorktreeListResult } from '../../shared/runtime-types'
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
-import { buildWorktreeListingPage } from './worktree-listing-host-scope'
+import { buildWorktreeListingPage, listingKnownHostIds } from './worktree-listing-host-scope'
 import { readWorktreeMetaForHost } from '../persistence/host-qualified-worktree-meta'
 import { getRepoOwnedWorktreeMeta } from '../worktree-metadata-ownership'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
@@ -80,7 +80,7 @@ export class RuntimeManagedWorktreeQueries {
       throw new Error('invalid_limit')
     }
     const resolved = await this.deps.listResolved()
-    const repoId = repoSelector ? (await this.deps.resolveRepo(repoSelector)).id : null
+    const scopedRepo = repoSelector ? await this.deps.resolveRepo(repoSelector) : null
     const pathsByRepo = new Map<string, string[]>()
     for (const worktree of resolved) {
       const paths = pathsByRepo.get(worktree.repoId) ?? []
@@ -100,12 +100,12 @@ export class RuntimeManagedWorktreeQueries {
     )
     const worktrees = resolved.filter(
       (worktree) =>
-        (!repoId || worktree.repoId === repoId) &&
+        (!scopedRepo || worktree.repoId === scopedRepo.id) &&
         this.isVisible(worktree, matchers.get(worktree.repoId), sourceDefaultsSupported)
     )
-    // Why: a `--repo` listing was scoped by the caller, so naming every configured host as
-    // omitted would report a gap the caller deliberately excluded.
-    return buildWorktreeListingPage(worktrees, limit, repoId ? [] : this.deps.listKnownHostIds())
+    // See `listingKnownHostIds`: a scoped listing must still name the host it was asked about.
+    const knownHostIds = listingKnownHostIds(scopedRepo, () => this.deps.listKnownHostIds())
+    return buildWorktreeListingPage(worktrees, limit, knownHostIds)
   }
 
   resolveRepoForConnection(selector: string, connectionId?: string | null): Promise<Repo> {

--- a/src/main/runtime/worktree-listing-host-scope.ts
+++ b/src/main/runtime/worktree-listing-host-scope.ts
@@ -1,4 +1,5 @@
-import type { ExecutionHostId } from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { selectHostBalancedPage } from '../../shared/host-balanced-listing-page'
 import type { RuntimeListingHostScope } from '../../shared/runtime-listing-host-scope'
 
@@ -61,4 +62,29 @@ export function buildWorktreeListingHostScope(args: {
     }
   }
   return { hostIds: [...covered].sort(), omittedHostIds: [...omitted].sort() }
+}
+
+/**
+ * Which hosts a listing claims to have been looking at.
+ *
+ * A `--repo` listing was scoped by the caller, so naming every configured host would report gaps
+ * the caller deliberately excluded. Naming NONE — which is what a scoped listing did before — means
+ * the scope can never report a gap at all, for any host kind, because `covered` and `omitted` are
+ * both derived from the returned rows plus this list. A scoped listing whose scan did not succeed
+ * then answers `{hostIds: [], omittedHostIds: []}`: byte-identical to a repo that genuinely has no
+ * worktrees, which is the one thing docs/reference/ssh-execution-boundary.md forbids a listing from
+ * implying.
+ *
+ * Measured before the fix, on one runtime with one refusing SSH host, in the same second: the
+ * unscoped listing reported `omittedHostIds: ["local", "ssh:<target>"]` while the scoped listing
+ * reported `[]`.
+ *
+ * Naming the single host the caller asked about costs nothing when rows come back — it lands in
+ * `covered`, so it is never reported omitted — and is the whole answer when they do not.
+ */
+export function listingKnownHostIds(
+  scopedRepo: Repo | null,
+  listKnownHostIds: () => Iterable<ExecutionHostId>
+): Iterable<ExecutionHostId> {
+  return scopedRepo ? [getRepoExecutionHostId(scopedRepo)] : listKnownHostIds()
 }


### PR DESCRIPTION
## ELI5

Ask Orca to list the worktrees for one repo, and it used to say "no worktrees" whether the repo really had none or whether it never managed to reach the machine the repo lives on. Those two answers were byte-identical. Now, when it comes back empty, it names the host it was supposed to look at.

## What Changed

`orca worktree list --repo <id>` passed `[]` as `knownHostIds` to `buildWorktreeListingPage`, so a scoped listing **could never report a gap — for any host kind, reachable or not.** `covered` and `omitted` are both derived from the returned rows plus that list, so with zero matched rows both come back empty:

```json
{"hostIds": [], "omittedHostIds": []}
```

A scoped listing now names the one host the caller asked about (`listingKnownHostIds` in `worktree-listing-host-scope.ts`). Hosts the caller scoped out are still never named.

## Why

`docs/reference/ssh-execution-boundary.md` forbids a listing from implying that a host it could not reach has nothing on it. Measured on one runtime with one refusing SSH host, in the same second:

```
UNSCOPED   totalCount 0   omittedHostIds ["local","ssh:ssh-scope-refused"]  (+ --host selectors)
SCOPED     totalCount 0   hostScope {"hostIds":[],"omittedHostIds":[]}
```

And against a live profile, same instant: unscoped named **9** omitted hosts, six scoped listings named **0**. One runtime giving two contradictory answers about its own coverage.

Costs nothing when rows come back — the host lands in `covered`, so it is never reported omitted — and is the whole answer when they don't.

## Linked Issue

Related to #18595 (the reporter's `worktree list` returning `[]` on the client). Not a full fix for that issue, so no `Fixes #`: this addresses the *reporting* of the gap, not whatever caused the underlying scan to come back empty. Filing as a standalone defect at the lead's direction.

## Visual Proof

`N/A` — CLI/RPC field only, no UI surface. Every renderer gate on `omittedHostIds` reads `terminal.list`, not `worktree.list` (verified: `host-live-terminal-probe.ts:80`, `web-session-terminal-orphan-recovery-inventory.ts:168`, `worktree-live-terminal-surface-owners.ts:118`). The before/after is the JSON above.

## Testing

Reproduced on hardware before fixing, using a scratch profile so the live profile was untouched (verified by content invariant — 13 repos, `sshTargets: ['openclaw']` — before and after):

1. Scratch dir seeded **before first launch**: `orca-profile-index.json`, plus `profiles/local-default/orca-data.json` with one `sshTargets` entry `{host:"127.0.0.1", port:1}`, one repo carrying its `connectionId`, and `"worktreeMeta": {}`.
2. `open -n -a /Applications/Orca.app --args --user-data-dir=<scratch>`
3. `ORCA_USER_DATA_PATH=<scratch> orca worktree list --repo <id> --json`

**Use a host that REFUSES, not one paused or firewalled.** A hang takes the `withTimeout` fallback to stored rows and reads as "no defect" — a false negative that would close this wrongly. Verify with `nc -z 127.0.0.1 1` first.

Two traps for anyone reusing that recipe: `ORCA_USER_DATA_PATH` aims the **CLI** only (the app needs `--user-data-dir`; setting the env var alone hits the live profile's single-instance lock), and a **hash is not a valid untouched-oracle** for a live profile — it changed three times in two minutes with nothing acting on it.

Platforms: macOS host, SSH remote (refusing Linux target). Not exercised on Windows or WSL; the changed code is host-kind agnostic.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

**Revert-tested in both directions.** 4 of 6 tests fail with the fix reverted; the other 2 are regression guards and I am not claiming otherwise:

| revert | failing tests |
|---|---|
| back to `[]` (the bug) | names the scoped repo host as omitted…; never names a host the caller scoped out; names the local host…; prefers executionHostId… |
| **over-fix**: name every configured host when scoped | names the scoped repo host as omitted…; never names a host the caller scoped out |

That second row is the point: **the obvious over-correction is rejected by a test rather than by assertion.**

`pnpm tc`, `oxlint`, `check:code-quality:changed` (0 findings), `check:max-lines-ratchet` (no new bypasses) clean. 1594 test files / 16994 tests pass across `src/main/runtime`, `src/main/ipc`, `src/shared`.

## AI Disclosure

Internal contributor — section not applicable.

## Review

Reviewed against the `readiness-checklist` skill. Candidate verdict PASS, no P0/P1. Consumers of `hostScope` traced across CLI, renderer, paired web, mobile, docs and the cross-version wire suite: the only reader of the **worktree**-listing scope is the CLI's informational scope line; nothing gates, retries or errors on it. Mobile has zero references.

**Wire:** Rule 3 in principle — same shape, different content — and safe, because no client reacts to `worktree.list`'s `omittedHostIds` beyond rendering it, and older clients that predate `hostScope` ignore the key. No persisted state touched. No mobile-facing surface touched.

**Known behaviour this introduces, stated plainly:** a scoped repo whose scan *succeeded* but returned zero visible rows is now also reported as `not covered`. Row-derived coverage cannot distinguish "reached and empty" from "not reached" — the unscoped path has the same conflation. It errs toward `unverifiable`, which is the direction the boundary doc sanctions, but it is a real consequence, not a free win. Distinguishing the two needs `scan.ok` threaded from `repo-worktree-row-resolution.ts` through the resolved-worktree snapshot; that is a larger change and deliberately not in this PR.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Security: none — no new I/O, no user input parsed. Cross-platform: host-kind agnostic; no path, shell or process handling. Remote SSH: this is the SSH-facing fix. Mobile: no surface touched. Backwards compatibility: see Review. Performance: `getRepoExecutionHostId` is a field read; the unscoped host list is passed as a thunk so it is not evaluated on the scoped path.

**Known limitation, deliberately not fixed here:** `buildWorktreeListingHostScope` is host-granular by construction — `covered` and `omitted` are both `Set<ExecutionHostId>`, so "repo X on host H was not covered" is unrepresentable. With an unreachable repo *and* a reachable repo on the same host, the host lands in `hostIds` and the unreachable repo's gap is masked. Fixing it means changing a type the CLI, mobile and paired web all read — a wire-visible shape change needing its own decision. Recorded as a design constraint, not an oversight.

Note for future edits to `runtime-managed-worktree-queries.ts`: it sits ~1 line under the 300 cap. `max-lines` here is `{skipBlankLines: true, skipComments: true}`, so **a comment-padded positive control proves nothing** — pad with real code when testing that rule.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof (CLI/RPC field, no UI surface)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck`, `oxlint`, and the affected `pnpm test` suites pass locally; CI covers the rest
