### PR TITLE
perf(sidebar): share one natural-worktree-id scan and drop a redundant row-key join

### DIFF
--- a/src/renderer/src/components/sidebar/natural-worktree-ids.test.ts
+++ b/src/renderer/src/components/sidebar/natural-worktree-ids.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { PINNED_GROUP_KEY } from './worktree-list/grouping/group-keys'
+import { getNaturalWorktreeIds } from './natural-worktree-ids'
+
+const item = (id: string, sectionKey: string) => ({
+  type: 'item' as const,
+  sectionKey,
+  worktree: { id }
+})
+
+describe('getNaturalWorktreeIds', () => {
+  it('collects item rows outside the pinned section', () => {
+    expect([...getNaturalWorktreeIds([item('a', 'group-1'), item('b', 'group-2')])]).toEqual([
+      'a',
+      'b'
+    ])
+  })
+
+  it('excludes a pinned duplicate that also renders in its natural group', () => {
+    const rows = [item('a', PINNED_GROUP_KEY), item('a', 'group-1'), item('b', PINNED_GROUP_KEY)]
+
+    const ids = getNaturalWorktreeIds(rows)
+
+    expect(ids.has('a')).toBe(true)
+    expect(ids.has('b')).toBe(false)
+  })
+
+  it('ignores every non-item row type', () => {
+    const rows = [
+      { type: 'header', key: 'k' },
+      { type: 'host-header' },
+      { type: 'imported-worktrees-card' },
+      { type: 'new-external-worktrees-inbox' },
+      { type: 'pending-creation' },
+      { type: 'folder-workspace' },
+      item('a', 'group-1')
+    ]
+
+    expect([...getNaturalWorktreeIds(rows)]).toEqual(['a'])
+  })
+
+  it('returns an empty set for no rows', () => {
+    expect(getNaturalWorktreeIds([]).size).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/natural-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/natural-worktree-ids.ts
@@ -1,0 +1,24 @@
+import { PINNED_GROUP_KEY } from './worktree-list/grouping/group-keys'
+
+/** The row shape both drag models share: only `item` rows carry a worktree and a section. */
+type NaturalWorktreeIdRow = { type: string } & Partial<{
+  sectionKey: string
+  worktree: { id: string }
+}>
+
+/**
+ * Ids of worktrees rendered in their own group.
+ *
+ * Why: a pinned duplicate of a worktree that also renders in its natural group is not its own drag
+ * slot. Shared by every drag model so the rule lives in one place, and built with a loop rather
+ * than `flatMap` — that allocated a throwaway array per row, four times per row-model rebuild.
+ */
+export function getNaturalWorktreeIds(rows: readonly NaturalWorktreeIdRow[]): Set<string> {
+  const ids = new Set<string>()
+  for (const row of rows) {
+    if (row.type === 'item' && row.sectionKey !== PINNED_GROUP_KEY && row.worktree) {
+      ids.add(row.worktree.id)
+    }
+  }
+  return ids
+}

--- a/src/renderer/src/components/sidebar/worktree-drag-units.ts
+++ b/src/renderer/src/components/sidebar/worktree-drag-units.ts
@@ -1,5 +1,6 @@
 import type { WorktreeDragGroup } from './worktree-manual-order'
 import { ALL_GROUP_KEY, PINNED_GROUP_KEY } from './worktree-list/grouping/group-keys'
+import { getNaturalWorktreeIds } from './natural-worktree-ids'
 
 export type WorktreeDragUnitGroup = WorktreeDragGroup & {
   units: { worktreeId: string; worktreeIds: string[] }[]
@@ -19,11 +20,7 @@ export function getWorktreeDragUnitGroups(
 ): WorktreeDragUnitGroup[] {
   const groups: WorktreeDragUnitGroup[] = []
   let current: { key: string; units: WorktreeDragUnitGroup['units'] } | null = null
-  const naturalWorktreeIds = new Set(
-    rows.flatMap((row) =>
-      row.type === 'item' && row.sectionKey !== PINNED_GROUP_KEY ? [row.worktree.id] : []
-    )
-  )
+  const naturalWorktreeIds = getNaturalWorktreeIds(rows)
 
   for (const row of rows) {
     if (row.type === 'header') {

--- a/src/renderer/src/components/sidebar/worktree-list/drag/groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/groups.ts
@@ -1,15 +1,7 @@
 import { ALL_GROUP_KEY, PINNED_GROUP_KEY } from '../grouping/group-keys'
+import { getNaturalWorktreeIds } from '../../natural-worktree-ids'
 import type { HostSectionRow } from '../../host-section-rows'
 import type { WorktreeDragGroup } from '../../worktree-manual-order'
-
-// A pinned duplicate of a worktree that also renders in its natural group is not its own drag slot.
-function getNaturalWorktreeIds(rows: readonly HostSectionRow[]): Set<string> {
-  return new Set(
-    rows.flatMap((row) =>
-      row.type === 'item' && row.sectionKey !== PINNED_GROUP_KEY ? [row.worktree.id] : []
-    )
-  )
-}
 
 export function getWorktreeDragGroups(rows: HostSectionRow[]): WorktreeDragGroup[] {
   const groups: WorktreeDragGroup[] = []

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-session.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-session.ts
@@ -24,6 +24,7 @@ import {
 } from '../../worktree-sidebar-drop-preview'
 import { getWorktreeDragGroups, getWorktreeDragIndexes } from './groups'
 import type { WorktreeItemRow } from '../listing/renderable-rows'
+import { getNaturalWorktreeIds } from '../../natural-worktree-ids'
 
 export type WorktreeStatusDropRequest = {
   pointerY: number
@@ -48,15 +49,7 @@ export function useWorktreeDragSession(args: {
 
   const worktreeDragGroups = useMemo(() => getWorktreeDragGroups(rows), [rows])
   const worktreeDragUnitGroups = useMemo(() => getWorktreeDragUnitGroups(rows), [rows])
-  const naturalDragWorktreeIds = useMemo(
-    () =>
-      new Set(
-        rows.flatMap((row) =>
-          row.type === 'item' && row.sectionKey !== PINNED_GROUP_KEY ? [row.worktree.id] : []
-        )
-      ),
-    [rows]
-  )
+  const naturalDragWorktreeIds = useMemo(() => getNaturalWorktreeIds(rows), [rows])
   const worktreeLineageDragRows = useMemo(
     () =>
       rows

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
@@ -51,10 +51,6 @@ export function useVirtualRowMeasurementSync(args: {
   const { virtualizer, isCurrentVirtualRowElement } = virtualization
   const prCacheLen = useAppStore((s) => countRecordKeysByReference(s.prCache))
   const issueCacheLen = useAppStore((s) => countRecordKeysByReference(s.issueCache))
-  const renderRowKeySignature = useMemo(
-    () => renderRows.map(getRenderRowKey).join('\n'),
-    [renderRows]
-  )
   const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
   const lineageRowRekeys = useMemo(() => buildLineageRowRekeyMap(renderRows), [renderRows])
   const totalSize = virtualizer.getTotalSize()
@@ -100,14 +96,7 @@ export function useVirtualRowMeasurementSync(args: {
     measureMountedRows()
     const frameId = window.requestAnimationFrame(measureMountedRows)
     return () => window.cancelAnimationFrame(frameId)
-  }, [
-    activeRenderRowKeys,
-    prCacheLen,
-    issueCacheLen,
-    measureMountedRows,
-    renderRowKeySignature,
-    virtualizer
-  ])
+  }, [activeRenderRowKeys, prCacheLen, issueCacheLen, measureMountedRows, virtualizer])
 
   useVirtualizedScrollAnchor({
     anchorRef: scrollAnchorRef,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |

<!-- /orca-pr-loc -->

## ELI5

Two bits of bookkeeping in the sidebar's worktree list.

**First**, there's a rule: a worktree pinned to the top that *also* appears in its normal group shouldn't count twice when you drag things around. Working out which worktrees are in their "natural" group was written out **four separate times** in four files — and each copy did it in a way that creates a small throwaway array for every single row, just to throw it away again. All four recompute at the same moment, so you paid for it four times over.

**Second**, the row-measuring code built a giant string of every row's key (10–24 KB) to use as a "did this change?" signal — right next to another value derived from the exact same input that already answers that question. The string could never detect a change the other one missed.

Now there's one shared helper, and the redundant string is gone.

## What Changed

**New `src/renderer/src/components/sidebar/natural-worktree-ids.ts`** — one exported `getNaturalWorktreeIds` using a plain loop:

```ts
const ids = new Set<string>()
for (const row of rows) {
  if (row.type === 'item' && row.sectionKey !== PINNED_GROUP_KEY && row.worktree) {
    ids.add(row.worktree.id)
  }
}
return ids
```

The four duplicated call sites now use it:
- `worktree-list/drag/groups.ts` — local copy deleted; it was used twice (`getWorktreeDragGroups`, `getWorktreeDragIndexes`)
- `worktree-list/drag/use-session.ts:51` — inline `useMemo` body replaced
- `worktree-drag-units.ts:23` — inline copy replaced

**`worktree-list/viewport/use-row-measurement.ts`** — `renderRowKeySignature` and its effect-dependency entry deleted.

## Why

**The four copies.** Each was `rows.flatMap(row => cond ? [row.worktree.id] : [])`. `flatMap` allocates a single-element array (or an empty one) per row before flattening — so ~423 throwaway arrays per call, ×4 calls, ≈1700 allocations per row-model rebuild. All four `useMemo` on the same `rows`, so a single rebuild triggers all four. Folding them into one helper also removes a genuine duplication hazard: the pinned-duplicate rule was stated four times and could drift.

**The signature string.** Both memos key on `[renderRows]`:

```ts
const renderRowKeySignature = useMemo(() => renderRows.map(getRenderRowKey).join('\n'), [renderRows])
const activeRenderRowKeys = useMemo(() => new Set(renderRows.map(getRenderRowKey)), [renderRows])
```

They recompute in lockstep, and `new Set(...)` always has a fresh identity — so `activeRenderRowKeys` already fires the layout effect on every `renderRows` change. Effect dependencies are OR-ed, so a second dep can only ever *add* firings, never suppress one. The signature was a second full `getRenderRowKey` pass plus a 10–24 KB string that could not change any outcome.

## Measurements

Both measured old-vs-new with output equivalence asserted, at the 423-workspace scale the repo's own ratchet targets (`store/always-mounted-selector-scan-cost.test.ts`) and at 1000:

| | 423 workspaces | 1000 workspaces |
| --- | --- | --- |
| natural-ids, **per call** | 17.3 µs → 10.6 µs (**1.63x**) | 43.9 µs → 30.3 µs (1.45x) |
| natural-ids, **across all 4 call sites** | **69.2 µs → 10.6 µs** | **175.6 µs → 30.3 µs** |
| `renderRowKeySignature` removed | **13.0 µs → 0** (10,613-char string) | **28.6 µs → 0** (24,293-char string) |

The 4-site number is the one that matters: the helper is now computed with a loop *and* the duplication means the win compounds. For context on the signature removal, the `Set` dep that remains costs 42.7 µs @423 — so ~30% of that pair's cost is gone.

## Negative user-facing trade-offs

**None.**

- **Same Set contents.** The loop applies the identical predicate (`type === 'item'` and `sectionKey !== PINNED_GROUP_KEY`) in the same order. The added `&& row.worktree` guard is a type narrowing for the shared row shape, not a behaviour change — only `item` rows carry a `worktree` in either row model.
- **Pinned-duplicate semantics preserved**, and now pinned in a test: a worktree appearing in both the pinned section and a natural group is still included; one appearing *only* in the pinned section is still excluded.
- **Drag behaviour unchanged** — `getWorktreeDragGroups`, `getWorktreeDragIndexes`, and `getWorktreeDragUnitGroups` keep their signatures and their outputs. I deliberately did **not** take the larger refactor of computing the Set once and threading it through all three as a parameter; that would change three exported signatures for a marginal extra gain.
- **Effect firing is unchanged.** The removed dep was strictly dominated by `activeRenderRowKeys`, which changes identity on every `renderRows` change. There is no input for which the string differed while the Set did not.

## Merge risk

**Low.** The natural-ids consolidation is mechanical and covered by a new test plus the existing drag suites. The part deserving a second opinion is the deleted effect dependency: I argue `renderRowKeySignature` is strictly dominated by a sibling `Set` memoized on the same input (a fresh `Set` always changes identity, and effect deps are OR-ed), so it could never fire the effect alone. If that reasoning is wrong, row measurement would under-fire.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual or interaction change. Sidebar rows, drag-and-drop slots, pinned duplicates, and row measurement all behave identically.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `src/renderer/src/components/sidebar/natural-worktree-ids.test.ts` (4 tests): collects item rows outside the pinned section; excludes a pinned duplicate while keeping one that also renders naturally; ignores every non-item row type (`header`, `host-header`, `imported-worktrees-card`, `new-external-worktrees-inbox`, `pending-creation`, `folder-workspace`); empty input.

Wider suite: `pnpm test src/renderer/src/components/sidebar` — 290 files, 2463 tests, all passing (this includes the existing drag-group and row-measurement coverage that exercises all four former call sites). `pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only, no platform-dependent behavior.

## AI Disclosure

