### PR TITLE
perf: remember equivalent session tab source identities

### DIFF
--- a/src/renderer/src/lib/session-write-subscriber-allocation.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber-allocation.test.ts
@@ -90,6 +90,34 @@ afterEach(() => {
 })
 
 describe('session write subscriber allocation', () => {
+  it.each(['tabsByWorktree', 'unifiedTabsByWorktree'] as const)(
+    'remembers an equivalent %s source before unrelated writes',
+    (field) => {
+      const harness = createHarness()
+      try {
+        harness.write(() => ({ [field]: { 'wt-1': [] } }))
+        vi.advanceTimersByTime(500)
+        harness.persisted.length = 0
+
+        harness.write(() => ({ [field]: { 'wt-1': [] } }))
+        const calls = countFilterCalls(() => {
+          for (let write = 0; write < 200; write += 1) {
+            harness.write(() => ({ runtimePaneTitlesByTabId: {} }))
+          }
+        })
+        expect(calls).toBe(0)
+        vi.advanceTimersByTime(500)
+        expect(harness.persisted).toHaveLength(0)
+
+        harness.write(() => ({ activeTabId: 'next-tab' }))
+        vi.advanceTimersByTime(500)
+        expect(harness.persisted).toHaveLength(1)
+      } finally {
+        harness.dispose()
+      }
+    }
+  )
+
   it('allocates nothing for store writes that touch no session field', () => {
     const harness = createHarness()
     try {

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -233,12 +233,13 @@ export function createSessionWriteSubscriber({
       prev === null
         ? [...SESSION_RELEVANT_FIELDS]
         : SESSION_RELEVANT_FIELDS.filter((key) => prev?.[key] !== next[key])
+    // Equivalent projections still consume the new source identities.
+    prevTabsSource = state.tabsByWorktree
+    prevUnifiedTabsSource = state.unifiedTabsByWorktree
     if (changedFields.length === 0 && pendingChangedFields.size === 0) {
       return
     }
     prev = next
-    prevTabsSource = state.tabsByWorktree
-    prevUnifiedTabsSource = state.unifiedTabsByWorktree
     for (const field of changedFields) {
       pendingChangedFields.add(field)
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

An equivalent terminal or unified-tab map refresh leaves the session writer remembering an older raw map. Every later unrelated store update then rebuilds the session-field snapshot and change list, even though there is nothing to save. Record the inspected source identities before the unchanged-projection return.

ELI5: after checking that a refreshed tab list says the same thing, remember that it was checked. Otherwise unrelated activity keeps checking it again.

Measurements: the regression drives the actual subscriber with an equivalent map refresh followed by 200 unrelated updates. Both terminal and unified-tab cases produce **200 → 0 changed-field arrays and accompanying snapshots**. Both budget tests fail on the parent and pass with this change. This is an allocation/work-count improvement, not an end-to-end latency claim.

Negative user-facing trade-offs: none identified. No debounce, persisted field, title classification, host routing, write ordering, or wake-up behavior changes. The identity references already exist; no new cache or retained collection is introduced.

Validation: 54 tests across subscriber allocation, subscriber behavior, deferred persistence, persistence gates, and host partitioning; renderer typecheck; oxlint and oxfmt. Run `pnpm test src/renderer/src/lib/session-write-subscriber-allocation.test.ts src/renderer/src/lib/session-write-subscriber.test.ts src/renderer/src/lib/session-write-subscriber-deferred-persist.test.ts src/renderer/src/lib/workspace-session-persistence-gate.test.ts src/renderer/src/lib/workspace-session-host-persistence.test.ts` and `pnpm tc:web`.

Reliability: `workspace-session.persistence` invariant: equivalent projections produce no writes, meaningful changes still persist, and deferred writes remain owed. Failure source is an equivalent tab refresh followed by unrelated activity. The deterministic regression checks zero writes followed by a real update producing one write; existing tests cover decorative titles and deferred/gated writes. No matching manifest gate exists for this identity-only allocation budget; the residual gate gap is documented here. Local/daemon PTY, WSL, and mobile execution are unaffected; shared renderer logic is platform-independent, with native Windows/Linux execution untested. Host-partition tests cover routing behavior, not live SSH. No GUI or Electron launch was used.
