### PR TITLE
fix(nsis): detect a running Orca without spawning Windows PowerShell

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -912,6 +912,12 @@ jobs:
           ORCA_REUSE_PREPARED_NATIVE_RUNTIME: '1'
         run: pnpm exec electron-builder --config config/electron-builder.config.cjs --dir
 
+      # Compile both installer and uninstaller hooks against the real bundled plugins.
+      - name: Compile NSIS installer
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: pnpm exec electron-builder --config config/electron-builder.config.cjs --win nsis --prepackaged dist/win-unpacked --publish never
+
       - name: Smoke packaged Windows PTY native capability
         run: pnpm run smoke:windows-pty-native-capability -- --exe=dist/win-unpacked/Orca.exe
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -912,17 +912,19 @@ jobs:
           ORCA_REUSE_PREPARED_NATIVE_RUNTIME: '1'
         run: pnpm exec electron-builder --config config/electron-builder.config.cjs --dir
 
-      # Compile both installer and uninstaller hooks against the real bundled plugins.
-      - name: Compile NSIS installer
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
-        run: pnpm exec electron-builder --config config/electron-builder.config.cjs --win nsis --prepackaged dist/win-unpacked --publish never
-
       - name: Smoke packaged Windows PTY native capability
         run: pnpm run smoke:windows-pty-native-capability -- --exe=dist/win-unpacked/Orca.exe
 
       - name: Smoke packaged CLI
         run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/win-unpacked
+
+      # Compile both installer and uninstaller hooks against the real bundled plugins.
+      # Why last: the smokes assert on dist/win-unpacked, which must reach them exactly
+      # as electron-builder left it.
+      - name: Compile NSIS installer
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
+        run: pnpm exec electron-builder --config config/electron-builder.config.cjs --win nsis --prepackaged dist/win-unpacked --publish never
 
   e2e:
     name: e2e

--- a/config/nsis/orca-installer-hooks.nsh
+++ b/config/nsis/orca-installer-hooks.nsh
@@ -13,7 +13,12 @@
     Sleep 300
   ${endIf}
 
+  orca_check_again:
   ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+  ${if} $R0 != 0
+  ${andIf} $R0 != 603
+    Goto orca_check_failed
+  ${endIf}
   ${if} $R0 == 0
     ${if} ${isUpdated}
       Sleep 1000
@@ -34,16 +39,22 @@
 
     orca_wait_loop:
       ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
-      ${if} $R0 != 0
+      ${if} $R0 == 603
         Goto orca_not_running
+      ${endIf}
+      ${if} $R0 != 0
+        Goto orca_check_failed
       ${endIf}
 
       Sleep 1000
       ${nsProcess::KillProcess} "${APP_EXECUTABLE_FILENAME}" $R0
 
       ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
-      ${if} $R0 != 0
+      ${if} $R0 == 603
         Goto orca_not_running
+      ${endIf}
+      ${if} $R0 != 0
+        Goto orca_check_failed
       ${endIf}
 
       DetailPrint `Waiting for "${PRODUCT_NAME}" to close.`
@@ -61,6 +72,15 @@
     orca_not_running:
   ${endIf}
 
+  Goto orca_check_done
+
+  orca_check_failed:
+    MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Unable to check whether ${PRODUCT_NAME} is running (process query error $R0). Close ${PRODUCT_NAME} and retry." /SD IDCANCEL IDRETRY orca_check_again
+    ${nsProcess::Unload}
+    SetErrorLevel 2
+    Quit
+
+  orca_check_done:
   ${nsProcess::Unload}
 !macroend
 

--- a/config/nsis/orca-installer-hooks.nsh
+++ b/config/nsis/orca-installer-hooks.nsh
@@ -3,6 +3,67 @@
 ; electron-builder accepts exactly ONE `nsis.include` file, so every customInstall /
 ; customUnInstall hook Orca needs lives here.
 
+; Native process checks avoid false success when GPO blocks Windows PowerShell
+; while returning exit code 0 (issues #13924, #16528).
+; customCheckAppRunning also prevents electron-builder from expanding its
+; PowerShell-based probe; nsProcess is already bundled by electron-builder.
+!macro customCheckAppRunning
+  ${if} ${isUpdated}
+    ; Preserve electron-builder's update grace period.
+    Sleep 300
+  ${endIf}
+
+  ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+  ${if} $R0 == 0
+    ${if} ${isUpdated}
+      Sleep 1000
+    ${else}
+      MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION "$(appRunning)" /SD IDOK IDOK orca_stop_app
+      ${nsProcess::Unload}
+      Quit
+    ${endIf}
+
+    orca_stop_app:
+
+    DetailPrint "$(appClosing)"
+    ; Allow state to flush before forcing termination.
+    ${nsProcess::CloseProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+    Sleep 300
+
+    StrCpy $R1 0
+
+    orca_wait_loop:
+      ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+      ${if} $R0 != 0
+        Goto orca_not_running
+      ${endIf}
+
+      Sleep 1000
+      ${nsProcess::KillProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+
+      ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
+      ${if} $R0 != 0
+        Goto orca_not_running
+      ${endIf}
+
+      DetailPrint `Waiting for "${PRODUCT_NAME}" to close.`
+      Sleep 2000
+
+      IntOp $R1 $R1 + 1
+      ; An elevated process may require manual closure.
+      ${if} $R1 > 1
+        MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY orca_wait_loop
+        ${nsProcess::Unload}
+        Quit
+      ${endIf}
+      Goto orca_wait_loop
+
+    orca_not_running:
+  ${endIf}
+
+  ${nsProcess::Unload}
+!macroend
+
 ; ---------------------------------------------------------------------------
 ; Markdown "Open with Orca" (issue #10138)
 ;

--- a/config/scripts/electron-builder-markdown-associations.test.mjs
+++ b/config/scripts/electron-builder-markdown-associations.test.mjs
@@ -165,4 +165,13 @@ describe('electron-builder app-running check', () => {
     expect(macro).toContain('${nsProcess::KillProcess}')
     expect(macro).not.toMatch(/powershell|nsExec::Exec|!insertmacro\s+(?:FIND|KILL)_PROCESS/i)
   })
+
+  it('only treats code 603 as absence and reports process enumeration errors', async () => {
+    const macro = extractNsisMacro(await readInstallerHooks(), 'customCheckAppRunning')
+    expect(macro.match(/Goto orca_check_failed/g)).toHaveLength(3)
+    expect(macro.match(/\$\{if\} \$R0 == 603/g)).toHaveLength(2)
+    expect(macro).toContain('${andIf} $R0 != 603')
+    expect(macro).toContain('process query error $R0')
+    expect(macro).toContain('SetErrorLevel 2')
+  })
 })

--- a/config/scripts/electron-builder-markdown-associations.test.mjs
+++ b/config/scripts/electron-builder-markdown-associations.test.mjs
@@ -23,6 +23,12 @@ const stripNsisCommentLines = (source) =>
 
 const readInstallerHooks = () => readFile(electronBuilderConfig.nsis.include, 'utf8')
 
+const extractNsisMacro = (source, name) => {
+  const match = source.match(new RegExp(`!macro\\s+${name}\\b[\\s\\S]*?!macroend`))
+  expect(match, `${name} macro`).not.toBeNull()
+  return match[0]
+}
+
 describe('electron-builder markdown file associations', () => {
   // Why: any top-level (or `win.`) fileAssociations entry makes app-builder-lib's NSIS
   // packager emit `!insertmacro APP_ASSOCIATE`, whose first line writes that DEFAULT value
@@ -122,5 +128,16 @@ describe('electron-builder markdown file associations', () => {
     // Without this guard, uninstallOldVersion would kill the daemon on every update —
     // defeating the relocation that keeps terminals alive across updates.
     expect(script).toMatch(/\$\{ifNot\}\s+\$\{isUpdated\}/)
+  })
+})
+
+describe('electron-builder app-running check', () => {
+  it('uses the bundled native process plugin instead of a child shell', async () => {
+    const macro = extractNsisMacro(await readInstallerHooks(), 'customCheckAppRunning')
+
+    expect(macro).toContain('${nsProcess::FindProcess}')
+    expect(macro).toContain('${nsProcess::CloseProcess}')
+    expect(macro).toContain('${nsProcess::KillProcess}')
+    expect(macro).not.toMatch(/powershell|nsExec::Exec|!insertmacro\s+(?:FIND|KILL)_PROCESS/i)
   })
 })

--- a/config/scripts/electron-builder-markdown-associations.test.mjs
+++ b/config/scripts/electron-builder-markdown-associations.test.mjs
@@ -24,7 +24,9 @@ const stripNsisCommentLines = (source) =>
 const readInstallerHooks = () => readFile(electronBuilderConfig.nsis.include, 'utf8')
 
 const extractNsisMacro = (source, name) => {
-  const match = source.match(new RegExp(`!macro\\s+${name}\\b[\\s\\S]*?!macroend`))
+  const match = stripNsisCommentLines(source).match(
+    new RegExp(`^[\\t ]*!macro[\\t ]+${name}\\b[\\s\\S]*?^[\\t ]*!macroend\\b`, 'm')
+  )
   expect(match, `${name} macro`).not.toBeNull()
   return match[0]
 }
@@ -132,6 +134,29 @@ describe('electron-builder markdown file associations', () => {
 })
 
 describe('electron-builder app-running check', () => {
+  it.each([';', '#'])('rejects a macro disabled with %s comments', async (prefix) => {
+    const macro = extractNsisMacro(await readInstallerHooks(), 'customCheckAppRunning')
+    const disabled = macro
+      .split('\n')
+      .map((line) => `${prefix} ${line}`)
+      .join('\n')
+    expect(() => extractNsisMacro(disabled, 'customCheckAppRunning')).toThrow()
+  })
+
+  it('ignores commented calls and macro terminators', () => {
+    const source = [
+      '!macro example',
+      '; !macroend',
+      '# ${nsProcess::FindProcess}',
+      '  DetailPrint "still inside"',
+      '!macroend'
+    ].join('\n')
+    const macro = extractNsisMacro(source, 'example')
+    expect(macro).toContain('DetailPrint "still inside"')
+    expect(macro).not.toContain('nsProcess::FindProcess')
+    expect(() => extractNsisMacro('DetailPrint "!macro example"\n!macroend', 'example')).toThrow()
+  })
+
   it('uses the bundled native process plugin instead of a child shell', async () => {
     const macro = extractNsisMacro(await readInstallerHooks(), 'customCheckAppRunning')
 

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -196,6 +196,7 @@ const LINUX_PACKAGE_PREFIXES = [
 
 const WINDOWS_PACKAGE_PREFIXES = [
   ...SHARED_PACKAGE_PREFIXES,
+  'config/nsis/',
   'native/windows-cli-launcher/',
   'native/computer-use-windows/',
   'resources/win32/',

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -111,6 +111,8 @@ describe('per-job path classification', () => {
     expect(steps[compileIndex].run).toContain('--publish never')
     expect(steps[compileIndex]['continue-on-error']).not.toBe(true)
     expect(steps[compileIndex].if).toBeUndefined()
+    // PR CI has no signing certificate; discovery would fail the compile.
+    expect(steps[compileIndex].env).toMatchObject({ CSC_IDENTITY_AUTO_DISCOVERY: 'false' })
   })
 
   it('runs every expensive job on an empty diff rather than skipping by accident', () => {

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -100,6 +100,19 @@ describe('docs-only path classification', () => {
 })
 
 describe('per-job path classification', () => {
+  it('compiles Windows installers for NSIS-only changes', () => {
+    expectClassification(['config/nsis/orca-installer-hooks.nsh'], { package_windows: true })
+    const steps = prWorkflow.jobs.package_windows.steps
+    const compileIndex = steps.findIndex((step) => step.name === 'Compile NSIS installer')
+    expect(compileIndex).toBeGreaterThan(
+      steps.findIndex((step) => step.name === 'Package unpacked app')
+    )
+    expect(steps[compileIndex].run).toContain('--win nsis --prepackaged dist/win-unpacked')
+    expect(steps[compileIndex].run).toContain('--publish never')
+    expect(steps[compileIndex]['continue-on-error']).not.toBe(true)
+    expect(steps[compileIndex].if).toBeUndefined()
+  })
+
   it('runs every expensive job on an empty diff rather than skipping by accident', () => {
     const result = classifyPrJobs([])
     expect(result.should_run).toBe(true)


### PR DESCRIPTION
## ELI5

On Windows machines where PowerShell is blocked, the installer can incorrectly say Orca is running even when it is not. Check running processes using the native plugin already shipped with electron-builder.

## What Changed

- Override `customCheckAppRunning` with bundled nsProcess detection and closure, retaining update delays and retry/cancel prompts for both installation and uninstallation.
- Strip NSIS comment lines and anchor macro directives in the contract test. Regression cases reject disabled macros, commented calls/terminators, and directives embedded inside other text.
- Compile the actual NSIS installer and uninstaller in the Windows PR packaging job using the existing unpacked application and `--publish never`.
- Include `config/nsis/` in Windows packaging path detection so an NSIS-only change cannot skip that job.

## Why

The reported PowerShell-blocking environment returns exit code 0 without executing the probe. That makes electron-builder's availability and process checks report false success and prevents its fallback from running. Native process checks remove that dependency. Compiling real installer scripts catches syntax, label, and plugin integration failures that a source-text test cannot.

## Linked Issue

Fixes #13924
Fixes #16528

## Visual Proof

N/A — this changes installer process detection and validation, with no new UI or layout. Existing installer dialogs are retained. No interactive before/after recording was captured.

## Testing

Windows local validation:

- `corepack pnpm test config/scripts/electron-builder-markdown-associations.test.mjs config/scripts/pr-code-change-scope.test.mjs config/scripts/skills-cli-package-workflow.test.mjs config/scripts/package-electron-runtime-contract.test.mjs`: 65 tests passed.
- `corepack pnpm run check:code-quality:changed`: no new findings.
- Formatting and `git diff --check`: passed.
- `corepack pnpm exec electron-builder --config config/electron-builder.config.cjs --win nsis --prepackaged dist/win-unpacked --publish never`: real installer/uninstaller compilation and blockmap generation passed, with `CSC_IDENTITY_AUTO_DISCOVERY=false`.

- [ ] Interactive installation/update/uninstallation under the reported GPO policy manually tested in this revision.
- [x] Automated tests added/updated.

The local installer is unsigned; production signing remains the existing release workflow's responsibility. The packaging check reuses existing compiled app inputs. Full lint, typecheck, application rebuild, and full-suite testing were not rerun locally; PR CI covers the configured gates. macOS/Linux/SSH execution was not exercised for this Windows installer change.

## AI Disclosure

Prepared with AI coding assistance (Claude and OpenAI Codex). This revision used Codex to inspect review mail/comments, implement the fixes, and run local validation.

## Review

Addressed CodeRabbit's commented-macro false-positive finding, Pullfrog's missing NSIS compilation coverage, and the incomplete PR description. Also corrected the NSIS-only path filter that would otherwise bypass the new compilation step.

## Agent skill upstream boundary

- [x] Not applicable: no upstream skill-installer content is copied or translated.

## Notes

Matching is by executable image name rather than installation path, so another Orca installation/session with the same executable name can be affected, subject to process permissions. The separately named terminal daemon is not targeted by this check. Detection-error handling and actual closure behavior under elevated/multi-user conditions still need interactive validation. This change does not modify SSH execution, remote wire formats, folder workspace handling, mobile behavior, or non-Windows packaging.

## Checklist

- [x] This PR is small and focused.
- [x] Explained what changed and why, including ELI5.
- [x] Visual proof applicability and testing limitations documented.
- [x] Self-reviewed the changes and validation wiring.
- [x] Cross-platform, SSH/remote, and path impacts considered.
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` confirmed green for this revision (CI pending).
