### PR TITLE
Show Claude background task status in Native Chat

### DIFF
--- a/src/main/claude/claude-agent-sdk-control-requests.test.ts
+++ b/src/main/claude/claude-agent-sdk-control-requests.test.ts
@@ -1,0 +1,26 @@
+import type { Query } from '@anthropic-ai/claude-agent-sdk'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createClaudeControlSurface } from './claude-agent-sdk-control-requests'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createClaudeControlSurface stopTask', () => {
+  it('bounds a lost reply and permits a later stop request', async () => {
+    vi.useFakeTimers()
+    const stopTask = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(() => new Promise(() => {}))
+      .mockResolvedValueOnce()
+    const controls = createClaudeControlSurface({ stopTask } as unknown as Query)
+    const timedOut = expect(controls.stopTask('task-1', { timeoutMs: 25 })).rejects.toThrow(
+      'claude stop_task request timed out'
+    )
+
+    await vi.advanceTimersByTimeAsync(25)
+    await timedOut
+    await expect(controls.stopTask('task-2', { timeoutMs: 25 })).resolves.toBeUndefined()
+    expect(stopTask).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/claude/claude-agent-sdk-control-requests.ts
+++ b/src/main/claude/claude-agent-sdk-control-requests.ts
@@ -91,6 +91,7 @@ export type ClaudeControlSurface = {
     settings: Parameters<Query['applyFlagSettings']>[0],
     options?: ClaudeControlOptions
   ) => Promise<void>
+  stopTask: (taskId: string, options?: ClaudeControlOptions) => Promise<void>
   supportedModels: (options?: ClaudeControlOptions) => Promise<unknown[]>
   initializationResult: (options?: ClaudeControlOptions) => Promise<unknown>
   getSettings: (options?: ClaudeControlOptions) => Promise<unknown>
@@ -135,6 +136,10 @@ export function createClaudeControlSurface(query: Query): ClaudeControlSurface {
         () => query.applyFlagSettings(settings),
         options?.timeoutMs
       ).then(() => {}),
+    stopTask: (taskId, options) =>
+      runClaudeControl('stop_task', () => query.stopTask(taskId), options?.timeoutMs).then(
+        () => {}
+      ),
     supportedModels: (options) =>
       runClaudeControl('list_models', () => query.supportedModels(), options?.timeoutMs),
     initializationResult: (options) =>

--- a/src/main/claude/claude-background-task-tracker.test.ts
+++ b/src/main/claude/claude-background-task-tracker.test.ts
@@ -38,7 +38,10 @@ describe('ClaudeBackgroundTaskTracker', () => {
     expect(tracker.state).toBeNull()
 
     expect(tracker.observe(result())).toBe(true)
-    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-1', kind: 'agent' }]
+    })
   })
 
   it('uses an explicit background update for a foreground task and ignores progress alone', () => {
@@ -56,7 +59,46 @@ describe('ClaudeBackgroundTaskTracker', () => {
     expect(tracker.state).toBeNull()
 
     tracker.observe(system('task_updated', { task_id: 'task-1', patch: { is_backgrounded: true } }))
-    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-1', kind: 'command' }]
+    })
+  })
+
+  it('publishes bounded display details when a running task description changes', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    expect(
+      tracker.observe(
+        system('task_started', {
+          task_id: 'task-1',
+          task_type: 'local_bash',
+          is_backgrounded: true,
+          description: '  run\n  the build  '
+        })
+      )
+    ).toBe(true)
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-1', kind: 'command', description: 'run the build' }]
+    })
+
+    expect(
+      tracker.observe(
+        system('task_updated', {
+          task_id: 'task-1',
+          patch: { description: 'x'.repeat(600) }
+        })
+      )
+    ).toBe(true)
+    expect(tracker.state?.tasks?.[0]?.description).toHaveLength(512)
+    expect(
+      tracker.observe(
+        system('task_updated', {
+          task_id: 'task-1',
+          patch: { description: 'x'.repeat(600) }
+        })
+      )
+    ).toBe(false)
   })
 
   it('replaces its roster from aggregate lifecycle frames and preserves stoppable provider ids', () => {
@@ -70,14 +112,24 @@ describe('ClaudeBackgroundTaskTracker', () => {
       )
     ).toBe(true)
     expect(tracker.stoppableTaskIds).toEqual(['task-agent', 'task-bash'])
-    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [
+        { id: 'task-agent', kind: 'agent', description: 'agent' },
+        { id: 'task-bash', kind: 'command', description: 'bash' }
+      ]
+    })
 
     expect(
       tracker.observe(
         aggregate([{ task_id: 'task-next', task_type: 'local_workflow', description: 'workflow' }])
       )
-    ).toBe(false)
+    ).toBe(true)
     expect(tracker.stoppableTaskIds).toEqual(['task-next'])
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-next', kind: 'workflow', description: 'workflow' }]
+    })
 
     expect(tracker.observe(aggregate([]))).toBe(true)
     expect(tracker.stoppableTaskIds).toEqual([])
@@ -127,7 +179,10 @@ describe('ClaudeBackgroundTaskTracker', () => {
     )
 
     expect(tracker.stoppableTaskIds).toEqual(['task-live'])
-    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-live', kind: 'agent', description: 'agent' }]
+    })
   })
 
   it('keeps terminal edges authoritative on either side of aggregate replacement', () => {
@@ -180,7 +235,10 @@ describe('ClaudeBackgroundTaskTracker', () => {
         task_type: 'monitor'
       })
     )
-    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-live', kind: 'monitor' }]
+    })
     expect(
       tracker.observe(system('task_updated', { task_id: 'task-live', patch: { status: 'killed' } }))
     ).toBe(true)
@@ -191,7 +249,10 @@ describe('ClaudeBackgroundTaskTracker', () => {
     for (const taskType of ['local_workflow', 'monitor']) {
       const tracker = new ClaudeBackgroundTaskTracker()
       tracker.observe(system('task_started', { task_id: taskType, task_type: taskType }))
-      expect(tracker.state).toEqual({ state: 'monitoring' })
+      expect(tracker.state).toEqual({
+        state: 'monitoring',
+        tasks: [{ id: taskType, kind: taskType === 'local_workflow' ? 'workflow' : 'monitor' }]
+      })
     }
   })
 
@@ -247,7 +308,10 @@ describe('ClaudeBackgroundTaskTracker', () => {
     expect(tracker.state).toBeNull()
 
     expect(tracker.observe(result())).toBe(true)
-    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(tracker.state).toEqual({
+      state: 'monitoring',
+      tasks: [{ id: 'task-live', kind: 'command', description: 'command' }]
+    })
   })
 
   it('ignores ambient SDK tasks and clears all liveness when the session ends', () => {

--- a/src/main/claude/claude-background-task-tracker.test.ts
+++ b/src/main/claude/claude-background-task-tracker.test.ts
@@ -118,6 +118,18 @@ describe('ClaudeBackgroundTaskTracker', () => {
     expect(tracker.state).toBeNull()
   })
 
+  it('lets an authoritative aggregate roster replace earlier terminal-edge evidence', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe(system('task_notification', { task_id: 'task-live', status: 'completed' }))
+
+    tracker.observe(
+      aggregate([{ task_id: 'task-live', task_type: 'local_agent', description: 'agent' }])
+    )
+
+    expect(tracker.stoppableTaskIds).toEqual(['task-live'])
+    expect(tracker.state).toEqual({ state: 'monitoring' })
+  })
+
   it('keeps terminal edges authoritative on either side of aggregate replacement', () => {
     const terminalFirst = new ClaudeBackgroundTaskTracker()
     terminalFirst.observe(

--- a/src/main/claude/claude-background-task-tracker.test.ts
+++ b/src/main/claude/claude-background-task-tracker.test.ts
@@ -54,7 +54,9 @@ describe('ClaudeBackgroundTaskTracker', () => {
         is_backgrounded: false
       })
     )
-    tracker.observe(system('task_progress', { task_id: 'task-1', description: 'still working' }))
+    expect(
+      tracker.observe(system('task_progress', { task_id: 'task-1', description: 'still working' }))
+    ).toBe(false)
     tracker.observe(result())
     expect(tracker.state).toBeNull()
 

--- a/src/main/claude/claude-background-task-tracker.test.ts
+++ b/src/main/claude/claude-background-task-tracker.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ClaudeBackgroundTaskTracker,
+  classifyClaudeBackgroundTaskKind
+} from './claude-background-task-tracker'
+
+function system(subtype: string, fields: Record<string, unknown>): Record<string, unknown> {
+  return { type: 'system', subtype, session_id: 'provider-1', uuid: crypto.randomUUID(), ...fields }
+}
+
+function result(): Record<string, unknown> {
+  return { type: 'result', subtype: 'success', session_id: 'provider-1', uuid: crypto.randomUUID() }
+}
+
+function aggregate(tasks: unknown[]): Record<string, unknown> {
+  return system('background_tasks_changed', { tasks })
+}
+
+describe('ClaudeBackgroundTaskTracker', () => {
+  it('classifies SDK task types without inferring them from descriptions', () => {
+    expect(classifyClaudeBackgroundTaskKind('local_agent')).toBe('agent')
+    expect(classifyClaudeBackgroundTaskKind('local_workflow')).toBe('workflow')
+    expect(classifyClaudeBackgroundTaskKind('local_bash')).toBe('command')
+    expect(classifyClaudeBackgroundTaskKind('monitor')).toBe('monitor')
+    expect(classifyClaudeBackgroundTaskKind('future_task')).toBe('unknown')
+  })
+
+  it('waits for the foreground turn to settle before monitoring a background task', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe({ type: 'user' }, true)
+    tracker.observe(
+      system('task_started', {
+        task_id: 'task-1',
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    )
+    expect(tracker.state).toBeNull()
+
+    expect(tracker.observe(result())).toBe(true)
+    expect(tracker.state).toEqual({ state: 'monitoring' })
+  })
+
+  it('uses an explicit background update for a foreground task and ignores progress alone', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe({ type: 'user' }, true)
+    tracker.observe(
+      system('task_started', {
+        task_id: 'task-1',
+        task_type: 'local_bash',
+        is_backgrounded: false
+      })
+    )
+    tracker.observe(system('task_progress', { task_id: 'task-1', description: 'still working' }))
+    tracker.observe(result())
+    expect(tracker.state).toBeNull()
+
+    tracker.observe(system('task_updated', { task_id: 'task-1', patch: { is_backgrounded: true } }))
+    expect(tracker.state).toEqual({ state: 'monitoring' })
+  })
+
+  it('replaces its roster from aggregate lifecycle frames and preserves stoppable provider ids', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    expect(
+      tracker.observe(
+        aggregate([
+          { task_id: 'task-agent', task_type: 'local_agent', description: 'agent' },
+          { task_id: 'task-bash', task_type: 'local_bash', description: 'bash' }
+        ])
+      )
+    ).toBe(true)
+    expect(tracker.stoppableTaskIds).toEqual(['task-agent', 'task-bash'])
+    expect(tracker.state).toEqual({ state: 'monitoring' })
+
+    expect(
+      tracker.observe(
+        aggregate([{ task_id: 'task-next', task_type: 'local_workflow', description: 'workflow' }])
+      )
+    ).toBe(false)
+    expect(tracker.stoppableTaskIds).toEqual(['task-next'])
+
+    expect(tracker.observe(aggregate([]))).toBe(true)
+    expect(tracker.stoppableTaskIds).toEqual([])
+    expect(tracker.state).toBeNull()
+  })
+
+  it('excludes ambient aggregate tasks', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe(
+      aggregate([
+        { task_id: 'ambient', task_type: 'monitor', description: 'watcher', ambient: true },
+        { task_id: 'visible', task_type: 'local_bash', description: 'command' }
+      ])
+    )
+
+    expect(tracker.stoppableTaskIds).toEqual(['visible'])
+  })
+
+  it('does not let late edge frames revive tasks cleared by an aggregate roster', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe(
+      aggregate([{ task_id: 'task-late', task_type: 'local_agent', description: 'agent' }])
+    )
+    tracker.observe(aggregate([]))
+
+    tracker.observe(
+      system('task_started', {
+        task_id: 'task-late',
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    )
+    tracker.observe(
+      system('task_updated', { task_id: 'task-late', patch: { is_backgrounded: true } })
+    )
+
+    expect(tracker.stoppableTaskIds).toEqual([])
+    expect(tracker.state).toBeNull()
+  })
+
+  it('keeps terminal edges authoritative on either side of aggregate replacement', () => {
+    const terminalFirst = new ClaudeBackgroundTaskTracker()
+    terminalFirst.observe(
+      system('task_notification', { task_id: 'task-first', status: 'completed' })
+    )
+    terminalFirst.observe(aggregate([]))
+    terminalFirst.observe(
+      system('task_started', {
+        task_id: 'task-first',
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    )
+    expect(terminalFirst.state).toBeNull()
+
+    const terminalLast = new ClaudeBackgroundTaskTracker()
+    terminalLast.observe(
+      aggregate([{ task_id: 'task-last', task_type: 'local_agent', description: 'agent' }])
+    )
+    terminalLast.observe(system('task_notification', { task_id: 'task-last', status: 'completed' }))
+    terminalLast.observe(
+      system('task_started', {
+        task_id: 'task-last',
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    )
+    expect(terminalLast.state).toBeNull()
+  })
+
+  it('keeps terminal evidence authoritative across duplicates and out-of-order starts', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    const terminal = system('task_notification', { task_id: 'task-late', status: 'completed' })
+    tracker.observe(terminal)
+    tracker.observe(terminal)
+    tracker.observe(
+      system('task_started', {
+        task_id: 'task-late',
+        task_type: 'local_workflow',
+        is_backgrounded: true
+      })
+    )
+    expect(tracker.state).toBeNull()
+
+    tracker.observe(
+      system('task_started', {
+        task_id: 'task-live',
+        task_type: 'monitor'
+      })
+    )
+    expect(tracker.state).toEqual({ state: 'monitoring' })
+    expect(
+      tracker.observe(system('task_updated', { task_id: 'task-live', patch: { status: 'killed' } }))
+    ).toBe(true)
+    expect(tracker.state).toBeNull()
+  })
+
+  it('recognizes task types that are registered only as background work', () => {
+    for (const taskType of ['local_workflow', 'monitor']) {
+      const tracker = new ClaudeBackgroundTaskTracker()
+      tracker.observe(system('task_started', { task_id: taskType, task_type: taskType }))
+      expect(tracker.state).toEqual({ state: 'monitoring' })
+    }
+  })
+
+  it('admits unknown background updates conservatively and bounds edge-only fallback ids', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe(
+      system('task_updated', { task_id: 'unknown', patch: { is_backgrounded: true } })
+    )
+    expect(tracker.stoppableTaskIds).toEqual(['unknown'])
+
+    for (let index = 0; index < 400; index += 1) {
+      tracker.observe(
+        system('task_started', {
+          task_id: `task-${index}`,
+          task_type: 'local_agent',
+          is_backgrounded: true
+        })
+      )
+    }
+    expect(tracker.stoppableTaskIds.length).toBeLessThanOrEqual(256)
+  })
+
+  it('bounds aggregate rosters and resets to the edge-only fallback on clear', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe(
+      aggregate(
+        Array.from({ length: 400 }, (_, index) => ({
+          task_id: `aggregate-${index}`,
+          task_type: 'local_bash',
+          description: 'command'
+        }))
+      )
+    )
+    expect(tracker.stoppableTaskIds).toHaveLength(256)
+
+    tracker.clear()
+    tracker.observe(
+      system('task_started', {
+        task_id: 'edge-after-reset',
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    )
+    expect(tracker.stoppableTaskIds).toEqual(['edge-after-reset'])
+  })
+
+  it('gates aggregate monitoring behind foreground turn completion', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe({ type: 'user' }, true)
+    tracker.observe(
+      aggregate([{ task_id: 'task-live', task_type: 'local_bash', description: 'command' }])
+    )
+    expect(tracker.state).toBeNull()
+
+    expect(tracker.observe(result())).toBe(true)
+    expect(tracker.state).toEqual({ state: 'monitoring' })
+  })
+
+  it('ignores ambient SDK tasks and clears all liveness when the session ends', () => {
+    const tracker = new ClaudeBackgroundTaskTracker()
+    tracker.observe(
+      system('task_started', {
+        task_id: 'ambient',
+        task_type: 'monitor',
+        is_backgrounded: true,
+        ambient: true
+      })
+    )
+    expect(tracker.state).toBeNull()
+    tracker.observe(
+      system('task_started', {
+        task_id: 'task-live',
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    )
+    expect(tracker.clear()).toBe(true)
+    expect(tracker.state).toBeNull()
+  })
+})

--- a/src/main/claude/claude-background-task-tracker.ts
+++ b/src/main/claude/claude-background-task-tracker.ts
@@ -85,7 +85,11 @@ export class ClaudeBackgroundTaskTracker {
     if (message.type === 'result') {
       this.foregroundTurnActive = false
     } else if (message.type === 'system') {
-      this.observeSystemFrame(message)
+      if (!this.observeSystemFrame(message) && !startsTurn) {
+        return false
+      }
+    } else if (!startsTurn) {
+      return false
     }
     return this.refreshMonitoring()
   }
@@ -98,27 +102,27 @@ export class ClaudeBackgroundTaskTracker {
     return this.refreshMonitoring()
   }
 
-  private observeSystemFrame(message: Record<string, unknown>): void {
+  private observeSystemFrame(message: Record<string, unknown>): boolean {
     if (message.subtype === 'background_tasks_changed') {
       this.replaceAggregateRoster(message.tasks)
-      return
+      return true
     }
     const id = taskId(message)
     if (!id) {
-      return
+      return false
     }
     if (message.subtype === 'task_notification') {
       this.finish(id)
-      return
+      return true
     }
     if (message.subtype === 'task_updated') {
       const patch = record(message.patch)
       if (!patch) {
-        return
+        return false
       }
       if (TERMINAL_TASK_STATES.has(String(patch.status))) {
         this.finish(id)
-        return
+        return true
       }
       const existing = this.tasks.get(id)
       if (
@@ -130,18 +134,19 @@ export class ClaudeBackgroundTaskTracker {
           kind: existing?.kind ?? 'unknown',
           description: taskDescription(patch.description) ?? existing?.description
         })
+        return true
       }
-      return
+      return false
     }
     if (message.subtype !== 'task_started' || this.terminalTaskIds.has(id)) {
-      return
+      return false
     }
     if (message.ambient === true || message.skip_transcript === true) {
       this.finish(id)
-      return
+      return true
     }
     if (this.aggregateRosterObserved && !this.tasks.has(id)) {
-      return
+      return false
     }
     const kind = classifyClaudeBackgroundTaskKind(message.task_type)
     this.upsert(id, {
@@ -149,6 +154,7 @@ export class ClaudeBackgroundTaskTracker {
       kind,
       description: taskDescription(message.description)
     })
+    return true
   }
 
   private replaceAggregateRoster(value: unknown): void {

--- a/src/main/claude/claude-background-task-tracker.ts
+++ b/src/main/claude/claude-background-task-tracker.ts
@@ -1,0 +1,204 @@
+import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
+
+const MAX_TRACKED_TASKS = 256
+const MAX_TASK_ID_LENGTH = 512
+const TERMINAL_TASK_STATES = new Set(['completed', 'failed', 'killed', 'stopped'])
+
+export type ClaudeBackgroundTaskKind = 'agent' | 'workflow' | 'command' | 'monitor' | 'unknown'
+
+type TrackedTask = {
+  backgrounded: boolean
+  kind: ClaudeBackgroundTaskKind
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : null
+}
+
+function taskId(message: Record<string, unknown>): string | null {
+  const value = message.task_id
+  return typeof value === 'string' && value.length > 0 && value.length <= MAX_TASK_ID_LENGTH
+    ? value
+    : null
+}
+
+export function classifyClaudeBackgroundTaskKind(taskType: unknown): ClaudeBackgroundTaskKind {
+  switch (taskType) {
+    case 'local_agent':
+      return 'agent'
+    case 'local_workflow':
+      return 'workflow'
+    case 'local_bash':
+      return 'command'
+    case 'monitor':
+      return 'monitor'
+    default:
+      return 'unknown'
+  }
+}
+
+export class ClaudeBackgroundTaskTracker {
+  private readonly tasks = new Map<string, TrackedTask>()
+  private readonly terminalTaskIds = new Set<string>()
+  private aggregateRosterObserved = false
+  private foregroundTurnActive = false
+  private monitoring = false
+
+  get state(): AgentSessionBackgroundTaskState | null {
+    return this.monitoring ? { state: 'monitoring' } : null
+  }
+
+  get stoppableTaskIds(): string[] {
+    const ids: string[] = []
+    for (const [id, task] of this.tasks) {
+      if (task.backgrounded) {
+        ids.push(id)
+      }
+    }
+    return ids
+  }
+
+  observe(message: Record<string, unknown>, startsTurn = false): boolean {
+    if (startsTurn) {
+      this.foregroundTurnActive = true
+    }
+    if (message.type === 'result') {
+      this.foregroundTurnActive = false
+    } else if (message.type === 'system') {
+      this.observeSystemFrame(message)
+    }
+    return this.refreshMonitoring()
+  }
+
+  clear(): boolean {
+    this.tasks.clear()
+    this.terminalTaskIds.clear()
+    this.aggregateRosterObserved = false
+    this.foregroundTurnActive = false
+    return this.refreshMonitoring()
+  }
+
+  private observeSystemFrame(message: Record<string, unknown>): void {
+    if (message.subtype === 'background_tasks_changed') {
+      this.replaceAggregateRoster(message.tasks)
+      return
+    }
+    const id = taskId(message)
+    if (!id) {
+      return
+    }
+    if (message.subtype === 'task_notification') {
+      this.finish(id)
+      return
+    }
+    if (message.subtype === 'task_updated') {
+      const patch = record(message.patch)
+      if (!patch) {
+        return
+      }
+      if (TERMINAL_TASK_STATES.has(String(patch.status))) {
+        this.finish(id)
+        return
+      }
+      if (patch.is_backgrounded === true && (!this.aggregateRosterObserved || this.tasks.has(id))) {
+        this.upsert(id, { backgrounded: true, kind: this.tasks.get(id)?.kind ?? 'unknown' })
+      }
+      return
+    }
+    if (message.subtype !== 'task_started' || this.terminalTaskIds.has(id)) {
+      return
+    }
+    if (message.ambient === true || message.skip_transcript === true) {
+      this.finish(id)
+      return
+    }
+    if (this.aggregateRosterObserved && !this.tasks.has(id)) {
+      return
+    }
+    const kind = classifyClaudeBackgroundTaskKind(message.task_type)
+    this.upsert(id, {
+      backgrounded: message.is_backgrounded === true || kind === 'workflow' || kind === 'monitor',
+      kind
+    })
+  }
+
+  private replaceAggregateRoster(value: unknown): void {
+    if (!Array.isArray(value)) {
+      return
+    }
+    this.aggregateRosterObserved = true
+    this.tasks.clear()
+    this.terminalTaskIds.clear()
+    for (const valueTask of value) {
+      if (this.tasks.size >= MAX_TRACKED_TASKS) {
+        break
+      }
+      const task = record(valueTask)
+      if (!task || task.ambient === true) {
+        continue
+      }
+      const id = taskId(task)
+      if (!id) {
+        continue
+      }
+      this.tasks.set(id, {
+        backgrounded: true,
+        kind: classifyClaudeBackgroundTaskKind(task.task_type)
+      })
+    }
+  }
+
+  private upsert(id: string, task: TrackedTask): void {
+    const existing = this.tasks.get(id)
+    if (existing) {
+      this.tasks.set(id, {
+        backgrounded: existing.backgrounded || task.backgrounded,
+        kind: existing.kind === 'unknown' ? task.kind : existing.kind
+      })
+      return
+    }
+    if (this.tasks.size >= MAX_TRACKED_TASKS) {
+      let foregroundId: string | undefined
+      for (const [candidateId, candidate] of this.tasks) {
+        if (!candidate.backgrounded) {
+          foregroundId = candidateId
+          break
+        }
+      }
+      if (!foregroundId) {
+        return
+      }
+      this.tasks.delete(foregroundId)
+    }
+    this.tasks.set(id, task)
+  }
+
+  private finish(id: string): void {
+    this.tasks.delete(id)
+    this.terminalTaskIds.delete(id)
+    this.terminalTaskIds.add(id)
+    if (this.terminalTaskIds.size > MAX_TRACKED_TASKS) {
+      const oldest = this.terminalTaskIds.values().next()
+      if (!oldest.done) {
+        this.terminalTaskIds.delete(oldest.value)
+      }
+    }
+  }
+
+  private refreshMonitoring(): boolean {
+    let next = false
+    if (!this.foregroundTurnActive) {
+      for (const task of this.tasks.values()) {
+        if (task.backgrounded) {
+          next = true
+          break
+        }
+      }
+    }
+    if (next === this.monitoring) {
+      return false
+    }
+    this.monitoring = next
+    return true
+  }
+}

--- a/src/main/claude/claude-background-task-tracker.ts
+++ b/src/main/claude/claude-background-task-tracker.ts
@@ -1,14 +1,19 @@
-import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
+import type {
+  AgentSessionBackgroundTask,
+  AgentSessionBackgroundTaskState
+} from '../../shared/agent-session-wire'
 
 const MAX_TRACKED_TASKS = 256
 const MAX_TASK_ID_LENGTH = 512
+const MAX_TASK_DESCRIPTION_LENGTH = 512
 const TERMINAL_TASK_STATES = new Set(['completed', 'failed', 'killed', 'stopped'])
 
-export type ClaudeBackgroundTaskKind = 'agent' | 'workflow' | 'command' | 'monitor' | 'unknown'
+export type ClaudeBackgroundTaskKind = AgentSessionBackgroundTask['kind']
 
 type TrackedTask = {
   backgrounded: boolean
   kind: ClaudeBackgroundTaskKind
+  description?: string
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -20,6 +25,14 @@ function taskId(message: Record<string, unknown>): string | null {
   return typeof value === 'string' && value.length > 0 && value.length <= MAX_TASK_ID_LENGTH
     ? value
     : null
+}
+
+function taskDescription(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim().replace(/\s+/g, ' ')
+  return trimmed.length > 0 ? trimmed.slice(0, MAX_TASK_DESCRIPTION_LENGTH) : undefined
 }
 
 export function classifyClaudeBackgroundTaskKind(taskType: unknown): ClaudeBackgroundTaskKind {
@@ -43,9 +56,16 @@ export class ClaudeBackgroundTaskTracker {
   private aggregateRosterObserved = false
   private foregroundTurnActive = false
   private monitoring = false
+  private publishedTasksFingerprint = ''
 
   get state(): AgentSessionBackgroundTaskState | null {
-    return this.monitoring ? { state: 'monitoring' } : null
+    if (!this.monitoring) {
+      return null
+    }
+    return {
+      state: 'monitoring',
+      tasks: this.backgroundTaskDetails()
+    }
   }
 
   get stoppableTaskIds(): string[] {
@@ -100,8 +120,16 @@ export class ClaudeBackgroundTaskTracker {
         this.finish(id)
         return
       }
-      if (patch.is_backgrounded === true && (!this.aggregateRosterObserved || this.tasks.has(id))) {
-        this.upsert(id, { backgrounded: true, kind: this.tasks.get(id)?.kind ?? 'unknown' })
+      const existing = this.tasks.get(id)
+      if (
+        (patch.is_backgrounded === true || taskDescription(patch.description)) &&
+        (!this.aggregateRosterObserved || existing)
+      ) {
+        this.upsert(id, {
+          backgrounded: patch.is_backgrounded === true || existing?.backgrounded === true,
+          kind: existing?.kind ?? 'unknown',
+          description: taskDescription(patch.description) ?? existing?.description
+        })
       }
       return
     }
@@ -118,7 +146,8 @@ export class ClaudeBackgroundTaskTracker {
     const kind = classifyClaudeBackgroundTaskKind(message.task_type)
     this.upsert(id, {
       backgrounded: message.is_backgrounded === true || kind === 'workflow' || kind === 'monitor',
-      kind
+      kind,
+      description: taskDescription(message.description)
     })
   }
 
@@ -143,7 +172,8 @@ export class ClaudeBackgroundTaskTracker {
       }
       this.tasks.set(id, {
         backgrounded: true,
-        kind: classifyClaudeBackgroundTaskKind(task.task_type)
+        kind: classifyClaudeBackgroundTaskKind(task.task_type),
+        description: taskDescription(task.description)
       })
     }
   }
@@ -153,7 +183,8 @@ export class ClaudeBackgroundTaskTracker {
     if (existing) {
       this.tasks.set(id, {
         backgrounded: existing.backgrounded || task.backgrounded,
-        kind: existing.kind === 'unknown' ? task.kind : existing.kind
+        kind: existing.kind === 'unknown' ? task.kind : existing.kind,
+        description: task.description ?? existing.description
       })
       return
     }
@@ -186,19 +217,29 @@ export class ClaudeBackgroundTaskTracker {
   }
 
   private refreshMonitoring(): boolean {
-    let next = false
-    if (!this.foregroundTurnActive) {
-      for (const task of this.tasks.values()) {
-        if (task.backgrounded) {
-          next = true
-          break
-        }
-      }
-    }
-    if (next === this.monitoring) {
+    const details = this.foregroundTurnActive ? [] : this.backgroundTaskDetails()
+    const next = details.length > 0
+    const fingerprint = next ? JSON.stringify(details) : ''
+    if (next === this.monitoring && fingerprint === this.publishedTasksFingerprint) {
       return false
     }
     this.monitoring = next
+    this.publishedTasksFingerprint = fingerprint
     return true
+  }
+
+  private backgroundTaskDetails(): AgentSessionBackgroundTask[] {
+    const details: AgentSessionBackgroundTask[] = []
+    for (const [id, task] of this.tasks) {
+      if (!task.backgrounded) {
+        continue
+      }
+      details.push({
+        id,
+        kind: task.kind,
+        ...(task.description ? { description: task.description } : {})
+      })
+    }
+    return details
   }
 }

--- a/src/main/claude/claude-stream-json-connection.ts
+++ b/src/main/claude/claude-stream-json-connection.ts
@@ -76,6 +76,7 @@ export type ClaudeStreamJsonConnection = ClaudeControlSurface & {
   /** What the ladder has observed so far; read after a `close()` that returned false. */
   readonly exitVerdict: ClaudeChildExitVerdict
   send: (message: Record<string, unknown>) => Promise<void>
+  stopTask: (taskId: string) => Promise<void>
   /** Resolves true after processless settlement, or root exit plus observed tree exit. */
   close: () => Promise<boolean>
 }
@@ -278,6 +279,7 @@ export async function openClaudeStreamJsonConnection(
       } as const
     },
     send,
+    stopTask: (taskId) => session.stopTask(taskId),
     close
   }
 }

--- a/src/main/claude/claude-stream-json-connection.ts
+++ b/src/main/claude/claude-stream-json-connection.ts
@@ -76,7 +76,6 @@ export type ClaudeStreamJsonConnection = ClaudeControlSurface & {
   /** What the ladder has observed so far; read after a `close()` that returned false. */
   readonly exitVerdict: ClaudeChildExitVerdict
   send: (message: Record<string, unknown>) => Promise<void>
-  stopTask: (taskId: string) => Promise<void>
   /** Resolves true after processless settlement, or root exit plus observed tree exit. */
   close: () => Promise<boolean>
 }
@@ -279,7 +278,6 @@ export async function openClaudeStreamJsonConnection(
       } as const
     },
     send,
-    stopTask: (taskId) => session.stopTask(taskId),
     close
   }
 }

--- a/src/main/claude/claude-structured-acquisition-release.ts
+++ b/src/main/claude/claude-structured-acquisition-release.ts
@@ -23,6 +23,7 @@ export async function releaseClaudeAcquisition(input: {
   onExitProven?: (sessionId: string, exit: ClaudeSessionExit) => Promise<void>
   persistHandle?: ClaudeStructuredSessionAdapterDeps['persistHandle']
   onEvent?: ClaudeStructuredSessionAdapterDeps['onEvent']
+  onBackgroundTasksChanged?: ClaudeStructuredSessionAdapterDeps['onBackgroundTasksChanged']
 }): Promise<boolean> {
   const exit = input.exits.get(input.sessionId)
   if (!exit || input.sessions.has(input.sessionId) || input.acquisitions.get(input.sessionId)) {

--- a/src/main/claude/claude-structured-control-actions.test.ts
+++ b/src/main/claude/claude-structured-control-actions.test.ts
@@ -128,11 +128,14 @@ describe('stopClaudeBackgroundTasks', () => {
         { task_id: 'task-bash', task_type: 'local_bash', description: 'bash' }
       ]
     })
-    const stopTask = vi.fn(async (_taskId: string) => {})
+    const stopTask = vi.fn(async (_taskId: string, _options?: { timeoutMs?: number }) => {})
     const session = { backgroundTasks, connection: { stopTask } } as unknown as ClaudeSession
 
-    await expect(stopClaudeBackgroundTasks(session)).resolves.toEqual({ cancelled: true })
-    expect(stopTask.mock.calls.map(([taskId]) => taskId)).toEqual(['task-agent', 'task-bash'])
+    await expect(stopClaudeBackgroundTasks(session, 5_000)).resolves.toEqual({ cancelled: true })
+    expect(stopTask.mock.calls).toEqual([
+      ['task-agent', { timeoutMs: 5_000 }],
+      ['task-bash', { timeoutMs: 5_000 }]
+    ])
   })
 
   it('stops issuing requests when ownership changes between tasks', async () => {
@@ -152,7 +155,7 @@ describe('stopClaudeBackgroundTasks', () => {
     })
     const session = { backgroundTasks, connection: { stopTask } } as unknown as ClaudeSession
 
-    await stopClaudeBackgroundTasks(session, () => current)
+    await stopClaudeBackgroundTasks(session, undefined, () => current)
     expect(stopTask).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/claude/claude-structured-control-actions.test.ts
+++ b/src/main/claude/claude-structured-control-actions.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from 'vitest'
-import { cancelClaudeTurn, answerClaudePrompt } from './claude-structured-control-actions'
+import {
+  cancelClaudeTurn,
+  answerClaudePrompt,
+  stopClaudeBackgroundTasks
+} from './claude-structured-control-actions'
 import { ClaudeControlRequestError } from './claude-stream-json-connection'
 import { ClaudePromptRegistry } from './claude-structured-prompt-replies'
 import type { ClaudeSession } from './claude-structured-session-state'
+import { ClaudeBackgroundTaskTracker } from './claude-background-task-tracker'
 
 type InterruptResult = Awaited<ReturnType<ClaudeSession['connection']['interrupt']>>
 
@@ -109,5 +114,45 @@ describe('answerClaudePrompt', () => {
     await expect(
       answerClaudePrompt(session, { itemId: 'missing', kind: 'approval', optionId: 'allow' })
     ).rejects.toThrow(/no longer waiting/)
+  })
+})
+
+describe('stopClaudeBackgroundTasks', () => {
+  it('stops each live SDK task id and never depends on an active turn id', async () => {
+    const backgroundTasks = new ClaudeBackgroundTaskTracker()
+    backgroundTasks.observe({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [
+        { task_id: 'task-agent', task_type: 'local_agent', description: 'agent' },
+        { task_id: 'task-bash', task_type: 'local_bash', description: 'bash' }
+      ]
+    })
+    const stopTask = vi.fn(async (_taskId: string) => {})
+    const session = { backgroundTasks, connection: { stopTask } } as unknown as ClaudeSession
+
+    await expect(stopClaudeBackgroundTasks(session)).resolves.toEqual({ cancelled: true })
+    expect(stopTask.mock.calls.map(([taskId]) => taskId)).toEqual(['task-agent', 'task-bash'])
+  })
+
+  it('stops issuing requests when ownership changes between tasks', async () => {
+    const backgroundTasks = new ClaudeBackgroundTaskTracker()
+    for (const taskId of ['task-1', 'task-2']) {
+      backgroundTasks.observe({
+        type: 'system',
+        subtype: 'task_started',
+        task_id: taskId,
+        task_type: 'local_agent',
+        is_backgrounded: true
+      })
+    }
+    let current = true
+    const stopTask = vi.fn(async (_taskId: string) => {
+      current = false
+    })
+    const session = { backgroundTasks, connection: { stopTask } } as unknown as ClaudeSession
+
+    await stopClaudeBackgroundTasks(session, () => current)
+    expect(stopTask).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/claude/claude-structured-control-actions.ts
+++ b/src/main/claude/claude-structured-control-actions.ts
@@ -43,6 +43,28 @@ export async function cancelClaudeTurn(
   }
 }
 
+export async function stopClaudeBackgroundTasks(
+  session: ClaudeSession,
+  isCurrent: ClaudeTurnCancellationGuard = () => true
+): Promise<{ cancelled: boolean }> {
+  const taskIds = session.backgroundTasks.stoppableTaskIds
+  let cancelled = false
+  for (const taskId of taskIds) {
+    if (!isCurrent()) {
+      break
+    }
+    try {
+      await session.connection.stopTask(taskId)
+      cancelled = true
+    } catch (error) {
+      if (!(error instanceof ClaudeControlRequestError)) {
+        throw error
+      }
+    }
+  }
+  return { cancelled }
+}
+
 export async function answerClaudePrompt(
   session: ClaudeSession,
   input: { itemId: string; kind: 'approval' | 'question'; optionId: string }

--- a/src/main/claude/claude-structured-control-actions.ts
+++ b/src/main/claude/claude-structured-control-actions.ts
@@ -45,6 +45,7 @@ export async function cancelClaudeTurn(
 
 export async function stopClaudeBackgroundTasks(
   session: ClaudeSession,
+  timeoutMs: number | undefined,
   isCurrent: ClaudeTurnCancellationGuard = () => true
 ): Promise<{ cancelled: boolean }> {
   const taskIds = session.backgroundTasks.stoppableTaskIds
@@ -54,7 +55,7 @@ export async function stopClaudeBackgroundTasks(
       break
     }
     try {
-      await session.connection.stopTask(taskId)
+      await session.connection.stopTask(taskId, { timeoutMs })
       cancelled = true
     } catch (error) {
       if (!(error instanceof ClaudeControlRequestError)) {

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -6,6 +6,7 @@ import type { AgentJournalMessageItem } from '../../shared/agent-session-journal
 import { dispatchClaudeTurn, resolveClaudeReplayWaiter } from './claude-structured-dispatch'
 import { readClaudeImage } from './claude-structured-dispatch-content'
 import type { ClaudeSession } from './claude-structured-session-state'
+import { ClaudeBackgroundTaskTracker } from './claude-background-task-tracker'
 
 function sessionFor(send = vi.fn().mockResolvedValue(undefined)): ClaudeSession {
   return {
@@ -19,6 +20,7 @@ function sessionFor(send = vi.fn().mockResolvedValue(undefined)): ClaudeSession 
     dispatchWaiters: [],
     retiredDispatchWaiters: [],
     replayContentFallbackBlocked: false,
+    backgroundTasks: new ClaudeBackgroundTaskTracker(),
     dispatchSequence: 0,
     optionMutationSequence: 0,
     options: new Map(),

--- a/src/main/claude/claude-structured-options.test.ts
+++ b/src/main/claude/claude-structured-options.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { setClaudeStructuredOption } from './claude-structured-options'
 import type { ClaudeSession } from './claude-structured-session-state'
+import { ClaudeBackgroundTaskTracker } from './claude-background-task-tracker'
 
 function sessionFor(setModel: ClaudeSession['connection']['setModel']): ClaudeSession {
   return {
@@ -14,6 +15,7 @@ function sessionFor(setModel: ClaudeSession['connection']['setModel']): ClaudeSe
     dispatchWaiters: [],
     retiredDispatchWaiters: [],
     replayContentFallbackBlocked: false,
+    backgroundTasks: new ClaudeBackgroundTaskTracker(),
     dispatchSequence: 0,
     optionMutationSequence: 0,
     options: new Map(),

--- a/src/main/claude/claude-structured-session-acquisition-processless.test.ts
+++ b/src/main/claude/claude-structured-session-acquisition-processless.test.ts
@@ -40,6 +40,7 @@ describe('Claude structured processless acquisition', () => {
         setPermissionMode: async () => {},
         applyFlagSettings: async () => {},
         send: async () => {},
+        stopTask: async () => {},
         close
       }
       return connection

--- a/src/main/claude/claude-structured-session-adapter.ts
+++ b/src/main/claude/claude-structured-session-adapter.ts
@@ -207,7 +207,7 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
   stopBackgroundTasks: StructuredAgentSessionAdapter['stopBackgroundTasks'] = (input) => {
     const session = this.session(input.sessionId)
     const acquisitionGeneration = session.acquisitionGeneration
-    return stopClaudeBackgroundTasks(session, () =>
+    return stopClaudeBackgroundTasks(session, this.deps.requestTimeoutMs, () =>
       Boolean(
         this.sessions.get(input.sessionId) === session &&
         session.fence === input.fence &&

--- a/src/main/claude/claude-structured-session-adapter.ts
+++ b/src/main/claude/claude-structured-session-adapter.ts
@@ -4,7 +4,11 @@ import type {
   StructuredAgentSessionAdapter
 } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { StructuredAgentSessionEventSink } from '../native-chat/agent-session-wire/structured-agent-session-event-sink'
-import { answerClaudePrompt, cancelClaudeTurn } from './claude-structured-control-actions'
+import {
+  answerClaudePrompt,
+  cancelClaudeTurn,
+  stopClaudeBackgroundTasks
+} from './claude-structured-control-actions'
 import { dispatchClaudeTurn } from './claude-structured-dispatch'
 import { releaseClaudeAcquisition } from './claude-structured-acquisition-release'
 import { acquireClaudeSession } from './claude-structured-session-acquisition'
@@ -149,12 +153,21 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
   }
 
   private emit(
-    _session: ClaudeSession | null,
+    session: ClaudeSession | null,
     _events: StructuredAgentSessionEventSink | undefined,
     event: ClaudeStructuredSessionEvent
   ): void {
-    _session?.translator?.handle(event)
+    const backgroundTasksChanged =
+      event.type === 'ended'
+        ? (session?.backgroundTasks.clear() ?? false)
+        : event.type === 'message'
+          ? (session?.backgroundTasks.observe(event.message, event.startsTurn === true) ?? false)
+          : false
+    session?.translator?.handle(event)
     this.deps.onEvent?.(event)
+    if (backgroundTasksChanged) {
+      this.deps.onBackgroundTasksChanged?.(event.sessionId, session?.backgroundTasks.state ?? null)
+    }
   }
 
   bindPromptItemId(
@@ -191,6 +204,21 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
       )
     })
   }
+  stopBackgroundTasks: StructuredAgentSessionAdapter['stopBackgroundTasks'] = (input) => {
+    const session = this.session(input.sessionId)
+    const acquisitionGeneration = session.acquisitionGeneration
+    return stopClaudeBackgroundTasks(session, () =>
+      Boolean(
+        this.sessions.get(input.sessionId) === session &&
+        session.fence === input.fence &&
+        session.acquisitionGeneration === acquisitionGeneration &&
+        session.backgroundTasks.state
+      )
+    )
+  }
+  backgroundTaskState: NonNullable<StructuredAgentSessionAdapter['backgroundTaskState']> = (
+    sessionId
+  ) => this.sessions.get(sessionId)?.backgroundTasks.state
   answerPrompt: StructuredAgentSessionAdapter['answerPrompt'] = (input) =>
     answerClaudePrompt(this.session(input.sessionId), input)
   setOption: StructuredAgentSessionAdapter['setOption'] = (input) =>
@@ -210,6 +238,9 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
       exits: this.exits,
       onExitProven: (sessionId, exit) => this.settleUnexpectedExit(sessionId, exit),
       ...(this.deps.persistHandle ? { persistHandle: this.deps.persistHandle } : {}),
+      ...(this.deps.onBackgroundTasksChanged
+        ? { onBackgroundTasksChanged: this.deps.onBackgroundTasksChanged }
+        : {}),
       ...(this.deps.onEvent ? { onEvent: this.deps.onEvent } : {})
     })
 
@@ -223,6 +254,9 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
       acquisitions: this.acquisitions,
       ...(this.deps.persistHandle ? { persistHandle: this.deps.persistHandle } : {}),
       ...(this.deps.readTranscriptLeaf ? { readTranscriptLeaf: this.deps.readTranscriptLeaf } : {}),
+      ...(this.deps.onBackgroundTasksChanged
+        ? { onBackgroundTasksChanged: this.deps.onBackgroundTasksChanged }
+        : {}),
       ...(this.deps.onEvent ? { onEvent: this.deps.onEvent } : {})
     })
   }

--- a/src/main/claude/claude-structured-session-close.test.ts
+++ b/src/main/claude/claude-structured-session-close.test.ts
@@ -4,7 +4,13 @@ import type {
   ClaudeStructuredSessionAdapterDeps,
   ClaudeStructuredSessionEvent
 } from './claude-structured-session-adapter'
-import { adapterFor, fakeClaude, identityFor } from './claude-structured-session-test-support'
+import {
+  PROVIDER_SESSION_ID,
+  adapterFor,
+  fakeClaude,
+  identityFor
+} from './claude-structured-session-test-support'
+import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
 
 describe('Claude published session close lifecycle', () => {
   it('ends the session even when the durable handle write rejects', async () => {
@@ -15,7 +21,17 @@ describe('Claude published session close lifecycle', () => {
       .fn<NonNullable<ClaudeStructuredSessionAdapterDeps['persistHandle']>>()
       .mockRejectedValueOnce(persistenceError)
       .mockResolvedValueOnce(undefined)
-    const adapter = adapterFor(claude, {}, events, [], undefined, undefined, persistHandle)
+    const backgroundStates: (AgentSessionBackgroundTaskState | null)[] = []
+    const adapter = adapterFor(
+      claude,
+      {},
+      events,
+      [],
+      undefined,
+      undefined,
+      persistHandle,
+      (_sessionId, state) => backgroundStates.push(state)
+    )
     const journalSink: StructuredAgentSessionEventSink = {
       appendItem: () => {},
       appendTombstone: () => {},
@@ -27,6 +43,16 @@ describe('Claude published session close lifecycle', () => {
       spawnToken: 'spawn-9',
       events: journalSink
     })
+    claude.connections[0]!.handlers.onMessage?.({
+      type: 'system',
+      subtype: 'task_started',
+      session_id: PROVIDER_SESSION_ID,
+      uuid: 'task-start',
+      task_id: 'background-1',
+      task_type: 'local_agent',
+      is_backgrounded: true
+    })
+    expect(backgroundStates).toEqual([{ state: 'monitoring' }])
     const session = (
       adapter as unknown as {
         sessions: Map<string, { translator: { dispose: () => void } | null }>
@@ -39,6 +65,7 @@ describe('Claude published session close lifecycle', () => {
     expect(events.filter((event) => event.type === 'ended')).toHaveLength(1)
     expect(events.filter((event) => event.type === 'handle')).toHaveLength(0)
     expect(disposeTranslator).toHaveBeenCalledOnce()
+    expect(backgroundStates).toEqual([{ state: 'monitoring' }, null])
 
     await expect(adapter.closeSession('session-1')).resolves.toBe(true)
     expect(persistHandle).toHaveBeenCalledTimes(2)

--- a/src/main/claude/claude-structured-session-close.test.ts
+++ b/src/main/claude/claude-structured-session-close.test.ts
@@ -52,7 +52,9 @@ describe('Claude published session close lifecycle', () => {
       task_type: 'local_agent',
       is_backgrounded: true
     })
-    expect(backgroundStates).toEqual([{ state: 'monitoring' }])
+    expect(backgroundStates).toEqual([
+      { state: 'monitoring', tasks: [{ id: 'background-1', kind: 'agent' }] }
+    ])
     const session = (
       adapter as unknown as {
         sessions: Map<string, { translator: { dispose: () => void } | null }>
@@ -65,7 +67,10 @@ describe('Claude published session close lifecycle', () => {
     expect(events.filter((event) => event.type === 'ended')).toHaveLength(1)
     expect(events.filter((event) => event.type === 'handle')).toHaveLength(0)
     expect(disposeTranslator).toHaveBeenCalledOnce()
-    expect(backgroundStates).toEqual([{ state: 'monitoring' }, null])
+    expect(backgroundStates).toEqual([
+      { state: 'monitoring', tasks: [{ id: 'background-1', kind: 'agent' }] },
+      null
+    ])
 
     await expect(adapter.closeSession('session-1')).resolves.toBe(true)
     expect(persistHandle).toHaveBeenCalledTimes(2)

--- a/src/main/claude/claude-structured-session-close.ts
+++ b/src/main/claude/claude-structured-session-close.ts
@@ -11,6 +11,7 @@ import {
   AgentSessionPreSpawnError
 } from '../native-chat/agent-session-wire/structured-agent-session-adapter'
 import type { ClaudeStreamJsonConnection } from './claude-stream-json-connection'
+import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
 import { closeProcessRegistry } from '../../shared/child-process/close-process-registry'
 import { readClaudeTranscriptLeafWithReproof } from './claude-transcript-branch-proof'
 
@@ -52,6 +53,10 @@ type CloseClaudePublishedSessionInput = {
     fence: number
   }) => Promise<void>
   onEvent?: (event: ClaudeStructuredSessionEvent) => void
+  onBackgroundTasksChanged?: (
+    sessionId: string,
+    state: AgentSessionBackgroundTaskState | null
+  ) => void
   readTranscriptLeaf?: (input: {
     providerSessionId: string
     previousLeafUuid: string | null
@@ -71,6 +76,9 @@ async function finalizeClaudePublishedSession(
   }
   if ((await session.connection.close()) !== true) {
     return false
+  }
+  if (session.backgroundTasks.clear()) {
+    input.onBackgroundTasksChanged?.(input.sessionId, null)
   }
   try {
     const transcriptLeaf = input.readTranscriptLeaf
@@ -194,6 +202,10 @@ export function closeClaudePublishedSessionForDeps(
       fence: number
     }) => Promise<void>
     onEvent?: (event: ClaudeStructuredSessionEvent) => void
+    onBackgroundTasksChanged?: (
+      sessionId: string,
+      state: AgentSessionBackgroundTaskState | null
+    ) => void
     readTranscriptLeaf?: (input: {
       providerSessionId: string
       previousLeafUuid: string | null
@@ -215,6 +227,10 @@ export async function closeClaudeSession(input: {
     fence: number
   }) => Promise<void>
   onEvent?: (event: ClaudeStructuredSessionEvent) => void
+  onBackgroundTasksChanged?: (
+    sessionId: string,
+    state: AgentSessionBackgroundTaskState | null
+  ) => void
   readTranscriptLeaf?: (input: {
     providerSessionId: string
     previousLeafUuid: string | null

--- a/src/main/claude/claude-structured-session-publication.ts
+++ b/src/main/claude/claude-structured-session-publication.ts
@@ -4,6 +4,7 @@ import { claudeProviderHandleLink } from './claude-structured-owner-identity'
 import type { ClaudePromptRegistry } from './claude-structured-prompt-replies'
 import type { ClaudeJournalTranslator } from './claude-structured-journal-translation'
 import type { ClaudeSession } from './claude-structured-session-state'
+import { ClaudeBackgroundTaskTracker } from './claude-background-task-tracker'
 
 export function createClaudeSessionPublication(input: {
   connection: ClaudeSession['connection']
@@ -50,6 +51,7 @@ export function createClaudeSessionPublication(input: {
       dispatchWaiters: [],
       retiredDispatchWaiters: [],
       replayContentFallbackBlocked: false,
+      backgroundTasks: new ClaudeBackgroundTaskTracker(),
       dispatchSequence: 0,
       optionMutationSequence: 0,
       options: new Map(input.options),

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -9,6 +9,8 @@ import type { ClaudeJournalTranslator } from './claude-structured-journal-transl
 import type { ClaudePendingPrompt, ClaudePromptRegistry } from './claude-structured-prompt-replies'
 import { cancelProcessAcquisition } from '../../shared/child-process/cancel-process-acquisition'
 import { randomUUID } from 'node:crypto'
+import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
+import type { ClaudeBackgroundTaskTracker } from './claude-background-task-tracker'
 
 export type ClaudeAuthDiagnostic = {
   apiKeySourceConfigured: boolean
@@ -54,6 +56,10 @@ export type ClaudeStructuredSessionAdapterDeps = {
     identity: AgentSessionJournalIdentity
   }) => Promise<ClaudeStructuredLaunch>
   onEvent?: (event: ClaudeStructuredSessionEvent) => void
+  onBackgroundTasksChanged?: (
+    sessionId: string,
+    state: AgentSessionBackgroundTaskState | null
+  ) => void
   openConnection?: typeof openClaudeStreamJsonConnection
   readProcessStartTime?: (pid: number) => Promise<number | null>
   mintLinkId?: () => string
@@ -119,6 +125,7 @@ export type ClaudeSession = {
   capabilities: readonly string[]
   /** Provider uuid of the most recently admitted turn, if one is active. */
   activeTurnId?: string
+  backgroundTasks: ClaudeBackgroundTaskTracker
   /** Monotonic fence advanced when a dispatch starts, including unresolved dispatches. */
   dispatchSequence: number
   /** Dispatch sequence that admitted activeTurnId. */

--- a/src/main/claude/claude-structured-session-test-support.ts
+++ b/src/main/claude/claude-structured-session-test-support.ts
@@ -155,6 +155,10 @@ export function fakeClaude(
         connection.calls.push({ subtype: 'cancel_async_message', params: { uuid } })
         routed('cancel_async_message', { uuid })
       },
+      stopTask: async (taskId) => {
+        connection.calls.push({ subtype: 'stop_task', params: { taskId } })
+        routed('stop_task', { taskId })
+      },
       send: async (message) => {
         connection.sent.push(message)
         if (message.type === 'user' && options.replayUuid !== null) {
@@ -191,7 +195,8 @@ export function adapterFor(
   persistedHandles: unknown[] = [],
   initTimeoutMs?: number,
   readTranscriptLeaf?: ClaudeStructuredSessionAdapterDeps['readTranscriptLeaf'],
-  persistHandle?: ClaudeStructuredSessionAdapterDeps['persistHandle']
+  persistHandle?: ClaudeStructuredSessionAdapterDeps['persistHandle'],
+  onBackgroundTasksChanged?: ClaudeStructuredSessionAdapterDeps['onBackgroundTasksChanged']
 ): ClaudeStructuredSessionAdapter {
   return new ClaudeStructuredSessionAdapter({
     resolveLaunch: async () => ({
@@ -215,6 +220,7 @@ export function adapterFor(
       (async (handle) => {
         persistedHandles.push(handle)
       }),
+    ...(onBackgroundTasksChanged ? { onBackgroundTasksChanged } : {}),
     ...(readTranscriptLeaf ? { readTranscriptLeaf } : {})
   })
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-adapter-router.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-adapter-router.ts
@@ -49,6 +49,17 @@ export class StructuredAgentSessionAdapterRouter implements StructuredAgentSessi
   cancelTurn: StructuredAgentSessionAdapter['cancelTurn'] = (input) =>
     this.owner(input.sessionId).cancelTurn(input)
 
+  stopBackgroundTasks: NonNullable<StructuredAgentSessionAdapter['stopBackgroundTasks']> = (
+    input
+  ) => {
+    const stop = this.owner(input.sessionId).stopBackgroundTasks
+    return stop ? stop(input) : Promise.resolve({ cancelled: false })
+  }
+
+  backgroundTaskState: NonNullable<StructuredAgentSessionAdapter['backgroundTaskState']> = (
+    sessionId
+  ) => this.owners.get(sessionId)?.backgroundTaskState?.(sessionId)
+
   answerPrompt: StructuredAgentSessionAdapter['answerPrompt'] = (input) =>
     this.owner(input.sessionId).answerPrompt(input)
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
@@ -17,6 +17,7 @@ import type {
   AgentSessionProcessIdentity
 } from '../../../shared/agent-session-record'
 import type {
+  AgentSessionBackgroundTaskState,
   AgentSessionOptionsResult,
   AgentSessionWireRefusalCode
 } from '../../../shared/agent-session-wire'
@@ -136,6 +137,8 @@ export type StructuredAgentSessionAdapter = {
     turnId: string
     fence: number
   }): Promise<{ cancelled: boolean }>
+  stopBackgroundTasks?(input: { sessionId: string; fence: number }): Promise<{ cancelled: boolean }>
+  backgroundTaskState?(sessionId: string): AgentSessionBackgroundTaskState | null | undefined
   /** Fires the provider callback for an approval or a question. The wire calls
    *  this only after the durable compare-and-set won, so it runs exactly once. */
   answerPrompt(input: {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-background-task-channel.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-background-task-channel.ts
@@ -1,0 +1,62 @@
+import type {
+  AgentSessionBackgroundTaskState,
+  AgentSessionHistoryRequest,
+  AgentSessionHistoryResult
+} from '../../../shared/agent-session-wire'
+import { readStructuredAgentSessionHistoryResult } from './structured-agent-session-history-result'
+import type {
+  AgentSessionSubscribers,
+  AgentSessionSubscribeInput
+} from './structured-agent-session-subscribers'
+import type {
+  StructuredAgentSessionHostDeps,
+  StructuredAgentSessionHostSession
+} from './structured-agent-session-host-types'
+
+export class StructuredAgentSessionBackgroundTaskChannel {
+  constructor(
+    private readonly deps: StructuredAgentSessionHostDeps,
+    private readonly sessions: Map<string, StructuredAgentSessionHostSession>,
+    private readonly subscribers: AgentSessionSubscribers,
+    private readonly requireSession: (sessionId: string) => StructuredAgentSessionHostSession,
+    private readonly handoffStatus: (
+      sessionId: string
+    ) => Parameters<AgentSessionSubscribers['open']>[0]['handoff']
+  ) {}
+
+  history(request: AgentSessionHistoryRequest): AgentSessionHistoryResult {
+    const result = readStructuredAgentSessionHistoryResult({
+      journal: this.requireSession(request.sessionId).journal,
+      record: this.deps.store.getRecord(request.sessionId),
+      request
+    })
+    const backgroundTasks = this.state(request.sessionId)
+    return backgroundTasks === undefined
+      ? result
+      : { ...result, page: { ...result.page, backgroundTasks } }
+  }
+
+  subscribe(input: AgentSessionSubscribeInput): () => void {
+    const session = this.requireSession(input.sessionId)
+    const backgroundTasks = this.state(input.sessionId)
+    return this.subscribers.open({
+      ...input,
+      journal: session.journal,
+      fence: this.deps.store.getRecord(input.sessionId)?.lease.runtimeFence ?? 0,
+      handoff: this.handoffStatus(input.sessionId),
+      ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
+    })
+  }
+
+  publish(sessionId: string, publishedState?: AgentSessionBackgroundTaskState | null): void {
+    const session = this.sessions.get(sessionId)
+    const state = publishedState !== undefined ? publishedState : this.state(sessionId)
+    if (session && state !== undefined) {
+      this.subscribers.backgroundTasks(sessionId, state, session.fence)
+    }
+  }
+
+  private state(sessionId: string): AgentSessionBackgroundTaskState | null | undefined {
+    return this.deps.adapter.backgroundTaskState?.(sessionId)
+  }
+}

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-mutations.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-mutations.ts
@@ -74,7 +74,11 @@ export function sendStructuredAgentSessionTurn(
 export function cancelStructuredAgentSessionTurn(
   context: StructuredAgentSessionMutationContext,
   caller: StructuredAgentSessionCaller,
-  params: { envelope: AgentSessionMutationEnvelope; turnId: string }
+  params: {
+    envelope: AgentSessionMutationEnvelope
+    turnId: string
+    scope?: 'background-tasks'
+  }
 ): Promise<AgentSessionMutationResult<AgentSessionCancelResult>> {
   return mutate(context, caller, params.envelope, cancelPlan(params))
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -57,8 +57,8 @@ import type {
   StructuredAgentSessionHostDeps,
   StructuredAgentSessionHostSession
 } from './structured-agent-session-host-types'
-import { readStructuredAgentSessionHistoryResult } from './structured-agent-session-history-result'
 import { StructuredAgentSessionEventRecovery } from './structured-agent-session-event-recovery'
+import { StructuredAgentSessionBackgroundTaskChannel } from './structured-agent-session-background-task-channel'
 export type { StructuredAgentSessionHostDeps } from './structured-agent-session-host-types'
 export class StructuredAgentSessionHost {
   private readonly sessions = new Map<string, StructuredAgentSessionHostSession>()
@@ -71,8 +71,16 @@ export class StructuredAgentSessionHost {
   private readonly restartRestore = new StructuredAgentSessionRestartRestoreGate()
   private readonly holds: StructuredAgentSessionHolds
   private readonly eventRecovery: StructuredAgentSessionEventRecovery
+  private readonly backgroundTasks: StructuredAgentSessionBackgroundTaskChannel
 
   constructor(readonly deps: StructuredAgentSessionHostDeps) {
+    this.backgroundTasks = new StructuredAgentSessionBackgroundTaskChannel(
+      deps,
+      this.sessions,
+      this.subscribers,
+      (sessionId) => this.requireSession(sessionId),
+      (sessionId) => this.handoffs.status(sessionId)
+    )
     this.runtimeState = new StructuredAgentSessionHostRuntimeState(
       deps,
       (record) => this.restoreRenewedHandoff(record.sessionId),
@@ -308,24 +316,16 @@ export class StructuredAgentSessionHost {
     )
   }
 
-  history(request: AgentSessionHistoryRequest): AgentSessionHistoryResult {
-    return readStructuredAgentSessionHistoryResult({
-      journal: this.requireSession(request.sessionId).journal,
-      record: this.deps.store.getRecord(request.sessionId),
-      request
-    })
-  }
+  history = (request: AgentSessionHistoryRequest): AgentSessionHistoryResult =>
+    this.backgroundTasks.history(request)
 
-  subscribe(input: AgentSessionSubscribeInput): () => void {
-    const session = this.requireSession(input.sessionId)
-    const fence = this.deps.store.getRecord(input.sessionId)?.lease.runtimeFence ?? 0
-    return this.subscribers.open({
-      ...input,
-      journal: session.journal,
-      fence,
-      handoff: this.handoffs.status(input.sessionId)
-    })
-  }
+  subscribe = (input: AgentSessionSubscribeInput): (() => void) =>
+    this.backgroundTasks.subscribe(input)
+
+  publishBackgroundTaskState: StructuredAgentSessionBackgroundTaskChannel['publish'] = (
+    sessionId,
+    state
+  ) => this.backgroundTasks.publish(sessionId, state)
   unsubscribe = (sessionId: string, id: string): void => this.subscribers.close(sessionId, id)
 
   private requireSession(sessionId: string): StructuredAgentSessionHostSession {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -75,14 +75,16 @@ export function sendPlan(params: {
 export function cancelPlan(params: {
   envelope: AgentSessionMutationEnvelope
   turnId: string
+  scope?: 'background-tasks'
 }): MutationPlan<AgentSessionCancelResult> {
   return {
     method: 'agentSession.cancel',
-    fields: { turnId: params.turnId },
+    fields: { turnId: params.turnId, ...(params.scope ? { scope: params.scope } : {}) },
     run: (ctx) =>
       performCancel(ctx, {
         clientOperationId: params.envelope.clientOperationId,
-        turnId: params.turnId
+        turnId: params.turnId,
+        ...(params.scope ? { scope: params.scope } : {})
       }),
     // Interrupting twice would kill a turn the client never asked to stop, so a
     // replay reports the turn as already handled instead.

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.test.ts
@@ -114,7 +114,7 @@ describe('AgentSessionSubscribers', () => {
     })
   })
 
-  it('publishes background lifecycle without advancing or serializing the journal', async () => {
+  it('publishes background lifecycle without advancing the journal and carries its fence forward', async () => {
     const journal = await journals.open({
       identity: {
         sessionId: SESSION,
@@ -137,16 +137,25 @@ describe('AgentSessionSubscribers', () => {
     })
     const cursor = journal.cursor()
 
-    subscribers.backgroundTasks(SESSION, { state: 'monitoring' }, 1)
+    subscribers.backgroundTasks(SESSION, { state: 'monitoring' }, 2)
 
     expect(journal.cursor()).toEqual(cursor)
     expect(events.at(-1)).toEqual({
       type: 'batch',
       sessionId: SESSION,
       batch: { cursor, items: [], removedItemIds: [], submissions: [] },
-      fence: 1,
+      fence: 2,
       backgroundTasks: { state: 'monitoring' }
     })
+
+    await journal.appendItem(
+      { provider: 'orca', clientMessageId: 'after-background-fence' },
+      { kind: 'status', text: 'After background state' },
+      { fence: 2 }
+    )
+    subscribers.publish(SESSION, journal)
+
+    expect(events.at(-1)).toMatchObject({ type: 'batch', fence: 2 })
   })
 
   it('catches a subscriber up past a pre-existing unsendable removal with a bounded reset', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.test.ts
@@ -114,6 +114,41 @@ describe('AgentSessionSubscribers', () => {
     })
   })
 
+  it('publishes background lifecycle without advancing or serializing the journal', async () => {
+    const journal = await journals.open({
+      identity: {
+        sessionId: SESSION,
+        workspaceId: 'workspace-1',
+        hostId: 'local',
+        agent: 'claude',
+        providerHandle: { kind: 'claude', sessionId: 'provider-1', leafUuid: null }
+      },
+      journalDir: join(root, 'background-journal')
+    })
+    const subscribers = new AgentSessionSubscribers()
+    const events: AgentSessionSubscribeEvent[] = []
+    subscribers.open({
+      id: 'subscriber-1',
+      sessionId: SESSION,
+      journal,
+      fence: 1,
+      backgroundTasks: null,
+      emit: (event) => events.push(event)
+    })
+    const cursor = journal.cursor()
+
+    subscribers.backgroundTasks(SESSION, { state: 'monitoring' }, 1)
+
+    expect(journal.cursor()).toEqual(cursor)
+    expect(events.at(-1)).toEqual({
+      type: 'batch',
+      sessionId: SESSION,
+      batch: { cursor, items: [], removedItemIds: [], submissions: [] },
+      fence: 1,
+      backgroundTasks: { state: 'monitoring' }
+    })
+  })
+
   it('catches a subscriber up past a pre-existing unsendable removal with a bounded reset', async () => {
     const journalDir = join(root, 'oversized-removal-journal')
     const seeded = await journals.open({

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.test.ts
@@ -137,7 +137,11 @@ describe('AgentSessionSubscribers', () => {
     })
     const cursor = journal.cursor()
 
-    subscribers.backgroundTasks(SESSION, { state: 'monitoring' }, 2)
+    const backgroundTasks = {
+      state: 'monitoring' as const,
+      tasks: [{ id: 'task-1', kind: 'command' as const, description: 'run the build' }]
+    }
+    subscribers.backgroundTasks(SESSION, backgroundTasks, 2)
 
     expect(journal.cursor()).toEqual(cursor)
     expect(events.at(-1)).toEqual({
@@ -145,7 +149,7 @@ describe('AgentSessionSubscribers', () => {
       sessionId: SESSION,
       batch: { cursor, items: [], removedItemIds: [], submissions: [] },
       fence: 2,
-      backgroundTasks: { state: 'monitoring' }
+      backgroundTasks
     })
 
     await journal.appendItem(

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../shared/agent-session-journal-types'
 import {
   AGENT_SESSION_HISTORY_MAX_LIMIT,
+  type AgentSessionBackgroundTaskState,
   type AgentSessionHandoffStatus,
   type AgentSessionSubscribeEvent
 } from '../../../shared/agent-session-wire'
@@ -48,6 +49,7 @@ export class AgentSessionSubscribers {
     emit: AgentSessionSubscriberEmit
     cursor?: AgentJournalCursor
     handoff?: AgentSessionHandoffStatus
+    backgroundTasks?: AgentSessionBackgroundTaskState | null
   }): () => void {
     const liveCursor = input.journal.cursor()
     const subscriber: Subscriber = {
@@ -62,7 +64,7 @@ export class AgentSessionSubscribers {
     this.bySession.set(input.sessionId, session)
 
     if (input.cursor) {
-      this.deliver(subscriber, input.journal, input.handoff, true)
+      this.deliver(subscriber, input.journal, input.handoff, true, input.backgroundTasks)
     } else {
       const page = readAgentSessionHydrationPage(input.journal, input.fence)
       this.emit(subscriber, {
@@ -70,7 +72,8 @@ export class AgentSessionSubscribers {
         sessionId: input.sessionId,
         page,
         fence: input.fence,
-        ...(input.handoff ? { handoff: input.handoff } : {})
+        ...(input.handoff ? { handoff: input.handoff } : {}),
+        ...(input.backgroundTasks !== undefined ? { backgroundTasks: input.backgroundTasks } : {})
       })
       subscriber.cursor = page.liveCursor ?? page.window.nextCursor
     }
@@ -104,20 +107,39 @@ export class AgentSessionSubscribers {
     sessionId: string,
     journal: AgentSessionJournal,
     reason: AgentJournalResetReason,
-    fence: number
+    fence: number,
+    backgroundTasks?: AgentSessionBackgroundTaskState | null
   ): void {
     const page = readAgentSessionHydrationPage(journal, fence)
     for (const subscriber of this.subscribers(sessionId)) {
-      this.emit(subscriber, { type: 'reset', sessionId, reset: reason, page, fence })
+      this.emit(subscriber, {
+        type: 'reset',
+        sessionId,
+        reset: reason,
+        page,
+        fence,
+        ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
+      })
       subscriber.cursor = page.liveCursor ?? page.window.nextCursor
       subscriber.fence = fence
     }
   }
 
-  snapshot(sessionId: string, journal: AgentSessionJournal, fence: number): void {
+  snapshot(
+    sessionId: string,
+    journal: AgentSessionJournal,
+    fence: number,
+    backgroundTasks?: AgentSessionBackgroundTaskState | null
+  ): void {
     const page = readAgentSessionHydrationPage(journal, fence)
     for (const subscriber of this.subscribers(sessionId)) {
-      this.emit(subscriber, { type: 'snapshot', sessionId, page, fence })
+      this.emit(subscriber, {
+        type: 'snapshot',
+        sessionId,
+        page,
+        fence,
+        ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
+      })
       subscriber.cursor = page.liveCursor ?? page.window.nextCursor
       subscriber.fence = fence
     }
@@ -141,6 +163,27 @@ export class AgentSessionSubscribers {
     }
   }
 
+  backgroundTasks(
+    sessionId: string,
+    state: AgentSessionBackgroundTaskState | null,
+    fence: number
+  ): void {
+    for (const subscriber of this.subscribers(sessionId)) {
+      this.emit(subscriber, {
+        type: 'batch',
+        sessionId,
+        batch: {
+          cursor: subscriber.cursor,
+          items: [],
+          removedItemIds: [],
+          submissions: []
+        },
+        fence,
+        backgroundTasks: state
+      })
+    }
+  }
+
   private subscribers(sessionId: string): Subscriber[] {
     return [...(this.bySession.get(sessionId)?.values() ?? [])]
   }
@@ -149,7 +192,8 @@ export class AgentSessionSubscribers {
     subscriber: Subscriber,
     journal: AgentSessionJournal,
     handoff?: AgentSessionHandoffStatus,
-    emitCheckpoint = false
+    emitCheckpoint = false,
+    backgroundTasks?: AgentSessionBackgroundTaskState | null
   ): void {
     while (true) {
       const result = readAgentSessionHistory(journal, {
@@ -166,7 +210,8 @@ export class AgentSessionSubscribers {
           reset: result.reset,
           page,
           fence: subscriber.fence,
-          ...(handoff ? { handoff } : {})
+          ...(handoff ? { handoff } : {}),
+          ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
         })
         subscriber.cursor = page.liveCursor ?? page.window.nextCursor
         return
@@ -185,7 +230,8 @@ export class AgentSessionSubscribers {
               submissions: []
             },
             fence: subscriber.fence,
-            ...(handoff ? { handoff } : {})
+            ...(handoff ? { handoff } : {}),
+            ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
           })
         }
         return
@@ -200,7 +246,8 @@ export class AgentSessionSubscribers {
           submissions: page.submissions
         },
         fence: subscriber.fence,
-        ...(handoff ? { handoff } : {})
+        ...(handoff ? { handoff } : {}),
+        ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
       })
       subscriber.cursor = page.window.nextCursor
       if (!page.hasNewer || !this.isActive(subscriber)) {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-subscribers.ts
@@ -181,6 +181,7 @@ export class AgentSessionSubscribers {
         fence,
         backgroundTasks: state
       })
+      subscriber.fence = fence
     }
   }
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.test.ts
@@ -73,4 +73,35 @@ describe('performCancel', () => {
       { kind: 'status', text: 'Cancellation requested.' }
     ])
   })
+
+  it('stops background tasks without interrupting the foreground turn or writing a row', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-background-task-cancel-'))
+    const journal = await journals.open({ identity: IDENTITY, journalDir: root })
+    const cancelTurn = vi.fn(async () => ({ cancelled: true }))
+    const stopBackgroundTasks = vi.fn(async () => ({ cancelled: true }))
+    const ctx: AgentSessionTurnContext = {
+      sessionId: 'session-1',
+      journal,
+      fence: 1,
+      adapter: { cancelTurn, stopBackgroundTasks } as unknown as StructuredAgentSessionAdapter,
+      persistOptions: async () => undefined,
+      resolvedBy: 'client-1',
+      publish: vi.fn(),
+      now: () => 1
+    }
+
+    const result = await performCancel(ctx, {
+      clientOperationId: 'cancel-background-tasks',
+      turnId: 'background-tasks',
+      scope: 'background-tasks'
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: { turnId: 'background-tasks', cancelled: true }
+    })
+    expect(stopBackgroundTasks).toHaveBeenCalledWith({ sessionId: 'session-1', fence: 1 })
+    expect(cancelTurn).not.toHaveBeenCalled()
+    expect(journal.snapshot().items).toEqual([])
+  })
 })

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
@@ -146,18 +146,29 @@ export async function performSend(
 
 export async function performCancel(
   ctx: AgentSessionTurnContext,
-  input: { clientOperationId: string; turnId: string }
+  input: {
+    clientOperationId: string
+    turnId: string
+    scope?: 'background-tasks'
+  }
 ): Promise<TurnOutcome<AgentSessionCancelResult>> {
   let cancelled = false
   let note = 'Cancellation requested.'
   try {
-    cancelled = (
-      await ctx.adapter.cancelTurn({
-        sessionId: ctx.sessionId,
-        turnId: input.turnId,
-        fence: ctx.fence
-      })
-    ).cancelled
+    cancelled = input.scope
+      ? (
+          await ctx.adapter.stopBackgroundTasks?.({
+            sessionId: ctx.sessionId,
+            fence: ctx.fence
+          })
+        )?.cancelled === true
+      : (
+          await ctx.adapter.cancelTurn({
+            sessionId: ctx.sessionId,
+            turnId: input.turnId,
+            fence: ctx.fence
+          })
+        ).cancelled
     if (!cancelled) {
       note = 'The provider had already finished this turn.'
     }
@@ -165,6 +176,9 @@ export async function performCancel(
     note = `Cancellation was not confirmed: ${
       error instanceof Error ? error.message : String(error)
     }`
+  }
+  if (input.scope) {
+    return { ok: true, value: { turnId: input.turnId, cancelled } }
   }
   // Keyed by the operation id so a replayed cancel upserts one item, not two.
   await appendStatus(ctx, input.clientOperationId, note)

--- a/src/main/runtime/claude-structured-session-integration.test.ts
+++ b/src/main/runtime/claude-structured-session-integration.test.ts
@@ -119,6 +119,9 @@ function fakeClaude() {
         return undefined
       },
       cancelAsyncMessage: async () => {},
+      stopTask: async (taskId) => {
+        connection.calls.push({ subtype: 'stop_task', params: { taskId } })
+      },
       send: async (message) => {
         connection.sent.push(message)
         if (message.type === 'user') {

--- a/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
@@ -149,7 +149,11 @@ export const SendParams = z
   .strict()
 
 export const CancelParams = z
-  .object({ envelope: MutationEnvelope, turnId: Identifier('Invalid turn id') })
+  .object({
+    envelope: MutationEnvelope,
+    turnId: Identifier('Invalid turn id'),
+    scope: z.literal('background-tasks').optional()
+  })
   .strict()
 
 export const RespondParams = z

--- a/src/main/runtime/structured-agent-session-runtime.ts
+++ b/src/main/runtime/structured-agent-session-runtime.ts
@@ -246,6 +246,8 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
           }
         })
       },
+      onBackgroundTasksChanged: (sessionId, state) =>
+        host?.publishBackgroundTaskState(sessionId, state),
       ...(deps.openClaudeConnection ? { openClaudeConnection: deps.openClaudeConnection } : {}),
       ...(deps.readProcessStartTime ? { readProcessStartTime: deps.readProcessStartTime } : {})
     })

--- a/src/main/runtime/structured-claude-runtime-adapter.ts
+++ b/src/main/runtime/structured-claude-runtime-adapter.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionRecord } from '../../shared/agent-session-record'
+import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
 import { join } from 'node:path'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import type { ClaudeStructuredAuthPolicy } from '../claude-accounts/claude-structured-auth-policy'
@@ -29,6 +30,10 @@ export type StructuredClaudeRuntimeAdapterDeps = {
   openClaudeConnection?: ClaudeStructuredSessionAdapterDeps['openConnection']
   readProcessStartTime?: ClaudeStructuredSessionAdapterDeps['readProcessStartTime']
   onUnexpectedExit: (event: StructuredAgentSessionLifecycleEvent) => void
+  onBackgroundTasksChanged?: (
+    sessionId: string,
+    state: AgentSessionBackgroundTaskState | null
+  ) => void
 }
 
 export function createStructuredClaudeRuntimeAdapter(
@@ -92,6 +97,9 @@ export function createStructuredClaudeRuntimeAdapter(
         })
       }
     },
+    ...(deps.onBackgroundTasksChanged
+      ? { onBackgroundTasksChanged: deps.onBackgroundTasksChanged }
+      : {}),
     ...(deps.openClaudeConnection ? { openConnection: deps.openClaudeConnection } : {}),
     ...(deps.readProcessStartTime ? { readProcessStartTime: deps.readProcessStartTime } : {})
   })

--- a/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
@@ -1,36 +1,107 @@
+import { useId, useState } from 'react'
+import { ChevronDown } from 'lucide-react'
+import type { AgentSessionBackgroundTask } from '../../../../shared/agent-session-wire'
 import { AgentStateDot } from '@/components/AgentStateDot'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 
+function backgroundTaskLabel(task: AgentSessionBackgroundTask): string {
+  if (task.description) {
+    return task.description
+  }
+  switch (task.kind) {
+    case 'agent':
+      return translate('components.native-chat.backgroundTasks.agent', 'Background agent')
+    case 'workflow':
+      return translate('components.native-chat.backgroundTasks.workflow', 'Background workflow')
+    case 'command':
+      return translate('components.native-chat.backgroundTasks.command', 'Background command')
+    case 'monitor':
+      return translate('components.native-chat.backgroundTasks.monitor', 'Background monitor')
+    case 'unknown':
+      return translate('components.native-chat.backgroundTasks.task', 'Background task')
+  }
+}
+
 export function NativeChatBackgroundTasksStatus(props: {
+  tasks: readonly AgentSessionBackgroundTask[]
   stopping: boolean
   onStop: () => void
 }): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const taskListId = useId()
   return (
     <div
       data-native-chat-background-tasks="true"
       className="shrink-0 bg-background px-3 pt-2 sm:px-4"
     >
-      <div className="mx-auto flex h-8 w-full max-w-4xl items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 text-xs text-muted-foreground shadow-xs">
-        <span aria-hidden="true">
-          <AgentStateDot state="monitoring" size="md" title={null} />
-        </span>
-        <span>
-          {translate(
-            'components.native-chat.backgroundTasks.monitoring',
-            'Monitoring background tasks'
-          )}
-        </span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="xs"
-          className="ml-auto"
-          disabled={props.stopping}
-          onClick={props.onStop}
-        >
-          {translate('components.native-chat.backgroundTasks.stop', 'Stop')}
-        </Button>
+      <div className="mx-auto w-full max-w-4xl overflow-hidden rounded-lg border border-border bg-muted/50 text-xs text-muted-foreground shadow-xs">
+        <div className="flex h-8 items-center gap-1 px-1.5">
+          <button
+            type="button"
+            className="flex h-6 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-1.5 text-left outline-none hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            aria-expanded={expanded}
+            aria-controls={taskListId}
+            onClick={() => setExpanded((current) => !current)}
+          >
+            <span aria-hidden="true">
+              <AgentStateDot state="monitoring" size="md" title={null} />
+            </span>
+            <span className="min-w-0 flex-1 truncate">
+              {translate(
+                'components.native-chat.backgroundTasks.monitoring',
+                'Monitoring background tasks'
+              )}
+            </span>
+            <ChevronDown
+              aria-hidden="true"
+              className={`size-3 transition-transform ${expanded ? 'rotate-180' : ''}`}
+            />
+          </button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            disabled={props.stopping}
+            onClick={props.onStop}
+          >
+            {translate('components.native-chat.backgroundTasks.stop', 'Stop')}
+          </Button>
+        </div>
+        {expanded ? (
+          <div
+            id={taskListId}
+            className="scrollbar-sleek max-h-40 overflow-y-auto border-t border-border px-3 py-2"
+          >
+            {props.tasks.length > 0 ? (
+              <ul
+                role="list"
+                aria-label={translate(
+                  'components.native-chat.backgroundTasks.runningList',
+                  'Running background tasks'
+                )}
+                className="space-y-1.5"
+              >
+                {props.tasks.map((task) => (
+                  <li key={task.id} className="flex min-w-0 items-start gap-2 text-foreground/80">
+                    <span
+                      aria-hidden="true"
+                      className="mt-1 size-1.5 shrink-0 rounded-full bg-primary"
+                    />
+                    <span className="min-w-0 break-words">{backgroundTaskLabel(task)}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p>
+                {translate(
+                  'components.native-chat.backgroundTasks.detailsUnavailable',
+                  'Task details are unavailable for this session.'
+                )}
+              </p>
+            )}
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
@@ -1,0 +1,37 @@
+import { AgentStateDot } from '@/components/AgentStateDot'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+
+export function NativeChatBackgroundTasksStatus(props: {
+  stopping: boolean
+  onStop: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      data-native-chat-background-tasks="true"
+      className="shrink-0 bg-background px-3 pt-2 sm:px-4"
+    >
+      <div className="mx-auto flex h-8 w-full max-w-4xl items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 text-xs text-muted-foreground shadow-xs">
+        <span aria-hidden="true">
+          <AgentStateDot state="monitoring" size="md" title={null} />
+        </span>
+        <span>
+          {translate(
+            'components.native-chat.backgroundTasks.monitoring',
+            'Monitoring background tasks'
+          )}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="ml-auto"
+          disabled={props.stopping}
+          onClick={props.onStop}
+        >
+          {translate('components.native-chat.backgroundTasks.stop', 'Stop')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import React, { forwardRef, useImperativeHandle } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentJournalRenderItem } from '../../../../shared/agent-session-journal-types'
+import type { AgentSessionBackgroundTask } from '../../../../shared/agent-session-wire'
 import { decodeAgentSessionQuestionAnswers } from '../../../../shared/agent-session-question-answer'
 import type { NativeChatQuestionCardProps } from './NativeChatQuestionCard'
 
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   pasteFromClipboard: vi.fn(),
   submissions: [] as unknown[],
   monitoringBackgroundTasks: false,
+  backgroundTasks: [] as AgentSessionBackgroundTask[],
   stopBackgroundTasks: vi.fn()
 }))
 
@@ -73,6 +75,7 @@ vi.mock('./use-structured-agent-session', async () => {
         retry: outbox.retry,
         isWorking: false,
         isMonitoringBackgroundTasks: mocks.monitoringBackgroundTasks,
+        backgroundTasks: mocks.backgroundTasks,
         turnId: null,
         cancel: vi.fn(),
         stopBackgroundTasks: mocks.stopBackgroundTasks,
@@ -164,6 +167,7 @@ describe('NativeChatStructuredSession', () => {
     mocks.submissions = []
     mocks.monitoringBackgroundTasks = false
     mocks.stopBackgroundTasks.mockReset()
+    mocks.backgroundTasks = []
   })
 
   it('routes app-menu paste into the structured composer', () => {
@@ -221,6 +225,10 @@ describe('NativeChatStructuredSession', () => {
 
   it('places background monitoring above the usable composer and stops without an active turn', async () => {
     mocks.monitoringBackgroundTasks = true
+    mocks.backgroundTasks = [
+      { id: 'task-command', kind: 'command', description: 'sleep 180' },
+      { id: 'task-agent', kind: 'agent' }
+    ]
     mocks.stopBackgroundTasks.mockResolvedValue({ cancelled: true })
 
     render(
@@ -230,7 +238,6 @@ describe('NativeChatStructuredSession', () => {
         sessionId="session-background"
         target={{ kind: 'local' }}
         agent="claude"
-        allowFileUriLinks={false}
       />
     )
 
@@ -243,6 +250,15 @@ describe('NativeChatStructuredSession', () => {
     }
     expect(status.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(mocks.composerProps?.isWorking).toBe(false)
+    expect(screen.queryByRole('list', { name: 'Running background tasks' })).toBeNull()
+
+    const disclosure = screen.getByRole('button', { name: 'Monitoring background tasks' })
+    expect(disclosure.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(disclosure)
+    expect(disclosure.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('list', { name: 'Running background tasks' })).toBeTruthy()
+    expect(screen.getByText('sleep 180')).toBeTruthy()
+    expect(screen.getByText('Background agent')).toBeTruthy()
 
     fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
     await waitFor(() => expect(mocks.stopBackgroundTasks).toHaveBeenCalledOnce())

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -17,13 +17,18 @@ const mocks = vi.hoisted(() => ({
     showTurnStatus?: boolean
     runtimeContext?: unknown
   },
-  composerProps: null as null | { structuredTransport?: Record<string, unknown> },
+  composerProps: null as null | {
+    structuredTransport?: Record<string, unknown>
+    isWorking?: boolean
+  },
   questionCardProps: null as NativeChatQuestionCardProps | null,
   promptItems: [] as AgentJournalRenderItem[],
   respond: vi.fn(),
   handlePasteEvent: vi.fn(),
   pasteFromClipboard: vi.fn(),
-  submissions: [] as unknown[]
+  submissions: [] as unknown[],
+  monitoringBackgroundTasks: false,
+  stopBackgroundTasks: vi.fn()
 }))
 
 vi.mock('@/runtime/structured-agent-session-client', () => ({
@@ -67,8 +72,10 @@ vi.mock('./use-structured-agent-session', async () => {
         send: outbox.send,
         retry: outbox.retry,
         isWorking: false,
+        isMonitoringBackgroundTasks: mocks.monitoringBackgroundTasks,
         turnId: null,
         cancel: vi.fn(),
+        stopBackgroundTasks: mocks.stopBackgroundTasks,
         respond: mocks.respond,
         optionSnapshot: [
           {
@@ -155,6 +162,8 @@ describe('NativeChatStructuredSession', () => {
     mocks.handlePasteEvent.mockReset()
     mocks.pasteFromClipboard.mockReset()
     mocks.submissions = []
+    mocks.monitoringBackgroundTasks = false
+    mocks.stopBackgroundTasks.mockReset()
   })
 
   it('routes app-menu paste into the structured composer', () => {
@@ -209,6 +218,35 @@ describe('NativeChatStructuredSession', () => {
       expect(mocks.messageListProps?.runtimeContext).not.toBeUndefined()
     }
   )
+
+  it('places background monitoring above the usable composer and stops without an active turn', async () => {
+    mocks.monitoringBackgroundTasks = true
+    mocks.stopBackgroundTasks.mockResolvedValue({ cancelled: true })
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-background"
+        sessionId="session-background"
+        target={{ kind: 'local' }}
+        agent="claude"
+        allowFileUriLinks={false}
+      />
+    )
+
+    const status = screen
+      .getByText('Monitoring background tasks')
+      .closest('[data-native-chat-background-tasks="true"]')
+    const composer = screen.getByTestId('structured-composer')
+    if (!status) {
+      throw new Error('background task status was not rendered')
+    }
+    expect(status.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(mocks.composerProps?.isWorking).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+    await waitFor(() => expect(mocks.stopBackgroundTasks).toHaveBeenCalledOnce())
+  })
 
   it('routes a bare model command to the native option picker', async () => {
     render(

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -276,6 +276,7 @@ export function NativeChatStructuredSession(
       ) : null}
       {controller.isMonitoringBackgroundTasks ? (
         <NativeChatBackgroundTasksStatus
+          tasks={controller.backgroundTasks}
           stopping={stoppingBackgroundTasks}
           onStop={() => {
             setStoppingBackgroundTasks(true)

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -20,6 +20,7 @@ import { NativeChatOrchestrationPausedNotice } from './NativeChatOrchestrationPa
 import { useNativeChatImageRuntimeContext } from './native-chat-image-runtime-context'
 import { useStructuredNativeChatPaneCommands } from './use-structured-native-chat-pane-commands'
 import type { NativeChatStructuredViewProps } from './native-chat-view-types'
+import { NativeChatBackgroundTasksStatus } from './NativeChatBackgroundTasksStatus'
 
 function encodeQuestionAnswer(questionId: string, answer: string): string {
   return `${encodeURIComponent(questionId)}:${encodeURIComponent(answer)}`
@@ -30,6 +31,7 @@ export function NativeChatStructuredSession(
 ): React.JSX.Element {
   const controller = useStructuredAgentSession(props)
   const [composerError, setComposerError] = useState<string | null>(null)
+  const [stoppingBackgroundTasks, setStoppingBackgroundTasks] = useState(false)
   const [optionPickerRequest, setOptionPickerRequest] = useState<{
     id: string
     sequence: number
@@ -271,6 +273,15 @@ export function NativeChatStructuredSession(
         <p className="mx-auto w-full max-w-4xl px-4 py-1 text-xs text-destructive">
           {controller.error ?? composerError}
         </p>
+      ) : null}
+      {controller.isMonitoringBackgroundTasks ? (
+        <NativeChatBackgroundTasksStatus
+          stopping={stoppingBackgroundTasks}
+          onStop={() => {
+            setStoppingBackgroundTasks(true)
+            void controller.stopBackgroundTasks().finally(() => setStoppingBackgroundTasks(false))
+          }}
+        />
       ) : null}
       {prompt ? null : (
         <NativeChatComposer

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -140,6 +140,8 @@ export function useStructuredAgentSession(args: {
   // on the frame that opens each one, so re-read the options as a turn changes
   // rather than leaving the last write unconfirmed for the life of the session.
   const turnId = activeStructuredAgentSessionTurnId(state.items)
+  const isMonitoringBackgroundTasks =
+    turnId === null && state.backgroundTasks?.state === 'monitoring'
 
   useEffect(() => {
     if (!isVisible || !optionCatalog) {
@@ -241,8 +243,14 @@ export function useStructuredAgentSession(args: {
     send: outboxController.send,
     retry: outboxController.retry,
     isWorking: turnId !== null,
+    isMonitoringBackgroundTasks,
     turnId,
     cancel: (turnId: string) => mutate('agentSession.cancel', 'agentSession.cancel', { turnId }),
+    stopBackgroundTasks: () =>
+      mutate('agentSession.cancel', 'agentSession.cancel', {
+        turnId: 'background-tasks',
+        scope: 'background-tasks'
+      }),
     respond: (item: StructuredPromptItem, optionId: string) =>
       mutate<AgentSessionPromptResult>(
         item.body.kind === 'approval'

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -244,6 +244,7 @@ export function useStructuredAgentSession(args: {
     retry: outboxController.retry,
     isWorking: turnId !== null,
     isMonitoringBackgroundTasks,
+    backgroundTasks: state.backgroundTasks?.tasks ?? [],
     turnId,
     cancel: (turnId: string) => mutate('agentSession.cancel', 'agentSession.cancel', { turnId }),
     stopBackgroundTasks: () =>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16973,7 +16973,14 @@
       },
       "backgroundTasks": {
         "monitoring": "Monitoring background tasks",
-        "stop": "Stop"
+        "stop": "Stop",
+        "agent": "Background agent",
+        "workflow": "Background workflow",
+        "command": "Background command",
+        "monitor": "Background monitor",
+        "task": "Background task",
+        "runningList": "Running background tasks",
+        "detailsUnavailable": "Task details are unavailable for this session."
       },
       "jumpToLatest": "Jump to latest",
       "toggle": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16971,6 +16971,10 @@
         "workedFor": "Worked for {{value0}}",
         "toggleDetails": "Toggle turn details"
       },
+      "backgroundTasks": {
+        "monitoring": "Monitoring background tasks",
+        "stop": "Stop"
+      },
       "jumpToLatest": "Jump to latest",
       "toggle": {
         "showTerminal": "Show terminal",

--- a/src/shared/agent-session-wire.ts
+++ b/src/shared/agent-session-wire.ts
@@ -49,7 +49,17 @@ export type AgentSessionHandoffRequest = {
 
 export type AgentSessionHandoffResult = { status: AgentSessionHandoffStatus }
 
-export type AgentSessionBackgroundTaskState = { state: 'monitoring' }
+export type AgentSessionBackgroundTask = {
+  id: string
+  kind: 'agent' | 'workflow' | 'command' | 'monitor' | 'unknown'
+  description?: string
+}
+
+export type AgentSessionBackgroundTaskState = {
+  state: 'monitoring'
+  /** Optional so mixed-version clients can consume state-only hosts. */
+  tasks?: AgentSessionBackgroundTask[]
+}
 
 /** Backward paging is the client's normal read; 40 matches the page size the
  *  mobile list renders without a visible fill-in. */

--- a/src/shared/agent-session-wire.ts
+++ b/src/shared/agent-session-wire.ts
@@ -49,6 +49,8 @@ export type AgentSessionHandoffRequest = {
 
 export type AgentSessionHandoffResult = { status: AgentSessionHandoffStatus }
 
+export type AgentSessionBackgroundTaskState = { state: 'monitoring' }
+
 /** Backward paging is the client's normal read; 40 matches the page size the
  *  mobile list renders without a visible fill-in. */
 export const AGENT_SESSION_HISTORY_DEFAULT_LIMIT = 40
@@ -92,6 +94,8 @@ export type AgentSessionHistoryPage = {
   liveCursor?: AgentJournalCursor
   hasOlder: boolean
   hasNewer: boolean
+  /** Present on hosts that expose provider-owned background task lifecycle. */
+  backgroundTasks?: AgentSessionBackgroundTaskState | null
 }
 
 export type AgentSessionHistoryResult =
@@ -123,6 +127,7 @@ export type AgentSessionSubscribeEvent =
       page: AgentSessionHistoryPage
       fence: number
       handoff?: AgentSessionHandoffStatus
+      backgroundTasks?: AgentSessionBackgroundTaskState | null
     }
   | {
       type: 'batch'
@@ -131,6 +136,7 @@ export type AgentSessionSubscribeEvent =
       /** Added with handoff state so mixed-version cursors retain the ownership fence. */
       fence?: number
       handoff?: AgentSessionHandoffStatus
+      backgroundTasks?: AgentSessionBackgroundTaskState | null
     }
   | {
       type: 'reset'
@@ -139,6 +145,7 @@ export type AgentSessionSubscribeEvent =
       page: AgentSessionHistoryPage
       fence: number
       handoff?: AgentSessionHandoffStatus
+      backgroundTasks?: AgentSessionBackgroundTaskState | null
     }
   | { type: 'end' }
 

--- a/src/shared/structured-agent-session-coalescer.test.ts
+++ b/src/shared/structured-agent-session-coalescer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentSessionSubscribeEvent } from './agent-session-wire'
+import { createStructuredAgentSessionEventCoalescer } from './structured-agent-session-coalescer'
+
+function batch(
+  sequence: number,
+  backgroundTasks?: Extract<AgentSessionSubscribeEvent, { type: 'batch' }>['backgroundTasks']
+): Extract<AgentSessionSubscribeEvent, { type: 'batch' }> {
+  return {
+    type: 'batch',
+    sessionId: 'session-1',
+    batch: {
+      cursor: { epoch: 'epoch-1', sequence },
+      items: [],
+      removedItemIds: [],
+      submissions: []
+    },
+    ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
+  }
+}
+
+describe('structured agent session event coalescer', () => {
+  it('preserves background task state when a journal batch follows it', () => {
+    const events: AgentSessionSubscribeEvent[] = []
+    const coalescer = createStructuredAgentSessionEventCoalescer((event) => events.push(event))
+
+    coalescer.push(batch(1, { state: 'monitoring' }))
+    coalescer.push(batch(2))
+    coalescer.flush()
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ backgroundTasks: { state: 'monitoring' } })
+  })
+
+  it('keeps an explicit terminal state as the newest coalesced value', () => {
+    const events: AgentSessionSubscribeEvent[] = []
+    const coalescer = createStructuredAgentSessionEventCoalescer((event) => events.push(event))
+
+    coalescer.push(batch(1, { state: 'monitoring' }))
+    coalescer.push(batch(1, null))
+    coalescer.flush()
+
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ backgroundTasks: null })
+  })
+})

--- a/src/shared/structured-agent-session-coalescer.test.ts
+++ b/src/shared/structured-agent-session-coalescer.test.ts
@@ -24,12 +24,22 @@ describe('structured agent session event coalescer', () => {
     const events: AgentSessionSubscribeEvent[] = []
     const coalescer = createStructuredAgentSessionEventCoalescer((event) => events.push(event))
 
-    coalescer.push(batch(1, { state: 'monitoring' }))
+    coalescer.push(
+      batch(1, {
+        state: 'monitoring',
+        tasks: [{ id: 'task-1', kind: 'command', description: 'run the build' }]
+      })
+    )
     coalescer.push(batch(2))
     coalescer.flush()
 
     expect(events).toHaveLength(1)
-    expect(events[0]).toMatchObject({ backgroundTasks: { state: 'monitoring' } })
+    expect(events[0]).toMatchObject({
+      backgroundTasks: {
+        state: 'monitoring',
+        tasks: [{ id: 'task-1', kind: 'command', description: 'run the build' }]
+      }
+    })
   })
 
   it('keeps an explicit terminal state as the newest coalesced value', () => {

--- a/src/shared/structured-agent-session-coalescer.ts
+++ b/src/shared/structured-agent-session-coalescer.ts
@@ -35,7 +35,15 @@ function mergeBatch(
     ...(right.fence !== undefined || left.fence !== undefined
       ? { fence: right.fence ?? left.fence }
       : {}),
-    ...(right.handoff || left.handoff ? { handoff: right.handoff ?? left.handoff } : {})
+    ...(right.handoff || left.handoff ? { handoff: right.handoff ?? left.handoff } : {}),
+    ...(right.backgroundTasks !== undefined || left.backgroundTasks !== undefined
+      ? {
+          backgroundTasks:
+            right.backgroundTasks !== undefined
+              ? right.backgroundTasks
+              : (left.backgroundTasks ?? null)
+        }
+      : {})
   }
 }
 

--- a/src/shared/structured-agent-session-reducer.test.ts
+++ b/src/shared/structured-agent-session-reducer.test.ts
@@ -250,4 +250,65 @@ describe('structured agent session reducer', () => {
     expect(state.submissions[0]?.clientMessageId).toBe('client-44')
     expect(state.submissions.at(-1)?.clientMessageId).toBe('client-299')
   })
+
+  it('projects additive background task state without changing transcript identity', () => {
+    const initial = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 1,
+        page: hydrationPage([item('message', 1)]),
+        backgroundTasks: null
+      }
+    })
+    const monitoring = reduceStructuredAgentSession(initial, {
+      type: 'event',
+      event: {
+        type: 'batch',
+        sessionId: 'session-a',
+        batch: {
+          cursor: initial.cursor!,
+          items: [],
+          removedItemIds: [],
+          submissions: []
+        },
+        fence: 1,
+        backgroundTasks: { state: 'monitoring' }
+      }
+    })
+
+    expect(monitoring.backgroundTasks).toEqual({ state: 'monitoring' })
+    expect(monitoring.items).toBe(initial.items)
+  })
+
+  it('returns the same state for duplicate background task publications', () => {
+    const monitoring = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 1,
+        page: hydrationPage([item('message', 1)]),
+        backgroundTasks: { state: 'monitoring' }
+      }
+    })
+    const duplicate = reduceStructuredAgentSession(monitoring, {
+      type: 'event',
+      event: {
+        type: 'batch',
+        sessionId: 'session-a',
+        batch: {
+          cursor: monitoring.cursor!,
+          items: [],
+          removedItemIds: [],
+          submissions: []
+        },
+        fence: 1,
+        backgroundTasks: { state: 'monitoring' }
+      }
+    })
+
+    expect(duplicate).toBe(monitoring)
+  })
 })

--- a/src/shared/structured-agent-session-reducer.test.ts
+++ b/src/shared/structured-agent-session-reducer.test.ts
@@ -312,6 +312,46 @@ describe('structured agent session reducer', () => {
     expect(duplicate).toBe(monitoring)
   })
 
+  it('applies background task roster changes without a journal update', () => {
+    const monitoring = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 1,
+        page: hydrationPage([item('message', 1)]),
+        backgroundTasks: {
+          state: 'monitoring',
+          tasks: [{ id: 'task-1', kind: 'command', description: 'first command' }]
+        }
+      }
+    })
+    const changed = reduceStructuredAgentSession(monitoring, {
+      type: 'event',
+      event: {
+        type: 'batch',
+        sessionId: 'session-a',
+        batch: {
+          cursor: monitoring.cursor!,
+          items: [],
+          removedItemIds: [],
+          submissions: []
+        },
+        fence: 1,
+        backgroundTasks: {
+          state: 'monitoring',
+          tasks: [{ id: 'task-1', kind: 'agent', description: 'review the change' }]
+        }
+      }
+    })
+
+    expect(changed).not.toBe(monitoring)
+    expect(changed.backgroundTasks?.tasks).toEqual([
+      { id: 'task-1', kind: 'agent', description: 'review the change' }
+    ])
+    expect(changed.items).toBe(monitoring.items)
+  })
+
   it('clears additive background state when a replacement snapshot omits the field', () => {
     const monitoring = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
       type: 'event',

--- a/src/shared/structured-agent-session-reducer.test.ts
+++ b/src/shared/structured-agent-session-reducer.test.ts
@@ -311,4 +311,28 @@ describe('structured agent session reducer', () => {
 
     expect(duplicate).toBe(monitoring)
   })
+
+  it('clears additive background state when a replacement snapshot omits the field', () => {
+    const monitoring = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 1,
+        page: hydrationPage([item('message', 1)]),
+        backgroundTasks: { state: 'monitoring' }
+      }
+    })
+    const withoutCapability = reduceStructuredAgentSession(monitoring, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 2,
+        page: hydrationPage([item('message', 1)])
+      }
+    })
+
+    expect(withoutCapability.backgroundTasks).toBeUndefined()
+  })
 })

--- a/src/shared/structured-agent-session-reducer.ts
+++ b/src/shared/structured-agent-session-reducer.ts
@@ -4,6 +4,7 @@ import type {
   AgentJournalSubmission
 } from './agent-session-journal-types'
 import type {
+  AgentSessionBackgroundTaskState,
   AgentSessionHandoffStatus,
   AgentSessionHistoryPage,
   AgentSessionSubscribeEvent
@@ -19,6 +20,7 @@ export type StructuredAgentSessionState = {
   status: 'idle' | 'loading' | 'ready' | 'error'
   error?: string
   handoff: AgentSessionHandoffStatus | null
+  backgroundTasks?: AgentSessionBackgroundTaskState | null
 }
 
 export type StructuredAgentSessionAction =
@@ -45,7 +47,8 @@ const MAX_RETAINED_SUBMISSIONS = 256
 function replacePage(
   page: AgentSessionHistoryPage,
   fence: number,
-  handoff?: AgentSessionHandoffStatus
+  handoff?: AgentSessionHandoffStatus,
+  backgroundTasks?: AgentSessionBackgroundTaskState | null
 ): StructuredAgentSessionState {
   return {
     epoch: page.epoch,
@@ -55,7 +58,12 @@ function replacePage(
     submissions: page.submissions,
     hasOlder: page.hasOlder,
     status: 'ready',
-    handoff: handoff ?? null
+    handoff: handoff ?? null,
+    ...(backgroundTasks !== undefined
+      ? { backgroundTasks }
+      : page.backgroundTasks !== undefined
+        ? { backgroundTasks: page.backgroundTasks }
+        : {})
   }
 }
 
@@ -113,12 +121,23 @@ export function reduceStructuredAgentSession(
       state.cursor &&
       (!pageCursor || pageCursor.sequence <= state.cursor.sequence)
     ) {
+      const backgroundTasksChanged =
+        action.page.backgroundTasks !== undefined &&
+        action.page.backgroundTasks?.state !== state.backgroundTasks?.state
       if (
         pageCursor?.sequence === state.cursor.sequence &&
-        action.page.fence !== undefined &&
-        action.page.fence !== state.fence
+        ((action.page.fence !== undefined && action.page.fence !== state.fence) ||
+          backgroundTasksChanged)
       ) {
-        return { ...state, fence: action.page.fence, status: 'ready', error: undefined }
+        return {
+          ...state,
+          ...(action.page.fence !== undefined ? { fence: action.page.fence } : {}),
+          ...(action.page.backgroundTasks !== undefined
+            ? { backgroundTasks: action.page.backgroundTasks }
+            : {}),
+          status: 'ready',
+          error: undefined
+        }
       }
       return state
     }
@@ -133,7 +152,12 @@ export function reduceStructuredAgentSession(
         : action.page.submissions,
       hasOlder: action.page.hasOlder,
       status: 'ready',
-      handoff: state.handoff
+      handoff: state.handoff,
+      ...(action.page.backgroundTasks !== undefined
+        ? { backgroundTasks: action.page.backgroundTasks }
+        : state.backgroundTasks !== undefined
+          ? { backgroundTasks: state.backgroundTasks }
+          : {})
     }
   }
   if (action.type === 'older-page') {
@@ -152,7 +176,7 @@ export function reduceStructuredAgentSession(
     return state
   }
   if (event.type === 'snapshot' || event.type === 'reset') {
-    return replacePage(event.page, event.fence, event.handoff)
+    return replacePage(event.page, event.fence, event.handoff, event.backgroundTasks)
   }
   if (state.epoch !== event.batch.cursor.epoch) {
     return state
@@ -160,15 +184,37 @@ export function reduceStructuredAgentSession(
   if (state.cursor && event.batch.cursor.sequence < state.cursor.sequence) {
     return state
   }
+  const backgroundTasks =
+    event.backgroundTasks !== undefined ? event.backgroundTasks : state.backgroundTasks
+  const journalUnchanged =
+    event.batch.items.length === 0 &&
+    event.batch.removedItemIds.length === 0 &&
+    event.batch.submissions.length === 0
+  if (
+    event.batch.cursor.sequence === state.cursor?.sequence &&
+    journalUnchanged &&
+    (event.fence === undefined || event.fence === state.fence) &&
+    (event.handoff === undefined || event.handoff === state.handoff) &&
+    backgroundTasks?.state === state.backgroundTasks?.state &&
+    state.status === 'ready' &&
+    state.error === undefined
+  ) {
+    return state
+  }
   return {
     ...state,
     cursor: event.batch.cursor,
     fence: event.fence ?? state.fence,
-    items: mergeItems(state.items, event.batch.items, event.batch.removedItemIds),
-    submissions: mergeSubmissions(state.submissions, event.batch.submissions),
+    items: journalUnchanged
+      ? state.items
+      : mergeItems(state.items, event.batch.items, event.batch.removedItemIds),
+    submissions: journalUnchanged
+      ? state.submissions
+      : mergeSubmissions(state.submissions, event.batch.submissions),
     status: 'ready',
     error: undefined,
-    handoff: event.handoff ?? state.handoff
+    handoff: event.handoff ?? state.handoff,
+    ...(backgroundTasks !== undefined ? { backgroundTasks } : {})
   }
 }
 

--- a/src/shared/structured-agent-session-reducer.ts
+++ b/src/shared/structured-agent-session-reducer.ts
@@ -44,6 +44,30 @@ export const EMPTY_STRUCTURED_AGENT_SESSION: StructuredAgentSessionState = {
 
 const MAX_RETAINED_SUBMISSIONS = 256
 
+function backgroundTaskStatesEqual(
+  left: AgentSessionBackgroundTaskState | null | undefined,
+  right: AgentSessionBackgroundTaskState | null | undefined
+): boolean {
+  if (left === right) {
+    return true
+  }
+  if (!left || !right || left.state !== right.state) {
+    return false
+  }
+  if (left.tasks === right.tasks) {
+    return true
+  }
+  if (!left.tasks || !right.tasks || left.tasks.length !== right.tasks.length) {
+    return false
+  }
+  return left.tasks.every(
+    (task, index) =>
+      task.id === right.tasks?.[index]?.id &&
+      task.kind === right.tasks[index]?.kind &&
+      task.description === right.tasks[index]?.description
+  )
+}
+
 function replacePage(
   page: AgentSessionHistoryPage,
   fence: number,
@@ -123,7 +147,7 @@ export function reduceStructuredAgentSession(
     ) {
       const backgroundTasksChanged =
         action.page.backgroundTasks !== undefined &&
-        action.page.backgroundTasks?.state !== state.backgroundTasks?.state
+        !backgroundTaskStatesEqual(action.page.backgroundTasks, state.backgroundTasks)
       if (
         pageCursor?.sequence === state.cursor.sequence &&
         ((action.page.fence !== undefined && action.page.fence !== state.fence) ||
@@ -195,7 +219,7 @@ export function reduceStructuredAgentSession(
     journalUnchanged &&
     (event.fence === undefined || event.fence === state.fence) &&
     (event.handoff === undefined || event.handoff === state.handoff) &&
-    backgroundTasks?.state === state.backgroundTasks?.state &&
+    backgroundTaskStatesEqual(backgroundTasks, state.backgroundTasks) &&
     state.status === 'ready' &&
     state.error === undefined
   ) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​773 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​768 |
| Prod | 27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​793 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​55 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​738 |

<!-- /orca-pr-loc -->

## ELI5

When Claude keeps tasks running after it finishes replying, Native Chat now shows a small status footer above the composer. Click it to see what is running, keep chatting normally, or stop only the background work.

## What Changed

- detect Claude Agent SDK background-task lifecycle state with a bounded tracker
- publish additive, optional monitoring state through the structured-session wire path
- render a footer directly above the enabled composer: monitoring icon → “Monitoring background tasks” → chevron → Stop
- expand the status area on click to show a bounded list of live task descriptions
- stop active background tasks without cancelling the foreground chat turn or adding a cancellation transcript row
- preserve runtime fences and clear monitoring state across completion, teardown, and old-host snapshots

## Why

Background work previously continued without a clear Native Chat status or scoped stop action. The implementation follows the SDK lifecycle as the source of truth, keeps the normal composer usable, and confines cancellation to the provider task IDs that are actually running.

## Linked Issue

Follow-up to #18560.

## Visual Proof

Validated in an isolated Electron instance on exact SHA `516cf64abf8cd64da5c954f35386dc81c7294a25` with a real Claude Agent SDK session and live background process.

[Full Electron validation and process evidence](https://github.com/stablyai/orca/pull/18757#issuecomment-5549133777)

Collapsed:

![Collapsed monitoring footer](https://github.com/user-attachments/assets/5de87301-2522-476e-9e35-b2b42294c276)

Expanded task details:

![Expanded running task details](https://github.com/user-attachments/assets/3a61d113-5fb6-4a62-9b10-7272c5449d76)

After Stop:

![Footer cleared with composer still enabled](https://github.com/user-attachments/assets/6e3a024d-ee8a-4d7a-a20f-12f4ea0d7043)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Verification:

- 173 tests across the 17 changed test files; final clean-review delta rerun: 59 tests across 7 focused files
- `pnpm tc`
- `pnpm run check:code-quality:changed` — zero code-quality, type-aware, and React Doctor findings
- `git diff --check`
- Electron/CDP validation on macOS with a real SDK background task
- CI covers static analysis, typecheck, cross-version wire compatibility, all test shards, and Windows/Linux packaging

## AI Disclosure

<!-- Internal contributor; intentionally left blank. -->

## Review

Same-model review-until-clean completed on the pushed semantic diff through three final passes. Proven lifecycle and performance issues were fixed with regression coverage: subscriber-fence rollback, an unbounded provider control request, and needless roster serialization for irrelevant SDK frames. The English localization catalog was synchronized. The final pass found no remaining in-scope correctness, lifecycle, compatibility, accessibility, localization, or performance issues.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no dependency, credential, shell-evaluation, or new network surface
- Cross-platform: shared structured-session and renderer paths; Windows package CI included
- SSH/remote: execution remains host-owned; optional wire state preserves mixed-version behavior
- Mobile: no mobile-facing surface touched
- Backward compatibility: new wire state and cancel scope are optional and capability-gated; old-host snapshot clearing is covered
- Performance: no polling, subprocess churn, or unbounded state; tracking is capped, and provider control requests use a cleared, unref'd timeout

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered
- [x] Changed-file quality, typecheck, focused tests, and applicable CI checks pass
