### PR TITLE
Keep the floating workspace above a working native chat pane

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -392,9 +392,9 @@
   z-index: 40 !important;
 }
 
-/* Keep interruption controls above unrelated updater/onboarding chrome. */
+/* Above the z-40 updater/onboarding chrome, below the floating workspace panel's z-45. */
 .native-chat-pane-shell:has([data-native-chat-working='true']) {
-  z-index: 50;
+  z-index: 44;
 }
 
 [data-sonner-toaster] [data-sonner-toast][data-styled='true'] {

--- a/src/renderer/src/components/native-chat/native-chat-stop-layering.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-stop-layering.test.ts
@@ -6,6 +6,15 @@ function source(path: string): string {
   return readFileSync(join(process.cwd(), path), 'utf8')
 }
 
+function workingChatZIndex(css: string): number {
+  const match =
+    /\.native-chat-pane-shell:has\(\[data-native-chat-working='true'\]\)[^{]*\{[^}]*z-index:\s*(\d+);/s.exec(
+      css
+    )
+  expect(match, 'working native-chat z-index rule not found in main.css').not.toBeNull()
+  return Number(match?.[1])
+}
+
 describe('native chat Stop layering', () => {
   it('keeps a working chat pane above bottom-right product chrome', () => {
     const css = source('src/renderer/src/assets/main.css')
@@ -15,9 +24,19 @@ describe('native chat Stop layering', () => {
 
     expect(terminalPane).toContain('native-chat-pane-shell absolute inset-0 z-10')
     expect(css).toMatch(/\[data-sonner-toaster\][^{]*\{[^}]*z-index:\s*40\s*!important;/s)
-    expect(css).toMatch(
-      /\.native-chat-pane-shell:has\(\[data-native-chat-working='true'\]\)[^{]*\{[^}]*z-index:\s*50;/s
+    expect(workingChatZIndex(css)).toBeGreaterThan(40)
+  })
+
+  // Why both bounds: raising the working pane over the panel hides a summoned
+  // floating workspace behind the chat column while an agent streams.
+  it('stays under the floating workspace panel while working', () => {
+    const panel = source(
+      'src/renderer/src/components/floating-terminal/FloatingTerminalPanelSurface.tsx'
     )
+    const panelZIndex = Number(/data-floating-terminal-panel[\s\S]*?z-\[(\d+)\]/.exec(panel)?.[1])
+
+    expect(panelZIndex).toBe(45)
+    expect(workingChatZIndex(source('src/renderer/src/assets/main.css'))).toBeLessThan(panelZIndex)
   })
 
   it('publishes working state from both structured and bridge chat roots', () => {

--- a/src/renderer/src/components/native-chat/native-chat-stop-layering.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-stop-layering.test.ts
@@ -30,11 +30,16 @@ describe('native chat Stop layering', () => {
   // Why both bounds: raising the working pane over the panel hides a summoned
   // floating workspace behind the chat column while an agent streams.
   it('stays under the floating workspace panel while working', () => {
+    // Comments stripped first: the surrounding layering comment cites bare z-40/z-50
+    // tiers, and a reworded one could otherwise be read as the panel's own class.
     const panel = source(
       'src/renderer/src/components/floating-terminal/FloatingTerminalPanelSurface.tsx'
+    ).replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, '')
+    const panelZIndex = Number(
+      /data-floating-terminal-panel[\s\S]*?className=[\s\S]*?z-\[(\d+)\]/.exec(panel)?.[1]
     )
-    const panelZIndex = Number(/data-floating-terminal-panel[\s\S]*?z-\[(\d+)\]/.exec(panel)?.[1])
 
+    // FloatingTerminalPanel.bounds.test.tsx pins this same 45 through a real render.
     expect(panelZIndex).toBe(45)
     expect(workingChatZIndex(source('src/renderer/src/assets/main.css'))).toBeLessThan(panelZIndex)
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |

<!-- /orca-pr-loc -->

## Problem

With a floating workspace open, the panel disappears behind the native chat column while an agent is streaming — only the sliver sticking out past the chat's right edge stays visible.

`main.css` promotes the chat pane shell from `z-10` to `z-50` whenever an agent is working:

```css
.native-chat-pane-shell:has([data-native-chat-working='true']) {
  z-index: 50;
}
```

The floating panel is `position: fixed; z-index: 45` at the app root, and no ancestor of the chat pane creates a stacking context, so the two compete directly in the root stacking context. `50` wins and the chat column paints over the panel.

The panel's geometry was never wrong — 920px wide anchored 24px off the right edge puts its right edge exactly where it renders. It also correctly paints *over* the session-history sidebar, which rules out clipping. Because the rule is gated on the working state, an idle chat shows the panel fine, so this only reproduces mid-stream.

## Fix

Lower the working-state rule to `z-index: 44`.

That preserves the intent it was added with in #16729 — keeping the interruption controls above the `z-40` updater/onboarding chrome — and the 41–44 band was otherwise empty, so nothing else shifts.

Raising the floating panel instead was rejected: its own comment pins it under the `z-50` Radix modal layer, so raising it would put the floating workspace over every dialog.

## Tests

`native-chat-stop-layering.test.ts` already guarded this rule but asserted `z-index: 50` as a literal with **no upper bound** — that one-sided assertion is what let the regression in. It now derives both bounds from source (reading the panel's `z-[45]` out of the component) so neither side can drift silently.

Ablation on the real head: reverting the CSS to `50` fails the new assertion (`expected 50 to be less than 45`) while the other three tests still pass, confirming the prior suite had no coverage here.

- Target test: 4/4 pass
- `native-chat` + `floating-terminal` suites: 113 files / 1115 tests pass
- `pnpm tc` clean, `oxlint` clean, `oxfmt` no reflow
