### PR TITLE
fix(workspace): delete the active workspace when no card is hovered

### DIFF
--- a/src/renderer/src/app-shell/app-command-handlers-workspace-delete.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers-workspace-delete.test.ts
@@ -5,7 +5,7 @@ import type { AppShortcutState, ShortcutDispatchInput } from './app-command-hand
 
 const mocks = vi.hoisted(() => ({
   deleteHoveredWorkspaceImmediately: vi.fn(),
-  hoveredTarget: { kind: 'worktree', worktree: {} } as HoveredWorkspaceDeleteTarget | null,
+  deleteTarget: { kind: 'worktree', worktree: {} } as HoveredWorkspaceDeleteTarget | null,
   store: {} as AppState
 }))
 
@@ -15,7 +15,7 @@ vi.mock('../store', () => ({
 
 vi.mock('../components/sidebar/hovered-workspace-delete', () => ({
   deleteHoveredWorkspaceImmediately: mocks.deleteHoveredWorkspaceImmediately,
-  resolveHoveredWorkspaceDeleteTarget: () => mocks.hoveredTarget
+  resolveWorkspaceDeleteTarget: () => mocks.deleteTarget
 }))
 
 vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
@@ -59,7 +59,7 @@ describe('workspace delete app command', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.store = { activeWorktreeId: 'repo::/feature' } as AppState
-    mocks.hoveredTarget = { kind: 'worktree', worktree: {} as never }
+    mocks.deleteTarget = { kind: 'worktree', worktree: {} as never }
   })
 
   it('claims the chord and immediately deletes the active workspace', () => {
@@ -72,15 +72,15 @@ describe('workspace delete app command', () => {
     expect(input.preventDefault).toHaveBeenCalledOnce()
     expect(mocks.deleteHoveredWorkspaceImmediately).toHaveBeenCalledWith(
       mocks.store,
-      mocks.hoveredTarget
+      mocks.deleteTarget
     )
   })
 
-  it('does not claim the chord without a hovered workspace', () => {
+  it('does not claim the chord when no workspace resolves', () => {
     const input = shortcutInput()
     const handler = createAppCommandHandlers(shortcutState(), input).get('workspace.delete')
 
-    mocks.hoveredTarget = null
+    mocks.deleteTarget = null
     expect(handler?.()).toBe(false)
     expect(input.preventDefault).not.toHaveBeenCalled()
     expect(mocks.deleteHoveredWorkspaceImmediately).not.toHaveBeenCalled()

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -8,7 +8,7 @@ import { TOGGLE_WORKSPACE_BOARD_EVENT } from '../components/sidebar/useWorkspace
 import { requestTerminalTabRename } from '../components/tab-bar/terminal-tab-rename-request'
 import {
   deleteHoveredWorkspaceImmediately,
-  resolveHoveredWorkspaceDeleteTarget
+  resolveWorkspaceDeleteTarget
 } from '../components/sidebar/hovered-workspace-delete'
 import { useAppStore } from '../store'
 import type { usePluginCommands } from '@/store/plugin-panels'
@@ -203,7 +203,7 @@ export function createAppCommandHandlers(
           return false
         }
         const store = useAppStore.getState()
-        const target = resolveHoveredWorkspaceDeleteTarget(store)
+        const target = resolveWorkspaceDeleteTarget(store)
         if (!target) {
           return false
         }

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts
@@ -106,6 +106,33 @@ describe('hovered workspace delete', () => {
     })
   })
 
+  // Why: activation resolves the host (undefined -> 'local'), but a
+  // pre-host-qualification row still carries no hostId, so the composed
+  // 'local|<id>' identity never matched its '|<id>' one and delete no-opped.
+  it('falls back to a legacy workspace whose row predates host qualification', () => {
+    const legacy = worktree({ id: 'repo::/legacy', path: '/legacy' })
+    const legacyState = state([legacy])
+    legacyState.activeWorkspaceExecutionHostId = 'local'
+
+    expect(getActiveWorkspaceIdentity(legacyState)).toEqual({
+      workspaceId: 'repo::/legacy',
+      hostIdentity: 'local|repo::/legacy'
+    })
+    expect(resolveWorkspaceDeleteTarget(legacyState, hoveredDocument())).toEqual({
+      kind: 'worktree',
+      worktree: legacy
+    })
+  })
+
+  it("never lets the legacy fallback reach another host's row", () => {
+    const remote = worktree({ id: 'repo::/shared', path: '/shared', hostId: 'ssh:build' })
+    const remoteState = state([remote])
+    remoteState.activeWorktreeId = 'repo::/shared'
+    remoteState.activeWorkspaceExecutionHostId = 'local'
+
+    expect(resolveWorkspaceDeleteTarget(remoteState, hoveredDocument())).toBeNull()
+  })
+
   it('applies the same guards to the active workspace as to a hovered one', () => {
     const primary = worktree({ hostId: 'local', isMainWorktree: true })
     expect(resolveWorkspaceDeleteTarget(state([primary]), hoveredDocument())).toBeNull()

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts
@@ -3,8 +3,9 @@ import type { AppState } from '@/store/types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
   deleteHoveredWorkspaceImmediately,
+  getActiveWorkspaceIdentity,
   getHoveredWorkspaceIdentity,
-  resolveHoveredWorkspaceDeleteTarget
+  resolveWorkspaceDeleteTarget
 } from './hovered-workspace-delete'
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
@@ -67,7 +68,7 @@ describe('hovered workspace delete', () => {
     const hovered = worktree({ hostId: 'ssh:build', instanceId: 'instance-2' })
 
     expect(
-      resolveHoveredWorkspaceDeleteTarget(
+      resolveWorkspaceDeleteTarget(
         state([active, hovered]),
         hoveredDocument({ workspaceId: hovered.id, hostIdentity: 'ssh:build|repo::/feature' })
       )
@@ -76,7 +77,7 @@ describe('hovered workspace delete', () => {
 
   it('retains the hovered host when resolving a folder workspace', () => {
     expect(
-      resolveHoveredWorkspaceDeleteTarget(
+      resolveWorkspaceDeleteTarget(
         state(),
         hoveredDocument({
           workspaceId: 'folder:folder-1',
@@ -91,23 +92,60 @@ describe('hovered workspace delete', () => {
     })
   })
 
+  it('falls back to the active workspace when the pointer is nowhere near a card', () => {
+    // The shortcut is usable from the terminal, where hover is never true.
+    const active = worktree({ id: 'repo::/active', path: '/active', hostId: 'local' })
+
+    expect(getActiveWorkspaceIdentity(state([active]))).toEqual({
+      workspaceId: 'repo::/active',
+      hostIdentity: 'local|repo::/active'
+    })
+    expect(resolveWorkspaceDeleteTarget(state([active]), hoveredDocument())).toEqual({
+      kind: 'worktree',
+      worktree: active
+    })
+  })
+
+  it('applies the same guards to the active workspace as to a hovered one', () => {
+    const primary = worktree({ hostId: 'local', isMainWorktree: true })
+    expect(resolveWorkspaceDeleteTarget(state([primary]), hoveredDocument())).toBeNull()
+
+    const deleting = worktree({ hostId: 'local' })
+    const current = state([deleting])
+    current.deleteStateByWorktreeId = {
+      'local|repo::/feature': {
+        isDeleting: true,
+        error: null,
+        canForceDelete: false,
+        forceDeleteReason: null
+      }
+    }
+    expect(resolveWorkspaceDeleteTarget(current, hoveredDocument())).toBeNull()
+  })
+
+  it('has no active fallback when no workspace is active', () => {
+    const current = state()
+    expect(getActiveWorkspaceIdentity(current)).toBeNull()
+    expect(resolveWorkspaceDeleteTarget(current, hoveredDocument())).toBeNull()
+  })
+
   it('rejects primary worktrees, stale rows, and missing hover', () => {
     const primary = worktree({ hostId: 'local', isMainWorktree: true })
     const current = state([primary])
 
     expect(
-      resolveHoveredWorkspaceDeleteTarget(
+      resolveWorkspaceDeleteTarget(
         current,
         hoveredDocument({ workspaceId: primary.id, hostIdentity: 'local|repo::/feature' })
       )
     ).toBeNull()
     expect(
-      resolveHoveredWorkspaceDeleteTarget(
+      resolveWorkspaceDeleteTarget(
         current,
         hoveredDocument({ workspaceId: 'stale', hostIdentity: 'local|stale' })
       )
     ).toBeNull()
-    expect(resolveHoveredWorkspaceDeleteTarget(current, hoveredDocument())).toBeNull()
+    expect(resolveWorkspaceDeleteTarget(current, hoveredDocument())).toBeNull()
   })
 
   it('rejects worktrees that are already deleting', () => {
@@ -123,7 +161,7 @@ describe('hovered workspace delete', () => {
     }
 
     expect(
-      resolveHoveredWorkspaceDeleteTarget(
+      resolveWorkspaceDeleteTarget(
         current,
         hoveredDocument({ workspaceId: target.id, hostIdentity: 'ssh:build|repo::/feature' })
       )
@@ -145,7 +183,7 @@ describe('hovered workspace delete', () => {
     Object.defineProperty(doc, 'activeElement', { value: new EditableElement() })
 
     try {
-      expect(resolveHoveredWorkspaceDeleteTarget(state([target]), doc)).toBeNull()
+      expect(resolveWorkspaceDeleteTarget(state([target]), doc)).toBeNull()
     } finally {
       vi.unstubAllGlobals()
     }

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../../shared/worktree/host-qualified-identity'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
 import { runWorktreeDelete } from './delete-worktree-flow'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
 
@@ -107,11 +107,16 @@ export function resolveWorkspaceDeleteTarget(
       workspaceKey: hovered.workspaceId
     }
   }
-  const worktree = getAllWorktreesFromState(state).find(
-    (candidate) =>
-      candidate.id === hovered.workspaceId &&
-      getWorktreeHostIdentity(candidate) === hovered.hostIdentity
+  const candidates = getAllWorktreesFromState(state).filter(
+    (candidate) => candidate.id === hovered.workspaceId
   )
+  const worktree =
+    candidates.find((candidate) => getWorktreeHostIdentity(candidate) === hovered.hostIdentity) ??
+    // Why: pre-host-qualification rows carry no hostId, so their `|<id>` identity
+    // never matches the `local|<id>` a click resolves — the exact no-op this fixes.
+    (getExecutionHostIdFromWorktreeHostIdentity(hovered.hostIdentity) === LOCAL_EXECUTION_HOST_ID
+      ? candidates.find((candidate) => candidate.hostId === undefined)
+      : undefined)
   return worktree &&
     !worktree.isMainWorktree &&
     !getDeleteStateForWorktreeHost(worktree, state.deleteStateByWorktreeId)?.isDeleting

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
@@ -19,6 +19,7 @@ type DeleteWorktree = typeof runWorktreeDelete
 type HoveredWorkspaceDeleteState = Pick<
   AppState,
   | 'activeModal'
+  | 'activeWorkspaceExecutionHostId'
   | 'activeWorktreeId'
   | 'deleteFolderWorkspace'
   | 'deleteStateByWorktreeId'
@@ -55,14 +56,41 @@ export function getHoveredWorkspaceIdentity(
   return workspaceId && hostIdentity ? { workspaceId, hostIdentity } : null
 }
 
-export function resolveHoveredWorkspaceDeleteTarget(
+/**
+ * The workspace the sidebar is currently showing as active.
+ *
+ * Why: the delete shortcut is usable from the terminal, where the pointer is
+ * nowhere near a card, so hover alone leaves it silently dead (#17815).
+ *
+ * @param state Store slice carrying the active workspace.
+ * @returns The active workspace's identity, or null when none is active.
+ */
+export function getActiveWorkspaceIdentity(
+  state: Pick<HoveredWorkspaceDeleteState, 'activeWorkspaceExecutionHostId' | 'activeWorktreeId'>
+): { hostIdentity: string; workspaceId: string } | null {
+  const workspaceId = state.activeWorktreeId
+  return workspaceId
+    ? {
+        workspaceId,
+        hostIdentity: composeWorktreeHostIdentity(
+          state.activeWorkspaceExecutionHostId ?? undefined,
+          workspaceId
+        )
+      }
+    : null
+}
+
+export function resolveWorkspaceDeleteTarget(
   state: HoveredWorkspaceDeleteState,
   doc: HoveredWorkspaceDocument = document
 ): HoveredWorkspaceDeleteTarget | null {
   if (state.activeModal !== 'none' || (doc.activeElement && isEditableTarget(doc.activeElement))) {
     return null
   }
-  const hovered = getHoveredWorkspaceIdentity(doc)
+  // Why hover first: with the pointer on a card, that card is what the user
+  // means — the sidebar highlights it. Otherwise fall back to the active
+  // workspace, which is the one the rest of the UI is already about.
+  const hovered = getHoveredWorkspaceIdentity(doc) ?? getActiveWorkspaceIdentity(state)
   if (!hovered) {
     return null
   }
@@ -93,7 +121,7 @@ export function resolveHoveredWorkspaceDeleteTarget(
 
 export function deleteHoveredWorkspaceImmediately(
   state: HoveredWorkspaceDeleteState,
-  target: HoveredWorkspaceDeleteTarget | null = resolveHoveredWorkspaceDeleteTarget(state),
+  target: HoveredWorkspaceDeleteTarget | null = resolveWorkspaceDeleteTarget(state),
   dependencies: HoveredWorkspaceDeleteDependencies = {
     deleteWorktree: runWorktreeDelete,
     getCurrentState: useAppStore.getState


### PR DESCRIPTION
## ELI5

`Mod+Shift+Backspace` deletes a workspace — but only while your mouse happens to be sitting on that workspace's card in the sidebar. The shortcut is explicitly allowed while you are typing in a terminal, which is exactly when your pointer is nowhere near a card, so it did nothing at all: no dialog, no toast, no message. It looked broken. Now, with no card hovered, it acts on the workspace you are actually in.

## What Changed

`src/renderer/src/components/sidebar/hovered-workspace-delete.ts`:

- New `getActiveWorkspaceIdentity(state)` — the active workspace's `{ workspaceId, hostIdentity }`, composed from `activeWorktreeId` and `activeWorkspaceExecutionHostId`.
- `resolveHoveredWorkspaceDeleteTarget` → **`resolveWorkspaceDeleteTarget`**, and its one line of resolution becomes:

  ```ts
  const hovered = getHoveredWorkspaceIdentity(doc) ?? getActiveWorkspaceIdentity(state)
  ```

Everything downstream — the folder/worktree split, the guards, `deleteHoveredWorkspaceImmediately` — is unchanged, so the fallback cannot take a path the hovered case does not already take.

## Why

`workspace.delete` is registered with `allowInTerminal: true`. That flag is a statement that the shortcut is meant to work while the terminal has focus — and in that state the pointer is, by definition, not hovering a sidebar card. The handler returned early and silently, which is the worst version of this: a shortcut that is indistinguishable from an unbound one.

**Why the active workspace.** It is the workspace the sidebar already highlights, the terminal already belongs to, and every other workspace-scoped shortcut already acts on. There is no ambiguity about what "this workspace" means when you are typing inside it.

**Why hover still wins.** When the pointer *is* on a card, the sidebar visually marks that card, and the user is plainly aiming at it — often a different workspace from the active one. Reversing that precedence would break the existing behavior the issue does not complain about. There is already a test asserting hover beats active (`resolves the exact hovered host instead of the active workspace`), and it still passes unchanged.

**Why the guards are shared rather than re-implemented.** The fallback only supplies an identity; resolution continues through the same code, so the primary-worktree refusal, the already-deleting refusal, the open-modal check, and the editable-field check all apply identically. A separate active-workspace path would have been a second place for those to drift.

**Why the rename.** `resolveHoveredWorkspaceDeleteTarget` would now be a lie — hover is one of two ways it resolves. Two call sites and one test import it.

## Linked Issue

Fixes #17815

## Visual Proof

`N/A` — no UI is added or restyled. The change is which workspace an existing shortcut resolves; the delete flow it hands off to (confirmation dialog or immediate delete, per the user's settings) is untouched and looks exactly the same. The behavior difference:

| pointer | before | after |
|---|---|---|
| on a workspace card | deletes that workspace | unchanged |
| anywhere else (e.g. typing in a terminal) | **nothing happens, silently** | deletes the active workspace |
| anywhere else, active is the primary worktree | nothing happens | nothing happens (guard) |
| anywhere else, active is already deleting | nothing happens | nothing happens (guard) |

## Testing

`src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts` — three cases added to the existing suite:

- `falls back to the active workspace when the pointer is nowhere near a card` — with an empty hover document, `getActiveWorkspaceIdentity` returns the composed identity and the resolver returns that worktree. I confirmed this fails with the `?? getActiveWorkspaceIdentity(state)` removed, so it pins the fix.
- `applies the same guards to the active workspace as to a hovered one` — the primary worktree and an already-deleting workspace both still resolve to null through the fallback.
- `has no active fallback when no workspace is active` — no active workspace resolves to null rather than throwing.

The existing `resolves the exact hovered host instead of the active workspace` case is the precedence guard and passes unchanged.

`app-command-handlers-workspace-delete.test.ts` mocked the old export name, so its mock and one test title were updated; its assertions are unchanged.

Ran on macOS: `src/renderer/src/components/sidebar/`, `src/renderer/src/app-shell/`, and `src/renderer/src/hooks/` — 3,541 tests passing — plus `pnpm tc` and `pnpm run check:code-quality:changed`. CI covers the full `pnpm test` and `pnpm build`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). The root cause the issue names was confirmed by reading the resolver before changing it; the change, tests, and this description were authored in that session and reviewed by me.

## Review

- **Cross-platform (macOS / Linux / Windows):** no platform-dependent code. The binding itself is untouched — this only changes how the handler picks its target.
- **Remote / SSH:** covered deliberately. The fallback composes a **host-qualified** identity (`composeWorktreeHostIdentity(activeWorkspaceExecutionHostId, activeWorktreeId)`), so a workspace on an SSH or runtime host resolves to that host's workspace, not a same-id local one. The subsequent lookup matches on `getWorktreeHostIdentity`, exactly as the hovered path does, and `deleteHoveredWorkspaceImmediately` still passes `expectedHostId` / `expectedInstanceId` through to the delete. No RPC or wire change.
- **Folder workspaces:** covered — the fallback identity goes through the same `parseWorkspaceKey` branch, so an active folder workspace resolves as `kind: 'folder'` with its execution host, like a hovered one.
- **Destructive-action safety:** worth a reviewer's eye, since this makes a delete shortcut fire in a state where it previously did nothing. Three things bound it: the primary worktree can never be deleted, an in-flight delete is refused, and the shortcut is inert while a modal is open or a text field has focus. Beyond that it enters the same confirmation flow the sidebar's own delete uses, honouring the user's "skip delete confirmation" setting exactly as before — this PR does not bypass or add a confirmation.
- **Mobile:** not affected.
- **Backwards compatibility:** no persisted state, settings, or schema change.
- **Performance:** one string composition when nothing is hovered.
- **Security:** no new input surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The file is still named `hovered-workspace-delete.ts`, which is now slightly narrow for what it does. I left the filename alone to keep the diff reviewable; renaming it (and its test) is a clean follow-up if maintainers prefer.

Author: [@AntonioKL](https://x.com/AntonioKL)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
