### PR TITLE
fix(native-chat): make document paths and links clickable in chat

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -156,6 +156,7 @@ function MessageRow({
           className="text-sm"
           onLinkClick={onLinkClick}
           allowFileUriLinks={allowFileUriLinks}
+          linkifyFilePaths={onLinkClick !== undefined}
         />
       ) : null}
       {tools.length > 0 ? (

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -202,7 +202,6 @@ describe('NativeChatStructuredSession', () => {
           sessionId="session-parity"
           target={{ kind: 'local' }}
           agent={agent}
-          allowFileUriLinks
         />
       )
 

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -621,7 +621,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-questions"
         target={{ kind: 'local' }}
         agent="claude"
-        allowFileUriLinks={false}
       />
     )
 
@@ -680,7 +679,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-legacy-question"
         target={{ kind: 'local' }}
         agent="claude"
-        allowFileUriLinks={false}
       />
     )
 

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -165,7 +165,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-paste"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -176,15 +175,14 @@ describe('NativeChatStructuredSession', () => {
     expect(mocks.pasteFromClipboard).toHaveBeenCalledOnce()
   })
 
-  it('wires local structured file links through the native chat opener', () => {
+  it('wires remote structured file links through the host-aware native chat opener', () => {
     render(
       <NativeChatStructuredSession
         isVisible
         tabId="structured-tab-1"
         sessionId="session-1"
-        target={{ kind: 'local' }}
+        target={{ kind: 'environment', environmentId: 'env-1' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -221,7 +219,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-1"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
     const dispatchCommand = mocks.composerProps?.structuredTransport?.dispatchCommand as
@@ -257,7 +254,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-1"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -289,7 +285,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-wedge"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -321,7 +316,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-probe-flag"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -354,7 +348,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-parked"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -404,7 +397,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-churn"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
     const { rerender } = render(makeView())
@@ -458,7 +450,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-target-switch"
         target={target}
         agent="codex"
-        allowFileUriLinks
       />
     )
     const { rerender } = render(makeView({ kind: 'local' }))
@@ -493,7 +484,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-forced"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -532,7 +522,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-pending"
         target={{ kind: 'local' }}
         agent="codex"
-        allowFileUriLinks
       />
     )
 
@@ -562,7 +551,6 @@ describe('NativeChatStructuredSession', () => {
           sessionId="session-budget"
           target={{ kind: 'local' }}
           agent="codex"
-          allowFileUriLinks
         />
       )
 

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -80,7 +80,7 @@ export function NativeChatStructuredSession(
   const fontScale = useNativeChatFontScale(viewState.kind === 'ready')
   const fileLinkContext = useNativeChatFileLinkContext(props.tabId)
   const imageRuntimeContext = useNativeChatImageRuntimeContext(props.tabId)
-  const fileLinkClick = useNativeChatFileLinkClick(props.allowFileUriLinks ? fileLinkContext : null)
+  const fileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
   const prompt = controller.prompts[0] ?? null
   const questionBody = prompt?.body.kind === 'question' ? prompt.body : null
   const questions =

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.test.tsx
@@ -8,7 +8,6 @@ type MockAppState = {
   unifiedTabsByWorktree: Record<string, readonly Tab[]>
   groupsByWorktree: Record<string, readonly TabGroup[]>
   runtimeEnvironmentId: string | null
-  executionHostId: string
   focusGroup: (worktreeId: string, groupId: string) => void
 }
 
@@ -26,7 +25,6 @@ vi.mock('@/store', async () => {
     unifiedTabsByWorktree: {},
     groupsByWorktree: {},
     runtimeEnvironmentId: null,
-    executionHostId: 'local',
     focusGroup: mocks.focusGroup
   }))
   mocks.store = useAppStore
@@ -34,8 +32,7 @@ vi.mock('@/store', async () => {
 })
 
 vi.mock('@/lib/worktree-runtime-owner', () => ({
-  getRuntimeEnvironmentIdForWorktree: (state: MockAppState) => state.runtimeEnvironmentId,
-  getExecutionHostIdForWorktree: (state: MockAppState) => state.executionHostId
+  getRuntimeEnvironmentIdForWorktree: (state: MockAppState) => state.runtimeEnvironmentId
 }))
 
 vi.mock('@/runtime/runtime-rpc-client', () => ({
@@ -177,7 +174,6 @@ function createState(activeTabId: string): MockAppState {
     },
     groupsByWorktree: { [WORKTREE_ID]: [createGroup(activeTabId)] },
     runtimeEnvironmentId: null,
-    executionHostId: 'local',
     focusGroup: mocks.focusGroup
   }
 }

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionPaneOverlayLayer.tsx
@@ -3,10 +3,7 @@ import { useShallow } from 'zustand/react/shallow'
 import type { Tab, TabGroup } from '../../../../shared/tab-types'
 import { isAgentSessionHandleProvider } from '../../../../shared/agent-session-provider-handle'
 import { useAppStore } from '@/store'
-import {
-  getExecutionHostIdForWorktree,
-  getRuntimeEnvironmentIdForWorktree
-} from '@/lib/worktree-runtime-owner'
+import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { getActiveRuntimeTarget, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { tabGroupBodyAnchorName } from '../tab-group/tab-group-body-anchor'
 import NativeChatView from './NativeChatView'
@@ -24,14 +21,12 @@ const StructuredAgentSessionOverlaySlot = memo(function StructuredAgentSessionOv
   groupId,
   isActive,
   target,
-  allowFileUriLinks,
   onFocusOwningGroup
 }: {
   tab: StructuredAgentSessionTab
   groupId: string | undefined
   isActive: boolean
   target: RuntimeClientTarget
-  allowFileUriLinks: boolean
   onFocusOwningGroup: ((groupId: string) => void) | undefined
 }): React.JSX.Element {
   const anchorName = groupId !== undefined ? tabGroupBodyAnchorName(groupId) : undefined
@@ -74,7 +69,6 @@ const StructuredAgentSessionOverlaySlot = memo(function StructuredAgentSessionOv
         agent={tab.agentSessionAgent}
         isVisible={isActive}
         target={target}
-        allowFileUriLinks={allowFileUriLinks}
       />
     </div>
   )
@@ -88,12 +82,11 @@ const StructuredAgentSessionPaneOverlayLayer = memo(
     worktreeId: string
     isWorktreeActive: boolean
   }): React.JSX.Element {
-    const { unifiedTabs, groups, runtimeEnvironmentId, allowFileUriLinks } = useAppStore(
+    const { unifiedTabs, groups, runtimeEnvironmentId } = useAppStore(
       useShallow((state) => ({
         unifiedTabs: state.unifiedTabsByWorktree[worktreeId] ?? EMPTY_UNIFIED_TABS,
         groups: state.groupsByWorktree[worktreeId] ?? EMPTY_GROUPS,
-        runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId),
-        allowFileUriLinks: getExecutionHostIdForWorktree(state, worktreeId) === 'local'
+        runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
       }))
     )
     const focusGroup = useAppStore((state) => state.focusGroup)
@@ -128,7 +121,6 @@ const StructuredAgentSessionPaneOverlayLayer = memo(
             groupId={tab.groupId}
             isActive={Boolean(isWorktreeActive && groupActiveTabById.get(tab.groupId) === tab.id)}
             target={target}
-            allowFileUriLinks={allowFileUriLinks}
             onFocusOwningGroup={focusOwningGroup}
           />
         ))}

--- a/src/renderer/src/components/native-chat/native-chat-view-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-view-types.ts
@@ -42,7 +42,6 @@ export type NativeChatStructuredViewProps = NativeChatOrchestrationProps & {
   target: RuntimeClientTarget
   agent: AgentType
   isVisible: boolean
-  allowFileUriLinks: boolean
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }
 

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -238,6 +238,27 @@ describe('CommentMarkdown link click handler', () => {
     )
   })
 
+  it('links each relative path separately when prose joins them', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Updated src/foo.ts and src/bar.ts, then docs/My Folder/notes.md."
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(Array.from(container.querySelectorAll('a')).map((anchor) => anchor.textContent)).toEqual(
+      ['src/foo.ts', 'src/bar.ts', 'docs/My Folder/notes.md']
+    )
+  })
+
   it('prevents the default action for an unresolved internal file href', () => {
     const onLinkClick = vi.fn()
     container = document.createElement('div')

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { routeNativeChatHref } from '../../../../shared/native-chat-href-routing'
 import CommentMarkdown from './CommentMarkdown'
 
 describe('CommentMarkdown link click handler', () => {
@@ -145,5 +146,96 @@ describe('CommentMarkdown link click handler', () => {
 
     expect(onLinkClick).toHaveBeenCalledWith(expect.any(Object), 'assets/diagram.png')
     expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('linkifies bare POSIX and Windows document paths without an extension allowlist', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content={String.raw`Open /tmp/sta-6481-explainer.html, docs/review.docx, C:\Reports\final.pages, and ./scripts/release.`}
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const routes = Array.from(container.querySelectorAll<HTMLAnchorElement>('a')).map((anchor) =>
+      routeNativeChatHref(anchor.getAttribute('href'))
+    )
+    expect(routes).toEqual([
+      { kind: 'file', pathText: '/tmp/sta-6481-explainer.html', line: null },
+      { kind: 'file', pathText: 'docs/review.docx', line: null },
+      { kind: 'file', pathText: String.raw`C:\Reports\final.pages`, line: null },
+      { kind: 'file', pathText: './scripts/release', line: null }
+    ])
+  })
+
+  it('makes an inline-code file path clickable while preserving code styling', () => {
+    const onLinkClick = vi.fn((event: React.MouseEvent<HTMLElement>) => event.preventDefault())
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content={'Open `C:\\Reports\\release.docx`.'}
+          onLinkClick={onLinkClick}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const code = container.querySelector('code')
+    const anchor = code?.closest('a')
+    expect(anchor).not.toBeNull()
+    expect(routeNativeChatHref(anchor?.getAttribute('href'))).toEqual({
+      kind: 'file',
+      pathText: String.raw`C:\Reports\release.docx`,
+      line: null
+    })
+
+    act(() => {
+      anchor?.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
+    })
+    expect(onLinkClick).toHaveBeenCalledOnce()
+  })
+
+  it('normalizes Windows markdown hrefs but leaves fenced paths as source text', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content={[
+            String.raw`[report](C:\Reports\summary.pdf)`,
+            '',
+            '```text',
+            '/tmp/not-a-link.html',
+            '```'
+          ].join('\n')}
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchors = container.querySelectorAll<HTMLAnchorElement>('a')
+    expect(anchors).toHaveLength(1)
+    expect(routeNativeChatHref(anchors[0]?.getAttribute('href'))).toEqual({
+      kind: 'file',
+      pathText: String.raw`C:\Reports\summary.pdf`,
+      line: null
+    })
+    expect(container.querySelector('pre')?.textContent).toContain('/tmp/not-a-link.html')
   })
 })

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -300,6 +300,46 @@ describe('CommentMarkdown link click handler', () => {
     expect(container.textContent).toContain('/tmp/$draft/report.html')
   })
 
+  it('links paths before common sentence punctuation', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Open src/foo.ts! Read docs/guide.md? View assets/report.pdf—then continue."
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(Array.from(container.querySelectorAll('a')).map((anchor) => anchor.textContent)).toEqual(
+      ['src/foo.ts', 'docs/guide.md', 'assets/report.pdf']
+    )
+  })
+
+  it('does not link partial paths across unsupported punctuation', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Leave src/foo.ts!draft/file.html, src/foo.ts—draft/file.html."
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+  })
+
   it('prevents the default action for an unresolved internal file href', () => {
     const onLinkClick = vi.fn()
     container = document.createElement('div')

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -52,6 +52,72 @@ describe('CommentMarkdown link click handler', () => {
     expect(event.defaultPrevented).toBe(true)
   })
 
+  it('intercepts auxiliary clicks on generated native file links', () => {
+    const onLinkClick = vi.fn((event: React.MouseEvent<HTMLElement>) => {
+      event.preventDefault()
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Open src/foo.ts"
+          onLinkClick={onLinkClick}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchor = container.querySelector<HTMLAnchorElement>('a')
+    const event = new window.MouseEvent('auxclick', {
+      bubbles: true,
+      cancelable: true,
+      button: 1
+    })
+
+    act(() => {
+      anchor?.dispatchEvent(event)
+    })
+
+    expect(onLinkClick).toHaveBeenCalledWith(expect.any(Object), expect.stringMatching(/^#orca-/))
+    expect(event.defaultPrevented).toBe(true)
+  })
+
+  it('does not activate generated native file links on right-click', () => {
+    const onLinkClick = vi.fn()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Open src/foo.ts"
+          onLinkClick={onLinkClick}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchor = container.querySelector<HTMLAnchorElement>('a')
+    const event = new window.MouseEvent('auxclick', {
+      bubbles: true,
+      cancelable: true,
+      button: 2
+    })
+
+    act(() => {
+      anchor?.dispatchEvent(event)
+    })
+
+    expect(onLinkClick).not.toHaveBeenCalled()
+    expect(event.defaultPrevented).toBe(false)
+  })
+
   it('sanitizes file URI links unless the caller opts in', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -214,6 +280,7 @@ describe('CommentMarkdown link click handler', () => {
   it('leaves prose-shaped slash tokens and numeric versions unlinked', () => {
     const proseFalsePositives = ['and/or', 'TCP/IP', '24/7', 'N/A', 'km/h', 'A/B test']
     const inlineCodeFalsePositives = ['origin/main', 'v1.2.3', '1.0']
+    const quotedFalsePositives = ['"and/or"', '"A/B test"']
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -222,7 +289,7 @@ describe('CommentMarkdown link click handler', () => {
       root?.render(
         <CommentMarkdown
           variant="document"
-          content={`${proseFalsePositives.join(', ')}; ${inlineCodeFalsePositives.map((value) => `\`${value}\``).join(', ')}`}
+          content={`${proseFalsePositives.join(', ')}; ${inlineCodeFalsePositives.map((value) => `\`${value}\``).join(', ')}; ${quotedFalsePositives.join(', ')}`}
           onLinkClick={vi.fn()}
           linkifyFilePaths
         />
@@ -231,6 +298,9 @@ describe('CommentMarkdown link click handler', () => {
 
     expect(container.querySelectorAll('a')).toHaveLength(0)
     for (const value of proseFalsePositives) {
+      expect(container.textContent).toContain(value)
+    }
+    for (const value of quotedFalsePositives) {
       expect(container.textContent).toContain(value)
     }
     expect(Array.from(container.querySelectorAll('code')).map((code) => code.textContent)).toEqual(
@@ -257,6 +327,63 @@ describe('CommentMarkdown link click handler', () => {
     expect(Array.from(container.querySelectorAll('a')).map((anchor) => anchor.textContent)).toEqual(
       ['src/foo.ts', 'src/bar.ts', 'docs/My Folder/notes.md']
     )
+  })
+
+  it('links quoted spaced-first-segment paths around apostrophes', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content={"Don't skip \"Brennan's Folder/notes.md\"; open 'My Folder/guide.md'."}
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchors = container.querySelectorAll<HTMLAnchorElement>('a')
+    expect(Array.from(anchors).map((anchor) => anchor.textContent)).toEqual([
+      "Brennan's Folder/notes.md",
+      'My Folder/guide.md'
+    ])
+    expect(container.textContent).toBe(
+      "Don't skip \"Brennan's Folder/notes.md\"; open 'My Folder/guide.md'."
+    )
+    expect(
+      Array.from(anchors).map((anchor) => routeNativeChatHref(anchor.getAttribute('href')))
+    ).toEqual([
+      { kind: 'file', pathText: "Brennan's Folder/notes.md", line: null },
+      { kind: 'file', pathText: 'My Folder/guide.md', line: null }
+    ])
+  })
+
+  it('links a spaced-first-segment relative path when inline code disambiguates it', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Open `My Folder/notes.md`."
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchor = container.querySelector<HTMLAnchorElement>('a')
+    expect(anchor?.textContent).toBe('My Folder/notes.md')
+    expect(routeNativeChatHref(anchor?.getAttribute('href'))).toEqual({
+      kind: 'file',
+      pathText: 'My Folder/notes.md',
+      line: null
+    })
   })
 
   it('links complete Unicode paths and extensions that begin with a digit', () => {
@@ -318,6 +445,27 @@ describe('CommentMarkdown link click handler', () => {
 
     expect(Array.from(container.querySelectorAll('a')).map((anchor) => anchor.textContent)).toEqual(
       ['src/foo.ts', 'docs/guide.md', 'assets/report.pdf']
+    )
+  })
+
+  it('links paths after CLI assignment and before Unicode sentence punctuation', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Run --config=./config.yaml。然后打开 docs/指南.md！再看 docs/报告.pdf？"
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(Array.from(container.querySelectorAll('a')).map((anchor) => anchor.textContent)).toEqual(
+      ['./config.yaml', 'docs/指南.md', 'docs/报告.pdf']
     )
   })
 

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -3,7 +3,10 @@
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { routeNativeChatHref } from '../../../../shared/native-chat-href-routing'
+import {
+  NATIVE_CHAT_FILE_HREF_PREFIX,
+  routeNativeChatHref
+} from '../../../../shared/native-chat-href-routing'
 import CommentMarkdown from './CommentMarkdown'
 
 describe('CommentMarkdown link click handler', () => {
@@ -157,7 +160,7 @@ describe('CommentMarkdown link click handler', () => {
       root?.render(
         <CommentMarkdown
           variant="document"
-          content={String.raw`Open /tmp/sta-6481-explainer.html, docs/review.docx, C:\Reports\final.pages, and ./scripts/release.`}
+          content={String.raw`Open /tmp/sta-6481-explainer.html, docs/review.docx, C:\Reports\final.pages, ./scripts/release, and src/release:12.`}
           onLinkClick={vi.fn()}
           linkifyFilePaths
         />
@@ -171,7 +174,8 @@ describe('CommentMarkdown link click handler', () => {
       { kind: 'file', pathText: '/tmp/sta-6481-explainer.html', line: null },
       { kind: 'file', pathText: 'docs/review.docx', line: null },
       { kind: 'file', pathText: String.raw`C:\Reports\final.pages`, line: null },
-      { kind: 'file', pathText: './scripts/release', line: null }
+      { kind: 'file', pathText: './scripts/release', line: null },
+      { kind: 'file', pathText: 'src/release:12', line: null }
     ])
   })
 
@@ -205,6 +209,62 @@ describe('CommentMarkdown link click handler', () => {
       anchor?.dispatchEvent(new window.MouseEvent('click', { bubbles: true, cancelable: true }))
     })
     expect(onLinkClick).toHaveBeenCalledOnce()
+  })
+
+  it('leaves prose-shaped slash tokens and numeric versions unlinked', () => {
+    const proseFalsePositives = ['and/or', 'TCP/IP', '24/7', 'N/A', 'km/h', 'A/B test']
+    const inlineCodeFalsePositives = ['origin/main', 'v1.2.3', '1.0']
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content={`${proseFalsePositives.join(', ')}; ${inlineCodeFalsePositives.map((value) => `\`${value}\``).join(', ')}`}
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+    for (const value of proseFalsePositives) {
+      expect(container.textContent).toContain(value)
+    }
+    expect(Array.from(container.querySelectorAll('code')).map((code) => code.textContent)).toEqual(
+      inlineCodeFalsePositives
+    )
+  })
+
+  it('prevents the default action for an unresolved internal file href', () => {
+    const onLinkClick = vi.fn()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Open ~/x"
+          onLinkClick={onLinkClick}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchor = container.querySelector<HTMLAnchorElement>('a')
+    expect(anchor?.getAttribute('href')).toMatch(new RegExp(`^${NATIVE_CHAT_FILE_HREF_PREFIX}`))
+    const event = new window.MouseEvent('click', { bubbles: true, cancelable: true })
+
+    act(() => {
+      anchor?.dispatchEvent(event)
+    })
+
+    expect(onLinkClick).toHaveBeenCalledOnce()
+    expect(event.defaultPrevented).toBe(true)
   })
 
   it('normalizes Windows markdown hrefs but leaves fenced paths as source text', () => {

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -386,6 +386,58 @@ describe('CommentMarkdown link click handler', () => {
     })
   })
 
+  it('requires path shape before a spaced line suffix can make a link', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content='Keep `aspect 16:9` and "John 3:16" as references.'
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+    expect(container.querySelector('code')?.textContent).toBe('aspect 16:9')
+    expect(container.textContent).toContain('"John 3:16"')
+  })
+
+  it('preserves line suffixes on valid spaced path shapes', () => {
+    const content =
+      'Open "My Folder/notes:12", `My Notes.md:7`, and "C:\\My Folder\\notes.txt:12:3".'
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content={content}
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    const anchors = Array.from(container.querySelectorAll<HTMLAnchorElement>('a'))
+    expect(anchors.map((anchor) => anchor.textContent)).toEqual([
+      'My Folder/notes:12',
+      'My Notes.md:7',
+      String.raw`C:\My Folder\notes.txt:12:3`
+    ])
+    expect(anchors.map((anchor) => routeNativeChatHref(anchor.getAttribute('href')))).toEqual([
+      { kind: 'file', pathText: 'My Folder/notes:12', line: null },
+      { kind: 'file', pathText: 'My Notes.md:7', line: null },
+      { kind: 'file', pathText: String.raw`C:\My Folder\notes.txt:12:3`, line: null }
+    ])
+  })
+
   it('links complete Unicode paths and extensions that begin with a digit', () => {
     container = document.createElement('div')
     document.body.appendChild(container)

--- a/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.link-click.test.tsx
@@ -259,6 +259,47 @@ describe('CommentMarkdown link click handler', () => {
     )
   })
 
+  it('links complete Unicode paths and extensions that begin with a digit', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Open /tmp/报告.html, docs/报告/file.html, docs/café/report.pdf, and docs/archive.7z."
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(Array.from(container.querySelectorAll('a')).map((anchor) => anchor.textContent)).toEqual(
+      ['/tmp/报告.html', 'docs/报告/file.html', 'docs/café/report.pdf', 'docs/archive.7z']
+    )
+  })
+
+  it('never links an ASCII suffix inside a path containing an unsupported character', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root?.render(
+        <CommentMarkdown
+          variant="document"
+          content="Leave /tmp/$draft/report.html as one path or plain text."
+          onLinkClick={vi.fn()}
+          linkifyFilePaths
+        />
+      )
+    })
+
+    expect(container.querySelectorAll('a')).toHaveLength(0)
+    expect(container.textContent).toContain('/tmp/$draft/report.html')
+  })
+
   it('prevents the default action for an unresolved internal file href', () => {
     const onLinkClick = vi.fn()
     container = document.createElement('div')

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -13,6 +13,7 @@ import {
   isTrustedCompactImageSrc,
   type CommentMarkdownLinkClickHandler
 } from './comment-markdown-element-renderers'
+import { remarkNativeChatFileLinks } from './comment-markdown-native-chat-file-links'
 
 export type { CommentMarkdownLinkClickHandler } from './comment-markdown-element-renderers'
 
@@ -185,6 +186,7 @@ type CommentMarkdownProps = React.ComponentPropsWithoutRef<'div'> & {
   githubRepo?: GitHubRepoReference | null
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
+  linkifyFilePaths?: boolean
   expandImages?: boolean
 }
 
@@ -200,6 +202,7 @@ const CommentMarkdown = React.memo(
       githubRepo,
       onLinkClick,
       allowFileUriLinks = false,
+      linkifyFilePaths = false,
       expandImages = false,
       ...rest
     },
@@ -217,10 +220,12 @@ const CommentMarkdown = React.memo(
         ? createDocumentCommentMarkdownComponents(onLinkClick)
         : createCompactCommentMarkdownComponents(onLinkClick, expandImages)
     }, [expandImages, variant, onLinkClick])
-    const activeRemarkPlugins = React.useMemo(
-      () => (githubRepo ? [...remarkPlugins, remarkGitHubReferences(githubRepo)] : remarkPlugins),
-      [githubRepo]
-    )
+    const activeRemarkPlugins = React.useMemo(() => {
+      const plugins = linkifyFilePaths
+        ? [...remarkPlugins, remarkNativeChatFileLinks]
+        : remarkPlugins
+      return githubRepo ? [...plugins, remarkGitHubReferences(githubRepo)] : plugins
+    }, [githubRepo, linkifyFilePaths])
 
     return (
       <div

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -43,6 +43,16 @@ function handleMarkdownAnchorClick(
   onLinkClick?.(event, href)
 }
 
+function handleMarkdownAnchorAuxClick(
+  event: React.MouseEvent<HTMLAnchorElement>,
+  href: string | undefined,
+  onLinkClick: CommentMarkdownLinkClickHandler | undefined
+): void {
+  if (event.button === 1) {
+    handleMarkdownAnchorClick(event, href, onLinkClick)
+  }
+}
+
 function handleMarkdownImageClick(
   event: React.MouseEvent<HTMLImageElement>,
   src: string | undefined,
@@ -70,6 +80,7 @@ export function createCompactCommentMarkdownComponents(
         rel="noreferrer"
         className="underline underline-offset-2 text-foreground/80 hover:text-foreground"
         onClick={(e) => handleMarkdownAnchorClick(e, href, onLinkClick)}
+        onAuxClick={(e) => handleMarkdownAnchorAuxClick(e, href, onLinkClick)}
       >
         {children}
       </a>
@@ -159,6 +170,7 @@ export function createCompactCommentMarkdownComponents(
             rel="noreferrer"
             className="underline underline-offset-2 text-foreground/80 hover:text-foreground"
             onClick={(e) => handleMarkdownAnchorClick(e, src, onLinkClick)}
+            onAuxClick={(e) => handleMarkdownAnchorAuxClick(e, src, onLinkClick)}
           >
             {alt || src}
           </a>
@@ -189,6 +201,7 @@ export function createCompactCommentMarkdownComponents(
           target="_blank"
           rel="noreferrer"
           onClick={(e) => handleMarkdownAnchorClick(e, src, onLinkClick)}
+          onAuxClick={(e) => handleMarkdownAnchorAuxClick(e, src, onLinkClick)}
         >
           {image}
         </a>
@@ -226,6 +239,7 @@ export function createDocumentCommentMarkdownComponents(
           rel="noreferrer"
           className="break-all text-primary underline underline-offset-2 hover:text-primary/80"
           onClick={(e) => handleMarkdownAnchorClick(e, href, onLinkClick)}
+          onAuxClick={(e) => handleMarkdownAnchorAuxClick(e, href, onLinkClick)}
         >
           {children}
         </a>

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Components } from 'react-markdown'
+import { NATIVE_CHAT_FILE_HREF_PREFIX } from '../../../../shared/native-chat-href-routing'
 import { isMermaidFence, isMermaidPre, renderMermaidFence } from './comment-mermaid-fence'
 import {
   GitHubUserAttachmentImage,
@@ -32,7 +33,11 @@ function handleMarkdownAnchorClick(
   // Why: link clicks should not also trigger an outer row/card click handler;
   // images only claim the click when an image handler is wired below.
   event.stopPropagation()
-  if (href?.trim().toLowerCase().startsWith('file:')) {
+  const trimmedHref = href?.trim()
+  if (
+    trimmedHref?.toLowerCase().startsWith('file:') ||
+    trimmedHref?.startsWith(NATIVE_CHAT_FILE_HREF_PREFIX)
+  ) {
     event.preventDefault()
   }
   onLinkClick?.(event, href)

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -2,6 +2,7 @@ import {
   createNativeChatFileHref,
   routeNativeChatHref
 } from '../../../../shared/native-chat-href-routing'
+import { parseFileLinkLocation } from '../../../../shared/file-link-location'
 import { extractTerminalFileLinks, type ParsedTerminalFileLink } from '@/lib/terminal-links'
 
 type MarkdownNode = {
@@ -27,9 +28,11 @@ function isLinkifiableFile(link: ParsedTerminalFileLink, requireSeparator: boole
   )
 }
 
-const SAFE_LEADING_BOUNDARY_PATTERN = /[\s([{'",;]/
-const SAFE_TRAILING_BOUNDARY_PATTERN = /[\s)\]}>'",;.:]/
-const SENTENCE_PATH_PUNCTUATION_PATTERN = /\.[\p{L}\p{N}][\p{L}\p{N}\p{M}_+-]*([!?—])/gu
+const SAFE_LEADING_BOUNDARY_PATTERN = /[\s([{'",;=]/
+const SAFE_TRAILING_BOUNDARY_PATTERN = /[\s)\]}>'",;.:。！？，、；：]/
+const SENTENCE_PATH_PUNCTUATION_PATTERN =
+  /\.[\p{L}\p{N}][\p{L}\p{N}\p{M}_+-]*([!?—。！？，、；：])/gu
+const QUOTED_TEXT_PATTERN = /"([^"\r\n]+)"|'([^"'\r\n]+)'/gu
 const MAX_DASHED_PROSE_WORD_LENGTH = 32
 
 function hasBoundedProseAfterDash(value: string, startIndex: number): boolean {
@@ -128,7 +131,7 @@ function splitTextSegment(value: string): MarkdownNode[] {
   return children
 }
 
-function splitTextNode(value: string): MarkdownNode[] {
+function splitUnquotedText(value: string): MarkdownNode[] {
   const children: MarkdownNode[] = []
   let cursor = 0
   for (const match of value.matchAll(SENTENCE_PATH_PUNCTUATION_PATTERN)) {
@@ -147,15 +150,58 @@ function splitTextNode(value: string): MarkdownNode[] {
   return children
 }
 
+function exactFileLink(value: string, allowSpacedRelative: boolean): ParsedTerminalFileLink | null {
+  const exactLink = extractTerminalFileLinks(value).find(
+    (link) => link.startIndex === 0 && link.endIndex === value.length
+  )
+  if (exactLink && isLinkifiableFile(exactLink, false)) {
+    return exactLink
+  }
+  if (!allowSpacedRelative || !/\s/.test(value)) {
+    return null
+  }
+  const parsed = parseFileLinkLocation(value)
+  if (!parsed) {
+    return null
+  }
+  const explicitLink = {
+    ...parsed,
+    startIndex: 0,
+    endIndex: value.length,
+    displayText: value
+  }
+  return isLinkifiableFile(explicitLink, false) ? explicitLink : null
+}
+
+function splitTextNode(value: string): MarkdownNode[] {
+  const children: MarkdownNode[] = []
+  let cursor = 0
+  for (const match of value.matchAll(QUOTED_TEXT_PATTERN)) {
+    const content = match[1] ?? match[2]
+    if (!content || !exactFileLink(content, true)) {
+      continue
+    }
+    const matchIndex = match.index ?? 0
+    const quote = match[0][0]
+    children.push(...splitUnquotedText(value.slice(cursor, matchIndex)))
+    children.push({ type: 'text', value: quote })
+    children.push(createFileLinkNode(content, { type: 'text', value: content }))
+    children.push({ type: 'text', value: quote })
+    cursor = matchIndex + match[0].length
+  }
+  if (cursor === 0) {
+    return splitUnquotedText(value)
+  }
+  children.push(...splitUnquotedText(value.slice(cursor)))
+  return children
+}
+
 function inlineCodeFileLink(node: MarkdownNode): MarkdownNode | null {
   const value = node.value?.trim()
   if (!value) {
     return null
   }
-  const exactLink = extractTerminalFileLinks(value).find(
-    (link) => link.startIndex === 0 && link.endIndex === value.length
-  )
-  return exactLink && isLinkifiableFile(exactLink, false) ? createFileLinkNode(value, node) : null
+  return exactFileLink(value, true) ? createFileLinkNode(value, node) : null
 }
 
 function transformFileLinks(node: MarkdownNode): void {

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -164,6 +164,13 @@ function exactFileLink(value: string, allowSpacedRelative: boolean): ParsedTermi
   if (!parsed) {
     return null
   }
+  const hasPathShape =
+    ROOTED_PATH_PREFIX_PATTERN.test(parsed.pathText) ||
+    /[\\/]/.test(parsed.pathText) ||
+    /\.[\p{L}][\p{L}\p{N}\p{M}_+-]*$/u.test(parsed.pathText)
+  if (!hasPathShape) {
+    return null
+  }
   const explicitLink = {
     ...parsed,
     startIndex: 0,

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -1,0 +1,93 @@
+import {
+  createNativeChatFileHref,
+  routeNativeChatHref
+} from '../../../../shared/native-chat-href-routing'
+import { extractTerminalFileLinks, type ParsedTerminalFileLink } from '@/lib/terminal-links'
+
+type MarkdownNode = {
+  type: string
+  value?: string
+  url?: string
+  children?: MarkdownNode[]
+}
+
+function isLinkifiableFile(link: ParsedTerminalFileLink, requireSeparator: boolean): boolean {
+  return (
+    (!requireSeparator || /[\\/]/.test(link.pathText)) &&
+    routeNativeChatHref(link.displayText).kind === 'file'
+  )
+}
+
+function createFileLinkNode(value: string, child: MarkdownNode): MarkdownNode {
+  return {
+    type: 'link',
+    url: createNativeChatFileHref(value),
+    children: [child]
+  }
+}
+
+function splitTextNode(value: string): MarkdownNode[] {
+  const links = extractTerminalFileLinks(value).filter((link) => isLinkifiableFile(link, true))
+  if (links.length === 0) {
+    return [{ type: 'text', value }]
+  }
+
+  const children: MarkdownNode[] = []
+  let cursor = 0
+  for (const link of links) {
+    if (link.startIndex < cursor) {
+      continue
+    }
+    if (link.startIndex > cursor) {
+      children.push({ type: 'text', value: value.slice(cursor, link.startIndex) })
+    }
+    children.push(createFileLinkNode(link.displayText, { type: 'text', value: link.displayText }))
+    cursor = link.endIndex
+  }
+  if (cursor < value.length) {
+    children.push({ type: 'text', value: value.slice(cursor) })
+  }
+  return children
+}
+
+function inlineCodeFileLink(node: MarkdownNode): MarkdownNode | null {
+  const value = node.value?.trim()
+  if (!value) {
+    return null
+  }
+  const exactLink = extractTerminalFileLinks(value).find(
+    (link) => link.startIndex === 0 && link.endIndex === value.length
+  )
+  return exactLink && isLinkifiableFile(exactLink, false) ? createFileLinkNode(value, node) : null
+}
+
+function transformFileLinks(node: MarkdownNode): void {
+  if (node.type === 'link') {
+    if (node.url && routeNativeChatHref(node.url).kind === 'file') {
+      node.url = createNativeChatFileHref(node.url)
+    }
+    return
+  }
+  if (!node.children || node.type === 'image') {
+    return
+  }
+
+  const children: MarkdownNode[] = []
+  for (const child of node.children) {
+    if (child.type === 'text' && child.value !== undefined) {
+      children.push(...splitTextNode(child.value))
+      continue
+    }
+    if (child.type === 'inlineCode') {
+      children.push(inlineCodeFileLink(child) ?? child)
+      continue
+    }
+    transformFileLinks(child)
+    children.push(child)
+  }
+  node.children = children
+}
+
+export function remarkNativeChatFileLinks(): (tree: MarkdownNode) => void {
+  return (tree) => transformFileLinks(tree)
+}

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -11,8 +11,10 @@ type MarkdownNode = {
   children?: MarkdownNode[]
 }
 
+const ROOTED_PATH_PREFIX_PATTERN = /^(?:~[\\/]|\.{1,2}[\\/]|[\\/]|[A-Za-z]:[\\/])/
+
 function isLinkifiableFile(link: ParsedTerminalFileLink, requireSeparator: boolean): boolean {
-  const hasRootedPrefix = /^(?:~[\\/]|\.{1,2}[\\/]|[\\/]|[A-Za-z]:[\\/])/.test(link.pathText)
+  const hasRootedPrefix = ROOTED_PATH_PREFIX_PATTERN.test(link.pathText)
   const hasLineSuffix = link.line !== null || link.column !== null
   const hasAlphabeticExtension = /\.[A-Za-z][A-Za-z0-9_+-]*$/.test(link.pathText)
   return (
@@ -30,8 +32,34 @@ function createFileLinkNode(value: string, child: MarkdownNode): MarkdownNode {
   }
 }
 
+// Why: the terminal extractor spans "src/a.ts and src/b.ts" as one spaced path.
+// An unrooted span holding a bare word or several linkable tokens is prose
+// joining paths, so link the tokens on their own; a spaced folder name keeps
+// every token path-shaped and stays one link.
+function splitProseJoinedLinks(link: ParsedTerminalFileLink): ParsedTerminalFileLink[] {
+  if (ROOTED_PATH_PREFIX_PATTERN.test(link.pathText)) {
+    return [link]
+  }
+  const tokens = Array.from(link.displayText.matchAll(/\S+/g))
+  const tokenLinks: ParsedTerminalFileLink[] = []
+  for (const match of tokens) {
+    const token = match[0]
+    const exactLink = extractTerminalFileLinks(token).find(
+      (candidate) => candidate.startIndex === 0 && candidate.endIndex === token.length
+    )
+    if (exactLink && isLinkifiableFile(exactLink, true)) {
+      const startIndex = link.startIndex + (match.index ?? 0)
+      tokenLinks.push({ ...exactLink, startIndex, endIndex: startIndex + token.length })
+    }
+  }
+  const hasBareWord = tokens.some((match) => !/[\\/.]/.test(match[0]))
+  return hasBareWord || tokenLinks.length > 1 ? tokenLinks : [link]
+}
+
 function splitTextNode(value: string): MarkdownNode[] {
-  const links = extractTerminalFileLinks(value).filter((link) => isLinkifiableFile(link, true))
+  const links = extractTerminalFileLinks(value)
+    .filter((link) => isLinkifiableFile(link, true))
+    .flatMap(splitProseJoinedLinks)
   if (links.length === 0) {
     return [{ type: 'text', value }]
   }

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -16,11 +16,26 @@ const ROOTED_PATH_PREFIX_PATTERN = /^(?:~[\\/]|\.{1,2}[\\/]|[\\/]|[A-Za-z]:[\\/]
 function isLinkifiableFile(link: ParsedTerminalFileLink, requireSeparator: boolean): boolean {
   const hasRootedPrefix = ROOTED_PATH_PREFIX_PATTERN.test(link.pathText)
   const hasLineSuffix = link.line !== null || link.column !== null
-  const hasAlphabeticExtension = /\.[A-Za-z][A-Za-z0-9_+-]*$/.test(link.pathText)
+  const hasAlphabeticExtension = /\.[\p{L}][\p{L}\p{N}\p{M}_+-]*$/u.test(link.pathText)
+  const hasPathExtension = /\.[\p{L}\p{N}][\p{L}\p{N}\p{M}_+-]*$/u.test(link.pathText)
   return (
     (!requireSeparator || /[\\/]/.test(link.pathText)) &&
-    (hasRootedPrefix || hasLineSuffix || hasAlphabeticExtension) &&
+    (hasRootedPrefix ||
+      hasLineSuffix ||
+      (requireSeparator ? hasPathExtension : hasAlphabeticExtension)) &&
     routeNativeChatHref(link.displayText).kind === 'file'
+  )
+}
+
+const SAFE_LEADING_BOUNDARY_PATTERN = /[\s([{'",;]/
+const SAFE_TRAILING_BOUNDARY_PATTERN = /[\s)\]}>'",;.:]/
+
+function hasPartialPathBoundary(value: string, link: ParsedTerminalFileLink): boolean {
+  const before = value[link.startIndex - 1]
+  const after = value[link.endIndex]
+  return (
+    (before !== undefined && !SAFE_LEADING_BOUNDARY_PATTERN.test(before)) ||
+    (after !== undefined && !SAFE_TRAILING_BOUNDARY_PATTERN.test(after))
   )
 }
 
@@ -58,6 +73,7 @@ function splitProseJoinedLinks(link: ParsedTerminalFileLink): ParsedTerminalFile
 
 function splitTextNode(value: string): MarkdownNode[] {
   const links = extractTerminalFileLinks(value)
+    .filter((link) => !hasPartialPathBoundary(value, link))
     .filter((link) => isLinkifiableFile(link, true))
     .flatMap(splitProseJoinedLinks)
   if (links.length === 0) {

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -12,8 +12,12 @@ type MarkdownNode = {
 }
 
 function isLinkifiableFile(link: ParsedTerminalFileLink, requireSeparator: boolean): boolean {
+  const hasRootedPrefix = /^(?:~[\\/]|\.{1,2}[\\/]|[\\/]|[A-Za-z]:[\\/])/.test(link.pathText)
+  const hasLineSuffix = link.line !== null || link.column !== null
+  const hasAlphabeticExtension = /\.[A-Za-z][A-Za-z0-9_+-]*$/.test(link.pathText)
   return (
     (!requireSeparator || /[\\/]/.test(link.pathText)) &&
+    (hasRootedPrefix || hasLineSuffix || hasAlphabeticExtension) &&
     routeNativeChatHref(link.displayText).kind === 'file'
   )
 }

--- a/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
+++ b/src/renderer/src/components/sidebar/comment-markdown-native-chat-file-links.ts
@@ -29,13 +29,43 @@ function isLinkifiableFile(link: ParsedTerminalFileLink, requireSeparator: boole
 
 const SAFE_LEADING_BOUNDARY_PATTERN = /[\s([{'",;]/
 const SAFE_TRAILING_BOUNDARY_PATTERN = /[\s)\]}>'",;.:]/
+const SENTENCE_PATH_PUNCTUATION_PATTERN = /\.[\p{L}\p{N}][\p{L}\p{N}\p{M}_+-]*([!?—])/gu
+const MAX_DASHED_PROSE_WORD_LENGTH = 32
+
+function hasBoundedProseAfterDash(value: string, startIndex: number): boolean {
+  const endIndex = Math.min(value.length, startIndex + MAX_DASHED_PROSE_WORD_LENGTH)
+  for (let index = startIndex; index < endIndex; index += 1) {
+    const char = value[index]
+    if (!char || SAFE_TRAILING_BOUNDARY_PATTERN.test(char)) {
+      return true
+    }
+    if (char === '/' || char === '\\') {
+      return false
+    }
+  }
+  return endIndex === value.length
+}
+
+function isSafeTrailingBoundary(value: string, endIndex: number): boolean {
+  const boundary = value[endIndex]
+  if (boundary === undefined || SAFE_TRAILING_BOUNDARY_PATTERN.test(boundary)) {
+    return true
+  }
+  if (boundary === '!' || boundary === '?') {
+    const next = value[endIndex + 1]
+    return next === undefined || SAFE_TRAILING_BOUNDARY_PATTERN.test(next)
+  }
+  if (boundary === '—') {
+    return hasBoundedProseAfterDash(value, endIndex + 1)
+  }
+  return false
+}
 
 function hasPartialPathBoundary(value: string, link: ParsedTerminalFileLink): boolean {
   const before = value[link.startIndex - 1]
-  const after = value[link.endIndex]
   return (
     (before !== undefined && !SAFE_LEADING_BOUNDARY_PATTERN.test(before)) ||
-    (after !== undefined && !SAFE_TRAILING_BOUNDARY_PATTERN.test(after))
+    !isSafeTrailingBoundary(value, link.endIndex)
   )
 }
 
@@ -71,7 +101,7 @@ function splitProseJoinedLinks(link: ParsedTerminalFileLink): ParsedTerminalFile
   return hasBareWord || tokenLinks.length > 1 ? tokenLinks : [link]
 }
 
-function splitTextNode(value: string): MarkdownNode[] {
+function splitTextSegment(value: string): MarkdownNode[] {
   const links = extractTerminalFileLinks(value)
     .filter((link) => !hasPartialPathBoundary(value, link))
     .filter((link) => isLinkifiableFile(link, true))
@@ -95,6 +125,25 @@ function splitTextNode(value: string): MarkdownNode[] {
   if (cursor < value.length) {
     children.push({ type: 'text', value: value.slice(cursor) })
   }
+  return children
+}
+
+function splitTextNode(value: string): MarkdownNode[] {
+  const children: MarkdownNode[] = []
+  let cursor = 0
+  for (const match of value.matchAll(SENTENCE_PATH_PUNCTUATION_PATTERN)) {
+    const punctuationIndex = (match.index ?? 0) + match[0].length - 1
+    if (!isSafeTrailingBoundary(value, punctuationIndex)) {
+      continue
+    }
+    children.push(...splitTextSegment(value.slice(cursor, punctuationIndex)))
+    children.push({ type: 'text', value: value[punctuationIndex] })
+    cursor = punctuationIndex + 1
+  }
+  if (cursor === 0) {
+    return splitTextSegment(value)
+  }
+  children.push(...splitTextSegment(value.slice(cursor)))
   return children
 }
 

--- a/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPaneNativeChatPortal.tsx
@@ -76,7 +76,6 @@ export function TerminalPaneNativeChatPortal({
           agent={structuredChatAgent}
           isVisible={isRendererVisible}
           target={structuredChatTarget}
-          allowFileUriLinks
           contextMenuActions={contextMenuActions}
           orchestrationDispatchStatus={chatPaneDispatchStatus}
         />

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -115,6 +115,15 @@ describe('terminal path helpers', () => {
   })
 
   describe('extractTerminalFileLinks local path tokens', () => {
+    it('keeps Unicode path segments in the detected range', () => {
+      expect(extractTerminalFileLinks('/tmp/报告.html').map((link) => link.displayText)).toEqual([
+        '/tmp/报告.html'
+      ])
+      expect(
+        extractTerminalFileLinks('docs/café/report.pdf').map((link) => link.displayText)
+      ).toEqual(['docs/café/report.pdf'])
+    })
+
     it('detects tilde-prefixed POSIX paths', () => {
       const links = extractTerminalFileLinks('~/Documents/Path/file_name')
       expect(links).toHaveLength(1)

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -224,6 +224,15 @@ describe('terminal path helpers', () => {
       expect(links).toHaveLength(20_000)
       expect(links[0].pathText).toBe('/tmp/Foo Bar/file')
     }, 5_000)
+
+    it('keeps extension-heavy assistant prose on a bounded scan path', () => {
+      const filenames = Array.from({ length: 20_000 }, (_, index) => `report-${index}.txt`)
+      const links = extractTerminalFileLinks(`/tmp/root/${filenames.join(' ')}`)
+
+      expect(links).toHaveLength(2)
+      expect(links[0].pathText).toBe(`/tmp/root/${filenames.slice(0, -1).join(' ')}`)
+      expect(links.at(-1)?.pathText).toBe('report-19999.txt')
+    })
   })
 
   it('supports Windows cwd resolution for terminal file links', () => {

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -125,11 +125,18 @@ function trimSpacedPathTrailingProse(
   // prose like "failed to start app.py" must not be swallowed.
   let selected: string | null = null
   const extensionPrefixPattern = /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$)/g
+  const pathStartPattern = /(?:^|\s)(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/g
+  let pathStartCount = 0
+  let nextPathStart = pathStartPattern.exec(range.text)
   let match: RegExpExecArray | null
   while ((match = extensionPrefixPattern.exec(range.text)) !== null) {
     const end = match.index + match[0].length
     const text = range.text.slice(0, end)
-    if (countPathStarts(text) > 1) {
+    while (nextPathStart && nextPathStart.index + nextPathStart[0].length <= end) {
+      pathStartCount += 1
+      nextPathStart = pathStartPattern.exec(range.text)
+    }
+    if (pathStartCount > 1) {
       continue
     }
     if (
@@ -148,15 +155,6 @@ function trimSpacedPathTrailingProse(
     startIndex: range.startIndex,
     endIndex: range.startIndex + selected.length
   }
-}
-
-function countPathStarts(text: string): number {
-  let count = 0
-  for (const match of text.matchAll(/(?:^|\s)(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/g)) {
-    void match
-    count += 1
-  }
-  return count
 }
 
 function trimTrailingWhitespace(

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -34,7 +34,7 @@ export type ResolvedTerminalFileLink = Pick<ParsedTerminalFileLink, 'line' | 'co
 // Why: framework route files commonly use punctuation segments like
 // `app/(shop)/products/[id]/page.tsx`; keep those links whole.
 const LOCAL_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{N}\p{M}._-]+[\\/])[\p{L}\p{N}\p{M}._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/gu
 
 // Matches separator paths whose file or folder names include spaces. This runs
 // before LOCAL_PATH_REGEX so `/Users/A/Foo Bar/file.ts` is claimed as one link

--- a/src/shared/native-chat-href-routing.test.ts
+++ b/src/shared/native-chat-href-routing.test.ts
@@ -62,6 +62,20 @@ describe('routeNativeChatHref', () => {
     })
   })
 
+  it('bounds nested renderer file target decoding', () => {
+    let href = '/tmp/report.html'
+    for (let depth = 0; depth < 4; depth += 1) {
+      href = createNativeChatFileHref(` ${href}`)
+    }
+    expect(routeNativeChatHref(href)).toEqual({
+      kind: 'file',
+      pathText: '/tmp/report.html',
+      line: null
+    })
+
+    expect(routeNativeChatHref(createNativeChatFileHref(` ${href}`))).toEqual({ kind: 'none' })
+  })
+
   it('drops anchors, unknown schemes, malformed file URIs, and empty hrefs', () => {
     expect(routeNativeChatHref('#section')).toEqual({ kind: 'none' })
     expect(routeNativeChatHref(undefined)).toEqual({ kind: 'none' })

--- a/src/shared/native-chat-href-routing.test.ts
+++ b/src/shared/native-chat-href-routing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { routeNativeChatHref } from './native-chat-href-routing'
+import { createNativeChatFileHref, routeNativeChatHref } from './native-chat-href-routing'
 
 describe('routeNativeChatHref', () => {
   it('classifies web and mail links', () => {
@@ -43,6 +43,21 @@ describe('routeNativeChatHref', () => {
     expect(routeNativeChatHref(String.raw`C:\repo\src\index.ts`)).toEqual({
       kind: 'file',
       pathText: String.raw`C:\repo\src\index.ts`,
+      line: null
+    })
+  })
+
+  it('routes encoded renderer file targets without treating Windows drives as schemes', () => {
+    expect(
+      routeNativeChatHref(createNativeChatFileHref(String.raw`C:\repo\report.docx:12`))
+    ).toEqual({
+      kind: 'file',
+      pathText: String.raw`C:\repo\report.docx:12`,
+      line: null
+    })
+    expect(routeNativeChatHref(createNativeChatFileHref('/tmp/report.html'))).toEqual({
+      kind: 'file',
+      pathText: '/tmp/report.html',
       line: null
     })
   })

--- a/src/shared/native-chat-href-routing.ts
+++ b/src/shared/native-chat-href-routing.ts
@@ -9,6 +9,7 @@ export type NativeChatHrefRoute =
 const WEB_SCHEME_PATTERN = /^(?:https?|mailto):/i
 const SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:/
 export const NATIVE_CHAT_FILE_HREF_PREFIX = '#orca-native-chat-file='
+const MAX_NATIVE_CHAT_FILE_HREF_DECODES = 4
 
 export function createNativeChatFileHref(pathText: string): string {
   return `${NATIVE_CHAT_FILE_HREF_PREFIX}${encodeURIComponent(pathText)}`
@@ -62,13 +63,19 @@ function maybeDecodeHrefPath(value: string): string {
 }
 
 export function routeNativeChatHref(href: string | null | undefined): NativeChatHrefRoute {
-  const trimmed = href?.trim()
+  let trimmed = href?.trim()
   if (!trimmed) {
     return { kind: 'none' }
   }
-  const encodedFileHref = decodeNativeChatFileHref(trimmed)
-  if (encodedFileHref) {
-    return routeNativeChatHref(encodedFileHref)
+  for (let depth = 0; depth < MAX_NATIVE_CHAT_FILE_HREF_DECODES; depth += 1) {
+    const encodedFileHref = decodeNativeChatFileHref(trimmed)
+    if (!encodedFileHref) {
+      break
+    }
+    trimmed = encodedFileHref.trim()
+  }
+  if (!trimmed || trimmed.startsWith(NATIVE_CHAT_FILE_HREF_PREFIX)) {
+    return { kind: 'none' }
   }
   if (trimmed.startsWith('#')) {
     return { kind: 'none' }

--- a/src/shared/native-chat-href-routing.ts
+++ b/src/shared/native-chat-href-routing.ts
@@ -8,6 +8,23 @@ export type NativeChatHrefRoute =
 
 const WEB_SCHEME_PATTERN = /^(?:https?|mailto):/i
 const SCHEME_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:/
+export const NATIVE_CHAT_FILE_HREF_PREFIX = '#orca-native-chat-file='
+
+export function createNativeChatFileHref(pathText: string): string {
+  return `${NATIVE_CHAT_FILE_HREF_PREFIX}${encodeURIComponent(pathText)}`
+}
+
+function decodeNativeChatFileHref(href: string): string | null {
+  if (!href.startsWith(NATIVE_CHAT_FILE_HREF_PREFIX)) {
+    return null
+  }
+  try {
+    const decoded = decodeURIComponent(href.slice(NATIVE_CHAT_FILE_HREF_PREFIX.length))
+    return decoded && !decoded.startsWith(NATIVE_CHAT_FILE_HREF_PREFIX) ? decoded : null
+  } catch {
+    return null
+  }
+}
 
 function parseLineFragment(hash: string): number | null {
   if (!hash) {
@@ -46,7 +63,14 @@ function maybeDecodeHrefPath(value: string): string {
 
 export function routeNativeChatHref(href: string | null | undefined): NativeChatHrefRoute {
   const trimmed = href?.trim()
-  if (!trimmed || trimmed.startsWith('#')) {
+  if (!trimmed) {
+    return { kind: 'none' }
+  }
+  const encodedFileHref = decodeNativeChatFileHref(trimmed)
+  if (encodedFileHref) {
+    return routeNativeChatHref(encodedFileHref)
+  }
+  if (trimmed.startsWith('#')) {
     return { kind: 'none' }
   }
   if (WEB_SCHEME_PATTERN.test(trimmed)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​505 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​482 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​287 |

<!-- /orca-pr-loc -->

**Item 4** (flagged high-priority): *"Unable to click the html link or other document type"*, and later *"sometimes the doc link is clickable, but many times it's not."*

Reported by Jinjing in the Chat UI UI/UX feedback thread: https://stablygroup.slack.com/archives/C0BV03ZK1KN/p1788474468997739

## ELI5
When the agent tells you "I saved the report to `/tmp/report.html`" or "edit `src/foo.ts`", those words used to be plain text. You had to select the path, copy it, and open it yourself. Now the path is a link: click it and Orca opens the file. Orca only turns something into a link when it actually looks like a file path, so everyday phrases like "and/or", "24/7", or a branch name like `origin/main` stay as plain words.

## What you'll see

**Before**
- Assistant messages showed file paths as inert text unless the agent wrote a full markdown link.
- The same message was sometimes clickable and sometimes not, because links were silently disabled in any chat running on a remote or SSH host.
- Clicking a linked path that Orca could not resolve could hand the raw link off to the system browser.

**After**
- Absolute, home (`~/`), relative (`./`, `../`), and Windows paths in assistant prose and inline code are clickable, with `:line` and `:line:col` honored.
- Links work the same on local, remote, and SSH chats.
- Prose with slashes ("and/or", "TCP/IP", "24/7", "N/A") and inline code like `origin/main` or `v1.2.3` are not linked.
- A sentence such as "Updated src/foo.ts and src/bar.ts" gives two separate links, one per file.
- Unresolvable links do nothing instead of escaping to the system browser.

## Root cause
Two independent gates, neither an extension allowlist. (1) Chat never wired its existing terminal path detector into assistant prose or inline code, so a bare path like `/tmp/foo.html` rendered as inert text and only an explicit markdown link worked. (2) Structured sessions suppressed file handlers on any non-local execution host, so remote/SSH chats had no clickable file links at all -- which explains the intermittency.

## Fix
Wired renderer-safe linkification for bare POSIX and Windows paths, inline-code paths, and explicit document links, and removed the structured-session local-host gate across the shared href router, the CommentMarkdown/native-chat surfaces, and the terminal portal. The final review also bounded nested internal-href decoding, added CLI/Unicode boundaries, preserved whole quoted paths with spaced first segments, and routed middle-clicks without activating links on right-click.

## Validation
9 focused test files / 142 tests; changed-code quality checks, formatting, `git diff --check`, and `pnpm tc:web` verified clean. Final Electron CDP validation at exact PR head `fac9ee1cdfaffbe6d4f5b3950a9b386566aff953` exercised the real Grok native-chat surface, verified rendered link boundaries and false-positive controls, and opened real in-app editor/browser destinations. Real SSH/remote UI was not exercised; host-aware routing remains covered by focused tests.

Reproduced in the real Electron app over CDP before the fix and verified after.

## Visual proof

Grok Electron CDP QA ran at exact final PR head `fac9ee1cdfaffbe6d4f5b3950a9b386566aff953` (`window.api.app.getIdentity()`: `Orca: brennanb2025/chatui-4-clickable-links`; store worktree path and host git head matched). Native chat rendered six whole internal file anchors: quoted `"My Folder/notes.md"` with quotes outside, the path-only portion of `--config=./config.yaml`, Unicode paths with `。` / `！` / `？` outside, and two absolute click-through targets. `and/or`, `A/B test`, `origin/main`, `v1.2.3`, `aspect 16:9`, and `"John 3:16"` stayed plain. Right-click was inert; middle-click opened the intended file in Orca's in-app editor with one Orca CDP page and no unmanaged Chromium window; left-click opened the HTML target in Orca's in-app browser with URL `file:///tmp/orca-qa-pr18712/proof.html`, title `PR18712 HTML proof`, and marker `PR18712-CLICKABLE-HTML-MARKER`. Playwright reported 0 console errors. A bounded long-message check appended one 80-line mixed-path assistant record (~6.4KB) to the live Grok transcript and polled the native-chat DOM for a unique marker (50ms interval, 8s cap, no contention loops); the marker was already present on the first poll (4ms) with 246 native-file anchors, with no pathological slowdown. Real SSH/remote UI was not exercised in this pass; host-aware routing remains covered by focused tests. Host PTY exhaustion prevented a live Grok TUI in this isolated profile (`No live terminal — toggle back to reconnect`); click routing still used the real Grok native-chat renderer.

**Final native-chat links** — quoted spaced path, CLI assignment, Unicode punctuation, absolute targets, and false-positive controls in the full Orca window:

![Final native-chat clickable-link validation](https://github.com/user-attachments/assets/9c7af33b-2dba-45e0-88af-765aca119ded)

**Middle-click route** — the native link opens the intended file in Orca's in-app editor; no extra Chromium window was created:

![Middle-click opens the in-app editor](https://github.com/user-attachments/assets/515f0204-10d2-4538-939f-f51ad6a38fec)

**Left-click route** — the HTML target opens in Orca's in-app browser with the expected local URL and proof marker:

![Left-click opens the in-app browser](https://github.com/user-attachments/assets/b3264a4a-b16f-4f75-b281-c028c7ee782b)
