### PR TITLE
fix(diff): render created files inline even when Side by Side is on

### DIFF
--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -141,7 +141,7 @@ export function DiffSectionBody({
             modifiedContent={section.diffResult.modifiedContent}
             filePath={section.path}
             mimeType={section.diffResult.mimeType}
-            sideBySide={sideBySide}
+            sideBySide={resolveDiffRenderSideBySide(sideBySide, section.diffResult)}
             layout={useIntrinsicImageHeight ? 'intrinsic' : 'fill'}
           />
         ) : (

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -13,6 +13,7 @@ import { LargeDiffFallback } from './LargeDiffFallback'
 import { LargeDiffLoadPrompt } from './LargeDiffLoadPrompt'
 import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
+import { resolveDiffRenderSideBySide } from './diff-added-file-inline-mode'
 import { monacoFindOptions } from './monaco-find-options'
 
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
@@ -200,7 +201,7 @@ export function DiffSectionBody({
           options={{
             readOnly: !isEditable,
             originalEditable: false,
-            renderSideBySide: sideBySide,
+            renderSideBySide: resolveDiffRenderSideBySide(sideBySide, section),
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
             fontSize: diffEditorFontSize,

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -17,17 +17,14 @@ import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-opti
 import type { DiffComment } from '../../../../shared/diff-comment-types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
-import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { getLargeDiffRenderLimit } from './large-diff-render-limit'
 import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecycle'
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
-import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
-import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
+import { buildDiffViewerEditorOptions } from './diff-viewer-editor-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
-import { monacoFindOptions } from './monaco-find-options'
 
 export default function DiffViewer({
   modelKey,
@@ -374,6 +371,17 @@ export default function DiffViewer({
     }
   }, [sideBySide])
 
+  const diffEditorOptions = buildDiffViewerEditorOptions({
+    editable: editable ?? false,
+    sideBySide,
+    originalContent,
+    modifiedContent,
+    fontSize: diffEditorFontSize,
+    fontFamily: resolveEditorFontFamily(settings),
+    wordWrap: settings?.diffWordWrap,
+    showWhitespace: settings?.diffShowWhitespace
+  })
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div ref={diffBodyRef} className="flex-1 min-h-0 relative">
@@ -417,23 +425,7 @@ export default function DiffViewer({
             modifiedModelPath={currentDiffModelPaths.modifiedModelPath}
             keepCurrentOriginalModel
             keepCurrentModifiedModel
-            options={{
-              readOnly: !editable,
-              originalEditable: false,
-              renderSideBySide: sideBySide,
-              minimap: { enabled: false },
-              scrollBeyondLastLine: false,
-              fontSize: diffEditorFontSize,
-              fontFamily: resolveEditorFontFamily(settings),
-              lineNumbers: 'on',
-              ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
-              ...buildDiffEditorWhitespaceOptions(settings?.diffShowWhitespace),
-              automaticLayout: true,
-              renderOverviewRuler: true,
-              scrollbar: diffEditorScrollbarOptions,
-              padding: { top: 0 },
-              find: monacoFindOptions
-            }}
+            options={diffEditorOptions}
           />
         )}
       </div>

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -23,6 +23,7 @@ import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecyc
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
 import { buildDiffViewerEditorOptions } from './diff-viewer-editor-options'
+import { resolveDiffRenderSideBySide } from './diff-added-file-inline-mode'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
 
@@ -358,18 +359,28 @@ export default function DiffViewer({
     }
   }, [modelKey])
 
+  // Why: a created file renders inline whatever the toolbar says, so the
+  // gutter policy has to follow the effective mode, not the raw setting.
+  const effectiveSideBySide = resolveDiffRenderSideBySide(sideBySide, {
+    originalContent,
+    modifiedContent
+  })
+
   useEffect(() => {
     const diffEditor = diffEditorRef.current
     if (!diffEditor) {
       return
     }
     lineNumberOptionsSubRef.current?.dispose()
-    lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(diffEditor, sideBySide)
+    lineNumberOptionsSubRef.current = applyDiffEditorLineNumberOptions(
+      diffEditor,
+      effectiveSideBySide
+    )
     return () => {
       lineNumberOptionsSubRef.current?.dispose()
       lineNumberOptionsSubRef.current = null
     }
-  }, [sideBySide])
+  }, [effectiveSideBySide])
 
   const diffEditorOptions = buildDiffViewerEditorOptions({
     editable: editable ?? false,

--- a/src/renderer/src/components/editor/diff-added-file-inline-mode.test.ts
+++ b/src/renderer/src/components/editor/diff-added-file-inline-mode.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { resolveDiffRenderSideBySide, shouldForceInlineDiff } from './diff-added-file-inline-mode'
+import { buildDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 
 describe('shouldForceInlineDiff', () => {
   it('treats a created file as inline-only', () => {
@@ -38,5 +39,31 @@ describe('resolveDiffRenderSideBySide', () => {
     expect(
       resolveDiffRenderSideBySide(false, { originalContent: 'a\n', modifiedContent: 'b\n' })
     ).toBe(false)
+  })
+})
+
+describe('created-file inline mode at its call sites', () => {
+  const addedImage = { originalContent: '', modifiedContent: 'data:image/png;base64,AAAA' }
+
+  // Why: ImageDiffViewer picks grid-cols-2 straight off this flag, so an added
+  // image resolved from the raw setting draws an empty Original pane.
+  it('collapses an added image preview to one column', () => {
+    expect(resolveDiffRenderSideBySide(true, addedImage)).toBe(false)
+  })
+
+  // Why: the gutter policy reads the effective mode, not the toolbar. Fed the
+  // raw setting, a created file keeps a duplicate original gutter inline.
+  it('turns the original gutter off for a created file', () => {
+    const created = { originalContent: '', modifiedContent: 'new\n' }
+
+    expect(buildDiffEditorLineNumberOptions(resolveDiffRenderSideBySide(true, created))).toEqual({
+      original: 'off',
+      modified: 'on'
+    })
+    expect(
+      buildDiffEditorLineNumberOptions(
+        resolveDiffRenderSideBySide(true, { originalContent: 'a\n', modifiedContent: 'b\n' })
+      )
+    ).toEqual({ original: 'on', modified: 'on' })
   })
 })

--- a/src/renderer/src/components/editor/diff-added-file-inline-mode.test.ts
+++ b/src/renderer/src/components/editor/diff-added-file-inline-mode.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { resolveDiffRenderSideBySide, shouldForceInlineDiff } from './diff-added-file-inline-mode'
+
+describe('shouldForceInlineDiff', () => {
+  it('treats a created file as inline-only', () => {
+    expect(shouldForceInlineDiff({ originalContent: '', modifiedContent: 'new file\n' })).toBe(true)
+  })
+
+  it('keeps two real sides two-sided', () => {
+    // A rename with edits has a real original, so it stays a modification.
+    expect(shouldForceInlineDiff({ originalContent: 'was\n', modifiedContent: 'is\n' })).toBe(false)
+  })
+
+  it('leaves a deletion alone', () => {
+    // The mirror case is a deliberate non-goal: deletions are read far less
+    // often, and changing them is a separate decision.
+    expect(shouldForceInlineDiff({ originalContent: 'gone\n', modifiedContent: '' })).toBe(false)
+  })
+
+  it('does not fire when neither side has content', () => {
+    expect(shouldForceInlineDiff({ originalContent: '', modifiedContent: '' })).toBe(false)
+  })
+})
+
+describe('resolveDiffRenderSideBySide', () => {
+  it('overrides Side by Side only for created files', () => {
+    const created = { originalContent: '', modifiedContent: 'new\n' }
+    const modified = { originalContent: 'a\n', modifiedContent: 'b\n' }
+
+    expect(resolveDiffRenderSideBySide(true, created)).toBe(false)
+    expect(resolveDiffRenderSideBySide(true, modified)).toBe(true)
+  })
+
+  it('changes nothing while the toolbar is set to Inline', () => {
+    expect(
+      resolveDiffRenderSideBySide(false, { originalContent: '', modifiedContent: 'new\n' })
+    ).toBe(false)
+    expect(
+      resolveDiffRenderSideBySide(false, { originalContent: 'a\n', modifiedContent: 'b\n' })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/diff-added-file-inline-mode.ts
+++ b/src/renderer/src/components/editor/diff-added-file-inline-mode.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether a diff should ignore Side by Side and render as one inline column.
+ *
+ * A created file has no original side, so Side by Side draws a blank left
+ * column for the whole file and squeezes every new line into the remaining
+ * half. An empty column is never what turning Side by Side on asked for.
+ *
+ * Keyed on content rather than the status string: a rename with edits has a
+ * real original and stays two-sided, and a file that gained its first content
+ * reads as an addition regardless of how git labelled it.
+ *
+ * @param diff The two sides about to be handed to Monaco.
+ * @returns True when the original side is empty and the modified side is not.
+ */
+export function shouldForceInlineDiff(diff: {
+  originalContent: string
+  modifiedContent: string
+}): boolean {
+  return diff.originalContent.length === 0 && diff.modifiedContent.length > 0
+}
+
+/**
+ * Resolve the effective `renderSideBySide` for one diff.
+ *
+ * @param sideBySide The toolbar's global mode, which this never mutates.
+ * @param diff The two sides about to be handed to Monaco.
+ * @returns The mode Monaco should use for this diff.
+ */
+export function resolveDiffRenderSideBySide(
+  sideBySide: boolean,
+  diff: { originalContent: string; modifiedContent: string }
+): boolean {
+  return sideBySide && !shouldForceInlineDiff(diff)
+}

--- a/src/renderer/src/components/editor/diff-viewer-editor-options.ts
+++ b/src/renderer/src/components/editor/diff-viewer-editor-options.ts
@@ -1,0 +1,51 @@
+import type { editor } from 'monaco-editor'
+import { buildDiffEditorWhitespaceOptions } from './diff-editor-whitespace-options'
+import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
+import { diffEditorScrollbarOptions } from './diff-editor-scrollbar-options'
+import { monacoFindOptions } from './monaco-find-options'
+import { resolveDiffRenderSideBySide } from './diff-added-file-inline-mode'
+
+/**
+ * Build the Monaco options for a single-file diff tab.
+ *
+ * Extracted so the option set lives next to the other `buildDiffEditor*Options`
+ * helpers rather than inline in an already max-lines-capped component.
+ *
+ * @param input.editable Whether the modified side accepts edits.
+ * @param input.sideBySide The toolbar's global Side by Side mode.
+ * @param input.originalContent The original side, used to detect a created file.
+ * @param input.modifiedContent The modified side.
+ * @param input.fontSize Diff editor font size.
+ * @param input.fontFamily Resolved editor font stack.
+ * @param input.wordWrap Whether the diff wraps long lines.
+ * @param input.showWhitespace Whether whitespace is rendered.
+ * @returns Options for the diff editor.
+ */
+export function buildDiffViewerEditorOptions(input: {
+  editable: boolean
+  sideBySide: boolean
+  originalContent: string
+  modifiedContent: string
+  fontSize: number
+  fontFamily: string
+  wordWrap: boolean | undefined
+  showWhitespace: boolean | undefined
+}): editor.IDiffEditorConstructionOptions {
+  return {
+    readOnly: !input.editable,
+    originalEditable: false,
+    renderSideBySide: resolveDiffRenderSideBySide(input.sideBySide, input),
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    fontSize: input.fontSize,
+    fontFamily: input.fontFamily,
+    lineNumbers: 'on',
+    ...buildDiffEditorWordWrapOptions(input.wordWrap),
+    ...buildDiffEditorWhitespaceOptions(input.showWhitespace),
+    automaticLayout: true,
+    renderOverviewRuler: true,
+    scrollbar: diffEditorScrollbarOptions,
+    padding: { top: 0 },
+    find: monacoFindOptions
+  }
+}


### PR DESCRIPTION
## ELI5

Turn on **Side by Side** and review a turn that added new files. A new file has no "before" — so Orca draws an empty left column down its entire length and crams every new line into the right half, wrapping for no reason. Side by Side is genuinely useful for the *modified* files in the same scroll, so you end up flipping the toolbar back and forth. Now created files just render as one full-width column, and everything else is untouched.

## What Changed

- **New `diff-added-file-inline-mode.ts`** — `shouldForceInlineDiff({ originalContent, modifiedContent })` and `resolveDiffRenderSideBySide(sideBySide, diff)`.
- **`DiffSectionBody.tsx`** (combined diff) — `renderSideBySide` goes through the resolver.
- **`DiffViewer.tsx`** (single-file diff tab) — same, via the new options builder below.
- **New `diff-viewer-editor-options.ts`** — `DiffViewer`'s inline Monaco `options` object moved into a `buildDiffViewerEditorOptions` helper. See Notes; this is a mechanical extraction, not a behavior change.

The toolbar state, the store, and every other section are untouched: this only overrides the option handed to one Monaco instance.

## Why

`originalContent` is empty for a created file by definition, so the left column can never contain anything. An empty column is never what turning Side by Side on asked for.

**Why content, not the status string.** `DiffSection.status` is a plain `string` and the same viewer serves git status, combined diffs, and PR files, which do not label additions identically. Keying on "the original side is empty and the modified side is not" is both simpler and more accurate at the thing that actually matters — whether there is a left column worth drawing. It also handles the issue's edge cases for free:

- A **rename with content changes** has a real original, so it stays two-sided, exactly as the issue's acceptance sketch requires.
- A file that gained its first content reads as an addition however git labelled it, which is the right rendering regardless.

**Why deletions are left alone.** They are the mirror case — an empty modified side — and the issue calls them a separate decision, read far less often. `shouldForceInlineDiff` returns false for them today, and a test pins that so the choice is explicit rather than accidental.

**Why unconditional rather than a setting.** The issue offered `settings.diffInlineForAddedFiles` as an alternative and preferred unconditional; I agree. A setting here would mostly exist to let someone re-enable a blank column.

**Why the toolbar does not flip.** The override is computed per diff at render and never written back, so the button keeps showing and controlling the global mode while you scroll across added sections — the third acceptance point.

## Linked Issue

Fixes #18331

## Visual Proof

I could not capture a trustworthy before/after frame for this one: it needs the app running against a repo with a combined diff containing both added and modified files, and a screenshot of Monaco's internal layout from my machine would not show a reviewer anything the description does not. Rather than attach a frame that adds no information, here is the exact rendered difference, pinned by tests:

| toolbar | file | before | after |
|---|---|---|---|
| Side by Side | created | blank left column + squeezed right column | one full-width inline column |
| Side by Side | modified | two columns | two columns (unchanged) |
| Side by Side | renamed with edits | two columns | two columns (unchanged) |
| Side by Side | deleted | two columns | two columns (unchanged) |
| Inline | anything | one column | one column (unchanged) |

Happy to add a captured frame if a maintainer would like one.

## Testing

`src/renderer/src/components/editor/diff-added-file-inline-mode.test.ts` — six cases, covering the whole truth table above:

- a created file forces inline; a rename-with-edits does not; a deletion does not; neither-side-has-content does not.
- `resolveDiffRenderSideBySide` overrides only for created files, and changes nothing at all while the toolbar is set to Inline.

The predicate is a pure function, so these are exact rather than approximate; the two call sites pass `section` and `{ originalContent, modifiedContent }` straight through.

Ran on macOS: the full `src/renderer/src/components/editor/` suite — 1,394 tests passing — plus `pnpm tc`, `pnpm run check:code-quality:changed`, and `check:max-lines-ratchet`. CI covers the full `pnpm test` and `pnpm build`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). Both `renderSideBySide` call sites were located and read before changing either; the change, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code — a string-length comparison and a boolean.
- **Remote / SSH:** none. The decision is made in the renderer from content the viewer already holds; no IPC, RPC params, or stream frames. A diff of a remote file behaves identically.
- **Git providers:** provider-agnostic by construction. Because it keys on content rather than a status label, GitHub and GitLab PR file diffs get the same treatment without either provider's status vocabulary being enumerated.
- **Mobile:** not affected.
- **Backwards compatibility:** no persisted state, settings, or schema change. The toolbar's stored Side by Side preference keeps its meaning.
- **Performance:** two `.length` checks per rendered diff.
- **Security:** no new input surface.
- **UI quality:** no new markup or strings, so the localization catalog is untouched.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

**Why `DiffViewer.tsx` has a bigger diff than the one-line change it should be.** That file sits at **exactly** the 400-line `max-lines` cap on `main` — adding even a single line fails `oxlint`. Per AGENTS.md ("NEVER add a `max-lines` disable"), I moved its inline Monaco `options` object into `buildDiffViewerEditorOptions`, next to the `buildDiffEditorWordWrapOptions` / `buildDiffEditorWhitespaceOptions` / `diffEditorScrollbarOptions` helpers the file already imported. The option values are carried over verbatim; the only change inside is `renderSideBySide` calling the resolver. That leaves the file at 435 raw lines, comfortably under the counted cap, and `check:max-lines-ratchet` stays clean.

Worth flagging for maintainers independently of this PR: a file resting on the cap means the next person to touch `DiffViewer.tsx` hits the same wall.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
