### PR TITLE
test(e2e): follow current sidebar project and activity actions

### DIFF
--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -251,6 +251,8 @@ test.describe('Activity Agent Pane Isolation', () => {
         activeLeafId: first.leafId
       })
 
+    // Revealing a workspace returns the sidebar to its workspace list.
+    await agentsSidebarButton(orcaPage).click()
     await orcaPage.getByRole('button').filter({ hasText: second.prompt }).first().click()
     await expect
       .poll(async () => readActivePaneSelection(orcaPage), {

--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -32,7 +32,7 @@ type SplitGroupTerminal = {
 }
 
 function agentsSidebarButton(page: Page) {
-  return page.getByRole('radio', { name: /^Agents$/ }).first()
+  return page.getByRole('button', { name: 'View activity', exact: true })
 }
 
 async function seedActivityThread(
@@ -124,8 +124,7 @@ async function enableInlineAgentCards(page: Page): Promise<void> {
 
 async function enableActivityAgentsView(page: Page): Promise<void> {
   await page.evaluate(async () => {
-    // Why: the Agents tab is on by default, but a fresh profile opens the intro popover
-    // over it; stamping it as shown keeps the toggle clickable without dismissing it first.
+    // Keep the migration intro from covering the activity toggle.
     const settings = await window.api.settings.set({
       agentsSidebarIntroShown: true
     })

--- a/tests/e2e/add-project-default-checkout.spec.ts
+++ b/tests/e2e/add-project-default-checkout.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
@@ -86,10 +87,7 @@ test.describe('Add project default checkout', () => {
     await waitForSessionReady(orcaPage)
     const fixture = await createCloneFixture()
 
-    await orcaPage
-      .getByRole('button', { name: /Add Project/i })
-      .first()
-      .click()
+    await openSidebarProjectDialog(orcaPage)
     const addDialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
     await expect(addDialog).toBeVisible()
     await addDialog.getByRole('button', { name: /Clone from URL/i }).click()

--- a/tests/e2e/folder-setup-shallow-priority.spec.ts
+++ b/tests/e2e/folder-setup-shallow-priority.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
@@ -166,10 +167,7 @@ test('prioritizes shallow sibling repositories in a bounded nested scan', async 
   const fixture = await createShallowPriorityTruncationFixture()
   await chooseFolderInNativeDialog(electronApp, fixture.parentPath)
 
-  await orcaPage
-    .getByRole('button', { name: /Add Project/i })
-    .first()
-    .click()
+  await openSidebarProjectDialog(orcaPage)
   const dialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
   await expect(dialog).toBeVisible()
   await dialog.getByRole('button', { name: /Browse folder/i }).click()
@@ -256,10 +254,7 @@ test('can stop a nested repo scan and import repositories found so far', async (
   })
   await chooseFolderInNativeDialog(electronApp, fixture.parentPath)
 
-  await orcaPage
-    .getByRole('button', { name: /Add Project/i })
-    .first()
-    .click()
+  await openSidebarProjectDialog(orcaPage)
   const dialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
   await dialog.getByRole('button', { name: /Browse folder/i }).click()
 

--- a/tests/e2e/folder-setup.spec.ts
+++ b/tests/e2e/folder-setup.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
@@ -122,10 +123,7 @@ test.describe('Folder setup', () => {
     const fixture = await createNestedRepoFixture()
     await chooseFolderInNativeDialog(electronApp, fixture.parentPath)
 
-    await orcaPage
-      .getByRole('button', { name: /Add Project/i })
-      .first()
-      .click()
+    await openSidebarProjectDialog(orcaPage)
     const dialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
     await expect(dialog).toBeVisible()
     await dialog.getByRole('button', { name: /Browse folder/i }).click()
@@ -190,10 +188,7 @@ test.describe('Folder setup', () => {
     const fixture = await createLargeNestedRepoFixture()
     await chooseFolderInNativeDialog(electronApp, fixture.parentPath)
 
-    await orcaPage
-      .getByRole('button', { name: /Add Project/i })
-      .first()
-      .click()
+    await openSidebarProjectDialog(orcaPage)
     const dialog = orcaPage.getByRole('dialog', { name: /Add a project/i })
     await expect(dialog).toBeVisible()
     await dialog.getByRole('button', { name: /Browse folder/i }).click()

--- a/tests/e2e/golden-core-flows.spec.ts
+++ b/tests/e2e/golden-core-flows.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import { execFileSync } from 'node:child_process'
 import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { mkdtemp } from 'node:fs/promises'
@@ -211,10 +212,7 @@ async function addProjectFromSidebar(
   repoPath: string
 ): Promise<void> {
   await chooseFolderInNativeDialog(electronApp, repoPath)
-  await page
-    .getByRole('button', { name: /Add Project/i })
-    .first()
-    .click()
+  await openSidebarProjectDialog(page)
   const addDialog = page.getByRole('dialog', { name: /Add a project/i })
   await expect(addDialog).toBeVisible()
   await addDialog.getByRole('button', { name: /Browse folder/i }).click()

--- a/tests/e2e/helpers/sidebar-project-dialog.ts
+++ b/tests/e2e/helpers/sidebar-project-dialog.ts
@@ -1,0 +1,9 @@
+import { expect, type Page } from '@stablyai/playwright-test'
+
+export async function openSidebarProjectDialog(page: Page): Promise<void> {
+  // The compact overflow retains standalone project import; the composer hosts a different flow.
+  await page.evaluate(() => window.__store!.getState().setSidebarWidth(220))
+  await page.getByRole('button', { name: 'More workspace actions', exact: true }).click()
+  await page.getByRole('menuitem', { name: 'Add Project', exact: true }).click()
+  await expect(page.getByRole('dialog', { name: /Add a project/i })).toBeVisible()
+}

--- a/tests/e2e/helpers/ssh-config-host-picker.ts
+++ b/tests/e2e/helpers/ssh-config-host-picker.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './sidebar-project-dialog'
 /**
  * Shared helpers for SSH config host picker / import E2E specs.
  * Prefer role/label locators and user-visible copy over ids / data-*.
@@ -101,10 +102,7 @@ export async function returnToAppShell(page: Page): Promise<void> {
 /** Add Project → Host → Add remote host → Add SSH host → form dialog. */
 export async function openAddSshHostDialog(page: Page): Promise<Locator> {
   await returnToAppShell(page)
-  await page
-    .getByRole('button', { name: /Add Project/i })
-    .first()
-    .click()
+  await openSidebarProjectDialog(page)
   const addProjectDialog = page.getByRole('dialog', { name: /Add a project/i })
   await expect(addProjectDialog).toBeVisible({ timeout: 10_000 })
 

--- a/tests/e2e/multi-client-navigation-isolation.spec.ts
+++ b/tests/e2e/multi-client-navigation-isolation.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import { execFileSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { mkdtempSync, rmSync } from 'node:fs'
@@ -343,10 +344,7 @@ test('routes Add Project folder browsing through the paired host', async ({
   const offer = await createPairingOffer(orcaPage)
   const client = await openPairedClient(electronApp, offer, visibleWorktreeId)
   try {
-    await client
-      .getByRole('button', { name: /Add Project/i })
-      .first()
-      .click()
+    await openSidebarProjectDialog(client)
     const addDialog = client.getByRole('dialog', { name: /Add a project/i })
     await expect(addDialog).toBeVisible()
     await expect(addDialog).not.toContainText('Local Mac')

--- a/tests/e2e/paired-web-add-project-unavailable-host.spec.ts
+++ b/tests/e2e/paired-web-add-project-unavailable-host.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import type { ElectronApplication, Page, TestInfo } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
 import {
@@ -61,10 +62,7 @@ async function assertCreationActionsDisabled(args: {
   testInfo: TestInfo
   topology: 'headed' | 'headless'
 }): Promise<void> {
-  await args.page
-    .getByRole('button', { name: /Add Project/i })
-    .first()
-    .click()
+  await openSidebarProjectDialog(args.page)
   const dialog = args.page.getByRole('dialog', { name: /Add a project/i })
   await expect(dialog).toBeVisible()
   const hostPicker = dialog.getByRole('combobox')

--- a/tests/e2e/pr11346-selected-runtime-add.spec.ts
+++ b/tests/e2e/pr11346-selected-runtime-add.spec.ts
@@ -1,3 +1,4 @@
+import { openSidebarProjectDialog } from './helpers/sidebar-project-dialog'
 import { rmSync } from 'node:fs'
 import path from 'node:path'
 import type { ElectronApplication, Locator, Page, TestInfo } from '@stablyai/playwright-test'
@@ -22,10 +23,7 @@ import {
 } from './pr11346-selected-runtime-identity-oracle'
 
 async function selectRuntimeHost(page: Page, runtimeName: string): Promise<Locator> {
-  await page
-    .getByRole('button', { name: /Add Project/i })
-    .first()
-    .click()
+  await openSidebarProjectDialog(page)
   const dialog = page.getByRole('dialog', { name: /Add a project/i })
   await expect(dialog).toBeVisible()
   const hostPicker = dialog.getByRole('combobox')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The scheduled Electron suite still clicks the removed sidebar Add Project button and Agents radio, causing recurring entry-point timeouts. The tests now use the compact sidebar’s standalone Add Project action and the current View activity button. After selecting an agent row, the test reopens Activity because workspace reveal returns the sidebar to the workspace list.

The reusable project helper preserves standalone import behavior, including opening the default checkout after cloning.

Validation:
- Clone/default checkout, nested folder imports, and SSH config picker/import flows passed twice each in Electron.
- Corrected activity pane-selection case passed three fresh runs. Golden flows and selected-runtime Add Project passed.
- Paired-web Add Project routing and unavailable-host checks passed. An unchanged paired create-with-agent case failed once, then passed both alone and in the full four-case rerun; that intermittent failure remains under investigation separately.
- Formatting, lint, and node/web typechecks passed.
