### PR TITLE
fix(orchestration): attribute trust-blocked startup to the launching agent

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -501,6 +501,34 @@ describe('orchestration RPC methods', () => {
       }
     )
 
+    it('attributes a trust block to the launching agent, not codex (#15123)', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'running',
+        exitCode: null,
+        blockedReason: 'codex-trust-workspace'
+      })
+      const task = db.createTask({ spec: 'blocked antigravity trust' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'antigravity'
+      })) as { state: string; failedStage: string; lastError: string }
+
+      expect(result).toMatchObject({
+        state: 'failed',
+        failedStage: 'agent_readiness',
+        lastError:
+          'Agent startup blocked: antigravity workspace trust prompt (codex-trust-workspace)'
+      })
+      expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    })
+
     it('creates a child worktree agent-first with setup run by default', async () => {
       setup()
       mockCurrentWorkerStart()

--- a/src/main/runtime/rpc/methods/orchestration-federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.ts
@@ -22,6 +22,7 @@ import {
   isWorkerStartTimeoutWithinTimerLimit,
   resolveWorkerStartReadinessTimeoutMs
 } from '../../../../shared/orchestration-timing-budgets'
+import { formatWorkerBlockedReason } from '../../../../shared/runtime-terminal-contracts'
 
 export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
   defineMethod({
@@ -219,7 +220,7 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
           }
           throw new Error(
             wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
+              ? formatWorkerBlockedReason(wait.blockedReason, agent)
               : `Agent did not become ready (${wait.status}).`
           )
         }

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -26,6 +26,7 @@ import {
   isWorkerStartTimeoutWithinTimerLimit,
   resolveWorkerStartReadinessTimeoutMs
 } from '../../../../shared/orchestration-timing-budgets'
+import { formatWorkerBlockedReason } from '../../../../shared/runtime-terminal-contracts'
 
 export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
   defineMethod({
@@ -228,7 +229,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           }
           throw new Error(
             wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
+              ? formatWorkerBlockedReason(wait.blockedReason, agent)
               : `Agent did not become ready (${wait.status}).`
           )
         }

--- a/src/shared/runtime-terminal-contracts.test.ts
+++ b/src/shared/runtime-terminal-contracts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { formatWorkerBlockedReason } from './runtime-terminal-contracts'
+
+describe('formatWorkerBlockedReason', () => {
+  it('attributes a trust block to the launching agent, not codex (#15123)', () => {
+    expect(formatWorkerBlockedReason('codex-trust-workspace', 'antigravity')).toBe(
+      'Agent startup blocked: antigravity workspace trust prompt (codex-trust-workspace)'
+    )
+  })
+
+  it('keeps the codex reason for codex launches', () => {
+    expect(formatWorkerBlockedReason('codex-trust-workspace', 'codex')).toBe(
+      'Agent startup blocked: codex-trust-workspace'
+    )
+  })
+
+  it('keeps the reason when no agent is known', () => {
+    expect(formatWorkerBlockedReason('codex-trust-workspace')).toBe(
+      'Agent startup blocked: codex-trust-workspace'
+    )
+    expect(formatWorkerBlockedReason('codex-trust-workspace', null)).toBe(
+      'Agent startup blocked: codex-trust-workspace'
+    )
+  })
+
+  it('leaves non-trust reasons untouched', () => {
+    expect(formatWorkerBlockedReason('codex-update-prompt', 'antigravity')).toBe(
+      'Agent startup blocked: codex-update-prompt'
+    )
+    expect(formatWorkerBlockedReason('agent-approval-prompt', 'antigravity')).toBe(
+      'Agent startup blocked: agent-approval-prompt'
+    )
+  })
+})

--- a/src/shared/runtime-terminal-contracts.ts
+++ b/src/shared/runtime-terminal-contracts.ts
@@ -331,3 +331,16 @@ export type RuntimeTerminalWait = {
   exitCause?: TerminalExitCause
   blockedReason?: RuntimeTerminalWaitBlockedReason
 }
+
+// Why (#15123): trust classifiers match screen text, so another agent's trust
+// prompt (e.g. Antigravity's) reports the codex-named reason. Attribute the
+// human message to the launching agent; the machine blockedReason is unchanged.
+export function formatWorkerBlockedReason(
+  blockedReason: RuntimeTerminalWaitBlockedReason,
+  agent?: string | null
+): string {
+  if (blockedReason === 'codex-trust-workspace' && agent && agent !== 'codex') {
+    return `Agent startup blocked: ${agent} workspace trust prompt (${blockedReason})`
+  }
+  return `Agent startup blocked: ${blockedReason}`
+}


### PR DESCRIPTION
Related to #15123.

A worker-start readiness wait reports screen-text classifier reasons verbatim, so an Antigravity trust prompt fails as `Agent startup blocked: codex-trust-workspace`. This attributes the human-facing message to the launching agent when it is known and is not codex:

- new `formatWorkerBlockedReason()` in `shared/runtime-terminal-contracts.ts` (machine `blockedReason` persisted to telemetry/stages is unchanged)
- applied at both failure sites: `orchestration-workers.ts` and `orchestration-federation.ts`
- new unit tests plus a composed worker-start case (antigravity + trust block)

Verified: node typecheck clean, composed-workers suite (18 tests) and new formatter tests (4 tests) pass, oxlint clean. Live on runtime 1.4.197: `worker-start --agent antigravity` and `dispatch --inject` into agy both reach accepted `worker_done`, so the remaining defect here was attribution, not gating.