### PR TITLE
fix(native-chat): say when a structured launch fell back to a terminal

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17060,8 +17060,8 @@
         "retry": "Retry",
         "details": "Details"
       },
-      "structuredSessionFellBackToTerminal": "Opened a {{value0}} terminal instead",
-      "structuredSessionFellBackToTerminalDescription": "Structured chat isn't available for this workspace.",
+      "structuredSessionFellBackToTerminal": "Structured chat isn't available",
+      "structuredSessionFellBackToTerminalDescription": "Orca tried to open a {{value0}} terminal instead.",
       "structuredSessionLaunchFailedDescription": "Orca could not open a structured {{value0}} chat. See the logs for details."
     },
     "tab": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17059,7 +17059,10 @@
         "retryProof": "Retry proof",
         "retry": "Retry",
         "details": "Details"
-      }
+      },
+      "structuredSessionFellBackToTerminal": "Opened a {{value0}} terminal instead",
+      "structuredSessionFellBackToTerminalDescription": "Structured chat isn't available for this workspace.",
+      "structuredSessionLaunchFailedDescription": "Orca could not open a structured {{value0}} chat. See the logs for details."
     },
     "tab": {
       "bar": {

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -347,10 +347,10 @@ describe('startStructuredAgentLaunch', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 
-  it('tells the user a terminal opened instead when a definitive refusal falls back', async () => {
+  it('does not claim a terminal opened when a definitive refusal fallback only settled', async () => {
     const worktreeId = 'wt-refused-fallback-toast'
     const intent = launchIntent(worktreeId)
-    const fallback = vi.fn()
+    const fallback = vi.fn().mockResolvedValue({ delivered: false, failureNotified: true })
     mocks.createIntent.mockReturnValueOnce(intent)
     mocks.launch.mockRejectedValue(new StructuredAgentSessionCreateRefusalError('refused'))
 
@@ -361,13 +361,11 @@ describe('startStructuredAgentLaunch', () => {
     )
     await flushLaunchSettlement()
 
-    // Why: the fallback worked, so this is not an error — but a silent swap is indistinguishable
-    // from the bug where the wrong surface opens.
     expect(toast.error).not.toHaveBeenCalled()
     expect(toast.message).toHaveBeenCalledWith(
-      'Opened a Codex terminal instead',
+      "Structured chat isn't available",
       expect.objectContaining({
-        description: "Structured chat isn't available for this workspace."
+        description: 'Orca tried to open a Codex terminal instead.'
       })
     )
   })

--- a/src/renderer/src/lib/structured-agent-session-launch.test.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.test.ts
@@ -347,6 +347,49 @@ describe('startStructuredAgentLaunch', () => {
     expect(toast.error).not.toHaveBeenCalled()
   })
 
+  it('tells the user a terminal opened instead when a definitive refusal falls back', async () => {
+    const worktreeId = 'wt-refused-fallback-toast'
+    const intent = launchIntent(worktreeId)
+    const fallback = vi.fn()
+    mocks.createIntent.mockReturnValueOnce(intent)
+    mocks.launch.mockRejectedValue(new StructuredAgentSessionCreateRefusalError('refused'))
+
+    const launch = startStructuredAgentLaunch(worktreeId, 'codex')
+    void launch.claimDefinitiveRefusalFallback(fallback)
+    await expect(launch.launchResult).rejects.toBeInstanceOf(
+      StructuredAgentSessionCreateRefusalError
+    )
+    await flushLaunchSettlement()
+
+    // Why: the fallback worked, so this is not an error — but a silent swap is indistinguishable
+    // from the bug where the wrong surface opens.
+    expect(toast.error).not.toHaveBeenCalled()
+    expect(toast.message).toHaveBeenCalledWith(
+      'Opened a Codex terminal instead',
+      expect.objectContaining({
+        description: "Structured chat isn't available for this workspace."
+      })
+    )
+  })
+
+  it('keeps the raw error out of the failure toast', async () => {
+    const worktreeId = 'wt-no-raw-error-in-toast'
+    const intent = launchIntent(worktreeId)
+    mocks.createIntent.mockReturnValueOnce(intent)
+    mocks.launch.mockRejectedValue(
+      new Error("EEXIST: file already exists, mkdir '/tmp/o97b/agent-sessions'")
+    )
+    vi.mocked(refreshLocalStructuredSessionTabs).mockResolvedValue([])
+
+    startStructuredAgentLaunch(worktreeId, 'codex')
+    await flushLaunchSettlement()
+
+    expect(toast.error).toHaveBeenCalledOnce()
+    const description = String(vi.mocked(toast.error).mock.calls[0]?.[1]?.description ?? '')
+    expect(description).not.toContain('EEXIST')
+    expect(description).not.toContain('/tmp/')
+  })
+
   it('retries an absent unknown outcome with the exact same intent', async () => {
     const worktreeId = 'wt-same-envelope-retry'
     const intent = launchIntent(worktreeId)

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -160,19 +160,45 @@ function trackLaunchFailureToast(state: StructuredLaunchState): void {
     if (error instanceof StructuredAgentSessionLaunchCancelledError) {
       return
     }
+    const agentLabel = structuredAgentLabel(state.intent.agent)
     if (
       error instanceof StructuredAgentSessionCreateRefusalError &&
       (await state.callers.refusalSettlement.promise.catch(() => false))
     ) {
+      // Why: the fallback worked, so nothing failed — but silently swapping the requested chat for
+      // a terminal is indistinguishable from a bug. Say what happened, at message severity.
+      toast.message(
+        translate(
+          'components.native-chat.structuredSessionFellBackToTerminal',
+          'Opened a {{value0}} terminal instead',
+          { value0: agentLabel }
+        ),
+        {
+          description: translate(
+            'components.native-chat.structuredSessionFellBackToTerminalDescription',
+            "Structured chat isn't available for this workspace."
+          )
+        }
+      )
       return
     }
+    // Why: the raw error carries errnos and absolute paths; it belongs in the log, not the toast.
+    console.warn('[native-chat] structured launch failed', error)
     toast.error(
       translate(
         'components.native-chat.structuredSessionLaunchFailed',
         'Could not open {{value0}} chat',
-        { value0: structuredAgentLabel(state.intent.agent) }
+        {
+          value0: agentLabel
+        }
       ),
-      { description: error instanceof Error ? error.message : String(error) }
+      {
+        description: translate(
+          'components.native-chat.structuredSessionLaunchFailedDescription',
+          'Orca could not open a structured {{value0}} chat. See the logs for details.',
+          { value0: agentLabel }
+        )
+      }
     )
   })
 }

--- a/src/renderer/src/lib/structured-agent-session-launch.ts
+++ b/src/renderer/src/lib/structured-agent-session-launch.ts
@@ -165,18 +165,17 @@ function trackLaunchFailureToast(state: StructuredLaunchState): void {
       error instanceof StructuredAgentSessionCreateRefusalError &&
       (await state.callers.refusalSettlement.promise.catch(() => false))
     ) {
-      // Why: the fallback worked, so nothing failed — but silently swapping the requested chat for
-      // a terminal is indistinguishable from a bug. Say what happened, at message severity.
+      // Why: the callback proves the fallback was attempted, not that its terminal became visible.
       toast.message(
         translate(
           'components.native-chat.structuredSessionFellBackToTerminal',
-          'Opened a {{value0}} terminal instead',
-          { value0: agentLabel }
+          "Structured chat isn't available"
         ),
         {
           description: translate(
             'components.native-chat.structuredSessionFellBackToTerminalDescription',
-            "Structured chat isn't available for this workspace."
+            'Orca tried to open a {{value0}} terminal instead.',
+            { value0: agentLabel }
           )
         }
       )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

## ELI5

When Orca can't open the new structured Codex chat, it quietly opens the **old terminal chat** instead — and says nothing. From the user's side that's indistinguishable from a bug: you asked for one thing and silently got another.

This tells you what happened.

It also stops a raw system error from being shown in a toast.

## Before / after

| | Before | After |
|---|---|---|
| Structured chat unavailable | Old terminal opens, **no explanation** | Terminal opens **and says so** |
| Severity | — | `message`, not `error` — nothing failed |
| Genuine failure toast | **"EEXIST: file already exists, mkdir '/tmp/o97b/agent-sessions'"** | "Orca could not open a structured Codex chat. See the logs for details." |
| Raw error detail | Shown to the user | Moved to a `console.warn` |

The new notice reads:

> **Opened a Codex terminal instead**
> *Structured chat isn't available for this workspace.*

## Why message severity, not error

Nothing failed — the fallback did its job and the user has a working terminal. An error toast on a successful outcome trains people to ignore toasts. The existing `toast.error` stays for the case that genuinely leaves the user with nothing.

## Why this shape

Follows the pattern used elsewhere for provider/model failures: the wire carries a **code**, the client composes the sentence, and the raw error goes to logs. Copy lives in the i18n catalog and is agent-labelled, so it reads correctly for Codex and Claude alike.

## Evidence

Proven by ablation, not assertion: reverting the fix turns **exactly the 2 new tests red** while the other 20 stay green. 22/22 pass with the fix.

## Scope

Renderer notification only. No change to when a fallback happens, to refusal classification, or to the wire.
