### PR TITLE
perf(automations): reuse collation setup when sorting names

### DIFF
--- a/config/scripts/locale-collator-sort-benchmark.mjs
+++ b/config/scripts/locale-collator-sort-benchmark.mjs
@@ -3,10 +3,12 @@
 import { performance } from 'node:perf_hooks'
 import { fileURLToPath } from 'node:url'
 import { createJiti } from 'jiti'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
 
-const ROUND_COUNT = 5
+const ROUND_COUNT = 6
 const MIN_ROUND_MS = 120
 const jiti = createJiti(import.meta.url, {
+  jsx: true,
   alias: { '@': fileURLToPath(new URL('../../src/renderer/src', import.meta.url)) }
 })
 const { compareBaseSensitivityLocaleText } = await jiti.import(
@@ -15,6 +17,10 @@ const { compareBaseSensitivityLocaleText } = await jiti.import(
 const { sortJiraIssues } = await jiti.import(
   '../../src/renderer/src/components/jira-issue-sorter.ts'
 )
+const { sortAutomationListViewItems } = await jiti.import(
+  '../../src/renderer/src/components/automations/automation-list-view.ts'
+)
+const { getIntlLocale } = await jiti.import('../../src/renderer/src/i18n/i18n.ts')
 
 let randomState = 0x9e3779b9
 function random() {
@@ -83,20 +89,21 @@ function measurePair(before, after) {
   const afterIterations = calibrate(after)
   const beforeSamples = []
   const afterSamples = []
-  for (let round = 0; round < ROUND_COUNT; round += 1) {
-    if (round % 2 === 0) {
-      beforeSamples.push(measureRound(before, beforeIterations))
-      afterSamples.push(measureRound(after, afterIterations))
-    } else {
-      afterSamples.push(measureRound(after, afterIterations))
-      beforeSamples.push(measureRound(before, beforeIterations))
+  for (const pair of buildCounterbalancedSchedule(ROUND_COUNT, 'before', 'after')) {
+    for (const arm of pair) {
+      if (arm === 'before') {
+        beforeSamples.push(measureRound(before, beforeIterations))
+      } else {
+        afterSamples.push(measureRound(after, afterIterations))
+      }
     }
   }
-  const middle = Math.floor(ROUND_COUNT / 2)
-  return {
-    beforeMs: beforeSamples.sort((a, b) => a - b)[middle],
-    afterMs: afterSamples.sort((a, b) => a - b)[middle]
+  const median = (samples) => {
+    samples.sort((a, b) => a - b)
+    const middle = samples.length / 2
+    return (samples[middle - 1] + samples[middle]) / 2
   }
+  return { beforeMs: median(beforeSamples), afterMs: median(afterSamples) }
 }
 
 function assertSameOrder(before, after, label) {
@@ -111,7 +118,9 @@ function assertSameOrder(before, after, label) {
 }
 
 const pad = (value, width) => String(value).padStart(width)
-console.log('Renderer locale sort, ms per sort (median of 5 rounds). Lower is better.')
+console.log(
+  'Renderer locale sort, ms per sort (median of 6 counterbalanced rounds). Lower is better.'
+)
 console.log(
   `${pad('mode', 9)} ${pad('items', 7)} ${pad('per-call', 11)} ${pad('reused', 11)} ${pad('speedup', 9)}`
 )
@@ -144,4 +153,32 @@ for (const count of [10, 50, 250]) {
 
 console.log(
   '\n36 rows matches the Linear page size, 50 matches the picker/Jira scale, and\n250 is a stress case. Both arms assert identical output before timing.'
+)
+
+for (const count of [10, 100, 1000]) {
+  const items = makeBaseSensitivityValues(count).map((name, index) => ({
+    id: `automation-${index}`,
+    name,
+    lastRunAt: null
+  }))
+  const before = () => {
+    const locale = getIntlLocale()
+    function compare(left, right) {
+      return (
+        left.name.localeCompare(right.name, locale, { sensitivity: 'base' }) ||
+        left.id.localeCompare(right.id)
+      )
+    }
+    return [...items].sort(compare).map((item) => item.id)
+  }
+  const after = () =>
+    sortAutomationListViewItems(items, { field: 'name', direction: 'asc' }).map((item) => item.id)
+  assertSameOrder(before, after, `automation ${count}`)
+  const { beforeMs, afterMs } = measurePair(before, after)
+  console.log(
+    `${pad('automation', 10)} ${pad(count, 7)} ${pad(`${beforeMs.toFixed(3)} ms`, 11)} ${pad(`${afterMs.toFixed(3)} ms`, 11)} ${pad(`${(beforeMs / afterMs).toFixed(1)}x`, 9)}`
+  )
+}
+console.log(
+  'Automation arm calls the production sorter; 1000 rows is a scaling fixture, not a measured user inventory. No timing gate.'
 )

--- a/src/renderer/src/components/automations/automation-list-view-sort.test.ts
+++ b/src/renderer/src/components/automations/automation-list-view-sort.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  buildAutomationListViewItems,
+  sortAutomationListViewItems,
+  type AutomationListSort,
+  type AutomationListViewItem
+} from './automation-list-view'
+import { makeAutomation } from './automations-page-fixtures'
+
+const locale = vi.hoisted(() => ({ value: 'en' }))
+vi.mock('@/i18n/i18n', () => ({ getIntlLocale: () => locale.value }))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  locale.value = 'en'
+})
+
+function rows(count = 512): AutomationListViewItem[] {
+  const names = ['Alpha', 'álpha', 'Ångström', 'Zebra', 'Örebro', 'I', 'ı', 'İ', 'job 10', 'job 2']
+  return buildAutomationListViewItems({
+    automations: Array.from({ length: count }, (_, index) =>
+      makeAutomation({ id: `job-${index}`, name: names[(index * 7) % names.length] })
+    ),
+    externalEntries: [],
+    runs: []
+  })
+}
+
+function previousOrder(items: AutomationListViewItem[], sort: AutomationListSort) {
+  function compare(left: AutomationListViewItem, right: AutomationListViewItem) {
+    const value =
+      sort.field === 'name'
+        ? left.name.localeCompare(right.name, locale.value, { sensitivity: 'base' })
+        : (left.lastRunAt ?? 0) - (right.lastRunAt ?? 0)
+    return value !== 0
+      ? sort.direction === 'asc'
+        ? value
+        : -value
+      : left.id.localeCompare(right.id)
+  }
+  return [...items].sort(compare)
+}
+
+describe('automation list collation', () => {
+  it.each(['en', 'sv', 'tr', 'ja'])(
+    'preserves %s ordering, tie-breaks and input identity',
+    (language) => {
+      locale.value = language
+      const items = rows()
+      const original = [...items]
+      for (const direction of ['asc', 'desc'] as const) {
+        const sort = { field: 'name', direction } as const
+        const expected = previousOrder(items, sort)
+        const result = sortAutomationListViewItems(items, sort)
+        expect(result).toEqual(expected)
+        expect(result.every((row, index) => row === expected[index])).toBe(true)
+      }
+      expect(items).toEqual(original)
+    }
+  )
+
+  it('resolves collation once per name sort and responds to locale changes', () => {
+    const items = rows()
+    const OriginalCollator = Intl.Collator
+    const construct = vi.spyOn(Intl, 'Collator').mockImplementation(function (locales, options) {
+      return new OriginalCollator(locales, options)
+    })
+    const compare = vi.spyOn(String.prototype, 'localeCompare')
+    sortAutomationListViewItems(items, { field: 'name', direction: 'asc' })
+    locale.value = 'sv'
+    sortAutomationListViewItems(items, { field: 'name', direction: 'desc' })
+    expect(construct.mock.calls).toEqual([
+      ['en', { sensitivity: 'base' }],
+      ['sv', { sensitivity: 'base' }]
+    ])
+    expect(compare.mock.calls.filter((args) => args.length >= 3)).toHaveLength(0)
+  })
+
+  it('does not construct collation for unsorted, time-sorted or trivial lists', () => {
+    const items = rows()
+    const construct = vi.spyOn(Intl, 'Collator')
+    expect(sortAutomationListViewItems(items, null)).toEqual(items)
+    const sort = { field: 'lastRun', direction: 'desc' } as const
+    expect(sortAutomationListViewItems(items, sort)).toEqual(previousOrder(items, sort))
+    expect(sortAutomationListViewItems([], { field: 'name', direction: 'asc' })).toEqual([])
+    expect(
+      sortAutomationListViewItems(items.slice(0, 1), { field: 'name', direction: 'asc' })
+    ).toEqual(items.slice(0, 1))
+    expect(construct).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/automations/automation-list-view.ts
+++ b/src/renderer/src/components/automations/automation-list-view.ts
@@ -237,16 +237,18 @@ export function sortAutomationListViewItems(
   items: readonly AutomationListViewItem[],
   sort: AutomationListSort | null
 ): AutomationListViewItem[] {
-  if (!sort) {
+  if (!sort || items.length < 2) {
     return [...items]
   }
   const next = [...items]
-  const locale = getIntlLocale()
+  const compareNames =
+    sort.field === 'name'
+      ? new Intl.Collator(getIntlLocale(), { sensitivity: 'base' }).compare
+      : null
   next.sort((left, right) => {
-    const compared =
-      sort.field === 'name'
-        ? left.name.localeCompare(right.name, locale, { sensitivity: 'base' })
-        : (left.lastRunAt ?? 0) - (right.lastRunAt ?? 0)
+    const compared = compareNames
+      ? compareNames(left.name, right.name)
+      : (left.lastRunAt ?? 0) - (right.lastRunAt ?? 0)
     if (compared !== 0) {
       return sort.direction === 'asc' ? compared : -compared
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 |

<!-- /orca-pr-loc -->

Automation-name sorting resolved collation options for every comparison. Reuse one `Intl.Collator` per name sort, using the current UI locale each time. Preserve direction, ID tie-breaks, input row identities and input immutability; unsorted, time-sorted and trivial lists avoid collation setup.

Found by the source audit in #18822. This PR is independently based on main. It extends the existing locale-sort benchmark to call the production automation sorter, enables JSX for its real import graph, and uses six counterbalanced rounds with an even-sample median.

Measured on macOS arm64 / Node 24.18.0 (milliseconds per sort):

| Rows | Previous | Candidate |
| --- | ---: | ---: |
| 10 | 0.039 | 0.004 |
| 100 | 0.952 | 0.040 |
| 1,000 | 14.603 | 0.628 |

The 1,000-row case is a scaling fixture, not a measured user inventory. These are sorter timings, not end-to-end UI latency. Both benchmark arms assert identical output; there is no hardware-dependent timing gate.

Validation: 16 tests across the existing list-view suite and six new regressions; the operation-count test fails on the original implementation. Differential checks cover English, Swedish, Turkish and Japanese, both directions and ties; the count oracle verifies one constructor per sort and zero optioned `localeCompare` calls. `pnpm tc:web`, changed-code quality and formatting passed. Run `node config/scripts/locale-collator-sort-benchmark.mjs` to reproduce. Sorting remains client-side for local and external automation rows; no wire, host-execution, Git-provider or workspace identity changes.
