### PR TITLE
ci: expose existing E2E spec selection for manual dispatch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,10 @@ on:
         description: Ref to check out (defaults to the workflow ref)
         required: false
         type: string
+      test_files:
+        description: JSON array of specs to run; empty runs the full suite
+        required: false
+        type: string
   schedule:
     # Why: GitHub cron uses UTC; these slots map to 10am and 3pm
     # America/Phoenix for the default-branch E2E run.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

Manual Electron E2E runs currently expose only a checkout ref, so reproducing one failed spec requires the full matrix. Expose the existing `test_files` input on `workflow_dispatch`; it already selects the changed-spec job for reusable PR calls. Empty input retains the full-suite behavior.

This enables focused CI validation while keeping Electron test windows off the developer’s desktop. Example:

```sh
gh workflow run e2e.yml -f ref=<branch-or-sha> -f 'test_files=["tests/e2e/tabs.spec.ts"]'
```

Validation: uses the existing input consumption, JSON parsing, build, and test execution path; no test assertions, retries, timeouts, or job conditions change. Targeted dispatch execution will be checked from this branch before merge.


Validated manual dispatch in https://github.com/stablyai/orca/actions/runs/34005240462: built the pinned checkout, selected only `tests/e2e/tabs.spec.ts`, ran all nine cases, and skipped the full matrix and SSH lane. Eight passed; the existing New Markdown menu failure was correctly reported as a failed job. Workflow checks and pullfrog are green.
