### PR TITLE
fix(native-chat): clarify active progress

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -215,7 +215,7 @@ describe('NativeChatMessageList assistant messages', () => {
     )
 
     const user = screen.getByText('Run the checks')
-    const status = screen.getByText('Working for 0 seconds')
+    const status = screen.getByText('Working for 0s')
     const assistant = screen.getByText('I am checking now.')
     expect(user.compareDocumentPosition(status)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(status.compareDocumentPosition(assistant)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
@@ -252,7 +252,7 @@ describe('NativeChatMessageList assistant messages', () => {
       />
     )
 
-    expect(screen.getByText('Working for 3 seconds')).toBeInTheDocument()
+    expect(screen.getByText('Working for 3s')).toBeInTheDocument()
   })
 
   it('keeps the completed duration below the user message', () => {
@@ -298,7 +298,7 @@ describe('NativeChatMessageList assistant messages', () => {
     )
 
     const user = screen.getByText('Complete this task')
-    const status = screen.getByText('Worked for 3 seconds')
+    const status = screen.getByText('Worked for 3s')
     const assistant = screen.getByText('Task complete.')
     expect(user.compareDocumentPosition(status)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(status.compareDocumentPosition(assistant)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
@@ -326,7 +326,7 @@ describe('NativeChatMessageList assistant messages', () => {
       />
     )
 
-    expect(screen.getByText('Worked for 3 seconds')).toBeInTheDocument()
+    expect(screen.getByText('Worked for 3s')).toBeInTheDocument()
     expect(screen.getByText('Thinking')).toBeInTheDocument()
   })
 

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.test.tsx
@@ -99,7 +99,9 @@ describe('NativeChatToolRun', () => {
 
     const { container } = render(<NativeChatToolRun blocks={blocks} expandSignal={false} />)
 
-    expect(screen.getByText('Running cat package.json')).toBeInTheDocument()
+    const activeLabel = screen.getByText('Running cat package.json')
+    expect(activeLabel).toBeInTheDocument()
+    expect(activeLabel).toHaveClass('animate-pulse', 'motion-reduce:animate-none')
     expect(screen.queryByText('Running date')).toBeNull()
     expect(screen.queryByText('Running pwd')).toBeNull()
     expect(screen.queryByText('Ran 3 commands and used 1 tool')).toBeNull()

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -227,7 +227,7 @@ export function NativeChatToolRun({
           <span className="flex size-6 shrink-0 items-center justify-center text-muted-foreground">
             <ActiveToolIcon className="size-4" />
           </span>
-          <span className="min-w-0 flex-1 truncate text-foreground/85">
+          <span className="min-w-0 flex-1 animate-pulse truncate text-foreground/85 motion-reduce:animate-none">
             {activeToolLabel(latestActiveCall)}
           </span>
           {open ? <ChevronRight className="size-3.5 rotate-90 text-muted-foreground" /> : null}

--- a/src/renderer/src/components/native-chat/NativeChatWorkingStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatWorkingStatus.tsx
@@ -3,6 +3,21 @@ import { ChevronRight } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { useNow } from '@/hooks/use-now'
 
+/** Format turn time without exposing an ever-growing raw seconds count. */
+export function formatNativeChatDuration(seconds: number): string {
+  const totalSeconds = Number.isFinite(seconds) ? Math.max(0, Math.floor(seconds)) : 0
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`
+  }
+  const minutes = Math.floor(totalSeconds / 60)
+  const remainingSeconds = totalSeconds % 60
+  if (minutes < 60) {
+    return `${minutes}m ${remainingSeconds}s`
+  }
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}m ${remainingSeconds}s`
+}
+
 export function NativeChatWorkingStatus({
   startedAt,
   thinking,
@@ -30,13 +45,13 @@ export function NativeChatWorkingStatus({
 
   const label =
     workedSeconds != null
-      ? translate('components.native-chat.status.workedFor', 'Worked for {{value0}} seconds', {
-          value0: workedSeconds
+      ? translate('components.native-chat.status.workedFor', 'Worked for {{value0}}', {
+          value0: formatNativeChatDuration(workedSeconds)
         })
       : thinking
         ? translate('components.native-chat.status.thinking', 'Thinking')
-        : translate('components.native-chat.status.workingFor', 'Working for {{value0}} seconds', {
-            value0: elapsedSeconds
+        : translate('components.native-chat.status.workingFor', 'Working for {{value0}}', {
+            value0: formatNativeChatDuration(elapsedSeconds)
           })
 
   const className = `flex min-h-8 items-center gap-1 text-sm text-muted-foreground${thinking ? '' : ' border-b border-border'}`

--- a/src/renderer/src/components/native-chat/native-chat-working-status-shared-clock.test.tsx
+++ b/src/renderer/src/components/native-chat/native-chat-working-status-shared-clock.test.tsx
@@ -3,7 +3,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { NativeChatWorkingStatus } from './NativeChatWorkingStatus'
+import { formatNativeChatDuration, NativeChatWorkingStatus } from './NativeChatWorkingStatus'
 
 let container: HTMLDivElement
 let root: Root
@@ -49,34 +49,50 @@ afterEach(() => {
 })
 
 describe('native chat working status elapsed clock', () => {
+  it.each([
+    [0, '0s'],
+    [59, '59s'],
+    [60, '1m 0s'],
+    [69, '1m 9s'],
+    [3_725, '1h 2m 5s']
+  ])('formats %s seconds as %s', (seconds, expected) => {
+    expect(formatNativeChatDuration(seconds)).toBe(expected)
+  })
+
+  it('renders the compact duration in the completed status label', () => {
+    act(() => {
+      root.render(
+        <NativeChatWorkingStatus startedAt={1_000_000} thinking={false} workedSeconds={69} />
+      )
+    })
+
+    expect(elapsedLabels()).toEqual(['Worked for 1m 9s'])
+  })
+
   it('collapses every in-flight turn onto one shared visibility-gated timer', () => {
     renderTurns(3, 1_000_000)
 
     // One shared 1s clock for all three turns, not one interval per turn.
     expect(vi.getTimerCount()).toBe(1)
     act(() => vi.advanceTimersByTime(3_000))
-    expect(elapsedLabels()).toEqual([
-      'Working for 3 seconds',
-      'Working for 3 seconds',
-      'Working for 3 seconds'
-    ])
+    expect(elapsedLabels()).toEqual(['Working for 3s', 'Working for 3s', 'Working for 3s'])
   })
 
   it('stops ticking while hidden and re-syncs the elapsed value on return', () => {
     renderTurns(1, 1_000_000)
     act(() => vi.advanceTimersByTime(3_000))
-    expect(elapsedLabels()).toEqual(['Working for 3 seconds'])
+    expect(elapsedLabels()).toEqual(['Working for 3s'])
 
     setDocumentVisibility('hidden')
     expect(vi.getTimerCount()).toBe(0)
 
     // A minute of hidden wall-clock: no callbacks, no commits, label frozen.
     act(() => vi.advanceTimersByTime(60_000))
-    expect(elapsedLabels()).toEqual(['Working for 3 seconds'])
+    expect(elapsedLabels()).toEqual(['Working for 3s'])
 
     // Returning re-derives elapsed from startedAt, so nothing was lost.
     setDocumentVisibility('visible')
-    expect(elapsedLabels()).toEqual(['Working for 63 seconds'])
+    expect(elapsedLabels()).toEqual(['Working for 1m 3s'])
     expect(vi.getTimerCount()).toBe(1)
   })
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16950,8 +16950,8 @@
         "responding": "Agent is responding",
         "working": "Working…",
         "thinking": "Thinking",
-        "workingFor": "Working for {{value0}} seconds",
-        "workedFor": "Worked for {{value0}} seconds",
+        "workingFor": "Working for {{value0}}",
+        "workedFor": "Worked for {{value0}}",
         "toggleDetails": "Toggle turn details"
       },
       "jumpToLatest": "Jump to latest",


### PR DESCRIPTION
## ELI5

Native chat now shows elapsed time in compact minutes and seconds, and the tool that is currently running visibly pulses so it no longer looks finished.

## What Changed

- Format native-chat elapsed labels as compact durations such as `59s`, `1m 9s`, and `1h 2m 5s`.
- Keep the latest running tool surfaced as `Running …` while completed calls remain settled.
- Pulse the active tool label, with reduced-motion support.
- Add regression coverage for active/completed tool states and duration boundaries.

## Why

Long-running turns previously displayed an ever-growing raw seconds count. Active tool activity could also look completed, especially in runs containing several shell calls, leaving users without a clear indication of what was still running.

## Linked Issue

Reported directly; no linked issue.

## Visual Proof

Exact-head Electron validation on `260f5b19925dcc0454e4a61910d931b72e9f8139` against the real native Codex chat surface in a disposable sample git repo.

Observed while the latest shell call stayed active:
- The active tool rendered as `Running /bin/zsh -lc 'sleep 70'` with `animation-name: pulse` (2s) and changing opacity; no completion check on that row.
- Earlier sequential calls stayed settled (`echo first` / `echo second` results, and the previous turn’s checked `3×` summary).
- Elapsed labels crossed 60 seconds as compact `1m 4s`, `1m 9s`, `1m 14s` (live first-turn ticks also showed `1m 0s` through `1m 19s`). Never a raw total such as `65 seconds` or `64s`.
- Completed turns rendered `Worked for 1m 22s` and `Worked for 1m 18s`.

Pulse (temporal):

https://github.com/user-attachments/assets/5d1b9ae8-b088-4a32-aab2-04c09d54cb86

Duration crossing 60s while still running (`Working for 1m 4s` → `1m 14s`):

https://github.com/user-attachments/assets/6c1ce6b9-7a04-4601-a216-d4ef2511dd6c

Active running still (`Working for 29s`, latest tool Running, earlier calls settled):

![native-chat-running-active.png](https://github.com/user-attachments/assets/fbb2ccdb-46f2-4a8c-b418-2da323af72f8)

Compact minutes+seconds while the last tool is still running:

![native-chat-working-for-1m4s.png](https://github.com/user-attachments/assets/0d7d7621-2c8d-4d50-9948-bd3a068230ef)

Settled completed turn (`Worked for 1m 22s` plus checked `3×` tool summary):

![native-chat-worked-for-1m22s.png](https://github.com/user-attachments/assets/8232fab7-99dd-48bc-9ddf-2004dac91b9a)


## Testing

- [x] Focused native-chat tests: 28 passed
- [x] `pnpm tc:web`
- [x] `pnpm run check:code-quality:changed`
- [x] Exact-head Electron validation on 260f5b19925dcc0454e4a61910d931b72e9f8139 (native Codex chat: Running pulse, settled earlier calls, compact 1m Ns duration)

## AI Disclosure

<!-- Internal contributor; intentionally blank. -->

## Review

Self-reviewed for lifecycle state handling, accessibility, reduced motion, and focused scope.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill implementation is changed.

## Notes

No execution-host, SSH, folder-workspace, remote-wire, Git, or platform-specific behavior changes. This is renderer-only presentation logic.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Full CI passed: static analysis, typecheck, packaging (macOS/Linux and Windows), and all eight test shards


