### PR TITLE
fix: keep paired tab updates live after runtime terminal fallback

### DIFF
--- a/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
@@ -120,7 +120,7 @@ export class OrcaRuntimeWithCreateRuntimeOwnedMobileSessionTerminal extends Orca
     }
     const next: RuntimeMobileSessionTabsSnapshot = {
       worktree: worktreeId,
-      // A fallback adds a surface without retiring the renderer that will publish its next tabs.
+      // Why: a fresh epoch retires the current publisher, so clients drop its later tab updates.
       publicationEpoch: existing?.publicationEpoch ?? `headless:${Date.now().toString(36)}`,
       snapshotVersion: (existing?.snapshotVersion ?? 0) + 1,
       // Why: activating the new tab also focuses its group, so a "+" targeting a specific split group makes that group active too.

--- a/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts
@@ -120,7 +120,8 @@ export class OrcaRuntimeWithCreateRuntimeOwnedMobileSessionTerminal extends Orca
     }
     const next: RuntimeMobileSessionTabsSnapshot = {
       worktree: worktreeId,
-      publicationEpoch: `headless:${Date.now().toString(36)}`,
+      // A fallback adds a surface without retiring the renderer that will publish its next tabs.
+      publicationEpoch: existing?.publicationEpoch ?? `headless:${Date.now().toString(36)}`,
       snapshotVersion: (existing?.snapshotVersion ?? 0) + 1,
       // Why: activating the new tab also focuses its group, so a "+" targeting a specific split group makes that group active too.
       activeGroupId:

--- a/src/main/runtime/runtime-owned-terminal-publication-lineage.test.ts
+++ b/src/main/runtime/runtime-owned-terminal-publication-lineage.test.ts
@@ -1,0 +1,57 @@
+import { expect, it, vi } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../shared/runtime-types'
+
+await import('./orca-runtime-test-mocks.spec')
+await import('./orca-runtime-test-lifecycle.spec')
+const { OrcaRuntimeService } = await import('./orca-runtime-test-mocks.spec')
+const { store, TEST_WORKTREE_ID } = await import('./orca-runtime-test-fixtures.spec')
+
+it.each(['renderer:active-generation', 'headless:active-generation'])(
+  'keeps %s live when runtime-owned creation supplements its inventory',
+  async (publicationEpoch) => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-runtime-fallback' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    runtime.syncWindowGraph(0, {
+      tabs: [],
+      leaves: [],
+      mobileSessionTabs: [
+        {
+          worktree: TEST_WORKTREE_ID,
+          publicationEpoch,
+          snapshotVersion: 7,
+          activeGroupId: null,
+          activeTabId: null,
+          activeTabType: null,
+          tabs: []
+        }
+      ]
+    })
+    const events: RuntimeMobileSessionTabsResult[] = []
+    const unsubscribe = runtime.onMobileSessionTabsChanged(
+      (snapshot) => events.push(snapshot),
+      'paired-client'
+    )
+    try {
+      const created = await runtime.createMobileSessionTerminal(`id:${TEST_WORKTREE_ID}`, {
+        activate: false,
+        select: false,
+        navigation: 'caller',
+        clientNavigationId: 'paired-client'
+      })
+      expect(created.tab.status).toBe('ready')
+      expect(created.publicationEpoch).toBe(publicationEpoch)
+      expect(created.snapshotVersion).toBeGreaterThan(7)
+      expect(events.at(-1)).toMatchObject({
+        publicationEpoch: `${publicationEpoch}:client-navigation`,
+        tabs: [expect.objectContaining({ id: created.tab.id, status: 'ready' })]
+      })
+    } finally {
+      unsubscribe()
+    }
+  }
+)

--- a/src/main/runtime/runtime-owned-terminal-publication-lineage.test.ts
+++ b/src/main/runtime/runtime-owned-terminal-publication-lineage.test.ts
@@ -1,9 +1,9 @@
 import { expect, it, vi } from 'vitest'
 import type { RuntimeMobileSessionTabsResult } from '../../shared/runtime-types'
 
-await import('./orca-runtime-test-mocks.spec')
-await import('./orca-runtime-test-lifecycle.spec')
+// Fragments stay side-effect ordered: mocks, then lifecycle, then fixtures.
 const { OrcaRuntimeService } = await import('./orca-runtime-test-mocks.spec')
+await import('./orca-runtime-test-lifecycle.spec')
 const { store, TEST_WORKTREE_ID } = await import('./orca-runtime-test-fixtures.spec')
 
 it.each(['renderer:active-generation', 'headless:active-generation'])(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

Orca lets you watch the same workspace from two places at once — say the desktop app and a phone or browser tab. The desktop app is normally the one that announces "here are the terminals in this workspace," and the phone just listens.

When you asked for a new terminal and the desktop app couldn't make it itself, Orca quietly made one on the server instead. But in doing so it also announced itself as a *brand new* narrator. The phone took that literally: it assumed the old narrator had gone away for good and stopped listening to it. So the desktop kept announcing new terminals and the phone ignored every one of them — it sat frozen showing three terminals while the server had seven.

Now the server-made terminal simply joins the existing announcement instead of starting a new one. The original narrator stays trusted, the phone keeps listening, and your terminal list stays correct and live.

## What Changed

One line in `src/main/runtime/orca-runtime-create-runtime-owned-mobile-session-terminal.ts`: when a runtime-owned (fallback) terminal is added to a workspace that already has a published snapshot, the snapshot keeps the existing `publicationEpoch` instead of minting a fresh `headless:<ts>` one. A fresh epoch is still minted for the first publication, when there is nothing to inherit. `snapshotVersion` still advances, so ordering is unchanged.

This matches the convention two sibling publishers already use:

- `orca-runtime-publish-pty-backed-mobile-session-terminal.ts:131` — `existing?.publicationEpoch ?? \`headless:pty-backed:…\``
- `orca-runtime-restore-structured-agent-session-tabs-once.ts:139` — `existing?.publicationEpoch ?? \`structured:…\``

## Why

`publicationEpoch` identifies the *publisher generation*, not the content. Clients treat a change of epoch as "the previous publisher was retired": `src/renderer/src/runtime/web-session-tabs-sync/tracking-decisions.ts` records the old epoch in a retired set, and every later frame carrying it is dropped as `WEB_SESSION_TABS_FRAME_OUTRANKED`.

So the old code had a fallback terminal creation — an *additive* event — declare the live renderer retired. The renderer went on publishing under its own epoch, and the paired client discarded all of it. CI reproduced a client pinned at three tabs while the host published seven; raw subscription logs confirm the later frames did arrive and were dropped.

Applies to native, SSH, and folder-workspace terminal creation, since all three share this fallback path.

## Tradeoffs

Real, user-facing consequences of the change — not "none":

- **Preservation is now narrower for the fallback tab.** With an inherited `renderer:` epoch, the snapshot is no longer classified as "headless-built" by `isHeadlessBuiltMobileSessionPublicationBase`, so the blanket *preserve-every-terminal* arm in `orca-runtime-stored-mobile-snapshot-has-stale-preserved-tab.ts:91` no longer applies. The runtime-owned tab now survives a renderer republish only through its persisted serve/SSH binding. The create path does pass `persistHostSessionBinding: true`, and `graph-sync-live-daemon-pty-tab-preservation.test.ts` covers exactly this under a `renderer:` epoch — but it is a narrower guarantee than a blanket one.
- **A previously dead code path is now live.** `releaseRuntimeSessionOwnershipForRendererRetiredTabs` used to early-return on a `headless:` epoch. After a fallback create it now runs, and can release runtime session ownership for a runtime-owned terminal the renderer has dropped from its persisted session. That is the intended semantic (the old behaviour leaked ownership), but it is newly reachable.
- **Freshness now depends solely on the version bump.** `advancesSessionTabsFreshness` counted any epoch change as inherently fresh. The fallback create no longer changes the epoch, so it relies entirely on `snapshotVersion` advancing. A publisher that ever failed to advance the version would now be silently dropped instead of accepted.
- **PTY resolution is slightly looser for this snapshot.** `runtime-mobile-session-projection.ts:85` sets `allowWorktreeOnlyMatch` from `!publicationEpoch.startsWith('headless')`, so it flips `false → true` here. This is still keyed on the exact `snapshotPtyId`; it only additionally tolerates a PTY not yet stamped with a pane identity, and the `claimedLivePtyIds` guard still prevents two tabs sharing a handle.
- **Regression surface** is concentrated on paired/mobile clients and on `orca terminal create` against a host with a live renderer.
- **No** added latency, publications, or wire traffic: the frame count, shape, and ordering are unchanged — only the value of one existing string field differs.

## Linked Issue

Fixes # <!-- no tracked issue; found via CI reproduction of the paired parked-reveal E2E scenario -->

## Visual Proof

N/A — no rendered UI change. The fix is in host-side publication bookkeeping; the visible symptom (a paired client's tab strip going stale) is a multi-device, timing-dependent sync failure that a screenshot of a single window cannot demonstrate. It is covered instead by the two regression cases and by the paired parked-reveal E2E scenario. Per this repo's current AGENTS.md directive, local Electron launches are paused, so no local app launch was used.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally — local Electron launches are paused for this work; validated in CI instead.

Automated:

- `src/main/runtime/runtime-owned-terminal-publication-lineage.test.ts` (new) parameterises over a `renderer:` and a `headless:` epoch and asserts the epoch is inherited, `snapshotVersion` advances, and the paired client receives `<epoch>:client-navigation`.
- Verified the test genuinely catches the bug: reverting the one-line fix fails both cases (`expected 'headless:mtqbjzj4' to be 'renderer:active-generation'`); restoring it passes.
- `src/main/runtime/graph-sync-live-daemon-pty-tab-preservation.test.ts` re-run to confirm the narrowed preservation path still holds.
- `pnpm tc:node`, `oxlint` on both changed files, and the full sharded `test` job in CI all pass.
- CI run 34013835405 passed three repetitions of the paired parked-reveal E2E scenario; nine scenario probes verified restored output, live input/rendering, and matching pane/PTY geometry, including reconnect while parked.

## Notes

Remote wire (`docs/reference/remote-wire-compatibility.md`): this is a **Rule 3** change — the frame shape is untouched, but the host publishes a different *value* for an existing field, which reaches old clients. It is safe because no client branches on `renderer:` vs `headless:`; client-side epoch handling only special-cases the `:headless-merge:` infix (`publisher-identity-fences.ts:145`) and otherwise compares epochs for equality. Epoch length does not grow unboundedly — `getMergedMobileSessionPublicationEpoch` strips rather than appends a merge suffix, so the worst case (`renderer:<uuid>:client-navigation`, 63 chars) stays well inside the `z.string().max(128)` cap on the close-lifecycle RPC.

Cross-platform / SSH / folder workspace: no platform-dependent code; the single changed expression is shared by native, SSH, and folder-workspace creation.

Residual risk — this is a correct but **partial** fix for the class. Eleven other sites across seven files still mint an epoch unconditionally rather than inheriting, so the same "additive change retires the live publisher" failure remains reachable by other routes. Most notably `orca-runtime-reconcile-headless-mobile-session-browser-tabs.ts:56` always mints `headless-hydrated:<ts>`, so a worktree with browser tabs can still retire a renderer epoch. Others: `orca-runtime-close-structured-agent-session-tab.ts:159,210`, `orca-runtime-move-headless-mobile-session-tab.ts:64,107,143`, `orca-runtime-persist-headless-session-tab-props.ts:94,180`, `orca-runtime-close-headless-mobile-terminal-tab.ts:91`, `orca-runtime-apply-mobile-session-tab-navigation.ts:132`. Scoped out deliberately: the terminal-creation path is the one CI actually reproduced, and each of the others needs its own reasoning about whether inheriting is correct (a close or a move may legitimately be a new generation). Worth a follow-up audit.

Known coverage gap: `src/main/runtime/` is not in `CROSS_VERSION_WIRE_PREFIXES` in `config/scripts/pr-code-change-scope.mjs`, so the cross-version wire job skipped for this PR even though this is a Rule 3 published-content change. Left as-is rather than widening CI scope unilaterally, since many other files also write this epoch.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Lint, typecheck, and tests pass (CI covers the full suite)
