### PR TITLE
fix(skills): pin the skills package spec so npx cannot run a PATH collision

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -865,9 +865,9 @@ is resolved.
 ## Installing Agent Skills Without A Desktop
 
 Orca's agent skills (CLI usage, orchestration, computer use, etc.) are normally
-installed from Orca Settings, which pre-fills an `npx skills add ... --global`
-command in a terminal for you to run. A headless host has no Settings UI, so
-use `orca skills install` instead:
+installed from Orca Settings, which pre-fills an
+`npx skills@latest add ... --global` command in a terminal for you to run. A
+headless host has no Settings UI, so use `orca skills install` instead:
 
 ```bash
 orca skills install                                      # list installable skills
@@ -877,7 +877,7 @@ orca skills install --all                                 # install every bundle
 orca skills install --all --dry-run                       # print the npx command without running it
 ```
 
-This resolves the same `npx skills add <repo> --skill <name> ...` command
+This resolves the same `npx skills@latest add <repo> --skill <name> ...` command
 Settings would show you (adding `--global` unless `--local` is passed), then
 runs it and forwards its output and exit code. It requires `node`/`npx` on the
 host; it does not need a running Orca runtime.
@@ -905,7 +905,7 @@ If Orca detects no agent at all, `orca skills install` stops and asks for
 
 To refresh already-installed skills, `orca skills update` mirrors the same
 selection flags (`--skill`, `--all`, `--local`, `--dry-run`) and resolves to
-`npx skills update <names...>` with a matching scope flag — `--global`, or
+`npx skills@latest update <names...>` with a matching scope flag — `--global`, or
 `--project` when you pass `--local`:
 
 ```bash

--- a/docs/site/content/docs/cli/computer-use.mdx
+++ b/docs/site/content/docs/cli/computer-use.mdx
@@ -102,7 +102,7 @@ On Linux and Windows, action payloads also pass briefly through a local operatio
 The shipped `computer-use` skill packages the same command surface with safety guidance. Install it into the agent's skill directory:
 
 ```
-npx skills add https://github.com/stablyai/orca --skill computer-use
+npx skills@latest add https://github.com/stablyai/orca --skill computer-use
 ```
 
 See [Skills registry & MCP](/docs/cli/skills) for how skills are picked up.

--- a/docs/site/content/docs/cli/overview.mdx
+++ b/docs/site/content/docs/cli/overview.mdx
@@ -19,7 +19,7 @@ It ships with the desktop app; register it under [Settings → General → Orca 
 Agents can install the matching Orca CLI skill with:
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orca-cli
+npx skills@latest add https://github.com/stablyai/orca --skill orca-cli
 # headless / no Settings UI:
 orca skills install --skill orca-cli
 ```

--- a/docs/site/content/docs/cli/reference.mdx
+++ b/docs/site/content/docs/cli/reference.mdx
@@ -296,7 +296,7 @@ orca skills install --all --dry-run
 orca skills update --all
 ```
 
-`install` / `update` shell out to the same `npx skills` commands Settings uses. They do not contact the Orca runtime. See [Orca skills](/docs/cli/skills#keep-skills-up-to-date).
+`install` / `update` shell out to the same `npx skills@latest` commands Settings uses. They do not contact the Orca runtime. See [Orca skills](/docs/cli/skills#keep-skills-up-to-date).
 
 ## Account (host-local runtime)
 

--- a/docs/site/content/docs/cli/skills.mdx
+++ b/docs/site/content/docs/cli/skills.mdx
@@ -20,13 +20,13 @@ Use `npx skills add` with the public Orca repo and the skill name. Default agent
 
 | Skill                                               | Install                                                                                   | Use it for                                                    |
 | --------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| [`orca-cli`](#orca-cli)                             | `npx skills add https://github.com/stablyai/orca --skill orca-cli --global`               | Worktrees, terminals, files, automations, embedded browser.   |
-| [`orchestration`](#orchestration)                   | `npx skills add https://github.com/stablyai/orca --skill orchestration --global`          | Multi-agent Runs, tasks, supervised workers, messages, gates. |
-| [`computer-use`](#computer-use)                     | `npx skills add https://github.com/stablyai/orca --skill computer-use --global`           | Desktop apps via accessibility trees and safe UI actions.     |
-| [`orca-linear`](#orca-linear)                       | `npx skills add https://github.com/stablyai/orca --skill orca-linear --global`            | Linear ticket read/write through `orca linear`.               |
-| [`orca-emulator`](#orca-emulator)                   | `npx skills add https://github.com/stablyai/orca --skill orca-emulator --global`          | iOS Simulator control.                                        |
-| [`orca-emulator-android`](#orca-emulator-android)   | `npx skills add https://github.com/stablyai/orca --skill orca-emulator-android --global`  | Android emulator/device via adb.                              |
-| [`orca-per-workspace-env`](#orca-per-workspace-env) | `npx skills add https://github.com/stablyai/orca --skill orca-per-workspace-env --global` | Per-workspace environment recipes (`orca.yaml`).              |
+| [`orca-cli`](#orca-cli)                             | `npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --global`               | Worktrees, terminals, files, automations, embedded browser.   |
+| [`orchestration`](#orchestration)                   | `npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global`          | Multi-agent Runs, tasks, supervised workers, messages, gates. |
+| [`computer-use`](#computer-use)                     | `npx skills@latest add https://github.com/stablyai/orca --skill computer-use --global`           | Desktop apps via accessibility trees and safe UI actions.     |
+| [`orca-linear`](#orca-linear)                       | `npx skills@latest add https://github.com/stablyai/orca --skill orca-linear --global`            | Linear ticket read/write through `orca linear`.               |
+| [`orca-emulator`](#orca-emulator)                   | `npx skills@latest add https://github.com/stablyai/orca --skill orca-emulator --global`          | iOS Simulator control.                                        |
+| [`orca-emulator-android`](#orca-emulator-android)   | `npx skills@latest add https://github.com/stablyai/orca --skill orca-emulator-android --global`  | Android emulator/device via adb.                              |
+| [`orca-per-workspace-env`](#orca-per-workspace-env) | `npx skills@latest add https://github.com/stablyai/orca --skill orca-per-workspace-env --global` | Per-workspace environment recipes (`orca.yaml`).              |
 
 ## Hybrid stubs vs the live guide
 
@@ -57,7 +57,7 @@ When Orca ships a newer skill package than the one installed globally, the app c
 Manual equivalent (desktop Settings still shows the same `npx` form):
 
 ```bash
-npx skills update orca-cli orchestration computer-use --global
+npx skills@latest update orca-cli orchestration computer-use --global
 ```
 
 On headless hosts (SSH, containers, CI, `orca serve`) with no Settings UI, use the local CLI wrappers — they resolve the same `npx` commands, add non-interactive flags, and do **not** need a running Orca runtime:
@@ -102,7 +102,7 @@ orca skills share --skill frontend --skill testing --bundle-name "Team Toolkit" 
 ## orca-cli
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orca-cli --global
+npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --global
 ```
 
 After install, load the version-matched command guide with `orca skills get orca-cli`. See [Orca CLI](/docs/cli/overview).
@@ -110,7 +110,7 @@ After install, load the version-matched command guide with `orca skills get orca
 ## orchestration
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orchestration --global
+npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global
 ```
 
 Use this when an agent should coordinate other agents through Runs, tasks, supervised workers, and decision gates. See [Orchestration](/docs/cli/orchestration). Always load `orca skills get orchestration --full` before mutating orchestration state — the legacy `orchestration run` command is retired.
@@ -118,7 +118,7 @@ Use this when an agent should coordinate other agents through Runs, tasks, super
 ## computer-use
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill computer-use --global
+npx skills@latest add https://github.com/stablyai/orca --skill computer-use --global
 ```
 
 Use this when an agent needs to inspect and operate local desktop app windows. See [Computer use](/docs/cli/computer-use).
@@ -126,7 +126,7 @@ Use this when an agent needs to inspect and operate local desktop app windows. S
 ## orca-linear
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orca-linear --global
+npx skills@latest add https://github.com/stablyai/orca --skill orca-linear --global
 ```
 
 Agents should load `orca skills get orca-linear` before mutating tickets. Covers `issue --full`, `save-issue`, `list-issues`, relations, completion attach+comment flow, and untrusted-ticket rules. Existing `linear-tickets` installs still resolve. See [CLI reference → Linear](/docs/cli/reference#linear).
@@ -134,7 +134,7 @@ Agents should load `orca skills get orca-linear` before mutating tickets. Covers
 ## orca-emulator
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orca-emulator --global
+npx skills@latest add https://github.com/stablyai/orca --skill orca-emulator --global
 ```
 
 Use this when an agent should control an iOS Simulator from inside Orca through `orca emulator` commands.
@@ -142,7 +142,7 @@ Use this when an agent should control an iOS Simulator from inside Orca through 
 ## orca-emulator-android
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orca-emulator-android --global
+npx skills@latest add https://github.com/stablyai/orca --skill orca-emulator-android --global
 ```
 
 Use for adb-connected Android AVDs/devices: list/boot, tap/swipe/type, hardware buttons, install/launch, permissions, accessibility tree, logcat. Load details with `orca skills get orca-emulator-android`.
@@ -150,7 +150,7 @@ Use for adb-connected Android AVDs/devices: list/boot, tap/swipe/type, hardware 
 ## orca-per-workspace-env
 
 ```bash
-npx skills add https://github.com/stablyai/orca --skill orca-per-workspace-env --global
+npx skills@latest add https://github.com/stablyai/orca --skill orca-per-workspace-env --global
 ```
 
 Use when setting up or debugging per-workspace environment recipes in `orca.yaml`. See [Ways to run Orca](/docs/ways-to-run#4-cloud-vms-per-workspace-environments).

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -339,7 +339,7 @@ describe('orca skills CLI', () => {
     await main(['skills', 'install', '--skill', 'alpha', '--dry-run'], '/tmp/repo')
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y\n\n' +
+      'npx --yes skills@latest add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y\n\n' +
         'Rerun without --dry-run to install now.\n'
     )
     expect(spawnMock).not.toHaveBeenCalled()
@@ -354,7 +354,7 @@ describe('orca skills CLI', () => {
       `${JSON.stringify(
         {
           command:
-            'npx --yes skills add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y',
+            'npx --yes skills@latest add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y',
           skills: ['alpha'],
           global: true,
           executed: false
@@ -371,7 +371,7 @@ describe('orca skills CLI', () => {
     await main(['skills', 'install', '--skill', 'alpha', '--local', '--dry-run'], '/tmp/repo')
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills add https://github.com/stablyai/orca --skill alpha --agent claude-code --agent universal -y\n\n' +
+      'npx --yes skills@latest add https://github.com/stablyai/orca --skill alpha --agent claude-code --agent universal -y\n\n' +
         'Rerun without --dry-run to install now.\n'
     )
 
@@ -385,7 +385,7 @@ describe('orca skills CLI', () => {
       `${JSON.stringify(
         {
           command:
-            'npx --yes skills add https://github.com/stablyai/orca --skill alpha --agent claude-code --agent universal -y',
+            'npx --yes skills@latest add https://github.com/stablyai/orca --skill alpha --agent claude-code --agent universal -y',
           skills: ['alpha'],
           global: false,
           executed: false
@@ -410,7 +410,7 @@ describe('orca skills CLI', () => {
       'npx',
       [
         '--yes',
-        'skills',
+        'skills@latest',
         'add',
         'https://github.com/stablyai/orca',
         '--skill',
@@ -445,7 +445,7 @@ describe('orca skills CLI', () => {
         '/c',
         'C:\\Program Files\\nodejs\\npx.cmd',
         '--yes',
-        'skills',
+        'skills@latest',
         'add',
         'https://github.com/stablyai/orca',
         '--skill',
@@ -493,7 +493,7 @@ describe('orca skills CLI', () => {
       'npx',
       [
         '--yes',
-        'skills',
+        'skills@latest',
         'add',
         'https://github.com/stablyai/orca',
         '--skill',
@@ -523,7 +523,7 @@ describe('orca skills CLI', () => {
       'npx',
       [
         '--yes',
-        'skills',
+        'skills@latest',
         'add',
         'https://github.com/stablyai/orca',
         '--skill',
@@ -587,7 +587,7 @@ describe('orca skills CLI', () => {
     await main(['skills', 'update', '--skill', 'legacy-alpha', '--dry-run'], '/tmp/repo')
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills update alpha --global -y\n\nRerun without --dry-run to update now.\n'
+      'npx --yes skills@latest update alpha --global -y\n\nRerun without --dry-run to update now.\n'
     )
     expect(spawnMock).not.toHaveBeenCalled()
   })
@@ -603,7 +603,7 @@ describe('orca skills CLI', () => {
     expect(stdoutText(stdoutSpy)).toBe(
       `${JSON.stringify(
         {
-          command: 'npx --yes skills update alpha --project -y',
+          command: 'npx --yes skills@latest update alpha --project -y',
           skills: ['alpha'],
           global: false,
           executed: false
@@ -626,7 +626,7 @@ describe('orca skills CLI', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'npx',
-      ['--yes', 'skills', 'update', 'alpha', '--project', '-y'],
+      ['--yes', 'skills@latest', 'update', 'alpha', '--project', '-y'],
       expect.objectContaining({ stdio: 'inherit' })
     )
   })
@@ -895,7 +895,7 @@ describe('orca skills CLI', () => {
       'npx',
       [
         '--yes',
-        'skills',
+        'skills@latest',
         'add',
         'https://github.com/stablyai/orca',
         '--skill',
@@ -922,7 +922,7 @@ describe('orca skills CLI', () => {
     )
 
     expect(stdoutText(stdoutSpy)).toBe(
-      'npx --yes skills add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y\n\n' +
+      'npx --yes skills@latest add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y\n\n' +
         'Rerun without --dry-run to install now.\n'
     )
     expect(spawnMock).not.toHaveBeenCalled()
@@ -940,11 +940,11 @@ describe('orca skills CLI', () => {
 
     // Why: stdout belongs to the child, so this record has to go to stderr.
     expect(stderrSpy).toHaveBeenCalledWith(
-      'Running: npx --yes skills add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y\n'
+      'Running: npx --yes skills@latest add https://github.com/stablyai/orca --skill alpha --global --agent claude-code --agent universal -y\n'
     )
   })
 
-  it('runs npx skills update for --all and forwards its exit code', async () => {
+  it('runs npx skills@latest update for --all and forwards its exit code', async () => {
     const child = createFakeChild()
     spawnMock.mockReturnValue(child)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
@@ -956,7 +956,7 @@ describe('orca skills CLI', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       'npx',
-      ['--yes', 'skills', 'update', 'alpha', 'gamma', 'zeta', '--global', '-y'],
+      ['--yes', 'skills@latest', 'update', 'alpha', 'gamma', 'zeta', '--global', '-y'],
       expect.objectContaining({ stdio: 'inherit' })
     )
     expect(process.exitCode).toBe(2)

--- a/src/cli/specs/skills.ts
+++ b/src/cli/specs/skills.ts
@@ -66,7 +66,7 @@ export const SKILL_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'skill', 'all', 'agent', 'local', 'dry-run'],
     notes: [
       'Reads the bundled skill registry locally without contacting the Orca runtime.',
-      'Resolves to the same `npx skills add <repo> --skill <name> ...` command used by ' +
+      'Resolves to the same `npx skills@latest add <repo> --skill <name> ...` command used by ' +
         'Orca Settings, plus the non-interactive flags an unattended host needs ' +
         '(`npx --yes` and `-y`), then runs it and forwards its output and exit code.',
       'Installs globally (all projects, adds --global) by default. Use --local to install ' +
@@ -98,7 +98,7 @@ export const SKILL_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'skill', 'all', 'local', 'dry-run'],
     notes: [
       'Reads the bundled skill registry locally without contacting the Orca runtime.',
-      'Resolves to the same `npx skills update <names...>` command used by Orca Settings, ' +
+      'Resolves to the same `npx skills@latest update <names...>` command used by Orca Settings, ' +
         'plus the non-interactive flags an unattended host needs (`npx --yes` and `-y`), ' +
         'then runs it and forwards its output and exit code.',
       'Updates the global install (all projects, adds --global) by default. Use --local to ' +

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -306,7 +306,7 @@ describe('skill discovery', () => {
     const claudeSkills = join(home, '.claude', 'skills')
     await mkdir(join(claudeSkills, 'orchestration'), { recursive: true })
     await writeFile(join(claudeSkills, 'orchestration', 'SKILL.md'), '# orchestration')
-    // `npx skills add --global` links a provider home onto an existing install.
+    // `npx skills@latest add --global` links a provider home onto an existing install.
     await mkdir(join(home, '.grok'), { recursive: true })
     await symlink(
       claudeSkills,

--- a/src/main/skills/skill-freshness-eligibility.test.ts
+++ b/src/main/skills/skill-freshness-eligibility.test.ts
@@ -171,7 +171,7 @@ describe('skill freshness name-scoped update eligibility', () => {
 
   it('builds only an explicit, deterministic global command', () => {
     expect(buildTargetedSkillUpdateCommand(['orchestration', 'orca-cli', 'orca-cli'])).toBe(
-      'npx skills update orca-cli orchestration --global'
+      'npx skills@latest update orca-cli orchestration --global'
     )
     expect(buildTargetedSkillUpdateCommand([])).toBeNull()
     expect(buildTargetedSkillUpdateCommand(['orca-cli;echo unsafe'])).toBeNull()

--- a/src/main/skills/skill-update-run.test.ts
+++ b/src/main/skills/skill-update-run.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
+import { SKILLS_CLI_PACKAGE_SPEC } from '../../shared/agent-feature-install-commands'
 import type { SkillUpdateRun } from '../../shared/skill-freshness'
 import {
   getSpawnArgsForWindows,
@@ -55,7 +56,7 @@ describe('SkillUpdateRunner', () => {
     // non-interactive branch. Dropping either can wedge the run.
     expect(spawnCalls[0].args).toEqual([
       '--yes',
-      'skills',
+      SKILLS_CLI_PACKAGE_SPEC,
       'update',
       'orca-cli',
       'orchestration',

--- a/src/main/skills/skill-update-run.ts
+++ b/src/main/skills/skill-update-run.ts
@@ -4,6 +4,7 @@ import {
   type SkillUpdateRun,
   type SkillUpdateStartResult
 } from '../../shared/skill-freshness'
+import { SKILLS_CLI_PACKAGE_SPEC } from '../../shared/agent-feature-install-commands'
 import { resolveCliCommand } from '../codex-cli/command'
 import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { killWithDescendantSweep } from '../pty-descendant-termination'
@@ -48,7 +49,7 @@ function clampOutput(value: string): string {
 }
 
 /**
- * Runs `npx --yes skills update <names> --global -y` headlessly.
+ * Runs `npx --yes skills@latest update <names> --global -y` headlessly.
  *
  * Both `--yes` flags are load-bearing and distinct: `npx --yes` skips the
  * install-this-package prompt, and `skills … -y` takes the CLI's own
@@ -93,7 +94,14 @@ export class SkillUpdateRunner {
     const resolveCommand = this.deps.resolveCommand ?? ((name: string) => resolveCliCommand(name))
     const spawnProcess = this.deps.spawnProcess ?? spawn
     const npxCommand = resolveCommand('npx')
-    const npxArgs = ['--yes', 'skills', 'update', ...canonicalNames, '--global', '-y']
+    const npxArgs = [
+      '--yes',
+      SKILLS_CLI_PACKAGE_SPEC,
+      'update',
+      ...canonicalNames,
+      '--global',
+      '-y'
+    ]
 
     let spawnCmd: string
     let spawnArgs: string[]

--- a/src/main/telemetry/onboarding-feature-setup-validator.test.ts
+++ b/src/main/telemetry/onboarding-feature-setup-validator.test.ts
@@ -49,7 +49,7 @@ describe('onboarding feature setup telemetry validation', () => {
         linear_tickets: false,
         orchestration: true,
         selected_count: 2,
-        command: 'npx skills add https://github.com/stablyai/orca --global'
+        command: 'npx skills@latest add https://github.com/stablyai/orca --global'
       } as never).ok
     ).toBe(false)
     expect(

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
@@ -63,46 +63,61 @@ describe('FeatureSetupInlineTerminal', () => {
 
   it('runs the command through the resolved WSL runtime', () => {
     render(
-      <FeatureSetupInlineTerminal command="npx skills add orchestration" selection={SELECTION} />
+      <FeatureSetupInlineTerminal
+        command="npx skills@latest add orchestration"
+        selection={SELECTION}
+      />
     )
 
-    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', {
+    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills@latest add orchestration', {
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
       label: 'WSL Ubuntu'
     })
     expect(mocks.terminalProps).toMatchObject({
-      command: 'wsl:npx skills add orchestration',
+      command: 'wsl:npx skills@latest add orchestration',
       forceHostRuntime: false,
       shellOverride: 'powershell.exe'
     })
     expect(
-      mocks.terminalProps?.prepareCommandForShell?.('wsl:npx skills add orchestration', 'wsl.exe')
-    ).toBe('wsl-wsl.exe:wsl:npx skills add orchestration')
+      mocks.terminalProps?.prepareCommandForShell?.(
+        'wsl:npx skills@latest add orchestration',
+        'wsl.exe'
+      )
+    ).toBe('wsl-wsl.exe:wsl:npx skills@latest add orchestration')
   })
 
   it('uses the host command builder when the WSL runtime needs repair', () => {
     mocks.runtime.installDisabledReason = 'The selected WSL distro is unavailable.'
 
     render(
-      <FeatureSetupInlineTerminal command="npx skills add orchestration" selection={SELECTION} />
+      <FeatureSetupInlineTerminal
+        command="npx skills@latest add orchestration"
+        selection={SELECTION}
+      />
     )
 
-    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', undefined)
+    expect(mocks.buildCommand).toHaveBeenCalledWith(
+      'npx skills@latest add orchestration',
+      undefined
+    )
     expect(mocks.terminalProps).toMatchObject({
-      command: 'host:npx skills add orchestration',
+      command: 'host:npx skills@latest add orchestration',
       forceHostRuntime: true,
       shellOverride: 'powershell.exe'
     })
     expect(
-      mocks.terminalProps?.prepareCommandForShell?.('host:npx skills add orchestration', 'wsl.exe')
-    ).toBe('host-wsl.exe:host:npx skills add orchestration')
+      mocks.terminalProps?.prepareCommandForShell?.(
+        'host:npx skills@latest add orchestration',
+        'wsl.exe'
+      )
+    ).toBe('host-wsl.exe:host:npx skills@latest add orchestration')
   })
 
   it('keeps the runtime captured when setup started', () => {
     render(
       <FeatureSetupInlineTerminal
-        command="npx skills add orchestration"
+        command="npx skills@latest add orchestration"
         runtimeContext={{
           agentRuntime: { runtime: 'host', label: 'Windows' },
           installDisabledReason: null,
@@ -112,16 +127,19 @@ describe('FeatureSetupInlineTerminal', () => {
       />
     )
 
-    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', {
+    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills@latest add orchestration', {
       runtime: 'host',
       label: 'Windows'
     })
     expect(mocks.terminalProps).toMatchObject({
-      command: 'host:npx skills add orchestration',
+      command: 'host:npx skills@latest add orchestration',
       shellOverride: 'cmd.exe'
     })
     expect(
-      mocks.terminalProps?.prepareCommandForShell?.('host:npx skills add orchestration', 'cmd.exe')
-    ).toBe('host-cmd.exe:host:npx skills add orchestration')
+      mocks.terminalProps?.prepareCommandForShell?.(
+        'host:npx skills@latest add orchestration',
+        'cmd.exe'
+      )
+    ).toBe('host-cmd.exe:host:npx skills@latest add orchestration')
   })
 })

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx
@@ -99,7 +99,7 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
       await act(async () => {
         root?.render(
           <OnboardingInlineCommandTerminal
-            command="npx skills add orchestration"
+            command="npx skills@latest add orchestration"
             prepareCommandForShell={prepareCommandForShell}
             shellOverride="powershell.exe"
             title="Skill setup"
@@ -114,7 +114,7 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
       await act(async () => {
         root?.render(
           <OnboardingInlineCommandTerminal
-            command="npx skills add orchestration"
+            command="npx skills@latest add orchestration"
             forceHostRuntime
             prepareCommandForShell={prepareCommandForShell}
             shellOverride="powershell.exe"
@@ -128,9 +128,12 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
         vi.advanceTimersByTime(250)
       })
 
-      expect(prepareCommandForShell).toHaveBeenCalledWith('npx skills add orchestration', 'wsl.exe')
       expect(prepareCommandForShell).toHaveBeenCalledWith(
-        'npx skills add orchestration',
+        'npx skills@latest add orchestration',
+        'wsl.exe'
+      )
+      expect(prepareCommandForShell).toHaveBeenCalledWith(
+        'npx skills@latest add orchestration',
         'powershell.exe'
       )
       expect(mocks.createTab).toHaveBeenCalledWith(
@@ -141,11 +144,11 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
       )
       expect(pasted).toContainEqual({
         tabId: 'tab-1',
-        text: 'wsl.exe:npx skills add orchestration'
+        text: 'wsl.exe:npx skills@latest add orchestration'
       })
       expect(pasted).toContainEqual({
         tabId: 'tab-2',
-        text: 'powershell.exe:npx skills add orchestration'
+        text: 'powershell.exe:npx skills@latest add orchestration'
       })
     } finally {
       window.removeEventListener(PASTE_TERMINAL_TEXT_EVENT, handlePaste)
@@ -160,7 +163,7 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
     await act(async () => {
       root?.render(
         <OnboardingInlineCommandTerminal
-          command="npx skills add --skill orchestration --global"
+          command="npx skills@latest add --skill orchestration --global"
           title="Skill setup"
           ariaLabel="Skill setup terminal"
           worktreeId="settings-orchestration-skill-terminal"

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -125,7 +125,7 @@ describe('onboarding feature setup runner', () => {
 
     expect(text).toBe(ALL_SKILL_INSTALL_COMMAND)
     expect(text).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --skill computer-use --skill orchestration --skill orca-linear --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --skill computer-use --skill orchestration --skill orca-linear --global'
     )
   })
 

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.freshness.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.freshness.test.tsx
@@ -31,7 +31,7 @@ function panelProps(
   return {
     title: 'Linear skill',
     description: null,
-    command: 'npx skills add orca-linear --global',
+    command: 'npx skills@latest add orca-linear --global',
     terminalTitle: 'Linear skill setup',
     terminalAriaLabel: 'Linear skill install terminal',
     terminalWorktreeId: 'settings-linear-skill-terminal',

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -7,8 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { TooltipProvider } from '../ui/tooltip'
 
-const INSTALL_COMMAND = 'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
-const UPDATE_COMMAND = 'npx skills update orca-cli --global'
+const INSTALL_COMMAND =
+  'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --global'
+const UPDATE_COMMAND = 'npx skills@latest update orca-cli --global'
 
 const mocks = vi.hoisted(() => ({
   clipboardWrite: vi.fn(),

--- a/src/renderer/src/components/settings/BrowserUseSkillStep.test.tsx
+++ b/src/renderer/src/components/settings/BrowserUseSkillStep.test.tsx
@@ -16,8 +16,8 @@ vi.mock('./AgentSkillSetupPanel', () => ({
 describe('BrowserUseSkillStep', () => {
   it('forwards a single-skill installed command even when setup installs a bundle', () => {
     const bundleInstallCommand =
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --skill orchestration --global'
-    const updateCommand = 'npx skills update orca-cli --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --skill orchestration --global'
+    const updateCommand = 'npx skills@latest update orca-cli --global'
 
     renderToStaticMarkup(
       <BrowserUseSkillStep

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -38,7 +38,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1'
 
   it('keeps copied WSL skill installs valid for the target POSIX shell', () => {
-    const skillCommand = 'npx skills add orchestration --global'
+    const skillCommand = 'npx skills@latest add orchestration --global'
     const runtime = {
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
@@ -53,12 +53,12 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
       `& { $PSNativeCommandArgumentPassing = 'Legacy'; wsl.exe -d 'Ubuntu' --exec sh -c 'sh -c \\"$(printf %s ${encoded} | base64 -d)\\"' } # Runs: ${skillCommand}`
     )
     expect(decodeWslLoginShellScript(setupCommand)).toContain(
-      'exec "$_orca_wsl_shell" -ilc \'npx skills add orchestration --global\''
+      'exec "$_orca_wsl_shell" -ilc \'npx skills@latest add orchestration --global\''
     )
   })
 
   it('keeps a Windows-selected WSL install inside WSL without the host preflight', () => {
-    const skillCommand = 'npx skills add orchestration --global'
+    const skillCommand = 'npx skills@latest add orchestration --global'
     const runtime = {
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
@@ -71,7 +71,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     expect(setupCommand).toContain("wsl.exe -d 'Ubuntu'")
     expect(setupCommand).not.toContain('where.exe npx')
     expect(decodeWslLoginShellScript(setupCommand)).toContain(
-      'exec "$_orca_wsl_shell" -ilc \'npx skills add orchestration --global\''
+      'exec "$_orca_wsl_shell" -ilc \'npx skills@latest add orchestration --global\''
     )
   })
 
@@ -81,17 +81,23 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
       wslDistro: 'Fedora Remix',
       label: 'WSL Fedora Remix'
     } as const
-    const command = buildSkillCommandForRuntime('npx skills update orchestration --global', runtime)
+    const command = buildSkillCommandForRuntime(
+      'npx skills@latest update orchestration --global',
+      runtime
+    )
     const setupCommand = buildSkillSetupTerminalCommand(command, 'powershell.exe', runtime, 'win32')
 
     expect(decodeWslLoginShellScript(setupCommand)).toContain(
-      'exec "$_orca_wsl_shell" -ilc \'npx skills update orchestration --global\''
+      'exec "$_orca_wsl_shell" -ilc \'npx skills@latest update orchestration --global\''
     )
   })
 
   it('scopes the PS5-compatible argv mode in the PowerShell setup terminal', () => {
     const runtime = { runtime: 'wsl', label: 'WSL' } as const
-    const command = buildSkillCommandForRuntime('npx skills update orchestration --global', runtime)
+    const command = buildSkillCommandForRuntime(
+      'npx skills@latest update orchestration --global',
+      runtime
+    )
     const setupCommand = buildSkillSetupTerminalCommand(command, 'powershell.exe', runtime, 'win32')
 
     expect(setupCommand).toMatch(
@@ -133,7 +139,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
           label: 'WSL'
         } as const
         const copied = buildSkillCommandForRuntime(
-          'npx skills update orchestration --global',
+          'npx skills@latest update orchestration --global',
           runtime
         )
         const wrapped = buildSkillSetupTerminalCommand(copied, 'powershell.exe', runtime, 'win32')
@@ -148,7 +154,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
               ORCA_TEST_NPX_BIN: npxBin
             }
           })
-        ).toBe('skills update orchestration --global:terminal-input')
+        ).toBe('skills@latest update orchestration --global:terminal-input')
       } finally {
         rmSync(root, { recursive: true, force: true })
       }
@@ -183,7 +189,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
 
     expect(
       buildSkillCommandForRuntime(
-        'npx skills update orchestration --global',
+        'npx skills@latest update orchestration --global',
         {
           runtime: 'host',
           label: 'Windows'
@@ -197,7 +203,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     const installCommand = buildAgentFeatureSkillInstallCommand(['orca-cli'])
 
     expect(
-      buildSkillCommandForRuntime('npx skills update orca-cli --global', undefined, 'win32')
+      buildSkillCommandForRuntime('npx skills@latest update orca-cli --global', undefined, 'win32')
     ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
   })
 
@@ -219,14 +225,14 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
   it('keeps non-Windows host skill updates on the update path', () => {
     expect(
       buildSkillCommandForRuntime(
-        'npx skills update orchestration --global',
+        'npx skills@latest update orchestration --global',
         {
           runtime: 'host',
           label: 'This device'
         },
         'linux'
       )
-    ).toBe('npx skills update orchestration --global')
+    ).toBe('npx skills@latest update orchestration --global')
   })
 
   it('skips the Windows preflight while a remote runtime environment is focused', () => {
@@ -329,7 +335,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
 
   it('adapts bare WSL setup commands to the shell that Orca created', () => {
     const runtime = { runtime: 'wsl', wslDistro: 'Ubuntu', label: 'WSL Ubuntu' } as const
-    const skillCommand = 'npx skills add orchestration --global'
+    const skillCommand = 'npx skills@latest add orchestration --global'
     const copiedCommand = buildSkillCommandForRuntime(skillCommand, runtime, 'win32')
 
     expect(copiedCommand).toBe(skillCommand)
@@ -341,12 +347,12 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     )
     expect(
       buildSkillSetupTerminalCommand(
-        'npx skills add orchestration --global',
+        'npx skills@latest add orchestration --global',
         undefined,
         undefined,
         'linux'
       )
-    ).toBe('npx skills add orchestration --global')
+    ).toBe('npx skills@latest add orchestration --global')
   })
 
   it('preserves the exact WSL script when adapting setup-terminal auto-paste', () => {
@@ -379,7 +385,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     try {
       expect(
         buildSkillCommandForRuntime(
-          'npx skills update orchestration --global',
+          'npx skills@latest update orchestration --global',
           { runtime: 'host', label: 'Windows' },
           'win32'
         )

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -109,7 +109,10 @@ function normalizeWindowsSkillUpdateCommand(
   }
 
   const trimmedCommand = command.trim()
-  const updateMatch = /^npx\s+skills\s+update\s+([A-Za-z0-9_-]+)\s+--global$/i.exec(trimmedCommand)
+  // The package spec carries a version (`skills@latest`), so match it loosely.
+  const updateMatch = /^npx\s+skills(?:@\S+)?\s+update\s+([A-Za-z0-9_-]+)\s+--global$/i.exec(
+    trimmedCommand
+  )
   if (!updateMatch) {
     return command
   }
@@ -227,7 +230,7 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
     // shells rewrite cmd.exe's leading /d /s /c switches into drive paths,
     // starting an interactive cmd session instead of running the payload.
     (target === 'copied-command' && isPosixFamilyWindowsShellConfigured()) ||
-    !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
+    !/^npx\s+skills(?:@\S+)?\s+(?:add|update)\b/i.test(trimmedCommand)
   ) {
     return command
   }

--- a/src/renderer/src/components/settings/LinearAgentSkillPane.test.tsx
+++ b/src/renderer/src/components/settings/LinearAgentSkillPane.test.tsx
@@ -11,7 +11,7 @@ import {
 import { getLinearUsageExamples } from '@/lib/linear-usage-examples'
 import { LinearAgentSkillPane } from './LinearAgentSkillPane'
 
-const UPDATE_COMMAND = 'npx skills update orca-linear --global'
+const UPDATE_COMMAND = 'npx skills@latest update orca-linear --global'
 
 const mocks = vi.hoisted(() => ({
   panelProps: [] as Record<string, unknown>[],

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -13,10 +13,10 @@ import { getOrchestrationPaneSearchEntries } from './orchestration-search'
 import { matchesSettingsSearch } from './settings-search'
 
 const INSTALL_COMMAND =
-  'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+  'npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global'
 const UPDATE_COMMAND = INSTALL_COMMAND
 const WINDOWS_INSTALL_COMMAND =
-  'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1) else (npx skills add https://github.com/stablyai/orca --skill orchestration --global)"'
+  'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1) else (npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global)"'
 
 const mocks = vi.hoisted(() => ({
   dialogProps: [] as Record<string, unknown>[],

--- a/src/renderer/src/components/settings/TaskSourceLinearSetup.test.tsx
+++ b/src/renderer/src/components/settings/TaskSourceLinearSetup.test.tsx
@@ -27,7 +27,7 @@ vi.mock('./CliSkillRuntimeSetup', () => ({
 
 vi.mock('@/lib/linear-agent-skill-update-command', () => ({
   getLinearAgentSkillUpdateTarget: () => ({
-    command: 'npx skills update orca-linear --global',
+    command: 'npx skills@latest update orca-linear --global',
     skillName: 'orca-linear'
   })
 }))

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -116,7 +116,7 @@ describe('LinearAgentSkillInstallCta', () => {
       'Full guided setup (connect + skill + visibility) is under Settings → Task Sources.'
     )
     expect(rendered.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-linear --global'
     )
   })
 
@@ -130,7 +130,7 @@ describe('LinearAgentSkillInstallCta', () => {
     })
 
     expect(mocks.clipboardWrite).toHaveBeenCalledWith(
-      'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-linear --global'
     )
     expect(mocks.toastSuccess).toHaveBeenCalled()
   })
@@ -143,7 +143,7 @@ describe('LinearAgentSkillInstallCta', () => {
 
     expect(rendered.textContent).toContain('Installed')
     expect(rendered.textContent).toContain('Agent skill installed. To update it, run:')
-    expect(rendered.textContent).toContain('npx skills update orca-linear --global')
+    expect(rendered.textContent).toContain('npx skills@latest update orca-linear --global')
     expect(rendered.textContent).not.toContain('Not installed')
   })
 
@@ -159,7 +159,7 @@ describe('LinearAgentSkillInstallCta', () => {
 
     const rendered = await renderCta()
 
-    expect(rendered.textContent).toContain('npx skills update linear-tickets --global')
+    expect(rendered.textContent).toContain('npx skills@latest update linear-tickets --global')
   })
 
   it('notes that remote agent environments need their own setup', async () => {

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -341,10 +341,10 @@ describe('LinearAgentSkillSetupPrompt', () => {
     })
     await settleRender()
 
-    expect(document.body.textContent).toContain('npx skills add')
+    expect(document.body.textContent).toContain('npx skills@latest add')
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
-        installedCommand: 'npx skills update orca-linear --global',
+        installedCommand: 'npx skills@latest update orca-linear --global',
         terminalShellOverride: 'powershell.exe',
         terminalRuntime: expect.objectContaining({ runtime: 'wsl', wslDistro: 'Fedora' }),
         getPrerequisiteStatus: expect.any(Function)
@@ -889,7 +889,7 @@ describe('LinearAgentSkillSetupPrompt', () => {
         ?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
     await settleRender()
-    expect(mocks.panelProps.at(-1)?.command).toContain('npx skills add')
+    expect(mocks.panelProps.at(-1)?.command).toContain('npx skills@latest add')
     expect(mocks.panelProps.at(-1)?.terminalRuntime).toEqual(
       expect.objectContaining({ runtime: 'wsl', wslDistro: 'Ubuntu' })
     )

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx
@@ -156,7 +156,7 @@ describe('LinearAgentSkillSetupPrompt update command', () => {
     await renderPrompt()
 
     expect(mocks.panelProps.at(-1)).toEqual(
-      expect.objectContaining({ installedCommand: 'npx skills update orca-linear --global' })
+      expect.objectContaining({ installedCommand: 'npx skills@latest update orca-linear --global' })
     )
   })
 
@@ -166,7 +166,9 @@ describe('LinearAgentSkillSetupPrompt update command', () => {
     await renderPrompt()
 
     expect(mocks.panelProps.at(-1)).toEqual(
-      expect.objectContaining({ installedCommand: 'npx skills update linear-tickets --global' })
+      expect.objectContaining({
+        installedCommand: 'npx skills@latest update linear-tickets --global'
+      })
     )
   })
 
@@ -176,7 +178,7 @@ describe('LinearAgentSkillSetupPrompt update command', () => {
     await renderPrompt()
 
     expect(mocks.panelProps.at(-1)).toEqual(
-      expect.objectContaining({ installedCommand: 'npx skills update orca-linear --global' })
+      expect.objectContaining({ installedCommand: 'npx skills@latest update orca-linear --global' })
     )
   })
 })

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.test.tsx
@@ -533,7 +533,7 @@ describe('SkillFreshnessUpdateDialog', () => {
     await openViaRequest()
 
     expect(container?.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global'
     )
   })
 
@@ -564,7 +564,7 @@ describe('SkillFreshnessUpdateDialog', () => {
 
     const row = container?.querySelector('[data-skill-row="orchestration"]')
     expect(row?.textContent).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global'
     )
     expect(row?.textContent).not.toContain('This is a project skill, not a global one')
     // Still listed, though — ownership silences the explanation, never the location.

--- a/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-skipped-reason.test.ts
@@ -40,7 +40,7 @@ describe('skippedReason', () => {
     const reason = skippedReason([row(null)], 'orchestration')
     expect(reason).toContain('reports the skill as already up to date')
     expect(reason).toContain(
-      'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orchestration --global'
     )
   })
 
@@ -63,7 +63,7 @@ describe('skippedReason', () => {
     // skip swapped the one runnable command for advice about a copy Orca never judged.
     const reason = skippedReason([row(null), projectRow()], 'orchestration')
     expect(reason).toContain('reports the skill as already up to date')
-    expect(reason).toContain('skills add')
+    expect(reason).toContain('skills@latest add')
     expect(reason).not.toContain('This is a project skill')
   })
 

--- a/src/shared/agent-feature-install-commands.test.ts
+++ b/src/shared/agent-feature-install-commands.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { buildTargetedSkillUpdateCommand } from './skill-freshness'
 import {
+  SKILLS_CLI_PACKAGE_SPEC,
   buildAgentFeatureSkillInstallArgs,
   buildAgentFeatureSkillInstallCommand,
   ORCA_CLI_SKILL_INSTALL_COMMAND,
@@ -17,22 +19,41 @@ import {
 describe('agent feature skill commands', () => {
   it('builds a global install command by default', () => {
     expect(buildAgentFeatureSkillInstallCommand(['orca-cli'])).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --global'
     )
   })
 
   it('drops --global when installing locally', () => {
     expect(buildAgentFeatureSkillInstallCommand(['orca-cli'], { global: false })).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli'
+    )
+  })
+
+  // Regression (#18687): a bare name lets npx run any `skills` executable on PATH
+  // before it will fetch from the registry, so every generated command must carry
+  // a version spec.
+  it('always pins a version spec so npx cannot resolve a PATH collision', () => {
+    expect(SKILLS_CLI_PACKAGE_SPEC).toMatch(/^skills@\S+$/)
+    for (const args of [
+      buildAgentFeatureSkillInstallArgs(['orca-cli']),
+      buildAgentFeatureSkillInstallArgs(['orca-cli'], { global: false }),
+      buildAgentFeatureSkillUpdateArgs(['orca-cli']),
+      buildAgentFeatureSkillUpdateArgs('orca-cli', { global: false })
+    ]) {
+      expect(args[0]).toBe(SKILLS_CLI_PACKAGE_SPEC)
+      expect(args[0]).not.toBe('skills')
+    }
+    expect(buildTargetedSkillUpdateCommand(['orca-cli'])).toContain(
+      `npx ${SKILLS_CLI_PACKAGE_SPEC} update`
     )
   })
 
   it('repeats --skill per name for multi-skill installs', () => {
     expect(buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --skill orchestration --global'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --skill orchestration --global'
     )
     expect(buildAgentFeatureSkillInstallArgs(['orca-cli', 'orchestration'])).toEqual([
-      'skills',
+      SKILLS_CLI_PACKAGE_SPEC,
       'add',
       'https://github.com/stablyai/orca',
       '--skill',
@@ -76,10 +97,10 @@ describe('agent feature skill commands', () => {
     expect(
       buildAgentFeatureSkillInstallCommand(['orca-cli'], { yes: true, agents: ['universal'] })
     ).toBe(
-      'npx skills add https://github.com/stablyai/orca --skill orca-cli --global --agent universal -y'
+      'npx skills@latest add https://github.com/stablyai/orca --skill orca-cli --global --agent universal -y'
     )
     expect(buildAgentFeatureSkillUpdateCommand(['orca-cli'], { global: false, yes: true })).toBe(
-      'npx skills update orca-cli --project -y'
+      'npx skills@latest update orca-cli --project -y'
     )
     expect(
       buildAgentFeatureSkillInstallArgs(['orca-cli'], { yes: true, agents: ['universal'] }).at(-1)
@@ -89,26 +110,26 @@ describe('agent feature skill commands', () => {
 
   it('builds single-skill update commands', () => {
     expect(buildAgentFeatureSkillUpdateCommand('orchestration')).toBe(
-      'npx skills update orchestration --global'
+      'npx skills@latest update orchestration --global'
     )
   })
 
   it('trims and rejects blank update skill names', () => {
     expect(buildAgentFeatureSkillUpdateCommand('  orca-cli  ')).toBe(
-      'npx skills update orca-cli --global'
+      'npx skills@latest update orca-cli --global'
     )
     expect(() => buildAgentFeatureSkillUpdateCommand('   ')).toThrow('A skill name is required.')
   })
 
   it('builds multi-skill update commands and selects project scope for --local', () => {
     expect(buildAgentFeatureSkillUpdateCommand(['orca-cli', 'orchestration'])).toBe(
-      'npx skills update orca-cli orchestration --global'
+      'npx skills@latest update orca-cli orchestration --global'
     )
     expect(buildAgentFeatureSkillUpdateCommand(['orca-cli'], { global: false })).toBe(
-      'npx skills update orca-cli --project'
+      'npx skills@latest update orca-cli --project'
     )
     expect(buildAgentFeatureSkillUpdateArgs(['orca-cli'], { global: false })).toEqual([
-      'skills',
+      SKILLS_CLI_PACKAGE_SPEC,
       'update',
       'orca-cli',
       '--project'
@@ -117,14 +138,18 @@ describe('agent feature skill commands', () => {
   })
 
   it('exports single-skill update constants without changing install bundles', () => {
-    expect(ORCA_CLI_SKILL_UPDATE_COMMAND).toBe('npx skills update orca-cli --global')
-    expect(COMPUTER_USE_SKILL_UPDATE_COMMAND).toBe('npx skills update computer-use --global')
-    expect(ORCHESTRATION_SKILL_UPDATE_COMMAND).toBe('npx skills update orchestration --global')
-    expect(EPHEMERAL_VMS_SKILL_UPDATE_COMMAND).toBe(
-      'npx skills update orca-per-workspace-env --global'
+    expect(ORCA_CLI_SKILL_UPDATE_COMMAND).toBe('npx skills@latest update orca-cli --global')
+    expect(COMPUTER_USE_SKILL_UPDATE_COMMAND).toBe('npx skills@latest update computer-use --global')
+    expect(ORCHESTRATION_SKILL_UPDATE_COMMAND).toBe(
+      'npx skills@latest update orchestration --global'
     )
-    expect(ORCA_LINEAR_SKILL_UPDATE_COMMAND).toBe('npx skills update orca-linear --global')
-    expect(LINEAR_TICKETS_SKILL_UPDATE_COMMAND).toBe('npx skills update linear-tickets --global')
+    expect(EPHEMERAL_VMS_SKILL_UPDATE_COMMAND).toBe(
+      'npx skills@latest update orca-per-workspace-env --global'
+    )
+    expect(ORCA_LINEAR_SKILL_UPDATE_COMMAND).toBe('npx skills@latest update orca-linear --global')
+    expect(LINEAR_TICKETS_SKILL_UPDATE_COMMAND).toBe(
+      'npx skills@latest update linear-tickets --global'
+    )
     expect(ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND).toBe(
       buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
     )

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -2,6 +2,12 @@ import { isSkillsCliAgentKeyShaped } from './skills-cli-agent-keys'
 
 export const ORCA_SKILLS_REPOSITORY_URL = 'https://github.com/stablyai/orca'
 
+// Why the version spec: `npx skills` resolves a bare name from node_modules/.bin
+// and then PATH before it will fetch from the registry, so any unrelated
+// executable named `skills` on the host silently receives these arguments
+// (#18687). Only a spec makes npx treat the argument as a package to fetch.
+export const SKILLS_CLI_PACKAGE_SPEC = 'skills@latest'
+
 export const ORCA_CLI_SKILL_NAME = 'orca-cli'
 export const COMPUTER_USE_SKILL_NAME = 'computer-use'
 export const ORCHESTRATION_SKILL_NAME = 'orchestration'
@@ -42,7 +48,7 @@ export function buildAgentFeatureSkillInstallArgs(
   // Why: one flag per name remains compatible with both single-value and variadic parsers.
   const skillArgs = skillNames.flatMap((name) => ['--skill', name])
   return [
-    'skills',
+    SKILLS_CLI_PACKAGE_SPEC,
     'add',
     ORCA_SKILLS_REPOSITORY_URL,
     ...skillArgs,
@@ -75,7 +81,7 @@ export function buildAgentFeatureSkillUpdateArgs(
   }
   const global = options.global ?? true
   return [
-    'skills',
+    SKILLS_CLI_PACKAGE_SPEC,
     'update',
     ...names,
     global ? '--global' : '--project',

--- a/src/shared/skill-freshness.ts
+++ b/src/shared/skill-freshness.ts
@@ -1,3 +1,4 @@
+import { SKILLS_CLI_PACKAGE_SPEC } from './agent-feature-install-commands'
 import type { SkillProvider, SkillSourceKind } from './skills'
 
 export type SkillBundleFileIdentity = {
@@ -216,7 +217,9 @@ export function canonicalizeSkillUpdateNames(names: readonly string[]): string[]
 
 export function buildTargetedSkillUpdateCommand(names: readonly string[]): string | null {
   const canonicalNames = canonicalizeSkillUpdateNames(names)
-  return canonicalNames ? `npx skills update ${canonicalNames.join(' ')} --global` : null
+  return canonicalNames
+    ? `npx ${SKILLS_CLI_PACKAGE_SPEC} update ${canonicalNames.join(' ')} --global`
+    : null
 }
 
 // Why: `skills update` has no --json (that flag only exists on `list`), so the


### PR DESCRIPTION
## ELI5

Orca installs skills by running `npx --yes skills add …`. `npx` looks for a program called `skills` on your `PATH` first, and only fetches from the npm registry if it does not find one. So on a machine that has some *other* program named `skills`, Orca was politely handing its arguments to a stranger. The error looked like Orca passing a bad flag. Adding a version to the name (`skills@latest`) makes `npx` fetch the package we actually mean.

## What Changed

New `SKILLS_CLI_PACKAGE_SPEC = 'skills@latest'` in `src/shared/agent-feature-install-commands.ts`, used as the package argument by every path that builds the command:

- `buildAgentFeatureSkillInstallArgs` / `buildAgentFeatureSkillUpdateArgs` — the shared builders behind Settings, onboarding, and `orca skills install|update`.
- `buildTargetedSkillUpdateCommand` (`src/shared/skill-freshness.ts`) — the terminal-fallback command.
- `SkillUpdateRunner` (`src/main/skills/skill-update-run.ts`) — the headless update spawn.

Two regexes in `CliSkillRuntimeSetup.tsx` re-parse a command Orca generated, so they now accept the spec (`skills(?:@\S+)?`). The CLI help text for `orca skills install|update` and the runnable commands in the CLI docs are pinned to match what Orca now runs.

The rest of the diff is test expectations: these commands are asserted as literal strings in a lot of places.

## Why

`--yes` is often misread as "always fetch". It only suppresses the install prompt. For a bare name, `npx` checks `node_modules/.bin` and then `PATH` and executes any match without consulting the registry. Only a version or tag spec makes `npx` treat the argument as a package to fetch.

The reporter's host had Headlong's `skills` binary at `~/.local/bin/skills`, with `~/.local/bin` third on `PATH`:

```
bare npx  -> skills 0.1.0     # the wrong program
pinned    -> 1.5.23           # npx --yes skills@latest --version
```

and the resulting failure reads like an Orca bug:

```
$ orca skills update --skill orchestration
Running: npx --yes skills update orchestration --global -y
skills: error: Unknown option: --global (try skills --help)
```

Removing the colliding binary is not always available as a workaround — in that case Headlong invokes bare `skills prompt` at every agent wake, so it legitimately needs that name on `PATH`.

More broadly: a control plane that runs `npx <bare-name>` on hosts it orchestrates is trusting an unowned name in a global namespace. That is worth closing on its own, separately from this particular collision.

`skills@latest` rather than the `-p skills@latest skills …` form the issue also offered: the npm package publishes `bin: { skills, add-skill }`, so a bin matches the package name and `npx skills@latest` resolves it unambiguously. The `-p` form adds two tokens to a command that also has to survive `cmd.exe` wrapping and the WSL login-shell path, for no additional guarantee here.

Distinct from #13807, which is about resolving the **`npx` binary** to a dead version-manager shim. This one is `npx` running correctly and then resolving the **package name** to the wrong program.

## Linked Issue

Fixes #18687

## Visual Proof

`N/A` — no UI layout or styling change. The only user-visible difference is the command text shown in Settings / `--dry-run` output, which now reads `npx skills@latest add …`. The behavior is a command-construction change, pinned by tests:

| | before | after |
|---|---|---|
| generated install | `npx --yes skills add …` | `npx --yes skills@latest add …` |
| host with a colliding `skills` on PATH | runs that program | runs the npm package |
| host without one | runs the npm package | unchanged |

## Testing

New regression test in `src/shared/agent-feature-install-commands.test.ts` — `always pins a version spec so npx cannot resolve a PATH collision` — asserts the spec is shaped `skills@<something>` and that the first argument of every generated arg list is that spec and *not* the bare `skills`, across install/update and both scopes, plus the terminal-fallback command. It fails if any future builder reverts to a bare name.

Existing tests that assert the literal command were updated rather than loosened, so the exact string a user sees stays pinned. Two array-form expectations now reference `SKILLS_CLI_PACKAGE_SPEC` directly so they cannot drift from the source.

Ran on macOS: `src/shared/`, `src/cli/`, `src/main/skills/`, `src/main/telemetry/`, and the renderer settings / skills / onboarding / sidebar suites — 1353 files, 12,772 tests, all passing, plus `pnpm tc` and `pnpm run check:code-quality:changed`. CI covers the full `pnpm test` and `pnpm build`.

Also confirmed the package identity directly rather than assuming it: `npm view skills` reports `1.5.23`, `bin = { skills, add-skill }`, `repository git+https://github.com/vercel-labs/skills.git`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The call sites were traced from the shared builder outward; the fix, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** the spec is one more argv token, so the Windows `getSpawnArgsForWindows` / `cmd.exe` rail and the WSL login-shell path carry it unchanged; both have tests that now assert the pinned form. `@` is not special to `cmd.exe` argument parsing and the token is never free text.
- **Remote / SSH:** the same generated command is what a remote/WSL setup terminal runs, so remote hosts get the same protection. No RPC params, stream frames, or published content change — no wire-compatibility surface.
- **Mobile:** not affected.
- **Performance:** `@latest` makes `npx` re-check the registry rather than reuse a globally installed binary. See Notes — this is the real trade and it is deliberate.
- **Security:** this is the point of the change. It removes an unowned global name from Orca's trusted execution path on every host it orchestrates.
- **Backwards compatibility:** no persisted state, settings, or schema changes. Commands users have already copied still work; they are simply still exposed to the collision.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

**The trade, stated plainly.** `@latest` costs an npm registry check that a bare name could sometimes skip by reusing an already-installed `skills` on `PATH` — which is exactly the resolution this PR is removing, so the two cannot be had at once. `npx` still caches, so the cost is a metadata check rather than a re-download, but a fully offline host that previously succeeded via a globally installed `skills` will now fail. An exact pin (`skills@1.5.23`) would be cacheable and fully deterministic at the cost of freezing users on a version Orca has to bump; `@latest` matches what the reporter proposed and verified. Happy to switch to an exact pin with a renovate-style bump if maintainers prefer that.

**Not in this PR** — the two follow-ons the issue raises, both worth their own change:

- Verify the CLI that actually executed is the expected one (parse `--version`) and report the resolved path when it is not, so a future collision names itself instead of surfacing as `Unknown option: --global`.
- `orca skills update <name>` on a skill present in an agent home but absent from the CLI's registry reports `No installed skills found matching: <name>` with no hint that `orca skills install` is the fix.

Prose and search-keyword mentions of `npx skills add` in the docs were left as-is; only runnable commands were pinned.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
