### PR TITLE
perf(palette): reuse allowed quality arrays during matching

### DIFF
--- a/src/renderer/src/lib/palette-match/match-field-allocation.test.ts
+++ b/src/renderer/src/lib/palette-match/match-field-allocation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  indexPaletteField,
+  type PaletteIdentifierKind,
+  type PaletteFieldProfile
+} from './indexed-field'
+import { matchPaletteField } from './match-field'
+import { createPaletteQueryToken } from './palette-query'
+
+describe('palette field quality allocation', () => {
+  it.each(['scan', 's', '123', 'scna', 'zzz'])(
+    'does not allocate a Set per field for %s',
+    (query) => {
+      const profiles: PaletteFieldProfile[] = [
+        'structured-label',
+        'identifier',
+        'path',
+        'prose',
+        'exact-alias'
+      ]
+      const fields = Array.from({ length: 1_000 }, (_, i) =>
+        indexPaletteField({
+          id: String(i),
+          profile: profiles[i % profiles.length],
+          text: 'scan daily 1234 workspace',
+          ...(i % 2 === 0 ? { identifier: { kind: 'number' as const } } : {})
+        })!
+      )
+      const token = createPaletteQueryToken(query, 0)
+      let allocations = 0
+      const NativeSet = globalThis.Set
+      class CountedSet<T> extends NativeSet<T> {
+        constructor(values?: Iterable<T> | null) {
+          super(values)
+          allocations++
+        }
+      }
+      vi.stubGlobal('Set', CountedSet)
+      try {
+        for (const field of fields) {
+          matchPaletteField(field, token)
+        }
+      } finally {
+        vi.unstubAllGlobals()
+      }
+      expect(allocations).toBe(0)
+    }
+  )
+})
+
+describe('palette quality restrictions remain local to each match', () => {
+  it.each<PaletteIdentifierKind>(['number', 'version', 'date', 'port', 'sha', 'key'])(
+    'preserves prefix permissions for %s',
+    (kind) => {
+      const field = indexPaletteField({
+        id: 'id',
+        profile: 'identifier',
+        text: '12345',
+        identifier: { kind }
+      })!
+      const prefix = createPaletteQueryToken('123', 0)
+      const exact = createPaletteQueryToken('12345', 0)
+      const expected = ['port', 'sha', 'key'].includes(kind)
+        ? { quality: 'field-prefix', ranges: [{ start: 0, end: 3 }] }
+        : null
+      expect(matchPaletteField(field, prefix)).toEqual(expected)
+      expect(matchPaletteField(field, exact)).toEqual({
+        quality: 'field-exact',
+        ranges: [{ start: 0, end: 5 }]
+      })
+      expect(matchPaletteField(field, prefix)).toEqual(expected)
+    }
+  )
+
+  it.each<PaletteFieldProfile>(['structured-label', 'identifier', 'path', 'prose', 'exact-alias'])(
+    'preserves typo restrictions for %s without mutating the profile',
+    (profile) => {
+      const field = indexPaletteField({ id: 'id', profile, text: 'scan' })!
+      expect(matchPaletteField(field, createPaletteQueryToken('s', 0))).toEqual({
+        quality: 'field-prefix',
+        ranges: [{ start: 0, end: 1 }]
+      })
+      expect(matchPaletteField(field, createPaletteQueryToken('scam', 0))).toEqual(
+        ['structured-label', 'prose'].includes(profile)
+          ? { quality: 'typo', ranges: [{ start: 0, end: 4 }] }
+          : null
+      )
+    }
+  )
+})

--- a/src/renderer/src/lib/palette-match/match-field.ts
+++ b/src/renderer/src/lib/palette-match/match-field.ts
@@ -32,7 +32,7 @@ const SIGILS = new Set(['#', '!'])
 function allowedQualities(
   field: PaletteIndexedField,
   token: PaletteQueryToken
-): ReadonlySet<PaletteMatchQuality> {
+): readonly PaletteMatchQuality[] {
   let qualities = paletteProfileAllowedQualities(field.profile)
   if (field.identifier && !identifierKindAllowsPrefix(field.identifier.kind)) {
     qualities = qualities.filter((quality) => !PREFIX_QUALITIES.has(quality))
@@ -43,7 +43,7 @@ function allowedQualities(
   if (token.isIdentifierLike) {
     qualities = qualities.filter((quality) => quality !== 'typo')
   }
-  return new Set(qualities)
+  return qualities
 }
 
 /** `#123` must not reach a GitLab MR, and `!123` must not reach a GitHub PR. */
@@ -83,15 +83,15 @@ function toRanges(field: PaletteIndexedField, start: number, end: number): reado
 function matchLiteral(
   field: PaletteIndexedField,
   token: PaletteQueryToken,
-  qualities: ReadonlySet<PaletteMatchQuality>
+  qualities: readonly PaletteMatchQuality[]
 ): PaletteFieldMatch | null {
   const normalized = field.text.normalized
   const text = token.text
 
-  if (qualities.has('field-exact') && normalized === text) {
+  if (qualities.includes('field-exact') && normalized === text) {
     return { quality: 'field-exact', ranges: toRanges(field, 0, normalized.length) }
   }
-  if (qualities.has('word-exact')) {
+  if (qualities.includes('word-exact')) {
     const word = field.words.find((entry) => entry.text === text)
     if (word) {
       return { quality: 'word-exact', ranges: toRanges(field, word.start, word.end) }
@@ -101,10 +101,10 @@ function matchLiteral(
       return { quality: 'word-exact', ranges: toRanges(field, atom.start, atom.end) }
     }
   }
-  if (qualities.has('field-prefix') && normalized.startsWith(text)) {
+  if (qualities.includes('field-prefix') && normalized.startsWith(text)) {
     return { quality: 'field-prefix', ranges: toRanges(field, 0, text.length) }
   }
-  if (qualities.has('word-prefix')) {
+  if (qualities.includes('word-prefix')) {
     const word = field.words.find((entry) => entry.text.startsWith(text))
     const atom = field.atoms.find((entry) => normalized.startsWith(text, entry.start))
     const start = word && atom ? Math.min(word.start, atom.start) : (word?.start ?? atom?.start)
@@ -117,13 +117,13 @@ function matchLiteral(
   if (literalIndex === -1) {
     return null
   }
-  if (qualities.has('boundary-substring') && isWordStart(field, literalIndex)) {
+  if (qualities.includes('boundary-substring') && isWordStart(field, literalIndex)) {
     return {
       quality: 'boundary-substring',
       ranges: toRanges(field, literalIndex, literalIndex + text.length)
     }
   }
-  if (qualities.has('literal-substring')) {
+  if (qualities.includes('literal-substring')) {
     return {
       quality: 'literal-substring',
       ranges: toRanges(field, literalIndex, literalIndex + text.length)
@@ -135,9 +135,9 @@ function matchLiteral(
 function matchCompact(
   field: PaletteIndexedField,
   token: PaletteQueryToken,
-  qualities: ReadonlySet<PaletteMatchQuality>
+  qualities: readonly PaletteMatchQuality[]
 ): PaletteFieldMatch | null {
-  if (!qualities.has('compact') || token.compact.length < MIN_COMPACT_LENGTH) {
+  if (!qualities.includes('compact') || token.compact.length < MIN_COMPACT_LENGTH) {
     return null
   }
   for (const atom of field.atoms) {
@@ -152,9 +152,9 @@ function matchCompact(
 function matchTypo(
   field: PaletteIndexedField,
   token: PaletteQueryToken,
-  qualities: ReadonlySet<PaletteMatchQuality>
+  qualities: readonly PaletteMatchQuality[]
 ): PaletteFieldMatch | null {
-  if (!qualities.has('typo') || !token.isLetterOnly || !isPaletteTypoCandidate(token.text)) {
+  if (!qualities.includes('typo') || !token.isLetterOnly || !isPaletteTypoCandidate(token.text)) {
     return null
   }
   for (const word of field.words) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | 0 |

<!-- /orca-pr-loc -->

## ELI5
Each palette search checks many fields. Orca already has a short list of allowed match types, but copied that list into a new Set for every field and query token. Read the existing list directly to avoid those temporary allocations.

## What changed
Return the existing readonly quality array after the existing filters, and use `includes` for membership. Profiles contain at most eight string qualities. Matching precedence, range mapping, provider sigils, prefix rules, and typo restrictions are unchanged. Module-level Sets remain unchanged; no cache is added.

## Measurements
The committed test runs 1,000 indexed fields across all five profiles, including restricted numeric identifiers, for each of `scan`, `s`, `123`, `scna`, and `zzz`.

| Measurement | Before | After |
|---|---:|---:|
| Set allocations per 1,000 field matches, each query | 1,000 | 0 |
| Total over the five test cases | 5,000 | 0 |

All five allocation tests fail against the old implementation and pass with the change. Eleven additional assertions cover identifier-prefix and profile-typo semantics, including repeated restricted/unrestricted calls. Reproduce with `pnpm test src/renderer/src/lib/palette-match/match-field-allocation.test.ts`; the old parent fails only the five allocation budgets when run with the new test.

Additional temporary production-bundle differential checks compared 8,190 field cases and an 800-worktree document fixture across eight queries: complete results, nulls, qualities, and highlight ranges matched exactly. The document fixture eliminated 12,000 Set allocations per single-token query and 36,000 for three tokens. Timing varied across repeated local runs, so this PR claims allocation reduction, not a fixed typing-latency improvement.

## Negative user-facing trade-offs
- None identified in the covered semantics: results, ranking inputs, highlights, search coverage, and query handling are unchanged.
- Internal trade-off: membership scans at most eight strings instead of hashing a newly constructed Set. This removes construction and garbage-collection work; wall-clock samples varied and do not prove a universal latency improvement.
- No retained cache, delayed searches, result caps, or dropped work. Existing filtered arrays remain; this specifically removes the extra Set copy.

## Testing
- 196 tests across eight suites passed: field allocation/restrictions, matching core/performance, worktree search/multi-keyword, workspace tabs, browser, and simulator search.
- `pnpm tc:web`, changed-file oxlint, React Doctor lint, and oxfmt passed.
- Independent semantic review found no blocker; additional identifier and profile matrix coverage added.
- Local platform: macOS/Node. Pure renderer computation; no platform, filesystem, folder/worktree identity, SSH execution, provider routing, or wire changes. Native Windows/Linux and live SSH were not separately exercised.

## Visual Proof
N/A — no visual or interaction behavior change; the same match results and ranges are produced with fewer temporary allocations.

## Linked Issue
None. The user explicitly requested no GitHub issues.

## Review
Self-reviewed and independently inspected. No upstream skill source copied. No application windows launched for this change.
