### PR TITLE
fix: avoid starting browser helpers just to reset absent sessions

### DIFF
--- a/src/main/browser/agent-browser-bridge-execution.ts
+++ b/src/main/browser/agent-browser-bridge-execution.ts
@@ -176,7 +176,6 @@ export abstract class AgentBrowserBridgeExecution extends AgentBrowserBridgeTabs
   protected closeStaleAgentBrowserSession(sessionName: string): Promise<void> {
     if (
       canSkipAgentBrowserSessionReset({
-        platform: process.platform,
         ownsSocketDirectory: this.ownsAgentBrowserSocketDirectory,
         socketDirectory: this.agentBrowserEnv.AGENT_BROWSER_SOCKET_DIR,
         sessionName

--- a/src/main/browser/agent-browser-bridge-execution.ts
+++ b/src/main/browser/agent-browser-bridge-execution.ts
@@ -12,6 +12,7 @@ import {
 import { translateResult } from './agent-browser-bridge-result'
 import { AgentBrowserBridgeTabs } from './agent-browser-bridge-tabs'
 import { ORCA_TAB_SESSION_PREFIX } from './agent-browser-orphan-sweep'
+import { canSkipAgentBrowserSessionReset } from './agent-browser-session-reset'
 import {
   STALE_SESSION_CLOSE_TIMEOUT_MS,
   type AgentBrowserExecOptions,
@@ -173,6 +174,16 @@ export abstract class AgentBrowserBridgeExecution extends AgentBrowserBridgeTabs
   }
 
   protected closeStaleAgentBrowserSession(sessionName: string): Promise<void> {
+    if (
+      canSkipAgentBrowserSessionReset({
+        platform: process.platform,
+        ownsSocketDirectory: this.ownsAgentBrowserSocketDirectory,
+        socketDirectory: this.agentBrowserEnv.AGENT_BROWSER_SOCKET_DIR,
+        sessionName
+      })
+    ) {
+      return Promise.resolve()
+    }
     return new Promise((resolve, reject) => {
       let child: ReturnType<typeof execFile> | null = null
       let settled = false

--- a/src/main/browser/agent-browser-bridge-session-lifecycle.test.ts
+++ b/src/main/browser/agent-browser-bridge-session-lifecycle.test.ts
@@ -81,6 +81,14 @@ function closeCallCount(): number {
 describe('AgentBrowserBridge', () => {
   let bridge: AgentBrowserBridge
 
+  // The mocked fs has no mkdirSync, so the constructor never claims a socket directory itself.
+  function ownSocketDirectory(): void {
+    Object.assign(bridge, {
+      ownsAgentBrowserSocketDirectory: true,
+      agentBrowserEnv: { AGENT_BROWSER_SOCKET_DIR: '/tmp/orca-ab-test' }
+    })
+  }
+
   beforeEach(() => {
     resetAgentBrowserBridgeMocks({
       webContentsFromIdMock,
@@ -89,35 +97,28 @@ describe('AgentBrowserBridge', () => {
       stdinWrites,
       cdpWsProxyInstances: CdpWsProxyMock.instances
     })
+    // Default to a socket that exists so an unprepared test still takes the reset path.
+    lstatSyncMock.mockReset()
+    lstatSyncMock.mockReturnValue({})
     bridge = new AgentBrowserBridge(mockBrowserManager())
     bridge.setActiveTab(100)
   })
 
   it('snapshots a fresh owned session without launching a helper just to close it', async () => {
-    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
-    Object.assign(bridge, {
-      ownsAgentBrowserSocketDirectory: true,
-      agentBrowserEnv: { AGENT_BROWSER_SOCKET_DIR: '/tmp/orca-ab-test' }
-    })
+    ownSocketDirectory()
     lstatSyncMock.mockImplementation(() => {
       throw Object.assign(new Error('No socket'), { code: 'ENOENT' })
     })
     webContentsFromIdMock.mockReturnValue(mockWebContents(100))
     succeedWith({ snapshot: 'ready' })
 
-    try {
-      expect(await bridge.snapshot()).toMatchObject({ snapshot: 'ready' })
-      expect(closeCallCount()).toBe(0)
-    } finally {
-      vi.restoreAllMocks()
-    }
+    expect(await bridge.snapshot()).toMatchObject({ snapshot: 'ready' })
+    expect(closeCallCount()).toBe(0)
+    expect(lstatSyncMock).toHaveBeenCalledWith('/tmp/orca-ab-test/orca-tab-tab-1.sock')
   })
 
   it('fails closed when stale agent-browser session ownership cannot be reset', async () => {
-    Object.assign(bridge, {
-      ownsAgentBrowserSocketDirectory: true,
-      agentBrowserEnv: { AGENT_BROWSER_SOCKET_DIR: '/tmp/orca-ab-test' }
-    })
+    ownSocketDirectory()
     lstatSyncMock.mockReturnValue({})
     vi.useFakeTimers()
     try {

--- a/src/main/browser/agent-browser-bridge-session-lifecycle.test.ts
+++ b/src/main/browser/agent-browser-bridge-session-lifecycle.test.ts
@@ -1,18 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { execFileMock, webContentsFromIdMock, existsSyncMock, readFileSyncMock, stdinWrites } =
-  vi.hoisted(() => ({
-    execFileMock: vi.fn(),
-    webContentsFromIdMock: vi.fn(),
-    existsSyncMock: vi.fn(() => false),
-    readFileSyncMock: vi.fn(() => Buffer.from('')),
-    stdinWrites: [] as string[]
-  }))
+const {
+  execFileMock,
+  webContentsFromIdMock,
+  existsSyncMock,
+  readFileSyncMock,
+  lstatSyncMock,
+  stdinWrites
+} = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  webContentsFromIdMock: vi.fn(),
+  existsSyncMock: vi.fn(() => false),
+  readFileSyncMock: vi.fn(() => Buffer.from('')),
+  lstatSyncMock: vi.fn(),
+  stdinWrites: [] as string[]
+}))
 
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 vi.mock('fs', () => ({
   existsSync: existsSyncMock,
   readFileSync: readFileSyncMock,
+  lstatSync: lstatSyncMock,
   accessSync: vi.fn(),
   chmodSync: vi.fn(),
   constants: { X_OK: 1 }
@@ -85,7 +93,32 @@ describe('AgentBrowserBridge', () => {
     bridge.setActiveTab(100)
   })
 
+  it('snapshots a fresh owned session without launching a helper just to close it', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    Object.assign(bridge, {
+      ownsAgentBrowserSocketDirectory: true,
+      agentBrowserEnv: { AGENT_BROWSER_SOCKET_DIR: '/tmp/orca-ab-test' }
+    })
+    lstatSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('No socket'), { code: 'ENOENT' })
+    })
+    webContentsFromIdMock.mockReturnValue(mockWebContents(100))
+    succeedWith({ snapshot: 'ready' })
+
+    try {
+      expect(await bridge.snapshot()).toMatchObject({ snapshot: 'ready' })
+      expect(closeCallCount()).toBe(0)
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+
   it('fails closed when stale agent-browser session ownership cannot be reset', async () => {
+    Object.assign(bridge, {
+      ownsAgentBrowserSocketDirectory: true,
+      agentBrowserEnv: { AGENT_BROWSER_SOCKET_DIR: '/tmp/orca-ab-test' }
+    })
+    lstatSyncMock.mockReturnValue({})
     vi.useFakeTimers()
     try {
       const closeKill = vi.fn()

--- a/src/main/browser/agent-browser-session-reset.test.ts
+++ b/src/main/browser/agent-browser-session-reset.test.ts
@@ -6,27 +6,28 @@ vi.mock('node:fs', () => ({ lstatSync }))
 import { canSkipAgentBrowserSessionReset } from './agent-browser-session-reset'
 
 const owned = {
-  platform: 'darwin' as const,
   ownsSocketDirectory: true,
   socketDirectory: '/tmp/orca-ab-profile',
   sessionName: 'orca-tab-page'
 }
+const socketPath = join(owned.socketDirectory, 'orca-tab-page.sock')
 
 beforeEach(() => {
   lstatSync.mockReset()
 })
 
-it.each(['darwin', 'linux'] as const)('skips an absent owned socket on %s', (platform) => {
+it('skips an absent owned socket', () => {
   lstatSync.mockImplementation(() => {
     throw Object.assign(new Error('No socket'), { code: 'ENOENT' })
   })
-  expect(canSkipAgentBrowserSessionReset({ ...owned, platform })).toBe(true)
-  expect(lstatSync).toHaveBeenCalledWith(join(owned.socketDirectory, 'orca-tab-page.sock'))
+  expect(canSkipAgentBrowserSessionReset(owned)).toBe(true)
+  expect(lstatSync).toHaveBeenCalledWith(socketPath)
 })
 
 it('requires reset when a socket or symlink exists', () => {
   lstatSync.mockReturnValue({})
   expect(canSkipAgentBrowserSessionReset(owned)).toBe(false)
+  expect(lstatSync).toHaveBeenCalledWith(socketPath)
 })
 
 it.each(['EACCES', 'EIO', 'ENOTDIR'])('requires reset for %s', (code) => {
@@ -34,14 +35,15 @@ it.each(['EACCES', 'EIO', 'ENOTDIR'])('requires reset for %s', (code) => {
     throw Object.assign(new Error('Socket inspection failed'), { code })
   })
   expect(canSkipAgentBrowserSessionReset(owned)).toBe(false)
+  expect(lstatSync).toHaveBeenCalledWith(socketPath)
 })
 
+// Windows and inherited socket directories both arrive as ownsSocketDirectory: false.
 it.each([
-  { platform: 'win32' as const },
   { ownsSocketDirectory: false },
   { socketDirectory: undefined },
-  { socketDirectory: 'relative' },
   { sessionName: '../other' },
+  { sessionName: 'has space' },
   { sessionName: '' }
 ])('requires reset without an owned Unix socket address: %j', (override) => {
   expect(canSkipAgentBrowserSessionReset({ ...owned, ...override })).toBe(false)

--- a/src/main/browser/agent-browser-session-reset.test.ts
+++ b/src/main/browser/agent-browser-session-reset.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
+
+const { lstatSync } = vi.hoisted(() => ({ lstatSync: vi.fn() }))
+vi.mock('node:fs', () => ({ lstatSync }))
+import { canSkipAgentBrowserSessionReset } from './agent-browser-session-reset'
+
+const owned = {
+  platform: 'darwin' as const,
+  ownsSocketDirectory: true,
+  socketDirectory: '/tmp/orca-ab-profile',
+  sessionName: 'orca-tab-page'
+}
+
+beforeEach(() => {
+  lstatSync.mockReset()
+})
+
+it.each(['darwin', 'linux'] as const)('skips an absent owned socket on %s', (platform) => {
+  lstatSync.mockImplementation(() => {
+    throw Object.assign(new Error('No socket'), { code: 'ENOENT' })
+  })
+  expect(canSkipAgentBrowserSessionReset({ ...owned, platform })).toBe(true)
+  expect(lstatSync).toHaveBeenCalledWith(join(owned.socketDirectory, 'orca-tab-page.sock'))
+})
+
+it('requires reset when a socket or symlink exists', () => {
+  lstatSync.mockReturnValue({})
+  expect(canSkipAgentBrowserSessionReset(owned)).toBe(false)
+})
+
+it.each(['EACCES', 'EIO', 'ENOTDIR'])('requires reset for %s', (code) => {
+  lstatSync.mockImplementation(() => {
+    throw Object.assign(new Error('Socket inspection failed'), { code })
+  })
+  expect(canSkipAgentBrowserSessionReset(owned)).toBe(false)
+})
+
+it.each([
+  { platform: 'win32' as const },
+  { ownsSocketDirectory: false },
+  { socketDirectory: undefined },
+  { socketDirectory: 'relative' },
+  { sessionName: '../other' },
+  { sessionName: '' }
+])('requires reset without an owned Unix socket address: %j', (override) => {
+  expect(canSkipAgentBrowserSessionReset({ ...owned, ...override })).toBe(false)
+  expect(lstatSync).not.toHaveBeenCalled()
+})

--- a/src/main/browser/agent-browser-session-reset.ts
+++ b/src/main/browser/agent-browser-session-reset.ts
@@ -1,28 +1,30 @@
 import { lstatSync } from 'node:fs'
-import { basename, isAbsolute, join } from 'node:path'
+import { join } from 'node:path'
 
+// agent-browser's own session-name rule; doubles as a traversal fence for the `join` below.
+const SAFE_SESSION_NAME = /^[A-Za-z0-9_-]+$/
+
+/**
+ * True when no daemon can be holding `sessionName`, so closing it would only start one.
+ *
+ * Only an Orca-derived socket directory proves that (`ownsSocketDirectory`): it is a
+ * private per-profile `/tmp` directory, never an inherited one shared with a second
+ * profile, and never Windows, which uses named pipes and leaves no socket to inspect.
+ */
 export function canSkipAgentBrowserSessionReset(options: {
-  platform: NodeJS.Platform
   ownsSocketDirectory: boolean
   socketDirectory: string | undefined
   sessionName: string
 }): boolean {
   const { socketDirectory, sessionName } = options
-  if (
-    options.platform === 'win32' ||
-    !options.ownsSocketDirectory ||
-    !socketDirectory ||
-    !isAbsolute(socketDirectory) ||
-    !sessionName ||
-    basename(sessionName) !== sessionName
-  ) {
+  if (!options.ownsSocketDirectory || !socketDirectory || !SAFE_SESSION_NAME.test(sessionName)) {
     return false
   }
   try {
     lstatSync(join(socketDirectory, `${sessionName}.sock`))
     return false
   } catch (error) {
-    // An absent owned socket cannot be reused; permission and other failures prove nothing.
+    // Only a proven-absent socket is safe to skip; permission and other failures prove nothing.
     return (error as NodeJS.ErrnoException).code === 'ENOENT'
   }
 }

--- a/src/main/browser/agent-browser-session-reset.ts
+++ b/src/main/browser/agent-browser-session-reset.ts
@@ -1,0 +1,28 @@
+import { lstatSync } from 'node:fs'
+import { basename, isAbsolute, join } from 'node:path'
+
+export function canSkipAgentBrowserSessionReset(options: {
+  platform: NodeJS.Platform
+  ownsSocketDirectory: boolean
+  socketDirectory: string | undefined
+  sessionName: string
+}): boolean {
+  const { socketDirectory, sessionName } = options
+  if (
+    options.platform === 'win32' ||
+    !options.ownsSocketDirectory ||
+    !socketDirectory ||
+    !isAbsolute(socketDirectory) ||
+    !sessionName ||
+    basename(sessionName) !== sessionName
+  ) {
+    return false
+  }
+  try {
+    lstatSync(join(socketDirectory, `${sessionName}.sock`))
+    return false
+  } catch (error) {
+    // An absent owned socket cannot be reused; permission and other failures prove nothing.
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​85 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |

<!-- /orca-pr-loc -->

## ELI5

Orca's built-in browser uses a small background helper program to drive each tab. Before opening a tab, Orca would tidy up by telling that helper "close any leftover session with this name" — even when there was no leftover session at all. The catch is that saying "close it" to a helper that isn't running actually *starts* one first, just so it can be told to shut down. That wasted round trip took longer than the three seconds Orca allows, so the very first screenshot of a page could fail with an "owner unavailable" error instead of returning the picture.

Now Orca first glances at its own private folder to see whether a helper is really running for that tab. If there's nothing there, it skips the pointless cleanup and gets straight to work. If a helper is there — or if Orca can't be sure — it cleans up exactly as before.

## What Changed

- New `canSkipAgentBrowserSessionReset` (`src/main/browser/agent-browser-session-reset.ts`): returns true only when Orca owns the agent-browser socket directory and the session's `<session>.sock` is provably absent (`ENOENT`).
- `closeStaleAgentBrowserSession` returns early in that case instead of spawning `agent-browser --session <name> close`.
- Unit tests for the predicate, plus a lifecycle regression test that pins the exact probed socket path.

Every other case keeps the original unconditional reset: an existing socket, any non-`ENOENT` `lstat` failure (`EACCES`, `EIO`, `ENOTDIR`), an inherited `AGENT_BROWSER_SOCKET_DIR`, a session name outside agent-browser's own `[A-Za-z0-9_-]+` rule, and Windows (named pipes leave no socket to inspect — it arrives as `ownsSocketDirectory: false`).

## Why

A first snapshot of a rendered paired browser page could fail with `browser_owner_unavailable`: resetting an absent helper session starts a daemon purely so it can be closed. The observed reset exceeded the existing three-second `STALE_SESSION_CLOSE_TIMEOUT_MS`; an isolated fresh-session close measured 1.4s.

The check reuses the existing `ownsSocketDirectory` flag rather than inventing new ownership semantics — the same proof-of-exclusivity that already gates `sweepOrphanedAgentBrowserSessions`. It runs on the desktop hosting the guest webContents, against the same local filesystem the daemon would bind, and changes no remote protocol, RPC shape, or stream opcode.

The `<session>.sock` layout was verified against the `agent-browser` v0.27.0 binary's own string table (sidecar suffixes `.sock` / `.pid` / `.version` / `.stream` beside `src/native/daemon.rs`, plus its `"Session name '…' is too long. Socket path would be N bytes (max 103)"` error, which only makes sense if the session name is embedded verbatim in `sun_path`).

## Tradeoffs

Genuine, user-facing costs of this approach:

- **New coupling to an external CLI's private filesystem layout.** Orca now assumes agent-browser names its socket `<session>.sock` directly under `AGENT_BROWSER_SOCKET_DIR`. If a future agent-browser release renames or nests that file, `lstat` would always return `ENOENT` and Orca would *always* skip the reset — silently reintroducing the stale-daemon bug from #16367 (a replacement daemon ignores `--cdp` and dials a dead port). Nothing in CI runs the real binary here, so the regression would surface as flaky browser tabs, not a red test. This is the main risk in the PR.
- **A crash can leave a `.pid`/`.version`/`.stream` sidecar with the `.sock` already unlinked.** Orca would then skip a reset for a session whose sidecars still exist. `.sock` is the daemon's real liveness marker and agent-browser auto-cleans stale sidecars, so this should be benign, but it is a narrower liveness signal than "close it and see".
- **One extra `lstat` per session creation.** Negligible (a single stat on a local `/tmp` path), but it is new work on the tab-open path, and it runs even in the cases that then fall through to the full reset.
- **The win is unevenly distributed.** The skip only fires when that specific session has no socket. Opening tab N+1 while other tabs hold sockets still pays the full reset for its own (absent) session — which is fine — but users on Windows or with an inherited `AGENT_BROWSER_SOCKET_DIR` get no improvement at all and keep the original latency.
- **Behavioural divergence between platforms.** macOS/Linux and Windows now take different code paths for the same operation, so a first-snapshot timeout reproduces on Windows but not on macOS, making field reports harder to compare.

Not a tradeoff, checked: the early return skips no other work — `closeStaleAgentBrowserSession` only spawns the close subprocess and settles; it mutates no session map, no `pendingSessionDestruction`, and no intercept-restore state, and its sole caller (`agent-browser-bridge-lifecycle.ts`) simply awaits it before creating the CDP proxy.

## Linked Issue

Fixes #

## Visual Proof

`N/A` — no rendered UI changes. This removes a subprocess spawn on the tab-open path; the only observable difference is the absence of a `browser_owner_unavailable` error on a first snapshot, which has no distinct visual state to capture (the "after" is simply the page screenshot that already worked when the race did not fire). Per repo AGENTS.md, local Electron launches are paused for this change, so validation was done in CI and by unit/integration tests rather than a local app launch.

## Testing

- `pnpm test src/main/browser/agent-browser` — 10 files, 144 tests pass.
- `pnpm test` on the two changed files plus `agent-browser-process-environment` and `agent-browser-orphan-sweep` — 49 pass.
- Mutation check: forcing `canSkipAgentBrowserSessionReset` to always return `false` makes the lifecycle regression test fail, confirming it pins the fix rather than passing vacuously.
- `pnpm tc`, `oxlint`, and `oxfmt --check` on the changed files pass.
- Platforms: logic exercised on macOS locally; Windows and inherited-directory paths are covered by the `ownsSocketDirectory: false` branch, which an existing `agent-browser-process-environment.test.ts` case already ratchets.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Follow-up review pass tightened the original implementation:

- Dropped the `platform` and `isAbsolute` guards as provably dead — `createAgentBrowserProcessEnvironment` already returns `ownsSocketDirectory: false` for `win32` and for inherited directories, and an Orca-derived directory is always `/tmp/orca-ab-<hash>`. An existing test ratchets the Windows half.
- Folded the empty-name and path-traversal checks into a single regex matching agent-browser's own documented session-name rule.
- Fixed test-state leakage: `lstatSync` is now reset per test with an "exists" default, so an unprepared test still takes the reset path.
- The lifecycle regression test now asserts the exact probed path, so it cannot pass on an unwired mock via a real `ENOENT`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security**: the probed path is fenced by the session-name regex, so `join` cannot escape the Orca-owned 0700 directory. Non-`ENOENT` failures fail closed into the reset.
- **Cross-platform**: Windows keeps the original path unchanged.
- **Remote SSH / paired web**: no wire change. The bridge always spawns agent-browser locally on the host that owns the guest webContents, so the `lstat` inspects the same filesystem the daemon binds to.
- **Backwards compatibility**: no persisted state, schema, or serialized contract touched.
- **Performance**: replaces a process spawn with one `lstat` on the tab-open path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
