### PR TITLE
fix(windows): unblock structured native chat by exposing process creation time

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -858,6 +858,7 @@ jobs:
           src/main/windows/windows-pty-job.win32.test.ts
           src/main/windows/windows-host-job.win32.test.ts
           src/main/windows/windows-process-tree-command-line-patch.test.ts
+          src/main/windows/windows-process-table-native-addon.win32.test.ts
           src/main/windows-live-tree-kill.win32.test.ts
           src/main/wsl/wsl-runner.test.ts
           src/main/wsl/wsl-guest-environment.test.ts

--- a/config/patches/@vscode__windows-process-tree@0.8.0.patch
+++ b/config/patches/@vscode__windows-process-tree@0.8.0.patch
@@ -24,184 +24,11 @@ index 855bd4b86f0a3c18c7594212c0e42b6e35bc4001..0bb2af7923b6e6f1f0da40cae8067304
            "msvs_settings": {
              "VCCLCompilerTool": {
 +              "ExceptionHandling": 1,
-<<<<<<< HEAD
-               "AdditionalOptions": [
-                 "/guard:cf",
-                 "/sdl",
-diff --git a/src/process.cc b/src/process.cc
-index 3eea92077c4d1d433119361d5c432881859131e9..738775f6fcdfb676054386fe34c0380327ed1863 100644
---- a/src/process.cc
-+++ b/src/process.cc
-@@ -1,108 +1,112 @@
--/*---------------------------------------------------------------------------------------------
-- *  Copyright (c) Microsoft Corporation. All rights reserved.
-- *  Licensed under the MIT License. See License.txt in the project root for license information.
-- *--------------------------------------------------------------------------------------------*/
--
--#include "process.h"
--#include "process_commandline.h"
--
--#include <tlhelp32.h>
--#include <psapi.h>
--#include <limits>
--
--uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
--                           DWORD process_data_flags) {
--  // Fetch the PID and PPIDs
--  PROCESSENTRY32 process_entry = { 0 };
--  DWORD parent_pid = 0;
--  uint32_t process_count = 0;
--  HANDLE snapshot_handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
--  process_entry.dwSize = sizeof(PROCESSENTRY32);
--  if (Process32First(snapshot_handle, &process_entry)) {
--    do {
--      if (process_entry.th32ProcessID != 0) {
--        ProcessInfo pinfo;
--        pinfo.pid = process_entry.th32ProcessID;
--        pinfo.ppid = process_entry.th32ParentProcessID;
--
--        if (MEMORY & process_data_flags) {
--          GetProcessMemoryUsage(pinfo);
--        }
--
--        if (COMMANDLINE & process_data_flags) {
--          GetProcessCommandLine(pinfo);
--        }
--
--        strcpy(pinfo.name, process_entry.szExeFile);
--        process_info.push_back(std::move(pinfo));
--        process_count++;
--      }
--    } while (process_count < 1024 && Process32Next(snapshot_handle, &process_entry));
--  }
--
--  CloseHandle(snapshot_handle);
--  return process_count;
--}
--
--void GetProcessMemoryUsage(ProcessInfo& process_info) {
--  DWORD pid = process_info.pid;
--  HANDLE hProcess;
--  PROCESS_MEMORY_COUNTERS pmc;
--
--  hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
--
--  if (hProcess == NULL) {
--    return;
--  }
--
--  if (GetProcessMemoryInfo(hProcess, &pmc, sizeof(pmc))) {
--    process_info.memory = (DWORD)pmc.WorkingSetSize;
--  }
--
--  CloseHandle(hProcess);
--}
--
--// Per documentation, it is not recommended to add or subtract values from the FILETIME
--// structure, or to cast it to ULARGE_INTEGER as this can cause alignment faults on 64-bit Windows.
--// Copy the high and low part to a ULARGE_INTEGER and peform arithmetic on that instead.
--// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
--ULONGLONG GetTotalTime(const FILETIME* kernelTime, const FILETIME* userTime) {
--  ULARGE_INTEGER kt, ut;
--  kt.LowPart = (*kernelTime).dwLowDateTime;
--  kt.HighPart = (*kernelTime).dwHighDateTime;
--
--  ut.LowPart = (*userTime).dwLowDateTime;
--  ut.HighPart = (*userTime).dwHighDateTime;
--
--  return kt.QuadPart + ut.QuadPart;
--}
--
--void GetCpuUsage(Cpu& cpu_info, bool first_pass) {
--  DWORD pid = cpu_info.pid;
--  HANDLE hProcess;
--
--  hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
--
--  if (hProcess == NULL) {
--    return;
--  }
--
--  FILETIME creationTime, exitTime, kernelTime, userTime;
--  FILETIME sysIdleTime, sysKernelTime, sysUserTime;
--  if (GetProcessTimes(hProcess, &creationTime, &exitTime, &kernelTime, &userTime)
--    && GetSystemTimes(&sysIdleTime, &sysKernelTime, &sysUserTime)) {
--    if (first_pass) {
--      cpu_info.initialProcRunTime = GetTotalTime(&kernelTime, &userTime);
--      cpu_info.initialSystemTime = GetTotalTime(&sysKernelTime, &sysUserTime);
--    } else {
--      ULONGLONG endProcTime = GetTotalTime(&kernelTime, &userTime);
--      ULONGLONG endSysTime = GetTotalTime(&sysKernelTime, &sysUserTime);
--
--      cpu_info.cpu = 100.0 * (endProcTime - cpu_info.initialProcRunTime) / (endSysTime - cpu_info.initialSystemTime);
--    }
--  } else {
--    cpu_info.cpu = std::numeric_limits<double>::quiet_NaN();
--  }
--
--  CloseHandle(hProcess);
-+/*---------------------------------------------------------------------------------------------
-+ *  Copyright (c) Microsoft Corporation. All rights reserved.
-+ *  Licensed under the MIT License. See License.txt in the project root for license information.
-+ *--------------------------------------------------------------------------------------------*/
-+
-+#include "process.h"
-+#include "process_commandline.h"
-+
-+#include <tlhelp32.h>
-+#include <psapi.h>
-+#include <limits>
-+
-+uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
-+                           DWORD process_data_flags) {
-+  // Fetch the PID and PPIDs
-+  PROCESSENTRY32 process_entry = { 0 };
-+  DWORD parent_pid = 0;
-+  uint32_t process_count = 0;
-+  HANDLE snapshot_handle = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-+  process_entry.dwSize = sizeof(PROCESSENTRY32);
-+  if (Process32First(snapshot_handle, &process_entry)) {
-+    do {
-+      if (process_entry.th32ProcessID != 0) {
-+        // Value-initialize: `memory` is otherwise stack garbage when the flag is unset.
-+        ProcessInfo pinfo{};
-+        pinfo.pid = process_entry.th32ProcessID;
-+        pinfo.ppid = process_entry.th32ParentProcessID;
-+
-+        if (MEMORY & process_data_flags) {
-+          GetProcessMemoryUsage(pinfo);
-+        }
-+
-+        if (COMMANDLINE & process_data_flags) {
-+          GetProcessCommandLine(pinfo);
-+        }
-+
-+        strcpy(pinfo.name, process_entry.szExeFile);
-+        process_info.push_back(std::move(pinfo));
-+        process_count++;
-+      }
-+    } while (Process32Next(snapshot_handle, &process_entry));
-+  }
-+
-+  CloseHandle(snapshot_handle);
-+  return process_count;
-+}
-+
-+void GetProcessMemoryUsage(ProcessInfo& process_info) {
-+  DWORD pid = process_info.pid;
-+  HANDLE hProcess;
-+  PROCESS_MEMORY_COUNTERS pmc;
-+
-+  // PROCESS_VM_READ is never used here -- GetProcessMemoryInfo reads counters the
-+  // kernel keeps, not the address space -- and acquiring it is what EDR scores.
-+  hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
-+
-=======
                "AdditionalOptions": [
                  "/guard:cf",
                  "/sdl",
 diff --git a/lib/index.js b/lib/index.js
-index 9747a7402600cd252859144d32580ed45c8c93f7..8b1f467f2c18289f75419d30a43d6fa3a516c4cc 100644
+index 9747a7402600cd252859144d32580ed45c8c93f7..001e81fa8bc89091971d06aaf9d051ba20906615 100644
 --- a/lib/index.js
 +++ b/lib/index.js
 @@ -7,11 +7,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
@@ -233,7 +60,7 @@ index 9747a7402600cd252859144d32580ed45c8c93f7..8b1f467f2c18289f75419d30a43d6fa3
      });
      return buildNode(root, maxDepth);
 diff --git a/lib/index.ts b/lib/index.ts
-index f9aa005d9ced9e42885b8a976de5eb5bd61899ee..270967c1d1192b37cb6b095457bf52b213f88e8d 100644
+index f9aa005d9ced9e42885b8a976de5eb5bd61899ee..1b509af0b9065918bcb5cb75f2d7f23821d4a56a 100644
 --- a/lib/index.ts
 +++ b/lib/index.ts
 @@ -6,12 +6,15 @@
@@ -283,19 +110,20 @@ index 9214aff281251e797a70ecb9f6e0b52932a0503f..722edd42ddb4740296bfc47582a181bd
  }
  
 diff --git a/src/process.cc b/src/process.cc
-index 3eea92077c4d1d433119361d5c432881859131e9..c69442e2917b8474dbabaa1aa5b2c5ce746a56e7 100644
+index 3eea92077c4d1d433119361d5c432881859131e9..22a47421da919c76e2194280974d39c2287b098d 100644
 --- a/src/process.cc
 +++ b/src/process.cc
-@@ -21,7 +21,7 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
+@@ -21,7 +21,8 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
    if (Process32First(snapshot_handle, &process_entry)) {
      do {
        if (process_entry.th32ProcessID != 0) {
 -        ProcessInfo pinfo;
++        // Value-initialize: `memory` is otherwise stack garbage when the flag is unset.
 +        ProcessInfo pinfo{};
          pinfo.pid = process_entry.th32ProcessID;
          pinfo.ppid = process_entry.th32ParentProcessID;
  
-@@ -33,17 +33,43 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
+@@ -33,23 +34,51 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
            GetProcessCommandLine(pinfo);
          }
  
@@ -317,63 +145,50 @@ index 3eea92077c4d1d433119361d5c432881859131e9..c69442e2917b8474dbabaa1aa5b2c5ce
  
 +void GetProcessCreationTime(ProcessInfo& process_info) {
 +  HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_info.pid);
->>>>>>> 41a13099e8 (fix(windows): make the compiled addon prove its own CreationTime support)
-+  if (hProcess == NULL) {
-+    return;
-+  }
-+
-+  if (GetProcessMemoryInfo(hProcess, &pmc, sizeof(pmc))) {
-+    process_info.memory = (DWORD)pmc.WorkingSetSize;
-+  }
-+
-+  CloseHandle(hProcess);
-+}
-+
-<<<<<<< HEAD
-+// Per documentation, it is not recommended to add or subtract values from the FILETIME
-+// structure, or to cast it to ULARGE_INTEGER as this can cause alignment faults on 64-bit Windows.
-+// Copy the high and low part to a ULARGE_INTEGER and peform arithmetic on that instead.
-+// See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
-+ULONGLONG GetTotalTime(const FILETIME* kernelTime, const FILETIME* userTime) {
-+  ULARGE_INTEGER kt, ut;
-+  kt.LowPart = (*kernelTime).dwLowDateTime;
-+  kt.HighPart = (*kernelTime).dwHighDateTime;
-+
-+  ut.LowPart = (*userTime).dwLowDateTime;
-+  ut.HighPart = (*userTime).dwHighDateTime;
-+
-+  return kt.QuadPart + ut.QuadPart;
-+}
-+
-+void GetCpuUsage(Cpu& cpu_info, bool first_pass) {
-+  DWORD pid = cpu_info.pid;
-+  HANDLE hProcess;
-+
-+  // GetProcessTimes needs no more than PROCESS_QUERY_LIMITED_INFORMATION.
-+  hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
-+
 +  if (hProcess == NULL) {
 +    return;
 +  }
 +
 +  FILETIME creationTime, exitTime, kernelTime, userTime;
-+  FILETIME sysIdleTime, sysKernelTime, sysUserTime;
-+  if (GetProcessTimes(hProcess, &creationTime, &exitTime, &kernelTime, &userTime)
-+    && GetSystemTimes(&sysIdleTime, &sysKernelTime, &sysUserTime)) {
-+    if (first_pass) {
-+      cpu_info.initialProcRunTime = GetTotalTime(&kernelTime, &userTime);
-+      cpu_info.initialSystemTime = GetTotalTime(&sysKernelTime, &sysUserTime);
-+    } else {
-+      ULONGLONG endProcTime = GetTotalTime(&kernelTime, &userTime);
-+      ULONGLONG endSysTime = GetTotalTime(&sysKernelTime, &sysUserTime);
++  if (GetProcessTimes(hProcess, &creationTime, &exitTime, &kernelTime, &userTime)) {
++    ULARGE_INTEGER timestamp;
++    timestamp.LowPart = creationTime.dwLowDateTime;
++    timestamp.HighPart = creationTime.dwHighDateTime;
++    constexpr ULONGLONG WINDOWS_EPOCH_OFFSET_100NS = 116444736000000000ULL;
++    constexpr ULONGLONG HUNDRED_NS_PER_MILLISECOND = 10000ULL;
++    if (timestamp.QuadPart >= WINDOWS_EPOCH_OFFSET_100NS) {
++      process_info.creationTimeMs =
++          (timestamp.QuadPart - WINDOWS_EPOCH_OFFSET_100NS) / HUNDRED_NS_PER_MILLISECOND;
++    }
++  }
 +
-+      cpu_info.cpu = 100.0 * (endProcTime - cpu_info.initialProcRunTime) / (endSysTime - cpu_info.initialSystemTime);
-=======
++  CloseHandle(hProcess);
++}
++
  void GetProcessMemoryUsage(ProcessInfo& process_info) {
    DWORD pid = process_info.pid;
    HANDLE hProcess;
+   PROCESS_MEMORY_COUNTERS pmc;
+ 
+-  hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
++  // PROCESS_VM_READ is never used here -- GetProcessMemoryInfo reads counters the
++  // kernel keeps, not the address space -- and acquiring it is what EDR scores.
++  hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
+ 
+   if (hProcess == NULL) {
+     return;
+@@ -81,7 +110,8 @@ void GetCpuUsage(Cpu& cpu_info, bool first_pass) {
+   DWORD pid = cpu_info.pid;
+   HANDLE hProcess;
+ 
+-  hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, false, pid);
++  // GetProcessTimes needs no more than PROCESS_QUERY_LIMITED_INFORMATION.
++  hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
+ 
+   if (hProcess == NULL) {
+     return;
 diff --git a/src/process.h b/src/process.h
-index 82f8e4bcfa742551e5d874a7632736a7611d7aa7..087bf4ca81768918922a1e26836c70d7aec349ec 100644
+index 82f8e4bcfa742551e5d874a7632736a7611d7aa7..78d1d2c3b2360ed06fd624b4cb2f5042510f7a77 100644
 --- a/src/process.h
 +++ b/src/process.h
 @@ -22,18 +22,22 @@ struct ProcessInfo {
@@ -400,110 +215,19 @@ index 82f8e4bcfa742551e5d874a7632736a7611d7aa7..087bf4ca81768918922a1e26836c70d7
  void GetCpuUsage(Cpu& cpu_info, bool first_run);
  
  #endif  // SRC_PROCESS_H_
-diff --git a/src/process_worker.cc b/src/process_worker.cc
-index c9e3457a759c1acaa2644231a4917d45aed951f8..89f3339d5dc3b454397941c958b95965afed5788 100644
---- a/src/process_worker.cc
-+++ b/src/process_worker.cc
-@@ -43,6 +43,11 @@ void GetProcessesWorker::OnOK() {
-           Napi::String::New(env, pinfo.commandLine));
-     }
- 
-+    if ((CREATIONTIME & process_data_flags_) && pinfo.creationTimeMs != 0) {
-+      object.Set("creationTimeMs",
-+                 Napi::Number::New(env, static_cast<double>(pinfo.creationTimeMs)));
->>>>>>> 41a13099e8 (fix(windows): make the compiled addon prove its own CreationTime support)
-+    }
-+  } else {
-+    cpu_info.cpu = std::numeric_limits<double>::quiet_NaN();
-+  }
-+
-<<<<<<< HEAD
-+  CloseHandle(hProcess);
- }
-\ No newline at end of file
 diff --git a/src/process_commandline.cc b/src/process_commandline.cc
 index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3210c3cfd 100644
 --- a/src/process_commandline.cc
 +++ b/src/process_commandline.cc
-@@ -1,67 +1,125 @@
--/*---------------------------------------------------------------------------------------------
-- *  Copyright (c) Microsoft Corporation. All rights reserved.
-- *  Licensed under the MIT License. See License.txt in the project root for license information.
-- *--------------------------------------------------------------------------------------------*/
--
--#include "process.h"
--#include "process_commandline.h"
--#include <windows.h>
--#include <winternl.h>
+@@ -7,61 +7,119 @@
+ #include "process_commandline.h"
+ #include <windows.h>
+ #include <winternl.h>
 -#include <iostream>
--
++#include <vector>
+ 
 -bool GetProcessCommandLine(ProcessInfo& process_info) {
 -  HINSTANCE ntdll = GetModuleHandleW(L"ntdll.dll");
--  if (!ntdll) {
--    return false;
--  }
--
--  decltype(NtQueryInformationProcess)* nt_query_information_process =
--      reinterpret_cast<decltype(NtQueryInformationProcess)*>(
--          GetProcAddress(ntdll, "NtQueryInformationProcess"));
--
--  if (!nt_query_information_process) {
--    return false;
--  }
--
--  PROCESS_BASIC_INFORMATION pbi{};
--  PEB peb = {NULL};
--  RTL_USER_PROCESS_PARAMETERS process_parameters = {NULL};
--
--  // Get process handle
--  DWORD pid = process_info.pid;
--  HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
--  if (hProcess == INVALID_HANDLE_VALUE) {
--    return false;
--  }
--
--  // Get Process Environment Block (PEB)
--  NTSTATUS status = nt_query_information_process(hProcess, ProcessBasicInformation, &pbi, sizeof(pbi), nullptr);
--  if (NT_SUCCESS(status) && pbi.PebBaseAddress) {
--    // Read PEB
--    if (ReadProcessMemory(hProcess, pbi.PebBaseAddress, &peb, sizeof(peb), nullptr)) {
--      // Read the processs parameters
--      if (ReadProcessMemory(hProcess, peb.ProcessParameters, &process_parameters, sizeof(RTL_USER_PROCESS_PARAMETERS), nullptr)) {
--        if (process_parameters.CommandLine.Length > 0) {
--          std::wstring buffer;
--          buffer.resize(process_parameters.CommandLine.Length / sizeof(wchar_t));
--          if (ReadProcessMemory(hProcess, process_parameters.CommandLine.Buffer, &buffer[0], process_parameters.CommandLine.Length, nullptr)) {
--            int wide_length = static_cast<int>(buffer.length());
--            int charcount = WideCharToMultiByte(CP_UTF8, 0, buffer.data(), wide_length,
--                                      NULL, 0, NULL, NULL);
--            if (charcount) {
--              process_info.commandLine.resize(static_cast<size_t>(charcount));
--              WideCharToMultiByte(CP_UTF8, 0, buffer.data(), wide_length,
--                                  &process_info.commandLine[0], charcount,
--                                  NULL, NULL);
--            }
--            CloseHandle(hProcess);
--            return true;
--          }
--        }
--      }
--    }
--  }
--
--  CloseHandle(hProcess);
--  return false;
--}
-+/*---------------------------------------------------------------------------------------------
-+ *  Copyright (c) Microsoft Corporation. All rights reserved.
-+ *  Licensed under the MIT License. See License.txt in the project root for license information.
-+ *--------------------------------------------------------------------------------------------*/
-+
-+#include "process.h"
-+#include "process_commandline.h"
-+#include <windows.h>
-+#include <winternl.h>
-+#include <vector>
-+
 +namespace {
 +
 +// Windows 8.1 and later hand back a process's command line as a UNICODE_STRING
@@ -536,7 +260,7 @@ index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3
 +// ntdll ships no import library for this entry point; it has to be resolved.
 +NtQueryInformationProcessFn ResolveNtQueryInformationProcess() {
 +  HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-+  if (!ntdll) {
+   if (!ntdll) {
 +    return nullptr;
 +  }
 +  return reinterpret_cast<NtQueryInformationProcessFn>(
@@ -555,8 +279,8 @@ index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3
 +  int length = static_cast<int>(wide_length);
 +  int charcount = WideCharToMultiByte(CP_UTF8, 0, data, length, NULL, 0, NULL, NULL);
 +  if (!charcount) {
-+    return false;
-+  }
+     return false;
+   }
 +  process_info.commandLine.resize(static_cast<size_t>(charcount));
 +  WideCharToMultiByte(CP_UTF8, 0, data, length, &process_info.commandLine[0], charcount, NULL,
 +                      NULL);
@@ -564,18 +288,25 @@ index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3
 +}
 +
 +}  // namespace
-+
+ 
+-  decltype(NtQueryInformationProcess)* nt_query_information_process =
+-      reinterpret_cast<decltype(NtQueryInformationProcess)*>(
+-          GetProcAddress(ntdll, "NtQueryInformationProcess"));
 +bool GetProcessCommandLine(ProcessInfo& process_info) {
 +  NtQueryInformationProcessFn query = NtQueryInformationProcessEntry();
 +  if (!query) {
 +    return false;
 +  }
-+
+ 
+-  if (!nt_query_information_process) {
 +  HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, process_info.pid);
 +  if (process == NULL) {
-+    return false;
-+  }
-+
+     return false;
+   }
+ 
+-  PROCESS_BASIC_INFORMATION pbi{};
+-  PEB peb = {NULL};
+-  RTL_USER_PROCESS_PARAMETERS process_parameters = {NULL};
 +  ULONG size = 0;
 +  NTSTATUS status = query(process, kProcessCommandLineInformation, nullptr, 0, &size);
 +  if (NT_SUCCESS(status)) {
@@ -591,14 +322,44 @@ index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3
 +    CloseHandle(process);
 +    return false;
 +  }
-+
+ 
+-  // Get process handle
+-  DWORD pid = process_info.pid;
+-  HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION | PROCESS_VM_READ, FALSE, pid);
+-  if (hProcess == INVALID_HANDLE_VALUE) {
 +  std::vector<unsigned char> buffer(size);
 +  status = query(process, kProcessCommandLineInformation, &buffer[0], size, &size);
 +  CloseHandle(process);
 +  if (!NT_SUCCESS(status)) {
-+    return false;
-+  }
-+
+     return false;
+   }
+ 
+-  // Get Process Environment Block (PEB)
+-  NTSTATUS status = nt_query_information_process(hProcess, ProcessBasicInformation, &pbi, sizeof(pbi), nullptr);
+-  if (NT_SUCCESS(status) && pbi.PebBaseAddress) {
+-    // Read PEB
+-    if (ReadProcessMemory(hProcess, pbi.PebBaseAddress, &peb, sizeof(peb), nullptr)) {
+-      // Read the processs parameters
+-      if (ReadProcessMemory(hProcess, peb.ProcessParameters, &process_parameters, sizeof(RTL_USER_PROCESS_PARAMETERS), nullptr)) {
+-        if (process_parameters.CommandLine.Length > 0) {
+-          std::wstring buffer;
+-          buffer.resize(process_parameters.CommandLine.Length / sizeof(wchar_t));
+-          if (ReadProcessMemory(hProcess, process_parameters.CommandLine.Buffer, &buffer[0], process_parameters.CommandLine.Length, nullptr)) {
+-            int wide_length = static_cast<int>(buffer.length());
+-            int charcount = WideCharToMultiByte(CP_UTF8, 0, buffer.data(), wide_length,
+-                                      NULL, 0, NULL, NULL);
+-            if (charcount) {
+-              process_info.commandLine.resize(static_cast<size_t>(charcount));
+-              WideCharToMultiByte(CP_UTF8, 0, buffer.data(), wide_length,
+-                                  &process_info.commandLine[0], charcount,
+-                                  NULL, NULL);
+-            }
+-            CloseHandle(hProcess);
+-            return true;
+-          }
+-        }
+-      }
+-    }
 +  // Header and characters arrive in one allocation, but treat the header as
 +  // untrusted: a hooked ntdll is the case this reader is written for, and an
 +  // unchecked Buffer/Length here would be an over-read encoded straight into JS.
@@ -610,20 +371,34 @@ index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3
 +  if (chars == nullptr || chars < begin + sizeof(UNICODE_STRING) || chars > end ||
 +      command_line->Length > static_cast<ULONG>(end - chars)) {
 +    return false;
-+  }
-+
+   }
+ 
+-  CloseHandle(hProcess);
+-  return false;
 +  // True only when a command line was actually stored, so "empty" and "not
 +  // recovered" stay the same answer they were before this reader replaced the
 +  // PEB read. `src/process.cc` discards the result either way.
 +  return StoreCommandLineUtf8(process_info, command_line->Buffer,
 +                              command_line->Length / sizeof(wchar_t));
-+}
-=======
+ }
+diff --git a/src/process_worker.cc b/src/process_worker.cc
+index c9e3457a759c1acaa2644231a4917d45aed951f8..3f26a354477f062b34bd31fbd17be529e6a2fd7a 100644
+--- a/src/process_worker.cc
++++ b/src/process_worker.cc
+@@ -43,6 +43,11 @@ void GetProcessesWorker::OnOK() {
+           Napi::String::New(env, pinfo.commandLine));
+     }
+ 
++    if ((CREATIONTIME & process_data_flags_) && pinfo.creationTimeMs != 0) {
++      object.Set("creationTimeMs",
++                 Napi::Number::New(env, static_cast<double>(pinfo.creationTimeMs)));
++    }
++
      result.Set(i, object);
    }
  
 diff --git a/typings/windows-process-tree.d.ts b/typings/windows-process-tree.d.ts
-index 08bdac2fdc5ead6f0fcfb5ee5a021e2298c7d523..2c515242d78f9d8b8e63271d86f59d1024d71604 100644
+index 08bdac2fdc5ead6f0fcfb5ee5a021e2298c7d523..458981566fc45c0084badff566b1e3791ec1b629 100644
 --- a/typings/windows-process-tree.d.ts
 +++ b/typings/windows-process-tree.d.ts
 @@ -7,9 +7,17 @@ declare module '@vscode/windows-process-tree' {
@@ -663,4 +438,3 @@ index 08bdac2fdc5ead6f0fcfb5ee5a021e2298c7d523..2c515242d78f9d8b8e63271d86f59d10
      children: IProcessTreeNode[];
    }
  
->>>>>>> 41a13099e8 (fix(windows): make the compiled addon prove its own CreationTime support)

--- a/config/patches/@vscode__windows-process-tree@0.8.0.patch
+++ b/config/patches/@vscode__windows-process-tree@0.8.0.patch
@@ -1,5 +1,5 @@
 diff --git a/binding.gyp b/binding.gyp
-index 855bd4b86f0a3c18c7594212c0e42b6e35bc4001..33774e7ae296f0de39dd94156673c9e773638bf4 100644
+index 855bd4b86f0a3c18c7594212c0e42b6e35bc4001..0bb2af7923b6e6f1f0da40cae8067304cd1fea14 100644
 --- a/binding.gyp
 +++ b/binding.gyp
 @@ -3,7 +3,6 @@
@@ -10,7 +10,8 @@ index 855bd4b86f0a3c18c7594212c0e42b6e35bc4001..33774e7ae296f0de39dd94156673c9e7
        ],
        "conditions": [
          ['OS=="win"', {
-@@ -15,12 +14,11 @@
+@@ -14,13 +13,12 @@
+             "src/process_worker.cc",
              "src/process_commandline.cc"
            ],
 -          "include_dirs": [],
@@ -23,6 +24,7 @@ index 855bd4b86f0a3c18c7594212c0e42b6e35bc4001..33774e7ae296f0de39dd94156673c9e7
            "msvs_settings": {
              "VCCLCompilerTool": {
 +              "ExceptionHandling": 1,
+<<<<<<< HEAD
                "AdditionalOptions": [
                  "/guard:cf",
                  "/sdl",
@@ -194,6 +196,128 @@ index 3eea92077c4d1d433119361d5c432881859131e9..738775f6fcdfb676054386fe34c03803
 +  // kernel keeps, not the address space -- and acquiring it is what EDR scores.
 +  hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, pid);
 +
+=======
+               "AdditionalOptions": [
+                 "/guard:cf",
+                 "/sdl",
+diff --git a/lib/index.js b/lib/index.js
+index 9747a7402600cd252859144d32580ed45c8c93f7..8b1f467f2c18289f75419d30a43d6fa3a516c4cc 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -7,11 +7,13 @@ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.getAllProcesses = exports.getProcessTree = exports.getProcessCpuUsage = exports.getProcessList = exports.filterProcessList = exports.buildProcessTree = exports.ProcessDataFlag = void 0;
+ const util_1 = require("util");
+ const native = process.platform === 'win32' ? require('../build/Release/windows_process_tree.node') : undefined;
++exports.supportedProcessDataFlags = native === undefined ? undefined : native.supportedProcessDataFlags;
+ var ProcessDataFlag;
+ (function (ProcessDataFlag) {
+     ProcessDataFlag[ProcessDataFlag["None"] = 0] = "None";
+     ProcessDataFlag[ProcessDataFlag["Memory"] = 1] = "Memory";
+     ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";
++    ProcessDataFlag[ProcessDataFlag["CreationTime"] = 4] = "CreationTime";
+ })(ProcessDataFlag = exports.ProcessDataFlag || (exports.ProcessDataFlag = {}));
+ // requestInProgress is used for any function that uses CreateToolhelp32Snapshot, as multiple calls
+ // to this cannot be done at the same time.
+@@ -66,11 +68,12 @@ function buildProcessTree(rootPid, processList, maxDepth = MAX_FILTER_DEPTH) {
+     // • the properties are inlined/splatted
+     // • the 'ppid' field is omitted
+     // • the depth of the tree is limited by `maxDepth`
+-    const buildNode = ({ info: { pid, name, memory, commandLine }, children }, depth) => ({
++    const buildNode = ({ info: { pid, name, memory, commandLine, creationTimeMs }, children }, depth) => ({
+         pid,
+         name,
+         memory,
+         commandLine,
++        creationTimeMs,
+         children: depth > 0 ? children.map(c => buildNode(c, depth - 1)) : [],
+     });
+     return buildNode(root, maxDepth);
+diff --git a/lib/index.ts b/lib/index.ts
+index f9aa005d9ced9e42885b8a976de5eb5bd61899ee..270967c1d1192b37cb6b095457bf52b213f88e8d 100644
+--- a/lib/index.ts
++++ b/lib/index.ts
+@@ -6,12 +6,15 @@
+ import { promisify } from 'util';
+ 
+ const native = process.platform === 'win32' ? require('../build/Release/windows_process_tree.node') : undefined;
++/** The flag bits this compiled addon reports; undefined off win32. */
++export const supportedProcessDataFlags: number | undefined = native?.supportedProcessDataFlags;
+ import { IProcessInfo, IProcessTreeNode, IProcessCpuInfo } from '@vscode/windows-process-tree';
+ 
+ export enum ProcessDataFlag {
+   None = 0,
+   Memory = 1,
+-  CommandLine = 2
++  CommandLine = 2,
++  CreationTime = 4
+ }
+ 
+ type RequestCallback = (processList: IProcessInfo[]) => void;
+@@ -81,11 +84,12 @@ export function buildProcessTree(rootPid: number, processList: Iterable<IProcess
+   // • the properties are inlined/splatted
+   // • the 'ppid' field is omitted
+   // • the depth of the tree is limited by `maxDepth`
+-  const buildNode = ({ info: { pid, name, memory, commandLine }, children }: IProcessInfoNode, depth: number): IProcessTreeNode => ({
++  const buildNode = ({ info: { pid, name, memory, commandLine, creationTimeMs }, children }: IProcessInfoNode, depth: number): IProcessTreeNode => ({
+     pid,
+     name,
+     memory,
+     commandLine,
++    creationTimeMs,
+     children: depth > 0 ? children.map(c => buildNode(c, depth - 1)) : [],
+   });
+ 
+diff --git a/src/addon.cc b/src/addon.cc
+index 9214aff281251e797a70ecb9f6e0b52932a0503f..722edd42ddb4740296bfc47582a181bd6d00c464 100644
+--- a/src/addon.cc
++++ b/src/addon.cc
+@@ -53,6 +53,10 @@ void GetProcessCpuUsage(const Napi::CallbackInfo& args) {
+ Napi::Object Init(Napi::Env env, Napi::Object exports) {
+   exports.Set("getProcessList", Napi::Function::New(env, GetProcessList));
+   exports.Set("getProcessCpuUsage", Napi::Function::New(env, GetProcessCpuUsage));
++  // Lets a caller prove THIS BINARY understands CREATIONTIME. The JS enum is
++  // patched source and says nothing about what the .node was compiled from.
++  exports.Set("supportedProcessDataFlags",
++              Napi::Number::New(env, MEMORY | COMMANDLINE | CREATIONTIME));
+   return exports;
+ }
+ 
+diff --git a/src/process.cc b/src/process.cc
+index 3eea92077c4d1d433119361d5c432881859131e9..c69442e2917b8474dbabaa1aa5b2c5ce746a56e7 100644
+--- a/src/process.cc
++++ b/src/process.cc
+@@ -21,7 +21,7 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
+   if (Process32First(snapshot_handle, &process_entry)) {
+     do {
+       if (process_entry.th32ProcessID != 0) {
+-        ProcessInfo pinfo;
++        ProcessInfo pinfo{};
+         pinfo.pid = process_entry.th32ProcessID;
+         pinfo.ppid = process_entry.th32ParentProcessID;
+ 
+@@ -33,17 +33,43 @@ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info,
+           GetProcessCommandLine(pinfo);
+         }
+ 
++        if (CREATIONTIME & process_data_flags) {
++          GetProcessCreationTime(pinfo);
++        }
++
+         strcpy(pinfo.name, process_entry.szExeFile);
+         process_info.push_back(std::move(pinfo));
+         process_count++;
+       }
+-    } while (process_count < 1024 && Process32Next(snapshot_handle, &process_entry));
++    } while (Process32Next(snapshot_handle, &process_entry));
+   }
+ 
+   CloseHandle(snapshot_handle);
+   return process_count;
+ }
+ 
++void GetProcessCreationTime(ProcessInfo& process_info) {
++  HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_info.pid);
+>>>>>>> 41a13099e8 (fix(windows): make the compiled addon prove its own CreationTime support)
 +  if (hProcess == NULL) {
 +    return;
 +  }
@@ -205,6 +329,7 @@ index 3eea92077c4d1d433119361d5c432881859131e9..738775f6fcdfb676054386fe34c03803
 +  CloseHandle(hProcess);
 +}
 +
+<<<<<<< HEAD
 +// Per documentation, it is not recommended to add or subtract values from the FILETIME
 +// structure, or to cast it to ULARGE_INTEGER as this can cause alignment faults on 64-bit Windows.
 +// Copy the high and low part to a ULARGE_INTEGER and peform arithmetic on that instead.
@@ -243,11 +368,56 @@ index 3eea92077c4d1d433119361d5c432881859131e9..738775f6fcdfb676054386fe34c03803
 +      ULONGLONG endSysTime = GetTotalTime(&sysKernelTime, &sysUserTime);
 +
 +      cpu_info.cpu = 100.0 * (endProcTime - cpu_info.initialProcRunTime) / (endSysTime - cpu_info.initialSystemTime);
+=======
+ void GetProcessMemoryUsage(ProcessInfo& process_info) {
+   DWORD pid = process_info.pid;
+   HANDLE hProcess;
+diff --git a/src/process.h b/src/process.h
+index 82f8e4bcfa742551e5d874a7632736a7611d7aa7..087bf4ca81768918922a1e26836c70d7aec349ec 100644
+--- a/src/process.h
++++ b/src/process.h
+@@ -22,18 +22,22 @@ struct ProcessInfo {
+   DWORD ppid;
+   DWORD memory; // Reported in bytes
+   std::string commandLine;
++  ULONGLONG creationTimeMs;
+ };
+ 
+ enum ProcessDataFlags {
+   NONE = 0,
+   MEMORY = 1,
+-  COMMANDLINE = 2
++  COMMANDLINE = 2,
++  CREATIONTIME = 4
+ };
+ 
+ uint32_t GetRawProcessList(std::vector<ProcessInfo>& process_info, DWORD flags);
+ 
+ void GetProcessMemoryUsage(ProcessInfo& process_info);
+ 
++void GetProcessCreationTime(ProcessInfo& process_info);
++
+ void GetCpuUsage(Cpu& cpu_info, bool first_run);
+ 
+ #endif  // SRC_PROCESS_H_
+diff --git a/src/process_worker.cc b/src/process_worker.cc
+index c9e3457a759c1acaa2644231a4917d45aed951f8..89f3339d5dc3b454397941c958b95965afed5788 100644
+--- a/src/process_worker.cc
++++ b/src/process_worker.cc
+@@ -43,6 +43,11 @@ void GetProcessesWorker::OnOK() {
+           Napi::String::New(env, pinfo.commandLine));
+     }
+ 
++    if ((CREATIONTIME & process_data_flags_) && pinfo.creationTimeMs != 0) {
++      object.Set("creationTimeMs",
++                 Napi::Number::New(env, static_cast<double>(pinfo.creationTimeMs)));
+>>>>>>> 41a13099e8 (fix(windows): make the compiled addon prove its own CreationTime support)
 +    }
 +  } else {
 +    cpu_info.cpu = std::numeric_limits<double>::quiet_NaN();
 +  }
 +
+<<<<<<< HEAD
 +  CloseHandle(hProcess);
  }
 \ No newline at end of file
@@ -448,3 +618,49 @@ index ea822b120e8038a4803e34647042f08f4aaf5ca1..25907c0bf542bed6c72b1b462b19bcf3
 +  return StoreCommandLineUtf8(process_info, command_line->Buffer,
 +                              command_line->Length / sizeof(wchar_t));
 +}
+=======
+     result.Set(i, object);
+   }
+ 
+diff --git a/typings/windows-process-tree.d.ts b/typings/windows-process-tree.d.ts
+index 08bdac2fdc5ead6f0fcfb5ee5a021e2298c7d523..2c515242d78f9d8b8e63271d86f59d1024d71604 100644
+--- a/typings/windows-process-tree.d.ts
++++ b/typings/windows-process-tree.d.ts
+@@ -7,9 +7,17 @@ declare module '@vscode/windows-process-tree' {
+   export enum ProcessDataFlag {
+     None = 0,
+     Memory = 1,
+-    CommandLine = 2
++    CommandLine = 2,
++    CreationTime = 4
+   }
+ 
++  /**
++   * The flag bits the compiled addon actually understands, or undefined off
++   * win32. `ProcessDataFlag` above is source; this is what the binary reports,
++   * so it is the only way to tell a patched build from a stale prebuilt.
++   */
++  export const supportedProcessDataFlags: number | undefined;
++
+   export interface IProcessInfo {
+     pid: number;
+     ppid: number;
+@@ -24,6 +32,9 @@ declare module '@vscode/windows-process-tree' {
+      * The string returned is at most 512 chars, strings exceeding this length are truncated.
+      */
+     commandLine?: string;
++
++    /** Process creation time in Unix milliseconds. */
++    creationTimeMs?: number;
+   }
+ 
+   export interface IProcessCpuInfo extends IProcessInfo {
+@@ -35,6 +46,7 @@ declare module '@vscode/windows-process-tree' {
+     name: string;
+     memory?: number;
+     commandLine?: string;
++    creationTimeMs?: number;
+     children: IProcessTreeNode[];
+   }
+ 
+>>>>>>> 41a13099e8 (fix(windows): make the compiled addon prove its own CreationTime support)

--- a/config/scripts/build-windows-process-tree-relay-addon.mjs
+++ b/config/scripts/build-windows-process-tree-relay-addon.mjs
@@ -98,6 +98,152 @@ function assertPatchApplied() {
         'config/patches/@vscode__windows-process-tree@0.8.0.patch; run pnpm install.'
     )
   }
+  const requiredCreationTimeSources = [
+    ['src/process.h', 'CREATIONTIME = 4'],
+    ['src/process.h', 'ULONGLONG creationTimeMs'],
+    ['src/process.cc', 'GetProcessCreationTime(pinfo)'],
+    ['src/process.cc', 'GetProcessTimes(hProcess, &creationTime'],
+    ['src/process_worker.cc', 'object.Set("creationTimeMs"'],
+    ['lib/index.js', '["CreationTime"] = 4'],
+    ['lib/index.ts', 'CreationTime = 4'],
+    ['typings/windows-process-tree.d.ts', 'creationTimeMs?: number']
+  ]
+  for (const [relativePath, expected] of requiredCreationTimeSources) {
+    if (!readFileSync(join(PACKAGE_DIR, relativePath), 'utf8').includes(expected)) {
+      throw new Error(
+        `${relativePath} does not contain the process creation-time patch (${expected}). ` +
+          'Run pnpm install before building the relay addon.'
+      )
+    }
+  }
+}
+
+function repairCreationTimeSources() {
+  let repaired = false
+  const rewrite = (relativePath, transform) => {
+    const filePath = join(PACKAGE_DIR, relativePath)
+    const source = readFileSync(filePath, 'utf8')
+    const next = transform(source, source.includes('\r\n') ? '\r\n' : '\n')
+    if (next !== source) {
+      writeFileSync(filePath, next)
+      repaired = true
+    }
+  }
+
+  rewrite('src/process.h', (source, eol) => {
+    let next = source
+    if (!next.includes('ULONGLONG creationTimeMs')) {
+      next = next.replace(
+        /  std::string commandLine;\r?\n/,
+        `  std::string commandLine;${eol}  ULONGLONG creationTimeMs;${eol}`
+      )
+    }
+    if (!next.includes('CREATIONTIME = 4')) {
+      next = next.replace(
+        /  COMMANDLINE = 2\r?\n/,
+        `  COMMANDLINE = 2,${eol}  CREATIONTIME = 4${eol}`
+      )
+    }
+    if (!next.includes('void GetProcessCreationTime')) {
+      next = next.replace(
+        /void GetProcessMemoryUsage\(ProcessInfo& process_info\);\r?\n/,
+        `void GetProcessMemoryUsage(ProcessInfo& process_info);${eol}${eol}` +
+          `void GetProcessCreationTime(ProcessInfo& process_info);${eol}`
+      )
+    }
+    return next
+  })
+
+  rewrite('src/process.cc', (source, eol) => {
+    let next = source.replace('ProcessInfo pinfo;', 'ProcessInfo pinfo{};')
+    if (!next.includes('GetProcessCreationTime(pinfo)')) {
+      next = next.replace(
+        /(        if \(COMMANDLINE & process_data_flags\) \{\r?\n          GetProcessCommandLine\(pinfo\);\r?\n        \})/,
+        `$1${eol}${eol}        if (CREATIONTIME & process_data_flags) {${eol}` +
+          `          GetProcessCreationTime(pinfo);${eol}        }`
+      )
+    }
+    if (!next.includes('void GetProcessCreationTime(ProcessInfo& process_info) {')) {
+      const producer = [
+        'void GetProcessCreationTime(ProcessInfo& process_info) {',
+        '  HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, false, process_info.pid);',
+        '  if (hProcess == NULL) {',
+        '    return;',
+        '  }',
+        '',
+        '  FILETIME creationTime, exitTime, kernelTime, userTime;',
+        '  if (GetProcessTimes(hProcess, &creationTime, &exitTime, &kernelTime, &userTime)) {',
+        '    ULARGE_INTEGER timestamp;',
+        '    timestamp.LowPart = creationTime.dwLowDateTime;',
+        '    timestamp.HighPart = creationTime.dwHighDateTime;',
+        '    constexpr ULONGLONG WINDOWS_EPOCH_OFFSET_100NS = 116444736000000000ULL;',
+        '    constexpr ULONGLONG HUNDRED_NS_PER_MILLISECOND = 10000ULL;',
+        '    if (timestamp.QuadPart >= WINDOWS_EPOCH_OFFSET_100NS) {',
+        '      process_info.creationTimeMs =',
+        '          (timestamp.QuadPart - WINDOWS_EPOCH_OFFSET_100NS) / HUNDRED_NS_PER_MILLISECOND;',
+        '    }',
+        '  }',
+        '',
+        '  CloseHandle(hProcess);',
+        '}',
+        ''
+      ].join(eol)
+      next = next.replace(
+        'void GetProcessMemoryUsage',
+        `${producer}${eol}void GetProcessMemoryUsage`
+      )
+    }
+    return next
+  })
+
+  rewrite('src/process_worker.cc', (source, eol) => {
+    if (source.includes('object.Set("creationTimeMs"')) {
+      return source
+    }
+    const emission = [
+      '    if ((CREATIONTIME & process_data_flags_) && pinfo.creationTimeMs != 0) {',
+      '      object.Set("creationTimeMs",',
+      '                 Napi::Number::New(env, static_cast<double>(pinfo.creationTimeMs)));',
+      '    }',
+      ''
+    ].join(eol)
+    return source.replace(
+      '    result.Set(i, object);',
+      `${emission}${eol}    result.Set(i, object);`
+    )
+  })
+
+  for (const relativePath of ['lib/index.ts', 'lib/index.js']) {
+    rewrite(relativePath, (source, eol) => {
+      if (source.includes('CreationTime')) {
+        return source
+      }
+      return relativePath.endsWith('.ts')
+        ? source.replace('  CommandLine = 2', `  CommandLine = 2,${eol}  CreationTime = 4`)
+        : source.replace(
+            '    ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";',
+            '    ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";' +
+              `${eol}    ProcessDataFlag[ProcessDataFlag["CreationTime"] = 4] = "CreationTime";`
+          )
+    })
+  }
+
+  rewrite('typings/windows-process-tree.d.ts', (source, eol) => {
+    let next = source
+    if (!next.includes('CreationTime = 4')) {
+      next = next.replace('    CommandLine = 2', `    CommandLine = 2,${eol}    CreationTime = 4`)
+    }
+    if (!next.includes('creationTimeMs?: number')) {
+      next = next.replace(
+        /    commandLine\?: string;\r?\n/,
+        `    commandLine?: string;${eol}${eol}` +
+          `    /** Process creation time in Unix milliseconds. */${eol}` +
+          `    creationTimeMs?: number;${eol}`
+      )
+    }
+    return next
+  })
+  return repaired
 }
 
 // pnpm can materialize this CRLF package without applying its patch. Repair the
@@ -146,9 +292,15 @@ function applyWindowsProcessTreeBuildFixes() {
   if (processCc !== originalProcess) {
     writeFileSync(processPath, processCc)
   }
+  const repairedCreationTime = repairCreationTimeSources()
   stageWindowsProcessTreeNodeAddonApiHeaders(PACKAGE_DIR)
   const repairedCommandLine = ensureWindowsProcessTreeCommandLinePatch(PACKAGE_DIR)
-  if (bindingGyp !== originalBinding || processCc !== originalProcess || repairedCommandLine) {
+  if (
+    bindingGyp !== originalBinding ||
+    processCc !== originalProcess ||
+    repairedCommandLine ||
+    repairedCreationTime
+  ) {
     console.warn('[windows-process-tree] Repaired un-applied pnpm patch hunks before build.')
   }
 }

--- a/config/scripts/build-windows-process-tree-relay-addon.mjs
+++ b/config/scripts/build-windows-process-tree-relay-addon.mjs
@@ -98,18 +98,31 @@ function assertPatchApplied() {
         'config/patches/@vscode__windows-process-tree@0.8.0.patch; run pnpm install.'
     )
   }
+  // Every string the repair below can write, so a repaired tree cannot be
+  // declared patched while one of the pieces is silently missing.
   const requiredCreationTimeSources = [
     ['src/process.h', 'CREATIONTIME = 4'],
     ['src/process.h', 'ULONGLONG creationTimeMs'],
     ['src/process.cc', 'GetProcessCreationTime(pinfo)'],
     ['src/process.cc', 'GetProcessTimes(hProcess, &creationTime'],
     ['src/process_worker.cc', 'object.Set("creationTimeMs"'],
+    ['src/addon.cc', 'exports.Set("supportedProcessDataFlags"'],
     ['lib/index.js', '["CreationTime"] = 4'],
+    ['lib/index.js', 'exports.supportedProcessDataFlags'],
+    ['lib/index.js', 'creationTimeMs,'],
     ['lib/index.ts', 'CreationTime = 4'],
-    ['typings/windows-process-tree.d.ts', 'creationTimeMs?: number']
+    ['lib/index.ts', 'export const supportedProcessDataFlags'],
+    ['lib/index.ts', 'creationTimeMs,'],
+    ['typings/windows-process-tree.d.ts', 'creationTimeMs?: number'],
+    // A regex because IProcessInfo declares the same field: only the tree node
+    // is followed by `children`, and that is the one buildNode fills.
+    ['typings/windows-process-tree.d.ts', /creationTimeMs\?: number;\r?\n\s*children:/],
+    ['typings/windows-process-tree.d.ts', 'export const supportedProcessDataFlags']
   ]
   for (const [relativePath, expected] of requiredCreationTimeSources) {
-    if (!readFileSync(join(PACKAGE_DIR, relativePath), 'utf8').includes(expected)) {
+    const source = readFileSync(join(PACKAGE_DIR, relativePath), 'utf8')
+    const present = typeof expected === 'string' ? source.includes(expected) : expected.test(source)
+    if (!present) {
       throw new Error(
         `${relativePath} does not contain the process creation-time patch (${expected}). ` +
           'Run pnpm install before building the relay addon.'
@@ -213,18 +226,51 @@ function repairCreationTimeSources() {
     )
   })
 
+  rewrite('src/addon.cc', (source, eol) => {
+    if (source.includes('exports.Set("supportedProcessDataFlags"')) {
+      return source
+    }
+    return source.replace(
+      /(  exports\.Set\("getProcessCpuUsage", Napi::Function::New\(env, GetProcessCpuUsage\)\);\r?\n)/,
+      `$1  exports.Set("supportedProcessDataFlags",${eol}` +
+        `              Napi::Number::New(env, MEMORY | COMMANDLINE | CREATIONTIME));${eol}`
+    )
+  })
+
+  // Each piece is guarded on its own: an early-out on the enum alone would let a
+  // tree with the enum but no buildNode splat pass as repaired.
+  const NATIVE_CONST =
+    "const native = process.platform === 'win32' ? require('../build/Release/windows_process_tree.node') : undefined;"
   for (const relativePath of ['lib/index.ts', 'lib/index.js']) {
+    const isTs = relativePath.endsWith('.ts')
     rewrite(relativePath, (source, eol) => {
-      if (source.includes('CreationTime')) {
-        return source
+      let next = source
+      if (!next.includes('CreationTime')) {
+        next = isTs
+          ? next.replace('  CommandLine = 2', `  CommandLine = 2,${eol}  CreationTime = 4`)
+          : next.replace(
+              '    ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";',
+              '    ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";' +
+                `${eol}    ProcessDataFlag[ProcessDataFlag["CreationTime"] = 4] = "CreationTime";`
+            )
       }
-      return relativePath.endsWith('.ts')
-        ? source.replace('  CommandLine = 2', `  CommandLine = 2,${eol}  CreationTime = 4`)
-        : source.replace(
-            '    ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";',
-            '    ProcessDataFlag[ProcessDataFlag["CommandLine"] = 2] = "CommandLine";' +
-              `${eol}    ProcessDataFlag[ProcessDataFlag["CreationTime"] = 4] = "CreationTime";`
-          )
+      if (!next.includes('supportedProcessDataFlags')) {
+        const reExport = isTs
+          ? `/** The flag bits this compiled addon reports; undefined off win32. */${eol}` +
+            'export const supportedProcessDataFlags: number | undefined = native?.supportedProcessDataFlags;'
+          : 'exports.supportedProcessDataFlags = native === undefined ? undefined : native.supportedProcessDataFlags;'
+        next = next.replace(NATIVE_CONST, `${NATIVE_CONST}${eol}${reExport}`)
+      }
+      // buildNode drops any field it does not name, so the destructure and the
+      // splat have to move together.
+      next = next.replace(/(memory, commandLine)( \}, children \})/, '$1, creationTimeMs$2')
+      if (!/\bcreationTimeMs,/.test(next)) {
+        next = next.replace(
+          /(\r?\n)(\s*)commandLine,(\r?\n\s*children:)/,
+          `$1$2commandLine,$1$2creationTimeMs,$3`
+        )
+      }
+      return next
     })
   }
 
@@ -232,6 +278,13 @@ function repairCreationTimeSources() {
     let next = source
     if (!next.includes('CreationTime = 4')) {
       next = next.replace('    CommandLine = 2', `    CommandLine = 2,${eol}    CreationTime = 4`)
+    }
+    if (!next.includes('supportedProcessDataFlags')) {
+      next = next.replace(
+        /(    CreationTime = 4\r?\n  \}\r?\n)/,
+        `$1${eol}  /** The flag bits the compiled addon reports; undefined off win32. */${eol}` +
+          `  export const supportedProcessDataFlags: number | undefined;${eol}`
+      )
     }
     if (!next.includes('creationTimeMs?: number')) {
       next = next.replace(
@@ -241,6 +294,11 @@ function repairCreationTimeSources() {
           `    creationTimeMs?: number;${eol}`
       )
     }
+    // IProcessTreeNode is the second declaration; only it is followed by children.
+    next = next.replace(
+      /(    commandLine\?: string;\r?\n)(    children:)/,
+      `$1    creationTimeMs?: number;${eol}$2`
+    )
     return next
   })
   return repaired

--- a/config/scripts/ensure-native-runtime.mjs
+++ b/config/scripts/ensure-native-runtime.mjs
@@ -2,7 +2,7 @@
 
 import { spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { release } from 'node:os'
 import { basename, dirname, resolve } from 'node:path'
 import {
@@ -14,6 +14,7 @@ import {
 
 const require = createRequire(import.meta.url)
 const { assertNodePtyJobOwnership } = require('./node-pty-job-ownership.cjs')
+const { assertWindowsProcessTreeCreationTime } = require('./windows-process-tree-creation-time.cjs')
 const scriptPath = import.meta.filename
 const projectDir = resolve(import.meta.dirname, '../..')
 const runtime = readRuntimeArg()
@@ -262,9 +263,10 @@ function loadNativeModule(moduleName) {
     // A bare require loads the .node addon on win32, so it catches an ABI
     // mismatch on its own. What it cannot catch is *which* addon loaded: the
     // published tarball ships a prebuilt built from unpatched source that is
-    // node-addon-api, so it requires cleanly and then reads every process's
-    // command line out of its address space. Check the binary, not the load.
-    require(moduleName)
+    // node-addon-api, so it requires cleanly, reads every process's command
+    // line out of its address space, and ignores the CreationTime flag. Check
+    // the binary on both counts, not the load.
+    assertWindowsProcessTreeCreationTime({ module: require(moduleName) })
     if (inspectWindowsProcessTreeAddon(windowsProcessTreeAddonPath()) === 'unpatched') {
       throw new Error(
         'the loaded addon still calls ReadProcessMemory, so it was not built from the patched ' +
@@ -380,14 +382,18 @@ function getWindowsBuildNumber() {
 
 function rebuildNodeRuntimeModules(moduleNames) {
   for (const moduleName of moduleNames) {
-    const moduleDir = dirname(require.resolve(`${moduleName}/package.json`))
+    let moduleDir = dirname(require.resolve(`${moduleName}/package.json`))
     if (moduleName === '@vscode/windows-process-tree') {
       // Why before node-gyp: this module is rebuilt precisely because the
       // binary was the unpatched one, and pnpm materializes it unpatched often
       // enough that compiling the source as-is would just rebuild the same
-      // reader and fail the verify pass.
+      // reader and fail the verify pass. The patched binding.gyp then includes
+      // deps/node-addon-api, which the tarball does not ship, and node-gyp must
+      // run from the physical dir -- both reasons live in
+      // windows-process-tree-gyp-rebuild.mjs.
       ensureWindowsProcessTreeCommandLinePatch(moduleDir)
       stageWindowsProcessTreeNodeAddonApiHeaders(moduleDir)
+      moduleDir = realpathSync(moduleDir)
     }
     console.warn(`[native-runtime] Rebuilding ${moduleName} with node-gyp.`)
     runPnpm(['exec', 'node-gyp', 'rebuild'], { cwd: moduleDir })

--- a/config/scripts/ensure-native-runtime.test.mjs
+++ b/config/scripts/ensure-native-runtime.test.mjs
@@ -15,9 +15,12 @@ import { describe, expect, it } from 'vitest'
 import { copyScriptWithLocalModules } from './script-module-dependencies.mjs'
 
 const sourceScriptPath = fileURLToPath(new URL('./ensure-native-runtime.mjs', import.meta.url))
-const sourceNodePtyJobOwnershipPath = fileURLToPath(
-  new URL('./node-pty-job-ownership.cjs', import.meta.url)
-)
+// The import walk sees `from './x.mjs'` only, so the createRequire'd CJS
+// siblings have to be named. Without them the temp project cannot even load.
+const REQUIRED_CJS_SIBLINGS = [
+  'node-pty-job-ownership.cjs',
+  'windows-process-tree-creation-time.cjs'
+]
 
 describe('ensure-native-runtime', () => {
   it('rechecks Node native modules in fresh child processes after rebuilding', () => {
@@ -197,10 +200,12 @@ function mkTempProject() {
   // Walked, not listed: the script imports windows-process-tree-gyp-rebuild.mjs, and a fixture
   // missing it fails every case with a module-resolution error instead of the defect under test.
   copyScriptWithLocalModules(sourceScriptPath, join(projectDir, 'config', 'scripts'))
-  copyFileSync(
-    sourceNodePtyJobOwnershipPath,
-    join(projectDir, 'config', 'scripts', 'node-pty-job-ownership.cjs')
-  )
+  for (const name of REQUIRED_CJS_SIBLINGS) {
+    copyFileSync(
+      fileURLToPath(new URL(`./${name}`, import.meta.url)),
+      join(projectDir, 'config', 'scripts', name)
+    )
+  }
   return projectDir
 }
 

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -224,6 +224,7 @@ const WINDOWS_PACKAGE_TESTS = [
   'src/main/windows/windows-pty-job.win32.test.ts',
   'src/main/windows/windows-host-job.win32.test.ts',
   'src/main/windows/windows-process-tree-command-line-patch.test.ts',
+  'src/main/windows/windows-process-table-native-addon.win32.test.ts',
   'src/main/windows-live-tree-kill.win32.test.ts',
   'src/main/wsl/wsl-runner.test.ts',
   'src/main/wsl/wsl-guest-environment.test.ts',

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -140,6 +140,8 @@ const NATIVE_RUNTIME_PREFIXES = [
   'config/scripts/ensure-native-runtime',
   'config/scripts/rebuild-native-deps',
   'config/scripts/node-pty-job-ownership',
+  'config/scripts/windows-process-tree-creation-time',
+  'config/scripts/windows-process-tree-gyp-rebuild',
   'config/scripts/electron-builder-native-rebuild',
   'config/patches/node-pty@',
   'config/patches/@vscode__windows-process-tree'

--- a/config/scripts/rebuild-native-deps.mjs
+++ b/config/scripts/rebuild-native-deps.mjs
@@ -567,6 +567,15 @@ function loadNativeModule(moduleName) {
     }
     return
   }
+  if (moduleName === '@vscode/windows-process-tree') {
+    // The tarball prebuilt loads under Electron too -- the addon is N-API, so
+    // a bare require proves nothing about which source it was built from.
+    const { assertWindowsProcessTreeCreationTime } = projectRequire(
+      './config/scripts/windows-process-tree-creation-time.cjs'
+    )
+    assertWindowsProcessTreeCreationTime({ module: projectRequire(moduleName) })
+    return
+  }
   projectRequire(moduleName)
 }
 

--- a/config/scripts/windows-process-tree-creation-time.cjs
+++ b/config/scripts/windows-process-tree-creation-time.cjs
@@ -1,0 +1,42 @@
+'use strict'
+
+/**
+ * Prove the COMPILED addon understands `CREATIONTIME`, not just the patched JS.
+ *
+ * Unlike node-pty, this package ships a prebuilt `.node` at the same
+ * `build/Release/` path node-gyp writes to, so neither a load nor a path check
+ * can tell a stale prebuilt from a source build. pnpm patches the source tree
+ * and leaves that prebuilt in place, which is how `ProcessDataFlag.CreationTime`
+ * came to exist in `lib/index.js` on a binary that ignores flag 4 -- the gate
+ * read true and every row came back without `creationTimeMs`.
+ *
+ * `supportedProcessDataFlags` is exported by the patched `addon.cc`, so its
+ * presence is the binary's own answer. Shared by the Node and Electron probes
+ * the way `node-pty-job-ownership.cjs` is.
+ */
+
+/** `ProcessDataFlags::CREATIONTIME` in src/process.h. */
+const CREATION_TIME_FLAG = 4
+
+function assertWindowsProcessTreeCreationTime({ module, platform = process.platform }) {
+  if (platform !== 'win32') {
+    return
+  }
+  const supported = module?.supportedProcessDataFlags
+  if (typeof supported === 'number' && (supported & CREATION_TIME_FLAG) !== 0) {
+    return
+  }
+  throw new Error(
+    [
+      '@vscode/windows-process-tree does not report CreationTime support',
+      `(supportedProcessDataFlags=${String(supported)}).`,
+      'That is the tarball prebuilt, not a build of the patched source, so every',
+      'process row comes back without creationTimeMs: Windows descendant exit',
+      'verification cannot identify a PID and structured Claude/Codex chat runs',
+      'with an unprovable child-tree reaper.',
+      'Rebuild it from source so config/patches/@vscode__windows-process-tree@0.8.0.patch applies.'
+    ].join(' ')
+  )
+}
+
+module.exports = { assertWindowsProcessTreeCreationTime, CREATION_TIME_FLAG }

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -344,7 +344,7 @@ on any other OS keeps using the scan.
 
 ## Why the package is patched
 
-`config/patches/@vscode__windows-process-tree@0.8.0.patch` carries four hunks.
+`config/patches/@vscode__windows-process-tree@0.8.0.patch` carries five changes.
 
 1. **Spectre mitigation.** The upstream `binding.gyp` requires Spectre-mitigated
    libraries, which Orca's Windows build agents do not install. `node-pty` is
@@ -360,6 +360,14 @@ on any other OS keeps using the scan.
    `node_addon_api.gyp` resolves outside the repo and hourly Windows builds
    die at configure. `node-pty` is patched the same way for the same reason.
 4. **No PEB reads, no `PROCESS_VM_READ`.** See below.
+5. **The `CreationTime` flag (4).** Upstream exposes no process start time, and
+   `isWindowsProcessStartTimeAvailable()` gates structured Claude and Codex
+   chat on it, so without this change win32 silently fell back to the legacy
+   transcript path. `GetProcessCreationTime` opens
+   `PROCESS_QUERY_LIMITED_INFORMATION` and converts `GetProcessTimes`' FILETIME
+   to Unix ms; a process that denies the handle is emitted with the field
+   absent, never zero, because callers must be able to tell "cannot identify"
+   from a timestamp.
 
 The typings claim `commandLine` is truncated at 512 characters. Measured, it is
 not: the longest observed on a real host was 26,059.
@@ -494,10 +502,10 @@ already has, which is why the addon is checked again at load.
 
 ## What the snapshot does not provide
 
-`CreationDate` (process start time) has no equivalent. Anything using a start
-time to prove a PID has not been recycled — daemon identity, managed-hook
-ownership, and CPU accounting in the memory collector — still reads it through
-its own query. Those callers are not migrated.
+`CreationDate` (process start time) now has an equivalent — `creationTimeMs`,
+above — but only inside this module. Daemon identity, managed-hook ownership and
+CPU accounting in the memory collector still read a start time through their own
+queries; those callers are not migrated.
 
 Committed private bytes have no equivalent either, and the one memory value the
 addon can produce is unusable for the sizes Orca now sees: `process.cc` stores
@@ -509,10 +517,12 @@ counters in the same pass. Migrating it to the native table would cost both, and
 it is why this module no longer sets the `Memory` flag at all: the field had no
 reader, and asking for it opened a handle per process on every snapshot.
 
-Start time is a proxy for identity, not identity. The durable answer for the
-process trees Orca itself spawns is an inherited handle: a job object names the
-tree Orca created, so no start-time comparison is needed. Those readers should
-be resolved that way rather than by adding a start time to this module.
+Start time is a proxy for identity, not identity. For the process trees Orca
+itself spawns the durable answer is still an inherited handle: a job object
+names the tree Orca created, so no start-time comparison is needed. The
+`creationTimeMs` this snapshot now carries is for the trees Orca did **not**
+create the handle for — a recovered agent session, a descendant walked out of
+the table — where a bare PID is all there is to re-identify.
 
 Do not adopt `getProcessCpuUsage()` from the package. It takes both CPU samples
 inside one call with a blocking `Sleep(1000)` in the middle, which would hold a

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -368,6 +368,24 @@ on any other OS keeps using the scan.
    to Unix ms; a process that denies the handle is emitted with the field
    absent, never zero, because callers must be able to tell "cannot identify"
    from a timestamp.
+5. **`supportedProcessDataFlags`.** `addon.cc` exports the flag bits the
+   compiled binary understands, and `lib/index.js` re-exports it.
+
+   Why a fifth hunk and not just the enum: unlike `node-pty`, this package
+   publishes a prebuilt `.node` at the same `build/Release/` path node-gyp
+   writes to. pnpm patches the source tree and leaves that prebuilt alone, so a
+   host can hold a patched `lib/index.js` — `ProcessDataFlag.CreationTime` and
+   all — over a binary that ignores flag 4. CI produced exactly that: the gate
+   read available and every row came back without `creationTimeMs`. Neither a
+   load check nor a path check can see the difference, so the binary has to say
+   so itself.
+
+   Two readers depend on it. `isWindowsProcessStartTimeAvailable()` returns
+   false unless this bit is set, because claiming otherwise leaves
+   `captureWindowsDescendantSnapshot` returning null forever while structured
+   chat believes it has a reaper. And `windows-process-tree-creation-time.cjs`
+   asserts it during install, which is what forces a from-source rebuild —
+   the same role `node-pty-job-ownership.cjs` plays for node-pty's job exports.
 
 The typings claim `commandLine` is truncated at 512 characters. Measured, it is
 not: the longest observed on a real host was 26,059.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,7 @@ overrides:
   monaco-editor>dompurify: 3.4.13
 
 patchedDependencies:
-  '@vscode/windows-process-tree@0.8.0': f8ea245391c94da5770045aeea01fa6de466c2199c6ef46b5b769b398aa9823e
+  '@vscode/windows-process-tree@0.8.0': e66202cc623996d02040c93449eb9ae353fddadf426cb53202a59ee710ee6fe7
   '@xterm/addon-ligatures@0.11.0-beta.300': 47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920
   '@xterm/addon-search@0.17.0-beta.300': eee5338dd2621ece46e79c61ec06766cd7fadaf79ffdb24e2a8ab68e97ef31f0
   '@xterm/addon-serialize@0.15.0-beta.300': 851eac3d75e6d8c013b9f4c053e61d824b23965cb19ecc28e335e05059f3a294
@@ -510,7 +510,7 @@ importers:
     optionalDependencies:
       '@vscode/windows-process-tree':
         specifier: 0.8.0
-        version: 0.8.0(patch_hash=f8ea245391c94da5770045aeea01fa6de466c2199c6ef46b5b769b398aa9823e)
+        version: 0.8.0(patch_hash=e66202cc623996d02040c93449eb9ae353fddadf426cb53202a59ee710ee6fe7)
       sherpa-onnx-darwin-arm64:
         specifier: 1.12.37
         version: 1.12.37
@@ -9821,7 +9821,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vscode/windows-process-tree@0.8.0(patch_hash=f8ea245391c94da5770045aeea01fa6de466c2199c6ef46b5b769b398aa9823e)':
+  '@vscode/windows-process-tree@0.8.0(patch_hash=e66202cc623996d02040c93449eb9ae353fddadf426cb53202a59ee710ee6fe7)':
     dependencies:
       node-addon-api: 7.1.0
     optional: true

--- a/src/main/claude/claude-structured-location-support.test.ts
+++ b/src/main/claude/claude-structured-location-support.test.ts
@@ -56,8 +56,11 @@ describe('supportsClaudeStructuredLocation', () => {
 
   it('accepts Windows local locations once creation-time proof is available', () => {
     previousPlatform = setPlatform('win32')
+    // supportedProcessDataFlags is the addon's own report; the enum alone is
+    // not proof, because pnpm patches the source over the tarball's prebuilt.
     __setWindowsProcessTreeLoaderForTests(() => ({
       ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2, CreationTime: 4 },
+      supportedProcessDataFlags: 7,
       getAllProcesses: () => undefined
     }))
     expect(

--- a/src/main/windows/windows-process-table-native-addon.win32.test.ts
+++ b/src/main/windows/windows-process-table-native-addon.win32.test.ts
@@ -1,0 +1,16 @@
+import { expect, it } from 'vitest'
+import {
+  isWindowsProcessStartTimeAvailable,
+  readWindowsProcessTableFresh
+} from './windows-process-table'
+
+it.runIf(process.platform === 'win32')(
+  'reads creation times from the real Windows process-tree addon',
+  async () => {
+    expect(isWindowsProcessStartTimeAvailable()).toBe(true)
+
+    const rows = await readWindowsProcessTableFresh()
+    const rowsWithCreationTime = rows.filter((row) => typeof row.creationTimeMs === 'number').length
+    expect(rowsWithCreationTime).toBeGreaterThan(0)
+  }
+)

--- a/src/main/windows/windows-process-table-native-addon.win32.test.ts
+++ b/src/main/windows/windows-process-table-native-addon.win32.test.ts
@@ -12,5 +12,15 @@ it.runIf(process.platform === 'win32')(
     const rows = await readWindowsProcessTableFresh()
     const rowsWithCreationTime = rows.filter((row) => typeof row.creationTimeMs === 'number').length
     expect(rowsWithCreationTime).toBeGreaterThan(0)
+
+    // Why our own row and not merely a count: a single stray row satisfies a
+    // count, and an addon that forwards the raw FILETIME satisfies it too. We
+    // opened our own handle, so this row is the one the addon can never fail to
+    // answer, and its value is bounded on both sides -- a 1601-epoch stamp lands
+    // below the floor, an unconverted 100ns tick lands astronomically above now.
+    const self = rows.find((row) => row.pid === process.pid)
+    expect(typeof self?.creationTimeMs).toBe('number')
+    expect(self?.creationTimeMs).toBeGreaterThan(Date.parse('2020-01-01T00:00:00Z'))
+    expect(self?.creationTimeMs).toBeLessThanOrEqual(Date.now())
   }
 )

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -149,6 +149,7 @@ describe('windows process table', () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     __setWindowsProcessTreeLoaderForTests(() => ({
       ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2, CreationTime: 4 },
+      supportedProcessDataFlags: 7,
       getAllProcesses
     }))
   })
@@ -327,10 +328,23 @@ describe('windows process table', () => {
     vi.useRealTimers()
   })
 
-  it('only advertises PID-safe ownership when the native creation-time field exists', () => {
+  it('only advertises PID-safe ownership when the BINARY reports creation-time support', () => {
     expect(isWindowsProcessStartTimeAvailable()).toBe(true)
+
+    // The shape CI produced: pnpm patched the source tree, so the enum carries
+    // CreationTime, while the tarball's prebuilt .node still ignores flag 4.
+    // Believing the enum here is what let structured chat run with a reaper
+    // that can never identify a PID.
     __setWindowsProcessTreeLoaderForTests(() => ({
-      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2, CreationTime: 4 },
+      supportedProcessDataFlags: 3,
+      getAllProcesses
+    }))
+    expect(isWindowsProcessStartTimeAvailable()).toBe(false)
+
+    // An addon predating the export at all reports nothing, which is also false.
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2, CreationTime: 4 },
       getAllProcesses
     }))
     expect(isWindowsProcessStartTimeAvailable()).toBe(false)
@@ -654,10 +668,19 @@ describe('resolving the native reader', () => {
     }
   })
 
-  function addonReturning(rows: unknown): { getProcessList: ReturnType<typeof vi.fn> } {
+  function addonReturning(rows: unknown): {
+    getProcessList: ReturnType<typeof vi.fn>
+    supportedProcessDataFlags: number
+  } {
     return {
-      getProcessList: vi.fn((cb: (r: unknown) => void) => cb(rows))
+      getProcessList: vi.fn((cb: (r: unknown) => void) => cb(rows)),
+      supportedProcessDataFlags: 7
     }
+  }
+
+  /** An addon built before the creation-time patch: no capability export at all. */
+  function staleAddonReturning(rows: unknown): { getProcessList: ReturnType<typeof vi.fn> } {
+    return { getProcessList: vi.fn((cb: (r: unknown) => void) => cb(rows)) }
   }
 
   it('prefers the npm package where the desktop app installs it', async () => {
@@ -724,6 +747,22 @@ describe('resolving the native reader', () => {
     // CreationTime (4) and nothing else: no CommandLine, so the only per-process
     // handle is the PROCESS_QUERY_LIMITED_INFORMATION one GetProcessTimes needs.
     expect(addon.getProcessList).toHaveBeenCalledWith(expect.any(Function), 4)
+  })
+
+  it('trusts the staged addon on its own report, not on ours', async () => {
+    // A relay carrying an addon built before the creation-time patch still
+    // enumerates, so the table stays usable -- but it cannot prove identity,
+    // and saying otherwise would hand teardown a PID it can never re-check.
+    const addon = staleAddonReturning(NATIVE)
+    __setWindowsProcessTreeRequireForTests((specifier: string) => {
+      if (specifier === ADDON_SPECIFIER) {
+        return addon
+      }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(2)
+    expect(isWindowsProcessTableAvailable()).toBe(true)
+    expect(isWindowsProcessStartTimeAvailable()).toBe(false)
   })
 
   it('reaches the CIM scan when neither the package nor the addon is present', async () => {

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -695,7 +695,7 @@ describe('resolving the native reader', () => {
     expect(isWindowsProcessTableAvailable()).toBe(true)
   })
 
-  it('asks the addon for the command line, as the package path does', async () => {
+  it('asks the addon for the command line and creation time, as the package path does', async () => {
     const addon = addonReturning(NATIVE)
     __setWindowsProcessTreeRequireForTests((specifier: string) => {
       if (specifier === ADDON_SPECIFIER) {
@@ -704,13 +704,15 @@ describe('resolving the native reader', () => {
       throw new Error('MODULE_NOT_FOUND')
     })
     await readWindowsProcessTableFresh()
-    // CommandLine alone: a bare snapshot would silently drop the command line
-    // every agent-recognition caller matches on first, and Memory would add a
-    // second per-process handle nothing reads.
-    expect(addon.getProcessList).toHaveBeenCalledWith(expect.any(Function), 2)
+    // Same flag set as the package path (6). Dropping CreationTime would strand
+    // the relay's own teardown on bare pids: every Windows descendant identity
+    // is a pid plus a creation time, so a table without one can never prove a
+    // tree exited. Memory stays off -- a second per-process handle nothing reads.
+    expect(addon.getProcessList).toHaveBeenCalledWith(expect.any(Function), 6)
+    expect(isWindowsProcessStartTimeAvailable()).toBe(true)
   })
 
-  it('asks the addon for nothing per-process on the identity path', async () => {
+  it('asks the addon for the creation time alone on the identity path', async () => {
     const addon = addonReturning(NATIVE)
     __setWindowsProcessTreeRequireForTests((specifier: string) => {
       if (specifier === ADDON_SPECIFIER) {
@@ -719,9 +721,9 @@ describe('resolving the native reader', () => {
       throw new Error('MODULE_NOT_FOUND')
     })
     await readWindowsProcessIdentityTableFresh()
-    // The relay addon exposes no CreationTime bit, so this is a bare Toolhelp32
-    // walk: zero OpenProcess calls.
-    expect(addon.getProcessList).toHaveBeenCalledWith(expect.any(Function), 0)
+    // CreationTime (4) and nothing else: no CommandLine, so the only per-process
+    // handle is the PROCESS_QUERY_LIMITED_INFORMATION one GetProcessTimes needs.
+    expect(addon.getProcessList).toHaveBeenCalledWith(expect.any(Function), 4)
   })
 
   it('reaches the CIM scan when neither the package nor the addon is present', async () => {

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -33,8 +33,13 @@ import { readWindowsProcessRowsWithCim } from './windows-process-table-cim-scan'
  *
  * Dropping Memory removed the second per-process handle: it took an
  * OpenProcess(...|VM_READ) it never read through. CommandLine's own read is no
- * longer a PEB walk either -- the patched addon asks the kernel, so identity is
- * now the only flag set that opens nothing at all.
+ * longer a PEB walk either -- the patched addon asks the kernel.
+ *
+ * Both Toolhelp32 rows predate `CreationTime`, which both flag sets now also
+ * ask for and which is unmeasured here: it costs one
+ * OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION) plus GetProcessTimes per
+ * process, so identity no longer opens nothing at all -- but that pair is far
+ * cheaper than either handle the rows above measure.
  *
  * All Toolhelp32 rows assume the optional `windows-process-tree.node` addon.
  * The desktop bundles it; no released relay carries it, so on an SSH host the
@@ -110,8 +115,13 @@ type WindowsProcessTreeAddon = {
  * Mirrors the package's enum; the addon takes the raw bit field. `Memory` (1)
  * is listed for completeness and is deliberately never set — see the projections
  * below.
+ *
+ * Why `CreationTime` can be named here rather than probed: the bare addon is a
+ * content-hashed relay artifact, so it ships in the same immutable relay
+ * directory as the bundle reading it and can never be an older build than the
+ * code asking for the bit.
  */
-const PROCESS_DATA_FLAG = { None: 0, Memory: 1, CommandLine: 2 } as const
+const PROCESS_DATA_FLAG = { None: 0, Memory: 1, CommandLine: 2, CreationTime: 4 } as const
 
 /** Staged beside the relay bundle by build-relay; see RELAY_ARTIFACTS. */
 const RELAY_ADDON_FILENAME = './windows-process-tree.node'
@@ -492,9 +502,9 @@ export function isWindowsProcessTableAvailable(): boolean {
 
 /**
  * PID-reuse-safe ownership needs the native creation-time field, not merely a
- * process list. Older addon builds expose the table without that field; keep
- * structured ownership unavailable on those hosts instead of fabricating proof
- * from a PID.
+ * process list. An install whose pnpm patch never applied exposes the table
+ * without that field; keep structured ownership unavailable on those hosts
+ * instead of fabricating proof from a PID.
  */
 export function isWindowsProcessStartTimeAvailable(): boolean {
   const native = moduleLoader()

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -75,6 +75,13 @@ type WindowsProcessTreeModule = {
     CommandLine: number
     CreationTime?: number
   }
+  /**
+   * Flag bits the COMPILED addon reports, straight from `addon.cc`. Absent on a
+   * build that predates the patch — which is not the same question as the enum
+   * above, because pnpm patches the source tree and leaves the tarball's
+   * prebuilt `.node` in place.
+   */
+  supportedProcessDataFlags?: number
   getAllProcesses: (
     callback: (processes: NativeProcessInfo[] | undefined) => void,
     flags?: number
@@ -109,6 +116,7 @@ type WindowsProcessTreeAddon = {
     callback: (processes: NativeProcessInfo[] | undefined) => void,
     flags: number
   ) => void
+  supportedProcessDataFlags?: number
 }
 
 /**
@@ -116,10 +124,8 @@ type WindowsProcessTreeAddon = {
  * is listed for completeness and is deliberately never set — see the projections
  * below.
  *
- * Why `CreationTime` can be named here rather than probed: the bare addon is a
- * content-hashed relay artifact, so it ships in the same immutable relay
- * directory as the bundle reading it and can never be an older build than the
- * code asking for the bit.
+ * Naming `CreationTime` here only decides what we ASK for; whether the binary
+ * answers is `supportedProcessDataFlags`, which the addon reports itself.
  */
 const PROCESS_DATA_FLAG = { None: 0, Memory: 1, CommandLine: 2, CreationTime: 4 } as const
 
@@ -170,6 +176,7 @@ let cimScan: () => Promise<WindowsProcessRow[]> = readWindowsProcessRowsWithCim
 function adaptAddon(addon: WindowsProcessTreeAddon): WindowsProcessTreeModule {
   return {
     ProcessDataFlag: PROCESS_DATA_FLAG,
+    supportedProcessDataFlags: addon.supportedProcessDataFlags,
     getAllProcesses: (callback, flags) => addon.getProcessList(callback, flags ?? 0)
   }
 }
@@ -502,13 +509,23 @@ export function isWindowsProcessTableAvailable(): boolean {
 
 /**
  * PID-reuse-safe ownership needs the native creation-time field, not merely a
- * process list. An install whose pnpm patch never applied exposes the table
- * without that field; keep structured ownership unavailable on those hosts
- * instead of fabricating proof from a PID.
+ * process list.
+ *
+ * Why the binary's own answer and not the enum: pnpm patches the package's
+ * source tree but leaves the tarball's prebuilt `.node` at the same
+ * `build/Release/` path, so a host can hold a patched `lib/index.js` — enum and
+ * all — over a binary that ignores flag 4. CI produced exactly that: the enum
+ * said available, and every row came back without `creationTimeMs`. Answering
+ * true there is worse than answering false: the descendant snapshot then
+ * returns null forever and the exit proof latches `unverifiable`, while
+ * structured chat believes it has a reaper.
  */
 export function isWindowsProcessStartTimeAvailable(): boolean {
   const native = moduleLoader()
-  return native !== null && typeof native.ProcessDataFlag.CreationTime === 'number'
+  return (
+    native !== null &&
+    ((native.supportedProcessDataFlags ?? 0) & PROCESS_DATA_FLAG.CreationTime) !== 0
+  )
 }
 
 function resetSnapshotReaders(): void {

--- a/src/main/windows/windows-process-tree-command-line-patch.test.ts
+++ b/src/main/windows/windows-process-tree-command-line-patch.test.ts
@@ -94,7 +94,9 @@ describe('windows-process-tree command line patch', () => {
       expect(source).not.toMatch(/ReadProcessMemory\(/)
     }
     // Memory and CPU counters kept VM_READ and never read an address space.
-    expect(processSource.match(/OpenProcess\(PROCESS_QUERY_LIMITED_INFORMATION/g)).toHaveLength(2)
+    // Three sites now: those two plus GetProcessCreationTime, which needs the
+    // same limited handle for GetProcessTimes.
+    expect(processSource.match(/OpenProcess\(PROCESS_QUERY_LIMITED_INFORMATION/g)).toHaveLength(3)
   })
 
   it('value-initializes ProcessInfo so memory is not stack garbage', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​640 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​324 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​316 |

<!-- /orca-pr-loc -->

## What this fixes

Structured Claude native chat is unavailable on Windows, and nothing in the Claude code path is at fault. `supportsClaudeStructuredLocation` reduces on win32 to `isWindowsProcessStartTimeAvailable()`, which needs a process creation time from `@vscode/windows-process-tree`. Our pinned patch never added that field, so the gate failed closed and every structured session on Windows silently fell back to the legacy terminal path.

Fixing that surfaced three further defects in the same family, each of which would have made the fix look correct while leaving it broken.

## The change

**The dependency.** The patch gains `CreationTime` (flag 4) — `GetProcessCreationTime` opens `PROCESS_QUERY_LIMITED_INFORMATION` and converts `GetProcessTimes`' FILETIME to Unix ms. A process that denies the handle is emitted with the field **absent, never zero**, so callers can distinguish "cannot identify" from a timestamp.

**The binary describes itself.** The patch also exports `supportedProcessDataFlags` from `src/addon.cc`. This package publishes its prebuilt at the exact path node-gyp writes to, and the field is only discoverable through an async call — so there was no synchronous way to tell a patched binary from a stock one. `isWindowsProcessStartTimeAvailable()` now reads that export rather than the JS enum.

**The build actually rebuilds it.** `ensure-native-runtime.mjs` proved nothing but `require()`, which succeeds against upstream's prebuilt, so the patched C++ was never compiled in the node-runtime lane. A shared `config/scripts/windows-process-tree-creation-time.cjs` now asserts the capability and routes into the existing failure→rebuild path, mirroring `node-pty-job-ownership.cjs`. `rebuildNodeRuntimeModules` also could not have rebuilt this package even when asked — the patched `binding.gyp` includes `deps/node-addon-api`, which the tarball does not ship — so headers are staged and the realpath resolved first.

**The relay path asked for nothing.** `PROCESS_DATA_FLAG` omitted `CreationTime`, so `flags = CommandLine | (CreationTime ?? 0)` resolved to `2`. A relay host would compile the addon with support and never request it, leaving `verifyWindowsProcessIdentity` permanently false and `terminateIdentifiedWindowsProcessTree` unable to kill.

**A guard that runs on the platform it guards.** `windows-process-table.test.ts` pins the predicate through an injected fake loader, so it can never observe the real addon. The new `*.win32.test.ts` uses the existing `it.runIf(process.platform === 'win32')` idiom and asserts the gate opens, that rows carry `creationTimeMs`, and that **our own** row's value is between 2020 and now — an unconverted 100ns tick lands astronomically high, a 1601 epoch below the floor.

## Measured on real Windows hardware

Two-point ablation, same box and worktree, only the patch differing:

| | before | after |
|---|---|---|
| addon size / mtime | 152064 / 23:45:44Z | 152576 / 23:50:19Z |
| `ProcessDataFlag` | None, Memory, CommandLine | **+ CreationTime: 4** |
| `isWindowsProcessStartTimeAvailable()` | **false** | **true** |
| rows carrying `creationTimeMs` | — | **402 / 540** |

Both binaries differ in size *and* mtime, ruling out the case where patched JS opens the gate while a stale `.node` returns nothing.

**CI proved that case is not hypothetical.** The guard's first run failed with `expected 0 to be greater than 0` while the gate assertion passed — exactly the stale-binary state, caused by the rebuild gap above. An enum-only assertion would have gone green.

## Parity sweep on Windows

Structured chat driven end to end in a running app: routing to `agent-session`, multi-turn state carried across turns, a real tool call reading a repo file, interrupt leaving the composer usable, transcript surviving tab switches, and **teardown leaving no orphaned descendants** (`claude` and its `conhost` child both reaped, no reparented stream-json processes).

Three platform differences worth knowing, none blocking: Windows spawns a `conhost.exe` child per agent that orphan logic must expect; the capability gate has no macOS/Linux analogue; tool-call paths render with native backslashes.

## Note for the Windows Codex lane

Once this lands, `supportsCodexStructuredLocation` also answers `supported: true` on Windows. Codex still routes to legacy because of the client-side term in `src/renderer/src/lib/agent-launch-routing.ts`, which is that lane's to lift. Measured: host gate true, routing still `legacy-native-chat`. No Codex behaviour changes here.

## Deliberately excluded

`CLAUDE_SECURESTORAGE_CONFIG_DIR` is absent from `CLAUDE_AUTH_ENV_VARS`, so an inherited value overrides the pinned account home for credential lookup; nothing normalizes config-dir path separators; `refreshLocalRuntimeCapabilities()` is async and an agent launched before it settles sees empty capabilities and silently routes legacy; the `.gitattributes` comment on `config/patches/*.patch` describes pnpm as hashing "byte-for-byte" when it normalizes line endings first. All real, none required here, all filed rather than bundled.
