### PR TITLE
test: make SSH artifact regression fixtures reliable at narrow widths

### DIFF
--- a/tests/e2e/ssh-codex-display-artifacts-repro.spec.ts
+++ b/tests/e2e/ssh-codex-display-artifacts-repro.spec.ts
@@ -48,7 +48,7 @@ import { resetWebglAndCaptureGraySlabAnalysis } from './terminal-webgl-reset-cap
 
 const RUN_DOCKER_SSH = process.env.ORCA_E2E_SSH_DOCKER === '1'
 const RUN_REAL_REMOTE_CODEX = process.env.ORCA_E2E_REAL_REMOTE_CODEX === '1'
-const EXPECT_NO_ARTIFACTS = process.env.ORCA_E2E_EXPECT_NO_CODEX_ARTIFACTS === '1'
+const EXPECT_NO_ARTIFACTS = process.env.ORCA_E2E_EXPECT_NO_CODEX_ARTIFACTS !== '0'
 const CAPTURE_WHILE_REMOTE_TUI_RUNNING =
   process.env.ORCA_E2E_CAPTURE_WHILE_REMOTE_TUI_RUNNING === '1'
 const HIDE_UNTIL_REMOTE_TUI_DONE = process.env.ORCA_E2E_HIDE_UNTIL_REMOTE_TUI_DONE === '1'

--- a/tests/e2e/ssh-codex-repro-remote-fixtures.ts
+++ b/tests/e2e/ssh-codex-repro-remote-fixtures.ts
@@ -135,7 +135,7 @@ async function insertCodexHistory(frame) {
     const phase = String(frame).padStart(4, '0') + '.' + index
     await write('\\r\\n')
     await write(\`\\x1b[48;2;72;72;72m\\x1b[K\`)
-    await write(\`\\x1b[38;2;220;220;220;48;2;72;72;72m\${pad('gpt-5.5 high · ~/code/pr-12250-migration-compare-move-baseprice-claim · /ps to view · /stop to close ' + phase, width)}\\x1b[0m\`)
+    await write(\`\\x1b[38;2;220;220;220;48;2;72;72;72m\${pad('gpt-5.5 high · ' + phase + ' · ~/code/pr-12250-migration-compare-move-baseprice-claim · /ps to view · /stop to close', width)}\\x1b[0m\`)
   }
   await write('\\x1b[r')
   await write(\`\\x1b[\${viewportBottom};1H\`)
@@ -176,7 +176,7 @@ for (let frame = 0; frame < ${REMOTE_CODEX_FIXTURE_FRAMES}; frame += 1) {
     await reverseIndexCodexHistory(frame)
   }
   if (frame % 9 === 0) {
-    await grayScrollLine(\`gpt-5.5 high · ~/code/pr-12250-migration-compare-move-baseprice-claim · /ps to view · /stop to close \${frame}\`)
+    await grayScrollLine(\`gpt-5.5 high · \${frame} · ~/code/pr-12250-migration-compare-move-baseprice-claim · /ps to view · /stop to close\`)
   }
   await sleep(${REMOTE_CODEX_FIXTURE_FRAME_DELAY_MS})
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The Docker SSH Codex artifact spec defaulted to requiring visible artifacts, so a clean screen failed. Default to its existing strict regression assertions; ORCA_E2E_EXPECT_NO_CODEX_ARTIFACTS=0 still selects reproduction mode.

Keep each deterministic history row’s frame identifier near the start: on narrow terminals, truncating the fixture line removed its trailing identifier and made distinct frames look like duplicate replay. The duplicate-output assertion remains intact.

Validation: two Docker SSH Electron runs with the default regression mode passed, followed by two runs at a 1280×800 window with the narrow-width fixture correction. Inspected the final clean frame. oxfmt and oxlint passed. Test-only change.
