### PR TITLE
perf(terminal): cheap-tier process inspection for anchored local agent panes

### DIFF
--- a/src/main/daemon/daemon-foreground-process-protocol.ts
+++ b/src/main/daemon/daemon-foreground-process-protocol.ts
@@ -18,5 +18,7 @@ export type InspectProcessRequest = Omit<GetForegroundProcessRequest, 'type'> & 
   type: 'inspectProcess'
   payload: GetForegroundProcessRequest['payload'] & {
     expectedIncarnationId?: string
+    /** Optional; a daemon that predates it answers with the full capture as it always did. */
+    steadyState?: boolean
   }
 }

--- a/src/main/daemon/daemon-pty-adapter-steady-state-compat.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-steady-state-compat.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION, PROTOCOL_VERSION } from './types'
+
+type ClientInternals = {
+  client: { request: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }
+}
+
+function createAdapter(
+  protocolVersion: number,
+  request: ReturnType<typeof vi.fn>
+): DaemonPtyAdapter {
+  const adapter = new DaemonPtyAdapter({
+    socketPath: '/tmp/orca-steady-state-compat.sock',
+    tokenPath: '/tmp/orca-steady-state-compat.token',
+    protocolVersion
+  })
+  ;(adapter as unknown as ClientInternals).client = { request, disconnect: vi.fn() }
+  return adapter
+}
+
+describe('steadyState across daemon versions', () => {
+  it('sends steadyState as an additive optional field on the existing inspectProcess request', async () => {
+    const request = vi.fn(async () => ({ foregroundProcess: 'claude', hasChildProcesses: true }))
+    const adapter = createAdapter(PROTOCOL_VERSION, request)
+    await adapter.inspectProcess('sess-a', { steadyState: true })
+    expect(request).toHaveBeenCalledWith('inspectProcess', {
+      sessionId: 'sess-a',
+      steadyState: true
+    })
+    adapter.dispose()
+  })
+
+  it('omits the field entirely when not requested, so the wire is byte-identical to before', async () => {
+    const request = vi.fn(async () => ({ foregroundProcess: null, hasChildProcesses: false }))
+    const adapter = createAdapter(PROTOCOL_VERSION, request)
+    await adapter.inspectProcess('sess-a', { expectedIncarnationId: 'inc-1', steadyState: false })
+    expect(request).toHaveBeenCalledWith('inspectProcess', {
+      sessionId: 'sess-a',
+      expectedIncarnationId: 'inc-1'
+    })
+    adapter.dispose()
+  })
+
+  it('an old daemon that ignores steadyState still answers with the full-capture shape, and the client accepts it', async () => {
+    // A pre-field daemon returns exactly what it always did: name + evidence, never a cheap answer.
+    const oldDaemonAnswer = {
+      foregroundProcess: 'claude',
+      hasChildProcesses: true,
+      foregroundProcessEvidence: {
+        verdict: 'live',
+        processName: 'claude',
+        authorityGeneration: 'gen',
+        observationEpoch: 1,
+        capturedAgeMs: 0,
+        ptyId: 'sess-a',
+        ptyIncarnationId: 'inc-1'
+      }
+    }
+    const request = vi.fn(async () => oldDaemonAnswer)
+    const adapter = createAdapter(COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION, request)
+    await expect(adapter.inspectProcess('sess-a', { steadyState: true })).resolves.toEqual(
+      oldDaemonAnswer
+    )
+    adapter.dispose()
+  })
+
+  it('a pre-inspection daemon never sees the field: the client composes from getForegroundProcess as before', async () => {
+    const request = vi.fn(async () => ({ foregroundProcess: 'codex' }))
+    const adapter = createAdapter(COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION - 1, request)
+    await expect(adapter.inspectProcess('sess-a', { steadyState: true })).resolves.toEqual({
+      foregroundProcess: 'codex',
+      hasChildProcesses: true
+    })
+    expect(request).toHaveBeenCalledWith('getForegroundProcess', { sessionId: 'sess-a' })
+    adapter.dispose()
+  })
+})

--- a/src/main/daemon/daemon-pty-process-inspection.ts
+++ b/src/main/daemon/daemon-pty-process-inspection.ts
@@ -25,7 +25,7 @@ export abstract class DaemonPtyProcessInspection extends DaemonPtyBufferSnapshot
 
   async inspectProcess(
     id: string,
-    options?: { expectedIncarnationId?: string }
+    options?: { expectedIncarnationId?: string; steadyState?: boolean }
   ): Promise<PtyProcessInspection> {
     if (this.protocolVersion < GET_FOREGROUND_PROCESS_PROTOCOL_VERSION) {
       return clientOnlyUnverifiableInspection('old_host')
@@ -47,7 +47,9 @@ export abstract class DaemonPtyProcessInspection extends DaemonPtyBufferSnapshot
       sessionId: id,
       ...(options?.expectedIncarnationId
         ? { expectedIncarnationId: options.expectedIncarnationId }
-        : {})
+        : {}),
+      // Additive: an older daemon ignores it and pays for the full capture.
+      ...(options?.steadyState === true ? { steadyState: true } : {})
     })
   }
 

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -179,7 +179,7 @@ export class DaemonPtyRouter implements IPtyProvider {
 
   async inspectProcess(
     id: string,
-    options?: { expectedIncarnationId?: string }
+    options?: { expectedIncarnationId?: string; steadyState?: boolean }
   ): Promise<PtyProcessInspection> {
     return this.adapterForInspection(id).inspectProcess(id, options)
   }

--- a/src/main/daemon/daemon-request-router.ts
+++ b/src/main/daemon/daemon-request-router.ts
@@ -105,12 +105,17 @@ export class DaemonRequestRouter {
         return {
           foregroundProcess: this.options.host.getForegroundProcess(request.payload.sessionId)
         }
-      case 'inspectProcess':
-        return request.payload.expectedIncarnationId
-          ? this.options.host.inspectProcess(request.payload.sessionId, {
-              expectedIncarnationId: request.payload.expectedIncarnationId
-            })
+      case 'inspectProcess': {
+        const options = {
+          ...(request.payload.expectedIncarnationId
+            ? { expectedIncarnationId: request.payload.expectedIncarnationId }
+            : {}),
+          ...(request.payload.steadyState === true ? { steadyState: true } : {})
+        }
+        return Object.keys(options).length > 0
+          ? this.options.host.inspectProcess(request.payload.sessionId, options)
           : this.options.host.inspectProcess(request.payload.sessionId)
+      }
       case 'confirmForegroundProcess':
         return {
           foregroundProcess: await this.options.host.confirmForegroundProcess(

--- a/src/main/daemon/pty-subprocess/foreground-process-tracker.ts
+++ b/src/main/daemon/pty-subprocess/foreground-process-tracker.ts
@@ -36,7 +36,9 @@ type CachedAgentForeground = { processName: string; pid: number | null; refreshe
 export type PtyForegroundProcessTracker = {
   recordOutput(data: string): void
   markDead(): void
-  getForegroundProcess(): string | null
+  /** `rawFallback`: node-pty's own name only, with no identity cache and no background
+   *  process-table refresh -- the cheap-tier tick must not fork a full `ps` as a side effect. */
+  getForegroundProcess(options?: { rawFallback?: boolean }): string | null
   confirmForegroundProcess(): Promise<string | null>
   confirmShellForeground(): Promise<boolean>
 }
@@ -213,9 +215,12 @@ export function createPtyForegroundProcessTracker(args: {
       cachedAgentForeground = null
       startupAgentForeground = null
     },
-    getForegroundProcess: () => {
+    getForegroundProcess: (options) => {
       if (args.isDead()) {
         return null
+      }
+      if (options?.rawFallback === true) {
+        return getFallbackProcess()
       }
       try {
         const fallbackProcess = getFallbackProcess()

--- a/src/main/daemon/session-subprocess-handle.ts
+++ b/src/main/daemon/session-subprocess-handle.ts
@@ -6,7 +6,7 @@ export type SubprocessHandle = {
   pid: number
   /** Live foreground process name of the PTY (node-pty's `.process`), e.g.
    *  'claude' / 'codex' / 'zsh'. Null once the child has exited. */
-  getForegroundProcess(): string | null
+  getForegroundProcess(options?: { rawFallback?: boolean }): string | null
   /** Await process-table evidence captured after this confirmation request. */
   confirmForegroundProcess?(): Promise<string | null>
   /** Proves a fresh post-boundary PTY process tree contains only the shell. */

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -252,8 +252,8 @@ export class Session {
     return this.output.getCwd()
   }
 
-  getForegroundProcess(): string | null {
-    return this.subprocess.getForegroundProcess()
+  getForegroundProcess(options?: { rawFallback?: boolean }): string | null {
+    return this.subprocess.getForegroundProcess(options)
   }
 
   async confirmForegroundProcess(): Promise<string | null> {

--- a/src/main/daemon/terminal-host-cheap-tier-ps-scan-volume.test.ts
+++ b/src/main/daemon/terminal-host-cheap-tier-ps-scan-volume.test.ts
@@ -1,0 +1,206 @@
+// Measurement for the cheap-tier process inspection. Drives the REAL daemon inspection
+// entrypoint (`inspectTerminalHostProcess`) for 8 idle agent panes over a simulated 60s idle
+// cadence (POLL_TIER_INTERVAL_MS.idle = 2,000ms) and counts `ps` forks BY COLUMN SET: a fork
+// asking for `command=` is the full capture (measured 0.34-0.50s on a 1,900-process Mac, 1.15s
+// on Linux), one without it is the cheap capture (0.03s on both). CI cannot time a real `ps`
+// portably, so fork counts by column set are what this test measures; the per-fork costs above
+// are the numbers measured by hand on the reference hosts.
+//
+// The second test is the zero-trade-off proof: the same tick sequence, including an agent exit
+// and a restart, produces the identical foregroundProcess series with the cheap tier on and off.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+import { resetCheapProcessTableSnapshotForTests } from '../../shared/cheap-process-table-snapshot-reader'
+import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot-reader'
+import { createPtyForegroundProcessTracker } from './pty-subprocess/foreground-process-tracker'
+import { inspectTerminalHostProcess } from './terminal-host-process-inspection'
+import type { Session } from './session'
+
+const PANE_COUNT = 8
+const IDLE_POLL_INTERVAL_MS = 2_000 // POLL_TIER_INTERVAL_MS.idle
+const WINDOW_SECONDS = 60
+const TICKS = Math.floor((WINDOW_SECONDS * 1000) / IDLE_POLL_INTERVAL_MS)
+
+const shellPid = (pane: number): number => 1000 + pane * 100
+const agentPid = (pane: number): number => shellPid(pane) + 1
+
+type PaneState = { agent: boolean; agentStart: string }
+const panes: PaneState[] = Array.from({ length: PANE_COUNT }, () => ({
+  agent: true,
+  agentStart: 'Thu Sep  3 16:02:05 2026'
+}))
+
+const forks = { full: 0, cheap: 0 }
+
+function renderRows(): { full: string; cheap: string } {
+  const full: string[] = []
+  const cheap: string[] = []
+  panes.forEach((pane, i) => {
+    const s = shellPid(i)
+    const a = agentPid(i)
+    const tpgid = pane.agent ? a : s
+    const shellStat = pane.agent ? 'Ss' : 'Ss+'
+    cheap.push(`${s} 1 ${s} ${tpgid} ${shellStat} Thu Sep  3 16:02:01 2026`)
+    full.push(`${s} 1 ${s} ${tpgid} ${shellStat} ttys00${i} Thu Sep  3 16:02:01 2026 -zsh`)
+    if (pane.agent) {
+      cheap.push(`${a} ${s} ${a} ${a} S+ ${pane.agentStart}`)
+      full.push(`${a} ${s} ${a} ${a} S+ ttys00${i} ${pane.agentStart} node /usr/local/bin/claude`)
+    }
+  })
+  return { full: `${full.join('\n')}\n`, cheap: `${cheap.join('\n')}\n` }
+}
+
+function installCountingPs(): void {
+  execFileMock.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb: unknown) => {
+    const isFull = (args[1] ?? '').includes('command=')
+    forks[isFull ? 'full' : 'cheap'] += 1
+    const rendered = renderRows()
+    ;(cb as (err: unknown, r: { stdout: string; stderr: string }) => void)(null, {
+      stdout: isFull ? rendered.full : rendered.cheap,
+      stderr: ''
+    })
+  })
+}
+
+function createSession(pane: number): Session {
+  const tracker = createPtyForegroundProcessTracker({
+    process: {
+      pid: shellPid(pane),
+      get process() {
+        return panes[pane].agent ? 'node' : 'zsh'
+      }
+    } as never,
+    shellPath: '/bin/zsh',
+    sessionId: `wt:pane-${pane}`,
+    startupAgentRecognition: null,
+    isDead: () => false
+  })
+  return {
+    pid: shellPid(pane),
+    incarnationId: `inc-${pane}`,
+    isAlive: true,
+    getForegroundProcess: (options?: { rawFallback?: boolean }) =>
+      tracker.getForegroundProcess(options)
+  } as unknown as Session
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve()
+  }
+}
+
+async function runTick(sessions: Session[], steadyState: boolean): Promise<(string | null)[]> {
+  const results = await Promise.all(
+    sessions.map((session, pane) =>
+      inspectTerminalHostProcess({
+        sessionId: `wt:pane-${pane}`,
+        session,
+        ...(steadyState ? { steadyState: true } : {}),
+        authorityGeneration: 'gen',
+        nextObservationEpoch: () => 1
+      })
+    )
+  )
+  await settle()
+  return results.map((r) => r.foregroundProcess)
+}
+
+describe('cheap-tier ps scan volume at 8 idle agent panes over 60s', () => {
+  let platform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+    resetCheapProcessTableSnapshotForTests()
+    forks.full = 0
+    forks.cheap = 0
+    panes.forEach((pane) => {
+      pane.agent = true
+      pane.agentStart = 'Thu Sep  3 16:02:05 2026'
+    })
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(1_000_000)
+    installCountingPs()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  it('replaces ~all full captures with cheap ones once every pane holds an anchor', async () => {
+    const sessions = Array.from({ length: PANE_COUNT }, (_, pane) => createSession(pane))
+    for (let tick = 0; tick < TICKS; tick += 1) {
+      vi.setSystemTime(1_000_000 + tick * IDLE_POLL_INTERVAL_MS)
+      const names = await runTick(sessions, true)
+      expect(names.every((name) => name === 'claude')).toBe(true)
+    }
+    // Baseline today: one full capture per tick (TTL-shared across the 8 panes) = TICKS.
+    // Now: the first tick establishes every anchor from one full capture; every later tick is
+    // one TTL-shared cheap capture. Published numbers, from this run:
+    //   before: 30 full (~0.34-0.50s each on macOS, 1.15s Linux) + 0 cheap
+    //   after:   1 full + 29 cheap (~0.03s each)
+    expect(forks.full).toBe(1)
+    expect(forks.cheap).toBe(TICKS - 1)
+    expect(forks.full + forks.cheap).toBe(TICKS)
+  })
+
+  it('keeps today’s cost when the caller does not opt in (old client / remote / restore)', async () => {
+    const sessions = Array.from({ length: PANE_COUNT }, (_, pane) => createSession(pane))
+    for (let tick = 0; tick < TICKS; tick += 1) {
+      vi.setSystemTime(1_000_000 + tick * IDLE_POLL_INTERVAL_MS)
+      await runTick(sessions, false)
+    }
+    expect(forks.cheap).toBe(0)
+    expect(forks.full).toBe(TICKS)
+  })
+
+  it('completion detection is byte-for-byte unchanged: exit, idle, and restart resolve identically with and without the cheap tier', async () => {
+    const script = async (steadyState: boolean): Promise<(string | null)[][]> => {
+      resetProcessTableSnapshotForTests()
+      resetCheapProcessTableSnapshotForTests()
+      panes.forEach((pane) => {
+        pane.agent = true
+        pane.agentStart = 'Thu Sep  3 16:02:05 2026'
+      })
+      const sessions = Array.from({ length: PANE_COUNT }, (_, pane) => createSession(pane))
+      const series: (string | null)[][] = []
+      for (let tick = 0; tick < TICKS; tick += 1) {
+        vi.setSystemTime(1_000_000 + tick * IDLE_POLL_INTERVAL_MS)
+        if (tick === 5) {
+          panes[2].agent = false // pane 2's agent exits
+        }
+        if (tick === 12) {
+          panes[2].agent = true // ...and is restarted with a new start time
+          panes[2].agentStart = 'Thu Sep  3 16:30:00 2026'
+        }
+        if (tick === 20) {
+          panes[6].agent = false
+        }
+        series.push(await runTick(sessions, steadyState))
+      }
+      return series
+    }
+    const withCheapTier = await script(true)
+    const cheapForks = forks.cheap
+    forks.cheap = 0
+    forks.full = 0
+    const fullOnly = await script(false)
+    expect(withCheapTier).toEqual(fullOnly)
+    // And the exit was seen on the very tick it happened, in both modes.
+    expect(withCheapTier[4][2]).toBe('claude')
+    expect(withCheapTier[5][2]).not.toBe('claude')
+    expect(withCheapTier[12][2]).toBe('claude')
+    expect(withCheapTier[19][6]).toBe('claude')
+    expect(withCheapTier[20][6]).not.toBe('claude')
+    expect(cheapForks).toBeGreaterThan(0)
+  })
+})

--- a/src/main/daemon/terminal-host-cheap-tier-ps-scan-volume.test.ts
+++ b/src/main/daemon/terminal-host-cheap-tier-ps-scan-volume.test.ts
@@ -10,8 +10,14 @@
 // and a restart, produces the identical foregroundProcess series with the cheap tier on and off.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+// Two seams because the two tiers spawn differently: the full evidence reader still forks
+// through node:child_process, the cheap reader through Orca's runProcess entry point.
+const { execFileMock, runProcessMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  runProcessMock: vi.fn()
+}))
 vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
 
 import { resetCheapProcessTableSnapshotForTests } from '../../shared/cheap-process-table-snapshot-reader'
 import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot-reader'
@@ -55,13 +61,17 @@ function renderRows(): { full: string; cheap: string } {
 
 function installCountingPs(): void {
   execFileMock.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb: unknown) => {
-    const isFull = (args[1] ?? '').includes('command=')
-    forks[isFull ? 'full' : 'cheap'] += 1
-    const rendered = renderRows()
+    expect(args[1]).toContain('command=')
+    forks.full += 1
     ;(cb as (err: unknown, r: { stdout: string; stderr: string }) => void)(null, {
-      stdout: isFull ? rendered.full : rendered.cheap,
+      stdout: renderRows().full,
       stderr: ''
     })
+  })
+  runProcessMock.mockImplementation(async (spec: { args: readonly string[] }) => {
+    expect(spec.args[1]).not.toContain('command=')
+    forks.cheap += 1
+    return { code: 0, signal: null, stdout: renderRows().cheap, stderr: '', timedOut: false }
   })
 }
 
@@ -114,6 +124,7 @@ describe('cheap-tier ps scan volume at 8 idle agent panes over 60s', () => {
 
   beforeEach(() => {
     execFileMock.mockReset()
+    runProcessMock.mockReset()
     resetProcessTableSnapshotForTests()
     resetCheapProcessTableSnapshotForTests()
     forks.full = 0

--- a/src/main/daemon/terminal-host-process-inspection-cheap-tier.test.ts
+++ b/src/main/daemon/terminal-host-process-inspection-cheap-tier.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+// Two seams because the two tiers spawn differently: the full evidence reader still forks
+// through node:child_process, the cheap reader through Orca's runProcess entry point.
+const { execFileMock, runProcessMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  runProcessMock: vi.fn()
+}))
 vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
 
 import { resetCheapProcessTableSnapshotForTests } from '../../shared/cheap-process-table-snapshot-reader'
 import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot-reader'
@@ -60,14 +66,23 @@ let table: Table = { agent: 'claude' }
 
 function installPs(): void {
   execFileMock.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb: unknown) => {
-    const columns = args[1] ?? ''
-    const rendered = renderTable(table)
-    const isFull = columns.includes('command=')
-    forks[isFull ? 'full' : 'cheap'] += 1
+    expect(args[1]).toContain('command=')
+    forks.full += 1
     ;(cb as (err: unknown, r: { stdout: string; stderr: string }) => void)(null, {
-      stdout: isFull ? rendered.full : rendered.cheap,
+      stdout: renderTable(table).full,
       stderr: ''
     })
+  })
+  runProcessMock.mockImplementation(async (spec: { args: readonly string[] }) => {
+    expect(spec.args[1]).not.toContain('command=')
+    forks.cheap += 1
+    return {
+      code: 0,
+      signal: null,
+      stdout: renderTable(table).cheap,
+      stderr: '',
+      timedOut: false
+    }
   })
 }
 
@@ -137,6 +152,7 @@ describe('daemon cheap-tier process inspection', () => {
 
   beforeEach(() => {
     execFileMock.mockReset()
+    runProcessMock.mockReset()
     resetProcessTableSnapshotForTests()
     resetCheapProcessTableSnapshotForTests()
     forks.full = 0
@@ -248,9 +264,7 @@ describe('daemon cheap-tier process inspection', () => {
   it('falls through to the full capture when the cheap fork fails, and after an incarnation mismatch', async () => {
     const session = await anchoredSession()
     await advance(2_000)
-    execFileMock.mockImplementationOnce((_c: string, _a: string[], _o: unknown, cb: unknown) => {
-      ;(cb as (err: unknown) => void)(new Error('ps died'))
-    })
+    runProcessMock.mockRejectedValueOnce(new Error('ps died'))
     expect((await inspect(session, { steadyState: true })).tier).toBe('full')
     await advance(2_000)
     const mismatched = await inspect(session, { steadyState: true, expectedIncarnationId: 'other' })

--- a/src/main/daemon/terminal-host-process-inspection-cheap-tier.test.ts
+++ b/src/main/daemon/terminal-host-process-inspection-cheap-tier.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+import { resetCheapProcessTableSnapshotForTests } from '../../shared/cheap-process-table-snapshot-reader'
+import { resetProcessTableSnapshotForTests } from '../../shared/process-table-snapshot-reader'
+import { createPtyForegroundProcessTracker } from './pty-subprocess/foreground-process-tracker'
+import {
+  inspectTerminalHostProcess,
+  type TerminalHostInspectionTier
+} from './terminal-host-process-inspection'
+import { getSteadyStateAnchor } from './terminal-host-steady-state-anchor'
+import type { Session } from './session'
+
+const SHELL_PID = 4242
+const AGENT_PID = 4300
+const START_SHELL = 'Thu Sep  3 16:02:01 2026'
+const START_AGENT = 'Thu Sep  3 16:02:05 2026'
+
+type Table = { agent: 'claude' | 'stopped' | 'gone' | 'replaced'; children?: number }
+
+/** One host table rendered in both column sets, so each fork answers by the args it asked for. */
+function renderTable(table: Table): { full: string; cheap: string } {
+  const shellTpgid = table.agent === 'claude' || table.agent === 'replaced' ? AGENT_PID : SHELL_PID
+  const shellStat = shellTpgid === SHELL_PID ? 'Ss+' : 'Ss'
+  const rows: { cheap: string; full: string }[] = [
+    {
+      cheap: `${SHELL_PID} 1 ${SHELL_PID} ${shellTpgid} ${shellStat} ${START_SHELL}`,
+      full: `${SHELL_PID} 1 ${SHELL_PID} ${shellTpgid} ${shellStat} ttys004 ${START_SHELL} -zsh`
+    },
+    {
+      cheap: `9000 1 9000 9000 Ss+ Thu Sep  3 12:00:00 2026`,
+      full: `9000 1 9000 9000 Ss+ ttys009 Thu Sep  3 12:00:00 2026 -zsh`
+    }
+  ]
+  if (table.agent !== 'gone') {
+    const stat = table.agent === 'stopped' ? 'T' : 'S+'
+    const start = table.agent === 'replaced' ? 'Thu Sep  3 16:30:00 2026' : START_AGENT
+    rows.push({
+      cheap: `${AGENT_PID} ${SHELL_PID} ${AGENT_PID} ${shellTpgid} ${stat} ${start}`,
+      full: `${AGENT_PID} ${SHELL_PID} ${AGENT_PID} ${shellTpgid} ${stat} ttys004 ${start} node /usr/local/bin/claude`
+    })
+    for (let i = 0; i < (table.children ?? 0); i += 1) {
+      const pid = AGENT_PID + 10 + i
+      rows.push({
+        cheap: `${pid} ${AGENT_PID} ${AGENT_PID} ${shellTpgid} S+ Thu Sep  3 16:05:0${i} 2026`,
+        full: `${pid} ${AGENT_PID} ${AGENT_PID} ${shellTpgid} S+ ttys004 Thu Sep  3 16:05:0${i} 2026 rg --files`
+      })
+    }
+  }
+  return {
+    full: `${rows.map((r) => r.full).join('\n')}\n`,
+    cheap: `${rows.map((r) => r.cheap).join('\n')}\n`
+  }
+}
+
+const forks = { full: 0, cheap: 0 }
+let table: Table = { agent: 'claude' }
+
+function installPs(): void {
+  execFileMock.mockImplementation((_cmd: string, args: string[], _opts: unknown, cb: unknown) => {
+    const columns = args[1] ?? ''
+    const rendered = renderTable(table)
+    const isFull = columns.includes('command=')
+    forks[isFull ? 'full' : 'cheap'] += 1
+    ;(cb as (err: unknown, r: { stdout: string; stderr: string }) => void)(null, {
+      stdout: isFull ? rendered.full : rendered.cheap,
+      stderr: ''
+    })
+  })
+}
+
+function createSession(processName: () => string): Session {
+  let dead = false
+  const tracker = createPtyForegroundProcessTracker({
+    process: {
+      pid: SHELL_PID,
+      get process() {
+        return processName()
+      }
+    } as never,
+    shellPath: '/bin/zsh',
+    sessionId: 'wt-1:pane-1',
+    startupAgentRecognition: null,
+    isDead: () => dead
+  })
+  return {
+    pid: SHELL_PID,
+    incarnationId: 'inc-1',
+    get isAlive() {
+      return !dead
+    },
+    getForegroundProcess: (options?: { rawFallback?: boolean }) =>
+      tracker.getForegroundProcess(options),
+    markDead: () => {
+      dead = true
+      tracker.markDead()
+    }
+  } as unknown as Session & { markDead(): void }
+}
+
+async function inspect(
+  session: Session,
+  options: { steadyState?: boolean; expectedIncarnationId?: string } = {}
+): Promise<{
+  tier: TerminalHostInspectionTier
+  result: Awaited<ReturnType<typeof inspectTerminalHostProcess>>
+}> {
+  let tier: TerminalHostInspectionTier = 'full'
+  const result = await inspectTerminalHostProcess({
+    sessionId: 'wt-1:pane-1',
+    session,
+    ...options,
+    authorityGeneration: 'gen-1',
+    nextObservationEpoch: () => 1,
+    onTier: (t) => {
+      tier = t
+    }
+  })
+  return { tier, result }
+}
+
+async function settle(): Promise<void> {
+  // The tracker's recognizing refresh runs off the same TTL-shared capture; let it land.
+  for (let i = 0; i < 8; i += 1) {
+    await Promise.resolve()
+  }
+}
+
+async function advance(ms: number): Promise<void> {
+  vi.setSystemTime(Date.now() + ms)
+}
+
+describe('daemon cheap-tier process inspection', () => {
+  let platform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetProcessTableSnapshotForTests()
+    resetCheapProcessTableSnapshotForTests()
+    forks.full = 0
+    forks.cheap = 0
+    table = { agent: 'claude' }
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(1_000_000)
+    installPs()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  /** Bring a session to a recognized anchor the way production does: one full cadence tick. */
+  async function anchoredSession(): Promise<Session> {
+    const session = createSession(() => 'node')
+    const first = await inspect(session, { steadyState: true })
+    await settle()
+    expect(first.tier).toBe('full')
+    expect(first.result.foregroundProcess).toBe('claude')
+    expect(getSteadyStateAnchor(session)?.agentName).toBe('claude')
+    return session
+  }
+
+  it('a pane with NO recognized anchor never takes the cheap path, even when asked', async () => {
+    table = { agent: 'gone' }
+    const session = createSession(() => 'zsh')
+    for (let tick = 0; tick < 5; tick += 1) {
+      await advance(2_000)
+      const { tier, result } = await inspect(session, { steadyState: true })
+      expect(tier).toBe('full')
+      expect(result.foregroundProcessEvidence).toBeDefined()
+    }
+    expect(forks.cheap).toBe(0)
+    expect(forks.full).toBe(5)
+  })
+
+  it('serves an unchanged anchored pane from the cheap tier and OMITS evidence rather than faking it', async () => {
+    const session = await anchoredSession()
+    const fullBefore = forks.full
+    for (let tick = 0; tick < 4; tick += 1) {
+      await advance(2_000)
+      const { tier, result } = await inspect(session, { steadyState: true })
+      expect(tier).toBe('cheap')
+      expect(result.foregroundProcess).toBe('claude')
+      expect(result.hasChildProcesses).toBe(true)
+      expect(result).not.toHaveProperty('foregroundProcessEvidence')
+    }
+    expect(forks.cheap).toBe(4)
+    expect(forks.full).toBe(fullBefore)
+  })
+
+  it('a request without steadyState (old client, remote client, restore path) always gets the full capture with evidence', async () => {
+    const session = await anchoredSession()
+    await advance(2_000)
+    const { tier, result } = await inspect(session)
+    expect(tier).toBe('full')
+    expect(result.foregroundProcessEvidence).toMatchObject({
+      verdict: 'live',
+      processName: 'claude'
+    })
+    expect(forks.cheap).toBe(0)
+  })
+
+  it('escalates to the full capture the moment the agent exits, and reports the exit', async () => {
+    const session = await anchoredSession()
+    await advance(2_000)
+    expect((await inspect(session, { steadyState: true })).tier).toBe('cheap')
+    table = { agent: 'gone' }
+    await advance(2_000)
+    const { tier, result } = await inspect(session, { steadyState: true })
+    expect(tier).toBe('full')
+    expect(result.foregroundProcessEvidence).toMatchObject({ verdict: 'live', processName: null })
+  })
+
+  it.each<[string, Table]>([
+    ['Ctrl-Z stops the agent', { agent: 'stopped' }],
+    ['exit-and-replace reuses the pid', { agent: 'replaced' }],
+    ['a child spawns under the agent', { agent: 'claude', children: 1 }]
+  ])('escalates when %s', async (_name, next) => {
+    const session = await anchoredSession()
+    await advance(2_000)
+    expect((await inspect(session, { steadyState: true })).tier).toBe('cheap')
+    table = next
+    await advance(2_000)
+    expect((await inspect(session, { steadyState: true })).tier).toBe('full')
+  })
+
+  it('escalates when node-pty reports a different foreground name, without waiting on ps', async () => {
+    let name = 'node'
+    const session = createSession(() => name)
+    await inspect(session, { steadyState: true })
+    await settle()
+    await advance(2_000)
+    expect((await inspect(session, { steadyState: true })).tier).toBe('cheap')
+    name = 'zsh'
+    await advance(2_000)
+    const cheapBefore = forks.cheap
+    expect((await inspect(session, { steadyState: true })).tier).toBe('full')
+    expect(forks.cheap).toBe(cheapBefore)
+  })
+
+  it('falls through to the full capture when the cheap fork fails, and after an incarnation mismatch', async () => {
+    const session = await anchoredSession()
+    await advance(2_000)
+    execFileMock.mockImplementationOnce((_c: string, _a: string[], _o: unknown, cb: unknown) => {
+      ;(cb as (err: unknown) => void)(new Error('ps died'))
+    })
+    expect((await inspect(session, { steadyState: true })).tier).toBe('full')
+    await advance(2_000)
+    const mismatched = await inspect(session, { steadyState: true, expectedIncarnationId: 'other' })
+    expect(mismatched.tier).toBe('full')
+    expect(mismatched.result.foregroundProcessEvidence).toMatchObject({
+      reason: 'incarnation_mismatch'
+    })
+  })
+
+  it('a dead session is never served from its anchor', async () => {
+    const session = (await anchoredSession()) as Session & { markDead(): void }
+    session.markDead()
+    await expect(inspect(session, { steadyState: true })).rejects.toThrow('not found')
+    expect(forks.cheap).toBe(0)
+  })
+
+  it('an anchor is dropped when a full capture stops naming a recognized agent', async () => {
+    const session = await anchoredSession()
+    table = { agent: 'gone' }
+    await advance(2_000)
+    await inspect(session, { steadyState: true })
+    expect(getSteadyStateAnchor(session)).toBeNull()
+    // Back with a new agent, but the pane must re-anchor via a FULL capture first.
+    table = { agent: 'claude' }
+    await advance(2_000)
+    const cheapBefore = forks.cheap
+    expect((await inspect(session, { steadyState: true })).tier).toBe('full')
+    expect(forks.cheap).toBe(cheapBefore)
+  })
+})

--- a/src/main/daemon/terminal-host-process-inspection.ts
+++ b/src/main/daemon/terminal-host-process-inspection.ts
@@ -1,8 +1,15 @@
 import { isShellProcess } from '../../shared/agent-detection'
 import type { RemoteForegroundEvidence } from '../../shared/foreground-process-evidence'
+import { getCheapProcessTableSnapshot } from '../../shared/cheap-process-table-snapshot-reader'
 import { getStrictProcessTableSnapshotWithAge } from '../../shared/process-table-snapshot-reader'
 import { resolveRemoteForegroundEvidence } from '../providers/agent-foreground-process'
+import { buildPaneProcessFingerprint } from '../providers/posix-pane-foreground-fingerprint'
 import type { Session } from './session'
+import {
+  clearSteadyStateAnchor,
+  getSteadyStateAnchor,
+  rememberSteadyStateAnchor
+} from './terminal-host-steady-state-anchor'
 import { SessionNotFoundError } from './types'
 
 export type TerminalHostProcessInspection = {
@@ -13,13 +20,23 @@ export type TerminalHostProcessInspection = {
 
 type RetiredIncarnation = { incarnationId: string; code: number; expiresAt: number }
 
+/**
+ * Tick tiers for a POSIX pane. `cheap` forks `ps` without `tty=`/`command=` (11-38x cheaper)
+ * and answers from the anchored identity when the pane fingerprint is unchanged; anything it
+ * cannot prove escalates to `full`, today's evidence capture.
+ */
+export type TerminalHostInspectionTier = 'full' | 'cheap'
+
 export async function inspectTerminalHostProcess(args: {
   sessionId: string
   session: Session | null
   expectedIncarnationId?: string
+  /** The caller is a self-correcting poll that only reads the process name, never evidence. */
+  steadyState?: boolean
   retiredIncarnation?: RetiredIncarnation
   authorityGeneration: string
   nextObservationEpoch: () => number
+  onTier?: (tier: TerminalHostInspectionTier) => void
 }): Promise<TerminalHostProcessInspection> {
   const { sessionId, session, expectedIncarnationId, retiredIncarnation } = args
   if (!session || !session.isAlive) {
@@ -45,9 +62,22 @@ export async function inspectTerminalHostProcess(args: {
     throw new SessionNotFoundError(sessionId)
   }
 
+  const incarnationMatches =
+    !expectedIncarnationId || expectedIncarnationId === session.incarnationId
+  if (args.steadyState === true && incarnationMatches) {
+    const anchored = await readAnchoredForeground(session)
+    if (anchored !== null) {
+      args.onTier?.('cheap')
+      // No evidence member on purpose: a tty-less capture cannot fence anything, and a
+      // fabricated fence would be read by remote/restore consumers as an observation.
+      return { foregroundProcess: anchored, hasChildProcesses: true }
+    }
+  }
+  args.onTier?.('full')
+
   const foregroundProcess = session.getForegroundProcess()
   let evidence: RemoteForegroundEvidence
-  if (expectedIncarnationId && expectedIncarnationId !== session.incarnationId) {
+  if (!incarnationMatches) {
     evidence = unverifiableEvidence(args, session, 'incarnation_mismatch')
   } else {
     try {
@@ -64,14 +94,42 @@ export async function inspectTerminalHostProcess(args: {
         },
         snapshot.rows
       )
+      await rememberSteadyStateAnchor(session, evidence, snapshot.rows)
     } catch {
       evidence = unverifiableEvidence(args, session, 'process_table_unreadable')
+      clearSteadyStateAnchor(session)
     }
   }
   return {
     foregroundProcess: evidence.verdict === 'live' ? evidence.processName : foregroundProcess,
     hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess),
     foregroundProcessEvidence: evidence
+  }
+}
+
+/**
+ * Cheap tier, gated on an anchor the last full capture established. Start discovery therefore
+ * keeps today's exact behaviour: a pane with no anchor never gets here. A recognized agent's
+ * exit is a pid vanishing from the subtree, which the fingerprint always sees, so completion
+ * detection is unaffected. Any mismatch, unreadable capture, changed node-pty name, or non-POSIX
+ * host answers null -> full tier.
+ */
+async function readAnchoredForeground(session: Session): Promise<string | null> {
+  const anchor = getSteadyStateAnchor(session)
+  if (process.platform === 'win32' || !anchor) {
+    return null
+  }
+  if (session.getForegroundProcess({ rawFallback: true }) !== anchor.rawFallback) {
+    return null
+  }
+  try {
+    const observed = await buildPaneProcessFingerprint(
+      await getCheapProcessTableSnapshot(),
+      session.pid
+    )
+    return observed !== null && observed === anchor.fingerprint ? anchor.agentName : null
+  } catch {
+    return null
   }
 }
 

--- a/src/main/daemon/terminal-host-steady-state-anchor.ts
+++ b/src/main/daemon/terminal-host-steady-state-anchor.ts
@@ -1,0 +1,58 @@
+import { recognizeAgentProcess } from '../../shared/agent-process-recognition'
+import type { RemoteForegroundEvidence } from '../../shared/foreground-process-evidence'
+import { buildPaneProcessFingerprint } from '../providers/posix-pane-foreground-fingerprint'
+import type { Session } from './session'
+
+/**
+ * What the last FULL capture proved about a pane: a recognized agent name, the pane subtree
+ * fingerprint at that moment, and node-pty's raw foreground name at that moment. A later cheap
+ * tick may re-serve `agentName` only while both of the latter still match.
+ */
+export type SteadyStateAnchor = {
+  agentName: string
+  fingerprint: string
+  rawFallback: string | null
+}
+
+// Weakly keyed: an anchor dies with its Session, and a recycled pid under a new Session can
+// never inherit one. Retired sessions fail `isAlive` before any read gets here regardless.
+const anchors = new WeakMap<Session, SteadyStateAnchor>()
+
+export function getSteadyStateAnchor(session: Session): SteadyStateAnchor | null {
+  return anchors.get(session) ?? null
+}
+
+export function clearSteadyStateAnchor(session: Session): void {
+  anchors.delete(session)
+}
+
+/**
+ * Record (or drop) the anchor after a full capture. Only a `live` verdict naming a recognized
+ * agent establishes one: the cheap tier is licensed by proven identity, never by a fallback name
+ * or an unverifiable read, so a pane without one always pays for the full capture.
+ */
+export async function rememberSteadyStateAnchor(
+  session: Session,
+  evidence: RemoteForegroundEvidence,
+  rows: Parameters<typeof buildPaneProcessFingerprint>[0]
+): Promise<void> {
+  if (evidence.verdict !== 'live' || !recognizeAgentProcess(evidence.processName)) {
+    anchors.delete(session)
+    return
+  }
+  let fingerprint: string | null
+  try {
+    fingerprint = await buildPaneProcessFingerprint(rows, session.pid)
+  } catch {
+    fingerprint = null
+  }
+  if (fingerprint === null || evidence.processName === null) {
+    anchors.delete(session)
+    return
+  }
+  anchors.set(session, {
+    agentName: evidence.processName,
+    fingerprint,
+    rawFallback: session.getForegroundProcess({ rawFallback: true })
+  })
+}

--- a/src/main/daemon/terminal-host.ts
+++ b/src/main/daemon/terminal-host.ts
@@ -233,7 +233,7 @@ export class TerminalHost {
 
   inspectProcess(
     sessionId: string,
-    options?: { expectedIncarnationId?: string }
+    options?: { expectedIncarnationId?: string; steadyState?: boolean }
   ): Promise<TerminalHostProcessInspection> {
     pruneRetiredPtyIncarnations(this.retiredIncarnations)
     const session = this.sessions.get(sessionId)
@@ -253,6 +253,7 @@ export class TerminalHost {
       ...(options?.expectedIncarnationId
         ? { expectedIncarnationId: options.expectedIncarnationId }
         : {}),
+      ...(options?.steadyState === true ? { steadyState: true } : {}),
       retiredIncarnation: this.retiredIncarnations.get(sessionId),
       authorityGeneration: this.authorityGeneration,
       nextObservationEpoch: () => ++this.observationEpoch

--- a/src/main/ipc/pty/ipc/inspect.ts
+++ b/src/main/ipc/pty/ipc/inspect.ts
@@ -172,7 +172,12 @@ export function installPtyInspectIpcHandlers(deps: {
     'pty:inspectProcess',
     async (
       _event,
-      args: { id: string; expectedIncarnationId?: string; scanChildProcesses?: boolean }
+      args: {
+        id: string
+        expectedIncarnationId?: string
+        scanChildProcesses?: boolean
+        steadyState?: boolean
+      }
     ) => {
       // Why: same routing hazard as pty:hasPty — an unroutable id must read as client-only unverifiable, not as a local-provider answer or a raised IPC error.
       if (typeof args?.id !== 'string' || !args.id || args.id.startsWith('remote:')) {
@@ -189,7 +194,8 @@ export function installPtyInspectIpcHandlers(deps: {
         ...(args.expectedIncarnationId
           ? { expectedIncarnationId: args.expectedIncarnationId }
           : {}),
-        ...(args.scanChildProcesses === true ? { scanChildProcesses: true } : {})
+        ...(args.scanChildProcesses === true ? { scanChildProcesses: true } : {}),
+        ...(args.steadyState === true ? { steadyState: true } : {})
       }
       return Object.keys(options).length > 0
         ? inspectPtyProviderProcessForRenderer(getProviderForPty(args.id), args.id, options)

--- a/src/main/providers/local-pty-foreground-inspection-cheap-tier.test.ts
+++ b/src/main/providers/local-pty-foreground-inspection-cheap-tier.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ProcessTableSnapshotReader from '../../shared/process-table-snapshot-reader'
+
+const { cheapSnapshotMock, fullSnapshotMock, resolveMock } = vi.hoisted(() => ({
+  cheapSnapshotMock: vi.fn(),
+  fullSnapshotMock: vi.fn(),
+  resolveMock: vi.fn()
+}))
+
+vi.mock('../../shared/cheap-process-table-snapshot-reader', () => ({
+  getCheapProcessTableSnapshot: cheapSnapshotMock
+}))
+vi.mock('../../shared/process-table-snapshot-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof ProcessTableSnapshotReader>()),
+  getProcessTableSnapshot: fullSnapshotMock
+}))
+vi.mock('./agent-foreground-process', () => ({
+  resolveAgentForegroundProcessWithAvailability: resolveMock,
+  confirmShellForegroundProcess: vi.fn()
+}))
+
+import { getLocalPtyForegroundProcess } from './local-pty-foreground-inspection'
+import { ptyLastRecognizedForeground, ptyProcesses, ptyShellName } from './local-pty-provider-state'
+
+const SHELL_PID = 4242
+const AGENT_PID = 4300
+const ID = 'pty-1'
+
+type Table = 'agent' | 'shell-only'
+let table: Table = 'agent'
+
+function rows(): Record<string, unknown>[] {
+  const tpgid = table === 'agent' ? AGENT_PID : SHELL_PID
+  const out: Record<string, unknown>[] = [
+    {
+      pid: SHELL_PID,
+      ppid: 1,
+      pgid: SHELL_PID,
+      tpgid,
+      stat: table === 'agent' ? 'Ss' : 'Ss+',
+      tty: 'ttys004',
+      startTime: 'Thu Sep  3 16:02:01 2026',
+      command: '-zsh'
+    }
+  ]
+  if (table === 'agent') {
+    out.push({
+      pid: AGENT_PID,
+      ppid: SHELL_PID,
+      pgid: AGENT_PID,
+      tpgid,
+      stat: 'S+',
+      tty: 'ttys004',
+      startTime: 'Thu Sep  3 16:02:05 2026',
+      command: 'node /usr/local/bin/claude'
+    })
+  }
+  return out
+}
+
+describe('local POSIX provider cheap-tier revalidation', () => {
+  let platform: PropertyDescriptor | undefined
+  const proc = { pid: SHELL_PID, process: 'node' }
+
+  beforeEach(() => {
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    table = 'agent'
+    proc.process = 'node'
+    cheapSnapshotMock.mockReset()
+    cheapSnapshotMock.mockImplementation(async () => rows())
+    fullSnapshotMock.mockReset()
+    fullSnapshotMock.mockImplementation(async () => rows())
+    resolveMock.mockReset()
+    resolveMock.mockImplementation(async () => ({
+      available: true,
+      processName: table === 'agent' ? 'claude' : 'zsh'
+    }))
+    ptyProcesses.set(ID, proc as never)
+    ptyShellName.set(ID, 'zsh')
+    ptyLastRecognizedForeground.delete(ID)
+  })
+
+  afterEach(() => {
+    ptyProcesses.delete(ID)
+    ptyShellName.delete(ID)
+    ptyLastRecognizedForeground.delete(ID)
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  it('a pane with NO recognized anchor never consults the cheap tier', async () => {
+    table = 'shell-only'
+    proc.process = 'zsh'
+    for (let i = 0; i < 3; i += 1) {
+      expect(await getLocalPtyForegroundProcess(ID)).toBe('zsh')
+    }
+    expect(cheapSnapshotMock).not.toHaveBeenCalled()
+    expect(resolveMock).toHaveBeenCalledTimes(3)
+    expect(ptyLastRecognizedForeground.get(ID)).toBeUndefined()
+  })
+
+  it('once recognized, an unchanged pane re-proves the agent from the cheap tier without a full scan', async () => {
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('claude')
+    expect(resolveMock).toHaveBeenCalledTimes(1)
+    expect(ptyLastRecognizedForeground.get(ID)?.steady?.fingerprint).toEqual(expect.any(String))
+    for (let i = 0; i < 3; i += 1) {
+      expect(await getLocalPtyForegroundProcess(ID)).toBe('claude')
+    }
+    expect(cheapSnapshotMock).toHaveBeenCalledTimes(3)
+    expect(resolveMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('an agent exit changes the fingerprint, escalates to the full scan, and clears the anchor', async () => {
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('claude')
+    table = 'shell-only'
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('zsh')
+    expect(resolveMock).toHaveBeenCalledTimes(2)
+    expect(ptyLastRecognizedForeground.get(ID)).toBeUndefined()
+  })
+
+  it('a changed node-pty foreground name escalates without consulting the cheap tier', async () => {
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('claude')
+    proc.process = 'zsh'
+    table = 'shell-only'
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('zsh')
+    expect(cheapSnapshotMock).not.toHaveBeenCalled()
+    expect(resolveMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('a cheap capture failure falls through to the full scan', async () => {
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('claude')
+    cheapSnapshotMock.mockRejectedValueOnce(new Error('ps died'))
+    expect(await getLocalPtyForegroundProcess(ID)).toBe('claude')
+    expect(resolveMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/providers/local-pty-foreground-inspection.ts
+++ b/src/main/providers/local-pty-foreground-inspection.ts
@@ -1,8 +1,11 @@
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
+import { getCheapProcessTableSnapshot } from '../../shared/cheap-process-table-snapshot-reader'
+import { getProcessTableSnapshot } from '../../shared/process-table-snapshot-reader'
 import {
   confirmShellForegroundProcess,
   resolveAgentForegroundProcessWithAvailability
 } from './agent-foreground-process'
+import { buildPaneProcessFingerprint } from './posix-pane-foreground-fingerprint'
 import { resolveForegroundFallbackProcess } from './local-pty-launch-helpers'
 import {
   ptyAgentForegroundContextPaths,
@@ -30,6 +33,34 @@ export async function hasLocalPtyChildProcesses(id: string): Promise<boolean> {
       return true
     }
     return foreground !== shell
+  } catch {
+    return false
+  }
+}
+
+/**
+ * POSIX twin of the Windows job-membership short-circuit below: a pane that already holds a
+ * recognized agent re-proves it from the cheap `ps` tier when the subtree fingerprint is
+ * unchanged. Panes with no anchor never get here, so start discovery is untouched.
+ */
+async function revalidateCachedPosixAgent(
+  proc: { pid: number },
+  cachedEntry: {
+    name: string
+    steady?: { fingerprint: string; fallbackProcess: string | null } | null
+  },
+  fallbackProcess: string | null
+): Promise<boolean> {
+  const steady = cachedEntry.steady
+  if (!steady || steady.fallbackProcess !== fallbackProcess) {
+    return false
+  }
+  try {
+    const observed = await buildPaneProcessFingerprint(
+      await getCheapProcessTableSnapshot(),
+      proc.pid
+    )
+    return observed !== null && observed === steady.fingerprint
   } catch {
     return false
   }
@@ -89,6 +120,18 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
       paneMembershipUnavailable = true
     }
   }
+  if (
+    process.platform !== 'win32' &&
+    cachedEntry &&
+    cachedAgent !== null &&
+    (await revalidateCachedPosixAgent(proc, cachedEntry, fallbackProcess))
+  ) {
+    if (ptyProcesses.get(id) !== proc) {
+      return null
+    }
+    ptyLastRecognizedForeground.set(id, { ...cachedEntry, at: Date.now() })
+    return cachedAgent
+  }
   try {
     const resolution = await resolveAgentForegroundProcessWithAvailability(
       proc.pid,
@@ -129,7 +172,8 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
           stable.lastRecognizedAgent === resolution.processName
             ? (resolution.processId ?? null)
             : null,
-        at: Date.now()
+        at: Date.now(),
+        steady: await readPosixSteadyState(proc.pid, fallbackProcess)
       })
     } else if (stable.lastRecognizedAgent && cachedAgentAliveInJob && !anchorContradicted) {
       // The anchor pid in the job is proof of life; restamp so the
@@ -148,6 +192,23 @@ export async function getLocalPtyForegroundProcess(id: string): Promise<string |
     }
     // Why: an inspection error is a degraded read; fall back to last recognized agent (null reads as an exit).
     return ptyLastRecognizedForeground.get(id)?.name ?? null
+  }
+}
+
+/** The fingerprint of the TTL-shared capture the recognition just read; null on Windows or
+ *  when the pane is unfenced, which simply means the next read pays for the full scan. */
+async function readPosixSteadyState(
+  shellPid: number,
+  fallbackProcess: string | null
+): Promise<{ fingerprint: string; fallbackProcess: string | null } | null> {
+  if (process.platform === 'win32') {
+    return null
+  }
+  try {
+    const fingerprint = await buildPaneProcessFingerprint(await getProcessTableSnapshot(), shellPid)
+    return fingerprint === null ? null : { fingerprint, fallbackProcess }
+  } catch {
+    return null
   }
 }
 

--- a/src/main/providers/local-pty-provider-state.ts
+++ b/src/main/providers/local-pty-provider-state.ts
@@ -43,9 +43,16 @@ export const ptyAgentForegroundContextPaths = new Map<string, string[]>()
 // Why: remember the last recognized agent foreground so a degraded scan doesn't report the shell and look like an exit.
 // `pid` anchors the identity to the row that proved it (null when ambiguous);
 // `at` is the last confirmation, so unanchored job evidence -- only a superset -- cannot hold it forever.
+// `steady` (POSIX) is the pane fingerprint the recognizing capture proved plus node-pty's name at
+// that moment; a cheap capture matching it re-proves the identity without the full table.
 export const ptyLastRecognizedForeground = new Map<
   string,
-  { name: string; pid: number | null; at: number }
+  {
+    name: string
+    pid: number | null
+    at: number
+    steady?: { fingerprint: string; fallbackProcess: string | null } | null
+  }
 >()
 export const ptyTerminalHandle = new Map<string, string>()
 export const ptyWorktreeId = new Map<string, string>()

--- a/src/main/providers/posix-pane-foreground-fingerprint.test.ts
+++ b/src/main/providers/posix-pane-foreground-fingerprint.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildPaneProcessFingerprint,
+  type PaneFingerprintRow
+} from './posix-pane-foreground-fingerprint'
+
+const SHELL = 4242
+const AGENT = 4300
+const OTHER_PANE = 9000
+
+type Row = PaneFingerprintRow
+
+const shell = (over: Partial<Row> = {}): Row => ({
+  pid: SHELL,
+  ppid: 1,
+  pgid: SHELL,
+  tpgid: AGENT,
+  stat: 'Ss',
+  startTime: 'Thu Sep 3 16:02:01 2026',
+  ...over
+})
+const agent = (over: Partial<Row> = {}): Row => ({
+  pid: AGENT,
+  ppid: SHELL,
+  pgid: AGENT,
+  tpgid: AGENT,
+  stat: 'S+',
+  startTime: 'Thu Sep 3 16:02:05 2026',
+  ...over
+})
+const child = (pid: number, ppid: number, over: Partial<Row> = {}): Row => ({
+  pid,
+  ppid,
+  pgid: AGENT,
+  tpgid: AGENT,
+  stat: 'S+',
+  startTime: `Thu Sep 3 16:03:${String(pid % 60).padStart(2, '0')} 2026`,
+  ...over
+})
+const foreign = (): Row => ({
+  pid: OTHER_PANE,
+  ppid: 1,
+  pgid: OTHER_PANE,
+  tpgid: OTHER_PANE,
+  stat: 'Ss+',
+  startTime: 'Thu Sep 3 12:00:00 2026'
+})
+
+const fp = (rows: Row[]): Promise<string | null> =>
+  buildPaneProcessFingerprint(rows, SHELL, { platform: 'darwin' })
+
+describe('buildPaneProcessFingerprint', () => {
+  const baseline = [foreign(), shell(), agent()]
+
+  it('is stable across captures that differ only in scheduler state, row order, and foreign panes', async () => {
+    const a = await fp(baseline)
+    expect(a).not.toBeNull()
+    // R vs S: a working agent flips this every tick and it says nothing about the pane.
+    expect(await fp([agent({ stat: 'R+' }), shell({ stat: 'Ss' }), foreign()])).toBe(a)
+    // The shell going idle-vs-runnable, or a foreign pane starting/exiting, is not our business.
+    expect(await fp([shell({ stat: 'Rs' }), agent()])).toBe(a)
+    // lstart padding differs between column sets; both must stamp identically.
+    expect(await fp([shell({ startTime: 'Thu Sep  3 16:02:01 2026' }), agent()])).toBe(a)
+  })
+
+  describe('escalates (fingerprint changes) on every completion-relevant transition', () => {
+    it('agent exit: the recognized pid vanishes from the subtree', async () => {
+      const before = await fp(baseline)
+      expect(await fp([foreign(), shell({ tpgid: SHELL, stat: 'Ss+' })])).not.toBe(before)
+    })
+
+    it('exit-and-replace: the same pid is reused by a new process with a new start time', async () => {
+      const before = await fp(baseline)
+      expect(await fp([shell(), agent({ startTime: 'Thu Sep 3 16:09:00 2026' })])).not.toBe(before)
+    })
+
+    it('Ctrl-Z: the agent stops and the shell takes the terminal back', async () => {
+      const before = await fp(baseline)
+      expect(await fp([shell({ tpgid: SHELL, stat: 'Ss+' }), agent({ stat: 'T' })])).not.toBe(
+        before
+      )
+    })
+
+    it('bg: the stopped job resumes in the background, foreground stays with the shell', async () => {
+      const stopped = await fp([shell({ tpgid: SHELL, stat: 'Ss+' }), agent({ stat: 'T' })])
+      const backgrounded = await fp([shell({ tpgid: SHELL, stat: 'Ss+' }), agent({ stat: 'S' })])
+      expect(backgrounded).not.toBe(stopped)
+      expect(backgrounded).not.toBe(await fp(baseline))
+    })
+
+    it('child churn: a subprocess appearing or disappearing under the agent', async () => {
+      const before = await fp(baseline)
+      const withChild = await fp([shell(), agent(), child(4310, AGENT)])
+      expect(withChild).not.toBe(before)
+      expect(await fp([shell(), agent(), child(4310, AGENT), child(4311, 4310)])).not.toBe(
+        withChild
+      )
+      // A child exec'ing away from the group (setsid / disown) is also a change.
+      expect(await fp([shell(), agent(), child(4310, AGENT, { pgid: 4310 })])).not.toBe(withChild)
+    })
+
+    it('shell replaced: same pid, different start time', async () => {
+      const before = await fp(baseline)
+      expect(await fp([shell({ startTime: 'Thu Sep 3 17:00:00 2026' }), agent()])).not.toBe(before)
+    })
+  })
+
+  describe('refuses to fingerprint an unfenced pane (caller must take the full capture)', () => {
+    it('root shell missing from the capture', async () => {
+      expect(await fp([foreign(), agent()])).toBeNull()
+    })
+
+    it('root shell has no start marker', async () => {
+      expect(await fp([shell({ startTime: undefined }), agent()])).toBeNull()
+    })
+
+    it('root shell has no job-control columns', async () => {
+      expect(await fp([shell({ pgid: undefined, tpgid: undefined }), agent()])).toBeNull()
+    })
+  })
+
+  describe('Linux', () => {
+    it('reads /proc start times for the pane subtree only and ignores ps start markers', async () => {
+      const asked: number[] = []
+      const read = async (pid: number): Promise<string | null> => {
+        asked.push(pid)
+        return pid === SHELL ? '1000' : pid === AGENT ? '2000' : null
+      }
+      const rows = [foreign(), shell({ startTime: undefined }), agent({ startTime: undefined })]
+      const a = await buildPaneProcessFingerprint(rows, SHELL, {
+        platform: 'linux',
+        readLinuxStartTime: read
+      })
+      expect(a).toContain(`${SHELL}@1000`)
+      expect(a).toContain(`${AGENT}@2000`)
+      expect(asked.sort()).toEqual([SHELL, AGENT].sort())
+      // An exit-and-replace changes only the /proc start ticks.
+      const replaced = await buildPaneProcessFingerprint(rows, SHELL, {
+        platform: 'linux',
+        readLinuxStartTime: async (pid) => (pid === AGENT ? '2500' : read(pid))
+      })
+      expect(replaced).not.toBe(a)
+    })
+
+    it('refuses when the root /proc entry cannot be read', async () => {
+      expect(
+        await buildPaneProcessFingerprint([shell(), agent()], SHELL, {
+          platform: 'linux',
+          readLinuxStartTime: async () => null
+        })
+      ).toBeNull()
+    })
+  })
+})

--- a/src/main/providers/posix-pane-foreground-fingerprint.test.ts
+++ b/src/main/providers/posix-pane-foreground-fingerprint.test.ts
@@ -150,5 +150,38 @@ describe('buildPaneProcessFingerprint', () => {
         })
       ).toBeNull()
     })
+    it('refuses when a DESCENDANT start marker cannot be read', async () => {
+      // Why: the start marker is what makes a pid comparison recycle-safe. Stamping a missing
+      // one as a placeholder let two captures that both failed to read it compare equal across
+      // a recycled pid, so a vanished agent looked unchanged and the cheap tier kept serving
+      // its name. Refusing sends the caller to the full capture.
+      const rows = [shell(), agent()]
+
+      expect(
+        await buildPaneProcessFingerprint(rows, SHELL, {
+          platform: 'linux',
+          readLinuxStartTime: async (pid) => (pid === SHELL ? '2400' : null)
+        })
+      ).toBeNull()
+    })
+
+    it('does not let a recycled descendant pid reuse a fingerprint', async () => {
+      // Both captures fail to read the descendant marker; the pid is reused by a different
+      // process in between. Equal fingerprints here would mask the agent's exit.
+      const readNoDescendant = async (pid: number): Promise<string | null> =>
+        pid === SHELL ? '2400' : null
+      const before = await buildPaneProcessFingerprint([shell(), agent()], SHELL, {
+        platform: 'linux',
+        readLinuxStartTime: readNoDescendant
+      })
+      const after = await buildPaneProcessFingerprint(
+        [shell(), agent({ stat: 'S+', pgid: AGENT })],
+        SHELL,
+        { platform: 'linux', readLinuxStartTime: readNoDescendant }
+      )
+
+      expect(before).toBeNull()
+      expect(after).toBeNull()
+    })
   })
 })

--- a/src/main/providers/posix-pane-foreground-fingerprint.ts
+++ b/src/main/providers/posix-pane-foreground-fingerprint.ts
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+import { collectDescendantsFromIndex, getProcessTableIndex } from '../../shared/process-table-index'
+import { parseLinuxProcStatStartTime } from '../../shared/process-table-snapshot-reader'
+
+/** The job-control columns both `ps` tiers carry; `command`/`tty` are deliberately absent. */
+export type PaneFingerprintRow = {
+  pid: number
+  ppid: number
+  pgid?: number
+  tpgid?: number
+  stat: string
+  startTime?: string
+}
+
+export type PaneFingerprintDeps = {
+  platform?: NodeJS.Platform
+  /** Linux: `/proc/<pid>/stat` field 22, read for the pane subtree only. */
+  readLinuxStartTime?: (pid: number) => Promise<string | null>
+}
+
+/**
+ * Only the job-control bits of `stat`. The scheduler letter (R/S/D/I/U) flips every tick
+ * on a working agent and says nothing about whether the pane changed hands; stopped,
+ * zombie, and foreground-group membership do.
+ */
+function jobControlState(stat: string): string {
+  const head = stat[0] ?? ''
+  const lifecycle = head === 'T' || head === 't' ? 'T' : head === 'Z' ? 'Z' : ''
+  return lifecycle + (stat.includes('+') ? '+' : '')
+}
+
+async function readLinuxProcStartTime(pid: number): Promise<string | null> {
+  try {
+    return parseLinuxProcStatStartTime(await readFile(`/proc/${pid}/stat`, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
+/**
+ * A per-pane summary of everything the cheap `ps` tier can see: the root shell's identity
+ * (pid + start marker) and terminal foreground group, and every descendant's identity, group,
+ * and job-control state. Two captures with equal fingerprints describe the same pane
+ * subtree, so the name resolved from the last full capture still holds.
+ *
+ * Null when the root is missing or unfenced (no start marker, no group columns): callers
+ * must then take the full capture rather than trust a comparison that could not be made.
+ */
+export async function buildPaneProcessFingerprint(
+  rows: readonly PaneFingerprintRow[],
+  rootPid: number,
+  deps: PaneFingerprintDeps = {}
+): Promise<string | null> {
+  const platform = deps.platform ?? process.platform
+  const index = getProcessTableIndex(rows)
+  const root = index.byPid.get(rootPid)
+  if (!root || root.pgid === undefined || root.tpgid === undefined) {
+    return null
+  }
+  const descendants = collectDescendantsFromIndex(index, rootPid)
+  const subtree = [root, ...descendants]
+  let startTimes: ReadonlyMap<number, string | null>
+  if (platform === 'linux') {
+    const read = deps.readLinuxStartTime ?? readLinuxProcStartTime
+    const entries = await Promise.all(
+      subtree.map(async (row) => [row.pid, await read(row.pid)] as const)
+    )
+    startTimes = new Map(entries)
+  } else {
+    // Collapse `lstart` padding (`Sep  3`) so both column sets stamp identically.
+    startTimes = new Map(
+      subtree.map((row) => [row.pid, row.startTime?.replace(/\s+/g, ' ') ?? null] as const)
+    )
+  }
+  const rootStart = startTimes.get(rootPid)
+  if (!rootStart) {
+    return null
+  }
+  const members = descendants
+    .map(
+      (row) =>
+        `${row.pid}@${startTimes.get(row.pid) ?? '?'}:${row.pgid ?? '?'}:${jobControlState(row.stat)}`
+    )
+    .sort()
+  return `${rootPid}@${rootStart}#${root.tpgid}:${jobControlState(root.stat)}|${members.join(',')}`
+}

--- a/src/main/providers/posix-pane-foreground-fingerprint.ts
+++ b/src/main/providers/posix-pane-foreground-fingerprint.ts
@@ -76,11 +76,18 @@ export async function buildPaneProcessFingerprint(
   if (!rootStart) {
     return null
   }
-  const members = descendants
-    .map(
-      (row) =>
-        `${row.pid}@${startTimes.get(row.pid) ?? '?'}:${row.pgid ?? '?'}:${jobControlState(row.stat)}`
-    )
-    .sort()
+  // Why every member, not just the root: a start marker is what makes a pid comparison
+  // recycle-safe. Stamping a missing one as a placeholder would let two captures that both
+  // failed to read it compare equal across a recycled pid, so a vanished agent could look
+  // unchanged. Refusing the fingerprint sends the caller to the full capture instead.
+  const members: string[] = []
+  for (const row of descendants) {
+    const startTime = startTimes.get(row.pid)
+    if (!startTime) {
+      return null
+    }
+    members.push(`${row.pid}@${startTime}:${row.pgid ?? '?'}:${jobControlState(row.stat)}`)
+  }
+  members.sort()
   return `${rootPid}@${rootStart}#${root.tpgid}:${jobControlState(root.stat)}|${members.join(',')}`
 }

--- a/src/main/providers/pty-process-inspection.ts
+++ b/src/main/providers/pty-process-inspection.ts
@@ -23,6 +23,9 @@ type CompletionSensitivePtyProvider = IPtyProvider & {
 export type PtyProcessInspectionOptions = {
   expectedIncarnationId?: PtyIncarnationId
   scanChildProcesses?: boolean
+  /** A self-correcting cadence poll that reads only the process name: licenses a host to answer
+   *  from a cheap capture and OMIT evidence. Never set by a caller that consumes evidence. */
+  steadyState?: boolean
 }
 
 export async function inspectPtyProviderProcess(

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -112,7 +112,11 @@ export type PtyApi = {
   getForegroundProcess: (id: string) => Promise<string | null>
   inspectProcess: (
     id: string,
-    options?: { expectedIncarnationId?: string; scanChildProcesses?: boolean }
+    options?: {
+      expectedIncarnationId?: string
+      scanChildProcesses?: boolean
+      steadyState?: boolean
+    }
   ) => Promise<TerminalProcessInspection>
   confirmForegroundProcess: (id: string) => Promise<string | null>
   getCwd: (id: string) => Promise<string>

--- a/src/preload/api/pty-bridge-stream-and-serialization.ts
+++ b/src/preload/api/pty-bridge-stream-and-serialization.ts
@@ -7,7 +7,11 @@ import type { TerminalProcessInspection } from '../../shared/terminal-process-in
 export const ptyStreamAndSerializationApi = {
   inspectProcess: (
     id: string,
-    options?: { expectedIncarnationId?: string; scanChildProcesses?: boolean }
+    options?: {
+      expectedIncarnationId?: string
+      scanChildProcesses?: boolean
+      steadyState?: boolean
+    }
   ): Promise<TerminalProcessInspection> =>
     ipcRenderer.invoke('pty:inspectProcess', { id, ...options }),
   confirmForegroundProcess: (id: string): Promise<string | null> =>

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -32,7 +32,7 @@ export type AgentCompletionCoordinatorOptions = {
   inspectProcess: (
     settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
     ptyId: string,
-    options?: { expectedIncarnationId?: string }
+    options?: { expectedIncarnationId?: string; steadyState?: boolean }
   ) => Promise<RuntimeTerminalProcessInspection>
   dispatchCompletion: (title: string, meta?: AgentCompletionDispatchMeta) => void
   dispatchAttention?: (title: string, meta: AgentAttentionDispatchMeta) => void

--- a/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-process-monitor.ts
@@ -108,10 +108,18 @@ export function createAgentCompletionProcessMonitor({
         let inspectedRecognizedAgent = false
         let inspectionSucceeded = false
         try {
-          const result = await (expectedIncarnationIdAtRequest
-            ? options.inspectProcess(options.getSettings(), ptyId, {
-                expectedIncarnationId: expectedIncarnationIdAtRequest
-              })
+          // Only a cadence tick on a local pane reads nothing but the name; every other read
+          // (pending-title, remote) needs the full capture and must not ask for the cheap one.
+          const inspectOptions = {
+            ...(expectedIncarnationIdAtRequest
+              ? { expectedIncarnationId: expectedIncarnationIdAtRequest }
+              : {}),
+            ...(priority === 'cadence' && options.isRemotePtyId?.(ptyId) !== true
+              ? { steadyState: true }
+              : {})
+          }
+          const result = await (Object.keys(inspectOptions).length > 0
+            ? options.inspectProcess(options.getSettings(), ptyId, inspectOptions)
             : options.inspectProcess(options.getSettings(), ptyId))
           if (
             !state.disposed &&

--- a/src/renderer/src/components/terminal-pane/agent-completion-steady-state-opt-in.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-steady-state-opt-in.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import {
+  flushAsyncTicks,
+  processResult,
+  useAgentCompletionCoordinatorLifecycle
+} from './agent-completion-coordinator-test-harness'
+
+// The renderer opts a read into the cheap tier ONLY when it is a self-correcting cadence poll on a
+// local pane. Pending-title reads decide a completion once and remote reads consume evidence, so
+// neither may ask for a capture that omits evidence.
+describe('agent completion steadyState opt-in', () => {
+  useAgentCompletionCoordinatorLifecycle()
+
+  const optionsOf = (call: unknown[]): unknown => call[2]
+
+  it('marks cadence polls on a local pane as steadyState', async () => {
+    const inspectProcess = vi.fn(async () => processResult('codex'))
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess,
+      dispatchCompletion: vi.fn(),
+      isLive: () => true,
+      shouldPollProcessCadence: () => true
+    })
+    coordinator.startProcessTracking()
+    coordinator.observeTitle('Codex working')
+    vi.advanceTimersByTime(3_000)
+    await flushAsyncTicks()
+    expect(inspectProcess).toHaveBeenCalled()
+    for (const call of inspectProcess.mock.calls) {
+      expect(optionsOf(call as unknown[])).toEqual({ steadyState: true })
+    }
+    coordinator.dispose()
+  })
+
+  it('a pending-title read on a local pane is NOT steadyState: it decides a completion once', async () => {
+    const inspectProcess = vi.fn(async () => processResult('codex'))
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess,
+      dispatchCompletion: vi.fn(),
+      isLive: () => true,
+      shouldPollProcessCadence: () => false
+    })
+    coordinator.observeTitle('Codex working')
+    coordinator.observeTitle('/tmp/orca-e2e-repo')
+    await flushAsyncTicks()
+    expect(inspectProcess).toHaveBeenCalled()
+    for (const call of inspectProcess.mock.calls) {
+      expect(optionsOf(call as unknown[])).toBeUndefined()
+    }
+    coordinator.dispose()
+  })
+
+  it('never marks a remote pane as steadyState: remote identity needs evidence', async () => {
+    const inspectProcess = vi.fn(async () => processResult('codex'))
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'remote:pty-1',
+      isRemotePtyId: () => true,
+      getExpectedIncarnationId: () => 'inc-1',
+      getSettings: () => null,
+      inspectProcess,
+      dispatchCompletion: vi.fn(),
+      isLive: () => true,
+      shouldPollProcessCadence: () => true
+    })
+    coordinator.startProcessTracking()
+    coordinator.observeTitle('Codex working')
+    coordinator.observeTitle('/tmp/orca-e2e-repo')
+    vi.advanceTimersByTime(3_000)
+    await flushAsyncTicks()
+    expect(inspectProcess).toHaveBeenCalled()
+    for (const call of inspectProcess.mock.calls) {
+      expect(optionsOf(call as unknown[])).toEqual({ expectedIncarnationId: 'inc-1' })
+    }
+    coordinator.dispose()
+  })
+})

--- a/src/renderer/src/runtime/runtime-terminal-inspection.ts
+++ b/src/renderer/src/runtime/runtime-terminal-inspection.ts
@@ -138,7 +138,7 @@ export function recordRuntimeTerminalInputForPtyId(ptyId: string, timestamp = Da
 export async function inspectRuntimeTerminalProcess(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   ptyId: string,
-  options?: { expectedIncarnationId?: string; scanChildProcesses?: boolean }
+  options?: { expectedIncarnationId?: string; scanChildProcesses?: boolean; steadyState?: boolean }
 ): Promise<RuntimeTerminalProcessInspection> {
   const ownerEnvironmentId = getRemoteRuntimePtyEnvironmentId(ptyId)
   const target = ownerEnvironmentId

--- a/src/shared/cheap-process-table-snapshot-reader.ts
+++ b/src/shared/cheap-process-table-snapshot-reader.ts
@@ -1,0 +1,54 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+import {
+  CHEAP_PS_ARGS,
+  PS_MAX_BUFFER_BYTES,
+  ProcessTableCaptureError,
+  parseCheapProcessTableRows,
+  type CheapProcessTableRow
+} from './process-table-snapshot'
+import {
+  PS_TIMEOUT_MS,
+  createProcessTableSnapshotReader,
+  withEvidenceBudget
+} from './process-table-snapshot-reader'
+
+const execFile = promisify(execFileCb)
+
+/**
+ * The cheap-tier sibling of the strict evidence reader: same coalescing and TTL, a
+ * column set without `tty=`/`command=`. Separate instance because the two column sets
+ * parse differently and a cheap capture must never be served to an evidence consumer.
+ */
+const cheapProcessTableReader = createProcessTableSnapshotReader<CheapProcessTableRow[]>({
+  runPs: async () => {
+    let stdout: string
+    try {
+      ;({ stdout } = await execFile('ps', [...CHEAP_PS_ARGS], {
+        encoding: 'utf-8',
+        timeout: PS_TIMEOUT_MS,
+        maxBuffer: PS_MAX_BUFFER_BYTES
+      }))
+    } catch (error) {
+      if ((error as { code?: unknown } | null)?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+        throw new ProcessTableCaptureError('capture_truncated')
+      }
+      throw error
+    }
+    if (Buffer.byteLength(stdout, 'utf-8') >= PS_MAX_BUFFER_BYTES) {
+      throw new ProcessTableCaptureError('capture_truncated')
+    }
+    return parseCheapProcessTableRows(stdout)
+  },
+  now: () => Date.now()
+})
+
+/** Same wait bound as the evidence read: a stalled cheap capture must fall through to the full
+ *  path's own handling rather than pin a polled tick. */
+export async function getCheapProcessTableSnapshot(): Promise<CheapProcessTableRow[]> {
+  return withEvidenceBudget(cheapProcessTableReader.getSnapshot())
+}
+
+export function resetCheapProcessTableSnapshotForTests(): void {
+  cheapProcessTableReader.reset()
+}

--- a/src/shared/cheap-process-table-snapshot-reader.ts
+++ b/src/shared/cheap-process-table-snapshot-reader.ts
@@ -1,5 +1,4 @@
-import { execFile as execFileCb } from 'node:child_process'
-import { promisify } from 'node:util'
+import { runProcess } from './child-process/run-process'
 import {
   CHEAP_PS_ARGS,
   PS_MAX_BUFFER_BYTES,
@@ -13,8 +12,6 @@ import {
   withEvidenceBudget
 } from './process-table-snapshot-reader'
 
-const execFile = promisify(execFileCb)
-
 /**
  * The cheap-tier sibling of the strict evidence reader: same coalescing and TTL, a
  * column set without `tty=`/`command=`. Separate instance because the two column sets
@@ -22,23 +19,23 @@ const execFile = promisify(execFileCb)
  */
 const cheapProcessTableReader = createProcessTableSnapshotReader<CheapProcessTableRow[]>({
   runPs: async () => {
-    let stdout: string
-    try {
-      ;({ stdout } = await execFile('ps', [...CHEAP_PS_ARGS], {
-        encoding: 'utf-8',
-        timeout: PS_TIMEOUT_MS,
-        maxBuffer: PS_MAX_BUFFER_BYTES
-      }))
-    } catch (error) {
-      if ((error as { code?: unknown } | null)?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
-        throw new ProcessTableCaptureError('capture_truncated')
-      }
-      throw error
-    }
-    if (Buffer.byteLength(stdout, 'utf-8') >= PS_MAX_BUFFER_BYTES) {
+    const result = await runProcess({
+      program: 'ps',
+      args: CHEAP_PS_ARGS,
+      timeoutMs: PS_TIMEOUT_MS,
+      maxOutputBytes: PS_MAX_BUFFER_BYTES
+    })
+    // A ceiling hit is truncation, not absence: name it in the domain vocabulary.
+    if (result.outputTruncated) {
       throw new ProcessTableCaptureError('capture_truncated')
     }
-    return parseCheapProcessTableRows(stdout)
+    if (result.timedOut) {
+      throw new ProcessTableCaptureError('capture_timeout')
+    }
+    if (result.code !== 0) {
+      throw new ProcessTableCaptureError(`ps_exit_${result.code ?? result.signal ?? 'unknown'}`)
+    }
+    return parseCheapProcessTableRows(result.stdout)
   },
   now: () => Date.now()
 })

--- a/src/shared/cheap-process-table-snapshot.test.ts
+++ b/src/shared/cheap-process-table-snapshot.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
 
-vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+// The cheap reader goes through Orca's single child-process entry point (windowsHide, argv
+// encoding, tree termination); mock at that seam rather than node:child_process.
+vi.mock('./child-process/run-process', () => ({ runProcess: runProcessMock }))
 
 import {
   getCheapProcessTableSnapshot,
   resetCheapProcessTableSnapshotForTests
 } from './cheap-process-table-snapshot-reader'
+import { PS_TIMEOUT_MS } from './process-table-snapshot-reader'
 import {
   CHEAP_PS_ARGS,
   PS_ARGS,
@@ -16,14 +19,11 @@ import {
   ProcessTableCaptureError
 } from './process-table-snapshot'
 
-function installPs(stdout: string): string[][] {
+function installPs(stdout: string, outputTruncated = false): string[][] {
   const calls: string[][] = []
-  execFileMock.mockImplementation((cmd: string, args: string[], _opts: unknown, cb: unknown) => {
-    calls.push([cmd, ...args])
-    ;(cb as (err: unknown, result: { stdout: string; stderr: string }) => void)(null, {
-      stdout,
-      stderr: ''
-    })
+  runProcessMock.mockImplementation(async (spec: { program: string; args: readonly string[] }) => {
+    calls.push([spec.program, ...spec.args])
+    return { code: 0, signal: null, stdout, stderr: '', timedOut: false, outputTruncated }
   })
   return calls
 }
@@ -82,7 +82,7 @@ describe('parseCheapProcessTableRows', () => {
 
 describe('getCheapProcessTableSnapshot', () => {
   beforeEach(() => {
-    execFileMock.mockReset()
+    runProcessMock.mockReset()
     resetCheapProcessTableSnapshotForTests()
     vi.useFakeTimers({ toFake: ['Date'] })
     vi.setSystemTime(0)
@@ -110,19 +110,38 @@ describe('getCheapProcessTableSnapshot', () => {
     expect(calls).toHaveLength(2)
   })
 
-  it('names a capture at the buffer ceiling as truncated', async () => {
-    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: unknown) => {
-      ;(cb as (err: unknown) => void)(
-        Object.assign(new Error('maxBuffer'), { code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' })
-      )
-    })
+  it('passes the full-tier buffer ceiling and timeout to the runner', async () => {
+    installPs(' 7 1 7 7 S\n')
+    await getCheapProcessTableSnapshot()
+    expect(runProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({ maxOutputBytes: PS_MAX_BUFFER_BYTES, timeoutMs: PS_TIMEOUT_MS })
+    )
+  })
+
+  it('names a clipped capture as truncated, a killed one as a timeout, and a non-zero exit by its code', async () => {
+    installPs(' 7 1 7 7 S\n', true)
     await expect(getCheapProcessTableSnapshot()).rejects.toMatchObject({
       reason: 'capture_truncated'
     })
     resetCheapProcessTableSnapshotForTests()
-    installPs(' 7 1 7 7 S\n'.padEnd(PS_MAX_BUFFER_BYTES, ' '))
-    await expect(getCheapProcessTableSnapshot()).rejects.toMatchObject({
-      reason: 'capture_truncated'
+    runProcessMock.mockResolvedValueOnce({
+      code: null,
+      signal: 'SIGKILL',
+      stdout: '',
+      stderr: '',
+      timedOut: true
     })
+    await expect(getCheapProcessTableSnapshot()).rejects.toMatchObject({
+      reason: 'capture_timeout'
+    })
+    resetCheapProcessTableSnapshotForTests()
+    runProcessMock.mockResolvedValueOnce({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'ps: bad column',
+      timedOut: false
+    })
+    await expect(getCheapProcessTableSnapshot()).rejects.toMatchObject({ reason: 'ps_exit_1' })
   })
 })

--- a/src/shared/cheap-process-table-snapshot.test.ts
+++ b/src/shared/cheap-process-table-snapshot.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+import {
+  getCheapProcessTableSnapshot,
+  resetCheapProcessTableSnapshotForTests
+} from './cheap-process-table-snapshot-reader'
+import {
+  CHEAP_PS_ARGS,
+  PS_ARGS,
+  PS_MAX_BUFFER_BYTES,
+  parseCheapProcessTableRows,
+  ProcessTableCaptureError
+} from './process-table-snapshot'
+
+function installPs(stdout: string): string[][] {
+  const calls: string[][] = []
+  execFileMock.mockImplementation((cmd: string, args: string[], _opts: unknown, cb: unknown) => {
+    calls.push([cmd, ...args])
+    ;(cb as (err: unknown, result: { stdout: string; stderr: string }) => void)(null, {
+      stdout,
+      stderr: ''
+    })
+  })
+  return calls
+}
+
+describe('parseCheapProcessTableRows', () => {
+  it('parses the macOS column set with a padded lstart marker', () => {
+    const rows = parseCheapProcessTableRows(
+      [
+        '    1     0     1    0 Ss   Tue Sep  1 01:49:39 2026',
+        ' 4242  4200  4242 4243 S    Thu Sep  3 16:02:01 2026',
+        ' 4243  4242  4243 4243 S+   Thu Sep  3 16:02:05 2026',
+        ''
+      ].join('\n')
+    )
+    expect(rows).toEqual([
+      { pid: 1, ppid: 0, pgid: 1, tpgid: 0, stat: 'Ss', startTime: 'Tue Sep  1 01:49:39 2026' },
+      {
+        pid: 4242,
+        ppid: 4200,
+        pgid: 4242,
+        tpgid: 4243,
+        stat: 'S',
+        startTime: 'Thu Sep  3 16:02:01 2026'
+      },
+      {
+        pid: 4243,
+        ppid: 4242,
+        pgid: 4243,
+        tpgid: 4243,
+        stat: 'S+',
+        startTime: 'Thu Sep  3 16:02:05 2026'
+      }
+    ])
+  })
+
+  it('parses the Linux column set, which carries no start marker', () => {
+    const rows = parseCheapProcessTableRows(
+      '   2     0     0   -1 S\r\n 900   1   900  900 Ss+\r\n'
+    )
+    expect(rows).toEqual([
+      { pid: 2, ppid: 0, pgid: 0, tpgid: -1, stat: 'S' },
+      { pid: 900, ppid: 1, pgid: 900, tpgid: 900, stat: 'Ss+' }
+    ])
+  })
+
+  it('skips malformed rows rather than failing the capture', () => {
+    expect(parseCheapProcessTableRows('garbage\n 7 1 7 7 S\n')).toEqual([
+      { pid: 7, ppid: 1, pgid: 7, tpgid: 7, stat: 'S' }
+    ])
+  })
+
+  it('treats an empty capture as unreadable, never as "no processes"', () => {
+    expect(() => parseCheapProcessTableRows('\n\n')).toThrow(ProcessTableCaptureError)
+  })
+})
+
+describe('getCheapProcessTableSnapshot', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    resetCheapProcessTableSnapshotForTests()
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(0)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('forks ps with the cheap column set only, never tty or command', async () => {
+    const calls = installPs(' 7 1 7 7 S\n')
+    await getCheapProcessTableSnapshot()
+    expect(calls).toEqual([['ps', ...CHEAP_PS_ARGS]])
+    expect(CHEAP_PS_ARGS.join(' ')).not.toMatch(/tty=|command=|etimes=/)
+    expect(CHEAP_PS_ARGS).not.toEqual(PS_ARGS)
+  })
+
+  it('coalesces concurrent readers onto one fork and honours the TTL', async () => {
+    const calls = installPs(' 7 1 7 7 S\n')
+    await Promise.all([getCheapProcessTableSnapshot(), getCheapProcessTableSnapshot()])
+    await getCheapProcessTableSnapshot()
+    expect(calls).toHaveLength(1)
+    vi.setSystemTime(600)
+    await getCheapProcessTableSnapshot()
+    expect(calls).toHaveLength(2)
+  })
+
+  it('names a capture at the buffer ceiling as truncated', async () => {
+    execFileMock.mockImplementation((_c: string, _a: string[], _o: unknown, cb: unknown) => {
+      ;(cb as (err: unknown) => void)(
+        Object.assign(new Error('maxBuffer'), { code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER' })
+      )
+    })
+    await expect(getCheapProcessTableSnapshot()).rejects.toMatchObject({
+      reason: 'capture_truncated'
+    })
+    resetCheapProcessTableSnapshotForTests()
+    installPs(' 7 1 7 7 S\n'.padEnd(PS_MAX_BUFFER_BYTES, ' '))
+    await expect(getCheapProcessTableSnapshot()).rejects.toMatchObject({
+      reason: 'capture_truncated'
+    })
+  })
+})

--- a/src/shared/process-table-snapshot-reader.ts
+++ b/src/shared/process-table-snapshot-reader.ts
@@ -207,6 +207,19 @@ function assertWholeCapture(stdout: string): string {
   return stdout
 }
 
+/** Field 22 (`starttime`) of `/proc/<pid>/stat`, read past the parenthesised comm. */
+export function parseLinuxProcStatStartTime(stat: string): string | null {
+  const closingParen = stat.lastIndexOf(')')
+  if (closingParen === -1) {
+    return null
+  }
+  const tail = stat
+    .slice(closingParen + 1)
+    .trim()
+    .split(/\s+/)
+  return tail[19] || null
+}
+
 /** Read Linux's stable PID start-time ticks without spawning another process. */
 async function readLinuxProcessStartTimes(
   rows: readonly ProcessTableRow[]
@@ -218,16 +231,9 @@ async function readLinuxProcessStartTimes(
   const starts = await Promise.all(
     candidates.map(async (row) => {
       try {
-        const stat = await readFile(`/proc/${row.pid}/stat`, 'utf8')
-        const closingParen = stat.lastIndexOf(')')
-        if (closingParen === -1) {
-          return null
-        }
-        const tail = stat
-          .slice(closingParen + 1)
-          .trim()
-          .split(/\s+/)
-        const startTime = tail[19]
+        const startTime = parseLinuxProcStatStartTime(
+          await readFile(`/proc/${row.pid}/stat`, 'utf8')
+        )
         return startTime ? ([row.pid, startTime] as const) : null
       } catch {
         return null
@@ -300,7 +306,7 @@ export const PROCESS_TABLE_EVIDENCE_BUDGET_MS = 1_200
  *  capture some identity probe started under the 15s budget; abandoning the wait leaves that
  *  capture running to fill the cache instead of forking a second whole-machine `ps` on the host
  *  that can least afford one. */
-async function withEvidenceBudget<T>(pending: Promise<T>): Promise<T> {
+export async function withEvidenceBudget<T>(pending: Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined
   try {
     return await Promise.race([

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -20,6 +20,60 @@ export const PS_ARGS = (
     : ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,tty=,etimes=,command=']
 ) as readonly string[]
 
+/**
+ * Cheap tier: the same job-control columns without `tty=` (0.29s of the 0.34s on a
+ * 1,900-process Mac) or `command=` (per-pid argv read, 1.15s on Linux). Enough to prove a
+ * pane's subtree is unchanged since the last full capture; never enough to name a process.
+ * No `etimes=` on Linux: it is elapsed seconds, so it changes every tick; the stable start
+ * marker comes from `/proc/<pid>/stat` for the pane subtree only.
+ */
+export const CHEAP_PS_ARGS = (
+  process.platform === 'darwin'
+    ? ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,lstart=']
+    : ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=']
+) as readonly string[]
+
+export type CheapProcessTableRow = {
+  pid: number
+  ppid: number
+  pgid: number
+  tpgid: number
+  stat: string
+  /** Host start marker when the column set carries one (macOS `lstart`). */
+  startTime?: string
+}
+
+/**
+ * Parse a {@link CHEAP_PS_ARGS} capture. Lenient on purpose: a dropped row can only make a
+ * fingerprint DIFFER from the strict full-capture one, which escalates to the full capture --
+ * the safe direction. An empty capture is unreadable, not "no processes".
+ */
+export function parseCheapProcessTableRows(stdout: string): CheapProcessTableRow[] {
+  const rows: CheapProcessTableRow[] = []
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const match = rawLine.trim().match(/^(\d+)\s+(\d+)\s+(-?\d+)\s+(-?\d+)\s+(\S+)(?:\s+(.+?))?$/)
+    if (!match) {
+      continue
+    }
+    const pid = Number(match[1])
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      continue
+    }
+    rows.push({
+      pid,
+      ppid: Number(match[2]),
+      pgid: Number(match[3]),
+      tpgid: Number(match[4]),
+      stat: match[5],
+      ...(match[6] !== undefined ? { startTime: match[6] } : {})
+    })
+  }
+  if (rows.length === 0) {
+    throw new ProcessTableCaptureError('empty_capture')
+  }
+  return rows
+}
+
 // Why: execFile's 1MB default leaves ~3x headroom (326KB / 1,460 processes, and
 // a single 5KB argv row is ordinary), so a busy host overflows it and then EVERY
 // capture fails — a readable process table degrading into permanent


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1148 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1148 |
| Prod | 23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​466 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​428 |

<!-- /orca-pr-loc -->

## ELI5

Every terminal pane running an agent asks the daemon "what's in front?" every couple of seconds. To answer, the daemon read the entire machine's process table with two expensive columns (`tty=`, `command=`) so it could build a proof-of-identity record. For local panes the renderer never reads that proof; it only uses the process name. So we were paying 0.34-0.50s (macOS, 1,900 procs) or 1.15s (Linux) per tick for a record that was thrown away.

Now, once a pane has already been proven to be running a recognized agent, each tick first takes a 0.03s "cheap" look (same job-control columns, no tty/command) and checks whether the pane's process subtree is byte-for-byte what the last full look saw. If yes, the cached name is served. If anything at all differs, it does the full look exactly as before.

## What changed

- `src/shared/process-table-snapshot.ts`: `CHEAP_PS_ARGS` (macOS `pid,ppid,pgid,tpgid,stat,lstart`; Linux drops `lstart` and reads `/proc/<pid>/stat` field 22 for the pane subtree only) and a lenient `parseCheapProcessTableRows`.
- `src/shared/cheap-process-table-snapshot-reader.ts`: second `createProcessTableSnapshotReader` instance with the same TTL/coalescing/budget as the strict reader, so 8 panes share one cheap fork per tick. Spawns through `runProcess` (Orca's single child-process entry point; the import-boundary and `windowsHide` ratchet tests reject a direct `node:child_process` import), mapping `outputTruncated`/`timedOut`/non-zero exit onto the existing `ProcessTableCaptureError` vocabulary.
- `src/main/providers/posix-pane-foreground-fingerprint.ts`: per-pane fingerprint = root shell `pid@startTime`, `tpgid`, job-control state, plus every descendant's `pid@startTime:pgid:jobControlState` (sorted). Job-control state keeps only stopped/zombie/`+`; the scheduler letter is deliberately excluded because a working agent flips R/S every tick.
- `src/main/daemon/terminal-host-steady-state-anchor.ts`: a `WeakMap<Session, anchor>` set only after a full capture returns `live` with a recognized agent name; cleared on any full capture that does not.
- `src/main/daemon/terminal-host-process-inspection.ts`: when `steadyState: true` and the incarnation matches and an anchor exists and node-pty's raw name is unchanged and the cheap fingerprint matches, return `{ foregroundProcess, hasChildProcesses: true }` **with no `foregroundProcessEvidence` member**. Every other path is today's code unchanged.
- `src/main/providers/local-pty-foreground-inspection.ts`: POSIX twin of the existing Windows job-membership short-circuit, for the non-daemon `LocalPtyProvider`. Stores the fingerprint alongside `ptyLastRecognizedForeground`.
- `steadyState` plumbed as an optional field: preload `pty-api.ts` / bridge, `inspect.ts` IPC handler, `PtyProcessInspectionOptions`, `DaemonPtyProcessInspection`, `DaemonPtyRouter`, `TerminalHost`, daemon request router, `InspectProcessRequest`. The renderer sets it only for `priority === 'cadence'` on a local pane.
- `foreground-process-tracker.ts`: one new read option, `getForegroundProcess({ rawFallback: true })`, which returns node-pty's own name with no cache and no background refresh. Needed so the cheap tick cannot trigger a full `ps` as a side effect.

Deliberately **not** touched: `windows-process-table.ts`, `windows-agent-foreground-process.ts`, `pty-handler.ts` (relay/SSH), `terminal-query-methods.ts` / `unary-schemas.ts` (runtime RPC), `confirmForegroundProcess`, pending-title reads.

## Negative user-facing trade-offs

**Panes without a recognized agent anchor always take the full capture, which is why start discovery is unchanged.** The cheap tier is only ever consulted on a pane whose last full capture returned a `live` verdict naming a recognized agent. A pane at a shell prompt, a pane whose agent was just launched, a pane whose agent just exited, a pane after an `unverifiable` read, and every pane with a fresh incarnation pays exactly what it paid before. The one case the cheap tier cannot see (a non-leader descendant `exec`ing into an agent with the same pid/pgid/start time) can therefore only occur on a pane that is already anchored, and on such a pane it is by definition not a start.

Completion detection: a recognized agent's exit is always a pid disappearing from the subtree, or a start-time change if the pid is reused, and both change the fingerprint. The scan-volume test drives an exit, a restart, and a second exit through the same tick sequence with the tier on and off and asserts the `foregroundProcess` series is identical (`toEqual`).

What still costs the same as today:
- The first cadence tick of every pane, and the first tick after any change.
- Every `pending-title` read (decides a completion once).
- Every remote/paired-runtime `terminal.inspectProcess` and the restore path; neither sends `steadyState` and both keep consuming full evidence.
- Every `confirmForegroundProcess` / `confirmShellForeground`.
- Windows entirely.

Nothing gets slower. Nothing is detected later than before.

## Measured

`src/main/daemon/terminal-host-cheap-tier-ps-scan-volume.test.ts`: 8 idle agent panes, 60s at the 2,000ms idle cadence (30 ticks), forks counted **by column set** because CI cannot time a real `ps` portably.

| | full forks | cheap forks |
|---|---|---|
| Before (or any caller that does not opt in) | 30 | 0 |
| After | **1** | **29** |

Per-fork cost measured by hand on this Mac (1,924 procs, 3 runs each): full column set 0.34-0.49s, cheap column set 0.03s. `tty=` alone is 0.29s of the full cost. So for this workload, ~10-15s of `ps` CPU per minute becomes ~0.3-0.5s + one full capture.

Honest caveat: the "1 full" is the best case (every pane anchored on tick 1 and nothing changes for 60s). Any real event (an agent spawning a subprocess, a child exiting, Ctrl-Z) costs one full capture on that tick, then returns to cheap. Agents that spawn short-lived helpers every tick would see little benefit; they would see no regression either, since a changed fingerprint costs a cheap fork plus the full fork that was already being paid.

## Wire compatibility

`steadyState` is a new optional field on an existing daemon request and IPC payload (Rule 1 in `docs/reference/remote-wire-compatibility.md`). An old daemon ignores it and answers with the full capture; the client then reads evidence it did not strictly need, which is today's behaviour. `daemon-pty-adapter-steady-state-compat.test.ts` covers: field sent when requested, wire byte-identical when not, old daemon's full-shape answer accepted, pre-inspection daemon never sees it. It is not sent over the runtime RPC or the SSH relay at all.

## Tests

- `cheap-process-table-snapshot.test.ts`: parser (macOS padded `lstart`, Linux, malformed rows, empty capture), reader (column set, coalescing/TTL, truncation).
- `posix-pane-foreground-fingerprint.test.ts`: stability under scheduler-state/row-order/foreign-pane changes; escalation on agent exit, exit-and-replace, Ctrl-Z, `bg`, child churn (spawn, nest, leave group), shell replaced; null on unfenced root; Linux `/proc` reads scoped to the subtree.
- `terminal-host-process-inspection-cheap-tier.test.ts`: no-anchor pane never takes the cheap path; anchored pane served cheap **with no evidence member**; no `steadyState` always gets full + evidence; escalation matrix; changed node-pty name escalates without a cheap fork; cheap fork failure and incarnation mismatch fall through; dead session never served; anchor dropped when a full capture stops naming an agent.
- `local-pty-foreground-inspection-cheap-tier.test.ts`: same gate on the non-daemon provider.
- `agent-completion-steady-state-opt-in.test.ts`: cadence on local pane sends it; pending-title does not; remote pane never does.
- `terminal-host-cheap-tier-ps-scan-volume.test.ts`: the numbers above plus the on/off differential proof.

Zero existing tests modified.
