### PR TITLE
test: isolate window mocks from inherited launch flags

### DIFF
--- a/src/main/ipc/dashboard-popout.test.ts
+++ b/src/main/ipc/dashboard-popout.test.ts
@@ -97,6 +97,14 @@ function makeStore(enabled = true) {
   }
 }
 
+// These cases exercise foreground behavior against Electron mocks.
+beforeEach(() => {
+  vi.stubEnv('ORCA_BACKGROUND_LAUNCH', undefined)
+  vi.stubEnv('ORCA_E2E_HEADLESS', undefined)
+  vi.stubEnv('ORCA_E2E_HEADFUL', undefined)
+})
+afterEach(() => vi.unstubAllEnvs())
+
 describe('registerDashboardPopoutHandlers', () => {
   let store: ReturnType<typeof makeStore>
 

--- a/src/main/ipc/notifications-retention-lifecycle.test.ts
+++ b/src/main/ipc/notifications-retention-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   getAllWindowsMock,
@@ -29,6 +29,14 @@ vi.mock('../tray/system-tray', async () =>
 )
 
 import { registerNotificationHandlers } from './notifications'
+
+// These cases exercise foreground behavior against Electron mocks.
+beforeEach(() => {
+  vi.stubEnv('ORCA_BACKGROUND_LAUNCH', undefined)
+  vi.stubEnv('ORCA_E2E_HEADLESS', undefined)
+  vi.stubEnv('ORCA_E2E_HEADFUL', undefined)
+})
+afterEach(() => vi.unstubAllEnvs())
 
 describe('registerNotificationHandlers', () => {
   beforeEach(() => {

--- a/src/main/window/createMainWindow-startup-reveal.test.ts
+++ b/src/main/window/createMainWindow-startup-reveal.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 vi.mock('electron', async () =>
   (await import('./createMainWindow-test-harness')).electronModuleMock()
@@ -21,6 +21,14 @@ import {
   resetMainWindowMocks,
   withPlatform
 } from './createMainWindow-test-harness'
+
+// These cases exercise foreground behavior against Electron mocks.
+beforeEach(() => {
+  vi.stubEnv('ORCA_BACKGROUND_LAUNCH', undefined)
+  vi.stubEnv('ORCA_E2E_HEADLESS', undefined)
+  vi.stubEnv('ORCA_E2E_HEADFUL', undefined)
+})
+afterEach(() => vi.unstubAllEnvs())
 
 describe('createMainWindow', () => {
   beforeEach(() => {
@@ -77,34 +85,6 @@ describe('createMainWindow', () => {
       updateUI: vi.fn()
     }
   }
-
-  it.each(['darwin', 'linux', 'win32'] as const)(
-    'keeps explicit background startup hidden through ready/load/fallback on %s',
-    (platform) => {
-      vi.useFakeTimers()
-      vi.stubEnv('ORCA_BACKGROUND_LAUNCH', '1')
-      const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
-      const showInactive = vi.fn()
-      Object.assign(browserWindowInstance, { showInactive })
-      try {
-        withPlatform(platform, () => {
-          createMainWindow(createStartupRevealStore(true) as never, { revealOnDidFinishLoad: true })
-          const revealAfterLoad = browserWindowInstance.webContents.on.mock.calls.find(
-            ([event]) => event === 'did-finish-load'
-          )?.[1]
-          expect(revealAfterLoad).toBeTypeOf('function')
-          revealAfterLoad?.()
-          windowHandlers['ready-to-show']()
-          vi.advanceTimersByTime(10_000)
-          expect(browserWindowInstance.show).not.toHaveBeenCalled()
-          expect(showInactive).not.toHaveBeenCalled()
-          expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
-        })
-      } finally {
-        vi.unstubAllEnvs()
-      }
-    }
-  )
 
   it('ignores duplicate ready-to-show events after startup maximize has already run', () => {
     const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()

--- a/src/main/window/createMainWindow-startup-reveal.test.ts
+++ b/src/main/window/createMainWindow-startup-reveal.test.ts
@@ -86,6 +86,34 @@ describe('createMainWindow', () => {
     }
   }
 
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'keeps explicit background startup hidden through ready/load/fallback on %s',
+    (platform) => {
+      vi.useFakeTimers()
+      vi.stubEnv('ORCA_BACKGROUND_LAUNCH', '1')
+      const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
+      const showInactive = vi.fn()
+      Object.assign(browserWindowInstance, { showInactive })
+      try {
+        withPlatform(platform, () => {
+          createMainWindow(createStartupRevealStore(true) as never, { revealOnDidFinishLoad: true })
+          const revealAfterLoad = browserWindowInstance.webContents.on.mock.calls.find(
+            ([event]) => event === 'did-finish-load'
+          )?.[1]
+          expect(revealAfterLoad).toBeTypeOf('function')
+          revealAfterLoad?.()
+          windowHandlers['ready-to-show']()
+          vi.advanceTimersByTime(10_000)
+          expect(browserWindowInstance.show).not.toHaveBeenCalled()
+          expect(showInactive).not.toHaveBeenCalled()
+          expect(browserWindowInstance.maximize).not.toHaveBeenCalled()
+        })
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    }
+  )
+
   it('ignores duplicate ready-to-show events after startup maximize has already run', () => {
     const { browserWindowInstance, windowHandlers } = createStartupRevealWindowFixture()
 

--- a/src/main/window/dashboard-popout-window.test.ts
+++ b/src/main/window/dashboard-popout-window.test.ts
@@ -171,6 +171,14 @@ function makeStore(ui: Record<string, unknown> = {}): {
 
 const RENDERER_URL = 'http://localhost:5173'
 
+// These cases exercise foreground behavior against Electron mocks.
+beforeEach(() => {
+  vi.stubEnv('ORCA_BACKGROUND_LAUNCH', undefined)
+  vi.stubEnv('ORCA_E2E_HEADLESS', undefined)
+  vi.stubEnv('ORCA_E2E_HEADFUL', undefined)
+})
+afterEach(() => vi.unstubAllEnvs())
+
 describe('createOrFocusDashboardPopout', () => {
   beforeEach(() => {
     instances.length = 0

--- a/src/main/window/focus-existing-window.test.ts
+++ b/src/main/window/focus-existing-window.test.ts
@@ -1,5 +1,5 @@
 import type { App, BrowserWindow } from 'electron'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { focusExistingMainWindow } from './focus-existing-window'
 
 type FakeWindowOptions = {
@@ -78,32 +78,15 @@ function makeTimer(): {
   }
 }
 
+// These cases exercise foreground behavior against Electron mocks.
+beforeEach(() => {
+  vi.stubEnv('ORCA_BACKGROUND_LAUNCH', undefined)
+  vi.stubEnv('ORCA_E2E_HEADLESS', undefined)
+  vi.stubEnv('ORCA_E2E_HEADFUL', undefined)
+})
 afterEach(() => vi.unstubAllEnvs())
 
 describe('focusExistingMainWindow', () => {
-  it.each(['darwin', 'linux', 'win32'] as const)(
-    'never restores or activates a background window on %s',
-    (platform) => {
-      vi.stubEnv('ORCA_BACKGROUND_LAUNCH', '1')
-      vi.stubEnv('ORCA_E2E_FOREGROUND', '1')
-      const app = makeFakeApp()
-      const window = makeFakeWindow({ minimized: true })
-      const timer = makeTimer()
-      focusExistingMainWindow({
-        app,
-        getWindow: () => window,
-        openWindow: vi.fn(),
-        platform,
-        setTimeout: timer.setTimeout
-      })
-      expect(app.focus).not.toHaveBeenCalled()
-      for (const call of Object.values(window.calls)) {
-        expect(call).not.toHaveBeenCalled()
-      }
-      expect(timer.scheduledMs()).toEqual([])
-    }
-  )
-
   it('aggressively foregrounds an existing Windows window on second launch', () => {
     const app = makeFakeApp()
     const window = makeFakeWindow()

--- a/src/main/window/focus-existing-window.test.ts
+++ b/src/main/window/focus-existing-window.test.ts
@@ -87,6 +87,29 @@ beforeEach(() => {
 afterEach(() => vi.unstubAllEnvs())
 
 describe('focusExistingMainWindow', () => {
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'never restores or activates a background window on %s',
+    (platform) => {
+      vi.stubEnv('ORCA_BACKGROUND_LAUNCH', '1')
+      vi.stubEnv('ORCA_E2E_FOREGROUND', '1')
+      const app = makeFakeApp()
+      const window = makeFakeWindow({ minimized: true })
+      const timer = makeTimer()
+      focusExistingMainWindow({
+        app,
+        getWindow: () => window,
+        openWindow: vi.fn(),
+        platform,
+        setTimeout: timer.setTimeout
+      })
+      expect(app.focus).not.toHaveBeenCalled()
+      for (const call of Object.values(window.calls)) {
+        expect(call).not.toHaveBeenCalled()
+      }
+      expect(timer.scheduledMs()).toEqual([])
+    }
+  )
+
   it('aggressively foregrounds an existing Windows window on second launch', () => {
     const app = makeFakeApp()
     const window = makeFakeWindow()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Running the unit suite with `ORCA_BACKGROUND_LAUNCH=1` caused 18 mocked window-activation assertions to fail: production code correctly suppressed the expected mock focus/show calls. These foreground-behavior fixtures did not establish their own launch environment.

Clear inherited background/headless/headful flags within the five mocked fixture files and restore the environment after each test. Electron windows and app activation remain mocks; real launches retain the background policy. Existing behavior assertions are unchanged.

Validation: the broad audit produced 73,045 passes and these 18 failures (real Electron-process probes excluded). After the fixture fix, all 60 tests across the five files pass with all three launch flags inherited as `1`. Targeted lint and formatting pass; no Electron app was launched.
