### PR TITLE
fix(agent-resume): restore Cursor conversations after restart

### DIFF
--- a/src/renderer/src/lib/ai-vault-resume-command.resumable-agent.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.resumable-agent.test.ts
@@ -46,6 +46,13 @@ const KIMI_SESSION = {
   codexHome: null
 }
 
+const CURSOR_SESSION = {
+  agent: 'cursor' as const,
+  sessionId: 'cursor-conversation-1',
+  cwd: '/Users/ada/repo/packages/api',
+  codexHome: null
+}
+
 describe('AI Vault resume for Kimi', () => {
   it('keeps the cd prefix on the copied resume line', () => {
     // Why: Kimi sessions are work-dir-scoped — resuming from the worktree root instead of the
@@ -78,6 +85,22 @@ describe('AI Vault resume for Kimi', () => {
         key: 'session_id',
         id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201'
       }
+    })
+  })
+})
+
+describe('AI Vault resume for Cursor', () => {
+  it('uses the Cursor conversation id as the provider session', () => {
+    expect(
+      buildAiVaultResumeStartupForWorktree({
+        state: makeState(),
+        worktreeId: 'repo-1::worktree-1',
+        session: CURSOR_SESSION
+      })
+    ).toMatchObject({
+      command: "cursor-agent '--yolo' '--resume' 'cursor-conversation-1'",
+      cwd: '/Users/ada/repo/packages/api',
+      providerSession: { key: 'conversation_id', id: 'cursor-conversation-1' }
     })
   })
 })

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -152,9 +152,7 @@ describe('ai vault resume command runtime', () => {
     ).toBe("claude '--resume' 'session one'")
   })
 
-  it('follows the live Windows shell for non-resumable agents in the fallback path', () => {
-    // Why: agents without a TUI startup plan (e.g. cursor) queue through the
-    // shared-builder fallback, which must quote for the live shell too (#6152).
+  it('follows the live Windows shell for Cursor resume', () => {
     const state = makeState({ worktreePath: 'C:\\Users\\alice\\repo' })
 
     expect(
@@ -168,7 +166,7 @@ describe('ai vault resume command runtime', () => {
           codexHome: null
         }
       })
-    ).toBe("cursor-agent --resume 'session one'")
+    ).toBe("cursor-agent '--yolo' '--resume' 'session one'")
   })
 
   it('queues a PowerShell-valid local OMP resume by absolute transcript path', () => {

--- a/src/renderer/src/lib/ai-vault-resume-command.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.ts
@@ -259,6 +259,9 @@ export function getAiVaultAgentProviderSession(
   if (session.agent === 'antigravity') {
     return { key: 'conversation_id', id: session.sessionId }
   }
+  if (session.agent === 'cursor') {
+    return { key: 'conversation_id', id: session.sessionId }
+  }
   if (session.agent === 'pi' || session.agent === 'prime-agent') {
     return session.filePath
       ? { key: 'session_id', id: session.sessionId, transcriptPath: session.filePath }

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { RESUMABLE_TUI_AGENTS } from '../../../shared/agent-session-resume'
 import {
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   RUNTIME_CAPABILITIES
@@ -8,6 +9,12 @@ import {
 import { agentResumeHostAuthorityCapability } from './agent-resume-host-authority-capability'
 
 describe('agentResumeHostAuthorityCapability', () => {
+  it('gates Cursor resume behind its own capability', () => {
+    expect(agentResumeHostAuthorityCapability('cursor')).toBe(
+      AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
+    )
+  })
+
   it('gates Kimi resume behind its own capability', () => {
     expect(agentResumeHostAuthorityCapability('kimi')).toBe(
       AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
@@ -28,6 +35,10 @@ describe('agentResumeHostAuthorityCapability', () => {
 
   it('advertises the Kimi resume capability from the host', () => {
     expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY)
+  })
+
+  it('advertises the Cursor resume capability from the host', () => {
+    expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY)
   })
 
   it('pins the gate for every resumable agent so a new member is a deliberate decision', () => {
@@ -51,7 +62,8 @@ describe('agentResumeHostAuthorityCapability', () => {
       'prime-agent': undefined,
       copilot: undefined,
       omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
-      kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+      kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+      cursor: AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
     })
   })
 })

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -1,6 +1,7 @@
 import type { ResumableTuiAgent } from '../../../shared/agent-session-resume'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import {
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   type RuntimeCapability
@@ -30,7 +31,8 @@ const RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT = {
   // Ungated to match how main shipped copilot resume; gating it is its own change.
   copilot: undefined,
   omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
-  kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+  kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  cursor: AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY
 } satisfies Record<ResumableTuiAgent, RuntimeCapability | undefined>
 
 export function agentResumeHostAuthorityCapability(

--- a/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
@@ -39,4 +39,38 @@ describe('quit-time capture for newly resumable agents', () => {
       origin: 'live'
     })
   })
+
+  it('keeps a completed Cursor conversation checkpoint through quit capture', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+    const providerSession = { key: 'conversation_id' as const, id: 'cursor-conversation-1' }
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'finish the task', agentType: 'cursor' },
+        'Cursor',
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession }
+      )
+    store.getState().setAgentStatus('tab-1:leaf-1', {
+      state: 'done',
+      prompt: 'finish the task',
+      agentType: 'cursor'
+    })
+    store.getState().captureAllSleepingAgentSessions('quit')
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      agent: 'cursor',
+      state: 'done',
+      providerSession,
+      origin: 'live'
+    })
+  })
 })

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -28,6 +28,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('kimi')).toBe(true)
   })
 
+  it('treats Cursor as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('cursor')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -63,6 +67,15 @@ describe('agent session resume metadata', () => {
       'kimi',
       { session_id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
       { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' }
+    ],
+    [
+      'cursor',
+      { conversation_id: 'cursor-conversation-1', transcript_path: '/tmp/cursor.jsonl' },
+      {
+        key: 'conversation_id',
+        id: 'cursor-conversation-1',
+        transcriptPath: '/tmp/cursor.jsonl'
+      }
     ]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
@@ -94,6 +107,11 @@ describe('agent session resume metadata', () => {
       'kimi',
       { key: 'session_id', id: 'session_431324d7' },
       ['kimi', '--session', 'session_431324d7']
+    ],
+    [
+      'cursor',
+      { key: 'conversation_id', id: 'cursor-conversation-1' },
+      ['cursor-agent', '--resume', 'cursor-conversation-1']
     ]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -16,7 +16,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'omp',
   'prime-agent',
   'copilot',
-  'kimi'
+  'kimi',
+  'cursor'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -238,8 +239,11 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id', 'sessionId'])
       return id ? { key: 'session_id', id } : null
     }
+    case 'cursor': {
+      const id = readSessionId(payload, ['conversation_id'])
+      return id ? withTranscriptPath({ key: 'conversation_id', id }, payload) : null
+    }
     case 'amp':
-    case 'cursor':
     case 'command-code':
     case 'hermes':
       return null
@@ -291,5 +295,7 @@ export function getAgentResumeArgv(
     // Why: Kimi resumes by id with --session; sessions are work-dir-scoped (enforced by callers).
     case 'kimi':
       return providerSession.key === 'session_id' ? ['kimi', '--session', id] : null
+    case 'cursor':
+      return providerSession.key === 'conversation_id' ? ['cursor-agent', '--resume', id] : null
   }
 }

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -137,6 +137,8 @@ export const STRUCTURED_AGENT_SESSION_HOLD_RUNTIME_CAPABILITY =
 // older host answers the unknown member with invalid_argument — a code the launch fallback does
 // not retry on — so clients must probe before taking the host-authority path.
 export const AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1' as const
+export const AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY =
+  'agent-session.cursor-resume.v1' as const
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
@@ -230,6 +232,7 @@ export const RUNTIME_CAPABILITIES = [
   STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY,
   STRUCTURED_AGENT_SESSION_HOLD_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  AGENT_SESSION_CURSOR_RESUME_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   GITHUB_MARK_PR_READY_RUNTIME_CAPABILITY,
   GITLAB_READY_FOR_REVIEW_RUNTIME_CAPABILITY,

--- a/tests/e2e/agent-session-live-force-exit-resume.spec.ts
+++ b/tests/e2e/agent-session-live-force-exit-resume.spec.ts
@@ -19,6 +19,10 @@ import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 
 const PROVIDER_SESSION_ID = 'e2e-live-force-exit-session'
+const RECOVERY_CASES = [
+  { agent: 'codex', providerSessionKey: 'session_id', label: 'Codex' },
+  { agent: 'cursor', providerSessionKey: 'conversation_id', label: 'Cursor' }
+] as const
 
 type PersistedWorkspaceSession = {
   tabsByWorktree?: Record<string, { id?: unknown; ptyId?: unknown }[]>
@@ -149,133 +153,149 @@ function persistedLiveRecordExists(userDataDir: string): boolean {
 
 test.describe.configure({ mode: 'serial' })
 
-test('resumes a live agent record after force-exit restart when pane PTY ownership is gone', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
-{}, testInfo) => {
-  const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
-  if (!repoPath || !existsSync(repoPath)) {
-    test.skip(true, 'Global setup did not produce a seeded test repo')
-    return
-  }
+for (const { agent, providerSessionKey, label } of RECOVERY_CASES) {
+  test(`resumes a live ${label} record after force-exit restart when pane PTY ownership is gone`, async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+  {}, testInfo) => {
+    const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
+    if (!repoPath || !existsSync(repoPath)) {
+      test.skip(true, 'Global setup did not produce a seeded test repo')
+      return
+    }
 
-  const session = createRestartSession(testInfo)
-  let firstApp: ElectronApplication | null = null
-  let secondApp: ElectronApplication | null = null
+    const session = createRestartSession(testInfo)
+    let firstApp: ElectronApplication | null = null
+    let secondApp: ElectronApplication | null = null
 
-  try {
-    const firstLaunch = await session.launch()
-    firstApp = firstLaunch.app
-    const page = firstLaunch.page
-    const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
-    await waitForSessionReady(page)
-    // Why: the session writer persists only once hydrationSucceeded flips (not
-    // just workspaceSessionReady) — see shouldPersistWorkspaceSession — so the
-    // record write below is a silent no-op until hydration completes.
-    await expect
-      .poll(() => page.evaluate(() => window.__store?.getState().hydrationSucceeded === true), {
-        timeout: 30_000,
-        message: 'hydrationSucceeded did not become true before persisting the live record'
-      })
-      .toBe(true)
-    await waitForActiveWorktree(page)
-    await ensureTerminalVisible(page)
-    await waitForActiveTerminalManager(page, 30_000)
-    await waitForPaneCount(page, 1, 30_000)
+    try {
+      const firstLaunch = await session.launch()
+      firstApp = firstLaunch.app
+      const page = firstLaunch.page
+      const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+      await waitForSessionReady(page)
+      // Why: the session writer persists only once hydrationSucceeded flips (not
+      // just workspaceSessionReady) — see shouldPersistWorkspaceSession — so the
+      // record write below is a silent no-op until hydration completes.
+      await expect
+        .poll(() => page.evaluate(() => window.__store?.getState().hydrationSucceeded === true), {
+          timeout: 30_000,
+          message: 'hydrationSucceeded did not become true before persisting the live record'
+        })
+        .toBe(true)
+      await waitForActiveWorktree(page)
+      await ensureTerminalVisible(page)
+      await waitForActiveTerminalManager(page, 30_000)
+      await waitForPaneCount(page, 1, 30_000)
 
-    const descriptor = await waitForActivePaneHookDescriptor(page)
-    const ptyId = await waitForActivePanePtyId(page)
-    const transcriptPath = session.seedCodexResumeRollout(PROVIDER_SESSION_ID, repoPath)
-    const marker = `AGENT_LIVE_FORCE_EXIT_${Date.now()}`
-    await execInTerminal(page, ptyId, `echo ${marker}`)
-    await waitForTerminalOutput(page, marker)
+      const descriptor = await waitForActivePaneHookDescriptor(page)
+      const ptyId = await waitForActivePanePtyId(page)
+      const transcriptPath =
+        agent === 'codex'
+          ? session.seedCodexResumeRollout(PROVIDER_SESSION_ID, repoPath)
+          : undefined
+      const marker = `AGENT_LIVE_FORCE_EXIT_${Date.now()}`
+      await execInTerminal(page, ptyId, `echo ${marker}`)
+      await waitForTerminalOutput(page, marker)
 
-    await page.evaluate(
-      ({ paneKey, worktreeId: wtId, providerSessionId, transcriptPath }) => {
-        window.__store?.getState().setAgentStatus(
+      await page.evaluate(
+        ({
           paneKey,
-          { state: 'working', prompt: 'finish the task', agentType: 'codex' },
-          'Codex',
-          undefined,
-          { worktreeId: wtId },
-          {
-            providerSession: {
-              key: 'session_id',
-              id: providerSessionId,
-              transcriptPath
+          worktreeId: wtId,
+          providerSessionId,
+          agentType,
+          sessionKey,
+          displayName,
+          transcriptPath
+        }) => {
+          window.__store?.getState().setAgentStatus(
+            paneKey,
+            { state: 'working', prompt: 'finish the task', agentType },
+            displayName,
+            undefined,
+            { worktreeId: wtId },
+            {
+              providerSession: {
+                key: sessionKey,
+                id: providerSessionId,
+                ...(transcriptPath ? { transcriptPath } : {})
+              }
             }
-          }
+          )
+        },
+        {
+          paneKey: descriptor.paneKey,
+          worktreeId: descriptor.worktreeId,
+          providerSessionId: PROVIDER_SESSION_ID,
+          agentType: agent,
+          sessionKey: providerSessionKey,
+          displayName: label,
+          transcriptPath
+        }
+      )
+
+      // Exercise quit capture: origin:'quit' changes the live record, triggering the
+      // hydration-gated writer before polling persisted state.
+      await page.evaluate(() => window.__store?.getState().captureAllSleepingAgentSessions('quit'))
+
+      // Why: the record reaches disk via the debounced session writer (150ms) plus
+      // the main-process scheduleSave (up to 5s). Under CI event-loop starvation —
+      // the same shard drifts renderer timers ~1s — both stages need headroom, so
+      // poll to 30s (this suite's other readiness budget). On a miss, surface store
+      // vs disk state to separate a lost write from a merely slow flush.
+      const persistDeadline = Date.now() + 30_000
+      let persisted = false
+      while (Date.now() < persistDeadline) {
+        if (persistedLiveRecordExists(session.userDataDir)) {
+          persisted = true
+          break
+        }
+        await page.waitForTimeout(250)
+      }
+      if (!persisted) {
+        const storeRecords = await page.evaluate(
+          () => window.__store?.getState().sleepingAgentSessionsByPaneKey
         )
-      },
-      {
-        paneKey: descriptor.paneKey,
-        worktreeId: descriptor.worktreeId,
-        providerSessionId: PROVIDER_SESSION_ID,
-        transcriptPath
+        throw new Error(
+          `Live sleeping-agent record was not persisted before force exit. store=${JSON.stringify(
+            storeRecords
+          )} disk=${JSON.stringify(
+            readPersistedData(session.userDataDir).workspaceSession?.sleepingAgentSessionsByPaneKey
+          )}`
+        )
       }
-    )
 
-    // Exercise quit capture: origin:'quit' changes the live record, triggering the
-    // hydration-gated writer before polling persisted state.
-    await page.evaluate(() => window.__store?.getState().captureAllSleepingAgentSessions('quit'))
-
-    // Why: the record reaches disk via the debounced session writer (150ms) plus
-    // the main-process scheduleSave (up to 5s). Under CI event-loop starvation —
-    // the same shard drifts renderer timers ~1s — both stages need headroom, so
-    // poll to 30s (this suite's other readiness budget). On a miss, surface store
-    // vs disk state to separate a lost write from a merely slow flush.
-    const persistDeadline = Date.now() + 30_000
-    let persisted = false
-    while (Date.now() < persistDeadline) {
-      if (persistedLiveRecordExists(session.userDataDir)) {
-        persisted = true
-        break
-      }
-      await page.waitForTimeout(250)
-    }
-    if (!persisted) {
-      const storeRecords = await page.evaluate(
-        () => window.__store?.getState().sleepingAgentSessionsByPaneKey
-      )
-      throw new Error(
-        `Live sleeping-agent record was not persisted before force exit. store=${JSON.stringify(
-          storeRecords
-        )} disk=${JSON.stringify(
-          readPersistedData(session.userDataDir).workspaceSession?.sleepingAgentSessionsByPaneKey
-        )}`
-      )
-    }
-
-    const daemonPid = readDaemonPid(session.userDataDir)
-    await forceKillElectronApp(firstApp)
-    firstApp = null
-    killPid(daemonPid)
-    stripPersistedPtyOwnership(session.userDataDir)
-
-    const secondLaunch = await session.launch()
-    secondApp = secondLaunch.app
-    await waitForSessionReady(secondLaunch.page)
-    await expect
-      .poll(
-        async () => secondLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId),
-        { timeout: 15_000 }
-      )
-      .toBe(worktreeId)
-    await ensureTerminalVisible(secondLaunch.page)
-    await waitForActiveTerminalManager(secondLaunch.page, 30_000)
-
-    await waitForTerminalOutput(secondLaunch.page, PROVIDER_SESSION_ID, 30_000)
-
-    const terminalTabCount = await secondLaunch.page.evaluate(
-      (wtId) => (window.__store?.getState().tabsByWorktree[wtId] ?? []).length,
-      worktreeId
-    )
-    expect(terminalTabCount).toBe(2)
-  } finally {
-    if (secondApp) {
-      await session.close(secondApp)
-    }
-    if (firstApp) {
+      const daemonPid = readDaemonPid(session.userDataDir)
       await forceKillElectronApp(firstApp)
+      firstApp = null
+      killPid(daemonPid)
+      stripPersistedPtyOwnership(session.userDataDir)
+
+      const secondLaunch = await session.launch()
+      secondApp = secondLaunch.app
+      await waitForSessionReady(secondLaunch.page)
+      await expect
+        .poll(
+          async () => secondLaunch.page.evaluate(() => window.__store?.getState().activeWorktreeId),
+          { timeout: 15_000 }
+        )
+        .toBe(worktreeId)
+      await ensureTerminalVisible(secondLaunch.page)
+      await waitForActiveTerminalManager(secondLaunch.page, 30_000)
+
+      await waitForTerminalOutput(secondLaunch.page, PROVIDER_SESSION_ID, 30_000)
+
+      const terminalTabCount = await secondLaunch.page.evaluate(
+        (wtId) => (window.__store?.getState().tabsByWorktree[wtId] ?? []).length,
+        worktreeId
+      )
+      expect(terminalTabCount).toBe(2)
+    } finally {
+      if (secondApp) {
+        await session.close(secondApp)
+      }
+      if (firstApp) {
+        await forceKillElectronApp(firstApp)
+      }
+      await session.dispose()
     }
-    await session.dispose()
-  }
-})
+  })
+}


### PR DESCRIPTION
Cursor tabs currently lose automatic conversation recovery after the terminal process is gone because Cursor is excluded from the resumable-agent list and its hook conversation ID is discarded.

Capture Cursor's stable `conversation_id`, persist it through the existing recovery path, and resume with `cursor-agent --resume <id>`. Use the same identity for session history and advertise a Cursor-specific runtime capability so older remote hosts keep the existing fallback. Completed conversations retain their recovery checkpoint.

Validation: 86 focused tests passed; Node, CLI, and web type checks passed; formatting and changed-file lint passed. The Electron force-exit/restart suite passed for both Cursor and the existing Codex case. These cases verify persistence and resume dispatch with a deterministic replacement command. A separate disposable real Cursor conversation resumed through the compiled command and retained its previous context across CLI processes. Local EZ-Verify push-tier verification passed.
