### PR TITLE
perf(search): assemble fragmented subprocess lines incrementally

### DIFF
--- a/src/main/ipc/filesystem-search-git.ts
+++ b/src/main/ipc/filesystem-search-git.ts
@@ -1,3 +1,4 @@
+import { SearchSubprocessLineAccumulator } from '../../shared/search-subprocess-lines'
 import type { SearchOptions, SearchResult } from '../../shared/code-search-types'
 import {
   buildGitGrepArgs,
@@ -39,7 +40,7 @@ export async function searchWithGitGrep(
   return new Promise((resolve) => {
     const matchRegex = buildSubmatchRegex(args.query, args)
     const acc = createAccumulator()
-    let stdoutBuffer = ''
+    const lines = new SearchSubprocessLineAccumulator(Number.MAX_SAFE_INTEGER)
     let done = false
 
     let killTimeout: ReturnType<typeof setTimeout>
@@ -49,6 +50,7 @@ export async function searchWithGitGrep(
         return
       }
       done = true
+      lines.clear()
       clearTimeout(killTimeout)
       // Why: child.kill() is advisory. If git ignores it, detach our
       // closures so repeated fallback searches do not retain old scans.
@@ -67,12 +69,7 @@ export async function searchWithGitGrep(
     }
 
     function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
-      }
+      lines.push(chunk, processLine)
     }
 
     function handleStderrData(): void {
@@ -84,8 +81,9 @@ export async function searchWithGitGrep(
     }
 
     function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
+      const tail = lines.finish()
+      if (tail !== null) {
+        processLine(tail)
       }
       resolveOnce()
     }

--- a/src/main/ipc/filesystem/filesystem-search-handlers.ts
+++ b/src/main/ipc/filesystem/filesystem-search-handlers.ts
@@ -1,3 +1,4 @@
+import { SearchSubprocessLineAccumulator } from '../../../shared/search-subprocess-lines'
 import { ipcMain } from 'electron'
 import type { ChildProcess } from 'node:child_process'
 import type { SearchOptions, SearchResult } from '../../../shared/code-search-types'
@@ -68,7 +69,7 @@ export function registerFilesystemSearchHandlers(context: FilesystemHandlerConte
         }
 
         const acc = createAccumulator()
-        let stdoutBuffer = ''
+        const lines = new SearchSubprocessLineAccumulator(Number.MAX_SAFE_INTEGER)
         let resolved = false
         let processErrorObserved = false
         let unavailableExitObserved = false
@@ -88,6 +89,7 @@ export function registerFilesystemSearchHandlers(context: FilesystemHandlerConte
           if (activeTextSearches.get(searchKey) === child) {
             activeTextSearches.delete(searchKey)
           }
+          lines.clear()
           clearTimeout(killTimeout)
           // Why: child.kill() is advisory; detach our closures so repeated searches don't retain old scans if rg ignores it.
           child?.stdout?.off('data', handleStdoutData)
@@ -121,12 +123,7 @@ export function registerFilesystemSearchHandlers(context: FilesystemHandlerConte
         activeTextSearches.set(searchKey, nextChild)
 
         const handleStdoutData = (chunk: string): void => {
-          stdoutBuffer += chunk
-          const lines = stdoutBuffer.split('\n')
-          stdoutBuffer = lines.pop() ?? ''
-          for (const line of lines) {
-            processLine(line)
-          }
+          lines.push(chunk, processLine)
         }
         const handleStderrData = (): void => {
           // Drain stderr so rg cannot block on a full pipe.
@@ -150,8 +147,9 @@ export function registerFilesystemSearchHandlers(context: FilesystemHandlerConte
             resolveWithoutRipgrep()
             return
           }
-          if (stdoutBuffer) {
-            processLine(stdoutBuffer)
+          const tail = lines.finish()
+          if (tail !== null) {
+            processLine(tail)
           }
           resolveOnce()
         }

--- a/src/main/runtime/runtime-file-commands-search-local-runtime-files.ts
+++ b/src/main/runtime/runtime-file-commands-search-local-runtime-files.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split class members.
+import { SearchSubprocessLineAccumulator } from '../../shared/search-subprocess-lines'
 import { RuntimeFileCommandsWithSearchRuntimeFiles } from './runtime-file-commands-search-runtime-files'
 import type { SearchOptions, SearchResult } from '../../shared/code-search-types'
 import { resolveAuthorizedPath } from '../ipc/filesystem-auth'
@@ -58,7 +59,7 @@ export class RuntimeFileCommandsWithSearchLocalRuntimeFiles extends RuntimeFileC
       }
 
       const acc = createAccumulator()
-      let stdoutBuffer = ''
+      const lines = new SearchSubprocessLineAccumulator(Number.MAX_SAFE_INTEGER)
       let resolved = false
       let processErrorObserved = false
       let unavailableExitObserved = false
@@ -84,6 +85,7 @@ export class RuntimeFileCommandsWithSearchLocalRuntimeFiles extends RuntimeFileC
 
       let killTimeout: ReturnType<typeof setTimeout> | null = null
       const cleanupListeners = (): void => {
+        lines.clear()
         if (killTimeout) {
           clearTimeout(killTimeout)
           killTimeout = null
@@ -123,12 +125,7 @@ export class RuntimeFileCommandsWithSearchLocalRuntimeFiles extends RuntimeFileC
 
       nextChild.stdout!.setEncoding('utf-8')
       const onStdoutData = (chunk: string): void => {
-        stdoutBuffer += chunk
-        const lines = stdoutBuffer.split('\n')
-        stdoutBuffer = lines.pop() ?? ''
-        for (const line of lines) {
-          processLine(line)
-        }
+        lines.push(chunk, processLine)
       }
       const onStderrData = (): void => {
         // Drain stderr so rg cannot block on a full pipe.
@@ -152,8 +149,9 @@ export class RuntimeFileCommandsWithSearchLocalRuntimeFiles extends RuntimeFileC
           resolveWithoutRipgrep()
           return
         }
-        if (stdoutBuffer) {
-          processLine(stdoutBuffer)
+        const tail = lines.finish()
+        if (tail !== null) {
+          processLine(tail)
         }
         resolveOnce()
       }

--- a/src/main/runtime/runtime-search-line-fragments.test.ts
+++ b/src/main/runtime/runtime-search-line-fragments.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import {
+  checkRgAvailableMock,
+  resolveAuthorizedPathMock,
+  wslAwareSpawnMock
+} from './orca-runtime-files-mock-registry'
+import {
+  createRuntimeFileCommands,
+  useRuntimeFileCommandsLifecycle
+} from './orca-runtime-files-test-harness'
+
+vi.mock('fs', async () => (await import('./orca-runtime-files-mock-registry')).fsModuleMock())
+vi.mock('fs/promises', async () =>
+  (await import('./orca-runtime-files-mock-registry')).fsPromisesModuleMock()
+)
+vi.mock(
+  './file-watcher-host',
+  async () => (await import('./orca-runtime-files-mock-registry')).fileWatcherHostMock
+)
+vi.mock('../ipc/filesystem-auth', async () =>
+  (await import('./orca-runtime-files-mock-registry')).filesystemAuthModuleMock()
+)
+vi.mock('../git/runner', async () =>
+  (await import('./orca-runtime-files-mock-registry')).gitRunnerModuleMock()
+)
+vi.mock(
+  '../ipc/rg-availability',
+  async () => (await import('./orca-runtime-files-mock-registry')).rgAvailabilityMock
+)
+vi.mock(
+  '../ipc/local-worktree-runtime-options',
+  async () => (await import('./orca-runtime-files-mock-registry')).localWorktreeRuntimeOptionsMock
+)
+vi.mock(
+  '../ipc/filesystem-search-git',
+  async () => (await import('./orca-runtime-files-mock-registry')).filesystemSearchGitMock
+)
+vi.mock(
+  '../providers/ssh-filesystem-dispatch',
+  async () => (await import('./orca-runtime-files-mock-registry')).sshFilesystemDispatchMock
+)
+
+type MockRuntimeSearchChild = EventEmitter & {
+  stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+  stderr: EventEmitter
+  kill: ReturnType<typeof vi.fn>
+}
+
+function createRuntimeSearchChild(): MockRuntimeSearchChild {
+  const child = new EventEmitter() as MockRuntimeSearchChild
+  child.stdout = new EventEmitter() as MockRuntimeSearchChild['stdout']
+  child.stdout.setEncoding = vi.fn()
+  child.stderr = new EventEmitter()
+  child.kill = vi.fn()
+  return child
+}
+
+async function flushRuntimeSearchMicrotasks(): Promise<void> {
+  for (let index = 0; index < 8; index++) {
+    await Promise.resolve()
+  }
+}
+
+describe('RuntimeFileCommands', () => {
+  useRuntimeFileCommandsLifecycle()
+
+  it('assembles a fragmented runtime search record without rescanning the carry', async () => {
+    const { commands } = createRuntimeFileCommands({
+      resolveRuntimeFileTarget: vi.fn(async () => ({
+        worktree: { id: 'wt-1', repoId: 'repo-1', path: '/repo' },
+        executionHostId: 'local'
+      }))
+    })
+    const child = createRuntimeSearchChild()
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    checkRgAvailableMock.mockResolvedValue(true)
+    wslAwareSpawnMock.mockReturnValue(child)
+    const resultPromise = commands.searchRuntimeFiles('id:wt-1', {
+      query: 'needle',
+      maxResults: 10
+    })
+    await flushRuntimeSearchMicrotasks()
+    const line = JSON.stringify({
+      type: 'match',
+      data: {
+        path: { text: '/repo/file.ts' },
+        line_number: 1,
+        lines: { text: `needle🐋${'x'.repeat(128 * 1024)}` },
+        submatches: [{ start: 0, end: 6 }]
+      }
+    })
+    const originalSplit = String.prototype.split
+    let scanned = 0
+    const spy = vi.spyOn(String.prototype, 'split').mockImplementation(function (
+      this: string,
+      separator: unknown,
+      limit?: number
+    ) {
+      if (separator === '\n') {
+        scanned += this.length
+      }
+      return Reflect.apply(originalSplit, this, [separator, limit])
+    })
+    try {
+      for (let offset = 0; offset < line.length; offset += 1024) {
+        child.stdout.emit('data', line.slice(offset, offset + 1024))
+      }
+      child.emit('close', 0, null)
+    } finally {
+      spy.mockRestore()
+    }
+    const result = await resultPromise
+    expect(result.totalMatches).toBe(1)
+    expect(result.files[0].filePath).toBe('/repo/file.ts')
+    expect(result.files[0].matches[0].lineContent).toContain('needle🐋')
+    expect(scanned).toBeLessThanOrEqual(line.length * 2)
+    expect(child.stdout.listenerCount('data')).toBe(0)
+  })
+})

--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -6,6 +6,7 @@
  * and git grep as universal fallbacks — git is always available since this is
  * a git-focused app.
  */
+import { SearchSubprocessLineAccumulator } from '../shared/search-subprocess-lines'
 import { spawn } from 'node:child_process'
 import { fileListingCancellationError } from '../shared/file-listing-cancellation'
 import type { SearchOptions, SearchResult } from './fs-handler-utils'
@@ -277,7 +278,7 @@ export function searchWithGitGrep(
     const gitArgs = buildGitGrepArgs(query, opts)
     const matchRegex = buildSubmatchRegex(query, opts)
     const acc = createAccumulator()
-    let stdoutBuffer = ''
+    const lines = new SearchSubprocessLineAccumulator(Number.MAX_SAFE_INTEGER)
     let done = false
 
     const child = spawn('git', gitArgs, {
@@ -292,6 +293,7 @@ export function searchWithGitGrep(
         return
       }
       done = true
+      lines.clear()
       clearTimeout(killTimeout)
       // Why: child.kill() is advisory. If git ignores it, detach our
       // closures so repeated relay searches do not retain old scans.
@@ -310,12 +312,7 @@ export function searchWithGitGrep(
     }
 
     function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
-      }
+      lines.push(chunk, processLine)
     }
 
     function handleStderrData(): void {
@@ -327,8 +324,9 @@ export function searchWithGitGrep(
     }
 
     function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
+      const tail = lines.finish()
+      if (tail !== null) {
+        processLine(tail)
       }
       resolveOnce()
     }

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -5,6 +5,7 @@
  * These functions depend only on their arguments (plus `rg` being on PATH),
  * so they are straightforward to test independently.
  */
+import { SearchSubprocessLineAccumulator } from '../shared/search-subprocess-lines'
 import { spawn } from 'node:child_process'
 import { open } from 'node:fs/promises'
 import {
@@ -99,7 +100,7 @@ export function searchWithRg(
   return new Promise((resolve, reject) => {
     const rgArgs = buildRgArgs(query, rootPath, opts)
     const acc = createAccumulator()
-    let buffer = ''
+    const lines = new SearchSubprocessLineAccumulator(Number.MAX_SAFE_INTEGER)
     let resolved = false
     let processErrorObserved = false
     let unavailableExitObserved = false
@@ -127,6 +128,7 @@ export function searchWithRg(
         return
       }
       resolved = true
+      lines.clear()
       clearTimeout(killTimeout)
       // Why: child.kill() is advisory over SSH; detach listeners if the
       // process ignores timeout kill so old searches cannot retain closures.
@@ -146,6 +148,7 @@ export function searchWithRg(
         return
       }
       resolved = true
+      lines.clear()
       clearTimeout(killTimeout)
       child.stdout!.off('data', handleStdoutData)
       child.stderr!.off('data', handleStderrData)
@@ -179,12 +182,7 @@ export function searchWithRg(
     }
 
     function handleStdoutData(chunk: string): void {
-      buffer += chunk
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-      for (const line of lines) {
-        processLine(line)
-      }
+      lines.push(chunk, processLine)
     }
 
     function handleStderrData(): void {
@@ -210,8 +208,9 @@ export function searchWithRg(
         settleLaunchFailure()
         return
       }
-      if (buffer) {
-        processLine(buffer)
+      const tail = lines.finish()
+      if (tail !== null) {
+        processLine(tail)
       }
       resolveOnce()
     }

--- a/src/relay/fs-search-line-fragments.test.ts
+++ b/src/relay/fs-search-line-fragments.test.ts
@@ -1,0 +1,129 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+import { searchWithGitGrep } from './fs-handler-git-fallback'
+import { searchWithRg } from './fs-handler-utils'
+
+function createProcess(): ChildProcess {
+  return Object.assign(new EventEmitter(), {
+    stdout: Object.assign(new EventEmitter(), { setEncoding: vi.fn() }),
+    stderr: new EventEmitter(),
+    kill: vi.fn()
+  }) as unknown as ChildProcess
+}
+
+const searchCases = [
+  {
+    name: 'ripgrep',
+    search: searchWithRg,
+    encode: (text: string, line: number) =>
+      JSON.stringify({
+        type: 'match',
+        data: {
+          path: { text: '/remote/root/unicode.ts' },
+          lines: { text: `${text}\n` },
+          line_number: line,
+          submatches: [{ start: 0, end: 3 }]
+        }
+      })
+  },
+  {
+    name: 'git grep',
+    search: searchWithGitGrep,
+    encode: (text: string, line: number) => `unicode.ts\0${line}\0${text}`
+  }
+]
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.useRealTimers()
+  spawnMock.mockReset()
+})
+
+describe.each(searchCases)('relay $name line fragments', ({ search, encode }) => {
+  async function run(chunks: string[]) {
+    const child = createProcess()
+    spawnMock.mockReturnValueOnce(child)
+    const result = search('/remote/root', 'hit', { maxResults: 100 })
+    expect(child.stdout!.setEncoding).toHaveBeenCalledWith('utf-8')
+    for (const chunk of chunks) {
+      child.stdout!.emit('data', chunk)
+    }
+    child.emit('close', 0, null)
+    const value = await result
+    expect(child.stdout!.listenerCount('data')).toBe(0)
+    expect(child.stderr!.listenerCount('data')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.kill).not.toHaveBeenCalled()
+    return value
+  }
+
+  it('preserves decoded Unicode, batched lines, empty lines and the final unterminated match', async () => {
+    const text = 'hit café 漢字 🐋'
+    const wire = `${encode(text, 1)}\n\n${encode('hit second', 2)}\n${encode(text, 3)}`
+    const complete = await run([wire])
+    const fragmented = await run(Array.from(wire))
+    expect(fragmented).toEqual(complete)
+    expect(fragmented.totalMatches).toBe(3)
+    expect(fragmented.truncated).toBe(false)
+    expect(fragmented.files[0].matches.map((match) => match.line)).toEqual([1, 2, 3])
+    expect(fragmented.files[0].matches[0].lineContent).toBe(text)
+    expect(fragmented.files[0].matches[2].lineContent).toBe(text)
+  })
+
+  it('does not repeatedly split the growing partial output of a large matching line', async () => {
+    const wire = `${encode(`hit ${'x'.repeat(1024 * 1024)}`, 7)}\n`
+    const complete = await run([wire])
+    const chunks: string[] = []
+    for (let offset = 0; offset < wire.length; offset += 4096) {
+      chunks.push(wire.slice(offset, offset + 4096))
+    }
+    const originalSplit = String.prototype.split
+    let scannedCharacters = 0
+    const spy = vi.spyOn(String.prototype, 'split').mockImplementation(function (
+      this: string,
+      separator: unknown,
+      limit?: number
+    ) {
+      if (separator === '\n') {
+        scannedCharacters += this.length
+      }
+      return Reflect.apply(originalSplit, this, [separator, limit])
+    })
+    let fragmented
+    try {
+      fragmented = await run(chunks)
+    } finally {
+      spy.mockRestore()
+    }
+    expect(fragmented).toEqual(complete)
+    expect(fragmented.totalMatches).toBe(1)
+    expect(fragmented.files[0].matches[0].line).toBe(7)
+    expect(scannedCharacters).toBe(0)
+  })
+
+  it('discards an unfinished line on timeout and detaches the output listeners', async () => {
+    vi.useFakeTimers()
+    const child = createProcess()
+    spawnMock.mockReturnValueOnce(child)
+    const result = search('/remote/root', 'hit', { maxResults: 100 })
+    child.stdout!.emit('data', `${encode('hit complete', 1)}\n${encode('hit partial', 2)}`)
+    await vi.runOnlyPendingTimersAsync()
+    const value = await result
+    expect(value.totalMatches).toBe(1)
+    expect(value.truncated).toBe(true)
+    expect(child.kill).toHaveBeenCalled()
+    expect(child.stdout!.listenerCount('data')).toBe(0)
+    expect(child.stderr!.listenerCount('data')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+    child.stdout!.emit('data', '\n')
+    child.emit('close', 0, null)
+    expect(value.totalMatches).toBe(1)
+  })
+})

--- a/src/shared/search-subprocess-lines.test.ts
+++ b/src/shared/search-subprocess-lines.test.ts
@@ -1,7 +1,32 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { SearchSubprocessLineAccumulator } from './search-subprocess-lines'
 
 describe('SearchSubprocessLineAccumulator', () => {
+  it('keeps complete decoded batches as strings without allocating byte copies', () => {
+    const parser = new SearchSubprocessLineAccumulator()
+    const lines: string[] = []
+    const from = vi.spyOn(Buffer, 'from')
+    let copies: number
+    try {
+      parser.push('first🐋\n\nlast\n', (line) => lines.push(line))
+      copies = from.mock.calls.length
+    } finally {
+      from.mockRestore()
+    }
+    expect(copies).toBe(0)
+    expect(lines).toEqual(['first🐋', '', 'last'])
+    expect(parser.finish()).toBeNull()
+  })
+
+  it('still enforces per-line UTF-8 byte limits for decoded batches', () => {
+    const parser = new SearchSubprocessLineAccumulator(4)
+    const lines: string[] = []
+    expect(parser.push('éé\n漢\n', (line) => lines.push(line))).toBe(true)
+    expect(parser.push('漢é\n', (line) => lines.push(line))).toBe(false)
+    expect(lines).toEqual(['éé', '漢'])
+    expect(parser.finish()).toBeNull()
+  })
+
   it('preserves UTF-8 records split across raw byte chunks', () => {
     const parser = new SearchSubprocessLineAccumulator(32)
     const bytes = Buffer.from('first🐋\nsecond')

--- a/src/shared/search-subprocess-lines.ts
+++ b/src/shared/search-subprocess-lines.ts
@@ -12,6 +12,20 @@ export class SearchSubprocessLineAccumulator {
   }
 
   push(rawChunk: Buffer | string, onLine: (line: string) => void): boolean {
+    // Three bytes per UTF-16 code unit bounds UTF-8 size without re-encoding complete batches.
+    if (
+      typeof rawChunk === 'string' &&
+      this.bytes === 0 &&
+      rawChunk.endsWith('\n') &&
+      rawChunk.length * 3 <= this.maxLineBytes
+    ) {
+      const lines = rawChunk.split('\n')
+      lines.pop()
+      for (const line of lines) {
+        onLine(line)
+      }
+      return true
+    }
     const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk, 'utf8')
     let cursor = 0
     while (cursor < chunk.length) {


### PR DESCRIPTION
## ELI5
When a search tool returns a long line in small pieces, Orca kept rereading everything received so far to find the next newline. Feed those pieces into Orca's existing incremental line accumulator, then decode the completed line once.

## What changed
Use `SearchSubprocessLineAccumulator` in all five duplicated text-search buffering paths: desktop IPC ripgrep, runtime ripgrep, desktop/runtime Git fallback, relay ripgrep, and relay Git fallback. Keep existing UTF-8 stream decoding, final unterminated-line processing on close, timeout behavior, result limits, and fallback routing. Explicitly clear partial storage on settlement.

Complete decoded batches use the existing split-once approach inside the accumulator, avoiding unnecessary byte copies for ordinary output. A conservative UTF-8 size bound preserves the helper's configured per-line byte limit. Search callers pass `Number.MAX_SAFE_INTEGER` so adopting the helper does not introduce its default 64 MiB line cap.

## Measurements
Deterministic tests drive the actual runtime and relay search callbacks with fragmented output and count characters passed to repeated newline splitting.

| Actual callback / fixture | Before | After |
|---|---:|---:|
| Runtime ripgrep, 128 KiB record / 1 KiB chunks | 8,585,352 scanned code units | 0 |
| Relay ripgrep, 1 MiB record / 4 KiB chunks | 135,790,737 scanned code units | 0 |
| Relay Git fallback, 1 MiB record / 4 KiB chunks | 135,790,610 scanned code units | 0 |

The new byte accumulator still scans each arriving segment once; these zeros mean repeated growing-string splitting is removed, not that parsing costs zero. All three budget tests fail against the old code. Completed versus fragmented output is identical, including Unicode and match metadata.

Reproduce with `pnpm test src/main/runtime/runtime-search-line-fragments.test.ts src/relay/fs-search-line-fragments.test.ts`. Shared helper tests additionally verify complete decoded batches allocate zero `Buffer.from` copies and still enforce configured UTF-8 byte limits.

## Negative user-facing trade-offs
- The common path is slightly slower, not free. Any chunk that does not end in `\n` (typical for streamed `rg` output) now pays a `Buffer.from(chunk, 'utf8')` re-encode plus a per-line `Buffer.toString('utf8')` decode (`src/shared/search-subprocess-lines.ts:29`, `:41`, `:85`), where the old code did one string concat + `split` returning cheap V8 sliced substrings. The win only materialises for lines spanning many chunks. A two-chunk 1 KiB loop microbenchmark measured roughly 0.008 ms extra per iteration; the 4 MiB fragmented-loop case fell from roughly 930 ms to 1.15 ms. These isolated buffering timings exclude subprocess execution, JSON parsing, transport, and rendered UI; no universal end-to-end latency claim.
- The helper's 64 MiB line cap is deliberately opted out. All five call sites pass `Number.MAX_SAFE_INTEGER`, which preserves the old unbounded behavior intentionally, but changes the failure mode for a pathological single line larger than about 512 MB: the old code threw V8's "Invalid string length" at that point, while the new code keeps geometric-doubling `Buffer.allocUnsafe` toward Node's roughly 4 GB buffer limit, so it retains far more memory before failing. Rare, but strictly worse in that tail case. Buffer capacity can also temporarily exceed used bytes due to geometric growth; it is released on completion and every settlement path.
- Otherwise no change in covered output and lifecycle behavior: no reduced search coverage, additional result truncation, changed timeout, or deferred results.

## Testing
- 113 tests across 11 suites passed: new runtime/relay fragment budgets, shared accumulator, text-search parsing/counts, runtime and desktop search, relay fallback, timeout and unavailable-process cleanup.
- Node typecheck, changed-file oxlint, React Doctor lint, and oxfmt passed.
- Exact Unicode, batched and empty lines, final unterminated records, timeout-discard behavior, timer/listener cleanup, WSL path routing, and fallback cases covered.
- Real subprocess validation: 60 native `rg`/`git grep` searches over an owned temporary Git fixture (Unicode filename/content, hidden file, final unterminated line, 4 MiB matching line). Exact per-file match output matched before/after for ordinary, Unicode, and no-match queries. File arrays were sorted only in the comparator because ripgrep traversal order varies between separate process runs. Each search completed through its real child close event; the audit process exited and removed its fixture. Process-level timings were variable and are not a universal latency claim.
- Local platform: macOS. Native Windows/Linux and live SSH were not exercised; execution stays on its existing host. No Git arguments, protocol fields, cancellation APIs, provider selection, or folder/worktree path semantics change.

## Visual Proof
N/A — identical search results; only subprocess output assembly changes. No application windows launched.

## Linked Issue
None. The user explicitly requested no GitHub issues.

## Review
Self-reviewed; independent relay test and semantic review. No upstream skill source copied.

