### PR TITLE
feat(i18n): localize onboarding flow to Japanese

### DIFF
--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14561,6 +14561,41 @@
     }
   },
   "components": {
+    "onboarding": {
+      "flow": {
+        "stepTooltip": {
+          "agent": "デフォルトの Agent",
+          "theme": "外観",
+          "windowsTerminal": "Windows ターミナル",
+          "notifications": "通知",
+          "integrations": "連携"
+        },
+        "actions": {
+          "addFirstProject": "最初のプロジェクトを追加",
+          "continue": "続行",
+          "openingAddProject": "[プロジェクトを追加] を開いています…"
+        }
+      },
+      "skipConfirmation": {
+        "skip": "スキップ",
+        "keepGoing": "いいえ、続ける"
+      },
+      "theme": {
+        "hints": {
+          "system": "OS に合わせる",
+          "dark": "目にやさしい",
+          "light": "明るく鮮明"
+        }
+      },
+      "integrations": {
+        "capabilities": {
+          "startWorkspaceFromIssue": "GitHub の Issue や PR から、タイトルとコンテキストがあらかじめ入力されたワークスペースを開始",
+          "browseIssues": "Orca から離れずに、「タスク」ページで GitHub の Issue と PR を閲覧",
+          "reviewStatus": "すべてのワークツリーで Issue の状態、レビュー状況、CI チェックを確認",
+          "managePullRequests": "Orca から離れずに、PR の閲覧、コメント、マージ"
+        }
+      }
+    },
     "native-chat": {
       "composer": {
         "imageUnsupported": "この Agent では画像の貼り付けはサポートされていません。",


### PR DESCRIPTION
## ELI5

When Orca's UI language is set to Japanese, the first-run onboarding still shows English in a few places: the tooltips over the step-progress bars, the footer buttons (Continue / Add your first project), the "Skip onboarding?" dialog buttons, the short hints under the System / Dark / Light theme cards, and the GitHub capability bullets on the Integrations step.

#17992 moved those strings onto semantic `components.onboarding.*` keys and added Korean; `ja.json` never got the namespace, so Japanese users still see the English fallback on the very first screens. This PR adds the Japanese translations so the onboarding flow reads fully in Japanese.

## What Changed

Added the 17 missing `components.onboarding.*` keys to `src/renderer/src/i18n/locales/ja.json`, mirroring the `en.json` structure exactly:

| Key | English | Japanese |
|---|---|---|
| `flow.stepTooltip.agent` | Default Agent | デフォルトの Agent |
| `flow.stepTooltip.theme` | Appearance | 外観 |
| `flow.stepTooltip.windowsTerminal` | Windows Terminal | Windows ターミナル |
| `flow.stepTooltip.notifications` | Notifications | 通知 |
| `flow.stepTooltip.integrations` | Integrations | 連携 |
| `flow.actions.addFirstProject` | Add your first project | 最初のプロジェクトを追加 |
| `flow.actions.continue` | Continue | 続行 |
| `flow.actions.openingAddProject` | Opening Add Project... | [プロジェクトを追加] を開いています… |
| `skipConfirmation.skip` | Skip | スキップ |
| `skipConfirmation.keepGoing` | No, keep going | いいえ、続ける |
| `theme.hints.system` | Match OS | OS に合わせる |
| `theme.hints.dark` | Easy on the eyes | 目にやさしい |
| `theme.hints.light` | Bright & crisp | 明るく鮮明 |
| `integrations.capabilities.startWorkspaceFromIssue` | Start a workspace from any GitHub issue or pull request, prefilled with its title and context | GitHub の Issue や PR から、タイトルとコンテキストがあらかじめ入力されたワークスペースを開始 |
| `integrations.capabilities.browseIssues` | Browse GitHub issues and pull requests in the Tasks view without leaving Orca | Orca から離れずに、「タスク」ページで GitHub の Issue と PR を閲覧 |
| `integrations.capabilities.reviewStatus` | See issue state, review status, and CI checks on every worktree | すべてのワークツリーで Issue の状態、レビュー状況、CI チェックを確認 |
| `integrations.capabilities.managePullRequests` | Read, comment on, and merge pull requests without leaving Orca | Orca から離れずに、PR の閲覧、コメント、マージ |

Kept the change strictly scoped to `ja.json` (no source code, English source, or other locale files touched), the same shape as the Korean half of #17992. All existing `ja.json` entries are preserved unchanged.

## Why

These strings are rendered via `translate('components.onboarding.*', …)` in `OnboardingFlow.tsx`, `OnboardingSkipConfirmationDialog.tsx`, `ThemeStep.tsx`, `IntegrationsStep.tsx`, and `use-onboarding-flow-actions.ts`. `ja.json` lacked the keys, so i18next fell back to the English defaults under the Japanese locale. Adding the values restores a fully localized onboarding.

## Linked Issue

Fixes #18784

## Localization Notes

- Kept `Agent` in Latin script in `デフォルトの Agent`, matching the existing `ja.json` convention (the catalog uses `Agent` throughout and never `エージェント`) and the `기본 Agent` choice in #17992.
- Translated `Appearance` as `外観`, the rendering used by VS Code, JetBrains, and macOS; `Windows Terminal` as `Windows ターミナル` (Microsoft's official Japanese product name); `Integrations` as `連携`, the existing `ja.json` rendering for the Settings > Integrations pane.
- Preserved technical literals `GitHub`, `PR`, `Issue`, `CI`, `OS`, `Orca`, as `ja.json` already does (`PR` / `Issue` are its established renderings of pull request / issue).
- `Continue` → `続行` follows the existing `ja.json` buttons and VS Code; `No, keep going` → `いいえ、続ける` follows the existing `いいえ、個別にインポート` / `はい、グループとしてインポート` pair; `Opening Add Project...` uses the catalog's `[UI 名]` bracket style (`[設定] > [連携]`); the Tasks surface is named `「タスク」ページ` as in the Settings copy (`「タスク」ページとサイドバーに表示する…`).
- `Match OS` → `OS に合わせる` is kept short so the three theme hints stay on one line down to the 600px minimum window width (cf. ko `OS 설정에 맞춤`).
- Tooltip labels are noun phrases, buttons use the short dictionary form, and CJK/Latin spacing follows the catalog policy (`applyCjkLatinTermSpacing`). Translations were checked against the Japanese UI of Claude Desktop, the VS Code language pack, the Codex app, GitHub Docs (ja), and Microsoft Learn (ja).

## Visual Proof

Japanese locale, fresh profile, macOS. Before = English fallback on `main`, After = this PR. Layout is unchanged; only the text differs. (`gh` was removed from `PATH` for the capture so the Integrations step is not auto-skipped.)

### Step tooltip and footer action

| Before | After |
| --- | --- |
| <img width="480" alt="tooltip-before" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/before-02-tooltip-1.png" /> | <img width="480" alt="tooltip-after" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/after-02-tooltip-1.png" /> |

### Theme step (hints)

| Before | After |
| --- | --- |
| <img width="480" alt="theme-before" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/before-04-theme-step.png" /> | <img width="480" alt="theme-after" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/after-04-theme-step-v2.png" /> |

### Integrations step (capability bullets)

| Before | After |
| --- | --- |
| <img width="480" alt="integrations-before" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/before-05-integrations-step.png" /> | <img width="480" alt="integrations-after" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/after-05-integrations-step-v2.png" /> |

### Last step (Add your first project)

| Before | After |
| --- | --- |
| <img width="480" alt="notifications-before" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/before-06-notifications-step.png" /> | <img width="480" alt="notifications-after" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/after-06-notifications-step.png" /> |

### Skip confirmation

| Before | After |
| --- | --- |
| <img width="480" alt="skip-before" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/before-03-skip-dialog.png" /> | <img width="480" alt="skip-after" src="https://raw.githubusercontent.com/tb-soshiro/orca/screenshots/onboarding-ja/after-03-skip-dialog.png" /> |

`flow.actions.openingAddProject` is the transient busy label shown while the Add Project dialog opens; it is in the bundle but too brief to capture. `flow.stepTooltip.windowsTerminal` only appears on the Windows-only step.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm run verify:localization-catalog`
- [x] `pnpm run verify:localization-extraction`
- [x] `pnpm run verify:localization-coverage`
- [x] i18n tests (`src/renderer/src/i18n`) — 171 passed
- [x] Reviewed the Japanese onboarding flow in the running Electron app (macOS)

No new test: this is a data-only locale change covered by the existing i18n guards and the localization verifiers. `pnpm test` initially showed 7 failures in `tests/e2e/cross-version-wire/release-checkout.unit.test.ts` caused by a shallow clone with no release tags; after fetching tags that file passes 10/10.

## AI Disclosure

Claude Code (Claude Fable 5.1) was used to locate the missing keys, draft the translations, verify them against other products' Japanese UIs, and capture the screenshots. The final wording was reviewed and decided by the author (native Japanese speaker).

## Review

- **Cross-platform / SSH / Remote:** Localization-only catalog change; no platform-specific, execution, SSH, or remote behavior changed.
- **Agents / integrations / git providers:** No behavior changed; `GitHub` stays a literal brand string.
- **Performance:** 17 additional catalog entries, no measurable impact.
- **UI quality:** Strings were checked in the running app for fit (tooltips 2–14 characters, hints 5–10 characters); no wrapping or layout change.
- **Security:** No security-sensitive behavior changed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- The `onboarding` subtree is inserted as the first child of `components` in `ja.json` to mirror the `en.json` ordering.
- Existing Japanese onboarding copy outside these 17 keys is intentionally unchanged.
- No release or version changes are included.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
