### PR TITLE
test: keep artifact share fixtures unexpired across calendar dates

### DIFF
--- a/src/main/artifacts/artifact-cloud-recovery.test.ts
+++ b/src/main/artifacts/artifact-cloud-recovery.test.ts
@@ -336,7 +336,7 @@ function createResponseBody(slug: string): object {
       renderedContentType: 'text/html',
       createdAt: '2026-08-06T00:00:00.000Z',
       updatedAt: '2026-08-06T00:00:00.000Z',
-      expiresAt: '2026-09-06T00:00:00.000Z',
+      expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
       byteSize: 17,
       deletedAt: null
     },

--- a/src/main/artifacts/artifact-cloud-service-races.test.ts
+++ b/src/main/artifacts/artifact-cloud-service-races.test.ts
@@ -33,7 +33,7 @@ function createResponse(slug: string): Response {
         renderedContentType: 'text/html',
         createdAt: '2026-08-06T00:00:00.000Z',
         updatedAt: '2026-08-06T00:00:00.000Z',
-        expiresAt: '2026-09-06T00:00:00.000Z',
+        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
         byteSize: 12,
         deletedAt: null
       },

--- a/src/main/artifacts/artifact-cloud-service.test.ts
+++ b/src/main/artifacts/artifact-cloud-service.test.ts
@@ -43,7 +43,10 @@ const cloudB: OrcaProfileCloudSummary = {
   linkedAt: 2
 }
 
-function createResponse(slug = 'artifact-a', expiresAt = '2026-09-06T00:00:00.000Z'): Response {
+function createResponse(
+  slug = 'artifact-a',
+  expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+): Response {
   return new Response(
     JSON.stringify({
       artifact: {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Artifact service fixtures expired at midnight UTC on September 6, 2026. Reuse and race tests then lost their stored share mappings before reaching the behavior they exercise. Give ordinary response fixtures an expiry 30 days after creation; the explicit fake-clock expiry test keeps its fixed dates.

Validation: reproduced 11 failures across the three affected files; all 64 artifact tests now pass. oxfmt and oxlint passed. Test-only change.
