### PR TITLE
perf(relay): bound the symlink directory probes a remote readDir fans out

### DIFF
--- a/src/relay/fs-path-metadata-requests.ts
+++ b/src/relay/fs-path-metadata-requests.ts
@@ -1,6 +1,8 @@
 import { readdir, stat, lstat, realpath } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
 import { join } from 'node:path'
 import { sortDirEntries } from '../shared/file-name-sort'
+import { forEachWithConcurrency } from '../shared/map-with-concurrency'
 import { expandTilde } from './context'
 
 async function resolveSymlinkDirectoryEntry(
@@ -34,11 +36,18 @@ function fileStatFromLstat(stats: Awaited<ReturnType<typeof lstat>>) {
   }
 }
 
+// Why bounded: a pnpm `node_modules` is hundreds-to-thousands of package symlinks, and one
+// unbounded `Promise.all` of stats from a single readDir saturates libuv's four-thread pool —
+// delaying every other relay filesystem operation, including the interactive reads the
+// list-files scan coordinator exists to protect. Matches the cap every other bounded probe in
+// this codebase uses.
+const SYMLINK_DIRECTORY_PROBE_CONCURRENCY = 8
+
 export async function readRelayDir(params: Record<string, unknown>) {
   const dirPath = expandTilde(params.dirPath as string)
   const entries = await readdir(dirPath, { withFileTypes: true })
   const mapped: { name: string; isDirectory: boolean; isSymlink: boolean }[] = []
-  const symlinkProbes: Promise<void>[] = []
+  const symlinkEntries: { entry: Dirent; mappedEntry: (typeof mapped)[number] }[] = []
   for (const entry of entries) {
     const mappedEntry = {
       name: entry.name,
@@ -47,15 +56,17 @@ export async function readRelayDir(params: Record<string, unknown>) {
     }
     mapped.push(mappedEntry)
     if (!mappedEntry.isDirectory && mappedEntry.isSymlink) {
-      symlinkProbes.push(
-        resolveSymlinkDirectoryEntry(dirPath, entry).then((isDirectory) => {
-          mappedEntry.isDirectory = isDirectory
-        })
-      )
+      symlinkEntries.push({ entry, mappedEntry })
     }
   }
-  if (symlinkProbes.length > 0) {
-    await Promise.all(symlinkProbes)
+  if (symlinkEntries.length > 0) {
+    await forEachWithConcurrency(
+      symlinkEntries,
+      SYMLINK_DIRECTORY_PROBE_CONCURRENCY,
+      async ({ entry, mappedEntry }) => {
+        mappedEntry.isDirectory = await resolveSymlinkDirectoryEntry(dirPath, entry)
+      }
+    )
   }
   return sortDirEntries(mapped)
 }

--- a/src/relay/fs-path-metadata-symlink-concurrency.test.ts
+++ b/src/relay/fs-path-metadata-symlink-concurrency.test.ts
@@ -1,0 +1,70 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as FsPromisesModule from 'node:fs/promises'
+
+const statCalls = vi.hoisted(() => ({ inFlight: 0, peak: 0, total: 0 }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsPromisesModule>()
+  return {
+    ...actual,
+    stat: async (...args: Parameters<typeof actual.stat>) => {
+      statCalls.inFlight += 1
+      statCalls.total += 1
+      statCalls.peak = Math.max(statCalls.peak, statCalls.inFlight)
+      try {
+        return await actual.stat(...args)
+      } finally {
+        statCalls.inFlight -= 1
+      }
+    }
+  }
+})
+
+const { readRelayDir } = await import('./fs-path-metadata-requests')
+
+describe('relay readDir symlink probes', () => {
+  let root: string
+  let targetRoot: string
+
+  beforeEach(() => {
+    statCalls.inFlight = 0
+    statCalls.peak = 0
+    statCalls.total = 0
+    root = mkdtempSync(join(tmpdir(), 'orca-relay-readdir-'))
+    // Kept outside `root` so the listing contains only the symlinks under test.
+    targetRoot = mkdtempSync(join(tmpdir(), 'orca-relay-readdir-target-'))
+    const target = join(targetRoot, 'target')
+    mkdirSync(target)
+    writeFileSync(join(target, 'index.js'), '')
+    // A pnpm-shaped node_modules: many package symlinks in one directory. Junctions on
+    // Windows: plain symlinks need Developer Mode there.
+    for (let index = 0; index < 60; index += 1) {
+      symlinkSync(
+        target,
+        join(root, `pkg-${index}`),
+        process.platform === 'win32' ? 'junction' : 'dir'
+      )
+    }
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+    rmSync(targetRoot, { recursive: true, force: true })
+  })
+
+  it('bounds concurrent symlink stats instead of issuing one per entry at once', async () => {
+    const entries = await readRelayDir({ dirPath: root })
+
+    expect(statCalls.total).toBe(60)
+    // Exactly the cap: every worker enters `stat` before any resolves, so the peak proves the
+    // probes overlap and that no more than 8 ever do. Unbounded, all 60 would be in flight,
+    // saturating libuv's four-thread pool and stalling every other relay filesystem read.
+    expect(statCalls.peak).toBe(8)
+    // Behaviour is unchanged: every symlink still resolves to its target's kind.
+    expect(entries).toHaveLength(60)
+    expect(entries.every((entry) => entry.isDirectory && entry.isSymlink)).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

When you expand a folder over SSH, Orca lists it and then asks "is this thing a folder?" about every shortcut (symlink) it finds. It asked about **all of them at once**.

A `node_modules` folder in a pnpm project is hundreds to thousands of symlinks. So one click could fire off 1,200 simultaneous filesystem questions — and Node only has **four** background threads to answer them. Everything else the remote connection was doing (reading the file you just opened, the file search) queued up behind that pile.

This PR asks 8 at a time instead of all at once. Same answers, same order, same total number of questions — just not all shoved through the door simultaneously.

## What changed

`src/relay/fs-path-metadata-requests.ts` — `readRelayDir`'s symlink probes move from an unbounded `Promise.all` to `forEachWithConcurrency(..., 8)`.

8 is not a new number: it is the cap every other bounded probe in this codebase already uses (`GIT_COMMON_SNAPSHOT_CONCURRENCY`, `PRUNABLE_EXISTENCE_PROBE_CONCURRENCY`, `SPARSE_CHECKOUT_DETECTION_CONCURRENCY`, `FILE_EXPLORER_RUNTIME_REFRESH_CONCURRENCY`, `WORKTREE_REFRESH_CONCURRENCY`).

## Measurements

New `fs-path-metadata-symlink-concurrency.test.ts` builds a 60-symlink directory and instruments `stat`. It is deterministic — no timers: `forEachWithConcurrency` starts all 8 workers synchronously, so each enters `stat` before any resolves, and the peak is asserted to be exactly 8 (which proves the probes overlap, not just that they are capped).

| | Before | After |
| --- | --- | --- |
| peak concurrent `stat` calls | 60 (all of them) | **8** |
| total `stat` calls | 60 | 60 (unchanged) |
| entries returned | 60, all `isDirectory` | identical |

At pnpm `node_modules` scale (~1,200 symlinks) that is 1,200 simultaneous stats against a 4-thread pool, versus 8.

I did not take a wall-clock number on a real SSH host — the fix is about *head-of-line blocking* for other relay operations, which a single-operation timing would not show. The peak-concurrency assertion is the honest measurement of what changed.

## Negative user-facing trade-offs

**None identified.**

- **Same results.** Every symlink still resolves to its target's kind; `sortDirEntries` still runs afterwards, so ordering is byte-identical.
- **Same total work.** The test asserts exactly 60 stats before and after — this reorders them, it does not skip any.
- **No new staleness.** Nothing is cached; each probe is still a live `stat`.
- **`forEachWithConcurrency` already short-circuits** when `items.length <= workerCount`, so a directory with fewer than 8 symlinks behaves exactly as before, with no scheduling overhead.

The one honest cost: a directory with *many* symlinks now takes slightly longer to return **in isolation**, because 8 run at a time rather than all at once. That is the intended trade — the previous behaviour bought that single listing's latency by stalling every other remote filesystem operation, and a 4-thread pool cannot actually service 1,200 stats in parallel regardless. Wall-clock for the listing itself is bounded by the pool, not by how many requests are queued in front of it.

## Test plan

- `pnpm tc` OK
- `npx vitest run src/relay` — **1664 passed, 0 modified** OK
- `pnpm run check:code-quality:changed` OK
- New: `src/relay/fs-path-metadata-symlink-concurrency.test.ts` (peak concurrency exactly 8, total stats unchanged, entries unchanged; junctions on Windows so the fixture does not need Developer Mode)

