### PR TITLE
feat(agents): launch profiles — run one agent under several credential homes or providers at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ docs/**
 !docs/reference/windows-process-enumeration.md
 !docs/reference/wsl-runner-verification.md
 !docs/reference/remote-wire-compatibility.md
+!docs/reference/agent-launch-profiles.md
 !docs/reference/renderer-agent-status-performance.md
 !docs/reference/ssh-execution-boundary.md
 !docs/reference/ssh-host-key-verification.md

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Works with **any CLI agent** — if it runs in a terminal, it runs in Orca.
 - **[Download from onOrca.dev](https://onorca.dev/download)**
 - Or grab a build directly: [macOS Apple Silicon](https://github.com/stablyai/orca/releases/latest/download/orca-macos-arm64.dmg) · [macOS Intel](https://github.com/stablyai/orca/releases/latest/download/orca-macos-x64.dmg) · [Windows (.exe)](https://github.com/stablyai/orca/releases/latest/download/orca-windows-setup.exe) · [Linux AppImage](https://github.com/stablyai/orca/releases/latest/download/orca-linux.AppImage) · [All builds](https://github.com/stablyai/orca/releases/latest)
 - Running `orca serve` on a headless Linux server? See the [headless Linux server guide](docs/reference/headless-linux-server.md).
+- Running one agent under several credential homes or providers? See the [agent launch profiles reference](docs/reference/agent-launch-profiles.md).
 
 _Or via a package manager:_
 

--- a/docs/reference/agent-launch-profiles.md
+++ b/docs/reference/agent-launch-profiles.md
@@ -67,6 +67,9 @@ remote's own `ORCA_*_SECONDARY_HOME` override is not consulted there.
 
 ## Surfaces
 
+The pickers are off by default: Settings → Agents → **Agent launch profiles** turns them on.
+The RPC fields and the CLI flag accept a profile id regardless of the setting.
+
 - Desktop tab bar: the agent row becomes a submenu when profiles exist (`Default launch` +
   one item per profile).
 - Paired web / thin clients: `launchProfileId` rides `terminal.createAgentSession`; hosts

--- a/docs/reference/agent-launch-profiles.md
+++ b/docs/reference/agent-launch-profiles.md
@@ -73,4 +73,9 @@ remote's own `ORCA_*_SECONDARY_HOME` override is not consulted there.
   advertise `agent-session.launch-profile.v1`, and the client refuses to fall back to the legacy
   env-only create on hosts that lack it.
 - CLI: `orca worktree create --agent codex --launch-profile codex-secondary-home`.
-- Mobile: the same RPC fields are accepted; the app-side picker is a follow-up.
+- New Workspace composer: a `Launch profile` select appears under the agent picker when the
+  chosen agent has profiles; the profile is layered into the startup command and env the
+  renderer already sends, so no new create field is needed.
+- Mobile: the new-tab sheet lists each agent's profiles beneath its default launch once the
+  host advertises the capability, and a terminal tab shows a small badge with the profile it
+  runs under (built-ins shortened, custom ids as-is).

--- a/docs/reference/agent-launch-profiles.md
+++ b/docs/reference/agent-launch-profiles.md
@@ -1,0 +1,76 @@
+# Agent launch profiles
+
+A launch profile pins **one launch** of a CLI agent to a credential home and/or process-local
+overrides. Selection is per launch, never a global slot, so two panes on the same host can run
+the same agent under different accounts or model providers at the same time.
+
+This is orthogonal to managed accounts. A managed account is a credential Orca captured and
+stores; a launch profile decides where a particular launch reads its credentials from and which
+extra args/env it carries. A plain launch (no profile) behaves exactly as before.
+
+## Profiles
+
+| Profile                                 | Agent  | What it does                                                                                                                                                                                                                      |
+| --------------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `codex-secondary-home` (built-in)       | codex  | Runs Codex with `CODEX_HOME=~/.codex-2` (or `$ORCA_CODEX_SECONDARY_HOME`). Log in there once with `CODEX_HOME=~/.codex-2 codex login`.                                                                                            |
+| `claude-secondary-home` (built-in)      | claude | Runs Claude Code with `CLAUDE_CONFIG_DIR=~/.claude-2` (or `$ORCA_CLAUDE_SECONDARY_HOME`). Log in there once with `CLAUDE_CONFIG_DIR=~/.claude-2 claude auth login`.                                                               |
+| custom (`settings.agentLaunchProfiles`) | any    | Appends `args` after the agent's configured args and merges `env` over the agent's default env. Use this for an OpenAI-compatible or Anthropic-compatible provider (`-c model_provider=...`, `ANTHROPIC_BASE_URL`, key env vars). |
+
+Custom rows are plain settings, like `agentDefaultArgs` / `agentDefaultEnv`:
+
+```json
+{
+  "agentLaunchProfiles": [
+    {
+      "id": "codex-work-proxy",
+      "agent": "codex",
+      "label": "Codex · work proxy",
+      "args": "-c model_provider=\"work\" -c model_providers.work.base_url=\"https://llm.example.com/v1\" -c model_providers.work.env_key=\"WORK_API_KEY\"",
+      "env": { "WORK_API_KEY": "..." }
+    }
+  ]
+}
+```
+
+Ids are lowercase slugs; built-in ids cannot be shadowed. `args` is tokenized for the launch
+shell the same way `agentDefaultArgs` is, so quoting rules do not change per profile.
+
+## How a launch travels
+
+```
+client picks a profile ──► terminal.createAgentSession { agent, launchProfileId }
+                           (or session.tabs.createTerminal / worktree.create startupLaunchProfileId)
+host validates the id against its own catalog
+host layers args/env and stamps ORCA_AGENT_LAUNCH_PROFILE=<id>
+secondary-home profiles also stamp a marker: ORCA_CODEX_HOME_PROFILE / ORCA_CLAUDE_CONFIG_DIR_PROFILE
+execution host (daemon spawn) turns the marker into the real path — host: ~/.codex-2, WSL: <distro home>/.codex-2
+```
+
+Only the execution host ever knows the real path. The runtime never sends a path to a client and a
+client never sends one to the host.
+
+Named errors from the host: `agent_session_launch_profile_unknown`,
+`agent_session_launch_profile_agent_mismatch`, `agent_session_launch_profile_remote_unsupported`
+(raised at spawn when an SSH session never learned the remote home a secondary home needs).
+
+On SSH hosts the env reaches the relay as a literal map, so the secondary home is joined from
+the home directory the session probed at connect time, in the remote's path flavor. The
+remote's own `ORCA_*_SECONDARY_HOME` override is not consulted there.
+
+## What changes for the managed-account machinery
+
+- A Codex launch carrying the Codex marker skips managed-home selection and the managed-auth
+  wait, drops the managed-home hook preflight, and is recorded in `codex-pane-accounts.json` as
+  `homeRoute: 'custom-home'` with `launchProfileId`, so stale-account prompts never name it.
+- A Claude launch carrying the Claude marker skips the managed credential materialization into
+  `~/.claude` and its auth-env stripping, because the launch reads a different directory.
+
+## Surfaces
+
+- Desktop tab bar: the agent row becomes a submenu when profiles exist (`Default launch` +
+  one item per profile).
+- Paired web / thin clients: `launchProfileId` rides `terminal.createAgentSession`; hosts
+  advertise `agent-session.launch-profile.v1`, and the client refuses to fall back to the legacy
+  env-only create on hosts that lack it.
+- CLI: `orca worktree create --agent codex --launch-profile codex-secondary-home`.
+- Mobile: the same RPC fields are accepted; the app-side picker is a follow-up.

--- a/mobile/src/session/MobileSessionHeader.tsx
+++ b/mobile/src/session/MobileSessionHeader.tsx
@@ -14,9 +14,11 @@ import { MobileSessionHeaderIconButton } from './MobileSessionHeaderIconButton'
 import { triggerMediumImpact } from '../platform/haptics'
 import { StatusDot } from '../components/StatusDot'
 import { MobileAgentIcon } from '../components/MobileAgentIcon'
+import { mobileLaunchProfileBadge } from './mobile-launch-profile-labels'
 import {
   getMobileSessionTabTitle,
-  resolveMobileTerminalTabAgentId
+  resolveMobileTerminalTabAgentId,
+  resolveMobileTerminalTabLaunchProfileId
 } from './mobile-terminal-tab-agent'
 import { colors } from '../theme/mobile-theme'
 import { QuickCommandsTabButton } from './QuickCommandsTabButton'
@@ -173,6 +175,17 @@ export function MobileSessionHeader({ controller }: { controller: MobileSessionC
                     (() => {
                       const agentId = resolveMobileTerminalTabAgentId(t)
                       return agentId ? <MobileAgentIcon agentId={agentId} size={13} /> : null
+                    })()}
+                  {t.type === 'terminal' &&
+                    (() => {
+                      const badge = mobileLaunchProfileBadge(
+                        resolveMobileTerminalTabLaunchProfileId(t)
+                      )
+                      return badge ? (
+                        <Text style={styles.tabProfileBadge} numberOfLines={1}>
+                          {badge}
+                        </Text>
+                      ) : null
                     })()}
                   <Text
                     style={[styles.tabText, t.id === activeSessionTabId && styles.tabTextActive]}

--- a/mobile/src/session/mobile-launch-profile-capability.ts
+++ b/mobile/src/session/mobile-launch-profile-capability.ts
@@ -1,0 +1,25 @@
+import { AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY } from '../../../src/shared/protocol-version'
+import type { RpcClient } from '../transport/rpc-client'
+
+// Why: source the capability string from the shared contract so a host bump can never
+// silently drift from the mobile probe.
+export const MOBILE_AGENT_LAUNCH_PROFILE_CAPABILITY =
+  AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY
+
+/** Whether the paired host honors `launchProfileId`; older hosts silently ignore unknown fields. */
+export async function readAgentLaunchProfileCapability(
+  client: Pick<RpcClient, 'sendRequest'>
+): Promise<boolean> {
+  try {
+    const response = await client.sendRequest('status.get')
+    if (!response.ok || !response.result || typeof response.result !== 'object') {
+      return false
+    }
+    const capabilities = (response.result as { capabilities?: unknown }).capabilities
+    return (
+      Array.isArray(capabilities) && capabilities.includes(MOBILE_AGENT_LAUNCH_PROFILE_CAPABILITY)
+    )
+  } catch {
+    return false
+  }
+}

--- a/mobile/src/session/mobile-launch-profile-labels.test.ts
+++ b/mobile/src/session/mobile-launch-profile-labels.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { mobileLaunchProfileBadge } from './mobile-launch-profile-labels'
+
+describe('mobileLaunchProfileBadge', () => {
+  it('shortens built-in labels to their distinguishing half', () => {
+    expect(mobileLaunchProfileBadge('codex-secondary-home')).toBe('secondary home')
+    expect(mobileLaunchProfileBadge('claude-secondary-home')).toBe('secondary home')
+  })
+
+  it('shows custom ids as-is and nothing for a default launch', () => {
+    expect(mobileLaunchProfileBadge('codex-work-proxy')).toBe('codex-work-proxy')
+    expect(mobileLaunchProfileBadge(undefined)).toBeNull()
+    expect(mobileLaunchProfileBadge(' ')).toBeNull()
+  })
+})

--- a/mobile/src/session/mobile-launch-profile-labels.ts
+++ b/mobile/src/session/mobile-launch-profile-labels.ts
@@ -1,0 +1,19 @@
+import { BUILT_IN_AGENT_LAUNCH_PROFILES } from '../../../src/shared/agent-launch-profile/agent-launch-profile'
+
+// Why: the tab strip already shows the agent icon, so a built-in label such as
+// "Codex · secondary home" only needs its distinguishing half. Custom profiles are host
+// settings the device does not hold, so their id is the honest fallback.
+export function mobileLaunchProfileBadge(
+  launchProfileId: string | null | undefined
+): string | null {
+  const id = launchProfileId?.trim()
+  if (!id) {
+    return null
+  }
+  const builtIn = BUILT_IN_AGENT_LAUNCH_PROFILES.find((profile) => profile.id === id)
+  if (!builtIn) {
+    return id
+  }
+  const separator = builtIn.label.indexOf(' · ')
+  return separator === -1 ? builtIn.label : builtIn.label.slice(separator + ' · '.length)
+}

--- a/mobile/src/session/mobile-new-tab-agent-loader.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.test.ts
@@ -38,7 +38,41 @@ describe('mobile new-tab agent loading', () => {
     ])
     expect(client.sendRequest.mock.calls.map(([method]) => method)).toEqual([
       'preflight.detectAgents',
-      'settings.get'
+      'settings.get',
+      'status.get'
+    ])
+  })
+
+  it('adds launch-profile rows when the host advertises the capability', async () => {
+    const client = createClient(async (method) => {
+      if (method === 'settings.get') {
+        return {
+          ok: true,
+          result: { settings: { defaultTuiAgent: 'codex', disabledTuiAgents: ['claude'] } }
+        }
+      }
+      if (method === 'preflight.detectAgents') {
+        return { ok: true, result: ['claude', 'codex'] }
+      }
+      if (method === 'status.get') {
+        return { ok: true, result: { capabilities: ['agent-session.launch-profile.v1'] } }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({
+        client,
+        worktreeId: FLOATING_WORKSPACE_WORKTREE_ID
+      })
+    ).resolves.toEqual([
+      { agent: 'codex', label: 'Codex' },
+      {
+        agent: 'codex',
+        label: 'Codex · secondary home',
+        launchProfileId: 'codex-secondary-home',
+        hint: 'Codex launch profile'
+      }
     ])
   })
 
@@ -66,6 +100,7 @@ describe('mobile new-tab agent loading', () => {
     expect(client.sendRequest.mock.calls.map(([method]) => method)).toEqual([
       'repo.list',
       'settings.get',
+      'status.get',
       'preflight.detectRemoteAgents'
     ])
   })

--- a/mobile/src/session/mobile-new-tab-agent-loader.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.test.ts
@@ -43,12 +43,18 @@ describe('mobile new-tab agent loading', () => {
     ])
   })
 
-  it('adds launch-profile rows when the host advertises the capability', async () => {
+  it('adds launch-profile rows when the host advertises the capability and opted in', async () => {
     const client = createClient(async (method) => {
       if (method === 'settings.get') {
         return {
           ok: true,
-          result: { settings: { defaultTuiAgent: 'codex', disabledTuiAgents: ['claude'] } }
+          result: {
+            settings: {
+              defaultTuiAgent: 'codex',
+              disabledTuiAgents: ['claude'],
+              agentLaunchProfilesEnabled: true
+            }
+          }
         }
       }
       if (method === 'preflight.detectAgents') {

--- a/mobile/src/session/mobile-new-tab-agent-loader.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.ts
@@ -1,6 +1,7 @@
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcFailure, RpcSuccess } from '../transport/types'
 import { isFloatingWorkspaceWorktreeId } from './floating-workspace'
+import { readAgentLaunchProfileCapability } from './mobile-launch-profile-capability'
 import { getRepoIdFromMobileWorktreeId } from './mobile-session-route-helpers'
 import {
   buildMobileNewTabAgentOptions,
@@ -22,9 +23,10 @@ export async function loadMobileNewTabAgentOptions(args: {
   const detectedAgentsRequest = isFloatingWorkspaceWorktreeId(worktreeId)
     ? client.sendRequest('preflight.detectAgents')
     : loadWorkspaceDetectedAgents(client, worktreeId)
-  const [settingsResponse, detectedResponse] = await Promise.all([
+  const [settingsResponse, detectedResponse, launchProfilesSupported] = await Promise.all([
     client.sendRequest('settings.get'),
-    detectedAgentsRequest
+    detectedAgentsRequest,
+    readAgentLaunchProfileCapability(client)
   ])
   if (!settingsResponse.ok) {
     throw new Error((settingsResponse as RpcFailure).error.message)
@@ -39,7 +41,8 @@ export async function loadMobileNewTabAgentOptions(args: {
   ).settings
   return buildMobileNewTabAgentOptions(
     settings,
-    (detectedResponse as RpcSuccess).result as unknown[]
+    (detectedResponse as RpcSuccess).result as unknown[],
+    { launchProfilesSupported }
   )
 }
 

--- a/mobile/src/session/mobile-new-tab-agent-options.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-options.test.ts
@@ -30,9 +30,21 @@ describe('mobile new-tab agent options', () => {
   it('lists launch profiles under their agent only when the host supports them', () => {
     const settings = {
       defaultTuiAgent: 'codex' as const,
-      agentLaunchProfiles: [{ id: 'codex-work-proxy', agent: 'codex', label: 'Work proxy' }]
+      agentLaunchProfiles: [{ id: 'codex-work-proxy', agent: 'codex', label: 'Work proxy' }],
+      agentLaunchProfilesEnabled: true
     }
     expect(buildMobileNewTabAgentOptions(settings, ['codex', 'claude'])).toEqual([
+      { agent: 'codex', label: 'Codex' },
+      { agent: 'claude', label: 'Claude' }
+    ])
+    // Why: the host's setting is off by default; a capable host still shows plain rows then.
+    expect(
+      buildMobileNewTabAgentOptions(
+        { ...settings, agentLaunchProfilesEnabled: false },
+        ['codex', 'claude'],
+        { launchProfilesSupported: true }
+      )
+    ).toEqual([
       { agent: 'codex', label: 'Codex' },
       { agent: 'claude', label: 'Claude' }
     ])
@@ -67,7 +79,10 @@ describe('mobile new-tab agent options', () => {
   it('drops malformed custom profiles instead of failing the picker', () => {
     expect(
       buildMobileNewTabAgentOptions(
-        { agentLaunchProfiles: [{ id: 'Bad Id', agent: 'codex' }, 'nonsense'] },
+        {
+          agentLaunchProfiles: [{ id: 'Bad Id', agent: 'codex' }, 'nonsense'],
+          agentLaunchProfilesEnabled: true
+        },
         ['codex'],
         { launchProfilesSupported: true }
       ).map((option) => option.launchProfileId ?? null)

--- a/mobile/src/session/mobile-new-tab-agent-options.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-options.test.ts
@@ -26,4 +26,51 @@ describe('mobile new-tab agent options', () => {
   it('does not show stale presets while detection is pending', () => {
     expect(buildMobileNewTabAgentOptions({ defaultTuiAgent: 'codex' }, null)).toEqual([])
   })
+
+  it('lists launch profiles under their agent only when the host supports them', () => {
+    const settings = {
+      defaultTuiAgent: 'codex' as const,
+      agentLaunchProfiles: [{ id: 'codex-work-proxy', agent: 'codex', label: 'Work proxy' }]
+    }
+    expect(buildMobileNewTabAgentOptions(settings, ['codex', 'claude'])).toEqual([
+      { agent: 'codex', label: 'Codex' },
+      { agent: 'claude', label: 'Claude' }
+    ])
+    expect(
+      buildMobileNewTabAgentOptions(settings, ['codex', 'claude'], {
+        launchProfilesSupported: true
+      })
+    ).toEqual([
+      { agent: 'codex', label: 'Codex' },
+      {
+        agent: 'codex',
+        label: 'Codex · secondary home',
+        launchProfileId: 'codex-secondary-home',
+        hint: 'Codex launch profile'
+      },
+      {
+        agent: 'codex',
+        label: 'Work proxy',
+        launchProfileId: 'codex-work-proxy',
+        hint: 'Codex launch profile'
+      },
+      { agent: 'claude', label: 'Claude' },
+      {
+        agent: 'claude',
+        label: 'Claude Code · secondary home',
+        launchProfileId: 'claude-secondary-home',
+        hint: 'Claude launch profile'
+      }
+    ])
+  })
+
+  it('drops malformed custom profiles instead of failing the picker', () => {
+    expect(
+      buildMobileNewTabAgentOptions(
+        { agentLaunchProfiles: [{ id: 'Bad Id', agent: 'codex' }, 'nonsense'] },
+        ['codex'],
+        { launchProfilesSupported: true }
+      ).map((option) => option.launchProfileId ?? null)
+    ).toEqual([null, 'codex-secondary-home'])
+  })
 })

--- a/mobile/src/session/mobile-new-tab-agent-options.ts
+++ b/mobile/src/session/mobile-new-tab-agent-options.ts
@@ -15,6 +15,7 @@ export type MobileNewTabAgentSettings = {
   defaultTuiAgent?: TuiAgent | 'blank' | null
   disabledTuiAgents?: unknown
   agentLaunchProfiles?: unknown
+  agentLaunchProfilesEnabled?: unknown
 }
 
 export type MobileNewTabAgentOption = {
@@ -50,11 +51,15 @@ export function buildMobileNewTabAgentOptions(
   if (!detectedAgentIds) {
     return []
   }
-  // Why: only a host that advertises the capability resolves profile ids; an older host would
-  // ignore the field and silently start the default launch under the profile's name.
-  const profiles = options.launchProfilesSupported
-    ? resolveAgentLaunchProfiles(normalizeAgentLaunchProfileSettings(settings?.agentLaunchProfiles))
-    : []
+  // Why: only a host that advertises the capability resolves profile ids (an older host would
+  // ignore the field and silently start the default launch under the profile's name), and the
+  // host's setting decides whether pickers show profiles at all.
+  const profiles =
+    options.launchProfilesSupported && settings?.agentLaunchProfilesEnabled === true
+      ? resolveAgentLaunchProfiles(
+          normalizeAgentLaunchProfileSettings(settings?.agentLaunchProfiles)
+        )
+      : []
   return orderMobileNewTabAgents(
     settings?.defaultTuiAgent,
     detectedAgentIds,

--- a/mobile/src/session/mobile-new-tab-agent-options.ts
+++ b/mobile/src/session/mobile-new-tab-agent-options.ts
@@ -1,3 +1,8 @@
+import {
+  agentLaunchProfilesForAgent,
+  normalizeAgentLaunchProfileSettings,
+  resolveAgentLaunchProfiles
+} from '../../../src/shared/agent-launch-profile/agent-launch-profile'
 import type { TuiAgent } from '../../../src/shared/tui-agent'
 import {
   filterEnabledMobileTuiAgents,
@@ -9,11 +14,15 @@ import {
 export type MobileNewTabAgentSettings = {
   defaultTuiAgent?: TuiAgent | 'blank' | null
   disabledTuiAgents?: unknown
+  agentLaunchProfiles?: unknown
 }
 
 export type MobileNewTabAgentOption = {
   agent: TuiAgent
   label: string
+  /** Set on launch-profile rows; the default launch of an agent carries none. */
+  launchProfileId?: string
+  hint?: string
 }
 
 export function orderMobileNewTabAgents(
@@ -35,17 +44,31 @@ export function orderMobileNewTabAgents(
 
 export function buildMobileNewTabAgentOptions(
   settings: MobileNewTabAgentSettings | null | undefined,
-  detectedAgentIds: Iterable<unknown> | null
+  detectedAgentIds: Iterable<unknown> | null,
+  options: { launchProfilesSupported?: boolean } = {}
 ): MobileNewTabAgentOption[] {
   if (!detectedAgentIds) {
     return []
   }
+  // Why: only a host that advertises the capability resolves profile ids; an older host would
+  // ignore the field and silently start the default launch under the profile's name.
+  const profiles = options.launchProfilesSupported
+    ? resolveAgentLaunchProfiles(normalizeAgentLaunchProfileSettings(settings?.agentLaunchProfiles))
+    : []
   return orderMobileNewTabAgents(
     settings?.defaultTuiAgent,
     detectedAgentIds,
     settings?.disabledTuiAgents
-  ).map((agent) => ({
-    agent,
-    label: MOBILE_TUI_AGENT_LABELS[agent]
-  }))
+  ).flatMap((agent) => {
+    const agentLabel = MOBILE_TUI_AGENT_LABELS[agent]
+    return [
+      { agent, label: agentLabel },
+      ...agentLaunchProfilesForAgent(profiles, agent).map((profile) => ({
+        agent,
+        label: profile.label,
+        launchProfileId: profile.id,
+        hint: `${agentLabel} launch profile`
+      }))
+    ]
+  })
 }

--- a/mobile/src/session/mobile-session-frame-styles.ts
+++ b/mobile/src/session/mobile-session-frame-styles.ts
@@ -121,6 +121,18 @@ export const mobileSessionFrameStyles = StyleSheet.create({
   tabTextActive: {
     color: colors.textPrimary
   },
+  // Why: the profile is secondary to the title; a small capsule keeps it readable without
+  // competing with the tab label.
+  tabProfileBadge: {
+    flexShrink: 1,
+    color: colors.textSecondary,
+    fontSize: 10,
+    lineHeight: 14,
+    paddingHorizontal: 5,
+    borderRadius: 7,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.textSecondary
+  },
   newTerminalButton: {
     width: 40,
     height: 36,

--- a/mobile/src/session/mobile-terminal-tab-agent.test.ts
+++ b/mobile/src/session/mobile-terminal-tab-agent.test.ts
@@ -5,6 +5,7 @@ import type { MobileSessionTab } from './mobile-session-route-types'
 import {
   getMobileSessionTabTitle,
   resolveMobileTerminalTabAgentId,
+  resolveMobileTerminalTabLaunchProfileId,
   resolveMobileTerminalTabOwnedAgentId
 } from './mobile-terminal-tab-agent'
 
@@ -73,6 +74,25 @@ describe('resolveMobileTerminalTabAgentId', () => {
     expect(
       resolveMobileTerminalTabAgentId(terminalTab('Codex ready', { agentType: 'unknown' }))
     ).toBe('codex')
+  })
+})
+
+describe('resolveMobileTerminalTabLaunchProfileId', () => {
+  it('reports the host-stamped launch profile and nothing for a default launch', () => {
+    const tab = terminalTab('Terminal', { agentType: 'codex' })
+    expect(resolveMobileTerminalTabLaunchProfileId(tab)).toBeNull()
+    expect(
+      resolveMobileTerminalTabLaunchProfileId({
+        ...tab,
+        agentStatus: { ...tab.agentStatus!, launchProfileId: 'codex-secondary-home' }
+      })
+    ).toBe('codex-secondary-home')
+    expect(
+      resolveMobileTerminalTabLaunchProfileId({
+        ...tab,
+        agentStatus: { ...tab.agentStatus!, launchProfileId: '  ' }
+      })
+    ).toBeNull()
   })
 })
 

--- a/mobile/src/session/mobile-terminal-tab-agent.ts
+++ b/mobile/src/session/mobile-terminal-tab-agent.ts
@@ -17,8 +17,18 @@ import type { MobileSessionTab } from './mobile-session-route-types'
  */
 type MobileTerminalTabAgentIdentity = {
   title: string
-  agentStatus?: { agentType?: AgentStatusEntry['agentType'] | null } | null
+  agentStatus?: {
+    agentType?: AgentStatusEntry['agentType'] | null
+    launchProfileId?: AgentStatusEntry['launchProfileId'] | null
+  } | null
   launchAgent?: TuiAgent | null
+}
+
+/** The launch profile the host reports for the tab's agent, or null for a default launch. */
+export function resolveMobileTerminalTabLaunchProfileId(
+  tab: MobileTerminalTabAgentIdentity
+): string | null {
+  return tab.agentStatus?.launchProfileId?.trim() || null
 }
 
 /** Agent identity Orca owns, excluding the display-only title fallback. */

--- a/mobile/src/session/use-mobile-session-panel-route-actions.tsx
+++ b/mobile/src/session/use-mobile-session-panel-route-actions.tsx
@@ -50,10 +50,11 @@ export function useMobileSessionPanelRouteActions(scope: MobileSessionPresentati
       : createTabAgentOptions.length > 0
         ? createTabAgentOptions.map((option) => ({
             label: option.label,
+            ...(option.hint ? { hint: option.hint } : {}),
             renderIcon: () => <MobileAgentIcon agentId={option.agent} size={16} />,
             onPress: () => {
               setShowCreateTabDrawer(false)
-              void handleCreateTerminal(option.agent)
+              void handleCreateTerminal(option.agent, undefined, option.launchProfileId)
             }
           }))
         : createTabAgentLoadState === 'loaded'
@@ -100,10 +101,14 @@ export function useMobileSessionPanelRouteActions(scope: MobileSessionPresentati
                 if (!delivery) {
                   return
                 }
-                void handleCreateTerminal(option.agent, {
-                  initialPrompt: delivery.prompt,
-                  onPromptSent: () => void clearDeliveredDiffComments(delivery.comments)
-                })
+                void handleCreateTerminal(
+                  option.agent,
+                  {
+                    initialPrompt: delivery.prompt,
+                    onPromptSent: () => void clearDeliveredDiffComments(delivery.comments)
+                  },
+                  option.launchProfileId
+                )
               }
             }))
           : createTabAgentLoadState === 'loaded'

--- a/mobile/src/session/use-mobile-session-terminal-create-actions.test.ts
+++ b/mobile/src/session/use-mobile-session-terminal-create-actions.test.ts
@@ -111,6 +111,28 @@ describe('mobile + Codex tab creation routing', () => {
     expect(scope.unsubscribeTerminal).toHaveBeenCalledWith('existing-terminal')
   })
 
+  it('routes a Codex launch profile through the terminal path with the profile id', async () => {
+    const client = clientReturning(terminalCreateResponse())
+    const scope = createScope(client)
+    let actions: ReturnType<typeof useMobileSessionTerminalCreateActions> | undefined
+    function Harness() {
+      actions = useMobileSessionTerminalCreateActions(scope as never)
+      return null
+    }
+    await act(async () => {
+      renderer = create(createElement(Harness))
+    })
+    await act(async () => {
+      await actions?.handleCreateTerminal('codex', undefined, 'codex-secondary-home')
+    })
+
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
+    expect(client.sendRequest).toHaveBeenCalledWith(
+      'session.tabs.createTerminal',
+      expect.objectContaining({ agent: 'codex', launchProfileId: 'codex-secondary-home' })
+    )
+  })
+
   it('keeps the legacy terminal path when structured support is disabled', async () => {
     const client = clientReturning(
       { ok: false, error: { code: 'structured_agent_session_unsupported', message: 'off' } },

--- a/mobile/src/session/use-mobile-session-terminal-create-actions.ts
+++ b/mobile/src/session/use-mobile-session-terminal-create-actions.ts
@@ -47,7 +47,8 @@ export function useMobileSessionTerminalCreateActions(scope: MobileSessionAttach
     options?: MobileQuickCommandLaunch['options'] & {
       onPromptSent?: () => void
       errorToast?: string
-    }
+    },
+    launchProfileId?: MobileNewTabAgentOption['launchProfileId']
   ) {
     if (!client || creatingTerminalRef.current) {
       return
@@ -63,8 +64,9 @@ export function useMobileSessionTerminalCreateActions(scope: MobileSessionAttach
       .slice(2, 10)}`
 
     try {
-      // Bare Codex launches follow structured support; prompted launches keep their startup semantics.
-      if (agent === 'codex' && options === undefined) {
+      // Bare Codex launches follow structured support; prompted launches keep their startup
+      // semantics, and a launch profile is a PTY launch the structured session cannot carry.
+      if (agent === 'codex' && options === undefined && !launchProfileId) {
         const structured = await createMobileStructuredCodexSession(client, worktreeId)
         if (structured.kind === 'created') {
           const previous = activeHandleRef.current
@@ -102,6 +104,7 @@ export function useMobileSessionTerminalCreateActions(scope: MobileSessionAttach
           : {}),
         ...(options?.agentPrompt ? { agentPrompt: options.agentPrompt } : {}),
         ...(agent ? { agent } : {}),
+        ...(launchProfileId ? { launchProfileId } : {}),
         activate: false,
         select: true,
         navigation: 'caller'

--- a/src/cli/handlers/worktree-startup-agent-flags.test.ts
+++ b/src/cli/handlers/worktree-startup-agent-flags.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { getWorktreeStartupAgentFlags } from './worktree-startup-agent-flags'
+
+function flags(entries: Record<string, string | boolean>): Map<string, string | boolean> {
+  return new Map(Object.entries(entries))
+}
+
+describe('getWorktreeStartupAgentFlags', () => {
+  it('returns nothing without --agent', () => {
+    expect(getWorktreeStartupAgentFlags(flags({}))).toEqual({})
+  })
+
+  it('requires --agent for --prompt and --launch-profile', () => {
+    expect(() => getWorktreeStartupAgentFlags(flags({ prompt: 'hi' }))).toThrow(
+      '--prompt requires --agent'
+    )
+    expect(() =>
+      getWorktreeStartupAgentFlags(flags({ 'launch-profile': 'codex-secondary-home' }))
+    ).toThrow('--launch-profile requires --agent')
+  })
+
+  it('passes a well-formed profile id through untouched', () => {
+    expect(
+      getWorktreeStartupAgentFlags(flags({ agent: 'codex', 'launch-profile': 'codex-work' }))
+    ).toEqual({ startupAgent: 'codex', startupLaunchProfileId: 'codex-work' })
+    expect(getWorktreeStartupAgentFlags(flags({ agent: 'codex' }))).toEqual({
+      startupAgent: 'codex'
+    })
+  })
+
+  it('rejects malformed ids and unknown agents locally', () => {
+    expect(() =>
+      getWorktreeStartupAgentFlags(flags({ agent: 'codex', 'launch-profile': 'Not A Slug' }))
+    ).toThrow(/Invalid --launch-profile/)
+    expect(() => getWorktreeStartupAgentFlags(flags({ agent: 'nope' }))).toThrow(
+      'Unknown TUI agent "nope"'
+    )
+    expect(() =>
+      getWorktreeStartupAgentFlags(flags({ agent: 'codex', 'launch-profile': '' }))
+    ).toThrow('Missing value for --launch-profile')
+  })
+})

--- a/src/cli/handlers/worktree-startup-agent-flags.ts
+++ b/src/cli/handlers/worktree-startup-agent-flags.ts
@@ -44,11 +44,10 @@ export function getWorktreeStartupAgentFlags(
   }
   // Why: only the shape is checked here; the host owns the profile catalog and reports
   // agent_session_launch_profile_unknown / _agent_mismatch for ids it does not serve.
+  // Why: the guard narrows the rejected branch to never, so the message is built before it.
+  const rejected = `Invalid --launch-profile "${launchProfileId}" (expected a lowercase slug such as codex-secondary-home)`
   if (!isAgentLaunchProfileId(launchProfileId)) {
-    throw new RuntimeClientError(
-      'invalid_argument',
-      `Invalid --launch-profile "${launchProfileId}" (expected a lowercase slug such as codex-secondary-home)`
-    )
+    throw new RuntimeClientError('invalid_argument', rejected)
   }
   return { startupAgent: agent, startupLaunchProfileId: launchProfileId }
 }

--- a/src/cli/handlers/worktree-startup-agent-flags.ts
+++ b/src/cli/handlers/worktree-startup-agent-flags.ts
@@ -1,0 +1,54 @@
+import { isAgentLaunchProfileId } from '../../shared/agent-launch-profile/agent-launch-profile'
+import { isTuiAgent } from '../../shared/tui-agent-config'
+import { RuntimeClientError } from '../runtime-client'
+
+function getPresentStringFlag(
+  flags: Map<string, string | boolean>,
+  name: string
+): string | undefined {
+  if (!flags.has(name)) {
+    return undefined
+  }
+  const value = flags.get(name)
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  throw new RuntimeClientError('invalid_argument', `Missing value for --${name}`)
+}
+
+export type WorktreeStartupAgentFlags = {
+  startupAgent?: string
+  startupLaunchProfileId?: string
+}
+
+/** `--agent` plus its dependents; `--prompt` and `--launch-profile` are meaningless without it. */
+export function getWorktreeStartupAgentFlags(
+  flags: Map<string, string | boolean>
+): WorktreeStartupAgentFlags {
+  const agent = getPresentStringFlag(flags, 'agent')
+  if (agent === undefined) {
+    if (flags.has('prompt')) {
+      throw new RuntimeClientError('invalid_argument', '--prompt requires --agent')
+    }
+    if (flags.has('launch-profile')) {
+      throw new RuntimeClientError('invalid_argument', '--launch-profile requires --agent')
+    }
+    return {}
+  }
+  if (!isTuiAgent(agent)) {
+    throw new RuntimeClientError('invalid_argument', `Unknown TUI agent "${agent}"`)
+  }
+  const launchProfileId = getPresentStringFlag(flags, 'launch-profile')
+  if (launchProfileId === undefined) {
+    return { startupAgent: agent }
+  }
+  // Why: only the shape is checked here; the host owns the profile catalog and reports
+  // agent_session_launch_profile_unknown / _agent_mismatch for ids it does not serve.
+  if (!isAgentLaunchProfileId(launchProfileId)) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Invalid --launch-profile "${launchProfileId}" (expected a lowercase slug such as codex-secondary-home)`
+    )
+  }
+  return { startupAgent: agent, startupLaunchProfileId: launchProfileId }
+}

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -24,7 +24,7 @@ import {
   getRequiredWorktreeSelector,
   resolveCurrentWorktreeSelector
 } from '../selectors'
-import { isTuiAgent } from '../../shared/tui-agent-config'
+import { getWorktreeStartupAgentFlags } from './worktree-startup-agent-flags'
 import { isWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
 import { printLineageSummary } from './worktree-lineage-summary'
 import {
@@ -103,20 +103,6 @@ function getPresentStringFlag(
     return value
   }
   throw new RuntimeClientError('invalid_argument', `Missing value for --${name}`)
-}
-
-function getOptionalStartupAgent(flags: Map<string, string | boolean>): string | undefined {
-  const agent = getPresentStringFlag(flags, 'agent')
-  if (agent === undefined) {
-    if (flags.has('prompt')) {
-      throw new RuntimeClientError('invalid_argument', '--prompt requires --agent')
-    }
-    return undefined
-  }
-  if (!isTuiAgent(agent)) {
-    throw new RuntimeClientError('invalid_argument', `Unknown TUI agent "${agent}"`)
-  }
-  return agent
 }
 
 function getOptionalSetupDecision(
@@ -216,7 +202,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
     const explicitParent = await resolveCreateParentSelector(flags, cwd, client)
     const explicitParentWorktree = explicitParent.parentWorktree
     const explicitParentWorkspace = explicitParent.parentWorkspace
-    const startupAgent = getOptionalStartupAgent(flags)
+    const { startupAgent, startupLaunchProfileId } = getWorktreeStartupAgentFlags(flags)
     const setupDecision = getOptionalSetupDecision(flags)
     const noParent = flags.get('no-parent') === true
     const envParentWorkspace =
@@ -268,6 +254,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       ...(startupAgent
         ? {
             startupAgent,
+            ...(startupLaunchProfileId ? { startupLaunchProfileId } : {}),
             startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
           }
         : {})

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -89,7 +89,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--launch-profile <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -98,6 +98,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'project-host-setup',
       'name',
       'agent',
+      'launch-profile',
       'prompt',
       'base-branch',
       'issue',
@@ -120,6 +121,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       '--no-parent only affects Orca lineage; omit --base-branch to use the repo default base, or pass the default base ref explicitly for independent top-level work.',
       'By default this creates the worktree and its first terminal without switching the active Orca view.',
       'Pass --agent to launch an agent in the first terminal; --prompt sends initial work to that agent.',
+      'Pass --launch-profile with --agent to run that agent under a launch profile: the built-in codex-secondary-home / claude-secondary-home (a second CODEX_HOME or CLAUDE_CONFIG_DIR, so two accounts run side by side) or a profile defined in Settings → Agents. The host validates the id.',
       'With --agent --json, read the new agent handle from result.agentTerminalHandle; older runtimes return only result.startupTerminal.handle, and may return neither for folder-based repos.',
       'Repo-defined setup hooks follow the repository setup policy; pass --setup run to force them.',
       'Pass --activate when the CLI caller intentionally wants to reveal the new worktree in the app.',
@@ -127,6 +129,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     ],
     examples: [
       'orca worktree create --name agent-task --agent codex --prompt "hi" --json',
+      'orca worktree create --name second-account --agent codex --launch-profile codex-secondary-home --json',
       'orca worktree create --repo id:<repoId> --name related-task --json',
       'orca worktree create --project github:stablyai/orca --host runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3 --name benchmark --json',
       'orca worktree create --repo id:<repoId> --name linear-task --linear-issue https://linear.app/stably/issue/STA-335/test-issue --json',

--- a/src/main/agent-launch-profile/launch-profile-home.test.ts
+++ b/src/main/agent-launch-profile/launch-profile-home.test.ts
@@ -1,0 +1,116 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  CLAUDE_SECONDARY_HOME_PROFILE_ID,
+  CODEX_SECONDARY_HOME_PROFILE_ID
+} from '../../shared/agent-launch-profile/agent-launch-profile'
+
+const wslMocks = vi.hoisted(() => ({
+  getDefaultWslDistro: vi.fn<() => string | null>(() => null),
+  getWslHome: vi.fn<(distro: string) => string | null>(() => null)
+}))
+
+vi.mock('../wsl', () => ({
+  getDefaultWslDistro: wslMocks.getDefaultWslDistro,
+  getWslHome: wslMocks.getWslHome
+}))
+
+import {
+  applyLaunchProfileHomeMarkers,
+  launchProfileHostHomeOrNull,
+  SECONDARY_HOME_PROFILES
+} from './launch-profile-home'
+
+describe('launch profile home markers', () => {
+  beforeEach(() => {
+    wslMocks.getDefaultWslDistro.mockReset().mockReturnValue(null)
+    wslMocks.getWslHome.mockReset().mockReturnValue(null)
+  })
+
+  it('covers exactly the built-in secondary-home profiles', () => {
+    expect(SECONDARY_HOME_PROFILES.map((profile) => profile.id)).toEqual([
+      CODEX_SECONDARY_HOME_PROFILE_ID,
+      CLAUDE_SECONDARY_HOME_PROFILE_ID
+    ])
+  })
+
+  it('leaves an env without markers untouched', () => {
+    const env = { CODEX_HOME: '/managed/home', ORCA_CODEX_HOME: '/managed/home' }
+    applyLaunchProfileHomeMarkers({ env, hostEnv: {} })
+    expect(env).toEqual({ CODEX_HOME: '/managed/home', ORCA_CODEX_HOME: '/managed/home' })
+  })
+
+  it('replaces a pre-set managed Codex home with the secondary home and mirrors it', () => {
+    const env = {
+      CODEX_HOME: '/managed/default-codex-home',
+      ORCA_CODEX_HOME: '/managed/default-codex-home',
+      ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID
+    }
+    applyLaunchProfileHomeMarkers({ env, hostEnv: {}, hostHome: '/home/dev' })
+    expect(env).toEqual({
+      CODEX_HOME: join('/home/dev', '.codex-2'),
+      ORCA_CODEX_HOME: join('/home/dev', '.codex-2')
+    })
+  })
+
+  it('resolves the Claude secondary home without a mirror', () => {
+    const env = { ORCA_CLAUDE_CONFIG_DIR_PROFILE: CLAUDE_SECONDARY_HOME_PROFILE_ID }
+    applyLaunchProfileHomeMarkers({ env, hostEnv: {} })
+    expect(env).toEqual({ CLAUDE_CONFIG_DIR: join(homedir(), '.claude-2') })
+  })
+
+  it('honors an absolute host override and rejects a relative one', () => {
+    const env: Record<string, string> = {
+      ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID
+    }
+    applyLaunchProfileHomeMarkers({
+      env,
+      hostEnv: { ORCA_CODEX_SECONDARY_HOME: join(homedir(), 'codex-work') }
+    })
+    expect(env.CODEX_HOME).toBe(join(homedir(), 'codex-work'))
+    expect(() =>
+      applyLaunchProfileHomeMarkers({
+        env: { ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID },
+        hostEnv: { ORCA_CODEX_SECONDARY_HOME: 'relative/dir' }
+      })
+    ).toThrow(/absolute path/)
+  })
+
+  it('ignores a marker whose value is not the profile id', () => {
+    const env = { ORCA_CODEX_HOME_PROFILE: 'someone-else' }
+    applyLaunchProfileHomeMarkers({ env, hostEnv: {} })
+    expect(env).toEqual({ ORCA_CODEX_HOME_PROFILE: 'someone-else' })
+  })
+
+  it('resolves inside the WSL distro home for a WSL launch', () => {
+    wslMocks.getWslHome.mockImplementation((distro) =>
+      distro === 'Ubuntu' ? '\\\\wsl.localhost\\Ubuntu\\home\\dev' : null
+    )
+    const env: Record<string, string> = {
+      ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID
+    }
+    applyLaunchProfileHomeMarkers({ env, isWslLaunch: true, wslDistro: 'Ubuntu' })
+    expect(env.CODEX_HOME).toBe(join('\\\\wsl.localhost\\Ubuntu\\home\\dev', '.codex-2'))
+    expect(env.ORCA_CODEX_HOME).toBe(env.CODEX_HOME)
+    expect(() =>
+      applyLaunchProfileHomeMarkers({
+        env: { ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID },
+        isWslLaunch: true,
+        wslDistro: 'Missing'
+      })
+    ).toThrow(/WSL home/)
+  })
+
+  it('offers a non-throwing lookup for scanners', () => {
+    expect(launchProfileHostHomeOrNull(CLAUDE_SECONDARY_HOME_PROFILE_ID, { hostHome: '/h' })).toBe(
+      join('/h', '.claude-2')
+    )
+    expect(
+      launchProfileHostHomeOrNull(CODEX_SECONDARY_HOME_PROFILE_ID, {
+        hostEnv: { ORCA_CODEX_SECONDARY_HOME: 'relative' }
+      })
+    ).toBeNull()
+    expect(launchProfileHostHomeOrNull('codex-work')).toBeNull()
+  })
+})

--- a/src/main/agent-launch-profile/launch-profile-home.test.ts
+++ b/src/main/agent-launch-profile/launch-profile-home.test.ts
@@ -8,16 +8,19 @@ import {
 
 const wslMocks = vi.hoisted(() => ({
   getDefaultWslDistro: vi.fn<() => string | null>(() => null),
-  getWslHome: vi.fn<(distro: string) => string | null>(() => null)
+  getWslHome: vi.fn<(distro: string) => string | null>(() => null),
+  parseWslPath: vi.fn<(path: string) => { distro: string; linuxPath: string } | null>(() => null)
 }))
 
 vi.mock('../wsl', () => ({
   getDefaultWslDistro: wslMocks.getDefaultWslDistro,
-  getWslHome: wslMocks.getWslHome
+  getWslHome: wslMocks.getWslHome,
+  parseWslPath: wslMocks.parseWslPath
 }))
 
 import {
   applyLaunchProfileHomeMarkers,
+  exportLaunchProfileHomesForWsl,
   launchProfileHostHomeOrNull,
   SECONDARY_HOME_PROFILES
 } from './launch-profile-home'
@@ -26,6 +29,29 @@ describe('launch profile home markers', () => {
   beforeEach(() => {
     wslMocks.getDefaultWslDistro.mockReset().mockReturnValue(null)
     wslMocks.getWslHome.mockReset().mockReturnValue(null)
+    wslMocks.parseWslPath.mockReset().mockReturnValue(null)
+  })
+
+  it('exports a resolved WSL home as a Linux path through WSLENV', () => {
+    wslMocks.parseWslPath.mockImplementation((value) =>
+      value.startsWith('\\\\wsl.localhost\\Ubuntu\\')
+        ? {
+            distro: 'Ubuntu',
+            linuxPath: `/${value.slice('\\\\wsl.localhost\\Ubuntu\\'.length).replaceAll('\\', '/')}`
+          }
+        : null
+    )
+    const env: Record<string, string> = {
+      CODEX_HOME: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.codex-2',
+      ORCA_CODEX_HOME: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\.codex-2',
+      CLAUDE_CONFIG_DIR: 'C:\\Users\\dev\\.claude-2'
+    }
+    exportLaunchProfileHomesForWsl(env)
+    expect(env.CODEX_HOME).toBe('/home/dev/.codex-2')
+    expect(env.ORCA_CODEX_HOME).toBe('/home/dev/.codex-2')
+    expect(env.CLAUDE_CONFIG_DIR).toBe('C:\\Users\\dev\\.claude-2')
+    expect(env.WSLENV).toContain('CODEX_HOME')
+    expect(env.WSLENV).toContain('ORCA_CODEX_HOME')
   })
 
   it('covers exactly the built-in secondary-home profiles', () => {

--- a/src/main/agent-launch-profile/launch-profile-home.ts
+++ b/src/main/agent-launch-profile/launch-profile-home.ts
@@ -1,0 +1,102 @@
+import { homedir } from 'node:os'
+import { isAbsolute, join } from 'node:path'
+import {
+  BUILT_IN_AGENT_LAUNCH_PROFILES,
+  agentLaunchProfileHomeMarkerEnv,
+  type AgentLaunchProfile,
+  type AgentLaunchProfileHome
+} from '../../shared/agent-launch-profile/agent-launch-profile'
+import { getDefaultWslDistro, getWslHome } from '../wsl'
+
+// Why: shell-ready wrappers restore CODEX_HOME from ORCA_CODEX_HOME after profile scripts, so a
+// relocated Codex home must set both. Claude Code reads CLAUDE_CONFIG_DIR directly.
+const MIRROR_ENV_VARS: Readonly<Record<string, readonly string[]>> = {
+  CODEX_HOME: ['ORCA_CODEX_HOME']
+}
+
+/** Only built-in profiles relocate a home; custom profiles carry args/env and no marker. */
+export const SECONDARY_HOME_PROFILES: readonly (AgentLaunchProfile & {
+  home: AgentLaunchProfileHome
+})[] = BUILT_IN_AGENT_LAUNCH_PROFILES.filter(
+  (profile): profile is AgentLaunchProfile & { home: AgentLaunchProfileHome } =>
+    profile.home !== undefined
+)
+
+export type LaunchProfileHomeHostContext = {
+  hostEnv?: NodeJS.ProcessEnv
+  hostHome?: string
+}
+
+/** Absolute home for a secondary-home profile on the machine that runs the PTY. */
+export function resolveLaunchProfileHostHome(
+  home: AgentLaunchProfileHome,
+  context: LaunchProfileHomeHostContext = {}
+): string {
+  const configured = (context.hostEnv ?? process.env)[home.overrideEnv]?.trim()
+  if (configured) {
+    if (!isAbsolute(configured)) {
+      throw new Error(`${home.overrideEnv} must be an absolute path on the execution host.`)
+    }
+    return configured
+  }
+  return join(context.hostHome ?? homedir(), home.dirName)
+}
+
+function resolveLaunchProfileWslHome(
+  profile: AgentLaunchProfile & { home: AgentLaunchProfileHome },
+  distro: string | null | undefined
+): string {
+  const target = distro?.trim() || getDefaultWslDistro()
+  const wslHome = target ? getWslHome(target) : null
+  if (!wslHome) {
+    throw new Error(`${profile.label} could not resolve the selected WSL home directory.`)
+  }
+  return join(wslHome, profile.home.dirName)
+}
+
+/**
+ * Turns every secondary-home marker a launch carries into a real home directory.
+ *
+ * The launch only ships a marker; only the execution host knows the real path. A WSL launch
+ * gets the distro home as a UNC path, which the caller's existing WSL translation rewrites to
+ * a Linux path and exports through WSLENV.
+ */
+export function applyLaunchProfileHomeMarkers(args: {
+  env: Record<string, string>
+  isWslLaunch?: boolean
+  wslDistro?: string | null
+  hostEnv?: NodeJS.ProcessEnv
+  hostHome?: string
+}): void {
+  for (const profile of SECONDARY_HOME_PROFILES) {
+    const markerEnv = agentLaunchProfileHomeMarkerEnv(profile.home.envVar)
+    if (args.env[markerEnv] !== profile.id) {
+      continue
+    }
+    // Why: main may already have injected the selected managed home; the explicit profile wins.
+    delete args.env[markerEnv]
+    const profileHome = args.isWslLaunch
+      ? resolveLaunchProfileWslHome(profile, args.wslDistro)
+      : resolveLaunchProfileHostHome(profile.home, args)
+    args.env[profile.home.envVar] = profileHome
+    for (const mirror of MIRROR_ENV_VARS[profile.home.envVar] ?? []) {
+      args.env[mirror] = profileHome
+    }
+  }
+}
+
+/** Same resolution for read-only scanners, which must not fail a scan over one bad override. */
+export function launchProfileHostHomeOrNull(
+  profileId: string,
+  context: LaunchProfileHomeHostContext = {}
+): string | null {
+  const profile = SECONDARY_HOME_PROFILES.find((candidate) => candidate.id === profileId)
+  if (!profile) {
+    return null
+  }
+  try {
+    return resolveLaunchProfileHostHome(profile.home, context)
+  } catch {
+    return null
+  }
+}

--- a/src/main/agent-launch-profile/launch-profile-home.ts
+++ b/src/main/agent-launch-profile/launch-profile-home.ts
@@ -6,7 +6,8 @@ import {
   type AgentLaunchProfile,
   type AgentLaunchProfileHome
 } from '../../shared/agent-launch-profile/agent-launch-profile'
-import { getDefaultWslDistro, getWslHome } from '../wsl'
+import { getDefaultWslDistro, getWslHome, parseWslPath } from '../wsl'
+import { addWslEnvKeys } from '../wsl-env'
 
 // Why: shell-ready wrappers restore CODEX_HOME from ORCA_CODEX_HOME after profile scripts, so a
 // relocated Codex home must set both. Claude Code reads CLAUDE_CONFIG_DIR directly.
@@ -82,6 +83,26 @@ export function applyLaunchProfileHomeMarkers(args: {
     for (const mirror of MIRROR_ENV_VARS[profile.home.envVar] ?? []) {
       args.env[mirror] = profileHome
     }
+  }
+}
+
+/**
+ * Rewrites a resolved WSL home (a `\\wsl.localhost\...` UNC path) to the Linux path the distro
+ * shell needs and exports it through WSLENV. The daemon lane does this inside its own WSL
+ * translation; the in-process lane resolves markers after that translation ran, so it calls this.
+ */
+export function exportLaunchProfileHomesForWsl(env: Record<string, string>): void {
+  for (const profile of SECONDARY_HOME_PROFILES) {
+    const value = env[profile.home.envVar]
+    const wslInfo = value ? parseWslPath(value) : null
+    if (!wslInfo) {
+      continue
+    }
+    env[profile.home.envVar] = wslInfo.linuxPath
+    for (const mirror of MIRROR_ENV_VARS[profile.home.envVar] ?? []) {
+      env[mirror] = wslInfo.linuxPath
+    }
+    addWslEnvKeys(env, [profile.home.envVar, ...(MIRROR_ENV_VARS[profile.home.envVar] ?? [])])
   }
 }
 

--- a/src/main/agent-launch-profile/launch-profile-home.ts
+++ b/src/main/agent-launch-profile/launch-profile-home.ts
@@ -15,13 +15,35 @@ const MIRROR_ENV_VARS: Readonly<Record<string, readonly string[]>> = {
   CODEX_HOME: ['ORCA_CODEX_HOME']
 }
 
+export type SecondaryHomeProfile = AgentLaunchProfile & { home: AgentLaunchProfileHome }
+
 /** Only built-in profiles relocate a home; custom profiles carry args/env and no marker. */
-export const SECONDARY_HOME_PROFILES: readonly (AgentLaunchProfile & {
-  home: AgentLaunchProfileHome
-})[] = BUILT_IN_AGENT_LAUNCH_PROFILES.filter(
-  (profile): profile is AgentLaunchProfile & { home: AgentLaunchProfileHome } =>
-    profile.home !== undefined
-)
+export const SECONDARY_HOME_PROFILES: readonly SecondaryHomeProfile[] =
+  BUILT_IN_AGENT_LAUNCH_PROFILES.filter(
+    (profile): profile is SecondaryHomeProfile => profile.home !== undefined
+  )
+
+/** The secondary-home profiles a launch env carries a marker for. */
+export function requestedSecondaryHomeProfiles(
+  env: Readonly<Record<string, string>>
+): SecondaryHomeProfile[] {
+  return SECONDARY_HOME_PROFILES.filter(
+    (profile) => env[agentLaunchProfileHomeMarkerEnv(profile.home.envVar)] === profile.id
+  )
+}
+
+/** Writes the resolved home, its mirrors, and drops the marker the launch carried. */
+export function assignLaunchProfileHome(
+  env: Record<string, string>,
+  profile: SecondaryHomeProfile,
+  home: string
+): void {
+  delete env[agentLaunchProfileHomeMarkerEnv(profile.home.envVar)]
+  env[profile.home.envVar] = home
+  for (const mirror of MIRROR_ENV_VARS[profile.home.envVar] ?? []) {
+    env[mirror] = home
+  }
+}
 
 export type LaunchProfileHomeHostContext = {
   hostEnv?: NodeJS.ProcessEnv
@@ -44,7 +66,7 @@ export function resolveLaunchProfileHostHome(
 }
 
 function resolveLaunchProfileWslHome(
-  profile: AgentLaunchProfile & { home: AgentLaunchProfileHome },
+  profile: SecondaryHomeProfile,
   distro: string | null | undefined
 ): string {
   const target = distro?.trim() || getDefaultWslDistro()
@@ -69,20 +91,15 @@ export function applyLaunchProfileHomeMarkers(args: {
   hostEnv?: NodeJS.ProcessEnv
   hostHome?: string
 }): void {
-  for (const profile of SECONDARY_HOME_PROFILES) {
-    const markerEnv = agentLaunchProfileHomeMarkerEnv(profile.home.envVar)
-    if (args.env[markerEnv] !== profile.id) {
-      continue
-    }
+  for (const profile of requestedSecondaryHomeProfiles(args.env)) {
     // Why: main may already have injected the selected managed home; the explicit profile wins.
-    delete args.env[markerEnv]
-    const profileHome = args.isWslLaunch
-      ? resolveLaunchProfileWslHome(profile, args.wslDistro)
-      : resolveLaunchProfileHostHome(profile.home, args)
-    args.env[profile.home.envVar] = profileHome
-    for (const mirror of MIRROR_ENV_VARS[profile.home.envVar] ?? []) {
-      args.env[mirror] = profileHome
-    }
+    assignLaunchProfileHome(
+      args.env,
+      profile,
+      args.isWslLaunch
+        ? resolveLaunchProfileWslHome(profile, args.wslDistro)
+        : resolveLaunchProfileHostHome(profile.home, args)
+    )
   }
 }
 

--- a/src/main/agent-launch-profile/launch-profile-remote-home.test.ts
+++ b/src/main/agent-launch-profile/launch-profile-remote-home.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CLAUDE_SECONDARY_HOME_PROFILE_ID,
+  CODEX_SECONDARY_HOME_PROFILE_ID
+} from '../../shared/agent-launch-profile/agent-launch-profile'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { applyLaunchProfileHomeMarkersForRemoteHost } from './launch-profile-remote-home'
+import { AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED } from './requested-launch-profile'
+
+describe('applyLaunchProfileHomeMarkersForRemoteHost', () => {
+  it('joins the probed remote home in the host path flavor and mirrors Codex', () => {
+    const env: Record<string, string> = {
+      ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID,
+      CODEX_HOME: '/ignored/managed'
+    }
+    applyLaunchProfileHomeMarkersForRemoteHost(env, {
+      remoteHome: '/home/dev',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+    expect(env).toEqual({ CODEX_HOME: '/home/dev/.codex-2', ORCA_CODEX_HOME: '/home/dev/.codex-2' })
+  })
+
+  it('uses the Windows flavor for a Windows remote and leaves Claude unmirrored', () => {
+    const env: Record<string, string> = {
+      ORCA_CLAUDE_CONFIG_DIR_PROFILE: CLAUDE_SECONDARY_HOME_PROFILE_ID
+    }
+    applyLaunchProfileHomeMarkersForRemoteHost(env, {
+      remoteHome: 'C:\\Users\\dev',
+      hostPlatform: getRemoteHostPlatform('win32-x64')
+    })
+    expect(Object.keys(env)).toEqual(['CLAUDE_CONFIG_DIR'])
+    expect(env.CLAUDE_CONFIG_DIR).toMatch(/Users\/dev\/\.claude-2$/)
+  })
+
+  it('fails the launch when the remote home was never probed', () => {
+    const env = { ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID }
+    expect(() => applyLaunchProfileHomeMarkersForRemoteHost(env, undefined)).toThrow(
+      AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED
+    )
+    expect(() =>
+      applyLaunchProfileHomeMarkersForRemoteHost({ ...env }, { remoteHome: '/home/dev' })
+    ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
+  })
+
+  it('leaves a launch without markers untouched even without a probe', () => {
+    const env = { CODEX_HOME: '/home/dev/.codex' }
+    applyLaunchProfileHomeMarkersForRemoteHost(env, undefined)
+    expect(env).toEqual({ CODEX_HOME: '/home/dev/.codex' })
+  })
+})

--- a/src/main/agent-launch-profile/launch-profile-remote-home.ts
+++ b/src/main/agent-launch-profile/launch-profile-remote-home.ts
@@ -1,0 +1,34 @@
+import { joinRemotePath, type RemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { assignLaunchProfileHome, requestedSecondaryHomeProfiles } from './launch-profile-home'
+import { AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED } from './requested-launch-profile'
+
+export type LaunchProfileRemoteHost = {
+  remoteHome?: string
+  hostPlatform?: RemoteHostPlatform
+}
+
+/**
+ * Resolves secondary-home markers for a PTY that spawns on an SSH host.
+ *
+ * The SSH env travels to the relay as a literal JSON map, so nothing there expands `$HOME`.
+ * The session probed the remote home and platform when it connected; that probe is the
+ * execution host's own answer, so the path is joined here in the host's flavor. The remote's
+ * `ORCA_*_SECONDARY_HOME` override is not consulted: this runtime cannot read a remote env.
+ */
+export function applyLaunchProfileHomeMarkersForRemoteHost(
+  env: Record<string, string>,
+  host: LaunchProfileRemoteHost | undefined
+): void {
+  for (const profile of requestedSecondaryHomeProfiles(env)) {
+    // Why: without the probe the only alternative is the remote default home, which is exactly
+    // the home the user asked not to use; fail the launch instead.
+    if (!host?.remoteHome || !host.hostPlatform) {
+      throw new Error(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
+    }
+    assignLaunchProfileHome(
+      env,
+      profile,
+      joinRemotePath(host.hostPlatform, host.remoteHome, profile.home.dirName)
+    )
+  }
+}

--- a/src/main/agent-launch-profile/pane-launch-profile-registry.test.ts
+++ b/src/main/agent-launch-profile/pane-launch-profile-registry.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  _internals,
+  forgetPaneLaunchProfile,
+  getPaneLaunchProfile,
+  recordPaneLaunchProfileForSpawn
+} from './pane-launch-profile-registry'
+
+let userDataPath: string
+let previousUserDataPath: string | undefined
+
+beforeEach(() => {
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  userDataPath = mkdtempSync(join(tmpdir(), 'orca-pane-launch-profile-'))
+  process.env.ORCA_USER_DATA_PATH = userDataPath
+  _internals.resetCache()
+})
+
+afterEach(() => {
+  rmSync(userDataPath, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  _internals.resetCache()
+})
+
+describe('pane launch profile registry', () => {
+  it('records the profile from the spawn env and survives a re-read', () => {
+    recordPaneLaunchProfileForSpawn({
+      ptyId: 'pty-1',
+      isReattach: false,
+      launchEnv: { ORCA_AGENT_LAUNCH_PROFILE: 'codex-secondary-home' }
+    })
+    _internals.resetCache()
+    expect(getPaneLaunchProfile('pty-1')).toBe('codex-secondary-home')
+    expect(
+      JSON.parse(readFileSync(join(userDataPath, 'agent-launch-profile-panes.json'), 'utf-8'))
+    ).toEqual({ version: 1, panes: { 'pty-1': 'codex-secondary-home' } })
+  })
+
+  it('keeps a reattached pane on its recorded profile', () => {
+    recordPaneLaunchProfileForSpawn({
+      ptyId: 'pty-1',
+      isReattach: false,
+      launchEnv: { ORCA_AGENT_LAUNCH_PROFILE: 'claude-secondary-home' }
+    })
+    recordPaneLaunchProfileForSpawn({ ptyId: 'pty-1', isReattach: true, launchEnv: {} })
+    expect(getPaneLaunchProfile('pty-1')).toBe('claude-secondary-home')
+  })
+
+  it('clears a pane that respawns without a profile and forgets exited panes', () => {
+    recordPaneLaunchProfileForSpawn({
+      ptyId: 'pty-1',
+      isReattach: false,
+      launchEnv: { ORCA_AGENT_LAUNCH_PROFILE: 'codex-secondary-home' }
+    })
+    recordPaneLaunchProfileForSpawn({ ptyId: 'pty-1', isReattach: false, launchEnv: {} })
+    expect(getPaneLaunchProfile('pty-1')).toBeUndefined()
+    recordPaneLaunchProfileForSpawn({
+      ptyId: 'pty-2',
+      isReattach: false,
+      launchEnv: { ORCA_AGENT_LAUNCH_PROFILE: 'codex-secondary-home' }
+    })
+    forgetPaneLaunchProfile('pty-2')
+    expect(getPaneLaunchProfile('pty-2')).toBeUndefined()
+    expect(getPaneLaunchProfile(undefined)).toBeUndefined()
+  })
+
+  it('ignores a malformed id in the file', () => {
+    recordPaneLaunchProfileForSpawn({
+      ptyId: 'pty-1',
+      isReattach: false,
+      launchEnv: { ORCA_AGENT_LAUNCH_PROFILE: 'Not A Slug' }
+    })
+    expect(getPaneLaunchProfile('pty-1')).toBeUndefined()
+  })
+})

--- a/src/main/agent-launch-profile/pane-launch-profile-registry.ts
+++ b/src/main/agent-launch-profile/pane-launch-profile-registry.ts
@@ -1,0 +1,107 @@
+import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import {
+  agentLaunchProfileIdFromEnv,
+  isAgentLaunchProfileId
+} from '../../shared/agent-launch-profile/agent-launch-profile'
+import { getOrcaUserDataPath } from '../codex/codex-home-paths'
+
+// Why: the profile is baked into a PTY's environment at spawn and the daemon keeps that shell
+// alive across app restarts, so only an on-disk record can tell a reattached pane's profile.
+// Keyed by pty id like the Codex pane account registry, which this mirrors for every agent.
+
+type PaneLaunchProfileRegistryFile = {
+  version: 1
+  panes: Record<string, string>
+}
+
+const MAX_TRACKED_PANES = 2000
+
+let cached: PaneLaunchProfileRegistryFile | null = null
+
+function registryPath(): string {
+  return join(getOrcaUserDataPath(), 'agent-launch-profile-panes.json')
+}
+
+function readRegistry(): PaneLaunchProfileRegistryFile {
+  if (cached) {
+    return cached
+  }
+  const empty: PaneLaunchProfileRegistryFile = { version: 1, panes: {} }
+  try {
+    const parsed = JSON.parse(readFileSync(registryPath(), 'utf-8')) as unknown
+    const panes = (parsed as Partial<PaneLaunchProfileRegistryFile> | null)?.panes
+    if (panes && typeof panes === 'object' && !Array.isArray(panes)) {
+      for (const [ptyId, profileId] of Object.entries(panes)) {
+        if (ptyId && isAgentLaunchProfileId(profileId)) {
+          empty.panes[ptyId] = profileId
+        }
+      }
+    }
+  } catch {
+    // Why: a missing or unreadable file only loses an attribution hint; never fail a spawn over it.
+  }
+  cached = empty
+  return empty
+}
+
+function writeRegistry(registry: PaneLaunchProfileRegistryFile): void {
+  const target = registryPath()
+  const temporary = `${target}.${process.pid}.tmp`
+  try {
+    mkdirSync(dirname(target), { recursive: true })
+    writeFileSync(temporary, `${JSON.stringify(registry)}\n`, { encoding: 'utf-8', mode: 0o600 })
+    renameSync(temporary, target)
+  } catch (error) {
+    console.warn('[agent-launch-profile] Failed to persist pane profile registry:', error)
+    try {
+      rmSync(temporary, { force: true })
+    } catch {}
+  }
+}
+
+/** Records the profile a fresh spawn launched under; a reattach keeps the earlier record. */
+export function recordPaneLaunchProfileForSpawn(args: {
+  ptyId: string | undefined
+  isReattach: boolean
+  launchEnv: Record<string, string> | NodeJS.ProcessEnv | undefined
+}): void {
+  if (!args.ptyId || args.isReattach) {
+    return
+  }
+  const profileId = agentLaunchProfileIdFromEnv(args.launchEnv)
+  const registry = readRegistry()
+  if (registry.panes[args.ptyId] === profileId || (!profileId && !registry.panes[args.ptyId])) {
+    return
+  }
+  if (profileId) {
+    registry.panes[args.ptyId] = profileId
+    // Why: a crash mid-session would otherwise leak one entry per terminal forever.
+    const overflow = Object.keys(registry.panes).length - MAX_TRACKED_PANES
+    for (const staleId of Object.keys(registry.panes).slice(0, Math.max(0, overflow))) {
+      delete registry.panes[staleId]
+    }
+  } else {
+    delete registry.panes[args.ptyId]
+  }
+  writeRegistry(registry)
+}
+
+export function forgetPaneLaunchProfile(ptyId: string): void {
+  const registry = readRegistry()
+  if (!(ptyId in registry.panes)) {
+    return
+  }
+  delete registry.panes[ptyId]
+  writeRegistry(registry)
+}
+
+export function getPaneLaunchProfile(ptyId: string | null | undefined): string | undefined {
+  return ptyId ? readRegistry().panes[ptyId] : undefined
+}
+
+export const _internals = {
+  resetCache(): void {
+    cached = null
+  }
+}

--- a/src/main/agent-launch-profile/requested-launch-profile.test.ts
+++ b/src/main/agent-launch-profile/requested-launch-profile.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH,
-  AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED,
   AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN,
   resolveRequestedAgentLaunchProfile
 } from './requested-launch-profile'
@@ -16,8 +15,7 @@ describe('resolveRequestedAgentLaunchProfile', () => {
       resolveRequestedAgentLaunchProfile({
         agent: 'codex',
         launchProfileId: undefined,
-        settings,
-        isRemote: false
+        settings
       })
     ).toBeNull()
   })
@@ -27,16 +25,14 @@ describe('resolveRequestedAgentLaunchProfile', () => {
       resolveRequestedAgentLaunchProfile({
         agent: 'codex',
         launchProfileId: 'codex-secondary-home',
-        settings,
-        isRemote: false
+        settings
       })?.home?.envVar
     ).toBe('CODEX_HOME')
     expect(
       resolveRequestedAgentLaunchProfile({
         agent: 'codex',
         launchProfileId: 'codex-work',
-        settings,
-        isRemote: false
+        settings
       })?.args
     ).toBe('-c a=b')
   })
@@ -46,36 +42,25 @@ describe('resolveRequestedAgentLaunchProfile', () => {
       resolveRequestedAgentLaunchProfile({
         agent: 'codex',
         launchProfileId: 'missing',
-        settings,
-        isRemote: false
+        settings
       })
     ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN)
     expect(() =>
       resolveRequestedAgentLaunchProfile({
         agent: 'claude',
         launchProfileId: 'codex-work',
-        settings,
-        isRemote: false
+        settings
       })
     ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH)
   })
 
-  it('refuses a secondary home on a remote execution host but allows args-only profiles', () => {
-    expect(() =>
+  it('does not refuse a secondary home up front; the SSH lane resolves it at spawn', () => {
+    expect(
       resolveRequestedAgentLaunchProfile({
         agent: 'claude',
         launchProfileId: 'claude-secondary-home',
-        settings,
-        isRemote: true
-      })
-    ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
-    expect(
-      resolveRequestedAgentLaunchProfile({
-        agent: 'codex',
-        launchProfileId: 'codex-work',
-        settings,
-        isRemote: true
+        settings
       })?.id
-    ).toBe('codex-work')
+    ).toBe('claude-secondary-home')
   })
 })

--- a/src/main/agent-launch-profile/requested-launch-profile.test.ts
+++ b/src/main/agent-launch-profile/requested-launch-profile.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH,
+  AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED,
+  AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN,
+  resolveRequestedAgentLaunchProfile
+} from './requested-launch-profile'
+
+const settings = {
+  agentLaunchProfiles: [{ id: 'codex-work', agent: 'codex' as const, args: '-c a=b' }]
+}
+
+describe('resolveRequestedAgentLaunchProfile', () => {
+  it('returns null for a plain launch', () => {
+    expect(
+      resolveRequestedAgentLaunchProfile({
+        agent: 'codex',
+        launchProfileId: undefined,
+        settings,
+        isRemote: false
+      })
+    ).toBeNull()
+  })
+
+  it('resolves built-in and custom profiles for the matching agent', () => {
+    expect(
+      resolveRequestedAgentLaunchProfile({
+        agent: 'codex',
+        launchProfileId: 'codex-secondary-home',
+        settings,
+        isRemote: false
+      })?.home?.envVar
+    ).toBe('CODEX_HOME')
+    expect(
+      resolveRequestedAgentLaunchProfile({
+        agent: 'codex',
+        launchProfileId: 'codex-work',
+        settings,
+        isRemote: false
+      })?.args
+    ).toBe('-c a=b')
+  })
+
+  it('names the failure so clients can tell unknown from mismatch', () => {
+    expect(() =>
+      resolveRequestedAgentLaunchProfile({
+        agent: 'codex',
+        launchProfileId: 'missing',
+        settings,
+        isRemote: false
+      })
+    ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN)
+    expect(() =>
+      resolveRequestedAgentLaunchProfile({
+        agent: 'claude',
+        launchProfileId: 'codex-work',
+        settings,
+        isRemote: false
+      })
+    ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH)
+  })
+
+  it('refuses a secondary home on a remote execution host but allows args-only profiles', () => {
+    expect(() =>
+      resolveRequestedAgentLaunchProfile({
+        agent: 'claude',
+        launchProfileId: 'claude-secondary-home',
+        settings,
+        isRemote: true
+      })
+    ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
+    expect(
+      resolveRequestedAgentLaunchProfile({
+        agent: 'codex',
+        launchProfileId: 'codex-work',
+        settings,
+        isRemote: true
+      })?.id
+    ).toBe('codex-work')
+  })
+})

--- a/src/main/agent-launch-profile/requested-launch-profile.ts
+++ b/src/main/agent-launch-profile/requested-launch-profile.ts
@@ -9,18 +9,18 @@ import type { TuiAgent } from '../../shared/tui-agent'
 export const AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN = 'agent_session_launch_profile_unknown'
 export const AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH =
   'agent_session_launch_profile_agent_mismatch'
+/** Raised at SSH spawn when the session never learned the remote home a secondary home needs. */
 export const AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED =
   'agent_session_launch_profile_remote_unsupported'
 
 /**
  * Resolves a client-supplied profile id against this host's catalog. Named errors let a
- * client built for a newer catalog tell "unknown here" from "wrong agent" from "not on SSH".
+ * client built for a newer catalog tell "unknown here" from "wrong agent".
  */
 export function resolveRequestedAgentLaunchProfile(args: {
   agent: TuiAgent
   launchProfileId: string | null | undefined
   settings: Pick<GlobalSettings, 'agentLaunchProfiles'>
-  isRemote: boolean
 }): AgentLaunchProfile | null {
   if (!args.launchProfileId) {
     return null
@@ -33,11 +33,6 @@ export function resolveRequestedAgentLaunchProfile(args: {
         ? AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH
         : AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN
     )
-  }
-  // Why: a secondary home is resolved on the execution host, which for SSH is a machine this
-  // runtime cannot inspect; refuse rather than launch on the wrong home.
-  if (profile.home && args.isRemote) {
-    throw new Error(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
   }
   return profile
 }

--- a/src/main/agent-launch-profile/requested-launch-profile.ts
+++ b/src/main/agent-launch-profile/requested-launch-profile.ts
@@ -1,0 +1,43 @@
+import {
+  findAgentLaunchProfile,
+  resolveAgentLaunchProfiles,
+  type AgentLaunchProfile
+} from '../../shared/agent-launch-profile/agent-launch-profile'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+import type { TuiAgent } from '../../shared/tui-agent'
+
+export const AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN = 'agent_session_launch_profile_unknown'
+export const AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH =
+  'agent_session_launch_profile_agent_mismatch'
+export const AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED =
+  'agent_session_launch_profile_remote_unsupported'
+
+/**
+ * Resolves a client-supplied profile id against this host's catalog. Named errors let a
+ * client built for a newer catalog tell "unknown here" from "wrong agent" from "not on SSH".
+ */
+export function resolveRequestedAgentLaunchProfile(args: {
+  agent: TuiAgent
+  launchProfileId: string | null | undefined
+  settings: Pick<GlobalSettings, 'agentLaunchProfiles'>
+  isRemote: boolean
+}): AgentLaunchProfile | null {
+  if (!args.launchProfileId) {
+    return null
+  }
+  const profiles = resolveAgentLaunchProfiles(args.settings.agentLaunchProfiles)
+  const profile = findAgentLaunchProfile(profiles, args.agent, args.launchProfileId)
+  if (!profile) {
+    throw new Error(
+      profiles.some((candidate) => candidate.id === args.launchProfileId)
+        ? AGENT_SESSION_LAUNCH_PROFILE_AGENT_MISMATCH
+        : AGENT_SESSION_LAUNCH_PROFILE_UNKNOWN
+    )
+  }
+  // Why: a secondary home is resolved on the execution host, which for SSH is a machine this
+  // runtime cannot inspect; refuse rather than launch on the wrong home.
+  if (profile.home && args.isRemote) {
+    throw new Error(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
+  }
+  return profile
+}

--- a/src/main/codex/codex-pane-account-record-validation.ts
+++ b/src/main/codex/codex-pane-account-record-validation.ts
@@ -1,0 +1,56 @@
+import type {
+  CodexEnvironmentHomeOverride,
+  CodexShellStartupHomeOverride
+} from './codex-real-home-path'
+import type {
+  CodexPaneAccountRecord,
+  CodexPaneHomeRoute
+} from './codex-pane-account-registry-types'
+
+// Shape checks for records read back from `codex-pane-accounts.json`; the file is user-writable
+// state, so every field is validated rather than trusted.
+
+export function isEnvironmentHomeOverride(value: unknown): value is CodexEnvironmentHomeOverride {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const context = value as Partial<CodexEnvironmentHomeOverride>
+  return typeof context.codexHome === 'string' && context.codexHome.length > 0
+}
+
+export function isShellStartupHomeOverride(value: unknown): value is CodexShellStartupHomeOverride {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const context = value as Partial<CodexShellStartupHomeOverride>
+  return (
+    typeof context.home === 'string' &&
+    context.home.length > 0 &&
+    (context.shell === undefined || typeof context.shell === 'string') &&
+    (context.configHome === undefined || typeof context.configHome === 'string') &&
+    typeof context.codexHome === 'string' &&
+    context.codexHome.length > 0
+  )
+}
+
+export function isPaneAccountRecord(value: unknown): value is CodexPaneAccountRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+  const record = value as Partial<CodexPaneAccountRecord>
+  return (
+    (record.selectionKey === 'host' ||
+      (typeof record.selectionKey === 'string' && /^wsl:.+/.test(record.selectionKey))) &&
+    (record.accountId === null || typeof record.accountId === 'string')
+  )
+}
+
+export function isPaneHomeRoute(value: unknown): value is CodexPaneHomeRoute {
+  return (
+    value === 'real-home' ||
+    value === 'shared-home' ||
+    value === 'account-home' ||
+    value === 'custom-home' ||
+    value === 'wsl-home'
+  )
+}

--- a/src/main/codex/codex-pane-account-registry-launch-profile.test.ts
+++ b/src/main/codex/codex-pane-account-registry-launch-profile.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  _internals,
+  getCodexPaneAccount,
+  recordCodexPaneAccount
+} from './codex-pane-account-registry'
+
+let userDataPath: string
+let previousUserDataPath: string | undefined
+
+beforeEach(() => {
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  userDataPath = mkdtempSync(join(tmpdir(), 'orca-codex-pane-launch-profile-'))
+  process.env.ORCA_USER_DATA_PATH = userDataPath
+  _internals.resetCache()
+})
+
+afterEach(() => {
+  rmSync(userDataPath, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  _internals.resetCache()
+})
+
+describe('codex pane account registry launch profile', () => {
+  it('keeps launchProfileId across a re-read of the persisted file', () => {
+    recordCodexPaneAccount('pty-1', {
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'custom-home',
+      launchProfileId: 'codex-secondary-home'
+    })
+    // Why: a restart reads the file back through parseRegistry, which whitelists fields.
+    _internals.resetCache()
+    expect(getCodexPaneAccount('pty-1')).toEqual({
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'custom-home',
+      launchProfileId: 'codex-secondary-home'
+    })
+  })
+
+  it('drops a malformed launchProfileId instead of trusting the file', () => {
+    recordCodexPaneAccount('pty-2', {
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'custom-home',
+      launchProfileId: 'Not A Slug'
+    })
+    _internals.resetCache()
+    expect(getCodexPaneAccount('pty-2')).toEqual({
+      selectionKey: 'host',
+      accountId: null,
+      homeRoute: 'custom-home'
+    })
+  })
+})

--- a/src/main/codex/codex-pane-account-registry-types.ts
+++ b/src/main/codex/codex-pane-account-registry-types.ts
@@ -21,6 +21,8 @@ export type CodexPaneAccountRecord = {
   shellStartupHomeOverride?: CodexShellStartupHomeOverride
   /** Rechecked after restart when CODEX_HOME came from the process environment. */
   environmentHomeOverride?: CodexEnvironmentHomeOverride
+  /** Set when the pane launched under an agent launch profile that relocated CODEX_HOME. */
+  launchProfileId?: string
 }
 
 export type CodexPaneAccountRegistryFile = {

--- a/src/main/codex/codex-pane-account-registry.ts
+++ b/src/main/codex/codex-pane-account-registry.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { isAgentLaunchProfileId } from '../../shared/agent-launch-profile/agent-launch-profile'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
 import { dirname, join } from 'node:path'
 import { getOrcaUserDataPath } from './codex-home-paths'
@@ -8,10 +9,12 @@ import type {
   CodexPaneAccountRegistryFile,
   CodexPaneHomeRoute
 } from './codex-pane-account-registry-types'
-import type {
-  CodexEnvironmentHomeOverride,
-  CodexShellStartupHomeOverride
-} from './codex-real-home-path'
+import {
+  isEnvironmentHomeOverride,
+  isPaneAccountRecord,
+  isPaneHomeRoute,
+  isShellStartupHomeOverride
+} from './codex-pane-account-record-validation'
 
 export type {
   CodexPaneAccountRecord,
@@ -138,56 +141,14 @@ function parseRegistry(parsed: unknown): CodexPaneAccountRegistryFile {
           : {}),
         ...(isEnvironmentHomeOverride(record.environmentHomeOverride)
           ? { environmentHomeOverride: record.environmentHomeOverride }
+          : {}),
+        ...(isAgentLaunchProfileId(record.launchProfileId)
+          ? { launchProfileId: record.launchProfileId }
           : {})
       }
     }
   }
   return empty
-}
-
-function isEnvironmentHomeOverride(value: unknown): value is CodexEnvironmentHomeOverride {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false
-  }
-  const context = value as Partial<CodexEnvironmentHomeOverride>
-  return typeof context.codexHome === 'string' && context.codexHome.length > 0
-}
-
-function isShellStartupHomeOverride(value: unknown): value is CodexShellStartupHomeOverride {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false
-  }
-  const context = value as Partial<CodexShellStartupHomeOverride>
-  return (
-    typeof context.home === 'string' &&
-    context.home.length > 0 &&
-    (context.shell === undefined || typeof context.shell === 'string') &&
-    (context.configHome === undefined || typeof context.configHome === 'string') &&
-    typeof context.codexHome === 'string' &&
-    context.codexHome.length > 0
-  )
-}
-
-function isPaneAccountRecord(value: unknown): value is CodexPaneAccountRecord {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    return false
-  }
-  const record = value as Partial<CodexPaneAccountRecord>
-  return (
-    (record.selectionKey === 'host' ||
-      (typeof record.selectionKey === 'string' && /^wsl:.+/.test(record.selectionKey))) &&
-    (record.accountId === null || typeof record.accountId === 'string')
-  )
-}
-
-function isPaneHomeRoute(value: unknown): value is CodexPaneHomeRoute {
-  return (
-    value === 'real-home' ||
-    value === 'shared-home' ||
-    value === 'account-home' ||
-    value === 'custom-home' ||
-    value === 'wsl-home'
-  )
 }
 
 function writeRegistry(registry: CodexPaneAccountRegistryFile): boolean {

--- a/src/main/daemon/pty-subprocess/shell-launch-plan.ts
+++ b/src/main/daemon/pty-subprocess/shell-launch-plan.ts
@@ -37,6 +37,7 @@ import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../../shared/hermes-startup-qu
 import { WINDOWS_GIT_BASH_SHELL } from '../../../shared/windows-terminal-shell'
 import { getShellLaunchConfig, resolvePtyShellPath } from '../shell-ready'
 import { resolveWslSessionContext } from '../wsl-session-context'
+import { applyLaunchProfileHomeMarkers } from '../../agent-launch-profile/launch-profile-home'
 import { finalizeDaemonPtyEnvironment, rescrubDaemonPtyEnvironment } from './spawn-environment'
 import type { PtySubprocessOptions } from '../pty-subprocess'
 
@@ -55,6 +56,12 @@ export function createPtyShellLaunchPlan(
   env: Record<string, string>
 ): PtyShellLaunchPlan {
   const resolvedWslContext = resolveWslSessionContext(opts)
+  // Why: a launch profile only ships a home marker; only the execution host knows the real path.
+  applyLaunchProfileHomeMarkers({
+    env,
+    isWslLaunch: Boolean(resolvedWslContext),
+    wslDistro: resolvedWslContext?.distro
+  })
   let shellPath = resolvedWslContext ? 'wsl.exe' : opts.shellOverride || resolvePtyShellPath(env)
   let shellArgs: string[]
   let startupCommandDeliveredInShellArgs = false

--- a/src/main/ipc/pty/host-env/assembly.ts
+++ b/src/main/ipc/pty/host-env/assembly.ts
@@ -1,4 +1,5 @@
 import { join, delimiter } from 'node:path'
+import { hasAgentLaunchProfileHomeMarker } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { resolveSetupAgentSequenceLaunchCommand } from '../../../../shared/setup-agent-sequencing'
 import {
   detectExplicitPiAgentKindFromCommand,
@@ -221,6 +222,11 @@ export function buildPtyHostEnv(
     stripInheritedOrcaCodexHomeOverride(baseEnv)
     delete baseEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
   } else {
+    delete baseEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
+  }
+  if (hasAgentLaunchProfileHomeMarker(baseEnv, 'CODEX_HOME')) {
+    // Why: the preflight repairs hooks inside the managed home; a secondary home is user-owned
+    // and the daemon relocates CODEX_HOME after this env is built.
     delete baseEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
   }
 

--- a/src/main/ipc/pty/host-env/codex-home.ts
+++ b/src/main/ipc/pty/host-env/codex-home.ts
@@ -1,3 +1,8 @@
+import {
+  agentLaunchProfileIdFromEnv,
+  hasAgentLaunchProfileHomeMarker
+} from '../../../../shared/agent-launch-profile/agent-launch-profile'
+import { getCodexSelectionLaneKey } from '../../../../shared/codex-selection-lane'
 import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import { isTuiAgentEnabled } from '../../../../shared/tui-agent-selection'
@@ -230,6 +235,20 @@ export function recordCodexPaneAccountForSpawn(args: {
   settings: GlobalSettings | undefined
 }): void {
   if (!args.ptyId || !args.isDaemonHostSpawn || args.isReattach) {
+    return
+  }
+  // Why: a secondary-home launch runs on a user-owned directory the managed selection never
+  // touched, so attributing it to the selected account would mislabel every stale-pane prompt.
+  const launchProfileId = hasAgentLaunchProfileHomeMarker(args.launchEnv, 'CODEX_HOME')
+    ? agentLaunchProfileIdFromEnv(args.launchEnv)
+    : null
+  if (launchProfileId) {
+    recordCodexPaneAccount(args.ptyId, {
+      selectionKey: getCodexSelectionLaneKey(args.target),
+      accountId: null,
+      homeRoute: 'custom-home',
+      launchProfileId
+    })
     return
   }
   const customHomeOverride = getCustomCodexHomeOverrideForLaunch(args.launchEnv)

--- a/src/main/ipc/pty/ipc/spawn-commit-persist.ts
+++ b/src/main/ipc/pty/ipc/spawn-commit-persist.ts
@@ -3,6 +3,7 @@ import { markNativeWindowsConptyPty } from '../../../runtime/terminal-model-quer
 import { closeStartupQueryAuthorityForPty, getRelayPtyId } from '../provider/registry'
 import { createTerminalSessionStateSaveFailureMessage } from '../../../../shared/terminal-session-state-save-failure'
 import { recordCodexPaneAccountForSpawn } from '../host-env/codex-home'
+import { recordPaneLaunchProfileForSpawn } from '../../../agent-launch-profile/pane-launch-profile-registry'
 import { persistAdmittedStablePaneBinding } from '../pane/stable-owner'
 import {
   pendingByPaneKey,
@@ -50,6 +51,11 @@ export async function persistPtyIpcSpawnCommit(ctx: PtyIpcSpawnState): Promise<{
     launchEnv: ctx.baseEnv,
     target: ctx.codexSelectionTarget,
     settings: ctx.deps.getSettings?.()
+  })
+  recordPaneLaunchProfileForSpawn({
+    ptyId: ctx.result.id,
+    isReattach: ctx.result.isReattach === true,
+    launchEnv: ctx.baseEnv
   })
   ptyOwnership.set(ctx.result.id, args.connectionId ?? null)
   if (ctx.result.incarnationId) {

--- a/src/main/ipc/pty/ipc/spawn-env-codex.ts
+++ b/src/main/ipc/pty/ipc/spawn-env-codex.ts
@@ -1,3 +1,4 @@
+import { hasAgentLaunchProfileHomeMarker } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { getAppEnvironment } from '../../../../shared/app-environment'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { isAgentStatusHooksEnabled } from '../../../agent-hooks/managed-agent-hook-controls'
@@ -60,8 +61,11 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
       workspacePath: ctx.cwd,
       launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
     })) ?? null
+  // Why: a secondary-home profile relocates CODEX_HOME on the execution host, so the managed
+  // selection (and its auth wait) must not be resolved for a launch that never reads it.
+  const codexHomeProfileLaunch = hasAgentLaunchProfileHomeMarker(ctx.baseEnv, 'CODEX_HOME')
   ctx.selectedCodexHomePath =
-    !ctx.preAdoptedStablePane && !args.connectionId
+    !ctx.preAdoptedStablePane && !args.connectionId && !codexHomeProfileLaunch
       ? getCompatibleSelectedCodexHomePath(
           ctx.codexSelectionTarget,
           codexResumeHome
@@ -74,7 +78,12 @@ export async function assemblePtyIpcSpawnCodexEnv(ctx: PtyIpcSpawnState): Promis
             : await selectLaunchCodexHome()
         )
       : null
-  if (!ctx.preAdoptedStablePane && args.launchAgent === 'codex' && args.sessionId === undefined) {
+  if (
+    !ctx.preAdoptedStablePane &&
+    args.launchAgent === 'codex' &&
+    args.sessionId === undefined &&
+    !codexHomeProfileLaunch
+  ) {
     const resolution = resolveCodexHomeAfterManagedAuthReadiness({
       selectedCodexHomePath: ctx.selectedCodexHomePath,
       getSettings: () => ctx.deps.getSettings?.(),

--- a/src/main/ipc/pty/ipc/spawn-preflight.ts
+++ b/src/main/ipc/pty/ipc/spawn-preflight.ts
@@ -3,6 +3,7 @@ import {
   resolveLocalWindowsTerminalRuntimeOptions
 } from '../../../../shared/local-windows-terminal-runtime'
 import { isWslUncPath, toWindowsWslPath } from '../../../../shared/wsl-paths'
+import { hasAgentLaunchProfileHomeMarker } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { isClaudeAuthSwitchInProgress } from '../../../claude-accounts/live-pty-gate'
 import { mintPtySessionId } from '../../../daemon/pty-session-id'
 import { resolveWslSessionContext } from '../../../daemon/wsl-session-context'
@@ -221,8 +222,12 @@ export async function preparePtyIpcSpawnPreflight(ctx: PtyIpcSpawnState): Promis
     ctx.cwd,
     ctx.expectedWslDistro
   )
+  // Why: a secondary-home profile carries its own Claude credentials; materializing the managed
+  // account into ~/.claude (and stripping auth env) would target a directory this launch never reads.
   ctx.claudeAuth =
-    ctx.isClaudeLaunch && ctx.deps.prepareClaudeAuth
+    ctx.isClaudeLaunch &&
+    ctx.deps.prepareClaudeAuth &&
+    !hasAgentLaunchProfileHomeMarker(args.env, 'CLAUDE_CONFIG_DIR')
       ? await ctx.deps.prepareClaudeAuth(initialSelectionTarget)
       : null
   ctx.spawnTiming.mark('auth')

--- a/src/main/ipc/pty/provider/state-cleanup.ts
+++ b/src/main/ipc/pty/provider/state-cleanup.ts
@@ -2,6 +2,7 @@ import { advertisedUrlWatcher } from '../../../ports/advertised-url-watcher'
 import { unregisterPty } from '../../../memory/pty-registry'
 import { markClaudePtyExited } from '../../../claude-accounts/live-pty-gate'
 import { forgetCodexPaneAccount } from '../../../codex/codex-pane-account-registry'
+import { forgetPaneLaunchProfile } from '../../../agent-launch-profile/pane-launch-profile-registry'
 import { openCodeHookService } from '../../../opencode/hook-service'
 import { piTitlebarExtensionService } from '../../../pi/titlebar-extension-service'
 import { agentHookServer } from '../../../agent-hooks/server'
@@ -45,6 +46,7 @@ export function clearProviderPtyState(
     // may drop it — a disconnect that can reconnect is not a death, and a reused
     // id must never inherit a dead pane's Codex account.
     forgetCodexPaneAccount(id)
+    forgetPaneLaunchProfile(id)
   }
   // Why: OpenCode and Pi both allocate PTY-scoped runtime state outside the
   // node-pty process table. Centralizing provider cleanup avoids drift where a

--- a/src/main/ipc/pty/runtime/spawn-commit.ts
+++ b/src/main/ipc/pty/runtime/spawn-commit.ts
@@ -7,6 +7,7 @@ import {
   codexReattachedHomeRouteField
 } from '../host-env/codex-home'
 import { markClaudePtySpawned } from '../../../claude-accounts/live-pty-gate'
+import { recordPaneLaunchProfileForSpawn } from '../../../agent-launch-profile/pane-launch-profile-registry'
 import { registerPty } from '../../../memory/pty-registry'
 import { rememberPaneKeyForPty } from '../pane/key-state'
 import {
@@ -138,6 +139,11 @@ export async function commitRuntimePtySpawn(ctx: RuntimePtySpawnState) {
     launchEnv: args.env,
     target: ctx.codexSelectionTarget,
     settings: ctx.deps.getSettings?.()
+  })
+  recordPaneLaunchProfileForSpawn({
+    ptyId: ctx.result.id,
+    isReattach: ctx.result.isReattach === true,
+    launchEnv: args.env
   })
   if (ctx.hostSessionBinding && !ctx.stablePaneBindingPersisted) {
     try {

--- a/src/main/persistence/applying-settings/settings-update.ts
+++ b/src/main/persistence/applying-settings/settings-update.ts
@@ -5,6 +5,7 @@ import {
   normalizeTuiAgentArgsRecord,
   normalizeTuiAgentEnvRecord
 } from '../../../shared/tui-agent-launch-defaults'
+import { normalizeAgentLaunchProfileSettings } from '../../../shared/agent-launch-profile/agent-launch-profile'
 import { normalizeTerminalQuickCommands } from '../../../shared/terminal-quick-commands'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { normalizeTerminalCursorStyleDefault } from '../../../shared/terminal-cursor-style-settings'
@@ -98,6 +99,11 @@ export function updateSettings(
   if ('agentDefaultEnv' in updates) {
     sanitizedUpdates.agentDefaultEnv = normalizeTuiAgentEnvRecord(updates.agentDefaultEnv)
     sanitizedUpdates.agentYoloDefaultsMigrated = true
+  }
+  if ('agentLaunchProfiles' in updates) {
+    sanitizedUpdates.agentLaunchProfiles = normalizeAgentLaunchProfileSettings(
+      updates.agentLaunchProfiles
+    )
   }
   if ('terminalQuickCommands' in updates) {
     sanitizedUpdates.terminalQuickCommands = normalizeTerminalQuickCommands(

--- a/src/main/providers/local-pty-spawn-environment.ts
+++ b/src/main/providers/local-pty-spawn-environment.ts
@@ -1,4 +1,8 @@
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
+import {
+  applyLaunchProfileHomeMarkers,
+  exportLaunchProfileHomesForWsl
+} from '../agent-launch-profile/launch-profile-home'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
 import { removeInheritedNoColor } from '../pty/terminal-color-env'
@@ -69,7 +73,8 @@ export function buildLocalPtySpawnEnvironment(args: {
 
 export function enforceLocalPtySpawnEnvironmentOverrides(
   spawn: PtySpawnOptions,
-  finalEnv: Record<string, string>
+  finalEnv: Record<string, string>,
+  plan?: Pick<LocalPtyLaunchPlan, 'isWslShell' | 'launchWslDistro'>
 ): void {
   // Why: app-level env hooks can re-add scrubbed vars; delete last so shims like Claude Agent Teams keep their PATH.
   for (const key of spawn.envToDelete ?? []) {
@@ -77,5 +82,15 @@ export function enforceLocalPtySpawnEnvironmentOverrides(
   }
   if (spawn.env?.TERM) {
     finalEnv.TERM = spawn.env.TERM
+  }
+  // Why: this lane spawns in-process, so it is the execution host that must turn a launch-profile
+  // home marker into a real path — after the host env (which may have injected a managed home).
+  applyLaunchProfileHomeMarkers({
+    env: finalEnv,
+    isWslLaunch: plan?.isWslShell === true,
+    wslDistro: plan?.launchWslDistro
+  })
+  if (plan?.isWslShell) {
+    exportLaunchProfileHomesForWsl(finalEnv)
   }
 }

--- a/src/main/providers/local-pty-spawn.ts
+++ b/src/main/providers/local-pty-spawn.ts
@@ -50,7 +50,7 @@ export async function spawnLocalPty(
     plan
   })
   const finalEnv = envResult instanceof Promise ? await envResult : envResult
-  enforceLocalPtySpawnEnvironmentOverrides(args, finalEnv)
+  enforceLocalPtySpawnEnvironmentOverrides(args, finalEnv, plan)
   const historyResult = finalizeLocalPtySpawnEnvironment({
     spawn: args,
     getOptions,

--- a/src/main/providers/ssh-pty-provider-contract.ts
+++ b/src/main/providers/ssh-pty-provider-contract.ts
@@ -1,6 +1,10 @@
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import type { RemoteHostPlatform } from '../ssh/ssh-remote-platform'
 
 export type RemoteCliBridgeEnv = {
+  /** Probed at connect time; the execution host's home for launch-profile secondary homes. */
+  remoteHome?: string
+  hostPlatform?: RemoteHostPlatform
   binDir: string
   relayDir: string
   nodePath: string

--- a/src/main/providers/ssh-pty-spawn-env.test.ts
+++ b/src/main/providers/ssh-pty-spawn-env.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { CODEX_SECONDARY_HOME_PROFILE_ID } from '../../shared/agent-launch-profile/agent-launch-profile'
+import { AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED } from '../agent-launch-profile/requested-launch-profile'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { buildSshPtySpawnEnv } from './ssh-pty-spawn-env'
+
+const bridge = {
+  remoteHome: '/home/dev',
+  hostPlatform: getRemoteHostPlatform('linux-x64'),
+  binDir: '/home/dev/.orca-relay/bin',
+  relayDir: '/home/dev/.orca-relay',
+  nodePath: '/home/dev/.orca-relay/node',
+  sockPath: '/tmp/orca.sock'
+}
+
+describe('buildSshPtySpawnEnv launch profiles', () => {
+  it('resolves a secondary-home marker against the probed remote home', () => {
+    const env = buildSshPtySpawnEnv({
+      env: { ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID, PATH: '/usr/bin' },
+      remoteCliBridgeEnv: bridge
+    })
+    expect(env.CODEX_HOME).toBe('/home/dev/.codex-2')
+    expect(env.ORCA_CODEX_HOME).toBe('/home/dev/.codex-2')
+    expect(env.ORCA_CODEX_HOME_PROFILE).toBeUndefined()
+  })
+
+  it('fails rather than launching on the remote default home when the probe is missing', () => {
+    expect(() =>
+      buildSshPtySpawnEnv({
+        env: { ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID }
+      })
+    ).toThrow(AGENT_SESSION_LAUNCH_PROFILE_REMOTE_UNSUPPORTED)
+  })
+})

--- a/src/main/providers/ssh-pty-spawn-env.ts
+++ b/src/main/providers/ssh-pty-spawn-env.ts
@@ -1,3 +1,4 @@
+import { applyLaunchProfileHomeMarkersForRemoteHost } from '../agent-launch-profile/launch-profile-remote-home'
 import { seedPowerlevel10kWizardEnv } from '../pty/powerlevel10k-wizard-env'
 import type { RemoteCliBridgeEnv } from './ssh-pty-provider-contract'
 
@@ -30,6 +31,9 @@ export function buildSshPtySpawnEnv(args: {
   for (const key of args.envToDelete ?? []) {
     delete merged[key]
   }
+  // Why: this lane skips main's host-env builder and the relay never expands values, so the
+  // execution host's probed home is the only place a secondary-home marker can resolve.
+  applyLaunchProfileHomeMarkersForRemoteHost(merged, args.remoteCliBridgeEnv)
   seedPowerlevel10kWizardEnv(merged, { envToDelete: args.envToDelete })
   return merged
 }

--- a/src/main/runtime/orca-runtime-activate-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-activate-managed-worktree.ts
@@ -139,7 +139,8 @@ export class OrcaRuntimeWithActivateManagedWorktree extends OrcaRuntimeWithListM
     repo: Repo,
     agent: TuiAgent,
     prompt: string | undefined,
-    launchPreferences?: AgentLaunchPreferences
+    launchPreferences?: AgentLaunchPreferences,
+    launchProfileId?: string
   ): { agent: TuiAgent; startup: WorktreeStartupLaunch; followup?: WorktreeStartupFollowup } {
     if (!this.store) {
       throw new Error('runtime_unavailable')
@@ -149,6 +150,7 @@ export class OrcaRuntimeWithActivateManagedWorktree extends OrcaRuntimeWithListM
       agent,
       ...(prompt !== undefined ? { prompt } : {}),
       ...(launchPreferences ? { launchPreferences } : {}),
+      ...(launchProfileId ? { launchProfileId } : {}),
       settings: this.store.getSettings(),
       getLaunchPlatform: () => this.getAgentLaunchPlatformForRepo(repo),
       toSessionOptions: (preferences) => this.toAgentSessionOptions(preferences)

--- a/src/main/runtime/orca-runtime-create-agent-session.ts
+++ b/src/main/runtime/orca-runtime-create-agent-session.ts
@@ -165,8 +165,7 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
       const launchProfile = resolveRequestedAgentLaunchProfile({
         agent: request.agent,
         launchProfileId: request.launchProfileId,
-        settings,
-        isRemote
+        settings
       })
       const launch = applyAgentLaunchProfile({
         profile: launchProfile,

--- a/src/main/runtime/orca-runtime-create-agent-session.ts
+++ b/src/main/runtime/orca-runtime-create-agent-session.ts
@@ -16,6 +16,8 @@ import {
   AGENT_SESSION_OPERATION_PER_CLIENT_LIMIT
 } from './orca-runtime-core'
 import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
+import { applyAgentLaunchProfile } from '../../shared/agent-launch-profile/agent-launch-profile'
+import { resolveRequestedAgentLaunchProfile } from '../agent-launch-profile/requested-launch-profile'
 import { resolveLocalWindowsAgentStartupShell } from '../../shared/windows-terminal-shell'
 import {
   resolveTuiAgentLaunchArgs,
@@ -138,6 +140,7 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
             request.launchPreferences?.model ?? null,
             request.launchPreferences?.effort ?? null,
             request.launchPreferences?.mode ?? null,
+            request.launchProfileId ?? null,
             startupCwd ?? null,
             request.presentation ?? null,
             request.placement?.tabId ?? null,
@@ -159,14 +162,25 @@ export class OrcaRuntimeWithCreateAgentSession extends OrcaRuntimeWithGetAgentSe
         isRemote,
         terminalWindowsShell: settings.terminalWindowsShell
       })
+      const launchProfile = resolveRequestedAgentLaunchProfile({
+        agent: request.agent,
+        launchProfileId: request.launchProfileId,
+        settings,
+        isRemote
+      })
+      const launch = applyAgentLaunchProfile({
+        profile: launchProfile,
+        agentArgs:
+          request.agentArgs !== undefined
+            ? (request.agentArgs ?? '')
+            : resolveTuiAgentLaunchArgs(request.agent, settings.agentDefaultArgs),
+        agentEnv: resolveTuiAgentLaunchEnv(request.agent, settings.agentDefaultEnv)
+      })
       const startupArgs = {
         agent: request.agent,
         cmdOverrides: settings.agentCmdOverrides ?? {},
-        agentArgs:
-          request.agentArgs !== undefined
-            ? request.agentArgs
-            : resolveTuiAgentLaunchArgs(request.agent, settings.agentDefaultArgs),
-        agentEnv: resolveTuiAgentLaunchEnv(request.agent, settings.agentDefaultEnv),
+        agentArgs: request.agentArgs === null && !launchProfile ? null : launch.agentArgs,
+        agentEnv: launch.agentEnv,
         sessionOptions: this.toAgentSessionOptions(request.launchPreferences),
         platform,
         shell,

--- a/src/main/runtime/orca-runtime-create-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-worktree.ts
@@ -43,7 +43,8 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
             repo,
             args.startupAgent,
             args.startupPrompt,
-            args.startupLaunchPreferences
+            args.startupLaunchPreferences,
+            args.startupLaunchProfileId
           )
         : null
     const draftStartup =

--- a/src/main/runtime/orca-runtime-prune-mobile-session-tab-group-layout.ts
+++ b/src/main/runtime/orca-runtime-prune-mobile-session-tab-group-layout.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithScheduleMobileSessionTabsChanged } from './orca-runtime-schedule-mobile-session-tabs-changed'
 import type { TabGroupLayoutNode } from '../../shared/tab-types'
+import { getPaneLaunchProfile } from '../agent-launch-profile/pane-launch-profile-registry'
 import type {
   RuntimeMobileSessionSnapshotTab,
   RuntimeMobileSessionTabGroup,
@@ -209,6 +210,10 @@ export class OrcaRuntimeWithPruneMobileSessionTabGroupLayout extends OrcaRuntime
 
   getAgentStatusTerminalHandleForPaneKey(paneKey: string): string | undefined {
     return this.getTerminalHandleForPaneKey(paneKey) ?? undefined
+  }
+
+  getAgentStatusLaunchProfileForPaneKey(paneKey: string): string | undefined {
+    return getPaneLaunchProfile(this.getPtyRecordForPaneKey(paneKey)?.ptyId)
   }
 
   getAgentStatusLaunchConfigForPaneKey(

--- a/src/main/runtime/orca-runtime-resolve-mobile-session-terminal-command.ts
+++ b/src/main/runtime/orca-runtime-resolve-mobile-session-terminal-command.ts
@@ -5,6 +5,8 @@ import type { WorktreeStartupLaunch } from '../../shared/worktree/launch-types'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { SleepingAgentLaunchConfig } from '../../shared/agent-session-resume'
 import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
+import { applyAgentLaunchProfile } from '../../shared/agent-launch-profile/agent-launch-profile'
+import { resolveRequestedAgentLaunchProfile } from '../agent-launch-profile/requested-launch-profile'
 import { resolveLocalWindowsAgentStartupShell } from '../../shared/windows-terminal-shell'
 import { buildAgentStartupPlan } from '../../shared/tui-agent-startup'
 import {
@@ -22,6 +24,7 @@ export class OrcaRuntimeWithResolveMobileSessionTerminalCommand extends OrcaRunt
       startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
       agent?: TuiAgent
       agentPrompt?: string
+      launchProfileId?: string
       launchConfig?: SleepingAgentLaunchConfig
       launchAgent?: TuiAgent
     }
@@ -59,12 +62,22 @@ export class OrcaRuntimeWithResolveMobileSessionTerminalCommand extends OrcaRunt
       isRemote,
       terminalWindowsShell: settings.terminalWindowsShell
     })
+    const launch = applyAgentLaunchProfile({
+      profile: resolveRequestedAgentLaunchProfile({
+        agent: opts.agent,
+        launchProfileId: opts.launchProfileId,
+        settings,
+        isRemote
+      }),
+      agentArgs: resolveTuiAgentLaunchArgs(opts.agent, settings.agentDefaultArgs),
+      agentEnv: resolveTuiAgentLaunchEnv(opts.agent, settings.agentDefaultEnv)
+    })
     const startupPlan = buildAgentStartupPlan({
       agent: opts.agent,
       prompt: opts.agentPrompt ?? '',
       cmdOverrides: settings.agentCmdOverrides ?? {},
-      agentArgs: resolveTuiAgentLaunchArgs(opts.agent, settings.agentDefaultArgs),
-      agentEnv: resolveTuiAgentLaunchEnv(opts.agent, settings.agentDefaultEnv),
+      agentArgs: launch.agentArgs,
+      agentEnv: launch.agentEnv,
       platform,
       shell: queuedShell,
       isRemote,

--- a/src/main/runtime/orca-runtime-resolve-mobile-session-terminal-command.ts
+++ b/src/main/runtime/orca-runtime-resolve-mobile-session-terminal-command.ts
@@ -66,8 +66,7 @@ export class OrcaRuntimeWithResolveMobileSessionTerminalCommand extends OrcaRunt
       profile: resolveRequestedAgentLaunchProfile({
         agent: opts.agent,
         launchProfileId: opts.launchProfileId,
-        settings,
-        isRemote
+        settings
       }),
       agentArgs: resolveTuiAgentLaunchArgs(opts.agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(opts.agent, settings.agentDefaultEnv)

--- a/src/main/runtime/orca-runtime-run-create-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-run-create-mobile-session-terminal.ts
@@ -26,6 +26,7 @@ export class OrcaRuntimeWithRunCreateMobileSessionTerminal extends OrcaRuntimeWi
       startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
       agent?: TuiAgent
       agentPrompt?: string
+      launchProfileId?: string
       launchConfig?: SleepingAgentLaunchConfig
       launchAgent?: TuiAgent
       viewMode?: 'terminal' | 'chat'

--- a/src/main/runtime/rpc/methods/agent-session.ts
+++ b/src/main/runtime/rpc/methods/agent-session.ts
@@ -15,6 +15,7 @@ import {
   AGENT_SESSION_OPERATION_FUTURE_SKEW_MS,
   parseAgentSessionOperationTimestamp
 } from '../../../../shared/agent-session-host-authority'
+import { isAgentLaunchProfileId } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
 import type { OrcaRuntimeService } from '../../orca-runtime'
@@ -176,6 +177,9 @@ export const CreateAgentSessionParams: z.ZodType<RuntimeCreateAgentSessionReques
     promptDelivery: PromptDelivery.optional(),
     agentArgs: AgentArgs.optional(),
     launchPreferences: LaunchPreferences.optional(),
+    // Why: shape-only here; the host resolves the id against its own profile list so a client
+    // built for a newer catalog fails with a named error instead of a schema rejection.
+    launchProfileId: z.string().refine(isAgentLaunchProfileId, 'Invalid launch profile').optional(),
     startupCwd: z.string().min(1).max(MAX_WORKTREE_SELECTOR_LENGTH).optional(),
     presentation: Presentation.optional(),
     placement: Placement.optional(),

--- a/src/main/runtime/rpc/methods/client-settings-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-settings-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { normalizeAgentLaunchProfileSettings } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { normalizePRBotAuthorOverrides } from '../../../../shared/pr-bot-author-overrides'
 import { isTaskProvider } from '../../../../shared/task-providers'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
@@ -67,6 +68,11 @@ export const SettingsUpdate = z
       .optional(),
     experimentalNewWorktreeCardStyle: z.boolean().optional(),
     agentStatusHooksEnabled: z.boolean().optional(),
+    agentLaunchProfiles: z
+      .unknown()
+      .transform((value) => normalizeAgentLaunchProfileSettings(value))
+      .optional(),
+    agentLaunchProfilesEnabled: z.boolean().optional(),
     defaultRepoSelection: z.array(z.string()).nullable().optional(),
     defaultLinearTeamSelection: z.array(z.string()).nullable().optional(),
     compactWorktreeCards: z.boolean().optional(),

--- a/src/main/runtime/rpc/methods/session-tabs-schemas.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { isAgentLaunchProfileId } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { MAX_QUICK_COMMAND_AGENT_PROMPT_LENGTH } from '../../../../shared/terminal-quick-commands'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../../shared/tui-agent'
@@ -153,6 +154,8 @@ export const CreateTerminalTab = WorktreeTabSelector.extend({
     .max(MAX_QUICK_COMMAND_AGENT_PROMPT_LENGTH)
     .refine((value) => value.trim().length > 0, { message: 'Agent prompt cannot be empty' })
     .optional(),
+  // Why: shape-only; the host resolves the id against its own catalog (see agent-session).
+  launchProfileId: z.string().refine(isAgentLaunchProfileId, 'Invalid launch profile').optional(),
   // Why: `agent` is the legacy preset field; `launchAgent` is the launch-plan
   // identity used when preserving resume config across runtime boundaries.
   launchAgent: z

--- a/src/main/runtime/rpc/methods/session-tabs.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.ts
@@ -61,6 +61,7 @@ export const SESSION_TAB_METHODS: RpcAnyMethod[] = [
         startupCommandDelivery: params.startupCommandDelivery,
         agent: params.agent,
         ...(params.agentPrompt !== undefined ? { agentPrompt: params.agentPrompt } : {}),
+        ...(params.launchProfileId ? { launchProfileId: params.launchProfileId } : {}),
         ...(params.launchConfig ? { launchConfig: params.launchConfig } : {}),
         ...(params.launchToken ? { launchToken: params.launchToken } : {}),
         ...(params.launchAgent ? { launchAgent: params.launchAgent } : {}),

--- a/src/main/runtime/rpc/methods/worktree-create-args.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-args.ts
@@ -77,6 +77,9 @@ export function buildManagedWorktreeCreateArgs(
         }
       : undefined,
     ...(params.startupAgent ? { startupAgent: params.startupAgent } : {}),
+    ...(params.startupLaunchProfileId
+      ? { startupLaunchProfileId: params.startupLaunchProfileId }
+      : {}),
     ...(params.startupPrompt !== undefined ? { startupPrompt: params.startupPrompt } : {}),
     startupDraft: params.startupDraft,
     lineage: {

--- a/src/main/runtime/rpc/methods/worktree-create-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-create-schemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { isAgentLaunchProfileId } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { isTuiAgent } from '../../../../shared/tui-agent-config'
 import { workspaceSourceSchema } from '../../../../shared/telemetry-events'
 import { sleepingAgentLaunchConfigSchema } from '../../../../shared/workspace-session-sleeping-agents'
@@ -109,6 +110,10 @@ export const WorktreeCreate = z
     // Why: CLI clients should not hardcode agent launch quoting because SSH
     // workspaces execute in a different shell than the client process.
     startupAgent: OptionalTuiAgent,
+    startupLaunchProfileId: z
+      .string()
+      .refine(isAgentLaunchProfileId, 'Invalid launch profile')
+      .optional(),
     startupPrompt: OptionalString,
     // Why: task-driven mobile creates need desktop parity: the host chooses
     // the same default/detected agent and drafts the linked issue/PR URL into it.
@@ -135,6 +140,13 @@ export const WorktreeCreate = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Choose either one parent selector or --no-parent.'
+      })
+    }
+    if (params.startupLaunchProfileId !== undefined && params.startupAgent === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['startupLaunchProfileId'],
+        message: 'startupLaunchProfileId requires startupAgent'
       })
     }
     if (params.startupPrompt !== undefined && params.startupAgent === undefined) {

--- a/src/main/runtime/runtime-managed-worktree-create-types.ts
+++ b/src/main/runtime/runtime-managed-worktree-create-types.ts
@@ -50,6 +50,8 @@ export type RuntimeManagedWorktreeCreateArgs = {
   createdWithAgent?: TuiAgent
   startupAgent?: TuiAgent
   startupLaunchPreferences?: AgentLaunchPreferences
+  /** Launch profile for `startupAgent`; validated against the host catalog at create time. */
+  startupLaunchProfileId?: string
   startupPrompt?: string
   pendingFirstAgentMessageRename?: boolean
   automationProvenance?: AutomationWorkspaceProvenance

--- a/src/main/runtime/runtime-mobile-agent-status-builder.ts
+++ b/src/main/runtime/runtime-mobile-agent-status-builder.ts
@@ -11,6 +11,7 @@ import {
   selectRuntimeHookAgentRowForPane
 } from './runtime-mobile-agent-status-projection'
 import type { RuntimeLeafRecord, RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+import { getPaneLaunchProfile } from '../agent-launch-profile/pane-launch-profile-registry'
 import type { RuntimeAgentRowSnapshot } from './runtime-worktree-agent-rows'
 import {
   classifyAgentTitle,
@@ -95,6 +96,7 @@ export function buildRuntimeMobileAgentStatus(
   )
   // Why: OSC 9999 hook payload carries real state/prompt/agent; without preferring it, hook-only transitions never surfaced (#7970).
   const liveRow = retained ?? resolveRuntimeHookLiveAgentRow(hookRow.live, pty, nonAgentTitle)
+  const launchProfileId = getPaneLaunchProfile(pty?.ptyId)
   if (liveRow) {
     const liveStatus = normalizeCompatibleAgentStatusEntryForOwner(
       {
@@ -104,6 +106,7 @@ export function buildRuntimeMobileAgentStatus(
         stateStartedAt: liveRow.stateStartedAt,
         stateHistory: [],
         ...(terminalHandle ? { terminalHandle } : {}),
+        ...(launchProfileId ? { launchProfileId } : {}),
         ...((pty?.worktreeId ?? liveRow.worktreeId)
           ? { worktreeId: pty?.worktreeId ?? liveRow.worktreeId }
           : {}),
@@ -143,6 +146,7 @@ export function buildRuntimeMobileAgentStatus(
       stateStartedAt: pty?.lastAgentStatusStartedAtEpochMs ?? evidenceAt,
       paneKey,
       ...(terminalHandle ? { terminalHandle } : {}),
+      ...(launchProfileId ? { launchProfileId } : {}),
       ...(agentType ? { agentType } : {}),
       ...(pty?.worktreeId ? { worktreeId: pty.worktreeId } : {}),
       tabId: tab.parentTabId,

--- a/src/main/runtime/runtime-mobile-session-projection.ts
+++ b/src/main/runtime/runtime-mobile-session-projection.ts
@@ -204,6 +204,9 @@ export function projectRuntimeMobileSessionTabs(
               paneKey: normalizedTabAgentStatus.paneKey,
               stateHistory: [],
               agentType: normalizedTabAgentStatus.agentType,
+              ...(normalizedTabAgentStatus.launchProfileId
+                ? { launchProfileId: normalizedTabAgentStatus.launchProfileId }
+                : {}),
               ...(normalizedTabAgentStatus.providerSession
                 ? { providerSession: normalizedTabAgentStatus.providerSession }
                 : {})

--- a/src/main/runtime/runtime-store-contract.ts
+++ b/src/main/runtime/runtime-store-contract.ts
@@ -84,6 +84,7 @@ export type RuntimeStore = {
     agentCmdOverrides?: GlobalSettings['agentCmdOverrides']
     agentDefaultArgs?: GlobalSettings['agentDefaultArgs']
     agentDefaultEnv?: GlobalSettings['agentDefaultEnv']
+    agentLaunchProfiles?: GlobalSettings['agentLaunchProfiles']
     terminalWindowsShell?: GlobalSettings['terminalWindowsShell']
     floatingTerminalEnabled?: GlobalSettings['floatingTerminalEnabled']
     agentStatusHooksEnabled?: GlobalSettings['agentStatusHooksEnabled']

--- a/src/main/runtime/runtime-worktree-agent-startup.ts
+++ b/src/main/runtime/runtime-worktree-agent-startup.ts
@@ -149,8 +149,7 @@ export function buildWorktreeStartupForAgent(
     profile: resolveRequestedAgentLaunchProfile({
       agent,
       launchProfileId: environment.launchProfileId,
-      settings,
-      isRemote
+      settings
     }),
     agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
     agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv)

--- a/src/main/runtime/runtime-worktree-agent-startup.ts
+++ b/src/main/runtime/runtime-worktree-agent-startup.ts
@@ -3,6 +3,8 @@ import type { Repo } from '../../shared/repo-types'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { WorktreeStartupLaunch } from '../../shared/worktree/launch-types'
 import { repoIsRemote } from '../../shared/agent-launch-remote'
+import { applyAgentLaunchProfile } from '../../shared/agent-launch-profile/agent-launch-profile'
+import { resolveRequestedAgentLaunchProfile } from '../agent-launch-profile/requested-launch-profile'
 import { getRepoSshConnectionId } from '../../shared/execution-host'
 import { isTuiAgent, TUI_AGENT_CONFIG } from '../../shared/tui-agent-config'
 import { isTuiAgentEnabled, pickTuiAgent } from '../../shared/tui-agent-selection'
@@ -130,6 +132,7 @@ export function buildWorktreeStartupForAgent(
     agent: TuiAgent
     prompt?: string
     launchPreferences?: AgentLaunchPreferences
+    launchProfileId?: string
     toSessionOptions: (
       preferences?: AgentLaunchPreferences
     ) => Parameters<typeof buildAgentStartupPlan>[0]['sessionOptions'] | undefined
@@ -142,12 +145,22 @@ export function buildWorktreeStartupForAgent(
   const platform = environment.getLaunchPlatform()
   const isRemote = repoIsRemote(repo)
   const sessionOptions = environment.toSessionOptions(environment.launchPreferences)
+  const launch = applyAgentLaunchProfile({
+    profile: resolveRequestedAgentLaunchProfile({
+      agent,
+      launchProfileId: environment.launchProfileId,
+      settings,
+      isRemote
+    }),
+    agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
+    agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv)
+  })
   const startupPlan = buildAgentStartupPlan({
     agent,
     prompt: environment.prompt ?? '',
     cmdOverrides: settings.agentCmdOverrides ?? {},
-    agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
-    agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
+    agentArgs: launch.agentArgs,
+    agentEnv: launch.agentEnv,
     sessionOptions,
     sessionOptionsOverrideAgentArgs: Boolean(sessionOptions),
     platform,

--- a/src/main/startup/main-window-agent-status.ts
+++ b/src/main/startup/main-window-agent-status.ts
@@ -72,6 +72,7 @@ export function installMainWindowAgentStatusListeners(options: MainWindowAgentSt
       const runtime = state.runtime
       const orchestration = runtime?.getAgentStatusOrchestrationContextForPaneKey(paneKey)
       const terminalHandle = runtime?.getAgentStatusTerminalHandleForPaneKey(paneKey)
+      const launchProfileId = runtime?.getAgentStatusLaunchProfileForPaneKey(paneKey)
       const suppressSyntheticCodexAutoApprovalTitle =
         payload.agentType === 'codex' &&
         (payload.state === 'waiting' || payload.state === 'blocked')
@@ -86,6 +87,7 @@ export function installMainWindowAgentStatusListeners(options: MainWindowAgentSt
         paneKey,
         ...(launchToken ? { launchToken } : {}),
         ...(terminalHandle ? { terminalHandle } : {}),
+        ...(launchProfileId ? { launchProfileId } : {}),
         tabId,
         worktreeId,
         connectionId,

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test-fixture.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test-fixture.tsx
@@ -52,6 +52,8 @@ export async function renderCard(
       <NewWorkspaceComposerCard
         quickAgent={null}
         onQuickAgentChange={() => {}}
+        quickLaunchProfileId={null}
+        onQuickLaunchProfileChange={() => {}}
         eligibleRepos={[]}
         repoId="repo-a"
         projectOptions={projectOptions}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -30,7 +30,11 @@ vi.mock('@/store', () => ({
         openSettingsTarget: storeMocks.openSettingsTarget,
         setRuntimeEnvironmentStatus: storeMocks.setRuntimeEnvironmentStatus,
         activeModal: 'none',
-        settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
+        settings: {
+          defaultTuiAgent: null,
+          disabledTuiAgents: [],
+          agentLaunchProfilesEnabled: true
+        },
         updateSettings: vi.fn(),
         projects: [],
         repos: []

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -221,6 +221,8 @@ function renderCard(
       <NewWorkspaceComposerCard
         quickAgent={null}
         onQuickAgentChange={() => {}}
+        quickLaunchProfileId={null}
+        onQuickLaunchProfileChange={() => {}}
         eligibleRepos={[]}
         repoId="repo-a"
         projectOptions={projectOptions}
@@ -922,5 +924,14 @@ describe('NewWorkspaceComposerCard note sizing', () => {
     expect(className).toContain('overflow-y-auto')
     expect(className).toContain('scrollbar-sleek')
     expect(className).not.toContain('overflow-hidden')
+  })
+
+  it('offers a launch-profile picker only for agents that have profiles', () => {
+    current = renderCard({ quickAgent: 'codex' })
+    expect(current.container.querySelector('[aria-label="Launch profile"]')).not.toBeNull()
+    unmountCurrent()
+
+    current = renderCard({ quickAgent: 'gemini' })
+    expect(current.container.querySelector('[aria-label="Launch profile"]')).toBeNull()
   })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -25,6 +25,10 @@ import type { RuntimeStatus } from '../../../shared/runtime-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import { NewWorkspaceComposerAdvancedSection } from './new-workspace/NewWorkspaceComposerAdvancedSection'
 import { NewWorkspaceComposerAgentSection } from './new-workspace/NewWorkspaceComposerAgentSection'
+import {
+  agentLaunchProfilesForAgent,
+  resolveAgentLaunchProfiles
+} from '../../../shared/agent-launch-profile/agent-launch-profile'
 import { NewWorkspaceComposerFooter } from './new-workspace/NewWorkspaceComposerFooter'
 import { NewWorkspaceComposerNameSection } from './new-workspace/NewWorkspaceComposerNameSection'
 import { NewWorkspaceComposerProjectSection } from './new-workspace/NewWorkspaceComposerProjectSection'
@@ -157,6 +161,17 @@ export default function NewWorkspaceComposerCard(
   const setupSkipButtonLabel = setupConfig?.kind === 'setup' ? 'Skip for now' : 'Skip commands'
   const showSetupAgentStartupPolicy =
     setupControlsEnabled && setupConfig !== null && setupConfig.kind !== 'default-tabs'
+  const agentLaunchProfiles = useAppStore((state) => state.settings?.agentLaunchProfiles)
+  const quickLaunchProfiles = React.useMemo(
+    () =>
+      props.quickAgent
+        ? agentLaunchProfilesForAgent(
+            resolveAgentLaunchProfiles(agentLaunchProfiles),
+            props.quickAgent
+          )
+        : [],
+    [agentLaunchProfiles, props.quickAgent]
+  )
   const agentCatalog = getAgentCatalog()
   const enabledAgentIds = new Set(
     filterEnabledTuiAgents(
@@ -323,6 +338,7 @@ export default function NewWorkspaceComposerCard(
         <NewWorkspaceComposerNameSection {...props} onNamePlainEnter={handleNamePlainEnter} />
         <NewWorkspaceComposerAgentSection
           {...props}
+          quickLaunchProfiles={quickLaunchProfiles}
           visibleQuickAgents={visibleQuickAgents}
           defaultTuiAgent={defaultTuiAgent}
           handleSetDefaultAgent={handleSetDefaultAgent}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -27,7 +27,7 @@ import { NewWorkspaceComposerAdvancedSection } from './new-workspace/NewWorkspac
 import { NewWorkspaceComposerAgentSection } from './new-workspace/NewWorkspaceComposerAgentSection'
 import {
   agentLaunchProfilesForAgent,
-  resolveAgentLaunchProfiles
+  resolveAgentLaunchProfilesForPicker
 } from '../../../shared/agent-launch-profile/agent-launch-profile'
 import { NewWorkspaceComposerFooter } from './new-workspace/NewWorkspaceComposerFooter'
 import { NewWorkspaceComposerNameSection } from './new-workspace/NewWorkspaceComposerNameSection'
@@ -162,15 +162,21 @@ export default function NewWorkspaceComposerCard(
   const showSetupAgentStartupPolicy =
     setupControlsEnabled && setupConfig !== null && setupConfig.kind !== 'default-tabs'
   const agentLaunchProfiles = useAppStore((state) => state.settings?.agentLaunchProfiles)
+  const agentLaunchProfilesEnabled = useAppStore(
+    (state) => state.settings?.agentLaunchProfilesEnabled === true
+  )
   const quickLaunchProfiles = React.useMemo(
     () =>
       props.quickAgent
         ? agentLaunchProfilesForAgent(
-            resolveAgentLaunchProfiles(agentLaunchProfiles),
+            resolveAgentLaunchProfilesForPicker({
+              agentLaunchProfiles,
+              agentLaunchProfilesEnabled
+            }),
             props.quickAgent
           )
         : [],
-    [agentLaunchProfiles, props.quickAgent]
+    [agentLaunchProfiles, agentLaunchProfilesEnabled, props.quickAgent]
   )
   const agentCatalog = getAgentCatalog()
   const enabledAgentIds = new Set(

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -21,6 +21,10 @@ import { shouldAllowComposerEnterSubmitTarget } from '@/lib/new-workspace-enter-
 import { isScreenSubmitShortcut } from '@/lib/screen-submit-shortcut'
 import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
+import {
+  findAgentLaunchProfile,
+  resolveAgentLaunchProfiles
+} from '../../../shared/agent-launch-profile/agent-launch-profile'
 import type { WorkspaceSource as WorkspaceCreateTelemetrySource } from '../../../shared/workspace-source'
 import type { WorkspaceStatus } from '../../../shared/worktree/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
@@ -178,14 +182,29 @@ function QuickTabBody({
     setQuickAgentOverride(resolvedQuickAgentSelection.quickAgentOverride)
   }
   const quickAgent = resolvedQuickAgentSelection.quickAgent
+  const [quickLaunchProfileOverride, setQuickLaunchProfileOverride] = useState<string | null>(null)
+  // Why: the profile belongs to one agent, and the catalog can change under an open composer;
+  // derive validity during render the same way the agent selection repairs itself.
+  const quickLaunchProfileId =
+    quickAgent && quickLaunchProfileOverride
+      ? (findAgentLaunchProfile(
+          resolveAgentLaunchProfiles(settings?.agentLaunchProfiles),
+          quickAgent,
+          quickLaunchProfileOverride
+        )?.id ?? null)
+      : null
+  if (quickLaunchProfileId !== quickLaunchProfileOverride) {
+    setQuickLaunchProfileOverride(quickLaunchProfileId)
+  }
 
   const handleQuickAgentChange = useCallback((agent: TuiAgent | null) => {
     setQuickAgentOverride(agent)
+    setQuickLaunchProfileOverride(null)
   }, [])
 
   const handleCreate = useCallback(async (): Promise<void> => {
-    await submitQuick(quickAgent)
-  }, [quickAgent, submitQuick])
+    await submitQuick(quickAgent, quickLaunchProfileId)
+  }, [quickAgent, quickLaunchProfileId, submitQuick])
   // Why: Add Project layers over the composer as a nested dialog instead of
   // replacing it in the activeModal slot — closing the composer mid-flow (and
   // losing the typed name/prompt) was the old, abrupt behavior. Once opened it
@@ -301,6 +320,8 @@ function QuickTabBody({
         nameInputRef={nameInputRef}
         quickAgent={quickAgent}
         onQuickAgentChange={handleQuickAgentChange}
+        quickLaunchProfileId={quickLaunchProfileId}
+        onQuickLaunchProfileChange={setQuickLaunchProfileOverride}
         {...cardProps}
         primaryActionLabel={primaryActionLabel}
         onOpenAgentSettings={() => setAgentSettingsOpen(true)}

--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -23,7 +23,7 @@ import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import {
   findAgentLaunchProfile,
-  resolveAgentLaunchProfiles
+  resolveAgentLaunchProfilesForPicker
 } from '../../../shared/agent-launch-profile/agent-launch-profile'
 import type { WorkspaceSource as WorkspaceCreateTelemetrySource } from '../../../shared/workspace-source'
 import type { WorkspaceStatus } from '../../../shared/worktree/types'
@@ -188,7 +188,7 @@ function QuickTabBody({
   const quickLaunchProfileId =
     quickAgent && quickLaunchProfileOverride
       ? (findAgentLaunchProfile(
-          resolveAgentLaunchProfiles(settings?.agentLaunchProfiles),
+          resolveAgentLaunchProfilesForPicker(settings),
           quickAgent,
           quickLaunchProfileOverride
         )?.id ?? null)

--- a/src/renderer/src/components/new-workspace/NewWorkspaceComposerAgentSection.tsx
+++ b/src/renderer/src/components/new-workspace/NewWorkspaceComposerAgentSection.tsx
@@ -2,6 +2,14 @@ import React from 'react'
 import { ChevronDown, Settings2 } from 'lucide-react'
 import AgentCombobox from '@/components/agent/AgentCombobox'
 import { Button } from '@/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
+import type { AgentLaunchProfile } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -11,12 +19,16 @@ type NewWorkspaceComposerAgentSectionProps = Pick<
   NewWorkspaceComposerCardProps,
   | 'quickAgent'
   | 'onQuickAgentChange'
+  | 'quickLaunchProfileId'
+  | 'onQuickLaunchProfileChange'
   | 'onOpenAgentSettings'
   | 'createDisabled'
   | 'onCreate'
   | 'advancedOpen'
   | 'onToggleAdvanced'
 > & {
+  /** Profiles of the selected agent; the picker stays hidden while this is empty. */
+  quickLaunchProfiles: readonly AgentLaunchProfile[]
   visibleQuickAgents: React.ComponentProps<typeof AgentCombobox>['agents']
   defaultTuiAgent: React.ComponentProps<typeof AgentCombobox>['defaultAgent']
   handleSetDefaultAgent: (
@@ -24,9 +36,16 @@ type NewWorkspaceComposerAgentSectionProps = Pick<
   ) => void
 }
 
+// Why: Radix Select rejects an empty value, and a profile id is a lowercase dash slug, so an
+// underscored token can never collide with one.
+const DEFAULT_LAUNCH_VALUE = '__default_launch__'
+
 export function NewWorkspaceComposerAgentSection({
   quickAgent,
   onQuickAgentChange,
+  quickLaunchProfileId,
+  onQuickLaunchProfileChange,
+  quickLaunchProfiles,
   onOpenAgentSettings,
   createDisabled,
   onCreate,
@@ -76,6 +95,38 @@ export function NewWorkspaceComposerAgentSection({
           triggerClassName="h-9 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
           onTriggerEnter={createDisabled ? undefined : onCreate}
         />
+        {quickLaunchProfiles.length > 0 ? (
+          <Select
+            value={quickLaunchProfileId ?? DEFAULT_LAUNCH_VALUE}
+            onValueChange={(value) =>
+              onQuickLaunchProfileChange(value === DEFAULT_LAUNCH_VALUE ? null : value)
+            }
+          >
+            <SelectTrigger
+              size="sm"
+              className="w-full min-w-0"
+              aria-label={translate(
+                'auto.components.NewWorkspaceComposerCard.launchProfileLabel',
+                'Launch profile'
+              )}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={DEFAULT_LAUNCH_VALUE}>
+                {translate(
+                  'auto.components.NewWorkspaceComposerCard.launchProfileDefault',
+                  'Default launch'
+                )}
+              </SelectItem>
+              {quickLaunchProfiles.map((profile) => (
+                <SelectItem key={profile.id} value={profile.id}>
+                  {profile.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
       </div>
 
       <div className="!mb-2">

--- a/src/renderer/src/components/new-workspace/new-workspace-composer-card-props.ts
+++ b/src/renderer/src/components/new-workspace/new-workspace-composer-card-props.ts
@@ -35,6 +35,9 @@ export type NewWorkspaceComposerCardProps = {
   nameInputRef?: React.RefObject<HTMLInputElement | null>
   quickAgent: TuiAgent | null
   onQuickAgentChange: (agent: TuiAgent | null) => void
+  /** Null is the agent's default launch; ids come from the host's launch-profile catalog. */
+  quickLaunchProfileId: string | null
+  onQuickLaunchProfileChange: (launchProfileId: string | null) => void
   eligibleRepos: readonly RepoOption[]
   repoId: string
   projectOptions?: NewWorkspaceProjectOption[]

--- a/src/renderer/src/components/settings/AgentLaunchProfilesSetting.tsx
+++ b/src/renderer/src/components/settings/AgentLaunchProfilesSetting.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import {
+  getAgentLaunchProfilesDescription,
+  getAgentLaunchProfilesTitle
+} from './agent-launch-profiles-copy'
+import { SettingsSwitchRow } from './SettingsFormControls'
+
+type AgentLaunchProfilesSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+}
+
+/** Off by default: the pickers add a submenu and a select most users never need. */
+export function AgentLaunchProfilesSetting({
+  settings,
+  updateSettings
+}: AgentLaunchProfilesSettingProps): React.JSX.Element {
+  const enabled = settings.agentLaunchProfilesEnabled === true
+  return (
+    <section className="space-y-3">
+      <SettingsSwitchRow
+        label={getAgentLaunchProfilesTitle()}
+        description={getAgentLaunchProfilesDescription()}
+        checked={enabled}
+        onChange={() => updateSettings({ agentLaunchProfilesEnabled: !enabled })}
+        ariaLabel={getAgentLaunchProfilesTitle()}
+      />
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { AgentLaunchProfilesSetting } from './AgentLaunchProfilesSetting'
 import { Info } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { TuiAgent } from '../../../../shared/tui-agent'
@@ -255,6 +256,7 @@ export function AgentsPane({
         wslCapabilitiesLoading={wslCapabilitiesLoading}
       />
       <AgentStatusHooksSetting settings={settings} updateSettings={updateSettings} />
+      <AgentLaunchProfilesSetting settings={settings} updateSettings={updateSettings} />
       <AgentGeneratedTabTitlesSetting settings={settings} updateSettings={updateSettings} />
       {!isPairedWebClientWindow() ? (
         <AgentAwakeSetting settings={settings} updateSettings={updateSettings} />

--- a/src/renderer/src/components/settings/agent-launch-profiles-copy.ts
+++ b/src/renderer/src/components/settings/agent-launch-profiles-copy.ts
@@ -1,0 +1,35 @@
+import { translate } from '@/i18n/i18n'
+import { searchKeywords } from './settings-search-keywords'
+
+const AGENT_LAUNCH_PROFILES_TITLE_KEY = 'auto.components.settings.agent-launch-profiles-copy.title'
+const AGENT_LAUNCH_PROFILES_DESCRIPTION_KEY =
+  'auto.components.settings.agent-launch-profiles-copy.description'
+
+export function getAgentLaunchProfilesTitle(): string {
+  return translate(AGENT_LAUNCH_PROFILES_TITLE_KEY, 'Agent launch profiles')
+}
+
+export function getAgentLaunchProfilesDescription(): string {
+  return translate(
+    AGENT_LAUNCH_PROFILES_DESCRIPTION_KEY,
+    'Offer a second credential home or a provider profile when launching Codex or Claude, in the tab bar, the New Workspace composer and Orca Mobile. Off by default; the CLI and paired clients can pass a profile either way.'
+  )
+}
+
+export function getAgentLaunchProfilesSearchKeywords(): string[] {
+  return searchKeywords([
+    { key: 'auto.components.settings.agents.search.launchProfile', fallback: 'launch profile' },
+    { key: 'auto.components.settings.agents.search.secondAccount', fallback: 'second account' },
+    { key: 'auto.components.settings.agents.search.provider', fallback: 'provider' },
+    {
+      key: 'auto.components.settings.agents.search.f412abbba5',
+      fallback: 'claude',
+      englishOnly: true
+    },
+    {
+      key: 'auto.components.settings.agents.search.5ded38b843',
+      fallback: 'codex',
+      englishOnly: true
+    }
+  ])
+}

--- a/src/renderer/src/components/settings/agents-search.ts
+++ b/src/renderer/src/components/settings/agents-search.ts
@@ -14,6 +14,11 @@ import {
   getAgentStatusHooksSearchKeywords,
   getAgentStatusHooksTitle
 } from './agent-status-hooks-copy'
+import {
+  getAgentLaunchProfilesDescription,
+  getAgentLaunchProfilesSearchKeywords,
+  getAgentLaunchProfilesTitle
+} from './agent-launch-profiles-copy'
 import { getAgentCacheTimerSearchEntries } from './agent-cache-timer-search'
 import { translate } from '@/i18n/i18n'
 import { searchKeywords, translateSearchKeyword, uniqueKeywords } from './settings-search-keywords'
@@ -107,6 +112,11 @@ const getAllAgentsPaneSearchEntries = createLocalizedCatalog(() => [
     title: getAgentStatusHooksTitle(),
     description: getAgentStatusHooksDescription(),
     keywords: getAgentStatusHooksSearchKeywords()
+  },
+  {
+    title: getAgentLaunchProfilesTitle(),
+    description: getAgentLaunchProfilesDescription(),
+    keywords: getAgentLaunchProfilesSearchKeywords()
   },
   {
     title: getAgentGeneratedTabTitlesTitle(),

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import {
   agentLaunchProfilesForAgent,
-  resolveAgentLaunchProfiles
+  resolveAgentLaunchProfilesForPicker
 } from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
 import { useAppStore } from '@/store'
@@ -135,9 +135,16 @@ function QuickLaunchAgentMenuItemsInner({
   }, [openSettingsPage, openSettingsTarget])
 
   const launchProfileSettings = useAppStore((s) => s.settings?.agentLaunchProfiles)
+  const launchProfilePickerEnabled = useAppStore(
+    (s) => s.settings?.agentLaunchProfilesEnabled === true
+  )
   const launchProfiles = useMemo(
-    () => resolveAgentLaunchProfiles(launchProfileSettings),
-    [launchProfileSettings]
+    () =>
+      resolveAgentLaunchProfilesForPicker({
+        agentLaunchProfiles: launchProfileSettings,
+        agentLaunchProfilesEnabled: launchProfilePickerEnabled
+      }),
+    [launchProfileSettings, launchProfilePickerEnabled]
   )
 
   const runLaunch = useCallback(

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -1,7 +1,17 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { Loader2, Settings as SettingsIcon } from 'lucide-react'
 import { toast } from 'sonner'
-import { DropdownMenuItem, DropdownMenuShortcut } from '@/components/ui/dropdown-menu'
+import {
+  DropdownMenuItem,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import {
+  agentLaunchProfilesForAgent,
+  resolveAgentLaunchProfiles
+} from '../../../../shared/agent-launch-profile/agent-launch-profile'
 import { getAgentCatalog, AgentIcon } from '@/lib/agent-catalog'
 import { useAppStore } from '@/store'
 import { useAgentDetectionTargetForWorktree } from '@/hooks/useAgentDetectionTarget'
@@ -124,14 +134,21 @@ function QuickLaunchAgentMenuItemsInner({
     openSettingsPage()
   }, [openSettingsPage, openSettingsTarget])
 
+  const launchProfileSettings = useAppStore((s) => s.settings?.agentLaunchProfiles)
+  const launchProfiles = useMemo(
+    () => resolveAgentLaunchProfiles(launchProfileSettings),
+    [launchProfileSettings]
+  )
+
   const runLaunch = useCallback(
-    (agent: TuiAgent) => {
+    (agent: TuiAgent, launchProfileId?: string) => {
       const entry = getCatalogEntry(agent)
       const label = entry?.label ?? agent
       const result = launchAgentInNewTab({
         agent,
         worktreeId,
         groupId,
+        ...(launchProfileId ? { launchProfileId } : {}),
         ...(prompt !== undefined ? { prompt } : {}),
         ...(promptDelivery !== undefined ? { promptDelivery } : {}),
         ...(launchSource !== undefined ? { launchSource } : {}),
@@ -177,6 +194,7 @@ function QuickLaunchAgentMenuItemsInner({
     },
     [worktreeId, groupId, onFocusTerminal, prompt, promptDelivery, launchSource, onPromptDelivered]
   )
+  const profileItemClassName = 'gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium'
 
   const enabledDetectedIds = detectedIds ? filterEnabledTuiAgents(detectedIds, disabledAgents) : []
   const agents = detectedIds ? orderAgents(defaultAgent, enabledDetectedIds) : []
@@ -204,20 +222,9 @@ function QuickLaunchAgentMenuItemsInner({
         const menuLabel = isStructuredCodexPending ? 'Starting Codex chat…' : label
         const showsDefaultAgentShortcut =
           newAgentShortcut !== null && defaultAgent !== 'blank' && agent === defaultAgent
-        return (
-          <DropdownMenuItem
-            key={agent}
-            disabled={isStructuredCodexPending}
-            onSelect={() => runLaunch(agent)}
-            className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
-            title={translate(
-              'auto.components.tab.bar.QuickLaunchButton.ec2adf093e',
-              isStructuredCodexPending
-                ? 'Starting Codex chat…'
-                : 'Launch {{value0}} in a new terminal',
-              isStructuredCodexPending ? undefined : { value0: label }
-            )}
-          >
+        const agentProfiles = agentLaunchProfilesForAgent(launchProfiles, agent)
+        const itemContent = (
+          <>
             {isStructuredCodexPending ? (
               <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden="true" />
             ) : (
@@ -227,6 +234,64 @@ function QuickLaunchAgentMenuItemsInner({
             {showsDefaultAgentShortcut ? (
               <DropdownMenuShortcut>{newAgentShortcut}</DropdownMenuShortcut>
             ) : null}
+          </>
+        )
+        if (agentProfiles.length > 0) {
+          // Why: a profile is an alternative way to launch the same agent, so it nests under the
+          // agent instead of widening the flat list with one row per account or provider.
+          return (
+            <DropdownMenuSub key={agent}>
+              <DropdownMenuSubTrigger
+                disabled={isStructuredCodexPending}
+                className={profileItemClassName}
+              >
+                {itemContent}
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent className="min-w-48">
+                <DropdownMenuItem
+                  onSelect={() => runLaunch(agent)}
+                  className={profileItemClassName}
+                >
+                  <span className="flex-1">
+                    {translate(
+                      'auto.components.tab.bar.QuickLaunchButton.launchProfileDefault',
+                      'Default launch'
+                    )}
+                  </span>
+                </DropdownMenuItem>
+                {agentProfiles.map((profile) => (
+                  <DropdownMenuItem
+                    key={profile.id}
+                    onSelect={() => runLaunch(agent, profile.id)}
+                    className={profileItemClassName}
+                    title={translate(
+                      'auto.components.tab.bar.QuickLaunchButton.launchProfileTitle',
+                      'Launch {{value0}} with the {{value1}} profile',
+                      { value0: label, value1: profile.label }
+                    )}
+                  >
+                    <span className="flex-1">{profile.label}</span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          )
+        }
+        return (
+          <DropdownMenuItem
+            key={agent}
+            disabled={isStructuredCodexPending}
+            onSelect={() => runLaunch(agent)}
+            className={profileItemClassName}
+            title={translate(
+              'auto.components.tab.bar.QuickLaunchButton.ec2adf093e',
+              isStructuredCodexPending
+                ? 'Starting Codex chat…'
+                : 'Launch {{value0}} in a new terminal',
+              isStructuredCodexPending ? undefined : { value0: label }
+            )}
+          >
+            {itemContent}
           </DropdownMenuItem>
         )
       })}

--- a/src/renderer/src/hooks/composer-state/composer-submit-model.ts
+++ b/src/renderer/src/hooks/composer-state/composer-submit-model.ts
@@ -88,7 +88,8 @@ export type ComposerSubmitModel = {
     workspaceNameSeed: string,
     workspaceRunContext: WorktreeCreationRequest['workspaceRunContext'],
     repoId: string,
-    selectedRepo: Repo
+    selectedRepo: Repo,
+    launchProfileId?: string | null
   ) => Promise<void>
   prepareFullSubmit: (
     resolution: PendingSmartGitHubSubmitResolution
@@ -108,6 +109,9 @@ export type ComposerSubmitModel = {
   ) => QuickSubmitSource | null
   resetForNextCreate: () => void
   submit: () => Promise<void>
-  submitQuick: (agent: TuiAgent | null) => Promise<void>
-  submitFolderTarget: (requestedAgent: TuiAgent | null) => Promise<void>
+  submitQuick: (agent: TuiAgent | null, launchProfileId?: string | null) => Promise<void>
+  submitFolderTarget: (
+    requestedAgent: TuiAgent | null,
+    launchProfileId?: string | null
+  ) => Promise<void>
 }

--- a/src/renderer/src/hooks/composer-state/folder-submit-orchestration.ts
+++ b/src/renderer/src/hooks/composer-state/folder-submit-orchestration.ts
@@ -35,10 +35,7 @@ import {
   resolveFolderWorkspaceLaunchDraft,
   submitFolderWorkspaceCreate
 } from '@/components/sidebar/folder-workspace-composer-submit'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../../shared/tui-agent-launch-defaults'
+import { resolveAgentLaunchWithProfileFallback } from '@/lib/launch-agent-profile'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { translate } from '@/i18n/i18n'
@@ -77,7 +74,7 @@ export function useFolderSubmitOrchestration(input: FolderSubmitOrchestrationInp
   const { canResolveFolderSmartGitHubSubmit } = decisions
 
   const submitFolderTarget = useCallback(
-    async (requestedAgent: TuiAgent | null): Promise<void> => {
+    async (requestedAgent: TuiAgent | null, launchProfileId?: string | null): Promise<void> => {
       if (!selectedProjectGroup?.parentPath || folderCreateDisabled) {
         return
       }
@@ -104,6 +101,9 @@ export function useFolderSubmitOrchestration(input: FolderSubmitOrchestrationInp
           requestedAgent && isTuiAgentEnabled(requestedAgent, disabledTuiAgents)
             ? requestedAgent
             : null
+        const agentLaunch = agent
+          ? resolveAgentLaunchWithProfileFallback(settings, agent, launchProfileId)
+          : null
         if (isSubmissionCancelled()) {
           return
         }
@@ -121,10 +121,8 @@ export function useFolderSubmitOrchestration(input: FolderSubmitOrchestrationInp
           quickAgent: agent,
           autoRenameBranchFromWork: settings?.autoRenameBranchFromWork,
           agentCmdOverrides: settings?.agentCmdOverrides,
-          agentArgs: agent
-            ? resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs)
-            : undefined,
-          agentEnv: agent ? resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv) : undefined,
+          agentArgs: agentLaunch?.agentArgs ?? undefined,
+          agentEnv: agentLaunch?.agentEnv,
           sessionOptions: agent
             ? resolveInitialNativeChatSessionOptions(
                 {

--- a/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
@@ -92,7 +92,8 @@ export function useQuickCreationExecution(input: QuickCreationExecutionInput) {
       workspaceNameSeed: string,
       workspaceRunContext: WorktreeCreationRequest['workspaceRunContext'],
       repoId: string,
-      selectedRepo: Repo
+      selectedRepo: Repo,
+      launchProfileId?: string | null
     ): Promise<void> => {
       const prepared = await prepareQuickSubmit(
         smartGitHubResolution,
@@ -137,6 +138,7 @@ export function useQuickCreationExecution(input: QuickCreationExecutionInput) {
         telemetry: quickTelemetry
       } = buildQuickComposerStartup({
         agent,
+        launchProfileId,
         prompt: quickPrompt,
         draftPrompt: quickDraftPrompt,
         settings,

--- a/src/renderer/src/hooks/composer-state/quick-startup-plan.test.ts
+++ b/src/renderer/src/hooks/composer-state/quick-startup-plan.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { buildQuickComposerStartup } from './quick-startup-plan'
+
+const settings = {
+  agentLaunchProfiles: [
+    { id: 'codex-work', agent: 'codex', label: 'Work', args: '-c model_provider="work"' }
+  ]
+} as unknown as GlobalSettings
+
+function build(launchProfileId: string | null) {
+  return buildQuickComposerStartup({
+    agent: 'codex',
+    launchProfileId,
+    prompt: '',
+    draftPrompt: null,
+    settings,
+    repoConnectionId: null,
+    platform: 'linux',
+    shell: null,
+    isRemote: false,
+    telemetrySource: 'sidebar'
+  })
+}
+
+describe('buildQuickComposerStartup launch profiles', () => {
+  it('layers the profile into the startup command and env the host receives', () => {
+    const startup = build('codex-work')
+    expect(startup.backendStartup?.command).toContain('model_provider')
+    expect(startup.backendStartup?.env?.ORCA_AGENT_LAUNCH_PROFILE).toBe('codex-work')
+  })
+
+  it('stamps only the home marker for a built-in secondary home', () => {
+    const env = build('codex-secondary-home').backendStartup?.env
+    expect(env?.ORCA_CODEX_HOME_PROFILE).toBe('codex-secondary-home')
+    expect(env?.CODEX_HOME).toBeUndefined()
+  })
+
+  it('keeps the default launch without a profile', () => {
+    expect(build(null).backendStartup?.env?.ORCA_AGENT_LAUNCH_PROFILE).toBeUndefined()
+  })
+})

--- a/src/renderer/src/hooks/composer-state/quick-startup-plan.ts
+++ b/src/renderer/src/hooks/composer-state/quick-startup-plan.ts
@@ -5,16 +5,14 @@ import type { AgentStartedTelemetry } from '@/lib/worktree-startup-payload'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agent-startup'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../../shared/tui-agent-launch-defaults'
+import { resolveAgentLaunchWithProfileFallback } from '@/lib/launch-agent-profile'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { tuiAgentToAgentKind } from '@/lib/telemetry'
 
 export type QuickComposerStartupInput = {
   agent: TuiAgent | null
+  launchProfileId?: string | null
   prompt: string
   draftPrompt: string | null | undefined
   settings: GlobalSettings | null | undefined
@@ -33,6 +31,10 @@ export type QuickComposerStartup = {
 
 export function buildQuickComposerStartup(input: QuickComposerStartupInput): QuickComposerStartup {
   const { agent, draftPrompt, prompt, settings } = input
+  const agentLaunch =
+    agent === null
+      ? null
+      : resolveAgentLaunchWithProfileFallback(settings, agent, input.launchProfileId)
   const sessionOptions =
     agent === null
       ? undefined
@@ -59,8 +61,8 @@ export function buildQuickComposerStartup(input: QuickComposerStartupInput): Qui
           agent,
           draft: draftPrompt,
           cmdOverrides: settings?.agentCmdOverrides ?? {},
-          agentArgs: resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs),
-          agentEnv: resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv),
+          agentArgs: agentLaunch?.agentArgs ?? '',
+          agentEnv: agentLaunch?.agentEnv ?? {},
           sessionOptions,
           platform: input.platform,
           shell: input.shell ?? undefined,
@@ -85,8 +87,8 @@ export function buildQuickComposerStartup(input: QuickComposerStartupInput): Qui
       agent,
       prompt,
       cmdOverrides: settings?.agentCmdOverrides ?? {},
-      agentArgs: resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs),
-      agentEnv: resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv),
+      agentArgs: agentLaunch?.agentArgs ?? '',
+      agentEnv: agentLaunch?.agentEnv ?? {},
       sessionOptions,
       platform: input.platform,
       shell: input.shell ?? undefined,

--- a/src/renderer/src/hooks/composer-state/quick-submit-action.ts
+++ b/src/renderer/src/hooks/composer-state/quick-submit-action.ts
@@ -66,9 +66,9 @@ export function useQuickSubmitAction(input: QuickSubmitActionInput) {
   } = input
 
   const submitQuick = useCallback(
-    async (requestedAgent: TuiAgent | null): Promise<void> => {
+    async (requestedAgent: TuiAgent | null, launchProfileId?: string | null): Promise<void> => {
       if (isProjectGroupTarget) {
-        await submitFolderTarget(requestedAgent)
+        await submitFolderTarget(requestedAgent, launchProfileId)
         return
       }
 
@@ -144,7 +144,8 @@ export function useQuickSubmitAction(input: QuickSubmitActionInput) {
           workspaceNameSeed,
           workspaceRunContext,
           repoId,
-          selectedRepo
+          selectedRepo,
+          launchProfileId
         )
       } catch (error) {
         if (isSubmissionCancelled()) {

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -59,7 +59,7 @@ export type UseComposerStateResult = {
   promptTextareaRef: RefObject<HTMLTextAreaElement | null>
   nameInputRef: RefObject<HTMLInputElement | null>
   submit: () => Promise<void>
-  submitQuick: (agent: TuiAgent | null) => Promise<void>
+  submitQuick: (agent: TuiAgent | null, launchProfileId?: string | null) => Promise<void>
   createDisabled: boolean
   selectAddedProjectRepo: (repoId: string) => void
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8828,6 +8828,9 @@
         },
         "agents": {
           "search": {
+            "launchProfile": "launch profile",
+            "secondAccount": "second account",
+            "provider": "provider",
             "2814401339": "installed",
             "719f53350c": "path",
             "839e82c81f": "detect",
@@ -10533,6 +10536,10 @@
           "modeTitle": "Keep computer awake",
           "modeDescriptionWindows": "Choose On, Agent, or Off. Agent mode stays awake while agents are working; lid-close behavior follows this device's power settings.",
           "modeDescriptionDefault": "Choose On, Agent, or Off. Agent mode stays awake while agents are working. Orca also asks this device to stay awake when the lid is closed, subject to its power policy."
+        },
+        "agent-launch-profiles-copy": {
+          "title": "Agent launch profiles",
+          "description": "Offer a second credential home or a provider profile when launching Codex or Claude, in the tab bar, the New Workspace composer and Orca Mobile. Off by default; the CLI and paired clients can pass a profile either way."
         },
         "agent-status-hooks-copy": {
           "7707c15abb": "Agent status hooks",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1611,6 +1611,8 @@
         "startNewWorkspace": "Start new workspace"
       },
       "NewWorkspaceComposerCard": {
+        "launchProfileLabel": "Launch profile",
+        "launchProfileDefault": "Default launch",
         "reuseExistingBranch": "Reuse branch",
         "reuseExistingBranchHint": "Check out the existing branch instead of creating a new one from it.",
         "createMultiple": "Create more",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3343,7 +3343,9 @@
             "ec2adf093e": "Launch {{value0}} in a new terminal",
             "465e432ef1": "Could not build launch command for {{value0}}.",
             "e518f544b1": "No agents detected",
-            "8dea9b5cdf": "No enabled agents"
+            "8dea9b5cdf": "No enabled agents",
+            "launchProfileDefault": "Default launch",
+            "launchProfileTitle": "Launch {{value0}} with the {{value1}} profile"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "Switch Tab",
@@ -16784,7 +16786,8 @@
         "reconnectTimeout": "The server did not reconnect on the updated version."
       },
       "webRuntimeSession": {
-        "remoteHostDisconnected": "The workspace is not connected to a remote Orca host."
+        "remoteHostDisconnected": "The workspace is not connected to a remote Orca host.",
+        "launchProfileUnsupported": "This Orca host is too old to launch agent profiles. Update the host and try again."
       },
       "gitlabJobTraceClient": {
         "loadFailed": "Failed to load the GitLab job log.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2969,7 +2969,9 @@
             "ec2adf093e": "在新终端中启动 {{value0}}",
             "465e432ef1": "无法为 {{value0}} 构建启动命令。",
             "e518f544b1": "未检测到智能体",
-            "8dea9b5cdf": "没有启用智能体"
+            "8dea9b5cdf": "没有启用智能体",
+            "launchProfileDefault": "默认启动",
+            "launchProfileTitle": "用 {{value1}} 配置启动 {{value0}}"
           },
           "RecentTabSwitcher": {
             "329638ff6f": "切换选项卡",
@@ -14585,7 +14587,8 @@
         "reconnectTimeout": "服务器未以更新后的版本重新连接。"
       },
       "webRuntimeSession": {
-        "remoteHostDisconnected": "工作区未连接到远程 Orca 主机。"
+        "remoteHostDisconnected": "工作区未连接到远程 Orca 主机。",
+        "launchProfileUnsupported": "这台 Orca 主机版本过旧，无法按启动配置启动智能体。请更新主机后重试。"
       },
       "gitlabJobTraceClient": {
         "loadFailed": "加载 GitLab 作业日志失败。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7774,6 +7774,9 @@
         },
         "agents": {
           "search": {
+            "launchProfile": "启动配置",
+            "secondAccount": "第二个账号",
+            "provider": "供应商",
             "2814401339": "已安装",
             "719f53350c": "路径",
             "839e82c81f": "检测",
@@ -9337,6 +9340,10 @@
           "on": "开启",
           "auto": "智能体",
           "off": "关闭"
+        },
+        "agent-launch-profiles-copy": {
+          "title": "智能体启动配置",
+          "description": "启动 Codex 或 Claude 时可选择第二个凭据目录或某个供应商配置，在标签栏、新建工作区面板和 Orca Mobile 中显示。默认关闭；CLI 与配对客户端不受影响，仍可传入配置。"
         },
         "agent-status-hooks-copy": {
           "7707c15abb": "智能体状态钩子",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1293,6 +1293,8 @@
         "startNewWorkspace": "启动新工作区"
       },
       "NewWorkspaceComposerCard": {
+        "launchProfileLabel": "启动配置",
+        "launchProfileDefault": "默认启动",
         "cbb47ee0dc": "仅适用于本地 Git 项目。",
         "d861de981b": "稀疏检出",
         "090cfedeb4": "写备注",

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -19,10 +19,7 @@ import {
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
 import { launchAgentInWebHostTab } from '@/lib/launch-agent-web-host-tab'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../shared/tui-agent-launch-defaults'
+import { resolveNewTabAgentLaunch } from '@/lib/launch-agent-profile'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
@@ -49,6 +46,8 @@ export type LaunchAgentInNewTabArgs = {
   prompt?: string
   /** Optional CLI arguments appended to the selected agent command. */
   agentArgs?: string | null
+  /** Built-in or user-defined launch profile for `agent`; unknown ids fail the launch. */
+  launchProfileId?: string | null
   initialCwd?: string | null
   /** How to deliver the prompt: `draft` leaves it editable, `submit-after-ready` sends it once the TUI is ready. */
   promptDelivery?: 'auto-submit' | 'draft' | 'submit-after-ready'
@@ -97,6 +96,7 @@ function launchAgentInNewTabInternal(
     groupId,
     prompt,
     agentArgs,
+    launchProfileId,
     initialCwd,
     promptDelivery = 'auto-submit',
     launchSource,
@@ -130,11 +130,10 @@ function launchAgentInNewTabInternal(
     terminalWindowsShell: store.settings?.terminalWindowsShell
   })
   const cmdOverrides = store.settings?.agentCmdOverrides ?? {}
-  const effectiveAgentArgs =
-    agentArgs !== undefined
-      ? agentArgs
-      : resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
-  const agentEnv = resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv)
+  const agentLaunch = resolveNewTabAgentLaunch(store.settings, agent, agentArgs, launchProfileId)
+  if (!agentLaunch) {
+    return null
+  }
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
   const isFollowupPath = TUI_AGENT_CONFIG[agent].promptInjectionMode === 'stdin-after-start'
@@ -155,8 +154,8 @@ function launchAgentInNewTabInternal(
     platform: resolvedLaunchPlatform,
     shell: queuedShell,
     isRemote,
-    agentArgs: effectiveAgentArgs,
-    agentEnv,
+    agentArgs: agentLaunch.agentArgs,
+    agentEnv: agentLaunch.agentEnv,
     sessionOptions: resolveInitialNativeChatSessionOptions(store.settings, initialViewModeOptions)
   }
   const { startupPlan, pasteDraftAfterLaunch, submitPastedPrompt } = planLaunchAgentStartupPrompt({
@@ -185,6 +184,7 @@ function launchAgentInNewTabInternal(
       pastePromptAfterReady: pasteDraftAfterLaunch,
       submitPastedPrompt,
       agentArgs,
+      ...(agentLaunch.launchProfileId ? { launchProfileId: agentLaunch.launchProfileId } : {}),
       // Why: omission means terminal locally, but would let a paired host apply
       // its own default; send the client's resolved terminal choice explicitly.
       viewMode: initialViewModeProps.viewMode ?? 'terminal',

--- a/src/renderer/src/lib/launch-agent-profile.test.ts
+++ b/src/renderer/src/lib/launch-agent-profile.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { resolveNewTabAgentLaunch } from './launch-agent-profile'
+
+describe('resolveNewTabAgentLaunch', () => {
+  const settings = {
+    agentDefaultArgs: { codex: '--full-auto' },
+    agentDefaultEnv: { codex: { CODEX_DEFAULT: '1' } },
+    agentLaunchProfiles: [{ id: 'codex-work', agent: 'codex' as const, args: '-c model="x"' }]
+  }
+
+  it('keeps the plain launch on the agent defaults', () => {
+    expect(resolveNewTabAgentLaunch(settings, 'codex', undefined, undefined)).toEqual({
+      agentArgs: '--full-auto',
+      agentEnv: { CODEX_DEFAULT: '1' }
+    })
+  })
+
+  it('preserves an explicit args override, including null', () => {
+    expect(resolveNewTabAgentLaunch(settings, 'codex', null, undefined)?.agentArgs).toBeNull()
+    expect(resolveNewTabAgentLaunch(settings, 'codex', '--x', undefined)?.agentArgs).toBe('--x')
+  })
+
+  it('layers a built-in profile and echoes its id', () => {
+    const launch = resolveNewTabAgentLaunch(settings, 'codex', undefined, 'codex-secondary-home')
+    expect(launch).toEqual({
+      agentArgs: '--full-auto',
+      agentEnv: {
+        CODEX_DEFAULT: '1',
+        ORCA_AGENT_LAUNCH_PROFILE: 'codex-secondary-home',
+        ORCA_CODEX_HOME_PROFILE: 'codex-secondary-home'
+      },
+      launchProfileId: 'codex-secondary-home'
+    })
+  })
+
+  it('appends custom profile args after the defaults', () => {
+    expect(resolveNewTabAgentLaunch(settings, 'codex', undefined, 'codex-work')?.agentArgs).toBe(
+      '--full-auto -c model="x"'
+    )
+  })
+
+  it('fails the launch for an unknown or foreign profile', () => {
+    expect(resolveNewTabAgentLaunch(settings, 'codex', undefined, 'nope')).toBeNull()
+    expect(resolveNewTabAgentLaunch(settings, 'claude', undefined, 'codex-work')).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/launch-agent-profile.test.ts
+++ b/src/renderer/src/lib/launch-agent-profile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveNewTabAgentLaunch } from './launch-agent-profile'
+import {
+  resolveAgentLaunchWithProfileFallback,
+  resolveNewTabAgentLaunch
+} from './launch-agent-profile'
 
 describe('resolveNewTabAgentLaunch', () => {
   const settings = {
@@ -42,5 +45,15 @@ describe('resolveNewTabAgentLaunch', () => {
   it('fails the launch for an unknown or foreign profile', () => {
     expect(resolveNewTabAgentLaunch(settings, 'codex', undefined, 'nope')).toBeNull()
     expect(resolveNewTabAgentLaunch(settings, 'claude', undefined, 'codex-work')).toBeNull()
+  })
+
+  it('falls back to the default launch for a stale profile id', () => {
+    const launch = resolveAgentLaunchWithProfileFallback(settings, 'codex', 'codex-gone')
+    expect(launch.launchProfileId).toBeUndefined()
+    expect(launch.agentEnv.ORCA_AGENT_LAUNCH_PROFILE).toBeUndefined()
+    expect(
+      resolveAgentLaunchWithProfileFallback(settings, 'codex', 'codex-secondary-home')
+        .launchProfileId
+    ).toBe('codex-secondary-home')
   })
 })

--- a/src/renderer/src/lib/launch-agent-profile.ts
+++ b/src/renderer/src/lib/launch-agent-profile.ts
@@ -1,0 +1,56 @@
+import {
+  applyAgentLaunchProfile,
+  findAgentLaunchProfile,
+  resolveAgentLaunchProfiles
+} from '../../../shared/agent-launch-profile/agent-launch-profile'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../shared/tui-agent-launch-defaults'
+
+export type NewTabAgentLaunch = {
+  agentArgs: string | null
+  agentEnv: Record<string, string>
+  /** Echoed only when a profile applied, so the host re-validates the same id. */
+  launchProfileId?: string
+}
+
+/**
+ * Resolves the args/env a new agent tab launches with, layering an optional launch profile
+ * over the agent defaults. Returns null when `launchProfileId` names no profile for `agent`,
+ * which the caller reports like any other unbuildable launch.
+ */
+export function resolveNewTabAgentLaunch(
+  settings:
+    | Pick<GlobalSettings, 'agentDefaultArgs' | 'agentDefaultEnv' | 'agentLaunchProfiles'>
+    | null
+    | undefined,
+  agent: TuiAgent,
+  agentArgs: string | null | undefined,
+  launchProfileId: string | null | undefined
+): NewTabAgentLaunch | null {
+  const effectiveAgentArgs =
+    agentArgs !== undefined
+      ? agentArgs
+      : resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs)
+  const agentEnv = resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv)
+  if (!launchProfileId) {
+    return { agentArgs: effectiveAgentArgs, agentEnv }
+  }
+  const profile = findAgentLaunchProfile(
+    resolveAgentLaunchProfiles(settings?.agentLaunchProfiles),
+    agent,
+    launchProfileId
+  )
+  if (!profile) {
+    return null
+  }
+  const launch = applyAgentLaunchProfile({
+    profile,
+    agentArgs: effectiveAgentArgs ?? '',
+    agentEnv
+  })
+  return { agentArgs: launch.agentArgs, agentEnv: launch.agentEnv, launchProfileId: profile.id }
+}

--- a/src/renderer/src/lib/launch-agent-profile.ts
+++ b/src/renderer/src/lib/launch-agent-profile.ts
@@ -54,3 +54,19 @@ export function resolveNewTabAgentLaunch(
   })
   return { agentArgs: launch.agentArgs, agentEnv: launch.agentEnv, launchProfileId: profile.id }
 }
+
+/**
+ * Same resolution for flows that must not block on a stale id: settings can change under an
+ * open composer, and its picker repairs itself on the next render, so the default launch is
+ * the right answer for the one submit that raced it.
+ */
+export function resolveAgentLaunchWithProfileFallback(
+  settings: Parameters<typeof resolveNewTabAgentLaunch>[0],
+  agent: TuiAgent,
+  launchProfileId: string | null | undefined
+): NewTabAgentLaunch {
+  return (
+    resolveNewTabAgentLaunch(settings, agent, undefined, launchProfileId) ??
+    resolveNewTabAgentLaunch(settings, agent, undefined, null)!
+  )
+}

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -44,6 +44,7 @@ export function launchAgentInWebHostTab(args: {
   pastePromptAfterReady: string | null
   submitPastedPrompt: boolean
   agentArgs?: string | null
+  launchProfileId?: string
   viewMode?: Tab['viewMode']
   onPromptDelivered?: () => void
 }): Promise<{ delivered: boolean; failureNotified: boolean }> {
@@ -59,6 +60,7 @@ export function launchAgentInWebHostTab(args: {
     pastePromptAfterReady,
     submitPastedPrompt,
     agentArgs,
+    launchProfileId,
     viewMode,
     onPromptDelivered
   } = args
@@ -91,6 +93,7 @@ export function launchAgentInWebHostTab(args: {
       ? { promptDelivery: structuredPromptDelivery }
       : {}),
     ...(agentArgs !== undefined ? { agentArgs } : {}),
+    ...(launchProfileId ? { launchProfileId } : {}),
     ...(launchPreferences ? { launchPreferences } : {})
   } as const
 

--- a/src/renderer/src/runtime/web-runtime-launch-profile-support.ts
+++ b/src/renderer/src/runtime/web-runtime-launch-profile-support.ts
@@ -1,0 +1,28 @@
+import { AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import { translate } from '../i18n/i18n'
+import { runtimeEnvironmentSupportsCapability } from './runtime-rpc-client'
+
+/**
+ * Why: the legacy terminal create carries a launch profile only as env, so a host that cannot
+ * validate the id would launch it unchecked. Refuse on such hosts instead of falling through.
+ */
+export async function assertWebRuntimeLaunchProfileSupported(
+  environmentId: string,
+  launchProfileId: string | undefined
+): Promise<void> {
+  if (!launchProfileId) {
+    return
+  }
+  const supported = await runtimeEnvironmentSupportsCapability(
+    environmentId,
+    AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY
+  )
+  if (!supported) {
+    throw new Error(
+      translate(
+        'auto.runtime.webRuntimeSession.launchProfileUnsupported',
+        'This Orca host is too old to launch agent profiles. Update the host and try again.'
+      )
+    )
+  }
+}

--- a/src/renderer/src/runtime/web-runtime-session-types.ts
+++ b/src/renderer/src/runtime/web-runtime-session-types.ts
@@ -33,6 +33,8 @@ export type CreateWebRuntimeSessionTerminalArgs = {
   promptDelivery?: AgentPromptDelivery
   /** Explicit CLI override; omission leaves the remote host's defaults authoritative. */
   agentArgs?: string | null
+  /** Host-validated launch profile; requires the launch-profile capability on the host. */
+  launchProfileId?: string
   launchPreferences?: AgentLaunchPreferences
   providerSession?: AgentProviderSessionMetadata
   viewMode?: 'terminal' | 'chat'

--- a/src/renderer/src/runtime/web-runtime-terminal-create-operation.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-create-operation.ts
@@ -14,6 +14,8 @@ import {
 } from './agent-session-create-operation'
 import { runRemoteAgentSessionLaunch } from './remote-agent-session-launch'
 import { unwrapRuntimeRpcResult } from './runtime-rpc-client'
+import { AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import { assertWebRuntimeLaunchProfileSupported } from './web-runtime-launch-profile-support'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 import { resolveWebRuntimeSessionEnvironmentId } from './web-runtime-session-workspace-routing'
 import { recordWebSessionFocusIntent } from './web-session-focus-intent'
@@ -128,6 +130,7 @@ export async function createWebRuntimeSessionTerminalResult(
                         ...(agentArgsOverride !== undefined
                           ? { agentArgs: agentArgsOverride }
                           : {}),
+                        ...(args.launchProfileId ? { launchProfileId: args.launchProfileId } : {}),
                         ...(args.launchPreferences
                           ? { launchPreferences: args.launchPreferences }
                           : {}),
@@ -141,17 +144,20 @@ export async function createWebRuntimeSessionTerminalResult(
                   })) as RuntimeRpcResponse<RuntimeCreateAgentSessionResult>
                 )
               )
-      const resumeHostAuthorityCapability =
-        args.agentSessionKind === 'resume' ? agentResumeHostAuthorityCapability(agent) : undefined
+      const hostAuthorityCapability =
+        args.agentSessionKind === 'resume'
+          ? agentResumeHostAuthorityCapability(agent)
+          : args.launchProfileId
+            ? AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY
+            : undefined
       const created = await runRemoteAgentSessionLaunch<{
         terminal: CreatedAgentTerminalIdentity
       }>({
         environmentId,
         ...(hostAuthority ? { hostAuthority } : {}),
-        ...(resumeHostAuthorityCapability
-          ? { hostAuthorityCapability: resumeHostAuthorityCapability }
-          : {}),
+        ...(hostAuthorityCapability ? { hostAuthorityCapability } : {}),
         legacy: async () => {
+          await assertWebRuntimeLaunchProfileSupported(environmentId, args.launchProfileId)
           const response = await callEnvironment({
             method: 'session.tabs.createTerminal',
             params: {
@@ -167,6 +173,7 @@ export async function createWebRuntimeSessionTerminalResult(
               ...(args.launchToken ? { launchToken: args.launchToken } : {}),
               ...(args.agent ? { agent: args.agent } : {}),
               ...(args.launchAgent ? { launchAgent: args.launchAgent } : {}),
+              ...(args.launchProfileId ? { launchProfileId: args.launchProfileId } : {}),
               ...(args.viewMode ? { viewMode: args.viewMode } : {}),
               // Why: old hosts understand activate:false; new hosts use select/navigation for caller-local focus.
               activate: false,

--- a/src/shared/agent-launch-profile/agent-launch-profile.test.ts
+++ b/src/shared/agent-launch-profile/agent-launch-profile.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_LAUNCH_PROFILE_ENV,
+  BUILT_IN_AGENT_LAUNCH_PROFILES,
+  CLAUDE_SECONDARY_HOME_PROFILE_ID,
+  CODEX_SECONDARY_HOME_PROFILE_ID,
+  agentLaunchProfileHomeMarkerEnv,
+  agentLaunchProfileIdFromEnv,
+  agentLaunchProfilesForAgent,
+  applyAgentLaunchProfile,
+  findAgentLaunchProfile,
+  hasAgentLaunchProfileHomeMarker,
+  isAgentLaunchProfileId,
+  normalizeAgentLaunchProfileSettings,
+  resolveAgentLaunchProfiles
+} from './agent-launch-profile'
+
+describe('agent launch profiles', () => {
+  it('ships one secondary-home profile per credential-home agent', () => {
+    expect(BUILT_IN_AGENT_LAUNCH_PROFILES.map((profile) => profile.id)).toEqual([
+      CODEX_SECONDARY_HOME_PROFILE_ID,
+      CLAUDE_SECONDARY_HOME_PROFILE_ID
+    ])
+    for (const profile of BUILT_IN_AGENT_LAUNCH_PROFILES) {
+      expect(profile.source).toBe('built-in')
+      expect(profile.home).toBeDefined()
+      expect(profile.args).toBeUndefined()
+    }
+  })
+
+  it('derives the marker from the home env var so a new family needs no constant', () => {
+    expect(agentLaunchProfileHomeMarkerEnv('CODEX_HOME')).toBe('ORCA_CODEX_HOME_PROFILE')
+    expect(agentLaunchProfileHomeMarkerEnv('CLAUDE_CONFIG_DIR')).toBe(
+      'ORCA_CLAUDE_CONFIG_DIR_PROFILE'
+    )
+  })
+
+  it('accepts slug ids only', () => {
+    expect(isAgentLaunchProfileId('codex-provider-work')).toBe(true)
+    expect(isAgentLaunchProfileId('Codex')).toBe(false)
+    expect(isAgentLaunchProfileId('-leading')).toBe(false)
+    expect(isAgentLaunchProfileId('a'.repeat(65))).toBe(false)
+    expect(isAgentLaunchProfileId('')).toBe(false)
+  })
+
+  it('normalizes custom rows and refuses to shadow built-ins or duplicate ids', () => {
+    const rows = normalizeAgentLaunchProfileSettings([
+      { id: 'codex-secondary-home', agent: 'codex', label: 'shadow' },
+      { id: 'codex-work', agent: 'codex', label: '  Work  ', args: ' -c model="gpt-5" ' },
+      { id: 'codex-work', agent: 'codex', label: 'duplicate' },
+      { id: 'claude-proxy', agent: 'claude', env: { ANTHROPIC_BASE_URL: 'https://p', ' ': 'x' } },
+      { id: 'bad id', agent: 'codex' },
+      { id: 'unknown-agent', agent: 'nope' },
+      null,
+      'string'
+    ])
+    expect(rows).toEqual([
+      { id: 'codex-work', agent: 'codex', label: 'Work', args: '-c model="gpt-5"' },
+      { id: 'claude-proxy', agent: 'claude', env: { ANTHROPIC_BASE_URL: 'https://p' } }
+    ])
+  })
+
+  it('resolves built-ins first, then custom rows with the id as fallback label', () => {
+    const profiles = resolveAgentLaunchProfiles([{ id: 'codex-work', agent: 'codex' }])
+    expect(profiles.map((profile) => profile.id)).toEqual([
+      CODEX_SECONDARY_HOME_PROFILE_ID,
+      CLAUDE_SECONDARY_HOME_PROFILE_ID,
+      'codex-work'
+    ])
+    expect(profiles[2]).toMatchObject({ label: 'codex-work', source: 'custom' })
+    expect(agentLaunchProfilesForAgent(profiles, 'codex').map((profile) => profile.id)).toEqual([
+      CODEX_SECONDARY_HOME_PROFILE_ID,
+      'codex-work'
+    ])
+  })
+
+  it('rejects a profile that belongs to another agent', () => {
+    const profiles = resolveAgentLaunchProfiles([])
+    expect(findAgentLaunchProfile(profiles, 'claude', CODEX_SECONDARY_HOME_PROFILE_ID)).toBeNull()
+    expect(findAgentLaunchProfile(profiles, 'codex', CODEX_SECONDARY_HOME_PROFILE_ID)?.id).toBe(
+      CODEX_SECONDARY_HOME_PROFILE_ID
+    )
+    expect(findAgentLaunchProfile(profiles, 'codex', undefined)).toBeNull()
+  })
+
+  it('layers args after configured args and stamps the profile and home marker into env', () => {
+    const profiles = resolveAgentLaunchProfiles([
+      { id: 'codex-work', agent: 'codex', args: '-c model_provider="work"', env: { WORK_KEY: '1' } }
+    ])
+    const secondary = applyAgentLaunchProfile({
+      profile: findAgentLaunchProfile(profiles, 'codex', CODEX_SECONDARY_HOME_PROFILE_ID),
+      agentArgs: '--full-auto',
+      agentEnv: { EXISTING: 'yes' }
+    })
+    expect(secondary.agentArgs).toBe('--full-auto')
+    expect(secondary.agentEnv).toEqual({
+      EXISTING: 'yes',
+      [AGENT_LAUNCH_PROFILE_ENV]: CODEX_SECONDARY_HOME_PROFILE_ID,
+      ORCA_CODEX_HOME_PROFILE: CODEX_SECONDARY_HOME_PROFILE_ID
+    })
+    const custom = applyAgentLaunchProfile({
+      profile: findAgentLaunchProfile(profiles, 'codex', 'codex-work'),
+      agentArgs: '--full-auto',
+      agentEnv: { WORK_KEY: 'default' }
+    })
+    expect(custom.agentArgs).toBe('--full-auto -c model_provider="work"')
+    expect(custom.agentEnv).toEqual({ WORK_KEY: '1', [AGENT_LAUNCH_PROFILE_ENV]: 'codex-work' })
+    expect(hasAgentLaunchProfileHomeMarker(custom.agentEnv, 'CODEX_HOME')).toBe(false)
+    expect(hasAgentLaunchProfileHomeMarker(secondary.agentEnv, 'CODEX_HOME')).toBe(true)
+    expect(agentLaunchProfileIdFromEnv(custom.agentEnv)).toBe('codex-work')
+    expect(agentLaunchProfileIdFromEnv({})).toBeNull()
+  })
+
+  it('leaves a plain launch byte-identical', () => {
+    const agentEnv = { A: '1' }
+    const result = applyAgentLaunchProfile({ profile: null, agentArgs: '--x', agentEnv })
+    expect(result.agentArgs).toBe('--x')
+    expect(result.agentEnv).toBe(agentEnv)
+  })
+})

--- a/src/shared/agent-launch-profile/agent-launch-profile.test.ts
+++ b/src/shared/agent-launch-profile/agent-launch-profile.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  resolveAgentLaunchProfilesForPicker,
   AGENT_LAUNCH_PROFILE_ENV,
   BUILT_IN_AGENT_LAUNCH_PROFILES,
   CLAUDE_SECONDARY_HOME_PROFILE_ID,
@@ -116,5 +117,18 @@ describe('agent launch profiles', () => {
     const result = applyAgentLaunchProfile({ profile: null, agentArgs: '--x', agentEnv })
     expect(result.agentArgs).toBe('--x')
     expect(result.agentEnv).toBe(agentEnv)
+  })
+})
+
+describe('resolveAgentLaunchProfilesForPicker', () => {
+  it('hides every profile, built-ins included, until the setting is on', () => {
+    const custom = [{ id: 'codex-work', agent: 'codex' as const }]
+    expect(resolveAgentLaunchProfilesForPicker({ agentLaunchProfiles: custom })).toEqual([])
+    expect(
+      resolveAgentLaunchProfilesForPicker({
+        agentLaunchProfiles: custom,
+        agentLaunchProfilesEnabled: true
+      }).map((profile) => profile.id)
+    ).toEqual(['codex-secondary-home', 'claude-secondary-home', 'codex-work'])
   })
 })

--- a/src/shared/agent-launch-profile/agent-launch-profile.ts
+++ b/src/shared/agent-launch-profile/agent-launch-profile.ts
@@ -223,3 +223,24 @@ export function hasAgentLaunchProfileHomeMarker(
 ): boolean {
   return isAgentLaunchProfileId(env?.[agentLaunchProfileHomeMarkerEnv(envVar)])
 }
+
+export type AgentLaunchProfilePickerSettings = {
+  agentLaunchProfiles?: readonly AgentLaunchProfileSetting[] | null
+  agentLaunchProfilesEnabled?: boolean
+}
+
+/** Pickers stay hidden until the user opts in; RPC and CLI accept profile ids either way. */
+export function isAgentLaunchProfilePickerEnabled(
+  settings: AgentLaunchProfilePickerSettings | null | undefined
+): boolean {
+  return settings?.agentLaunchProfilesEnabled === true
+}
+
+/** The catalog a picker may show: empty while the setting is off. */
+export function resolveAgentLaunchProfilesForPicker(
+  settings: AgentLaunchProfilePickerSettings | null | undefined
+): AgentLaunchProfile[] {
+  return isAgentLaunchProfilePickerEnabled(settings)
+    ? resolveAgentLaunchProfiles(settings?.agentLaunchProfiles)
+    : []
+}

--- a/src/shared/agent-launch-profile/agent-launch-profile.ts
+++ b/src/shared/agent-launch-profile/agent-launch-profile.ts
@@ -1,0 +1,225 @@
+import { isTuiAgent } from '../tui-agent-config'
+import type { TuiAgent } from '../tui-agent'
+
+// An agent launch profile pins one launch of a CLI agent to a credential home
+// and/or process-local overrides, so one host can run the same agent under
+// several accounts or model providers at the same time. Selection is per launch,
+// never a global slot, which is what lets two panes differ.
+
+export const AGENT_LAUNCH_PROFILE_ID_MAX_LENGTH = 64
+const AGENT_LAUNCH_PROFILE_ID_RE = /^[a-z0-9][a-z0-9-]*$/
+const AGENT_LAUNCH_PROFILE_LABEL_MAX_LENGTH = 80
+const AGENT_LAUNCH_PROFILE_ARGS_MAX_LENGTH = 4_000
+const AGENT_LAUNCH_PROFILE_ENV_MAX_ENTRIES = 32
+const AGENT_LAUNCH_PROFILE_ENV_VALUE_MAX_LENGTH = 4_000
+const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+/** Env var each CLI reads its credential home from; the whole credential lives there. */
+export type AgentLaunchProfileHomeEnvVar = 'CODEX_HOME' | 'CLAUDE_CONFIG_DIR'
+
+export type AgentLaunchProfileHome = {
+  envVar: AgentLaunchProfileHomeEnvVar
+  /** Directory under the execution host's home when `overrideEnv` is unset. */
+  dirName: string
+  /** Host-side env var that relocates the directory (absolute path). */
+  overrideEnv: string
+}
+
+export type AgentLaunchProfile = {
+  id: string
+  agent: TuiAgent
+  label: string
+  source: 'built-in' | 'custom'
+  /** Appended after the agent's configured args; tokenized for the launch shell like `agentDefaultArgs`. */
+  args?: string
+  env?: Record<string, string>
+  /** Present only for secondary-home profiles; resolved on the execution host. */
+  home?: AgentLaunchProfileHome
+}
+
+/** Exported into every profile launch so hooks and status can attribute the pane. */
+export const AGENT_LAUNCH_PROFILE_ENV = 'ORCA_AGENT_LAUNCH_PROFILE'
+
+/** Marker carried by a launch; only the execution host turns it into a real path. */
+export function agentLaunchProfileHomeMarkerEnv(envVar: AgentLaunchProfileHomeEnvVar): string {
+  return `ORCA_${envVar}_PROFILE`
+}
+
+export const CODEX_SECONDARY_HOME_PROFILE_ID = 'codex-secondary-home'
+export const CLAUDE_SECONDARY_HOME_PROFILE_ID = 'claude-secondary-home'
+
+export const BUILT_IN_AGENT_LAUNCH_PROFILES: readonly AgentLaunchProfile[] = [
+  {
+    id: CODEX_SECONDARY_HOME_PROFILE_ID,
+    agent: 'codex',
+    label: 'Codex · secondary home',
+    source: 'built-in',
+    home: { envVar: 'CODEX_HOME', dirName: '.codex-2', overrideEnv: 'ORCA_CODEX_SECONDARY_HOME' }
+  },
+  {
+    id: CLAUDE_SECONDARY_HOME_PROFILE_ID,
+    agent: 'claude',
+    label: 'Claude Code · secondary home',
+    source: 'built-in',
+    home: {
+      envVar: 'CLAUDE_CONFIG_DIR',
+      dirName: '.claude-2',
+      overrideEnv: 'ORCA_CLAUDE_SECONDARY_HOME'
+    }
+  }
+]
+
+const BUILT_IN_IDS: ReadonlySet<string> = new Set(
+  BUILT_IN_AGENT_LAUNCH_PROFILES.map((profile) => profile.id)
+)
+
+export function isAgentLaunchProfileId(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= AGENT_LAUNCH_PROFILE_ID_MAX_LENGTH &&
+    AGENT_LAUNCH_PROFILE_ID_RE.test(value)
+  )
+}
+
+/** User-defined profile as persisted in settings. Env values are plain strings, like `agentDefaultEnv`. */
+export type AgentLaunchProfileSetting = {
+  id: string
+  agent: TuiAgent
+  label?: string
+  args?: string
+  env?: Record<string, string>
+}
+
+function normalizeProfileEnv(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const env: Record<string, string> = {}
+  for (const [rawName, raw] of Object.entries(value)) {
+    const name = rawName.trim()
+    if (
+      !ENV_NAME_RE.test(name) ||
+      typeof raw !== 'string' ||
+      raw.length > AGENT_LAUNCH_PROFILE_ENV_VALUE_MAX_LENGTH ||
+      Object.keys(env).length >= AGENT_LAUNCH_PROFILE_ENV_MAX_ENTRIES
+    ) {
+      continue
+    }
+    env[name] = raw
+  }
+  return Object.keys(env).length > 0 ? env : undefined
+}
+
+/** Drops malformed rows instead of failing the whole settings write; built-in ids cannot be shadowed. */
+export function normalizeAgentLaunchProfileSettings(value: unknown): AgentLaunchProfileSetting[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const seen = new Set<string>()
+  const normalized: AgentLaunchProfileSetting[] = []
+  for (const row of value) {
+    if (!row || typeof row !== 'object') {
+      continue
+    }
+    const candidate = row as Partial<AgentLaunchProfileSetting>
+    if (
+      !isAgentLaunchProfileId(candidate.id) ||
+      BUILT_IN_IDS.has(candidate.id) ||
+      seen.has(candidate.id) ||
+      !isTuiAgent(candidate.agent)
+    ) {
+      continue
+    }
+    const label =
+      typeof candidate.label === 'string' && candidate.label.trim()
+        ? candidate.label.trim().slice(0, AGENT_LAUNCH_PROFILE_LABEL_MAX_LENGTH)
+        : undefined
+    const args =
+      typeof candidate.args === 'string' && candidate.args.trim()
+        ? candidate.args.trim().slice(0, AGENT_LAUNCH_PROFILE_ARGS_MAX_LENGTH)
+        : undefined
+    const env = normalizeProfileEnv(candidate.env)
+    seen.add(candidate.id)
+    normalized.push({
+      id: candidate.id,
+      agent: candidate.agent,
+      ...(label ? { label } : {}),
+      ...(args ? { args } : {}),
+      ...(env ? { env } : {})
+    })
+  }
+  return normalized
+}
+
+/** Built-ins first, then custom rows in settings order. */
+export function resolveAgentLaunchProfiles(
+  custom: readonly AgentLaunchProfileSetting[] | null | undefined
+): AgentLaunchProfile[] {
+  const customProfiles = (custom ?? []).map((row): AgentLaunchProfile => ({
+    id: row.id,
+    agent: row.agent,
+    label: row.label ?? row.id,
+    source: 'custom',
+    ...(row.args ? { args: row.args } : {}),
+    ...(row.env ? { env: { ...row.env } } : {})
+  }))
+  return [...BUILT_IN_AGENT_LAUNCH_PROFILES, ...customProfiles]
+}
+
+export function agentLaunchProfilesForAgent(
+  profiles: readonly AgentLaunchProfile[],
+  agent: TuiAgent
+): AgentLaunchProfile[] {
+  return profiles.filter((profile) => profile.agent === agent)
+}
+
+/** Null when the id is unknown or belongs to another agent; callers decide which error to raise. */
+export function findAgentLaunchProfile(
+  profiles: readonly AgentLaunchProfile[],
+  agent: TuiAgent,
+  id: string | null | undefined
+): AgentLaunchProfile | null {
+  if (!id) {
+    return null
+  }
+  return profiles.find((profile) => profile.id === id && profile.agent === agent) ?? null
+}
+
+/** Layers a profile over the resolved launch args/env. Profile env wins over agent defaults. */
+export function applyAgentLaunchProfile(opts: {
+  profile: AgentLaunchProfile | null
+  agentArgs: string
+  agentEnv: Record<string, string>
+}): { agentArgs: string; agentEnv: Record<string, string> } {
+  const { profile, agentArgs, agentEnv } = opts
+  if (!profile) {
+    return { agentArgs, agentEnv }
+  }
+  return {
+    agentArgs: [agentArgs.trim(), profile.args?.trim()].filter(Boolean).join(' '),
+    agentEnv: {
+      ...agentEnv,
+      ...profile.env,
+      [AGENT_LAUNCH_PROFILE_ENV]: profile.id,
+      ...(profile.home
+        ? { [agentLaunchProfileHomeMarkerEnv(profile.home.envVar)]: profile.id }
+        : {})
+    }
+  }
+}
+
+/** Profile id a launch env carries, or null for a plain launch. */
+export function agentLaunchProfileIdFromEnv(
+  env: Record<string, string> | NodeJS.ProcessEnv | null | undefined
+): string | null {
+  const id = env?.[AGENT_LAUNCH_PROFILE_ENV]
+  return isAgentLaunchProfileId(id) ? id : null
+}
+
+/** True when the launch asks the execution host to relocate this credential home. */
+export function hasAgentLaunchProfileHomeMarker(
+  env: Record<string, string> | NodeJS.ProcessEnv | null | undefined,
+  envVar: AgentLaunchProfileHomeEnvVar
+): boolean {
+  return isAgentLaunchProfileId(env?.[agentLaunchProfileHomeMarkerEnv(envVar)])
+}

--- a/src/shared/agent-session-host-authority.ts
+++ b/src/shared/agent-session-host-authority.ts
@@ -128,6 +128,8 @@ export type RuntimeCreateAgentSessionRequest = {
   /** Explicit client override. Omission keeps launch defaults host-owned. */
   agentArgs?: string | null
   launchPreferences?: AgentLaunchPreferences
+  /** Built-in or user-defined launch profile; the host validates it against `agent`. */
+  launchProfileId?: string
   startupCwd?: string
   presentation?: RuntimeTerminalPresentation
   placement?: { tabId?: string; leafId?: string }

--- a/src/shared/agent-status-ipc-payload.ts
+++ b/src/shared/agent-status-ipc-payload.ts
@@ -26,6 +26,8 @@ export type MigrationUnsupportedPtyEntry = {
 export type AgentStatusIpcPayload = ParsedAgentStatusPayload & {
   paneKey: string
   launchToken?: string
+  /** Agent launch profile the pane spawned under, stamped by main from the spawn record. */
+  launchProfileId?: string
   terminalHandle?: string
   tabId?: string
   worktreeId?: string

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -117,6 +117,8 @@ export type AgentStatusEntry = {
   agentType?: AgentType
   /** Provider model currently used by this session. */
   model?: string
+  /** Agent launch profile the pane spawned under (secondary home, custom provider); absent for plain launches. */
+  launchProfileId?: string
   /** Composite key: `${tabId}:${leafId}` where leafId is a stable UUID layout leaf. */
   paneKey: string
   /** Runtime terminal handle for matching retained parent rows when the parent

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -1,3 +1,4 @@
+import type { AgentLaunchProfileSetting } from './agent-launch-profile/agent-launch-profile'
 import type { ExecutionHostId } from './execution-host'
 import type { GitHubProjectSettings } from './github/project-types'
 import type { VoiceSettings } from './speech-types'
@@ -376,6 +377,8 @@ export type GlobalSettings = {
   agentDefaultArgs?: Partial<Record<TuiAgent, string>>
   /** Per-agent launch environment defaults used when yolo mode is exposed as env. */
   agentDefaultEnv?: Partial<Record<TuiAgent, Record<string, string>>>
+  /** User-defined launch profiles (args/env per launch) on top of the built-in secondary homes. */
+  agentLaunchProfiles?: AgentLaunchProfileSetting[]
   /** One-shot guard for adding yolo-mode default args to untouched agent launch profiles. */
   agentYoloDefaultsMigrated?: boolean
   /** Why: disabling must persist so startup doesn't reinstall global agent hook entries the user just removed. */

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -379,6 +379,8 @@ export type GlobalSettings = {
   agentDefaultEnv?: Partial<Record<TuiAgent, Record<string, string>>>
   /** User-defined launch profiles (args/env per launch) on top of the built-in secondary homes. */
   agentLaunchProfiles?: AgentLaunchProfileSetting[]
+  /** Shows launch-profile choices in the tab bar, composer and mobile picker; hosts accept ids regardless. */
+  agentLaunchProfilesEnabled?: boolean
   /** One-shot guard for adding yolo-mode default args to untouched agent launch profiles. */
   agentYoloDefaultsMigrated?: boolean
   /** Why: disabling must persist so startup doesn't reinstall global agent hook entries the user just removed. */

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -134,6 +134,9 @@ export const STRUCTURED_AGENT_SESSION_HOLD_RUNTIME_CAPABILITY =
 // older host answers the unknown member with invalid_argument — a code the launch fallback does
 // not retry on — so clients must probe before taking the host-authority path.
 export const AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1' as const
+/** Host validates `launchProfileId` on agent-session creation; older hosts reject the unknown field. */
+export const AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY =
+  'agent-session.launch-profile.v1' as const
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
@@ -227,6 +230,7 @@ export const RUNTIME_CAPABILITIES = [
   STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY,
   STRUCTURED_AGENT_SESSION_HOLD_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  AGENT_SESSION_LAUNCH_PROFILE_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   GITHUB_MARK_PR_READY_RUNTIME_CAPABILITY,
   GITLAB_READY_FOR_REVIEW_RUNTIME_CAPABILITY,

--- a/tests/e2e/agent-launch-profile-conformance.spec.ts
+++ b/tests/e2e/agent-launch-profile-conformance.spec.ts
@@ -1,0 +1,175 @@
+import { randomBytes } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { RuntimeTerminalRead } from '../../src/shared/runtime-terminal-contracts'
+import { expect, test } from './helpers/orca-app'
+import {
+  launchHeadlessPairedRuntimeHost,
+  type HeadlessPairedRuntimeHost
+} from './helpers/headless-paired-runtime-host'
+
+// Host-contract conformance for agent launch profiles. Everything is asserted over the
+// runtime RPC, so the same expectations hold for any client (desktop, paired web, mobile, CLI)
+// that reaches this host: a fake agent echoes the env the profile is supposed to produce.
+
+type LaunchProfileEcho = {
+  codexHome: string | null
+  claudeConfigDir: string | null
+  profile: string | null
+  codexMarker: string | null
+  claudeMarker: string | null
+}
+
+const ECHO_PREFIX = 'LAUNCH_PROFILE_ENV:'
+
+function operationId(): string {
+  return `${Date.now()}-${randomBytes(16).toString('hex')}`
+}
+
+function fixtureCommand(fixturePath: string): string {
+  return process.platform === 'win32'
+    ? `& "${process.execPath.replaceAll('"', '`"')}" "${fixturePath.replaceAll('"', '`"')}"`
+    : `'${process.execPath.replaceAll("'", `'\\''`)}' '${fixturePath.replaceAll("'", `'\\''`)}'`
+}
+
+async function readEcho(
+  host: HeadlessPairedRuntimeHost,
+  handle: string
+): Promise<LaunchProfileEcho> {
+  let echo: LaunchProfileEcho | null = null
+  await expect
+    .poll(
+      async () => {
+        const read = await host.client.call<{ terminal: RuntimeTerminalRead }>('terminal.read', {
+          terminal: handle,
+          limit: 200
+        })
+        const line = read.result.terminal.tail.find((entry) => entry.includes(ECHO_PREFIX))
+        if (!line) {
+          return null
+        }
+        echo = JSON.parse(
+          line.slice(line.indexOf(ECHO_PREFIX) + ECHO_PREFIX.length)
+        ) as LaunchProfileEcho
+        return echo
+      },
+      { timeout: 30_000, message: `terminal ${handle} never echoed its launch env` }
+    )
+    .not.toBeNull()
+  return echo!
+}
+
+test('launch profiles relocate credential homes on the execution host', async ({
+  testRepoPath
+}) => {
+  const fixtureRoot = mkdtempSync(path.join(os.tmpdir(), 'orca-launch-profile-'))
+  const fixturePath = path.join(fixtureRoot, 'launch-profile-echo.mjs')
+  writeFileSync(
+    fixturePath,
+    [
+      'const env = process.env',
+      `process.stdout.write(${JSON.stringify(ECHO_PREFIX)} + JSON.stringify({`,
+      '  codexHome: env.CODEX_HOME ?? null,',
+      '  claudeConfigDir: env.CLAUDE_CONFIG_DIR ?? null,',
+      '  profile: env.ORCA_AGENT_LAUNCH_PROFILE ?? null,',
+      '  codexMarker: env.ORCA_CODEX_HOME_PROFILE ?? null,',
+      '  claudeMarker: env.ORCA_CLAUDE_CONFIG_DIR_PROFILE ?? null',
+      "}) + '\\r\\n')",
+      'setInterval(() => {}, 1000)',
+      ''
+    ].join('\n')
+  )
+  const command = fixtureCommand(fixturePath)
+  const host = await launchHeadlessPairedRuntimeHost({
+    settings: {
+      agentCmdOverrides: { codex: command, claude: command },
+      agentLaunchProfiles: [
+        { id: 'codex-echo-route', agent: 'codex', label: 'Echo route', env: { ECHO_ROUTE: '1' } }
+      ]
+    }
+  })
+  const handles: string[] = []
+  try {
+    await host.client.call('repo.add', { path: testRepoPath, kind: 'git' })
+    const ps = await host.client.call<{ worktrees: { worktreeId: string }[] }>('worktree.ps', {
+      limit: 50
+    })
+    const worktreeId = ps.result.worktrees[0]?.worktreeId
+    expect(worktreeId).toBeTruthy()
+    const worktree = `id:${worktreeId}`
+
+    const codex = await host.client.call<{ terminal: { handle: string } }>(
+      'terminal.createAgentSession',
+      {
+        clientOperationId: operationId(),
+        worktree,
+        agent: 'codex',
+        launchProfileId: 'codex-secondary-home',
+        presentation: 'background'
+      }
+    )
+    handles.push(codex.result.terminal.handle)
+    const codexEcho = await readEcho(host, codex.result.terminal.handle)
+    // Why: the headless host runs with an isolated HOME under its userData dir, so assert the
+    // shape (its own home + .codex-2) rather than this machine's real home directory.
+    expect(codexEcho.codexHome).toBe(path.join(host.userDataDir, 'home', '.codex-2'))
+    expect(codexEcho.profile).toBe('codex-secondary-home')
+    // Why: the marker is consumed by the execution host; leaking it would let a nested launch re-resolve it.
+    expect(codexEcho.codexMarker).toBeNull()
+
+    // Why: the legacy create path (mobile, older web clients) carries the profile as a field too.
+    const claude = await host.client.call<{ tab: { id: string }; terminal?: { handle: string } }>(
+      'session.tabs.createTerminal',
+      { worktree, agent: 'claude', launchProfileId: 'claude-secondary-home', activate: false }
+    )
+    const claudeHandle =
+      claude.result.terminal?.handle ??
+      (
+        await host.client.call<{ terminals: { handle: string; tabId?: string }[] }>(
+          'terminal.list',
+          { worktree }
+        )
+      ).result.terminals.find((entry) => !handles.includes(entry.handle))?.handle
+    expect(claudeHandle).toBeTruthy()
+    handles.push(claudeHandle!)
+    const claudeEcho = await readEcho(host, claudeHandle!)
+    expect(claudeEcho.claudeConfigDir).toBe(path.join(host.userDataDir, 'home', '.claude-2'))
+    expect(claudeEcho.profile).toBe('claude-secondary-home')
+    expect(claudeEcho.claudeMarker).toBeNull()
+
+    const plain = await host.client.call<{ terminal: { handle: string } }>(
+      'terminal.createAgentSession',
+      { clientOperationId: operationId(), worktree, agent: 'codex', presentation: 'background' }
+    )
+    handles.push(plain.result.terminal.handle)
+    const plainEcho = await readEcho(host, plain.result.terminal.handle)
+    expect(plainEcho.profile).toBeNull()
+    expect(plainEcho.codexHome).not.toBe(codexEcho.codexHome)
+
+    await expect(
+      host.client.call('terminal.createAgentSession', {
+        clientOperationId: operationId(),
+        worktree,
+        agent: 'codex',
+        launchProfileId: 'no-such-profile',
+        presentation: 'background'
+      })
+    ).rejects.toThrow(/agent_session_launch_profile_unknown/)
+    await expect(
+      host.client.call('terminal.createAgentSession', {
+        clientOperationId: operationId(),
+        worktree,
+        agent: 'claude',
+        launchProfileId: 'codex-echo-route',
+        presentation: 'background'
+      })
+    ).rejects.toThrow(/agent_session_launch_profile_agent_mismatch/)
+  } finally {
+    for (const handle of handles) {
+      await host.client.call('terminal.close', { terminal: handle }).catch(() => undefined)
+    }
+    await host.dispose()
+    rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
+++ b/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
@@ -15,12 +15,23 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
   await waitForSessionReady(orcaPage)
   await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
+  // Why: the e2e profile can surface the recoverable-UI-error dialog on startup (reproduces on
+  // untouched main); while it is open the rest of the page is inert to role queries.
+  const dismissError = orcaPage.getByRole('button', { name: /^(Don't send|不发送)$/ }).first()
+  if (await dismissError.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await dismissError.click()
+  }
   // Why: the aria-label is localized; the e2e profile follows the OS locale.
   const newTab = orcaPage.getByRole('button', { name: /^(New tab|新标签页)$/ }).first()
 
-  await orcaPage.evaluate(async () => {
-    await window.__store?.getState().updateSettings({ agentLaunchProfiles: [] })
-  })
+  // Why: the e2e PATH is isolated, so point the Codex command at a binary that exists to make
+  // agent detection list it; the menu never launches it here.
+  await orcaPage.evaluate(async (codexCommand) => {
+    await window.__store?.getState().updateSettings({
+      agentLaunchProfiles: [],
+      agentCmdOverrides: { codex: codexCommand }
+    })
+  }, process.execPath)
   await newTab.click({ force: true })
   const codexRow = orcaPage.getByRole('menuitem', { name: /^Codex$/ }).first()
   await expect(codexRow).toBeVisible({ timeout: 30_000 })

--- a/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
+++ b/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
@@ -1,0 +1,57 @@
+import { mkdirSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+// Captures the before/after screenshots for the launch-profile quick-launch submenu. Not a
+// conformance test: it only runs when ORCA_LAUNCH_PROFILE_SHOTS names an output directory.
+
+const outputDir = process.env.ORCA_LAUNCH_PROFILE_SHOTS
+
+test.skip(!outputDir, 'set ORCA_LAUNCH_PROFILE_SHOTS=<dir> to capture screenshots')
+
+test('quick-launch submenu before and after launch profiles @headful', async ({ orcaPage }) => {
+  mkdirSync(outputDir!, { recursive: true })
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  // Why: the aria-label is localized; the e2e profile follows the OS locale.
+  const newTab = orcaPage.getByRole('button', { name: /^(New tab|新标签页)$/ }).first()
+
+  await orcaPage.evaluate(async () => {
+    await window.__store?.getState().updateSettings({ agentLaunchProfiles: [] })
+  })
+  await newTab.click({ force: true })
+  const codexRow = orcaPage.getByRole('menuitem', { name: /^Codex$/ }).first()
+  await expect(codexRow).toBeVisible({ timeout: 30_000 })
+  await codexRow.hover()
+  await orcaPage.screenshot({
+    path: path.join(outputDir!, 'quick-launch-before.png'),
+    animations: 'disabled'
+  })
+  await orcaPage.keyboard.press('Escape')
+
+  await orcaPage.evaluate(async () => {
+    await window.__store?.getState().updateSettings({
+      agentLaunchProfiles: [
+        {
+          id: 'codex-work-proxy',
+          agent: 'codex',
+          label: 'Codex · work proxy',
+          args: '-c model_provider="work"'
+        }
+      ]
+    })
+  })
+  await newTab.click({ force: true })
+  const codexSub = orcaPage.getByRole('menuitem', { name: /^Codex$/ }).first()
+  await expect(codexSub).toBeVisible({ timeout: 30_000 })
+  await codexSub.hover()
+  await expect(orcaPage.getByRole('menuitem', { name: 'Codex · secondary home' })).toBeVisible({
+    timeout: 10_000
+  })
+  await orcaPage.screenshot({
+    path: path.join(outputDir!, 'quick-launch-after.png'),
+    animations: 'disabled'
+  })
+})

--- a/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
+++ b/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
@@ -45,10 +45,15 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
   })
   // Why: the e2e profile can surface the recoverable-UI-error dialog on startup (reproduces on
   // untouched main); while it is open the rest of the page is inert to role queries.
-  const dismissError = orcaPage.getByRole('button', { name: /^(don't send|不发送)$/i }).first()
-  if (await dismissError.isVisible({ timeout: 5_000 }).catch(() => false)) {
-    await dismissError.click()
+  // Why: the e2e profile can surface the recoverable-UI-error dialog at any point (reproduces on
+  // untouched main); while it is open the rest of the page is inert to role queries.
+  const dismissRecoverableError = async (): Promise<void> => {
+    const dismiss = orcaPage.getByRole('button', { name: /^(don't send|不发送)$/i }).first()
+    if (await dismiss.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await dismiss.click()
+    }
   }
+  await dismissRecoverableError()
   // Why: the aria-label is localized; the e2e profile follows the OS locale.
   const newTab = orcaPage.getByRole('button', { name: /^(New tab|新标签页)$/ }).first()
   const codexItem = (): ReturnType<typeof orcaPage.getByRole> =>
@@ -59,6 +64,7 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
       await window.__store?.getState().updateSettings({ agentLaunchProfiles: [] })
     })
   }
+  await dismissRecoverableError()
   await newTab.click({ force: true })
   await expect(codexItem()).toBeVisible({ timeout: 30_000 })
   await codexItem().hover()
@@ -88,6 +94,7 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
       ]
     })
   })
+  await dismissRecoverableError()
   await newTab.click({ force: true })
   await expect(codexItem()).toBeVisible({ timeout: 30_000 })
   await codexItem().hover()
@@ -98,5 +105,71 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
     path: path.join(outputDir!, 'quick-launch-after.png'),
     animations: 'disabled',
     clip: menuClip
+  })
+
+  // Composer: the Launch profile select under the agent picker, shown because Codex has profiles.
+  for (let attempt = 0; attempt < 3 && (await codexItem().isVisible()); attempt += 1) {
+    await orcaPage.keyboard.press('Escape')
+  }
+  const agentSection = orcaPage.locator('[data-contextual-tour-target="workspace-creation-agent"]')
+  // Why: the error dialog can land between the menu closing and this click; retry the open.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await dismissRecoverableError()
+    await orcaPage
+      .getByRole('button', { name: /^(New workspace|新建工作区)$/ })
+      .first()
+      .click({ force: true })
+    if (await agentSection.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      break
+    }
+  }
+  await expect(agentSection).toBeVisible({ timeout: 15_000 })
+  // Why: opening the composer re-detects for its own context, which is empty in the isolated
+  // profile and would leave only Blank Terminal; seed the store again once that settles.
+  await orcaPage.waitForTimeout(1_500)
+  await orcaPage.evaluate(() => {
+    const store = window.__store!
+    const byContext = Object.fromEntries(
+      Object.keys(store.getState().localDetectedAgentIdsByContext).map((key) => [
+        key,
+        ['codex', 'claude']
+      ])
+    )
+    store.setState({
+      detectedAgentIds: ['codex', 'claude'],
+      isDetectingAgents: false,
+      localDetectedAgentIdsByContext: byContext
+    })
+  })
+  await agentSection.locator('[role="combobox"]').first().click()
+  await orcaPage
+    .getByRole('option', { name: /^Codex(?:\s|$)/i })
+    .first()
+    .click()
+  const profileSelect = agentSection.getByRole('combobox', { name: /^(Launch profile|启动配置)$/ })
+  await expect(profileSelect).toBeVisible({ timeout: 15_000 })
+  await profileSelect.click()
+  await expect(orcaPage.getByRole('option', { name: 'Codex · secondary home' })).toBeVisible({
+    timeout: 10_000
+  })
+  const dialogBox = await orcaPage
+    .locator('[role="dialog"]')
+    .filter({ hasText: /Create worktree|创建工作树/ })
+    .first()
+    .boundingBox()
+    .catch(() => null)
+  await orcaPage.screenshot({
+    path: path.join(outputDir!, 'composer-launch-profile.png'),
+    animations: 'disabled',
+    ...(dialogBox
+      ? {
+          clip: {
+            x: Math.max(0, dialogBox.x - 8),
+            y: Math.max(0, dialogBox.y - 8),
+            width: dialogBox.width + 16,
+            height: dialogBox.height + 16
+          }
+        }
+      : {})
   })
 })

--- a/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
+++ b/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
@@ -61,7 +61,9 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
 
   if (!baselineOnly) {
     await orcaPage.evaluate(async () => {
-      await window.__store?.getState().updateSettings({ agentLaunchProfiles: [] })
+      await window.__store
+        ?.getState()
+        .updateSettings({ agentLaunchProfiles: [], agentLaunchProfilesEnabled: false })
     })
   }
   await dismissRecoverableError()
@@ -84,6 +86,7 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
 
   await orcaPage.evaluate(async () => {
     await window.__store?.getState().updateSettings({
+      agentLaunchProfilesEnabled: true,
       agentLaunchProfiles: [
         {
           id: 'codex-work-proxy',

--- a/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
+++ b/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
@@ -115,13 +115,12 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
     await orcaPage.keyboard.press('Escape')
   }
   const agentSection = orcaPage.locator('[data-contextual-tour-target="workspace-creation-agent"]')
-  // Why: the error dialog can land between the menu closing and this click; retry the open.
+  // Why: the sidebar entry differs between Orca and its forks; the store action is the contract.
   for (let attempt = 0; attempt < 3; attempt += 1) {
     await dismissRecoverableError()
-    await orcaPage
-      .getByRole('button', { name: /^(New workspace|新建工作区)$/ })
-      .first()
-      .click({ force: true })
+    await orcaPage.evaluate(() => {
+      window.__store?.getState().openModal('new-workspace-composer', { telemetrySource: 'unknown' })
+    })
     if (await agentSection.isVisible({ timeout: 5_000 }).catch(() => false)) {
       break
     }

--- a/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
+++ b/tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts
@@ -1,12 +1,20 @@
 import { mkdirSync } from 'node:fs'
 import path from 'node:path'
 import { expect, test } from './helpers/orca-app'
+import { configureGoldenStubAgent, getGoldenStubAgentLaunchEnv } from './helpers/golden-stub-agent'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 // Captures the before/after screenshots for the launch-profile quick-launch submenu. Not a
 // conformance test: it only runs when ORCA_LAUNCH_PROFILE_SHOTS names an output directory.
 
 const outputDir = process.env.ORCA_LAUNCH_PROFILE_SHOTS
+// Why: the "before" capture runs against the base branch, which has no launch-profile settings.
+const baselineOnly = process.env.ORCA_LAUNCH_PROFILE_SHOTS_BASELINE === '1'
+// Why: crop to the tab bar and menu so the proof stays legible at PR width.
+const menuClip = { x: 290, y: 0, width: 800, height: 450 }
+
+// Why: the e2e PATH is isolated; the golden stub fixture puts a detectable `codex` on it.
+test.use({ launchEnv: getGoldenStubAgentLaunchEnv() })
 
 test.skip(!outputDir, 'set ORCA_LAUNCH_PROFILE_SHOTS=<dir> to capture screenshots')
 
@@ -15,32 +23,58 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
   await waitForSessionReady(orcaPage)
   await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
+  await configureGoldenStubAgent(orcaPage, { agent: 'codex' })
+  // Why: detection ran before the stub override existed and is cached per context; re-detect, and
+  // seed the store when the isolated PATH still yields nothing (this is a screenshot, not a probe).
+  await orcaPage.evaluate(async () => {
+    const store = window.__store!
+    await store.getState().updateSettings({ uiLanguage: 'en' })
+    await store.getState().refreshDetectedAgents(store.getState().activeWorktreeId ?? undefined)
+    if ((store.getState().detectedAgentIds ?? []).length === 0) {
+      const byContext = Object.fromEntries(
+        Object.keys(store.getState().localDetectedAgentIdsByContext).map((key) => [
+          key,
+          ['codex', 'claude']
+        ])
+      )
+      store.setState({
+        detectedAgentIds: ['codex', 'claude'],
+        localDetectedAgentIdsByContext: byContext
+      })
+    }
+  })
   // Why: the e2e profile can surface the recoverable-UI-error dialog on startup (reproduces on
   // untouched main); while it is open the rest of the page is inert to role queries.
-  const dismissError = orcaPage.getByRole('button', { name: /^(Don't send|不发送)$/ }).first()
+  const dismissError = orcaPage.getByRole('button', { name: /^(don't send|不发送)$/i }).first()
   if (await dismissError.isVisible({ timeout: 5_000 }).catch(() => false)) {
     await dismissError.click()
   }
   // Why: the aria-label is localized; the e2e profile follows the OS locale.
   const newTab = orcaPage.getByRole('button', { name: /^(New tab|新标签页)$/ }).first()
+  const codexItem = (): ReturnType<typeof orcaPage.getByRole> =>
+    orcaPage.getByRole('menuitem', { name: /^Codex(?:\s|$)/i }).first()
 
-  // Why: the e2e PATH is isolated, so point the Codex command at a binary that exists to make
-  // agent detection list it; the menu never launches it here.
-  await orcaPage.evaluate(async (codexCommand) => {
-    await window.__store?.getState().updateSettings({
-      agentLaunchProfiles: [],
-      agentCmdOverrides: { codex: codexCommand }
+  if (!baselineOnly) {
+    await orcaPage.evaluate(async () => {
+      await window.__store?.getState().updateSettings({ agentLaunchProfiles: [] })
     })
-  }, process.execPath)
+  }
   await newTab.click({ force: true })
-  const codexRow = orcaPage.getByRole('menuitem', { name: /^Codex$/ }).first()
-  await expect(codexRow).toBeVisible({ timeout: 30_000 })
-  await codexRow.hover()
+  await expect(codexItem()).toBeVisible({ timeout: 30_000 })
+  await codexItem().hover()
   await orcaPage.screenshot({
     path: path.join(outputDir!, 'quick-launch-before.png'),
-    animations: 'disabled'
+    animations: 'disabled',
+    clip: menuClip
   })
-  await orcaPage.keyboard.press('Escape')
+  if (baselineOnly) {
+    return
+  }
+  // Why: the first Escape only closes the hovered submenu; the root menu needs its own.
+  for (let attempt = 0; attempt < 3 && (await codexItem().isVisible()); attempt += 1) {
+    await orcaPage.keyboard.press('Escape')
+  }
+  await expect(codexItem()).toBeHidden({ timeout: 10_000 })
 
   await orcaPage.evaluate(async () => {
     await window.__store?.getState().updateSettings({
@@ -55,14 +89,14 @@ test('quick-launch submenu before and after launch profiles @headful', async ({ 
     })
   })
   await newTab.click({ force: true })
-  const codexSub = orcaPage.getByRole('menuitem', { name: /^Codex$/ }).first()
-  await expect(codexSub).toBeVisible({ timeout: 30_000 })
-  await codexSub.hover()
+  await expect(codexItem()).toBeVisible({ timeout: 30_000 })
+  await codexItem().hover()
   await expect(orcaPage.getByRole('menuitem', { name: 'Codex · secondary home' })).toBeVisible({
     timeout: 10_000
   })
   await orcaPage.screenshot({
     path: path.join(outputDir!, 'quick-launch-after.png'),
-    animations: 'disabled'
+    animations: 'disabled',
+    clip: menuClip
   })
 })

--- a/tests/e2e/helpers/headless-paired-runtime-host.ts
+++ b/tests/e2e/helpers/headless-paired-runtime-host.ts
@@ -81,6 +81,8 @@ export async function launchHeadlessPairedRuntimeHost(
     executablePath?: string
     /** Bind a stable loopback port so `restartServeProcess` can reclaim it. */
     pinnedServePort?: boolean
+    /** Settings merged into the seeded profile before the host starts (e.g. `agentCmdOverrides`). */
+    settings?: Record<string, unknown>
     userDataParent?: string
   } = {}
 ): Promise<HeadlessPairedRuntimeHost> {
@@ -94,9 +96,14 @@ export async function launchHeadlessPairedRuntimeHost(
     agentBrowserSocketDir = options.agentBrowserSocketParent
       ? mkdtempSync(path.join(options.agentBrowserSocketParent, 'orca-ab-'))
       : null
+    const profile = getE2ECompletedOnboardingProfile()
     writeFileSync(
       path.join(userDataDir, 'orca-data.json'),
-      `${JSON.stringify(getE2ECompletedOnboardingProfile(), null, 2)}\n`
+      `${JSON.stringify(
+        { ...profile, settings: { ...profile.settings, ...options.settings } },
+        null,
+        2
+      )}\n`
     )
     const { ELECTRON_RUN_AS_NODE: _unused, ...cleanEnv } = process.env
     void _unused


### PR DESCRIPTION
## ELI5

Today Orca can hold several Codex or Claude accounts, but only one of them is "the" account at a time, and API-key or proxy providers have no seat at all. This PR adds **launch profiles**: when you start an agent you can say "run this one under my second Codex home" or "run this one against my work proxy", per launch. Two panes on the same host can then run the same CLI under different accounts or providers side by side. Launching without a profile is unchanged.

## What Changed

- **Shared contract** `src/shared/agent-launch-profile/`: two built-in secondary-home profiles (`codex-secondary-home` → `CODEX_HOME=~/.codex-2`, `claude-secondary-home` → `CLAUDE_CONFIG_DIR=~/.claude-2`, both overridable with `ORCA_*_SECONDARY_HOME`) plus user-defined `settings.agentLaunchProfiles` rows (`args` + `env`, tokenized for the launch shell exactly like `agentDefaultArgs`). Ids are slugs; built-ins cannot be shadowed.
- **Host**: `terminal.createAgentSession`, `session.tabs.createTerminal` and `worktree.create` take an optional `launchProfileId` / `startupLaunchProfileId`. The host resolves it against its own catalog and raises `agent_session_launch_profile_unknown` or `_agent_mismatch`; `_remote_unsupported` is raised at SSH spawn only when the session never learned the remote home. New capability `agent-session.launch-profile.v1`.
- **Execution host**: a secondary-home launch only carries a marker (`ORCA_CODEX_HOME_PROFILE` / `ORCA_CLAUDE_CONFIG_DIR_PROFILE`); the daemon spawn turns it into the real directory (WSL: the distro home) and consumes the marker. Such launches skip managed Codex home selection, the managed-auth wait and the hook preflight; skip managed Claude credential materialization and auth-env stripping; and are recorded in `codex-pane-accounts.json` as `custom-home` with `launchProfileId`, so stale-account prompts never name them.
- **SSH lane**: the env reaches the relay as a literal map, so the secondary home is joined from the remote home and platform the session probed at connect time (in the remote's path flavor) and the marker is dropped before the spawn RPC. Without that probe the launch fails with the named error rather than starting on the remote default home.
- **Desktop**: the tab-bar agent row becomes a submenu (`Default launch` + one item per profile) when profiles exist for that agent. The New Workspace composer gets a `Launch profile` select under the agent picker, shown only when the chosen agent has profiles; the profile is layered into the startup command/env the renderer already sends, so `worktree.create` needs no new field on that path.
- **Mobile**: the new-tab sheet lists each agent's profiles beneath its default launch once the host advertises the capability (an older host never gets a profile id it would ignore), a Codex profile launch bypasses the structured chat path it cannot ride, and a terminal tab shows a small badge with the profile it runs under.
- **Paired web**: `launchProfileId` rides the structured create; the legacy env-only create is refused on hosts that lack the capability instead of launching unvalidated.
- **CLI**: `orca worktree create --agent codex --launch-profile codex-secondary-home`.
- **Status attribution**: `AgentStatusEntry.launchProfileId` (optional) is stamped by main from a small per-pty registry (`agent-launch-profile-panes.json`, mirroring the Codex pane account registry) so desktop and paired clients can show which profile a pane runs under; it survives daemon reattach across restarts.
- **In-process local lane**: fresh spawns routed to `LocalPtyProvider` resolve the home marker too (after the host env, so it wins over an injected managed home) and export a WSL-resolved home through WSLENV, matching the daemon lane.
- **Opt-in**: the pickers are behind a new `agentLaunchProfilesEnabled` setting (Settings → Agents → Agent launch profiles, off by default, searchable). With it off nothing in the UI changes; the RPC fields and the CLI flag accept a profile id regardless. The strict client settings schema now also lists `agentLaunchProfiles` so paired clients can save profiles over RPC.
- **Docs**: `docs/reference/agent-launch-profiles.md`.

## Why

- #2314 asks for Claude accounts beyond subscription OAuth (API key, Bedrock, Vertex, compatible proxies). #8770 asks for a CLI way to pick the account a headless spawn uses. #9129 asks for per-project env. All three need the same primitive: a per-launch, host-validated choice of credential home and process-local overrides.
- A managed account answers "which credential did Orca capture"; a launch profile answers "which home and overrides does *this* launch use". Keeping them separate lets the second home be a plain user-owned directory (log in once with `CODEX_HOME=~/.codex-2 codex login`) and keeps the existing account machinery untouched for plain launches.
- Only the execution host resolves the marker, so the runtime never sends a path to a client and a client never sends one to the host — the same boundary the managed homes already respect. On SSH the execution host's answer is the home it reported during connect, which the session already stores; the remote's own override variable is not consulted because this runtime cannot read a remote env.

Relation to open work: this is the per-launch primitive underneath rp0927's pinned-account stack (#13270–#13275) and #10394 (import existing CODEX_HOME); a pinned managed account can later become one more home source of a profile.

## Linked Issue

Addresses #8770 (CLI selection via `--launch-profile`) and the launch-scoped half of #2314. Refs #9129.

## Visual Proof

Tab-bar quick-launch menu and the New Workspace composer (below), captured with the setting turned on; with the default (off) setting both surfaces look exactly like the base. Mobile picker/badge screenshots will be added before this leaves draft. Web, CLI and host changes have no visual change.

| Before (base) | After |
| --- | --- |
| ![Quick-launch menu before: Codex and Claude are flat items](https://raw.githubusercontent.com/ColorC/orca-lite/assets/agent-launch-profiles/agent-launch-profiles/quick-launch-before.png) | ![Quick-launch menu after: Codex opens a submenu with Default launch, the built-in secondary home and a custom profile](https://raw.githubusercontent.com/ColorC/orca-lite/assets/agent-launch-profiles/agent-launch-profiles/quick-launch-after.png) |

**Composer**: the `Launch profile` select appears under the agent picker only when the chosen agent has profiles (before: no such control).

![New Workspace composer with the Launch profile select open under Codex](https://raw.githubusercontent.com/ColorC/orca-lite/assets/agent-launch-profiles/agent-launch-profiles/composer-launch-profile.png)

An agent with no profiles keeps its flat item and no composer select. Captured with `tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts` (opt-in via `ORCA_LAUNCH_PROFILE_SHOTS`; the "before" frame is the same spec in baseline mode on the base commit).

## Testing

- Unit: `src/shared/agent-launch-profile/*.test.ts`, `src/main/agent-launch-profile/*.test.ts`, `src/main/codex/codex-pane-account-registry-launch-profile.test.ts`, `src/main/providers/ssh-pty-spawn-env.test.ts`, `src/renderer/src/lib/launch-agent-profile.test.ts`, `src/renderer/src/hooks/composer-state/quick-startup-plan.test.ts`, `src/renderer/src/components/NewWorkspaceComposerCard.test.tsx` (profile picker case), `src/cli/handlers/worktree-startup-agent-flags.test.ts`; mobile: `mobile/src/session/mobile-new-tab-agent-options.test.ts`, `mobile-new-tab-agent-loader.test.ts`, `mobile-terminal-tab-agent.test.ts`, `mobile-launch-profile-labels.test.ts`, `use-mobile-session-terminal-create-actions.test.ts`.
- E2E: `tests/e2e/agent-launch-profile-conformance.spec.ts` — a headless paired host plus an env-echo fake agent; asserts over RPC only that both secondary homes resolve under the host's HOME, the marker is consumed, a plain launch stays profile-free, and the two error codes fire. Passes on Windows (electron-headless). `tests/e2e/agent-launch-profile-quick-launch-screenshot.spec.ts` is the opt-in @headful capture behind the screenshots above.
- Static gates from the PR workflow run locally against the base commit and pass: `check:code-quality:changed` (incl. type-aware and React Doctor), the max-lines / ts-nocheck / runtime-Electron ratchets, Zustand fan-out, reliability-gate manifest, root-directory guard, and the four localization verifications. `pnpm typecheck` (node, cli, web) passes. Full `pnpm test` and `pnpm build` are left to CI.
- Platforms exercised locally: Windows 10 (daemon spawn, PowerShell). WSL and SSH resolution are unit-tested; macOS/Linux and a live SSH host are not exercised.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude (Claude Code); reviewed and driven by a human.

## Review

- Cross-platform: marker resolution uses `path.join` and `homedir()`; WSL resolves inside the distro home and is exported through the existing WSLENV path; nothing platform-specific in the renderer.
- SSH/remote: secondary homes resolve from the connect-time remote home probe in the remote path flavor and fail closed when the probe is absent; args-only profiles pass through the existing quoting path (`planAgentCliArgsSuffix`). Resolution sits in main because the session already holds the probe; the relay is version-locked to the app, so moving this into the relay's `buildSpawnEnv` (which would also honor an `ORCA_*_SECONDARY_HOME` override set on the remote box) is a possible follow-up rather than a compatibility concern.
- Agents/integrations: only Codex and Claude have home profiles; every other agent can use args/env profiles. Managed-account paths are bypassed only when a home marker is present.
- Backwards compatibility: every new wire field is optional; hosts advertise a capability; clients refuse the env-only fallback on old hosts.
- Performance: no new I/O on the plain launch path; profile resolution is an in-memory lookup.
- UI: submenu and composer select use the existing dropdown/select primitives and tokens; en/zh catalogs updated. Mobile has no i18n layer; its strings follow the existing inline-English pattern.
- Security: profile env values are stored like `agentDefaultEnv` (settings) and never logged; markers are consumed on the execution host so a nested launch cannot re-resolve them.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)