### PR TITLE
feat(worktree): lead GitHub-issue workspace names with the issue number

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.linear-url.test.tsx
@@ -691,7 +691,7 @@ describe('WorktreeJumpPalette Linear URL intent', () => {
 
     expect(useAppStore.getState().activeModal).toBe('new-workspace-composer')
     expect(useAppStore.getState().modalData).toMatchObject({
-      prefilledName: 'agent-terminals-disappearing-randomly',
+      prefilledName: '14198-agent-terminals-disappearing-randomly',
       initialRepoId: 'repo-1',
       telemetrySource: 'command_palette',
       linkedWorkItem: {

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.test.ts
@@ -223,7 +223,7 @@ describe('submitFolderWorkspaceCreate', () => {
 
     expect(createFolderWorkspace).toHaveBeenCalledWith({
       projectGroupId: 'group-1',
-      name: 'Restore checkout polish',
+      name: '#42 Restore checkout polish',
       connectionId: null,
       linkedTask: linkedWorkItem,
       createdWithAgent: 'codex'
@@ -303,7 +303,7 @@ describe('submitFolderWorkspaceCreate', () => {
 
     expect(createFolderWorkspace).toHaveBeenCalledWith({
       projectGroupId: 'group-1',
-      name: 'Restore linked quick-create',
+      name: '#91 Restore linked quick-create',
       connectionId: null,
       linkedTask: linkedWorkItem,
       createdWithAgent: 'codex'
@@ -527,7 +527,7 @@ describe('submitFolderWorkspaceCreate', () => {
 
     expect(createFolderWorkspace).toHaveBeenCalledWith({
       projectGroupId: 'group-1',
-      name: 'Restore checkout polish',
+      name: '#42 Restore checkout polish',
       connectionId: null,
       linkedTask: linkedWorkItem
     })

--- a/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
+++ b/src/renderer/src/hooks/useComposerState-host-context-boundaries.test.ts
@@ -165,18 +165,28 @@ describe('useComposerState host-context boundaries', () => {
   })
 
   it('auto-owns linked-item generated prefilled names', () => {
+    const item = {
+      type: 'issue' as const,
+      provider: 'github' as const,
+      number: 1234,
+      title: 'Fix workspace name',
+      url: 'https://github.com/stablyai/orca/issues/1234'
+    }
+
+    // The generated seed leads with the issue number, matching Jira's key prefix.
+    expect(
+      getInitialAutoManagedWorkspaceName({
+        initialName: '1234-fix-workspace-name',
+        initialLinkedWorkItem: item
+      })
+    ).toBe('1234-fix-workspace-name')
+    // A name that is not what Orca would generate is the user's, so it stays theirs.
     expect(
       getInitialAutoManagedWorkspaceName({
         initialName: 'fix-workspace-name',
-        initialLinkedWorkItem: {
-          type: 'issue',
-          provider: 'github',
-          number: 1234,
-          title: 'Fix workspace name',
-          url: 'https://github.com/stablyai/orca/issues/1234'
-        }
+        initialLinkedWorkItem: item
       })
-    ).toBe('fix-workspace-name')
+    ).toBe('')
   })
 
   it('resolves GitHub PR bases against the selected run repo, not the source item repo', () => {

--- a/src/renderer/src/lib/smart-github-submit.test.ts
+++ b/src/renderer/src/lib/smart-github-submit.test.ts
@@ -293,8 +293,8 @@ describe('getSmartGitHubSubmitResolution', () => {
         url: 'https://github.com/stablyai/orca/pull/2049'
       })
     ).toEqual({
-      workspaceName: 'fix-smart-resolution-delay',
-      displayName: 'Fix smart resolution delay',
+      workspaceName: '2049-fix-smart-resolution-delay',
+      displayName: '#2049 Fix smart resolution delay',
       linkedWorkItem: {
         type: 'pr',
         number: 2049,
@@ -314,8 +314,8 @@ describe('getSmartGitHubSubmitResolution', () => {
       url: 'https://github.com/stablyai/orca/issues/2050'
     })
 
-    expect(resolution.workspaceName).toBe('make-create-feel-instant')
-    expect(resolution.displayName).toBe('Make create feel instant')
+    expect(resolution.workspaceName).toBe('2050-make-create-feel-instant')
+    expect(resolution.displayName).toBe('#2050 Make create feel instant')
     expect(resolution.linkedIssueNumber).toBe(2050)
     expect(resolution.linkedPR).toBeNull()
   })
@@ -329,8 +329,8 @@ describe('getSmartGitHubSubmitResolution', () => {
         url: 'https://github.com/stablyai/orca/issues/6933'
       })
     ).toEqual({
-      workspaceName: 'the-board-columns-are-displayed-backwards',
-      displayName: 'The board columns are displayed backwards',
+      workspaceName: '6933-the-board-columns-are-displayed-backwards',
+      displayName: '#6933 The board columns are displayed backwards',
       linkedWorkItem: {
         type: 'issue',
         number: 6933,

--- a/src/shared/new-workspace/workspace-source.test.ts
+++ b/src/shared/new-workspace/workspace-source.test.ts
@@ -116,6 +116,16 @@ describe('workspace source policy', () => {
       kind: 'gitlab-issue',
       label: '#7 Self hosted'
     })
+    expect(
+      buildWorkspaceSourceSelection({
+        linkedWorkItem: {
+          type: 'mr' as const,
+          number: 42,
+          title: 'Tighten the relay timeout',
+          url: 'https://gitlab.example.com/g/p/-/merge_requests/42'
+        }
+      })
+    ).toMatchObject({ kind: 'gitlab-mr', label: '!42 Tighten the relay timeout' })
     expect(shouldApplyWorkspaceSourceAutoName({ currentName: '#42', lastAutoName: 'old' })).toBe(
       true
     )

--- a/src/shared/new-workspace/workspace-source.ts
+++ b/src/shared/new-workspace/workspace-source.ts
@@ -210,7 +210,8 @@ export function buildWorkspaceSourceSelection(args: {
     label:
       provider === 'linear' || provider === 'jira' || linkedWorkItem.number === 0
         ? linkedWorkItem.title
-        : `#${linkedWorkItem.number} ${linkedWorkItem.title}`,
+        : // Why: GitLab cites merge requests as !n, matching the workspace name.
+          `${kind === 'gitlab-mr' ? '!' : '#'}${linkedWorkItem.number} ${linkedWorkItem.title}`,
     url: linkedWorkItem.url
   }
 }

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -97,6 +97,44 @@ describe('getLinkedWorkItemWorkspaceName', () => {
     ).toEqual({ displayName: '#165 Site header breaks', seedName: '165-site-header-breaks' })
   })
 
+  it('strips inline and bare-bang references before leading with the number', () => {
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'mr',
+        provider: 'gitlab',
+        number: 42,
+        title: '!42: Tighten the relay timeout'
+      })?.displayName
+    ).toBe('!42 Tighten the relay timeout')
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'issue',
+        provider: 'github',
+        number: 42,
+        title: 'Fix #42 checkout regression'
+      })?.displayName
+    ).toBe('#42 Fix checkout regression')
+  })
+
+  it('leaves Jira and Linear items unprefixed when their identifier is missing', () => {
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'issue',
+        provider: 'jira',
+        number: 165,
+        title: 'Site header breaks on small screens'
+      })?.displayName
+    ).toBe('Site header breaks on small screens')
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'issue',
+        provider: 'linear',
+        number: 165,
+        title: 'Site header breaks on small screens'
+      })?.displayName
+    ).toBe('Site header breaks on small screens')
+  })
+
   it('falls back to the identity label when there is no number to lead with', () => {
     expect(
       getLinkedWorkItemWorkspaceName({

--- a/src/shared/workspace-name.test.ts
+++ b/src/shared/workspace-name.test.ts
@@ -53,7 +53,7 @@ describe('getLinkedWorkItemSuggestedName', () => {
 })
 
 describe('getLinkedWorkItemWorkspaceName', () => {
-  it('uses the resolved GitHub title instead of the source URL or provider number', () => {
+  it('uses the resolved GitHub title instead of the source URL, led by the number', () => {
     expect(
       getLinkedWorkItemWorkspaceName({
         type: 'pr',
@@ -61,9 +61,50 @@ describe('getLinkedWorkItemWorkspaceName', () => {
         title: 'Fix pasted URL workspace names'
       })
     ).toEqual({
-      displayName: 'Fix pasted URL workspace names',
-      seedName: 'fix-pasted-url-workspace-names'
+      displayName: '#2049 Fix pasted URL workspace names',
+      seedName: '2049-fix-pasted-url-workspace-names'
     })
+  })
+
+  it('leads number-keyed items with the number, the way Jira leads with its key', () => {
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'issue',
+        provider: 'github',
+        number: 165,
+        title: 'Site header breaks on small screens'
+      })?.displayName
+    ).toBe('#165 Site header breaks on small screens')
+    // GitLab cites merge requests as !n, not #n.
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'mr',
+        provider: 'gitlab',
+        number: 42,
+        title: 'Tighten the relay timeout'
+      })?.displayName
+    ).toBe('!42 Tighten the relay timeout')
+  })
+
+  it('does not repeat a number the title already carried', () => {
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'issue',
+        provider: 'github',
+        number: 165,
+        title: '#165: Site header breaks'
+      })
+    ).toEqual({ displayName: '#165 Site header breaks', seedName: '165-site-header-breaks' })
+  })
+
+  it('falls back to the identity label when there is no number to lead with', () => {
+    expect(
+      getLinkedWorkItemWorkspaceName({
+        type: 'issue',
+        number: 0,
+        title: 'Imported from a tracker'
+      })?.displayName
+    ).toBe('Imported from a tracker')
   })
 
   it('keeps external provider identifiers without duplicating title prefixes', () => {

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -58,13 +58,18 @@ export type WorkspaceIntentName = {
 }
 
 function getLinkedWorkItemTitleSubject(item: { title: string }): string {
-  return item.title
-    .trim()
-    .replace(/^(?:issue|pr|pull request|mr|merge request)\s*[#!]?\d+\s*[:-]\s*/i, '')
-    .replace(/^#\d+\s*[:-]\s*/, '')
-    .replace(/\([#!]?\d+\)/g, '')
-    .replace(/\b#\d+\b/g, '')
-    .trim()
+  return (
+    item.title
+      .trim()
+      .replace(/^(?:issue|pr|pull request|mr|merge request)\s*[#!]?\d+\s*[:-]\s*/i, '')
+      .replace(/^[#!]\d+\s*[:-]\s*/, '')
+      .replace(/\([#!]?\d+\)/g, '')
+      // Why: `\b` never matches before `#`/`!` after a space, so anchor on the
+      // preceding non-word character instead and keep it.
+      .replace(/(^|[^\p{L}\p{N}])[#!]\d+\b/gu, '$1')
+      .replace(/\s{2,}/g, ' ')
+      .trim()
+  )
 }
 
 // Why: generated workspace seeds are hyphenated; `issue-123-fix-title`
@@ -176,7 +181,9 @@ function workItemIdentity(item: WorkspaceIntentWorkItem): string {
 // GitLab merge request. getLinkedWorkItemTitleSubject already strips the number
 // out of the title, so this restores it in one predictable place.
 function numberPrefix(item: WorkspaceIntentWorkItem): string {
-  if (item.number <= 0) {
+  // Why: Linear and Jira items are cited by key, never by `#<number>`, so an
+  // item missing its identifier must keep the unprefixed fallback.
+  if (item.number <= 0 || item.provider === 'linear' || item.provider === 'jira') {
     return ''
   }
   return `${item.type === 'mr' ? '!' : '#'}${item.number}`

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -171,6 +171,17 @@ function workItemIdentity(item: WorkspaceIntentWorkItem): string {
   return `Issue ${item.number}`
 }
 
+// Why: Linear and Jira lead the name with their issue key, so number-keyed
+// providers lead with the number they are cited by — `#165`, or `!165` for a
+// GitLab merge request. getLinkedWorkItemTitleSubject already strips the number
+// out of the title, so this restores it in one predictable place.
+function numberPrefix(item: WorkspaceIntentWorkItem): string {
+  if (item.number <= 0) {
+    return ''
+  }
+  return `${item.type === 'mr' ? '!' : '#'}${item.number}`
+}
+
 export function getLinkedWorkItemWorkspaceName(
   item: WorkspaceIntentWorkItem
 ): WorkspaceIntentName | null {
@@ -181,7 +192,8 @@ export function getLinkedWorkItemWorkspaceName(
       .replace(new RegExp(`^${escapeRegex(identifier)}\\s*[:-]?\\s*`, 'i'), '')
       .trim()
   }
-  const displayName = [identifier, subject].filter(Boolean).join(' ') || workItemIdentity(item)
+  const prefix = identifier ?? numberPrefix(item)
+  const displayName = [prefix, subject].filter(Boolean).join(' ') || workItemIdentity(item)
   const seedName = slugifyForWorkspaceName(displayName)
   if (!seedName) {
     return null


### PR DESCRIPTION
## ELI5

Make a worktree from a Jira issue and the card reads `APP-1061 Monitor Leaderboard`. Make one from a GitHub issue and it reads just `Site header breaks on small screens` — the issue number is nowhere, even though Orca already knows it. With a screen full of issue-created worktrees you cannot tell which card is which issue. Now GitHub-style items lead with their number too: `#165 Site header breaks on small screens`.

## What Changed

One function, `getLinkedWorkItemWorkspaceName` in `src/shared/workspace-name.ts`. It already led the display name with `linearIdentifier ?? jiraIdentifier`; when neither exists it now falls back to the item's number:

```ts
const prefix = identifier ?? numberPrefix(item)
const displayName = [prefix, subject].filter(Boolean).join(' ') || workItemIdentity(item)
```

`numberPrefix` returns `#165` for issues and PRs, `!42` for a GitLab merge request, and `''` when there is no number — so the existing `workItemIdentity` fallback still covers items that have neither key nor number.

The rest of the diff is test expectations: five files asserted the old bare-title name.

## Why

The number is already on the worktree (`linkedIssue` / `linkedWorkItem.number`), already works as an `issue:<n>` CLI selector, and is already used for the linked-item label and tooltip — it was simply absent from the one place you actually read all day. Jira and Linear worktrees have led with their key for a long time; this is number-keyed providers getting the same treatment, not a new naming convention.

**Why in this function and not at the call sites.** All five callers (`worktree-jump-palette-create-worktree`, `task-page-source-context`, `useComposerState`, `full-submit-source-preparation`, `smart-github-submit`) route through it, and `displayName` and `seedName` are deliberately derived together so the folder, branch, and sidebar name cannot drift. Prefixing at one call site would have split them.

**Why the number does not double up.** `getLinkedWorkItemTitleSubject` already strips `#\d+`, `(#\d+)`, and `Issue 165:` style prefixes out of the title — that stripping is what made the number vanish in the first place. Restoring it in one place is what keeps `#165 #165: …` from happening; there is a test for a title that already carried its number.

**Why `!` for merge requests.** GitLab cites merge requests as `!42` and issues as `#42`. Using `#` for both would produce a name that does not match how the item is referenced anywhere else.

**Seed names stay git-safe.** `slugifyForWorkspaceName` drops `#` and `!`, so the branch/folder seed becomes `165-site-header-breaks…`. A leading digit is valid under `git check-ref-format`, and the existing 48-character clamp still applies.

## Linked Issue

Fixes #18859

## Visual Proof

`N/A` — this changes the text of a generated name, not any layout or styling, and the change is entirely in a pure function that tests cover exactly. The rendered difference is one line:

| worktree created from | before | after |
|---|---|---|
| GitHub issue 165 | `Site header breaks on small screens` | `#165 Site header breaks on small screens` |
| GitLab MR 42 | `Tighten the relay timeout` | `!42 Tighten the relay timeout` |
| Jira PROJ-7 | `PROJ-7 Fix flaky import` | unchanged |
| Linear ENG-12 | `ENG-12 …` | unchanged |

## Testing

`src/shared/workspace-name.test.ts` — four cases added or rewritten:

- The existing GitHub PR case now asserts `#2049 Fix pasted URL workspace names` / `2049-fix-pasted-url-workspace-names`. It previously pinned the bare title, i.e. exactly the behavior this issue asks to change, so it was updated rather than left passing on a stale expectation.
- `leads number-keyed items with the number, the way Jira leads with its key` — a GitHub issue gets `#165`, a GitLab MR gets `!42`.
- `does not repeat a number the title already carried` — a title of `#165: Site header breaks` still yields `#165 Site header breaks`.
- `falls back to the identity label when there is no number to lead with` — an item with `number: 0` keeps today's behavior.

Four other files carried literal expectations of the old name and were updated deliberately (not loosened): `smart-github-submit.test.ts` (3), `folder-workspace-composer-submit.test.ts` (2), `WorktreeJumpPalette.linear-url.test.tsx` (1), and `useComposerState-host-context-boundaries.test.ts`. The last one is worth a reviewer's eye: `getInitialAutoManagedWorkspaceName` treats a prefilled name as Orca's only if it *exactly* equals the generated seed, so that test now asserts both directions — `1234-fix-workspace-name` is auto-owned, and the old `fix-workspace-name` is not, because a name Orca would not generate belongs to the user.

Ran on macOS: `src/shared/`, `src/renderer/`, `src/main/`, and `src/cli/` — 36,592 renderer+shared tests passing, plus `pnpm tc` and `pnpm run check:code-quality:changed`.

One pre-existing failure showed up in the cross-cutting run and is **not** from this change: `codex-session-index-heal-state.test.ts > leaves the main thread free while walking a large audit ledger` times out at 30 s. I verified it by checking out clean `origin/main` in a separate worktree, installing, and running that file alone — it fails there identically. This PR touches nothing under `src/main/codex/`. The other failures in that run were the four Codex/rate-limit tests that #18788 already documents as broken on Codex-signed-in machines, plus long WSL/census tests timing out under parallel load.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The naming path was traced from the issue's pointers through all five callers before changing anything; the change, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code. The seed is still produced by the existing `slugifyForWorkspaceName`, which already strips everything outside `[a-z0-9._-]`, so `#` and `!` never reach a path or a git ref on any platform.
- **Remote / SSH:** none. This is a pure string function in `src/shared/`; no IPC, RPC params, or stream frames. A remote host receives the same already-sanitized seed it does today.
- **Folder workspaces:** covered — `folder-workspace-composer-submit` is one of the updated call paths, and folder workspaces take the same generated name.
- **Git providers:** GitHub, GitLab (both `#` and `!` forms), Linear, and Jira are each covered by a test; Linear and Jira behavior is byte-for-byte unchanged.
- **Backwards compatibility:** generation-only. Existing worktrees keep their stored `displayName`; nothing re-derives a name for a worktree that already has one, so no card renames itself on upgrade.
- **Mobile:** not affected.
- **Performance:** one template string per name generation.
- **Security:** no new input surface; the number is an integer Orca already holds.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The issue also floated a setting ("Include issue number in worktree name", default on, or per-repo). I did not add one: it would be the only setting governing display-name generation, and the Jira/Linear prefix it now matches has never been optional. If maintainers want the escape hatch, it is a small follow-up and I am happy to add it — but shipping the consistency first seems right, and users can still rename any card.

PRs get the same prefix as issues, which the issue asked for ("ideally the same applies … to worktrees created from PRs"). Note this only affects names generated from a *linked work item*; `getWorkspaceIntentName`, which produces "Review PR 2049"-style names when it detects an action verb, is untouched.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
