### PR TITLE
perf(editor): reuse live Markdown search matches across unrelated renders

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-search-matches-cache.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-search-matches-cache.test.ts
@@ -1,0 +1,93 @@
+import { Schema } from '@tiptap/pm/model'
+import { describe, expect, it, vi } from 'vitest'
+import { findRichMarkdownSearchMatches } from './rich-markdown-search'
+import { createRichMarkdownSearchMatchesCache } from './rich-markdown-search-matches-cache'
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: { content: 'text*' },
+    text: {}
+  }
+})
+
+function createDoc(text = 'Beta beta betas', count = 1) {
+  return schema.node(
+    'doc',
+    null,
+    Array.from({ length: count }, () => schema.node('paragraph', null, schema.text(text)))
+  )
+}
+
+describe('rich markdown search match reuse', () => {
+  it('keeps separate live and debounced results without rewalking the document', () => {
+    const doc = createDoc()
+    const find = createRichMarkdownSearchMatchesCache()
+    const walk = vi.spyOn(doc, 'nodesBetween')
+    const highlighted = find(doc, 'beta')
+    const live = find(doc, 'betas')
+    for (let index = 0; index < 100; index++) {
+      expect(find(doc, 'beta')).toBe(highlighted)
+      expect(find(doc, 'betas')).toBe(live)
+    }
+    expect(walk).toHaveBeenCalledTimes(2)
+  })
+
+  it('keys by document and both matching options', () => {
+    const find = createRichMarkdownSearchMatchesCache()
+    const doc = createDoc()
+    const anyCase = find(doc, 'beta')
+    expect(find(doc, 'beta', { matchCase: false, wholeWord: false })).toBe(anyCase)
+    for (const options of [
+      { matchCase: true },
+      { wholeWord: true },
+      { matchCase: true, wholeWord: true }
+    ]) {
+      expect(find(doc, 'beta', options)).toEqual(
+        findRichMarkdownSearchMatches(doc, 'beta', options)
+      )
+    }
+    const changedDoc = createDoc('A different beta')
+    expect(find(changedDoc, 'beta')).toEqual(findRichMarkdownSearchMatches(changedDoc, 'beta'))
+    expect(find(doc, 'beta')).not.toBe(anyCase)
+  })
+
+  it('bounds retained results to two queries for one document', () => {
+    const find = createRichMarkdownSearchMatchesCache()
+    const doc = createDoc()
+    const first = find(doc, 'beta')
+    find(doc, 'Beta')
+    find(doc, 'betas')
+    expect(find(doc, 'beta')).not.toBe(first)
+  })
+})
+
+it.skipIf(process.env.ORCA_SEARCH_CACHE_BENCH !== '1')(
+  'benchmarks repeated live-match checks',
+  () => {
+    for (const blockCount of [250, 1000]) {
+      const doc = createDoc('Beta beta betas with searchable content', blockCount)
+      const find = createRichMarkdownSearchMatchesCache()
+      const expected = findRichMarkdownSearchMatches(doc, 'beta')
+      expect(find(doc, 'beta')).toEqual(expected)
+      const measure = (run: () => unknown) => {
+        const samples: number[] = []
+        for (let round = 0; round < 5; round++) {
+          const start = performance.now()
+          for (let index = 0; index < 100; index++) {
+            run()
+          }
+          samples.push((performance.now() - start) / 100)
+        }
+        return samples.sort((a, b) => a - b)[2]!
+      }
+      const beforeMs = measure(() =>
+        findRichMarkdownSearchMatches(doc, 'beta').some((match) => match.touchesReadOnlyAtom)
+      )
+      const afterMs = measure(() => find(doc, 'beta').some((match) => match.touchesReadOnlyAtom))
+      process.stdout.write(
+        `${JSON.stringify({ blockCount, matchCount: expected.length, beforeMs, afterMs })}\n`
+      )
+    }
+  }
+)

--- a/src/renderer/src/components/editor/rich-markdown-search-matches-cache.ts
+++ b/src/renderer/src/components/editor/rich-markdown-search-matches-cache.ts
@@ -1,0 +1,36 @@
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model'
+import type { TextMatchOptions } from './markdown-preview-search'
+import { findRichMarkdownSearchMatches, type RichMarkdownSearchMatch } from './rich-markdown-search'
+
+type CachedMatches = {
+  query: string
+  matchCase: boolean
+  wholeWord: boolean
+  matches: RichMarkdownSearchMatch[]
+}
+
+export function createRichMarkdownSearchMatchesCache(): typeof findRichMarkdownSearchMatches {
+  let previousDoc: ProseMirrorNode | undefined
+  let entries: CachedMatches[] = []
+
+  return (doc, query, options: TextMatchOptions = {}, stats) => {
+    if (doc !== previousDoc) {
+      previousDoc = doc
+      entries = []
+    }
+    const matchCase = options.matchCase ?? false
+    const wholeWord = options.wholeWord ?? false
+    const existing = entries.find(
+      (entry) =>
+        entry.query === query && entry.matchCase === matchCase && entry.wholeWord === wholeWord
+    )
+    if (existing) {
+      return existing.matches
+    }
+
+    const matches = findRichMarkdownSearchMatches(doc, query, options, stats)
+    // The live replacement guard and debounced highlights can have different queries.
+    entries = [...entries.slice(-1), { query, matchCase, wholeWord, matches }]
+    return matches
+  }
+}

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.reuse.test.tsx
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.reuse.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { Schema, type Node as ProseMirrorNode } from '@tiptap/pm/model'
+import { EditorState } from '@tiptap/pm/state'
+import type { Editor } from '@tiptap/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as visibleText from './rich-markdown-visible-text-map'
+import { useRichMarkdownSearch } from './useRichMarkdownSearch'
+
+vi.mock('@/store', () => ({
+  useAppStore: (select: (state: unknown) => unknown) => select({ keybindings: {} })
+}))
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: { content: 'inline*' },
+    text: { group: 'inline' },
+    atom: {
+      group: 'inline',
+      inline: true,
+      atom: true,
+      attrs: { label: {} },
+      leafText: (node) => node.attrs.label
+    }
+  }
+})
+
+function createDoc(atomLabel = 'locked') {
+  return schema.node(
+    'doc',
+    null,
+    schema.node('paragraph', null, [
+      schema.text('beta beta '),
+      schema.node('atom', { label: atomLabel })
+    ])
+  )
+}
+
+function mountSearch() {
+  let state = EditorState.create({ doc: createDoc() })
+  const listeners = new Set<() => void>()
+  const editor = {
+    get state() {
+      return state
+    },
+    commands: { focus: vi.fn() },
+    on: (_event: string, listener: () => void) => listeners.add(listener),
+    off: (_event: string, listener: () => void) => listeners.delete(listener),
+    registerPlugin: vi.fn(),
+    unregisterPlugin: vi.fn(),
+    view: {
+      dispatch: (tr: EditorState['tr']) => {
+        state = state.apply(tr)
+        if (tr.docChanged) {
+          listeners.forEach((listener) => listener())
+        }
+      }
+    }
+  } as unknown as Editor
+  const hook = renderHook(() =>
+    useRichMarkdownSearch({
+      editor,
+      rootRef: { current: null },
+      scrollContainerRef: { current: null }
+    })
+  )
+  return {
+    hook,
+    editor,
+    replaceDocSilently: (doc: ProseMirrorNode) => {
+      state = EditorState.create({ doc })
+    }
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('live rich markdown search reuse', () => {
+  it('does not rescan while typing replacement text, navigating, or publishing debounced highlights', () => {
+    vi.useFakeTimers()
+    const walk = vi.spyOn(visibleText, 'createRichMarkdownVisibleTextMap')
+    const { hook } = mountSearch()
+    act(() => hook.result.current.openSearch())
+    act(() => hook.result.current.searchActions.setSearchQuery('beta'))
+    expect(walk).toHaveBeenCalledTimes(1)
+    act(() => vi.advanceTimersByTime(150))
+    expect(hook.result.current.searchState.matchCount).toBe(2)
+    for (let index = 0; index < 20; index++) {
+      act(() => hook.result.current.searchActions.setReplaceQuery(`replacement ${index}`))
+      act(() => hook.result.current.searchActions.moveToMatch(1))
+    }
+    expect(walk).toHaveBeenCalledTimes(1)
+    act(() => hook.result.current.searchActions.closeSearch())
+    act(() => hook.result.current.openSearch())
+    act(() => hook.result.current.searchActions.setSearchQuery('beta'))
+    expect(walk).toHaveBeenCalledTimes(2)
+    hook.unmount()
+  })
+
+  it('uses the immediate query for atom guards and replacements during the debounce window', () => {
+    vi.useFakeTimers()
+    const { hook, editor } = mountSearch()
+    act(() => hook.result.current.openSearch())
+    act(() => hook.result.current.searchActions.setSearchQuery('beta'))
+    act(() => vi.advanceTimersByTime(150))
+    act(() => hook.result.current.searchActions.setSearchQuery('locked'))
+    expect(hook.result.current.searchState.matchCount).toBe(2)
+    expect(hook.result.current.searchState.replaceDisabled).toBe(true)
+    const doc = editor.state.doc
+    act(() => hook.result.current.searchActions.replaceAllMatches())
+    expect(editor.state.doc).toBe(doc)
+    act(() => hook.result.current.searchActions.setSearchQuery('beta'))
+    act(() => hook.result.current.searchActions.setReplaceQuery('changed'))
+    act(() => hook.result.current.searchActions.replaceAllMatches())
+    expect(editor.state.doc.textContent).toBe('changed changed locked')
+    hook.unmount()
+  })
+
+  it('checks the latest document even before an editor update reaches React', () => {
+    vi.useFakeTimers()
+    const { hook, editor, replaceDocSilently } = mountSearch()
+    act(() => hook.result.current.openSearch())
+    act(() => hook.result.current.searchActions.setSearchQuery('beta'))
+    act(() => vi.advanceTimersByTime(150))
+    replaceDocSilently(createDoc('beta'))
+    const doc = editor.state.doc
+    act(() => hook.result.current.searchActions.replaceCurrentMatch())
+    expect(editor.state.doc).toBe(doc)
+    hook.unmount()
+  })
+})

--- a/src/renderer/src/components/editor/useRichMarkdownSearch.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownSearch.ts
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import type { Editor } from '@tiptap/react'
 import { TextSelection } from '@tiptap/pm/state'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
@@ -14,6 +13,7 @@ import {
   findRichMarkdownSearchMatches,
   richMarkdownSearchPluginKey
 } from './rich-markdown-search'
+import { createRichMarkdownSearchMatchesCache } from './rich-markdown-search-matches-cache'
 
 export function useRichMarkdownSearch({
   editor,
@@ -27,6 +27,13 @@ export function useRichMarkdownSearch({
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const keybindings = useAppStore((state) => state.keybindings)
   const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const findMatches = useMemo(
+    () =>
+      editor && isSearchOpen
+        ? createRichMarkdownSearchMatchesCache()
+        : findRichMarkdownSearchMatches,
+    [editor, isSearchOpen]
+  )
   const [isReplaceMode, setIsReplaceMode] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [replaceQuery, setReplaceQuery] = useState('')
@@ -57,13 +64,13 @@ export function useRichMarkdownSearch({
     if (!editor || !isSearchOpen || !searchRequestQuery) {
       return []
     }
-    return findRichMarkdownSearchMatches(editor.state.doc, searchRequestQuery, {
+    return findMatches(editor.state.doc, searchRequestQuery, {
       matchCase,
       wholeWord
     })
     // searchRevision is bumped on ProseMirror doc edits to trigger recomputation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, isSearchOpen, searchRequestQuery, searchRevision, matchCase, wholeWord])
+  }, [editor, findMatches, isSearchOpen, searchRequestQuery, searchRevision, matchCase, wholeWord])
 
   const matchCount = matches.length
 
@@ -78,11 +85,11 @@ export function useRichMarkdownSearch({
     }
     // Why: replace mutates document ranges immediately, so it must use the
     // current input value instead of the debounced highlight match set.
-    return findRichMarkdownSearchMatches(editor.state.doc, searchQuery, {
+    return findMatches(editor.state.doc, searchQuery, {
       matchCase,
       wholeWord
     })
-  }, [editor, isSearchOpen, matchCase, searchQuery, wholeWord])
+  }, [editor, findMatches, isSearchOpen, matchCase, searchQuery, wholeWord])
 
   // Why: mirror the guard used by replaceCurrentMatch/replaceAllMatches so the
   // disabled state never disagrees with what a click will actually do during the


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## ELI5

Typing replacement text or jumping to the next match does not change what the document contains. Orca was searching the whole document again on those renders. It now reuses the same search results until the document or search options change.

## What changed

Add a bounded matcher cache owned by the open search hook. It retains up to two query results for the current immutable ProseMirror document so immediate replacement guards and debounced highlights can safely use different queries. Document identity, query, case and whole-word options remain part of the key. Closing search or changing editor resets ownership. The current-input guard still runs immediately, preserving read-only atoms and replacements during the debounce interval.

Requested as part of the performance audit. No GitHub issue was opened.

## Measurements

MacOS / Node 24.18, repeated production matcher-plus-replacement-guard work on real ProseMirror documents; CPU microbenchmarks, not end-to-end frame-rate claims:

| Document | Before | After |
|---|---:|---:|
| 250 blocks / 750 matches | 0.309 ms | 0.00904 ms |
| 1,000 blocks / 3,000 matches | 3.255 ms | 0.01311 ms |

Reproduce: `ORCA_SEARCH_CACHE_BENCH=1 pnpm test src/renderer/src/components/editor/rich-markdown-search-matches-cache.test.ts`.

**Real Electron, hidden CDP validation:** 251 blocks / 250 matches, ten replacement-text edits plus ten Next clicks. Search-attributed full-document walks fell from **120 to 0**; all observed full-document walks fell from **180 to 30**, because unrelated editor work remains. Both runs ended at the exact same selection (862–871) with 250 highlights and replacement text `Section 9`. Clicking Replace changed exactly one occurrence (249 original matches, one replacement), then undo restored it. Native macOS observation confirmed the app stayed inactive with zero on-screen windows.

## Visual proof

Both images were captured through CDP without showing the app on the user's desktop.

| Before | After |
|---|---|
| ![Before](https://github.com/user-attachments/assets/7f6c854b-19cb-4e02-8456-bc24716e7a0c) | ![After](https://github.com/user-attachments/assets/1f2bbda7-57c7-408a-9fa6-4b47f6188fea) |

## Testing

- Final three-file matcher/hook run: 8 tests passed with the opt-in benchmark enabled.
- Hook regression test proves one search traversal across initial query, debounce publication, 20 replacement edits and 20 navigation actions; closing/reopening invalidates.
- Tests cover current-query guards, read-only atoms, document replacement before update notification, query/options keys and bounded caching.
- `pnpm tc` passes across node, CLI and renderer. Scoped lint passes; changed-code quality gate reports zero new native, type-aware or React Doctor findings across the audit changes.
- Real rendered checks ran on macOS. Linux/Windows native UI was not run; logic is renderer/document based and applies equally to local, SSH and folder workspaces. No Git, wire or filesystem behavior changes.

Switching the hook's structure through dev HMR caused a recoverable hook-order error during comparison. Those runs were discarded; the reported before/after results came from clean renderer reloads. No diagnostic report was sent.

## Negative user-facing trade-offs

- None identified: no delayed guards, stale replacements, dropped matches or changed search semantics.
- Internal cost: at most two result arrays for the current document while search is open; prior document results are released on the next lookup and hook ownership resets on close/editor change.

## Review

- [x] Focused change, ELI5, reproducible CPU measurement and inspected rendered evidence.
- [x] Cache ownership, invalidation, read-only guards and exact replacement behavior reviewed.
- [x] Agent skill upstream boundary: not applicable.
- [ ] Remaining full build/platform checks: CI.
