### PR TITLE
fix(renderer): stop a shared poll-interval constant white-screening the app

### DIFF
--- a/config/scripts/agent-inspection-cadence-batching-benchmark.mjs
+++ b/config/scripts/agent-inspection-cadence-batching-benchmark.mjs
@@ -57,7 +57,7 @@ const { POLL_TIER_INTERVAL_MS } = await import(
   path.join(ROOT, 'src/renderer/src/components/terminal-pane/agent-completion-poll-cadence.ts')
 )
 const { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } = await import(
-  path.join(ROOT, 'src/shared/process-table-snapshot-reader.ts')
+  path.join(ROOT, 'src/shared/process-table-snapshot-ttl.ts')
 )
 
 // Pre-change: independent ±10% jitter per pane, re-rolled on every reschedule.

--- a/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot-reader'
+import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot-ttl'
 import { POLL_TIER_INTERVAL_MS } from './agent-completion-poll-cadence'
 import { nextCadenceInspectionDelayMs } from './agent-completion-poll-interval'
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.ts
@@ -1,4 +1,4 @@
-import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot-reader'
+import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot-ttl'
 
 /**
  * Picks the delay until a pane's next cadence inspection.

--- a/src/renderer/src/renderer-node-builtin-import-boundary.test.ts
+++ b/src/renderer/src/renderer-node-builtin-import-boundary.test.ts
@@ -20,17 +20,30 @@ import { describe, expect, it } from 'vitest'
 const REPO_ROOT = resolve(__dirname, '../../..')
 const RENDERER_ENTRY = join(REPO_ROOT, 'src/renderer/src/main.tsx')
 
-const NODE_BUILTIN_IMPORT = /(?:from\s+['"](node:[\w/]+)['"]|require\(\s*['"](node:[\w/]+)['"])/g
-const MODULE_SPECIFIER =
-  /(?:^|\n)\s*(?:import|export)[\s\S]{0,400}?from\s+['"]([^'"]+)['"]|import\(\s*['"]([^'"]+)['"]\s*\)/g
+/** Every specifier shape that creates a real edge, including bare `import './x'` — a
+ *  side-effect import has no `from`, and is the exact shape that runs module-level code. */
+const MODULE_SPECIFIER = /(?:\bfrom|\bimport|\brequire)\s*\(?\s*['"]([^'"]+)['"]/g
 /** Type-only imports are erased before the bundle, so they never reach the sandbox. */
-const TYPE_ONLY_IMPORT = /import\s+type[\s\S]*?from\s+['"][^'"]+['"]/g
+const TYPE_ONLY_IMPORT = /\bimport\s+type\b[\s\S]*?from\s+['"][^'"]+['"]/g
+const COMMENT = /\/\*[\s\S]*?\*\/|(?<![:'"`\\])\/\/[^\n]*/g
 
-function resolveRelativeImport(fromFile: string, specifier: string): string | null {
-  if (!specifier.startsWith('.')) {
+/** Mirrors `renderer.resolve.alias` in electron.vite.config.ts. Most renderer imports are
+ *  aliased, not relative, so a walker that only follows `./` sees a fraction of the graph. */
+const ALIAS_PREFIXES: readonly [string, string][] = [
+  ['@renderer/', 'src/renderer/src/'],
+  ['@/', 'src/renderer/src/']
+]
+
+function resolveImport(fromFile: string, specifier: string): string | null {
+  const alias = ALIAS_PREFIXES.find(([prefix]) => specifier.startsWith(prefix))
+  let base: string
+  if (alias) {
+    base = join(REPO_ROOT, alias[1], specifier.slice(alias[0].length))
+  } else if (specifier.startsWith('.')) {
+    base = resolve(dirname(fromFile), specifier)
+  } else {
     return null
   }
-  const base = resolve(dirname(fromFile), specifier)
   const candidates = [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')]
   return (
     candidates.find((candidate) => existsSync(candidate) && statSync(candidate).isFile()) ?? null
@@ -42,6 +55,7 @@ function collectNodeBuiltinImporters(): { file: string; builtin: string; chain: 
   const visited = new Set<string>([RENDERER_ENTRY])
   const queue = [RENDERER_ENTRY]
   const offenders: { file: string; builtin: string; chain: string[] }[] = []
+  const reported = new Set<string>()
 
   const chainTo = (file: string): string[] => {
     const chain: string[] = []
@@ -62,26 +76,28 @@ function collectNodeBuiltinImporters(): { file: string; builtin: string; chain: 
     } catch {
       continue
     }
-    const runtimeSource = source.replaceAll(TYPE_ONLY_IMPORT, '')
-
-    NODE_BUILTIN_IMPORT.lastIndex = 0
-    const builtin = NODE_BUILTIN_IMPORT.exec(runtimeSource)
-    if (builtin) {
-      offenders.push({
-        file: relative(REPO_ROOT, file),
-        builtin: builtin[1] ?? builtin[2] ?? 'node:?',
-        chain: chainTo(file)
-      })
-    }
+    const runtimeSource = source.replaceAll(COMMENT, '').replaceAll(TYPE_ONLY_IMPORT, '')
 
     MODULE_SPECIFIER.lastIndex = 0
     let match: RegExpExecArray | null
     while ((match = MODULE_SPECIFIER.exec(runtimeSource))) {
-      const specifier = match[1] ?? match[2]
+      const specifier = match[1]
       if (!specifier) {
         continue
       }
-      const resolved = resolveRelativeImport(file, specifier)
+      if (specifier.startsWith('node:')) {
+        // First builtin per file is enough to fail; the chain is what makes it fixable.
+        if (!reported.has(file)) {
+          reported.add(file)
+          offenders.push({
+            file: relative(REPO_ROOT, file),
+            builtin: specifier,
+            chain: chainTo(file)
+          })
+        }
+        continue
+      }
+      const resolved = resolveImport(file, specifier)
       if (resolved && !visited.has(resolved)) {
         visited.add(resolved)
         parents.set(resolved, file)

--- a/src/renderer/src/renderer-node-builtin-import-boundary.test.ts
+++ b/src/renderer/src/renderer-node-builtin-import-boundary.test.ts
@@ -1,0 +1,104 @@
+import { existsSync, readFileSync, statSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Walk the renderer's real module graph and fail on any Node builtin inside it.
+ *
+ * The renderer is sandboxed: no `process`, no `require`, and the bundler stubs `node:*` rather
+ * than failing the build. So a shared module that spends `process.platform` or `promisify` at
+ * import time does not break CI or packaging — it throws while the entry chunk evaluates, React
+ * never mounts, and the app ships a white window. That is exactly how it shipped once: a renderer
+ * poll-interval helper imported one constant from `shared/process-table-snapshot-reader`, which
+ * pulled in `node:child_process`, `node:fs/promises`, `node:util`, and a top-level
+ * `process.platform`.
+ *
+ * Seeded from the entry, not from every renderer file, because reachability is the whole property:
+ * a `*.test-support.ts` file may import `node:path` freely as long as nothing shipped reaches it.
+ */
+
+const REPO_ROOT = resolve(__dirname, '../../..')
+const RENDERER_ENTRY = join(REPO_ROOT, 'src/renderer/src/main.tsx')
+
+const NODE_BUILTIN_IMPORT = /(?:from\s+['"](node:[\w/]+)['"]|require\(\s*['"](node:[\w/]+)['"])/g
+const MODULE_SPECIFIER =
+  /(?:^|\n)\s*(?:import|export)[\s\S]{0,400}?from\s+['"]([^'"]+)['"]|import\(\s*['"]([^'"]+)['"]\s*\)/g
+/** Type-only imports are erased before the bundle, so they never reach the sandbox. */
+const TYPE_ONLY_IMPORT = /import\s+type[\s\S]*?from\s+['"][^'"]+['"]/g
+
+function resolveRelativeImport(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) {
+    return null
+  }
+  const base = resolve(dirname(fromFile), specifier)
+  const candidates = [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts'), join(base, 'index.tsx')]
+  return (
+    candidates.find((candidate) => existsSync(candidate) && statSync(candidate).isFile()) ?? null
+  )
+}
+
+function collectNodeBuiltinImporters(): { file: string; builtin: string; chain: string[] }[] {
+  const parents = new Map<string, string>()
+  const visited = new Set<string>([RENDERER_ENTRY])
+  const queue = [RENDERER_ENTRY]
+  const offenders: { file: string; builtin: string; chain: string[] }[] = []
+
+  const chainTo = (file: string): string[] => {
+    const chain: string[] = []
+    for (let cursor: string | undefined = file; cursor; cursor = parents.get(cursor)) {
+      chain.push(relative(REPO_ROOT, cursor))
+    }
+    return chain.toReversed()
+  }
+
+  while (queue.length > 0) {
+    const file = queue.shift()
+    if (!file) {
+      break
+    }
+    let source: string
+    try {
+      source = readFileSync(file, 'utf8')
+    } catch {
+      continue
+    }
+    const runtimeSource = source.replaceAll(TYPE_ONLY_IMPORT, '')
+
+    NODE_BUILTIN_IMPORT.lastIndex = 0
+    const builtin = NODE_BUILTIN_IMPORT.exec(runtimeSource)
+    if (builtin) {
+      offenders.push({
+        file: relative(REPO_ROOT, file),
+        builtin: builtin[1] ?? builtin[2] ?? 'node:?',
+        chain: chainTo(file)
+      })
+    }
+
+    MODULE_SPECIFIER.lastIndex = 0
+    let match: RegExpExecArray | null
+    while ((match = MODULE_SPECIFIER.exec(runtimeSource))) {
+      const specifier = match[1] ?? match[2]
+      if (!specifier) {
+        continue
+      }
+      const resolved = resolveRelativeImport(file, specifier)
+      if (resolved && !visited.has(resolved)) {
+        visited.add(resolved)
+        parents.set(resolved, file)
+        queue.push(resolved)
+      }
+    }
+  }
+
+  return offenders
+}
+
+describe('renderer module graph', () => {
+  it('reaches no Node builtin from the entry', () => {
+    const offenders = collectNodeBuiltinImporters()
+    const report = offenders
+      .map((o) => `${o.file} imports ${o.builtin}\n  via ${o.chain.join('\n   -> ')}`)
+      .join('\n\n')
+    expect(report).toBe('')
+  })
+})

--- a/src/shared/process-table-snapshot-reader.ts
+++ b/src/shared/process-table-snapshot-reader.ts
@@ -9,8 +9,13 @@ import {
   parseStrictProcessTableRows,
   type ProcessTableRow
 } from './process-table-snapshot'
+import {
+  DEFAULT_PROCESS_TABLE_SNAPSHOT_TTL_MS,
+  PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS
+} from './process-table-snapshot-ttl'
 
 export { PS_ARGS, PS_MAX_BUFFER_BYTES }
+export { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS }
 
 const execFile = promisify(execFileCb)
 
@@ -20,7 +25,6 @@ const execFile = promisify(execFileCb)
 // whole subsystem answered "unverifiable" about a table it could read. This keeps a wedged
 // `ps` bounded while staying out of reach of a host that is merely busy.
 export const PS_TIMEOUT_MS = 15_000
-const DEFAULT_SNAPSHOT_TTL_MS = 500
 
 type Snapshot<T> = { value: T; capturedAtMs: number; completedAtMs: number }
 
@@ -39,7 +43,7 @@ export function createProcessTableSnapshotReader<T = string>(
   getFreshSnapshot: () => Promise<T>
   reset: () => void
 } {
-  const ttlMs = deps.ttlMs ?? DEFAULT_SNAPSHOT_TTL_MS
+  const ttlMs = deps.ttlMs ?? DEFAULT_PROCESS_TABLE_SNAPSHOT_TTL_MS
   let cached: Snapshot<T> | null = null
   let inFlight: Promise<T> | null = null
   let sequence = 0
@@ -330,10 +334,6 @@ export async function getStrictProcessTableSnapshotWithAge(): Promise<{
   const snapshot = await withEvidenceBudget(processTableReader.getSnapshotWithAge())
   return { rows: snapshot.value.strict(), capturedAgeMs: snapshot.capturedAgeMs }
 }
-
-/** How much older than its own await a TTL-cached capture may be, on top of the capture's own
- *  duration. Reported ages carry both, so this alone is not the staleness bound. */
-export const PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS = DEFAULT_SNAPSHOT_TTL_MS
 
 export function resetProcessTableSnapshotForTests(): void {
   processTableReader.reset()

--- a/src/shared/process-table-snapshot-reader.ts
+++ b/src/shared/process-table-snapshot-reader.ts
@@ -9,13 +9,9 @@ import {
   parseStrictProcessTableRows,
   type ProcessTableRow
 } from './process-table-snapshot'
-import {
-  DEFAULT_PROCESS_TABLE_SNAPSHOT_TTL_MS,
-  PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS
-} from './process-table-snapshot-ttl'
+import { DEFAULT_PROCESS_TABLE_SNAPSHOT_TTL_MS } from './process-table-snapshot-ttl'
 
 export { PS_ARGS, PS_MAX_BUFFER_BYTES }
-export { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS }
 
 const execFile = promisify(execFileCb)
 

--- a/src/shared/process-table-snapshot-ttl.ts
+++ b/src/shared/process-table-snapshot-ttl.ts
@@ -1,0 +1,10 @@
+/** How long an in-flight/just-finished process-table capture may be reused before a fresh `ps`.
+ *
+ *  Deliberately a leaf module with no imports: the renderer schedules pane inspections against
+ *  this bound, and reaching it through the reader drags `node:child_process`/`node:fs` and a
+ *  top-level `process.platform` into the renderer bundle, which throws before React mounts. */
+export const DEFAULT_PROCESS_TABLE_SNAPSHOT_TTL_MS = 500
+
+/** How much older than its own await a TTL-cached capture may be, on top of the capture's own
+ *  duration. Reported ages carry both, so this alone is not the staleness bound. */
+export const PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS = DEFAULT_PROCESS_TABLE_SNAPSHOT_TTL_MS


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​120 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## The bug

`1.4.198-hourly.202609050816` launches to a fully white window. `<div id="root">` is empty; nothing mounts.

Attaching CDP to the packaged app:

```
[pageerror] ReferenceError: process is not defined
    at .../out/renderer/assets/web-session-tabs-sync-ABfGRZ9n.js:1:68349
```

Shimming `globalThis.process` advances it exactly one step, to the next Node stub — `(0, it(...).promisify) is not a function` — which pins the offending module.

## Root cause

**Broken by #18742 (`e1599c94b8b`, "perf(terminals): let idle panes share one process-table capture instead of forking their own", merged 2026-09-05 00:05 PDT).** It added `agent-completion-poll-interval.ts`, which imports one constant from `shared/process-table-snapshot-reader`. That reader is main-process-only:

```
main.tsx → App.tsx → … → agent-completion-poll-scheduler.ts
        → agent-completion-poll-interval.ts
        → shared/process-table-snapshot-reader.ts   (node:child_process, node:fs/promises, node:util)
        → shared/process-table-snapshot.ts          (top-level `process.platform`)
```

`process-table-snapshot.ts` spends `process.platform` at module scope to pick its `ps` argv. The renderer is sandboxed — no `process` — so the entry chunk throws during evaluation and React never gets to render.

Nothing in #18742's own logic is wrong; the perf change is fine. The single import line is the whole defect. Every gate was green because Vite stubs `node:*` instead of failing the build, so it typechecked, tested, packaged, signed, and shipped.

## Fix

- `shared/process-table-snapshot-ttl.ts` — new leaf module, zero imports, owns the TTL and `PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS`.
- `process-table-snapshot-reader.ts` imports and re-exports it, so main-side callers are untouched.
- `agent-completion-poll-interval.ts` imports the leaf module.

## Guard

`renderer-node-builtin-import-boundary.test.ts` walks the renderer's real module graph from `main.tsx` and fails on any reachable `node:` builtin, printing the full import chain:

```
src/shared/process-table-snapshot-reader.ts imports node:child_process
  via src/renderer/src/main.tsx
   -> src/renderer/src/App.tsx
   -> src/renderer/src/app-shell/use-app-shell-services.ts
   ...
   -> src/renderer/src/components/terminal-pane/agent-completion-poll-interval.ts
   -> src/shared/process-table-snapshot-reader.ts
```

Seeded from the entry rather than from every renderer file on purpose — reachability is the property that matters. A `*.test-support.ts` may import `node:path` freely as long as nothing shipped reaches it.

The second commit fixes two blind spots found while reviewing the first: the walker only followed relative specifiers and required a `from`, so it missed the 10,828 `@/`-aliased imports the renderer actually uses, and every bare `import './x'` — the exact shape that runs module-level code. Coverage: 5,122 → 6,323 reachable modules.

## Verification

- Root cause reproduced live against the installed 1.4.198 build via CDP, not inferred from the diff.
- Ratchet verified red on the unpatched tree (chain above) and green after.
- `process-table-snapshot.ts` and its reader are no longer renderer-reachable.
- `pnpm tc` clean, `oxlint` clean, related tests pass.
