### PR TITLE
test(e2e): fence SSH recovery and release exited Electron pipes

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -17922,6 +17922,139 @@
         "The sentinel changes a pane title within an existing layout; concurrent split and close conflicts remain separate coverage."
       ],
       "demotionRule": "Demote if a failed push suppresses an identical retry, a successful equal write resumes redundant churn, or the routed observer journey flakes without a diagnosed cause."
+    },
+    {
+      "id": "ssh.docker-recovery-and-resource-lifecycle",
+      "title": "Docker SSH reconnect, host faults, listing and watcher lifecycle",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "electron-docker-ssh",
+      "surfaces": [
+        "SSH terminal recovery",
+        "SSH remote resource ownership",
+        "remote file listing",
+        "remote explorer watcher recovery",
+        "Electron test process cleanup"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["ssh"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["ssh"],
+      "coverageNotes": "A macOS Electron client drives a Linux Docker SSH execution host. The six-spec suite passed ten enabled cases with clean worker exit (5.2m). The formerly skipped frozen-host input case now waits for recovered authority before sending input and passed four separate executions (one initial and three repetitions). The existing flooded-shell fixme remains an explicitly reproduced application gap.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/18018",
+        "https://github.com/stablyai/orca/pull/18546",
+        "https://github.com/stablyai/orca/issues/12547"
+      ],
+      "invariant": "Transport loss and frozen-host silence must preserve the remote session; host relay loss may rebind a pane without accumulating reattachable leases. Reconnects must preserve usable terminal content, bounded PTYs/fds/processes, complete large listings, and independently recoverable watcher processes. Electron test shutdown must release inherited pipes after confirmed root exit without closing live-process pipes.",
+      "oracle": "Poll a changed connected SSH authority after injected faults, then require terminal output and appropriate PTY identity. Read remote process/fd state, listFiles replies, and rendered explorer rows. Resolve Playwright cleanup only after the root process exits and its inherited pipes close; live-process pipes remain untouched.",
+      "commands": [
+        "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-transport-drop-recovery.spec.ts tests/e2e/ssh-docker-half-open-link.spec.ts tests/e2e/ssh-docker-quick-open-large-listing.spec.ts tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts tests/e2e/ssh-docker-resource-accumulation.spec.ts tests/e2e/ssh-docker-watcher-isolation.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+        "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts"
+      ],
+      "testFiles": [
+        "tests/e2e/ssh-docker-transport-drop-recovery.spec.ts",
+        "tests/e2e/ssh-docker-half-open-link.spec.ts",
+        "tests/e2e/ssh-docker-quick-open-large-listing.spec.ts",
+        "tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts",
+        "tests/e2e/ssh-docker-resource-accumulation.spec.ts",
+        "tests/e2e/ssh-docker-watcher-isolation.spec.ts",
+        "tests/e2e/helpers/electron-process-shutdown.unit.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "tests/e2e/ssh-docker-transport-drop-recovery.spec.ts",
+          "assertions": [
+            "preserves transport-drop PTY and scrollback, replaces relay-loss binding, and keeps one reattachable lease per pane"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-docker-half-open-link.spec.ts",
+          "assertions": [
+            "leaves connected after host freeze and renders process-produced output after recovery"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-docker-quick-open-large-listing.spec.ts",
+          "assertions": [
+            "returns both a bounded client page and a complete legacy-client remote listing"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts",
+          "assertions": [
+            "restores shell scrollback and full-screen output and opens a usable fresh tab"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-docker-resource-accumulation.spec.ts",
+          "assertions": [
+            "keeps remote pts devices, relay fds, process counts and inherited master fds bounded"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-docker-watcher-isolation.spec.ts",
+          "assertions": [
+            "keeps rendered explorer changes and terminal output live after watcher crash and repairs a deleted watcher artifact"
+          ]
+        },
+        {
+          "file": "tests/e2e/helpers/electron-process-shutdown.unit.test.ts",
+          "assertions": [
+            "releases inherited pipes after confirmed exit, including prior exit",
+            "retains live-process pipes on shutdown timeout"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-05",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts",
+          "durationSeconds": 0.168,
+          "summary": "All three shutdown regression tests passed; disabling pipe release fails the first two by timeout. Two half-open Electron repetitions separately passed in 1.7m without worker teardown timeout."
+        },
+        {
+          "date": "2026-09-05",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-transport-drop-recovery.spec.ts tests/e2e/ssh-docker-half-open-link.spec.ts tests/e2e/ssh-docker-quick-open-large-listing.spec.ts tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts tests/e2e/ssh-docker-resource-accumulation.spec.ts tests/e2e/ssh-docker-watcher-isolation.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "durationSeconds": 312,
+          "summary": "Six specs: ten passed, two existing fixme skipped, clean worker shutdown. Baseline same enabled suite: ten passed but worker teardown timed out (7.3m)."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 420,
+        "scope": "per Electron Docker test; measured suite p95 and CI soak not yet established"
+      },
+      "flakeHistory": {
+        "status": "flaky",
+        "evidence": "Baseline: ten enabled tests passed, two fixme skipped, worker teardown timed out (7.3m). After pipe cleanup: ten passed and worker exited cleanly (5.2m); two half-open repeats passed (1.7m). The formerly skipped thaw-input case failed before its recovered-authority wait and passed 1+3 executions afterward (56.9s + 2.6m). Flood failed both its original input oracle and a strengthened producer-completion oracle after recovery."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Disabling exited-process pipe release causes two shutdown contract tests to time out; restoring it passes 3/3. Baseline Docker worker teardown failed; final six-spec enabled run and half-open repeats exit successfully. Frozen-host input fails without the post-thaw recovered-authority wait and passes four runs with it. Full product fault/recovery mutation coverage and CI history remain missing."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Test-only bounded pipe destruction and authority polling; no production polling, subprocesses, or runtime work added. Remote resources are counted instead of using wall-clock leak thresholds."
+      },
+      "promotionCriteria": [
+        "Require complete six-spec repeat runs with clean worker shutdown.",
+        "Resolve the remaining #18018 flooded-shell reproduction and remove its fixme marker.",
+        "Collect CI runtime and flake history plus product red/green evidence before blocking."
+      ],
+      "knownGaps": [
+        "The disconnected 48MB flood still loses its relay channel: original post-flood input marker failed in 60s, and waiting for the finite producer completion marker failed in 120s. It remains an explicit #18018 fixme reproduction; frozen-host input is re-enabled after four successful runs.",
+        "Linux and Windows desktop clients, WSL, folder workspaces, paired runtimes and live agent CLIs are not exercised by these Docker specs.",
+        "Some legacy assertions inspect terminal serialization or backing state rather than rendered DOM; no blanket visual coverage claim.",
+        "No p95 CI history or full product mutation proof."
+      ],
+      "demotionRule": "Keep experimental while any recovery reproduction fails or any teardown, identity, resource-count, or rendered oracle flakes; never promote by extending sleeps or retries."
     }
   ]
 }

--- a/tests/e2e/helpers/docker-ssh-relay-connection.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-connection.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@stablyai/playwright-test'
+import { expect, type Page } from '@stablyai/playwright-test'
 
 import {
   DOCKER_SSH_PROXY_JUMP_REMOTE_REPO_PATH,
@@ -226,4 +226,34 @@ export async function reconnectDisconnectedDockerSshRelayTarget(
   targetId: string
 ): Promise<void> {
   return performDockerSshRelayReconnect(page, targetId, false)
+}
+
+export async function recoverDockerSshRelayAfterFault(
+  page: Page,
+  targetId: string,
+  injectFault: () => void | Promise<void>
+): Promise<void> {
+  const readAuthority = () =>
+    page.evaluate((id) => window.__store?.getState().sshConnectionStates.get(id), targetId)
+  const before = await readAuthority()
+  expect(before).toMatchObject({
+    status: 'connected',
+    providerEpoch: expect.any(String),
+    connectionGeneration: expect.any(Number)
+  })
+  await injectFault()
+  // The pre-fault connected publication can remain visible until the next IPC event.
+  await expect
+    .poll(
+      async () => {
+        const after = await readAuthority()
+        return (
+          after?.status === 'connected' &&
+          (after.providerEpoch !== before?.providerEpoch ||
+            after.connectionGeneration !== before?.connectionGeneration)
+        )
+      },
+      { timeout: 120_000, message: 'SSH authority did not recover after the injected fault' }
+    )
+    .toBe(true)
 }

--- a/tests/e2e/helpers/electron-process-shutdown.ts
+++ b/tests/e2e/helpers/electron-process-shutdown.ts
@@ -19,6 +19,16 @@ function hasExited(proc: ChildProcess): boolean {
   return proc.exitCode !== null || proc.signalCode !== null
 }
 
+function releaseExitedProcessPipes(proc: ChildProcess): void {
+  if (!hasExited(proc)) {
+    return
+  }
+  // Detached SSH helpers can retain inherited pipes after Electron itself exits.
+  for (const stream of proc.stdio) {
+    stream?.destroy()
+  }
+}
+
 function waitForExit(proc: ChildProcess, timeoutMs: number): Promise<boolean> {
   if (hasExited(proc)) {
     return Promise.resolve(true)
@@ -166,12 +176,16 @@ export async function forceQuitElectronAppForE2E(app: ElectronApplication): Prom
     }
   }
   await waitForExit(proc, PROCESS_EXIT_TIMEOUT_MS)
+  releaseExitedProcessPipes(proc)
   // Hands the dead app back to Playwright so worker teardown has nothing left to wait on.
   await app.close().catch(() => undefined)
 }
 
 export async function closeElectronAppForE2E(app: ElectronApplication): Promise<void> {
   const proc = app.process()
+  const releasePipes = (): void => releaseExitedProcessPipes(proc)
+  proc.once('exit', releasePipes)
+  releasePipes()
   try {
     await withTimeout(app.close(), GRACEFUL_CLOSE_TIMEOUT_MS, 'Timed out closing Electron app')
     if (proc) {
@@ -184,6 +198,9 @@ export async function closeElectronAppForE2E(app: ElectronApplication): Promise<
     if (proc) {
       await forceKillProcessTree(proc)
     }
+  } finally {
+    proc.off('exit', releasePipes)
+    releasePipes()
   }
 }
 

--- a/tests/e2e/helpers/electron-process-shutdown.unit.test.ts
+++ b/tests/e2e/helpers/electron-process-shutdown.unit.test.ts
@@ -1,0 +1,59 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import type { ChildProcess } from 'node:child_process'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { closeElectronAppForE2E } from './electron-process-shutdown'
+
+function exitedAppFixture() {
+  const proc = Object.assign(new EventEmitter(), {
+    exitCode: null as number | null,
+    signalCode: null,
+    stdio: [new PassThrough(), new PassThrough(), new PassThrough()]
+  })
+  const pipesClosed = Promise.all(
+    proc.stdio.map((stream) => new Promise<void>((resolve) => stream.once('close', resolve)))
+  )
+  const close = vi.fn(() => pipesClosed)
+  const app = {
+    process: () => proc as unknown as ChildProcess,
+    close
+  } as unknown as ElectronApplication
+  return { proc, app, close }
+}
+
+afterEach(() => vi.useRealTimers())
+
+describe('Electron shutdown with inherited pipes', () => {
+  it('releases retained pipes only after Electron exits, settling Playwright cleanup', async () => {
+    const { proc, app, close } = exitedAppFixture()
+    const closing = closeElectronAppForE2E(app)
+    expect(close).toHaveBeenCalledOnce()
+    expect(proc.stdio.every((stream) => !stream.destroyed)).toBe(true)
+    proc.exitCode = 0
+    proc.emit('exit', 0, null)
+    await closing
+    expect(proc.stdio.every((stream) => stream.destroyed)).toBe(true)
+    expect(proc.listenerCount('exit')).toBe(0)
+  })
+
+  it('releases pipes when Electron already exited before cleanup starts', async () => {
+    const { proc, app } = exitedAppFixture()
+    proc.exitCode = 0
+    await closeElectronAppForE2E(app)
+    expect(proc.stdio.every((stream) => stream.destroyed)).toBe(true)
+  })
+
+  it('does not release pipes if shutdown times out without confirmed process exit', async () => {
+    vi.useFakeTimers()
+    const { proc, app } = exitedAppFixture()
+    const closing = closeElectronAppForE2E(app)
+    await vi.advanceTimersByTimeAsync(10_000)
+    await closing
+    expect(proc.stdio.every((stream) => !stream.destroyed)).toBe(true)
+    expect(proc.listenerCount('exit')).toBe(0)
+    for (const stream of proc.stdio) {
+      stream.destroy()
+    }
+  })
+})

--- a/tests/e2e/ssh-docker-half-open-link.spec.ts
+++ b/tests/e2e/ssh-docker-half-open-link.spec.ts
@@ -68,7 +68,7 @@ test.describe('Docker SSH half-open link', () => {
       const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
 
       const runId = String(Date.now())
-      await execInTerminal(orcaPage, ptyId, `echo LIVE_${runId}`)
+      await execInTerminal(orcaPage, ptyId, `printf 'LIVE_%s\\n' ${runId}`)
       await waitForTerminalOutput(orcaPage, `LIVE_${runId}`, 60_000)
       expect(await readSshStatus(orcaPage, remote.targetId)).toBe('connected')
 
@@ -78,13 +78,15 @@ test.describe('Docker SSH half-open link', () => {
       const frozenAt = Date.now()
 
       let verdict: string | null = 'connected'
-      while (Date.now() - frozenAt < LOST_VERDICT_BUDGET_MS) {
-        verdict = await readSshStatus(orcaPage, remote.targetId)
-        if (verdict !== 'connected') {
-          break
-        }
-        await orcaPage.waitForTimeout(1_000)
-      }
+      await expect
+        .poll(
+          async () => {
+            verdict = await readSshStatus(orcaPage, remote.targetId)
+            return verdict
+          },
+          { timeout: LOST_VERDICT_BUDGET_MS, message: 'frozen host remained connected' }
+        )
+        .not.toBe('connected')
       const verdictMs = Date.now() - frozenAt
       console.log(
         `[half-open] ${JSON.stringify({ verdict, verdictMs, budgetMs: LOST_VERDICT_BUDGET_MS })}`
@@ -105,7 +107,7 @@ test.describe('Docker SSH half-open link', () => {
         .poll(() => readSshStatus(orcaPage, remote.targetId), { timeout: 120_000 })
         .toBe('connected')
       const recoveredPtyId = await waitForActivePanePtyId(orcaPage, 60_000)
-      await execInTerminal(orcaPage, recoveredPtyId, `echo RECOVERED_${runId}`)
+      await execInTerminal(orcaPage, recoveredPtyId, `printf 'RECOVERED_%s\\n' ${runId}`)
       await waitForTerminalOutput(orcaPage, `RECOVERED_${runId}`, 90_000)
     } finally {
       if (target && paused) {

--- a/tests/e2e/ssh-docker-transport-drop-recovery.spec.ts
+++ b/tests/e2e/ssh-docker-transport-drop-recovery.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 import { readFileSync } from 'node:fs'
-import type { ElectronApplication, Page } from '@playwright/test'
+import type { ElectronApplication } from '@playwright/test'
 import { test, expect } from './helpers/orca-app'
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 import { sshRemotePtyLeaseAllowsReattach, type SshRemotePtyLease } from '../../src/shared/ssh-types'
@@ -18,7 +18,10 @@ import {
   startDockerSshRelayTarget,
   type DockerSshRelayTarget
 } from './helpers/docker-ssh-relay-target'
-import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
+import {
+  connectDockerSshRelayTarget,
+  recoverDockerSshRelayAfterFault
+} from './helpers/docker-ssh-relay-connection'
 import {
   clearDockerSshRelayFaults,
   dropDockerSshRelayTransport,
@@ -46,13 +49,6 @@ const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
  * with only the first cannot tell a resume from a silent cold start
  * (docs/reference/ssh-execution-boundary.md).
  */
-async function readSshStatus(orcaPage: Page, targetId: string) {
-  return orcaPage.evaluate(
-    (targetId) => window.__store?.getState().sshConnectionStates.get(targetId)?.status ?? null,
-    targetId
-  )
-}
-
 /**
  * Every lease `reattachKnownPtys` would feed to `pty.attach` on the next connect, read from the
  * durable store rather than from the renderer — leases are main-owned and never published.
@@ -122,7 +118,9 @@ test.describe('SSH transport drop recovery', () => {
       enableDockerSshRelayTargetShellTitle(target)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target, {
+        relayGracePeriodSeconds: 0
+      })
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 60_000)
       const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
@@ -134,20 +132,12 @@ test.describe('SSH transport drop recovery', () => {
       await execInTerminal(orcaPage, ptyId, `printf 'DROP_MARKER_%s\\n' ${markerSuffix}`)
       await waitForTerminalOutput(orcaPage, marker, 30_000)
 
-      const dropped = dropDockerSshRelayTransport(target)
-      expect(dropped, 'no live SSH connection was found to drop').toBeGreaterThan(0)
-
-      // Nothing below calls ssh.connect(). Recovery has to come from the client's own ladder,
-      // which is the behaviour users depend on and the thing a scripted reconnect never exercised.
-      await expect
-        .poll(() => readSshStatus(orcaPage, remote.targetId), {
-          timeout: 120_000,
-          message: 'SSH target never returned to connected after the transport was dropped'
-        })
-        .toBe('connected')
+      await recoverDockerSshRelayAfterFault(orcaPage, remote.targetId, () => {
+        expect(dropDockerSshRelayTransport(target!)).toBeGreaterThan(0)
+      })
 
       await waitForActiveTerminalManager(orcaPage, 60_000)
-      await waitForActivePanePtyId(orcaPage, 60_000)
+      expect(await waitForActivePanePtyId(orcaPage, 60_000)).toBe(ptyId)
 
       // The pane must still show what it had. A blank pane here is the reported bug.
       await waitForTerminalOutput(orcaPage, marker, 60_000)
@@ -170,10 +160,7 @@ test.describe('SSH transport drop recovery', () => {
     }
   })
 
-  // Fixme: fails in CI on its first real run — the pane keeps its PTY and repaints, but a command
-  // run after the flood produces no output within the poll budget. Same shape as #18018 (deaf pane
-  // after a stalled host resumes), and not caused by this spec. Tracked there; the three verdict
-  // assertions around it stay enforced.
+  // #18018: local authority-aware recovery still loses the flooded pane's relay channel.
   test.fixme('stays bounded when a disconnected shell floods its pty', async ({
     orcaPage
   }, testInfo) => {
@@ -195,7 +182,9 @@ test.describe('SSH transport drop recovery', () => {
       enableDockerSshRelayTargetShellTitle(target)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target, {
+        relayGracePeriodSeconds: 0
+      })
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 240_000)
       const ptyId = await waitForActivePanePtyId(orcaPage, 240_000)
@@ -214,18 +203,12 @@ test.describe('SSH transport drop recovery', () => {
       await execInTerminal(
         orcaPage,
         ptyId,
-        `yes "$(printf 'ORCA_%s' FLOOD_LINE)" | head -c 48000000; echo FLOODED`
+        `yes "$(printf 'ORCA_%s' FLOOD_LINE)" | head -c 48000000; printf 'FLOO%s\\n' DED`
       )
       await waitForTerminalOutput(orcaPage, 'ORCA_FLOOD_LINE', 30_000, 20_000)
-      const dropped = dropDockerSshRelayTransport(target)
-      expect(dropped).toBeGreaterThan(0)
-
-      await expect
-        .poll(() => readSshStatus(orcaPage, remote.targetId), {
-          timeout: 120_000,
-          message: 'SSH target never returned to connected'
-        })
-        .toBe('connected')
+      await recoverDockerSshRelayAfterFault(orcaPage, remote.targetId, () => {
+        expect(dropDockerSshRelayTransport(target!)).toBeGreaterThan(0)
+      })
       await waitForActiveTerminalManager(orcaPage, 240_000)
 
       // Why a generous ceiling: this is an OOM guard, not a memory budget. Unbounded retention of
@@ -235,6 +218,9 @@ test.describe('SSH transport drop recovery', () => {
         afterRssKb - baselineRssKb,
         `relay grew ${afterRssKb - baselineRssKb}KB after 48MB of undeliverable output`
       ).toBeLessThan(200_000)
+
+      // Wait for the finite producer to finish before sending a shell command behind it.
+      await waitForTerminalOutput(orcaPage, 'FLOODED', 120_000, 20_000)
 
       // And the session must still be usable, not merely alive.
       const markerSuffix = Date.now()
@@ -273,7 +259,9 @@ test.describe('SSH transport drop recovery', () => {
       enableDockerSshRelayTargetShellTitle(target)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target, {
+        relayGracePeriodSeconds: 0
+      })
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 60_000)
       const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
@@ -283,15 +271,9 @@ test.describe('SSH transport drop recovery', () => {
       await execInTerminal(orcaPage, ptyId, `printf 'KILL_MARKER_%s\\n' ${markerSuffix}`)
       await waitForTerminalOutput(orcaPage, marker, 30_000)
 
-      const killed = killDockerSshRelayDaemon(target)
-      expect(killed, 'no relay process was found to kill').toBeGreaterThan(0)
-
-      await expect
-        .poll(() => readSshStatus(orcaPage, remote.targetId), {
-          timeout: 120_000,
-          message: 'SSH target never returned to connected after the relay was killed'
-        })
-        .toBe('connected')
+      await recoverDockerSshRelayAfterFault(orcaPage, remote.targetId, () => {
+        expect(killDockerSshRelayDaemon(target!)).toBeGreaterThan(0)
+      })
       await waitForActiveTerminalManager(orcaPage, 60_000)
 
       // The verdict, expressed as the only thing a user can observe: the pane is now backed by a
@@ -345,7 +327,9 @@ test.describe('SSH transport drop recovery', () => {
       enableDockerSshRelayTargetShellTitle(target)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      const remote = await connectDockerSshRelayTarget(orcaPage, target)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target, {
+        relayGracePeriodSeconds: 0
+      })
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 60_000)
       await waitForActivePanePtyId(orcaPage, 60_000)
@@ -354,22 +338,20 @@ test.describe('SSH transport drop recovery', () => {
       const generations: string[][] = []
 
       for (let generation = 1; generation <= 5; generation++) {
-        expect(
-          killDockerSshRelayDaemon(target),
-          'no relay process was found to kill'
-        ).toBeGreaterThan(0)
+        const predecessor = await waitForActivePanePtyId(orcaPage, 60_000)
+        await recoverDockerSshRelayAfterFault(orcaPage, remote.targetId, () => {
+          expect(killDockerSshRelayDaemon(target!)).toBeGreaterThan(0)
+        })
         await expect
-          .poll(() => readSshStatus(orcaPage, remote.targetId), {
-            timeout: 120_000,
-            message: `SSH target never reconnected after relay kill ${generation}`
-          })
-          .toBe('connected')
+          .poll(() => waitForActivePanePtyId(orcaPage, 60_000), { timeout: 120_000 })
+          .not.toBe(predecessor)
         await waitForActiveTerminalManager(orcaPage, 120_000)
         // The pane must be usable again before the count is meaningful: recovery is what mints the
         // successor lease that retires the generation before it.
         const ptyId = await waitForActivePanePtyId(orcaPage, 120_000)
-        const marker = `LEASE_GEN_${generation}_${Date.now()}`
-        await execInTerminal(orcaPage, ptyId, `printf '%s\\n' ${marker}`)
+        const markerSuffix = `${generation}_${Date.now()}`
+        const marker = `LEASE_GEN_${markerSuffix}`
+        await execInTerminal(orcaPage, ptyId, `printf 'LEASE_GEN_%s\\n' ${markerSuffix}`)
         await waitForTerminalOutput(orcaPage, marker, 60_000)
 
         try {
@@ -418,7 +400,7 @@ test.describe('SSH transport drop recovery', () => {
       enableDockerSshRelayTargetShellTitle(target)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      await connectDockerSshRelayTarget(orcaPage, target)
+      await connectDockerSshRelayTarget(orcaPage, target, { relayGracePeriodSeconds: 0 })
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 60_000)
       const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
@@ -446,17 +428,8 @@ test.describe('SSH transport drop recovery', () => {
     }
   })
 
-  /**
-   * Known broken on main, kept as the reproduction. The verdict test above passes: after a 30s
-   * freeze the pane keeps its PTY and repaints its scrollback. What does not come back is the
-   * shell — a command run afterwards produces no output within 60s, so the pane is live-looking and
-   * deaf. Measured twice at `waitForTerminalOutput(STALL_AFTER_…)`, and it reproduces unchanged
-   * with the reattach-token/delivery-ownership fix applied, so that is not the cause.
-   *
-   * Split out rather than folded into the test above so the `unverifiable` verdict stays enforced
-   * in CI instead of being masked by this failure.
-   */
-  test.fixme('accepts input again after a frozen host resumes', async ({ orcaPage }, testInfo) => {
+  // #18018: wait for the recovered authority before input; a retained manager can still be disconnected.
+  test('accepts input again after a frozen host resumes', async ({ orcaPage }, testInfo) => {
     test.slow()
     let target: DockerSshRelayTarget | null = null
     try {
@@ -464,13 +437,17 @@ test.describe('SSH transport drop recovery', () => {
       enableDockerSshRelayTargetShellTitle(target)
       await waitForSessionReady(orcaPage)
       await waitForActiveWorktree(orcaPage)
-      await connectDockerSshRelayTarget(orcaPage, target)
+      const remote = await connectDockerSshRelayTarget(orcaPage, target, {
+        relayGracePeriodSeconds: 0
+      })
       await ensureTerminalVisible(orcaPage, 45_000)
       await waitForActiveTerminalManager(orcaPage, 60_000)
       const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
 
-      await withStalledDockerSshRelayTarget(target, async () => {
-        await orcaPage.waitForTimeout(30_000)
+      await recoverDockerSshRelayAfterFault(orcaPage, remote.targetId, async () => {
+        await withStalledDockerSshRelayTarget(target!, async () => {
+          await orcaPage.waitForTimeout(30_000)
+        })
       })
       await waitForActiveTerminalManager(orcaPage, 60_000)
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​169 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​84 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​85 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 |

<!-- /orca-pr-loc -->

The six Docker SSH specs could pass their assertions and still fail when Playwright waited for inherited Electron pipes during worker teardown. Cleanup now releases those pipes only after confirmed Electron exit. Recovery checks require a new connected authority, and relay restart checks wait for the new pane generation before sending a command. Output markers require shell execution rather than matching terminal echo.

The frozen-host input reproduction now waits for reconnection before sending input and is re-enabled. All six specs are registered in the experimental reliability manifest, with the remaining #18018 disconnected-output flood failure recorded explicitly.

Validation:
- Six-spec run: 10 passed, 2 existing skips, clean shutdown in 5.2 minutes; baseline passed assertions but failed worker teardown.
- Formerly skipped frozen-host input: four passes after the fix; half-open recovery: two repeated passes.
- Pipe cleanup regressions: 3 passed; disabling cleanup makes 2 fail.
- Lint, formatting, node/web typechecks, and 103-gate manifest validation passed.

The flooded-shell case remains skipped after two failed diagnostic executions. No application code changes are included.
