### PR TITLE
feat(native-chat): parse Cursor CLI transcripts in Chat UI

### DIFF
--- a/docs/site/content/docs/agents/cursor-cli.mdx
+++ b/docs/site/content/docs/agents/cursor-cli.mdx
@@ -2,7 +2,7 @@
 title: Cursor CLI in Orca
 ---
 
-Cursor CLI is Cursor's command-line agent. Orca runs it with first-class support — launch from the combobox, full OSC state detection, and restart chip on exit.
+Cursor CLI is Cursor's command-line agent. Orca runs it with first-class support — launch from the combobox, full OSC state detection, restart chip on exit, and Chat UI (native chat) that reads the on-disk JSONL transcript.
 
 ## Setup
 

--- a/mobile/src/session/mobile-native-chat-eligibility.test.ts
+++ b/mobile/src/session/mobile-native-chat-eligibility.test.ts
@@ -84,6 +84,27 @@ describe('resolveMobileNativeChat', () => {
     expect(resolveMobileNativeChat({ type: 'terminal', launchAgent: 'gemini' })).toBeNull()
   })
 
+  it('admits Cursor terminal sessions', () => {
+    expect(
+      resolveMobileNativeChat({
+        type: 'terminal',
+        launchAgent: 'cursor',
+        agentStatus: status({
+          agentType: 'cursor',
+          providerSession: {
+            key: 'session_id',
+            id: 'cursor-session',
+            transcriptPath: '/tmp/cursor.jsonl'
+          }
+        })
+      })
+    ).toEqual({
+      agent: 'cursor',
+      sessionId: 'cursor-session',
+      transcriptPath: '/tmp/cursor.jsonl'
+    })
+  })
+
   it('admits Grok only when its transcript is readable by the serving host', () => {
     const tab = { type: 'terminal', launchAgent: 'grok' }
     expect(resolveMobileNativeChat(tab, isMobileNativeChatTranscriptReadable(null))).toMatchObject({

--- a/src/main/native-chat/agent-session-journal/journal-legacy-identity.ts
+++ b/src/main/native-chat/agent-session-journal/journal-legacy-identity.ts
@@ -8,7 +8,7 @@
 // store, and `uuid` survives `--fork-session` unchanged, so a later structured
 // session reconciles against these keys directly.
 //
-// Codex, Grok, and omp get the `legacy` namespace. A Codex rollout file records
+// Codex, Cursor, Grok, and omp get the `legacy` namespace. A Codex rollout file records
 // `response_item` ids (`msg_…`, `rs_…`, `ctc_…`) which are a different namespace
 // from the app-server's positional `item-N` ordinals, and rollout records carry
 // no turn id at all — so a rollout line cannot be expressed as a stable

--- a/src/main/native-chat/agent-session-journal/journal-legacy-import.ts
+++ b/src/main/native-chat/agent-session-journal/journal-legacy-import.ts
@@ -24,6 +24,7 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from '../sessi
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
+  decodeCursorTranscriptLine,
   decodeGrokTranscriptLine,
   decodeOmpTranscriptLine
 } from '../transcript-line-decoders'
@@ -166,6 +167,7 @@ export async function importLegacyTranscriptIntoJournal(input: {
 const TRANSCRIPT_DECODERS = {
   claude: decodeClaudeTranscriptLine,
   codex: decodeCodexTranscriptLine,
+  cursor: decodeCursorTranscriptLine,
   grok: decodeGrokTranscriptLine,
   omp: decodeOmpTranscriptLine
 } as const

--- a/src/main/native-chat/session-file-resolver-cursor.ts
+++ b/src/main/native-chat/session-file-resolver-cursor.ts
@@ -1,0 +1,30 @@
+import { homedir } from 'node:os'
+import { basename, extname, join } from 'node:path'
+import { sessionIdFromFileName } from '../ai-vault/session-scanner-accumulator'
+import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
+
+function cursorProjectsDir(): string {
+  return join(homedir(), '.cursor', 'projects')
+}
+
+/** Cursor stores JSONL under `~/.cursor/projects/<slug>/agent-transcripts/`. */
+export async function resolveCursorSessionFile(
+  sessionId: string,
+  projectsDir = cursorProjectsDir(),
+  signal?: AbortSignal
+): Promise<string | null> {
+  const files = await walkSessionFiles(projectsDir, 'cursor', [], {
+    extensions: new Set(['.jsonl']),
+    filePredicate: (filePath) => isCursorTranscriptForSession(filePath, sessionId),
+    signal
+  })
+  return files[0] ?? null
+}
+
+function isCursorTranscriptForSession(filePath: string, sessionId: string): boolean {
+  if (!filePath.split(/[/\\]/).includes('agent-transcripts')) {
+    return false
+  }
+  const name = basename(filePath, extname(filePath))
+  return name === sessionId || sessionIdFromFileName(filePath) === sessionId
+}

--- a/src/main/native-chat/session-file-resolver.test.ts
+++ b/src/main/native-chat/session-file-resolver.test.ts
@@ -545,6 +545,28 @@ describe('resolveSessionFilePath', () => {
     ).resolves.toBe(join(cwdDir, `${stem}.jsonl`))
   })
 
+  it('resolves Cursor transcripts under project/agent-transcripts by file name', async () => {
+    const root = await makeRoot('orca-native-chat-resolve-cursor-')
+    const cursorProjectsDir = join(root, 'cursor-projects')
+    const transcriptsDir = join(cursorProjectsDir, 'my-repo', 'agent-transcripts')
+    await mkdir(transcriptsDir, { recursive: true })
+    const nestedId = 'aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee'
+    const nested = join(transcriptsDir, nestedId, `${nestedId}.jsonl`)
+    await mkdir(join(transcriptsDir, nestedId), { recursive: true })
+    await writeFile(nested, '{}\n')
+    await writeFile(join(transcriptsDir, 'cursor-session.jsonl'), '{}\n')
+
+    await expect(
+      resolveSessionFilePath('cursor', 'cursor-session', { cursorProjectsDir })
+    ).resolves.toBe(join(transcriptsDir, 'cursor-session.jsonl'))
+    await expect(resolveSessionFilePath('cursor', nestedId, { cursorProjectsDir })).resolves.toBe(
+      nested
+    )
+    await expect(
+      resolveSessionFilePath('cursor', 'missing', { cursorProjectsDir })
+    ).resolves.toBeNull()
+  })
+
   it('honors OMP_CODING_AGENT_DIR when resolving omp transcripts', async () => {
     const root = await makeRoot('orca-native-chat-resolve-omp-env-')
     const cwdDir = join(root, 'omp-sessions', '-Users-ada-repo')

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -25,6 +25,7 @@ import {
 import { findWslCodexSessionPath } from './wsl-codex-session-path-scan'
 import { wslTranscriptFsRefusal, type WslTranscriptFsError } from './wsl-transcript-fs-gate'
 import { proveClaudeTranscriptBranch } from '../claude/claude-transcript-branch-proof'
+import { resolveCursorSessionFile } from './session-file-resolver-cursor'
 
 // Why: these mirror the path constants in ai-vault/session-scanner.ts. Reads
 // run in the main process against the runtime's own home directory; over SSH
@@ -87,6 +88,8 @@ export type ResolveSessionFileOptions = {
   grokSessionsDir?: string
   /** Override the omp sessions root (`~/.omp/agent/sessions`). */
   ompSessionsDir?: string
+  /** Override the Cursor projects root (`~/.cursor/projects`). */
+  cursorProjectsDir?: string
   /** Authoritative transcript path reported by the agent hook
    *  (`providerSession.transcriptPath`). When set and the file exists, it is used
    *  directly — recent Claude Code names the transcript with a UUID that differs
@@ -209,6 +212,9 @@ async function resolveSessionFileById(
   }
   if (transcriptAgent === 'omp') {
     return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir(), signal)
+  }
+  if (transcriptAgent === 'cursor') {
+    return resolveCursorSessionFile(trimmedId, options.cursorProjectsDir, signal)
   }
   // Why: a new transcript agent must pick its own resolver. Falling through to
   // OMP's scan would search the wrong root with a foreign session id, so fail

--- a/src/main/native-chat/transcript-line-decoders-cursor.ts
+++ b/src/main/native-chat/transcript-line-decoders-cursor.ts
@@ -1,0 +1,97 @@
+// Cursor agent-transcripts JSONL line → NativeChatMessage decoder.
+
+import type { NativeChatBlock, NativeChatMessage } from '../../shared/native-chat-types'
+import {
+  asRecord,
+  extractString,
+  parseJsonObject,
+  timestampMs
+} from '../ai-vault/session-scanner-values'
+import { claudeContentBlocks } from './transcript-record-blocks'
+
+/**
+ * Cursor `agent-transcripts/*.jsonl` rows: `{ role, message.content, timestamp }`.
+ * Content is Claude-shaped (text / tool_use). User turns wrap the typed prompt in
+ * `<timestamp>` and `<user_query>` envelopes that do not belong in the bubble.
+ */
+export function decodeCursorTranscriptLine(
+  line: string,
+  fallbackId: string
+): NativeChatMessage | null {
+  const record = parseJsonObject(line)
+  if (!record) {
+    return null
+  }
+  const role = extractString(record.role)
+  if (role !== 'user' && role !== 'assistant') {
+    return null
+  }
+  const message = asRecord(record.message)
+  const rawBlocks = claudeContentBlocks(message?.content ?? record.content)
+  const blocks = role === 'user' ? rawBlocks.flatMap(normalizeCursorUserBlock) : rawBlocks
+  if (blocks.length === 0) {
+    return null
+  }
+  return {
+    id: extractString(record.id) ?? extractString(record.uuid) ?? fallbackId,
+    role,
+    blocks,
+    timestamp: parseTimestamp(record.timestamp),
+    source: 'transcript'
+  }
+}
+
+function normalizeCursorUserBlock(block: NativeChatBlock): NativeChatBlock[] {
+  if (block.type !== 'text') {
+    return [block]
+  }
+  const stripped = stripCursorUserEnvelope(block.text)
+  if (!stripped.trim()) {
+    return []
+  }
+  return stripped === block.text ? [block] : [{ type: 'text', text: stripped }]
+}
+
+function stripCursorUserEnvelope(text: string): string {
+  return unwrapTaggedEnvelope(removeTaggedEnvelope(text, 'timestamp'), 'user_query')
+}
+
+function removeTaggedEnvelope(text: string, tag: string): string {
+  const bounds = taggedEnvelopeBounds(text, tag)
+  if (!bounds) {
+    return text
+  }
+  return `${text.slice(0, bounds.start)}${text.slice(bounds.end)}`.trim()
+}
+
+function unwrapTaggedEnvelope(text: string, tag: string): string {
+  const bounds = taggedEnvelopeBounds(text, tag)
+  if (!bounds) {
+    return text.trim()
+  }
+  return text.slice(bounds.innerStart, bounds.innerEnd).trim()
+}
+
+function taggedEnvelopeBounds(
+  text: string,
+  tag: string
+): { start: number; innerStart: number; innerEnd: number; end: number } | null {
+  const opener = `<${tag}>`
+  const closer = `</${tag}>`
+  const lower = text.toLowerCase()
+  const start = lower.indexOf(opener)
+  if (start === -1) {
+    return null
+  }
+  const innerStart = start + opener.length
+  const innerEnd = lower.indexOf(closer, innerStart)
+  if (innerEnd === -1) {
+    return { start, innerStart, innerEnd: text.length, end: text.length }
+  }
+  return { start, innerStart, innerEnd, end: innerEnd + closer.length }
+}
+
+function parseTimestamp(value: unknown): number | null {
+  const parsed = timestampMs(value)
+  return Number.isFinite(parsed) ? parsed : null
+}

--- a/src/main/native-chat/transcript-line-decoders.cursor.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.cursor.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { decodeCursorTranscriptLine } from './transcript-line-decoders'
+
+describe('decodeCursorTranscriptLine', () => {
+  it('skips malformed lines and non-conversation records', () => {
+    expect(decodeCursorTranscriptLine('not json', 'f')).toBeNull()
+    expect(decodeCursorTranscriptLine(JSON.stringify({ role: 'system' }), 'f')).toBeNull()
+    expect(decodeCursorTranscriptLine(JSON.stringify({ role: 'assistant' }), 'f')).toBeNull()
+  })
+
+  it('strips Cursor timestamp and user_query envelopes from user turns', () => {
+    const line = JSON.stringify({
+      role: 'user',
+      message: {
+        content: [
+          {
+            type: 'text',
+            text: '<timestamp>Friday, Aug 28, 2026, 10:20 AM (UTC-4)</timestamp>\n<user_query>\nplease rebase\n</user_query>'
+          }
+        ]
+      },
+      timestamp: '2026-08-28T14:20:00.000Z'
+    })
+    expect(decodeCursorTranscriptLine(line, 'fb-1')).toEqual({
+      id: 'fb-1',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'please rebase' }],
+      timestamp: Date.parse('2026-08-28T14:20:00.000Z'),
+      source: 'transcript'
+    })
+  })
+
+  it('decodes assistant text and tool_use on the same row', () => {
+    const line = JSON.stringify({
+      role: 'assistant',
+      uuid: 'asst-1',
+      message: {
+        content: [
+          { type: 'text', text: 'Checking git status.' },
+          { type: 'tool_use', name: 'Shell', input: { command: 'git status' } }
+        ]
+      }
+    })
+    expect(decodeCursorTranscriptLine(line, 'fb-2')).toEqual({
+      id: 'asst-1',
+      role: 'assistant',
+      blocks: [
+        { type: 'text', text: 'Checking git status.' },
+        { type: 'tool-call', name: 'Shell', input: { command: 'git status' } }
+      ],
+      timestamp: null,
+      source: 'transcript'
+    })
+  })
+
+  it('accepts the vault fixture message.content string shape', () => {
+    const line = JSON.stringify({
+      role: 'assistant',
+      message: { content: 'cursor seed answer' },
+      timestamp: '2026-05-01T10:01:00.000Z'
+    })
+    expect(decodeCursorTranscriptLine(line, 'fb-3')).toMatchObject({
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'cursor seed answer' }]
+    })
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders.ts
+++ b/src/main/native-chat/transcript-line-decoders.ts
@@ -11,5 +11,6 @@
 
 export { decodeClaudeTranscriptLine } from './transcript-line-decoders-claude'
 export { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
+export { decodeCursorTranscriptLine } from './transcript-line-decoders-cursor'
 export { decodeGrokTranscriptLine } from './transcript-line-decoders-grok'
 export { decodeOmpTranscriptLine } from './transcript-line-decoders-omp'

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -300,6 +300,35 @@ describe('readNativeChatTranscript (errors)', () => {
   })
 })
 
+describe('readNativeChatTranscript (cursor)', () => {
+  it('decodes Cursor agent-transcripts rows and strips user envelopes', async () => {
+    const filePath = await writeFixture('orca-native-chat-cursor-', [
+      {
+        role: 'user',
+        message: {
+          content: [
+            {
+              type: 'text',
+              text: '<timestamp>Friday, Aug 28, 2026, 10:20 AM (UTC-4)</timestamp>\n<user_query>\nplease rebase\n</user_query>'
+            }
+          ]
+        }
+      },
+      {
+        role: 'assistant',
+        message: { content: [{ type: 'text', text: 'Rebasing onto master.' }] }
+      }
+    ])
+
+    await expect(readNativeChatTranscript('cursor', 'sess', { filePath })).resolves.toMatchObject({
+      messages: [
+        { role: 'user', blocks: [{ type: 'text', text: 'please rebase' }] },
+        { role: 'assistant', blocks: [{ type: 'text', text: 'Rebasing onto master.' }] }
+      ]
+    })
+  })
+})
+
 describe('readNativeChatTranscriptTailFile', () => {
   it('keeps a missing tail retry-worthy for the live-session seed', async () => {
     const result = await readNativeChatTranscriptTail({

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -3,17 +3,11 @@ import type {
   NativeChatMessage,
   NativeChatTurnLifecycle
 } from '../../shared/native-chat-types'
-import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
 import { errorMessage } from '../ai-vault/session-scanner-values'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
 import { openTranscriptReadStream } from './wsl-transcript-fs-access'
 import { wslTranscriptFsRefusal } from './wsl-transcript-fs-gate'
-import {
-  decodeClaudeTranscriptLine,
-  decodeCodexTranscriptLine,
-  decodeGrokTranscriptLine,
-  decodeOmpTranscriptLine
-} from './transcript-line-decoders'
+import { nativeChatLineDecoderForAgent } from './transcript-tail-reader'
 import { decodeTranscriptStream } from './transcript-stream-lines'
 
 export type ReadTranscriptResult =
@@ -31,11 +25,10 @@ export type ReadTranscriptOptions = ResolveSessionFileOptions & {
 }
 
 /**
- * Read the ENTIRE Claude/Codex JSONL transcript for an agent + session id into
- * the NativeChatMessage model. Unlike the AI-Vault preview scan, this applies
- * NO message cap. Unknown record types are skipped rather than throwing, so a
- * single malformed/unrecognized line cannot fail the whole read. The per-line
- * record-to-message mapping is shared with the live tailer.
+ * Read a supported agent's JSONL transcript into the NativeChatMessage model.
+ * Unlike the AI-Vault preview scan, this applies no message cap. Unknown records
+ * are skipped rather than thrown so one malformed line cannot fail the read.
+ * The per-line mapping is shared with the live tailer.
  */
 export async function readNativeChatTranscript(
   agent: AgentType,
@@ -54,20 +47,11 @@ export async function readNativeChatTranscript(
     return { error: `No transcript found for ${agent} session ${sessionId}`, notFound: true }
   }
   try {
-    const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-    if (transcriptAgent === 'claude') {
-      return { messages: await readTranscript(filePath, decodeClaudeTranscriptLine) }
+    const decode = nativeChatLineDecoderForAgent(agent)
+    if (!decode) {
+      return { error: `Unsupported agent for Chat UI transcript: ${agent}` }
     }
-    if (transcriptAgent === 'codex') {
-      return { messages: await readTranscript(filePath, decodeCodexTranscriptLine) }
-    }
-    if (transcriptAgent === 'grok') {
-      return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }
-    }
-    if (transcriptAgent === 'omp') {
-      return { messages: await readTranscript(filePath, decodeOmpTranscriptLine) }
-    }
-    return { error: `Unsupported agent for Chat UI transcript: ${agent}` }
+    return { messages: await readTranscript(filePath, decode) }
   } catch (err) {
     // Why: ENOENT after a successful resolve is the same first-flush/rotation
     // race as an unresolved path — keep it retry-worthy (#8401).

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -8,6 +8,7 @@ import { resolveSessionFilePath, type ResolveSessionFileOptions } from './sessio
 import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
+  decodeCursorTranscriptLine,
   decodeGrokTranscriptLine,
   decodeOmpTranscriptLine
 } from './transcript-line-decoders'
@@ -40,6 +41,9 @@ export function nativeChatLineDecoderForAgent(agent: AgentType): NativeChatLineD
   }
   if (transcriptAgent === 'codex') {
     return decodeCodexTranscriptLine
+  }
+  if (transcriptAgent === 'cursor') {
+    return decodeCursorTranscriptLine
   }
   if (transcriptAgent === 'grok') {
     return decodeGrokTranscriptLine

--- a/src/renderer/src/components/native-chat/native-chat-availability.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-availability.test.ts
@@ -11,6 +11,13 @@ describe('canToggleNativeChat', () => {
         launchAgent: 'claude'
       })
     ).toBe(true)
+    expect(
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: 'cursor'
+      })
+    ).toBe(true)
   })
 
   it('allows a terminal with a live detected supported agent but no launchAgent', () => {

--- a/src/renderer/src/components/settings/NativeChatSupportedAgents.test.tsx
+++ b/src/renderer/src/components/settings/NativeChatSupportedAgents.test.tsx
@@ -16,6 +16,7 @@ const EXPECTED_SUPPORTED_AGENTS = [
   'claude',
   'openclaude',
   'codex',
+  'cursor',
   'grok',
   'omp'
 ] as const satisfies readonly TuiAgent[]

--- a/src/renderer/src/components/settings/native-chat-experimental-search-entry.ts
+++ b/src/renderer/src/components/settings/native-chat-experimental-search-entry.ts
@@ -31,6 +31,10 @@ export function getNativeChatExperimentalSearchEntry(): SettingsSearchEntry {
         'codex'
       ),
       ...translateSearchKeyword(
+        'auto.components.settings.experimental.search.nativeChat.cursor',
+        'cursor'
+      ),
+      ...translateSearchKeyword(
         'auto.components.settings.experimental.search.nativeChat.openclaude',
         'openclaude'
       ),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9392,6 +9392,7 @@
               "chat": "chat",
               "claude": "claude",
               "codex": "codex",
+              "cursor": "cursor",
               "openclaude": "openclaude",
               "omp": "omp",
               "terminal": "terminal",

--- a/src/renderer/src/lib/agent-launch-routing.test.ts
+++ b/src/renderer/src/lib/agent-launch-routing.test.ts
@@ -114,9 +114,10 @@ describe('resolveAgentLaunchRoute', () => {
 
   it('fails closed for missing capability, unsupported providers, and explicit TUI options', () => {
     expect(route({ hostCapabilities: [] })).toBe('legacy-native-chat')
-    // openclaude and grok render native chat but have no structured adapter.
+    // openclaude, grok, and cursor render native chat but have no structured adapter.
     expect(route({ agent: 'openclaude' })).toBe('legacy-native-chat')
     expect(route({ agent: 'grok' })).toBe('legacy-native-chat')
+    expect(route({ agent: 'cursor' })).toBe('legacy-native-chat')
     expect(route({ requiresTuiLaunchCustomization: true })).toBe('legacy-native-chat')
     expect(route({ initialSessionOptions: { model: 'gpt-5.6-sol' } })).toBe('legacy-native-chat')
   })

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -63,7 +63,13 @@ describe('agent session resume metadata', () => {
       'kimi',
       { session_id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
       { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' }
-    ]
+    ],
+    [
+      'cursor',
+      { conversation_id: 'cursor-conversation' },
+      { key: 'session_id', id: 'cursor-conversation' }
+    ],
+    ['cursor', { session_id: 'cursor-session' }, { key: 'session_id', id: 'cursor-session' }]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -100,7 +106,6 @@ describe('agent session resume metadata', () => {
   })
 
   it('rejects unsupported sources and unsafe ids', () => {
-    expect(extractAgentProviderSession('cursor', { session_id: 'cursor-session' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: 'bad\nid' })).toBeNull()
     expect(normalizeAgentProviderSession({ key: 'session_id', id: '--last' })).toBeNull()
     expect(extractAgentProviderSession('codex', { session_id: '--last' })).toBeNull()
@@ -146,6 +151,16 @@ describe('agent session resume metadata', () => {
     expect(
       extractAgentProviderSession('codex', { session_id: 'xs', transcriptPath: '/x/r.jsonl' })
     ).toEqual({ key: 'session_id', id: 'xs', transcriptPath: '/x/r.jsonl' })
+    expect(
+      extractAgentProviderSession('cursor', {
+        conversation_id: 'cs',
+        transcript_path: '/home/u/.cursor/projects/slug/agent-transcripts/cs.jsonl'
+      })
+    ).toEqual({
+      key: 'session_id',
+      id: 'cs',
+      transcriptPath: '/home/u/.cursor/projects/slug/agent-transcripts/cs.jsonl'
+    })
   })
 
   it('does not attach transcript_path for non-native-chat agents', () => {

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -194,6 +194,13 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id'])
       return id ? withTranscriptPath({ key: 'session_id', id }, payload) : null
     }
+    // Why: Cursor hooks identify the chat as `conversation_id` (and sometimes
+    // `session_id`, which Cursor docs say is the same value) and may report the
+    // JSONL path as `transcript_path` — same native-chat locator as Claude/Codex.
+    case 'cursor': {
+      const id = readSessionId(payload, ['session_id', 'conversation_id', 'conversationId'])
+      return id ? withTranscriptPath({ key: 'session_id', id }, payload) : null
+    }
     case 'gemini':
     case 'droid':
     // Why: Kimi Code posts a Claude-shaped `session_id` (e.g. session_<uuid>).
@@ -239,7 +246,6 @@ export function extractAgentProviderSession(
       return id ? { key: 'session_id', id } : null
     }
     case 'amp':
-    case 'cursor':
     case 'command-code':
     case 'hermes':
       return null

--- a/src/shared/native-chat-agent-profiles.test.ts
+++ b/src/shared/native-chat-agent-profiles.test.ts
@@ -22,6 +22,11 @@ describe('native chat agent picker profiles', () => {
       groupedSlash: true,
       skillSourceOwner: 'grok'
     })
+    expect(getNativeChatAgentProfile('cursor')).toMatchObject({
+      skillPrefix: '/',
+      groupedSlash: true,
+      skillSourceOwner: 'cursor'
+    })
   })
 
   it('does not grant custom or unverified agents a skill grammar', () => {

--- a/src/shared/native-chat-agent-profiles.ts
+++ b/src/shared/native-chat-agent-profiles.ts
@@ -28,6 +28,11 @@ const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfi
     skillPrefix: '/',
     groupedSlash: true,
     skillSourceOwner: 'grok'
+  },
+  cursor: {
+    skillPrefix: '/',
+    groupedSlash: true,
+    skillSourceOwner: 'cursor'
   }
 }
 

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -12,11 +12,12 @@ describe('resolveNativeChatTranscriptAgent', () => {
     expect(resolveNativeChatTranscriptAgent('claude')).toBe('claude')
   })
 
-  it('passes codex, grok and omp through and rejects everything else', () => {
+  it('passes codex, cursor, grok and omp through and rejects everything else', () => {
     expect(resolveNativeChatTranscriptAgent('codex')).toBe('codex')
+    expect(resolveNativeChatTranscriptAgent('cursor')).toBe('cursor')
     expect(resolveNativeChatTranscriptAgent('grok')).toBe('grok')
     expect(resolveNativeChatTranscriptAgent('omp')).toBe('omp')
-    expect(resolveNativeChatTranscriptAgent('cursor')).toBeNull()
+    expect(resolveNativeChatTranscriptAgent('gemini')).toBeNull()
     expect(resolveNativeChatTranscriptAgent(null)).toBeNull()
     expect(resolveNativeChatTranscriptAgent(undefined)).toBeNull()
   })
@@ -27,7 +28,7 @@ describe('isNativeChatSupportedAgent', () => {
     expect(isNativeChatSupportedAgent('claude')).toBe(true)
     expect(isNativeChatSupportedAgent('openclaude')).toBe(true)
     expect(isNativeChatSupportedAgent('omp')).toBe(true)
-    expect(isNativeChatSupportedAgent('cursor')).toBe(false)
+    expect(isNativeChatSupportedAgent('cursor')).toBe(true)
     expect(isNativeChatSupportedAgent(null)).toBe(false)
     expect(isNativeChatSupportedAgent(undefined)).toBe(false)
   })

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,6 +1,6 @@
 import type { TuiAgent } from './tui-agent'
 
-export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'omp'
+export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'cursor' | 'grok' | 'omp'
 
 /** Agents whose transcripts the native chat view can parse and render, in the
  *  order the settings pane advertises them. */
@@ -8,6 +8,7 @@ export const NATIVE_CHAT_SUPPORTED_AGENT_LIST: readonly TuiAgent[] = [
   'claude',
   'openclaude',
   'codex',
+  'cursor',
   'grok',
   'omp'
 ]
@@ -47,7 +48,7 @@ export function resolveNativeChatTranscriptAgent(
   if (agent === 'claude' || agent === 'openclaude') {
     return 'claude'
   }
-  if (agent === 'codex' || agent === 'grok' || agent === 'omp') {
+  if (agent === 'codex' || agent === 'cursor' || agent === 'grok' || agent === 'omp') {
     return agent
   }
   return null


### PR DESCRIPTION
## ELI5

Chat UI can already render Codex/Claude/Grok/OMP conversations from their on-disk JSONL transcripts. Cursor CLI writes the same kind of file and already posts session identity from hooks — Orca just refused to open Chat UI for it. This allowlists Cursor and teaches native chat how to find and decode those transcripts, so a Cursor terminal can switch into Chat UI like Codex.

## What Changed

- Added `cursor` to the native-chat support list (settings chips, desktop toggle, mobile terminal eligibility).
- Extract Cursor hook `session_id` / `conversation_id` plus `transcript_path` so Chat UI has a session to subscribe to.
- Decode `~/.cursor/projects/*/agent-transcripts/*.jsonl` rows (Claude-shaped `role` + `message.content`, stripping `<timestamp>` / `<user_query>` envelopes).
- Resolve transcripts by hook path, then by session id under the Cursor projects tree.
- Cursor launches still use the terminal-backed (legacy) Chat UI path, not structured Codex/Claude sessions.

## Why

Mobile Chat UI is transcript-driven, not TUI-driven. Cursor was excluded from `NATIVE_CHAT_SUPPORTED_AGENT_LIST` and `extractAgentProviderSession` returned null, so the view never had a session id or parser. The vault scanner already knew the file layout; this reuses that shape for the native-chat message model.

## Linked Issue

No existing GitHub issue. Requested to match Codex Chat UI for Cursor CLI sessions.

## Visual Proof

N/A — no Orca desktop/mobile screenshots in this environment. Behavior is covered by unit tests for allowlisting, hook session extraction, JSONL decoding (including user-envelope stripping), and session-file resolution. Enabling Chat UI and opening a Cursor terminal should now show the Cursor chip and allow the terminal⇄chat toggle.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Ran targeted vitest for native-chat support, decoder, reader, session resolver, settings chips, availability, and launch routing (151 tests). Changed-file oxlint / React Doctor / localization extraction and catalog checks passed. Did not run the full `pnpm test` / `pnpm build` suite or a live Orca Chat UI session. Mobile eligibility test was updated; mobile workspace deps were not installed locally.

Platforms: unit tests on macOS. SSH: Cursor reports `transcript_path` like Claude/Codex, so it is not gated as local-transcript-only (Grok/OMP). Model-A SSH without a hook path still falls back to scanning `~/.cursor/projects` on the serving host.

## AI Disclosure

Implemented with Cursor Grok 4.6.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

Cursor JSONL lives under `~/.cursor/projects/<slug>/agent-transcripts/` (including nested `<uuid>/<uuid>.jsonl`). Hook `transcript_path` is preferred when present. Structured `agent-session` tabs remain Codex-only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Made with [Cursor](https://cursor.com)