### PR TITLE
fix(ci): store vetted refs in a reftable so case-twin branches don't fail the fetch

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -127,9 +127,12 @@ jobs:
           esac
           # Bare: a work-tree repo refuses to fetch over its own checked-out
           # branch. tree:0 keeps the fetch to the commit graph — no trees, no
-          # blobs — so this stays cheap next to the build it fronts.
+          # blobs — so this stays cheap next to the build it fronts. reftable
+          # because this repo has branches that differ only in casing, and the
+          # files backend cannot store both on a case-insensitive runner disk —
+          # it fails the entire fetch, not just the one ref.
           scratch="$RUNNER_TEMP/vet-requested-ref"
-          git init -q --bare "$scratch"
+          git init -q --bare --ref-format=reftable "$scratch"
           git -C "$scratch" fetch -q --filter=tree:0 "$REPO_URL" '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
           # Branch first to keep actions/checkout's old tie-break: bare
           # rev-parse would prefer the tag when a branch shares its name.

--- a/.github/workflows/dev-channel-win-build.yml
+++ b/.github/workflows/dev-channel-win-build.yml
@@ -149,9 +149,12 @@ jobs:
           fi
           # Reachability is the trust test: GitHub serves PR-only commits by SHA,
           # so resolving the object is not proof a branch or tag of this repo
-          # reaches it. Bare + tree:0 keeps this to the commit graph.
+          # reaches it. Bare + tree:0 keeps this to the commit graph; reftable
+          # because branches that differ only in casing cannot both be stored by
+          # the files backend on a case-insensitive runner disk, which fails the
+          # entire fetch rather than the one ref.
           scratch="$RUNNER_TEMP/vet-requested-ref"
-          git init -q --bare "$scratch"
+          git init -q --bare --ref-format=reftable "$scratch"
           git -C "$scratch" fetch -q --filter=tree:0 "$REPO_URL" '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
           if ! git -C "$scratch" rev-parse --verify --quiet "$REQUESTED_SHA^{commit}" >/dev/null; then
             echo "::error::Commit $REQUESTED_SHA is not in stablyai/orca."

--- a/config/scripts/workflow-ref-mirror-case-safety.test.mjs
+++ b/config/scripts/workflow-ref-mirror-case-safety.test.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+const readWorkflow = (relativePath) => parse(readFileSync(join(projectDir, relativePath), 'utf8'))
+
+// Every step that mirrors this repo's whole ref namespace onto a runner disk to
+// prove a commit is reachable from a branch or tag before signing it.
+const REF_MIRRORS = [
+  ['.github/workflows/adhoc-mac-build.yml', 'build-adhoc-mac', 'Vet the requested ref'],
+  ['.github/workflows/dev-channel-win-build.yml', 'build-win', 'Vet the requested inputs']
+]
+
+describe('ref-mirroring vet steps', () => {
+  // Why: macOS and Windows runner disks are case-insensitive, and this repo has
+  // branches that differ only in casing. The files backend cannot store both, and
+  // it fails the whole fetch rather than the one ref — so the vet step dies before
+  // any build runs. reftable keys refs in a table instead of file paths.
+  it.each(REF_MIRRORS)(
+    '%s creates its scratch repo with the reftable backend',
+    (path, job, step) => {
+      const run = readWorkflow(path).jobs[job].steps.find(
+        (candidate) => candidate.name === step
+      ).run
+
+      expect(run).toContain('+refs/heads/*:refs/heads/*')
+      expect(run).toMatch(/git init\b[^\n]*--ref-format=reftable/)
+      expect(run).not.toMatch(/git init -q --bare "\$scratch"/)
+    }
+  )
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## Problem

[Adhoc build run 34000825719](https://github.com/stablyai/orca/actions/runs/34000825719/job/101399264121) failed in **Vet the requested ref**, before checkout:

```
error: You're on a case-insensitive filesystem, and the remote you are
trying to fetch from has references that only differ in casing. It
is impossible to store such references with the 'files' backend.
```

The vet step mirrors every branch and tag of this repo into a scratch bare repo so it can prove the requested commit is reachable from one of them. `refs/heads/nwparker/faster-CI` and `refs/heads/nwparker/faster-ci` both exist, and a macOS/Windows runner disk is case-insensitive, so the `files` ref backend refuses — and it fails the *entire* fetch, not just the one ref. Every adhoc build has been dead since that branch was pushed, regardless of which ref was requested.

## Fix

Create the scratch repo with `--ref-format=reftable`. reftable keys refs in a table rather than as file paths, so casing stops mattering and **every** ref stays in the reachability set — no refs dropped, no change to the trust test itself.

`dev-channel-win-build.yml` carries the same mirror-and-check step and the same latent bug (NTFS is case-insensitive too), so it gets the same fix.

## Verification

Reproduced and fixed on a case-insensitive macOS filesystem against the real remote:

- `git init -q --bare` + the workflow's fetch → reproduces the failure exactly.
- `git init -q --bare --ref-format=reftable` + the same fetch → exit 0, 7246 refs stored, **both** case twins present.
- Replayed the step's full resolve + `for-each-ref --contains` logic: `improve-notification-view` (the ref that failed in CI), `main`, and each of `nwparker/faster-CI` / `nwparker/faster-ci` all resolve to distinct SHAs and pass the reachability check.

Both runner images are new enough for the backend: mac `git 2.54.0`, Windows `git 2.55.0.windows.5` (reftable landed in 2.45).

A contract test pins the invariant for both vet steps so a future copy of this pattern can't regress to the files backend.