### PR TITLE
test: isolate Source Control generation from shared repository remotes

### DIFF
--- a/tests/e2e/helpers/seeded-test-repo.ts
+++ b/tests/e2e/helpers/seeded-test-repo.ts
@@ -28,7 +28,7 @@ export function isValidGitRepo(repoPath: string): boolean {
   }
 }
 
-export function createSeededTestRepo(): string {
+export function createSeededTestRepo(options: { publishPath?: boolean } = {}): string {
   // Why: realpathSync so the seeded path matches the store's repo.path on
   // macOS, where os.tmpdir() (/var/...) symlinks to /private/var/... and the
   // app canonicalizes repo.path via `git rev-parse --show-toplevel` on add.
@@ -63,6 +63,8 @@ export function createSeededTestRepo(): string {
     stdio: 'pipe'
   })
 
-  writeFileSync(TEST_REPO_PATH_FILE, testRepoDir)
+  if (options.publishPath !== false) {
+    writeFileSync(TEST_REPO_PATH_FILE, testRepoDir)
+  }
   return testRepoDir
 }

--- a/tests/e2e/helpers/source-control-generation-app.ts
+++ b/tests/e2e/helpers/source-control-generation-app.ts
@@ -1,0 +1,21 @@
+import { test as base, expect } from './orca-app'
+import { createSeededTestRepo } from './seeded-test-repo'
+import { cleanupTestRepository } from '../global-teardown'
+
+export { expect }
+
+export const test = base.extend({
+  testRepoPath: [
+    // oxlint-disable-next-line no-empty-pattern -- Playwright requires destructured fixture arguments.
+    async ({}, provideFixture) => {
+      // Generation must not fetch external remotes installed by unrelated specs.
+      const repoPath = createSeededTestRepo({ publishPath: false })
+      try {
+        await provideFixture(repoPath)
+      } finally {
+        cleanupTestRepository(repoPath)
+      }
+    },
+    { scope: 'worker' }
+  ]
+})

--- a/tests/e2e/source-control-pr-generation-switch.spec.ts
+++ b/tests/e2e/source-control-pr-generation-switch.spec.ts
@@ -1,7 +1,7 @@
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
-import { test, expect } from './helpers/orca-app'
+import { test, expect } from './helpers/source-control-generation-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
   createBranchCommit,

--- a/tests/e2e/source-control-pr-linked-issue-ai.spec.ts
+++ b/tests/e2e/source-control-pr-linked-issue-ai.spec.ts
@@ -1,7 +1,7 @@
 import { rmSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { test, expect } from './helpers/orca-app'
+import { test, expect } from './helpers/source-control-generation-app'
 import {
   createBranchCommit,
   openSourceControl,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Source Control generation specs passed alone but failed in the full sweep when unrelated specs left an external `origin` in the shared repository. PR context preparation then attempted a real fetch and failed authentication before invoking the fake generator.

Give the generation specs their own worker-owned seeded repository and clean it up after Electron teardown. Reuse the existing seeder and repository cleanup; an optional seeder flag leaves the suite-wide repository pointer untouched.

Validation: all 16 repeated cases pass with two workers; both linked-issue cases also pass with an intentionally unusable origin in the suite-wide repository. Formatting and lint pass. The full E2E TypeScript check reports existing errors elsewhere, with none in these changed files. Assertions and timeouts are unchanged.
