### PR TITLE
feat(native-chat): stop monitored tasks individually

### DIFF
--- a/src/main/claude/claude-structured-control-actions.test.ts
+++ b/src/main/claude/claude-structured-control-actions.test.ts
@@ -158,4 +158,42 @@ describe('stopClaudeBackgroundTasks', () => {
     await stopClaudeBackgroundTasks(session, undefined, () => current)
     expect(stopTask).toHaveBeenCalledTimes(1)
   })
+
+  it('stops only the requested live task id', async () => {
+    const backgroundTasks = new ClaudeBackgroundTaskTracker()
+    backgroundTasks.observe({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      tasks: [
+        { task_id: 'task-one', task_type: 'local_agent' },
+        { task_id: 'task-two', task_type: 'local_bash' }
+      ]
+    })
+    const stopTask = vi.fn(async (_taskId: string) => {})
+    const session = { backgroundTasks, connection: { stopTask } } as unknown as ClaudeSession
+
+    await expect(
+      stopClaudeBackgroundTasks(session, 5_000, () => true, 'task-two')
+    ).resolves.toEqual({ cancelled: true })
+    expect(stopTask).toHaveBeenCalledWith('task-two', { timeoutMs: 5_000 })
+    expect(stopTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('refuses a stale or unknown task id without a provider call', async () => {
+    const backgroundTasks = new ClaudeBackgroundTaskTracker()
+    backgroundTasks.observe({
+      type: 'system',
+      subtype: 'task_started',
+      task_id: 'task-live',
+      task_type: 'local_agent',
+      is_backgrounded: true
+    })
+    const stopTask = vi.fn(async (_taskId: string) => {})
+    const session = { backgroundTasks, connection: { stopTask } } as unknown as ClaudeSession
+
+    await expect(
+      stopClaudeBackgroundTasks(session, undefined, () => true, 'task-stale')
+    ).resolves.toEqual({ cancelled: false })
+    expect(stopTask).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/claude/claude-structured-control-actions.ts
+++ b/src/main/claude/claude-structured-control-actions.ts
@@ -46,9 +46,12 @@ export async function cancelClaudeTurn(
 export async function stopClaudeBackgroundTasks(
   session: ClaudeSession,
   timeoutMs: number | undefined,
-  isCurrent: ClaudeTurnCancellationGuard = () => true
+  isCurrent: ClaudeTurnCancellationGuard = () => true,
+  taskId?: string
 ): Promise<{ cancelled: boolean }> {
-  const taskIds = session.backgroundTasks.stoppableTaskIds
+  const stoppableTaskIds = session.backgroundTasks.stoppableTaskIds
+  const taskIds =
+    taskId === undefined ? stoppableTaskIds : stoppableTaskIds.includes(taskId) ? [taskId] : []
   let cancelled = false
   for (const taskId of taskIds) {
     if (!isCurrent()) {

--- a/src/main/claude/claude-structured-session-adapter.ts
+++ b/src/main/claude/claude-structured-session-adapter.ts
@@ -30,6 +30,7 @@ import {
   settleClaudeExitedSession
 } from './claude-structured-session-close'
 import { readClaudeTranscriptLeafWithReproof } from './claude-transcript-branch-proof'
+import type { AgentSessionBackgroundTaskState } from '../../shared/agent-session-wire'
 
 export type { ClaudeStructuredLaunch } from './claude-structured-launch-resolution'
 export type {
@@ -39,6 +40,11 @@ export type {
 } from './claude-structured-session-state'
 
 const DISPATCH_ACK_TIMEOUT_MS = 10_000
+
+function backgroundTaskState(session: ClaudeSession): AgentSessionBackgroundTaskState | null {
+  const state = session.backgroundTasks.state
+  return state ? { ...state, supportsTaskStop: true } : null
+}
 
 export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAdapter {
   private readonly sessions = new Map<string, ClaudeSession>()
@@ -166,7 +172,10 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
     session?.translator?.handle(event)
     this.deps.onEvent?.(event)
     if (backgroundTasksChanged) {
-      this.deps.onBackgroundTasksChanged?.(event.sessionId, session?.backgroundTasks.state ?? null)
+      this.deps.onBackgroundTasksChanged?.(
+        event.sessionId,
+        session ? backgroundTaskState(session) : null
+      )
     }
   }
 
@@ -207,18 +216,25 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
   stopBackgroundTasks: StructuredAgentSessionAdapter['stopBackgroundTasks'] = (input) => {
     const session = this.session(input.sessionId)
     const acquisitionGeneration = session.acquisitionGeneration
-    return stopClaudeBackgroundTasks(session, this.deps.requestTimeoutMs, () =>
-      Boolean(
-        this.sessions.get(input.sessionId) === session &&
-        session.fence === input.fence &&
-        session.acquisitionGeneration === acquisitionGeneration &&
-        session.backgroundTasks.state
-      )
+    return stopClaudeBackgroundTasks(
+      session,
+      this.deps.requestTimeoutMs,
+      () =>
+        Boolean(
+          this.sessions.get(input.sessionId) === session &&
+          session.fence === input.fence &&
+          session.acquisitionGeneration === acquisitionGeneration &&
+          session.backgroundTasks.state
+        ),
+      input.taskId
     )
   }
   backgroundTaskState: NonNullable<StructuredAgentSessionAdapter['backgroundTaskState']> = (
     sessionId
-  ) => this.sessions.get(sessionId)?.backgroundTasks.state
+  ) => {
+    const session = this.sessions.get(sessionId)
+    return session ? backgroundTaskState(session) : undefined
+  }
   answerPrompt: StructuredAgentSessionAdapter['answerPrompt'] = (input) =>
     answerClaudePrompt(this.session(input.sessionId), input)
   setOption: StructuredAgentSessionAdapter['setOption'] = (input) =>

--- a/src/main/claude/claude-structured-session-close.test.ts
+++ b/src/main/claude/claude-structured-session-close.test.ts
@@ -53,7 +53,11 @@ describe('Claude published session close lifecycle', () => {
       is_backgrounded: true
     })
     expect(backgroundStates).toEqual([
-      { state: 'monitoring', tasks: [{ id: 'background-1', kind: 'agent' }] }
+      {
+        state: 'monitoring',
+        tasks: [{ id: 'background-1', kind: 'agent' }],
+        supportsTaskStop: true
+      }
     ])
     const session = (
       adapter as unknown as {
@@ -68,7 +72,11 @@ describe('Claude published session close lifecycle', () => {
     expect(events.filter((event) => event.type === 'handle')).toHaveLength(0)
     expect(disposeTranslator).toHaveBeenCalledOnce()
     expect(backgroundStates).toEqual([
-      { state: 'monitoring', tasks: [{ id: 'background-1', kind: 'agent' }] },
+      {
+        state: 'monitoring',
+        tasks: [{ id: 'background-1', kind: 'agent' }],
+        supportsTaskStop: true
+      },
       null
     ])
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-adapter.ts
@@ -137,7 +137,11 @@ export type StructuredAgentSessionAdapter = {
     turnId: string
     fence: number
   }): Promise<{ cancelled: boolean }>
-  stopBackgroundTasks?(input: { sessionId: string; fence: number }): Promise<{ cancelled: boolean }>
+  stopBackgroundTasks?(input: {
+    sessionId: string
+    fence: number
+    taskId?: string
+  }): Promise<{ cancelled: boolean }>
   backgroundTaskState?(sessionId: string): AgentSessionBackgroundTaskState | null | undefined
   /** Fires the provider callback for an approval or a question. The wire calls
    *  this only after the durable compare-and-set won, so it runs exactly once. */

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-mutations.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-mutations.ts
@@ -78,6 +78,7 @@ export function cancelStructuredAgentSessionTurn(
     envelope: AgentSessionMutationEnvelope
     turnId: string
     scope?: 'background-tasks'
+    taskId?: string
   }
 ): Promise<AgentSessionMutationResult<AgentSessionCancelResult>> {
   return mutate(context, caller, params.envelope, cancelPlan(params))

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-mutation-plans.ts
@@ -76,15 +76,21 @@ export function cancelPlan(params: {
   envelope: AgentSessionMutationEnvelope
   turnId: string
   scope?: 'background-tasks'
+  taskId?: string
 }): MutationPlan<AgentSessionCancelResult> {
   return {
     method: 'agentSession.cancel',
-    fields: { turnId: params.turnId, ...(params.scope ? { scope: params.scope } : {}) },
+    fields: {
+      turnId: params.turnId,
+      ...(params.scope ? { scope: params.scope } : {}),
+      ...(params.taskId ? { taskId: params.taskId } : {})
+    },
     run: (ctx) =>
       performCancel(ctx, {
         clientOperationId: params.envelope.clientOperationId,
         turnId: params.turnId,
-        ...(params.scope ? { scope: params.scope } : {})
+        ...(params.scope ? { scope: params.scope } : {}),
+        ...(params.taskId ? { taskId: params.taskId } : {})
       }),
     // Interrupting twice would kill a turn the client never asked to stop, so a
     // replay reports the turn as already handled instead.

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.test.ts
@@ -104,4 +104,40 @@ describe('performCancel', () => {
     expect(cancelTurn).not.toHaveBeenCalled()
     expect(journal.snapshot().items).toEqual([])
   })
+
+  it('routes one background task id without interrupting the foreground turn or writing a row', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-background-task-targeted-cancel-'))
+    const journal = await journals.open({ identity: IDENTITY, journalDir: root })
+    const cancelTurn = vi.fn(async () => ({ cancelled: true }))
+    const stopBackgroundTasks = vi.fn(async () => ({ cancelled: true }))
+    const ctx: AgentSessionTurnContext = {
+      sessionId: 'session-1',
+      journal,
+      fence: 1,
+      adapter: { cancelTurn, stopBackgroundTasks } as unknown as StructuredAgentSessionAdapter,
+      persistOptions: async () => undefined,
+      resolvedBy: 'client-1',
+      publish: vi.fn(),
+      now: () => 1
+    }
+
+    const result = await performCancel(ctx, {
+      clientOperationId: 'cancel-background-task-2',
+      turnId: 'background-tasks',
+      scope: 'background-tasks',
+      taskId: 'task-2'
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: { turnId: 'background-tasks', cancelled: true }
+    })
+    expect(stopBackgroundTasks).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      fence: 1,
+      taskId: 'task-2'
+    })
+    expect(cancelTurn).not.toHaveBeenCalled()
+    expect(journal.snapshot().items).toEqual([])
+  })
 })

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns.ts
@@ -150,6 +150,7 @@ export async function performCancel(
     clientOperationId: string
     turnId: string
     scope?: 'background-tasks'
+    taskId?: string
   }
 ): Promise<TurnOutcome<AgentSessionCancelResult>> {
   let cancelled = false
@@ -159,7 +160,8 @@ export async function performCancel(
       ? (
           await ctx.adapter.stopBackgroundTasks?.({
             sessionId: ctx.sessionId,
-            fence: ctx.fence
+            fence: ctx.fence,
+            ...(input.taskId ? { taskId: input.taskId } : {})
           })
         )?.cancelled === true
       : (

--- a/src/main/runtime/claude-structured-session-integration.test.ts
+++ b/src/main/runtime/claude-structured-session-integration.test.ts
@@ -602,6 +602,46 @@ describe('a structured Claude session over agentSession.*', () => {
       `claude:${PROVIDER_SESSION}:assistant-leaf`
     )
 
+    claude.live().handlers.onMessage?.({
+      type: 'system',
+      subtype: 'background_tasks_changed',
+      session_id: PROVIDER_SESSION,
+      uuid: 'background-roster',
+      tasks: [
+        { task_id: 'task-one', task_type: 'local_agent', description: 'First task' },
+        { task_id: 'task-two', task_type: 'local_bash', description: 'Second task' }
+      ]
+    })
+    const itemsBeforeTaskStop = itemsOf(stream)
+    const targetedStopFields = {
+      turnId: 'background-tasks',
+      scope: 'background-tasks',
+      taskId: 'task-two'
+    }
+    await expect(
+      ok('agentSession.cancel', {
+        envelope: envelope('agentSession.cancel', targetedStopFields, created.fence),
+        ...targetedStopFields
+      })
+    ).resolves.toMatchObject({ turnId: 'background-tasks', cancelled: true })
+    expect(claude.live().calls.filter((entry) => entry.subtype === 'stop_task')).toEqual([
+      { subtype: 'stop_task', params: { taskId: 'task-two' } }
+    ])
+    expect(itemsOf(stream)).toEqual(itemsBeforeTaskStop)
+
+    const staleStopFields = {
+      turnId: 'background-tasks',
+      scope: 'background-tasks',
+      taskId: 'task-stale'
+    }
+    await expect(
+      ok('agentSession.cancel', {
+        envelope: envelope('agentSession.cancel', staleStopFields, created.fence),
+        ...staleStopFields
+      })
+    ).resolves.toMatchObject({ turnId: 'background-tasks', cancelled: false })
+    expect(claude.live().calls.filter((entry) => entry.subtype === 'stop_task')).toHaveLength(1)
+
     const answeredPermission = Promise.resolve(
       claude.live().handlers.canUseTool?.('Bash', { command: 'ls' }, {
         requestId: 'permission-1',

--- a/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-schemas.ts
@@ -152,9 +152,13 @@ export const CancelParams = z
   .object({
     envelope: MutationEnvelope,
     turnId: Identifier('Invalid turn id'),
-    scope: z.literal('background-tasks').optional()
+    scope: z.literal('background-tasks').optional(),
+    taskId: Identifier('Invalid task id').optional()
   })
   .strict()
+  .refine((value) => value.taskId === undefined || value.scope === 'background-tasks', {
+    message: 'A task id requires background-task scope'
+  })
 
 export const RespondParams = z
   .object({

--- a/src/main/runtime/rpc/methods/structured-agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.test.ts
@@ -480,6 +480,20 @@ describe('method routing', () => {
     ])
   })
 
+  it('routes an optional background task id through cancellation', async () => {
+    const params = {
+      envelope: envelope(),
+      turnId: 'background-tasks',
+      scope: 'background-tasks' as const,
+      taskId: 'task-2'
+    }
+
+    const response = await call('agentSession.cancel', params, STRUCTURED_CLIENT)
+
+    expect(response).toMatchObject({ ok: true })
+    expect(hostCalls.cancel).toHaveBeenCalledWith(expect.anything(), params)
+  })
+
   it('routes the structured handoff mutation through the host', async () => {
     const response = await call('agentSession.requestHandoff', {
       envelope: envelope(),
@@ -508,6 +522,21 @@ describe('parameter validation', () => {
       ...sendParams(),
       envelope: { ...envelope(), priority: 'high' }
     })
+  })
+
+  it('rejects invalid or unscoped background task ids', async () => {
+    await rejects('agentSession.cancel', {
+      envelope: envelope(),
+      turnId: 'background-tasks',
+      scope: 'background-tasks',
+      taskId: ' task-2'
+    })
+    await rejects('agentSession.cancel', {
+      envelope: envelope(),
+      turnId: 'turn-1',
+      taskId: 'task-2'
+    })
+    expect(hostCalls.cancel).not.toHaveBeenCalled()
   })
 
   it('refuses to let a client author anything but a user turn', async () => {

--- a/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatBackgroundTasksStatus.tsx
@@ -25,8 +25,10 @@ function backgroundTaskLabel(task: AgentSessionBackgroundTask): string {
 
 export function NativeChatBackgroundTasksStatus(props: {
   tasks: readonly AgentSessionBackgroundTask[]
-  stopping: boolean
-  onStop: () => void
+  supportsTaskStop: boolean
+  stoppingTaskIds: ReadonlySet<string>
+  stoppingAll: boolean
+  onStop: (taskId?: string) => void
 }): React.JSX.Element {
   const [expanded, setExpanded] = useState(false)
   const taskListId = useId()
@@ -36,7 +38,7 @@ export function NativeChatBackgroundTasksStatus(props: {
       className="shrink-0 bg-background px-3 pt-2 sm:px-4"
     >
       <div className="mx-auto w-full max-w-4xl overflow-hidden rounded-lg border border-border bg-muted/50 text-xs text-muted-foreground shadow-xs">
-        <div className="flex h-8 items-center gap-1 px-1.5">
+        <div className="flex h-8 items-center px-1.5">
           <button
             type="button"
             className="flex h-6 min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-1.5 text-left outline-none hover:bg-accent hover:text-accent-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50"
@@ -58,15 +60,6 @@ export function NativeChatBackgroundTasksStatus(props: {
               className={`size-3 transition-transform ${expanded ? 'rotate-180' : ''}`}
             />
           </button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="xs"
-            disabled={props.stopping}
-            onClick={props.onStop}
-          >
-            {translate('components.native-chat.backgroundTasks.stop', 'Stop')}
-          </Button>
         </div>
         {expanded ? (
           <div
@@ -82,15 +75,37 @@ export function NativeChatBackgroundTasksStatus(props: {
                 )}
                 className="space-y-1.5"
               >
-                {props.tasks.map((task) => (
-                  <li key={task.id} className="flex min-w-0 items-start gap-2 text-foreground/80">
-                    <span
-                      aria-hidden="true"
-                      className="mt-1 size-1.5 shrink-0 rounded-full bg-primary"
-                    />
-                    <span className="min-w-0 break-words">{backgroundTaskLabel(task)}</span>
-                  </li>
-                ))}
+                {props.tasks.map((task) => {
+                  const label = backgroundTaskLabel(task)
+                  return (
+                    <li
+                      key={task.id}
+                      className="flex min-w-0 items-center gap-2 text-foreground/80"
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="size-1.5 shrink-0 rounded-full bg-primary"
+                      />
+                      <span className="min-w-0 flex-1 break-words">{label}</span>
+                      {props.supportsTaskStop ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="xs"
+                          aria-label={translate(
+                            'components.native-chat.backgroundTasks.stopTask',
+                            'Stop {{value0}}',
+                            { value0: label }
+                          )}
+                          disabled={props.stoppingTaskIds.has(task.id)}
+                          onClick={() => props.onStop(task.id)}
+                        >
+                          {translate('components.native-chat.backgroundTasks.stop', 'Stop')}
+                        </Button>
+                      ) : null}
+                    </li>
+                  )
+                })}
               </ul>
             ) : (
               <p>
@@ -100,6 +115,23 @@ export function NativeChatBackgroundTasksStatus(props: {
                 )}
               </p>
             )}
+            {!props.supportsTaskStop ? (
+              <div className={props.tasks.length > 0 ? 'mt-2 border-t border-border pt-2' : 'mt-2'}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  aria-label={translate(
+                    'components.native-chat.backgroundTasks.stopAll',
+                    'Stop background tasks'
+                  )}
+                  disabled={props.stoppingAll}
+                  onClick={() => props.onStop()}
+                >
+                  {translate('components.native-chat.backgroundTasks.stop', 'Stop')}
+                </Button>
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.test.tsx
@@ -29,8 +29,9 @@ const mocks = vi.hoisted(() => ({
   pasteFromClipboard: vi.fn(),
   submissions: [] as unknown[],
   monitoringBackgroundTasks: false,
+  supportsBackgroundTaskStop: false,
   backgroundTasks: [] as AgentSessionBackgroundTask[],
-  stopBackgroundTasks: vi.fn()
+  stopBackgroundTask: vi.fn()
 }))
 
 vi.mock('@/runtime/structured-agent-session-client', () => ({
@@ -75,10 +76,11 @@ vi.mock('./use-structured-agent-session', async () => {
         retry: outbox.retry,
         isWorking: false,
         isMonitoringBackgroundTasks: mocks.monitoringBackgroundTasks,
+        supportsBackgroundTaskStop: mocks.supportsBackgroundTaskStop,
         backgroundTasks: mocks.backgroundTasks,
         turnId: null,
         cancel: vi.fn(),
-        stopBackgroundTasks: mocks.stopBackgroundTasks,
+        stopBackgroundTask: (taskId?: string) => mocks.stopBackgroundTask(props.sessionId, taskId),
         respond: mocks.respond,
         optionSnapshot: [
           {
@@ -166,7 +168,8 @@ describe('NativeChatStructuredSession', () => {
     mocks.pasteFromClipboard.mockReset()
     mocks.submissions = []
     mocks.monitoringBackgroundTasks = false
-    mocks.stopBackgroundTasks.mockReset()
+    mocks.supportsBackgroundTaskStop = false
+    mocks.stopBackgroundTask.mockReset()
     mocks.backgroundTasks = []
   })
 
@@ -225,11 +228,12 @@ describe('NativeChatStructuredSession', () => {
 
   it('places background monitoring above the usable composer and stops without an active turn', async () => {
     mocks.monitoringBackgroundTasks = true
+    mocks.supportsBackgroundTaskStop = true
     mocks.backgroundTasks = [
       { id: 'task-command', kind: 'command', description: 'sleep 180' },
       { id: 'task-agent', kind: 'agent' }
     ]
-    mocks.stopBackgroundTasks.mockResolvedValue({ cancelled: true })
+    mocks.stopBackgroundTask.mockResolvedValue({ cancelled: true })
 
     render(
       <NativeChatStructuredSession
@@ -251,6 +255,7 @@ describe('NativeChatStructuredSession', () => {
     expect(status.compareDocumentPosition(composer) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(mocks.composerProps?.isWorking).toBe(false)
     expect(screen.queryByRole('list', { name: 'Running background tasks' })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^Stop / })).toBeNull()
 
     const disclosure = screen.getByRole('button', { name: 'Monitoring background tasks' })
     expect(disclosure.getAttribute('aria-expanded')).toBe('false')
@@ -260,8 +265,130 @@ describe('NativeChatStructuredSession', () => {
     expect(screen.getByText('sleep 180')).toBeTruthy()
     expect(screen.getByText('Background agent')).toBeTruthy()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
-    await waitFor(() => expect(mocks.stopBackgroundTasks).toHaveBeenCalledOnce())
+    fireEvent.click(screen.getByRole('button', { name: 'Stop sleep 180' }))
+    await waitFor(() =>
+      expect(mocks.stopBackgroundTask).toHaveBeenCalledWith('session-background', 'task-command')
+    )
+  })
+
+  it('tracks concurrent task stops independently and clears each pending result', async () => {
+    mocks.monitoringBackgroundTasks = true
+    mocks.supportsBackgroundTaskStop = true
+    mocks.backgroundTasks = [
+      { id: 'task-one', kind: 'command', description: 'First task' },
+      { id: 'task-two', kind: 'command', description: 'Second task' }
+    ]
+    let finishFirst!: (value: unknown) => void
+    let finishSecond!: (value: unknown) => void
+    mocks.stopBackgroundTask.mockImplementation(
+      (_sessionId: string, taskId: string) =>
+        new Promise((resolve) => {
+          if (taskId === 'task-one') {
+            finishFirst = resolve
+          } else {
+            finishSecond = resolve
+          }
+        })
+    )
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-concurrent-background"
+        sessionId="session-concurrent-background"
+        target={{ kind: 'local' }}
+        agent="claude"
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Monitoring background tasks' }))
+    const firstStop = screen.getByRole('button', { name: 'Stop First task' })
+    const secondStop = screen.getByRole('button', { name: 'Stop Second task' })
+
+    fireEvent.click(firstStop)
+    fireEvent.click(secondStop)
+    expect((firstStop as HTMLButtonElement).disabled).toBe(true)
+    expect((secondStop as HTMLButtonElement).disabled).toBe(true)
+
+    await act(async () => finishFirst({ cancelled: true }))
+    await waitFor(() => expect((firstStop as HTMLButtonElement).disabled).toBe(false))
+    expect((secondStop as HTMLButtonElement).disabled).toBe(true)
+
+    await act(async () => finishSecond(null))
+    await waitFor(() => expect((secondStop as HTMLButtonElement).disabled).toBe(false))
+  })
+
+  it('keeps a stale session stop result from clearing the current session pending state', async () => {
+    mocks.monitoringBackgroundTasks = true
+    mocks.supportsBackgroundTaskStop = true
+    mocks.backgroundTasks = [{ id: 'task-one', kind: 'command', description: 'Shared task' }]
+    let finishOld!: (value: unknown) => void
+    let finishCurrent!: (value: unknown) => void
+    mocks.stopBackgroundTask.mockImplementation(
+      (sessionId: string) =>
+        new Promise((resolve) => {
+          if (sessionId === 'session-old') {
+            finishOld = resolve
+          } else {
+            finishCurrent = resolve
+          }
+        })
+    )
+    const { rerender } = render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-stale-background"
+        sessionId="session-old"
+        target={{ kind: 'local' }}
+        agent="claude"
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Monitoring background tasks' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Stop Shared task' }))
+
+    rerender(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-stale-background"
+        sessionId="session-current"
+        target={{ kind: 'local' }}
+        agent="claude"
+      />
+    )
+    const currentStop = screen.getByRole('button', { name: 'Stop Shared task' })
+    expect((currentStop as HTMLButtonElement).disabled).toBe(false)
+    fireEvent.click(currentStop)
+    expect((currentStop as HTMLButtonElement).disabled).toBe(true)
+
+    await act(async () => finishOld({ cancelled: true }))
+    expect((currentStop as HTMLButtonElement).disabled).toBe(true)
+    await act(async () => finishCurrent({ cancelled: true }))
+    await waitFor(() => expect((currentStop as HTMLButtonElement).disabled).toBe(false))
+  })
+
+  it('keeps the expanded all-task stop fallback for a taskless older host', async () => {
+    mocks.monitoringBackgroundTasks = true
+    mocks.stopBackgroundTask.mockResolvedValue({ cancelled: true })
+
+    render(
+      <NativeChatStructuredSession
+        isVisible
+        tabId="structured-tab-taskless-background"
+        sessionId="session-taskless-background"
+        target={{ kind: 'local' }}
+        agent="claude"
+      />
+    )
+    expect(screen.queryByRole('button', { name: 'Stop background tasks' })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Monitoring background tasks' }))
+    expect(screen.getByText('Task details are unavailable for this session.')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Stop background tasks' }))
+
+    await waitFor(() =>
+      expect(mocks.stopBackgroundTask).toHaveBeenCalledWith(
+        'session-taskless-background',
+        undefined
+      )
+    )
   })
 
   it('routes a bare model command to the native option picker', async () => {

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -22,6 +22,14 @@ import { useStructuredNativeChatPaneCommands } from './use-structured-native-cha
 import type { NativeChatStructuredViewProps } from './native-chat-view-types'
 import { NativeChatBackgroundTasksStatus } from './NativeChatBackgroundTasksStatus'
 
+type StoppingBackgroundTasks = {
+  sessionId: string
+  taskIds: ReadonlySet<string>
+  all: boolean
+}
+
+const NO_STOPPING_TASKS: ReadonlySet<string> = new Set()
+
 function encodeQuestionAnswer(questionId: string, answer: string): string {
   return `${encodeURIComponent(questionId)}:${encodeURIComponent(answer)}`
 }
@@ -31,7 +39,8 @@ export function NativeChatStructuredSession(
 ): React.JSX.Element {
   const controller = useStructuredAgentSession(props)
   const [composerError, setComposerError] = useState<string | null>(null)
-  const [stoppingBackgroundTasks, setStoppingBackgroundTasks] = useState(false)
+  const [stoppingBackgroundTasks, setStoppingBackgroundTasks] =
+    useState<StoppingBackgroundTasks | null>(null)
   const [optionPickerRequest, setOptionPickerRequest] = useState<{
     id: string
     sequence: number
@@ -83,6 +92,8 @@ export function NativeChatStructuredSession(
   const fileLinkContext = useNativeChatFileLinkContext(props.tabId)
   const imageRuntimeContext = useNativeChatImageRuntimeContext(props.tabId)
   const fileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
+  const activeStoppingBackgroundTasks =
+    stoppingBackgroundTasks?.sessionId === props.sessionId ? stoppingBackgroundTasks : null
   const prompt = controller.prompts[0] ?? null
   const questionBody = prompt?.body.kind === 'question' ? prompt.body : null
   const questions =
@@ -277,10 +288,39 @@ export function NativeChatStructuredSession(
       {controller.isMonitoringBackgroundTasks ? (
         <NativeChatBackgroundTasksStatus
           tasks={controller.backgroundTasks}
-          stopping={stoppingBackgroundTasks}
-          onStop={() => {
-            setStoppingBackgroundTasks(true)
-            void controller.stopBackgroundTasks().finally(() => setStoppingBackgroundTasks(false))
+          supportsTaskStop={controller.supportsBackgroundTaskStop}
+          stoppingTaskIds={activeStoppingBackgroundTasks?.taskIds ?? NO_STOPPING_TASKS}
+          stoppingAll={activeStoppingBackgroundTasks?.all ?? false}
+          onStop={(taskId) => {
+            const targetSessionId = props.sessionId
+            setStoppingBackgroundTasks((current) => {
+              const taskIds = new Set(
+                current?.sessionId === targetSessionId ? current.taskIds : NO_STOPPING_TASKS
+              )
+              if (taskId) {
+                taskIds.add(taskId)
+              }
+              return {
+                sessionId: targetSessionId,
+                taskIds,
+                all: taskId ? current?.sessionId === targetSessionId && current.all : true
+              }
+            })
+            void controller.stopBackgroundTask(taskId).finally(() => {
+              setStoppingBackgroundTasks((current) => {
+                if (current?.sessionId !== targetSessionId) {
+                  return current
+                }
+                const taskIds = new Set(current.taskIds)
+                if (taskId) {
+                  taskIds.delete(taskId)
+                }
+                const all = taskId ? current.all : false
+                return taskIds.size === 0 && !all
+                  ? null
+                  : { sessionId: targetSessionId, taskIds, all }
+              })
+            })
           }}
         />
       ) : null}

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
@@ -296,4 +296,40 @@ describe('useStructuredAgentSession options', () => {
 
     expect(result.current.error).toBeNull()
   })
+
+  it('includes one background task id in the cancel fingerprint and payload', async () => {
+    mocks.call.mockImplementation((_target, method) =>
+      method === 'agentSession.options'
+        ? Promise.resolve(OPTIONS)
+        : Promise.resolve({
+            ok: true,
+            value: { turnId: 'background-tasks', cancelled: true }
+          })
+    )
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        target: LOCAL_TARGET,
+        agent: 'claude',
+        isVisible: true
+      })
+    )
+
+    await act(async () => {
+      await expect(result.current.stopBackgroundTask('task-2')).resolves.toMatchObject({
+        cancelled: true
+      })
+    })
+
+    const mutation = mocks.call.mock.calls.find(([, method]) => method === 'agentSession.cancel')
+    expect(mutation?.[2]).toMatchObject({
+      envelope: {
+        sessionId: 'session-1',
+        expectedRuntimeFence: 3
+      },
+      turnId: 'background-tasks',
+      scope: 'background-tasks',
+      taskId: 'task-2'
+    })
+  })
 })

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -245,12 +245,14 @@ export function useStructuredAgentSession(args: {
     isWorking: turnId !== null,
     isMonitoringBackgroundTasks,
     backgroundTasks: state.backgroundTasks?.tasks ?? [],
+    supportsBackgroundTaskStop: state.backgroundTasks?.supportsTaskStop === true,
     turnId,
     cancel: (turnId: string) => mutate('agentSession.cancel', 'agentSession.cancel', { turnId }),
-    stopBackgroundTasks: () =>
+    stopBackgroundTask: (taskId?: string) =>
       mutate('agentSession.cancel', 'agentSession.cancel', {
         turnId: 'background-tasks',
-        scope: 'background-tasks'
+        scope: 'background-tasks',
+        ...(taskId ? { taskId } : {})
       }),
     respond: (item: StructuredPromptItem, optionId: string) =>
       mutate<AgentSessionPromptResult>(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16989,6 +16989,8 @@
       "backgroundTasks": {
         "monitoring": "Monitoring background tasks",
         "stop": "Stop",
+        "stopTask": "Stop {{value0}}",
+        "stopAll": "Stop background tasks",
         "agent": "Background agent",
         "workflow": "Background workflow",
         "command": "Background command",

--- a/src/shared/agent-session-wire.ts
+++ b/src/shared/agent-session-wire.ts
@@ -59,6 +59,8 @@ export type AgentSessionBackgroundTaskState = {
   state: 'monitoring'
   /** Optional so mixed-version clients can consume state-only hosts. */
   tasks?: AgentSessionBackgroundTask[]
+  /** Optional so clients only send targeted stops to hosts that accept them. */
+  supportsTaskStop?: boolean
 }
 
 /** Backward paging is the client's normal read; 40 matches the page size the

--- a/src/shared/structured-agent-session-reducer.test.ts
+++ b/src/shared/structured-agent-session-reducer.test.ts
@@ -54,6 +54,39 @@ function hydrationPage(
 }
 
 describe('structured agent session reducer', () => {
+  it('applies an additive targeted-stop capability update without journal churn', () => {
+    const backgroundTasks = {
+      state: 'monitoring' as const,
+      tasks: [{ id: 'task-1', kind: 'agent' as const }]
+    }
+    const initial = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
+      type: 'event',
+      event: {
+        type: 'snapshot',
+        sessionId: 'session-a',
+        fence: 1,
+        page: { ...hydrationPage([]), backgroundTasks }
+      }
+    })
+    const updated = reduceStructuredAgentSession(initial, {
+      type: 'event',
+      event: {
+        type: 'batch',
+        sessionId: 'session-a',
+        batch: {
+          cursor: { epoch: 'epoch-a', sequence: 0 },
+          items: [],
+          removedItemIds: [],
+          submissions: []
+        },
+        backgroundTasks: { ...backgroundTasks, supportsTaskStop: true }
+      }
+    })
+
+    expect(updated.backgroundTasks).toEqual({ ...backgroundTasks, supportsTaskStop: true })
+    expect(updated.items).toBe(initial.items)
+  })
+
   it('uses the bounded hydration page pagination boundary', () => {
     const restored = reduceStructuredAgentSession(EMPTY_STRUCTURED_AGENT_SESSION, {
       type: 'event',

--- a/src/shared/structured-agent-session-reducer.ts
+++ b/src/shared/structured-agent-session-reducer.ts
@@ -51,7 +51,12 @@ function backgroundTaskStatesEqual(
   if (left === right) {
     return true
   }
-  if (!left || !right || left.state !== right.state) {
+  if (
+    !left ||
+    !right ||
+    left.state !== right.state ||
+    left.supportsTaskStop !== right.supportsTaskStop
+  ) {
     return false
   }
   if (left.tasks === right.tasks) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​355 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​347 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |

<!-- /orca-pr-loc -->

## ELI5

When several background tasks are still running, Claude Native Chat now lists them together and lets you stop just the task you choose.

## What Changed

- Added an optional, capability-gated background task ID to the existing cancellation request.
- Replaced the single disclosure-header Stop action with an accessible Stop action on each expanded task row.
- Tracked pending stops per task so concurrent requests do not disable or disturb sibling tasks.
- Preserved the expanded all-task fallback for older hosts that do not publish task-stop support.
- Refused stale or unknown task IDs before making a provider control call.

## Why

A session can monitor multiple background tasks concurrently. Cancellation needs to preserve task identity end to end so stopping one task does not cancel the foreground turn or any sibling task.

## Linked Issue

Follow-up requested during the native background-task monitoring rollout; no standalone issue was provided.

## Visual Proof

Validated at exact HEAD `1a4be990768c58ef94a019e02b81af09c58f2dcf` in an isolated Electron instance (Playwright CDP, isolated profile and ports) against a real Claude Agent SDK Native Chat session with two concurrent long-lived background tasks (`QA Task Alpha heartbeat`, `QA Task Bravo heartbeat`).

Collapsed composer-adjacent footer (no header Stop):

![01-collapsed-footer.png](https://github.com/user-attachments/assets/68f44550-8a45-463a-8c9f-a41cf10127bc)

Expanded: both rows, per-row accessible Stop, composer draft still enabled:

![02-expanded-both-rows.png](https://github.com/user-attachments/assets/a5f8eca0-e57c-4bae-bcca-1b186349f993)

After stopping Alpha: only Bravo remains, draft and session stay live, no cancellation transcript row:

![03-after-stop-alpha.png](https://github.com/user-attachments/assets/b5cfd22d-bfab-4fb1-a3e7-27295f403e68)

After stopping Bravo: footer clears, composer draft remains, foreground session stays live:

![04-after-stop-bravo-footer-cleared.png](https://github.com/user-attachments/assets/36acec06-1556-4f21-9092-60be386e0f0b)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

- `pnpm test` on 11 focused files: 145 passed
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `pnpm format`
- `git diff --check`

Validated locally on macOS. The change adds no path, keyboard, subprocess, polling, or platform-specific behavior; remote hosts are protected through an additive optional capability and task ID.

## Review

- Targeted and omitted-ID cancellation paths retain the existing deadline and provider error handling.
- Background-task cancellation does not write a transcript row or invoke foreground cancellation.
- The task inventory remains bounded and event-driven.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Older hosts continue to receive the prior omitted-ID all-task request. New clients send a task ID only after the host advertises targeted-stop support.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after proof attached from isolated Electron validation at `1a4be990768c`
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and backwards-compatibility impact considered
- [x] Focused tests, typecheck, formatting, and changed-code quality pass; CI will run broader checks

