### PR TITLE
fix(status-bar): refresh inactive Claude account usage on popover open and Refresh

### DIFF
--- a/src/renderer/src/components/status-bar/ClaudeSwitcherMenu.tsx
+++ b/src/renderer/src/components/status-bar/ClaudeSwitcherMenu.tsx
@@ -114,14 +114,20 @@ export function ClaudeSwitcherMenu({
     })
   }, [loadAccounts, claudeAccountSyncKey])
 
-  const handleOpenChange = useCallback((nextOpen: boolean): void => {
-    setOpen(nextOpen)
-    if (!nextOpen) {
-      setAccountsExpanded(false)
-    }
-  }, [])
+  // Why: the popover is where saved accounts get compared, so fill their usage on open, not only on
+  // "Switch to" expansion (#14833). The service debounces repeats; remote-owned accounts have no local cache to fill.
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean): void => {
+      setOpen(nextOpen)
+      if (!nextOpen) {
+        setAccountsExpanded(false)
+      } else if (!hasActiveRuntimeEnvironment) {
+        void fetchInactiveClaudeAccountUsage()
+      }
+    },
+    [fetchInactiveClaudeAccountUsage, hasActiveRuntimeEnvironment]
+  )
 
-  // Why: fetch inactive-account usage only on switcher expansion; remote-owned accounts have no local cache to fill.
   const handleAccountsExpandedToggle = useCallback((): void => {
     const nextExpanded = !accountsExpanded
     setAccountsExpanded(nextExpanded)

--- a/src/renderer/src/components/status-bar/use-status-bar-controller-refresh.test.tsx
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller-refresh.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { useAppStore } from '../../store'
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useShortcutLabel: () => ''
+}))
+
+vi.mock('./ProviderDetailsMenu', () => ({
+  CLOSE_ALL_CONTEXT_MENUS_EVENT: 'close-all-context-menus',
+  useStatusBarMenuFocusHandoff: () => ({
+    reset: () => {},
+    onPointerDownOutside: () => {},
+    onCloseAutoFocus: () => {}
+  })
+}))
+
+vi.mock('./status-bar-container-observer', () => ({
+  observeStatusBarContainer: () => ({ disconnect: () => {} })
+}))
+
+import { useStatusBarController } from './use-status-bar-controller'
+
+const initialState = useAppStore.getState()
+
+const mocks = {
+  refreshRateLimits: vi.fn(async () => {}),
+  refreshDetectedAgents: vi.fn(async () => []),
+  // Why: the controller ensures agent detection on mount; keep that out of the refresh assertions.
+  ensureDetectedAgents: vi.fn(async () => []),
+  fetchInactiveClaudeAccountUsage: vi.fn(async () => {}),
+  fetchInactiveCodexAccountUsage: vi.fn(async () => {})
+}
+
+describe('useStatusBarController refresh', () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) {
+      mock.mockClear()
+    }
+    useAppStore.setState({
+      settings: getDefaultSettings('/tmp'),
+      ...mocks
+    })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState, true)
+  })
+
+  it('refreshes saved-but-inactive accounts along with the active providers (#14833)', async () => {
+    const { result } = renderHook(() => useStatusBarController(false))
+
+    await act(async () => {
+      await result.current!.handleRefresh()
+    })
+
+    expect(mocks.refreshRateLimits).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshDetectedAgents).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchInactiveClaudeAccountUsage).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchInactiveCodexAccountUsage).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves inactive-account caches alone while a remote environment owns the accounts', async () => {
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'env-1' }
+    })
+    const { result } = renderHook(() => useStatusBarController(false))
+
+    await act(async () => {
+      await result.current!.handleRefresh()
+    })
+
+    expect(mocks.refreshRateLimits).toHaveBeenCalledTimes(1)
+    expect(mocks.fetchInactiveClaudeAccountUsage).not.toHaveBeenCalled()
+    expect(mocks.fetchInactiveCodexAccountUsage).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/status-bar/use-status-bar-controller-refresh.test.tsx
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller-refresh.test.tsx
@@ -62,6 +62,25 @@ describe('useStatusBarController refresh', () => {
     expect(mocks.fetchInactiveCodexAccountUsage).toHaveBeenCalledTimes(1)
   })
 
+  it('does not hold the spinner on the staggered inactive probes', async () => {
+    let releaseCodexProbe: () => void = () => {}
+    mocks.fetchInactiveCodexAccountUsage.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseCodexProbe = resolve
+        })
+    )
+    const { result } = renderHook(() => useStatusBarController(false))
+
+    await act(async () => {
+      await result.current!.handleRefresh()
+    })
+
+    // Active providers are done, so refreshing is over even though the Codex probe is still running.
+    expect(result.current!.isRefreshing).toBe(false)
+    releaseCodexProbe()
+  })
+
   it('leaves inactive-account caches alone while a remote environment owns the accounts', async () => {
     useAppStore.setState({
       settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'env-1' }

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -89,16 +89,15 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     }
     setIsRefreshing(true)
     try {
+      // Why: saved-but-inactive accounts refresh too (#14833), but fire-and-forget like the
+      // switcher does: the Codex probes are staggered per account and must not hold the spinner.
+      // The service's on-open debounce bounds them; remote-owned accounts have no local cache to fill.
+      if (!hasActiveRuntimeEnvironment) {
+        void fetchInactiveClaudeAccountUsage()
+        void fetchInactiveCodexAccountUsage()
+      }
       // Why: re-run PATH detection so a freshly-installed/removed CLI's bar appears/hides without restarting Orca.
-      // Saved-but-inactive accounts refresh too (#14833); the service's on-open debounce still bounds the probes,
-      // and remote-owned accounts have no local cache to fill.
-      await Promise.all([
-        refreshRateLimits(),
-        refreshDetectedAgents(),
-        ...(hasActiveRuntimeEnvironment
-          ? []
-          : [fetchInactiveClaudeAccountUsage(), fetchInactiveCodexAccountUsage()])
-      ])
+      await Promise.all([refreshRateLimits(), refreshDetectedAgents()])
     } finally {
       if (mountedRef.current) {
         setIsRefreshing(false)

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -80,6 +80,9 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   }, [])
 
   const refreshDetectedAgents = useAppStore((s) => s.refreshDetectedAgents)
+  const fetchInactiveClaudeAccountUsage = useAppStore((s) => s.fetchInactiveClaudeAccountUsage)
+  const fetchInactiveCodexAccountUsage = useAppStore((s) => s.fetchInactiveCodexAccountUsage)
+  const hasActiveRuntimeEnvironment = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
   const handleRefresh = useCallback(async () => {
     if (isRefreshing) {
       return
@@ -87,13 +90,28 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     setIsRefreshing(true)
     try {
       // Why: re-run PATH detection so a freshly-installed/removed CLI's bar appears/hides without restarting Orca.
-      await Promise.all([refreshRateLimits(), refreshDetectedAgents()])
+      // Saved-but-inactive accounts refresh too (#14833); the service's on-open debounce still bounds the probes,
+      // and remote-owned accounts have no local cache to fill.
+      await Promise.all([
+        refreshRateLimits(),
+        refreshDetectedAgents(),
+        ...(hasActiveRuntimeEnvironment
+          ? []
+          : [fetchInactiveClaudeAccountUsage(), fetchInactiveCodexAccountUsage()])
+      ])
     } finally {
       if (mountedRef.current) {
         setIsRefreshing(false)
       }
     }
-  }, [isRefreshing, refreshRateLimits, refreshDetectedAgents])
+  }, [
+    isRefreshing,
+    refreshRateLimits,
+    refreshDetectedAgents,
+    fetchInactiveClaudeAccountUsage,
+    fetchInactiveCodexAccountUsage,
+    hasActiveRuntimeEnvironment
+  ])
 
   if (!statusBarVisible) {
     return null


### PR DESCRIPTION
## ELI5

Orca only looked up the usage of your other saved Claude accounts when you expanded the "Switch to" list. Opening the Claude usage popover or pressing Refresh did nothing for them, so they stayed blank or showed old numbers. Now both of those also ask for the saved accounts' usage.

## What Changed

- `ClaudeSwitcherMenu.tsx`: opening the Claude popover calls `fetchInactiveClaudeAccountUsage` (same gate as the "Switch to" expansion: skipped while a remote environment owns the accounts). The expansion trigger stays; the service's 60 s on-open debounce makes the second call a no-op.
- `use-status-bar-controller.ts`: the status bar Refresh button also runs `fetchInactiveClaudeAccountUsage` and `fetchInactiveCodexAccountUsage`, under the same remote-environment gate. Codex is included because Refresh is provider-wide; its inactive probes keep their own 60 s debounce and stagger in the service.
- New test `use-status-bar-controller-refresh.test.tsx` (real store, `renderHook`): Refresh fans out to both inactive fetches locally, and leaves them alone when `activeRuntimeEnvironmentId` is set.

## Why

Point 6 of #14833: "Fetch inactive accounts when the user opens Switch to, when they open the Usage popover, and on explicit refresh — not only on switcher expand." The main-side fetch already exists with its own debounce, so this is two call sites, no new polling.

## Linked Issue

Part of #14833 (point 6). Does not close it.

## Visual Proof

N/A: no visible element changes; the existing rows fill in earlier. The popover-open path reuses the exact call the "Switch to" expansion already makes.

## Testing

Platforms: Windows 11 (local). Renderer-only, platform-neutral.

- `vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar`: 52 files, 338 tests passed (includes the 2 new).
- `pnpm tc:web`: clean. `oxlint` and `oxfmt --check` on the three changed files: clean.
- `pnpm build:desktop`: exit 0 (full typecheck, relay, CLI, electron-vite, web projection).
- Not covered by a test: the popover-open call in `ClaudeSwitcherMenu`. The component is not rendered in isolation anywhere in the suite today, and it is a one-line addition to an existing handler with the same gate as the expansion path.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implementation and tests by Claude (Fable 5.1) via Claude Code, driven and verified by me.

## Review

Agent code-review summary:

- **Cross-platform**: none; renderer store calls only.
- **SSH / remote**: both call sites skip when `activeRuntimeEnvironmentId` is set, matching the existing expansion trigger, because remote-owned accounts have no local cache to fill.
- **Agents / integrations**: Claude popover open touches Claude only; Refresh touches Claude and Codex inactive caches. The Codex probe spawns a real `codex` per inactive account, which is why it keeps the service-side debounce and stagger; Refresh within 60 s of a previous probe is a no-op.
- **Performance**: no new timers. Worst case one extra usage GET per inactive Claude account per minute if the user keeps reopening the popover; the usage endpoint's 429 handling in the service already covers that.
- **UI**: no change.
- **Security**: none.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Review follow-up (c47dcac): the inactive fetches are fired without awaiting, so the Refresh spinner tracks only the active-provider refresh.

Independent of #18732 and #18736 (separate call sites). With #18732 the fetch actually succeeds for expired tokens; with #18736 a failed fetch shows a reason instead of a blank row.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

X: @EnricoPin
