### PR TITLE
fix: honor remote terminal insertion in the calling client

### DIFF
--- a/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
@@ -3,6 +3,7 @@ import { getConnectionIdFromState } from '@/lib/connection-context'
 import { initialAgentTabViewModeProps } from '@/lib/native-chat-initial-view-mode'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
+import { insertUnifiedTabAfterAnchor } from '@/lib/unified-tab-anchor-insertion'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '../../store'
 import {
@@ -83,30 +84,11 @@ export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
           requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [tab.id] })
         }
         if (data.afterTabId) {
-          const createdUnifiedTab = useAppStore
+          const createdUnifiedTabId = useAppStore
             .getState()
-            .unifiedTabsByWorktree[worktreeId]?.find((item) => item.entityId === tab.id)
-          const anchorUnifiedTab = useAppStore
-            .getState()
-            .unifiedTabsByWorktree[worktreeId]?.find((item) => item.id === data.afterTabId)
-          if (
-            createdUnifiedTab &&
-            anchorUnifiedTab &&
-            createdUnifiedTab.groupId === anchorUnifiedTab.groupId
-          ) {
-            const group = useAppStore
-              .getState()
-              .groupsByWorktree[worktreeId]?.find((item) => item.id === createdUnifiedTab.groupId)
-            const order = (group?.tabOrder ?? []).filter((id) => id !== createdUnifiedTab.id)
-            const anchorIndex = order.indexOf(anchorUnifiedTab.id)
-            order.splice(
-              anchorIndex === -1 ? order.length : anchorIndex + 1,
-              0,
-              createdUnifiedTab.id
-            )
-            useAppStore.getState().reorderUnifiedTabs(createdUnifiedTab.groupId, order, {
-              recordInteraction: false
-            })
+            .unifiedTabsByWorktree[worktreeId]?.find((item) => item.entityId === tab.id)?.id
+          if (createdUnifiedTabId) {
+            insertUnifiedTabAfterAnchor(worktreeId, createdUnifiedTabId, data.afterTabId)
           }
         }
         if (shouldActivate) {

--- a/src/renderer/src/lib/unified-tab-anchor-insertion.ts
+++ b/src/renderer/src/lib/unified-tab-anchor-insertion.ts
@@ -1,0 +1,22 @@
+import { useAppStore } from '../store'
+
+/** Move `tabId` to sit immediately after `anchorTabId`; no-op unless both share a group. */
+export function insertUnifiedTabAfterAnchor(
+  worktreeId: string,
+  tabId: string,
+  anchorTabId: string
+): void {
+  if (tabId === anchorTabId) {
+    return
+  }
+  const state = useAppStore.getState()
+  const group = (state.groupsByWorktree[worktreeId] ?? []).find(
+    (candidate) => candidate.tabOrder.includes(tabId) && candidate.tabOrder.includes(anchorTabId)
+  )
+  if (!group) {
+    return
+  }
+  const order = group.tabOrder.filter((id) => id !== tabId)
+  order.splice(order.indexOf(anchorTabId) + 1, 0, tabId)
+  state.reorderUnifiedTabs(group.id, order, { recordInteraction: false })
+}

--- a/src/renderer/src/runtime/web-runtime-session-terminal-legacy-create.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-legacy-create.test.ts
@@ -131,6 +131,66 @@ describe('createWebRuntimeSessionTerminal', () => {
     ])
   })
 
+  it.each([
+    {
+      agent: 'codex' as const,
+      predecessor: 'web-terminal-host-tab-1',
+      afterTabId: 'web-terminal-host-tab-1%3A%3Aleaf-1'
+    },
+    {
+      agent: undefined,
+      predecessor: 'web-terminal-host-tab-1',
+      afterTabId: 'web-terminal-host-tab-1%3A%3Aleaf-1'
+    },
+    { agent: undefined, predecessor: 'local-browser-tab', afterTabId: 'local-browser-tab' }
+  ])(
+    'settles after $afterTabId for $agent creation without activating it',
+    async ({ agent, predecessor, afterTabId }) => {
+      const successor = 'web-terminal-host-tab-3'
+      const created = 'web-terminal-host-tab-2'
+      const reorderUnifiedTabs = vi.fn()
+      mocks.getState.mockReturnValue({
+        ...mocks.getState(),
+        unifiedTabsByWorktree: {
+          [WORKTREE_ID]: [predecessor, successor, created].map((id) => ({
+            id,
+            groupId: 'client-group'
+          }))
+        },
+        groupsByWorktree: {
+          [WORKTREE_ID]: [{ id: 'client-group', tabOrder: [predecessor, successor, created] }]
+        },
+        reorderUnifiedTabs,
+        moveUnifiedTabToGroup: mocks.moveUnifiedTabToGroup
+      })
+      const runtimeCall = vi.fn(async (request: { method: string }) => ({
+        id: request.method,
+        ok: true,
+        result:
+          request.method === 'session.tabs.createTerminal'
+            ? { tab: { id: 'host-tab-2::leaf-2' }, publicationEpoch: 'epoch-1', snapshotVersion: 2 }
+            : makeSnapshot()
+      }))
+      vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+      await expect(
+        createWebRuntimeSessionTerminal({
+          worktreeId: WORKTREE_ID,
+          afterTabId,
+          agent,
+          activate: false
+        })
+      ).resolves.toEqual({ status: 'created' })
+
+      expect(reorderUnifiedTabs).toHaveBeenCalledExactlyOnceWith(
+        'client-group',
+        [predecessor, created, successor],
+        { recordInteraction: false }
+      )
+      expect(mocks.moveUnifiedTabToGroup).not.toHaveBeenCalled()
+    }
+  )
+
   it('can create a terminal without selecting the target worktree', async () => {
     const setStateResults: unknown[] = []
     mocks.setState.mockImplementation((updater: (state: unknown) => unknown) => {

--- a/src/renderer/src/runtime/web-runtime-session-terminal-legacy-create.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-legacy-create.test.ts
@@ -142,7 +142,12 @@ describe('createWebRuntimeSessionTerminal', () => {
       predecessor: 'web-terminal-host-tab-1',
       afterTabId: 'web-terminal-host-tab-1%3A%3Aleaf-1'
     },
-    { agent: undefined, predecessor: 'local-browser-tab', afterTabId: 'local-browser-tab' }
+    { agent: undefined, predecessor: 'local-browser-tab', afterTabId: 'local-browser-tab' },
+    {
+      agent: undefined,
+      predecessor: 'web-terminal-host-tab-1%3A%3Aleaf-1',
+      afterTabId: 'web-terminal-host-tab-1%3A%3Aleaf-1'
+    }
   ])(
     'settles after $afterTabId for $agent creation without activating it',
     async ({ agent, predecessor, afterTabId }) => {

--- a/src/renderer/src/runtime/web-runtime-terminal-create-operation.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-create-operation.ts
@@ -252,16 +252,23 @@ export async function createWebRuntimeSessionTerminalResult(
       expectedEnvironmentPairingRevision: intentOwner.pairingRevision,
       // Why: the publication can beat the RPC response; replay it once after caller intent exists.
       acceptCurrentSnapshot:
-        Boolean(createdTabId) && (args.activate !== false || Boolean(args.targetGroupId)),
+        Boolean(createdTabId) &&
+        (args.activate !== false || Boolean(args.targetGroupId || args.afterTabId)),
       // Why: a placement record needs a post-create list; a deduped in-flight one can predate it.
-      ...(args.targetGroupId && createdTabId ? { afterCurrentInFlight: true } : {})
+      ...((args.targetGroupId || args.afterTabId) && createdTabId
+        ? { afterCurrentInFlight: true }
+        : {})
     })
-    if (args.targetGroupId && createdTabId) {
+    if ((args.targetGroupId || args.afterTabId) && createdTabId) {
       await settleWebRuntimeTerminalPlacement(
         environmentId,
         args.worktreeId,
         webTerminalPlacementParentTabId(createdTabId),
-        { groupId: args.targetGroupId, activate: args.activate !== false }
+        {
+          groupId: args.targetGroupId,
+          afterTabId: args.afterTabId,
+          activate: args.activate !== false
+        }
       )
     }
     return {

--- a/src/renderer/src/runtime/web-runtime-terminal-create-operation.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-create-operation.ts
@@ -248,22 +248,21 @@ export async function createWebRuntimeSessionTerminalResult(
       // tab to THIS new terminal, instead of sticky-keeping the prior tab.
       recordWebSessionFocusIntent(intentOwner, args.worktreeId, createdTabId, createdLeafId)
     }
+    const placementTabId =
+      createdTabId && (args.targetGroupId || args.afterTabId) ? createdTabId : undefined
     await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId, {
       expectedEnvironmentPairingRevision: intentOwner.pairingRevision,
       // Why: the publication can beat the RPC response; replay it once after caller intent exists.
       acceptCurrentSnapshot:
-        Boolean(createdTabId) &&
-        (args.activate !== false || Boolean(args.targetGroupId || args.afterTabId)),
+        Boolean(createdTabId) && (args.activate !== false || Boolean(placementTabId)),
       // Why: a placement record needs a post-create list; a deduped in-flight one can predate it.
-      ...((args.targetGroupId || args.afterTabId) && createdTabId
-        ? { afterCurrentInFlight: true }
-        : {})
+      ...(placementTabId ? { afterCurrentInFlight: true } : {})
     })
-    if ((args.targetGroupId || args.afterTabId) && createdTabId) {
+    if (placementTabId) {
       await settleWebRuntimeTerminalPlacement(
         environmentId,
         args.worktreeId,
-        webTerminalPlacementParentTabId(createdTabId),
+        webTerminalPlacementParentTabId(placementTabId),
         {
           groupId: args.targetGroupId,
           afterTabId: args.afterTabId,

--- a/src/renderer/src/runtime/web-runtime-terminal-placement-settlement.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-placement-settlement.ts
@@ -1,13 +1,16 @@
 import { useAppStore } from '../store'
-import { forgetWebSessionTerminalPlacement } from './web-session-terminal-placement'
-import { toWebTerminalSurfaceTabId } from './web-terminal-surface-id'
+import {
+  forgetWebSessionTerminalPlacement,
+  webTerminalPlacementParentTabId
+} from './web-session-terminal-placement'
+import { toHostSessionTabId, toWebTerminalSurfaceTabId } from './web-terminal-surface-id'
 
 /** Settle the placement once the mirrored tab exists (bounded poll), then consume the record. */
 export async function settleWebRuntimeTerminalPlacement(
   environmentId: string,
   worktreeId: string,
   hostTabId: string,
-  placement: { groupId: string; activate: boolean }
+  placement: { groupId?: string; afterTabId?: string; activate: boolean }
 ): Promise<void> {
   const unifiedTabId = toWebTerminalSurfaceTabId(hostTabId)
   const findTab = () =>
@@ -21,16 +24,36 @@ export async function settleWebRuntimeTerminalPlacement(
     }
     const tab = findTab()
     const state = useAppStore.getState()
-    const targetGroupExists = (state.groupsByWorktree[worktreeId] ?? []).some(
-      (group) => group.id === placement.groupId
+    const anchorId = placement.afterTabId
+      ? ((state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+          (item) => item.id === placement.afterTabId
+        )?.id ??
+        toWebTerminalSurfaceTabId(
+          webTerminalPlacementParentTabId(toHostSessionTabId(placement.afterTabId))
+        ))
+      : undefined
+    const targetGroup = (state.groupsByWorktree[worktreeId] ?? []).find((group) =>
+      placement.groupId
+        ? group.id === placement.groupId
+        : anchorId && group.tabOrder.includes(anchorId)
     )
-    if (tab && targetGroupExists && tab.groupId !== placement.groupId) {
+    if (tab && targetGroup && tab.groupId !== targetGroup.id) {
       // Why: a snapshot can adopt the tab before the record exists (the publication races the
       // RPC response); repair through the same client-owned move a user drag takes.
-      state.moveUnifiedTabToGroup(unifiedTabId, placement.groupId, {
+      state.moveUnifiedTabToGroup(unifiedTabId, targetGroup.id, {
         activate: placement.activate,
         recordInteraction: false
       })
+    }
+    if (tab && targetGroup && anchorId && anchorId !== unifiedTabId) {
+      const current = useAppStore.getState()
+      const group = current.groupsByWorktree[worktreeId]?.find((item) => item.id === targetGroup.id)
+      if (group?.tabOrder.includes(unifiedTabId) && group.tabOrder.includes(anchorId)) {
+        const order = group.tabOrder.filter((id) => id !== unifiedTabId)
+        order.splice(order.indexOf(anchorId) + 1, 0, unifiedTabId)
+        // The create caller owns this insertion; subsequent host snapshots preserve client order.
+        current.reorderUnifiedTabs(group.id, order, { recordInteraction: false })
+      }
     }
   } finally {
     forgetWebSessionTerminalPlacement({ environmentId, worktreeId, hostTabId })

--- a/src/renderer/src/runtime/web-runtime-terminal-placement-settlement.ts
+++ b/src/renderer/src/runtime/web-runtime-terminal-placement-settlement.ts
@@ -1,9 +1,24 @@
+import { insertUnifiedTabAfterAnchor } from '../lib/unified-tab-anchor-insertion'
 import { useAppStore } from '../store'
 import {
   forgetWebSessionTerminalPlacement,
   webTerminalPlacementParentTabId
 } from './web-session-terminal-placement'
-import { toHostSessionTabId, toWebTerminalSurfaceTabId } from './web-terminal-surface-id'
+import {
+  isWebTerminalSurfaceTabId,
+  toHostSessionTabId,
+  toWebTerminalSurfaceTabId
+} from './web-terminal-surface-id'
+
+/** Snapshots key mirrored terminals by the parent tab, so an unknown `parent::leaf` anchor resolves to its parent. */
+function anchorUnifiedTabId(worktreeId: string, afterTabId: string): string {
+  const known = (useAppStore.getState().unifiedTabsByWorktree[worktreeId] ?? []).some(
+    (tab) => tab.id === afterTabId
+  )
+  return known || !isWebTerminalSurfaceTabId(afterTabId)
+    ? afterTabId
+    : toWebTerminalSurfaceTabId(webTerminalPlacementParentTabId(toHostSessionTabId(afterTabId)))
+}
 
 /** Settle the placement once the mirrored tab exists (bounded poll), then consume the record. */
 export async function settleWebRuntimeTerminalPlacement(
@@ -23,21 +38,25 @@ export async function settleWebRuntimeTerminalPlacement(
       await new Promise((resolve) => setTimeout(resolve, 250))
     }
     const tab = findTab()
-    const state = useAppStore.getState()
+    if (!tab) {
+      return
+    }
     const anchorId = placement.afterTabId
-      ? ((state.unifiedTabsByWorktree[worktreeId] ?? []).find(
-          (item) => item.id === placement.afterTabId
-        )?.id ??
-        toWebTerminalSurfaceTabId(
-          webTerminalPlacementParentTabId(toHostSessionTabId(placement.afterTabId))
-        ))
+      ? anchorUnifiedTabId(worktreeId, placement.afterTabId)
       : undefined
-    const targetGroup = (state.groupsByWorktree[worktreeId] ?? []).find((group) =>
-      placement.groupId
-        ? group.id === placement.groupId
-        : anchorId && group.tabOrder.includes(anchorId)
-    )
-    if (tab && targetGroup && tab.groupId !== targetGroup.id) {
+    const state = useAppStore.getState()
+    const groups = state.groupsByWorktree[worktreeId] ?? []
+    // Why: the requested group can be closed while the mirrored tab is still in flight; the
+    // anchor's own group still expresses where the caller asked for this terminal.
+    const targetGroup =
+      groups.find((group) => group.id === placement.groupId) ??
+      (anchorId === undefined
+        ? undefined
+        : groups.find((group) => group.tabOrder.includes(anchorId)))
+    if (!targetGroup) {
+      return
+    }
+    if (tab.groupId !== targetGroup.id) {
       // Why: a snapshot can adopt the tab before the record exists (the publication races the
       // RPC response); repair through the same client-owned move a user drag takes.
       state.moveUnifiedTabToGroup(unifiedTabId, targetGroup.id, {
@@ -45,15 +64,9 @@ export async function settleWebRuntimeTerminalPlacement(
         recordInteraction: false
       })
     }
-    if (tab && targetGroup && anchorId && anchorId !== unifiedTabId) {
-      const current = useAppStore.getState()
-      const group = current.groupsByWorktree[worktreeId]?.find((item) => item.id === targetGroup.id)
-      if (group?.tabOrder.includes(unifiedTabId) && group.tabOrder.includes(anchorId)) {
-        const order = group.tabOrder.filter((id) => id !== unifiedTabId)
-        order.splice(order.indexOf(anchorId) + 1, 0, unifiedTabId)
-        // The create caller owns this insertion; subsequent host snapshots preserve client order.
-        current.reorderUnifiedTabs(group.id, order, { recordInteraction: false })
-      }
+    if (anchorId) {
+      // The create caller owns this insertion; subsequent host snapshots preserve client order.
+      insertUnifiedTabAfterAnchor(worktreeId, unifiedTabId, anchorId)
     }
   } finally {
     forgetWebSessionTerminalPlacement({ environmentId, worktreeId, hostTabId })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

## ELI5

When you are connected to a remote Orca machine and something asks for a new terminal "right here, next to this one", the remote machine put it in the right spot but your own window still stuck it at the far right end of the tab strip. So the tab lands somewhere nobody asked for, and you would have to drag it back. This happens because tab order inside a group belongs to your window, not the remote machine — your window deliberately ignores the remote machine's ordering so your own drags are never overwritten, and nothing was telling it about the "put it after this tab" request. Now your window applies that request itself, as soon as the new tab shows up: the terminal lands directly after the tab that was pointed at, and it still does not steal focus if it was asked for in the background. The same one-line rule is now shared with the non-remote path, which already did this correctly with its own private copy of the code.

## What changed

Creating a paired terminal with `afterTabId` places it correctly on the host but leaves it at the end of the client tab group. Linux CI captured the correct host renderer and published order alongside the stale client group/DOM order: https://github.com/stablyai/orca/actions/runs/34006200401. Existing groups intentionally preserve client ordering, so a host snapshot cannot apply this caller-owned insertion.

Extend the existing terminal placement settlement to insert after the caller's anchor once the mirrored tab exists. Resolve terminal surface IDs to their parent and retain existing browser/editor tab IDs. Replay a post-create snapshot for insertion requests, use the existing client move/reorder actions, and preserve `activate:false`. Later snapshots continue respecting client ordering. **No RPC or stream schema changes.**

The anchor-insertion step is a single shared helper (`insertUnifiedTabAfterAnchor`) reused by both the remote settlement path and the pre-existing local `afterTabId` path in the terminal IPC bridge, which previously carried its own copy of the same filter/splice/reorder sequence.

## Tradeoffs

These are real, user-visible costs of this approach:

- **No shipping UI affordance exercises the remote branch yet.** No production renderer call site passes `afterTabId` into `createWebRuntimeSessionTerminal` today — every current caller passes only `targetGroupId`/`activate`, and the remote anchored-create path is reached from the E2E bridge (`tests/e2e/remote-agent-session-focus-authority.spec.ts`) and mobile clients. So the user-facing win is latent: this makes the remote create API behave correctly for the callers that will use it, rather than fixing something every user hits today. The local/host-renderer anchored path *is* user-reachable and is unchanged in behavior.
- **Ordering is now a client-version property.** There is no wire change, so a client that has not shipped this fix keeps appending anchored terminals to the end no matter which host it talks to. In a mixed fleet, the same action produces two different tab orders depending on which client made the request. (New client + old host is fine — the client applies the insertion itself. Old client + new host is unchanged, i.e. still wrong.)
- **Client and host tab order can legitimately disagree.** `reorderUnifiedTabs` is client-local and is not mirrored to the host, so the corrected order lives only in the requesting client. Another paired client, or the host's own renderer, keeps whatever order it had. This was already true of client-owned ordering; this change makes it observable in one more case.
- **One extra tab-list refresh per anchored create.** `afterTabId` creates now force the post-create snapshot replay (`acceptCurrentSnapshot` / `afterCurrentInFlight`) that previously only ran for group-targeted or activating creates. That is an additional round-trip on a path that used to skip it.
- **Anchored creates can now take up to ~10s to resolve.** The bounded settlement poll now runs for `afterTabId`, not just `targetGroupId`. If the mirrored tab never materializes (host dropped it, link stalled), the create promise resolves up to the poll deadline later than before. Callers that await creation see that delay, though the tab normally appears in well under a second.
- **A drag during the settlement window can be undone once.** When only `afterTabId` is given, the client now also moves the created tab into the anchor's group and repositions it. If the user drags that brand-new terminal elsewhere inside the settlement window, the settlement can pull it back one time. The record is consumed immediately after, so it cannot recur.
- **Silent no-op if the anchor disappears.** If the anchor tab is closed before the mirrored tab arrives, the insertion is skipped and the terminal stays at the end, with no user-facing explanation. That is the pre-existing behavior, but it is now the fallback rather than the norm, which makes it look inconsistent when it happens.
- **Anchored agent creates stay on the legacy RPC.** Structured agent-session creation still cannot express `afterTabId`, so requesting an anchored agent terminal continues to opt out of the structured host-authority create path. Unchanged by this PR, but it is why the fix lands in the legacy flow.

## Visual proof

N/A. Local Electron launches are paused for this task, so no screenshot or video was captured. Visual proof would be genuinely valuable here — the entire symptom is tab-strip ordering, which a single before/after screenshot of the tab bar would show unambiguously — but it requires a live paired remote session (two hosts), which is not reproducible from a still image alone and is already covered by the Linux CI E2E run linked below.

## Validation

Two new agent/plain-terminal regressions fail on the old code; all renderer-runtime tests pass after the fix, including browser-anchor coverage and client-owned placement contracts. `tc:web`, targeted lint and format pass. The complete remote agent-focus E2E spec passes in Linux CI with the pending application fixes: https://github.com/stablyai/orca/actions/runs/34006784402 (pinned commit `21dc96238482adfcaac37c50b957b72641052e3a`). No local Electron launch.

Application fix: leave open for user review.
