### PR TITLE
fix: keep macOS shell ownership proof within recovery budget

### DIFF
--- a/src/main/providers/agent-foreground-process.test.ts
+++ b/src/main/providers/agent-foreground-process.test.ts
@@ -221,13 +221,13 @@ describe('resolveAgentForegroundProcess', () => {
   })
 
   it('confirms a quoted login shell only when its fresh PTY tree contains shells', async () => {
-    mockPs(['100 99 Ss+  "/bin/zsh" -l', '101 100 S+   /bin/bash'].join('\n'))
+    mockPs(['100 99 100 100 Ss+ "/bin/zsh" -l', '101 100 101 100 S+ /bin/bash'].join('\n'))
 
     await expect(confirmShellForegroundProcess(100, 'zsh')).resolves.toBe(true)
   })
 
   it('uses spawned-shell identity instead of a lagging foreground child label', async () => {
-    mockPs(['100 99 Ss+  /bin/zsh -l'].join('\n'))
+    mockPs(['100 99 100 100 Ss+ /bin/zsh -l'].join('\n'))
 
     await expect(confirmShellForegroundProcess(100, '/bin/zsh')).resolves.toBe(true)
   })
@@ -235,11 +235,11 @@ describe('resolveAgentForegroundProcess', () => {
   it('confirms the spawned shell behind a login wrapper while prompt hooks run', async () => {
     mockPs(
       [
-        '100 99 Ss   /usr/bin/login -pfl developer /bin/zsh',
-        '101 100 S+   -zsh',
-        '102 101 S+   (zsh)',
-        '103 102 S+   (sed)',
-        '104 102 R+   (git)'
+        '100 99 100 101 Ss /usr/bin/login -pfl developer /bin/zsh',
+        '101 100 101 101 S+ -zsh',
+        '102 101 101 101 S+ (zsh)',
+        '103 102 101 101 S+ (sed)',
+        '104 102 101 101 R+ (git)'
       ].join('\n')
     )
 
@@ -249,10 +249,10 @@ describe('resolveAgentForegroundProcess', () => {
   it('rejects a foreground nested shell while the spawned shell remains suspended', async () => {
     mockPs(
       [
-        '100 99 Ss   /usr/bin/login -pfl developer /bin/zsh',
-        '101 100 S    -zsh',
-        '102 101 S+   agent-tui',
-        '103 102 S+   /bin/zsh -i'
+        '100 99 100 102 Ss /usr/bin/login -pfl developer /bin/zsh',
+        '101 100 101 102 S -zsh',
+        '102 101 102 102 S+ agent-tui',
+        '103 102 102 102 S+ /bin/zsh -i'
       ].join('\n')
     )
 
@@ -262,9 +262,9 @@ describe('resolveAgentForegroundProcess', () => {
   it('rejects shell ownership while a TUI and its nested shell remain in the PTY tree', async () => {
     mockPs(
       [
-        '100 99 Ss   /bin/zsh -l',
-        '101 100 S+   /usr/local/bin/agent-tui',
-        '102 101 S+   /bin/bash -i'
+        '100 99 100 101 Ss /bin/zsh -l',
+        '101 100 101 101 S+ /usr/local/bin/agent-tui',
+        '102 101 101 101 S+ /bin/bash -i'
       ].join('\n')
     )
 
@@ -272,7 +272,7 @@ describe('resolveAgentForegroundProcess', () => {
   })
 
   it('rejects shell ownership while a stopped TUI remains resumable', async () => {
-    mockPs(['100 99 Ss+  /bin/zsh -l', '101 100 T    /usr/local/bin/agent-tui'].join('\n'))
+    mockPs(['100 99 100 100 Ss+ /bin/zsh -l', '101 100 101 100 T agent-tui'].join('\n'))
 
     await expect(confirmShellForegroundProcess(100, 'zsh')).resolves.toBe(false)
   })

--- a/src/main/providers/agent-foreground-process.ts
+++ b/src/main/providers/agent-foreground-process.ts
@@ -3,6 +3,7 @@ import { resolveOuterWrapperForegroundProcess } from '../../shared/foreground-wr
 import type { ProcessTableRow } from '../../shared/process-table-snapshot'
 import {
   getFreshProcessTableSnapshot,
+  getFreshShellForegroundSnapshot,
   getProcessTableSnapshot
 } from '../../shared/process-table-snapshot-reader'
 import { collectDescendantsFromIndex, getProcessTableIndex } from '../../shared/process-table-index'
@@ -76,7 +77,7 @@ export async function confirmShellForegroundProcess(
     }
   }
   try {
-    const index = getProcessTableIndex(await getFreshProcessTableSnapshot())
+    const index = getProcessTableIndex(await getFreshShellForegroundSnapshot())
     const root = index.byPid.get(shellPid)
     if (!root) {
       return false

--- a/src/shared/process-table-snapshot-reader.ts
+++ b/src/shared/process-table-snapshot-reader.ts
@@ -6,7 +6,9 @@ import {
   PS_ARGS,
   PS_MAX_BUFFER_BYTES,
   ProcessTableCaptureError,
+  SHELL_FOREGROUND_PS_ARGS,
   parseProcessTableRows,
+  parseShellForegroundRows,
   parseStrictProcessTableRows,
   type ProcessTableRow
 } from './process-table-snapshot'
@@ -278,12 +280,10 @@ const processTableReader = createProcessTableSnapshotReader<ProcessTableCapture>
   now: () => Date.now()
 })
 
-// macOS terminal-name resolution dominates capture time; shell proof needs only job control and argv.
+// Its own reader, not a column-set flag on the shared one: terminal-name resolution dominates
+// macOS capture time, and a shell proof must not queue behind a full capture it cannot use.
 const shellForegroundReader = createProcessTableSnapshotReader<ProcessTableRow[]>({
-  runPs: async () =>
-    parseProcessTableRows(
-      await captureProcessTable(['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,command='])
-    ),
+  runPs: async () => parseShellForegroundRows(await captureProcessTable(SHELL_FOREGROUND_PS_ARGS)),
   now: () => Date.now()
 })
 

--- a/src/shared/process-table-snapshot-reader.ts
+++ b/src/shared/process-table-snapshot-reader.ts
@@ -250,28 +250,48 @@ async function readLinuxProcessStartTimes(
   return result
 }
 
+async function captureProcessTable(args: readonly string[]): Promise<string> {
+  let stdout: string
+  try {
+    ;({ stdout } = await execFile('ps', [...args], {
+      encoding: 'utf-8',
+      timeout: PS_TIMEOUT_MS,
+      maxBuffer: PS_MAX_BUFFER_BYTES
+    }))
+  } catch (error) {
+    // A ceiling hit is truncation, not absence: name it in the domain vocabulary.
+    if ((error as { code?: unknown } | null)?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
+      throw new ProcessTableCaptureError('capture_truncated')
+    }
+    throw error
+  }
+  return assertWholeCapture(stdout)
+}
+
 const processTableReader = createProcessTableSnapshotReader<ProcessTableCapture>({
   runPs: async () => {
-    let stdout: string
-    try {
-      ;({ stdout } = await execFile('ps', [...PS_ARGS], {
-        encoding: 'utf-8',
-        timeout: PS_TIMEOUT_MS,
-        maxBuffer: PS_MAX_BUFFER_BYTES
-      }))
-    } catch (error) {
-      // A ceiling hit is truncation, not absence: name it in the domain vocabulary.
-      if ((error as { code?: unknown } | null)?.code === 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER') {
-        throw new ProcessTableCaptureError('capture_truncated')
-      }
-      throw error
-    }
-    const baseCapture = createProcessTableCapture(assertWholeCapture(stdout))
+    const stdout = await captureProcessTable(PS_ARGS)
+    const baseCapture = createProcessTableCapture(stdout)
     const startTimesByPid = await readLinuxProcessStartTimes(baseCapture.lenient())
     return createProcessTableCapture(stdout, startTimesByPid, process.platform === 'linux')
   },
   now: () => Date.now()
 })
+
+// macOS terminal-name resolution dominates capture time; shell proof needs only job control and argv.
+const shellForegroundReader = createProcessTableSnapshotReader<ProcessTableRow[]>({
+  runPs: async () =>
+    parseProcessTableRows(
+      await captureProcessTable(['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,command='])
+    ),
+  now: () => Date.now()
+})
+
+export async function getFreshShellForegroundSnapshot(): Promise<ProcessTableRow[]> {
+  return process.platform === 'darwin'
+    ? shellForegroundReader.getFreshSnapshot()
+    : getFreshProcessTableSnapshot()
+}
 
 export async function getProcessTableSnapshot(): Promise<ProcessTableRow[]> {
   return (await processTableReader.getSnapshot()).lenient()
@@ -334,4 +354,5 @@ export async function getStrictProcessTableSnapshotWithAge(): Promise<{
 
 export function resetProcessTableSnapshotForTests(): void {
   processTableReader.reset()
+  shellForegroundReader.reset()
 }

--- a/src/shared/process-table-snapshot.ts
+++ b/src/shared/process-table-snapshot.ts
@@ -38,6 +38,47 @@ export const CHEAP_PS_ARGS = (
     : ['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=']
 ) as readonly string[]
 
+/**
+ * Shell-proof tier: job control plus argv, dropping only the columns the shell predicate never
+ * reads — macOS `tty=` (0.29s of the 0.34s on a 1,900-process Mac) and the start marker. Enough
+ * to name a pane's foreground process; never enough to correlate a pid across captures.
+ */
+export const SHELL_FOREGROUND_PS_ARGS = [
+  '-axo',
+  'pid=,ppid=,pgid=,tpgid=,stat=,command='
+] as readonly string[]
+
+/**
+ * Parse a {@link SHELL_FOREGROUND_PS_ARGS} capture, anchored to exactly those columns.
+ * Not {@link parseProcessTableRows}: with no `tty=` to absorb it, that parser's optional
+ * tty/start pair eats the head of an argv shaped `python 3 app.py`, and a command-less zombie
+ * row parses into a garbage pid/stat pair.
+ *
+ * Lenient per row like its siblings, but a capture yielding none is unreadable rather than a
+ * machine with no processes: the shell proof must not read that as "the shell is gone".
+ */
+export function parseShellForegroundRows(stdout: string): ProcessTableRow[] {
+  const rows: ProcessTableRow[] = []
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const match = rawLine.trim().match(/^(\d+)\s+(\d+)\s+(-?\d+)\s+(-?\d+)\s+(\S+)\s+(.+)$/)
+    const pid = match ? Number(match[1]) : 0
+    if (match && Number.isSafeInteger(pid) && pid > 0) {
+      rows.push({
+        pid,
+        ppid: Number(match[2]),
+        pgid: Number(match[3]),
+        tpgid: Number(match[4]),
+        stat: match[5],
+        command: match[6]
+      })
+    }
+  }
+  if (rows.length === 0) {
+    throw new ProcessTableCaptureError('empty_capture')
+  }
+  return rows
+}
+
 export type CheapProcessTableRow = {
   pid: number
   ppid: number

--- a/src/shared/shell-foreground-snapshot.test.ts
+++ b/src/shared/shell-foreground-snapshot.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+
+import {
+  getFreshShellForegroundSnapshot,
+  getProcessTableSnapshot,
+  resetProcessTableSnapshotForTests
+} from './process-table-snapshot-reader'
+
+type Callback = (error: Error | null, result: { stdout: string; stderr: string }) => void
+const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
+const shell = '100 99 100 100 Ss+ /bin/zsh -l'
+
+beforeEach(() => {
+  Object.defineProperty(process, 'platform', { value: 'darwin' })
+  execFileMock.mockReset()
+  resetProcessTableSnapshotForTests()
+})
+afterEach(() => Object.defineProperty(process, 'platform', platform))
+
+it('answers concurrent shell proofs without waiting for a pending full capture', async () => {
+  let finishFull!: Callback
+  execFileMock.mockImplementation((_program, args: string[], _options, callback: Callback) => {
+    if (args[1]?.includes('tty=')) {
+      finishFull = callback
+    } else {
+      expect(args).toEqual(['-axo', 'pid=,ppid=,pgid=,tpgid=,stat=,command='])
+      callback(null, { stdout: shell, stderr: '' })
+    }
+  })
+  const full = getProcessTableSnapshot()
+  const [first, second] = await Promise.all([
+    getFreshShellForegroundSnapshot(),
+    getFreshShellForegroundSnapshot()
+  ])
+  expect(first).toEqual([
+    { pid: 100, ppid: 99, pgid: 100, tpgid: 100, stat: 'Ss+', command: '/bin/zsh -l' }
+  ])
+  expect(second).toBe(first)
+  expect(execFileMock).toHaveBeenCalledTimes(2)
+  finishFull(null, { stdout: shell, stderr: '' })
+  await full
+  await getFreshShellForegroundSnapshot()
+  expect(execFileMock).toHaveBeenCalledTimes(3)
+})
+
+it('requires a new capture after an earlier shell proof has started', async () => {
+  const callbacks: Callback[] = []
+  execFileMock.mockImplementation((_program, _args, _options, callback: Callback) => {
+    callbacks.push(callback)
+  })
+  const first = getFreshShellForegroundSnapshot()
+  await vi.waitFor(() => expect(callbacks).toHaveLength(1))
+  const second = getFreshShellForegroundSnapshot()
+  callbacks[0]!(null, { stdout: shell, stderr: '' })
+  await first
+  await vi.waitFor(() => expect(callbacks).toHaveLength(2))
+  callbacks[1]!(null, { stdout: shell.replace('Ss+', 'Ss'), stderr: '' })
+  expect((await second)[0]?.stat).toBe('Ss')
+})
+
+it('rejects an unreadable shell capture', async () => {
+  execFileMock.mockImplementation((_program, _args, _options, callback: Callback) => {
+    callback(null, { stdout: '', stderr: '' })
+  })
+  await expect(getFreshShellForegroundSnapshot()).rejects.toThrow('empty_capture')
+})

--- a/src/shared/shell-foreground-snapshot.test.ts
+++ b/src/shared/shell-foreground-snapshot.test.ts
@@ -8,6 +8,7 @@ import {
   getProcessTableSnapshot,
   resetProcessTableSnapshotForTests
 } from './process-table-snapshot-reader'
+import { parseShellForegroundRows } from './process-table-snapshot'
 
 type Callback = (error: Error | null, result: { stdout: string; stderr: string }) => void
 const platform = Object.getOwnPropertyDescriptor(process, 'platform')!
@@ -59,6 +60,13 @@ it('requires a new capture after an earlier shell proof has started', async () =
   await vi.waitFor(() => expect(callbacks).toHaveLength(2))
   callbacks[1]!(null, { stdout: shell.replace('Ss+', 'Ss'), stderr: '' })
   expect((await second)[0]?.stat).toBe('Ss')
+})
+
+// With no `tty=` column to absorb them, the shared parser read `python`/`3` as tty/start.
+it('keeps an argv whose second token is numeric', () => {
+  expect(parseShellForegroundRows('101 100 101 101 S+ /usr/bin/python 3 app.py')).toEqual([
+    { pid: 101, ppid: 100, pgid: 101, tpgid: 101, stat: 'S+', command: '/usr/bin/python 3 app.py' }
+  ])
 })
 
 it('rejects an unreadable shell capture', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 |

<!-- /orca-pr-loc -->

## ELI5

When a coding agent running inside a terminal tab dies suddenly, Orca has to repaint the tab so you get your normal shell prompt back instead of a frozen screenful of the dead agent's interface. Before it repaints, it double-checks with the operating system that the shell — and nothing else — is really in charge of that tab, and it only waits three-quarters of a second for that answer. On a busy Mac with a couple of thousand processes running, that check was asking the system for far more information than it needed, including the human-readable name of every terminal on the machine, which is the slow part; the answer came back after almost four seconds, long past the deadline. By then Orca had given up, so the tab stayed stuck showing the dead agent and you had to close it and open a new one. Now the check asks only for the handful of facts it actually uses, which took 0.1s instead of 2.8s on the same machine, so the answer arrives in time and the tab recovers on its own.

## Tradeoffs

Real costs of this change, not hypotheticals:

- **An extra `ps` on macOS.** The shell proof now runs its own capture instead of sharing the general-purpose one. A pane recovering while another subsystem is mid-scan forks a second whole-machine `ps` — more CPU on exactly the loaded host that can least afford it. This is deliberate: the sharing *was* the latency, because a proof had to wait out the in-flight full capture before starting its own.
- **Two same-moment questions now cost two captures.** The shell reader keeps its own TTL cache, so a shell proof and a foreground-name resolution asked at the same instant no longer collapse into one `ps`.
- **The macOS shell snapshot is narrower.** Its rows carry no `tty` and no start marker. Nothing in the shell predicate reads either today, but any future check that wants to confirm the controlling terminal or correlate a pid across captures cannot use this snapshot and must escalate to the full reader.
- **Only macOS gets the fix.** Linux and Windows are untouched by design, so a Linux host with a large process table still pays the full capture — including the per-pid `/proc` start-time reads — inside the same unchanged 750 ms barrier. The reported failure class is fixed on macOS only.
- **No behavior is removed.** The 750 ms deadline, the shell predicate, the generation guards, the queue bound, and the stopped-descendant refutation are all unchanged; this only makes the evidence cheaper to gather. There is no new bound that can give up early and mis-classify a live shell.

## Detail

When a child TUI exits on a busy macOS host, shell ownership confirmation can arrive after the 750 ms recovery deadline (`MAX_PENDING_MS` in `terminal-shell-recovery-barrier.ts`). The observed confirmation returned true after 3,922 ms, leaving the shell without ownership metadata and preventing recovery after cleanup-free SIGKILL.

Give macOS shell confirmation a separate coalesced fresh process reader that omits unused terminal names and start metadata. On the same ~2,400-process host, the full query took 2.8 s and the query without terminal names took 0.1 s. The shell predicate, generation guards, recovery deadline, queue bound, and Linux/Windows readers retain their existing behavior.

The narrower column set gets its own anchored parser (`parseShellForegroundRows`) rather than reusing the shared lenient one. Without a `tty=` column to absorb it, the shared parser's optional tty/start pair eats the head of an argv shaped `python 3 app.py` — and a command-less zombie row parses into a garbage pid/stat pair — either of which can flip a shell-ownership verdict.

Validation: 90 focused tests; 1,603 recovery/wire gate tests (3 existing skips); unchanged normal/SIGKILL Electron cases repeated twice, all 4 passed; node typecheck, lint, and formatting passed. A deterministic regression verifies that a pending full capture cannot block concurrent shell proofs, same-turn proofs share a scan, and later requests capture fresh evidence.

Reliability: `terminal-session.shell-owned-mode-recovery`. Only a fresh execution-host shell proof may authorize recovery; stopped descendants and foreground TUIs still refute it. The failure source is the unchanged hidden-child Electron journey. Evidence is shell snapshot ownership, normal/non-mouse renderer state, post-exit input, and unrelated-pane survival. Capture counts remain bounded and event-driven, with no new polling. Diagnostic timing and test logs are retained in `/tmp/orca-deflake-shell-*`.

Coverage: macOS daemon/Desktop Electron is exercised; local macOS uses the same classifier. Linux, Windows, WSL, and direct SSH behavior is unchanged — the new column set is produced only by the darwin-only reader, and relay/SSH captures continue to go through the full `PS_ARGS` path, so there is no wire or remote-host change. Paired macOS hosts use the same host reader but have no new live paired journey in this PR; existing wire contracts pass. Leave open for application review.
