### PR TITLE
feat(editor): add bindable copy-path commands for the active file

### DIFF
--- a/src/renderer/src/components/editor/editor-shortcuts.test.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/store', () => ({
 
 import {
   installEditorAddReviewNoteShortcut,
+  installEditorCopyPathShortcuts,
   installEditorFindShortcut,
   installMonacoDiffChangeNavigationShortcut,
   installMonacoEditorFindShortcut,
@@ -394,5 +395,111 @@ describe('installMonacoDiffChangeNavigationShortcut', () => {
     expect(disposedEvent.defaultPrevented).toBe(false)
     expect(fixture.goToDiff).toHaveBeenCalledTimes(1)
     expect(fixture.goToDiff).toHaveBeenCalledWith('next')
+  })
+})
+
+describe('installEditorCopyPathShortcuts', () => {
+  function createCopyPathFixture(paths = { filePath: '/repo/src/a.ts', relativePath: 'src/a.ts' }) {
+    const container = document.createElement('div')
+    const input = document.createElement('textarea')
+    const current = { paths }
+    container.appendChild(input)
+    document.body.appendChild(container)
+    const writeClipboardText = vi.fn()
+    vi.stubGlobal('window', { ...window, api: { ui: { writeClipboardText } } })
+    return {
+      input,
+      current,
+      writeClipboardText,
+      dispose: installEditorCopyPathShortcuts(container, () => current.paths)
+    }
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('copies the relative path on the default binding', () => {
+    const fixture = createCopyPathFixture()
+
+    const event = dispatchKeyDown(fixture.input, {
+      key: 'c',
+      code: 'KeyC',
+      metaKey: true,
+      altKey: true,
+      shiftKey: true
+    })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(fixture.writeClipboardText).toHaveBeenCalledWith('src/a.ts')
+    fixture.dispose()
+  })
+
+  it('ships the absolute-path action unbound so it cannot steal editor.copyContext', () => {
+    const fixture = createCopyPathFixture()
+
+    // Mod+Alt+C is editor.copyContext's default; this action must not answer it.
+    const event = dispatchKeyDown(fixture.input, {
+      key: 'c',
+      code: 'KeyC',
+      metaKey: true,
+      altKey: true
+    })
+
+    expect(event.defaultPrevented).toBe(false)
+    expect(fixture.writeClipboardText).not.toHaveBeenCalled()
+    fixture.dispose()
+  })
+
+  it('copies the absolute path once a user binds it', () => {
+    shortcutState.keybindings = { 'editor.copyPath': ['Mod+Alt+P'] }
+    const fixture = createCopyPathFixture()
+
+    const event = dispatchKeyDown(fixture.input, {
+      key: 'p',
+      code: 'KeyP',
+      metaKey: true,
+      altKey: true
+    })
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(fixture.writeClipboardText).toHaveBeenCalledWith('/repo/src/a.ts')
+    fixture.dispose()
+  })
+
+  it('reads the paths at press time so a switched tab copies its own file', () => {
+    const fixture = createCopyPathFixture()
+    fixture.current.paths = { filePath: '/repo/src/b.ts', relativePath: 'src/b.ts' }
+
+    dispatchKeyDown(fixture.input, {
+      key: 'c',
+      code: 'KeyC',
+      metaKey: true,
+      altKey: true,
+      shiftKey: true
+    })
+
+    expect(fixture.writeClipboardText).toHaveBeenCalledWith('src/b.ts')
+    fixture.dispose()
+  })
+
+  it('consumes matched repeats without copying again, and stops after dispose', () => {
+    const fixture = createCopyPathFixture()
+    const chord = {
+      key: 'c',
+      code: 'KeyC',
+      metaKey: true,
+      altKey: true,
+      shiftKey: true
+    }
+
+    dispatchKeyDown(fixture.input, chord)
+    const repeat = dispatchKeyDown(fixture.input, { ...chord, repeat: true })
+    fixture.dispose()
+    const afterDispose = dispatchKeyDown(fixture.input, chord)
+
+    expect(repeat.defaultPrevented).toBe(true)
+    expect(afterDispose.defaultPrevented).toBe(false)
+    expect(fixture.writeClipboardText).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/editor/editor-shortcuts.ts
+++ b/src/renderer/src/components/editor/editor-shortcuts.ts
@@ -46,6 +46,42 @@ export function installEditorFindShortcut(target: HTMLElement, onFind: () => voi
   return () => target.removeEventListener('keydown', handleKeyDown, true)
 }
 
+/**
+ * Editor-scoped Copy Path / Copy Relative Path, the same two actions the editor
+ * tab's context menu offers, made bindable so they work without the mouse.
+ *
+ * @param target The editor DOM node the chords are scoped to.
+ * @param getPaths Reads the active file's paths at press time, so the handler
+ * survives the tab switching under it.
+ * @returns A disposer that removes the listener.
+ */
+export function installEditorCopyPathShortcuts(
+  target: HTMLElement,
+  getPaths: () => { filePath: string; relativePath: string }
+): () => void {
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    const relative = editorShortcutMatches('editor.copyRelativePath', event)
+    if (!relative && !editorShortcutMatches('editor.copyPath', event)) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    // Consume matched repeats but copy once per press, like the find shortcut.
+    if (event.repeat) {
+      return
+    }
+    const paths = getPaths()
+    const value = relative ? paths.relativePath : paths.filePath
+    if (!value) {
+      return
+    }
+    void window.api.ui.writeClipboardText(value)
+  }
+
+  target.addEventListener('keydown', handleKeyDown, true)
+  return () => target.removeEventListener('keydown', handleKeyDown, true)
+}
+
 type MonacoDiffNavigationEditor = {
   getContainerDomNode: () => HTMLElement
   goToDiff: (target: 'next' | 'previous') => void

--- a/src/renderer/src/components/editor/monaco-editor-input-bindings.ts
+++ b/src/renderer/src/components/editor/monaco-editor-input-bindings.ts
@@ -7,6 +7,7 @@ import { getMonacoCodebaseSearchQuery } from './monaco-codebase-search'
 import { getDiffCommentPopoverLeft } from '../diff-comments/diff-comment-popover-position'
 import {
   installEditorAddReviewNoteShortcut,
+  installEditorCopyPathShortcuts,
   installEditorSaveShortcut,
   installMonacoEditorFindShortcut
 } from './editor-shortcuts'
@@ -20,6 +21,7 @@ import type { MonacoEditorPropsRef } from './monaco-editor-mount-params'
 
 type MonacoEditorInputBindingsParams = {
   editorInstance: editor.IStandaloneCodeEditor
+  filePath: string
   worktreeId: string | undefined
   editorContainerRef: MutableRefObject<HTMLDivElement | null>
   propsRef: MonacoEditorPropsRef
@@ -34,12 +36,13 @@ type MonacoEditorInputBindingsParams = {
   >
 }
 
-// Why: save/find/review-note chords, the context-menu action, and the large-paste capture share one teardown so onDidDispose keeps their original order.
+// Why: save/find/copy-path/review-note chords, the context-menu action, and the large-paste capture share one teardown so onDidDispose keeps their original order.
 export function installMonacoEditorInputBindings(params: MonacoEditorInputBindingsParams): {
   disposeInputBindings: () => void
 } {
   const {
     editorInstance,
+    filePath,
     worktreeId,
     editorContainerRef,
     propsRef,
@@ -58,6 +61,10 @@ export function installMonacoEditorInputBindings(params: MonacoEditorInputBindin
     propsRef.current.onSave(value)
   })
   const cleanupFindShortcut = installMonacoEditorFindShortcut(editorInstance)
+  const cleanupCopyPathShortcuts = installEditorCopyPathShortcuts(editorDomNode, () => ({
+    filePath,
+    relativePath: propsRef.current.relativePath
+  }))
   // Opens the same composer as the selection "+" button.
   const cleanupAddReviewNoteShortcut = installEditorAddReviewNoteShortcut(editorDomNode, () => {
     // Why: keep an open draft instead of remounting, to avoid same-tick chord races before the composer guard runs.
@@ -132,6 +139,7 @@ export function installMonacoEditorInputBindings(params: MonacoEditorInputBindin
     disposeInputBindings: () => {
       cleanupSaveShortcut()
       cleanupFindShortcut()
+      cleanupCopyPathShortcuts()
       cleanupAddReviewNoteShortcut()
       editorDomNode.removeEventListener('paste', onLargeTextPaste, { capture: true })
       searchInFilesAction.dispose()

--- a/src/renderer/src/components/editor/use-monaco-editor-mount.ts
+++ b/src/renderer/src/components/editor/use-monaco-editor-mount.ts
@@ -131,6 +131,7 @@ export function useMonacoEditorMount(params: MonacoEditorMountParams): OnMount {
 
       const { disposeInputBindings } = installMonacoEditorInputBindings({
         editorInstance,
+        filePath,
         worktreeId,
         editorContainerRef,
         propsRef,

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -105,6 +105,8 @@ export function EditorFileTabContextMenu({
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
   const closeShortcut = useOptionalShortcutLabel('tab.close')
   const closeAllShortcut = useOptionalShortcutLabel('tab.closeAll')
+  const copyPathShortcut = useOptionalShortcutLabel('editor.copyPath')
+  const copyRelativePathShortcut = useOptionalShortcutLabel('editor.copyRelativePath')
 
   return (
     <DropdownMenu open={open} onOpenChange={onOpenChange} modal={false}>
@@ -220,6 +222,9 @@ export function EditorFileTabContextMenu({
         >
           <Copy className="size-3.5" />
           {translate('auto.components.tab.bar.EditorFileTabContextMenu.5b85754786', 'Copy Path')}
+          {copyPathShortcut ? (
+            <DropdownMenuShortcut>{copyPathShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuItem
           onSelect={() => {
@@ -231,6 +236,9 @@ export function EditorFileTabContextMenu({
             'auto.components.tab.bar.EditorFileTabContextMenu.52ce4f4605',
             'Copy Relative Path'
           )}
+          {copyRelativePathShortcut ? (
+            <DropdownMenuShortcut>{copyRelativePathShortcut}</DropdownMenuShortcut>
+          ) : null}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/src/shared/keybindings/definitions-core-4.ts
+++ b/src/shared/keybindings/definitions-core-4.ts
@@ -3,6 +3,25 @@ import { platformBindings } from './definitions-support'
 
 export const KEYBINDING_DEFINITION_CORE_4: readonly KeybindingDefinition[] = [
   {
+    id: 'editor.copyPath',
+    title: 'Copy file path',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: ['shortcut', 'editor', 'copy', 'path', 'absolute'],
+    // Why unbound: Mod+Alt+C already belongs to editor.copyContext in this scope,
+    // and every near neighbour is either taken or AltGr text input off macOS.
+    defaultBindings: { darwin: [], linux: [], win32: [] }
+  },
+  {
+    id: 'editor.copyRelativePath',
+    title: 'Copy relative file path',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: ['shortcut', 'editor', 'copy', 'relative', 'path'],
+    // Matches fileExplorer.copyRelativePath; the scopes never both hold focus.
+    defaultBindings: platformBindings(['Mod+Alt+Shift+C'])
+  },
+  {
     id: 'terminal.clearPaneTitle',
     title: 'Clear Pane Title',
     group: 'Terminal Panes',

--- a/src/shared/keybindings/types.ts
+++ b/src/shared/keybindings/types.ts
@@ -97,6 +97,8 @@ export type KeybindingActionId =
   | 'fileExplorer.redo'
   | 'fileExplorer.copyPath'
   | 'fileExplorer.copyRelativePath'
+  | 'editor.copyPath'
+  | 'editor.copyRelativePath'
   | 'fileExplorer.delete'
   | 'settings.search'
   | 'terminal.copySelection'


### PR DESCRIPTION
## ELI5

Orca can already copy a file's path with a keyboard shortcut — but only while the file *explorer* has focus, because the shortcut handler lives inside the explorer's own key listener. If you are typing in the editor, the only way to get the open file's path is to right-click its tab. This adds two editor-scoped commands so the same copy works from the editor, and so users can bind them however they like.

## What Changed

- **`src/shared/keybindings/types.ts` + `definitions-core-4.ts`** — two new action ids:
  - `editor.copyRelativePath` — default `Mod+Alt+Shift+C`, matching `fileExplorer.copyRelativePath`.
  - `editor.copyPath` — ships **unbound**.
- **`editor-shortcuts.ts`** — `installEditorCopyPathShortcuts(target, getPaths)`, following the `(target, callback) => disposer` shape the other installers in that file already use.
- **`monaco-editor-input-bindings.ts` / `use-monaco-editor-mount.ts`** — wires it into the shared editor teardown, threading `filePath` through alongside the `relativePath` already on `propsRef`.
- **`EditorFileTabContextMenu.tsx`** — the existing Copy Path / Copy Relative Path items now display whatever the actions are bound to, the way Rename and Close already do.

## Why

Copying a path is a constant action in Orca — pasting `@path` into an agent prompt, naming a file in a terminal, pointing at a location in a review — and reaching for the mouse each time adds up. The clipboard write already exists in the tab context menu; the only thing missing was a bindable command id, and custom keybindings can only rebind ids that exist, so users could not work around it themselves.

**Why `editor.copyPath` ships unbound.** `Mod+Alt+C` is already `editor.copyContext` in this same scope, so it cannot be the default. Every near neighbour is worse: on Windows and Linux `Ctrl+Alt+<letter>` *is* AltGr text input, which is why `editor.addReviewNote` carries a comment about not reserving characters like Polish `ń`, and why `fileExplorer.copyPath` uses `Alt+Shift+C` off macOS rather than mirroring its own macOS binding. Rather than pick a chord that is wrong on two platforms, the action ships unbound and appears in Settings → Keyboard Shortcuts for anyone who wants it — the pattern `terminal.equalizePaneSizes` and `terminal.setTitle` already use. The relative path, which the issue calls "the important one", does get a default.

**Why `Mod+Alt+Shift+C` is safe for the relative path.** It is `fileExplorer.copyRelativePath`'s binding, but the two actions are in different scopes and their handlers each gate on their own surface having focus, so both can hold the same chord without conflicting — which is what the issue predicted.

**Why paths are read at press time.** `getPaths` is a callback rather than a captured value, so if the active file changes under a mounted editor the shortcut copies the file that is actually open. A captured value would copy a stale path — a silent, wrong-looking result.

## Linked Issue

Fixes #18785

## Visual Proof

`N/A` for the shortcut itself — copying to the clipboard has no visual state. There is one small visible change, in the editor tab's right-click menu, where the two existing items now carry a shortcut hint:

| menu item | before | after |
|---|---|---|
| Copy Path | *(no hint)* | *(no hint until the user binds it)* |
| Copy Relative Path | *(no hint)* | `⌥⇧⌘C` on macOS, `Ctrl+Alt+Shift+C` elsewhere |

This reuses `DropdownMenuShortcut` and `useOptionalShortcutLabel` exactly as the Rename / Close / Close All items in that same menu already do, so there is no new styling to review — and `useOptionalShortcutLabel` returns nothing for an unbound action, which is why Copy Path stays bare until bound.

## Testing

Five new cases in `src/renderer/src/components/editor/editor-shortcuts.test.ts`, using the file's existing fixture style:

- `copies the relative path on the default binding` — `Mod+Alt+Shift+C` writes `src/a.ts` and consumes the event.
- `ships the absolute-path action unbound so it cannot steal editor.copyContext` — `Mod+Alt+C` is **not** consumed and copies nothing. This is the regression that would matter most: a default here would silently break Copy Context.
- `copies the absolute path once a user binds it` — with `{'editor.copyPath': ['Mod+Alt+P']}` in the store, the chord copies `/repo/src/a.ts`.
- `reads the paths at press time so a switched tab copies its own file` — mutating the source between install and keypress copies the new file.
- `consumes matched repeats without copying again, and stops after dispose` — held-key and teardown behavior, matching what the find and diff-nav shortcuts already assert.

Ran on macOS: the keybinding suites (`unassigned-actions`, `conflicts`, `default-bindings`) plus the editor and tab-bar suites — 1,885 tests passing — with `pnpm tc`, `pnpm run check:code-quality:changed`, `check:max-lines-ratchet`, `check:reliability-gates`, and the localization gates all clean. CI covers the full `pnpm test` and `pnpm build`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The existing explorer handler, tab menu, and installer patterns were read first so this follows them rather than inventing a parallel path; the change, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** the default binding goes through `platformBindings`, and matching goes through `keybindingMatchesAction`, so `Mod` resolves per platform — no `metaKey` is hardcoded. The AltGr hazard on Windows/Linux is the explicit reason `editor.copyPath` ships unbound. The tab-menu label is rendered by `useOptionalShortcutLabel`, which already formats `⌘`/`Ctrl+` per platform.
- **Remote / SSH:** none. This copies strings the editor already holds to the local clipboard; no IPC beyond the existing `window.api.ui.writeClipboardText`, no RPC params, no stream frames, nothing a client and host exchange. For a file opened on a remote host, `filePath` is that host's path — the same value the tab menu already copies.
- **Mobile:** not affected.
- **Backwards compatibility:** additive. Existing `~/.orca/keybindings.json` files keep working; two new ids simply become bindable. No persisted state or schema change.
- **Performance:** one capture-phase keydown listener per mounted editor, disposed with the rest of that editor's bindings, which returns immediately on any non-matching key.
- **Security:** no new input surface. The clipboard write is the same call the tab menu makes on the same values.
- **Folder workspaces:** `relativePath` comes from the open file, so folder workspaces behave exactly as git worktrees do — nothing here assumes a worktree.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

`definitions-core-3.ts` was one line under the 300-line `max-lines` cap, so adding two definitions there would have broken the lint gate. Per AGENTS.md ("NEVER add a max-lines disable"), the two entries went into `definitions-core-4.ts` instead — same exported list, no suppression, and `check:max-lines-ratchet` stays clean.

Happy to give `editor.copyPath` a default if maintainers have a chord in mind that is safe on all three platforms; I did not want to spend one speculatively.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
