### PR TITLE
test: canonicalize setup fixture paths before worktree lookup

### DIFF
--- a/tests/e2e/setup-script-import.spec.ts
+++ b/tests/e2e/setup-script-import.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import type { Locator, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
@@ -108,7 +108,7 @@ async function addAndActivateRepo(page: Page, repoPath: string): Promise<string>
     state.setActiveWorktree(worktree.id)
     state.setSidebarOpen(true)
     return addedRepo.id
-  }, repoPath)
+  }, realpathSync.native(repoPath))
 }
 
 async function openRepoSettings(page: Page, repoId: string): Promise<Locator> {

--- a/tests/e2e/setup-script-prompt-unreadable-orca-yaml.spec.ts
+++ b/tests/e2e/setup-script-prompt-unreadable-orca-yaml.spec.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
@@ -112,17 +112,10 @@ async function addRepoAndActivateMainWorktree(
       if (!store) {
         throw new Error('window.__store is not available')
       }
-      const normalize = (value: string): string =>
-        value.startsWith('/private/var/') ? value.slice('/private'.length) : value
-
       const state = store.getState()
       const worktrees = state.worktreesByRepo[targetRepoId] ?? []
-      const mainWorktree = worktrees.find(
-        (entry) => normalize(entry.path) === normalize(targetRepoPath)
-      )
-      const featureWorktree = worktrees.find(
-        (entry) => normalize(entry.path) === normalize(targetFeaturePath)
-      )
+      const mainWorktree = worktrees.find((entry) => entry.path === targetRepoPath)
+      const featureWorktree = worktrees.find((entry) => entry.path === targetFeaturePath)
       if (!mainWorktree || !featureWorktree) {
         throw new Error(
           `Missing worktrees for ${targetRepoPath}: ${worktrees.map((entry) => entry.path).join(', ')}`
@@ -145,7 +138,11 @@ async function addRepoAndActivateMainWorktree(
         featureWorktreeId: featureWorktree.id
       }
     },
-    { targetRepoId: repoId, targetRepoPath: repoPath, targetFeaturePath: featureWorktreePath }
+    {
+      targetRepoId: repoId,
+      targetRepoPath: realpathSync.native(repoPath),
+      targetFeaturePath: realpathSync.native(featureWorktreePath)
+    }
   )
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The setup-import and unreadable-orca.yaml journeys fail when Playwright output lives under a filesystem alias such as macOS `/tmp`: Git publishes `/private/tmp`, so fixture lookup cannot find either worktree. Resolve the existing local fixture directories with `realpathSync.native` before sending their paths into the renderer. This replaces the unreadable-file spec’s incomplete `/private/var` string special case.

All three cases reproduced the path mismatch in the full Electron sweep; both repeats of all three now pass (six macOS electron-headless cases). The orca.yaml case still proves the error prompt clears after activation rechecks the healed file; both import cases still verify the saved setup/archive commands. Targeted lint passes. No application behavior, assertion, timeout, or retry budget changed. Native Windows and Linux runs remain unverified locally.
