### PR TITLE
perf(ssh): reuse and release relay startup buffers

### DIFF
--- a/config/scripts/benchmark-sentinel-retention.mjs
+++ b/config/scripts/benchmark-sentinel-retention.mjs
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert'
+import { EventEmitter } from 'node:events'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'esbuild'
+
+if (!global.gc) {
+  throw new Error('Run with node --expose-gc')
+}
+const root = resolve(import.meta.dirname, '../..')
+const directory = await mkdtemp(join(tmpdir(), 'orca-sentinel-retention-'))
+const output = join(directory, 'sentinel.cjs')
+try {
+  await build({
+    stdin: {
+      contents: `export {waitForSentinel} from './src/main/ssh/ssh-relay-deploy-helpers';
+export {RELAY_SENTINEL} from './src/main/ssh/relay-protocol';`,
+      resolveDir: root,
+      loader: 'ts'
+    },
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    packages: 'external',
+    banner: {
+      js: `var require = require('node:module').createRequire(${JSON.stringify(join(root, 'package.json'))});`
+    },
+    outfile: output
+  })
+  const { waitForSentinel, RELAY_SENTINEL } = createRequire(import.meta.url)(output)
+  const held = []
+  const banners = []
+  for (let i = 0; i < 100; i++) {
+    const channel = Object.assign(new EventEmitter(), {
+      stderr: new EventEmitter(),
+      stdin: { write: () => true },
+      close: () => {}
+    })
+    const pending = waitForSentinel(channel)
+    banners.push(feedBanner(channel))
+    channel.emit('data', Buffer.from(RELAY_SENTINEL))
+    const transport = await pending
+    const received = []
+    transport.onData((bytes) => received.push(bytes.toString()))
+    channel.emit('data', Buffer.from('frame'))
+    assert.deepEqual(received, ['frame'])
+    held.push({ channel, transport })
+  }
+  await new Promise((resolve) => setImmediate(resolve))
+  for (let i = 0; i < 5; i++) {
+    global.gc()
+  }
+  const retained = banners.filter((reference) => reference.deref() !== undefined).length
+  console.log(
+    JSON.stringify({
+      connections: held.length,
+      bannerBytes: 65536,
+      retainedBannerBuffers: retained,
+      retainedBannerBytes: retained * 65536
+    })
+  )
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}
+
+function feedBanner(channel) {
+  const banner = Buffer.alloc(65536, 120)
+  channel.emit('data', banner)
+  return new WeakRef(banner.buffer)
+}

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -258,7 +258,7 @@ export function waitForSentinel(
         return
       }
 
-      bufferedStdout = bufferedStdout.length === 0 ? data : Buffer.concat([bufferedStdout, data])
+      bufferedStdout = startupStdout
     })
   })
 }

--- a/src/main/ssh/ssh-relay-deploy-helpers.ts
+++ b/src/main/ssh/ssh-relay-deploy-helpers.ts
@@ -209,6 +209,7 @@ export function waitForSentinel(
         const afterSentinelOffset =
           sentinelIdx + RELAY_SENTINEL_BUFFER.length - bufferedStdout.length
         const afterSentinel = data.subarray(Math.max(0, afterSentinelOffset))
+        bufferedStdout = Buffer.alloc(0)
 
         if (afterSentinel.length > 0) {
           pendingAfterSentinel = afterSentinel

--- a/src/main/ssh/ssh-relay-sentinel-copy-budget.test.ts
+++ b/src/main/ssh/ssh-relay-sentinel-copy-budget.test.ts
@@ -1,0 +1,62 @@
+import { EventEmitter } from 'node:events'
+import type { ClientChannel } from 'ssh2'
+import { expect, it, vi } from 'vitest'
+import { RELAY_SENTINEL } from './relay-protocol'
+import { waitForSentinel } from './ssh-relay-deploy-helpers'
+
+it.each([1, 256])('copies each startup prefix once across %i chunks', async (chunks) => {
+  const channel = Object.assign(new EventEmitter(), {
+    stderr: new EventEmitter(),
+    stdin: { write: vi.fn(() => true) },
+    close: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
+  })
+  const pending = waitForSentinel(channel as unknown as ClientChannel)
+  const chunk = Buffer.alloc((64 * 1024) / chunks, 120)
+  const concat = vi.spyOn(Buffer, 'concat')
+  let calls = 0
+  let copied = 0
+  try {
+    for (let i = 0; i < chunks; i++) {
+      channel.emit('data', chunk)
+    }
+    calls = concat.mock.calls.length
+    copied = concat.mock.calls.reduce(
+      (sum, [buffers]) => sum + buffers.reduce((bytes, buffer) => bytes + buffer.length, 0),
+      0
+    )
+  } finally {
+    concat.mockRestore()
+  }
+  channel.emit('data', Buffer.from(`${RELAY_SENTINEL}first-frame`))
+  const transport = await pending
+  const received: string[] = []
+  transport.onData((bytes) => received.push(bytes.toString()))
+  expect(received).toEqual(['first-frame'])
+  expect(channel.close).not.toHaveBeenCalled()
+  expect(calls).toBe(chunks - 1)
+  expect(copied).toBe(chunk.length * ((chunks * (chunks + 1)) / 2 - 1))
+})
+
+it.each(Array.from({ length: RELAY_SENTINEL.length + 1 }, (_, i) => i))(
+  'preserves the marker and binary payload when split at byte %i',
+  async (split) => {
+    const channel = Object.assign(new EventEmitter(), {
+      stderr: new EventEmitter(),
+      stdin: { write: vi.fn(() => true) },
+      close: vi.fn()
+    })
+    const pending = waitForSentinel(channel as unknown as ClientChannel)
+    const marker = Buffer.from(RELAY_SENTINEL)
+    const payload = Buffer.from([0, 255, 128, 10, 13, 1])
+    channel.emit('data', Buffer.alloc(63 * 1024, 120))
+    channel.emit('data', marker.subarray(0, split))
+    channel.emit('data', Buffer.concat([marker.subarray(split), payload]))
+    const transport = await pending
+    const received: Buffer[] = []
+    transport.onData((bytes) => received.push(bytes))
+    expect(Buffer.concat(received)).toEqual(payload)
+    expect(channel.close).not.toHaveBeenCalled()
+  }
+)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /orca-pr-loc -->

SSH relay startup collects banner bytes until the ready marker arrives. Each nonmatching chunk previously joined the accumulated prefix twice: once to search, then again to retain identical bytes for the next chunk. Reuse the buffer already built for the search, then release the startup prefix on the sentinel path once the relay is ready. Previously, the ready transport’s data handler kept that obsolete banner allocation alive for the connection lifetime.

ELI5: stop photocopying the same startup message twice. Keep the first copy for the next piece of the message, then throw the startup message away once the connection is ready.

The existing cap check guarantees that, on the retained-prefix path, the searched buffer contains the entire incoming chunk. Marker detection, the 64 KiB cap, timeout/error precedence, and post-marker byte delivery keep their current behavior. After calculating the post-marker offset, clear the startup prefix reference. Release happens only on the sentinel path; the timeout, abort, error, and cap-fail settlements do not clear it, so those paths retain up to 64 KiB in the data-handler closure until the channel is torn down (which happens anyway on those paths). Pending frame bytes remain separately owned and are delivered intact.

Deterministic measurements from the actual `waitForSentinel` with an EventEmitter channel, counting Buffer.concat calls and their input bytes before marker delivery:

| 64 KiB startup banner | Before | After |
|---|---:|---:|
| 256 chunks: prefix joins | 510 | 255 |
| 256 chunks: bytes copied by joins | 16,842,240 | 8,421,120 |
| One chunk: prefix joins / copied bytes | 0 / 0 | 0 / 0 |

This halves prefix-copy allocations and bytes for fragmented startup noise. These are allocation/copy counts, not measured connection-latency or network-throughput improvements. The zero-banner path is unchanged.

Forced-GC measurement of 100 ready connections, each with a 64 KiB banner:

| Ready transports retained after GC | Before | After |
|---|---:|---:|
| Startup banner backing allocations | 100 | 0 |
| Startup banner backing bytes | 6,553,600 | 0 |

The benchmark uses the bundled production function and WeakRefs to the ArrayBuffers, preserving the live channels and transports. It verifies later frame delivery too. These are controlled maximum-banner measurements, not a claim that typical connections retain 64 KiB.

Validation: 98 tests across five suites pass; node typecheck, lint, and formatting pass. The allocation regression fails against the original production code (510 versus the 255 budget) and passes with the fix. Tests exercise every marker split position, exact binary payload delivery, marker at the 64 KiB boundary, cap rejection, abort/error/timeout behavior, and multiplexer backpressure/settlement.

Reproduce:

```sh
pnpm test src/main/ssh/ssh-relay-sentinel-copy-budget.test.ts src/main/ssh/ssh-relay-deploy-helpers.test.ts src/main/ssh/ssh-channel-multiplexer.test.ts src/main/ssh/ssh-channel-multiplexer-backpressure.test.ts src/main/ssh/ssh-channel-multiplexer-settlement.test.ts
pnpm tc:node
node --expose-gc config/scripts/benchmark-sentinel-retention.mjs
```

Negative user-facing trade-offs:
- None identified: this removes a redundant copy and releases obsolete startup bytes on the sentinel path without adding caching, delays, thresholds, or new limits.
- No data dropping, timeout reduction, endpoint selection change, or additional network requests.

The client-side buffer is independent of Git provider, folder/worktree type, and remote OS. No SSH command, RPC schema, frame, sentinel, version negotiation, or remote-process liveness judgment changes. Validation uses controlled channels on macOS; native Windows/Linux and live SSH latency are unmeasured. No app launch is needed for this transport-only change.

