### PR TITLE
fix(tests): provide a window manager for Linux Electron CI

### DIFF
--- a/.github/scripts/e2e-with-window-manager.sh
+++ b/.github/scripts/e2e-with-window-manager.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+openbox --sm-disable > /tmp/orca-e2e-window-manager.log 2>&1 &
+wm_pid=$!
+cleanup() {
+  kill "$wm_pid" 2>/dev/null || true
+  wait "$wm_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+ready=false
+for attempt in {1..100}; do
+  if xprop -root _NET_SUPPORTING_WM_CHECK 2>/dev/null | rg -q 'window id # 0x[1-9a-fA-F]'; then
+    ready=true
+    break
+  fi
+  if ! kill -0 "$wm_pid" 2>/dev/null; then
+    cat /tmp/orca-e2e-window-manager.log
+    exit 1
+  fi
+  sleep 0.1
+done
+if [ "$ready" != true ]; then
+  echo 'Window manager did not acquire the Xvfb root window' >&2
+  exit 1
+fi
+"$@"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -150,7 +150,7 @@ jobs:
       # Native cache misses need the compiler, Electron needs Xvfb, and paired
       # Quick Open needs ripgrep. Install them in one apt transaction per shard.
       - name: Install native build and headless UI tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 ripgrep xvfb zsh
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 ripgrep xvfb zsh openbox x11-utils
 
       - uses: ./.github/actions/install-node-dependencies
         with:
@@ -171,7 +171,7 @@ jobs:
       # ORCA_E2E_FORWARD_APP_LOGS keeps startup failures visible when Electron
       # launches but never creates a BrowserWindow.
       - name: Run E2E tests (${{ matrix.shard_name }})
-        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 ORCA_RELAY_PATH="$GITHUB_WORKSPACE/out/relay" pnpm run test:e2e --shard=${{ matrix.shard }}
+        run: xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 ORCA_RELAY_PATH="$GITHUB_WORKSPACE/out/relay" pnpm run test:e2e --shard=${{ matrix.shard }}
 
       # Why: Playwright retains traces/screenshots only on failure. Uploading
       # them as an artifact makes post-mortem debugging on CI possible without
@@ -205,7 +205,7 @@ jobs:
         # unbounded inventory fallback; the paired fixture exercises that real boundary.
         # Why openssh-client: the Docker-SSH fixture shells out to ssh/ssh-keygen, and this
         # lane now receives those specs from pr.yml's SSH source mapping.
-        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk openssh-client python3 ripgrep xvfb zsh
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk openssh-client python3 ripgrep xvfb zsh openbox x11-utils
 
       - uses: ./.github/actions/install-node-dependencies
         with:
@@ -245,7 +245,7 @@ jobs:
           if grep -l '@headful' "${TEST_FILES[@]}" >/dev/null; then
             E2E_PROJECT_ARGS+=(--project=electron-headful)
           fi
-          xvfb-run --auto-servernum env "${E2E_ENV[@]}" \
+          xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env "${E2E_ENV[@]}" \
             pnpm run test:e2e "${TEST_FILES[@]}" --workers=1 "${E2E_PROJECT_ARGS[@]}"
 
       - name: Upload Playwright traces
@@ -282,7 +282,7 @@ jobs:
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Install native build and headless UI tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk openssh-client python3 xvfb zsh
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk openssh-client python3 ripgrep xvfb zsh openbox x11-utils
 
       - uses: ./.github/actions/install-node-dependencies
         with:
@@ -297,7 +297,7 @@ jobs:
       # Why: this is the release-path proof that the deployed Linux relay keeps
       # its PTY and explorer live across a real watcher SIGSEGV.
       - name: Run Docker SSH watcher isolation E2E
-        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker-watcher-isolation
+        run: xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker-watcher-isolation
 
       # Why: Playwright empties test-results/ when it starts, so each step here used to
       # destroy the previous step's traces. Only the last lane's failure was ever
@@ -314,7 +314,7 @@ jobs:
       # readiness across live SSH, headed paired, and headless serve topologies.
       - name: Run Docker SSH terminal parking + startup readiness E2E
         if: always()
-        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker-terminal-parking
+        run: xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker-terminal-parking
 
       - name: Keep terminal-parking traces
         if: always()
@@ -330,7 +330,7 @@ jobs:
       # legible as an SSH-named failure.
       - name: Run remaining Docker SSH E2E
         if: always()
-        run: xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker
+        run: xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 pnpm run test:e2e:ssh-docker
 
       - name: Keep remaining-ssh-docker traces
         if: always()

--- a/tests/e2e/paired-remote-terminal-stall-recovery.spec.ts
+++ b/tests/e2e/paired-remote-terminal-stall-recovery.spec.ts
@@ -1,3 +1,4 @@
+import { runProcess } from '../../src/shared/child-process/run-process'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -101,11 +102,26 @@ async function minimizeHeadedHost(electronApp: ElectronApplication, page: Page):
     .poll(() =>
       host.evaluate((window) => ({
         backgroundThrottling: window.webContents.getBackgroundThrottling(),
-        minimized: window.isMinimized(),
-        visible: window.isVisible()
+        minimized: window.isMinimized()
       }))
     )
-    .toEqual({ backgroundThrottling: true, minimized: true, visible: false })
+    .toEqual({ backgroundThrottling: true, minimized: true })
+  // Linux reports isVisible/document visibility differently; the window manager owns iconification.
+  if (process.platform === 'linux') {
+    const nativeId = await host.evaluate((window) => window.getNativeWindowHandle().readUInt32LE(0))
+    await expect
+      .poll(async () => {
+        const result = await runProcess({
+          program: 'xprop',
+          args: ['-id', String(nativeId), '_NET_WM_STATE'],
+          timeoutMs: 5_000
+        })
+        return result.stdout
+      })
+      .toContain('_NET_WM_STATE_HIDDEN')
+  } else {
+    await expect.poll(() => page.evaluate(() => document.visibilityState)).toBe('hidden')
+  }
 }
 
 async function restoreHeadedHost(electronApp: ElectronApplication, page: Page): Promise<void> {


### PR DESCRIPTION
Xvfb provides a display but no window manager, so Electron minimize requests did not take effect in Linux CI. Start Openbox inside each Xvfb session, wait until it owns the root window, and stop it when the test command exits. Apply this to sharded, selected-spec, and Docker SSH lanes.

The paired stalled-stream test now verifies native minimization and background throttling, then checks X11’s `_NET_WM_STATE_HIDDEN` on Linux. Electron’s `isVisible()` and renderer visibility remained true after actual Linux minimization. Other platforms require renderer visibility to become hidden. Restore, publication deadlines, real ACK starvation, PTY identity, and close convergence assertions remain unchanged.

Validation: CI run 34010118868 passed the full paired stalled-stream case with the window manager confirming hidden state during both create and close. That run included pending application fixes; the main-based PR CI also passed the full case (1.1m). All PR checks and pullfrog passed before merge. Shell syntax, formatting, and targeted lint pass. All Electron runs are in CI.
