### PR TITLE
feat(agents): recognize omo / senpi as a known agent

### DIFF
--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -584,7 +584,8 @@
           "da41abbdd4": "Ante",
           "060d152fb5": "Trae",
           "d443a47995": "Prime Agent",
-          "mimo_code_label": "MiMo Code"
+          "mimo_code_label": "MiMo Code",
+          "20f4d5938b": "omo"
         },
         "skill": {
           "cli": {

--- a/src/renderer/src/lib/agent-catalog.tsx
+++ b/src/renderer/src/lib/agent-catalog.tsx
@@ -301,6 +301,15 @@ export const getAgentCatalog = createLocalizedCatalog((): AgentCatalogEntry[] =>
     homepageUrl: 'https://devin.ai/cli'
   },
   {
+    id: 'omo',
+    label: translate('auto.lib.agent.catalog.20f4d5938b', 'omo'),
+    // Why: `omo` is the native build (npm `omo-ai`); the original `senpi`
+    // (npm `@code-yeongyu/senpi`) is recognized as an alias of the same agent.
+    cmd: 'omo',
+    faviconDomain: 'github.com',
+    homepageUrl: 'https://github.com/code-yeongyu/oh-my-openagent'
+  },
+  {
     id: 'openclaw',
     label: translate('auto.lib.agent.catalog.5dff448636', 'OpenClaw'),
     cmd: 'openclaw',

--- a/src/renderer/src/lib/agent-status.ts
+++ b/src/renderer/src/lib/agent-status.ts
@@ -108,6 +108,7 @@ const ICONABLE_AGENT_TYPES: Record<TuiAgent, true> = {
   pi: true,
   omp: true,
   'prime-agent': true,
+  omo: true,
   gemini: true,
   antigravity: true,
   aider: true,

--- a/src/shared/agent-kind.ts
+++ b/src/shared/agent-kind.ts
@@ -49,7 +49,8 @@ const TUI_AGENT_KIND_BY_AGENT = {
   grok: 'grok',
   devin: 'devin',
   ante: 'ante',
-  trae: 'trae'
+  trae: 'trae',
+  omo: 'omo'
 } satisfies Record<TuiAgent, ConcreteAgentKind>
 
 // Why: `satisfies Record<TuiAgent, …>` makes the lookup exhaustive at compile

--- a/src/shared/agent-process-recognition.test.ts
+++ b/src/shared/agent-process-recognition.test.ts
@@ -178,6 +178,20 @@ describe('agent process recognition', () => {
     expect(isRecognizedAgentType('vibe')).toBe(true)
   })
 
+  it('recognizes omo under both of its executable names', () => {
+    // One agent, two entry points: `omo` is the native build (npm `omo-ai`),
+    // `senpi` the original (npm `@code-yeongyu/senpi`).
+    expect(recognizeAgentProcess('/home/dev/.local/bin/omo')).toEqual({
+      agent: 'omo',
+      processName: 'omo'
+    })
+    expect(recognizeAgentProcess('senpi')).toEqual({
+      agent: 'omo',
+      processName: 'senpi'
+    })
+    expect(isRecognizedAgentType('senpi')).toBe(true)
+  })
+
   it('recognizes Qwen Code by its installed qwen executable', () => {
     expect(recognizeAgentProcess('/home/dev/.local/bin/qwen')).toEqual({
       agent: 'qwen-code',

--- a/src/shared/skills-cli-agent-keys.ts
+++ b/src/shared/skills-cli-agent-keys.ts
@@ -23,6 +23,7 @@ export const SKILLS_CLI_AGENT_KEY_BY_TUI_AGENT = {
   pi: 'pi',
   omp: null,
   'prime-agent': null,
+  omo: null,
   gemini: 'gemini-cli',
   antigravity: 'antigravity',
   aider: null,

--- a/src/shared/telemetry-property-schemas.ts
+++ b/src/shared/telemetry-property-schemas.ts
@@ -44,6 +44,7 @@ export const AGENT_KIND_VALUES = [
   'devin',
   'ante',
   'trae',
+  'omo',
   'other'
 ] as const
 export const agentKindSchema = z.enum(AGENT_KIND_VALUES)

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -232,6 +232,15 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     windowsShiftEnterEncoding: 'csi-u',
     ctrlEnterEncoding: 'csi-u'
   },
+  omo: {
+    // Why: one agent with two entry points — `omo` is the native build (npm `omo-ai`),
+    // `senpi` the original (npm `@code-yeongyu/senpi`); either binary means the same agent.
+    detectCmd: 'omo',
+    detectCmdAliases: ['senpi'],
+    // Why: conservative until omo's argv surface is confirmed — typing into the started
+    // TUI works for any agent, while a wrong --flag would launch nothing.
+    promptInjectionMode: 'stdin-after-start'
+  },
   kimi: {
     detectCmd: 'kimi',
     promptInjectionMode: 'stdin-after-start'

--- a/src/shared/tui-agent-display-names.ts
+++ b/src/shared/tui-agent-display-names.ts
@@ -35,6 +35,7 @@ export const TUI_AGENT_DISPLAY_NAMES: Record<TuiAgent, string> = {
   cursor: 'Cursor',
   droid: 'Droid',
   kimi: 'Kimi',
+  omo: 'omo',
   'mistral-vibe': 'Mistral Vibe',
   'qwen-code': 'Qwen Code',
   rovo: 'Rovo Dev',

--- a/src/shared/tui-agent-selection.ts
+++ b/src/shared/tui-agent-selection.ts
@@ -39,6 +39,7 @@ export const TUI_AGENT_AUTO_PICK_ORDER = [
   'rovo',
   'hermes',
   'devin',
+  'omo',
   'openclaw'
 ] as const satisfies readonly TuiAgent[]
 

--- a/src/shared/tui-agent.ts
+++ b/src/shared/tui-agent.ts
@@ -37,3 +37,4 @@ export type TuiAgent =
   | 'ante' // Ante (Antigma Labs)
   | 'trae' // Trae CLI
   | 'prime-agent' // Prime Agent (Prime Intellect)
+  | 'omo' // OmO Native / senpi (code-yeongyu)


### PR DESCRIPTION
## ELI5

`senpi` and its newer native build `omo` are real CLI agents, but Orca did not know their names — so they ran as plain terminal commands and missed everything Orca does for a *known* agent (status in the sidebar, the agent picker, reuse of an existing terminal, telemetry attribution). They are two binaries for the same agent, so this adds one catalog entry, `omo`, that recognizes both.

## What Changed

One agent, eleven files — all of them places the type system forces to stay exhaustive over `TuiAgent`:

- **`tui-agent.ts`** — `'omo'` joins the union.
- **`tui-agent-config.ts`** — `detectCmd: 'omo'`, `detectCmdAliases: ['senpi']`, `promptInjectionMode: 'stdin-after-start'`.
- **`agent-catalog.tsx`** — the catalog entry (label, cmd, homepage) that drives the picker.
- **`tui-agent-selection.ts`** — a slot in `TUI_AGENT_AUTO_PICK_ORDER`, which a ratchet test requires to match the catalog exactly, in order.
- **`agent-kind.ts` + `telemetry-property-schemas.ts`** — `omo` as its own `AgentKind` rather than falling into `'other'`.
- **`tui-agent-display-names.ts`**, **`skills-cli-agent-keys.ts`**, **`agent-status.ts`** — the remaining `Record<TuiAgent, …>` maps.
- **`en.json`** — the label, via `pnpm sync:localization-catalog`.

## Why

The catalog already lists a long tail of smaller CLI agents including Pi and oh-my-pi, so the bar is "a real CLI agent with real users" rather than a popularity cutoff, and these clear it.

**Why one entry and not two.** `omo` (npm `omo-ai`) is the native build of `senpi` (npm `@code-yeongyu/senpi`) — the same agent, two entry points. Two catalog entries would show one agent twice in the picker and split its status and telemetry. `detectCmdAliases` is exactly the mechanism for this and is already used by `mistral-vibe` (`vibe` + `mistral-vibe`) and `claude-agent-teams` (`orca` + `orca-dev` + `orca-ide`). It also feeds `PROCESS_TO_AGENT`, so a pane running either binary is recognized as the same agent — which is what makes terminal reuse work. (That mechanism's absence is the bug in #18633, for kimi.)

**Why `stdin-after-start`.** I do not have this CLI installed and could not verify its argv surface, so I picked the mode that cannot be wrong by construction: typing the prompt into the TUI after it starts works for any agent. `argv` or `flag-prompt` would assume a positional or a `--prefill`-style flag, and a wrong guess there launches nothing. `kimi` uses the same conservative mode. If the maintainers or the issue author know omo accepts a prompt argument, upgrading is a one-line change that makes prompt injection instant instead of typed.

**Why `github.com` for the favicon.** The project has no dedicated domain — its home is the GitHub repo — and `AgentCatalogEntry` requires either `faviconDomain` or `iconUrl`. Happy to swap in a real mark; the issue author offered logos.

## Linked Issue

Fixes #18573

## Visual Proof

`N/A` — no layout or styling change. The visible difference is one more row in existing lists, rendered by the existing catalog components:

| surface | before | after |
|---|---|---|
| Settings → agent picker | no omo | `omo` row, with its icon and homepage link |
| Sidebar pane running `omo` or `senpi` | generic terminal | recognized as the `omo` agent |
| `orca worktree ps` / telemetry | `other` | `omo` |

## Testing

`src/shared/agent-process-recognition.test.ts` — `recognizes omo under both of its executable names` asserts `recognizeAgentProcess` maps `/home/dev/.local/bin/omo` **and** `senpi` to the same `omo` agent, and that `isRecognizedAgentType('senpi')` is true. It mirrors the existing Mistral Vibe alias case. I confirmed it fails with `detectCmdAliases` removed, so it pins the alias rather than the entry.

The exhaustiveness ratchets did most of the verification here and are worth naming, because they caught two integration points I would otherwise have missed: `pnpm tc` rejected the four `Record<TuiAgent, …>` maps until each was filled in, and `quick-workspace-agent-selection.test.ts > keeps the fallback order in sync with the desktop agent catalog` failed until `TUI_AGENT_AUTO_PICK_ORDER` and `AGENT_CATALOG` matched element-for-element.

Ran on macOS: `src/shared/` and `src/renderer/` in full — 4,201 files, 36,593 tests, all passing — plus `pnpm tc`, `pnpm run check:code-quality:changed`, and the localization catalog/extraction gates. CI covers the full `pnpm test` and `pnpm build`.

Not tested: launching the real binary. I do not have `omo` or `senpi` installed, so detection and prompt injection against the live CLI are unverified — see Notes.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The integration points were found by adding the union member and letting `pnpm tc` and the ratchet tests enumerate what broke, rather than by guessing a list; the change, test, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code. Detection normalizes process names and already handles Windows `.cmd`/`.exe` suffixes (`isExpectedAgentProcess` matches `name.` prefixes), so both binaries resolve on all three.
- **Remote / SSH:** none. Agent detection runs on the execution host through the existing shared config, which ships to remote hosts unchanged. No RPC params or stream frames.
- **Wire compatibility:** `omo` is a new *value* in the existing `agentKindSchema` enum, not a new field or opcode. Worth a reviewer's eye anyway: an older client receiving `agentType: "omo"` from a newer host falls back to `'other'` via `tuiAgentToAgentKind`'s documented `?? 'other'` escape hatch rather than failing validation — which is what that fallback exists for.
- **Mobile:** not affected.
- **Backwards compatibility:** purely additive. No persisted state changes; `DEFAULT_DISABLED_TUI_AGENTS` stays empty, so the agent is available but nothing is auto-selected differently — omo sits near the end of the auto-pick order, so it can only be chosen when no earlier agent is detected.
- **Performance:** one more entry in maps built once at module load.
- **Security:** no new input surface. Orca launches the binary the user already has on `PATH`, exactly as it does for every other catalog agent.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

**What a reviewer with the CLI should check**, since I could not: that `omo` and `senpi` are the actual installed binary names on `PATH` (the issue states this, and the npm packages support it, but I verified neither by running them), and whether `promptInjectionMode` can be upgraded from `stdin-after-start` to `argv`/`flag-prompt`. Both are one-line changes.

`skills-cli-agent-keys` gets `null` — the community `skills` CLI has no `--agent` key for this agent, so skills installs must not claim one. Same as `pi`, `omp`, `aider`, and `prime-agent`.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
