### PR TITLE
ci: preserve case-twin release refs through checkout and verify trust

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -160,6 +160,9 @@ jobs:
 
       - name: Checkout the requested ref
         uses: actions/checkout@v6
+        env:
+          # Full-history checkout must also preserve case-twin branch and tag names.
+          GIT_DEFAULT_REF_FORMAT: reftable
         with:
           # Why an input at all rather than just github.ref: the whole point is to
           # build code that has not landed, and the workflow definition itself

--- a/.github/workflows/release-ref-validation.yml
+++ b/.github/workflows/release-ref-validation.yml
@@ -1,0 +1,38 @@
+name: Release ref validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/adhoc-mac-build.yml'
+      - '.github/workflows/dev-channel-win-build.yml'
+      - '.github/workflows/release-ref-validation.yml'
+      - 'config/scripts/workflow-ref-reachability.test.mjs'
+      - 'config/scripts/workflow-ref-mirror-case-safety.test.mjs'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-ref-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-15, windows-2022]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+      - name: Verify case-twin refs and release trust boundary
+        run: >-
+          pnpm exec vitest run --config config/vitest.config.ts
+          config/scripts/workflow-ref-reachability.test.mjs
+          config/scripts/workflow-ref-mirror-case-safety.test.mjs
+          config/scripts/dev-channel-windows-workflow-contract.test.mjs

--- a/config/scripts/workflow-ref-mirror-case-safety.test.mjs
+++ b/config/scripts/workflow-ref-mirror-case-safety.test.mjs
@@ -15,6 +15,16 @@ const REF_MIRRORS = [
 ]
 
 describe('ref-mirroring vet steps', () => {
+  it('keeps the full-history adhoc checkout on the same case-safe backend', () => {
+    const steps = readWorkflow('.github/workflows/adhoc-mac-build.yml').jobs['build-adhoc-mac']
+      .steps
+    const checkout = steps.find((step) => step.name === 'Checkout the requested ref')
+    expect(checkout.env.GIT_DEFAULT_REF_FORMAT).toBe('reftable')
+    expect(checkout.with.ref).toBe('${{ steps.vetted.outputs.sha }}')
+    expect(checkout.with['fetch-depth']).toBe(0)
+    expect(checkout.with['persist-credentials']).toBe(false)
+  })
+
   // Why: macOS and Windows runner disks are case-insensitive, and this repo has
   // branches that differ only in casing. The files backend cannot store both, and
   // it fails the whole fetch rather than the one ref — so the vet step dies before

--- a/config/scripts/workflow-ref-reachability.test.mjs
+++ b/config/scripts/workflow-ref-reachability.test.mjs
@@ -1,0 +1,125 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+import { runProcess } from '../../src/shared/child-process/run-process'
+
+const readWorkflow = (name) => parse(readFileSync(`.github/workflows/${name}.yml`, 'utf8'))
+const windowsVet = readWorkflow('dev-channel-win-build').jobs['build-win'].steps.find(
+  (step) => step.id === 'vetted'
+)
+const macSteps = readWorkflow('adhoc-mac-build').jobs['build-adhoc-mac'].steps
+const macVet = macSteps.find((step) => step.id === 'vetted')
+const macCheckout = macSteps.find((step) => step.name === 'Checkout the requested ref')
+const directory = mkdtempSync(join(tmpdir(), 'workflow-ref-reachability-'))
+const repository = join(directory, 'remote.git')
+const identity = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Ref test',
+  GIT_AUTHOR_EMAIL: 'ref-test@example.com',
+  GIT_COMMITTER_NAME: 'Ref test',
+  GIT_COMMITTER_EMAIL: 'ref-test@example.com'
+}
+let ancestor, upper, lower, untrusted
+
+async function git(args, env = identity) {
+  const result = await runProcess({ program: 'git', args, env })
+  expect(result.code, result.stderr).toBe(0)
+  return result.stdout.trim()
+}
+
+beforeAll(async () => {
+  await git(['init', '--bare', '--ref-format=reftable', repository])
+  const tree = await git(['-C', repository, 'mktree'])
+  ancestor = await git(['-C', repository, 'commit-tree', tree, '-m', 'ancestor'])
+  upper = await git(['-C', repository, 'commit-tree', tree, '-p', ancestor, '-m', 'upper'])
+  lower = await git(['-C', repository, 'commit-tree', tree, '-p', ancestor, '-m', 'lower'])
+  untrusted = await git(['-C', repository, 'commit-tree', tree, '-m', 'PR only'])
+  for (const [ref, sha] of [
+    ['refs/heads/Fix', upper],
+    ['refs/heads/fix', lower],
+    ['refs/pull/1/head', untrusted]
+  ]) {
+    await git(['-C', repository, 'update-ref', ref, sha])
+  }
+  await git(['-C', repository, 'tag', '-a', 'Release', upper, '-m', 'upper tag'])
+  await git(['-C', repository, 'tag', '-a', 'release', lower, '-m', 'lower tag'])
+  await git(['-C', repository, 'config', 'uploadpack.allowFilter', 'true'])
+})
+
+afterAll(() => rmSync(directory, { recursive: true, force: true }))
+
+async function vet(step, ref) {
+  const scratch = mkdtempSync(join(directory, 'attempt-'))
+  const script = join(scratch, 'vet.sh')
+  writeFileSync(script, step.run)
+  return runProcess({
+    program: 'bash',
+    args: [script],
+    env: {
+      ...identity,
+      REPO_URL: pathToFileURL(repository).href,
+      RUNNER_TEMP: scratch,
+      GITHUB_OUTPUT: join(scratch, 'output'),
+      REQUESTED_REF: ref,
+      REQUESTED_SHA: ref,
+      CHANNEL: 'hourly',
+      TAG: 'v1.0.0-hourly.test',
+      VERSION: '1.0.0-hourly.test'
+    }
+  })
+}
+
+describe('release ref trust with case-twin names', () => {
+  it('accepts both branch tips, annotated tags, and their common ancestor', async () => {
+    for (const sha of [upper, lower, ancestor]) {
+      const result = await vet(windowsVet, sha)
+      expect(result.code, result.stderr).toBe(0)
+    }
+    for (const ref of ['Fix', 'fix', 'Release', 'release', ancestor]) {
+      const result = await vet(macVet, ref)
+      expect(result.code, result.stderr).toBe(0)
+    }
+  })
+
+  it('rejects PR-only commits even when the server has their objects', async () => {
+    for (const step of [windowsVet, macVet]) {
+      const result = await vet(step, untrusted)
+      expect(result.code).not.toBe(0)
+      expect(result.stdout).toContain('not reachable from any branch or tag')
+    }
+    const result = await vet(macVet, 'refs/pull/1/head')
+    expect(result.code).not.toBe(0)
+    expect(result.stdout).toContain('Refusing to build PR ref')
+  })
+
+  it('preserves both case variants in the subsequent full-history checkout', async () => {
+    const checkout = join(directory, 'checkout')
+    const env = { ...identity, ...macCheckout.env }
+    await git(['init', checkout], env)
+    await git(
+      [
+        '-C',
+        checkout,
+        'fetch',
+        '--no-tags',
+        repository,
+        '+refs/heads/*:refs/remotes/origin/*',
+        '+refs/tags/*:refs/tags/*'
+      ],
+      env
+    )
+    await git(['-C', checkout, 'checkout', '--detach', upper], env)
+    for (const [ref, sha] of [
+      ['refs/remotes/origin/Fix', upper],
+      ['refs/remotes/origin/fix', lower],
+      ['refs/tags/Release', upper],
+      ['refs/tags/release', lower]
+    ]) {
+      expect(await git(['-C', checkout, 'rev-parse', `${ref}^{commit}`], env)).toBe(sha)
+    }
+    expect(await git(['-C', checkout, 'rev-parse', 'HEAD'], env)).toBe(upper)
+  })
+})


### PR DESCRIPTION
Release vetting must accept branch/tag names differing only by case without trusting commits available only through PR refs. #18970 fixed the scratch ref store, but the subsequent full-history adhoc Mac checkout still initialized the ordinary files backend and could fail on the same collision.

Use reftable for that checkout too, preserving full history and the exact vetted SHA. Add real-Git tests that execute both workflows' actual vetting scripts, accept case-twin branch tips/tags and their ancestor, reject PR-only commits/refs, and verify both case variants survive the subsequent full-history checkout. Run these contracts on macOS 15 and Windows 2022 for relevant PRs, without signing credentials or publishing.

Local validation: 27 workflow/ref-trust contracts pass; oxlint and formatting pass. actionlint reports only the pre-existing custom Blacksmith runner label in the adhoc workflow. Observed production runner Git versions (Windows 2.55.0.windows.5, Blacksmith Mac 2.54.0) support reftable; this is CI-only and does not change the application's Git baseline.

Independent sub-agent review approved commit b372a26b82d with no blocking findings and independently ran all 27 focused tests. Hosted [Release ref validation 34004061551](https://github.com/stablyai/orca/actions/runs/34004061551) passed on both Windows 2022 and macOS 15. Full [PR CI 34004061661](https://github.com/stablyai/orca/actions/runs/34004061661) passed. The live hourly [run 34003822975](https://github.com/stablyai/orca/actions/runs/34003822975) also passed the previously failing Windows input-vetting step against the actual repository.
