### PR TITLE
fix: use fallback shell readiness and assert fish startup timing

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -27,8 +27,6 @@ const {
   isDaemonStaleForCurrentBundleMock: vi.fn(async () => false)
 }))
 
-const itOnPosix = process.platform === 'win32' ? it.skip : it
-
 vi.mock('./daemon-health', async (importOriginal) => {
   const actual = await importOriginal<typeof DaemonHealthModule>()
   return {
@@ -342,34 +340,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           Object.defineProperty(process, 'platform', platform)
         }
       }
-    })
-
-    itOnPosix('preserves the existing fast-start timing for fish', async () => {
-      await adapter.spawn({ cols: 80, rows: 24, command: 'codex', env: { SHELL: '/usr/bin/fish' } })
-      await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
-      expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith('codex\n')
-      expect(lastSpawnOpts).not.toEqual(
-        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
-      )
-    })
-
-    itOnPosix.each([
-      { command: 'codex' },
-      { command: 'codex', startupCommandDelivery: 'fast' as const },
-      { command: "codex 'linked issue context'", startupCommandDelivery: 'shell-ready' as const }
-    ])('waits past 300ms and submits once after readiness: %j', async (startup) => {
-      await adapter.spawn({ cols: 80, rows: 24, ...startup, env: { SHELL: '/bin/zsh' } })
-
-      await new Promise((resolve) => setTimeout(resolve, 350))
-      expect(lastSubprocess.write).not.toHaveBeenCalled()
-      expect(lastSpawnOpts).toEqual(
-        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
-      )
-      lastSubprocess._simulateData('\x1b]777;orca-shell-ready\x07')
-      lastSubprocess._simulateData('\r\nuser@host $ ')
-
-      await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
-      expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith(`${startup.command}\n`)
     })
   })
 

--- a/src/main/daemon/daemon-pty-session-spawn.ts
+++ b/src/main/daemon/daemon-pty-session-spawn.ts
@@ -13,7 +13,7 @@ import type { DaemonPtySpawnContext } from './daemon-pty-spawn-request'
 import type { ColdRestoreInfo } from './history-reader'
 import { mintPtySessionId } from './pty-session-id'
 import {
-  supportsPtyStartupBarrier,
+  shellPathSupportsPtyStartupBarrier,
   shellReadyMarkerComesFromLineEditor,
   resolvePtyShellPath
 } from './shell-ready'
@@ -216,10 +216,12 @@ export abstract class DaemonPtySessionSpawn extends DaemonPtySpawnResult {
     let effectiveCols = restoreInfo?.cols ?? opts.cols
     let effectiveRows = restoreInfo?.rows ?? opts.rows
 
-    const shellReadySupported = opts.command ? supportsPtyStartupBarrier(opts.env ?? {}) : false
-    const immediateMarker =
-      process.platform !== 'win32' &&
-      shellReadyMarkerComesFromLineEditor(opts.shellOverride || resolvePtyShellPath(opts.env ?? {}))
+    const effectiveShellPath =
+      process.platform !== 'win32' && opts.command
+        ? resolveUnixShellPath(opts.shellOverride || resolvePtyShellPath(opts.env ?? {}))
+        : ''
+    const shellReadySupported = shellPathSupportsPtyStartupBarrier(effectiveShellPath)
+    const immediateMarker = shellReadyMarkerComesFromLineEditor(effectiveShellPath)
     const shellReadyTimeoutMs =
       shellReadySupported &&
       !immediateMarker &&

--- a/src/main/daemon/daemon-pty-startup-delivery.test.ts
+++ b/src/main/daemon/daemon-pty-startup-delivery.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { rmSync } from 'node:fs'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import * as localPtyUtils from '../providers/local-pty-utils'
 import {
   createMockSubprocess,
@@ -62,10 +62,12 @@ describe('DaemonPtyAdapter startup delivery', () => {
     }
   })
 
-  itOnPosix.each(['environment', 'override'] as const)(
+  itOnPosix.for(['environment', 'override'] as const)(
     'waits for the fallback shell when the %s shell is missing',
-    async (source) => {
+    async (source, context) => {
       const missingShell = join(dir, 'missing-fish')
+      const fallbackName = basename(localPtyUtils.resolveUnixShellPath(missingShell))
+      context.skip(!['bash', 'zsh'].includes(fallbackName), 'Requires a Bash/zsh fallback')
       await adapter.spawn({
         cols: 80,
         rows: 24,

--- a/src/main/daemon/daemon-pty-startup-delivery.test.ts
+++ b/src/main/daemon/daemon-pty-startup-delivery.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { rmSync } from 'node:fs'
+import { join } from 'node:path'
+import * as localPtyUtils from '../providers/local-pty-utils'
+import {
+  createMockSubprocess,
+  startDaemonAdapterHarness,
+  waitFor,
+  type DaemonAdapterHarness,
+  type SpawnSubprocess
+} from './daemon-pty-adapter-test-harness'
+
+const itOnPosix = process.platform === 'win32' ? it.skip : it
+
+describe('DaemonPtyAdapter startup delivery', () => {
+  let harness: DaemonAdapterHarness
+  let adapter: DaemonAdapterHarness['adapter']
+  let dir: string
+  let lastSubprocess: ReturnType<typeof createMockSubprocess>
+  let lastSpawnOpts: Parameters<SpawnSubprocess>[0] | null
+
+  beforeEach(async () => {
+    lastSpawnOpts = null
+    harness = await startDaemonAdapterHarness((opts) => {
+      lastSpawnOpts = opts
+      lastSubprocess = createMockSubprocess()
+      return lastSubprocess
+    })
+    adapter = harness.adapter
+    dir = harness.dir
+  })
+
+  afterEach(async () => {
+    adapter.dispose()
+    await harness.server.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  itOnPosix('preserves the existing fast-start timing for fish', async () => {
+    // The mock subprocess represents installed fish even on hosts without it.
+    const resolveShell = vi
+      .spyOn(localPtyUtils, 'resolveUnixShellPath')
+      .mockReturnValue('/usr/bin/fish')
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    try {
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        command: 'codex',
+        env: { SHELL: '/usr/bin/fish' }
+      })
+      await vi.advanceTimersByTimeAsync(299)
+      expect(lastSubprocess.write).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith('codex\n')
+      expect(lastSpawnOpts).not.toEqual(
+        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
+      )
+    } finally {
+      vi.useRealTimers()
+      resolveShell.mockRestore()
+    }
+  })
+
+  itOnPosix.each(['environment', 'override'] as const)(
+    'waits for the fallback shell when the %s shell is missing',
+    async (source) => {
+      const missingShell = join(dir, 'missing-fish')
+      await adapter.spawn({
+        cols: 80,
+        rows: 24,
+        command: 'codex',
+        env: { SHELL: source === 'environment' ? missingShell : '/bin/sh' },
+        ...(source === 'override' ? { shellOverride: missingShell } : {})
+      })
+      await new Promise((resolve) => setTimeout(resolve, 350))
+      expect(lastSubprocess.write).not.toHaveBeenCalled()
+      expect(lastSpawnOpts).toEqual(
+        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
+      )
+      lastSubprocess._simulateData('\x1b]777;orca-shell-ready\x07\r\nuser@host $ ')
+      await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
+      expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith('codex\n')
+    }
+  )
+
+  itOnPosix.each([
+    { command: 'codex' },
+    { command: 'codex', startupCommandDelivery: 'fast' as const },
+    { command: "codex 'linked issue context'", startupCommandDelivery: 'shell-ready' as const }
+  ])('waits past 300ms and submits once after readiness: %j', async (startup) => {
+    await adapter.spawn({ cols: 80, rows: 24, ...startup, env: { SHELL: '/bin/zsh' } })
+
+    await new Promise((resolve) => setTimeout(resolve, 350))
+    expect(lastSubprocess.write).not.toHaveBeenCalled()
+    expect(lastSpawnOpts).toEqual(
+      expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
+    )
+    lastSubprocess._simulateData('\x1b]777;orca-shell-ready\x07')
+    lastSubprocess._simulateData('\r\nuser@host $ ')
+
+    await waitFor(() => vi.mocked(lastSubprocess.write).mock.calls.length > 0)
+    expect(lastSubprocess.write).toHaveBeenCalledExactlyOnceWith(`${startup.command}\n`)
+  })
+})

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -198,11 +198,9 @@ describePosix('daemon shell-ready launch config', () => {
   })
 
   it('extends the startup barrier to fish so launch commands queue until the prompt', async () => {
-    const { shellPathSupportsPtyStartupBarrier, supportsPtyStartupBarrier } =
-      await importFreshShellReady()
+    const { shellPathSupportsPtyStartupBarrier } = await importFreshShellReady()
 
     expect(shellPathSupportsPtyStartupBarrier('/opt/homebrew/bin/fish')).toBe(true)
-    expect(supportsPtyStartupBarrier({ SHELL: '/usr/local/bin/fish' })).toBe(true)
     // Why: unwrapped shells must stay off the barrier or their first command queues forever.
     expect(shellPathSupportsPtyStartupBarrier('/usr/bin/tcsh')).toBe(false)
   })

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -113,13 +113,6 @@ export function shellPathSupportsPtyStartupBarrier(shellPath: string): boolean {
   return shellName === 'zsh' || shellName === 'bash' || shellName === 'fish'
 }
 
-export function supportsPtyStartupBarrier(env: Record<string, string>): boolean {
-  if (process.platform === 'win32') {
-    return false
-  }
-  return shellPathSupportsPtyStartupBarrier(resolvePtyShellPath(env))
-}
-
 export type ShellLaunchConfig = {
   args: string[] | null
   env: Record<string, string>


### PR DESCRIPTION
## ELI5

When a saved shell no longer exists, Orca picks a working replacement. Startup must wait for that replacement to be ready, rather than use timing rules for the missing shell. This follow-up fixes two missed review comments from #18729.

## What Changed

- Resolve the effective Unix shell once before deciding whether startup readiness is supported and whether its marker permits immediate input. Reuse the same resolver as the actual launch plan.
- Test missing shells supplied through both SHELL and shellOverride: no command at 350 ms, then exactly one command after readiness; assert the existing compatibility hint is sent.
- Pin existing fish delivery to exactly 300 ms using fake timers. The review suggestion of less than 300 ms was incorrect: fish already uses a 300 ms fallback. No timing change is made to fish.
- Remove the now-unused environment-based readiness helper, and explicitly require Bash/zsh for fallback-marker test fixtures.
- Move startup delivery tests into a dedicated file, reusing the existing daemon/socket harness and keeping the adapter test below its line limit.

## Why

Checking only the configured shell can omit readiness or choose the short Codex timeout when the actual replacement is Bash/zsh. Merely fixing immediateMarker misses the separate shellReadySupported decision, so both now use the resolved path. No new delay, polling, subprocess, protocol field, or persistence change.

## Linked Issue

Follow-up to #18728 and merged PR #18729.

Review threads: https://github.com/stablyai/orca/pull/18729#discussion_r3938549324 and https://github.com/stablyai/orca/pull/18729#discussion_r3938549315

## Proof

The two new fallback tests were run against the merged production code, then against the fix:

| Implementation | Missing SHELL | Missing shellOverride |
| --- | --- | --- |
| Merged code | FAIL: command already written before readiness | FAIL: command already written before readiness |
| Fixed code | PASS: queued past 350 ms, executes once after marker | PASS: queued past 350 ms, executes once after marker |

Fish fake-clock assertion: zero writes at 299 ms, exactly one at 300 ms. This catches delayed delivery without wall-clock flakiness.

The original duplicate-echo screenshots and shell-startup benchmarks remain in #18729; this follow-up verifies the fallback edge case through the daemon/socket regression harness, not a new rendered UI capture.

## Testing

- 113 tests pass across adapter, managed-agent launch, Windows shell launch, shell readiness and flush gate suites. After splitting startup cases into their own file, all 55 adapter/startup tests pass again.
- After review cleanup, all 28 shell/startup tests pass with no skips on macOS.
- Node typecheck, changed-file oxlint, formatting and commit hooks pass.
- Tested on macOS; Windows launch branches are covered by existing unit contracts. This path remains disabled on native Windows. SSH relay behavior is unchanged; host daemon uses its own shell resolver. No mobile-facing schema or protocol changes.

## Review

Fable independently reviewed the complete original PR via Orca orchestration and confirmed both missed-comment fixes. Its report was static; the coordinator additionally reproduced the alternate-Bash latency case below. Follow-up inline comments (unused helper, fallback-fixture prerequisite) were fixed, replied to, and resolved; latest Pullfrog review reports no new issues.

Additional original-PR findings are tracked separately:
- #18768: a profile execing a different Bash binary loses readiness, leading to ~15 s fallback latency. Real-PTY comparison measured 311.6 ms with the previous 300 ms timeout policy versus 15003.6 ms with the current default. Configure the intended Bash directly as a workaround. This remains open and is not fixed by this PR; the existing exact-executable guard protects against non-shell impostors, so a name-only relaxation is inappropriate.
- #18767: existing relay and non-daemon local-provider duplicate-echo coverage gap (source-inspected, no new live capture).
- Other Fable notes concerned possible CI-test placement/flakiness and informational marker/hint semantics; no further production blocker was demonstrated. The PTY regression does run in CI shards, so it is not an absent test gate.

All configured CI checks pass or are path-filtered skips on `4b2705588226bcd2820b3ffe43e277bed5755621`.

## Agent skill upstream boundary

- [x] Not applicable; no skill changes.
