### PR TITLE
fix: prefer retained provider snapshots during hidden terminal recovery

### DIFF
--- a/src/main/runtime/hidden-output-restored-provider-snapshot.test.ts
+++ b/src/main/runtime/hidden-output-restored-provider-snapshot.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRuntime, syncSinglePty } from './orca-runtime-test-fixtures.spec'
+
+describe('hidden-output recovery after provider reattach', () => {
+  it('uses retained provider modes instead of the pre-attach redraw suffix', async () => {
+    const runtime = createRuntime()
+    const serializeProviderBuffer = vi.fn(async () => ({
+      data: '\x1b[?1049hRetained TUI',
+      cols: 100,
+      rows: 30,
+      seq: 1000,
+      source: 'headless' as const,
+      alternateScreen: true
+    }))
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer
+    })
+    syncSinglePty(runtime, 'pty-1')
+    runtime.onPtyData('pty-1', '\x1b[HRedraw without the original alternate-screen entry', 60)
+    runtime.synchronizePtyOutputSequenceFromProvider('pty-1', {
+      value: 1000,
+      generation: 'continued'
+    })
+
+    const snapshot = await runtime.serializeHiddenOutputRecoveryBuffer('pty-1', {
+      scrollbackRows: 5000
+    })
+
+    expect(snapshot).toMatchObject({ data: '\x1b[?1049hRetained TUI', alternateScreen: true })
+    expect(serializeProviderBuffer).toHaveBeenCalledWith('pty-1', { scrollbackRows: 5000 })
+  })
+
+  it('keeps the renderer fallback for providers without retained snapshots', async () => {
+    const runtime = createRuntime()
+    runtime.onPtyData('pty-1', 'partial redraw', 14)
+    runtime.synchronizePtyOutputSequenceFromProvider('pty-1', {
+      value: 1000,
+      generation: 'continued'
+    })
+    const serializeBuffer = vi.fn(async () => ({
+      data: '\x1b[?1049hRenderer TUI',
+      cols: 100,
+      rows: 30
+    }))
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      hasRendererSerializer: () => true,
+      serializeBuffer
+    })
+
+    await expect(runtime.serializeHiddenOutputRecoveryBuffer('pty-1')).resolves.toMatchObject({
+      data: '\x1b[?1049hRenderer TUI',
+      source: 'renderer'
+    })
+  })
+
+  it('keeps an authoritative main model without polling the provider', async () => {
+    const runtime = createRuntime()
+    const serializeProviderBuffer = vi.fn(async () => null)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer
+    })
+    runtime.onPtyData('pty-1', '\x1b[?1049hLive TUI', 20)
+
+    await expect(runtime.serializeHiddenOutputRecoveryBuffer('pty-1')).resolves.toMatchObject({
+      alternateScreen: true,
+      source: 'headless'
+    })
+    expect(serializeProviderBuffer).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/orca-runtime-serialize-main-terminal-buffer.ts
+++ b/src/main/runtime/orca-runtime-serialize-main-terminal-buffer.ts
@@ -47,6 +47,10 @@ export class OrcaRuntimeWithSerializeMainTerminalBuffer extends OrcaRuntimeWithA
     pendingEscapeTailAnsi?: string
     terminalOwner?: 'shell'
   } | null> {
+    const restoredSnapshot = await this.serializePreferredRestoredTerminalBuffer(ptyId, opts)
+    if (restoredSnapshot) {
+      return restoredSnapshot
+    }
     const headlessSnapshot = await this.serializeHeadlessTerminalBuffer(ptyId, {
       ...opts,
       includeEmpty: true

--- a/src/main/runtime/orca-runtime-serialize-terminal-buffer-from-available-state.ts
+++ b/src/main/runtime/orca-runtime-serialize-terminal-buffer-from-available-state.ts
@@ -23,18 +23,9 @@ export class OrcaRuntimeWithSerializeTerminalBufferFromAvailableState extends Or
     kittyKeyboardFlags?: number
     terminalOwner?: 'shell'
   } | null> {
-    if (this.providerSnapshotPreferredPtys.has(ptyId)) {
-      // Why: pre-attach stream bytes only form a suffix of restored state. A
-      // sequenced provider snapshot safely reconciles live bytes; renderer is
-      // the fallback when an older provider cannot expose that boundary.
-      const providerSnapshot = await this.serializeProviderTerminalBuffer(ptyId, opts)
-      if (providerSnapshot) {
-        return providerSnapshot
-      }
-      const rendererSnapshot = await this.serializeRendererTerminalBuffer(ptyId, opts)
-      if (rendererSnapshot) {
-        return rendererSnapshot
-      }
+    const restoredSnapshot = await this.serializePreferredRestoredTerminalBuffer(ptyId, opts)
+    if (restoredSnapshot) {
+      return restoredSnapshot
     }
     const headlessSnapshot = await this.serializeHeadlessTerminalBuffer(ptyId, opts)
     if (headlessSnapshot) {
@@ -56,6 +47,20 @@ export class OrcaRuntimeWithSerializeTerminalBufferFromAvailableState extends Or
       (providerSnapshot.data.length > 0 || Boolean(providerSnapshot.scrollbackAnsi))
       ? providerSnapshot
       : rendererSnapshot
+  }
+
+  protected async serializePreferredRestoredTerminalBuffer(
+    ptyId: string,
+    opts: { scrollbackRows?: number } = {}
+  ) {
+    if (!this.providerSnapshotPreferredPtys.has(ptyId)) {
+      return null
+    }
+    // Pre-attach bytes are only a suffix; older providers can fall back to the renderer.
+    return (
+      (await this.serializeProviderTerminalBuffer(ptyId, opts)) ??
+      (await this.serializeRendererTerminalBuffer(ptyId, opts))
+    )
   }
 
   async serializeRendererTerminalBuffer(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​79 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps its own copy of what each terminal looks like so it can redraw a tab you hid and later came back to. Right after you restart the app, that copy can be built from only the last few characters a program happened to reprint — a fragment, not the whole screen. Orca already knew this fragment was untrustworthy and kept a complete saved picture elsewhere, but the specific code path that redraws a *hidden* tab forgot to check for it. So if you hid a tab running a full-screen program like vim or Claude Code and then reopened it, Orca painted the fragment instead of the real screen, and the program's output spilled into your scroll history as garbage. Now that path asks for the complete saved picture first, exactly like every other part of the app already did, so reopening a hidden tab shows the screen you actually left behind.

## What Changed

`serializeHiddenOutputRecoveryBuffer` now consults the same provider-snapshot preference every other serialization entry point already used. The existing `providerSnapshotPreferredPtys` branch in `serializeTerminalBufferFromAvailableState` was extracted into one shared `serializePreferredRestoredTerminalBuffer` helper and reused, rather than duplicating the logic.

- `orca-runtime-serialize-terminal-buffer-from-available-state.ts` — extract the existing provider-first / renderer-fallback branch into `serializePreferredRestoredTerminalBuffer`.
- `orca-runtime-serialize-main-terminal-buffer.ts` — call it at the top of `serializeHiddenOutputRecoveryBuffer`.
- New regression test covering retained provider state, the older-provider renderer fallback, and not polling the provider when the main model is authoritative.

No new mechanism is introduced; this is the "reuse before reimplementing" fix for the one caller that was missing the check.

## Why

`providerSnapshotPreferredPtys` means exactly "the main-process headless emulator for this PTY is a partial suffix, do not trust it". It is set when a provider sequence synchronizes with `generation: 'continued'` before a full snapshot has arrived (`orca-runtime-record-agent-prompt-lifecycle-state.ts`), and cleared once real state is seeded.

After an app restart, live redraw bytes can build a partial main-process model before the retained snapshot arrives. Hiding and revealing that terminal replaced the correctly restored alternate screen with the partial normal-buffer model, leaving a live TUI painting into scrollback. Hidden-output recovery was the only serialization path that ignored the flag, so it was the only one that could regress a correctly restored terminal.

## Linked Issue

Fixes #

No tracking issue; found while deflaking the duplicate-PTY restart/reveal Electron test.

## Visual Proof

`N/A` — per the repo's current AGENTS.md directive, all local Electron launches are paused for this workstream and Electron validation runs in CI. The change is main-process serialization with no renderer or styling surface; the observable difference (restored alternate screen vs. partial normal-buffer suffix on reveal) is asserted by the Electron duplicate-PTY restart/reveal test rather than by a screenshot. A before/after capture would be legitimately valuable here if local launches were permitted, since the symptom is visual.

## Tradeoffs

Genuine, user-facing:

- **Extra provider round-trip on reveal.** For provider-preferred PTYs, revealing a hidden terminal now makes a provider snapshot call before falling back to the local model. Previously it returned the local model immediately. The daemon path is a local unix socket, but it is real added latency on a UI-blocking path.
- **Worst-case stall is bounded but long.** `serializePreferredRestoredTerminalBuffer` calls `serializeProviderTerminalBuffer` without a `wait.timeoutMs`, so a wedged local daemon can hold the call for the daemon RPC timeout (`REQUEST_TIMEOUT_MS = 30_000`, `src/main/daemon/client.ts:29`) rather than failing fast. The hidden-restore path caps user-visible impact at the renderer's 750 ms foreground deadline, but the non-SSH park-reveal repaint (`reattach-result-handler.ts`) awaits unguarded and could visibly stall. This matches the pre-existing behavior of the sibling caller for the same PTY set; adding a timeout was deliberately rejected because timing out falls back to the partial model this PR exists to avoid.
- **Asymmetry with sibling callers.** This is the only `serializeProviderTerminalBuffer` caller that omits a timeout; others pass 8 s with `retireOnTimeout` or 750 ms.
- **Renderer fallback may carry no `seq`.** When the provider returns nothing, a renderer snapshot is now returned where a `seq`-bearing headless one was returned before. `seq` is optional on renderer snapshots, and without it the IPC layer skips `pendingDeliveryStartSeq` bounding. In practice the renderer serializer does supply `seq`; correct content without a bound still beats wrong content with one.
- **Memory:** no change. Provider snapshots are fetched on demand and the acquisition cache is deleted on settle; nothing new is retained for the session.

Not affected: no wire fields, opcodes, persisted state, or schema change; older providers keep the renderer fallback; SSH is untouched because `SshPtyProvider` does not implement `getBufferSnapshot`, so the provider call short-circuits.

## Testing

- `pnpm test src/main/runtime/hidden-output-restored-provider-snapshot.test.ts` — 3/3 pass; the first case reproduces the normal-buffer suffix before the fix.
- Full runtime suite (`vitest run src/main/runtime/`, excluding `*.electron.test.ts`) — 597 files, 6481 passed, 9 skipped.
- `src/main/ipc/pty/` — 12 files, 61 passed (covers the `pty:getMainBufferSnapshot` caller).
- `pnpm tc:node` — pass. `oxlint` on the three changed files — clean.
- Electron duplicate-PTY restart/reveal ran 8× with two workers, all passing (previous diagnostic run: two failures in six). Current-main revalidation: the unchanged assertion fails on `b44aaf20` (run 34051101447) and passes with only this change (run 34051222629).
- Platforms: logic is platform-neutral main-process code; CI covers macOS/Linux/Windows package + test jobs.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Overlaps in territory with #18904 (hidden-restore fit overflow) but shares no files and merges cleanly in either order. They are the server and client halves of the same call: #18904 changes how the renderer reacts to a snapshot, this changes what the snapshot contains. Recommend landing this one first so #18904's post-flood repaint is validated against corrected snapshot content.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — reviewed; see Tradeoffs. The one accepted residual risk is the untimed provider await, which is bounded by the daemon RPC timeout and matches existing sibling behavior.

Application fix: left open for user review.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
