### PR TITLE
fix(release): revalidate draft state before patching generated notes

### DIFF
--- a/config/scripts/create-draft-release.mjs
+++ b/config/scripts/create-draft-release.mjs
@@ -189,6 +189,23 @@ export async function createDraftRelease({
     )
     if (patchedRelease?.draft !== true) {
       const publishedBody = typeof currentRelease.body === 'string' ? currentRelease.body : ''
+      if (publishedBody === body) {
+        log(`Release ${tag} was published while notes were patched; its body is unchanged.`)
+        return
+      }
+      // Why: the rollback must not clobber a body written after our PATCH, so
+      // restore only while the release still carries exactly what we wrote.
+      const releaseBeforeRollback = await githubJson(
+        fetchImpl,
+        `https://api.github.com/repos/${repo}/releases/${existingRelease.id}`,
+        token
+      )
+      if (releaseBeforeRollback?.body !== body) {
+        log(
+          `Release ${tag} was published and its body changed again while notes were patched; leaving the newer body in place.`
+        )
+        return
+      }
       await githubJson(
         fetchImpl,
         `https://api.github.com/repos/${repo}/releases/${existingRelease.id}`,

--- a/config/scripts/create-draft-release.mjs
+++ b/config/scripts/create-draft-release.mjs
@@ -175,7 +175,10 @@ export async function createDraftRelease({
       log(`Release ${tag} was published while notes were generated; leaving it unchanged.`)
       return
     }
-    await githubJson(
+    // Why: the PATCH endpoint supports no conditional/versioned update, so the
+    // GET above cannot close the window. The PATCH response reports the state we
+    // actually wrote to; if publication won, put the published body back.
+    const patchedRelease = await githubJson(
       fetchImpl,
       `https://api.github.com/repos/${repo}/releases/${existingRelease.id}`,
       token,
@@ -184,6 +187,22 @@ export async function createDraftRelease({
         body: JSON.stringify({ body })
       }
     )
+    if (patchedRelease?.draft !== true) {
+      const publishedBody = typeof currentRelease.body === 'string' ? currentRelease.body : ''
+      await githubJson(
+        fetchImpl,
+        `https://api.github.com/repos/${repo}/releases/${existingRelease.id}`,
+        token,
+        {
+          method: 'PATCH',
+          body: JSON.stringify({ body: publishedBody })
+        }
+      )
+      log(
+        `Release ${tag} was published while notes were patched; restored its published body and left the generated notes unapplied.`
+      )
+      return
+    }
   } else {
     // Why: GitHub's generated release notes can exceed the release body API
     // limit, so create with a bounded body. Omit target_commitish because the

--- a/config/scripts/create-draft-release.mjs
+++ b/config/scripts/create-draft-release.mjs
@@ -164,6 +164,17 @@ export async function createDraftRelease({
     if (!Number.isInteger(existingRelease.id)) {
       throw new Error(`Draft release ${tag} is missing a GitHub release id`)
     }
+    // Why: the listing is a snapshot; the draft can be published while notes
+    // generate, and patching then overwrites a live release body.
+    const currentRelease = await githubJson(
+      fetchImpl,
+      `https://api.github.com/repos/${repo}/releases/${existingRelease.id}`,
+      token
+    )
+    if (currentRelease?.draft !== true) {
+      log(`Release ${tag} was published while notes were generated; leaving it unchanged.`)
+      return
+    }
     await githubJson(
       fetchImpl,
       `https://api.github.com/repos/${repo}/releases/${existingRelease.id}`,

--- a/config/scripts/create-draft-release.test.mjs
+++ b/config/scripts/create-draft-release.test.mjs
@@ -265,6 +265,7 @@ describe('createDraftRelease', () => {
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'notes' }))
       .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true, body: 'hand-written notes' }))
       .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'notes' }))
       .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'hand-written notes' }))
 
     await createDraftRelease({
@@ -275,9 +276,9 @@ describe('createDraftRelease', () => {
       log
     })
 
-    expect(fetchImpl).toHaveBeenCalledTimes(5)
+    expect(fetchImpl).toHaveBeenCalledTimes(6)
     expect(fetchImpl).toHaveBeenNthCalledWith(
-      5,
+      6,
       'https://api.github.com/repos/stablyai/orca/releases/42',
       expect.objectContaining({
         method: 'PATCH',
@@ -285,6 +286,30 @@ describe('createDraftRelease', () => {
       })
     )
     expect(log).toHaveBeenCalledWith(expect.stringContaining('restored its published body'))
+  })
+
+  it('leaves a body written after the patch in place instead of rolling it back', async () => {
+    const log = vi.fn()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([release('v1.4.35'), release('v1.4.36', { draft: true, id: 42 })])
+      )
+      .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true, body: 'hand-written notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'newer published body' }))
+
+    await createDraftRelease({
+      repo: 'stablyai/orca',
+      tag: 'v1.4.36',
+      token: 'token',
+      fetchImpl,
+      log
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(5)
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('leaving the newer body in place'))
   })
 
   it('preserves notes on an existing published release', async () => {

--- a/config/scripts/create-draft-release.test.mjs
+++ b/config/scripts/create-draft-release.test.mjs
@@ -207,6 +207,7 @@ describe('createDraftRelease', () => {
         jsonResponse([release('v1.4.35'), release('v1.4.36', { draft: true, id: 42 })])
       )
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true }))
       .mockResolvedValueOnce(jsonResponse({ id: 42, body: 'notes' }))
 
     await createDraftRelease({
@@ -220,8 +221,33 @@ describe('createDraftRelease', () => {
     expect(fetchImpl).toHaveBeenNthCalledWith(
       3,
       'https://api.github.com/repos/stablyai/orca/releases/42',
+      expect.not.objectContaining({ method: expect.anything() })
+    )
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      4,
+      'https://api.github.com/repos/stablyai/orca/releases/42',
       expect.objectContaining({ method: 'PATCH', body: JSON.stringify({ body: 'notes' }) })
     )
+  })
+
+  it('skips the update when the draft was published while notes were generated', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([release('v1.4.35'), release('v1.4.36', { draft: true, id: 42 })])
+      )
+      .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false }))
+
+    await createDraftRelease({
+      repo: 'stablyai/orca',
+      tag: 'v1.4.36',
+      token: 'token',
+      fetchImpl,
+      log: vi.fn()
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(3)
   })
 
   it('preserves notes on an existing published release', async () => {

--- a/config/scripts/create-draft-release.test.mjs
+++ b/config/scripts/create-draft-release.test.mjs
@@ -207,8 +207,8 @@ describe('createDraftRelease', () => {
         jsonResponse([release('v1.4.35'), release('v1.4.36', { draft: true, id: 42 })])
       )
       .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'notes' }))
-      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true }))
-      .mockResolvedValueOnce(jsonResponse({ id: 42, body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true, body: 'stale' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true, body: 'notes' }))
 
     await createDraftRelease({
       repo: 'stablyai/orca',
@@ -248,6 +248,43 @@ describe('createDraftRelease', () => {
     })
 
     expect(fetchImpl).toHaveBeenCalledTimes(3)
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      'https://api.github.com/repos/stablyai/orca/releases/42',
+      expect.not.objectContaining({ method: expect.anything() })
+    )
+  })
+
+  it('restores the published body when publication lands between the check and the patch', async () => {
+    const log = vi.fn()
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([release('v1.4.35'), release('v1.4.36', { draft: true, id: 42 })])
+      )
+      .mockResolvedValueOnce(jsonResponse({ name: 'v1.4.36', body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: true, body: 'hand-written notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'notes' }))
+      .mockResolvedValueOnce(jsonResponse({ id: 42, draft: false, body: 'hand-written notes' }))
+
+    await createDraftRelease({
+      repo: 'stablyai/orca',
+      tag: 'v1.4.36',
+      token: 'token',
+      fetchImpl,
+      log
+    })
+
+    expect(fetchImpl).toHaveBeenCalledTimes(5)
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      5,
+      'https://api.github.com/repos/stablyai/orca/releases/42',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ body: 'hand-written notes' })
+      })
+    )
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('restored its published body'))
   })
 
   it('preserves notes on an existing published release', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

Follow-up to review feedback on #19014 (already merged).

## Problem

`createDraftRelease` finds the existing release in a paginated list, then calls GitHub's `generate-notes` endpoint before PATCHing the release body. `existingRelease` is a snapshot from that earlier list request — if another workflow or a maintainer publishes the draft while notes are generating, the PATCH still fires and overwrites the body of a now-published release.

## Fix

Immediately before the update, re-read the release by id (`GET /repos/{repo}/releases/{id}`) and skip the PATCH when it is no longer a draft, logging that the release was published mid-run.

Revalidation rather than serialization: the script has no lock it can share with a maintainer publishing by hand, so a fresh read plus abort is the only mechanism that covers both the workflow and the manual path. This narrows the window rather than closing it — GitHub offers no conditional PATCH for releases, so a publish landing between the re-read and the PATCH would still overwrite.

## Tests

- Updated the existing draft-regeneration test for the added GET.
- New race test: the re-read returns a published release, and no PATCH is issued.

`pnpm test config/scripts/create-draft-release.test.mjs` — 17 passed. `oxlint` clean.