### PR TITLE
ci(package): retry apt fetches and docker builds behind the Ubuntu mirror

### DIFF
--- a/config/docker/cli-launch-contract/Dockerfile
+++ b/config/docker/cli-launch-contract/Dockerfile
@@ -6,8 +6,13 @@ ARG LIBASOUND_PACKAGE=libasound2t64
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Electron's link-time libraries without adding a display server or FUSE.
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+# Why: archive.ubuntu.com mid-sync returns Hash Sum mismatch / wrong-size indexes and stalls per-package fetches; retry with bounded timeouts and drop half-synced lists between attempts.
+RUN for attempt in 1 2 3 4 5; do \
+      apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && break; \
+      if [ "$attempt" = 5 ]; then exit 100; fi; \
+      rm -rf /var/lib/apt/lists/*; sleep 20; \
+    done \
+  && apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y --no-install-recommends \
     bash \
     ca-certificates \
     coreutils \

--- a/config/docker/headless-pairing/Dockerfile
+++ b/config/docker/headless-pairing/Dockerfile
@@ -5,8 +5,13 @@ ARG LIBASOUND_PACKAGE=libasound2t64
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+# Why: archive.ubuntu.com mid-sync returns Hash Sum mismatch / wrong-size indexes and stalls per-package fetches; retry with bounded timeouts and drop half-synced lists between attempts.
+RUN for attempt in 1 2 3 4 5; do \
+      apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && break; \
+      if [ "$attempt" = 5 ]; then exit 100; fi; \
+      rm -rf /var/lib/apt/lists/*; sleep 20; \
+    done \
+  && apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y --no-install-recommends \
     bash \
     ca-certificates \
     dbus-x11 \

--- a/config/docker/headless-serve-shutdown/Dockerfile
+++ b/config/docker/headless-serve-shutdown/Dockerfile
@@ -2,8 +2,13 @@ FROM ubuntu@sha256:678c6550cc43645e08669028bc177f50be4e7c5b8cca677067b1914d4afc7
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
+# Why: archive.ubuntu.com mid-sync returns Hash Sum mismatch / wrong-size indexes and stalls per-package fetches; retry with bounded timeouts and drop half-synced lists between attempts.
+RUN for attempt in 1 2 3 4 5; do \
+      apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && break; \
+      if [ "$attempt" = 5 ]; then exit 100; fi; \
+      rm -rf /var/lib/apt/lists/*; sleep 20; \
+    done \
+  && apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y --no-install-recommends \
     bash \
     ca-certificates \
     dbus-x11 \

--- a/config/scripts/run-headless-linux-pairing-docker.mjs
+++ b/config/scripts/run-headless-linux-pairing-docker.mjs
@@ -70,7 +70,7 @@ function valueAfter(flag) {
 
 function buildImage(image) {
   console.log(`Building ${image.name} fixture...`)
-  docker([
+  const buildArgs = [
     'build',
     '--build-arg',
     `BASE_IMAGE=${image.base}`,
@@ -81,7 +81,16 @@ function buildImage(image) {
     '-t',
     image.tag,
     '.'
-  ])
+  ]
+  // Why: apt fetches from archive.ubuntu.com stall or fail mid-sync; a second build usually lands on a healthy index.
+  try {
+    docker(buildArgs)
+  } catch (error) {
+    console.error(
+      `${error instanceof Error ? error.message : String(error)}\nRetrying docker build once...`
+    )
+    docker(buildArgs)
+  }
 }
 
 function extractAppImage(image) {

--- a/config/scripts/run-headless-serve-shutdown-docker.mjs
+++ b/config/scripts/run-headless-serve-shutdown-docker.mjs
@@ -43,7 +43,7 @@ const artifactVolume = `orca-headless-serve-shutdown-${suffix}`
 const sha256 = createHash('sha256').update(readFileSync(appImage)).digest('hex')
 
 try {
-  docker([
+  const buildArgs = [
     'build',
     '--platform',
     platform,
@@ -52,7 +52,15 @@ try {
     '-t',
     image,
     shutdownDockerDirectory
-  ])
+  ]
+  // Why: apt fetches from archive.ubuntu.com stall or fail mid-sync; a second build usually lands on a healthy index.
+  const firstBuild = docker(buildArgs, { allowFailure: true })
+  if (firstBuild.status !== 0) {
+    process.stderr.write(
+      `${firstBuild.stdout}${firstBuild.stderr}\ndocker build failed with status ${firstBuild.status}; retrying once...\n`
+    )
+    docker(buildArgs)
+  }
   docker(['volume', 'create', artifactVolume])
   runDesktopStartupOracle({ image, appImage, platform })
   docker([

--- a/config/scripts/run-linux-cli-launch-contract-docker.mjs
+++ b/config/scripts/run-linux-cli-launch-contract-docker.mjs
@@ -173,20 +173,26 @@ function runCase(caseName) {
 
 function buildImage() {
   console.log(`Building ${tag}…`)
-  docker(
-    [
-      'build',
-      ...dockerPlatformArgs,
-      '--build-arg',
-      `BASE_IMAGE=${base}`,
-      '-f',
-      'config/docker/cli-launch-contract/Dockerfile',
-      '-t',
-      tag,
-      'config/docker/cli-launch-contract'
-    ],
-    { timeoutMs: BUILD_TIMEOUT_MS }
-  )
+  const buildArgs = [
+    'build',
+    ...dockerPlatformArgs,
+    '--build-arg',
+    `BASE_IMAGE=${base}`,
+    '-f',
+    'config/docker/cli-launch-contract/Dockerfile',
+    '-t',
+    tag,
+    'config/docker/cli-launch-contract'
+  ]
+  // Why: apt fetches from archive.ubuntu.com stall or fail mid-sync; a second build usually lands on a healthy index.
+  try {
+    docker(buildArgs, { timeoutMs: BUILD_TIMEOUT_MS })
+  } catch (error) {
+    console.error(
+      `${error instanceof Error ? error.message : String(error)}\nRetrying docker build once…`
+    )
+    docker(buildArgs, { timeoutMs: BUILD_TIMEOUT_MS })
+  }
 }
 
 // Extract unprivileged so chrome-sandbox is not root-owned setuid.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## ELI5

When Ubuntu's package mirror is mid-sync, the three Docker images the `package` job builds either hang downloading packages or fail with a corrupt index. Now each image retries the index refresh a few times (with per-download timeouts) and the runner scripts retry the whole `docker build` once, so a flaky mirror no longer fails unrelated PRs.

## What Changed

- `config/docker/cli-launch-contract/Dockerfile`, `config/docker/headless-serve-shutdown/Dockerfile`, `config/docker/headless-pairing/Dockerfile`: the bare `apt-get update` is now a bounded 5-attempt loop with `-o Acquire::Retries=5 -o Acquire::http::Timeout=30`, clearing `/var/lib/apt/lists/*` between attempts so a half-synced index is never reused. `apt-get install` gets the same acquire options. Package lists are byte-identical; `FROM`, `ARG`, `ENV`, `useradd`, `COPY`, `ENTRYPOINT` untouched.
- `config/scripts/run-linux-cli-launch-contract-docker.mjs`, `config/scripts/run-headless-serve-shutdown-docker.mjs`, `config/scripts/run-headless-linux-pairing-docker.mjs`: `docker build` is retried once on failure or timeout; the first error is logged before the retry, and only a second failure throws.

## Why

Six `package` job failures across four PRs tonight, all inside the Dockerfile `RUN apt-get update && apt-get install ...` against `archive.ubuntu.com` (91.189.91.81), in three shapes:

- per-package fetch stalls (~64 s each, `Ign:` lines) until the runner's 10-minute `docker build` timeout: https://github.com/stablyai/orca/actions/runs/33935104546/job/101221447425
- `apt-get update` exit 100 with `Hash Sum mismatch` on `noble-updates/restricted/Packages.gz`: https://github.com/stablyai/orca/actions/runs/33935104546/job/101226099525
- `apt-get update` exit 100 with `File has unexpected size (742980 != 742981). Mirror sync in progress?`: https://github.com/stablyai/orca/actions/runs/33935244026/job/101231083497

There was no retry, mirror, cache, or apt timeout anywhere (`Acquire::Retries|type=cache|mirror|sources.list|apt-get -o` has zero hits under `config/docker/` and `config/scripts/run-*docker*.mjs`). apt's own `Acquire::Retries` covers transient per-file failures; the outer loop covers the index-level `Hash Sum mismatch` / wrong-size cases where apt refuses to proceed; the build-level retry covers a whole-image stall. No GitHub-Azure-only mirror, registry auth, or BuildKit cache mounts, because the reliability gate in `config/reliability-gates.jsonc` also records local runs of these scripts.

## Linked Issue

N/A — CI infrastructure flake. Blocked PRs: #18739, #18744, #18747, #18764.

## Visual Proof

N/A — CI-only change, no UI or user-facing behavior.

## Testing

- `docker build -f config/docker/cli-launch-contract/Dockerfile config/docker/cli-launch-contract` succeeds locally (macOS, Docker Desktop); the apt `RUN` layer completed in 16 s on the first attempt.
- `node --check` on the three `.mjs` runners; `oxfmt --check` and `oxlint` clean on them.
- `pnpm run check:code-quality:changed`: 0 new findings across 3 changed files (oxlint, type-aware, React Doctor).
- CI on this PR exercises all three images via the `package` job.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below — no unit tests: the change is a Dockerfile shell loop and a `docker build` retry in CI runner scripts; the `package` job on this PR is the test.

## Negative user-facing trade-offs

None for users. CI cost: only when the mirror is unhealthy, up to 5 × 20 s of extra sleep per image plus one extra `docker build` attempt (bounded by the existing 10-minute build timeout). On a healthy mirror the build is unchanged.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
