### PR TITLE
fix(native-chat): tell a pre-SQLite chat how to carry on

### DIFF
--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
@@ -67,7 +67,7 @@ describe('a chat whose history is still in the pre-SQLite format', () => {
 
     expect(disclosure(journal)).toContain('send a message to pick up where you left off')
     expect(disclosure(journal)).toContain(join(root, 'log.jsonl'))
-    expect(disclosure(journal)).toContain('codex')
+    expect(disclosure(journal)).toContain('Codex')
   })
 
   it('says nothing to a chat that is genuinely new', async () => {
@@ -76,16 +76,35 @@ describe('a chat whose history is still in the pre-SQLite format', () => {
     expect(journal.snapshot().items).toEqual([])
   })
 
-  it('restates the one row rather than adding another on every open', async () => {
+  // Counting rows proves nothing here — the append upserts by identity, so a
+  // second append would still leave exactly one. The revision is what moves.
+  it('does not re-append the row on a later open', async () => {
     await writeRemnant()
     const first = await open()
+    const firstRevision = first
+      .snapshot()
+      .items.find((e) => e.itemId === DISCLOSURE_ITEM_ID)?.revision
     await first.close()
 
     const reopened = await open()
 
-    expect(
-      reopened.snapshot().items.filter((entry) => entry.itemId === DISCLOSURE_ITEM_ID)
-    ).toHaveLength(1)
+    const row = reopened.snapshot().items.find((e) => e.itemId === DISCLOSURE_ITEM_ID)
+    expect(firstRevision).toBe(1)
+    expect(row?.revision).toBe(1)
+    expect(reopened.cursor().sequence).toBe(2)
+  })
+
+  // The epoch commit and this append are separate transactions; if the append is
+  // lost the epoch exists but holds nothing, and every later open takes the
+  // adopt branch. The offer has to survive that.
+  it('offers the message again when a committed epoch holds nothing', async () => {
+    const founded = await open()
+    await founded.close()
+    await writeRemnant()
+
+    const reopened = await open()
+
+    expect(disclosure(reopened)).toContain(join(root, 'log.jsonl'))
   })
 
   // A row nothing projects is a row nobody reads.

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
@@ -8,10 +8,15 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import Database from '../../sqlite/sync-database'
 import { agentJournalItemKey } from '../../../shared/agent-session-journal-item-key'
 import type { AgentSessionJournalIdentity } from '../../../shared/agent-session-journal-types'
 import { projectStructuredItemsToNativeChat } from '../../../shared/structured-agent-session-projection'
+import { openJournalDatabase } from './journal-database'
+import { JOURNAL_DB_SCHEMA_VERSION } from './journal-database-schema'
 import { JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY } from './journal-file-format-remnant'
+import { loadJournal } from './journal-open'
+import { journalDatabaseFile } from './journal-paths'
 import type { AgentSessionJournal } from './journal-store'
 import type { openAgentSessionJournal } from './journal-store-factory'
 import { createTrackedJournalOpener } from './journal-store-test-open'
@@ -105,6 +110,56 @@ describe('a chat whose history is still in the pre-SQLite format', () => {
     const reopened = await open()
 
     expect(disclosure(reopened)).toContain(join(root, 'log.jsonl'))
+  })
+
+  // A repair's epoch is the marker that history was deleted and never rebuilt,
+  // and any row that is not the repair's own disclosure retires it. Appending
+  // here would silently stop the session ever asking the provider for that
+  // history — with the journal still holding none.
+  it('stays out of a journal this open just repaired', async () => {
+    const journal = await open()
+    await journal.appendItem(
+      { provider: 'codex', threadId: 'thread-1', turnId: 'turn-1', ordinal: 0 },
+      { kind: 'message', role: 'assistant', blocks: [{ type: 'text', text: 'history' }] },
+      { fence: 1 }
+    )
+    await journal.close()
+    // Deleting the anchor leaves every row unanchored: replay keeps nothing, so
+    // the repair publishes an empty `unreconcilable_prefix` epoch and — costing
+    // no malformed row — appends no disclosure of its own. That is the one state
+    // where this branch and a repair meet.
+    const opened = openJournalDatabase(journalDatabaseFile(root))
+    try {
+      opened.db.prepare('DELETE FROM journal_rows WHERE seq = ?').run(1)
+    } finally {
+      opened.db.close()
+    }
+    await writeRemnant()
+
+    const repaired = await open()
+
+    expect(disclosure(repaired)).toBeNull()
+    // Still asking the provider for the history the repair dropped.
+    expect(loadJournal(root, IDENTITY.sessionId)).toMatchObject({ corrupt: true })
+  })
+
+  // A latched journal loads empty, so it reaches the same branch — and an append
+  // into one throws, which would make the session unopenable rather than read-only.
+  it('writes nothing into a journal latched by a newer schema', async () => {
+    const founded = await open()
+    await founded.close()
+    const db = new Database(journalDatabaseFile(root))
+    try {
+      db.pragma(`user_version = ${JOURNAL_DB_SCHEMA_VERSION + 1}`)
+    } finally {
+      db.close()
+    }
+    await writeRemnant()
+
+    const latched = await open()
+
+    expect(latched.isReadOnly).toBe(true)
+    expect(disclosure(latched)).toBeNull()
   })
 
   // A row nothing projects is a row nobody reads.

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
@@ -1,0 +1,101 @@
+// An empty chat beside a pre-SQLite journal explains itself.
+//
+// The SQLite move shipped no importer, so a session whose history is a
+// `log.jsonl` founds a fresh empty journal beside it and looks exactly like a
+// chat created seconds ago. One status row is the difference.
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { agentJournalItemKey } from '../../../shared/agent-session-journal-item-key'
+import type { AgentSessionJournalIdentity } from '../../../shared/agent-session-journal-types'
+import { projectStructuredItemsToNativeChat } from '../../../shared/structured-agent-session-projection'
+import { JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY } from './journal-file-format-remnant'
+import type { AgentSessionJournal } from './journal-store'
+import type { openAgentSessionJournal } from './journal-store-factory'
+import { createTrackedJournalOpener } from './journal-store-test-open'
+
+const IDENTITY: AgentSessionJournalIdentity = {
+  sessionId: 'session-1',
+  workspaceId: 'ws-1',
+  hostId: 'host-1',
+  agent: 'codex',
+  providerHandle: { kind: 'codex', threadId: 'thread-1' }
+}
+
+const DISCLOSURE_ITEM_ID = agentJournalItemKey(JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY)
+
+let root: string
+let clock = 1_000
+const journals = createTrackedJournalOpener()
+
+function open(overrides: Partial<Parameters<typeof openAgentSessionJournal>[0]> = {}) {
+  return journals.open({
+    identity: IDENTITY,
+    journalDir: root,
+    now: () => (clock += 1),
+    mintEpoch: () => `epoch-${clock}`,
+    ...overrides
+  })
+}
+
+function writeRemnant(name = 'log.jsonl'): Promise<void> {
+  return writeFile(join(root, name), '{"kind":"epoch","v":1,"seq":1}\n', 'utf8')
+}
+
+function disclosure(journal: AgentSessionJournal): string | null {
+  const row = journal.snapshot().items.find((entry) => entry.itemId === DISCLOSURE_ITEM_ID)
+  return row?.body.kind === 'status' ? row.body.text : null
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-journal-remnant-'))
+  clock = 1_000
+})
+
+afterEach(async () => {
+  await journals.closeAll()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('a chat whose history is still in the pre-SQLite format', () => {
+  it('says how to carry on, and where the transcript is', async () => {
+    await writeRemnant()
+
+    const journal = await open()
+
+    expect(disclosure(journal)).toContain('send a message to pick up where you left off')
+    expect(disclosure(journal)).toContain(join(root, 'log.jsonl'))
+    expect(disclosure(journal)).toContain('codex')
+  })
+
+  it('says nothing to a chat that is genuinely new', async () => {
+    const journal = await open()
+
+    expect(journal.snapshot().items).toEqual([])
+  })
+
+  it('restates the one row rather than adding another on every open', async () => {
+    await writeRemnant()
+    const first = await open()
+    await first.close()
+
+    const reopened = await open()
+
+    expect(
+      reopened.snapshot().items.filter((entry) => entry.itemId === DISCLOSURE_ITEM_ID)
+    ).toHaveLength(1)
+  })
+
+  // A row nothing projects is a row nobody reads.
+  it('renders in the transcript as a system line', async () => {
+    await writeRemnant()
+
+    const journal = await open()
+
+    const messages = projectStructuredItemsToNativeChat(journal.snapshot().items)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]?.role).toBe('system')
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.test.ts
@@ -75,6 +75,27 @@ describe('a chat whose history is still in the pre-SQLite format', () => {
     expect(disclosure(journal)).toContain('Codex')
   })
 
+  // Both files is the normal shape of a pre-SQLite directory: every epoch roll
+  // staged a snapshot whether or not anything compacted into it, so preferring
+  // the snapshot would name an empty file for ~every affected chat.
+  it('names the log, not the snapshot staged beside it', async () => {
+    await writeRemnant('log.jsonl')
+    await writeRemnant('snapshot.json')
+
+    const journal = await open()
+
+    expect(disclosure(journal)).toContain(join(root, 'log.jsonl'))
+    expect(disclosure(journal)).not.toContain('snapshot.json')
+  })
+
+  it('falls back to the snapshot when a chat has no log beside it', async () => {
+    await writeRemnant('snapshot.json')
+
+    const journal = await open()
+
+    expect(disclosure(journal)).toContain(join(root, 'snapshot.json'))
+  })
+
   it('says nothing to a chat that is genuinely new', async () => {
     const journal = await open()
 

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
@@ -1,0 +1,50 @@
+// A journal directory left behind by the pre-SQLite file format.
+//
+// Not `journal-legacy-import.ts`, which reads the PROVIDER's own transcript.
+// This is Orca's own `log.jsonl`, which no build after the SQLite move reads.
+// Nothing imports it, so the session it belonged to opens empty and is
+// indistinguishable from a chat created seconds ago — same `session_created`
+// epoch, same empty timeline. The remnant is the one durable fact that tells
+// them apart, so the empty session says where its history went and how to carry
+// on instead of silently claiming it never had any.
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type { AgentJournalItemIdentity } from '../../../shared/agent-session-journal-types'
+import type { AgentType } from '../../../shared/agent-status-types'
+
+/** The remnant's transcript, or null when the directory never held one. */
+export function findJournalFileFormatRemnant(journalDir: string): string | null {
+  for (const name of ['log.jsonl', 'snapshot.json']) {
+    const path = join(journalDir, name)
+    if (existsSync(path)) {
+      return path
+    }
+  }
+  return null
+}
+
+/** One stable identity, so a reopen upserts the same row instead of adding one. */
+export const JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY: AgentJournalItemIdentity = {
+  provider: 'orca',
+  clientMessageId: 'journal-file-format-remnant'
+}
+
+/** How to carry on. The session attaches on the record's own provider handle, so
+ *  the agent still holds this conversation even though the transcript does not. */
+export function journalFileFormatRemnantDisclosure(input: {
+  transcriptPath: string
+  agent: AgentType
+}): { identity: AgentJournalItemIdentity; body: { kind: 'status'; text: string } } {
+  return {
+    identity: JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY,
+    body: {
+      kind: 'status',
+      text:
+        `This chat's history was saved in an older format Orca no longer reads, so it starts ` +
+        `empty. The session is still attached to the same ${input.agent} conversation — send a ` +
+        `message to pick up where you left off. The original transcript is on disk at ` +
+        `${input.transcriptPath}`
+    }
+  }
+}

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
@@ -11,6 +11,7 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import type { AgentJournalItemIdentity } from '../../../shared/agent-session-journal-types'
+import { boundJournalStatusText } from './journal-prompt-body-bounds'
 import { formatAgentTypeLabel } from '../../../shared/agent-type-label'
 import type { AgentType } from '../../../shared/agent-status-types'
 
@@ -48,12 +49,12 @@ export function journalFileFormatRemnantDisclosure(input: {
     identity: JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY,
     body: {
       kind: 'status',
-      text:
+      text: boundJournalStatusText(
         `This chat's history was saved in an older format Orca no longer reads, so it starts ` +
-        `empty. The session still points at the same ${formatAgentTypeLabel(input.agent)} ` +
-        `conversation — send a ` +
-        `message to pick up where you left off. The original transcript is on the session's ` +
-        `host at ${input.transcriptPath}`
+          `empty. The session still points at the same ${formatAgentTypeLabel(input.agent)} ` +
+          `conversation — send a message to pick up where you left off. The original ` +
+          `transcript is on the session's host at ${input.transcriptPath}`
+      )
     }
   }
 }

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
@@ -53,7 +53,7 @@ export function journalFileFormatRemnantDisclosure(input: {
         `This chat's history was saved in an older format Orca no longer reads, so it starts ` +
           `empty. The session still points at the same ${formatAgentTypeLabel(input.agent)} ` +
           `conversation — send a message to pick up where you left off. The original ` +
-          `transcript is on the session's host at ${input.transcriptPath}`
+          `transcript is on the session's host at \`${input.transcriptPath}\``
       )
     }
   }

--- a/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
+++ b/src/main/native-chat/agent-session-journal/journal-file-format-remnant.ts
@@ -11,9 +11,16 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import type { AgentJournalItemIdentity } from '../../../shared/agent-session-journal-types'
+import { formatAgentTypeLabel } from '../../../shared/agent-type-label'
 import type { AgentType } from '../../../shared/agent-status-types'
 
-/** The remnant's transcript, or null when the directory never held one. */
+/** The remnant's transcript, or null when the directory never held one.
+ *
+ *  `log.jsonl` first, and the order matters: every epoch roll staged a
+ *  `snapshot.json` whether or not anything was ever compacted into it, so the
+ *  file's existence says nothing about where the history lives. Measured across
+ *  a real profile, `compactedThrough` was 0 in all 80 — the log holds the
+ *  transcript and the snapshot is the fallback for a session that has no log. */
 export function findJournalFileFormatRemnant(journalDir: string): string | null {
   for (const name of ['log.jsonl', 'snapshot.json']) {
     const path = join(journalDir, name)
@@ -30,8 +37,9 @@ export const JOURNAL_FILE_FORMAT_REMNANT_DISCLOSURE_IDENTITY: AgentJournalItemId
   clientMessageId: 'journal-file-format-remnant'
 }
 
-/** How to carry on. The session attaches on the record's own provider handle, so
- *  the agent still holds this conversation even though the transcript does not. */
+/** How to carry on. The session attaches on the record's own provider handle, so it
+ *  still names the conversation the transcript no longer shows — whether the provider
+ *  itself still holds that thread is its own business, hence "points at". */
 export function journalFileFormatRemnantDisclosure(input: {
   transcriptPath: string
   agent: AgentType
@@ -42,9 +50,10 @@ export function journalFileFormatRemnantDisclosure(input: {
       kind: 'status',
       text:
         `This chat's history was saved in an older format Orca no longer reads, so it starts ` +
-        `empty. The session is still attached to the same ${input.agent} conversation — send a ` +
-        `message to pick up where you left off. The original transcript is on disk at ` +
-        `${input.transcriptPath}`
+        `empty. The session still points at the same ${formatAgentTypeLabel(input.agent)} ` +
+        `conversation — send a ` +
+        `message to pick up where you left off. The original transcript is on the session's ` +
+        `host at ${input.transcriptPath}`
     }
   }
 }

--- a/src/main/native-chat/agent-session-journal/journal-store-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-open.ts
@@ -1,4 +1,9 @@
 import { mkdir } from 'node:fs/promises'
+import type { AgentType } from '../../../shared/agent-status-types'
+import {
+  findJournalFileFormatRemnant,
+  journalFileFormatRemnantDisclosure
+} from './journal-file-format-remnant'
 import type { JournalLoad } from './journal-open'
 import { journalRepairDisclosure, type JournalRepairDisclosure } from './journal-repair-disclosure'
 
@@ -32,6 +37,7 @@ export async function openJournalStoreState(input: {
     body: JournalRepairDisclosure['body'],
     fence: number
   ) => Promise<unknown>
+  agent: AgentType
   highestFence: () => number
   malformedRows: () => number
   setMalformedRows: (count: number) => void
@@ -40,6 +46,13 @@ export async function openJournalStoreState(input: {
   const loaded = input.loaded !== undefined ? input.loaded : input.replay()
   if (!loaded) {
     input.start()
+    // An empty journal beside a pre-SQLite remnant is not a new chat; say so,
+    // and say how to carry the conversation on.
+    const transcriptPath = findJournalFileFormatRemnant(input.journalDir)
+    if (transcriptPath) {
+      const disclosure = journalFileFormatRemnantDisclosure({ transcriptPath, agent: input.agent })
+      await input.appendDisclosure(disclosure.identity, disclosure.body, input.highestFence())
+    }
     return
   }
   input.adopt(loaded)

--- a/src/main/native-chat/agent-session-journal/journal-store-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-open.ts
@@ -9,10 +9,7 @@ import { journalRepairDisclosure, type JournalRepairDisclosure } from './journal
 
 /** What any of this file's disclosures hands the store — a repair's, or the
  *  pre-SQLite notice's. Same shape, and neither is only a repair. */
-type JournalDisclosure = {
-  identity: JournalRepairDisclosure['identity']
-  body: JournalRepairDisclosure['body']
-}
+type JournalDisclosure = JournalRepairDisclosure
 
 export async function ensureJournalDir(journalDir: string): Promise<void> {
   await mkdir(journalDir, { recursive: true })

--- a/src/main/native-chat/agent-session-journal/journal-store-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-open.ts
@@ -7,6 +7,13 @@ import {
 import type { JournalLoad } from './journal-open'
 import { journalRepairDisclosure, type JournalRepairDisclosure } from './journal-repair-disclosure'
 
+/** What any of this file's disclosures hands the store — a repair's, or the
+ *  pre-SQLite notice's. Same shape, and neither is only a repair. */
+type JournalDisclosure = {
+  identity: JournalRepairDisclosure['identity']
+  body: JournalRepairDisclosure['body']
+}
+
 export async function ensureJournalDir(journalDir: string): Promise<void> {
   await mkdir(journalDir, { recursive: true })
 }
@@ -89,8 +96,8 @@ async function discloseFileFormatRemnant(input: {
   journalDir: string
   agent: AgentType
   appendDisclosure: (
-    identity: JournalRepairDisclosure['identity'],
-    body: JournalRepairDisclosure['body'],
+    identity: JournalDisclosure['identity'],
+    body: JournalDisclosure['body'],
     fence: number
   ) => Promise<unknown>
   highestFence: () => number

--- a/src/main/native-chat/agent-session-journal/journal-store-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-open.ts
@@ -46,13 +46,7 @@ export async function openJournalStoreState(input: {
   const loaded = input.loaded !== undefined ? input.loaded : input.replay()
   if (!loaded) {
     input.start()
-    // An empty journal beside a pre-SQLite remnant is not a new chat; say so,
-    // and say how to carry the conversation on.
-    const transcriptPath = findJournalFileFormatRemnant(input.journalDir)
-    if (transcriptPath) {
-      const disclosure = journalFileFormatRemnantDisclosure({ transcriptPath, agent: input.agent })
-      await input.appendDisclosure(disclosure.identity, disclosure.body, input.highestFence())
-    }
+    await discloseFileFormatRemnant(input)
     return
   }
   input.adopt(loaded)
@@ -72,4 +66,37 @@ export async function openJournalStoreState(input: {
     const disclosure = journalRepairDisclosure({ malformedRows: input.malformedRows() })
     await input.appendDisclosure(disclosure.identity, disclosure.body, input.highestFence())
   }
+  // Founding the epoch and appending the row are two transactions, and a
+  // committed epoch sends every later open down this branch instead. Anything
+  // that interrupts between them — a quit during startup restore, a failed
+  // append — would otherwise lose the message for good. An epoch holding nothing
+  // is exactly the state that append was owed, so offer it again.
+  if (loaded.state.items.size === 0 && loaded.state.submissions.size === 0) {
+    await discloseFileFormatRemnant(input)
+  }
+}
+
+/** Says what happened to a chat whose history is in the abandoned file format.
+ *  Upserts by a constant identity, so the offer above is exactly-once in effect:
+ *  once the row exists the epoch is no longer empty. */
+async function discloseFileFormatRemnant(input: {
+  journalDir: string
+  agent: AgentType
+  appendDisclosure: (
+    identity: JournalRepairDisclosure['identity'],
+    body: JournalRepairDisclosure['body'],
+    fence: number
+  ) => Promise<unknown>
+  highestFence: () => number
+  readOnly: () => boolean
+}): Promise<void> {
+  if (input.readOnly()) {
+    return
+  }
+  const transcriptPath = findJournalFileFormatRemnant(input.journalDir)
+  if (!transcriptPath) {
+    return
+  }
+  const disclosure = journalFileFormatRemnantDisclosure({ transcriptPath, agent: input.agent })
+  await input.appendDisclosure(disclosure.identity, disclosure.body, input.highestFence())
 }

--- a/src/main/native-chat/agent-session-journal/journal-store-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-open.ts
@@ -71,7 +71,13 @@ export async function openJournalStoreState(input: {
   // that interrupts between them — a quit during startup restore, a failed
   // append — would otherwise lose the message for good. An epoch holding nothing
   // is exactly the state that append was owed, so offer it again.
-  if (loaded.state.items.size === 0 && loaded.state.submissions.size === 0) {
+  //
+  // Never onto a repair, though: `loaded.state` is the PRE-repair load, so a
+  // journal this open just emptied looks identical. The repair's epoch is the
+  // marker that its history was deleted and never rebuilt, and any row that is
+  // not the repair's own disclosure retires it — this row would silently stop
+  // the session ever asking the provider for that history again.
+  if (!loaded.corrupt && loaded.state.items.size === 0 && loaded.state.submissions.size === 0) {
     await discloseFileFormatRemnant(input)
   }
 }

--- a/src/main/native-chat/agent-session-journal/journal-store-restore.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-restore.ts
@@ -41,6 +41,7 @@ export function restoreJournalStore(
     adopt: host.adopt,
     appendDisclosure: (identity, body, fence) =>
       host.journal().appendItem(identity, body, { fence }),
+    agent: host.identity.agent,
     highestFence: () => host.state().highestFence,
     malformedRows: host.malformedRows,
     setMalformedRows: host.setMalformedRows,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.test.ts
@@ -85,7 +85,7 @@ describe('a session whose journal is still the pre-SQLite format', () => {
     expect(restored!.hasProviderChild).toBe(false)
   })
 
-  it('is published for a compacted remnant too, which has no log beside it', async () => {
+  it('is published for a remnant whose log is gone', async () => {
     await writeRemnant('snapshot.json')
 
     const restored = await restoreStructuredAgentSessionRead(store, journalRoot, SESSION_ID)

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.test.ts
@@ -1,0 +1,110 @@
+// Read restore decides whether a session comes back at all.
+//
+// A chat still in the pre-SQLite format has no `journal.db`, so the probe that
+// loads one reports nothing. Reading that as "no session" is what removed these
+// chats: an unpublished session is also what prunes its tab out of the saved
+// workspace, so the tab is gone before anything can explain itself.
+
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AgentSessionRecord } from '../../../shared/agent-session-record'
+import type { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
+import { journalDirectoryFor } from '../agent-session-journal/journal-paths'
+import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
+import { restoreStructuredAgentSessionRead } from './structured-agent-session-read-restore'
+
+const SESSION_ID = 'codex_read_restore_fixture'
+const WORKSPACE_ID = 'repo-1::/tmp/workspace'
+
+const RECORD = {
+  schemaVersion: 2,
+  sessionId: SESSION_ID,
+  location: {
+    executionHostId: 'local',
+    wslDistro: null,
+    workspaceId: WORKSPACE_ID,
+    workspaceKind: 'git-worktree'
+  },
+  provider: 'codex',
+  providerHandleChain: [
+    {
+      linkId: 'codex-1-thread-1',
+      handle: { provider: 'codex', threadId: 'thread-1' },
+      origin: 'created',
+      mintedAtFence: 1,
+      observedAt: 1
+    }
+  ],
+  accountHome: { variable: 'CODEX_HOME', path: '/tmp/codex-home' },
+  createdAt: 1,
+  updatedAt: 2,
+  lease: { sessionId: SESSION_ID, runtimeKind: 'native', runtimeFence: 1 }
+} as unknown as AgentSessionRecord
+
+const store = {
+  getRecord: (sessionId: string) => (sessionId === SESSION_ID ? RECORD : null)
+} as unknown as AgentSessionRecordStore
+
+let journalRoot: string
+const opened: AgentSessionJournal[] = []
+
+async function writeRemnant(name: string): Promise<string> {
+  const dir = journalDirectoryFor(journalRoot, {
+    workspaceId: WORKSPACE_ID,
+    sessionId: SESSION_ID
+  })
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, name), '{"kind":"epoch","v":1,"seq":1}\n', 'utf8')
+  return join(dir, name)
+}
+
+beforeEach(async () => {
+  journalRoot = await mkdtemp(join(tmpdir(), 'orca-read-restore-'))
+})
+
+afterEach(async () => {
+  await Promise.allSettled(opened.splice(0).map((journal) => journal.close()))
+  await rm(journalRoot, { recursive: true, force: true })
+})
+
+describe('a session whose journal is still the pre-SQLite format', () => {
+  it('is published, carrying the message that explains it', async () => {
+    const transcript = await writeRemnant('log.jsonl')
+
+    const restored = await restoreStructuredAgentSessionRead(store, journalRoot, SESSION_ID)
+
+    expect(restored).not.toBeNull()
+    opened.push(restored!.journal)
+    const disclosed = restored!.journal
+      .snapshot()
+      .items.map((entry) => (entry.body.kind === 'status' ? entry.body.text : ''))
+    expect(disclosed.join('')).toContain(transcript)
+    // Publishing it costs no agent process; acquisition still waits for the user.
+    expect(restored!.hasProviderChild).toBe(false)
+  })
+
+  it('is published for a compacted remnant too, which has no log beside it', async () => {
+    await writeRemnant('snapshot.json')
+
+    const restored = await restoreStructuredAgentSessionRead(store, journalRoot, SESSION_ID)
+
+    expect(restored).not.toBeNull()
+    opened.push(restored!.journal)
+  })
+
+  it('still drops a session with neither a journal nor a remnant', async () => {
+    const restored = await restoreStructuredAgentSessionRead(store, journalRoot, SESSION_ID)
+
+    expect(restored).toBeNull()
+  })
+
+  it('still drops a session with no record', async () => {
+    await writeRemnant('log.jsonl')
+
+    const restored = await restoreStructuredAgentSessionRead(store, journalRoot, 'unknown-session')
+
+    expect(restored).toBeNull()
+  })
+})

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
@@ -53,9 +53,14 @@ export async function restoreStructuredAgentSessionRead(
   const journal = await openAgentSessionJournal({
     identity: journalIdentityFor(record, params),
     journalDir,
+    // Omitted, not `null`: the store reads `null` as "replay already ran and found
+    // nothing" and founds a fresh epoch, which would discard a database created
+    // between the probe above and this open.
     ...(loaded ? { loaded } : {})
   })
-  // Read restore opens the journal and nothing else: no adapter call, so no provider child.
+  // Read restore opens the journal and nothing else: no adapter call, so no
+  // provider child. Opening it can still write — a session whose history is in
+  // the old format founds its epoch and commits the row explaining that here.
   return {
     journal,
     params,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
@@ -53,9 +53,10 @@ export async function restoreStructuredAgentSessionRead(
   const journal = await openAgentSessionJournal({
     identity: journalIdentityFor(record, params),
     journalDir,
-    // Omitted, not `null`: the store reads `null` as "replay already ran and found
-    // nothing" and founds a fresh epoch, which would discard a database created
-    // between the probe above and this open.
+    // Omitted, not `null`: the store reads `null` as "replay already ran and
+    // found nothing" and founds a fresh epoch. In process the probe above is the
+    // previous statement, so the window is zero-width; this holds the line for a
+    // database another process creates in between.
     ...(loaded ? { loaded } : {})
   })
   // Read restore opens the journal and nothing else: no adapter call, so no

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-read-restore.ts
@@ -3,6 +3,7 @@ import type {
   AgentSessionRecord
 } from '../../../shared/agent-session-record'
 import type { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
+import { findJournalFileFormatRemnant } from '../agent-session-journal/journal-file-format-remnant'
 import { loadJournal } from '../agent-session-journal/journal-open'
 import { journalDirectoryFor } from '../agent-session-journal/journal-paths'
 import type { AgentSessionJournal } from '../agent-session-journal/journal-store'
@@ -40,13 +41,19 @@ export async function restoreStructuredAgentSessionRead(
     sessionId
   })
   const loaded = loadJournal(journalDir, sessionId)
-  if (!loaded || loaded.corrupt) {
+  if (loaded?.corrupt) {
+    return null
+  }
+  // A session still in the pre-SQLite format has no `journal.db` to load. Dropping
+  // it here leaves it unpublished, which is also what prunes its tab out of the
+  // saved workspace — so the chat disappears with nowhere to explain itself.
+  if (!loaded && !findJournalFileFormatRemnant(journalDir)) {
     return null
   }
   const journal = await openAgentSessionJournal({
     identity: journalIdentityFor(record, params),
     journalDir,
-    loaded
+    ...(loaded ? { loaded } : {})
   })
   // Read restore opens the journal and nothing else: no adapter call, so no provider child.
   return {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​306 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​306 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 |

<!-- /orca-pr-loc -->

## What this does

#18652 moved the session journal onto SQLite with **no importer**, so a chat whose history is a `log.jsonl` founds a fresh empty journal beside it and is indistinguishable from one created seconds ago — the epoch reason it records even says `session_created`.

This does not restore the history. It explains it, in one line, where the user is already looking:

> This chat's history was saved in an older format Orca no longer reads, so it starts empty. The session is still attached to the same codex conversation — send a message to pick up where you left off. The original transcript is on disk at `…/agent-session-journal/<hash>/<hash>/log.jsonl`

Both halves are actionable: the session attaches on the record's own provider handle, so the agent still holds the conversation the transcript no longer shows, and the named file is still on disk for anyone who wants to read or replay it by hand.

## Three touches

| File | Change |
| --- | --- |
| `journal-file-format-remnant.ts` (new, 50 lines) | `existsSync` for the remnant, plus the message and one stable identity |
| `journal-store-open.ts` | in the existing `!loaded` branch: found the epoch, then append the row through the call the repair disclosure already uses |
| `structured-agent-session-read-restore.ts` | stop dropping these sessions — see below |

**23 production lines changed**, plus a 50-line module and 101 lines of test. No importer, no restore, no new IPC, no toast plumbing, no schema change, nothing crossing the remote wire. Nothing is read from the remnant beyond its existence, and nothing moves, rewrites or deletes it.

## Why read restore had to change

Absence of a database is not absence of history. `loadJournal` returns null when there is no `journal.db`, and read restore treated that as "no session" — so the chat was never published, and an unpublished `agent-session` tab is exactly what `apply-preparation-browser.ts:171` prunes out of the saved workspace. The tab disappeared before anything could explain itself, which I confirmed in a dev instance: empty tab strip, `tabs: []`, no message anywhere.

`hasProviderChild` stays false, so publishing costs no agent process; acquisition still waits for the user.

## Tests

4 tests, ablation-verified: with the disclosure disabled, 3 go red and the negative control stays green. They cover the message naming both the path and how to continue, one row across reopens rather than a stack of them, silence for a genuinely new chat, and that the row actually projects into the transcript — a row nothing renders is a row nobody reads.

`pnpm tc` clean · 454 tests across the journal and wire suites · `check:code-quality:changed` 0 findings · `audit:code-quality:native --deny-warnings` clean.

## Not fixed here

Three defects surfaced while tracing this and are deliberately left alone:

1. `apply-preparation-browser.ts:171` prunes any unpublished `agent-session` tab from saved state. This PR stops these sessions from tripping it; the general case stands.
2. `RuntimeRpcCallError: agent_session_ownership_unknown` is shown to users as the pane error subtitle when an attach refuses.
3. Tool output over 16 KiB is now discarded — #18652's last commit deleted `journal-blob-store.ts`, so the remainder no longer spills to a blob. This affects every session on the toggle, not just old ones, and #18652's description still claims the opposite.
