### PR TITLE
Remove the deprecated verified parameter from the url stanza

### DIFF
--- a/Casks/orca.rb
+++ b/Casks/orca.rb
@@ -5,8 +5,7 @@ cask "orca" do
   sha256 arm:   "fc707f290ff3b631b7b7947bf339885b61a43d2e89475997c125b61268ed4966",
          intel: "5f677c13a08f7a5740442e29d388285a86488c8c1f7aa5f10a8721a2c6ede8e4"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"

--- a/Casks/orca@rc.rb
+++ b/Casks/orca@rc.rb
@@ -5,8 +5,7 @@ cask "orca@rc" do
   sha256 arm:   "563b6b14323fc9d5489299c82442d514bc12cabffc9d06d3964ed572af4b3955",
          intel: "457088c7021f07de1a419197f7b2bd00092741ad4727d4fef3d86af38a6831e7"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca RC"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"


### PR DESCRIPTION
## ELI5

Homebrew used to let a cask say "I have verified this download URL". It dropped that feature, so anything still saying it gets told off. The orca cask still says it, and the telling-off is printed on almost every `brew` command anyone with orca installed runs. This deletes the one line that asks for it. Nothing about how orca installs or updates changes.

## What Changed

Removed the deprecated `verified:` parameter from the `url` stanza of `Casks/orca.rb` and `Casks/orca@rc.rb` (and the now-trailing comma on the `url` line). Two lines, no other change.

## Why

Homebrew deprecated the parameter on 2026-07-23 (Homebrew/brew@a3fc881, "Remove cask verified parameter"). Since then, every Homebrew command that loads an installed cask from a tap prints:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the stablyai/homebrew-orca tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/stablyai/homebrew-orca/Casks/orca.rb:8
```

Casks served from the homebrew-cask API never hit this, but a tapped cask is parsed as Ruby by every command that enumerates installed casks, so orca users get it from `brew list`, `outdated`, `upgrade`, `cleanup` and `autoremove` alike. On one routine update run it printed 11 times: 33 of the 75 output lines.

The parameter is inert in current Homebrew — `Cask::URL` still accepts and stores it, but nothing reads it any more, since the audit that used it went away in the same commit — so dropping it changes no behaviour. Homebrew's own message says to rely on the default URL verification instead.

It is also on a clock: `odeprecated` raises instead of warning once a deprecation is flipped to disabled, and already does so today for anyone with `HOMEBREW_DEVELOPER` set.

```ruby
disable = true if disable_for_developers && Homebrew::EnvConfig.developer?
```

At that point `brew list` / `outdated` / `upgrade` abort outright for every user with orca installed, rather than just printing a warning.

Both casks are changed here because the tap is generated from this repo (`homebrew-orca` README: "do not hand-edit here"). A code search confirms these are the only two occurrences.

## Linked Issue

Fixes #18849

## Visual Proof

`N/A` — this is a Homebrew cask definition, not application code. There is no UI or interaction surface; the only observable difference is the absence of the warning on stderr, shown under Testing.

## Testing

Verified on Homebrew 6.0.22 (macOS 26.6.2, arm64) by applying this exact change to the installed tap copy and restoring it afterwards:

```
# before
$ brew info --cask stablyai/orca/orca 2>&1 >/dev/null
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! ...
Please report this issue to the stablyai/homebrew-orca tap ...

# after
$ brew info --cask stablyai/orca/orca 2>&1 >/dev/null
(no output)
```

The cask still loads and resolves correctly after the change:

```
$ brew info --cask stablyai/orca/orca
==> orca (Orca): 1.4.197 (auto_updates)
IDE for orchestrating AI coding agents across terminals and worktrees
https://onorca.dev/
```

`ruby -c` passes on both files.

`pnpm lint` / `typecheck` / `test` / `build` were not run: the change touches no TypeScript, no runtime code and no build input — only two Ruby cask definitions — so those checks are unaffected. Happy to run them if you would rather have them on the record.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No test added: the repo has no test surface for the cask definitions, and the behaviour under test would be Homebrew's own deprecation handling.

## AI Disclosure

Claude Opus 5, used through Claude Code, for the diagnosis and for drafting this change and description. Reviewed by me before opening.

## Review

Code review summary against the areas the contributing guide asks for:

- **Cross-platform:** no impact. The cask is macOS-only by definition (`depends_on macos: :big_sur`), and the parameter removed is metadata read by Homebrew, which exists only on macOS and Linux. No Windows or Linux code path touches it.
- **Remote / SSH / local:** no impact. Nothing here participates in worktree, process, credential or network resolution; the download URL string itself is unchanged.
- **Agent / integration / git provider:** no impact. No provider-specific or agent-specific behaviour is involved.
- **Performance:** no impact, beyond removing one deprecation warning per cask load.
- **UI quality:** not applicable, no UI surface.
- **Security:** no weakening. `verified:` was a hint used by `brew audit` to accept a URL whose host differs from the homepage; that audit no longer exists, and nothing in current Homebrew reads the stored value. The URL, its host and the `sha256` checksums that actually gate the install are untouched.
- **Backwards compatibility:** the parameter has been accepted-but-ignored since 2026-07-23 and is scheduled to become a hard error. Removing it is strictly forward-compatible; older Homebrew versions parse the stanza without it just fine.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No release version changes are included, per the contributing guide. The tap's `version` and `sha256` lines are rewritten by the release bot on every bump and are untouched here, so this change survives future bumps.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
