### PR TITLE
fix(agent-hooks): stop the Claude hook claiming panes that Grok owns

### DIFF
--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -4,7 +4,7 @@
 // missing-Orca-env path, so their writer may break there.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
@@ -283,6 +283,16 @@ describe('Windows managed hook stdin structure', () => {
       expect(claude.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')).toBeLessThan(
         claude.indexOf('if not "%DEVIN_PROJECT_DIR%"=="" goto :orca_agent_hook_drain_stdin')
       )
+      // The Grok compat skips jump to the same label, so they carry the same ordering rule.
+      for (const guard of [
+        'if not "%GROK_HOOK_EVENT%"=="" goto :orca_agent_hook_drain_stdin',
+        'if not "%GROK_SESSION_ID%"=="" goto :orca_agent_hook_drain_stdin'
+      ]) {
+        expect(claude, `claude grok guard present: ${guard}`).toContain(guard)
+        expect(claude.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')).toBeLessThan(
+          claude.indexOf(guard)
+        )
+      }
 
       // Why (#11549 class): every Windows-local hook now guards before owning stdin —
       // the caller may abandon the pipe, and the payload is discarded on this path anyway.
@@ -538,6 +548,50 @@ describe.skipIf(process.platform === 'win32')('managed hook stdin lifecycle', ()
     expect(result.exitCode).toBe(0)
     expect(result.stdinErrors).toHaveLength(0)
   })
+
+  it.each([['GROK_HOOK_EVENT'], ['GROK_SESSION_ID']])(
+    'drains before Claude skips hooks imported by Grok (%s)',
+    async (variable) => {
+      const script = (await generatePosixScripts()).get('claude claude-hook.sh')
+      expect(script).toBeDefined()
+      const result = await runPosixHook(script!, { [variable]: 'grok-compat' })
+      expect(result.exitCode).toBe(0)
+      expect(result.stdinErrors).toHaveLength(0)
+    }
+  )
+
+  it.each([['GROK_HOOK_EVENT'], ['GROK_SESSION_ID']])(
+    'stops the Claude hook posting under Grok .claude compat (%s)',
+    async (variable) => {
+      const script = (await generatePosixScripts()).get('claude claude-hook.sh')
+      expect(script).toBeDefined()
+      const binDir = mkdtempSync(join(tmpdir(), 'orca-hook-grok-compat-'))
+      try {
+        const marker = join(binDir, 'posted')
+        // A stub curl records the post so the skip is observed, not inferred.
+        writeFileSync(join(binDir, 'curl'), `#!/bin/sh\ntouch '${marker}'\nexit 0\n`, {
+          mode: 0o755
+        })
+        const orcaEnv = {
+          ORCA_AGENT_HOOK_PORT: '1',
+          ORCA_AGENT_HOOK_TOKEN: 'token',
+          ORCA_PANE_KEY: 'pane',
+          PATH: `${binDir}:${process.env.PATH ?? ''}`
+        }
+
+        const baseline = await runPosixHook(script!, orcaEnv)
+        expect(baseline.exitCode).toBe(0)
+        expect(existsSync(marker), 'baseline posts to /hook/claude').toBe(true)
+        rmSync(marker)
+
+        const underGrok = await runPosixHook(script!, { ...orcaEnv, [variable]: 'grok-compat' })
+        expect(underGrok.exitCode).toBe(0)
+        expect(existsSync(marker), `no post while ${variable} is set`).toBe(false)
+      } finally {
+        rmSync(binDir, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('drains a large payload when the configured script is missing', async () => {
     const result = await runPosixHook(wrapPosixHookCommand('/missing/orca-hook.sh'))

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -283,16 +283,13 @@ describe('Windows managed hook stdin structure', () => {
       expect(claude.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')).toBeLessThan(
         claude.indexOf('if not "%DEVIN_PROJECT_DIR%"=="" goto :orca_agent_hook_drain_stdin')
       )
-      // The Grok compat skips jump to the same label, so they carry the same ordering rule.
-      for (const guard of [
-        'if not "%GROK_HOOK_EVENT%"=="" goto :orca_agent_hook_drain_stdin',
-        'if not "%GROK_SESSION_ID%"=="" goto :orca_agent_hook_drain_stdin'
-      ]) {
-        expect(claude, `claude grok guard present: ${guard}`).toContain(guard)
-        expect(claude.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')).toBeLessThan(
-          claude.indexOf(guard)
-        )
-      }
+      // The Grok compat skip jumps to the same label, so it carries the same ordering rule.
+      const grokGuard = 'if not "%GROK_HOOK_EVENT%"=="" goto :orca_agent_hook_drain_stdin'
+      expect(claude, 'claude grok guard present').toContain(grokGuard)
+      expect(claude.indexOf('if "%ORCA_PANE_KEY%"=="" exit /b 0')).toBeLessThan(
+        claude.indexOf(grokGuard)
+      )
+      expect(claude, 'no GROK_SESSION_ID guard').not.toContain('GROK_SESSION_ID')
 
       // Why (#11549 class): every Windows-local hook now guards before owning stdin —
       // the caller may abandon the pipe, and the payload is discarded on this path anyway.
@@ -549,49 +546,52 @@ describe.skipIf(process.platform === 'win32')('managed hook stdin lifecycle', ()
     expect(result.stdinErrors).toHaveLength(0)
   })
 
-  it.each([['GROK_HOOK_EVENT'], ['GROK_SESSION_ID']])(
-    'drains before Claude skips hooks imported by Grok (%s)',
-    async (variable) => {
-      const script = (await generatePosixScripts()).get('claude claude-hook.sh')
-      expect(script).toBeDefined()
-      const result = await runPosixHook(script!, { [variable]: 'grok-compat' })
-      expect(result.exitCode).toBe(0)
-      expect(result.stdinErrors).toHaveLength(0)
-    }
-  )
+  it('drains before Claude skips hooks imported by Grok', async () => {
+    const script = (await generatePosixScripts()).get('claude claude-hook.sh')
+    expect(script).toBeDefined()
+    const result = await runPosixHook(script!, { GROK_HOOK_EVENT: 'PreToolUse' })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdinErrors).toHaveLength(0)
+  })
 
-  it.each([['GROK_HOOK_EVENT'], ['GROK_SESSION_ID']])(
-    'stops the Claude hook posting under Grok .claude compat (%s)',
-    async (variable) => {
-      const script = (await generatePosixScripts()).get('claude claude-hook.sh')
-      expect(script).toBeDefined()
-      const binDir = mkdtempSync(join(tmpdir(), 'orca-hook-grok-compat-'))
-      try {
-        const marker = join(binDir, 'posted')
-        // A stub curl records the post so the skip is observed, not inferred.
-        writeFileSync(join(binDir, 'curl'), `#!/bin/sh\ntouch '${marker}'\nexit 0\n`, {
-          mode: 0o755
-        })
-        const orcaEnv = {
-          ORCA_AGENT_HOOK_PORT: '1',
-          ORCA_AGENT_HOOK_TOKEN: 'token',
-          ORCA_PANE_KEY: 'pane',
-          PATH: `${binDir}:${process.env.PATH ?? ''}`
-        }
-
-        const baseline = await runPosixHook(script!, orcaEnv)
-        expect(baseline.exitCode).toBe(0)
-        expect(existsSync(marker), 'baseline posts to /hook/claude').toBe(true)
-        rmSync(marker)
-
-        const underGrok = await runPosixHook(script!, { ...orcaEnv, [variable]: 'grok-compat' })
-        expect(underGrok.exitCode).toBe(0)
-        expect(existsSync(marker), `no post while ${variable} is set`).toBe(false)
-      } finally {
-        rmSync(binDir, { recursive: true, force: true })
+  it('stops the Claude hook posting under Grok .claude compat', async () => {
+    const script = (await generatePosixScripts()).get('claude claude-hook.sh')
+    expect(script).toBeDefined()
+    const binDir = mkdtempSync(join(tmpdir(), 'orca-hook-grok-compat-'))
+    try {
+      const marker = join(binDir, 'posted')
+      // A stub curl records the post so the skip is observed, not inferred.
+      writeFileSync(join(binDir, 'curl'), `#!/bin/sh\ntouch '${marker}'\nexit 0\n`, {
+        mode: 0o755
+      })
+      const orcaEnv = {
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'token',
+        ORCA_PANE_KEY: 'pane',
+        PATH: `${binDir}:${process.env.PATH ?? ''}`
       }
+
+      const baseline = await runPosixHook(script!, orcaEnv)
+      expect(baseline.exitCode).toBe(0)
+      expect(existsSync(marker), 'baseline posts to /hook/claude').toBe(true)
+      rmSync(marker)
+
+      const underGrok = await runPosixHook(script!, {
+        ...orcaEnv,
+        GROK_HOOK_EVENT: 'PreToolUse'
+      })
+      expect(underGrok.exitCode).toBe(0)
+      expect(existsSync(marker), 'no post while GROK_HOOK_EVENT is set').toBe(false)
+
+      // A stray GROK_SESSION_ID alone must never silence a real Claude pane: Grok
+      // co-sets it with GROK_HOOK_EVENT in every hook process, so it is not a signal.
+      rmSync(marker, { force: true })
+      await runPosixHook(script!, { ...orcaEnv, GROK_SESSION_ID: 'stray' })
+      expect(existsSync(marker), 'GROK_SESSION_ID alone still posts').toBe(true)
+    } finally {
+      rmSync(binDir, { recursive: true, force: true })
     }
-  )
+  })
 
   it('drains a large payload when the configured script is missing', async () => {
     const result = await runPosixHook(wrapPosixHookCommand('/missing/orca-hook.sh'))

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -217,6 +217,7 @@ describe('ClaudeHookService.install', () => {
         'utf-8'
       )
       expect(managedScript).toContain('DEVIN_PROJECT_DIR')
+      expect(managedScript).toContain('GROK_SESSION_ID')
       // Why: guard and Devin-skip paths must still return neutral JSON (#14818).
       expect(managedScript).toMatch(
         process.platform === 'win32'
@@ -535,6 +536,9 @@ describe('ClaudeHookService.installRemote', () => {
     const script = fs.files.get('/home/dev/.orca/agent-hooks/claude-hook.sh')
     expect(script).toContain('#!/bin/sh')
     expect(script).toContain('DEVIN_PROJECT_DIR')
+    // Grok reads .claude hooks under [compat.claude]; the same skip must cover it.
+    expect(script).toContain('GROK_HOOK_EVENT')
+    expect(script).toContain('GROK_SESSION_ID')
     // Why: remote guard paths must still return neutral JSON (#14818).
     expect(script!.indexOf('printf "{}\\n"')).toBe(
       script!.indexOf('#!/bin/sh') + '#!/bin/sh\n'.length
@@ -637,6 +641,9 @@ describe('OpenClaudeHookService-compatible install', () => {
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')
       ).not.toContain('DEVIN_PROJECT_DIR')
+      expect(
+        readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')
+      ).not.toContain('GROK_SESSION_ID')
       // Why: the statusline usage feed is Claude-only; OpenClaude installs must not set statusLine.
       expect(parsed.statusLine).toBeUndefined()
       expect(existsSync(join(tmpHome, '.claude', 'settings.json'))).toBe(false)

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -217,7 +217,7 @@ describe('ClaudeHookService.install', () => {
         'utf-8'
       )
       expect(managedScript).toContain('DEVIN_PROJECT_DIR')
-      expect(managedScript).toContain('GROK_SESSION_ID')
+      expect(managedScript).toContain('GROK_HOOK_EVENT')
       // Why: guard and Devin-skip paths must still return neutral JSON (#14818).
       expect(managedScript).toMatch(
         process.platform === 'win32'
@@ -538,7 +538,6 @@ describe('ClaudeHookService.installRemote', () => {
     expect(script).toContain('DEVIN_PROJECT_DIR')
     // Grok reads .claude hooks under [compat.claude]; the same skip must cover it.
     expect(script).toContain('GROK_HOOK_EVENT')
-    expect(script).toContain('GROK_SESSION_ID')
     // Why: remote guard paths must still return neutral JSON (#14818).
     expect(script!.indexOf('printf "{}\\n"')).toBe(
       script!.indexOf('#!/bin/sh') + '#!/bin/sh\n'.length
@@ -643,7 +642,7 @@ describe('OpenClaudeHookService-compatible install', () => {
       ).not.toContain('DEVIN_PROJECT_DIR')
       expect(
         readFileSync(join(tmpHome, '.orca', 'agent-hooks', OPENCLAUDE_SCRIPT_FILE_NAME), 'utf-8')
-      ).not.toContain('GROK_SESSION_ID')
+      ).not.toContain('GROK_HOOK_EVENT')
       // Why: the statusline usage feed is Claude-only; OpenClaude installs must not set statusLine.
       expect(parsed.statusLine).toBeUndefined()
       expect(existsSync(join(tmpHome, '.claude', 'settings.json'))).toBe(false)

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -84,8 +84,7 @@ function getManagedScript(
             // Why: Devin and Grok read .claude hooks by default; skip Orca's managed hook under
             // either so status posts stay attributed to the agent that actually owns the pane.
             `if not "%DEVIN_PROJECT_DIR%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
-            `if not "%GROK_HOOK_EVENT%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
-            `if not "%GROK_SESSION_ID%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`
+            `if not "%GROK_HOOK_EVENT%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`
           ]
         : []),
       // Why: use curl.exe to avoid an extra PowerShell startup per hook.
@@ -106,7 +105,9 @@ function getManagedScript(
       ? [
           // Why: Devin and Grok read .claude hooks by default; skip Orca's managed hook under
           // either so status posts stay attributed to the agent that actually owns the pane.
-          'if [ -n "$DEVIN_PROJECT_DIR" ] || [ -n "$GROK_HOOK_EVENT" ] || [ -n "$GROK_SESSION_ID" ]; then',
+          // GROK_HOOK_EVENT only: Grok sets it in every hook process, and it is absent from a
+          // plain shell, so this cannot silence a real Claude pane.
+          'if [ -n "$DEVIN_PROJECT_DIR" ] || [ -n "$GROK_HOOK_EVENT" ]; then',
           '  exit 0',
           'fi'
         ]

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -61,7 +61,7 @@ const DEFAULT_CLAUDE_HOOK_SERVICE_OPTIONS: ClaudeHookServiceOptions = {
 
 function getManagedScript(
   target: 'local' | 'posix' = 'local',
-  options: { skipWhenDevinImportsClaude?: boolean } = {}
+  options: { skipWhenCompatAgentImportsClaude?: boolean } = {}
 ): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
@@ -79,10 +79,13 @@ function getManagedScript(
       // Why exit, not the drain label: the drain parks in more.com and a worker is outside
       // an Orca pane — the abandoned-stdin hang #11549 guards against.
       'if not "%CLAUDE_JOB_DIR%"=="" exit /b 0',
-      ...(options.skipWhenDevinImportsClaude
+      ...(options.skipWhenCompatAgentImportsClaude
         ? [
-            // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.
-            `if not "%DEVIN_PROJECT_DIR%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`
+            // Why: Devin and Grok read .claude hooks by default; skip Orca's managed hook under
+            // either so status posts stay attributed to the agent that actually owns the pane.
+            `if not "%DEVIN_PROJECT_DIR%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
+            `if not "%GROK_HOOK_EVENT%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`,
+            `if not "%GROK_SESSION_ID%"=="" goto :${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`
           ]
         : []),
       // Why: use curl.exe to avoid an extra PowerShell startup per hook.
@@ -99,10 +102,11 @@ function getManagedScript(
     'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
     ...buildPosixHookSpoolLines('claude'),
-    ...(options.skipWhenDevinImportsClaude
+    ...(options.skipWhenCompatAgentImportsClaude
       ? [
-          // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.
-          'if [ -n "$DEVIN_PROJECT_DIR" ]; then',
+          // Why: Devin and Grok read .claude hooks by default; skip Orca's managed hook under
+          // either so status posts stay attributed to the agent that actually owns the pane.
+          'if [ -n "$DEVIN_PROJECT_DIR" ] || [ -n "$GROK_HOOK_EVENT" ] || [ -n "$GROK_SESSION_ID" ]; then',
           '  exit 0',
           'fi'
         ]
@@ -188,7 +192,9 @@ export class ClaudeHookService {
   async refreshManagedScripts(): Promise<void> {
     await refreshManagedScriptIfPresent(
       getManagedScriptPath(this.options.settings),
-      getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+      getManagedScript('local', {
+        skipWhenCompatAgentImportsClaude: this.options.agent === 'claude'
+      })
     )
     // Why: no agent gate — the statusline script only ever exists for claude, so presence is the gate.
     await refreshManagedScriptIfPresent(
@@ -219,7 +225,9 @@ export class ClaudeHookService {
     )
     writeManagedScript(
       scriptPath,
-      getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+      getManagedScript('local', {
+        skipWhenCompatAgentImportsClaude: this.options.agent === 'claude'
+      })
     )
     // Why: the statusline usage feed is Claude-only — OpenClaude data would be misattributed to the Claude provider.
     if (this.options.agent === 'claude') {
@@ -281,7 +289,9 @@ export class ClaudeHookService {
       await writeManagedScriptRemote(
         sftp,
         remoteScriptPath,
-        getManagedScript('posix', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+        getManagedScript('posix', {
+          skipWhenCompatAgentImportsClaude: this.options.agent === 'claude'
+        })
       )
       // Why: no statusline install here — this path serves SSH remotes and WSL guests, whose relay hook
       // listener doesn't route /statusline/claude, and an SSH box's Claude login can be a different


### PR DESCRIPTION
## ELI5

Grok reads Claude's hook files on purpose — that is what its `[compat.claude]` setting is for. So when Orca puts its own hook script into `~/.claude/settings.json`, a Grok pane runs it too, and that script says "this pane is Claude." The sidebar draws its icon from that, so a Grok session showed Claude's mark. Orca already had this exact problem with Devin and already solved it: the Claude hook script bails when it sees Devin's environment. This adds Grok to the same bail.

## What Changed

`src/main/claude/hook-service.ts` — the existing `skipWhenDevinImportsClaude` option is renamed `skipWhenCompatAgentImportsClaude` and now covers Grok as well:

- POSIX: `if [ -n "$DEVIN_PROJECT_DIR" ] || [ -n "$GROK_HOOK_EVENT" ] || [ -n "$GROK_SESSION_ID" ]; then exit 0; fi`
- Windows batch: two more `goto :orca_agent_hook_drain_stdin` jumps, next to the Devin one and below the same env guards.

The flag is internal to that module and is still passed as `this.options.agent === 'claude'`, so the OpenClaude variant keeps no skip at all — unchanged.

## Why

Grok's compat scan is the point of the feature, not the bug. The mistake is Orca's script treating its own firing as proof of which agent owns the pane.

The reported payload shows the split plainly:

```json
{ "source": "claude", "hookEventName": "PreToolUse", "payload": { "state": "working", "agentType": "grok" } }
```

`agentType` is right; `source` is wrong, and the icon uses `source`. The same pane also runs Orca's `grok-hook.sh` against `/hook/grok`, so both hooks fire and the last writer wins — which was Claude.

This is the same shape Orca already fixed for Devin, which imports `.claude` hooks by default. Rather than a second parallel skip, the existing one is generalized: one guard list, one comment, both agents.

`GROK_HOOK_EVENT` and nothing else. Grok's [hook docs](https://docs.x.ai/build/features/hooks) state that "every hook process also receives `GROK_HOOK_EVENT`, `GROK_HOOK_NAME`, `GROK_SESSION_ID`, and `GROK_WORKSPACE_ROOT` in its environment", so the event var is present in exactly the moment that matters and absent from a plain shell. An earlier revision of this PR also guarded on `GROK_SESSION_ID`; that was redundant — Grok co-sets the two — and it was the one path by which a stray env var could silence a real Claude pane, so it is gone. Orca's own `grok-hook` already reports the pane, so exiting quietly loses no status.

The alternative the reporter raised and rejected — turning off Grok's `[compat.claude] hooks` — is the wrong knob: it would also drop the other Claude hooks users deliberately keep.

## Linked Issue

Fixes #18612

## Visual Proof

`N/A` — no UI code changes. The visible symptom is which icon the sidebar draws, and that is decided upstream by the `source` field in the hook post; this PR stops the wrong post being made at all. The behavior is pinned by an executable test that observes the HTTP post rather than a screenshot:

| | before | after |
|---|---|---|
| Grok pane, Orca's `grok-hook` | posts `/hook/grok`, `source: "grok"` | unchanged |
| Grok pane, Orca's `claude-hook` via compat | posts `/hook/claude`, `source: "claude"` — overwrites the above | exits 0, no post |
| Real Claude pane | posts `/hook/claude` | unchanged |
| Claude pane with a stray `GROK_SESSION_ID` | posts `/hook/claude` | unchanged — asserted by test |

## Testing

`src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts`:

- `stops the Claude hook posting under Grok .claude compat` (new) — generates the real installed `claude-hook.sh`, puts a stub `curl` on `PATH` that touches a marker file, and runs the script with `/bin/sh` three times: with a full Orca hook env (marker **is** created — the baseline proves the harness would catch a post), with `GROK_HOOK_EVENT` set (marker is **not** created), and with a stray `GROK_SESSION_ID` alone (marker **is** created again). The skip is observed, not inferred from script text, and the last case pins that a session id on its own never silences a real Claude pane.
- `drains before Claude skips hooks imported by Grok` (new) — mirrors the existing Devin drain case, asserting the skip still consumes stdin so the caller is never stranded (the #11549 contract).
- The Windows structure test now also asserts the Grok jump exists and sits *below* the env guards, the same ordering rule the Devin jump carries — otherwise a Grok session outside an Orca pane would park in `more.com` — and that the script contains no `GROK_SESSION_ID` at all.

`src/main/claude/hook-service.test.ts` — the install and remote-install cases assert the generated script carries the Grok guards; the OpenClaude case asserts it does not.

All five new assertions were confirmed to fail against the unmodified `hook-service.ts` and pass with it.

Ran on macOS: `src/main/claude/`, `src/main/agent-hooks/`, and `src/main/grok/` — 127 files, 1205 tests, all passing; plus `pnpm tc` and `pnpm run check:code-quality:changed`. The touched files were run three extra times to check for flakiness (30 passed each time). CI covers the full `pnpm test` and `pnpm build`.

Manual: I do not have a Grok CLI licence to drive the real TUI, so the compat path was exercised through the executable test above against the actually-generated script rather than a live Grok session. A reviewer with Grok can confirm by running `grok --resume` in a pane and checking that `agent-hooks/last-status.json` keeps `"source": "grok"`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The Devin precedent was found by reading `hook-service.ts`; the fix, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** both script paths are covered. The Windows jumps deliberately sit below `buildWindowsHookEnvironmentGuardLines()` so the `more.com` drain is never reached from outside an Orca pane (#11549). The POSIX skip stays after `buildPosixHookPayloadCapture()`, so stdin is already consumed before the exit.
- **Remote / SSH:** the remote installer writes the same generated script (`getManagedScript('posix', …)`), so the guard ships to SSH hosts unchanged; `hook-service.test.ts`'s remote case asserts it. No RPC params, stream frames, or published content change, so there is no wire-compatibility surface.
- **Agents / integrations:** Claude and OpenClaude behavior is unchanged except under Grok/Devin env. Orca's Grok hook is untouched and still owns Grok panes.
- **Mobile:** not affected.
- **Performance:** two string comparisons per hook invocation on a path that already runs several.
- **Security:** no new input surface. Strictly fewer HTTP posts.
- **Backwards compatibility:** no persisted state, settings, or schema changes. The script is regenerated on install/refresh like any other hook-script change.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

An earlier revision guarded on `GROK_SESSION_ID` as well. Review pointed at Grok's own docs showing all four `GROK_*` vars are set together in every hook process, so that clause could never fire alone — while still being the one way a stray env var could silence a real Claude pane. It is dropped, and a test now asserts a lone `GROK_SESSION_ID` still posts.

The `DEVIN_PROJECT_DIR` guard this generalizes has the same shape and predates this PR; whether it wants the same narrowing is worth a look, but not from here.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

