### PR TITLE
test: lower child-process import pin after ACL migration

### DIFF
--- a/src/shared/child-process/child-process-import-boundary.test.ts
+++ b/src/shared/child-process/child-process-import-boundary.test.ts
@@ -29,7 +29,7 @@ const CHILD_PROCESS_IMPORT_ALLOWLIST: readonly string[] = readFileSync(
  * May only ever be DECREASED, and only by migrating a file off
  * `node:child_process`. Raising it is never the fix.
  */
-const DIRECT_IMPORTER_PIN = 157
+const DIRECT_IMPORTER_PIN = 156
 
 const IMPORT_PATTERN =
   /(?:from\s+['"]node:child_process['"]|from\s+['"]child_process['"]|require\(\s*['"]node:child_process['"]|require\(\s*['"]child_process['"])/


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Merged #17884 moved the Windows ACL helper to `runProcess` and removed its direct-import allowlist entry, but left `DIRECT_IMPORTER_PIN` at 157. PR unit checks now fail because the actual count is 156. Lower the pin to 156 to preserve the stricter boundary.

Validation: scanned current main source imports and confirmed all 156 match the allowlist exactly. The existing boundary test reproduced the stale-pin failure in #18993 CI (job 101427154577). No runtime changes.
