### PR TITLE
test(pty): make the F24 patch pins catch the regressions they name

### DIFF
--- a/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
+++ b/src/main/pty/node-pty-self-exit-pseudoconsole-close.test.ts
@@ -46,6 +46,35 @@ import { describe, expect, it } from 'vitest'
 
 const PATCH = readFileSync(join(__dirname, '../../../config/patches/node-pty@1.1.0.patch'), 'utf8')
 
+/**
+ * Just the `PtyKill` hunk. Several markers below also occur in the `PtyConnect`
+ * hunk above it, and a bare `indexOf` on the whole patch silently matched the
+ * wrong one — an assertion that then held regardless of what `PtyKill` did.
+ */
+const ptyKillHunk = (() => {
+  // Anchored on the hunk header's function context rather than its line
+  // numbers, which shift whenever anything above it in the patch changes.
+  const header = /^@@ .* @@ static Napi::Value PtyKill\(.*$/m.exec(PATCH)
+  if (!header) {
+    throw new Error('no PtyKill hunk in config/patches/node-pty@1.1.0.patch')
+  }
+  const from = header.index
+  const next = PATCH.indexOf('\n@@ ', from + 1)
+  return PATCH.slice(from, next === -1 ? undefined : next)
+})()
+
+/**
+ * `indexOf` that throws instead of returning -1. A missing marker must fail the
+ * assertion that depends on it, not quietly make a slice or comparison vacuous.
+ */
+function indexIn(haystack: string, marker: string): number {
+  const at = haystack.indexOf(marker)
+  if (at === -1) {
+    throw new Error(`marker not found in the PtyKill hunk: ${marker}`)
+  }
+  return at
+}
+
 describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
   it('does not let the exit watcher free the baton while the close is still owed', () => {
     // Pinned as one block: the erase must stay INSIDE the consoleClosed guard.
@@ -73,10 +102,15 @@ describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
     // LoadConptyDll throws when conpty.dll is missing. Throwing after
     // consoleClosed was set would strand the pseudoconsole for good: the retry
     // finds the work claimed and does nothing.
-    const dllResolve = PATCH.indexOf('+  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);')
-    const claim = PATCH.indexOf('+      handle->consoleClosed = true;')
-    expect(dllResolve).toBeGreaterThan(-1)
-    expect(claim).toBeGreaterThan(-1)
+    //
+    // Anchored inside PtyKill, not by a bare indexOf: the identical line also
+    // appears in the PtyConnect hunk, earlier in the file, and matching that one
+    // made this assertion pass no matter where PtyKill resolved the DLL.
+    const dllResolve = indexIn(
+      ptyKillHunk,
+      '+  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);'
+    )
+    const claim = indexIn(ptyKillHunk, '+      handle->consoleClosed = true;')
     expect(dllResolve).toBeLessThan(claim)
   })
 
@@ -84,11 +118,9 @@ describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
     // Pinned as one block. The watcher nulls hShell on exit, and upstream
     // dereferenced it unconditionally; every remaining use — the duplication and
     // the failure fallback below it — must stay inside this guard.
-    const guarded = PATCH.slice(
-      PATCH.indexOf('+      if (useConptyDll && handle->hShell != nullptr) {'),
-      PATCH.indexOf('+      if (handle->shellExited) {')
-    )
-    expect(guarded).not.toBe('')
+    const start = indexIn(ptyKillHunk, '+      if (useConptyDll && handle->hShell != nullptr) {')
+    const end = indexIn(ptyKillHunk, '+      if (handle->shellExited) {')
+    const guarded = ptyKillHunk.slice(start, end)
     expect(guarded).toContain('DuplicateHandle(GetCurrentProcess(), handle->hShell')
     expect(guarded).toContain('TerminateProcess(handle->hShell, 1);')
     // No ADDED line outside that guard may terminate through hShell. Removed
@@ -97,6 +129,20 @@ describe('node-pty patch: pseudoconsole close on the self-exit path', () => {
       .split('\n')
       .filter((line) => line.startsWith('+') && line.includes('TerminateProcess(handle->hShell'))
     expect(strayAdds).toEqual([])
+  })
+
+  it('frees the baton from PtyKill when the shell has already exited', () => {
+    // The other half of the two-sided handshake. Without it a self-exit followed
+    // by kill() — the ordinary pane close — leaks one baton and one entry in the
+    // vector get_pty_baton scans linearly, forever.
+    expect(ptyKillHunk).toContain(
+      [
+        '+      if (handle->shellExited) {',
+        '+        const bool removed = remove_pty_baton(id);',
+        '+        assert(removed);',
+        '+        (void)removed;'
+      ].join('\n')
+    )
   })
 
   it('still kills the shell when DuplicateHandle fails', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Follow-up to #18635 (merged). **Test-only** — two of the patch pins I added there did not discriminate, so they would not have caught the regressions they name. The fix itself is unaffected; a readiness review of the merged change found these.

## Defect 1 — the ordering pin matched the wrong hunk

```ts
const dllResolve = PATCH.indexOf('+  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);')
const claim = PATCH.indexOf('+      handle->consoleClosed = true;')
expect(dllResolve).toBeLessThan(claim)
```

That line occurs **twice** as an added line — in the `PtyConnect` hunk (earlier in the file) and in `PtyKill`. `indexOf` always matched PtyConnect's, so the comparison held no matter where `PtyKill` resolved the DLL.

Verified by simulation rather than argued: moving `PtyKill`'s resolve back below the claim — the exact regression the assertion names — left the suite **green, 8/8**.

## Defect 2 — a slice bound that could vanish silently

`reaches hShell only under the null check` used `PATCH.indexOf(marker)` as the **end** of a slice without checking the marker existed. On `-1` the slice ran to the end of the patch, the stray-line filter found nothing outside it, and the test passed. A missing marker made the assertion vacuous instead of failing it.

## Defect 3 — a pin that was missing entirely

Nothing pinned `PtyKill`'s half of the two-sided baton free. Without it, a self-exit followed by `kill()` — the ordinary pane close — leaks one baton and one entry in the vector `get_pty_baton` scans linearly, forever. Added.

## The fix

Both assertions now anchor **inside the `PtyKill` hunk only**, located by the hunk header's function context (`@@ ... @@ static Napi::Value PtyKill(`) rather than its line numbers, which shift whenever anything above it in the patch changes. A helper `indexIn` throws on a missing marker instead of returning `-1`, so a marker that moves fails the assertion that depends on it rather than quietly making it vacuous.

## Mutation-tested, not just revert-tested

This is the part that matters, and it is how the defect got through in the first place. **Wholesale reverting the patch fails every assertion for the trivial reason that nothing matches** — so it cannot tell a discriminating pin from a vacuous one. Simulating each *specific* regression instead:

| mutation | before | after |
| --- | --- | --- |
| move `PtyKill`'s DLL resolve below the claim | 0 failed (**green**) | **1 failed** |
| drop `PtyKill`'s baton free, line-count-neutral | 0 failed (**green**) | **2 failed** |
| wholesale revert to the pre-F24 patch | 9 failed | 9 failed |

The second mutation has to be line-count-neutral: deleting the lines outright leaves the hunk header inconsistent and pnpm rejects the patch with `ERR_PNPM_INVALID_PATCH` before vitest runs, which would "fail" for the wrong reason. (Worth knowing on its own — pnpm's parser is a real second line of defence against a malformed resync.)

## Checks

- 9 assertions pass; `config/scripts/node-pty-windows-pty-teardown-patch.test.mjs` still passes (14 total across both files)
- `pnpm tc` clean; `npx oxlint` clean
- `pnpm test src/main/pty config/scripts` — 1649 passed, 15 skipped

No production code changes, so no re-measurement on Windows hardware was needed; the patch file is byte-identical to what merged in #18635.

Refs F24.
