### PR TITLE
test: isolate native crash restoration and refresh stale fixtures

### DIFF
--- a/tests/e2e/electron-home-isolation.spec.ts
+++ b/tests/e2e/electron-home-isolation.spec.ts
@@ -1,4 +1,5 @@
 import type { ElectronApplication } from '@stablyai/playwright-test'
+import { realpathSync } from 'node:fs'
 import path from 'node:path'
 import { expect, test } from './helpers/orca-app'
 
@@ -23,7 +24,7 @@ async function readElectronHomeState(electronApp: ElectronApplication) {
 // HOME boundary and that real-home routing lands inside the disposable profile.
 test('isolates Electron and Codex from the developer home by default', async ({ electronApp }) => {
   const state = await readElectronHomeState(electronApp)
-  const expectedHome = path.join(state.userDataDir!, 'home')
+  const expectedHome = realpathSync.native(path.join(state.userDataDir!, 'home'))
 
   expect(state.appHome).toBe(expectedHome)
   expect(state.nodeHome).toBe(expectedHome)

--- a/tests/e2e/feature-wall.spec.ts
+++ b/tests/e2e/feature-wall.spec.ts
@@ -179,9 +179,40 @@ test.describe('Feature tour modal', () => {
   })
 
   test('does not pre-check configured workflows until the user visits them', async ({
-    orcaPage
+    orcaPage,
+    electronApp
   }) => {
-    await orcaPage.evaluate(() => {
+    await electronApp.evaluate(
+      ({ ipcMain }, preflightStatus) => {
+        ipcMain.removeHandler('preflight:check')
+        ipcMain.handle('preflight:check', () => preflightStatus)
+        ipcMain.removeHandler('linear:status')
+        ipcMain.handle('linear:status', () => ({ connected: false, viewer: null }))
+        ipcMain.removeHandler('jira:status')
+        ipcMain.handle('jira:status', () => ({ connected: false, viewer: null }))
+      },
+      {
+        git: { installed: true },
+        gh: { installed: true, authenticated: true },
+        glab: { installed: false, authenticated: false },
+        bitbucket: { configured: false, authenticated: false, account: null },
+        azureDevOps: {
+          configured: false,
+          authenticated: false,
+          account: null,
+          baseUrl: null,
+          tokenConfigured: false
+        },
+        gitea: {
+          configured: false,
+          authenticated: false,
+          account: null,
+          baseUrl: null,
+          tokenConfigured: false
+        }
+      }
+    )
+    await orcaPage.evaluate(async () => {
       for (const key of [
         'orca.featureWall.visitedWorkflows.v1',
         'orca.featureWall.visitedAgentSteps.v1',
@@ -198,32 +229,12 @@ test.describe('Feature tour modal', () => {
       if (!store) {
         throw new Error('window.__store is not available')
       }
-      store.setState({
-        preflightStatus: {
-          git: { installed: true },
-          gh: { installed: true, authenticated: true },
-          glab: { installed: false, authenticated: false },
-          bitbucket: { configured: false, authenticated: false, account: null },
-          azureDevOps: {
-            configured: false,
-            authenticated: false,
-            account: null,
-            baseUrl: null,
-            tokenConfigured: false
-          },
-          gitea: {
-            configured: false,
-            authenticated: false,
-            account: null,
-            baseUrl: null,
-            tokenConfigured: false
-          }
-        },
-        preflightStatusChecked: true,
-        preflightStatusLoading: false,
-        linearStatus: { connected: false, viewer: null },
-        linearStatusChecked: true
-      })
+      // Seed through the status actions so each result gets the current execution context.
+      await Promise.all([
+        store.getState().refreshPreflightStatus({ force: true }),
+        store.getState().checkLinearConnection(true),
+        store.getState().checkJiraConnection()
+      ])
       store.getState().openModal('feature-wall', { source: 'help_menu' })
     })
 

--- a/tests/e2e/github-url-smart-input-transition.spec.ts
+++ b/tests/e2e/github-url-smart-input-transition.spec.ts
@@ -203,6 +203,12 @@ async function installHeldGitLabLookup(
         __releaseGitLabUrlLookup?: () => void
       }
       fixture.__gitlabUrlLookupStarted = false
+      ipcMain.removeHandler('preflight:check')
+      ipcMain.handle('preflight:check', () => ({
+        git: { installed: true },
+        gh: { installed: true, authenticated: true },
+        glab: { installed: true, authenticated: true }
+      }))
       ipcMain.removeHandler('gitlab:listMRs')
       ipcMain.handle('gitlab:listMRs', () => ({
         items: [wrongItem],
@@ -221,23 +227,12 @@ async function installHeldGitLabLookup(
     },
     { wrongItem: GITLAB_WRONG_ITEM, targetItem: GITLAB_TARGET_ITEM }
   )
-  await page.evaluate(() => {
+  await page.evaluate(async () => {
     const store = window.__store
     if (!store) {
       throw new Error('window.__store is not available')
     }
-    const state = store.getState()
-    if (!state.preflightStatusContextKey) {
-      throw new Error('preflight context is not ready')
-    }
-    store.setState({
-      preflightStatus: {
-        git: state.preflightStatus?.git ?? { installed: true },
-        gh: state.preflightStatus?.gh ?? { installed: true, authenticated: true },
-        glab: { installed: true, authenticated: true }
-      },
-      preflightStatusChecked: true
-    })
+    await store.getState().refreshPreflightStatus({ force: true })
   })
 }
 

--- a/tests/e2e/helpers/electron-launch-args.ts
+++ b/tests/e2e/helpers/electron-launch-args.ts
@@ -7,6 +7,10 @@ export function getOrcaElectronLaunchArgs(mainPath: string, headful: boolean): s
   // these Chromium switches startup can block before the first renderer target.
   const keychainArgs =
     process.platform === 'darwin' ? ['--password-store=basic', '--use-mock-keychain'] : []
+  if (process.platform === 'darwin') {
+    // Crash tests must not block later launches on AppKit's saved-window recovery dialog.
+    return [...keychainArgs, appPath, '-ApplePersistenceIgnoreState', 'YES']
+  }
   if (headful || process.platform !== 'linux') {
     return [...keychainArgs, appPath]
   }

--- a/tests/e2e/helpers/electron-launch-args.unit.test.ts
+++ b/tests/e2e/helpers/electron-launch-args.unit.test.ts
@@ -8,10 +8,17 @@ describe('getOrcaElectronLaunchArgs', () => {
     const mainPath = join(root, 'out', 'main', 'index.js')
 
     const args = getOrcaElectronLaunchArgs(mainPath, true)
-    expect(args.at(-1)).toBe(root)
     if (process.platform === 'darwin') {
-      expect(args.slice(0, -1)).toEqual(['--password-store=basic', '--use-mock-keychain'])
+      expect(args).toEqual([
+        '--password-store=basic',
+        '--use-mock-keychain',
+        root,
+        '-ApplePersistenceIgnoreState',
+        'YES'
+      ])
+    } else {
+      expect(args.at(-1)).toBe(root)
     }
-    expect(getOrcaElectronLaunchArgs(mainPath, false).at(-1)).toBe(root)
+    expect(getOrcaElectronLaunchArgs(mainPath, false)).toContain(root)
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

macOS crash tests can leave Electron's native saved-window recovery prompt blocking every later launch before `app.ready`. Disable native window restoration for test processes with the per-launch `ApplePersistenceIgnoreState` argument. Orca's own session restore still runs; no developer defaults are changed.

Also canonicalize the expected isolated home path and seed the feature-tour provider results through IPC/status actions, so the fixture carries the current execution context and cannot be overwritten by real provider checks. The GitLab URL-paste fixture also awaits scoped preflight instead of racing the initial check. Completion and per-frame stale-result assertions remain intact.

Validation: 20 Electron cases passed across two fresh runs of home isolation, feature tour, and floating Markdown rename/restart. Both GitHub/GitLab URL-paste cases passed three fresh runs (6 more cases). The launch-argument unit test and targeted lint passed. Before the launch fix, a native process sample showed `NSPersistentUIRestorer` blocked in `NSAlert runModal`; the previously blocked rename cases pass afterward.
