### PR TITLE
fix(sidebar): confirm filter reset before revealing active workspace

### DIFF
--- a/src/renderer/src/components/confirmation-dialog-context.ts
+++ b/src/renderer/src/components/confirmation-dialog-context.ts
@@ -1,4 +1,5 @@
 import { createContext, useContext } from 'react'
+import type { LucideIcon } from 'lucide-react'
 
 // Keep the context component-free so Fast Refresh preserves its identity.
 
@@ -9,6 +10,9 @@ export type ConfirmationDialogOptions = {
   confirmLabel?: string
   cancelLabel?: string
   confirmVariant?: 'default' | 'destructive'
+  icon?: LucideIcon
+  cancelVariant?: 'outline' | 'ghost'
+  initialFocus?: 'confirm'
   /** Renders a "Don't ask again" checkbox. `onConfirmed` runs only when the user confirms with it checked. */
   dontAskAgain?: { label?: string; onConfirmed: () => void }
 }

--- a/src/renderer/src/components/confirmation-dialog.test.tsx
+++ b/src/renderer/src/components/confirmation-dialog.test.tsx
@@ -44,6 +44,37 @@ function renderDialog(options: ConfirmationDialogOptions): { onSettled: ReturnTy
 describe('ConfirmationDialogProvider', () => {
   afterEach(cleanup)
 
+  it('focuses the primary action when requested and confirms with Enter', async () => {
+    const { onSettled } = renderDialog({
+      title: 'Reveal hidden workspace?',
+      confirmLabel: 'Clear filters and reveal',
+      initialFocus: 'confirm'
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'ask' }))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Clear filters and reveal' })).toHaveFocus()
+    )
+    await userEvent.keyboard('{Enter}')
+    await waitFor(() => expect(onSettled).toHaveBeenCalledWith(true))
+  })
+
+  it('still cancels with Escape when the primary action has focus', async () => {
+    const { onSettled } = renderDialog({
+      title: 'Reveal hidden workspace?',
+      initialFocus: 'confirm'
+    })
+    await userEvent.click(screen.getByRole('button', { name: 'ask' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Confirm' })).toHaveFocus())
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(onSettled).toHaveBeenCalledWith(false))
+  })
+
+  it('keeps the default cancel focus for callers that do not opt in', async () => {
+    renderDialog({ title: 'Delete artifact?', confirmVariant: 'destructive' })
+    await userEvent.click(screen.getByRole('button', { name: 'ask' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus())
+  })
+
   it('omits the checkbox unless the caller opts in', async () => {
     renderDialog({ title: 'Delete artifact?' })
 

--- a/src/renderer/src/components/confirmation-dialog.tsx
+++ b/src/renderer/src/components/confirmation-dialog.tsx
@@ -32,6 +32,7 @@ export function ConfirmationDialogProvider({
   children: React.ReactNode
 }): React.JSX.Element {
   const nextIdRef = useRef(0)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
   const [queue, setQueue] = useState<ConfirmationDialogRequest[]>([])
   const [dontAskAgain, setDontAskAgain] = useState(false)
   const activeRequest = queue[0] ?? null
@@ -46,6 +47,7 @@ export function ConfirmationDialogProvider({
   }
   // Why: Radix keeps dialog content mounted while closing; keep labels stable without a post-render Effect.
   const displayedRequest = activeRequest ?? lastDisplayedRequestRef.current
+  const Icon = displayedRequest?.options.icon
 
   useEffect(() => {
     // Why: this provider's dialog is not represented by activeModal. Block
@@ -96,18 +98,37 @@ export function ConfirmationDialogProvider({
         open={activeRequest !== null}
         onOpenChange={(open) => !open && settleActiveRequest(false)}
       >
-        <DialogContent showCloseButton={false} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{displayedRequest?.options.title}</DialogTitle>
-            {displayedRequest?.options.description ? (
-              // Callers pass multi-line descriptions (e.g. one path per line).
-              <DialogDescription
-                className={cn('whitespace-pre-line', displayedRequest.options.descriptionClassName)}
-              >
-                {displayedRequest.options.description}
-              </DialogDescription>
-            ) : null}
-          </DialogHeader>
+        <DialogContent
+          showCloseButton={false}
+          className={cn('sm:max-w-md', Icon && 'gap-6')}
+          onOpenAutoFocus={(event) => {
+            if (activeRequest?.options.initialFocus === 'confirm') {
+              event.preventDefault()
+              confirmButtonRef.current?.focus()
+            }
+          }}
+        >
+          <div className={cn(Icon && 'flex items-start gap-4')}>
+            {Icon && (
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border bg-muted text-muted-foreground">
+                <Icon className="size-5" aria-hidden="true" />
+              </div>
+            )}
+            <DialogHeader className={cn(Icon && 'min-w-0 gap-2 text-left')}>
+              <DialogTitle>{displayedRequest?.options.title}</DialogTitle>
+              {displayedRequest?.options.description ? (
+                // Callers pass multi-line descriptions (e.g. one path per line).
+                <DialogDescription
+                  className={cn(
+                    'whitespace-pre-line',
+                    displayedRequest.options.descriptionClassName
+                  )}
+                >
+                  {displayedRequest.options.description}
+                </DialogDescription>
+              ) : null}
+            </DialogHeader>
+          </div>
           {displayedRequest?.options.dontAskAgain ? (
             <div className="flex items-center gap-2">
               <Checkbox
@@ -124,12 +145,21 @@ export function ConfirmationDialogProvider({
               </Label>
             </div>
           ) : null}
-          <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => settleActiveRequest(false)}>
+          <DialogFooter
+            className={cn(
+              Icon && '-mx-6 -mb-6 rounded-b-lg border-t border-border bg-muted/30 px-6 py-4'
+            )}
+          >
+            <Button
+              type="button"
+              variant={displayedRequest?.options.cancelVariant ?? 'outline'}
+              onClick={() => settleActiveRequest(false)}
+            >
               {displayedRequest?.options.cancelLabel ??
                 translate('auto.components.confirmation.dialog.56f5c60e0c', 'Cancel')}
             </Button>
             <Button
+              ref={confirmButtonRef}
               type="button"
               variant={displayedRequest?.options.confirmVariant ?? 'default'}
               onClick={() => settleActiveRequest(true)}

--- a/src/renderer/src/components/sidebar/WorktreeList.card-memo-stability.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.card-memo-stability.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment happy-dom
 
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn().mockResolvedValue(false)
+}))
+
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-agent-expansion-coupling.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-agent-expansion-coupling.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment happy-dom
 
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn().mockResolvedValue(false)
+}))
+
 // Regression test for the child-worktrees <-> agent-list expansion coupling:
 // in a worktree card that shows BOTH inline agent rows (with orchestration
 // lineage) AND a "N children" child-worktrees chip, toggling the child-worktrees

--- a/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.lineage-child-real-card.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment happy-dom
 
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn().mockResolvedValue(false)
+}))
+
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/src/components/sidebar/WorktreeList.status-lane-lineage-drop.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.status-lane-lineage-drop.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment happy-dom
 
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn().mockResolvedValue(false)
+}))
+
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'

--- a/src/renderer/src/components/sidebar/worktree-list-lineage-card-test-harness.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-lineage-card-test-harness.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { vi } from 'vitest'
+import { ConfirmationDialogContext } from '@/components/confirmation-dialog-context'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 
@@ -20,10 +21,14 @@ export async function loadWorktreeList(): Promise<void> {
 
 export async function renderWorktreeListMarkup(): Promise<string> {
   return renderToStaticMarkup(
-    React.createElement(WorktreeList!, {
-      scrollOffsetRef: { current: 0 },
-      scrollAnchorRef: { current: null }
-    })
+    React.createElement(
+      ConfirmationDialogContext.Provider,
+      { value: async () => false },
+      React.createElement(WorktreeList!, {
+        scrollOffsetRef: { current: 0 },
+        scrollAnchorRef: { current: null }
+      })
+    )
   )
 }
 

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ConfirmationDialogProvider } from '@/components/confirmation-dialog'
+import {
+  requestScrollToCurrentWorkspaceReveal,
+  requestScrollToCurrentWorkspaceRevealAndRename
+} from '@/lib/scroll-to-current-workspace-status'
+import { folderWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { useSidebarRevealRequests } from './use-reveal-requests'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const state = vi.hoisted(() => ({
+  setGroupBy: vi.fn(),
+  pendingRevealSidebarRow: null,
+  revealSidebarRow: vi.fn(),
+  revealWorktreeInSidebar: vi.fn(),
+  setContextualToursBlockingSurfaceVisible: vi.fn()
+}))
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (value: typeof state) => unknown) => selector(state)
+}))
+
+type Args = Parameters<typeof useSidebarRevealRequests>[0]
+function Host({ args }: { args: Args }): null {
+  useSidebarRevealRequests(args)
+  return null
+}
+
+let root: Root
+let container: HTMLDivElement
+let args: Args
+
+async function render(): Promise<void> {
+  await act(async () => {
+    root.render(
+      <ConfirmationDialogProvider>
+        <Host args={args} />
+      </ConfirmationDialogProvider>
+    )
+  })
+}
+
+async function click(label: string): Promise<void> {
+  const button = Array.from(document.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent === label
+  )
+  expect(button).toBeDefined()
+  await act(async () => button!.click())
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  container = document.createElement('div')
+  document.body.append(container)
+  root = createRoot(container)
+  const worktree: Worktree = {
+    id: 'wt-1',
+    hostId: 'ssh:dev',
+    repoId: 'repo-1',
+    path: '/repo/feature',
+    displayName: 'Feature',
+    branch: 'feature',
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1
+  }
+  args = {
+    groupBy: 'repo',
+    renderedSidebarRowKeys: new Set(),
+    renderedWorktreeIdentities: [],
+    currentSidebarWorktreeId: worktree.id,
+    currentSidebarExecutionHostId: 'ssh:dev',
+    worktreeMap: new Map([[worktree.id, worktree]]),
+    worktrees: [worktree],
+    folderWorkspaces: [],
+    hasFilters: true,
+    clearFilters: vi.fn()
+  }
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+})
+
+describe('revealing a filtered workspace', () => {
+  it('explains the filter reset and leaves filters intact when dismissed', async () => {
+    await render()
+    await act(async () => requestScrollToCurrentWorkspaceReveal())
+    expect(document.body.textContent).toContain('Revealing it will clear your sidebar filters.')
+    expect(args.clearFilters).not.toHaveBeenCalled()
+    expect(state.revealWorktreeInSidebar).not.toHaveBeenCalled()
+    await click('Keep filters')
+    expect(args.clearFilters).not.toHaveBeenCalled()
+    expect(state.revealWorktreeInSidebar).not.toHaveBeenCalled()
+  })
+
+  it('clears filters and reveals on the original execution host only after confirmation', async () => {
+    await render()
+    await act(async () => {
+      requestScrollToCurrentWorkspaceReveal()
+      requestScrollToCurrentWorkspaceReveal()
+    })
+    await click('Clear filters and reveal')
+    expect(args.clearFilters).toHaveBeenCalledTimes(1)
+    expect(state.revealWorktreeInSidebar).toHaveBeenCalledWith('wt-1', {
+      behavior: 'smooth',
+      highlight: true,
+      beginRename: false,
+      executionHostId: 'ssh:dev'
+    })
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+  })
+
+  it.each([true, false])(
+    'reveals immediately when clearing filters is unnecessary (%s)',
+    async (visible) => {
+      args = {
+        ...args,
+        hasFilters: visible,
+        renderedWorktreeIdentities: visible ? ['ssh:dev|wt-1'] : []
+      }
+      await render()
+      await act(async () => requestScrollToCurrentWorkspaceReveal())
+      expect(document.querySelector('[role="dialog"]')).toBeNull()
+      expect(args.clearFilters).not.toHaveBeenCalled()
+      expect(state.revealWorktreeInSidebar).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('does not apply a stale confirmation after switching workspaces', async () => {
+    await render()
+    await act(async () => requestScrollToCurrentWorkspaceReveal())
+    args = { ...args, currentSidebarWorktreeId: 'wt-2' }
+    await render()
+    await click('Clear filters and reveal')
+    expect(args.clearFilters).not.toHaveBeenCalled()
+    expect(state.revealWorktreeInSidebar).not.toHaveBeenCalled()
+  })
+
+  it('confirms filtered folder workspaces and preserves the rename request', async () => {
+    args = {
+      ...args,
+      currentSidebarWorktreeId: folderWorkspaceKey('folder-1'),
+      currentSidebarExecutionHostId: null,
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'project-1',
+          name: 'Notes',
+          folderPath: '/notes',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 1,
+          lastActivityAt: 1,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    }
+    await render()
+    await act(async () => requestScrollToCurrentWorkspaceRevealAndRename())
+    expect(args.clearFilters).not.toHaveBeenCalled()
+    await click('Clear filters and reveal')
+    expect(args.clearFilters).toHaveBeenCalledTimes(1)
+    expect(state.revealWorktreeInSidebar).toHaveBeenCalledWith(folderWorkspaceKey('folder-1'), {
+      behavior: 'smooth',
+      highlight: true,
+      beginRename: true,
+      executionHostId: undefined
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react'
 import { Crosshair } from 'lucide-react'
 import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
 import { translate } from '@/i18n/i18n'
@@ -47,7 +47,9 @@ export function useSidebarRevealRequests(args: {
   const confirm = useConfirmationDialog()
   const confirmationPending = useRef(false)
   const latestArgs = useRef(args)
-  latestArgs.current = args
+  useLayoutEffect(() => {
+    latestArgs.current = args
+  })
 
   useEffect(() => {
     if (!pendingRevealSidebarRow) {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
+import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import {
   SCROLL_TO_CURRENT_WORKSPACE_REVEAL_REQUEST_EVENT,
@@ -41,6 +43,10 @@ export function useSidebarRevealRequests(args: {
   const pendingRevealSidebarRow = useAppStore((s) => s.pendingRevealSidebarRow)
   const revealSidebarRow = useAppStore((s) => s.revealSidebarRow)
   const revealWorktreeInSidebar = useAppStore((s) => s.revealWorktreeInSidebar)
+  const confirm = useConfirmationDialog()
+  const confirmationPending = useRef(false)
+  const latestArgs = useRef(args)
+  latestArgs.current = args
 
   useEffect(() => {
     if (!pendingRevealSidebarRow) {
@@ -68,7 +74,7 @@ export function useSidebarRevealRequests(args: {
   ])
 
   const handleRevealCurrentWorkspaceRequest = useCallback(
-    (event: Event) => {
+    async (event: Event) => {
       const detail =
         event instanceof CustomEvent
           ? (event.detail as ScrollToCurrentWorkspaceRevealRequestDetail | undefined)
@@ -101,9 +107,37 @@ export function useSidebarRevealRequests(args: {
         currentSidebarExecutionHostId ?? undefined,
         currentSidebarWorktreeId
       )
-      if (!renderedWorktreeIdentities.includes(currentIdentity)) {
-        // Why: the reveal action must show the current workspace, so relax filters that hide it first.
-        clearFilters()
+      if (hasFilters && !renderedWorktreeIdentities.includes(currentIdentity)) {
+        if (confirmationPending.current) {
+          return
+        }
+        confirmationPending.current = true
+        let confirmed: boolean
+        try {
+          confirmed = await confirm({
+            title: translate('sidebar.revealFiltered.title', 'Reveal hidden workspace?'),
+            description: translate(
+              'sidebar.revealFiltered.description',
+              'The active workspace is hidden in the sidebar. Revealing it will clear your sidebar filters.'
+            ),
+            confirmLabel: translate('sidebar.revealFiltered.confirm', 'Clear filters and reveal'),
+            cancelLabel: translate('sidebar.revealFiltered.cancel', 'Keep filters')
+          })
+        } finally {
+          confirmationPending.current = false
+        }
+        const latest = latestArgs.current
+        // A workspace switch while the dialog is open must not clear filters for a stale target.
+        if (
+          !confirmed ||
+          latest.currentSidebarWorktreeId !== currentSidebarWorktreeId ||
+          latest.currentSidebarExecutionHostId !== currentSidebarExecutionHostId
+        ) {
+          return
+        }
+        if (latest.hasFilters && !latest.renderedWorktreeIdentities.includes(currentIdentity)) {
+          latest.clearFilters()
+        }
       }
       revealWorktreeInSidebar(currentSidebarWorktreeId, {
         behavior: 'smooth',
@@ -113,7 +147,8 @@ export function useSidebarRevealRequests(args: {
       })
     },
     [
-      clearFilters,
+      confirm,
+      hasFilters,
       currentSidebarWorktreeId,
       currentSidebarExecutionHostId,
       folderWorkspaces,

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-reveal-requests.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react'
+import { Crosshair } from 'lucide-react'
 import { useConfirmationDialog } from '@/components/confirmation-dialog-context'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
@@ -115,6 +116,9 @@ export function useSidebarRevealRequests(args: {
         let confirmed: boolean
         try {
           confirmed = await confirm({
+            icon: Crosshair,
+            initialFocus: 'confirm',
+            cancelVariant: 'ghost',
             title: translate('sidebar.revealFiltered.title', 'Reveal hidden workspace?'),
             description: translate(
               'sidebar.revealFiltered.description',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1,4 +1,12 @@
 {
+  "sidebar": {
+    "revealFiltered": {
+      "title": "Reveal hidden workspace?",
+      "description": "The active workspace is hidden in the sidebar. Revealing it will clear your sidebar filters.",
+      "confirm": "Clear filters and reveal",
+      "cancel": "Keep filters"
+    }
+  },
   "app": {
     "recoverableError": {
       "rootTitle": "Orca hit a renderer error.",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​238 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​238 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​112 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |

<!-- /orca-pr-loc -->

## ELI5

Revealing the active workspace could silently remove sidebar filters. Orca now explains the change first and lets you keep your filters or clear them and reveal the workspace.

## What Changed

- Reuse the compact confirmation dialog when the active workspace is absent from the rendered sidebar and filters are active.
- Give the prompt a reveal icon, clearer spacing, a subtle action footer, and a quiet cancel button. Autofocus the primary action so Enter proceeds; other confirmations retain their existing focus behavior.
- “Keep filters” and Escape leave filters intact. “Clear filters and reveal” continues the existing reveal flow; already-visible workspaces reveal immediately.
- Deduplicate repeated requests and ignore confirmation if the active workspace or execution host changes while the dialog is open.
- Preserve folder workspace, SSH host identity, and reveal-and-rename behavior; add English copy and regression coverage.

## Why

Changing the sidebar view should be an explicit choice when a navigation action would reset filters.

## Linked Issue

Direct user-reported bug; this worktree has no linked issue.

## Visual Proof

Captured through Playwright CDP in this branch’s macOS Electron instance. These show the new flow before revealing, at the confirmation, and after proceeding.

| Before revealing: workspace filtered out | After confirming: workspace revealed |
| --- | --- |
| ![Filtered sidebar](https://github.com/user-attachments/assets/b08a8b58-24df-4bc4-9419-7ad76500f20a) | ![Revealed workspace](https://github.com/user-attachments/assets/b1686ace-83f4-4867-b658-540bbe12c3f3) |

The new confirmation appears before any filter reset:

| Dark | Light |
| --- | --- |
| ![Confirmation in dark mode](https://github.com/user-attachments/assets/1e2eb8d6-1b07-4eb7-b758-29e4180c7360) | ![Confirmation in light mode](https://github.com/user-attachments/assets/a39b0039-e1de-41bf-aa5c-61f2cd63d193) |

## Testing

- [x] Manually exercised the rendered macOS Electron flow via Playwright CDP: Keep filters, Escape, and Clear filters and reveal.
- [x] Verified primary-action autofocus and Enter-to-reveal in Electron; inspected light and dark themes. All 13 tests in the confirmation provider and reveal-hook suites pass, including opt-in focus, Enter, Escape, and preserved default cancel focus.
- [x] Automated tests added/updated: 22 tests passing across the reveal hook and four sidebar integration suites, including duplicate requests, stale targets, SSH identity, folder workspaces, and rename.
- `pnpm tc:web` passed.
- Changed-code quality gate and targeted oxlint passed; commit hooks passed.
- Localization catalog verification and `git diff --check` passed.
- Linux, Windows, and live SSH were not exercised; SSH identity is covered by unit tests. Full repository checks are left to CI.

## Review

- [x] Small, focused change; existing dialog and filter reset reused.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform and remote behavior considered; no IPC, path, shortcut, or wire changes.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill source copied into the implementation.
