### PR TITLE
perf(relay): per-cell inventory locks, delta counters, and a pool statement timeout

### DIFF
--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -645,9 +645,17 @@ export class RelayAssignmentStore {
   ): Promise<RelayAssignment | null> {
     const now = this.now()
     return await this.database.transaction(async (transaction) => {
-      const lockedCells = inventoryFirst
-        ? await this.lockCellInventory(transaction, lockMode)
+      // Why: the retry exists to take a cell row before the assignment row, the
+      // order placement uses. It only ever needs the one cell this host is
+      // pinned to, so read the pin unlocked and lock that row alone; taking all
+      // 23 queued every sticky refresh in the fleet behind every other one.
+      const pinnedCellId = inventoryFirst
+        ? await this.pinnedCellId(transaction, identity)
         : undefined
+      const lockedCells =
+        pinnedCellId === undefined
+          ? undefined
+          : await this.lockCellRows(transaction, [pinnedCellId], lockMode)
       const existing = await this.assignmentRow(transaction, identity, inventoryFirst)
       if (!existing) return null
       const activityLeases = await this.lockAssignmentActivities(transaction, identity, true)
@@ -661,6 +669,11 @@ export class RelayAssignmentStore {
       }
 
       const currentCellId = text(existing, 'cell_id')
+      // The pin moved between the unlocked read and the assignment lock, so the
+      // row held is the wrong one. Same recovery as losing the lock: retry.
+      if (pinnedCellId !== undefined && pinnedCellId !== currentCellId) {
+        throw new Error('database_lock_unavailable')
+      }
       const hadControl = holdsControlLease(
         activityLeases,
         currentCellId,
@@ -701,14 +714,9 @@ export class RelayAssignmentStore {
       if (hadControl) {
         await this.touchAssignment(transaction, identity, leaseExpiresAt, now)
       } else {
-        const nextReservation = integer(currentRow, 'reserved_requests') + 1
-        if (nextReservation > integer(currentRow, 'capacity_requests')) {
-          throw new Error('relay_capacity_exhausted')
-        }
-        await transaction.query(
-          `UPDATE relay_cells SET reserved_requests = ?, updated_at = ? WHERE cell_id = ?`,
-          [nextReservation, now, currentCellId]
-        )
+        // Delta, not the value read from the snapshot: an absolute write here
+        // would clobber any concurrent movement of the same counter.
+        await this.adjustCellReservationAtomically(transaction, currentCellId, 1)
         await this.adjustActivityCount(transaction, identity, 'control', 1, leaseExpiresAt, now)
         await this.insertPendingControlLease(
           transaction,
@@ -6864,13 +6872,24 @@ export class RelayAssignmentStore {
           targetCellId
         ]
       )
-      const cells = await this.lockCellInventory(transaction, 'pool-default')
+      // Only the two cells this repairs need holding. The id set below is an
+      // existence check against a table that only reconcileCells writes, so it
+      // reads unlocked instead of dragging the other 21 rows into the section.
+      const cellIds = new Set(
+        (await transaction.query(`SELECT cell_id FROM relay_cells`)).map((row) =>
+          text(row, 'cell_id')
+        )
+      )
+      const cells = await this.lockCellRows(
+        transaction,
+        [sourceCellId, targetCellId],
+        'pool-default'
+      )
       const assignmentKeys = new Set(
         assignments.map((row) =>
           assignmentKey(text(row, 'user_id'), text(row, 'relay_host_id'))
         )
       )
-      const cellIds = new Set(cells.map((row) => text(row, 'cell_id')))
       const assignmentCounts = new Map<
         string,
         { counts: Record<AssignmentActivityKind, number>; leaseExpiresAt: number }
@@ -6924,9 +6943,7 @@ export class RelayAssignmentStore {
         )
       }
 
-      for (const row of cells.filter((cell) =>
-        [sourceCellId, targetCellId].includes(text(cell, 'cell_id'))
-      )) {
+      for (const row of cells) {
         const cellId = text(row, 'cell_id')
         const expected = cellUnits.get(cellId) ?? 0
         if (expected > integer(row, 'capacity_requests')) {
@@ -6958,14 +6975,38 @@ export class RelayAssignmentStore {
   // Per-connection paths touch one or two cells. Locking exactly those rows,
   // in the same ascending order the inventory lock uses (ORDER BY fixes the
   // row-lock order), keeps them off the fleet-wide lock without a cycle.
-  private async lockCellRows(database: RelayDatabase, cellIds: string[]): Promise<SqlRow[]> {
+  // The wait policy follows the caller for the same reason the inventory lock's
+  // does: a sweep must not fail terminally on ordinary contention. Hold time is
+  // deliberately not sampled here — the metric tracks the fleet-wide lock these
+  // rows replace, and mixing in short single-row holds would flatter it.
+  private async lockCellRows(
+    database: RelayDatabase,
+    cellIds: string[],
+    mode: CellInventoryLockMode = 'request'
+  ): Promise<SqlRow[]> {
     const distinct = [...new Set(cellIds)]
+    const { measureHoldMs: _sampled, ...wait } = cellInventoryLockOptions(mode)
     return await database.queryLocked(
       `SELECT * FROM relay_cells WHERE cell_id IN (${distinct.map(() => '?').join(', ')})
        ORDER BY cell_id ASC`,
       distinct,
-      { lockTimeoutMs: CELL_INVENTORY_LOCK_TIMEOUT_MS }
+      wait
     )
+  }
+
+  // Unlocked on purpose: this only names the row to lock next, and the caller
+  // re-checks the pin once the assignment row is held.
+  private async pinnedCellId(
+    database: RelayDatabase,
+    identity: AssignmentIdentity
+  ): Promise<string | undefined> {
+    const row = (
+      await database.query(
+        `SELECT cell_id FROM relay_assignments WHERE user_id = ? AND relay_host_id = ?`,
+        [identity.userId, identity.relayHostId]
+      )
+    )[0]
+    return row ? text(row, 'cell_id') : undefined
   }
 
   private async lockGeneralCellInventory(
@@ -6986,10 +7027,11 @@ export class RelayAssignmentStore {
 
   private async leastLoadedCell(
     database: RelayDatabase,
-    lockedCells: SqlRow[] | undefined,
+    // Required: the one caller has already locked the inventory it selects from,
+    // and an optional parameter left a second fleet-wide lock reachable here.
+    rows: SqlRow[],
     preferredRegion: RelayRegion
   ): Promise<CellRow | null> {
-    const rows = lockedCells ?? (await this.lockCellInventory(database, 'pool-default'))
     const regions = new Map(
       (await database.query(`SELECT cell_id, region FROM relay_cell_regions`)).map((row) => [
         text(row, 'cell_id'),

--- a/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-lock-census.test.ts
@@ -18,7 +18,9 @@ type CensusEntry = { method: string; mode: CensusMode; reach: Reachability }
 // assignment-store.ts, in source order. A new site fails this test until it is
 // classified here, which is the point.
 const CENSUS: CensusEntry[] = [
-  { method: 'assignStickyOnce', mode: 'caller', reach: 'both' },
+  // assignStickyOnce is gone from this list: its retry now locks only the row
+  // the host is pinned to (lockCellRows), which is what a sticky refresh
+  // touches. Placement below is the one genuinely fleet-wide decision left.
   { method: 'assignOnce', mode: 'caller', reach: 'both' },
   { method: 'assignOnce', mode: 'caller', reach: 'both' },
   { method: 'assignOnce', mode: 'nowait', reach: 'both' },
@@ -49,8 +51,9 @@ const CENSUS: CensusEntry[] = [
   { method: 'abortExpiredEvacuations', mode: 'nowait', reach: 'sweep' },
   { method: 'releaseExpiredActivityLeases', mode: 'nowait', reach: 'sweep' },
   { method: 'releaseExpiredActivity', mode: 'nowait', reach: 'sweep' },
-  { method: 'reconcileReservationAccounting', mode: 'pool-default', reach: 'both' },
-  { method: 'leastLoadedCell', mode: 'pool-default', reach: 'both' }
+  // reconcileReservationAccounting and leastLoadedCell are gone too: the first
+  // repairs exactly two cells' counters and now holds only those rows, and the
+  // second selects from the inventory its single caller has already locked.
 ]
 
 // Every inline `FROM relay_cells ... FOR UPDATE` outside the named lock helpers,

--- a/cloud/apps/relay/src/cell-inventory-per-cell-locking-postgres.test.ts
+++ b/cloud/apps/relay/src/cell-inventory-per-cell-locking-postgres.test.ts
@@ -1,0 +1,206 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { RelayAssignmentStore } from './assignment-store.js'
+import { openRelayDatabase, type RelayDatabase } from './database.js'
+
+const databaseUrl = process.env.ORCA_RELAY_TEST_POSTGRES_URL
+const describePostgres = databaseUrl ? describe : describe.skip
+
+// Sorted ascending, and the host is pinned to the LAST id on purpose: the
+// fleet-wide lock is one ordered scan, so it holds every earlier row while it
+// waits on the pinned one. Pinning to the first id would make the two locking
+// models indistinguishable.
+const cells = ['a', 'b', 'c'].map((suffix) => ({
+  id: `percell-postgres-${suffix}`,
+  url: `https://percell-postgres-${suffix}.example.com`,
+  capacityRequests: 1_000,
+  connectionHardCap: 600 as const,
+  connectionUnobservedBound: 50
+}))
+const [cellA, cellB, cellC] = cells as [(typeof cells)[0], (typeof cells)[0], (typeof cells)[0]]
+const identity = { userId: 'percell-postgres-user', relayHostId: 'percellhost00001' }
+
+function heartbeat(cell: (typeof cells)[number]) {
+  return {
+    cellId: cell.id,
+    cellUrl: cell.url,
+    cellIncarnation: '11111111-1111-4111-8111-111111111111',
+    startedAt: 50,
+    ready: true,
+    observedRequests: 0,
+    totalConnections: 0,
+    inFlightConnections: 0,
+    reservedConnectionUnits: 0,
+    enforcedConnectionUnits: 0,
+    connectionInclusionWatermark: 1,
+    connectionHardCap: 600 as const,
+    connectionUnobservedBound: 50
+  }
+}
+
+describePostgres('PostgreSQL per-cell inventory locking', () => {
+  const databases: RelayDatabase[] = []
+
+  beforeAll(async () => {
+    for (let index = 0; index < 3; index++) {
+      databases.push(await openRelayDatabase({ databaseUrl, dataDir: '' }))
+    }
+  })
+
+  async function removeTestRows(database: RelayDatabase): Promise<void> {
+    await database.query(
+      `DELETE FROM relay_control_connection_reservations WHERE user_id LIKE 'percell-postgres-%'`
+    )
+    for (const table of [
+      'relay_assignment_activity_leases',
+      'relay_post_drain_migration_pins',
+      'relay_assignment_migration_incarnations',
+      'relay_assignment_migrations',
+      'relay_assignment_region_preferences',
+      'relay_assignments'
+    ]) {
+      await database.query(`DELETE FROM ${table} WHERE user_id LIKE 'percell-postgres-%'`)
+    }
+    for (const cell of cells) {
+      for (const table of [
+        'relay_cell_connection_snapshots',
+        'relay_cell_connection_runtime',
+        'relay_cell_connection_limits',
+        'relay_cell_runtime',
+        'relay_cells'
+      ]) {
+        await database.query(`DELETE FROM ${table} WHERE cell_id = ?`, [cell.id])
+      }
+    }
+  }
+
+  afterAll(async () => {
+    if (databases[0]) await removeTestRows(databases[0])
+    for (const connection of databases) await connection.close()
+  })
+
+  async function pinHostToLastCell(store: RelayAssignmentStore): Promise<void> {
+    await store.reconcileCells(cells)
+    for (const cell of cells) await store.recordCellHeartbeat(heartbeat(cell))
+    await store.setCellEnabled(cellA.id, false)
+    await store.setCellEnabled(cellB.id, false)
+    const assignment = await store.assign(identity)
+    expect(assignment.cellId).toBe(cellC.id)
+    await store.setCellEnabled(cellA.id, true)
+    await store.setCellEnabled(cellB.id, true)
+  }
+
+  async function lockWaiterAppeared(database: RelayDatabase): Promise<boolean> {
+    const deadline = Date.now() + 4_000
+    while (Date.now() < deadline) {
+      const rows = await database.query(
+        `SELECT count(*) AS waiting FROM pg_stat_activity
+         WHERE datname = current_database() AND wait_event_type = 'Lock'`
+      )
+      if (Number(rows[0]!.waiting) > 0) return true
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    }
+    return false
+  }
+
+  // Why: a sticky refresh whose first NOWAIT probe loses retries by taking a
+  // cell row before the assignment row. That retry used to take the whole
+  // inventory, so one busy cell stalled every other cell's reconnects.
+  it('waits only on the pinned cell row while refreshing a sticky assignment', async () => {
+    await removeTestRows(databases[0]!)
+    const store = new RelayAssignmentStore(databases[0]!, () => 100)
+    await pinHostToLastCell(store)
+    // A host whose control lease was already reaped still holds its pin; that
+    // is the shape that reaches the cell-row probe instead of touchAssignment.
+    await databases[0]!.query(
+      `DELETE FROM relay_assignment_activity_leases WHERE user_id = ?`,
+      [identity.userId]
+    )
+
+    let releaseRow!: () => void
+    const rowReleased = new Promise<void>((resolve) => {
+      releaseRow = resolve
+    })
+    let rowHeld!: () => void
+    const rowHeldPromise = new Promise<void>((resolve) => {
+      rowHeld = resolve
+    })
+    const holder = databases[1]!.transaction(async (transaction) => {
+      await transaction.queryLocked(`SELECT * FROM relay_cells WHERE cell_id = ?`, [cellC.id])
+      rowHeld()
+      await rowReleased
+    })
+    await rowHeldPromise
+
+    const refresh = store.assign(identity)
+    expect(await lockWaiterAppeared(databases[2]!)).toBe(true)
+    // The refresh is blocked on cell C. Every earlier row must still be free:
+    // the ordered fleet-wide scan would be holding both of them by now.
+    const heldWhileRefreshWaits: string[] = []
+    await databases[2]!.transaction(async (transaction) => {
+      for (const cell of [cellA, cellB]) {
+        try {
+          await transaction.queryLocked(
+            `SELECT * FROM relay_cells WHERE cell_id = ?`,
+            [cell.id],
+            { failIfUnavailable: true }
+          )
+        } catch {
+          heldWhileRefreshWaits.push(cell.id)
+        }
+      }
+    })
+    releaseRow()
+    await holder
+
+    expect(heldWhileRefreshWaits).toEqual([])
+    expect((await refresh).cellId).toBe(cellC.id)
+  }, 15_000)
+
+  // Why: the counter moves by a delta now instead of an absolute value read
+  // from a snapshot, so concurrent movement on the same cell must still sum.
+  it('keeps a cell reservation exact under concurrent same-cell activity', async () => {
+    await removeTestRows(databases[0]!)
+    const store = new RelayAssignmentStore(databases[0]!, () => 100)
+    await store.reconcileCells(cells)
+    for (const cell of cells) await store.recordCellHeartbeat(heartbeat(cell))
+    await store.setCellEnabled(cellA.id, false)
+    await store.setCellEnabled(cellB.id, false)
+
+    const hosts = Array.from({ length: 6 }, (_, index) => ({
+      userId: `percell-postgres-user-${index}`,
+      relayHostId: `percellhost0000${index}`
+    }))
+    const stores = databases.map((database) => new RelayAssignmentStore(database, () => 100))
+    await Promise.all(hosts.map((host, index) => stores[index % stores.length]!.assign(host)))
+
+    // One splice each (2 units) on the same cell, from three connections at once.
+    await Promise.all(
+      hosts.map((host, index) =>
+        stores[index % stores.length]!.acquireActivity(host, {
+          activityId: `splice:percell-${index}`,
+          kind: 'splice',
+          cellId: cellC.id
+        })
+      )
+    )
+    const afterAcquire = await databases[0]!.query(
+      `SELECT reserved_requests FROM relay_cells WHERE cell_id = ?`,
+      [cellC.id]
+    )
+    // 6 pending control grants + 6 splices at 2 units each.
+    expect(Number(afterAcquire[0]!.reserved_requests)).toBe(6 + 12)
+
+    await Promise.all(
+      hosts.map((host, index) =>
+        stores[index % stores.length]!.releaseActivity(host, `splice:percell-${index}`)
+      )
+    )
+    const afterRelease = await databases[0]!.query(
+      `SELECT reserved_requests FROM relay_cells WHERE cell_id = ?`,
+      [cellC.id]
+    )
+    expect(Number(afterRelease[0]!.reserved_requests)).toBe(6)
+    await store.setCellEnabled(cellA.id, true)
+    await store.setCellEnabled(cellB.id, true)
+  }, 15_000)
+})

--- a/cloud/apps/relay/src/database-postgres-timeout.test.ts
+++ b/cloud/apps/relay/src/database-postgres-timeout.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const fakes = vi.hoisted(() => ({
   configs: [] as Array<Record<string, unknown>>,
-  query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+  // Pool construction and pool shutdown interleaved, so "the schema pool is
+  // gone before the serving pool opens" is checkable rather than assumed.
+  lifecycle: [] as string[],
+  query: vi.fn(async (_sql: string) => ({ rows: [], rowCount: 0 })),
   release: vi.fn(),
   end: vi.fn(async () => undefined)
 }))
@@ -13,19 +16,36 @@ vi.mock('pg', () => ({
       totalCount = 1
       idleCount = 1
       waitingCount = 0
-      end = fakes.end
       on = vi.fn()
       connect = vi.fn(async () => ({ query: fakes.query, release: fakes.release }))
+      private readonly label: string
 
       constructor(config: Record<string, unknown>) {
         fakes.configs.push(config)
+        this.label = `max=${String(config.max)} statement_timeout=${String(config.statement_timeout)}`
+        fakes.lifecycle.push(`open ${this.label}`)
+      }
+
+      async end(): Promise<void> {
+        fakes.lifecycle.push(`end ${this.label}`)
+        await fakes.end()
       }
     }
   }
 }))
 
-import { openRelayDatabase } from './database.js'
+import { openRelayDatabase, relayPostgresStatementTimeoutMs } from './database.js'
 import { applyPostgresSchema } from './postgres-schema-startup.js'
+
+const SCHEMA_POOL = {
+  max: 1,
+  application_name: 'orca-relay/director/director/schema',
+  connectionTimeoutMillis: 2_000,
+  // Why: DDL must not inherit the request deadline.
+  statement_timeout: 0,
+  lock_timeout: 1_000,
+  idle_in_transaction_session_timeout: 5_000
+}
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -34,9 +54,11 @@ afterEach(() => {
 describe('PostgreSQL relay deadlines', () => {
   beforeEach(() => {
     fakes.configs.length = 0
+    fakes.lifecycle.length = 0
     fakes.query.mockClear()
     fakes.release.mockClear()
     fakes.end.mockClear()
+    delete process.env.ORCA_RELAY_POSTGRES_STATEMENT_TIMEOUT_MS
   })
 
   it('bounds pool acquisition, statements, locks, and abandoned transactions', async () => {
@@ -48,6 +70,7 @@ describe('PostgreSQL relay deadlines', () => {
     })
 
     expect(fakes.configs).toEqual([
+      expect.objectContaining(SCHEMA_POOL),
       expect.objectContaining({
         max: 3,
         application_name: 'orca-relay/director/director',
@@ -57,6 +80,110 @@ describe('PostgreSQL relay deadlines', () => {
         idle_in_transaction_session_timeout: 5_000
       })
     ])
+    await database.close()
+  })
+
+  // Why: an untimed session left open would be a standing way for request work
+  // to escape the deadline this whole pool config exists to enforce.
+  it('closes the untimed schema pool before the serving pool opens', async () => {
+    const database = await openRelayDatabase({
+      databaseUrl: 'postgresql://relay:secret@127.0.0.1:5432/relay',
+      dataDir: './unused',
+      poolMax: 3,
+      applicationName: 'orca-relay/director/director'
+    })
+
+    expect(fakes.lifecycle).toEqual([
+      'open max=1 statement_timeout=0',
+      'end max=1 statement_timeout=0',
+      'open max=3 statement_timeout=5000'
+    ])
+    await database.close()
+  })
+
+  it('applies the schema on the untimed pool, never on the serving one', async () => {
+    fakes.query.mockClear()
+    const ddl: string[] = []
+    fakes.query.mockImplementation(async (sql: string) => {
+      // Every statement issued before the serving pool exists is schema work.
+      if (fakes.lifecycle.length === 1) ddl.push(sql)
+      return { rows: [], rowCount: 0 }
+    })
+    const database = await openRelayDatabase({
+      databaseUrl: 'postgresql://relay:secret@127.0.0.1:5432/relay',
+      dataDir: './unused'
+    })
+
+    expect(ddl.length).toBeGreaterThan(0)
+    // Statements can open with a leading `--` rationale comment.
+    const body = (statement: string): string =>
+      statement.replace(/^(?:\s*--[^\n]*\n)*\s*/, '')
+    expect(ddl.every((statement) => /^CREATE\b/i.test(body(statement)))).toBe(true)
+    // The backfill is DML, so it stays on the deadline-bearing serving pool.
+    expect(ddl.some((statement) => statement.includes('INSERT INTO'))).toBe(false)
+    await database.close()
+  })
+
+  it('takes the serving statement deadline from the environment', async () => {
+    process.env.ORCA_RELAY_POSTGRES_STATEMENT_TIMEOUT_MS = '2500'
+
+    const database = await openRelayDatabase({
+      databaseUrl: 'postgresql://relay:secret@127.0.0.1:5432/relay',
+      dataDir: './unused'
+    })
+
+    expect(fakes.configs).toEqual([
+      expect.objectContaining({ statement_timeout: 0 }),
+      expect.objectContaining({ statement_timeout: 2_500 })
+    ])
+    await database.close()
+  })
+
+  it.each(['0', '-1', '2.5', 'soon', ' '])(
+    'refuses %s as a statement deadline instead of running unbounded',
+    (value) => {
+      expect(() =>
+        relayPostgresStatementTimeoutMs({ ORCA_RELAY_POSTGRES_STATEMENT_TIMEOUT_MS: value })
+      ).toThrow('invalid_statement_timeout')
+    }
+  )
+
+  it.each([undefined, ''])('defaults to 5s when the environment says %s', (value) => {
+    expect(
+      relayPostgresStatementTimeoutMs(
+        value === undefined ? {} : { ORCA_RELAY_POSTGRES_STATEMENT_TIMEOUT_MS: value }
+      )
+    ).toBe(5_000)
+  })
+
+  // Why: a statement deadline that reaches the caller as a crash converts a
+  // transient stall into a failed assignment. It aborts the transaction exactly
+  // as a lock timeout does, so it belongs on the same bounded retry.
+  it('retries a statement timeout on a fresh client', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const database = await openRelayDatabase({
+      databaseUrl: 'postgresql://relay:secret@127.0.0.1:5432/relay',
+      dataDir: './unused'
+    })
+    let attempts = 0
+
+    const result = await database.transaction(async (transaction) => {
+      attempts += 1
+      if (attempts === 1) {
+        await transaction.query('SELECT 1')
+        throw Object.assign(new Error('canceling statement due to statement timeout'), {
+          code: '57014'
+        })
+      }
+      return 'committed'
+    })
+
+    expect(result).toBe('committed')
+    expect(attempts).toBe(2)
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('"event":"orca_relay_postgres_transaction_retry"')
+    )
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('"code":"57014"'))
     await database.close()
   })
 })

--- a/cloud/apps/relay/src/database-statement-timeout-postgres.test.ts
+++ b/cloud/apps/relay/src/database-statement-timeout-postgres.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { openRelayDatabase, type RelayDatabase } from './database.js'
+
+const databaseUrl = process.env.ORCA_RELAY_TEST_POSTGRES_URL
+const describePostgres = databaseUrl ? describe : describe.skip
+const applicationName = 'orca-relay/statement-timeout-postgres'
+
+describePostgres('PostgreSQL statement deadline', () => {
+  const databases: RelayDatabase[] = []
+
+  beforeAll(async () => {
+    databases.push(await openRelayDatabase({ databaseUrl, dataDir: '' }))
+  })
+
+  afterAll(async () => {
+    for (const database of databases) await database.close()
+  })
+
+  it('serves requests under the configured deadline', async () => {
+    const database = await openRelayDatabase({ databaseUrl, dataDir: '', statementTimeoutMs: 300 })
+    databases.push(database)
+
+    expect(await database.query(`SELECT current_setting('statement_timeout') AS statement_timeout`)).toEqual([
+      { statement_timeout: '300ms' }
+    ])
+  })
+
+  // Why: a real 57014 aborts the transaction exactly as a lock timeout does. If
+  // it escapes the bounded retry it becomes a failed assignment instead of a
+  // slow one.
+  it('retries a real statement timeout on a fresh client', async () => {
+    const database = await openRelayDatabase({ databaseUrl, dataDir: '', statementTimeoutMs: 300 })
+    databases.push(database)
+    let attempts = 0
+
+    const result = await database.transaction(async (transaction) => {
+      attempts += 1
+      if (attempts === 1) await transaction.query(`SELECT pg_sleep(2)`)
+      return attempts
+    })
+
+    expect(result).toBe(2)
+  }, 15_000)
+
+  // Why: DDL runs on its own untimed connection. relay_invites carries a
+  // CREATE INDEX IF NOT EXISTS, which (unlike CREATE TABLE IF NOT EXISTS)
+  // really does queue behind an ACCESS EXCLUSIVE lock on the table.
+  it('applies the schema behind a held ACCESS EXCLUSIVE lock', async () => {
+    let releaseTable!: () => void
+    const tableReleased = new Promise<void>((resolve) => {
+      releaseTable = resolve
+    })
+    let tableHeld!: () => void
+    const tableHeldPromise = new Promise<void>((resolve) => {
+      tableHeld = resolve
+    })
+    const holder = databases[0]!.transaction(async (transaction) => {
+      await transaction.query(`LOCK TABLE relay_invites IN ACCESS EXCLUSIVE MODE`)
+      tableHeld()
+      await tableReleased
+    })
+    await tableHeldPromise
+
+    const opening = openRelayDatabase({
+      databaseUrl,
+      dataDir: '',
+      applicationName,
+      // Far too short for a blocked DDL; the serving pool wears it, the schema
+      // connection must not.
+      statementTimeoutMs: 200
+    })
+    const blockedOnSchemaConnection = async (): Promise<boolean> => {
+      const deadline = Date.now() + 4_000
+      while (Date.now() < deadline) {
+        const rows = await databases[0]!.query(
+          `SELECT count(*) AS waiting FROM pg_stat_activity
+           WHERE datname = current_database() AND wait_event_type = 'Lock'
+             AND application_name = ?`,
+          [`${applicationName}/schema`]
+        )
+        if (Number(rows[0]!.waiting) > 0) return true
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      }
+      return false
+    }
+    const blocked = await blockedOnSchemaConnection()
+    releaseTable()
+    await holder
+
+    const database = await opening
+    databases.push(database)
+    expect(blocked).toBe(true)
+    // The serving pool still carries the short deadline it was opened with.
+    expect(await database.query(`SELECT current_setting('statement_timeout') AS statement_timeout`)).toEqual([
+      { statement_timeout: '200ms' }
+    ])
+  }, 15_000)
+})

--- a/cloud/apps/relay/src/database.ts
+++ b/cloud/apps/relay/src/database.ts
@@ -796,12 +796,34 @@ class PostgresTransaction implements RelayDatabase {
 const POSTGRES_TRANSACTION_ATTEMPTS = 3
 const POSTGRES_RETRY_MAX_DELAY_MS = 25
 const POSTGRES_CONNECTION_TIMEOUT_MS = 2_000
-const POSTGRES_STATEMENT_TIMEOUT_MS = 5_000
+// Derivation: a control renewal must land inside its own 30s tick
+// (RELAY_PROTOCOL_LIMITS.controlPingIntervalMs * 2), and a transaction gets
+// POSTGRES_TRANSACTION_ATTEMPTS tries, so the worst case a renewal can spend in
+// Postgres is attempts * timeout. 5s keeps that at 15s, half the tick, and still
+// leaves room for the connect timeout above.
+export const POSTGRES_STATEMENT_TIMEOUT_MS = 5_000
 const POSTGRES_IDLE_TRANSACTION_TIMEOUT_MS = 5_000
+
+export function relayPostgresStatementTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const configured = env.ORCA_RELAY_POSTGRES_STATEMENT_TIMEOUT_MS
+  if (configured === undefined || configured === '') return POSTGRES_STATEMENT_TIMEOUT_MS
+  const milliseconds = Number(configured)
+  // 0 is PostgreSQL's "no timeout"; refusing it keeps the deadline this exists
+  // to enforce from being disabled by a typo in an environment variable.
+  if (!Number.isInteger(milliseconds) || milliseconds < 1) {
+    throw new Error('invalid_statement_timeout')
+  }
+  return milliseconds
+}
 
 function retryablePostgresTransactionError(error: unknown): boolean {
   const code = String((error as { code?: unknown }).code)
-  return code === '40P01' || code === '40001' || code === '55P03'
+  // 57014 is the pool statement_timeout firing. It aborts the transaction the
+  // same way a lock timeout does, so it belongs on the bounded retry path
+  // rather than surfacing as a terminal failure to the caller.
+  return code === '40P01' || code === '40001' || code === '55P03' || code === '57014'
 }
 
 export function isRelayDatabaseTransientError(error: unknown): boolean {
@@ -963,11 +985,36 @@ async function applySchema(database: RelayDatabase): Promise<void> {
   }
 }
 
-async function applySchemaWithPostgresRetries(database: RelayDatabase): Promise<void> {
-  await applyPostgresSchema(
-    SCHEMA.split(';').filter((statement) => statement.trim()),
-    async (statement) => await database.query(statement)
-  )
+// Why: DDL is not a request. A CREATE INDEX on a grown table legitimately runs
+// longer than the request statement_timeout, and inheriting that timeout would
+// make every startup fail at the same statement instead of finishing once. One
+// short-lived connection of its own, ended before the serving pool opens, keeps
+// the untimed session off the request path entirely.
+async function applySchemaOnUntimedPool(
+  databaseUrl: string,
+  applicationName: string | undefined
+): Promise<void> {
+  const pool = new pg.Pool({
+    connectionString: databaseUrl,
+    max: 1,
+    application_name: applicationName ? `${applicationName}/schema` : undefined,
+    connectionTimeoutMillis: POSTGRES_CONNECTION_TIMEOUT_MS,
+    statement_timeout: 0,
+    // Kept: a DDL blocked behind another director's ACCESS EXCLUSIVE lock must
+    // yield to the bounded schema retry instead of holding the connection.
+    lock_timeout: POSTGRES_LOCK_TIMEOUT_MS,
+    idle_in_transaction_session_timeout: POSTGRES_IDLE_TRANSACTION_TIMEOUT_MS
+  })
+  absorbPostgresIdleClientErrors(pool)
+  const database = new PostgresDatabase(pool)
+  try {
+    await applyPostgresSchema(
+      SCHEMA.split(';').filter((statement) => statement.trim()),
+      async (statement) => await database.query(statement)
+    )
+  } finally {
+    await database.close().catch(() => undefined)
+  }
 }
 
 async function backfillRelayCellRegions(database: RelayDatabase): Promise<void> {
@@ -983,15 +1030,17 @@ export async function openRelayDatabase(input: {
   dataDir: string
   poolMax?: number
   applicationName?: string
+  statementTimeoutMs?: number
 }): Promise<RelayDatabase> {
   let database: RelayDatabase
   if (input.databaseUrl) {
+    await applySchemaOnUntimedPool(input.databaseUrl, input.applicationName)
     const pool = new pg.Pool({
       connectionString: input.databaseUrl,
       max: input.poolMax ?? 10,
       application_name: input.applicationName,
       connectionTimeoutMillis: POSTGRES_CONNECTION_TIMEOUT_MS,
-      statement_timeout: POSTGRES_STATEMENT_TIMEOUT_MS,
+      statement_timeout: input.statementTimeoutMs ?? relayPostgresStatementTimeoutMs(),
       lock_timeout: POSTGRES_LOCK_TIMEOUT_MS,
       idle_in_transaction_session_timeout: POSTGRES_IDLE_TRANSACTION_TIMEOUT_MS
     })
@@ -1004,8 +1053,7 @@ export async function openRelayDatabase(input: {
     database = new SqliteDatabase(sqlite)
   }
   try {
-    if (input.databaseUrl) await applySchemaWithPostgresRetries(database)
-    else await applySchema(database)
+    if (!input.databaseUrl) await applySchema(database)
     await backfillRelayCellRegions(database)
     return database
   } catch (error) {

--- a/cloud/apps/relay/src/postgres-transaction-recovery.test.ts
+++ b/cloud/apps/relay/src/postgres-transaction-recovery.test.ts
@@ -503,12 +503,19 @@ describePostgres('PostgreSQL transaction recovery', () => {
     const directorLockOrder: string[] = []
     const assignmentDatabase = new TransactionProbeDatabase(database, async (phase, sql) => {
       if (phase === 'before') {
-        if (sql.includes('FROM relay_assignments WHERE user_id = ?')) {
+        // Only locked statements reach this hook, so classifying the pin read
+        // is what proves it stays unlocked: if it ever grows a FOR UPDATE it
+        // shows up in the order below instead of silently joining the queue.
+        if (sql.includes('SELECT cell_id FROM relay_assignments')) {
+          directorLockOrder.push('pin-read')
+        } else if (sql.includes('FROM relay_assignments WHERE user_id = ?')) {
           directorLockOrder.push('assignment')
         } else if (sql.includes('FROM relay_assignment_activity_leases')) {
           directorLockOrder.push('activity')
         } else if (sql.includes('FROM relay_cells ORDER BY')) {
           directorLockOrder.push('cell-inventory')
+        } else if (sql.includes('FROM relay_cells WHERE cell_id IN')) {
+          directorLockOrder.push('cell-rows')
         } else if (sql.includes('FROM relay_cells WHERE cell_id = ?')) {
           directorLockOrder.push('cell')
         }
@@ -530,11 +537,14 @@ describePostgres('PostgreSQL transaction recovery', () => {
     })
     await expect(legacyTransaction).resolves.toBeUndefined()
     expect(assignmentDatabase.attempts).toBe(2)
+    // The retry still takes a cell row before the assignment row — the order
+    // that avoids the legacy cycle — but only the pinned row, never the
+    // inventory.
     expect(directorLockOrder).toEqual([
       'assignment',
       'activity',
       'cell',
-      'cell-inventory',
+      'cell-rows',
       'assignment',
       'activity'
     ])


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​452 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​444 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |

<!-- /orca-pr-loc -->

## Why

`postgres_retries` on the director is ~100% `55P03` against one self-imposed critical
section: `SELECT * FROM relay_cells ORDER BY cell_id ASC FOR UPDATE` over a 23-row table,
taken by the assignment hot path and by director sweeps alike. #18521 bounded the wait to
500 ms and #18606 took per-connection paths off it, but two paths that mutate one or two
cells still took all 23:

- **the sticky refresh retry.** A returning host whose first NOWAIT probe of its own cell
  row loses retries by taking a cell row *before* the assignment row (the order that avoids
  the legacy cell-first cycle). That retry took the whole inventory, so a rebind anywhere in
  the fleet stalled every other cell's reconnects.
- **`reconcileReservationAccounting`.** It repairs exactly two cells' counters — source and
  target of a migration — and locked the other 21 to do it. It runs on nine migration paths.

Separately, `statement_timeout` was hardcoded, DDL ran on the same deadline-bearing pool as
requests, and `57014` was **not** in `retryablePostgresTransactionError`, so a statement
deadline reached the caller as a terminal failure rather than a retry.

## Before / after locking model

| path | before | after |
| --- | --- | --- |
| sticky refresh retry | `relay_cells ORDER BY cell_id ASC FOR UPDATE` (all 23) | unlocked pin read, then `FOR UPDATE` on that one row |
| reservation reconciliation | all 23 `FOR UPDATE` | `FOR UPDATE` on `{source, target}`; unlocked `SELECT cell_id` for the existence check |
| `leastLoadedCell` | optional `lockedCells`, else a second fleet-wide lock | `rows` is required; the fallback is gone |
| sticky grant counter | `SET reserved_requests = <snapshot + 1>` | `adjustCellReservationAtomically` (`reserved_requests + $1` with the capacity guard in the same statement) |
| **placement** | ordered inventory lock | **unchanged, deliberately** |

Placement keeps the narrow global lock. Choosing the least-loaded cell is a genuinely
fleet-wide decision, and the existing comment records that dynamically locking only the
selected target is what allowed cross-cell cycles. Row order is still ascending `cell_id`
everywhere (`lockCellRows` keeps its `ORDER BY`), so the per-cell locks cannot cycle with it.

`lockCellRows` now takes the caller's `CellInventoryLockMode` instead of hardcoding the
500 ms request bound, so a sweep-reachable site does not turn ordinary contention into a
terminal `55P03`. It still does not sample hold time: `cellInventoryHoldMs*` tracks the
fleet-wide lock these rows replace, and mixing in short single-row holds would flatter it.

## Invariants preserved, and how each is tested

- **Lock order (cell before assignment on the retry).** `postgres-transaction-recovery.test.ts`
  now traces `assignment, activity, cell, cell-rows, assignment, activity` against a legacy
  cell-first holder. The pin read is classified in the same hook but must *not* appear —
  only locked statements reach it, so its absence is the proof it stays unlocked.
- **A held cell row blocks only that cell.** New `cell-inventory-per-cell-locking-postgres.test.ts`
  pins the host to the *last* cell id, holds that row, and NOWAIT-probes the two earlier
  rows while the refresh waits. Mutation-checked: restoring `lockCellInventory` there fails
  with `["percell-postgres-a", "percell-postgres-b"]`.
- **Counters stay exact under concurrency.** Six hosts across three connections acquire and
  release splices on one cell; `reserved_requests` lands on 18 then back to 6.
- **Capacity / headroom / supersession / admission selector.** Unchanged code paths; the
  full suite (591 tests) passes against real PostgreSQL, including the connection-headroom,
  control-supersession, migration-recovery and control-lease-recovery suites.
- **Census.** `cell-inventory-lock-census.test.ts` still requires every `lockCellInventory`
  site to be classified and every raw `relay_cells` lock to be routed through a named
  helper, so re-adding a fleet-wide lock at any of the three removed sites fails the test.
- **Statement deadline is retryable, not terminal.** Unit test with a faked `57014` and a
  real-PostgreSQL test that drives `pg_sleep(2)` under a 300 ms deadline; both die when
  `57014` is removed from `retryablePostgresTransactionError`.
- **DDL is untimed.** Unit test pins the schema pool's shape (`max: 1`,
  `statement_timeout: 0`) and the lifecycle order `open schema → end schema → open serving`,
  and asserts only `CREATE …` statements run before the serving pool exists. A
  real-PostgreSQL test holds `ACCESS EXCLUSIVE` on `relay_invites` (whose
  `CREATE INDEX IF NOT EXISTS` genuinely queues, unlike `CREATE TABLE IF NOT EXISTS`) and
  confirms the blocked backend is the `…/schema` connection and that the open still
  completes with a 200 ms serving deadline.

## The timeout value and its derivation

Default stays **5 s**, now overridable with `ORCA_RELAY_POSTGRES_STATEMENT_TIMEOUT_MS`.
A control renewal must land inside its own tick, which is
`RELAY_PROTOCOL_LIMITS.controlPingIntervalMs * 2 = 30 s`. A transaction gets
`POSTGRES_TRANSACTION_ATTEMPTS = 3` tries, so the worst case a renewal spends in PostgreSQL
is `attempts × timeout`. 5 s keeps that at 15 s — half the tick — with room for the 2 s
connect timeout. The parser refuses `0`: that is PostgreSQL's "no timeout", and a typo
should not disable the deadline this exists to enforce.

The DDL pool keeps `lock_timeout` (1 s) so a blocked `CREATE INDEX` yields to
`applyPostgresSchema`'s bounded retry instead of pinning a connection forever; only
`statement_timeout` is disabled there.

## Rollout

No protocol change and no schema change; wire-compatible in both directions.

Ships in the next cell roll, **director first** — the director is the process taking the
contended lock, and a director on the new build against cells on the old one still only
reduces contention. Note that each process now opens one extra `max: 1` connection at
startup, ended before the serving pool opens; the Cloud SQL budget model reads `poolMax`
from `config.ts` and terraform, so it is unchanged, but a fleet-wide simultaneous restart
adds up to one transient connection per process.

Expect `orca_relay_postgres_transaction_exhausted` to fall: per the #471 rollout, the 500 ms
bound raised exhaustions ~30x because waiters that used to succeed slowly now fail fast, and
this PR removes the contention that made them wait. Watch `cellInventoryHoldMsP95` and the
exhausted-retry rate on the director before rolling cells.
