### PR TITLE
perf(worktree): skip remote probes with no possible result

### DIFF
--- a/src/main/git/git-username.ts
+++ b/src/main/git/git-username.ts
@@ -259,7 +259,15 @@ async function getConfiguredBranchRemote(repoPath: string, branch: string | null
  * the GitHub account name as its branch prefix.
  */
 async function localRepoHasEffectiveGitHubRemote(repoPath: string): Promise<boolean> {
-  const remotes = (await readGitStdout(repoPath, ['remote'])).split('\n').filter(Boolean)
+  const remoteList = await gitExecFileAsync(['remote'], {
+    cwd: repoPath,
+    timeout: LOCAL_GIT_READ_TIMEOUT_MS
+  }).catch(() => null)
+  const remotes = (remoteList?.stdout.trim() ?? '').split('\n').filter(Boolean)
+  // Only a successful empty list proves there is no hosted remote to inspect.
+  if (remoteList && remotes.length === 0) {
+    return false
+  }
   const defaultBaseRef = await resolveDefaultBaseRefViaExec((argv) =>
     gitExecFileAsync(argv, { cwd: repoPath, timeout: LOCAL_GIT_READ_TIMEOUT_MS })
   )

--- a/src/main/git/repo-username.test.ts
+++ b/src/main/git/repo-username.test.ts
@@ -140,6 +140,33 @@ describe('resolveLocalGitUsername', () => {
     await expect(resolveLocalGitUsername('/repo')).resolves.toBe('gh-demo')
   })
 
+  it('stops after a successful empty remote list', async () => {
+    await expect(resolveLocalGitUsernameDetailed('/repo')).resolves.toEqual({
+      username: '',
+      authoritative: true
+    })
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+      ['config', '--get', 'github.user'],
+      ['config', '--get', 'user.username'],
+      ['remote']
+    ])
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps remote fallback probes when remote enumeration fails', async () => {
+    originRemoteUrl = 'https://github.com/stablyai/orca.git'
+    const original = gitExecFileAsyncMock.getMockImplementation()!
+    gitExecFileAsyncMock.mockImplementation(async (...args) => {
+      if (args[0].length === 1 && args[0][0] === 'remote') {
+        throw makeExecError('remote enumeration failed')
+      }
+      return original(...args)
+    })
+    ghExecFileAsyncMock.mockResolvedValue({ stdout: 'gh-demo\n', stderr: '' })
+
+    await expect(resolveLocalGitUsername('/repo')).resolves.toBe('gh-demo')
+  })
+
   it('uses GitHub CLI login for GitHub remotes instead of repo-local author identity', async () => {
     originRemoteUrl = 'https://github.com/stablyai/orca.git'
     gitConfig['user.email'] = 'demo@example.com'

--- a/src/main/runtime/fetch-remote-cache.test.ts
+++ b/src/main/runtime/fetch-remote-cache.test.ts
@@ -176,6 +176,18 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
     expect(caches.fetchLastCompletedAt.has('/repo/cache-0::origin')).toBe(false)
   })
 
+  it.each(['main', 'a'.repeat(40), 'refs/remotes/main', ''])(
+    'does not launch Git for a base without a remote/branch separator: %s',
+    async (base) => {
+      const runtime = new OrcaRuntimeService(null)
+      await expect(runtime.resolveRemoteTrackingBase('/repo/e', base)).resolves.toBeNull()
+      await expect(
+        runtime.resolveRemoteTrackingBase('/repo/e', base, { wslDistro: 'Ubuntu' })
+      ).resolves.toBeNull()
+      expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    }
+  )
+
   it('resolves remote-tracking bases with longest configured remote matching', async () => {
     gitExecFileAsyncMock.mockResolvedValue({ stdout: 'foo\nfoo/bar\norigin\n', stderr: '' })
     const runtime = new OrcaRuntimeService(null)

--- a/src/main/runtime/runtime-remote-fetch-controller.ts
+++ b/src/main/runtime/runtime-remote-fetch-controller.ts
@@ -226,6 +226,14 @@ export class RuntimeRemoteFetchController {
     baseBranch: string,
     gitOptions: GitOptions = {}
   ): Promise<RemoteTrackingBase | null> {
+    const remoteRefPrefix = 'refs/remotes/'
+    const shortBaseBranch = baseBranch.startsWith(remoteRefPrefix)
+      ? baseBranch.slice(remoteRefPrefix.length)
+      : baseBranch
+    // A remote-tracking base needs both a configured remote and a branch component.
+    if (!shortBaseBranch.includes('/')) {
+      return null
+    }
     let remotes: string[]
     try {
       const { stdout } = await gitExecFileAsync(['remote'], { cwd: repoPath, ...gitOptions })
@@ -236,10 +244,6 @@ export class RuntimeRemoteFetchController {
     } catch {
       return null
     }
-    const remoteRefPrefix = 'refs/remotes/'
-    const shortBaseBranch = baseBranch.startsWith(remoteRefPrefix)
-      ? baseBranch.slice(remoteRefPrefix.length)
-      : baseBranch
     const remote = remotes
       .filter((candidate) => shortBaseBranch.startsWith(`${candidate}/`))
       .sort((a, b) => b.length - a.length)[0]


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Worktree creation sometimes asks Git questions whose answers cannot affect the result. Skip those reads to reduce subprocess work.

## What Changed

- Return immediately when a base has no remote/branch separator.
- Stop GitHub identity probing after a successful empty remote list; preserve fallback probes when enumeration fails.

## Why

This is an independently mergeable subset of the technical work in #18793. It adds no speculative checkout, fetch, shell startup, or worker tuning.

## Linked Issue

User-requested worktree-create performance work, extracted from #18793; no separate issue supplied.

## Visual Proof

N/A — only redundant backend reads are removed; there is no visual or interaction change.

## Testing

- 53 tests passed in repo-username and fetch-remote-cache suites on macOS, including deterministic subprocess-count assertions and WSL routing cases.
- Full `pnpm tc`, changed-code quality, formatting, and commit hooks passed on main at `9f2a9a248e60` plus this change.
- CI will cover broader integration and packaging; no new live Windows/WSL/SSH run.

## Review

Independent native-agent review covered all eight readiness-checklist areas, followed by an elegance pass: zero proven findings and no required fixes. No mobile-facing surface touched. Existing Git commands, timeouts, provider routing, and failure behavior are preserved.

**Merge risk: low. User-facing negative trade-offs: none identified.** This is a subprocess reduction, not an end-to-end near-instant-create claim.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small and focused; self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, provider, and compatibility impact considered.
- [x] Automated tests and typecheck pass; CI covers broader build integration.
