### PR TITLE
fix(native-chat): render Claude structured chat through the same UI as Codex

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.test.tsx
@@ -6,7 +6,6 @@ import type {
   SessionOptionDescriptor,
   SessionOptionsSurface
 } from '../../../../shared/native-chat-session-options'
-import type * as nativeChatAgentProfiles from '../../../../shared/native-chat-agent-profiles'
 import { clearNativeChatSessionOptionCacheForTests } from './native-chat-session-option-cache'
 import { clearNativeChatModelEnrichmentForTests } from './native-chat-session-option-enrichment'
 
@@ -27,6 +26,7 @@ const mocks = vi.hoisted(() => ({
     sessionOptionsSnapshot?: SessionOptionDescriptor[]
     attachDisabled?: boolean
     sendButtonDisabled?: boolean
+    autocomplete?: { mode: string; items?: { kind: string; name: string }[] }
   } | null,
   modelSwitchOutcome: 'applied' as 'applied' | 'rejected' | 'unknown',
   confirmationObserver: null as {
@@ -89,10 +89,6 @@ vi.mock('./native-chat-runtime-image-send', () => ({
 vi.mock('./claude-model-switch-confirmation', () => ({
   createClaudeModelSwitchConfirmationObserver: (...args: unknown[]) =>
     mocks.createClaudeModelSwitchConfirmationObserver(...args)
-}))
-vi.mock('../../../../shared/native-chat-agent-profiles', async (importOriginal) => ({
-  ...(await importOriginal<typeof nativeChatAgentProfiles>()),
-  getVerifiedNativeChatCommands: () => []
 }))
 vi.mock('@/lib/native-chat-telemetry', () => ({
   emitNativeChatMessageSent: vi.fn(),
@@ -306,6 +302,43 @@ describe('NativeChatComposer', () => {
     expect(send).toHaveBeenCalledWith('hello', [])
     expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
     expect(mocks.setDraft).toHaveBeenCalledWith('')
+  })
+
+  // The structured slash menu must offer the running agent's own catalog. Offering
+  // another agent's tokens sends them past the command guard as literal prompt text.
+  it.each([
+    ['claude', 'compact', 'vim'],
+    ['codex', 'vim', 'help']
+  ] as const)('offers %s its own structured slash commands', (agent, offered, withheld) => {
+    mocks.draft = '/'
+    render(
+      <NativeChatComposer
+        terminalTabId="tab-1"
+        paneKey={`tab-1:structured-${agent}`}
+        targetPtyId={null}
+        agent={agent}
+        structuredTransport={{
+          send: vi.fn(() => true),
+          dispatchCommand: vi.fn(async () => ({ handled: false, accepted: false, error: null })),
+          optionsSurface: {
+            getSnapshot: () => [],
+            setOption: vi.fn(),
+            invokeAction: vi.fn(),
+            subscribe: () => () => {}
+          },
+          optionSnapshot: [],
+          onError: vi.fn(),
+          runtime: 'local'
+        }}
+      />
+    )
+
+    const names = (mocks.fieldProps?.autocomplete?.items ?? [])
+      .filter((item) => item.kind === 'command')
+      .map((item) => item.name)
+    expect(names).toContain(offered)
+    expect(names).toContain('effort')
+    expect(names).not.toContain(withheld)
   })
 
   it('sends structured image attachments through the durable transport', async () => {

--- a/src/renderer/src/components/native-chat/NativeChatComposer.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposer.tsx
@@ -3,7 +3,7 @@ import { useAppStore } from '../../store'
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
-import { STRUCTURED_AGENT_SESSION_SLASH_COMMANDS } from '../../../../shared/structured-agent-session-composer'
+import { structuredSlashCommands } from '../../../../shared/structured-agent-session-composer'
 import {
   applyMentionSuggestion,
   EMPTY_HISTORY,
@@ -111,9 +111,7 @@ const NativeChatComposerPane = forwardRef<NativeChatComposerHandle, NativeChatCo
 
     const agentCommands = useMemo(
       () =>
-        structuredTransport
-          ? STRUCTURED_AGENT_SESSION_SLASH_COMMANDS
-          : getVerifiedNativeChatCommands(agent),
+        structuredTransport ? structuredSlashCommands(agent) : getVerifiedNativeChatCommands(agent),
       [agent, structuredTransport]
     )
     const picker = useNativeChatPickerState({

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -200,7 +200,7 @@ export function NativeChatMessageList({
   onLinkClick?: CommentMarkdownLinkClickHandler
   allowFileUriLinks?: boolean
   failedDeliveryMessageIds?: ReadonlySet<string>
-  /** Turn timing/disclosure is available only on the structured Codex lane. */
+  /** Turn timing and disclosure are available on structured agent sessions. */
   showTurnStatus?: boolean
   runtimeContext?: RuntimeFileOperationArgs | null
 }): React.JSX.Element {

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   messageListProps: null as null | {
     allowFileUriLinks?: boolean
     onLinkClick?: (...args: unknown[]) => void
+    showTurnStatus?: boolean
+    runtimeContext?: unknown
   },
   composerProps: null as null | { structuredTransport?: Record<string, unknown> },
   questionCardProps: null as NativeChatQuestionCardProps | null,
@@ -189,6 +191,27 @@ describe('NativeChatStructuredSession', () => {
     expect(mocks.messageListProps?.allowFileUriLinks).toBe(true)
     expect(mocks.messageListProps?.onLinkClick).toBe(mocks.fileLinkClick)
   })
+
+  // Turn status and transcript image previews shipped Codex-first. Every
+  // structured session renders through the same list, so neither is agent-gated.
+  it.each(['codex', 'claude'] as const)(
+    'renders the same structured transcript chrome for %s',
+    (agent) => {
+      render(
+        <NativeChatStructuredSession
+          isVisible
+          tabId="structured-tab-parity"
+          sessionId="session-parity"
+          target={{ kind: 'local' }}
+          agent={agent}
+          allowFileUriLinks
+        />
+      )
+
+      expect(mocks.messageListProps?.showTurnStatus).toBe(true)
+      expect(mocks.messageListProps?.runtimeContext).not.toBeUndefined()
+    }
+  )
 
   it('routes a bare model command to the native option picker', async () => {
     render(

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -166,10 +166,10 @@ export function NativeChatStructuredSession(
             expandSignal={false}
             fontScale={fontScale.scale}
             workingStartedAt={null}
-            showTurnStatus={props.agent === 'codex'}
+            showTurnStatus
             onLinkClick={fileLinkClick}
             allowFileUriLinks={fileLinkClick !== undefined}
-            runtimeContext={props.agent === 'codex' ? imageRuntimeContext : undefined}
+            runtimeContext={imageRuntimeContext}
           />
         )}
       </div>

--- a/src/shared/structured-agent-session-composer.test.ts
+++ b/src/shared/structured-agent-session-composer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isStructuredAgentSessionComposerCommand,
+  structuredSlashCommands
+} from './structured-agent-session-composer'
+
+describe('structuredSlashCommands', () => {
+  // The composer menu and the dispatcher read this one list. When they disagreed,
+  // a Claude session was offered Codex-only tokens that missed the command guard
+  // and reached the model as literal prompt text instead of erroring.
+  it.each(['codex', 'claude'] as const)('offers %s only commands it also accepts', (agent) => {
+    const offered = structuredSlashCommands(agent)
+    expect(offered.length).toBeGreaterThan(0)
+    for (const command of offered) {
+      expect(isStructuredAgentSessionComposerCommand(`/${command.name}`, agent)).toBe(true)
+    }
+  })
+
+  it('offers each agent its own catalog', () => {
+    const claude = structuredSlashCommands('claude').map((command) => command.name)
+    expect(claude).toContain('compact')
+    expect(claude).not.toContain('vim')
+    expect(structuredSlashCommands('codex').map((command) => command.name)).toContain('vim')
+  })
+
+  it('offers effort to every structured agent', () => {
+    for (const agent of ['codex', 'claude'] as const) {
+      expect(structuredSlashCommands(agent).map((command) => command.name)).toContain('effort')
+    }
+  })
+})

--- a/src/shared/structured-agent-session-composer.ts
+++ b/src/shared/structured-agent-session-composer.ts
@@ -35,7 +35,10 @@ function commandParts(text: string): { name: string; argument: string } | null {
   return match ? { name: match[1]!.toLowerCase(), argument: match[2]?.trim() ?? '' } : null
 }
 
-function structuredSlashCommands(agent: AgentType): readonly SlashCommandSuggestion[] {
+/** The command catalog a structured session offers and accepts. The composer menu
+ *  and the dispatcher must read the same list, or a menu pick falls through the
+ *  command guard and reaches the model as literal prompt text. */
+export function structuredSlashCommands(agent: AgentType): readonly SlashCommandSuggestion[] {
   if (agent === 'codex') {
     return STRUCTURED_AGENT_SESSION_SLASH_COMMANDS
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Claude's Chat UI sessions were missing the nice chrome that Codex sessions have — the "Worked for 5s" row, the live "Running …" tool line, image previews — and its `/` menu listed Codex's commands. All three were hardcoded to Codex. This removes the hardcoding so Claude runs through the exact same code.

## What Changed

Structured native chat is already one shared, agent-agnostic component tree. Three Codex-hardcoded terms on that path made a Claude session render differently:

| Location | Was | Now |
|---|---|---|
| `NativeChatStructuredSession.tsx` | `showTurnStatus={props.agent === 'codex'}` | `showTurnStatus` |
| `NativeChatStructuredSession.tsx` | `runtimeContext={props.agent === 'codex' ? … : undefined}` | `runtimeContext={imageRuntimeContext}` |
| `NativeChatComposer.tsx` | `STRUCTURED_AGENT_SESSION_SLASH_COMMANDS` (Codex catalog) | `structuredSlashCommands(agent)` |

`showTurnStatus` is not a small flag — it gates the whole structured presentation: the live tool-progress row, the completion check and activity grouping (`structuredActivityUi`), and the Thinking / Working for N / Worked for N rows. `runtimeContext` gates transcript image previews.

No new rendering logic — two gates deleted and one **existing** shared function reused. There are now zero `agent === 'codex' | 'claude'` branches in any `native-chat` component.

## Why

The first two gates landed Codex-first in #17597 (commit: *"limit turn status UI to structured Codex"*) and #18266, both **before** the Claude structured lane existed (#18560). They were rollout scoping, not capability limits — neither `useNativeChatTurnStatus` nor `useNativeChatImageRuntimeContext` has any agent-specific logic.

The slash menu was a live defect, not just cosmetics. The menu ignored `agent` while the dispatcher `structuredSlashCommands(agent)` did branch. So Codex-only tokens offered in a Claude session (`/vim`, `/pets`, `/mcp`, `/permissions`, `/subagents`) missed the command guard, returned `handled: false`, and fell through to `transport.send()` — picking `/vim` sent the literal string "/vim" to the model as a chat turn. The same pick on Codex correctly shows "not available in chat sessions." Menu and dispatcher now read one list.

## Linked Issue

No existing issue covers this — I searched open/closed issues for Claude structured chat UI parity and found none. Happy to file one if you'd like it tracked.

Fixes #

## Visual Proof

Same Claude conversation, toggling only this change via HMR. See comment below for images.

- **Transcript BEFORE**: no turn-status row at all; the tool run sits bare as `1× Bash cat …`, always visible.
- **Transcript AFTER**: `Worked for 5s ›` disclosure, with the activity tucked behind it — the Codex behavior.
- **Slash menu BEFORE**: Codex's catalog (`/model`, `/vim`, `/pets`, `/permissions` …) in a Claude session.
- **Slash menu AFTER**: Claude's own (`/clear /compact /init /review /help`) plus `/effort`.

## Testing

Automated — ablation-proven: reverting each fix turns its test red **on `claude` only** while `codex` stays green, so the tests bind to the real mechanism.

- `NativeChatStructuredSession.test.tsx` — `it.each(['codex','claude'])` asserts identical transcript chrome props
- `NativeChatComposer.test.tsx` — `it.each` asserts each agent is offered its own catalog and not the other's
- `src/shared/structured-agent-session-composer.test.ts` (new) — menu/dispatcher agreement invariant

`pnpm test src/renderer/src/components/native-chat src/shared/…`: **1004 passing / 101 files**. `tc:node` and `tc:web` exit 0. Changed-code quality gate clean.

Manual — macOS, isolated dev instance under CDP, real Claude Agent SDK session (verified `contentType: agent-session`, `agent: claude`):

- turn status across a live turn: `Thinking` → `Working for 3s/6s/9s` → settles `Worked for 11s`
- live tool row captured mid-turn: pulsing `aria-live` **`Running echo four`**
- settled activity group: check-mark, `1×` count, expands to `Bash` + command and `Result` + output
- slash menu: Claude catalog only; asserted `vim/pets/mcp/permissions/subagents` all absent
- image preview: pasted image renders as an 80px thumbnail in the bubble (not a filename chip) and Claude read it

Not tested: Linux, Windows, SSH/remote (structured chat is gated to `executionHostId === 'local'`). Approval/question cards are covered by unit tests only — I couldn't get Claude to trigger one live.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Reviewers may want to weigh in on one intentional behavior change: **completed Claude tool runs now collapse behind the turn disclosure** instead of always showing. That is the Codex rule and the point of the change, but it is the most visible difference for existing Claude Chat users.

Adapter-side gaps deliberately **out of scope** here (they need new Claude translator code, not UI changes):
- Claude emits no `kind: 'diff'` items, so an `Edit` renders inside the collapsed tool line rather than a dedicated Diff row
- Claude emits `image-ref` only for `url` sources, not local paths, so local-path previews stay chips
- no exit/interruption settlement, so a killed Claude leaves tool rows spinning

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: none — no new data flows, no IPC or wire changes.
- **Cross-platform**: no platform-dependent code touched; structured chat is local-host gated. The Codex Windows refusal at `agent-launch-routing.ts` is untouched.
- **Remote SSH**: unaffected — structured sessions require `executionHostId === 'local'`.
- **Mobile**: unaffected — `showTurnStatus`/`structuredActivityUi` are desktop-only components; no mobile file changed.
- **Backwards compatibility**: no wire, RPC, or journal schema change. Both adapters already normalize into the same `AgentJournalItemBody` model, and unknown frames already share `unhandledProviderFrameJournalItem`.
- **Performance**: strictly fewer branches; `useNativeChatImageRuntimeContext` was already called unconditionally, only its result was discarded.

One test-scaffolding note for reviewers: proving the composer fix required deleting a `getVerifiedNativeChatCommands: () => []` mock in `NativeChatComposer.test.tsx`. The Codex catalog constant is frozen at module load, so a per-test override can't reach it. All pre-existing tests in that file still pass against the real catalogs.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
