### PR TITLE
fix(automation): keep explicit background launches off screen

### DIFF
--- a/config/scripts/run-electron-vite-dev.mjs
+++ b/config/scripts/run-electron-vite-dev.mjs
@@ -616,7 +616,7 @@ if (!isHelpOrVersion && process.env.ORCA_DEV_INSTANCE_LABEL) {
 // Why: automation launches this app while someone is working; announce that the
 // window will come up without taking the foreground so the mode is visible in logs.
 if (!isHelpOrVersion && process.env.ORCA_BACKGROUND_LAUNCH === '1') {
-  console.error('[orca-dev] Background launch: window shows without stealing focus')
+  console.error('[orca-dev] Background launch: window stays off screen; automate through CDP')
 }
 let forwardedExtras = []
 if (!userPassedPort && !isHelpOrVersion) {

--- a/src/main/window/createMainWindow-startup-reveal.test.ts
+++ b/src/main/window/createMainWindow-startup-reveal.test.ts
@@ -78,6 +78,34 @@ describe('createMainWindow', () => {
     }
   }
 
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'keeps explicit background startup hidden through ready/load/fallback on %s',
+    (platform) => {
+      vi.useFakeTimers()
+      vi.stubEnv('ORCA_BACKGROUND_LAUNCH', '1')
+      const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+      const showInactive = vi.fn()
+      Object.assign(browserWindowInstance, { showInactive })
+      try {
+        withPlatform(platform, () => {
+          createMainWindow(createStartupRevealStore(true) as never, { revealOnDidFinishLoad: true })
+          const revealAfterLoad = browserWindowInstance.webContents.on.mock.calls.find(
+            ([event]) => event === 'did-finish-load'
+          )?.[1]
+          expect(revealAfterLoad).toBeTypeOf('function')
+          revealAfterLoad?.()
+          windowHandlers['ready-to-show']()
+          vi.advanceTimersByTime(10_000)
+          expect(browserWindowInstance.show).not.toHaveBeenCalled()
+          expect(showInactive).not.toHaveBeenCalled()
+          expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+        })
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    }
+  )
+
   it('ignores duplicate ready-to-show events after startup maximize has already run', () => {
     const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
 

--- a/src/main/window/focus-existing-window.test.ts
+++ b/src/main/window/focus-existing-window.test.ts
@@ -1,5 +1,5 @@
 import type { App, BrowserWindow } from 'electron'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { focusExistingMainWindow } from './focus-existing-window'
 
 type FakeWindowOptions = {
@@ -78,7 +78,32 @@ function makeTimer(): {
   }
 }
 
+afterEach(() => vi.unstubAllEnvs())
+
 describe('focusExistingMainWindow', () => {
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'never restores or activates a background window on %s',
+    (platform) => {
+      vi.stubEnv('ORCA_BACKGROUND_LAUNCH', '1')
+      vi.stubEnv('ORCA_E2E_FOREGROUND', '1')
+      const app = makeFakeApp()
+      const window = makeFakeWindow({ minimized: true })
+      const timer = makeTimer()
+      focusExistingMainWindow({
+        app,
+        getWindow: () => window,
+        openWindow: vi.fn(),
+        platform,
+        setTimeout: timer.setTimeout
+      })
+      expect(app.focus).not.toHaveBeenCalled()
+      for (const call of Object.values(window.calls)) {
+        expect(call).not.toHaveBeenCalled()
+      }
+      expect(timer.scheduledMs()).toEqual([])
+    }
+  )
+
   it('aggressively foregrounds an existing Windows window on second launch', () => {
     const app = makeFakeApp()
     const window = makeFakeWindow()

--- a/src/main/window/focus-existing-window.ts
+++ b/src/main/window/focus-existing-window.ts
@@ -1,5 +1,9 @@
 import type { App, BrowserWindow } from 'electron'
-import { isBackgroundLaunch, showWindowWithoutStealingFocus } from './foreground-activation-policy'
+import {
+  isBackgroundLaunch,
+  isWindowlessLaunch,
+  showWindowWithoutStealingFocus
+} from './foreground-activation-policy'
 
 type FocusTimer = (callback: () => void, ms: number) => unknown
 
@@ -34,7 +38,7 @@ function safelyFocusApp(app: Pick<App, 'focus'>): void {
 }
 
 export function safelyRevealWindow(window: BrowserWindow): void {
-  if (window.isDestroyed()) {
+  if (window.isDestroyed() || isWindowlessLaunch()) {
     return
   }
   if (window.isMinimized()) {

--- a/src/main/window/foreground-activation-policy.test.ts
+++ b/src/main/window/foreground-activation-policy.test.ts
@@ -32,6 +32,10 @@ describe('isBackgroundLaunch', () => {
     expect(isBackgroundLaunch({})).toBe(false)
   })
 
+  it('keeps an explicit background request despite inherited foreground flags', () => {
+    expect(isBackgroundLaunch({ ORCA_BACKGROUND_LAUNCH: '1', ORCA_E2E_FOREGROUND: '1' })).toBe(true)
+  })
+
   it('lets native-focus specs opt back into the foreground', () => {
     expect(isBackgroundLaunch({ ORCA_E2E_HEADFUL: '1', ORCA_E2E_FOREGROUND: '1' })).toBe(false)
     expect(isWindowlessLaunch({ ORCA_E2E_HEADLESS: '1', ORCA_E2E_FOREGROUND: '1' })).toBe(false)
@@ -39,10 +43,17 @@ describe('isBackgroundLaunch', () => {
 })
 
 describe('isWindowlessLaunch', () => {
-  it('is headless-only; a headful run still paints', () => {
+  it('keeps explicit background launches hidden while headful E2E can paint', () => {
     expect(isWindowlessLaunch({ ORCA_E2E_HEADLESS: '1' })).toBe(true)
     expect(isWindowlessLaunch({ ORCA_E2E_HEADLESS: '1', ORCA_E2E_HEADFUL: '1' })).toBe(false)
-    expect(isWindowlessLaunch({ ORCA_BACKGROUND_LAUNCH: '1' })).toBe(false)
+    expect(isWindowlessLaunch({ ORCA_BACKGROUND_LAUNCH: '1' })).toBe(true)
+    expect(
+      isWindowlessLaunch({
+        ORCA_BACKGROUND_LAUNCH: '1',
+        ORCA_E2E_HEADFUL: '1',
+        ORCA_E2E_FOREGROUND: '1'
+      })
+    ).toBe(true)
   })
 })
 
@@ -54,9 +65,16 @@ describe('showWindowWithoutStealingFocus', () => {
     expect(window.showInactive).not.toHaveBeenCalled()
   })
 
-  it('shows a background window without activating it', () => {
+  it('never reveals an explicitly background window', () => {
     const window = makeWindow()
     showWindowWithoutStealingFocus(window, { ORCA_BACKGROUND_LAUNCH: '1' })
+    expect(window.showInactive).not.toHaveBeenCalled()
+    expect(window.show).not.toHaveBeenCalled()
+  })
+
+  it('still reveals explicitly headful E2E without activation', () => {
+    const window = makeWindow()
+    showWindowWithoutStealingFocus(window, { ORCA_E2E_HEADFUL: '1' })
     expect(window.showInactive).toHaveBeenCalledOnce()
     expect(window.show).not.toHaveBeenCalled()
   })
@@ -83,18 +101,21 @@ describe('applyBackgroundActivationPolicy', () => {
     }
   }
 
-  it('drops the macOS Dock tile and menu bar for headless runs', () => {
-    const app = makeApp()
-    expect(
-      applyBackgroundActivationPolicy({
-        app,
-        env: { ORCA_E2E_HEADLESS: '1' },
-        platform: 'darwin'
-      })
-    ).toBe(true)
-    expect(app.dock.hide).toHaveBeenCalledOnce()
-    expect(app.setActivationPolicy).toHaveBeenCalledWith('accessory')
-  })
+  it.each(['ORCA_E2E_HEADLESS', 'ORCA_BACKGROUND_LAUNCH'])(
+    'drops the macOS Dock tile and menu bar for %s',
+    (flag) => {
+      const app = makeApp()
+      expect(
+        applyBackgroundActivationPolicy({
+          app,
+          env: { [flag]: '1' },
+          platform: 'darwin'
+        })
+      ).toBe(true)
+      expect(app.dock.hide).toHaveBeenCalledOnce()
+      expect(app.setActivationPolicy).toHaveBeenCalledWith('accessory')
+    }
+  )
 
   it('leaves a headful or user launch with its normal Dock presence', () => {
     const headful = makeApp()

--- a/src/main/window/foreground-activation-policy.ts
+++ b/src/main/window/foreground-activation-policy.ts
@@ -5,8 +5,8 @@ import { app as electronApp, type BrowserWindow } from 'electron'
  * validation). These runs may use the machine, but must never take the OS
  * foreground away from whatever the developer is doing.
  *
- * ORCA_BACKGROUND_LAUNCH=1 opts a normal launch in; ORCA_E2E_FOREGROUND=1 opts
- * back out for the few specs whose subject *is* native focus (IME, key events).
+ * ORCA_BACKGROUND_LAUNCH=1 keeps automation off screen. Native-focus specs
+ * can use ORCA_E2E_FOREGROUND=1 only without an explicit background request.
  */
 
 type ActivationPolicyApp = {
@@ -19,19 +19,21 @@ type PolicyEnv = Readonly<Record<string, string | undefined>>
 
 /** True when this process must not steal focus, raise windows, or activate the app. */
 export function isBackgroundLaunch(env: PolicyEnv = process.env): boolean {
+  if (env.ORCA_BACKGROUND_LAUNCH === '1') {
+    return true
+  }
   if (env.ORCA_E2E_FOREGROUND === '1') {
     return false
   }
-  return (
-    env.ORCA_BACKGROUND_LAUNCH === '1' ||
-    env.ORCA_E2E_HEADLESS === '1' ||
-    env.ORCA_E2E_HEADFUL === '1'
-  )
+  return env.ORCA_E2E_HEADLESS === '1' || env.ORCA_E2E_HEADFUL === '1'
 }
 
-/** True when no window should reach the screen at all (headless E2E; Playwright drives via CDP). */
+/** True when no window should reach the screen at all (background or headless E2E; Playwright drives via CDP). */
 export function isWindowlessLaunch(env: PolicyEnv = process.env): boolean {
-  return isBackgroundLaunch(env) && env.ORCA_E2E_HEADLESS === '1' && env.ORCA_E2E_HEADFUL !== '1'
+  return (
+    env.ORCA_BACKGROUND_LAUNCH === '1' ||
+    (isBackgroundLaunch(env) && env.ORCA_E2E_HEADLESS === '1' && env.ORCA_E2E_HEADFUL !== '1')
+  )
 }
 
 /**
@@ -63,7 +65,7 @@ export function applyBackgroundActivationPolicy(
 
 /**
  * Reveal a window without taking the foreground: hidden entirely when windowless,
- * `showInactive()` (visible, not raised over the active app) in background launches.
+ * `showInactive()` for explicitly headful E2E runs.
  */
 export function showWindowWithoutStealingFocus(
   window: BrowserWindow,

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -6,16 +6,18 @@ take the foreground — no window raised over the editor, no focus stolen, no Do
 `src/main/window/foreground-activation-policy.ts` enforces this in the main process. It is on
 whenever `ORCA_E2E_HEADLESS=1`, `ORCA_E2E_HEADFUL=1`, or `ORCA_BACKGROUND_LAUNCH=1`:
 
-- headless → the window never reaches the screen (Playwright drives it via CDP)
-- headful / background → `showInactive()`, no `app.focus({ steal: true })`, no
+- headless / explicit background → the window never reaches the screen (Playwright drives it via CDP)
+- headful without explicit background → `showInactive()`, no `app.focus({ steal: true })`, no
   `moveTop()`/always-on-top reinforcement
-- macOS headless → `accessory` activation policy, so no Dock tile and no menu-bar takeover
+- macOS headless / explicit background → `accessory` activation policy, so no Dock tile and no menu-bar takeover
 
 Rules when adding tests or scripts:
 
 - Launch through `tests/e2e/helpers/orca-app.ts` (or `orca-restart.ts`) — they already set the env.
 - A raw `electron.launch()` outside those helpers must pass `ORCA_BACKGROUND_LAUNCH: '1'`.
-- Call `showInactive()`, never `show()`, when an `app.evaluate()` block reveals a window.
+- Do not reveal windows in explicit background or headless runs. Only an explicitly headful run
+  may call `showInactive()`; never call `show()` or `bringToFront()` in automated background checks.
 - Tag a spec `@headful` only when it needs real pixels; it still runs in the background.
 - `ORCA_E2E_FOREGROUND=1` is the only opt-out, for runs whose subject _is_ native focus (IME and
-  other OS-level key injection). Add a comment saying why.
+  other OS-level key injection). Clear `ORCA_BACKGROUND_LAUNCH` for that isolated run and add a
+  comment saying why; an explicit background request takes precedence.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

“Run in the background” should keep the test app off your screen. Orca's background flag previously displayed an inactive window and kept its normal macOS Dock presence. Explicit background runs now keep the window hidden, while Playwright can still inspect and screenshot the renderer through CDP.

## What changed

- `ORCA_BACKGROUND_LAUNCH=1` now selects the existing windowless path and takes precedence over inherited foreground-test flags.
- Reopen/second-instance handling cannot restore a minimized window in windowless mode.
- The existing macOS accessory activation policy now applies to explicit background runs too.
- Update the dev-runner message and test instructions to describe hidden background validation. Normal launches and explicitly headful E2E without the background flag retain their existing behavior.

Requested directly by the user during the performance audit. No GitHub issue was opened.

## Validation

- 42 tests pass across foreground policy, second-instance activation, and startup ready/load/fallback paths. Platform branches cover macOS, Linux and Windows. Native foreground opt-in still works when explicit background mode is absent.
- `pnpm tc` passes across node, CLI and renderer with the current audit changes present; scoped lint passes.
- Launched the patched dev app on macOS with an isolated profile and `ORCA_BACKGROUND_LAUNCH=1`. Playwright CDP confirmed this worktree's app identity and captured its rendered Markdown document.
- Native macOS observation of that exact process: `active=false activationPolicy=1 onScreenWindows=0` (`1` is accessory). No foreground baseline was launched for comparison, honoring the user's request.

This verifies the running app's hidden/inactive state and usable CDP renderer, not every native startup instant or all platforms' native window managers. Linux/Windows native runs remain untested.

## User-facing trade-offs

Normal user launches are unchanged. Explicit background automation is intentionally no longer visible or manually focusable through the reopen path; use CDP, or run an explicitly foreground/headful test on an isolated machine when native focus is the subject. No polling, subprocesses, remote wire fields, Git commands, or workspace semantics are added.

## Visual proof

The native visibility observation is the relevant oracle: zero on-screen windows. The renderer remains screenshot-capable through CDP. Reproducing the old foreground behavior on the user's desktop was deliberately avoided.

## Review

- [x] Focused change; regression tests cover native-operation suppression and ordinary-launch compatibility.
- [x] Agent skill upstream boundary: not applicable.
- [ ] Remaining build/platform checks: CI.
