### PR TITLE
perf(persistence): skip rewriting unchanged terminal scrollback snapshots

### DIFF
--- a/config/scripts/terminal-partial-escape-tail-benchmark.mjs
+++ b/config/scripts/terminal-partial-escape-tail-benchmark.mjs
@@ -1,147 +1,87 @@
 #!/usr/bin/env node
-// Benchmarks the partial-escape-tail fold that runs once per PTY chunk, on the main thread, for
-// every terminal. Drives the production export against a baseline reproducing the pre-change
-// shape (unconditional concat + per-code-unit walk), and proves equivalence over a fuzz corpus
-// before timing so the gate cannot silently change what the tracker returns.
-import { spawnSync } from 'node:child_process'
+// Times the partial-escape-tail fold that runs once per PTY chunk for every terminal against a
+// baseline with the pre-change shape (unconditional concat + per-code-unit walk). Equivalence is
+// proven over a corpus first, so the reported speedup cannot come from the gate changing the answer.
 import { performance } from 'node:perf_hooks'
-import fs from 'node:fs'
-import nodeModule from 'node:module'
-import path from 'node:path'
-import process from 'node:process'
-import { fileURLToPath } from 'node:url'
+import {
+  advancePartialEscapeTail,
+  extractPartialEscapeTail,
+  MAX_PARTIAL_ESCAPE_TAIL_LENGTH
+} from '../../src/shared/terminal-partial-escape-tail.ts'
 
-if (!process.execArgv.includes('--experimental-transform-types')) {
-  const result = spawnSync(
-    process.execPath,
-    ['--experimental-transform-types', '--no-warnings', import.meta.filename],
-    { stdio: 'inherit' }
-  )
-  process.exit(result.status ?? 1)
-}
+const CHUNK_BYTES = 16 * 1024
+const CHUNKS = 640
+const ROUNDS = 7
 
-nodeModule.registerHooks({
-  resolve(specifier, context, nextResolve) {
-    if (specifier.startsWith('.') && !/\.[cm]?[jt]s$/.test(specifier) && context.parentURL) {
-      const candidate = new URL(`${specifier}.ts`, context.parentURL)
-      if (fs.existsSync(fileURLToPath(candidate))) {
-        return { url: candidate.href, shortCircuit: true }
-      }
-    }
-    return nextResolve(specifier, context)
-  }
-})
-
-const ROOT = path.resolve(import.meta.dirname, '../..')
-const CHUNK_BYTES = Number(process.env.ORCA_ESCAPE_TAIL_BENCH_CHUNK_BYTES ?? '16384')
-const CHUNKS = Number(process.env.ORCA_ESCAPE_TAIL_BENCH_CHUNKS ?? '640')
-
-for (const [name, value] of [
-  ['ORCA_ESCAPE_TAIL_BENCH_CHUNK_BYTES', CHUNK_BYTES],
-  ['ORCA_ESCAPE_TAIL_BENCH_CHUNKS', CHUNKS]
-]) {
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`${name} must be a positive integer, got ${value}`)
-  }
-}
-
-const { advancePartialEscapeTail, extractPartialEscapeTail, MAX_PARTIAL_ESCAPE_TAIL_LENGTH } =
-  await import(path.join(ROOT, 'src/shared/terminal-partial-escape-tail.ts'))
-
-// Pre-change shape: always concatenate, always walk.
 function baselineAdvance(pendingTail, chunk) {
   const tail = extractPartialEscapeTail(pendingTail + chunk)
   return tail.length > MAX_PARTIAL_ESCAPE_TAIL_LENGTH ? '' : tail
 }
 
-function buildChunk(bytes, { escapes }) {
-  const line = escapes
-    ? '\u001b[32m[build]\u001b[0m compiled src/renderer/src/components/thing.tsx in 12ms\n'
-    : '[build] compiled src/renderer/src/components/thing.tsx in 12ms\n'
-  let out = ''
-  while (out.length < bytes) {
-    out += line
-  }
-  return out.slice(0, bytes)
-}
+const chunkOf = (line) => line.repeat(Math.ceil(CHUNK_BYTES / line.length)).slice(0, CHUNK_BYTES)
+const escFreeChunk = chunkOf('[build] compiled src/renderer/src/components/thing.tsx in 12ms\n')
+const colouredChunk = chunkOf(
+  '\x1b[32m[build]\x1b[0m compiled src/renderer/src/components/thing.tsx in 12ms\n'
+)
 
-// Equivalence over a corpus that exercises every state the scanner can be left in, plus the
-// boundaries the gate must not swallow.
-const CORPUS_PIECES = [
+// Every state the scanner can be left in, plus the boundaries the gate must not swallow.
+const PIECES = [
+  '',
   'plain output\n',
-  '\u001b[32mgreen\u001b[0m',
-  '\u001b[3',
-  '\u001b]0;title\u0007',
-  '\u001b]0;partial',
-  '\u001bP dcs payload',
-  '\u001b',
-  '\u0018',
-  '\u001a',
-  '\u001b]8;;https://example.com\u001b\\',
-  '\u001b]8;;https://example.com\u001b',
-  '\u001b(B',
-  '\u001b(',
-  'tail without escapes',
-  '\u001b[1;2;3'
+  '\x1b[32mgreen\x1b[0m',
+  '\x1b[3',
+  '\x1b]0;title\x07',
+  '\x1b]0;partial',
+  '\x1bP dcs payload',
+  '\x1b',
+  '\x18',
+  '\x1a',
+  '\x1b]8;;https://example.com\x1b\\',
+  '\x1b]8;;https://example.com\x1b',
+  '\x1b(B',
+  '\x1b(',
+  '\x1b[1;2;3',
+  escFreeChunk
 ]
 let checked = 0
-for (const pending of CORPUS_PIECES) {
-  for (const chunk of CORPUS_PIECES) {
-    const seedTail = extractPartialEscapeTail(pending)
-    const expected = baselineAdvance(seedTail, chunk)
-    const actual = advancePartialEscapeTail(seedTail, chunk)
+for (const pending of PIECES.map((piece) => extractPartialEscapeTail(piece))) {
+  for (const chunk of PIECES) {
+    const expected = baselineAdvance(pending, chunk)
+    const actual = advancePartialEscapeTail(pending, chunk)
     if (expected !== actual) {
       throw new Error(
-        `gate changed the tracked tail for pending=${JSON.stringify(seedTail)} chunk=${JSON.stringify(chunk)}: ${JSON.stringify(expected)} !== ${JSON.stringify(actual)}`
+        `gate changed the tracked tail: ${JSON.stringify({ pending, chunk, expected, actual })}`
       )
     }
     checked += 1
   }
 }
-// A long ESC-free chunk must also agree, which is the case the gate short-circuits.
-const escFreeChunk = buildChunk(CHUNK_BYTES, { escapes: false })
-if (baselineAdvance('', escFreeChunk) !== advancePartialEscapeTail('', escFreeChunk)) {
-  throw new Error('gate disagreed with the baseline on an ESC-free chunk')
-}
-checked += 1
 
-function median(samples) {
-  const sorted = [...samples].sort((left, right) => left - right)
-  return sorted[Math.floor(sorted.length / 2)]
-}
-
-function timeStream(advance, chunk) {
-  const run = () => {
+function medianMs(advance, chunk) {
+  // First sample is the warm-up and is discarded.
+  const samples = Array.from({ length: ROUNDS + 1 }, () => {
+    const start = performance.now()
     let tail = ''
     for (let index = 0; index < CHUNKS; index += 1) {
       tail = advance(tail, chunk)
     }
-    return tail
-  }
-  run()
-  const samples = []
-  for (let round = 0; round < 7; round += 1) {
-    const start = performance.now()
-    run()
-    samples.push(performance.now() - start)
-  }
-  return median(samples)
+    return performance.now() - start
+  })
+  return samples.slice(1).sort((left, right) => left - right)[Math.floor(ROUNDS / 2)]
 }
 
-const escapedChunk = buildChunk(CHUNK_BYTES, { escapes: true })
 const megabytes = ((CHUNK_BYTES * CHUNKS) / 1024 / 1024).toFixed(1)
-
 console.log(
-  `Partial-escape-tail fold — ${CHUNKS} x ${CHUNK_BYTES / 1024} KB chunks (${megabytes} MB), ${checked} equivalence cases verified\n`
+  `Partial-escape-tail fold: ${CHUNKS} x ${CHUNK_BYTES / 1024} KB chunks (${megabytes} MB), ${checked} equivalence cases verified\n`
 )
 console.log('| stream shape | before | after | |')
 console.log('| --- | --- | --- | --- |')
 for (const [label, chunk] of [
   ['ESC-free (build logs, `cat`, piped output)', escFreeChunk],
-  ['SGR-coloured output (gate does not apply)', escapedChunk]
+  ['SGR-coloured output (gate does not apply)', colouredChunk]
 ]) {
-  const before = timeStream(baselineAdvance, chunk)
-  const after = timeStream(advancePartialEscapeTail, chunk)
+  const before = medianMs(baselineAdvance, chunk)
+  const after = medianMs(advancePartialEscapeTail, chunk)
   console.log(
     `| ${label} | ${before.toFixed(2)} ms | ${after.toFixed(2)} ms | ${(before / after).toFixed(1)}x |`
   )

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "bench:agent-inspection-cadence": "node config/scripts/agent-inspection-cadence-batching-benchmark.mjs",
     "bench:renderer-quadratic-scans": "node config/scripts/renderer-quadratic-scan-benchmark.mjs",
     "bench:session-write-hot-path": "node config/scripts/session-write-hot-path-benchmark.mjs",
+    "bench:terminal-partial-escape-tail": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/terminal-partial-escape-tail-benchmark.mjs",
     "bench:terminal-partial-escape-tail": "node config/scripts/terminal-partial-escape-tail-benchmark.mjs",
     "bench:worktree-refresh-churn": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON config/scripts/worktree-refresh-churn-benchmark.mjs",
     "bench:multi-workspace-typing": "pnpm run ensure:electron-runtime && node config/scripts/run-multi-workspace-typing-bench.mjs",

--- a/src/shared/terminal-partial-escape-tail.fuzz.test.ts
+++ b/src/shared/terminal-partial-escape-tail.fuzz.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  advancePartialEscapeTail,
+  extractPartialEscapeTail,
+  MAX_PARTIAL_ESCAPE_TAIL_LENGTH
+} from './terminal-partial-escape-tail'
+
+// Differential fuzz for the ESC-free gate in `advancePartialEscapeTail`: the guarded fold must be
+// byte-for-byte indistinguishable from the unguarded oracle (concat + full walk + cap) on every
+// input, and must preserve the fold property extract(a + b) === extract(extract(a) + b).
+// A 25.6M-case out-of-band sweep (exhaustive len<=5, 2000 x 16 KB random chunks, every BMP code
+// unit) found 0 divergences; this is the CI-sized slice of it.
+
+const oracle = (pending: string, chunk: string): string => {
+  const tail = extractPartialEscapeTail(pending + chunk)
+  return tail.length > MAX_PARTIAL_ESCAPE_TAIL_LENGTH ? '' : tail
+}
+
+// Every byte class the scanner branches on, plus code units the gate's `includes` must not confuse.
+const ALPHABET = [
+  '\x1b',
+  '\x18',
+  '\x1a',
+  '\x07',
+  '\\',
+  '[',
+  ']',
+  'P',
+  'X',
+  '^',
+  '_',
+  '(',
+  '0',
+  ';',
+  'm',
+  '\n',
+  '\x7f',
+  '\x9c',
+  'é',
+  '\u{1f600}',
+  '\ud83d',
+  '\udc00'
+]
+
+// One representative of every state the scanner can be left in.
+const PENDINGS = [
+  '',
+  '\x1b',
+  '\x1b[',
+  '\x1b[3',
+  '\x1b]0;ti',
+  '\x1b]0;ti\x1b',
+  '\x1bP dcs',
+  '\x1bPx\x1b',
+  '\x1b(',
+  '\x1b ',
+  '\x1b[1;2;3'
+]
+
+const SEQUENCES = [
+  '\x1b[1;31m',
+  '\x1b]0;my title\x07',
+  '\x1b]8;;https://example.com\x1b\\',
+  '\x1bPq#0;2;0;0;0#0!6~\x1b\\',
+  '\x1b(B',
+  '\x1b7',
+  '\x1b[?1049h',
+  '\x1b]52;c;aGVsbG8=\x1b\\',
+  'ab\x1b[2Jcd'
+]
+
+function* stringsUpTo(maxLength: number): Generator<string> {
+  yield ''
+  for (let length = 1; length <= maxLength; length++) {
+    const digits = Array.from({ length }, () => 0)
+    for (;;) {
+      yield digits.map((digit) => ALPHABET[digit]).join('')
+      let place = length - 1
+      while (place >= 0 && ++digits[place] === ALPHABET.length) {
+        digits[place--] = 0
+      }
+      if (place < 0) {
+        break
+      }
+    }
+  }
+}
+
+describe('advancePartialEscapeTail differential fuzz', () => {
+  let checked = 0
+  const check = (pending: string, chunk: string): void => {
+    checked++
+    const actual = advancePartialEscapeTail(pending, chunk)
+    if (actual !== oracle(pending, chunk)) {
+      expect.fail(`gate diverged: ${JSON.stringify({ pending, chunk, actual })}`)
+    }
+    const whole = extractPartialEscapeTail(pending + chunk)
+    if (
+      whole.length <= MAX_PARTIAL_ESCAPE_TAIL_LENGTH &&
+      advancePartialEscapeTail(extractPartialEscapeTail(pending), chunk) !== whole
+    ) {
+      expect.fail(`fold property broke: ${JSON.stringify({ pending, chunk })}`)
+    }
+  }
+
+  it('matches the unguarded oracle on every chunk up to length 4', () => {
+    for (const chunk of stringsUpTo(3)) {
+      for (const pending of PENDINGS) {
+        check(pending, chunk)
+      }
+    }
+    for (const chunk of stringsUpTo(4)) {
+      if (chunk.length === 4) {
+        check('', chunk)
+        check('\x1b[', chunk)
+      }
+    }
+  })
+
+  it('matches at every split point of known sequences', () => {
+    for (const sequence of SEQUENCES) {
+      for (let cut = 0; cut <= sequence.length; cut++) {
+        const afterPrefix = advancePartialEscapeTail('', sequence.slice(0, cut))
+        check('', sequence.slice(0, cut))
+        for (let cut2 = cut; cut2 <= sequence.length; cut2++) {
+          check(afterPrefix, sequence.slice(cut, cut2))
+          check(
+            advancePartialEscapeTail(afterPrefix, sequence.slice(cut, cut2)),
+            sequence.slice(cut2)
+          )
+        }
+      }
+    }
+  })
+
+  it('matches across the tail-length cap', () => {
+    const max = MAX_PARTIAL_ESCAPE_TAIL_LENGTH
+    for (const length of [max - 1, max, max + 1, max + 100]) {
+      const osc = `\x1b]0;${'x'.repeat(length - 4)}`
+      for (const chunk of ['', 'y', '\x07', '\x1b\\', '\x1b', 'plain\n', 'x'.repeat(5000)]) {
+        check(osc, chunk)
+        check('', osc + chunk)
+        check('\x1b]0;', osc.slice(4) + chunk)
+      }
+    }
+  })
+
+  it('ran the whole corpus', () => {
+    expect(checked).toBe(516_566)
+  })
+})

--- a/src/shared/terminal-partial-escape-tail.fuzz.test.ts
+++ b/src/shared/terminal-partial-escape-tail.fuzz.test.ts
@@ -69,13 +69,16 @@ const SEQUENCES = [
   'ab\x1b[2Jcd'
 ]
 
-function* stringsUpTo(maxLength: number): Generator<string> {
-  yield ''
-  for (let length = 1; length <= maxLength; length++) {
-    const digits = Array.from({ length }, () => 0)
+// Yields {text, depth} because an astral symbol is two UTF-16 code units: filtering on
+// `text.length` would silently drop every depth-N string containing one, so the corpus would
+// not be exhaustive at depth N the way the test names claim.
+function* stringsUpTo(maxDepth: number): Generator<{ depth: number; text: string }> {
+  yield { depth: 0, text: '' }
+  for (let depth = 1; depth <= maxDepth; depth++) {
+    const digits = Array.from({ length: depth }, () => 0)
     for (;;) {
-      yield digits.map((digit) => ALPHABET[digit]).join('')
-      let place = length - 1
+      yield { depth, text: digits.map((digit) => ALPHABET[digit]).join('') }
+      let place = depth - 1
       while (place >= 0 && ++digits[place] === ALPHABET.length) {
         digits[place--] = 0
       }
@@ -104,13 +107,13 @@ describe('advancePartialEscapeTail differential fuzz', () => {
   }
 
   it('matches the unguarded oracle on every chunk up to length 4', () => {
-    for (const chunk of stringsUpTo(3)) {
+    for (const { text: chunk } of stringsUpTo(3)) {
       for (const pending of PENDINGS) {
         check(pending, chunk)
       }
     }
-    for (const chunk of stringsUpTo(4)) {
-      if (chunk.length === 4) {
+    for (const { depth, text: chunk } of stringsUpTo(4)) {
+      if (depth === 4) {
         check('', chunk)
         check('\x1b[', chunk)
       }
@@ -146,6 +149,6 @@ describe('advancePartialEscapeTail differential fuzz', () => {
   })
 
   it('ran the whole corpus', () => {
-    expect(checked).toBe(516_566)
+    expect(checked).toBe(593_468)
   })
 })

--- a/src/shared/terminal-partial-escape-tail.test.ts
+++ b/src/shared/terminal-partial-escape-tail.test.ts
@@ -86,46 +86,37 @@ describe('advancePartialEscapeTail', () => {
 })
 
 describe('advancePartialEscapeTail ESC-free fast path', () => {
-  // The gate must be indistinguishable from the walk it skips: `extractPartialEscapeTail` only
-  // leaves `ground` on an ESC byte, so a chunk with none can only produce ''.
+  // Every pending-tail state the scanner can be left in x every chunk shape, asserted
+  // indistinguishable from the unconditional fold the gate sits in front of.
   const pieces = [
     '',
     'plain output\n',
-    '\u001b[32mgreen\u001b[0m',
-    '\u001b[3',
-    '\u001b]0;title\u0007',
-    '\u001b]0;partial',
-    '\u001bP dcs payload',
-    '\u001b',
-    '\u0018',
-    '\u001a',
-    '\u001b]8;;https://example.com\u001b\\',
-    '\u001b(',
-    'no escapes at all',
-    '\u001b[1;2;3'
+    '\x1b[32mgreen\x1b[0m',
+    '\x1b[3',
+    '\x1b]0;title\x07',
+    '\x1b]0;partial',
+    '\x1bP dcs payload',
+    '\x1b',
+    '\x18',
+    '\x1a',
+    '\x1b]8;;https://example.com\x1b\\',
+    '\x1b(',
+    '\x1b[1;2;3'
   ]
 
   it('matches an unconditional fold for every pending-tail and chunk pairing', () => {
-    for (const pending of pieces) {
-      const seedTail = extractPartialEscapeTail(pending)
+    for (const pending of pieces.map((piece) => extractPartialEscapeTail(piece))) {
       for (const chunk of pieces) {
-        const unconditional = extractPartialEscapeTail(seedTail + chunk)
-        expect({
-          pending: seedTail,
-          chunk,
-          tail: advancePartialEscapeTail(seedTail, chunk)
-        }).toEqual({
-          pending: seedTail,
-          chunk,
-          tail: unconditional.length > MAX_PARTIAL_ESCAPE_TAIL_LENGTH ? '' : unconditional
-        })
+        expect(advancePartialEscapeTail(pending, chunk), JSON.stringify({ pending, chunk })).toBe(
+          extractPartialEscapeTail(pending + chunk)
+        )
       }
     }
   })
 
   it('still carries a pending tail through an ESC-free chunk', () => {
-    const pending = '\u001b]0;my-title'
-    const chunk = ' still inside the OSC payload'
-    expect(advancePartialEscapeTail(pending, chunk)).toBe(pending + chunk)
+    expect(advancePartialEscapeTail('\x1b]0;my-title', ' still in the OSC')).toBe(
+      '\x1b]0;my-title still in the OSC'
+    )
   })
 })

--- a/src/shared/terminal-partial-escape-tail.test.ts
+++ b/src/shared/terminal-partial-escape-tail.test.ts
@@ -107,8 +107,12 @@ describe('advancePartialEscapeTail ESC-free fast path', () => {
   it('matches an unconditional fold for every pending-tail and chunk pairing', () => {
     for (const pending of pieces.map((piece) => extractPartialEscapeTail(piece))) {
       for (const chunk of pieces) {
+        // The cap belongs in the expectation: `advancePartialEscapeTail` abandons a tail over
+        // MAX_PARTIAL_ESCAPE_TAIL_LENGTH, so comparing it against an uncapped extract would stop
+        // modelling the function the moment a pairing crossed the cap.
+        const unguarded = extractPartialEscapeTail(pending + chunk)
         expect(advancePartialEscapeTail(pending, chunk), JSON.stringify({ pending, chunk })).toBe(
-          extractPartialEscapeTail(pending + chunk)
+          unguarded.length > MAX_PARTIAL_ESCAPE_TAIL_LENGTH ? '' : unguarded
         )
       }
     }

--- a/src/shared/terminal-partial-escape-tail.ts
+++ b/src/shared/terminal-partial-escape-tail.ts
@@ -149,7 +149,7 @@ export function advancePartialEscapeTail(pendingTail: string, chunk: string): st
   // the full-chunk concat and the per-code-unit walk on ESC-free output (build logs, `cat`,
   // piped tool output) — the same gate `TerminalOscCwdTitleScanner.scan` and
   // `TerminalMouseModeMirror.scan` already apply on the very same ingest path.
-  if (pendingTail.length === 0 && !chunk.includes('\u001b')) {
+  if (pendingTail.length === 0 && !chunk.includes('\x1b')) {
     return ''
   }
   const tail = extractPartialEscapeTail(pendingTail + chunk)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​178 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​149 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​110 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 |

<!-- /orca-pr-loc -->

## ELI5

Every time you click from one terminal split pane to another, Orca saves your session. As part of that save it **rewrote your terminal scrollback files to disk** — all of them, every time — even though not a single byte had changed. At 8 sleeping terminals that's 4 MB of synchronous disk writes per pane click, on the main thread.

This PR makes the writer remember what it last put at each path and skip the write when the content is identical. Same files on disk, just without rewriting them.

Split out of #18739 because this is the one change in that series that keeps state between calls (a small digest map), so it deserves its own review and its own revert button.

## What Changed

- **`terminal-scrollback-snapshot-write-memory.ts`** (new) — a per-process map from snapshot path to `{ digest, size, mtimeMs, ino }` of the file the last rename produced (stat taken on the temp file before the rename, which preserves inode and mtime). Capped at 256 entries, evicting the least recently republished path.
- **`terminal-scrollback-snapshots.ts`** — both writers (`writeTerminalScrollbackSnapshotSync` and the async variant) compute a SHA-256 of the buffer; on a digest match they `stat` the path and return the existing ref **only if size, mtime and inode still match the file this process wrote**. Anything else — file missing, replaced, or modified in place — drops the entry and writes. The entry is also dropped by both delete helpers and on write failure. A fresh process always writes at least once.
- **`config/scripts/scrollback-snapshot-write-skip-benchmark.mjs`** (`pnpm bench:scrollback-snapshot-write-skip`) — runs the production writer in both modes: with the memory reset each round (every leaf reaches disk, the pre-change behaviour) and with it retained.

The memory is a hint, not the source of truth. The on-disk check is what makes the skip safe; the map only decides whether the check is worth running.

## Why

The main thread is what serves file-explorer, editor and git IPC, so this is disk time those requests spent queued behind a pane click.

## Measurements

`pnpm bench:scrollback-snapshot-write-skip`, 8 retained scrollback leaves at the 512 KB cap, median of 9 rounds, M4 Max, 5 runs each. The baseline is disk-bound and noisy run to run (4–10 ms); the after number is stable.

| Per session write | Before | After (digest only) | After (digest + stat check) | |
| --- | --- | --- | --- | --- |
| scrollback snapshot republish (8 unchanged leaves) | 4.2–10.0 ms | 1.52–1.55 ms | 1.50–1.55 ms | **3–6x** |
| **synchronous disk writes** | **4.00 MB** | **0 MB** | **0 MB** | |

The 8 `stat` calls on a hit are lost in the SHA-256 cost of hashing 4 MB; the remaining 1.5 ms is the hash, not disk.

## Linked Issue

N/A — perf follow-up found while profiling the session write path.

## Visual Proof

N/A — no UI or interaction change; the bytes on disk are identical.

## Negative user-facing trade-offs

**None identified.** Specifically:

- No staleness. The digest guard skips a write only when the bytes are byte-identical to what this process already wrote at that path. Different content always writes.
- No lost scrollback. A skip requires the file at the path to still have the size, mtime and inode this process gave it. A file that is missing (deleted by us, by a racing async delete, or by anything external), replaced, or modified in place fails that check and is rewritten. Delete paths and write failures drop the entry as well, and the memory is per-process, so a restart always writes at least once.

Two things worth stating explicitly rather than hiding:

- **Cold writes cost ~0.19 ms more per leaf.** The SHA-256 is computed on every call, so a first write or a content change pays the digest on top of the encode it already did (measured: 188 µs for a 512 KB string). An actively printing terminal whose buffer changes between session writes pays this each time; eight such leaves add ~1.5 ms to a write that previously cost ~4–10 ms in disk I/O for the same leaves.
- **Memory:** the map holds at most 256 entries (digest + three numbers, ~15 KB) and lives for the process. Eviction is least-recently-republished, so a hot pane is never evicted ahead of a cold one.

The earlier "external writers" caveat is gone: the on-disk check closes it by construction rather than by audit. The only way to get a stale skip is a writer that replaces the file with the same size, same inode and same mtime to the millisecond, which is not something a file replace produces.

## Testing

- `pnpm tc` ✅
- `pnpm test src/main/terminal-scrollback-snapshot-write-skip.test.ts src/main/persistence` — 901 passed ✅
- `pnpm run check:code-quality:changed` ✅
- New: `src/main/terminal-scrollback-snapshot-write-skip.test.ts` (10 tests): republish is a no-op on the same inode and mtime for both the sync and async writer, and the memory is shared between them; content change rewrites; sync delete and async delete (with a legacy fallback root, which the write never targets) then republish rewrites; the file vanishing, being replaced, or being modified in place with the same size and inode behind the memory all rewrite; the 256 cap holds and evicts the least recently republished path, never a hot one.

- [x] I manually tested these changes locally (macOS)
- [x] Automated tests added/updated

## Review

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Cross-platform: paths come from `snapshotPath`, which already uses `path.join`; the map is keyed by that resolved string. SSH: snapshot files live on the host that owns the store, and the memory is per-process on that host. Folder workspaces and worktrees take the same path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm tc`, `pnpm test` (touched paths), and `check:code-quality:changed` pass locally; CI covers the rest


