### PR TITLE
fix: recover from an alternate shell install, and close the relay duplicate-echo gap

### DIFF
--- a/src/main/daemon/daemon-pty-session-spawn.ts
+++ b/src/main/daemon/daemon-pty-session-spawn.ts
@@ -12,11 +12,8 @@ import { DaemonPtySpawnResult } from './daemon-pty-spawn-result'
 import type { DaemonPtySpawnContext } from './daemon-pty-spawn-request'
 import type { ColdRestoreInfo } from './history-reader'
 import { mintPtySessionId } from './pty-session-id'
-import {
-  shellPathSupportsPtyStartupBarrier,
-  shellReadyMarkerComesFromLineEditor,
-  resolvePtyShellPath
-} from './shell-ready'
+import { shellPathSupportsPtyStartupBarrier, resolvePtyShellPath } from './shell-ready'
+import { shellReadyMarkerComesFromLineEditor } from '../../shared/shell-ready-marker-timing'
 import { getRecoveredHistorySeedSegments } from './terminal-history-seed-segments'
 import { AGENT_SESSION_CLAIM_DAEMON_PROTOCOL_VERSION, type CreateOrAttachResult } from './types'
 import { normalizeWslColdRestoreCwd } from './wsl-cold-restore-cwd'

--- a/src/main/daemon/pty-subprocess/shell-launch-plan.ts
+++ b/src/main/daemon/pty-subprocess/shell-launch-plan.ts
@@ -35,11 +35,7 @@ import {
 } from '../../../shared/agent-process-recognition'
 import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../../shared/hermes-startup-query'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../shared/windows-terminal-shell'
-import {
-  getShellLaunchConfig,
-  resolvePtyShellPath,
-  shellReadyMarkerComesFromLineEditor
-} from '../shell-ready'
+import { getShellLaunchConfig, resolvePtyShellPath } from '../shell-ready'
 import { resolveWslSessionContext } from '../wsl-session-context'
 import { finalizeDaemonPtyEnvironment, rescrubDaemonPtyEnvironment } from './spawn-environment'
 import type { PtySubprocessOptions } from '../pty-subprocess'
@@ -196,10 +192,10 @@ export function createPtyShellLaunchPlan(
     const waitsForShellReady =
       Boolean(opts.command) &&
       (startupAgentRecognition?.agent !== 'codex' ||
-        shellReadyMarkerComesFromLineEditor(shellPath) ||
         shouldUseShellReadyStartupDelivery({
           command: opts.command,
-          startupCommandDelivery: opts.startupCommandDelivery
+          startupCommandDelivery: opts.startupCommandDelivery,
+          shellPath
         }))
     delete env.ORCA_SHELL_FEATURES
     const shellLaunch = getShellLaunchConfig(

--- a/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
+++ b/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
@@ -11,11 +11,19 @@ const hasZsh = process.platform !== 'win32' && spawnSync('/bin/zsh', ['--version
 const hasBash = process.platform !== 'win32' && spawnSync('/bin/bash', ['--version']).status === 0
 const COMMAND_OUTPUT = 'ORCA_STARTUP_COMMAND_RAN'
 // A second Bash install with its own canonical path -- the shape a login profile
-// switches to (`exec /opt/homebrew/bin/bash`) and the one #18768 stalled on.
+// switches to (`exec /opt/homebrew/bin/bash`) and the one #18768 stalled on. A
+// symlink cannot stand in: both sides are realpath'd before they are compared.
 const alternateBashPath = ['/opt/homebrew/bin/bash', '/usr/local/bin/bash', '/usr/bin/bash'].find(
   (candidate) =>
     hasBash && existsSync(candidate) && realpathSync(candidate) !== realpathSync('/bin/bash')
 )
+if (process.platform !== 'win32' && !alternateBashPath) {
+  // Why announced: usrmerge hosts resolve /usr/bin/bash back to /bin/bash, so these
+  // two skip on most Linux CI. A silent skip reads as coverage that does not exist.
+  console.warn(
+    '[repro-13767] no second Bash install with a distinct realpath; skipping the alternate-install recovery tests'
+  )
+}
 const READ_STARTED_FILE = '.orca-read-started'
 
 type ShellFixture = {

--- a/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
+++ b/src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { createPtySubprocess } from './pty-subprocess'
 import { Session } from './session'
@@ -10,6 +10,12 @@ const describePosix = process.platform === 'win32' ? describe.skip : describe
 const hasZsh = process.platform !== 'win32' && spawnSync('/bin/zsh', ['--version']).status === 0
 const hasBash = process.platform !== 'win32' && spawnSync('/bin/bash', ['--version']).status === 0
 const COMMAND_OUTPUT = 'ORCA_STARTUP_COMMAND_RAN'
+// A second Bash install with its own canonical path -- the shape a login profile
+// switches to (`exec /opt/homebrew/bin/bash`) and the one #18768 stalled on.
+const alternateBashPath = ['/opt/homebrew/bin/bash', '/usr/local/bin/bash', '/usr/bin/bash'].find(
+  (candidate) =>
+    hasBash && existsSync(candidate) && realpathSync(candidate) !== realpathSync('/bin/bash')
+)
 const READ_STARTED_FILE = '.orca-read-started'
 
 type ShellFixture = {
@@ -122,7 +128,8 @@ type RunningFixture = {
 async function startFixture(
   fixture: ShellFixture,
   startupContent: string,
-  extraFiles: Record<string, string> = {}
+  extraFiles: Record<string, string> = {},
+  pathEnv: string = process.env.PATH ?? '/usr/bin:/bin'
 ): Promise<RunningFixture> {
   const tempHome = mkdtempSync(join(tmpdir(), 'orca-shell-ready-exec-'))
   const previousHome = process.env.HOME
@@ -150,7 +157,7 @@ async function startFixture(
       shellOverride: fixture.shellPath,
       env: {
         HOME: tempHome,
-        PATH: process.env.PATH ?? '/usr/bin:/bin',
+        PATH: pathEnv,
         SHELL: fixture.shellPath,
         TERM: 'xterm-256color'
       },
@@ -408,6 +415,51 @@ fi
           running.output().includes('NO_BRACKET_PROMPT> ')
         )
         await new Promise((resolve) => setTimeout(resolve, 300))
+        expect(running.session.shellState).toBe('pending')
+        expect(running.output()).not.toContain(COMMAND_OUTPUT)
+      } finally {
+        await running.cleanup()
+      }
+    },
+    10_000
+  )
+
+  const bashFixture = FIXTURES[2] as ShellFixture
+  const alternateBashTest = alternateBashPath ? it : it.skip
+  const alternateBashProfile = `if [[ -z "\${ORCA_EXEC_REPRO_DONE:-}" ]]; then
+  export ORCA_EXEC_REPRO_DONE=1
+  exec ${alternateBashPath ?? '/bin/bash'} --noprofile --norc -l -i
+fi
+`
+
+  alternateBashTest(
+    'releases at the prompt of a second Bash install the pane PATH resolves',
+    async () => {
+      const running = await startFixture(
+        bashFixture,
+        alternateBashProfile,
+        {},
+        `${dirname(alternateBashPath ?? '/bin/bash')}:/usr/bin:/bin`
+      )
+      try {
+        await waitForOutput(running.subscribe, () => running.output().includes(COMMAND_OUTPUT))
+        expect(running.session.shellState).toBe('ready')
+        expect(count(running.output(), COMMAND_OUTPUT)).toBe(1)
+        expect(running.output()).not.toContain('orca-shell-start')
+      } finally {
+        await running.cleanup()
+      }
+    },
+    10_000
+  )
+
+  alternateBashTest(
+    'does not trust a Bash install that the pane PATH cannot reach',
+    async () => {
+      const running = await startFixture(bashFixture, alternateBashProfile, {}, '/usr/bin:/bin')
+      try {
+        await waitForOutput(running.subscribe, () => running.output().includes('$'))
+        await new Promise((resolve) => setTimeout(resolve, 500))
         expect(running.session.shellState).toBe('pending')
         expect(running.output()).not.toContain(COMMAND_OUTPUT)
       } finally {

--- a/src/main/daemon/session-shell-ready-barrier.ts
+++ b/src/main/daemon/session-shell-ready-barrier.ts
@@ -1,4 +1,4 @@
-import { shellReadyMarkerComesFromLineEditor } from './shell-ready'
+import { shellReadyMarkerComesFromLineEditor } from '../../shared/shell-ready-marker-timing'
 import {
   installDeviceAttributesResponder,
   STARTUP_DA1_RESPONSE

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -22,8 +22,6 @@ import {
 import { inheritedZdotdirEnv, resolveInheritedZdotdir } from '../zsh-wrapper-dir-ownership'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
 
-export { shellReadyMarkerComesFromLineEditor } from '../../shared/shell-ready-marker-timing'
-
 const ORCA_USER_DATA_PATH_ENV = 'ORCA_USER_DATA_PATH'
 
 function getShellReadyWrapperBaseDir(): string {

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -22,6 +22,8 @@ import {
 import { inheritedZdotdirEnv, resolveInheritedZdotdir } from '../zsh-wrapper-dir-ownership'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
 
+export { shellReadyMarkerComesFromLineEditor } from '../../shared/shell-ready-marker-timing'
+
 const ORCA_USER_DATA_PATH_ENV = 'ORCA_USER_DATA_PATH'
 
 function getShellReadyWrapperBaseDir(): string {
@@ -99,11 +101,6 @@ export function resolvePtyShellPath(env: Record<string, string>): string {
     return env.ORCA_TERMINAL_WINDOWS_SHELL || 'powershell.exe'
   }
   return env.SHELL || process.env.SHELL || '/bin/zsh'
-}
-
-export function shellReadyMarkerComesFromLineEditor(shellPath: string): boolean {
-  const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
-  return shellName === 'bash' || shellName === 'zsh'
 }
 
 export function shellPathSupportsPtyStartupBarrier(shellPath: string): boolean {

--- a/src/main/providers/local-pty-finalize-environment.ts
+++ b/src/main/providers/local-pty-finalize-environment.ts
@@ -109,6 +109,9 @@ export function finalizeLocalPtySpawnEnvironment(args: {
         codexStartupCommand !== undefined && supportsPosixShellStartupCommand(shell)
           ? codexStartupCommand
           : undefined
+      // Why no line-editor widening here (unlike the daemon and relay): a Codex
+      // startup command this provider wraps is run by the wrapper's own prompt
+      // hook, never written into the PTY, so there is no early write to double-echo.
       const waitsForShellReady =
         Boolean(spawn.command) && (!isCodexStartupCommand || codexRequiresShellReady)
       return getShellLaunchConfig(

--- a/src/main/shell-prompt-readiness-probe.test.ts
+++ b/src/main/shell-prompt-readiness-probe.test.ts
@@ -3,12 +3,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const lineEditorProbe = vi.hoisted(() => vi.fn())
 const processReadinessProbe = vi.hoisted(() => vi.fn())
 const resolveExecutablePath = vi.hoisted(() => vi.fn((value: string) => Promise.resolve(value)))
+const resolveInstalledExecutablePaths = vi.hoisted(() =>
+  vi.fn((): Promise<string[]> => Promise.resolve([]))
+)
 vi.mock('../shared/pty-slave-line-discipline-echo', () => ({
   createPtySlaveLineEditorProbe: () => lineEditorProbe
 }))
 vi.mock('../shared/shell-process-readiness', () => ({
   readShellProcessReadiness: processReadinessProbe,
-  resolveShellExecutablePath: resolveExecutablePath
+  resolveShellExecutablePath: resolveExecutablePath,
+  resolveInstalledShellExecutablePaths: resolveInstalledExecutablePaths
 }))
 
 import { createShellPromptReadinessProbe } from './shell-prompt-readiness-probe'
@@ -19,6 +23,8 @@ describe('shell prompt readiness probe', () => {
     lineEditorProbe.mockReset()
     processReadinessProbe.mockReset()
     resolveExecutablePath.mockClear()
+    resolveInstalledExecutablePaths.mockClear()
+    resolveInstalledExecutablePaths.mockResolvedValue([])
   })
 
   afterEach(() => {
@@ -93,6 +99,99 @@ describe('shell prompt readiness probe', () => {
     if (terminalState === 'other') {
       expect(processReadinessProbe).not.toHaveBeenCalled()
     }
+  })
+
+  it('accepts a second installation of the same shell that the pane PATH resolves', async () => {
+    lineEditorProbe.mockResolvedValue('line-editor')
+    processReadinessProbe.mockResolvedValue({
+      executablePath: '/opt/homebrew/bin/bash',
+      foreground: true
+    })
+    resolveInstalledExecutablePaths.mockResolvedValue(['/bin/bash', '/opt/homebrew/bin/bash'])
+    const onPromptReady = vi.fn()
+    const probe = createShellPromptReadinessProbe({
+      slavePath: '/dev/ttys048',
+      shellPath: '/bin/bash',
+      shellCwd: '/work',
+      shellPathEnv: '/opt/homebrew/bin:/usr/bin:/bin',
+      getShellPid: () => 42,
+      onPromptReady,
+      settleMs: 10
+    })
+
+    probe?.notifyOutput('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(resolveInstalledExecutablePaths).toHaveBeenCalledWith(
+      'bash',
+      '/work',
+      '/opt/homebrew/bin:/usr/bin:/bin'
+    )
+    expect(onPromptReady).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a replacement with the shell basename that the pane PATH cannot reach', async () => {
+    lineEditorProbe.mockResolvedValue('line-editor')
+    processReadinessProbe.mockResolvedValue({ executablePath: '/tmp/bash', foreground: true })
+    resolveInstalledExecutablePaths.mockResolvedValue(['/bin/bash', '/opt/homebrew/bin/bash'])
+    const onPromptReady = vi.fn()
+    const probe = createShellPromptReadinessProbe({
+      slavePath: '/dev/ttys048',
+      shellPath: '/bin/bash',
+      getShellPid: () => 42,
+      onPromptReady,
+      settleMs: 10
+    })
+
+    probe?.notifyOutput('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(onPromptReady).not.toHaveBeenCalled()
+  })
+
+  it('does not widen identity when the launched shell path resolves exactly', async () => {
+    lineEditorProbe.mockResolvedValue('line-editor')
+    processReadinessProbe.mockResolvedValue({ executablePath: '/bin/zsh', foreground: true })
+    const probe = createShellPromptReadinessProbe({
+      slavePath: '/dev/ttys048',
+      shellPath: '/bin/zsh',
+      getShellPid: () => 42,
+      onPromptReady: vi.fn(),
+      settleMs: 10
+    })
+
+    probe?.notifyOutput('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(10)
+
+    expect(resolveInstalledExecutablePaths).not.toHaveBeenCalled()
+  })
+
+  it('invalidates an alternate-installation result that resolves after disposal', async () => {
+    const pending: { resolve?: (value: string[]) => void } = {}
+    lineEditorProbe.mockResolvedValue('line-editor')
+    processReadinessProbe.mockResolvedValue({
+      executablePath: '/opt/homebrew/bin/bash',
+      foreground: true
+    })
+    resolveInstalledExecutablePaths.mockImplementation(
+      () => new Promise((resolve) => (pending.resolve = resolve))
+    )
+    const onPromptReady = vi.fn()
+    const probe = createShellPromptReadinessProbe({
+      slavePath: '/dev/ttys048',
+      shellPath: '/bin/bash',
+      getShellPid: () => 42,
+      onPromptReady,
+      settleMs: 10
+    })
+
+    probe?.notifyOutput('\x1b[?2004h')
+    await vi.advanceTimersByTimeAsync(10)
+    probe?.dispose()
+    pending.resolve?.(['/opt/homebrew/bin/bash'])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onPromptReady).not.toHaveBeenCalled()
   })
 
   it('does no external work when the ready marker cancels the settle window', async () => {

--- a/src/main/shell-prompt-readiness-probe.ts
+++ b/src/main/shell-prompt-readiness-probe.ts
@@ -1,6 +1,7 @@
 import { createPtySlaveLineEditorProbe } from '../shared/pty-slave-line-discipline-echo'
 import {
   readShellProcessReadiness,
+  resolveInstalledShellExecutablePaths,
   resolveShellExecutablePath
 } from '../shared/shell-process-readiness'
 import {
@@ -32,6 +33,7 @@ export function createShellPromptReadinessProbe(options: {
   }
   const settleMs = options.settleMs ?? SHELL_PROMPT_PROBE_SETTLE_MS
   const expectedShellName = options.shellPath ? basename(options.shellPath).toLowerCase() : null
+  const shellCwd = options.shellCwd ?? process.cwd()
   const outputScanState = createLineEditorReadyOutputScanState()
   let disposed = false
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -52,11 +54,7 @@ export function createShellPromptReadinessProbe(options: {
     const [shell, expectedPath] = await Promise.all([
       readShellProcessReadiness(shellPid),
       options.shellPath
-        ? resolveShellExecutablePath(
-            options.shellPath,
-            options.shellCwd ?? process.cwd(),
-            options.shellPathEnv
-          )
+        ? resolveShellExecutablePath(options.shellPath, shellCwd, options.shellPathEnv)
         : Promise.resolve(null)
     ])
     if (disposed || scheduledGeneration !== generation) {
@@ -66,10 +64,27 @@ export function createShellPromptReadinessProbe(options: {
       !shell?.foreground ||
       !expectedShellName ||
       !expectedPath ||
-      basename(shell.executablePath).toLowerCase() !== expectedShellName ||
-      shell.executablePath !== expectedPath
+      basename(shell.executablePath).toLowerCase() !== expectedShellName
     ) {
       return
+    }
+    if (shell.executablePath !== expectedPath) {
+      // Why widen past the launched path: a startup profile that `exec`s a second
+      // install of the same shell (Homebrew Bash over /bin/bash) keeps the pid but
+      // loses the wrapper's marker. Only installs this pane's own PATH resolves
+      // count, so a binary merely *named* bash/zsh outside it stays rejected.
+      const installedPaths = await resolveInstalledShellExecutablePaths(
+        expectedShellName,
+        shellCwd,
+        options.shellPathEnv
+      )
+      if (
+        disposed ||
+        scheduledGeneration !== generation ||
+        !installedPaths.includes(shell.executablePath)
+      ) {
+        return
+      }
     }
     disposed = true
     options.onPromptReady()

--- a/src/relay/pty-handler-startup-command-delivery.test.ts
+++ b/src/relay/pty-handler-startup-command-delivery.test.ts
@@ -134,6 +134,73 @@ describe('PtyHandler', () => {
   )
 
   it.skipIf(process.platform === 'win32')(
+    'emits shell-ready markers for plain Codex on a line-editor shell',
+    async () => {
+      const oldShell = process.env.SHELL
+      const oldHome = process.env.HOME
+      const homeDir = mkdtempSync(join(tmpdir(), 'relay-plain-codex-spawn-'))
+
+      process.env.SHELL = '/bin/bash'
+      process.env.HOME = homeDir
+      try {
+        // No prefill flag and no shell-ready hint: the host decides from its own
+        // shell, because the client cannot see it (#18767).
+        await dispatcher.callRequest('pty.spawn', {
+          env: { HOME: homeDir },
+          command: 'codex'
+        })
+      } finally {
+        if (oldShell === undefined) {
+          delete process.env.SHELL
+        } else {
+          process.env.SHELL = oldShell
+        }
+        if (oldHome === undefined) {
+          delete process.env.HOME
+        } else {
+          process.env.HOME = oldHome
+        }
+        rmSync(homeDir, { recursive: true, force: true })
+      }
+
+      const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
+        | { env?: Record<string, string> }
+        | undefined
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES).toContain('ready')
+      vi.advanceTimersByTime(15_000)
+      expect(handler.retainedStartupCommandCount).toBe(0)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'leaves plain Codex unwaited on a shell that emits the marker before its reader',
+    async () => {
+      const oldHome = process.env.HOME
+      const homeDir = mkdtempSync(join(tmpdir(), 'relay-plain-codex-fish-spawn-'))
+
+      process.env.HOME = homeDir
+      try {
+        await dispatcher.callRequest('pty.spawn', {
+          env: { HOME: homeDir, SHELL: '/usr/bin/fish' },
+          command: 'codex'
+        })
+      } finally {
+        if (oldHome === undefined) {
+          delete process.env.HOME
+        } else {
+          process.env.HOME = oldHome
+        }
+        rmSync(homeDir, { recursive: true, force: true })
+      }
+
+      const spawnOptions = mockPtySpawn.mock.calls[0]?.[2] as
+        | { env?: Record<string, string> }
+        | undefined
+      expect(spawnOptions?.env?.ORCA_SHELL_FEATURES ?? '').not.toContain('ready')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'emits shell-ready markers for renderer-delivered Codex native prefill commands',
     async () => {
       const oldShell = process.env.SHELL

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1896,12 +1896,16 @@ export class PtyHandler {
       isUnattended: launchAgent !== undefined,
       platform: process.platform
     })
+    // Why the shell is part of the decision here and not on the client: the client
+    // cannot see which shell this host runs, and plain Codex must still wait where
+    // the marker rides the line editor rather than double-echoing an early write.
     const shouldEmitShellReadyMarker =
       launchCommandHint !== undefined &&
       shouldUseShellReadyStartupDelivery({
         command: launchCommandHint,
         startupCommandDelivery:
-          params.startupCommandDelivery === 'shell-ready' ? 'shell-ready' : undefined
+          params.startupCommandDelivery === 'shell-ready' ? 'shell-ready' : undefined,
+        shellPath: shell
       })
     const managedStartupCommand = shouldProviderDeliverCommand ? command : launchCommandHint
     // Why: both renderer- and provider-delivered startup commands use this marker; the delivering side strips it from output.

--- a/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
@@ -219,6 +219,33 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
     }
   })
 
+  // #18767: a plain Codex launch carries no shell-ready hint, but the remote host
+  // still arms the marker for it, so writing early would display the launch twice.
+  it('waits for shell-ready for a promptless SSH background Codex launch', async () => {
+    vi.useFakeTimers()
+    try {
+      state.repos = [{ id: 'repo-1', connectionId: 'ssh-1', path: '/repo' }]
+      const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+      await launchAgentBackgroundSession({ agent: 'codex', worktreeId: 'wt-1' })
+      const dataSidecar = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+      dataSidecar('user@remote repo % ')
+      vi.advanceTimersByTime(1_400)
+
+      expect(mockWrite).not.toHaveBeenCalled()
+
+      dataSidecar('\x1b]777;orca-shell-ready\x07user@remote repo % ')
+      vi.advanceTimersByTime(50)
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        'pty-1',
+        "codex '--dangerously-bypass-approvals-and-sandbox'\r"
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('falls back when an SSH shell produces no observable startup data', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -28,8 +28,10 @@ import {
   subscribeToRuntimeTerminalData,
   toRemoteRuntimePtyId
 } from '@/runtime/runtime-terminal-stream'
-import { createSshBackgroundStartupDelivery } from '@/lib/ssh-background-startup-delivery'
-import { shouldUseShellReadyStartupDelivery } from '../../../shared/codex-startup-delivery'
+import {
+  createSshBackgroundStartupDelivery,
+  sshBackgroundLaunchWaitsForShellReady
+} from '@/lib/ssh-background-startup-delivery'
 import { isMainTerminalSideEffectAuthorityForPty } from '@/components/terminal-pane/terminal-side-effect-facts-handler'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
 import { runBestEffortAgentBackgroundCleanups } from '@/lib/agent-background-session-cleanup'
@@ -115,11 +117,7 @@ export async function launchAgentBackgroundSession(
   const sshStartupDelivery = createSshBackgroundStartupDelivery({
     command: sshConnectionId ? startupPlan.launchCommand : null,
     waitForShellReady:
-      Boolean(sshConnectionId) &&
-      shouldUseShellReadyStartupDelivery({
-        command: startupPlan.launchCommand,
-        startupCommandDelivery: startupPlan.startupCommandDelivery
-      }),
+      Boolean(sshConnectionId) && sshBackgroundLaunchWaitsForShellReady(startupPlan),
     write: (ptyId, data) => window.api.pty.write(ptyId, data)
   })
   // Route by the worktree's owner host, not the focused runtime.

--- a/src/renderer/src/lib/ssh-background-startup-delivery.test.ts
+++ b/src/renderer/src/lib/ssh-background-startup-delivery.test.ts
@@ -18,6 +18,25 @@ function createDelivery(): {
   }
 }
 
+// Bracketed paste only wraps multiline submissions, so the marker's effect on it
+// is only observable through a command that carries a newline.
+const MULTILINE_COMMAND = 'codex "run the\nautomation"'
+
+function createMultilineDelivery(waitForShellReady: boolean): {
+  delivery: ReturnType<typeof createSshBackgroundStartupDelivery>
+  write: ReturnType<typeof vi.fn>
+} {
+  const write = vi.fn()
+  return {
+    delivery: createSshBackgroundStartupDelivery({
+      command: MULTILINE_COMMAND,
+      waitForShellReady,
+      write
+    }),
+    write
+  }
+}
+
 beforeEach(() => {
   vi.useFakeTimers()
 })
@@ -88,5 +107,29 @@ describe('createSshBackgroundStartupDelivery shell-ready fallback', () => {
     vi.advanceTimersByTime(1_550)
 
     expect(write).toHaveBeenCalledTimes(1)
+  })
+
+  // #18767: the marker is what proves the host wrapped the shell and armed
+  // bracketed paste. A fallback release means it never did.
+  it('uses bracketed paste only after the marker actually arrived', () => {
+    const { delivery, write } = createMultilineDelivery(true)
+
+    delivery.armFallback('pty-1')
+    delivery.handleData(`${SHELL_READY}user@remote repo % `)
+    vi.advanceTimersByTime(50)
+
+    expect(write.mock.calls[0]?.[1]).toContain('\x1b[200~')
+  })
+
+  it('submits raw when the wait ends at the fallback instead of the marker', () => {
+    const { delivery, write } = createMultilineDelivery(true)
+
+    delivery.armFallback('pty-1')
+    delivery.handleData('user@remote repo % ')
+    vi.advanceTimersByTime(1_550)
+    vi.advanceTimersByTime(50)
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(write.mock.calls[0]?.[1]).not.toContain('\x1b[200~')
   })
 })

--- a/src/renderer/src/lib/ssh-background-startup-delivery.ts
+++ b/src/renderer/src/lib/ssh-background-startup-delivery.ts
@@ -12,8 +12,10 @@ import { buildStartupCommandSubmission } from '../../../shared/startup-command-s
 /**
  * Why every Codex launch waits and not only the prompt-carrying ones: the remote
  * shell is the host's to know, and it arms the ready marker for plain Codex too
- * (#18767). Waiting costs nothing there, and the fallback below still covers a
- * host shell that never publishes one.
+ * (#18767). On such a host the wait ends at the prompt and costs nothing. On one
+ * that never publishes a marker -- fish, sh, Windows, or a host predating #18767 --
+ * the fallback below releases instead, at the same price prompt-carrying Codex
+ * already paid there.
  */
 export function sshBackgroundLaunchWaitsForShellReady(startupPlan: {
   launchCommand: string | null | undefined

--- a/src/renderer/src/lib/ssh-background-startup-delivery.ts
+++ b/src/renderer/src/lib/ssh-background-startup-delivery.ts
@@ -2,7 +2,31 @@ import {
   createShellReadyMarkerScanState,
   scanForShellReadyMarker
 } from '@/components/terminal-pane/shell-ready-marker-scan'
+import {
+  isCodexStartupCommand,
+  shouldUseShellReadyStartupDelivery,
+  type StartupCommandDelivery
+} from '../../../shared/codex-startup-delivery'
 import { buildStartupCommandSubmission } from '../../../shared/startup-command-submission'
+
+/**
+ * Why every Codex launch waits and not only the prompt-carrying ones: the remote
+ * shell is the host's to know, and it arms the ready marker for plain Codex too
+ * (#18767). Waiting costs nothing there, and the fallback below still covers a
+ * host shell that never publishes one.
+ */
+export function sshBackgroundLaunchWaitsForShellReady(startupPlan: {
+  launchCommand: string | null | undefined
+  startupCommandDelivery?: StartupCommandDelivery
+}): boolean {
+  return (
+    isCodexStartupCommand(startupPlan.launchCommand) ||
+    shouldUseShellReadyStartupDelivery({
+      command: startupPlan.launchCommand,
+      startupCommandDelivery: startupPlan.startupCommandDelivery
+    })
+  )
+}
 
 const SSH_SHELL_READY_STARTUP_FALLBACK_MS = 1500
 // Why: a remote shell that has not emitted a single byte is still booting —
@@ -31,6 +55,10 @@ export function createSshBackgroundStartupDelivery(
   let pendingCommand = options.command
   let lastPtyId: string | null = null
   let startupShellReady = !options.waitForShellReady
+  // Why tracked apart from `startupShellReady`: only an observed marker proves the
+  // host wrapped the shell and armed bracketed paste. A fallback release means the
+  // host shell never published one, so the raw submit is the only safe form.
+  let markerObserved = false
   const markerScan = options.waitForShellReady ? createShellReadyMarkerScanState() : null
   let injectTimer: ReturnType<typeof setTimeout> | null = null
   let fallbackTimer: ReturnType<typeof setTimeout> | null = null
@@ -53,6 +81,7 @@ export function createSshBackgroundStartupDelivery(
       return
     }
     startupShellReady = true
+    markerObserved = true
     clearFallbackTimer()
     if (pendingCommand && lastPtyId) {
       schedule(lastPtyId)
@@ -100,14 +129,14 @@ export function createSshBackgroundStartupDelivery(
       // Why: the SSH relay treats spawn.command as metadata for interactive
       // PTYs; hidden automation tabs still submit the command themselves.
       // Why bracketed paste: multiline prompts are pasted literally only when we
-      // synchronized on the Orca shell-ready marker (waitForShellReady) — that
-      // is the bash/zsh overlay with bracketed-paste mode armed. Submit with CR
-      // since the relay drives a remote shell.
+      // synchronized on the Orca shell-ready marker — that is the bash/zsh overlay
+      // with bracketed-paste mode armed. Submit with CR since the relay drives a
+      // remote shell.
       options.write(
         ptyId,
         buildStartupCommandSubmission(command, {
           submit: '\r',
-          bracketedPasteSafe: options.waitForShellReady
+          bracketedPasteSafe: markerObserved
         })
       )
     }, 50)

--- a/src/shared/codex-startup-delivery.test.ts
+++ b/src/shared/codex-startup-delivery.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { hasCodexNativeDraftFlag } from './codex-startup-delivery'
+import {
+  hasCodexNativeDraftFlag,
+  shouldUseShellReadyStartupDelivery
+} from './codex-startup-delivery'
 
 describe('hasCodexNativeDraftFlag', () => {
   it('matches Codex --prefill option tokens', () => {
@@ -24,5 +27,44 @@ describe('hasCodexNativeDraftFlag', () => {
   it('leaves plain Codex and normal Codex arguments on the fast path', () => {
     expect(hasCodexNativeDraftFlag('codex')).toBe(false)
     expect(hasCodexNativeDraftFlag('codex --model gpt-5')).toBe(false)
+  })
+})
+
+describe('shouldUseShellReadyStartupDelivery', () => {
+  it('honours an explicit shell-ready hint whatever the command', () => {
+    expect(
+      shouldUseShellReadyStartupDelivery({
+        command: 'claude',
+        startupCommandDelivery: 'shell-ready'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps plain Codex on the fast path when the shell is unknown', () => {
+    expect(shouldUseShellReadyStartupDelivery({ command: 'codex' })).toBe(false)
+  })
+
+  it('waits for plain Codex on shells that publish the marker from the line editor', () => {
+    expect(shouldUseShellReadyStartupDelivery({ command: 'codex', shellPath: '/bin/bash' })).toBe(
+      true
+    )
+    expect(
+      shouldUseShellReadyStartupDelivery({ command: 'codex', shellPath: '/opt/homebrew/bin/zsh' })
+    ).toBe(true)
+  })
+
+  it('leaves plain Codex unwaited on shells that emit the marker before the reader', () => {
+    expect(
+      shouldUseShellReadyStartupDelivery({ command: 'codex', shellPath: '/usr/bin/fish' })
+    ).toBe(false)
+  })
+
+  it('does not change non-Codex commands, which their transports already wait for', () => {
+    expect(shouldUseShellReadyStartupDelivery({ command: 'claude', shellPath: '/bin/bash' })).toBe(
+      false
+    )
+    expect(shouldUseShellReadyStartupDelivery({ command: undefined, shellPath: '/bin/bash' })).toBe(
+      false
+    )
   })
 })

--- a/src/shared/codex-startup-delivery.ts
+++ b/src/shared/codex-startup-delivery.ts
@@ -1,4 +1,5 @@
 import { recognizeAgentProcessFromCommandLine } from './agent-process-recognition'
+import { shellReadyMarkerComesFromLineEditor } from './shell-ready-marker-timing'
 
 export type StartupCommandDelivery = 'fast' | 'shell-ready'
 
@@ -74,9 +75,23 @@ export function hasCodexNativeDraftFlag(command: string | null | undefined): boo
   )
 }
 
+export function isCodexStartupCommand(command: string | null | undefined): boolean {
+  return recognizeAgentProcessFromCommandLine(command)?.agent === 'codex'
+}
+
 export function shouldUseShellReadyStartupDelivery(args: {
   command: string | null | undefined
   startupCommandDelivery?: StartupCommandDelivery
+  /** The shell that will run the command, when the deciding side knows it. Plain Codex
+   *  waits for the handshake on shells that publish the marker from their line editor:
+   *  there the wait ends at the prompt, while an early write double-echoes the launch. */
+  shellPath?: string
 }): boolean {
-  return args.startupCommandDelivery === 'shell-ready' || hasCodexNativeDraftFlag(args.command)
+  return (
+    args.startupCommandDelivery === 'shell-ready' ||
+    hasCodexNativeDraftFlag(args.command) ||
+    (args.shellPath !== undefined &&
+      shellReadyMarkerComesFromLineEditor(args.shellPath) &&
+      isCodexStartupCommand(args.command))
+  )
 }

--- a/src/shared/shell-process-readiness.test.ts
+++ b/src/shared/shell-process-readiness.test.ts
@@ -2,7 +2,11 @@ import { mkdir, mkdtemp, rm, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { parseDarwinExecutablePath, resolveShellExecutablePath } from './shell-process-readiness'
+import {
+  parseDarwinExecutablePath,
+  resolveInstalledShellExecutablePaths,
+  resolveShellExecutablePath
+} from './shell-process-readiness'
 
 describe('shell process readiness', () => {
   it('extracts the primary text image from macOS lsof output', () => {
@@ -65,6 +69,48 @@ describe('shell process readiness', () => {
         await expect(
           resolveShellExecutablePath('shell-name', root, `${first}:${second}`)
         ).resolves.toBe(await resolveShellExecutablePath(process.execPath, root, ''))
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'lists every PATH installation of a shell name, deduplicated and canonical',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-installed-shells-'))
+      const first = join(root, 'first')
+      const second = join(root, 'second')
+      const missing = join(root, 'missing')
+      await mkdir(first)
+      await mkdir(second)
+      await symlink(process.execPath, join(first, 'shell-name'))
+      await symlink(process.execPath, join(second, 'shell-name'))
+      try {
+        const canonical = await resolveShellExecutablePath(process.execPath, root, '')
+        await expect(
+          resolveInstalledShellExecutablePaths('shell-name', root, `${first}:${missing}:${second}`)
+        ).resolves.toEqual([canonical])
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'omits a same-name executable that no PATH entry reaches',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orca-offpath-shell-'))
+      const onPath = join(root, 'bin')
+      const offPath = join(root, 'dropped')
+      await mkdir(onPath)
+      await mkdir(offPath)
+      await symlink(process.execPath, join(onPath, 'shell-name'))
+      await symlink(process.execPath, join(offPath, 'shell-name'))
+      try {
+        await expect(
+          resolveInstalledShellExecutablePaths('shell-name', root, onPath)
+        ).resolves.not.toContain(join(offPath, 'shell-name'))
       } finally {
         await rm(root, { recursive: true, force: true })
       }

--- a/src/shared/shell-process-readiness.ts
+++ b/src/shared/shell-process-readiness.ts
@@ -56,12 +56,12 @@ export async function readShellProcessReadiness(
     : null
 }
 
-export async function resolveShellExecutablePath(
+function shellExecutableCandidates(
   shellPath: string,
   cwd: string,
   pathEnv: string | undefined
-): Promise<string | null> {
-  const candidates = shellPath.includes('/')
+): string[] {
+  return shellPath.includes('/')
     ? [isAbsolute(shellPath) ? shellPath : resolve(cwd, shellPath)]
     : (
         pathEnv ??
@@ -69,14 +69,42 @@ export async function resolveShellExecutablePath(
       )
         .split(delimiter)
         .map((entry) => resolve(isAbsolute(entry) ? entry : resolve(cwd, entry), shellPath))
-  for (const candidate of candidates) {
-    try {
-      await access(candidate, constants.X_OK)
-      const canonicalPath = await realpath(candidate)
-      if ((await stat(canonicalPath)).isFile()) {
-        return canonicalPath
-      }
-    } catch {}
+}
+
+async function canonicalizeExecutable(candidate: string): Promise<string | null> {
+  try {
+    await access(candidate, constants.X_OK)
+    const canonicalPath = await realpath(candidate)
+    return (await stat(canonicalPath)).isFile() ? canonicalPath : null
+  } catch {
+    return null
+  }
+}
+
+export async function resolveShellExecutablePath(
+  shellPath: string,
+  cwd: string,
+  pathEnv: string | undefined
+): Promise<string | null> {
+  for (const candidate of shellExecutableCandidates(shellPath, cwd, pathEnv)) {
+    const canonicalPath = await canonicalizeExecutable(candidate)
+    if (canonicalPath) {
+      return canonicalPath
+    }
   }
   return null
+}
+
+/** Every canonical executable `shellName` names on `pathEnv` — the installations a
+ *  startup profile could legitimately `exec` into, and nothing a dropped-in binary
+ *  outside the search path can reach. `shellName` must be a bare name. */
+export async function resolveInstalledShellExecutablePaths(
+  shellName: string,
+  cwd: string,
+  pathEnv: string | undefined
+): Promise<string[]> {
+  const canonicalPaths = await Promise.all(
+    shellExecutableCandidates(shellName, cwd, pathEnv).map(canonicalizeExecutable)
+  )
+  return [...new Set(canonicalPaths.filter((path): path is string => path !== null))]
 }

--- a/src/shared/shell-ready-marker-timing.ts
+++ b/src/shared/shell-ready-marker-timing.ts
@@ -1,0 +1,18 @@
+/**
+ * When in a shell's startup Orca's OSC 777 ready marker is published.
+ *
+ * Why this is a decision of its own: it is what separates "waiting for the marker
+ * is free" from "waiting for the marker costs the user real startup latency", and
+ * all three transports (daemon, relay, local provider) have to answer it the same
+ * way or a startup command is delivered twice on one of them.
+ */
+
+/**
+ * True when the marker rides the shell's line editor (zsh `precmd`, bash
+ * `PROMPT_COMMAND`), so it arrives at the same moment the prompt can accept input.
+ * Every other wrapped shell emits it from startup, ahead of the reader.
+ */
+export function shellReadyMarkerComesFromLineEditor(shellPath: string): boolean {
+  const shellName = shellPath.replace(/\\/g, '/').split('/').pop()?.toLowerCase() ?? ''
+  return shellName === 'bash' || shellName === 'zsh'
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​391 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​384 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​149 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​49 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 |

<!-- /orca-pr-loc -->

Resolves #18768 and #18767, the two follow-ups from the review of #18729.

## #18768 — alternate Bash install cost plain Codex the full 15s barrier

A startup profile that `exec`s a second install of the same shell (Homebrew Bash over `/bin/bash`) keeps the pid but loses the wrapper's ready marker. The recovery probe required the running executable's canonical path to equal the launched shell's, so it never fired and plain Codex waited out the whole barrier.

`shell-prompt-readiness-probe.ts` now falls back to accepting a same-named install that **this pane's own PATH resolves** (`resolveInstalledShellExecutablePaths`, new in `shared/shell-process-readiness.ts`). A binary merely *named* `bash`/`zsh` outside the search path is still rejected, so the existing identity-negative tests are unchanged. The PATH scan only runs when the exact-path match fails, and re-checks disposal/generation after its await.

Proven on real PTYs in the existing `repro-13767` harness against a genuinely distinct install, skipped where none exists:

| | Time to command output |
| --- | ---: |
| Before | 5s (test timeout) |
| After | 141ms |

Plus a negative case: the same install *off* PATH keeps the barrier `pending` and delivers nothing.

## #18767 — duplicate Codex launch echo on the relay

The SSH relay left plain Codex on early startup delivery, so initialization lasting past that write displayed the command twice.

The remote shell is the host's to know, so the relay now folds it into the same rule the daemon uses — `shouldUseShellReadyStartupDelivery` gained an optional `shellPath`, and the line-editor predicate moved to `shared/shell-ready-marker-timing.ts` so all three transports share one definition. The SSH background client waits for the marker on any Codex launch rather than only prompt-carrying ones.

Also fixed while there: `bracketedPasteSafe` was keyed on the *intent* to wait, so a fallback release on a host shell that never publishes a marker pasted `ESC[200~` literally. It is now keyed on an **observed** marker.

### The non-daemon local provider does not have this bug

The issue flagged it from source inspection, but `local-pty-session-activation.ts:160` short-circuits the PTY write when `ORCA_POSIX_SHELL_STARTUP_COMMAND` carries the command — the wrapper's prompt hook runs it and prints it once. That path is left alone, with a comment recording why.

## Scope note

The relay change is scoped to Codex. Non-Codex agents on the SSH *background* path still deliver early, unlike the daemon and unlike interactive SSH panes — a real pre-existing inconsistency, but outside what #18767 asked for.

## Verification

- Each of the three behaviour changes has a test verified to fail without its fix (probe recovery, relay marker arming, promptless SSH Codex wait, bracketed-paste gating).
- Full daemon / relay / providers / renderer suites, `pnpm tc`, and the changed-code quality gate pass.
- No wire change: the relay decides from state it already has, so mixed-version clients are unaffected.