### PR TITLE
Reduce minimum tab width from 88px to 72px

### DIFF
--- a/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
+++ b/src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx
@@ -188,10 +188,10 @@ function expectTabContainerWidth(markup: string, root: string): void {
   const container = firstOpeningTag(markup)
   // Why: pinned literally — a definite `w-*` is what stops live title updates from resizing
   // every tab, so asserting against the constant would let that guarantee be edited away.
-  const widthClasses = 'w-[180px] min-w-[88px] min-[1280px]:w-[220px]'
+  const widthClasses = 'w-[180px] min-w-[72px] min-[1280px]:w-[220px]'
   expect(container).toContain(widthClasses)
   expect(root).not.toContain('w-[180px]')
-  expect(root).not.toContain('min-w-[88px]')
+  expect(root).not.toContain('min-w-[72px]')
   expect(root).not.toContain('min-[1280px]:w-[220px]')
 }
 

--- a/src/renderer/src/components/tab-bar/tab-width-rules.ts
+++ b/src/renderer/src/components/tab-bar/tab-width-rules.ts
@@ -1,5 +1,5 @@
 // Why: the strip shrink-wraps its tabs, so a content-derived width lets one live title update
 // resize every tab; a definite width pins them and flex-shrink still narrows to the floor.
-export const TAB_CONTAINER_WIDTH_CLASSES = 'w-[180px] min-w-[88px] min-[1280px]:w-[220px]'
+export const TAB_CONTAINER_WIDTH_CLASSES = 'w-[180px] min-w-[72px] min-[1280px]:w-[220px]'
 
 export const TAB_LABEL_WIDTH_CLASSES = 'min-w-0 flex-1 truncate'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## Problem

Tabs currently have an 88px minimum width, which wastes space in narrow layouts like side-by-side editors or terminal panes.

## Solution

Reduce the minimum tab width to 72px, allowing tabs to shrink further and better utilize constrained spaces.

## ELI5

Tabs are now allowed to get smaller, giving more room for content when you have narrow panes.

## What Changed

Updated the minimum width constraint in tab styling from 88px to 72px:
- Modified `TAB_CONTAINER_WIDTH_CLASSES` constant in `src/renderer/src/components/tab-bar/tab-width-rules.ts`
- Updated corresponding test assertions in `src/renderer/src/components/tab-bar/tab-title-tooltip.test.tsx`

## Why

This change improves UX in narrow layouts while maintaining tab readability and usability at the smaller size.

## Linked Issue

Fixes #

## Visual Proof

N/A — This is a CSS constant update with no new visual behavior, verified through existing tab rendering with the new constraint.

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)