### PR TITLE
fix: reseed emptied workspaces after agent inventory settles

### DIFF
--- a/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
+++ b/src/renderer/src/lib/worktree-activation-emptied-workspace-reseed.test.ts
@@ -26,6 +26,27 @@ function seedClosedLastTerminal(worktreeId: string): void {
 }
 
 describe('activating a workspace whose last terminal was closed', () => {
+  it('re-seeds after the asynchronous agent inventory confirms the workspace is empty', async () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+    seedClosedLastTerminal(worktree.id)
+    useAppStore.setState({
+      workspaceSessionReady: true,
+      terminalStartupRestorationReady: true
+    })
+    vi.stubGlobal('window', {
+      api: {
+        runtime: { call: vi.fn(async () => ({ ok: true, result: { snapshots: [] } })) },
+        pty: { listSessions: vi.fn(async () => []) }
+      }
+    })
+
+    activateAndRevealWorktree(worktree.id, { notifyHostRuntime: false })
+    await waitForWorktreeAgentActivationGateForTests(worktree.id)
+
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+  })
+
   it('re-seeds a terminal when the workspace is opened from elsewhere', () => {
     const worktree = makeWorktree()
     seedEmptyActivatableWorktree(worktree)

--- a/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
+++ b/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
@@ -23,7 +23,10 @@ const SURFACE_PROVIDING_CALLERS = [
 ]
 
 // The activation seam itself: declares the option and forwards it into the tombstone gate.
-const SEAM_FILES = ['src/renderer/src/lib/worktree-activation.ts']
+const SEAM_FILES = [
+  'src/renderer/src/lib/worktree-activation.ts',
+  'src/renderer/src/lib/worktree-initial-terminal-seeding.ts'
+]
 
 function listSourceFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -1,4 +1,3 @@
-import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
 import type {
   WorktreeDefaultTabsLaunch,
   WorktreeSetupLaunch
@@ -30,7 +29,10 @@ import type { ExecutionHostId } from '../../../shared/execution-host'
 import { findFolderWorkspaceOwner } from './folder-workspace-runtime-owner'
 import type { WorktreeStartupPayload } from '@/lib/worktree-startup-payload'
 import type { IssueCommandLaunch } from '@/lib/worktree-setup-issue-command-queue'
-import { ensureWorktreeHasInitialTerminal } from '@/lib/worktree-initial-terminal-seeding'
+import {
+  ensureFolderWorkspaceInitialTerminal,
+  ensureWorktreeHasInitialTerminal
+} from '@/lib/worktree-initial-terminal-seeding'
 import { ensureWebRuntimeWorktreeTerminalAfterWake } from '@/lib/web-runtime-worktree-terminal-after-wake'
 import { applyWorktreeNavViewEntry } from '@/lib/worktree-nav-view-history-replay'
 
@@ -43,28 +45,6 @@ export type ActivateAndRevealResult = {
   /** Id of the primary terminal tab seeded with `opts.startup`, or null. Prefer this over
    *  `activeTabIdByWorktree`, which may point at another tab if setup/issue scripts opened their own. */
   primaryTabId: string | null
-}
-
-function ensureFolderWorkspaceInitialTerminal(
-  folderWorkspace: FolderWorkspace,
-  startup?: WorktreeStartupPayload,
-  providesInitialSurface?: boolean
-): string | null {
-  if (providesInitialSurface === true && startup === undefined) {
-    return null
-  }
-  const state = useAppStore.getState()
-  const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
-  const primaryTabId = ensureWorktreeHasInitialTerminal(
-    state,
-    workspaceKey,
-    startup,
-    undefined,
-    undefined,
-    undefined,
-    { reseedEmptiedWorkspace: providesInitialSurface !== true }
-  )
-  return primaryTabId
 }
 
 function canInspectAgentActivationInventory(): boolean {
@@ -270,7 +250,15 @@ export function activateAndRevealWorktree(
         opts?.providesInitialSurface !== true &&
         currentState.activeWorktreeId === worktreeId
       ) {
-        ensureWorktreeHasInitialTerminal(currentState, worktreeId)
+        ensureWorktreeHasInitialTerminal(
+          currentState,
+          worktreeId,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          { reseedEmptiedWorkspace: true }
+        )
       }
     })
   }

--- a/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
+++ b/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
@@ -225,16 +225,13 @@ export function ensureFolderWorkspaceInitialTerminal(
   if (providesInitialSurface === true && startup === undefined) {
     return null
   }
-  const state = useAppStore.getState()
-  const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
-  const primaryTabId = ensureWorktreeHasInitialTerminal(
-    state,
-    workspaceKey,
+  return ensureWorktreeHasInitialTerminal(
+    useAppStore.getState(),
+    folderWorkspaceKey(folderWorkspace.id),
     startup,
     undefined,
     undefined,
     undefined,
     { reseedEmptiedWorkspace: providesInitialSurface !== true }
   )
-  return primaryTabId
 }

--- a/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
+++ b/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
@@ -1,3 +1,5 @@
+import type { FolderWorkspace } from '../../../shared/folder-workspace-types'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
 import type {
   WorktreeDefaultTabsLaunch,
   WorktreeSetupLaunch
@@ -213,4 +215,26 @@ export function ensureWorktreeHasInitialTerminal(
   )
 
   return terminalTab.id
+}
+
+export function ensureFolderWorkspaceInitialTerminal(
+  folderWorkspace: FolderWorkspace,
+  startup?: WorktreeStartupPayload,
+  providesInitialSurface?: boolean
+): string | null {
+  if (providesInitialSurface === true && startup === undefined) {
+    return null
+  }
+  const state = useAppStore.getState()
+  const workspaceKey = folderWorkspaceKey(folderWorkspace.id)
+  const primaryTabId = ensureWorktreeHasInitialTerminal(
+    state,
+    workspaceKey,
+    startup,
+    undefined,
+    undefined,
+    undefined,
+    { reseedEmptiedWorkspace: providesInitialSurface !== true }
+  )
+  return primaryTabId
 }

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -269,7 +269,7 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
 
     const expectedRecovery = {
       origin: 'live',
-      state: 'working',
+      state: 'done',
       providerSessionId: PROVIDER_SESSION_ID
     }
     await expect


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Orca lets you close the last terminal in a workspace, and it remembers you did that on purpose so it doesn't keep popping a new one back at you. But when you later click that workspace open again, you're asking for it back — so you should get a fresh terminal.

That only worked some of the time. When Orca first had to check in the background whether any agent sessions were still running there, the check came back "nothing running" and then Orca forgot the last step: actually creating the terminal. You clicked the workspace and got a blank screen with nothing to type into, and had to add a terminal by hand.

The background check now finishes the job the same way the normal path already did, so opening an emptied workspace gives you a usable terminal either way.


Opening a workspace after its last terminal is retired can leave a blank workspace. The asynchronous agent-inventory check correctly reports no sessions, but its continuation omits `reseedEmptiedWorkspace`, so the closed-tab tombstone prevents the fallback terminal from being created.

Pass the same reseeding option used by normal explicit activation after the inventory gate reports empty. Move the existing folder seeding helper into the terminal-seeding module to keep the activation module within its line limit; folder behavior is unchanged. Correct the worker-retirement E2E setup expectation to `done`, matching its explicit done event and the durable recovery contract.

Validation: the new asynchronous-inventory regression fails before the fix; 27 focused unit tests pass afterward, including folder and remote activation cases. Targeted lint and `pnpm tc:web` pass. The existing worker-retirement E2E reproduced the blank workspace before the fix. A separate e2e build now passes both retirement modes; two further runs of both modes plus the whole-tab close/restart scenario passed (8 rendered cases total).

Application behavior change: left open for user review; do not merge automatically.


Reliability: `agent-session.provider-ownership` covers the invariant that explicit activation may seed an emptied workspace only after session inventory resolves empty; existing sessions still retain ownership. The new unit oracle controls the asynchronous inventory and asserts terminal creation, while the rendered oracle closes/retires terminals and reopens the workspace. No new polling, provider scans, timers, or subprocesses were added. macOS local/daemon behavior is covered by the eight rendered cases; folder and remote activation branches have focused unit coverage. Rendered Linux, Windows, SSH, WSL, and mobile/relay validation remain gaps. Playwright traces and the asynchronous inventory regression provide failure diagnostics.

## Tradeoffs

These are the genuine user-facing costs of making the gated path re-seed:

- **Reopening a deliberately-emptied workspace now always costs a shell.** The seeded tab carries `pendingActivationSpawn`, so a PTY is spawned. On an SSH or relay host that is a *remote* shell process on the server, not just a local one. In the gated path you previously got nothing and paid nothing.
- **A workspace can no longer be kept empty as a "bookmark."** Users who close the last terminal and reopen the workspace only to read a diff or browse files get a terminal back on every open, unless the entry point opts out via `providesInitialSurface`.
- **Narrow ordering race on slow inventory.** The continuation only re-checks that the workspace is still active — not which view is showing. If the inventory RPC is slow and you switch to a non-terminal surface *inside the same workspace* during that window, the seeded terminal can still appear and take tab focus. Bounded, not eliminated: seeding re-reads `renderableTabCount` and bails if any surface appeared meanwhile, and bails entirely when the execution host owns terminal creation (`hostAuthority === 'live'`), which covers the live-remote case.
- **Slightly larger unhandled-rejection surface.** `gateWorktreeAgentActivation(...).then(...)` still has no `.catch()` (pre-existing on both call sites), and the continuation now does more work — tab creation plus store writes — inside it. A throw there becomes an unhandled rejection instead of a no-op.
- **Regression risk is concentrated in one flag.** The behavior difference is entirely `reseedEmptiedWorkspace: true` on one call. The blast radius is every non-`providesInitialSurface` activation that hits the async agent-inventory gate, which is the common sidebar/palette open path — high traffic, so a mistake here would be widely felt even though the change is one line.

Not affected: no wire/RPC/IPC payload, persisted schema, or platform-specific code changes; folder-workspace behavior is unchanged (that path already passed the flag).

## Visual Proof

N/A — no rendered UI surface changes. The fix restores an existing code path
(creating the workspace's fallback terminal); it introduces no new component,
layout, styling, or copy. Local Electron launches are paused for this task per
AGENTS.md, so rendered validation is deferred to CI, where the existing
`completed-worker-retirement-resume` e2e spec covers the reopen-after-retirement
flow that originally exposed the blank workspace.

## Note: why the e2e expectation moves to `done`

`tests/e2e/completed-worker-retirement-resume.spec.ts` drives `setAgentStatus`
twice on the same pane key — `working`, then `done` — and asserted the recovery
record stayed `working`. That was correct until #16308 ("stop ghost resume tabs
after finished turns", `c60d2ba8958`) added `existing.state === next.state` to
`recoveryRecordMatches`
(`src/renderer/src/store/slices/agent-status-recovery-equivalence.ts`), so the
`done` update now correctly replaces the `working` checkpoint.

That same commit already flipped this expectation in the sibling unit test
`tests/e2e/completed-worker-retirement-resume.unit.test.ts`, but missed the
Playwright spec's copy — this spec only runs when it changes, so the stale
expectation went unnoticed. Recording `done` is the desired behavior: it is what
marks passive completed hibernation evidence and suppresses auto-resume, which is
exactly what this spec's later assertions (`resumeClaimCount: 0`, no `--resume`)
require. Nothing on this branch touches the `agent-status-*` slices.
