### PR TITLE
test: drain project menu focus restoration before teardown

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentMapWorkspaceContextMenu.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorkspaceContextMenu.test.tsx
@@ -314,7 +314,19 @@ describe('Agent Map workspace context menu', () => {
       clientX: 100,
       clientY: 110
     })
-    fireEvent.click(await screen.findByText('Create new worktree for Orca', {}, { timeout: 5_000 }))
+    const createWorktree = await screen.findByText(
+      'Create new worktree for Orca',
+      {},
+      { timeout: 5_000 }
+    )
+    // Radix restores focus after unmount; drain it before the next test opens a menu.
+    const focusRestored = new Promise<void>((resolve) => {
+      screen
+        .getByRole('menu')
+        .addEventListener('focusScope.autoFocusOnUnmount', () => resolve(), { once: true })
+    })
+    fireEvent.click(createWorktree)
+    await act(async () => focusRestored)
 
     expect(useAppStore.getState().activeModal).toBe('new-workspace-composer')
     expect(useAppStore.getState().modalData).toEqual({


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The project-ring composer test ends while Radix still has a deferred focus-restoration callback. That callback can dismiss the next test's folder-workspace menu before its item is clicked.

Await the menu's unmount autofocus event before ending the preceding test. The folder-workspace interaction and both composer assertions stay unchanged.

Validation: the original failure reproduced in the full unit suite and focused reruns; the folder case passed alone. With the lifecycle wait, all 10 tests passed in normal and shuffled order (seed 12). Focused lint and format passed.
