### PR TITLE
fix(relay-ops): retry freshness-only preflight failures on the first same-cap wave too

### DIFF
--- a/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
+++ b/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
@@ -181,11 +181,12 @@ jobs:
         env:
           ORCA_RELAY_ADMIN_ID_TOKEN: ${{ steps.deploy-auth.outputs.id_token }}
         run: |
-          RETRY_ARGS=()
-          if test "${WAVE_INDEX}" != 0; then RETRY_ARGS=(--retry-freshness); fi
+          # Freshness-only failures are publish lag, not health, on every wave
+          # including the first; the CLI still caps the retry at the wave's
+          # evidence-age budget, so this cannot mutate on aged evidence.
           pnpm incident:relay-preflight -- \
             --state-file "${OUTPUT_DIRECTORY}/relay-${MONITOR_RUN_ID}-dry-run.state.json" \
-            --wave-index "${WAVE_INDEX}" "${RETRY_ARGS[@]}"
+            --wave-index "${WAVE_INDEX}" --retry-freshness
 
       - name: Require durable rehome disabled and exact selector
         env:

--- a/cloud/apps/relay-ops/src/incident-live-preflight-cli.test.ts
+++ b/cloud/apps/relay-ops/src/incident-live-preflight-cli.test.ts
@@ -331,6 +331,39 @@ describe('relay incident live preflight', () => {
     expect(wait).toHaveBeenNthCalledWith(2, 15_000)
   })
 
+  it('retries a first-wave stale sample and passes on the fresh one', async () => {
+    const stale = sample()
+    stale.sources['cloud-monitoring']!.signals['cloud_sql.cpu']!.observedAt =
+      new Date(now - 180_001).toISOString()
+    const collect = vi.fn().mockResolvedValueOnce(stale).mockResolvedValueOnce(sample())
+    const wait = vi.fn(async () => undefined)
+    await expect(runIncidentLivePreflight(
+      ['--state-file', stateFile(), '--wave-index', '0', '--retry-freshness'],
+      { now: () => now, collect, wait }
+    )).resolves.toBeUndefined()
+    expect(collect).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledOnce()
+  })
+
+  it('stops retrying when the next wait would exceed the evidence-age bound', async () => {
+    const completedAt = now - 290_000
+    const stale = sample()
+    stale.sources['cloud-monitoring']!.observedAt = new Date(now - 180_001).toISOString()
+    const collect = vi.fn(async () => stale)
+    const wait = vi.fn(async () => undefined)
+    await expect(runIncidentLivePreflight(
+      ['--state-file', stateFile('strict', {
+        startedAt: new Date(completedAt - 17 * 60_000).toISOString(),
+        windowStartedAt: new Date(completedAt - 16 * 60_000).toISOString(),
+        lastSampleAt: new Date(completedAt - 30_000).toISOString(),
+        completedAt: new Date(completedAt).toISOString()
+      }), '--retry-freshness'],
+      { now: () => now, collect, wait }
+    )).rejects.toThrow('cloud-monitoring/source_stale')
+    expect(collect).toHaveBeenCalledOnce()
+    expect(wait).not.toHaveBeenCalled()
+  })
+
   it('does not retry a threshold failure', async () => {
     const unhealthy = sample()
     unhealthy.sources['cloud-monitoring']!.signals['cloud_sql.cpu']!.value = 0.9

--- a/cloud/apps/relay-ops/src/incident-live-preflight-cli.ts
+++ b/cloud/apps/relay-ops/src/incident-live-preflight-cli.ts
@@ -173,7 +173,11 @@ export async function runIncidentLivePreflight(
     const freshnessOnly = evaluation.failures.every((failure) =>
       FRESHNESS_FAILURE_CODES.has(failure.code)
     )
-    if (!freshnessOnly || attempt === attempts) {
+    // Waiting must never carry the mutation past the same evidence-age bound
+    // the entry check enforces, so the wave budget also caps the retry window.
+    const budgetExhausted =
+      now() + FRESHNESS_RETRY_INTERVAL_MS - completedAt > maxEvidenceAgeMs
+    if (!freshnessOnly || attempt === attempts || budgetExhausted) {
       throw new Error(
         `relay live preflight failed: ${evaluation.failures
           .map((failure) => `${failure.source}/${failure.code}`)

--- a/cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs
+++ b/cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs
@@ -92,7 +92,11 @@ test('same-cap wrapper is reusable, canary-bound, and sequential', () => {
   // age checks must scale by wave or cell_2+ can never pass; the bound's
   // per-wave step is the cell job timeout, so the two must move together.
   assert.match(job, /--required-migration-policy strict \\\n            --wave-index "\$\{WAVE_INDEX\}"/)
-  assert.match(job, /dry-run\.state\.json" \\\n            --wave-index "\$\{WAVE_INDEX\}" "\$\{RETRY_ARGS\[@\]\}"/)
+  // Wave 0 must retry freshness-only failures too: one Cloud Monitoring publish
+  // lag at the sample instant is not health evidence, and single-shot wave 0
+  // failed a whole batch on a series that was fresh again a minute later.
+  assert.match(job, /dry-run\.state\.json" \\\n            --wave-index "\$\{WAVE_INDEX\}" --retry-freshness/)
+  assert.doesNotMatch(job, /RETRY_ARGS/)
   assert.match(job, /timeout-minutes: 75/)
   // Both age gates step by the cell job timeout above; the constant is
   // duplicated across the two languages, so pin each copy to it.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## Problem

Run [33940290163](https://github.com/stablyai/orca/actions/runs/33940290163), job `cell_1 / rollout` for `production-gce-c10` (2026-09-05 02:54:39Z), failed the same-cap batch apply in **Recheck aggregate SQL, pool, reconnect, migration, and selector safety** with:

```
relay live preflight failed: cloud-monitoring/signal_stale
```

The step only passed `--retry-freshness` when `WAVE_INDEX != 0`, so the first cell of every batch was single-shot. One Cloud Monitoring publish lag over the 180 s signal bound at the sample instant killed the whole batch before any mutation. Every series was fresh again within a minute. The monitor gate itself hit the same publish lag twice earlier that day (`auth.errors` stale 181-255 s at 23:24Z and 23:25Z).

A publish lag is not a health signal, and wave 0 has no property that makes it more sensitive to one than waves 1-3.

## Change

- Drop the `WAVE_INDEX` condition in `.github/workflows/cloud-deploy-relay-production-same-cap-job.yml` so `--retry-freshness` is always passed. There was no documented rationale for the wave-0 carve-out; the only history is the cloud import squash (3eec77c11a) and no comment near the step.
- Cap the retry loop in `cloud/apps/relay-ops/src/incident-live-preflight-cli.ts` by the same evidence-age bound the entry check enforces. The bound was previously checked once, before the loop, so retrying could begin a mutation on monitor evidence older than the bound allows. The loop now stops when the next 15 s wait would push past `MONITOR_EVIDENCE_MAX_AGE_MS + waveIndex * WAVE_PREDECESSOR_TIMEOUT_MS`.

The CLI already accepted `--retry-freshness` at wave 0; the restriction was purely in the workflow. `freshnessRetryCount > 1` still rejects a duplicated flag, and the flag is passed exactly once.

## Freshness-bound math for wave 0

Wave 0 budget is `MONITOR_EVIDENCE_MAX_AGE_MS` = 300 s from `completedAt`. Canary dispatch is ~30 s after the gate goes green and the job's setup steps take ~2 min, so the preflight step starts at roughly 150 s of evidence age. The retry budget is 4 waits x 15 s = 60 s plus up to 5 collections; each collection fans out in parallel under a 30 s `AbortSignal.timeout`, so a typical collection is well under 10 s and the worst case is 30 s.

| case | age at step entry | retry cost | age at mutation |
|---|---|---|---|
| typical (8 s collections) | 150 s | 100 s | 250 s |
| worst (30 s collections) | 150 s | 210 s | 360 s |

The typical path fits inside 300 s. The worst case does not, which is why this PR bounds the loop rather than leaving the bound checked only at entry. **The bound value itself is unchanged.** If the entry age is already near 300 s the loop now fails on the first freshness failure instead of waiting, which is fail-closed and strictly better than the previous wave-0 behaviour of never retrying at all.

## Tests

- `cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs` now asserts the unconditional `--retry-freshness` and that `RETRY_ARGS` is gone.
- Two new cases in `cloud/apps/relay-ops/src/incident-live-preflight-cli.test.ts`: wave 0 with one stale sample followed by a fresh one passes after a single wait, and the loop stops without waiting when the next wait would exceed the evidence-age bound.

```
pnpm --filter @orca-cloud/relay-ops test   ->  12 files, 86 tests passed
node --test dev/scripts/*.test.mjs         ->  650 tests, 650 pass, 0 fail
```

`relay-load-control-peer.test.mjs` fails in a fresh worktree until `@orca-cloud/relay-contract` is built; it passes after `pnpm --filter @orca-cloud/relay-contract build` and is unrelated to this change.

## Not in this PR

`.github/workflows/cloud-deploy-relay-production-capacity-job.yml:416` has the identical wave-0 carve-out on its `continuation` evidence path, and its `single` evidence path (line ~400) never retries at all. Same root cause, different rollout workflow, no production failure evidence attached here. Worth a follow-up.