### PR TITLE
test(child-process): lower DIRECT_IMPORTER_PIN to the ground two PRs took

### DIFF
--- a/src/shared/child-process/child-process-import-boundary.test.ts
+++ b/src/shared/child-process/child-process-import-boundary.test.ts
@@ -29,7 +29,7 @@ const CHILD_PROCESS_IMPORT_ALLOWLIST: readonly string[] = readFileSync(
  * May only ever be DECREASED, and only by migrating a file off
  * `node:child_process`. Raising it is never the fix.
  */
-const DIRECT_IMPORTER_PIN = 157
+const DIRECT_IMPORTER_PIN = 156
 
 const IMPORT_PATTERN =
   /(?:from\s+['"]node:child_process['"]|from\s+['"]child_process['"]|require\(\s*['"]node:child_process['"]|require\(\s*['"]child_process['"])/


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## What broke

`main` fails `child-process-import-boundary.test.ts` right now:

```
AssertionError: Only 156 files import child_process directly.
Lower DIRECT_IMPORTER_PIN to 156 to keep the ground you just took.:
expected 156 to be greater than or equal to 157
```

## Why

#17861 migrated `src/relay/windows-port-scan.ts` off `node:child_process`. #17884 migrated `src/shared/secure-path-windows-acl.ts`. Each removed **one** importer and each independently lowered the pin `158 -> 157` on its own branch. Both were correct in isolation; landed together they took two files, so the true count is **156**.

The pin is two-sided (`toBeLessThanOrEqual` **and** `toBeGreaterThanOrEqual`), so it failed loudly rather than silently — working as designed.

## The fix

Lower the pin to 156. This **tightens** the ratchet: a pin left above reality re-opens room for the next direct import to land for free, which is what the assertion's own message says.

`UNHIDDEN_SPAWNER_PIN` is unaffected — only #17861 moved it (66 -> 65), so there was no collision there.

## Verification

Both ratchets pass at 156: `child-process-import-boundary.test.ts` and `windows-console-visibility.test.ts`, 8 tests, 2 files.