### PR TITLE
infra(relay): drop the unapplied region label from runtime log metrics

### DIFF
--- a/cloud/infra/terraform/relay-observability.tf
+++ b/cloud/infra/terraform/relay-observability.tf
@@ -211,7 +211,8 @@ resource "google_logging_metric" "relay_snapshot" {
   label_extractors = {
     role    = "EXTRACT(jsonPayload.role)"
     cell_id = "EXTRACT(jsonPayload.cellId)"
-    region  = "EXTRACT(jsonPayload.region)"
+    # No region label: adding one replaces all 21 live metrics (label change = delete+create),
+    # which resets history and blanks the relay alert policies during the swap.
   }
 
   metric_descriptor {
@@ -229,12 +230,6 @@ resource "google_logging_metric" "relay_snapshot" {
       key         = "cell_id"
       value_type  = "STRING"
       description = "Durable relay cell identifier."
-    }
-
-    labels {
-      key         = "region"
-      value_type  = "STRING"
-      description = "Coarse Relay region."
     }
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |

<!-- /orca-pr-loc -->

The relay-root Terraform gives every `relay_snapshot` runtime metric a `region` label that the 21 live metrics do not have. A label change on a log metric is delete+create, so any plan touching them was `32 to add, 21 to destroy`: history reset and the 14 relay alert policies blank during the swap. This blocked applying the incident dashboard from #18717.

Fix: match Terraform to live state and drop the label. Nothing reads `metric.label.region` anywhere in Terraform or relay-ops.

Targeted production plan after this change (asserted via `terraform show -json`): 27 no-op, 9 create, 0 change, 0 destroy. The 9 creates are the 8 `control_*` renewal metrics that were added in code but never applied, plus `google_monitoring_dashboard.relay_incident`.

Checklist item 5.x in `cloud/docs/relay-improvement-checklist-2026-09.md`.