### PR TITLE
ci: reduce runner overhead and disposable package compression

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -15,6 +15,7 @@ on:
       # Why: this job holds the only checks that load the Fastfile, so edits to
       # it or to the release workflow it guards must re-run them.
       - '.github/workflows/mobile.yml'
+      - '.github/actions/install-node-dependencies/**'
       - '.github/workflows/mobile-ios-release.yml'
 
 concurrency:

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/mobile.yml'
       - '.github/workflows/mobile-ios-release.yml'
 
+concurrency:
+  group: mobile-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -35,10 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: package.json
+      - uses: ./.github/actions/install-node-dependencies
 
       # bundler-cache installs mobile/Gemfile.lock, so this job is also what
       # proves the pinned fastlane the release workflow depends on still
@@ -49,23 +50,6 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: mobile
-
-      - name: Setup pnpm
-        uses: pnpm/setup@v2
-        with:
-          install: false
-
-      # Why: the mobile typecheck imports shared types from ../src/shared, and
-      # some of those files import runtime deps (tweetnacl, ws) resolved from
-      # the repo-root node_modules. Without a root install, tsc fails with
-      # "Cannot find module 'tweetnacl'/'ws'". Mobile is a separate pnpm project
-      # (not in the root workspace), so this is a distinct install.
-      # --ignore-scripts skips the root postinstall (Electron native-module
-      # rebuild) which is irrelevant to a type-only check and would only add
-      # time and failure surface on this ubuntu mobile runner.
-      - name: Install root dependencies
-        working-directory: .
-        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,10 @@ jobs:
       managed_hook_node18: ${{ steps.filter.outputs.managed_hook_node18 }}
       package: ${{ steps.filter.outputs.package }}
       package_windows: ${{ steps.filter.outputs.package_windows }}
+      e2e_should_run: ${{ steps.e2e_filter.outputs.should_run }}
+      test_files: ${{ steps.e2e_filter.outputs.test_files }}
+      ssh_source_changed: ${{ steps.e2e_filter.outputs.ssh_source_changed }}
+      native_ime_source_changed: ${{ steps.e2e_filter.outputs.native_ime_source_changed }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -65,6 +69,37 @@ jobs:
           echo "Changed paths:"
           printf '%s\n' "$CHANGED"
           printf '%s\n' "$CHANGED" | node config/scripts/pr-code-change-scope.mjs | tee -a "$GITHUB_OUTPUT"
+
+      # Reuse the path-detector checkout instead of queuing another runner.
+      - name: Filter changed E2E specs
+        id: e2e_filter
+        if: github.event.pull_request.draft != true && steps.filter.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          CHANGED="$(git diff --name-only --diff-filter=AMCR --merge-base "$BASE" "$HEAD")"
+          # Source routes are executable contracts so a test can prove exact
+          # authorities, exclusions, and sentinels without evaluating workflow shell.
+          TEST_FILES_JSON="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs)"
+          echo "test_files=$TEST_FILES_JSON" >> "$GITHUB_OUTPUT"
+          # Why a separate signal: the Docker-SSH lane must trigger on SSH source, not on a
+          # spec name surviving in a route's list. Same routes, so the two cannot drift.
+          SSH_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --ssh-source)"
+          echo "ssh_source_changed=$SSH_SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "SSH source changed: $SSH_SOURCE_CHANGED"
+          # Why its own signal: the real-IME lane is a whole ibus session, not a spec, so it must
+          # trigger on IME source rather than on a spec name in some route's list.
+          NATIVE_IME_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --native-ime-source)"
+          echo "native_ime_source_changed=$NATIVE_IME_SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
+          echo "Native IME source changed: $NATIVE_IME_SOURCE_CHANGED"
+          if [ "$TEST_FILES_JSON" != '[]' ]; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "Changed E2E specs: $TEST_FILES_JSON"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No changed E2E specs"
+          fi
 
   static_analysis:
     name: static analysis
@@ -712,7 +747,11 @@ jobs:
       - name: Package unpacked app
         env:
           ORCA_REUSE_PREPARED_NATIVE_RUNTIME: '1'
-        run: pnpm exec electron-builder --config config/electron-builder.config.cjs --linux AppImage deb rpm --x64 --publish never
+        # PR artifacts are only inspected locally; gzip avoids release-size xz compression.
+        run: >-
+          pnpm exec electron-builder --config config/electron-builder.config.cjs
+          --linux AppImage deb rpm --x64 --publish never
+          --config.deb.compression=gz --config.rpm.compression=gzip
 
       - name: Verify root-package marker payloads
         run: |
@@ -861,65 +900,10 @@ jobs:
       - name: Smoke packaged CLI
         run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/win-unpacked
 
-  # Why: PR E2E is advisory and only validates changed specs; scheduled and
-  # release runs retain full-suite coverage.
-  e2e-paths:
-    name: detect changed e2e specs
-    needs: [code_paths]
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft != true && needs.code_paths.outputs.should_run == 'true'
-    # Why: detector only needs to read the checkout; do not inherit repo defaults.
-    permissions:
-      contents: read
-    outputs:
-      should_run: ${{ steps.filter.outputs.should_run }}
-      test_files: ${{ steps.filter.outputs.test_files }}
-      ssh_source_changed: ${{ steps.filter.outputs.ssh_source_changed }}
-      native_ime_source_changed: ${{ steps.filter.outputs.native_ime_source_changed }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          # Why blob:none: full history is needed for the merge-base diff, but historical
-          # file contents are not. Blobs are ~89% of this repo's pack, and Git fetches the
-          # few this job actually reads on demand.
-          fetch-depth: 0
-          filter: blob:none
-          persist-credentials: false
-
-      - name: Filter changed E2E specs
-        id: filter
-        run: |
-          set -euo pipefail
-          BASE="${{ github.event.pull_request.base.sha }}"
-          HEAD="${{ github.event.pull_request.head.sha }}"
-          CHANGED="$(git diff --name-only --diff-filter=AMCR --merge-base "$BASE" "$HEAD")"
-          # Source routes are executable contracts so a test can prove exact
-          # authorities, exclusions, and sentinels without evaluating workflow shell.
-          TEST_FILES_JSON="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs)"
-          echo "test_files=$TEST_FILES_JSON" >> "$GITHUB_OUTPUT"
-          # Why a separate signal: the Docker-SSH lane must trigger on SSH source, not on a
-          # spec name surviving in a route's list. Same routes, so the two cannot drift.
-          SSH_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --ssh-source)"
-          echo "ssh_source_changed=$SSH_SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
-          echo "SSH source changed: $SSH_SOURCE_CHANGED"
-          # Why its own signal: the real-IME lane is a whole ibus session, not a spec, so it must
-          # trigger on IME source rather than on a spec name in some route's list.
-          NATIVE_IME_SOURCE_CHANGED="$(printf '%s\n' "$CHANGED" | node config/scripts/pr-e2e-source-routing.mjs --native-ime-source)"
-          echo "native_ime_source_changed=$NATIVE_IME_SOURCE_CHANGED" >> "$GITHUB_OUTPUT"
-          echo "Native IME source changed: $NATIVE_IME_SOURCE_CHANGED"
-          if [ "$TEST_FILES_JSON" != '[]' ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            echo "Changed E2E specs: $TEST_FILES_JSON"
-          else
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            echo "No changed E2E specs"
-          fi
-
   e2e:
     name: e2e
-    needs: e2e-paths
-    if: needs.e2e-paths.outputs.should_run == 'true'
+    needs: code_paths
+    if: needs.code_paths.outputs.e2e_should_run == 'true'
     # Why: reusable e2e.yml only checkouts, builds, and uploads artifacts.
     permissions:
       contents: read
@@ -928,8 +912,8 @@ jobs:
       # The synthetic pull-request merge ref can disappear while this reusable
       # workflow is queued. The head SHA is immutable and works for every PR.
       ref: ${{ github.event.pull_request.head.sha }}
-      test_files: ${{ needs.e2e-paths.outputs.test_files }}
-      ssh_source_changed: ${{ needs.e2e-paths.outputs.ssh_source_changed }}
+      test_files: ${{ needs.code_paths.outputs.test_files }}
+      ssh_source_changed: ${{ needs.code_paths.outputs.ssh_source_changed }}
 
   # Why this is not in verify's needs: it is the first PR-gate run of a harness whose reliability
   # is only known from nightly main runs (20/20 green, 2026-08-09..2026-08-29, p50 3m25s). It
@@ -939,8 +923,8 @@ jobs:
   # require `success || skipped` outside the strict loop — see the note on `e2e`.
   terminal_ime_native:
     name: real IME
-    needs: e2e-paths
-    if: needs.e2e-paths.outputs.native_ime_source_changed == 'true'
+    needs: code_paths
+    if: needs.code_paths.outputs.native_ime_source_changed == 'true'
     # Why: the reusable workflow only checks out, builds, and uploads artifacts.
     permissions:
       contents: read

--- a/.github/workflows/skill-update-roundtrip.yml
+++ b/.github/workflows/skill-update-roundtrip.yml
@@ -22,6 +22,10 @@ on:
       - main
     paths: *skill-roundtrip-paths
 
+concurrency:
+  group: skill-roundtrip-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   roundtrip:
     strategy:

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -414,10 +414,11 @@ describe('PR Checks skip wiring', () => {
   })
 
   it('skips e2e detection on docs-only PRs without dropping the draft gate', () => {
-    expect(prWorkflow.jobs['e2e-paths'].needs).toEqual(['code_paths'])
-    expect(prWorkflow.jobs['e2e-paths'].if).toBe(
-      "github.event.pull_request.draft != true && needs.code_paths.outputs.should_run == 'true'"
+    const filter = prWorkflow.jobs.code_paths.steps.find((step) => step.id === 'e2e_filter')
+    expect(filter.if).toBe(
+      "github.event.pull_request.draft != true && steps.filter.outputs.should_run == 'true'"
     )
+    expect(prWorkflow.jobs['e2e-paths']).toBeUndefined()
   })
 
   it('lets verify pass skipped jobs the classifier turned off', () => {

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -39,7 +39,7 @@ const nativeImeSpec = readFileSync(
   'utf8'
 )
 
-const filterStep = prWorkflow.jobs['e2e-paths'].steps.find(
+const filterStep = prWorkflow.jobs.code_paths.steps.find(
   (step) => step.name === 'Filter changed E2E specs'
 )
 const rollbackStep = prWorkflow.jobs.static_analysis.steps.find(
@@ -106,16 +106,16 @@ describe('PR E2E gate contract', () => {
     // Why: without this the job could lose its filter and run on every PR — the
     // cost the path filter exists to avoid — while the gate assertions above
     // stay green.
-    expect(prWorkflow.jobs.e2e.needs).toBe('e2e-paths')
-    expect(prWorkflow.jobs.e2e.if).toBe("needs.e2e-paths.outputs.should_run == 'true'")
-    expect(prWorkflow.jobs['e2e-paths'].outputs.should_run).toBe(
-      '${{ steps.filter.outputs.should_run }}'
+    expect(prWorkflow.jobs.e2e.needs).toBe('code_paths')
+    expect(prWorkflow.jobs.e2e.if).toBe("needs.code_paths.outputs.e2e_should_run == 'true'")
+    expect(prWorkflow.jobs.code_paths.outputs.e2e_should_run).toBe(
+      '${{ steps.e2e_filter.outputs.should_run }}'
     )
-    expect(prWorkflow.jobs['e2e-paths'].outputs.test_files).toBe(
-      '${{ steps.filter.outputs.test_files }}'
+    expect(prWorkflow.jobs.code_paths.outputs.test_files).toBe(
+      '${{ steps.e2e_filter.outputs.test_files }}'
     )
     expect(prWorkflow.jobs.e2e.with.ref).toBe('${{ github.event.pull_request.head.sha }}')
-    expect(prWorkflow.jobs.e2e.with.test_files).toBe('${{ needs.e2e-paths.outputs.test_files }}')
+    expect(prWorkflow.jobs.e2e.with.test_files).toBe('${{ needs.code_paths.outputs.test_files }}')
   })
 
   it('enforces every job verify depends on', () => {
@@ -360,11 +360,11 @@ describe('PR E2E gate contract', () => {
     expect(sshLaneCondition).toContain("inputs.ssh_source_changed == 'true' ||")
 
     expect(e2eWorkflow.on.workflow_call.inputs.ssh_source_changed.type).toBe('string')
-    expect(prWorkflow.jobs['e2e-paths'].outputs.ssh_source_changed).toBe(
-      '${{ steps.filter.outputs.ssh_source_changed }}'
+    expect(prWorkflow.jobs.code_paths.outputs.ssh_source_changed).toBe(
+      '${{ steps.e2e_filter.outputs.ssh_source_changed }}'
     )
     expect(prWorkflow.jobs.e2e.with.ssh_source_changed).toBe(
-      '${{ needs.e2e-paths.outputs.ssh_source_changed }}'
+      '${{ needs.code_paths.outputs.ssh_source_changed }}'
     )
     expect(filterStep.run).toContain('pr-e2e-source-routing.mjs --ssh-source')
     expect(filterStep.run).toContain('ssh_source_changed=$SSH_SOURCE_CHANGED')
@@ -565,12 +565,12 @@ describe('PR E2E gate contract', () => {
     expect(prWorkflow.jobs.terminal_ime_native.uses).toBe(
       './.github/workflows/terminal-ime-e2e.yml'
     )
-    expect(prWorkflow.jobs.terminal_ime_native.needs).toBe('e2e-paths')
+    expect(prWorkflow.jobs.terminal_ime_native.needs).toBe('code_paths')
     expect(prWorkflow.jobs.terminal_ime_native.if).toBe(
-      "needs.e2e-paths.outputs.native_ime_source_changed == 'true'"
+      "needs.code_paths.outputs.native_ime_source_changed == 'true'"
     )
-    expect(prWorkflow.jobs['e2e-paths'].outputs.native_ime_source_changed).toBe(
-      '${{ steps.filter.outputs.native_ime_source_changed }}'
+    expect(prWorkflow.jobs.code_paths.outputs.native_ime_source_changed).toBe(
+      '${{ steps.e2e_filter.outputs.native_ime_source_changed }}'
     )
     expect(filterStep.run).toContain('pr-e2e-source-routing.mjs --native-ime-source')
     expect(filterStep.run).toContain('native_ime_source_changed=$NATIVE_IME_SOURCE_CHANGED')

--- a/docs/reference/ci-runner-efficiency.md
+++ b/docs/reference/ci-runner-efficiency.md
@@ -1,0 +1,99 @@
+# CI efficiency and runner capacity
+
+Audit date: September 5, 2026. No paid capacity or provider configuration changed.
+
+## Measurements and changes
+
+Three recent successful PR runs used 54.6–64.9 aggregate runner minutes:
+[33998366568](https://github.com/stablyai/orca/actions/runs/33998366568),
+[33998220287](https://github.com/stablyai/orca/actions/runs/33998220287), and
+[33998181502](https://github.com/stablyai/orca/actions/runs/33998181502).
+These are sums of active job durations, excluding skipped jobs; they are not
+billing minutes or queue time. This small sample is not a historical average.
+
+- Consolidate E2E routing into the existing code-path detector. The removed
+  detector occupied 20–22 seconds and required another runner allocation and
+  full-history checkout per nondraft code PR. The same routing commands remain,
+  including SSH and native IME selection; actual E2E results remain advisory.
+  A routing-script error now fails the required code-path detector.
+- Use gzip for PR-only Debian/RPM artifacts. The two sampled Linux packaging
+  jobs took 8m10s and 8m19s overall; one spent 3m47s in electron-builder. Its
+  default Debian/RPM compression is xz. PR artifacts are inspected on the same
+  runner, so their download size offers no benefit. Keep all AppImage, Debian,
+  RPM, payload, launcher, and shutdown checks. Release compression is unchanged.
+  Compression savings need a hosted run; do not equate the full packaging step
+  with removable compression time.
+- Cancel superseded Mobile Checks and Skill update round-trip PR runs. The
+  skill matrix has 13 jobs. Preserve non-cancelling main/merge-group skill runs,
+  with separate concurrency groups per event.
+- Reuse the existing script-free root dependency action in Mobile Checks,
+  including the pnpm cache keyed by both root and mobile lockfiles. The root
+  install remains necessary because mobile types import root dependencies.
+
+The repository already has eight unit shards, path-scoped platform checks,
+native caches, one shared E2E build, PR cancellation, incremental TypeScript
+caching, and changed-spec E2E routing. Increasing shards would increase setup
+work and simultaneous runner demand. Do not adjust the count without comparing
+critical-path time and aggregate job time on the same commit.
+
+## Runner recommendations
+
+The repository is **public**, verified using the GitHub API. Standard
+GitHub-hosted Linux, Windows, and macOS runners have free compute minutes for
+public repositories. Queue pressure and third-party provider allowances still
+matter; artifact storage and larger runners have separate billing rules.
+See [GitHub Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions).
+
+1. Keep standard GitHub-hosted runners as the default. Ask GitHub Support for a
+   higher concurrent-job limit before paying for more capacity. The documented
+   standard limits depend on the account plan (Free: 20 total/5 macOS; Team:
+   60/5; Enterprise: 500/50), and increases are subject to approval. The actual
+   account entitlement was not verified. See [limits](https://docs.github.com/en/actions/reference/limits).
+2. Reserve existing Blacksmith allowance for macOS if that is the priority.
+   Blacksmith documents 3,000 free x64 2-vCPU-equivalent minutes per organization;
+   a 6-vCPU Mac minute consumes 20 equivalents, or 150 actual Mac minutes if
+   it uses the entire free pool. Cloud workflows also use Blacksmith Linux.
+   Moving Linux to hosted GitHub saves shared allowance, but does not necessarily
+   free Mac hardware capacity. Account-specific contracts and usage were not
+   inspected. See [Blacksmith runners](https://docs.blacksmith.sh/blacksmith-runners/overview).
+3. Treat Ubicloud as an optional small Linux overflow trial. Its documented
+   $2.50 monthly credit buys 1,250 premium 2-vCPU minutes at $0.002/minute, or
+   2,000 standard 2-vCPU minutes at $0.00125/minute. New accounts default to
+   premium and require a credit card. No enforceable hard spending cap was
+   verified, so changing runner labels cannot guarantee the no-spend constraint.
+   One PR's roughly 55–65 runner minutes also makes clear how small this pool
+   is relative to repository activity (hardware speeds differ).
+   See [pricing](https://ubicloud.com/docs/about/pricing) and
+   [setup](https://ubicloud.com/docs/github-actions-integration/quickstart).
+
+## Machines that also run coding agents
+
+Do not register the credentialed host directly as a public-PR runner. A PR can
+execute arbitrary build/test code, and a persistent host lets it access local
+credentials or affect subsequent jobs. Docker alone is not adequate isolation
+when it exposes the host home, Docker socket, SSH agent, or office network.
+
+A possible no-new-hardware experiment is a disposable VM per job, preferably on
+a dedicated spare machine, with a just-in-time single-job runner, no shared
+home/keychain/SSH agent or host mounts, restricted network access, and CPU/RAM
+limits that leave room for coding agents. Destroy the VM after every job;
+ephemeral runner registration by itself does not clean the machine. Start with
+trusted branch/manual workloads and keep public fork PRs on hosted runners.
+Provisioning and ongoing patching are real operational costs even when the
+machine is already owned. See GitHub's
+[self-hosted runner security guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions).
+
+## Release waits
+
+The latest successful sampled Windows release used 13m59s of a 21m56s job in
+signing wait/download steps. The same release held an Ubuntu job for 11m38s
+polling the isolated Mac build. These are stronger occupancy opportunities than
+small checkout savings, especially when approval takes hours.
+
+[Windows signing without occupying a runner](windows-signing-runner-time.md)
+describes a staged, same-run design, required protected environments, and
+rehearsal criteria. No callback integration or protected Windows signing
+environments currently exist. An environment-gated design adds a GitHub
+approval after each SignPath approval and changes the current automatic inner
+signing timeout fallback; those are explicit release-policy decisions, so this
+PR leaves production signing behavior unchanged.

--- a/docs/reference/windows-signing-runner-time.md
+++ b/docs/reference/windows-signing-runner-time.md
@@ -1,0 +1,137 @@
+# Windows signing without occupying a runner during approval
+
+Status: implementation proposal; production signing behavior is unchanged.
+
+## Measured cost
+
+In [release run 33821033674](https://github.com/stablyai/orca/actions/runs/33821033674)
+(September 4, 2026), the Windows job took 21m56s. The inner-binary download step
+took 13m19s and the installer download step took 40s: 13m59s, or 64% of the job,
+was spent in the signing download/wait steps. These durations include the
+download itself, so they are an upper bound on removable idle time, not a
+prediction of net savings after transferring state between jobs.
+
+`release-cut.yml` submits both requests with `wait-for-completion: false`, but
+then invokes `Get-SignedArtifact` on the same Windows runner with one-hour and
+four-hour completion timeouts. The six-hour job timeout accommodates both
+waits. Changing the submission flag again, polling less often, or running the
+wait inside a container does not release the runner slot.
+
+This is runner occupancy, not a billing estimate. Standard GitHub-hosted
+runners in a public repository may be free; removing the waits still releases
+concurrency for other work. Check actual billing before assigning dollar savings.
+
+The same release also occupied an Ubuntu runner for 11m38s while
+`run-release-mac-build-workflow.mjs` waited on the isolated macOS workflow.
+That is a separate orchestration optimization. Windows development-channel
+builds deliberately ship unsigned and have no SignPath wait to remove.
+
+## Proposed execution graph
+
+Keep all Windows stages in the original `release-cut.yml` run to preserve the
+current SignPath GitHub artifact provenance boundary:
+
+1. `build-windows` builds and uploads the unpacked app, original installer,
+   updater metadata, and inner-signing manifest. It submits the inner request,
+   sends the existing notification, exposes the request ID, and finishes.
+2. `package-windows` depends on that job and uses a protected environment named
+   `windows-inner-signing`. Its runner is allocated only after GitHub approval.
+   It restores the exact build, downloads the signed binaries with a short,
+   bounded completion wait, applies the existing signature restoration and
+   signed `elevate.exe` cache replacement, builds the NSIS installer, uploads it,
+   submits the second signing request, notifies approvers, and finishes.
+3. `finalize-windows` depends on packaging and uses a second protected environment
+   named `windows-installer-signing`. After approval it downloads the signed
+   installer, regenerates its blockmap and `latest.yml`, runs existing outer and
+   inner signature checks, uploads evidence, and uploads the assets to the draft.
+4. `publish-release` depends on finalization as well as the existing Linux, macOS,
+   and blocking release gates. It remains the only job that publishes the draft.
+
+The approver signs in SignPath, waits for that request to finish, and then
+approves the corresponding pending GitHub job. Each notification should link
+to both places and explain the order. GitHub approval is an extra action;
+approving in SignPath alone does not release an environment gate.
+
+## Required configuration
+
+The repository environments were inspected through the GitHub API on
+September 5, 2026. Neither Windows environment exists. `adhoc-mac-build` has no
+protection rules; it cannot be reused as an approval gate. No SignPath callback
+handler was found in the repository's workflows, scripts, application, or cloud
+code.
+
+Before enabling the graph:
+
+1. Create both environments in repository Settings → Environments.
+2. Add the release approvers as required reviewers for each environment. Decide
+   whether a release initiator may approve their own job, and configure that
+   consistently with the existing SignPath policy.
+3. Restrict deployment branches to the trusted refs used to dispatch release
+   workflows, and check that the release workflow's ref passes the restriction.
+   The workflow ref and the checked-out release tag are different concepts.
+4. Read back both environments through the API and verify that
+   `required_reviewers` rules exist before changing the release graph. Merely
+   referring to a new environment name in YAML can create an unprotected
+   environment and silently leave the wait on the runner.
+5. Add a preflight assertion for those rules so accidental removal fails before
+   any signing request is submitted. Verify the API access required for this
+   assertion using the release workflow's token; do not assume an administrator's
+   local `gh` access proves workflow-token access.
+
+An automatic alternative requires a SignPath completion callback and an
+authenticated integration that releases the corresponding deployment gate.
+Confirm the Foundation plan supports the necessary callback before choosing
+that architecture. Do not introduce a long-running GitHub polling job as the
+callback substitute: it would continue occupying a slot.
+
+## State and failure contracts
+
+- Use artifacts from this exact run and attempt, with a manifest containing the
+  tag, tag commit SHA, workflow SHA, request IDs, artifact IDs, and SHA-256 hashes.
+  Artifact names alone are insufficient. Preserve the original unsigned
+  installer for the existing inner-signing fallback.
+- Restore `dist/win-unpacked`, the staging list, the installer, and updater
+  metadata as one checkpoint. Use an archive to preserve the tree. Do not ship
+  a fresh rebuild of the app after approving a different binary tree.
+- Each new Windows runner needs the pinned Node/pnpm toolchain, build
+  dependencies, SignPath module, and electron-builder tool cache. The second
+  runner must populate the NSIS cache before replacing `elevate.exe`; the old
+  code assumes the first installer build already populated that cache.
+- Retain checkout-from-tag behavior and the existing support for release tags
+  that predate the composite action. Explicitly restore new orchestration code
+  from the workflow SHA when necessary.
+- Preserve the rule that rerunning a workflow never submits a new signing
+  request. A resume must consume the recorded request and artifacts. Test failed
+  stage reruns, whole-workflow reruns, and missing/expired checkpoints separately.
+- Keep installer signature checks blocking. Keep inner verification evidence
+  and its current warning-only policy unless changed in a separate decision.
+- Resolve the current one-hour inner-signing fallback deliberately: an
+  environment approval can remain pending longer than one hour and rejection
+  skips dependent jobs. It cannot reproduce the existing automatic timeout
+  fallback by itself. A first migration should explicitly document the new
+  manual release/cancellation behavior; silently treating rejected approval as
+  permission to ship is not acceptable.
+- Keep the release-wide concurrency lock while the graph waits, preventing
+  another release from overtaking this draft. This saves worker occupancy, but
+  does not shorten the serialized release queue's human approval time.
+
+## Validation before production
+
+First adapt `windows-signing-rehearsal.yml` to exercise the same staged code
+using the auto-approved test-signing policy. Then run a manual rehearsal with
+the protected environments and confirm that pending approval has no allocated
+Windows runner. Verify signed bytes through the existing extraction-based
+installer checks, not only the outer installer signature.
+
+Cover approval before SignPath completion, rejected approval, missing signed
+files, changed checkpoint hashes, lost checkpoints, expired artifacts, failed
+packaging, and stage reruns without duplicate submissions. Confirm no release
+becomes public until all platform and signature gates pass. Compare transferred
+artifact/setup time with the original 13m59s wait sample to measure net savings.
+
+A separate `workflow_dispatch` continuation can avoid environment provisioning,
+but changes this design substantially: the original release run finishes,
+workflow-level concurrency no longer protects the pending draft, and SignPath
+must accept artifacts assembled from a prior run. That option needs a durable
+release state machine and provenance validation before production use; it is
+not a drop-in replacement for the two download steps.


### PR DESCRIPTION
## ELI5

Reduce CI work and runner allocations without buying capacity: reuse PR change detection, cancel obsolete mobile/skill runs, cache mobile dependencies, and compress disposable Linux test packages faster.

## What Changed

- Move E2E/SSH/IME routing into the existing code-path detector, removing one queued job and full-history checkout per nondraft code PR. Keep the same selected tests, required check names, and advisory E2E execution. Routing-script errors now fail the required detector.
- Use gzip instead of xz for PR-only Debian/RPM packages. All artifact/payload/launcher/shutdown checks and release packaging settings remain in place.
- Cancel superseded mobile and skill round-trip PR runs; preserve non-cancelling main/merge-group skill runs.
- Reuse the existing dependency-install action in mobile CI, including its root/mobile pnpm cache and script-free root install.
- Document measured runner usage, no-new-spend runner options, and a staged Windows signing proposal with setup and validation requirements.

## Why

Three successful PR samples used 54.6–64.9 aggregate runner minutes. The redundant E2E detector took 20–22 seconds plus a separate allocation; Linux packaging spent 3m47s in electron-builder in one sample. In hosted run [33999422341](https://github.com/stablyai/orca/actions/runs/33999422341), the package-build step took **2m13s**, versus **3m47s / 4m07s** in the two baseline samples (94–114 seconds less). This is a small observational sample, not a controlled benchmark or a guarantee for every run.

The public repository already gets free standard GitHub compute minutes. Blacksmith has a separate shared allowance, and Ubicloud requires a card with no hard no-spend cap verified. Windows signing occupied 13m59s of a 21m56s release job in wait/download steps; the proposal explains how to free that runner, but requires approval configuration and a release-policy decision, so production signing is unchanged.

## Linked Issue

User-requested CI maintenance; no linked issue in this worktree.

## Visual Proof

N/A — CI workflows and documentation only.

## Testing

- [x] 109 targeted workflow/routing/dependency-action contract tests passed locally.
- [x] actionlint passed for all three changed workflows.
- [x] Targeted oxlint, oxfmt checks, and git diff whitespace checks passed.
- [x] Hosted Mobile Checks and all 13 skill round-trip matrix jobs passed.
- [x] Hosted Windows packaging passed.
- [x] Hosted Linux packaging passed every existing artifact/CLI/shutdown smoke check; full job **6m17s**, versus **8m10s / 8m19s** in baseline samples.
- [x] All eight unit shards and the required PR verification gate passed on `5f862be7cce65d15b2985330b22f5c71f71298ac`.
- [x] Git compatibility, cross-version wire compatibility, shell contracts, static analysis, and typechecking passed in hosted CI.

## Review

Cross-platform, SSH E2E selection, native IME selection, draft filtering, and release behavior considered. No application runtime or remote wire changes. No paid runners, account configuration, deployment, or signing requests added.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill implementation copied.
