### PR TITLE
perf(renderer): index four projections that rescanned their inputs per keystroke

### DIFF
--- a/config/scripts/renderer-quadratic-scan-benchmark.mjs
+++ b/config/scripts/renderer-quadratic-scan-benchmark.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+// Benchmarks four renderer projections that scaled worse than linearly with user data, each on a
+// path that reruns per keystroke or per store write.
+//
+// Scenarios 1, 3 and 4 time the production export against a hand-written reproduction of the
+// pre-change shape and assert both agree first. Scenario 2 is MODELLED on both sides: the
+// projection lives inside the `useTabGroupItemProjections` React hook and cannot be imported
+// without a renderer, so it reproduces the before/after loops rather than driving production.
+import { spawnSync } from 'node:child_process'
+import { transformSync } from 'esbuild'
+import { performance } from 'node:perf_hooks'
+import fs from 'node:fs'
+import nodeModule from 'node:module'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+if (!process.execArgv.includes('--experimental-transform-types')) {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', import.meta.filename],
+    { stdio: 'inherit' }
+  )
+  process.exit(result.status ?? 1)
+}
+
+const ROOT = path.resolve(import.meta.dirname, '../..')
+const RENDERER = path.join(ROOT, 'src/renderer/src')
+
+nodeModule.registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (!context.parentURL) {
+      return nextResolve(specifier, context)
+    }
+    const candidates = specifier.startsWith('@/')
+      ? ['.ts', '.tsx', '/index.ts', '/index.tsx', ''].map(
+          (suffix) => path.join(RENDERER, specifier.slice(2)) + suffix
+        )
+      : specifier.startsWith('.') && !/\.[cm]?[jt]sx?$/.test(specifier)
+        ? ['.ts', '.tsx'].map((suffix) =>
+            fileURLToPath(new URL(specifier + suffix, context.parentURL))
+          )
+        : []
+    const resolved = candidates.find((file) => fs.existsSync(file) && fs.statSync(file).isFile())
+    return resolved
+      ? { url: pathToFileURL(resolved).href, shortCircuit: true }
+      : nextResolve(specifier, context)
+  },
+  // Node strips types from .ts but not .tsx; the sidebar row model transitively imports icons.
+  load(url, context, nextLoad) {
+    if (url.endsWith('.tsx')) {
+      const source = fs.readFileSync(fileURLToPath(url), 'utf8')
+      const { code } = transformSync(source, { loader: 'tsx', format: 'esm', jsx: 'automatic' })
+      return { format: 'module', source: code, shortCircuit: true }
+    }
+    if (url.endsWith('.json') && !url.includes('/node_modules/')) {
+      const source = fs.readFileSync(fileURLToPath(url), 'utf8')
+      return { format: 'module', source: `export default ${source}`, shortCircuit: true }
+    }
+    return nextLoad(url, context)
+  }
+})
+
+const importRenderer = (relativePath) =>
+  import(pathToFileURL(path.join(RENDERER, relativePath)).href)
+
+function envInt(name, fallback) {
+  const value = Number(process.env[name] ?? fallback)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${value}`)
+  }
+  return value
+}
+
+const KEYSTROKES = envInt('ORCA_QUADRATIC_BENCH_KEYSTROKES', 12)
+const WORKTREES = envInt('ORCA_QUADRATIC_BENCH_WORKTREES', 300)
+const TABS = envInt('ORCA_QUADRATIC_BENCH_TABS', 60)
+const OPEN_FILES = envInt('ORCA_QUADRATIC_BENCH_OPEN_FILES', 120)
+const CHANGED_FILES = envInt('ORCA_QUADRATIC_BENCH_CHANGED_FILES', 5000)
+const SIDEBAR_ROWS = envInt('ORCA_QUADRATIC_BENCH_SIDEBAR_ROWS', 600)
+const SIDEBAR_REPOS = envInt('ORCA_QUADRATIC_BENCH_SIDEBAR_REPOS', 80)
+if (SIDEBAR_REPOS > SIDEBAR_ROWS) {
+  throw new Error(
+    'ORCA_QUADRATIC_BENCH_SIDEBAR_REPOS must not exceed ORCA_QUADRATIC_BENCH_SIDEBAR_ROWS'
+  )
+}
+
+function timeRounds(run, rounds = 7) {
+  run()
+  const samples = Array.from({ length: rounds }, () => {
+    const start = performance.now()
+    run()
+    return performance.now() - start
+  }).sort((left, right) => left - right)
+  return samples[Math.floor(rounds / 2)]
+}
+
+function repeat(times, run) {
+  return () => {
+    let last
+    for (let round = 0; round < times; round += 1) {
+      last = run()
+    }
+    return last
+  }
+}
+
+const results = []
+function compare({ label, scale, drives, before, after }) {
+  if (JSON.stringify(before()) !== JSON.stringify(after())) {
+    throw new Error(`${label}: baseline disagreed with the indexed shape`)
+  }
+  results.push({ label, scale, drives, beforeMs: timeRounds(before), afterMs: timeRounds(after) })
+}
+
+// ------------------------------------------------- 1. workspace board search index
+
+const { buildWorkspaceBoardPaletteDocuments, matchWorkspaceBoardWorktrees } = await importRenderer(
+  'components/sidebar/workspace-kanban-search.ts'
+)
+
+const repoMap = new Map([
+  ['repo-1', { id: 'repo-1', name: 'orca', path: '/tmp/orca', branch: 'main' }]
+])
+const boardWorktrees = Array.from({ length: WORKTREES }, (_, index) => ({
+  id: `repo-1::/tmp/worktree-${index}`,
+  repoId: 'repo-1',
+  path: `/tmp/worktree-${index}`,
+  branch: `feature/search-target-${index}`,
+  title: `Workspace ${index} search target`,
+  isMain: false
+}))
+const queries = Array.from({ length: KEYSTROKES }, (_, index) => 'search'.slice(0, (index % 6) + 1))
+const matchAll = (documents) =>
+  queries.map((query) => [
+    ...matchWorkspaceBoardWorktrees({ worktrees: boardWorktrees, query, repoMap, documents })
+  ])
+
+compare({
+  label: 'workspace board filter (per keystroke burst)',
+  scale: `${WORKTREES} worktrees x ${KEYSTROKES} keystrokes`,
+  drives: 'production',
+  // Omitting `documents` is the pre-change shape: the index is rebuilt inside every match.
+  before: () => matchAll(undefined),
+  // The hook memoizes the index on [worktrees, repoMap]; only the match reruns per keystroke.
+  after: () => matchAll(buildWorkspaceBoardPaletteDocuments({ worktrees: boardWorktrees, repoMap }))
+})
+
+// ------------------------------------------------- 2. tab-group projections (modelled)
+
+const groupTabs = Array.from({ length: TABS }, (_, index) => ({
+  id: `tab-${index}`,
+  entityId: `entity-${index}`,
+  contentType: index % 3 === 0 ? 'editor' : 'terminal'
+}))
+const openFiles = Array.from({ length: OPEN_FILES }, (_, index) => ({
+  id: `entity-${index}`,
+  path: `/tmp/file-${index}.ts`
+}))
+const tabOrder = groupTabs.map((tab) => tab.id)
+// Production memoizes each index on its own source list, so a unified-tab write reuses it.
+const openFileById = new Map(openFiles.map((item) => [item.id, item]))
+const groupTabById = new Map(groupTabs.map((item) => [item.id, item]))
+
+function tabProjections(findOpenFile, findGroupTab) {
+  const editorItems = groupTabs
+    .filter((item) => item.contentType === 'editor')
+    .map((item) => findOpenFile(item.entityId))
+    .filter((file) => file !== undefined)
+  const order = tabOrder.map((itemId) => findGroupTab(itemId)?.entityId ?? itemId)
+  return [editorItems, order]
+}
+
+compare({
+  label: 'tab-group projections (per unified-tab write)',
+  scale: `${TABS} tabs x ${OPEN_FILES} open files`,
+  drives: 'modelled',
+  before: repeat(200, () =>
+    tabProjections(
+      (id) => openFiles.find((candidate) => candidate.id === id),
+      (id) => groupTabs.find((candidate) => candidate.id === id)
+    )
+  ),
+  after: repeat(200, () =>
+    tabProjections(
+      (id) => openFileById.get(id),
+      (id) => groupTabById.get(id)
+    )
+  )
+})
+
+// ------------------------------------------------- 3. source-control tree build
+
+const { buildSourceControlTree } = await importRenderer(
+  'components/right-sidebar/source-control-tree.ts'
+)
+const { normalizeRelativePath } = await importRenderer('lib/path.ts')
+const { splitPathSegments } = await importRenderer('components/right-sidebar/path-tree.ts')
+const { compareFileNames } = await import(
+  pathToFileURL(path.join(ROOT, 'src/shared/file-name-sort.ts')).href
+)
+
+const changedEntries = Array.from({ length: CHANGED_FILES }, (_, index) => ({
+  path: `src/area-${index % 20}/module-${index % 60}/nested/deep/part-${index % 7}/file-${index}.ts`
+}))
+
+// Pre-change `buildSourceControlTree`: identical except each ancestor path is re-joined.
+function buildSourceControlTreeBefore(area, entries) {
+  const makeDirectory = (dirPath, name, depth) => ({
+    type: 'directory',
+    key: `dir::${area}::${dirPath}`,
+    name,
+    path: dirPath,
+    area,
+    depth,
+    fileCount: 0,
+    children: [],
+    directoryChildren: new Map()
+  })
+  const root = makeDirectory('', '', -1)
+  for (const entry of entries) {
+    const normalizedPath = normalizeRelativePath(entry.path)
+    const segments = splitPathSegments(normalizedPath)
+    if (segments.length === 0) {
+      continue
+    }
+    let parent = root
+    for (let index = 0; index < segments.length - 1; index += 1) {
+      const name = segments[index]
+      const dirPath = segments.slice(0, index + 1).join('/')
+      let dir = parent.directoryChildren.get(name)
+      if (!dir) {
+        dir = makeDirectory(dirPath, name, index)
+        parent.directoryChildren.set(name, dir)
+        parent.children.push(dir)
+      }
+      parent = dir
+    }
+    parent.children.push({
+      type: 'file',
+      key: `${area}::${entry.path}`,
+      name: segments.at(-1),
+      path: normalizedPath,
+      entry,
+      area,
+      depth: segments.length - 1
+    })
+  }
+  const finalize = (node) => {
+    const directories = node.children.filter((child) => child.type === 'directory').map(finalize)
+    const files = node.children.filter((child) => child.type === 'file')
+    directories.sort((a, b) => compareFileNames(a.name, b.name))
+    files.sort((a, b) => compareFileNames(a.entry.path, b.entry.path))
+    const { directoryChildren: _, ...rest } = node
+    return {
+      ...rest,
+      fileCount: files.length + directories.reduce((count, dir) => count + dir.fileCount, 0),
+      children: [...directories, ...files]
+    }
+  }
+  return finalize(root).children
+}
+
+compare({
+  label: 'source-control tree build (per filter keystroke)',
+  scale: `${CHANGED_FILES} changed files`,
+  drives: 'production',
+  before: () => buildSourceControlTreeBefore('unstaged', changedEntries),
+  after: () => buildSourceControlTree('unstaged', changedEntries)
+})
+
+// ------------------------------------------------- 4. sidebar header boundaries
+
+const { getRepoHeaderSectionEndByRepoId } = await importRenderer(
+  'components/sidebar/worktree-header-section-boundaries.ts'
+)
+const { estimateRenderRowSize } = await importRenderer(
+  'components/sidebar/worktree-list/viewport/virtual-rows.ts'
+)
+
+const headerRowIndexes = new Set(
+  Array.from({ length: SIDEBAR_REPOS }, (_, repo) =>
+    Math.floor((repo * SIDEBAR_ROWS) / SIDEBAR_REPOS)
+  )
+)
+const sidebarRows = Array.from({ length: SIDEBAR_ROWS }, (_, index) =>
+  headerRowIndexes.has(index)
+    ? {
+        type: 'header',
+        key: `repo:${index}`,
+        label: '',
+        count: 0,
+        tone: '',
+        repo: { id: `repo-${index}` }
+      }
+    : { type: 'item', rowKey: `wt:${index}`, sectionKey: '', depth: 0, groupDepth: 0 }
+)
+const headerRepoIds = sidebarRows.filter((row) => row.type === 'header').map((row) => row.repo.id)
+const boundaryArgs = {
+  rows: sidebarRows,
+  firstHeaderIndex: 0,
+  // What `getSidebarOrderedRepoHeaderIdsByBucket` yields for repos outside any project group.
+  sidebarRepoHeaderIdsByBucket: new Map([['ungrouped', headerRepoIds]]),
+  repoHeaderBucketByRepoId: new Map(headerRepoIds.map((id) => [id, 'ungrouped']))
+}
+
+// Pre-change `getRepoHeaderSectionEndByRepoId`: a findIndex and an indexOf per header row.
+function getRepoHeaderSectionEndByRepoIdBefore(args) {
+  const rowStarts = []
+  let offset = 0
+  for (let index = 0; index < args.rows.length; index += 1) {
+    rowStarts[index] = offset
+    offset += estimateRenderRowSize(args.rows, index, args.firstHeaderIndex, null)
+  }
+  rowStarts[args.rows.length] = offset
+  const sectionEndByRepoId = new Map()
+  for (let index = 0; index < args.rows.length; index += 1) {
+    const row = args.rows[index]
+    const repoId = row?.type === 'header' ? row.repo?.id : undefined
+    if (!repoId) {
+      continue
+    }
+    const bucketKey = args.repoHeaderBucketByRepoId.get(repoId)
+    const bucketRepoIds = bucketKey ? args.sidebarRepoHeaderIdsByBucket.get(bucketKey) : undefined
+    const bucketIndex = bucketRepoIds?.indexOf(repoId) ?? -1
+    const nextRepoId = bucketIndex >= 0 ? bucketRepoIds?.[bucketIndex + 1] : undefined
+    let endIndex = -1
+    if (nextRepoId) {
+      endIndex = args.rows.findIndex((r) => r.type === 'header' && r.repo?.id === nextRepoId)
+    } else {
+      endIndex = args.rows.length
+      for (let next = index + 1; next < args.rows.length; next += 1) {
+        if (args.rows[next]?.type === 'header' || args.rows[next]?.type === 'host-header') {
+          endIndex = next
+          break
+        }
+      }
+    }
+    sectionEndByRepoId.set(
+      repoId,
+      rowStarts[endIndex >= 0 ? endIndex : args.rows.length] ?? rowStarts[args.rows.length] ?? 0
+    )
+  }
+  return sectionEndByRepoId
+}
+
+compare({
+  label: 'sidebar header boundaries (per row-model rebuild)',
+  scale: `${SIDEBAR_REPOS} repos x ${SIDEBAR_ROWS} rows`,
+  drives: 'production',
+  before: repeat(50, () => [...getRepoHeaderSectionEndByRepoIdBefore(boundaryArgs)]),
+  after: repeat(50, () => [...getRepoHeaderSectionEndByRepoId(boundaryArgs)])
+})
+
+// -------------------------------------------------
+
+console.log('Renderer quadratic-scan removals\n')
+console.log('| projection | drives | scale | before | after | |')
+console.log('| --- | --- | --- | --- | --- | --- |')
+for (const row of results) {
+  console.log(
+    `| ${row.label} | ${row.drives} | ${row.scale} | ${row.beforeMs.toFixed(2)} ms | ${row.afterMs.toFixed(2)} ms | ${(row.beforeMs / row.afterMs).toFixed(1)}x |`
+  )
+}

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "bench:worktree-deletion": "node tests/tools/benchmarks/worktree-deletion-dev-bench.mjs",
     "bench:zustand-selector-fanout": "node config/scripts/zustand-selector-fanout-benchmark.mjs",
     "bench:agent-inspection-cadence": "node config/scripts/agent-inspection-cadence-batching-benchmark.mjs",
+    "bench:renderer-quadratic-scans": "node config/scripts/renderer-quadratic-scan-benchmark.mjs",
     "bench:session-write-hot-path": "node config/scripts/session-write-hot-path-benchmark.mjs",
     "bench:worktree-refresh-churn": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/worktree-refresh-churn-benchmark.mjs",
     "bench:multi-workspace-typing": "pnpm run ensure:electron-runtime && node config/scripts/run-multi-workspace-typing-bench.mjs",

--- a/src/renderer/src/components/right-sidebar/source-control-tree.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-tree.ts
@@ -128,12 +128,16 @@ export function buildSourceControlTree<
     }
 
     let parent = root
+    // Why accumulated and only materialized on a miss: `slice().join('/')` per segment made
+    // tree building O(files x depth^2) in characters copied, and the Source Control filter
+    // rebuilds this whole tree on every keystroke.
+    let ancestorPath = ''
     for (let index = 0; index < segments.length - 1; index += 1) {
       const name = segments[index]
-      const path = segments.slice(0, index + 1).join('/')
+      ancestorPath = ancestorPath ? `${ancestorPath}/${name}` : name
       let dir = parent.directoryChildren.get(name)
       if (!dir) {
-        dir = makeDirectoryNode<Entry, Area>(area, path, name, index)
+        dir = makeDirectoryNode<Entry, Area>(area, ancestorPath, name, index)
         parent.directoryChildren.set(name, dir)
         parent.children.push(dir)
       }

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-search.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-search.ts
@@ -2,7 +2,10 @@ import { useCallback, useDeferredValue, useMemo, useState } from 'react'
 import { isWorktreePaletteQueryTooLarge } from '@/lib/worktree-palette-query-bounds'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
-import { matchWorkspaceBoardWorktrees } from './workspace-kanban-search'
+import {
+  buildWorkspaceBoardPaletteDocuments,
+  matchWorkspaceBoardWorktrees
+} from './workspace-kanban-search'
 
 function areWorktreeIdSetsEqual(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
   if (a.size !== b.size) {
@@ -48,14 +51,27 @@ export function useWorkspaceKanbanSearch(args: {
   // lets React interrupt the board re-render.
   const deferredQuery = useDeferredValue(query)
 
+  // Why split from the match memo: the index only depends on the worktrees and repos, so a
+  // keystroke reruns the search over an already-built index instead of rebuilding every
+  // worktree's normalized fields.
+  const documents = useMemo(
+    () =>
+      buildWorkspaceBoardPaletteDocuments({
+        worktrees: args.worktrees,
+        repoMap: args.repoMap
+      }),
+    [args.repoMap, args.worktrees]
+  )
+
   const matched = useMemo(
     () =>
       matchWorkspaceBoardWorktrees({
         worktrees: args.worktrees,
         query: deferredQuery,
-        repoMap: args.repoMap
+        repoMap: args.repoMap,
+        documents
       }),
-    [args.repoMap, args.worktrees, deferredQuery]
+    [args.repoMap, args.worktrees, deferredQuery, documents]
   )
 
   const matchingWorktreeIds =

--- a/src/renderer/src/components/sidebar/workspace-kanban-search.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-search.ts
@@ -1,5 +1,7 @@
 import { isWorktreePaletteQueryTooLarge } from '@/lib/worktree-palette-query-bounds'
-import { searchWorktrees } from '@/lib/worktree-palette-search'
+import { searchWorktreeDocuments } from '@/lib/worktree-palette-search'
+import { buildWorktreePaletteDocuments } from '@/lib/worktree-palette-document'
+import type { PaletteDocument } from '@/lib/palette-match/palette-document'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorkspaceStatus, Worktree } from '../../../../shared/worktree/types'
 import {
@@ -12,8 +14,25 @@ export type WorkspaceKanbanLaneView = {
   totalCount: number
 }
 
-// Why: the board is a drag surface for named workspaces, so a card may only be
-// hidden by fields the user can read on it. PR/issue/port matches are palette-only.
+/**
+ * Builds the board's palette index once per worktree/repo identity.
+ *
+ * Why separate from the match: the index is identical across keystrokes, and building it inline
+ * meant normalizing and segmenting every indexed field of every worktree on every character —
+ * and again on every agent-status tick, which churns board identities while a query is active.
+ */
+export function buildWorkspaceBoardPaletteDocuments(args: {
+  worktrees: readonly Worktree[]
+  repoMap: ReadonlyMap<string, Repo>
+}): Map<string, PaletteDocument> {
+  // Why the board policy (#15170): the board is a drag surface for named workspaces, so a card
+  // may only be hidden by text printed on it. Ports, reviews and automation runs are palette-only.
+  return buildWorktreePaletteDocuments(args.worktrees, {
+    repoMap: args.repoMap,
+    evidencePolicy: 'board'
+  })
+}
+
 /**
  * Returns `null` when no filtering is active — distinct from an empty set, which
  * means a real query matched nothing.
@@ -22,6 +41,7 @@ export function matchWorkspaceBoardWorktrees(args: {
   worktrees: Worktree[]
   query: string
   repoMap: Map<string, Repo>
+  documents?: ReadonlyMap<string, PaletteDocument>
 }): ReadonlySet<string> | null {
   if (!args.query.trim()) {
     return null
@@ -33,10 +53,14 @@ export function matchWorkspaceBoardWorktrees(args: {
   }
 
   const matched = new Set<string>()
-  // Why the board policy (#15170): a card may only be hidden by text printed on it, so
-  // palette-only evidence such as ports, reviews and automation runs is excluded.
-  for (const result of searchWorktrees(args.worktrees, args.query, args.repoMap, {
-    evidencePolicy: 'board'
+  const documents =
+    args.documents ??
+    buildWorkspaceBoardPaletteDocuments({ worktrees: args.worktrees, repoMap: args.repoMap })
+  for (const result of searchWorktreeDocuments({
+    worktrees: args.worktrees,
+    query: args.query,
+    documents,
+    repoMap: args.repoMap
   })) {
     if (result.matchedFields.length) {
       // Why (STA-4343): two hosts can publish the same id, and a board filter keyed on the

--- a/src/renderer/src/components/sidebar/worktree-header-section-boundaries.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-header-section-boundaries.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getProjectGroupHeaderSectionEndByGroupId,
+  getRepoHeaderSectionEndByRepoId
+} from './worktree-header-section-boundaries'
+import type { RenderRow } from './worktree-list/listing/render-row'
+
+const repoHeader = (id: string): RenderRow =>
+  ({ type: 'header', key: `repo:${id}`, label: id, count: 1, tone: '', repo: { id } }) as RenderRow
+const groupHeader = (id: string): RenderRow =>
+  ({
+    type: 'header',
+    key: `group:${id}`,
+    label: id,
+    count: 1,
+    tone: '',
+    projectGroup: { id },
+    projectGroupDepth: 0
+  }) as RenderRow
+const item = { type: 'item' } as RenderRow
+
+// Estimated starts: first header 28, later headers 32, items 116.
+const rows = [repoHeader('a'), item, repoHeader('b'), item, repoHeader('c'), item]
+const startOfB = 28 + 116
+const startOfC = startOfB + 32 + 116
+
+describe('getRepoHeaderSectionEndByRepoId', () => {
+  it('ends a section at the successor from the header’s own bucket', () => {
+    const ends = getRepoHeaderSectionEndByRepoId({
+      rows,
+      firstHeaderIndex: 0,
+      sidebarRepoHeaderIdsByBucket: new Map([
+        ['group:one', ['a', 'b']],
+        ['group:two', ['a', 'c']]
+      ]),
+      repoHeaderBucketByRepoId: new Map([
+        ['a', 'group:two'],
+        ['b', 'group:one'],
+        ['c', 'group:two']
+      ])
+    })
+
+    // Regression: a successor index keyed on id alone picked `b` from the first bucket.
+    expect(ends.get('a')).toBe(startOfC)
+    expect(ends.get('b')).toBe(startOfC)
+  })
+
+  it('falls back to the next header when a bucket has no successor', () => {
+    const ends = getRepoHeaderSectionEndByRepoId({
+      rows,
+      firstHeaderIndex: 0,
+      sidebarRepoHeaderIdsByBucket: new Map([['ungrouped', ['a']]]),
+      repoHeaderBucketByRepoId: new Map([['a', 'ungrouped']])
+    })
+
+    expect(ends.get('a')).toBe(startOfB)
+  })
+
+  it('resolves a header id that renders twice to its first row, matching findIndex', () => {
+    const ends = getRepoHeaderSectionEndByRepoId({
+      rows: [repoHeader('a'), item, repoHeader('b'), item, repoHeader('b')],
+      firstHeaderIndex: 0,
+      sidebarRepoHeaderIdsByBucket: new Map([['ungrouped', ['a', 'b', 'b']]]),
+      repoHeaderBucketByRepoId: new Map([
+        ['a', 'ungrouped'],
+        ['b', 'ungrouped']
+      ])
+    })
+
+    expect(ends.get('a')).toBe(startOfB)
+    // The first `b` succeeds itself; a last-wins index would jump to the second `b` row.
+    expect(ends.get('b')).toBe(startOfB)
+  })
+})
+
+describe('getProjectGroupHeaderSectionEndByGroupId', () => {
+  it('ends a section at the successor from the group’s own bucket', () => {
+    const ends = getProjectGroupHeaderSectionEndByGroupId({
+      rows: [groupHeader('a'), item, groupHeader('b'), item, groupHeader('c'), item],
+      firstHeaderIndex: 0,
+      sidebarProjectGroupHeaderIdsByBucket: new Map([
+        ['root', ['a', 'b']],
+        ['parent:x', ['a', 'c']]
+      ]),
+      projectGroupHeaderBucketByGroupId: new Map([
+        ['a', 'parent:x'],
+        ['b', 'root'],
+        ['c', 'parent:x']
+      ])
+    })
+
+    expect(ends.get('a')).toBe(startOfC)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-header-section-boundaries.ts
+++ b/src/renderer/src/components/sidebar/worktree-header-section-boundaries.ts
@@ -1,5 +1,6 @@
 import { estimateRenderRowSize } from './worktree-list/viewport/virtual-rows'
 import type { RenderRow } from './worktree-list/listing/render-row'
+import type { GroupHeaderRow } from './worktree-list/grouping/row-types'
 
 function getEstimatedRenderRowStarts(
   rows: readonly RenderRow[],
@@ -15,18 +16,39 @@ function getEstimatedRenderRowStarts(
   return starts
 }
 
-function findRepoHeaderRenderRowIndex(rows: readonly RenderRow[], repoId: string): number {
-  return rows.findIndex((row) => row.type === 'header' && row.repo?.id === repoId)
+// Why indexed once instead of a findIndex per header: both boundary passes ran a full row scan
+// for every header row, so the sidebar row model cost O(headers x rows) on every rebuild — and it
+// rebuilds on agent-status ticks, not just on drag. First match wins, matching findIndex.
+function indexHeaderRenderRows(
+  rows: readonly RenderRow[],
+  keyOf: (row: GroupHeaderRow) => string | null | undefined
+): Map<string, number> {
+  const indexByKey = new Map<string, number>()
+  rows.forEach((row, index) => {
+    const key = row.type === 'header' ? keyOf(row) : undefined
+    if (typeof key === 'string' && !indexByKey.has(key)) {
+      indexByKey.set(key, index)
+    }
+  })
+  return indexByKey
 }
 
-function findProjectGroupHeaderRenderRowIndex(rows: readonly RenderRow[], groupId: string): number {
-  return rows.findIndex(
-    (row) =>
-      row.type === 'header' &&
-      !row.repo &&
-      typeof row.projectGroup?.id === 'string' &&
-      row.projectGroup.id === groupId
-  )
+// Kept per bucket: an id can sit in more than one bucket, and the caller's bucket lookup decides
+// which ordering applies. First occurrence wins within a bucket, matching indexOf.
+function indexBucketSuccessors(
+  idsByBucket: ReadonlyMap<string, readonly string[]>
+): Map<string, ReadonlyMap<string, string | undefined>> {
+  const successorsByBucket = new Map<string, ReadonlyMap<string, string | undefined>>()
+  for (const [bucketKey, ids] of idsByBucket) {
+    const successorById = new Map<string, string | undefined>()
+    ids.forEach((id, index) => {
+      if (!successorById.has(id)) {
+        successorById.set(id, ids[index + 1])
+      }
+    })
+    successorsByBucket.set(bucketKey, successorById)
+  }
+  return successorsByBucket
 }
 
 function findNextHeaderRenderRowIndex(rows: readonly RenderRow[], startIndex: number): number {
@@ -70,6 +92,8 @@ export function getRepoHeaderSectionEndByRepoId(args: {
   repoHeaderBucketByRepoId: ReadonlyMap<string, string>
 }): Map<string, number> {
   const rowStarts = getEstimatedRenderRowStarts(args.rows, args.firstHeaderIndex)
+  const repoHeaderIndexByRepoId = indexHeaderRenderRows(args.rows, (row) => row.repo?.id)
+  const repoSuccessorsByBucket = indexBucketSuccessors(args.sidebarRepoHeaderIdsByBucket)
   const sectionEndByRepoId = new Map<string, number>()
   for (let index = 0; index < args.rows.length; index++) {
     const row = args.rows[index]
@@ -78,11 +102,9 @@ export function getRepoHeaderSectionEndByRepoId(args: {
       continue
     }
     const bucketKey = args.repoHeaderBucketByRepoId.get(repoId)
-    const bucketRepoIds = bucketKey ? args.sidebarRepoHeaderIdsByBucket.get(bucketKey) : undefined
-    const bucketIndex = bucketRepoIds?.indexOf(repoId) ?? -1
-    const nextRepoId = bucketIndex >= 0 ? bucketRepoIds?.[bucketIndex + 1] : undefined
+    const nextRepoId = bucketKey ? repoSuccessorsByBucket.get(bucketKey)?.get(repoId) : undefined
     const endIndex = nextRepoId
-      ? findRepoHeaderRenderRowIndex(args.rows, nextRepoId)
+      ? (repoHeaderIndexByRepoId.get(nextRepoId) ?? -1)
       : findNextHeaderRenderRowIndex(args.rows, index + 1)
     sectionEndByRepoId.set(
       repoId,
@@ -99,6 +121,10 @@ export function getProjectGroupHeaderSectionEndByGroupId(args: {
   projectGroupHeaderBucketByGroupId: ReadonlyMap<string, string>
 }): Map<string, number> {
   const rowStarts = getEstimatedRenderRowStarts(args.rows, args.firstHeaderIndex)
+  const projectGroupHeaderIndexByGroupId = indexHeaderRenderRows(args.rows, (row) =>
+    row.repo ? undefined : row.projectGroup?.id
+  )
+  const groupSuccessorsByBucket = indexBucketSuccessors(args.sidebarProjectGroupHeaderIdsByBucket)
   const sectionEndByGroupId = new Map<string, number>()
   for (let index = 0; index < args.rows.length; index++) {
     const row = args.rows[index]
@@ -114,14 +140,10 @@ export function getProjectGroupHeaderSectionEndByGroupId(args: {
       continue
     }
     const bucketKey = args.projectGroupHeaderBucketByGroupId.get(groupId)
-    const bucketGroupIds = bucketKey
-      ? args.sidebarProjectGroupHeaderIdsByBucket.get(bucketKey)
-      : undefined
-    const bucketIndex = bucketGroupIds?.indexOf(groupId) ?? -1
-    const nextGroupId = bucketIndex >= 0 ? bucketGroupIds?.[bucketIndex + 1] : undefined
+    const nextGroupId = bucketKey ? groupSuccessorsByBucket.get(bucketKey)?.get(groupId) : undefined
     const depth = projectGroupHeader.row.projectGroupDepth ?? 0
     const endIndex = nextGroupId
-      ? findProjectGroupHeaderRenderRowIndex(args.rows, nextGroupId)
+      ? (projectGroupHeaderIndexByGroupId.get(nextGroupId) ?? -1)
       : findProjectGroupSectionEndIndex(args.rows, index + 1, depth)
     sectionEndByGroupId.set(
       groupId,

--- a/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
@@ -50,6 +50,18 @@ export function useTabGroupItemProjections({
     () => new Map(worktreeState.terminalTabs.map((item) => [item.id, item])),
     [worktreeState.terminalTabs]
   )
+  // Why indexed like the terminal tabs above: `openFiles` is the global list across every
+  // worktree and `tabOrder` is as long as the group, so the per-tab `.find` scans below were
+  // quadratic in tab count on a path that reruns whenever any unified tab is written.
+  const openFileById = useMemo(
+    () => new Map(worktreeState.openFiles.map((item) => [item.id, item])),
+    [worktreeState.openFiles]
+  )
+  const browserTabById = useMemo(
+    () => new Map(worktreeState.browserTabs.map((item) => [item.id, item])),
+    [worktreeState.browserTabs]
+  )
+  const groupTabById = useMemo(() => new Map(groupTabs.map((item) => [item.id, item])), [groupTabs])
 
   const terminalTabs = useMemo<TerminalTabItem[]>(
     () =>
@@ -100,11 +112,11 @@ export function useTabGroupItemProjections({
             item.contentType === 'check-details'
         )
         .map((item) => {
-          const file = worktreeState.openFiles.find((candidate) => candidate.id === item.entityId)
+          const file = openFileById.get(item.entityId)
           return file ? { ...file, tabId: item.id } : null
         })
         .filter((item): item is GroupEditorItem => item !== null),
-    [groupTabs, worktreeState.openFiles]
+    [groupTabs, openFileById]
   )
 
   const browserItems = useMemo<GroupBrowserItem[]>(
@@ -112,11 +124,11 @@ export function useTabGroupItemProjections({
       groupTabs
         .filter((item) => item.contentType === 'browser')
         .map((item) => {
-          const bt = worktreeState.browserTabs.find((candidate) => candidate.id === item.entityId)
+          const bt = browserTabById.get(item.entityId)
           return bt ? { ...bt, tabId: item.id } : null
         })
         .filter((item): item is GroupBrowserItem => item !== null),
-    [groupTabs, worktreeState.browserTabs]
+    [browserTabById, groupTabs]
   )
 
   const agentSessionItems = useMemo<GroupAgentSessionItem[]>(
@@ -130,7 +142,7 @@ export function useTabGroupItemProjections({
   const tabBarOrder = useMemo(
     () =>
       (group?.tabOrder ?? []).map((itemId) => {
-        const item = groupTabs.find((candidate) => candidate.id === itemId)
+        const item = groupTabById.get(itemId)
         if (!item) {
           return itemId
         }
@@ -138,7 +150,7 @@ export function useTabGroupItemProjections({
           ? item.entityId
           : item.id
       }),
-    [group, groupTabs]
+    [group, groupTabById]
   )
 
   return {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​481 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​443 |

<!-- /orca-pr-loc -->

## ELI5

Four places in the UI were looking things up the slow way: for each item in one list, scan the *whole* of another list. That's fine for five items and terrible for five hundred — and all four sit on paths that rerun **on every keystroke** or **every time any tab or agent status changes**.

The fix in every case is the same and boring: build a lookup table once, then look things up in it. Same results, same order, same everything — just without re-reading the phone book for every name.

Concretely:
1. **Typing in the workspace board filter** re-indexed every workspace's searchable text on every character. Now the index is built once and only the search reruns.
2. **The tab bar** resolved each editor tab against the *global* list of open files across all worktrees, once per tab. Now it's a map.
3. **The Source Control file tree** rebuilt every folder's full path by re-joining its parent segments — for every folder, for every file. Now it accumulates as it walks down.
4. **The sidebar** scanned all its rows from the top, once per project header, to find where each section ends. Now one pass builds all the answers.

## What Changed

| File | Was | Now |
| --- | --- | --- |
| `sidebar/workspace-kanban-search.ts` + `use-workspace-kanban-search.ts` | palette document index rebuilt inside the query-keyed `useMemo` | `buildWorkspaceBoardPaletteDocuments` split out, memoized on `[worktrees, repoMap]` |
| `tab-group/useTabGroupItemProjections.ts` | `.find` over `state.openFiles` per editor tab; `.find` over `groupTabs` per `tabOrder` entry | `openFileById` / `browserTabById` / `groupTabById` maps, alongside the `terminalTabById` this file already built |
| `right-sidebar/source-control-tree.ts` | `segments.slice(0, i + 1).join('/')` per segment → O(files × depth²) chars copied | path accumulated down the walk |
| `sidebar/worktree-header-section-boundaries.ts` | full `findIndex` over render rows per header + `indexOf` per bucket | one indexing pass each, first-match-wins to match `findIndex`/`indexOf`; successors indexed **per bucket** since an id can sit in more than one bucket ordering |
| `sidebar/worktree-header-section-boundaries.test.ts` | — | new: per-bucket successor, no-successor fallback, and duplicate-header first-wins cases |

The board change mirrors the shape `worktree-jump-palette-document-index.ts` already provides for Cmd-J — the board caller was simply skipping the memoized entry point.

## Why

All four projections are O(n·m) on paths that rerun per keystroke or per store write, so they scale with the user's data in exactly the place that produces input lag. Indexing once per stable input is what each surrounding file already does for its other lookups.

## Linked Issue

N/A — found during a renderer performance audit; no tracking issue.

## Visual Proof

N/A — no visual or interaction change. The benchmark asserts each indexed shape returns the same result as the scan it replaces.

## Measurements

`pnpm bench:renderer-quadratic-scans` (new, checked in). Three of the four scenarios import and time the **production export** against a hand-written reproduction of the pre-change function. The tab-group scenario is **modelled on both sides** — the projection lives inside the `useTabGroupItemProjections` React hook and cannot be imported without a renderer — so its row measures a reproduction of the change, not the change. Every scenario asserts before/after produce the same result before timing.

| projection | drives | scale | before | after | |
| --- | --- | --- | --- | --- | --- |
| workspace board filter (per keystroke burst) | production | 300 worktrees × 12 keystrokes | 15.4 ms | 4.4 ms | **3.5x** |
| tab-group projections (per unified-tab write) | **modelled** | 60 tabs × 120 open files | 1.23 ms | 0.34 ms | 3.6x |
| source-control tree build (per filter keystroke) | production | 5000 changed files | 6.2 ms | 3.9 ms | **1.6x** |
| sidebar header boundaries (per row-model rebuild) | production | 80 repos × 600 rows | 2.0 ms | 0.8 ms | **2.6x** |

The tree and sidebar wins are smaller than the scans they remove: the rest of each function (tree finalize/sort, per-row size estimation) is linear and now dominates. Earlier revisions of this PR reported 18.1x and 2.3x for those two rows from proxies that timed only the removed loop; those numbers were a model, not the function.

## Negative user-facing trade-offs

**None identified.** Each change replaces a linear scan with an index built from the same input:

- **Same results, same order.** `Map` construction is first-wins and I kept it that way explicitly, matching `findIndex`/`indexOf` semantics. The benchmark asserts the production function's output equals the pre-change reproduction before timing, and the new boundaries test pins the duplicate-header and multi-bucket cases.
- **Same paths in the tree.** The accumulated ancestor path produces byte-identical strings to `slice().join('/')`.
- **Same filter behaviour.** The board still uses the `evidencePolicy: 'board'` documents (#15170 — a card may only be hidden by text printed on it). Moving the build out did not change which fields are indexed.
- **No new memory of note.** The new maps hold references to objects already in the store; they are memoized on the same inputs the surrounding memos already key on, so they are rebuilt exactly when the data changes.
- **No debouncing added.** I deliberately did not debounce the Source Control filter — that *would* be a visible trade-off (a beat of lag while typing). This PR only makes the existing per-keystroke work cheaper.

`matchWorkspaceBoardWorktrees` keeps `documents` optional and falls back to building them, so no existing caller (including its tests) changes behaviour.

## Testing

- `pnpm tc` ✅
- `npx vitest run src/renderer/src/components/{sidebar,tab-group,right-sidebar}` — **4541 passed** (4537 existing unmodified + 4 new) ✅
- `pnpm run check:code-quality:changed` ✅
- `pnpm bench:renderer-quadratic-scans` ✅ (macOS; pure TypeScript projections, no platform-dependent behaviour)

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
