### PR TITLE
fix(native-chat): tell old mobile builds why a structured chat is missing

### DIFF
--- a/src/main/runtime/rpc/methods/session-tab-agent-capability-mutations.test.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-capability-mutations.test.ts
@@ -50,6 +50,8 @@ const METHODS = [
   }
 ] as const
 
+const DESTRUCTIVE_METHOD_NAMES = new Set(['session.tabs.close', 'session.tabs.closeLifecycle'])
+
 describe('session tab structured capability mutations', () => {
   for (const method of METHODS) {
     it(`rejects ${method.name} when the structured row is hidden`, async () => {
@@ -89,7 +91,9 @@ describe('session tab structured capability mutations', () => {
   }
 
   for (const method of METHODS) {
-    it(`allows ${method.name} on a row an old mobile client was prompted to update`, async () => {
+    const expectedToAllowPromptedRow = !DESTRUCTIVE_METHOD_NAMES.has(method.name)
+
+    it(`${expectedToAllowPromptedRow ? 'allows' : 'rejects'} ${method.name} on a row an old mobile client was prompted to update`, async () => {
       const { calls, dispatch } = createFixture([], {
         clientKind: 'mobile',
         structuredNativeChatEnabled: true
@@ -97,11 +101,13 @@ describe('session tab structured capability mutations', () => {
 
       const response = await dispatch(method.name, method.params('codex-session'))
 
-      expect(response.ok).toBe(true)
-      expect(calls[method.runtimeMethod as keyof typeof calls]).toHaveBeenCalled()
+      expect(response.ok).toBe(expectedToAllowPromptedRow)
+      expect(calls[method.runtimeMethod as keyof typeof calls]).toHaveBeenCalledTimes(
+        expectedToAllowPromptedRow ? 1 : 0
+      )
     })
 
-    it(`allows ${method.name} on a prompted Claude row for a mobile client without the Claude capability`, async () => {
+    it(`${expectedToAllowPromptedRow ? 'allows' : 'rejects'} ${method.name} on a prompted Claude row for a mobile client without the Claude capability`, async () => {
       const { calls, dispatch } = createFixture([STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY], {
         clientKind: 'mobile',
         structuredNativeChatEnabled: true
@@ -109,8 +115,10 @@ describe('session tab structured capability mutations', () => {
 
       const response = await dispatch(method.name, method.params('claude-session'))
 
-      expect(response.ok).toBe(true)
-      expect(calls[method.runtimeMethod as keyof typeof calls]).toHaveBeenCalled()
+      expect(response.ok).toBe(expectedToAllowPromptedRow)
+      expect(calls[method.runtimeMethod as keyof typeof calls]).toHaveBeenCalledTimes(
+        expectedToAllowPromptedRow ? 1 : 0
+      )
     })
   }
 

--- a/src/main/runtime/rpc/methods/session-tab-agent-capability-mutations.test.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-capability-mutations.test.ts
@@ -88,6 +88,32 @@ describe('session tab structured capability mutations', () => {
     })
   }
 
+  for (const method of METHODS) {
+    it(`allows ${method.name} on a row an old mobile client was prompted to update`, async () => {
+      const { calls, dispatch } = createFixture([], {
+        clientKind: 'mobile',
+        structuredNativeChatEnabled: true
+      })
+
+      const response = await dispatch(method.name, method.params('codex-session'))
+
+      expect(response.ok).toBe(true)
+      expect(calls[method.runtimeMethod as keyof typeof calls]).toHaveBeenCalled()
+    })
+
+    it(`allows ${method.name} on a prompted Claude row for a mobile client without the Claude capability`, async () => {
+      const { calls, dispatch } = createFixture([STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY], {
+        clientKind: 'mobile',
+        structuredNativeChatEnabled: true
+      })
+
+      const response = await dispatch(method.name, method.params('claude-session'))
+
+      expect(response.ok).toBe(true)
+      expect(calls[method.runtimeMethod as keyof typeof calls]).toHaveBeenCalled()
+    })
+  }
+
   it.each(['session.tabs.close', 'session.tabs.closeLifecycle'] as const)(
     'allows capable mobile clients to close structured tabs when the experiment is enabled (%s)',
     async (method) => {
@@ -131,7 +157,10 @@ describe('session tab structured capability mutations', () => {
   )
 })
 
-function createFixture(capabilities: RuntimeCapability[]) {
+function createFixture(
+  capabilities: RuntimeCapability[],
+  options: { clientKind?: 'mobile' | 'runtime'; structuredNativeChatEnabled?: boolean } = {}
+) {
   const snapshot = agentSnapshot()
   const calls = {
     closeMobileSessionTab: vi.fn().mockResolvedValue({ closed: true }),
@@ -142,11 +171,14 @@ function createFixture(capabilities: RuntimeCapability[]) {
   const runtime = {
     getRuntimeId: () => 'test-runtime',
     listMobileSessionTabs: vi.fn().mockResolvedValue(snapshot),
+    getClientSettings: () => ({
+      experimentalStructuredNativeChat: options.structuredNativeChatEnabled === true
+    }),
     ...calls
   } as unknown as OrcaRuntimeService
   const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
   const context: RpcDispatchStreamingOptions = {
-    clientKind: 'runtime',
+    clientKind: options.clientKind ?? 'runtime',
     pairedDeviceId: 'paired-client',
     clientCapabilities: capabilities
   }

--- a/src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../shared/protocol-version'
 import type { RuntimeMobileSessionTabsSnapshot } from '../../../../shared/runtime-types'
 import {
+  CLAUDE_STRUCTURED_CHAT_DESKTOP_ONLY_TAB_TITLE,
   STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE,
   projectSessionTabAgentStatus
 } from './session-tab-agent-status-projection'
@@ -180,7 +181,7 @@ describe('projectSessionTabAgentStatus', () => {
     expect(projected.activeTabType).toBe('agent-session')
   })
 
-  it('prompts a Claude row to update on mobile instead of withholding it', () => {
+  it('uses a desktop fallback for an unsupported Claude row instead of withholding it', () => {
     const projected = projectSessionTabAgentStatus(
       claudeSnapshot,
       'mobile',
@@ -195,7 +196,7 @@ describe('projectSessionTabAgentStatus', () => {
     ])
     expect(projected.tabs.map((tab) => tab.title)).toEqual([
       'Codex Chat',
-      STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE
+      CLAUDE_STRUCTURED_CHAT_DESKTOP_ONLY_TAB_TITLE
     ])
     // Nothing is removed, so the layout it belonged to is untouched.
     expect(projected.tabGroups?.map((group) => group.id)).toEqual(['group-a', 'group-b'])
@@ -203,14 +204,28 @@ describe('projectSessionTabAgentStatus', () => {
     expect(projected.activeTabId).toBe('agent-session:codex')
   })
 
-  it('prompts every structured row to update on a mobile client with no capabilities', () => {
+  it('projects agent-specific fallback titles for a mobile client with no capabilities', () => {
     const projected = projectSessionTabAgentStatus(claudeSnapshot, 'mobile', [], true)
 
     expect(projected.tabs.map((tab) => tab.title)).toEqual([
       STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE,
-      STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE
+      CLAUDE_STRUCTURED_CHAT_DESKTOP_ONLY_TAB_TITLE
     ])
     expect(projected.tabGroupLayout).toEqual(claudeSnapshot.tabGroupLayout)
+  })
+
+  it('does not treat the Claude capability as a substitute for the base structured capability', () => {
+    const projected = projectSessionTabAgentStatus(
+      claudeSnapshot,
+      'mobile',
+      [CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY],
+      true
+    )
+
+    expect(projected.tabs.map((tab) => tab.title)).toEqual([
+      STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE,
+      CLAUDE_STRUCTURED_CHAT_DESKTOP_ONLY_TAB_TITLE
+    ])
   })
 
   it('shows both real titles once mobile negotiates Claude', () => {

--- a/src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts
@@ -5,7 +5,10 @@ import {
   STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY
 } from '../../../../shared/protocol-version'
 import type { RuntimeMobileSessionTabsSnapshot } from '../../../../shared/runtime-types'
-import { projectSessionTabAgentStatus } from './session-tab-agent-status-projection'
+import {
+  STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE,
+  projectSessionTabAgentStatus
+} from './session-tab-agent-status-projection'
 
 function makeSnapshot(sessionBoundary: boolean): RuntimeMobileSessionTabsSnapshot {
   return {
@@ -160,23 +163,82 @@ describe('projectSessionTabAgentStatus', () => {
     CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY
   ]
 
-  it.each([
-    ['mobile', 'mobile' as const, [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]],
-    ['runtime', 'runtime' as const, [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]]
-  ])(
-    'withholds Claude rows from a paired %s client that never negotiated them',
-    (_name, clientKind, capabilities) => {
-      const projected = projectSessionTabAgentStatus(claudeSnapshot, clientKind, capabilities, true)
+  it('withholds Claude rows from a paired runtime client that never negotiated them', () => {
+    const projected = projectSessionTabAgentStatus(
+      claudeSnapshot,
+      'runtime',
+      [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY],
+      true
+    )
 
-      expect(projected.tabs.map((tab) => tab.id)).toEqual(['agent-session:codex'])
-      // A row pruned from `tabs` but left in the layout is its own dead tab.
-      expect(projected.tabGroups?.map((group) => group.id)).toEqual(['group-a'])
-      expect(projected.tabGroupLayout).toEqual({ type: 'leaf', groupId: 'group-a' })
-      expect(projected.activeGroupId).toBe('group-a')
-      expect(projected.activeTabId).toBe('agent-session:codex')
-      expect(projected.activeTabType).toBe('agent-session')
+    expect(projected.tabs.map((tab) => tab.id)).toEqual(['agent-session:codex'])
+    // A row pruned from `tabs` but left in the layout is its own dead tab.
+    expect(projected.tabGroups?.map((group) => group.id)).toEqual(['group-a'])
+    expect(projected.tabGroupLayout).toEqual({ type: 'leaf', groupId: 'group-a' })
+    expect(projected.activeGroupId).toBe('group-a')
+    expect(projected.activeTabId).toBe('agent-session:codex')
+    expect(projected.activeTabType).toBe('agent-session')
+  })
+
+  it('prompts a Claude row to update on mobile instead of withholding it', () => {
+    const projected = projectSessionTabAgentStatus(
+      claudeSnapshot,
+      'mobile',
+      [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY],
+      true
+    )
+
+    // The row survives so the chat the desktop shows is not simply absent on the phone.
+    expect(projected.tabs.map((tab) => tab.id)).toEqual([
+      'agent-session:codex',
+      'agent-session:claude'
+    ])
+    expect(projected.tabs.map((tab) => tab.title)).toEqual([
+      'Codex Chat',
+      STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE
+    ])
+    // Nothing is removed, so the layout it belonged to is untouched.
+    expect(projected.tabGroups?.map((group) => group.id)).toEqual(['group-a', 'group-b'])
+    expect(projected.tabGroupLayout).toEqual(claudeSnapshot.tabGroupLayout)
+    expect(projected.activeTabId).toBe('agent-session:codex')
+  })
+
+  it('prompts every structured row to update on a mobile client with no capabilities', () => {
+    const projected = projectSessionTabAgentStatus(claudeSnapshot, 'mobile', [], true)
+
+    expect(projected.tabs.map((tab) => tab.title)).toEqual([
+      STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE,
+      STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE
+    ])
+    expect(projected.tabGroupLayout).toEqual(claudeSnapshot.tabGroupLayout)
+  })
+
+  it('shows both real titles once mobile negotiates Claude', () => {
+    expect(projectSessionTabAgentStatus(claudeSnapshot, 'mobile', structuredMobile, true)).toBe(
+      claudeSnapshot
+    )
+  })
+
+  // Why: updating cannot reveal a chat the desktop is not serving, so the prompt would lie.
+  it('withholds rather than prompts when the desktop experiment is off', () => {
+    for (const capabilities of [
+      [],
+      [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY],
+      structuredMobile
+    ]) {
+      const projected = projectSessionTabAgentStatus(claudeSnapshot, 'mobile', capabilities, false)
+      expect(projected.tabs).toEqual([])
     }
-  )
+  })
+
+  it('never emits an empty structured tab title', () => {
+    for (const capabilities of [[], [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]]) {
+      const projected = projectSessionTabAgentStatus(claudeSnapshot, 'mobile', capabilities, true)
+      for (const tab of projected.tabs) {
+        expect(tab.title.length).toBeGreaterThan(0)
+      }
+    }
+  })
 
   it.each([
     ['mobile', 'mobile' as const, structuredMobile],

--- a/src/main/runtime/rpc/methods/session-tab-agent-status-projection.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-status-projection.ts
@@ -16,29 +16,39 @@ type SessionTabsPayload = RuntimeMobileSessionTabsResult | RuntimeMobileSessionT
 
 /** Capped at 128px / one line in every shipped mobile build, so ~15-18 characters render. */
 export const STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE = 'Update to view'
+export const CLAUDE_STRUCTURED_CHAT_DESKTOP_ONLY_TAB_TITLE = 'Open on desktop'
 
-/** Which structured tabs a mobile client should be shown as an update prompt instead of the real
- *  chat, or null when this client is not owed one. Keyed on the capability for THAT agent: a build
- *  that cannot render the chat gets a row telling it to update, because a later build can. */
-function resolveMobileUpdatePromptScope(args: {
-  clientKind: 'mobile' | 'runtime' | undefined
+function clientCanRenderStructuredAgentSessionTab(
+  tab: RuntimeMobileSessionAgentTab,
   clientCapabilities: readonly RuntimeCapability[] | undefined
-  structuredNativeChatEnabled?: boolean
-}): ((tab: RuntimeMobileSessionAgentTab) => boolean) | null {
-  if (args.clientKind !== 'mobile') {
+): boolean {
+  if (!clientCapabilities?.includes(STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)) {
+    return false
+  }
+  return (
+    tab.agent === 'codex' ||
+    clientCapabilities.includes(CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)
+  )
+}
+
+function resolveMobileStructuredChatFallbackTitle(
+  tab: RuntimeMobileSessionAgentTab,
+  args: {
+    clientKind: 'mobile' | 'runtime' | undefined
+    clientCapabilities: readonly RuntimeCapability[] | undefined
+    structuredNativeChatEnabled?: boolean
+  }
+): string | null {
+  if (
+    args.clientKind !== 'mobile' ||
+    args.structuredNativeChatEnabled !== true ||
+    clientCanRenderStructuredAgentSessionTab(tab, args.clientCapabilities)
+  ) {
     return null
   }
-  // Why: with the experiment off there is no chat to reach after updating, so the prompt would lie.
-  if (args.structuredNativeChatEnabled !== true) {
-    return null
-  }
-  if (!args.clientCapabilities?.includes(STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)) {
-    return () => true
-  }
-  if (!args.clientCapabilities.includes(CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)) {
-    return (tab) => tab.agent !== 'codex'
-  }
-  return null
+  return tab.agent === 'claude'
+    ? CLAUDE_STRUCTURED_CHAT_DESKTOP_ONLY_TAB_TITLE
+    : STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE
 }
 
 export function projectSessionTabAgentStatus<TPayload extends SessionTabsPayload>(
@@ -52,16 +62,15 @@ export function projectSessionTabAgentStatus<TPayload extends SessionTabsPayload
     clientCapabilities,
     structuredNativeChatEnabled
   })
-  const updatePromptScope = resolveMobileUpdatePromptScope({
-    clientKind,
-    clientCapabilities,
-    structuredNativeChatEnabled
-  })
   let projected: TPayload
-  if (updatePromptScope) {
+  if (clientKind === 'mobile' && structuredNativeChatEnabled === true) {
     // Why: deleting the row left the user hunting for a chat the desktop says exists; the row
     // survives with a title naming the fix. Nothing is removed, so no group/layout repair applies.
-    projected = promptAgentSessionTabsToUpdate(payload, updatePromptScope)
+    projected = projectUnsupportedAgentSessionTabTitles(payload, {
+      clientKind,
+      clientCapabilities,
+      structuredNativeChatEnabled
+    })
   } else {
     projected = structuredVisible ? payload : projectAgentSessionTabsOut(payload, () => true)
     // Why: a paired client renders only codex structured tabs unless it says otherwise
@@ -95,19 +104,45 @@ export function projectSessionTabAgentStatus<TPayload extends SessionTabsPayload
   return changed ? ({ ...projected, tabs } as TPayload) : projected
 }
 
-function promptAgentSessionTabsToUpdate<TPayload extends SessionTabsPayload>(
+function projectUnsupportedAgentSessionTabTitles<TPayload extends SessionTabsPayload>(
   payload: TPayload,
-  shouldPrompt: (tab: RuntimeMobileSessionAgentTab) => boolean
+  args: {
+    clientKind: 'mobile'
+    clientCapabilities: readonly RuntimeCapability[] | undefined
+    structuredNativeChatEnabled: true
+  }
 ): TPayload {
   let changed = false
   const tabs = payload.tabs.map((tab) => {
-    if (tab.type !== 'agent-session' || !shouldPrompt(tab)) {
+    if (tab.type !== 'agent-session') {
+      return tab
+    }
+    const title = resolveMobileStructuredChatFallbackTitle(tab, args)
+    if (title === null) {
       return tab
     }
     changed = true
-    return { ...tab, title: STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE }
+    return { ...tab, title }
   })
   return changed ? ({ ...payload, tabs } as TPayload) : payload
+}
+
+export function assertAgentSessionTabDestructiveMutationSupported(
+  payload: SessionTabsPayload,
+  tabId: string,
+  clientKind: 'mobile' | 'runtime' | undefined,
+  clientCapabilities: readonly RuntimeCapability[] | undefined
+): void {
+  if (clientKind === undefined) {
+    return
+  }
+  const tab = payload.tabs.find((candidate) => candidate.id === tabId)
+  if (
+    tab?.type === 'agent-session' &&
+    !clientCanRenderStructuredAgentSessionTab(tab, clientCapabilities)
+  ) {
+    throw new Error('structured_agent_session_unsupported')
+  }
 }
 
 function projectAgentSessionTabsOut<TPayload extends SessionTabsPayload>(

--- a/src/main/runtime/rpc/methods/session-tab-agent-status-projection.ts
+++ b/src/main/runtime/rpc/methods/session-tab-agent-status-projection.ts
@@ -1,6 +1,7 @@
 import {
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
   CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY,
+  STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY,
   type RuntimeCapability
 } from '../../../../shared/protocol-version'
 import type {
@@ -13,6 +14,33 @@ import { structuredNativeChatProjectionEnabled } from './structured-agent-sessio
 
 type SessionTabsPayload = RuntimeMobileSessionTabsResult | RuntimeMobileSessionTabsSnapshot
 
+/** Capped at 128px / one line in every shipped mobile build, so ~15-18 characters render. */
+export const STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE = 'Update to view'
+
+/** Which structured tabs a mobile client should be shown as an update prompt instead of the real
+ *  chat, or null when this client is not owed one. Keyed on the capability for THAT agent: a build
+ *  that cannot render the chat gets a row telling it to update, because a later build can. */
+function resolveMobileUpdatePromptScope(args: {
+  clientKind: 'mobile' | 'runtime' | undefined
+  clientCapabilities: readonly RuntimeCapability[] | undefined
+  structuredNativeChatEnabled?: boolean
+}): ((tab: RuntimeMobileSessionAgentTab) => boolean) | null {
+  if (args.clientKind !== 'mobile') {
+    return null
+  }
+  // Why: with the experiment off there is no chat to reach after updating, so the prompt would lie.
+  if (args.structuredNativeChatEnabled !== true) {
+    return null
+  }
+  if (!args.clientCapabilities?.includes(STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)) {
+    return () => true
+  }
+  if (!args.clientCapabilities.includes(CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)) {
+    return (tab) => tab.agent !== 'codex'
+  }
+  return null
+}
+
 export function projectSessionTabAgentStatus<TPayload extends SessionTabsPayload>(
   payload: TPayload,
   clientKind: 'mobile' | 'runtime' | undefined,
@@ -24,16 +52,28 @@ export function projectSessionTabAgentStatus<TPayload extends SessionTabsPayload
     clientCapabilities,
     structuredNativeChatEnabled
   })
-  let projected = structuredVisible ? payload : projectAgentSessionTabsOut(payload, () => true)
-  // Why: a paired client renders only codex structured tabs unless it says otherwise
-  // (mobile's resolveMobileNativeChat returns null for every other agent), so an
-  // ungated row would list and select into a pane that shows neither chat nor terminal.
-  if (
-    structuredVisible &&
-    clientKind !== undefined &&
-    !clientCapabilities?.includes(CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)
-  ) {
-    projected = projectAgentSessionTabsOut(projected, (tab) => tab.agent !== 'codex')
+  const updatePromptScope = resolveMobileUpdatePromptScope({
+    clientKind,
+    clientCapabilities,
+    structuredNativeChatEnabled
+  })
+  let projected: TPayload
+  if (updatePromptScope) {
+    // Why: deleting the row left the user hunting for a chat the desktop says exists; the row
+    // survives with a title naming the fix. Nothing is removed, so no group/layout repair applies.
+    projected = promptAgentSessionTabsToUpdate(payload, updatePromptScope)
+  } else {
+    projected = structuredVisible ? payload : projectAgentSessionTabsOut(payload, () => true)
+    // Why: a paired client renders only codex structured tabs unless it says otherwise
+    // (mobile's resolveMobileNativeChat returns null for every other agent), so an
+    // ungated row would list and select into a pane that shows neither chat nor terminal.
+    if (
+      structuredVisible &&
+      clientKind !== undefined &&
+      !clientCapabilities?.includes(CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)
+    ) {
+      projected = projectAgentSessionTabsOut(projected, (tab) => tab.agent !== 'codex')
+    }
   }
   // Why: only paired runtimes have legacy `done` completion side effects; mobile must keep its row without changing the exact v2 auth shape.
   if (
@@ -53,6 +93,21 @@ export function projectSessionTabAgentStatus<TPayload extends SessionTabsPayload
     return legacyTab
   })
   return changed ? ({ ...projected, tabs } as TPayload) : projected
+}
+
+function promptAgentSessionTabsToUpdate<TPayload extends SessionTabsPayload>(
+  payload: TPayload,
+  shouldPrompt: (tab: RuntimeMobileSessionAgentTab) => boolean
+): TPayload {
+  let changed = false
+  const tabs = payload.tabs.map((tab) => {
+    if (tab.type !== 'agent-session' || !shouldPrompt(tab)) {
+      return tab
+    }
+    changed = true
+    return { ...tab, title: STRUCTURED_CHAT_UPDATE_REQUIRED_TAB_TITLE }
+  })
+  return changed ? ({ ...payload, tabs } as TPayload) : payload
 }
 
 function projectAgentSessionTabsOut<TPayload extends SessionTabsPayload>(

--- a/src/main/runtime/rpc/methods/session-tab-close-methods.ts
+++ b/src/main/runtime/rpc/methods/session-tab-close-methods.ts
@@ -3,6 +3,7 @@ import { SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY } from '../../../../shared/
 import { defineMethod, type RpcAnyMethod } from '../core'
 import { CloseLifecycleTab, CloseTab } from './session-tabs-schemas'
 import { assertProjectedSessionTabVisible } from './session-tab-browser-placement-projection'
+import { assertAgentSessionTabDestructiveMutationSupported } from './session-tab-agent-status-projection'
 import { projectSessionTabsForClient } from './session-tabs-inventory'
 import { isStructuredNativeChatEnabled } from './structured-agent-session-policy'
 
@@ -12,8 +13,12 @@ export const SESSION_TAB_CLOSE_METHODS: RpcAnyMethod[] = [
     params: CloseTab,
     handler: async (params, context) => {
       if (context.clientKind) {
+        const raw = await context.runtime.listMobileSessionTabs(
+          params.worktree,
+          context.pairedDeviceId
+        )
         const visible = projectSessionTabsForClient(
-          await context.runtime.listMobileSessionTabs(params.worktree, context.pairedDeviceId),
+          raw,
           context.clientKind,
           context.clientCapabilities,
           context.clientKind === 'mobile'
@@ -21,6 +26,12 @@ export const SESSION_TAB_CLOSE_METHODS: RpcAnyMethod[] = [
             : undefined
         )
         assertProjectedSessionTabVisible(visible, params.tabId)
+        assertAgentSessionTabDestructiveMutationSupported(
+          raw,
+          params.tabId,
+          context.clientKind,
+          context.clientCapabilities
+        )
       }
       const requiresIntent =
         context.clientKind === undefined ||
@@ -81,8 +92,12 @@ export const SESSION_TAB_CLOSE_METHODS: RpcAnyMethod[] = [
     params: CloseLifecycleTab,
     handler: async (params, context) => {
       if (context.clientKind) {
+        const raw = await context.runtime.listMobileSessionTabs(
+          params.worktree,
+          context.pairedDeviceId
+        )
         const visible = projectSessionTabsForClient(
-          await context.runtime.listMobileSessionTabs(params.worktree, context.pairedDeviceId),
+          raw,
           context.clientKind,
           context.clientCapabilities,
           context.clientKind === 'mobile'
@@ -90,6 +105,12 @@ export const SESSION_TAB_CLOSE_METHODS: RpcAnyMethod[] = [
             : undefined
         )
         assertProjectedSessionTabVisible(visible, params.tabId)
+        assertAgentSessionTabDestructiveMutationSupported(
+          raw,
+          params.tabId,
+          context.clientKind,
+          context.clientCapabilities
+        )
       }
       return withSpan(
         'runtime.session-tabs.close-lifecycle',

--- a/src/main/runtime/rpc/methods/session-tabs-structured-restore.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-structured-restore.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RpcDispatcher } from '../dispatcher'
+import type { RpcRequest } from '../core'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { SESSION_TAB_METHODS } from './session-tabs'
+
+function makeRequest(method: string, params?: unknown): RpcRequest {
+  return { id: 'req-1', authToken: 'tok', method, params }
+}
+
+describe('session tab structured restore gating', () => {
+  it('does not restore structured tabs for mobile while the host setting is off', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getClientSettings: vi.fn(() => ({ experimentalStructuredNativeChat: false })),
+      restoreStructuredAgentSessionTabs: vi.fn(),
+      listMobileSessionTabs: vi.fn().mockResolvedValue(visibleSnapshot())
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('session.tabs.list', { worktree: 'id:wt-1' }),
+      {
+        clientKind: 'mobile',
+        clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
+      }
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.restoreStructuredAgentSessionTabs).not.toHaveBeenCalled()
+  })
+
+  // Why: an old build has no capability to advertise, and skipping the restore left it with
+  // nothing to project after a desktop restart — neither the chat nor the prompt to update.
+  it('restores structured tabs for a mobile client that advertises no capability', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getClientSettings: vi.fn(() => ({ experimentalStructuredNativeChat: true })),
+      restoreStructuredAgentSessionTabs: vi.fn(),
+      listMobileSessionTabs: vi.fn().mockResolvedValue(visibleSnapshot())
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('session.tabs.list', { worktree: 'id:wt-1' }),
+      { clientKind: 'mobile', clientCapabilities: [] }
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.restoreStructuredAgentSessionTabs).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores structured tabs for mobile once the setting is present', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      getClientSettings: vi.fn(() => ({ experimentalStructuredNativeChat: true })),
+      restoreStructuredAgentSessionTabs: vi.fn(),
+      listMobileSessionTabs: vi.fn().mockResolvedValue(visibleSnapshot())
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('session.tabs.list', { worktree: 'id:wt-1' }),
+      {
+        clientKind: 'mobile',
+        clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
+      }
+    )
+
+    expect(response.ok).toBe(true)
+    expect(runtime.restoreStructuredAgentSessionTabs).toHaveBeenCalledTimes(1)
+  })
+})
+
+function visibleSnapshot() {
+  return {
+    worktree: 'wt-1',
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: 'group-1',
+    activeTabId: 'tab-1::leaf-1',
+    activeTabType: 'terminal' as const,
+    tabGroups: [{ id: 'group-1', activeTabId: 'tab-1', tabOrder: ['tab-1'] }],
+    tabs: [
+      {
+        type: 'terminal' as const,
+        id: 'tab-1::leaf-1',
+        parentTabId: 'tab-1',
+        leafId: 'leaf-1',
+        title: 'Terminal',
+        status: 'ready' as const,
+        terminal: 'pty-1',
+        isActive: true
+      }
+    ]
+  }
+}

--- a/src/main/runtime/rpc/methods/session-tabs-structured-restore.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-structured-restore.test.ts
@@ -32,7 +32,7 @@ describe('session tab structured restore gating', () => {
   })
 
   // Why: an old build has no capability to advertise, and skipping the restore left it with
-  // nothing to project after a desktop restart — neither the chat nor the prompt to update.
+  // nothing to project after a desktop restart — neither the chat nor its fallback row.
   it('restores structured tabs for a mobile client that advertises no capability', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -2,10 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
-import {
-  SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
-  STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY
-} from '../../../../shared/protocol-version'
+import { SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 import { SESSION_TAB_METHODS } from './session-tabs'
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
@@ -13,48 +10,6 @@ function makeRequest(method: string, params?: unknown): RpcRequest {
 }
 
 describe('session tab RPC methods', () => {
-  it('does not restore structured tabs for mobile while the host setting is off', async () => {
-    const runtime = {
-      getRuntimeId: () => 'test-runtime',
-      getClientSettings: vi.fn(() => ({ experimentalStructuredNativeChat: false })),
-      restoreStructuredAgentSessionTabs: vi.fn(),
-      listMobileSessionTabs: vi.fn().mockResolvedValue(visibleSnapshot())
-    } as unknown as OrcaRuntimeService
-    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
-
-    const response = await dispatcher.dispatch(
-      makeRequest('session.tabs.list', { worktree: 'id:wt-1' }),
-      {
-        clientKind: 'mobile',
-        clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
-      }
-    )
-
-    expect(response.ok).toBe(true)
-    expect(runtime.restoreStructuredAgentSessionTabs).not.toHaveBeenCalled()
-  })
-
-  it('restores structured tabs for mobile only after capability and setting are present', async () => {
-    const runtime = {
-      getRuntimeId: () => 'test-runtime',
-      getClientSettings: vi.fn(() => ({ experimentalStructuredNativeChat: true })),
-      restoreStructuredAgentSessionTabs: vi.fn(),
-      listMobileSessionTabs: vi.fn().mockResolvedValue(visibleSnapshot())
-    } as unknown as OrcaRuntimeService
-    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
-
-    const response = await dispatcher.dispatch(
-      makeRequest('session.tabs.list', { worktree: 'id:wt-1' }),
-      {
-        clientKind: 'mobile',
-        clientCapabilities: [STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY]
-      }
-    )
-
-    expect(response.ok).toBe(true)
-    expect(runtime.restoreStructuredAgentSessionTabs).toHaveBeenCalledTimes(1)
-  })
-
   it('routes mobile-only activation without notifying desktop clients', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/structured-agent-session-gate.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-gate.ts
@@ -2,11 +2,11 @@
 //
 // Shared by every structured method file so one gate governs the whole surface: a client that does
 // not advertise `agent-session.structured.v1` is told the surface does not exist rather than being
-// handed a session it cannot render or drive.
+// handed the session journal or mutation surface.
 //
 // This gate no longer implies such a client cannot make the host exist: session-tab restore runs
-// for every client so an old build still receives the update-prompt row, and that path constructs
-// the host. `agentSession.*` stays refused either way, which is what this gate is for.
+// for old mobile clients while structured chat is enabled so they receive a fallback row, and that
+// path constructs the host. `agentSession.*` stays refused either way, which is what this gate is for.
 
 import { getStructuredAgentSessionHost } from '../../../native-chat/agent-session-wire/structured-agent-session-registry'
 import type { StructuredAgentSessionHost } from '../../../native-chat/agent-session-wire/structured-agent-session-host'

--- a/src/main/runtime/rpc/methods/structured-agent-session-gate.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-gate.ts
@@ -2,8 +2,11 @@
 //
 // Shared by every structured method file so one gate governs the whole surface: a client that does
 // not advertise `agent-session.structured.v1` is told the surface does not exist rather than being
-// handed a session it cannot render or drive — and, just as importantly, cannot make the host EXIST
-// by calling into it, which is an observable side effect.
+// handed a session it cannot render or drive.
+//
+// This gate no longer implies such a client cannot make the host exist: session-tab restore runs
+// for every client so an old build still receives the update-prompt row, and that path constructs
+// the host. `agentSession.*` stays refused either way, which is what this gate is for.
 
 import { getStructuredAgentSessionHost } from '../../../native-chat/agent-session-wire/structured-agent-session-registry'
 import type { StructuredAgentSessionHost } from '../../../native-chat/agent-session-wire/structured-agent-session-host'

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -2,9 +2,8 @@
 //
 // Every method here is gated on the client advertising
 // `agent-session.structured.v1`. A client that does not is told the surface does
-// not exist rather than being handed a session it cannot render or drive; that
-// is the whole visibility rule, because nothing else on the runtime publishes a
-// structured session.
+// not exist rather than receiving the journal or mutation surface. Session-tab
+// inventory may expose only a metadata placeholder for an incapable mobile client.
 
 import {
   agentSessionFingerprintConflict,

--- a/src/main/runtime/rpc/methods/structured-session-tab-restore.ts
+++ b/src/main/runtime/rpc/methods/structured-session-tab-restore.ts
@@ -7,7 +7,7 @@ import {
 /** Republishes structured tabs into the host's own snapshot map.
  *
  *  Mobile is gated on the host setting alone, NOT on the client's capability: an old build is
- *  shown an update prompt in place of each chat, and gating on capability left it with nothing to
+ *  shown a fallback prompt in place of each chat, and gating on capability left it with nothing to
  *  project after a desktop restart — no chat and no prompt. The setting still gates it, because
  *  with structured chat off there is nothing for any mobile client to reach. Restoring spawns no
  *  provider child for a cleanly closed session. */

--- a/src/main/runtime/rpc/methods/structured-session-tab-restore.ts
+++ b/src/main/runtime/rpc/methods/structured-session-tab-restore.ts
@@ -1,13 +1,24 @@
 import type { RpcContext } from '../core'
-import { supportsStructuredAgentSessions } from './structured-agent-session-policy'
+import {
+  isStructuredNativeChatEnabled,
+  supportsStructuredAgentSessions
+} from './structured-agent-session-policy'
 
+/** Republishes structured tabs into the host's own snapshot map.
+ *
+ *  Mobile is gated on the host setting alone, NOT on the client's capability: an old build is
+ *  shown an update prompt in place of each chat, and gating on capability left it with nothing to
+ *  project after a desktop restart — no chat and no prompt. The setting still gates it, because
+ *  with structured chat off there is nothing for any mobile client to reach. Restoring spawns no
+ *  provider child for a cleanly closed session. */
 export async function restoreStructuredTabsIfSupported(
   context: Pick<RpcContext, 'runtime' | 'clientKind' | 'clientCapabilities'>
 ): Promise<void> {
-  if (
-    supportsStructuredAgentSessions(context) &&
-    typeof context.runtime.restoreStructuredAgentSessionTabs === 'function'
-  ) {
+  const shouldRestore =
+    context.clientKind === 'mobile'
+      ? isStructuredNativeChatEnabled(context.runtime)
+      : supportsStructuredAgentSessions(context)
+  if (shouldRestore && typeof context.runtime.restoreStructuredAgentSessionTabs === 'function') {
     await context.runtime.restoreStructuredAgentSessionTabs()
   }
 }

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -121,13 +121,12 @@ export const AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY =
   'agent-session.host-authority.v1' as const
 export const AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY =
   'agent-session.omp-resume-path.v1' as const
-// Why: structured sessions are journal-backed, not PTY-backed, so a client that
-// cannot read them must not see them at all — it would render an agent tab it
-// can neither display nor drive. The host also refuses every agentSession.*
-// method from a connection that does not advertise this.
+// Why: structured sessions are journal-backed, not PTY-backed, so an incapable client must not
+// receive their journal or drive their lifecycle. Mobile may receive a metadata-only placeholder;
+// the host still refuses agentSession.* methods and destructive tab mutations without capability.
 export const STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY = 'agent-session.structured.v1' as const
-// Why: mobile clients advertise Claude-structured session support during E2EE
-// pairing so the desktop can keep structured-specific affordances enabled.
+// Why: paired clients advertise Claude-structured support so the host can gate its agent-specific
+// journal and lifecycle surfaces independently from Codex support.
 export const CLAUDE_STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY =
   'agent-session.structured.claude.v1' as const
 // Why: paired structured clients explicitly hold every visible session surface, allowing the host

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -2,14 +2,13 @@
 // way the terminal wire harness is: current code against a real published release.
 //
 // Three skews matter here, and none can be checked from one build alone — an old
-// client must not be handed a session it cannot DRIVE, a new client must find an
-// old host's missing surface cleanly, and a client's cursor must survive the host
-// process that minted it.
+// client must not receive a journal-backed RPC surface it cannot read, a new client
+// must find an old host's missing surface cleanly, and a client's cursor must survive
+// the host process that minted it.
 //
-// "Cannot drive" is narrower than it used to be: the session-tabs projection now keeps the
-// row for an uncapable mobile client and retitles it as an update prompt, so the chat is not
-// simply absent on the phone. Every `agentSession.*` method stays refused, which is what the
-// tests below pin; the row-level behaviour is pinned in
+// The session-tabs projection may keep a metadata-only row for an incapable mobile client so the
+// chat is not simply absent on the phone. Every `agentSession.*` method and destructive close stays
+// refused, which is what the tests below pin; the row-level behaviour is pinned in
 // src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts.
 
 import { mkdtemp, rm } from 'node:fs/promises'

--- a/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
+++ b/tests/e2e/cross-version-wire/cross-version-agent-session-wire.unit.test.ts
@@ -2,9 +2,15 @@
 // way the terminal wire harness is: current code against a real published release.
 //
 // Three skews matter here, and none can be checked from one build alone — an old
-// client must not be shown a session it cannot render, a new client must find an
+// client must not be handed a session it cannot DRIVE, a new client must find an
 // old host's missing surface cleanly, and a client's cursor must survive the host
 // process that minted it.
+//
+// "Cannot drive" is narrower than it used to be: the session-tabs projection now keeps the
+// row for an uncapable mobile client and retitles it as an update prompt, so the chat is not
+// simply absent on the phone. Every `agentSession.*` method stays refused, which is what the
+// tests below pin; the row-level behaviour is pinned in
+// src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts.
 
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​67 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​175 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 |

<!-- /orca-pr-loc -->

## ELI5

You start a chat with Codex on your computer. You pick up your phone to check on it — and the chat
isn't there. No tab, no error, nothing. It looks like it never happened.

The reason is that your phone's app is older than the feature. The desktop knows an old app can't
display this kind of chat, so it hides it completely rather than showing something broken. The
problem is that "hide it completely" and "it doesn't exist" look identical from the couch.

This PR stops hiding it. The chat now appears on your phone as a tab that says **"Update to view"**.
You still can't read the chat on an old app — that genuinely needs the update — but you can see it
exists and you're told what to do about it.

## Before / After

| | Before | After |
|---|---|---|
| Workspace with a Codex chat, old phone | Nothing. No tab, no message. | Tab appears, titled **"Update to view"** |
| Tapping that tab | — | Opens to a blank pane; the tab title is the message |
| Same, after restarting the desktop | Still nothing | Tab is there |
| Claude chats | Nothing | Tab appears, titled **"Open on desktop"** |
| Once the phone supports that agent | Chat appears | Chat appears — unchanged |
| Phone is current, desktop feature is off | Nothing | Nothing — unchanged, deliberately |
| Desktop | Unchanged | Unchanged |

The last two rows are the ones worth checking: an up-to-date phone must never be told to update.

## What's in this PR

Three host-side changes. No mobile release needed — this reaches phones already in the App Store.

1. **The chat's tab is kept and retitled instead of deleted.** Old phones don't filter tab types
   they don't recognise, so they render whatever title the desktop sends. Nothing is removed, so
   the surrounding tabs, groups and layout are untouched.

2. **The fallback is decided per agent.** A phone that can show Codex chats but not Claude ones
   gets the real Codex tab and **"Open on desktop"** for Claude. An old phone gets
   **"Update to view"** for Codex. A phone whose desktop simply has the feature switched off gets
   nothing at all, because updating would not help it.

3. **The message survives a desktop restart.** Previously the desktop only rebuilt this list for
   phones that could already read it, so after a restart an old phone saw nothing — not even the
   message.

Tab titles are capped at about 15 characters on a phone, which is why the label is short.

## Mutation boundary

Because the tab is visible, an old phone can select and arrange the placeholder. Destructive close
and lifecycle-close require the relevant structured-chat capability and are refused for incapable
clients. This keeps the explanatory row without letting an old client tear down a chat it cannot
render. Tests pin the boundary for both Codex and Claude.

## Testing

Focused projection, mutation, restore, and cross-version wire suites pass. The tests cover Codex
and Claude fallbacks, missing/base/agent-specific capability combinations, restart restoration,
non-destructive placeholder actions, destructive-close refusal for incapable clients, and unchanged
behavior for capable and desktop-remote clients.

## Follow-ups, not in this PR

1. **Remember what each phone last reported about itself.** A current phone whose check-in gets lost
   on a bad connection currently looks identical to an old one, and would be shown the message. Needs
   to land before this feature becomes the default.
2. **Before replacing Claude's desktop fallback**, confirm the mobile build advertises
   `agent-session.structured.claude.v1` and actually renders Claude structured chat. Only then
   should the host expose the real Claude row.
3. **Check it on a real 0.0.47 build.** The blank pane and the exact truncation are read from the
   shipped app's source, not observed on a device.

Separately: a workspace running one of these chats shows no agent activity at all on mobile or in
`orca worktree ps`, even on an up-to-date phone. Different bug, planned separately.
