### PR TITLE
fix(sidebar): keep the send-target label on one line inside its button

### DIFF
--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -109,6 +109,16 @@ function dismissButtonClassTokens(markup: string): string[] {
   return dismissButtonClass(markup).split(/\s+/).filter(Boolean)
 }
 
+function sendTargetButtonClassTokens(markup: string): string[] {
+  const match = markup.match(
+    /<button\b(?=[^>]*aria-label="Send to this agent")[^>]*class="([^"]*)"/
+  )
+  if (!match) {
+    throw new Error('Expected send target button in rendered markup')
+  }
+  return match[1].split(/\s+/).filter(Boolean)
+}
+
 function tokenCount(markup: string, token: string): number {
   return classTokens(markup).filter((classToken) => classToken === token).length
 }
@@ -188,6 +198,19 @@ describe('DashboardAgentRow', () => {
     expect(tokens).toContain('w-12')
     expect(markup).toContain('lucide-send')
     expect(markup).not.toContain('aria-label="Dismiss agent"')
+  })
+
+  it('keeps a localized send-target label on one line and bounded in width', () => {
+    const markup = renderSendTargetRow({ sendTargetStatus: 'eligible' })
+    const tokens = sendTargetButtonClassTokens(markup)
+
+    // Why: the button is a fixed-height overlay, so a label that wraps escapes it
+    // and overlaps the row. CJK labels break between characters, and a long
+    // unbreakable word grows left over the agent name.
+    expect(tokens).toContain('h-5')
+    expect(tokens).toContain('whitespace-nowrap')
+    expect(tokens).toContain('max-w-28')
+    expect(markup).toContain('min-w-0 truncate')
   })
 
   it('marks disabled send-target rows as muted without an eligibility ring', () => {

--- a/src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRowTrailingControls.tsx
@@ -74,7 +74,10 @@ export function DashboardAgentRowTrailingControls({
           onKeyDown={stopKeyDown}
           disabled={sendTargetStatus === 'sending'}
           className={cn(
-            'worktree-agent-send-target-button absolute right-0 top-1/2 z-10 inline-flex h-5 -translate-y-1/2 items-center gap-1 rounded-md border px-1.5 text-[10px] font-medium leading-none transition-[background-color,border-color,color,opacity]',
+            // Why nowrap + max-w: the button is a fixed-height overlay, so a label
+            // that wraps escapes it and overlaps the row. CJK breaks between
+            // characters, and an unbreakable word grows left over the agent name.
+            'worktree-agent-send-target-button absolute right-0 top-1/2 z-10 inline-flex h-5 max-w-28 -translate-y-1/2 items-center gap-1 whitespace-nowrap rounded-md border px-1.5 text-[10px] font-medium leading-none transition-[background-color,border-color,color,opacity]',
             sendTargetStatus === 'sending' && 'cursor-progress opacity-75'
           )}
           aria-label={translate(
@@ -86,8 +89,10 @@ export function DashboardAgentRowTrailingControls({
             'Send to this agent'
           )}
         >
-          <Send className="size-3" />
-          <span>{translate('auto.components.dashboard.DashboardAgentRow.912e136cd9', 'Send')}</span>
+          <Send className="size-3 shrink-0" />
+          <span className="min-w-0 truncate">
+            {translate('auto.components.dashboard.DashboardAgentRow.912e136cd9', 'Send')}
+          </span>
         </button>
       )}
       {!sendTargetStatus && hideDismiss && relativeTimestamp !== null && (


### PR DESCRIPTION
## ELI5

When you send a diff note to an agent, each eligible agent row in the sidebar grows a little "Send" button. That button has a fixed height, but nothing stopped its label from wrapping onto a second line. Korean and Chinese break between individual characters, so the label wrapped, spilled out of the button, and overlapped the row around it. This pins the label to one line and puts a ceiling on how wide the button can get.

## What Changed

`DashboardAgentRowTrailingControls` now renders the inline send-target button with `whitespace-nowrap` and `max-w-28`, and its label span with `min-w-0 truncate`. The send icon gets `shrink-0` so it cannot be squeezed by a long label.

No behavior, layout structure, or styling tokens changed. The button keeps its existing `h-5` height, absolute placement, and `worktree-agent-send-target-button` treatment.

## Why

The button is a fixed-height absolute overlay sitting on top of an agent row. That combination has two failure modes once the label is not English:

- CJK text breaks between characters, so `보내기` wraps to `보내` / `기`. The second line renders outside the `h-5` box and overlaps neighbouring content.
- An unbreakable localized word grows leftward without limit, covering the agent name in a narrow sidebar.

`whitespace-nowrap` removes the first. `max-w-28` bounds the second. The max width is a safety ceiling rather than an active constraint: at `text-[10px]`, the longest label across the shipped locales (`Enviar`) needs roughly 62px including the icon and padding, so nothing truncates in practice.

## Linked Issue

Fixes #18473

## Visual Proof

<img width="640" height="260" alt="orca-18473-before-after" src="https://github.com/user-attachments/assets/664f0891-b033-4212-a63b-2c7bf034baf5" />

Rendered from the component's own classes plus the `worktree-agent-send-target-button` rules in `main.css`, at the sidebar's narrow width. Before, `보내기` wraps and escapes the fixed-height button. After, it stays on one line inside it. Spanish is shown alongside as the unbreakable-word case.

## Testing

Added `keeps a localized send-target label on one line and bounded in width` to `DashboardAgentRow.test.tsx`, asserting on the send button's own class list rather than the whole row. Verified it is a real regression test: with `whitespace-nowrap` and `max-w-28` removed it fails, and with them it passes.

- `pnpm test src/renderer/src/components/dashboard src/renderer/src/components/sidebar` — 359 files, 2999 tests, all passing
- `pnpm tc` — clean
- `pnpm run check:code-quality:changed` — 0 new findings across the 2 changed files, React Doctor included
- `oxlint` and `oxfmt --check` — clean

Tested on macOS. This is a pure CSS-class change in renderer markup with no platform-conditional code, so Linux and Windows behave identically.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (claude-opus-5).

## Review

- **Cross-platform:** no platform-conditional code, no path handling, no keyboard accelerators. Tailwind utilities only, so macOS, Linux, and Windows render the same.
- **SSH / remote / local:** the send-target button is renderer-side presentation driven by props already computed upstream. No transcript, process, or execution-host behavior is touched, and nothing here reads or reports on remote state.
- **Agents and integrations:** the row is agent-neutral. The label comes from the existing i18n key, so no agent or git provider is treated specially.
- **Remote wire:** no RPC params, stream frames, or published content change, so mixed client and host versions are unaffected.
- **Performance:** four static utility classes on an element that only renders during send-target mode. No new state, effects, subscriptions, or re-render paths.
- **UI quality:** no new color, size, or shadow values, and no token invented. `h-5`, the accent treatment, and the absolute placement are all unchanged, so light and dark mode are untouched. `truncate` is a ceiling that no shipped locale reaches.
- **Security:** no new input handling, no URL or path construction, no IPC surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Scoped deliberately to the reported defect. The surrounding `w-12` slot, the button's absolute placement, and the rest of the trailing-controls layout are left alone.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: [@celiarozalenm](https://x.com/celiarozalenm)
