### PR TITLE
fix(ui): unmount project selector before Add Project handoff

### DIFF
--- a/src/renderer/src/components/new-workspace/ProjectCombobox.dialog-handoff.test.tsx
+++ b/src/renderer/src/components/new-workspace/ProjectCombobox.dialog-handoff.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+
+import React, { act, useRef, useState } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import ProjectCombobox from './ProjectCombobox'
+
+vi.mock('./use-recent-project-ids', () => ({ useRecentProjectIds: () => [] }))
+
+function Composer({ populated }: { populated: boolean }): React.JSX.Element {
+  const [adding, setAdding] = useState(false)
+  const nameRef = useRef<HTMLInputElement>(null)
+  return (
+    <Dialog open>
+      <DialogContent aria-describedby={undefined}>
+        <DialogTitle>New workspace</DialogTitle>
+        <ProjectCombobox
+          options={
+            populated
+              ? [
+                  {
+                    kind: 'project',
+                    id: 'project:existing',
+                    projectId: 'project:existing',
+                    displayName: 'Existing project',
+                    badgeColor: 'var(--muted)',
+                    detail: 'Project'
+                  }
+                ]
+              : []
+          }
+          value={populated ? 'project:existing' : null}
+          onValueChange={vi.fn()}
+          onAddProject={() => setAdding(true)}
+        />
+        <input ref={nameRef} aria-label="Workspace name" />
+        <Dialog open={adding} onOpenChange={setAdding}>
+          <DialogContent
+            aria-describedby={undefined}
+            onCloseAutoFocus={(event) => {
+              event.preventDefault()
+              nameRef.current?.focus()
+            }}
+          >
+            <DialogTitle>Add a project</DialogTitle>
+            <input aria-label="Project path" />
+            <button onClick={() => setAdding(false)}>Cancel</button>
+          </DialogContent>
+        </Dialog>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  // Radix Presence retains closing content when the production exit animation runs.
+  const getStyle = window.getComputedStyle.bind(window)
+  vi.spyOn(window, 'getComputedStyle').mockImplementation((element, ...args) => {
+    const style = getStyle(element, ...args)
+    if (element.getAttribute('data-slot') === 'popover-content') {
+      return new Proxy(style, {
+        get: (target, property) =>
+          property === 'animationName'
+            ? element.getAttribute('data-state') === 'closed'
+              ? 'exit'
+              : 'enter'
+            : Reflect.get(target, property)
+      })
+    }
+    return style
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+function projectField(): HTMLInputElement {
+  return document.querySelector<HTMLInputElement>('[role="combobox"][aria-label="Project"]')!
+}
+
+function addOption(): HTMLElement {
+  return Array.from(document.querySelectorAll<HTMLElement>('[role="option"]')).find((option) =>
+    option.textContent?.includes('Add a new project')
+  )!
+}
+
+describe.each([false, true])(
+  'project selector to nested dialog handoff (populated: %s)',
+  (populated) => {
+    it.each(['mouse', 'keyboard'] as const)(
+      'removes the selector before the creation dialog is active via %s',
+      async (input) => {
+        await act(async () => root.render(<Composer populated={populated} />))
+        await act(async () => projectField().click())
+        expect(document.querySelector('[role="listbox"]')).not.toBeNull()
+
+        await act(async () => {
+          if (input === 'mouse') {
+            addOption().dispatchEvent(
+              new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+            )
+            addOption().click()
+          } else if (populated) {
+            projectField().dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true })
+            )
+          }
+        })
+        if (input === 'keyboard') {
+          await act(async () => {
+            projectField().dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+            )
+          })
+        }
+
+        expect(document.querySelector('[role="listbox"]')).toBeNull()
+        expect(document.querySelector('[data-slot="popover-content"]')).toBeNull()
+        expect(projectField().getAttribute('aria-expanded')).toBe('false')
+        expect(projectField().hasAttribute('aria-activedescendant')).toBe(false)
+        const path = document.querySelector<HTMLInputElement>('[aria-label="Project path"]')!
+        expect(document.activeElement).toBe(path)
+        expect(path.closest('[aria-hidden="true"]')).toBeNull()
+        expect(projectField().closest('[aria-hidden="true"]')).not.toBeNull()
+
+        await act(async () => {
+          Array.from(document.querySelectorAll('button'))
+            .find((b) => b.textContent === 'Cancel')!
+            .click()
+        })
+        await vi.waitFor(() =>
+          expect(document.activeElement).toBe(
+            document.querySelector('[aria-label="Workspace name"]')
+          )
+        )
+        await act(async () => projectField().click())
+        expect(projectField().getAttribute('aria-expanded')).toBe('true')
+        expect(document.querySelector('[role="listbox"]')).not.toBeNull()
+      }
+    )
+  }
+)

--- a/src/renderer/src/components/new-workspace/ProjectCombobox.test.tsx
+++ b/src/renderer/src/components/new-workspace/ProjectCombobox.test.tsx
@@ -72,7 +72,7 @@ function field(): HTMLInputElement {
 
 function openList(): void {
   act(() => {
-    field().dispatchEvent(new FocusEvent('focus', { bubbles: true }))
+    field().focus()
   })
 }
 

--- a/src/renderer/src/components/new-workspace/ProjectCombobox.tsx
+++ b/src/renderer/src/components/new-workspace/ProjectCombobox.tsx
@@ -229,129 +229,132 @@ export default function ProjectCombobox({
           </button>
         </div>
       </PopoverAnchor>
-      <PopoverContent
-        align="start"
-        sideOffset={4}
-        // Why opaque + no fade: this popover lands directly on the composer
-        // dialog, not the app canvas. The shared surface is translucent and
-        // fades 0→1, so mid-animation the Name field underneath reads straight
-        // through the list — two layers at once, which is the "double flash".
-        // An opaque surface that zooms without fading resolves it. (`bg-popover`
-        // alone loses to the primitive's arbitrary-value background, hence the
-        // matching arbitrary form.) Every other caller keeps the blur and fade.
-        className={cn(
-          'flex w-[var(--radix-popover-trigger-width)] min-w-[17rem] flex-col p-0',
-          COMBOBOX_POPOVER_SURFACE
-        )}
-        // Focus stays in the field — it's the search box — so the popover must
-        // not steal it on open, nor yank it back on close after a pick.
-        onOpenAutoFocus={(event) => event.preventDefault()}
-        onCloseAutoFocus={(event) => event.preventDefault()}
-        // Why: the field lives in the anchor, not inside the content, so Radix
-        // sees a focus/pointer event "outside" the layer and dismisses it the
-        // instant you tab in. Keep the layer open whenever the interaction is
-        // within this control; genuine outside events still close it.
-        onFocusOutside={(event) => {
-          if (isWithinComboboxRoot(event.target, ROOT_ATTRIBUTE)) {
-            event.preventDefault()
-          }
-        }}
-        onInteractOutside={(event) => {
-          if (isWithinComboboxRoot(event.target, ROOT_ATTRIBUTE)) {
-            event.preventDefault()
-          }
-        }}
-      >
-        {/* The listbox wraps a scrolling pane plus the pinned Add row, so both
-            stay `option` children of one listbox. */}
-        <div
-          id={listId}
-          role="listbox"
-          aria-label={translate(
-            'auto.components.new.workspace.ProjectCombobox.listLabel',
-            'Projects'
+      {/* Closing must remove the selector before a nested dialog takes focus. */}
+      {open ? (
+        <PopoverContent
+          align="start"
+          sideOffset={4}
+          // Why opaque + no fade: this popover lands directly on the composer
+          // dialog, not the app canvas. The shared surface is translucent and
+          // fades 0→1, so mid-animation the Name field underneath reads straight
+          // through the list — two layers at once, which is the "double flash".
+          // An opaque surface that zooms without fading resolves it. (`bg-popover`
+          // alone loses to the primitive's arbitrary-value background, hence the
+          // matching arbitrary form.) Every other caller keeps the blur and fade.
+          className={cn(
+            'flex w-[var(--radix-popover-trigger-width)] min-w-[17rem] flex-col p-0',
+            COMBOBOX_POPOVER_SURFACE
           )}
-          className="flex min-h-0 flex-col"
+          // Focus stays in the field — it's the search box — so the popover must
+          // not steal it on open, nor yank it back on close after a pick.
+          onOpenAutoFocus={(event) => event.preventDefault()}
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          // Why: the field lives in the anchor, not inside the content, so Radix
+          // sees a focus/pointer event "outside" the layer and dismisses it the
+          // instant you tab in. Keep the layer open whenever the interaction is
+          // within this control; genuine outside events still close it.
+          onFocusOutside={(event) => {
+            if (isWithinComboboxRoot(event.target, ROOT_ATTRIBUTE)) {
+              event.preventDefault()
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (isWithinComboboxRoot(event.target, ROOT_ATTRIBUTE)) {
+              event.preventDefault()
+            }
+          }}
         >
-          {/* Why: `presentation` — this element exists to scroll, and an
+          {/* The listbox wraps a scrolling pane plus the pinned Add row, so both
+            stay `option` children of one listbox. */}
+          <div
+            id={listId}
+            role="listbox"
+            aria-label={translate(
+              'auto.components.new.workspace.ProjectCombobox.listLabel',
+              'Projects'
+            )}
+            className="flex min-h-0 flex-col"
+          >
+            {/* Why: `presentation` — this element exists to scroll, and an
               unroled div between a listbox and its options breaks the
               ownership relationship assistive tech relies on. */}
-          <div
-            ref={setListNode}
-            role="presentation"
-            className="max-h-72 min-h-0 flex-1 overflow-y-auto p-1 scrollbar-sleek"
-          >
-            {matches.length === 0 ? (
-              // Why: row-height rather than a tall centred block — a 60px panel
-              // next to 32px rows reads as a different kind of surface and
-              // makes an empty result feel like an error.
-              <p className="flex h-8 items-center justify-center px-2 text-sm text-muted-foreground">
-                {options.length === 0
-                  ? translate(
-                      'auto.components.new.workspace.ProjectCombobox.noProjects',
-                      'No projects yet.'
-                    )
-                  : translate(
-                      'auto.components.new.workspace.ProjectCombobox.empty',
-                      'No projects match your search.'
-                    )}
-              </p>
-            ) : null}
-            {sections.map((section) => (
-              // Why: `role="group"` — a bare div between a listbox and its
-              // options breaks the ownership relationship for screen readers,
-              // which is the only thing that makes the headings announceable.
-              <div key={section.key} role="group" aria-label={section.heading ?? undefined}>
-                {section.heading ? (
-                  <div
-                    aria-hidden="true"
-                    className="px-2 pt-2.5 pb-1 text-[11px] font-semibold tracking-[0.05em] text-muted-foreground uppercase"
-                  >
-                    {section.heading}
-                  </div>
-                ) : null}
-                {section.items.map((scored) => (
-                  <ProjectOptionRow
-                    key={scored.option.id}
-                    option={scored.option}
-                    nameHits={scored.nameHits}
-                    detailHits={scored.detailHits}
-                    armed={armedKey === scored.option.id}
-                    current={scored.option.id === value}
-                    ambiguous={ambiguous.has(scored.option.id)}
-                    optionId={armedKey === scored.option.id ? `${listId}-armed` : undefined}
-                    onArm={() => arm(scored.option.id)}
-                    onCommit={() => commit(scored.option.id)}
-                  />
-                ))}
-              </div>
-            ))}
-          </div>
-          {onAddProject ? (
             <div
-              role="option"
-              id={armedKey === ADD_PROJECT_KEY ? `${listId}-armed` : undefined}
-              aria-selected={armedKey === ADD_PROJECT_KEY}
-              data-armed={armedKey === ADD_PROJECT_KEY || undefined}
-              onMouseDown={(event) => event.preventDefault()}
-              onMouseMove={() => arm(ADD_PROJECT_KEY)}
-              onClick={() => commit(ADD_PROJECT_KEY)}
-              className={cn(
-                'flex h-9 shrink-0 cursor-default items-center gap-2 border-t border-border px-2 text-sm',
-                armedKey === ADD_PROJECT_KEY && 'bg-accent text-accent-foreground'
-              )}
+              ref={setListNode}
+              role="presentation"
+              className="max-h-72 min-h-0 flex-1 overflow-y-auto p-1 scrollbar-sleek"
             >
-              <FolderPlus className="size-3.5 shrink-0 text-muted-foreground" />
-              <span className="truncate">
-                {translate(
-                  'auto.components.new.workspace.ProjectCombobox.addProject',
-                  'Add a new project'
-                )}
-              </span>
+              {matches.length === 0 ? (
+                // Why: row-height rather than a tall centred block — a 60px panel
+                // next to 32px rows reads as a different kind of surface and
+                // makes an empty result feel like an error.
+                <p className="flex h-8 items-center justify-center px-2 text-sm text-muted-foreground">
+                  {options.length === 0
+                    ? translate(
+                        'auto.components.new.workspace.ProjectCombobox.noProjects',
+                        'No projects yet.'
+                      )
+                    : translate(
+                        'auto.components.new.workspace.ProjectCombobox.empty',
+                        'No projects match your search.'
+                      )}
+                </p>
+              ) : null}
+              {sections.map((section) => (
+                // Why: `role="group"` — a bare div between a listbox and its
+                // options breaks the ownership relationship for screen readers,
+                // which is the only thing that makes the headings announceable.
+                <div key={section.key} role="group" aria-label={section.heading ?? undefined}>
+                  {section.heading ? (
+                    <div
+                      aria-hidden="true"
+                      className="px-2 pt-2.5 pb-1 text-[11px] font-semibold tracking-[0.05em] text-muted-foreground uppercase"
+                    >
+                      {section.heading}
+                    </div>
+                  ) : null}
+                  {section.items.map((scored) => (
+                    <ProjectOptionRow
+                      key={scored.option.id}
+                      option={scored.option}
+                      nameHits={scored.nameHits}
+                      detailHits={scored.detailHits}
+                      armed={armedKey === scored.option.id}
+                      current={scored.option.id === value}
+                      ambiguous={ambiguous.has(scored.option.id)}
+                      optionId={armedKey === scored.option.id ? `${listId}-armed` : undefined}
+                      onArm={() => arm(scored.option.id)}
+                      onCommit={() => commit(scored.option.id)}
+                    />
+                  ))}
+                </div>
+              ))}
             </div>
-          ) : null}
-        </div>
-      </PopoverContent>
+            {onAddProject ? (
+              <div
+                role="option"
+                id={armedKey === ADD_PROJECT_KEY ? `${listId}-armed` : undefined}
+                aria-selected={armedKey === ADD_PROJECT_KEY}
+                data-armed={armedKey === ADD_PROJECT_KEY || undefined}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseMove={() => arm(ADD_PROJECT_KEY)}
+                onClick={() => commit(ADD_PROJECT_KEY)}
+                className={cn(
+                  'flex h-9 shrink-0 cursor-default items-center gap-2 border-t border-border px-2 text-sm',
+                  armedKey === ADD_PROJECT_KEY && 'bg-accent text-accent-foreground'
+                )}
+              >
+                <FolderPlus className="size-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate">
+                  {translate(
+                    'auto.components.new.workspace.ProjectCombobox.addProject',
+                    'Add a new project'
+                  )}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </PopoverContent>
+      ) : null}
     </Popover>
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​153 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​116 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

The project selector was told to close, but its opaque exit animation kept it over the Add Project dialog. Closing now removes the selector immediately so the new dialog owns interaction and focus.

## What Changed

Mount `ProjectCombobox`'s popover content only while its existing `open` state is true. Add deterministic component coverage using real Radix dialogs/popovers for mouse and keyboard handoffs with empty and populated project lists, cancellation, accessibility state, focus restoration, and reopening. Correct the existing component test helper to use actual input focus.

## Why

The selection handler already closes before invoking Add Project. Radix Presence retained the closing content through its exit animation, extending the overlay lifetime beyond its owning state. Keeping content lifetime at that state boundary fixes the invariant without extra state, parent plumbing, timers, z-index changes, or shared primitive changes. All project-selector dismissals now skip exit animation; entrance animation remains.

## Linked Issue

Direct user-reported regression; no existing issue linked. Reproduction: New workspace → Project → Add a new project. Warm/reopened Add Project exposes the overlap reliably because lazy loading can mask it on first open.

## Visual Proof

Before: full app window, with the selector exit animation held at its first frame for capture. Normal instrumentation observed roughly 156 ms of overlap; a permanent stall was not reproduced.

![Before: retained project selector obscures Add Project](https://github.com/user-attachments/assets/ef5fc5f4-328c-498f-a708-b2410f2f6ec6)

After: full app window, Add Project unobscured. A transition MutationObserver recorded zero overlapping selector/dialog states.

![After: Add Project owns the surface](https://github.com/user-attachments/assets/7fadce79-c6b4-4527-95ea-f90b2eaadf0b)

## Testing

- [x] Manually tested locally in isolated-profile Electron with dedicated CDP/renderer ports; verified the worktree identity.
- [x] Automated regression tests added with real overlay primitives and deterministic exit-animation metadata.
- Baseline/candidate/revert/restore oracle: **4 fail → 4 pass → 4 fail → 4 pass**; baseline fails on the retained listbox.
- 20 focused suites / 189 tests passed.
- Renderer typecheck (`pnpm tc:web`), direct changed-file oxlint, changed-code quality (native, type-aware, React Doctor), formatting, and commit hooks passed.
- Desktop: cold/warm mouse and keyboard Add, no-match Enter, Tab trap, Close/Escape/click-away cancellation, restoration to workspace name, reopening, selector Escape/click-away, and real Git project creation/selection handoff passed.
- Actually tested: macOS, dark mode. Native Windows/Linux, light mode, and live SSH were not run. Host routing and project/folder-option logic are unchanged; neighboring option/group tests passed.
- Full build and broader checks are left to CI.

## Review

Self-reviewed the complete diff. Three fresh independent agents reviewed the ownership boundary, adversarial overlay/focus behavior, and regression risk; no blocking findings. The component fixture approximates the parent composition, with ordinary-flow Electron checks providing the full app evidence.

## Agent skill upstream boundary

- [x] Not applicable; no agent skill code changed.

## Checklist

- [x] Small, focused production change (the larger diff is JSX indentation).
- [x] Explained what changed and why.
- [x] Before/after screenshots attached.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered.
- [ ] Full lint/typecheck/test/build suite (CI); focused local checks passed as listed above.
