### PR TITLE
Fix status bar render loop in runtime target hook

### DIFF
--- a/src/renderer/src/components/status-bar/PortsStatusSegment.render-stability.test.tsx
+++ b/src/renderer/src/components/status-bar/PortsStatusSegment.render-stability.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/SelectedTextCopyMenu', () => ({
+  SelectedTextCopyMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('./ports-status-popover-rows', () => ({
+  PortRow: () => <div />,
+  WorkspaceGroupRows: () => <div />
+}))
+
+vi.mock('@/lib/react-error-boundary-reporting', () => ({
+  reportReactErrorBoundaryCrash: vi.fn()
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, options?: Record<string, unknown>) =>
+    options
+      ? fallback.replace(/{{(\w+)}}/g, (_match, name: string) => String(options[name] ?? ''))
+      : fallback
+}))
+
+import { RecoverableRenderErrorBoundary } from '../error-boundaries/RecoverableRenderErrorBoundary'
+import { useAppStore } from '@/store'
+import { PortsStatusSegment } from './PortsStatusSegment'
+
+describe('PortsStatusSegment render stability', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    useAppStore.setState(useAppStore.getInitialState(), true)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    consoleError.mockRestore()
+  })
+
+  it('keeps the status controls mounted when the runtime owner is local', () => {
+    act(() => {
+      root.render(
+        <RecoverableRenderErrorBoundary
+          boundaryId="oracle.status-bar"
+          surface="overlay"
+          compact
+          reportAsCrash={false}
+          title="The status bar hit an error."
+          description="Retry the status bar to remount its controls."
+        >
+          <PortsStatusSegment iconOnly={false} />
+        </RecoverableRenderErrorBoundary>
+      )
+    })
+
+    const underlyingException = consoleError.mock.calls.find(
+      ([message, error]) =>
+        message === '[oracle.status-bar] render crash contained by boundary' &&
+        error instanceof Error &&
+        error.message.includes('Maximum update depth exceeded')
+    )
+
+    expect.soft(container.textContent).not.toContain('The status bar hit an error.')
+    expect.soft(underlyingException).toBeUndefined()
+    expect(container.querySelector('button[aria-label^="Ports, 0 workspace"]')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/runtime/use-worktree-runtime-target.ts
+++ b/src/renderer/src/runtime/use-worktree-runtime-target.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useAppStore } from '@/store'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { runtimeTargetForExecutionHostId, type RuntimeClientTarget } from './runtime-client-target'
@@ -10,7 +11,6 @@ import { runtimeTargetForExecutionHostId, type RuntimeClientTarget } from './run
 export function useWorktreeRuntimeTarget(
   worktreeId: string | null | undefined
 ): RuntimeClientTarget | null {
-  return useAppStore((state) =>
-    runtimeTargetForExecutionHostId(getExecutionHostIdForWorktree(state, worktreeId))
-  )
+  const executionHostId = useAppStore((state) => getExecutionHostIdForWorktree(state, worktreeId))
+  return useMemo(() => runtimeTargetForExecutionHostId(executionHostId), [executionHostId])
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The status bar asked Zustand for a newly created runtime-target object on every store snapshot. React treated each object as a different snapshot, rendered forever, and eventually replaced the status bar with its error boundary. This changes the subscription to the stable execution-host ID and derives the runtime target afterward.

## What Changed

- Subscribe to the primitive worktree execution-host ID in `useWorktreeRuntimeTarget`.
- Memoize the derived `RuntimeClientTarget` outside the Zustand selector.
- Add a production-component regression oracle that checks both the visible boundary state and the underlying maximum-update-depth exception.

## Why

The runtime-target hook owns the conversion from worktree host ownership to the RPC target. Fixing it there protects every consumer while preserving local, paired-runtime, direct-SSH, and folder-workspace routing. A call-site workaround or selector cache would leave the unstable ownership boundary in place.

## Linked Issue

- [Internal Slack report](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1788543731150729)
- Regression introduced by #17048

## Visual Proof

### Before

![F0BV5N4FLUR.png](https://github.com/user-attachments/assets/f5b51ba7-791d-4412-96f0-38a2781adeeb)

### After

![statusbar-fixed-candidate.png](https://github.com/user-attachments/assets/9483a52f-d7f4-4b51-9cf7-308c85d16ebf)

## Testing

- Reproduced on untouched `origin/main` with the visible status-bar boundary and `Maximum update depth exceeded`.
- Identical deterministic oracle: good hourly passed; PR #17048 merge, bad hourly, and baseline main failed; candidate passed; candidate with the fix disabled failed.
- `pnpm tc`
- 54 relevant test files / 383 tests
- Final status-bar render-stability and host-routing suites: 11/11
- Post-commit render-stability oracle: 1/1
- `pnpm run check:code-quality:changed`
- Electron/Playwright CDP on macOS with an isolated profile: correct worktree identity, Ports control visible, boundary text absent, zero renderer console errors.
- Linux, Windows, and SSH were assessed structurally; no platform or wire behavior changed. CI will cover the full platform/build matrix.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Fresh performance, architecture/adversarial, and regression reviews were clean. The internal review-until-clean loop completed with no in-scope findings.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No persisted state, IPC/RPC payload, polling, retry, or wire contract changed. Direct SSH still resolves to no runtime client target.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)