### PR TITLE
fix(renderer): stop a Node-only process-table module blanking the app at boot

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.ts
@@ -1,4 +1,6 @@
-import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot-reader'
+// Why not the sibling reader that re-exports this: it imports `node:child_process`, which the
+// renderer cannot load — reaching it blanks the window at module evaluation.
+import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot'
 
 /**
  * Picks the delay until a pane's next cadence inspection.

--- a/src/renderer/src/renderer-node-builtin-boundary.test.ts
+++ b/src/renderer/src/renderer-node-builtin-boundary.test.ts
@@ -1,0 +1,111 @@
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The renderer runs sandboxed with contextIsolation: `node:*` builtins do not resolve and even a
+ * bare `process` read throws. A module that reaches one is not a degraded feature — the chunk
+ * fails at evaluation, React never mounts, and the window stays blank with `workspaceSessionReady`
+ * stuck false (#18742 did exactly this by importing one constant out of a `node:child_process`
+ * module). Bundling hides it: the offending module can sit in a shared chunk far from the import
+ * that pulled it in.
+ *
+ * So walk the import graph from every renderer entry — lazy routes included, since a `node:`
+ * builtin behind one is just a blank route instead of a blank app — and refuse any builtin.
+ */
+const RENDERER_SRC = import.meta.dirname
+const REPO_SRC = path.resolve(RENDERER_SRC, '../..')
+const ENTRIES = ['main.tsx', 'popout.tsx', 'web/main.tsx']
+const EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx']
+
+/** `import`/`export ... from` and `import(...)` specifiers, minus type-only ones, which erase. */
+function collectValueImportSpecifiers(source: string): string[] {
+  const specifiers: string[] = []
+  const pattern =
+    /(?:^|[\s;}])(?:import|export)(\s+type\s|\s*\{[^}]*\}|[^'"]*?)?\s*from\s*['"]([^'"]+)['"]|(?:^|[\s;}])import\s*['"]([^'"]+)['"]|import\s*\(\s*['"]([^'"]+)['"]\s*\)/g
+  for (const match of source.matchAll(pattern)) {
+    const clause = match[1] ?? ''
+    const specifier = match[2] ?? match[3] ?? match[4]
+    if (!specifier || /^\s*type\s/.test(clause)) {
+      continue
+    }
+    // A brace clause whose every binding is `type`-prefixed also erases entirely.
+    const bindings = clause.trim().startsWith('{') ? clause.trim().slice(1, -1).split(',') : null
+    if (bindings && bindings.some((b) => b.trim()) && bindings.every((b) => /^\s*type\s/.test(b))) {
+      continue
+    }
+    specifiers.push(specifier)
+  }
+  return specifiers
+}
+
+function resolveModule(specifier: string, fromFile: string): string | null {
+  let base: string
+  if (specifier.startsWith('@renderer/')) {
+    base = path.join(RENDERER_SRC, specifier.slice('@renderer/'.length))
+  } else if (specifier.startsWith('@/')) {
+    base = path.join(RENDERER_SRC, specifier.slice(2))
+  } else if (specifier.startsWith('.')) {
+    base = path.resolve(path.dirname(fromFile), specifier)
+  } else {
+    // Bare package specifiers are npm dependencies, not first-party source.
+    return null
+  }
+  for (const candidate of [
+    ...EXTENSIONS.map((ext) => `${base}${ext}`),
+    ...EXTENSIONS.map((ext) => path.join(base, `index${ext}`))
+  ]) {
+    if (existsSync(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+function walkRendererImportGraph(): Map<string, string[]> {
+  /** file -> the chain of first-party importers that reached it, entry first. */
+  const pathToFile = new Map<string, string[]>()
+  const queue: string[] = []
+  for (const entry of ENTRIES) {
+    const file = path.join(RENDERER_SRC, entry)
+    pathToFile.set(file, [file])
+    queue.push(file)
+  }
+  while (queue.length > 0) {
+    const file = queue.shift() as string
+    const chain = pathToFile.get(file) as string[]
+    for (const specifier of collectValueImportSpecifiers(readFileSync(file, 'utf8'))) {
+      const resolved = resolveModule(specifier, file)
+      if (!resolved || pathToFile.has(resolved)) {
+        continue
+      }
+      pathToFile.set(resolved, [...chain, resolved])
+      queue.push(resolved)
+    }
+  }
+  return pathToFile
+}
+
+describe('renderer node-builtin boundary', () => {
+  it('reaches no module that imports a node: builtin', () => {
+    const graph = walkRendererImportGraph()
+    const offenders: string[] = []
+    for (const [file, chain] of graph) {
+      const builtins = collectValueImportSpecifiers(readFileSync(file, 'utf8')).filter(
+        (specifier) => specifier.startsWith('node:')
+      )
+      if (builtins.length === 0) {
+        continue
+      }
+      const relativeChain = chain.map((step) => path.relative(REPO_SRC, step)).join('\n    -> ')
+      offenders.push(`${builtins.join(', ')} via\n    ${relativeChain}`)
+    }
+    expect(offenders.join('\n\n')).toBe('')
+  })
+
+  it('walks a real graph, so an empty offender list means something', () => {
+    const graph = walkRendererImportGraph()
+    expect(graph.size).toBeGreaterThan(3_000)
+    expect(graph.has(path.join(REPO_SRC, 'shared/process-table-snapshot.ts'))).toBe(true)
+  })
+})

--- a/src/shared/process-table-snapshot-reader.ts
+++ b/src/shared/process-table-snapshot-reader.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCb } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { promisify } from 'node:util'
 import {
+  PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS,
   PS_ARGS,
   PS_MAX_BUFFER_BYTES,
   ProcessTableCaptureError,
@@ -10,7 +11,7 @@ import {
   type ProcessTableRow
 } from './process-table-snapshot'
 
-export { PS_ARGS, PS_MAX_BUFFER_BYTES }
+export { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS, PS_ARGS, PS_MAX_BUFFER_BYTES }
 
 const execFile = promisify(execFileCb)
 
@@ -20,7 +21,7 @@ const execFile = promisify(execFileCb)
 // whole subsystem answered "unverifiable" about a table it could read. This keeps a wedged
 // `ps` bounded while staying out of reach of a host that is merely busy.
 export const PS_TIMEOUT_MS = 15_000
-const DEFAULT_SNAPSHOT_TTL_MS = 500
+const DEFAULT_SNAPSHOT_TTL_MS = PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS
 
 type Snapshot<T> = { value: T; capturedAtMs: number; completedAtMs: number }
 
@@ -330,10 +331,6 @@ export async function getStrictProcessTableSnapshotWithAge(): Promise<{
   const snapshot = await withEvidenceBudget(processTableReader.getSnapshotWithAge())
   return { rows: snapshot.value.strict(), capturedAgeMs: snapshot.capturedAgeMs }
 }
-
-/** How much older than its own await a TTL-cached capture may be, on top of the capture's own
- *  duration. Reported ages carry both, so this alone is not the staleness bound. */
-export const PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS = DEFAULT_SNAPSHOT_TTL_MS
 
 export function resetProcessTableSnapshotForTests(): void {
   processTableReader.reset()

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -13,9 +13,14 @@ export type ProcessTableRow = {
   command: string
 }
 
+// Why guarded: this module is the renderer-safe half of the process-table pair, and the renderer
+// runs sandboxed with contextIsolation, where a bare `process` read throws at module evaluation
+// and takes the whole chunk — and the app — down with it. Only hosts ever run these argv.
+const HOST_IS_DARWIN = typeof process !== 'undefined' && process.platform === 'darwin'
+
 /** Columns used by the evidence reader. Keep command last so its spaces survive parsing. */
 export const PS_ARGS = (
-  process.platform === 'darwin'
+  HOST_IS_DARWIN
     ? ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,tty=,lstart=,command=']
     : ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,tty=,etimes=,command=']
 ) as readonly string[]
@@ -28,7 +33,7 @@ export const PS_ARGS = (
  * marker comes from `/proc/<pid>/stat` for the pane subtree only.
  */
 export const CHEAP_PS_ARGS = (
-  process.platform === 'darwin'
+  HOST_IS_DARWIN
     ? ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,lstart=']
     : ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=']
 ) as readonly string[]
@@ -79,6 +84,14 @@ export function parseCheapProcessTableRows(stdout: string): CheapProcessTableRow
 // capture fails — a readable process table degrading into permanent
 // "unverifiable". Matches the sibling reader in pty-descendant-termination.ts.
 export const PS_MAX_BUFFER_BYTES = 32 * 1024 * 1024
+
+/** How much older than its own await a TTL-cached capture may be, on top of the capture's own
+ *  duration. Reported ages carry both, so this alone is not the staleness bound.
+ *
+ *  Why here and not beside the reader that applies it: the renderer's cadence scheduler pulls a
+ *  pane's next poll forward by at most this much, and the reader is a `node:child_process` module
+ *  the renderer must never reach. */
+export const PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS = 500
 
 /**
  * Parse legacy or evidence-shaped `ps` output into rows. Tolerates CRLF so a


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## Severity: main currently boots to a blank white window on every launch

This is not an e2e-only problem. On current main the renderer throws before React mounts, so the app shows an empty window. Every Playwright spec that boots the app fails with `workspaceSessionReady did not become true`; a control PR of main plus one no-op line failed **14 SSH specs**, all with that error. It also reproduces locally on plain `origin/main`.

## Regressing commit

`e1599c94b8b` — `perf(terminals): let idle panes share one process-table capture instead of forking their own (#18742)`.

Bisected by building the renderer at each candidate: `7856e5a677c` (its parent) passes; `e1599c94b8b` onward fails. `e95d247be1e` (#18780) later added a second copy of the same landmine.

## Root cause

`agent-completion-poll-interval.ts` value-imported one constant, `PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS`, from `src/shared/process-table-snapshot-reader.ts` — a `node:child_process` / `node:fs/promises` module. Its dependency `process-table-snapshot.ts` evaluates `process.platform` **at module scope** to choose `ps` columns. The renderer runs sandboxed with contextIsolation, where `process` is undefined, so evaluating that chunk threw `ReferenceError: process is not defined` and took the whole bundle down.

The import chain is 10 hops from `main.tsx`, which is why a pure-perf terminal change silently reached a Node-only module:

```
main.tsx → App.tsx → use-app-shell-services → useIpcEvents → app-lifetime-ipc-bridge
  → agent-hook-completion-notifications → agent-completion-coordinator
  → agent-completion-process-monitor → agent-completion-poll-scheduler
  → agent-completion-poll-interval → process-table-snapshot-reader
```

Evidence: with `ORCA_STARTUP_DIAGNOSTICS=1`, main reaches `did-finish-load` at t=1323ms then idles for 40s with **zero** `renderer-*` diagnostics. CDP `Runtime.exceptionThrown` pins it to the emitted `PS_ARGS` initializer.

## Fix

- `src/shared/process-table-snapshot.ts:88` — constant moved to the environment-neutral half of the pair; `process-table-snapshot-reader.ts:14` re-exports it, so every host caller is unchanged and the value (500) is identical.
- `src/renderer/src/components/terminal-pane/agent-completion-poll-interval.ts:3` — imports the neutral module; the renderer reaches no `node:` builtin.
- `src/shared/process-table-snapshot.ts:19` — both `ps` column sets read the platform through one `typeof process`-guarded `HOST_IS_DARWIN`, defusing the same trap for any future renderer import. Only hosts ever run the argv.

## Ratchet test

`src/renderer/src/renderer-node-builtin-boundary.test.ts` walks the import graph (including lazy `import()` routes) from all three renderer entries and fails on any reachable module importing a `node:` builtin. The graph is 6,361 modules with zero other offenders — so this class of regression cannot land silently again.

## Verification

Red-then-green on the real symptom, confirmed independently of the authoring run:
- `default-branch-visibility.spec.ts` — **passes in 14.2s** with the fix; **fails** with the three source files reverted to main and the test kept.
- The ratchet test fails on the pre-fix import (printing the full 10-hop chain) and passes after.
- `ssh-docker-transport-drop-recovery.spec.ts -g "keeps one reattachable lease"` passes (39.4s) — this is the spec whose CI failures started this investigation.
- 7,125 unit tests pass; `pnpm tc`, oxlint, oxfmt and the changed-code quality gate all clean.