### PR TITLE
fix(ssh): compile node-pty from the host's own Node headers instead of nodejs.org (STA-6674)

### DIFF
--- a/src/main/ssh/build-toolchain-diagnosis.ts
+++ b/src/main/ssh/build-toolchain-diagnosis.ts
@@ -174,10 +174,13 @@ const NODE_HEADERS_TARBALL_RE = /node-v[0-9.]+-headers\.tar\.gz/i
  * depends on what the local-headers export found first, so the formatter takes that answer.
  */
 export function isNodeHeadersDownloadFailure(message: string): boolean {
+  // Why `configure error` is required: node-gyp's fetch client logs `attempt N failed with <code>`
+  // on retries it then recovers from, so a network token alone also matches a build that got its
+  // headers and died later for an unrelated reason. Only the configure step downloads headers.
   return (
-    message.toLowerCase().includes('gyp') &&
+    /gyp ERR! configure error/i.test(message) &&
     NODE_HEADERS_TARBALL_RE.test(message) &&
-    /\b(ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|EHOSTUNREACH|ENETUNREACH|fetch failed|FetchError)\b/i.test(
+    /\b(ECONNREFUSED|ENOTFOUND|ETIMEDOUT|EHOSTUNREACH|ENETUNREACH|EAI_AGAIN|ECONNRESET)\b/.test(
       message
     )
   )
@@ -213,11 +216,11 @@ export function formatNodeHeadersDownloadError(
       ]
     : [
         'The remote host could not download the Node.js headers needed to compile node-pty, and ' +
-          `its Node install does not ship them locally. ${NODE_HEADERS_CONTEXT}`,
+          `its Node install has no local headers matching its own version. ${NODE_HEADERS_CONTEXT}`,
         '',
         'Fix one of the following on the remote host, then reconnect:',
         '  - Install Node.js from an official build or a version manager (nvm, fnm, volta, n), ' +
-          'which include the headers; or',
+          'which ship headers for exactly the Node they run; or',
         '  - Allow outbound HTTPS to nodejs.org, or point npm at a mirror: ' +
           'npm config set disturl https://<mirror>/dist'
       ]

--- a/src/main/ssh/build-toolchain-diagnosis.ts
+++ b/src/main/ssh/build-toolchain-diagnosis.ts
@@ -170,9 +170,8 @@ const NODE_HEADERS_TARBALL_RE = /node-v[0-9.]+-headers\.tar\.gz/i
  * Whether a native-deps failure is node-gyp failing to download Node headers from nodejs.org.
  *
  * Why it needs naming: the raw output is forty lines of `gyp http` and stack frames around one
- * `ECONNREFUSED`, and it reads as a broken host or a broken Orca. It is neither -- the host's Node
- * ships no headers at `<prefix>/include/node` (so the local-headers export found nothing) AND it
- * cannot reach nodejs.org. Both are things the operator can fix; neither is visible from the log.
+ * `ECONNREFUSED`, and it reads as a broken host or a broken Orca. Which of two things it is
+ * depends on what the local-headers export found first, so the formatter takes that answer.
  */
 export function isNodeHeadersDownloadFailure(message: string): boolean {
   return (
@@ -184,19 +183,43 @@ export function isNodeHeadersDownloadFailure(message: string): boolean {
   )
 }
 
-export function formatNodeHeadersDownloadError(underlyingError: string): string {
-  return [
-    'The remote host could not download the Node.js headers needed to compile node-pty, and its ' +
-      'Node install does not ship them locally. node-pty has no prebuilt binary for Linux, so it ' +
-      'must be compiled on the remote host, and node-gyp fetches the headers from nodejs.org ' +
-      'unless the Node install provides them at <prefix>/include/node.',
-    '',
-    'Fix one of the following on the remote host, then reconnect:',
-    '  - Install Node.js from an official build or a version manager (nvm, fnm, volta, n), ' +
-      'which include the headers; or',
-    '  - Allow outbound HTTPS to nodejs.org, or point npm at a mirror: ' +
-      'npm config set disturl https://<mirror>/dist',
-    '',
-    `Underlying install error: ${underlyingError}`
-  ].join('\n')
+const NODE_HEADERS_CONTEXT =
+  'node-pty has no prebuilt binary for Linux, so it must be compiled on the remote host, and ' +
+  'node-gyp fetches the Node.js headers from nodejs.org unless the Node install provides them ' +
+  'at <prefix>/include/node.'
+
+/**
+ * @param localHeadersDir what the local-headers export found: a dir it exported, `null` when
+ *   the host's Node ships no matching headers, `undefined` when the answer never came back.
+ *
+ * Why the exported-dir case is its own message: the export is the fix, so node-gyp downloading
+ * anyway means its `nodedir` env keys were not honoured (a future npm dropping the passthrough,
+ * a wrapper scrubbing the env). That is an Orca defect, not a host problem, and must not be
+ * reported as one -- it names the dir so the report is checkable.
+ */
+export function formatNodeHeadersDownloadError(
+  underlyingError: string,
+  localHeadersDir: string | null | undefined
+): string {
+  const lines = localHeadersDir
+    ? [
+        `The remote host could not download the Node.js headers needed to compile node-pty, even ` +
+          `though its Node install ships matching headers at ${localHeadersDir}/include/node and ` +
+          `Orca pointed node-gyp at them. node-gyp ignored that setting; this is an Orca defect, ` +
+          `please report it with the log below.`,
+        '',
+        'Workaround on the remote host until then: allow outbound HTTPS to nodejs.org, or point ' +
+          'npm at a mirror: npm config set disturl https://<mirror>/dist'
+      ]
+    : [
+        'The remote host could not download the Node.js headers needed to compile node-pty, and ' +
+          `its Node install does not ship them locally. ${NODE_HEADERS_CONTEXT}`,
+        '',
+        'Fix one of the following on the remote host, then reconnect:',
+        '  - Install Node.js from an official build or a version manager (nvm, fnm, volta, n), ' +
+          'which include the headers; or',
+        '  - Allow outbound HTTPS to nodejs.org, or point npm at a mirror: ' +
+          'npm config set disturl https://<mirror>/dist'
+      ]
+  return [...lines, '', `Underlying install error: ${underlyingError}`].join('\n')
 }

--- a/src/main/ssh/build-toolchain-diagnosis.ts
+++ b/src/main/ssh/build-toolchain-diagnosis.ts
@@ -163,3 +163,40 @@ export function formatMissingToolchainError(
   ]
   return lines.join('\n')
 }
+
+const NODE_HEADERS_TARBALL_RE = /node-v[0-9.]+-headers\.tar\.gz/i
+
+/**
+ * Whether a native-deps failure is node-gyp failing to download Node headers from nodejs.org.
+ *
+ * Why it needs naming: the raw output is forty lines of `gyp http` and stack frames around one
+ * `ECONNREFUSED`, and it reads as a broken host or a broken Orca. It is neither -- the host's Node
+ * ships no headers at `<prefix>/include/node` (so the local-headers export found nothing) AND it
+ * cannot reach nodejs.org. Both are things the operator can fix; neither is visible from the log.
+ */
+export function isNodeHeadersDownloadFailure(message: string): boolean {
+  return (
+    message.toLowerCase().includes('gyp') &&
+    NODE_HEADERS_TARBALL_RE.test(message) &&
+    /\b(ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|EAI_AGAIN|EHOSTUNREACH|ENETUNREACH|fetch failed|FetchError)\b/i.test(
+      message
+    )
+  )
+}
+
+export function formatNodeHeadersDownloadError(underlyingError: string): string {
+  return [
+    'The remote host could not download the Node.js headers needed to compile node-pty, and its ' +
+      'Node install does not ship them locally. node-pty has no prebuilt binary for Linux, so it ' +
+      'must be compiled on the remote host, and node-gyp fetches the headers from nodejs.org ' +
+      'unless the Node install provides them at <prefix>/include/node.',
+    '',
+    'Fix one of the following on the remote host, then reconnect:',
+    '  - Install Node.js from an official build or a version manager (nvm, fnm, volta, n), ' +
+      'which include the headers; or',
+    '  - Allow outbound HTTPS to nodejs.org, or point npm at a mirror: ' +
+      'npm config set disturl https://<mirror>/dist',
+    '',
+    `Underlying install error: ${underlyingError}`
+  ].join('\n')
+}

--- a/src/main/ssh/ssh-relay-build-toolchain.test.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.test.ts
@@ -3,7 +3,9 @@ import {
   buildToolchainProbeCommand,
   parseBuildToolchainProbe,
   formatMissingToolchainError,
+  formatNodeHeadersDownloadError,
   formatSkippedNodePtyWarning,
+  isNodeHeadersDownloadFailure,
   shouldProbeBuildToolchainAfterNativeDepsFailure
 } from './ssh-relay-build-toolchain'
 
@@ -123,5 +125,49 @@ describe('formatSkippedNodePtyWarning', () => {
     const warning = formatSkippedNodePtyWarning(parseBuildToolchainProbe(''))
     expect(warning).not.toContain('apt-get')
     expect(warning).toContain('install a C/C++ toolchain')
+  })
+})
+
+// Verbatim shape of the STA-6674 failure: node-gyp on a host whose nodejs.org is refused.
+const HEADERS_REFUSED =
+  'npm error gyp http GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz\n' +
+  'npm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED\n' +
+  'npm error gyp ERR! configure error\n' +
+  'npm error gyp ERR! stack FetchError: request to https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz failed, reason: connect ECONNREFUSED 127.0.0.1:443'
+
+describe('isNodeHeadersDownloadFailure', () => {
+  it('matches node-gyp failing to fetch the Node headers tarball', () => {
+    expect(isNodeHeadersDownloadFailure(HEADERS_REFUSED)).toBe(true)
+    expect(
+      isNodeHeadersDownloadFailure(
+        'gyp http fetch GET https://nodejs.org/download/release/v20.19.0/node-v20.19.0-headers.tar.gz attempt 1 failed with ENOTFOUND'
+      )
+    ).toBe(true)
+  })
+
+  it('is not the toolchain diagnosis, and does not fire on other network failures', () => {
+    expect(shouldProbeBuildToolchainAfterNativeDepsFailure(HEADERS_REFUSED)).toBe(false)
+    // The registry, not nodejs.org: a different remedy.
+    expect(
+      isNodeHeadersDownloadFailure(
+        'npm error network request to https://registry.npmjs.org/node-pty failed, reason: connect ECONNREFUSED'
+      )
+    ).toBe(false)
+    // Headers named but the build failed for another reason.
+    expect(
+      isNodeHeadersDownloadFailure(
+        'gyp info using node-v24.12.0-headers.tar.gz\ngyp ERR! build error make failed with exit code: 2'
+      )
+    ).toBe(false)
+  })
+})
+
+describe('formatNodeHeadersDownloadError', () => {
+  it('names both remedies and keeps the underlying error', () => {
+    const msg = formatNodeHeadersDownloadError(HEADERS_REFUSED)
+    expect(msg).toContain('<prefix>/include/node')
+    expect(msg).toContain('nodejs.org')
+    expect(msg).toContain('disturl')
+    expect(msg).toContain('ECONNREFUSED')
   })
 })

--- a/src/main/ssh/ssh-relay-build-toolchain.test.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.test.ts
@@ -163,11 +163,21 @@ describe('isNodeHeadersDownloadFailure', () => {
 })
 
 describe('formatNodeHeadersDownloadError', () => {
-  it('names both remedies and keeps the underlying error', () => {
-    const msg = formatNodeHeadersDownloadError(HEADERS_REFUSED)
+  it('names both host remedies when the host ships no headers', () => {
+    const msg = formatNodeHeadersDownloadError(HEADERS_REFUSED, null)
+    expect(msg).toContain('does not ship them locally')
     expect(msg).toContain('<prefix>/include/node')
-    expect(msg).toContain('nodejs.org')
+    expect(msg).toContain('nvm, fnm, volta, n')
     expect(msg).toContain('disturl')
+    expect(msg).toContain('ECONNREFUSED')
+  })
+
+  it('reports an Orca defect, not a host problem, when headers were exported and ignored', () => {
+    const msg = formatNodeHeadersDownloadError(HEADERS_REFUSED, '/usr/local')
+    expect(msg).toContain('/usr/local/include/node')
+    expect(msg).toContain('Orca defect')
+    expect(msg).not.toContain('does not ship them locally')
+    expect(msg).not.toContain('nvm, fnm, volta, n')
     expect(msg).toContain('ECONNREFUSED')
   })
 })

--- a/src/main/ssh/ssh-relay-build-toolchain.test.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.test.ts
@@ -140,7 +140,7 @@ describe('isNodeHeadersDownloadFailure', () => {
     expect(isNodeHeadersDownloadFailure(HEADERS_REFUSED)).toBe(true)
     expect(
       isNodeHeadersDownloadFailure(
-        'gyp http fetch GET https://nodejs.org/download/release/v20.19.0/node-v20.19.0-headers.tar.gz attempt 1 failed with ENOTFOUND'
+        'gyp http fetch GET https://nodejs.org/download/release/v20.19.0/node-v20.19.0-headers.tar.gz attempt 1 failed with ENOTFOUND\ngyp ERR! configure error'
       )
     ).toBe(true)
   })
@@ -159,13 +159,27 @@ describe('isNodeHeadersDownloadFailure', () => {
         'gyp info using node-v24.12.0-headers.tar.gz\ngyp ERR! build error make failed with exit code: 2'
       )
     ).toBe(false)
+    // A retried attempt that recovered, then a compile failure: not a download failure.
+    expect(
+      isNodeHeadersDownloadFailure(
+        'gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNRESET\n' +
+          'gyp http 200 https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz\n' +
+          'gyp ERR! build error\ngyp ERR! stack Error: `make` failed with exit code: 2'
+      )
+    ).toBe(false)
+    // A mirror answering non-2xx is a FetchError without a network code: a different remedy.
+    expect(
+      isNodeHeadersDownloadFailure(
+        'gyp ERR! configure error\ngyp ERR! stack FetchError: 404 Not Found https://mirror/dist/v24.12.0/node-v24.12.0-headers.tar.gz'
+      )
+    ).toBe(false)
   })
 })
 
 describe('formatNodeHeadersDownloadError', () => {
   it('names both host remedies when the host ships no headers', () => {
     const msg = formatNodeHeadersDownloadError(HEADERS_REFUSED, null)
-    expect(msg).toContain('does not ship them locally')
+    expect(msg).toContain('no local headers matching its own version')
     expect(msg).toContain('<prefix>/include/node')
     expect(msg).toContain('nvm, fnm, volta, n')
     expect(msg).toContain('disturl')
@@ -176,7 +190,7 @@ describe('formatNodeHeadersDownloadError', () => {
     const msg = formatNodeHeadersDownloadError(HEADERS_REFUSED, '/usr/local')
     expect(msg).toContain('/usr/local/include/node')
     expect(msg).toContain('Orca defect')
-    expect(msg).not.toContain('does not ship them locally')
+    expect(msg).not.toContain('no local headers matching its own version')
     expect(msg).not.toContain('nvm, fnm, volta, n')
     expect(msg).toContain('ECONNREFUSED')
   })

--- a/src/main/ssh/ssh-relay-build-toolchain.ts
+++ b/src/main/ssh/ssh-relay-build-toolchain.ts
@@ -16,7 +16,9 @@ export {
   shouldProbeBuildToolchainAfterNativeDepsFailure,
   toolchainInstallHintLines,
   formatSkippedNodePtyWarning,
-  formatMissingToolchainError
+  formatMissingToolchainError,
+  formatNodeHeadersDownloadError,
+  isNodeHeadersDownloadFailure
 } from './build-toolchain-diagnosis'
 export type { BuildToolchainStatus } from './build-toolchain-diagnosis'
 

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -53,11 +53,14 @@ import {
 } from './ssh-relay-deploy-timing'
 import { createSshOperationAbortError, shellEscape } from './ssh-connection-utils'
 import { isWindowsRelayPlatform } from '../../shared/relay-artifacts'
+import { exportLocalNodeHeadersPrefix } from './ssh-relay-node-headers'
 import {
   probeBuildToolchain,
   formatMissingToolchainError,
   formatSkippedNodePtyWarning,
-  shouldProbeBuildToolchainAfterNativeDepsFailure
+  shouldProbeBuildToolchainAfterNativeDepsFailure,
+  formatNodeHeadersDownloadError,
+  isNodeHeadersDownloadFailure
 } from './ssh-relay-build-toolchain'
 import {
   commandWithNodePath,
@@ -1174,7 +1177,7 @@ async function installNativeDeps(
           hostPlatform,
           nodePath,
           remoteDir,
-          `${resetPrefix}npm install --ignore-scripts=false --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
+          `${exportLocalNodeHeadersPrefix(nodePath)}${resetPrefix}npm install --ignore-scripts=false --omit=dev --no-audit --no-fund ${installArgs} 2>&1`
         )
     await execHostCommand(conn, hostPlatform, command, {
       timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS,
@@ -1235,6 +1238,11 @@ async function installNativeDeps(
         )
         return
       }
+    }
+    // Why: the local-headers export already found nothing on this host, so what is left is a host
+    // that is both header-less and offline -- name it, or the log reads as a broken relay.
+    if (platform.startsWith('linux') && isNodeHeadersDownloadFailure(msg)) {
+      throw new Error(formatNodeHeadersDownloadError(msg), { cause: err })
     }
     throw err
   }
@@ -1347,7 +1355,7 @@ async function applyNodePtyMasterCloexecPatch(
       hostPlatform,
       nodePath,
       remoteDir,
-      `${shellEscape(nodePath)} ${shellEscape(NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME)} 2>&1`
+      `${exportLocalNodeHeadersPrefix(nodePath)}${shellEscape(nodePath)} ${shellEscape(NODE_PTY_MASTER_CLOEXEC_PATCH_FILENAME)} 2>&1`
     )
     const output = await execHostCommand(conn, hostPlatform, command, {
       timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS,
@@ -1529,7 +1537,7 @@ async function rebuildNativeDeps(
         hostPlatform,
         nodePath,
         remoteDir,
-        `npm rebuild --ignore-scripts=false ${depNames.map(shellEscape).join(' ')} 2>&1`
+        `${exportLocalNodeHeadersPrefix(nodePath)}npm rebuild --ignore-scripts=false ${depNames.map(shellEscape).join(' ')} 2>&1`
       )
   await execHostCommand(conn, hostPlatform, command, {
     timeoutMs: NATIVE_DEPS_COMMAND_TIMEOUT_MS,

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -1265,8 +1265,15 @@ async function installNativeDeps(
         throw err
       }
       signal?.throwIfAborted()
+      // Same diagnosis as the install catch: this fallback is non-fatal, so the log is the only
+      // place the offline-headers cause can reach anyone.
+      const rebuildMsg = (err as Error).message
       console.warn(
-        `[ssh-relay][NATIVE-DEPS-REBUILD-FAIL] npm rebuild native deps failed at ${remoteDir} (${platform}): ${(err as Error).message}`
+        `[ssh-relay][NATIVE-DEPS-REBUILD-FAIL] npm rebuild native deps failed at ${remoteDir} (${platform}): ${
+          platform.startsWith('linux') && isNodeHeadersDownloadFailure(rebuildMsg)
+            ? formatNodeHeadersDownloadError(rebuildMsg, localNodeHeadersFromOutput(rebuildMsg))
+            : rebuildMsg
+        }`
       )
     }
     signal?.throwIfAborted()

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -53,7 +53,7 @@ import {
 } from './ssh-relay-deploy-timing'
 import { createSshOperationAbortError, shellEscape } from './ssh-connection-utils'
 import { isWindowsRelayPlatform } from '../../shared/relay-artifacts'
-import { exportLocalNodeHeadersPrefix } from './ssh-relay-node-headers'
+import { exportLocalNodeHeadersPrefix, localNodeHeadersFromOutput } from './ssh-relay-node-headers'
 import {
   probeBuildToolchain,
   formatMissingToolchainError,
@@ -1239,10 +1239,13 @@ async function installNativeDeps(
         return
       }
     }
-    // Why: the local-headers export already found nothing on this host, so what is left is a host
-    // that is both header-less and offline -- name it, or the log reads as a broken relay.
+    // Why: either the local-headers export found nothing (a host both header-less and offline) or
+    // it did and node-gyp downloaded anyway (the export is broken) -- name which, or the log reads
+    // as a broken relay either way.
     if (platform.startsWith('linux') && isNodeHeadersDownloadFailure(msg)) {
-      throw new Error(formatNodeHeadersDownloadError(msg), { cause: err })
+      throw new Error(formatNodeHeadersDownloadError(msg, localNodeHeadersFromOutput(msg)), {
+        cause: err
+      })
     }
     throw err
   }

--- a/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
@@ -177,20 +177,26 @@ describe('installNativeDeps staged uploads', () => {
     }
   })
 
+  // What execCommand actually rejects with: the whole command line (marker echo included) quoted
+  // ahead of the host's output. A fixture that omits the command hides the marker-parsing bug.
+  function rejectNpmInstallLikeExecCommand(hostOutput: string): void {
+    vi.mocked(execCommand).mockImplementationOnce(async (_conn, command) => {
+      throw new Error(`Command "${command}" failed (exit 1): ${hostOutput}`)
+    })
+  }
+  const HEADERS_REFUSED =
+    'npm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED\nnpm error gyp ERR! configure error'
+
   it('names the fix when node-gyp cannot download headers and the host ships none (STA-6674)', async () => {
     const conn = makeMockConnection(sftpCapture)
-    feed(
-      makeExecResponses({
-        npmInstall: {
-          reject:
-            'Command "npm install" failed (exit 1): npm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED\nnpm error gyp ERR! configure error'
-        }
-      })
-    )
+    feed(makeStagedFirstInstallExecPrefix())
+    rejectNpmInstallLikeExecCommand(`ORCA-NODE-HEADERS:none\n${HEADERS_REFUSED}`)
+    feed(['']) // clean stage root
 
     const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
     expect((error as Error).message).toContain('could not download the Node.js headers')
     expect((error as Error).message).toContain('no local headers matching its own version')
+    expect((error as Error).message).not.toContain('Orca defect')
     expect((error as Error).message).toContain('ECONNREFUSED')
     // A full toolchain: the toolchain probe must not run, and this is not a "build tools" error.
     expect((error as Error).message).not.toContain('build tools')
@@ -201,14 +207,9 @@ describe('installNativeDeps staged uploads', () => {
   it('reports an Orca defect when headers were exported but node-gyp downloaded anyway', async () => {
     // The marker says the export happened; a download after it means node-gyp never read the env.
     const conn = makeMockConnection(sftpCapture)
-    feed(
-      makeExecResponses({
-        npmInstall: {
-          reject:
-            'Command "npm install" failed (exit 1): ORCA-NODE-HEADERS:/usr/local\nnpm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED\nnpm error gyp ERR! configure error'
-        }
-      })
-    )
+    feed(makeStagedFirstInstallExecPrefix())
+    rejectNpmInstallLikeExecCommand(`ORCA-NODE-HEADERS:/usr/local\n${HEADERS_REFUSED}`)
+    feed(['']) // clean stage root
 
     const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
     expect((error as Error).message).toContain('/usr/local/include/node')

--- a/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
@@ -190,7 +190,7 @@ describe('installNativeDeps staged uploads', () => {
 
     const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
     expect((error as Error).message).toContain('could not download the Node.js headers')
-    expect((error as Error).message).toContain('does not ship them locally')
+    expect((error as Error).message).toContain('no local headers matching its own version')
     expect((error as Error).message).toContain('ECONNREFUSED')
     // A full toolchain: the toolchain probe must not run, and this is not a "build tools" error.
     expect((error as Error).message).not.toContain('build tools')
@@ -205,7 +205,7 @@ describe('installNativeDeps staged uploads', () => {
       makeExecResponses({
         npmInstall: {
           reject:
-            'Command "npm install" failed (exit 1): ORCA-NODE-HEADERS:/usr/local\nnpm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED'
+            'Command "npm install" failed (exit 1): ORCA-NODE-HEADERS:/usr/local\nnpm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED\nnpm error gyp ERR! configure error'
         }
       })
     )
@@ -213,7 +213,7 @@ describe('installNativeDeps staged uploads', () => {
     const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
     expect((error as Error).message).toContain('/usr/local/include/node')
     expect((error as Error).message).toContain('Orca defect')
-    expect((error as Error).message).not.toContain('does not ship them locally')
+    expect((error as Error).message).not.toContain('no local headers matching its own version')
   })
 
   it('promotes only after the first-install lock is acquired', async () => {

--- a/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
@@ -154,6 +154,47 @@ describe('installNativeDeps staged uploads', () => {
     expect(writeObservedAt).toBeLessThanOrEqual(npmInstallIdx)
   })
 
+  it('exports the host Node headers dir to node-gyp on every command that can compile node-pty (STA-6674)', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    // Install succeeds, the probe fails, the rebuild repairs it, then the cloexec patch rebuilds again.
+    feed(makeExecResponses({ npmInstall: 'ok', probe: 'missing', repairProbe: 'ok' }))
+
+    await deployAndLaunchRelay(conn)
+
+    const commands = vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+    const compiling = ['npm install', 'npm rebuild', 'node-pty-1.1.0-master-cloexec-patch.cjs']
+    for (const compileStep of compiling) {
+      const command = commands.find((candidate) => candidate.includes(compileStep))
+      expect(command, compileStep).toBeDefined()
+      // Both spellings: node-gyp 10 (Node 20) reads only npm_config_, node-gyp >= 11.4 prefers the other.
+      expect(command).toContain('export npm_config_nodedir=')
+      expect(command).toContain('npm_package_config_node_gyp_nodedir=')
+      // The export precedes the compile on the same command line, and only when the probe found headers.
+      expect(command!.indexOf('npm_config_nodedir')).toBeLessThan(command!.indexOf(compileStep))
+      expect(command).toContain('node_version.h')
+    }
+  })
+
+  it('names the fix when node-gyp cannot download headers and the host ships none (STA-6674)', async () => {
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: {
+          reject:
+            'Command "npm install" failed (exit 1): npm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED\nnpm error gyp ERR! configure error'
+        }
+      })
+    )
+
+    const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
+    expect((error as Error).message).toContain('could not download the Node.js headers')
+    expect((error as Error).message).toContain('ECONNREFUSED')
+    // A full toolchain: the toolchain probe must not run, and this is not a "build tools" error.
+    expect((error as Error).message).not.toContain('build tools')
+    const commands = vi.mocked(execCommand).mock.calls.map(([, command]) => command)
+    expect(commands.some((command) => command.includes('command -v "$t"'))).toBe(false)
+  })
+
   it('promotes only after the first-install lock is acquired', async () => {
     const conn = makeMockConnection(sftpCapture)
     feed(makeExecResponses({ npmInstall: 'ok', probe: 'ok' }))

--- a/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
+++ b/src/main/ssh/ssh-relay-native-deps-install-staged-upload.test.ts
@@ -172,6 +172,8 @@ describe('installNativeDeps staged uploads', () => {
       // The export precedes the compile on the same command line, and only when the probe found headers.
       expect(command!.indexOf('npm_config_nodedir')).toBeLessThan(command!.indexOf(compileStep))
       expect(command).toContain('node_version.h')
+      // The marker lands in the captured output, so a failure after it can say what was exported.
+      expect(command).toContain('echo "ORCA-NODE-HEADERS:${ORCA_NODE_HEADERS_DIR:-none}"')
     }
   })
 
@@ -188,11 +190,30 @@ describe('installNativeDeps staged uploads', () => {
 
     const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
     expect((error as Error).message).toContain('could not download the Node.js headers')
+    expect((error as Error).message).toContain('does not ship them locally')
     expect((error as Error).message).toContain('ECONNREFUSED')
     // A full toolchain: the toolchain probe must not run, and this is not a "build tools" error.
     expect((error as Error).message).not.toContain('build tools')
     const commands = vi.mocked(execCommand).mock.calls.map(([, command]) => command)
     expect(commands.some((command) => command.includes('command -v "$t"'))).toBe(false)
+  })
+
+  it('reports an Orca defect when headers were exported but node-gyp downloaded anyway', async () => {
+    // The marker says the export happened; a download after it means node-gyp never read the env.
+    const conn = makeMockConnection(sftpCapture)
+    feed(
+      makeExecResponses({
+        npmInstall: {
+          reject:
+            'Command "npm install" failed (exit 1): ORCA-NODE-HEADERS:/usr/local\nnpm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED'
+        }
+      })
+    )
+
+    const error = await deployAndLaunchRelay(conn).catch((e: Error) => e)
+    expect((error as Error).message).toContain('/usr/local/include/node')
+    expect((error as Error).message).toContain('Orca defect')
+    expect((error as Error).message).not.toContain('does not ship them locally')
   })
 
   it('promotes only after the first-install lock is acquired', async () => {

--- a/src/main/ssh/ssh-relay-node-headers.test.ts
+++ b/src/main/ssh/ssh-relay-node-headers.test.ts
@@ -4,17 +4,24 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
 import { afterEach, describe, expect, it } from 'vitest'
-import { exportLocalNodeHeadersPrefix } from './ssh-relay-node-headers'
+import { exportLocalNodeHeadersPrefix, localNodeHeadersFromOutput } from './ssh-relay-node-headers'
 
 const POSIX = process.platform !== 'win32'
 
 /** Runs the prefix under /bin/sh exactly as the relay does, then prints what node-gyp would see. */
-function runPrefix(nodePath: string): { nodedir: string; pkgNodedir: string } {
+function runPrefix(nodePath: string): {
+  nodedir: string
+  pkgNodedir: string
+  marker: string | null | undefined
+} {
   const script = `${exportLocalNodeHeadersPrefix(nodePath)}printf '%s\\n%s\\n' "$npm_config_nodedir" "$npm_package_config_node_gyp_nodedir"`
   const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' })
   expect(result.status).toBe(0)
-  const [nodedir = '', pkgNodedir = ''] = result.stdout.split('\n')
-  return { nodedir, pkgNodedir }
+  const marker = localNodeHeadersFromOutput(result.stdout)
+  const [nodedir = '', pkgNodedir = ''] = result.stdout
+    .split('\n')
+    .filter((line) => !line.startsWith('ORCA-NODE-HEADERS:'))
+  return { nodedir, pkgNodedir, marker }
 }
 
 /** A fake `<prefix>/bin/node` whose `include/node/node_version.h` claims `version`. */
@@ -44,9 +51,10 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
   it('exports nodedir when the running Node ships headers for its own version', () => {
     // The test runner's Node is an official build, so its prefix has include/node.
     const prefix = dirname(dirname(process.execPath))
-    const { nodedir, pkgNodedir } = runPrefix(process.execPath)
+    const { nodedir, pkgNodedir, marker } = runPrefix(process.execPath)
     expect(nodedir).toBe(prefix)
     expect(pkgNodedir).toBe(prefix)
+    expect(marker).toBe(prefix)
   })
 
   it('leaves nodedir unset when the shipped headers are for another Node version', () => {
@@ -64,9 +72,10 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
     )
     const copied = join(prefix, 'bin', 'node')
     spawnSync('cp', [process.execPath, copied])
-    const { nodedir, pkgNodedir } = runPrefix(copied)
+    const { nodedir, pkgNodedir, marker } = runPrefix(copied)
     expect(nodedir).toBe('')
     expect(pkgNodedir).toBe('')
+    expect(marker).toBeNull()
   })
 
   it('leaves nodedir unset when the prefix has no headers at all', () => {
@@ -93,6 +102,16 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
     const script = `${exportLocalNodeHeadersPrefix('/nonexistent/node')}echo "after:$npm_config_nodedir"`
     const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' })
     expect(result.status).toBe(0)
-    expect(result.stdout.trim()).toBe('after:')
+    expect(result.stdout.trim()).toBe('ORCA-NODE-HEADERS:none\nafter:')
+  })
+})
+
+describe('localNodeHeadersFromOutput', () => {
+  it('distinguishes an exported dir, an explicit none, and no marker at all', () => {
+    expect(localNodeHeadersFromOutput('x\nORCA-NODE-HEADERS:/usr/local\ngyp ERR!')).toBe(
+      '/usr/local'
+    )
+    expect(localNodeHeadersFromOutput('ORCA-NODE-HEADERS:none\ngyp ERR!')).toBeNull()
+    expect(localNodeHeadersFromOutput('gyp ERR! only')).toBeUndefined()
   })
 })

--- a/src/main/ssh/ssh-relay-node-headers.test.ts
+++ b/src/main/ssh/ssh-relay-node-headers.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import process from 'node:process'
@@ -71,7 +79,8 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
       '#define NODE_MAJOR_VERSION 1\n#define NODE_MINOR_VERSION 0\n#define NODE_PATCH_VERSION 0\n'
     )
     const copied = join(prefix, 'bin', 'node')
-    spawnSync('cp', [process.execPath, copied])
+    copyFileSync(process.execPath, copied)
+    chmodSync(copied, 0o755)
     const { nodedir, pkgNodedir, marker } = runPrefix(copied)
     expect(nodedir).toBe('')
     expect(pkgNodedir).toBe('')
@@ -83,7 +92,8 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
     roots.push(root)
     const copied = join(root, 'bin', 'node')
     mkdirSync(dirname(copied), { recursive: true })
-    spawnSync('cp', [process.execPath, copied])
+    copyFileSync(process.execPath, copied)
+    chmodSync(copied, 0o755)
     const { nodedir } = runPrefix(copied)
     expect(nodedir).toBe('')
   })
@@ -104,18 +114,20 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
     roots.push(root)
     const copied = join(root, 'bin', 'node')
     mkdirSync(dirname(copied), { recursive: true })
-    spawnSync('cp', [process.execPath, copied])
-    const script = `${exportLocalNodeHeadersPrefix(copied)}printf '%s|%s' "$npm_config_nodedir" "$npm_package_config_node_gyp_nodedir"`
+    copyFileSync(process.execPath, copied)
+    chmodSync(copied, 0o755)
+    const script = `${exportLocalNodeHeadersPrefix(copied)}printf '%s|%s|%s' "$npm_config_nodedir" "$NPM_CONFIG_NODEDIR" "$npm_package_config_node_gyp_nodedir"`
     const result = spawnSync('/bin/sh', ['-c', script], {
       encoding: 'utf8',
       env: {
         ...process.env,
         npm_config_nodedir: '/usr/stale-headers',
+        NPM_CONFIG_NODEDIR: '/usr/stale-headers',
         npm_package_config_node_gyp_nodedir: '/usr/stale-headers'
       }
     })
     expect(result.status).toBe(0)
-    expect(result.stdout.split('\n').at(-1)).toBe('|')
+    expect(result.stdout.split('\n').at(-1)).toBe('||')
   })
 
   it('does not fail the command line when node itself cannot run', () => {
@@ -127,6 +139,21 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
 })
 
 describe('localNodeHeadersFromOutput', () => {
+  it('reads the host answer, not the copy of the marker echo quoted in an exec-failure head', () => {
+    // The real shape: execCommand quotes the whole command line, prefix included, before the output.
+    const command = `export PATH='/usr/local/bin':$PATH && cd '/root/.orca-remote/relay-x' && ${exportLocalNodeHeadersPrefix('/usr/local/bin/node')}npm install node-pty 2>&1`
+    const failed = (hostOutput: string): string =>
+      `Command "${command}" failed (exit 1): ${hostOutput}`
+    expect(
+      localNodeHeadersFromOutput(failed('ORCA-NODE-HEADERS:none\ngyp ERR! configure error'))
+    ).toBeNull()
+    expect(
+      localNodeHeadersFromOutput(failed('ORCA-NODE-HEADERS:/usr/local\ngyp ERR! configure error'))
+    ).toBe('/usr/local')
+    // No host output at all after the head: the command copy alone must not count as a marker.
+    expect(localNodeHeadersFromOutput(failed(''))).toBeUndefined()
+  })
+
   it('distinguishes an exported dir, an explicit none, and no marker at all', () => {
     expect(localNodeHeadersFromOutput('x\nORCA-NODE-HEADERS:/usr/local\ngyp ERR!')).toBe(
       '/usr/local'

--- a/src/main/ssh/ssh-relay-node-headers.test.ts
+++ b/src/main/ssh/ssh-relay-node-headers.test.ts
@@ -98,6 +98,26 @@ describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
     expect(nodedir).toBe(dirname(dirname(process.execPath)))
   })
 
+  it('clears an inherited nodedir when the probe finds no matching headers', () => {
+    // A remote profile's stale nodedir must not survive past the version check.
+    const root = mkdtempSync(join(tmpdir(), 'orca-node-headers-'))
+    roots.push(root)
+    const copied = join(root, 'bin', 'node')
+    mkdirSync(dirname(copied), { recursive: true })
+    spawnSync('cp', [process.execPath, copied])
+    const script = `${exportLocalNodeHeadersPrefix(copied)}printf '%s|%s' "$npm_config_nodedir" "$npm_package_config_node_gyp_nodedir"`
+    const result = spawnSync('/bin/sh', ['-c', script], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        npm_config_nodedir: '/usr/stale-headers',
+        npm_package_config_node_gyp_nodedir: '/usr/stale-headers'
+      }
+    })
+    expect(result.status).toBe(0)
+    expect(result.stdout.split('\n').at(-1)).toBe('|')
+  })
+
   it('does not fail the command line when node itself cannot run', () => {
     const script = `${exportLocalNodeHeadersPrefix('/nonexistent/node')}echo "after:$npm_config_nodedir"`
     const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' })

--- a/src/main/ssh/ssh-relay-node-headers.test.ts
+++ b/src/main/ssh/ssh-relay-node-headers.test.ts
@@ -1,0 +1,98 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import process from 'node:process'
+import { afterEach, describe, expect, it } from 'vitest'
+import { exportLocalNodeHeadersPrefix } from './ssh-relay-node-headers'
+
+const POSIX = process.platform !== 'win32'
+
+/** Runs the prefix under /bin/sh exactly as the relay does, then prints what node-gyp would see. */
+function runPrefix(nodePath: string): { nodedir: string; pkgNodedir: string } {
+  const script = `${exportLocalNodeHeadersPrefix(nodePath)}printf '%s\\n%s\\n' "$npm_config_nodedir" "$npm_package_config_node_gyp_nodedir"`
+  const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' })
+  expect(result.status).toBe(0)
+  const [nodedir = '', pkgNodedir = ''] = result.stdout.split('\n')
+  return { nodedir, pkgNodedir }
+}
+
+/** A fake `<prefix>/bin/node` whose `include/node/node_version.h` claims `version`. */
+function fakeNodePrefix(root: string, version: string): string {
+  const prefix = join(root, 'prefix')
+  mkdirSync(join(prefix, 'bin'), { recursive: true })
+  mkdirSync(join(prefix, 'include', 'node'), { recursive: true })
+  const [major, minor, patch] = version.split('.')
+  writeFileSync(
+    join(prefix, 'include', 'node', 'node_version.h'),
+    `#define NODE_MAJOR_VERSION ${major}\n#define NODE_MINOR_VERSION ${minor}\n#define NODE_PATCH_VERSION ${patch}\n`
+  )
+  // Why a symlink to the real binary: the probe reads process.execPath, which Node resolves
+  // through symlinks -- so this stands in for `/usr/bin/node -> /opt/node/bin/node` shims too.
+  symlinkSync(process.execPath, join(prefix, 'bin', 'node'))
+  return join(prefix, 'bin', 'node')
+}
+
+describe.skipIf(!POSIX)('exportLocalNodeHeadersPrefix', () => {
+  const roots: string[] = []
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('exports nodedir when the running Node ships headers for its own version', () => {
+    // The test runner's Node is an official build, so its prefix has include/node.
+    const prefix = dirname(dirname(process.execPath))
+    const { nodedir, pkgNodedir } = runPrefix(process.execPath)
+    expect(nodedir).toBe(prefix)
+    expect(pkgNodedir).toBe(prefix)
+  })
+
+  it('leaves nodedir unset when the shipped headers are for another Node version', () => {
+    // A symlinked node resolves execPath to the real binary, whose prefix is the real one; so
+    // to stage a mismatch the probe must run a node whose execPath lands in the fake prefix.
+    // A copy does that.
+    const root = mkdtempSync(join(tmpdir(), 'orca-node-headers-'))
+    roots.push(root)
+    const prefix = join(root, 'prefix')
+    mkdirSync(join(prefix, 'bin'), { recursive: true })
+    mkdirSync(join(prefix, 'include', 'node'), { recursive: true })
+    writeFileSync(
+      join(prefix, 'include', 'node', 'node_version.h'),
+      '#define NODE_MAJOR_VERSION 1\n#define NODE_MINOR_VERSION 0\n#define NODE_PATCH_VERSION 0\n'
+    )
+    const copied = join(prefix, 'bin', 'node')
+    spawnSync('cp', [process.execPath, copied])
+    const { nodedir, pkgNodedir } = runPrefix(copied)
+    expect(nodedir).toBe('')
+    expect(pkgNodedir).toBe('')
+  })
+
+  it('leaves nodedir unset when the prefix has no headers at all', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-node-headers-'))
+    roots.push(root)
+    const copied = join(root, 'bin', 'node')
+    mkdirSync(dirname(copied), { recursive: true })
+    spawnSync('cp', [process.execPath, copied])
+    const { nodedir } = runPrefix(copied)
+    expect(nodedir).toBe('')
+  })
+
+  it('follows a symlinked node to the install that owns the headers', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-node-headers-'))
+    roots.push(root)
+    const shim = fakeNodePrefix(root, '0.0.0')
+    // The shim's own fake headers are ignored: execPath resolves to the real binary, and the
+    // real prefix's headers are the ones that match.
+    const { nodedir } = runPrefix(shim)
+    expect(nodedir).toBe(dirname(dirname(process.execPath)))
+  })
+
+  it('does not fail the command line when node itself cannot run', () => {
+    const script = `${exportLocalNodeHeadersPrefix('/nonexistent/node')}echo "after:$npm_config_nodedir"`
+    const result = spawnSync('/bin/sh', ['-c', script], { encoding: 'utf8' })
+    expect(result.status).toBe(0)
+    expect(result.stdout.trim()).toBe('after:')
+  })
+})

--- a/src/main/ssh/ssh-relay-node-headers.ts
+++ b/src/main/ssh/ssh-relay-node-headers.ts
@@ -1,0 +1,52 @@
+/**
+ * Point node-gyp at the headers the host's Node install already ships, so compiling node-pty
+ * needs nothing from nodejs.org.
+ *
+ * Why: node-pty has no Linux prebuild, so every Linux relay compiles it, and node-gyp's default
+ * is to download `node-v<ver>-headers.tar.gz` before configuring. Every official Node build, and
+ * every version manager that unpacks one (nvm, fnm, volta, mise, n), already has those exact
+ * headers at `<prefix>/include/node`. The download was the only step that needed the internet,
+ * so a firewalled host failed with ECONNREFUSED on work that never had to happen (STA-6674).
+ *
+ * Why both variables: node-gyp >= 11.4 prefers `npm_package_config_node_gyp_<key>` and npm 11+
+ * warns that arbitrary `npm_config_<key>` is deprecated, but node-gyp 10 (bundled with Node 20)
+ * reads only `npm_config_<key>`. Both together cover every Node the relay runs on.
+ *
+ * Why the version check: node-gyp trusts `nodedir` blindly. A distro `/usr/include/node` left by
+ * an older headers package would compile a binding for the wrong ABI, which loads and crashes
+ * instead of failing at install. A mismatch leaves the variables unset, which is today's path.
+ */
+import { shellEscape } from './ssh-connection-utils'
+
+/** Shell variable the probe answers into; namespaced so it cannot collide with npm's own. */
+const NODEDIR_SHELL_VAR = 'ORCA_NODE_HEADERS_DIR'
+
+/**
+ * Prints the running Node's install prefix when `<prefix>/include/node/node_version.h` matches
+ * `process.versions.node`, and nothing otherwise. `process.execPath` is symlink-resolved, so a
+ * `/usr/bin/node` -> `/opt/node/bin/node` shim still finds `/opt/node/include`.
+ */
+export const LOCAL_NODE_HEADERS_PROBE_JS = [
+  'const p=require("path"),f=require("fs");',
+  'const d=p.dirname(p.dirname(process.execPath));',
+  'try{',
+  'const h=f.readFileSync(p.join(d,"include","node","node_version.h"),"utf8");',
+  'const v=["MAJOR","MINOR","PATCH"].map(k=>(h.match(new RegExp("#define NODE_"+k+"_VERSION ([0-9]+)"))||[])[1]).join(".");',
+  'if(v===process.versions.node)process.stdout.write(d)',
+  '}catch{}'
+].join('')
+
+/**
+ * POSIX-sh prefix (`...; `) that exports node-gyp's `nodedir` for the rest of the command line
+ * when the host's Node ships matching headers. Prepend to any command that may compile node-pty:
+ * `npm install`, `npm rebuild`, and the cloexec patch (its `npm rebuild` inherits the env).
+ */
+export function exportLocalNodeHeadersPrefix(nodePath: string): string {
+  const probe = `${shellEscape(nodePath)} -e ${shellEscape(LOCAL_NODE_HEADERS_PROBE_JS)} 2>/dev/null`
+  return (
+    `${NODEDIR_SHELL_VAR}=$(${probe}); ` +
+    `if [ -n "$${NODEDIR_SHELL_VAR}" ]; then ` +
+    `export npm_config_nodedir="$${NODEDIR_SHELL_VAR}" npm_package_config_node_gyp_nodedir="$${NODEDIR_SHELL_VAR}"; ` +
+    `fi; `
+  )
+}

--- a/src/main/ssh/ssh-relay-node-headers.ts
+++ b/src/main/ssh/ssh-relay-node-headers.ts
@@ -12,9 +12,10 @@
  * warns that arbitrary `npm_config_<key>` is deprecated, but node-gyp 10 (bundled with Node 20)
  * reads only `npm_config_<key>`. Both together cover every Node the relay runs on.
  *
- * Why the version check: node-gyp trusts `nodedir` blindly. A distro `/usr/include/node` left by
- * an older headers package would compile a binding for the wrong ABI, which loads and crashes
- * instead of failing at install. A mismatch leaves the variables unset, which is today's path.
+ * Why the version check: node-gyp trusts `nodedir` blindly, so a distro `/usr/include/node` left
+ * by an older headers package would be compiled against as-is. Whether that binding then misbehaves
+ * is not established (one measured run loaded a node-20-header build under node 24); refusing is
+ * the conservative default. A mismatch leaves the variables unset, which is today's path.
  */
 import { shellEscape } from './ssh-connection-utils'
 
@@ -50,8 +51,8 @@ export const LOCAL_NODE_HEADERS_MARKER_PREFIX = 'ORCA-NODE-HEADERS:'
 export function exportLocalNodeHeadersPrefix(nodePath: string): string {
   const probe = `${shellEscape(nodePath)} -e ${shellEscape(LOCAL_NODE_HEADERS_PROBE_JS)} 2>/dev/null`
   // Why the unset: a remote profile can already export a nodedir (a stale distro header dir), in
-  // either case npm accepts. Left alone it would bypass the version check above and build a
-  // wrong-ABI binding. Deliberately env only: a `nodedir=` in ~/.npmrc is not reachable from here
+  // either case npm accepts. Left alone it would bypass the version check above and compile
+  // against those headers. Deliberately env only: a `nodedir=` in ~/.npmrc is not reachable from here
   // -- npm ignores an empty env override, and a CLI `--nodedir=` would also override the good
   // export -- so an npmrc setting stays the operator's, as it was before this prefix existed.
   return (

--- a/src/main/ssh/ssh-relay-node-headers.ts
+++ b/src/main/ssh/ssh-relay-node-headers.ts
@@ -49,11 +49,14 @@ export const LOCAL_NODE_HEADERS_MARKER_PREFIX = 'ORCA-NODE-HEADERS:'
  */
 export function exportLocalNodeHeadersPrefix(nodePath: string): string {
   const probe = `${shellEscape(nodePath)} -e ${shellEscape(LOCAL_NODE_HEADERS_PROBE_JS)} 2>/dev/null`
-  // Why the unset: a remote profile can already carry a nodedir (a stale distro header dir, an old
-  // ~/.npmrc). Left alone it would bypass the version check above and build a wrong-ABI binding.
+  // Why the unset: a remote profile can already export a nodedir (a stale distro header dir), in
+  // either case npm accepts. Left alone it would bypass the version check above and build a
+  // wrong-ABI binding. Deliberately env only: a `nodedir=` in ~/.npmrc is not reachable from here
+  // -- npm ignores an empty env override, and a CLI `--nodedir=` would also override the good
+  // export -- so an npmrc setting stays the operator's, as it was before this prefix existed.
   return (
     `${NODEDIR_SHELL_VAR}=$(${probe}); ` +
-    `unset npm_config_nodedir npm_package_config_node_gyp_nodedir; ` +
+    `unset npm_config_nodedir NPM_CONFIG_NODEDIR npm_package_config_node_gyp_nodedir; ` +
     `if [ -n "$${NODEDIR_SHELL_VAR}" ]; then ` +
     `export npm_config_nodedir="$${NODEDIR_SHELL_VAR}" npm_package_config_node_gyp_nodedir="$${NODEDIR_SHELL_VAR}"; ` +
     `fi; ` +
@@ -66,9 +69,15 @@ export function exportLocalNodeHeadersPrefix(nodePath: string): string {
  * marker is absent (output truncated, or the command never reached the prefix).
  */
 export function localNodeHeadersFromOutput(output: string): string | null | undefined {
-  // Why not line-anchored: a failed exec's message prepends `Command "..." failed (exit N): ` to
-  // the first output line, and the marker is that line.
-  for (const line of output.split(/\r?\n/)) {
+  // Why the head is stripped first: a failed exec's message is `Command "<command>" failed
+  // (exit N): <output>`, and <command> quotes this prefix verbatim -- including the marker's
+  // `echo`. Scanning from the start would match that copy and return `${ORCA_NODE_HEADERS_DIR:-
+  // none}"...` as a "dir". Only what follows the head is the host's answer.
+  const head = output.match(EXEC_FAILURE_HEAD_RE)
+  const hostOutput = head ? output.slice(head[0].length) : output
+  // First match, not last: the host's own line comes first, and later lines are npm/gyp output
+  // that must not be able to spoof it.
+  for (const line of hostOutput.split(/\r?\n/)) {
     const at = line.indexOf(LOCAL_NODE_HEADERS_MARKER_PREFIX)
     if (at === -1) {
       continue
@@ -78,3 +87,6 @@ export function localNodeHeadersFromOutput(output: string): string | null | unde
   }
   return undefined
 }
+
+/** `Command "<anything, quotes included>" failed (exit N): ` -- see ssh-relay-exec-command.ts. */
+const EXEC_FAILURE_HEAD_RE = /^Command "[\s\S]*?" failed \(exit -?\d+\): /

--- a/src/main/ssh/ssh-relay-node-headers.ts
+++ b/src/main/ssh/ssh-relay-node-headers.ts
@@ -37,6 +37,12 @@ export const LOCAL_NODE_HEADERS_PROBE_JS = [
 ].join('')
 
 /**
+ * Stdout marker naming what the probe found, printed before the compile so the answer is in the
+ * captured output of any failure that follows. `none` means no matching local headers.
+ */
+export const LOCAL_NODE_HEADERS_MARKER_PREFIX = 'ORCA-NODE-HEADERS:'
+
+/**
  * POSIX-sh prefix (`...; `) that exports node-gyp's `nodedir` for the rest of the command line
  * when the host's Node ships matching headers. Prepend to any command that may compile node-pty:
  * `npm install`, `npm rebuild`, and the cloexec patch (its `npm rebuild` inherits the env).
@@ -47,6 +53,25 @@ export function exportLocalNodeHeadersPrefix(nodePath: string): string {
     `${NODEDIR_SHELL_VAR}=$(${probe}); ` +
     `if [ -n "$${NODEDIR_SHELL_VAR}" ]; then ` +
     `export npm_config_nodedir="$${NODEDIR_SHELL_VAR}" npm_package_config_node_gyp_nodedir="$${NODEDIR_SHELL_VAR}"; ` +
-    `fi; `
+    `fi; ` +
+    `echo "${LOCAL_NODE_HEADERS_MARKER_PREFIX}\${${NODEDIR_SHELL_VAR}:-none}"; `
   )
+}
+
+/**
+ * The headers dir the prefix exported, `null` when it found none, or `undefined` when the
+ * marker is absent (output truncated, or the command never reached the prefix).
+ */
+export function localNodeHeadersFromOutput(output: string): string | null | undefined {
+  // Why not line-anchored: a failed exec's message prepends `Command "..." failed (exit N): ` to
+  // the first output line, and the marker is that line.
+  for (const line of output.split(/\r?\n/)) {
+    const at = line.indexOf(LOCAL_NODE_HEADERS_MARKER_PREFIX)
+    if (at === -1) {
+      continue
+    }
+    const dir = line.slice(at + LOCAL_NODE_HEADERS_MARKER_PREFIX.length).trim()
+    return dir === 'none' || dir === '' ? null : dir
+  }
+  return undefined
 }

--- a/src/main/ssh/ssh-relay-node-headers.ts
+++ b/src/main/ssh/ssh-relay-node-headers.ts
@@ -49,8 +49,11 @@ export const LOCAL_NODE_HEADERS_MARKER_PREFIX = 'ORCA-NODE-HEADERS:'
  */
 export function exportLocalNodeHeadersPrefix(nodePath: string): string {
   const probe = `${shellEscape(nodePath)} -e ${shellEscape(LOCAL_NODE_HEADERS_PROBE_JS)} 2>/dev/null`
+  // Why the unset: a remote profile can already carry a nodedir (a stale distro header dir, an old
+  // ~/.npmrc). Left alone it would bypass the version check above and build a wrong-ABI binding.
   return (
     `${NODEDIR_SHELL_VAR}=$(${probe}); ` +
+    `unset npm_config_nodedir npm_package_config_node_gyp_nodedir; ` +
     `if [ -n "$${NODEDIR_SHELL_VAR}" ]; then ` +
     `export npm_config_nodedir="$${NODEDIR_SHELL_VAR}" npm_package_config_node_gyp_nodedir="$${NODEDIR_SHELL_VAR}"; ` +
     `fi; ` +

--- a/src/main/ssh/ssh-relay-node-headers.ts
+++ b/src/main/ssh/ssh-relay-node-headers.ts
@@ -89,5 +89,9 @@ export function localNodeHeadersFromOutput(output: string): string | null | unde
   return undefined
 }
 
-/** `Command "<anything, quotes included>" failed (exit N): ` -- see ssh-relay-exec-command.ts. */
+/**
+ * `Command "<anything, quotes included>" failed (exit N): ` -- see ssh-relay-exec-command.ts.
+ * Lazy `[\s\S]*?` is safe: it stops at the first `" failed (exit N): `, and no command this
+ * module builds contains that literal, so the match cannot end early inside the command.
+ */
 const EXEC_FAILURE_HEAD_RE = /^Command "[\s\S]*?" failed \(exit -?\d+\): /

--- a/src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
+++ b/src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
@@ -176,5 +176,29 @@ describe.skipIf(!RUN_REVIEW_ORACLE)(
         await connection.disconnect()
       }
     }, 600_000)
+
+    it('names the missing-local-headers cause, not an Orca defect, when the host ships no headers', async () => {
+      // Same offline host, headers removed and the relay uninstalled so the deploy compiles again.
+      // This is the shape a review found misreported: the exec-failure message quotes the whole
+      // command (marker echo included) ahead of the output, and the parser must not read that copy.
+      const activeFixture = fixture as TargetFixture
+      dockerExec(
+        activeFixture,
+        'rm -rf /usr/local/include/node /root/.orca-remote /root/.cache/node-gyp'
+      )
+      const connection = createConnection(activeFixture)
+      await connection.connect()
+      try {
+        const error = await deployAndLaunchRelay(connection, undefined, 60).catch((e: Error) => e)
+        expect(error).toBeInstanceOf(Error)
+        const message = (error as Error).message
+        console.log(`[offline-node-headers] ${NODE_IMAGE} no-headers: ${message.split('\n')[0]}`)
+        expect(message).toContain('no local headers matching its own version')
+        expect(message).not.toContain('Orca defect')
+        expect(message).toContain('ECONNREFUSED')
+      } finally {
+        await connection.disconnect()
+      }
+    }, 600_000)
   }
 )

--- a/src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
+++ b/src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
@@ -11,6 +11,7 @@
 import { execFileSync, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { connect } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
@@ -45,7 +46,7 @@ function dockerExec(fixture: TargetFixture, command: string): string {
   return run('docker', ['exec', fixture.containerName, 'bash', '-lc', command], 60_000)
 }
 
-function startTarget(): TargetFixture {
+async function startTarget(): Promise<TargetFixture> {
   const image = `orca-review-offline-headers:${NODE_IMAGE.replace(/[^A-Za-z0-9_.-]/g, '-')}`
   run(
     'docker',
@@ -85,7 +86,33 @@ function startTarget(): TargetFixture {
     120_000
   )
   const port = Number(run('docker', ['port', containerName, '22/tcp']).split(':').at(-1))
+  // `docker run -d` returns before sshd binds; connect() against a closed port is a flake.
+  await waitForSshBanner(port)
   return { containerName, identityFile, port, tempDir }
+}
+
+/** Resolves once sshd answers with its banner on the mapped port, or throws after the deadline. */
+async function waitForSshBanner(port: number, deadlineMs = 60_000): Promise<void> {
+  const deadline = Date.now() + deadlineMs
+  for (;;) {
+    const gotBanner = await new Promise<boolean>((resolve) => {
+      const socket = connect({ host: TARGET_HOST, port })
+      const done = (value: boolean): void => {
+        socket.destroy()
+        resolve(value)
+      }
+      socket.setTimeout(2_000, () => done(false))
+      socket.once('data', (chunk) => done(chunk.toString('utf8').startsWith('SSH-')))
+      socket.once('error', () => done(false))
+    })
+    if (gotBanner) {
+      return
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`sshd on port ${port} did not answer within ${deadlineMs / 1000}s`)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500))
+  }
 }
 
 function stopTarget(fixture: TargetFixture | null): void {
@@ -115,8 +142,8 @@ describe.skipIf(!RUN_REVIEW_ORACLE)(
   () => {
     let fixture: TargetFixture | null = null
 
-    beforeAll(() => {
-      fixture = startTarget()
+    beforeAll(async () => {
+      fixture = await startTarget()
     }, 900_000)
 
     afterAll(() => {

--- a/src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
+++ b/src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
@@ -1,0 +1,153 @@
+// Why this exists (STA-6674): a Linux host whose only unreachable endpoint is nodejs.org could
+// not run a relay. node-pty ships no Linux prebuild, so npm hands it to node-gyp, and node-gyp
+// downloads `node-v<ver>-headers.tar.gz` unless told the host already has the headers -- which
+// every official Node install does, at `<prefix>/include/node`. This drives the real deploy at a
+// Docker sshd whose nodejs.org resolves to 127.0.0.1 (ECONNREFUSED, exactly what the user saw).
+//
+// Run: ORCA_REVIEW_SSH_OFFLINE_HEADERS=1 pnpm test src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts
+// Needs Docker and `pnpm build:relay`. ORCA_REVIEW_SSH_NODE_IMAGE picks the Node image
+// (default node:24.12.0-bookworm, the user's version); ORCA_REVIEW_SSH_TARGET_HOST overrides
+// the address the app connects to (default 127.0.0.1).
+import { execFileSync, spawnSync } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ app: { getAppPath: () => process.cwd() } }))
+
+import { SshConnection } from './ssh-connection'
+import { deployAndLaunchRelay } from './ssh-relay-deploy'
+import type { SshTarget } from '../../shared/ssh-types'
+
+const RUN_REVIEW_ORACLE = process.env.ORCA_REVIEW_SSH_OFFLINE_HEADERS === '1'
+const NODE_IMAGE = process.env.ORCA_REVIEW_SSH_NODE_IMAGE ?? 'node:24.12.0-bookworm'
+const TARGET_HOST = process.env.ORCA_REVIEW_SSH_TARGET_HOST ?? '127.0.0.1'
+
+type TargetFixture = {
+  containerName: string
+  identityFile: string
+  port: number
+  tempDir: string
+}
+
+function run(command: string, args: string[], timeout = 30_000, input?: string): string {
+  return execFileSync(command, args, {
+    encoding: 'utf8',
+    stdio: [input === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'],
+    timeout,
+    input
+  }).trim()
+}
+
+function dockerExec(fixture: TargetFixture, command: string): string {
+  return run('docker', ['exec', fixture.containerName, 'bash', '-lc', command], 60_000)
+}
+
+function startTarget(): TargetFixture {
+  const image = `orca-review-offline-headers:${NODE_IMAGE.replace(/[^A-Za-z0-9_.-]/g, '-')}`
+  run(
+    'docker',
+    ['build', '-q', '-t', image, '-'],
+    600_000,
+    [
+      `FROM ${NODE_IMAGE}`,
+      'RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends openssh-server git && rm -rf /var/lib/apt/lists/* && mkdir -p /run/sshd /root/.ssh && chmod 700 /root/.ssh',
+      ''
+    ].join('\n')
+  )
+  const tempDir = mkdtempSync(join(tmpdir(), 'orca-offline-headers-ssh-'))
+  const identityFile = join(tempDir, 'id_ed25519')
+  run('ssh-keygen', ['-t', 'ed25519', '-N', '', '-f', identityFile, '-q'])
+  const publicKey = readFileSync(`${identityFile}.pub`, 'utf8').trim()
+  const containerName = `orca-offline-headers-${randomUUID().slice(0, 12)}`
+  // Why a refused connection and not a dropped one: a timeout takes node-gyp's retry path and
+  // burns the deploy budget; the user's host refused, and that is the path under test.
+  run(
+    'docker',
+    [
+      'run',
+      '-d',
+      '--name',
+      containerName,
+      '--add-host',
+      'nodejs.org:127.0.0.1',
+      '-p',
+      '0.0.0.0::22',
+      '-e',
+      `AUTHORIZED_KEY=${publicKey}`,
+      image,
+      'bash',
+      '-lc',
+      'printf "%s\\n" "$AUTHORIZED_KEY" > /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys && exec /usr/sbin/sshd -D -e'
+    ],
+    120_000
+  )
+  const port = Number(run('docker', ['port', containerName, '22/tcp']).split(':').at(-1))
+  return { containerName, identityFile, port, tempDir }
+}
+
+function stopTarget(fixture: TargetFixture | null): void {
+  if (!fixture) {
+    return
+  }
+  spawnSync('docker', ['rm', '-f', fixture.containerName], { stdio: 'ignore', timeout: 30_000 })
+  rmSync(fixture.tempDir, { recursive: true, force: true })
+}
+
+function createConnection(fixture: TargetFixture): SshConnection {
+  const target: SshTarget = {
+    id: `offline-headers-${randomUUID()}`,
+    label: 'Offline node headers Docker SSH target',
+    source: 'manual',
+    host: TARGET_HOST,
+    port: fixture.port,
+    username: 'root',
+    identityFile: fixture.identityFile,
+    identitiesOnly: true
+  }
+  return new SshConnection(target, { onStateChange: vi.fn() })
+}
+
+describe.skipIf(!RUN_REVIEW_ORACLE)(
+  'SSH relay deploy on a host that cannot reach nodejs.org',
+  () => {
+    let fixture: TargetFixture | null = null
+
+    beforeAll(() => {
+      fixture = startTarget()
+    }, 900_000)
+
+    afterAll(() => {
+      stopTarget(fixture)
+    })
+
+    it('compiles node-pty from the host Node install headers instead of downloading them', async () => {
+      const activeFixture = fixture as TargetFixture
+      expect(dockerExec(activeFixture, 'getent hosts nodejs.org')).toContain('127.0.0.1')
+      const connection = createConnection(activeFixture)
+      await connection.connect()
+      try {
+        const result = await deployAndLaunchRelay(connection, undefined, 60)
+        expect(result.remoteRelayDir).toBeTruthy()
+
+        const evidence = dockerExec(
+          activeFixture,
+          [
+            `cd '${result.remoteRelayDir}'`,
+            'test -f node_modules/node-pty/build/Release/pty.node && echo PTY_NODE=built',
+            'test -d /root/.cache/node-gyp && echo HEADERS=downloaded || echo HEADERS=local',
+            `node -e "require('node-pty'); require('@parcel/watcher'); console.log('NATIVE=loadable')"`
+          ].join('; ')
+        )
+        console.log(`[offline-node-headers] ${NODE_IMAGE}: ${evidence.replace(/\n/g, ' ')}`)
+        expect(evidence).toContain('PTY_NODE=built')
+        expect(evidence).toContain('HEADERS=local')
+        expect(evidence).toContain('NATIVE=loadable')
+      } finally {
+        await connection.disconnect()
+      }
+    }, 600_000)
+  }
+)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​501 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​501 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​186 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |

<!-- /orca-pr-loc -->

Fixes STA-6674 ("Unable to connect to remote SSH"): https://linear.app/stably/issue/STA-6674

## What the user hit

Target `root@10.131.137.248:22` stuck **Disconnected**. Their log:

```
npm error gyp info using node@24.12.0 | linux | x64
npm error gyp http GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz
npm error gyp http fetch GET ... attempt 1 failed with ECONNREFUSED
npm error gyp ERR! configure error
npm error gyp ERR! cwd /root/.orca-remote/relay-0.1.0+8ea4ce15e4c7/node_modules/node-pty
```

## Root cause

node-pty 1.1.0 ships prebuilds only for `darwin-*` and `win32-*`. On every Linux relay host, `npm install` therefore falls through to `node-gyp rebuild`, and **node-gyp's default first step is to download `node-v<ver>-headers.tar.gz` from nodejs.org**. The user's host refuses outbound connections to nodejs.org, so the relay's native-deps install fails before compiling anything and the deploy aborts.

The download is unnecessary. Every official Node build, and every version manager that unpacks one (nvm, fnm, volta, mise, n), already has those exact headers at `<prefix>/include/node`. node-gyp only uses them when told to via `nodedir`; nothing in the relay told it. (Node's own `use_prefix_to_find_headers` shortcut is off in official builds — checked in the `node:24.12.0` image.)

This is not a prebuild-matrix gap. `MATRIX_SLOTS` / `node-pty-prebuilt-slot.ts` belong to the orcad daemon deploy and pin a different Node ABI; the SSH relay has always compiled node-pty on the host by design (`TODO(#1693)` in `ssh-relay-deploy.ts`). Every Linux relay deploy has been downloading headers from nodejs.org; this is the first host that couldn't. Not fixed on `main` (`df7b1028ddd`): the install command was unchanged since #8686.

## Fix

- **`ssh-relay-node-headers.ts`** (new): a POSIX prefix that runs the remote `node` once, unsets any inherited `npm_config_nodedir` / `NPM_CONFIG_NODEDIR` / `npm_package_config_node_gyp_nodedir` (a stale dir exported by the remote profile must not bypass the version check; a `~/.npmrc` `nodedir=` is out of reach from the env and stays the operator's, as before), and if `<prefix>/include/node/node_version.h` matches `process.versions.node`, exports `npm_config_nodedir` and `npm_package_config_node_gyp_nodedir` to that prefix, then echoes `ORCA-NODE-HEADERS:<dir|none>` into the command output.
- **`ssh-relay-deploy.ts`**: prepend it to every command that can compile node-pty — `npm install`, `npm rebuild`, and the cloexec patch (whose `npm rebuild` inherits the env). Not the Windows branch (prebuilt) and not `installNativeDepsWithoutNodePty` (nothing to compile).
- **`build-toolchain-diagnosis.ts`**: a node-gyp header-download failure is now named in the deploy error instead of 40 lines of `gyp http`, with the remedy depending on what the prefix found (see below). This reaches the settings toast via `ssh:connect`'s rejection; the card status itself is unchanged (separate renderer change).

## What this does and does not fix — read this

**Fixed:** a Linux host with no route to nodejs.org whose Node install ships its own headers (official tarball/installer, nvm, fnm, volta, mise, n, the `node:*` Docker images). This is the common case and the user's case (`/usr/local/nodejs/bin/node`, an official layout).

**Not fixed, but now diagnosed:** a host with no route to nodejs.org whose Node ships **no** headers, or headers for a **different** version (e.g. a distro `nodejs` package with a stale `/usr/include/node`). The prefix deliberately leaves `nodedir` unset on a mismatch — node-gyp trusts `nodedir` blindly, and compiling against another version's headers is not something this PR wants to vouch for. (Inference, not measured: an independent run built node-pty against node 20 headers and it loaded under node 24 via node-addon-api, so a mismatch may often be benign; refusing is the conservative default, not an observed crash.) That host still fails, but the error now says: "Node install has no local headers matching its own version … install an official Node build or a version manager, or allow nodejs.org / set `disturl`". The same diagnosis is logged from the non-fatal `npm rebuild` fallback. Offline hosts are not universally fine after this PR; header-shipping offline hosts are.

**The two env var names, and what happens if a future npm stops forwarding them.** node-gyp reads `npm_config_<key>` (all versions) and, from 11.4, prefers `npm_package_config_node_gyp_<key>`. Verified today that npm 10.8 / 11.6 / 11.19 / 12.0 all forward both pre-set variables into lifecycle scripts (node-gyp 10.1 / 11.4 / 12.4 / 13.0). If a future npm drops the passthrough, node-gyp would silently fall back to downloading — so the prefix's `ORCA-NODE-HEADERS:` marker is read back on failure: **an exported dir followed by a download attempt is reported as an Orca defect naming the dir** ("Orca pointed node-gyp at `/usr/local/include/node`; node-gyp ignored that setting; please report"), not as a host problem. It cannot fail silently into the wrong diagnosis; it fails loudly and correctly attributed. On a host with network it would still succeed via download either way.

## Reproduction (Docker)

`src/main/ssh/ssh-relay-offline-node-headers.docker.test.ts` (two cases: the fix on a header-shipping host, and the diagnosis on the same host with `/usr/local/include/node` removed) — gated on `ORCA_REVIEW_SSH_OFFLINE_HEADERS=1` like the existing `ssh-relay-upload-cancel.docker.test.ts`. Builds `node:<ver>-bookworm` + sshd, runs it with `--add-host nodejs.org:127.0.0.1` (a **refused** connection, matching the user; a dropped one takes node-gyp's retry path), and drives the real `deployAndLaunchRelay` at it.

**Before the fix** (same test, unfixed `main`, `node:24.12.0-bookworm`):
```
[ssh-relay][NATIVE-DEPS-INSTALL-FAIL] npm install native deps failed at /root/.orca-remote/relay-0.1.0+68070d120624 (linux-arm64): ...
npm error gyp http fetch GET https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz attempt 1 failed with ECONNREFUSED
npm error gyp ERR! stack FetchError: request to https://nodejs.org/download/release/v24.12.0/node-v24.12.0-headers.tar.gz failed, reason: connect ECONNREFUSED 127.0.0.1:443
 × compiles node-pty from the host Node install headers instead of downloading them
```

**After** — deploy succeeds, `pty.node` is built, `~/.cache/node-gyp` never appears (no download), both addons load:

| image | npm | node-gyp | result |
|---|---|---|---|
| `node:24.12.0-bookworm` (user's version) | 11.6.2 | 11.4.2 | pass |
| `node:20-bookworm` | 10.8.2 | 10.1.0 | pass |
| `node:26-bookworm` | 11.19.0 | 12.4.0 | pass |

## Tests

- `ssh-relay-node-headers.test.ts`: runs the real prefix under `/bin/sh` — exports on a matching install and emits the marker; the parser reads the host answer past an `execCommand` failure head that quotes the whole prefix; stays unset (marker `none`) on a version mismatch, on no headers, and when `node` can't run; follows a symlinked shim to the owning install; the marker parser distinguishes dir / none / absent.
- `ssh-relay-native-deps-install-staged-upload.test.ts`: the export and marker precede each of the three compile commands; the header-download failure is named without probing the toolchain; an exported dir plus a download is reported as an Orca defect.
- `ssh-relay-build-toolchain.test.ts`: the diagnosis matches the verbatim STA-6674 output (requires `gyp ERR! configure error` plus a network errno) and not registry failures, a recovered retry followed by a compile error, or a mirror 404; both message variants.

Revert-tested by mutating each specific regression, not the whole change: not stripping the exec-failure head before the marker scan (fails the parser test and the deploy-level "host ships none" test), dropping the uppercase `unset`, dropping the export from `npm rebuild` alone, dropping the version check alone, dropping the diagnosis branch alone, ignoring the marker when formatting, not emitting the marker, dropping the `unset`, and dropping the configure-error requirement each fail exactly the test that claims to pin it.

`pnpm tc`, `oxlint`, `pnpm run check:code-quality:changed` clean; full `src/main/ssh` suite passes.

## Known residuals (noted, not chased)

- `execCommand` tail-caps output at 1 MiB and the `ORCA-NODE-HEADERS:` marker is the first line of stdout, so a failure log over 1 MiB loses the marker and the diagnosis falls back to `undefined` (treated as "no local headers"). Not seen in practice; a node-gyp failure log is tens of KB.
- The common case now goes through the local-headers path by design. A host whose `<prefix>/include/node` has a version-matching `node_version.h` but is otherwise incomplete would fail to compile where it used to download. Inferred, not measured; no such layout is known.
- A `nodedir=` in `~/.npmrc` is honoured as before this PR (measured: an empty env override does not beat npmrc on npm 10.8 / 11.6). Only exported env is cleared.

## Review

CodeRabbit (4) and pullfrog (1) findings on `d1209` are addressed in `609685e`. An independent Docker exercise of `609685e` then found the marker parser reading the quoted command in `execCommand`'s failure message rather than the host output, so every real no-headers failure was reported as an "Orca defect"; fixed in `2e1ee1c` with the unit fixture made to reject the way production does and a Docker no-headers case added. Each inline thread has a reply naming the fix and its pin.
