### PR TITLE
perf(browser): assemble fragmented tunnel frames once

### DIFF
--- a/config/scripts/benchmark-browser-tunnel-framing.mjs
+++ b/config/scripts/benchmark-browser-tunnel-framing.mjs
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { stripTypeScriptTypes } from 'node:module'
+import { performance } from 'node:perf_hooks'
+
+// Run from the worktree root: node config/scripts/benchmark-browser-tunnel-framing.mjs [base-ref]
+const path = 'src/shared/browser-network-tunnel-stream-framing.ts'
+const baselineRef = process.argv[2] ?? 'HEAD'
+const beforeSource = execFileSync('git', ['show', `${baselineRef}:${path}`], {
+  encoding: 'utf8'
+})
+const afterSource = readFileSync(path, 'utf8')
+const load = (source) =>
+  import(
+    `data:text/javascript;base64,${Buffer.from(
+      stripTypeScriptTypes(source, { mode: 'transform' })
+    ).toString('base64')}`
+  )
+const before = await load(beforeSource)
+const after = await load(afterSource)
+
+function measure(module, chunks, payload, repetitions) {
+  let frameCount = 0
+  let lastFrame
+  const onFrame = (frame) => {
+    frameCount++
+    lastFrame = frame
+  }
+  const onError = (error) => {
+    throw error
+  }
+  const run = () => {
+    const decoder = new module.BrowserNetworkTunnelStreamFrameDecoder(onFrame, onError)
+    for (const chunk of chunks) {
+      decoder.feed(chunk)
+    }
+  }
+  run()
+  assert.deepEqual(lastFrame, payload)
+  const samples = []
+  for (let sample = 0; sample < 5; sample++) {
+    const start = performance.now()
+    for (let iteration = 0; iteration < repetitions; iteration++) {
+      run()
+    }
+    samples.push((performance.now() - start) / repetitions)
+  }
+  assert.equal(frameCount, 1 + 5 * repetitions)
+  return samples.sort((a, b) => a - b)[2]
+}
+
+function countCopies(module, chunks) {
+  const originalSet = Uint8Array.prototype.set
+  const originalSlice = Uint8Array.prototype.slice
+  let copied = 0
+  Uint8Array.prototype.set = function (source, offset) {
+    copied += source.length
+    return originalSet.call(this, source, offset)
+  }
+  Uint8Array.prototype.slice = function (...args) {
+    const result = originalSlice.apply(this, args)
+    copied += result.length
+    return result
+  }
+  try {
+    const decoder = new module.BrowserNetworkTunnelStreamFrameDecoder(
+      () => {},
+      (error) => {
+        throw error
+      }
+    )
+    for (const chunk of chunks) {
+      decoder.feed(chunk)
+    }
+  } finally {
+    Uint8Array.prototype.set = originalSet
+    Uint8Array.prototype.slice = originalSlice
+  }
+  return copied
+}
+
+const rows = []
+for (const [payloadBytes, chunkBytes, repetitions] of [
+  [1, 5, 10000],
+  [64 * 1024, 65540, 1000],
+  [64 * 1024, 4096, 100],
+  [64 * 1024, 256, 25],
+  [64 * 1024, 16, 5],
+  [64 * 1024, 1, 1]
+]) {
+  const payload = Uint8Array.from({ length: payloadBytes }, (_, index) => index % 251)
+  const encoded = before.encodeBrowserNetworkTunnelStreamFrame(payload)
+  const chunks = []
+  for (let offset = 0; offset < encoded.length; offset += chunkBytes) {
+    chunks.push(encoded.subarray(offset, offset + chunkBytes))
+  }
+  const beforeMs = measure(before, chunks, payload, repetitions)
+  const afterMs = measure(after, chunks, payload, repetitions)
+  rows.push({
+    payloadBytes,
+    chunkBytes,
+    beforeMs: +beforeMs.toFixed(6),
+    afterMs: +afterMs.toFixed(6),
+    speedup: +(beforeMs / afterMs).toFixed(2),
+    beforeCopiedBytes: countCopies(before, chunks),
+    afterCopiedBytes: countCopies(after, chunks)
+  })
+}
+console.log(JSON.stringify({ node: process.version, baselineRef, rows }, null, 2))

--- a/src/shared/browser-network-tunnel-stream-framing.test.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.test.ts
@@ -55,6 +55,98 @@ describe('browser network tunnel stream framing', () => {
     )
   })
 
+  it.each([1, 2, 3, 16, 256, 4096, 65556])(
+    'preserves maximum-size frames split into %i-byte chunks',
+    (chunkSize) => {
+      const payload = Uint8Array.from({ length: 65552 }, (_, index) => index % 251)
+      const encoded = encodeBrowserNetworkTunnelStreamFrame(payload)
+      const frames: Uint8Array[] = []
+      const onError = vi.fn()
+      const decoder = new BrowserNetworkTunnelStreamFrameDecoder(
+        (frame) => frames.push(frame),
+        onError
+      )
+      for (let offset = 0; offset < encoded.length; offset += chunkSize) {
+        decoder.feed(encoded.subarray(offset, offset + chunkSize))
+      }
+      expect(frames).toEqual([payload])
+      expect(onError).not.toHaveBeenCalled()
+    }
+  )
+
+  it('copies fragmented bytes once instead of recopying the growing carry', () => {
+    const encoded = encodeBrowserNetworkTunnelStreamFrame(new Uint8Array(65536))
+    const decoder = new BrowserNetworkTunnelStreamFrameDecoder(
+      () => {},
+      () => {}
+    )
+    const originalSet = Uint8Array.prototype.set
+    let copiedBytes = 0
+    const set = vi
+      .spyOn(Uint8Array.prototype, 'set')
+      .mockImplementation(function (this: Uint8Array, source, offset) {
+        copiedBytes += source.length
+        originalSet.call(this, source, offset)
+      })
+    try {
+      for (const byte of encoded) {
+        decoder.feed(new Uint8Array([byte]))
+      }
+      expect(copiedBytes).toBe(encoded.length)
+    } finally {
+      set.mockRestore()
+    }
+  })
+
+  it('owns partial input and emitted frames independently of caller buffers', () => {
+    const frames: Uint8Array[] = []
+    const decoder = new BrowserNetworkTunnelStreamFrameDecoder(
+      (frame) => frames.push(frame),
+      () => {}
+    )
+    const first = new Uint8Array([0, 0, 0, 3, 1])
+    decoder.feed(first)
+    first.fill(255)
+    const rest = new Uint8Array([2, 3])
+    decoder.feed(rest)
+    rest.fill(255)
+    decoder.feed(encodeBrowserNetworkTunnelStreamFrame(new Uint8Array([4])))
+    expect(frames).toEqual([new Uint8Array([1, 2, 3]), new Uint8Array([4])])
+  })
+
+  it('enforces the retained cap before decoding complete frames in a feed', () => {
+    const onFrame = vi.fn()
+    const onError = vi.fn()
+    const decoder = new BrowserNetworkTunnelStreamFrameDecoder(onFrame, onError, 16, 8)
+    decoder.feed(new Uint8Array([0, 0]))
+    decoder.feed(new Uint8Array([0, 1, 7, 0, 0, 0, 1]))
+    decoder.feed(new Uint8Array([8]))
+    expect(onFrame).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ message: 'browser_tunnel_stream_buffer_overflow' })
+    )
+  })
+
+  it('counts the retained header and payload against the exact cap', () => {
+    const onFrame = vi.fn()
+    const onError = vi.fn()
+    const decoder = new BrowserNetworkTunnelStreamFrameDecoder(onFrame, onError, 16, 7)
+    decoder.feed(new Uint8Array([0, 0, 0, 3, 1]))
+    decoder.feed(new Uint8Array([2, 3]))
+    expect(onFrame).toHaveBeenCalledExactlyOnceWith(new Uint8Array([1, 2, 3]))
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  it('stops decoding coalesced frames when the callback closes the decoder', () => {
+    const onFrame = vi.fn(() => decoder.close())
+    const onError = vi.fn()
+    const decoder = new BrowserNetworkTunnelStreamFrameDecoder(onFrame, onError)
+    decoder.feed(new Uint8Array([0, 0, 0, 1, 7, 0, 0, 0, 1, 8]))
+    decoder.feed(new Uint8Array([0, 0, 0, 1, 9]))
+    expect(onFrame).toHaveBeenCalledExactlyOnceWith(new Uint8Array([7]))
+    expect(onError).not.toHaveBeenCalled()
+  })
+
   it('serializes writes and rejects bounded queue overflow', () => {
     const callbacks: ((error?: Error | null) => void)[] = []
     const writes: Uint8Array[] = []

--- a/src/shared/browser-network-tunnel-stream-framing.ts
+++ b/src/shared/browser-network-tunnel-stream-framing.ts
@@ -15,7 +15,10 @@ export function encodeBrowserNetworkTunnelStreamFrame(frame: Uint8Array): Uint8A
 }
 
 export class BrowserNetworkTunnelStreamFrameDecoder {
-  private retained = new Uint8Array()
+  private readonly header = new Uint8Array(LENGTH_BYTES)
+  private headerBytes = 0
+  private frame: Uint8Array | null = null
+  private frameBytes = 0
   private closed = false
 
   constructor(
@@ -29,30 +32,50 @@ export class BrowserNetworkTunnelStreamFrameDecoder {
     if (this.closed || chunk.byteLength === 0) {
       return
     }
-    if (this.retained.byteLength + chunk.byteLength > this.maxRetainedBytes) {
+    if (this.headerBytes + this.frameBytes + chunk.byteLength > this.maxRetainedBytes) {
       this.fail(new Error('browser_tunnel_stream_buffer_overflow'))
       return
     }
-    const combined = new Uint8Array(this.retained.byteLength + chunk.byteLength)
-    combined.set(this.retained)
-    combined.set(chunk, this.retained.byteLength)
     let offset = 0
-    while (combined.byteLength - offset >= LENGTH_BYTES) {
-      const length = new DataView(
-        combined.buffer,
-        combined.byteOffset + offset,
-        LENGTH_BYTES
-      ).getUint32(0, false)
-      if (length === 0 || length > this.maxFrameBytes) {
-        this.fail(new Error('browser_tunnel_stream_frame_invalid'))
+    while (offset < chunk.byteLength) {
+      if (this.headerBytes < LENGTH_BYTES) {
+        let length: number
+        if (this.headerBytes === 0 && chunk.byteLength - offset >= LENGTH_BYTES) {
+          length = new DataView(chunk.buffer, chunk.byteOffset + offset, LENGTH_BYTES).getUint32(
+            0,
+            false
+          )
+          this.headerBytes = LENGTH_BYTES
+          offset += LENGTH_BYTES
+        } else {
+          const count = Math.min(LENGTH_BYTES - this.headerBytes, chunk.byteLength - offset)
+          this.header.set(chunk.subarray(offset, offset + count), this.headerBytes)
+          this.headerBytes += count
+          offset += count
+          if (this.headerBytes < LENGTH_BYTES) {
+            return
+          }
+          length = new DataView(this.header.buffer).getUint32(0, false)
+        }
+        if (length === 0 || length > this.maxFrameBytes) {
+          this.fail(new Error('browser_tunnel_stream_frame_invalid'))
+          return
+        }
+        this.frame = new Uint8Array(length)
+      }
+      const frame = this.frame!
+      const count = Math.min(frame.byteLength - this.frameBytes, chunk.byteLength - offset)
+      frame.set(chunk.subarray(offset, offset + count), this.frameBytes)
+      this.frameBytes += count
+      offset += count
+      if (this.frameBytes < frame.byteLength) {
         return
       }
-      const end = offset + LENGTH_BYTES + length
-      if (end > combined.byteLength) {
-        break
-      }
+      this.frame = null
+      this.frameBytes = 0
+      this.headerBytes = 0
       try {
-        this.onFrame(combined.slice(offset + LENGTH_BYTES, end))
+        this.onFrame(frame)
       } catch (error) {
         this.fail(error instanceof Error ? error : new Error(String(error)))
         return
@@ -60,14 +83,14 @@ export class BrowserNetworkTunnelStreamFrameDecoder {
       if (this.closed) {
         return
       }
-      offset = end
     }
-    this.retained = combined.slice(offset)
   }
 
   close(): void {
     this.closed = true
-    this.retained = new Uint8Array()
+    this.frame = null
+    this.frameBytes = 0
+    this.headerBytes = 0
   }
 
   private fail(error: Error): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 |

<!-- /orca-pr-loc -->

## ELI5

Imagine receiving a parcel one small piece at a time. Orca was copying every piece received so far whenever another arrived. It now puts each piece directly in its final place, so fragmented browser-network traffic takes much less CPU and memory-copy work.

## What Changed / Why

Assemble the WSL browser network tunnel's header and payload incrementally into owned buffers. Preserve the existing wire format, pre-feed retained-byte ceiling (including header bytes), maximum frame size, caller-buffer independence, callback error behavior and close handling.

## Measurements

Actual original/current production decoder; macOS / Node 24.18, median of five local runs. Copy counts include `set` and `slice`; these are decoder microbenchmarks, not page-load speed claims.

| 64 KiB payload arrival | Before | After | Copied bytes before → after |
|---|---:|---:|---:|
| 4 KiB fragments | 0.07065 ms | 0.00561 ms | 1,245,188 → 65,536 |
| 256-byte fragments | 1.035 ms | 0.01556 ms | 16,973,828 → 65,536 |
| 1-byte adverse fragments | 353.83 ms | 2.816 ms | 4,295,557,136 → 65,540 |
| Whole frame | 0.007338 ms | 0.00317 ms | 131,076 → 65,536 |

Reproduce: `node config/scripts/benchmark-browser-tunnel-framing.mjs d8c4c830639bf3d603c9250a536e0323ca0a7a19`. The one-byte payload control also improved locally (0.000229 → 0.000144 ms); its absolute cost is tiny.

## Visual Proof

N/A — internal network-frame decoding; no visual or interaction behavior changes.

## Testing

- 19 framing and WSL execution-route tests pass. Cases include maximum frames split at seven fragment sizes, coalesced frames, exact copy counts, cap boundaries, independent ownership, callback failures and close during a callback.
- `pnpm tc` passes for node, CLI and renderer with the audit fixes present; scoped lint and formatting pass.
- Tested on macOS with deterministic WSL route contracts. A live Windows/WSL browser was not exercised; native platform CI remains a validation gap.

## Negative user-facing trade-offs

- None identified. Frame bytes, limits and delivery behavior remain the same; no output is dropped or delayed.
- Internal allocation timing changes: after a validated header, one payload allocation reserves at most 65,552 bytes under the existing default cap. It is released on delivery, error or close.
- No RPC field/opcode changes; mixed-version peers use identical framing. No Git or filesystem-path changes; folder/SSH workspace semantics are unaffected.

## Review

- [x] Focused change with ELI5, measurements and deterministic regression tests.
- [x] Self-reviewed for ownership, error/close cleanup and remote compatibility.
- [x] Agent skill upstream boundary: not applicable.
- [ ] Full build and remaining repository checks: CI.
