### PR TITLE
fix(cmd-j): pass browser tab ownership into palette search

### DIFF
--- a/src/renderer/src/components/use-worktree-jump-palette-browser-ownership.test.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-browser-ownership.test.ts
@@ -10,7 +10,7 @@ import { useWorktreeJumpPaletteOpenTabs } from './use-worktree-jump-palette-open
 
 afterEach(cleanup)
 
-it('keeps same-id browser results on their owner and updates when tab ownership changes', () => {
+it('keeps same-id browser results on their owner with recency, and follows ownership changes', () => {
   const worktrees = [
     makeWorktree('same-id', 'Local workspace', { hostId: 'local' }),
     makeWorktree('same-id', 'Remote workspace', { hostId: 'runtime:paired' })
@@ -37,11 +37,13 @@ it('keeps same-id browser results on their owner and updates when tab ownership 
   const tab: Tab = {
     ...makeUnifiedTab('tab', 'same-id', 'browser', 'Browser proof'),
     contentType: 'browser',
-    executionHostId: 'runtime:paired'
+    executionHostId: 'runtime:paired',
+    lastFocusedAt: 5_000
   }
   type PaletteInput = Parameters<typeof useWorktreeJumpPaletteOpenTabs>[0]
   const input: Partial<PaletteInput> = {
     ...useAppStore.getInitialState(),
+    // The store holds {key, result}; the hook takes the unwrapped result.
     workspacePortScan: null,
     paletteStatusInputsActive: true,
     allWorktrees: worktrees,
@@ -60,10 +62,15 @@ it('keeps same-id browser results on their owner and updates when tab ownership 
     (props: Partial<PaletteInput>) => useWorktreeJumpPaletteOpenTabs(props as PaletteInput),
     { initialProps: input }
   )
+  // lastActiveAt rides the same map: without it every browser row sorts as never-focused.
   const owners = () =>
-    result.current.browserItems.map(({ result: entry }) => [entry.pageId, entry.executionHostId])
+    result.current.browserItems.map(({ result: entry }) => [
+      entry.pageId,
+      entry.executionHostId,
+      entry.lastActiveAt
+    ])
 
-  expect(owners()).toEqual([['page', 'runtime:paired']])
+  expect(owners()).toEqual([['page', 'runtime:paired', 5_000]])
 
   rerender({
     ...input,
@@ -71,5 +78,5 @@ it('keeps same-id browser results on their owner and updates when tab ownership 
       'same-id': [{ ...tab, executionHostId: 'local' }]
     }
   })
-  expect(owners()).toEqual([['page', 'local']])
+  expect(owners()).toEqual([['page', 'local', 5_000]])
 })

--- a/src/renderer/src/components/use-worktree-jump-palette-browser-ownership.test.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-browser-ownership.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import type { BrowserPage, BrowserWorkspace } from '../../../shared/browser-workspace-types'
+import type { Tab } from '../../../shared/tab-types'
+import { makeUnifiedTab, makeWorktree } from './worktree-jump-palette-test-fixtures'
+import { useWorktreeJumpPaletteOpenTabs } from './use-worktree-jump-palette-open-tabs'
+
+afterEach(cleanup)
+
+it('keeps same-id browser results on their owner and updates when tab ownership changes', () => {
+  const worktrees = [
+    makeWorktree('same-id', 'Local workspace', { hostId: 'local' }),
+    makeWorktree('same-id', 'Remote workspace', { hostId: 'runtime:paired' })
+  ]
+  const page: BrowserPage = {
+    id: 'page',
+    workspaceId: 'browser',
+    worktreeId: 'same-id',
+    url: 'https://example.test/docs',
+    title: 'Browser proof',
+    loading: false,
+    faviconUrl: null,
+    canGoBack: false,
+    canGoForward: false,
+    loadError: null,
+    createdAt: 1
+  }
+  const workspace: BrowserWorkspace = {
+    ...page,
+    id: 'browser',
+    activePageId: page.id,
+    pageIds: [page.id]
+  }
+  const tab: Tab = {
+    ...makeUnifiedTab('tab', 'same-id', 'browser', 'Browser proof'),
+    contentType: 'browser',
+    executionHostId: 'runtime:paired'
+  }
+  type PaletteInput = Parameters<typeof useWorktreeJumpPaletteOpenTabs>[0]
+  const input: Partial<PaletteInput> = {
+    ...useAppStore.getInitialState(),
+    workspacePortScan: null,
+    paletteStatusInputsActive: true,
+    allWorktrees: worktrees,
+    browserSortedWorktrees: worktrees,
+    repoMap: new Map(),
+    repoByHostIdentity: new Map(),
+    worktreeOrder: new Map(),
+    worktreeMatches: [],
+    hasQuery: true,
+    deferredQuery: 'Browser proof',
+    browserTabsByWorktree: { 'same-id': [workspace] },
+    browserPagesByWorkspace: { browser: [page] },
+    unifiedTabsByWorktree: { 'same-id': [tab] }
+  }
+  const { result, rerender } = renderHook(
+    (props: Partial<PaletteInput>) => useWorktreeJumpPaletteOpenTabs(props as PaletteInput),
+    { initialProps: input }
+  )
+  const owners = () =>
+    result.current.browserItems.map(({ result: entry }) => [entry.pageId, entry.executionHostId])
+
+  expect(owners()).toEqual([['page', 'runtime:paired']])
+
+  rerender({
+    ...input,
+    unifiedTabsByWorktree: {
+      'same-id': [{ ...tab, executionHostId: 'local' }]
+    }
+  })
+  expect(owners()).toEqual([['page', 'local']])
+})

--- a/src/renderer/src/components/use-worktree-jump-palette-open-tabs.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-open-tabs.ts
@@ -80,6 +80,7 @@ export function useWorktreeJumpPaletteOpenTabs({
       worktreeOrder,
       browserTabsByWorktree,
       browserPagesByWorkspace,
+      unifiedTabsByWorktree,
       activeBrowserTabId,
       activeWorktreeId,
       activeWorkspaceExecutionHostId,
@@ -95,6 +96,7 @@ export function useWorktreeJumpPaletteOpenTabs({
     browserPagesByWorkspace,
     browserTabsByWorktree,
     browserSortedWorktrees,
+    unifiedTabsByWorktree,
     repoByHostIdentity,
     repoMap,
     worktreeOrder


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Orca lets you open the same project in two places at once — on your own laptop and on a remote machine you are paired with. Both copies can end up carrying the same internal name. When that happened, pressing Cmd-J and searching for a web page you had open showed nothing at all: the search had no way to tell which machine each page belonged to, so it hid all of them rather than risk sending you to the wrong one. Separately, browser results had lost their "last used" time, so they always sank to the bottom of the list and never showed an age. This change hands the search the ownership information it was already being given everywhere else, so those pages show up again, jump to the right machine, and sort by when you actually used them.

## What Changed

`useWorktreeJumpPaletteOpenTabs` now passes the `unifiedTabsByWorktree` map into `buildSearchableBrowserPages` and lists it in the memo dependencies, so entries rebuild when tab ownership changes.

## Why

This is a regression restore, not a new mechanism. `buildSearchableBrowserPages` has accepted `unifiedTabsByWorktree` since #15551, and the sibling call site in `src/renderer/src/components/tab-bar/open-tab-search-entries.ts` still passes it. The Cmd-J call site lost the argument when `WorktreeJumpPalette.tsx` was split into hooks in `286c21005b0` ("refactor(renderer): split oversized UI surfaces") — the pre-split file passed `unifiedTabsByWorktree` and listed it in the dependency array. Because the parameter is optional, the drop was silent.

Two consequences inside the builder:

- **Rows vanish on colliding IDs.** With no unified tabs, no workspace resolves an owning tab, so `if (!unifiedTab && ambiguousWorktreeIds.has(worktree.id)) continue` skipped *every* browser page of any worktree ID shared by two hosts.
- **Ownership and recency degrade everywhere.** `executionHostId` always fell back to `worktree.hostId` instead of the tab's alias, and `focusedAtByWorkspaceId` stayed empty, so `lastActiveAt` was always `null`. `executionHostId` is what `activateBrowserPagePaletteResult` feeds to `getKnownWorktreeById` and `activateAndRevealWorktree`, so it decides which host a selected result opens on.

## Linked Issue

No tracked issue — found while reviewing fallout from the palette file split.

## Visual Proof

`N/A` for this PR. The change is user-visible, but reproducing it needs a real paired remote host holding a workspace whose ID collides with a local one, which is not reproducible from a single local launch. Per `AGENTS.md`, local Electron launches are paused for this work and validation runs in CI. The existing paired browser-and-simulator Cmd-J Electron spec covers this surface and is unchanged.

## Tradeoffs

Real, user-facing costs of this change:

- **Cmd-J "Open Tabs" ordering shifts for everyone, not just collision cases.** Browser rows previously always carried `lastActiveAt: null`, which `comparePaletteRankedItems` treats as `0`, so they lost every recency tiebreak. With real focus timestamps restored, browser rows can now outrank terminal, chat, and simulator rows they used to sit below. Anyone with muscle memory for the old order will see rows move.
- **Browser rows now display a session age.** `worktree-jump-palette-browser-simulator-rows.tsx` renders `formatPaletteSessionAge(result.lastActiveAt, ...)`, which was always blank before. Rows gain a relative timestamp, so the list reads slightly denser.
- **The fix is not total on colliding IDs.** A browser workspace with no matching owned unified tab is still skipped by that same `continue`. If the unified tab has not hydrated yet, that workspace's pages stay invisible on a duplicated ID — better than before, but not guaranteed complete.
- **Host resolution can change without any collision.** `getUnifiedTabPaletteExecutionHostId` now prefers the unified tab's `executionHostId` alias over `worktree.hostId`, so a single-host user's row may resolve to a different host id string than before. It is alias-checked against the worktree, so it should not misroute, but it is a behavior change beyond the reported bug.
- **One more memo rebuild.** `browserPageEntries` now recomputes whenever `unifiedTabsByWorktree` changes, which includes tab focus and reorder. The palette's simulator and workspace-tab memos already depended on that slice, so this adds a third rebuild at an existing churn point rather than introducing a new one; per rebuild the builder does a linear `unifiedTabs.find` per workspace.
- **Regression risk is concentrated in activation.** `executionHostId` steers which worktree a selected browser result opens, so a wrong value would send the user to the wrong host rather than merely rendering an odd row.

## Testing

`src/renderer/src/components/use-worktree-jump-palette-browser-ownership.test.ts` renders the hook with two worktrees sharing the ID `same-id` on `local` and `runtime:paired`, and asserts the browser row resolves to `runtime:paired`. It then reruns with the tab moved to `local` and asserts the row follows, which also covers the added memo dependency. The test fails on `main` — rows are dropped entirely, so the first assertion sees an empty list — and passes with the fix.

- [ ] I manually tested these changes locally — not done: local Electron launches are paused for this work per `AGENTS.md`, and the bug needs a live paired host to reproduce by hand.
- [x] Automated tests added/updated, or explained why not below

Local runs: the focused browser-palette suites, `pnpm tc`, and `oxlint` on the changed files. Full CI is green on this branch (typecheck, static analysis, all 8 test shards, package on macOS and Windows). Native Linux/Windows desktop and a live SSH host were not exercised by hand; the change is renderer-only and has no platform-specific branches.

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->

## Review

Application fix — leave open for user review.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance.

- **Security:** none. No new data source; the map was already in the palette's store state and is already consumed by two sibling memos in the same hook.
- **Cross-platform:** renderer-only. No path, shell, or keyboard handling is touched.
- **Remote SSH / paired hosts:** this is the point of the change. Host identity resolves through the existing `isExecutionHostAliasForWorktree` check rather than any new assumption, and loss of contact is not inferred anywhere.
- **Remote wire compatibility:** no wire change. Nothing crosses the client/host boundary; the map is renderer-local store state.
- **Folder workspaces:** unaffected. Ownership keys off worktree ID and execution host, not off being a git worktree.
- **Mobile:** no mobile-facing surface touched.
- **Backwards compatibility:** no persisted state, schema, or serialized contract involved.
- **Performance:** see Tradeoffs. One additional memo rebuild on a slice the same hook already watches.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason (see Visual Proof)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
