### PR TITLE
test: order restart fixture readiness around daemon recovery

### DIFF
--- a/tests/e2e/paired-remote-terminal-host-restart-background-sync.spec.ts
+++ b/tests/e2e/paired-remote-terminal-host-restart-background-sync.spec.ts
@@ -283,6 +283,24 @@ async function expectTerminalInteractive(
 }
 
 async function moveHostAwayFromWorktree(page: Page, targetWorktreeId: string): Promise<string> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(async (targetId) => {
+          const state = window.__store?.getState()
+          const target = state?.allWorktrees().find((worktree) => worktree.id === targetId)
+          if (!state || !target) {
+            return false
+          }
+          await state.fetchWorktrees(target.repoId)
+          return window
+            .__store!.getState()
+            .allWorktrees()
+            .some((worktree) => worktree.repoId === target.repoId && worktree.id !== targetId)
+        }, targetWorktreeId),
+      { message: 'Seeded alternate host worktree never loaded' }
+    )
+    .toBe(true)
   const alternateWorktreeId = await page.evaluate((targetId) => {
     const state = window.__store?.getState()
     const alternate = state?.allWorktrees().find((worktree) => worktree.id !== targetId)
@@ -423,6 +441,9 @@ test('foregrounds a preserved daemon PTY after the paired host relaunches', asyn
     expect(reconnectControl.ptyId).not.toBe(target.ptyId)
     await openClientTab(client.page, worktreeId, reconnectControl.webTabId)
     await waitForPaneConnected(client.page, reconnectControl.webTabId)
+    await expect
+      .poll(() => readPaneContent(client!.page, reconnectControl.webTabId), { timeout: 30_000 })
+      .toContain('READY')
     await expectTerminalInteractive(client, reconnectControl, 'y')
   } finally {
     if (client) {

--- a/tests/e2e/restart-restore-terminal-input.spec.ts
+++ b/tests/e2e/restart-restore-terminal-input.spec.ts
@@ -239,7 +239,6 @@ test('restored pane recovers input after the daemon un-wedges', async (// oxlint
 
     const second = await session.launch()
     secondApp = second.app
-    await settleRestoredLaunch(second.page)
 
     // Field-fidelity check, not a hard gate: does the pane paint restored
     // content while its PTY attach cannot complete? That visible-but-dead
@@ -258,6 +257,8 @@ test('restored pane recovers input after the daemon un-wedges', async (// oxlint
     }
     stoppedDaemonPid = null
 
+    // Session readiness requires a daemon response; resume it before waiting for restoration.
+    await settleRestoredLaunch(second.page)
     await expectRestoredPaneAcceptsInput(
       second.page,
       `daemon wedged during relaunch (painted while wedged: ${paintedWhileWedged}, ` +


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Restart fixtures can read an incomplete alternate-worktree inventory or wait for daemon-dependent session readiness before sending SIGCONT. Refresh and await the alternate worktree, resume the daemon before waiting for restoration, and require the new reconnect-control terminal to emit READY before typing, matching the original target terminal. Existing daemon identity and input assertions remain.

Validation: two focused cases passed, then all four restart cases repeated twice with one worker: 8 passed. After adding the control READY wait, the full paired host-restart scenario passed twice again. oxfmt and oxlint passed. A concurrent run exposed a separate intermittent daemon replacement failure in both restart specs; these fixture changes do not resolve that observed behavior.
