### PR TITLE
fix(cloud): validate protocol-0 same-cap cell plans without rehome trust lines

### DIFF
--- a/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
+++ b/.github/workflows/cloud-deploy-relay-production-same-cap-job.yml
@@ -501,6 +501,7 @@ jobs:
                 --rollback-image "${DESIRED_IMAGE}" \
                 --rehome-director-service-account "${DIRECTOR_RUNTIME_SERVICE_ACCOUNT}" \
                 --rehome-audience https://relay.onorca.dev/v1/admin/host-drain \
+                --regional-rehome-protocol "${DESIRED_REHOME_PROTOCOL}" \
               | jq -e '.changes == 2' >/dev/null
           fi
           gcloud compute instance-groups managed wait-until "${MIG_NAME}" --stable \
@@ -526,7 +527,8 @@ jobs:
               --unobserved-bound "${EXPECTED_UNOBSERVED_BOUND}" --image "${DESIRED_IMAGE}" \
               --rollback-image "${IMAGE_REPOSITORY}@${CURRENT_IMAGE_DIGEST}" \
               --rehome-director-service-account "${DIRECTOR_RUNTIME_SERVICE_ACCOUNT}" \
-              --rehome-audience https://relay.onorca.dev/v1/admin/host-drain
+              --rehome-audience https://relay.onorca.dev/v1/admin/host-drain \
+              --regional-rehome-protocol "${DESIRED_REHOME_PROTOCOL}"
           terraform -chdir=infra/terraform apply -auto-approve \
             "${RUNNER_TEMP}/relay-same-cap.tfplan"
           gcloud compute instance-groups managed wait-until "${MIG_NAME}" --stable \

--- a/cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs
+++ b/cloud/dev/scripts/relay-regional-rehome-workflow.test.mjs
@@ -73,7 +73,10 @@ test('same-cap wrapper is reusable, canary-bound, and sequential', () => {
     job,
     /--rollback-image "\$\{DESIRED_IMAGE\}" \\\n {16}--rehome-director-service-account "\$\{DIRECTOR_RUNTIME_SERVICE_ACCOUNT\}"/
   )
-  assert.match(job, /host-drain \\\n {14}\| jq -e '\.changes == 2' >\/dev\/null/)
+  assert.match(
+    job,
+    /host-drain \\\n {16}--regional-rehome-protocol "\$\{DESIRED_REHOME_PROTOCOL\}" \\\n {14}\| jq -e '\.changes == 2' >\/dev\/null/
+  )
   assert.match(job, /resume requires the isolated migration-only cell/)
   assert.match(job, /test "\$\{TARGET_INCARNATION\}" = "\$\{SOURCE_INCARNATION\}"/)
   assert.match(job, /\(.regionalRehomeProtocol \/\/ 0\) == \$protocol/)

--- a/cloud/dev/scripts/relay-same-cap-script-census.test.mjs
+++ b/cloud/dev/scripts/relay-same-cap-script-census.test.mjs
@@ -1,12 +1,108 @@
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
 import { describe, it } from 'node:test'
 import { parseProductionCapacityCellArguments } from './prepare-relay-production-capacity-canary.mjs'
 import { SAME_CAP_CELLS } from './relay-production-same-cap-wave.mjs'
 import { readRelayWorkflow } from './relay-repository.mjs'
+import { validateCapacityPlan } from './validate-relay-capacity-plan.mjs'
 
 const workflow = readRelayWorkflow('deploy-relay-production-same-cap-job.yml')
 const capacityWorkflow = readRelayWorkflow('deploy-relay-production-capacity-job.yml')
+const production = readFileSync(
+  new URL('../../infra/terraform/environments/production.tfvars', import.meta.url),
+  'utf8'
+)
+const REHOME_SOURCE_CELLS = rehomeSourceCells()
+const DIRECTOR_IDENTITY = 'relay-director@onorca-cloud.iam.gserviceaccount.com'
+const AUDIENCE = 'https://relay.onorca.dev/v1/admin/host-drain'
+const ROLLBACK_IMAGE = `us-central1-docker.pkg.dev/p/orca-cloud/relay@sha256:${'d'.repeat(64)}`
+const TARGET_IMAGE = `us-central1-docker.pkg.dev/p/orca-cloud/relay@sha256:${'e'.repeat(64)}`
+
+// The startup template emits rehome trust only for cells in this list, so it is what decides
+// whether a cell's plan may carry those lines at all.
+function rehomeSourceCells() {
+  const start = production.indexOf('relay_region_rehome_source_cell_ids = [')
+  assert.notEqual(start, -1, 'production.tfvars has no rehome source cell list')
+  const end = production.indexOf(']', start)
+  assert.notEqual(end, -1, 'the rehome source cell list is unterminated')
+  return new Set(
+    [...production.slice(start, end).matchAll(/"([^"]+)"/g)].map(([, cell]) => cell)
+  )
+}
+
+function startupScript({ cap, image, trusted }) {
+  return [
+    `  printf 'ORCA_RELAY_CELL_CONNECTION_HARD_CAP=%s\\n' '${cap}'`,
+    `  printf 'ORCA_RELAY_CELL_CONNECTION_UNOBSERVED_BOUND=%s\\n' '60'`,
+    ...(trusted ? [
+      `  printf 'ORCA_RELAY_REHOME_DIRECTOR_SERVICE_ACCOUNT=%s\\n' '${DIRECTOR_IDENTITY}'`,
+      `  printf 'ORCA_RELAY_REHOME_AUDIENCE=%s\\n' '${AUDIENCE}'`
+    ] : []),
+    `printf 'ORCA_RELAY_IMAGE_DIGEST=%s\\n' '${image.split('@')[1]}'`,
+    `docker pull '${image}'`,
+    'docker run --detach \\',
+    '  --name orca-relay \\',
+    `  '${image}'`
+  ].join('\n')
+}
+
+// The exact shape the apply step's plan has: template replaced, MIG rebound to it.
+function rollPlan({ cellId, cap, protocol }) {
+  return {
+    configuration: {
+      root_module: {
+        resources: [{
+          address: 'google_compute_instance_group_manager.relay_gce_cell',
+          expressions: {
+            version: [{
+              instance_template: {
+                references: [
+                  'google_compute_instance_template.relay_gce_cell',
+                  'each.key'
+                ]
+              },
+              name: { constant_value: 'primary' }
+            }]
+          }
+        }]
+      }
+    },
+    resource_changes: [
+      {
+        address: `google_compute_instance_template.relay_gce_cell[${JSON.stringify(cellId)}]`,
+        change: {
+          actions: ['create', 'delete'],
+          before: {
+            metadata_startup_script: startupScript({
+              cap,
+              image: ROLLBACK_IMAGE,
+              trusted: protocol === 1
+            })
+          },
+          after: {
+            metadata_startup_script: startupScript({
+              cap,
+              image: TARGET_IMAGE,
+              trusted: protocol === 1
+            }),
+            self_link: null
+          },
+          after_unknown: { self_link: true }
+        }
+      },
+      {
+        address: `google_compute_instance_group_manager.relay_gce_cell[${JSON.stringify(cellId)}]`,
+        change: {
+          actions: ['update'],
+          before: { target_size: 1, version: [{ instance_template: 'old' }] },
+          after: { target_size: 1, version: [{ instance_template: null }] },
+          after_unknown: { version: [{ instance_template: true }] }
+        }
+      }
+    ]
+  }
+}
 
 function hostname(cellId) {
   return cellId.slice('production-gce-'.length)
@@ -66,6 +162,52 @@ describe('same-cap roll scripts accept every same-cap cell', () => {
       const call = lines.slice(0, end + 1).join(' ')
       assert.match(call, /--approved-cells same-cap/)
       assert.match(call, /--mode (isolate|drain|activate)/)
+    }
+  })
+
+  it('passes this cell\'s rehome protocol on every plan validation the job runs', () => {
+    const invocations = workflow.split('validate-relay-capacity-plan.mjs').slice(1)
+    assert.equal(invocations.length, 2)
+    for (const invocation of invocations) {
+      const lines = invocation.split('\n')
+      const end = lines.findIndex((line) => !line.trimEnd().endsWith('\\'))
+      const call = lines.slice(0, end + 1).join(' ')
+      assert.match(call, /--mode same-cap-cell/)
+      assert.match(call, /--regional-rehome-protocol "\$\{DESIRED_REHOME_PROTOCOL\}"/)
+    }
+  })
+
+  it('validates a correct plan for every wave cell at that cell\'s rehome protocol', () => {
+    for (const cellId of SAME_CAP_CELLS) {
+      const [region, cap] = resolveCellShape(cellId).stdout.trim().split(' ')
+      const protocol = REHOME_SOURCE_CELLS.has(cellId) ? 1 : 0
+      assert.equal(protocol, region === 'us-central1' ? 1 : 0, cellId)
+      const config = {
+        mode: 'same-cap-cell',
+        cellId,
+        hardCap: Number(cap),
+        unobservedBound: 60,
+        image: TARGET_IMAGE,
+        rollbackImage: ROLLBACK_IMAGE,
+        rehomeDirectorServiceAccount: DIRECTOR_IDENTITY,
+        rehomeAudience: AUDIENCE,
+        regionalRehomeProtocol: String(protocol)
+      }
+      const plan = rollPlan({ cellId, cap, protocol })
+      assert.deepEqual(
+        validateCapacityPlan(plan, config),
+        { mode: 'same-cap-cell', changes: 2 },
+        cellId
+      )
+      // The other protocol must reject the same plan, or the flag decides nothing.
+      assert.throws(
+        () => validateCapacityPlan(plan, {
+          ...config,
+          regionalRehomeProtocol: String(1 - protocol)
+        }),
+        /reviewed image and capacity/,
+        cellId
+      )
     }
   })
 

--- a/cloud/dev/scripts/validate-relay-capacity-plan.mjs
+++ b/cloud/dev/scripts/validate-relay-capacity-plan.mjs
@@ -4,7 +4,18 @@ import { pathToFileURL } from 'node:url'
 const SERVICE_ACCOUNT_EMAIL =
   /^[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z0-9-]+\.iam\.gserviceaccount\.com$/
 
-function parseArguments(argv) {
+const REHOME_CONFIG =
+  /^  printf 'ORCA_RELAY_REHOME_(?:DIRECTOR_SERVICE_ACCOUNT|AUDIENCE)=%s\\n' '[^'\n]+'$/
+
+// Only cells listed as regional rehome sources get rehome trust lines in their startup script.
+function rehomeProtocol({ regionalRehomeProtocol }) {
+  if (![0, 1, '0', '1'].includes(regionalRehomeProtocol)) {
+    throw new Error('same-cap Terraform plan has an invalid regional rehome protocol')
+  }
+  return Number(regionalRehomeProtocol)
+}
+
+export function parseCapacityPlanArguments(argv) {
   const values = {}
   for (let index = 0; index < argv.length; index += 2) {
     const key = argv[index]
@@ -31,8 +42,12 @@ function parseArguments(argv) {
     values.mode === 'same-cap-cell' &&
     (!values['rollback-image'] ||
       !values['rehome-director-service-account'] ||
-      !values['rehome-audience'])
+      !values['rehome-audience'] ||
+      !['0', '1'].includes(values['regional-rehome-protocol']))
   ) throw new Error('same-cap validation requires rollback image and rehome trust config')
+  if (values.mode !== 'same-cap-cell' && values['regional-rehome-protocol'] !== undefined) {
+    throw new Error('--regional-rehome-protocol applies only to same-cap-cell validation')
+  }
   if (values.mode === 'same-cap-image' && !values['rollback-image']) {
     throw new Error('same-cap image validation requires a rollback image')
   }
@@ -51,7 +66,8 @@ function parseArguments(argv) {
     capacityServiceAccount: values['capacity-service-account'],
     rollbackImage: values['rollback-image'],
     rehomeDirectorServiceAccount: values['rehome-director-service-account'],
-    rehomeAudience: values['rehome-audience']
+    rehomeAudience: values['rehome-audience'],
+    regionalRehomeProtocol: values['regional-rehome-protocol']
   }
 }
 
@@ -175,15 +191,13 @@ function normalizedStartupScript(
     /^  printf 'ORCA_RELAY_CELL_CONNECTION_(?:HARD_CAP|UNOBSERVED_BOUND)=%s\\n' '[0-9]+'$/
   const capacityIdentity =
     /^  printf 'ORCA_RELAY_CAPACITY_SERVICE_ACCOUNT=%s\\n' '[a-z][a-z0-9-]{4,28}[a-z0-9]@[a-z0-9-]+\.iam\.gserviceaccount\.com'$/
-  const rehomeConfig =
-    /^  printf 'ORCA_RELAY_REHOME_(?:DIRECTOR_SERVICE_ACCOUNT|AUDIENCE)=%s\\n' '[^'\n]+'$/
   return script
     .split('\n')
     .filter(
       (line) =>
         (preserveCapacity || !capacityAssignment.test(line)) &&
         (!stripCapacityIdentity || !capacityIdentity.test(line)) &&
-        (!stripRehomeConfig || !rehomeConfig.test(line))
+        (!stripRehomeConfig || !REHOME_CONFIG.test(line))
     )
     .join('\n')
     .replaceAll(image, '<relay-image>')
@@ -213,7 +227,8 @@ function requireDesiredStartupScript(script, config) {
       `  printf 'ORCA_RELAY_CAPACITY_SERVICE_ACCOUNT=%s\\n' '${config.capacityServiceAccount}'`
     ])
   }
-  if (config.mode === 'same-cap-cell') {
+  const rehomeTrusted = config.mode === 'same-cap-cell' && rehomeProtocol(config) === 1
+  if (rehomeTrusted) {
     expected.push(
       [
         /^  printf 'ORCA_RELAY_REHOME_DIRECTOR_SERVICE_ACCOUNT=%s\\n' '[^'\n]+'$/,
@@ -225,9 +240,15 @@ function requireDesiredStartupScript(script, config) {
       ]
     )
   }
+  // A protocol-0 cell is not a rehome source, so gaining any rehome trust line is real drift.
+  const unexpectedRehome =
+    config.mode === 'same-cap-cell' &&
+    !rehomeTrusted &&
+    lines.some((line) => REHOME_CONFIG.test(line))
   if (
     typeof script !== 'string' ||
     relayImage(script) !== config.image ||
+    unexpectedRehome ||
     expected.some(([pattern, line]) => !hasExactSingleAssignment(lines, pattern, line))
   ) {
     throw new Error('cell plan does not contain the reviewed image and capacity')
@@ -450,6 +471,9 @@ export function validateCapacityPlan(plan, config) {
   ) {
     throw new Error('capacity Terraform plan has an invalid service account')
   }
+  if (config.mode === 'same-cap-cell') {
+    rehomeProtocol(config)
+  }
   if (
     config.mode === 'same-cap-cell' &&
     (!SERVICE_ACCOUNT_EMAIL.test(config.rehomeDirectorServiceAccount ?? '') ||
@@ -504,7 +528,7 @@ export function validateCapacityPlan(plan, config) {
 }
 
 export function main(argv = process.argv.slice(2)) {
-  const config = parseArguments(argv)
+  const config = parseCapacityPlanArguments(argv)
   const plan = JSON.parse(readFileSync(0, 'utf8'))
   process.stdout.write(`${JSON.stringify({ event: 'relay_capacity_plan_verified', ...validateCapacityPlan(plan, config) })}\n`)
 }

--- a/cloud/dev/scripts/validate-relay-capacity-plan.test.mjs
+++ b/cloud/dev/scripts/validate-relay-capacity-plan.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict'
 import { test } from 'node:test'
-import { validateCapacityPlan as validateCapacityPlanRaw } from './validate-relay-capacity-plan.mjs'
+import {
+  parseCapacityPlanArguments,
+  validateCapacityPlan as validateCapacityPlanRaw
+} from './validate-relay-capacity-plan.mjs'
 
 const config = {
   cellId: 'staging-gce-c3',
@@ -466,7 +469,8 @@ test('same-cap mode preserves 1000/60 while adding only the reviewed trust confi
     image,
     rollbackImage,
     rehomeDirectorServiceAccount: directorIdentity,
-    rehomeAudience: audience
+    rehomeAudience: audience,
+    regionalRehomeProtocol: '1'
   }
   assert.deepEqual(
     validateCapacityPlan({ resource_changes: [template, manager] }, sameCapConfig),
@@ -642,5 +646,136 @@ test('same-cap mode preserves 1000/60 while adding only the reviewed trust confi
       imageOnlyConfig
     ),
     { mode: 'same-cap-image', changes: 1, changeKind: 'manager-convergence' }
+  )
+})
+
+test('protocol-0 same-cap cells roll without rehome trust lines', () => {
+  const rollbackImage = `us-docker.pkg.dev/project/relay/image@sha256:${'d'.repeat(64)}`
+  const image = `us-docker.pkg.dev/project/relay/image@sha256:${'e'.repeat(64)}`
+  const directorIdentity = 'relay-director@project.iam.gserviceaccount.com'
+  const audience = 'https://relay.example.com/v1/admin/host-drain'
+  const startup = ({ selectedImage, trust = false }) => [
+    `  printf 'ORCA_RELAY_CELL_CONNECTION_HARD_CAP=%s\\n' '3000'`,
+    `  printf 'ORCA_RELAY_CELL_CONNECTION_UNOBSERVED_BOUND=%s\\n' '60'`,
+    `  printf 'ORCA_RELAY_CELL_REGION=%s\\n' 'asia-east2'`,
+    ...(trust ? [
+      `  printf 'ORCA_RELAY_REHOME_DIRECTOR_SERVICE_ACCOUNT=%s\\n' '${directorIdentity}'`,
+      `  printf 'ORCA_RELAY_REHOME_AUDIENCE=%s\\n' '${audience}'`
+    ] : []),
+    `printf 'ORCA_RELAY_IMAGE_DIGEST=%s\\n' '${selectedImage.split('@')[1]}'`,
+    `docker pull '${selectedImage}'`,
+    'docker run --detach \\',
+    '  --name orca-relay \\',
+    `  '${selectedImage}'`
+  ].join('\n')
+  const template = {
+    address: 'google_compute_instance_template.relay_gce_cell["production-gce-c27"]',
+    change: {
+      actions: ['create', 'delete'],
+      before: { metadata_startup_script: startup({ selectedImage: rollbackImage }) },
+      after: { metadata_startup_script: startup({ selectedImage: image }), self_link: null },
+      after_unknown: { self_link: true }
+    }
+  }
+  const manager = {
+    address: 'google_compute_instance_group_manager.relay_gce_cell["production-gce-c27"]',
+    change: {
+      actions: ['update'],
+      before: { target_size: 1, version: [{ instance_template: 'old' }] },
+      after: { target_size: 1, version: [{ instance_template: null }] },
+      after_unknown: { version: [{ instance_template: true }] }
+    }
+  }
+  const asiaConfig = {
+    cellId: 'production-gce-c27',
+    hardCap: 3_000,
+    unobservedBound: 60,
+    mode: 'same-cap-cell',
+    image,
+    rollbackImage,
+    rehomeDirectorServiceAccount: directorIdentity,
+    rehomeAudience: audience,
+    regionalRehomeProtocol: '0'
+  }
+  assert.deepEqual(
+    validateCapacityPlan({ resource_changes: [template, manager] }, asiaConfig),
+    { mode: 'same-cap-cell', changes: 2 }
+  )
+  const gainsTrust = structuredClone(template)
+  gainsTrust.change.after.metadata_startup_script = startup({
+    selectedImage: image,
+    trust: true
+  })
+  assert.throws(
+    () => validateCapacityPlan({ resource_changes: [gainsTrust, manager] }, asiaConfig),
+    /reviewed image and capacity/
+  )
+  // Under protocol 1 that same script is the reviewed roll: trust is added, not drift.
+  assert.deepEqual(
+    validateCapacityPlan(
+      { resource_changes: [gainsTrust, manager] },
+      { ...asiaConfig, regionalRehomeProtocol: '1' }
+    ),
+    { mode: 'same-cap-cell', changes: 2 }
+  )
+  // A protocol-1 cell whose script has no rehome lines is the pre-existing failure, unchanged.
+  assert.throws(
+    () => validateCapacityPlan(
+      { resource_changes: [template, manager] },
+      { ...asiaConfig, regionalRehomeProtocol: '1' }
+    ),
+    /reviewed image and capacity/
+  )
+  for (const protocol of [undefined, '', '2', 'yes']) {
+    assert.throws(
+      () => validateCapacityPlan(
+        { resource_changes: [template, manager] },
+        { ...asiaConfig, regionalRehomeProtocol: protocol }
+      ),
+      /invalid regional rehome protocol/
+    )
+  }
+})
+
+test('the rehome protocol argument is required by same-cap-cell mode alone', () => {
+  const image = `us-docker.pkg.dev/project/relay/image@sha256:${'e'.repeat(64)}`
+  const rollbackImage = `us-docker.pkg.dev/project/relay/image@sha256:${'d'.repeat(64)}`
+  const sameCapArguments = (...extra) => [
+    '--mode', 'same-cap-cell',
+    '--cell-id', 'production-gce-c27',
+    '--hard-cap', '3000',
+    '--unobserved-bound', '60',
+    '--image', image,
+    '--rollback-image', rollbackImage,
+    '--rehome-director-service-account', 'relay-director@project.iam.gserviceaccount.com',
+    '--rehome-audience', 'https://relay.onorca.dev/v1/admin/host-drain',
+    ...extra
+  ]
+  assert.equal(
+    parseCapacityPlanArguments(sameCapArguments('--regional-rehome-protocol', '0'))
+      .regionalRehomeProtocol,
+    '0'
+  )
+  assert.throws(
+    () => parseCapacityPlanArguments(sameCapArguments()),
+    /requires rollback image and rehome trust config/
+  )
+  for (const protocol of ['', '2', 'true']) {
+    assert.throws(
+      () => parseCapacityPlanArguments(sameCapArguments('--regional-rehome-protocol', protocol)),
+      /requires rollback image and rehome trust config/
+    )
+  }
+  assert.throws(
+    () => parseCapacityPlanArguments([
+      '--mode', 'bootstrap-cell',
+      '--cell-id', 'staging-gce-c3',
+      '--hard-cap', '1000',
+      '--unobserved-bound', '60',
+      '--image', image,
+      '--capacity-service-account', 'orca-cap@onorca-cloud.iam.gserviceaccount.com',
+      '--regional-rehome-protocol', '0'
+    ]),
+    /applies only to same-cap-cell validation/
   )
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​283 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​280 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

## What happened

Run [33957151726](https://github.com/stablyai/orca/actions/runs/33957151726) rolled the first Asia same-cap cell, `production-gce-c27` (asia-east2). It failed **after** the reversible isolate/drain and **before** any apply, in "Apply only the selected same-cap template and MIG":

```
cell plan does not contain the reviewed image and capacity
```

The Terraform plan was correct (template replaced to the target image, MIG updated in place). The validator was wrong. The failsafe held: c27 stayed migration-only with rehome disabled, and nothing was applied.

## Root cause

In `same-cap-cell` mode, `requireDesiredStartupScript` unconditionally required exactly one `ORCA_RELAY_REHOME_DIRECTOR_SERVICE_ACCOUNT` line and one `ORCA_RELAY_REHOME_AUDIENCE` line with exact values.

`relay-gce-startup.sh.tftpl` emits those two lines only when `rehome_source_enabled`, which is `contains(var.relay_region_rehome_source_cell_ids, each.key)`. That list in `environments/production.tfvars` holds the 16 US cells (c7-c10, c13-c16, c19-c26). The Asia cells c27-c29 are not rehome sources, so their startup scripts have no rehome lines and their runtime reports `regionalRehomeProtocol: 0`. The expectation was written when every same-cap cell was a US rehome source.

## Fix

`validate-relay-capacity-plan.mjs` takes a new `--regional-rehome-protocol 0|1`, required in `same-cap-cell` mode and rejected in every other mode.

- **Protocol 1**: unchanged. Both rehome lines required, exactly once, with the exact reviewed values.
- **Protocol 0**: both rehome lines must be absent. A protocol-0 cell that gains rehome trust is real drift and still fails closed.

The job passes `--regional-rehome-protocol "${DESIRED_REHOME_PROTOCOL}"` on both `same-cap-cell` invocations, the resume drift check and the apply-step plan validation. That is the same value already asserted against the live runtime by `verify-relay-capacity-transition.mjs` and by the preflight `runtime-status` check, so the plan check and the runtime check now agree by construction instead of by coincidence.

`normalizedStartupScript`'s strip-rehome behaviour is unchanged; for protocol 0 it is a harmless no-op since neither side has those lines.

## Unchanged

- `cloud-deploy-relay-production-capacity-job.yml` (US-only, `--mode bootstrap-cell`).
- `same-cap-image` mode, used by the staging c4 recovery and staging capacity proof workflows.
- The protocol-1 US path: every existing check still runs with the same exact-value expectations.
- The rehome-trust probe step, already gated on `rehome-protocol == '1'`, so it correctly skips for Asia.

## Tests

`validate-relay-capacity-plan.test.mjs`:
- protocol-0 asia-east2 fixture at cap 3000 with no rehome lines is accepted
- protocol-0 with rehome lines present is rejected
- the same script under protocol 1 is accepted, the trust-free one under protocol 1 is rejected
- `0`, `''`, `2`, `yes` and a missing value are all rejected as an invalid protocol
- the argument is required in `same-cap-cell` mode and rejected in `bootstrap-cell` mode

`relay-same-cap-script-census.test.mjs`:
- both `same-cap-cell` validator invocations in the job carry `--regional-rehome-protocol "${DESIRED_REHOME_PROTOCOL}"`
- for all 19 `SAME_CAP_CELLS`, the protocol derived from `relay_region_rehome_source_cell_ids` in `production.tfvars` matches the region the job's own cell-shape block resolves, and the validator accepts a minimal correct roll plan at that protocol while rejecting the same plan at the other one

`relay-regional-rehome-workflow.test.mjs`: the pinned resume-call assertion now requires the protocol flag between `host-drain` and the `jq -e '.changes == 2'` pipe.

Full `cloud` suite: 529 passing, 0 failing. `pnpm typecheck` in `cloud` clean.