### PR TITLE
perf: avoid splitting every path during file autocomplete

### DIFF
--- a/config/scripts/mobile-file-ranking-benchmark.mjs
+++ b/config/scripts/mobile-file-ranking-benchmark.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { stripTypeScriptTypes } from 'node:module'
+import { performance } from 'node:perf_hooks'
+
+const baseline = process.argv[2]
+if (!baseline) {
+  throw new Error('Usage: node config/scripts/mobile-file-ranking-benchmark.mjs <baseline-ref>')
+}
+async function load(source) {
+  const js = stripTypeScriptTypes(source, { mode: 'transform' })
+  return await import(`data:text/javascript;base64,${Buffer.from(js).toString('base64')}`)
+}
+function measure(fn, paths, query) {
+  for (let warmup = 0; warmup < 10; warmup++) {
+    fn(paths, query, 16)
+  }
+  const samples = []
+  for (let i = 0; i < 9; i++) {
+    const start = performance.now()
+    fn(paths, query, 16)
+    samples.push(performance.now() - start)
+  }
+  return samples.sort((a, b) => a - b)[4]
+}
+const results = []
+for (const [file, name] of [
+  ['src/main/runtime/runtime-mobile-file-path-search.ts', 'rankRuntimeMobileFilePaths'],
+  ['mobile/src/session/mobile-native-chat-autocomplete.ts', 'rankSuggestions']
+]) {
+  const before = (
+    await load(execFileSync('git', ['show', `${baseline}:${file}`], { encoding: 'utf8' }))
+  )[name]
+  const after = (await load(readFileSync(file, 'utf8')))[name]
+  for (const count of [100, 100000]) {
+    const paths = Array.from(
+      { length: count },
+      (_, i) => `src/components/workspace/group-${i % 100}/file-${i}.tsx`
+    )
+    for (const query of ['file-9', 'missing', 'workspace']) {
+      assert.deepEqual(after(paths, query, 16), before(paths, query, 16))
+      results.push({
+        function: name,
+        paths: count,
+        query,
+        beforeMs: measure(before, paths, query),
+        afterMs: measure(after, paths, query)
+      })
+    }
+  }
+}
+console.log(JSON.stringify({ node: process.version, platform: process.platform, results }, null, 2))

--- a/mobile/src/session/mobile-native-chat-autocomplete.ts
+++ b/mobile/src/session/mobile-native-chat-autocomplete.ts
@@ -81,7 +81,7 @@ export function rankSuggestions(candidates: readonly string[], query: string, li
   const substring: string[] = []
   for (const candidate of candidates) {
     const lower = candidate.toLowerCase()
-    const base = lower.split('/').pop() ?? lower
+    const base = lower.slice(lower.lastIndexOf('/') + 1)
     if (lower.startsWith(q) || base.startsWith(q)) {
       prefix.push(candidate)
     } else if (lower.includes(q)) {

--- a/src/main/runtime/runtime-mobile-file-path-search.test.ts
+++ b/src/main/runtime/runtime-mobile-file-path-search.test.ts
@@ -6,6 +6,37 @@ import {
 } from './runtime-mobile-file-path-search'
 
 describe('rankRuntimeMobileFilePaths', () => {
+  it('preserves basename matching, ordering and total counts for unusual paths', () => {
+    const paths = [
+      '',
+      '/',
+      'a/',
+      'a//b.ts',
+      'b.ts',
+      'B.TS',
+      'a\\b.ts',
+      '界/😀.ts',
+      '.hidden',
+      'a/./b.ts'
+    ]
+    for (const query of ['', ' ', 'b', '.ts', '😀', '/', 'a\\', 'missing']) {
+      for (const limit of [0, 1, 3, 100]) {
+        const q = query.trim().toLowerCase()
+        const prefix = paths.filter((path) => {
+          const lower = path.toLowerCase()
+          return lower.startsWith(q) || (lower.split('/').pop() ?? lower).startsWith(q)
+        })
+        const other = paths.filter(
+          (path) => !prefix.includes(path) && path.toLowerCase().includes(q)
+        )
+        expect(rankRuntimeMobileFilePaths(paths, query, limit)).toEqual({
+          paths: [...prefix, ...other].slice(0, limit),
+          totalCount: prefix.length + other.length
+        })
+      }
+    }
+  })
+
   it('ranks path and basename prefixes before substrings and caps output', () => {
     expect(
       rankRuntimeMobileFilePaths(

--- a/src/main/runtime/runtime-mobile-file-path-search.ts
+++ b/src/main/runtime/runtime-mobile-file-path-search.ts
@@ -76,7 +76,7 @@ export function rankRuntimeMobileFilePaths(
   let totalCount = 0
   for (const path of paths) {
     const lower = path.toLowerCase()
-    const basename = lower.split('/').pop() ?? lower
+    const basename = lower.slice(lower.lastIndexOf('/') + 1)
     if (lower.startsWith(normalizedQuery) || basename.startsWith(normalizedQuery)) {
       totalCount++
       if (prefix.length < limit) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 |

<!-- /orca-pr-loc -->

## ELI5

File autocomplete split every candidate path into an array just to inspect its filename. Find the last slash and take the filename directly instead, avoiding arrays for the preceding directories.

Apply the same equivalent expression in host-side file ranking and the mobile fallback used with older hosts. Keep their different query normalization, result counting and early-stop behavior intact.

## Measurements

Complete original/current production ranking functions, macOS / Node 24.18, warmed median of nine runs, 100,000 paths. CPU-only ranking; not filesystem scanning, network or native phone rendering latency.

| Query/path | Before | After |
|---|---:|---:|
| Host filename prefix | 13.182 ms | 4.674 ms |
| Host nonmatching query | 12.090 ms | 3.598 ms |
| Mobile fallback nonmatching query | 12.459 ms | 3.628 ms |
| Mobile fallback substring query | 13.537 ms | 4.436 ms |

100-path cases remain below 0.03 ms; do not interpret tiny timings as a user-visible latency claim. Reproduce with Node 24: `node config/scripts/mobile-file-ranking-benchmark.mjs d8c4c830639bf3d603c9250a536e0323ca0a7a19`.

## Validation

21 tests pass across host ranking/cache, mobile autocomplete and file search. Added parity checks for empty/trailing/repeated separators, backslashes, Unicode, case, limits and total counts. Full desktop `pnpm tc`, mobile typecheck, scoped lint and formatting pass. The benchmark asserts full result equality.

No filesystem operations, host routing, wire data, Git commands, cache behavior, folder handling or rendered UI change. Existing slash-separated path semantics remain intact, including literal backslashes. No native mobile app was launched.

## Negative user-facing trade-offs

None identified. Suggestions, ordering, counts, limits, query normalization and early stopping remain identical. No cache, delay, truncation or retained index is added.
