### PR TITLE
fix(native-chat): stop a settling handoff throwing an unhandled rejection at teardown

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-flow-runner.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-flow-runner.test.ts
@@ -20,79 +20,111 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
+const fields = { direction: 'to-native' as const, mode: 'now' as const, action: 'retry' as const }
+
+const params: AgentSessionHandoffRequest = {
+  envelope: {
+    sessionId: SESSION,
+    clientOperationId: OPERATION,
+    expectedRuntimeFence: null,
+    payloadFingerprint: computeAgentSessionPayloadFingerprint({
+      method: 'agentSession.requestHandoff',
+      sessionId: SESSION,
+      fields
+    })
+  },
+  ...fields
+}
+
+/** A runner whose scheduled flow always rejects, so every case here exercises the failure path. */
+async function failingFlowRunner(
+  fail: (params: AgentSessionHandoffRequest, error: unknown) => void
+): Promise<{
+  runner: StructuredAgentSessionHandoffFlowRunner
+  store: AgentSessionRecordStore
+  root: string
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-handoff-flow-runner-'))
+  roots.push(root)
+  const store = await AgentSessionRecordStore.open({
+    directory: join(root, 'store'),
+    hostId: 'local'
+  })
+  const journal = await openAgentSessionJournal({
+    identity: {
+      sessionId: SESSION,
+      workspaceId: 'workspace-1',
+      hostId: 'local',
+      agent: 'codex',
+      providerHandle: { kind: 'codex', threadId: THREAD }
+    },
+    journalDir: join(root, 'journal')
+  })
+  const runner = new StructuredAgentSessionHandoffFlowRunner({
+    deps: {
+      store,
+      claimKeyId: 'key-1',
+      session: () => ({ journal, fence: 1 }),
+      suspendNative: async () => ({ state: 'stopped' as const }),
+      acquireNative: async () => {
+        throw new Error('unused')
+      },
+      importTuiHistory: async () => {},
+      publish: () => {},
+      schedule: async () => {
+        throw new Error('scheduling failed')
+      },
+      now: () => NOW
+    },
+    operationGuard: new StructuredAgentSessionHandoffOperationGuard(store),
+    flowContext: (): StructuredAgentSessionHandoffFlowContext => {
+      throw new Error('unreachable: scheduling rejects before the flow needs context')
+    },
+    fail
+  })
+  return { runner, store, root }
+}
+
 describe('structured handoff flow runner outcome-write failure', () => {
   it('still reports the flow failure when the failed-outcome ledger write throws', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'orca-handoff-flow-runner-'))
-    roots.push(root)
-    const store = await AgentSessionRecordStore.open({
-      directory: join(root, 'store'),
-      hostId: 'local'
-    })
-    // Materialize the store file so its later disappearance reads as corruption,
-    // making every subsequent ledger write reject.
+    const failures: unknown[] = []
+    const { runner, store, root } = await failingFlowRunner(
+      (_params, error) => void failures.push(error)
+    )
+    // Materialize the store file so its later disappearance reads as corruption, making every
+    // subsequent ledger write reject.
     await store.admitOperation({
       callerKey: 'seed',
       operationId: `${NOW}-00000000000000000000000000000009`,
       fingerprint: 'seed',
       now: NOW
     })
-    const journal = await openAgentSessionJournal({
-      identity: {
-        sessionId: SESSION,
-        workspaceId: 'workspace-1',
-        hostId: 'local',
-        agent: 'codex',
-        providerHandle: { kind: 'codex', threadId: THREAD }
-      },
-      journalDir: join(root, 'journal')
-    })
     await rm(join(root, 'store'), { recursive: true, force: true })
-    const failures: unknown[] = []
-    const fields = {
-      direction: 'to-native' as const,
-      mode: 'now' as const,
-      action: 'retry' as const
-    }
-    const params: AgentSessionHandoffRequest = {
-      envelope: {
-        sessionId: SESSION,
-        clientOperationId: OPERATION,
-        expectedRuntimeFence: null,
-        payloadFingerprint: computeAgentSessionPayloadFingerprint({
-          method: 'agentSession.requestHandoff',
-          sessionId: SESSION,
-          fields
-        })
-      },
-      ...fields
-    }
-    const runner = new StructuredAgentSessionHandoffFlowRunner({
-      deps: {
-        store,
-        claimKeyId: 'key-1',
-        session: () => ({ journal, fence: 1 }),
-        suspendNative: async () => ({ state: 'stopped' as const }),
-        acquireNative: async () => {
-          throw new Error('unused')
-        },
-        importTuiHistory: async () => {},
-        publish: () => {},
-        schedule: async () => {
-          throw new Error('scheduling failed')
-        },
-        now: () => NOW
-      },
-      operationGuard: new StructuredAgentSessionHandoffOperationGuard(store),
-      flowContext: (): StructuredAgentSessionHandoffFlowContext => {
-        throw new Error('unreachable: scheduling rejects before the flow needs context')
-      },
-      fail: (_params, error) => {
-        failures.push(error)
-      }
-    })
+
     runner.begin({ callerKey: 'client-1', params, turnId: null, fingerprint: 'fp' })
     await runner.drain()
+
     expect(failures).toHaveLength(1)
     expect((failures[0] as Error).message).toBe('scheduling failed')
+  })
+
+  it('does not leak an unhandled rejection when the failure notification itself throws', async () => {
+    // The host's status publish threw exactly here once eviction had dropped the session.
+    const { runner } = await failingFlowRunner(() => {
+      throw new Error('agent_session_ownership_unknown')
+    })
+    const leaked: unknown[] = []
+    const observe = (reason: unknown): void => void leaked.push(reason)
+    process.on('unhandledRejection', observe)
+    try {
+      runner.begin({ callerKey: 'client-1', params, turnId: null, fingerprint: 'fp' })
+      await runner.drain()
+      // Node reports an orphaned rejection on the tick after it settles.
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    } finally {
+      process.off('unhandledRejection', observe)
+    }
+
+    expect(leaked).toEqual([])
   })
 })

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-flow-runner.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-handoff-flow-runner.ts
@@ -28,7 +28,11 @@ export class StructuredAgentSessionHandoffFlowRunner {
 
   track(task: Promise<void>): void {
     this.active.add(task)
-    void task.finally(() => this.active.delete(task))
+    // Settle-only bookkeeping. `.finally` forwards a rejection onto a promise nobody awaits, so a
+    // failure notification that threw escaped as an unhandled rejection even though `drain` — the
+    // one consumer — settles the flow through `allSettled`.
+    const forget = (): void => void this.active.delete(task)
+    void task.then(forget, forget)
   }
 
   begin(input: {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.test.ts
@@ -6,12 +6,14 @@ import type {
   AgentSessionExecutionLocation,
   AgentSessionRecord
 } from '../../../shared/agent-session-record'
+import type { AgentSessionHandoffStatus } from '../../../shared/agent-session-wire'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
 import { createTrackedJournalOpener } from '../agent-session-journal/journal-store-test-open'
 import { createDeferredStructuredAgentSessionEventSink } from './structured-agent-session-event-sink'
 import {
   acquireNativeHandoffOwner,
+  createStructuredAgentSessionHostHandoff,
   structuredTuiTranscriptImportOptions
 } from './structured-agent-session-host-handoff'
 
@@ -173,6 +175,7 @@ describe('native handoff acquisition', () => {
       },
       {
         session: () => session,
+        findSession: () => session,
         eventSink: () => eventSink,
         flush: async () => undefined,
         serialize: async (_session, task) => task(),
@@ -198,5 +201,93 @@ describe('native handoff acquisition', () => {
     await acquiring
 
     expect(order).toEqual(['append-entered', 'append-complete', 'unbind', 'acquire'])
+  })
+})
+
+describe('handoff status published for a session the host no longer holds', () => {
+  const sessionId = 'session-handoff-publish-detached'
+  const now = 1_800_000_000_000
+  const failed: AgentSessionHandoffStatus = {
+    owner: 'native',
+    direction: 'to-tui',
+    phase: 'failed',
+    stage: null,
+    operationId: null
+  }
+  let root: string
+  let store: AgentSessionRecordStore
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-handoff-publish-'))
+    store = await AgentSessionRecordStore.open({ directory: join(root, 'store'), hostId: 'local' })
+  })
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true })
+  })
+
+  function detachedHandoff(frames: { fence: number; status: AgentSessionHandoffStatus }[]) {
+    return createStructuredAgentSessionHostHandoff(
+      { store, adapter: {} as never, journalRoot: root, claimKeyId: 'key-1' },
+      {
+        // Eviction and host teardown both drop the map entry while a flow is still settling.
+        session: () => {
+          throw new Error('agent_session_ownership_unknown')
+        },
+        findSession: () => undefined,
+        eventSink: () => {
+          throw new Error('unreachable: publishing reads no sink')
+        },
+        flush: async () => undefined,
+        serialize: async (_sessionId, task) => task(),
+        subscribers: {
+          publish: vi.fn(),
+          reset: vi.fn(),
+          snapshot: vi.fn(),
+          handoff: (_id: string, fence: number, status: AgentSessionHandoffStatus) =>
+            void frames.push({ fence, status })
+        } as never,
+        now: () => now
+      }
+    )
+  }
+
+  it('still reaches subscribers at the record fence instead of throwing', async () => {
+    const reserved = await store.reserveOwner({
+      sessionId,
+      location: {
+        executionHostId: LOCAL_EXECUTION_HOST_ID,
+        wslDistro: null,
+        workspaceId: 'workspace-1',
+        workspaceKind: 'git-worktree'
+      },
+      provider: 'codex',
+      accountHome: { variable: 'CODEX_HOME', path: join(root, 'codex-home') },
+      runtimeKind: 'native',
+      expectedFence: null,
+      spawnToken: 'detached-publish',
+      claimKeyId: 'key-1',
+      handoffOperationId: `${now}-00000000000000000000000000000001`,
+      probe: { outcome: 'reservation-unused' },
+      operation: {
+        callerKey: 'test',
+        operationId: `${now}-00000000000000000000000000000002`,
+        fingerprint: 'handoff'
+      },
+      now
+    })
+    const frames: { fence: number; status: AgentSessionHandoffStatus }[] = []
+
+    expect(() => detachedHandoff(frames).setStatus(sessionId, failed)).not.toThrow()
+
+    expect(frames).toEqual([{ fence: reserved.record.lease.runtimeFence, status: failed }])
+  })
+
+  it('drops the publish when neither a session nor a record remains', () => {
+    const frames: { fence: number; status: AgentSessionHandoffStatus }[] = []
+
+    expect(() => detachedHandoff(frames).setStatus(sessionId, failed)).not.toThrow()
+
+    expect(frames).toEqual([])
   })
 })

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-handoff.ts
@@ -17,6 +17,8 @@ import { StructuredTuiTranscriptCatchup } from './structured-tui-transcript-catc
 
 type HostHandoffAccess = {
   session: (sessionId: string) => StructuredAgentSessionHostSession
+  /** Non-throwing lookup, for the paths that only observe a detached session. */
+  findSession: (sessionId: string) => StructuredAgentSessionHostSession | undefined
   eventSink: (sessionId: string) => DeferredStructuredAgentSessionEventSink
   flush: (sessionId: string) => Promise<void>
   serialize: (sessionId: string, task: () => Promise<void>) => Promise<void>
@@ -95,8 +97,14 @@ export function createStructuredAgentSessionHostHandoff(
     activateTuiHistoryCatchup: (sessionId) => tuiHistoryCatchup.activate(sessionId),
     stopTuiHistoryCatchup: (sessionId) => tuiHistoryCatchup.stop(sessionId),
     publish: (sessionId, status) => {
-      const session = host.session(sessionId)
-      const fence = deps.store.getRecord(sessionId)?.lease.runtimeFence ?? session.fence
+      // A status publish is a notification, not a mutation. Eviction and host teardown both drop
+      // the session while a handoff flow is still settling, and `requireSession` would turn that
+      // last publish — usually the FAILED one — into an unhandled rejection nothing can catch.
+      const fence =
+        deps.store.getRecord(sessionId)?.lease.runtimeFence ?? host.findSession(sessionId)?.fence
+      if (fence === undefined) {
+        return
+      }
       host.subscribers.handoff(sessionId, fence, status)
     },
     schedule: host.serialize,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -59,7 +59,11 @@ import type {
 } from './structured-agent-session-host-types'
 import { StructuredAgentSessionEventRecovery } from './structured-agent-session-event-recovery'
 import { StructuredAgentSessionBackgroundTaskChannel } from './structured-agent-session-background-task-channel'
+import { withTimeout } from '../../../shared/promise-timeout-fallback'
 export type { StructuredAgentSessionHostDeps } from './structured-agent-session-host-types'
+/** Quit must not wait indefinitely on an in-flight handoff; see the drain phase below. */
+const HANDOFF_DRAIN_TIMEOUT_MS = 5_000
+
 export class StructuredAgentSessionHost {
   private readonly sessions = new Map<string, StructuredAgentSessionHostSession>()
   private readonly subscribers = new AgentSessionSubscribers()
@@ -261,7 +265,13 @@ export class StructuredAgentSessionHost {
         { name: 'stop-tui-catchup', run: () => this.handoffs.stopTuiHistoryCatchup() },
         // Before the session map is dropped: a handoff flow left running writes rows into a
         // journal this teardown is about to close, and publishes against a session it removed.
-        { name: 'drain-handoffs', run: () => this.handoffs.drain() },
+        // Why bounded: this phase is on the app-quit path, and a flow wedged in `launchTui` would
+        // otherwise hold the quit open forever. Giving up merely restores the old orphaning, which
+        // the publish guard above already makes survivable.
+        {
+          name: 'drain-handoffs',
+          run: () => withTimeout(this.handoffs.drain(), HANDOFF_DRAIN_TIMEOUT_MS, undefined)
+        },
         { name: 'drain-attaches', run: () => this.tasks.drainAttaches() },
         { name: 'flush-event-sinks', run: () => this.runtimeState.flushAllEventSinks() }
       ],

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -100,6 +100,7 @@ export class StructuredAgentSessionHost {
     })
     this.handoffs = createStructuredAgentSessionHostHandoff(deps, {
       session: (sessionId) => this.requireSession(sessionId),
+      findSession: (sessionId) => this.sessions.get(sessionId),
       eventSink: (sessionId) => this.runtimeState.eventSinkFor(sessionId),
       flush: (sessionId) => this.flushStreamedEvents(sessionId),
       serialize: (sessionId, task) => this.serialize(sessionId, task),
@@ -258,6 +259,9 @@ export class StructuredAgentSessionHost {
         { name: 'dispose-holds', run: () => this.holds.dispose() },
         { name: 'stop-lease-renewal', run: () => this.runtimeState.stopLeaseRenewal() },
         { name: 'stop-tui-catchup', run: () => this.handoffs.stopTuiHistoryCatchup() },
+        // Before the session map is dropped: a handoff flow left running writes rows into a
+        // journal this teardown is about to close, and publishes against a session it removed.
+        { name: 'drain-handoffs', run: () => this.handoffs.drain() },
         { name: 'drain-attaches', run: () => this.tasks.drainAttaches() },
         { name: 'flush-event-sinks', run: () => this.runtimeState.flushAllEventSinks() }
       ],

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-teardown-handoff-drain.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-teardown-handoff-drain.test.ts
@@ -1,0 +1,149 @@
+// Host teardown against a handoff that has not finished switching owners.
+//
+// The flow runs on the session's serialized chain and nothing else awaits it, so a teardown that
+// only flushed sinks left it writing into a journal it had just closed — and publishing a status
+// against a session it had just dropped, which surfaced as an unhandled rejection.
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
+import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
+import { StructuredAgentSessionHost } from './structured-agent-session-host'
+import {
+  HOST_TEST_NOW as NOW,
+  HOST_TEST_SESSION as SESSION,
+  HOST_TEST_THREAD as THREAD,
+  hostTestAttachParams,
+  hostTestOperationId,
+  resetHostTestOperationIds
+} from './structured-agent-session-host-test-data'
+import { StructuredHandoffTestRequests } from './structured-agent-session-handoff-test-requests'
+import type {
+  StructuredAgentSessionHandoffTransport,
+  StructuredTuiOwner
+} from './structured-agent-session-handoff-types'
+
+const CALLER = { callerKey: 'client-1' }
+
+let root: string
+let store: AgentSessionRecordStore
+let host: StructuredAgentSessionHost
+let launchEntered: PromiseWithResolvers<void>
+let launchGate: PromiseWithResolvers<void>
+
+const requests = new StructuredHandoffTestRequests(
+  NOW,
+  SESSION,
+  () => store.getRecord(SESSION)?.lease.runtimeFence ?? 0
+)
+
+function tuiOwner(fence: number, spawnToken: string): StructuredTuiOwner {
+  return {
+    terminal: { handle: 'term-tui', tabId: 'tab-tui', paneKey: 'pane-tui', ptyId: 'pty-tui' },
+    process: { hostId: 'local', pid: 5200, processStartTimeMs: NOW, spawnToken },
+    link: {
+      linkId: `tui-link-${fence}`,
+      handle: { provider: 'codex', threadId: THREAD },
+      origin: 'resumed',
+      mintedAtFence: fence,
+      observedAt: NOW
+    }
+  }
+}
+
+function gatedTransport(): StructuredAgentSessionHandoffTransport {
+  return {
+    hostLabel: 'Test host',
+    launchTui: async ({ fence, spawnToken }) => {
+      launchEntered.resolve()
+      await launchGate.promise
+      return tuiOwner(fence, spawnToken)
+    },
+    reproveTuiOwner: async ({ owner }) => owner,
+    recoverTuiOwner: async (record) =>
+      tuiOwner(record.lease.runtimeFence, record.lease.reservedSpawnToken ?? 'recovered'),
+    stopRecoveredOwner: async () => undefined,
+    closeTuiOwner: async (owner) => ({ transcriptPath: owner.transcriptPath }),
+    waitForTuiExit: async (owner) => ({ transcriptPath: owner.transcriptPath }),
+    waitForTuiIdleOrExit: async () => 'idle',
+    tuiStatus: () => 'idle'
+  }
+}
+
+function adapter(): StructuredAgentSessionAdapter {
+  return {
+    acquire: vi.fn(async ({ fence, spawnToken }) => ({
+      process: { hostId: 'local', pid: 4242, processStartTimeMs: NOW, spawnToken },
+      link: {
+        linkId: `native-link-${fence}`,
+        handle: { provider: 'codex' as const, threadId: THREAD },
+        origin: 'created' as const,
+        mintedAtFence: fence,
+        observedAt: NOW
+      }
+    })),
+    dispatchTurn: vi.fn(async () => ({ state: 'accepted' as const })),
+    cancelTurn: vi.fn(async () => ({ cancelled: true })),
+    answerPrompt: vi.fn(async () => undefined),
+    setOption: vi.fn(async () => undefined),
+    closeSession: vi.fn(async () => true),
+    supportsCreate: () => true,
+    supportsRecord: () => true
+  } as unknown as StructuredAgentSessionAdapter
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-teardown-handoff-drain-'))
+  resetHostTestOperationIds()
+  launchEntered = Promise.withResolvers<void>()
+  launchGate = Promise.withResolvers<void>()
+  store = await AgentSessionRecordStore.open({ directory: join(root, 'store'), hostId: 'local' })
+  host = new StructuredAgentSessionHost({
+    store,
+    adapter: adapter(),
+    journalRoot: root,
+    claimKeyId: 'key-1',
+    mintSpawnToken: () => 'spawn-native',
+    handoffTransport: gatedTransport(),
+    now: () => NOW
+  })
+  expect(await host.attach(CALLER, hostTestAttachParams(null))).toMatchObject({ ok: true })
+})
+
+afterEach(async () => {
+  launchGate.resolve()
+  await host.flushAllStreamedEvents()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('structured agent-session host teardown', () => {
+  it('waits for an in-flight handoff before dropping the session it is switching', async () => {
+    // One operation-id source with attach, so the durable ledger sees no duplicate.
+    const request = requests.request('to-tui', 'now', { operationId: hostTestOperationId() })
+    expect(await host.requestHandoff(CALLER, request)).toMatchObject({ ok: true })
+    await launchEntered.promise
+
+    let settled = false
+    const teardown = host.flushAllStreamedEvents().then(() => {
+      settled = true
+    })
+    // Quiescence probe, not a wait for the flow: teardown must still be blocked on it.
+    for (let tick = 0; tick < 20; tick += 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    }
+    expect(settled).toBe(false)
+
+    launchGate.resolve()
+    await teardown
+
+    // The new owner was proven while the session was still indexed, not after it vanished.
+    expect(store.getRecord(SESSION)?.lease).toMatchObject({
+      runtimeKind: 'tui',
+      claimStatus: 'live',
+      handoffStage: null
+    })
+    expect(host.hasSession(SESSION)).toBe(false)
+  })
+})

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-teardown-handoff-drain.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-teardown-handoff-drain.test.ts
@@ -146,4 +146,20 @@ describe('structured agent-session host teardown', () => {
     })
     expect(host.hasSession(SESSION)).toBe(false)
   })
+
+  it('gives up on a wedged handoff instead of holding the quit open', async () => {
+    const request = requests.request('to-tui', 'now', { operationId: hostTestOperationId() })
+    expect(await host.requestHandoff(CALLER, request)).toMatchObject({ ok: true })
+    await launchEntered.promise
+
+    // The gate is never opened: this is the flow that never comes back.
+    vi.useFakeTimers()
+    try {
+      const teardown = host.flushAllStreamedEvents()
+      await vi.advanceTimersByTimeAsync(5_000)
+      await expect(teardown).resolves.toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/runtime/claude-structured-session-integration.test.ts
+++ b/src/main/runtime/claude-structured-session-integration.test.ts
@@ -707,9 +707,10 @@ describe('a structured Claude session over agentSession.*', () => {
 
     await ok('agentSession.requestHandoff', handoffParams('to-tui', created.fence))
     const host = getStructuredAgentSessionHost()!
-    await vi.waitFor(async () =>
-      expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'tui', phase: 'idle' })
-    )
+    // No poll: the request enqueues the flow on the session's serialized chain before it returns,
+    // so this status read is already ordered behind it. Polling only added a wall-clock deadline
+    // that a loaded runner missed, abandoning a live flow into the suite's teardown.
+    expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'tui', phase: 'idle' })
     expect(claude.connections[0]?.closed).toBe(true)
 
     const tuiFence = (
@@ -719,9 +720,7 @@ describe('a structured Claude session over agentSession.*', () => {
     ).deps.store.getRecord(SESSION).lease.runtimeFence
     readClaudeTranscriptLeafUuid.mockResolvedValueOnce('tui-assistant')
     await ok('agentSession.requestHandoff', handoffParams('to-native', tuiFence))
-    await vi.waitFor(async () =>
-      expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'native', phase: 'idle' })
-    )
+    expect(await host.handoffStatus(SESSION)).toMatchObject({ owner: 'native', phase: 'idle' })
 
     const frames = await subscribe()
     const texts = itemsOf(frames).map(textOf).filter(Boolean)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​354 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​67 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​287 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

`claude-structured-session-integration.test.ts` fails in CI shard `test / tests node 24 3/8` ("completes a scripted native to TUI to native cycle with provider-history rehydration") with three linked symptoms: `Timed out in waitFor!`, an unhandled `agent_session_ownership_unknown`, and `ENOTEMPTY` in teardown. Present on main — it reproduced on a control PR of main plus one no-op line.

## Cause

`vi.waitFor` was never polling. `requestHandoff` enqueues the flow on the session's serialized chain before it returns (`schedule: host.serialize`, `structured-agent-session-host-handoff.ts:57`), and `handoffStatus` serializes on that same chain — so the first call *blocks*, and `vi.waitFor`'s 1 s default became a hard deadline on a multi-fsync durable flow that costs ~185 ms locally. A loaded runner exceeds it.

Expiring that deadline abandoned a **live** flow into `afterEach`, which cleared `host.sessions`. The orphaned flow then failed, and its failure notification threw: `publish` → `host.session()` → `requireSession` → `agent_session_ownership_unknown`. `FlowRunner.track` used `void task.finally(...)`, which forwards that rejection onto a promise nobody awaits. The un-drained flow kept writing journal rows into the temp dir mid-`rm`, giving the `ENOTEMPTY`.

Three of the four defects are production bugs, each reachable in the app — `host.close()` on last-hold release and app-quit teardown both drop a session while a handoff is in flight.

## Fix

| Location | Change |
|---|---|
| `structured-agent-session-host-handoff.ts:99-108` | `publish` resolves the fence via the record, falling back to a non-throwing `findSession`, and no-ops when neither exists. A status publish is a notification; a vanished session must not make it throw. |
| `structured-agent-session-handoff-flow-runner.ts:29-36` | `track` is settle-only (`then(forget, forget)`) rather than `.finally`, so bookkeeping cannot resurface a rejection. `drain` already settles via `allSettled`. |
| `structured-agent-session-host.ts:270` | New `drain-handoffs` teardown phase before the session map is dropped. `drain()` existed but was **never wired into production** — only tests called it. **Bounded** at 5s via the existing `withTimeout` helper, because this sits on the app-quit path and a flow wedged in `launchTui` would otherwise hold quit open forever; giving up merely restores the old orphaning, which the publish guard now makes survivable. |
| `claude-structured-session-integration.test.ts:708-723` | Both `vi.waitFor` wrappers removed — **not** widened, no retry or sleep. The assertions are unchanged; only the redundant poll and its deadline are gone. |

## Verification

Every test below was verified to fail with its source fix reverted, then restored:
- `structured-agent-session-host-handoff.test.ts` — 2 new tests; without the publish fix both fail with `agent_session_ownership_unknown`.
- `structured-agent-session-handoff-flow-runner.test.ts` — leaked-rejection test; fails without the `track` fix.
- `structured-agent-session-teardown-handoff-drain.test.ts` — new file. `waits for an in-flight handoff…` fails without the drain phase (and reproduces the `ENOTEMPTY`); `gives up on a wedged handoff…` **hangs to the 30s test timeout** without the bound, which is exactly the quit-hang it guards.

Plus: `src/main/native-chat/agent-session-wire` + `src/main/runtime` 644 files / 6,732 tests pass; target file 5/5 consecutive clean runs; `pnpm tc`, oxlint and the changed-code quality gate clean.

## Known, not fixed here

A **second, unrelated flake in the same file**, present on main before and after this change: `routes a published Claude first-hand exit through fenced host reconciliation` failed 9/24 under 8x local concurrency both pre- and post-fix (`claimStatus` stays `live`, expected `released`). Same class — a bounded poll at `:526-534` racing the adapter-exit recovery chain — but the barrier is the runtime's `waitForRecovery()`, which the test has no handle on. Out of scope here; deserves its own fix.