### PR TITLE
fix(tests): stabilize divider viewport and pointer-capture event ordering

### DIFF
--- a/tests/e2e/terminal-pane-divider-capture-loss.spec.ts
+++ b/tests/e2e/terminal-pane-divider-capture-loss.spec.ts
@@ -148,11 +148,11 @@ test('@headful keeps resizing after the divider loses pointer capture', async ({
     }
     element.releasePointerCapture(pointerId)
   })
+  // Pending capture changes are dispatched with the next pointer event.
+  await orcaPage.mouse.move(startX + 260, startY, { steps: 10 })
   await expect
     .poll(() => divider.evaluate((element) => Number(element.dataset.captureLossCount ?? '0')))
     .toBe(1)
-
-  await orcaPage.mouse.move(startX + 260, startY, { steps: 10 })
   await orcaPage.mouse.up()
   await expect.poll(async () => gridsMatch(await readDividerGeometry(orcaPage))).toBe(true)
   const after = await readDividerGeometry(orcaPage)

--- a/tests/e2e/terminal-pane-divider-capture-loss.spec.ts
+++ b/tests/e2e/terminal-pane-divider-capture-loss.spec.ts
@@ -1,4 +1,4 @@
-import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import {
   splitActiveTerminalPane,
@@ -21,32 +21,6 @@ type DividerGeometry = {
 }
 
 test.use({ seedTestRepo: false })
-
-async function setFullscreen(electronApp: ElectronApplication, page: Page): Promise<void> {
-  await expect
-    .poll(async () => {
-      try {
-        return await electronApp.evaluate(({ BrowserWindow }) => {
-          const window = BrowserWindow.getAllWindows()[0]
-          if (!window) {
-            return false
-          }
-          if (window.isMinimized()) {
-            window.restore()
-          }
-          window.show()
-          window.focus()
-          window.setFullScreen(true)
-          return window.isFullScreen()
-        })
-      } catch {
-        return false
-      }
-    })
-    .toBe(true)
-  await expect.poll(() => page.evaluate(() => innerWidth >= 1000 && innerHeight >= 700)).toBe(true)
-  await page.waitForTimeout(1200)
-}
 
 async function addTestRepo(page: Page, repoPath: string): Promise<void> {
   const repoId = await page.evaluate(async (path) => {
@@ -122,16 +96,20 @@ function gridsMatch(geometry: DividerGeometry): boolean {
 }
 
 test('@headful keeps resizing after the divider loses pointer capture', async ({
-  electronApp,
   orcaPage,
   testRepoPath
 }, testInfo) => {
-  await setFullscreen(electronApp, orcaPage)
+  // Keep the 260px drag above the fit floor regardless of the CI display resolution.
+  await orcaPage.setViewportSize({ width: 1600, height: 1000 })
   await addTestRepo(orcaPage, testRepoPath)
   await ensureTerminalVisible(orcaPage, 30_000)
   await waitForActiveTerminalManager(orcaPage, 30_000)
   await splitActiveTerminalPane(orcaPage, 'vertical')
   await waitForPaneCount(orcaPage, 2, 30_000)
+
+  await expect
+    .poll(async () => (await readDividerGeometry(orcaPage)).second.width)
+    .toBeGreaterThan(400)
 
   const divider = orcaPage.locator('.pane-divider.is-vertical').first()
   await expect(divider).toBeVisible()


### PR DESCRIPTION
The divider capture-loss test had two environment-sensitive assumptions. Fullscreen on Linux CI left a 64px second pane after the 260px drag: it proposed six columns, below Orca’s existing eight-column fit guard. It also awaited lostpointercapture before sending the next pointer event that dispatches the pending capture change.

Use a 1600×1000 renderer viewport and assert sufficient starting pane width. Send the existing continuation drag after releasePointerCapture and then assert exactly one capture-loss event. The real browser capture release, full 260px drag, both >180px movement assertions, and exact terminal/proposed-grid equality remain intact. Native show/focus/fullscreen calls and the fixed 1.2-second sleep are removed.

Validation: CI run 34009196145 reproduced the stable 6 proposed / 9 actual column mismatch. The first viewport-only run reached the pending capture-loss wait, confirming the second race. Final full spec passed in PR CI. Run 34009848261 then passed all five repetitions (1.7m), preserving every capture-loss, movement, and grid assertion. Lint, formatting, typecheck, and PR unit checks pass; pullfrog reviewed the final commit with no new issues. No local Electron launches.