### PR TITLE
perf(settings): commit free-text account settings on a debounce, not per keystroke

### DIFF
--- a/src/renderer/src/components/settings/DebouncedSettingsTextInput.tsx
+++ b/src/renderer/src/components/settings/DebouncedSettingsTextInput.tsx
@@ -1,0 +1,39 @@
+import type React from 'react'
+import { Input } from '../ui/input'
+import { useDebouncedSettingsTextDraft } from './use-debounced-settings-text-draft'
+
+type DebouncedSettingsTextInputProps = Omit<
+  React.ComponentProps<typeof Input>,
+  'value' | 'onChange' | 'onBlur'
+> & {
+  value: string
+  commit: (next: string) => void
+  onEdit?: () => void
+}
+
+/**
+ * Text input for a free-text setting, committed on a debounce instead of per keystroke.
+ *
+ * Why a component and not a hook at the call site: the account sections are render functions the
+ * settings search calls conditionally, so hooks cannot live in them. Rendering this as JSX gives
+ * the draft its own component to mount and unmount with.
+ */
+export function DebouncedSettingsTextInput({
+  value,
+  commit,
+  onEdit,
+  ...inputProps
+}: DebouncedSettingsTextInputProps): React.JSX.Element {
+  const draft = useDebouncedSettingsTextDraft({ value, commit })
+  return (
+    <Input
+      {...inputProps}
+      value={draft.value}
+      onChange={(event) => {
+        onEdit?.()
+        draft.onChange(event.target.value)
+      }}
+      onBlur={draft.onBlur}
+    />
+  )
+}

--- a/src/renderer/src/components/settings/accounts-pane-minimax-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-minimax-section.tsx
@@ -10,6 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover'
 import { MiniMaxIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import type { AccountsPaneSectionModel } from './accounts-pane-types'
+import { DebouncedSettingsTextInput } from './DebouncedSettingsTextInput'
 
 const MINIMAX_CONSOLE_URL = 'https://platform.minimax.io/console/usage'
 
@@ -265,10 +266,10 @@ export function renderMiniMaxAccountsSection(model: AccountsPaneSectionModel): R
           <Label>
             {translate('auto.components.settings.AccountsPane.bf160bb6c0', 'Group ID override')}
           </Label>
-          <Input
+          <DebouncedSettingsTextInput
             type="text"
             value={settings.minimaxGroupId}
-            onChange={(e) => updateSettings({ minimaxGroupId: e.target.value })}
+            commit={(minimaxGroupId) => updateSettings({ minimaxGroupId })}
             placeholder={translate(
               'auto.components.settings.AccountsPane.0747d6391a',
               'Use group ID from cookie'
@@ -290,10 +291,10 @@ export function renderMiniMaxAccountsSection(model: AccountsPaneSectionModel): R
           <Label>
             {translate('auto.components.settings.AccountsPane.4ff2af7524', 'Usage model names')}
           </Label>
-          <Input
+          <DebouncedSettingsTextInput
             type="text"
             value={settings.minimaxUsageModels}
-            onChange={(e) => updateSettings({ minimaxUsageModels: e.target.value })}
+            commit={(minimaxUsageModels) => updateSettings({ minimaxUsageModels })}
             placeholder={translate('auto.components.settings.AccountsPane.3c92b0d31c', 'general')}
             spellCheck={false}
             className="text-xs"

--- a/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-provider-setting-sections.tsx
@@ -1,11 +1,11 @@
 import { translate } from '@/i18n/i18n'
 import { Button } from '../ui/button'
-import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Switch } from '../ui/switch'
 import { GeminiIcon, OpenCodeGoIcon } from '../status-bar/icons'
 import { SearchableSetting } from './SearchableSetting'
 import type { AccountsPaneSectionModel } from './accounts-pane-types'
+import { DebouncedSettingsTextInput } from './DebouncedSettingsTextInput'
 
 export function renderGeminiAccountsSection(model: AccountsPaneSectionModel): React.JSX.Element {
   const { localAccountRuntimeSentenceLabel, recordFeatureInteraction, settings, updateSettings } =
@@ -114,13 +114,11 @@ export function renderOpenCodeAccountsSection(model: AccountsPaneSectionModel): 
           )}
         </Label>
         <div className="flex gap-2">
-          <Input
+          <DebouncedSettingsTextInput
             type="password"
             value={settings.opencodeSessionCookie}
-            onChange={(e) => {
-              recordOpenCodeSettingEdit('cookie')
-              updateSettings({ opencodeSessionCookie: e.target.value })
-            }}
+            onEdit={() => recordOpenCodeSettingEdit('cookie')}
+            commit={(opencodeSessionCookie) => updateSettings({ opencodeSessionCookie })}
             placeholder={translate(
               'auto.components.settings.AccountsPane.a7e38affcd',
               'Fe26.2**… token or auth=Fe26.2**… header'
@@ -180,13 +178,11 @@ export function renderOpenCodeAccountsSection(model: AccountsPaneSectionModel): 
           {translate('auto.components.settings.AccountsPane.dbdb0b0bd8', 'Workspace ID override')}
         </Label>
         <div className="flex gap-2">
-          <Input
+          <DebouncedSettingsTextInput
             type="text"
             value={settings.opencodeWorkspaceId}
-            onChange={(e) => {
-              recordOpenCodeSettingEdit('workspaceId')
-              updateSettings({ opencodeWorkspaceId: e.target.value })
-            }}
+            onEdit={() => recordOpenCodeSettingEdit('workspaceId')}
+            commit={(opencodeWorkspaceId) => updateSettings({ opencodeWorkspaceId })}
             placeholder={translate(
               'auto.components.settings.AccountsPane.a122332371',
               'wrk_… (leave blank for automatic lookup)'

--- a/src/renderer/src/components/settings/use-debounced-settings-text-draft.test.ts
+++ b/src/renderer/src/components/settings/use-debounced-settings-text-draft.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 
+import { StrictMode } from 'react'
 import { act, cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useDebouncedSettingsTextDraft } from './use-debounced-settings-text-draft'
@@ -95,5 +96,127 @@ describe('useDebouncedSettingsTextDraft', () => {
     act(() => result.current.onBlur())
 
     expect(commit).not.toHaveBeenCalled()
+  })
+})
+
+describe('useDebouncedSettingsTextDraft flush paths', () => {
+  it('commits a pending edit on beforeunload, since a window close never unmounts the tree', () => {
+    const commit = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useDebouncedSettingsTextDraft({ value: '', commit })
+    )
+
+    act(() => result.current.onChange('quit-mid-word'))
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    })
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith('quit-mid-word')
+
+    // The later unmount and timer must not commit the same value again.
+    unmount()
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not commit on beforeunload when nothing is pending', () => {
+    const commit = vi.fn()
+    renderHook(() => useDebouncedSettingsTextDraft({ value: 'x', commit }))
+
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    })
+
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('stops listening for beforeunload after unmount', () => {
+    const commit = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useDebouncedSettingsTextDraft({ value: '', commit })
+    )
+
+    act(() => result.current.onChange('abc'))
+    unmount()
+    act(() => {
+      window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    })
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith('abc')
+  })
+
+  it('commits every edit burst, not only the first', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDebouncedSettingsTextDraft({ value: '', commit }))
+
+    act(() => result.current.onChange('one'))
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    act(() => result.current.onChange('one two'))
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+
+    expect(commit).toHaveBeenNthCalledWith(1, 'one')
+    expect(commit).toHaveBeenNthCalledWith(2, 'one two')
+  })
+
+  it('adopts external values again once a pending edit has been committed', () => {
+    const commit = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedSettingsTextDraft({ value, commit }),
+      { initialProps: { value: '' } }
+    )
+
+    act(() => result.current.onChange('typed'))
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    expect(commit).toHaveBeenCalledExactlyOnceWith('typed')
+
+    // The store echoes the commit, then another window writes a different value.
+    rerender({ value: 'typed' })
+    rerender({ value: 'from-another-window' })
+
+    expect(result.current.value).toBe('from-another-window')
+  })
+
+  it('keeps a keystroke typed while the previous commit is still in flight', () => {
+    const commit = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedSettingsTextDraft({ value, commit }),
+      { initialProps: { value: '' } }
+    )
+
+    act(() => result.current.onChange('abc'))
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+    act(() => result.current.onChange('abcd'))
+    // The store echoes the first commit after the user has already typed more.
+    rerender({ value: 'abc' })
+
+    expect(result.current.value).toBe('abcd')
+
+    act(() => result.current.onBlur())
+    expect(commit).toHaveBeenLastCalledWith('abcd')
+    expect(commit).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not spuriously commit under StrictMode effect replay', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDebouncedSettingsTextDraft({ value: 'x', commit }), {
+      wrapper: StrictMode
+    })
+
+    expect(commit).not.toHaveBeenCalled()
+
+    act(() => result.current.onChange('xy'))
+    act(() => result.current.onBlur())
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith('xy')
   })
 })

--- a/src/renderer/src/components/settings/use-debounced-settings-text-draft.test.ts
+++ b/src/renderer/src/components/settings/use-debounced-settings-text-draft.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDebouncedSettingsTextDraft } from './use-debounced-settings-text-draft'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('useDebouncedSettingsTextDraft', () => {
+  it('shows every keystroke immediately but commits once', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDebouncedSettingsTextDraft({ value: '', commit }))
+
+    for (const next of ['w', 'wr', 'wrk']) {
+      act(() => result.current.onChange(next))
+    }
+
+    expect(result.current.value).toBe('wrk')
+    expect(commit).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+
+    expect(commit).toHaveBeenCalledTimes(1)
+    expect(commit).toHaveBeenCalledWith('wrk')
+  })
+
+  it('commits immediately on blur without waiting for the debounce', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDebouncedSettingsTextDraft({ value: '', commit }))
+
+    act(() => result.current.onChange('abc'))
+    act(() => result.current.onBlur())
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith('abc')
+
+    act(() => {
+      vi.advanceTimersByTime(700)
+    })
+
+    // The pending timer must not fire a second, duplicate commit.
+    expect(commit).toHaveBeenCalledTimes(1)
+  })
+
+  it('commits a pending edit when the field unmounts', () => {
+    const commit = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useDebouncedSettingsTextDraft({ value: '', commit })
+    )
+
+    act(() => result.current.onChange('half-typed'))
+    unmount()
+
+    expect(commit).toHaveBeenCalledExactlyOnceWith('half-typed')
+  })
+
+  it('adopts an external value while the field is untouched', () => {
+    const commit = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedSettingsTextDraft({ value, commit }),
+      { initialProps: { value: 'first' } }
+    )
+
+    rerender({ value: 'from-another-window' })
+
+    expect(result.current.value).toBe('from-another-window')
+    expect(commit).not.toHaveBeenCalled()
+  })
+
+  it('does not let an external value overwrite an in-progress edit', () => {
+    const commit = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedSettingsTextDraft({ value, commit }),
+      { initialProps: { value: 'first' } }
+    )
+
+    act(() => result.current.onChange('typing'))
+    rerender({ value: 'from-another-window' })
+
+    expect(result.current.value).toBe('typing')
+  })
+
+  it('does not commit when nothing was edited', () => {
+    const commit = vi.fn()
+    const { result } = renderHook(() => useDebouncedSettingsTextDraft({ value: 'x', commit }))
+
+    act(() => result.current.onBlur())
+
+    expect(commit).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/use-debounced-settings-text-draft.ts
+++ b/src/renderer/src/components/settings/use-debounced-settings-text-draft.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Matches the repository-hook script draft, the established debounce for settings text in this pane.
+const SETTINGS_TEXT_COMMIT_DEBOUNCE_MS = 700
+
+export type DebouncedSettingsTextDraft = {
+  value: string
+  onChange: (next: string) => void
+  onBlur: () => void
+}
+
+/**
+ * Local draft for a free-text setting, committed on a debounce and flushed on blur and unmount.
+ *
+ * Why: binding an `<Input>` straight to `updateSettings` sends one IPC round trip per keystroke,
+ * and each one replaces the `settings` object identity in every other window, re-rendering every
+ * component subscribed to it. The committed value is unchanged — only the number of commits is.
+ */
+export function useDebouncedSettingsTextDraft(args: {
+  value: string
+  commit: (next: string) => void
+}): DebouncedSettingsTextDraft {
+  const { value, commit } = args
+  const [draft, setDraft] = useState(value)
+  const draftRef = useRef(draft)
+  const dirtyRef = useRef(false)
+  const commitRef = useRef(commit)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  commitRef.current = commit
+
+  // Why gated on dirty: an external write (another window, a reset) should land in the field, but
+  // must not yank characters out from under someone mid-edit.
+  useEffect(() => {
+    if (dirtyRef.current) {
+      return
+    }
+    draftRef.current = value
+    setDraft(value)
+  }, [value])
+
+  const flush = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    if (!dirtyRef.current) {
+      return
+    }
+    dirtyRef.current = false
+    commitRef.current(draftRef.current)
+  }, [])
+
+  const onChange = useCallback(
+    (next: string) => {
+      draftRef.current = next
+      dirtyRef.current = true
+      setDraft(next)
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+      }
+      timerRef.current = setTimeout(flush, SETTINGS_TEXT_COMMIT_DEBOUNCE_MS)
+    },
+    [flush]
+  )
+
+  // Why on unmount too: closing the pane mid-word must persist the same value typing it would have.
+  const flushRef = useRef(flush)
+  flushRef.current = flush
+  useEffect(() => {
+    return () => {
+      flushRef.current()
+    }
+  }, [])
+
+  return { value: draft, onChange, onBlur: flush }
+}

--- a/src/renderer/src/components/settings/use-debounced-settings-text-draft.ts
+++ b/src/renderer/src/components/settings/use-debounced-settings-text-draft.ts
@@ -27,7 +27,10 @@ export function useDebouncedSettingsTextDraft(args: {
   const commitRef = useRef(commit)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  commitRef.current = commit
+  // Why an effect, not a render-time write: render must stay pure, and React can replay it.
+  useEffect(() => {
+    commitRef.current = commit
+  }, [commit])
 
   // Why gated on dirty: an external write (another window, a reset) should land in the field, but
   // must not yank characters out from under someone mid-edit.
@@ -65,13 +68,12 @@ export function useDebouncedSettingsTextDraft(args: {
   )
 
   // Why on unmount too: closing the pane mid-word must persist the same value typing it would have.
-  const flushRef = useRef(flush)
-  flushRef.current = flush
+  // `flush` has no dependencies, so this cleanup only ever runs on unmount.
   useEffect(() => {
     return () => {
-      flushRef.current()
+      flush()
     }
-  }, [])
+  }, [flush])
 
   return { value: draft, onChange, onBlur: flush }
 }

--- a/src/renderer/src/components/settings/use-debounced-settings-text-draft.ts
+++ b/src/renderer/src/components/settings/use-debounced-settings-text-draft.ts
@@ -10,11 +10,16 @@ export type DebouncedSettingsTextDraft = {
 }
 
 /**
- * Local draft for a free-text setting, committed on a debounce and flushed on blur and unmount.
+ * Local draft for a free-text setting, committed on a debounce and flushed on blur, unmount, and
+ * window unload.
  *
  * Why: binding an `<Input>` straight to `updateSettings` sends one IPC round trip per keystroke,
  * and each one replaces the `settings` object identity in every other window, re-rendering every
  * component subscribed to it. The committed value is unchanged — only the number of commits is.
+ *
+ * A pending timer is the single source of truth for "the draft has uncommitted edits": `onChange`
+ * is the only place that arms it and `flush` the only place that clears it, so there is no separate
+ * dirty flag to fall out of sync.
  */
 export function useDebouncedSettingsTextDraft(args: {
   value: string
@@ -23,7 +28,6 @@ export function useDebouncedSettingsTextDraft(args: {
   const { value, commit } = args
   const [draft, setDraft] = useState(value)
   const draftRef = useRef(draft)
-  const dirtyRef = useRef(false)
   const commitRef = useRef(commit)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -32,10 +36,10 @@ export function useDebouncedSettingsTextDraft(args: {
     commitRef.current = commit
   }, [commit])
 
-  // Why gated on dirty: an external write (another window, a reset) should land in the field, but
-  // must not yank characters out from under someone mid-edit.
+  // Why gated on a pending commit: an external write (another window, a reset) should land in the
+  // field, but must not yank characters out from under someone mid-edit.
   useEffect(() => {
-    if (dirtyRef.current) {
+    if (timerRef.current !== null) {
       return
     }
     draftRef.current = value
@@ -43,21 +47,17 @@ export function useDebouncedSettingsTextDraft(args: {
   }, [value])
 
   const flush = useCallback(() => {
-    if (timerRef.current !== null) {
-      clearTimeout(timerRef.current)
-      timerRef.current = null
-    }
-    if (!dirtyRef.current) {
+    if (timerRef.current === null) {
       return
     }
-    dirtyRef.current = false
+    clearTimeout(timerRef.current)
+    timerRef.current = null
     commitRef.current(draftRef.current)
   }, [])
 
   const onChange = useCallback(
     (next: string) => {
       draftRef.current = next
-      dirtyRef.current = true
       setDraft(next)
       if (timerRef.current !== null) {
         clearTimeout(timerRef.current)
@@ -67,10 +67,17 @@ export function useDebouncedSettingsTextDraft(args: {
     [flush]
   )
 
-  // Why on unmount too: closing the pane mid-word must persist the same value typing it would have.
-  // `flush` has no dependencies, so this cleanup only ever runs on unmount.
+  // Why unmount: closing the pane (or the settings search hiding the section) mid-word must persist
+  // the same value typing it would have. `flush` has no dependencies, so this cleanup only ever runs
+  // on unmount.
+  // Why beforeunload: a window close or app quit never unmounts the tree, so the cleanup cannot run.
+  // The close coordinator dispatches a synthetic beforeunload while the tree is still mounted so
+  // listeners like this one can flush; `updateSettings` issues its IPC synchronously, ahead of the
+  // close confirmation, so main persists the value before it flushes the store on quit.
   useEffect(() => {
+    window.addEventListener('beforeunload', flush)
     return () => {
+      window.removeEventListener('beforeunload', flush)
       flush()
     }
   }, [flush])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​222 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​222 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​137 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 |

<!-- /orca-pr-loc -->

## ELI5

Four text boxes in Settings (MiniMax group ID and usage models, OpenCode session cookie and workspace ID) saved to the app's settings store on **every single keystroke**.

Each save is a round trip to the main process, and each one hands back a brand-new settings object to **every open Orca window**. Since a large number of components watch "the settings" as a whole, typing one character in one window re-rendered a lot of components in *all* of them.

Now the box updates instantly as you type, and the actual save happens once you pause (700ms), leave the field, or close the pane.

## What Changed

**New `use-debounced-settings-text-draft.ts`** — local draft state, debounced commit, flush on blur, flush on unmount, and an external-value adopt that is gated on the field being untouched.

**New `DebouncedSettingsTextInput.tsx`** — a thin `Input` wrapper that owns that draft, plus an optional `onEdit` callback so the OpenCode telemetry (`recordOpenCodeSettingEdit`) still fires per keystroke exactly as before.

Four inputs swapped over:
- `accounts-pane-minimax-section.tsx` — `minimaxGroupId`, `minimaxUsageModels`
- `accounts-pane-provider-setting-sections.tsx` — `opencodeSessionCookie`, `opencodeWorkspaceId`

## Why

The old shape was:

```tsx
<Input value={settings.minimaxGroupId}
       onChange={(e) => updateSettings({ minimaxGroupId: e.target.value })} />
```

Per keystroke that runs `window.api.settings.set` → `store.updateSettings` (which spreads the whole settings object) → a synchronous `settings:changed` broadcast to every *other* `BrowserWindow` (`src/main/ipc/settings.ts:87-95`). Each receiving window then does `useAppStore.setState({ settings: {...} })` (`settings-sidebar-ipc-bridge.ts:97-128`), replacing the `settings` object identity — and **121 call sites across the renderer subscribe to `state.settings` as a whole object** rather than a narrow field. So one character re-renders all of them, in every window.

Disk writes were already debounced via `scheduleSave`, so this is IPC + broadcast + re-render fan-out, not disk I/O.

The 700ms debounce and flush-on-blur are not invented here — they mirror `use-repository-hook-settings-draft.ts:70`, the established pattern for settings text in this same directory.

## Measurements

Deterministic from the code path and pinned by tests, rather than a wall-clock number I can't honestly attribute:

| typing an N-character value | before | after |
| --- | --- | --- |
| `settings.set` IPC round trips | **N** | **1** |
| cross-window `settings:changed` broadcasts | **N** | **1** |
| `settings` identity replacements per other window | **N** | **1** |
| re-renders of each of the ~121 whole-`settings` subscribers, per window | **N** | **1** |

For a 40-character OpenCode cookie typed by hand, that is 40 round trips and 40 full broadcast fan-outs reduced to one. I have marked the wall-clock impact **unmeasured** deliberately: it depends on how many windows are open and what is mounted in them, and I did not build a multi-window profiling harness.

## Negative user-facing trade-offs

**None**, and the two ways a debounce normally loses data are both closed:

- **Typing still feels instant.** The draft is local state updated synchronously on every keystroke, so the field never lags — only the commit is deferred.
- **Nothing is lost on close.** The draft flushes on blur *and* on unmount, so closing the settings pane or the section mid-word persists exactly the value typing it would have. Both are tested.
- **No double commit.** Blur cancels the pending timer before committing, and a no-op blur (nothing edited) commits nothing. Both are tested.
- **External updates still land.** A settings change from another window is adopted into the field — but only while the field is untouched, so it cannot yank characters out mid-edit. Both directions are tested.
- **Telemetry unchanged.** `recordOpenCodeSettingEdit('cookie' | 'workspaceId')` still fires on every keystroke via `onEdit`; only the persistence is debounced.
- **Durability is effectively unchanged.** The disk write was already behind `scheduleSave`'s debounce, so a crash could always lose the last moments of typing; this adds at most 700ms to that existing window.
- **No component restructuring.** I first tried converting the two account sections into real components so they could hold hooks — but they are `render*` functions the settings search calls **conditionally** (`AccountsPane.tsx:360-365`), so hooks there would violate the Rules of Hooks as the search text changes the number of hooks. Putting the draft inside the input component instead keeps those sections plain functions and leaves their existing structure untouched. (That attempt also surfaced a pre-existing `Date.now()`-during-render in the MiniMax section, which I deliberately left alone — it is unrelated to this change and belongs in its own fix.)

## Merge risk

**Low.** **Was Medium; de-risked, and a real defect was found and fixed.** A dedicated pass found that Electron does not unmount the React tree on window close, so the unmount flush never ran and a value typed within the last 700ms was silently dropped on quit — a genuine data-loss path that the per-keystroke code did not have. It now flushes on the codebase's existing synthetic `beforeunload` (the same mechanism `window-close-request-coordinator.ts` and `use-terminal-editor-close-foundation.ts` already dispatch), so no new mechanism was invented. The hook also got simpler: `dirtyRef` is gone, because "pending edit" is now just `timerRef.current !== null` — one source of truth instead of two. Tests went 6 → 13, covering beforeunload, no-double-commit, listener removal, repeated bursts, in-flight echo ordering, and StrictMode replay.

## Linked Issue

No tracked issue — found by a repository-wide performance audit.

## Visual Proof

N/A — no visual change. The fields look and behave the same while typing; the only difference is how often the value is persisted and broadcast.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

New `use-debounced-settings-text-draft.test.ts` (6 tests): shows every keystroke immediately but commits once; commits immediately on blur without a duplicate timer commit; commits a pending edit on unmount; adopts an external value while untouched; does not let an external value overwrite an in-progress edit; does not commit when nothing was edited.

Wider suite: `pnpm test src/renderer/src/components/settings` — 172 files, 1122 tests, all passing. `pnpm tc`, `oxlint`, and `pnpm run check:code-quality:changed` clean.

Platforms: renderer-only, no platform-dependent behavior.

## AI Disclosure


