### PR TITLE
fix(terminal): keep find-bar decorations on Cmd+G navigation

### DIFF
--- a/src/renderer/src/components/TerminalSearch.test.tsx
+++ b/src/renderer/src/components/TerminalSearch.test.tsx
@@ -16,6 +16,12 @@ type ResultsListener = (event: { resultIndex: number; resultCount: number }) => 
 
 const emitResults = new WeakMap<SearchAddon, ResultsListener>()
 
+/**
+ * Builds a stub addon whose `onDidChangeResults` listener is reachable through
+ * `emitResults`, so a test can fire a result event the way xterm would.
+ *
+ * @returns A stub standing in for the pane's addon.
+ */
 function createSearchAddon(): SearchAddon {
   let listener: ResultsListener | undefined
   const addon = {
@@ -31,6 +37,12 @@ function createSearchAddon(): SearchAddon {
   return addon
 }
 
+/**
+ * Renders an open find bar against one addon.
+ *
+ * @param searchAddon The addon the bar should search.
+ * @returns The testing-library render result.
+ */
 function renderSearch(searchAddon: SearchAddon): ReturnType<typeof render> {
   return render(
     <TerminalSearch

--- a/src/renderer/src/components/TerminalSearch.test.tsx
+++ b/src/renderer/src/components/TerminalSearch.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
 import type { SearchAddon } from '@xterm/addon-search'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import TerminalSearch from './TerminalSearch'
@@ -11,12 +11,23 @@ vi.mock('@/i18n/i18n', () => ({
 
 afterEach(cleanup)
 
+type ResultsListener = (event: { resultIndex: number; resultCount: number }) => void
+
+const emitResults = new WeakMap<SearchAddon, ResultsListener>()
+
 function createSearchAddon(): SearchAddon {
-  return {
+  let listener: ResultsListener | undefined
+  const addon = {
     findNext: vi.fn(() => true),
     findPrevious: vi.fn(() => true),
-    clearDecorations: vi.fn()
+    clearDecorations: vi.fn(),
+    onDidChangeResults: vi.fn((next: ResultsListener) => {
+      listener = next
+      return { dispose: vi.fn() }
+    })
   } as unknown as SearchAddon
+  emitResults.set(addon, (event) => listener?.(event))
+  return addon
 }
 
 function renderSearch(searchAddon: SearchAddon): ReturnType<typeof render> {
@@ -82,5 +93,38 @@ describe('TerminalSearch cleanup', () => {
 
     expect(addon.clearDecorations).toHaveBeenCalledTimes(1)
     expect(addon.findNext).toHaveBeenCalledWith('')
+  })
+})
+
+describe('TerminalSearch match count', () => {
+  it('reports matches found beyond the visible screen', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+
+    act(() => emitResults.get(addon)?.({ resultIndex: 2, resultCount: 47 }))
+
+    await waitFor(() =>
+      expect(view.container.querySelector('[data-terminal-search-match-count]')?.textContent).toBe(
+        '3/47'
+      )
+    )
+  })
+
+  it('drops the count when the query is erased', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+    act(() => emitResults.get(addon)?.({ resultIndex: 0, resultCount: 3 }))
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: '' } })
+
+    await waitFor(() =>
+      expect(view.container.querySelector('[data-terminal-search-match-count]')).toBeNull()
+    )
   })
 })

--- a/src/renderer/src/components/TerminalSearch.test.tsx
+++ b/src/renderer/src/components/TerminalSearch.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react
 import type { SearchAddon } from '@xterm/addon-search'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import TerminalSearch from './TerminalSearch'
+import { TERMINAL_SEARCH_HIGHLIGHT_LIMIT } from './terminal-search-options'
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
@@ -109,6 +110,59 @@ describe('TerminalSearch match count', () => {
     await waitFor(() =>
       expect(view.container.querySelector('[data-terminal-search-match-count]')?.textContent).toBe(
         '3/47'
+      )
+    )
+  })
+
+  it('reports a zero result in red', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+
+    act(() => emitResults.get(addon)?.({ resultIndex: -1, resultCount: 0 }))
+
+    await waitFor(() => {
+      const counter = view.container.querySelector('[data-terminal-search-match-count]')
+      expect(counter?.textContent).toBe('0/0')
+      expect(counter?.className).toContain('text-red-400')
+    })
+  })
+
+  it('shows a capped total instead of a zero index past the highlight limit', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+
+    act(() =>
+      emitResults.get(addon)?.({
+        resultIndex: -1,
+        resultCount: TERMINAL_SEARCH_HIGHLIGHT_LIMIT
+      })
+    )
+
+    await waitFor(() =>
+      expect(view.container.querySelector('[data-terminal-search-match-count]')?.textContent).toBe(
+        `${TERMINAL_SEARCH_HIGHLIGHT_LIMIT}+`
+      )
+    )
+  })
+
+  it('shows the bare total when no match is selected yet', async () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
+
+    act(() => emitResults.get(addon)?.({ resultIndex: -1, resultCount: 12 }))
+
+    await waitFor(() =>
+      expect(view.container.querySelector('[data-terminal-search-match-count]')?.textContent).toBe(
+        '12'
       )
     )
   })

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -6,6 +6,7 @@ import type { SearchState } from '@/components/terminal-pane/keyboard-handlers'
 import { translate } from '@/i18n/i18n'
 import { getFindRequestQuery } from '@/lib/find-query-bounds'
 import { safeFind } from './terminal-search-safe-find'
+import { buildTerminalSearchOptions } from './terminal-search-options'
 
 type TerminalSearchProps = {
   isOpen: boolean
@@ -32,28 +33,14 @@ export default function TerminalSearch({
   const [query, setQuery] = useState('')
   const [caseSensitive, setCaseSensitive] = useState(false)
   const [regex, setRegex] = useState(false)
+  // Why surfaced: the count spans the whole scrollback, so it is the only signal
+  // that matches exist above the visible screen.
+  const [matches, setMatches] = useState<{ index: number; count: number } | null>(null)
   const requestQuery = getFindRequestQuery(query)
 
-  // Why: the default xterm SearchAddon highlights blend into common
-  // terminal backgrounds (see orca#612). Providing explicit decoration
-  // colors gives all matches a visible yellow background and the
-  // current match a brighter orange, matching the contrast VS Code and
-  // iTerm2 use for terminal search. xterm requires #RRGGBB format for
-  // the background colors.
   const searchOptions = useCallback(
-    (incremental: boolean = false) => ({
-      caseSensitive,
-      regex,
-      incremental,
-      decorations: {
-        matchBackground: '#5c4a00',
-        matchBorder: '#5c4a00',
-        matchOverviewRuler: '#ffcc00',
-        activeMatchBackground: '#c4580e',
-        activeMatchBorder: '#ffcf6b',
-        activeMatchColorOverviewRuler: '#ff9900'
-      }
-    }),
+    (incremental: boolean = false) =>
+      buildTerminalSearchOptions({ caseSensitive, regex, incremental }),
     [caseSensitive, regex]
   )
 
@@ -88,17 +75,28 @@ export default function TerminalSearch({
     [searchAddon]
   )
 
+  // Declared before the search effect so a pane switch is subscribed to the new
+  // addon before that effect issues its first find against it.
+  useEffect(() => {
+    if (!searchAddon) {
+      return
+    }
+    setMatches(null)
+    const subscription = searchAddon.onDidChangeResults(({ resultIndex, resultCount }) => {
+      setMatches({ index: resultIndex, count: resultCount })
+    })
+    return () => subscription.dispose()
+  }, [searchAddon])
+
   useEffect(() => {
     // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
     // can read the current search state without lifting it to parent state.
     searchStateRef.current = { query: requestQuery ?? '', caseSensitive, regex }
 
-    if (!isOpen) {
+    if (!isOpen || !requestQuery) {
       clearTerminalSearch(searchAddon)
-      return
-    }
-    if (!requestQuery) {
-      clearTerminalSearch(searchAddon)
+      // Clearing fires no results event, so the stale count has to go with it.
+      setMatches(null)
       return
     }
     if (searchAddon) {
@@ -144,6 +142,17 @@ export default function TerminalSearch({
         placeholder={translate('auto.components.TerminalSearch.e07012f26e', 'Search...')}
         className="min-w-0 flex-1 border-none bg-transparent text-sm text-white outline-none placeholder:text-zinc-500"
       />
+
+      {requestQuery && matches ? (
+        <span
+          data-terminal-search-match-count
+          className={`shrink-0 text-xs tabular-nums ${
+            matches.count === 0 ? 'text-red-400' : 'text-zinc-400'
+          }`}
+        >
+          {`${matches.count === 0 ? 0 : matches.index + 1}/${matches.count}`}
+        </span>
+      ) : null}
 
       <Button
         type="button"

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -6,13 +6,33 @@ import type { SearchState } from '@/components/terminal-pane/keyboard-handlers'
 import { translate } from '@/i18n/i18n'
 import { getFindRequestQuery } from '@/lib/find-query-bounds'
 import { safeFind } from './terminal-search-safe-find'
-import { buildTerminalSearchOptions } from './terminal-search-options'
+import {
+  TERMINAL_SEARCH_HIGHLIGHT_LIMIT,
+  buildTerminalSearchOptions
+} from './terminal-search-options'
 
 type TerminalSearchProps = {
   isOpen: boolean
   onClose: () => void
   searchAddon: SearchAddon | null
   searchStateRef: React.RefObject<SearchState>
+}
+
+type MatchCount = { addon: SearchAddon; query: string | null; index: number; count: number }
+
+// The addon reports index -1 when the selected match is not among the tracked
+// results — past `highlightLimit`, or before a match is selected — so a position
+// is unknowable there and only the (capped) total can be shown.
+function formatMatchCount(matches: { index: number; count: number }): string {
+  if (matches.count === 0) {
+    return '0/0'
+  }
+  if (matches.index < 0) {
+    return matches.count >= TERMINAL_SEARCH_HIGHLIGHT_LIMIT
+      ? `${matches.count}+`
+      : `${matches.count}`
+  }
+  return `${matches.index + 1}/${matches.count}`
 }
 
 function clearTerminalSearch(searchAddon: SearchAddon | null): void {
@@ -34,9 +54,13 @@ export default function TerminalSearch({
   const [caseSensitive, setCaseSensitive] = useState(false)
   const [regex, setRegex] = useState(false)
   // Why surfaced: the count spans the whole scrollback, so it is the only signal
-  // that matches exist above the visible screen.
-  const [matches, setMatches] = useState<{ index: number; count: number } | null>(null)
+  // that matches exist above the visible screen. Tagged with the addon and query
+  // it was reported for, so a pane switch or an edited query invalidates it in
+  // render rather than through a state reset the user would see one frame late.
+  const [matches, setMatches] = useState<MatchCount | null>(null)
   const requestQuery = getFindRequestQuery(query)
+  const currentMatches =
+    matches && matches.addon === searchAddon && matches.query === requestQuery ? matches : null
 
   const searchOptions = useCallback(
     (incremental: boolean = false) =>
@@ -75,18 +99,23 @@ export default function TerminalSearch({
     [searchAddon]
   )
 
-  // Declared before the search effect so a pane switch is subscribed to the new
-  // addon before that effect issues its first find against it.
+  // Declared before the search effect so a pane switch or an edited query is
+  // subscribed before that effect issues its first find, and so the listener
+  // closes over the query its results belong to.
   useEffect(() => {
     if (!searchAddon) {
       return
     }
-    setMatches(null)
     const subscription = searchAddon.onDidChangeResults(({ resultIndex, resultCount }) => {
-      setMatches({ index: resultIndex, count: resultCount })
+      setMatches({
+        addon: searchAddon,
+        query: requestQuery,
+        index: resultIndex,
+        count: resultCount
+      })
     })
     return () => subscription.dispose()
-  }, [searchAddon])
+  }, [searchAddon, requestQuery])
 
   useEffect(() => {
     // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
@@ -95,8 +124,6 @@ export default function TerminalSearch({
 
     if (!isOpen || !requestQuery) {
       clearTerminalSearch(searchAddon)
-      // Clearing fires no results event, so the stale count has to go with it.
-      setMatches(null)
       return
     }
     if (searchAddon) {
@@ -143,14 +170,14 @@ export default function TerminalSearch({
         className="min-w-0 flex-1 border-none bg-transparent text-sm text-white outline-none placeholder:text-zinc-500"
       />
 
-      {requestQuery && matches ? (
+      {requestQuery && currentMatches ? (
         <span
           data-terminal-search-match-count
           className={`shrink-0 text-xs tabular-nums ${
-            matches.count === 0 ? 'text-red-400' : 'text-zinc-400'
+            currentMatches.count === 0 ? 'text-red-400' : 'text-zinc-400'
           }`}
         >
-          {`${matches.count === 0 ? 0 : matches.index + 1}/${matches.count}`}
+          {formatMatchCount(currentMatches)}
         </span>
       ) : null}
 

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -20,9 +20,16 @@ type TerminalSearchProps = {
 
 type MatchCount = { addon: SearchAddon; query: string | null; index: number; count: number }
 
-// The addon reports index -1 when the selected match is not among the tracked
-// results — past `highlightLimit`, or before a match is selected — so a position
-// is unknowable there and only the (capped) total can be shown.
+/**
+ * Renders the find bar's match counter.
+ *
+ * The addon reports index -1 when the selected match is not among the tracked
+ * results — past `highlightLimit`, or before a match is selected — so a position
+ * is unknowable there and only the (capped) total can be shown.
+ *
+ * @param matches The position and total last reported by `onDidChangeResults`.
+ * @returns `3/47`, `0/0`, a bare total, or `1000+` once the total is truncated.
+ */
 function formatMatchCount(matches: { index: number; count: number }): string {
   if (matches.count === 0) {
     return '0/0'
@@ -35,6 +42,11 @@ function formatMatchCount(matches: { index: number; count: number }): string {
   return `${matches.index + 1}/${matches.count}`
 }
 
+/**
+ * Drops every trace of the current search from a pane's addon.
+ *
+ * @param searchAddon The pane's addon, or null when no pane is attached.
+ */
 function clearTerminalSearch(searchAddon: SearchAddon | null): void {
   if (!searchAddon) {
     return
@@ -44,6 +56,17 @@ function clearTerminalSearch(searchAddon: SearchAddon | null): void {
   searchAddon.findNext('')
 }
 
+/**
+ * The terminal find bar: query input, case/regex toggles, match navigation, and
+ * a counter spanning the whole scrollback.
+ *
+ * @param props.isOpen Whether the bar is showing; closing clears the search.
+ * @param props.onClose Invoked on Escape and on the close button.
+ * @param props.searchAddon The focused pane's addon; changes on a pane switch.
+ * @param props.searchStateRef Written on every change so the Cmd+G / Ctrl+G
+ * handler can navigate without this state being lifted to the parent.
+ * @returns The find bar, or null while closed.
+ */
 export default function TerminalSearch({
   isOpen,
   onClose,

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -9,6 +9,12 @@ import {
   runTerminalSearchNavigation
 } from './keyboard-handlers'
 
+/**
+ * Builds the subset of a keyboard event the shortcut matchers read.
+ *
+ * @param overrides Fields to change; the rest default to an unmodified `g`.
+ * @returns A stand-in keyboard event.
+ */
 function makeKeyEvent(
   overrides: Partial<{
     key: string

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
@@ -1,6 +1,7 @@
 // src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts
 import { describe, it, expect, vi } from 'vitest'
 import { FIND_QUERY_MAX_BYTES } from '@/lib/find-query-bounds'
+import { buildTerminalSearchOptions } from '../terminal-search-options'
 import {
   matchFileSearchShortcut,
   matchSearchNavigate,
@@ -161,7 +162,10 @@ describe('runTerminalSearchNavigation', () => {
     >[0]
 
     expect(runTerminalSearchNavigation(pane, 'next', searchState)).toBe(true)
-    expect(findNext).toHaveBeenCalledWith('hello', { caseSensitive: true, regex: false })
+    expect(findNext).toHaveBeenCalledWith(
+      'hello',
+      buildTerminalSearchOptions({ caseSensitive: true, regex: false })
+    )
     expect(findPrevious).not.toHaveBeenCalled()
   })
 
@@ -173,8 +177,25 @@ describe('runTerminalSearchNavigation', () => {
     >[0]
 
     expect(runTerminalSearchNavigation(pane, 'previous', searchState)).toBe(true)
-    expect(findPrevious).toHaveBeenCalledWith('hello', { caseSensitive: true, regex: false })
+    expect(findPrevious).toHaveBeenCalledWith(
+      'hello',
+      buildTerminalSearchOptions({ caseSensitive: true, regex: false })
+    )
     expect(findNext).not.toHaveBeenCalled()
+  })
+
+  it('carries decorations so the active match moves off the visible screen', () => {
+    // Why: without decorations the addon creates no active-match decoration,
+    // reports no result change, and stops refreshing highlights on write — the
+    // selection walks the scrollback while the highlight stays on screen.
+    const findNext = vi.fn((_term: string, _options?: unknown) => true)
+    const pane = { searchAddon: { findNext } } as unknown as Parameters<
+      typeof runTerminalSearchNavigation
+    >[0]
+
+    runTerminalSearchNavigation(pane, 'next', searchState)
+
+    expect(findNext.mock.calls[0][1]).toHaveProperty('decorations.activeMatchBackground')
   })
 
   it('contains the xterm decoration positive-integer crash from shortcut navigation', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-shortcut-matching.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-shortcut-matching.ts
@@ -1,5 +1,6 @@
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { safeFind } from '../terminal-search-safe-find'
+import { buildTerminalSearchOptions } from '../terminal-search-options'
 import { resolveTerminalShortcutAction, type MacOptionAsAlt } from './terminal-shortcut-policy'
 import {
   keybindingMatchesAction,
@@ -92,7 +93,7 @@ export function runTerminalSearchNavigation(
   direction: SearchNavigationDirection,
   searchState: SearchState
 ): boolean {
-  const options = { caseSensitive: searchState.caseSensitive, regex: searchState.regex }
+  const options = buildTerminalSearchOptions(searchState)
   return direction === 'next'
     ? safeFind(
         (term, findOptions) => pane.searchAddon.findNext(term, findOptions),

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-shortcut-matching.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-shortcut-matching.ts
@@ -88,6 +88,18 @@ export function matchSearchNavigate(
   return e.shiftKey ? 'previous' : 'next'
 }
 
+/**
+ * Runs one Cmd+G / Ctrl+G jump between matches.
+ *
+ * Options come from `buildTerminalSearchOptions` so this path carries the same
+ * decorations the find bar does; without them the addon moves the selection but
+ * stops repainting highlights and reporting the position.
+ *
+ * @param pane The pane whose addon performs the search.
+ * @param direction Which way to walk the matches.
+ * @param searchState The active query and its case/regex flags.
+ * @returns Whether the addon found a match.
+ */
 export function runTerminalSearchNavigation(
   pane: Pick<ManagedPane, 'searchAddon'>,
   direction: SearchNavigationDirection,

--- a/src/renderer/src/components/terminal-search-options.ts
+++ b/src/renderer/src/components/terminal-search-options.ts
@@ -1,0 +1,38 @@
+import type { SearchAddon } from '@xterm/addon-search'
+
+type SearchOptions = NonNullable<Parameters<SearchAddon['findNext']>[1]>
+
+// Why: the default xterm SearchAddon highlights blend into common terminal
+// backgrounds (see orca#612). Explicit colors give every match a visible yellow
+// background and the current match a brighter orange, matching the contrast VS
+// Code and iTerm2 use. xterm requires #RRGGBB for the background colors.
+const TERMINAL_SEARCH_DECORATIONS = {
+  matchBackground: '#5c4a00',
+  matchBorder: '#5c4a00',
+  matchOverviewRuler: '#ffcc00',
+  activeMatchBackground: '#c4580e',
+  activeMatchBorder: '#ffcf6b',
+  activeMatchColorOverviewRuler: '#ff9900'
+} as const
+
+/**
+ * Why every find must build its options here: the addon keys three behaviors off
+ * `decorations` on the options of the *last* call. Without them `_selectResult`
+ * creates no active-match decoration, `fireResultsChanged` returns early so
+ * `onDidChangeResults` never reports the new position, and `_updateMatches`
+ * stops refreshing highlights on write. A navigation call that omits them
+ * therefore moves the selection into the scrollback while the visible highlight
+ * stays frozen on the previous match — search looks stuck to the current screen.
+ */
+export function buildTerminalSearchOptions(state: {
+  caseSensitive: boolean
+  regex: boolean
+  incremental?: boolean
+}): SearchOptions {
+  return {
+    caseSensitive: state.caseSensitive,
+    regex: state.regex,
+    incremental: state.incremental ?? false,
+    decorations: { ...TERMINAL_SEARCH_DECORATIONS }
+  }
+}

--- a/src/renderer/src/components/terminal-search-options.ts
+++ b/src/renderer/src/components/terminal-search-options.ts
@@ -15,6 +15,11 @@ const TERMINAL_SEARCH_DECORATIONS = {
   activeMatchColorOverviewRuler: '#ff9900'
 } as const
 
+// Pinned rather than left to the addon's identical default so the match counter
+// knows where `resultCount` is truncated and can say `1000+` instead of a total
+// that reads as exact. Constructor-level: not part of per-find options.
+export const TERMINAL_SEARCH_HIGHLIGHT_LIMIT = 1000
+
 /**
  * Why every find must build its options here: the addon keys three behaviors off
  * `decorations` on the options of the *last* call. Without them `_selectResult`

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -12,6 +12,7 @@ import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-typ
 import { buildDefaultTerminalOptions } from './pane-terminal-options'
 import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
 import { ENABLE_WEBGL_RENDERER } from './pane-webgl-renderer'
+import { TERMINAL_SEARCH_HIGHLIGHT_LIMIT } from '../../components/terminal-search-options'
 import { installGuardedLinkProviderRegistration } from './terminal-link-provider-guard'
 import { installWindowsCtrlAltChordRepair } from './terminal-windows-ctrl-alt-chord-classification'
 
@@ -52,7 +53,7 @@ export function createPaneDOM(
   installGuardedLinkProviderRegistration(terminal)
   installWindowsCtrlAltChordRepair(terminal)
   const fitAddon = new FitAddon()
-  const searchAddon = new SearchAddon()
+  const searchAddon = new SearchAddon({ highlightLimit: TERMINAL_SEARCH_HIGHLIGHT_LIMIT })
   const unicode11Addon = new Unicode11Addon()
   // Why: async tooltip formatting can resolve after hover changes, so stale
   // results must not overwrite the tooltip for the currently hovered link.

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -20,6 +20,19 @@ function defaultLinkTooltipText(uri: string, openLinkHint: string): string {
   return `${uri} (${openLinkHint})`
 }
 
+/**
+ * Builds one terminal pane's DOM and its xterm instance, with the addons, link
+ * tooltip, drag handle, and pointer wiring the pane needs.
+ *
+ * @param id The pane's runtime id, passed back to the pointer callbacks.
+ * @param leafId The pane's stable id in the split layout.
+ * @param options Pane manager options, including terminal appearance.
+ * @param dragState Shared reorder state this pane's drag handle mutates.
+ * @param dragCallbacks Reorder callbacks invoked while dragging this pane.
+ * @param onPointerDown Invoked on pointer down; focus is decided by the caller.
+ * @param onMouseEnter Invoked on hover, for link tooltips.
+ * @returns The pane record the manager tracks.
+ */
 export function createPaneDOM(
   id: number,
   leafId: TerminalLeafId,


### PR DESCRIPTION
## ELI5

Orca's terminal find has two ways to jump between matches: the arrows/Enter in the find bar, and the Cmd+G / Ctrl+G shortcut. They were asking xterm for slightly different things — the shortcut forgot to ask for the highlight colors. xterm treats that request as "this caller doesn't care about highlights", so on Cmd+G it quietly stopped moving the orange current-match marker, stopped reporting which match you're on, and stopped repainting highlights when new output arrived. The selection really did jump to the next match up in the scrollback, but nothing on screen said so, so find looked like it could only see the visible screen. Both paths now ask for the same thing, and the find bar shows `3/47` so you can tell there are matches above the viewport.

## What Changed

- **New `src/renderer/src/components/terminal-search-options.ts`** — a single `buildTerminalSearchOptions()` that owns the search flags and the decoration palette. The palette moved here verbatim from `TerminalSearch.tsx`; the colors are unchanged.
- **`terminal-keyboard-shortcut-matching.ts`** — `runTerminalSearchNavigation` builds its options through that helper instead of its own `{ caseSensitive, regex }` literal, so Cmd+G / Cmd+Shift+G carry `decorations` like the find bar already did.
- **`TerminalSearch.tsx`** — uses the same helper, and subscribes to `searchAddon.onDidChangeResults` to render a `3/47` match counter (red `0/0` when there are none). The addon reports `resultIndex: -1` when the selected match is not among the tracked results — past `highlightLimit`, or before a match is selected — so that case shows the total alone rather than a zero position, suffixed `+` (`1000+`) once `resultCount` has reached the limit that truncated it. The stored count is tagged with the addon and query it was reported for, so an emptied query or a pane switch invalidates it in render. The subscription effect is declared before the search effect so a pane switch is subscribed to the new addon before the first find runs against it.
- **`pane-dom-creation.ts`** — pins `highlightLimit` at addon construction to the same `TERMINAL_SEARCH_HIGHLIGHT_LIMIT` the counter formats against, instead of relying on the addon's identical default. No behavior change; it just stops the counter guessing where counting stops.
- **Tests** — a regression test that shortcut navigation carries `decorations`, and two tests covering the counter (reported position/total, and cleared on an emptied query).

## Why

`@xterm/addon-search` keys three separate behaviors off `decorations` on the options of the **last** call it received:

1. `_selectResult` creates the active-match decoration only `if (options)`, so the current-match marker was never moved.
2. `SearchResultTracker.fireResultsChanged` returns early when `hasDecorations` is false, so `onDidChangeResults` reported nothing.
3. `_updateMatches` guards on `lastSearchOptions?.decorations`, so the post-write highlight refresh switched off for the remainder of the search.

So `runTerminalSearchNavigation` omitting `decorations` moved the xterm selection into the scrollback while every visible signal stayed pinned to where the last decorated search left it. In a quiet shell that reads as a subtle highlight bug; in a pane running an agent CLI that repaints continuously (Claude Code), the frozen highlights sit on a screen that keeps changing underneath them, and find reads as "bound to the visible frame".

Two entry points independently constructing the same options is what allowed them to drift, so the fix is one shared builder rather than a second copy of the palette. The match counter is the missing signal: it spans the whole scrollback, so it is the only thing in the UI that can tell you matches exist above the viewport.

The scrollback itself was always reachable — `SearchEngine.findNextWithSelection` scans the full active buffer, and the existing `config/patches/@xterm__addon-search@0.17.0-beta.300.patch` does not touch that path.

## Linked Issue

Fixes #18843

## Visual Proof

Same scenario in both frames: 400 lines of scrollback where `NEEDLE` appears **only above the viewport**, never on the visible screen. Find bar opened, `NEEDLE` typed, then three presses of Cmd+G.

**Before** — the viewport scrolled to the match, but `NEEDLE` on `build step 120` carries only a plain selection. No active-match highlight, and no count in the find bar.

![before](https://raw.githubusercontent.com/AntonioKL/orca/pr-assets-terminal-search-highlight/pr-18844/before-closeup.png)

**After** — the same match now carries the orange active-match highlight, and the find bar reads `4/11`.

![after](https://raw.githubusercontent.com/AntonioKL/orca/pr-assets-terminal-search-highlight/pr-18844/after-closeup.png)

The scroll position is identical in both, which is the point: the selection always walked into the scrollback correctly — before this fix nothing on screen said so.

<details>
<summary>Full-window frames</summary>

Before:

![before window](https://raw.githubusercontent.com/AntonioKL/orca/pr-assets-terminal-search-highlight/pr-18844/before-window.png)

After:

![after window](https://raw.githubusercontent.com/AntonioKL/orca/pr-assets-terminal-search-highlight/pr-18844/after-window.png)

</details>

## Testing

`pnpm lint` and `pnpm typecheck` pass locally on macOS, as do the two test files this change touches. I interrupted the full `pnpm test` run partway through to free the machine for the evidence captures above; the failures it had reached by then were all in unrelated areas (WSL exec mode, real-binary integration specs, repo census tests) and none in code this PR touches. CI covers the full suite and `pnpm build`.

New automated coverage:

- `src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts` — asserts shortcut navigation passes `decorations.activeMatchBackground`, the exact property whose absence caused the bug.
- `src/renderer/src/components/TerminalSearch.test.tsx` — asserts the counter renders the reported position/total, is dropped when the query is emptied, renders red `0/0` for a zero result, and renders `1000+` / a bare total instead of a zero position when the addon reports `resultIndex: -1`.

The before/after frames were produced by a throwaway Playwright spec on the `electron-headless` project (isolated userData, seeded repo), run once on this branch and once with the two source files reverted to `main`. The spec is not part of the diff.

Manual repro (macOS; use Ctrl+G on Linux/Windows):

1. Run an agent CLI that redraws continuously (e.g. `claude`) in a terminal pane, or otherwise build up several screens of scrollback containing a repeated term that does **not** appear on the visible screen.
2. Cmd+F, type the term.
3. Press Cmd+G repeatedly.

Before: the view scrolls but no active-match highlight follows, and there is no count. After: the highlight follows each jump and the counter advances.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The root cause was identified by reading the pinned `@xterm/addon-search` sources against Orca's two search call sites; the fix, tests, and this description were authored in that session and reviewed by me.

## Review

Self-review across the dimensions the contributing guide asks for:

- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code added. The Cmd-vs-Ctrl decision already lives in `matchSearchNavigate` (`isMac ? e.metaKey : e.ctrlKey`) and is untouched; this change only alters the options object handed to the addon. No paths, no shell, no accelerators.
- **Remote / SSH:** none. Terminal find runs entirely in the renderer against the local xterm buffer — no IPC, no RPC params, no stream frames, no change to anything a client and host exchange, so there is no wire-compatibility surface.
- **Agents / integrations / git providers:** none touched. The behavior is agent-agnostic; Claude Code is only the workload that made the bug obvious, because it writes continuously.
- **Mobile:** not affected — `TerminalSearch` is desktop renderer only; nothing under `mobile/` references it.
- **Performance:** `buildTerminalSearchOptions` allocates one small object per find call, which is what the find bar already did. The real change is that shortcut-driven searches no longer switch off the addon's post-write highlight refresh, so that refresh now stays armed the way it already does for find-bar searches; it is bounded by the addon's own 200 ms debounce and its `highlightLimit` of 1000. Worth flagging honestly: #10879 (O(k²) scrollback trim when evicting decorated lines) is reachable from this path too now, but the exposure is not new — the find bar already armed the same refresh on every keystroke. This change makes the two paths consistent rather than adding a new cost.
- **UI quality:** the counter reuses the overlay's existing zinc palette and `text-xs` scale, uses `tabular-nums` so the width does not jitter as the index advances, and `text-red-400` for a zero result — the same treatment used elsewhere in the codebase. It renders only while a query is active, so the find bar is unchanged at rest. No new translatable strings (digits and a slash only), so the localization catalog is untouched and `pnpm lint`'s localization checks pass.
- **Security:** no new input surface, no IPC, no dynamic evaluation. The search term is still bounded by `getFindRequestQuery` / `FIND_QUERY_MAX_BYTES` before it reaches the addon, and `safeFind` still contains the decoration positive-integer crash on both paths.
- **Backwards compatibility:** no persisted state, settings, schema, or protocol changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

One behavior worth a reviewer's eye: keeping `decorations` on the shortcut path re-arms the addon's `_updateMatches` post-write refresh for shortcut-driven searches. That is deliberate — it is what keeps highlights in sync while a pane is producing output — but it is the one behavioral side effect beyond "the highlight now moves".

Separately, and out of scope here: in a pane that never stops writing, that same `_updateMatches` tick re-runs `findPrevious` 200 ms after every write, and `findPreviousWithSelection` falls back to the bottom of the buffer when the terminal has no selection. If a search anchor is ever lost mid-session, that fallback drags the current match back down to the live screen. Fixing it means changing `_updateMatches` in the vendored addon patch, so I left it out of this PR.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint` and `pnpm typecheck` pass locally, plus the tests this change touches; CI covers the full `pnpm test` and `pnpm build`

