### PR TITLE
test: deliver real terminal input and preserve setup reports

### DIFF
--- a/tests/e2e/terminal-scroll-intent-follow.spec.ts
+++ b/tests/e2e/terminal-scroll-intent-follow.spec.ts
@@ -168,6 +168,7 @@ async function injectQueuedWriteThenType(page: Page, paneKey: string): Promise<v
   await page.evaluate((targetPaneKey) => {
     const injectionTarget = window as Window & {
       __terminalPtyDataInjection?: { inject: (paneKey: string, data: string) => boolean }
+      __releaseScrollIntentTestWrite?: () => void
     }
     const state = window.__store?.getState()
     const worktreeId = state?.activeWorktreeId
@@ -184,38 +185,44 @@ async function injectQueuedWriteThenType(page: Page, paneKey: string): Promise<v
     }
     const terminal = pane.terminal
     const originalWrite = terminal.write
-    const holder: { write: { data: string; callback?: () => void } | null } = { write: null }
+    const heldWrites: { data: string; callback?: () => void }[] = []
     terminal.write = ((data: string, callback?: () => void) => {
-      holder.write = { data, callback }
+      heldWrites.push({ data, callback })
     }) as typeof terminal.write
+    injectionTarget.__releaseScrollIntentTestWrite = () => {
+      terminal.write = originalWrite
+      delete injectionTarget.__releaseScrollIntentTestWrite
+      for (const held of heldWrites) {
+        originalWrite.call(terminal, held.data, held.callback)
+      }
+    }
     try {
       const payload = '\x1b[?2026h\r\x1b[2KWorking in-flight\x1b[?2026l'
       if (!injectionTarget.__terminalPtyDataInjection?.inject(targetPaneKey, payload)) {
         throw new Error('PTY injector unavailable')
+      }
+      if (heldWrites.length === 0) {
+        throw new Error('Foreground terminal write was not captured')
       }
       const textarea = pane.container.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
       if (!textarea) {
         throw new Error('xterm helper textarea unavailable')
       }
       textarea.focus()
-      const event = new KeyboardEvent('keydown', {
-        bubbles: true,
-        cancelable: true,
-        key: 'x',
-        code: 'KeyX'
-      })
-      Object.defineProperty(event, 'keyCode', { configurable: true, value: 88 })
-      Object.defineProperty(event, 'which', { configurable: true, value: 88 })
-      textarea.dispatchEvent(event)
-    } finally {
-      terminal.write = originalWrite
+    } catch (error) {
+      injectionTarget.__releaseScrollIntentTestWrite()
+      throw error
     }
-    const heldWrite = holder.write
-    if (!heldWrite) {
-      throw new Error('Foreground terminal write was not captured')
-    }
-    originalWrite.call(terminal, heldWrite.data, heldWrite.callback)
   }, paneKey)
+  try {
+    await page.keyboard.press('x')
+  } finally {
+    await page.evaluate(() => {
+      ;(
+        window as Window & { __releaseScrollIntentTestWrite?: () => void }
+      ).__releaseScrollIntentTestWrite?.()
+    })
+  }
 }
 
 async function startStreamingFixturePhase1(page: Page): Promise<string> {
@@ -308,5 +315,6 @@ test.describe('terminal scroll intent keeps following output', () => {
         { timeout: 5_000, intervals: [25] }
       )
       .toBe(0)
+    await waitForMarkerAtBottom(orcaPage, 'STREAM_PHASE2_DONE')
   })
 })

--- a/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
+++ b/tests/e2e/terminal-send-agent-prompt-submit.spec.ts
@@ -58,6 +58,7 @@ async function createFakeCodexTerminal(
   if (!worktree) {
     throw new Error(`runtime did not register ${testRepoPath}`)
   }
+  rmSync(fixtureReport, { force: true })
   const created = await client.call<{ terminal: { handle: string } }>('terminal.create', {
     worktree: `id:${worktree.id}`,
     command: [fakeCodexCommand, ...args].join(' '),

--- a/tests/tools/repro-terminal-send-submit.mjs
+++ b/tests/tools/repro-terminal-send-submit.mjs
@@ -186,7 +186,9 @@ async function parentMain() {
   const expectBlocked = hasFlag('expect-blocked')
   const providedHandle = argValue('terminal')
   await mkdir(tempDir, { recursive: true })
-  await rm(reportPath, { force: true })
+  if (!providedHandle) {
+    await rm(reportPath, { force: true })
+  }
 
   let handle = providedHandle
   if (!handle) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Two terminal regression fixtures failed before exercising their intended input contracts.

The scroll-follow case dispatched only a synthetic printable keydown, which did not deliver input to the PTY. Send a real Playwright key while the injected xterm write is held, preserve every held write for ordered release, and require the fixture's input-triggered second output phase as well as the original bottom-follow assertion.

The permission case created its fake terminal before launching the driver, which then deleted the already-written setup report. Clear stale reports before external terminal creation, and let the driver clear a report only when it creates the terminal itself. The original zero-byte, zero-Enter permission assertions remain intact.

Validation: both original failures reproduced; all scroll cases repeated twice (8 passes) and all prompt-submit cases repeated twice (6 passes). Lint, formatting, and diff checks pass. Test-only changes; no timeout increase, retry, or application change.
