### PR TITLE
perf(cli): skip impossible typo distance comparisons

### DIFF
--- a/src/cli/command-suggestion-budget.test.ts
+++ b/src/cli/command-suggestion-budget.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as distance from '../shared/edit-distance'
+import { suggestCommands, unknownFlagData } from './command-suggestion'
+import type { CommandSpec } from './command-spec'
+
+const specs: CommandSpec[] = [
+  { path: ['list'], summary: '', usage: '', allowedFlags: [] },
+  { path: ['remove'], summary: '', usage: '', allowedFlags: [], destructive: true }
+]
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('suggestion distance work', () => {
+  it('does no distance calculations for a long command, including destructive intent', () => {
+    const spy = vi.spyOn(distance, 'levenshtein')
+    expect(suggestCommands(specs, ['x'.repeat(32_768)])).toEqual([])
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('does no distance calculations for a long flag but still lists valid flags', () => {
+    const spy = vi.spyOn(distance, 'levenshtein')
+    expect(unknownFlagData('x'.repeat(32_768), ['worktree', 'json'])).toEqual({
+      validFlags: ['json', 'worktree'],
+      suggestions: [],
+      nextSteps: ['Valid flags: --json, --worktree']
+    })
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('keeps the inclusive three-edit suggestion boundary', () => {
+    expect(suggestCommands(specs, ['listxxx'])).toEqual(['list'])
+    expect(unknownFlagData('jsonxxx', ['json']).suggestions).toEqual(['json'])
+  })
+
+  it('keeps the inclusive one-edit destructive intent boundary', () => {
+    expect(suggestCommands(specs, ['remov'])).toEqual(['remove'])
+    expect(suggestCommands(specs, ['remo'])).toEqual([])
+  })
+
+  it('retains UTF-16 distance semantics at the length boundary', () => {
+    expect(unknownFlagData('json😀x', ['json']).suggestions).toEqual(['json'])
+    expect(unknownFlagData('json😀😀', ['json']).suggestions).toEqual([])
+  })
+})

--- a/src/cli/command-suggestion.ts
+++ b/src/cli/command-suggestion.ts
@@ -37,7 +37,10 @@ function destructiveVerbs(specs: CommandSpec[]): Set<string> {
 // input token is itself a near-miss of a destructive verb. #6303
 function intendsDestruction(inputToken: string, verbs: Set<string>): boolean {
   for (const verb of verbs) {
-    if (levenshtein(inputToken, verb) <= DESTRUCTIVE_INTENT_THRESHOLD) {
+    if (
+      Math.abs(inputToken.length - verb.length) <= DESTRUCTIVE_INTENT_THRESHOLD &&
+      levenshtein(inputToken, verb) <= DESTRUCTIVE_INTENT_THRESHOLD
+    ) {
       return true
     }
   }
@@ -85,7 +88,9 @@ export function suggestCommands(specs: CommandSpec[], commandPath: string[]): st
         continue
       }
       seen.add(joined)
-      scored.push({ label: joined, distance: levenshtein(input, joined) })
+      if (Math.abs(input.length - joined.length) <= SUGGESTION_THRESHOLD) {
+        scored.push({ label: joined, distance: levenshtein(input, joined) })
+      }
     }
   }
   return rankByDistance(scored)
@@ -106,9 +111,13 @@ export type FlagErrorData = {
 }
 
 function suggestFlags(flag: string, validFlags: string[]): string[] {
-  return rankByDistance(
-    validFlags.map((candidate) => ({ label: candidate, distance: levenshtein(flag, candidate) }))
-  )
+  const scored: { label: string; distance: number }[] = []
+  for (const candidate of validFlags) {
+    if (Math.abs(flag.length - candidate.length) <= SUGGESTION_THRESHOLD) {
+      scored.push({ label: candidate, distance: levenshtein(flag, candidate) })
+    }
+  }
+  return rankByDistance(scored)
 }
 
 // Why: include the accepted set so agents can recover without another help call.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

CLI typo recovery calculates full edit distance even when a candidate's length makes it impossible to meet the accepted distance. Skip those comparisons for command suggestions, flag suggestions, and the existing destructive-intent check. Exact edit-distance behavior and ranking remain unchanged.

ELI5: If suggestions allow only three edits, a name that is thousands of letters longer cannot qualify. Skip the spelling calculation for that name.

Measurements: actual suggestion module and full command registry bundled before/after; Node v24.18.0, two warmup rounds and ten alternating measured rounds. Median function times (milliseconds; excludes CLI startup):

| Input | Before | After |
|---|---:|---:|
| `worktre lis` | 0.342542 | 0.158666 |
| 1 KiB invalid command | 1.295459 | 0.024791 |
| 32 KiB invalid command | 40.078625 | 0.038667 |
| Exact `json` flag | 0.004375 | 0.006958 |
| 32 KiB invalid flag | 1.834875 | 0.002542 |

Deterministic budget tests assert zero distance calls for impossible long commands and flags. Both assertions fail on the parent. Inclusive three-edit suggestions, one-edit destructive intent, UTF-16 behavior, valid-flag lists, hidden commands, aliases, and ranking are preserved. 13,782 differential comparisons against the full registry produced identical outputs.

Negative user-facing trade-offs: none identified. Each viable candidate pays a constant-time length comparison; microbenchmarks can vary or regress by a few microseconds (see exact-flag row). This is not a universal speedup or packaged-startup claim. No cache, truncation, command-execution change, remote routing change, or error-format change.

Validation: 62 tests across command suggestion, budget, argument and flag suites; CLI typecheck; targeted lint and formatting. Reproduce the deterministic budget with `pnpm test src/cli/command-suggestion-budget.test.ts src/cli/command-suggestion.test.ts src/cli/args.test.ts src/cli/flags.test.ts` and `pnpm tc:cli`. Pure CLI logic; no GUI launch, filesystem/provider execution, or wire changes. Native Linux/Windows were not exercised.
