### PR TITLE
perf(mobile): cancel direct probes when their owner stops

### DIFF
--- a/mobile/src/transport/mobile-direct-endpoint-probe.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.ts
@@ -31,7 +31,14 @@ export function directPathForEndpoint(
 // instead of holding the supervisor's operation mutex for the full outer bound.
 const RECONNECT_GRACE_MS = 2_000
 
-function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Promise<void> {
+function waitForAuthenticatedSession(
+  session: RpcClient,
+  timeoutMs: number,
+  signal?: AbortSignal
+): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.reject(new Error('probe cancelled'))
+  }
   if (session.getState() === 'connected') {
     return Promise.resolve()
   }
@@ -72,7 +79,13 @@ function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Pro
       finish()
       reject(new Error('probe session authentication timed out'))
     }, timeoutMs)
+    const onAbort = (): void => {
+      finish()
+      reject(new Error('probe cancelled'))
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
     function finish(): void {
+      signal?.removeEventListener('abort', onAbort)
       if (timer) {
         clearTimeout(timer)
       }
@@ -87,8 +100,12 @@ function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Pro
 export async function openAuthenticatedDirectEndpoint(
   host: HostProfile,
   openDirect: (endpoint: string) => RpcClient,
-  timeoutMs: number
+  timeoutMs: number,
+  signal?: AbortSignal
 ): Promise<{ client: RpcClient; path: Exclude<MobileConnectionPath, 'relay'> } | null> {
+  if (signal?.aborted) {
+    return null
+  }
   const endpoints = directEndpointUrls(host)
   return await new Promise((resolve) => {
     const clients = new Set<RpcClient>()
@@ -110,8 +127,13 @@ export async function openAuthenticatedDirectEndpoint(
         continue
       }
       clients.add(client)
-      void waitForAuthenticatedSession(client, timeoutMs).then(
+      void waitForAuthenticatedSession(client, timeoutMs, signal).then(
         () => {
+          if (signal?.aborted) {
+            client.close()
+            rejectCandidate()
+            return
+          }
           if (settled) {
             client.close()
             return

--- a/mobile/src/transport/mobile-direct-probe-stop-budget.test.ts
+++ b/mobile/src/transport/mobile-direct-probe-stop-budget.test.ts
@@ -1,0 +1,114 @@
+import { expect, it, vi } from 'vitest'
+import {
+  dependencies,
+  FakeLogicalClient,
+  FakeSession,
+  host
+} from './mobile-endpoint-supervisor-test-fakes'
+import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+it('closes in-flight candidates and clears their timeout when the owner stops', async () => {
+  vi.useFakeTimers()
+  try {
+    const candidate = new FakeSession('connecting')
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies({ openDirect: vi.fn(() => candidate) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(deps.openDirect).toHaveBeenCalledOnce()
+    supervisor.stop()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(candidate.close).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+    await vi.advanceTimersByTimeAsync(12_000)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(candidate.close).toHaveBeenCalledOnce()
+    expect(logical.migrateTo).not.toHaveBeenCalled()
+    expect(deps.openDirect).toHaveBeenCalledOnce()
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('closes an authenticated candidate when stop races its completion', async () => {
+  vi.useFakeTimers()
+  try {
+    const candidate = new FakeSession('connecting')
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies({ openDirect: vi.fn(() => candidate) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(15_000)
+    candidate.publishState('connected')
+    supervisor.stop()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(candidate.close).toHaveBeenCalledOnce()
+    expect(logical.migrateTo).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('preserves an in-flight probe across a transient background pause', async () => {
+  vi.useFakeTimers()
+  try {
+    const candidate = new FakeSession('connecting')
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies({ openDirect: vi.fn(() => candidate) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(15_000)
+    supervisor.setForeground(false)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(candidate.close).not.toHaveBeenCalled()
+    supervisor.stop()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(candidate.close).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})
+
+it('releases every candidate when multiple endpoint probes are pending', async () => {
+  vi.useFakeTimers()
+  try {
+    const candidates: FakeSession[] = []
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies({
+      openDirect: vi.fn(() => {
+        const candidate = new FakeSession('connecting')
+        candidates.push(candidate)
+        return candidate
+      })
+    })
+    const supervisor = new MobileEndpointSupervisor(
+      logical,
+      {
+        ...host,
+        endpoints: [{ id: 'alternate', kind: 'tailscale', url: 'ws://100.64.0.2:6768' }]
+      },
+      deps
+    )
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(candidates).toHaveLength(2)
+    supervisor.stop()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(vi.getTimerCount()).toBe(0)
+    for (const candidate of candidates) {
+      expect(candidate.close).toHaveBeenCalledOnce()
+      candidate.publishState('connected')
+    }
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(logical.migrateTo).not.toHaveBeenCalled()
+    expect(deps.openDirect).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+  } finally {
+    vi.useRealTimers()
+  }
+})

--- a/mobile/src/transport/mobile-direct-probe-stop-budget.test.ts
+++ b/mobile/src/transport/mobile-direct-probe-stop-budget.test.ts
@@ -5,6 +5,8 @@ import {
   FakeSession,
   host
 } from './mobile-endpoint-supervisor-test-fakes'
+import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+import { createStableLogicalRpcClient } from './stable-logical-rpc-client'
 import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
 vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
@@ -29,6 +31,7 @@ it('closes in-flight candidates and clears their timeout when the owner stops', 
     expect(logical.migrateTo).not.toHaveBeenCalled()
     expect(deps.openDirect).toHaveBeenCalledOnce()
   } finally {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   }
 })
@@ -49,6 +52,7 @@ it('closes an authenticated candidate when stop races its completion', async () 
     expect(logical.migrateTo).not.toHaveBeenCalled()
     expect(vi.getTimerCount()).toBe(0)
   } finally {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   }
 })
@@ -70,6 +74,7 @@ it('preserves an in-flight probe across a transient background pause', async () 
     expect(candidate.close).toHaveBeenCalledOnce()
     expect(vi.getTimerCount()).toBe(0)
   } finally {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   }
 })
@@ -109,6 +114,62 @@ it('releases every candidate when multiple endpoint probes are pending', async (
     expect(deps.openDirect).toHaveBeenCalledTimes(2)
     expect(vi.getTimerCount()).toBe(0)
   } finally {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   }
 })
+
+it.each([false, true])(
+  'fences migration finishing after stop (already swapped: %s)',
+  async (alreadySwapped) => {
+    vi.useFakeTimers()
+    try {
+      const recordedMigration = vi.spyOn(MobileEndpointHysteresis.prototype, 'recordMigration')
+      const relay = new FakeSession('connected')
+      const logical = createStableLogicalRpcClient(relay, 'relay')
+      const candidates: FakeSession[] = []
+      const deps = dependencies({
+        openDirect: vi.fn(() => {
+          const candidate = new FakeSession('connected')
+          candidates.push(candidate)
+          return candidate
+        })
+      })
+      const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+      const migrate = logical.migrateTo.bind(logical)
+      let release!: () => void
+      const pending = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const migration = vi.spyOn(logical, 'migrateTo').mockImplementation(async (...args) => {
+        if (alreadySwapped) {
+          await migrate(...args)
+        }
+        await pending
+        if (!alreadySwapped) {
+          await migrate(...args)
+        }
+      })
+      await supervisor.start()
+      await vi.advanceTimersByTimeAsync(60_000)
+      expect(migration).toHaveBeenCalledOnce()
+      const requestsBeforeStop = relay.sendRequest.mock.calls.length
+      const candidateRequestsBeforeStop = candidates[3].sendRequest.mock.calls.length
+      const migrationsBeforeStop = recordedMigration.mock.calls.length
+      supervisor.stop()
+      release()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(logical.getActivePath()).toBe(alreadySwapped ? 'lan' : 'relay')
+      expect(logical.getGeneration()).toBe(alreadySwapped ? 2 : 1)
+      expect(relay.sendRequest).toHaveBeenCalledTimes(requestsBeforeStop)
+      expect(candidates[3].sendRequest).toHaveBeenCalledTimes(candidateRequestsBeforeStop)
+      expect(recordedMigration).toHaveBeenCalledTimes(migrationsBeforeStop)
+      expect(candidates[3].close).toHaveBeenCalledTimes(alreadySwapped ? 0 : 1)
+      expect(vi.getTimerCount()).toBe(0)
+      logical.close()
+    } finally {
+      vi.restoreAllMocks()
+      vi.useRealTimers()
+    }
+  }
+)

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -27,7 +27,11 @@ export class DirectReturnProbe {
       canSchedule: () => boolean
       canAttempt: () => boolean
       beginOperation: () => void
-      migrate: (client: RpcClient, path: MobileConnectionPath) => Promise<void>
+      migrate: (
+        client: RpcClient,
+        path: MobileConnectionPath,
+        shouldAbort: () => boolean
+      ) => Promise<void>
       onDirectMigrated: () => Promise<void>
       afterProbe: () => void
     }
@@ -86,8 +90,20 @@ export class DirectReturnProbe {
         successful.client.close()
         return
       }
-      await this.hooks.migrate(successful.client, successful.path)
+      const candidate = successful
+      // Migration owns the candidate, including closing it if cutover is canceled.
       successful = null
+      try {
+        await this.hooks.migrate(candidate.client, candidate.path, () => this.stopped)
+      } catch (error) {
+        if (this.stopped) {
+          return
+        }
+        throw error
+      }
+      if (this.stopped) {
+        return
+      }
       this.hooks.hysteresis.recordMigration(this.deps.now())
       await this.hooks.onDirectMigrated()
     } finally {

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -11,6 +11,9 @@ const DIRECT_PROBE_INTERVAL_MS = 15_000
 export class DirectReturnProbe {
   private timer: ReturnType<typeof setTimeout> | null = null
 
+  private stopped = false
+  private activeProbe: AbortController | null = null
+
   constructor(
     private readonly deps: {
       now: () => number
@@ -31,7 +34,7 @@ export class DirectReturnProbe {
   ) {}
 
   schedule(delayMs = DIRECT_PROBE_INTERVAL_MS): void {
-    if (!this.hooks.canSchedule() || this.timer) {
+    if (this.stopped || !this.hooks.canSchedule() || this.timer) {
       return
     }
     this.timer = this.deps.setTimer(() => {
@@ -47,19 +50,34 @@ export class DirectReturnProbe {
     }
   }
 
+  stop(): void {
+    this.stopped = true
+    this.clear()
+    this.activeProbe?.abort()
+  }
+
   private async probe(): Promise<void> {
+    if (this.stopped) {
+      return
+    }
     if (!this.hooks.canAttempt() || !this.hooks.hysteresis.canProbe(this.deps.now())) {
       this.schedule()
       return
     }
+    const controller = new AbortController()
+    this.activeProbe = controller
     this.hooks.beginOperation()
     let successful: Awaited<ReturnType<typeof openAuthenticatedDirectEndpoint>> = null
     try {
       successful = await openAuthenticatedDirectEndpoint(
         this.hooks.host(),
         this.deps.openDirect,
-        12_000
+        12_000,
+        controller.signal
       )
+      if (this.stopped) {
+        return
+      }
       if (!successful) {
         this.hooks.hysteresis.recordDirectFailure(this.deps.now())
         return
@@ -73,6 +91,7 @@ export class DirectReturnProbe {
       this.hooks.hysteresis.recordMigration(this.deps.now())
       await this.hooks.onDirectMigrated()
     } finally {
+      this.activeProbe = null
       successful?.client.close()
       // Why: a relay drop or backoff timer can arrive while the probe owns the
       // operation mutex; afterProbe releases it and replays deferred recovery.

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -120,7 +120,7 @@ export class MobileEndpointSupervisor {
       canSchedule: () => this.isActive() && this.logical.getActivePath() === 'relay',
       canAttempt: () => this.isActive() && !this.operationInFlight,
       beginOperation: () => (this.operationInFlight = true),
-      migrate: (client, path) => this.logical.migrateTo(client, path),
+      migrate: (client, path, abort) => this.logical.migrateTo(client, path, undefined, abort),
       onDirectMigrated: async () => {
         this.leaseRotation.clear()
         this.relayRotationPending = false

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -195,6 +195,7 @@ export class MobileEndpointSupervisor {
 
   stop(): void {
     this.stopped = true
+    this.directProbe.stop()
     this.unsubscribeState?.()
     this.unsubscribeState = null
     this.backgroundGrace.stop()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​175 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​175 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 |

<!-- /orca-pr-loc -->

Closing a mobile host connection stops its endpoint supervisor, but the supervisor previously cleared only the next scheduled direct probe. A probe already connecting kept its client and authentication timeout alive for up to another 12 seconds.

ELI5: after you close a connection, cancel the background attempt to find a faster route too. It no longer needs to wait for its timeout before cleaning up.

Add a permanent `DirectReturnProbe.stop()` that aborts the current endpoint attempt and prevents later scheduling or adoption. Pass its local AbortSignal through the authentication wait so cancellation removes the state listener and timeout. The existing `clear()` remains the transient-background operation; ordinary app switching keeps its previous behavior.

Deterministic before/after measurements use the actual MobileEndpointSupervisor and direct-endpoint probe with controlled RPC clients and a fake clock:

| After permanent stop during a connecting probe | Before | After |
|---|---:|---:|
| Retained candidate clients, one endpoint | 1 | 0 |
| Remaining authentication timers, one endpoint | 1 | 0 |
| Retained candidates/timers, two endpoints | 2 / 2 | 0 / 0 |
| Delay until candidate closes | 12,000 ms | Promise settlement; no clock advance |
| Additional starts or migrations after cleanup | 0 | 0 |

Before, the one candidate is still open at 11,999 ms and closes at 12,000 ms. After, `advanceTimersByTimeAsync(0)` drains promise callbacks and observes the close and zero timers. These are resource-lifetime counts, not measured battery/network-rate claims. The candidate fake deliberately does not publish a state change from close, so cleanup cannot depend on a cooperative close event.

Validation: 61 tests passed across seven suites, covering the new budget, endpoint selection/authentication, supervisor recovery/nudges, stalled cellular paths, background grace, and direct-client close behavior. Mobile typecheck and targeted lint/format passed. All four new budget cases were run against the original production files and failed, then passed with the fix restored. The cases cover owner stop, authentication racing stop, multiple endpoints with late state events, and preservation of an active probe during temporary backgrounding.

Reproduce:

```sh
pnpm --dir mobile test src/transport/mobile-direct-probe-stop-budget.test.ts src/transport/mobile-direct-endpoint-probe.test.ts src/transport/mobile-endpoint-supervisor.test.ts src/transport/mobile-endpoint-supervisor-nudge.test.ts src/transport/mobile-endpoint-supervisor-stalled-cell.test.ts src/transport/mobile-relay-background-grace.test.ts src/transport/rpc-client-synthesized-close-diagnostics.test.ts
pnpm --dir mobile exec tsc --noEmit
```

The cleanup owns client-side transport candidates only. It neither stops remote PTYs nor changes host execution/liveness judgments, RPC payloads, frame formats, credentials, live-owner migration rules, or endpoint ranking. iOS/Android use this supervisor; the web host-client path bypasses it. Tests run in Node with controlled clients, not on physical phones or a live SSH/WSL host. No server update or wire negotiation is needed.

Negative user-facing trade-offs:
- None identified. Cleanup applies after permanent owner stop; temporary backgrounding and live probing remain intact.
- No reduced timeouts, polling-frequency change, or dropped application request/subscription data.

The stop fence also reaches the existing logical-client migration cancellation predicate. A candidate waiting to cut over cannot replace the relay after owner stop. If cutover already happened before stop, its late completion skips migration bookkeeping and endpoint refresh. Migration retains ownership of candidate cleanup, so cancellation closes it exactly once.

Additional measured regressions using the real logical client with deferred migration:

| Shutdown race | Before | After |
|---|---:|---:|
| Unwanted cutover after stop | 1 | 0 |
| Late migration records after stop | 1 | 0 |

Both new cases fail against the previous PR head and pass with the fence. Updated validation: 74 tests across six suites, including the stable logical client migration suite; mobile typecheck, lint, and format pass. No live-owner behavior or wire contract changes; no additional negative user-facing trade-offs identified.
