### PR TITLE
fix(terminal): keep restored host tabs on the host runtime

### DIFF
--- a/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
+++ b/src/main/daemon/daemon-foreground-confirmation-protocol.test.ts
@@ -3,7 +3,7 @@ import { PREVIOUS_DAEMON_PROTOCOL_VERSIONS, PROTOCOL_VERSION } from './types'
 
 describe('foreground-confirmation daemon protocol', () => {
   it('rejects daemons from before the fresh-confirmation RPC', () => {
-    expect(PROTOCOL_VERSION).toBe(33)
+    expect(PROTOCOL_VERSION).toBe(34)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(19)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(22)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(23)
@@ -16,5 +16,6 @@ describe('foreground-confirmation daemon protocol', () => {
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(30)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(31)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(32)
+    expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toContain(33)
   })
 })

--- a/src/main/daemon/daemon-protocol-version.test.ts
+++ b/src/main/daemon/daemon-protocol-version.test.ts
@@ -3,6 +3,7 @@ import {
   AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION,
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
   COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION,
+  FORCE_HOST_RUNTIME_DAEMON_PROTOCOL_VERSION,
   GET_FOREGROUND_PROCESS_PROTOCOL_VERSION,
   HISTORY_SEED_TRANSFER_PROTOCOL_VERSION,
   MODE_2031_UNSUBSCRIBE_FACT_PROTOCOL_VERSION,
@@ -16,7 +17,8 @@ import {
 
 describe('daemon protocol version', () => {
   it('ships bounded history transfer after the 2031-unsubscribe fact', () => {
-    expect(PROTOCOL_VERSION).toBe(33)
+    expect(PROTOCOL_VERSION).toBe(34)
+    expect(FORCE_HOST_RUNTIME_DAEMON_PROTOCOL_VERSION).toBe(34)
     expect(WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION).toBe(33)
     expect(SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION).toBe(32)
     expect(STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION).toBe(31)
@@ -27,7 +29,7 @@ describe('daemon protocol version', () => {
     expect(AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION).toBe(26)
     expect(PREVIOUS_DAEMON_PROTOCOL_VERSIONS).toEqual(
-      Array.from({ length: 32 }, (_, index) => index + 1)
+      Array.from({ length: 33 }, (_, index) => index + 1)
     )
   })
 

--- a/src/main/daemon/daemon-protocol-version.ts
+++ b/src/main/daemon/daemon-protocol-version.ts
@@ -1,6 +1,7 @@
 // Why: daemons survive app updates, so wire behavior must be version-gated.
-// v33 preserves selected-WSL POSIX cwd semantics; older owners remain attachable.
-export const PROTOCOL_VERSION = 33
+// v34 carries explicit host-runtime authority; older owners remain attachable for requests that do not use it.
+export const PROTOCOL_VERSION = 34
+export const FORCE_HOST_RUNTIME_DAEMON_PROTOCOL_VERSION = 34
 export const WSL_POSIX_CWD_DAEMON_PROTOCOL_VERSION = 33
 export const SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION = 32
 export const STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION = 31
@@ -27,7 +28,7 @@ export const CLEAN_DISCONNECT_PROTOCOL_VERSION = 24
 export const MODE_2031_UNSUBSCRIBE_FACT_PROTOCOL_VERSION = 29
 export const PREVIOUS_DAEMON_PROTOCOL_VERSIONS = [
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
-  28, 29, 30, 31, 32
+  28, 29, 30, 31, 32, 33
 ] as const
 
 export function supportsPtyStartupIngress(protocolVersion: number): boolean {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -105,6 +105,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     cwd?: string
     env?: Record<string, string>
     command?: string
+    forceHostRuntime?: boolean
   } | null
   let subprocessDataOnSubscribe: string | undefined
   let daemonLog: DaemonFileLog
@@ -147,6 +148,50 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     expect(adapter.supportsAgentSessionCreateOperations()).toBe(true)
     expect(legacy.supportsAgentSessionCreateOperations()).toBe(false)
     legacy.dispose()
+  })
+
+  it('fails closed when forced-host authority reaches an older daemon', async () => {
+    const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 33 })
+
+    try {
+      await expect(
+        legacy.spawn({
+          cols: 80,
+          rows: 24,
+          forceHostRuntime: true
+        })
+      ).rejects.toThrow('force_host_runtime_daemon_protocol_unavailable')
+    } finally {
+      legacy.dispose()
+    }
+  })
+
+  it('does not fail closed before an older daemon handles attach-only reattachment', async () => {
+    const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 33 })
+
+    try {
+      await expect(
+        legacy.spawn({
+          sessionId: 'legacy-session',
+          cols: 80,
+          rows: 24,
+          attachOnly: true,
+          forceHostRuntime: true
+        })
+      ).rejects.toThrow('Protocol version mismatch')
+    } finally {
+      legacy.dispose()
+    }
+  })
+
+  it('forwards forced-host authority to the current daemon', async () => {
+    await adapter.spawn({
+      cols: 80,
+      rows: 24,
+      forceHostRuntime: true
+    })
+
+    expect(lastSpawnOpts?.forceHostRuntime).toBe(true)
   })
 
   afterEach(async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -38,6 +38,7 @@ import {
   type TakePendingOutputResult
 } from './types'
 import {
+  FORCE_HOST_RUNTIME_DAEMON_PROTOCOL_VERSION,
   GET_SIZE_PROTOCOL_VERSION,
   HISTORY_SEED_TRANSFER_PROTOCOL_VERSION,
   SNAPSHOT_SERIALIZER_FIDELITY_DAEMON_PROTOCOL_VERSION,
@@ -386,6 +387,15 @@ export class DaemonPtyAdapter implements IPtyProvider {
     operation: PendingDaemonSpawnOperation,
     historyRecovery: HistoryRecoveryContext
   ): Promise<PtySpawnResult> {
+    // Why: an attach-only request starts no shell, so a preserved pre-v34 owner can safely keep its existing runtime.
+    const attachOnly = opts.attachOnly === true
+    if (
+      opts.forceHostRuntime &&
+      !attachOnly &&
+      this.protocolVersion < FORCE_HOST_RUNTIME_DAEMON_PROTOCOL_VERSION
+    ) {
+      throw new Error('force_host_runtime_daemon_protocol_unavailable')
+    }
     if (
       opts.agentSessionEnsure &&
       this.protocolVersion < AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION
@@ -394,7 +404,6 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     const requestedSessionId = opts.sessionId!
     // Why: v30 daemons survive upgrades; reject their accidental create result before publication.
-    const attachOnly = opts.attachOnly === true
     const emulateLegacyAttachOnly =
       attachOnly && this.protocolVersion < STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION
     let sessionId = requestedSessionId
@@ -402,7 +411,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
       cwd: opts.cwd,
       sessionId,
       shellOverride: opts.shellOverride,
-      terminalWindowsWslDistro: opts.terminalWindowsWslDistro
+      terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
+      forceHostRuntime: opts.forceHostRuntime
     })?.distro
     const freezeHistory = async (): Promise<void> => {
       if (!this.historyManager) {
@@ -522,6 +532,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         ...(attachOnly && !emulateLegacyAttachOnly ? { attachOnly: true } : {}),
         // Why: without forwarding the override, the daemon falls back to cmd.exe/PowerShell, ignoring the shell the renderer chose; this matches LocalPtyProvider.
         shellOverride: attachOnly ? undefined : opts.shellOverride,
+        forceHostRuntime: attachOnly ? undefined : opts.forceHostRuntime,
         terminalWindowsWslDistro: attachOnly ? undefined : opts.terminalWindowsWslDistro,
         terminalWindowsPowerShellImplementation: attachOnly
           ? undefined

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -408,7 +408,7 @@ describe('DaemonPtyRouter', () => {
     expect(current.confirmForegroundProcess).toHaveBeenCalledWith('current-session')
   })
 
-  it('preserves older session owners and routes new sessions to v33', async () => {
+  it('preserves older session owners and routes new sessions to v34', async () => {
     const current = createAdapter('current', [], undefined, PROTOCOL_VERSION)
     const legacyV30 = createAdapter(
       'v30',
@@ -423,26 +423,46 @@ describe('DaemonPtyRouter', () => {
       STABLE_PANE_ATTACH_ONLY_DAEMON_PROTOCOL_VERSION
     )
     const legacyV32 = createAdapter('v32', ['v32-session'], undefined, 32)
-    const router = new DaemonPtyRouter({ current, legacy: [legacyV30, legacyV31, legacyV32] })
+    const legacyV33 = createAdapter('v33', ['v33-session'], undefined, 33)
+    const router = new DaemonPtyRouter({
+      current,
+      legacy: [legacyV30, legacyV31, legacyV32, legacyV33]
+    })
 
     await router.discoverLegacySessions()
 
     await router.spawn({ sessionId: 'v30-session', cols: 80, rows: 24 })
     await router.spawn({ sessionId: 'v31-session', cols: 80, rows: 24 })
     await router.spawn({ sessionId: 'v32-session', cols: 80, rows: 24 })
+    await router.spawn({
+      sessionId: 'v33-session',
+      cols: 80,
+      rows: 24,
+      attachOnly: true,
+      forceHostRuntime: true
+    })
     const fresh = await router.spawn({ cols: 80, rows: 24 })
     router.write('v30-session', 'old-v30\n')
     router.write('v31-session', 'old-v31\n')
     router.write('v32-session', 'old-v32\n')
+    router.write('v33-session', 'old-v33\n')
     router.write(fresh.id, 'new\n')
 
     expect(legacyV30.spawn).toHaveBeenCalledWith({ sessionId: 'v30-session', cols: 80, rows: 24 })
     expect(legacyV31.spawn).toHaveBeenCalledWith({ sessionId: 'v31-session', cols: 80, rows: 24 })
     expect(legacyV32.spawn).toHaveBeenCalledWith({ sessionId: 'v32-session', cols: 80, rows: 24 })
+    expect(legacyV33.spawn).toHaveBeenCalledWith({
+      sessionId: 'v33-session',
+      cols: 80,
+      rows: 24,
+      attachOnly: true,
+      forceHostRuntime: true
+    })
     expect(current.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
     expect(legacyV30.write).toHaveBeenCalledWith('v30-session', 'old-v30\n')
     expect(legacyV31.write).toHaveBeenCalledWith('v31-session', 'old-v31\n')
     expect(legacyV32.write).toHaveBeenCalledWith('v32-session', 'old-v32\n')
+    expect(legacyV33.write).toHaveBeenCalledWith('v33-session', 'old-v33\n')
     expect(current.write).toHaveBeenCalledWith(fresh.id, 'new\n')
   })
 

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -1023,6 +1023,7 @@ export class DaemonServer {
             // Why: RPC payloads are untrusted JSON; persist only the allowlisted routing enum, never arbitrary identity.
             ...(isTuiAgent(p.launchAgent) ? { launchAgent: p.launchAgent } : {}),
             shellOverride: p.shellOverride,
+            ...(p.forceHostRuntime === true ? { forceHostRuntime: true } : {}),
             terminalWindowsWslDistro: p.terminalWindowsWslDistro,
             terminalWindowsPowerShellImplementation: p.terminalWindowsPowerShellImplementation,
             shellReadySupported: p.shellReadySupported,

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -2437,6 +2437,35 @@ describe('createPtySubprocess', () => {
     )
   })
 
+  it('keeps a native Windows cwd on cmd when the session id retains a WSL worktree', () => {
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    try {
+      createPtySubprocess({
+        sessionId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo@@deadbeef',
+        cols: 80,
+        rows: 24,
+        cwd: 'C:\\repo\\orca',
+        shellOverride: 'cmd.exe',
+        forceHostRuntime: true
+      })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'cmd.exe',
+      ['/K', 'chcp 65001 > nul'],
+      expect.objectContaining({ cwd: 'C:\\repo\\orca' })
+    )
+  })
+
   it('embeds short PowerShell startup commands in the Windows shell launch', () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -127,6 +127,8 @@ export type PtySubprocessOptions = {
    *  Overrides env.COMSPEC / env.SHELL resolution inside the daemon so a user
    *  who picks "New WSL terminal" from the "+" menu actually gets WSL. */
   shellOverride?: string
+  /** Current pane explicitly selected the local host instead of its project runtime. */
+  forceHostRuntime?: boolean
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   onMacosTccSpawnStrategy?: (strategy: 'wrapped' | 'direct') => void
@@ -644,7 +646,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
   env.LANG ??= 'en_US.UTF-8'
   // Why: shellOverride must win over env.COMSPEC, or Windows always resolves to cmd.exe/PowerShell regardless of the user's pick.
   const resolvedWslContext = resolveWslSessionContext(opts)
-  // Why: older persisted tabs can carry a PowerShell/cmd shellOverride; ignore it so WSL reconnects still enter the distro.
+  // Why: older WSL tabs can retain host-shell metadata; session identity wins unless this spawn explicitly forces the host.
   let shellPath = resolvedWslContext ? 'wsl.exe' : opts.shellOverride || resolvePtyShellPath(env)
   let shellArgs: string[]
   let startupCommandDeliveredInShellArgs = false

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -23,6 +23,8 @@ export type CreateOrAttachOptions = {
   attachOnly?: boolean
   /** Explicit shell the renderer asked for, forwarded to the subprocess. */
   shellOverride?: string
+  /** Current pane explicitly selected the local host instead of its project runtime. */
+  forceHostRuntime?: boolean
   terminalWindowsWslDistro?: string | null
   terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   shellReadySupported?: boolean

--- a/src/main/daemon/terminal-host-options.ts
+++ b/src/main/daemon/terminal-host-options.ts
@@ -15,6 +15,7 @@ export type TerminalHostOptions = {
     startupCommandDelivery?: StartupCommandDelivery
     launchAgent?: TuiAgent
     shellOverride?: string
+    forceHostRuntime?: boolean
     terminalWindowsWslDistro?: string | null
     terminalWindowsPowerShellImplementation?: 'auto' | 'powershell.exe' | 'pwsh.exe'
   }) => SubprocessHandle

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -85,6 +85,7 @@ export async function createOrAttachTerminalSession(
     startupCommandDelivery: opts.startupCommandDelivery,
     ...(opts.launchAgent ? { launchAgent: opts.launchAgent } : {}),
     shellOverride: opts.shellOverride,
+    forceHostRuntime: opts.forceHostRuntime,
     terminalWindowsWslDistro: opts.terminalWindowsWslDistro,
     terminalWindowsPowerShellImplementation: opts.terminalWindowsPowerShellImplementation
   })

--- a/src/main/daemon/terminal-host-wsl-context.test.ts
+++ b/src/main/daemon/terminal-host-wsl-context.test.ts
@@ -172,4 +172,47 @@ describe('TerminalHost WSL context', () => {
       }
     }
   })
+
+  it('lets explicit host authority defeat stale WSL session identity', () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const args = {
+        cwd: 'C:\\Users\\jin\\repo',
+        sessionId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo@@deadbeef',
+        shellOverride: 'cmd.exe'
+      }
+
+      expect(resolveWslSessionContext(args)).toEqual({
+        distro: 'Ubuntu',
+        treatPosixCwdAsWsl: true
+      })
+      expect(resolveWslSessionContext({ ...args, forceHostRuntime: true })).toBeUndefined()
+      expect(
+        resolveWslSessionContext({
+          ...args,
+          shellOverride: undefined,
+          forceHostRuntime: true
+        })
+      ).toBeUndefined()
+      expect(
+        resolveWslSessionContext({
+          ...args,
+          cwd: '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo',
+          forceHostRuntime: true
+        })
+      ).toEqual({ distro: 'Ubuntu', treatPosixCwdAsWsl: true })
+      expect(
+        resolveWslSessionContext({
+          ...args,
+          shellOverride: 'wsl.exe',
+          forceHostRuntime: true
+        })
+      ).toEqual({ distro: 'Ubuntu', treatPosixCwdAsWsl: true })
+    } finally {
+      if (platform) {
+        Object.defineProperty(process, 'platform', platform)
+      }
+    }
+  })
 })

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -76,6 +76,8 @@ export type CreateOrAttachRequest = {
      *  instead of defaulting to COMSPEC (which is always cmd.exe on Windows)
      *  or the hard-coded powershell.exe fallback. */
     shellOverride?: string
+    /** Current pane explicitly selected the local host instead of its project runtime. */
+    forceHostRuntime?: boolean
     /** Preferred WSL distro for generic `wsl.exe` launches. */
     terminalWindowsWslDistro?: string | null
     /** Why: the UI keeps PowerShell as one shell family, but the runtime may

--- a/src/main/daemon/wsl-session-context.ts
+++ b/src/main/daemon/wsl-session-context.ts
@@ -3,6 +3,7 @@ import { isWslShellName } from '../../shared/local-windows-terminal-runtime'
 import { getDefaultWslDistro, parseWslPath } from '../wsl'
 import { parsePtySessionId } from './pty-session-id'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 
 export type WslSessionContext = {
   distro: string
@@ -30,6 +31,7 @@ export function resolveWslSessionContext(args: {
   sessionId?: string
   shellOverride?: string
   terminalWindowsWslDistro?: string | null
+  forceHostRuntime?: boolean
 }): WslSessionContext | undefined {
   if (process.platform !== 'win32') {
     return undefined
@@ -37,6 +39,14 @@ export function resolveWslSessionContext(args: {
   const cwdDistro = args.cwd ? parseWslUncPath(args.cwd)?.distro : undefined
   if (cwdDistro) {
     return { distro: cwdDistro, treatPosixCwdAsWsl: true }
+  }
+  if (
+    args.forceHostRuntime === true &&
+    args.cwd &&
+    isWindowsAbsolutePathLike(args.cwd) &&
+    !isWslShellName(args.shellOverride ?? '')
+  ) {
+    return undefined
   }
   return (
     (args.sessionId ? getWslContextFromSessionId(args.sessionId) : undefined) ??

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -12328,6 +12328,53 @@ describe('registerPtyHandlers', () => {
     expect(result.startupCwdFallback).toEqual({ kind: 'worktree', cwd: worktreePath })
   })
 
+  it('threads forced-host authority without allowing a missing-cwd fallback', async () => {
+    const providerSpawn = vi.fn().mockResolvedValue({ id: 'pty-forced-host' })
+    installDaemonTestProvider({ spawn: providerSpawn })
+    registerPtyHandlers(mainWindow as never)
+    const missingCwd = 'C:\\Users\\alice\\repo\\deleted-folder'
+    statSyncMock.mockImplementation((target: string) => {
+      if (target === missingCwd) {
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      }
+      return { isDirectory: () => true, mode: 0o755 }
+    })
+
+    const result = (await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      cwd: missingCwd,
+      cwdFallback: 'worktree',
+      forceHostRuntime: true,
+      worktreeId: 'repo-1::\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
+    })) as { startupCwdFallback?: { kind: string; cwd: string } }
+
+    expect(providerSpawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: 'C:/Users/alice/repo/deleted-folder',
+        forceHostRuntime: true
+      })
+    )
+    expect(result.startupCwdFallback).toBeUndefined()
+  })
+
+  it('does not treat a truthy non-boolean IPC value as forced-host authority', async () => {
+    const providerSpawn = vi.fn().mockResolvedValue({ id: 'pty-not-forced-host' })
+    installDaemonTestProvider({ spawn: providerSpawn })
+    registerPtyHandlers(mainWindow as never)
+
+    await handlers.get('pty:spawn')!(null, {
+      cols: 80,
+      rows: 24,
+      cwd: 'C:\\Users\\alice\\repo',
+      forceHostRuntime: 'false'
+    } as never)
+
+    expect(providerSpawn).toHaveBeenCalledWith(
+      expect.not.objectContaining({ forceHostRuntime: true })
+    )
+  })
+
   it.each(['/home/alice/repo', '/a', '/c'])(
     'keeps an existing POSIX startup cwd for the selected WSL runtime (%s)',
     async (startupCwd) => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5817,6 +5817,8 @@ export function registerPtyHandlers(
         cwd?: string
         // Why: fresh local spawns opt into recovering a saved cwd whose dir was deleted (#7239); reattach/remote need exact cwd, so the flag alone isn't sufficient.
         cwdFallback?: 'worktree'
+        /** Current pane explicitly selected the local host instead of its project runtime. */
+        forceHostRuntime?: boolean
         env?: Record<string, string>
         envToDelete?: string[]
         command?: string
@@ -5969,7 +5971,10 @@ export function registerPtyHandlers(
         if (!preAdoptedStablePane) {
           // Why: reattach needs exact cwd, SSH cannot probe locally, and successful stable-pane adoption needs no launch preflight.
           const requestedMissingCwdFallback =
-            !args.connectionId && !args.sessionId && args.cwdFallback === 'worktree'
+            !args.connectionId &&
+            !args.sessionId &&
+            args.forceHostRuntime !== true &&
+            args.cwdFallback === 'worktree'
           const isPosixStartupCwd = args.cwd?.startsWith('/') === true
           const startupWorkspaceCwd =
             requestedMissingCwdFallback && isPosixStartupCwd
@@ -6097,7 +6102,8 @@ export function registerPtyHandlers(
               cwd,
               sessionId: effectiveSessionId,
               shellOverride: terminalRuntimeOptions.shellOverride,
-              terminalWindowsWslDistro: terminalRuntimeOptions.terminalWindowsWslDistro
+              terminalWindowsWslDistro: terminalRuntimeOptions.terminalWindowsWslDistro,
+              forceHostRuntime: args.forceHostRuntime === true
             })?.distro ?? null)
           : null
         const initialSelectionTarget = getCodexSelectionTargetForPty(
@@ -6391,6 +6397,7 @@ export function registerPtyHandlers(
           cols: args.cols,
           rows: args.rows,
           cwd,
+          ...(args.forceHostRuntime === true ? { forceHostRuntime: true } : {}),
           ...(prevalidatedCwd && !isDaemonHostSpawn ? { prevalidatedCwd } : {}),
           env: spawnEnv,
           ...(isMintedSessionId ? { isNewSession: true } : {})

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1308,6 +1308,32 @@ describe('LocalPtyProvider', () => {
       )
     })
 
+    it('keeps a native Windows cwd on the requested host shell when worktree context is WSL', async () => {
+      const platform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+
+      try {
+        await provider.spawn({
+          cols: 80,
+          rows: 24,
+          cwd: 'C:\\Users\\jin\\repo',
+          shellOverride: 'cmd.exe',
+          forceHostRuntime: true,
+          worktreeId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo'
+        })
+      } finally {
+        if (platform) {
+          Object.defineProperty(process, 'platform', platform)
+        }
+      }
+
+      expect(spawnMock).toHaveBeenCalledWith(
+        'cmd.exe',
+        ['/K', 'chcp 65001 > nul'],
+        expect.objectContaining({ cwd: 'C:\\Users\\jin\\repo' })
+      )
+    })
+
     it('resolves the Git Bash default shell and preserves the requested cwd', async () => {
       const platform = Object.getOwnPropertyDescriptor(process, 'platform')
       const originalProgramFiles = process.env.ProgramFiles

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -13,6 +13,8 @@ import { existsSync } from 'node:fs'
 import * as pty from 'node-pty'
 import { getDefaultWslDistro, parseWslPath, isWslAvailableAsync } from '../wsl'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
+import { isWslShellName } from '../../shared/local-windows-terminal-runtime'
 import { isBracketedPasteSafeShell } from '../../shared/startup-command-submission'
 import {
   injectHistoryEnv,
@@ -567,8 +569,17 @@ export class LocalPtyProvider implements IPtyProvider {
       assertSafeAgentStartupCwd(cwd, args.command)
     }
     const wslInfo = process.platform === 'win32' ? parseWslPath(cwd) : null
+    const requestedShellFamily =
+      args.shellOverride || this.opts.getWindowsShell?.() || process.env.COMSPEC || 'powershell.exe'
+    const nativeCwdSelectsHostShell =
+      args.forceHostRuntime === true &&
+      wslInfo === null &&
+      isWindowsAbsolutePathLike(cwd) &&
+      !isWslShellName(requestedShellFamily)
     const worktreeWslContext =
-      process.platform === 'win32' ? getWslContextFromWorktreeId(args.worktreeId) : undefined
+      process.platform === 'win32' && !nativeCwdSelectsHostShell
+        ? getWslContextFromWorktreeId(args.worktreeId)
+        : undefined
     const preferredWslContext =
       process.platform === 'win32'
         ? getWslContextFromPreferredDistro(args.terminalWindowsWslDistro)
@@ -596,11 +607,6 @@ export class LocalPtyProvider implements IPtyProvider {
       validationCwd = resolved.validationCwd
     } else if (process.platform === 'win32') {
       // Why: shellOverride opens one tab in a non-default shell without changing the user's setting; it wins over the setting.
-      const requestedShellFamily =
-        args.shellOverride ||
-        this.opts.getWindowsShell?.() ||
-        process.env.COMSPEC ||
-        'powershell.exe'
       const shellFamily = worktreeWslContext ? 'wsl.exe' : requestedShellFamily
       if (!launchWslContext && pathWin32.basename(shellFamily).toLowerCase() === 'wsl.exe') {
         launchWslContext = getWslContextFromPreferredDistro(getDefaultWslDistro())

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -81,6 +81,8 @@ export type PtySpawnOptions = {
    *  changing the user's persistent default shell setting. Only consulted on
    *  Windows; ignored on macOS/Linux where shell selection is not exposed. */
   shellOverride?: string
+  /** Current pane explicitly selected the local host instead of its project runtime. */
+  forceHostRuntime?: boolean
   /** Preferred WSL distro for generic `wsl.exe` launches. Worktree/session
    *  distro still wins when the cwd already identifies a WSL distro. */
   terminalWindowsWslDistro?: string | null

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1467,6 +1467,8 @@ export type PreloadApi = {
       rows: number
       cwd?: string
       cwdFallback?: 'worktree'
+      /** Current pane explicitly selected the local host instead of its project runtime. */
+      forceHostRuntime?: boolean
       env?: Record<string, string>
       envToDelete?: string[]
       command?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -943,6 +943,7 @@ const api = {
       rows: number
       cwd?: string
       cwdFallback?: 'worktree'
+      forceHostRuntime?: boolean
       env?: Record<string, string>
       envToDelete?: string[]
       command?: string

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8409,9 +8409,13 @@ describe('connectPanePty', () => {
 
   // Regression (#12320): a cold restore after reboot typed PowerShell single quotes into
   // cmd.exe tabs, so the agent CLI rejected the resume argv ("unexpected argument").
+  const DEFAULT_WINDOWS_COLD_RESTORE_CWD = 'C:\\Users\\neil\\orca\\workspaces\\orca\\feature'
   async function runWindowsColdRestoreResume(args: {
     terminalWindowsShell: string
     tabShellOverride?: string
+    worktreePath?: string
+    cwd?: string
+    forceHostRuntime?: boolean
   }): Promise<string | undefined> {
     const restoreNavigator = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
@@ -8458,7 +8462,8 @@ describe('connectPanePty', () => {
             {
               id: 'tab-1',
               ptyId: 'restored-session',
-              ...(args.tabShellOverride ? { shellOverride: args.tabShellOverride } : {})
+              ...(args.tabShellOverride ? { shellOverride: args.tabShellOverride } : {}),
+              ...(args.forceHostRuntime ? { forceHostRuntime: true } : {})
             }
           ]
         },
@@ -8480,9 +8485,20 @@ describe('connectPanePty', () => {
             capturedAt: 1,
             updatedAt: 1
           }
+        },
+        worktreesByRepo: {
+          repo1: [
+            {
+              id: 'wt-1',
+              repoId: 'repo1',
+              path: args.worktreePath ?? DEFAULT_WINDOWS_COLD_RESTORE_CWD,
+              displayName: 'feat/notis'
+            }
+          ]
         }
       } as StoreState
       const deps = createDeps({
+        cwd: args.cwd ?? DEFAULT_WINDOWS_COLD_RESTORE_CWD,
         restoredLeafId: LEAF_2,
         restoredPtyIdByLeafId: { [LEAF_2]: 'restored-session' }
       })
@@ -8523,6 +8539,19 @@ describe('connectPanePty', () => {
     await expect(
       runWindowsColdRestoreResume({ terminalWindowsShell: 'powershell.exe' })
     ).resolves.toBe("codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'")
+  })
+
+  it('uses the native spawn cwd when the catalog still points at WSL', async () => {
+    await expect(
+      runWindowsColdRestoreResume({
+        terminalWindowsShell: 'cmd.exe',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\repo',
+        cwd: 'C:\\Users\\neil\\orca\\workspaces\\orca\\feature',
+        forceHostRuntime: true
+      })
+    ).resolves.toBe('codex "--dangerously-bypass-approvals-and-sandbox" "resume" "codex-session-1"')
+    expect(createdTransportOptions.at(-1)).toMatchObject({ forceHostRuntime: true })
+    expect(createdTransportOptions.at(-1)).not.toHaveProperty('cwdFallback')
   })
 
   it('keeps a contentless reattach when the sleeping record represents a live session', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3785,7 +3785,10 @@ export function connectPanePty(
     // Why: only fresh local IPC spawns may recover from a saved startup cwd
     // whose directory was deleted (#7239); remote-runtime and SSH spawns
     // resolve cwd on another host and must keep exact cwd semantics.
-    ...(runtimeEnvironmentId === null && !connectionId ? { cwdFallback: 'worktree' as const } : {}),
+    ...(runtimeEnvironmentId === null && !connectionId && !tab?.forceHostRuntime
+      ? { cwdFallback: 'worktree' as const }
+      : {}),
+    ...(tab?.forceHostRuntime ? { forceHostRuntime: true } : {}),
     env: paneEnv,
     ...(paneStartup?.envToDelete ? { envToDelete: paneStartup.envToDelete } : {}),
     command: shouldDeliverStartupViaTerminalPaste ? undefined : paneStartup?.command,
@@ -5031,13 +5034,13 @@ export function connectPanePty(
       const launchConfig =
         (useLiveEntry && entry ? state.getAgentLaunchConfigForStatusEntry(entry) : undefined) ??
         matchingSleepingLaunchConfig
-      // Why: the resume line is typed into this pane's live shell, so its quoting must
-      // follow the tab's effective Windows shell, not the win32 PowerShell default.
+      // Why: quote for the shell selected by this exact spawn. The catalog worktree path
+      // can still be WSL UNC while a restored pane's authoritative cwd is native Windows.
       const resumeTarget = resolveAgentResumeLaunchTarget({
         projectRuntime,
         connectionId,
         executionHostId,
-        worktreePath: worktree?.path,
+        cwd: deps.cwd,
         terminalWindowsShell: state.settings?.terminalWindowsShell,
         tabShellOverride: shellOverride
       })

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -218,6 +218,8 @@ export type PtyTransport = {
 export type IpcPtyTransportOptions = {
   cwd?: string
   cwdFallback?: 'worktree'
+  /** Current pane explicitly selected the local host instead of its project runtime. */
+  forceHostRuntime?: boolean
   env?: Record<string, string>
   envToDelete?: string[]
   command?: string

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -603,6 +603,25 @@ describe('createIpcPtyTransport', () => {
     transport.disconnect()
   })
 
+  it('threads forced-host authority without allowing a worktree cwd fallback', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+
+    const transport = createIpcPtyTransport({
+      cwdFallback: 'worktree',
+      forceHostRuntime: true
+    })
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        forceHostRuntime: true
+      })
+    )
+    expect(spawn).toHaveBeenCalledWith(expect.not.objectContaining({ cwdFallback: 'worktree' }))
+    transport.disconnect()
+  })
+
   it('omits the missing-cwd fallback flag for session reattach spawns', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -557,6 +557,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   const {
     cwd,
     cwdFallback,
+    forceHostRuntime,
     env,
     envToDelete,
     command,
@@ -808,12 +809,13 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       try {
         // Why: cwd fallback is only for fresh local spawns — reattach keeps the session's cwd and SSH transports resolve cwd on the remote host.
         const shouldSendLocalCwdFallback =
-          cwdFallback === 'worktree' && !connectionId && !admittedSessionId
+          cwdFallback === 'worktree' && !forceHostRuntime && !connectionId && !admittedSessionId
         const result = await window.api.pty.spawn({
           cols: options.cols ?? 80,
           rows: options.rows ?? 24,
           cwd,
           ...(shouldSendLocalCwdFallback ? { cwdFallback } : {}),
+          ...(forceHostRuntime ? { forceHostRuntime: true } : {}),
           env: options.env ?? env,
           ...((options.envToDelete ?? envToDelete)
             ? { envToDelete: options.envToDelete ?? envToDelete }

--- a/src/renderer/src/lib/agent-resume-launch-target.test.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.test.ts
@@ -23,7 +23,7 @@ const LOCAL_WINDOWS_ARGS: AgentResumeLaunchTargetArgs = {
   projectRuntime: undefined,
   connectionId: null,
   executionHostId: 'local',
-  worktreePath: 'C:\\Users\\neil\\orca\\workspaces\\orca\\feature',
+  cwd: 'C:\\Users\\neil\\orca\\workspaces\\orca\\feature',
   terminalWindowsShell: null
 }
 
@@ -98,10 +98,10 @@ describe('resolveAgentResumeLaunchTarget on a Windows client', () => {
     ).resolves.toEqual({ platform: 'win32', shell: undefined })
   })
 
-  it('keeps POSIX quoting for a WSL UNC worktree', async () => {
+  it('keeps POSIX quoting for a WSL UNC cwd', async () => {
     await expect(
       resolveWith({
-        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\repo',
+        cwd: '\\\\wsl.localhost\\Ubuntu\\home\\neil\\repo',
         terminalWindowsShell: 'cmd.exe'
       })
     ).resolves.toEqual({ platform: 'linux', shell: undefined })
@@ -141,7 +141,7 @@ describe('resolveAgentResumeLaunchTarget off Windows', () => {
   it('ignores a stale Windows shell setting on a mac client', async () => {
     await expect(
       resolveWith({
-        worktreePath: '/Users/neil/repo',
+        cwd: '/Users/neil/repo',
         terminalWindowsShell: 'cmd.exe'
       })
     ).resolves.toEqual({ platform: 'darwin', shell: undefined })

--- a/src/renderer/src/lib/agent-resume-launch-target.ts
+++ b/src/renderer/src/lib/agent-resume-launch-target.ts
@@ -18,7 +18,7 @@ export type AgentResumeLaunchTargetArgs = {
   connectionId: string | null | undefined
   /** Pane/workspace execution owner; only a 'local' host is the one `terminalWindowsShell` describes. */
   executionHostId: string | null
-  worktreePath: string | null | undefined
+  cwd: string | null | undefined
   terminalWindowsShell: string | null | undefined
   /** Per-tab Windows shell override, which beats the global setting at spawn time. */
   tabShellOverride?: string | null
@@ -31,7 +31,7 @@ function resolveResumeLaunchPlatform(args: AgentResumeLaunchTargetArgs): NodeJS.
   if (args.projectRuntime?.status === 'resolved' && args.projectRuntime.runtime.kind === 'wsl') {
     return 'linux'
   }
-  if (args.connectionId || (args.worktreePath && isWslUncPath(args.worktreePath))) {
+  if (args.connectionId || (args.cwd && isWslUncPath(args.cwd))) {
     return 'linux'
   }
   return CLIENT_PLATFORM

--- a/src/renderer/src/lib/sleeping-agent-session-launch.ts
+++ b/src/renderer/src/lib/sleeping-agent-session-launch.ts
@@ -37,7 +37,7 @@ function getResumeLaunchTarget(worktreeId: string): AgentResumeLaunchTarget {
     projectRuntime: getLocalProjectExecutionRuntimeContext(state, worktreeId),
     connectionId: repo?.connectionId,
     executionHostId: getExecutionHostIdForWorktree(state, worktreeId),
-    worktreePath: worktree?.path,
+    cwd: worktree?.path,
     terminalWindowsShell: state.settings?.terminalWindowsShell
   })
 }

--- a/src/shared/agent-resume-launch-command.ts
+++ b/src/shared/agent-resume-launch-command.ts
@@ -53,6 +53,13 @@ function findClaudeExecutableIndex(tokens: readonly string[], shell: AgentStartu
   return -1
 }
 
+export function isResumeArgvSafe(resumeArgv: readonly string[], shell: AgentStartupShell): boolean {
+  return (
+    shell !== 'cmd' ||
+    resumeArgv.slice(1).every((value) => !/[\^&|<>()%!"]/.test(value) && !value.endsWith('\\'))
+  )
+}
+
 /** Joins the resolved base command with the agent's resume argv. Claude goes
  * through the selector guard below; other agents keep plain appending. */
 export function buildAgentResumeLaunchCommand(

--- a/src/shared/local-build-compatibility-contract.json
+++ b/src/shared/local-build-compatibility-contract.json
@@ -3,9 +3,9 @@
   "appId": "com.stablyai.orca",
   "stateSchemaVersion": 1,
   "readableStateSchemaVersions": [1],
-  "daemonProtocolVersion": 33,
+  "daemonProtocolVersion": 34,
   "attachableDaemonProtocolVersions": [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33
+    27, 28, 29, 30, 31, 32, 33, 34
   ]
 }

--- a/src/shared/local-build-compatibility-contract.ts
+++ b/src/shared/local-build-compatibility-contract.ts
@@ -3,9 +3,9 @@ export const LOCAL_BUILD_COMPATIBILITY_CONTRACT = {
   appId: 'com.stablyai.orca',
   stateSchemaVersion: 1,
   readableStateSchemaVersions: [1],
-  daemonProtocolVersion: 33,
+  daemonProtocolVersion: 34,
   attachableDaemonProtocolVersions: [
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-    27, 28, 29, 30, 31, 32, 33
+    27, 28, 29, 30, 31, 32, 33, 34
   ]
 } as const

--- a/src/shared/tui-agent-resume-cmd-security.test.ts
+++ b/src/shared/tui-agent-resume-cmd-security.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildAgentResumeStartupPlan } from './tui-agent-startup'
+
+describe('cmd agent resume security', () => {
+  it('accepts ordinary values and rejects bytes that can change cmd parsing', () => {
+    expect(
+      buildAgentResumeStartupPlan({
+        agent: 'grok',
+        providerSession: { key: 'session_id', id: 'session with spaces' },
+        cmdOverrides: {},
+        platform: 'win32',
+        shell: 'cmd'
+      })?.launchCommand
+    ).toBe('grok "--resume" "session with spaces"')
+
+    for (const id of [
+      'session & whoami',
+      'session ^ caret',
+      'session" --help "tail',
+      'session%PATH%',
+      'session!value!',
+      'session\\'
+    ]) {
+      expect(
+        buildAgentResumeStartupPlan({
+          agent: 'grok',
+          providerSession: { key: 'session_id', id },
+          cmdOverrides: {},
+          platform: 'win32',
+          shell: 'cmd'
+        })
+      ).toBeNull()
+    }
+  })
+})

--- a/src/shared/tui-agent-startup.ts
+++ b/src/shared/tui-agent-startup.ts
@@ -20,7 +20,7 @@ import { inlineAgentDraftFitsPlatform } from './agent-draft-platform-limit'
 import type { TuiAgent } from './types'
 import type { SessionOptionValue } from './native-chat-session-options'
 import { resolveAgentLaunchCommand } from './tui-agent-launch-command'
-import { buildAgentResumeLaunchCommand } from './agent-resume-launch-command'
+import { buildAgentResumeLaunchCommand, isResumeArgvSafe } from './agent-resume-launch-command'
 
 export type AgentStartupPlan = {
   agent: TuiAgent
@@ -204,6 +204,9 @@ export function buildAgentResumeStartupPlan(args: {
     return null
   }
   const shell = resolveStartupShell(args.platform, args.shell)
+  if (!isResumeArgvSafe(argv, shell)) {
+    return null
+  }
   const config = TUI_AGENT_CONFIG[args.agent]
   const resolvedAgentCommand = args.agentCommand?.trim()
   const baseCommand = resolvedAgentCommand


### PR DESCRIPTION
## ELI5

A terminal tab can explicitly choose the Windows host even when its workspace is backed by WSL. When Orca had to recreate that terminal, the host choice stopped at the renderer: stale WSL worktree or session identity could take control again, recreate the pane under WSL, and quote an agent resume command for the wrong shell.

This change carries the tab's explicit host-runtime authority through the complete PTY spawn path.

## What Changed

- Thread `forceHostRuntime` through renderer transport, preload IPC, main-process PTY routing, local and daemon providers, and terminal subprocess creation.
- Prevent stale WSL worktree or session identity from overriding a forced-host spawn with a native Windows cwd.
- Continue selecting WSL for a WSL cwd or an explicit `wsl.exe` shell.
- Prevent forced-host spawns from silently falling back to a WSL worktree root when their native cwd is missing.
- Resolve cold-resume command quoting from the pane's spawn cwd rather than the catalog worktree path.
- Keep main-process runtime metadata aligned with the runtime that will actually spawn.
- Bump the daemon protocol to v34 and update packaged local-build compatibility metadata.
- Preserve attach-only reattachment to older daemon generations while failing closed when a pre-v34 daemon would need to create a forced-host replacement.
- Fail closed when a machine-generated cmd.exe resume locator contains shell metacharacters or a trailing backslash that the existing command boundary cannot preserve safely.

## Why

`forceHostRuntime` was persisted on the terminal tab and excluded project-runtime selection in the renderer, but it was not part of the downstream PTY creation contract. Lower layers could therefore infer WSL again from the worktree or session identity.

Silently dropping the field for a replacement spawn is unsafe because a pre-v34 daemon could recreate the pane under WSL. Attach-only reattachment is safe because it launches no process and sends no shell-routing fields.

## Linked Issue

Part of #9827

This addresses one explicit-host cold-restore path within that tracking issue. It does not complete the broader WSL warm/cold restore matrix, multi-distro validation, OSC 7 recovery, or update-time relay handoff.

## Visual Proof

N/A - there is no layout or styling change. The observable change is which runtime owns a restored PTY and which shell dialect is used for its resume command.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Completed locally on Windows:

- 78 startup, prompt, Hermes, and resume-security tests passed.
- 16 focused renderer, IPC, provider, daemon, and protocol acceptance tests passed.
- `pnpm run typecheck`
- Changed-file `oxfmt --check`
- Changed-file `oxlint --deny-warnings`
- `pnpm run check:max-lines-ratchet`
- `pnpm run build:electron-vite`
- `git diff --check`

The broad Windows test sweep still includes existing host-dependent failures around the configured default WSL distro, a synthetic missing WSL UNC fixture, and Codex path/provenance expectations. The focused changed behavior is green; normal CI remains the merge gate.

## Security Audit

The restored host-shell path can generate a cmd.exe command containing an authoritative provider session ID or resume-file path. cmd.exe performs multiple parsing and expansion passes, so caret-escaping `^`, `&`, `|`, `<`, `>`, `(`, `)`, `%`, `!`, or `"` does not provide a reliable argv-preservation guarantee. A locator ending in a backslash can also corrupt the generated closing quote.

For cmd.exe cold resume, this change rejects a resume locator containing those bytes or a trailing backslash rather than emitting a command that could be reinterpreted or corrupted. Ordinary values, including values containing spaces, remain supported.

The check is intentionally scoped to machine-generated resume argv. The shared cmd quoting primitive, normal startup prompts, Hermes environment delivery, configured agent arguments, PowerShell/POSIX behavior, SSH, and non-resume launches remain unchanged.

`forceHostRuntime` is parsed as an exact boolean at both IPC and daemon trust boundaries; truthy strings or objects cannot claim host-runtime authority.

This does not claim that arbitrary cmd.exe command strings are safe to synthesize.

## AI Disclosure

Implemented with OpenAI GPT-5.6-Sol through OmO/Senpi. Parallel Oracle and QA agents reviewed goal alignment, code quality, security, cross-platform behavior, and upstream context.

## Review

Reviewed for:

- native Windows versus WSL runtime authority;
- explicit WSL cwd and shell precedence;
- preserved-daemon compatibility;
- attach-only versus replacement-spawn behavior;
- missing-cwd fallback;
- SSH and remote isolation;
- command quoting from the pane's authoritative cwd;
- packaged local-build compatibility.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Focused lint, typecheck, tests, and Electron build pass locally. Full CI is required because the broad Windows sweep has the pre-existing host-dependent failures described above.

## Author

- GitHub: @jh280722
