### PR TITLE
fix(agent-session): never open a sibling terminal on an unproven create

### DIFF
--- a/src/renderer/src/lib/launch-structured-agent-session.test.ts
+++ b/src/renderer/src/lib/launch-structured-agent-session.test.ts
@@ -5,7 +5,8 @@ import {
   createStructuredAgentSessionLaunchIntent,
   isDefinitiveStructuredAgentSessionCreateError,
   launchStructuredAgentSession,
-  StructuredAgentSessionCreateRefusalError
+  StructuredAgentSessionCreateRefusalError,
+  StructuredAgentSessionCreateUnknownOutcomeError
 } from './launch-structured-agent-session'
 
 vi.mock('@/runtime/structured-agent-session-client', () => ({
@@ -256,8 +257,28 @@ describe('structured agent session launch', () => {
       createStructuredAgentSessionLaunchIntent('workspace-unknown', 'codex')
     ).catch((caught: unknown) => caught)
 
+    expect(error).toBeInstanceOf(StructuredAgentSessionCreateUnknownOutcomeError)
     expect(error).not.toBeInstanceOf(StructuredAgentSessionCreateRefusalError)
     expect(error).toMatchObject({ code: 'agent_session_operation_unknown' })
+    expect(isDefinitiveStructuredAgentSessionCreateError(error)).toBe(false)
+  })
+
+  /** The class is the verdict, so a refusal message that happens to end in a definitive token
+   *  must not be re-read into one by the transport-error matcher. */
+  it('keeps an unknown outcome unknown even when its message ends in a definitive token', async () => {
+    vi.mocked(callStructuredAgentSession).mockResolvedValue({
+      ok: false,
+      refusal: {
+        code: 'agent_session_ownership_unknown',
+        message: 'Owner check failed: method_not_found'
+      }
+    })
+
+    const error = await launchStructuredAgentSession(
+      createStructuredAgentSessionLaunchIntent('workspace-unknown-token', 'codex')
+    ).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(StructuredAgentSessionCreateUnknownOutcomeError)
     expect(isDefinitiveStructuredAgentSessionCreateError(error)).toBe(false)
   })
 

--- a/src/renderer/src/lib/launch-structured-agent-session.ts
+++ b/src/renderer/src/lib/launch-structured-agent-session.ts
@@ -33,13 +33,37 @@ export type StructuredAgentSessionLaunchIntent = {
   params: StructuredAgentSessionCreateParams
 }
 
-export class StructuredAgentSessionCreateRefusalError extends Error {
+class StructuredAgentSessionCreateError extends Error {
   constructor(
     message: string,
-    readonly code: string = 'structured_agent_session_unsupported'
+    /** The wire refusal code, or the RPC error code when the create never reached a handler. */
+    readonly code: string
   ) {
     super(message)
+  }
+}
+
+/**
+ * The host proved it created nothing, so a caller may open a legacy terminal instead. The class
+ * itself is the verdict: `launchStructuredAgentSession` is the only place that decides it, against
+ * the shared allowlist, so no consumer has to remember to re-check a code.
+ */
+export class StructuredAgentSessionCreateRefusalError extends StructuredAgentSessionCreateError {
+  constructor(message: string, code: string = 'structured_agent_session_unsupported') {
+    super(message, code)
     this.name = 'StructuredAgentSessionCreateRefusalError'
+  }
+}
+
+/**
+ * Refused with a code that does not prove the session is absent. A sibling opened here would sit
+ * beside a session the host may already hold, so this deliberately is NOT a refusal error: it flows
+ * down the same path as a lost reply, which replays the intent and reconciles.
+ */
+export class StructuredAgentSessionCreateUnknownOutcomeError extends StructuredAgentSessionCreateError {
+  constructor(message: string, code: string) {
+    super(message, code)
+    this.name = 'StructuredAgentSessionCreateUnknownOutcomeError'
   }
 }
 
@@ -49,8 +73,12 @@ const DEFINITIVE_CREATE_FAILURE_CODES = [
 ] as const
 
 function definitiveStructuredAgentSessionCreateErrorCode(error: unknown): string | null {
-  if (error instanceof StructuredAgentSessionCreateRefusalError) {
-    return isDefinitiveAgentSessionCreateRefusal(error.code) ? error.code : null
+  if (error instanceof StructuredAgentSessionCreateError) {
+    // Our own classes already carry the verdict; message sniffing below could only invert it.
+    return error instanceof StructuredAgentSessionCreateRefusalError &&
+      isDefinitiveAgentSessionCreateRefusal(error.code)
+      ? error.code
+      : null
   }
   for (const code of DEFINITIVE_CREATE_FAILURE_CODES) {
     if (hasRuntimeRpcErrorCode(error, code)) {
@@ -200,15 +228,13 @@ export async function launchStructuredAgentSession(
     throw error
   }
   if (!result.ok) {
-    const error = new StructuredAgentSessionCreateRefusalError(
-      result.refusal.message,
-      result.refusal.code
-    )
-    if (isDefinitiveStructuredAgentSessionCreateError(error)) {
-      abandonStructuredAgentSessionLaunchIntent(intent)
-      throw error
+    const { code, message } = result.refusal
+    if (!isDefinitiveAgentSessionCreateRefusal(code)) {
+      // Keep the focus intent: the session may exist, and recovery still has to adopt it.
+      throw new StructuredAgentSessionCreateUnknownOutcomeError(message, code)
     }
-    throw Object.assign(new Error(error.message), { code: error.code })
+    abandonStructuredAgentSessionLaunchIntent(intent)
+    throw new StructuredAgentSessionCreateRefusalError(message, code)
   }
   return { sessionId: result.value.sessionId, fence: result.value.fence }
 }

--- a/src/renderer/src/lib/structured-agent-session-launch-refusal-fallback.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch-refusal-fallback.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment happy-dom
+
+// The duplicate-session guard: which create refusals may open a legacy terminal beside the chat.
+// Deliberately exercises the real `launch-structured-agent-session`, because the classification
+// under test lives there — mocking it out would assert nothing.
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-session-contracts'
+import { RuntimeRpcCallError } from '@/runtime/runtime-rpc-client'
+
+const mocks = vi.hoisted(() => ({
+  call: vi.fn(),
+  refresh: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), message: vi.fn() }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, options?: { value0?: string }) =>
+    fallback.replace('{{value0}}', options?.value0 ?? '')
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  getAgentCatalog: () => [{ id: 'codex', label: 'Codex' }]
+}))
+
+vi.mock('@/runtime/structured-agent-session-client', () => ({
+  callStructuredAgentSession: mocks.call
+}))
+
+vi.mock('@/runtime/local-structured-session-tabs-sync', () => ({
+  LOCAL_STRUCTURED_SESSION_OWNER: 'local',
+  refreshLocalStructuredSessionTabs: mocks.refresh
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({ unifiedTabsByWorktree: {} }),
+    subscribe: () => () => {}
+  }
+}))
+
+import {
+  StructuredAgentSessionCreateRefusalError,
+  StructuredAgentSessionCreateUnknownOutcomeError
+} from '@/lib/launch-structured-agent-session'
+import {
+  getStructuredAgentLaunchStatus,
+  startStructuredAgentLaunch
+} from './structured-agent-session-launch'
+
+type CreateReply = { ok: boolean; refusal?: { code: string; message: string } }
+
+/** Replies to every `agentSession.create` in turn, repeating the last reply thereafter. */
+function replyToCreates(...replies: CreateReply[]): void {
+  let index = 0
+  mocks.call.mockImplementation(async (_target: unknown, method: string, params: unknown) => {
+    if (method !== 'agentSession.create') {
+      return { ok: true, page: { fence: 1 } }
+    }
+    const reply = replies[Math.min(index, replies.length - 1)]
+    index += 1
+    if (!reply.ok) {
+      return reply
+    }
+    const sessionId = (params as { envelope: { sessionId: string } }).envelope.sessionId
+    return { ok: true, replayed: index > 1, fence: 1, value: { sessionId, fence: 1 } }
+  })
+}
+
+function refused(code: string): CreateReply {
+  return { ok: false, refusal: { code, message: `create refused: ${code}` } }
+}
+
+function publishedSnapshot(worktreeId: string, sessionId: string): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: worktreeId,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: [
+      {
+        type: 'agent-session',
+        id: 'tab-1',
+        title: 'Codex',
+        sessionId,
+        agent: 'codex',
+        isActive: true
+      }
+    ]
+  }
+}
+
+async function flushLaunchSettlement(): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('legacy terminal fallback after a refused structured create', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mocks.refresh.mockResolvedValue([])
+  })
+
+  it.each(['agent_session_operation_unknown', 'agent_session_ownership_unknown'])(
+    'opens no sibling terminal when the host answers %s',
+    async (code) => {
+      const worktreeId = `wt-${code}`
+      const legacyTerminals: string[] = []
+      replyToCreates(refused(code))
+
+      const launch = startStructuredAgentLaunch(worktreeId, 'codex')
+      void launch.claimDefinitiveRefusalFallback(() => {
+        legacyTerminals.push('legacy-terminal')
+      })
+
+      await expect(launch.launchResult).rejects.toBeInstanceOf(
+        StructuredAgentSessionCreateUnknownOutcomeError
+      )
+      await flushLaunchSettlement()
+
+      // The host may already hold the session, so the user keeps exactly one thing: no chat it
+      // could confirm, and no terminal beside a session it could not rule out.
+      expect(legacyTerminals).toEqual([])
+      expect(launch.isVisibilityUnknown()).toBe(true)
+      expect(toast.error).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('adopts the session an unknown outcome had already created, without a sibling', async () => {
+    const worktreeId = 'wt-unknown-then-published'
+    const legacyTerminals: string[] = []
+    replyToCreates(refused('agent_session_operation_unknown'), { ok: true })
+
+    const launch = startStructuredAgentLaunch(worktreeId, 'codex')
+    const fallbackRan = launch.claimDefinitiveRefusalFallback(() => {
+      legacyTerminals.push('legacy-terminal')
+    })
+    mocks.refresh
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([publishedSnapshot(worktreeId, launch.sessionId)])
+
+    await expect(launch.launchResult).resolves.toEqual({
+      sessionId: launch.sessionId,
+      fence: 1
+    })
+    await expect(fallbackRan).resolves.toBe(false)
+    await flushLaunchSettlement()
+
+    expect(legacyTerminals).toEqual([])
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('opens exactly one legacy terminal when the refusal is on the definitive allowlist', async () => {
+    const worktreeId = 'wt-unsupported'
+    const legacyTerminals: string[] = []
+    replyToCreates(refused('structured_agent_session_unsupported'))
+
+    const launch = startStructuredAgentLaunch(worktreeId, 'codex')
+    const fallbackRan = launch.claimDefinitiveRefusalFallback(() => {
+      legacyTerminals.push('legacy-terminal')
+    })
+
+    await expect(launch.launchResult).rejects.toBeInstanceOf(
+      StructuredAgentSessionCreateRefusalError
+    )
+    await expect(fallbackRan).resolves.toBe(true)
+    await flushLaunchSettlement()
+
+    expect(legacyTerminals).toEqual(['legacy-terminal'])
+    // A proven "nothing was created" needs no replay, so the terminal is the only surface open.
+    expect(
+      mocks.call.mock.calls.filter(([, method]) => method === 'agentSession.create')
+    ).toHaveLength(1)
+    expect(launch.isVisibilityUnknown()).toBe(false)
+  })
+
+  it('opens exactly one legacy terminal when an older runtime has no create method', async () => {
+    const legacyTerminals: string[] = []
+    mocks.call.mockRejectedValue(
+      new RuntimeRpcCallError({
+        id: 'rpc-old-runtime',
+        ok: false,
+        error: { code: 'method_not_found', message: 'Unknown method: agentSession.create' }
+      })
+    )
+
+    const launch = startStructuredAgentLaunch('wt-old-runtime', 'codex')
+    const fallbackRan = launch.claimDefinitiveRefusalFallback(() => {
+      legacyTerminals.push('legacy-terminal')
+    })
+
+    await expect(launch.launchResult).rejects.toBeInstanceOf(
+      StructuredAgentSessionCreateRefusalError
+    )
+    await expect(fallbackRan).resolves.toBe(true)
+    expect(legacyTerminals).toEqual(['legacy-terminal'])
+    expect(mocks.call).toHaveBeenCalledOnce()
+    expect(getStructuredAgentLaunchStatus('wt-old-runtime', 'codex')).toBe('idle')
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​230 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​229 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

**#18697 has merged** (2026-09-05), so this now targets `main` directly and was rebased onto it — the stale stacked history is gone and only this PR's own commit remains.

**What this PR is, precisely:** the duplicate-session behaviour is **already fixed on `main`**. This adds the typed `StructuredAgentSessionCreateUnknownOutcomeError`, closes a latent classification hole, and pins the behaviour with a regression suite so it cannot silently come back. It is hardening, not a behaviour fix — read the before/after below with that in mind.

> **Re-expressed onto a moved base (2026-09-04).** `brennanb2025/bug2-refusal-envelope` advanced and renamed the module this PR edits — `launch-structured-codex-session.ts` → `launch-structured-agent-session.ts` — as part of the agent-agnostic Codex→agent rename, and in the same move landed `8491e84` "gate legacy fallback on definitive refusals", which already carries a `code` on the refusal error and already keeps a non-definitive refusal out of `StructuredAgentSessionCreateRefusalError`. This PR was re-expressed against the renamed module and narrowed to what the base still lacks; the "what changed" section below says exactly what that is. The older-runtime `method_not_found` commit is fully superseded by the base and has been dropped.

## ELI5

You click "start a Codex chat". Orca asks the host to create one. Usually the host says "done" or "no". But sometimes it says **"I might have done it — I can't confirm"**: it really did create the session, then failed on the last step of showing you the tab.

If the desktop files that maybe under **no**, it helpfully opens a plain terminal for you instead — right next to the chat session that already exists. You asked for one thing and got two, and the extra one is the one you didn't ask for.

The base branch already stopped that from happening. What it did *not* do is write the difference down anywhere a reader — or the code — can see it: an unconfirmed outcome came back as a plain `Error` with a code string stapled on. This PR gives that outcome a name, so "I don't know" is a thing the type system knows about rather than a convention every future consumer has to re-derive, and adds the end-to-end test that actually counts the terminals.

## Before / after

| You click "new Codex chat" and the host… | Before the stack | After |
| --- | --- | --- |
| creates it and confirms it | 1 chat | 1 chat |
| **creates it but can't confirm the tab** (`agent_session_operation_unknown`) | **1 orphaned chat + 1 terminal you didn't ask for** | 1 chat — the retry finishes publishing its tab |
| **can't say who owns the session** (`agent_session_ownership_unknown`) | **1 possible chat + 1 terminal** | nothing extra; "couldn't confirm", and clicking again reconciles |
| genuinely can't do structured chat here (`structured_agent_session_unsupported`) | 1 terminal | 1 terminal — unchanged |
| never answers (transport error, timeout) | nothing extra | nothing extra — unchanged |

The only row that gets a terminal is the one where the host **proved** it created nothing.

## What changed in *this* PR

**Already on the base, not re-added here:** the `isDefinitiveAgentSessionCreateRefusal` import, `code` on `StructuredAgentSessionCreateRefusalError`, `definitiveStructuredAgentSessionCreateErrorCode`, the thrown-error classification, and the mocked-module unit test in `structured-agent-session-launch.test.ts`.

**What this PR adds:**

1. **`StructuredAgentSessionCreateUnknownOutcomeError`.** The base rejected an unconfirmed create with `Object.assign(new Error(message), { code })` — an anonymous error whose verdict existed only as a string. It is now a named sibling of `StructuredAgentSessionCreateRefusalError` (both extend a private `StructuredAgentSessionCreateError` that owns `code`), so "the host may already hold this session" is a type, not a convention.

2. **Classification short-circuits on our own classes.** This closes a real latent hole, not just a naming one. `definitiveStructuredAgentSessionCreateErrorCode` falls through to `hasRuntimeRpcErrorCode`, which — deliberately, for re-wrapped transport errors — also matches the *message*. An unknown refusal carrying a host message like `Owner check failed: method_not_found` therefore classified as **definitive** on the base: `isDefinitiveStructuredAgentSessionCreateError` returned `true` for an outcome that proves nothing. Verified by ablation (below). With the typed class, the verdict is read off the class and a message we wrote can never invert it.

3. **The end-to-end guard.** `structured-agent-session-launch-refusal-fallback.test.ts` (new; absent on the base) drives the *real* classifier through `startStructuredAgentLaunch` and counts legacy terminals through the fallback every caller uses. The base's coverage of this behaviour mocks `launch-structured-agent-session` out entirely, so it asserts the caller's contract but never the classification itself.

Making the class carry the verdict rather than adding a `definitive` flag was deliberate, and that finding **still holds after the rename** — the consumer list grew from eight sites to nine (`structured-agent-session-launch{,-recovery,-callers}.ts`, `NonGitFolderDialog.tsx`, `folder-workspace-composer-submit.ts`, `full-creation-structured-launch.ts`, `launch-work-item-direct-agent-routing.ts`, `worktree-creation-structured-session.ts`, `repo-add-actions.ts`), and because the unknown-outcome error is a *sibling* rather than a subclass, all nine `instanceof` checks keep meaning what they say with **zero edits**. A flag would have needed the same nine-site audit and left the original mistake re-makeable.

Two consequences worth naming:

- **The replay repairs the tab.** `agent_session_operation_unknown` on the create route means `publishStructuredAgentSessionTab` threw *after* the session committed. Replaying the same envelope replays the attach and re-attempts the publication, so recovery doesn't just avoid a duplicate — it usually produces the chat the user asked for.
- **An unknown outcome keeps its focus intent.** `abandonStructuredAgentSessionLaunchIntent` runs only on a definitive refusal; abandoning it on a maybe would leave a session that later publishes without focusing.

Per `CORRECTIONS.md`, `agentSessionRefusalOperationState` is deliberately **not** reused for this decision — it answers "did this durably settle?", for which `structured_agent_session_unsupported` is correctly *pending-admission*, the opposite of what the fallback needs.

## Tests

`structured-agent-session-launch-refusal-fallback.test.ts` (new, 4 cases) mocks the RPC rather than the module under test:

- `agent_session_operation_unknown` ⇒ no sibling, visibility-unknown, one error toast;
- `agent_session_ownership_unknown` ⇒ no sibling;
- unknown-then-published ⇒ the replay adopts the existing session, no sibling, no toast;
- `structured_agent_session_unsupported` ⇒ exactly one terminal and exactly one create (no pointless replay);
- plus an older runtime with no `agentSession.create` method ⇒ exactly one terminal, one call, launch state back to idle.

`launch-structured-agent-session.test.ts` gains the class assertion on the unknown outcome and the message-sniffing regression case.

**Ablation (two, both run).**

- *Collapse unknown into definitive* (every `{ ok: false }` becomes a refusal — the original defect): 5 tests go red, and with the class assertion relaxed so it can't short-circuit, the "no sibling" cases fail on `expected [ 'legacy-terminal' ] to deeply equal []`. The guard catches the duplicate session itself, not just a type name.
- *Restore the base's anonymous error* (`Object.assign(new Error(message), { code })`): exactly 4 tests go red, all on class identity — which is the honest measure of what this PR adds over the base. A targeted probe under that ablation confirms `isDefinitiveStructuredAgentSessionCreateError` returns `true` for `agent_session_ownership_unknown` with the message `Owner check failed: method_not_found`, i.e. hole (2) above is real on the base and closed here.

## Verification

`pnpm tc` clean (exit 0, run once) · 8 consumer suites / 66 tests green (renderer launch, launch-recovery, structured-chat guard, work-item routing, worktree-creation ×2, composer-state full-creation, and the new fallback suite) · `pnpm run check:code-quality:changed` — 0 new findings · `oxfmt` on changed paths only · `git status --porcelain` empty.

## Scope

Bug 1 only. Bugs 3 and 4 from the plan are out of scope here; bug 4 in particular is not desktop-inert (it also gates `restoreStructuredTabsIfSupported`) and ships separately.
