### PR TITLE
fix(ssh): let the host say whether it armed the shell-ready marker

### DIFF
--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -16,6 +16,11 @@ export type PtySpawnResult = {
   sourceActivation?: PtySourceReceivingActivation
   /** The provider observed this exact spawn exit before returning its spawn result. */
   exitedBeforeSpawnReply?: true
+  /** Whether the execution host armed the shell-ready marker for a renderer-delivered startup
+   *  command. `false` means the host looked and did not (fish, sh, Windows) so the client must
+   *  not wait; absent means the host predates the field and the client keeps its own guess.
+   *  Never collapse absent into `false`. */
+  shellReadyArmed?: boolean
   /** OS-level pid of the shell process, when available at spawn time.
    *  Why: the memory collector needs this to walk each PTY's process
    *  subtree. Daemon-backed providers return it from the RPC result;

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -69,6 +69,8 @@ export type PtyApi = {
     coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
     startupCwdFallback?: { kind: 'worktree'; cwd: string }
     agentResumeUnavailable?: true
+    /** Host verdict on the shell-ready marker; absent when the execution host predates the field. */
+    shellReadyArmed?: boolean
   }>
   write: (id: string, data: string) => void
   writeAccepted: (id: string, data: string) => Promise<boolean>

--- a/src/preload/api/pty-bridge-session-control.ts
+++ b/src/preload/api/pty-bridge-session-control.ts
@@ -66,6 +66,8 @@ export const ptySessionControlApi = {
     coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
     startupCwdFallback?: { kind: 'worktree'; cwd: string }
     agentResumeUnavailable?: true
+    /** Host verdict on the shell-ready marker; absent when the execution host predates the field. */
+    shellReadyArmed?: boolean
   }> => ipcRenderer.invoke('pty:spawn', opts),
   write: (id: string, data: string): void => {
     ipcRenderer.send('pty:write', { id, data })

--- a/src/relay/pty-handler-spawn-admission.test.ts
+++ b/src/relay/pty-handler-spawn-admission.test.ts
@@ -174,7 +174,13 @@ describe('PtyHandler', () => {
 
   it('spawns a PTY and returns an id', async () => {
     const result = await spawnPty({ cols: 80, rows: 24 })
-    expect(result).toEqual({ id: testPtyId(1), incarnationId: expect.any(String) })
+    // shellReadyArmed rides every spawn reply, false included: absent has to keep
+    // meaning "host predates the field", not "host did not arm".
+    expect(result).toEqual({
+      id: testPtyId(1),
+      incarnationId: expect.any(String),
+      shellReadyArmed: false
+    })
     expect(mockPtySpawn).toHaveBeenCalled()
     expect(handler.activePtyCount).toBe(1)
   })
@@ -193,7 +199,11 @@ describe('PtyHandler', () => {
       agentSessionCreateOperationId: operationId
     })
 
-    expect(replayed).toEqual({ id: testPtyId(1), incarnationId: expect.any(String) })
+    expect(replayed).toEqual({
+      id: testPtyId(1),
+      incarnationId: expect.any(String),
+      shellReadyArmed: false
+    })
     expect(mockPtySpawn).toHaveBeenCalledOnce()
     expect(mockPtyInstance.kill).not.toHaveBeenCalled()
     expect(handler.activePtyCount).toBe(1)

--- a/src/relay/pty-handler-startup-command-delivery.test.ts
+++ b/src/relay/pty-handler-startup-command-delivery.test.ts
@@ -145,10 +145,11 @@ describe('PtyHandler', () => {
       try {
         // No prefill flag and no shell-ready hint: the host decides from its own
         // shell, because the client cannot see it (#18767).
-        await dispatcher.callRequest('pty.spawn', {
+        const reply = await dispatcher.callRequest('pty.spawn', {
           env: { HOME: homeDir },
           command: 'codex'
         })
+        expect(reply).toMatchObject({ shellReadyArmed: true })
       } finally {
         if (oldShell === undefined) {
           delete process.env.SHELL
@@ -180,10 +181,13 @@ describe('PtyHandler', () => {
 
       process.env.HOME = homeDir
       try {
-        await dispatcher.callRequest('pty.spawn', {
+        const reply = await dispatcher.callRequest('pty.spawn', {
           env: { HOME: homeDir, SHELL: '/usr/bin/fish' },
           command: 'codex'
         })
+        // Why the reply carries it: the client cannot see this shell, and without
+        // the verdict it waits the full fallback for a marker fish never emits.
+        expect(reply).toMatchObject({ shellReadyArmed: false })
       } finally {
         if (oldHome === undefined) {
           delete process.env.HOME

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -231,6 +231,10 @@ type ManagedPty = {
   gitCredentialPromptGuarded: boolean
   historyIsolationEnabled?: boolean
   startupCommand?: ManagedStartupCommand
+  /** Whether this host armed the shell-ready marker for a renderer-delivered startup command.
+   *  Kept off `startupCommand`, which is dropped once delivered; the client reads it from the
+   *  spawn reply to skip waiting for a marker that will never come (fish, sh, Windows). */
+  shellReadyArmed?: boolean
   physicalExit?: PhysicalExitTracker
   forceKillSent?: boolean
   gracefulKillSent?: boolean
@@ -253,6 +257,7 @@ type RelayAgentSessionCreateResult = {
   replay?: string
   agentSessionEnsure?: unknown
   sourceActivation?: PtySourceReceivingActivation
+  shellReadyArmed?: boolean
 }
 
 const AGENT_SESSION_CREATE_OPERATION_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/
@@ -1804,7 +1809,10 @@ export class PtyHandler {
         incarnationId: managed.incarnationId,
         agentSessionEnsure: result,
         ...(sourceActivation ? { sourceActivation } : {}),
-        ...(adoptedReplay ? { replay: adoptedReplay } : {})
+        ...(adoptedReplay ? { replay: adoptedReplay } : {}),
+        ...(managed.shellReadyArmed !== undefined
+          ? { shellReadyArmed: managed.shellReadyArmed }
+          : {})
       }
     } catch (error) {
       if (!physicalSpawnCommitted) {
@@ -1827,6 +1835,7 @@ export class PtyHandler {
     id: string
     incarnationId: string
     sourceActivation?: PtySourceReceivingActivation
+    shellReadyArmed?: boolean
   }> {
     const pty = await this.loadPty()
     if (!pty) {
@@ -1998,6 +2007,7 @@ export class PtyHandler {
       }),
       ...(startupIngressIntent ? { startupIngressIntent } : {}),
       ...(terminalHandle ? { terminalHandle } : {}),
+      shellReadyArmed: rendererShellReadySupported,
       ...(managedStartupCommand && (shouldProviderDeliverCommand || rendererShellReadySupported)
         ? {
             startupCommand: {
@@ -2039,7 +2049,8 @@ export class PtyHandler {
     return {
       id,
       incarnationId: managed.incarnationId,
-      ...(sourceActivation ? { sourceActivation } : {})
+      ...(sourceActivation ? { sourceActivation } : {}),
+      shellReadyArmed: rendererShellReadySupported
     }
   }
 

--- a/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
+++ b/src/renderer/src/lib/launch-agent-background-session-remote.test.ts
@@ -246,6 +246,27 @@ describe('launchAgentBackgroundSession remote runtime and SSH startup delivery',
     }
   })
 
+  it('skips the shell-ready wait when the host reports it did not arm the marker', async () => {
+    vi.useFakeTimers()
+    try {
+      state.repos = [{ id: 'repo-1', connectionId: 'ssh-1', path: '/repo' }]
+      mockSpawn.mockResolvedValue({ id: 'pty-1', shellReadyArmed: false })
+      const { launchAgentBackgroundSession } = await import('./launch-agent-background-session')
+
+      await launchAgentBackgroundSession({ agent: 'codex', worktreeId: 'wt-1' })
+      const dataSidecar = mockSubscribeToPtyData.mock.calls[0]?.[1] as (data: string) => void
+      dataSidecar('user@remote repo % ')
+      vi.advanceTimersByTime(50)
+
+      expect(mockWrite).toHaveBeenCalledWith(
+        'pty-1',
+        "codex '--dangerously-bypass-approvals-and-sandbox'\r"
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('falls back when an SSH shell produces no observable startup data', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -221,6 +221,7 @@ export async function launchAgentBackgroundSession(
       })
       ptyId = result.id
       spawned = result
+      sshStartupDelivery.applyHostShellReadyArmed(result.shellReadyArmed)
     }
     const adopted = await adoptAgentBackgroundSessionTab({
       store,

--- a/src/renderer/src/lib/ssh-background-startup-delivery.test.ts
+++ b/src/renderer/src/lib/ssh-background-startup-delivery.test.ts
@@ -121,6 +121,67 @@ describe('createSshBackgroundStartupDelivery shell-ready fallback', () => {
     expect(write.mock.calls[0]?.[1]).toContain('\x1b[200~')
   })
 
+  // The host answers in the spawn reply whether it armed the marker. `false` means
+  // none will ever come, so the pre-#18796 fast path applies; `true` keeps the wait;
+  // absent is an older host and leaves the client-side prediction alone.
+  describe('host shell-ready verdict', () => {
+    it('delivers immediately and raw when the host reports the marker was not armed', () => {
+      const { delivery, write } = createMultilineDelivery(true)
+
+      delivery.applyHostShellReadyArmed(false)
+      delivery.armFallback('pty-1')
+      // The launch flow schedules on every data chunk (launch-agent-background-session).
+      delivery.handleData('user@remote repo % ')
+      delivery.schedule('pty-1')
+      vi.advanceTimersByTime(50)
+
+      expect(write).toHaveBeenCalledTimes(1)
+      expect(write.mock.calls[0]?.[1]).not.toContain('\x1b[200~')
+    })
+
+    it('keeps the short silent-shell budget once the host says no marker is coming', () => {
+      const { delivery, write } = createDelivery()
+
+      delivery.applyHostShellReadyArmed(false)
+      delivery.armFallback('pty-1')
+      vi.advanceTimersByTime(1_550)
+
+      expect(write).toHaveBeenCalledTimes(1)
+    })
+
+    it('still waits for the marker when the host reports it armed one', () => {
+      const { delivery, write } = createDelivery()
+
+      delivery.applyHostShellReadyArmed(true)
+      delivery.armFallback('pty-1')
+      delivery.handleData('user@remote repo % ')
+      vi.advanceTimersByTime(1_400)
+
+      expect(write).not.toHaveBeenCalled()
+
+      delivery.handleData(`${SHELL_READY}user@remote repo % `)
+      vi.advanceTimersByTime(50)
+
+      expect(write).toHaveBeenCalledTimes(1)
+    })
+
+    it('keeps the client-side prediction when an older host omits the verdict', () => {
+      const { delivery, write } = createDelivery()
+
+      delivery.applyHostShellReadyArmed(undefined)
+      delivery.armFallback('pty-1')
+      delivery.handleData('user@remote repo % ')
+      vi.advanceTimersByTime(1_400)
+
+      expect(write).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(150)
+      vi.advanceTimersByTime(50)
+
+      expect(write).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('submits raw when the wait ends at the fallback instead of the marker', () => {
     const { delivery, write } = createMultilineDelivery(true)
 

--- a/src/renderer/src/lib/ssh-background-startup-delivery.ts
+++ b/src/renderer/src/lib/ssh-background-startup-delivery.ts
@@ -48,6 +48,12 @@ export type SshBackgroundStartupDelivery = {
   handleData(data: string): string
   armFallback(ptyId: string): void
   schedule(ptyId: string): void
+  /**
+   * The host's verdict from the spawn reply, which lands after this delivery was built.
+   * `false` releases the wait: no marker will ever come. `true` keeps it. `undefined` is
+   * a host that predates the field, so the constructor-time prediction stands.
+   */
+  applyHostShellReadyArmed(armed: boolean | undefined): void
   clear(): void
 }
 
@@ -56,12 +62,13 @@ export function createSshBackgroundStartupDelivery(
 ): SshBackgroundStartupDelivery {
   let pendingCommand = options.command
   let lastPtyId: string | null = null
-  let startupShellReady = !options.waitForShellReady
+  let waitForShellReady = options.waitForShellReady
+  let startupShellReady = !waitForShellReady
   // Why tracked apart from `startupShellReady`: only an observed marker proves the
   // host wrapped the shell and armed bracketed paste. A fallback release means the
   // host shell never published one, so the raw submit is the only safe form.
   let markerObserved = false
-  const markerScan = options.waitForShellReady ? createShellReadyMarkerScanState() : null
+  let markerScan = waitForShellReady ? createShellReadyMarkerScanState() : null
   let injectTimer: ReturnType<typeof setTimeout> | null = null
   let fallbackTimer: ReturnType<typeof setTimeout> | null = null
   let sawOutput = false
@@ -97,7 +104,7 @@ export function createSshBackgroundStartupDelivery(
     }
     // The long budget only buys time for the shell-ready marker; the fast path
     // pastes nothing prompt-sensitive, so delaying it there is pure latency.
-    const waitingForSilentShell = options.waitForShellReady && !sawOutput
+    const waitingForSilentShell = waitForShellReady && !sawOutput
     fallbackTimer = setTimeout(
       () => {
         fallbackTimer = null
@@ -166,6 +173,19 @@ export function createSshBackgroundStartupDelivery(
     },
     armFallback,
     schedule,
+    applyHostShellReadyArmed(armed) {
+      if (armed !== false || !waitForShellReady) {
+        return
+      }
+      // Not a marker sighting: bracketed paste stays unproven, so the submit stays raw.
+      waitForShellReady = false
+      startupShellReady = true
+      markerScan = null
+      clearFallbackTimer()
+      if (lastPtyId) {
+        schedule(lastPtyId)
+      }
+    },
     clear() {
       clearInjectTimer()
       clearFallbackTimer()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​96 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |

<!-- /orca-pr-loc -->

Follow-up to #18796. Removes the latency regression that PR introduced on SSH hosts whose shell never publishes Orca's shell-ready marker.

## The regression

#18796 made every SSH Codex background launch wait for the marker, because the client cannot see which shell the remote host runs. But the relay only wraps bash/zsh (`pty-shell-launch.ts` returns `supportsReadyMarker: false` for everything else and for all win32). On a fish/sh/dash/Windows host — or a relay predating #18796 — no marker ever arrives, so delivery fell back at `SSH_SHELL_READY_STARTUP_FALLBACK_MS` (1.5s after first output) where it previously wrote at ~50ms.

## The fix

The relay already computes the answer as `rendererShellReadySupported`. Publish it as an optional `shellReadyArmed` on the `pty.spawn` reply, and let the client drop a wait it now knows is pointless.

Three-state, and the third state is the load-bearing one:

| value | meaning | client |
| --- | --- | --- |
| `true` | host armed the marker | wait for it (unchanged) |
| `false` | host looked and did not arm | deliver now, ~50ms |
| absent | host predates the field | **unknown** — keep the client's own prediction |

The field rides every reply, `false` included. Omitting it when false would collapse "not armed" into "old host" and defeat the whole fix, which is why the two exact-shape assertions in `pty-handler-spawn-admission.test.ts` were updated rather than the emission being made conditional.

A host that did not arm the marker did not arm bracketed paste either, so the released path keeps `markerObserved` false and submits raw.

## Wire compatibility

Additive optional field on an existing reply; per `docs/reference/remote-wire-compatibility.md` Rule 1 this needs no capability negotiation or version bump. Both directions:
- **New client + old host** — field absent, client keeps predicting exactly as it does today.
- **Old client + new host** — extra key ignored.

`shellReadyArmed` is never read through `?? false` at any hop. The runtime-owned CLI PTY path (`ipc/pty/runtime/spawn-commit.ts`) allowlists its response fields and is deliberately left alone — it does not use this delivery path.

## Verification

- New tests on all three hops (relay reply, client delivery, background launch), each verified to fail without the fix.
- 16,318 tests pass across relay / renderer-lib / providers / daemon / shared; `pnpm tc` clean; changed-code quality gate clean.