### PR TITLE
fix(ui): ignore the persistent workspace list when detecting overlays

### DIFF
--- a/src/renderer/src/lib/visible-overlay.test.ts
+++ b/src/renderer/src/lib/visible-overlay.test.ts
@@ -30,6 +30,16 @@ describe('hasVisibleOverlay', () => {
     expect(hasVisibleOverlay()).toBe(false)
   })
 
+  it('ignores the persistent workspace list while preserving its nested popups', () => {
+    mount('<div role="listbox" data-worktree-sidebar></div>')
+
+    expect(hasVisibleOverlay()).toBe(false)
+
+    document.querySelector('[data-worktree-sidebar]')!.innerHTML = '<div role="menu"></div>'
+
+    expect(hasVisibleOverlay()).toBe(true)
+  })
+
   it('ignores a display:none overlay', () => {
     mount('<div role="dialog" style="display: none"></div>')
 

--- a/src/renderer/src/lib/visible-overlay.test.ts
+++ b/src/renderer/src/lib/visible-overlay.test.ts
@@ -35,7 +35,7 @@ describe('hasVisibleOverlay', () => {
 
     expect(hasVisibleOverlay()).toBe(false)
 
-    document.querySelector('[data-worktree-sidebar]')!.innerHTML = '<div role="menu"></div>'
+    mount('<div role="listbox" data-worktree-sidebar><div role="menu"></div></div>')
 
     expect(hasVisibleOverlay()).toBe(true)
   })

--- a/src/renderer/src/lib/visible-overlay.ts
+++ b/src/renderer/src/lib/visible-overlay.ts
@@ -1,4 +1,6 @@
-const OVERLAY_SELECTOR = '[role="dialog"], [role="alertdialog"], [role="listbox"], [role="menu"]'
+// The always-mounted worktree sidebar is page chrome, not an Escape-owning popup.
+const OVERLAY_SELECTOR =
+  '[role="dialog"], [role="alertdialog"], [role="listbox"]:not([data-worktree-sidebar]), [role="menu"]'
 
 type VisibleOverlayOptions = {
   /** Overlays inside a match are treated as page content, not as a layer above it. */
@@ -13,10 +15,6 @@ type VisibleOverlayOptions = {
 export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
   return Array.from(document.querySelectorAll(OVERLAY_SELECTOR)).some((element) => {
     if (!(element instanceof HTMLElement)) {
-      return false
-    }
-    // The persistent workspace list is page chrome, not an Escape-owning popup.
-    if (element.matches('[role="listbox"][data-worktree-sidebar]')) {
       return false
     }
     if (element.closest('[aria-hidden="true"]')) {

--- a/src/renderer/src/lib/visible-overlay.ts
+++ b/src/renderer/src/lib/visible-overlay.ts
@@ -15,6 +15,10 @@ export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
     if (!(element instanceof HTMLElement)) {
       return false
     }
+    // The persistent workspace list is page chrome, not an Escape-owning popup.
+    if (element.matches('[role="listbox"][data-worktree-sidebar]')) {
+      return false
+    }
     if (element.closest('[aria-hidden="true"]')) {
       return false
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Orca's left sidebar always shows your list of workspaces. Under the hood that list was tagged with the same accessibility label the app uses for pop-up menus, so whenever the app asked itself "is a pop-up open right now?", the answer was always yes — because the sidebar is always on screen. The Automations and Skills pages use that question to decide whether the Escape key should close them, so Escape quietly stopped working: you'd press it and nothing happened. Now the app knows the always-present workspace list is ordinary page furniture rather than a pop-up. Escape closes those pages again, and real menus and dialogs still get the first press for themselves.

## What Changed

`hasVisibleOverlay()` in `src/renderer/src/lib/visible-overlay.ts` no longer counts the persistent worktree sidebar scroll container as an overlay. The exclusion is expressed in the selector itself:

```
'[role="dialog"], [role="alertdialog"], [role="listbox"]:not([data-worktree-sidebar]), [role="menu"]'
```

Popups nested *inside* the sidebar — row context menus, dropdowns, dialogs — are still detected, because they are separate elements matched on their own. A unit test pins both halves of that contract.

## Why

The sidebar container (`VirtualizedWorktreeViewport.tsx:330`) is correctly marked `role="listbox"` for accessibility — it is a multi-selectable list of workspace options — and it is mounted for effectively the whole session. `hasVisibleOverlay()` treats any visible `listbox` as an Escape-owning popup, so on pages where the sidebar is mounted the predicate was pinned to `true` and the page-level Escape handler bailed out unconditionally.

Crucially, the sidebar listbox has **no Escape handler of its own** — nothing under `src/renderer/src/components/sidebar/worktree-list/` binds `Escape`. The old behavior was therefore not "the sidebar wins Escape"; it was "nobody handles Escape". Deferring to it was always wrong.

**Which pages were actually affected.** `use-app-chrome-layout.ts:76` gates the sidebar with `showSidebar = activeView !== 'settings' && activeView !== 'activity' && activeView !== 'space'`, so the sidebar is *unmounted* on Settings and Workspace Space. Those two call the same predicate but never coexisted with the sidebar listbox and were never broken by it. The real fix is for **Automations and Skills**, the two page surfaces where the sidebar is mounted. (Skills already passes `ignoreSelector: '[data-skills-page-list="true"]'`, but that exempts its own list, not the sidebar.)

A related nuance: Radix marks outside content `aria-hidden` while a modal dialog is open, so the sidebar was already excluded by the existing `aria-hidden` check in that case. The bug bit for non-modal popovers and, mostly, for the plain "no overlay at all" case.

**Why this layer, and why a named exception.** The sidebar is global chrome present on every page it affects, so the existing per-call `ignoreSelector` option — designed for page-local lists — would have to be repeated at every current and future call site. A named self-exclusion baked into the overlay selector is also the established convention in this codebase: `useWorkspaceBoardPanel.ts:19` uses `[role="dialog"][data-state="open"]:not([data-workspace-board-sheet])` and `AgentDashboardDrawer.tsx:22` uses `:not([data-agent-dashboard-sheet])`. This change follows the same shape rather than inventing a new mechanism.

## Tradeoffs

Genuine, user-facing downsides:

- **Escape inside the sidebar now closes the page.** With keyboard focus in the workspace list while Automations or Skills is open, Escape now closes the page instead of doing nothing. Nothing is lost today (the list binds no Escape handler), but if the sidebar later wants Escape-to-clear-selection it must claim the key explicitly with `preventDefault()` rather than relying on being mistaken for an overlay.
- **A named exception couples a generic lib to one component's attribute.** `lib/visible-overlay.ts` now hardcodes `data-worktree-sidebar`. If that attribute is renamed, or a second always-mounted `role="listbox"`/`role="menu"` is added to chrome, the same class of bug returns silently — no test on the sidebar component asserts it keeps the attribute.
- **A real popup that ever reuses the marker would be ignored.** Any future `role="listbox"` carrying `data-worktree-sidebar` is unconditionally skipped. Narrow today: the attribute is on exactly one scroll container.
- **Behavior change with no opt-out.** Users who had adapted to Escape being inert on Automations/Skills now get a page close. No setting gates it.
- **Escape-to-close on these pages still has no e2e coverage.** No spec under `tests/e2e/` presses Escape to close Automations or Skills, so a future regression of the same shape would again be caught only by unit tests on the predicate.

No latency, memory, or resource cost: the predicate runs only on an Escape keypress, and the change removes a per-element `matches()` call rather than adding work.

**Known-better alternative, deliberately out of scope:** the more principled fix is to require `[data-state="open"]` on candidate overlays (Radix sets it on real popups; page chrome never has it), as the two sibling implementations above already do. That was not adopted here because ~30 cmdk `CommandList` call sites render `role="listbox"` *without* `data-state` — the attribute sits on the Radix parent — so tightening the predicate that way would stop detecting them and cause the opposite bug. Worth a follow-up that migrates the predicate wholesale with coverage.

## Linked Issue

No tracking issue; found during the test reliability audit.

## Visual Proof

`N/A` — deliberately not captured. Per this repo's `AGENTS.md`, local Electron launches are paused for this task, so no app window was started. Visual proof would also be weak evidence here: the change is a keypress behavior (Escape closes a page), which a still screenshot cannot show, and a before/after video would be hard to distinguish from a mis-aimed keypress. The Electron regression named under Testing is the stronger artifact, and CI e2e is the right place to run it.

## Testing

- `pnpm test src/renderer/src/lib/visible-overlay.test.ts` — 10/10 pass, including the new case asserting the sidebar is ignored *and* that a menu nested inside it is still detected.
- `pnpm test src/renderer/src/components/automations/AutomationsPage.escape-precedence.test.tsx src/renderer/src/components/skills/SkillsPage.test.tsx` — 16/16 pass (the two page surfaces actually affected).
- `pnpm tc` — pass.
- `oxlint` on both changed files — clean.
- Per the original author: the existing Electron Escape regression failed before this change and passed after, alongside seven focused Escape/tab-close checks. Not re-run locally (Electron launches paused); CI covers it.
- Platforms: renderer-only DOM predicate, no platform-conditional code. No SSH, remote-wire, folder-workspace, or mobile surface touched (`mobile/` has no equivalent of this module).

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- Security: none — no I/O, no user input parsing, pure DOM read.
- Cross-platform: DOM-only, runs in the Chromium renderer on all three platforms; no path, shell, or shortcut handling. `:not()` with an attribute selector is universally supported and verified under the `happy-dom` test environment.
- Remote SSH / remote wire: not touched. No RPC params, stream frames, or published host content change.
- Folder workspaces: unaffected — the predicate does not distinguish worktrees from folder workspaces.
- Mobile: no equivalent module exists under `mobile/`.
- Backwards compatibility: no persisted state, schema, or serialized contract involved.
- Performance: strictly less work than before, and only on an Escape keypress.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
