### PR TITLE
Fix Codex action recipe submit key

### DIFF
--- a/src/main/codex/codex-tui-rollout-proof.ts
+++ b/src/main/codex/codex-tui-rollout-proof.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path'
 import { stripAnsiEscapeSequences } from '../../shared/ansi-escape-sequences'
 import { relativePathInsideRoot } from '../../shared/cross-platform-path'
+import { TERMINAL_ENTER_INPUT } from '../../shared/terminal-ctrl-enter-input'
 import { readCodexRolloutSessionMetaId } from './codex-rollout-session-meta'
 import { listCodexSessionJsonlFilesIncrementally } from './codex-session-file-listing'
 
@@ -32,7 +33,7 @@ export function parseCodexTuiStatusSessionId(output: string): string | null {
 }
 
 export function codexTuiStatusSubmitInput(kittyKeyboardFlags: number): string {
-  return kittyKeyboardFlags > 0 ? KITTY_ENTER : '\r'
+  return kittyKeyboardFlags > 0 ? KITTY_ENTER : TERMINAL_ENTER_INPUT
 }
 
 export function codexTuiStatusProbeInput(kittyKeyboardFlags: number): {

--- a/src/main/persistence/loading-store/normalize-loaded-global-settings.ts
+++ b/src/main/persistence/loading-store/normalize-loaded-global-settings.ts
@@ -2,6 +2,7 @@ import { getDefaultVoiceSettings } from '../../../shared/constants'
 import { normalizePRBotAuthorOverrides } from '../../../shared/pr-bot-author-overrides'
 import { normalizeTerminalQuickCommands } from '../../../shared/terminal-quick-commands'
 import { normalizeOpenInApplications } from '../../../shared/open-in-applications'
+import { normalizeAgentPostPasteSubmitInputs } from '../../../shared/tui-agent-post-paste-submit'
 import { normalizeTerminalShortcutPolicy } from '../../../shared/keybindings'
 import { normalizeAppIconId } from '../../../shared/app-icon'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
@@ -106,6 +107,9 @@ export function normalizeLoadedGlobalSettings(
     terminalScrollbackRows: migratedTerminalScrollback.rows,
     terminalQuickCommands: normalizeTerminalQuickCommands(parsed.settings?.terminalQuickCommands),
     terminalCustomThemes: normalizeTerminalCustomThemes(parsed.settings?.terminalCustomThemes),
+    agentPostPasteSubmitInputs: normalizeAgentPostPasteSubmitInputs(
+      parsed.settings?.agentPostPasteSubmitInputs
+    ),
     appIcon: normalizeAppIconId(parsed.settings?.appIcon),
     mobilePairingCustomAddress,
     mobilePairingCustomAddresses,

--- a/src/renderer/src/components/settings/AgentCatalogRow.tsx
+++ b/src/renderer/src/components/settings/AgentCatalogRow.tsx
@@ -12,8 +12,10 @@ import { stringifyAgentDefaultEnvDraft } from './agent-default-env-draft'
 import {
   AgentCommandOverrideInput,
   AgentDefaultArgsInput,
-  AgentDefaultEnvInput
+  AgentDefaultEnvInput,
+  AgentPostPasteSubmitInputControl
 } from './AgentLaunchDefaultsEditor'
+import type { AgentPostPasteSubmitInput } from '../../../../shared/tui-agent-post-paste-submit'
 
 type AgentAvailability = 'enabled' | 'disabled'
 
@@ -68,11 +70,13 @@ export type AgentCatalogRowProps = {
   cmdOverride: string | undefined
   argsOverride: string
   envOverride: Record<string, string>
+  postPasteSubmitInput: AgentPostPasteSubmitInput
   onSetDefault: () => void
   onSetEnabled: (enabled: boolean) => void
   onSaveOverride: (value: string) => void
   onSaveArgs: (value: string) => void
   onSaveEnv: (value: Record<string, string>) => void
+  onSavePostPasteSubmitInput: (value: AgentPostPasteSubmitInput) => void
   sessionSourceHome?: AgentSessionSourceHomeControl
 }
 
@@ -89,11 +93,13 @@ export function AgentCatalogRow({
   cmdOverride,
   argsOverride,
   envOverride,
+  postPasteSubmitInput,
   onSetDefault,
   onSetEnabled,
   onSaveOverride,
   onSaveArgs,
   onSaveEnv,
+  onSavePostPasteSubmitInput,
   sessionSourceHome
 }: AgentCatalogRowProps): React.JSX.Element {
   const envSummary = stringifyAgentDefaultEnvDraft(envOverride)
@@ -226,6 +232,12 @@ export function AgentCatalogRow({
               />
             </div>
           )}
+          <div className="mt-2">
+            <AgentPostPasteSubmitInputControl
+              value={postPasteSubmitInput}
+              onSave={onSavePostPasteSubmitInput}
+            />
+          </div>
           {sessionSourceHome && (
             <div className="mt-2">
               <AgentSessionSourceHomeInput

--- a/src/renderer/src/components/settings/AgentLaunchDefaultsEditor.tsx
+++ b/src/renderer/src/components/settings/AgentLaunchDefaultsEditor.tsx
@@ -4,6 +4,8 @@ import { Input } from '../ui/input'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { parseAgentDefaultEnvDraft, stringifyAgentDefaultEnvDraft } from './agent-default-env-draft'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+import type { AgentPostPasteSubmitInput } from '../../../../shared/tui-agent-post-paste-submit'
 
 export function AgentCommandOverrideInput({
   defaultCmd,
@@ -211,6 +213,44 @@ export function AgentDefaultEnvInput({
           )}
         </p>
       )}
+    </div>
+  )
+}
+
+export function AgentPostPasteSubmitInputControl({
+  value,
+  onSave
+}: {
+  value: AgentPostPasteSubmitInput
+  onSave: (value: AgentPostPasteSubmitInput) => void
+}): React.JSX.Element {
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-xs text-muted-foreground">
+        {translate('auto.components.settings.AgentsPane.postPasteSubmit', 'Paste-submit key')}
+      </span>
+      <SettingsSegmentedControl<AgentPostPasteSubmitInput>
+        value={value}
+        onChange={onSave}
+        ariaLabel={translate(
+          'auto.components.settings.AgentsPane.postPasteSubmit',
+          'Paste-submit key'
+        )}
+        size="sm"
+        options={[
+          {
+            value: 'enter',
+            label: translate('auto.components.settings.AgentsPane.postPasteSubmitEnter', 'Enter')
+          },
+          {
+            value: 'ctrl-enter',
+            label: translate(
+              'auto.components.settings.AgentsPane.postPasteSubmitCtrlEnter',
+              'Ctrl+Enter'
+            )
+          }
+        ]}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -34,6 +34,10 @@ import {
   resolveAgentPermissionModeSummary,
   type AgentPermissionMode
 } from '../../../../shared/tui-agent-permissions'
+import {
+  resolveAgentPostPasteSubmitInput,
+  type AgentPostPasteSubmitInput
+} from '../../../../shared/tui-agent-post-paste-submit'
 import { getSettingOwnershipSummary } from './setting-ownership'
 import { translate } from '@/i18n/i18n'
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
@@ -177,6 +181,7 @@ export function AgentsPane({
   const cmdOverrides = settings.agentCmdOverrides ?? {}
   const agentDefaultArgs = settings.agentDefaultArgs ?? {}
   const agentDefaultEnv = settings.agentDefaultEnv ?? {}
+  const agentPostPasteSubmitInputs = settings.agentPostPasteSubmitInputs ?? {}
   const disabledAgents = normalizeDisabledTuiAgents(settings.disabledTuiAgents)
   const detectedAgents =
     detectedIds === null ? [] : catalog.filter((agent) => detectedIds.has(agent.id))
@@ -212,6 +217,7 @@ export function AgentsPane({
     cmdOverride: isDetected ? cmdOverrides[agent.id] : undefined,
     argsOverride: resolveTuiAgentLaunchArgs(agent.id, agentDefaultArgs),
     envOverride: resolveTuiAgentLaunchEnv(agent.id, agentDefaultEnv),
+    postPasteSubmitInput: resolveAgentPostPasteSubmitInput(agent.id, agentPostPasteSubmitInputs),
     onSetDefault: isDetected ? () => updateSettings({ defaultTuiAgent: agent.id }) : () => {},
     onSetEnabled: (enabled) => setAgentEnabled(agent.id, enabled),
     onSaveOverride: isDetected
@@ -229,6 +235,10 @@ export function AgentsPane({
       updateSettings({ agentDefaultArgs: { ...agentDefaultArgs, [agent.id]: value } }),
     onSaveEnv: (value) =>
       updateSettings({ agentDefaultEnv: { ...agentDefaultEnv, [agent.id]: value } }),
+    onSavePostPasteSubmitInput: (value: AgentPostPasteSubmitInput) =>
+      updateSettings({
+        agentPostPasteSubmitInputs: { ...agentPostPasteSubmitInputs, [agent.id]: value }
+      }),
     sessionSourceHome:
       isDetected && agent.id === 'codex'
         ? buildCodexSessionSourceHomeControl(settings, updateSettings)

--- a/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/terminal-keydown-fit.ts
@@ -2,6 +2,10 @@ import { useAppStore } from '@/store'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { bindPanePtyId, getFitOverrideForPty } from '@/lib/pane-manager/mobile-fit-overrides'
 import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
+import {
+  registerPtyKittyKeyboardModeTracker,
+  unregisterPtyKittyKeyboardModeTracker
+} from '../terminal-pty-kitty-keyboard-flags'
 import { isFreshNonDoneAgentStatus } from '../../../../../shared/agent-status-types'
 import { isCtrlCKeyEvent, isPlainEscapeKeyEvent } from '../agent-interrupt-inference'
 import { createAgentCompletionCoordinator } from '../agent-completion-coordinator'
@@ -85,6 +89,11 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
   session.visibleRemoteViewportClaimPtyId = null
   session.pendingVisibleRemoteViewportClaim = false
   session.setPanePtyFitBinding = (ptyId: string): void => {
+    const previousPtyId = session.activePanePtyBinding
+    if (previousPtyId && previousPtyId !== ptyId) {
+      unregisterPtyKittyKeyboardModeTracker(previousPtyId, session.kittyKeyboardModes)
+    }
+    registerPtyKittyKeyboardModeTracker(ptyId, session.kittyKeyboardModes)
     bindPanePtyId(session.pane.id, ptyId, session.deps.tabId)
     session.pane.container.dataset.ptyId = ptyId
     if (
@@ -163,6 +172,12 @@ export function installTerminalKeydownFit(session: ConnectPanePtySession): void 
   session.clearPanePtyFitBinding = (): void => {
     // Why: fit bindings live in a module-level map, so pane teardown must
     // clear them explicitly instead of relying on DOM removal.
+    if (session.activePanePtyBinding) {
+      unregisterPtyKittyKeyboardModeTracker(
+        session.activePanePtyBinding,
+        session.kittyKeyboardModes
+      )
+    }
     bindPanePtyId(session.pane.id, null, session.deps.tabId)
     session.visibleRemoteViewportClaimPtyId = null
     session.pendingVisibleRemoteViewportClaim = false

--- a/src/renderer/src/components/terminal-pane/terminal-pty-kitty-keyboard-flags.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pty-kitty-keyboard-flags.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
+import {
+  getPtyKittyKeyboardFlags,
+  registerPtyKittyKeyboardModeTracker,
+  resetPtyKittyKeyboardModeTrackersForTests,
+  unregisterPtyKittyKeyboardModeTracker
+} from './terminal-pty-kitty-keyboard-flags'
+
+describe('terminal PTY Kitty keyboard flags registry', () => {
+  beforeEach(() => {
+    resetPtyKittyKeyboardModeTrackersForTests()
+  })
+
+  it('reads the current flags for a registered PTY tracker', () => {
+    const tracker = new TerminalKittyKeyboardModeTracker()
+
+    registerPtyKittyKeyboardModeTracker('pty-1', tracker)
+    expect(getPtyKittyKeyboardFlags('pty-1')).toBe(0)
+
+    tracker.scan('\x1b[>1u')
+    expect(getPtyKittyKeyboardFlags('pty-1')).toBe(1)
+
+    unregisterPtyKittyKeyboardModeTracker('pty-1', tracker)
+    expect(getPtyKittyKeyboardFlags('pty-1')).toBe(0)
+  })
+
+  it('does not let a stale unregister clear a successor tracker', () => {
+    const stale = new TerminalKittyKeyboardModeTracker()
+    const successor = new TerminalKittyKeyboardModeTracker()
+    stale.scan('\x1b[>1u')
+    successor.scan('\x1b[>2u')
+
+    registerPtyKittyKeyboardModeTracker('pty-1', stale)
+    registerPtyKittyKeyboardModeTracker('pty-1', successor)
+    unregisterPtyKittyKeyboardModeTracker('pty-1', stale)
+
+    expect(getPtyKittyKeyboardFlags('pty-1')).toBe(2)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pty-kitty-keyboard-flags.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pty-kitty-keyboard-flags.ts
@@ -1,0 +1,28 @@
+import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
+
+const ptyKittyKeyboardModeTrackers = new Map<string, TerminalKittyKeyboardModeTracker>()
+
+export function registerPtyKittyKeyboardModeTracker(
+  ptyId: string,
+  tracker: TerminalKittyKeyboardModeTracker
+): void {
+  ptyKittyKeyboardModeTrackers.set(ptyId, tracker)
+}
+
+export function unregisterPtyKittyKeyboardModeTracker(
+  ptyId: string,
+  tracker?: TerminalKittyKeyboardModeTracker
+): void {
+  if (tracker && ptyKittyKeyboardModeTrackers.get(ptyId) !== tracker) {
+    return
+  }
+  ptyKittyKeyboardModeTrackers.delete(ptyId)
+}
+
+export function getPtyKittyKeyboardFlags(ptyId: string): number {
+  return ptyKittyKeyboardModeTrackers.get(ptyId)?.flags ?? 0
+}
+
+export function resetPtyKittyKeyboardModeTrackersForTests(): void {
+  ptyKittyKeyboardModeTrackers.clear()
+}

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -5,6 +5,10 @@ import {
   type KeybindingOverrides,
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
+import {
+  TERMINAL_CTRL_ENTER_CSI_U_INPUT,
+  TERMINAL_ENTER_INPUT
+} from '../../../../shared/terminal-ctrl-enter-input'
 import type { WindowsShiftEnterEncoding } from './terminal-windows-shift-enter'
 import {
   resolveTerminalOptionShortcutAction,
@@ -193,7 +197,7 @@ export function resolveTerminalShortcutAction(
       hasCtrlEnterCsiUAuthority?.() === true
     return {
       type: 'sendInput',
-      data: canSendCsiU ? '\x1b[13;5u' : '\r'
+      data: canSendCsiU ? TERMINAL_CTRL_ENTER_CSI_U_INPUT : TERMINAL_ENTER_INPUT
     }
   }
 

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -111,7 +111,8 @@ export async function handleAutomationDispatchRequest({
             const submitted = await submitPromptToAgentPty({
               tabId: reusableSession.tabId,
               ptyId: reusableSession.ptyId,
-              content: automation.prompt
+              content: automation.prompt,
+              agent: automation.agentId
             })
             if (!submitted) {
               completion.cleanupRunObservers()

--- a/src/renderer/src/lib/agent-draft-paste-content-chunking.test.ts
+++ b/src/renderer/src/lib/agent-draft-paste-content-chunking.test.ts
@@ -107,8 +107,18 @@ describe('agent draft paste content chunking', () => {
     ).resolves.toBe(false)
 
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(3)
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(1, {}, 'pty-1', '[200~')
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(3, {}, 'pty-1', '[201~')
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      1,
+      {},
+      'pty-1',
+      '\x1b[200~'
+    )
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      3,
+      {},
+      'pty-1',
+      '\x1b[201~'
+    )
     expect(testState.sendRuntimePtyInputVerified.mock.calls.some((call) => call[2] === '\r')).toBe(
       false
     )

--- a/src/renderer/src/lib/agent-draft-paste-content-chunking.test.ts
+++ b/src/renderer/src/lib/agent-draft-paste-content-chunking.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES,
+  AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES,
+  AGENT_DRAFT_PASTE_MAX_BYTES,
+  chunkAgentDraftPasteContent,
+  iterateAgentDraftPasteContentChunks,
+  POST_PASTE_SUBMIT_DELAY_MS,
+  sendAgentDraftPasteContent,
+  sendBracketedPasteToRunningAgent
+} from './agent-paste-draft'
+
+const testState = vi.hoisted(() => ({
+  appState: {
+    settings: {}
+  },
+  sendRuntimePtyInputVerified: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => testState.appState
+  }
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: vi.fn(),
+  isRemoteRuntimePtyId: vi.fn(),
+  sendRuntimePtyInputVerified: testState.sendRuntimePtyInputVerified
+}))
+
+describe('agent draft paste content chunking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout
+    })
+    testState.sendRuntimePtyInputVerified.mockReset()
+    testState.sendRuntimePtyInputVerified.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('streams large running-agent drafts as bounded bracketed chunks before submit', async () => {
+    const content = 'x'.repeat(
+      AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES + 7
+    )
+    const promise = sendBracketedPasteToRunningAgent({
+      ptyId: 'pty-1',
+      content
+    })
+
+    await flushMicrotasks(20)
+
+    const calls = testState.sendRuntimePtyInputVerified.mock.calls
+    expect(calls.at(0)).toEqual([{}, 'pty-1', '\x1b[200~'])
+    expect(calls.at(-1)?.[2]).toBe('\x1b[201~')
+    expect(
+      calls
+        .slice(1, -1)
+        .map((call) => call[2])
+        .join('')
+    ).toBe(content)
+    for (const call of calls.slice(1, -1)) {
+      expect((call[2] as string).length).toBeLessThanOrEqual(AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES)
+    }
+
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith({}, 'pty-1', '\r')
+  })
+
+  it('normalizes multiline running-agent drafts like terminal paste', async () => {
+    const promise = sendBracketedPasteToRunningAgent({
+      ptyId: 'pty-1',
+      content: 'line one\r\nline two\nline three'
+    })
+
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+      {},
+      'pty-1',
+      '\x1b[200~line one\rline two\rline three\x1b[201~'
+    )
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS)
+    await expect(promise).resolves.toBe(true)
+  })
+
+  it('closes bracketed paste and does not submit when a chunked draft write is rejected', async () => {
+    testState.sendRuntimePtyInputVerified
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+    const content = 'x'.repeat(
+      AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES + 7
+    )
+
+    await expect(
+      sendBracketedPasteToRunningAgent({
+        ptyId: 'pty-1',
+        content
+      })
+    ).resolves.toBe(false)
+
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(3)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(1, {}, 'pty-1', '[200~')
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(3, {}, 'pty-1', '[201~')
+    expect(testState.sendRuntimePtyInputVerified.mock.calls.some((call) => call[2] === '\r')).toBe(
+      false
+    )
+  })
+
+  it('sanitizes escape bytes inside chunked agent draft paste content', () => {
+    const chunks = chunkAgentDraftPasteContent('before\x1b[201~after😀', 6)
+
+    expect(chunks.at(0)).toBe('\x1b[200~')
+    expect(chunks.at(-1)).toBe('\x1b[201~')
+    expect(chunks.slice(1, -1).join('')).toBe('before␛[201~after😀')
+    expect(chunks.slice(1, -1).join('')).not.toContain('\x1b[201~')
+  })
+
+  it('normalizes agent draft line endings before a CRLF chunk boundary', () => {
+    const chunks = chunkAgentDraftPasteContent('abc\r\ndef\nghi', 4)
+
+    expect(chunks).toEqual(['\x1b[200~', 'abc\r', 'def\r', 'ghi', '\x1b[201~'])
+    expect(chunks.join('')).not.toContain('\n')
+  })
+
+  it('chunks escape-heavy agent draft paste without per-character string sanitizer scans', () => {
+    const content = Array.from({ length: 64 }, (_value, index) => `draft-${index}\x1b[201~`).join(
+      ''
+    )
+    const includesSpy = vi.spyOn(String.prototype, 'includes')
+    const replaceAllSpy = vi.spyOn(String.prototype, 'replaceAll')
+
+    const chunks = chunkAgentDraftPasteContent(content, 12)
+    const includesCallCount = includesSpy.mock.calls.length
+    const replaceAllCallCount = replaceAllSpy.mock.calls.length
+    includesSpy.mockRestore()
+    replaceAllSpy.mockRestore()
+
+    expect(chunks.at(0)).toBe('\x1b[200~')
+    expect(chunks.at(-1)).toBe('\x1b[201~')
+    expect(chunks.slice(1, -1).join('')).not.toContain('\x1b[201~')
+    expect(chunks.slice(1, -1).join('')).toContain('␛[201~')
+    expect(includesCallCount).toBe(0)
+    expect(replaceAllCallCount).toBe(0)
+  })
+
+  it('keeps agent draft chunk arrays aligned with lazy chunk iteration', () => {
+    const content = 'before\x1b[201~after😀'
+
+    expect(chunkAgentDraftPasteContent(content, 6)).toEqual([
+      ...iterateAgentDraftPasteContentChunks(content, 6)
+    ])
+  })
+
+  it('iterates large agent draft chunks lazily', () => {
+    const text = 'x'.repeat(128)
+    const codePointAt = vi.spyOn(String.prototype, 'codePointAt')
+    const chunks = iterateAgentDraftPasteContentChunks(text, 8)
+
+    expect(chunks.next()).toEqual({ done: false, value: '\x1b[200~' })
+    expect(chunks.next()).toEqual({ done: false, value: 'x'.repeat(8) })
+    expect(codePointAt.mock.calls.length).toBeLessThan(text.length)
+
+    codePointAt.mockRestore()
+  })
+
+  it('yields during large accepted-size preflight before writing agent draft chunks', async () => {
+    const content = 'x'.repeat(AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + 300 * 1024)
+    const promise = sendAgentDraftPasteContent({}, 'pty-1', content)
+
+    await flushMicrotasks(5)
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+
+    await vi.runOnlyPendingTimersAsync()
+    await flushMicrotasks(10)
+
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith({}, 'pty-1', '\x1b[200~')
+    await expect(promise).resolves.toBe(true)
+  })
+
+  it('rejects oversized agent drafts before any PTY write', async () => {
+    await expect(
+      sendAgentDraftPasteContent({}, 'pty-1', 'x'.repeat(AGENT_DRAFT_PASTE_MAX_BYTES + 1))
+    ).resolves.toBe(false)
+
+    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
+  })
+})
+
+async function flushMicrotasks(iterations = 2): Promise<void> {
+  for (let index = 0; index < iterations; index += 1) {
+    await Promise.resolve()
+  }
+}

--- a/src/renderer/src/lib/agent-paste-draft-submit-retry.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft-submit-retry.test.ts
@@ -21,6 +21,7 @@ const testState = vi.hoisted(() => ({
   subscribeToPtyData: vi.fn(),
   replayPreHandlerPtyData: vi.fn(),
   isRemoteRuntimePtyId: vi.fn(),
+  getPtyKittyKeyboardFlags: vi.fn(),
   sendRuntimePtyInputVerified: vi.fn(),
   inspectRuntimeTerminalProcess: vi.fn(),
   subscribeToRuntimeTerminalData: vi.fn()
@@ -49,6 +50,10 @@ vi.mock('@/runtime/runtime-terminal-inspection', () => ({
 
 vi.mock('@/runtime/runtime-terminal-stream', () => ({
   subscribeToRuntimeTerminalData: testState.subscribeToRuntimeTerminalData
+}))
+
+vi.mock('@/components/terminal-pane/terminal-pty-kitty-keyboard-flags', () => ({
+  getPtyKittyKeyboardFlags: testState.getPtyKittyKeyboardFlags
 }))
 
 const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
@@ -84,6 +89,8 @@ describe('post-paste submit retry input', () => {
     testState.replayPreHandlerPtyData.mockReset()
     testState.isRemoteRuntimePtyId.mockReset()
     testState.isRemoteRuntimePtyId.mockReturnValue(false)
+    testState.getPtyKittyKeyboardFlags.mockReset()
+    testState.getPtyKittyKeyboardFlags.mockReturnValue(0)
     testState.sendRuntimePtyInputVerified.mockReset()
     testState.sendRuntimePtyInputVerified.mockResolvedValue(true)
     testState.inspectRuntimeTerminalProcess.mockReset()
@@ -95,7 +102,19 @@ describe('post-paste submit retry input', () => {
     vi.useRealTimers()
   })
 
+  it('keeps Codex paste-submit on Enter when no submit key is configured', async () => {
+    const promise = startCodexSubmit()
+    await signalCodexComposerReady()
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
+
+    await expect(promise).resolves.toBe(true)
+    expect(submitWrites(ENTER_SUBMIT_INPUT)).toHaveLength(2)
+    expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(0)
+  })
+
   it('sends one retry submit input after the configured gap for agents that can eat the first submit', async () => {
+    testState.appState.settings = { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } }
+    testState.getPtyKittyKeyboardFlags.mockReturnValue(1)
     const promise = startCodexSubmit()
     await signalCodexComposerReady()
     await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS)
@@ -108,11 +127,23 @@ describe('post-paste submit retry input', () => {
     await expect(promise).resolves.toBe(true)
     expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(2)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith(
-      {},
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
       'pty-1',
       CODEX_SUBMIT_INPUT
     )
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('retries Enter when configured Codex Ctrl+Enter lacks Kitty keyboard proof', async () => {
+    testState.appState.settings = { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } }
+    const promise = startCodexSubmit()
+    await signalCodexComposerReady()
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
+
+    await expect(promise).resolves.toBe(true)
+    expect(submitWrites(ENTER_SUBMIT_INPUT)).toHaveLength(2)
+    expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(0)
+    expect(testState.getPtyKittyKeyboardFlags).toHaveBeenCalledWith('pty-1')
   })
 
   it('sends exactly one Enter for agents without a configured submit input or retry delay', async () => {
@@ -135,6 +166,8 @@ describe('post-paste submit retry input', () => {
 
   it('holds the PTY input transaction across the retry submit input', async () => {
     const writes: string[] = []
+    testState.appState.settings = { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } }
+    testState.getPtyKittyKeyboardFlags.mockReturnValue(1)
     testState.sendRuntimePtyInputVerified.mockImplementation(
       async (_settings: unknown, _ptyId: string, data: string) => {
         writes.push(data)
@@ -163,6 +196,8 @@ describe('post-paste submit retry input', () => {
   })
 
   it('keeps a successful submit successful when the retry input is rejected', async () => {
+    testState.appState.settings = { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } }
+    testState.getPtyKittyKeyboardFlags.mockReturnValue(1)
     testState.sendRuntimePtyInputVerified
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true)

--- a/src/renderer/src/lib/agent-paste-draft-submit-retry.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft-submit-retry.test.ts
@@ -56,9 +56,11 @@ const CODEX_COMPOSER_PROMPT_RENDER = '\x1b[1m›\x1b[0m Ask Codex to do anything
 const RENDER_QUIET_MS = 1500
 const ISSUE_URL = 'https://github.com/stablyai/orca/issues/123'
 const PASTED_ISSUE_URL = `\x1b[200~${ISSUE_URL}\x1b[201~`
+const ENTER_SUBMIT_INPUT = '\r'
+const CODEX_SUBMIT_INPUT = '\x1b[13;5u'
 const CODEX_SUBMIT_RETRY_DELAY_MS = TUI_AGENT_CONFIG.codex.submitRetryDelayMs ?? 0
 
-describe('post-paste submit retry Enter', () => {
+describe('post-paste submit retry input', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.stubGlobal('window', {
@@ -93,23 +95,27 @@ describe('post-paste submit retry Enter', () => {
     vi.useRealTimers()
   })
 
-  it('sends one retry Enter after the configured gap for agents that can eat the first Enter', async () => {
+  it('sends one retry submit input after the configured gap for agents that can eat the first submit', async () => {
     const promise = startCodexSubmit()
     await signalCodexComposerReady()
     await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS)
 
-    expect(enterWrites()).toHaveLength(1)
+    expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(1)
     await vi.advanceTimersByTimeAsync(CODEX_SUBMIT_RETRY_DELAY_MS - 1)
-    expect(enterWrites()).toHaveLength(1)
+    expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(1)
     await vi.advanceTimersByTimeAsync(1)
 
     await expect(promise).resolves.toBe(true)
-    expect(enterWrites()).toHaveLength(2)
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith({}, 'pty-1', '\r')
+    expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(2)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith(
+      {},
+      'pty-1',
+      CODEX_SUBMIT_INPUT
+    )
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('sends exactly one Enter for agents without a submit retry delay', async () => {
+  it('sends exactly one Enter for agents without a configured submit input or retry delay', async () => {
     const promise = pasteDraftWhenAgentReady({
       tabId: 'tab-1',
       content: ISSUE_URL,
@@ -123,11 +129,11 @@ describe('post-paste submit retry Enter', () => {
     await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
 
     await expect(promise).resolves.toBe(true)
-    expect(enterWrites()).toHaveLength(1)
+    expect(submitWrites(ENTER_SUBMIT_INPUT)).toHaveLength(1)
     expect(vi.getTimerCount()).toBe(0)
   })
 
-  it('holds the PTY input transaction across the retry Enter', async () => {
+  it('holds the PTY input transaction across the retry submit input', async () => {
     const writes: string[] = []
     testState.sendRuntimePtyInputVerified.mockImplementation(
       async (_settings: unknown, _ptyId: string, data: string) => {
@@ -146,17 +152,17 @@ describe('post-paste submit retry Enter', () => {
       'y'.repeat(AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + 1)
     )
     await flushMicrotasks(10)
-    expect(writes).toEqual([PASTED_ISSUE_URL, '\r'])
+    expect(writes).toEqual([PASTED_ISSUE_URL, CODEX_SUBMIT_INPUT])
 
     await vi.advanceTimersByTimeAsync(CODEX_SUBMIT_RETRY_DELAY_MS)
     await expect(promise).resolves.toBe(true)
     await expect(competing).resolves.toBe(true)
 
-    expect(writes.slice(0, 3)).toEqual([PASTED_ISSUE_URL, '\r', '\r'])
+    expect(writes.slice(0, 3)).toEqual([PASTED_ISSUE_URL, CODEX_SUBMIT_INPUT, CODEX_SUBMIT_INPUT])
     expect(writes.at(3)).toBe('\x1b[200~')
   })
 
-  it('keeps a successful submit successful when the retry Enter is rejected', async () => {
+  it('keeps a successful submit successful when the retry input is rejected', async () => {
     testState.sendRuntimePtyInputVerified
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true)
@@ -167,12 +173,12 @@ describe('post-paste submit retry Enter', () => {
     await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
 
     await expect(promise).resolves.toBe(true)
-    expect(enterWrites()).toHaveLength(2)
+    expect(submitWrites(CODEX_SUBMIT_INPUT)).toHaveLength(2)
   })
 })
 
-function enterWrites(): unknown[][] {
-  return testState.sendRuntimePtyInputVerified.mock.calls.filter((call) => call[2] === '\r')
+function submitWrites(input: string): unknown[][] {
+  return testState.sendRuntimePtyInputVerified.mock.calls.filter((call) => call[2] === input)
 }
 
 function startCodexSubmit(): Promise<boolean> {

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -26,6 +26,7 @@ const testState = vi.hoisted(() => ({
   subscribeToPtyData: vi.fn(),
   replayPreHandlerPtyData: vi.fn(),
   isRemoteRuntimePtyId: vi.fn(),
+  getPtyKittyKeyboardFlags: vi.fn(),
   sendRuntimePtyInputVerified: vi.fn(),
   inspectRuntimeTerminalProcess: vi.fn(),
   subscribeToRuntimeTerminalData: vi.fn()
@@ -61,12 +62,17 @@ vi.mock('@/runtime/runtime-terminal-stream', () => ({
   subscribeToRuntimeTerminalData: testState.subscribeToRuntimeTerminalData
 }))
 
+vi.mock('@/components/terminal-pane/terminal-pty-kitty-keyboard-flags', () => ({
+  getPtyKittyKeyboardFlags: testState.getPtyKittyKeyboardFlags
+}))
+
 const DECSET_BRACKETED_PASTE = '\x1b[?2004h'
 const SHOW_CURSOR = '\x1b[?25h'
 const CODEX_COMPOSER_PROMPT_RENDER = '\x1b[1m›\x1b[0m Ask Codex to do anything'
 const CODEX_DYNAMIC_COMPOSER_PROMPT_RENDER = '\x1b[?1049h\x1b[1m›\x1b[0m Implement {feature}'
 const ISSUE_URL = 'https://github.com/stablyai/orca/issues/123'
 const PASTED_ISSUE_URL = `\x1b[200~${ISSUE_URL}\x1b[201~`
+const ENTER_SUBMIT_INPUT = '\r'
 const CODEX_SUBMIT_INPUT = '\x1b[13;5u'
 const CODEX_SUBMIT_RETRY_DELAY_MS = TUI_AGENT_CONFIG.codex.submitRetryDelayMs ?? 0
 
@@ -96,6 +102,8 @@ describe('pasteDraftWhenAgentReady', () => {
     testState.replayPreHandlerPtyData.mockReset()
     testState.isRemoteRuntimePtyId.mockReset()
     testState.isRemoteRuntimePtyId.mockReturnValue(false)
+    testState.getPtyKittyKeyboardFlags.mockReset()
+    testState.getPtyKittyKeyboardFlags.mockReturnValue(0)
     testState.sendRuntimePtyInputVerified.mockReset()
     testState.sendRuntimePtyInputVerified.mockResolvedValue(true)
     testState.inspectRuntimeTerminalProcess.mockReset()
@@ -174,7 +182,7 @@ describe('pasteDraftWhenAgentReady', () => {
       2,
       {},
       'pty-1',
-      CODEX_SUBMIT_INPUT
+      ENTER_SUBMIT_INPUT
     )
     expect(testState.unsubscribe).toHaveBeenCalledTimes(1)
     expect(vi.getTimerCount()).toBe(0)
@@ -773,7 +781,8 @@ describe('pasteDraftWhenAgentReady', () => {
     )
   })
 
-  it('uses the Codex submit input for exact PTY submits', async () => {
+  it('falls back to Enter when configured Codex Ctrl+Enter has no Kitty keyboard proof', async () => {
+    testState.appState.settings = { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } }
     const promise = submitPromptToAgentPty({
       tabId: 'tab-1',
       ptyId: 'pty-1',
@@ -787,19 +796,54 @@ describe('pasteDraftWhenAgentReady', () => {
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
       1,
-      {},
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
       'pty-1',
       PASTED_ISSUE_URL
     )
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
       2,
-      {},
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
+      'pty-1',
+      ENTER_SUBMIT_INPUT
+    )
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      3,
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
+      'pty-1',
+      ENTER_SUBMIT_INPUT
+    )
+  })
+
+  it('uses configured Codex Ctrl+Enter for exact PTY submits with Kitty keyboard proof', async () => {
+    testState.appState.settings = { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } }
+    testState.getPtyKittyKeyboardFlags.mockReturnValue(1)
+    const promise = submitPromptToAgentPty({
+      tabId: 'tab-1',
+      ptyId: 'pty-1',
+      content: ISSUE_URL,
+      agent: 'codex'
+    })
+
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
+
+    await expect(promise).resolves.toBe(true)
+    expect(testState.getPtyKittyKeyboardFlags).toHaveBeenCalledWith('pty-1')
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      1,
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
+      'pty-1',
+      PASTED_ISSUE_URL
+    )
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      2,
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
       'pty-1',
       CODEX_SUBMIT_INPUT
     )
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
       3,
-      {},
+      { agentPostPasteSubmitInputs: { codex: 'ctrl-enter' } },
       'pty-1',
       CODEX_SUBMIT_INPUT
     )

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES,
   AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES,
-  AGENT_DRAFT_PASTE_MAX_BYTES,
-  chunkAgentDraftPasteContent,
   getSettingsForAgentTabRuntimeOwner,
-  iterateAgentDraftPasteContentChunks,
   pasteDraftToAgentPtyWhenReady,
   pasteDraftWhenAgentReady,
   POST_PASTE_SUBMIT_DELAY_MS,
@@ -71,6 +67,7 @@ const CODEX_COMPOSER_PROMPT_RENDER = '\x1b[1m›\x1b[0m Ask Codex to do anything
 const CODEX_DYNAMIC_COMPOSER_PROMPT_RENDER = '\x1b[?1049h\x1b[1m›\x1b[0m Implement {feature}'
 const ISSUE_URL = 'https://github.com/stablyai/orca/issues/123'
 const PASTED_ISSUE_URL = `\x1b[200~${ISSUE_URL}\x1b[201~`
+const CODEX_SUBMIT_INPUT = '\x1b[13;5u'
 const CODEX_SUBMIT_RETRY_DELAY_MS = TUI_AGENT_CONFIG.codex.submitRetryDelayMs ?? 0
 
 describe('pasteDraftWhenAgentReady', () => {
@@ -173,7 +170,12 @@ describe('pasteDraftWhenAgentReady', () => {
     )
     await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
     await expect(promise).resolves.toBe(true)
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(2, {}, 'pty-1', '\r')
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      2,
+      {},
+      'pty-1',
+      CODEX_SUBMIT_INPUT
+    )
     expect(testState.unsubscribe).toHaveBeenCalledTimes(1)
     expect(vi.getTimerCount()).toBe(0)
   })
@@ -771,151 +773,36 @@ describe('pasteDraftWhenAgentReady', () => {
     )
   })
 
-  it('streams large running-agent drafts as bounded bracketed chunks before submit', async () => {
-    const content = 'x'.repeat(
-      AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES + 7
-    )
-    const promise = sendBracketedPasteToRunningAgent({
+  it('uses the Codex submit input for exact PTY submits', async () => {
+    const promise = submitPromptToAgentPty({
+      tabId: 'tab-1',
       ptyId: 'pty-1',
-      content
+      content: ISSUE_URL,
+      agent: 'codex'
     })
 
-    await flushMicrotasks(20)
-
-    const calls = testState.sendRuntimePtyInputVerified.mock.calls
-    expect(calls.at(0)).toEqual([{}, 'pty-1', '\x1b[200~'])
-    expect(calls.at(-1)?.[2]).toBe('\x1b[201~')
-    expect(
-      calls
-        .slice(1, -1)
-        .map((call) => call[2])
-        .join('')
-    ).toBe(content)
-    for (const call of calls.slice(1, -1)) {
-      expect((call[2] as string).length).toBeLessThanOrEqual(AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES)
-    }
-
-    await vi.advanceTimersByTimeAsync(50)
+    await flushMicrotasks()
+    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
 
     await expect(promise).resolves.toBe(true)
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenLastCalledWith({}, 'pty-1', '\r')
-  })
-
-  it('normalizes multiline running-agent drafts like terminal paste', async () => {
-    const promise = sendBracketedPasteToRunningAgent({
-      ptyId: 'pty-1',
-      content: 'line one\r\nline two\nline three'
-    })
-
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith(
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      1,
       {},
       'pty-1',
-      '\x1b[200~line one\rline two\rline three\x1b[201~'
+      PASTED_ISSUE_URL
     )
-    await vi.advanceTimersByTimeAsync(50)
-    await expect(promise).resolves.toBe(true)
-  })
-
-  it('closes bracketed paste and does not submit when a chunked draft write is rejected', async () => {
-    testState.sendRuntimePtyInputVerified
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false)
-      .mockResolvedValueOnce(true)
-    const content = 'x'.repeat(
-      AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + AGENT_DRAFT_PASTE_CHUNK_MAX_BYTES + 7
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      2,
+      {},
+      'pty-1',
+      CODEX_SUBMIT_INPUT
     )
-
-    await expect(
-      sendBracketedPasteToRunningAgent({
-        ptyId: 'pty-1',
-        content
-      })
-    ).resolves.toBe(false)
-
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(3)
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(1, {}, 'pty-1', '[200~')
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(3, {}, 'pty-1', '[201~')
-    expect(testState.sendRuntimePtyInputVerified.mock.calls.some((call) => call[2] === '\r')).toBe(
-      false
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(
+      3,
+      {},
+      'pty-1',
+      CODEX_SUBMIT_INPUT
     )
-  })
-
-  it('sanitizes escape bytes inside chunked agent draft paste content', () => {
-    const chunks = chunkAgentDraftPasteContent('before\x1b[201~after😀', 6)
-
-    expect(chunks.at(0)).toBe('\x1b[200~')
-    expect(chunks.at(-1)).toBe('\x1b[201~')
-    expect(chunks.slice(1, -1).join('')).toBe('before␛[201~after😀')
-    expect(chunks.slice(1, -1).join('')).not.toContain('\x1b[201~')
-  })
-
-  it('normalizes agent draft line endings before a CRLF chunk boundary', () => {
-    const chunks = chunkAgentDraftPasteContent('abc\r\ndef\nghi', 4)
-
-    expect(chunks).toEqual(['\x1b[200~', 'abc\r', 'def\r', 'ghi', '\x1b[201~'])
-    expect(chunks.join('')).not.toContain('\n')
-  })
-
-  it('chunks escape-heavy agent draft paste without per-character string sanitizer scans', () => {
-    const content = Array.from({ length: 64 }, (_value, index) => `draft-${index}\x1b[201~`).join(
-      ''
-    )
-    const includesSpy = vi.spyOn(String.prototype, 'includes')
-    const replaceAllSpy = vi.spyOn(String.prototype, 'replaceAll')
-
-    const chunks = chunkAgentDraftPasteContent(content, 12)
-    const includesCallCount = includesSpy.mock.calls.length
-    const replaceAllCallCount = replaceAllSpy.mock.calls.length
-    includesSpy.mockRestore()
-    replaceAllSpy.mockRestore()
-
-    expect(chunks.at(0)).toBe('\x1b[200~')
-    expect(chunks.at(-1)).toBe('\x1b[201~')
-    expect(chunks.slice(1, -1).join('')).not.toContain('\x1b[201~')
-    expect(chunks.slice(1, -1).join('')).toContain('␛[201~')
-    expect(includesCallCount).toBe(0)
-    expect(replaceAllCallCount).toBe(0)
-  })
-
-  it('keeps agent draft chunk arrays aligned with lazy chunk iteration', () => {
-    const content = 'before\x1b[201~after😀'
-
-    expect(chunkAgentDraftPasteContent(content, 6)).toEqual([
-      ...iterateAgentDraftPasteContentChunks(content, 6)
-    ])
-  })
-
-  it('iterates large agent draft chunks lazily', () => {
-    const text = 'x'.repeat(128)
-    const codePointAt = vi.spyOn(String.prototype, 'codePointAt')
-    const chunks = iterateAgentDraftPasteContentChunks(text, 8)
-
-    expect(chunks.next()).toEqual({ done: false, value: '\x1b[200~' })
-    expect(chunks.next()).toEqual({ done: false, value: 'x'.repeat(8) })
-
-    expect(codePointAt.mock.calls.length).toBeLessThan(text.length)
-  })
-
-  it('yields during large accepted-size preflight before writing agent draft chunks', async () => {
-    const content = 'x'.repeat(AGENT_DRAFT_PASTE_DIRECT_MAX_BYTES + 300 * 1024)
-    const promise = sendAgentDraftPasteContent({}, 'pty-1', content)
-
-    await flushMicrotasks(5)
-    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
-
-    await vi.runOnlyPendingTimersAsync()
-    await flushMicrotasks(10)
-
-    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledWith({}, 'pty-1', '\x1b[200~')
-    await expect(promise).resolves.toBe(true)
-  })
-
-  it('rejects oversized agent drafts before any PTY write', async () => {
-    await expect(
-      sendAgentDraftPasteContent({}, 'pty-1', 'x'.repeat(AGENT_DRAFT_PASTE_MAX_BYTES + 1))
-    ).resolves.toBe(false)
-
-    expect(testState.sendRuntimePtyInputVerified).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -30,10 +30,12 @@ export {
 // Why: bracketed paste markers let modern TUIs (Claude Code / Codex / Pi /
 // OpenCode / Gemini / cursor-agent / copilot) treat the inserted text as a
 // single atomic paste instead of echoing character-by-character or triggering
-// line-edit shortcuts. Callers choose whether to append Enter after the paste.
+// line-edit shortcuts. Callers choose whether to submit after the paste.
 export const BRACKETED_PASTE_BEGIN = BRACKETED_PASTE_START
 export { BRACKETED_PASTE_END }
 export const POST_PASTE_SUBMIT_DELAY_MS = 50
+const POST_PASTE_ENTER_INPUT = '\r'
+const POST_PASTE_CTRL_ENTER_INPUT = '\x1b[13;5u'
 
 // Why: "the tab has a PTY" and "the agent's composer accepts input" are separate
 // states with separate failure modes, so they get separate budgets. A PTY that
@@ -59,7 +61,7 @@ export function getSettingsForAgentTabRuntimeOwner(
 /**
  * Wait until the agent on `tabId` has rendered its input-accepting TUI,
  * then bracketed-paste `content` into its input buffer. By default the
- * draft stays editable; `submit: true` appends Enter after the paste.
+ * draft stays editable; `submit: true` submits after the paste.
  *
  * Returns true when the paste was issued, false on timeout or missing
  * PTY. `onTimeout` lets the caller surface a UI hint (e.g. toast) when
@@ -178,20 +180,28 @@ export async function submitPromptToAgentPty(args: {
   tabId: string
   ptyId: string
   content: string
+  agent?: TuiAgent
 }): Promise<boolean> {
   return await sendBracketedPasteToAgent({
     settings: getSettingsForAgentTabRuntimeOwner(args.tabId),
     ptyId: args.ptyId,
     content: args.content,
-    submit: true
+    submit: true,
+    agent: args.agent
   })
 }
 
 export async function sendBracketedPasteToRunningAgent(args: {
   ptyId: string
   content: string
+  agent?: TuiAgent
 }): Promise<boolean> {
-  return await sendBracketedPasteToAgent({ ptyId: args.ptyId, content: args.content, submit: true })
+  return await sendBracketedPasteToAgent({
+    ptyId: args.ptyId,
+    content: args.content,
+    submit: true,
+    agent: args.agent
+  })
 }
 
 async function sendBracketedPasteToAgent(args: {
@@ -203,8 +213,9 @@ async function sendBracketedPasteToAgent(args: {
 }): Promise<boolean> {
   const { settings = useAppStore.getState().settings, ptyId, content, submit, agent } = args
   const submitRetryDelayMs = agent ? TUI_AGENT_CONFIG[agent]?.submitRetryDelayMs : undefined
+  const submitInput = resolvePostPasteSubmitInput(agent)
   try {
-    // Why: paste + Enter (+ retry Enter) must be one transaction, or a concurrent
+    // Why: paste + submit (+ retry submit) must be one transaction, or a concurrent
     // paste on this PTY can slip between them and submit a half-written prompt.
     return await runTerminalPtyInputTransaction(ptyId, async () => {
       const pasted = await sendAgentDraftPasteContentNow(settings, ptyId, content)
@@ -214,18 +225,18 @@ async function sendBracketedPasteToAgent(args: {
 
       // Why: Claude Code can leave a prompt as editable text when paste-end and
       // Enter arrive in the same PTY write. Split the submit into the next turn so
-      // the TUI processes bracketed-paste termination before handling Enter.
+      // the TUI processes bracketed-paste termination before handling submit.
       await new Promise<void>((resolve) => window.setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
-      const submitted = await sendRuntimePtyInputVerified(settings, ptyId, '\r')
+      const submitted = await sendRuntimePtyInputVerified(settings, ptyId, submitInput)
 
       if (submitRetryDelayMs !== undefined) {
-        // Why: agents that render their composer before Enter is live silently eat
-        // the first Enter; the retry is best-effort and never downgrades `submitted`.
+        // Why: agents that render their composer before submit is live silently eat
+        // the first input; the retry is best-effort and never downgrades `submitted`.
         await new Promise<void>((resolve) => window.setTimeout(resolve, submitRetryDelayMs))
         try {
-          await sendRuntimePtyInputVerified(settings, ptyId, '\r')
+          await sendRuntimePtyInputVerified(settings, ptyId, submitInput)
         } catch {
-          // Why: a rejected retry leaves the first Enter's verdict untouched.
+          // Why: a rejected retry leaves the first submit verdict untouched.
         }
       }
 
@@ -234,6 +245,12 @@ async function sendBracketedPasteToAgent(args: {
   } catch {
     return false
   }
+}
+
+function resolvePostPasteSubmitInput(agent?: TuiAgent): string {
+  return agent && TUI_AGENT_CONFIG[agent]?.postPasteSubmitInput === 'ctrl-enter'
+    ? POST_PASTE_CTRL_ENTER_INPUT
+    : POST_PASTE_ENTER_INPUT
 }
 
 function waitForAgentDraftInputReadyOnTab(args: {

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -1,8 +1,14 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+import { resolveAgentPostPasteSubmitInput } from '../../../shared/tui-agent-post-paste-submit'
+import {
+  resolveTerminalCtrlEnterInput,
+  TERMINAL_ENTER_INPUT
+} from '../../../shared/terminal-ctrl-enter-input'
 import { resolveDraftPasteReadyTimeoutMs } from '../../../shared/draft-paste-ready-timeout'
 import { useAppStore } from '@/store'
+import { getPtyKittyKeyboardFlags } from '@/components/terminal-pane/terminal-pty-kitty-keyboard-flags'
 import {
   inspectRuntimeTerminalProcess,
   sendRuntimePtyInputVerified
@@ -34,8 +40,6 @@ export {
 export const BRACKETED_PASTE_BEGIN = BRACKETED_PASTE_START
 export { BRACKETED_PASTE_END }
 export const POST_PASTE_SUBMIT_DELAY_MS = 50
-const POST_PASTE_ENTER_INPUT = '\r'
-const POST_PASTE_CTRL_ENTER_INPUT = '\x1b[13;5u'
 
 // Why: "the tab has a PTY" and "the agent's composer accepts input" are separate
 // states with separate failure modes, so they get separate budgets. A PTY that
@@ -46,13 +50,19 @@ const PTY_SPAWN_TIMEOUT_MS = 8000
 
 export function getSettingsForAgentTabRuntimeOwner(
   tabId: string
-): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined {
+):
+  | Pick<GlobalSettings, 'activeRuntimeEnvironmentId' | 'agentPostPasteSubmitInputs'>
+  | null
+  | undefined {
   const store = useAppStore.getState()
   for (const [worktreeId, tabs] of Object.entries(store.tabsByWorktree ?? {})) {
     if (tabs?.some((tab) => tab.id === tabId)) {
       // Why: legacy remote PTY ids may not embed their runtime owner. The tab's
       // worktree still identifies which host should receive readiness/send RPCs.
-      return getSettingsForWorktreeRuntimeOwner(store, worktreeId)
+      return {
+        ...getSettingsForWorktreeRuntimeOwner(store, worktreeId),
+        agentPostPasteSubmitInputs: store.settings?.agentPostPasteSubmitInputs
+      }
     }
   }
   return store.settings
@@ -205,7 +215,10 @@ export async function sendBracketedPasteToRunningAgent(args: {
 }
 
 async function sendBracketedPasteToAgent(args: {
-  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  settings?: Pick<
+    GlobalSettings,
+    'activeRuntimeEnvironmentId' | 'agentPostPasteSubmitInputs'
+  > | null
   ptyId: string
   content: string
   submit: boolean
@@ -213,7 +226,11 @@ async function sendBracketedPasteToAgent(args: {
 }): Promise<boolean> {
   const { settings = useAppStore.getState().settings, ptyId, content, submit, agent } = args
   const submitRetryDelayMs = agent ? TUI_AGENT_CONFIG[agent]?.submitRetryDelayMs : undefined
-  const submitInput = resolvePostPasteSubmitInput(agent)
+  const submitInput = resolvePostPasteSubmitSequence(
+    agent,
+    settings?.agentPostPasteSubmitInputs,
+    ptyId
+  )
   try {
     // Why: paste + submit (+ retry submit) must be one transaction, or a concurrent
     // paste on this PTY can slip between them and submit a half-written prompt.
@@ -247,10 +264,16 @@ async function sendBracketedPasteToAgent(args: {
   }
 }
 
-function resolvePostPasteSubmitInput(agent?: TuiAgent): string {
-  return agent && TUI_AGENT_CONFIG[agent]?.postPasteSubmitInput === 'ctrl-enter'
-    ? POST_PASTE_CTRL_ENTER_INPUT
-    : POST_PASTE_ENTER_INPUT
+function resolvePostPasteSubmitSequence(
+  agent: TuiAgent | undefined,
+  configuredInputs: GlobalSettings['agentPostPasteSubmitInputs'] | undefined,
+  ptyId: string
+): string {
+  const configuredInput = resolveAgentPostPasteSubmitInput(agent, configuredInputs)
+  if (configuredInput === 'ctrl-enter') {
+    return resolveTerminalCtrlEnterInput(getPtyKittyKeyboardFlags(ptyId))
+  }
+  return TERMINAL_ENTER_INPUT
 }
 
 function waitForAgentDraftInputReadyOnTab(args: {

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -20,6 +20,7 @@ import {
   normalizeTuiAgentArgsRecord,
   normalizeTuiAgentEnvRecord
 } from '../../../../shared/tui-agent-launch-defaults'
+import { normalizeAgentPostPasteSubmitInputs } from '../../../../shared/tui-agent-post-paste-submit'
 import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-context'
 import { normalizeUiLanguage } from '../../../../shared/ui-language'
 import { normalizeDesktopTerminalScrollbackRows } from '../../../../shared/terminal-scrollback-policy'
@@ -110,6 +111,11 @@ function normalizeSettingsUpdates(
   if ('agentDefaultEnv' in updates) {
     sanitizedUpdates.agentDefaultEnv = normalizeTuiAgentEnvRecord(updates.agentDefaultEnv)
     sanitizedUpdates.agentYoloDefaultsMigrated = true
+  }
+  if ('agentPostPasteSubmitInputs' in updates) {
+    sanitizedUpdates.agentPostPasteSubmitInputs = normalizeAgentPostPasteSubmitInputs(
+      updates.agentPostPasteSubmitInputs
+    )
   }
   if ('uiLanguage' in updates) {
     sanitizedUpdates.uiLanguage = normalizeUiLanguage(updates.uiLanguage)

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -203,6 +203,7 @@ export function buildDefaultSettings(args: {
     agentCmdOverrides: {},
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
+    agentPostPasteSubmitInputs: {},
     agentYoloDefaultsMigrated: true,
     agentStatusHooksEnabled: true,
     tabAutoGenerateTitle: false,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -25,6 +25,7 @@ import type { CtrlTabOrderMode } from './tab-types'
 import type { TerminalColorOverrides } from './terminal-color-overrides'
 import type { TerminalQuickCommand } from './terminal-quick-command-types'
 import type { TuiAgent } from './tui-agent'
+import type { AgentPostPasteSubmitInput } from './tui-agent-post-paste-submit'
 import type {
   AgentDashboardMode,
   BranchPrefixStrategy,
@@ -376,6 +377,8 @@ export type GlobalSettings = {
   agentDefaultArgs?: Partial<Record<TuiAgent, string>>
   /** Per-agent launch environment defaults used when yolo mode is exposed as env. */
   agentDefaultEnv?: Partial<Record<TuiAgent, Record<string, string>>>
+  /** Per-agent key Orca sends after paste-submit; missing values use Enter. */
+  agentPostPasteSubmitInputs?: Partial<Record<TuiAgent, AgentPostPasteSubmitInput>>
   /** One-shot guard for adding yolo-mode default args to untouched agent launch profiles. */
   agentYoloDefaultsMigrated?: boolean
   /** Why: disabling must persist so startup doesn't reinstall global agent hook entries the user just removed. */

--- a/src/shared/terminal-ctrl-enter-input.ts
+++ b/src/shared/terminal-ctrl-enter-input.ts
@@ -1,0 +1,8 @@
+export const TERMINAL_ENTER_INPUT = '\r'
+export const TERMINAL_CTRL_ENTER_CSI_U_INPUT = '\x1b[13;5u'
+
+export function resolveTerminalCtrlEnterInput(
+  kittyKeyboardFlags: number | null | undefined
+): string {
+  return (kittyKeyboardFlags ?? 0) > 0 ? TERMINAL_CTRL_ENTER_CSI_U_INPUT : TERMINAL_ENTER_INPUT
+}

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -15,8 +15,6 @@ export type DraftPasteReadySignal =
   | 'render-cursor-after-bracketed-paste'
   | 'grok-composer-prompt'
 
-export type AgentPostPasteSubmitInput = 'enter' | 'ctrl-enter'
-
 export type TuiAgentDetectionRuntime = NodeJS.Platform | 'wsl'
 
 export type TuiAgentConfig = {
@@ -46,8 +44,6 @@ export type TuiAgentConfig = {
   draftPasteReadyTimeoutMs?: number
   /** Delay before one extra blind submit input, for agents that render their composer before submit is live (codex). */
   submitRetryDelayMs?: number
-  /** Submit input Orca sends after a post-ready paste; defaults to plain Enter. */
-  postPasteSubmitInput?: AgentPostPasteSubmitInput
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
   windowsShiftEnterEncoding?: 'csi-u'
   /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
@@ -105,8 +101,7 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     preflightTrust: 'codex',
     draftPasteReadySignal: 'codex-composer-prompt',
     draftPasteReadyTimeoutMs: 20_000,
-    submitRetryDelayMs: 1200,
-    postPasteSubmitInput: 'ctrl-enter'
+    submitRetryDelayMs: 1200
   },
   autohand: {
     detectCmd: 'autohand',

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -15,6 +15,8 @@ export type DraftPasteReadySignal =
   | 'render-cursor-after-bracketed-paste'
   | 'grok-composer-prompt'
 
+export type AgentPostPasteSubmitInput = 'enter' | 'ctrl-enter'
+
 export type TuiAgentDetectionRuntime = NodeJS.Platform | 'wsl'
 
 export type TuiAgentConfig = {
@@ -42,8 +44,10 @@ export type TuiAgentConfig = {
   draftPasteReadySignal?: DraftPasteReadySignal
   /** Hard deadline for the agent's composer readiness signal. */
   draftPasteReadyTimeoutMs?: number
-  /** Delay before one extra blind submit Enter, for agents that render their composer before Enter is live (codex); a no-op if the first Enter landed. */
+  /** Delay before one extra blind submit input, for agents that render their composer before submit is live (codex). */
   submitRetryDelayMs?: number
+  /** Submit input Orca sends after a post-ready paste; defaults to plain Enter. */
+  postPasteSubmitInput?: AgentPostPasteSubmitInput
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
   windowsShiftEnterEncoding?: 'csi-u'
   /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
@@ -101,7 +105,8 @@ const TUI_AGENT_CONFIG_SOURCE: Record<TuiAgent, TuiAgentConfigSource> = {
     preflightTrust: 'codex',
     draftPasteReadySignal: 'codex-composer-prompt',
     draftPasteReadyTimeoutMs: 20_000,
-    submitRetryDelayMs: 1200
+    submitRetryDelayMs: 1200,
+    postPasteSubmitInput: 'ctrl-enter'
   },
   autohand: {
     detectCmd: 'autohand',

--- a/src/shared/tui-agent-post-paste-submit.ts
+++ b/src/shared/tui-agent-post-paste-submit.ts
@@ -1,0 +1,40 @@
+import { isTuiAgent } from './tui-agent-config'
+import type { TuiAgent } from './tui-agent'
+
+export type AgentPostPasteSubmitInput = 'enter' | 'ctrl-enter'
+
+function isAgentPostPasteSubmitInput(value: unknown): value is AgentPostPasteSubmitInput {
+  return value === 'enter' || value === 'ctrl-enter'
+}
+
+export function normalizeAgentPostPasteSubmitInput(
+  value: unknown
+): AgentPostPasteSubmitInput | undefined {
+  return isAgentPostPasteSubmitInput(value) ? value : undefined
+}
+
+export function normalizeAgentPostPasteSubmitInputs(
+  value: unknown
+): Partial<Record<TuiAgent, AgentPostPasteSubmitInput>> {
+  const normalized: Partial<Record<TuiAgent, AgentPostPasteSubmitInput>> = {}
+  if (!value || typeof value !== 'object') {
+    return normalized
+  }
+  for (const [agent, submitInput] of Object.entries(value)) {
+    const normalizedSubmitInput = normalizeAgentPostPasteSubmitInput(submitInput)
+    if (isTuiAgent(agent) && normalizedSubmitInput) {
+      normalized[agent] = normalizedSubmitInput
+    }
+  }
+  return normalized
+}
+
+export function resolveAgentPostPasteSubmitInput(
+  agent: TuiAgent | undefined,
+  configuredInputs: Partial<Record<TuiAgent, AgentPostPasteSubmitInput>> | null | undefined
+): AgentPostPasteSubmitInput {
+  if (agent && configuredInputs && Object.hasOwn(configuredInputs, agent)) {
+    return normalizeAgentPostPasteSubmitInput(configuredInputs[agent]) ?? 'enter'
+  }
+  return 'enter'
+}


### PR DESCRIPTION
## ELI5

When Orca pastes an Action Recipe prompt into Codex, it now keeps the normal Enter-to-submit behavior by default. If a user has configured Codex so Ctrl+Enter submits instead, Orca can be told to use Ctrl+Enter for that agent, and it only sends the special terminal bytes when the pane has proven it can understand them.

## What Changed

- Added a per-agent post-paste submit key setting, defaulting to Enter.
- Added a Settings > Agents control for choosing Enter or Ctrl+Enter per agent.
- Removed the hardcoded Codex Ctrl+Enter submit input from the agent catalog.
- Reused shared Enter / Ctrl+Enter CSI-u terminal input constants.
- Registered kitty keyboard mode trackers by PTY id so paste-submit can fall back to Enter when CSI-u is not active for the target pane.
- Reused the resolved submit input for Codex's post-paste retry path.
- Passed the automation agent id through reused-session prompt submission so reused Codex sessions follow the configured behavior.
- Updated paste/chunking tests, including bracketed-paste control sequence assertions and Ctrl+Enter fallback coverage.

## Why

Codex submit is user-configurable. The default Codex binding submits with Enter, while some users remap submit to Ctrl+Enter so Enter can insert newlines. A hardcoded Codex Ctrl+Enter fixed the remapped case but would regress default users. Keeping this as an explicit per-agent setting preserves the default and lets remapped users opt in.

The kitty fallback also avoids sending CSI-u bytes to panes that have not negotiated the keyboard protocol.

## Linked Issue

Fixes #18825

## Visual Proof

UI change present: Settings > Agents now has a `Paste-submit key` segmented control with `Enter` and `Ctrl+Enter`.

Screenshot not captured in this turn because the local `$electron` validation skill required by this repository was not available in the current Codex environment. The screenshot checklist item below is intentionally left unchecked until a follow-up run or reviewer attaches visual proof.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local checks run on the rebased branch:

- `./node_modules/.bin/vitest.CMD run --config config/vitest.config.ts src/renderer/src/lib/agent-paste-draft.test.ts src/renderer/src/lib/agent-paste-draft-submit-retry.test.ts src/renderer/src/lib/agent-draft-paste-content-chunking.test.ts src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts src/renderer/src/components/terminal-pane/terminal-pty-kitty-keyboard-flags.test.ts`
- `git diff --check origin/main...HEAD`

Notes:

- The global `pnpm` shim failed in this environment, so repository-local binaries/direct Node commands were used where possible.
- Full typecheck / changed-code quality were attempted after rebasing, but the Windows process stalled without diagnostics before completion; CI should provide the authoritative full validation.

## AI Disclosure

Implemented with ChatGPT/Codex assistance under human direction.

## Review

Ready for maintainer review. This update addresses the Pullfrog default-Codex regression, the CSI-u fallback issue, and the CodeRabbit bracketed-paste test assertion.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security impact is limited to selecting PTY input bytes after an already-authorized paste. Enter remains the default for all agents. Ctrl+Enter emits CSI-u only when configured and the target PTY has proven kitty keyboard flags; local, remote, WSL, and SSH delivery still flow through the existing PTY input path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)