### PR TITLE
fix(agent-hooks): keep Claude parent working after child stop

### DIFF
--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -42,7 +42,7 @@ describe('shared agent-hook-listener', () => {
       expect(stop?.payload.turnCompletedAt).toBeUndefined()
     })
 
-    it('stamps turnCompletedAt on a gated lead Stop and repeats it on the all-clear', () => {
+    it('keeps turnCompletedAt when a runtime child stop wakes the parent', () => {
       vi.useFakeTimers()
       try {
         vi.setSystemTime(1_700_000_005_000)
@@ -71,7 +71,7 @@ describe('shared agent-hook-listener', () => {
 
         vi.setSystemTime(1_700_000_055_000)
         const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
-        expect(drained?.payload.state).toBe('done')
+        expect(drained?.payload.state).toBe('working')
         expect(drained?.payload.turnCompletedAt).toBe(1_700_000_005_000)
 
         claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'next turn' })
@@ -81,6 +81,28 @@ describe('shared agent-hook-listener', () => {
       } finally {
         vi.useRealTimers()
       }
+    })
+
+    it('wakes the parent when a runtime child stops after a gated lead boundary', () => {
+      claudeEvent({
+        hook_event_name: 'SubagentStart',
+        agent_id: 'a1',
+        agent_type: 'general-purpose'
+      })
+      const gatedStop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+      })
+      expect(gatedStop?.payload.state).toBe('working')
+
+      const childStop = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      expect(childStop?.payload.state).toBe('working')
+
+      const duplicateChildStop = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      expect(duplicateChildStop?.payload.state).toBe('working')
+
+      const finalStop = claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
+      expect(finalStop?.payload.state).toBe('done')
     })
 
     it('does not stamp an interrupted Stop even while a child still gates the pane', () => {
@@ -181,9 +203,10 @@ describe('shared agent-hook-listener', () => {
       ])
 
       const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'r1' })
-      expect(stopped?.payload.state).toBe('done')
       // Why: a finished one-shot leaves the sidebar instead of squatting as a
-      // permanent idle row for the rest of the session.
+      // permanent idle row, while its stop wakes the parent until the lead's
+      // next authoritative boundary.
+      expect(stopped?.payload.state).toBe('working')
       expect(stopped?.payload.subagents).toBeUndefined()
     })
 
@@ -217,9 +240,9 @@ describe('shared agent-hook-listener', () => {
       ])
 
       const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a9' })
-      // Why: the lead's own last state was done, so with no working children
-      // the pane settles back to done rather than a phantom working spinner.
-      expect(stopped?.payload.state).toBe('done')
+      // Why: a current-runtime child ending resumes the parent, which can
+      // generate without another hook until its next tool or turn boundary.
+      expect(stopped?.payload.state).toBe('working')
     })
 
     it('parks a teammate as a persistent idle row across its stop/idle/lead-Stop cycle', () => {
@@ -295,8 +318,8 @@ describe('shared agent-hook-listener', () => {
       // Why: teammate name and agent type are separate Agent-tool inputs; the
       // lifecycle id embeds the former while the hook reports the latter.
       // TeammateIdle keyed by name parks it via the id prefix (fallback when
-      // its SubagentStop was lost), so the pane settles back to the lead's
-      // done state while the row stays visible as idle.
+      // its SubagentStop was lost) and wakes the parent while the row remains
+      // visible as idle.
       const idled = claudeEvent({
         hook_event_name: 'TeammateIdle',
         teammate_name: 'reviewer',
@@ -305,7 +328,7 @@ describe('shared agent-hook-listener', () => {
       expect(idled?.payload.subagents).toEqual([
         expect.objectContaining({ id: 'areviewer-6d3cb5b52120b7bf', state: 'idle' })
       ])
-      expect(idled?.payload.state).toBe('done')
+      expect(idled?.payload.state).toBe('working')
     })
 
     it('scopes subagent rosters per pane', () => {
@@ -421,7 +444,7 @@ describe('shared agent-hook-listener', () => {
       expect(stopped?.payload.state).toBe('working')
     })
 
-    it('restores a finished lead to done after a child permission wait clears', () => {
+    it('wakes a finished lead after a child permission wait clears and the child stops', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'bg task' })
       claudeEvent({
         hook_event_name: 'SubagentStart',
@@ -449,13 +472,13 @@ describe('shared agent-hook-listener', () => {
       })
       expect(approved?.payload.state).toBe('working')
 
-      // Why: the lead already stopped before the wait; draining the child
-      // must resolve to done, not pin the pane on an invented 'working'.
+      // Why: even though the lead stopped before the wait, a current-runtime
+      // child ending resumes the parent until its next authoritative boundary.
       const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
-      expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.state).toBe('working')
     })
 
-    it('resolves to done when a blocked child dies after the lead finished', () => {
+    it('wakes the parent when a blocked child dies after the lead finished', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'bg task' })
       claudeEvent({
         hook_event_name: 'SubagentStart',
@@ -474,7 +497,7 @@ describe('shared agent-hook-listener', () => {
       })
 
       const stopped = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
-      expect(stopped?.payload.state).toBe('done')
+      expect(stopped?.payload.state).toBe('working')
     })
 
     it('removes a snapshot-seeded child missing from a present background_tasks list', () => {
@@ -722,7 +745,7 @@ describe('shared agent-hook-listener', () => {
       })
 
       const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
-      expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.state).toBe('working')
     })
 
     it('falls back to working when no lead record exists', () => {

--- a/src/shared/agent-hook-listener-roster-retention.test.ts
+++ b/src/shared/agent-hook-listener-roster-retention.test.ts
@@ -64,7 +64,7 @@ describe('Claude hook roster retention', () => {
       hook_event_name: 'TeammateIdle',
       teammate_name: 'reviewer'
     })
-    expect(idled?.payload.state).toBe('done')
+    expect(idled?.payload.state).toBe('working')
     expect(idled?.payload.subagents).toEqual([
       expect.objectContaining({ id: 'areviewer-6d3cb5b52120b7bf', state: 'idle' })
     ])

--- a/src/shared/agent-hook-listener/listener-state.ts
+++ b/src/shared/agent-hook-listener/listener-state.ts
@@ -44,9 +44,9 @@ export type ClaudeLeadTurnState = {
   waitingAgentId?: string
   /** Tool call that owns the wait; late completions from parallel sibling tools must not dismiss its card. */
   waitingToolUseId?: string
-  /** End time of the lead turn closed while background inventory kept the pane `working`. Repeated on the later all-clear `done`. */
+  /** End time of a lead turn closed while background inventory kept the pane `working`; retained across lifecycle reconciliation for stable completion identity. */
   turnCompletedAt?: number
-  /** Lead state a child-induced wait displaced, restored when the wait clears; can't invent 'working' since the done-gate only downgrades done→working, never back. */
+  /** Lead state a child-induced wait displaced, restored when the wait clears so the later child lifecycle can decide whether the parent resumes. */
   stateBeforeWait?: Pick<ClaudeLeadTurnState, 'state' | 'interrupted' | 'turnCompletedAt'>
 }
 

--- a/src/shared/agent-hook-listener/providers/claude-events.ts
+++ b/src/shared/agent-hook-listener/providers/claude-events.ts
@@ -184,7 +184,7 @@ export function normalizeClaudeEvent(
       })
     }
     // Why: approval granted — update the tool snapshot (drop the pending card) as the lead's own next tool event would.
-    // Restore the stashed lead state, not this child's 'working': the lead may already be done, and the done-gate never upgrades working back to done once the roster drains.
+    // Restore the stashed lead state, not this child's `working`; the child's later lifecycle event decides whether a finished parent resumes.
     const restored = lead.stateBeforeWait ?? { state: 'working' as const }
     state.claudeLeadStateByPaneKey.set(paneKey, restored)
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
@@ -216,7 +216,7 @@ export function normalizeClaudeEvent(
       )
     }
   }
-  // Why: a child-induced wait displaces the lead state; stash it so clearing restores reality (lead may be done). A 2nd child wait carries the ORIGINAL stash, not the intermediate waiting state.
+  // Why: a child-induced wait displaces the lead state; stash it so clearing restores reality (lead may be done). A second child wait carries the original stash, not the intermediate waiting state.
   const stateBeforeWait =
     isWaitingInducing && eventAgentId && previousLead
       ? previousLead.state === 'waiting'

--- a/src/shared/agent-hook-listener/providers/claude-lifecycle-events.ts
+++ b/src/shared/agent-hook-listener/providers/claude-lifecycle-events.ts
@@ -16,7 +16,7 @@ import {
 } from './claude-roster-state'
 import { buildClaudeStatusPayload } from './claude-status-build'
 
-/** SubagentStart/Stop/TeammateIdle update the roster and re-emit the lead's last known state with the fresh child list, so the sidebar reflects spawn/finish even when a background child outlives the lead turn with no other hook traffic. */
+/** SubagentStart/Stop/TeammateIdle update the roster and reconcile the cached lead with the fresh child list, so the sidebar reflects spawn/finish and the parent's resumed work even when no other hook fires. */
 export function normalizeClaudeSubagentLifecycleEvent(
   state: HookListenerState,
   eventName: 'SubagentStart' | 'SubagentStop' | 'TeammateIdle',
@@ -106,7 +106,7 @@ export function normalizeClaudeSubagentLifecycleEvent(
     endedRuntimeChildWork
   })
 }
-/** Re-emit the cached lead state without touching its tool/prompt caches; child churn and parallel completions must not dismiss live cards. */
+/** Reconcile the cached lead without touching its tool/prompt caches; child churn and parallel completions must not dismiss live cards. */
 export function buildClaudeCachedLeadStatusPayload(
   state: HookListenerState,
   eventName: unknown,
@@ -120,6 +120,11 @@ export function buildClaudeCachedLeadStatusPayload(
 ): ParsedAgentStatusPayload | null {
   const lead = state.claudeLeadStateByPaneKey.get(paneKey)
   let leadState = lead?.state
+  if (evidence.endedRuntimeChildWork && leadState === 'done' && lead?.interrupted !== true) {
+    // Why: Claude resumes the parent after a current-runtime child ends, often without another hook until its next tool. Keep the pane live through that silent generation window.
+    leadState = 'working'
+    state.claudeLeadStateByPaneKey.set(paneKey, { ...lead, state: leadState })
+  }
   if (!leadState) {
     if (evidence.workingChildEvidence || evidence.endedRuntimeChildWork) {
       // Why: ending a current-runtime child wakes its parent; only a cached lead boundary can prove the whole pane completed.
@@ -138,7 +143,7 @@ export function buildClaudeCachedLeadStatusPayload(
     }),
     updateToolSnapshot: false,
     interrupted: lead?.interrupted,
-    // Why: draining the last background child is this turn's all-clear; the stamp lets a consumer pair it with the announcement already sent.
+    // Why: lifecycle updates retain the lead boundary's completion identity even when a current child ending wakes the parent.
     turnCompletedAt: lead?.turnCompletedAt
   })
 }

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -229,7 +229,7 @@ describe('Claude background task status', () => {
     expect(finished?.turnCompletedAt).toBeUndefined()
   })
 
-  it('keeps foreground child work active before falling back to monitoring', () => {
+  it('keeps the resumed parent active before its next boundary falls back to monitoring', () => {
     const state = createHookListenerState()
     claudeEvent(state, SOURCE_PANE, {
       hook_event_name: 'SubagentStart',
@@ -246,6 +246,12 @@ describe('Claude background task status', () => {
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'SubagentStop',
         agent_id: 'child-1'
+      })
+    ).toMatchObject({ state: 'working', workingMode: undefined })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        background_tasks: [RUNNING_SHELL]
       })
     ).toMatchObject({ state: 'working', workingMode: 'monitoring' })
   })

--- a/tests/e2e/claude-parent-resume-after-child-stop.spec.ts
+++ b/tests/e2e/claude-parent-resume-after-child-stop.spec.ts
@@ -85,4 +85,5 @@ test('keeps the Claude parent working after its runtime child stops', async ({
     background_tasks: []
   })
   await expect(agentRow.getByLabel('Done').first()).toBeVisible()
+  await expect(agentRow.getByLabel('Working').first()).toBeHidden()
 })

--- a/tests/e2e/claude-parent-resume-after-child-stop.spec.ts
+++ b/tests/e2e/claude-parent-resume-after-child-stop.spec.ts
@@ -1,0 +1,88 @@
+import type { AgentHookEndpoint } from '../../src/shared/agent-hook-endpoint-file'
+import { test, expect } from './helpers/orca-app'
+import { readHookEndpoint } from './helpers/agent-hook-endpoint'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
+import { worktreeRow } from './worktree-row-locators'
+
+async function emitClaudeHookPayload(
+  endpoint: AgentHookEndpoint,
+  descriptor: { paneKey: string; worktreeId: string },
+  payload: Record<string, unknown>
+): Promise<void> {
+  const [tabId] = descriptor.paneKey.split(':')
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/claude`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': endpoint.token
+    },
+    body: JSON.stringify({
+      ...descriptor,
+      tabId,
+      env: endpoint.env,
+      version: endpoint.version,
+      payload
+    })
+  })
+  expect(response.status).toBe(204)
+}
+
+async function showFullAgentRows(page: Parameters<typeof worktreeRow>[0]): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    if (!state) {
+      throw new Error('window.__store is not available')
+    }
+    state.setAgentActivityDisplayMode('full')
+    if (!state.worktreeCardProperties.includes('inline-agents')) {
+      state.setWorktreeCardProperties([...state.worktreeCardProperties, 'inline-agents'])
+    }
+  })
+}
+
+test('keeps the Claude parent working after its runtime child stops', async ({
+  electronApp,
+  orcaPage
+}) => {
+  await waitForSessionReady(orcaPage)
+  const worktreeId = await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage)
+  await showFullAgentRows(orcaPage)
+
+  const endpoint = await readHookEndpoint(electronApp)
+  const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+  expect(descriptor.worktreeId).toBe(worktreeId)
+
+  await emitClaudeHookPayload(endpoint, descriptor, {
+    hook_event_name: 'UserPromptSubmit',
+    prompt: 'Continue after the child finishes'
+  })
+  await emitClaudeHookPayload(endpoint, descriptor, {
+    hook_event_name: 'SubagentStart',
+    agent_id: 'a1',
+    agent_type: 'general-purpose'
+  })
+  await emitClaudeHookPayload(endpoint, descriptor, {
+    hook_event_name: 'Stop',
+    background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+  })
+  await emitClaudeHookPayload(endpoint, descriptor, {
+    hook_event_name: 'SubagentStop',
+    agent_id: 'a1'
+  })
+
+  const agentRow = worktreeRow(orcaPage, worktreeId)
+    .locator('[aria-label="Agents"]')
+    .getByText('Continue after the child finishes')
+    .locator('xpath=ancestor::div[contains(@class, "group/agent-row")][1]')
+  await expect(agentRow).toBeVisible({ timeout: 15_000 })
+  await expect(agentRow.getByLabel('Working').first()).toBeVisible()
+
+  await emitClaudeHookPayload(endpoint, descriptor, {
+    hook_event_name: 'Stop',
+    background_tasks: []
+  })
+  await expect(agentRow.getByLabel('Done').first()).toBeVisible()
+})


### PR DESCRIPTION
## ELI5

When a Claude child agent finishes, Claude may immediately continue working in the parent without emitting another hook. Orca now keeps the parent yellow and working during that gap instead of incorrectly showing a green Done state.

## What Changed

- Reconcile a cached completed Claude parent back to `working` when its last current-runtime child stops.
- Preserve the existing safeguards for interrupted parents and restored-snapshot children.
- Persist the reconciled parent state so later lifecycle updates do not republish the stale Done status.
- Add unit regressions and a real Electron E2E test covering Working after child stop and Done after the parent itself stops.

## Why

Claude can emit the parent `Stop` hook while a child is still running. Orca caches that parent as done. When the last child later emits `SubagentStop`, the parent resumes, but the lifecycle normalizer previously republished the cached Done state. Because Claude may not emit another hook until its next tool call, the sidebar could stay green while the parent was visibly still typing.

The fix only wakes a non-interrupted cached parent when a child from the current runtime actually ends. Existing restored-state and interruption protections remain unchanged.

## Linked Issue

Fixes #18610

## Visual Proof

| Before — incorrect green Done | After — correct yellow Working |
| --- | --- |
| Parent is still working after the child stops. | Parent stays Working until its own Stop hook. |
| <img width="468" alt="before-sidebar-row" src="https://github.com/user-attachments/assets/8a0d13fc-3003-4d31-bf9f-175a71157ce6" /> | <img width="468" alt="after-sidebar-row" src="https://github.com/user-attachments/assets/b19c5826-fbd4-42d0-b4c0-4b7e104abd43" /> |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validation performed on macOS:

- Reproduced the bug in the real Electron app before the fix: the row changed to green Done after `SubagentStop` while the parent remained active.
- Verified the fix in the real Electron app: the row remains yellow Working after `SubagentStop`, then changes to Done after the parent `Stop`.
- Relevant unit and Electron E2E coverage: 95/95 passed.
- Additional affected lifecycle suites: 65/65 passed.
- `pnpm lint`: passed.
- `pnpm typecheck`: passed.
- `pnpm build`: passed for desktop, relay targets, CLI, web, and native macOS.
- `pnpm test`: 71,812 passed and 291 skipped. Two unrelated `structured-tui-transcript-catchup.test.ts` watcher/timing cases failed under full parallel load; both passed immediately in isolation and also passed on detached `upstream/main`.
- `pnpm typecheck:e2e`: the repository-wide command remains baseline-broken with existing errors; the new E2E file passes focused lint/type-safe API usage checks and its Electron test passes.

## AI Disclosure

OpenAI Codex (GPT-5.6 sol) was used for issue analysis, implementation, test authoring, and PR drafting.

## Review

- **Correctness:** The transition is limited to a cached `done` lead when current-runtime child work has just ended. A later parent `Stop` still produces Done.
- **Security:** No authentication, command execution, IPC schema, network surface, dependency, or credential behavior changes.
- **Cross-platform:** The production change is platform-neutral shared TypeScript with no filesystem, shell, shortcut, or native API changes. Interactive validation ran on macOS; the same normalization path is used on Linux and Windows.
- **Remote SSH:** Hook normalization is shared by local and relay-delivered events; no host routing or transport behavior changes.
- **Agents/integrations:** The change is scoped to Claude lifecycle events. Other providers and integrations are unchanged.
- **Performance/backwards compatibility:** The fix adds one guarded in-memory map update during child completion and does not add polling, I/O, or persistence-format changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- X: [@Avichal2205](https://x.com/Avichal2205)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
