### PR TITLE
fix(relay-ops): retry a failed MIG inventory read once before calling a cell's power state unknown

### DIFF
--- a/cloud/apps/relay-ops/src/resource-inventory.test.ts
+++ b/cloud/apps/relay-ops/src/resource-inventory.test.ts
@@ -13,6 +13,41 @@ const runService = {
   latestReadyRevision: 'projects/project/revisions/revision-one'
 }
 
+const sleepingStagingGcloud: GcloudClient = { accessToken: async () => 'a'.repeat(40) }
+
+// Staging's Cloud SQL is stopped, so this inventory reads REST only and probes no endpoint.
+type MigOutcome = 'ok' | 'throw' | 'missing'
+const sleepingStagingFetch = (migOutcome: (migName: string) => MigOutcome): typeof fetch =>
+  async (input) => {
+    const url = new URL(String(input))
+    if (url.hostname === 'run.googleapis.com') return Response.json(runService)
+    if (url.hostname === 'sqladmin.googleapis.com') return Response.json({
+      state: 'STOPPED',
+      databaseVersion: 'POSTGRES_17',
+      settings: { activationPolicy: 'NEVER', availabilityType: 'ZONAL', tier: 'db-custom-1-3840' }
+    })
+    if (url.hostname === 'certificatemanager.googleapis.com') return Response.json({
+      managed: { domains: ['*.relay-staging.onorca.dev'], state: 'ACTIVE' }
+    })
+    if (url.pathname.includes('/instanceGroupManagers/')) {
+      const name = url.pathname.split('/').at(-1)!
+      const outcome = migOutcome(name)
+      if (outcome === 'throw') throw new TypeError('fetch failed')
+      if (outcome === 'missing') return new Response(null, { status: 404 })
+      return Response.json({
+        name,
+        targetSize: 0,
+        size: '0',
+        instanceGroup: `projects/project/zones/zone/instanceGroups/${name}`,
+        instanceTemplate: `projects/project/global/instanceTemplates/template-${name}`,
+        status: { isStable: true }
+      })
+    }
+    if (url.pathname.includes('/instanceTemplates/')) return Response.json({ properties: {} })
+    if (url.pathname.endsWith('/getHealth')) return Response.json([])
+    throw new Error(`Unexpected request to ${url.hostname}${url.pathname}`)
+  }
+
 describe('readResourceInventory', () => {
   it('does not delay a healthy endpoint sample', async () => {
     let calls = 0
@@ -247,6 +282,74 @@ describe('readResourceInventory', () => {
     expect(result.cells.every((cell) => cell.endpoint.health === null)).toBe(true)
     expect(result.cells.every((cell) => cell.imageDigest === digest)).toBe(true)
     expect(JSON.stringify(result)).not.toContain('SECRET_TEXT')
+  })
+
+  it('re-asks a MIG read that failed once before calling a cell powered-unknown', async () => {
+    const parkedCell = RELAY_OPS_ENVIRONMENTS.staging.cells[0]!
+    const waits: number[] = []
+    let parkedMigCalls = 0
+    const result = await readResourceInventory(
+      RELAY_OPS_ENVIRONMENTS.staging,
+      sleepingStagingGcloud,
+      sleepingStagingFetch((migName) => {
+        if (!migName.endsWith(parkedCell.hostname)) return 'ok'
+        parkedMigCalls += 1
+        return parkedMigCalls === 1 ? 'throw' : 'ok'
+      }),
+      { wait: async (ms) => { waits.push(ms) } }
+    )
+
+    const parked = result.cells.find((cell) => cell.cellId === parkedCell.cellId)!
+    // The MIG was fine and parked at zero; one transient read must not erase that reading.
+    expect(parked.targetSize).toBe(0)
+    expect(parkedMigCalls).toBe(2)
+    expect(waits).toEqual([1_000])
+    expect(result.warnings).toEqual([])
+  })
+
+  it('reports a MIG unavailable only when the retry fails too', async () => {
+    const parkedCell = RELAY_OPS_ENVIRONMENTS.staging.cells[0]!
+    const waits: number[] = []
+    let parkedMigCalls = 0
+    const result = await readResourceInventory(
+      RELAY_OPS_ENVIRONMENTS.staging,
+      sleepingStagingGcloud,
+      sleepingStagingFetch((migName) => {
+        if (!migName.endsWith(parkedCell.hostname)) return 'ok'
+        parkedMigCalls += 1
+        return 'throw'
+      }),
+      { wait: async (ms) => { waits.push(ms) } }
+    )
+
+    const parked = result.cells.find((cell) => cell.cellId === parkedCell.cellId)!
+    expect(parked.targetSize).toBeNull()
+    expect(parked.backendHealth).toBe('unknown')
+    expect(parkedMigCalls).toBe(2)
+    expect(waits).toEqual([1_000])
+    expect(result.warnings).toEqual([
+      `${parkedCell.hostname.toUpperCase()} MIG inventory is unavailable.`
+    ])
+  })
+
+  it('does not re-ask a MIG read the API answered with 404', async () => {
+    const missingCell = RELAY_OPS_ENVIRONMENTS.staging.cells[0]!
+    const waits: number[] = []
+    let missingMigCalls = 0
+    const result = await readResourceInventory(
+      RELAY_OPS_ENVIRONMENTS.staging,
+      sleepingStagingGcloud,
+      sleepingStagingFetch((migName) => {
+        if (!migName.endsWith(missingCell.hostname)) return 'ok'
+        missingMigCalls += 1
+        return 'missing'
+      }),
+      { wait: async (ms) => { waits.push(ms) } }
+    )
+
+    expect(result.cells.find((cell) => cell.cellId === missingCell.cellId)!.targetSize).toBeNull()
+    expect(missingMigCalls).toBe(1)
+    expect(waits).toEqual([])
   })
 
   it('represents missing credentials as unknown inventory, never sleeping', async () => {

--- a/cloud/apps/relay-ops/src/resource-inventory.ts
+++ b/cloud/apps/relay-ops/src/resource-inventory.ts
@@ -103,6 +103,8 @@ export type ResourceInventory = {
 const unavailableEndpoint = (): EndpointHealth => ({ health: null, ready: null, latencyMs: null })
 const independentEndpointRetryDelayMs = 11_000
 const transientProbeRetryDelayMs = 1_000
+const sleep = async (ms: number): Promise<void> =>
+  await new Promise((resolvePromise) => setTimeout(resolvePromise, ms))
 
 function finalSegment(value: string): string {
   return value.split('/').at(-1) ?? value
@@ -121,6 +123,12 @@ function parseService(value: unknown): ServiceInventory {
   }
 }
 
+class GoogleApiError extends Error {
+  constructor(readonly status: number) {
+    super(`Google API returned ${status}`)
+  }
+}
+
 async function googleRequest(
   fetchImpl: typeof fetch,
   token: string,
@@ -135,8 +143,22 @@ async function googleRequest(
     },
     signal: AbortSignal.timeout(30_000)
   })
-  if (!response.ok) throw new Error(`Google API returned ${response.status}`)
+  if (!response.ok) throw new GoogleApiError(response.status)
   return await response.json()
+}
+
+// A 404 is the API's answer about the resource; anything else is the absence of a reading, so re-ask.
+async function readOnceMore(
+  read: () => Promise<unknown>,
+  wait: (ms: number) => Promise<void>
+): Promise<unknown> {
+  try {
+    return await read()
+  } catch (error) {
+    if (error instanceof GoogleApiError && error.status === 404) throw error
+    await wait(transientProbeRetryDelayMs)
+    return await read()
+  }
 }
 
 // A reading the endpoint actually produced: ok is its answer, latencyMs is that answer's round trip.
@@ -201,8 +223,7 @@ export async function probeEndpointHealth(
   options: EndpointProbeOptions = {}
 ): Promise<EndpointHealth> {
   const requiresReady = options.requiresReady ?? true
-  const wait = options.wait ??
-    (async (ms: number) => await new Promise((resolvePromise) => setTimeout(resolvePromise, ms)))
+  const wait = options.wait ?? sleep
   const accepted = (probe: EndpointHealth): boolean =>
     probe.health === true &&
     (!requiresReady || probe.ready === true) &&
@@ -325,11 +346,17 @@ function unavailableInventory(environment: RelayOpsEnvironment, warning: string)
   }
 }
 
+export type ResourceInventoryOptions = {
+  wait?: (ms: number) => Promise<void>
+}
+
 export async function readResourceInventory(
   environment: RelayOpsEnvironment,
   gcloud: GcloudClient,
-  fetchImpl: typeof fetch = fetch
+  fetchImpl: typeof fetch = fetch,
+  options: ResourceInventoryOptions = {}
 ): Promise<ResourceInventory> {
+  const wait = options.wait ?? sleep
   let token: string
   try {
     token = await gcloud.accessToken()
@@ -356,7 +383,10 @@ export async function readResourceInventory(
       token,
       `https://certificatemanager.googleapis.com/v1/projects/${environment.project}/locations/global/certificates/${environment.certificateName}`
     ),
-    ...environment.cells.map((cell) => googleRequest(fetchImpl, token, migUrl(cell)))
+    // One transient Compute read must never become a verdict on a cell's power state.
+    ...environment.cells.map((cell) =>
+      readOnceMore(async () => await googleRequest(fetchImpl, token, migUrl(cell)), wait)
+    )
   ])
   const warnings: string[] = []
   const directorValue = parsed(settled[0]!, RunServiceSchema, 'Director service inventory is unavailable.', warnings)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |

<!-- /orca-pr-loc -->

## Production evidence

The relay incident monitor froze a 15-minute pre-drain gate at `2026-09-04T23:35:38Z` (workflow run `33928912676`) with `runtime_power_unknown` for `cell.production-gce-c11.powered`.

The MIG itself was fine: stable, `targetSize` 0, an existing-only parked cell. What failed was one Compute API read.

Chain: `readResourceInventory` fetched every cell's MIG with a single `googleRequest` inside `Promise.allSettled`. That one GET rejected, so `parsed(...)` yielded `null`, `readCell` returned `unavailableCell` with `targetSize: null`, `incident-monitor-sources.ts` set `runtimeKnown: false`, and `checkCell` turned that into a hard freeze.

One transient read is not a fleet-health verdict.

## Change

The per-cell MIG GET now retries once after 1s when the request rejects or returns a non-2xx. A definitive 404 is the API's answer about the resource, so it is not retried. When both attempts fail, the cell still becomes `unavailableCell` and the warning is still recorded, exactly as today.

`googleRequest` now throws a `GoogleApiError` carrying the HTTP status so the caller can tell an answer from a hiccup. Director, auth, Cloud SQL, and certificate reads are unchanged.

This mirrors #18723, which added the same no-reading-is-not-a-reading retry to `probePath`.

`readResourceInventory` takes an optional `wait` so tests do not sleep; it defaults to real `setTimeout`, shared now with `probeEndpointHealth`.

## Tests

Three new cases in `resource-inventory.test.ts`, all against sleeping staging so no endpoint probe runs:

- First MIG GET rejects, second succeeds. The cell reads `targetSize: 0` rather than `null`, exactly the c11 shape, with two GETs, one 1s wait, and no warning.
- Both GETs reject. The cell is unavailable with `backendHealth: 'unknown'` and the `MIG inventory is unavailable.` warning, as today.
- A 404 is not retried: one GET, no wait.

The first two fail on the unpatched source (verified by reverting the retry call and re-running). Full suite: 84 passed, 12 files. `typecheck` clean.
