### PR TITLE
feat(settings): let the Ghostty import read a config file you pick

### DIFF
--- a/config/localization-coverage-allowlist.json
+++ b/config/localization-coverage-allowlist.json
@@ -67,14 +67,14 @@
     "kind": "object-property:keywords",
     "text": "Ghostty",
     "dynamic": false,
-    "count": 2
+    "count": 3
   },
   {
     "filePath": "src/renderer/src/components/settings/terminal-advanced-platform-search.ts",
     "kind": "object-property:keywords",
     "text": "ghostty",
     "dynamic": false,
-    "count": 2
+    "count": 3
   },
   {
     "filePath": "src/renderer/src/components/settings/terminal-pane-appearance-search.ts",

--- a/src/main/ghostty/ghostty-import-source-validation.ts
+++ b/src/main/ghostty/ghostty-import-source-validation.ts
@@ -1,0 +1,18 @@
+import type { GhosttyImportSource } from '../../shared/global-settings-types'
+
+const VALID_SOURCE_KINDS = new Set(['auto', 'chooseFile'])
+
+export function validateGhosttyImportSource(source: unknown): GhosttyImportSource | null {
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    return null
+  }
+  const entries = Object.entries(source)
+  if (entries.length !== 1 || entries[0]?.[0] !== 'kind') {
+    return null
+  }
+  const kind = entries[0][1]
+  if (typeof kind !== 'string' || !VALID_SOURCE_KINDS.has(kind)) {
+    return null
+  }
+  return { kind } as GhosttyImportSource
+}

--- a/src/main/ghostty/index.test.ts
+++ b/src/main/ghostty/index.test.ts
@@ -7,6 +7,11 @@ const { statMock, readFileMock } = vi.hoisted(() => ({
   readFileMock: vi.fn()
 }))
 
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: { showOpenDialog: vi.fn() }
+}))
+
 vi.mock('fs/promises', () => ({
   stat: statMock,
   readFile: readFileMock

--- a/src/main/ghostty/index.ts
+++ b/src/main/ghostty/index.ts
@@ -1,8 +1,15 @@
 import { readFile, stat } from 'node:fs/promises'
 import { platform } from 'node:os'
-import type { GhosttyImportPreview, GlobalSettings } from '../../shared/global-settings-types'
+import type { WebContents } from 'electron'
+import type {
+  GhosttyImportPreview,
+  GhosttyImportSource,
+  GlobalSettings
+} from '../../shared/global-settings-types'
 import type { Store } from '../persistence'
 import { findGhosttyConfigPaths } from './discovery'
+import { validateGhosttyImportSource } from './ghostty-import-source-validation'
+import { chooseManualGhosttyConfigPath } from './manual-ghostty-config-file'
 import { parseGhosttyConfig } from './parser'
 import { mapGhosttyToOrca } from './mapper'
 import { resolveGhosttyThemeColors } from './theme-resolution'
@@ -100,8 +107,46 @@ async function applyThemeReference(parsed: Record<string, string | string[]>): P
   return []
 }
 
-export async function previewGhosttyImport(store: Store): Promise<GhosttyImportPreview> {
-  const configPaths = await findGhosttyConfigPaths()
+type GhosttyConfigSelection = { canceled: true } | { canceled: false; configPaths: string[] }
+
+async function resolveGhosttyConfigSource(
+  source: GhosttyImportSource,
+  webContents?: WebContents
+): Promise<GhosttyConfigSelection> {
+  switch (source.kind) {
+    case 'auto': {
+      return { canceled: false, configPaths: await findGhosttyConfigPaths() }
+    }
+    case 'chooseFile': {
+      const chosenPath = await chooseManualGhosttyConfigPath(webContents)
+      return chosenPath === null
+        ? { canceled: true }
+        : { canceled: false, configPaths: [chosenPath] }
+    }
+  }
+}
+
+export async function previewGhosttyImport(
+  store: Store,
+  source: unknown = { kind: 'auto' },
+  webContents?: WebContents
+): Promise<GhosttyImportPreview> {
+  const validatedSource = validateGhosttyImportSource(source)
+  if (!validatedSource) {
+    return {
+      found: false,
+      diff: {},
+      unsupportedKeys: [],
+      error: 'Invalid Ghostty import source.'
+    }
+  }
+
+  const selection = await resolveGhosttyConfigSource(validatedSource, webContents)
+  if (selection.canceled) {
+    return { found: false, canceled: true, diff: {}, unsupportedKeys: [] }
+  }
+
+  const configPaths = selection.configPaths
   if (configPaths.length === 0) {
     return { found: false, diff: {}, unsupportedKeys: [] }
   }

--- a/src/main/ghostty/manual-config-import.test.ts
+++ b/src/main/ghostty/manual-config-import.test.ts
@@ -1,0 +1,208 @@
+import type { Store } from '../persistence'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { statMock, readFileMock, showOpenDialogMock, fromWebContentsMock } = vi.hoisted(() => ({
+  statMock: vi.fn(),
+  readFileMock: vi.fn(),
+  showOpenDialogMock: vi.fn(),
+  fromWebContentsMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: fromWebContentsMock },
+  dialog: { showOpenDialog: showOpenDialogMock }
+}))
+
+vi.mock('fs/promises', () => ({
+  stat: statMock,
+  readFile: readFileMock
+}))
+
+vi.mock('os', () => ({
+  platform: vi.fn(() => 'darwin'),
+  homedir: vi.fn(() => '/Users/alice')
+}))
+
+import { previewGhosttyImport } from './index'
+
+const DISCOVERED_CONFIG_PATH = '/Users/alice/.config/ghostty/config'
+const PICKED_CONFIG_PATH = '/Users/alice/Documents/ghostty-backup/config'
+const CONFIG_CONTENT = `
+font-family = JetBrains Mono
+font-size = 15
+background = #1a1a1a
+mouse-hide-while-typing = true
+`
+
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+
+beforeEach(() => {
+  delete process.env.XDG_CONFIG_HOME
+})
+
+afterEach(() => {
+  vi.clearAllMocks()
+  if (originalXdgConfigHome !== undefined) {
+    process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+  } else {
+    delete process.env.XDG_CONFIG_HOME
+  }
+})
+
+function createStore(settings: Record<string, unknown> = {}): Store {
+  return {
+    getSettings: () => settings as GlobalSettings
+  } as Store
+}
+
+function mockReadableFiles(files: Record<string, { content: string; size?: number }>): void {
+  statMock.mockImplementation(async (filePath: string) => {
+    const file = files[filePath]
+    if (!file) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    }
+    return { isFile: () => true, size: file.size ?? file.content.length }
+  })
+  readFileMock.mockImplementation(async (filePath: string) => {
+    const file = files[filePath]
+    if (!file) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    }
+    return file.content
+  })
+}
+
+describe('previewGhosttyImport manual config file', () => {
+  it('falls back to auto discovery when no source is given', async () => {
+    mockReadableFiles({ [DISCOVERED_CONFIG_PATH]: { content: CONFIG_CONTENT } })
+
+    const result = await previewGhosttyImport(createStore())
+
+    expect(showOpenDialogMock).not.toHaveBeenCalled()
+    expect(result.found).toBe(true)
+    expect(result.configPaths).toEqual([DISCOVERED_CONFIG_PATH])
+  })
+
+  it('rejects an invalid source without discovering or prompting', async () => {
+    const surprise = await previewGhosttyImport(createStore(), { kind: 'chooseFolder' })
+    const nullSource = await previewGhosttyImport(createStore(), null)
+    const extraField = await previewGhosttyImport(createStore(), {
+      kind: 'chooseFile',
+      path: '/Users/alice/.config/ghostty/config'
+    })
+
+    expect(surprise).toEqual({
+      found: false,
+      diff: {},
+      unsupportedKeys: [],
+      error: 'Invalid Ghostty import source.'
+    })
+    expect(nullSource.error).toBe('Invalid Ghostty import source.')
+    expect(extraField.error).toBe('Invalid Ghostty import source.')
+    expect(statMock).not.toHaveBeenCalled()
+    expect(showOpenDialogMock).not.toHaveBeenCalled()
+  })
+
+  it('marks a dismissed file picker as canceled without touching settings', async () => {
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: true, filePaths: [] })
+
+    const result = await previewGhosttyImport(createStore(), { kind: 'chooseFile' })
+
+    expect(result).toEqual({ found: false, canceled: true, diff: {}, unsupportedKeys: [] })
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty file-picker selection as canceled', async () => {
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: false, filePaths: [] })
+
+    const result = await previewGhosttyImport(createStore(), { kind: 'chooseFile' })
+
+    expect(result).toEqual({ found: false, canceled: true, diff: {}, unsupportedKeys: [] })
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses a picked config above the import size limit', async () => {
+    mockReadableFiles({
+      [PICKED_CONFIG_PATH]: { content: CONFIG_CONTENT, size: 1_000_001 }
+    })
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: false, filePaths: [PICKED_CONFIG_PATH] })
+
+    const result = await previewGhosttyImport(createStore(), { kind: 'chooseFile' })
+
+    expect(result.found).toBe(false)
+    expect(result.canceled).toBeUndefined()
+    expect(result.error).toBe('Config file is too large to import (1000001 bytes, limit 1000000).')
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('reports a picked config that cannot be read', async () => {
+    mockReadableFiles({})
+    statMock.mockResolvedValue({ isFile: () => true, size: 128 })
+    readFileMock.mockRejectedValue(new Error('EACCES: permission denied'))
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: false, filePaths: [PICKED_CONFIG_PATH] })
+
+    const result = await previewGhosttyImport(createStore(), { kind: 'chooseFile' })
+
+    expect(result.found).toBe(false)
+    expect(result.error).toBe('Could not read config: EACCES: permission denied')
+  })
+
+  it('produces the same preview from a picked file as from auto discovery', async () => {
+    const settings = { terminalFontFamily: 'Menlo', terminalFontSize: 12 }
+    mockReadableFiles({ [DISCOVERED_CONFIG_PATH]: { content: CONFIG_CONTENT } })
+    const discovered = await previewGhosttyImport(createStore(settings), { kind: 'auto' })
+
+    vi.clearAllMocks()
+    mockReadableFiles({ [PICKED_CONFIG_PATH]: { content: CONFIG_CONTENT } })
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: false, filePaths: [PICKED_CONFIG_PATH] })
+    const picked = await previewGhosttyImport(createStore(settings), { kind: 'chooseFile' })
+
+    expect(discovered.found).toBe(true)
+    expect(picked.found).toBe(true)
+    expect(picked.diff).toEqual(discovered.diff)
+    expect(picked.unsupportedKeys).toEqual(discovered.unsupportedKeys)
+    expect(picked.configPath).toBe(PICKED_CONFIG_PATH)
+    expect(picked.configPaths).toEqual([PICKED_CONFIG_PATH])
+  })
+
+  it('reads only the picked file, ignoring the discovered config paths', async () => {
+    mockReadableFiles({
+      [DISCOVERED_CONFIG_PATH]: { content: 'font-size = 30\n' },
+      [PICKED_CONFIG_PATH]: { content: CONFIG_CONTENT }
+    })
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: false, filePaths: [PICKED_CONFIG_PATH] })
+
+    const result = await previewGhosttyImport(createStore(), { kind: 'chooseFile' })
+
+    expect(result.configPaths).toEqual([PICKED_CONFIG_PATH])
+    expect(result.diff.terminalFontSize).toBe(15)
+    expect(readFileMock).not.toHaveBeenCalledWith(DISCOVERED_CONFIG_PATH, 'utf-8')
+  })
+
+  it('anchors the picker to the requesting window when one is resolvable', async () => {
+    const ownerWindow = { id: 1 }
+    fromWebContentsMock.mockReturnValue(ownerWindow)
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: true, filePaths: [] })
+    const webContents = { id: 42 } as never
+
+    await previewGhosttyImport(createStore(), { kind: 'chooseFile' }, webContents)
+
+    expect(fromWebContentsMock).toHaveBeenCalledWith(webContents)
+    expect(showOpenDialogMock).toHaveBeenCalledWith(
+      ownerWindow,
+      expect.objectContaining({ properties: ['openFile'] })
+    )
+  })
+
+  it('opens a window-less picker when no web contents is given', async () => {
+    showOpenDialogMock.mockResolvedValueOnce({ canceled: true, filePaths: [] })
+
+    await previewGhosttyImport(createStore(), { kind: 'chooseFile' })
+
+    expect(fromWebContentsMock).not.toHaveBeenCalled()
+    expect(showOpenDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ properties: ['openFile'] })
+    )
+  })
+})

--- a/src/main/ghostty/manual-ghostty-config-file.ts
+++ b/src/main/ghostty/manual-ghostty-config-file.ts
@@ -1,0 +1,20 @@
+import { BrowserWindow, dialog, type OpenDialogOptions, type WebContents } from 'electron'
+
+export async function chooseManualGhosttyConfigPath(
+  webContents?: WebContents
+): Promise<string | null> {
+  const ownerWindow = webContents ? BrowserWindow.fromWebContents(webContents) : null
+  const options: OpenDialogOptions = {
+    title: 'Import Ghostty Config',
+    // Why: Ghostty's canonical config file is the extensionless `config`, which an
+    // extension filter would grey out on macOS, so the picker stays unfiltered.
+    properties: ['openFile']
+  }
+  const result = ownerWindow
+    ? await dialog.showOpenDialog(ownerWindow, options)
+    : await dialog.showOpenDialog(options)
+  if (result.canceled || result.filePaths.length === 0) {
+    return null
+  }
+  return result.filePaths[0] ?? null
+}

--- a/src/main/ghostty/theme-import.test.ts
+++ b/src/main/ghostty/theme-import.test.ts
@@ -7,6 +7,11 @@ const { statMock, readFileMock } = vi.hoisted(() => ({
   readFileMock: vi.fn()
 }))
 
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: vi.fn() },
+  dialog: { showOpenDialog: vi.fn() }
+}))
+
 vi.mock('fs/promises', () => ({
   stat: statMock,
   readFile: readFileMock

--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -269,11 +269,25 @@ describe('registerSettingsHandlers', () => {
 
     const handler = handleMock.mock.calls.find(
       (call) => call[0] === 'settings:previewGhosttyImport'
-    )?.[1] as (_event: unknown, args: unknown) => Promise<unknown>
+    )?.[1] as (event: { sender: unknown }, args?: unknown) => Promise<unknown>
 
-    const result = await handler!(null, {})
+    const sender = { id: 7 }
+    const result = await handler!({ sender })
     expect(result).toEqual(expected)
-    expect(previewGhosttyImportMock).toHaveBeenCalledWith(store)
+    expect(previewGhosttyImportMock).toHaveBeenCalledWith(store, { kind: 'auto' }, sender)
+  })
+
+  it('settings:previewGhosttyImport forwards an explicit import source', async () => {
+    previewGhosttyImportMock.mockResolvedValue({ found: false, diff: {}, unsupportedKeys: [] })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find(
+      (call) => call[0] === 'settings:previewGhosttyImport'
+    )?.[1] as (event: { sender: unknown }, args?: unknown) => Promise<unknown>
+
+    const sender = { id: 9 }
+    await handler!({ sender }, { kind: 'chooseFile' })
+    expect(previewGhosttyImportMock).toHaveBeenCalledWith(store, { kind: 'chooseFile' }, sender)
   })
 
   it('settings:previewWarpThemeImport returns preview result', async () => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -318,8 +318,9 @@ export function registerSettingsHandlers(
     return listSystemFontFamilies()
   })
 
-  ipcMain.handle('settings:previewGhosttyImport', () => {
-    return previewGhosttyImport(store)
+  ipcMain.handle('settings:previewGhosttyImport', (event, args?: unknown) => {
+    const source = args === undefined ? { kind: 'auto' } : args
+    return previewGhosttyImport(store, source, event.sender)
   })
 
   ipcMain.handle('settings:previewWarpThemeImport', (event, args?: unknown) => {

--- a/src/preload/api/settings-api.ts
+++ b/src/preload/api/settings-api.ts
@@ -3,7 +3,11 @@ import type {
   WarpThemeImportPreview,
   WarpThemeImportSource
 } from '../../shared/terminal-custom-themes'
-import type { GhosttyImportPreview, GlobalSettings } from '../../shared/global-settings-types'
+import type {
+  GhosttyImportPreview,
+  GhosttyImportSource,
+  GlobalSettings
+} from '../../shared/global-settings-types'
 
 export type SettingsApi = {
   get: () => Promise<GlobalSettings>
@@ -15,7 +19,7 @@ export type SettingsApi = {
   }) => Promise<GlobalSettings>
   updatePRBotAuthorOverride: (args: { author: string; isBot: boolean }) => Promise<GlobalSettings>
   listFonts: () => Promise<string[]>
-  previewGhosttyImport: () => Promise<GhosttyImportPreview>
+  previewGhosttyImport: (source?: GhosttyImportSource) => Promise<GhosttyImportPreview>
   previewWarpThemeImport: (source: WarpThemeImportSource) => Promise<WarpThemeImportPreview>
   /** Subscribe to out-of-band settings updates (e.g. View > Appearance toggles) to stay in sync with main. */
   onChanged: (callback: (updates: Partial<GlobalSettings>) => void) => () => void

--- a/src/preload/api/settings-bridge.ts
+++ b/src/preload/api/settings-bridge.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron'
-import type { GhosttyImportPreview } from '../../shared/global-settings-types'
+import type { GhosttyImportPreview, GhosttyImportSource } from '../../shared/global-settings-types'
 import type {
   WarpThemeImportPreview,
   WarpThemeImportSource
@@ -22,8 +22,8 @@ export const settingsApi = {
 
   listFonts: (): Promise<string[]> => ipcRenderer.invoke('settings:listFonts'),
 
-  previewGhosttyImport: (): Promise<GhosttyImportPreview> =>
-    ipcRenderer.invoke('settings:previewGhosttyImport'),
+  previewGhosttyImport: (source?: GhosttyImportSource): Promise<GhosttyImportPreview> =>
+    ipcRenderer.invoke('settings:previewGhosttyImport', source),
 
   previewWarpThemeImport: (source: WarpThemeImportSource): Promise<WarpThemeImportPreview> =>
     ipcRenderer.invoke('settings:previewWarpThemeImport', source),

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
@@ -154,6 +154,7 @@ const ghosttyMock = {
   applied: true,
   applyError: null,
   handleClick: vi.fn(),
+  handleChooseFileClick: vi.fn(),
   handleApply: vi.fn(),
   handleOpenChange: vi.fn()
 }
@@ -372,6 +373,43 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
 
     importButton?.onClick?.()
     expect(ghosttyMock.handleClick).toHaveBeenCalled()
+  })
+
+  it('renders the Choose Config File button next to the discovered-config import', () => {
+    const element = TerminalAppearanceSection({
+      settings: {} as never,
+      updateSettings: () => {},
+      systemPrefersDark: true,
+      terminalFontSuggestions: [],
+      ghostty: ghosttyMock,
+      warpThemes: warpThemesMock
+    })
+
+    const buttons = findButtons(element)
+    const chooseFileButton = buttons.find((b) => b.text === 'Choose Config File')
+    expect(chooseFileButton).toBeDefined()
+
+    chooseFileButton?.onClick?.()
+    expect(ghosttyMock.handleChooseFileClick).toHaveBeenCalled()
+    expect(ghosttyMock.handleClick).not.toHaveBeenCalled()
+  })
+
+  it('hides the Choose Config File button on the paired web client', () => {
+    vi.stubGlobal('window', { location: { pathname: '/web-index.html' } })
+
+    const element = TerminalAppearanceSection({
+      settings: {} as never,
+      updateSettings: () => {},
+      systemPrefersDark: true,
+      terminalFontSuggestions: [],
+      ghostty: ghosttyMock,
+      warpThemes: warpThemesMock
+    })
+
+    const buttons = findButtons(element)
+    expect(buttons.some((b) => b.text === 'Choose Config File')).toBe(false)
+    // Why: the existing discovered-config button is out of scope here; it stays as-is.
+    expect(buttons.some((b) => b.text === 'Import from Ghostty')).toBe(true)
   })
 
   it('passes shared theme import controls into the theme catalog on desktop', () => {

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { FileUp } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import {
   matchesSettingsSearch,
@@ -11,6 +12,7 @@ import {
   getTerminalAdvancedTypographySearchEntries,
   getTerminalCursorSearchEntries,
   getTerminalDarkThemeSearchEntries,
+  getTerminalGhosttyConfigFileImportSearchEntries,
   getTerminalGhosttyImportSearchEntries,
   getTerminalLightThemeSearchEntries,
   getTerminalPaneAppearanceSearchEntries,
@@ -84,10 +86,16 @@ export function TerminalAppearanceSection({
   const [themeSearch, setThemeSearch] = useState('')
   const [previewFontFamily, setPreviewFontFamily] = useState<string | null>(null)
   const showWarpThemeImport = !isWebClientLocation()
+  // Why: the config picker is a native dialog the paired web client cannot open,
+  // so it stays desktop-only rather than adding another silently failing button.
+  const showGhosttyConfigFileImport = !isWebClientLocation()
   const darkThemeSearchEntries = getTerminalDarkThemeSearchEntries()
   const lightThemeSearchEntries = getTerminalLightThemeSearchEntries()
   const terminalTypographyEntries = getTerminalTypographySearchEntries()
-  const ghosttyImportEntries = getTerminalGhosttyImportSearchEntries()
+  const ghosttyImportEntries = [
+    ...getTerminalGhosttyImportSearchEntries(),
+    ...(showGhosttyConfigFileImport ? getTerminalGhosttyConfigFileImportSearchEntries() : [])
+  ]
   const themeCatalogSearchEntries = [
     ...getTerminalThemeTargetSearchEntries(),
     ...darkThemeSearchEntries,
@@ -183,18 +191,34 @@ export function TerminalAppearanceSection({
             )}
             action={
               showGhosttyImport ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="gap-1.5"
-                  onClick={() => void ghostty.handleClick()}
-                >
-                  <img src={ghosttyIcon} alt="" aria-hidden="true" className="size-4" />
-                  {translate(
-                    'auto.components.settings.TerminalAppearanceSection.855a76343a',
-                    'Import from Ghostty'
-                  )}
-                </Button>
+                <div className="flex flex-wrap items-center justify-end gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={() => void ghostty.handleClick()}
+                  >
+                    <img src={ghosttyIcon} alt="" aria-hidden="true" className="size-4" />
+                    {translate(
+                      'auto.components.settings.TerminalAppearanceSection.855a76343a',
+                      'Import from Ghostty'
+                    )}
+                  </Button>
+                  {showGhosttyConfigFileImport ? (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="gap-1.5"
+                      onClick={() => void ghostty.handleChooseFileClick()}
+                    >
+                      <FileUp className="size-4" />
+                      {translate(
+                        'auto.components.settings.TerminalAppearanceSection.ghostty_choose_config_file',
+                        'Choose Config File'
+                      )}
+                    </Button>
+                  ) : null}
+                </div>
               ) : null
             }
           />

--- a/src/renderer/src/components/settings/terminal-advanced-platform-search.ts
+++ b/src/renderer/src/components/settings/terminal-advanced-platform-search.ts
@@ -93,6 +93,28 @@ export const getTerminalMacYenSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getTerminalGhosttyConfigFileImportSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.ghostty_choose_config_file',
+      'Choose Config File'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.ghostty_choose_config_file_description',
+      'Import a Ghostty config from a file you pick instead of the discovered paths.'
+    ),
+    keywords: [
+      // Why: product name stays untranslated so search matches "Ghostty".
+      'Ghostty',
+      'ghostty',
+      ...translateSearchKeyword('auto.components.settings.terminal.search.fd752b3cac', 'import'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.f66a7cf715', 'terminal'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.2ade3ea490', 'config'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.file', 'file')
+    ]
+  }
+])
+
 export const getTerminalGhosttyImportSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate('auto.components.settings.terminal.search.a979df0083', 'Import from Ghostty'),

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -1,6 +1,7 @@
 import type { SettingsSearchEntry } from './settings-search'
 import {
   getTerminalAdvancedSearchEntries,
+  getTerminalGhosttyConfigFileImportSearchEntries,
   getTerminalGhosttyImportSearchEntries,
   getTerminalMacOptionSearchEntries,
   getTerminalMacYenSearchEntries
@@ -54,6 +55,7 @@ export {
   getTerminalAdvancedSearchEntries,
   getTerminalMacOptionSearchEntries,
   getTerminalMacYenSearchEntries,
+  getTerminalGhosttyConfigFileImportSearchEntries,
   getTerminalGhosttyImportSearchEntries
 } from './terminal-advanced-platform-search'
 export {
@@ -81,9 +83,12 @@ const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
 
 // Why: compose rather than filter — entry titles are localized, so matching on
 // an English title would leak the Warp entry back in under non-English locales.
+// The Ghostty config picker rides the same flag: it is a native dialog, so it is
+// only listed where desktop-only controls are shown.
 const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
     ...getTerminalAppearanceSearchEntriesWithoutWarp(),
+    ...getTerminalGhosttyConfigFileImportSearchEntries(),
     ...getTerminalWarpImportSearchEntries(),
     ...getTerminalYamlImportSearchEntries()
   ]

--- a/src/renderer/src/components/settings/useGhosttyImport.test.ts
+++ b/src/renderer/src/components/settings/useGhosttyImport.test.ts
@@ -200,6 +200,86 @@ describe('useGhosttyImport', () => {
     expect(updateSettings).not.toHaveBeenCalled()
   })
 
+  it('requests auto discovery for the discovered-config entry point', async () => {
+    const previewMock = vi.fn().mockResolvedValue({ found: false, diff: {}, unsupportedKeys: [] })
+    vi.stubGlobal('window', {
+      api: { settings: { previewGhosttyImport: previewMock } }
+    })
+
+    const ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    resetMockState()
+    await ghostty.handleClick()
+
+    expect(previewMock).toHaveBeenCalledWith({ kind: 'auto' })
+  })
+
+  it('opens the modal only after the file picker returns a config', async () => {
+    const previewResponse: GhosttyImportPreview = {
+      found: true,
+      configPath: '/Users/alice/Documents/config',
+      diff: { terminalFontSize: 15 },
+      unsupportedKeys: []
+    }
+    const previewMock = vi.fn().mockResolvedValue(previewResponse)
+    vi.stubGlobal('window', {
+      api: { settings: { previewGhosttyImport: previewMock } }
+    })
+
+    let ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.open).toBe(false)
+
+    resetMockState()
+    await ghostty.handleChooseFileClick()
+
+    expect(previewMock).toHaveBeenCalledWith({ kind: 'chooseFile' })
+
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.open).toBe(true)
+    expect(ghostty.loading).toBe(false)
+    expect(ghostty.preview).toEqual(previewResponse)
+  })
+
+  it('leaves the modal closed and the preview untouched when the picker is dismissed', async () => {
+    const previewMock = vi
+      .fn()
+      .mockResolvedValueOnce({ found: false, canceled: true, diff: {}, unsupportedKeys: [] })
+    vi.stubGlobal('window', {
+      api: { settings: { previewGhosttyImport: previewMock } }
+    })
+
+    let ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    resetMockState()
+    await ghostty.handleChooseFileClick()
+
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.open).toBe(false)
+    expect(ghostty.preview).toBeNull()
+    expect(ghostty.loading).toBe(false)
+  })
+
+  it('surfaces file-picker preview failures in the modal', async () => {
+    const previewMock = vi.fn().mockRejectedValue(new Error('picker exploded'))
+    vi.stubGlobal('window', {
+      api: { settings: { previewGhosttyImport: previewMock } }
+    })
+
+    let ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    resetMockState()
+    await ghostty.handleChooseFileClick()
+
+    resetMockState()
+    ghostty = useGhosttyImport(vi.fn(), baseSettings)
+    expect(ghostty.open).toBe(true)
+    expect(ghostty.preview).toEqual({
+      found: false,
+      diff: {},
+      unsupportedKeys: [],
+      error: 'picker exploded'
+    })
+  })
+
   it('merges terminalColorOverrides with existing settings on apply', async () => {
     const existingSettings: GlobalSettings = {
       ...baseSettings,

--- a/src/renderer/src/components/settings/useGhosttyImport.ts
+++ b/src/renderer/src/components/settings/useGhosttyImport.ts
@@ -1,6 +1,11 @@
 import { useState } from 'react'
-import type { GhosttyImportPreview, GlobalSettings } from '../../../../shared/global-settings-types'
+import type {
+  GhosttyImportPreview,
+  GhosttyImportSource,
+  GlobalSettings
+} from '../../../../shared/global-settings-types'
 import { useMountedRef } from '../../hooks/useMountedRef'
+import { translate } from '@/i18n/i18n'
 
 export type UseGhosttyImportReturn = {
   open: boolean
@@ -9,6 +14,7 @@ export type UseGhosttyImportReturn = {
   applied: boolean
   applyError: string | null
   handleClick: () => Promise<void>
+  handleChooseFileClick: () => Promise<void>
   handleApply: () => Promise<void>
   handleOpenChange: (open: boolean) => void
 }
@@ -28,23 +34,49 @@ export function useGhosttyImport(
   const [applyError, setApplyError] = useState<string | null>(null)
   const mountedRef = useMountedRef()
 
-  async function handleClick(): Promise<void> {
-    setOpen(true)
+  async function previewSource(source: GhosttyImportSource): Promise<GhosttyImportPreview> {
     setLoading(true)
     try {
-      const result = await window.api.settings.previewGhosttyImport()
-      if (mountedRef.current) {
+      const result = await window.api.settings.previewGhosttyImport(source)
+      // Why: a dismissed native picker keeps whatever preview was already
+      // showing instead of wiping it with an empty result.
+      if (mountedRef.current && !result.canceled) {
         setPreview(result)
       }
+      return result
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      if (mountedRef.current) {
-        setPreview({ found: false, diff: {}, unsupportedKeys: [], error: message })
+      const message =
+        err instanceof Error
+          ? err.message
+          : translate('auto.components.settings.useGhosttyImport.unknown_error', 'Unknown error')
+      const failure: GhosttyImportPreview = {
+        found: false,
+        diff: {},
+        unsupportedKeys: [],
+        error: message
       }
+      if (mountedRef.current) {
+        setPreview(failure)
+      }
+      return failure
     } finally {
       if (mountedRef.current) {
         setLoading(false)
       }
+    }
+  }
+
+  async function handleClick(): Promise<void> {
+    setOpen(true)
+    await previewSource({ kind: 'auto' })
+  }
+
+  async function handleChooseFileClick(): Promise<void> {
+    // Why: go straight to the native picker and only surface the modal once
+    // there is a config to preview — canceling leaves settings untouched.
+    const result = await previewSource({ kind: 'chooseFile' })
+    if (mountedRef.current && !result.canceled) {
+      setOpen(true)
     }
   }
 
@@ -97,6 +129,7 @@ export function useGhosttyImport(
     applied,
     applyError,
     handleClick,
+    handleChooseFileClick,
     handleApply,
     handleOpenChange
   }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8456,7 +8456,8 @@
           "e90afcc44f": "off",
           "16c471ee03": "on",
           "typographyAdvanced": "Typography",
-          "dimUnfocusedPanes": "Dim unfocused panes."
+          "dimUnfocusedPanes": "Dim unfocused panes.",
+          "ghostty_choose_config_file": "Choose Config File"
         },
         "TerminalAdvancedTypographyControls": {
           "f5fa1a08f1": "Bold Font Weight",
@@ -10419,7 +10420,10 @@
             "agent": "agent",
             "process": "process",
             "prompt": "prompt",
-            "stop": "stop"
+            "stop": "stop",
+            "ghostty_choose_config_file": "Choose Config File",
+            "ghostty_choose_config_file_description": "Import a Ghostty config from a file you pick instead of the discovered paths.",
+            "file": "file"
           },
           "windows": {
             "search": {
@@ -11741,6 +11745,9 @@
         },
         "NativeChatSupportedAgents": {
           "label": "Supported agents:"
+        },
+        "useGhosttyImport": {
+          "unknown_error": "Unknown error"
         }
       },
       "right": {

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -484,8 +484,13 @@ export type OrcaWorkspaceLayout = {
   nestWorkspaces: boolean
 }
 
+/** Where the Ghostty import reads its config from: the auto-discovered paths, or a file the user picks. */
+export type GhosttyImportSource = { kind: 'auto' } | { kind: 'chooseFile' }
+
 export type GhosttyImportPreview = {
   found: boolean
+  /** True when the user dismissed the native picker without selecting anything. */
+  canceled?: boolean
   configPath?: string
   configPaths?: string[]
   diff: Partial<GlobalSettings>


### PR DESCRIPTION
## ELI5

Orca can copy a terminal appearance from a Ghostty config. The import reads only the paths that Ghostty uses. This change adds a second button. The button lets you select any file. The import itself does not change.

## What Changed

- `previewGhosttyImport` takes an optional `{ kind: 'auto' | 'chooseFile' }`. Warp validates its source the same way. The source is an object with only `kind`. Extra fields, `null`, and `chooseFolder` are rejected.
- `chooseFile` opens the native dialog. The function reads only the picked file. If you dismiss the dialog, or pick nothing, the function returns `{ found: false, canceled: true }`. The function applies nothing. The preview modal opens only after you pick a file. Cancel leaves the modal closed.
- The picked file uses the same read, parse, map, and diff pipeline. The existing size ceiling applies. Parser, mapper, and apply are untouched. Discovery (`src/main/ghostty/discovery.ts`) is untouched.
- The picker is unfiltered. Ghostty's canonical file is the extensionless `config`. An extension filter would grey out that file on macOS.
- A second button, "Choose Config File", is next to "Import from Ghostty". New strings use i18n and the settings search index. The new button is hidden on the paired web client (`!isWebClientLocation()`). A native dialog cannot open there.
- A call with no argument still uses auto-discovery. The onboarding theme step is unchanged.

## Why

Auto-discovery reads only the config locations that Ghostty uses. You cannot import a config that is in a different location. You must first write that config into `~/.config/ghostty/config`. That action overwrites an unrelated file. That file belongs to a different program.

The import already works. The gap is that you cannot select a file as the source. The Warp theme import is in the same section. That import already has a file picker. This change removes a difference between two buttons that are next to each other. This change does not add a new concept. Ghostty does not get Warp's `chooseFolder`. This import reads a config file. It does not read a theme directory.

## Linked Issue

Fixes #18658

## Visual Proof

Settings -> Appearance -> Terminal Typography, at the same window size and crop.

**Before.** The heading action is only "Import from Ghostty".

![Before](https://raw.githubusercontent.com/DeVFirmino/orca/pr18659-assets/before.png)

**After.** "Import from Ghostty" and "Choose Config File" are next to each other.

![After](https://raw.githubusercontent.com/DeVFirmino/orca/pr18659-assets/after.png)

The images are on a separate branch of my fork, not in this pull request. The template asks that image files are not committed here.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Ten new main-process tests: no-argument auto-discovery, invalid source, cancel, empty selection, file over the size ceiling, unreadable file, picked file that produces the same diff as auto-discovery, only the picked file is read, dialog anchoring, and a window-less picker. Plus IPC (source forwarded), hook (the modal opens only after a pick. Cancel leaves the modal closed), and UI (button next to the existing one. Hidden on the paired web client).

`pnpm lint` and `pnpm typecheck` pass. `pnpm test` reports 13 failures out of 72,121. All 13 failures are pre-existing and unrelated. The cross-version-wire harness needs git tags. This run used a shallow clone. One flake occurred under load. Every test file in the touched areas passes. `pnpm build` was not run locally. CI should cover it.

Tested on macOS. Linux and Windows use the same Electron dialog and the existing read path. Unit tests cover those platforms.

## AI Disclosure

I implemented this with Claude (Claude Code). I reviewed the work before I submitted it.

## Review

Cross-platform: this change has no new path handling. The picker returns an absolute path. The existing read path is unchanged. The dialog is unfiltered on purpose (extensionless `config`). SSH/remote: the dialog and the file read happen on the desktop client. This is the same as the existing import. Mobile: untouched. Mobile keeps its own typography. Paired web: the new button is gated on `!isWebClientLocation()`. Agents/integrations: no agent or provider surface. Security: no new IPC channel. The source is validated before use (rejects extra fields). The size ceiling still applies. Performance: one extra dialog on an explicit click. The change does no work at startup. UI: the new button is next to the existing one and wraps. Cancel does not flash an empty modal. Backwards compatibility: the no-argument call keeps auto-discovery.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

A separate, pre-existing gap exists. The discovered-config button is not gated on the paired web client. The web settings API does not implement `previewGhosttyImport`. The button appears there and fails silently. This PR does not change that. This PR stays on one topic. I can open a follow-up.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)