### PR TITLE
test: match explorer filenames independently of git badges

### DIFF
--- a/tests/e2e/file-explorer-watch-refresh.spec.ts
+++ b/tests/e2e/file-explorer-watch-refresh.spec.ts
@@ -35,7 +35,7 @@ test('refreshes the visible tree after external Windows file changes', async ({ 
   const row = (name: string) =>
     orcaPage
       .locator('[data-file-explorer-row]')
-      .filter({ hasText: new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`) })
+      .filter({ has: orcaPage.getByText(name, { exact: true }) })
 
   rmSync(originalPath, { force: true })
   rmSync(renamedPath, { force: true })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The file watcher E2E test matches the complete file-row text with an anchored filename regex. FileExplorerRow renders a Git status badge beside the filename, so an asynchronously decorated untracked row has text such as `WATCH-REFRESH-CASE.txtU` and stops matching even when the filename is correct. Linux CI failed at the case-only rename assertion: https://github.com/stablyai/orca/actions/runs/34005529764/job/101412159700.

Find the row by its exact filename child instead. Creation, case-only rename, old-name disappearance, and deletion assertions retain their original timeouts.

Validation: targeted lint/format pass; the complete file-watcher spec will run in CI. Keep unmerged until E2E and all checks including pullfrog pass. Local Electron launches remain paused.
