### PR TITLE
fix(e2e): stop deleting a pre-created agent's setup report

### DIFF
--- a/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
+++ b/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
@@ -39,6 +39,9 @@ async function createFakeCodexTerminal(
   testRepoPath: string,
   args: string[] = []
 ): Promise<string> {
+  // Clear before the agent starts: it may write its report immediately, and the
+  // repro tool no longer clears a slot it did not create.
+  rmSync(fixtureReport, { force: true })
   const client = new RuntimeClient(userDataDir, 30_000, null, null)
   const expectedPath = path.resolve(testRepoPath)
   const findWorktree = async (): Promise<{ id: string } | undefined> => {

--- a/tests/tools/repro-terminal-send-submit.mjs
+++ b/tests/tools/repro-terminal-send-submit.mjs
@@ -186,7 +186,11 @@ async function parentMain() {
   const expectBlocked = hasFlag('expect-blocked')
   const providedHandle = argValue('terminal')
   await mkdir(tempDir, { recursive: true })
-  await rm(reportPath, { force: true })
+  // Only safe when this process also starts the agent; a caller-supplied handle
+  // means the agent already ran and may have written its setup report.
+  if (!providedHandle) {
+    await rm(reportPath, { force: true })
+  }
 
   let handle = providedHandle
   if (!handle) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Failure signature

`tests/e2e/terminal-send-agent-prompt-submit.spec.ts` › `CLI does not write prompt bytes into an active permission dialog` fails on every run:

```
Error: Command failed: node tests/tools/repro-terminal-send-submit.mjs ... --expect-blocked ...
Error: terminal permission prompt did not materialize
   at ../tools/repro-terminal-send-submit.mjs:237
```

## Evidence it is broken on main

| Workflow run | head sha | job | result |
| --- | --- | --- | --- |
| [33906859057](https://github.com/stablyai/orca/actions/runs/33906859057) | `3e4fd4a7af` | `e2e 12-of-14` | this test failed, its two siblings passed |
| [33898773935](https://github.com/stablyai/orca/actions/runs/33898773935) | `67999dcaae` | `e2e 12-of-14` | same |

## Root cause

`repro-terminal-send-submit.mjs` deleted the report file at startup:

```js
await mkdir(tempDir, { recursive: true })
await rm(reportPath, { force: true })
```

That is correct only while the tool also spawns the fake agent, which was the case when the flag was added in #14962.

#16300 changed this spec to pre-create the terminal with `createFakeCodexTerminal` and pass `--terminal <handle>`. The fake agent now starts during that helper and, under `--permission-before-send`, writes its setup report 250 ms later. The repro tool then starts, deletes that report, and waits 10 s for a write that never happens, because the agent only writes it once.

The other two tests in the file are unaffected: their fake agent writes a report only in response to stdin, which arrives after the tool has already run.

## Fix

- The tool clears the report path only when it is the process that starts the agent.
- The spec clears the report path before creating the terminal, so the pre-created path keeps its stale-file guard.

No timeouts were loosened and no retries were added.

## Verification

Ran the spec locally in a clean worktree off `main` (`macOS`, `electron-headless`, full `build:cli` + `electron-vite build --mode e2e`):

- Unfixed baseline: the permission-dialog test fails with the exact CI signature.
- With this commit: `3 passed`.

`oxlint` and `oxlint --config config/oxlint-react-doctor.json` pass on both changed files.
