### PR TITLE
Bump mobile app.json to 0.0.48

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.47",
+    "version": "0.0.48",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## Summary
- Bump `mobile/app.json` `expo.version` to 0.0.48 so the repo matches what shipped.

iOS 0.0.48 (build 3) is already uploaded to TestFlight and distributed to external testers via [run 33912984352](https://github.com/stablyai/orca/actions/runs/33912984352). The workflow resolves the marketing version from the dispatch input, not from `app.json`, so the file had drifted at 0.0.47 — this closes that gap.

`expo.ios.buildNumber` and `expo.android.versionCode` are intentionally untouched; CI owns both.

## Verification
- `node -e` parse of mobile/app.json: version 0.0.48, buildNumber 1, versionCode 15 (unchanged)
- Single-line diff, no other keys touched