### PR TITLE
fix(relay-ops): a thrown health fetch is not a health reading; auth probe does not require /ready

### DIFF
--- a/cloud/apps/relay-ops/src/resource-inventory.test.ts
+++ b/cloud/apps/relay-ops/src/resource-inventory.test.ts
@@ -23,8 +23,10 @@ describe('readResourceInventory', () => {
         calls += 1
         return new Response(null, { status: 200 })
       },
-      async () => {
-        waits += 1
+      {
+        wait: async () => {
+          waits += 1
+        }
       }
     )
 
@@ -45,8 +47,10 @@ describe('readResourceInventory', () => {
         calls.set(path, call)
         return new Response(null, { status: path === '/ready' && call === 1 ? 503 : 200 })
       },
-      async (ms) => {
-        waits.push(ms)
+      {
+        wait: async (ms) => {
+          waits.push(ms)
+        }
       }
     )
 
@@ -65,15 +69,128 @@ describe('readResourceInventory', () => {
         calls += 1
         return new Response(null, { status: 503 })
       },
-      async (ms) => {
-        waits.push(ms)
+      {
+        wait: async (ms) => {
+          waits.push(ms)
+        }
       }
     )
 
     expect(result.health).toBe(false)
     expect(result.ready).toBe(false)
     expect(calls).toBe(4)
+    // A refusing endpoint is a reading, so only the independent retry runs.
     expect(waits).toEqual([11_000])
+  })
+
+  it('treats a thrown fetch as no reading and re-asks that path once', async () => {
+    const calls: string[] = []
+    const waits: number[] = []
+    const result = await probeEndpointHealth(
+      'https://c9.relay.onorca.dev',
+      async (input) => {
+        const path = new URL(String(input)).pathname
+        calls.push(path)
+        if (path === '/health' && calls.filter((call) => call === '/health').length === 1) {
+          throw new TypeError('fetch failed')
+        }
+        return new Response(null, { status: 200 })
+      },
+      {
+        wait: async (ms) => {
+          waits.push(ms)
+        }
+      }
+    )
+
+    expect(result.health).toBe(true)
+    expect(result.ready).toBe(true)
+    expect(calls.filter((call) => call === '/health')).toEqual(['/health', '/health'])
+    expect(waits).toEqual([1_000])
+  })
+
+  it('fails closed when both attempts of a path throw', async () => {
+    const calls: string[] = []
+    const waits: number[] = []
+    const result = await probeEndpointHealth(
+      'https://c9.relay.onorca.dev',
+      async (input) => {
+        const path = new URL(String(input)).pathname
+        calls.push(path)
+        if (path === '/health') throw new TypeError('fetch failed')
+        return new Response(null, { status: 200 })
+      },
+      {
+        wait: async (ms) => {
+          waits.push(ms)
+        }
+      }
+    )
+
+    expect(result.health).toBe(false)
+    expect(calls.filter((call) => call === '/health')).toHaveLength(4)
+    expect(waits).toEqual([1_000, 11_000, 1_000])
+  })
+
+  it('accepts an auth-shaped endpoint that serves no readiness path', async () => {
+    const calls: string[] = []
+    const waits: number[] = []
+    const result = await probeEndpointHealth(
+      'https://login.onorca.dev',
+      async (input) => {
+        const path = new URL(String(input)).pathname
+        calls.push(path)
+        return new Response(null, { status: path === '/ready' ? 404 : 200 })
+      },
+      {
+        requiresReady: false,
+        wait: async (ms) => {
+          waits.push(ms)
+        }
+      }
+    )
+
+    expect(result.health).toBe(true)
+    expect(result.ready).toBeNull()
+    expect(calls).toEqual(['/health'])
+    expect(waits).toEqual([])
+  })
+
+  it('still requires readiness for the director and cells', async () => {
+    const waits: number[] = []
+    const result = await probeEndpointHealth(
+      'https://relay.onorca.dev',
+      async (input) => new Response(null, {
+        status: new URL(String(input)).pathname === '/ready' ? 503 : 200
+      }),
+      {
+        wait: async (ms) => {
+          waits.push(ms)
+        }
+      }
+    )
+
+    expect(result.health).toBe(true)
+    expect(result.ready).toBe(false)
+    expect(waits).toEqual([11_000])
+  })
+
+  it('measures latency as the answering round trip, not the retry delay', async () => {
+    let healthCalls = 0
+    const result = await probeEndpointHealth(
+      'https://c9.relay.onorca.dev',
+      async (input) => {
+        if (new URL(String(input)).pathname !== '/health') return new Response(null, { status: 200 })
+        healthCalls += 1
+        if (healthCalls === 1) throw new TypeError('fetch failed')
+        return new Response(null, { status: 200 })
+      },
+      { wait: async (ms) => await new Promise((resolve) => setTimeout(resolve, Math.min(ms, 60))) }
+    )
+
+    expect(result.health).toBe(true)
+    expect(result.latencyMs).not.toBeNull()
+    expect(result.latencyMs!).toBeLessThan(60)
   })
 
   it('uses aggregate REST inventory without probing sleeping staging endpoints', async () => {

--- a/cloud/apps/relay-ops/src/resource-inventory.ts
+++ b/cloud/apps/relay-ops/src/resource-inventory.ts
@@ -102,6 +102,7 @@ export type ResourceInventory = {
 
 const unavailableEndpoint = (): EndpointHealth => ({ health: null, ready: null, latencyMs: null })
 const independentEndpointRetryDelayMs = 11_000
+const transientProbeRetryDelayMs = 1_000
 
 function finalSegment(value: string): string {
   return value.split('/').at(-1) ?? value
@@ -138,41 +139,80 @@ async function googleRequest(
   return await response.json()
 }
 
-async function endpointProbe(origin: string, fetchImpl: typeof fetch): Promise<EndpointHealth> {
-  const startedAt = performance.now()
-  const check = async (path: '/health' | '/ready'): Promise<boolean> => {
+// A reading the endpoint actually produced: ok is its answer, latencyMs is that answer's round trip.
+type PathReading = { ok: boolean; latencyMs: number | null }
+
+async function probePath(
+  origin: string,
+  path: '/health' | '/ready',
+  fetchImpl: typeof fetch,
+  wait: (ms: number) => Promise<void>
+): Promise<PathReading> {
+  // null means the request never produced an answer (DNS/TCP/TLS failure or the 8s abort).
+  const attempt = async (): Promise<PathReading | null> => {
+    const startedAt = performance.now()
     try {
       const response = await fetchImpl(`${origin}${path}`, {
         redirect: 'error',
         signal: AbortSignal.timeout(8_000)
       })
-      return response.ok
+      return { ok: response.ok, latencyMs: Math.round(performance.now() - startedAt) }
     } catch {
-      return false
+      return null
     }
   }
-  const [health, ready] = await Promise.all([check('/health'), check('/ready')])
-  return { health, ready, latencyMs: Math.round(performance.now() - startedAt) }
+  const first = await attempt()
+  if (first) return first
+  // A thrown fetch is the absence of a reading, not an unhealthy answer, so re-ask before concluding.
+  await wait(transientProbeRetryDelayMs)
+  return (await attempt()) ?? { ok: false, latencyMs: null }
+}
+
+async function endpointProbe(
+  origin: string,
+  fetchImpl: typeof fetch,
+  requiresReady: boolean,
+  wait: (ms: number) => Promise<void>
+): Promise<EndpointHealth> {
+  const [health, ready] = await Promise.all([
+    probePath(origin, '/health', fetchImpl, wait),
+    requiresReady ? probePath(origin, '/ready', fetchImpl, wait) : null
+  ])
+  // Latency is the slowest answering round trip in this probe; retry delays are not serving latency.
+  const latencies = [health.latencyMs, ready?.latencyMs ?? null].filter(
+    (value): value is number => value !== null
+  )
+  return {
+    health: health.ok,
+    ready: ready ? ready.ok : null,
+    latencyMs: latencies.length > 0 ? Math.max(...latencies) : null
+  }
+}
+
+export type EndpointProbeOptions = {
+  // Auth serves no /ready by design, so it is judged on /health and latency alone.
+  requiresReady?: boolean
+  wait?: (ms: number) => Promise<void>
 }
 
 export async function probeEndpointHealth(
   origin: string,
   fetchImpl: typeof fetch,
-  wait: (ms: number) => Promise<void> = async (ms) =>
-    await new Promise((resolvePromise) => setTimeout(resolvePromise, ms))
+  options: EndpointProbeOptions = {}
 ): Promise<EndpointHealth> {
-  const first = await endpointProbe(origin, fetchImpl)
-  if (
-    first.health &&
-    first.ready &&
-    first.latencyMs !== null &&
-    first.latencyMs <= INCIDENT_MONITOR_THRESHOLDS.endpointLatencyMs
-  ) {
-    return first
-  }
+  const requiresReady = options.requiresReady ?? true
+  const wait = options.wait ??
+    (async (ms: number) => await new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
+  const accepted = (probe: EndpointHealth): boolean =>
+    probe.health === true &&
+    (!requiresReady || probe.ready === true) &&
+    probe.latencyMs !== null &&
+    probe.latencyMs <= INCIDENT_MONITOR_THRESHOLDS.endpointLatencyMs
+  const first = await endpointProbe(origin, fetchImpl, requiresReady, wait)
+  if (accepted(first)) return first
   // Outwait Relay's ten-second readiness cache before treating the retry as independent.
   await wait(independentEndpointRetryDelayMs)
-  return await endpointProbe(origin, fetchImpl)
+  return await endpointProbe(origin, fetchImpl, requiresReady, wait)
 }
 
 function imageDigest(template: z.infer<typeof TemplateSchema>): string | null {
@@ -338,7 +378,8 @@ export async function readResourceInventory(
     ? [unavailableEndpoint(), unavailableEndpoint()]
     : await Promise.all([
         probeEndpointHealth(environment.directorOrigin, fetchImpl),
-        probeEndpointHealth(environment.authOrigin, fetchImpl)
+        // The auth service exposes no /ready, so requiring it would fail every first probe.
+        probeEndpointHealth(environment.authOrigin, fetchImpl, { requiresReady: false })
       ])
   const cells = await Promise.all(environment.cells.map((cell, index) =>
     readCell(environment, cell, migValues[index] ?? null, token, fetchImpl)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |

<!-- /orca-pr-loc -->

## What froze

Two consecutive read-only dry-runs of `cloud-monitor-relay-production` froze on infrastructure noise rather than fleet health:

- **Run 33922255205** — `signal_missing cloud_sql.backends`. Cloud Monitoring published no `num_backends` point for a 6-minute window (every other minute had one). Google-side gap; **not addressed here**, `signal_missing` semantics for Cloud Monitoring are deliberately unchanged.
- **Run 33922844671** — `threshold_equal auth.health observed 0`, while the auth service answered `/health` 200 continuously. This PR fixes that one.

Why the auth probe reported 0 for a healthy service, in two compounding steps:

1. `probeEndpointHealth` accepted the first probe only if `first.ready` was true. The auth service exposes no `/ready` (404 by design), so **every** auth sample fell through to the 11s independent retry and was decided by that retry alone.
2. In `endpointProbe`, `check()` wrapped `fetch` in `try { … } catch { return false }`. On the third sample the retry fetch failed at the network layer on the GitHub runner — the Cloud Run request log shows the 21:52:05 probe pair and **nothing** at ~21:52:16, so no request reached the service. That thrown fetch was recorded as `health: false` and froze the gate.

## Before / after

| | before | after |
|---|---|---|
| fetch throws (DNS/TCP/TLS/abort) | recorded as `false` — a health reading the endpoint never gave | recorded as *no reading*; that single path is re-asked once after 1s. Only a second throw yields `false` |
| HTTP response not ok (503/404/500) | `false` | `false`, unchanged, and **no** extra retry — a refusal is a reading |
| auth first probe | can never be accepted (`/ready` 404), always decided by the 11s retry | judged on `/health` + latency; `/ready` is not probed for auth, `authEndpoint.ready` is `null` |
| director / cells | `/health` + `/ready` + latency required | unchanged — `requiresReady` defaults to true |
| `latencyMs` | wall time of the whole probe | slowest *answering* round trip in the probe; retry sleeps are excluded, so the 1s and 11s delays are never reported as serving latency |

`requiresReady` is threaded per endpoint at the call site (director and cells `true`, auth `false`) rather than special-cased by hostname.

## Why this does not weaken the gate

- No threshold, no `cloudDataMaxAgeMs`, no `signal_missing` rule, and no freeze-on-any-threshold behaviour changed. `NUMERIC_RULES` is untouched.
- Every genuinely bad answer still freezes: a non-ok response is `false` on the first reading with no extra attempt, and two consecutive throws are `false`.
- If a path never answers at all, `latencyMs` is `null`, the `*.latency_ms` signal is omitted, and the monitor freezes on `signal_missing` — it fails closed, it does not skip.
- The retry added is *within a single path* and only on the absence of an answer; the independent 11s re-probe that outwaits Relay's readiness cache is still there and still gates acceptance.
- `auth.ready` was already consumed by nothing: `NUMERIC_RULES` has no `auth.ready` rule, `public/app.js` renders the auth row from `resources.auth.ready` (the Cloud Run condition) and `authEndpoint.health` only, and `incident-monitor.test.ts` already asserts a sample with no `auth.ready` evaluates green ("allows missing auth readiness"). Dropping it removes a permanently-`false` signal and one guaranteed-404 request per probe. Cells keep `unavailableIsZero`, so cell readiness is unaffected.

## Tests

`resource-inventory.test.ts`, all with injected `wait`/`fetchImpl`, no real network:

- thrown then ok → `health: true`, exactly one 1s wait, that path called twice
- thrown twice → `health: false`, waits `[1s, 11s, 1s]`
- non-ok (503) → `false`, no 1s wait, only the 11s independent retry
- auth-shaped endpoint (`requiresReady: false`, `/ready` would 404) → accepted on the first probe, `ready: null`, `/health` the only request, zero waits
- director/cell shape → `/ready` 503 still forces the 11s retry and `ready: false`
- latency of a probe whose first attempt threw stays below the injected retry delay

Gates: `pnpm --filter ./apps/relay-ops test` (81 passed), `pnpm --filter ./apps/relay-ops typecheck`, `node --test cloud/dev/scripts/relay-monitor-evidence.test.mjs` (9 passed, `schemaVersion` untouched), and the repo-root changed-code quality gate (which ignores `cloud/` by design).