### PR TITLE
fix(sidebar): stop a drifted virtualizer offset pinning the wrong project header

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-adjustment.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-adjustment.test.ts
@@ -62,9 +62,19 @@ describe('shouldAdjustWorktreeSidebarMeasuredRowScroll', () => {
     }
   })
 
+  // A row fully above a viewport scrolled to 300px.
+  const rowAboveFold = {
+    itemStart: 100,
+    itemEnd: 216,
+    scrollOffset: 300,
+    isFirstMeasure: false,
+    scrollDirection: null
+  } as const
+
   it('suppresses measured-row scroll correction while TanStack is scrolling', () => {
     expect(
       shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        ...rowAboveFold,
         isScrolling: true,
         now: 1_000,
         suppressUntil: 0
@@ -75,6 +85,7 @@ describe('shouldAdjustWorktreeSidebarMeasuredRowScroll', () => {
   it('suppresses measured-row scroll correction during direct scroll input grace period', () => {
     expect(
       shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        ...rowAboveFold,
         isScrolling: false,
         now: 1_000,
         suppressUntil: 1_250
@@ -85,11 +96,81 @@ describe('shouldAdjustWorktreeSidebarMeasuredRowScroll', () => {
   it('allows measured-row scroll correction after direct scrolling settles', () => {
     expect(
       shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        ...rowAboveFold,
         isScrolling: false,
         now: 1_500,
         suppressUntil: 1_250
       })
     ).toBe(true)
+  })
+
+  it('never corrects for a row at or below the fold', () => {
+    // Regression: with every resize corrected, a card growing under an
+    // unscrollable list booked a scrollOffset the element never reached, and
+    // the sticky header pinned the second project over the first row.
+    const belowFold = { isScrolling: false, now: 1_500, suppressUntil: 0 }
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        ...belowFold,
+        itemStart: 32,
+        itemEnd: 148,
+        scrollOffset: 0,
+        isFirstMeasure: true,
+        scrollDirection: null
+      })
+    ).toBe(false)
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        ...belowFold,
+        itemStart: 32,
+        itemEnd: 148,
+        scrollOffset: 0,
+        isFirstMeasure: false,
+        scrollDirection: null
+      })
+    ).toBe(false)
+  })
+
+  it('corrects a first measurement whose top is above the fold even when it spans it', () => {
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        isScrolling: false,
+        now: 1_500,
+        suppressUntil: 0,
+        itemStart: 250,
+        itemEnd: 366,
+        scrollOffset: 300,
+        isFirstMeasure: true,
+        scrollDirection: null
+      })
+    ).toBe(true)
+  })
+
+  it('leaves a remeasured row that spans the fold alone', () => {
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        isScrolling: false,
+        now: 1_500,
+        suppressUntil: 0,
+        itemStart: 250,
+        itemEnd: 366,
+        scrollOffset: 300,
+        isFirstMeasure: false,
+        scrollDirection: null
+      })
+    ).toBe(false)
+  })
+
+  it('skips remeasure correction while scrolling backward', () => {
+    expect(
+      shouldAdjustWorktreeSidebarMeasuredRowScroll({
+        ...rowAboveFold,
+        isScrolling: false,
+        now: 1_500,
+        suppressUntil: 0,
+        scrollDirection: 'backward'
+      })
+    ).toBe(false)
   })
 
   it('keeps pending reveal requests when the worktree still exists but the row is unresolved', () => {

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-drift.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-drift.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest'
+import { Virtualizer, elementScroll } from '@tanstack/react-virtual'
+import { getReconciledVirtualScrollOffset } from './scroll-offset-reconcile'
+import { shouldAdjustWorktreeSidebarMeasuredRowScroll } from './use-scroll-suppression'
+
+const VIEWPORT_HEIGHT = 285
+const ESTIMATED_ROW = 116
+
+// A list two cards tall inside a taller viewport: the browser clamps every
+// scrollTo back to 0, so no scroll event ever reaches the virtualizer.
+function createUnscrollableVirtualizer(): {
+  virtualizer: Virtualizer<HTMLDivElement, HTMLDivElement>
+  element: HTMLDivElement
+} {
+  const element = document.createElement('div')
+  Object.defineProperty(element, 'clientHeight', { value: VIEWPORT_HEIGHT })
+  Object.defineProperty(element, 'scrollHeight', { value: ESTIMATED_ROW * 2 })
+  element.scrollTo = () => {}
+  const virtualizer = new Virtualizer<HTMLDivElement, HTMLDivElement>({
+    count: 2,
+    getScrollElement: () => element,
+    estimateSize: () => ESTIMATED_ROW,
+    scrollToFn: elementScroll,
+    observeElementRect: (_instance, callback) => {
+      callback({ width: 300, height: VIEWPORT_HEIGHT })
+      return () => {}
+    },
+    observeElementOffset: () => () => {}
+  })
+  virtualizer._willUpdate()
+  virtualizer.getVirtualItems()
+  return { virtualizer, element }
+}
+
+const wireSidebarPredicate = (virtualizer: Virtualizer<HTMLDivElement, HTMLDivElement>): void => {
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) =>
+    shouldAdjustWorktreeSidebarMeasuredRowScroll({
+      isScrolling: instance.isScrolling,
+      now: 1_000,
+      suppressUntil: 0,
+      itemStart: item.start,
+      itemEnd: item.end,
+      scrollOffset: (instance.scrollOffset ?? 0) + instance.scrollAdjustments,
+      isFirstMeasure: !instance.itemSizeCache.has(item.key),
+      scrollDirection: instance.scrollDirection
+    })
+}
+
+describe('virtualizer scroll offset under an unscrollable sidebar', () => {
+  it('drifts when every measured resize is corrected (the previous predicate)', () => {
+    const { virtualizer, element } = createUnscrollableVirtualizer()
+    virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => true
+
+    virtualizer.resizeItem(1, ESTIMATED_ROW + 24)
+
+    expect(element.scrollTop).toBe(0)
+    expect(virtualizer.scrollOffset).toBe(24)
+    expect(virtualizer.getVirtualItems().at(0)?.start).toBe(0)
+  })
+
+  it('stays anchored to the element when only rows above the fold are corrected', () => {
+    const { virtualizer, element } = createUnscrollableVirtualizer()
+    wireSidebarPredicate(virtualizer)
+
+    virtualizer.resizeItem(1, ESTIMATED_ROW + 24)
+    virtualizer.resizeItem(0, ESTIMATED_ROW + 40)
+
+    expect(element.scrollTop).toBe(0)
+    expect(virtualizer.scrollOffset).toBe(0)
+  })
+
+  it('reconciles an already-drifted belief back to the element', () => {
+    const { virtualizer, element } = createUnscrollableVirtualizer()
+    virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => true
+    virtualizer.resizeItem(1, ESTIMATED_ROW + 70)
+
+    const reconciled = getReconciledVirtualScrollOffset({
+      believedOffset: virtualizer.scrollOffset,
+      scrollTop: element.scrollTop,
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+      isScrolling: virtualizer.isScrolling
+    })
+
+    expect(virtualizer.scrollOffset).toBe(70)
+    expect(reconciled).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest'
+import type { VirtualItem } from '@tanstack/react-virtual'
+import { getReconciledVirtualScrollOffset } from './scroll-offset-reconcile'
+import { GROUP_HEADER_ROW_HEIGHT, getActiveStickyIndexesForScroll } from './virtual-rows'
+import type { Row } from '../grouping/row-types'
+
+const makeHeaderRow = (key: string): Extract<Row, { type: 'header' }> => ({
+  type: 'header',
+  key,
+  label: key,
+  count: 1,
+  tone: 'text-foreground',
+  projectGroupDepth: 0
+})
+
+describe('getReconciledVirtualScrollOffset', () => {
+  it('snaps a belief the element cannot reach back to the element', () => {
+    // Six collapsed project headers fit inside the viewport, so the element never scrolls.
+    expect(
+      getReconciledVirtualScrollOffset({
+        believedOffset: 70,
+        scrollTop: 0,
+        scrollHeight: 198,
+        clientHeight: 285,
+        isScrolling: false
+      })
+    ).toBe(0)
+  })
+
+  it('clamps to the scrollable end when the belief overshoots a scrollable list', () => {
+    expect(
+      getReconciledVirtualScrollOffset({
+        believedOffset: 500,
+        scrollTop: 120,
+        scrollHeight: 600,
+        clientHeight: 400,
+        isScrolling: false
+      })
+    ).toBe(120)
+  })
+
+  it('leaves a reachable belief alone so an in-flight scroll write can land', () => {
+    expect(
+      getReconciledVirtualScrollOffset({
+        believedOffset: 40,
+        scrollTop: 0,
+        scrollHeight: 600,
+        clientHeight: 400,
+        isScrolling: false
+      })
+    ).toBeNull()
+  })
+
+  it('tolerates sub-pixel rounding at the scrollable end', () => {
+    expect(
+      getReconciledVirtualScrollOffset({
+        believedOffset: 200.6,
+        scrollTop: 200,
+        scrollHeight: 600,
+        clientHeight: 400,
+        isScrolling: false
+      })
+    ).toBeNull()
+  })
+
+  it('does nothing before the virtualizer has an offset or while it is scrolling', () => {
+    expect(
+      getReconciledVirtualScrollOffset({
+        believedOffset: null,
+        scrollTop: 0,
+        scrollHeight: 0,
+        clientHeight: 0,
+        isScrolling: false
+      })
+    ).toBeNull()
+    expect(
+      getReconciledVirtualScrollOffset({
+        believedOffset: 70,
+        scrollTop: 0,
+        scrollHeight: 198,
+        clientHeight: 285,
+        isScrolling: true
+      })
+    ).toBeNull()
+  })
+
+  it('restores the first project header as the pinned one once the offset is reconciled', () => {
+    // Regression: the virtualizer believed it sat at 70px while the element was at 0, so the
+    // third header pinned in flow at the top over the first row and left a gap in its own slot.
+    const rows = ['orca', 'Agentic-AI-Portal', 'BI-Portal-v2', 'Snowflake-REST-API'].map((key) =>
+      makeHeaderRow(`repo:${key}`)
+    )
+    const rowHeight = GROUP_HEADER_ROW_HEIGHT + 4
+    const virtualItems: VirtualItem[] = rows.map((row, index) => ({
+      key: `hdr:${row.key}`,
+      index,
+      start: index * rowHeight,
+      end: (index + 1) * rowHeight,
+      size: rowHeight,
+      lane: 0
+    }))
+    const stickyHeaderIndexes = [0, 1, 2, 3]
+    const believedOffset = 70
+    const staleRangeStartIndex = Math.floor(believedOffset / rowHeight)
+
+    expect(
+      getActiveStickyIndexesForScroll({
+        rows,
+        rangeStartIndex: staleRangeStartIndex,
+        scrollOffset: believedOffset,
+        stickyHeaderIndexes,
+        virtualItems
+      }).groupIndex
+    ).toBe(2)
+
+    const reconciled = getReconciledVirtualScrollOffset({
+      believedOffset,
+      scrollTop: 0,
+      scrollHeight: rows.length * rowHeight,
+      clientHeight: 285,
+      isScrolling: false
+    })
+    expect(reconciled).toBe(0)
+    expect(
+      getActiveStickyIndexesForScroll({
+        rows,
+        rangeStartIndex: 0,
+        scrollOffset: reconciled ?? believedOffset,
+        stickyHeaderIndexes,
+        virtualItems
+      }).groupIndex
+    ).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import type { VirtualItem } from '@tanstack/react-virtual'
-import { getReconciledVirtualScrollOffset } from './scroll-offset-reconcile'
+import {
+  getReconciledVirtualScrollOffset,
+  reconcileVirtualizerScrollOffset
+} from './scroll-offset-reconcile'
 import { GROUP_HEADER_ROW_HEIGHT, getActiveStickyIndexesForScroll } from './virtual-rows'
 import type { Row } from '../grouping/row-types'
 
@@ -130,5 +133,45 @@ describe('getReconciledVirtualScrollOffset', () => {
         virtualItems
       }).groupIndex
     ).toBe(0)
+  })
+})
+
+describe('reconcileVirtualizerScrollOffset', () => {
+  const unscrollableElement = { scrollTop: 0, scrollHeight: 198, clientHeight: 285 }
+
+  it('waits out an in-flight scroll and re-anchors once it settles', () => {
+    const virtualizer = { scrollOffset: 70, scrollAdjustments: 12, isScrolling: true }
+    const scrollOffsetRef = { current: 70 }
+
+    expect(
+      reconcileVirtualizerScrollOffset({
+        virtualizer,
+        element: unscrollableElement,
+        scrollOffsetRef
+      })
+    ).toBe(false)
+    expect(virtualizer).toMatchObject({ scrollOffset: 70, scrollAdjustments: 12 })
+
+    virtualizer.isScrolling = false
+    expect(
+      reconcileVirtualizerScrollOffset({
+        virtualizer,
+        element: unscrollableElement,
+        scrollOffsetRef
+      })
+    ).toBe(true)
+    expect(virtualizer).toMatchObject({ scrollOffset: 0, scrollAdjustments: 0 })
+    expect(scrollOffsetRef.current).toBe(0)
+  })
+
+  it('reports no change when the belief is already where the element is', () => {
+    const virtualizer = { scrollOffset: 0, scrollAdjustments: 0, isScrolling: false }
+    expect(
+      reconcileVirtualizerScrollOffset({
+        virtualizer,
+        element: unscrollableElement,
+        scrollOffsetRef: { current: 0 }
+      })
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.ts
@@ -1,0 +1,30 @@
+/**
+ * The offset the virtualizer should believe once its remembered one is
+ * provably not where the scroll element is, or null when nothing needs fixing.
+ *
+ * TanStack books a size correction into `scrollOffset` before the element
+ * scrolls and only re-reads the element on a scroll event. A write the element
+ * cannot honor — the list is shorter than the viewport, or the target sits past
+ * the scrollable end — fires no event, so the belief keeps an offset the DOM
+ * never reached. Range and sticky-header math then pin a later project header
+ * over the first row and leave its own slot empty.
+ *
+ * Only an unreachable belief is corrected: a reachable difference can be a
+ * scroll write whose event has not landed yet, and the event will settle it.
+ */
+export function getReconciledVirtualScrollOffset(args: {
+  believedOffset: number | null | undefined
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  isScrolling: boolean
+}): number | null {
+  if (args.believedOffset == null || args.isScrolling) {
+    return null
+  }
+  const maxScrollTop = Math.max(0, args.scrollHeight - args.clientHeight)
+  if (args.believedOffset <= maxScrollTop + 1) {
+    return null
+  }
+  return Math.min(args.scrollTop, maxScrollTop)
+}

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/scroll-offset-reconcile.ts
@@ -28,3 +28,38 @@ export function getReconciledVirtualScrollOffset(args: {
   }
   return Math.min(args.scrollTop, maxScrollTop)
 }
+
+type ReconcilableVirtualizer = {
+  scrollOffset: number | null
+  scrollAdjustments: number
+  isScrolling: boolean
+}
+
+type ReconcilableScrollElement = Pick<Element, 'scrollTop' | 'scrollHeight' | 'clientHeight'>
+
+/**
+ * Re-anchors the virtualizer to its element when its belief is unreachable and
+ * reports whether anything changed. Nothing is touched while a scroll is in
+ * flight; the caller runs this again when scrolling settles.
+ */
+export function reconcileVirtualizerScrollOffset(args: {
+  virtualizer: ReconcilableVirtualizer
+  element: ReconcilableScrollElement
+  scrollOffsetRef: { current: number }
+}): boolean {
+  const { virtualizer, element, scrollOffsetRef } = args
+  const reconciled = getReconciledVirtualScrollOffset({
+    believedOffset: virtualizer.scrollOffset,
+    scrollTop: element.scrollTop,
+    scrollHeight: element.scrollHeight,
+    clientHeight: element.clientHeight,
+    isScrolling: virtualizer.isScrolling
+  })
+  if (reconciled === null) {
+    return false
+  }
+  virtualizer.scrollOffset = reconciled
+  virtualizer.scrollAdjustments = 0
+  scrollOffsetRef.current = reconciled
+  return true
+}

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useMemo } from 'react'
+import { useCallback, useLayoutEffect, useMemo, useReducer } from 'react'
 import type React from 'react'
 import { useAppStore } from '@/store'
 import {
@@ -15,6 +15,7 @@ import { getRenderRowKey } from '../listing/render-row'
 import type { RenderRow } from '../listing/render-row'
 import type { WorktreeListVirtualizer } from './use-virtualizer'
 import { useVirtualRowRemovalAnimation } from './use-row-removal-animation'
+import { getReconciledVirtualScrollOffset } from './scroll-offset-reconcile'
 
 const recordKeyCountCache = new WeakMap<Record<string, unknown>, number>()
 
@@ -108,6 +109,31 @@ export function useVirtualRowMeasurementSync(args: {
     renderRowKeySignature,
     virtualizer
   ])
+
+  const [, rerenderAfterOffsetReconcile] = useReducer((count: number) => count + 1, 0)
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) {
+      return
+    }
+    const reconciled = getReconciledVirtualScrollOffset({
+      believedOffset: virtualizer.scrollOffset,
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      isScrolling: virtualizer.isScrolling
+    })
+    if (reconciled === null) {
+      return
+    }
+    // Why: a booked-but-unhonored scroll write leaves TanStack ranging and pinning from
+    // an offset the element never reached (see getReconciledVirtualScrollOffset); the
+    // element is the truth, and the re-render lets range and sticky slots follow it.
+    virtualizer.scrollOffset = reconciled
+    virtualizer.scrollAdjustments = 0
+    scrollOffsetRef.current = reconciled
+    rerenderAfterOffsetReconcile()
+  }, [renderRowKeySignature, scrollOffsetRef, scrollRef, totalSize, virtualizer])
 
   useVirtualizedScrollAnchor({
     anchorRef: scrollAnchorRef,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-row-measurement.ts
@@ -15,7 +15,7 @@ import { getRenderRowKey } from '../listing/render-row'
 import type { RenderRow } from '../listing/render-row'
 import type { WorktreeListVirtualizer } from './use-virtualizer'
 import { useVirtualRowRemovalAnimation } from './use-row-removal-animation'
-import { getReconciledVirtualScrollOffset } from './scroll-offset-reconcile'
+import { reconcileVirtualizerScrollOffset } from './scroll-offset-reconcile'
 
 const recordKeyCountCache = new WeakMap<Record<string, unknown>, number>()
 
@@ -111,29 +111,27 @@ export function useVirtualRowMeasurementSync(args: {
   ])
 
   const [, rerenderAfterOffsetReconcile] = useReducer((count: number) => count + 1, 0)
+  // Why: a booked-but-unhonored scroll write leaves TanStack ranging and pinning from an
+  // offset the element never reached (see getReconciledVirtualScrollOffset); the element is
+  // the truth, and the re-render lets range and sticky slots follow it. isScrolling is a dep
+  // so a check skipped mid-scroll runs again once scrolling settles.
+  const isVirtualizerScrolling = virtualizer.isScrolling
   useLayoutEffect(() => {
     const el = scrollRef.current
     if (!el) {
       return
     }
-    const reconciled = getReconciledVirtualScrollOffset({
-      believedOffset: virtualizer.scrollOffset,
-      scrollTop: el.scrollTop,
-      scrollHeight: el.scrollHeight,
-      clientHeight: el.clientHeight,
-      isScrolling: virtualizer.isScrolling
-    })
-    if (reconciled === null) {
-      return
+    if (reconcileVirtualizerScrollOffset({ virtualizer, element: el, scrollOffsetRef })) {
+      rerenderAfterOffsetReconcile()
     }
-    // Why: a booked-but-unhonored scroll write leaves TanStack ranging and pinning from
-    // an offset the element never reached (see getReconciledVirtualScrollOffset); the
-    // element is the truth, and the re-render lets range and sticky slots follow it.
-    virtualizer.scrollOffset = reconciled
-    virtualizer.scrollAdjustments = 0
-    scrollOffsetRef.current = reconciled
-    rerenderAfterOffsetReconcile()
-  }, [renderRowKeySignature, scrollOffsetRef, scrollRef, totalSize, virtualizer])
+  }, [
+    isVirtualizerScrolling,
+    renderRowKeySignature,
+    scrollOffsetRef,
+    scrollRef,
+    totalSize,
+    virtualizer
+  ])
 
   useVirtualizedScrollAnchor({
     anchorRef: scrollAnchorRef,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-scroll-suppression.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-scroll-suppression.ts
@@ -10,12 +10,35 @@ import {
 export const USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 500
 export const EXPANDING_CARD_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 300
 
-export function shouldAdjustWorktreeSidebarMeasuredRowScroll(args: {
+export type MeasuredRowScrollAdjustmentArgs = {
   isScrolling: boolean
   now: number
   suppressUntil: number
-}): boolean {
-  return !args.isScrolling && args.now >= args.suppressUntil
+  /** Row top/bottom before this measurement, in list coordinates. */
+  itemStart: number
+  itemEnd: number
+  scrollOffset: number
+  isFirstMeasure: boolean
+  scrollDirection: 'forward' | 'backward' | null
+}
+
+// Mirrors TanStack's default fold rule on top of the input-quiet gates: only a row
+// above the viewport top moves what the user is looking at. Correcting for a row at
+// or below the fold scrolls the list when it can and, when it cannot (list shorter
+// than the viewport), TanStack still books the write into scrollOffset — the range
+// and sticky header then follow an offset the element never reached.
+export function shouldAdjustWorktreeSidebarMeasuredRowScroll(
+  args: MeasuredRowScrollAdjustmentArgs
+): boolean {
+  if (args.isScrolling || args.now < args.suppressUntil) {
+    return false
+  }
+  if (args.isFirstMeasure) {
+    return args.itemStart < args.scrollOffset
+  }
+  // Why: a row spanning the fold grows below the anchor point; a backward scroll
+  // cascades corrections into visible jumps (TanStack #1218).
+  return args.itemEnd <= args.scrollOffset && args.scrollDirection !== 'backward'
 }
 
 export type WorktreeSidebarScrollSuppression = ReturnType<

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/use-virtualizer.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/use-virtualizer.ts
@@ -139,11 +139,17 @@ export function useWorktreeListVirtualizer(args: {
   })
   // Why: TanStack's default correction writes scrollTop while cards remeasure mid-wheel, which feels like rubber-banding.
   // TODO(scroll-origin-migration): wall-clock suppression misclassifies under jank; migrate to programmaticScrollMarks + restoreSignal (see CombinedDiffViewer).
-  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (_item, _delta, instance) =>
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = (item, _delta, instance) =>
     shouldAdjustWorktreeSidebarMeasuredRowScroll({
       isScrolling: instance.isScrolling,
       now: window.performance.now(),
-      suppressUntil: args.suppressMeasurementAdjustmentUntilRef.current
+      suppressUntil: args.suppressMeasurementAdjustmentUntilRef.current,
+      itemStart: item.start,
+      itemEnd: item.end,
+      scrollOffset: (instance.scrollOffset ?? scrollOffsetRef.current) + instance.scrollAdjustments,
+      // Why: TanStack consults this before caching the new size, so a miss means first paint.
+      isFirstMeasure: !instance.itemSizeCache.has(item.key),
+      scrollDirection: instance.scrollDirection
     })
 
   return {


### PR DESCRIPTION
## ELI5

The sidebar keeps a note of how far it thinks it has scrolled. When a workspace card grew in a list too short to scroll, that note moved even though the list did not. The pinned project header is chosen from that note, so the wrong project got pinned over the first row and left a hole where it should have been. Now the note only moves for rows that are actually above the top of the list, and if it ever ends up somewhere the list cannot reach, it is snapped back to where the list really is.

## What Changed

- `use-scroll-suppression.ts` / `use-virtualizer.ts`: `shouldAdjustScrollPositionOnItemSizeChange` now applies TanStack's fold rule on top of the existing scrolling and suppression gates. A first measurement corrects only when the row's top is above the viewport top; a re-measurement only when the row is entirely above it and the scroll direction is not backward.
- `scroll-offset-reconcile.ts` (new) + `use-row-measurement.ts`: after layout, a believed offset the element cannot reach (beyond `scrollHeight - clientHeight`) is snapped back to the element's `scrollTop` and the list re-renders so range and sticky slots follow the DOM. Only an unreachable belief is touched; a reachable difference can be an in-flight scroll write whose event has not landed yet. The effect depends on `isScrolling` so a check skipped mid-scroll reruns once scrolling settles.
- Tests: `scroll-adjustment.test.ts` (fold-aware predicate), `scroll-offset-reconcile.test.ts` (reconcile rules, the reported scenario, the in-flight → settled transition), `scroll-offset-drift.test.ts` (drives the real `Virtualizer` against an unscrollable element and shows the old predicate drifting `scrollOffset` while the new one holds 0).

## Why

The active project header renders `sticky` in normal flow at the top of the list and its own virtual slot is left empty. That is only right when the pinned header is the first row. Which header pins is derived from the virtualizer's remembered `scrollOffset` (`getActiveStickyIndexesForScroll` and the range extractor's `startIndex`).

TanStack Virtual 3.17 books every size correction into `scrollOffset` before the element scrolls (`applyScrollAdjustment`) and only re-reads the element on a scroll event. The sidebar predicate returned `true` for every measured resize, replacing TanStack's default "only rows above the fold" rule with "always" (its intent, per #2175, was only to stay quiet during wheel input). So a card growing under a project, in a list shorter than the viewport, moved the believed offset to roughly 70 px while the element stayed at 0, and no scroll event ever corrected it. The header at that offset pinned over row 0 and left its slot blank; expanding a project shifted the indices and a different header pinned, which reads as a reorder.

Two reviewer notes: the predicate change also removes a pre-existing visible jump when a card below the viewport grows in a scrollable list, and the reconcile writes `virtualizer.scrollOffset` directly, which is a public field but not a documented mutation path.

## Linked Issue

Fixes #18667

## Visual Proof

**Before:** 12s screen recording of the bug. Project names are redacted to "Project A" through "Project E"; Project A is the one being collapsed and expanded. Watch for the blank band under Project A while it is collapsed, and Project A jumping above Project B when it is expanded. There are six projects in the list; the sixth is never visible because the mis-pinned header sits over it.

[Screencast_20260904_091046_redacted.webm](https://github.com/user-attachments/assets/7ef8d422-f084-4990-9238-0ae9b5733973)


**After:** not captured on a packaged build. The behavior is pinned by `scroll-offset-drift.test.ts`, which runs the real TanStack `Virtualizer` against an unscrollable element and asserts the offset stays at 0 under the new predicate, and by the scenario test that shows index 0 pinning once the offset is reconciled.

## Testing

Linux only. Automated, not a manual run of a packaged build:

- `tsc --noEmit -p config/tsconfig.tc.web.json` clean
- `oxlint`, `oxfmt --check`, and `check-changed-code-quality.mjs` clean
- `vitest` over `src/renderer/src/components/sidebar`: 294 files, 2501 tests passing before the follow-up commit; viewport + `WorktreeList` suites re-run after it, 131 tests passing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Diagnosed and implemented with Claude Code (Claude Fable 5.1): frame extraction from the screen recording, tracing the sticky-header and TanStack scroll-offset behaviour, the code changes, and the tests. The author reviewed the diagnosis and the diff, directed the fix and the review follow-up, and ran the verification listed above.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only change in the sidebar virtualizer; no platform, SSH, path, or wire-format surface is touched. Performance: the reconcile runs in an existing layout effect, reads three properties of the scroll element, and re-renders only when it corrects something.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

