### PR TITLE
perf(relay): drain fragmented frame buffers in linear time

### DIFF
--- a/config/scripts/relay-frame-buffer-benchmark.mjs
+++ b/config/scripts/relay-frame-buffer-benchmark.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { stripTypeScriptTypes } from 'node:module'
+import { performance } from 'node:perf_hooks'
+
+// Pass the pre-change source saved with git show <base>:src/shared/relay-frame-buffer.ts.
+const baselinePath = process.argv[2]
+if (!baselinePath)
+  throw new Error('Usage: node config/scripts/relay-frame-buffer-benchmark.mjs <baseline.ts>')
+async function load(source) {
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(stripTypeScriptTypes(source)).toString('base64')}`
+    )
+  ).RelayFrameBuffer
+}
+const Before = await load(readFileSync(baselinePath, 'utf8'))
+const After = await load(
+  readFileSync(new URL('../../src/shared/relay-frame-buffer.ts', import.meta.url), 'utf8')
+)
+function median(values) {
+  return values.sort((a, b) => a - b)[Math.floor(values.length / 2)]
+}
+for (const count of [1, 256, 16384, 65536]) {
+  const chunks = Array.from({ length: count }, (_, index) => Buffer.alloc(64, index % 256))
+  const expected = Buffer.concat(chunks)
+  for (const mode of ['take', 'discard']) {
+    const times = [[], []]
+    for (let round = 0; round < 9; round += 1) {
+      for (const arm of round % 2 === 0 ? [0, 1] : [1, 0]) {
+        const FrameBuffer = arm === 0 ? Before : After
+        const buffer = new FrameBuffer()
+        for (const chunk of chunks) buffer.append(chunk)
+        const start = performance.now()
+        const output = buffer[mode](expected.length)
+        times[arm].push(performance.now() - start)
+        if (mode === 'take') assert.deepEqual(output, expected)
+        assert.equal(buffer.length, 0)
+        buffer.append(Buffer.from('tail'))
+        assert.equal(buffer.drain().toString(), 'tail')
+      }
+    }
+    const beforeMs = median(times[0]),
+      afterMs = median(times[1])
+    console.log(
+      JSON.stringify({
+        mode,
+        chunks: count,
+        bytes: expected.length,
+        beforeMs,
+        afterMs,
+        speedup: beforeMs / afterMs
+      })
+    )
+  }
+}

--- a/config/scripts/relay-frame-buffer-benchmark.mjs
+++ b/config/scripts/relay-frame-buffer-benchmark.mjs
@@ -6,8 +6,9 @@ import { performance } from 'node:perf_hooks'
 
 // Pass the pre-change source saved with git show <base>:src/shared/relay-frame-buffer.ts.
 const baselinePath = process.argv[2]
-if (!baselinePath)
+if (!baselinePath) {
   throw new Error('Usage: node config/scripts/relay-frame-buffer-benchmark.mjs <baseline.ts>')
+}
 async function load(source) {
   return (
     await import(
@@ -31,11 +32,15 @@ for (const count of [1, 256, 16384, 65536]) {
       for (const arm of round % 2 === 0 ? [0, 1] : [1, 0]) {
         const FrameBuffer = arm === 0 ? Before : After
         const buffer = new FrameBuffer()
-        for (const chunk of chunks) buffer.append(chunk)
+        for (const chunk of chunks) {
+          buffer.append(chunk)
+        }
         const start = performance.now()
         const output = buffer[mode](expected.length)
         times[arm].push(performance.now() - start)
-        if (mode === 'take') assert.deepEqual(output, expected)
+        if (mode === 'take') {
+          assert.deepEqual(output, expected)
+        }
         assert.equal(buffer.length, 0)
         buffer.append(Buffer.from('tail'))
         assert.equal(buffer.drain().toString(), 'tail')

--- a/src/shared/relay-frame-buffer.test.ts
+++ b/src/shared/relay-frame-buffer.test.ts
@@ -33,7 +33,9 @@ describe('RelayFrameBuffer', () => {
   it('releases consumed references and amortizes storage compaction in a large backlog', () => {
     const buffer = new RelayFrameBuffer()
     const chunks = Array.from({ length: 32768 }, (_, index) => Buffer.from([index % 256]))
-    for (const chunk of chunks) buffer.append(chunk)
+    for (const chunk of chunks) {
+      buffer.append(chunk)
+    }
     const shifted = vi.spyOn(Array.prototype, 'shift')
     let shiftCount: number
     try {

--- a/src/shared/relay-frame-buffer.test.ts
+++ b/src/shared/relay-frame-buffer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RelayFrameBuffer } from './relay-frame-buffer'
+
+describe('RelayFrameBuffer', () => {
+  it('preserves a byte stream across fragmented peeks, takes, discards and drains', () => {
+    const buffer = new RelayFrameBuffer()
+    let expected = Buffer.alloc(0)
+    for (let step = 0; step < 5000; step += 1) {
+      const chunk = Buffer.from([step % 256, (step + 1) % 256, (step + 2) % 256])
+      buffer.append(chunk)
+      expected = Buffer.concat([expected, chunk])
+      if (step % 3 === 0) {
+        const count = Math.min(expected.length, 5)
+        expect(buffer.peek(count).subarray(0, count)).toEqual(expected.subarray(0, count))
+        expect(buffer.take(count)).toEqual(expected.subarray(0, count))
+        expected = expected.subarray(count)
+      }
+      if (step % 7 === 0) {
+        const count = Math.min(expected.length, 4)
+        buffer.discard(count)
+        expected = expected.subarray(count)
+      }
+      if (step % 101 === 0) {
+        expect(buffer.drain()).toEqual(expected)
+        expected = Buffer.alloc(0)
+      }
+      expect(buffer.length).toBe(expected.length)
+    }
+    expect(buffer.drain()).toEqual(expected)
+    expect(buffer.drain()).toEqual(Buffer.alloc(0))
+  })
+
+  it('releases consumed references and amortizes storage compaction in a large backlog', () => {
+    const buffer = new RelayFrameBuffer()
+    const chunks = Array.from({ length: 32768 }, (_, index) => Buffer.from([index % 256]))
+    for (const chunk of chunks) buffer.append(chunk)
+    const shifted = vi.spyOn(Array.prototype, 'shift')
+    let shiftCount: number
+    try {
+      buffer.discard(16000)
+      shiftCount = shifted.mock.calls.length
+    } finally {
+      shifted.mockRestore()
+    }
+    expect(shiftCount).toBe(0)
+    const storage = buffer as unknown as { chunks: (Buffer | undefined)[]; head: number }
+    expect(storage.chunks.slice(0, storage.head).every((chunk) => chunk === undefined)).toBe(true)
+    expect(buffer.take(1000)).toEqual(Buffer.concat(chunks.slice(16000, 17000)))
+    expect(storage.chunks.length).toBeLessThan(chunks.length)
+    expect(buffer.drain()).toEqual(Buffer.concat(chunks.slice(17000)))
+    expect(storage.chunks).toHaveLength(0)
+    expect(buffer.length).toBe(0)
+  })
+
+  it('keeps single-chunk views and clears partial data before reuse', () => {
+    const buffer = new RelayFrameBuffer()
+    const chunk = Buffer.from('abcdef')
+    buffer.append(chunk)
+    expect(buffer.peek(2)).toBe(chunk)
+    const taken = buffer.take(2)
+    expect(taken.buffer).toBe(chunk.buffer)
+    expect(taken.toString()).toBe('ab')
+    buffer.clear()
+    buffer.append(Buffer.from('fresh'))
+    expect(buffer.drain().toString()).toBe('fresh')
+  })
+})

--- a/src/shared/relay-frame-buffer.ts
+++ b/src/shared/relay-frame-buffer.ts
@@ -1,5 +1,6 @@
 export class RelayFrameBuffer {
-  private chunks: Buffer[] = []
+  private chunks: (Buffer | undefined)[] = []
+  private head = 0
   private bytes = 0
 
   get length(): number {
@@ -13,23 +14,28 @@ export class RelayFrameBuffer {
 
   clear(): void {
     this.chunks = []
+    this.head = 0
     this.bytes = 0
   }
 
   drain(): Buffer {
-    const out = this.chunks.length === 1 ? this.chunks[0] : Buffer.concat(this.chunks, this.bytes)
+    const out =
+      this.chunks.length - this.head === 1
+        ? this.chunks[this.head]!
+        : Buffer.concat(this.chunks.slice(this.head) as Buffer[], this.bytes)
     this.clear()
     return out
   }
 
   peek(count: number): Buffer {
-    const first = this.chunks[0]
+    const first = this.chunks[this.head]!
     if (first.length >= count) {
       return first
     }
     const out = Buffer.allocUnsafe(count)
     let copied = 0
-    for (const part of this.chunks) {
+    for (let index = this.head; index < this.chunks.length; index += 1) {
+      const part = this.chunks[index]!
       copied += part.copy(out, copied, 0, Math.min(part.length, count - copied))
       if (copied >= count) {
         break
@@ -39,43 +45,56 @@ export class RelayFrameBuffer {
   }
 
   take(count: number): Buffer {
-    const first = this.chunks[0]
+    const first = this.chunks[this.head]!
     if (first.length === count) {
-      this.chunks.shift()
+      this.removeHead()
       this.bytes -= count
       return first
     }
     if (first.length > count) {
-      this.chunks[0] = first.subarray(count)
+      this.chunks[this.head] = first.subarray(count)
       this.bytes -= count
       return first.subarray(0, count)
     }
     const out = Buffer.allocUnsafe(count)
     let copied = 0
     while (copied < count) {
-      const part = this.chunks[0]
+      const part = this.chunks[this.head]!
       const take = Math.min(part.length, count - copied)
       part.copy(out, copied, 0, take)
       copied += take
       if (take === part.length) {
-        this.chunks.shift()
+        this.removeHead()
       } else {
-        this.chunks[0] = part.subarray(take)
+        this.chunks[this.head] = part.subarray(take)
       }
     }
     this.bytes -= count
     return out
   }
 
+  private removeHead(): void {
+    this.chunks[this.head] = undefined
+    this.head += 1
+    // Amortize compaction without retaining consumed buffers.
+    if (
+      this.head === this.chunks.length ||
+      (this.head >= 1024 && this.head * 2 >= this.chunks.length)
+    ) {
+      this.chunks = this.chunks.slice(this.head)
+      this.head = 0
+    }
+  }
+
   discard(count: number): void {
     let remaining = count
     while (remaining > 0) {
-      const part = this.chunks[0]
+      const part = this.chunks[this.head]!
       if (part.length <= remaining) {
-        this.chunks.shift()
+        this.removeHead()
         remaining -= part.length
       } else {
-        this.chunks[0] = part.subarray(remaining)
+        this.chunks[this.head] = part.subarray(remaining)
         remaining = 0
       }
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |

<!-- /orca-pr-loc -->

## ELI5

When network data arrives in many little pieces, Orca was moving the entire remaining pile every time it picked up one piece. It now advances a pointer and occasionally tidies the pile. The same bytes arrive in the same order, with much less work.

## What Changed

Replace per-fragment `Array.shift()` in `RelayFrameBuffer` with a head cursor. Clear consumed references immediately and compact only after at least half the slots are consumed, keeping total compaction work linear. Preserve single-chunk buffer views and drain/reset behavior.

## Why / measurements

Local macOS, Node 24.18; medians of nine alternating before/after samples using the actual pre-change and current buffer classes. These are buffer-operation microbenchmarks, not end-to-end network speed claims.

| Operation | Fixture | Before | After |
|---|---|---:|---:|
| Take | 4 MiB, 65,536 chunks | 417.33 ms | 1.26 ms |
| Discard | 4 MiB, 65,536 chunks | 286.50 ms | 0.44 ms |
| Take | 1 MiB, 16,384 chunks | 11.77 ms | 0.29 ms |

Reproduce: save `git show d8c4c830639:src/shared/relay-frame-buffer.ts` to a temporary `.ts` file, then run `node config/scripts/relay-frame-buffer-benchmark.mjs <temporary-file>`. Small buffers remain in the sub-millisecond range; tiny timing differences are too small to establish an interaction-level change.

## Visual Proof

N/A — internal buffer bookkeeping; no visual, timing policy, or interaction behavior changes.

## Testing

- 31 targeted buffer, decoder backpressure, and socket-handshake tests passed.
- 189 tests across the 16-file SSH/relay command from `terminal-performance.output-backpressure-budget` passed.
- `pnpm tc` passed across node, CLI and renderer with the other audit fixes present; scoped lint and formatting pass.
- Byte-stream tests cover mixed peek/take/discard/drain, partial views, reset/reuse and compaction; consumed references are released.

## Reliability contract

Invariant: `terminal-performance.output-backpressure-budget` — decoder output, ordering, retained-input caps and scheduling remain exact. Failure source: fragmented large relay frames previously require quadratic synchronous queue maintenance. Oracle: exact byte-stream comparison, released queue references, existing decoder/handshake and SSH source-credit tests. Diagnostics: reproducible benchmark plus deterministic tests. No new scans, timers, polling, subprocesses or wire fields.

Provider/platform coverage: host-independent Node Buffer logic tested on macOS; shared relay/SSH decoding covered by deterministic contracts. No local/daemon lifecycle, WSL launch/path, mobile wire, Git provider, or git-versus-folder behavior changes. Live Linux/Windows/remote process runs were not performed; native CI remains the platform verification gap. Existing experimental gate maturity is unchanged.

## Negative user-facing trade-offs

- None identified. No output is discarded, limits reduced, refreshes delayed, or caches introduced.
- Internal cost: consumed array slots temporarily remain as `undefined` until bounded amortized compaction; they retain no consumed Buffer references.

## Review

- [x] Small, focused change with before/after measurements and ELI5.
- [x] Self-reviewed for bytes, resource cleanup, cross-platform and remote compatibility.
- [x] Agent skill upstream boundary: not applicable.
- [ ] Full build and remaining repository checks: CI.
