### PR TITLE
test: align Source Control AI generation fixtures

### DIFF
--- a/tests/e2e/helpers/source-control-ai-generation.ts
+++ b/tests/e2e/helpers/source-control-ai-generation.ts
@@ -67,7 +67,7 @@ export async function seedCreatePrComposer(page: Page): Promise<{
   prWorktreePath: string
   primaryBranch: string
 }> {
-  return page.evaluate(async () => {
+  const seeded = await page.evaluate(async () => {
     const store =
       window.__store ??
       (() => {
@@ -101,6 +101,7 @@ export async function seedCreatePrComposer(page: Page): Promise<{
     const eligibility = {
       provider: 'github' as const,
       review: null,
+      reviewLookupOutcome: 'not_found' as const,
       canCreate: true,
       blockedReason: null,
       nextAction: null,
@@ -121,7 +122,7 @@ export async function seedCreatePrComposer(page: Page): Promise<{
         ...current.remoteStatusesByWorktree,
         [prWorktree.id]: {
           hasUpstream: true,
-          upstreamName: `origin/${branch}`,
+          upstreamName: primaryBranch,
           ahead: 0,
           behind: 0
         }
@@ -130,6 +131,10 @@ export async function seedCreatePrComposer(page: Page): Promise<{
         args.branch === branch ? eligibility : { ...eligibility, canCreate: false },
       fetchHostedReviewForBranch: async () => null,
       fetchPRForBranch: async () => null,
+      enqueueGitHubPRRefresh: () => undefined,
+      // Ignore provider work queued before this generation-only fixture was installed.
+      getEffectiveGitHubPRRefreshState: () => undefined,
+      prRefreshStates: {},
       fetchUpstreamStatus: async () => undefined,
       setUpstreamStatus: () => undefined
     }))
@@ -141,6 +146,12 @@ export async function seedCreatePrComposer(page: Page): Promise<{
       primaryBranch
     }
   })
+  // Checks reads fresh Git state instead of the seeded store cache.
+  execFileSync('git', ['branch', '--set-upstream-to', seeded.primaryBranch], {
+    cwd: seeded.prWorktreePath,
+    stdio: 'pipe'
+  })
+  return seeded
 }
 
 export async function seedCommitMessageComposer(page: Page): Promise<{

--- a/tests/e2e/helpers/source-control-ai-generators.ts
+++ b/tests/e2e/helpers/source-control-ai-generators.ts
@@ -14,13 +14,13 @@ async function setCustomGenerator(page: Page, scriptPath: string): Promise<void>
     }
     await store.getState().updateSettings({
       activeRuntimeEnvironmentId: null,
-      commitMessageAi: {
-        ...currentSettings.commitMessageAi,
+      sourceControlAi: {
         enabled: true,
         agentId: 'custom' as const,
         selectedModelByAgent: {},
         selectedThinkingByModel: {},
-        customPrompt: '',
+        instructionsByOperation: {},
+        actions: {},
         customAgentCommand: `node ${JSON.stringify(scriptPath)}`
       }
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Source Control AI generation tests still seeded retired settings and cached upstream/provider state. Seed the current sourceControlAi custom command, establish a real tracking branch for fresh Checks snapshots, and isolate provider refreshes (including work queued before setup) in this generation-only fixture.

Validation: both generation-switch and linked-issue specs repeated twice, 16 passed. oxfmt and oxlint passed. No application changes.
