### PR TITLE
fix: show agent commands once without startup polling

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -127,10 +127,6 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\033]133;A\007"
-  # Why: emit the shell-ready marker here (not a trailing PROMPT_COMMAND entry)
-  # so a framework that must be last in PROMPT_COMMAND — bash-preexec — is not
-  # displaced by one of Orca's own hooks.
-  [[ -n "$__orca_ready_marker" ]] && printf "\033]777;orca-shell-ready\007"
   return "$exit_code"
 }
 __orca_osc133_preexec() {
@@ -188,6 +184,11 @@ __orca_osc133_epilogue() {
   unset __orca_in_prompt_command
   __orca_adopt_outer_debug_trap
   trap '__orca_osc133_preexec' DEBUG
+  # Readline renders PS1 after entering raw mode; prompt hooks still run in cooked mode.
+  if [[ -n "$__orca_ready_marker" ]]; then
+    PS1="${PS1-}"'\[\e]777;orca-shell-ready\a\]'
+    __orca_ready_marker=""
+  fi
 }
 __orca_normalize_prompt_command_part() {
   local __orca_value="$1" __orca_output_name="$2" __orca_character __orca_chunk

--- a/src/main/daemon/agent-startup-prompt-latency.node-pty.test.ts
+++ b/src/main/daemon/agent-startup-prompt-latency.node-pty.test.ts
@@ -1,0 +1,123 @@
+import { appendFileSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createPtySubprocess } from './pty-subprocess'
+import { Session } from './session'
+
+const SHELLS = process.platform === 'win32' ? [] : ['/bin/bash', '/bin/zsh'].filter(existsSync)
+const COMMAND = "printf 'AGENT_%s\\n' STARTED"
+
+async function launch(
+  shell: string,
+  slow: boolean,
+  legacy = false
+): Promise<{ output: string; ms: number }> {
+  const root = mkdtempSync(join(tmpdir(), 'orca-startup-latency-'))
+  const bash = shell.endsWith('bash')
+  const pause = slow ? 'sleep 0.6\n' : ''
+  const prompt = slow ? "PS1='$(sleep 0.3)prompt> '\n" : "PS1='prompt> '\n"
+  writeFileSync(
+    join(root, bash ? '.bash_profile' : '.zshrc'),
+    `${pause}${bash ? '' : 'setopt PROMPT_SUBST\n'}${prompt}`
+  )
+  vi.stubEnv('HOME', root)
+  vi.stubEnv('ZDOTDIR', root)
+  vi.stubEnv('ORCA_ORIG_ZDOTDIR', root)
+  let session: Session | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let legacyTimer: ReturnType<typeof setTimeout> | undefined
+  const readinessEvents: string[] = []
+  const started = performance.now()
+  try {
+    const subprocess = await createPtySubprocess({
+      sessionId: 'startup-latency',
+      cols: 120,
+      rows: 30,
+      cwd: root,
+      shellOverride: shell,
+      command: COMMAND,
+      env: { HOME: root, SHELL: shell, TERM: 'xterm-256color' }
+    })
+    session = new Session({
+      sessionId: 'startup-latency',
+      cols: 120,
+      rows: 30,
+      subprocess,
+      shellReadySupported: !legacy,
+      reportReadinessEvent: (event) => readinessEvents.push(event)
+    })
+    const active = session
+    return await new Promise((resolve, reject) => {
+      let output = ''
+      timer = setTimeout(
+        () => reject(new Error(`Startup timed out: ${JSON.stringify(output)}`)),
+        5000
+      )
+      active.attachClient({
+        onExit: () => {},
+        onData: (data) => {
+          output += data
+          if (output.includes('AGENT_STARTED')) {
+            resolve({ output, ms: performance.now() - started })
+          }
+        }
+      })
+      if (legacy) {
+        legacyTimer = setTimeout(() => active.write(`${COMMAND}\n`), 300)
+      } else {
+        active.write(`${COMMAND}\n`)
+      }
+    })
+  } finally {
+    clearTimeout(timer)
+    clearTimeout(legacyTimer)
+    if (session) {
+      await session.forceKillAndWaitForExit(3000)
+      session.dispose()
+    }
+    vi.unstubAllEnvs()
+    rmSync(root, { recursive: true, force: true })
+    expect(readinessEvents).toEqual([])
+  }
+}
+
+describe('agent startup at the rendered shell prompt', () => {
+  afterEach(() => vi.unstubAllEnvs())
+  it.each(SHELLS)(
+    '%s displays the command once after slow startup and prompt expansion',
+    async (shell) => {
+      const before = await launch(shell, true, true)
+      expect(before.output.split(COMMAND)).toHaveLength(3)
+      const result = await launch(shell, true)
+      expect(result.output).not.toContain('orca-shell-ready')
+      expect(result.output.split(COMMAND)).toHaveLength(2)
+      expect(result.output.indexOf('prompt> ')).toBeLessThan(result.output.indexOf(COMMAND))
+    }
+  )
+
+  it.skipIf(!process.env.ORCA_STARTUP_BENCH || SHELLS.length === 0)(
+    'compares legacy input timing with prompt delivery',
+    async () => {
+      for (const shell of SHELLS) {
+        for (const slow of [false, true]) {
+          const legacy: number[] = []
+          const current: number[] = []
+          for (let i = 0; i < 5; i++) {
+            legacy.push((await launch(shell, slow, true)).ms)
+            const result = await launch(shell, slow)
+            expect(result.output).not.toContain('orca-shell-ready')
+            expect(result.output.split(COMMAND)).toHaveLength(2)
+            current.push(result.ms)
+          }
+          const result = JSON.stringify({ shell, slow, legacy, current })
+          if (process.env.ORCA_STARTUP_BENCH_OUTPUT) {
+            appendFileSync(process.env.ORCA_STARTUP_BENCH_OUTPUT, `${result}\n`)
+          }
+          console.log(result)
+        }
+      }
+    },
+    60_000
+  )
+})

--- a/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
+++ b/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
@@ -2,7 +2,6 @@ import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
 import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-composition'
 import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
-import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
 
 export function getDaemonBashShellReadyRcfileContent(): string {
   return `# Orca daemon bash shell-ready wrapper
@@ -56,10 +55,6 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
-  # Why: emit the shell-ready marker here (not a trailing PROMPT_COMMAND entry)
-  # so a framework that must be last in PROMPT_COMMAND — bash-preexec — is not
-  # displaced by one of Orca's own hooks.
-  [[ -n "$__orca_ready_marker" ]] && printf "${SHELL_READY_MARKER}"
   return "$exit_code"
 }
 __orca_osc133_preexec() {
@@ -117,6 +112,11 @@ __orca_osc133_epilogue() {
   unset __orca_in_prompt_command
   __orca_adopt_outer_debug_trap
   trap '__orca_osc133_preexec' DEBUG
+  # Readline renders PS1 after entering raw mode; prompt hooks still run in cooked mode.
+  if [[ -n "$__orca_ready_marker" ]]; then
+    PS1="\${PS1-}"'\\[\\e]777;orca-shell-ready\\a\\]'
+    __orca_ready_marker=""
+  fi
 }
 ${BASH_PROMPT_COMMAND_COMPOSITION_BLOCK}
 __orca_prepend_prompt_command "__orca_osc133_precmd"

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -344,6 +344,15 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
+    itOnPosix('preserves the existing fast-start timing for fish', async () => {
+      await adapter.spawn({ cols: 80, rows: 24, command: 'codex', env: { SHELL: '/usr/bin/fish' } })
+      await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
+      expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith('codex\n')
+      expect(lastSpawnOpts).not.toEqual(
+        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
+      )
+    })
+
     itOnPosix.each([
       { command: 'codex' },
       { command: 'codex', startupCommandDelivery: 'fast' as const },

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -344,35 +344,23 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       }
     })
 
-    itOnPosix('keeps plain Codex startup on the short daemon shell-ready timeout', async () => {
-      await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        command: 'codex',
-        env: { SHELL: '/bin/zsh' }
-      })
-
-      await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
-      expect(lastSubprocess.write).toHaveBeenCalledWith('codex\n')
-    })
-
-    itOnPosix('waits for shell-ready for delivery-hinted Codex startup', async () => {
-      await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        command: "codex 'linked issue context'",
-        startupCommandDelivery: 'shell-ready',
-        env: { SHELL: '/bin/zsh' }
-      })
+    itOnPosix.each([
+      { command: 'codex' },
+      { command: 'codex', startupCommandDelivery: 'fast' as const },
+      { command: "codex 'linked issue context'", startupCommandDelivery: 'shell-ready' as const }
+    ])('waits past 300ms and submits once after readiness: %j', async (startup) => {
+      await adapter.spawn({ cols: 80, rows: 24, ...startup, env: { SHELL: '/bin/zsh' } })
 
       await new Promise((resolve) => setTimeout(resolve, 350))
       expect(lastSubprocess.write).not.toHaveBeenCalled()
-
+      expect(lastSpawnOpts).toEqual(
+        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
+      )
       lastSubprocess._simulateData('\x1b]777;orca-shell-ready\x07')
       lastSubprocess._simulateData('\r\nuser@host $ ')
 
       await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
-      expect(lastSubprocess.write).toHaveBeenCalledWith("codex 'linked issue context'\n")
+      expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith(`${startup.command}\n`)
     })
   })
 

--- a/src/main/daemon/daemon-pty-session-spawn.ts
+++ b/src/main/daemon/daemon-pty-session-spawn.ts
@@ -1,5 +1,3 @@
-import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
-import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
 import type {
   HistoryRecoveryContext,
   PendingDaemonSpawnOperation
@@ -11,7 +9,6 @@ import { DaemonPtySpawnResult } from './daemon-pty-spawn-result'
 import type { DaemonPtySpawnContext } from './daemon-pty-spawn-request'
 import type { ColdRestoreInfo } from './history-reader'
 import { mintPtySessionId } from './pty-session-id'
-import { CODEX_SHELL_READY_TIMEOUT_MS } from './session-shell-ready-barrier'
 import { supportsPtyStartupBarrier } from './shell-ready'
 import { getRecoveredHistorySeedSegments } from './terminal-history-seed-segments'
 import { AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION, type CreateOrAttachResult } from './types'
@@ -213,21 +210,9 @@ export abstract class DaemonPtySessionSpawn extends DaemonPtySpawnResult {
     let effectiveRows = restoreInfo?.rows ?? opts.rows
 
     const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
-    const isCodexStartupCommand =
-      recognizeAgentProcessFromCommandLine(opts.command)?.agent === 'codex'
-    const shouldWaitForShellReady =
-      isCodexStartupCommand &&
-      shouldUseShellReadyStartupDelivery({
-        command: opts.command,
-        startupCommandDelivery: opts.startupCommandDelivery
-      })
-    const shellReadyTimeoutMs =
-      shellReadySupported && isCodexStartupCommand && !shouldWaitForShellReady
-        ? CODEX_SHELL_READY_TIMEOUT_MS
-        : undefined
-
     const context: DaemonPtySpawnContext = {
-      opts,
+      // Older daemons also need the existing hint to enable their ready marker.
+      opts: opts.command ? { ...opts, startupCommandDelivery: 'shell-ready' } : opts,
       operation,
       historyRecovery,
       requestedSessionId,
@@ -241,7 +226,6 @@ export abstract class DaemonPtySessionSpawn extends DaemonPtySpawnResult {
       effectiveCols,
       effectiveRows,
       shellReadySupported,
-      shellReadyTimeoutMs,
       historySeedSegments: restoreInfo ? getRecoveredHistorySeedSegments(restoreInfo) : null,
       detectColdRestore
     }

--- a/src/main/daemon/daemon-pty-session-spawn.ts
+++ b/src/main/daemon/daemon-pty-session-spawn.ts
@@ -1,3 +1,6 @@
+import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import { shouldUseShellReadyStartupDelivery } from '../../shared/codex-startup-delivery'
+import { CODEX_SHELL_READY_TIMEOUT_MS } from './session-shell-ready-barrier'
 import type {
   HistoryRecoveryContext,
   PendingDaemonSpawnOperation
@@ -9,7 +12,11 @@ import { DaemonPtySpawnResult } from './daemon-pty-spawn-result'
 import type { DaemonPtySpawnContext } from './daemon-pty-spawn-request'
 import type { ColdRestoreInfo } from './history-reader'
 import { mintPtySessionId } from './pty-session-id'
-import { supportsPtyStartupBarrier } from './shell-ready'
+import {
+  supportsPtyStartupBarrier,
+  shellReadyMarkerComesFromLineEditor,
+  resolvePtyShellPath
+} from './shell-ready'
 import { getRecoveredHistorySeedSegments } from './terminal-history-seed-segments'
 import { AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION, type CreateOrAttachResult } from './types'
 import { normalizeWslColdRestoreCwd } from './wsl-cold-restore-cwd'
@@ -210,9 +217,23 @@ export abstract class DaemonPtySessionSpawn extends DaemonPtySpawnResult {
     let effectiveRows = restoreInfo?.rows ?? opts.rows
 
     const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
+    const immediateMarker =
+      process.platform !== 'win32' &&
+      shellReadyMarkerComesFromLineEditor(opts.shellOverride || resolvePtyShellPath(opts.env ?? {}))
+    const shellReadyTimeoutMs =
+      shellReadySupported &&
+      !immediateMarker &&
+      recognizeAgentProcessFromCommandLine(opts.command)?.agent === 'codex' &&
+      !shouldUseShellReadyStartupDelivery({
+        command: opts.command,
+        startupCommandDelivery: opts.startupCommandDelivery
+      })
+        ? CODEX_SHELL_READY_TIMEOUT_MS
+        : undefined
     const context: DaemonPtySpawnContext = {
       // Older daemons also need the existing hint to enable their ready marker.
-      opts: opts.command ? { ...opts, startupCommandDelivery: 'shell-ready' } : opts,
+      opts:
+        opts.command && immediateMarker ? { ...opts, startupCommandDelivery: 'shell-ready' } : opts,
       operation,
       historyRecovery,
       requestedSessionId,
@@ -226,6 +247,7 @@ export abstract class DaemonPtySessionSpawn extends DaemonPtySpawnResult {
       effectiveCols,
       effectiveRows,
       shellReadySupported,
+      shellReadyTimeoutMs,
       historySeedSegments: restoreInfo ? getRecoveredHistorySeedSegments(restoreInfo) : null,
       detectColdRestore
     }

--- a/src/main/daemon/daemon-pty-spawn-request.ts
+++ b/src/main/daemon/daemon-pty-spawn-request.ts
@@ -33,7 +33,6 @@ export type DaemonPtySpawnContext = {
   effectiveCols: number
   effectiveRows: number
   shellReadySupported: boolean
-  shellReadyTimeoutMs: number | undefined
   historySeedSegments: readonly string[] | null
   detectColdRestore(options?: { ignoreCleanEnd?: boolean }): Promise<ColdRestoreInfo | null>
 }
@@ -123,9 +122,6 @@ export abstract class DaemonPtySpawnRequest extends DaemonPtyRuntimeState {
           ? undefined
           : opts.terminalWindowsPowerShellImplementation,
         shellReadySupported: context.attachOnly ? false : context.shellReadySupported,
-        ...(!context.attachOnly && context.shellReadyTimeoutMs !== undefined
-          ? { shellReadyTimeoutMs: context.shellReadyTimeoutMs }
-          : {}),
         ...(historySeed ? { historySeed } : {}),
         ...(historySeedTransferId ? { historySeedTransferId } : {}),
         ...(this.supportsStartupIngress && !context.attachOnly && opts.startupIngress

--- a/src/main/daemon/daemon-pty-spawn-request.ts
+++ b/src/main/daemon/daemon-pty-spawn-request.ts
@@ -33,6 +33,7 @@ export type DaemonPtySpawnContext = {
   effectiveCols: number
   effectiveRows: number
   shellReadySupported: boolean
+  shellReadyTimeoutMs: number | undefined
   historySeedSegments: readonly string[] | null
   detectColdRestore(options?: { ignoreCleanEnd?: boolean }): Promise<ColdRestoreInfo | null>
 }
@@ -122,6 +123,9 @@ export abstract class DaemonPtySpawnRequest extends DaemonPtyRuntimeState {
           ? undefined
           : opts.terminalWindowsPowerShellImplementation,
         shellReadySupported: context.attachOnly ? false : context.shellReadySupported,
+        ...(!context.attachOnly && context.shellReadyTimeoutMs !== undefined
+          ? { shellReadyTimeoutMs: context.shellReadyTimeoutMs }
+          : {}),
         ...(historySeed ? { historySeed } : {}),
         ...(historySeedTransferId ? { historySeedTransferId } : {}),
         ...(this.supportsStartupIngress && !context.attachOnly && opts.startupIngress

--- a/src/main/daemon/post-ready-flush-gate.test.ts
+++ b/src/main/daemon/post-ready-flush-gate.test.ts
@@ -20,50 +20,12 @@ describe('PostReadyFlushGate', () => {
     vi.useRealTimers()
   })
 
-  it('waits while a slow prompt still has cooked echo enabled', async () => {
-    const probe = vi.fn().mockResolvedValue('other')
-    gate = new PostReadyFlushGate(onFlush, probe)
-    gate.arm(true)
-    await vi.advanceTimersByTimeAsync(1000)
-    expect(onFlush).not.toHaveBeenCalled()
-    expect(gate.isPending).toBe(true)
-    probe.mockResolvedValue('line-editor')
-    await vi.advanceTimersByTimeAsync(250)
-    expect(onFlush).toHaveBeenCalledTimes(1)
-    expect(gate.isPending).toBe(false)
-  })
-
-  it('drops an in-flight probe result after teardown', async () => {
-    let resolveProbe!: (state: 'line-editor') => void
-    gate = new PostReadyFlushGate(
-      onFlush,
-      () =>
-        new Promise((resolve) => {
-          resolveProbe = resolve
-        })
-    )
-    gate.arm(true)
-    await vi.advanceTimersByTimeAsync(POST_READY_FLUSH_DELAY_MS)
-    gate.clear()
-    resolveProbe('line-editor')
-    await vi.advanceTimersByTimeAsync(1000)
-    expect(onFlush).not.toHaveBeenCalled()
-    expect(gate.isPending).toBe(false)
-  })
-
-  it.each(['unknown', 'unavailable'])('retains the fallback when probing is %s', async (state) => {
-    gate = new PostReadyFlushGate(onFlush, vi.fn().mockResolvedValue(state))
+  it('flushes synchronously when the marker comes from the line editor', () => {
+    gate = new PostReadyFlushGate(onFlush, true)
     gate.arm()
-    await vi.advanceTimersByTimeAsync(POST_READY_FLUSH_FALLBACK_MS)
-    expect(onFlush).toHaveBeenCalledTimes(1)
-  })
-
-  it('bounds waiting when a shell never enters its line editor', async () => {
-    gate = new PostReadyFlushGate(onFlush, vi.fn().mockResolvedValue('other'))
-    gate.arm(true)
-    await vi.advanceTimersByTimeAsync(15_500)
     expect(onFlush).toHaveBeenCalledTimes(1)
     expect(gate.isPending).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
   })
 
   it('does not flush immediately when armed', () => {

--- a/src/main/daemon/post-ready-flush-gate.test.ts
+++ b/src/main/daemon/post-ready-flush-gate.test.ts
@@ -20,6 +20,52 @@ describe('PostReadyFlushGate', () => {
     vi.useRealTimers()
   })
 
+  it('waits while a slow prompt still has cooked echo enabled', async () => {
+    const probe = vi.fn().mockResolvedValue('other')
+    gate = new PostReadyFlushGate(onFlush, probe)
+    gate.arm(true)
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(onFlush).not.toHaveBeenCalled()
+    expect(gate.isPending).toBe(true)
+    probe.mockResolvedValue('line-editor')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(gate.isPending).toBe(false)
+  })
+
+  it('drops an in-flight probe result after teardown', async () => {
+    let resolveProbe!: (state: 'line-editor') => void
+    gate = new PostReadyFlushGate(
+      onFlush,
+      () =>
+        new Promise((resolve) => {
+          resolveProbe = resolve
+        })
+    )
+    gate.arm(true)
+    await vi.advanceTimersByTimeAsync(POST_READY_FLUSH_DELAY_MS)
+    gate.clear()
+    resolveProbe('line-editor')
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(onFlush).not.toHaveBeenCalled()
+    expect(gate.isPending).toBe(false)
+  })
+
+  it.each(['unknown', 'unavailable'])('retains the fallback when probing is %s', async (state) => {
+    gate = new PostReadyFlushGate(onFlush, vi.fn().mockResolvedValue(state))
+    gate.arm()
+    await vi.advanceTimersByTimeAsync(POST_READY_FLUSH_FALLBACK_MS)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds waiting when a shell never enters its line editor', async () => {
+    gate = new PostReadyFlushGate(onFlush, vi.fn().mockResolvedValue('other'))
+    gate.arm(true)
+    await vi.advanceTimersByTimeAsync(15_500)
+    expect(onFlush).toHaveBeenCalledTimes(1)
+    expect(gate.isPending).toBe(false)
+  })
+
   it('does not flush immediately when armed', () => {
     gate.arm()
     expect(onFlush).not.toHaveBeenCalled()

--- a/src/main/daemon/post-ready-flush-gate.ts
+++ b/src/main/daemon/post-ready-flush-gate.ts
@@ -1,22 +1,4 @@
-/**
- * Defers a flush callback until after the shell has drawn its prompt and
- * switched the PTY into raw mode.
- *
- * Why: the OSC 777 shell-ready marker fires from zsh's precmd_functions /
- * bash's PROMPT_COMMAND — before the shell draws its prompt and before
- * zle/readline flips the PTY into raw mode. Flushing queued input then lets
- * the kernel (ECHO still on) echo the command once, and the line editor
- * redraws it under the prompt — producing a visible duplicate (e.g. "claude"
- * appears twice on agent launch).
- *
- * Strategy: after arm() is called, wait for prompt bytes plus a short delay
- * for the tcsetattr() that enables raw mode. If the marker-completing scan
- * already saw post-marker bytes, use that same short path immediately.
- * A conservative wall-clock fallback covers ambiguous marker-only cases.
- *
- * Mirrors the gate in local-pty-shell-ready.ts::writeStartupCommandWhenShellReady,
- * which solves the same race on the non-daemon path.
- */
+import type { PtySlaveLineEditorProbe } from '../../shared/pty-slave-line-discipline-echo'
 
 export const POST_READY_FLUSH_DELAY_MS = 30
 export const POST_READY_FLUSH_FALLBACK_MS = 200
@@ -26,18 +8,58 @@ export class PostReadyFlushGate {
   private postDataTimer: ReturnType<typeof setTimeout> | null = null
   private fallbackTimer: ReturnType<typeof setTimeout> | null = null
 
-  constructor(private readonly onFlush: () => void) {}
+  private generation = 0
+  private probePending = false
+  private probeDeadline = 0
+
+  constructor(
+    private readonly onFlush: () => void,
+    private readonly lineEditorProbe?: PtySlaveLineEditorProbe
+  ) {}
+
+  private async flushWhenLineEditorReady(): Promise<void> {
+    const generation = this.generation
+    this.probePending = true
+    const state = await this.lineEditorProbe?.().catch(() => 'unknown')
+    if (generation !== this.generation) {
+      return
+    }
+    this.probePending = false
+    // Slow prompt hooks can leave cooked echo enabled long after the ready marker.
+    if (state === 'other' && Date.now() < this.probeDeadline) {
+      this.postDataTimer = setTimeout(() => {
+        this.postDataTimer = null
+        void this.flushWhenLineEditorReady()
+      }, 250)
+      return
+    }
+    this.onFlush()
+  }
+
+  private flush(): void {
+    if (this.lineEditorProbe) {
+      void this.flushWhenLineEditorReady()
+    } else {
+      this.onFlush()
+    }
+  }
 
   /** True between arm() and the actual flush firing. Callers should treat
    *  input as still-queued during this window to preserve ordering. */
   get isPending(): boolean {
-    return this.awaitingPromptDraw || this.postDataTimer !== null || this.fallbackTimer !== null
+    return (
+      this.probePending ||
+      this.awaitingPromptDraw ||
+      this.postDataTimer !== null ||
+      this.fallbackTimer !== null
+    )
   }
 
   /** Arm the gate after observing the shell-ready marker. Starts the
    *  wall-clock fallback unless the marker scan already observed post-marker
    *  bytes, in which case the short post-data settle path is enough. */
   arm(postMarkerBytesObserved = false): void {
+    this.probeDeadline = Date.now() + 15_000
     this.awaitingPromptDraw = true
     if (postMarkerBytesObserved) {
       this.notifyData()
@@ -46,7 +68,7 @@ export class PostReadyFlushGate {
     this.fallbackTimer = setTimeout(() => {
       this.fallbackTimer = null
       this.awaitingPromptDraw = false
-      this.onFlush()
+      this.flush()
     }, POST_READY_FLUSH_FALLBACK_MS)
   }
 
@@ -65,13 +87,15 @@ export class PostReadyFlushGate {
     if (this.postDataTimer === null) {
       this.postDataTimer = setTimeout(() => {
         this.postDataTimer = null
-        this.onFlush()
+        this.flush()
       }, POST_READY_FLUSH_DELAY_MS)
     }
   }
 
   /** Cancel any pending flush. Call on session teardown. */
   clear(): void {
+    this.generation += 1
+    this.probePending = false
     this.awaitingPromptDraw = false
     if (this.postDataTimer) {
       clearTimeout(this.postDataTimer)

--- a/src/main/daemon/post-ready-flush-gate.ts
+++ b/src/main/daemon/post-ready-flush-gate.ts
@@ -1,5 +1,5 @@
-import type { PtySlaveLineEditorProbe } from '../../shared/pty-slave-line-discipline-echo'
-
+// Bash's prompt and zsh's line-init marker are ready for input immediately.
+// Other shells retain the existing settling delay.
 export const POST_READY_FLUSH_DELAY_MS = 30
 export const POST_READY_FLUSH_FALLBACK_MS = 200
 
@@ -8,58 +8,25 @@ export class PostReadyFlushGate {
   private postDataTimer: ReturnType<typeof setTimeout> | null = null
   private fallbackTimer: ReturnType<typeof setTimeout> | null = null
 
-  private generation = 0
-  private probePending = false
-  private probeDeadline = 0
-
   constructor(
     private readonly onFlush: () => void,
-    private readonly lineEditorProbe?: PtySlaveLineEditorProbe
+    private readonly markerIsLineEditorReady = false
   ) {}
-
-  private async flushWhenLineEditorReady(): Promise<void> {
-    const generation = this.generation
-    this.probePending = true
-    const state = await this.lineEditorProbe?.().catch(() => 'unknown')
-    if (generation !== this.generation) {
-      return
-    }
-    this.probePending = false
-    // Slow prompt hooks can leave cooked echo enabled long after the ready marker.
-    if (state === 'other' && Date.now() < this.probeDeadline) {
-      this.postDataTimer = setTimeout(() => {
-        this.postDataTimer = null
-        void this.flushWhenLineEditorReady()
-      }, 250)
-      return
-    }
-    this.onFlush()
-  }
-
-  private flush(): void {
-    if (this.lineEditorProbe) {
-      void this.flushWhenLineEditorReady()
-    } else {
-      this.onFlush()
-    }
-  }
 
   /** True between arm() and the actual flush firing. Callers should treat
    *  input as still-queued during this window to preserve ordering. */
   get isPending(): boolean {
-    return (
-      this.probePending ||
-      this.awaitingPromptDraw ||
-      this.postDataTimer !== null ||
-      this.fallbackTimer !== null
-    )
+    return this.awaitingPromptDraw || this.postDataTimer !== null || this.fallbackTimer !== null
   }
 
   /** Arm the gate after observing the shell-ready marker. Starts the
    *  wall-clock fallback unless the marker scan already observed post-marker
    *  bytes, in which case the short post-data settle path is enough. */
   arm(postMarkerBytesObserved = false): void {
-    this.probeDeadline = Date.now() + 15_000
+    if (this.markerIsLineEditorReady) {
+      this.onFlush()
+      return
+    }
     this.awaitingPromptDraw = true
     if (postMarkerBytesObserved) {
       this.notifyData()
@@ -68,7 +35,7 @@ export class PostReadyFlushGate {
     this.fallbackTimer = setTimeout(() => {
       this.fallbackTimer = null
       this.awaitingPromptDraw = false
-      this.flush()
+      this.onFlush()
     }, POST_READY_FLUSH_FALLBACK_MS)
   }
 
@@ -87,15 +54,13 @@ export class PostReadyFlushGate {
     if (this.postDataTimer === null) {
       this.postDataTimer = setTimeout(() => {
         this.postDataTimer = null
-        this.flush()
+        this.onFlush()
       }, POST_READY_FLUSH_DELAY_MS)
     }
   }
 
   /** Cancel any pending flush. Call on session teardown. */
   clear(): void {
-    this.generation += 1
-    this.probePending = false
     this.awaitingPromptDraw = false
     if (this.postDataTimer) {
       clearTimeout(this.postDataTimer)

--- a/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
+++ b/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
@@ -261,7 +261,7 @@ describe('createPtySubprocess', () => {
     expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
   })
 
-  it('keeps plain Codex startup commands on the no-marker wrapper', async () => {
+  it('enables readiness and shell identity for plain Codex startup', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)
     const platform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -285,7 +285,8 @@ describe('createPtySubprocess', () => {
     const lastCall = spawnMock.mock.calls.at(-1)!
     expect(lastCall[1]).toEqual(['-l'])
     expect(lastCall[2].env.ZDOTDIR).toMatch(ZSH_SHELL_READY_DIR)
-    expect(lastCall[2].env.ORCA_SHELL_FEATURES).not.toContain('ready')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).toContain('ready')
+    expect(lastCall[2].env.ORCA_SHELL_FEATURES).toContain('identity')
   })
 
   it('uses shell-ready wrapper for delivery-hinted Codex startup commands', async () => {

--- a/src/main/daemon/pty-subprocess/shell-launch-plan.ts
+++ b/src/main/daemon/pty-subprocess/shell-launch-plan.ts
@@ -1,3 +1,4 @@
+import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
 import { win32 as pathWin32 } from 'node:path'
 import { isWindowsGitBashShellPath, resolveWindowsGitBashShellPath } from '../../git-bash'
 import { isPwshAvailable } from '../../pwsh'
@@ -34,7 +35,11 @@ import {
 } from '../../../shared/agent-process-recognition'
 import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../../shared/hermes-startup-query'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../shared/windows-terminal-shell'
-import { getShellLaunchConfig, resolvePtyShellPath } from '../shell-ready'
+import {
+  getShellLaunchConfig,
+  resolvePtyShellPath,
+  shellReadyMarkerComesFromLineEditor
+} from '../shell-ready'
 import { resolveWslSessionContext } from '../wsl-session-context'
 import { finalizeDaemonPtyEnvironment, rescrubDaemonPtyEnvironment } from './spawn-environment'
 import type { PtySubprocessOptions } from '../pty-subprocess'
@@ -188,8 +193,14 @@ export function createPtyShellLaunchPlan(
         `[daemon/pty] Preferred shell "${preferredShellPath}" is unavailable, fell back to "${shellPath}"`
       )
     }
-    // PTY input must wait for the line editor, including plain Codex launches.
-    const waitsForShellReady = Boolean(opts.command)
+    const waitsForShellReady =
+      Boolean(opts.command) &&
+      (startupAgentRecognition?.agent !== 'codex' ||
+        shellReadyMarkerComesFromLineEditor(shellPath) ||
+        shouldUseShellReadyStartupDelivery({
+          command: opts.command,
+          startupCommandDelivery: opts.startupCommandDelivery
+        }))
     delete env.ORCA_SHELL_FEATURES
     const shellLaunch = getShellLaunchConfig(
       shellPath,

--- a/src/main/daemon/pty-subprocess/shell-launch-plan.ts
+++ b/src/main/daemon/pty-subprocess/shell-launch-plan.ts
@@ -32,7 +32,6 @@ import {
   recognizeAgentProcessFromCommandLine,
   type RecognizedAgentProcess
 } from '../../../shared/agent-process-recognition'
-import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
 import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../../shared/hermes-startup-query'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../shared/windows-terminal-shell'
 import { getShellLaunchConfig, resolvePtyShellPath } from '../shell-ready'
@@ -60,7 +59,6 @@ export function createPtyShellLaunchPlan(
   let startupCommandDeliveredInShellArgs = false
   let windowsFallbackAttempts: WindowsShellSpawnAttempt[] = []
   const startupAgentRecognition = recognizeAgentProcessFromCommandLine(opts.command)
-  const isCodexStartupCommand = startupAgentRecognition?.agent === 'codex'
   const requestedCwd = opts.cwd || resolveSafePtyDefaultCwd()
   if (opts.command && startupAgentRecognition) {
     assertSafeAgentStartupCwd(requestedCwd, opts.command)
@@ -190,13 +188,8 @@ export function createPtyShellLaunchPlan(
         `[daemon/pty] Preferred shell "${preferredShellPath}" is unavailable, fell back to "${shellPath}"`
       )
     }
-    const waitsForShellReady =
-      Boolean(opts.command) &&
-      (!isCodexStartupCommand ||
-        shouldUseShellReadyStartupDelivery({
-          command: opts.command as string,
-          startupCommandDelivery: opts.startupCommandDelivery
-        }))
+    // PTY input must wait for the line editor, including plain Codex launches.
+    const waitsForShellReady = Boolean(opts.command)
     delete env.ORCA_SHELL_FEATURES
     const shellLaunch = getShellLaunchConfig(
       shellPath,

--- a/src/main/daemon/session-shell-ready-barrier.ts
+++ b/src/main/daemon/session-shell-ready-barrier.ts
@@ -1,4 +1,4 @@
-import { createPtySlaveLineEditorProbe } from '../../shared/pty-slave-line-discipline-echo'
+import { shellReadyMarkerComesFromLineEditor } from './shell-ready'
 import {
   installDeviceAttributesResponder,
   STARTUP_DA1_RESPONSE
@@ -20,6 +20,7 @@ import { basename } from 'node:path'
 import type { ShellReadyState } from './types'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
+export const CODEX_SHELL_READY_TIMEOUT_MS = 300
 
 export type SessionShellReadyBarrierDeps = {
   sessionId: string
@@ -70,7 +71,7 @@ export class SessionShellReadyBarrier {
 
     this.postReadyFlushGate = new PostReadyFlushGate(
       () => this.flushPreReadyQueue(),
-      createPtySlaveLineEditorProbe(deps.subprocess.slavePath)
+      shellReadyMarkerComesFromLineEditor(deps.subprocess.shellPath ?? '')
     )
   }
 

--- a/src/main/daemon/session-shell-ready-barrier.ts
+++ b/src/main/daemon/session-shell-ready-barrier.ts
@@ -1,3 +1,4 @@
+import { createPtySlaveLineEditorProbe } from '../../shared/pty-slave-line-discipline-echo'
 import {
   installDeviceAttributesResponder,
   STARTUP_DA1_RESPONSE
@@ -19,8 +20,6 @@ import { basename } from 'node:path'
 import type { ShellReadyState } from './types'
 
 const SHELL_READY_TIMEOUT_MS = 15_000
-// Why: Codex skips marker-gated command delivery; this only bounds older daemon/local paths that still report shell-ready for Codex.
-export const CODEX_SHELL_READY_TIMEOUT_MS = 300
 
 export type SessionShellReadyBarrierDeps = {
   sessionId: string
@@ -69,7 +68,10 @@ export class SessionShellReadyBarrier {
       this._state = 'unsupported'
     }
 
-    this.postReadyFlushGate = new PostReadyFlushGate(() => this.flushPreReadyQueue())
+    this.postReadyFlushGate = new PostReadyFlushGate(
+      () => this.flushPreReadyQueue(),
+      createPtySlaveLineEditorProbe(deps.subprocess.slavePath)
+    )
   }
 
   get state(): ShellReadyState {

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -101,6 +101,11 @@ export function resolvePtyShellPath(env: Record<string, string>): string {
   return env.SHELL || process.env.SHELL || '/bin/zsh'
 }
 
+export function shellReadyMarkerComesFromLineEditor(shellPath: string): boolean {
+  const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
+  return shellName === 'bash' || shellName === 'zsh'
+}
+
 export function shellPathSupportsPtyStartupBarrier(shellPath: string): boolean {
   const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
   // Why fish: markerless, its startup command is written before fish's reader owns

--- a/src/main/shell-wrapper-generated-file-snapshot.test.ts
+++ b/src/main/shell-wrapper-generated-file-snapshot.test.ts
@@ -73,6 +73,7 @@ const CONTRACT_GLOBALS = new Set([
   'OPENCODE_CONFIG_DIR',
   'PATH',
   'PROMPT_COMMAND',
+  'PS1', // Bash appends its non-printing Readline readiness marker.
   'CURSOR',
   'ZDOTDIR',
   'precmd_functions',


### PR DESCRIPTION
## ELI5

Orca typed the agent command before the shell was ready, so the terminal echoed it once and the shell displayed it again. Bash now signals readiness when its actual prompt is rendered, and Orca submits immediately. The command appears once without adding a polling delay.

## What Changed

- Enable readiness for plain Codex launches in Bash/zsh and use the existing delivery hint for older daemons.
- Emit Bash's ready marker as a non-printing part of its first Readline prompt, after slow prompt expansion. Keep the existing prompt-hook order and lifecycle markers.
- Submit synchronously on Bash/zsh readiness. Remove the added terminal-state polling and bypass the settling timer for these precise markers.
- Preserve existing startup timing for fish, Windows, and other shells.

## Why

Reproduced via **New tab → Codex** on macOS/Bash with a Conda prompt. A 300 ms startup write can arrive during shell initialization. Bash's former marker also fired before slow prompt expansion finished. The actual prompt gives Orca the event it needs to send input immediately without cooked terminal echo.

## Linked Issue

Fixes #18728

## Visual Proof

Before:

![Before](https://github.com/user-attachments/assets/2a4372b3-23b1-4631-a281-e1b7ff897c88)

After, using the revised immediate-delivery implementation:

![After](https://github.com/user-attachments/assets/3380db1a-a811-4d0d-94a2-520b45ec75bb)

## Startup Timing

Real macOS PTYs, five alternating runs per case. Medians from PTY creation to first command output; this isolates shell handoff and excludes Codex's own initialization. The control uses the original 300 ms input timing.

| Shell fixture | Original | Revised |
| --- | ---: | ---: |
| Bash, fast profile | 303 ms | 18 ms |
| zsh, fast profile | 303 ms | 20 ms |
| Bash, 600 ms profile + 300 ms prompt expansion | 926 ms | 930 ms |
| zsh, 600 ms profile + 300 ms prompt expansion | 938 ms | 937 ms |

Slow-fixture ranges overlap: Bash 925–931 vs 926–932 ms; zsh 931–939 vs 932–940 ms. These samples show no material slowdown, and the immediate-marker unit test proves there is no added settling timer. They do not measure end-to-end Codex model/auth startup.

Reproduce with `ORCA_STARTUP_BENCH=1 pnpm test src/main/daemon/agent-startup-prompt-latency.node-pty.test.ts`. Set `ORCA_STARTUP_BENCH_OUTPUT` to a file path to retain raw JSONL samples.

## Testing

- [x] Reproduced and verified the rendered Electron UI via Playwright CDP on macOS.
- [x] Real Bash/zsh regression proves the original timing displays two commands and immediate prompt delivery displays one, including slow profile and PS1 expansion. Asserts the normal path does not use timeout or replacement-shell recovery.
- [x] Unit test proves synchronous delivery with zero settling timers; adapter tests cover plain/fast/hinted Codex and unchanged fish timing.
- 407 tests pass across 24 suites, including the shell-readiness gate, Bash prompt composition, shell replacement, session, relay, Windows/WSL launch, and protocol compatibility tests. The opt-in benchmark also passed separately.
- `pnpm tc:node`, changed-file `oxlint`, formatting, and `git diff --check` pass. Development Electron build succeeds. Full packaged-build/platform matrix remains for CI.

## Reliability and Coverage

Invariant: `terminal-session.shell-ready-exec-prompt-fallback` — startup input executes once, after the owning shell accepts it, while the interactive shell and existing replacement-shell recovery remain available. Failure source: #18728. Oracles: exact visible command count under real PTYs, immediate-delivery timer count, and the rendered Codex screenshot. Gate: existing readiness suite plus the new prompt-latency regression. Existing daemon readiness logs identify timeout/replacement recovery; the benchmark can retain raw samples.

Daemon macOS Bash/zsh are exercised live. Local PTY and relay implementations are unchanged, with their readiness contracts tested. Native Linux Bash also passed a real-PTY single-echo check. Live SSH reconnect assertions passed twice on HEAD and once with the pre-change production implementation; all three runs then hit the same 120-second Playwright worker teardown timeout, so these are assertion passes, not clean end-to-end suite passes. WSL/Windows, paired mobile/web, folder workspaces, and new-worktree creation remain live-validation gaps; Windows/WSL and relay unit contracts pass. No Git/worktree-specific logic changed. Fish and unsupported-shell timing retain their previous behavior.

No new wire fields/opcodes. The owning host generates and interprets the prompt marker; the immediate-delivery fix requires the updated host. Older hosts retain their own settling behavior. Existing bounded fallback remains for profiles that replace the wrapper or suppress readiness.

## Agent skill upstream boundary

- [x] Not applicable; no skill source changes.

## Checklist

- [x] Focused change with ELI5, timing evidence, and before/after proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, folder-workspace, and compatibility impacts considered
- [x] Configured CI matrix: static analysis, typecheck, eight test shards, shell contracts, packaging and native smoke checks pass. Path-filtered jobs are skipped by CI.

## Readiness review

Reviewed all eight readiness-checklist areas, including performance, mobile compatibility, Windows/Linux and remote execution contracts. Four-model findings counsel plus blind peer ratings unanimously classified the one finding as P2: the generated Bash fixture and intentional PS1 global audit needed updating. Fixed in `2c87a39ae3c`; all seven CI-mode snapshot tests pass. No proven production blocker remains.

All eight CI test shards, typecheck, static analysis, shell contracts, Windows packaging, and native smoke checks on macOS/Linux/Windows pass at `2c87a39ae3cd4396b4c782edee803e5cf854d21b`. Main packaging and final verification also pass.

The live SSH cleanup timeout reproduces with this PR's production changes removed, using the same test and environment (baseline assertions 24.9 s; HEAD 29.1/26.1 s, followed in every case by worker teardown timeout). It is a pre-existing harness limitation; no claim of clean SSH suite completion. No mobile-facing protocol or persisted-state surface changed.
