### PR TITLE
test(rate-limits): stop the PTY settle spec reading the developer's real Codex auth

### DIFF
--- a/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
+++ b/src/main/rate-limits/codex-fetcher-pty-settle.test.ts
@@ -1,13 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { childSpawnMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
   childSpawnMock: vi.fn(),
+  readFileMock: vi.fn(),
   resolveCodexCommandMock: vi.fn(),
   ptySpawnMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({
   spawn: childSpawnMock
+}))
+
+// Why: without this the fetcher reads the developer's real ~/.codex/auth.json,
+// reaches the backend with that token and returns live quota data instead of
+// the panel these tests inject. Mirrors the sibling codex-fetcher specs.
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock
 }))
 
 vi.mock('../codex-cli/command', () => ({
@@ -33,6 +41,7 @@ describe('fetchCodexRateLimits PTY settle timers', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
+    readFileMock.mockRejectedValue(new Error('no auth fixture'))
     resolveCodexCommandMock.mockReturnValue('codex')
   })
 


### PR DESCRIPTION
## ELI5

Four tests in `codex-fetcher-pty-settle.test.ts` fail on any machine that is signed in to Codex. They feed the parser a fake status panel, but the code underneath quietly finds the developer's real `~/.codex/auth.json`, asks the backend, and returns real numbers instead. One missing mock, one line to add it.

## What Changed

`src/main/rate-limits/codex-fetcher-pty-settle.test.ts` now stubs `node:fs/promises` and rejects `readFile`, exactly as the four sibling specs in the same directory already do:

```ts
vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
// …
readFileMock.mockRejectedValue(new Error('no auth fixture'))
```

Ten added lines, one changed, one file. No production code touched.

## Why

This is the only `codex-fetcher-*` spec in the directory without that stub. `codex-fetcher.test.ts:137`, `codex-fetcher-runtime-pairing.test.ts:66`, `codex-fetcher-probe-shutdown.test.ts:91` and `codex-fetcher-backend.test.ts` all have it.

Without it, `fetchCodexRateLimits` reads the real `auth.json`, reaches the backend with that token, and resolves with live quota data. The assertions then fail against values that never came from the injected fixture:

```
AssertionError: expected { provider: 'codex', …(7) } to match object { session: null, …(2) }

- Expected              + Received
-   "session": null,    +   "session": { "resetDescription": "Sat 4:15 AM", "usedPercent": 0, … }
```

`usedPercent: 0` and a real reset timestamp — the panel the test wrote is nowhere in the result.

The four failing cases are:

- `keeps the reset text on the weekly window for weekly-only plans`
- `parses the framed codex 0.145 status panel via the /status nudge`
- `never selects a model-scoped weekly row even when it renders first`
- `re-sends Enter once when the panel does not render after the first submit`

Two things follow from this beyond the red suite. A spec whose result depends on whether the person running it happens to be logged in is not testing what it claims to test. And it sends that person's real Codex token to the backend as a side effect of running `pnpm test`, which is not something a unit test should do.

Note that `probeCodexAuthPresence` is already mocked to `'present'` in this file — the auth gate is not the problem. The live read happens further down, in the backend usage client.

## Linked Issue

Fixes #18788 (first of the three items reported there).

## Visual Proof

`N/A` — test-only change, no user-visible surface.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS 26.5.2, Node v22.21.1, with a real `~/.codex/auth.json` present — the condition that triggers the failure.

```bash
# before, on this branch's parent
node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/main/rate-limits/codex-fetcher-pty-settle.test.ts
# → exit 1, "Tests  4 failed | 2 passed"

# after
node_modules/.bin/vitest run --config config/vitest.config.ts \
  src/main/rate-limits/codex-fetcher-pty-settle.test.ts
# → exit 0, "Tests  6 passed"   (run twice, same result)
```

Also `oxlint` on the file: exit 0. Full typecheck: exit 0.

No new test was added: the change makes four existing tests actually exercise the code path they were written for, and a test that asserts "this spec does not read the real filesystem" would be testing vitest rather than Orca.

I cannot verify the *pass*-side on a machine without Codex installed, since this one has it — but that is the state CI is already in, and the change only removes a real filesystem read, so it cannot introduce a dependency there.

## AI Disclosure

Written with Claude Code (Claude Opus 5). The cause was found by reading the failing assertion and comparing this spec against its four siblings, and confirmed by running the suite before and after rather than by accepting a plausible explanation — an earlier diagnosis blamed `codex-auth-presence.ts` and was wrong, because that module is already mocked in this file.

## Review

## Agent skill upstream boundary

- [x] Not applicable — touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: this is the interesting one. The current spec transmits the developer's real Codex credentials to the backend when `pnpm test` runs. This change stops that.
- **Cross-platform**: the mock replaces a filesystem read, so behaviour is identical on macOS, Linux and Windows.
- **Remote SSH / mobile / backwards compatibility / performance**: unaffected — test-only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `oxlint` and `pnpm tc` pass locally; the targeted spec passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYgp5ts728yzof2NbFymSx
