### PR TITLE
perf(tabs): index saved tab order during hydration repair

### DIFF
--- a/config/scripts/benchmark-tab-group-repair.mjs
+++ b/config/scripts/benchmark-tab-group-repair.mjs
@@ -1,0 +1,80 @@
+import { strict as assert } from 'node:assert'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { build } from 'esbuild'
+
+const root = resolve(import.meta.dirname, '../..')
+const source = join(root, 'src/renderer/src/store/slices/tab-group-reference-repair.ts')
+const directory = await mkdtemp(join(tmpdir(), 'orca-tab-repair-'))
+const current = await readFile(source, 'utf8')
+const indexed = `const orderedTabIds = new Set(group.tabOrder)
+    const missingTabIds = ownedTabIds.filter((tabId) => !orderedTabIds.has(tabId))`
+assert(current.includes(indexed), 'Expected indexed implementation')
+try {
+  const implementations = []
+  for (const baseline of [true, false]) {
+    const outfile = join(directory, baseline ? 'before.cjs' : 'after.cjs')
+    await build({
+      stdin: {
+        contents: baseline
+          ? current.replace(
+              indexed,
+              'const missingTabIds = ownedTabIds.filter((tabId) => !group.tabOrder.includes(tabId))'
+            )
+          : current,
+        resolveDir: resolve(source, '..'),
+        loader: 'ts'
+      },
+      bundle: true,
+      platform: 'node',
+      format: 'cjs',
+      outfile,
+      alias: { '@': join(root, 'src/renderer/src') }
+    })
+    implementations.push(createRequire(import.meta.url)(outfile).appendOwnedTabIdsToGroups)
+  }
+  const rows = []
+  for (const count of [1, 10, 100, 1_000, 10_000]) {
+    for (const missing of [false, true]) {
+      const ids = Array.from({ length: count }, (_, i) => `tab-${i}`)
+      const groups = [
+        { id: 'group', worktreeId: 'workspace', activeTabId: null, tabOrder: ids, recentTabIds: [] }
+      ]
+      const owners = new Map(ids.map((id) => [missing ? `missing-${id}` : id, 'group']))
+      assert.deepEqual(implementations[0](groups, owners), implementations[1](groups, owners))
+      const iterations = Math.max(1, Math.floor(10_000 / count))
+      const samples = [[], []]
+      for (let sample = -3; sample < 11; sample++) {
+        for (const index of sample % 2 === 0 ? [0, 1] : [1, 0]) {
+          const start = performance.now()
+          for (let i = 0; i < iterations; i++) {
+            implementations[index](groups, owners)
+          }
+          const elapsed = (performance.now() - start) / iterations
+          if (sample >= 0) {
+            samples[index].push(elapsed)
+          }
+        }
+      }
+      rows.push({
+        count,
+        missing,
+        iterations,
+        beforeMs: samples[0].sort((a, b) => a - b)[5],
+        afterMs: samples[1].sort((a, b) => a - b)[5]
+      })
+    }
+  }
+  console.log(
+    JSON.stringify(
+      { node: process.version, platform: process.platform, samples: 11, warmups: 3, rows },
+      null,
+      2
+    )
+  )
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}

--- a/src/renderer/src/store/slices/tab-group-reference-repair.test.ts
+++ b/src/renderer/src/store/slices/tab-group-reference-repair.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroup } from '../../../../shared/tab-types'
+import { appendOwnedTabIdsToGroups } from './tab-group-reference-repair'
+
+function group(id: string, tabOrder: string[]): TabGroup {
+  return { id, worktreeId: 'workspace', activeTabId: null, tabOrder, recentTabIds: [] }
+}
+
+describe('appendOwnedTabIdsToGroups', () => {
+  it('preserves existing order, duplicates, and untouched group identities', () => {
+    const complete = group('complete', ['b', 'a', 'a'])
+    const missing = group('missing', ['stale', 'c'])
+    const unowned = group('unowned', ['external'])
+    const owners = new Map([
+      ['a', 'complete'],
+      ['b', 'complete'],
+      ['d', 'missing'],
+      ['c', 'missing'],
+      ['e', 'missing'],
+      ['elsewhere', 'absent']
+    ])
+    const result = appendOwnedTabIdsToGroups([complete, missing, unowned], owners)
+    expect(result).toEqual([complete, { ...missing, tabOrder: ['stale', 'c', 'd', 'e'] }, unowned])
+    expect(result[0]).toBe(complete)
+    expect(result[2]).toBe(unowned)
+    expect(missing.tabOrder).toEqual(['stale', 'c'])
+  })
+
+  it.each([false, true])('bounds saved-order reads with missing tabs: %s', (missing) => {
+    const count = 1_000
+    const ids = Array.from({ length: count }, (_, i) => `tab-${i}`)
+    let reads = 0
+    const order = new Proxy(ids, {
+      get(target, property, receiver) {
+        if (typeof property === 'string' && /^\d+$/.test(property)) {
+          reads++
+        }
+        return Reflect.get(target, property, receiver)
+      }
+    })
+    const original = group('group', order)
+    const ownedIds = missing ? ids.map((id) => `missing-${id}`) : ids
+    const result = appendOwnedTabIdsToGroups(
+      [original],
+      new Map(ownedIds.map((id) => [id, original.id]))
+    )
+    const repairReads = reads
+    expect(result[0].tabOrder).toEqual(missing ? [...ids, ...ownedIds] : ids)
+    if (!missing) {
+      expect(result[0]).toBe(original)
+    }
+    expect(repairReads).toBeLessThanOrEqual(count * 2)
+  })
+})

--- a/src/renderer/src/store/slices/tab-group-reference-repair.ts
+++ b/src/renderer/src/store/slices/tab-group-reference-repair.ts
@@ -72,7 +72,8 @@ export function appendOwnedTabIdsToGroups(
     if (!ownedTabIds) {
       return group
     }
-    const missingTabIds = ownedTabIds.filter((tabId) => !group.tabOrder.includes(tabId))
+    const orderedTabIds = new Set(group.tabOrder)
+    const missingTabIds = ownedTabIds.filter((tabId) => !orderedTabIds.has(tabId))
     return missingTabIds.length > 0
       ? { ...group, tabOrder: [...group.tabOrder, ...missingTabIds] }
       : group


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 |

<!-- /orca-pr-loc -->

## ELI5
When restoring saved tabs, Orca checks which tabs are missing from each group. Previously it reread the whole saved order for every tab. Build one lookup per group so each membership check is cheap.

## What changed and why
`appendOwnedTabIdsToGroups` indexes the existing saved order in a temporary Set. Existing order and duplicates remain untouched; missing IDs append in owner-map order; complete and unowned groups keep their identities. The lookup is scoped to one synchronous repair call, with no cache or invalidation.

## Measurements
macOS, Node v24.18.0, production helper bundled with esbuild. Eleven alternating samples after three warmups; medians per call. The committed benchmark reconstructs the old membership expression against the same source.

| Saved tabs in one group | Case | Before | After |
|---|---|---:|---:|
| 100 | Already ordered | 0.00998 ms | 0.00318 ms |
| 1,000 | Already ordered | 1.49965 ms | 0.03600 ms |
| 1,000 | All owned IDs missing | 0.49983 ms | 0.04463 ms |
| 10,000 | Already ordered, stress case | 156.86442 ms | 0.66662 ms |
| 10,000 | All owned IDs missing, stress case | 109.66487 ms | 0.70154 ms |

Deterministic saved-order reads at 1,000 entries: already ordered 500,500 → 1,000; all missing 1,001,000 → 2,000 (includes copying the preserved order). Both regression cases fail against the old helper. These measure repair work, not rendered startup latency.

Reproduce: `node config/scripts/benchmark-tab-group-repair.mjs`.

## Negative user-facing trade-offs
- None identified: output, duplicate handling, ordering, group identity, and input immutability remain unchanged.
- Internal cost: one temporary Set with up to one entry per saved ID. It is not retained. Tiny 1–10-tab cases measured up to 0.00011 ms extra per call; no meaningful user-facing latency claim follows from such small timings.
- No tabs are capped, delayed, discarded, or hidden to obtain the improvement.

## Testing
- 32 tests across tab ownership repair, tab hydration, group validation, session hydration, and generated titles passed.
- `pnpm tc:web` passed; changed-file oxlint, React Doctor lint, and oxfmt passed.
- New tests verify exact repair output, duplicates, ordering, untouched identities, input immutability, and bounded saved-order reads.
- Pure string-ID logic: no filesystem, platform, provider, SSH execution, folder/worktree identity, or wire changes. Native Windows/Linux and live SSH were not exercised locally; CI covers broader checks.

## Visual Proof
N/A — no visual or interaction change; only membership lookup during existing hydration repair changes.

## Linked Issue
None. The user explicitly requested no GitHub issues.

## Review
Self-reviewed. No upstream skill source copied. No application windows launched for this change.
