### PR TITLE
perf(speech): reuse the model download idle timer

### DIFF
--- a/src/main/speech/model-manager-stream-cleanup.test.ts
+++ b/src/main/speech/model-manager-stream-cleanup.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
@@ -34,15 +34,17 @@ describe('ModelManager stream cleanup', () => {
     netRequestMock.mockReset()
   })
 
-  it('removes response progress listeners after a model download finishes', async () => {
+  it('reuses the idle timer and removes progress listeners after a fragmented download', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const timeoutSpy = vi.spyOn(globalThis, 'setTimeout')
     try {
       const response = new PassThrough() as PassThrough & {
         statusCode: number
         headers: Record<string, string>
       }
       response.statusCode = 200
-      response.headers = { 'content-length': '4' }
+      response.headers = { 'content-length': '1000' }
       const responseHandlers: ((response: unknown) => void)[] = []
       const request = {
         abort: vi.fn(() => request),
@@ -66,16 +68,26 @@ describe('ModelManager stream cleanup', () => {
       const download = manager.downloadFile(
         'https://example.com/model.bin',
         join(dir, 'model.bin'),
-        4,
+        1000,
         'm',
         () => false
       )
-      response.write(Buffer.from('ab'))
-      response.end(Buffer.from('cd'))
+      await vi.advanceTimersByTimeAsync(60_000)
+      for (let index = 0; index < 1000; index += 1) {
+        response.write(Buffer.from('a'))
+      }
+      await vi.advanceTimersByTimeAsync(119_999)
+      expect(request.abort).not.toHaveBeenCalled()
+      response.end()
 
       await expect(download).resolves.toBeUndefined()
       expect(response.listenerCount('data')).toBe(0)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(readFileSync(join(dir, 'model.bin'), 'utf8')).toBe('a'.repeat(1000))
+      expect(timeoutSpy.mock.calls.filter(([, delay]) => delay === 120_000)).toHaveLength(1)
     } finally {
+      timeoutSpy.mockRestore()
+      vi.useRealTimers()
       rmSync(dir, { recursive: true, force: true })
     }
   })

--- a/src/main/speech/speech-model-http-download.ts
+++ b/src/main/speech/speech-model-http-download.ts
@@ -71,8 +71,11 @@ export abstract class SpeechModelHttpDownload {
         request = null
       }
       const resetIdleTimeout = (): void => {
-        clearIdleTimeout()
-        idleTimeout = setTimeout(onRequestTimeout, DOWNLOAD_IDLE_TIMEOUT_MS)
+        if (idleTimeout) {
+          idleTimeout.refresh()
+        } else {
+          idleTimeout = setTimeout(onRequestTimeout, DOWNLOAD_IDLE_TIMEOUT_MS)
+        }
       }
       const resolveOnce = (): void => {
         if (settled) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

Speech-model downloads reset a 120-second idle deadline after every response chunk by clearing and allocating a new timer. Refresh the existing Node timeout instead.

ELI5: move the same alarm forward when more data arrives, instead of throwing away the alarm and building a new one for every chunk.

The production download pipeline, driven by a controlled response stream, measured:

| Download fixture | Before | After |
|---|---:|---:|
| 1,000 chunks: idle-timer allocations | 1,001 | 1 |
| Completed download bytes | 1,000 identical bytes | 1,000 identical bytes |
| Timers / progress listeners after completion | 0 / 0 | 0 / 0 |

The test first advances 60 seconds, supplies the chunks, then advances another 119,999 ms. The request remains active past the original deadline and completes with identical bytes. This verifies activity refreshes the same 120-second idle budget. The allocation assertion fails on the original implementation with 1,001 calls to setTimeout. This is an allocation-count improvement, not a measured download-throughput or battery claim.

Validation: 86 speech tests across 15 files passed, including download timeout/abort/error cleanup; Node typecheck, lint, and formatting passed.

```sh
pnpm test src/main/speech
pnpm tc:node
```

Negative user-facing trade-offs:
- None identified. The idle timeout, download data, progress reporting, cancellation, and error handling remain unchanged.
- No new scheduling delay, rate limit, cache, or polling.

This uses Node's Timeout.refresh in the main-process HTTP download path on macOS/Linux/Windows. It changes no UI, execution-host routing, or protocol. Validation used the real file pipeline with a controlled HTTP response and fake clock; a live model download was not required.
