### PR TITLE
test: pin worker visibility fixture command and handle

### DIFF
--- a/tests/e2e/orchestration-worker-terminal-visibility.spec.ts
+++ b/tests/e2e/orchestration-worker-terminal-visibility.spec.ts
@@ -11,6 +11,10 @@ import {
   waitForSessionReady
 } from './helpers/store'
 import { waitForActivePaneHookDescriptor, waitForActivePanePtyId } from './helpers/terminal'
+import {
+  buildFakeAgentCommandOverride,
+  FAKE_AGENT_WINDOWS_SHELL
+} from './helpers/fake-agent-command-override'
 import { RuntimeClient } from '../../src/cli/runtime-client'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
 
@@ -111,6 +115,22 @@ test('worker-start preserves one live inactive worker across workspace re-entry'
   electronApp
 }) => {
   await waitForSessionReady(orcaPage)
+  await orcaPage.evaluate(
+    async ({ command, windowsShell }) => {
+      const state = window.__store!.getState()
+      await state.updateSettings({
+        agentCmdOverrides: { ...state.settings?.agentCmdOverrides, codex: command },
+        terminalWindowsShell: windowsShell
+      })
+    },
+    {
+      command: buildFakeAgentCommandOverride(
+        path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+      ),
+      windowsShell: FAKE_AGENT_WINDOWS_SHELL
+    }
+  )
+
   const worktreeId = await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   const coordinatorTabId = await getActiveTabId(orcaPage)
@@ -160,7 +180,7 @@ test('worker-start preserves one live inactive worker across workspace re-entry'
 
   const terminals = await client.call<RuntimeTerminalListResult>('terminal.list')
   const workerTerminal = terminals.result.terminals.find(
-    (terminal) => terminal.title === 'Codex Ready'
+    (terminal) => terminal.handle === workerHandle
   )
   expect(workerTerminal?.tabId).toBeTruthy()
   expect(workerTerminal?.leafId).toBeTruthy()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The worker visibility journey could launch an installed Codex instead of its fake agent because shell startup replaced the fixture PATH. It also located the new worker by a transient title. Pin the existing shell-aware fake command through settings and find the terminal by the worker handle returned by worker-start.

The existing `orchestration.worker-terminal-delivery` experimental gate remains unchanged. Its invariant is one live inactive worker across workspace re-entry without coordinator focus changes. The oracle checks the rendered worker tab, process ledger, ACK output, and stable terminal identity; deterministic polling waits for those signals. Real Electron/PTY/RPC behavior requires E2E coverage. No timeout, retry, or assertion budget changed.

Validation: before pinning the command, all three handle-only repeats failed with an empty fixture spawn ledger; after both fixes, three consecutive macOS electron-headless runs passed (about 55 seconds each). Changed-file lint passed. Linux, Windows, SSH, and WSL runs remain gaps; Windows uses the existing shell-aware fixture quoting helper.
