### PR TITLE
fix(native-chat): stop parked chat views from capturing the zoom shortcut

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
@@ -315,9 +315,8 @@ export function NativeChatResolvedView({
   }, [interactiveSend, pendingScope])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
-  // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so
-  // the chord is inert on the loading/empty/error states and elsewhere.
-  const fontScale = useNativeChatFontScale(isConversation)
+  // Chat-only font zoom via Cmd/Ctrl +/-/0 stays inert for parked and non-live views.
+  const fontScale = useNativeChatFontScale({ enabled: isConversation, isVisible })
 
   return (
     <div

--- a/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatResolvedView.tsx
@@ -316,7 +316,7 @@ export function NativeChatResolvedView({
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
   // Chat-only font zoom via Cmd/Ctrl +/-/0 stays inert for parked and non-live views.
-  const fontScale = useNativeChatFontScale({ enabled: isConversation, isVisible })
+  const fontScale = useNativeChatFontScale({ enabled: isConversation, isVisible, rootRef })
 
   return (
     <div

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -174,7 +174,9 @@ describe('NativeChatStructuredSession', () => {
       />
     )
 
-    expect(mocks.fontScale).toHaveBeenCalledWith({ enabled: true, isVisible: false })
+    expect(mocks.fontScale).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, isVisible: false })
+    )
   })
 
   it('wires local structured file links through the native chat opener', () => {

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
     onLinkClick?: (...args: unknown[]) => void
   },
   composerProps: null as null | { structuredTransport?: Record<string, unknown> },
+  fontScale: vi.fn(() => ({ scale: 1 })),
   handlePasteEvent: vi.fn(),
   pasteFromClipboard: vi.fn(),
   submissions: [] as unknown[]
@@ -89,7 +90,7 @@ vi.mock('./use-structured-agent-session', async () => {
 })
 
 vi.mock('./use-native-chat-font-scale', () => ({
-  useNativeChatFontScale: () => ({ scale: 1 })
+  useNativeChatFontScale: mocks.fontScale
 }))
 
 vi.mock('./use-native-chat-file-link-context', () => ({
@@ -136,6 +137,7 @@ describe('NativeChatStructuredSession', () => {
     mocks.mode = 'static'
     mocks.messageListProps = null
     mocks.composerProps = null
+    mocks.fontScale.mockClear()
     mocks.handlePasteEvent.mockReset()
     mocks.pasteFromClipboard.mockReset()
     mocks.submissions = []
@@ -158,6 +160,21 @@ describe('NativeChatStructuredSession', () => {
     window.dispatchEvent(new Event('orca-app-menu-paste', { cancelable: true }))
 
     expect(mocks.pasteFromClipboard).toHaveBeenCalledOnce()
+  })
+
+  it('disables font zoom while the structured session is parked', () => {
+    render(
+      <NativeChatStructuredSession
+        isVisible={false}
+        tabId="structured-tab-hidden"
+        sessionId="session-hidden"
+        target={{ kind: 'local' }}
+        agent="codex"
+        allowFileUriLinks
+      />
+    )
+
+    expect(mocks.fontScale).toHaveBeenCalledWith({ enabled: true, isVisible: false })
   })
 
   it('wires local structured file links through the native chat opener', () => {

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -81,7 +81,8 @@ export function NativeChatStructuredSession(props: {
   const viewState = selectNativeChatViewState(session)
   const fontScale = useNativeChatFontScale({
     enabled: viewState.kind === 'ready',
-    isVisible: props.isVisible
+    isVisible: props.isVisible,
+    rootRef
   })
   const fileLinkContext = useNativeChatFileLinkContext(props.tabId)
   const imageRuntimeContext = useNativeChatImageRuntimeContext(props.tabId)

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -79,7 +79,10 @@ export function NativeChatStructuredSession(props: {
     [controller, props.agent, props.sessionId]
   )
   const viewState = selectNativeChatViewState(session)
-  const fontScale = useNativeChatFontScale(viewState.kind === 'ready')
+  const fontScale = useNativeChatFontScale({
+    enabled: viewState.kind === 'ready',
+    isVisible: props.isVisible
+  })
   const fileLinkContext = useNativeChatFileLinkContext(props.tabId)
   const imageRuntimeContext = useNativeChatImageRuntimeContext(props.tabId)
   const fileLinkClick = useNativeChatFileLinkClick(props.allowFileUriLinks ? fileLinkContext : null)

--- a/src/renderer/src/components/native-chat/native-chat-zoom-owner.ts
+++ b/src/renderer/src/components/native-chat/native-chat-zoom-owner.ts
@@ -1,0 +1,51 @@
+import type { UIZoomDirection } from '../../../../shared/ui-zoom-level'
+
+type NativeChatZoomHandler = (direction: UIZoomDirection) => void
+
+const NATIVE_CHAT_ROOT_SELECTOR = '[data-native-chat-root="true"]'
+const handlersByRoot = new WeakMap<Element, NativeChatZoomHandler>()
+
+function findNativeChatRoot(activeElement: unknown): Element | null {
+  if (
+    typeof activeElement !== 'object' ||
+    activeElement === null ||
+    !('closest' in activeElement) ||
+    typeof (activeElement as { closest?: unknown }).closest !== 'function'
+  ) {
+    return null
+  }
+  return (
+    activeElement as {
+      closest: (selector: string) => Element | null
+    }
+  ).closest(NATIVE_CHAT_ROOT_SELECTOR)
+}
+
+export function isNativeChatZoomFocused(activeElement: unknown): boolean {
+  return findNativeChatRoot(activeElement) !== null
+}
+
+export function registerNativeChatZoomOwner(
+  root: Element,
+  handler: NativeChatZoomHandler
+): () => void {
+  handlersByRoot.set(root, handler)
+  return () => {
+    if (handlersByRoot.get(root) === handler) {
+      handlersByRoot.delete(root)
+    }
+  }
+}
+
+export function dispatchNativeChatZoom(
+  activeElement: unknown,
+  direction: UIZoomDirection
+): boolean {
+  const root = findNativeChatRoot(activeElement)
+  const handler = root ? handlersByRoot.get(root) : undefined
+  if (!handler) {
+    return false
+  }
+  handler(direction)
+  return true
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-font-scale.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-font-scale.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { isMacPlatform } from './native-chat-shortcut'
+import { useNativeChatFontScale } from './use-native-chat-font-scale'
+
+afterEach(cleanup)
+
+function increaseFontScale(): void {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: '=',
+      ...(isMacPlatform() ? { metaKey: true } : { ctrlKey: true })
+    })
+  )
+}
+
+describe('useNativeChatFontScale', () => {
+  it('ignores zoom shortcuts while a conversation is parked', () => {
+    const view = renderHook(
+      ({ isVisible }) => useNativeChatFontScale({ enabled: true, isVisible }),
+      { initialProps: { isVisible: false } }
+    )
+
+    act(increaseFontScale)
+    expect(view.result.current.scale).toBe(1)
+
+    view.rerender({ isVisible: true })
+    act(increaseFontScale)
+    expect(view.result.current.scale).toBe(1.1)
+
+    view.rerender({ isVisible: false })
+    act(increaseFontScale)
+    expect(view.result.current.scale).toBe(1.1)
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-font-scale.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-font-scale.test.tsx
@@ -1,11 +1,19 @@
 // @vitest-environment happy-dom
 
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { isMacPlatform } from './native-chat-shortcut'
 import { useNativeChatFontScale } from './use-native-chat-font-scale'
+import { dispatchNativeChatZoom } from './native-chat-zoom-owner'
 
-afterEach(cleanup)
+beforeEach(() => {
+  ;(globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+})
+
+afterEach(() => {
+  cleanup()
+  delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+})
 
 function increaseFontScale(): void {
   window.dispatchEvent(
@@ -18,8 +26,14 @@ function increaseFontScale(): void {
 
 describe('useNativeChatFontScale', () => {
   it('ignores zoom shortcuts while a conversation is parked', () => {
+    const root = document.createElement('div')
+    root.dataset.nativeChatRoot = 'true'
+    root.tabIndex = -1
+    document.body.append(root)
+    root.focus()
     const view = renderHook(
-      ({ isVisible }) => useNativeChatFontScale({ enabled: true, isVisible }),
+      ({ isVisible }) =>
+        useNativeChatFontScale({ enabled: true, isVisible, rootRef: { current: root } }),
       { initialProps: { isVisible: false } }
     )
 
@@ -33,5 +47,42 @@ describe('useNativeChatFontScale', () => {
     view.rerender({ isVisible: false })
     act(increaseFontScale)
     expect(view.result.current.scale).toBe(1.1)
+    root.remove()
+  })
+
+  it('does not capture web zoom outside the focused chat', () => {
+    const root = document.createElement('div')
+    root.dataset.nativeChatRoot = 'true'
+    document.body.append(root)
+    const view = renderHook(() =>
+      useNativeChatFontScale({ enabled: true, isVisible: true, rootRef: { current: root } })
+    )
+
+    document.body.focus()
+    act(increaseFontScale)
+    expect(view.result.current.scale).toBe(1)
+    root.remove()
+  })
+
+  it('applies routed desktop zoom only to the focused chat owner', () => {
+    delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+    const root = document.createElement('div')
+    root.dataset.nativeChatRoot = 'true'
+    const composer = document.createElement('textarea')
+    root.append(composer)
+    const view = renderHook(
+      ({ isVisible }) =>
+        useNativeChatFontScale({ enabled: true, isVisible, rootRef: { current: root } }),
+      { initialProps: { isVisible: true } }
+    )
+
+    act(() => {
+      expect(dispatchNativeChatZoom(composer, 'in')).toBe(true)
+    })
+    expect(view.result.current.scale).toBe(1.1)
+    expect(dispatchNativeChatZoom(document.body, 'in')).toBe(false)
+
+    view.rerender({ isVisible: false })
+    expect(dispatchNativeChatZoom(composer, 'in')).toBe(false)
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-font-scale.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-font-scale.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type RefObject } from 'react'
 import {
   chatFontScaleActionForEvent,
   decreaseChatFontScale,
@@ -6,6 +6,8 @@ import {
   increaseChatFontScale
 } from './native-chat-font-scale'
 import { isMacPlatform } from './native-chat-shortcut'
+import { registerNativeChatZoomOwner } from './native-chat-zoom-owner'
+import type { UIZoomDirection } from '../../../../shared/ui-zoom-level'
 
 export type ChatFontScaleControls = {
   /** Current chat text scale (1 = default). Apply as a font-size multiplier. */
@@ -16,17 +18,17 @@ export type ChatFontScaleControls = {
 }
 
 /**
- * In-session chat font scale plus the Cmd/Ctrl +/-/0 keyboard bindings — the
- * desktop analog of mobile pinch-zoom. Conversation readiness and visibility
- * both gate the listener so a parked chat cannot intercept another tab's zoom
- * shortcut. The scale lives in component state (in-session is fine per the plan).
+ * In-session chat font scale plus desktop routed zoom and web Cmd/Ctrl +/-/0
+ * bindings. The scale lives in component state (in-session is fine per the plan).
  */
 export function useNativeChatFontScale({
   enabled,
-  isVisible
+  isVisible,
+  rootRef
 }: {
   enabled: boolean
   isVisible: boolean
+  rootRef: RefObject<HTMLDivElement | null>
 }): ChatFontScaleControls {
   const [scale, setScale] = useState(DEFAULT_CHAT_FONT_SCALE)
 
@@ -34,8 +36,32 @@ export function useNativeChatFontScale({
   const decrease = useCallback(() => setScale((s) => decreaseChatFontScale(s)), [])
   const reset = useCallback(() => setScale(DEFAULT_CHAT_FONT_SCALE), [])
 
+  const applyZoom = useCallback(
+    (direction: UIZoomDirection) => {
+      if (direction === 'in') {
+        increase()
+      } else if (direction === 'out') {
+        decrease()
+      } else {
+        reset()
+      }
+    },
+    [decrease, increase, reset]
+  )
+
   useEffect(() => {
-    if (!enabled || !isVisible) {
+    const root = rootRef.current
+    if (!enabled || !isVisible || !root) {
+      return
+    }
+    return registerNativeChatZoomOwner(root, applyZoom)
+  }, [applyZoom, enabled, isVisible, rootRef])
+
+  useEffect(() => {
+    const root = rootRef.current
+    const isWebClient =
+      (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ === true
+    if (!enabled || !isVisible || !isWebClient || !root) {
       return
     }
     const isMac = isMacPlatform()
@@ -44,21 +70,18 @@ export function useNativeChatFontScale({
       if (!action) {
         return
       }
+      if (!root.contains(document.activeElement)) {
+        return
+      }
       // Why: capture-phase + preventDefault so the chord drives chat zoom instead
       // of the host (Electron) page zoom, and only while chat is active.
       e.preventDefault()
       e.stopPropagation()
-      if (action === 'increase') {
-        increase()
-      } else if (action === 'decrease') {
-        decrease()
-      } else {
-        reset()
-      }
+      applyZoom(action === 'increase' ? 'in' : action === 'decrease' ? 'out' : 'reset')
     }
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [enabled, isVisible, increase, decrease, reset])
+  }, [applyZoom, enabled, isVisible, rootRef])
 
   return { scale, increase, decrease, reset }
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-font-scale.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-font-scale.ts
@@ -17,12 +17,17 @@ export type ChatFontScaleControls = {
 
 /**
  * In-session chat font scale plus the Cmd/Ctrl +/-/0 keyboard bindings — the
- * desktop analog of mobile pinch-zoom. `enabled` gates the listener to the
- * focused/active chat view so the chord can't act when chat isn't on screen,
- * keeping the scale scoped to the chat surface rather than the whole app. The
- * scale lives in component state (in-session is fine per the plan).
+ * desktop analog of mobile pinch-zoom. Conversation readiness and visibility
+ * both gate the listener so a parked chat cannot intercept another tab's zoom
+ * shortcut. The scale lives in component state (in-session is fine per the plan).
  */
-export function useNativeChatFontScale(enabled: boolean): ChatFontScaleControls {
+export function useNativeChatFontScale({
+  enabled,
+  isVisible
+}: {
+  enabled: boolean
+  isVisible: boolean
+}): ChatFontScaleControls {
   const [scale, setScale] = useState(DEFAULT_CHAT_FONT_SCALE)
 
   const increase = useCallback(() => setScale((s) => increaseChatFontScale(s)), [])
@@ -30,7 +35,7 @@ export function useNativeChatFontScale(enabled: boolean): ChatFontScaleControls 
   const reset = useCallback(() => setScale(DEFAULT_CHAT_FONT_SCALE), [])
 
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || !isVisible) {
       return
     }
     const isMac = isMacPlatform()
@@ -53,7 +58,7 @@ export function useNativeChatFontScale(enabled: boolean): ChatFontScaleControls 
     }
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [enabled, increase, decrease, reset])
+  }, [enabled, isVisible, increase, decrease, reset])
 
   return { scale, increase, decrease, reset }
 }

--- a/src/renderer/src/hooks/ipc-events/zoom-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/zoom-ipc-bridge.ts
@@ -2,6 +2,7 @@ import { applyUIZoom } from '@/lib/ui-zoom'
 import { computeEditorFontSize, nextEditorFontZoomLevel } from '@/lib/editor-font-zoom'
 import { zoomLevelToPercent } from '@/components/settings/SettingsConstants'
 import { dispatchZoomLevelChanged } from '@/lib/zoom-events'
+import { dispatchNativeChatZoom } from '@/components/native-chat/native-chat-zoom-owner'
 import { stepUIZoomLevel } from '../../../../shared/ui-zoom-level'
 import { useAppStore } from '../../store'
 import { resolveZoomTarget } from '../resolve-zoom-target'
@@ -19,6 +20,9 @@ export function registerZoomIpcBridge(unsubs: (() => void)[]): void {
         activeElement: document.activeElement
       })
       if (target === 'terminal') {
+        return
+      }
+      if (target === 'chat' && dispatchNativeChatZoom(document.activeElement, direction)) {
         return
       }
       if (target === 'editor') {

--- a/src/renderer/src/hooks/resolve-zoom-target.ts
+++ b/src/renderer/src/hooks/resolve-zoom-target.ts
@@ -1,12 +1,14 @@
+import { isNativeChatZoomFocused } from '@/components/native-chat/native-chat-zoom-owner'
+
 /**
- * Determine which zoom domain (terminal, editor, simulator, or UI) should be adjusted
+ * Determine which zoom domain (terminal, chat, editor, simulator, or UI) should be adjusted
  * based on current view, tab type, and focused element.
  */
 export function resolveZoomTarget(args: {
   activeView: TopLevelView
   activeTabType: WorkspaceVisibleTabType
   activeElement: unknown
-}): 'terminal' | 'editor' | 'simulator' | 'ui' {
+}): 'terminal' | 'chat' | 'editor' | 'simulator' | 'ui' {
   const { activeView, activeTabType, activeElement } = args
   const terminalInputFocused =
     typeof activeElement === 'object' &&
@@ -45,6 +47,9 @@ export function resolveZoomTarget(args: {
   }
   if (activeTabType === 'editor' || editorFocused) {
     return 'editor'
+  }
+  if (isNativeChatZoomFocused(activeElement)) {
+    return 'chat'
   }
   // Why: terminal zoom is focus-owned. After the user clicks app chrome or
   // whitespace, the active terminal tab remains visible but app zoom should own

--- a/src/renderer/src/hooks/useIpcEvents-zoom-routing.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-zoom-routing.test.ts
@@ -2,16 +2,23 @@ import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveZoomTarget } from './resolve-zoom-target'
 
-function makeTarget(args: { hasXtermClass?: boolean; editorClosest?: boolean }): {
+function makeTarget(args: {
+  hasXtermClass?: boolean
+  editorClosest?: boolean
+  nativeChatClosest?: boolean
+}): {
   classList: { contains: (token: string) => boolean }
   closest: (selector: string) => Element | null
 } {
-  const { hasXtermClass = false, editorClosest = false } = args
+  const { hasXtermClass = false, editorClosest = false, nativeChatClosest = false } = args
   return {
     classList: {
       contains: (token: string) => hasXtermClass && token === 'xterm-helper-textarea'
     },
-    closest: () => (editorClosest ? ({} as Element) : null)
+    closest: (selector) =>
+      editorClosest || (nativeChatClosest && selector === '[data-native-chat-root="true"]')
+        ? ({} as Element)
+        : null
   }
 }
 
@@ -54,6 +61,16 @@ describe('resolveZoomTarget', () => {
         activeElement: makeTarget({ editorClosest: true })
       })
     ).toBe('editor')
+  })
+
+  it('routes to chat zoom when native chat owns focus', () => {
+    expect(
+      resolveZoomTarget({
+        activeView: 'terminal',
+        activeTabType: 'terminal',
+        activeElement: makeTarget({ nativeChatClosest: true })
+      })
+    ).toBe('chat')
   })
 
   it('routes to ui zoom outside terminal view', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |

<!-- /orca-pr-loc -->

**Item 1** from the Chat UI feedback thread: *"The font size from the AI response is super funky. It's so large."*

Reported by Jinjing in the Chat UI UI/UX feedback thread: https://stablygroup.slack.com/archives/C0BV03ZK1KN/p1788474468997739

## Root cause
A parked 0x0 native-chat view still captured `Cmd+=`. Six presses drove that hidden view's transcript zoom to its 1.6x cap, rendering the documented 14px assistant/user prose at 22.4px. Because the zoom hook is shared, this was agent-independent.

## Fix
Gated the shared native-chat zoom shortcuts on visibility in both the structured and bridge consumers, while preserving scale for a visible chat.

## Validation
`oxlint` on all 5 changed paths; 4 focused test files / 42 tests, plus a 2-file rerun / 14 tests; `pnpm tc:web`. Electron CDP after-evidence measured 14px prose, 12.88px inline code, 12px code blocks.

Reproduced in the real Electron app over CDP before the fix and verified after.
