### PR TITLE
fix(test): stop detached git maintenance racing the divergence fixture teardown

### DIFF
--- a/src/main/git/worktree-base-divergence-real-git.test.ts
+++ b/src/main/git/worktree-base-divergence-real-git.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fetch-auto-maintenance'
 import {
   measureRetargetDivergence,
   RETARGET_MAX_COMMIT_DIVERGENCE
@@ -10,8 +11,13 @@ import {
 
 const tempRoots: string[] = []
 
+// Why the maintenance suppression: `git commit` detaches `git maintenance run --auto`, and its
+// commit-graph task arms once a fixture crosses 100 new commits — which the cap-sized histories
+// below always do. That detached process keeps writing `.git/objects/info/commit-graphs` after the
+// synchronous exec has returned, so it re-creates entries under a `.git/objects` the temp-root
+// teardown is midway through deleting, and the recursive remove dies with ENOTEMPTY.
 function git(cwd: string, args: string[]): string {
-  return execFileSync('git', args, {
+  return execFileSync('git', [...GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS, ...args], {
     cwd,
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe']


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

`worktree-base-divergence-real-git.test.ts` fails intermittently on CI. It is not an assertion diff — the body passes and teardown throws:

```
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/orca-base-divergence-.../repo/.git/objects'
```

## Cause

Every `git commit` spawns `git maintenance run --auto --quiet --detach`. Its commit-graph task arms at `maintenance.commit-graph.auto` = 100 new commits, and this fixture is built around `RETARGET_MAX_COMMIT_DIVERGENCE = 100`, so both heavy tests (100+1 and 101 commits) always cross the threshold. Because that process is **detached** it outlives the synchronous `execFileSync` and keeps writing `.git/objects/info/commit-graphs` while `afterEach` is midway through removing `.git/objects` — so the final `rmdir` hits a directory that has been re-created underneath it.

Not a git-version issue: CI and the dev machine both run git 2.55.0. It is a timing race that the slower, more loaded CI host loses.

## Fix

The fixture's `git()` helper now prefixes the existing shared constant `GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS` (`src/shared/git-fetch-auto-maintenance.ts`), reused rather than reimplemented. It sets `maintenance.auto=false`, `maintenance.commit-graph.auto=0` and `gc.auto=0`, covering both modern maintenance and the pre-2.30 auto-gc path, so it holds at the Git 2.25 baseline (older git ignores unknown `-c` keys). The `-c` options stay before the subcommand, per AGENTS.md.

This removes the concurrent writer outright rather than retrying or sleeping in teardown, so it is deterministic, not probabilistic. No skip, no loosened assertion.

## Why the fixture and not production code

`src/main/git/worktree-base-divergence.ts` only runs `rev-list --count` and `merge-base`, neither of which triggers auto-maintenance, and Orca never issues the `git commit` that spawns the detached writer. Orca's real write path (fetch) already suppresses this via the same constant. There is no production defect here.

## Verification

- Target file 5/5; area suite (`worktree-base-divergence`, `git-fetch-head-lock`, `repo-ref-maintenance-real-git`) 32/32.
- `pnpm tc` clean; oxlint and the changed-code quality gate clean.
- Mechanism verified independently outside the test: 101 commits in a scratch repo produce 2 background commit-graph entries normally and **0** with the suppression applied.

**Caveat worth stating:** the literal ENOTEMPTY was never reproduced on macOS — the race window is too narrow locally. The causal chain is directly evidenced (detached writer, the files it creates, before/after spawn counts of 4 → 0 during a real vitest run), but this is not a red-then-green on the exact CI error.