### PR TITLE
feat(relay): let cells dial Cloud SQL over private IP

### DIFF
--- a/cloud/infra/terraform/relay-gce-cells.tf
+++ b/cloud/infra/terraform/relay-gce-cells.tf
@@ -242,6 +242,7 @@ resource "google_compute_instance_template" "relay_gce_cell" {
     artifact_registry_host          = "${var.region}-docker.pkg.dev"
     relay_image                     = each.value.image
     cloud_sql_proxy_image           = var.relay_gce_cloud_sql_proxy_image
+    cloud_sql_private_ip            = var.relay_cloud_sql_private_ip
     # Keep cell-only plans independent from unrelated database configuration drift.
     cloud_sql_connection_name = local.relay_database_connection_name
   })

--- a/cloud/infra/terraform/relay-gce-startup.sh.tftpl
+++ b/cloud/infra/terraform/relay-gce-startup.sh.tftpl
@@ -109,6 +109,9 @@ docker run --detach \
   --user 0:0 \
   --volume "$${cloudsql_dir}:/cloudsql" \
   '${cloud_sql_proxy_image}' \
+%{ if cloud_sql_private_ip ~}
+  --private-ip \
+%{ endif ~}
   --unix-socket=/cloudsql \
   '${cloud_sql_connection_name}'
 

--- a/cloud/infra/terraform/variables.tf
+++ b/cloud/infra/terraform/variables.tf
@@ -468,6 +468,12 @@ variable "relay_gce_fenced_cells" {
   default     = []
 }
 
+variable "relay_cloud_sql_private_ip" {
+  type        = bool
+  description = "Dial Cloud SQL over its private IP inside this VPC instead of its public IP through Cloud NAT. Requires the foundation root's private services access peering to be applied first; a cell that cannot reach the private IP never becomes ready."
+  default     = false
+}
+
 variable "relay_gce_cloud_sql_proxy_image" {
   type        = string
   description = "Digest-pinned Cloud SQL Auth Proxy image used by private relay workers."


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## What

Adds `relay_cloud_sql_private_ip` (default `false`). When true, relay GCE cells run `cloud-sql-proxy --private-ip`, dialing the auth database over VPC peering instead of its public IP through Cloud NAT. Roadmap item 2.1.

Today every cell-to-database connection consumes a Cloud NAT port on the relay gateway. On 2026-09-04 that per-VM allocation filled and every cell's proxy dial timed out at once; `enable_dynamic_port_allocation` in `relay-gce-foundation.tf` raised the ceiling but did not remove the dependency. Private IP takes the traffic off NAT.

**This PR changes nothing on its own.** The variable stays false here. Production flips it in `environments/production.tfvars` only after stablyai/orca-cloud#477 is applied.

## Changes

- `relay-gce-startup.sh.tftpl`: conditional `--private-ip` on the `cloud-sql-proxy` container.
- `variables.tf`: `relay_cloud_sql_private_ip`, default `false`.
- `relay-gce-cells.tf`: passes it into the template.

`--unix-socket=/cloudsql` is untouched, so nothing else moves. The two flags are orthogonal: `--private-ip` selects the upstream address the proxy dials, `--unix-socket` selects the listener local clients use. `DATABASE_URL` still points at `/cloudsql/<connection name>` and the relay container is unchanged.

Verified against the exact digest this repo pins (`gcr.io/cloud-sql-connectors/cloud-sql-proxy@sha256:fc22...0cd2`):

```
      --private-ip                           (*) Connect to the private ip address for all instances
  -u, --unix-socket string                   (*) Enables Unix sockets for all listeners with the provided directory.
```

The proxy still resolves instance metadata through the Cloud SQL Admin API. That path already avoids NAT: both cell subnets set `private_ip_google_access = true`.

## Verification

- `terraform -chdir=cloud/infra/terraform validate` passes; `fmt -check` clean.
- `cloud/dev/fixtures/terraform-root-partition/families.json` regenerated with **no diff** — this adds a variable and a template branch, no resource family. `node --test dev/scripts/terraform-root-partition.test.mjs` from `cloud/`: 7 pass, 0 fail.
- Rendered `relay-gce-startup.sh.tftpl` through `templatefile` on both branches. With the default false the output is **byte-identical to `origin/main`**, so merging this triggers no instance-template churn and no cell roll. With true, the only difference is the added `--private-ip \` line.

## The director

`orca-cloud-relay` (Cloud Run) uses the **built-in Cloud SQL connector**: a `cloud_sql_instance` volume mounted at `/cloudsql`, which the live service confirms as `run.googleapis.com/cloudsql-instances`. It has **no** `vpc_access` block and no egress annotation.

**It is not affected by this problem and is not changed here.** Cloud Run egresses through Google's managed path, not the relay VPC's Cloud NAT gateway, so the director consumes none of the ports that ran out. The same is true of the legacy `google_cloud_run_v2_service.relay_cell` services.

Moving it to private IP anyway would not be a small template change, so it is a follow-up rather than a variable here. Google documents the `/cloudsql` unix socket as a **public IP** method:

> For public IP paths, Cloud Run can be set up to use the Cloud SQL Auth Proxy for encryption in two ways.

and private IP as a separate, socket-less path:

> This method uses TCP to connect directly to the Cloud SQL instance without using the Cloud SQL Auth Proxy.
> If you route all egress traffic through Direct VPC egress or a Serverless VPC Access connector, use a private IP address.
> Connect using your instance's private IP address and port 5432.

[Connect from Cloud Run — Cloud SQL for PostgreSQL](https://docs.cloud.google.com/sql/docs/postgres/connect-run)

So it would need all of:

1. Direct VPC egress or a Serverless VPC Access connector on `orca-cloud-relay-gce`. Direct VPC egress draws addresses from the same `10.42.0.0/24` subnet the cells use, so the subnet would need resizing first.
2. Dropping the `cloudsql` volume and mount.
3. A **different** `DATABASE_URL`. The `orca-cloud-relay-database-url` secret is shared by the director and every cell, and its value is a unix-socket DSN. Cells still want the socket, so the director would need its own secret or its own env var, and the private IP address would become a Terraform-managed input.

That is a real change to the director's connection path with no NAT benefit, so it should be its own PR with its own rollback, if it is wanted at all.

## Rollout

Ordered, with the foundation PR. Steps 1-2 are stablyai/orca-cloud#477.

1. **Wait for Roll 1.** Every cell must run an image that survives a ~2 minute database blip.
2. **Apply orca-cloud#477 off-peak.** Adding a private IP to an existing instance **restarts it** — Google documents no in-place path. Cells are unaffected: they keep using the public IP through NAT.
   - *Rollback:* none, and none needed. Private IP cannot be un-assigned, but its presence alone moves no traffic.
3. **Merge this PR.** No-op by itself.
   - *Rollback:* revert. Nothing has changed.
4. **Flip `relay_cloud_sql_private_ip = true`** in `environments/production.tfvars` and apply. Rewrites the cell instance templates only; running cells are untouched until rolled.
   - *Rollback:* set it back to false, apply, roll.
5. **Roll the cells.** Do one cell first and confirm it becomes ready before continuing. Cell readiness gates on the proxy socket appearing, so a cell that cannot reach the private IP fails to start rather than serving badly. Watch for the startup script's socket wait timing out.
   - *Rollback:* roll back to the previous instance template version. Public IP is still enabled and still works, so this always recovers.
6. **Verify.** NAT `port_usage` on `orca-cloud-relay-gce` and `orca-cloud-relay-gce-asia-east2` should fall toward zero as old cells drain. It will not reach exactly zero: image pulls and other egress still use NAT.
7. **Later, optional: disable public IP** (`auth_database_public_ip_enabled = false` in the foundation root), plus `enable_private_path_for_google_cloud_services`, which Google documents as valid only once public IP is off.
   - This **breaks the local `cloud-sql-proxy --token` workflow**, which is how humans reach the database today. It needs an IAP tunnel or a bastion in the VPC first.
   - It also breaks the director, which still uses the public-IP connector. Do the director work above first.
   - Disabling public IP **releases** the IPv4 address; re-enabling later yields a different one.
   - *Rollback:* re-enable, accepting a new public IP.
