### PR TITLE
fix(sidebar): stop ⌘⇧↓ worktree navigation jumping to the first row

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -165,8 +165,11 @@ describe('WorktreeList keyboard cycling', () => {
 
     // Why: a second buildRows call drifts from the rendered layout (host sections,
     // pinned placement); cycling must read the same rows the viewport renders.
-    expect(navigateWorktree).toContain('getCyclableWorktrees(rows, pinnedDisplayPolicy)')
-    expect(navigateWorktree).toContain('getWorktreeHostIdentity')
+    expect(navigateWorktree).toContain('getCyclableWorktreeRows(rows, pinnedDisplayPolicy)')
+    expect(navigateWorktree).toContain('getCyclableRowIdentity')
+    // Why: the active host is stored resolved while a local row is unqualified; comparing raw identities wraps to the top.
+    expect(navigateWorktree).toContain('resolveActiveCycleIdentity')
+    expect(navigateWorktree).not.toContain('composeWorktreeHostIdentity')
     expect(navigateWorktree).toContain('executionHostId: nextWorktree.hostId')
     expect(navigateWorktree).toContain('resolveCycledWorktreeId')
     expect(navigateWorktree).not.toContain('buildRows(')

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
@@ -1,8 +1,48 @@
 import type { HostSectionRow } from './host-section-rows'
 import type { Worktree } from '../../../../shared/worktree/types'
-import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import { composeWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
+import { getWorktreeExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { PinnedWorktreeDisplayPolicy, WorktreeRow } from './worktree-list/grouping/row-types'
 import { getPreferredWorktreeRows } from './worktree-sidebar-row-preference'
+
+/** Host-resolved identity for a cyclable row.
+ *
+ * Why resolved rather than `getWorktreeHostIdentity`: a local worktree carries no
+ * `hostId` (`withRepoHostOwnership` leaves it unqualified), but every activation
+ * path stores the host it resolved to, so raw and resolved identities never match.
+ */
+export function getCyclableRowIdentity(row: Pick<WorktreeRow, 'worktree' | 'repo'>): string {
+  return composeWorktreeHostIdentity(
+    getWorktreeExecutionHostId(row.worktree, row.repo),
+    row.worktree.id
+  )
+}
+
+export function getCyclableWorktreeRows(
+  rows: readonly HostSectionRow[],
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
+): WorktreeRow[] {
+  const itemRows = rows.filter((row): row is WorktreeRow => row.type === 'item')
+  return getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy)
+}
+
+/** Identity that locates the active workspace among the cyclable rows. */
+export function resolveActiveCycleIdentity(args: {
+  rows: readonly WorktreeRow[]
+  activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId: ExecutionHostId | null
+}): string | null {
+  const { rows, activeWorktreeId, activeWorkspaceExecutionHostId } = args
+  if (!activeWorktreeId) {
+    return null
+  }
+  if (activeWorkspaceExecutionHostId) {
+    return composeWorktreeHostIdentity(activeWorkspaceExecutionHostId, activeWorktreeId)
+  }
+  // Host-unqualified activation names no host; the row it landed on does.
+  const row = rows.find((candidate) => candidate.worktree.id === activeWorktreeId)
+  return row ? getCyclableRowIdentity(row) : null
+}
 
 /** Worktree ids in sidebar order, taken from the rows the sidebar actually
  *  rendered, so collapsed groups and collapsed host sections drop out on their own. */
@@ -12,11 +52,10 @@ export function getCyclableWorktreeIds(
 ): string[] {
   // Why item-only: folder workspaces render as their own row type and are not
   // activatable through activateAndRevealWorktree, so cycling has never included them.
-  const itemRows = rows.filter((row): row is WorktreeRow => row.type === 'item')
   const ids: string[] = []
   const seen = new Set<string>()
-  for (const row of getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy)) {
-    const identity = getWorktreeHostIdentity(row.worktree)
+  for (const row of getCyclableWorktreeRows(rows, pinnedDisplayPolicy)) {
+    const identity = getCyclableRowIdentity(row)
     if (seen.has(identity)) {
       continue
     }
@@ -30,8 +69,7 @@ export function getCyclableWorktrees(
   rows: readonly HostSectionRow[],
   pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
 ): Worktree[] {
-  const itemRows = rows.filter((row): row is WorktreeRow => row.type === 'item')
-  return getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy).map((row) => row.worktree)
+  return getCyclableWorktreeRows(rows, pinnedDisplayPolicy).map((row) => row.worktree)
 }
 
 /** Pick the worktree that `worktree.navigateUp` / `worktree.navigateDown` moves

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.host-identity.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.host-identity.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import type { HostSectionRow } from '../../host-section-rows'
+import type { RenderRow } from '../listing/render-row'
+import { getShortcutPlatform } from '@/lib/shortcut-platform'
+
+const activateAndRevealWorktree = vi.fn()
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: (...args: unknown[]) => activateAndRevealWorktree(...args)
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: { keybindings: undefined }) => unknown) =>
+    selector({ keybindings: undefined })
+}))
+
+const { useWorktreeListKeyboardNavigation } = await import('./use-keyboard')
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const repo = { id: 'repo-1', path: '/repo-1', displayName: 'Repo 1' }
+
+// Local worktrees carry no `hostId` — `withRepoHostOwnership` leaves them unqualified.
+function localRow(id: string): HostSectionRow & { type: 'item' } {
+  return {
+    type: 'item',
+    rowKey: `row:${id}`,
+    sectionKey: 'repo:repo-1',
+    worktree: { id, repoId: repo.id } as unknown as Worktree,
+    repo: repo as never,
+    depth: 0,
+    groupDepth: 0,
+    lineageTrail: [],
+    isLastLineageChild: false,
+    lineageChildCount: 0
+  }
+}
+
+const rows: HostSectionRow[] = [localRow('a'), localRow('b'), localRow('c')]
+const renderRows = rows as unknown as RenderRow[]
+
+let container: HTMLDivElement
+let root: Root
+
+function press(direction: 'up' | 'down'): void {
+  const mod = getShortcutPlatform() === 'darwin' ? { metaKey: true } : { ctrlKey: true }
+  act(() => {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: direction === 'down' ? 'ArrowDown' : 'ArrowUp',
+        code: direction === 'down' ? 'ArrowDown' : 'ArrowUp',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+        ...mod
+      })
+    )
+  })
+}
+
+function renderProbe(activeWorktreeId: string, activeHostId: 'local' | null): void {
+  function Probe(): null {
+    useWorktreeListKeyboardNavigation({
+      rows,
+      renderRows,
+      activeWorktreeId,
+      activeWorkspaceExecutionHostId: activeHostId,
+      pinnedDisplayPolicy: 'single-location',
+      virtualizer: { scrollToIndex: () => {} } as never,
+      scrollRef: { current: null },
+      activeModal: 'none',
+      markDirectScrollInput: () => {}
+    })
+    return null
+  }
+  act(() => root.render(<Probe />))
+}
+
+beforeEach(() => {
+  activateAndRevealWorktree.mockClear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('worktree keyboard cycling with a resolved active host', () => {
+  it('steps to the next row when the active host resolved to local but rows are unqualified', () => {
+    // Why: a sidebar click activates with the repo-resolved host (`local`), while
+    // local rows carry no hostId; a raw identity compare misses and wraps to the top.
+    renderProbe('b', 'local')
+
+    press('down')
+
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('c', {})
+  })
+
+  it('steps to the previous row when the active host resolved to local', () => {
+    renderProbe('b', 'local')
+
+    press('up')
+
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('a', {})
+  })
+
+  it('still steps normally when the active host is unqualified', () => {
+    renderProbe('b', null)
+
+    press('down')
+
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('c', {})
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-keyboard.ts
@@ -4,16 +4,17 @@ import type { Virtualizer } from '@tanstack/react-virtual'
 import { useAppStore } from '@/store'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
-import {
-  composeWorktreeHostIdentity,
-  getWorktreeHostIdentity
-} from '../../../../../../shared/worktree/host-qualified-identity'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { keybindingMatchesAction } from '../../../../../../shared/keybindings'
 import type { HostSectionRow } from '../../host-section-rows'
 import type { PinnedWorktreeDisplayPolicy } from '../grouping/row-types'
 import type { RenderRow } from '../listing/render-row'
-import { getCyclableWorktrees, resolveCycledWorktreeId } from '../../worktree-keyboard-cycle'
+import {
+  getCyclableRowIdentity,
+  getCyclableWorktreeRows,
+  resolveActiveCycleIdentity,
+  resolveCycledWorktreeId
+} from '../../worktree-keyboard-cycle'
 import { findPreferredRenderRowIndexForWorktreeIdentity } from './render-row-lookup'
 
 function isEditableTarget(target: EventTarget | null): boolean {
@@ -65,24 +66,22 @@ export function useWorktreeListKeyboardNavigation(args: {
       // Why: cycle over the rows the sidebar actually rendered — collapsing a group
       // means "not now", and a rebuilt near-copy would drift from what is on screen
       // (host sections, pinned placement, folder workspaces).
-      const worktrees = getCyclableWorktrees(rows, pinnedDisplayPolicy)
-      const worktreeIdentities = worktrees.map(getWorktreeHostIdentity)
+      const worktreeRows = getCyclableWorktreeRows(rows, pinnedDisplayPolicy)
       const nextWorktreeIdentity = resolveCycledWorktreeId({
-        worktreeIds: worktreeIdentities,
-        activeWorktreeId: activeWorktreeId
-          ? composeWorktreeHostIdentity(
-              activeWorkspaceExecutionHostId ?? undefined,
-              activeWorktreeId
-            )
-          : null,
+        worktreeIds: worktreeRows.map(getCyclableRowIdentity),
+        activeWorktreeId: resolveActiveCycleIdentity({
+          rows: worktreeRows,
+          activeWorktreeId,
+          activeWorkspaceExecutionHostId
+        }),
         direction
       })
       if (nextWorktreeIdentity === null) {
         return
       }
-      const nextWorktree = worktrees.find(
-        (worktree) => getWorktreeHostIdentity(worktree) === nextWorktreeIdentity
-      )
+      const nextWorktree = worktreeRows.find(
+        (row) => getCyclableRowIdentity(row) === nextWorktreeIdentity
+      )?.worktree
       if (!nextWorktree) {
         return
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​125 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |

<!-- /orca-pr-loc -->

## Symptom

`⌘⇧↓` (next worktree) sometimes jumps to the very first worktree in the sidebar instead of stepping down one. `⌘⇧↑` has the mirror bug (jumps to the last).

## Root cause

`navigateWorktree` locates the active workspace by comparing **raw** host-qualified identities:

- Row identity came from `getWorktreeHostIdentity(worktree)` → `` `${worktree.hostId ?? ''}|${id}` ``. A local worktree carries **no** `hostId` — `withRepoHostOwnership` deliberately leaves it unqualified — so its identity is `|<id>`.
- Active identity came from `composeWorktreeHostIdentity(activeWorkspaceExecutionHostId, id)`. A sidebar click activates via `worktree.hostId ?? getRepoExecutionHostId(repo)`, which **resolves** to `local`, so the store holds `local|<id>`.

`indexOf` missed, `resolveCycledWorktreeId` fell into its "the active worktree is inside a collapsed group" branch, and the keypress entered from the end of the list — first row on `down`, last row on `up`.

## Why it looked intermittent

Keyboard cycling itself activates **hostless** (`nextWorktree.hostId ? {...} : {}` → `activeWorkspaceExecutionHostId: null`), which *does* match the unqualified row. So only the **first** `⌘⇧↓` after a click / jump-palette / any host-resolving activation jumped to the top; every press after that behaved.

## Fix

Resolve the host on both sides before comparing, using the same precedence the rest of the sidebar already uses (`getWorktreeExecutionHostId(worktree, repo)` — the identical rule `render-row-lookup.ts` applies). When the active workspace was activated without a host, take the host from the row it landed on instead of assuming one.

## Tests

New `use-keyboard.host-identity.test.tsx` drives the real hook with the real keybinding matcher. Against `main` it fails exactly as reported:

```
- "a"   ← first worktree
+ "c"   ← expected next
```

- `⌘⇧↓` with `activeWorkspaceExecutionHostId: 'local'` over unqualified local rows steps to the next row
- `⌘⇧↑` steps to the previous row
- hostless active workspace still steps normally (the case that used to work)

The existing source-guard test in `worktree-keyboard-cycle.test.ts` is updated to pin the resolved-identity path and to assert cycling no longer reaches for a raw `composeWorktreeHostIdentity`.

`pnpm tc`, `pnpm run check:code-quality:changed`, and the sidebar navigation suites (30 tests) pass.

## Note, not fixed here

`usePrimaryActiveWorktreeRow` (`navigation/use-active-row.ts`) compares identities the same raw way, so a clicked local worktree also loses its "primary row" marking when a pinned duplicate is rendered. Cosmetic only, and out of scope for this fix — happy to follow up.