### PR TITLE
fix(mobile): stop host streams after relay subscription cancellation

### DIFF
--- a/mobile/src/transport/mobile-relay-browser-cancel-budget.test.ts
+++ b/mobile/src/transport/mobile-relay-browser-cancel-budget.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+import { RuntimeBrowserScreencastController } from '../../../src/main/runtime/runtime-browser-screencast-controller'
+import type { RuntimeBrowserCommands } from '../../../src/main/runtime/orca-runtime-browser'
+import type { BrowserScreencastResult } from '../../../src/shared/runtime-types'
+import { MobileRelayRpcStreams } from './mobile-relay-rpc-streams'
+import type { RpcResponse } from './types'
+
+describe('relay browser cancellation resource budget', () => {
+  it.each([false, true])('stops host frames when cancellation precedes ready=%s', async (early) => {
+    const subscriptions = new Map<string, () => void | Promise<void>>()
+    const done = Promise.withResolvers<void>()
+    const ready = Promise.withResolvers<RpcResponse>()
+    let sequence = 0
+    let stopped = false
+    let frameSends = 0
+    let frameBytes = 0
+    let sendBinary: (bytes: Uint8Array) => boolean | void = () => false
+    let hostRun: Promise<void> | undefined
+    const methods: string[] = []
+    const cleanup = (id: string): void => {
+      const release = subscriptions.get(id)
+      subscriptions.delete(id)
+      void release?.()
+    }
+    const host = new RuntimeBrowserScreencastController({
+      getCommands: () =>
+        ({
+          browserScreencast: async (_params, stream) => {
+            sendBinary = stream.sendBinary
+            return {
+              subscriptionId: 'server-stream',
+              ready: { type: 'ready', subscriptionId: 'server-stream', browserPageId: 'page' },
+              session: {
+                done: done.promise,
+                stop: () => {
+                  stopped = true
+                  done.resolve()
+                }
+              },
+              flushPendingFrame: () => {}
+            }
+          }
+        }) as RuntimeBrowserCommands,
+      registerSubscriptionCleanup: (id, release) => subscriptions.set(id, release),
+      cleanupSubscription: cleanup,
+      getDriver: () => ({ kind: 'idle' }),
+      setDriver: () => {},
+      notifyRemoteViewersChanged: () => {}
+    })
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => `request-${++sequence}`,
+      waitForConnected: async () => {},
+      sendFrame: (request) => {
+        methods.push(request.method)
+        if (request.method === 'browser.screencast' && (request.params as { page?: string }).page) {
+          hostRun = host.start(request.params as Parameters<typeof host.start>[0], {
+            connectionId: 'relay-connection',
+            sendBinary: (bytes) => {
+              frameSends++
+              frameBytes += bytes.byteLength
+              return true
+            },
+            emit: (result: BrowserScreencastResult) => {
+              if (result.type === 'ready') {
+                ready.resolve({
+                  id: request.id,
+                  ok: true,
+                  streaming: true,
+                  result,
+                  _meta: { runtimeId: 'host' }
+                })
+              }
+            }
+          })
+        } else if (request.method === 'browser.screencast.unsubscribe') {
+          cleanup((request.params as { subscriptionId: string }).subscriptionId)
+        }
+        return true
+      }
+    })
+    const cancel = streams.subscribe('browser.screencast', { page: 'page' }, () => {})
+    try {
+      const response = await ready.promise
+      if (early) {
+        cancel()
+      }
+      streams.handleResponse(response)
+      if (!early) {
+        cancel()
+      }
+      for (let frame = 0; frame < 100; frame++) {
+        if (!stopped) {
+          sendBinary(new Uint8Array(65_536))
+        }
+      }
+      expect({ stopped, subscriptions: subscriptions.size, frameSends, frameBytes }).toEqual({
+        stopped: true,
+        subscriptions: 0,
+        frameSends: 0,
+        frameBytes: 0
+      })
+      expect(methods).toEqual(['browser.screencast', 'browser.screencast.unsubscribe'])
+    } finally {
+      cleanup('server-stream')
+      await hostRun
+      streams.clear()
+    }
+  })
+})

--- a/mobile/src/transport/mobile-relay-rpc-session.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.test.ts
@@ -136,6 +136,36 @@ describe('mobile relay RPC session', () => {
   })
   afterEach(() => vi.useRealTimers())
 
+  it('releases stream listeners on failure even when close follows it', async () => {
+    const { session } = await authenticateSession()
+    const listener = vi.fn()
+    session.subscribe('runtime.clientEvents.subscribe', {}, listener)
+    await Promise.resolve()
+    const request = JSON.parse(fakes.sendText.mock.calls[0]![0] as string) as { id: string }
+    fakes.linkOptions!.onText(
+      JSON.stringify({
+        id: request.id,
+        ok: true,
+        streaming: true,
+        result: { type: 'ready', subscriptionId: 'server-events' },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    expect(listener).toHaveBeenCalledTimes(1)
+    fakes.linkOptions!.onError(new Error('relay lost'))
+    session.close()
+    fakes.linkOptions!.onText(
+      JSON.stringify({
+        id: request.id,
+        ok: true,
+        streaming: true,
+        result: { type: 'event' },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
   it('requires exact resume observations and confirms by request ID before becoming connected', async () => {
     const { session, confirmationRequest, capabilityRequest } = await authenticateSession()
 

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -294,6 +294,7 @@ export function connectMobileRelayRpcSession(args: {
     closed = true
     failure = error
     livenessWatchdog.stop(livenessIdentity)
+    streams.clear()
     link.close()
     pending.rejectAll(error)
     publishState(error instanceof MobileE2EEAuthenticationError ? 'auth-failed' : 'disconnected')

--- a/mobile/src/transport/mobile-relay-rpc-stream-cancellation.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-stream-cancellation.test.ts
@@ -190,6 +190,55 @@ describe('mobile relay subscription cancellation', () => {
     }
   )
 
+  it.each([
+    ['nativeChat.subscribe', { agent: 'claude', sessionId: 's1', subscriptionId: 'claude:s1' }],
+    ['terminal.subscribe', { terminal: 'term', client: { id: 'phone' } }]
+  ])(
+    'keeps the newer %s live when an older same-token subscription unmounts',
+    async (method, params) => {
+      const { streams, sendFrame } = createStreams()
+      const older = vi.fn()
+      const newer = vi.fn()
+      const cancelOlder = streams.subscribe(method, params, older)
+      const cancelNewer = streams.subscribe(method, { ...params }, newer)
+      await Promise.resolve()
+      expect(sendFrame).toHaveBeenCalledTimes(2)
+      cancelOlder()
+      // The host keys cleanup by the deterministic token, so unsubscribing would evict the newer.
+      expect(sendFrame).toHaveBeenCalledTimes(2)
+      streams.handleResponse(response('request-2', { type: 'snapshot' }))
+      expect(newer).toHaveBeenCalledTimes(1)
+      expect(streams.handleResponse(response('request-1', { type: 'snapshot' }))).toBe(false)
+      expect(older).not.toHaveBeenCalled()
+      cancelNewer()
+      expect(sendFrame).toHaveBeenCalledTimes(3)
+      expect(sendFrame).toHaveBeenLastCalledWith(
+        expect.objectContaining({ method: method.replace(/\.subscribe$/, '.unsubscribe') })
+      )
+    }
+  )
+
+  it('still unsubscribes a shared-token nativeChat stream when the sibling is unsent', async () => {
+    const wait = Promise.withResolvers<void>()
+    let connected = false
+    const { streams, sendFrame } = createStreams(() =>
+      connected ? Promise.resolve() : wait.promise
+    )
+    const params = { agent: 'claude', sessionId: 's1', subscriptionId: 'claude:s1' }
+    connected = true
+    const cancelOlder = streams.subscribe('nativeChat.subscribe', params, vi.fn())
+    await Promise.resolve()
+    connected = false
+    streams.subscribe('nativeChat.subscribe', params, vi.fn())
+    cancelOlder()
+    expect(sendFrame).toHaveBeenCalledTimes(2)
+    expect(sendFrame).toHaveBeenLastCalledWith({
+      id: 'request-3',
+      method: 'nativeChat.unsubscribe',
+      params: { subscriptionId: 'claude:s1' }
+    })
+  })
+
   it('cleans up every cancelled server subscription across repeated late-ready cycles', async () => {
     const { streams, sendFrame } = createStreams()
     const listener = vi.fn()

--- a/mobile/src/transport/mobile-relay-rpc-stream-cancellation.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-stream-cancellation.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MobileRelayRpcStreams } from './mobile-relay-rpc-streams'
+import type { RpcResponse } from './types'
+
+function createStreams(waitForConnected = async () => {}) {
+  let sequence = 0
+  const sendFrame = vi.fn((_request: { id: string; method: string; params?: unknown }) => true)
+  const streams = new MobileRelayRpcStreams({
+    nextId: () => `request-${++sequence}`,
+    sendFrame,
+    waitForConnected
+  })
+  return { streams, sendFrame }
+}
+
+function response(id: string, result: unknown): RpcResponse {
+  return { id, ok: true, streaming: true, result, _meta: { runtimeId: 'test' } }
+}
+
+const serverSubscriptions = [
+  ['browser.screencast', 'browser.screencast.unsubscribe'],
+  ['runtime.clientEvents.subscribe', 'runtime.clientEvents.unsubscribe']
+] as const
+
+describe('mobile relay subscription cancellation', () => {
+  it.each(serverSubscriptions)('cleans up ready %s exactly once', async (method, unsubscribe) => {
+    const { streams, sendFrame } = createStreams()
+    const listener = vi.fn()
+    const cancel = streams.subscribe(method, {}, listener)
+    await Promise.resolve()
+    streams.handleResponse(response('request-1', { type: 'ready', subscriptionId: 'server-1' }))
+    cancel()
+    cancel()
+    expect(sendFrame.mock.calls).toEqual([
+      [{ id: 'request-1', method, params: {} }],
+      [{ id: 'request-2', method: unsubscribe, params: { subscriptionId: 'server-1' } }]
+    ])
+    expect(streams.handleResponse(response('request-1', { type: 'end' }))).toBe(false)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(serverSubscriptions)(
+    'cleans up late-ready %s without calling disposed listeners',
+    async (method, unsubscribe) => {
+      const { streams, sendFrame } = createStreams()
+      const listener = vi.fn()
+      const cancel = streams.subscribe(method, {}, listener)
+      await Promise.resolve()
+      cancel()
+      cancel()
+      expect(sendFrame).toHaveBeenCalledTimes(1)
+      expect(streams.handleResponse(response('request-1', { type: 'starting' }))).toBe(true)
+      streams.handleResponse(response('request-1', { type: 'ready', subscriptionId: 'server-1' }))
+      expect(sendFrame).toHaveBeenLastCalledWith({
+        id: 'request-2',
+        method: unsubscribe,
+        params: { subscriptionId: 'server-1' }
+      })
+      expect(
+        streams.handleResponse(response('request-1', { type: 'ready', subscriptionId: 'server-1' }))
+      ).toBe(false)
+      expect(listener).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['error', 'end', 'disconnect', 'completed'])(
+    'forgets cancelled cleanup routes on %s',
+    async (ending) => {
+      const { streams, sendFrame } = createStreams()
+      const cancel = streams.subscribe('browser.screencast', {}, vi.fn())
+      await Promise.resolve()
+      cancel()
+      if (ending === 'disconnect') {
+        streams.clear()
+      } else if (ending === 'completed') {
+        streams.handleResponse({
+          id: 'request-1',
+          ok: true,
+          result: null,
+          _meta: { runtimeId: 'test' }
+        })
+      } else if (ending === 'error') {
+        streams.handleResponse({
+          id: 'request-1',
+          ok: false,
+          error: { code: 'unsupported', message: 'failed' },
+          _meta: { runtimeId: 'test' }
+        })
+      } else {
+        streams.handleResponse(response('request-1', { type: 'end', subscriptionId: 'server-1' }))
+      }
+      expect(
+        streams.handleResponse(response('request-1', { type: 'ready', subscriptionId: 'server-1' }))
+      ).toBe(false)
+      expect(sendFrame).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it.each([
+    [
+      'terminal.subscribe',
+      { terminal: 'term', client: { id: 'phone' } },
+      'terminal.unsubscribe',
+      { subscriptionId: 'term:phone', client: { id: 'phone' } }
+    ],
+    [
+      'session.tabs.subscribe',
+      { worktree: 'id:workspace' },
+      'session.tabs.unsubscribe',
+      { worktree: 'id:workspace', subscriptionId: 'request-1' }
+    ],
+    [
+      'nativeChat.subscribe',
+      { subscriptionId: 'chat' },
+      'nativeChat.unsubscribe',
+      { subscriptionId: 'chat' }
+    ]
+  ])(
+    'cancels %s using its request cleanup identity',
+    async (method, params, unsubscribe, unsubscribeParams) => {
+      const { streams, sendFrame } = createStreams()
+      const cancel = streams.subscribe(method as string, params, vi.fn())
+      await Promise.resolve()
+      if (method === 'session.tabs.subscribe') {
+        streams.handleResponse(response('request-1', { type: 'snapshot' }))
+      }
+      cancel()
+      expect(sendFrame).toHaveBeenLastCalledWith({
+        id: 'request-2',
+        method: unsubscribe,
+        params: unsubscribeParams
+      })
+    }
+  )
+
+  it.each([
+    'terminal.subscribe',
+    'browser.screencast',
+    'runtime.clientEvents.subscribe',
+    'session.tabs.subscribe',
+    'nativeChat.subscribe'
+  ])('does not unsubscribe an unsent %s', async (method) => {
+    const wait = Promise.withResolvers<void>()
+    const { streams, sendFrame } = createStreams(() => wait.promise)
+    const cancel = streams.subscribe(
+      method,
+      { terminal: 'term', worktree: 'id:workspace', subscriptionId: 'chat' },
+      vi.fn()
+    )
+    cancel()
+    wait.resolve()
+    await Promise.resolve()
+    expect(sendFrame).not.toHaveBeenCalled()
+    expect(
+      streams.handleResponse(response('request-1', { type: 'ready', subscriptionId: 'server-1' }))
+    ).toBe(false)
+  })
+
+  it.each([false, true])(
+    'preserves a same-worktree sibling when cancellation precedes snapshot=%s',
+    async (early) => {
+      const { streams, sendFrame } = createStreams()
+      const first = vi.fn()
+      const second = vi.fn()
+      const cancel = streams.subscribe(
+        'session.tabs.subscribe',
+        { worktree: 'id:workspace' },
+        first
+      )
+      streams.subscribe('session.tabs.subscribe', { worktree: 'id:workspace' }, second)
+      await Promise.resolve()
+      if (early) {
+        cancel()
+      }
+      expect(sendFrame).toHaveBeenCalledTimes(2)
+      streams.handleResponse(response('request-1', { type: 'snapshot' }))
+      if (!early) {
+        cancel()
+      }
+      expect(sendFrame).toHaveBeenLastCalledWith({
+        id: 'request-3',
+        method: 'session.tabs.unsubscribe',
+        params: { worktree: 'id:workspace', subscriptionId: 'request-1' }
+      })
+      streams.handleResponse(response('request-2', { type: 'snapshot' }))
+      streams.handleResponse(response('request-2', { type: 'updated' }))
+      expect(second).toHaveBeenCalledTimes(2)
+      expect(first).toHaveBeenCalledTimes(early ? 0 : 1)
+      expect(streams.handleResponse(response('request-1', { type: 'updated' }))).toBe(false)
+    }
+  )
+
+  it('cleans up every cancelled server subscription across repeated late-ready cycles', async () => {
+    const { streams, sendFrame } = createStreams()
+    const listener = vi.fn()
+    for (let i = 0; i < 100; i++) {
+      const cancel = streams.subscribe('runtime.clientEvents.subscribe', {}, listener)
+      await Promise.resolve()
+      const requestId = `request-${2 * i + 1}`
+      cancel()
+      streams.handleResponse(response(requestId, { type: 'ready', subscriptionId: `server-${i}` }))
+    }
+    expect(
+      sendFrame.mock.calls.filter(
+        ([request]) => (request as { method: string }).method === 'runtime.clientEvents.unsubscribe'
+      )
+    ).toHaveLength(100)
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/mobile-relay-rpc-streams.ts
+++ b/mobile/src/transport/mobile-relay-rpc-streams.ts
@@ -28,6 +28,21 @@ type StreamRecord = {
   receivedSnapshot?: boolean
 }
 
+type StreamUnsubscribe = { method: string; params: unknown }
+
+/** Unsubscribe derived from the subscribe params alone (no server-assigned id). */
+function buildParamsUnsubscribe(
+  method: string,
+  params: unknown,
+  requestId: string
+): StreamUnsubscribe | null {
+  if (method === 'terminal.subscribe') {
+    const unsubscribeParams = buildTerminalUnsubscribeParams(params)
+    return unsubscribeParams ? { method: 'terminal.unsubscribe', params: unsubscribeParams } : null
+  }
+  return buildStreamUnsubscribe(method, params, requestId)
+}
+
 type StreamManagerOptions = {
   nextId: () => string
   sendFrame: (request: { id: string; method: string; params?: unknown }) => boolean
@@ -38,7 +53,7 @@ export class MobileRelayRpcStreams {
   private readonly streams = new Map<string, StreamRecord>()
   private readonly cancelledSubscriptions = new Map<
     string,
-    { method: string; unsubscribe?: NonNullable<ReturnType<typeof buildStreamUnsubscribe>> }
+    { method: string; unsubscribe?: StreamUnsubscribe }
   >()
   private readonly terminalListeners = new Map<number, (result: unknown) => void>()
   private readonly terminalSnapshots = new Map<number, TerminalSnapshotState>()
@@ -175,25 +190,20 @@ export class MobileRelayRpcStreams {
     }
     stream.cancelled = true
     if (stream.sent) {
+      const byParams = buildParamsUnsubscribe(stream.method, stream.params, id)
       if (stream.method === 'terminal.subscribe') {
-        const params = buildTerminalUnsubscribeParams(stream.params)
-        if (params) {
-          this.options.sendFrame({
-            id: this.options.nextId(),
-            method: 'terminal.unsubscribe',
-            params
-          })
+        if (byParams) {
+          this.sendUnsubscribe(byParams)
         }
       } else {
         const unsubscribe = stream.subscriptionId
           ? buildReadyStreamUnsubscribe(stream.method, stream.subscriptionId)
           : null
-        const byParams = buildStreamUnsubscribe(stream.method, stream.params, id)
         if (byParams && stream.method === 'session.tabs.subscribe' && !stream.receivedSnapshot) {
           // The host registers cleanup only after resolving the initial snapshot.
           this.cancelledSubscriptions.set(id, { method: stream.method, unsubscribe: byParams })
         } else if (unsubscribe || byParams) {
-          this.options.sendFrame({ id: this.options.nextId(), ...(unsubscribe ?? byParams)! })
+          this.sendUnsubscribe((unsubscribe ?? byParams)!)
         } else if (
           stream.method === 'browser.screencast' ||
           stream.method === 'runtime.clientEvents.subscribe'
@@ -201,8 +211,7 @@ export class MobileRelayRpcStreams {
           // Keep only the cleanup route while the server assigns its subscription ID.
           this.cancelledSubscriptions.set(id, { method: stream.method })
         } else if (stream.subscriptionId) {
-          this.options.sendFrame({
-            id: this.options.nextId(),
+          this.sendUnsubscribe({
             method: stream.method.replace(/\.subscribe$/, '.unsubscribe'),
             params: { subscriptionId: stream.subscriptionId }
           })
@@ -210,6 +219,29 @@ export class MobileRelayRpcStreams {
       }
     }
     this.remove(id)
+  }
+
+  /** Skip the unsubscribe when a live sibling shares the host cleanup token (e.g. nativeChat's
+   *  deterministic `agent:sessionId`), since the host would evict the sibling's registration. */
+  private sendUnsubscribe(unsubscribe: StreamUnsubscribe): void {
+    if (this.hasLiveOwner(unsubscribe)) {
+      return
+    }
+    this.options.sendFrame({ id: this.options.nextId(), ...unsubscribe })
+  }
+
+  private hasLiveOwner(unsubscribe: StreamUnsubscribe): boolean {
+    const token = JSON.stringify(unsubscribe)
+    for (const [siblingId, sibling] of this.streams) {
+      if (sibling.cancelled || !sibling.sent) {
+        continue
+      }
+      const siblingUnsubscribe = buildParamsUnsubscribe(sibling.method, sibling.params, siblingId)
+      if (siblingUnsubscribe && JSON.stringify(siblingUnsubscribe) === token) {
+        return true
+      }
+    }
+    return false
   }
 
   private remove(id: string): void {

--- a/mobile/src/transport/mobile-relay-rpc-streams.ts
+++ b/mobile/src/transport/mobile-relay-rpc-streams.ts
@@ -4,9 +4,11 @@ import {
   type TerminalSnapshotState
 } from './rpc-client-terminal-binary-frame'
 import {
+  buildStreamUnsubscribe,
   buildTerminalUnsubscribeParams,
   updateTerminalSubscriptionViewport
 } from './rpc-client-terminal-subscription'
+import { buildReadyStreamUnsubscribe } from './rpc-client-server-subscription'
 import type { RpcClient } from './rpc-client'
 import type { RpcResponse, RpcSuccess } from './types'
 
@@ -22,6 +24,8 @@ type StreamRecord = {
   streamIds: Set<number>
   subscriptionId?: string
   cancelled: boolean
+  sent: boolean
+  receivedSnapshot?: boolean
 }
 
 type StreamManagerOptions = {
@@ -32,6 +36,10 @@ type StreamManagerOptions = {
 
 export class MobileRelayRpcStreams {
   private readonly streams = new Map<string, StreamRecord>()
+  private readonly cancelledSubscriptions = new Map<
+    string,
+    { method: string; unsubscribe?: NonNullable<ReturnType<typeof buildStreamUnsubscribe>> }
+  >()
   private readonly terminalListeners = new Map<number, (result: unknown) => void>()
   private readonly terminalSnapshots = new Map<number, TerminalSnapshotState>()
   private activeBrowserStream: StreamRecord | null = null
@@ -51,13 +59,15 @@ export class MobileRelayRpcStreams {
       listener,
       onBinaryFrame: subscribeOptions?.onBinaryFrame,
       streamIds: new Set(),
-      cancelled: false
+      cancelled: false,
+      sent: false
     }
     this.streams.set(id, stream)
     void this.options
       .waitForConnected()
       .then(() => {
         if (!stream.cancelled) {
+          stream.sent = true
           if (!this.options.sendFrame({ id, method, params: stream.params })) {
             this.fail(id, stream, 'Connection interrupted')
           }
@@ -75,6 +85,30 @@ export class MobileRelayRpcStreams {
   }
 
   handleResponse(response: RpcResponse): boolean {
+    const cancelled = this.cancelledSubscriptions.get(response.id)
+    if (cancelled) {
+      if (!response.ok) {
+        this.cancelledSubscriptions.delete(response.id)
+      } else if (response.result && typeof response.result === 'object') {
+        const result = response.result as { subscriptionId?: unknown; type?: unknown }
+        if (result.type === 'end') {
+          this.cancelledSubscriptions.delete(response.id)
+        } else if (result.type === 'snapshot' && cancelled.unsubscribe) {
+          this.cancelledSubscriptions.delete(response.id)
+          this.options.sendFrame({ id: this.options.nextId(), ...cancelled.unsubscribe })
+        } else if (typeof result.subscriptionId === 'string') {
+          this.cancelledSubscriptions.delete(response.id)
+          const unsubscribe = buildReadyStreamUnsubscribe(cancelled.method, result.subscriptionId)
+          if (unsubscribe) {
+            this.options.sendFrame({ id: this.options.nextId(), ...unsubscribe })
+          }
+        }
+      }
+      if (response.ok && response.streaming !== true) {
+        this.cancelledSubscriptions.delete(response.id)
+      }
+      return true
+    }
     const stream = this.streams.get(response.id)
     if (!stream) {
       return false
@@ -86,6 +120,9 @@ export class MobileRelayRpcStreams {
     const result = (response as RpcSuccess).result
     if (result && typeof result === 'object') {
       const metadata = result as { subscriptionId?: unknown; streamId?: unknown; type?: unknown }
+      if (stream.method === 'session.tabs.subscribe' && metadata.type === 'snapshot') {
+        stream.receivedSnapshot = true
+      }
       if (typeof metadata.subscriptionId === 'string') {
         stream.subscriptionId = metadata.subscriptionId
       }
@@ -125,6 +162,7 @@ export class MobileRelayRpcStreams {
       stream.cancelled = true
     }
     this.streams.clear()
+    this.cancelledSubscriptions.clear()
     this.terminalListeners.clear()
     this.terminalSnapshots.clear()
     this.activeBrowserStream = null
@@ -136,21 +174,40 @@ export class MobileRelayRpcStreams {
       return
     }
     stream.cancelled = true
-    if (stream.method === 'terminal.subscribe') {
-      const params = buildTerminalUnsubscribeParams(stream.params)
-      if (params) {
-        this.options.sendFrame({
-          id: this.options.nextId(),
-          method: 'terminal.unsubscribe',
-          params
-        })
+    if (stream.sent) {
+      if (stream.method === 'terminal.subscribe') {
+        const params = buildTerminalUnsubscribeParams(stream.params)
+        if (params) {
+          this.options.sendFrame({
+            id: this.options.nextId(),
+            method: 'terminal.unsubscribe',
+            params
+          })
+        }
+      } else {
+        const unsubscribe = stream.subscriptionId
+          ? buildReadyStreamUnsubscribe(stream.method, stream.subscriptionId)
+          : null
+        const byParams = buildStreamUnsubscribe(stream.method, stream.params, id)
+        if (byParams && stream.method === 'session.tabs.subscribe' && !stream.receivedSnapshot) {
+          // The host registers cleanup only after resolving the initial snapshot.
+          this.cancelledSubscriptions.set(id, { method: stream.method, unsubscribe: byParams })
+        } else if (unsubscribe || byParams) {
+          this.options.sendFrame({ id: this.options.nextId(), ...(unsubscribe ?? byParams)! })
+        } else if (
+          stream.method === 'browser.screencast' ||
+          stream.method === 'runtime.clientEvents.subscribe'
+        ) {
+          // Keep only the cleanup route while the server assigns its subscription ID.
+          this.cancelledSubscriptions.set(id, { method: stream.method })
+        } else if (stream.subscriptionId) {
+          this.options.sendFrame({
+            id: this.options.nextId(),
+            method: stream.method.replace(/\.subscribe$/, '.unsubscribe'),
+            params: { subscriptionId: stream.subscriptionId }
+          })
+        }
       }
-    } else if (stream.subscriptionId) {
-      this.options.sendFrame({
-        id: this.options.nextId(),
-        method: stream.method.replace(/\.subscribe$/, '.unsubscribe'),
-        params: { subscriptionId: stream.subscriptionId }
-      })
     }
     this.remove(id)
   }

--- a/mobile/src/transport/rpc-client-terminal-subscription.ts
+++ b/mobile/src/transport/rpc-client-terminal-subscription.ts
@@ -38,7 +38,8 @@ export function updateTerminalSubscriptionViewport(
  *  the per-method echo logic out of the rpc-client teardown closure. */
 export function buildStreamUnsubscribe(
   method: string | undefined,
-  params: unknown
+  params: unknown,
+  requestId?: string
 ): { method: string; params: Record<string, unknown> } | null {
   if (!params || typeof params !== 'object') {
     return null
@@ -46,7 +47,10 @@ export function buildStreamUnsubscribe(
   if (method === 'session.tabs.subscribe') {
     const worktree = (params as { worktree?: unknown }).worktree
     return typeof worktree === 'string'
-      ? { method: 'session.tabs.unsubscribe', params: { worktree } }
+      ? {
+          method: 'session.tabs.unsubscribe',
+          params: { worktree, ...(requestId ? { subscriptionId: requestId } : {}) }
+        }
       : null
   }
   if (method === 'nativeChat.subscribe') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​398 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​398 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 |

<!-- /orca-pr-loc -->

## ELI5

Leaving a mobile browser view could stop showing its pictures without telling the host to stop making and sending them. The relay client built the wrong browser unsubscribe method and forgot subscriptions cancelled before the host returned their cleanup ID. Tab and native-chat subscriptions also missed their existing cleanup RPCs.

Reuse the existing unsubscribe builders, retain only cleanup routing metadata while an already-sent subscription becomes ready, and release listeners on relay failure. Tab cleanup uses the original request ID so one subscriber cannot stop another subscriber to the same workspace; early tab cancellation waits for the host's initial snapshot/cleanup registration. Cancelling an unsent request sends nothing.

## Measurements

Production `MobileRelayRpcStreams` connected to the production `RuntimeBrowserScreencastController`, with a controlled frame producer and in-memory transport. After cancellation the producer attempts 100 frames of 65,536 bytes if it is still running. This is a deterministic resource budget, not a measured network rate or device battery estimate.

| Resource after cancellation | Before | After |
|---|---:|---:|
| Retained host browser subscriptions | 1 | 0 |
| Frames sent during the next 100 frame opportunities | 100 | 0 |
| Bytes sent during those opportunities | 6,553,600 | 0 |

Both cancellation timings reproduce: after ready, and before the client receives ready. The checked-in budget tests fail against original `mobile-relay-rpc-streams.ts` from `d8c4c830639bf3d603c9250a536e0323ca0a7a19`, reporting all three before counts, and pass with this change.

Reproduce: `pnpm --dir mobile test src/transport/mobile-relay-browser-cancel-budget.test.ts`. Run the same test with only that production stream file restored from the baseline to reproduce the failure.

## Validation

39 mobile stream/session/cancellation tests pass in the final focused run, including 100 late-ready cancellation cycles, exactly-once cleanup, unsent requests, error/end/completion/disconnect, native-chat/terminal cleanup identities, and sibling tab subscriptions. Three existing host session-tab unsubscribe tests pass. Mobile typecheck, targeted lint, formatting, and diff checks pass.

Uses existing RPC methods and optional request-scoped cleanup fields; no new stream opcode, capability, or host schema. The existing parent revision's session-tab schema/handler accepts request-scoped cleanup. Execution stays with the owning host; cancellation unsubscribes the view and does not terminate remote PTYs or agent work. Folder workspaces use the same workspace selector path.

Visual proof: N/A — active-view rendering is unchanged; the regression is work continuing after its viewer has unsubscribed. The production-controller budget test verifies that cleanup stops that work. No foreground app or mobile simulator launched.

## Negative user-facing trade-offs

None identified. Active subscriptions keep receiving their existing data and same-workspace sibling subscriptions remain active. Pending cancellation retains only request/method/cleanup identifiers until the reply, completion, or disconnect; it does not retain disposed view listeners or frame buffers. No polling delay, shortened output, or cache freshness change.
