### PR TITLE
perf(browser): reuse decoded single-chunk upload buffers

### DIFF
--- a/src/main/browser/browser-client-upload-transfer.test.ts
+++ b/src/main/browser/browser-client-upload-transfer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { BrowserClientHostCommandEvent } from '../../shared/browser-client-host-protocol'
 import {
@@ -102,3 +102,38 @@ describe('readBrowserClientUploadPaths', () => {
     )
   })
 })
+
+it.each([0, 1, 128 * 1024])(
+  'avoids recopying 16 single-chunk uploads of %i bytes',
+  async (size) => {
+    const source = Buffer.alloc(size, 171)
+    const response = {
+      contentBase64: source.toString('base64'),
+      bytesRead: size,
+      totalBytes: size,
+      eof: true
+    }
+    const remotePaths = Array.from({ length: 16 }, (_, i) => `file-${i}.bin`)
+    const request = vi.fn(async () => response)
+    const concat = vi.spyOn(Buffer, 'concat')
+    let copies = 0
+    let files: Awaited<ReturnType<typeof fetchBrowserClientUploadFiles>>
+    try {
+      files = await fetchBrowserClientUploadFiles({ request, event, remotePaths })
+      copies = concat.mock.calls.length
+    } finally {
+      concat.mockRestore()
+    }
+    expect(copies).toBe(0)
+    expect(request).toHaveBeenCalledTimes(16)
+    expect(files.map((file) => file.remotePath)).toEqual(remotePaths)
+    for (const file of files) {
+      expect(file.contents).toEqual(source)
+    }
+    if (size > 0) {
+      files[0].contents[0] = 0
+      expect(files[1].contents[0]).toBe(171)
+      expect(source[0]).toBe(171)
+    }
+  }
+)

--- a/src/main/browser/browser-client-upload-transfer.ts
+++ b/src/main/browser/browser-client-upload-transfer.ts
@@ -74,7 +74,7 @@ export async function fetchBrowserClientUploadFiles(options: {
         throw new Error('browser_client_upload_transfer_stalled')
       }
     }
-    files.push({ remotePath, contents: Buffer.concat(chunks) })
+    files.push({ remotePath, contents: chunks.length === 1 ? chunks[0] : Buffer.concat(chunks) })
   }
   return files
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

Remote browser upload files that arrive in one chunk were decoded into a new owned Buffer and immediately copied again by Buffer.concat. Return the decoded buffer directly for that case; retain the existing join for multiple chunks.

ELI5: when a file arrives in one piece, use that piece instead of making a second identical copy.

The decoded buffer is created inside the transfer function from a validated base64 string. It does not alias a caller-supplied buffer or another file. The request order, authority fields, remote paths, decoder validation, empty-file handling, transfer limits, and stalled-transfer errors are unchanged.

Deterministic before/after measurements from the real transfer function with controlled remote responses:

| Batch of 16 single-chunk files | Before final joins | After | Avoided copied bytes |
|---|---:|---:|---:|
| Empty files | 16 | 0 | 0 |
| One-byte files | 16 | 0 | 16 |
| 128 KiB files (chunk maximum) | 16 | 0 | 2,097,152 |

Each scenario still makes exactly 16 reads. Multi-chunk files retain their existing Buffer.concat operation. These are avoided allocation/copy counts, not measured network-throughput or wall-clock upload improvements; no cache or network-request change is involved.

Validation: 34 tests across four suites passed; node typecheck, lint, and formatting passed. All three new allocation cases fail against the original code (16 final joins instead of zero), then pass with the fix. They verify exact bytes, file order, and mutation isolation across files and from the source. Existing suites cover multi-chunk reconstruction, malformed/stalled input, count limits, command handling, runtime routing, and temporary staging lifecycle.

Reproduce:

```sh
pnpm test src/main/browser/browser-client-upload-transfer.test.ts src/main/browser/browser-client-upload-command.test.ts src/main/browser/browser-client-page-upload-routing.test.ts src/main/browser/browser-client-upload-staging.test.ts
pnpm tc:node
```

Negative user-facing trade-offs:
- None identified: outputs remain independently owned and byte-identical, with the same validation and cleanup.
- No shorter timeout, dropped data, new limit, added network request, or changed multi-chunk algorithm.

Remote upload sources remain interpreted by the runtime against the remote workspace. This adds no desktop filesystem access, host command, Git-provider assumption, or folder/worktree distinction. No RPC, frame, capability, or wire change; independently updated clients and hosts keep the current contract. Tests run on macOS with controlled remote responses; no live SSH throughput, native Windows/Linux, or rendered browser UI claim. No app windows or GitHub issues were opened.
