### PR TITLE
Recover branch compare on visibility change

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare-refresh-triggers.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare-refresh-triggers.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+import type { GitUpstreamStatus } from '../../../../../../shared/git-status-types'
+import {
+  shouldRefreshBranchCompareForRemoteStatus,
+  shouldRefreshBranchCompareForStatusHead,
+  type BranchCompareRemoteStatusSnapshot,
+  type BranchCompareStatusHeadSnapshot
+} from './compare-summary'
+
+export function useBranchCompareRefreshTriggers({
+  activeWorktreeId,
+  worktreePath,
+  compareBaseRef,
+  isFolder,
+  isBranchVisible,
+  activeGitStatusHead,
+  remoteStatus,
+  refreshBranchCompareRef
+}: {
+  activeWorktreeId: string | null
+  worktreePath: string | null
+  compareBaseRef: string | null
+  isFolder: boolean
+  isBranchVisible: boolean
+  activeGitStatusHead: string | null
+  remoteStatus: GitUpstreamStatus | undefined
+  refreshBranchCompareRef: MutableRefObject<() => Promise<void>>
+}) {
+  const branchCompareStatusHeadRef = useRef<BranchCompareStatusHeadSnapshot | null>(null)
+  const branchCompareRemoteStatusRef = useRef<BranchCompareRemoteStatusSnapshot | null>(null)
+
+  useEffect(() => {
+    if (!activeWorktreeId || !worktreePath || !isBranchVisible || !compareBaseRef || isFolder) {
+      branchCompareStatusHeadRef.current = null
+      return
+    }
+    const current = {
+      baseRef: compareBaseRef,
+      statusHead: activeGitStatusHead,
+      worktreeId: activeWorktreeId
+    }
+    const previous = branchCompareStatusHeadRef.current
+    branchCompareStatusHeadRef.current = current
+    if (shouldRefreshBranchCompareForStatusHead(previous, current)) {
+      void refreshBranchCompareRef.current()
+    }
+  }, [
+    activeGitStatusHead,
+    activeWorktreeId,
+    compareBaseRef,
+    isBranchVisible,
+    isFolder,
+    refreshBranchCompareRef,
+    worktreePath
+  ])
+
+  useEffect(() => {
+    if (!activeWorktreeId || !worktreePath || !isBranchVisible || !compareBaseRef || isFolder) {
+      branchCompareRemoteStatusRef.current = null
+      return
+    }
+    // Why: pushing a branch can move its remote base and ahead count without changing local HEAD, which the HEAD-change effect alone misses.
+    const current = {
+      ahead: remoteStatus?.ahead ?? null,
+      baseRef: compareBaseRef,
+      behind: remoteStatus?.behind ?? null,
+      hasUpstream: remoteStatus?.hasUpstream ?? null,
+      upstreamName: remoteStatus?.upstreamName ?? null,
+      worktreeId: activeWorktreeId
+    }
+    const previous = branchCompareRemoteStatusRef.current
+    branchCompareRemoteStatusRef.current = current
+    if (shouldRefreshBranchCompareForRemoteStatus(previous, current)) {
+      void refreshBranchCompareRef.current()
+    }
+  }, [
+    activeWorktreeId,
+    compareBaseRef,
+    isBranchVisible,
+    isFolder,
+    refreshBranchCompareRef,
+    remoteStatus?.ahead,
+    remoteStatus?.behind,
+    remoteStatus?.hasUpstream,
+    remoteStatus?.upstreamName,
+    worktreePath
+  ])
+}

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare.ts
@@ -6,13 +6,8 @@ import { useAppStore } from '@/store'
 import { createLoadingBranchCompareSummary } from '@/store/slices/editor/git/branch-compare-state'
 import type { GitUpstreamStatus } from '../../../../../../shared/git-status-types'
 import { shouldClearBranchCompareForMissingBase } from './base-ref-resolution'
-import {
-  shouldRefreshBranchCompareForRemoteStatus,
-  shouldRefreshBranchCompareForStatusHead,
-  type BranchCompareRemoteStatusSnapshot,
-  type BranchCompareStatusHeadSnapshot
-} from './compare-summary'
 import { slowTaskRequiredIdleMs } from '../../coalesced-poll-runner'
+import { useBranchCompareRefreshTriggers } from './use-branch-compare-refresh-triggers'
 
 // Why: 30s poll — slow runs idle for their own duration; explicit commit/remote/manual/base-ref refreshes still run immediately.
 export const BRANCH_REFRESH_INTERVAL_MS = 30_000
@@ -56,8 +51,6 @@ export function useSourceControlBranchCompare({
   const branchComparePollEnabledRef = useRef(false)
   const branchCompareLastRunEndedAtRef = useRef(-Infinity)
   const branchCompareLastRunDurationRef = useRef(0)
-  const branchCompareStatusHeadRef = useRef<BranchCompareStatusHeadSnapshot | null>(null)
-  const branchCompareRemoteStatusRef = useRef<BranchCompareRemoteStatusSnapshot | null>(null)
 
   const runBranchCompare = useCallback(
     async (kind: BranchCompareRefreshKind) => {
@@ -143,8 +136,13 @@ export function useSourceControlBranchCompare({
       if (kind === 'recovery') {
         const summary =
           useAppStore.getState().gitBranchCompareSummaryByWorktree[activeWorktreeId ?? '']
-        // Why: reuse an in-flight result if it recovered the visible data before this rerun.
-        if (summary && summary.status !== 'loading' && summary.baseRef === compareBaseRef) {
+        // Why: reuse an in-flight result if it recovered the visible data before this rerun; a failed summary must still be retried.
+        if (
+          summary &&
+          summary.status !== 'loading' &&
+          summary.status !== 'error' &&
+          summary.baseRef === compareBaseRef
+        ) {
           scheduleBranchComparePoll()
           return
         }
@@ -221,60 +219,16 @@ export function useSourceControlBranchCompare({
     startBranchCompareRef.current = startBranchCompare
   }, [refreshBranchCompare, startBranchCompare])
 
-  useEffect(() => {
-    if (!activeWorktreeId || !worktreePath || !isBranchVisible || !compareBaseRef || isFolder) {
-      branchCompareStatusHeadRef.current = null
-      return
-    }
-    const current = {
-      baseRef: compareBaseRef,
-      statusHead: activeGitStatusHead,
-      worktreeId: activeWorktreeId
-    }
-    const previous = branchCompareStatusHeadRef.current
-    branchCompareStatusHeadRef.current = current
-    if (shouldRefreshBranchCompareForStatusHead(previous, current)) {
-      void refreshBranchCompareRef.current()
-    }
-  }, [
+  useBranchCompareRefreshTriggers({
+    activeWorktreeId,
+    worktreePath,
+    compareBaseRef,
+    isFolder,
+    isBranchVisible,
     activeGitStatusHead,
-    activeWorktreeId,
-    compareBaseRef,
-    isBranchVisible,
-    isFolder,
-    worktreePath
-  ])
-
-  useEffect(() => {
-    if (!activeWorktreeId || !worktreePath || !isBranchVisible || !compareBaseRef || isFolder) {
-      branchCompareRemoteStatusRef.current = null
-      return
-    }
-    // Why: pushing a branch can move its remote base and ahead count without changing local HEAD, which the HEAD-change effect alone misses.
-    const current = {
-      ahead: remoteStatus?.ahead ?? null,
-      baseRef: compareBaseRef,
-      behind: remoteStatus?.behind ?? null,
-      hasUpstream: remoteStatus?.hasUpstream ?? null,
-      upstreamName: remoteStatus?.upstreamName ?? null,
-      worktreeId: activeWorktreeId
-    }
-    const previous = branchCompareRemoteStatusRef.current
-    branchCompareRemoteStatusRef.current = current
-    if (shouldRefreshBranchCompareForRemoteStatus(previous, current)) {
-      void refreshBranchCompareRef.current()
-    }
-  }, [
-    activeWorktreeId,
-    compareBaseRef,
-    isBranchVisible,
-    isFolder,
-    remoteStatus?.ahead,
-    remoteStatus?.behind,
-    remoteStatus?.hasUpstream,
-    remoteStatus?.upstreamName,
-    worktreePath
-  ])
+    remoteStatus,
+    refreshBranchCompareRef
+  })
 
   useEffect(() => {
     if (!activeWorktreeId || !worktreePath || !isBranchVisible || !compareBaseRef || isFolder) {

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare.ts
@@ -14,7 +14,7 @@ export const BRANCH_REFRESH_INTERVAL_MS = 30_000
 const BRANCH_REFRESH_IDLE_MULTIPLIER = 1
 const BRANCH_REFRESH_MAX_INTERVAL_MS = 5 * 60_000
 
-type BranchCompareRefreshKind = 'immediate' | 'interval' | 'recovery'
+type BranchCompareRefreshKind = 'immediate' | 'interval'
 
 export function useSourceControlBranchCompare({
   activeRepoSettings,
@@ -43,7 +43,9 @@ export function useSourceControlBranchCompare({
   const branchCompareInFlightRef = useRef(false)
   const branchCompareRerunRef = useRef<BranchCompareRefreshKind | null>(null)
   const branchCompareRunPromiseRef = useRef<Promise<void> | null>(null)
+  const branchCompareRecoveryPendingRef = useRef(false)
   const refreshBranchCompareRef = useRef<() => Promise<void>>(async () => {})
+  const recoverBranchCompareRef = useRef<() => Promise<void>>(async () => {})
   const startBranchCompareRef = useRef<(kind: BranchCompareRefreshKind) => Promise<void>>(
     async () => {}
   )
@@ -133,20 +135,6 @@ export function useSourceControlBranchCompare({
 
   const startBranchCompare = useCallback(
     async (kind: BranchCompareRefreshKind) => {
-      if (kind === 'recovery') {
-        const summary =
-          useAppStore.getState().gitBranchCompareSummaryByWorktree[activeWorktreeId ?? '']
-        // Why: reuse an in-flight result if it recovered the visible data before this rerun; a failed summary must still be retried.
-        if (
-          summary &&
-          summary.status !== 'loading' &&
-          summary.status !== 'error' &&
-          summary.baseRef === compareBaseRef
-        ) {
-          scheduleBranchComparePoll()
-          return
-        }
-      }
       if (kind !== 'interval') {
         clearBranchComparePollTimer()
       }
@@ -185,10 +173,12 @@ export function useSourceControlBranchCompare({
           branchCompareInFlightRef.current = false
           const rerunKind = branchCompareRerunRef.current
           branchCompareRerunRef.current = null
+          const recoveryPending = branchCompareRecoveryPendingRef.current
+          branchCompareRecoveryPendingRef.current = false
           if (rerunKind === 'immediate') {
             await refreshBranchCompareRef.current()
-          } else if (rerunKind === 'recovery') {
-            await startBranchCompareRef.current('recovery')
+          } else if (recoveryPending) {
+            await recoverBranchCompareRef.current()
           } else if (rerunKind === 'interval') {
             scheduleBranchComparePoll()
           }
@@ -201,23 +191,36 @@ export function useSourceControlBranchCompare({
         }
       })
     },
-    [
-      activeWorktreeId,
-      compareBaseRef,
-      clearBranchComparePollTimer,
-      runBranchCompare,
-      scheduleBranchComparePoll
-    ]
+    [clearBranchComparePollTimer, runBranchCompare, scheduleBranchComparePoll]
   )
   const refreshBranchCompare = useCallback(
     () => startBranchCompare('immediate'),
     [startBranchCompare]
   )
+  const recoverBranchCompare = useCallback((): Promise<void> => {
+    const summary = useAppStore.getState().gitBranchCompareSummaryByWorktree[activeWorktreeId ?? '']
+    // Why: an in-flight result may recover visible data; loading, missing, changed-base, and failed results retry immediately.
+    if (
+      summary &&
+      summary.status !== 'loading' &&
+      summary.status !== 'error' &&
+      summary.baseRef === compareBaseRef
+    ) {
+      scheduleBranchComparePoll()
+      return Promise.resolve()
+    }
+    if (branchCompareInFlightRef.current) {
+      branchCompareRecoveryPendingRef.current = true
+      return branchCompareRunPromiseRef.current ?? Promise.resolve()
+    }
+    return refreshBranchCompareRef.current()
+  }, [activeWorktreeId, compareBaseRef, scheduleBranchComparePoll])
   // Why: publish in an effect, not the render body — a discarded render must not install its callback. Declared first so the effects below see the fresh one.
   useEffect(() => {
     refreshBranchCompareRef.current = refreshBranchCompare
+    recoverBranchCompareRef.current = recoverBranchCompare
     startBranchCompareRef.current = startBranchCompare
-  }, [refreshBranchCompare, startBranchCompare])
+  }, [recoverBranchCompare, refreshBranchCompare, startBranchCompare])
 
   useBranchCompareRefreshTriggers({
     activeWorktreeId,
@@ -238,7 +241,7 @@ export function useSourceControlBranchCompare({
     branchComparePollEnabledRef.current = true
     const stopInterval = installWindowVisibilityInterval({
       run: () => void startBranchCompareRef.current('interval'),
-      runOnVisible: () => void startBranchCompareRef.current('recovery'),
+      runOnVisible: () => void recoverBranchCompareRef.current(),
       jitterOnVisible: true,
       intervalMs: BRANCH_REFRESH_INTERVAL_MS
     })

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-compare.ts
@@ -3,6 +3,7 @@ import { installWindowVisibilityInterval } from '@/lib/window-visibility-interva
 import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeGitBranchCompare, type RuntimeGitContext } from '@/runtime/runtime-git-client'
 import { useAppStore } from '@/store'
+import { createLoadingBranchCompareSummary } from '@/store/slices/editor/git/branch-compare-state'
 import type { GitUpstreamStatus } from '../../../../../../shared/git-status-types'
 import { shouldClearBranchCompareForMissingBase } from './base-ref-resolution'
 import {
@@ -18,7 +19,7 @@ export const BRANCH_REFRESH_INTERVAL_MS = 30_000
 const BRANCH_REFRESH_IDLE_MULTIPLIER = 1
 const BRANCH_REFRESH_MAX_INTERVAL_MS = 5 * 60_000
 
-type BranchCompareRefreshKind = 'immediate' | 'interval'
+type BranchCompareRefreshKind = 'immediate' | 'interval' | 'recovery'
 
 export function useSourceControlBranchCompare({
   activeRepoSettings,
@@ -40,10 +41,7 @@ export function useSourceControlBranchCompare({
   isBranchVisible: boolean
   activeGitStatusHead: string | null
   remoteStatus: GitUpstreamStatus | undefined
-}): {
-  refreshBranchCompare: () => Promise<void>
-  refreshBranchCompareRef: React.RefObject<() => Promise<void>>
-} {
+}) {
   const beginGitBranchCompareRequest = useAppStore((s) => s.beginGitBranchCompareRequest)
   const setGitBranchCompareResult = useAppStore((s) => s.setGitBranchCompareResult)
   const clearGitBranchCompare = useAppStore((s) => s.clearGitBranchCompare)
@@ -67,27 +65,19 @@ export function useSourceControlBranchCompare({
         return
       }
       const requestKey = `${activeWorktreeId}:${compareBaseRef}:${Date.now()}`
-      const existingSummary =
-        useAppStore.getState().gitBranchCompareSummaryByWorktree[activeWorktreeId]
-      // Why: only reset to 'loading' on the first request or a base-ref change; resetting on every poll caused a visible loading→error→loading flicker.
-      const baseRefChanged = existingSummary && existingSummary.baseRef !== compareBaseRef
-      const shouldResetToLoading = !existingSummary || baseRefChanged
-      if (shouldResetToLoading) {
-        beginGitBranchCompareRequest(activeWorktreeId, requestKey, compareBaseRef)
-      } else {
-        beginGitBranchCompareRequest(activeWorktreeId, requestKey, compareBaseRef, {
-          preserveExistingSummary: true
-        })
-      }
+      const summary = useAppStore.getState().gitBranchCompareSummaryByWorktree[activeWorktreeId]
+      // Why: polling should preserve results unless the comparison base changed.
+      beginGitBranchCompareRequest(activeWorktreeId, requestKey, compareBaseRef, {
+        preserveExistingSummary: !!summary && summary.baseRef === compareBaseRef
+      })
       try {
-        const connectionId = getConnectionId(activeWorktreeId) ?? undefined
         const result = await getRuntimeGitBranchCompare(
           {
             // Why: route the branch compare by the repo OWNER host, not the focused runtime.
             settings: activeRepoSettings,
             worktreeId: activeWorktreeId,
             worktreePath,
-            connectionId
+            connectionId: getConnectionId(activeWorktreeId) ?? undefined
           },
           compareBaseRef,
           kind === 'interval' ? 'background' : 'interactive'
@@ -96,12 +86,8 @@ export function useSourceControlBranchCompare({
       } catch (error) {
         setGitBranchCompareResult(activeWorktreeId, requestKey, {
           summary: {
-            baseRef: compareBaseRef,
-            baseOid: null,
+            ...createLoadingBranchCompareSummary(compareBaseRef),
             compareRef: branchName,
-            headOid: null,
-            mergeBase: null,
-            changedFiles: 0,
             status: 'error',
             errorMessage: error instanceof Error ? error.message : 'Branch compare failed'
           },
@@ -154,11 +140,23 @@ export function useSourceControlBranchCompare({
 
   const startBranchCompare = useCallback(
     async (kind: BranchCompareRefreshKind) => {
-      if (kind === 'immediate') {
+      if (kind === 'recovery') {
+        const summary =
+          useAppStore.getState().gitBranchCompareSummaryByWorktree[activeWorktreeId ?? '']
+        // Why: reuse an in-flight result if it recovered the visible data before this rerun.
+        if (summary && summary.status !== 'loading' && summary.baseRef === compareBaseRef) {
+          scheduleBranchComparePoll()
+          return
+        }
+      }
+      if (kind !== 'interval') {
         clearBranchComparePollTimer()
       }
       if (branchCompareInFlightRef.current) {
-        if (kind === 'immediate' || branchCompareRerunRef.current === null) {
+        if (
+          branchCompareRerunRef.current !== 'immediate' &&
+          (kind !== 'interval' || branchCompareRerunRef.current === null)
+        ) {
           branchCompareRerunRef.current = kind
         }
         return branchCompareRunPromiseRef.current ?? undefined
@@ -191,21 +189,27 @@ export function useSourceControlBranchCompare({
           branchCompareRerunRef.current = null
           if (rerunKind === 'immediate') {
             await refreshBranchCompareRef.current()
+          } else if (rerunKind === 'recovery') {
+            await startBranchCompareRef.current('recovery')
           } else if (rerunKind === 'interval') {
             scheduleBranchComparePoll()
           }
         }
       })()
       branchCompareRunPromiseRef.current = runPromise
-      try {
-        await runPromise
-      } finally {
+      await runPromise.finally(() => {
         if (branchCompareRunPromiseRef.current === runPromise) {
           branchCompareRunPromiseRef.current = null
         }
-      }
+      })
     },
-    [clearBranchComparePollTimer, runBranchCompare, scheduleBranchComparePoll]
+    [
+      activeWorktreeId,
+      compareBaseRef,
+      clearBranchComparePollTimer,
+      runBranchCompare,
+      scheduleBranchComparePoll
+    ]
   )
   const refreshBranchCompare = useCallback(
     () => startBranchCompare('immediate'),
@@ -280,6 +284,7 @@ export function useSourceControlBranchCompare({
     branchComparePollEnabledRef.current = true
     const stopInterval = installWindowVisibilityInterval({
       run: () => void startBranchCompareRef.current('interval'),
+      runOnVisible: () => void startBranchCompareRef.current('recovery'),
       jitterOnVisible: true,
       intervalMs: BRANCH_REFRESH_INTERVAL_MS
     })

--- a/src/renderer/src/components/right-sidebar/use-source-control-branch-compare.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-source-control-branch-compare.test.tsx
@@ -372,7 +372,7 @@ describe('useSourceControlBranchCompare scheduler', () => {
 })
 
 describe('branch comparison visibility recovery', () => {
-  it.each(['loading', 'missing', 'base-change'])(
+  it.each(['loading', 'missing', 'base-change', 'error'])(
     'bypasses slow polling backoff for %s data',
     async (reason) => {
       vi.useFakeTimers()
@@ -389,7 +389,10 @@ describe('branch comparison visibility recovery', () => {
         reason === 'missing'
           ? {}
           : {
-              A: { baseRef: 'origin/main', status: reason === 'loading' ? 'loading' : 'ready' }
+              A: {
+                baseRef: 'origin/main',
+                status: reason === 'loading' ? 'loading' : reason === 'error' ? 'error' : 'ready'
+              }
             }
       await act(async () => {
         root.render(

--- a/src/renderer/src/components/right-sidebar/use-source-control-branch-compare.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-source-control-branch-compare.test.tsx
@@ -9,7 +9,10 @@ const mocks = vi.hoisted(() => ({
   beginGitBranchCompareRequest: vi.fn(),
   setGitBranchCompareResult: vi.fn(),
   clearGitBranchCompare: vi.fn(),
-  gitBranchCompareSummaryByWorktree: {} as Record<string, { baseRef: string } | undefined>
+  gitBranchCompareSummaryByWorktree: {} as Record<
+    string,
+    { baseRef: string; status?: string } | undefined
+  >
 }))
 
 vi.mock('@/runtime/runtime-git-client', () => ({
@@ -235,6 +238,9 @@ describe('useSourceControlBranchCompare scheduler', () => {
     vi.useFakeTimers()
     const first = deferred<typeof OK>()
     mocks.getRuntimeGitBranchCompare.mockReturnValueOnce(first.promise)
+    mocks.gitBranchCompareSummaryByWorktree = {
+      A: { baseRef: 'origin/main', status: 'ready' }
+    }
     // Visible mounts run once immediately through the visibility interval.
     await mount({ isBranchVisible: true })
     expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(1)
@@ -296,7 +302,8 @@ describe('useSourceControlBranchCompare scheduler', () => {
     expect(mocks.beginGitBranchCompareRequest).toHaveBeenLastCalledWith(
       'A',
       expect.any(String),
-      'origin/dev'
+      'origin/dev',
+      { preserveExistingSummary: false }
     )
   })
 
@@ -362,4 +369,133 @@ describe('useSourceControlBranchCompare scheduler', () => {
     await flush()
     expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(2)
   })
+})
+
+describe('branch comparison visibility recovery', () => {
+  it.each(['loading', 'missing', 'base-change'])(
+    'bypasses slow polling backoff for %s data',
+    async (reason) => {
+      vi.useFakeTimers()
+      const first = deferred<typeof OK>()
+      mocks.getRuntimeGitBranchCompare.mockReturnValueOnce(first.promise)
+      const root = await mount({ isBranchVisible: true, statusHead: 'head-1' })
+      await act(async () => {
+        root.render(<Probe isBranchVisible={false} statusHead="head-1" />)
+        await vi.advanceTimersByTimeAsync(90_000)
+        first.resolve(OK)
+      })
+      await flush()
+      mocks.gitBranchCompareSummaryByWorktree =
+        reason === 'missing'
+          ? {}
+          : {
+              A: { baseRef: 'origin/main', status: reason === 'loading' ? 'loading' : 'ready' }
+            }
+      await act(async () => {
+        root.render(
+          <Probe
+            isBranchVisible
+            statusHead="head-2"
+            compareBaseRef={reason === 'base-change' ? 'origin/dev' : 'origin/main'}
+          />
+        )
+      })
+      await flush()
+      expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(2)
+      expect(mocks.getRuntimeGitBranchCompare).toHaveBeenLastCalledWith(
+        expect.objectContaining({ worktreeId: 'A' }),
+        reason === 'base-change' ? 'origin/dev' : 'origin/main',
+        'interactive'
+      )
+    }
+  )
+
+  it('preserves slow polling backoff when reopening valid data', async () => {
+    vi.useFakeTimers()
+    const first = deferred<typeof OK>()
+    mocks.getRuntimeGitBranchCompare.mockReturnValueOnce(first.promise)
+    const root = await mount({ isBranchVisible: true, statusHead: 'head-1' })
+    await act(async () => {
+      root.render(<Probe isBranchVisible={false} statusHead="head-1" />)
+      await vi.advanceTimersByTimeAsync(90_000)
+      first.resolve(OK)
+    })
+    await flush()
+    mocks.gitBranchCompareSummaryByWorktree = {
+      A: { baseRef: 'origin/main', status: 'ready' }
+    }
+    await act(async () => {
+      root.render(<Probe isBranchVisible statusHead="head-1" />)
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(89_999)
+    })
+    expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
+    expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(2)
+    expect(mocks.getRuntimeGitBranchCompare).toHaveBeenLastCalledWith(
+      expect.objectContaining({ worktreeId: 'A' }),
+      'origin/main',
+      'background'
+    )
+  })
+
+  it('coalesces rapid stale reopenings behind a slow request', async () => {
+    const first = deferred<typeof OK>()
+    mocks.getRuntimeGitBranchCompare.mockReturnValueOnce(first.promise)
+    const root = await mount({ isBranchVisible: true, statusHead: 'head-1' })
+    mocks.gitBranchCompareSummaryByWorktree = {
+      A: { baseRef: 'origin/main', status: 'loading' }
+    }
+    for (let i = 0; i < 5; i++) {
+      await act(async () => {
+        root.render(<Probe isBranchVisible={false} statusHead="head-2" />)
+      })
+      await act(async () => {
+        root.render(<Probe isBranchVisible statusHead="head-2" />)
+      })
+    }
+    expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      first.resolve(OK)
+    })
+    await flush()
+    expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(2)
+  })
+})
+
+it('reuses a recovered in-flight result after reopening instead of immediately comparing twice', async () => {
+  vi.useFakeTimers()
+  const first = deferred<typeof OK>()
+  mocks.getRuntimeGitBranchCompare.mockReturnValueOnce(first.promise)
+  const root = await mount({ isBranchVisible: true, statusHead: 'head-1' })
+  mocks.gitBranchCompareSummaryByWorktree = {
+    A: { baseRef: 'origin/main', status: 'loading' }
+  }
+  await act(async () => {
+    root.render(<Probe isBranchVisible={false} statusHead="head-1" />)
+  })
+  await act(async () => {
+    root.render(<Probe isBranchVisible statusHead="head-1" />)
+  })
+  mocks.setGitBranchCompareResult.mockImplementation(() => {
+    mocks.gitBranchCompareSummaryByWorktree = {
+      A: { baseRef: 'origin/main', status: 'ready' }
+    }
+  })
+  await act(async () => {
+    first.resolve(OK)
+  })
+  await flush()
+  expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(1)
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(BRANCH_REFRESH_INTERVAL_MS - 1)
+  })
+  expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(1)
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(1)
+  })
+  expect(mocks.getRuntimeGitBranchCompare).toHaveBeenCalledTimes(2)
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​138 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​88 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 |

<!-- /orca-pr-loc -->

## Problem

When the window loses visibility during operations like rebasing, branch comparison polling pauses. Upon returning to the window, stale comparison data remains cached and doesn't refresh immediately, leaving the user viewing outdated information about commits ahead/behind.

## Solution

Add a 'recovery' refresh kind triggered when window visibility returns. The hook checks if cached comparison data exists and is valid (status is not 'loading' and baseRef matches). If valid, reuse the result and preserve polling backoff. If data is missing, loading, or the base changed, fetch immediately to reflect current state.

## ELI5

When you switch away from and back to a window, the branch compare now quickly checks if it needs fresh data or can reuse what's cached, instead of waiting for the next polling interval.

## What Changed

Added 'recovery' refresh kind to distinguish immediate reruns triggered by window visibility return from normal polling intervals. Window visibility callback now uses `runOnVisible` to trigger recovery refresh, which reuses valid cached results with preserved polling or fetches immediately for missing/loading/changed data. Simplified request logic to always compute `preserveExistingSummary` based on current data validity.

## Why

Rebasing and other long operations cause branch compare data to become stale while the window is hidden. Without immediate recovery on return, users see outdated diff information. The recovery mechanism balances responsiveness (fetch immediately for stale/missing data) with efficiency (preserve polling intervals for valid data).

## Linked Issue

Fixes #

## Visual Proof

N/A – internal state management change with no visual output change

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below
  - Added comprehensive test suite for visibility recovery: missing data, loading state, base ref changes, rapid toggles
  - Tests verify fast refresh on stale/missing data and polling backoff preservation for valid data
  - Tests confirm coalescing of rapid visibility toggles behind a single in-flight request

## AI Disclosure

<!-- DO NOT FILL IN IF YOU ARE STABLYAI TEAM MEMBER (INTERNAL CONTRIBUTOR), IGNORE SECTION: -->
<!-- Which AI model if anyone was used, please state the details -->

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)