### PR TITLE
test: expect completed worker recovery to remain done

### DIFF
--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -269,7 +269,7 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
 
     const expectedRecovery = {
       origin: 'live',
-      state: 'working',
+      state: 'done',
       providerSessionId: PROVIDER_SESSION_ID
     }
     await expect


### PR DESCRIPTION
The completed-worker fixture reports working then done, so the renderer and persisted recovery assertions must expect done. This corrects the saved-state expectation while preserving session identity, retirement, first activation, and restart checks. No retries or timeouts change.

Validation: 18 provider-session unit tests pass; formatting and lint pass. Both complete retirement modes passed in the combined pending-application-fixes CI run: https://github.com/stablyai/orca/actions/runs/34005529764. Main-based validation passed the corrected expectation but failed later while waiting for PaneManager to mount: https://github.com/stablyai/orca/actions/runs/34006268416. The empty-workspace reseeding fix #18886 is a likely dependency; the combined pass does not isolate that dependency. Keep this test PR unmerged until the full spec passes against main. Application PRs remain open for user review.
