### PR TITLE
fix: open editor rename after context menu releases focus

### DIFF
--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -402,6 +402,10 @@ describe('EditorFileTab rename menu', () => {
     // "untitled-N.md" files directly.
     expect(renameItem.props.disabled).toBe(false)
     ;(renameItem.props.onSelect as () => void)()
+    const content = findElementsByType(firstRender, 'DropdownMenuContent')[0]!
+    ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
+      preventDefault: vi.fn()
+    })
 
     const secondRender = expandNode((await renderEditorFileTab(file, onActivate)).element)
     const inputs = findElementsByType(secondRender, 'input')
@@ -428,6 +432,10 @@ describe('EditorFileTab rename menu', () => {
     const renameItem = findMenuItemByText(firstRender, 'Rename')
 
     ;(renameItem.props.onSelect as () => void)()
+    const content = findElementsByType(firstRender, 'DropdownMenuContent')[0]!
+    ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
+      preventDefault: vi.fn()
+    })
 
     const secondRender = expandNode((await renderEditorFileTab(file)).element)
     const input = findElementsByType(secondRender, 'input')[0]
@@ -460,6 +468,10 @@ describe('EditorFileTab rename menu', () => {
     const renameItem = findMenuItemByText(firstRender, 'Rename')
 
     ;(renameItem.props.onSelect as () => void)()
+    const content = findElementsByType(firstRender, 'DropdownMenuContent')[0]!
+    ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
+      preventDefault: vi.fn()
+    })
 
     const secondRender = expandNode((await renderEditorFileTab(file)).element)
     const input = findElementsByType(secondRender, 'input')[0]

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -345,6 +345,15 @@ function findMenuItemByText(node: unknown, label: string): ReactElementLike {
   return item
 }
 
+/** Picks Rename, then fires the close-autofocus that actually opens the input. */
+function selectRenameFromMenu(node: unknown): void {
+  ;(findMenuItemByText(node, 'Rename').props.onSelect as () => void)()
+  const content = findElementsByType(node, 'DropdownMenuContent')[0]!
+  ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
+    preventDefault: vi.fn()
+  })
+}
+
 function findSpanByText(node: unknown, label: string): ReactElementLike {
   const span = findElementsByType(node, 'span').find(
     (candidate) =>
@@ -401,11 +410,7 @@ describe('EditorFileTab rename menu', () => {
     // isUntitled; the tab menu must let users rename the screenshot-style
     // "untitled-N.md" files directly.
     expect(renameItem.props.disabled).toBe(false)
-    ;(renameItem.props.onSelect as () => void)()
-    const content = findElementsByType(firstRender, 'DropdownMenuContent')[0]!
-    ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
-      preventDefault: vi.fn()
-    })
+    selectRenameFromMenu(firstRender)
 
     const secondRender = expandNode((await renderEditorFileTab(file, onActivate)).element)
     const inputs = findElementsByType(secondRender, 'input')
@@ -429,13 +434,8 @@ describe('EditorFileTab rename menu', () => {
   it('ignores IME composition Enter before renaming the editor file tab', async () => {
     const file = baseFile()
     const firstRender = expandNode((await renderEditorFileTab(file)).element)
-    const renameItem = findMenuItemByText(firstRender, 'Rename')
 
-    ;(renameItem.props.onSelect as () => void)()
-    const content = findElementsByType(firstRender, 'DropdownMenuContent')[0]!
-    ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
-      preventDefault: vi.fn()
-    })
+    selectRenameFromMenu(firstRender)
 
     const secondRender = expandNode((await renderEditorFileTab(file)).element)
     const input = findElementsByType(secondRender, 'input')[0]
@@ -465,13 +465,8 @@ describe('EditorFileTab rename menu', () => {
   it('does not re-commit when unmounting the rename input emits multiple blur events', async () => {
     const file = baseFile()
     const firstRender = expandNode((await renderEditorFileTab(file)).element)
-    const renameItem = findMenuItemByText(firstRender, 'Rename')
 
-    ;(renameItem.props.onSelect as () => void)()
-    const content = findElementsByType(firstRender, 'DropdownMenuContent')[0]!
-    ;(content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void)({
-      preventDefault: vi.fn()
-    })
+    selectRenameFromMenu(firstRender)
 
     const secondRender = expandNode((await renderEditorFileTab(file)).element)
     const input = findElementsByType(secondRender, 'input')[0]

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -171,8 +171,8 @@ export default function EditorFileTab({
       if (!input) {
         return
       }
-      // Why: Radix closes the context menu after onSelect; defer focus so its
-      // teardown cannot steal focus back or blur-commit the newly mounted input.
+      // Why: the tab re-lays out around the input; focus on the next frame so
+      // that swap has settled before selecting text.
       renameFocusFrameRef.current = requestAnimationFrame(() => {
         renameFocusFrameRef.current = null
         if (renameInputRef.current !== input) {

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -202,7 +202,9 @@ function extractText(node: unknown): string {
   return el.props && 'children' in el.props ? extractText(el.props.children) : ''
 }
 
-async function renderMenu(): Promise<unknown> {
+async function renderMenu(
+  overrides: { onActivate?: () => void; onOpenRenameInput?: () => void } = {}
+): Promise<unknown> {
   const module = await import('./EditorFileTabContextMenu')
   return module.EditorFileTabContextMenu({
     open: true,
@@ -238,7 +240,8 @@ async function renderMenu(): Promise<unknown> {
     onCloseAll: vi.fn(),
     onCloseToRight: vi.fn(),
     onCloseToLeft: vi.fn(),
-    onOpenMarkdownPreview: vi.fn()
+    onOpenMarkdownPreview: vi.fn(),
+    ...overrides
   })
 }
 
@@ -264,6 +267,27 @@ describe('EditorFileTabContextMenu close-all shortcut', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('opens rename only after menu close releases focus and consumes the request once', async () => {
+    const onActivate = vi.fn()
+    const onOpenRenameInput = vi.fn()
+    const tree = expandNode(await renderMenu({ onActivate, onOpenRenameInput }))
+    const rename = findElementsByType(tree, 'DropdownMenuItem').find((item) =>
+      extractText(item.props.children).includes('Rename')
+    )!
+    const content = findElementsByType(tree, 'DropdownMenuContent')[0]!
+    ;(rename.props.onSelect as () => void)()
+    expect(onActivate).not.toHaveBeenCalled()
+    expect(onOpenRenameInput).not.toHaveBeenCalled()
+    const preventDefault = vi.fn()
+    const close = content.props.onCloseAutoFocus as (event: { preventDefault: () => void }) => void
+    close({ preventDefault })
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(onActivate).toHaveBeenCalledTimes(1)
+    expect(onOpenRenameInput).toHaveBeenCalledTimes(1)
+    close({ preventDefault })
+    expect(onOpenRenameInput).toHaveBeenCalledTimes(1)
   })
 
   it('renders assigned shortcuts next to Rename, Close, and Close All Editor Tabs', async () => {

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -126,7 +126,8 @@ export function EditorFileTabContextMenu({
           }
           skipMenuFocusRestoreRef.current = false
           event.preventDefault()
-          // The closing menu can still reclaim focus before its teardown completes.
+          // Why: opening the input in onSelect lets the still-closing menu reclaim
+          // focus, and the resulting blur commits the rename away before the user types.
           onActivate()
           onOpenRenameInput()
         }}

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.tsx
@@ -126,6 +126,9 @@ export function EditorFileTabContextMenu({
           }
           skipMenuFocusRestoreRef.current = false
           event.preventDefault()
+          // The closing menu can still reclaim focus before its teardown completes.
+          onActivate()
+          onOpenRenameInput()
         }}
       >
         <TabWorkspaceLayoutMenuSection
@@ -137,8 +140,6 @@ export function EditorFileTabContextMenu({
           disabled={!canRename || isRenaming}
           onSelect={() => {
             skipMenuFocusRestoreRef.current = true
-            onActivate()
-            onOpenRenameInput()
           }}
         >
           <Pencil className="size-3.5" />


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

Right-clicking a file tab and picking "Rename" is supposed to turn the tab's name into a little text box you can type a new filename into. But the menu you just clicked was still busy closing, and in that moment it grabbed the keyboard back for itself. The text box lost the keyboard the instant it appeared, took that as "the user is finished", and disappeared again — so nothing got renamed and it looked like the menu item did nothing. Now Orca waits for the menu to fully hand the keyboard over before it shows the text box. The box appears with the filename already selected and stays there until you press Enter or Escape.

## What Changed

Choosing Rename from an editor tab's context menu could focus the new input while the closing menu still owned focus. In the floating Markdown restart journey, the menu took focus back 4 ms later, blurring and removing the input before Enter could be pressed.

The Rename menu item now only raises the existing `skipMenuFocusRestoreRef` flag. `DropdownMenuContent`'s `onCloseAutoFocus` consumes that flag once, prevents the default focus restoration to the trigger, and only then activates the tab and opens the inline rename input. Keyboard (`tab.rename`) and double-click rename paths are unchanged.

## Why

`onCloseAutoFocus` is the event-driven signal that Radix's `FocusScope` has released focus — it is dispatched after the menu content unmounts. Ordering the rename behind it replaces a race with a guarantee, rather than papering over the race with a `setTimeout`/`requestAnimationFrame` delay.

## Linked Issue

N/A — no tracking issue; found while stabilizing the floating Markdown restart e2e journey.

## Visual Proof

N/A for this pass. Local Electron launches are paused for the agent working this PR, so no fresh before/after capture was taken here. The behavior is visual (the inline rename field surviving long enough to type into), so a short before/after video is the right proof and should be attached before merge if a reviewer wants one; the earlier validation run on this branch did capture a screenshot confirming the rename input remains present with the entered filename.

## Tradeoffs

Genuine user-facing costs of this change:

- **Slightly later appearance.** The rename field now mounts after the menu's close-autofocus dispatch (Radix defers that by one macrotask) plus the pre-existing focus frame — roughly one tick and one frame, under ~20 ms. Not perceptible in practice, but it is strictly later than before.
- **Tab activation moved too.** `onActivate()` also moved out of `onSelect`. The clicked tab now becomes the active tab when the menu finishes closing rather than the instant you click Rename. Same sub-frame magnitude, but it is an ordering change that other code can observe.
- **All-or-nothing on an interrupted close.** Previously, selecting Rename at least activated the tab even if the rename field then got blurred away. Now, if the menu's close-autofocus never runs (for example the tab unmounts mid-close), neither activation nor rename happens.
- **New dependency on a Radix callback.** Rename-from-menu now requires `onCloseAutoFocus` to fire. If a future Radix version or a new close path skips it, Rename degrades to a silent no-op instead of a partly-working rename.
- **The flag now carries an action, not just a suppression.** `skipMenuFocusRestoreRef` used to only suppress focus restoration, so a stale `true` was harmless. It now also queues a rename, meaning a stale flag could open a rename on the next menu close. Mitigated by consuming it before invoking the callbacks and covered by a test, but the blast radius of the flag grew.
- **Sibling path not fixed.** The editor panel header's path context menu (`EditorPanelHeaderPath.tsx`) still opens its rename input inside `onSelect` and has the same shape. This PR deliberately does not touch it, so that surface keeps whatever residual flakiness it has.

## Testing

- [x] Automated tests added/updated
- [ ] Manually tested locally (Electron launches paused for this pass)

Unit: `EditorFileTabContextMenu.test.tsx` asserts Rename's `onSelect` calls neither `onActivate` nor `onOpenRenameInput`, that `onCloseAutoFocus` prevents default and invokes both exactly once, and that a second close is a no-op. `EditorFileTab.test.tsx` drives the full menu → close → input path for the commit, blur, and IME cases.

e2e: `tests/e2e/floating-tab-rename.spec.ts` already right-clicks an editor file tab, clicks Rename, and asserts the rename textbox is present and that Enter commits exactly once — that spec is the one this race was breaking.

Prior validation on this branch: a deterministic focus-handoff regression failed before the fix; 9 focused menu/file-tab tests pass; all 4 unchanged floating-tab Electron cases passed twice, covering Enter, blur, collisions, Unicode aliases, and restart persistence.

Local run notes: `pnpm tc`, `oxlint`, `oxfmt --check`, and `pnpm run check:code-quality:changed` (0 new findings) all pass. `pnpm test src/renderer/src/components/tab-bar/` shows 6 failures on this machine, but the identical 6 fail with every change in this PR reverted to the base commit, so they are pre-existing and unrelated; CI is green.

## Notes

Renderer-only focus lifecycle change. No filesystem, provider, IPC, or remote-wire behavior changes, so SSH and remote workspaces are unaffected beyond the shared renderer fix. Applies equally to git worktrees, folder workspaces, floating windows, and remote workspaces. No platform-conditional code is involved; rendered evidence so far is macOS-only, so Linux and Windows remain unverified by hand.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after video attached for the UI change (see Visual Proof)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Typecheck, lint, and targeted tests pass locally; full CI green
