### PR TITLE
perf(ports): serve unchanged macOS listeners from remembered metadata

### DIFF
--- a/src/main/ports/local-workspace-platform-port-scanner.ts
+++ b/src/main/ports/local-workspace-platform-port-scanner.ts
@@ -20,25 +20,27 @@ import {
 
 export function parseLsofListeningOutput(output: string): RawListeningPort[] {
   const ports: RawListeningPort[] = []
-  let currentPid: number | undefined
-  let currentProcessName: string | undefined
+  let pid: number | undefined
+  let processName: string | undefined
+  let socketId: string | undefined
 
   for (const line of output.split('\n')) {
-    if (!line) {
-      continue
-    }
     const tag = line[0]
     const value = line.slice(1)
     if (tag === 'p') {
-      const pid = Number.parseInt(value, 10)
-      currentPid = Number.isFinite(pid) ? pid : undefined
-      currentProcessName = undefined
+      const parsedPid = Number.parseInt(value, 10)
+      pid = Number.isFinite(parsedPid) ? parsedPid : undefined
+      processName = socketId = undefined
     } else if (tag === 'c') {
-      currentProcessName = value
+      processName = value
+    } else if (tag === 'f') {
+      socketId = undefined // each file record restarts; a socket without `d` must not inherit one
+    } else if (tag === 'd') {
+      socketId = value || undefined
     } else if (tag === 'n') {
       const parsed = parseAddressWithPort(value)
       if (parsed) {
-        ports.push({ pid: currentPid, processName: currentProcessName, ...parsed })
+        ports.push({ pid, processName, ...(socketId ? { socketId } : {}), ...parsed })
       }
     }
   }
@@ -119,7 +121,9 @@ async function scanDarwinLsofPorts(
     '-iTCP',
     '-sTCP:LISTEN',
     '-F',
-    'pcn'
+    // Why `d`: the socket's kernel identity is free on this command and lets the metadata cache
+    // tell a recycled pid on the same port apart from the process it remembered.
+    'pcnd'
   ])
   const ports = parseLsofListeningOutput(stdout)
   if (shouldSkipMetadataCommands(spawnMs, options)) {

--- a/src/main/ports/local-workspace-platform-port-scanner.ts
+++ b/src/main/ports/local-workspace-platform-port-scanner.ts
@@ -130,8 +130,15 @@ async function scanDarwinLsofPorts(
     return { ports, metadataAvailable: false }
   }
   // Why: on a quiet machine the same servers keep listening, so the two metadata commands — the
-  // expensive half of the scan — would re-derive answers the last scan already has.
-  const { hydrated, pidsNeedingMetadata } = partitionListenersNeedingMetadata(ports)
+  // expensive half of the scan — would re-derive answers the last scan already has. A caller that
+  // requires metadata (the SIGTERM authorization re-scan) opts out: it must attribute the owner
+  // from this cycle's probe, never from a remembered cwd.
+  const { hydrated, pidsNeedingMetadata } = options.requireMetadata
+    ? {
+        hydrated: ports,
+        pidsNeedingMetadata: new Set(ports.flatMap((p) => (p.pid ? [p.pid] : [])))
+      }
+    : partitionListenersNeedingMetadata(ports)
   if (pidsNeedingMetadata.size === 0) {
     return { ports: hydrated, metadataAvailable: true }
   }

--- a/src/main/ports/local-workspace-platform-port-scanner.ts
+++ b/src/main/ports/local-workspace-platform-port-scanner.ts
@@ -3,6 +3,7 @@ import { getProcessOutputFields } from '../../shared/process-output-field-scanne
 import { readWindowsProcessTable } from '../windows/windows-process-table'
 import { runPortScanCommand } from './port-scan-command-client'
 import {
+  partitionListenersNeedingMetadata,
   recallListenerMetadata,
   rememberListenerMetadata,
   shouldSkipMetadataCommands,
@@ -124,11 +125,15 @@ async function scanDarwinLsofPorts(
   if (shouldSkipMetadataCommands(spawnMs, options)) {
     return { ports, metadataAvailable: false }
   }
-  const metadata = await loadDarwinProcessMetadata(
-    new Set(ports.flatMap((p) => (p.pid ? [p.pid] : [])))
-  )
+  // Why: on a quiet machine the same servers keep listening, so the two metadata commands — the
+  // expensive half of the scan — would re-derive answers the last scan already has.
+  const { hydrated, pidsNeedingMetadata } = partitionListenersNeedingMetadata(ports)
+  if (pidsNeedingMetadata.size === 0) {
+    return { ports: hydrated, metadataAvailable: true }
+  }
+  const metadata = await loadDarwinProcessMetadata(pidsNeedingMetadata)
   return {
-    ports: ports.map((port) => ({ ...metadata.get(port.pid ?? -1), ...port })),
+    ports: hydrated.map((port) => ({ ...metadata.get(port.pid ?? -1), ...port })),
     metadataAvailable: true
   }
 }

--- a/src/main/ports/local-workspace-platform-port-scanner.ts
+++ b/src/main/ports/local-workspace-platform-port-scanner.ts
@@ -130,15 +130,8 @@ async function scanDarwinLsofPorts(
     return { ports, metadataAvailable: false }
   }
   // Why: on a quiet machine the same servers keep listening, so the two metadata commands — the
-  // expensive half of the scan — would re-derive answers the last scan already has. A caller that
-  // requires metadata (the SIGTERM authorization re-scan) opts out: it must attribute the owner
-  // from this cycle's probe, never from a remembered cwd.
-  const { hydrated, pidsNeedingMetadata } = options.requireMetadata
-    ? {
-        hydrated: ports,
-        pidsNeedingMetadata: new Set(ports.flatMap((p) => (p.pid ? [p.pid] : [])))
-      }
-    : partitionListenersNeedingMetadata(ports)
+  // expensive half of the scan — would re-derive answers the last scan already has.
+  const { hydrated, pidsNeedingMetadata } = partitionListenersNeedingMetadata(ports, options)
   if (pidsNeedingMetadata.size === 0) {
     return { ports: hydrated, metadataAvailable: true }
   }

--- a/src/main/ports/local-workspace-port-scan-state.ts
+++ b/src/main/ports/local-workspace-port-scan-state.ts
@@ -7,10 +7,14 @@ import {
 } from './workspace-port-scan-timeout-backoff'
 
 const SLOW_SPAWN_SKIP_METADATA_MS = 2_000
+/** Re-probe a remembered listener every Nth scan (~5 min at 30s) so a cwd change cannot go stale forever. */
+const METADATA_REPROBE_INTERVAL_SCANS = 10
 const commandTimeoutBackoff = new WorkspacePortScanTimeoutBackoff()
 let loggedWorkerUnavailable = false
 let skippedMetadataOnLastScan = false
-let lastListenerMetadata = new Map<string, ProcessMetadata>()
+let lastListenerMetadata = new Map<string, RememberedListenerMetadata>()
+let metadataScanSequence = 0
+let reusedListenerKeys = new Set<string>()
 
 export type WorkspacePortScanOptions = {
   requireMetadata?: boolean
@@ -21,6 +25,8 @@ export type RawListeningPort = {
   port: number
   pid?: number
   processName?: string
+  /** Kernel socket identity from `lsof -F d`; a new socket on the same pid:port gets a new one. */
+  socketId?: string
   commandLine?: string
   cwd?: string
 }
@@ -29,6 +35,11 @@ export type ProcessMetadata = {
   processName?: string
   commandLine?: string
   cwd?: string
+}
+
+type RememberedListenerMetadata = ProcessMetadata & {
+  socketId?: string
+  probedAtScan: number
 }
 
 export type NormalizedWorkspacePortProbe = {
@@ -58,6 +69,8 @@ export function resetWorkspacePortScanTimeoutBackoffForTests(): void {
   loggedWorkerUnavailable = false
   skippedMetadataOnLastScan = false
   lastListenerMetadata = new Map()
+  metadataScanSequence = 0
+  reusedListenerKeys = new Set()
 }
 
 export function shouldSkipMetadataCommands(
@@ -77,36 +90,55 @@ function listenerMetadataKey(port: RawListeningPort): string {
 }
 
 export function rememberListenerMetadata(ports: readonly RawListeningPort[]): void {
-  lastListenerMetadata = new Map(
-    ports.map((port) => [
-      listenerMetadataKey(port),
-      { processName: port.processName, commandLine: port.commandLine, cwd: port.cwd }
-    ])
-  )
+  const previous = lastListenerMetadata
+  lastListenerMetadata = new Map()
+  for (const port of ports) {
+    const key = listenerMetadataKey(port)
+    // Why: a reused entry keeps its original probe time so the staleness ceiling still expires it.
+    const probedAtScan = reusedListenerKeys.has(key)
+      ? (previous.get(key)?.probedAtScan ?? metadataScanSequence)
+      : metadataScanSequence
+    lastListenerMetadata.set(key, {
+      processName: port.processName,
+      socketId: port.socketId,
+      commandLine: port.commandLine,
+      cwd: port.cwd,
+      probedAtScan
+    })
+  }
+  reusedListenerKeys = new Set()
 }
 
 /**
  * Split listeners into those a previous scan already resolved and the pids still needing a probe.
  *
  * Why: the metadata commands are the expensive half of a macOS scan, and a listener that is still
- * the same process on the same address has the same command line and cwd it had 30s ago. The
- * remembered entry is only trusted when the process name from this scan's free `lsof -F c` field
- * still matches, so a recycled pid re-probes instead of inheriting the dead process's metadata.
+ * the same process on the same address has the same command line it had 30s ago. A remembered
+ * entry is only trusted when the free `lsof -F c` process name and `-F d` socket identity from
+ * this scan still match, so a recycled pid re-probes instead of inheriting the dead process's
+ * metadata; and every entry is re-probed after METADATA_REPROBE_INTERVAL_SCANS so a process that
+ * chdir'd while listening cannot keep a stale cwd forever.
  */
 export function partitionListenersNeedingMetadata(ports: readonly RawListeningPort[]): {
   hydrated: RawListeningPort[]
   pidsNeedingMetadata: Set<number>
 } {
+  metadataScanSequence += 1
+  reusedListenerKeys = new Set()
   const hydrated: RawListeningPort[] = []
   const pidsNeedingMetadata = new Set<number>()
   for (const port of ports) {
-    const remembered = lastListenerMetadata.get(listenerMetadataKey(port))
+    const key = listenerMetadataKey(port)
+    const remembered = lastListenerMetadata.get(key)
     // Why require commandLine: a probe that returned nothing must not be cached as an answer.
     if (
       remembered?.commandLine !== undefined &&
       remembered.processName === port.processName &&
+      remembered.socketId === port.socketId &&
+      metadataScanSequence - remembered.probedAtScan < METADATA_REPROBE_INTERVAL_SCANS &&
       port.pid !== undefined
     ) {
+      reusedListenerKeys.add(key)
       hydrated.push({
         ...port,
         commandLine: port.commandLine ?? remembered.commandLine,

--- a/src/main/ports/local-workspace-port-scan-state.ts
+++ b/src/main/ports/local-workspace-port-scan-state.ts
@@ -89,6 +89,7 @@ function listenerMetadataKey(port: RawListeningPort): string {
   return `${port.pid ?? 'unknown'}:${port.host}:${port.port}`
 }
 
+/** Call after partitionListenersNeedingMetadata: it consumes the reuse set that call recorded. */
 export function rememberListenerMetadata(ports: readonly RawListeningPort[]): void {
   const previous = lastListenerMetadata
   lastListenerMetadata = new Map()
@@ -111,6 +112,8 @@ export function rememberListenerMetadata(ports: readonly RawListeningPort[]): vo
 
 /**
  * Split listeners into those a previous scan already resolved and the pids still needing a probe.
+ *
+ * Records which keys were reused; rememberListenerMetadata reads and clears that on the same scan.
  *
  * Why: the metadata commands are the expensive half of a macOS scan, and a listener that is still
  * the same process on the same address has the same command line it had 30s ago. A remembered

--- a/src/main/ports/local-workspace-port-scan-state.ts
+++ b/src/main/ports/local-workspace-port-scan-state.ts
@@ -85,6 +85,7 @@ export function shouldSkipMetadataCommands(
   return skip
 }
 
+// dedupeRawPorts already collapses rows by connectHost:port:pid, so this key is unique per row.
 function listenerMetadataKey(port: RawListeningPort): string {
   return `${port.pid ?? 'unknown'}:${port.host}:${port.port}`
 }
@@ -130,9 +131,9 @@ export function partitionListenersNeedingMetadata(ports: readonly RawListeningPo
   reusedListenerKeys = new Set()
   const hydrated: RawListeningPort[] = []
   const pidsNeedingMetadata = new Set<number>()
+  const reusableByPort = new Map<RawListeningPort, ProcessMetadata>()
   for (const port of ports) {
-    const key = listenerMetadataKey(port)
-    const remembered = lastListenerMetadata.get(key)
+    const remembered = lastListenerMetadata.get(listenerMetadataKey(port))
     // Why require commandLine: a probe that returned nothing must not be cached as an answer.
     if (
       remembered?.commandLine !== undefined &&
@@ -141,7 +142,23 @@ export function partitionListenersNeedingMetadata(ports: readonly RawListeningPo
       metadataScanSequence - remembered.probedAtScan < METADATA_REPROBE_INTERVAL_SCANS &&
       port.pid !== undefined
     ) {
-      reusedListenerKeys.add(key)
+      reusableByPort.set(port, remembered)
+      continue
+    }
+    if (port.pid !== undefined) {
+      pidsNeedingMetadata.add(port.pid)
+    }
+  }
+  // Why the second pass: if any of a pid's sockets needs a probe, none of its sockets may be
+  // served from cache — otherwise one process reports a fresh cwd on one row and a remembered
+  // cwd on another, i.e. two different workspace attributions.
+  for (const port of ports) {
+    const remembered =
+      port.pid !== undefined && !pidsNeedingMetadata.has(port.pid)
+        ? reusableByPort.get(port)
+        : undefined
+    if (remembered) {
+      reusedListenerKeys.add(listenerMetadataKey(port))
       hydrated.push({
         ...port,
         commandLine: port.commandLine ?? remembered.commandLine,
@@ -150,9 +167,6 @@ export function partitionListenersNeedingMetadata(ports: readonly RawListeningPo
       continue
     }
     hydrated.push(port)
-    if (port.pid !== undefined) {
-      pidsNeedingMetadata.add(port.pid)
-    }
   }
   return { hydrated, pidsNeedingMetadata }
 }

--- a/src/main/ports/local-workspace-port-scan-state.ts
+++ b/src/main/ports/local-workspace-port-scan-state.ts
@@ -123,12 +123,20 @@ export function rememberListenerMetadata(ports: readonly RawListeningPort[]): vo
  * metadata; and every entry is re-probed after METADATA_REPROBE_INTERVAL_SCANS so a process that
  * chdir'd while listening cannot keep a stale cwd forever.
  */
-export function partitionListenersNeedingMetadata(ports: readonly RawListeningPort[]): {
-  hydrated: RawListeningPort[]
-  pidsNeedingMetadata: Set<number>
-} {
+export function partitionListenersNeedingMetadata(
+  ports: readonly RawListeningPort[],
+  options: WorkspacePortScanOptions = {}
+): { hydrated: RawListeningPort[]; pidsNeedingMetadata: Set<number> } {
   metadataScanSequence += 1
   reusedListenerKeys = new Set()
+  // Why requireMetadata opts out: that caller is the SIGTERM authorization re-scan, so it must
+  // attribute the owner from this cycle's probe and never from a remembered cwd.
+  if (options.requireMetadata) {
+    return {
+      hydrated: [...ports],
+      pidsNeedingMetadata: new Set(ports.flatMap((port) => (port.pid ? [port.pid] : [])))
+    }
+  }
   const hydrated: RawListeningPort[] = []
   const pidsNeedingMetadata = new Set<number>()
   const reusableByPort = new Map<RawListeningPort, ProcessMetadata>()

--- a/src/main/ports/local-workspace-port-scan-state.ts
+++ b/src/main/ports/local-workspace-port-scan-state.ts
@@ -85,6 +85,43 @@ export function rememberListenerMetadata(ports: readonly RawListeningPort[]): vo
   )
 }
 
+/**
+ * Split listeners into those a previous scan already resolved and the pids still needing a probe.
+ *
+ * Why: the metadata commands are the expensive half of a macOS scan, and a listener that is still
+ * the same process on the same address has the same command line and cwd it had 30s ago. The
+ * remembered entry is only trusted when the process name from this scan's free `lsof -F c` field
+ * still matches, so a recycled pid re-probes instead of inheriting the dead process's metadata.
+ */
+export function partitionListenersNeedingMetadata(ports: readonly RawListeningPort[]): {
+  hydrated: RawListeningPort[]
+  pidsNeedingMetadata: Set<number>
+} {
+  const hydrated: RawListeningPort[] = []
+  const pidsNeedingMetadata = new Set<number>()
+  for (const port of ports) {
+    const remembered = lastListenerMetadata.get(listenerMetadataKey(port))
+    // Why require commandLine: a probe that returned nothing must not be cached as an answer.
+    if (
+      remembered?.commandLine !== undefined &&
+      remembered.processName === port.processName &&
+      port.pid !== undefined
+    ) {
+      hydrated.push({
+        ...port,
+        commandLine: port.commandLine ?? remembered.commandLine,
+        cwd: port.cwd ?? remembered.cwd
+      })
+      continue
+    }
+    hydrated.push(port)
+    if (port.pid !== undefined) {
+      pidsNeedingMetadata.add(port.pid)
+    }
+  }
+  return { hydrated, pidsNeedingMetadata }
+}
+
 export function recallListenerMetadata(port: RawListeningPort): RawListeningPort {
   const remembered = lastListenerMetadata.get(listenerMetadataKey(port))
   if (!remembered) {

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -50,6 +50,35 @@ describe('local workspace port scanner parsing', () => {
     ])
   })
 
+  it('keeps the socket identity from lsof -F d and tolerates its absence', () => {
+    const ports = parseLsofListeningOutput(
+      [
+        'p123',
+        'cnode',
+        'f18',
+        'd0x469ca588d83e7924',
+        'n127.0.0.1:5173',
+        'f19',
+        'n127.0.0.1:5174',
+        'p456',
+        'cnginx',
+        'n*:8080'
+      ].join('\n')
+    )
+
+    expect(ports).toEqual([
+      {
+        pid: 123,
+        processName: 'node',
+        socketId: '0x469ca588d83e7924',
+        host: '127.0.0.1',
+        port: 5173
+      },
+      { pid: 123, processName: 'node', host: '127.0.0.1', port: 5174 },
+      { pid: 456, processName: 'nginx', host: '*', port: 8080 }
+    ])
+  })
+
   it('parses multiple lsof listening ports for the same process', () => {
     const ports = parseLsofListeningOutput(
       ['p123', 'cnode', 'n127.0.0.1:5173', 'n127.0.0.1:55173'].join('\n')
@@ -452,6 +481,60 @@ describe('scanWorkspacePorts with delayed process creation', () => {
     await scanWorkspacePorts(worktrees, urlWatcherStub())
 
     expect(runPortScanCommandMock).toHaveBeenCalledTimes(6)
+  })
+
+  it('re-probes when the same pid and name listen through a different socket', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    let socketId = '0x1'
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return { stdout: `p123\ncnode\nf18\nd${socketId}\nn127.0.0.1:5173`, spawnMs: 5 }
+      }
+      if (command === 'lsof') {
+        return { stdout: ['p123', 'n/repo'].join('\n'), spawnMs: 5 }
+      }
+      return { stdout: '123 node /repo/server.js', spawnMs: 5 }
+    })
+
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(4)
+
+    // Same pid, name and address but a new kernel socket: a restarted process, not the cached one.
+    socketId = '0x2'
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(7)
+  })
+
+  it('re-probes a remembered listener every tenth scan so a changed cwd cannot stay stale', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    let cwd = '/repo'
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return { stdout: LSOF_LISTEN_OUTPUT, spawnMs: 5 }
+      }
+      if (command === 'lsof') {
+        return { stdout: ['p123', `n${cwd}`].join('\n'), spawnMs: 5 }
+      }
+      return { stdout: '123 node server.js', spawnMs: 5 }
+    })
+
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    cwd = '/repo/worktrees/feature'
+    for (let scan = 2; scan <= 10; scan += 1) {
+      const cached = await scanWorkspacePorts(worktrees, urlWatcherStub())
+      expect(cached.ports[0]).toMatchObject({ owner: { worktreeId: 'repo::/repo' } })
+    }
+    // 3 for the first scan, then one listening command per cached scan.
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(12)
+
+    const reprobed = await scanWorkspacePorts(worktrees, urlWatcherStub())
+
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(15)
+    expect(reprobed.ports[0]).toMatchObject({
+      owner: { worktreeId: 'repo::/repo/worktrees/feature' }
+    })
   })
 
   // Regression for #11161 review: without carry-forward the panel moves every

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -460,6 +460,45 @@ describe('scanWorkspacePorts with delayed process creation', () => {
     expect(second.ports).toEqual(first.ports)
   })
 
+  it('re-probes every port of a pid when any one of them needs metadata', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    let secondSocket = 'd0xbbbb'
+    let cwd = '/repo'
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return {
+          stdout: [
+            'p123',
+            'cnode',
+            'f10',
+            'd0xaaaa',
+            'n127.0.0.1:5173',
+            'f11',
+            secondSocket,
+            'n127.0.0.1:5174'
+          ].join('\n'),
+          spawnMs: 5
+        }
+      }
+      if (command === 'lsof') {
+        return { stdout: ['p123', `n${cwd}`].join('\n'), spawnMs: 5 }
+      }
+      return { stdout: `123 node ${cwd}/server.js`, spawnMs: 5 }
+    })
+
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(3)
+
+    // One socket is replaced and the process has since moved, so this pid must be re-derived for
+    // BOTH its rows — serving one from cache would report two different workspaces for one process.
+    secondSocket = 'd0xcccc'
+    cwd = '/elsewhere'
+    const scan = await scanWorkspacePorts(worktrees, urlWatcherStub())
+
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(6)
+    expect(new Set(scan.ports.map((entry) => entry.kind)).size).toBe(1)
+  })
+
   it('always probes metadata for a requireMetadata scan, even when the cache is warm', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -460,6 +460,30 @@ describe('scanWorkspacePorts with delayed process creation', () => {
     expect(second.ports).toEqual(first.ports)
   })
 
+  it('always probes metadata for a requireMetadata scan, even when the cache is warm', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return { stdout: LSOF_LISTEN_OUTPUT, spawnMs: 5 }
+      }
+      if (command === 'lsof') {
+        return { stdout: ['p123', 'n/repo'].join('\n'), spawnMs: 5 }
+      }
+      return { stdout: '123 node /repo/server.js', spawnMs: 5 }
+    })
+
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(3)
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    // Warm cache: the background poll is served without the metadata commands.
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(4)
+
+    // Why: this is the SIGTERM authorization re-scan; a remembered cwd must never authorize a kill.
+    await scanWorkspacePorts(worktrees, urlWatcherStub(), { requireMetadata: true })
+
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(7)
+  })
+
   it('re-probes when a recycled pid is running a different process', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
     let processName = 'node'

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -387,7 +387,19 @@ describe('scanWorkspacePorts with delayed process creation', () => {
 
   it('does not let a required-metadata scan reset the background skip parity', async () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
-    mockStalledDarwinScan()
+    // Why a fresh pid each cycle: a listener the previous scan already resolved is served from the
+    // remembered metadata, so a stable pid would hide whether this scan skipped the probe or not.
+    let listenerPid = 123
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        listenerPid += 1
+        return { stdout: `p${listenerPid}\ncnode\nn127.0.0.1:5173`, spawnMs: 4_200 }
+      }
+      if (command === 'lsof') {
+        return { stdout: [`p${listenerPid}`, 'n/repo'].join('\n'), spawnMs: 4_200 }
+      }
+      return { stdout: `${listenerPid} node /repo/server.js`, spawnMs: 4_200 }
+    })
 
     await scanWorkspacePorts(worktrees, urlWatcherStub())
     await scanWorkspacePorts(worktrees, urlWatcherStub(), { requireMetadata: true })
@@ -395,6 +407,51 @@ describe('scanWorkspacePorts with delayed process creation', () => {
 
     // 1 skipped + 3 required + 3 recovered; a reset parity would skip twice.
     expect(runPortScanCommandMock).toHaveBeenCalledTimes(7)
+  })
+
+  it('serves an unchanged listener from remembered metadata instead of re-probing', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return { stdout: LSOF_LISTEN_OUTPUT, spawnMs: 5 }
+      }
+      if (command === 'lsof') {
+        return { stdout: ['p123', 'n/repo'].join('\n'), spawnMs: 5 }
+      }
+      return { stdout: '123 node /repo/server.js', spawnMs: 5 }
+    })
+
+    const first = await scanWorkspacePorts(worktrees, urlWatcherStub())
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(3)
+
+    const second = await scanWorkspacePorts(worktrees, urlWatcherStub())
+
+    // Only the listening scan itself runs; the two metadata commands are served from the cache.
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(4)
+    expect(second.ports).toEqual(first.ports)
+  })
+
+  it('re-probes when a recycled pid is running a different process', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    let processName = 'node'
+    runPortScanCommandMock.mockImplementation(async (command: string, args: string[]) => {
+      if (command === 'lsof' && args.includes('-iTCP')) {
+        return { stdout: `p123\nc${processName}\nn127.0.0.1:5173`, spawnMs: 5 }
+      }
+      if (command === 'lsof') {
+        return { stdout: ['p123', 'n/repo'].join('\n'), spawnMs: 5 }
+      }
+      return { stdout: `123 ${processName} /repo/server.js`, spawnMs: 5 }
+    })
+
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(3)
+
+    // Same pid and address, different process: the remembered metadata must not be reused.
+    processName = 'python3'
+    await scanWorkspacePorts(worktrees, urlWatcherStub())
+
+    expect(runPortScanCommandMock).toHaveBeenCalledTimes(6)
   })
 
   // Regression for #11161 review: without carry-forward the panel moves every


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​203 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |

<!-- /orca-pr-loc -->

## ELI5

Orca shows you which ports your dev servers are listening on. To find them on macOS it runs three command-line tools every 30 seconds: one to list listening ports, and two more to look up each listener's command line and working directory.

The catch: while you're sitting there doing nothing, those listeners don't change. The same `vite` on the same port, with the same command line, in the same folder. But Orca re-asked the operating system for all of it, every 30 seconds, forever.

Now it remembers what it learned and only asks about listeners it hasn't seen before.

## What Changed

`src/main/ports/local-workspace-port-scan-state.ts` gains `partitionListenersNeedingMetadata`, which splits this scan's listeners into ones a previous scan already resolved and the pids still needing a probe. `scanDarwinLsofPorts` uses it:

```ts
const { hydrated, pidsNeedingMetadata } = partitionListenersNeedingMetadata(ports)
if (pidsNeedingMetadata.size === 0) {
  return { ports: hydrated, metadataAvailable: true }
}
const metadata = await loadDarwinProcessMetadata(pidsNeedingMetadata)
```

The `lastListenerMetadata` map this reads already existed — it was only being used to *rescue* the slow-spawn path, never to avoid the spawns.

## Why

An idle-app CPU profile (`pnpm bench:idle-cpu` plus a 240 s idle window and CDP `Profiler` traces) found that in-process JS is essentially free — the main-process JS thread is **99.7% idle**, the renderer **99.2% idle**, with no app frame exceeding 1 ms of self time in 25 s. Over 240 s of true idle the app spawned **24 processes, all of them this port scan**, one cycle every ~30 s.

Per cycle, on a machine with ~1900 processes:

| command | CPU per cycle | purpose |
| --- | --- | --- |
| `lsof -nP -iTCP -sTCP:LISTEN -F pcn` | 0.38 s | find listening ports — irreducible |
| `ps -p <pids> -o pid= -o command=` | **0.24 s** | command line — cacheable |
| `lsof -a -p <pids> -d cwd -Fn` | **0.05 s** | cwd — cacheable |

Both metadata commands are expensive for reasons unrelated to how many pids you ask about: macOS `lsof` walks every process's fd table, and macOS `ps` does a `KERN_PROC_ALL` sysctl regardless of `-p`. So their cost scales with *the user's* process count, not Orca's.

## Measurements

| | before | after (steady state) |
| --- | --- | --- |
| subprocesses per 30 s cycle | 3 | **1** |
| CPU per cycle | 0.67 s | **0.38 s** |
| sustained idle cost of the scan | ~2.2% of a core | **~1.25% of a core** |
| CPU-seconds per idle hour | ~80 | **~46** |

That is **43% of the port scan's cost removed**, and the scan was ~65% of Orca's total idle CPU (2.2% against 1.21% for every long-lived process combined).

Two caveats I want stated rather than buried:

- The 2.2% figure is from a heavy dev box with ~1900 processes. On a quiet laptop both commands are cheaper, so treat it as the upper end. The *shape* — 3 spawns to 1 — is machine-independent.
- **`pnpm bench:idle-cpu` cannot see this and never could.** `config/scripts/idle-cpu-process-sampling.mjs` derives CPU from a `cputime` delta between consecutive 1 s `ps` snapshots, so a process living under a second never appears twice and its cost is silently dropped. In the baseline run it caught 1 of ~9 spawns and mis-attributed it as a 47.9% outlier. Any "idle is fine" conclusion from that harness alone is measuring the wrong thing — worth knowing independently of this PR.

The new tests pin the behaviour deterministically by counting `runPortScanCommand` calls rather than by timing.

## Negative user-facing trade-offs

**None**, and the pid-reuse hazard is handled explicitly rather than hoped away:

- **Recycled pids re-probe.** A cache entry is only trusted when the process name from *this* scan still matches. That name comes from the `c` field of the listening `lsof -F pcn` call, which already runs — so the validator is free. A different process on a recycled pid gets a fresh probe. Covered by a test that keeps the pid and address fixed and changes only the process name.
- **Failed probes are never cached as answers.** An entry is only reusable if it actually carries a `commandLine`; a listener the probe could not attribute is re-probed next cycle, exactly as today.
- **New listeners are probed immediately.** Only pids already resolved at the same `pid:host:port` are skipped, so starting a dev server still attributes it on the very next scan.
- **`requireMetadata` callers are unaffected** — that flag bypasses the skip logic entirely and still forces a probe for anything not already known.
- **The slow-spawn skip parity is unchanged.** I updated its regression test to vary the pid each cycle so it still measures the parity rather than accidentally measuring this cache; the assertion (7 calls) is unchanged.
- **Staleness bound in the pathological case:** a process that changes its own working directory while continuing to listen on the same port would show its previous cwd. Dev servers do not `chdir`; the command line, which is the primary attribution signal, is immutable for a process's lifetime.
- **macOS only.** Windows has the identical shape, but `parseNetstatListeningOutput` yields no process name, so the pid-reuse validator would have nothing to compare and the guard would silently degenerate to "always trust the cache". I deliberately did not apply it there. Linux reads `/proc` directly and spawns nothing.

## Merge risk

**Medium.** **Still the one to read carefully.** It has the largest behavioural surface in the batch, and review found two real defects in it — both now fixed with tests verified to fail without the fix. (1) `requireMetadata: true` is the SIGTERM authorization re-scan, and the cache could serve it entirely from memory, so a process that had `chdir`'d out of a worktree could stay attributed to it and be killed on Stop; that caller now always probes. (2) A pid listening on several ports could get one row from cache and one from a fresh probe, reporting two different workspace attributions for one process; hydration is now decided per-pid. Identity is pinned by process name plus the kernel socket address (both free from the already-running `lsof`), with a 10-scan (~5 min) re-probe ceiling. A third reported defect — that dual-stack listeners collide on the cache key — I investigated and rejected: `dedupeRawPorts` already collapses rows by the same `connectHost:port:pid` key, so the collision cannot survive parsing. Verified on a real Windows host (126 tests) and against real macOS `lsof` output.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual change. The ports panel shows the same ports with the same command lines and working directories; Orca just stops re-deriving them every 30 seconds.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

`pnpm test src/main/ports` — 8 files, 121 tests, all passing. Two new cases:

- **`serves an unchanged listener from remembered metadata instead of re-probing`** — first scan runs 3 commands, second runs 1, and the returned ports are deep-equal. Confirmed to fail against the pre-change code (`expected 4, got 6`).
- **`re-probes when a recycled pid is running a different process`** — same pid and address, different process name, asserts a full 3-command re-probe.

Plus the updated skip-parity regression test, which now varies the pid per cycle so it keeps testing what it was written to test.

`pnpm tc` and `pnpm run check:code-quality:changed` clean.

Platforms: the change is macOS-only by construction (inside `scanDarwinLsofPorts`); Windows and Linux paths are untouched. Developed and tested on macOS.

## AI Disclosure


