### PR TITLE
perf(hooks): use native reverse search for transcript lines

### DIFF
--- a/config/scripts/benchmark-transcript-reverse-lines.mjs
+++ b/config/scripts/benchmark-transcript-reverse-lines.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import Module from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+
+const entry = 'src/shared/agent-hook-listener/transcript-reader.ts'
+assert.ok(process.argv[2], 'Pass a pre-change transcript-reader.ts snapshot.')
+const baseline = readFileSync(process.argv[2], 'utf8')
+assert.notEqual(baseline, readFileSync(entry, 'utf8'), 'Do not compare the source to itself.')
+
+async function load(useBaseline) {
+  const result = await build({
+    stdin: {
+      contents: `export * from './${entry}';
+export { extractAssistantTextFromLine } from './src/shared/agent-hook-listener/transcript-entry-text.ts';`,
+      resolveDir: process.cwd(),
+      loader: 'ts'
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    write: false,
+    logLevel: 'silent',
+    plugins: useBaseline
+      ? [
+          {
+            name: 'baseline-transcript-reader',
+            setup(builder) {
+              builder.onLoad({ filter: /transcript-reader\.ts$/ }, () => ({
+                contents: baseline,
+                loader: 'ts'
+              }))
+            }
+          }
+        ]
+      : []
+  })
+  const module = new Module(resolve('transcript-benchmark.cjs'))
+  module.paths = Module._nodeModulePaths(process.cwd())
+  module._compile(result.outputFiles[0].text, module.id)
+  return module.exports
+}
+
+const versions = [await load(true), await load(false)]
+function measure(functions, iterations) {
+  let sink = 0
+  const run = (fn) => {
+    for (let i = 0; i < iterations; i++) {
+      sink += fn()?.length ?? 0
+    }
+  }
+  for (const fn of functions) {
+    for (let i = 0; i < 3; i++) {
+      run(fn)
+    }
+  }
+  const samples = [[], []]
+  for (let round = 0; round < 11; round++) {
+    for (const index of round % 2 ? [1, 0] : [0, 1]) {
+      const start = performance.now()
+      run(functions[index])
+      samples[index].push((performance.now() - start) / iterations)
+    }
+  }
+  return {
+    beforeMs: samples[0].sort((a, b) => a - b)[5],
+    afterMs: samples[1].sort((a, b) => a - b)[5],
+    iterations,
+    sink
+  }
+}
+
+const cases = [
+  ['tiny', `${JSON.stringify({ role: 'assistant', content: 'hello' })}\n`, 10000],
+  ['64KiB line', `${JSON.stringify({ role: 'assistant', content: 'x'.repeat(65500) })}\n`, 100],
+  [
+    '4MiB line',
+    `${JSON.stringify({ role: 'assistant', content: 'x'.repeat(4 * 1024 * 1024 - 40) })}\n`,
+    10
+  ],
+  [
+    '1000 short tool lines',
+    Array.from({ length: 1000 }, () =>
+      JSON.stringify({ role: 'tool', content: 'x'.repeat(100) })
+    ).join('\n'),
+    50
+  ],
+  [
+    'Unicode line',
+    `${JSON.stringify({ role: 'assistant', content: '😀漢字'.repeat(16000) })}\n`,
+    100
+  ],
+  [
+    'leading and trailing blank lines',
+    `\n\r\n${JSON.stringify({ role: 'assistant', content: 'hello' })}\n\n`,
+    10000
+  ]
+]
+const directory = mkdtempSync(join(tmpdir(), 'orca-transcript-benchmark-'))
+try {
+  for (const [name, text, iterations] of cases) {
+    const file = join(directory, 'transcript.jsonl')
+    writeFileSync(file, text)
+    const scanners = versions.map(
+      (v) => () => v.findLastExtractedTranscriptLineText(text, v.extractAssistantTextFromLine)
+    )
+    const readers = versions.map((v) => () => v.readLastAssistantFromTranscriptOnce(file))
+    assert.equal(scanners[0](), scanners[1](), name)
+    assert.equal(readers[0](), readers[1](), name)
+    console.log(
+      JSON.stringify({
+        name,
+        bytes: Buffer.byteLength(text),
+        scanner: measure(scanners, iterations),
+        warmFileReader: measure(readers, Math.min(iterations, 100))
+      })
+    )
+  }
+} finally {
+  rmSync(directory, { recursive: true, force: true })
+}

--- a/src/shared/agent-hook-listener/transcript-reader.test.ts
+++ b/src/shared/agent-hook-listener/transcript-reader.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { findLastExtractedTranscriptLineText } from './transcript-reader'
+import { extractAssistantTextFromLine } from './transcript-entry-text'
+
+function expectedLines(text: string): string[] {
+  return text
+    .split('\n')
+    .toReversed()
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}
+
+describe('backward transcript line extraction', () => {
+  it.each(['', '\n', '\n\n', '\r\n', ' \t\r\n', '\na\n', 'a\nb', '😀\r\n漢字'])(
+    'visits each nonblank line once in reverse order for %j',
+    (text) => {
+      const seen: string[] = []
+      expect(
+        findLastExtractedTranscriptLineText(text, (line) => {
+          seen.push(line)
+          return undefined
+        })
+      ).toBeUndefined()
+      expect(seen).toEqual(expectedLines(text))
+    }
+  )
+
+  it('preserves line order and early return across generated delimiters', () => {
+    let seed = 29
+    const fragments = ['a', '\n', '\r\n', ' ', '\t', '😀', '\u2028', '\0']
+    for (let sample = 0; sample < 1000; sample++) {
+      let text = ''
+      for (let i = 0; i < sample % 100; i++) {
+        seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+        text += fragments[seed % fragments.length]
+      }
+      const lines = expectedLines(text)
+      const stop = sample % (lines.length + 1)
+      const seen: string[] = []
+      const result = findLastExtractedTranscriptLineText(text, (line) => {
+        seen.push(line)
+        return seen.length === stop + 1 ? line : undefined
+      })
+      expect(seen).toEqual(lines.slice(0, stop + 1))
+      expect(result).toBe(lines[stop])
+    }
+  })
+
+  it('returns the newest assistant message behind a long tool line', () => {
+    const message = JSON.stringify({ role: 'assistant', content: 'latest 😀' })
+    const tool = JSON.stringify({ role: 'tool', content: 'x'.repeat(256 * 1024) })
+    expect(
+      findLastExtractedTranscriptLineText(
+        `\n{"role":"assistant","content":"older"}\r\n${message}\r\n${tool}\n`,
+        extractAssistantTextFromLine
+      )
+    ).toBe('latest 😀')
+  })
+
+  it('treats an empty extracted string as a result and stops before older lines', () => {
+    const seen: string[] = []
+    expect(
+      findLastExtractedTranscriptLineText('older\nlatest\n', (line) => {
+        seen.push(line)
+        return ''
+      })
+    ).toBe('')
+    expect(seen).toEqual(['latest'])
+  })
+})

--- a/src/shared/agent-hook-listener/transcript-reader.ts
+++ b/src/shared/agent-hook-listener/transcript-reader.ts
@@ -88,10 +88,8 @@ export function findLastExtractedTranscriptLineText(
 ): string | undefined {
   let lineEnd = text.length
 
-  for (let index = text.length - 1; index >= -1; index--) {
-    if (index >= 0 && text.charCodeAt(index) !== 10) {
-      continue
-    }
+  while (lineEnd > 0) {
+    const index = text.lastIndexOf('\n', lineEnd - 1)
 
     const line = text.slice(index + 1, lineEnd).trim()
     if (line.length > 0) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 |

<!-- /orca-pr-loc -->

Agent completion hooks read the newest assistant message from JSONL transcripts. The reader currently checks each character while walking backward to a newline. Use JavaScript's native reverse newline search to visit the same nonblank lines in the same order.

ELI5: jump straight to each previous line break instead of checking every letter on the way. The JSON parser, extraction rules, 64 KiB reads, 4 MiB scan cap, and file lifetime stay the same.

Measured on macOS with production modules bundled by esbuild, three warmups and eleven alternating before/after samples; medians per call. The file-reader column includes real filesystem reads from warm temporary files, JSON validation, and extraction.

| Fixture | Line extraction before → after | Full warm file reader before → after |
|---|---:|---:|
| 64 KiB assistant line | 0.290 → 0.190 ms | 0.292 → 0.208 ms |
| 4 MiB assistant line | 19.675 → 12.607 ms | 15.400 → 11.127 ms |
| 1,000 short tool lines, no assistant | 1.152 → 0.912 ms | 0.703 → 0.574 ms |
| 160 KiB Unicode line | 0.268 → 0.173 ms | 0.287 → 0.234 ms |
| 39-byte assistant line | 0.000350 → 0.000329 ms | 0.0176 → 0.0180 ms |

Tiny filesystem timings are effectively tied; this is a long-line CPU improvement, not a cold-disk or app-startup claim. A separate Buffer-scanner experiment was excluded because tiny inputs regressed.

Reproduce from the PR checkout (save its base transcript-reader.ts as a temporary file):

```sh
git show 6a5c1f9535ee8d6b433eca58e9268ebc41d33e1a:src/shared/agent-hook-listener/transcript-reader.ts > /tmp/transcript-reader-before.ts
node config/scripts/benchmark-transcript-reverse-lines.mjs /tmp/transcript-reader-before.ts
pnpm test src/shared/agent-hook-listener/transcript-reader.test.ts src/shared/agent-hook-listener-command-code-transcript.test.ts src/shared/agent-hook-listener-hermes-codex-droid.test.ts src/shared/agent-hook-listener-grok.test.ts
pnpm tc
```

Validation: 49 tests passed across four files; all three desktop typechecks and targeted lint/format passed. The new test checks 1,000 generated strings against an independent split/reverse oracle, including blank lines, CRLF, Unicode, early return, and empty extracted results. Existing production hook tests cover oversized lines, read boundaries, scan limits, and interaction keys. The benchmark checks exact output equality for both extraction and full file reads.

Reliability invariant: the newest extractable assistant text and callback order remain identical. This CPU-only change does not alter PTY ownership, liveness, replay, execution-host routing, or exchanged payloads; local, daemon, SSH/WSL, and relay callers keep their existing reader. Native Windows/Linux runs remain CI coverage rather than local evidence. No reliability lifecycle gate is changed.

Negative user-facing trade-offs:
- None identified. No content is dropped, delayed, newly cached, or parsed differently.
- No new subprocesses, polling, buffers, or limits.
