### PR TITLE
fix(relay): abandon dead client accepts, jitter and lengthen the control lease, fail direct probes fast

### DIFF
--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -314,8 +314,10 @@ describe('control lease jitter', () => {
     expect(centeredAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS)
     expect(longestAck.leaseExpiresAt).toBeLessThan(now + CONTROL_LEASE_MS + CONTROL_LEASE_JITTER_MS)
     // The mean grant is unchanged, so steady-state rebind load is unchanged;
-    // hosts that connected together now differ by minutes, not zero.
-    expect(longestAck.leaseExpiresAt - shortestAck.leaseExpiresAt).toBeGreaterThan(9 * 60 * 1000)
+    // hosts that connected together now differ by most of the jitter band, not zero.
+    expect(longestAck.leaseExpiresAt - shortestAck.leaseExpiresAt).toBeGreaterThan(
+      CONTROL_LEASE_JITTER_MS
+    )
     shortest.registry.drain(0)
     centered.registry.drain(0)
     longest.registry.drain(0)

--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -1,0 +1,345 @@
+import { EventEmitter } from 'node:events'
+import { RELAY_CLOSE_CODE } from '@orca-cloud/relay-contract'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type WebSocket from 'ws'
+import type { RelayAssignmentStore } from './assignment-store.js'
+import type { RelayConfig } from './config.js'
+import type { CredentialReservation, RelayCredentialStore } from './credential-store.js'
+import {
+  CONTROL_LEASE_JITTER_MS,
+  CONTROL_LEASE_MS,
+  HostSessionRegistry
+} from './host-session-registry.js'
+import type { RelayRuntimeObserver } from './relay-observability.js'
+import type { RelayTokenClaims } from './relay-token-verifier.js'
+import { ProcessQueuedByteBudget } from './splice-forwarder.js'
+
+// Incident 2026-09-04 ~01:05Z: the phone's dial bound ran out while the cell was
+// still inside acceptClient's serialized Postgres phase (cell-inventory lock
+// contention). The cell then finished the work for a socket nobody held, leaked
+// a 90s activity lease, and logged `host_data_reservation_already_bound`.
+
+class FakeSocket extends EventEmitter {
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+  readyState = this.OPEN
+  readonly send = vi.fn()
+  readonly close = vi.fn((code?: number, reason?: string) => {
+    this.readyState = this.CLOSED
+    this.emit('close', code, Buffer.from(reason ?? ''))
+  })
+  readonly terminate = vi.fn(() => {
+    this.readyState = this.CLOSED
+    this.emit('close')
+  })
+}
+
+const config = {
+  port: 8080,
+  publicUrl: 'https://relay-c3.example.com',
+  cellUrl: 'https://relay-c3.example.com',
+  authIssuer: 'https://auth.example.com',
+  authAudience: 'orca-relay',
+  jwksUrl: 'https://auth.example.com/jwks',
+  assignmentSigningKey: new Uint8Array(32),
+  role: 'cell',
+  cellId: 'production-gce-c3',
+  cells: [{ id: 'production-gce-c3', url: 'https://relay-c3.example.com', capacityRequests: 4_000 }],
+  adminAudience: 'https://relay-c3.example.com/v1/admin/drain',
+  deployServiceAccount: 'deploy@example.com',
+  runtimeServiceAccount: 'runtime@example.com',
+  adminJwksUrl: 'https://auth.example.com/admin-jwks',
+  databasePoolMax: 10,
+  publicAssignmentsEnabled: true,
+  publicAssignmentConcurrency: 2,
+  publicAssignmentQueueMax: 128,
+  publicAssignmentWaitMs: 4_000,
+  publicResolveConcurrency: 1,
+  publicResolveWaitMs: 5_000,
+  publicAssignmentRetryAfterSeconds: 5,
+  dataDir: './test-data'
+} satisfies RelayConfig
+
+const identity = {
+  sub: 'user-1',
+  prof: 'profile-1',
+  relayHostId: 'abcdefghijklmnop',
+  purpose: 'host-control',
+  exp: 4_102_444_800
+} satisfies RelayTokenClaims
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => (resolve = next))
+  return { promise, resolve }
+}
+
+const reservation: CredentialReservation = {
+  userId: identity.sub,
+  relayHostId: identity.relayHostId,
+  credentialKind: 'resume',
+  relayDeviceId: 'device-1',
+  tokenHash: 'hash',
+  reservationId: 'reservation-1',
+  leaseExpiresAt: Date.now() + 60_000,
+  acceptedCredentialVersion: 2,
+  acceptedAs: 'current'
+}
+
+function harness(options: { random?: () => number; now?: () => number } = {}) {
+  const acquireActivity = vi.fn().mockResolvedValue(undefined)
+  const releaseActivity = vi.fn().mockResolvedValue(true)
+  const assignments = {
+    activateControl: vi.fn().mockResolvedValue('control:production-gce-c3:1'),
+    markMigrationTargetRegistered: vi.fn().mockResolvedValue(undefined),
+    resolve: vi.fn().mockResolvedValue({ cellId: config.cellId }),
+    acquireActivity,
+    renewControlActivity: vi.fn().mockResolvedValue(undefined),
+    releaseActivity
+  } as unknown as RelayAssignmentStore
+  const store = {
+    resolveResume: vi.fn().mockResolvedValue({ userId: identity.sub }),
+    reserveCredential: vi.fn().mockResolvedValue(reservation),
+    failReservation: vi.fn().mockResolvedValue(undefined)
+  }
+  const observer = {
+    recordAuth: vi.fn(),
+    recordForwardedBytes: vi.fn(),
+    recordHttp: vi.fn(),
+    recordReconnect: vi.fn(),
+    recordSql: vi.fn(),
+    recordClientAcceptAbandoned: vi.fn()
+  } satisfies RelayRuntimeObserver
+  const registry = new HostSessionRegistry(
+    config,
+    vi.fn(),
+    store as unknown as RelayCredentialStore,
+    assignments,
+    new ProcessQueuedByteBudget(),
+    observer,
+    options.now,
+    options.random
+  )
+  const activate = (
+    registry as unknown as {
+      activate: (
+        socket: WebSocket,
+        identity: RelayTokenClaims,
+        existing: null,
+        generation: number,
+        rebind: boolean,
+        assignmentEpoch: number,
+        appVersion: string
+      ) => Promise<void>
+    }
+  ).activate.bind(registry)
+  return { registry, store, assignments, acquireActivity, releaseActivity, observer, activate }
+}
+
+async function activeHost(h: ReturnType<typeof harness>): Promise<FakeSocket> {
+  const control = new FakeSocket()
+  await h.activate(control as unknown as WebSocket, identity, null, 1, false, 1, '1.4.197')
+  return control
+}
+
+describe('client accept abandoned mid-DB-phase', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('stops after a slow activity acquire when the phone already hung up', async () => {
+    const h = harness()
+    const control = await activeHost(h)
+    const slowAcquire = deferred<void>()
+    h.acquireActivity.mockReturnValueOnce(slowAcquire.promise)
+    const capacity = { bind: vi.fn(), release: vi.fn() }
+    const client = new FakeSocket()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const accepting = h.registry.acceptClient(
+        client as unknown as WebSocket,
+        identity.relayHostId,
+        'credential',
+        capacity
+      )
+      await vi.advanceTimersByTimeAsync(0)
+      expect(h.acquireActivity).toHaveBeenCalledOnce()
+      // The phone's 12s bound fires while the cell still waits on Postgres.
+      client.close(1000, 'client bound')
+      capacity.release()
+      slowAcquire.resolve()
+      await accepting
+
+      // No conn-open reached the desktop; nothing pending; the lease it just took is
+      // released instead of leaking to expiry cleanup; bind never throws.
+      expect(control.send).not.toHaveBeenCalledWith(expect.stringContaining('conn-open'))
+      expect(capacity.bind).not.toHaveBeenCalled()
+      const session = h.registry.get({ userId: identity.sub, relayHostId: identity.relayHostId })
+      expect(session?.pendingConns.size).toBe(0)
+      expect(h.store.failReservation).toHaveBeenCalledWith(reservation)
+      expect(h.releaseActivity).toHaveBeenCalledWith(
+        { userId: identity.sub, relayHostId: identity.relayHostId },
+        expect.stringMatching(/^confirmation:/)
+      )
+      expect(h.observer.recordClientAcceptAbandoned).toHaveBeenCalledWith(
+        'activity',
+        expect.any(Number)
+      )
+      const line = warn.mock.calls.map((call) => String(call[0])).find((entry) =>
+        entry.includes('orca_relay_client_accept_abandoned')
+      )
+      expect(line).toBeDefined()
+      expect(JSON.parse(line!)).toMatchObject({ stage: 'activity' })
+      expect(line).not.toContain(identity.relayHostId)
+    } finally {
+      warn.mockRestore()
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+
+  it('stops after a slow credential reservation without acquiring an activity lease', async () => {
+    const h = harness()
+    await activeHost(h)
+    const slowReserve = deferred<CredentialReservation>()
+    h.store.reserveCredential.mockReturnValueOnce(slowReserve.promise)
+    const client = new FakeSocket()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const accepting = h.registry.acceptClient(
+        client as unknown as WebSocket,
+        identity.relayHostId,
+        'credential'
+      )
+      await vi.advanceTimersByTimeAsync(0)
+      client.close(1000, 'client bound')
+      slowReserve.resolve(reservation)
+      await accepting
+
+      expect(h.acquireActivity).not.toHaveBeenCalled()
+      expect(h.store.failReservation).toHaveBeenCalledWith(reservation)
+      expect(h.observer.recordClientAcceptAbandoned).toHaveBeenCalledWith(
+        'credential',
+        expect.any(Number)
+      )
+    } finally {
+      warn.mockRestore()
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+
+  it('stops after a slow resume lookup before starting the invite and assignment lookups', async () => {
+    const h = harness()
+    await activeHost(h)
+    const store = h.store as typeof h.store & { resolveInviteForMove: ReturnType<typeof vi.fn> }
+    store.resolveInviteForMove = vi.fn().mockResolvedValue(null)
+    const slowResume = deferred<null>()
+    h.store.resolveResume.mockReturnValueOnce(slowResume.promise)
+    const resolveAssignment = (h.assignments as unknown as { resolve: ReturnType<typeof vi.fn> })
+      .resolve
+    resolveAssignment.mockClear()
+    const client = new FakeSocket()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const accepting = h.registry.acceptClient(
+        client as unknown as WebSocket,
+        identity.relayHostId,
+        'credential'
+      )
+      await vi.advanceTimersByTimeAsync(0)
+      client.close(1000, 'client bound')
+      slowResume.resolve(null)
+      await accepting
+
+      expect(store.resolveInviteForMove).not.toHaveBeenCalled()
+      expect(resolveAssignment).not.toHaveBeenCalled()
+      expect(h.store.reserveCredential).not.toHaveBeenCalled()
+      expect(h.observer.recordClientAcceptAbandoned).toHaveBeenCalledWith(
+        'assignment',
+        expect.any(Number)
+      )
+    } finally {
+      warn.mockRestore()
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+
+  it('still opens the connection when the phone is holding on', async () => {
+    const h = harness()
+    const control = await activeHost(h)
+    const capacity = { bind: vi.fn(), release: vi.fn() }
+    const client = new FakeSocket()
+    await h.registry.acceptClient(
+      client as unknown as WebSocket,
+      identity.relayHostId,
+      'credential',
+      capacity
+    )
+    expect(control.send).toHaveBeenCalledWith(expect.stringContaining('"type":"conn-open"'))
+    expect(capacity.bind).toHaveBeenCalledOnce()
+    expect(h.observer.recordClientAcceptAbandoned).not.toHaveBeenCalled()
+    expect(client.close).not.toHaveBeenCalled()
+    h.registry.drain(0)
+    vi.advanceTimersByTime(0)
+  })
+})
+
+describe('control lease jitter', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('grants a lease uniformly around its mean so cohorts drift apart at the same mean rate', async () => {
+    const now = 1_700_000_000_000
+    const helloAck = (socket: FakeSocket) =>
+      JSON.parse(
+        String(socket.send.mock.calls.find((call) => String(call[0]).includes('host-hello-ack'))![0])
+      ) as { leaseExpiresAt: number }
+
+    const shortest = harness({ now: () => now, random: () => 0 })
+    const shortestAck = helloAck(await activeHost(shortest))
+    const centered = harness({ now: () => now, random: () => 0.5 })
+    const centeredAck = helloAck(await activeHost(centered))
+    const longest = harness({ now: () => now, random: () => 0.999999 })
+    const longestAck = helloAck(await activeHost(longest))
+
+    expect(shortestAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS - CONTROL_LEASE_JITTER_MS)
+    expect(centeredAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS)
+    expect(longestAck.leaseExpiresAt).toBeLessThan(now + CONTROL_LEASE_MS + CONTROL_LEASE_JITTER_MS)
+    // The mean grant is unchanged, so steady-state rebind load is unchanged;
+    // hosts that connected together now differ by minutes, not zero.
+    expect(longestAck.leaseExpiresAt - shortestAck.leaseExpiresAt).toBeGreaterThan(9 * 60 * 1000)
+    shortest.registry.drain(0)
+    centered.registry.drain(0)
+    longest.registry.drain(0)
+    vi.advanceTimersByTime(0)
+  })
+
+  it('rebinds re-roll the jitter instead of pinning the cohort phase', async () => {
+    const now = 1_700_000_000_000
+    let roll = 0
+    const h = harness({ now: () => now, random: () => roll })
+    const first = await activeHost(h)
+    const session = h.registry.get({ userId: identity.sub, relayHostId: identity.relayHostId })!
+    const firstLease = session.leaseExpiresAt
+    roll = 0.75
+    const rebind = new FakeSocket()
+    await (
+      h.registry as unknown as {
+        activate: (...args: unknown[]) => Promise<void>
+      }
+    ).activate(rebind as unknown as WebSocket, identity, session, 1, true, 1, '1.4.197')
+    expect(session.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS + CONTROL_LEASE_JITTER_MS / 2)
+    expect(session.leaseExpiresAt).not.toBe(firstLease)
+    expect(first.close).toHaveBeenCalledWith(RELAY_CLOSE_CODE.PEER_DROPPED, 'control rebound')
+    h.registry.drain(0)
+    vi.advanceTimersByTime(0)
+  })
+})

--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -16,8 +16,9 @@ import { ProcessQueuedByteBudget } from './splice-forwarder.js'
 
 // Incident 2026-09-04 ~01:05Z: the phone's dial bound ran out while the cell was
 // still inside acceptClient's serialized Postgres phase (cell-inventory lock
-// contention). The cell then finished the work for a socket nobody held, leaked
-// a 90s activity lease, and logged `host_data_reservation_already_bound`.
+// contention). The cell then finished the work for a socket nobody held, holding
+// an activity lease for the 10s attach deadline before its timer unwound it, and
+// logged `host_data_reservation_already_bound`.
 
 class FakeSocket extends EventEmitter {
   readonly OPEN = 1
@@ -269,6 +270,39 @@ describe('client accept abandoned mid-DB-phase', () => {
     }
   })
 
+  it('stops after a slow same-cell assignment resolve, before reserving a credential', async () => {
+    const h = harness()
+    await activeHost(h)
+    const resolveAssignment = (h.assignments as unknown as { resolve: ReturnType<typeof vi.fn> })
+      .resolve
+    const slowResolve = deferred<{ cellId: string }>()
+    resolveAssignment.mockReturnValueOnce(slowResolve.promise)
+    const client = new FakeSocket()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    try {
+      const accepting = h.registry.acceptClient(
+        client as unknown as WebSocket,
+        identity.relayHostId,
+        'credential'
+      )
+      await vi.advanceTimersByTimeAsync(0)
+      client.close(1000, 'client bound')
+      // A correct, same-cell assignment: only the closed socket stops the accept.
+      slowResolve.resolve({ cellId: config.cellId })
+      await accepting
+
+      expect(h.store.reserveCredential).not.toHaveBeenCalled()
+      expect(h.observer.recordClientAcceptAbandoned).toHaveBeenCalledWith(
+        'assignment',
+        expect.any(Number)
+      )
+    } finally {
+      warn.mockRestore()
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+
   it('still opens the connection when the phone is holding on', async () => {
     const h = harness()
     const control = await activeHost(h)
@@ -313,11 +347,6 @@ describe('control lease jitter', () => {
     expect(shortestAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS - CONTROL_LEASE_JITTER_MS)
     expect(centeredAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS)
     expect(longestAck.leaseExpiresAt).toBeLessThan(now + CONTROL_LEASE_MS + CONTROL_LEASE_JITTER_MS)
-    // The mean grant is unchanged, so steady-state rebind load is unchanged;
-    // hosts that connected together now differ by most of the jitter band, not zero.
-    expect(longestAck.leaseExpiresAt - shortestAck.leaseExpiresAt).toBeGreaterThan(
-      CONTROL_LEASE_JITTER_MS
-    )
     shortest.registry.drain(0)
     centered.registry.drain(0)
     longest.registry.drain(0)

--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -291,6 +291,8 @@ describe('client accept abandoned mid-DB-phase', () => {
       slowResolve.resolve({ cellId: config.cellId })
       await accepting
 
+      // Proves the accept reached the third guard, not the first.
+      expect(resolveAssignment).toHaveBeenCalled()
       expect(h.store.reserveCredential).not.toHaveBeenCalled()
       expect(h.observer.recordClientAcceptAbandoned).toHaveBeenCalledWith(
         'assignment',
@@ -341,12 +343,16 @@ describe('control lease jitter', () => {
     const shortestAck = helloAck(await activeHost(shortest))
     const centered = harness({ now: () => now, random: () => 0.5 })
     const centeredAck = helloAck(await activeHost(centered))
-    const longest = harness({ now: () => now, random: () => 0.999999 })
+    const longestRoll = 0.999999
+    const longest = harness({ now: () => now, random: () => longestRoll })
     const longestAck = helloAck(await activeHost(longest))
 
+    // Pinned, not bounded: a jitter clamped to one side still satisfies an upper
+    // bound, so only the exact top of the band proves it is symmetric.
+    const longestOffset = Math.floor((longestRoll * 2 - 1) * CONTROL_LEASE_JITTER_MS)
     expect(shortestAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS - CONTROL_LEASE_JITTER_MS)
     expect(centeredAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS)
-    expect(longestAck.leaseExpiresAt).toBeLessThan(now + CONTROL_LEASE_MS + CONTROL_LEASE_JITTER_MS)
+    expect(longestAck.leaseExpiresAt).toBe(now + CONTROL_LEASE_MS + longestOffset)
     shortest.registry.drain(0)
     centered.registry.drain(0)
     longest.registry.drain(0)

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -129,12 +129,15 @@ function send(socket: WebSocket, type: string, message: object): void {
 // stalled predecessor only accumulates doomed sockets.
 const ACTIVATION_QUEUE_WAIT_MS = 30_000
 
-// Why: hosts rebind a few minutes before this expires, so every host that
-// (re)connected in the same minute (a cell recreate dumps hundreds at once)
-// rebinds as one cohort every cycle, forever. Symmetric jitter walks the cohort
-// apart across cycles without raising the mean rebind rate.
-export const CONTROL_LEASE_MS = 55 * 60 * 1000
-export const CONTROL_LEASE_JITTER_MS = 5 * 60 * 1000
+// Why: this lease bounds how long a host lingers on a cell after a missed drain,
+// and rebinding it is the only passive rebalancing we have, so it has to stay
+// finite. 6h keeps both properties while cutting control-activation traffic on
+// the contended cell-inventory lock ~6x; the relay JWT (5 min, refreshed by the
+// desktop) and the 75s silence watchdog are enforced separately, so a longer
+// grant authorizes nothing extra. Symmetric jitter walks same-minute reconnect
+// cohorts apart across cycles without changing the mean rebind rate.
+export const CONTROL_LEASE_MS = 6 * 60 * 60 * 1000
+export const CONTROL_LEASE_JITTER_MS = 30 * 60 * 1000
 
 export class HostSessionRegistry {
   private readonly sessions = new Map<string, HostSession>()

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -178,8 +178,8 @@ export class HostSessionRegistry {
     }
     // Why: the accept runs several serialized Postgres calls behind the contended
     // cell-inventory lock, and phones bound their dial. Finishing the work for a
-    // phone that already hung up used to acquire (and leak for 90s) an activity
-    // lease, then fail at bind with host_data_reservation_already_bound.
+    // phone that already hung up took an activity lease held for the 10s attach
+    // deadline, then failed at bind with host_data_reservation_already_bound.
     const acceptStartedAt = this.now()
     const abandonedByClient = (stage: RelayClientAcceptStage, cleanup?: () => void): boolean => {
       if (socket.readyState === socket.OPEN) return false

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -29,7 +29,7 @@ import {
 import { HostCloseReasonMemory } from './host-close-reason-memory.js'
 import { relayHostLogDigest } from './relay-host-log-digest.js'
 import type { RelayTokenClaims } from './relay-token-verifier.js'
-import type { RelayRuntimeObserver } from './relay-observability.js'
+import type { RelayClientAcceptStage, RelayRuntimeObserver } from './relay-observability.js'
 import type { PendingHostDataReservation } from './relay-connection-ledger.js'
 import { closeRelayWebSocket } from './relay-websocket-close.js'
 import { ProcessQueuedByteBudget, wireSplice } from './splice-forwarder.js'
@@ -129,6 +129,13 @@ function send(socket: WebSocket, type: string, message: object): void {
 // stalled predecessor only accumulates doomed sockets.
 const ACTIVATION_QUEUE_WAIT_MS = 30_000
 
+// Why: hosts rebind a few minutes before this expires, so every host that
+// (re)connected in the same minute (a cell recreate dumps hundreds at once)
+// rebinds as one cohort every cycle, forever. Symmetric jitter walks the cohort
+// apart across cycles without raising the mean rebind rate.
+export const CONTROL_LEASE_MS = 55 * 60 * 1000
+export const CONTROL_LEASE_JITTER_MS = 5 * 60 * 1000
+
 export class HostSessionRegistry {
   private readonly sessions = new Map<string, HostSession>()
   private readonly activationQueues = new Map<string, Promise<void>>()
@@ -145,8 +152,15 @@ export class HostSessionRegistry {
     private readonly assignments: RelayAssignmentStore,
     private readonly queuedByteBudget: ProcessQueuedByteBudget,
     private readonly observer: RelayRuntimeObserver,
-    private readonly now: () => number = Date.now
+    private readonly now: () => number = Date.now,
+    private readonly random: () => number = Math.random
   ) {}
+
+  // Uniform over [CONTROL_LEASE_MS - jitter, CONTROL_LEASE_MS + jitter).
+  private controlLeaseExpiresAt(): number {
+    const offset = Math.floor((this.random() * 2 - 1) * CONTROL_LEASE_JITTER_MS)
+    return this.now() + CONTROL_LEASE_MS + offset
+  }
 
   async acceptClient(
     socket: WebSocket,
@@ -159,10 +173,31 @@ export class HostSessionRegistry {
       this.rejectClient(socket, RELAY_CLOSE_CODE.DRAINING)
       return
     }
+    // Why: the accept runs several serialized Postgres calls behind the contended
+    // cell-inventory lock, and phones bound their dial. Finishing the work for a
+    // phone that already hung up used to acquire (and leak for 90s) an activity
+    // lease, then fail at bind with host_data_reservation_already_bound.
+    const acceptStartedAt = this.now()
+    const abandonedByClient = (stage: RelayClientAcceptStage, cleanup?: () => void): boolean => {
+      if (socket.readyState === socket.OPEN) return false
+      capacityReservation?.release()
+      cleanup?.()
+      const elapsedMs = this.now() - acceptStartedAt
+      this.observer.recordClientAcceptAbandoned?.(stage, elapsedMs)
+      console.warn(
+        JSON.stringify({ event: 'orca_relay_client_accept_abandoned', stage, elapsedMs })
+      )
+      return true
+    }
     if (this.config.role === 'cell') {
-      const outerIdentity =
-        (await this.store.resolveResume(hostId, credential)) ??
-        (await this.store.resolveInviteForMove(hostId, credential))
+      // Each lookup is its own pooled round trip; stop between them once the phone
+      // has left instead of running the rest of the chain for nobody.
+      let outerIdentity = await this.store.resolveResume(hostId, credential)
+      if (abandonedByClient('assignment')) return
+      if (!outerIdentity) {
+        outerIdentity = await this.store.resolveInviteForMove(hostId, credential)
+        if (abandonedByClient('assignment')) return
+      }
       const assignment = outerIdentity
         ? await this.assignments.resolve({ userId: outerIdentity.userId, relayHostId: hostId })
         : null
@@ -172,6 +207,7 @@ export class HostSessionRegistry {
         this.rejectClient(socket, RELAY_CLOSE_CODE.WRONG_CELL)
         return
       }
+      if (abandonedByClient('assignment')) return
     }
     const reservation = await this.store.reserveCredential(hostId, credential)
     if (!reservation) {
@@ -181,6 +217,7 @@ export class HostSessionRegistry {
       return
     }
     this.observer.recordAuth(true)
+    if (abandonedByClient('credential', () => this.failReservationBestEffort(reservation))) return
     const sessionKey = this.key(reservation.userId, hostId)
     const session = this.sessions.get(sessionKey)
     if (
@@ -226,6 +263,14 @@ export class HostSessionRegistry {
         this.rejectClient(socket, RELAY_CLOSE_CODE.LIMIT_EXCEEDED)
         return
       }
+    }
+    if (
+      abandonedByClient('activity', () => {
+        this.failReservationBestEffort(reservation)
+        if (credentialActivityId) this.releaseActivityBestEffort(identity, credentialActivityId)
+      })
+    ) {
+      return
     }
     const attachTimer = setTimeout(() => {
       session.pendingConns.delete(connId)
@@ -740,7 +785,7 @@ export class HostSessionRegistry {
       existing.socket = socket
       existing.state = existing.regionalDrainAttemptId ? 'drain-only' : 'active'
       existing.appVersion = appVersion
-      existing.leaseExpiresAt = this.now() + 55 * 60 * 1000
+      existing.leaseExpiresAt = this.controlLeaseExpiresAt()
       existing.lastPongAt = this.now()
       existing.activityRenewalDueAt =
         this.now() + RELAY_PROTOCOL_LIMITS.controlPingIntervalMs
@@ -791,7 +836,7 @@ export class HostSessionRegistry {
       appVersion,
       state: 'active',
       socket,
-      leaseExpiresAt: this.now() + 55 * 60 * 1000,
+      leaseExpiresAt: this.controlLeaseExpiresAt(),
       orphanTimer: null,
       heartbeatTimer: null,
       lastPongAt: this.now(),

--- a/cloud/apps/relay/src/relay-observability.test.ts
+++ b/cloud/apps/relay/src/relay-observability.test.ts
@@ -195,16 +195,23 @@ describe('relay observability', () => {
     observability.recordControlClose(4402)
     observability.recordSpliceClose('host-oversize-frame')
     observability.recordSpliceClose('queue-limit')
+    observability.recordClientAcceptAbandoned('activity', 14_250.4)
+    observability.recordClientAcceptAbandoned('activity', 2_000)
+    observability.recordClientAcceptAbandoned('credential', 3_000)
     observability.flush(counts)
     observability.flush(counts)
 
     expect(entries[0]).toMatchObject({
       controlClosesByCodeDelta: { 1006: 2, 4402: 1 },
-      spliceClosesByTriggerDelta: { 'host-oversize-frame': 1, 'queue-limit': 1 }
+      spliceClosesByTriggerDelta: { 'host-oversize-frame': 1, 'queue-limit': 1 },
+      clientAcceptsAbandonedByStageDelta: { activity: 2, credential: 1 },
+      clientAcceptAbandonedMsMax: 14_250.4
     })
     expect(entries[1]).toMatchObject({
       controlClosesByCodeDelta: {},
-      spliceClosesByTriggerDelta: {}
+      spliceClosesByTriggerDelta: {},
+      clientAcceptsAbandonedByStageDelta: {},
+      clientAcceptAbandonedMsMax: 0
     })
   })
 

--- a/cloud/apps/relay/src/relay-observability.ts
+++ b/cloud/apps/relay/src/relay-observability.ts
@@ -64,7 +64,11 @@ export interface RelayRuntimeObserver {
   }): void
   recordControlClose?(code: number): void
   recordSpliceClose?(trigger: string): void
+  recordClientAcceptAbandoned?(stage: RelayClientAcceptStage, elapsedMs: number): void
 }
+
+// Which serialized accept step the phone had already hung up behind.
+export type RelayClientAcceptStage = 'assignment' | 'credential' | 'activity'
 
 type RelayMetricDeltas = {
   forwardedBytes: number
@@ -87,6 +91,8 @@ type RelayMetricDeltas = {
   unavailableRegions: Record<string, number>
   controlClosesByCode: Record<string, number>
   spliceClosesByTrigger: Record<string, number>
+  clientAcceptsAbandonedByStage: Record<string, number>
+  clientAcceptAbandonedMsMax: number
   controlRenewalLatenciesMs: number[]
   controlRenewalsByOutcome: Record<string, number>
   controlActivityRecoveries: number
@@ -116,6 +122,8 @@ const emptyDeltas = (): RelayMetricDeltas => ({
   unavailableRegions: {},
   controlClosesByCode: {},
   spliceClosesByTrigger: {},
+  clientAcceptsAbandonedByStage: {},
+  clientAcceptAbandonedMsMax: 0,
   controlRenewalLatenciesMs: [],
   controlRenewalsByOutcome: {},
   controlActivityRecoveries: 0,
@@ -228,6 +236,14 @@ export class RelayObservability implements RelayRuntimeObserver {
       (this.deltas.spliceClosesByTrigger[trigger] ?? 0) + 1
   }
 
+  recordClientAcceptAbandoned(stage: RelayClientAcceptStage, elapsedMs: number): void {
+    increment(this.deltas.clientAcceptsAbandonedByStage, stage)
+    this.deltas.clientAcceptAbandonedMsMax = Math.max(
+      this.deltas.clientAcceptAbandonedMsMax,
+      elapsedMs
+    )
+  }
+
   start(readCounts: () => RelayProcessCounts, intervalMs = 30_000): void {
     if (this.timer) return
     this.eventLoop.enable()
@@ -289,6 +305,8 @@ export class RelayObservability implements RelayRuntimeObserver {
       unavailableRegionsDelta: deltas.unavailableRegions,
       controlClosesByCodeDelta: deltas.controlClosesByCode,
       spliceClosesByTriggerDelta: deltas.spliceClosesByTrigger,
+      clientAcceptsAbandonedByStageDelta: deltas.clientAcceptsAbandonedByStage,
+      clientAcceptAbandonedMsMax: Number(deltas.clientAcceptAbandonedMsMax.toFixed(3)),
       sqlQueriesDelta: deltas.sqlQueries,
       sqlFailuresDelta: deltas.sqlFailures,
       sqlLatencyMsMax: Number(deltas.sqlLatencyMsMax.toFixed(3)),

--- a/cloud/apps/relay/src/relay-server.ts
+++ b/cloud/apps/relay/src/relay-server.ts
@@ -88,6 +88,7 @@ export function createRelayServer(
   database: RelayDatabase,
   options: {
     now?: () => number
+    random?: () => number
     connectionLedgerLimits?: { hardCap: number; controlReserve: number }
     cellIncarnation?: string
   } = {}
@@ -123,7 +124,8 @@ export function createRelayServer(
     assignments,
     queuedBytes,
     observability,
-    options.now
+    options.now,
+    options.random
   )
   const app = createRelayApp(config, {
     store,

--- a/mobile/src/transport/mobile-direct-endpoint-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.test.ts
@@ -71,4 +71,28 @@ describe('mobile direct endpoint probe', () => {
     expect(clients.get(host.endpoint)?.close).toHaveBeenCalledOnce()
     expect(result?.client.close).not.toHaveBeenCalled()
   })
+
+  it('fails as soon as every candidate falls into its own reconnect backoff', async () => {
+    // Incident 2026-09-04: foregrounding on a dead LAN produced an instant 1006 and
+    // the direct client's 500/1000/2000ms redials, while the probe sat on the
+    // 'connecting' phase and held the supervisor mutex for the whole 12s bound.
+    const clients: FakeClient[] = []
+    const openDirect = vi.fn(() => {
+      const client = new FakeClient('connecting')
+      clients.push(client)
+      setTimeout(() => client.publishState('reconnecting'), 20)
+      return client
+    })
+
+    const probing = openAuthenticatedDirectEndpoint(host, openDirect, 12_000)
+    await vi.advanceTimersByTimeAsync(20)
+    await expect(probing).resolves.toBeNull()
+
+    expect(clients).toHaveLength(2)
+    for (const client of clients) {
+      expect(client.close).toHaveBeenCalledOnce()
+    }
+    // No 12s timer is left behind to fire into a settled probe.
+    expect(vi.getTimerCount()).toBe(0)
+  })
 })

--- a/mobile/src/transport/mobile-direct-endpoint-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.test.ts
@@ -72,7 +72,7 @@ describe('mobile direct endpoint probe', () => {
     expect(result?.client.close).not.toHaveBeenCalled()
   })
 
-  it('fails as soon as every candidate falls into its own reconnect backoff', async () => {
+  it('fails a whole dead LAN in seconds instead of holding the 12s bound', async () => {
     // Incident 2026-09-04: foregrounding on a dead LAN produced an instant 1006 and
     // the direct client's 500/1000/2000ms redials, while the probe sat on the
     // 'connecting' phase and held the supervisor mutex for the whole 12s bound.
@@ -86,6 +86,7 @@ describe('mobile direct endpoint probe', () => {
 
     const probing = openAuthenticatedDirectEndpoint(host, openDirect, 12_000)
     await vi.advanceTimersByTimeAsync(20)
+    await vi.advanceTimersByTimeAsync(2_000)
     await expect(probing).resolves.toBeNull()
 
     expect(clients).toHaveLength(2)
@@ -93,6 +94,47 @@ describe('mobile direct endpoint probe', () => {
       expect(client.close).toHaveBeenCalledOnce()
     }
     // No 12s timer is left behind to fire into a settled probe.
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('rides out one access-point flap that the first redial recovers', async () => {
+    // 'reconnecting' is published on any socket close, so a single RST on the first
+    // dial must not book a direct failure and its 60s cooldown.
+    const openDirect = vi.fn((endpoint: string) => {
+      const client = new FakeClient('connecting')
+      if (endpoint.includes('100.64.0.2')) {
+        setTimeout(() => client.publishState('reconnecting'), 20)
+        setTimeout(() => client.publishState('connected'), 600)
+      }
+      return client
+    })
+
+    const probing = openAuthenticatedDirectEndpoint(host, openDirect, 12_000)
+    await vi.advanceTimersByTimeAsync(600)
+    const result = await probing
+
+    expect(result?.path).toBe('tailscale')
+    expect(result?.client.close).not.toHaveBeenCalled()
+  })
+
+  it('gives up at the grace window when the redial never lands', async () => {
+    const openDirect = vi.fn(() => {
+      const client = new FakeClient('connecting')
+      setTimeout(() => client.publishState('reconnecting'), 20)
+      return client
+    })
+
+    const probing = openAuthenticatedDirectEndpoint(host, openDirect, 12_000)
+    await vi.advanceTimersByTimeAsync(2_019)
+    let settled = false
+    void probing.then(() => {
+      settled = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(probing).resolves.toBeNull()
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/mobile/src/transport/mobile-direct-endpoint-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.test.ts
@@ -117,6 +117,50 @@ describe('mobile direct endpoint probe', () => {
     expect(result?.client.close).not.toHaveBeenCalled()
   })
 
+  it('extends the grace once when the redial reaches a handshake', async () => {
+    // The redial fires at 500ms, but 'connected' waits on the Noise handshake and a
+    // capability RPC, so real work needs more than one grace window.
+    const openDirect = vi.fn((endpoint: string) => {
+      const client = new FakeClient('connecting')
+      if (endpoint.includes('100.64.0.2')) {
+        setTimeout(() => client.publishState('reconnecting'), 20)
+        setTimeout(() => client.publishState('handshaking'), 1_500)
+        // Past the first grace window: only the re-arm keeps this probe alive.
+        setTimeout(() => client.publishState('connected'), 3_000)
+      }
+      return client
+    })
+
+    const probing = openAuthenticatedDirectEndpoint(host, openDirect, 12_000)
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect((await probing)?.path).toBe('tailscale')
+  })
+
+  it('fails a handshake that stalls, one grace after it started', async () => {
+    const openDirect = vi.fn(() => {
+      const client = new FakeClient('connecting')
+      setTimeout(() => client.publishState('reconnecting'), 20)
+      setTimeout(() => client.publishState('handshaking'), 1_500)
+      // A restarted handshake must not buy a second extension.
+      setTimeout(() => client.publishState('handshaking'), 2_500)
+      return client
+    })
+
+    const probing = openAuthenticatedDirectEndpoint(host, openDirect, 12_000)
+    await vi.advanceTimersByTimeAsync(3_499)
+    let settled = false
+    void probing.then(() => {
+      settled = true
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(settled).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(probing).resolves.toBeNull()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
   it('gives up at the grace window when the redial never lands', async () => {
     const openDirect = vi.fn(() => {
       const client = new FakeClient('connecting')

--- a/mobile/src/transport/mobile-direct-endpoint-probe.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.ts
@@ -35,7 +35,11 @@ function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Pro
       if (state === 'connected') {
         finish()
         resolve()
-      } else if (state === 'disconnected' || state === 'auth-failed') {
+      } else if (state === 'disconnected' || state === 'auth-failed' || state === 'reconnecting') {
+        // Why: a probe asks whether direct answers NOW. 'reconnecting' is the direct
+        // client's own backoff loop after a failed dial (an instant 1006 on a dead
+        // LAN); waiting it out held the supervisor's operation mutex for the full
+        // 12s bound and blocked relay recovery behind three doomed redials.
         finish()
         reject(new Error(`probe session ${state}`))
       }

--- a/mobile/src/transport/mobile-direct-endpoint-probe.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.ts
@@ -38,6 +38,12 @@ function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Pro
   return new Promise((resolve, reject) => {
     let timer: ReturnType<typeof setTimeout> | null = null
     let graceTimer: ReturnType<typeof setTimeout> | null = null
+    let graceExtended = false
+    const armGrace = (): ReturnType<typeof setTimeout> =>
+      setTimeout(() => {
+        finish()
+        reject(new Error('probe session reconnecting'))
+      }, RECONNECT_GRACE_MS)
     const unsubscribe = session.onStateChange((state) => {
       if (state === 'connected') {
         finish()
@@ -45,10 +51,16 @@ function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Pro
         return
       }
       if (state === 'reconnecting' && !graceTimer) {
-        graceTimer = setTimeout(() => {
-          finish()
-          reject(new Error('probe session reconnecting'))
-        }, RECONNECT_GRACE_MS)
+        graceTimer = armGrace()
+        return
+      }
+      // Why: the redial fires at 500ms but 'connected' waits on the Noise handshake
+      // and a capability RPC. 'handshaking' is proof the peer answered, so extend
+      // once; a dead handshake still fails at ~4s, far inside the outer bound.
+      if (state === 'handshaking' && graceTimer && !graceExtended) {
+        graceExtended = true
+        clearTimeout(graceTimer)
+        graceTimer = armGrace()
         return
       }
       if (state === 'disconnected' || state === 'auth-failed' || state === 'reconnecting') {

--- a/mobile/src/transport/mobile-direct-endpoint-probe.ts
+++ b/mobile/src/transport/mobile-direct-endpoint-probe.ts
@@ -25,21 +25,33 @@ export function directPathForEndpoint(
   return 'lan'
 }
 
+// Why: 'reconnecting' is published on any socket close, so it cannot tell a dead
+// LAN (instant 1006, then doomed redials) from one access-point flap that the
+// first redial recovers. One redial fits here; a dead LAN still fails in ~2s
+// instead of holding the supervisor's operation mutex for the full outer bound.
+const RECONNECT_GRACE_MS = 2_000
+
 function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Promise<void> {
   if (session.getState() === 'connected') {
     return Promise.resolve()
   }
   return new Promise((resolve, reject) => {
     let timer: ReturnType<typeof setTimeout> | null = null
+    let graceTimer: ReturnType<typeof setTimeout> | null = null
     const unsubscribe = session.onStateChange((state) => {
       if (state === 'connected') {
         finish()
         resolve()
-      } else if (state === 'disconnected' || state === 'auth-failed' || state === 'reconnecting') {
-        // Why: a probe asks whether direct answers NOW. 'reconnecting' is the direct
-        // client's own backoff loop after a failed dial (an instant 1006 on a dead
-        // LAN); waiting it out held the supervisor's operation mutex for the full
-        // 12s bound and blocked relay recovery behind three doomed redials.
+        return
+      }
+      if (state === 'reconnecting' && !graceTimer) {
+        graceTimer = setTimeout(() => {
+          finish()
+          reject(new Error('probe session reconnecting'))
+        }, RECONNECT_GRACE_MS)
+        return
+      }
+      if (state === 'disconnected' || state === 'auth-failed' || state === 'reconnecting') {
         finish()
         reject(new Error(`probe session ${state}`))
       }
@@ -51,6 +63,9 @@ function waitForAuthenticatedSession(session: RpcClient, timeoutMs: number): Pro
     function finish(): void {
       if (timer) {
         clearTimeout(timer)
+      }
+      if (graceTimer) {
+        clearTimeout(graceTimer)
       }
       unsubscribe()
     }

--- a/mobile/src/transport/mobile-endpoint-supervisor-direct-probe.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-direct-probe.test.ts
@@ -39,8 +39,9 @@ describe('mobile endpoint supervisor direct probe', () => {
     direct.publishState('reconnecting')
     logical.publishState('disconnected')
 
-    // Relay recovery must not wait out the probe's 12s bound.
-    await vi.advanceTimersByTimeAsync(0)
+    // Relay recovery must not wait out the probe's 12s bound; the probe gives up
+    // one grace window after the redial fails to land.
+    await vi.advanceTimersByTimeAsync(2_000)
     expect(openRelay).toHaveBeenCalledOnce()
     expect(direct.close).toHaveBeenCalled()
     expect(logical.getState()).toBe('connected')

--- a/mobile/src/transport/mobile-endpoint-supervisor-direct-probe.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-direct-probe.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
+import {
+  dependencies,
+  FakeLogicalClient,
+  FakeRelaySession,
+  FakeSession,
+  host
+} from './mobile-endpoint-supervisor-test-fakes'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+describe('mobile endpoint supervisor direct probe', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-13T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not block relay recovery behind a direct probe stuck in its redial loop', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const direct = new FakeSession('connecting')
+    const openRelay = vi.fn(() => new FakeRelaySession('connected'))
+    const deps = dependencies({ openDirect: vi.fn(() => direct), openRelay })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+    await supervisor.start()
+
+    // Foreground return: the probe dials direct at once, the dead LAN answers with
+    // an instant 1006, and the direct client enters its 500/1000/2000ms backoff.
+    supervisor.setForeground(false)
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(deps.openDirect).toHaveBeenCalledOnce()
+    direct.publishState('reconnecting')
+    logical.publishState('disconnected')
+
+    // Relay recovery must not wait out the probe's 12s bound.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openRelay).toHaveBeenCalledOnce()
+    expect(direct.close).toHaveBeenCalled()
+    expect(logical.getState()).toBe('connected')
+    expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​552 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​550 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 |

<!-- /orca-pr-loc -->

## ELI5

The phone asks the relay to connect it to the Mac; the relay checks a shared database first. Under the 2026-09-04 lock storm that check took longer than the phone waited, so the relay finished work for a phone that had already hung up (the `already_bound` log line). Separately, every Mac renewed its relay link on a fixed 55-minute clock, so hundreds of Macs that reconnected together after a cell restart renewed together forever and hit the same lock in waves. And the phone spent 3.5 s retrying a dead Wi-Fi path before trying the relay.

This PR: stops the relay working for phones that left, spreads the renewals out and makes them six times rarer, and lets the phone give up on dead Wi-Fi at once.

## Changes

- **Relay accept abandonment**: `acceptClient` checks the client socket after each serialized DB step and stops once the phone closed, releasing the capacity reservation and any activity lease it already took. New observability event `orca_relay_client_accept_abandoned {stage, elapsedMs}`.
- **Control lease 6 h ± 30 min** (was flat 55 min). The lease bounds how long a host lingers on a cell after a missed drain and is the only passive rebalancing, so it stays finite; 6 h cuts control-activation traffic on the contended cell-inventory lock ~6x. The relay JWT (5 min) and the 75 s silence watchdog are enforced separately. Symmetric jitter walks same-minute reconnect cohorts apart. Wire-safe: the relay already sends `leaseExpiresAt` in the hello ack and desktops schedule from it; #18719's proportional ±10 % desktop jitter scales with it.
- **Mobile direct-probe fail-fast**: a dead direct path fails immediately instead of after 3.5 s of retries. The supervisor test moved to a sibling spec (`mobile-endpoint-supervisor-direct-probe.test.ts`) because the existing file is at the `max-lines` cap.

Supersedes #18565 (rebased onto main; the desktop rotation change there was dropped because #18719 shipped a proportional version). Ships in Roll 2 per `cloud/docs/relay-roll2-plan-2026-09.md` (#18958).

## Verification

- relay: 3 targeted specs 39/39; full relay app suite 508 passed, 87 skipped (Postgres suites, 55440 down); `tsc --noEmit` clean.
- mobile: `src/transport` 683 passed; `tsc --noEmit` clean; `oxfmt --check` clean.
- root `src/main/runtime/relay` 113 passed (untouched by this PR).
- `oxlint` clean on changed dirs; `check:code-quality:changed` 0 findings.