### PR TITLE
fix(relay-ops): per-region cell latency bar and attributable preflight failures

### DIFF
--- a/cloud/apps/relay-ops/src/incident-live-preflight-cli.test.ts
+++ b/cloud/apps/relay-ops/src/incident-live-preflight-cli.test.ts
@@ -72,6 +72,7 @@ function sample(): IncidentSample {
     expectedSelector: selector,
     cells: [{
       cellId: 'production-gce-c1',
+      region: 'us-central1',
       runtimeKnown: true,
       powered: true,
       expectedAdmissionState: 'existing-only'
@@ -251,6 +252,30 @@ describe('relay incident live preflight', () => {
       ['--state-file', stateFile()],
       { now: () => now, collect: async () => unhealthy }
     )).rejects.toThrow('cloud-monitoring/threshold_max')
+  })
+
+  // Why: a frozen wave has to name what froze it without re-reading the sample.
+  it('names the signal and its numbers in the failure message', async () => {
+    const slowCell = sample()
+    slowCell.sources['active-probe']!.signals[
+      'cell.production-gce-c1.latency_ms'
+    ]!.value = 2_568
+    await expect(runIncidentLivePreflight(
+      ['--state-file', stateFile()],
+      { now: () => now, collect: async () => slowCell }
+    )).rejects.toThrow(
+      'relay live preflight failed: active-probe/threshold_max cell.production-gce-c1.latency_ms observed=2568 threshold=2000'
+    )
+
+    // A failure with no signal keeps the source/code token and drops the rest.
+    const stale = sample()
+    stale.sources['active-probe']!.observedAt = new Date(now - 60_001).toISOString()
+    await expect(runIncidentLivePreflight(
+      ['--state-file', stateFile()],
+      { now: () => now, collect: async () => stale }
+    )).rejects.toThrow(
+      'relay live preflight failed: active-probe/source_stale observed=60001 threshold=60000'
+    )
   })
 
   it('enforces the signed migration policy', async () => {

--- a/cloud/apps/relay-ops/src/incident-live-preflight-cli.ts
+++ b/cloud/apps/relay-ops/src/incident-live-preflight-cli.ts
@@ -9,6 +9,7 @@ import {
   evaluateIncidentSample,
   FRESHNESS_FAILURE_CODES,
   preDrainDryRunPassed,
+  type IncidentFailure,
   type IncidentSample
 } from './incident-monitor.js'
 import { createIncidentSampleCollector } from './incident-monitor-sources.js'
@@ -68,6 +69,17 @@ const PreflightStateSchema = z.object({
     })
   }
 })
+
+// Keep the source/code prefix other tooling matches on, then name the signal and
+// its numbers so a frozen wave is attributable without re-reading the sample.
+function describeFailure(failure: IncidentFailure): string {
+  const detail = [
+    failure.signal,
+    failure.observed === undefined ? null : `observed=${failure.observed}`,
+    failure.threshold === undefined ? null : `threshold=${failure.threshold}`
+  ].filter((part): part is string => part !== null && part !== undefined)
+  return [`${failure.source}/${failure.code}`, ...detail].join(' ')
+}
 
 export async function runIncidentLivePreflight(
   argv: string[],
@@ -175,7 +187,7 @@ export async function runIncidentLivePreflight(
     if (!freshnessOnly || attempt === attempts || budgetExhausted) {
       throw new Error(
         `relay live preflight failed: ${evaluation.failures
-          .map((failure) => `${failure.source}/${failure.code}`)
+          .map(describeFailure)
         .join(',')}`
       )
     }

--- a/cloud/apps/relay-ops/src/incident-monitor-cli.test.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor-cli.test.ts
@@ -44,6 +44,7 @@ function sample(at: number): IncidentSample {
     expectedSelector: selector,
     cells: [{
       cellId,
+      region: 'us-central1',
       runtimeKnown: true,
       powered: true,
       expectedAdmissionState: 'general'

--- a/cloud/apps/relay-ops/src/incident-monitor-sources.test.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor-sources.test.ts
@@ -317,6 +317,49 @@ describe('incident monitor sources', () => {
     }, endAt)).toBeNull()
   })
 
+  // Why: the per-region cell latency bar is only correct if the tfvars region
+  // reaches the evaluator on every cell expectation.
+  it('carries the configured region onto every cell expectation', async () => {
+    const gcloud: GcloudClient = {
+      accessToken: async () => 'unused',
+      identityToken: async () => 'unused'
+    }
+    const selector = {
+      generation: 1,
+      membership: {
+        existingOnly: [],
+        migrationOnly: [],
+        general: productionCells
+      }
+    }
+    const fetchImpl: typeof fetch = async (_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { cellId?: string; sourceCellId?: string }
+      if (!body.cellId && !body.sourceCellId) return Response.json({ selector })
+      if (body.cellId) {
+        return Response.json({
+          status: {
+            enabled: true,
+            connectionCapacity: { hardCap: 600 },
+            runtime: { lastHeartbeatAt: now - 1_000, heartbeatFresh: true }
+          }
+        })
+      }
+      return Response.json({
+        blocked: 0,
+        blockedExpiredUnregistered: 0,
+        registeredTargetInactive: 0
+      })
+    }
+    const result = await directorSignals('production', selector, gcloud, now, fetchImpl)
+    const regionById = new Map(result.cells.map((cell) => [cell.cellId, cell.region]))
+    expect(regionById.get('production-gce-c1')).toBe('us-central1')
+    expect(regionById.get('production-gce-c27')).toBe('asia-east2')
+    expect(result.cells).toHaveLength(productionCells.length)
+    for (const cell of RELAY_OPS_ENVIRONMENTS.production.cells) {
+      expect(regionById.get(cell.cellId)).toBe(cell.region)
+    }
+  })
+
   it('aggregates admin state without returning tokens or response identities', async () => {
     const identityToken = 'secret.header.signature'
     const sensitiveIdentity = 'user@example.test'

--- a/cloud/apps/relay-ops/src/incident-monitor-sources.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor-sources.ts
@@ -558,6 +558,7 @@ export async function directorSignals(
     selector,
     cells: statuses.map(({ cell }) => ({
       cellId: cell.cellId,
+      region: cell.region,
       runtimeKnown: true,
       powered: true,
       expectedAdmissionState: selectorCellState(expectedSelector, cell.cellId)

--- a/cloud/apps/relay-ops/src/incident-monitor.test.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.test.ts
@@ -33,6 +33,7 @@ function healthySample(at = startedAt): IncidentSample {
     expectedSelector: selector,
     cells: [{
       cellId: 'production-gce-c1',
+      region: 'us-central1',
       runtimeKnown: true,
       powered: true,
       expectedAdmissionState: 'general'
@@ -147,6 +148,52 @@ describe('incident monitor evaluator', () => {
       status: 'freeze',
       failures: [
         expect.objectContaining({ signal: 'relay.postgres_retry_exhausted', threshold: 300 })
+      ]
+    })
+  })
+
+  // Why: an asia-east2 cell's /ready reaches auth and Cloud SQL in us-central1, so
+  // from the US runner it measures p50 0.88 s / max 2.7 s and the flat 2 000 bar
+  // froze three healthy gates on 2026-09-05 (c27 at 2568/2668/2685 ms).
+  it('holds cell endpoint latency to a per-region bar', () => {
+    const asiaTail = healthySample()
+    asiaTail.cells[0]!.region = 'asia-east2'
+    asiaTail.sources['active-probe']!.signals['cell.production-gce-c1.latency_ms'] =
+      signal(2_685)
+    expect(evaluateIncidentSample(asiaTail, startedAt)).toMatchObject({
+      status: 'green',
+      failures: []
+    })
+
+    const asiaIncident = healthySample()
+    asiaIncident.cells[0]!.region = 'asia-east2'
+    asiaIncident.sources['active-probe']!.signals['cell.production-gce-c1.latency_ms'] =
+      signal(4_001)
+    expect(evaluateIncidentSample(asiaIncident, startedAt)).toMatchObject({
+      status: 'freeze',
+      failures: [
+        expect.objectContaining({
+          code: 'threshold_max',
+          source: 'active-probe',
+          signal: 'cell.production-gce-c1.latency_ms',
+          observed: 4_001,
+          threshold: 4_000
+        })
+      ]
+    })
+
+    const usIncident = healthySample()
+    usIncident.sources['active-probe']!.signals['cell.production-gce-c1.latency_ms'] =
+      signal(2_001)
+    expect(evaluateIncidentSample(usIncident, startedAt)).toMatchObject({
+      status: 'freeze',
+      failures: [
+        expect.objectContaining({
+          code: 'threshold_max',
+          signal: 'cell.production-gce-c1.latency_ms',
+          observed: 2_001,
+          threshold: 2_000
+        })
       ]
     })
   })
@@ -401,12 +448,14 @@ describe('incident monitor evaluator', () => {
     ] = signal(0)
     sample.cells.push({
       cellId: 'production-gce-c2',
+      region: 'us-central1',
       runtimeKnown: true,
       powered: true,
       expectedAdmissionState: 'general'
     })
     sample.cells.push({
       cellId: 'production-gce-c3',
+      region: 'us-central1',
       runtimeKnown: true,
       powered: true,
       expectedAdmissionState: 'general'

--- a/cloud/apps/relay-ops/src/incident-monitor.ts
+++ b/cloud/apps/relay-ops/src/incident-monitor.ts
@@ -1,3 +1,4 @@
+import type { RelayOpsRegion } from './environment-config.js'
 import {
   exactAdmissionSelector,
   type AdmissionSelector,
@@ -30,6 +31,15 @@ export const INCIDENT_MONITOR_THRESHOLDS = {
   relayLogMaxAgeMs: 180_000,
   heartbeatMaxAgeMs: 45_000,
   endpointLatencyMs: 2_000,
+  // Why: a cell's /ready fetches the auth JWKS and runs SELECT 1 against Cloud SQL,
+  // both in us-central1, so from the US runner asia-east2 cells measure p50 0.88 s /
+  // max 2.7 s against 0.08-0.5 s for us-central1. The flat 2 000 bar froze three
+  // healthy 15-minute gates on 2026-09-05 (c27 at 2568/2668/2685 ms); hard faults
+  // are still caught by the .health/.ready equal-1 checks and the 8 s fetch timeout.
+  cellEndpointLatencyMs: {
+    'us-central1': 2_000,
+    'asia-east2': 4_000
+  } as const satisfies Record<RelayOpsRegion, number>,
   cloudSqlCpuUtilization: 0.8,
   cloudSqlMemoryUtilization: 0.9,
   // Why: healthy latest-sum backends idle near 100 but spike to 216 in 1-minute
@@ -126,6 +136,7 @@ export type IncidentSource = {
 
 export type IncidentCellExpectation = {
   cellId: string
+  region: RelayOpsRegion
   runtimeKnown: boolean
   powered: boolean
   expectedAdmissionState: AdmissionState
@@ -405,7 +416,7 @@ function checkCell(
       'active-probe',
       probe,
       `cell.${cell.cellId}.latency_ms`,
-      INCIDENT_MONITOR_THRESHOLDS.endpointLatencyMs,
+      INCIDENT_MONITOR_THRESHOLDS.cellEndpointLatencyMs[cell.region],
       'max'
     ],
     [


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## Why

The relay production monitor evaluates one active probe per minute against every cell's `/health` and `/ready`, and freezes the whole 15-minute gate when any cell's `cell.<id>.latency_ms` exceeds `endpointLatencyMs = 2000`. That bar was calibrated for the 16 us-central1 cells.

A cell's `/ready` (`cloud/apps/relay/src/relay-readiness.ts`) fetches the auth JWKS in us-central1 and runs `SELECT 1` against Cloud SQL in us-central1 before answering. Measured from the US GitHub runner on 2026-09-05, the asia-east2 cells sit far above the bar for that reason alone:

| Region | `/ready` p50 | p90 | max |
| --- | --- | --- | --- |
| asia-east2 | 0.88 s | 1.25-2.15 s | 2.7 s |
| us-central1 | 0.08 s | - | 0.5 s |

Three gates froze on this (runs 33987646501, 33988383401, 33988810139), each on `cell.production-gce-c27.latency_ms` at 2568 / 2668 / 2685 ms against 2000. 120 operator probes plus c28 and c29 in general admission showed the same tail, so it is path latency, not cell health.

Hard faults are still caught by the `.health` / `.ready` equal-1 checks and the probe's 8 s fetch timeout. Director and auth latency rules are unchanged at 2000.

## Threshold shape

`IncidentCellExpectation` gains `region: RelayOpsRegion`, populated from the tfvars region already parsed in `environment-config.ts`. The new threshold is a nested map:

```ts
cellEndpointLatencyMs: {
  'us-central1': 2_000,
  'asia-east2': 4_000
} as const satisfies Record<RelayOpsRegion, number>,
```

`satisfies Record<RelayOpsRegion, number>` makes a future region a compile error rather than a silent fallback.

The nested shape is safe because nothing reads the persisted thresholds back. `INCIDENT_MONITOR_THRESHOLDS` is serialized only into `IncidentCheckpoint.thresholds`, which is appended to the summary JSONL and re-read in `incident-monitor-cli.ts` with a bare `JSON.parse(line) as IncidentCheckpoint` that touches only `windowSequence`, `checkpointMinute`, `status`, `sampleCount`, `failures`, `expectedSelector`, `migrationPolicy`, `recoverySourceCellId` and `capacityCellId`. The one zod schema over persisted monitor data (`incident-monitor-cli.ts`, and `PreflightStateSchema`) validates `IncidentMonitorState`, which has no `thresholds` field. No script under `cloud/dev/scripts/` references `endpointLatencyMs` or the thresholds object; `relay-monitor-evidence.mjs` does not read it.

The change is additive: `endpointLatencyMs: 2_000` keeps its name and value and still backs the director rule, the auth rule, and `probeEndpointHealth` in `resource-inventory.ts`. Old artifacts stay readable.

## Attributable preflight failures

`incident-live-preflight-cli.ts` threw `relay live preflight failed: active-probe/threshold_max`, which does not say what froze the wave. The `source/code` token and the comma join are unchanged for tooling that matches on them; the signal name and observed/threshold are appended when present:

```
relay live preflight failed: active-probe/threshold_max cell.production-gce-c27.latency_ms observed=2568 threshold=2000
```

A failure with no signal degrades to `active-probe/source_stale observed=60001 threshold=60000`, and one with neither to `relay-logs/source_missing`.

## Tests

- `incident-monitor.test.ts` pins all three sides of the new bar: an asia-east2 cell at 2685 ms is green, an asia-east2 cell at 4001 ms freezes with `threshold_max` and threshold 4000, and a us-central1 cell at 2001 ms still freezes with threshold 2000. Verified as a real oracle by flipping the asia value to 2000, which fails the test.
- `incident-monitor-sources.test.ts` proves `directorSignals` carries the tfvars region onto every cell expectation, checking c1 as us-central1, c27 as asia-east2, and every production cell against its configured region.
- `incident-live-preflight-cli.test.ts` pins the new message for a threshold failure with a signal and for a stale-source failure without one.

Fixtures in `incident-monitor.test.ts`, `incident-monitor-cli.test.ts` and `incident-live-preflight-cli.test.ts` gained the required `region` field.

## Verification

Run from `cloud/` after `CI=true pnpm install --frozen-lockfile`:

```
pnpm --filter @orca-cloud/relay-ops typecheck   clean
pnpm --filter @orca-cloud/relay-ops test        12 files, 95 tests passed
pnpm test                                       633 passed, 0 failed, 87 skipped
pnpm typecheck / pnpm lint (all 4 workspaces)   clean
```

`pnpm test` from `cloud/` covers relay-contract (20), relay-fence-broker (16), relay-ops (95), relay (502 passed / 87 skipped) plus 529 node dev-script tests and the 148-test pretest batch. `oxlint` on the changed files reports "No files found to lint" because the root `.oxlintrc.json` lists `cloud/**` in `ignorePatterns`, so no `max-lines` budget applies to these files and no disable was added.