### PR TITLE
perf: find mobile Markdown placeholder prefixes in one scan

### DIFF
--- a/config/scripts/mobile-markdown-placeholder-benchmark.mjs
+++ b/config/scripts/mobile-markdown-placeholder-benchmark.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+
+const sourcePath = 'mobile/src/components/mobile-markdown-preview-html.ts'
+const baselineRef = process.argv[2]
+if (!baselineRef)
+  throw new Error(
+    'Usage: node config/scripts/mobile-markdown-placeholder-benchmark.mjs <baseline-ref>'
+  )
+async function load(source) {
+  const result = await build({
+    stdin: { contents: source, resolveDir: dirname(resolve(sourcePath)), loader: 'ts' },
+    bundle: true,
+    write: false,
+    platform: 'node',
+    format: 'esm'
+  })
+  return (
+    await import(
+      `data:text/javascript;base64,${Buffer.from(result.outputFiles[0].text).toString('base64')}`
+    )
+  ).normalizeMobileMarkdownPreviewHtml
+}
+const before = await load(
+  execFileSync('git', ['show', `${baselineRef}:${sourcePath}`], { encoding: 'utf8' })
+)
+const after = await load(readFileSync(sourcePath, 'utf8'))
+function measure(fn, input, repeats) {
+  const samples = []
+  for (let run = 0; run < repeats; run++) {
+    const start = performance.now()
+    fn(input)
+    samples.push(performance.now() - start)
+  }
+  return samples.sort((a, b) => a - b)[Math.floor(samples.length / 2)]
+}
+const results = []
+for (const [shape, input] of [
+  ['ordinary Markdown', '# Hello\n\n<p>Use `Array<string>` and <b>bold</b>.</p>'],
+  ...[2048, 8192, 16384].map((length) => [
+    `${length} underscore collision`,
+    `\uE000ORCA_MD_CODE_${'_'.repeat(length)}0\uE000 and \`Array<string>\``
+  ])
+]) {
+  assert.equal(after(input), before(input))
+  results.push({
+    shape,
+    bytes: Buffer.byteLength(input),
+    beforeMs: measure(before, input, 5),
+    afterMs: measure(after, input, 15)
+  })
+}
+console.log(JSON.stringify({ node: process.version, platform: process.platform, results }, null, 2))

--- a/config/scripts/mobile-markdown-placeholder-benchmark.mjs
+++ b/config/scripts/mobile-markdown-placeholder-benchmark.mjs
@@ -7,10 +7,11 @@ import { build } from 'esbuild'
 
 const sourcePath = 'mobile/src/components/mobile-markdown-preview-html.ts'
 const baselineRef = process.argv[2]
-if (!baselineRef)
+if (!baselineRef) {
   throw new Error(
     'Usage: node config/scripts/mobile-markdown-placeholder-benchmark.mjs <baseline-ref>'
   )
+}
 async function load(source) {
   const result = await build({
     stdin: { contents: source, resolveDir: dirname(resolve(sourcePath)), loader: 'ts' },

--- a/mobile/src/components/mobile-markdown-preview-html.ts
+++ b/mobile/src/components/mobile-markdown-preview-html.ts
@@ -212,6 +212,7 @@ function codePlaceholderPrefix(content: string): string {
     while (content[cursor] === '_') {
       cursor += 1
     }
+    // One extra underscore keeps the prefix longer than every authored run.
     suffixLength = Math.max(suffixLength, cursor - suffixStart + 1)
   }
   return CODE_PLACEHOLDER_PREFIX_BASE + '_'.repeat(suffixLength)

--- a/mobile/src/components/mobile-markdown-preview-html.ts
+++ b/mobile/src/components/mobile-markdown-preview-html.ts
@@ -204,11 +204,17 @@ function escapeRegExp(value: string): string {
 }
 
 function codePlaceholderPrefix(content: string): string {
-  let prefix = CODE_PLACEHOLDER_PREFIX_BASE
-  while (content.includes(prefix)) {
-    prefix = `${prefix}_`
+  let suffixLength = 0
+  let cursor = 0
+  while ((cursor = content.indexOf(CODE_PLACEHOLDER_PREFIX_BASE, cursor)) !== -1) {
+    cursor += CODE_PLACEHOLDER_PREFIX_BASE.length
+    const suffixStart = cursor
+    while (content[cursor] === '_') {
+      cursor += 1
+    }
+    suffixLength = Math.max(suffixLength, cursor - suffixStart + 1)
   }
-  return prefix
+  return CODE_PLACEHOLDER_PREFIX_BASE + '_'.repeat(suffixLength)
 }
 
 function protectMarkdownCode(content: string): {

--- a/mobile/src/components/mobile-markdown-preview-placeholder.test.ts
+++ b/mobile/src/components/mobile-markdown-preview-placeholder.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeMobileMarkdownPreviewHtml } from './mobile-markdown-preview-html'
+
+const marker = '\uE000ORCA_MD_CODE_'
+const suffix = '\uE000'
+
+describe('mobile Markdown code placeholder collisions', () => {
+  it.each([0, 1, 2, 15, 128, 16384])('preserves a literal marker with %i underscores', (length) => {
+    const literal = `${marker}${'_'.repeat(length)}0${suffix}`
+    const input = `${literal} and \`Array<string>\`\n\n\`\`\`html\n<p>literal</p>\n\`\`\``
+    expect(normalizeMobileMarkdownPreviewHtml(input)).toBe(input)
+  })
+
+  it('handles adjacent markers and repeated maximum suffixes', () => {
+    const literal = `${marker}${marker}__0${suffix}${marker}__1${suffix}${marker}_2${suffix}`
+    expect(normalizeMobileMarkdownPreviewHtml(`<p>${literal} and \`<div>\`</p>`)).toBe(
+      `${literal} and \`<div>\``
+    )
+  })
+
+  it('preserves authored markers across generated suffix orders and HTML islands', () => {
+    let seed = 173
+    for (let sample = 0; sample < 500; sample++) {
+      const literals: string[] = []
+      for (let index = 0; index < 8; index++) {
+        seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+        literals.push(`${marker}${'_'.repeat(seed % 32)}${index}${suffix}`)
+      }
+      const text = literals.join(' ') + ' and `Array<string>`'
+      expect(normalizeMobileMarkdownPreviewHtml(`<p>${text}</p>`)).toBe(text)
+    }
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |

<!-- /orca-pr-loc -->

## ELI5

Mobile Markdown preview protects code with an internal marker. If authored text contains that marker followed by many underscores, finding a nonconflicting marker repeatedly scanned the same text. Scan existing marker suffixes once to choose exactly the same replacement marker.

## Measurements

Complete production normalizeMobileMarkdownPreviewHtml before/after, macOS / Node 24.18. These measure normalization CPU, not phone rendering latency. The collision fixtures are unusual authored text, not ordinary Markdown.

| Input | Before | After |
|---|---:|---:|
| Marker + 2,048 underscores | 1.562 ms | 0.054 ms |
| Marker + 8,192 underscores | 22.083 ms | 0.195 ms |
| Marker + 16,384 underscores | 82.288 ms | 0.328 ms |

Ordinary Markdown measured 0.033 / 0.019 ms, too small for a meaningful speed claim. Reproduce: `node config/scripts/mobile-markdown-placeholder-benchmark.mjs d8c4c830639bf3d603c9250a536e0323ca0a7a19`.

## Validation

21 tests pass across MobileMarkdown and placeholder collision suites. Fixtures cover adjacent markers, repeated maximum suffixes, 500 generated suffix orders, inline/fenced code and HTML islands. `pnpm --dir mobile typecheck`, scoped mobile lint and formatting pass. No layout or interaction changes; no native mobile app was launched.

## Negative user-facing trade-offs

None identified. The chosen marker, normalized output and literal code preservation remain identical. No truncation, persistent cache, delayed rendering, wire or execution-host changes.
