### PR TITLE
perf: skip unrelated shared symlink probes during Git status

### DIFF
--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -14,7 +14,10 @@ import {
 } from '../../../shared/git-status-line-stats-cache'
 import { resolveWorktreeHostPath } from '../../../shared/git-metadata-path'
 import { gitOptionalLocksDisabledEnv, gitStreamStdout } from '../runner'
-import { findExistingWorktreeSymlinkPaths } from '../worktree-symlink-detection'
+import {
+  findExistingWorktreeSymlinkPaths,
+  getSafeRelativePath
+} from '../worktree-symlink-detection'
 import type { GetStatusOptions } from './get-status-options'
 import { statusReadLeaseOwner } from './git-read-cache-invalidation'
 import { detectConflictOperation } from './git-conflict-operation'
@@ -89,8 +92,18 @@ async function dropSharedSymlinkUntrackedEntries(
   if (sharedLinkPaths.length === 0 || !entries.some((entry) => entry.area === 'untracked')) {
     return
   }
+  const untrackedPaths = new Set(
+    entries.filter((entry) => entry.area === 'untracked').map((entry) => entry.path)
+  )
+  const candidatePaths = sharedLinkPaths.filter((rawPath) => {
+    const path = getSafeRelativePath(rawPath)
+    return path.safe && untrackedPaths.has(path.rel)
+  })
+  if (candidatePaths.length === 0) {
+    return
+  }
   const sharedLinks = new Set(
-    await findExistingWorktreeSymlinkPaths(worktreePath, sharedLinkPaths, {
+    await findExistingWorktreeSymlinkPaths(worktreePath, candidatePaths, {
       wslDistro: options.wslDistro
     })
   )

--- a/src/main/git/status-symlink-probe-budget.test.ts
+++ b/src/main/git/status-symlink-probe-budget.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { resolve } from 'node:path'
+import { getStatus } from './source-control/status-read'
+
+const { lstat, stream, conflict } = vi.hoisted(() => ({
+  lstat: vi.fn(),
+  stream: vi.fn(),
+  conflict: vi.fn()
+}))
+vi.mock('node:fs/promises', () => ({ lstat }))
+vi.mock('./source-control/git-conflict-operation', () => ({ detectConflictOperation: conflict }))
+vi.mock('./runner', () => ({
+  gitStreamStdout: stream,
+  gitOptionalLocksDisabledEnv: () => ({ GIT_OPTIONAL_LOCKS: '0' })
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  conflict.mockResolvedValue(undefined)
+  lstat.mockResolvedValue({ isSymbolicLink: () => true })
+  stream.mockImplementation(async (_args, options) => {
+    options.onStdout('? unrelated.txt\n')
+    return { stoppedEarly: false }
+  })
+})
+
+function status(sharedLinkPaths: string[]) {
+  return getStatus('/repo', { sharedLinkPaths, includeLineStats: false })
+}
+
+describe('status shared symlink probe budget', () => {
+  it.each([1, 8, 32])(
+    'does no unrelated symlink probes for %i configured paths over 100 refreshes',
+    async (count) => {
+      const paths = Array.from({ length: count }, (_, index) => `shared-${index}`)
+      for (let refresh = 0; refresh < 100; refresh++) {
+        expect((await status(paths)).entries).toEqual([
+          { path: 'unrelated.txt', status: 'untracked', area: 'untracked' }
+        ])
+      }
+      expect(lstat).not.toHaveBeenCalled()
+      expect(stream).toHaveBeenCalledTimes(100)
+    }
+  )
+
+  it('probes matching normalized paths, retaining duplicate probes and original order', async () => {
+    stream.mockImplementation(async (_args, options) => {
+      options.onStdout('? link\n? 日本 語\n? unrelated.txt\n')
+      return { stoppedEarly: false }
+    })
+    const result = await status(['absent', ' /link ', '\\日本 語', 'link', '../link', 'C:link'])
+    expect(lstat.mock.calls.map(([path]) => path)).toEqual([
+      resolve('/repo', 'link'),
+      resolve('/repo', '日本 語'),
+      resolve('/repo', 'link')
+    ])
+    expect(result.entries.map((entry) => entry.path)).toEqual(['unrelated.txt'])
+  })
+
+  it('rechecks matching paths after the filesystem changes and preserves unreadable paths', async () => {
+    const paths = ['unrelated.txt']
+    expect((await status(paths)).entries).toEqual([])
+    lstat.mockResolvedValueOnce({ isSymbolicLink: () => false })
+    expect((await status(paths)).entries).toHaveLength(1)
+    lstat.mockRejectedValueOnce(new Error('EACCES'))
+    expect((await status(paths)).entries).toHaveLength(1)
+    expect(lstat).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not broaden exact path matching to descendants or case variants', async () => {
+    stream.mockImplementation(async (_args, options) => {
+      options.onStdout('? link/child\n? LINK\n')
+      return { stoppedEarly: false }
+    })
+    expect((await status(['link'])).entries.map((entry) => entry.path)).toEqual([
+      'link/child',
+      'LINK'
+    ])
+    expect(lstat).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

## ELI5

An unrelated untracked file made every Git status refresh check every configured shared symlink on disk. Only a shared path that appears in the untracked results can be removed from those results. Filter to those candidates before asking the filesystem.

## Measurements

Actual production getStatus and symlink detector, with injected Git output and filesystem calls. Counts are deterministic; they do not claim end-to-end latency on a particular disk or WSL share.

100 sequential refreshes, each reporting one unrelated untracked file:

| Configured shared paths | Before lstat calls | After lstat calls |
|---|---:|---:|
| 1 | 100 | 0 |
| 8 | 800 | 0 |
| 32 | 3,200 | 0 |

Matching paths still receive a fresh lstat each refresh. Git is still queried 100 times; this adds no cache.

Reproduce: `pnpm exec vitest run --config config/vitest.config.ts src/main/git/status-symlink-probe-budget.test.ts`. Running this test against the previous status-read.ts demonstrably fails the call budgets with 100, 800 and 3,200 calls; restoring the fix passes.

## Validation

58 tests pass across status, real-Git shared-symlink integration, symlink detection, coalescing and probe budgets. Tests cover normalization, duplicate ordering, Unicode, case and descendant boundaries, filesystem changes, unreadable files, and WSL host paths. Full `pnpm tc`, scoped lint and formatting pass.

Reuse getSafeRelativePath and the existing detector. Pass original raw candidates to the detector to preserve its normalization exactly. Native/WSL execution routing, SSH's separate status route, Git arguments, result limits, folder behavior and source-control provider behavior are unchanged. No rendered UI changes; visual proof is not applicable. Live Windows/WSL and Linux validation remain with CI.

## Negative user-facing trade-offs

None identified. Regular files and unverifiable symlinks remain visible; only positively identified configured untracked symlinks are hidden. Matching paths remain freshly checked. Temporary path membership storage is proportional to returned untracked entries, and no cache or polling changes are introduced.
