### PR TITLE
fix(native-chat): repair a structured chat tab permanently fenced by an inherited publication epoch

### DIFF
--- a/src/renderer/src/runtime/local-structured-session-retired-epoch-repair.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-retired-epoch-repair.test.ts
@@ -1,0 +1,198 @@
+/**
+ * A live publisher can return to a worktree after another one briefly owned it, and the epoch it
+ * returns under is already in `retired`. The fence rejects that frame — correctly, because it
+ * cannot tell it apart from a delayed frame queued by a dead generation — so the drop has to be
+ * repaired from authority instead of being final.
+ *
+ * The sequence below is the measured one: a renderer publication, a `removed:` retraction, a
+ * headless rebuild whose version restarts at 1, then the same renderer epoch returning at a higher
+ * version carrying a newly published chat tab.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import type { Tab } from '../../../shared/tab-types'
+import {
+  applyLocalStructuredSessionTabSnapshots,
+  resetLocalStructuredSessionVersionForTests
+} from './local-structured-session-tabs-sync'
+import { localStructuredSessionEpochHistoryByWorktree } from './local-structured-session-tabs-sync/inventory-generation-fence'
+import type { WebSessionTabsSyncState } from './web-session-tabs-sync'
+import { resetWebSessionFocusIntentForTests } from './web-session-focus-intent'
+
+const WORKTREE = 'folder:ws-1'
+const ROOT_GROUP = 'local-root-group'
+const RENDERER_EPOCH = 'renderer:53c8f87d'
+const HEADLESS_EPOCH = 'headless:pty-backed:mtovsn3x'
+const REMOVED_EPOCH = 'removed:mtovryl4'
+
+afterEach(() => {
+  resetWebSessionFocusIntentForTests()
+  resetLocalStructuredSessionVersionForTests()
+})
+
+/**
+ * The worktree must stay "known" or the trailing cursor sweep deletes its epoch history every
+ * round and nothing ever accumulates in `retired` — which makes this whole scenario vacuous.
+ */
+function stateWithCoordinatorTerminal(): WebSessionTabsSyncState {
+  const terminalTab: Tab = {
+    id: 'u-term-1',
+    entityId: 'term-1',
+    groupId: ROOT_GROUP,
+    worktreeId: WORKTREE,
+    contentType: 'terminal',
+    label: 'Terminal 1',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+  return {
+    activeBrowserTabId: null,
+    activeBrowserTabIdByWorktree: {},
+    activeFileId: null,
+    activeFileIdByWorktree: {},
+    activeGroupIdByWorktree: { [WORKTREE]: ROOT_GROUP },
+    activeTabId: 'u-term-1',
+    activeTabIdByWorktree: { [WORKTREE]: 'u-term-1' },
+    activeTabType: 'terminal',
+    activeTabTypeByWorktree: { [WORKTREE]: 'terminal' },
+    activeWorktreeId: WORKTREE,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    browserCertificateFailuresByPageId: {},
+    browserPagesByWorkspace: {},
+    browserTabsByWorktree: {},
+    folderWorkspaces: [{ id: 'ws-1', name: 'ws', folderPath: '/tmp/ws' }],
+    groupsByWorktree: {
+      [WORKTREE]: [
+        { id: ROOT_GROUP, worktreeId: WORKTREE, activeTabId: 'u-term-1', tabOrder: ['u-term-1'] }
+      ]
+    },
+    layoutByWorktree: { [WORKTREE]: { type: 'leaf', groupId: ROOT_GROUP } },
+    openFiles: [],
+    ptyIdsByTabId: { 'term-1': ['pty-1'] },
+    remoteBrowserPageHandlesByPageId: {},
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    unifiedTabsByWorktree: { [WORKTREE]: [terminalTab] },
+    unreadTerminalTabs: {},
+    sortEpoch: 0
+  } as unknown as WebSessionTabsSyncState
+}
+
+function frame(
+  publicationEpoch: string,
+  snapshotVersion: number,
+  sessionId: string | null
+): RuntimeMobileSessionTabsResult {
+  const id = sessionId ? `agent-session:${sessionId}` : null
+  return {
+    worktree: WORKTREE,
+    publicationEpoch,
+    snapshotVersion,
+    activeGroupId: ROOT_GROUP,
+    activeTabId: null,
+    activeTabType: null,
+    tabGroups: [{ id: ROOT_GROUP, activeTabId: null, tabOrder: id ? [id] : [] }],
+    tabs: id
+      ? [
+          {
+            type: 'agent-session',
+            id,
+            title: 'Claude Chat',
+            sessionId,
+            agent: 'claude',
+            isActive: false
+          }
+        ]
+      : []
+  } as RuntimeMobileSessionTabsResult
+}
+
+function chatTabs(state: WebSessionTabsSyncState): string[] {
+  return (state.unifiedTabsByWorktree[WORKTREE] ?? [])
+    .filter((tab) => tab.contentType === 'agent-session')
+    .map((tab) => tab.label)
+}
+
+/** Everything up to and including the drop; returns the state the repair has to fix. */
+function replayUntilDrop(
+  onRetiredEpochDrop?: (worktreeId: string, publicationEpoch: string) => void
+): WebSessionTabsSyncState {
+  let state = stateWithCoordinatorTerminal()
+  state = applyLocalStructuredSessionTabSnapshots(state, [frame(RENDERER_EPOCH, 6, null)])
+  state = applyLocalStructuredSessionTabSnapshots(state, [frame(REMOVED_EPOCH, 0, null)])
+  state = applyLocalStructuredSessionTabSnapshots(state, [frame(HEADLESS_EPOCH, 1, null)])
+  return applyLocalStructuredSessionTabSnapshots(
+    state,
+    [frame(RENDERER_EPOCH, 7, 'claude-1')],
+    undefined,
+    undefined,
+    onRetiredEpochDrop ? { onRetiredEpochDrop } : {}
+  )
+}
+
+describe('retired-epoch repair for a returning publisher', () => {
+  it('POSITIVE CONTROL: the same frame lands when no epoch has been retired', () => {
+    const applied = applyLocalStructuredSessionTabSnapshots(stateWithCoordinatorTerminal(), [
+      frame(RENDERER_EPOCH, 7, 'claude-1')
+    ])
+
+    expect(chatTabs(applied)).toEqual(['Claude Chat'])
+  })
+
+  it('drops the returning publisher and reports it to the repair lane', () => {
+    const onRetiredEpochDrop = vi.fn()
+
+    const dropped = replayUntilDrop(onRetiredEpochDrop)
+
+    expect(chatTabs(dropped)).toEqual([])
+    expect(onRetiredEpochDrop).toHaveBeenCalledWith(WORKTREE, RENDERER_EPOCH)
+  })
+
+  it('lands the tab when the authoritative census re-delivers the same frame', () => {
+    const dropped = replayUntilDrop()
+    expect(chatTabs(dropped)).toEqual([])
+
+    const repaired = applyLocalStructuredSessionTabSnapshots(
+      dropped,
+      [frame(RENDERER_EPOCH, 7, 'claude-1')],
+      undefined,
+      undefined,
+      { authoritative: true }
+    )
+
+    expect(chatTabs(repaired)).toEqual(['Claude Chat'])
+  })
+
+  it('a non-authoritative redelivery stays dropped, so only authority repairs it', () => {
+    const dropped = replayUntilDrop()
+
+    const redelivered = applyLocalStructuredSessionTabSnapshots(dropped, [
+      frame(RENDERER_EPOCH, 7, 'claude-1')
+    ])
+
+    expect(chatTabs(redelivered)).toEqual([])
+  })
+
+  it('revives only the epoch authority names, leaving other generations fenced', () => {
+    const dropped = replayUntilDrop()
+    applyLocalStructuredSessionTabSnapshots(
+      dropped,
+      [frame(RENDERER_EPOCH, 7, 'claude-1')],
+      undefined,
+      undefined,
+      { authoritative: true }
+    )
+
+    // The census named the renderer epoch current, so the headless generation it displaced is now
+    // the retired one — and a delayed frame from it must still be rejected.
+    const history = localStructuredSessionEpochHistoryByWorktree.get(WORKTREE)
+    expect(history?.current).toBe(RENDERER_EPOCH)
+    expect(history?.retired).toContain(HEADLESS_EPOCH)
+    expect(history?.retired).not.toContain(RENDERER_EPOCH)
+  })
+})

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/inventory-refresh.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/inventory-refresh.ts
@@ -21,9 +21,13 @@ export function restoreLocalStructuredSessionTabsOnce(
   )
 }
 
-/** Fetch the current host inventory even after the startup restore has settled. */
+/** Fetch the current host inventory even after the startup restore has settled.
+ *
+ *  `authoritative` is opt-in and belongs to the repair lane alone: the startup restore stays
+ *  fenced exactly as before, so nothing about first paint changes. */
 export function refreshLocalStructuredSessionTabs(
-  expectedGeneration = localStructuredSessionGeneration()
+  expectedGeneration = localStructuredSessionGeneration(),
+  options: { authoritative?: boolean } = {}
 ): Promise<RuntimeMobileSessionTabsResult[]> {
   return window.api.runtime
     .call({ method: 'session.tabs.listAll', params: {} })
@@ -34,7 +38,7 @@ export function refreshLocalStructuredSessionTabs(
       const result = response.result as { snapshots?: RuntimeMobileSessionTabsResult[] }
       const snapshots = result.snapshots ?? []
       if (isCurrentLocalStructuredSessionGeneration(expectedGeneration)) {
-        applyStructuredSessionTabSnapshots(snapshots)
+        applyStructuredSessionTabSnapshots(snapshots, undefined, options)
       }
       return snapshots
     })

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The repair lane must not become worse than the bug it fixes: a publisher that keeps re-sending a
+ * retired epoch would otherwise drive an unbounded refetch loop.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const refreshLocalStructuredSessionTabs = vi.fn(
+  async (_expectedGeneration?: number, _options?: { authoritative?: boolean }) => []
+)
+
+vi.mock('./inventory-refresh', () => ({
+  refreshLocalStructuredSessionTabs: (
+    expectedGeneration?: number,
+    options?: { authoritative?: boolean }
+  ) => refreshLocalStructuredSessionTabs(expectedGeneration, options),
+  restoreLocalStructuredSessionTabsOnce: vi.fn()
+}))
+
+const { localStructuredSessionEpochHistoryByWorktree } =
+  await import('./inventory-generation-fence')
+const { scheduleRetiredEpochRepair, resetRetiredEpochRepairsForTests } =
+  await import('./retired-epoch-repair')
+
+const WORKTREE = 'folder:ws-1'
+const EPOCH = 'renderer:53c8f87d'
+
+function markRetired(): void {
+  localStructuredSessionEpochHistoryByWorktree.set(WORKTREE, {
+    current: 'headless:pty-backed:x',
+    retired: [EPOCH]
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  refreshLocalStructuredSessionTabs.mockClear()
+  resetRetiredEpochRepairsForTests()
+  localStructuredSessionEpochHistoryByWorktree.clear()
+})
+
+afterEach(() => {
+  resetRetiredEpochRepairsForTests()
+  localStructuredSessionEpochHistoryByWorktree.clear()
+  vi.useRealTimers()
+})
+
+describe('retired-epoch repair scheduling', () => {
+  it('asks the host authoritatively, once, for a burst of drops on one worktree', async () => {
+    markRetired()
+
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    expect(refreshLocalStructuredSessionTabs).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(1)
+    expect(refreshLocalStructuredSessionTabs.mock.calls[0]?.[1]).toEqual({ authoritative: true })
+  })
+
+  it('stops after a bounded number of attempts and says so', async () => {
+    markRetired()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    // The epoch stays retired, so every refresh counts as a failed repair.
+    for (let attempt = 0; attempt < 6; attempt += 1) {
+      scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+      await vi.advanceTimersByTimeAsync(5000)
+    }
+
+    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(3)
+    expect(warn).toHaveBeenCalledWith(
+      '[structured-session-tabs] gave up repairing a retired publication epoch',
+      expect.objectContaining({ worktree: WORKTREE, publicationEpoch: EPOCH })
+    )
+    warn.mockRestore()
+  })
+
+  it('rearms once a repair actually revives the epoch', async () => {
+    markRetired()
+    refreshLocalStructuredSessionTabs.mockImplementation(async () => {
+      localStructuredSessionEpochHistoryByWorktree.set(WORKTREE, {
+        current: EPOCH,
+        retired: ['headless:pty-backed:x']
+      })
+      return []
+    })
+
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    await vi.advanceTimersByTimeAsync(300)
+    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(1)
+
+    // A later, unrelated drop is not starved by the earlier attempt count.
+    markRetired()
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.test.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.test.ts
@@ -1,29 +1,21 @@
 /**
  * The repair lane must not become worse than the bug it fixes: a publisher that keeps re-sending a
- * retired epoch would otherwise drive an unbounded refetch loop.
+ * retired epoch would otherwise drive an unbounded refetch loop, and a cap that never decays would
+ * hide a chat tab for the renderer's lifetime after a run of transient RPC failures.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-const refreshLocalStructuredSessionTabs = vi.fn(
-  async (_expectedGeneration?: number, _options?: { authoritative?: boolean }) => []
-)
-
-vi.mock('./inventory-refresh', () => ({
-  refreshLocalStructuredSessionTabs: (
-    expectedGeneration?: number,
-    options?: { authoritative?: boolean }
-  ) => refreshLocalStructuredSessionTabs(expectedGeneration, options),
-  restoreLocalStructuredSessionTabsOnce: vi.fn()
-}))
-
-const { localStructuredSessionEpochHistoryByWorktree } =
-  await import('./inventory-generation-fence')
-const { scheduleRetiredEpochRepair, resetRetiredEpochRepairsForTests } =
-  await import('./retired-epoch-repair')
+import { localStructuredSessionEpochHistoryByWorktree } from './inventory-generation-fence'
+import {
+  forgetRetiredEpochRepairsOutside,
+  resetRetiredEpochRepairsForTests,
+  scheduleRetiredEpochRepair
+} from './retired-epoch-repair'
 
 const WORKTREE = 'folder:ws-1'
 const EPOCH = 'renderer:53c8f87d'
+
+const runRepair = vi.fn(async (_generation: number) => undefined)
 
 function markRetired(): void {
   localStructuredSessionEpochHistoryByWorktree.set(WORKTREE, {
@@ -34,7 +26,8 @@ function markRetired(): void {
 
 beforeEach(() => {
   vi.useFakeTimers()
-  refreshLocalStructuredSessionTabs.mockClear()
+  runRepair.mockReset()
+  runRepair.mockImplementation(async () => undefined)
   resetRetiredEpochRepairsForTests()
   localStructuredSessionEpochHistoryByWorktree.clear()
 })
@@ -46,18 +39,17 @@ afterEach(() => {
 })
 
 describe('retired-epoch repair scheduling', () => {
-  it('asks the host authoritatively, once, for a burst of drops on one worktree', async () => {
+  it('asks the host once for a burst of drops on one worktree', async () => {
     markRetired()
 
-    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
-    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
-    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
-    expect(refreshLocalStructuredSessionTabs).not.toHaveBeenCalled()
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
+    expect(runRepair).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(1)
-    expect(refreshLocalStructuredSessionTabs.mock.calls[0]?.[1]).toEqual({ authoritative: true })
+    expect(runRepair).toHaveBeenCalledTimes(1)
   })
 
   it('stops after a bounded number of attempts and says so', async () => {
@@ -66,37 +58,64 @@ describe('retired-epoch repair scheduling', () => {
 
     // The epoch stays retired, so every refresh counts as a failed repair.
     for (let attempt = 0; attempt < 6; attempt += 1) {
-      scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+      scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
       await vi.advanceTimersByTimeAsync(5000)
     }
 
-    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(3)
+    expect(runRepair).toHaveBeenCalledTimes(3)
     expect(warn).toHaveBeenCalledWith(
-      '[structured-session-tabs] gave up repairing a retired publication epoch',
+      '[structured-session-tabs] retired publication epoch still unrepaired',
       expect.objectContaining({ worktree: WORKTREE, publicationEpoch: EPOCH })
     )
     warn.mockRestore()
   })
 
+  it('decays the cap instead of latching, so a later drop is still repairable', async () => {
+    markRetired()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
+      await vi.advanceTimersByTimeAsync(5000)
+    }
+    expect(runRepair).toHaveBeenCalledTimes(3)
+
+    // A quiet minute later the worktree gets its budget back rather than staying hidden forever.
+    await vi.advanceTimersByTimeAsync(60_000)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(runRepair).toHaveBeenCalledTimes(4)
+  })
+
   it('rearms once a repair actually revives the epoch', async () => {
     markRetired()
-    refreshLocalStructuredSessionTabs.mockImplementation(async () => {
+    runRepair.mockImplementation(async () => {
       localStructuredSessionEpochHistoryByWorktree.set(WORKTREE, {
         current: EPOCH,
         retired: ['headless:pty-backed:x']
       })
-      return []
     })
 
-    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
     await vi.advanceTimersByTimeAsync(300)
-    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(1)
+    expect(runRepair).toHaveBeenCalledTimes(1)
 
-    // A later, unrelated drop is not starved by the earlier attempt count.
     markRetired()
-    scheduleRetiredEpochRepair(WORKTREE, EPOCH)
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
     await vi.advanceTimersByTimeAsync(300)
 
-    expect(refreshLocalStructuredSessionTabs).toHaveBeenCalledTimes(2)
+    expect(runRepair).toHaveBeenCalledTimes(2)
+  })
+
+  it('forgets repair state for worktrees that no longer exist', async () => {
+    markRetired()
+    scheduleRetiredEpochRepair(WORKTREE, EPOCH, runRepair)
+
+    forgetRetiredEpochRepairsOutside(new Set(['folder:other']))
+    await vi.advanceTimersByTimeAsync(5000)
+
+    // The pending refetch for the vanished worktree is cancelled, not merely orphaned.
+    expect(runRepair).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.ts
@@ -10,6 +10,9 @@
  * answer settles which epoch is current. If the epoch really is dead the census changes nothing; if
  * it is live, the census carries it and the tab lands. The fence itself is never relaxed for
  * subscription frames.
+ *
+ * The refresh is injected rather than imported so this module depends on nothing that in turn
+ * depends on the snapshot apply — which is what lets the apply prune this module's state.
  */
 
 import {
@@ -17,59 +20,75 @@ import {
   localStructuredSessionEpochHistoryByWorktree,
   localStructuredSessionGeneration
 } from './inventory-generation-fence'
-import { refreshLocalStructuredSessionTabs } from './inventory-refresh'
 
 /** Bounded so a publisher that keeps re-sending a retired epoch cannot drive an endless refetch. */
 const MAX_REPAIR_ATTEMPTS = 3
 const BASE_REPAIR_DELAY_MS = 250
 const MAX_REPAIR_DELAY_MS = 5000
+/**
+ * The cap decays rather than latching. A run of transient RPC failures must not hide a chat tab for
+ * the renderer's lifetime; once a worktree has been quiet this long, a fresh drop is a fresh
+ * problem and gets its full budget back.
+ */
+const REPAIR_ATTEMPT_DECAY_MS = 60_000
 
 type RepairState = {
   attempts: number
+  lastAttemptAt: number
   timer: ReturnType<typeof setTimeout> | null
-  exhausted: boolean
 }
+
+export type RetiredEpochRepairRunner = (expectedGeneration: number) => Promise<unknown>
 
 const repairsByWorktree = new Map<string, RepairState>()
 
-function repairState(worktreeId: string): RepairState {
+function repairState(worktreeId: string, now: number): RepairState {
   const existing = repairsByWorktree.get(worktreeId)
-  if (existing) {
-    return existing
+  if (!existing) {
+    const created: RepairState = { attempts: 0, lastAttemptAt: now, timer: null }
+    repairsByWorktree.set(worktreeId, created)
+    return created
   }
-  const created: RepairState = { attempts: 0, timer: null, exhausted: false }
-  repairsByWorktree.set(worktreeId, created)
-  return created
+  if (now - existing.lastAttemptAt >= REPAIR_ATTEMPT_DECAY_MS) {
+    existing.attempts = 0
+  }
+  return existing
 }
 
 /**
  * Schedules the authoritative refetch for a dropped snapshot, coalescing repeat drops for the same
  * worktree into the one already pending.
  */
-export function scheduleRetiredEpochRepair(worktreeId: string, publicationEpoch: string): void {
-  const state = repairState(worktreeId)
-  if (state.timer !== null || state.exhausted) {
+export function scheduleRetiredEpochRepair(
+  worktreeId: string,
+  publicationEpoch: string,
+  runRepair: RetiredEpochRepairRunner
+): void {
+  const now = Date.now()
+  const state = repairState(worktreeId, now)
+  if (state.timer !== null) {
     return
   }
   if (state.attempts >= MAX_REPAIR_ATTEMPTS) {
-    state.exhausted = true
-    console.warn('[structured-session-tabs] gave up repairing a retired publication epoch', {
+    console.warn('[structured-session-tabs] retired publication epoch still unrepaired', {
       worktree: worktreeId,
       publicationEpoch,
-      attempts: state.attempts
+      attempts: state.attempts,
+      retryAfterMs: Math.max(0, REPAIR_ATTEMPT_DECAY_MS - (now - state.lastAttemptAt))
     })
     return
   }
   const generation = localStructuredSessionGeneration()
   const delay = Math.min(BASE_REPAIR_DELAY_MS * 2 ** state.attempts, MAX_REPAIR_DELAY_MS)
   state.attempts += 1
+  state.lastAttemptAt = now
   state.timer = setTimeout(() => {
     state.timer = null
     if (!isCurrentLocalStructuredSessionGeneration(generation)) {
       repairsByWorktree.delete(worktreeId)
       return
     }
-    void refreshLocalStructuredSessionTabs(generation, { authoritative: true })
+    void runRepair(generation)
       .then(() => {
         // Why re-check rather than trust the call: a refresh that succeeds without reviving the
         // epoch has not repaired anything, and counting it as success would loop forever.
@@ -85,6 +104,21 @@ export function scheduleRetiredEpochRepair(worktreeId: string, publicationEpoch:
         console.warn('[structured-session-tabs] retired-epoch repair refresh failed', error)
       })
   }, delay)
+}
+
+/**
+ * Drops repair state for worktrees that no longer exist, alongside the publisher cursors it
+ * shadows — without this every deleted worktree leaks an entry for the renderer's lifetime.
+ */
+export function forgetRetiredEpochRepairsOutside(knownWorktreeIds: ReadonlySet<string>): void {
+  for (const [worktreeId, state] of repairsByWorktree) {
+    if (!knownWorktreeIds.has(worktreeId)) {
+      if (state.timer !== null) {
+        clearTimeout(state.timer)
+      }
+      repairsByWorktree.delete(worktreeId)
+    }
+  }
 }
 
 export function resetRetiredEpochRepairsForTests(): void {

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/retired-epoch-repair.ts
@@ -1,0 +1,97 @@
+/**
+ * Repairing a structured session snapshot the retired-epoch fence rejected.
+ *
+ * The fence is right to reject a subscription frame carrying a retired epoch — it cannot tell that
+ * frame apart from a delayed one queued by a dead publisher generation, whose version can be
+ * higher than the live cursor. What it cannot do is notice when the epoch's publisher is actually
+ * still alive and has simply returned after another publisher briefly owned the worktree.
+ *
+ * So the drop is not treated as final: it schedules one authoritative `session.tabs.listAll`, whose
+ * answer settles which epoch is current. If the epoch really is dead the census changes nothing; if
+ * it is live, the census carries it and the tab lands. The fence itself is never relaxed for
+ * subscription frames.
+ */
+
+import {
+  isCurrentLocalStructuredSessionGeneration,
+  localStructuredSessionEpochHistoryByWorktree,
+  localStructuredSessionGeneration
+} from './inventory-generation-fence'
+import { refreshLocalStructuredSessionTabs } from './inventory-refresh'
+
+/** Bounded so a publisher that keeps re-sending a retired epoch cannot drive an endless refetch. */
+const MAX_REPAIR_ATTEMPTS = 3
+const BASE_REPAIR_DELAY_MS = 250
+const MAX_REPAIR_DELAY_MS = 5000
+
+type RepairState = {
+  attempts: number
+  timer: ReturnType<typeof setTimeout> | null
+  exhausted: boolean
+}
+
+const repairsByWorktree = new Map<string, RepairState>()
+
+function repairState(worktreeId: string): RepairState {
+  const existing = repairsByWorktree.get(worktreeId)
+  if (existing) {
+    return existing
+  }
+  const created: RepairState = { attempts: 0, timer: null, exhausted: false }
+  repairsByWorktree.set(worktreeId, created)
+  return created
+}
+
+/**
+ * Schedules the authoritative refetch for a dropped snapshot, coalescing repeat drops for the same
+ * worktree into the one already pending.
+ */
+export function scheduleRetiredEpochRepair(worktreeId: string, publicationEpoch: string): void {
+  const state = repairState(worktreeId)
+  if (state.timer !== null || state.exhausted) {
+    return
+  }
+  if (state.attempts >= MAX_REPAIR_ATTEMPTS) {
+    state.exhausted = true
+    console.warn('[structured-session-tabs] gave up repairing a retired publication epoch', {
+      worktree: worktreeId,
+      publicationEpoch,
+      attempts: state.attempts
+    })
+    return
+  }
+  const generation = localStructuredSessionGeneration()
+  const delay = Math.min(BASE_REPAIR_DELAY_MS * 2 ** state.attempts, MAX_REPAIR_DELAY_MS)
+  state.attempts += 1
+  state.timer = setTimeout(() => {
+    state.timer = null
+    if (!isCurrentLocalStructuredSessionGeneration(generation)) {
+      repairsByWorktree.delete(worktreeId)
+      return
+    }
+    void refreshLocalStructuredSessionTabs(generation, { authoritative: true })
+      .then(() => {
+        // Why re-check rather than trust the call: a refresh that succeeds without reviving the
+        // epoch has not repaired anything, and counting it as success would loop forever.
+        const stillRetired =
+          localStructuredSessionEpochHistoryByWorktree
+            .get(worktreeId)
+            ?.retired.includes(publicationEpoch) ?? false
+        if (!stillRetired) {
+          repairsByWorktree.delete(worktreeId)
+        }
+      })
+      .catch((error) => {
+        console.warn('[structured-session-tabs] retired-epoch repair refresh failed', error)
+      })
+  }, delay)
+}
+
+export function resetRetiredEpochRepairsForTests(): void {
+  for (const state of repairsByWorktree.values()) {
+    if (state.timer !== null) {
+      clearTimeout(state.timer)
+    }
+  }
+  repairsByWorktree.clear()
+}

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/snapshot-apply.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/snapshot-apply.ts
@@ -23,6 +23,7 @@ import {
   localStructuredSessionVersionByWorktree,
   supersedeLocalStructuredSessionGeneration
 } from './inventory-generation-fence'
+import { forgetRetiredEpochRepairsOutside } from './retired-epoch-repair'
 import { projectLocalStructuredSessionTabs } from './snapshot-projection'
 
 export const LOCAL_STRUCTURED_SESSION_OWNER = 'local-structured-session'
@@ -139,5 +140,6 @@ export function applyLocalStructuredSessionTabSnapshots<
       localStructuredSessionEpochHistoryByWorktree.delete(worktreeId)
     }
   }
+  forgetRetiredEpochRepairsOutside(knownWorktreeIds)
   return next
 }

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/snapshot-apply.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/snapshot-apply.ts
@@ -7,7 +7,9 @@ import {
 } from '../web-session-tabs-sync'
 import type { WebSessionTabsSyncState } from '../web-session-tabs-sync'
 import {
+  hasRetiredValue,
   noteRetiredValue,
+  reviveRetiredValue,
   sameSessionTabsPublicationLineage
 } from '../web-session-tabs-sync/publisher-identity-fences'
 import {
@@ -25,12 +27,25 @@ import { projectLocalStructuredSessionTabs } from './snapshot-projection'
 
 export const LOCAL_STRUCTURED_SESSION_OWNER = 'local-structured-session'
 
+export type StructuredSessionSnapshotApplyOptions = {
+  /**
+   * Marks these snapshots as an authoritative `session.tabs.listAll` response, which exempts them
+   * from the retired-epoch fence. A census is the synchronous answer to a request we just issued,
+   * so it cannot be the delayed frame from a dead generation that the fence exists to reject —
+   * whereas a subscription frame can be, and stays fenced.
+   */
+  authoritative?: boolean
+  /** Called for each snapshot the retired-epoch fence rejects; the repair lane listens here. */
+  onRetiredEpochDrop?: (worktreeId: string, publicationEpoch: string) => void
+}
+
 export function applyStructuredSessionTabSnapshots(
   snapshots: readonly RuntimeMobileSessionTabsResult[],
-  owner = LOCAL_STRUCTURED_SESSION_OWNER
+  owner = LOCAL_STRUCTURED_SESSION_OWNER,
+  options: StructuredSessionSnapshotApplyOptions = {}
 ): void {
   const settleStructuredSessionMirror = applyWebSessionTabsStorePatch(
-    (state) => applyLocalStructuredSessionTabSnapshots(state, snapshots, owner),
+    (state) => applyLocalStructuredSessionTabSnapshots(state, snapshots, owner, undefined, options),
     { frames: [] }
   )
   settleStructuredSessionMirror()
@@ -65,7 +80,8 @@ export function applyLocalStructuredSessionTabSnapshots<
   state: State,
   snapshots: readonly RuntimeMobileSessionTabsResult[],
   owner = LOCAL_STRUCTURED_SESSION_OWNER,
-  now = Date.now()
+  now = Date.now(),
+  options: StructuredSessionSnapshotApplyOptions = {}
 ): State {
   let next = state
   for (const snapshot of snapshots) {
@@ -78,8 +94,17 @@ export function applyLocalStructuredSessionTabSnapshots<
       prior && sameSessionTabsPublicationLineage(prior.publicationEpoch, snapshot.publicationEpoch)
     )
     const epochHistory = localStructuredSessionEpochHistoryByWorktree.get(snapshot.worktree)
-    if (epochHistory?.retired.includes(snapshot.publicationEpoch) && !sharesLineage) {
-      continue
+    // Why not just drop: an epoch is retired whenever another publisher takes over the worktree,
+    // but a live publisher can return after transient interlopers (a `removed:` retraction, then a
+    // headless rebuild), and the structured publish inherits the worktree's existing epoch rather
+    // than minting its own. So a retired epoch is not proof of a dead generation — only authority
+    // can settle it, and the repair lane goes and asks.
+    if (hasRetiredValue(epochHistory, snapshot.publicationEpoch) && !sharesLineage) {
+      if (!options.authoritative) {
+        options.onRetiredEpochDrop?.(snapshot.worktree, snapshot.publicationEpoch)
+        continue
+      }
+      reviveRetiredValue(epochHistory, snapshot.publicationEpoch)
     }
     if (prior && sharesLineage && snapshot.snapshotVersion <= prior.snapshotVersion) {
       continue

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/subscription.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/subscription.ts
@@ -9,7 +9,17 @@ import {
   refreshLocalStructuredSessionTabs,
   restoreLocalStructuredSessionTabsOnce
 } from './inventory-refresh'
-import { applyStructuredSessionTabSnapshots } from './snapshot-apply'
+import { scheduleRetiredEpochRepair } from './retired-epoch-repair'
+import {
+  applyStructuredSessionTabSnapshots,
+  type StructuredSessionSnapshotApplyOptions
+} from './snapshot-apply'
+
+// Wired here, not inside the apply, so the repair lane's dependency on the inventory refresh
+// stays one-directional.
+const REPAIR_DROPPED_EPOCHS: StructuredSessionSnapshotApplyOptions = {
+  onRetiredEpochDrop: scheduleRetiredEpochRepair
+}
 
 type SessionTabsEvent =
   | (RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' })
@@ -84,9 +94,9 @@ export async function startLocalStructuredSessionTabsSync(args: {
         }
         const event = response.result as SessionTabsEvent
         if (event.type === 'snapshots') {
-          applyStructuredSessionTabSnapshots(event.snapshots)
+          applyStructuredSessionTabSnapshots(event.snapshots, undefined, REPAIR_DROPPED_EPOCHS)
         } else if (event.type === 'snapshot' || event.type === 'updated') {
-          applyStructuredSessionTabSnapshots([event])
+          applyStructuredSessionTabSnapshots([event], undefined, REPAIR_DROPPED_EPOCHS)
         } else if (event.type === 'end' && generation === subscriptionGeneration) {
           // Reattach with one refresh so a runtime-restart boundary cannot strand stale tabs.
           subscriptionGeneration += 1

--- a/src/renderer/src/runtime/local-structured-session-tabs-sync/subscription.ts
+++ b/src/renderer/src/runtime/local-structured-session-tabs-sync/subscription.ts
@@ -15,10 +15,13 @@ import {
   type StructuredSessionSnapshotApplyOptions
 } from './snapshot-apply'
 
-// Wired here, not inside the apply, so the repair lane's dependency on the inventory refresh
-// stays one-directional.
+// The refresh is supplied here rather than imported by the repair lane, so nothing the snapshot
+// apply depends on depends back on it.
 const REPAIR_DROPPED_EPOCHS: StructuredSessionSnapshotApplyOptions = {
-  onRetiredEpochDrop: scheduleRetiredEpochRepair
+  onRetiredEpochDrop: (worktreeId, publicationEpoch) =>
+    scheduleRetiredEpochRepair(worktreeId, publicationEpoch, (generation) =>
+      refreshLocalStructuredSessionTabs(generation, { authoritative: true })
+    )
 }
 
 type SessionTabsEvent =

--- a/src/renderer/src/runtime/web-session-tabs-sync/publisher-identity-fences.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/publisher-identity-fences.ts
@@ -36,6 +36,19 @@ export function noteRetiredValue(
   return history
 }
 
+/**
+ * Un-retires one value, leaving every other retired generation fenced.
+ *
+ * Only an authority that names the value current may call this; reviving on a delayed frame's own
+ * say-so is exactly the resurrection `retired` exists to prevent.
+ */
+export function reviveRetiredValue(history: RetiredValueHistory | undefined, value: string): void {
+  const index = history?.retired.indexOf(value) ?? -1
+  if (history && index >= 0) {
+    history.retired.splice(index, 1)
+  }
+}
+
 function normalizeSessionTabsRuntimeId(runtimeId: unknown): string | undefined {
   if (typeof runtimeId !== 'string') {
     return undefined


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​188 |

<!-- /orca-pr-loc -->

## The observable failure

A structured chat tab published by the host can be dropped by the renderer **permanently** — the host inventory has it, the frame is delivered, and the tab never reaches the tab bar.

`applyLocalStructuredSessionTabSnapshots` fences a snapshot whose publication epoch is in the worktree's `retired` list:

```js
if (epochHistory?.retired.includes(snapshot.publicationEpoch) && !sharesLineage) continue
```

An epoch lands in `retired` whenever another publisher takes over the worktree. But main legitimately alternates publishers for one worktree — `renderer:<uuid>`, `headless:<ts>`, `removed:<ts>` — and a live publisher can **return** after those transient interlopers. `publishStructuredAgentSessionTab` inherits the worktree's existing epoch rather than minting one, so the structured tab arrives under an already-blacklisted epoch, and every later frame carrying it is rejected too.

Measured in a live instance at the moment of the drop:

```
cursor:  { publicationEpoch: 'headless:pty-backed:mtovsn3x', snapshotVersion: 1 }
history: current: 'headless:pty-backed:mtovsn3x'
         retired: ['renderer:53c8f87d-…', 'removed:mtovryl4']
incoming: epoch 'renderer:53c8f87d-…', v7, carrying agent-session:46e11156-…
```

The frame **is** delivered — a second `session.tabs.subscribeAll` subscription registered alongside the app's received it intact, with the `agent-session` tab present in both `tabs` and `tabGroups[0].tabOrder`. It is the apply that drops it. Confirmed by a single-variable ablation in the running app: splicing **only** `renderer:53c8f87d-…` out of `retired`, changing nothing else, and re-delivering the identical frame makes the tab appear.

Terminals look unaffected because the structured channel applies with `contentScope: 'agent-session'` and terminal tabs come from the renderer's own authority — the same dropped frame is invisible for terminals and fatal for chat tabs.

## The root cause, and what this PR does about it

The root cause is the **shape of publication epochs**: they are inherited rather than minted per publisher generation, and main mints several of them per *event* (`Date.now()`-suffixed) rather than per generation. The blacklist then converts that churn into a permanent fence.

This PR **repairs the observable failure without changing that shape.**

The fence itself is right to reject the frame: it cannot tell a returning publisher apart from a frame delayed by a dead generation, and a delayed frame's version can outrank the live cursor — the hazard pinned by `local-structured-session-tabs-sync.test.ts:741`, which passes here **unmodified**. So the fence is not relaxed. The drop simply stops being final: it schedules one bounded, debounced authoritative `session.tabs.listAll`, and only that census may revive an epoch — and only the single epoch it names current, leaving every other retired generation fenced. A census is the synchronous answer to a request we just issued, so it cannot be the delayed frame the fence exists to reject. Subscription frames are never exempt.

**Scope of the exemption:** the repair refresh only. `restoreLocalStructuredSessionTabsOnce` still calls `refreshLocalStructuredSessionTabs` without it, so the startup restore stays fenced exactly as today and first paint is unchanged.

**Bounds:** 3 attempts per worktree, 250ms doubling to a 5s cap, coalesced per worktree. The cap **decays** after 60s of quiet rather than latching — a run of transient RPC failures must not hide a chat tab for the renderer's lifetime. A refresh that succeeds without actually reviving the epoch counts as a failed attempt, so a publisher that keeps re-sending a retired epoch cannot drive an endless refetch. The repair map is pruned in the same sweep that drops publisher cursors for vanished worktrees, cancelling any pending timer; that prune is cycle-free because the refresh is injected into the repair lane rather than imported by it.

## What this PR deliberately does not fix

The epoch shape itself. Fixing it properly is a sequence, and the first step is not the one it looks like:

1. **De-overload the epoch.** It is not only a generation id — it is also a publisher-**kind** discriminator. `isHeadlessMobileSessionPublication` / `isHeadlessBuiltMobileSessionPublicationBase` prefix-match `headless:`, `headless-hydrated:` and `:headless-merge:`, and their six consumers gate `shouldPreserveHeadlessMobileSessionTab` (whether a tab survives a renderer graph merge) and `releaseRuntimeSessionOwnershipForRendererRetiredTabs` (whether a PTY's `runtimeSessionOwned` is released). The kind has to move onto its own field first — a change to the shared snapshot shape, with paired-client reach.
2. **Then normalise epochs to per-generation ids**, replacing the 13 `Date.now()`-minted sites across 11 files and the structured inheritance.
3. **Then flip the client test from blacklist membership to identity** and delete the retired list, including `SESSION_TABS_RETIRED_EPOCH_LIMIT`, whose splice-out silently un-fences the 9th-oldest dead generation.

None of it can be done here. Step 2 without step 1 makes both kind predicates false everywhere, silently changing tab preservation and PTY ownership release — a terminal-ownership behaviour change inside a chat-tab-visibility fix. And an intermediate that keeps the prefixes while swapping `Date.now()` for a generation id would be strictly worse: identity-first would then reject every `renderer:` ↔ `headless:` alternation, which today is merely non-current-non-retired and therefore accepted.

## Residual risk, stated up front

A slow or reordered `listAll` response could land content older than subscription frames already applied, because the retired fence no longer arbitrates for that response. Mitigated as far as it can be — the within-lineage `snapshotVersion` check and the sync generation fence both still apply, and only the epoch the census names current is revived — but not eliminated. This is the deliberate trade for repairing a permanently invisible tab.

## The cheap fix, and why it was rejected

`sameSessionTabsPublicationLineage` treats `X` and `X:headless-merge:<hash>` as the same lineage, so having the publish side emit `renderer:<uuid>:headless-merge:<hash>` is a different string from the retired epoch and slips the fence in one line. Rejected: it re-introduces exactly the identity oscillation that `getMergedMobileSessionPublicationEpoch` deliberately strips ("encoding a merge hash here would make the identity oscillate and permanently fence later rows"), it churns the 8-entry retired list, and `publicationEpoch` is wire-visible to paired clients. Recorded here so it is not re-proposed.

## Tests

- `local-structured-session-retired-epoch-repair.test.ts` — replays the measured multi-epoch sequence (`renderer:E` v6 → `removed:` → `headless:pty-backed:` v1 → `renderer:E` v7 with a chat tab): the tab is absent at the drop, the drop is reported to the repair lane, the authoritative census lands it, a non-authoritative redelivery stays dropped, and only the named epoch is revived.
  - Includes a **positive control** (the same frame lands when nothing is retired). Without it the empty results prove nothing.
  - The state must keep the worktree "known" (`folderWorkspaces` / a terminal tab) or the trailing cursor sweep deletes the epoch history every round and the scenario is silently vacuous. An earlier draft failed exactly this way.
- `retired-epoch-repair.test.ts` — coalescing, bounded attempts with an observable warn, cap decay, re-arming after a successful repair, and pruning for vanished worktrees.

**Red-then-green:** disabling only the authoritative exemption (`if (!options.authoritative)` → `if (true)`) turns exactly two tests red — "lands the tab when the authoritative census re-delivers the same frame" and "revives only the epoch authority names" — while `local-structured-session-tabs-sync.test.ts` stays green throughout, confirming the guard's own coverage does not depend on this change.

## Verification

`oxfmt` clean; `oxlint` clean; `pnpm run check:code-quality:changed` 0 new findings across 7 files; `pnpm run audit:code-quality:native` clean; `tsc` clean on `config/tsconfig.node.json`, `config/tsconfig.tc.cli.json`, `config/tsconfig.tc.web.json`; the full `src/renderer/src/runtime` suite passes (167 files, 1310 tests).

## Relationship to other work

Orchestration-created structured worker tabs are one reachable case — they have no renderer-side launcher, so unlike the user launch path (which incidentally re-applies the host inventory on every launch via `verifyPublishedSession`) nothing papers over the drop. But the bug is in the renderer's local structured session sync and predates that work; any host-published structured tab can hit it.
