### PR TITLE
fix(orchestration): fence the dispatch CLI preamble so it stops rendering as headings

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -10,6 +10,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
 === CLI COMMANDS ===
 
+\`\`\`sh
   # Report the terminal task outcome (REQUIRED exactly once).
   #
   # RULE: --body must be a 3-sentence executive summary (what you did,
@@ -71,6 +72,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
   # Check for messages from the coordinator:
   orca orchestration check --terminal term_WORKER
+\`\`\`
 
 === AFTER YOU SEND worker_done ===
 

--- a/src/main/runtime/orchestration/coordinator-task-dispatch.ts
+++ b/src/main/runtime/orchestration/coordinator-task-dispatch.ts
@@ -132,7 +132,7 @@ export async function dispatchTaskToWorker(params: {
   let gateContext = ''
   if (gates.length > 0) {
     const latest = gates.at(-1)!
-    gateContext = `\n\n--- DECISION GATE RESOLVED ---\nQuestion: ${latest.question}\nResolution: ${latest.resolution}\n---\n`
+    gateContext = `\n\n--- DECISION GATE RESOLVED ---\nQuestion: ${latest.question}\nResolution: ${latest.resolution}\n\n---\n`
   }
 
   try {

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -31,6 +31,16 @@ function cliFence(result: string): string {
   return match?.[1] ?? ''
 }
 
+function markdownBlocks(result: string) {
+  const tree = unified().use(remarkParse).parse(result)
+  return {
+    headings: tree.children.filter((node) => node.type === 'heading'),
+    codeBlocks: tree.children.filter((node) => node.type === 'code')
+  }
+}
+
+const driftParams = { base: 'origin/main', behind: 3, recentSubjects: ['fix: a', 'feat: b'] }
+
 describe('buildDispatchPreamble', () => {
   it('substitutes template variables', () => {
     const result = buildDispatchPreamble(baseParams())
@@ -73,13 +83,34 @@ describe('buildDispatchPreamble', () => {
 
   it('fences shell comments so Markdown does not promote them to headings', () => {
     const result = buildDispatchPreamble(baseParams())
-    const tree = unified().use(remarkParse).parse(result)
-    const headings = tree.children.filter((node) => node.type === 'heading')
-    const codeBlocks = tree.children.filter((node) => node.type === 'code')
+    const { headings, codeBlocks } = markdownBlocks(result)
 
     expect(headings).toHaveLength(0)
     expect(codeBlocks).toHaveLength(1)
     expect(codeBlocks[0]).toMatchObject({ lang: 'sh', value: cliFence(result) })
+  })
+
+  // Why: a `---` rule directly under a paragraph is a setext H2, so the optional
+  // sections' closing rules must not turn their last sentence into a heading.
+  it('renders no Markdown headings when the sub-dispatch and drift sections are present', () => {
+    const result = buildDispatchPreamble(
+      baseParams({ canDispatchSubWorkers: true, baseDrift: driftParams })
+    )
+    const { headings, codeBlocks } = markdownBlocks(result)
+
+    expect(headings).toHaveLength(0)
+    expect(codeBlocks).toHaveLength(2)
+    expect(codeBlocks[1]).toMatchObject({ lang: 'sh' })
+    expect(codeBlocks[1].value).toContain('orchestration worker-start --task <task_id>')
+    expect(result).toContain('able to dispatch further.\n\n---')
+    expect(result).toContain('before starting.\n\n---')
+  })
+
+  it('sub-dispatch fence passes bash -n', { timeout: 15_000 }, () => {
+    const result = buildDispatchPreamble(baseParams({ canDispatchSubWorkers: true }))
+    const { codeBlocks } = markdownBlocks(result)
+    const check = spawnSync('bash', ['-n'], { input: codeBlocks[1].value, encoding: 'utf8' })
+    expect(check.status).toBe(0)
   })
 
   it('includes heartbeat CLI block with taskId and dispatchId and 5-minute cadence', () => {

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from 'node:child_process'
+import remarkParse from 'remark-parse'
+import { unified } from 'unified'
 import { describe, expect, it } from 'vitest'
 import { buildDispatchPreamble } from './preamble'
 
@@ -21,6 +23,12 @@ function afterWorkerDoneSection(result: string) {
   expect(sectionEnd).toBeGreaterThan(sectionStart)
 
   return result.slice(sectionStart, sectionEnd)
+}
+
+function cliFence(result: string): string {
+  const match = result.match(/=== CLI COMMANDS ===\n\n```sh\n([\s\S]*?)\n```/)
+  expect(match).not.toBeNull()
+  return match?.[1] ?? ''
 }
 
 describe('buildDispatchPreamble', () => {
@@ -58,24 +66,21 @@ describe('buildDispatchPreamble', () => {
     { timeout: 15_000 },
     () => {
       const result = buildDispatchPreamble(baseParams())
-      // Why: feeding `bash -n` the full preamble falsely fails on apostrophes
-      // in the surrounding prose. Slice between the CLI markers and strip
-      // shell-style comment lines so we only syntax-check the commands.
-      const cliStart = result.indexOf('=== CLI COMMANDS ===')
-      const cliEnd = result.indexOf('=== AFTER YOU SEND worker_done ===')
-      expect(cliStart).toBeGreaterThan(-1)
-      expect(cliEnd).toBeGreaterThan(cliStart)
-      const block = result.slice(cliStart, cliEnd)
-      const stripped = block
-        .split('\n')
-        .filter((line) => !line.trim().startsWith('#'))
-        .filter((line) => !line.trim().startsWith('==='))
-        .join('\n')
-
-      const check = spawnSync('bash', ['-n'], { input: stripped, encoding: 'utf8' })
+      const check = spawnSync('bash', ['-n'], { input: cliFence(result), encoding: 'utf8' })
       expect(check.status).toBe(0)
     }
   )
+
+  it('fences shell comments so Markdown does not promote them to headings', () => {
+    const result = buildDispatchPreamble(baseParams())
+    const tree = unified().use(remarkParse).parse(result)
+    const headings = tree.children.filter((node) => node.type === 'heading')
+    const codeBlocks = tree.children.filter((node) => node.type === 'code')
+
+    expect(headings).toHaveLength(0)
+    expect(codeBlocks).toHaveLength(1)
+    expect(codeBlocks[0]).toMatchObject({ lang: 'sh', value: cliFence(result) })
+  })
 
   it('includes heartbeat CLI block with taskId and dispatchId and 5-minute cadence', () => {
     const result = buildDispatchPreamble(baseParams())

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -196,6 +196,8 @@ work under the new Dispatch; ignore stale follow-ups from the settled task.`
 // Why the whole section is omitted rather than softened when nesting is off: a
 // worker told it "usually cannot" delegate still tries, then reports the refusal
 // as a blocker.
+// Why fenced + blank line before the closing `---`: unfenced `<placeholders>` are stripped as raw
+// HTML by the Chat UI, and a rule directly under a paragraph is a setext H2 (giant last sentence).
 function buildSubDispatchSection(cli: string): string {
   return `
 
@@ -203,13 +205,16 @@ function buildSubDispatchSection(cli: string): string {
 You may dispatch sub-workers for this task. Bind your own Run first, then create
 and start each one:
 
+\`\`\`sh
   ${cli} orchestration run-create --objective "<what the sub-workers are for>" --json
   ${cli} orchestration task-create --spec "<sub-task>" --json
   ${cli} orchestration worker-start --task <task_id> --worktree current --agent <agent> --json
+\`\`\`
 
 You own those sub-workers: wait for their worker_done, and do not report your own
 until they have settled. Nesting is capped, so a sub-worker of yours may not be
 able to dispatch further.
+
 ---`
 }
 
@@ -224,5 +229,6 @@ ${subjects}
 
 If any look relevant to your task, either pull them in (\`git pull --rebase
 ${drift.base}\` or equivalent) or escalate to the coordinator before starting.
+
 ---`
 }

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -59,6 +59,7 @@ export function buildDispatchPreamble(params: PreambleParams): string {
     ? ` --dispatch-capability ${params.dispatchCapability}`
     : ''
 
+  // Why: fencing keeps shell comments executable to agents without turning them into Chat UI headings.
   const header = `You are working inside Orca, a multi-agent IDE. You are a dispatched worker.
 Your coordinator's terminal handle is: ${params.coordinatorHandle}
 Your task ID is: ${params.taskId}
@@ -68,6 +69,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
 === CLI COMMANDS ===
 
+\`\`\`sh
   # Report the terminal task outcome (REQUIRED exactly once).
   #
   # RULE: --body must be a 3-sentence executive summary (what you did,
@@ -129,6 +131,7 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
   # Check for messages from the coordinator:
   ${cli} orchestration check --terminal ${params.workerHandle}
+\`\`\`
 
 ${postDoneInstructions}`
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

Fixes [STA-6725](https://linear.app/stably/issue/STA-6725/make-orchestration-not-use-h1-markdown)

**Item 1** from the Chat UI feedback thread: *"The font size from the AI response is super funky. It's so large."*

Reported by Jinjing: https://stablygroup.slack.com/archives/C0BV03ZK1KN/p1788474468997739

## ELI5
When Orca hands a task to an agent, it pastes a note that starts with a block of ready-to-run commands. Those commands have comment lines that begin with `#`. In Markdown, a line that begins with `#` means "big title", so the chat window turned every comment into a giant heading. Wrapping the command block in a code fence tells the chat window "this is code, show it as-is", and the agents that run those commands already read fenced code fine.

## What you'll see
**Before:** an agent or orchestrator message in the Chat UI opened with dozens of huge bold lines (18px, one per shell comment) stacked above the actual task, so the message looked shouty and was hard to scan for the task text.

**After:** the same message opens with one grey, monospace code block containing the commands, at the normal 12px code size. Prose and the `=== TASK ===` text keep the regular 14px body size, and nothing in the preamble renders as a heading.

## Root cause
`preamble.ts` emits its runnable CLI block as shell script indented **two** spaces. Markdown needs four to form a code block, so every `# ...` shell comment was parsed as an **H1 heading** and rendered at 18px bold against 14px body text. Reproduced as **38 H1 elements** in a single dispatched preamble.

This is why the symptom appeared specifically on agent/orchestrator messages while the rest of the Chat UI looked normal.

## Fix
Wrapped the runnable CLI section in an `sh` fence at the source layer. This was chosen over a renderer-side change because it preserves legitimate Markdown headings elsewhere in a preamble and keeps the block as native input for the agent TUIs that actually execute it.

## Validation
24 focused tests, `oxlint`, and `pnpm tc:web` all pass. The deliberate snapshot update is included. In Electron the preamble now renders **zero headings and one code block**, and both Codex and Claude Code returned ACK on the fenced preamble, confirming the TUI consumers still parse it.

Reproduced in the real Electron app before the fix and verified after.


