### PR TITLE
fix: preserve paired host sessions during startup residue cleanup

### DIFF
--- a/src/main/persistence-deregistered-repo-residue.test.ts
+++ b/src/main/persistence-deregistered-repo-residue.test.ts
@@ -1,7 +1,5 @@
 // Why this file exists: deregistering a project used to strand every row it owned. No sweeper could
-// reach them -- the missing-directory prune is gated on the repo still being registered, and a
-// paired client's mirror of a remote host's rows is keyed by ids that client never registers, so the
-// owning host's removal never reached it (#17776).
+// reach them because the missing-directory prune is gated on the repo still being registered.
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { rmSync, mkdtempSync } from 'node:fs'
 import { join } from 'node:path'
@@ -103,7 +101,7 @@ describe('deregistered repo residue', () => {
     expect(session.sleepingAgentSessionsByPaneKey ?? {}).toEqual({})
   })
 
-  it("sweeps a remote host's session partition the owning host's removal can never reach", async () => {
+  it('keeps a remote session whose repo is not registered on the desktop', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [makeRepo({ id: LIVE_REPO, path: '/workspace/live' })],
@@ -117,8 +115,10 @@ describe('deregistered repo residue', () => {
     store.flush()
 
     const partition = store.getWorkspaceSession(RUNTIME_HOST)
-    expect(partition.tabsByWorktree).toEqual({})
-    expect(partition.activeTabTypeByWorktree).toEqual({})
+    expect(partition.tabsByWorktree[GONE_WORKTREE]).toHaveLength(1)
+    expect(partition.activeTabTypeByWorktree).toEqual(
+      sessionFor(GONE_WORKTREE).activeTabTypeByWorktree
+    )
   })
 
   it('keeps rows for every registered repo, on any execution host', async () => {
@@ -204,15 +204,13 @@ describe('deregistered repo residue', () => {
       schemaVersion: 1,
       repos: [makeRepo({ id: LIVE_REPO, path: '/workspace/live' })],
       worktreeMeta: {},
-      workspaceSessionsByHostId: {
-        [RUNTIME_HOST]: { ...getDefaultWorkspaceSession(), ...session }
-      }
+      workspaceSession: { ...getDefaultWorkspaceSession(), ...session }
     })
 
     const store = await createStore()
     store.flush()
 
-    const partition = store.getWorkspaceSession(RUNTIME_HOST)
+    const partition = store.getWorkspaceSession()
     expect(partition.activeWorktreeId ?? null).toBeNull()
     expect(partition.activeWorkspaceKey ?? null).toBeNull()
     expect(partition.activeWorktreeIdsOnShutdown ?? []).toEqual([])

--- a/src/main/persistence-remote-session-startup.test.ts
+++ b/src/main/persistence-remote-session-startup.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import type { BrowserPage, BrowserWorkspace } from '../shared/browser-workspace-types'
+import { createStore, makeRepo, testState } from './persistence-test-harness'
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(),
+  sshConfigHostsToTargets: vi.fn()
+}))
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: { isEncryptionAvailable: () => false }
+}))
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn().mockReturnValue({}) }))
+
+const HOST = 'runtime:paired-host'
+const REPO = 'remote-repo'
+const WORKTREE = `${REPO}::/remote/project`
+const PAGE: BrowserPage = {
+  id: 'page-1',
+  workspaceId: 'browser-1',
+  worktreeId: WORKTREE,
+  url: 'https://example.test/moved',
+  title: 'Moved page',
+  loading: false,
+  canGoBack: true,
+  canGoForward: false,
+  faviconUrl: null,
+  loadError: null,
+  createdAt: 1,
+  browserRuntimeEnvironmentId: 'paired-host',
+  remoteBrowserPageId: 'remote-page-1',
+  remoteBrowserPageClientHosted: true
+}
+const BROWSER: BrowserWorkspace = {
+  id: PAGE.workspaceId,
+  worktreeId: WORKTREE,
+  sessionProfileId: null,
+  activePageId: PAGE.id,
+  pageIds: [PAGE.id],
+  url: PAGE.url,
+  title: PAGE.title,
+  loading: false,
+  faviconUrl: null,
+  canGoBack: true,
+  canGoForward: false,
+  loadError: null,
+  createdAt: 1
+}
+
+function browserSession() {
+  return {
+    ...getDefaultWorkspaceSession(),
+    browserTabsByWorktree: { [WORKTREE]: [BROWSER] },
+    browserPagesByWorkspace: { [BROWSER.id]: [PAGE] },
+    activeBrowserTabIdByWorktree: { [WORKTREE]: BROWSER.id }
+  }
+}
+
+describe('remote session startup ownership', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-remote-session-'))
+  })
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('keeps a paired browser row and its hosting identity across two Store reloads', () => {
+    const seed = createStore()
+    seed.addRepo(makeRepo({ id: 'local-repo', path: join(testState.dir, 'local') }))
+    seed.setWorkspaceSession(browserSession(), HOST)
+    seed.flush()
+
+    for (let i = 0; i < 2; i += 1) {
+      const reloaded = createStore()
+      expect(reloaded.getWorkspaceSession(HOST).browserPagesByWorkspace).toEqual({
+        [BROWSER.id]: [PAGE]
+      })
+      expect(reloaded.sweepDeregisteredRepoResidue()).toEqual([])
+      reloaded.flush()
+    }
+  })
+
+  it('retains remote metadata when no session or local catalog row names its repo', () => {
+    const seed = createStore()
+    seed.setWorktreeMetaForHost(WORKTREE, HOST, { displayName: 'Remote work' })
+    seed.flush()
+    const reloaded = createStore()
+    expect(reloaded.getWorktreeMeta(WORKTREE)).toMatchObject({ displayName: 'Remote work' })
+    expect(reloaded.sweepDeregisteredRepoResidue()).toEqual([])
+    reloaded.flush()
+  })
+
+  it('still applies an explicit remote project removal', () => {
+    const seed = createStore()
+    seed.setWorkspaceSession(browserSession(), HOST)
+    seed.flush()
+    const reloaded = createStore()
+    reloaded.removeProjectForHost(REPO, HOST)
+    reloaded.flush()
+    expect(createStore().getWorkspaceSession(HOST).browserPagesByWorkspace).toEqual({})
+  })
+})

--- a/src/main/persistence-remote-session-startup.test.ts
+++ b/src/main/persistence-remote-session-startup.test.ts
@@ -100,6 +100,8 @@ describe('remote session startup ownership', () => {
     seed.setWorkspaceSession(browserSession(), HOST)
     seed.flush()
     const reloaded = createStore()
+    // Assert the row survived load first, or an empty partition below would prove nothing.
+    expect(reloaded.getWorkspaceSession(HOST).browserPagesByWorkspace).not.toEqual({})
     reloaded.removeProjectForHost(REPO, HOST)
     reloaded.flush()
     expect(createStore().getWorkspaceSession(HOST).browserPagesByWorkspace).toEqual({})

--- a/src/main/persistence/loading-store/repo-lifecycle-operations.ts
+++ b/src/main/persistence/loading-store/repo-lifecycle-operations.ts
@@ -136,8 +136,9 @@ export class RepoLifecycleOperations {
   /**
    * Drop every persisted row owned by a repo id that is no longer registered.
    *
-   * Runs at load to reach leftover local rows after deregistration. Remote-owned rows await
-   * authoritative removal; their absence from the desktop catalog cannot establish deletion.
+   * Runs at load to reach leftover local rows after deregistration. Rows owned by a `runtime:*`
+   * host are exempt: this runs before pairing, so their absence from the local catalog cannot
+   * establish deletion. Only an explicit `removeProjectForHost` retires them.
    */
   sweepDeregisteredRepoResidue(): string[] {
     const state = this[repoLifecycleOperationsContext].runtime.state

--- a/src/main/persistence/loading-store/repo-lifecycle-operations.ts
+++ b/src/main/persistence/loading-store/repo-lifecycle-operations.ts
@@ -136,11 +136,8 @@ export class RepoLifecycleOperations {
   /**
    * Drop every persisted row owned by a repo id that is no longer registered.
    *
-   * Runs at load because no removal path can: `removeProject` only fires while the repo is still in
-   * `state.repos`, and a paired client's mirror of a remote host's rows is keyed by ids that client
-   * never registers, so the owning host's removal never reaches it (#17776). An orphan has no owner
-   * that could object, so this ignores the session-ownership and local-execution-host gates the
-   * missing-directory sweeper needs.
+   * Runs at load to reach leftover local rows after deregistration. Remote-owned rows await
+   * authoritative removal; their absence from the desktop catalog cannot establish deletion.
    */
   sweepDeregisteredRepoResidue(): string[] {
     const state = this[repoLifecycleOperationsContext].runtime.state

--- a/src/main/persistence/restoring-sessions/session-worktree-ownership.ts
+++ b/src/main/persistence/restoring-sessions/session-worktree-ownership.ts
@@ -209,7 +209,7 @@ export function collectWorkspaceSessionWorktreeOwners(
   return owners
 }
 
-function addWorkspaceSessionWorktreeOwners(
+export function addWorkspaceSessionWorktreeOwners(
   session: WorkspaceSessionState,
   collector: WorktreeOwnerCandidateCollector
 ): void {

--- a/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
+++ b/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
@@ -1,5 +1,10 @@
 import type { PersistedState } from '../../../shared/persisted-state-types'
-import { getWorktreeIdFromHostIdentity } from '../../../shared/worktree/host-qualified-identity'
+import {
+  getExecutionHostIdFromWorktreeHostIdentity,
+  getWorktreeIdFromHostIdentity
+} from '../../../shared/worktree/host-qualified-identity'
+import { parseExecutionHostId } from '../../../shared/execution-host'
+import { addPersistedSessionWorktreeOwners } from '../restoring-sessions/session-worktree-ownership'
 import { splitWorktreeId } from '../../../shared/worktree/id'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import { SESSION_FIELDS_PRUNED_BY_OWNER_KEY } from '../../orca-profiles/profile-project-session-field-disposition'
@@ -8,12 +13,41 @@ import { ownerKeyWorktreeIds } from '../../orca-profiles/profile-project-worktre
 /**
  * Repo ids that still own persisted rows but no longer appear in `state.repos`.
  *
- * Why nothing else finds them: every other sweeper is gated on the repo still being registered, so
- * deregistering a project stranded the rows it owned permanently — including a paired client's
- * mirror of a remote host's session partition, which no local repo removal can reach (#17776).
+ * Remote catalog absence is not removal evidence: paired repos are never locally registered.
  */
 export function collectDeregisteredRepoIds(state: PersistedState): Set<string> {
   const liveRepoIds = new Set(state.repos.map((repo) => repo.id))
+  const retainRemoteOwner = (ownerKey: string | null | undefined): void => {
+    if (!ownerKey) {
+      return
+    }
+    for (const worktreeId of ownerKeyWorktreeIds(ownerKey)) {
+      const repoId = splitWorktreeId(worktreeId)?.repoId
+      if (repoId) {
+        liveRepoIds.add(repoId)
+      }
+    }
+  }
+  for (const [hostId, session] of Object.entries(state.workspaceSessionsByHostId ?? {})) {
+    if (session && parseExecutionHostId(hostId)?.kind === 'runtime') {
+      addPersistedSessionWorktreeOwners(
+        { workspaceSession: session },
+        { owners: new Set(), addOwner: retainRemoteOwner }
+      )
+    }
+  }
+  for (const [worktreeId, meta] of Object.entries(state.worktreeMeta)) {
+    if (parseExecutionHostId(meta.hostId)?.kind === 'runtime') {
+      retainRemoteOwner(worktreeId)
+    }
+  }
+  for (const alias of Object.keys(state.worktreeIdentityAliases ?? {})) {
+    if (
+      parseExecutionHostId(getExecutionHostIdFromWorktreeHostIdentity(alias))?.kind === 'runtime'
+    ) {
+      retainRemoteOwner(getWorktreeIdFromHostIdentity(alias))
+    }
+  }
   const orphanRepoIds = new Set<string>()
   // Only a full `<repoId>::<path>` locator seeds the set. A bare key -- a folder workspace id, a
   // repo-keyed topology revision, a test-shaped locator -- cannot be told apart from a repo id, and

--- a/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
+++ b/src/main/persistence/tracking-repos/deregistered-repo-residue.ts
@@ -4,48 +4,56 @@ import {
   getWorktreeIdFromHostIdentity
 } from '../../../shared/worktree/host-qualified-identity'
 import { parseExecutionHostId } from '../../../shared/execution-host'
-import { addPersistedSessionWorktreeOwners } from '../restoring-sessions/session-worktree-ownership'
+import { addWorkspaceSessionWorktreeOwners } from '../restoring-sessions/session-worktree-ownership'
 import { splitWorktreeId } from '../../../shared/worktree/id'
 import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import { SESSION_FIELDS_PRUNED_BY_OWNER_KEY } from '../../orca-profiles/profile-project-session-field-disposition'
 import { ownerKeyWorktreeIds } from '../../orca-profiles/profile-project-worktree-identity'
 
+/** A `runtime:*` host addresses a paired Orca desktop's rows, whose catalog lives on that host. */
+const isPairedHost = (hostId: string | null | undefined): boolean =>
+  parseExecutionHostId(hostId)?.kind === 'runtime'
+
+/** Repo ids an owner key can name, across both readings (see `ownerKeyWorktreeIds`). */
+function ownerKeyRepoIds(ownerKey: string | null | undefined): string[] {
+  return ownerKey
+    ? ownerKeyWorktreeIds(ownerKey).flatMap((worktreeId) => {
+        const repoId = splitWorktreeId(worktreeId)?.repoId
+        return repoId ? [repoId] : []
+      })
+    : []
+}
+
 /**
  * Repo ids that still own persisted rows but no longer appear in `state.repos`.
  *
- * Remote catalog absence is not removal evidence: paired repos are never locally registered.
+ * Rows owned by a `runtime:*` host are held live instead of swept: a paired client mirrors that
+ * host's sessions without ever registering its repos, and this runs in the Store constructor,
+ * before pairing, so catalog absence there proves nothing (#17776 read it as proof and deleted
+ * live sessions). The cost is that residue outliving a removal is no longer swept for those hosts.
  */
 export function collectDeregisteredRepoIds(state: PersistedState): Set<string> {
   const liveRepoIds = new Set(state.repos.map((repo) => repo.id))
-  const retainRemoteOwner = (ownerKey: string | null | undefined): void => {
-    if (!ownerKey) {
-      return
-    }
-    for (const worktreeId of ownerKeyWorktreeIds(ownerKey)) {
-      const repoId = splitWorktreeId(worktreeId)?.repoId
-      if (repoId) {
-        liveRepoIds.add(repoId)
-      }
+  const retainOwner = (ownerKey: string | null | undefined): void => {
+    for (const repoId of ownerKeyRepoIds(ownerKey)) {
+      liveRepoIds.add(repoId)
     }
   }
+  // `owners` goes unread: the walker only ever calls `addOwner`.
+  const retainCollector = { owners: new Set<string>(), addOwner: retainOwner }
   for (const [hostId, session] of Object.entries(state.workspaceSessionsByHostId ?? {})) {
-    if (session && parseExecutionHostId(hostId)?.kind === 'runtime') {
-      addPersistedSessionWorktreeOwners(
-        { workspaceSession: session },
-        { owners: new Set(), addOwner: retainRemoteOwner }
-      )
+    if (session && isPairedHost(hostId)) {
+      addWorkspaceSessionWorktreeOwners(session, retainCollector)
     }
   }
   for (const [worktreeId, meta] of Object.entries(state.worktreeMeta)) {
-    if (parseExecutionHostId(meta.hostId)?.kind === 'runtime') {
-      retainRemoteOwner(worktreeId)
+    if (isPairedHost(meta.hostId)) {
+      retainOwner(worktreeId)
     }
   }
   for (const alias of Object.keys(state.worktreeIdentityAliases ?? {})) {
-    if (
-      parseExecutionHostId(getExecutionHostIdFromWorktreeHostIdentity(alias))?.kind === 'runtime'
-    ) {
-      retainRemoteOwner(getWorktreeIdFromHostIdentity(alias))
+    if (isPairedHost(getExecutionHostIdFromWorktreeHostIdentity(alias))) {
+      retainOwner(getWorktreeIdFromHostIdentity(alias))
     }
   }
   const orphanRepoIds = new Set<string>()
@@ -64,10 +72,7 @@ export function collectDeregisteredRepoIds(state: PersistedState): Set<string> {
    * other reading would hand the removal pass -- which accepts either -- a live row to delete.
    */
   const addOwnerKey = (ownerKey: string): void => {
-    const repoIds = ownerKeyWorktreeIds(ownerKey).flatMap((worktreeId) => {
-      const repoId = splitWorktreeId(worktreeId)?.repoId
-      return repoId ? [repoId] : []
-    })
+    const repoIds = ownerKeyRepoIds(ownerKey)
     if (repoIds.length > 0 && repoIds.every((repoId) => !liveRepoIds.has(repoId))) {
       for (const repoId of repoIds) {
         orphanRepoIds.add(repoId)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |

<!-- /orca-pr-loc -->

## ELI5

Orca lets you drive a second computer (a "paired host") from this one, and it remembers the browser tabs, documents and terminals you had open over there. When you quit and reopened Orca, a startup tidy-up step looked at that remembered work, could not find a matching project in *this* computer's project list, decided it was junk left behind, and deleted it. But that project was never in this computer's list — it lives on the other machine, and at startup Orca has not even reconnected yet to ask. So people came back to an empty workspace, or to a tab still showing the old address with "Client-hosted browser unavailable". Now the tidy-up leaves anything belonging to a paired host alone and only clears genuinely local leftovers; paired work still goes away the moment you actually remove that project yourself.

## What Changed

Quitting a paired desktop persists its browser rows correctly, but reopening it erased the remote session partition. Startup's deregistered-repo sweep treated absence from the desktop catalog as deletion, even though paired-host repos are never registered there. A double restart then showed the saved URL with "Client-hosted browser unavailable"; rows whose host had forgotten them disappeared entirely.

`collectDeregisteredRepoIds` (`src/main/persistence/tracking-repos/deregistered-repo-residue.ts`) now retains repo ids referenced by runtime-owned (`runtime:*`, i.e. paired-host) session partitions, worktree metadata, or host-qualified identity aliases during that local-catalog sweep. It reuses the existing persisted-session ownership walker (`addPersistedSessionWorktreeOwners`) so browser pages, terminals, sleeping agents and folder-workspace representations all follow one ownership rule. Explicit project removal still retires the state. Local orphan cleanup remains covered; the old assertion that an unregistered remote repo must be deleted is corrected, and scalar cleanup assertions run against the local partition. No RPC, wire format, stream opcode, timeout or retry changes.

## Why

The sweep runs inside the `Store` constructor, before pairing is established. At that moment the paired host's catalog is simply not present in this profile, so "not in `state.repos`" carries no information about whether the remote project still exists. The previous behavior (#17776) read that absence as proof of deletion and dropped the partition. This applies the rule `docs/reference/ssh-execution-boundary.md` already states for remote processes — loss of contact is never evidence of death — to persisted state: the execution host owns the verdict, and a local catalog alone cannot render it.

## Tradeoffs

Real and accepted, not hypothetical:

- **A project removed on the paired host now leaves stale rows here, with no reachable cleanup.** That is exactly the case #17776's sweep covered. The host's `reposChanged` broadcast only refreshes the renderer catalog (`runtime-repo-catalog-actions.ts`); it touches no persisted row. And the client's own "remove project" does not help either: `repo-removal.ts` guards the local `removeForHost` branch on `target.kind === 'local'` and routes runtime removals over RPC to the host. So `removeProjectForHost` — the one path that clears the persisted mirror, and the one this PR's test covers — has no product caller on a client today. Treat the mirrored residue as permanent until a real host-to-client reconciliation lands. **This is the main thing to weigh before merging.**
- **A serving host exempts its own partition too.** `runtime:*` is not exclusively the paired-remote case: a machine serving paired clients persists its own repos stamped `runtime:<selfEnv>` (`runtime-repository-registration-controller.ts`) and writes that partition to `workspaceSessionsByHostId['runtime:<selfEnv>']`. The retention cannot tell that apart from a paired desktop, so the #17776 load-time backstop no longer applies there either. Narrowing it (for example, skipping retention for a runtime host this profile registers repos for) was deliberately *not* done: over-retaining leaks rows, but getting that discriminator wrong deletes live sessions again, and only the second failure is destructive.
- **Ghost rows are now visible instead of silently deleted.** A session the host has genuinely forgotten restores and shows as unavailable, and the user closes it by hand. Previously it vanished — quieter, but it also vanished in the far more common case where the session was perfectly fine.
- **The persisted profile grows monotonically for paired work.** Pairing with many short-lived remote environments accumulates `runtime:*` session partitions that nothing prunes. Each is small JSON, but the profile is read at launch and rewritten on every save.
- **Retention is repo-id-wide, not partition-wide.** Marking a repo id live suppresses the sweep for that id everywhere, including any genuinely orphaned *local* rows sharing it. Deliberately the safe direction (over-retain rather than over-delete), but local cleanup can now be held back by remote state.
- **Slightly more startup work.** The sweep walks every `runtime:*` partition plus `worktreeMeta` and identity aliases before seeding — the same order as the seeding pass it already ran, so roughly one extra traversal of persisted rows on the `Store` constructor path.

Not affected: SSH and WSL hosts (their repos *are* registered in this profile, so their residue still sweeps normally), folder workspaces (folder keys name no repo id and were already skipped), and cross-platform behavior (no path or shell logic touched).

## Linked Issue

No tracking issue; regression found while validating paired-host session restore. Supersedes the paired-client half of #17776.

## Visual Proof

N/A for this revision. Per repo `AGENTS.md`, local Electron launches are paused for this task, so no new capture was taken. The behavior is visually observable (a restored paired browser tab versus "Client-hosted browser unavailable"), but reproducing it needs two paired desktops; the earlier Electron validation below covers it, and the state change is asserted directly against the persisted profile in the unit tests.

## Testing

- `src/main/persistence-remote-session-startup.test.ts` (new): a paired browser row and its hosting identity survive two `Store` reloads; remote worktree metadata survives with no session and no local catalog row; an explicit `removeProjectForHost` still clears the partition.
- `src/main/persistence-deregistered-repo-residue.test.ts`: the assertion that an unregistered remote repo *must* be swept is inverted to match the new contract; scalar-cleanup cases moved to the local partition, which is where that cleanup still applies. Local orphan, folder-workspace, sleeping-agent-only and byte-identical-reload coverage is unchanged.

All four retention tests were confirmed to fail against the pre-fix `collectDeregisteredRepoIds` and pass with it, so none of them is tautological. The removal test needed an added "row survived load" assertion to become a real regression test — without it, it passed on the old code too, because the sweep had already emptied the partition before the removal ran.

Earlier validation on this branch:

- The recorded partition survives schema parsing but disappears through the original Store constructor. Two permanent preservation regressions fail against the original implementation; all 12 focused tests and 46 persistence neighbors pass with the fix. Node typecheck and targeted lint pass.
- All four previously failing Electron cases pass unassisted: client quit/relaunch, double restart, restored ghost close, and close while the host is absent. The first three complete in 31-34 seconds instead of failing after roughly 2.5 minutes.
- Paired HTML document quit/relaunch now passes with a fresh grant. The persisted-session production-upgrade gate also passes. Six rendered cases total, using a clean background Electron review build on macOS.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Authored with Claude (Opus).

## Review

Reviewer attention is best spent on the first two tradeoffs: is losing automatic cleanup of host-removed projects acceptable in exchange for never deleting live paired sessions? I think yes — the sweep was inferring deletion from evidence it does not have, and `docs/reference/ssh-execution-boundary.md` makes that inference non-negotiable in the other direction. But the honest consequence is that paired-client residue is now unreachable, so the follow-up is a real host-to-client project reconciliation, not a return to catalog-absence-as-deletion.

Verified not a problem, so reviewers can skip them: no save-loop regression (the Store only schedules a save when the sweep returns ids, and retained ids never enter that set, so a remote-only profile stays byte-identical across reloads); no schema, migration or wire change; no new path or platform assumption. Rollback to a build without this fix simply reapplies the old deletion — the pre-existing bug, not new corruption.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Ensure no issues in: Security, cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance.

Backwards compatibility: the change is read-side only — no schema, field or wire change, and older builds reading the same profile still apply their own sweep rules. This is an application fix and remains open for user review. Native Windows/Linux, SSH/WSL hosts, and startup performance with a large profile remain validation gaps. The sweep now retains remote-only residue until authoritative removal; a local catalog alone cannot establish that the remote repo was removed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass (or CI covers)
