### PR TITLE
test: align desktop platform oracles with native behavior

### DIFF
--- a/tests/e2e/right-sidebar-windows-titlebar.spec.ts
+++ b/tests/e2e/right-sidebar-windows-titlebar.spec.ts
@@ -6,41 +6,19 @@ type RightSidebarHeaderGeometry = {
   stripTop: number
   closeTop: number
   titlebarActivityButtonCount: number
+  activityButtonCount: number
   firstButtonCenterHitsFirst: boolean
   lastButtonCenterHitsLast: boolean
 }
 
-test.describe('Right sidebar Windows titlebar spacing', () => {
-  test('top activity buttons render inside the sidebar instead of the titlebar', async ({
-    orcaPage
-  }) => {
-    await orcaPage.addInitScript(() => {
-      const userAgent =
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/146 Safari/537.36'
-      Object.defineProperty(navigator, 'userAgent', {
-        get: () => userAgent,
-        configurable: true
-      })
-    })
-    await orcaPage.reload({ waitUntil: 'domcontentloaded' })
-    await orcaPage.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })
+test.describe('Right sidebar native titlebar spacing', () => {
+  test('top activity buttons follow the native desktop chrome layout', async ({ orcaPage }) => {
     await waitForSessionReady(orcaPage)
     await waitForActiveWorktree(orcaPage)
     await ensureTerminalVisible(orcaPage)
 
-    await expect
-      .poll(
-        async () =>
-          orcaPage.evaluate(() => ({
-            hasWindowsUserAgent: navigator.userAgent.includes('Windows'),
-            hasWindowsTitlebarChrome: Boolean(document.querySelector('.window-controls'))
-          })),
-        {
-          timeout: 5_000,
-          message: 'Renderer did not switch to the Windows titlebar branch'
-        }
-      )
-      .toEqual({ hasWindowsUserAgent: true, hasWindowsTitlebarChrome: true })
+    const hasDesktopWindowChrome = process.platform !== 'darwin'
+    expect(await orcaPage.evaluate(() => window.api.platform.get().platform)).toBe(process.platform)
 
     await orcaPage.evaluate(() => {
       const store = window.__store
@@ -95,6 +73,7 @@ test.describe('Right sidebar Windows titlebar spacing', () => {
           stripTop: stripRect.top,
           closeTop: closeRect.top,
           titlebarActivityButtonCount,
+          activityButtonCount: activityButtons.length,
           firstButtonCenterHitsFirst:
             elementAtFirstCenter !== null && firstButton.contains(elementAtFirstCenter),
           lastButtonCenterHitsLast:
@@ -117,8 +96,13 @@ test.describe('Right sidebar Windows titlebar spacing', () => {
       .toBe(true)
 
     expect(headerGeometry).not.toBeNull()
-    expect(headerGeometry!.titlebarActivityButtonCount).toBe(0)
-    expect(headerGeometry!.stripTop).toBeGreaterThanOrEqual(headerGeometry!.headerBottom)
+    if (hasDesktopWindowChrome) {
+      expect(headerGeometry!.titlebarActivityButtonCount).toBe(0)
+      expect(headerGeometry!.stripTop).toBeGreaterThanOrEqual(headerGeometry!.headerBottom)
+    } else {
+      expect(headerGeometry!.titlebarActivityButtonCount).toBe(headerGeometry!.activityButtonCount)
+      expect(headerGeometry!.stripTop).toBeLessThan(headerGeometry!.headerBottom)
+    }
     expect(headerGeometry!.closeTop).toBeLessThan(headerGeometry!.headerBottom)
     expect(headerGeometry!.firstButtonCenterHitsFirst).toBe(true)
     expect(headerGeometry!.lastButtonCenterHitsLast).toBe(true)

--- a/tests/e2e/settings-agent-awake.spec.ts
+++ b/tests/e2e/settings-agent-awake.spec.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { runProcess } from '../../src/shared/child-process/run-process'
 import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
@@ -104,6 +105,19 @@ async function readPowerSaveBlockerProbe(
   })
 }
 
+async function readMacosSleepAssertionPids(electronApp: ElectronApplication): Promise<number[]> {
+  const result = await runProcess({
+    program: '/usr/bin/pgrep',
+    args: ['-P', String(electronApp.process().pid), '-f', '^/usr/bin/caffeinate -i -s$'],
+    maxOutputBytes: 4_096
+  })
+  if (result.code === 1) {
+    return []
+  }
+  expect(result.code, result.stderr).toBe(0)
+  return result.stdout.trim().split(/\s+/).filter(Boolean).map(Number)
+}
+
 async function postCodexHookEvent(
   electronApp: ElectronApplication,
   options: {
@@ -176,7 +190,9 @@ test.describe('Agent awake setting', () => {
     electronApp,
     orcaPage
   }) => {
-    await installPowerSaveBlockerProbe(electronApp)
+    if (process.platform !== 'darwin') {
+      await installPowerSaveBlockerProbe(electronApp)
+    }
     await setKeepAwake(orcaPage, true)
 
     const tabId = 'e2e-awake-tab'
@@ -187,24 +203,33 @@ test.describe('Agent awake setting', () => {
       eventName: 'UserPromptSubmit'
     })
 
-    await expect
-      .poll(async () => await readPowerSaveBlockerProbe(electronApp), {
-        timeout: 5_000,
-        message: 'powerSaveBlocker did not start for the working agent'
-      })
-      .toEqual(
-        expect.objectContaining({
-          activeIds: expect.arrayContaining([expect.any(Number)]),
-          starts: expect.arrayContaining([
-            expect.objectContaining({ type: 'prevent-display-sleep' })
-          ])
+    await expect(
+      orcaPage.getByRole('button', { name: 'Keep computer awake, Agent · Active' })
+    ).toBeVisible()
+    let startedIds: number[] = []
+    if (process.platform === 'darwin') {
+      // macOS uses an app-owned caffeinate assertion instead of Electron's display blocker.
+      await expect
+        .poll(() => readMacosSleepAssertionPids(electronApp), { timeout: 5_000 })
+        .not.toEqual([])
+    } else {
+      await expect
+        .poll(async () => await readPowerSaveBlockerProbe(electronApp), {
+          timeout: 5_000,
+          message: 'powerSaveBlocker did not start for the working agent'
         })
-      )
+        .toEqual(
+          expect.objectContaining({
+            activeIds: expect.arrayContaining([expect.any(Number)]),
+            starts: expect.arrayContaining([
+              expect.objectContaining({ type: 'prevent-display-sleep' })
+            ])
+          })
+        )
 
-    const startedIds = (await readPowerSaveBlockerProbe(electronApp)).starts.map(
-      (start) => start.id
-    )
-    expect(startedIds.length).toBeGreaterThan(0)
+      startedIds = (await readPowerSaveBlockerProbe(electronApp)).starts.map((start) => start.id)
+      expect(startedIds.length).toBeGreaterThan(0)
+    }
 
     await postCodexHookEvent(electronApp, {
       paneKey,
@@ -212,6 +237,15 @@ test.describe('Agent awake setting', () => {
       eventName: 'Stop'
     })
 
+    await expect(
+      orcaPage.getByRole('button', { name: 'Keep computer awake, Agent · Inactive' })
+    ).toBeVisible()
+    if (process.platform === 'darwin') {
+      await expect
+        .poll(() => readMacosSleepAssertionPids(electronApp), { timeout: 5_000 })
+        .toEqual([])
+      return
+    }
     await expect
       .poll(async () => await readPowerSaveBlockerProbe(electronApp), {
         timeout: 5_000,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​64 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​46 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Two rendered desktop tests assume platform behavior the app no longer uses. On macOS, keep-awake now owns `/usr/bin/caffeinate -i -s` and deliberately releases Electron’s display blocker. The sidebar reads its native platform from preload, so changing the user agent alone produces conflicting platform evidence.

For keep-awake, verify the macOS assertion process belongs to the test app and disappears when the hook reports Stop; retain the exact Electron blocker start/stop checks on Linux and Windows. Also assert the rendered Agent Active/Inactive status. Run the sidebar geometry oracle against the actual preload platform: Windows/Linux still require no activity buttons in the titlebar and the strip below it, while macOS requires its activity strip inside the header. Both retain button hit-target checks at a narrow sidebar width. No application behavior, timeout, or retry budget changed.

Validation: both original platform assumptions failed in the full macOS sweep. The two keep-awake cases now pass twice (four cases), and the native sidebar case passes three repeats. Targeted lint passes. Native Windows/Linux runs remain gaps; this removes the misleading claim that a macOS user-agent spoof exercises the Windows preload branch. macOS process inspection is scoped to the test app’s direct child and exact caffeinate command, through the shared process runner.
