### PR TITLE
feat(terminal): show TraeCLI session titles in tabs

### DIFF
--- a/src/renderer/src/components/floating-terminal/use-floating-terminal-panel-items.ts
+++ b/src/renderer/src/components/floating-terminal/use-floating-terminal-panel-items.ts
@@ -101,7 +101,9 @@ export function useFloatingTerminalPanelItems({
                 {
                   ...tab,
                   quickCommandLabel: tab.quickCommandLabel ?? terminalTab.quickCommandLabel,
-                  generatedLabel: tab.generatedLabel ?? terminalTab.generatedTitle
+                  generatedLabel: tab.generatedLabel ?? terminalTab.generatedTitle,
+                  defaultTitle: terminalTab.defaultTitle,
+                  launchAgent: terminalTab.launchAgent
                 },
                 generatedTabTitlesEnabled,
                 tab.label

--- a/src/renderer/src/components/tab-bar/recent-tab-switching.ts
+++ b/src/renderer/src/components/tab-bar/recent-tab-switching.ts
@@ -1,5 +1,6 @@
 import type { CtrlTabOrderMode, Tab, TabContentType, TabGroup } from '../../../../shared/tab-types'
 import { resolveUnifiedTabLabel } from '../../../../shared/tab-title-resolution'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { AppState } from '../../store/types'
 import { sanitizeRecentTabIds } from '../../store/slices/tab-group-state'
 import { getActiveTabNavOrder, type VisibleTabRef } from './group-tab-order'
@@ -87,23 +88,37 @@ function getActiveVisibleTabKey(
 
 function getTabLabel(
   tab: Tab | undefined,
+  terminalTab: TerminalTab | undefined,
   generatedTitlesEnabled: boolean,
   fallback: string
 ): string {
-  return resolveUnifiedTabLabel(tab, generatedTitlesEnabled, fallback)
+  return resolveUnifiedTabLabel(
+    tab
+      ? {
+          ...tab,
+          defaultTitle: terminalTab?.defaultTitle,
+          launchAgent: terminalTab?.launchAgent
+        }
+      : undefined,
+    generatedTitlesEnabled,
+    fallback
+  )
 }
 
 function toSwitcherItem(
   entry: VisibleTabRef,
   tabById: ReadonlyMap<string, Tab>,
+  terminalTabById: ReadonlyMap<string, TerminalTab>,
   dirtyFileIds: ReadonlySet<string>,
   generatedTitlesEnabled: boolean
 ): RecentTabSwitcherItem {
   const backingTab = entry.tabId ? tabById.get(entry.tabId) : undefined
+  const terminalTab =
+    backingTab?.contentType === 'terminal' ? terminalTabById.get(backingTab.entityId) : undefined
   return {
     ...entry,
     key: getVisibleTabKey(entry),
-    label: getTabLabel(backingTab, generatedTitlesEnabled, entry.id),
+    label: getTabLabel(backingTab, terminalTab, generatedTitlesEnabled, entry.id),
     contentType: backingTab?.contentType ?? (entry.type === 'editor' ? 'editor' : entry.type),
     isDirty: entry.type === 'editor' && dirtyFileIds.has(entry.id)
   }
@@ -162,6 +177,9 @@ export function buildRecentTabSwitcherModel(
   const tabById = new Map(
     (state.unifiedTabsByWorktree[worktreeId] ?? []).map((tab) => [tab.id, tab])
   )
+  const terminalTabById = new Map(
+    (state.tabsByWorktree[worktreeId] ?? []).map((tab) => [tab.id, tab])
+  )
   const dirtyFileIds = new Set(
     state.openFiles
       .filter((file) => file.worktreeId === worktreeId && file.isDirty)
@@ -170,7 +188,13 @@ export function buildRecentTabSwitcherModel(
   const generatedTitlesEnabled = state.settings?.tabAutoGenerateTitle === true
   const itemByKey = new Map(
     visibleEntries.map((entry) => {
-      const item = toSwitcherItem(entry, tabById, dirtyFileIds, generatedTitlesEnabled)
+      const item = toSwitcherItem(
+        entry,
+        tabById,
+        terminalTabById,
+        dirtyFileIds,
+        generatedTitlesEnabled
+      )
       return [item.key, item] as const
     })
   )

--- a/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupItemProjections.ts
@@ -78,7 +78,9 @@ export function useTabGroupItemProjections({
               {
                 ...item,
                 quickCommandLabel: item.quickCommandLabel ?? terminalTab?.quickCommandLabel,
-                generatedLabel: item.generatedLabel ?? terminalTab?.generatedTitle
+                generatedLabel: item.generatedLabel ?? terminalTab?.generatedTitle,
+                defaultTitle: terminalTab?.defaultTitle,
+                launchAgent: terminalTab?.launchAgent
               },
               worktreeState.generatedTabTitlesEnabled,
               item.label

--- a/src/renderer/src/lib/tui-agent-startup.test.ts
+++ b/src/renderer/src/lib/tui-agent-startup.test.ts
@@ -125,10 +125,11 @@ describe('buildAgentStartupPlan', () => {
       })
     ).toEqual({
       agent: 'trae',
-      launchCommand: "traecli -- 'Summarize the failing tests'",
+      launchCommand:
+        "traecli '-c' 'tui.terminal_title=[\"thread-title\"]' -- 'Summarize the failing tests'",
       expectedProcess: 'traecli',
       followupPrompt: null,
-      launchConfig: emptyLaunchConfig('traecli')
+      launchConfig: emptyLaunchConfig("traecli '-c' 'tui.terminal_title=[\"thread-title\"]'")
     })
   })
 
@@ -141,7 +142,7 @@ describe('buildAgentStartupPlan', () => {
         cmdOverrides: {},
         platform: 'linux'
       })?.launchCommand
-    ).toBe("traecli -- 'help me name this config'")
+    ).toBe("traecli '-c' 'tui.terminal_title=[\"thread-title\"]' -- 'help me name this config'")
   })
 
   it('passes the prompt to Prime Agent as a positional argv behind a `--` separator', () => {

--- a/src/renderer/src/lib/workspace-tab-palette-entry-builder.ts
+++ b/src/renderer/src/lib/workspace-tab-palette-entry-builder.ts
@@ -203,7 +203,9 @@ export function buildSearchableWorkspaceTabEntries({
             ...tab,
             customLabel: tab.customLabel ?? terminalTab?.customTitle ?? null,
             quickCommandLabel: tab.quickCommandLabel ?? terminalTab?.quickCommandLabel,
-            generatedLabel: tab.generatedLabel ?? terminalTab?.generatedTitle
+            generatedLabel: tab.generatedLabel ?? terminalTab?.generatedTitle,
+            defaultTitle: terminalTab?.defaultTitle,
+            launchAgent: terminalTab?.launchAgent
           },
           generatedTitlesEnabled,
           terminalTitle

--- a/src/renderer/src/runtime/sync-runtime-graph/sync-projections.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/sync-projections.ts
@@ -27,7 +27,13 @@ export function getBrowserPagesByWorkspace(state: AppState): AppState['browserPa
 export function resolveRuntimeTerminalTitle(
   tab: Pick<
     TerminalTab,
-    'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title'
+    | 'customTitle'
+    | 'quickCommandLabel'
+    | 'aiVaultTitle'
+    | 'generatedTitle'
+    | 'title'
+    | 'defaultTitle'
+    | 'launchAgent'
   >,
   generatedTitlesEnabled: boolean,
   liveTitle = tab.title

--- a/src/renderer/src/store/pinned-tab-close-guard.ts
+++ b/src/renderer/src/store/pinned-tab-close-guard.ts
@@ -11,7 +11,20 @@ export function resolvePinnedTabLabel(
   const tab = (state.unifiedTabsByWorktree?.[worktreeId] ?? []).find(
     (candidate) => candidate.id === visibleId || candidate.entityId === visibleId
   )
-  return resolveUnifiedTabLabel(tab, state.settings?.tabAutoGenerateTitle === true)
+  const terminalTab =
+    tab?.contentType === 'terminal'
+      ? (state.tabsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === tab.entityId)
+      : undefined
+  return resolveUnifiedTabLabel(
+    tab
+      ? {
+          ...tab,
+          defaultTitle: terminalTab?.defaultTitle,
+          launchAgent: terminalTab?.launchAgent
+        }
+      : undefined,
+    state.settings?.tabAutoGenerateTitle === true
+  )
 }
 
 /** Whether the unified tab matching `tabId` (by id or entityId) in the given

--- a/src/shared/tab-title-resolution.test.ts
+++ b/src/shared/tab-title-resolution.test.ts
@@ -48,6 +48,76 @@ describe('tab title resolution', () => {
     ).toBe('Refactor auth')
   })
 
+  it('uses TraeCLI native thread titles before generated titles', () => {
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          defaultTitle: 'Terminal 1',
+          generatedTitle: 'Orca generated',
+          launchAgent: 'trae',
+          title: 'Repair authentication retries'
+        },
+        true
+      )
+    ).toBe('Repair authentication retries')
+  })
+
+  it('keeps manual and quick command labels ahead of TraeCLI native titles', () => {
+    const tab = {
+      defaultTitle: 'Terminal 1',
+      generatedTitle: 'Orca generated',
+      launchAgent: 'trae' as const,
+      title: 'Repair authentication retries'
+    }
+    expect(
+      resolveTerminalTabTitle(
+        { ...tab, customTitle: 'Manual label', quickCommandLabel: 'Run tests' },
+        true
+      )
+    ).toBe('Manual label')
+    expect(
+      resolveTerminalTabTitle({ ...tab, customTitle: null, quickCommandLabel: 'Run tests' }, true)
+    ).toBe('Run tests')
+  })
+
+  it('does not promote generic, unnamed, or non-Trae live titles over generated titles', () => {
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          defaultTitle: 'Terminal 1',
+          generatedTitle: 'Orca generated',
+          launchAgent: 'trae',
+          title: 'Terminal 1'
+        },
+        true
+      )
+    ).toBe('Orca generated')
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'Orca generated',
+          launchAgent: 'trae',
+          title: '01991234-7abc-4def-8123-0123456789ab'
+        },
+        true
+      )
+    ).toBe('Orca generated')
+    expect(
+      resolveTerminalTabTitle(
+        {
+          customTitle: null,
+          generatedTitle: 'Orca generated',
+          launchAgent: 'codex',
+          title: 'Repair authentication retries'
+        },
+        true
+      )
+    ).toBe('Orca generated')
+  })
+
   it('places quick command labels between manual and generated titles', () => {
     expect(
       resolveTerminalTabTitle(
@@ -179,6 +249,21 @@ describe('tab title resolution', () => {
         true
       )
     ).toBe('OC | Native Stable Session')
+  })
+
+  it('uses TraeCLI native thread titles for unified labels', () => {
+    expect(
+      resolveUnifiedTabLabel(
+        {
+          customLabel: null,
+          defaultTitle: 'Terminal 1',
+          generatedLabel: 'Orca generated',
+          label: 'Repair authentication retries',
+          launchAgent: 'trae'
+        },
+        true
+      )
+    ).toBe('Repair authentication retries')
   })
 
   it('keeps manual and quick command labels ahead of native OpenCode labels', () => {

--- a/src/shared/tab-title-resolution.ts
+++ b/src/shared/tab-title-resolution.ts
@@ -2,10 +2,34 @@ import type { Tab } from './tab-types'
 import type { TerminalTab } from './terminal-tab-types'
 import { isMeaningfulOpenCodeTerminalTitle } from './opencode-terminal-title'
 
+type NativeTerminalTitleMetadata = Partial<Pick<TerminalTab, 'defaultTitle' | 'launchAgent'>>
+
+const UUID_TITLE_PATTERN = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i
+
+function isPreferredNativeTerminalTitle(
+  title: string,
+  metadata: NativeTerminalTitleMetadata
+): boolean {
+  if (isMeaningfulOpenCodeTerminalTitle(title)) {
+    return true
+  }
+  if (metadata.launchAgent !== 'trae') {
+    return false
+  }
+  const defaultTitle = metadata.defaultTitle?.trim()
+  return title !== defaultTitle && !/^Terminal \d+$/.test(title) && !UUID_TITLE_PATTERN.test(title)
+}
+
 export function resolveTerminalTabTitle(
   tab: Pick<
     TerminalTab,
-    'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title'
+    | 'customTitle'
+    | 'quickCommandLabel'
+    | 'aiVaultTitle'
+    | 'generatedTitle'
+    | 'title'
+    | 'defaultTitle'
+    | 'launchAgent'
   >,
   generatedTitlesEnabled: boolean,
   fallback = ''
@@ -14,7 +38,7 @@ export function resolveTerminalTabTitle(
   return (
     tab.customTitle?.trim() ||
     tab.quickCommandLabel?.trim() ||
-    (isMeaningfulOpenCodeTerminalTitle(liveTitle) ? liveTitle : '') ||
+    (isPreferredNativeTerminalTitle(liveTitle, tab) ? liveTitle : '') ||
     tab.aiVaultTitle?.title.trim() ||
     (generatedTitlesEnabled ? tab.generatedTitle?.trim() : '') ||
     liveTitle ||
@@ -24,7 +48,11 @@ export function resolveTerminalTabTitle(
 
 export function resolveUnifiedTabLabel(
   tab:
-    | Pick<Tab, 'customLabel' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedLabel' | 'label'>
+    | (Pick<
+        Tab,
+        'customLabel' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedLabel' | 'label'
+      > &
+        NativeTerminalTitleMetadata)
     | undefined,
   generatedTitlesEnabled: boolean,
   fallback = ''
@@ -33,7 +61,7 @@ export function resolveUnifiedTabLabel(
   return (
     tab?.customLabel?.trim() ||
     tab?.quickCommandLabel?.trim() ||
-    (isMeaningfulOpenCodeTerminalTitle(liveLabel) ? liveLabel : '') ||
+    (isPreferredNativeTerminalTitle(liveLabel, tab ?? {}) ? liveLabel : '') ||
     tab?.aiVaultTitle?.title.trim() ||
     (generatedTitlesEnabled ? tab?.generatedLabel?.trim() : '') ||
     liveLabel ||

--- a/src/shared/tui-agent-config.test.ts
+++ b/src/shared/tui-agent-config.test.ts
@@ -29,4 +29,8 @@ describe('TUI_AGENT_CONFIG', () => {
       expect(TUI_AGENT_CONFIG[agent as TuiAgent]).toMatchObject(expected)
     }
   })
+
+  it('enables TraeCLI native thread titles as structured launch arguments', () => {
+    expect(TUI_AGENT_CONFIG.trae.launchArgs).toEqual(['-c', 'tui.terminal_title=["thread-title"]'])
+  })
 })

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -26,6 +26,8 @@ export type TuiAgentConfig = {
   /** Detection runtimes where this launch mode is not available as a detected agent. */
   detectUnsupportedRuntimes?: readonly TuiAgentDetectionRuntime[]
   launchCmd: string
+  /** Arguments Orca always adds before user-configured agent arguments. */
+  launchArgs?: readonly string[]
   /** Platform-specific launch command when the public binary name differs. */
   launchCmdByPlatform?: Partial<Record<NodeJS.Platform, string>>
   expectedProcess: string
@@ -116,6 +118,10 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     // Why: the unrelated open-source bytedance/trae-agent also installs a `trae-cli`
     // binary, so detect TRAE CN's CLI on `traecli`, an alias only TRAE CN ships.
     detectCmd: 'traecli',
+    // Why: TraeCLI publishes its live thread name through OSC 0 only when the
+    // thread-title item is enabled. Keeping this as argv lets every target
+    // shell quote the JSON value correctly.
+    launchArgs: ['-c', 'tui.terminal_title=["thread-title"]'],
     // Why: `traecli [prompt]` takes the task as a positional argv, same as Claude/Codex.
     promptInjectionMode: 'argv',
     // Why: separator so prompts starting with `help`/`config`/`-…` aren't parsed as a

--- a/src/shared/tui-agent-launch-command.ts
+++ b/src/shared/tui-agent-launch-command.ts
@@ -32,11 +32,14 @@ export function resolveAgentLaunchCommand(args: {
   isRemote?: boolean
 }): ResolvedAgentLaunchCommand {
   const override = args.cmdOverrides[args.agent]
-  const command =
+  const launchCommand =
     override ||
     getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
       isRemote: args.isRemote
     })
+  const launchArgs = TUI_AGENT_CONFIG[args.agent].launchArgs ?? []
+  const quotedLaunchArgs = launchArgs.map((arg) => quoteStartupArg(arg, args.shell)).join(' ')
+  const command = quotedLaunchArgs ? `${launchCommand} ${quotedLaunchArgs}` : launchCommand
   const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
   if (!suffix.ok) {
     return suffix

--- a/src/shared/tui-agent-launch-command.ts
+++ b/src/shared/tui-agent-launch-command.ts
@@ -5,6 +5,7 @@ import {
 import type { SessionOptionValue } from './native-chat-session-options'
 import { getTuiAgentLaunchCommand, TUI_AGENT_CONFIG } from './tui-agent-config'
 import {
+  isPosixStartupShell,
   planAgentCliArgsSuffix,
   quoteStartupArg,
   tokenizeStartupCommand,
@@ -31,15 +32,26 @@ export function resolveAgentLaunchCommand(args: {
   sessionOptionsOverrideAgentArgs?: boolean
   isRemote?: boolean
 }): ResolvedAgentLaunchCommand {
+  const config = TUI_AGENT_CONFIG[args.agent]
   const override = args.cmdOverrides[args.agent]
   const launchCommand =
     override ||
-    getTuiAgentLaunchCommand(TUI_AGENT_CONFIG[args.agent], args.platform, {
+    getTuiAgentLaunchCommand(config, args.platform, {
       isRemote: args.isRemote
     })
-  const launchArgs = TUI_AGENT_CONFIG[args.agent].launchArgs ?? []
+  const launchArgs = config.launchArgs ?? []
   const quotedLaunchArgs = launchArgs.map((arg) => quoteStartupArg(arg, args.shell)).join(' ')
-  const command = quotedLaunchArgs ? `${launchCommand} ${quotedLaunchArgs}` : launchCommand
+  const command =
+    override && quotedLaunchArgs
+      ? insertLaunchArgsIntoOverride(
+          override,
+          quotedLaunchArgs,
+          [config.detectCmd, ...(config.detectCmdAliases ?? [])],
+          args.shell
+        )
+      : quotedLaunchArgs
+        ? `${launchCommand} ${quotedLaunchArgs}`
+        : launchCommand
   const suffix = planAgentCliArgsSuffix(args.agentArgs, args.shell)
   if (!suffix.ok) {
     return suffix
@@ -101,6 +113,47 @@ export function resolveAgentLaunchCommand(args: {
     commandWithoutSessionOptions,
     appliedSessionOptions: resolvedOptions.appliedValues
   }
+}
+
+/**
+ * Inserts Orca-owned arguments immediately after a directly invoked agent binary.
+ * User override arguments therefore stay later (and can override defaults), while
+ * an option terminator cannot turn the injected arguments into positional input.
+ */
+function insertLaunchArgsIntoOverride(
+  command: string,
+  quotedLaunchArgs: string,
+  executableNames: readonly string[],
+  shell: AgentStartupShell
+): string {
+  const tokenized = tokenizeStartupCommand(command, shell)
+  if (!tokenized.ok) {
+    return command
+  }
+  const normalizedNames = new Set(executableNames.map(normalizeExecutableName))
+  let commandPosition = true
+  for (let index = 0; index < tokenized.tokens.length; index += 1) {
+    const token = tokenized.tokens[index]
+    if (commandPosition && normalizedNames.has(normalizeExecutableName(token))) {
+      const insertionPoint = tokenized.spans[index].end
+      return `${command.slice(0, insertionPoint)} ${quotedLaunchArgs}${command.slice(insertionPoint)}`
+    }
+    if (commandPosition) {
+      if (isPosixStartupShell(shell) && /^[A-Za-z_][A-Za-z0-9_]*=/.test(token)) {
+        continue
+      }
+      if (shell === 'powershell' && index === 0 && token === '&') {
+        continue
+      }
+      commandPosition = false
+    }
+  }
+  return command
+}
+
+function normalizeExecutableName(commandToken: string): string {
+  const basename = commandToken.split(/[\\/]/).pop() ?? ''
+  return basename.replace(/\.(exe|cmd|bat|ps1)$/i, '').toLowerCase()
 }
 
 function insertBeforeTerminator(tokens: readonly string[], inserted: readonly string[]): string[] {

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -162,6 +162,70 @@ describe('tui agent startup plans', () => {
     )
   })
 
+  it.each([
+    {
+      shell: 'posix' as const,
+      platform: 'linux' as const,
+      override: '/opt/trae/bin/traecli --profile work --',
+      expected:
+        "/opt/trae/bin/traecli '-c' 'tui.terminal_title=[\"thread-title\"]' --profile work --"
+    },
+    {
+      shell: 'powershell' as const,
+      platform: 'win32' as const,
+      override: "& 'C:\\Tools\\traecli.exe' --profile work --",
+      expected:
+        "& 'C:\\Tools\\traecli.exe' '-c' 'tui.terminal_title=[\"thread-title\"]' --profile work --"
+    },
+    {
+      shell: 'cmd' as const,
+      platform: 'win32' as const,
+      override: '"C:\\Program Files\\traecli.cmd" --profile work --',
+      expected:
+        '"C:\\Program Files\\traecli.cmd" "-c" "tui.terminal_title=[^"thread-title^"]" --profile work --'
+    }
+  ])(
+    'inserts TraeCLI native arguments before override arguments and terminators on $shell',
+    ({ shell, platform, override, expected }) => {
+      const plan = buildAgentStartupPlan({
+        agent: 'trae',
+        prompt: '',
+        cmdOverrides: { trae: override },
+        platform,
+        shell,
+        allowEmptyPromptLaunch: true
+      })
+
+      expect(plan?.launchCommand).toBe(expected)
+    }
+  )
+
+  it('keeps explicit TraeCLI configuration in a command override after the native default', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'trae',
+      prompt: '',
+      cmdOverrides: { trae: "/opt/traecli -c 'tui.terminal_title=[]'" },
+      platform: 'linux',
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe(
+      "/opt/traecli '-c' 'tui.terminal_title=[\"thread-title\"]' -c 'tui.terminal_title=[]'"
+    )
+  })
+
+  it('does not pass TraeCLI arguments to an unrelated command override', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'trae',
+      prompt: '',
+      cmdOverrides: { trae: 'custom-trae-wrapper --mode proxy' },
+      platform: 'linux',
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe('custom-trae-wrapper --mode proxy')
+  })
+
   it('places the Grok prompt separator after configured agent arguments', () => {
     const plan = buildAgentStartupPlan({
       agent: 'grok',

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -119,6 +119,49 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe('grok -- "help"')
   })
 
+  it.each([
+    {
+      shell: 'posix' as const,
+      platform: 'linux' as const,
+      expected: "traecli '-c' 'tui.terminal_title=[\"thread-title\"]' -- 'fix the title'"
+    },
+    {
+      shell: 'powershell' as const,
+      platform: 'win32' as const,
+      expected: "traecli '-c' 'tui.terminal_title=[\"thread-title\"]' -- 'fix the title'"
+    },
+    {
+      shell: 'cmd' as const,
+      platform: 'win32' as const,
+      expected: 'traecli "-c" "tui.terminal_title=[^"thread-title^"]" -- "fix the title"'
+    }
+  ])('quotes TraeCLI thread-title configuration for $shell', ({ shell, platform, expected }) => {
+    const plan = buildAgentStartupPlan({
+      agent: 'trae',
+      prompt: 'fix the title',
+      cmdOverrides: {},
+      platform,
+      shell
+    })
+
+    expect(plan?.launchCommand).toBe(expected)
+  })
+
+  it('keeps explicit TraeCLI configuration after the native title default', () => {
+    const plan = buildAgentStartupPlan({
+      agent: 'trae',
+      prompt: '',
+      cmdOverrides: {},
+      agentArgs: '-c tui.terminal_title=[]',
+      platform: 'linux',
+      allowEmptyPromptLaunch: true
+    })
+
+    expect(plan?.launchCommand).toBe(
+      "traecli '-c' 'tui.terminal_title=[\"thread-title\"]' '-c' 'tui.terminal_title=[]'"
+    )
+  })
+
   it('places the Grok prompt separator after configured agent arguments', () => {
     const plan = buildAgentStartupPlan({
       agent: 'grok',

--- a/tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js
+++ b/tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js
@@ -23,6 +23,9 @@ function render() {
     `${keyboardProtocolMode ? '\x1b]0;\u280b Codex is thinking\x07\x1b[>1u' : '\x1b]0;Golden Stub Agent\x07'}${[
       '\x1b[H\x1b[2JGolden Stub Agent',
       `[${READY_MARKER}]`,
+      ...(process.env.GOLDEN_STUB_AGENT_REPORT_ARGS === '1'
+        ? [`[GOLDEN_STUB_AGENT_ARGS] ${JSON.stringify(process.argv.slice(2))}`]
+        : []),
       '',
       ...renderedComposer,
       '',

--- a/tests/e2e/fixtures/golden-stub-agent/traecli
+++ b/tests/e2e/fixtures/golden-stub-agent/traecli
@@ -1,0 +1,2 @@
+#!/bin/sh
+GOLDEN_STUB_AGENT_REPORT_ARGS=1 exec "$(dirname "$0")/golden-stub-agent" "$@"

--- a/tests/e2e/fixtures/golden-stub-agent/traecli.cmd
+++ b/tests/e2e/fixtures/golden-stub-agent/traecli.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+set "GOLDEN_STUB_AGENT_REPORT_ARGS=1"
+call "%~dp0golden-stub-agent.cmd" %*
+endlocal

--- a/tests/e2e/golden-tab-bar-agent-launch.spec.ts
+++ b/tests/e2e/golden-tab-bar-agent-launch.spec.ts
@@ -44,7 +44,44 @@ for (const { id, menuItemName } of GOLDEN_STUB_AGENTS) {
     const activeTab = orcaPage.locator('[data-testid="sortable-tab"][data-active="true"]')
     await expect(activeTab).toHaveAttribute('data-tab-title', /Golden Stub Agent|Codex|Claude/i)
     // The marker distinguishes an agent launch from an identical bare-shell tab.
-    expect(await getTerminalContent(orcaPage)).toContain(GOLDEN_STUB_READY_MARKER)
+    const terminalContent = await getTerminalContent(orcaPage)
+    expect(terminalContent).toContain(GOLDEN_STUB_READY_MARKER)
+    if (id === 'trae') {
+      expect(terminalContent).toContain('tui.terminal_title=["thread-title"]')
+      await orcaPage.evaluate(() => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('Orca store is unavailable')
+        }
+        const state = store.getState()
+        const worktreeId = state.activeWorktreeId
+        const terminalTab = (state.tabsByWorktree[worktreeId ?? ''] ?? []).find(
+          (tab) => tab.launchAgent === 'trae'
+        )
+        if (!worktreeId || !terminalTab) {
+          throw new Error('Launched Trae terminal tab is unavailable')
+        }
+        const generatedTitle = 'Orca generated title'
+        store.setState({
+          settings: { ...state.settings, tabAutoGenerateTitle: true },
+          tabsByWorktree: {
+            ...state.tabsByWorktree,
+            [worktreeId]: state.tabsByWorktree[worktreeId]!.map((tab) =>
+              tab.id === terminalTab.id ? { ...tab, generatedTitle } : tab
+            )
+          },
+          unifiedTabsByWorktree: {
+            ...state.unifiedTabsByWorktree,
+            [worktreeId]: (state.unifiedTabsByWorktree[worktreeId] ?? []).map((tab) =>
+              tab.contentType === 'terminal' && tab.entityId === terminalTab.id
+                ? { ...tab, generatedLabel: generatedTitle }
+                : tab
+            )
+          }
+        })
+      })
+      await expect(activeTab).toHaveAttribute('data-tab-title', 'Golden Stub Agent')
+    }
   })
 }
 

--- a/tests/e2e/helpers/golden-stub-agent.ts
+++ b/tests/e2e/helpers/golden-stub-agent.ts
@@ -10,7 +10,8 @@ export const GOLDEN_STUB_EXIT_MARKER = 'GOLDEN_STUB_AGENT_EXITED'
 /** Agents exposed by the fixture directory for tab-bar detection. */
 export const GOLDEN_STUB_AGENTS = [
   { id: 'codex', menuItemName: /^Codex(?:\s|$)/i },
-  { id: 'claude', menuItemName: /^Claude(?:\s|$)/i }
+  { id: 'claude', menuItemName: /^Claude(?:\s|$)/i },
+  { id: 'trae', menuItemName: /^Trae(?:\s|$)/i }
 ] as const
 
 const fixtureDir = path.join(process.cwd(), 'tests', 'e2e', 'fixtures', 'golden-stub-agent')

--- a/tests/e2e/helpers/golden-stub-agent.ts
+++ b/tests/e2e/helpers/golden-stub-agent.ts
@@ -3,6 +3,7 @@ import type { Page } from '@stablyai/playwright-test'
 import { expect } from '@stablyai/playwright-test'
 import { focusActiveTerminalInput, waitForTerminalOutput } from './terminal'
 import type { BuiltInWindowsTerminalShell } from '../../../src/shared/windows-terminal-shell'
+import { quoteStartupArg } from '../../../src/shared/tui-agent-startup-shell'
 
 export const GOLDEN_STUB_READY_MARKER = 'GOLDEN_STUB_AGENT_READY'
 export const GOLDEN_STUB_EXIT_MARKER = 'GOLDEN_STUB_AGENT_EXITED'
@@ -15,6 +16,17 @@ export const GOLDEN_STUB_AGENTS = [
 ] as const
 
 const fixtureDir = path.join(process.cwd(), 'tests', 'e2e', 'fixtures', 'golden-stub-agent')
+
+function getGoldenStubAgentCommand(agent: (typeof GOLDEN_STUB_AGENTS)[number]['id']): string {
+  const executable = agent === 'trae' ? 'traecli' : agent
+  // Why absolute on POSIX: Orca's bash wrapper sources /etc/profile, and some
+  // distributions replace PATH there before the startup command is delivered.
+  // Windows shells keep the fixture PATH and need different absolute-path
+  // invocation syntax, so use the bare shim name there.
+  return process.platform === 'win32'
+    ? executable
+    : quoteStartupArg(path.join(fixtureDir, executable), 'posix')
+}
 
 export function getGoldenStubAgentLaunchEnv(): NodeJS.ProcessEnv {
   const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
@@ -33,20 +45,26 @@ export async function configureGoldenStubAgent(
   } = {}
 ): Promise<void> {
   const agent = options.agent ?? 'codex'
+  const agentCommand = getGoldenStubAgentCommand(agent)
   await page.evaluate(
-    async ({ agent, agentArgs, windowsShell }) => {
+    async ({ agent, agentCommand, agentArgs, windowsShell }) => {
       const store = window.__store
       if (!store) {
         throw new Error('Orca store is unavailable')
       }
       await store.getState().updateSettings({
         defaultTuiAgent: agent,
-        agentCmdOverrides: { [agent]: 'golden-stub-agent' },
+        agentCmdOverrides: { [agent]: agentCommand },
         agentDefaultArgs: { [agent]: agentArgs },
         ...(windowsShell ? { terminalWindowsShell: windowsShell } : {})
       })
     },
-    { agent, agentArgs: options.agentArgs ?? '', windowsShell: options.windowsShell ?? null }
+    {
+      agent,
+      agentCommand,
+      agentArgs: options.agentArgs ?? '',
+      windowsShell: options.windowsShell ?? null
+    }
   )
 }
 


### PR DESCRIPTION
## ELI5

TraeCLI already knows the current session name and can publish it to the terminal. Orca now enables that signal when it launches TraeCLI and uses the live session name for the tab, so a renamed TraeCLI session is as easy to find as a Codex session.

## What Changed

- Launch TraeCLI with `-c 'tui.terminal_title=["thread-title"]'` so it publishes its thread title through OSC 0.
- Keep launch arguments structured until shell rendering, including POSIX, PowerShell, and cmd quoting. Explicit user agent arguments remain last and can override the default setting.
- Prefer meaningful TraeCLI live titles over AI Vault/generated titles across the tab strip, floating terminals, command palette, recent-tab switcher, pinned-tab close prompt, and runtime/mobile projections.
- Preserve the existing higher priority of manual names and quick-command labels. Ignore default terminal labels and initial UUID placeholders.
- Extend the existing golden agent-launch E2E matrix with TraeCLI and add focused title-resolution and shell-rendering coverage.

## Why

Without the launch setting, TraeCLI does not publish its thread name. Even when a live OSC title is available, Orca's generated title currently wins, so the tab can remain stuck on its workspace or first generated description. Consuming TraeCLI's native terminal title updates live and avoids coupling Orca to TraeCLI session files.

## Linked Issue

Fixes #18853

## Visual Proof

These are real baseline-vs-PR screenshots, not a stub agent. Both use the same clean `orca` workspace, the installed TraeCode CLI v0.202.3, a real authenticated session in an isolated config home, and the same `/rename Trae session titles` command through Orca's real Electron/PTY path.

**Before — base `af82126`: Orca keeps the default workspace title `orca`**

![Baseline Orca with the normal TraeCode CLI UI and a renamed thread, while the tab remains orca](https://github.com/user-attachments/assets/46963a5d-63ed-42c6-8b56-4a67cdbaec7b)

**After — PR head: the same tab follows the TraeCLI session title**

![PR head with the same normal TraeCode CLI UI and the tab updated to Trae session titles](https://github.com/user-attachments/assets/971263db-1218-4ff9-bfee-1bd6ca12e35f)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated on Linux:

- Real Orca baseline/head black-box comparison: both Electron builds launched the installed TraeCLI through a real PTY, with real auth copied into an isolated `TRAE_HOME`/`TRAECLI_HOME`. On the same clean `orca` workspace and after the same `/rename Trae session titles`, base kept `orca` while PR head changed the tab to `Trae session titles` (`1 passed` on each revision).
- Real installed `traecli` in tmux with no mocks: the pane title started as a thread UUID; after `/rename`, it updated live to the session title.
- Automated Electron + PTY golden test: Codex, Claude, and Trae cases passed. The Trae case verifies the actual argv, OSC 0 ingestion, generated-title competition, and rendered tab DOM (`3 passed`, `4` Windows/WSL cases skipped on Linux). This stub-based test is automated regression coverage only; the screenshots above come from real TraeCLI.
- Focused Vitest coverage: `6` files, `118` tests passed.
- TypeScript checks: `tc:node`, `tc:web`, and `tc:cli` passed.
- Changed-code quality gate: `0` findings.
- `git diff --check` passed.
- The repository pre-commit hook completed successfully.

PowerShell, cmd, custom override ordering, and durable launch configuration are covered by unit tests. Windows and WSL execution remain for CI because this host is Linux. The local full `pnpm lint`, `pnpm test`, and `pnpm build` suites were not run; CI will cover the repository-wide gates.

## AI Disclosure

TraeCode (GPT-5) was used to help implement, test, and prepare this change. The user-visible behavior was validated with the real TraeCLI binary, real authentication, and real Electron/PTY runs on both the base and PR revisions.

## Review

The behavior is scoped to terminals launched with `launchAgent === 'trae'`; other agents retain their existing title precedence. The feature adds no session-file reads, network calls, or persisted user configuration.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Local, folder-workspace, SSH, and WSL launches share the same startup-plan builder.
- Shell quoting is selected at the execution boundary for POSIX shells, PowerShell, and cmd.
- User-provided agent arguments are appended after Orca's default, so a later `-c 'tui.terminal_title=[]'` can opt out.
- Existing manual-title and quick-command precedence is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for the UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` suite (focused local gates passed; CI will cover the full suite)
