### PR TITLE
fix: preserve overlay focus during terminal mounting and layout

### DIFF
--- a/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
@@ -90,6 +90,7 @@ describe('fitAndFocusPanes', () => {
     vi.stubGlobal('HTMLElement', FakeHTMLElement)
     vi.stubGlobal('document', {
       activeElement,
+      querySelectorAll: vi.fn(() => []),
       querySelector: vi.fn((selector: string) =>
         selector === '[data-tab-rename-input="true"]' && renameInputMounted
           ? (new FakeHTMLElement({ tagName: 'INPUT' }) as unknown as Element)

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -1,4 +1,5 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { focusPanePreservingOverlays } from '@/lib/pane-manager/pane-overlay-focus'
 
 export function fitPanes(manager: PaneManager): void {
   manager.fitAllPanes()
@@ -16,7 +17,9 @@ export function focusActivePane(manager: PaneManager): void {
   }
   const panes = manager.getPanes()
   const activePane = manager.getActivePane() ?? panes[0]
-  activePane?.terminal.focus()
+  if (activePane) {
+    focusPanePreservingOverlays(activePane)
+  }
 }
 
 export function fitAndFocusPanes(manager: PaneManager): void {

--- a/src/renderer/src/components/terminal-pane/terminal-layout-overlay-focus.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-overlay-focus.test.tsx
@@ -75,6 +75,16 @@ describe('terminal layout preserves overlay focus', () => {
     expect(document.activeElement).toBe(textarea)
   })
 
+  it('hands focus back to a menu that is animating closed', () => {
+    const { manager, terminal, textarea } = createLayoutFixture()
+    mountOverlay('menu').setAttribute('data-state', 'closed')
+
+    fitAndFocusPanes(manager)
+
+    expect(terminal.focus).toHaveBeenCalledOnce()
+    expect(document.activeElement).toBe(textarea)
+  })
+
   it('does not treat the workspace sidebar as a focus-owning overlay', () => {
     const { manager, terminal } = createLayoutFixture()
     const sidebar = mountOverlay('listbox')

--- a/src/renderer/src/components/terminal-pane/terminal-layout-overlay-focus.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-overlay-focus.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { fitAndFocusPanes } from './pane-helpers'
+
+function createLayoutFixture() {
+  const textarea = document.createElement('textarea')
+  textarea.className = 'xterm-helper-textarea'
+  document.body.append(textarea)
+  textarea.focus()
+  const terminal = { focus: vi.fn(() => textarea.focus()) }
+  const manager = {
+    fitAllPanes: vi.fn(),
+    getActivePane: () => ({ terminal }),
+    getPanes: () => [{ terminal }]
+  } as unknown as PaneManager
+  return { manager, terminal, textarea }
+}
+
+function mountOverlay(role: string) {
+  const overlay = document.createElement('div')
+  overlay.setAttribute('role', role)
+  overlay.tabIndex = -1
+  vi.spyOn(overlay, 'getClientRects').mockReturnValue([
+    new DOMRect(0, 0, 100, 100)
+  ] as unknown as DOMRectList)
+  document.body.append(overlay)
+  return overlay
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+  vi.restoreAllMocks()
+})
+
+describe('terminal layout preserves overlay focus', () => {
+  it.each(['menu', 'dialog', 'alertdialog', 'listbox'])(
+    'does not blur an open %s during a queued fit',
+    (role) => {
+      const { manager, terminal } = createLayoutFixture()
+      const overlay = mountOverlay(role)
+      overlay.focus()
+      const blurred = vi.fn()
+      overlay.addEventListener('blur', blurred)
+
+      fitAndFocusPanes(manager)
+
+      expect(manager.fitAllPanes).toHaveBeenCalledOnce()
+      expect(terminal.focus).not.toHaveBeenCalled()
+      expect(document.activeElement).toBe(overlay)
+      expect(blurred).not.toHaveBeenCalled()
+    }
+  )
+
+  it('leaves a mounted menu time to acquire focus', () => {
+    const { manager, terminal, textarea } = createLayoutFixture()
+    textarea.blur()
+    mountOverlay('menu')
+
+    fitAndFocusPanes(manager)
+
+    expect(terminal.focus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(document.body)
+  })
+
+  it('allows focus after the menu closes', () => {
+    const { manager, terminal, textarea } = createLayoutFixture()
+    const overlay = mountOverlay('menu')
+    overlay.focus()
+    overlay.remove()
+
+    fitAndFocusPanes(manager)
+
+    expect(terminal.focus).toHaveBeenCalledOnce()
+    expect(document.activeElement).toBe(textarea)
+  })
+
+  it('does not treat the workspace sidebar as a focus-owning overlay', () => {
+    const { manager, terminal } = createLayoutFixture()
+    const sidebar = mountOverlay('listbox')
+    sidebar.setAttribute('data-worktree-sidebar', '')
+
+    fitAndFocusPanes(manager)
+
+    expect(terminal.focus).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-manager-pane-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-pane-creation.ts
@@ -1,3 +1,4 @@
+import { focusPanePreservingOverlays } from './pane-overlay-focus'
 import type { ManagedPane, ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
 import type { PaneManagerHost } from './pane-manager-host'
 import { applyPaneOpacity } from './pane-divider'
@@ -23,7 +24,7 @@ export function createInitialManagedPane(
   applyPaneOpacity(host.panes.values(), host.getActivePaneId(), host.getStyleOptions())
 
   if (opts?.focus !== false) {
-    pane.terminal.focus()
+    focusPanePreservingOverlays(pane)
   }
 
   host.publishPaneCreated(pane)

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -297,7 +297,9 @@ export class PaneManager {
   }
 
   scheduleRevealRepaint(): void {
-    // Repainting after hide/destroy can revive WebGL contexts and force unrelated panes to DOM.
+    // Why: the settled-frame callback can fire after hide/destroy; repainting
+    // hidden or disposed panes can revive WebGL contexts and latch attach
+    // backoff, downgrading unrelated new panes to the DOM renderer.
     schedulePaneRevealRepaint(() => (this.isVisibleForAtlasRecovery() ? this.panes.values() : []))
   }
 

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -1,13 +1,11 @@
+import { focusPanePreservingOverlays } from './pane-overlay-focus'
 import type {
   PaneManagerOptions,
   PaneStyleOptions,
   ManagedPane,
   ManagedPaneInternal,
   PaneRenderingDiagnostics,
-  DropZone,
-  PaneExternalDropHandler,
-  PaneExternalDropResolver,
-  PaneExternalDropTarget
+  DropZone
 } from './pane-manager-types'
 import type { SplitPaneAroundLeafIdsOptions } from './pane-subtree-split'
 import type { PaneManagerHost } from './pane-manager-host'
@@ -68,7 +66,7 @@ export type {
   PaneExternalDropTarget,
   PaneExternalDropResolver,
   PaneExternalDropHandler
-}
+} from './pane-manager-types'
 
 export class PaneManager {
   private root: HTMLElement
@@ -235,7 +233,7 @@ export class PaneManager {
     applyPaneOpacity(this.panes.values(), this.activePaneId, this.styleOptions)
 
     if (opts?.focus !== false) {
-      pane.terminal.focus()
+      focusPanePreservingOverlays(pane)
     }
 
     if (changed) {
@@ -299,9 +297,7 @@ export class PaneManager {
   }
 
   scheduleRevealRepaint(): void {
-    // Why: the settled-frame callback can fire after hide/destroy; repainting
-    // hidden or disposed panes can revive WebGL contexts and latch attach
-    // backoff, downgrading unrelated new panes to the DOM renderer.
+    // Repainting after hide/destroy can revive WebGL contexts and force unrelated panes to DOM.
     schedulePaneRevealRepaint(() => (this.isVisibleForAtlasRecovery() ? this.panes.values() : []))
   }
 

--- a/src/renderer/src/lib/pane-manager/pane-overlay-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-overlay-focus.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { PaneManager } from './pane-manager'
+import { createInitialManagedPane } from './pane-manager-pane-creation'
+import type { PaneManagerHost } from './pane-manager-host'
+import type { ManagedPaneInternal } from './pane-manager-types'
+
+vi.mock('./pane-lifecycle', () => ({
+  openTerminal: vi.fn(),
+  createPaneDOM: vi.fn(),
+  disposePane: vi.fn(),
+  setLigaturesEnabled: vi.fn()
+}))
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function fixture() {
+  const root = document.createElement('div')
+  document.body.append(root)
+  const container = document.createElement('div')
+  const textarea = document.createElement('textarea')
+  container.append(textarea)
+  const pane = {
+    id: 1,
+    container,
+    terminal: { focus: vi.fn(() => textarea.focus()) }
+  } as unknown as ManagedPaneInternal
+  const panes = new Map([[pane.id, pane]])
+  const publishPaneCreated = vi.fn()
+  const onActivePaneChange = vi.fn()
+  const manager = Object.create(PaneManager.prototype) as PaneManager
+  Object.assign(manager, {
+    panes,
+    activePaneId: null,
+    styleOptions: {},
+    options: { onActivePaneChange }
+  })
+  const host = {
+    options: {},
+    root,
+    panes,
+    createPaneInternal: () => pane,
+    setActivePaneId: vi.fn(),
+    getActivePaneId: () => pane.id,
+    getStyleOptions: () => ({}),
+    publishPaneCreated
+  } as unknown as PaneManagerHost
+  return { root, container, textarea, pane, host, manager, publishPaneCreated, onActivePaneChange }
+}
+
+function overlay(role: string) {
+  const element = document.createElement('div')
+  element.setAttribute('role', role)
+  element.tabIndex = -1
+  document.body.append(element)
+  element.focus()
+  return element
+}
+
+describe.each(['initial', 'active'] as const)('%s pane focus', (operation) => {
+  function focus(f: ReturnType<typeof fixture>, requested = true) {
+    if (operation === 'initial') {
+      createInitialManagedPane(f.host, { focus: requested })
+      expect(f.publishPaneCreated).toHaveBeenCalledWith(f.pane)
+    } else {
+      f.root.append(f.container)
+      f.manager.setActivePane(f.pane.id, { focus: requested })
+      expect(f.manager.getActivePane()?.id).toBe(f.pane.id)
+      expect(f.onActivePaneChange).toHaveBeenCalledTimes(1)
+    }
+  }
+
+  it.each(['menu', 'dialog', 'alertdialog', 'listbox'])('preserves a visible %s', (role) => {
+    const f = fixture()
+    const popup = overlay(role)
+    focus(f)
+    expect(document.activeElement).toBe(popup)
+    expect(f.pane.terminal.focus).not.toHaveBeenCalled()
+  })
+
+  it('focuses a terminal hosted inside a dialog', () => {
+    const f = fixture()
+    overlay('dialog').append(f.root)
+    focus(f)
+    expect(document.activeElement).toBe(f.textarea)
+  })
+
+  it('preserves a nested popup over a dialog-hosted terminal', () => {
+    const f = fixture()
+    const dialog = overlay('dialog')
+    dialog.append(f.root)
+    const popup = overlay('menu')
+    dialog.append(popup)
+    popup.focus()
+    focus(f)
+    expect(document.activeElement).toBe(popup)
+  })
+
+  it('allows focus with only persistent sidebar chrome', () => {
+    const f = fixture()
+    overlay('listbox').setAttribute('data-worktree-sidebar', '')
+    focus(f)
+    expect(document.activeElement).toBe(f.textarea)
+  })
+
+  it('allows focus after the overlay closes', () => {
+    const f = fixture()
+    overlay('menu').style.display = 'none'
+    focus(f)
+    expect(document.activeElement).toBe(f.textarea)
+  })
+
+  it('preserves a popup nested inside sidebar chrome', () => {
+    const f = fixture()
+    const sidebar = overlay('listbox')
+    sidebar.setAttribute('data-worktree-sidebar', '')
+    const popup = overlay('menu')
+    sidebar.append(popup)
+    popup.focus()
+    focus(f)
+    expect(document.activeElement).toBe(popup)
+  })
+
+  it('honors an explicit no-focus request', () => {
+    const f = fixture()
+    focus(f, false)
+    expect(f.pane.terminal.focus).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-overlay-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-overlay-focus.ts
@@ -8,7 +8,8 @@ export function focusPanePreservingOverlays(
     typeof document !== 'undefined' &&
     hasVisibleOverlay({
       ignoreMatches: '[role="listbox"][data-worktree-sidebar]',
-      ignoreContaining: pane.container
+      ignoreContaining: pane.container,
+      ignoreDismissed: true
     })
   ) {
     return

--- a/src/renderer/src/lib/pane-manager/pane-overlay-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-overlay-focus.ts
@@ -1,0 +1,17 @@
+import { hasVisibleOverlay } from '../visible-overlay'
+import type { ManagedPane } from './pane-manager-types'
+
+export function focusPanePreservingOverlays(
+  pane: Pick<ManagedPane, 'container' | 'terminal'>
+): void {
+  if (
+    typeof document !== 'undefined' &&
+    hasVisibleOverlay({
+      ignoreMatches: '[role="listbox"][data-worktree-sidebar]',
+      ignoreContaining: pane.container
+    })
+  ) {
+    return
+  }
+  pane.terminal.focus()
+}

--- a/src/renderer/src/lib/visible-overlay.ts
+++ b/src/renderer/src/lib/visible-overlay.ts
@@ -12,7 +12,8 @@ type VisibleOverlayOptions = {
 /**
  * Whether a dialog, alert dialog, listbox, or menu is on screen. Page-level Escape
  * handlers ask this before acting: the overlay owns the first Escape, and a page
- * that preventDefaults instead vetoes the overlay's own dismissal.
+ * that preventDefaults instead vetoes the overlay's own dismissal. Terminal focus
+ * asks the same question: a live overlay outranks a queued pane focus.
  */
 export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
   return Array.from(document.querySelectorAll(OVERLAY_SELECTOR)).some((element) => {
@@ -29,6 +30,11 @@ export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
       return false
     }
     if (options?.ignoreContaining && element.contains(options.ignoreContaining)) {
+      return false
+    }
+    // Why: overlays stay mounted and painted through their exit animation, so a
+    // dismissed one would otherwise keep owning focus and Escape for ~300ms.
+    if (element.getAttribute('data-state') === 'closed') {
       return false
     }
     const style = window.getComputedStyle(element)

--- a/src/renderer/src/lib/visible-overlay.ts
+++ b/src/renderer/src/lib/visible-overlay.ts
@@ -7,6 +7,8 @@ type VisibleOverlayOptions = {
   ignoreMatches?: string
   /** A terminal hosted inside an overlay may still take focus within that overlay. */
   ignoreContaining?: Element
+  /** An overlay animating out no longer outranks focus that was queued before it closed. */
+  ignoreDismissed?: boolean
 }
 
 /**
@@ -33,8 +35,10 @@ export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
       return false
     }
     // Why: overlays stay mounted and painted through their exit animation, so a
-    // dismissed one would otherwise keep owning focus and Escape for ~300ms.
-    if (element.getAttribute('data-state') === 'closed') {
+    // dismissed one would otherwise keep owning a queued focus for ~300ms. Escape
+    // callers opt out: they run before the attribute flips, so it only ever hides
+    // a still-open overlay from them.
+    if (options?.ignoreDismissed && element.getAttribute('data-state') === 'closed') {
       return false
     }
     const style = window.getComputedStyle(element)

--- a/src/renderer/src/lib/visible-overlay.ts
+++ b/src/renderer/src/lib/visible-overlay.ts
@@ -3,6 +3,10 @@ const OVERLAY_SELECTOR = '[role="dialog"], [role="alertdialog"], [role="listbox"
 type VisibleOverlayOptions = {
   /** Overlays inside a match are treated as page content, not as a layer above it. */
   ignoreSelector?: string
+  /** Ignore matching chrome itself while retaining overlays nested within it. */
+  ignoreMatches?: string
+  /** A terminal hosted inside an overlay may still take focus within that overlay. */
+  ignoreContaining?: Element
 }
 
 /**
@@ -19,6 +23,12 @@ export function hasVisibleOverlay(options?: VisibleOverlayOptions): boolean {
       return false
     }
     if (options?.ignoreSelector && element.closest(options.ignoreSelector)) {
+      return false
+    }
+    if (options?.ignoreMatches && element.matches(options.ignoreMatches)) {
+      return false
+    }
+    if (options?.ignoreContaining && element.contains(options.ignoreContaining)) {
       return false
     }
     const style = window.getComputedStyle(element)


### PR DESCRIPTION
## ELI5

When you opened a menu in the sidebar — say to click "Add Project" — the menu would sometimes vanish before you could pick anything. The cause was a terminal finishing loading a moment later in the background. As soon as it appeared, it grabbed the keyboard for itself, and the open menu took that as "the user clicked somewhere else" and closed itself. It felt random, because it only happened when a terminal happened to finish loading at the same moment you opened a menu.

Now a terminal checks whether a menu or dialog is already open before it takes the keyboard, and waits its turn if one is. Menus stay open until you actually choose something or dismiss them. Once the menu is gone, the terminal takes the keyboard as it always did, so normal typing is unaffected.

## What Changed

Late terminal mounting and pane activation could focus the terminal after a sidebar menu opened, dismissing the menu before Add Project could be selected. Deferred layout had the same risk.

One overlay-aware focus policy now covers initial creation, activation, and deferred layout (`focusPanePreservingOverlays`). Activation and publication stay intact, focus is allowed within a containing dialog, and only the persistent sidebar listbox itself is ignored while nested popups are still respected.

`hasVisibleOverlay` gains an `ignoreDismissed` option that treats an overlay carrying `data-state="closed"` as gone. Every overlay primitive in `components/ui` has an exit animation (`data-[state=closed]:animate-out`, up to 300ms on sheets), so a dismissed overlay stays mounted and painted well past the point it should stop owning focus — and `activateTabAndFocusPane` defers focus by one rAF, landing squarely inside that window. Without this, revealing an agent from the dashboard drawer, a sheet, or a command palette left the terminal unfocused. This matches the `[role="..."][data-state="open"]` convention already used in `AgentDashboardDrawer.tsx`, `useWorkspaceBoardPanel.ts`, and `use-workspace-kanban-outside-dismiss.ts`.

Only `focusPanePreservingOverlays` passes `ignoreDismissed`, so Escape behavior for the four existing callers is unchanged. The rule is deliberately not global: the race is specific to *deferred* focus, whereas Escape is synchronous and never needs it — Radix's `useEscapeKeydown` is capture phase, so every Escape caller already runs while `data-state` is still `"open"`. Scoping it also keeps the Settings Escape path untouched, which unlike automations/skills/workspace-space (capture on `window`) is bubble phase on `document` with no ordering guarantee.

## Why

`focusActivePane` already refuses to steal focus from a mounted rename input and from editable elements. Overlay ownership is the same class of rule, so this extends that existing guard rather than adding a parallel mechanism.

`onlyIfFocusUnclaimed` (`lib/focus-terminal-tab-surface.ts`) was considered and rejected: it only defers when the overlay *already holds* focus, and the bug is precisely the race where a menu has mounted but has not yet taken focus.

## Linked Issue

No filed issue; found while reproducing the sidebar "Add Project" menu dismissal.

## Visual Proof

N/A — local Electron launches are paused for this task, so no before/after capture was recorded. The change is a focus-ownership rule with no rendered pixel change: the visible difference is a menu staying open, which the added regression tests assert directly (`terminal-layout-overlay-focus.test.tsx`, `pane-overlay-focus.test.ts`). A screen recording of the sidebar menu surviving a terminal mount would be the valuable artifact if this needs manual confirmation before merge.

## Tradeoffs

Genuine user-facing downsides of this approach:

- **A first click into a terminal while a non-modal overlay is open may not focus it.** The pane's `pointerdown` handler runs before Radix's document-level dismiss listener, so at that instant the overlay is still open and focus is skipped; the overlay closes but the terminal does not gain focus, costing a second click. Modal menus and dialogs are unaffected because the click never reaches the pane.
- **Any visible `dialog`/`alertdialog`/`listbox`/`menu` blocks pane focus, even one that does not hold focus.** This is deliberate — it is what closes the mount race — but it is broader than "the overlay owns focus", so a non-focus-owning overlay parked on screen also defers terminal focus.
- **Keyboard pane switching is now guarded too.** Cycling panes via `terminal-keyboard-action-dispatch` goes through `setActivePane({ focus: true })`, so switching panes while an overlay is open will not land focus in the terminal.
- **Guard coverage is partial.** `pane-split-close.ts`, `expand-collapse.ts`, and the direct `terminal.focus()` in `terminal-keyboard-action-dispatch.ts` still focus unconditionally, so splitting or closing a pane while a menu is open can still dismiss it. Those are explicit user actions, so this was left as-is rather than widening the diff.
- **Small added cost on the resize path.** `fitAndFocusPanes` is rAF-coalesced during a window resize, and each pass now runs an extra `querySelectorAll` plus `getComputedStyle`/`getClientRects`, i.e. one more forced style/layout read per frame. It is adjacent to an existing document-wide query on the same path, so the marginal cost is small.

## Testing

- [x] Automated tests added/updated
- [ ] Manual testing — not possible; local Electron launches are paused for this task

**Run locally, all passing:** `pnpm tc`; `oxlint` on `src/renderer/src/lib/` and `src/renderer/src/components/terminal-pane/`; and `pnpm test` over the focus suites plus the whole of `components/settings/` — 1178 tests across 176 files. Earlier, pre-scoping: 865 pass / 1 pre-existing skip across `lib/pane-manager/`. The new closing-overlay test was mutation-checked: it fails when the `data-state="closed"` branch is removed, so it is not vacuous.

`components/terminal-pane/` shows 3-17 failures under full-directory parallel load, all in unrelated `remote-runtime-*` transport tests. They vary run to run and pass in isolation, i.e. parallel-load flakes, not caused by this change.

**Not yet verified — `PR Checks` is still pending on head `00f0637b437`.** `PR test LoC` passed; the workflow carrying typecheck, static analysis, packaging and the 8 test shards has not completed on either of this branch's two newest commits (the runner queue is backed up). The green run referenced below is for the earlier head `dbaa947ce19`, before these commits. Local runs do **not** cover packaging, the Windows job, or the full sharded suite, so treat those as unverified until `PR Checks` reports.

Rendered run 34017675883 passed all 21 tests: three repetitions of each selected-runtime mode plus terminal reproduction and stress cases, with menu diagnostics removed. That run includes the virtualized-sidebar assertions from test PR #19003.

## Review

Overlaps with **#18881**, which excludes the sidebar at the selector level (`[role="listbox"]:not([data-worktree-sidebar])`). The two merge cleanly (verified with `git merge-tree`), but once #18881 lands, this PR's `ignoreMatches` option and its only call site become dead code and should be deleted. `ignoreMatches` is kept here because without it this PR alone would let the always-mounted sidebar listbox permanently suppress terminal focus. `ignoreContaining` is unaffected and remains necessary.

Note the two changes are independent, not redundant: the sidebar listbox is not a Radix primitive and carries no `data-state` attribute, so `ignoreDismissed` does not exclude it and #18881's selector is still required.

## Notes

Renderer-only DOM focus policy. No IPC, wire, or persisted-state surface; no SSH, mobile, or backward-compatibility impact. No platform-specific code paths.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof marked `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck`, `oxlint`, and targeted `pnpm test` pass locally
- [ ] CI — `PR Checks` still pending on head `00f0637b437`; not yet green on this commit
