### PR TITLE
fix: preserve renderer browser publication during client-hosted page updates

### DIFF
--- a/src/main/runtime/browser-session-tab-selection-snapshot.test.ts
+++ b/src/main/runtime/browser-session-tab-selection-snapshot.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest'
 import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
 import { applyBrowserSessionTabSelection } from './browser-session-tab-selection-snapshot'
 
-const EPOCH = 'headless:test'
-
 function makeSnapshot(): RuntimeMobileSessionTabsSnapshot {
   return {
     worktree: 'wt-1',
@@ -46,8 +44,7 @@ function select(overrides: { focusesHost: boolean; targetGroupId?: string }) {
     snapshot: makeSnapshot(),
     tabId: 'page-new',
     focusesHost: overrides.focusesHost,
-    ...(overrides.targetGroupId ? { targetGroupId: overrides.targetGroupId } : {}),
-    publicationEpoch: EPOCH
+    ...(overrides.targetGroupId ? { targetGroupId: overrides.targetGroupId } : {})
   })
 }
 
@@ -115,10 +112,11 @@ describe('applyBrowserSessionTabSelection', () => {
     expect(snapshot.activeGroupId).toBe('group-left')
   })
 
-  it('republishes under a fresh epoch and a newer version either way', () => {
+  // Rotating the epoch here retires the renderer's own publication client-side.
+  it('keeps the publication epoch and advances the version either way', () => {
     for (const focusesHost of [true, false]) {
       const { snapshot } = select({ focusesHost })
-      expect(snapshot.publicationEpoch).toBe(EPOCH)
+      expect(snapshot.publicationEpoch).toBe('headless:before')
       expect(snapshot.snapshotVersion).toBe(5)
     }
   })

--- a/src/main/runtime/browser-session-tab-selection-snapshot.ts
+++ b/src/main/runtime/browser-session-tab-selection-snapshot.ts
@@ -22,7 +22,6 @@ export function applyBrowserSessionTabSelection(args: {
   tabId: string
   targetGroupId?: string
   focusesHost: boolean
-  publicationEpoch: string
 }): BrowserSessionTabSelectionResult {
   const { snapshot, tabId, targetGroupId, focusesHost } = args
   const groups = snapshot.tabGroups ?? []
@@ -56,7 +55,6 @@ export function applyBrowserSessionTabSelection(args: {
     placedInTargetGroup,
     snapshot: {
       ...snapshot,
-      publicationEpoch: args.publicationEpoch,
       snapshotVersion: snapshot.snapshotVersion + 1,
       ...(placedInTargetGroup && focusesHost ? { activeGroupId: targetGroupId } : {}),
       ...(focusesHost

--- a/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
+++ b/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
@@ -206,8 +206,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
       snapshot,
       tabId: tab.id,
       ...(targetGroupId !== undefined ? { targetGroupId } : {}),
-      focusesHost,
-      publicationEpoch: snapshot.publicationEpoch
+      focusesHost
     })
     this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     // Why: browser group membership is otherwise live-only; persist it so a

--- a/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
+++ b/src/main/runtime/orca-runtime-close-structured-agent-session-tab.ts
@@ -207,7 +207,7 @@ export class OrcaRuntimeWithCloseStructuredAgentSessionTab extends OrcaRuntimeWi
       tabId: tab.id,
       ...(targetGroupId !== undefined ? { targetGroupId } : {}),
       focusesHost,
-      publicationEpoch: `headless:${Date.now().toString(36)}`
+      publicationEpoch: snapshot.publicationEpoch
     })
     this.storeMobileSessionSnapshot(worktreeId, nextSnapshot)
     // Why: browser group membership is otherwise live-only; persist it so a

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -25,11 +25,19 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
     worktreeId: string,
     existing: RuntimeMobileSessionTabsSnapshot
   ): void {
-    const liveBrowserTabs = this.buildHeadlessMobileSessionBrowserTabs(worktreeId)
-    const liveIds = liveBrowserTabs.map((tab) => tab.id)
     const existingBrowserTabs = existing.tabs.filter(
       (tab): tab is RuntimeMobileSessionBrowserTab => tab.type === 'browser'
     )
+    // An attached renderer owns its browser rows; the client-page registry cannot retire them.
+    const rendererBrowserTabs =
+      this.getAvailableAuthoritativeWindow() && !this.offscreenBrowserBackend
+        ? existingBrowserTabs.filter((tab) => tab.placement?.kind !== 'client')
+        : []
+    const liveBrowserTabs = [
+      ...rendererBrowserTabs,
+      ...this.buildHeadlessMobileSessionBrowserTabs(worktreeId)
+    ]
+    const liveIds = liveBrowserTabs.map((tab) => tab.id)
     const existingBrowserIds = existingBrowserTabs.map((tab) => tab.id)
     if (headlessBrowserTabsUnchanged(liveBrowserTabs, existingBrowserTabs)) {
       return
@@ -53,7 +61,6 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
       : (nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null)
     this.storeMobileSessionSnapshot(worktreeId, {
       ...existing,
-      publicationEpoch: `headless-hydrated:${Date.now().toString(36)}`,
       snapshotVersion: existing.snapshotVersion + 1,
       ...(activeStillPresent
         ? {}

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -29,16 +29,23 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
       (tab): tab is RuntimeMobileSessionBrowserTab => tab.type === 'browser'
     )
     const publishedBrowserTabs = this.buildHeadlessMobileSessionBrowserTabs(worktreeId)
-    const publishedIds = new Set(publishedBrowserTabs.map((tab) => tab.id))
     // An attached renderer owns its browser rows; the client-page registry cannot retire them.
-    // Ids the live build already published still lose, so a row can never appear twice.
     const rendererBrowserTabs =
       this.getAvailableAuthoritativeWindow() && !this.offscreenBrowserBackend
-        ? existingBrowserTabs.filter(
-            (tab) => tab.placement?.kind !== 'client' && !publishedIds.has(tab.id)
-          )
+        ? existingBrowserTabs.filter((tab) => tab.placement?.kind !== 'client')
         : []
-    const liveBrowserTabs = [...rendererBrowserTabs, ...publishedBrowserTabs]
+    // Keyed by id so no row can publish twice whatever the two sources overlap on; a freshly
+    // built row wins over the retained one it replaces.
+    const liveById = new Map(
+      [...rendererBrowserTabs, ...publishedBrowserTabs].map((tab) => [tab.id, tab])
+    )
+    // Emit in the order the snapshot already had, because the equality check below compares by
+    // index: rebuilding renderer-first would read a pure reordering as a change and republish.
+    const retainedInOrder = existingBrowserTabs.flatMap((tab) => {
+      const live = liveById.get(tab.id)
+      return live && liveById.delete(tab.id) ? [live] : []
+    })
+    const liveBrowserTabs = [...retainedInOrder, ...liveById.values()]
     const liveIds = liveBrowserTabs.map((tab) => tab.id)
     const existingBrowserIds = existingBrowserTabs.map((tab) => tab.id)
     if (headlessBrowserTabsUnchanged(liveBrowserTabs, existingBrowserTabs)) {

--- a/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
+++ b/src/main/runtime/orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts
@@ -28,15 +28,17 @@ export class OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs extends Or
     const existingBrowserTabs = existing.tabs.filter(
       (tab): tab is RuntimeMobileSessionBrowserTab => tab.type === 'browser'
     )
+    const publishedBrowserTabs = this.buildHeadlessMobileSessionBrowserTabs(worktreeId)
+    const publishedIds = new Set(publishedBrowserTabs.map((tab) => tab.id))
     // An attached renderer owns its browser rows; the client-page registry cannot retire them.
+    // Ids the live build already published still lose, so a row can never appear twice.
     const rendererBrowserTabs =
       this.getAvailableAuthoritativeWindow() && !this.offscreenBrowserBackend
-        ? existingBrowserTabs.filter((tab) => tab.placement?.kind !== 'client')
+        ? existingBrowserTabs.filter(
+            (tab) => tab.placement?.kind !== 'client' && !publishedIds.has(tab.id)
+          )
         : []
-    const liveBrowserTabs = [
-      ...rendererBrowserTabs,
-      ...this.buildHeadlessMobileSessionBrowserTabs(worktreeId)
-    ]
+    const liveBrowserTabs = [...rendererBrowserTabs, ...publishedBrowserTabs]
     const liveIds = liveBrowserTabs.map((tab) => tab.id)
     const existingBrowserIds = existingBrowserTabs.map((tab) => tab.id)
     if (headlessBrowserTabsUnchanged(liveBrowserTabs, existingBrowserTabs)) {

--- a/src/main/runtime/renderer-browser-session-reconciliation.test.ts
+++ b/src/main/runtime/renderer-browser-session-reconciliation.test.ts
@@ -102,6 +102,19 @@ it('removes retired client pages and publishes live ones while retaining rendere
   expect(published?.snapshotVersion).toBe(snapshot.snapshotVersion + 1)
 })
 
+it('never publishes a row twice when the live build reclaims a renderer-owned id', () => {
+  const reclaimed = {
+    ...clientPage,
+    id: rendererPage.id,
+    browserPageId: rendererPage.browserPageId
+  }
+
+  const published = reconcile({ live: [reclaimed] })
+
+  expect(published?.tabs).toEqual([reclaimed])
+  expect(published?.tabGroups?.[0].tabOrder).toEqual([rendererPage.id])
+})
+
 it('keeps the renderer publication epoch when selecting a client-hosted browser tab', () => {
   const storeMobileSessionSnapshot = vi.fn()
   const runtime = OrcaRuntimeWithCloseStructuredAgentSessionTab.prototype as unknown as {

--- a/src/main/runtime/renderer-browser-session-reconciliation.test.ts
+++ b/src/main/runtime/renderer-browser-session-reconciliation.test.ts
@@ -18,6 +18,18 @@ const rendererPage: RuntimeMobileSessionBrowserTab = {
   canGoForward: false,
   isActive: false
 }
+const clientPage: RuntimeMobileSessionBrowserTab = {
+  ...rendererPage,
+  id: 'client',
+  browserWorkspaceId: 'client',
+  browserPageId: 'client',
+  placement: {
+    kind: 'client',
+    browserHostClientId: 'host',
+    browserHostGeneration: 1,
+    pageHostGeneration: 1
+  }
+}
 const snapshot: RuntimeMobileSessionTabsSnapshot = {
   worktree: 'wt',
   publicationEpoch: 'renderer:1',
@@ -29,82 +41,51 @@ const snapshot: RuntimeMobileSessionTabsSnapshot = {
   tabGroups: [{ id: 'group', activeTabId: 'renderer-tab', tabOrder: ['renderer-tab'] }]
 }
 
-it('keeps renderer-owned browser pages when refreshing client-hosted pages on an attached desktop', () => {
+/** Drives the reconcile against a stub host and returns the published snapshot, if any. */
+function reconcile(
+  host: {
+    live?: RuntimeMobileSessionBrowserTab[]
+    attached?: boolean
+    offscreen?: boolean
+  },
+  existing: RuntimeMobileSessionTabsSnapshot = snapshot
+): RuntimeMobileSessionTabsSnapshot | undefined {
   const storeMobileSessionSnapshot = vi.fn()
-  const reconcile =
-    OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
-      reconcileHeadlessMobileSessionBrowserTabs(
-        worktreeId: string,
-        snapshot: RuntimeMobileSessionTabsSnapshot
-      ): void
-    }
-  reconcile.reconcileHeadlessMobileSessionBrowserTabs.call(
+  const runtime = OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
+    reconcileHeadlessMobileSessionBrowserTabs(
+      worktreeId: string,
+      existing: RuntimeMobileSessionTabsSnapshot
+    ): void
+  }
+  runtime.reconcileHeadlessMobileSessionBrowserTabs.call(
     {
-      buildHeadlessMobileSessionBrowserTabs: () => [],
-      getAvailableAuthoritativeWindow: () => ({}),
-      offscreenBrowserBackend: null,
+      buildHeadlessMobileSessionBrowserTabs: () => host.live ?? [],
+      getAvailableAuthoritativeWindow: () => (host.attached === false ? null : {}),
+      offscreenBrowserBackend: host.offscreen === true ? {} : null,
       storeMobileSessionSnapshot
     },
     'wt',
-    snapshot
+    existing
   )
-  const published = storeMobileSessionSnapshot.mock.calls[0]?.[1] ?? snapshot
+  return storeMobileSessionSnapshot.mock.calls[0]?.[1]
+}
+
+it('keeps renderer-owned browser pages when refreshing client-hosted pages on an attached desktop', () => {
+  const published = reconcile({}) ?? snapshot
+
   expect(published.tabs).toContainEqual(rendererPage)
-  expect(published.tabGroups[0].tabOrder).toContain('renderer-tab')
+  expect(published.tabGroups?.[0].tabOrder).toContain('renderer-tab')
 })
 
 it.each([false, true])('retires absent offscreen pages when attached=%s', (attached) => {
-  const storeMobileSessionSnapshot = vi.fn()
-  const reconcile =
-    OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
-      reconcileHeadlessMobileSessionBrowserTabs(
-        worktreeId: string,
-        snapshot: RuntimeMobileSessionTabsSnapshot
-      ): void
-    }
-  reconcile.reconcileHeadlessMobileSessionBrowserTabs.call(
-    {
-      buildHeadlessMobileSessionBrowserTabs: () => [],
-      getAvailableAuthoritativeWindow: () => (attached ? {} : null),
-      offscreenBrowserBackend: {},
-      storeMobileSessionSnapshot
-    },
-    'wt',
-    snapshot
-  )
-  expect(storeMobileSessionSnapshot.mock.calls[0]?.[1].tabs).toEqual([])
+  expect(reconcile({ attached, offscreen: true })?.tabs).toEqual([])
 })
 
 it('removes retired client pages and publishes live ones while retaining renderer rows and group order', () => {
-  const clientPage: RuntimeMobileSessionBrowserTab = {
-    ...rendererPage,
-    id: 'client',
-    browserWorkspaceId: 'client',
-    browserPageId: 'client',
-    placement: {
-      kind: 'client',
-      browserHostClientId: 'host',
-      browserHostGeneration: 1,
-      pageHostGeneration: 1
-    }
-  }
   const livePage = { ...clientPage, id: 'live', browserWorkspaceId: 'live', browserPageId: 'live' }
-  const storeMobileSessionSnapshot = vi.fn()
-  const reconcile =
-    OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
-      reconcileHeadlessMobileSessionBrowserTabs(
-        worktreeId: string,
-        snapshot: RuntimeMobileSessionTabsSnapshot
-      ): void
-    }
-  reconcile.reconcileHeadlessMobileSessionBrowserTabs.call(
-    {
-      buildHeadlessMobileSessionBrowserTabs: () => [livePage],
-      getAvailableAuthoritativeWindow: () => ({}),
-      offscreenBrowserBackend: null,
-      storeMobileSessionSnapshot
-    },
-    'wt',
+
+  const published = reconcile(
+    { live: [livePage] },
     {
       ...snapshot,
       tabs: [rendererPage, clientPage],
@@ -113,12 +94,12 @@ it('removes retired client pages and publishes live ones while retaining rendere
       ]
     }
   )
-  const published = storeMobileSessionSnapshot.mock.calls[0]?.[1]
-  expect(published.tabs).toEqual([rendererPage, livePage])
-  expect(published.tabGroups[0].tabOrder).toEqual(['renderer-tab', 'live'])
-  expect(published.activeTabId).toBe('renderer-tab')
-  expect(published.publicationEpoch).toBe(snapshot.publicationEpoch)
-  expect(published.snapshotVersion).toBe(snapshot.snapshotVersion + 1)
+
+  expect(published?.tabs).toEqual([rendererPage, livePage])
+  expect(published?.tabGroups?.[0].tabOrder).toEqual(['renderer-tab', 'live'])
+  expect(published?.activeTabId).toBe('renderer-tab')
+  expect(published?.publicationEpoch).toBe(snapshot.publicationEpoch)
+  expect(published?.snapshotVersion).toBe(snapshot.snapshotVersion + 1)
 })
 
 it('keeps the renderer publication epoch when selecting a client-hosted browser tab', () => {
@@ -130,6 +111,7 @@ it('keeps the renderer publication epoch when selecting a client-hosted browser 
       options: { focusesHost: boolean }
     ): void
   }
+
   runtime.markHeadlessBrowserSessionTabActive.call(
     {
       offscreenBrowserBackend: {},
@@ -142,6 +124,7 @@ it('keeps the renderer publication epoch when selecting a client-hosted browser 
     'renderer-page',
     { focusesHost: false }
   )
+
   expect(storeMobileSessionSnapshot.mock.calls[0]?.[1].publicationEpoch).toBe(
     snapshot.publicationEpoch
   )

--- a/src/main/runtime/renderer-browser-session-reconciliation.test.ts
+++ b/src/main/runtime/renderer-browser-session-reconciliation.test.ts
@@ -115,6 +115,16 @@ it('never publishes a row twice when the live build reclaims a renderer-owned id
   expect(published?.tabGroups?.[0].tabOrder).toEqual([rendererPage.id])
 })
 
+it('does not republish when a client row merely sits before a renderer row', () => {
+  const interleaved = {
+    ...snapshot,
+    tabs: [clientPage, rendererPage],
+    tabGroups: [{ id: 'group', activeTabId: 'renderer-tab', tabOrder: ['client', 'renderer-tab'] }]
+  }
+
+  expect(reconcile({ live: [clientPage] }, interleaved)).toBeUndefined()
+})
+
 it('keeps the renderer publication epoch when selecting a client-hosted browser tab', () => {
   const storeMobileSessionSnapshot = vi.fn()
   const runtime = OrcaRuntimeWithCloseStructuredAgentSessionTab.prototype as unknown as {

--- a/src/main/runtime/renderer-browser-session-reconciliation.test.ts
+++ b/src/main/runtime/renderer-browser-session-reconciliation.test.ts
@@ -1,0 +1,148 @@
+import { expect, it, vi } from 'vitest'
+import type {
+  RuntimeMobileSessionBrowserTab,
+  RuntimeMobileSessionTabsSnapshot
+} from '../../shared/runtime-types'
+import { OrcaRuntimeWithCloseStructuredAgentSessionTab } from './orca-runtime-close-structured-agent-session-tab'
+import { OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs } from './orca-runtime-reconcile-headless-mobile-session-browser-tabs'
+
+const rendererPage: RuntimeMobileSessionBrowserTab = {
+  type: 'browser',
+  id: 'renderer-tab',
+  browserWorkspaceId: 'renderer-workspace',
+  browserPageId: 'renderer-page',
+  title: 'Server page',
+  url: 'https://example.com/server',
+  loading: false,
+  canGoBack: false,
+  canGoForward: false,
+  isActive: false
+}
+const snapshot: RuntimeMobileSessionTabsSnapshot = {
+  worktree: 'wt',
+  publicationEpoch: 'renderer:1',
+  snapshotVersion: 1,
+  activeGroupId: 'group',
+  activeTabId: 'renderer-tab',
+  activeTabType: 'browser',
+  tabs: [rendererPage],
+  tabGroups: [{ id: 'group', activeTabId: 'renderer-tab', tabOrder: ['renderer-tab'] }]
+}
+
+it('keeps renderer-owned browser pages when refreshing client-hosted pages on an attached desktop', () => {
+  const storeMobileSessionSnapshot = vi.fn()
+  const reconcile =
+    OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
+      reconcileHeadlessMobileSessionBrowserTabs(
+        worktreeId: string,
+        snapshot: RuntimeMobileSessionTabsSnapshot
+      ): void
+    }
+  reconcile.reconcileHeadlessMobileSessionBrowserTabs.call(
+    {
+      buildHeadlessMobileSessionBrowserTabs: () => [],
+      getAvailableAuthoritativeWindow: () => ({}),
+      offscreenBrowserBackend: null,
+      storeMobileSessionSnapshot
+    },
+    'wt',
+    snapshot
+  )
+  const published = storeMobileSessionSnapshot.mock.calls[0]?.[1] ?? snapshot
+  expect(published.tabs).toContainEqual(rendererPage)
+  expect(published.tabGroups[0].tabOrder).toContain('renderer-tab')
+})
+
+it.each([false, true])('retires absent offscreen pages when attached=%s', (attached) => {
+  const storeMobileSessionSnapshot = vi.fn()
+  const reconcile =
+    OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
+      reconcileHeadlessMobileSessionBrowserTabs(
+        worktreeId: string,
+        snapshot: RuntimeMobileSessionTabsSnapshot
+      ): void
+    }
+  reconcile.reconcileHeadlessMobileSessionBrowserTabs.call(
+    {
+      buildHeadlessMobileSessionBrowserTabs: () => [],
+      getAvailableAuthoritativeWindow: () => (attached ? {} : null),
+      offscreenBrowserBackend: {},
+      storeMobileSessionSnapshot
+    },
+    'wt',
+    snapshot
+  )
+  expect(storeMobileSessionSnapshot.mock.calls[0]?.[1].tabs).toEqual([])
+})
+
+it('removes retired client pages and publishes live ones while retaining renderer rows and group order', () => {
+  const clientPage: RuntimeMobileSessionBrowserTab = {
+    ...rendererPage,
+    id: 'client',
+    browserWorkspaceId: 'client',
+    browserPageId: 'client',
+    placement: {
+      kind: 'client',
+      browserHostClientId: 'host',
+      browserHostGeneration: 1,
+      pageHostGeneration: 1
+    }
+  }
+  const livePage = { ...clientPage, id: 'live', browserWorkspaceId: 'live', browserPageId: 'live' }
+  const storeMobileSessionSnapshot = vi.fn()
+  const reconcile =
+    OrcaRuntimeWithReconcileHeadlessMobileSessionBrowserTabs.prototype as unknown as {
+      reconcileHeadlessMobileSessionBrowserTabs(
+        worktreeId: string,
+        snapshot: RuntimeMobileSessionTabsSnapshot
+      ): void
+    }
+  reconcile.reconcileHeadlessMobileSessionBrowserTabs.call(
+    {
+      buildHeadlessMobileSessionBrowserTabs: () => [livePage],
+      getAvailableAuthoritativeWindow: () => ({}),
+      offscreenBrowserBackend: null,
+      storeMobileSessionSnapshot
+    },
+    'wt',
+    {
+      ...snapshot,
+      tabs: [rendererPage, clientPage],
+      tabGroups: [
+        { id: 'group', activeTabId: 'renderer-tab', tabOrder: ['renderer-tab', 'client'] }
+      ]
+    }
+  )
+  const published = storeMobileSessionSnapshot.mock.calls[0]?.[1]
+  expect(published.tabs).toEqual([rendererPage, livePage])
+  expect(published.tabGroups[0].tabOrder).toEqual(['renderer-tab', 'live'])
+  expect(published.activeTabId).toBe('renderer-tab')
+  expect(published.publicationEpoch).toBe(snapshot.publicationEpoch)
+  expect(published.snapshotVersion).toBe(snapshot.snapshotVersion + 1)
+})
+
+it('keeps the renderer publication epoch when selecting a client-hosted browser tab', () => {
+  const storeMobileSessionSnapshot = vi.fn()
+  const runtime = OrcaRuntimeWithCloseStructuredAgentSessionTab.prototype as unknown as {
+    markHeadlessBrowserSessionTabActive(
+      worktreeId: string,
+      browserPageId: string,
+      options: { focusesHost: boolean }
+    ): void
+  }
+  runtime.markHeadlessBrowserSessionTabActive.call(
+    {
+      offscreenBrowserBackend: {},
+      hydrateHeadlessMobileSessionTabsFromWorkspaceSession: () => undefined,
+      mobileSessionTabsByWorktree: new Map([['wt', snapshot]]),
+      storeMobileSessionSnapshot,
+      emitMobileSessionTabsSnapshot: vi.fn()
+    },
+    'wt',
+    'renderer-page',
+    { focusesHost: false }
+  )
+  expect(storeMobileSessionSnapshot.mock.calls[0]?.[1].publicationEpoch).toBe(
+    snapshot.publicationEpoch
+  )
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

## ELI5

When your phone or tablet is paired with Orca on your desktop, both screens share one list of open browser tabs. Opening a browser page from the paired device used to make the desktop re-file that shared list under a brand-new name, while the desktop's own tabs were still filed under the old name — so from then on the desktop's updates were ignored as out of date. What you saw: you would open a browser tab from the paired device, it would spin, time out, and then disappear, sometimes taking the desktop's other browser tabs with it. Now the shared list keeps its name and simply counts up a version number, which is the ordering both sides already knew how to follow. Opening a browser page from a paired device leaves the desktop's browser tabs alone, and the new tab stays put.

## This fixes three distinct things, not one

They are separable and can be reviewed independently.

**1. Renderer-owned tab loss.** When a desktop renderer owns browser pages, its rows now survive a reconcile of the separate client-hosted registry. Offscreen and retired client pages still reconcile against their live owners.

**2. The main-side resync storm.** Browser selection and reconciliation no longer mint a fresh `headless:<ts>` / `headless-hydrated:<ts>` epoch; they keep the existing epoch and advance `snapshotVersion`.

**3. Mobile's staleness floor, which epoch rotation was silently defeating.** See below - this one is not obvious.

## What was wrong

Creating a client-hosted page on a paired desktop changed its session publication from the renderer epoch to a new headless epoch. Clients then rejected later renderer snapshots as retired, so creating a server-hosted fallback page timed out and removed the new tab.

Three distinct failures came out of that, all confirmed against the pre-fix code:

- **Tab loss.** The old reconcile computed `liveBrowserTabs` from the headless source only, with no preservation of renderer-owned tabs. Every `allowAttachedWindow: true` caller — `orca-runtime-hydrate-headless-mobile-session-tabs-from-workspace-session.ts:100-113` reconciles whenever `existing.tabs.length > 0 && onlyRuntimeOwnedTerminals !== true` — silently dropped every renderer-owned browser tab from the published snapshot.
- **Frames rejected as retired.** On the client, `noteSessionTabsPublicationEpoch` pushes the previous epoch onto a `retired` list (`web-session-tabs-sync/publisher-identity-fences.ts`), and `tracking-decisions.ts` then returns `WEB_SESSION_TABS_FRAME_OUTRANKED` for any later frame carrying it. Because the desktop renderer mints exactly one epoch per process lifetime (`renderer:${createBrowserUuid()}`, a module-level constant in `sync-runtime-graph/graph-state.ts`), retiring it fenced the renderer out until restart.
- **Resync storm.** The `unchanged` fast path in `orca-runtime-sync-mobile-session-tabs.ts:108-121` requires the stored epoch to equal the accepted one or extend it with `:headless-merge:`. A minted `headless:<ts>` matches neither against a remembered `renderer:1`, so after one browser-tab click every subsequent unchanged resend failed the gate forever. It also fed `isHeadlessBuiltMobileSessionPublicationBase`, misclassifying a renderer-owned worktree as headless-built.

## Why this is the right layer

`publicationEpoch` is a *lineage* identifier, not a change counter. Ordering *within* an epoch is already carried by `snapshotVersion`, and `orca-runtime-sync-mobile-session-tabs.ts` already keeps that counter strictly monotonic across both writers:

```ts
const storedVersion = existing
  ? Math.max(nextSnapshot.snapshotVersion, existing.snapshotVersion + 1)
  : nextSnapshot.snapshotVersion
```

That comment explicitly anticipates "main-local touches" bumping the version above the renderer's counter. This change makes the browser reconcile behave like every other main-local touch instead of inventing a parallel epoch. Preferring the existing epoch is already the established pattern here — see `orca-runtime-restore-structured-agent-session-tabs-once.ts`, which uses `existing?.publicationEpoch ?? ...`.

## Fix 3: this repairs mobile's staleness check

Not obvious, so worth stating explicitly. `mobile/src/session/session-tab-snapshot-gate.ts:20-33` treats a *different* epoch as a new publisher and resets the version floor (`marker.epoch = incomingEpoch`), skipping the `snapshotVersion < marker.version` rejection entirely. Under the old code every browser-tab click minted a fresh epoch, so mobile reset its floor each time and defeated its own out-of-order protection. Removing the rotation makes that check function as intended. The only other prefix-sensitive mobile consumer, `confirmsMirroredTabSelection`, keys on `mobile-local:` and is untouched.

## Tradeoffs

Genuine user-facing costs of this approach:

- **Renderer browser rows are retained longer.** While a desktop window is attached, this reconcile can no longer retire renderer-owned browser rows at all — retirement becomes solely the renderer's job. If the renderer's own publication is delayed or wedged, a browser tab closed on the desktop can linger in the paired device's tab strip until the renderer republishes. Previously the client-registry reconcile would incidentally prune it (which is exactly what caused this bug, but it did also prune).
- **The fix does not cover a promoted serve.** The guard is `getAvailableAuthoritativeWindow() && !this.offscreenBrowserBackend`. `attachWindow` can promote `HEADLESS_RUNTIME_WINDOW_ID` to a real window without clearing `offscreenBrowserBackend` (`orca-runtime-attach-window.ts:9-23`), and nothing clears that field, so in that mode renderer rows are still stripped. This is unchanged from today's behaviour rather than a new regression, and the `!offscreenBrowserBackend` half of the guard is deliberate: dropping it would wrongly retain genuinely-closed offscreen server rows.
- **Mid-detach, renderer rows still drop.** The guard is an undebounced live boolean, so during a window teardown a renderer-placed row the live build cannot reproduce is retired in that same call. This matches the existing preservation policy — `shouldPreserveHeadlessMobileSessionTab` already returns `false` for non-client browser rows when there is no offscreen backend, i.e. renderer-owned browser rows are designed to die with the renderer.

No new latency or resource use: the added work is one O(n) filter and one `Map` over the existing browser tabs.

## Remote wire compatibility

No new fields and no new stream opcodes, so no capability negotiation is required. The change only affects *which values* existing fields carry: an old client sees a stable `publicationEpoch` with a strictly increasing `snapshotVersion`, which is the ordinary accepted path in `tracking-decisions.ts`. Mixed versions are safe in both directions — an old host paired with a new client still rotates epochs and is still accepted, because the client-side retirement logic is unchanged. The per-client `:client-navigation` suffix preserves the base epoch, so the stable base propagates through client projection unchanged.

## Validation

Regressions reproduced renderer-row loss and both epoch changes; 79 focused tests, `tc:node`, formatting, and lint pass. The unchanged paired browser journey passed both desktop and headless topologies twice (4 cases). Local E2E used the combined validation build including #18952, which fixes the separate initial browser snapshot reset failure.

**Visual proof:** not viable for this change and not attached. The fix is main-process session-snapshot bookkeeping, and reproducing it visually requires two paired devices (a desktop renderer plus a paired client) driven simultaneously — CDP screenshots of a single hidden renderer cannot show the cross-device frame rejection. Per repo `AGENTS.md`, local Electron launches are paused for this work, so the paired journey is covered by the E2E topologies above instead.

Application change: left open for user review.
