### PR TITLE
fix(remote): make environment store writes durable

### DIFF
--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { encodePairingOffer } from './pairing'
 import {
   RuntimeEnvironmentStoreError,
@@ -12,6 +12,14 @@ import {
   markEnvironmentUsed,
   updateEnvironmentFromPairingCode
 } from './runtime-environment-store'
+
+// Why: keeps PowerShell ACL work out of this suite without lying about the platform, which the
+// store's durable write reads to pick its fsync flags (#14173).
+vi.mock('./secure-path-windows-acl', () => ({
+  bestEffortRestrictWindowsPath: () => {},
+  restrictWindowsPathSync: () => true,
+  resetSecureFileWindowsUserSidForTests: () => {}
+}))
 
 function pairingCode(endpoint = 'ws://127.0.0.1:6768', pairedDeviceId?: string): string {
   return encodePairingOffer({
@@ -26,11 +34,6 @@ function pairingCode(endpoint = 'ws://127.0.0.1:6768', pairedDeviceId?: string):
 describe('runtime environment store', () => {
   const tempDirs: string[] = []
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
-
-  beforeEach(() => {
-    // Why: this suite tests store timestamps, while secure-file tests cover Windows ACLs.
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
-  })
 
   afterEach(() => {
     if (originalPlatform) {

--- a/src/shared/runtime-environment-store.test.ts
+++ b/src/shared/runtime-environment-store.test.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -12,6 +13,23 @@ import {
   markEnvironmentUsed,
   updateEnvironmentFromPairingCode
 } from './runtime-environment-store'
+
+const storeWriteSyscalls = vi.hoisted(() => [] as ('fsync:file' | 'fsync:directory' | 'rename')[])
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    fsyncSync: (fd: number) => {
+      storeWriteSyscalls.push(actual.fstatSync(fd).isDirectory() ? 'fsync:directory' : 'fsync:file')
+      return actual.fsyncSync(fd)
+    },
+    renameSync: (from: NodeFs.PathLike, to: NodeFs.PathLike) => {
+      storeWriteSyscalls.push('rename')
+      return actual.renameSync(from, to)
+    }
+  }
+})
 
 // Why: keeps PowerShell ACL work out of this suite without lying about the platform, which the
 // store's durable write reads to pick its fsync flags (#14173).
@@ -39,9 +57,22 @@ describe('runtime environment store', () => {
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
     }
+    storeWriteSyscalls.length = 0
     for (const dir of tempDirs.splice(0)) {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  it('fsyncs the store before publishing it', () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-env-store-durable-'))
+    tempDirs.push(userDataPath)
+
+    addEnvironmentFromPairingCode(userDataPath, {
+      name: 'dev box',
+      pairingCode: pairingCode()
+    })
+
+    expect(storeWriteSyscalls.slice(0, 2)).toEqual(['fsync:file', 'rename'])
   })
 
   it('rejects duplicate server names instead of silently replacing the saved server', () => {

--- a/src/shared/runtime-environment-store.ts
+++ b/src/shared/runtime-environment-store.ts
@@ -260,7 +260,10 @@ function writeEnvironmentStore(userDataPath: string, store: RuntimeEnvironmentSt
     writeSecureJsonFileWithinLimit(
       path,
       RuntimeEnvironmentStoreSchema.parse(store),
-      MAX_RUNTIME_ENVIRONMENT_STORE_FILE_BYTES
+      MAX_RUNTIME_ENVIRONMENT_STORE_FILE_BYTES,
+      // Why: without the fsync, a crash can publish this name over unflushed bytes, and the
+      // NUL-filled file that survives blocks every later save.
+      { durable: true }
     )
   } catch (error) {
     if (error instanceof JsonStringifyByteLimitError) {


### PR DESCRIPTION
## ELI5

Orca saves your Remote Orca Servers into one small file. It wrote that file without ever telling the OS "put these bytes on the disk now", so a machine that stops running shortly after a save can leave the filename published over data that never landed — NTFS hands back a file of the right size containing nothing but zeros, and Orca can no longer save any remote server. This PR makes that write wait for the disk, the way the neighbouring stores already do.

## What Changed

One production behavior change, in `writeEnvironmentStore` (`src/shared/runtime-environment-store.ts`):

```diff
     writeSecureJsonFileWithinLimit(
       path,
       RuntimeEnvironmentStoreSchema.parse(store),
-      MAX_RUNTIME_ENVIRONMENT_STORE_FILE_BYTES
+      MAX_RUNTIME_ENVIRONMENT_STORE_FILE_BYTES,
+      { durable: true }
     )
```

`writeSecureFile` only fsyncs when asked, and this store never asked. Two neighboring call sites on the same helper — `ephemeral-vm-runtime-store.ts:101` and `ephemeral-vm-runtime-feature-store.ts:121` — already pass `{ durable: true }`, so this looks like the one that was missed rather than a deliberate exception.

**Why the test setup changes:** the suite writes through `addEnvironmentFromPairingCode` for real, so those writes now fsync, and `fsyncFileSync` reads `process.platform` to choose its open mode. The suite was overriding `process.platform` to `'linux'` in `beforeEach`, which on a real Windows host picks the read-only handle that `FlushFileBuffers` rejects — `EPERM: operation not permitted, fsync`, the failure #14173 fixed in production code. That override existed to keep the Windows ACL path (a synchronous PowerShell spawn, ~1-1.5s per write) out of the suite, so this stubs `./secure-path-windows-acl` instead: same goal, without lying about the platform.

## Why

`orca-environments.json` came back as 640 bytes of NUL after a machine hung and was reset — twice on the same machine. The rename had published the name; the data behind it never reached stable storage, which is what a non-durable write leaves behind. Full report in the linked issue.

**Scope:** this fixes the write only. The read-side behaviour described as the second defect in the issue — a *missing* store degrades to an empty one, but an *unparsable* store throws for every caller, so the app can never replace the bad file — is deliberately left alone here. This change protects future writes and does nothing for a profile already holding a NUL-filled store.

**Regression coverage:** the store suite now records `fsyncSync` and `renameSync` at the `node:fs` boundary during a real environment-store mutation and asserts that the file fsync precedes the rename. Removing `{ durable: true }` makes that test fail, so it guards the exact omission fixed here. The existing 8 behavior tests keep their names and assertions.

## Linked Issue

Fixes #18766

## Visual Proof

`N/A` — no UI or interaction surface is touched; the change is one argument in the persistence path.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `src/shared/runtime-environment-store.test.ts` — 9 passed on Windows (the 8 existing cases plus one fsync-before-rename regression guard)
- `pnpm tc` — clean
- `pnpm run check:code-quality:changed` — 0 new findings across 2 changed files (oxlint, type-aware, React Doctor)
- An earlier full-suite comparison produced 127 failed files / 358 failed tests / 6 errors on both the branch and its pre-rebase base (`0d2375a7`). Those failures are environmental (unix-socket `EACCES` on `listen` and similar); nothing in the failure set touched this store, `secure-file`, or `persistence`.
- `pnpm build` — passes

**Reproduced out of band.** A process kill cannot show this: unflushed bytes live in the OS page cache, so if only the app dies the rename has already published a complete file. It needs the OS itself to lose that cache with the metadata already committed. In a Hyper-V guest (Windows 11, NTFS), writing 640-byte files through the same sequence as `writeSecureFile` — one variant without the fsync, one with it — and cutting the power mid-write with `Stop-VM -TurnOff`: without the fsync the file comes back 640 bytes of NUL, with it intact. Across trials, not one fsync'd file was ever damaged.

## AI Disclosure

Claude Opus 5 via Claude Code — root-cause investigation and the production change. OpenAI Codex (GPT-5) — regression test, upstream rebase, verification, and PR preparation. The corrupt file and power-loss runs are from the affected machine.

## Review

Agent code review summary:

- **Cross-platform:** no platform branch is added. The change opts one more caller into `writeSecureFile`'s existing durable path, which already runs on macOS and Linux through `artifact-share-record-store`, `profile-artifact-cloud-cleanup`, and both ephemeral VM runtime stores. Inside that path the platform differences are pre-existing: Windows opens the file `'r+'` because `FlushFileBuffers` needs a write-capable handle (#14173) and skips the directory fsync; POSIX opens `'r'` and additionally fsyncs the directory, best-effort, tolerating `EINVAL`/`ENOTSUP`/`EOPNOTSUPP`. Verified on Windows 11; the test change is inert on POSIX, where `applySecurePathRestriction` never reaches the stubbed module.
- **SSH / remote / local:** the store is client-local state on the machine doing the pairing. No wire format, RPC parameter, or host-published content changes, so mixed-version clients and hosts are unaffected.
- **Agents / integrations / git providers:** untouched; the store holds pairing offers.
- **Performance:** one file fsync per store mutation, plus a best-effort directory fsync on POSIX. Mutations are user actions (add/remove/update) plus `markEnvironmentUsed`, which is already throttled by `LAST_USED_PERSIST_INTERVAL_MS` to one write per 60s per environment, precisely because these writes are not free — so no fsync lands in a hot path.
- **UI quality:** N/A.
- **Security:** no new file-lifecycle operation is introduced; the existing temporary-file, ACL-hardening, and rename sequence is unchanged apart from enabling its durability syncs.
- **Backwards compatibility:** a valid store reads and writes exactly as before; the on-disk format is unchanged.

## Agent skill upstream boundary

- [x] Not applicable — no skill installer, registry, or documentation source is touched.

## Author

- X / Twitter: [@z33](https://x.com/z33)
- GitHub: newbdez33

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — the pre-rebase full-suite failures were identical on branch and base, see Testing
