### PR TITLE
fix(windows): resolve a PowerShell host instead of naming Windows PowerShell

### DIFF
--- a/src/main/claude-accounts/claude-account-service-login-process.test.ts
+++ b/src/main/claude-accounts/claude-account-service-login-process.test.ts
@@ -529,7 +529,8 @@ describe('ClaudeAccountService credential capture', () => {
       waitForTerminationPid: () =>
         new Promise<number>((resolve) => {
           publishTerminationPid = resolve
-        })
+        }),
+      hasRelayedPid: () => true
     }))
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
     vi.doMock('../../shared/windows-interactive-login-spawn', () => ({

--- a/src/main/claude-accounts/claude-account-service-login-process.test.ts
+++ b/src/main/claude-accounts/claude-account-service-login-process.test.ts
@@ -40,6 +40,15 @@ vi.mock('./keychain', () => ({
   writeManagedClaudeKeychainCredentials: vi.fn(async () => {})
 }))
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('ClaudeAccountService credential capture', () => {
   beforeEach(() => {
     setPlatform('darwin')

--- a/src/main/claude-accounts/claude-command-process.ts
+++ b/src/main/claude-accounts/claude-command-process.ts
@@ -4,6 +4,7 @@ import {
   buildWindowsHostInteractiveLoginSpawn,
   type WindowsHostInteractiveLoginSpawn
 } from '../../shared/windows-interactive-login-spawn'
+import { recordLoginConsoleStartIfMissed } from '../crash-reporting/login-console-start-breadcrumb'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import { buildWindowsCommandInvocation } from './windows-command-invocation'
 import { terminateClaudeProcess } from './claude-login-process-termination'
@@ -150,6 +151,7 @@ export function runClaudeCommandProcess(
       }
       settle(() => {
         if (code === 0 || options?.allowFailure) {
+          recordLoginConsoleStartIfMissed(interactiveLogin, 'claude')
           resolvePromise(output)
           return
         }

--- a/src/main/claude-accounts/claude-command-process.ts
+++ b/src/main/claude-accounts/claude-command-process.ts
@@ -158,7 +158,14 @@ export async function runClaudeCommandProcess(
       }
       settle(() => {
         if (code === 0 || options?.allowFailure) {
-          recordLoginConsoleStartIfMissed(interactiveLogin, 'claude')
+          if (recordLoginConsoleStartIfMissed(interactiveLogin, 'claude')) {
+            rejectPromise(
+              new Error(
+                'PowerShell could not start the Claude sign-in console. Check that PowerShell 7 is available and try again.'
+              )
+            )
+            return
+          }
           resolvePromise(output)
           return
         }

--- a/src/main/claude-accounts/claude-command-process.ts
+++ b/src/main/claude-accounts/claude-command-process.ts
@@ -4,6 +4,7 @@ import {
   buildWindowsHostInteractiveLoginSpawn,
   type WindowsHostInteractiveLoginSpawn
 } from '../../shared/windows-interactive-login-spawn'
+import { warmWindowsPowerShellHostCache } from '../../shared/windows-powershell-host'
 import { recordLoginConsoleStartIfMissed } from '../crash-reporting/login-console-start-breadcrumb'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import { buildWindowsCommandInvocation } from './windows-command-invocation'
@@ -29,19 +30,25 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
-export function runClaudeCommandProcess(
+export async function runClaudeCommandProcess(
   args: string[],
   configDir: ClaudeCommandConfig,
   timeoutMs: number,
   options?: ClaudeCommandOptions
 ): Promise<string> {
+  const isWindowsHostInteractiveLogin =
+    process.platform === 'win32' &&
+    configDir.linuxPath === null &&
+    configDir.wslDistro === null &&
+    args[0] === 'auth' &&
+    args[1] === 'login'
+  if (isWindowsHostInteractiveLogin) {
+    // Why here and not at spawn time: resolving the host runs PowerShell, and
+    // the console builder is synchronous — probing there would block the main
+    // process for as long as the slowest candidate takes to start.
+    await warmWindowsPowerShellHostCache()
+  }
   return new Promise((resolvePromise, rejectPromise) => {
-    const isWindowsHostInteractiveLogin =
-      process.platform === 'win32' &&
-      configDir.linuxPath === null &&
-      configDir.wslDistro === null &&
-      args[0] === 'auth' &&
-      args[1] === 'login'
     // Why lazy: the WSL branch runs `claude` inside the distro, so resolving a
     // host binary there would be wasted filesystem probing for a path never used.
     let cachedHostClaudeCommand: string | null = null

--- a/src/main/claude-accounts/claude-command-process.ts
+++ b/src/main/claude-accounts/claude-command-process.ts
@@ -1,3 +1,4 @@
+import { waitForPromiseWithSignal } from '../../shared/abort-signal-reason'
 import { spawnProcess } from '../../shared/child-process/run-process'
 import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import {
@@ -11,6 +12,7 @@ import { buildWindowsCommandInvocation } from './windows-command-invocation'
 import { terminateClaudeProcess } from './claude-login-process-termination'
 
 const MAX_COMMAND_OUTPUT_CHARS = 4_000
+const CLAUDE_SIGN_IN_CANCELLED = 'Claude sign-in was cancelled.'
 const CLAUDE_AUTH_DENIED_PATTERN =
   /\baccess_denied\b|authorization (?:request )?(?:was )?denied|sign-?in (?:was )?denied|login (?:was )?denied/i
 
@@ -46,7 +48,19 @@ export async function runClaudeCommandProcess(
     // Why here and not at spawn time: resolving the host runs PowerShell, and
     // the console builder is synchronous — probing there would block the main
     // process for as long as the slowest candidate takes to start.
-    await warmWindowsPowerShellHostCache()
+    //
+    // Why the signal: that is up to 20s per candidate with nothing spawned yet,
+    // so a cancel during it must end this wait rather than sit out the budget
+    // and then open a console anyway. The warm-up itself is left running — it is
+    // shared and cached, so cancelling it would discard work other callers await.
+    await waitForPromiseWithSignal(warmWindowsPowerShellHostCache(), options?.signal).catch(
+      // The warm-up always yields a host, so the only rejection is the abort,
+      // which the check below turns into this caller's own cancellation error.
+      () => {}
+    )
+    if (options?.signal?.aborted) {
+      throw new Error(CLAUDE_SIGN_IN_CANCELLED)
+    }
   }
   return new Promise((resolvePromise, rejectPromise) => {
     // Why lazy: the WSL branch runs `claude` inside the distro, so resolving a
@@ -145,7 +159,7 @@ export async function runClaudeCommandProcess(
       }
     }
     const onAbort = (): void => {
-      killChild(() => settle(() => rejectPromise(new Error('Claude sign-in was cancelled.'))))
+      killChild(() => settle(() => rejectPromise(new Error(CLAUDE_SIGN_IN_CANCELLED))))
     }
     const onError = (error: Error): void => {
       if (!terminationPending) {

--- a/src/main/claude-accounts/claude-login-completion.oracle.test.ts
+++ b/src/main/claude-accounts/claude-login-completion.oracle.test.ts
@@ -19,6 +19,15 @@ vi.mock('../codex-cli/command', () => ({
   resolveClaudeCommand: () => 'claude.exe'
 }))
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so this stays a test about settling.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 vi.mock('./keychain', () => ({
   deleteActiveClaudeKeychainCredentialsStrict: vi.fn(),
   deleteManagedClaudeKeychainCredentials: vi.fn(),
@@ -113,6 +122,9 @@ describe('native Windows Claude login completion oracle', () => {
         completions += 1
       })
 
+    // Why: the native Windows login resolves a PowerShell host before it
+    // spawns, so the child has no listeners until that promise settles.
+    await flushPromiseCallbacks()
     child.emit('exit', 0)
     await flushPromiseCallbacks()
 

--- a/src/main/claude-accounts/claude-login-completion.oracle.test.ts
+++ b/src/main/claude-accounts/claude-login-completion.oracle.test.ts
@@ -1,6 +1,22 @@
 import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as LoginSpawn from '../../shared/windows-interactive-login-spawn'
+
+vi.mock('../../shared/windows-interactive-login-spawn', async () => {
+  const actual = await vi.importActual<typeof LoginSpawn>(
+    '../../shared/windows-interactive-login-spawn'
+  )
+  return {
+    ...actual,
+    buildWindowsHostInteractiveLoginSpawn: (
+      ...args: Parameters<typeof actual.buildWindowsHostInteractiveLoginSpawn>
+    ) => ({
+      ...actual.buildWindowsHostInteractiveLoginSpawn(...args),
+      hasRelayedPid: () => true
+    })
+  }
+})
 
 const processMocks = vi.hoisted(() => ({
   spawn: vi.fn()

--- a/src/main/claude-accounts/claude-login-completion.oracle.test.ts
+++ b/src/main/claude-accounts/claude-login-completion.oracle.test.ts
@@ -123,7 +123,15 @@ describe('native Windows Claude login completion oracle', () => {
     const destroyStdout = vi.spyOn(child.stdout, 'destroy')
     const destroyStderr = vi.spyOn(child.stderr, 'destroy')
     const abortController = new AbortController()
+    const addAbortListener = vi.spyOn(abortController.signal, 'addEventListener')
     const removeAbortListener = vi.spyOn(abortController.signal, 'removeEventListener')
+    // Why balance rather than a fixed count: the native Windows login also
+    // subscribes while it waits for a PowerShell host, so the property that
+    // matters is that every subscription is torn down — not how many there are.
+    const expectNoLeakedAbortListener = (): void => {
+      expect(addAbortListener.mock.calls.length).toBeGreaterThan(0)
+      expect(removeAbortListener).toHaveBeenCalledTimes(addAbortListener.mock.calls.length)
+    }
     processMocks.spawn.mockReturnValue(child)
     const runner = await createRunner()
     let completions = 0
@@ -154,7 +162,7 @@ describe('native Windows Claude login completion oracle', () => {
       expect(destroyStdin).toHaveBeenCalledTimes(1)
       expect(destroyStdout).toHaveBeenCalledTimes(1)
       expect(destroyStderr).toHaveBeenCalledTimes(1)
-      expect(removeAbortListener).toHaveBeenCalledTimes(1)
+      expectNoLeakedAbortListener()
 
       child.emit('close', 0)
       await vi.advanceTimersByTimeAsync(1001)
@@ -164,7 +172,7 @@ describe('native Windows Claude login completion oracle', () => {
       expect(destroyStdin).toHaveBeenCalledTimes(1)
       expect(destroyStdout).toHaveBeenCalledTimes(1)
       expect(destroyStderr).toHaveBeenCalledTimes(1)
-      expect(removeAbortListener).toHaveBeenCalledTimes(1)
+      expectNoLeakedAbortListener()
     } finally {
       child.emit('close', 0)
       await command

--- a/src/main/claude-accounts/claude-windows-interactive-login.test.ts
+++ b/src/main/claude-accounts/claude-windows-interactive-login.test.ts
@@ -13,6 +13,15 @@ vi.mock('../codex-cli/command', () => ({
   resolveClaudeCommand: vi.fn(() => 'C:\\Tools\\claude.cmd')
 }))
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('Claude Windows host interactive login', () => {
   afterEach(() => {
     restorePlatform()

--- a/src/main/claude-accounts/claude-windows-interactive-login.test.ts
+++ b/src/main/claude-accounts/claude-windows-interactive-login.test.ts
@@ -27,7 +27,7 @@ describe('Claude Windows host interactive login', () => {
     restorePlatform()
   })
 
-  it('resolves a Windows auth login whose child has no piped streams', async () => {
+  it.each([true, false])('requires proof of console startup: relayedPid=%s', async (relayedPid) => {
     setPlatform('win32')
     vi.resetModules()
     const child = new EventEmitter() as EventEmitter & {
@@ -59,7 +59,7 @@ describe('Claude Windows host interactive login', () => {
       ],
       stdio: 'ignore' as const,
       windowsHide: true,
-      hasRelayedPid: () => true
+      hasRelayedPid: () => relayedPid
     }))
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
     vi.doMock('../../shared/windows-interactive-login-spawn', () => ({
@@ -73,7 +73,7 @@ describe('Claude Windows host interactive login', () => {
         createService() as never,
         createService() as never
       )
-      await (
+      const login = (
         service as unknown as {
           runClaudeCommand(
             args: string[],
@@ -86,6 +86,9 @@ describe('Claude Windows host interactive login', () => {
         { windowsPath: 'C:\\tmp\\claude-auth', linuxPath: null, wslDistro: null },
         1000
       )
+      await (relayedPid
+        ? expect(login).resolves.toBe('')
+        : expect(login).rejects.toThrow('PowerShell could not start the Claude sign-in console'))
 
       expect(buildInteractiveLoginSpawn).toHaveBeenCalledWith('C:\\Tools\\claude.cmd', [
         'auth',

--- a/src/main/claude-accounts/claude-windows-interactive-login.test.ts
+++ b/src/main/claude-accounts/claude-windows-interactive-login.test.ts
@@ -49,7 +49,8 @@ describe('Claude Windows host interactive login', () => {
         '--claudeai'
       ],
       stdio: 'ignore' as const,
-      windowsHide: true
+      windowsHide: true,
+      hasRelayedPid: () => true
     }))
     vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
     vi.doMock('../../shared/windows-interactive-login-spawn', () => ({

--- a/src/main/claude-accounts/claude-windows-interactive-login.test.ts
+++ b/src/main/claude-accounts/claude-windows-interactive-login.test.ts
@@ -13,12 +13,13 @@ vi.mock('../codex-cli/command', () => ({
   resolveClaudeCommand: vi.fn(() => 'C:\\Tools\\claude.cmd')
 }))
 
+const POWERSHELL_HOST = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
 // Why: the login path now waits for a PowerShell host to be resolved, and that
 // resolution spawns real processes. Pin it so these tests keep testing the login.
 vi.mock('../../shared/windows-powershell-host', () => ({
-  warmWindowsPowerShellHostCache: () =>
-    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
-  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  warmWindowsPowerShellHostCache: () => Promise.resolve(POWERSHELL_HOST),
+  getWindowsPowerShellHost: () => POWERSHELL_HOST,
   setWindowsPowerShellHostResolutionObserver: () => {}
 }))
 
@@ -156,6 +157,49 @@ describe('Claude Windows host interactive login', () => {
     } finally {
       vi.useRealTimers()
       vi.doUnmock('node:child_process')
+    }
+  })
+
+  // Host resolution is up to 20s per candidate with nothing spawned yet, so a
+  // cancel during it must end this wait instead of sitting out the budget and
+  // then opening a sign-in console the user already dismissed.
+  it('ends the sign-in when cancelled while the PowerShell host is still resolving', async () => {
+    setPlatform('win32')
+    vi.resetModules()
+    const spawnMock = vi.fn()
+    let releaseWarmUp: (host: string) => void = () => {}
+    vi.doMock('../../shared/windows-powershell-host', () => ({
+      warmWindowsPowerShellHostCache: () =>
+        new Promise<string>((resolve) => {
+          releaseWarmUp = resolve
+        }),
+      getWindowsPowerShellHost: () => POWERSHELL_HOST,
+      setWindowsPowerShellHostResolutionObserver: () => {}
+    }))
+    vi.doMock('node:child_process', () => ({ spawn: spawnMock }))
+
+    try {
+      const { runClaudeCommandProcess } = await import('./claude-command-process')
+      const controller = new AbortController()
+      const login = runClaudeCommandProcess(
+        ['auth', 'login', '--claudeai'],
+        { windowsPath: 'C:\\tmp\\claude-auth', linuxPath: null, wslDistro: null },
+        1000,
+        { signal: controller.signal }
+      )
+
+      controller.abort()
+      await expect(login).rejects.toThrow('Claude sign-in was cancelled.')
+      expect(spawnMock).not.toHaveBeenCalled()
+
+      // The warm-up is shared and cached, so it is left running rather than
+      // cancelled — but its late answer must not revive the abandoned sign-in.
+      releaseWarmUp(POWERSHELL_HOST)
+      await Promise.resolve()
+      expect(spawnMock).not.toHaveBeenCalled()
+    } finally {
+      vi.doUnmock('node:child_process')
+      vi.doUnmock('../../shared/windows-powershell-host')
     }
   })
 })

--- a/src/main/codex-accounts/codex-login-session.ts
+++ b/src/main/codex-accounts/codex-login-session.ts
@@ -214,7 +214,17 @@ export async function runCodexLoginSession(
           code === 0 ||
           (loginTreeKilledAfterAuth && readLoginAuthSnapshot(authJsonPath) !== null)
         ) {
-          recordLoginConsoleStartIfMissed(spawnConfig.interactiveLogin, 'codex')
+          if (
+            !loginTreeKilledAfterAuth &&
+            recordLoginConsoleStartIfMissed(spawnConfig.interactiveLogin, 'codex')
+          ) {
+            rejectPromise(
+              new Error(
+                'PowerShell could not start the Codex sign-in console. Check that PowerShell 7 is available and try again.'
+              )
+            )
+            return
+          }
           resolvePromise()
           return
         }

--- a/src/main/codex-accounts/codex-login-session.ts
+++ b/src/main/codex-accounts/codex-login-session.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { WindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
 import { buildWindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
+import { recordLoginConsoleStartIfMissed } from '../crash-reporting/login-console-start-breadcrumb'
 import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { resolveCodexCommand } from '../codex-cli/command'
@@ -206,6 +207,7 @@ export async function runCodexLoginSession(
           code === 0 ||
           (loginTreeKilledAfterAuth && readLoginAuthSnapshot(authJsonPath) !== null)
         ) {
+          recordLoginConsoleStartIfMissed(spawnConfig.interactiveLogin, 'codex')
           resolvePromise()
           return
         }

--- a/src/main/codex-accounts/codex-login-session.ts
+++ b/src/main/codex-accounts/codex-login-session.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { WindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
 import { buildWindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
+import { warmWindowsPowerShellHostCache } from '../../shared/windows-powershell-host'
 import { recordLoginConsoleStartIfMissed } from '../crash-reporting/login-console-start-breadcrumb'
 import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { parseWslUncPath } from '../../shared/wsl-paths'
@@ -91,6 +92,12 @@ export async function runCodexLoginSession(
   const initialAuthSnapshot = wslInfo
     ? null
     : readLoginAuthSnapshot(join(managedHomePath, 'auth.json'))
+  if (!wslInfo && process.platform === 'win32') {
+    // Why here and not at spawn time: resolving the host runs PowerShell, and
+    // the console builder is synchronous — probing there would block the main
+    // process for as long as the slowest candidate takes to start.
+    await warmWindowsPowerShellHostCache()
+  }
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
     const spawnConfig = wslInfo

--- a/src/main/codex-accounts/codex-windows-interactive-login.test.ts
+++ b/src/main/codex-accounts/codex-windows-interactive-login.test.ts
@@ -37,7 +37,7 @@ vi.mock('../../shared/windows-powershell-host', () => ({
 describe('Codex Windows host interactive login', () => {
   registerCodexAccountsTestHomes()
 
-  it('resolves a Windows login whose child has no piped streams', async () => {
+  it.each([true, false])('requires proof of console startup: relayedPid=%s', async (relayedPid) => {
     vi.resetModules()
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
     Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
@@ -60,7 +60,7 @@ describe('Codex Windows host interactive login', () => {
       args: ['/d', '/c', 'start', '', '/wait', 'C:\\Tools\\codex.cmd', 'login'],
       stdio: 'ignore' as const,
       windowsHide: true,
-      hasRelayedPid: () => true
+      hasRelayedPid: () => relayedPid
     }))
     vi.doMock('node:child_process', () => ({
       execFileSync: vi.fn(),
@@ -80,11 +80,14 @@ describe('Codex Windows host interactive login', () => {
         createRateLimits() as never,
         createRuntimeHome() as never
       )
-      await (
+      const login = (
         service as unknown as {
           runCodexLogin(managedHomePath: string): Promise<void>
         }
       ).runCodexLogin(testState.fakeHomeDir)
+      await (relayedPid
+        ? expect(login).resolves.toBeUndefined()
+        : expect(login).rejects.toThrow('PowerShell could not start the Codex sign-in console'))
 
       expect(buildInteractiveLoginSpawn).toHaveBeenCalledWith('C:\\Tools\\codex.cmd', ['login'])
       expect(spawnMock).toHaveBeenCalledWith(

--- a/src/main/codex-accounts/codex-windows-interactive-login.test.ts
+++ b/src/main/codex-accounts/codex-windows-interactive-login.test.ts
@@ -50,7 +50,8 @@ describe('Codex Windows host interactive login', () => {
       command: getCmdExePath(),
       args: ['/d', '/c', 'start', '', '/wait', 'C:\\Tools\\codex.cmd', 'login'],
       stdio: 'ignore' as const,
-      windowsHide: true
+      windowsHide: true,
+      hasRelayedPid: () => true
     }))
     vi.doMock('node:child_process', () => ({
       execFileSync: vi.fn(),

--- a/src/main/codex-accounts/codex-windows-interactive-login.test.ts
+++ b/src/main/codex-accounts/codex-windows-interactive-login.test.ts
@@ -25,6 +25,15 @@ vi.mock('node:os', async () => {
   }
 })
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('Codex Windows host interactive login', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/service-account-add-login.test.ts
+++ b/src/main/codex-accounts/service-account-add-login.test.ts
@@ -31,6 +31,15 @@ vi.mock('node:os', async () => {
   }
 })
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('CodexAccountService config sync', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/service-account-add-login.test.ts
+++ b/src/main/codex-accounts/service-account-add-login.test.ts
@@ -40,6 +40,23 @@ vi.mock('../../shared/windows-powershell-host', () => ({
   setWindowsPowerShellHostResolutionObserver: () => {}
 }))
 
+// Why: on a Windows host the login runs behind a console wrapper whose payload
+// relays its PID, and a login that never relays one is now reported as a failed
+// sign-in. These tests drive a fake child that writes no PID file, so pin a
+// wrapper that did start — the subject here is the config seeding, not the host.
+vi.mock('../../shared/windows-interactive-login-spawn', () => ({
+  buildWindowsHostInteractiveLoginSpawn: (command: string, args: string[]) => ({
+    command,
+    args,
+    stdio: 'ignore' as const,
+    windowsHide: true,
+    cleanup: () => {},
+    getTerminationPid: () => null,
+    waitForTerminationPid: () => Promise.resolve(null),
+    hasRelayedPid: () => true
+  })
+}))
+
 describe('CodexAccountService config sync', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/service-login-process-teardown.test.ts
+++ b/src/main/codex-accounts/service-login-process-teardown.test.ts
@@ -27,6 +27,15 @@ vi.mock('node:os', async () => {
   }
 })
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('CodexAccountService config sync', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/service-quota-refresh-decoupling.test.ts
+++ b/src/main/codex-accounts/service-quota-refresh-decoupling.test.ts
@@ -28,6 +28,29 @@ vi.mock('node:os', async () => {
   }
 })
 
+// Why: the login path resolves a PowerShell host, and on a Windows host it runs
+// behind a console wrapper whose payload relays its PID. Both are real process
+// launches; pin them so this stays a test about the quota refresh.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
+vi.mock('../../shared/windows-interactive-login-spawn', () => ({
+  buildWindowsHostInteractiveLoginSpawn: (command: string, args: string[]) => ({
+    command,
+    args,
+    stdio: 'ignore' as const,
+    windowsHide: true,
+    cleanup: () => {},
+    getTerminationPid: () => null,
+    waitForTerminationPid: () => Promise.resolve(null),
+    hasRelayedPid: () => true
+  })
+}))
+
 describe('CodexAccountService config sync', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/service-reauthenticate-activation.test.ts
+++ b/src/main/codex-accounts/service-reauthenticate-activation.test.ts
@@ -11,6 +11,22 @@ import { EventEmitter } from 'node:events'
 import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
+import type * as LoginSpawn from '../../shared/windows-interactive-login-spawn'
+
+vi.mock('../../shared/windows-interactive-login-spawn', async () => {
+  const actual = await vi.importActual<typeof LoginSpawn>(
+    '../../shared/windows-interactive-login-spawn'
+  )
+  return {
+    ...actual,
+    buildWindowsHostInteractiveLoginSpawn: (
+      ...args: Parameters<typeof actual.buildWindowsHostInteractiveLoginSpawn>
+    ) => ({
+      ...actual.buildWindowsHostInteractiveLoginSpawn(...args),
+      hasRelayedPid: () => true
+    })
+  }
+})
 import type { GlobalSettings } from '../../shared/global-settings-types'
 import {
   createCodexAuthJson,

--- a/src/main/codex-accounts/service-reauthenticate-activation.test.ts
+++ b/src/main/codex-accounts/service-reauthenticate-activation.test.ts
@@ -78,6 +78,15 @@ function createLoginSpawn(onLogin?: () => void) {
   })
 }
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('CodexAccountService reauthenticate activation intent', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts
+++ b/src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts
@@ -133,6 +133,15 @@ function listManagedHomes(): string[] {
   return realReaddirSync(root).map((accountId) => join(root, accountId, 'home'))
 }
 
+// Why: the login path now waits for a PowerShell host to be resolved, and that
+// resolution spawns real processes. Pin it so these tests keep testing the login.
+vi.mock('../../shared/windows-powershell-host', () => ({
+  warmWindowsPowerShellHostCache: () =>
+    Promise.resolve('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'),
+  getWindowsPowerShellHost: () => 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+  setWindowsPowerShellHostResolutionObserver: () => {}
+}))
+
 describe('STA-4734 a locked auth.json must not delete a just-authenticated home', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts
+++ b/src/main/codex-accounts/sta-4734-login-rollback-deletes-authenticated-home.test.ts
@@ -142,6 +142,23 @@ vi.mock('../../shared/windows-powershell-host', () => ({
   setWindowsPowerShellHostResolutionObserver: () => {}
 }))
 
+// Why: on a Windows host the login runs behind a console wrapper whose payload
+// relays its PID, and a login that never relays one is now reported as a failed
+// sign-in. The fake child here writes no PID file, so pin a wrapper that did
+// start — the subject is the rollback, not the host.
+vi.mock('../../shared/windows-interactive-login-spawn', () => ({
+  buildWindowsHostInteractiveLoginSpawn: (command: string, args: string[]) => ({
+    command,
+    args,
+    stdio: 'ignore' as const,
+    windowsHide: true,
+    cleanup: () => {},
+    getTerminationPid: () => null,
+    waitForTerminationPid: () => Promise.resolve(null),
+    hasRelayedPid: () => true
+  })
+}))
+
 describe('STA-4734 a locked auth.json must not delete a just-authenticated home', () => {
   registerCodexAccountsTestHomes()
 

--- a/src/main/crash-reporting/login-console-start-breadcrumb.test.ts
+++ b/src/main/crash-reporting/login-console-start-breadcrumb.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const recordDurableCrashBreadcrumb = vi.fn()
+
+vi.mock('./durable-crash-breadcrumb', () => ({
+  recordDurableCrashBreadcrumb
+}))
+
+const { recordLoginConsoleStartIfMissed } = await import('./login-console-start-breadcrumb')
+
+beforeEach(() => {
+  recordDurableCrashBreadcrumb.mockClear()
+})
+
+describe('recordLoginConsoleStartIfMissed', () => {
+  it('records the console that closed without ever running its payload', () => {
+    recordLoginConsoleStartIfMissed({ hasRelayedPid: () => false }, 'codex')
+    expect(recordDurableCrashBreadcrumb).toHaveBeenCalledWith('login_console_never_started', {
+      provider: 'codex'
+    })
+  })
+
+  it('stays quiet for a console that relayed its PID', () => {
+    recordLoginConsoleStartIfMissed({ hasRelayedPid: () => true }, 'claude')
+    expect(recordDurableCrashBreadcrumb).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet off the Windows console path', () => {
+    recordLoginConsoleStartIfMissed(null, 'claude')
+    expect(recordDurableCrashBreadcrumb).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/crash-reporting/login-console-start-breadcrumb.ts
+++ b/src/main/crash-reporting/login-console-start-breadcrumb.ts
@@ -1,23 +1,14 @@
 import type { WindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
 import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
 
-/**
- * Records the Windows sign-in consoles that closed without ever running their
- * payload.
- *
- * Why a breadcrumb and not a rejection: `start /wait` does not relay the
- * payload's exit code, so a PowerShell host that dies before the login script
- * runs closes the wrapper with 0 and the sign-in is reported as finished. The
- * caller then fails on missing credentials — an error that names neither
- * PowerShell nor the console — and nothing in the logs contradicts it. This
- * leaves that contradiction on the record for the next field report.
- */
+// A clean wrapper exit alone does not prove that PowerShell ran the login payload.
 export function recordLoginConsoleStartIfMissed(
   interactiveLogin: Pick<WindowsHostInteractiveLoginSpawn, 'hasRelayedPid'> | null | undefined,
   provider: 'claude' | 'codex'
-): void {
+): boolean {
   if (!interactiveLogin?.hasRelayedPid || interactiveLogin.hasRelayedPid()) {
-    return
+    return false
   }
   recordDurableCrashBreadcrumb('login_console_never_started', { provider })
+  return true
 }

--- a/src/main/crash-reporting/login-console-start-breadcrumb.ts
+++ b/src/main/crash-reporting/login-console-start-breadcrumb.ts
@@ -1,0 +1,23 @@
+import type { WindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+
+/**
+ * Records the Windows sign-in consoles that closed without ever running their
+ * payload.
+ *
+ * Why a breadcrumb and not a rejection: `start /wait` does not relay the
+ * payload's exit code, so a PowerShell host that dies before the login script
+ * runs closes the wrapper with 0 and the sign-in is reported as finished. The
+ * caller then fails on missing credentials — an error that names neither
+ * PowerShell nor the console — and nothing in the logs contradicts it. This
+ * leaves that contradiction on the record for the next field report.
+ */
+export function recordLoginConsoleStartIfMissed(
+  interactiveLogin: Pick<WindowsHostInteractiveLoginSpawn, 'hasRelayedPid'> | null | undefined,
+  provider: 'claude' | 'codex'
+): void {
+  if (!interactiveLogin?.hasRelayedPid || interactiveLogin.hasRelayedPid()) {
+    return
+  }
+  recordDurableCrashBreadcrumb('login_console_never_started', { provider })
+}

--- a/src/main/crash-reporting/login-console-start-breadcrumb.ts
+++ b/src/main/crash-reporting/login-console-start-breadcrumb.ts
@@ -1,7 +1,7 @@
 import type { WindowsHostInteractiveLoginSpawn } from '../../shared/windows-interactive-login-spawn'
 import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
 
-// A clean wrapper exit alone does not prove that PowerShell ran the login payload.
+/** A clean wrapper exit alone does not prove that PowerShell ran the login payload. */
 export function recordLoginConsoleStartIfMissed(
   interactiveLogin: Pick<WindowsHostInteractiveLoginSpawn, 'hasRelayedPid'> | null | undefined,
   provider: 'claude' | 'codex'

--- a/src/main/crash-reporting/powershell-host-resolution-breadcrumb.test.ts
+++ b/src/main/crash-reporting/powershell-host-resolution-breadcrumb.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { sanitizeCrashReportDetails } from '../../shared/crash-report-redaction'
+import type { WindowsPowerShellHostResolution } from '../../shared/windows-powershell-host'
+
+const mocks = vi.hoisted(() => ({ observer: vi.fn(), record: vi.fn() }))
+vi.mock('../../shared/windows-powershell-host', () => ({
+  setWindowsPowerShellHostResolutionObserver: mocks.observer,
+  warmWindowsPowerShellHostCache: vi.fn()
+}))
+vi.mock('./durable-crash-breadcrumb', () => ({ recordDurableCrashBreadcrumb: mocks.record }))
+
+import { registerPowerShellHostResolutionBreadcrumb } from './powershell-host-resolution-breadcrumb'
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('PowerShell host diagnostics', () => {
+  it('distinguishes all candidates from attempts and preserves host identity after redaction', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    registerPowerShellHostResolutionBreadcrumb()
+    const observer = mocks.observer.mock.calls.at(-1)![0] as (
+      resolution: WindowsPowerShellHostResolution
+    ) => void
+    const host = 'C:\\Users\\private-name\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe'
+    observer({
+      host,
+      candidates: [
+        'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+        host,
+        'C:\\Windows\\powershell.exe'
+      ],
+      fellBack: false,
+      attempts: [
+        {
+          path: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+          absent: true,
+          ok: false,
+          durationMs: 0
+        },
+        { path: host, ok: true, exitCode: 7, markerOk: true, durationMs: 6620 }
+      ]
+    })
+    const data = sanitizeCrashReportDetails(mocks.record.mock.calls.at(-1)![1])
+    expect(data).toMatchObject({
+      host: '[redacted-path]',
+      hostName: 'pwsh.exe',
+      selectedIndex: 1,
+      candidateCount: 3,
+      probedCount: 1,
+      skippedCount: 1,
+      untriedCount: 1
+    })
+    expect(data.attempt0).toContain('absent=true')
+    expect(data.attempt1).toContain('#1 pwsh.exe absent=false ok=true exit=7 marker=true')
+    expect(JSON.stringify(data)).not.toContain('private-name')
+  })
+})

--- a/src/main/crash-reporting/powershell-host-resolution-breadcrumb.test.ts
+++ b/src/main/crash-reporting/powershell-host-resolution-breadcrumb.test.ts
@@ -47,10 +47,45 @@ describe('PowerShell host diagnostics', () => {
       candidateCount: 3,
       probedCount: 1,
       skippedCount: 1,
+      unwrappableCount: 0,
       untriedCount: 1
     })
     expect(data.attempt0).toContain('absent=true')
-    expect(data.attempt1).toContain('#1 pwsh.exe absent=false ok=true exit=7 marker=true')
+    expect(data.attempt1).toContain(
+      '#1 pwsh.exe absent=false unwrappable=false ok=true exit=7 marker=true'
+    )
     expect(JSON.stringify(data)).not.toContain('private-name')
+  })
+
+  // Why its own outcome: "exists but the sign-in wrapper cannot launch it" and
+  // "never answered the probe" are opposite problems, and counting the first as
+  // a probe failure would send the reader hunting for a PowerShell that is fine.
+  it('separates a candidate the wrapper cannot launch from one that failed the probe', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    registerPowerShellHostResolutionBreadcrumb()
+    const observer = mocks.observer.mock.calls.at(-1)![0] as (
+      resolution: WindowsPowerShellHostResolution
+    ) => void
+    const unwrappable = 'C:\\Tools & Utils\\PowerShell\\7\\pwsh.exe'
+    const fallback = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+    observer({
+      host: fallback,
+      candidates: [unwrappable, fallback],
+      fellBack: true,
+      attempts: [
+        { path: unwrappable, unwrappable: true, ok: false, durationMs: 0 },
+        { path: fallback, ok: false, exitCode: 0, markerOk: false, durationMs: 8120 }
+      ]
+    })
+    const data = sanitizeCrashReportDetails(mocks.record.mock.calls.at(-1)![1])
+    expect(data).toMatchObject({
+      fellBack: true,
+      candidateCount: 2,
+      probedCount: 1,
+      skippedCount: 0,
+      unwrappableCount: 1,
+      untriedCount: 0
+    })
+    expect(data.attempt0).toContain('unwrappable=true')
   })
 })

--- a/src/main/crash-reporting/powershell-host-resolution-breadcrumb.ts
+++ b/src/main/crash-reporting/powershell-host-resolution-breadcrumb.ts
@@ -1,3 +1,4 @@
+import { win32 } from 'node:path'
 import {
   setWindowsPowerShellHostResolutionObserver,
   warmWindowsPowerShellHostCache,
@@ -5,20 +6,18 @@ import {
 } from '../../shared/windows-powershell-host'
 import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
 
-// Why bounded: the candidate list grows with PATH, and a breadcrumb carrying
-// forty entries evicts the ring it is meant to be read alongside. The
-// candidates that were actually spawned are the ones worth keeping.
+// Keep separate bounded fields so path redaction and string truncation preserve each result.
 const MAX_REPORTED_ATTEMPTS = 6
 
-function summarizeAttempts(resolution: WindowsPowerShellHostResolution): string {
-  return resolution.attempts
-    .filter((attempt) => !attempt.absent)
-    .slice(0, MAX_REPORTED_ATTEMPTS)
-    .map(
-      (attempt) =>
-        `${attempt.path} ok=${attempt.ok} exit=${attempt.exitCode ?? 'none'} marker=${attempt.markerOk ?? false} timedOut=${attempt.timedOut ?? false} ms=${attempt.durationMs}`
-    )
-    .join(' | ')
+function summarizeAttempts(resolution: WindowsPowerShellHostResolution): Record<string, string> {
+  return Object.fromEntries(
+    resolution.attempts
+      .slice(0, MAX_REPORTED_ATTEMPTS)
+      .map((attempt, index) => [
+        `attempt${index}`,
+        `#${resolution.candidates.indexOf(attempt.path)} ${win32.basename(attempt.path)} absent=${attempt.absent ?? false} ok=${attempt.ok} exit=${attempt.exitCode ?? 'none'} marker=${attempt.markerOk ?? false} timedOut=${attempt.timedOut ?? false} ms=${attempt.durationMs}`
+      ])
+  )
 }
 
 /**
@@ -34,10 +33,14 @@ export function registerPowerShellHostResolutionBreadcrumb(): void {
   setWindowsPowerShellHostResolutionObserver((resolution) => {
     recordDurableCrashBreadcrumb('powershell_host_selected', {
       host: resolution.host,
+      hostName: win32.basename(resolution.host),
+      selectedIndex: resolution.candidates.indexOf(resolution.host),
       fellBack: resolution.fellBack,
       probedCount: resolution.attempts.filter((attempt) => !attempt.absent).length,
-      candidateCount: resolution.attempts.length,
-      attempts: summarizeAttempts(resolution)
+      candidateCount: resolution.candidates.length,
+      skippedCount: resolution.attempts.filter((attempt) => attempt.absent).length,
+      untriedCount: resolution.candidates.length - resolution.attempts.length,
+      ...summarizeAttempts(resolution)
     })
   })
 }

--- a/src/main/crash-reporting/powershell-host-resolution-breadcrumb.ts
+++ b/src/main/crash-reporting/powershell-host-resolution-breadcrumb.ts
@@ -1,0 +1,55 @@
+import {
+  setWindowsPowerShellHostResolutionObserver,
+  warmWindowsPowerShellHostCache,
+  type WindowsPowerShellHostResolution
+} from '../../shared/windows-powershell-host'
+import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+
+// Why bounded: the candidate list grows with PATH, and a breadcrumb carrying
+// forty entries evicts the ring it is meant to be read alongside. The
+// candidates that were actually spawned are the ones worth keeping.
+const MAX_REPORTED_ATTEMPTS = 6
+
+function summarizeAttempts(resolution: WindowsPowerShellHostResolution): string {
+  return resolution.attempts
+    .filter((attempt) => !attempt.absent)
+    .slice(0, MAX_REPORTED_ATTEMPTS)
+    .map(
+      (attempt) =>
+        `${attempt.path} ok=${attempt.ok} exit=${attempt.exitCode ?? 'none'} marker=${attempt.markerOk ?? false} timedOut=${attempt.timedOut ?? false} ms=${attempt.durationMs}`
+    )
+    .join(' | ')
+}
+
+/**
+ * Records which PowerShell host Orca picked, and what every probed candidate
+ * did. Without it a failed login only shows that some PowerShell ran — not
+ * whether the chosen host answered the probe or the fallback was taken because
+ * every candidate timed out, which are opposite problems with the same symptom.
+ */
+export function registerPowerShellHostResolutionBreadcrumb(): void {
+  if (process.platform !== 'win32') {
+    return
+  }
+  setWindowsPowerShellHostResolutionObserver((resolution) => {
+    recordDurableCrashBreadcrumb('powershell_host_selected', {
+      host: resolution.host,
+      fellBack: resolution.fellBack,
+      probedCount: resolution.attempts.filter((attempt) => !attempt.absent).length,
+      candidateCount: resolution.attempts.length,
+      attempts: summarizeAttempts(resolution)
+    })
+  })
+}
+
+/**
+ * Resolves the host in the background at startup so the first sign-in does not
+ * pay for it. Failures are the resolution's own business — it always yields a
+ * host — so nothing here needs to handle them.
+ */
+export function warmPowerShellHostInBackground(): void {
+  if (process.platform !== 'win32') {
+    return
+  }
+  void warmWindowsPowerShellHostCache()
+}

--- a/src/main/crash-reporting/powershell-host-resolution-breadcrumb.ts
+++ b/src/main/crash-reporting/powershell-host-resolution-breadcrumb.ts
@@ -15,7 +15,7 @@ function summarizeAttempts(resolution: WindowsPowerShellHostResolution): Record<
       .slice(0, MAX_REPORTED_ATTEMPTS)
       .map((attempt, index) => [
         `attempt${index}`,
-        `#${resolution.candidates.indexOf(attempt.path)} ${win32.basename(attempt.path)} absent=${attempt.absent ?? false} ok=${attempt.ok} exit=${attempt.exitCode ?? 'none'} marker=${attempt.markerOk ?? false} timedOut=${attempt.timedOut ?? false} ms=${attempt.durationMs}`
+        `#${resolution.candidates.indexOf(attempt.path)} ${win32.basename(attempt.path)} absent=${attempt.absent ?? false} unwrappable=${attempt.unwrappable ?? false} ok=${attempt.ok} exit=${attempt.exitCode ?? 'none'} marker=${attempt.markerOk ?? false} timedOut=${attempt.timedOut ?? false} ms=${attempt.durationMs}`
       ])
   )
 }
@@ -36,9 +36,11 @@ export function registerPowerShellHostResolutionBreadcrumb(): void {
       hostName: win32.basename(resolution.host),
       selectedIndex: resolution.candidates.indexOf(resolution.host),
       fellBack: resolution.fellBack,
-      probedCount: resolution.attempts.filter((attempt) => !attempt.absent).length,
+      probedCount: resolution.attempts.filter((attempt) => !attempt.absent && !attempt.unwrappable)
+        .length,
       candidateCount: resolution.candidates.length,
       skippedCount: resolution.attempts.filter((attempt) => attempt.absent).length,
+      unwrappableCount: resolution.attempts.filter((attempt) => attempt.unwrappable).length,
       untriedCount: resolution.candidates.length - resolution.attempts.length,
       ...summarizeAttempts(resolution)
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,10 @@ import { openMainWindow as openMainWindowController } from './startup/main-windo
 import { mainProcessState as state } from './startup/main-process-state'
 import { runMainProcessPreflight } from './startup/main-process-preflight'
 import { registerMainProcessIpcHandlers } from './startup/main-process-ipc-bootstrap'
+import {
+  registerPowerShellHostResolutionBreadcrumb,
+  warmPowerShellHostInBackground
+} from './crash-reporting/powershell-host-resolution-breadcrumb'
 import { initializeMainProcessReady } from './startup/main-process-ready'
 import { installMainProcessQuitHandlers } from './startup/main-process-quit'
 import { shouldActivateDesktopForSecondInstance } from './startup/single-instance-lock'
@@ -105,6 +109,8 @@ if (preflightReady) {
   // Why no publish: nothing is listening this early, so the first renderer pulls these on mount.
   state.osOpenedMarkdownFiles.capture(process.argv)
   registerMainProcessIpcHandlers()
+  registerPowerShellHostResolutionBreadcrumb()
+  warmPowerShellHostInBackground()
   installMainProcessQuitHandlers()
   void app.whenReady().then(async () => {
     await initializeMainProcessReady({

--- a/src/shared/windows-batch-spawn.ts
+++ b/src/shared/windows-batch-spawn.ts
@@ -35,7 +35,12 @@ const UNSAFE_WINDOWS_BATCH_SYNTAX = new RegExp(
   `[${WINDOWS_BATCH_UNSAFE_CHARACTERS.map((character) => character.replace(/[\\^\]-]/, '\\$&')).join('')}\\r\\n]`
 )
 
-function hasUnsafeWindowsBatchSyntax(value: string): boolean {
+/**
+ * True when cmd.exe re-parsing this value could start a command or expand a
+ * variable. Exported so callers that *choose* a program path can reject one the
+ * wrapper would refuse, instead of discovering it as a launch failure.
+ */
+export function hasUnsafeWindowsBatchSyntax(value: string): boolean {
   return UNSAFE_WINDOWS_BATCH_SYNTAX.test(value)
 }
 

--- a/src/shared/windows-interactive-login-spawn.test.ts
+++ b/src/shared/windows-interactive-login-spawn.test.ts
@@ -3,6 +3,8 @@ import { existsSync, writeFileSync } from 'node:fs'
 import { getCmdExePath } from './windows-batch-spawn'
 import { buildWindowsHostInteractiveLoginSpawn } from './windows-interactive-login-spawn'
 
+const POWERSHELL_HOST = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+
 function withWindows<T>(fn: () => T): T {
   const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
   Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
@@ -37,11 +39,11 @@ function pidFilePathFromSpawnArgs(args: string[]): string {
 describe('buildWindowsHostInteractiveLoginSpawn', () => {
   it('relays a batch login through a visible, PID-addressable console', () => {
     const spawn = withWindows(() =>
-      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\claude.cmd', [
-        'auth',
-        'login',
-        '--claudeai'
-      ])
+      buildWindowsHostInteractiveLoginSpawn(
+        'C:\\Tools\\claude.cmd',
+        ['auth', 'login', '--claudeai'],
+        POWERSHELL_HOST
+      )
     )
     expect(spawn.command).toBe(getCmdExePath())
     expect(spawn.args.slice(0, 5)).toEqual(['/d', '/c', 'start', '', '/wait'])
@@ -72,7 +74,7 @@ describe('buildWindowsHostInteractiveLoginSpawn', () => {
 
   it('routes executable logins through the same waiting console boundary', () => {
     const spawn = withWindows(() =>
-      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\codex.exe', ['login'])
+      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\codex.exe', ['login'], POWERSHELL_HOST)
     )
     const script = decodedScript(spawn.args)
     expect(script).toContain(encodedValue('C:\\Tools\\codex.exe'))
@@ -83,7 +85,11 @@ describe('buildWindowsHostInteractiveLoginSpawn', () => {
   it('waits for the relay PID when cancellation races console startup', async () => {
     vi.useFakeTimers()
     const spawn = withWindows(() =>
-      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\claude.exe', ['auth', 'login'])
+      buildWindowsHostInteractiveLoginSpawn(
+        'C:\\Tools\\claude.exe',
+        ['auth', 'login'],
+        POWERSHELL_HOST
+      )
     )
     try {
       const pendingPid = spawn.waitForTerminationPid()
@@ -99,5 +105,33 @@ describe('buildWindowsHostInteractiveLoginSpawn', () => {
       spawn.cleanup()
       vi.useRealTimers()
     }
+  })
+
+  it('drives the console through whichever PowerShell host was resolved', () => {
+    const pwsh = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+    const spawn = withWindows(() =>
+      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\codex.cmd', ['login'], pwsh)
+    )
+    expect(spawn.args[5]).toBe(pwsh)
+    spawn.cleanup()
+  })
+
+  it('reports a login that never relayed a PID, including after cleanup', () => {
+    const spawn = withWindows(() =>
+      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\codex.cmd', ['login'], POWERSHELL_HOST)
+    )
+    expect(spawn.hasRelayedPid()).toBe(false)
+    spawn.cleanup()
+    expect(spawn.hasRelayedPid()).toBe(false)
+  })
+
+  it('remembers a relayed PID once the file is gone', () => {
+    const spawn = withWindows(() =>
+      buildWindowsHostInteractiveLoginSpawn('C:\\Tools\\codex.cmd', ['login'], POWERSHELL_HOST)
+    )
+    writeFileSync(pidFilePathFromSpawnArgs(spawn.args), '1357')
+    spawn.cleanup()
+    expect(spawn.hasRelayedPid()).toBe(true)
+    expect(spawn.getTerminationPid()).toBe(1357)
   })
 })

--- a/src/shared/windows-interactive-login-spawn.test.ts
+++ b/src/shared/windows-interactive-login-spawn.test.ts
@@ -134,4 +134,18 @@ describe('buildWindowsHostInteractiveLoginSpawn', () => {
     expect(spawn.hasRelayedPid()).toBe(true)
     expect(spawn.getTerminationPid()).toBe(1357)
   })
+
+  it('resolves the relayed PID after cleanup removed the relay file', async () => {
+    const spawn = withWindows(() =>
+      buildWindowsHostInteractiveLoginSpawn(
+        'C:\\Tools\\claude.exe',
+        ['auth', 'login'],
+        POWERSHELL_HOST
+      )
+    )
+    writeFileSync(pidFilePathFromSpawnArgs(spawn.args), '5791')
+    spawn.cleanup()
+
+    await expect(spawn.waitForTerminationPid()).resolves.toBe(5791)
+  })
 })

--- a/src/shared/windows-interactive-login-spawn.ts
+++ b/src/shared/windows-interactive-login-spawn.ts
@@ -3,7 +3,7 @@ import { readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { getSpawnArgsForWindows, wrapWindowsStartWait } from './windows-batch-spawn'
-import { resolveWindowsPowerShellHost } from './windows-powershell-host'
+import { getWindowsPowerShellHost } from './windows-powershell-host'
 
 export type WindowsHostInteractiveLoginSpawn = {
   command: string
@@ -74,7 +74,7 @@ function waitForPidFile(pidFilePath: string): Promise<number | null> {
 export function buildWindowsHostInteractiveLoginSpawn(
   command: string,
   args: string[],
-  powerShellHost: string = resolveWindowsPowerShellHost()
+  powerShellHost: string = getWindowsPowerShellHost()
 ): WindowsHostInteractiveLoginSpawn {
   const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, args)
   const pidFilePath = join(tmpdir(), `orca-interactive-login-${randomUUID()}.pid`)

--- a/src/shared/windows-interactive-login-spawn.ts
+++ b/src/shared/windows-interactive-login-spawn.ts
@@ -104,9 +104,13 @@ export function buildWindowsHostInteractiveLoginSpawn(
     },
     getTerminationPid: () => capturePid(),
     waitForTerminationPid: async () => {
-      const pid = await waitForPidFile(pidFilePath)
-      relayedPid ??= pid
-      return pid
+      // Why check first: after cleanup the relay file is gone, so waiting would
+      // burn the timeout and then discard a PID we already hold.
+      if (relayedPid !== null) {
+        return relayedPid
+      }
+      relayedPid = await waitForPidFile(pidFilePath)
+      return relayedPid
     },
     hasRelayedPid: () => capturePid() !== null
   }

--- a/src/shared/windows-interactive-login-spawn.ts
+++ b/src/shared/windows-interactive-login-spawn.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import { readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join, win32 } from 'node:path'
+import { join } from 'node:path'
 import { getSpawnArgsForWindows, wrapWindowsStartWait } from './windows-batch-spawn'
+import { resolveWindowsPowerShellHost } from './windows-powershell-host'
 
 export type WindowsHostInteractiveLoginSpawn = {
   command: string
@@ -12,6 +13,12 @@ export type WindowsHostInteractiveLoginSpawn = {
   cleanup: () => void
   getTerminationPid: () => number | null
   waitForTerminationPid: () => Promise<number | null>
+  /**
+   * Whether the PowerShell payload ever wrote its PID. `start /wait` does not
+   * relay the child's exit code, so this is the only proof the login script ran
+   * at all — without it a host that never started reads as a clean success.
+   */
+  hasRelayedPid: () => boolean
 }
 
 const PID_RELAY_WAIT_TIMEOUT_MS = 2_000
@@ -66,35 +73,41 @@ function waitForPidFile(pidFilePath: string): Promise<number | null> {
 
 export function buildWindowsHostInteractiveLoginSpawn(
   command: string,
-  args: string[]
+  args: string[],
+  powerShellHost: string = resolveWindowsPowerShellHost()
 ): WindowsHostInteractiveLoginSpawn {
   const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, args)
   const pidFilePath = join(tmpdir(), `orca-interactive-login-${randomUUID()}.pid`)
-  const powershell = win32.join(
-    process.env.SystemRoot ?? 'C:\\Windows',
-    'System32',
-    'WindowsPowerShell',
-    'v1.0',
-    'powershell.exe'
-  )
   const script = buildPidRelayScript(spawnCmd, spawnArgs, pidFilePath)
   // Why: `-EncodedCommand` is not execution-policy gated (only `-File` is), so `-ExecutionPolicy
   // Bypass` was a no-op — and it is one of the most heavily EDR-flagged PowerShell tokens. The
   // base64 stays: `wrapWindowsStartWait` sends this through `cmd.exe /c start`, whose
   // `assertWindowsCmdSafeTokens` guard rejects the `&` and `"` the raw relay script contains.
-  const wrapped = wrapWindowsStartWait(powershell, [
+  const wrapped = wrapWindowsStartWait(powerShellHost, [
     '-NoLogo',
     '-NoProfile',
     '-EncodedCommand',
     Buffer.from(script, 'utf16le').toString('base64')
   ])
+  // Why remember it: cleanup deletes the relay file, and callers check whether
+  // the script ran only after settling, which is past that deletion.
+  let relayedPid: number | null = null
+  const capturePid = (): number | null => (relayedPid ??= readPidFile(pidFilePath))
   return {
     command: wrapped.spawnCmd,
     args: wrapped.spawnArgs,
     stdio: 'ignore',
     windowsHide: true,
-    cleanup: () => rmSync(pidFilePath, { force: true }),
-    getTerminationPid: () => readPidFile(pidFilePath),
-    waitForTerminationPid: () => waitForPidFile(pidFilePath)
+    cleanup: () => {
+      capturePid()
+      rmSync(pidFilePath, { force: true })
+    },
+    getTerminationPid: () => capturePid(),
+    waitForTerminationPid: async () => {
+      const pid = await waitForPidFile(pidFilePath)
+      relayedPid ??= pid
+      return pid
+    },
+    hasRelayedPid: () => capturePid() !== null
   }
 }

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as NodeFs from 'node:fs'
 
-const statSyncMock = vi.fn()
+const statSyncMock = vi.hoisted(() => vi.fn())
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof NodeFs>('node:fs')
   return { ...actual, statSync: (...args: unknown[]) => statSyncMock(...args) }
 })
 
-const runProcessMock = vi.fn()
+const runProcessMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./child-process/run-process', () => ({
   runProcess: (...args: unknown[]) => runProcessMock(...args)

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -8,6 +8,12 @@ vi.mock('node:fs', async () => {
   return { ...actual, statSync: (...args: unknown[]) => statSyncMock(...args) }
 })
 
+const runProcessMock = vi.fn()
+
+vi.mock('./child-process/run-process', () => ({
+  runProcess: (...args: unknown[]) => runProcessMock(...args)
+}))
+
 import type {
   WindowsPowerShellHostAsyncProbe,
   WindowsPowerShellHostResolution
@@ -17,6 +23,7 @@ import {
   getWindowsPowerShellHost,
   getWindowsPowerShellHostCandidates,
   isPossibleWindowsPowerShellHost,
+  probeWindowsPowerShellHostAsync,
   resetWindowsPowerShellHostCacheForTests,
   setWindowsPowerShellHostResolutionObserver,
   warmWindowsPowerShellHostCache
@@ -51,6 +58,7 @@ beforeEach(() => {
   resetWindowsPowerShellHostCacheForTests()
   statSyncMock.mockReset()
   statSyncMock.mockReturnValue({})
+  runProcessMock.mockReset()
 })
 
 describe('getWindowsPowerShellHostCandidates', () => {
@@ -216,5 +224,36 @@ describe('warmWindowsPowerShellHostCache', () => {
     await warmWindowsPowerShellHostCache(async () => ({ ok: false, timedOut: true }), ENV)
     expect(seen[0]?.fellBack).toBe(true)
     expect(seen[0]?.attempts.every((attempt) => attempt.timedOut)).toBe(true)
+  })
+})
+
+describe('probeWindowsPowerShellHostAsync', () => {
+  // Guards the removal of a no-op -ExecutionPolicy Bypass: the policy gates
+  // script files, never an encoded payload, so it was pure EDR signal.
+  it('encodes the payload without an execution-policy bypass', async () => {
+    runProcessMock.mockResolvedValue({ code: 7, timedOut: false })
+
+    await probeWindowsPowerShellHostAsync(PROGRAM_FILES_PWSH)
+
+    const { program, args } = runProcessMock.mock.calls[0][0]
+    expect(program).toBe(PROGRAM_FILES_PWSH)
+    expect(args).not.toContain('-ExecutionPolicy')
+    expect(args).not.toContain('Bypass')
+    expect(args.slice(0, 4)).toEqual([
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-EncodedCommand'
+    ])
+    expect(Buffer.from(args[4], 'base64').toString('utf16le')).toContain('exit 7')
+  })
+
+  it('rejects a host that reports the exit code without writing the marker', async () => {
+    runProcessMock.mockResolvedValue({ code: 7, timedOut: false })
+
+    await expect(probeWindowsPowerShellHostAsync(PROGRAM_FILES_PWSH)).resolves.toMatchObject({
+      ok: false,
+      markerOk: false
+    })
   })
 })

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getWindowsPowerShellHostCandidates,
+  resetWindowsPowerShellHostCacheForTests,
+  resolveWindowsPowerShellHost
+} from './windows-powershell-host'
+
+const ENV = {
+  SystemRoot: 'C:\\Windows',
+  ProgramFiles: 'C:\\Program Files',
+  LOCALAPPDATA: 'C:\\Users\\dev\\AppData\\Local',
+  PATH: 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Tools'
+} satisfies NodeJS.ProcessEnv
+
+const SYSTEM32_POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
+const PROGRAM_FILES_PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+const WINDOWS_APPS_PWSH = 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe'
+
+beforeEach(() => {
+  resetWindowsPowerShellHostCacheForTests()
+})
+
+describe('getWindowsPowerShellHostCandidates', () => {
+  it('offers Windows PowerShell first, then every place PowerShell 7 installs', () => {
+    const candidates = getWindowsPowerShellHostCandidates(ENV)
+    expect(candidates[0]).toBe(SYSTEM32_POWERSHELL)
+    expect(candidates).toContain(PROGRAM_FILES_PWSH)
+    expect(candidates).toContain(WINDOWS_APPS_PWSH)
+    expect(candidates).toContain('C:\\Tools\\pwsh.exe')
+  })
+
+  it('lists the WindowsApps alias once even though PATH also names it', () => {
+    const candidates = getWindowsPowerShellHostCandidates(ENV)
+    expect(candidates.filter((entry) => entry === WINDOWS_APPS_PWSH)).toHaveLength(1)
+  })
+})
+
+describe('resolveWindowsPowerShellHost', () => {
+  it('keeps Windows PowerShell when it can still run a script', () => {
+    const probe = vi.fn().mockReturnValue(true)
+    expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(SYSTEM32_POWERSHELL)
+  })
+
+  // Why this is the whole point: on a locked-down fleet powershell.exe exists and
+  // exits 0 without finishing the script, so only a probe that checks the script's
+  // effect can reject it in favour of the PowerShell 7 that actually works.
+  it('falls through to PowerShell 7 when Windows PowerShell exits without doing the work', () => {
+    const probe = vi.fn((candidate: string) => candidate === PROGRAM_FILES_PWSH)
+    expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(PROGRAM_FILES_PWSH)
+    expect(probe).toHaveBeenCalledWith(SYSTEM32_POWERSHELL)
+  })
+
+  // Why not report nothing: a probe can fail for reasons unrelated to the host,
+  // and every environment that worked before this resolver existed used this path.
+  it('falls back to Windows PowerShell when no candidate answers the probe', () => {
+    expect(resolveWindowsPowerShellHost(() => false, ENV)).toBe(SYSTEM32_POWERSHELL)
+  })
+
+  it('probes once for a working host', () => {
+    const probe = vi.fn().mockReturnValue(true)
+    resolveWindowsPowerShellHost(probe, ENV)
+    resolveWindowsPowerShellHost(probe, ENV)
+    expect(probe).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-probes after a negative answer expires so a later PowerShell 7 install is picked up', () => {
+    const probe = vi.fn().mockReturnValue(false)
+    expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(SYSTEM32_POWERSHELL)
+    const probeCallsWhileCached = probe.mock.calls.length
+    resolveWindowsPowerShellHost(probe, ENV)
+    expect(probe).toHaveBeenCalledTimes(probeCallsWhileCached)
+
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(Date.now() + 31_000)
+      probe.mockImplementation((candidate: string) => candidate === WINDOWS_APPS_PWSH)
+      expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(WINDOWS_APPS_PWSH)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -1,10 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-  getWindowsPowerShellHostCandidates,
-  resetWindowsPowerShellHostCacheForTests,
-  resolveWindowsPowerShellHost
+import type * as NodeFs from 'node:fs'
+
+const statSyncMock = vi.fn()
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return { ...actual, statSync: (...args: unknown[]) => statSyncMock(...args) }
+})
+
+import type {
+  WindowsPowerShellHostAsyncProbe,
+  WindowsPowerShellHostResolution
 } from './windows-powershell-host'
 
+import {
+  getWindowsPowerShellHost,
+  getWindowsPowerShellHostCandidates,
+  isPossibleWindowsPowerShellHost,
+  resetWindowsPowerShellHostCacheForTests,
+  setWindowsPowerShellHostResolutionObserver,
+  warmWindowsPowerShellHostCache
+} from './windows-powershell-host'
 const ENV = {
   SystemRoot: 'C:\\Windows',
   ProgramFiles: 'C:\\Program Files',
@@ -16,8 +32,25 @@ const SYSTEM32_POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\pow
 const PROGRAM_FILES_PWSH = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
 const WINDOWS_APPS_PWSH = 'C:\\Users\\dev\\AppData\\Local\\Microsoft\\WindowsApps\\pwsh.exe'
 
+const found = async (): Promise<{ ok: true; exitCode: number; markerOk: true }> => ({
+  ok: true,
+  exitCode: 7,
+  markerOk: true
+})
+const missed = async (): Promise<{ ok: false; exitCode: number; markerOk: false }> => ({
+  ok: false,
+  exitCode: 0,
+  markerOk: false
+})
+
+function throwFsError(code: string): never {
+  throw Object.assign(new Error(code), { code })
+}
+
 beforeEach(() => {
   resetWindowsPowerShellHostCacheForTests()
+  statSyncMock.mockReset()
+  statSyncMock.mockReturnValue({})
 })
 
 describe('getWindowsPowerShellHostCandidates', () => {
@@ -35,48 +68,112 @@ describe('getWindowsPowerShellHostCandidates', () => {
   })
 })
 
-describe('resolveWindowsPowerShellHost', () => {
-  it('keeps Windows PowerShell when it can still run a script', () => {
-    const probe = vi.fn().mockReturnValue(true)
-    expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(SYSTEM32_POWERSHELL)
+describe('isPossibleWindowsPowerShellHost', () => {
+  it('rules out a path that is definitively missing', () => {
+    statSyncMock.mockImplementation(() => throwFsError('ENOENT'))
+    expect(isPossibleWindowsPowerShellHost(PROGRAM_FILES_PWSH)).toBe(false)
+  })
+
+  // Why: the Store build of PowerShell 7 is reached through an App Execution
+  // Alias, a reparse point that runs but answers stat with EACCES. Treating any
+  // stat failure as missing threw away the only working host on such a machine.
+  it('keeps a candidate whose stat fails for a reason other than absence', () => {
+    statSyncMock.mockImplementation(() => throwFsError('EACCES'))
+    expect(isPossibleWindowsPowerShellHost(WINDOWS_APPS_PWSH)).toBe(true)
+  })
+})
+
+describe('getWindowsPowerShellHost', () => {
+  // Why it must not probe: this is the path the ACL hardening and the console
+  // builder take, and both run on the main process.
+  it('answers with Windows PowerShell until a warm-up resolves something better', async () => {
+    expect(getWindowsPowerShellHost(ENV)).toBe(SYSTEM32_POWERSHELL)
+    await warmWindowsPowerShellHostCache(
+      async (candidate) => (candidate === WINDOWS_APPS_PWSH ? found() : missed()),
+      ENV
+    )
+    expect(getWindowsPowerShellHost(ENV)).toBe(WINDOWS_APPS_PWSH)
+  })
+})
+
+describe('warmWindowsPowerShellHostCache', () => {
+  it('keeps Windows PowerShell when it can still run a script', async () => {
+    expect(await warmWindowsPowerShellHostCache(vi.fn(found), ENV)).toBe(SYSTEM32_POWERSHELL)
   })
 
   // Why this is the whole point: on a locked-down fleet powershell.exe exists and
   // exits 0 without finishing the script, so only a probe that checks the script's
   // effect can reject it in favour of the PowerShell 7 that actually works.
-  it('falls through to PowerShell 7 when Windows PowerShell exits without doing the work', () => {
-    const probe = vi.fn((candidate: string) => candidate === PROGRAM_FILES_PWSH)
-    expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(PROGRAM_FILES_PWSH)
+  it('falls through to PowerShell 7 when Windows PowerShell exits without doing the work', async () => {
+    const probe = vi.fn((candidate: string) =>
+      candidate === PROGRAM_FILES_PWSH ? found() : missed()
+    )
+    expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(PROGRAM_FILES_PWSH)
     expect(probe).toHaveBeenCalledWith(SYSTEM32_POWERSHELL)
+  })
+
+  it('probes an execution alias instead of skipping it as missing', async () => {
+    statSyncMock.mockImplementation((path: unknown) =>
+      path === WINDOWS_APPS_PWSH ? throwFsError('EACCES') : throwFsError('ENOENT')
+    )
+    const probe = vi.fn((candidate: string) =>
+      candidate === WINDOWS_APPS_PWSH ? found() : missed()
+    )
+    expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(WINDOWS_APPS_PWSH)
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(probe).toHaveBeenCalledWith(WINDOWS_APPS_PWSH)
   })
 
   // Why not report nothing: a probe can fail for reasons unrelated to the host,
   // and every environment that worked before this resolver existed used this path.
-  it('falls back to Windows PowerShell when no candidate answers the probe', () => {
-    expect(resolveWindowsPowerShellHost(() => false, ENV)).toBe(SYSTEM32_POWERSHELL)
+  it('falls back to Windows PowerShell when no candidate answers the probe', async () => {
+    expect(await warmWindowsPowerShellHostCache(missed, ENV)).toBe(SYSTEM32_POWERSHELL)
   })
 
-  it('probes once for a working host', () => {
-    const probe = vi.fn().mockReturnValue(true)
-    resolveWindowsPowerShellHost(probe, ENV)
-    resolveWindowsPowerShellHost(probe, ENV)
+  it('probes once for a working host', async () => {
+    const probe = vi.fn(found)
+    await warmWindowsPowerShellHostCache(probe, ENV)
+    await warmWindowsPowerShellHostCache(probe, ENV)
     expect(probe).toHaveBeenCalledTimes(1)
   })
 
-  it('re-probes after a negative answer expires so a later PowerShell 7 install is picked up', () => {
-    const probe = vi.fn().mockReturnValue(false)
-    expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(SYSTEM32_POWERSHELL)
-    const probeCallsWhileCached = probe.mock.calls.length
-    resolveWindowsPowerShellHost(probe, ENV)
-    expect(probe).toHaveBeenCalledTimes(probeCallsWhileCached)
+  it('re-probes after a fallback expires so a later PowerShell 7 install is picked up', async () => {
+    const probe: WindowsPowerShellHostAsyncProbe = vi.fn(missed)
+    expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(SYSTEM32_POWERSHELL)
+    const probeCallsWhileCached = vi.mocked(probe).mock.calls.length
+    await warmWindowsPowerShellHostCache(probe, ENV)
+    expect(vi.mocked(probe)).toHaveBeenCalledTimes(probeCallsWhileCached)
 
     vi.useFakeTimers()
     try {
       vi.setSystemTime(Date.now() + 31_000)
-      probe.mockImplementation((candidate: string) => candidate === WINDOWS_APPS_PWSH)
-      expect(resolveWindowsPowerShellHost(probe, ENV)).toBe(WINDOWS_APPS_PWSH)
+      vi.mocked(probe).mockImplementation(async (candidate: string) =>
+        candidate === WINDOWS_APPS_PWSH ? found() : missed()
+      )
+      expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(WINDOWS_APPS_PWSH)
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('reports the chosen host and what each probed candidate did', async () => {
+    const seen: WindowsPowerShellHostResolution[] = []
+    setWindowsPowerShellHostResolutionObserver((resolution) => seen.push(resolution))
+    await warmWindowsPowerShellHostCache(
+      (candidate) => (candidate === WINDOWS_APPS_PWSH ? found() : missed()),
+      ENV
+    )
+    expect(seen).toHaveLength(1)
+    expect(seen[0]?.host).toBe(WINDOWS_APPS_PWSH)
+    expect(seen[0]?.fellBack).toBe(false)
+    expect(seen[0]?.attempts.map((attempt) => attempt.path)).toContain(SYSTEM32_POWERSHELL)
+  })
+
+  it('reports the fallback as a fallback rather than a choice', async () => {
+    const seen: WindowsPowerShellHostResolution[] = []
+    setWindowsPowerShellHostResolutionObserver((resolution) => seen.push(resolution))
+    await warmWindowsPowerShellHostCache(async () => ({ ok: false, timedOut: true }), ENV)
+    expect(seen[0]?.fellBack).toBe(true)
+    expect(seen[0]?.attempts.every((attempt) => attempt.timedOut)).toBe(true)
   })
 })

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -54,9 +54,10 @@ beforeEach(() => {
 })
 
 describe('getWindowsPowerShellHostCandidates', () => {
-  it('offers Windows PowerShell first, then every place PowerShell 7 installs', () => {
+  it('tries every PowerShell 7 location before Windows PowerShell', () => {
     const candidates = getWindowsPowerShellHostCandidates(ENV)
-    expect(candidates[0]).toBe(SYSTEM32_POWERSHELL)
+    expect(candidates[0]).toBe(PROGRAM_FILES_PWSH)
+    expect(candidates.at(-1)).toBe(SYSTEM32_POWERSHELL)
     expect(candidates).toContain(PROGRAM_FILES_PWSH)
     expect(candidates).toContain(WINDOWS_APPS_PWSH)
     expect(candidates).toContain('C:\\Tools\\pwsh.exe')
@@ -97,8 +98,10 @@ describe('getWindowsPowerShellHost', () => {
 })
 
 describe('warmWindowsPowerShellHostCache', () => {
-  it('keeps Windows PowerShell when it can still run a script', async () => {
-    expect(await warmWindowsPowerShellHostCache(vi.fn(found), ENV)).toBe(SYSTEM32_POWERSHELL)
+  it('prefers PowerShell 7 even when Windows PowerShell happens to pass', async () => {
+    const probe = vi.fn(found)
+    expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(PROGRAM_FILES_PWSH)
+    expect(probe).not.toHaveBeenCalledWith(SYSTEM32_POWERSHELL)
   })
 
   // Why this is the whole point: on a locked-down fleet powershell.exe exists and
@@ -109,7 +112,44 @@ describe('warmWindowsPowerShellHostCache', () => {
       candidate === PROGRAM_FILES_PWSH ? found() : missed()
     )
     expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(PROGRAM_FILES_PWSH)
-    expect(probe).toHaveBeenCalledWith(SYSTEM32_POWERSHELL)
+    expect(probe).not.toHaveBeenCalledWith(SYSTEM32_POWERSHELL)
+  })
+
+  it('deduplicates quoted Windows PATH entries regardless of case or test host platform', () => {
+    const candidates = getWindowsPowerShellHostCandidates({
+      ...ENV,
+      PATH: '"C:\\Program Files\\PowerShell\\7";c:\\program files\\powershell\\7;C:\\Tools'
+    })
+    expect(candidates).toEqual([
+      PROGRAM_FILES_PWSH,
+      WINDOWS_APPS_PWSH,
+      'C:\\Tools\\pwsh.exe',
+      SYSTEM32_POWERSHELL
+    ])
+  })
+
+  it('uses Windows PowerShell when none of the PowerShell 7 hosts works', async () => {
+    const probe = vi.fn((candidate: string) =>
+      candidate === SYSTEM32_POWERSHELL ? found() : missed()
+    )
+    expect(await warmWindowsPowerShellHostCache(probe, ENV)).toBe(SYSTEM32_POWERSHELL)
+    expect(probe.mock.calls.at(-1)).toEqual([SYSTEM32_POWERSHELL])
+  })
+
+  it('shares the pending probe between startup and simultaneous login requests', async () => {
+    let finish!: (result: { ok: boolean }) => void
+    const probe = vi.fn(
+      () =>
+        new Promise<{ ok: boolean }>((resolve) => {
+          finish = resolve
+        })
+    )
+    const startup = warmWindowsPowerShellHostCache(probe, ENV)
+    const login = warmWindowsPowerShellHostCache(probe, ENV)
+    expect(startup).toBe(login)
+    expect(probe).toHaveBeenCalledTimes(1)
+    finish({ ok: true })
+    await expect(login).resolves.toBe(PROGRAM_FILES_PWSH)
   })
 
   it('probes an execution alias instead of skipping it as missing', async () => {
@@ -166,7 +206,8 @@ describe('warmWindowsPowerShellHostCache', () => {
     expect(seen).toHaveLength(1)
     expect(seen[0]?.host).toBe(WINDOWS_APPS_PWSH)
     expect(seen[0]?.fellBack).toBe(false)
-    expect(seen[0]?.attempts.map((attempt) => attempt.path)).toContain(SYSTEM32_POWERSHELL)
+    expect(seen[0]?.candidates).toEqual(getWindowsPowerShellHostCandidates(ENV))
+    expect(seen[0]?.attempts.map((attempt) => attempt.path)).not.toContain(SYSTEM32_POWERSHELL)
   })
 
   it('reports the fallback as a fallback rather than a choice', async () => {

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -138,6 +138,40 @@ describe('warmWindowsPowerShellHostCache', () => {
     expect(probe).not.toHaveBeenCalledWith(SYSTEM32_POWERSHELL)
   })
 
+  // The probe spawns the host directly, so a `&` in the path passes it — but the
+  // sign-in goes through `wrapWindowsStartWait`, whose cmd.exe guard refuses that
+  // same path. Caching it would break every login on a machine whose System32
+  // host worked, so the candidate must lose before it is ever probed.
+  it('skips a candidate the start /wait wrapper could not launch', async () => {
+    const unsafeEnv = { ...ENV, ProgramFiles: 'C:\\Tools & Utils', PATH: '' }
+    const unsafePwsh = 'C:\\Tools & Utils\\PowerShell\\7\\pwsh.exe'
+    const probe = vi.fn(found)
+
+    expect(await warmWindowsPowerShellHostCache(probe, unsafeEnv)).toBe(WINDOWS_APPS_PWSH)
+    expect(probe).not.toHaveBeenCalledWith(unsafePwsh)
+  })
+
+  it('reports an unlaunchable candidate as its own outcome, not as a probe failure', async () => {
+    const unsafeEnv = {
+      ...ENV,
+      ProgramFiles: 'C:\\Tools & Utils',
+      LOCALAPPDATA: 'C:\\Users\\a%b\\AppData\\Local',
+      PATH: ''
+    }
+    const resolutions: WindowsPowerShellHostResolution[] = []
+    setWindowsPowerShellHostResolutionObserver((resolution) => resolutions.push(resolution))
+
+    // Why System32 must miss: otherwise it passes on its own merits and the
+    // fallback this asserts is never taken.
+    expect(await warmWindowsPowerShellHostCache(missed, unsafeEnv)).toBe(SYSTEM32_POWERSHELL)
+    expect(resolutions[0]?.fellBack).toBe(true)
+    expect(resolutions[0]?.attempts.map((attempt) => attempt.unwrappable ?? false)).toEqual([
+      true,
+      true,
+      false
+    ])
+  })
+
   it('deduplicates quoted Windows PATH entries regardless of case or test host platform', () => {
     const candidates = getWindowsPowerShellHostCandidates({
       ...ENV,

--- a/src/shared/windows-powershell-host.test.ts
+++ b/src/shared/windows-powershell-host.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { writeFileSync } from 'node:fs'
 import type * as NodeFs from 'node:fs'
 
 const statSyncMock = vi.hoisted(() => vi.fn())
@@ -54,6 +55,20 @@ function throwFsError(code: string): never {
   throw Object.assign(new Error(code), { code })
 }
 
+/**
+ * Does what a working host does: decode the probe payload and write the marker
+ * it names. Reading the path out of the payload rather than restating it keeps
+ * the fixture honest if the script shape changes.
+ */
+function answerProbe(spec: { args: string[] }): void {
+  const script = Buffer.from(spec.args[4], 'base64').toString('utf16le')
+  const quoted = /WriteAllText\('(.*?)',/.exec(script)?.[1]
+  if (!quoted) {
+    throw new Error(`probe payload names no marker path: ${script}`)
+  }
+  writeFileSync(quoted.replaceAll("''", "'"), 'orca-powershell-host-ok')
+}
+
 beforeEach(() => {
   resetWindowsPowerShellHostCacheForTests()
   statSyncMock.mockReset()
@@ -93,8 +108,8 @@ describe('isPossibleWindowsPowerShellHost', () => {
 })
 
 describe('getWindowsPowerShellHost', () => {
-  // Why it must not probe: this is the path the ACL hardening and the console
-  // builder take, and both run on the main process.
+  // Why it must not probe: this is the path the console builder takes, and it
+  // runs on the main process.
   it('answers with Windows PowerShell until a warm-up resolves something better', async () => {
     expect(getWindowsPowerShellHost(ENV)).toBe(SYSTEM32_POWERSHELL)
     await warmWindowsPowerShellHostCache(
@@ -254,6 +269,37 @@ describe('probeWindowsPowerShellHostAsync', () => {
     await expect(probeWindowsPowerShellHostAsync(PROGRAM_FILES_PWSH)).resolves.toMatchObject({
       ok: false,
       markerOk: false
+    })
+  })
+
+  // Why the positive control: without it the timeout case below could pass on a
+  // helper that never writes the marker, asserting nothing about `timedOut`.
+  it('accepts a host that writes the marker and reports the exit code in time', async () => {
+    runProcessMock.mockImplementation(async (spec: { args: string[] }) => {
+      answerProbe(spec)
+      return { code: 7, timedOut: false }
+    })
+
+    await expect(probeWindowsPowerShellHostAsync(PROGRAM_FILES_PWSH)).resolves.toMatchObject({
+      ok: true,
+      markerOk: true
+    })
+  })
+
+  // The fleet laptop's 5.1 answered 13/15 trivial probes. `runProcess` kills on
+  // timeout but still settles from close, so a late answer arrives with a real
+  // exit code — caching it would reinstate the intermittent host.
+  it('rejects a host that answered only after the probe budget expired', async () => {
+    runProcessMock.mockImplementation(async (spec: { args: string[] }) => {
+      answerProbe(spec)
+      return { code: 7, timedOut: true }
+    })
+
+    await expect(probeWindowsPowerShellHostAsync(PROGRAM_FILES_PWSH)).resolves.toMatchObject({
+      ok: false,
+      timedOut: true,
+      exitCode: 7,
+      markerOk: true
     })
   })
 })

--- a/src/shared/windows-powershell-host.ts
+++ b/src/shared/windows-powershell-host.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { readFileSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { delimiter, join, win32 } from 'node:path'
+import { join, win32 } from 'node:path'
 import { runProcess } from './child-process/run-process'
 
 /**
@@ -43,6 +43,7 @@ export type WindowsPowerShellHostAttempt = WindowsPowerShellHostProbeResult & {
 
 export type WindowsPowerShellHostResolution = {
   host: string
+  candidates: string[]
   /** True when no candidate passed and Windows PowerShell was used anyway. */
   fellBack: boolean
   attempts: WindowsPowerShellHostAttempt[]
@@ -66,29 +67,31 @@ function getSystem32PowerShell(env: NodeJS.ProcessEnv): string {
 
 function getPathPwshCandidates(env: NodeJS.ProcessEnv): string[] {
   return (env.PATH ?? env.Path ?? '')
-    .split(delimiter)
+    .split(win32.delimiter)
     .map((entry) => entry.trim())
     .filter(Boolean)
-    .map((directory) => join(directory, 'pwsh.exe'))
+    .map((directory) => win32.join(directory.replace(/^"(.*)"$/, '$1'), 'pwsh.exe'))
 }
 
-/**
- * Ordered by preference: Windows PowerShell 5.1 first, because every existing
- * Orca script was written and tested against it, then PowerShell 7 wherever it
- * installs. The Store build's real path carries its version
- * (WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__…), so only its stable
- * execution alias and PATH entry are worth naming.
- */
+// PS5.1 can pass a probe intermittently on managed PCs, then fail every login.
 export function getWindowsPowerShellHostCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
   const candidates = [
-    getSystem32PowerShell(env),
     win32.join(env.ProgramFiles ?? 'C:\\Program Files', 'PowerShell', '7', 'pwsh.exe'),
     ...(env.LOCALAPPDATA
       ? [win32.join(env.LOCALAPPDATA, 'Microsoft', 'WindowsApps', 'pwsh.exe')]
       : []),
-    ...getPathPwshCandidates(env)
+    ...getPathPwshCandidates(env),
+    getSystem32PowerShell(env)
   ]
-  return [...new Set(candidates)]
+  const seen = new Set<string>()
+  return candidates.filter((candidate) => {
+    const key = candidate.toLowerCase()
+    if (seen.has(key)) {
+      return false
+    }
+    seen.add(key)
+    return true
+  })
 }
 
 /**
@@ -214,7 +217,8 @@ async function runWarmup(
   env: NodeJS.ProcessEnv
 ): Promise<string> {
   const attempts: WindowsPowerShellHostAttempt[] = []
-  for (const candidate of getWindowsPowerShellHostCandidates(env)) {
+  const candidates = getWindowsPowerShellHostCandidates(env)
+  for (const candidate of candidates) {
     if (!isPossibleWindowsPowerShellHost(candidate)) {
       attempts.push({ path: candidate, absent: true, ok: false, durationMs: 0 })
       continue
@@ -224,13 +228,13 @@ async function runWarmup(
     attempts.push({ ...result, path: candidate, durationMs: Date.now() - startedAt })
     if (result.ok) {
       hostCache = { host: candidate }
-      resolutionObserver?.({ host: candidate, fellBack: false, attempts })
+      resolutionObserver?.({ host: candidate, candidates, fellBack: false, attempts })
       return candidate
     }
   }
   hostCache = { host: null, cachedAt: Date.now() }
   const fallback = getSystem32PowerShell(env)
-  resolutionObserver?.({ host: fallback, fellBack: true, attempts })
+  resolutionObserver?.({ host: fallback, candidates, fellBack: true, attempts })
   return fallback
 }
 

--- a/src/shared/windows-powershell-host.ts
+++ b/src/shared/windows-powershell-host.ts
@@ -73,7 +73,7 @@ function getPathPwshCandidates(env: NodeJS.ProcessEnv): string[] {
     .map((directory) => win32.join(directory.replace(/^"(.*)"$/, '$1'), 'pwsh.exe'))
 }
 
-// PS5.1 can pass a probe intermittently on managed PCs, then fail every login.
+/** Ordered pwsh-first: PS5.1 can pass a probe intermittently, then fail every login. */
 export function getWindowsPowerShellHostCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
   const candidates = [
     win32.join(env.ProgramFiles ?? 'C:\\Program Files', 'PowerShell', '7', 'pwsh.exe'),
@@ -111,7 +111,7 @@ export function isPossibleWindowsPowerShellHost(executablePath: string): boolean
 }
 
 /**
- * Runs the same shape Orca depends on — an `-EncodedCommand` payload that writes
+ * Runs the shape that matters — an `-EncodedCommand` payload that writes
  * a file and then exits with a known code — and requires both halves. A host
  * that returns the exit code without producing the file is exactly the failure
  * this probe exists to catch.
@@ -132,8 +132,8 @@ function buildProbeSpec(
       '-NoLogo',
       '-NoProfile',
       '-NonInteractive',
-      '-ExecutionPolicy',
-      'Bypass',
+      // No -ExecutionPolicy Bypass: the policy gates script files, never an
+      // encoded payload, so it is pure EDR signal here (windows-edr-posture.md).
       '-EncodedCommand',
       Buffer.from(script, 'utf16le').toString('base64')
     ],
@@ -154,6 +154,7 @@ function newMarkerPath(): string {
   return join(tmpdir(), `orca-powershell-probe-${randomUUID()}.txt`)
 }
 
+/** Accepts a host only when it both wrote the marker and reported the exit code. */
 export async function probeWindowsPowerShellHostAsync(
   executablePath: string
 ): Promise<WindowsPowerShellHostProbeResult> {
@@ -248,6 +249,7 @@ export function setWindowsPowerShellHostResolutionObserver(
   resolutionObserver = observer
 }
 
+/** Clears the resolved host, any in-flight warm-up, and the observer. */
 export function resetWindowsPowerShellHostCacheForTests(): void {
   hostCache = null
   warmupInFlight = null

--- a/src/shared/windows-powershell-host.ts
+++ b/src/shared/windows-powershell-host.ts
@@ -1,0 +1,137 @@
+import { randomUUID } from 'node:crypto'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join, win32 } from 'node:path'
+import { runProcessSync } from './child-process/run-process'
+
+/**
+ * Resolves a PowerShell host that can actually run Orca's helper scripts.
+ *
+ * Why not the hardcoded System32 path: managed Windows fleets ship with Windows
+ * PowerShell 5.1 disabled and PowerShell 7 installed alongside it. There, the
+ * 5.1 host still exists and still exits 0 — it just stops partway through the
+ * script — so a path check or an exit-code check both report a working host and
+ * every dependent feature fails with an unrelated error downstream.
+ */
+
+const PROBE_TIMEOUT_MS = 5_000
+const PROBE_EXIT_CODE = 7
+const PROBE_MARKER = 'orca-powershell-host-ok'
+const NEGATIVE_CACHE_TTL_MS = 30_000
+
+export type WindowsPowerShellHostProbe = (executablePath: string) => boolean
+
+type HostCache = { host: string } | { host: null; cachedAt: number }
+
+let hostCache: HostCache | null = null
+
+function getSystem32PowerShell(env: NodeJS.ProcessEnv): string {
+  return win32.join(
+    env.SystemRoot ?? env.WINDIR ?? 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe'
+  )
+}
+
+function getPathPwshCandidates(env: NodeJS.ProcessEnv): string[] {
+  return (env.PATH ?? env.Path ?? '')
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((directory) => join(directory, 'pwsh.exe'))
+}
+
+/**
+ * Ordered by preference: Windows PowerShell 5.1 first, because every existing
+ * Orca script was written and tested against it, then PowerShell 7 wherever it
+ * installs. The Store build's real path carries its version
+ * (WindowsApps\Microsoft.PowerShell_7.6.5.0_x64__…), so only its stable
+ * execution alias and PATH entry are worth naming.
+ */
+export function getWindowsPowerShellHostCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+  const candidates = [
+    getSystem32PowerShell(env),
+    win32.join(env.ProgramFiles ?? 'C:\\Program Files', 'PowerShell', '7', 'pwsh.exe'),
+    ...(env.LOCALAPPDATA
+      ? [win32.join(env.LOCALAPPDATA, 'Microsoft', 'WindowsApps', 'pwsh.exe')]
+      : []),
+    ...getPathPwshCandidates(env)
+  ]
+  return [...new Set(candidates)]
+}
+
+/**
+ * Runs the same shape Orca depends on — an `-EncodedCommand` payload that writes
+ * a file and then exits with a known code — and requires both halves. A host
+ * that returns the exit code without producing the file is exactly the failure
+ * this probe exists to catch.
+ */
+export function probeWindowsPowerShellHost(executablePath: string): boolean {
+  if (!existsSync(executablePath)) {
+    return false
+  }
+  const markerPath = join(tmpdir(), `orca-powershell-probe-${randomUUID()}.txt`)
+  const script = `[IO.File]::WriteAllText('${markerPath.replaceAll("'", "''")}', '${PROBE_MARKER}'); exit ${PROBE_EXIT_CODE}`
+  try {
+    const result = runProcessSync({
+      program: executablePath,
+      args: [
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-EncodedCommand',
+        Buffer.from(script, 'utf16le').toString('base64')
+      ],
+      timeoutMs: PROBE_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+    if (result.code !== PROBE_EXIT_CODE) {
+      return false
+    }
+    return readFileSync(markerPath, 'utf-8').trim() === PROBE_MARKER
+  } catch {
+    return false
+  } finally {
+    rmSync(markerPath, { force: true })
+  }
+}
+
+/**
+ * The probe costs a process launch, so the answer is cached for the session. A
+ * fallback answer expires: PowerShell 7 can be installed while Orca is running.
+ *
+ * Why fall back to Windows PowerShell instead of reporting nothing: a probe can
+ * fail for reasons that have nothing to do with the host (no temp dir, a
+ * scanner holding the marker file). Returning the historical path keeps those
+ * environments exactly as they were, and callers that need proof the script ran
+ * have it in the PID relay.
+ */
+export function resolveWindowsPowerShellHost(
+  probe: WindowsPowerShellHostProbe = probeWindowsPowerShellHost,
+  env: NodeJS.ProcessEnv = process.env
+): string {
+  if (hostCache) {
+    if (hostCache.host !== null) {
+      return hostCache.host
+    }
+    if (Date.now() - hostCache.cachedAt < NEGATIVE_CACHE_TTL_MS) {
+      return getSystem32PowerShell(env)
+    }
+  }
+  for (const candidate of getWindowsPowerShellHostCandidates(env)) {
+    if (probe(candidate)) {
+      hostCache = { host: candidate }
+      return candidate
+    }
+  }
+  hostCache = { host: null, cachedAt: Date.now() }
+  return getSystem32PowerShell(env)
+}
+
+export function resetWindowsPowerShellHostCacheForTests(): void {
+  hostCache = null
+}

--- a/src/shared/windows-powershell-host.ts
+++ b/src/shared/windows-powershell-host.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from 'node:crypto'
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { readFileSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join, win32 } from 'node:path'
-import { runProcessSync } from './child-process/run-process'
+import { runProcess } from './child-process/run-process'
 
 /**
  * Resolves a PowerShell host that can actually run Orca's helper scripts.
@@ -14,16 +14,45 @@ import { runProcessSync } from './child-process/run-process'
  * every dependent feature fails with an unrelated error downstream.
  */
 
-const PROBE_TIMEOUT_MS = 5_000
+// Why 20s and not the 5s a warm shell needs: measured on a fleet laptop, the
+// same pwsh that starts in ~1s from cmd.exe takes 7.9s spawned from Orca, and
+// powershell.exe took 15.4s — endpoint security inspects the Electron child
+// tree. A short timeout rejects every working host and lands on the fallback.
+const PROBE_TIMEOUT_MS = 20_000
 const PROBE_EXIT_CODE = 7
 const PROBE_MARKER = 'orca-powershell-host-ok'
-const NEGATIVE_CACHE_TTL_MS = 30_000
+const FALLBACK_CACHE_TTL_MS = 30_000
 
-export type WindowsPowerShellHostProbe = (executablePath: string) => boolean
+export type WindowsPowerShellHostProbeResult = {
+  ok: boolean
+  timedOut?: boolean
+  exitCode?: number | null
+  markerOk?: boolean
+}
+
+export type WindowsPowerShellHostAsyncProbe = (
+  executablePath: string
+) => Promise<WindowsPowerShellHostProbeResult>
+
+export type WindowsPowerShellHostAttempt = WindowsPowerShellHostProbeResult & {
+  path: string
+  /** Ruled out by the cheap filesystem filter, so nothing was spawned. */
+  absent?: boolean
+  durationMs: number
+}
+
+export type WindowsPowerShellHostResolution = {
+  host: string
+  /** True when no candidate passed and Windows PowerShell was used anyway. */
+  fellBack: boolean
+  attempts: WindowsPowerShellHostAttempt[]
+}
 
 type HostCache = { host: string } | { host: null; cachedAt: number }
 
 let hostCache: HostCache | null = null
+let resolutionObserver: ((resolution: WindowsPowerShellHostResolution) => void) | null = null
+let warmupInFlight: Promise<string> | null = null
 
 function getSystem32PowerShell(env: NodeJS.ProcessEnv): string {
   return win32.join(
@@ -63,75 +92,160 @@ export function getWindowsPowerShellHostCandidates(env: NodeJS.ProcessEnv = proc
 }
 
 /**
+ * Only a definitive absence may skip the probe. An App Execution Alias — how the
+ * Store build of PowerShell 7 is normally reached — is a zero-length reparse
+ * point that runs fine but answers `stat` with EACCES, so treating every stat
+ * failure as "missing" discards the one candidate such a machine has.
+ */
+export function isPossibleWindowsPowerShellHost(executablePath: string): boolean {
+  try {
+    statSync(executablePath)
+    return true
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    return code !== 'ENOENT' && code !== 'ENOTDIR'
+  }
+}
+
+/**
  * Runs the same shape Orca depends on — an `-EncodedCommand` payload that writes
  * a file and then exits with a known code — and requires both halves. A host
  * that returns the exit code without producing the file is exactly the failure
  * this probe exists to catch.
  */
-export function probeWindowsPowerShellHost(executablePath: string): boolean {
-  if (!existsSync(executablePath)) {
-    return false
-  }
-  const markerPath = join(tmpdir(), `orca-powershell-probe-${randomUUID()}.txt`)
+function buildProbeSpec(
+  executablePath: string,
+  markerPath: string
+): {
+  program: string
+  args: string[]
+  timeoutMs: number
+  stdio: ['ignore', 'pipe', 'pipe']
+} {
   const script = `[IO.File]::WriteAllText('${markerPath.replaceAll("'", "''")}', '${PROBE_MARKER}'); exit ${PROBE_EXIT_CODE}`
+  return {
+    program: executablePath,
+    args: [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-EncodedCommand',
+      Buffer.from(script, 'utf16le').toString('base64')
+    ],
+    timeoutMs: PROBE_TIMEOUT_MS,
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+}
+
+function readProbeMarker(markerPath: string): boolean {
   try {
-    const result = runProcessSync({
-      program: executablePath,
-      args: [
-        '-NoLogo',
-        '-NoProfile',
-        '-NonInteractive',
-        '-ExecutionPolicy',
-        'Bypass',
-        '-EncodedCommand',
-        Buffer.from(script, 'utf16le').toString('base64')
-      ],
-      timeoutMs: PROBE_TIMEOUT_MS,
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
-    if (result.code !== PROBE_EXIT_CODE) {
-      return false
-    }
     return readFileSync(markerPath, 'utf-8').trim() === PROBE_MARKER
   } catch {
     return false
+  }
+}
+
+function newMarkerPath(): string {
+  return join(tmpdir(), `orca-powershell-probe-${randomUUID()}.txt`)
+}
+
+export async function probeWindowsPowerShellHostAsync(
+  executablePath: string
+): Promise<WindowsPowerShellHostProbeResult> {
+  const markerPath = newMarkerPath()
+  try {
+    const result = await runProcess(buildProbeSpec(executablePath, markerPath))
+    const markerOk = readProbeMarker(markerPath)
+    return {
+      ok: result.code === PROBE_EXIT_CODE && markerOk,
+      timedOut: result.timedOut,
+      exitCode: result.code,
+      markerOk
+    }
+  } catch {
+    return { ok: false }
   } finally {
     rmSync(markerPath, { force: true })
   }
 }
 
 /**
- * The probe costs a process launch, so the answer is cached for the session. A
- * fallback answer expires: PowerShell 7 can be installed while Orca is running.
+ * The host to run helper scripts with, without ever spawning anything: probing
+ * is the warm-up's job. A blocking probe on this path would freeze the main
+ * process for as long as endpoint security takes to let PowerShell start —
+ * measured at 15s on the fleet laptop that motivated this module.
+ */
+export function getWindowsPowerShellHost(env: NodeJS.ProcessEnv = process.env): string {
+  return hostCache?.host ?? getSystem32PowerShell(env)
+}
+
+/**
+ * Probes the candidates and caches the first host that runs the script. Safe to
+ * call repeatedly: a resolved host short-circuits, concurrent callers share one
+ * in-flight run, and a fallback is retried once its TTL expires (PowerShell 7
+ * can be installed while Orca is running, and a probe that only timed out may
+ * succeed on a quieter machine).
  *
  * Why fall back to Windows PowerShell instead of reporting nothing: a probe can
- * fail for reasons that have nothing to do with the host (no temp dir, a
- * scanner holding the marker file). Returning the historical path keeps those
- * environments exactly as they were, and callers that need proof the script ran
- * have it in the PID relay.
+ * fail for reasons that have nothing to do with the host, and returning the
+ * historical path keeps those environments exactly as they were. The fallback
+ * is reported through the observer so it is visible rather than silent.
  */
-export function resolveWindowsPowerShellHost(
-  probe: WindowsPowerShellHostProbe = probeWindowsPowerShellHost,
+export function warmWindowsPowerShellHostCache(
+  probe: WindowsPowerShellHostAsyncProbe = probeWindowsPowerShellHostAsync,
   env: NodeJS.ProcessEnv = process.env
-): string {
-  if (hostCache) {
-    if (hostCache.host !== null) {
-      return hostCache.host
-    }
-    if (Date.now() - hostCache.cachedAt < NEGATIVE_CACHE_TTL_MS) {
-      return getSystem32PowerShell(env)
-    }
+): Promise<string> {
+  if (hostCache?.host) {
+    return Promise.resolve(hostCache.host)
   }
+  if (hostCache?.host === null && Date.now() - hostCache.cachedAt < FALLBACK_CACHE_TTL_MS) {
+    return Promise.resolve(getSystem32PowerShell(env))
+  }
+  warmupInFlight ??= runWarmup(probe, env).finally(() => {
+    warmupInFlight = null
+  })
+  return warmupInFlight
+}
+
+async function runWarmup(
+  probe: WindowsPowerShellHostAsyncProbe,
+  env: NodeJS.ProcessEnv
+): Promise<string> {
+  const attempts: WindowsPowerShellHostAttempt[] = []
   for (const candidate of getWindowsPowerShellHostCandidates(env)) {
-    if (probe(candidate)) {
+    if (!isPossibleWindowsPowerShellHost(candidate)) {
+      attempts.push({ path: candidate, absent: true, ok: false, durationMs: 0 })
+      continue
+    }
+    const startedAt = Date.now()
+    const result = await probe(candidate)
+    attempts.push({ ...result, path: candidate, durationMs: Date.now() - startedAt })
+    if (result.ok) {
       hostCache = { host: candidate }
+      resolutionObserver?.({ host: candidate, fellBack: false, attempts })
       return candidate
     }
   }
   hostCache = { host: null, cachedAt: Date.now() }
-  return getSystem32PowerShell(env)
+  const fallback = getSystem32PowerShell(env)
+  resolutionObserver?.({ host: fallback, fellBack: true, attempts })
+  return fallback
+}
+
+/**
+ * Reports each real resolution (cache hits stay silent). Lets the main process
+ * record which host was chosen without this module reaching into its logging.
+ */
+export function setWindowsPowerShellHostResolutionObserver(
+  observer: ((resolution: WindowsPowerShellHostResolution) => void) | null
+): void {
+  resolutionObserver = observer
 }
 
 export function resetWindowsPowerShellHostCacheForTests(): void {
   hostCache = null
+  warmupInFlight = null
+  resolutionObserver = null
 }

--- a/src/shared/windows-powershell-host.ts
+++ b/src/shared/windows-powershell-host.ts
@@ -163,7 +163,11 @@ export async function probeWindowsPowerShellHostAsync(
     const result = await runProcess(buildProbeSpec(executablePath, markerPath))
     const markerOk = readProbeMarker(markerPath)
     return {
-      ok: result.code === PROBE_EXIT_CODE && markerOk,
+      // Why timedOut disqualifies: the timer kills the child but still resolves
+      // from close, so a host that answered just past the budget arrives with a
+      // real exit code. Caching it is the intermittent host this module exists
+      // to reject — every later call would then pay that same wait.
+      ok: !result.timedOut && result.code === PROBE_EXIT_CODE && markerOk,
       timedOut: result.timedOut,
       exitCode: result.code,
       markerOk
@@ -171,7 +175,14 @@ export async function probeWindowsPowerShellHostAsync(
   } catch {
     return { ok: false }
   } finally {
-    rmSync(markerPath, { force: true })
+    // Why swallow: `force` only ignores a missing path, and this runs in
+    // `finally` — a locked or undeletable marker would otherwise throw away a
+    // probe result that is already decided.
+    try {
+      rmSync(markerPath, { force: true })
+    } catch {
+      // Cleanup is best effort; a stale marker in tmpdir costs nothing.
+    }
   }
 }
 

--- a/src/shared/windows-powershell-host.ts
+++ b/src/shared/windows-powershell-host.ts
@@ -3,6 +3,7 @@ import { readFileSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
 import { runProcess } from './child-process/run-process'
+import { hasUnsafeWindowsBatchSyntax } from './windows-batch-spawn'
 
 /**
  * Resolves a PowerShell host that can actually run Orca's helper scripts.
@@ -38,6 +39,8 @@ export type WindowsPowerShellHostAttempt = WindowsPowerShellHostProbeResult & {
   path: string
   /** Ruled out by the cheap filesystem filter, so nothing was spawned. */
   absent?: boolean
+  /** Runs directly, but `start /wait` re-parses it through cmd.exe and would refuse it. */
+  unwrappable?: boolean
   durationMs: number
 }
 
@@ -233,6 +236,14 @@ async function runWarmup(
   for (const candidate of candidates) {
     if (!isPossibleWindowsPowerShellHost(candidate)) {
       attempts.push({ path: candidate, absent: true, ok: false, durationMs: 0 })
+      continue
+    }
+    // Why reject before probing: the probe spawns the host directly, so a path
+    // holding `&` or `%` passes it — but the interactive login goes through
+    // `wrapWindowsStartWait`, whose cmd.exe guard refuses that same path. Caching
+    // it would fail every sign-in on a machine whose System32 host worked.
+    if (hasUnsafeWindowsBatchSyntax(candidate)) {
+      attempts.push({ path: candidate, unwrappable: true, ok: false, durationMs: 0 })
       continue
     }
     const startedAt = Date.now()


### PR DESCRIPTION
## ELI5

Orca always asked for PowerShell by its full System32 path. On Windows machines where that
PowerShell is switched off and PowerShell 7 is installed instead, Orca kept calling the one that
doesn't work — and, because the wrapper hides the exit code, reported "sign-in finished, but no
credentials" instead of "PowerShell never ran". This finds a PowerShell that actually works, and
says so when none does.

## What Changed

**`src/shared/windows-powershell-host.ts` (new).** Resolves a PowerShell host instead of naming one.
Candidates, in order: `%ProgramFiles%\PowerShell\7\pwsh.exe`, the App Execution Alias at
`%LOCALAPPDATA%\Microsoft\WindowsApps\pwsh.exe`, `pwsh.exe` on PATH, and Windows PowerShell 5.1
last. Three details that matter:

- **The probe runs the shape that matters** — an `-EncodedCommand` payload that writes a
  file and exits with a known code — and requires *both* halves. A host that returns the exit code
  without producing the file is exactly the failure this exists to catch; exit codes alone cannot
  see it. A host that answers *past* the budget is rejected for the same reason: `runProcess` kills
  the child on the timer but still resolves with a real exit code, and caching that host makes every
  later call pay the same wait.
- **Only a definitive absence (`ENOENT`/`ENOTDIR`) skips a candidate.** The Store build's execution
  alias executes fine but answers `statSync` with `EACCES`, so an `existsSync` guard would discard
  the only working host on the machine that motivated this.
- **A candidate the login wrapper could not launch is rejected before it is probed.** The probe
  spawns the host directly, so a path holding `&` or `%` passes it — but the interactive login goes
  through `wrapWindowsStartWait`, whose `cmd.exe` guard refuses that same path, so caching it would
  fail every sign-in on a machine whose System32 host worked. `hasUnsafeWindowsBatchSyntax` is now
  exported from `src/shared/windows-batch-spawn.ts` for that check (no behavior change for its
  existing callers), and such a candidate is recorded as `unwrappable`.

Probing is a 20 s budget per candidate and runs **asynchronously**: a warm-up starts at launch and
both login paths await it before building a console. The Claude path wraps that wait in
`waitForPromiseWithSignal`, so a cancel arriving during it ends the sign-in rather than sitting out
the budget and then opening a console; the warm-up itself is left running, since it is shared and
cached and cancelling it would discard work other callers await. The Codex path awaits the same
warm-up without a signal. The synchronous accessor only ever reads that cache and never spawns —
blocking the main process for the length of a PowerShell cold start (measured at 15 s on the fleet
laptop) is not acceptable. If nothing answers, Windows PowerShell stays the fallback, so
environments that work today are unchanged — but the fallback is now reported rather than silent.

**Scope after rebase onto current `main`.** This PR originally also routed
`src/shared/secure-path-windows-acl.ts` through the resolver. #17884 has since replaced that file's
`powershell.exe` invocation with `icacls.exe`, so the call site no longer exists and the change is
dropped. That leaves
`buildWindowsHostInteractiveLoginSpawn` as the sole reader of the synchronous accessor; the async
warm-up keeps three callers — `index.ts` at launch (through
`warmPowerShellHostInBackground`) and the two login paths in `claude-command-process.ts` and
`codex-login-session.ts`.

**Failures are no longer silent.**
`buildWindowsHostInteractiveLoginSpawn` already writes a PID relay file as its payload's first
statement; that file now also serves as proof the script ran. A console that exits without ever
relaying a PID fails the sign-in with *"PowerShell could not start the … sign-in console"* and
records a `login_console_never_started` breadcrumb, instead of resolving and letting the caller
report a missing credential. The post-auth tree kill stays a success path.

**Diagnostics.** A `powershell_host_selected` breadcrumb records the chosen host, whether it was a
fallback, and per-candidate results (`ok`, `exit`, `marker`, `timedOut`, `unwrappable`, `ms`)
alongside `candidateCount` / `probedCount` / `skippedCount` / `unwrappableCount` / `untriedCount`.
Fields are shaped so they survive path redaction — `hostName` and `selectedIndex` stay
readable when paths are `[redacted-path]`.

## Why

Managed Windows fleets ship with Windows PowerShell 5.1 disabled and PowerShell 7 alongside it.
There, 5.1 still exists and still exits 0 — it just stops partway through a script — so both a path
check and an exit-code check report a working host while every dependent feature fails downstream
with an unrelated error. Full evidence in #18856; the short version is 0/24 vs 24/24 on the affected
machine.

Ordering pwsh first is deliberate: 5.1 passed a trivial probe 13/15 times there, so leading with it
cached an intermittently-working host for the whole session.

## Linked Issue

Fixes #18856

Follow-ups found during the same investigation, deliberately **not** in this PR: #18855

## Visual Proof

`N/A` — no UI change. The user-visible difference is an error message replacing a raw
`ENOENT …\auth.json`, quoted above and in #18856.

## Testing

Iterated over four builds against the affected machine, each verified with a 50 ms
process/filesystem monitor. Final build, both ZIP and NSIS installer. The breadcrumb below is the
verbatim field capture and predates the `unwrappable` field, so the shipping code emits one extra
`unwrappable=` per attempt plus an `unwrappableCount`:

```
powershell_host_selected
  hostName "pwsh.exe"  selectedIndex 1  fellBack false
  candidateCount 32  probedCount 1  skippedCount 1  untriedCount 30
  attempt0: "#0 pwsh.exe absent=true  ok=false exit=none marker=false timedOut=false ms=0"
  attempt1: "#1 pwsh.exe absent=false ok=true  exit=7   marker=true  timedOut=false ms=11270"
```

- Windows PowerShell was never probed (`untriedCount 30`) — the ordering fix.
- The execution alias reached the probe and passed (`absent=false`) — the `EACCES` fix.
- Probe took **11,270 / 8,319 / 6,978 ms**, every run over the original 5 s budget — the timeout fix.
- PID relay file appeared for the first time (`content='39056'`, matching the `pwsh.exe/39056` that
  started); `login_console_never_started` did not fire.
- **Codex sign-in completed** — `auth.json` (4,268 bytes) written and persisted, account listed.
- **Claude sign-in completed** — correctly rejected as `This Claude account is already added.`,
  which required the credential capture and identity resolution to have worked.

Platforms: **Windows** (the affected machine plus a healthy Windows dev machine). Not exercised on
macOS/Linux — the changed code is `process.platform === 'win32'`-gated, and the suites pass there.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

New coverage in `src/shared/windows-powershell-host.test.ts` (candidate order, the `EACCES` alias
reaching the probe, fallback, caching + TTL, observer reporting, the non-blocking accessor) and
`src/main/crash-reporting/powershell-host-resolution-breadcrumb.test.ts` (diagnostics survive
redaction). Existing Windows login suites were pinned to a resolved host so they keep testing the
login rather than the machine they run on.

## AI Disclosure

Written with Claude Opus 5 (Claude Code) and Codex, driven and reviewed by me. The field
investigation that produced the evidence above ran on the affected machine.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** the probe writes a marker file under `tmpdir()` with a random name and removes it in
  a `finally`. It carries `-EncodedCommand` but **not** `-ExecutionPolicy Bypass` — per
  `docs/reference/windows-edr-posture.md` the bypass is a measured no-op against an encoded payload,
  so it would add the doc's highest-signal pairing for no work, and the warm-up would fire it on
  every Windows startup. This PR still changes no policy flag on the login wrapper's own argv, but
  that argv is no longer what the field verification exercised: #17880 has since dropped
  `-ExecutionPolicy Bypass` from it on `main`. The verified command line and the shipping one now
  differ by exactly that flag, which the same measurement records as a no-op against an encoded
  payload. The EDR table's remaining suggestion for the wrapper (a temp `.ps1` with `-File`) stays a
  separate change that should be re-verified on the affected machine.
- **Cross-platform:** all new behavior is Windows-gated; the resolver returns the historical path on
  any non-Windows platform and nothing spawns.
- **Performance:** resolution happens once per session, off the main thread, and is cached; a
  negative result expires after 30 s so PowerShell 7 installed while Orca runs is picked up.
- **Backwards compatibility:** machines where Windows PowerShell works resolve it as before — it
  simply now has to prove it.
- One thing I would like a reviewer's opinion on: 20 s was chosen against a measured 11.3 s worst
  case, so the margin is ~2×. On a slower machine the fallback would win and the sign-in would fail
  the way it does today, just with a breadcrumb saying so.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


