### PR TITLE
chore: configure automatic incremental CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,5 @@
+reviews:
+  auto_review:
+    enabled: true
+    drafts: false
+    auto_incremental_review: true

--- a/.github/scripts/check-root-directory-entries.mjs
+++ b/.github/scripts/check-root-directory-entries.mjs
@@ -13,9 +13,8 @@ function readRootEntries(sha) {
   return stdout.split('\0').filter(Boolean)
 }
 
-// Why: the Cloud workspace import is the one reviewed root addition; it stays
-// listed until it lands on main, after which the base tree carries it.
-const REVIEWED_ROOT_ENTRIES = new Set(['cloud'])
+// CodeRabbit requires root configuration; allow reviewed additions until they land on main.
+const REVIEWED_ROOT_ENTRIES = new Set(['cloud', '.coderabbit.yaml'])
 
 function checkRootDirectoryEntries(argv) {
   if (argv.length !== 2) {


### PR DESCRIPTION
## ELI5

Keep CodeRabbit reviewing new changes automatically, while skipping draft PRs.

## What Changed

Add `.coderabbit.yaml` with automatic reviews and incremental reviews enabled, and draft reviews disabled. Allow this required root configuration file through the existing root-directory guard.

## Why

Make the desired review policy explicit in version control. These settings match CodeRabbit's documented defaults; this does not claim to speed up individual reviews.

## Linked Issue

N/A — requested configuration update; no linked issue provided.

## Visual Proof

N/A — review configuration only; no application UI changes.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated YAML syntax and exact settings on macOS. Checked the guard's JavaScript syntax with Node 22 and exercised it against temporary Git repositories: `.coderabbit.yaml` passes and an unrelated root addition fails. `git diff --check` passed. No new persistent tests for this small configuration change; full application checks were not run.

## AI Disclosure

Implemented with Codex.

## Review

The root-directory exception is limited to `.coderabbit.yaml`; other new root entries remain blocked.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill content copied.

## Notes

No application runtime, platform, SSH, mobile, or wire compatibility changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] Full lint, typecheck, test, and build checks (CI will cover)
