### PR TITLE
perf(watcher): skip remaining filesystem checks after cancellation

### DIFF
--- a/src/main/ipc/filesystem-watcher-local-events.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-events.test.ts
@@ -12,6 +12,7 @@ vi.mock('fs/promises', () => ({ stat: statMock }))
 vi.mock('./parcel-watcher-process', () => ({ subscribeViaWatcherProcess: subscribeMock }))
 
 import { createLocalWatcher } from './filesystem-watcher-local-events'
+import { cancelLocalBatchFlush } from './filesystem-watcher-batch-control'
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void
@@ -168,6 +169,35 @@ describe('local filesystem watcher flush serialization', () => {
         isDirectory: path.endsWith('-0.ts')
       }))
     )
+  })
+
+  it('starts no further stats when a full inflight batch is cancelled', async () => {
+    const eventCount = 5_000
+    const pendingStats = deferred<{ isDirectory: () => boolean }>()
+    statMock.mockReturnValue(pendingStats.promise)
+    const root = await createLocalWatcher('/repo', '/repo')
+    root.listeners.set(1, sender as never)
+
+    watcherCallback?.(
+      null,
+      Array.from({ length: eventCount }, (_, index) => ({
+        type: 'update' as const,
+        path: `/repo/file-${index}.ts`
+      }))
+    )
+    vi.advanceTimersByTime(WATCH_BATCH_TRAILING_MS)
+    await flushMicrotasks()
+    expect(statMock).toHaveBeenCalledTimes(8)
+
+    cancelLocalBatchFlush(root)
+    pendingStats.resolve({ isDirectory: () => false })
+    for (let i = 0; i < eventCount * 4 && root.batch.flushInFlight; i++) {
+      await Promise.resolve()
+    }
+
+    expect(root.batch.flushInFlight).toBe(false)
+    expect(statMock).toHaveBeenCalledTimes(8)
+    expect(sender.send).not.toHaveBeenCalled()
   })
 
   it('leaves an open debounce window to the armed timer instead of draining early', async () => {

--- a/src/main/ipc/filesystem-watcher-local-events.ts
+++ b/src/main/ipc/filesystem-watcher-local-events.ts
@@ -139,7 +139,10 @@ async function flushBatch(root: WatchedRoot): Promise<void> {
       DIRECTORY_STAT_CONCURRENCY,
       async (evt) => {
         // Why: a deleted path can't be stat'd; leave isDirectory undefined and let the renderer infer from dirCache.
-        const isDirectory = evt.type === 'delete' ? undefined : await tryStatIsDirectory(evt.path)
+        const isDirectory =
+          root.batch.cancelled || evt.type === 'delete'
+            ? undefined
+            : await tryStatIsDirectory(evt.path)
 
         return {
           kind: evt.type,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Stopping a filesystem watcher already prevented its final event batch from reaching the UI, but the batch kept checking every remaining file first. A full batch could start thousands of useless filesystem operations after cancellation, competing with useful file reads and persistence work.

Check the watcher's existing permanent cancellation flag before each remaining `stat()` admission. The up-to-eight operations already in flight still settle; a live batch follows the same path and emits the same ordered payload.

## Measurements

Actual watcher flush/concurrency/cancellation code with delayed mock `stat()` promises. Start a 5,000-update batch, wait for the eight admitted operations, cancel the batch, then resolve those operations. This measures deterministic I/O admission counts, not native storage latency.

| Scenario | Before | After |
|---|---:|---:|
| Total stat calls in canceled batch | 5,000 | 8 |
| Stat calls started after cancellation | 4,992 | 0 |
| Canceled batch payloads | 0 | 0 |
| Live control: stat calls | 5,000 | 5,000 |
| Live control: ordered payloads | 1 | 1 |

## Reproduce and validation

Run `pnpm test src/main/ipc/filesystem-watcher-local-events.test.ts`. The new full-batch cancellation regression fails with 5,000 calls against original `filesystem-watcher-local-events.ts` from `d8c4c830639bf3d603c9250a536e0323ca0a7a19`; it passes with exactly eight calls after this change.

69 watcher tests pass across event batching, local events, unsubscribe, removal deadlines, and large-batch controls. `pnpm tc:node`, targeted lint, formatting, and diff checks pass.

Only the permanent batch cancellation flag gates work. A transient empty listener set does not cancel admitted work, and watcher restoration creates a new batch. Existing delete-event handling, overflow behavior, debounce windows, and emission ordering remain unchanged. This is the local execution-host watcher path; no remote-host routing, wire protocol, or folder/worktree distinction changes.

Visual proof: N/A — canceled batches already emitted no UI events, and live payloads remain unchanged. No app windows launched.

## Negative user-facing trade-offs

None identified. Live watchers retain every metadata check and event. Already-running filesystem operations are allowed to finish, with no new timeout, sampling, stale cache, cancellation of remote processes, or shortened event stream.
