### PR TITLE
test: isolate skill cloud fixture ports across workers

### DIFF
--- a/tests/e2e/helpers/remote-skill-cloud-fixture.ts
+++ b/tests/e2e/helpers/remote-skill-cloud-fixture.ts
@@ -8,13 +8,12 @@ import {
 } from '../../../src/main/skills/skill-package-creation'
 import { SKILL_PACKAGE_CONTENT_TYPE } from '../../../src/shared/skill-package-manifest'
 
-export const REMOTE_SKILL_CLOUD_PORT = Number(process.env.ORCA_E2E_SKILL_CLOUD_PORT ?? '43961')
-export const REMOTE_SKILL_CLOUD_ORIGIN = `http://127.0.0.1:${REMOTE_SKILL_CLOUD_PORT}`
 export const REMOTE_SKILL_PACKAGE_ID = 'package_remote_e2e'
 export const REMOTE_SKILL_VERSION_ID = 'version_remote_e2e'
 export const REMOTE_SKILL_NAME = 'remote-e2e-skill'
 
 export type RemoteSkillCloudFixture = {
+  origin: string
   archive: CreatedSkillPackage
   bytes: Buffer
   requests: { method: string; path: string; body: unknown }[]
@@ -39,19 +38,30 @@ export async function startRemoteSkillCloudFixture(): Promise<RemoteSkillCloudFi
   })
   const bytes = await readFile(archive.archivePath)
   const requests: RemoteSkillCloudFixture['requests'] = []
+  let origin = ''
   const server = createServer((request, response) => {
-    void handleRemoteSkillCloudRequest({ request, response, archive, bytes, requests }).catch(
-      (error) => {
-        response.writeHead(500, { 'content-type': 'application/json' })
-        response.end(JSON.stringify({ code: 'fixture_failed', message: String(error) }))
-      }
-    )
+    void handleRemoteSkillCloudRequest({
+      request,
+      response,
+      archive,
+      bytes,
+      requests,
+      origin
+    }).catch((error) => {
+      response.writeHead(500, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ code: 'fixture_failed', message: String(error) }))
+    })
   })
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject)
-    server.listen(REMOTE_SKILL_CLOUD_PORT, '127.0.0.1', resolve)
+    server.listen(Number(process.env.ORCA_E2E_SKILL_CLOUD_PORT ?? 0), '127.0.0.1', resolve)
   })
-  return { archive, bytes, requests, root, server }
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Skill fixture has no TCP address')
+  }
+  origin = `http://127.0.0.1:${address.port}`
+  return { archive, bytes, requests, root, server, origin }
 }
 
 export async function stopRemoteSkillCloudFixture(fixture: RemoteSkillCloudFixture): Promise<void> {
@@ -60,13 +70,14 @@ export async function stopRemoteSkillCloudFixture(fixture: RemoteSkillCloudFixtu
 }
 
 async function handleRemoteSkillCloudRequest(input: {
+  origin: string
   request: IncomingMessage
   response: ServerResponse
   archive: CreatedSkillPackage
   bytes: Buffer
   requests: RemoteSkillCloudFixture['requests']
 }): Promise<void> {
-  const path = new URL(input.request.url ?? '/', REMOTE_SKILL_CLOUD_ORIGIN).pathname
+  const path = new URL(input.request.url ?? '/', input.origin).pathname
   if (input.request.method === 'GET' && path === '/package.tar.gz') {
     input.requests.push({ method: 'GET', path, body: null })
     input.response.writeHead(200, {
@@ -84,17 +95,19 @@ async function handleRemoteSkillCloudRequest(input: {
     const body = JSON.parse(await readRequestBody(input.request)) as unknown
     input.requests.push({ method: 'POST', path, body })
     input.response.writeHead(200, { 'content-type': 'application/json' })
-    input.response.end(JSON.stringify(downloadGrant(input.archive, input.bytes.length)))
+    input.response.end(
+      JSON.stringify(downloadGrant(input.archive, input.bytes.length, input.origin))
+    )
     return
   }
   input.response.writeHead(404, { 'content-type': 'application/json' })
   input.response.end(JSON.stringify({ code: 'not_found', message: 'Not found' }))
 }
 
-function downloadGrant(archive: CreatedSkillPackage, compressedBytes: number) {
+function downloadGrant(archive: CreatedSkillPackage, compressedBytes: number, origin: string) {
   return {
     grant: {
-      url: `${REMOTE_SKILL_CLOUD_ORIGIN}/package.tar.gz`,
+      url: `${origin}/package.tar.gz`,
       expiresAt: '2099-01-01T00:00:00.000Z'
     },
     version: {

--- a/tests/e2e/helpers/remote-skill-cloud-fixture.unit.test.ts
+++ b/tests/e2e/helpers/remote-skill-cloud-fixture.unit.test.ts
@@ -1,0 +1,41 @@
+import { expect, it, vi } from 'vitest'
+import {
+  REMOTE_SKILL_PACKAGE_ID,
+  REMOTE_SKILL_VERSION_ID,
+  startRemoteSkillCloudFixture,
+  stopRemoteSkillCloudFixture
+} from './remote-skill-cloud-fixture'
+
+it('serves concurrent skill fixtures from independent bound origins', async () => {
+  vi.stubEnv('ORCA_E2E_SKILL_CLOUD_PORT', undefined)
+  const results = await Promise.allSettled([
+    startRemoteSkillCloudFixture(),
+    startRemoteSkillCloudFixture()
+  ])
+  const fixtures = results.flatMap((result) =>
+    result.status === 'fulfilled' ? [result.value] : []
+  )
+  try {
+    expect(results.every((result) => result.status === 'fulfilled')).toBe(true)
+    expect(new Set(fixtures.map((fixture) => fixture.origin)).size).toBe(2)
+    for (const fixture of fixtures) {
+      const response = await fetch(
+        `${fixture.origin}/v1/skill-packages/${REMOTE_SKILL_PACKAGE_ID}/versions/${REMOTE_SKILL_VERSION_ID}/download-grants`,
+        {
+          method: 'POST',
+          body: '{}',
+          headers: { 'content-type': 'application/json' }
+        }
+      )
+      expect(response.status).toBe(200)
+      const result = (await response.json()) as { grant: { url: string } }
+      expect(result.grant.url).toBe(`${fixture.origin}/package.tar.gz`)
+      const archive = await fetch(result.grant.url)
+      expect(Buffer.from(await archive.arrayBuffer())).toEqual(fixture.bytes)
+      expect(fixture.requests).toHaveLength(2)
+    }
+  } finally {
+    await Promise.all(fixtures.map(stopRemoteSkillCloudFixture))
+    vi.unstubAllEnvs()
+  }
+})

--- a/tests/e2e/paired-skill-installation.spec.ts
+++ b/tests/e2e/paired-skill-installation.spec.ts
@@ -14,7 +14,6 @@ import {
   type HeadlessPairedRuntimeHost
 } from './helpers/headless-paired-runtime-host'
 import {
-  REMOTE_SKILL_CLOUD_ORIGIN,
   REMOTE_SKILL_NAME,
   REMOTE_SKILL_PACKAGE_ID,
   REMOTE_SKILL_VERSION_ID,
@@ -119,13 +118,14 @@ test('installs on a headless serve runtime through the same contract', async ({
 })
 
 function cloudClientEnvironment(): Record<string, string> {
+  const { origin } = requireCloudFixture()
   return {
-    ORCA_ARTIFACTS_API_URL: REMOTE_SKILL_CLOUD_ORIGIN,
-    ORCA_CLOUD_API_URL: REMOTE_SKILL_CLOUD_ORIGIN,
+    ORCA_ARTIFACTS_API_URL: origin,
+    ORCA_CLOUD_API_URL: origin,
     ORCA_CLOUD_CLIENT_ID: 'skills-e2e-client',
     ORCA_CLOUD_DEV_AUTH: '1',
     ORCA_CLOUD_ALLOW_PLAINTEXT_SESSION: '1',
-    ORCA_SKILL_PACKAGE_DOWNLOAD_ORIGINS: REMOTE_SKILL_CLOUD_ORIGIN
+    ORCA_SKILL_PACKAGE_DOWNLOAD_ORIGINS: origin
   }
 }
 

--- a/tests/e2e/ssh-skill-installation.spec.ts
+++ b/tests/e2e/ssh-skill-installation.spec.ts
@@ -10,7 +10,6 @@ import {
 import { connectDockerSshRelayTarget } from './helpers/docker-ssh-relay-connection'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
-  REMOTE_SKILL_CLOUD_ORIGIN,
   REMOTE_SKILL_NAME,
   REMOTE_SKILL_PACKAGE_ID,
   REMOTE_SKILL_VERSION_ID,
@@ -25,13 +24,19 @@ const REMOTE_FOLDER = '/tmp/orca-skill-folder-workspace'
 let cloud: RemoteSkillCloudFixture | null = null
 
 test.use({
-  orcaAppExtraEnv: {
-    ORCA_ARTIFACTS_API_URL: REMOTE_SKILL_CLOUD_ORIGIN,
-    ORCA_CLOUD_API_URL: REMOTE_SKILL_CLOUD_ORIGIN,
-    ORCA_CLOUD_CLIENT_ID: 'skills-e2e-client',
-    ORCA_CLOUD_DEV_AUTH: '1',
-    ORCA_CLOUD_ALLOW_PLAINTEXT_SESSION: '1',
-    ORCA_SKILL_PACKAGE_DOWNLOAD_ORIGINS: REMOTE_SKILL_CLOUD_ORIGIN
+  // oxlint-disable-next-line no-empty-pattern -- The server starts in beforeAll before this test fixture runs.
+  orcaAppExtraEnv: async ({}, provideEnv) => {
+    if (!cloud) {
+      throw new Error('Skill cloud fixture unavailable')
+    }
+    await provideEnv({
+      ORCA_ARTIFACTS_API_URL: cloud.origin,
+      ORCA_CLOUD_API_URL: cloud.origin,
+      ORCA_CLOUD_CLIENT_ID: 'skills-e2e-client',
+      ORCA_CLOUD_DEV_AUTH: '1',
+      ORCA_CLOUD_ALLOW_PLAINTEXT_SESSION: '1',
+      ORCA_SKILL_PACKAGE_DOWNLOAD_ORIGINS: cloud.origin
+    })
   }
 })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​85 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Paired and SSH skill installation specs used the same fixed localhost port, producing EADDRINUSE when workers overlapped. Bind an available port per fixture and propagate its actual origin into clients and download grants; preserve the explicit port override.

Validation: concurrency regression verifies two independent origins and exact archive downloads. Paired and real Docker SSH specs passed together, then repeated twice with two workers: 6 passed. oxfmt and oxlint passed. No application changes.
