### PR TITLE
test: pin terminal Codex home to an explicit managed account

### DIFF
--- a/tests/e2e/terminal-codex-home.spec.ts
+++ b/tests/e2e/terminal-codex-home.spec.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import {
   execInTerminal,
@@ -27,7 +29,42 @@ test.describe('Terminal Codex runtime home', () => {
     await ensureTerminalVisible(orcaPage)
   })
 
-  test('terminal process receives the Orca-managed Codex home', async ({ orcaPage }) => {
+  test('terminal process receives the selected account Codex home', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const userData = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+    const accountId = 'e2e-terminal-home'
+    const managedHomePath = path.join(userData, 'codex-accounts', accountId, 'home')
+    mkdirSync(managedHomePath, { recursive: true })
+    writeFileSync(path.join(managedHomePath, '.orca-managed-home'), `${accountId}\n`)
+    writeFileSync(
+      path.join(managedHomePath, 'auth.json'),
+      JSON.stringify({ OPENAI_API_KEY: 'e2e-placeholder' })
+    )
+    await orcaPage.evaluate(
+      async ({ accountId, managedHomePath }) => {
+        const state = window.__store!.getState()
+        await state.updateSettings({
+          codexManagedAccounts: [
+            {
+              id: accountId,
+              email: 'terminal-home@example.invalid',
+              managedHomePath,
+              createdAt: 1,
+              updatedAt: 1,
+              lastAuthenticatedAt: 1
+            }
+          ],
+          activeCodexManagedAccountId: accountId,
+          activeCodexManagedAccountIdsByRuntime: { host: accountId, wsl: {} }
+        })
+        const tab = state.createTab(state.activeWorktreeId!)
+        state.setActiveTab(tab.id)
+        state.setActiveTabType('terminal')
+      },
+      { accountId, managedHomePath }
+    )
     await waitForActiveTerminalManager(orcaPage)
     const ptyId = await waitForActivePanePtyId(orcaPage)
     const marker = `__ORCA_CODEX_HOME_E2E_${Date.now()}__`
@@ -43,17 +80,10 @@ test.describe('Terminal Codex runtime home', () => {
       .poll(
         async () => {
           probe = readCodexHomeProbe(await getTerminalContent(orcaPage), marker)
-          return Boolean(
-            probe?.codexHome &&
-            probe.orcaCodexHome &&
-            probe.codexHome === probe.orcaCodexHome &&
-            /[\\/]codex-runtime-home[\\/]home$/.test(probe.codexHome)
-          )
+          return probe
         },
-        { timeout: 15_000, message: 'Terminal did not expose Orca-managed Codex home env' }
+        { timeout: 15_000, message: 'Terminal did not expose the selected Codex account home' }
       )
-      .toBe(true)
-
-    expect(probe?.codexHome).toBe(probe?.orcaCodexHome)
+      .toEqual({ codexHome: managedHomePath, orcaCodexHome: managedHomePath })
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The terminal Codex-home test expected the retired shared `codex-runtime-home/home` route without selecting an account. Current system-default launches can use the real home, while managed accounts use their own homes.

Seed an explicit managed account inside the isolated Electron profile, select it, and launch a fresh terminal. Require both CODEX_HOME and ORCA_CODEX_HOME to equal that exact account directory. This preserves the environment-propagation oracle without depending on the developer's account selection or CLI availability.

Validation: the previous test failed with both variables absent; the corrected test passed twice. Lint and formatting pass. Test-only change.
