### PR TITLE
test: follow sidebar reveal confirmation with a stable workspace target

### DIFF
--- a/tests/e2e/worktree-scroll-to-current.spec.ts
+++ b/tests/e2e/worktree-scroll-to-current.spec.ts
@@ -39,22 +39,30 @@ test.describe('Reveal active workspace button', () => {
   // the "outside the virtualized window" test below.
 
   test('clears sidebar filters before revealing a hidden current workspace', async ({
-    orcaPage
+    orcaPage,
+    testRepoPath
   }) => {
     await prepareSidebarForScrollTest(orcaPage)
 
-    const renderedOptions = orcaPage.locator('[data-worktree-sidebar] [role="option"]')
-    await expect(renderedOptions).toHaveCount(2)
-
-    const targetId = await renderedOptions.last().getAttribute('data-worktree-id')
+    // Other specs can add worktrees to the shared repository before this test runs.
+    const targetId = await orcaPage.evaluate((repoPath) => {
+      const state = window.__store!.getState()
+      const repo = state.repos.find((candidate) => candidate.path === repoPath)
+      return repo
+        ? state.worktreesByRepo[repo.id]?.find(
+            (worktree) => worktree.branch === 'refs/heads/e2e-secondary'
+          )?.id
+        : undefined
+    }, testRepoPath)
     if (!targetId) {
-      throw new Error('Bottom workspace row did not expose a data-worktree-id')
+      throw new Error('Seeded secondary worktree is missing')
     }
 
     const targetRows = orcaPage.locator(
       `[data-worktree-sidebar] [data-worktree-id=${JSON.stringify(targetId)}]`
     )
     const targetRow = targetRows.first()
+    await expect(targetRows.and(orcaPage.getByRole('option'))).toHaveCount(1)
     const revealButton = orcaPage.getByRole('button', { name: 'Reveal active workspace' })
 
     await orcaPage.evaluate((targetId) => {
@@ -92,6 +100,10 @@ test.describe('Reveal active workspace button', () => {
     // contract under test is that reveal clears the filter (asserted below).
 
     await revealButton.click()
+    await orcaPage
+      .getByRole('dialog', { name: 'Reveal hidden workspace?' })
+      .getByRole('button', { name: 'Clear filters and reveal' })
+      .click()
 
     await expect(targetRow).toBeVisible()
     await expect(targetRow).toHaveAttribute('data-scroll-reveal-highlight', 'true')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The sidebar reveal test assumes the shared repository has exactly two worktrees and that Reveal immediately clears filters. The full suite had six rows, and the current UI requires confirmation before clearing the user’s filters.

Select the seeded secondary worktree by its repository and branch, verify its exact sidebar row, and click “Clear filters and reveal” in the confirmation dialog. Preserve the visible-row, highlight, current-workspace, and cleared-filter assertions. No application behavior, timeout, or retry budget changes.

Validation: all three specs passed twice (six cases); the filter case also passed with four extra Git worktrees (six total). Targeted lint and formatting pass. Validation ran in background Electron on macOS; native Windows/Linux remain gaps.
