### PR TITLE
Keep attention glyph knockout white when row is selected

### DIFF
--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -451,7 +451,7 @@ describe('palette live status', () => {
     expect(dotLabels()).toEqual(['Needs permission'])
   })
 
-  it('cuts the pip out of the dialog surface, and out of accent when selected', async () => {
+  it('positions the attention glyph over the row icon', async () => {
     setAgentState('working')
     await act(async () => {
       testRoot.render(
@@ -469,18 +469,8 @@ describe('palette live status', () => {
         </PaletteLiveStatusProvider>
       )
     })
-    const pip = testContainer.querySelector<HTMLElement>('[aria-hidden="true"].rounded-full')
+    const pip = testContainer.querySelector<HTMLElement>('[aria-hidden="true"]')
     expect(pip).not.toBeNull()
-    // Why popover and not background: the CommandDialog surface is --popover (#171717 dark), while
-    // --background is the app canvas (#0a0a0a) — the mismatch punched a dark halo through each row.
-    expect(pip?.className).toContain('bg-popover')
-    expect(pip?.className).toContain('ring-popover')
-    expect(pip?.className).not.toContain('bg-background')
-    expect(pip?.className).toContain(
-      'group-data-[selected=true]:bg-[var(--jump-palette-selection-surface)]'
-    )
-    expect(pip?.className).toContain(
-      'group-data-[selected=true]:ring-[var(--jump-palette-selection-surface)]'
-    )
+    expect(pip?.className).toBe('pointer-events-none absolute -right-0.5 -bottom-0.5')
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -451,7 +451,7 @@ describe('palette live status', () => {
     expect(dotLabels()).toEqual(['Needs permission'])
   })
 
-  it('positions the attention glyph over the row icon', async () => {
+  it('keeps the attention glyph knockout white when its row is selected', async () => {
     setAgentState('working')
     await act(async () => {
       testRoot.render(
@@ -471,6 +471,9 @@ describe('palette live status', () => {
     })
     const pip = testContainer.querySelector<HTMLElement>('[aria-hidden="true"]')
     expect(pip).not.toBeNull()
-    expect(pip?.className).toBe('pointer-events-none absolute -right-0.5 -bottom-0.5')
+    expect(pip?.className).toContain('bg-popover')
+    expect(pip?.className).toContain('ring-popover')
+    expect(pip?.className).toContain('rounded-full')
+    expect(pip?.className).not.toContain('group-data-[selected=true]')
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.test.tsx
@@ -451,7 +451,7 @@ describe('palette live status', () => {
     expect(dotLabels()).toEqual(['Needs permission'])
   })
 
-  it('keeps the attention glyph knockout white when its row is selected', async () => {
+  it('keeps the attention glyph knockout popover-colored when its row is selected', async () => {
     setAgentState('working')
     await act(async () => {
       testRoot.render(

--- a/src/renderer/src/components/cmd-j/palette-live-status.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.tsx
@@ -9,7 +9,6 @@ import {
   buildExplicitEntriesByTabId,
   type TabPaneInputSources
 } from '@/components/sidebar/smart-attention'
-import { cn } from '@/lib/utils'
 import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import { getLiveAgentStatusByWorktreeId } from '@/lib/worktree-activity-state'
 import {
@@ -255,15 +254,9 @@ export function PaletteRecentTabStatusDot({
       <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
         {fallback}
         <span
-          className={cn(
-            // Why popover, not background: the dialog surface is --popover (#171717 in dark), while
-            // --background is the app canvas (#0a0a0a) — using it punched a dark halo through every
-            // dark-mode row. Selected rows use --jump-palette-selection-surface so the cutout tracks
-            // the stronger keyboard highlight from main.css.
-            'pointer-events-none absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full',
-            'bg-popover ring-2 ring-popover',
-            'group-data-[selected=true]:bg-[var(--jump-palette-selection-surface)] group-data-[selected=true]:ring-[var(--jump-palette-selection-surface)]'
-          )}
+          // Keep the attention glyph as a lightweight overlay; a background ring reads as a
+          // second selection bubble around the row icon.
+          className="pointer-events-none absolute -right-0.5 -bottom-0.5"
           aria-hidden="true"
         >
           <RecentTabAttentionBadgeGlyph badge={badge} />

--- a/src/renderer/src/components/cmd-j/palette-live-status.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.tsx
@@ -254,9 +254,8 @@ export function PaletteRecentTabStatusDot({
       <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
         {fallback}
         <span
-          // Keep the attention glyph as a lightweight overlay; a background ring reads as a
-          // second selection bubble around the row icon.
-          className="pointer-events-none absolute -right-0.5 -bottom-0.5"
+          // The white knockout separates the glyph from its icon without inheriting row selection.
+          className="pointer-events-none absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full bg-popover ring-2 ring-popover"
           aria-hidden="true"
         >
           <RecentTabAttentionBadgeGlyph badge={badge} />

--- a/src/renderer/src/components/cmd-j/palette-live-status.tsx
+++ b/src/renderer/src/components/cmd-j/palette-live-status.tsx
@@ -254,7 +254,7 @@ export function PaletteRecentTabStatusDot({
       <span className="relative inline-flex size-3.5 shrink-0 items-center justify-center">
         {fallback}
         <span
-          // The white knockout separates the glyph from its icon without inheriting row selection.
+          // The popover-colored knockout separates the glyph from its icon without inheriting row selection.
           className="pointer-events-none absolute -right-0.5 -bottom-0.5 flex items-center justify-center rounded-full bg-popover ring-2 ring-popover"
           aria-hidden="true"
         >


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 |

<!-- /orca-pr-loc -->

## Problem

The attention glyph (white knockout indicator on recent tabs) was changing color when its containing row received keyboard focus, creating unwanted visual coupling.

## Solution

Remove conditional styling based on row selection state. The glyph now always renders with a white knockout (`bg-popover`), independent of whether the row is selected. This also simplifies the code by removing the `group-data-[selected=true]` conditional classes and their associated comment explaining the workaround.

## Changes

- Simplified `PaletteRecentTabStatusDot` className from conditional `cn()` utility call to plain string
- Removed import of unused `cn` utility
- Updated test to verify the knockout does not respond to row selection state
- Clarified inline comment explaining the knockout's purpose

## Testing

Test case renamed and updated to verify: the glyph knockout stays white regardless of row selection, and the `group-data-[selected=true]` class is not applied to it.