### PR TITLE
perf(repos): avoid quadratic icon source scans

### DIFF
--- a/config/scripts/repo-icon-source-href-benchmark.mjs
+++ b/config/scripts/repo-icon-source-href-benchmark.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { performance } from 'node:perf_hooks'
+import { extractIconHref } from '../../src/main/repo-icon-source-href.ts'
+
+// Original production expressions, preserved for the before/after measurement.
+const html =
+  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
+const object =
+  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
+const original = (source) => source.match(html)?.[1] ?? source.match(object)?.[1] ?? null
+
+function measure(fn, source, repetitions) {
+  const samples = []
+  for (let run = 0; run < repetitions; run++) {
+    const started = performance.now()
+    fn(source)
+    samples.push(performance.now() - started)
+  }
+  return samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]
+}
+
+const results = []
+for (const size of [8192, 16384, 32768]) {
+  for (const shape of ['no icon', 'rel without href']) {
+    const source = 'a'.repeat(size) + (shape === 'rel without href' ? ' rel:"icon"' : '')
+    assert.equal(extractIconHref(source), original(source))
+    const beforeMs = measure(original, source, 3)
+    const afterMs = measure(extractIconHref, source, 15)
+    results.push({
+      shape,
+      bytes: Buffer.byteLength(source),
+      beforeMs,
+      afterMs,
+      speedup: beforeMs / afterMs
+    })
+  }
+}
+console.log(JSON.stringify({ node: process.version, platform: process.platform, results }, null, 2))

--- a/config/scripts/repo-icon-source-href-benchmark.mjs
+++ b/config/scripts/repo-icon-source-href-benchmark.mjs
@@ -9,14 +9,29 @@ const object =
   /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
 const original = (source) => source.match(html)?.[1] ?? source.match(object)?.[1] ?? null
 
-function measure(fn, source, repetitions) {
-  const samples = []
-  for (let run = 0; run < repetitions; run++) {
-    const started = performance.now()
-    fn(source)
-    samples.push(performance.now() - started)
+function measurePair(source) {
+  original(source)
+  extractIconHref(source)
+  const beforeSamples = []
+  const afterSamples = []
+  for (let run = 0; run < 5; run++) {
+    const measurements = [
+      [original, beforeSamples],
+      [extractIconHref, afterSamples]
+    ]
+    if (run % 2 === 1) {
+      measurements.reverse()
+    }
+    for (const [fn, samples] of measurements) {
+      const started = performance.now()
+      fn(source)
+      samples.push(performance.now() - started)
+    }
   }
-  return samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]
+  return {
+    beforeMs: beforeSamples.sort((a, b) => a - b)[2],
+    afterMs: afterSamples.sort((a, b) => a - b)[2]
+  }
 }
 
 const results = []
@@ -27,8 +42,7 @@ for (const size of [8192, 16384, 32768]) {
         ? '<link '.repeat(Math.floor(size / 6))
         : 'a'.repeat(size) + (shape === 'rel without href' ? ' rel:"icon"' : '')
     assert.equal(extractIconHref(source), original(source))
-    const beforeMs = measure(original, source, 3)
-    const afterMs = measure(extractIconHref, source, 15)
+    const { beforeMs, afterMs } = measurePair(source)
     results.push({
       shape,
       bytes: Buffer.byteLength(source),

--- a/config/scripts/repo-icon-source-href-benchmark.mjs
+++ b/config/scripts/repo-icon-source-href-benchmark.mjs
@@ -21,8 +21,11 @@ function measure(fn, source, repetitions) {
 
 const results = []
 for (const size of [8192, 16384, 32768]) {
-  for (const shape of ['no icon', 'rel without href']) {
-    const source = 'a'.repeat(size) + (shape === 'rel without href' ? ' rel:"icon"' : '')
+  for (const shape of ['no icon', 'rel without href', 'unterminated link starts']) {
+    const source =
+      shape === 'unterminated link starts'
+        ? '<link '.repeat(Math.floor(size / 6))
+        : 'a'.repeat(size) + (shape === 'rel without href' ? ' rel:"icon"' : '')
     assert.equal(extractIconHref(source), original(source))
     const beforeMs = measure(original, source, 3)
     const afterMs = measure(extractIconHref, source, 15)

--- a/src/main/repo-icon-file-detection.test.ts
+++ b/src/main/repo-icon-file-detection.test.ts
@@ -1,4 +1,6 @@
-import { readFile, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import type * as FsPromisesModule from 'node:fs/promises'
 import { describe, expect, it, vi } from 'vitest'
 import type { ExecutionHostFilesystemRoute } from './providers/execution-host-provider-dispatch'
@@ -134,5 +136,57 @@ describe('detectRepoFileIcon connection boundary', () => {
     ).resolves.toBeNull()
 
     expect(stat).toHaveBeenCalled()
+  })
+})
+
+describe('declared repo icons through production filesystem routes', () => {
+  it.each([
+    ['local', false],
+    ['ssh', false],
+    ['local', true],
+    ['ssh', true]
+  ] as const)('preserves declared icon detection on %s (no icon: %s)', async (kind, noIcon) => {
+    const directory = await mkdtemp(join(tmpdir(), 'orca-icon-href-'))
+    const source = noIcon
+      ? 'a'.repeat(256 * 1024)
+      : `${'a'.repeat(32768)}{ rel: "icon", href: "/first.png", href: "/chosen.png" }`
+    try {
+      await mkdir(join(directory, 'public'))
+      await writeFile(join(directory, 'index.html'), source)
+      await writeFile(join(directory, 'public', 'chosen.png'), Buffer.from(PNG_BASE64, 'base64'))
+      const provider = remoteFilesystemProvider({
+        stat: async (path) => {
+          const info = await stat(path)
+          return {
+            type: info.isFile() ? 'file' : 'directory',
+            size: info.size,
+            mtime: info.mtimeMs
+          }
+        },
+        readFile: async (path) => {
+          const buffer = await readFile(path)
+          const isBinary = path.endsWith('.png')
+          return {
+            content: buffer.toString(isBinary ? 'base64' : 'utf8'),
+            isBinary,
+            mimeType: isBinary ? 'image/png' : 'text/html'
+          }
+        }
+      })
+      const route: ExecutionHostFilesystemRoute =
+        kind === 'local' ? { kind: 'local', hostId: 'local' } : sshRoute('icon-oracle', provider)
+      await expect(detectRepoFileIcon(directory, route)).resolves.toEqual(
+        noIcon
+          ? null
+          : {
+              type: 'image',
+              src: `data:image/png;base64,${PNG_BASE64}`,
+              source: 'file',
+              label: 'public/chosen.png'
+            }
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/repo-icon-file-detection.ts
+++ b/src/main/repo-icon-file-detection.ts
@@ -3,6 +3,7 @@ import { buildImageDataUri } from '../shared/image-data-uri'
 import { MAX_REPO_ICON_UPLOAD_BYTES, type RepoIcon } from '../shared/repo-icon'
 import type { ExecutionHostFilesystemRoute } from './providers/execution-host-provider-dispatch'
 import type { IFilesystemProvider } from './providers/types'
+import { extractIconHref } from './repo-icon-source-href'
 import { iconHrefCandidates } from './repo-icon-href-candidates'
 import { joinWorktreeRelativePath } from './runtime/runtime-relative-paths'
 
@@ -49,11 +50,6 @@ const REPO_ICON_SOURCE_FILE_CANDIDATES = [
 // not read large app entrypoints just to find a small favicon href.
 const MAX_REPO_ICON_SOURCE_BYTES = 256 * 1024
 
-const LINK_ICON_HTML_RE =
-  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
-const LINK_ICON_OBJECT_RE =
-  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
-
 type DetectedImageFormat = {
   mimeType: 'image/png' | 'image/webp'
 }
@@ -96,10 +92,6 @@ function detectImageFormat(buffer: Buffer): DetectedImageFormat | null {
     return { mimeType: 'image/webp' }
   }
   return null
-}
-
-function extractIconHref(source: string): string | null {
-  return source.match(LINK_ICON_HTML_RE)?.[1] ?? source.match(LINK_ICON_OBJECT_RE)?.[1] ?? null
 }
 
 function repoIconFromImageBuffer(buffer: Buffer, relativePath: string): RepoIcon | null {

--- a/src/main/repo-icon-source-href.test.ts
+++ b/src/main/repo-icon-source-href.test.ts
@@ -13,6 +13,11 @@ export function originalIconHref(source: string): string | null {
 
 describe('repo icon source href compatibility', () => {
   it.each([
+    '<link <link <link rel="icon" href="last.png">',
+    '<link rel="icon" href="first.png" href="last.png">',
+    '<link rel="icon" href="cross>angle.png">',
+    '<LINK rel="ICON" href="upper.png">',
+    '<link href="wrong.png"><link rel="icon" href="right.png">',
     '',
     'plain source without icon properties',
     '{ rel: "icon", href: "/first.png", href: "/last.png" }',
@@ -34,7 +39,22 @@ describe('repo icon source href compatibility', () => {
   })
 
   it('matches the original across generated malformed property sequences', () => {
-    const tokens = ['}', '{', ' ', 'rel:"icon"', 'href:"a"', 'href:"b"', 'rel:"other"', 'x', '\n']
+    const tokens = [
+      '}',
+      '{',
+      ' ',
+      'rel:"icon"',
+      'href:"a"',
+      'href:"b"',
+      'rel:"other"',
+      'x',
+      '\n',
+      '<link ',
+      '>',
+      'rel="icon"',
+      'href="a"',
+      'href="b"'
+    ]
     let seed = 97
     for (let sample = 0; sample < 3000; sample++) {
       let source = ''
@@ -44,6 +64,10 @@ describe('repo icon source href compatibility', () => {
       }
       expect(extractIconHref(source), source).toBe(originalIconHref(source))
     }
+  })
+
+  it('handles a maximum-size unterminated HTML tag region', () => {
+    expect(extractIconHref('<link '.repeat(Math.floor((256 * 1024) / 6)))).toBeNull()
   })
 
   it('handles a maximum-size icon-free entrypoint', () => {

--- a/src/main/repo-icon-source-href.test.ts
+++ b/src/main/repo-icon-source-href.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { extractIconHref } from './repo-icon-source-href'
+
+// Original production expressions are the compatibility oracle.
+const HTML_RE =
+  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
+const OBJECT_RE =
+  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
+
+export function originalIconHref(source: string): string | null {
+  return source.match(HTML_RE)?.[1] ?? source.match(OBJECT_RE)?.[1] ?? null
+}
+
+describe('repo icon source href compatibility', () => {
+  it.each([
+    '',
+    'plain source without icon properties',
+    '{ rel: "icon", href: "/first.png", href: "/last.png" }',
+    '{ href: "/first.png", rel: "icon", rel: "stylesheet" }',
+    '{ rel: "icon" } { href: "/unrelated.png" }',
+    '{ rel: "icon", href: "/first.png" } { rel: "icon", href: "/last.png" }',
+    '{ rel: "icon", href: "/object.png" } <link href="/html.png" rel="icon">',
+    '{ rel: "ICON", href: "/UPPER.png" }',
+    '}\n\n{href: "/line.png",\nrel : "shortcut icon"}',
+    '{ rel: "icon", href: "/unterminated}after brace',
+    '{ rel: "icon", href: "?query" }',
+    '{ rel: "icon", href: "/before?query" }',
+    '<link rel="stylesheet" href="/no.png">',
+    '<link rel="icon" href="/yes.png"',
+    '{rel:"icon",href:"/nested{brace}.png"}',
+    'xrel:"icon", xhref:"/no.png"'
+  ])('preserves original selection for %s', (source) => {
+    expect(extractIconHref(source)).toBe(originalIconHref(source))
+  })
+
+  it('matches the original across generated malformed property sequences', () => {
+    const tokens = ['}', '{', ' ', 'rel:"icon"', 'href:"a"', 'href:"b"', 'rel:"other"', 'x', '\n']
+    let seed = 97
+    for (let sample = 0; sample < 3000; sample++) {
+      let source = ''
+      for (let token = 0; token < 12; token++) {
+        seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+        source += tokens[seed % tokens.length]
+      }
+      expect(extractIconHref(source), source).toBe(originalIconHref(source))
+    }
+  })
+
+  it('handles a maximum-size icon-free entrypoint', () => {
+    expect(extractIconHref('a'.repeat(256 * 1024))).toBeNull()
+  })
+})

--- a/src/main/repo-icon-source-href.ts
+++ b/src/main/repo-icon-source-href.ts
@@ -1,11 +1,31 @@
+const LINK_START_RE = /<link\b/gi
 const LINK_ICON_HTML_RE =
-  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
+  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/iy
 const LINK_ICON_OBJECT_RE =
   /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/iy
 
+function extractHtmlIconHref(source: string): string | null {
+  LINK_START_RE.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = LINK_START_RE.exec(source))) {
+    LINK_ICON_HTML_RE.lastIndex = match.index
+    const href = LINK_ICON_HTML_RE.exec(source)?.[1]
+    if (href !== undefined) {
+      return href
+    }
+    // Later link starts before the same closing angle see only a subset of these attributes.
+    const closingAngle = source.indexOf('>', LINK_START_RE.lastIndex)
+    if (closingAngle === -1) {
+      return null
+    }
+    LINK_START_RE.lastIndex = closingAngle + 1
+  }
+  return null
+}
+
 export function extractIconHref(source: string): string | null {
-  const htmlHref = source.match(LINK_ICON_HTML_RE)?.[1]
-  if (htmlHref !== undefined) {
+  const htmlHref = extractHtmlIconHref(source)
+  if (htmlHref !== null) {
     return htmlHref
   }
   let start = 0

--- a/src/main/repo-icon-source-href.ts
+++ b/src/main/repo-icon-source-href.ts
@@ -1,0 +1,26 @@
+const LINK_ICON_HTML_RE =
+  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
+const LINK_ICON_OBJECT_RE =
+  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/iy
+
+export function extractIconHref(source: string): string | null {
+  const htmlHref = source.match(LINK_ICON_HTML_RE)?.[1]
+  if (htmlHref !== undefined) {
+    return htmlHref
+  }
+  let start = 0
+  while (start <= source.length) {
+    // Every suffix before the next closing brace sees the same candidate properties.
+    LINK_ICON_OBJECT_RE.lastIndex = start
+    const href = LINK_ICON_OBJECT_RE.exec(source)?.[1]
+    if (href !== undefined) {
+      return href
+    }
+    const closingBrace = source.indexOf('}', start)
+    if (closingBrace === -1) {
+      return null
+    }
+    start = closingBrace + 1
+  }
+  return null
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​131 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |

<!-- /orca-pr-loc -->

## ELI5

When Orca looks for a project's icon, it was rereading almost the same text from every character. It now checks each brace-delimited region and each candidate HTML tag region once. Icon-free projects stop making the main thread do the same unsuccessful search thousands of times.

## What Changed / Why

Move the existing source href extraction into a focused module. Evaluate the existing object expression with a sticky start at each closing-brace boundary. Preserve HTML-first priority, case-insensitivity, greedy duplicate href selection, path resolution, file-size limits and local/SSH filesystem routing. Skip repeated `<link` starts within the same failed tag region as well. No caching or new filesystem probes.

## Measurements

Actual old/current expressions, macOS / Node 24.18; one warmup each, five samples each with alternating order; local parser microbenchmark, not end-to-end add-project latency.

| Source | Before | After |
|---|---:|---:|
| 32 KiB with no icon | 431.33 ms | 0.0339 ms |
| 32 KiB with rel but no href | 563.66 ms | 0.0463 ms |
| 32 KiB unterminated HTML link starts | 511.08 ms | 0.0589 ms |

Reproduce: `node config/scripts/repo-icon-source-href-benchmark.mjs`. Tests also exercise the unchanged 256 KiB file limit.

## Visual Proof

N/A — the chosen icon and interaction behavior stay the same; this removes internal parser work.

## Testing

- 34 tests passed, including 3,000 generated mixed HTML/object malformed-source parity cases, curated capture/priority cases, and production local/SSH filesystem routes.
- `pnpm tc` passed for node, CLI and renderer with the audit changes present.
- Scoped lint and formatting passed.
- Runtime measurements and filesystem tests ran on macOS. Linux/Windows build checks remain with CI; no OS-specific logic or Git commands changed.

## Negative user-facing trade-offs

- None identified: source-size limits, icon choices, file priority, remote routing and errors are unchanged.
- No added cache, stale-data window, polling or deferred feedback.

## Review

- [x] Small, focused change with ELI5 and measurements.
- [x] Self-reviewed for exact regex semantics and local/SSH/folder behavior.
- [x] Agent skill upstream boundary: not applicable.
- [ ] Full build and remaining repository checks: CI.
