### PR TITLE
fix: preserve terminal command probes across control frames

### DIFF
--- a/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
@@ -44,7 +44,11 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
       this.queueOutputAcknowledgement(stream, frame.payload.byteLength)
       return
     }
-    stream.watchdog.recordInbound()
+    // Control frames prove transport activity, not delivery of command output.
+    stream.watchdog.recordInbound(
+      frame.opcode === TerminalStreamOpcode.Output ||
+        frame.opcode === TerminalStreamOpcode.OutputSpan
+    )
     if (frame.opcode === TerminalStreamOpcode.WriteUnavailable) {
       stream.callbacks.onWriteUnavailable?.()
       return

--- a/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-binary-controller.ts
@@ -25,38 +25,28 @@ export abstract class RemoteRuntimeTerminalBinaryController extends RemoteRuntim
       this.failConnection(new Error('Remote terminal stream received a malformed frame.'))
       return
     }
+    const isOutput =
+      frame.opcode === TerminalStreamOpcode.Output ||
+      frame.opcode === TerminalStreamOpcode.OutputSpan
     const stream = this.streams.get(frame.streamId)
     if (!stream) {
-      if (
-        frame.opcode === TerminalStreamOpcode.Output ||
-        frame.opcode === TerminalStreamOpcode.OutputSpan
-      ) {
+      if (isOutput) {
         // Why: the renderer already disposed this stream; unsubscribe releases server credit that cannot reach a parser.
         this.sendFrame(frame.streamId, TerminalStreamOpcode.Unsubscribe)
       }
       return
     }
-    if (
-      (frame.opcode === TerminalStreamOpcode.Output ||
-        frame.opcode === TerminalStreamOpcode.OutputSpan) &&
-      shouldDropE2eRemoteTerminalOutput(stream, frame.payload.byteLength)
-    ) {
+    if (isOutput && shouldDropE2eRemoteTerminalOutput(stream, frame.payload.byteLength)) {
       this.queueOutputAcknowledgement(stream, frame.payload.byteLength)
       return
     }
     // Control frames prove transport activity, not delivery of command output.
-    stream.watchdog.recordInbound(
-      frame.opcode === TerminalStreamOpcode.Output ||
-        frame.opcode === TerminalStreamOpcode.OutputSpan
-    )
+    stream.watchdog.recordInbound(isOutput)
     if (frame.opcode === TerminalStreamOpcode.WriteUnavailable) {
       stream.callbacks.onWriteUnavailable?.()
       return
     }
-    if (
-      frame.opcode === TerminalStreamOpcode.Output ||
-      frame.opcode === TerminalStreamOpcode.OutputSpan
-    ) {
+    if (isOutput) {
       this.handleOutputFrame(frame, stream)
       return
     }

--- a/src/renderer/src/runtime/remote-runtime-terminal-response-controller.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-response-controller.ts
@@ -40,7 +40,7 @@ export abstract class RemoteRuntimeTerminalResponseController extends RemoteRunt
     if (!stream) {
       return
     }
-    stream.watchdog.recordInbound()
+    stream.watchdog.recordInbound(false)
     if (event.type === 'end' && shouldHoldE2eRemoteTerminalEnd(stream.terminal)) {
       return
     }

--- a/src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts
@@ -236,60 +236,55 @@ describe('remote terminal stalled stream recovery', () => {
     stream.close()
   })
 
-  it.each([
-    undefined,
-    TerminalStreamOpcode.Resized,
-    TerminalStreamOpcode.Metadata,
-    'fit-override-changed',
-    'driver-changed',
-    'snapshot'
-  ])(
-    'recovers missing live output despite intervening control opcode %s',
-    async (controlOpcode) => {
-      const { getRemoteRuntimeTerminalMultiplexer } =
-        await import('./remote-runtime-terminal-multiplexer')
-      const onTransportClose = vi.fn()
-      const onData = vi.fn()
-      const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
-        terminal: 'term-stale-live-tail',
-        client: { id: 'mac-viewer', type: 'desktop' },
-        callbacks: { onData, onSnapshot: vi.fn(), onTransportClose }
-      })
-      emitOutput(stream.streamId, 'baseline')
-      sendBinary.mockClear()
-
-      expect(stream.sendInput('echo missing\r')).toBe(true)
-      if (controlOpcode === 'snapshot') {
-        emitSnapshot(stream.streamId, undefined, 'baseline', 8)
-      } else if (typeof controlOpcode === 'string') {
-        callbacks?.onResponse({
-          ok: true,
-          result: { type: controlOpcode, streamId: stream.streamId }
+  // Why: a control frame landing just after Enter is transport activity, not the command's answer.
+  it.each<[string, (streamId: number) => void]>([
+    ['no intervening frame', () => {}],
+    ['a resize acknowledgement', (id) => emitControlFrame(id, TerminalStreamOpcode.Resized)],
+    ['a metadata frame', (id) => emitControlFrame(id, TerminalStreamOpcode.Metadata)],
+    [
+      'a fit-override change',
+      (id) =>
+        emitStreamEvent({
+          type: 'fit-override-changed',
+          streamId: id,
+          mode: 'mobile-fit',
+          cols: 80,
+          rows: 24
         })
-      } else if (controlOpcode !== undefined) {
-        callbacks?.onBinary(
-          encodeTerminalStreamFrame({
-            opcode: controlOpcode,
-            streamId: stream.streamId,
-            seq: 0,
-            payload: encodeTerminalStreamJson({ cols: 80, rows: 24 })
-          })
-        )
-      }
-      await vi.advanceTimersByTimeAsync(REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS)
-      const request = sentFrames(TerminalStreamOpcode.SnapshotRequest)[0]
-      expect(request).toBeDefined()
-      const payload = request
-        ? decodeTerminalStreamJson<{ requestId: number }>(request.payload)
-        : null
-      emitSnapshot(stream.streamId, payload?.requestId ?? 0, 'baselinemissing', 15)
-      await vi.advanceTimersByTimeAsync(0)
+    ],
+    [
+      'a driver change',
+      (id) => emitStreamEvent({ type: 'driver-changed', streamId: id, driver: { kind: 'idle' } })
+    ],
+    ['an unsolicited snapshot', (id) => emitSnapshot(id, undefined, 'baseline', 8)]
+  ])('recovers missing live output despite %s', async (_label, emitIntervening) => {
+    const { getRemoteRuntimeTerminalMultiplexer } =
+      await import('./remote-runtime-terminal-multiplexer')
+    const onTransportClose = vi.fn()
+    const onData = vi.fn()
+    const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+      terminal: 'term-stale-live-tail',
+      client: { id: 'mac-viewer', type: 'desktop' },
+      callbacks: { onData, onSnapshot: vi.fn(), onTransportClose }
+    })
+    emitOutput(stream.streamId, 'baseline')
+    sendBinary.mockClear()
 
-      expect(onData).toHaveBeenCalledOnce()
-      expect(onTransportClose).toHaveBeenCalledWith({ recoverable: true })
-      expect(sentUnsubscribeStreamIds()).toEqual([stream.streamId])
-    }
-  )
+    expect(stream.sendInput('echo missing\r')).toBe(true)
+    emitIntervening(stream.streamId)
+    await vi.advanceTimersByTimeAsync(REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS)
+    const request = sentFrames(TerminalStreamOpcode.SnapshotRequest)[0]
+    expect(request).toBeDefined()
+    const payload = request
+      ? decodeTerminalStreamJson<{ requestId: number }>(request.payload)
+      : null
+    emitSnapshot(stream.streamId, payload?.requestId ?? 0, 'baselinemissing', 15)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onData).toHaveBeenCalledOnce()
+    expect(onTransportClose).toHaveBeenCalledWith({ recoverable: true })
+    expect(sentUnsubscribeStreamIds()).toEqual([stream.streamId])
+  })
 
   it('establishes a probe baseline before recovering an unsequenced stream', async () => {
     const { getRemoteRuntimeTerminalMultiplexer } =
@@ -471,6 +466,21 @@ describe('remote terminal stalled stream recovery', () => {
         payload: encodeTerminalStreamText(text)
       })
     )
+  }
+
+  function emitControlFrame(streamId: number, opcode: TerminalStreamOpcode): void {
+    callbacks?.onBinary(
+      encodeTerminalStreamFrame({
+        opcode,
+        streamId,
+        seq: 0,
+        payload: encodeTerminalStreamJson({ cols: 80, rows: 24 })
+      })
+    )
+  }
+
+  function emitStreamEvent(result: Record<string, unknown>): void {
+    callbacks?.onResponse({ ok: true, result })
   }
 
   function emitSnapshot(

--- a/src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-stall-recovery.test.ts
@@ -236,32 +236,60 @@ describe('remote terminal stalled stream recovery', () => {
     stream.close()
   })
 
-  it('restarts a stream when the authoritative snapshot advanced without live output', async () => {
-    const { getRemoteRuntimeTerminalMultiplexer } =
-      await import('./remote-runtime-terminal-multiplexer')
-    const onTransportClose = vi.fn()
-    const onData = vi.fn()
-    const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
-      terminal: 'term-stale-live-tail',
-      client: { id: 'mac-viewer', type: 'desktop' },
-      callbacks: { onData, onSnapshot: vi.fn(), onTransportClose }
-    })
-    emitOutput(stream.streamId, 'baseline')
-    sendBinary.mockClear()
+  it.each([
+    undefined,
+    TerminalStreamOpcode.Resized,
+    TerminalStreamOpcode.Metadata,
+    'fit-override-changed',
+    'driver-changed',
+    'snapshot'
+  ])(
+    'recovers missing live output despite intervening control opcode %s',
+    async (controlOpcode) => {
+      const { getRemoteRuntimeTerminalMultiplexer } =
+        await import('./remote-runtime-terminal-multiplexer')
+      const onTransportClose = vi.fn()
+      const onData = vi.fn()
+      const stream = await getRemoteRuntimeTerminalMultiplexer('windows-test').subscribeTerminal({
+        terminal: 'term-stale-live-tail',
+        client: { id: 'mac-viewer', type: 'desktop' },
+        callbacks: { onData, onSnapshot: vi.fn(), onTransportClose }
+      })
+      emitOutput(stream.streamId, 'baseline')
+      sendBinary.mockClear()
 
-    expect(stream.sendInput('echo missing\r')).toBe(true)
-    await vi.advanceTimersByTimeAsync(REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS)
-    const request = sentFrames(TerminalStreamOpcode.SnapshotRequest)[0]
-    const payload = request
-      ? decodeTerminalStreamJson<{ requestId: number }>(request.payload)
-      : null
-    emitSnapshot(stream.streamId, payload?.requestId ?? 0, 'baselinemissing', 15)
-    await vi.advanceTimersByTimeAsync(0)
+      expect(stream.sendInput('echo missing\r')).toBe(true)
+      if (controlOpcode === 'snapshot') {
+        emitSnapshot(stream.streamId, undefined, 'baseline', 8)
+      } else if (typeof controlOpcode === 'string') {
+        callbacks?.onResponse({
+          ok: true,
+          result: { type: controlOpcode, streamId: stream.streamId }
+        })
+      } else if (controlOpcode !== undefined) {
+        callbacks?.onBinary(
+          encodeTerminalStreamFrame({
+            opcode: controlOpcode,
+            streamId: stream.streamId,
+            seq: 0,
+            payload: encodeTerminalStreamJson({ cols: 80, rows: 24 })
+          })
+        )
+      }
+      await vi.advanceTimersByTimeAsync(REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS)
+      const request = sentFrames(TerminalStreamOpcode.SnapshotRequest)[0]
+      expect(request).toBeDefined()
+      const payload = request
+        ? decodeTerminalStreamJson<{ requestId: number }>(request.payload)
+        : null
+      emitSnapshot(stream.streamId, payload?.requestId ?? 0, 'baselinemissing', 15)
+      await vi.advanceTimersByTimeAsync(0)
 
-    expect(onData).toHaveBeenCalledOnce()
-    expect(onTransportClose).toHaveBeenCalledWith({ recoverable: true })
-    expect(sentUnsubscribeStreamIds()).toEqual([stream.streamId])
-  })
+      expect(onData).toHaveBeenCalledOnce()
+      expect(onTransportClose).toHaveBeenCalledWith({ recoverable: true })
+      expect(sentUnsubscribeStreamIds()).toEqual([stream.streamId])
+    }
+  )
 
   it('establishes a probe baseline before recovering an unsequenced stream', async () => {
     const { getRemoteRuntimeTerminalMultiplexer } =

--- a/src/renderer/src/runtime/remote-terminal-stream-watchdog.ts
+++ b/src/renderer/src/runtime/remote-terminal-stream-watchdog.ts
@@ -13,7 +13,8 @@ export type RemoteTerminalStreamWatchdog = {
   recordOutputAcknowledged: (bytes: number) => void
   completeCommandResponseProbe: () => void
   recordCommandInput: (text: string) => void
-  recordInbound: (answersCommand?: boolean) => void
+  /** Only live output answers a pending command; control frames prove transport activity alone. */
+  recordInbound: (carriesOutput: boolean) => void
   dispose: () => void
 }
 
@@ -111,9 +112,9 @@ export function createRemoteTerminalStreamWatchdog(
         REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS
       )
     },
-    recordInbound(answersCommand = true) {
+    recordInbound(carriesOutput) {
       lastInboundAtMs = Date.now()
-      if (answersCommand) {
+      if (carriesOutput) {
         clearResponseTimer()
       }
     },

--- a/src/renderer/src/runtime/remote-terminal-stream-watchdog.ts
+++ b/src/renderer/src/runtime/remote-terminal-stream-watchdog.ts
@@ -13,7 +13,7 @@ export type RemoteTerminalStreamWatchdog = {
   recordOutputAcknowledged: (bytes: number) => void
   completeCommandResponseProbe: () => void
   recordCommandInput: (text: string) => void
-  recordInbound: () => void
+  recordInbound: (answersCommand?: boolean) => void
   dispose: () => void
 }
 
@@ -111,9 +111,11 @@ export function createRemoteTerminalStreamWatchdog(
         REMOTE_TERMINAL_COMMAND_RESPONSE_TIMEOUT_MS
       )
     },
-    recordInbound() {
+    recordInbound(answersCommand = true) {
       lastInboundAtMs = Date.now()
-      clearResponseTimer()
+      if (answersCommand) {
+        clearResponseTimer()
+      }
     },
     dispose() {
       disposed = true


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

When you type a command into a terminal that is connected to another machine, Orca starts a ten-second stopwatch: if nothing comes back, it double-checks with the other machine that your command really ran. The problem was that *anything* arriving from the other machine stopped that stopwatch — including bookkeeping messages that have nothing to do with your command, like "your window was resized". So if a resize notice happened to land right after you pressed Enter, Orca thought your command had been answered and stopped watching. If the real output had been lost along the way, the terminal just sat there looking frozen: your command had actually run on the other machine, but you never saw a single line of it. Now only actual terminal output stops the stopwatch; bookkeeping messages leave it running, so Orca still checks and repairs the terminal. Nothing else about how terminals connect or run changes.

## What Changed

`recordInbound` on the remote terminal stream watchdog now takes an explicit `carriesOutput` flag:

- Transport-liveness tracking (`lastInboundAtMs`) still updates for **every** inbound frame and RPC event.
- Only `Output` / `OutputSpan` frames clear the command-response deadline.
- Control frames (`Resized`, `Metadata`, `WriteUnavailable`, snapshot frame groups, `Error`) and every RPC event (`subscribed`, `end`, `error`, `fit-override-changed`, `driver-changed`) leave the deadline armed.

The flag is a required parameter, so a future call site cannot silently disarm the probe by omitting it — that omission is the exact bug class this PR fixes.

Recovery itself is unchanged: the existing authoritative-snapshot comparison in `probeCommandResponse` still decides whether the stream is actually stale. No RPC fields, stream opcodes, host ownership, or process-liveness verdicts change.

## Why

When a paired terminal loses live output, an unrelated resize acknowledgement or snapshot arriving just after Enter cancelled the command-response watchdog. The host had processed the input and advanced its snapshot, but the client never probed and never replaced its stale stream — a permanently frozen-looking terminal with no recovery path except manual reconnect.

Transport activity and command-output delivery are two different signals; the watchdog was conflating them. Separating them is the smallest correct fix and reuses the probe/recovery machinery that already exists.

## Linked Issue

N/A — no tracking issue; found while investigating stalled remote terminals.

## Visual Proof

N/A — no rendered UI changes. This is renderer-side transport bookkeeping; the only observable difference is that a terminal which previously stayed frozen now recovers its output on its own. The before/after is a timing-dependent stall on a remote host, which a screenshot cannot distinguish from a normally idle terminal. Verified through deterministic fake-timer regressions and CI instead (see Testing).

## Tradeoffs

Genuine user-facing downsides, not "none":

- **More snapshot probes on quiet commands.** A command that produces no output for 10s while control frames arrive (a resize during `sleep 30`, a mobile fit change mid-command) now triggers one viewport snapshot request that previously would have been suppressed. Bounded: the probe snapshot uses `scrollbackRows ?? 0`, so it serializes one screen, not scrollback; and `commandResponseProbePending` allows at most one in-flight probe per command.
- **A slow host can now be restarted where it previously was not.** If the probe's snapshot request itself times out (`REMOTE_TERMINAL_SNAPSHOT_REQUEST_TIMEOUT_MS`, 10s), `recoverStalledStream` unsubscribes and reconnects the stream. On a congested SSH link this can restart a stream that was merely slow. The close is `{ recoverable: true }`, so the pane resubscribes and repaints from an authoritative snapshot — a brief re-render, not lost scrollback — but it is churn that did not happen before when a control frame masked the probe.
- **Slightly more breadcrumb volume.** Each additional trip writes a `remote_terminal_stream_stall_recovery` renderer crash breadcrumb, so stall breadcrumbs get noisier for anyone reading them.
- **Mobile/paired clients are the most exposed.** `fit-override-changed` and `driver-changed` fire on mobile fit and driver handoffs, so mobile sessions are where the extra probes will concentrate.

Mitigating the above: in normal operation the shell echoes the typed line back as real output within milliseconds, which clears the deadline before it can fire. The extra probes only materialize when live output is genuinely missing — which is precisely the case this PR exists to catch.

Explicitly checked and **not** affected: no wire/opcode/RPC-field change (old and new hosts interoperate unchanged); no host-ownership or process-liveness verdict change; no persisted state or migration; no platform-specific code; folder workspaces and git worktrees are equally unaffected. Probe leak/hang was audited — every `probeCommandResponse` path settles `commandResponseProbePending` (resolve, reject, and detached-stream), and `close()` / `end` / `recoverStalledStream` all `dispose()` the watchdog, clearing the armed timer.

## Testing

- `pnpm tc` — pass
- `pnpm test src/renderer/src/runtime/ --exclude '**/*.electron.test.ts'` — 168 files, 1321 tests, pass
- `oxlint` on all changed files — clean
- Six-case parameterized regression covering an intervening resize acknowledgement, metadata frame, fit-override change, driver change, unsolicited snapshot, and the no-control-frame baseline. Each asserts the probe still fires and the stale stream is still recovered. The resize and snapshot cases fail on `main`.
- CI run 34009727400 captured Enter followed by `Resized` and `SnapshotStart/Chunk/End` with no watchdog recovery before the fix; main-based run 34010102270 passed all five Electron repetitions (2.8m) with command output recovered and PTY identity preserved.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor.

## Review

Reviewed for correctness, probe lifetime (no leaked or hung probes), SSH/remote behavior, mobile exposure, wire compatibility, and performance. See Tradeoffs for the accepted downsides.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: no new IO, no new parsing, renderer-only. Cross-platform: no platform-dependent code. Remote SSH: this is the SSH/relay stall path — analyzed above. Mobile: no mobile-facing surface changed, but mobile clients see more probes. Backwards compatibility: no wire or persisted-state change. Performance: one extra viewport-only snapshot per silent command, bounded to one in-flight probe.

Application fix — leave open for user review; do not auto-merge.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
