### PR TITLE
test: bound release checkout fixtures and gate delayed imports

### DIFF
--- a/tests/e2e/cross-version-wire/release-checkout.unit.test.ts
+++ b/tests/e2e/cross-version-wire/release-checkout.unit.test.ts
@@ -263,11 +263,23 @@ afterEach(() => {
 describe('release checkout materialization', () => {
   it('single-flights concurrent consumers of one release identity', async () => {
     const cacheRoot = temporaryCacheRoot()
+    let publications = 0
+    const options = {
+      cacheRoot,
+      testHooks: {
+        populateStaging: async (context: CheckoutStagingContext) => {
+          publications++
+          await populateMinimalStaging(context)
+        }
+      }
+    }
     const checkouts = await Promise.all([
-      materializeReleaseCheckout('v1.4.190', { cacheRoot }),
-      materializeReleaseCheckout('v1.4.190', { cacheRoot }),
-      materializeReleaseCheckout('v1.4.190', { cacheRoot })
+      materializeReleaseCheckout('v1.4.190', options),
+      materializeReleaseCheckout('v1.4.190', options),
+      materializeReleaseCheckout('v1.4.190', options)
     ])
+
+    expect(publications).toBe(1)
 
     expect(new Set(checkouts.map(({ root }) => root))).toHaveLength(1)
     expect(relative(cacheRoot, checkouts[0]!.root)).not.toMatch(/^\.\./)
@@ -291,18 +303,29 @@ describe('release checkout materialization', () => {
     )
 
     const cacheRoot = temporaryCacheRoot()
-    const first = await materializeReleaseCheckout(firstRef, { cacheRoot })
+    const options = { cacheRoot, testHooks: { populateStaging: populateMinimalStaging } }
+    const first = await materializeReleaseCheckout(firstRef, options)
     const dependency = join(first.root, 'delayed-dependency.mjs')
     const entry = join(first.root, 'delayed-entry.mjs')
+    const importStarted = join(cacheRoot, 'import-started')
+    const continueImport = join(cacheRoot, 'continue-import')
     writeFileSync(dependency, "export const loaded = 'first-release'\n")
     writeFileSync(
       entry,
-      'await new Promise((resolve) => setTimeout(resolve, 100))\n' +
+      "import { existsSync, writeFileSync } from 'node:fs'\n" +
+        `writeFileSync(${JSON.stringify(importStarted)}, '')\n` +
+        `while (!existsSync(${JSON.stringify(continueImport)})) await new Promise((resolve) => setTimeout(resolve, 10))\n` +
         "export const loaded = (await import('./delayed-dependency.mjs')).loaded\n"
     )
 
     const loading = importReleaseCheckoutModule(first, '/delayed-entry.mjs')
-    const second = await materializeReleaseCheckout(secondRef, { cacheRoot })
+    let second: ReleaseCheckout
+    try {
+      await waitForFile(importStarted, 5_000)
+      second = await materializeReleaseCheckout(secondRef, options)
+    } finally {
+      writeFileSync(continueImport, '')
+    }
 
     await expect(loading).resolves.toMatchObject({ loaded: 'first-release' })
     expect(first.root).not.toBe(second.root)
@@ -311,7 +334,10 @@ describe('release checkout materialization', () => {
   it('causally single-flights a rival process before publishing an in-use checkout', async () => {
     const cacheRoot = temporaryCacheRoot()
     const scratch = temporaryCacheRoot()
-    const published = await materializeReleaseCheckout('v1.4.190', { cacheRoot })
+    const published = await materializeReleaseCheckout('v1.4.190', {
+      cacheRoot,
+      testHooks: { populateStaging: populateMinimalStaging }
+    })
 
     await expect(runContentionPhase(published, scratch, 'locked', false)).resolves.toBe(true)
     // In the same causally acknowledged interleaving, a no-lock materializer


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Release-checkout lock and identity tests repeatedly extracted entire source trees, exceeding their 30-second test budgets during the full suite. Use the existing minimal-staging seam for lock/publication and colliding-label fixtures, while retaining the real archive extraction and baseline module import test.

The concurrent-consumer test now asserts exactly one publication. The colliding-label test replaces its fixed 100 ms delay with a file barrier, proving the first import is pending until the second checkout is materialized. Real locks, subprocess contention, crash recovery, and assertions remain enabled; no timeout increases or retries.

Validation: unchanged suite passed in 43.08 s before the change. The final suite passed twice in concurrent shuffled runs (seeds 19 and 43), 10/10 tests each in 16.60 s and 16.27 s. Targeted lint and formatting pass. Full-suite validation remains outstanding.
