### PR TITLE
test: use a valid repo filter in workspace reveal coverage

### DIFF
--- a/tests/e2e/worktree-scroll-to-current.spec.ts
+++ b/tests/e2e/worktree-scroll-to-current.spec.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from 'node:fs'
+import { runProcess } from '../../src/shared/child-process/run-process'
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
@@ -41,7 +43,42 @@ test.describe('Reveal active workspace button', () => {
   test('clears sidebar filters before revealing a hidden current workspace', async ({
     orcaPage,
     testRepoPath
-  }) => {
+  }, testInfo) => {
+    const filterRepoPath = testInfo.outputPath('filter-repo')
+    mkdirSync(filterRepoPath, { recursive: true })
+    for (const args of [
+      ['init', filterRepoPath],
+      [
+        '-C',
+        filterRepoPath,
+        '-c',
+        'user.name=E2E',
+        '-c',
+        'user.email=e2e@test.local',
+        'commit',
+        '--allow-empty',
+        '-m',
+        'Filter fixture'
+      ]
+    ]) {
+      const result = await runProcess({ program: 'git', args })
+      expect(result.code, result.stderr).toBe(0)
+    }
+    const filterRepoId = await orcaPage.evaluate(async (repoPath) => {
+      const result = await window.api.repos.add({ path: repoPath })
+      if ('error' in result) {
+        throw new Error(result.error)
+      }
+      return result.repo.id
+    }, filterRepoPath)
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(async (id) => {
+          await window.__store!.getState().fetchRepos()
+          return window.__store!.getState().repos.some((repo) => repo.id === id)
+        }, filterRepoId)
+      )
+      .toBe(true)
     await prepareSidebarForScrollTest(orcaPage)
 
     // Other specs can add worktrees to the shared repository before this test runs.
@@ -86,18 +123,11 @@ test.describe('Reveal active workspace button', () => {
     }, targetId)
     await expect(targetRow).toHaveAttribute('aria-current', 'page')
 
-    await orcaPage.evaluate(() => {
-      const store = window.__store
-      if (!store) {
-        throw new Error('window.__store is not available')
-      }
-      store.getState().setFilterRepoIds(['__filtered_repo__'])
-    })
-
-    // Why: the filter's row-hiding side effect is covered deterministically by
-    // visible-worktrees.test.ts. Asserting an empty DOM here over-specifies an
-    // incidental render-settle state that flakes under the shared page; the
-    // contract under test is that reveal clears the filter (asserted below).
+    // Catalog refreshes prune nonexistent IDs, so use a real repo to keep the filter applied.
+    await orcaPage.evaluate((repoId) => {
+      window.__store!.getState().setFilterRepoIds([repoId])
+    }, filterRepoId)
+    await expect(targetRows).toHaveCount(0)
 
     await revealButton.click()
     await orcaPage


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The reveal test selected a nonexistent repo ID to hide the active workspace. Catalog refreshes prune invalid filter IDs, so the filter could disappear before the reveal click and the expected confirmation dialog never opened.

Create a real second Git repository, wait for it to enter the catalog, and filter by its ID. Assert that the target row is absent before clicking Reveal. Preserve the confirmation, visible-row highlight, and cleared-filter assertions.

Validation: all three full-file cases passed three repetitions against main (9 passed, CI run 34012200862). Format and lint passed. No application changes or timeout increases.
