### PR TITLE
fix(native-chat): keep the working indicator visible while a turn is in flight

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -153,7 +153,7 @@ describe('NativeChatMessageList assistant messages', () => {
     expect(screen.getByText('Running sleep 5')).toBeInTheDocument()
   })
 
-  it('shows a stable thinking status directly below the user message', () => {
+  it('pins a stable thinking status above the transcript', () => {
     const { container } = render(
       <NativeChatMessageList
         session={{
@@ -177,15 +177,16 @@ describe('NativeChatMessageList assistant messages', () => {
 
     const user = screen.getByText('Start the task')
     const thinking = screen.getByText('Thinking')
-    expect(user.compareDocumentPosition(thinking)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(thinking.compareDocumentPosition(user)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(thinking.parentElement).not.toHaveClass('border-b')
     expect(thinking.parentElement).toHaveClass('text-sm')
+    expect(thinking.parentElement?.parentElement).toHaveClass('sticky', 'top-0', 'bg-background')
     expect(container.querySelector('.animate-bounce')).toBeNull()
     expect(thinking).toHaveClass('animate-pulse')
     expect(container.querySelectorAll('.size-1.5.animate-pulse')).toHaveLength(0)
   })
 
-  it('places the thinking status directly after the latest user message', () => {
+  it('pins the working status above the current turn output', () => {
     render(
       <NativeChatMessageList
         session={{
@@ -217,9 +218,10 @@ describe('NativeChatMessageList assistant messages', () => {
     const user = screen.getByText('Run the checks')
     const status = screen.getByText('Working for 0 seconds')
     const assistant = screen.getByText('I am checking now.')
-    expect(user.compareDocumentPosition(status)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(status.compareDocumentPosition(user)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(status.compareDocumentPosition(assistant)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(status.parentElement).toHaveClass('border-b')
+    expect(status.closest('[data-native-chat-running-status]')).toHaveClass('sticky', 'top-0')
   })
 
   it('shows elapsed working time once tool activity starts', () => {

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -153,7 +153,7 @@ describe('NativeChatMessageList assistant messages', () => {
     expect(screen.getByText('Running sleep 5')).toBeInTheDocument()
   })
 
-  it('pins a stable thinking status above the transcript', () => {
+  it('keeps a sticky thinking status directly below the user message', () => {
     const { container } = render(
       <NativeChatMessageList
         session={{
@@ -171,22 +171,27 @@ describe('NativeChatMessageList assistant messages', () => {
         }}
         isWorking
         expandSignal={false}
-        fontScale={1}
+        fontScale={1.25}
       />
     )
 
     const user = screen.getByText('Start the task')
     const thinking = screen.getByText('Thinking')
-    expect(thinking.compareDocumentPosition(user)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    const stickyStatus = thinking.closest('[data-native-chat-running-status]')
+    const scrollContainer = container.querySelector('.overflow-y-auto')
+    expect(user.compareDocumentPosition(thinking)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(thinking.parentElement).not.toHaveClass('border-b')
     expect(thinking.parentElement).toHaveClass('text-sm')
-    expect(thinking.parentElement?.parentElement).toHaveClass('sticky', 'top-0', 'bg-background')
+    expect(stickyStatus).toHaveClass('sticky', 'top-0', 'bg-background')
+    expect(stickyStatus?.parentElement).toHaveClass('pt-10')
+    expect(stickyStatus?.parentElement?.style.zoom).toBe('1.25')
+    expect(scrollContainer).not.toHaveClass('pt-10')
     expect(container.querySelector('.animate-bounce')).toBeNull()
     expect(thinking).toHaveClass('animate-pulse')
     expect(container.querySelectorAll('.size-1.5.animate-pulse')).toHaveLength(0)
   })
 
-  it('pins the working status above the current turn output', () => {
+  it('pins the working status between the current user and assistant rows', () => {
     render(
       <NativeChatMessageList
         session={{
@@ -218,7 +223,7 @@ describe('NativeChatMessageList assistant messages', () => {
     const user = screen.getByText('Run the checks')
     const status = screen.getByText('Working for 0 seconds')
     const assistant = screen.getByText('I am checking now.')
-    expect(status.compareDocumentPosition(user)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
+    expect(user.compareDocumentPosition(status)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(status.compareDocumentPosition(assistant)).toBe(Node.DOCUMENT_POSITION_FOLLOWING)
     expect(status.parentElement).toHaveClass('border-b')
     expect(status.closest('[data-native-chat-running-status]')).toHaveClass('sticky', 'top-0')

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -342,26 +342,13 @@ export function NativeChatMessageList({
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="scrollbar-sleek h-full overflow-y-auto px-3 pt-10 pb-4 sm:px-4"
+        className="scrollbar-sleek h-full overflow-y-auto px-3 pb-4 sm:px-4"
       >
-        {showTurnStatus && isWorking && turnStatuses.active ? (
-          <div
-            data-native-chat-running-status="true"
-            className="sticky top-0 z-10 mx-auto w-full max-w-4xl bg-background"
-            style={{ zoom: fontScale }}
-          >
-            <NativeChatWorkingStatus
-              startedAt={turnStatuses.active.startedAt}
-              thinking={turnStatuses.active.thinking}
-              workedSeconds={turnStatuses.active.workedSeconds}
-            />
-          </div>
-        ) : null}
         <div
           ref={contentRef}
           // Why: same max width as the composer column; horizontal inset comes
           // from the scroll container so content aligns with the composer field.
-          className="mx-auto flex w-full max-w-4xl flex-col gap-5"
+          className="mx-auto flex w-full max-w-4xl flex-col gap-5 pt-10"
           // Why: `zoom` scales the chat transcript's text and layout together,
           // scoped to this container so the rest of the app is untouched. It's
           // the desktop analog of the mobile pinch-zoom (Chromium/Electron only).
@@ -413,7 +400,7 @@ export function NativeChatMessageList({
                   activityExpandOverride={turnKey ? expandedTurnIds.has(turnKey) : undefined}
                   runtimeContext={runtimeContext}
                 />
-                {showTurnStatus && status && (index !== latestUserIndex || !isWorking) ? (
+                {showTurnStatus && status ? (
                   <NativeChatWorkingStatus
                     startedAt={status.startedAt}
                     thinking={status.thinking}
@@ -424,11 +411,23 @@ export function NativeChatMessageList({
                         ? () => toggleExpandedTurn(turnKey)
                         : undefined
                     }
+                    sticky={index === latestUserIndex && isWorking}
                   />
                 ) : null}
               </Fragment>
             )
           })}
+          {showTurnStatus &&
+          latestUserIndex === -1 &&
+          turnStatuses.active &&
+          showTypingIndicator ? (
+            <NativeChatWorkingStatus
+              startedAt={turnStatuses.active.startedAt}
+              thinking={turnStatuses.active.thinking}
+              workedSeconds={turnStatuses.active.workedSeconds}
+              sticky
+            />
+          ) : null}
           {!showTurnStatus && showTypingIndicator ? <NativeChatTypingIndicatorRow /> : null}
         </div>
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -344,6 +344,19 @@ export function NativeChatMessageList({
         onScroll={handleScroll}
         className="scrollbar-sleek h-full overflow-y-auto px-3 pt-10 pb-4 sm:px-4"
       >
+        {showTurnStatus && isWorking && turnStatuses.active ? (
+          <div
+            data-native-chat-running-status="true"
+            className="sticky top-0 z-10 mx-auto w-full max-w-4xl bg-background"
+            style={{ zoom: fontScale }}
+          >
+            <NativeChatWorkingStatus
+              startedAt={turnStatuses.active.startedAt}
+              thinking={turnStatuses.active.thinking}
+              workedSeconds={turnStatuses.active.workedSeconds}
+            />
+          </div>
+        ) : null}
         <div
           ref={contentRef}
           // Why: same max width as the composer column; horizontal inset comes
@@ -400,9 +413,7 @@ export function NativeChatMessageList({
                   activityExpandOverride={turnKey ? expandedTurnIds.has(turnKey) : undefined}
                   runtimeContext={runtimeContext}
                 />
-                {showTurnStatus &&
-                status &&
-                (index !== latestUserIndex || showTypingIndicator || !isWorking) ? (
+                {showTurnStatus && status && (index !== latestUserIndex || !isWorking) ? (
                   <NativeChatWorkingStatus
                     startedAt={status.startedAt}
                     thinking={status.thinking}
@@ -418,16 +429,6 @@ export function NativeChatMessageList({
               </Fragment>
             )
           })}
-          {showTurnStatus &&
-          latestUserIndex === -1 &&
-          turnStatuses.active &&
-          showTypingIndicator ? (
-            <NativeChatWorkingStatus
-              startedAt={turnStatuses.active.startedAt}
-              thinking={turnStatuses.active.thinking}
-              workedSeconds={turnStatuses.active.workedSeconds}
-            />
-          ) : null}
           {!showTurnStatus && showTypingIndicator ? <NativeChatTypingIndicatorRow /> : null}
         </div>
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatWorkingStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatWorkingStatus.tsx
@@ -8,13 +8,15 @@ export function NativeChatWorkingStatus({
   thinking,
   workedSeconds,
   expanded = false,
-  onToggleExpanded
+  onToggleExpanded,
+  sticky = false
 }: {
   startedAt: number | null
   thinking: boolean
   workedSeconds?: number | null
   expanded?: boolean
   onToggleExpanded?: () => void
+  sticky?: boolean
 }): React.JSX.Element {
   // Why: elapsed seconds is ordinary render dataflow, not an external system.
   // The shared 1s clock is visibility-gated and collapses every in-flight turn
@@ -47,8 +49,8 @@ export function NativeChatWorkingStatus({
         aria-hidden="true"
       />
     ) : null
-  if (workedSeconds != null && onToggleExpanded) {
-    return (
+  const status =
+    workedSeconds != null && onToggleExpanded ? (
       <button
         type="button"
         className={`${className} w-full text-left hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70`}
@@ -59,17 +61,22 @@ export function NativeChatWorkingStatus({
         <span>{label}</span>
         {caret}
       </button>
+    ) : (
+      <div
+        className={className}
+        aria-label={translate('components.native-chat.status.responding', 'Agent is responding')}
+        aria-live="polite"
+      >
+        <span className={thinking ? 'animate-pulse' : undefined}>{label}</span>
+        {caret}
+      </div>
     )
-  }
 
-  return (
-    <div
-      className={className}
-      aria-label={translate('components.native-chat.status.responding', 'Agent is responding')}
-      aria-live="polite"
-    >
-      <span className={thinking ? 'animate-pulse' : undefined}>{label}</span>
-      {caret}
+  return sticky ? (
+    <div data-native-chat-running-status="true" className="sticky top-0 z-10 bg-background">
+      {status}
     </div>
+  ) : (
+    status
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

**Item 8** (reported P0): *"no running indicator when the AI is working"*, and *"I don't see the working bar at the top somehow."*

Reported by Jinjing in the Chat UI UI/UX feedback thread: https://stablygroup.slack.com/archives/C0BV03ZK1KN/p1788474468997739

## Root cause
The working status was mounted inline in the transcript flow rather than pinned. While `data-native-chat-working` was true, bottom-following output pushed it 194px above the clipped transcript viewport, so it scrolled out of sight exactly when it mattered.

## Fix
The single in-flight status now sticks to the top of the transcript while completed durations stay inline.

## Validation
1 file / 9 tests; `oxlint` clean; `pnpm tc:web`. After-fix Electron proof shows the status visible at 76-108px with `scrollTop` 4969.5. Renderer-only, so no execution or wire behavior changes.

Reproduced in the real Electron app over CDP before the fix and verified after.
