### PR TITLE
feat(analytics): persist local usage session identities

### DIFF
--- a/docs/reference/analytics-session-id.md
+++ b/docs/reference/analytics-session-id.md
@@ -1,0 +1,35 @@
+# Analytics session identity
+
+The local Claude, Codex, and OpenCode usage stores expose
+`getAnalyticsSessionId(providerSessionId): Promise<AnalyticsSessionId>` through
+`UsageProviderStoreLifecycle`. The result is a random UUID v4, independent of the
+provider's session ID. Repeated lookups and session resumes return the same ID,
+including after an application restart.
+
+Mappings are created on demand and saved before the accessor resolves. They live
+beside the provider cache in `<cache-name>-analytics-session-ids.json`, separately
+from disposable usage projections. Rebuilding or invalidating a usage cache does
+not reset session identities. Deleting the identity file or the profile does.
+A corrupt or unsupported identity file fails closed rather than silently replacing
+previously issued identities. The existing durable usage-cache writer handles
+atomic replacement, and the store's shutdown flush also waits for identity writes.
+
+Each identity store has one owner, matching the provider usage store lifecycle.
+Lookups and writes are serialized within that owner. Different providers and
+execution-host profiles use separate files, so matching provider session IDs do
+not join unrelated sessions. Future SSH reporting must request identities from
+the execution host's usage store, not mint replacements on each viewing client.
+The mapping has no repository or git-worktree dependency; folder workspaces use
+the same accessor.
+
+The provider-ID-to-analytics-ID mapping stays local. It is not added to usage
+snapshots, renderer APIs, RPC payloads, or PostHog events. This change adds only the
+identity primitive; a future exporter must apply consent before using it and send
+only the analytics ID. A stable analytics ID links observations of one session and
+is pseudonymous, not a guarantee of anonymity.
+
+Snapshot revisions are separate from identity. A future exporter can persist a
+counter that increases when a snapshot changes, preserving the same revision when
+retrying that snapshot. An online query can then select the highest revision for
+a session/day/model even when uploads arrive out of order. This PR does not add
+that counter or any session-usage transmission.

--- a/src/main/usage/analytics-session-id-store.test.ts
+++ b/src/main/usage/analytics-session-id-store.test.ts
@@ -1,0 +1,194 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type * as FsPromises from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AnalyticsSessionIdStore } from './analytics-session-id-store'
+
+const { writeGate } = vi.hoisted(() => ({
+  writeGate: {
+    entered: null as (() => void) | null,
+    wait: null as Promise<void> | null,
+    fail: false
+  }
+}))
+vi.mock('node:fs/promises', async () => {
+  const actual = await vi.importActual<typeof FsPromises>('node:fs/promises')
+  return {
+    ...actual,
+    open: (async (...args: Parameters<typeof actual.open>) => {
+      if (args[1] === 'w') {
+        writeGate.entered?.()
+        if (writeGate.wait) {
+          await writeGate.wait
+        }
+        if (writeGate.fail) {
+          throw new Error('simulated disk failure')
+        }
+      }
+      return actual.open(...args)
+    }) as typeof actual.open
+  }
+})
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+let directory: string
+let file: string
+let stores: AnalyticsSessionIdStore[]
+function createStore(path = file): AnalyticsSessionIdStore {
+  const store = new AnalyticsSessionIdStore(path)
+  stores.push(store)
+  return store
+}
+beforeEach(() => {
+  directory = mkdtempSync(join(tmpdir(), 'orca-analytics-session-id-'))
+  file = join(directory, 'identities.json')
+  stores = []
+  writeGate.entered = null
+  writeGate.wait = null
+  writeGate.fail = false
+})
+afterEach(async () => {
+  await Promise.all(stores.map((store) => store.flush()))
+  rmSync(directory, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+describe('AnalyticsSessionIdStore', () => {
+  it('is lazy and persists a random ID before returning it', async () => {
+    const store = createStore()
+    expect(existsSync(file)).toBe(false)
+    const id = await store.getOrCreate('provider-session-123')
+    expect(id).toMatch(UUID_V4)
+    expect(id).not.toContain('provider-session')
+    expect(JSON.parse(readFileSync(file, 'utf8'))).toEqual({
+      schemaVersion: 1,
+      entries: [['provider-session-123', id]]
+    })
+    expect(await store.getOrCreate('provider-session-123')).toBe(id)
+  })
+
+  it('restores the ID after a restart or session resume', async () => {
+    const original = createStore()
+    const id = await original.getOrCreate('resumed-session')
+    await original.flush()
+    expect(await createStore().getOrCreate('resumed-session')).toBe(id)
+  })
+
+  it('handles concurrent requests for the same and different sessions without lost writes', async () => {
+    const store = createStore()
+    const ids = await Promise.all(
+      Array.from({ length: 20 }, (_, index) => store.getOrCreate(`session-${index % 10}`))
+    )
+    expect(new Set(ids).size).toBe(10)
+    expect(ids.slice(0, 10)).toEqual(ids.slice(10))
+    const restored = createStore()
+    for (let index = 0; index < 10; index++) {
+      expect(await restored.getOrCreate(`session-${index}`)).toBe(ids[index])
+    }
+  })
+
+  it('isolates identical provider session IDs across provider and host/profile files', async () => {
+    const ids = await Promise.all([
+      createStore(join(directory, 'host-a', 'claude.json')).getOrCreate('same-session'),
+      createStore(join(directory, 'host-a', 'codex.json')).getOrCreate('same-session'),
+      createStore(join(directory, 'host-b', 'claude.json')).getOrCreate('same-session')
+    ])
+    expect(new Set(ids).size).toBe(3)
+  })
+
+  it.each(['', '   ', 'x'.repeat(1025)])(
+    'rejects invalid keys without creating a mapping',
+    async (key) => {
+      await expect(createStore().getOrCreate(key)).rejects.toThrow('Invalid provider session ID')
+      expect(existsSync(file)).toBe(false)
+    }
+  )
+
+  it('handles prototype names and delimiter characters as ordinary opaque keys', async () => {
+    const store = createStore()
+    const keys = ['__proto__', 'constructor', 'a::b/c', 'a/b::c']
+    const ids = await Promise.all(keys.map((key) => store.getOrCreate(key)))
+    expect(new Set(ids).size).toBe(keys.length)
+    const restored = createStore()
+    expect(await Promise.all(keys.map((key) => restored.getOrCreate(key)))).toEqual(ids)
+  })
+
+  it.each([
+    '{broken',
+    JSON.stringify({ schemaVersion: 2, entries: [] }),
+    JSON.stringify({ schemaVersion: 1, entries: [['session', 'provider-id']] }),
+    JSON.stringify({ schemaVersion: 1, entries: [], extra: 'secret' })
+  ])('fails closed on invalid persisted state without overwriting it', async (content) => {
+    writeFileSync(file, content)
+    await expect(createStore().getOrCreate('new-session')).rejects.toThrow(
+      'Invalid analytics session identity file'
+    )
+    expect(readFileSync(file, 'utf8')).toBe(content)
+  })
+
+  it('rejects conflicting provider keys and analytics IDs', async () => {
+    const first = '00000000-0000-4000-8000-000000000001'
+    const second = '00000000-0000-4000-8000-000000000002'
+    for (const entries of [
+      [
+        ['a', first],
+        ['a', second]
+      ],
+      [
+        ['a', first],
+        ['b', first]
+      ]
+    ]) {
+      writeFileSync(file, JSON.stringify({ schemaVersion: 1, entries }))
+      await expect(createStore().getOrCreate('new-session')).rejects.toThrow(
+        'Duplicate analytics session identity'
+      )
+    }
+  })
+
+  it('keeps all callers and shutdown waiting until the ID write completes', async () => {
+    let release!: () => void
+    let entered!: () => void
+    writeGate.wait = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const writing = new Promise<void>((resolve) => {
+      entered = resolve
+    })
+    writeGate.entered = entered
+    const store = createStore()
+    let resolved = false
+    let flushed = false
+    const first = store.getOrCreate('session').then((id) => {
+      resolved = true
+      return id
+    })
+    await writing
+    const second = store.getOrCreate('session')
+    const flush = store.flush().then(() => {
+      flushed = true
+    })
+    try {
+      await Promise.resolve()
+      expect(resolved).toBe(false)
+      expect(flushed).toBe(false)
+    } finally {
+      release()
+    }
+    expect(await first).toBe(await second)
+    await flush
+    expect(flushed).toBe(true)
+  })
+
+  it('does not return an unpersisted ID on write failure and allows retry', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = createStore()
+    writeGate.fail = true
+    await expect(store.getOrCreate('session')).rejects.toThrow('simulated disk failure')
+    expect(existsSync(file)).toBe(false)
+    writeGate.fail = false
+    const id = await store.getOrCreate('session')
+    expect(await createStore().getOrCreate('session')).toBe(id)
+  })
+})

--- a/src/main/usage/analytics-session-id-store.test.ts
+++ b/src/main/usage/analytics-session-id-store.test.ts
@@ -35,6 +35,7 @@ const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f
 let directory: string
 let file: string
 let stores: AnalyticsSessionIdStore[]
+/** Registers every instance for flush-before-cleanup, including simulated restarts. */
 function createStore(path = file): AnalyticsSessionIdStore {
   const store = new AnalyticsSessionIdStore(path)
   stores.push(store)

--- a/src/main/usage/analytics-session-id-store.ts
+++ b/src/main/usage/analytics-session-id-store.ts
@@ -25,6 +25,7 @@ export class AnalyticsSessionIdStore {
 
   constructor(private readonly file: string) {}
 
+  /** Resolves only after persistence succeeds, so an uploaded ID survives a restart. */
   async getOrCreate(providerSessionId: string): Promise<AnalyticsSessionId> {
     if (!providerSessionIdSchema.safeParse(providerSessionId).success) {
       throw new Error('Invalid provider session ID')
@@ -51,6 +52,7 @@ export class AnalyticsSessionIdStore {
     return operation
   }
 
+  /** Includes queued lookups that have not reached the durable writer yet. */
   async flush(): Promise<void> {
     await this.pending
     await this.writer?.flush()

--- a/src/main/usage/analytics-session-id-store.ts
+++ b/src/main/usage/analytics-session-id-store.ts
@@ -1,0 +1,86 @@
+import { randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { z } from 'zod'
+import { UsageCacheSnapshotWriter } from '../usage-cache-snapshot-writer'
+
+const providerSessionIdSchema = z
+  .string()
+  .min(1)
+  .max(1024)
+  .refine((id) => id.trim().length > 0)
+const analyticsSessionIdSchema = z.uuidv4().brand<'AnalyticsSessionId'>()
+export type AnalyticsSessionId = z.infer<typeof analyticsSessionIdSchema>
+const identityFileSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    entries: z.array(z.tuple([providerSessionIdSchema, analyticsSessionIdSchema]))
+  })
+  .strict()
+
+/** One owner per file, scoped to a provider's usage store on its execution host. */
+export class AnalyticsSessionIdStore {
+  private identities: Map<string, AnalyticsSessionId> | null = null
+  private pending: Promise<void> = Promise.resolve()
+  private writer: UsageCacheSnapshotWriter | null = null
+
+  constructor(private readonly file: string) {}
+
+  async getOrCreate(providerSessionId: string): Promise<AnalyticsSessionId> {
+    if (!providerSessionIdSchema.safeParse(providerSessionId).success) {
+      throw new Error('Invalid provider session ID')
+    }
+    // Serialize reads as well as writes so no caller sees an ID before it is durable.
+    const operation = this.pending.then(async () => {
+      const identities = this.identities ?? (await this.load())
+      this.identities = identities
+      const existing = identities.get(providerSessionId)
+      if (existing) {
+        return existing
+      }
+      const id = analyticsSessionIdSchema.parse(randomUUID())
+      const updated = new Map(identities).set(providerSessionId, id)
+      this.writer ??= new UsageCacheSnapshotWriter('[analytics-session-id]', () => this.file)
+      await this.writer.write(() => JSON.stringify({ schemaVersion: 1, entries: [...updated] }))
+      this.identities = updated
+      return id
+    })
+    this.pending = operation.then(
+      () => {},
+      () => {}
+    )
+    return operation
+  }
+
+  async flush(): Promise<void> {
+    await this.pending
+    await this.writer?.flush()
+  }
+
+  private async load(): Promise<Map<string, AnalyticsSessionId>> {
+    let content: string
+    try {
+      content = await readFile(this.file, 'utf8')
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return new Map()
+      }
+      throw error
+    }
+    let raw: unknown
+    try {
+      raw = JSON.parse(content)
+    } catch {
+      throw new Error('Invalid analytics session identity file')
+    }
+    const parsed = identityFileSchema.safeParse(raw)
+    if (!parsed.success) {
+      throw new Error('Invalid analytics session identity file')
+    }
+    const identities = new Map(parsed.data.entries)
+    const analyticsIds = new Set(parsed.data.entries.map(([, id]) => id))
+    if (identities.size !== parsed.data.entries.length || analyticsIds.size !== identities.size) {
+      throw new Error('Duplicate analytics session identity')
+    }
+    return identities
+  }
+}

--- a/src/main/usage/usage-provider-store-lifecycle.test.ts
+++ b/src/main/usage/usage-provider-store-lifecycle.test.ts
@@ -156,6 +156,34 @@ describe('UsageProviderStoreLifecycle', () => {
     vi.restoreAllMocks()
   })
 
+  it('keeps analytics identity separate from usage cache rebuilds and never puts it in snapshots', async () => {
+    const cacheFile = join(tempDirectory, 'provider.json')
+    const identityFile = join(tempDirectory, 'provider-analytics-session-ids.json')
+    const original = createStore(cacheFile)
+    expect(existsSync(identityFile)).toBe(false)
+    const id = await original.getAnalyticsSessionId('provider-session')
+    expect(existsSync(identityFile)).toBe(true)
+    await original.setEnabled(true)
+    await original.refresh(true)
+    await original.flush()
+    expect(JSON.stringify(original.getState())).not.toContain(id)
+    expect(readFileSync(cacheFile, 'utf8')).not.toContain(id)
+    rmSync(cacheFile)
+    const rebuilt = createStore(cacheFile)
+    expect(await rebuilt.getAnalyticsSessionId('provider-session')).toBe(id)
+    expect(await createStore().getAnalyticsSessionId('provider-session')).not.toBe(id)
+  })
+
+  it('flush waits for queued analytics identity creation', async () => {
+    const store = createStore()
+    const identity = store.getAnalyticsSessionId('session')
+    await store.flush()
+    const id = await identity
+    expect(
+      readFileSync(join(tempDirectory, 'usage-0-analytics-session-ids.json'), 'utf8')
+    ).toContain(id)
+  })
+
   it('skips disabled and fresh matching states', async () => {
     const store = createStore()
 

--- a/src/main/usage/usage-provider-store-lifecycle.ts
+++ b/src/main/usage/usage-provider-store-lifecycle.ts
@@ -1,4 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
+import { join, parse } from 'node:path'
+import { AnalyticsSessionIdStore, type AnalyticsSessionId } from './analytics-session-id-store'
 import type { Store } from '../persistence'
 import { UsageCacheSnapshotWriter } from '../usage-cache-snapshot-writer'
 import { loadKnownUsageWorktreesByRepo } from '../usage-worktree-metadata'
@@ -55,6 +57,7 @@ export abstract class UsageProviderStoreLifecycle<
 > {
   protected state: State
   private scanPromise: Promise<void> | null = null
+  private analyticsSessionIds: AnalyticsSessionIdStore | null = null
   private readonly writer: UsageCacheSnapshotWriter
 
   constructor(
@@ -74,9 +77,20 @@ export abstract class UsageProviderStoreLifecycle<
     } as PublicUsageProviderScanState<DataPresenceKey>
   }
 
+  /** Local identity only; callers must use the usage store on the execution host. */
+  getAnalyticsSessionId(providerSessionId: string): Promise<AnalyticsSessionId> {
+    if (!this.analyticsSessionIds) {
+      const { dir, name } = parse(this.config.resolveCacheFile())
+      this.analyticsSessionIds = new AnalyticsSessionIdStore(
+        join(dir, `${name}-analytics-session-ids.json`)
+      )
+    }
+    return this.analyticsSessionIds.getOrCreate(providerSessionId)
+  }
+
   /** Await queued cache writes so quit does not drop the final snapshot. */
-  flush(): Promise<void> {
-    return this.writer.flush()
+  async flush(): Promise<void> {
+    await Promise.all([this.writer.flush(), this.analyticsSessionIds?.flush()])
   }
 
   async setEnabled(enabled: boolean): Promise<PublicUsageProviderScanState<DataPresenceKey>> {


### PR DESCRIPTION
## ELI5

Give each agent conversation a random analytics ID so future usage reports can recognize the same conversation without sending its provider session ID. Keep the mapping on the machine that owns the usage store.

## What Changed

- Add a lazy `getAnalyticsSessionId(providerSessionId)` accessor to the existing Claude, Codex, and OpenCode usage-store lifecycle.
- Persist random UUID v4 mappings in a separate per-provider file, so restarts, resumes, and usage-cache rebuilds preserve identity.
- Serialize lookups and durable writes; return new IDs only after persistence succeeds and include pending identity writes in shutdown flushing.
- Reject malformed or conflicting saved mappings rather than silently replacing identities.

## Why

Session snapshots need stable identifiers independent of provider logs. A separate identity file preserves that stability when disposable usage projections are invalidated. Different provider stores and execution-host/profile directories remain independent. The mapping and accessor stay local; this PR adds no telemetry events, UI, snapshot revisions, or remote wire fields.

## Linked Issue

Fixes #18758

## Visual Proof

N/A — local persistence and an internal usage-store accessor only; no visual or interaction change.

## Testing

Validated on macOS with Node 24:

- 45 tests passed across the identity store, usage-store lifecycle, and Claude/Codex/OpenCode persistence suites. Coverage includes 20 concurrent requests, restart/resume stability, provider/host-profile isolation, cache rebuilds, blocked writes, failed-write retries, malformed state, and shutdown flushing.
- `tsc --noEmit -p config/tsconfig.node.json` passed.
- `node config/scripts/check-changed-code-quality.mjs --base HEAD` passed before committing: standard, type-aware, and React Doctor checks.
- `git diff --check` passed.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Self-reviewed persistence ordering, privacy boundaries, and failure recovery. The store follows the existing single-owner lifecycle; it is not a multi-process shared-file database.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Uses Node path utilities and the existing cross-platform durable writer. No git-worktree dependency, so folder workspaces use the same accessor. Future SSH reporting must obtain the ID from the execution host's store, not mint replacements on viewing clients. No Windows/Linux or live SSH execution was performed locally. Full lint/build and remaining platform coverage are left to CI.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
