### PR TITLE
fix(relay-ops): accept monitor evidence from an ancestor commit with identical monitor code

### DIFF
--- a/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
+++ b/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
@@ -91,7 +91,11 @@ jobs:
           test -n "${CAPACITY_SERVICE_ACCOUNT}"
           test -n "${DIRECTOR_RUNTIME_SERVICE_ACCOUNT}"
 
+      # Full history: the monitor evidence this job verifies is sealed at an ancestor commit,
+      # and the provenance check fails closed on a commit a shallow clone left out.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
         with: { package_json_file: cloud/package.json }

--- a/.github/workflows/cloud-deploy-relay-production-same-cap.yml
+++ b/.github/workflows/cloud-deploy-relay-production-same-cap.yml
@@ -87,13 +87,18 @@ jobs:
   gate:
     if: ${{ vars.ORCA_CLOUD_OPERATIONS_ENABLED == 'true' && (github.ref == 'refs/heads/main') }}
     runs-on: blacksmith-2vcpu-ubuntu-2204
-    timeout-minutes: 10
+    # Headroom for the full-history checkout the canary provenance check needs.
+    timeout-minutes: 15
     environment: production
     outputs:
       cells: ${{ steps.wave.outputs.cells }}
       job-mode: ${{ steps.wave.outputs.job-mode }}
     steps:
+      # Full history: the canary authority a batch verifies is sealed at an ancestor commit, and
+      # the provenance check fails closed on a commit a shallow clone left out.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with: { node-version: 24 }

--- a/.github/workflows/cloud-operate-relay-production-rehome-job.yml
+++ b/.github/workflows/cloud-operate-relay-production-rehome-job.yml
@@ -95,7 +95,11 @@ jobs:
               ;;
           esac
 
+      # Full history: the monitor evidence this job verifies is sealed at an ancestor commit,
+      # and the provenance check fails closed on a commit a shallow clone left out.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:

--- a/cloud/dev/scripts/relay-evidence-code-provenance.mjs
+++ b/cloud/dev/scripts/relay-evidence-code-provenance.mjs
@@ -1,0 +1,94 @@
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import {
+  RELAY_REPOSITORY_ROOT,
+  relayTreePath,
+  relayWorkflowPath
+} from './relay-repository.mjs'
+
+const SHA = /^[a-f0-9]{40}$/
+
+// Every file that decides how relay evidence is produced, sealed, verified, and then spent against
+// production; identical content across two commits is what makes the older commit's verdict binding.
+export const TRUSTED_EVIDENCE_CODE_PATHS = [
+  // Produces and seals the 15-minute dry-run evidence.
+  relayWorkflowPath('monitor-relay-production.yml'),
+  relayWorkflowPath('monitor-relay-production-job.yml'),
+  // Download it, verify its authority, and mutate production on it.
+  relayWorkflowPath('deploy-relay-production-same-cap.yml'),
+  relayWorkflowPath('deploy-relay-production-same-cap-job.yml'),
+  relayWorkflowPath('operate-relay-production-rehome.yml'),
+  relayWorkflowPath('operate-relay-production-rehome-job.yml'),
+  // Sealing, verification, the wave/canary authority, and the path constants below.
+  relayTreePath('dev/scripts/relay-evidence-code-provenance.mjs'),
+  relayTreePath('dev/scripts/relay-monitor-evidence.mjs'),
+  relayTreePath('dev/scripts/relay-production-same-cap-wave.mjs'),
+  relayTreePath('dev/scripts/relay-repository.mjs'),
+  // Every other script those jobs run against live production.
+  relayTreePath('dev/scripts/infra.mjs'),
+  relayTreePath('dev/scripts/operate-relay-regional-rehome.mjs'),
+  relayTreePath('dev/scripts/prepare-relay-production-capacity-canary.mjs'),
+  relayTreePath('dev/scripts/probe-relay-rehome-trust.mjs'),
+  relayTreePath('dev/scripts/validate-relay-capacity-plan.mjs'),
+  relayTreePath('dev/scripts/verify-relay-capacity-transition.mjs'),
+  // The monitor itself and the live preflight recheck, plus anything that changes their behaviour.
+  relayTreePath('apps/relay-ops'),
+  relayTreePath('package.json'),
+  relayTreePath('pnpm-lock.yaml'),
+  relayTreePath('pnpm-workspace.yaml'),
+  // The Cloud SQL rollout lease every mutation job takes and releases.
+  '.github/actions/cloud-sql-rollout-lease'
+]
+
+function git(root, args) {
+  const result = spawnSync('git', ['-C', root, ...args], { encoding: 'utf8' })
+  if (result.error) throw new Error('relay evidence provenance cannot run git')
+  return result
+}
+
+/**
+ * Accepts evidence sealed at a different commit only when the current commit descends from it and
+ * every trusted path is byte-identical, so the verdict provably came from this exact code. Anything
+ * git cannot answer (no checkout, unknown commit, shallow clone) fails closed.
+ */
+export function requireSameEvidenceCode({
+  sealedSha,
+  currentSha,
+  label,
+  repositoryRoot = fileURLToPath(RELAY_REPOSITORY_ROOT)
+}) {
+  if (!SHA.test(sealedSha ?? '') || !SHA.test(currentSha ?? '')) {
+    throw new Error(`${label} commit is invalid`)
+  }
+  if (sealedSha === currentSha) return
+  if (git(repositoryRoot, ['rev-parse', '--git-dir']).status !== 0) {
+    throw new Error(`${label} commit cannot be compared without a git checkout`)
+  }
+  for (const sha of [sealedSha, currentSha]) {
+    if (git(repositoryRoot, ['rev-parse', '--verify', '--quiet', `${sha}^{commit}`]).status !== 0) {
+      throw new Error(
+        `${label} commit ${sha} is unknown to this checkout; check out with fetch-depth: 0`
+      )
+    }
+  }
+  const ancestry = git(repositoryRoot, ['merge-base', '--is-ancestor', sealedSha, currentSha])
+  if (ancestry.status === 1) {
+    throw new Error(`${label} commit ${sealedSha} is not an ancestor of ${currentSha}`)
+  }
+  if (ancestry.status !== 0) {
+    throw new Error(`${label} commit ancestry could not be determined`)
+  }
+  const diff = git(repositoryRoot, [
+    'diff',
+    '--name-only',
+    sealedSha,
+    currentSha,
+    '--',
+    ...TRUSTED_EVIDENCE_CODE_PATHS
+  ])
+  if (diff.status !== 0) throw new Error(`${label} commit comparison failed`)
+  const changed = diff.stdout.split('\n').filter(Boolean)
+  if (changed.length > 0) {
+    throw new Error(`${label} code changed after it was sealed: ${changed.join(',')}`)
+  }
+}

--- a/cloud/dev/scripts/relay-monitor-evidence.mjs
+++ b/cloud/dev/scripts/relay-monitor-evidence.mjs
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { chmod, readFile, readdir, stat, writeFile } from 'node:fs/promises'
 import { basename, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { requireSameEvidenceCode } from './relay-evidence-code-provenance.mjs'
 
 const SAFE_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{1,127}$/
 const SHA = /^[a-f0-9]{40}$/
@@ -102,7 +103,7 @@ export async function createEvidenceManifest(argv) {
   return manifest
 }
 
-async function readAndVerifyManifest(directory, expected) {
+async function readAndVerifyManifest(directory, expected, sameCodeCommit) {
   const manifest = JSON.parse(
     await readFile(join(directory, 'evidence-manifest.json'), 'utf8')
   )
@@ -111,10 +112,22 @@ async function readAndVerifyManifest(directory, expected) {
     manifest.incidentId !== expected.incidentId ||
     manifest.runId !== expected.runId ||
     manifest.runAttempt !== expected.runAttempt ||
-    manifest.commitSha !== expected.commitSha ||
-    manifest.mode !== expected.mode
+    !SHA.test(manifest.commitSha ?? '') ||
+    manifest.mode !== expected.mode ||
+    (!sameCodeCommit && manifest.commitSha !== expected.commitSha)
   ) {
     throw new Error('relay monitor evidence provenance does not match')
+  }
+  // Unrelated merges land on main every few minutes, so the deployer resolves a newer commit than
+  // the monitor it must trust; identical monitor and mutation code is the property the SHA stood in
+  // for. Restore and mutation keep the exact-SHA bind: both run at the commit that sealed them.
+  if (sameCodeCommit) {
+    requireSameEvidenceCode({
+      sealedSha: manifest.commitSha,
+      currentSha: expected.commitSha,
+      label: 'relay monitor evidence',
+      ...sameCodeCommit
+    })
   }
   const names = Object.keys(manifest.files ?? {})
   if (!names.includes(`${expected.incidentId}.state.json`)) {
@@ -209,12 +222,12 @@ function validCompletedDryRunState(state, expected, nowMs, maxAgeMs) {
   )
 }
 
-export async function verifyDryRunAuthority(argv, now = Date.now) {
+export async function verifyDryRunAuthority(argv, now = Date.now, repositoryRoot) {
   const values = argumentsByName(argv)
   const directory = resolve(values.directory ?? '')
   const expected = provenance(values)
   if (expected.mode !== 'dry-run') throw new Error('relay mutation requires dry-run evidence')
-  const manifest = await readAndVerifyManifest(directory, expected)
+  const manifest = await readAndVerifyManifest(directory, expected, { repositoryRoot })
   const state = JSON.parse(
     await readFile(join(directory, `${expected.incidentId}.state.json`), 'utf8')
   )

--- a/cloud/dev/scripts/relay-monitor-evidence.test.mjs
+++ b/cloud/dev/scripts/relay-monitor-evidence.test.mjs
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import test from 'node:test'
-import { relayWorkflowPath, relayWorkflowUrl } from './relay-repository.mjs'
+import { TRUSTED_EVIDENCE_CODE_PATHS } from './relay-evidence-code-provenance.mjs'
+import {
+  RELAY_REPOSITORY_ROOT,
+  relayWorkflowPath,
+  relayWorkflowUrl
+} from './relay-repository.mjs'
 import {
   createEvidenceManifest,
   verifyDryRunAuthority,
@@ -12,7 +18,7 @@ import {
 } from './relay-monitor-evidence.mjs'
 
 const now = Date.parse('2026-07-28T12:00:00.000Z')
-const provenance = [
+const provenanceFor = (commitSha) => [
   '--incident-id',
   'relay-123',
   '--run-id',
@@ -20,10 +26,11 @@ const provenance = [
   '--run-attempt',
   '1',
   '--commit-sha',
-  'a'.repeat(40),
+  commitSha,
   '--mode',
   'dry-run'
 ]
+const provenance = provenanceFor('a'.repeat(40))
 const selector = {
   generation: 2,
   membership: {
@@ -512,4 +519,158 @@ test('monitor uses a reusable job so exact job_workflow_ref is present', async (
   )
   assert.match(job, /workflow_call:/)
   assert.match(job, /environment: production/)
+})
+
+function gitIn(root, ...args) {
+  return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim()
+}
+
+// A real repository shaped like main under unrelated merge traffic: one sealed commit, a
+// descendant that only touched untrusted files, a descendant that touched the monitor, and a
+// sibling that never descended from the seal.
+async function trustedCodeRepository() {
+  const root = await mkdtemp(join(tmpdir(), 'relay-evidence-repository-'))
+  gitIn(root, 'init', '--quiet')
+  gitIn(root, 'config', 'user.email', 'relay@example.test')
+  gitIn(root, 'config', 'user.name', 'Relay Evidence Test')
+  gitIn(root, 'config', 'commit.gpgsign', 'false')
+  const commit = async (path, body, message) => {
+    await mkdir(dirname(join(root, path)), { recursive: true })
+    await writeFile(join(root, path), body)
+    gitIn(root, 'add', '--all')
+    gitIn(root, 'commit', '--quiet', '--no-verify', '--message', message)
+    return gitIn(root, 'rev-parse', 'HEAD')
+  }
+  const base = await commit(
+    'cloud/apps/relay-ops/src/incident-monitor.ts',
+    'export const v = 1\n',
+    'monitor'
+  )
+  const sealed = await commit('README.md', 'base\n', 'base')
+  const sameCode = await commit('README.md', 'an unrelated merge\n', 'unrelated')
+  const changedCode = await commit(
+    'cloud/apps/relay-ops/src/incident-monitor.ts',
+    'export const v = 2\n',
+    'monitor change'
+  )
+  // Branches before the seal, so the seal is not in its history even though its code matches.
+  gitIn(root, 'checkout', '--quiet', '--detach', base)
+  const sibling = await commit('README.md', 'a divergent line\n', 'divergent')
+  return { root, sealed, sameCode, changedCode, sibling }
+}
+
+const authorityAt = (directory, commitSha, repositoryRoot) => verifyDryRunAuthority(
+  [
+    '--directory',
+    directory,
+    ...provenanceFor(commitSha),
+    '--required-migration-policy',
+    'strict'
+  ],
+  () => now,
+  repositoryRoot
+)
+
+test('accepts dry-run evidence sealed by identical code at an ancestor commit', async () => {
+  const repository = await trustedCodeRepository()
+  const directory = await evidenceDirectory()
+  try {
+    await createEvidenceManifest([
+      '--directory',
+      directory,
+      ...provenanceFor(repository.sealed)
+    ])
+    // An exact match never consults git: a root with no checkout at all still verifies.
+    await assert.doesNotReject(authorityAt(directory, repository.sealed, directory))
+    await assert.doesNotReject(authorityAt(directory, repository.sameCode, repository.root))
+  } finally {
+    await rm(repository.root, { recursive: true, force: true })
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('rejects dry-run evidence whose monitor code or lineage differs', async () => {
+  const repository = await trustedCodeRepository()
+  const directory = await evidenceDirectory()
+  try {
+    await createEvidenceManifest([
+      '--directory',
+      directory,
+      ...provenanceFor(repository.sealed)
+    ])
+    await assert.rejects(
+      authorityAt(directory, repository.changedCode, repository.root),
+      /code changed after it was sealed: cloud\/apps\/relay-ops\/src\/incident-monitor\.ts/
+    )
+    await assert.rejects(
+      authorityAt(directory, repository.sibling, repository.root),
+      /is not an ancestor of/
+    )
+    // Fails closed: a shallow clone that never fetched the sealed commit proves nothing.
+    await assert.rejects(
+      authorityAt(directory, 'f'.repeat(40), repository.root),
+      /unknown to this checkout/
+    )
+    // Fails closed: no checkout to compare against.
+    await assert.rejects(
+      authorityAt(directory, repository.sameCode, directory),
+      /cannot be compared without a git checkout/
+    )
+  } finally {
+    await rm(repository.root, { recursive: true, force: true })
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+test('keeps restore and mutation bound to the exact sealing commit', async () => {
+  const repository = await trustedCodeRepository()
+  const directory = await evidenceDirectory()
+  try {
+    await createEvidenceManifest([
+      '--directory',
+      directory,
+      ...provenanceFor(repository.sealed)
+    ])
+    await assert.rejects(
+      verifyRestoredEvidence([
+        '--directory',
+        directory,
+        ...provenanceFor(repository.sameCode)
+      ]),
+      /provenance does not match/
+    )
+    await assert.rejects(
+      verifyMutationEvidence(
+        [
+          '--directory',
+          directory,
+          ...provenanceFor(repository.sameCode),
+          '--mutation-mode',
+          'execute',
+          '--source-cell-id',
+          'c1',
+          '--director-origin',
+          'https://relay.example'
+        ],
+        { ORCA_RELAY_ADMIN_ID_TOKEN: 'aaa.bbb.ccc' },
+        async () => Response.json({ selector }),
+        () => now
+      ),
+      /provenance does not match/
+    )
+  } finally {
+    await rm(repository.root, { recursive: true, force: true })
+    await rm(directory, { recursive: true, force: true })
+  }
+})
+
+// A trusted path that no longer exists silently stops being compared, so the same-code rule would
+// pass over code it was written to pin.
+test('every trusted provenance path exists in this checkout', async () => {
+  for (const path of TRUSTED_EVIDENCE_CODE_PATHS) {
+    await assert.doesNotReject(
+      stat(new URL(path, RELAY_REPOSITORY_ROOT)),
+      `${path} is missing`
+    )
+  }
 })

--- a/cloud/dev/scripts/relay-production-same-cap-wave.mjs
+++ b/cloud/dev/scripts/relay-production-same-cap-wave.mjs
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
+import { requireSameEvidenceCode } from './relay-evidence-code-provenance.mjs'
 
 export const SAME_CAP_CELLS = [
   'production-gce-c7', 'production-gce-c8', 'production-gce-c9', 'production-gce-c10',
@@ -85,10 +86,10 @@ export function canaryAuthority(input) {
   }
 }
 
-export function verifyCanaryAuthority(authority, expected) {
+export function verifyCanaryAuthority(authority, expected, repositoryRoot) {
   if (
     authority?.v !== 1 ||
-    authority.commitSha !== expected.commitSha ||
+    !/^[0-9a-f]{40}$/.test(authority.commitSha ?? '') ||
     authority.runId !== expected.runId ||
     authority.targetDigest !== expected.targetDigest ||
     authority.rollbackDigest !== expected.rollbackDigest ||
@@ -96,6 +97,14 @@ export function verifyCanaryAuthority(authority, expected) {
     authority.rehomeGeneration !== Number(expected.rehomeGeneration) ||
     !SAME_CAP_CELLS.includes(authority.cellId)
   ) throw new Error('canary authority does not match this batch')
+  // The batch dispatch resolves main after the canary sealed, so bind to the same code, not the
+  // same SHA; every field above still pins this batch to that exact canary.
+  requireSameEvidenceCode({
+    sealedSha: authority.commitSha,
+    currentSha: expected.commitSha,
+    label: 'relay same-cap canary authority',
+    repositoryRoot
+  })
   return authority
 }
 

--- a/cloud/dev/scripts/relay-production-same-cap-wave.test.mjs
+++ b/cloud/dev/scripts/relay-production-same-cap-wave.test.mjs
@@ -1,4 +1,8 @@
 import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 import { test } from 'node:test'
 import {
   canaryAuthority,
@@ -103,4 +107,67 @@ test('seals and verifies canary authority for later batches', () => {
     selectorGeneration: '11',
     rehomeGeneration: '4'
   }), /does not match/)
+})
+
+function gitIn(root, ...args) {
+  return execFileSync('git', ['-C', root, ...args], { encoding: 'utf8' }).trim()
+}
+
+async function canaryRepository() {
+  const root = await mkdtemp(join(tmpdir(), 'relay-same-cap-canary-'))
+  gitIn(root, 'init', '--quiet')
+  gitIn(root, 'config', 'user.email', 'relay@example.test')
+  gitIn(root, 'config', 'user.name', 'Relay Wave Test')
+  gitIn(root, 'config', 'commit.gpgsign', 'false')
+  const commit = async (path, body, message) => {
+    await mkdir(dirname(join(root, path)), { recursive: true })
+    await writeFile(join(root, path), body)
+    gitIn(root, 'add', '--all')
+    gitIn(root, 'commit', '--quiet', '--no-verify', '--message', message)
+    return gitIn(root, 'rev-parse', 'HEAD')
+  }
+  const sealed = await commit(
+    'cloud/dev/scripts/relay-production-same-cap-wave.mjs',
+    'export const v = 1\n',
+    'wave'
+  )
+  const sameCode = await commit('README.md', 'an unrelated merge\n', 'unrelated')
+  const changedCode = await commit(
+    'cloud/dev/scripts/relay-production-same-cap-wave.mjs',
+    'export const v = 2\n',
+    'wave change'
+  )
+  return { root, sealed, sameCode, changedCode }
+}
+
+test('a batch trusts a canary sealed by identical code at an ancestor commit', async () => {
+  const repository = await canaryRepository()
+  try {
+    const authority = canaryAuthority({
+      cellIds: 'production-gce-c7',
+      targetDigest,
+      rollbackDigest,
+      confirmation: `ROLL_RELAY_SAME_CAP ${targetDigest} production-gce-c7`,
+      commitSha: repository.sealed,
+      runId: '42',
+      selectorGeneration: '11',
+      rehomeGeneration: '4'
+    })
+    const verifyAt = (commitSha, repositoryRoot) => verifyCanaryAuthority(authority, {
+      commitSha,
+      runId: '42',
+      targetDigest,
+      rollbackDigest,
+      selectorGeneration: '13',
+      rehomeGeneration: '4'
+    }, repositoryRoot)
+    assert.equal(verifyAt(repository.sameCode, repository.root).cellId, 'production-gce-c7')
+    assert.throws(
+      () => verifyAt(repository.changedCode, repository.root),
+      /code changed after it was sealed/
+    )
+    assert.throws(() => verifyAt('f'.repeat(40), repository.root), /unknown to this checkout/)
+  } finally {
+    await rm(repository.root, { recursive: true, force: true })
+  }
 })

--- a/cloud/dev/scripts/relay-repository.mjs
+++ b/cloud/dev/scripts/relay-repository.mjs
@@ -1,4 +1,6 @@
 import { readFileSync } from 'node:fs'
+import { relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // Single place naming the repository the Relay workflows live in and where their files sit. The
 // public-repo copy moves this tree under cloud/, prefixes every workflow filename, and changes the
@@ -10,6 +12,19 @@ export const RELAY_WORKFLOW_FILE_PREFIX = 'cloud-'
 // Where .github/workflows sits relative to this file. Workflows stay at the repository root while
 // this tree moves under cloud/, so the depth changes at the copy even though the layout does not.
 export const RELAY_WORKFLOW_DIRECTORY = new URL('../../../.github/workflows/', import.meta.url)
+
+// Repository root, derived from the one directory above that already tracks the copy's depth.
+export const RELAY_REPOSITORY_ROOT = new URL('../../', RELAY_WORKFLOW_DIRECTORY)
+
+// Repository-relative path for a file in this tree. The prefix is 'cloud/' here and empty where
+// the tree is the repository root, so callers naming git paths never restate the layout.
+export function relayTreePath(suffix) {
+  const prefix = relative(
+    fileURLToPath(RELAY_REPOSITORY_ROOT),
+    fileURLToPath(new URL('../../', import.meta.url))
+  ).split(/[\\/]/).filter(Boolean)
+  return [...prefix, suffix].join('/')
+}
 
 export function relayWorkflowFile(name) {
   return `${RELAY_WORKFLOW_FILE_PREFIX}${name}`


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​233 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​144 |

<!-- /orca-pr-loc -->

## Problem

The relay same-cap roll is blocked by unrelated pull-request traffic, not by fleet health.

A same-cap `canary-apply` requires a green 15-minute monitor dry-run. `relay-monitor-evidence.mjs verify-authority` rejected the evidence unless `manifest.commitSha === GITHUB_SHA`. Both workflows must run at `--ref main` (the production environment is main-only and every job gates on `github.ref == 'refs/heads/main'`), and main currently takes an unrelated merge every 5-10 minutes. So the canary always resolved a newer main SHA than the monitor that produced its evidence.

Three consecutive green monitor gates were invalidated this way:

- `33927238469`
- `33930229711`
- `33931177390`

Canary run `33928330631` failed at 23:09:07Z with `relay monitor evidence provenance does not match`, before any mutation.

## Intent preserved

The deployer must only trust evidence produced by the same monitor code and the same workflow definitions it would itself run, and that evidence must still be fresh and for the same expected selector and policy. Binding to the exact commit over-approximates that: it also rejects evidence whose monitor code is byte-identical.

`verify-authority` now accepts a manifest whose `commitSha` differs from `GITHUB_SHA` if and only if both hold:

1. the manifest commit is an ancestor of the current commit (`git merge-base --is-ancestor`), and
2. `git diff` between the two commits over the trusted path set is empty.

An exact SHA match still passes without invoking git at all.

Every other check is untouched: freshness bound and wave-index growth, sample count, lineage window, migration policy, per-file hashes, unexpected-file rejection, and the live selector recheck. `verify-restore` and `verify-mutation` keep the exact-SHA bind, because both run at the commit that sealed the evidence they read.

## Trusted path set

Listed as `TRUSTED_EVIDENCE_CODE_PATHS` in the new `cloud/dev/scripts/relay-evidence-code-provenance.mjs`:

| Path | Why |
| --- | --- |
| `.github/workflows/cloud-monitor-relay-production.yml` | produces the evidence |
| `.github/workflows/cloud-monitor-relay-production-job.yml` | the reusable job that actually runs the monitor and seals the manifest |
| `.github/workflows/cloud-deploy-relay-production-same-cap.yml` | gate that consumes and single-uses the evidence |
| `.github/workflows/cloud-deploy-relay-production-same-cap-job.yml` | verifies authority and mutates |
| `.github/workflows/cloud-operate-relay-production-rehome.yml` | the other `verify-authority` caller |
| `.github/workflows/cloud-operate-relay-production-rehome-job.yml` | same |
| `cloud/dev/scripts/relay-evidence-code-provenance.mjs` | the rule itself and this list |
| `cloud/dev/scripts/relay-monitor-evidence.mjs` | seals and verifies the manifest |
| `cloud/dev/scripts/relay-production-same-cap-wave.mjs` | wave validation and canary authority |
| `cloud/dev/scripts/relay-repository.mjs` | resolves every path above |
| `cloud/dev/scripts/infra.mjs` | run by the mutation job |
| `cloud/dev/scripts/operate-relay-regional-rehome.mjs` | run by the mutation job |
| `cloud/dev/scripts/prepare-relay-production-capacity-canary.mjs` | run by the mutation job |
| `cloud/dev/scripts/probe-relay-rehome-trust.mjs` | run by the mutation job |
| `cloud/dev/scripts/validate-relay-capacity-plan.mjs` | run by the mutation job |
| `cloud/dev/scripts/verify-relay-capacity-transition.mjs` | run by the mutation job |
| `cloud/apps/relay-ops/` (whole directory) | the monitor and the live preflight recheck |
| `cloud/package.json` | defines `incident:relay-preflight` and `incident:relay` |
| `cloud/pnpm-lock.yaml` | relay-ops dependency versions |
| `cloud/pnpm-workspace.yaml` | which packages those filters resolve to |
| `.github/actions/cloud-sql-rollout-lease` | the lease every mutation job takes and releases |

`relay-ops` imports nothing outside its own directory except `hono`, `zod`, and node builtins, so the package directory plus the lockfile closes over it.

Deliberately excluded: `cloud/infra/terraform`. It is data the deploy job plans against at HEAD, and the resulting plan is validated at apply time by `validate-relay-capacity-plan.mjs`. Pinning it to the evidence commit would add churn without adding provenance.

Over the last 90 days these paths took about 20 commits in total, against a main branch that merges every 5-10 minutes.

## Fail-closed cases

Every one of these rejects with a distinct message and never mutates:

- either SHA is not 40 hex characters
- `git` cannot be run at all
- the directory is not a git checkout
- either commit is unknown to the checkout, which is what a shallow clone produces
- ancestry cannot be determined
- the manifest commit is not an ancestor of the current commit
- any trusted path differs; the message names the changed files

## Checkout depth

`actions/checkout@v4` was used with its default `fetch-depth: 1` in all three jobs that verify sealed evidence, so the manifest commit would never be present and the check would fail closed on every run. I set `fetch-depth: 0` on those three checkouts rather than fetching the manifest commit explicitly, because the job cannot know the manifest SHA before it downloads and parses the artifact, and a bounded depth can silently be too shallow and reproduce exactly the block this PR removes. `cloud-verify.yml` and several release workflows already check out this repository at full depth. The same-cap gate job's timeout goes from 10 to 15 minutes for headroom.

## batch-apply canary

`relay-production-same-cap-wave.mjs verify-canary` had the identical problem: the gate compared `authority.commitSha` to `GITHUB_SHA`, and a batch dispatched after a canary always resolves a newer main. It now uses the same ancestor-plus-identical-trusted-paths rule. Every other field still pins the batch to that exact canary: run ID, both digests, entry selector generation, rehome generation, and cell membership.

## Verification

`node --test` over the full `cloud` dev-script list: 501 tests, 0 failures.

New tests build real temporary git repositories rather than mocking git, and cover exact match passing without git, an ancestor with no trusted-path diff passing, an ancestor with a trusted-path change failing with a message naming the file, a non-ancestor failing, an unknown commit failing closed, and a non-repository directory failing closed. One test asserts every trusted path still exists in the checkout, so a rename cannot silently drop a path from the comparison.

The command-line entry point was also exercised against this repository's real main history: evidence sealed 10 commits back is accepted at current main; a non-ancestor, an unknown commit, and a commit pair that straddles a `relay-ops` change are each rejected with their own message.
