### PR TITLE
fix(claude): make the recovery barrier cover an exit still climbing the close ladder

### DIFF
--- a/src/main/claude/claude-structured-session-adapter.ts
+++ b/src/main/claude/claude-structured-session-adapter.ts
@@ -91,9 +91,35 @@ export class ClaudeStructuredSessionAdapter implements StructuredAgentSessionAda
       closePromise
     }
     this.exits.set(sessionId, exit)
-    void closePromise
+    exit.publication = closePromise
       .then((proven) => (proven ? this.settleUnexpectedExit(sessionId, exit) : undefined))
       .catch(() => undefined)
+  }
+
+  /** Resolves once every first-hand exit observed so far has published its
+   *  lifecycle event — or has failed its tree proof and stayed indexed for a
+   *  retry. Publication trails observation by the close ladder and the
+   *  transcript cursor write, so nothing outside can otherwise tell the two
+   *  apart without guessing at wall-clock. */
+  drainObservedExits = async (): Promise<void> => {
+    const awaited = new Set<Promise<void>>()
+    for (;;) {
+      const pending = [...this.exits.values()]
+        .map((exit) => exit.publication)
+        .filter(
+          (publication): publication is Promise<void> =>
+            publication !== undefined && !awaited.has(publication)
+        )
+      if (pending.length === 0) {
+        return
+      }
+      for (const publication of pending) {
+        awaited.add(publication)
+      }
+      // A publication can settle an exit that itself observes another; only the
+      // ones this pass has not already awaited keep the loop going.
+      await Promise.all(pending)
+    }
   }
 
   /** Lifecycle recovery is published only after the child tree proof is true. */

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -162,6 +162,9 @@ export type ClaudeSessionExit = {
   closePromise?: Promise<boolean>
   /** Shared lifecycle settlement for concurrent proof retries. */
   settlementPromise?: Promise<void>
+  /** The whole ladder-then-settle tail, retained so a barrier can await an exit
+   *  that is observed but not yet published. Never rejects. */
+  publication?: Promise<void>
 }
 
 export type ClaudeAcquisitionAttempt = {

--- a/src/main/runtime/claude-structured-session-integration.test.ts
+++ b/src/main/runtime/claude-structured-session-integration.test.ts
@@ -30,7 +30,8 @@ import { RpcDispatcher } from './rpc/dispatcher'
 import { STRUCTURED_AGENT_SESSION_METHODS } from './rpc/methods/structured-agent-session'
 import {
   ensureStructuredAgentSessionHost,
-  stopStructuredAgentSessionRuntime
+  stopStructuredAgentSessionRuntime,
+  waitForStructuredAgentSessionRecovery
 } from './structured-agent-session-runtime'
 
 const SESSION = 'claude-integration-1'
@@ -524,13 +525,9 @@ describe('a structured Claude session over agentSession.*', () => {
     connection.exitVerdict = { root: 'exited', tree: 'unverifiable' }
     connection.handlers.onExit?.(new Error('claude stream-json exited (code 1): crashed'))
 
-    for (
-      let attempt = 0;
-      attempt < 20 && leaseOf(SESSION).claimStatus !== 'released';
-      attempt += 1
-    ) {
-      await new Promise((resolve) => setTimeout(resolve, 5))
-    }
+    // Claude publishes an exit only after its close ladder and transcript write,
+    // so the recovery barrier — not a wall-clock poll — is what says it landed.
+    await waitForStructuredAgentSessionRecovery()
     expect(leaseOf(SESSION)).toMatchObject({ claimStatus: 'released', handoffStage: null })
   })
 

--- a/src/main/runtime/structured-agent-session-runtime.ts
+++ b/src/main/runtime/structured-agent-session-runtime.ts
@@ -83,7 +83,8 @@ export type StructuredAgentSessionRuntimeDeps = {
 type InstalledRuntime = {
   host: StructuredAgentSessionHost
   adapter: { closeAll(): Promise<void> }
-  /** Resolves after every adapter-exit recovery callback has settled. */
+  /** Resolves after every observed adapter exit has published, and every
+   *  recovery callback it raised has settled. */
   waitForRecovery: () => Promise<void>
 }
 
@@ -111,6 +112,17 @@ export function ensureStructuredAgentSessionHost(
     throw error
   })
   return installing.then((installed) => installed.host)
+}
+
+/** Resolves once every provider exit observed so far has been published by its
+ *  adapter and reconciled by the host. Nothing is installed, nothing to wait on.
+ *
+ *  This is the only handle onto that barrier: reconciliation is driven by exit
+ *  callbacks, so a caller that needs the settled lease — rather than the one the
+ *  exit is still being reconciled out of — has no other way to know it landed. */
+export async function waitForStructuredAgentSessionRecovery(): Promise<void> {
+  const installed = await installing?.catch(() => null)
+  await installed?.waitForRecovery()
 }
 
 /** Drops the host and reaps every Codex child under it. Runtime teardown and
@@ -284,6 +296,10 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
         // A recovery may synchronously trigger another exit while it is
         // reacquiring. Observe until the chain stops growing.
         for (;;) {
+          // Claude reaches the chain only once its close ladder and transcript
+          // write publish the exit, so an observed death is not yet a chained
+          // one. Codex publishes inside its own exit callback and needs nothing.
+          await claude.drainObservedExits()
           const observed = recoveryChain
           await observed
           if (observed === recoveryChain) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |

<!-- /orca-pr-loc -->

`claude-structured-session-integration.test.ts` → `routes a published Claude first-hand exit through fenced host reconciliation` fails **19/24 under 16x local concurrency** on main (`claimStatus` stays `live`, expected `released`). It has not been seen in CI yet; it was found under deliberate load while fixing #18824.

## Root cause — a missing barrier, not a short poll

Instrumenting the two stages between `onExit()` and the lease release, under 16x load:

| Stage | Cost |
|---|---|
| 1. adapter publishes the exit | **77–204 ms** |
| 2. host reconciles it | ~15–25 ms |

Against the test's 100 ms poll budget — and essentially all of it is stage 1, which was unobservable from outside `ClaudeStructuredSessionAdapter`.

Claude does not publish an exit where it observes one. `handleExit` (`claude-structured-session-adapter.ts:77`) re-enters the connection's close ladder and persists the transcript cursor, and only *then* emits `ended` — the emission that reaches the runtime's `recoveryChain`. That tail was fire-and-forget (`void closePromise.then(...)`), so nothing could await it.

**This is a production defect, not just a test problem.** `structured-agent-session-runtime.ts:153` calls `waitForRecovery()` under the comment *"Drain an in-flight recovery before stopping children"* — but for an exit still climbing the ladder that call returned immediately, so the barrier missed exactly the window it was written for. Teardown survived only incidentally, because the later `adapter.closeAll()` drains `exits` via `releaseClaudeAcquisition`.

Note that simply exposing `waitForRecovery()` would **not** have fixed this — it would have returned in ~0 ms. Codex needs nothing: `handleCodexSessionExit` emits `ended` synchronously inside its exit callback, so `recoveryChain` is already complete there.

## Fix

- `claude-structured-session-state.ts:165` — retain `publication` on `ClaudeSessionExit`.
- `claude-structured-session-adapter.ts:94` — keep the ladder-then-settle tail instead of discarding it; new `drainObservedExits()` awaits every observed-but-unpublished exit, as a fixpoint over an `awaited` set so a failed tree proof that stays indexed cannot spin.
- `structured-agent-session-runtime.ts:299` — fold the drain into `waitForRecovery`'s existing fixpoint loop.
- `structured-agent-session-runtime.ts:116` — export `waitForStructuredAgentSessionRecovery()`.
- `claude-structured-session-integration.test.ts:528` — the 20x5 ms poll becomes `await waitForStructuredAgentSessionRecovery()`. No timeout, no sleep, no retry.

## Verification

| Condition | Result |
|---|---|
| Before, 24 runs @ 16x | **19/24 failed** |
| After, 24 runs @ 16x | 0/24 (twice) |
| After, 32 runs @ 24x | 0/32 |
| Source fix removed, 24 runs @ 16x | 24/24 failed |
| **Source fix removed, single run, idle machine** | **fails deterministically** |

That last row is the point: the fix converts a load-dependent flake into a hard check — I confirmed it independently by deleting the `drainObservedExits()` call and watching the test fail in 121 ms on an idle machine with `claimStatus: 'live'`.

Also: `src/main/native-chat/agent-session-wire` + `src/main/runtime` — 6,736 pass, 0 fail. `pnpm tc`, oxlint and the changed-code quality gate clean.