### PR TITLE
refactor(process-table): read the staleness bound from its own module, not the Node-only reader

### DIFF
--- a/config/scripts/agent-inspection-cadence-batching-benchmark.mjs
+++ b/config/scripts/agent-inspection-cadence-batching-benchmark.mjs
@@ -57,7 +57,7 @@ const { POLL_TIER_INTERVAL_MS } = await import(
   path.join(ROOT, 'src/renderer/src/components/terminal-pane/agent-completion-poll-cadence.ts')
 )
 const { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } = await import(
-  path.join(ROOT, 'src/shared/process-table-snapshot-reader.ts')
+  path.join(ROOT, 'src/shared/process-table-snapshot.ts')
 )
 
 // Pre-change: independent ±10% jitter per pane, re-rolled on every reschedule.

--- a/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-poll-interval.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot-reader'
+import { PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS } from '../../../../shared/process-table-snapshot'
 import { POLL_TIER_INTERVAL_MS } from './agent-completion-poll-cadence'
 import { nextCadenceInspectionDelayMs } from './agent-completion-poll-interval'
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

Follow-up to #18814. Not a bug fix — nothing here is broken today.

#18814 moved `PROCESS_TABLE_SNAPSHOT_MAX_STALENESS_MS` into `shared/process-table-snapshot.ts` and left a re-export on `shared/process-table-snapshot-reader.ts` so host callers stayed working. Two callers still take that route:

- `agent-completion-poll-interval.test.ts`
- `config/scripts/agent-inspection-cadence-batching-benchmark.mjs`

Both run in Node, so both resolve `node:child_process` fine.

The reason to move them anyway: the renderer file sitting directly beside that test is the one that blanked the app at boot by importing that exact path, and the boundary ratchet from #18814 only walks shipped entry points — it will never see a test or a benchmark. So the import shape that caused the outage is still present, one line away from the fix, with nothing watching it.

Points both at the defining module. No behavior change; the re-export stays for host callers.

Verified: `pnpm tc` clean, oxlint clean, `agent-completion-poll-interval` and `renderer-node-builtin-boundary` tests pass, benchmark still runs and reports the same batching numbers.