### PR TITLE
perf(jira): preserve replacement attachment download singleflight

### DIFF
--- a/src/main/jira/attachment-image-cache-generation.test.ts
+++ b/src/main/jira/attachment-image-cache-generation.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _resetAttachmentImageCache,
+  clearAttachmentImagesForSite,
+  getCachedAttachmentDataUrl,
+  loadAttachmentDataUrlWithCache
+} from './attachment-image-cache'
+
+type Image = { dataUrl: string; byteSize: number } | null
+function deferredImage() {
+  let resolve!: (image: Image) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<Image>((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(_resetAttachmentImageCache)
+
+describe.each(['site', 'all'] as const)('attachment download after clearing %s', (scope) => {
+  it.each(['success', 'empty', 'failure'] as const)(
+    'keeps the replacement singleflight when the old download completes with %s',
+    async (outcome) => {
+      const old = deferredImage()
+      const replacement = deferredImage()
+      let downloads = 0
+      const load = () => {
+        downloads += 1
+        return downloads === 1 ? old.promise : replacement.promise
+      }
+      const args = { siteId: 'site-a', attachmentId: 'image-1', load }
+      const first = loadAttachmentDataUrlWithCache(args).catch(() => 'old failure')
+      clearAttachmentImagesForSite(scope === 'site' ? 'site-a' : undefined)
+      const second = loadAttachmentDataUrlWithCache(args)
+      expect(downloads).toBe(2)
+
+      if (outcome === 'failure') {
+        old.reject(new Error('old failure'))
+      } else {
+        old.resolve(outcome === 'empty' ? null : { dataUrl: 'old image', byteSize: 3 })
+      }
+      expect(await first).toBe(
+        outcome === 'failure' ? 'old failure' : outcome === 'empty' ? null : 'old image'
+      )
+      expect(getCachedAttachmentDataUrl('site-a', 'image-1')).toBeNull()
+
+      const third = loadAttachmentDataUrlWithCache(args)
+      expect(downloads).toBe(2)
+      replacement.resolve({ dataUrl: 'new image', byteSize: 3 })
+      expect(await second).toBe('new image')
+      expect(await third).toBe('new image')
+      expect(getCachedAttachmentDataUrl('site-a', 'image-1')).toBe('new image')
+    }
+  )
+})

--- a/src/main/jira/attachment-image-cache.ts
+++ b/src/main/jira/attachment-image-cache.ts
@@ -133,7 +133,10 @@ export async function loadAttachmentDataUrlWithCache(args: {
       }
       return loaded.dataUrl
     } finally {
-      inFlight.delete(key)
+      // A cleared generation no longer owns the current download's singleflight slot.
+      if (currentEpoch(args.siteId) === epochAtStart) {
+        inFlight.delete(key)
+      }
     }
   })()
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

An older Jira attachment download can finish after a cache clear and delete the replacement download's singleflight entry. A third caller then starts a duplicate download even though the replacement is still running.

ELI5: clearing the cache starts a new generation of work. An old download should not erase the new download's “already downloading” marker. Reuse the existing generation check for cleanup as well as cache publication.

Measured with the production cache and controlled loader completions:

| Sequence: start A → clear → start B → finish A → request C | Before | After |
|---|---:|---:|
| Total loader calls | 3 | 2 |
| Loader calls in the new generation | 2 | 1 |
| Duplicate replacement downloads | 1 | 0 |

The count holds for site-specific and global clears and for old-download success, empty result, and failure. No timing or network-throughput claim is made. The old caller still receives its original result; post-clear callers share the fresh result. Old bytes still cannot repopulate the cache.

Validation: 26 tests passed across attachment cache, generation, and image resolution suites. All six new cases fail against the baseline with three loader calls instead of two, then pass with the fix restored. Node typecheck and targeted lint/format passed.

```sh
pnpm test src/main/jira/attachment-image-cache.test.ts src/main/jira/attachment-image-cache-generation.test.ts src/main/jira/attachment-images.test.ts
pnpm tc:node
```

Negative user-facing trade-offs:
- None identified. Cache lifetime, capacity, invalidation, failure retry, returned bytes, and site isolation stay unchanged.
- No new cache or persistent state; the existing monotonic generation identifies the owner.

This is confined to Jira's client-side attachment cache. Other providers, workspace kinds, execution-host routing, and RPC formats are unaffected. The regression tests use controlled downloads rather than a live Jira account.
