### PR TITLE
fix(settings): hide the Ghostty import on the paired web client

### DIFF
--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -147,7 +147,7 @@ export function AppearancePane({
   ]
   const terminalSearchEntries = [
     { title: terminalTitle },
-    ...getTerminalAppearanceSearchEntries({ showWarpImport: !isWebClient })
+    ...getTerminalAppearanceSearchEntries({ showThemeImports: !isWebClient })
   ]
   const windowSearchEntries = [
     {

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts
@@ -524,6 +524,29 @@ describe('TerminalAppearanceSection ghostty import wiring', () => {
 
     expect(findTerminalThemeCatalogSection(element)?.props.showThemeImport).toBe(false)
     expect(findWarpThemeImportModal(element)).toBeNull()
+    expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(false)
+    expect(findGhosttyImportModal(element)).toBeNull()
+  })
+
+  it('keeps the Ghostty import out of paired web client search results', () => {
+    vi.stubGlobal('window', {
+      __ORCA_WEB_CLIENT__: true,
+      location: { pathname: '/web-index.html' }
+    })
+    mockSettingsSearchQuery = 'ghostty'
+
+    const element = TerminalAppearanceSection({
+      settings: {} as never,
+      updateSettings: () => {},
+      systemPrefersDark: true,
+      terminalFontSuggestions: [],
+      ghostty: ghosttyMock,
+      warpThemes: warpThemesMock
+    })
+
+    expect(findButtons(element).some((button) => button.text === 'Import from Ghostty')).toBe(false)
+    // A query matching nothing visible must not force the typography group open.
+    expect(findComponentByTypeName(element, 'TerminalFontSizeSetting')).toBeNull()
   })
 
   it('passes hook state to GhosttyImportModal', () => {

--- a/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
@@ -84,10 +84,14 @@ export function TerminalAppearanceSection({
   const [themeSearch, setThemeSearch] = useState('')
   const [previewFontFamily, setPreviewFontFamily] = useState<string | null>(null)
   const showWarpThemeImport = !isWebClientLocation()
+  // Why: the web settings API implements neither import, so both controls are
+  // desktop-only. Dropping the search entries too keeps the index honest — a
+  // "ghostty" query must not force a group open around an invisible control.
+  const showGhosttyThemeImport = !isWebClientLocation()
   const darkThemeSearchEntries = getTerminalDarkThemeSearchEntries()
   const lightThemeSearchEntries = getTerminalLightThemeSearchEntries()
   const terminalTypographyEntries = getTerminalTypographySearchEntries()
-  const ghosttyImportEntries = getTerminalGhosttyImportSearchEntries()
+  const ghosttyImportEntries = showGhosttyThemeImport ? getTerminalGhosttyImportSearchEntries() : []
   const themeCatalogSearchEntries = [
     ...getTerminalThemeTargetSearchEntries(),
     ...darkThemeSearchEntries,
@@ -123,7 +127,8 @@ export function TerminalAppearanceSection({
     primaryTypographyMatches ||
     typographyMatches ||
     ghosttyImportMatches
-  const showGhosttyImport = !isSearching || forceVisiblePrimary || ghosttyImportMatches
+  const showGhosttyImport =
+    showGhosttyThemeImport && (!isSearching || forceVisiblePrimary || ghosttyImportMatches)
   const showTypographyAdvancedDisclosure = !isSearching || typographyMatches
 
   const advancedGroups = [
@@ -265,15 +270,17 @@ export function TerminalAppearanceSection({
         />
       ) : null}
 
-      <GhosttyImportModal
-        open={ghostty.open}
-        onOpenChange={ghostty.handleOpenChange}
-        preview={ghostty.preview}
-        loading={ghostty.loading}
-        onApply={ghostty.handleApply}
-        applied={ghostty.applied}
-        applyError={ghostty.applyError}
-      />
+      {showGhosttyThemeImport ? (
+        <GhosttyImportModal
+          open={ghostty.open}
+          onOpenChange={ghostty.handleOpenChange}
+          preview={ghostty.preview}
+          loading={ghostty.loading}
+          onApply={ghostty.handleApply}
+          applied={ghostty.applied}
+          applyError={ghostty.applyError}
+        />
+      ) : null}
       {showWarpThemeImport ? (
         <WarpThemeImportModal
           open={warpThemes.open}

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -223,7 +223,7 @@ const getAppearanceSectionEntries = createLocalizedCatalog((): SettingsSearchEnt
 ])
 
 type AppearancePaneSearchOptions = {
-  showWarpImport?: boolean
+  showThemeImports?: boolean
   showSystemTray?: boolean
   showMenuBarIcon?: boolean
 }
@@ -252,7 +252,7 @@ export function getAppearancePaneSearchEntries(
   options: AppearancePaneSearchOptions = {}
 ): SettingsSearchEntry[] {
   return buildAppearancePaneSearchEntries({
-    showWarpImport: options.showWarpImport ?? true,
+    showThemeImports: options.showThemeImports ?? true,
     showSystemTray: options.showSystemTray,
     showMenuBarIcon: options.showMenuBarIcon
   })

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -156,13 +156,18 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(matchesSettingsSearch(query, getAppearancePaneSearchEntries())).toBe(true)
   })
 
-  it('omits the Warp import appearance entry when desktop-only controls are hidden', () => {
-    const desktopEntries = getAppearancePaneSearchEntries({ showWarpImport: true })
-    const webEntries = getAppearancePaneSearchEntries({ showWarpImport: false })
+  it('omits every theme-import appearance entry when desktop-only controls are hidden', () => {
+    const desktopEntries = getAppearancePaneSearchEntries({ showThemeImports: true })
+    const webEntries = getAppearancePaneSearchEntries({ showThemeImports: false })
 
-    expect(desktopEntries.some((entry) => entry.title === 'Import from Warp')).toBe(true)
-    expect(webEntries.some((entry) => entry.title === 'Import from Warp')).toBe(false)
-    expect(webEntries.some((entry) => entry.title === 'Import from Ghostty')).toBe(true)
+    for (const title of ['Import from Warp', 'Import from Ghostty']) {
+      expect(desktopEntries.some((entry) => entry.title === title)).toBe(true)
+      expect(webEntries.some((entry) => entry.title === title)).toBe(false)
+    }
+    // Why: the pane index feeds the settings sidebar, so a web-client `ghostty`
+    // query must not rank a pane whose Ghostty control no longer renders.
+    expect(matchesSettingsSearch('ghostty', desktopEntries)).toBe(true)
+    expect(matchesSettingsSearch('ghostty', webEntries)).toBe(false)
   })
 
   it('includes the system tray appearance entry only when desktop tray controls are shown', () => {

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -63,10 +63,10 @@ export {
 } from './terminal-window-setup-search'
 
 type TerminalAppearanceSearchOptions = {
-  showWarpImport?: boolean
+  showThemeImports?: boolean
 }
 
-const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
+const getTerminalAppearanceSearchEntriesWithoutImports = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
     ...getTerminalTypographySearchEntries(),
     ...getTerminalCursorSearchEntries(),
@@ -74,16 +74,16 @@ const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
     ...getTerminalThemeTargetSearchEntries(),
     ...getTerminalDarkThemeSearchEntries(),
     ...getTerminalLightThemeSearchEntries(),
-    ...getTerminalWindowSearchEntries(),
-    ...getTerminalGhosttyImportSearchEntries()
+    ...getTerminalWindowSearchEntries()
   ]
 )
 
 // Why: compose rather than filter — entry titles are localized, so matching on
-// an English title would leak the Warp entry back in under non-English locales.
-const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
+// an English title would leak the import entries back in under non-English locales.
+const getTerminalAppearanceSearchEntriesWithImports = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
-    ...getTerminalAppearanceSearchEntriesWithoutWarp(),
+    ...getTerminalAppearanceSearchEntriesWithoutImports(),
+    ...getTerminalGhosttyImportSearchEntries(),
     ...getTerminalWarpImportSearchEntries(),
     ...getTerminalYamlImportSearchEntries()
   ]
@@ -92,9 +92,9 @@ const getTerminalAppearanceSearchEntriesWithWarp = createLocalizedCatalog(
 export function getTerminalAppearanceSearchEntries(
   options: TerminalAppearanceSearchOptions = {}
 ): SettingsSearchEntry[] {
-  return (options.showWarpImport ?? true)
-    ? getTerminalAppearanceSearchEntriesWithWarp()
-    : getTerminalAppearanceSearchEntriesWithoutWarp()
+  return (options.showThemeImports ?? true)
+    ? getTerminalAppearanceSearchEntriesWithImports()
+    : getTerminalAppearanceSearchEntriesWithoutImports()
 }
 
 export function getTerminalPaneSearchEntries(platform: {

--- a/src/renderer/src/hooks/settings-navigation-interface-sections.ts
+++ b/src/renderer/src/hooks/settings-navigation-interface-sections.ts
@@ -26,7 +26,7 @@ export function buildInterfaceSettingsSections({
       ),
       icon: Palette,
       searchEntries: getAppearancePaneSearchEntries({
-        showWarpImport: showDesktopOnlySettings,
+        showThemeImports: showDesktopOnlySettings,
         showSystemTray: showDesktopOnlySettings && isWindows,
         showMenuBarIcon: showDesktopOnlySettings && isMac
       }),


### PR DESCRIPTION
## ELI5

Settings → Appearance → Terminal Typography has an "Import from Ghostty" button. It reads a Ghostty config file off your disk, so it only works in the desktop app. On the paired web client the button was still drawn, and clicking it called a method the web settings API never implements. The Warp theme import right next to it was already hidden there; this hides the Ghostty one the same way.

## What Changed

`src/renderer/src/components/settings/TerminalAppearanceSection.tsx`:

- `showGhosttyThemeImport = !isWebClientLocation()`, mirroring the existing `showWarpThemeImport` one line above it.
- `showGhosttyImport` (the button) now requires it, in addition to the search-visibility logic it already had.
- `GhosttyImportModal` is rendered only when it is true — the same treatment `WarpThemeImportModal` already gets.
- `ghosttyImportEntries` is empty on the web client, so the settings search index stops advertising a control that cannot render there.

Two assertions were added to the existing web-client test, plus one new case for the search path.

## Why

`src/renderer/src/web/preload-api/web-settings-api.ts` builds the settings API for the paired web client. It implements `get`, `set`, `listFonts` and others; it implements neither `previewGhosttyImport` nor `previewWarpThemeImport`. So on the web client `window.api.settings.previewGhosttyImport` is `undefined` and the click throws.

The two controls sit next to each other and have the same constraint — both read a config file from the host's disk through a native file dialog. Only the Warp one was gated (`showWarpThemeImport = !isWebClientLocation()`, line 86). The Ghostty gate was simply missing.

The search entries are part of the same bug, not extra scope. `terminal-search.ts` already states the rule for the neighbouring case:

> Why: the settings search index must mirror the visible controls. Keeping platform-only controls out of other platforms' search results prevents users from landing on an option the UI intentionally hides.

Without dropping the entries, `ghosttyImportMatches` stays true on the web client, and because it feeds `showPrimaryTypography`, typing "ghostty" force-opens the whole Terminal Typography group around a button that renders `null`. Gating the button alone would trade a failing click for an empty group.

The alternative — implementing `previewGhosttyImport` on the web settings API — is not a fix for this: a native file dialog cannot open from a browser tab, so it would have to mean host-side auto-discovery, which is a product decision rather than a bug fix. The issue reporter reached the same conclusion.

## Linked Issue

Fixes #18661

## Visual Proof

`N/A` — the change only *removes* a control from the paired web client; there is no new or altered UI. The desktop path is untouched, and the "before" state on the web client is a button whose click throws in the console rather than a visible difference worth a frame. The behavior is pinned by tests instead:

| | before | after |
|---|---|---|
| desktop button | shown | shown (unchanged) |
| web client button | shown, click throws | not rendered |
| web client, search "ghostty" | forces the typography group open, button renders `null` | group stays closed |

## Testing

`src/renderer/src/components/settings/TerminalAppearanceSection.ghostty.test.ts`:

- `hides the theme import affordance on paired web clients` — extended to assert the Ghostty button and its modal are both absent, alongside the Warp assertions it already made.
- `keeps the Ghostty import out of paired web client search results` (new) — stubs `__ORCA_WEB_CLIENT__`, sets the search query to `ghostty`, and asserts the button is absent and the typography group is not forced open.

Both new assertions were confirmed to fail against the unmodified component (`expected true to be false`) and pass with it, so they pin the fix rather than the status quo.

Ran on macOS: the full `src/renderer/src/components/settings/` suite (172 files, 1131 tests) passes, as do `pnpm tc` and `pnpm run check:code-quality:changed`. CI covers the full `pnpm test` and `pnpm build`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The gap was diagnosed by reading the two controls against `web-settings-api.ts`; the fix, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code. `isWebClientLocation()` is a client-surface check, not an OS check, and is unchanged.
- **Remote / SSH:** none. This is renderer-only visibility logic — no IPC, no RPC params, no stream frames, nothing a client and host exchange. It affects what the *paired web client* draws, which is decided entirely client-side.
- **Mobile:** not affected — nothing under `mobile/` references this section.
- **Backwards compatibility:** no persisted state, settings, schema, or protocol changes. Desktop behavior is byte-for-byte the same.
- **Performance:** one boolean and an empty array on the web client; nothing measurable.
- **Security:** strictly reduces surface — it stops the renderer calling an undefined method on a client where the capability does not exist.
- **UI quality:** no new markup or strings, so the localization catalog is untouched. On the desktop the section renders exactly as before.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Deliberately *not* in this PR: `getTerminalAppearanceSearchEntries({ showWarpImport })` in `terminal-search.ts` still folds the Ghostty entries into its always-included set, so the settings **sidebar** can still rank the Terminal Appearance pane for a "ghostty" query on the web client. Fixing that means reshaping that option (it currently names only Warp) and touching its two callers, which is a wider change than this bug needs. The pane itself now renders nothing misleading when you land on it.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
