### PR TITLE
test(e2e): stabilize terminal launch and rename menu fixtures

### DIFF
--- a/tests/e2e/live-background-terminal-mount-authority.spec.ts
+++ b/tests/e2e/live-background-terminal-mount-authority.spec.ts
@@ -23,6 +23,10 @@ import type {
 } from '../../src/shared/runtime-types'
 import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
 import { makePaneKey } from '../../src/shared/stable-pane-id'
+import {
+  buildFakeAgentCommandOverride,
+  FAKE_AGENT_WINDOWS_SHELL
+} from './helpers/fake-agent-command-override'
 
 type SpawnEvent = { args: string[]; pid: number }
 type TerminalIdentity = Pick<
@@ -69,6 +73,10 @@ if (process.platform === 'win32') {
   writeFileSync(executable, `#!/usr/bin/env node\n${fakeCodexSource}`)
   chmodSync(executable, 0o755)
 }
+
+const fakeCodexCommand = buildFakeAgentCommandOverride(
+  path.join(fakeCliDir, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+)
 
 const test = base.extend({
   launchEnv: [
@@ -535,23 +543,28 @@ test('adopts runtime-owned agent and Setup PTYs on first mount', async ({
   const repoId = added.result.repo.id
   await expect
     .poll(() =>
-      orcaPage.evaluate(async (repoId) => {
-        const state = window.__store?.getState()
-        await state?.fetchRepos()
-        const repo = window.__store?.getState().repos.find((candidate) => candidate.id === repoId)
-        if (!repo) {
-          return false
-        }
-        await window.__store?.getState().updateRepo(repoId, {
-          hookSettings: { ...repo.hookSettings, setupAgentStartupPolicy: 'start-immediately' }
-        })
-        await window.__store?.getState().updateSettings({
-          disabledTuiAgents: [],
-          setupScriptLaunchMode: 'new-tab',
-          terminalHiddenViewParking: false
-        })
-        return true
-      }, repoId)
+      orcaPage.evaluate(
+        async ({ repoId, command, windowsShell }) => {
+          const state = window.__store?.getState()
+          await state?.fetchRepos()
+          const repo = window.__store?.getState().repos.find((candidate) => candidate.id === repoId)
+          if (!repo) {
+            return false
+          }
+          await window.__store?.getState().updateRepo(repoId, {
+            hookSettings: { ...repo.hookSettings, setupAgentStartupPolicy: 'start-immediately' }
+          })
+          await window.__store?.getState().updateSettings({
+            agentCmdOverrides: { codex: command },
+            terminalWindowsShell: windowsShell,
+            disabledTuiAgents: [],
+            setupScriptLaunchMode: 'new-tab',
+            terminalHiddenViewParking: false
+          })
+          return true
+        },
+        { repoId, command: fakeCodexCommand, windowsShell: FAKE_AGENT_WINDOWS_SHELL }
+      )
     )
     .toBe(true)
 

--- a/tests/e2e/tab-rename.spec.ts
+++ b/tests/e2e/tab-rename.spec.ts
@@ -126,7 +126,7 @@ test.describe('Tab Rename (Inline)', () => {
     expect(originalTitle.length).toBeGreaterThan(0)
 
     await tabLocatorByTitle(orcaPage, originalTitle).click({ button: 'right' })
-    await orcaPage.getByRole('menuitem', { name: 'Change Title', exact: true }).click()
+    await orcaPage.getByRole('menuitem', { name: /^Change Title(?:\s|$)/ }).click()
 
     const renameInput = orcaPage.getByRole('textbox', {
       name: `Rename tab ${originalTitle}`,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The background first-mount test relied on PATH to choose its fake Codex command; shell startup could select another executable, leaving its spawn ledger empty. Reuse the existing explicit fake-agent command override and Windows shell fixture before creating the background workspace.

The inline rename test matched exactly “Change Title,” but the menu item's accessible name now includes its platform shortcut. Match the label plus its optional shortcut suffix.

Validation: both original failures reproduced on Electron. Both corrected cases passed twice, retaining the PTY identity, adoption, signal, focus, and title assertions. Format and lint pass without raising or disabling the file line limit. Native Windows/Linux were not run locally.
