### PR TITLE
fix(terminal): preserve ordinary foreground command names

### DIFF
--- a/src/main/daemon/terminal-host-non-agent-foreground.test.ts
+++ b/src/main/daemon/terminal-host-non-agent-foreground.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ProcessTableRow } from '../../shared/process-table-snapshot'
+import type * as SnapshotReader from '../../shared/process-table-snapshot-reader'
+import { inspectTerminalHostProcess } from './terminal-host-process-inspection'
+import type { Session } from './session'
+
+const { readSnapshot } = vi.hoisted(() => ({ readSnapshot: vi.fn() }))
+vi.mock('../../shared/process-table-snapshot-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof SnapshotReader>()),
+  getStrictProcessTableSnapshotWithAge: readSnapshot
+}))
+
+function table(command: string | null): ProcessTableRow[] {
+  const foregroundPgid = command === null ? 100 : 101
+  const shell: ProcessTableRow = {
+    pid: 100,
+    ppid: 1,
+    pgid: 100,
+    tpgid: foregroundPgid,
+    tty: 'pts/1',
+    startTime: 'shell-start',
+    stat: command === null ? 'Ss+' : 'Ss',
+    command: '/bin/bash'
+  }
+  return command === null
+    ? [shell]
+    : [
+        shell,
+        {
+          ...shell,
+          pid: 101,
+          ppid: 100,
+          pgid: 101,
+          stat: 'S+',
+          startTime: 'command-start',
+          command
+        }
+      ]
+}
+
+async function inspect(rawName: string, command: string | null) {
+  readSnapshot.mockResolvedValue({ rows: table(command), capturedAgeMs: 0 })
+  return inspectTerminalHostProcess({
+    sessionId: 'busy-tab',
+    session: {
+      pid: 100,
+      incarnationId: 'incarnation-1',
+      isAlive: true,
+      getForegroundProcess: () => rawName
+    } as unknown as Session,
+    authorityGeneration: 'generation-1',
+    nextObservationEpoch: () => 1
+  })
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  readSnapshot.mockClear()
+})
+
+describe.each(['linux', 'darwin'] as const)('daemon ordinary foreground on %s', (platform) => {
+  it.each(['sleep', 'vim', 'node'])(
+    'retains the running %s name alongside agent-only evidence',
+    async (name) => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+      const result = await inspect(name, `${name} 300`)
+      expect(result).toMatchObject({
+        foregroundProcess: name,
+        hasChildProcesses: true,
+        foregroundProcessEvidence: { verdict: 'live', processName: null }
+      })
+      expect(readSnapshot).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('still clears a stale recognized agent after its process exits', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+    expect(await inspect('claude', null)).toMatchObject({
+      foregroundProcess: null,
+      foregroundProcessEvidence: { verdict: 'live', processName: null }
+    })
+  })
+
+  it('still reports no foreground command for an idle shell', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+    expect(await inspect('bash', null)).toMatchObject({
+      foregroundProcess: null,
+      hasChildProcesses: false,
+      foregroundProcessEvidence: { verdict: 'live', processName: null }
+    })
+  })
+})

--- a/src/main/daemon/terminal-host-process-inspection.ts
+++ b/src/main/daemon/terminal-host-process-inspection.ts
@@ -1,4 +1,5 @@
 import { isShellProcess } from '../../shared/agent-detection'
+import { recognizeAgentProcess } from '../../shared/agent-process-recognition'
 import type { RemoteForegroundEvidence } from '../../shared/foreground-process-evidence'
 import { getCheapProcessTableSnapshot } from '../../shared/cheap-process-table-snapshot-reader'
 import { getStrictProcessTableSnapshotWithAge } from '../../shared/process-table-snapshot-reader'
@@ -100,8 +101,18 @@ export async function inspectTerminalHostProcess(args: {
       clearSteadyStateAnchor(session)
     }
   }
+  // Agent-only evidence cannot erase an ordinary running command's PTY name.
+  const ordinaryForeground =
+    foregroundProcess !== null &&
+    !isShellProcess(foregroundProcess) &&
+    !recognizeAgentProcess(foregroundProcess)
+      ? foregroundProcess
+      : null
   return {
-    foregroundProcess: evidence.verdict === 'live' ? evidence.processName : foregroundProcess,
+    foregroundProcess:
+      evidence.verdict === 'live'
+        ? (evidence.processName ?? ordinaryForeground)
+        : foregroundProcess,
     hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess),
     foregroundProcessEvidence: evidence
   }

--- a/src/main/daemon/terminal-host-process-inspection.ts
+++ b/src/main/daemon/terminal-host-process-inspection.ts
@@ -101,19 +101,16 @@ export async function inspectTerminalHostProcess(args: {
       clearSteadyStateAnchor(session)
     }
   }
-  // Agent-only evidence cannot erase an ordinary running command's PTY name.
+  const nonShellForeground = foregroundProcess !== null && !isShellProcess(foregroundProcess)
+  // Evidence names recognized agents only, so its null must not erase an ordinary command (#18078).
   const ordinaryForeground =
-    foregroundProcess !== null &&
-    !isShellProcess(foregroundProcess) &&
-    !recognizeAgentProcess(foregroundProcess)
-      ? foregroundProcess
-      : null
+    nonShellForeground && !recognizeAgentProcess(foregroundProcess) ? foregroundProcess : null
   return {
     foregroundProcess:
       evidence.verdict === 'live'
         ? (evidence.processName ?? ordinaryForeground)
         : foregroundProcess,
-    hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess),
+    hasChildProcesses: nonShellForeground,
     foregroundProcessEvidence: evidence
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps an eye on each terminal tab so it knows what is running in it. The part that double-checks this was only taught to recognise coding assistants by name — Claude, Codex and friends. So when it looked at a tab busy running an everyday command like `sleep`, `vim` or `node`, it recognised nothing, and instead of answering "an ordinary command is running here" it wiped the name the terminal already knew and answered "nothing". The tab was still correctly marked as busy, so nothing broke visibly, but the "what is running" answer came back blank on Mac and Linux while the same tab over SSH answered correctly. Now, when the check comes back clean but spots no assistant, Orca keeps the everyday command name. Assistant names that really have finished are still cleared, and an idle shell still reports nothing running.

## What Changed

`inspectTerminalHostProcess` (`src/main/daemon/terminal-host-process-inspection.ts`) no longer lets a `verdict: 'live', processName: null` observation blank the PTY's own foreground name. When the evidence names no process, the PTY name is kept — unless it is a shell or a recognised agent, both of which keep today's clearing behaviour.

New test file `src/main/daemon/terminal-host-non-agent-foreground.test.ts` covers `sleep` / `vim` / `node` on Linux and macOS, a stale `claude` after its process exits, and an idle `bash`.

## Why

`resolveRemoteForegroundEvidenceFromRows` deliberately reports only *recognised agents* in `processName` (`src/main/providers/agent-foreground-process-remote-evidence.ts:121`), because that field carries a pid/start-time fence used for agent liveness. A successful capture of a pane running `sleep 300` therefore returns `verdict: 'live', processName: null` — which the daemon was reading as "nothing is in the foreground" rather than "no *agent* is in the foreground".

This is a **regression fix, not a new behaviour**. Immediately before #18078, `TerminalHost.inspectProcess` was:

```ts
const foregroundProcess = this.getAliveSession(sessionId).getForegroundProcess()
return {
  foregroundProcess,
  hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess)
}
```

(`git show d5803bdbc4c -- src/main/daemon/terminal-host.ts`). The raw PTY name — `sleep`, `vim`, `node` included — *was* the answer. #18078 routed the field through the new evidence resolver and silently dropped every name the resolver did not recognise as an agent.

Three more things confirm the blanking was a side effect rather than a contract:

1. The very next line of the same return, `hasChildProcesses: foregroundProcess !== null && !isShellProcess(foregroundProcess)`, still trusts the PTY name and returned `true` for the exact command whose name was being erased. `{ foregroundProcess: null, hasChildProcesses: true }` is self-contradictory.
2. **The relay host never lost the name.** `src/relay/pty-handler.ts:2738` resolves the same evidence with `evidence.processName ?? managed.pty.process`. The local daemon was the only host that dropped it.
3. **Local Windows never lost it either**, because `resolveRemoteForegroundEvidenceFromRows` short-circuits to `unverifiable` on `win32` and never reaches the blanking branch. The blank answer was specific to local macOS/Linux.

One concrete consequence being restored: `isCodexRestartEligiblePane` (`src/renderer/src/lib/codex-pane-restart-eligibility.ts:44-65`) returns early on `foregroundProcess === null`. An npm-wrapped Codex pane surfaces as `node`, which that function accepts via `isAgentForegroundWrapperProcess`. Since #18078 it saw `null` instead and the account-switch restart card could not appear; it can again.

The fix is deliberately kept in the daemon consumer rather than in the resolver: widening `processName` to include non-agent commands would change what the host publishes on `RemoteForegroundEvidence`, and that reaches older clients with no wire change at all (`docs/reference/remote-wire-compatibility.md`). The evidence payload emitted here is byte-identical to before.

Scope note: #18078 also blanked the **idle-shell** name (pre-#18078 this field returned `bash`). This PR deliberately does *not* restore that half — shell-foreground readings feed agent-exit conclusions, and the renderer already has a settling path for the `null` case (`pane-agent-identity.ts:193` → `settleDeferredCommandFinishedStatusDrop`). Left as a separate question.

The fix is deliberately kept in the daemon consumer rather than in the resolver: widening `processName` to include non-agent commands would change what the host publishes on `RemoteForegroundEvidence`, and that reaches older clients with no wire change at all (`docs/reference/remote-wire-compatibility.md`). The evidence payload emitted here is byte-identical to before.

## Linked Issue

No linked issue. Found while validating #18780; the npm Codex wrapper ambiguity noted there is a separate limitation and is not addressed here.

## Visual Proof

`N/A` — no rendered UI changed, and no screenshot would differ. The pane/tab agent identity is published only when `recognizeAgentProcess` matches (`src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts:161-176`); an ordinary name like `sleep` is not an agent, so the tab icon and title are identical before and after. The change is observable only in the `pty:inspectProcess` payload and in poll cadence, neither of which renders. Local Electron launches are paused on this branch in any case; CI covers the Electron suites.

## Tradeoffs

Real, concrete costs. Verified against every consumer of `TerminalHostProcessInspection.foregroundProcess`:

- **Extra inspection round-trips while an ordinary command runs (the main cost).** In `pane-foreground-agent-tracker.ts:186-197`, a non-null foreground name with `reason === 'command'` arms the bounded wrapper-resolve ladder (`[1200, 6000]` ms). A local macOS/Linux pane that starts a command lasting longer than ~1.2s now issues up to 2 extra `pty:inspectProcess` calls that it previously skipped, each riding the TTL-cached `ps` table. Short commands are unaffected because OSC `133;D` cancels the pending read. Local Windows already paid this; this makes POSIX match it.
- **A one-tick stale name window.** node-pty's foreground name and the `ps` capture are read at slightly different instants. If an ordinary command exits in between, the pane reports the just-exited command name for a single poll instead of `null`. Self-corrects next tick, and the fenced `foregroundProcessEvidence` member still says `processName: null`, so anything reading the evidence rather than the compatibility field is unaffected.
- **Asymmetric staleness handling.** A live/null observation still clears recognised agent names but no longer clears ordinary ones, so ordinary commands have weaker exit detection than agents do. Bounded by node-pty's POSIX foreground name being live (`tcgetpgrp`), not cached — the tracker's sticky cache only ever holds recognised agent names (`src/main/daemon/pty-subprocess/foreground-process-tracker.ts:196`).
- **One narrow `command-finished` edge case changes shape.** If OSC `133;D` arrives while a non-shell command still holds the foreground (nested shell without integration), the tracker now takes the `!isShellProcess(processName)` arm at `pane-foreground-agent-tracker.ts:245` instead of the `processName === null` arm at `:227`. With prior agent evidence it settles `inconclusive` rather than calling `onCommandFinishedUnavailable`; with none it publishes `shellForeground: true`. Rare, and the newly available real command name is better input than `null`, but it is a genuine behaviour delta in adjacent code.
- **Residual host divergence, narrowed but not closed.** For an *idle shell* the relay still returns `bash` where the local daemon returns `null`. This PR does not unify that.
- **The ordinary name can still be hidden for up to 1s.** The tracker's agent-identity cache has a 1s TTL (`foreground-process-tracker.ts:28,242-246`), so right after an agent exits and an ordinary command starts, `getForegroundProcess()` may still return the cached agent name, which this code then nulls. The ordinary name only appears once the TTL lapses. An overlay on `rawFallback: true` would close it; deliberately not done here to keep the diff to the regression.
- **Pre-existing gap this does not fix:** `isShellProcess` does not strip a login shell's leading dash, so a user-started nested `-bash` / `-zsh` would now be reported as an ordinary command. Orca's own panes are unaffected — it spawns `bash -l` as an args array (`shell-launch-plan.ts:212`), not a dash-prefixed `argv[0]` — and `hasChildProcesses` already returned `true` in that case before this PR, so the busy state was already asserted.

Explicitly checked and **not** affected:

- Close / cleanup confirmations. `pty-running-work-probe.ts:117-133`, `running-terminal-close-guard.ts:126-136` and `window-close-running-work.ts:63` gate on `hasChildProcesses` / `childProcessEvidence`, never on `foregroundProcess`. No new "still running?" prompts.
- Agent-completion notifications. `agent-completion-inspection-result.ts:131` only fires `process-exit` when `!result.hasChildProcesses`, which was already `false` for these panes.
- Text-injection gates (`agent-ready-wait.ts:96`, `agent-paste-draft.ts:311`, `agent-followup-delivery.ts:45`) match positively on the *expected agent* name; `sleep` fails that test exactly as `''` did.
- SSH / remote panes. The renderer reads `admitted.processName` from the evidence for remote PTYs (`pane-foreground-process-reader.ts:52-70`) and ignores the compatibility field, so remote behaviour is untouched.
- Wire compatibility, security, resource use. No field added or changed, no new input parsed, no new process forked; the added work is one `Map` lookup per full-tier inspection.

## Testing

- `pnpm tc` — pass (exit 0)
- `vitest run src/main/daemon/terminal-host-non-agent-foreground.test.ts src/main/daemon/terminal-host-process-inspection.test.ts src/main/daemon/terminal-host-process-inspection-cheap-tier.test.ts src/main/daemon/terminal-host-cheap-tier-ps-scan-volume.test.ts` — **4 files / 25 tests pass**
- `oxlint` on both changed files — clean
- **Bug reproduced first.** Reverting only the production hunk and re-running the new suite gives **6 failed / 4 passed**: the six `sleep`/`vim`/`node` × Linux/macOS cases fail, while the stale-`claude` and idle-`bash` cases still pass. That is the intended shape — the new tests guard the regression and do not restate unchanged behaviour.
- Platforms: Linux and macOS are unit-covered via `process.platform` spies. Windows never reaches the new branch (`resolveRemoteForegroundEvidenceFromRows` returns `unverifiable` on `win32`). The SSH/relay path is not touched by this diff.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — see the "explicitly checked" list under Tradeoffs. The one cost to weigh is the extra wrapper-resolve ladder reads for long-running ordinary commands on local POSIX panes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
