### PR TITLE
perf(ssh): reuse streamed response idle timers

### DIFF
--- a/src/main/ssh/ssh-file-stream-inactivity-deadline.test.ts
+++ b/src/main/ssh/ssh-file-stream-inactivity-deadline.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createSshFileStreamInactivityDeadline } from './ssh-file-stream-inactivity-deadline'
+import type { SystemPowerLifecycleListener } from '../system-power-lifecycle'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+})
+
+describe('SSH file stream inactivity timer', () => {
+  it('reuses one timer while retaining the deadline of the latest chunk', () => {
+    vi.useFakeTimers()
+    const allocate = vi.spyOn(globalThis, 'setTimeout')
+    const onTimeout = vi.fn()
+    const unsubscribe = vi.fn()
+    const deadline = createSshFileStreamInactivityDeadline(onTimeout, (listener) => {
+      listener.onResume()
+      return unsubscribe
+    })
+    deadline.reset()
+    vi.advanceTimersByTime(30_000)
+    for (let chunk = 0; chunk < 1000; chunk += 1) {
+      deadline.reset()
+    }
+    expect(allocate).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(59_999)
+    expect(onTimeout).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    deadline.clear()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('releases on suspend and creates a fresh timer on resume', () => {
+    vi.useFakeTimers()
+    const allocate = vi.spyOn(globalThis, 'setTimeout')
+    const onTimeout = vi.fn()
+    let power!: SystemPowerLifecycleListener
+    const deadline = createSshFileStreamInactivityDeadline(onTimeout, (listener) => {
+      power = listener
+      listener.onResume()
+      return vi.fn()
+    })
+    deadline.reset()
+    vi.advanceTimersByTime(30_000)
+    power.onSuspend()
+    for (let chunk = 0; chunk < 1000; chunk += 1) {
+      deadline.reset()
+    }
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(120_000)
+    expect(onTimeout).not.toHaveBeenCalled()
+    power.onResume()
+    expect(allocate).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(59_999)
+    expect(onTimeout).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onTimeout).toHaveBeenCalledTimes(1)
+    deadline.clear()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('clears the timer and subscription and supports a later reset', () => {
+    vi.useFakeTimers()
+    const onTimeout = vi.fn()
+    const unsubscribe = vi.fn()
+    const subscribe = vi.fn((listener: SystemPowerLifecycleListener) => {
+      listener.onResume()
+      return unsubscribe
+    })
+    const deadline = createSshFileStreamInactivityDeadline(onTimeout, subscribe)
+    deadline.reset()
+    deadline.clear()
+    deadline.clear()
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+    vi.advanceTimersByTime(120_000)
+    expect(onTimeout).not.toHaveBeenCalled()
+    deadline.reset()
+    expect(subscribe).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(1)
+    deadline.clear()
+    expect(unsubscribe).toHaveBeenCalledTimes(2)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
+++ b/src/main/ssh/ssh-file-stream-inactivity-deadline.ts
@@ -24,8 +24,11 @@ export function createSshFileStreamInactivityDeadline(
     }
   }
   const arm = (): void => {
-    clearTimer()
     if (suspended) {
+      return
+    }
+    if (timer) {
+      timer.refresh()
       return
     }
     timer = setTimeout(onTimeout, SSH_FILE_STREAM_INACTIVITY_TIMEOUT_MS)

--- a/src/main/ssh/ssh-git-response-stream-reader.ts
+++ b/src/main/ssh/ssh-git-response-stream-reader.ts
@@ -90,7 +90,10 @@ export function requestGitStreamable(
     // killed, but a wedged stream (no frames arriving) rejects instead of
     // hanging the caller forever.
     const armInactivity = (): void => {
-      clearInactivity()
+      if (inactivityTimer) {
+        inactivityTimer.refresh()
+        return
+      }
       inactivityTimer = setTimeout(() => {
         fail(
           new GitResponseStreamError(

--- a/src/main/ssh/ssh-git-stream-idle-timer.test.ts
+++ b/src/main/ssh/ssh-git-stream-idle-timer.test.ts
@@ -1,0 +1,80 @@
+import { expect, it, vi } from 'vitest'
+import type { SshChannelMultiplexer } from './ssh-channel-multiplexer'
+import { requestGitStreamable } from './ssh-git-response-stream-reader'
+
+it.each(['end', 'abort', 'timeout'] as const)(
+  'reuses the idle deadline across 1000 chunks and cleans up on %s',
+  async (finish) => {
+    vi.useFakeTimers()
+    const setTimer = vi.spyOn(globalThis, 'setTimeout')
+    try {
+      const listeners = new Map<string, (params: Record<string, unknown>) => void>()
+      const controller = new AbortController()
+      const content = 'x'.repeat(998)
+      const encoded = Buffer.from(JSON.stringify(content))
+      const notify = vi.fn()
+      const mux = {
+        request: vi.fn(async () => ({
+          __orcaGitResponseStream: { streamId: 7, totalBytes: encoded.length, chunkCount: 1000 }
+        })),
+        isDisposed: () => false,
+        notify,
+        onDispose: () => () => {},
+        onNotificationByMethod: (
+          method: string,
+          callback: (params: Record<string, unknown>) => void
+        ) => {
+          listeners.set(method, callback)
+          return () => listeners.delete(method)
+        }
+      }
+      const promise = requestGitStreamable(
+        mux as unknown as SshChannelMultiplexer,
+        'git.diff',
+        {},
+        {
+          signal: controller.signal
+        }
+      )
+      const outcome = promise.then(
+        (value) => ({ value }),
+        (error: Error) => ({ error: error.message })
+      )
+      await vi.advanceTimersByTimeAsync(15_000)
+      for (let seq = 0; seq < encoded.length; seq++) {
+        listeners.get('git.responseChunk')!({
+          streamId: 7,
+          seq,
+          data: encoded.subarray(seq, seq + 1).toString('base64')
+        })
+      }
+      await vi.advanceTimersByTimeAsync(29_999)
+      expect(listeners.size).toBe(3)
+      expect(notify.mock.calls.filter(([method]) => method === 'git.responseAck')).toHaveLength(
+        1000
+      )
+      const allocations = setTimer.mock.calls.filter(([, delay]) => delay === 30_000).length
+      if (finish === 'end') {
+        listeners.get('git.responseEnd')!({ streamId: 7 })
+        expect(await outcome).toEqual({ value: content })
+      } else if (finish === 'abort') {
+        controller.abort()
+        expect(await outcome).toEqual({ error: 'Request was cancelled' })
+      } else {
+        await vi.advanceTimersByTimeAsync(1)
+        expect(await outcome).toEqual({
+          error: 'Git response stream stalled (>30000ms without data)'
+        })
+      }
+      expect(allocations).toBe(1)
+      expect(vi.getTimerCount()).toBe(0)
+      expect(listeners.size).toBe(0)
+      expect(
+        notify.mock.calls.filter(([method]) => method === 'git.cancelResponseStream')
+      ).toHaveLength(finish === 'end' ? 0 : 1)
+    } finally {
+      setTimer.mockRestore()
+      vi.useRealTimers()
+    }
+  }
+)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​167 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​167 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

SSH Git and file-response readers slide an inactivity deadline forward whenever a chunk arrives. They previously canceled and allocated a new Node timer for each chunk. Reuse the existing timer with `refresh()` while it is armed.

ELI5: move the alarm forward when data arrives instead of throwing away the alarm clock and making a new one every time.

The Git reader retains its configurable 30-second default. The filesystem reader retains its 60-second deadline and power-lifecycle subscription: suspend clears the timer, resets during suspend create none, and resume starts a fresh deadline. Completion/error/disposal cleanup and timer `unref` behavior are unchanged. The two existing deadline implementations remain separate because their timeout and power semantics differ.

Deterministic before/after measurements:

| Scenario | Before timer allocations | After |
|---|---:|---:|
| Actual Git reader: initial marker + 1,000 one-byte chunks | 1,001 | 1 |
| File deadline: initial reset + 1,000 resets | 1,002 | 1 |
| File deadline: suspend then resume | 3 | 2 |

The extra initial filesystem allocation came from the power subscription synchronously reporting the current awake state, followed by the caller arming again. Both operations now share a timer. These counts measure avoided allocations, not network throughput, battery life, or lower transfer latency.

Validation: 27 tests across six suites passed, including six new lifecycle tests, provider streaming, and actual relay Git/large-response integration. Node typecheck, lint, and formatting pass. All three Git allocation cases fail against the original implementation; two filesystem allocation assertions fail against the original helper. Tests confirm exact Git data and ACK counts, survival past the original deadline, timeout at the refreshed deadline, cancellation, zero remaining timers/listeners, legacy fallback, strict stream checks, resume grace, and metadata arriving while suspended. Existing relay integration retains interactive PTY echo and exact result reassembly under bulk transfer.

Reproduce:

```sh
pnpm test src/main/ssh/ssh-file-stream-inactivity-deadline.test.ts src/main/ssh/ssh-git-stream-idle-timer.test.ts src/main/ssh/ssh-git-response-stream-reader.test.ts src/main/providers/ssh-filesystem-provider-stream.test.ts src/relay/git-response-pty-echo-backpressure.integration.test.ts src/relay/fs-list-files-large-response.integration.test.ts
pnpm tc:node
```

Negative user-facing trade-offs:
- None identified: deadlines, cancellation, sleep/resume behavior, stream content/order, and cleanup remain intact.
- No changed polling frequency, shorter timeout, dropped data, new cache, or additional network requests.

Changes run in the desktop's Node process; they add no host command or Git option. Native/WSL/SSH hosts, folder workspaces, and Git providers retain the same protocol and execution boundaries. No RPC or wire change, remote version requirement, or process-liveness judgment changes. Tests use controlled transport/power events and local relay integration on macOS; physical sleep, live SSH throughput, and native Windows/Linux execution are unmeasured. No app windows or GitHub issues were opened.
