### PR TITLE
fix: avoid credit deadlock during large SSH PTY recovery

### DIFF
--- a/src/relay/relay-pty-source-activation.ts
+++ b/src/relay/relay-pty-source-activation.ts
@@ -15,7 +15,11 @@ import type {
 } from './relay-pty-source-send-scheduler'
 import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
 
-export function boundedPtyRecoveryEnd(snapshot: PtySourceDeliverySnapshot): number {
+// Takes the post-rotation snapshot: creditedEndSu is the accepted checkpoint and windowSu the
+// reconnecting client's window. The pre-rotation snapshot would fence below the checkpoint.
+export function boundedPtyRecoveryEnd(
+  snapshot: Pick<PtySourceDeliverySnapshot, 'receivedEndSu' | 'creditedEndSu' | 'windowSu'>
+): number {
   const { receivedEndSu, creditedEndSu, windowSu } = snapshot
   // Oversized quarantine cannot earn credit; fence at the checkpoint and drain it live.
   return receivedEndSu - creditedEndSu > windowSu ? creditedEndSu : receivedEndSu

--- a/src/relay/relay-pty-source-activation.ts
+++ b/src/relay/relay-pty-source-activation.ts
@@ -4,13 +4,22 @@ import type {
   PtySourceRecoveryResult
 } from '../shared/pty-source-recovery-contract'
 import type { PtySourceReceivingActivation } from '../shared/pty-source-receiving-activation'
-import type { PtySourceDeliveryIdentity } from '../shared/pty-source-credit-contract'
+import type {
+  PtySourceDeliveryIdentity,
+  PtySourceDeliverySnapshot
+} from '../shared/pty-source-credit-contract'
 import type { RequestContext } from './dispatcher'
 import type {
   RelayPtySourceDeliveryRecord,
   RelayPtySourceSendScheduler
 } from './relay-pty-source-send-scheduler'
 import type { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+export function boundedPtyRecoveryEnd(snapshot: PtySourceDeliverySnapshot): number {
+  const { receivedEndSu, creditedEndSu, windowSu } = snapshot
+  // Oversized quarantine cannot earn credit; fence at the checkpoint and drain it live.
+  return receivedEndSu - creditedEndSu > windowSu ? creditedEndSu : receivedEndSu
+}
 
 export function createPtySourceReceivingActivation(
   identity: PtySourceDeliveryIdentity,

--- a/src/relay/relay-pty-source-publication.ts
+++ b/src/relay/relay-pty-source-publication.ts
@@ -7,6 +7,7 @@ import type { PtySourceReceivingActivation } from '../shared/pty-source-receivin
 import {
   createPtySourceReceivingActivation,
   pendingPtySourceRecoveryResult,
+  boundedPtyRecoveryEnd,
   registerCanceledPtySourceRetirement,
   registerPtySourceActivationSettlement,
   samePtySourceRecoveryRequest
@@ -66,9 +67,7 @@ export class RelayPtySourcePublication {
     recovery?: PtySourceRecoveryRequest
   ): false | 'opened' | 'rotated' | 'existing' | PtySourceRecoveryResult {
     let current = this.deliveries.get(id)
-    // A superseded request can find the delivery its own replacement opened: releasing that fence
-    // resumes a send the replacement is still rotating, and cancelling it blanks the pane that owns
-    // it. So every bail-out below acts only on a record this caller still owns.
+    // Only release this caller's delivery; its replacement may still be rotating.
     const owned = current?.clientId === context?.clientId ? current : undefined
     if (!context?.onResponseSettled) {
       this.sender.releaseRotationFence(owned)
@@ -141,7 +140,7 @@ export class RelayPtySourcePublication {
         identity = rotation.identity
         displayEnd = current.displayEnd
         recoveryCheckpointSourceEndSu = recovery.acceptedSourceEndSu
-        recoveryEndSu = snapshot.receivedEndSu
+        recoveryEndSu = boundedPtyRecoveryEnd(this.session.sourceDeliverySnapshot(identity))
         recoveryWasSealed = snapshot.state === 'sealed-unsettled'
         this.counters.rotated++
       } catch (error) {

--- a/src/relay/relay-pty-source-recovery-window.test.ts
+++ b/src/relay/relay-pty-source-recovery-window.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, expect, it } from 'vitest'
+import { RelayDispatcher, type RelayClientSessionIdentity } from './dispatcher'
+import { encodeJsonRpcFrame, MessageType } from './protocol'
+import { RelayPtySourcePublication } from './relay-pty-source-publication'
+import { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
+
+const endpointIdentity: RelayClientSessionIdentity = {
+  principal: 'endpoint-principal',
+  authenticated: true,
+  allowSessionOwner: true,
+  authenticationKind: 'endpoint-credential'
+}
+
+type Frame = {
+  id?: number
+  method?: string
+  params?: Record<string, unknown>
+  result?: Record<string, unknown>
+}
+
+function decode(buffer: Buffer): Frame | null {
+  return buffer[0] === MessageType.Regular
+    ? JSON.parse(buffer.subarray(13, 13 + buffer.readUInt32BE(9)).toString('utf8'))
+    : null
+}
+
+const flushRequests = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+let dispatcher: RelayDispatcher | undefined
+
+afterEach(() => dispatcher?.dispose())
+
+it.each([0, 4])(
+  'drains a retained tail larger than the window from checkpoint %i',
+  async (checkpoint) => {
+    const original: Frame[] = []
+    dispatcher = new RelayDispatcher(
+      (data, settled) => {
+        const frame = decode(data)
+        if (frame) {
+          original.push(frame)
+        }
+        settled({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true },
+      endpointIdentity
+    )
+    const mux = dispatcher
+    let publication: RelayPtySourcePublication
+    const adapter = new SshPtyConsumerSessionAdapter(mux, 'build', undefined, (id) =>
+      publication.onCreditAvailable(id)
+    )
+    publication = new RelayPtySourcePublication(mux, adapter, () => {})
+    const open = (clientId: number, id: number, resume?: Record<string, unknown>): void => {
+      mux.feedClient(
+        clientId,
+        encodeJsonRpcFrame(
+          {
+            jsonrpc: '2.0',
+            id,
+            method: 'pty.openClient',
+            params: {
+              protocolVersion: 1,
+              clientInstanceId: 'client',
+              requestedRole: 'session-owner',
+              resume,
+              capabilities: { outputFlowControl: { versions: [1], requestedWindowSu: 4 } }
+            }
+          },
+          id,
+          0
+        )
+      )
+    }
+    open(1, 1)
+    await flushRequests()
+    publication.activate('pty', 'incarnation', {
+      clientId: 1,
+      isStale: () => false,
+      sessionIdentity: endpointIdentity,
+      onResponseSettled: (settle) => queueMicrotask(() => settle({ ok: true }))
+    })
+    await flushRequests()
+    expect(publication.publish('pty', { data: 'abcdefghijkl' }, false)).toBe(true)
+    const oldFrame = original.find((frame) => frame.method === 'pty.data')!.params!
+    const grant = original.find((frame) => frame.id === 1)!.result!
+    mux.invalidateClient()
+    const replacement: Frame[] = []
+    const clientId = mux.attachClient(
+      (data, settled) => {
+        const frame = decode(data)
+        if (frame) {
+          replacement.push(frame)
+        }
+        settled({ ok: true })
+        return true
+      },
+      { supportsWriteCallback: true },
+      endpointIdentity
+    )
+    open(clientId, 2, { ownerGeneration: grant.ownerGeneration, ownerLease: grant.ownerLease })
+    await flushRequests()
+    const recovery = publication.activate(
+      'pty',
+      'incarnation',
+      {
+        clientId,
+        isStale: () => false,
+        sessionIdentity: endpointIdentity,
+        onResponseSettled: (settle) => queueMicrotask(() => settle({ ok: true }))
+      },
+      {
+        status: 'checkpoint',
+        clientGeneration: Number(oldFrame.clientGeneration),
+        ownerGeneration: Number(oldFrame.ownerGeneration),
+        deliveryToken: String(oldFrame.deliveryToken),
+        ptyIncarnation: 'incarnation',
+        acceptedSourceEndSu: checkpoint
+      }
+    )
+    expect(recovery).toMatchObject({ status: 'pending', checkpointSourceEndSu: checkpoint })
+    await flushRequests()
+    // The receiver cannot ACK quarantined data until this fence arrives.
+    expect(replacement.filter((frame) => frame.method === 'pty.recoveryComplete')).toHaveLength(1)
+    let accepted = checkpoint
+    let output = ''
+    for (let turn = 0; accepted < 12 && turn < 4; turn++) {
+      const frames = replacement.filter(
+        (frame) => frame.method === 'pty.data' && Number(frame.params!.sourceEndSu) > accepted
+      )
+      expect(frames.length).toBeGreaterThan(0)
+      for (const frame of frames) {
+        const params = frame.params!
+        expect(Number(params.sourceEndSu) - Number(params.sourceLengthSu)).toBe(accepted)
+        accepted = Number(params.sourceEndSu)
+        output += String(params.data)
+      }
+      expect(publication.getDebugSnapshot().outstandingSourceUnits).toBeLessThanOrEqual(4)
+      const params = frames.at(-1)!.params!
+      mux.feedClient(
+        clientId,
+        encodeJsonRpcFrame(
+          {
+            jsonrpc: '2.0',
+            method: 'pty.ackData',
+            params: {
+              acknowledgements: [
+                {
+                  id: 'pty',
+                  clientGeneration: params.clientGeneration,
+                  ownerGeneration: params.ownerGeneration,
+                  deliveryToken: params.deliveryToken,
+                  creditedEndSu: accepted
+                }
+              ]
+            }
+          },
+          3 + turn,
+          0
+        )
+      )
+      await flushRequests()
+    }
+    expect(accepted).toBe(12)
+    expect(output).toBe('abcdefghijkl'.slice(checkpoint))
+    expect(publication.getDebugSnapshot().outstandingSourceUnits).toBe(0)
+  }
+)

--- a/src/relay/relay-pty-source-recovery-window.test.ts
+++ b/src/relay/relay-pty-source-recovery-window.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, it } from 'vitest'
 import { RelayDispatcher, type RelayClientSessionIdentity } from './dispatcher'
+import { boundedPtyRecoveryEnd } from './relay-pty-source-activation'
 import { encodeJsonRpcFrame, MessageType } from './protocol'
 import { RelayPtySourcePublication } from './relay-pty-source-publication'
 import { SshPtyConsumerSessionAdapter } from './ssh-pty-consumer-session-adapter'
@@ -118,7 +119,12 @@ it.each([0, 4])(
         acceptedSourceEndSu: checkpoint
       }
     )
-    expect(recovery).toMatchObject({ status: 'pending', checkpointSourceEndSu: checkpoint })
+    // The fence lands on the checkpoint itself: the tail drains live rather than behind it.
+    expect(recovery).toMatchObject({
+      status: 'pending',
+      checkpointSourceEndSu: checkpoint,
+      recoveryEndSu: checkpoint
+    })
     await flushRequests()
     // The receiver cannot ACK quarantined data until this fence arrives.
     expect(replacement.filter((frame) => frame.method === 'pty.recoveryComplete')).toHaveLength(1)
@@ -166,3 +172,10 @@ it.each([0, 4])(
     expect(publication.getDebugSnapshot().outstandingSourceUnits).toBe(0)
   }
 )
+
+it('fences at the checkpoint only once the tail outgrows the window', () => {
+  const tail = (receivedEndSu: number) => ({ receivedEndSu, creditedEndSu: 4, windowSu: 4 })
+  // Exactly one window is still deliverable without credit, so it keeps the ordinary fence.
+  expect(boundedPtyRecoveryEnd(tail(8))).toBe(8)
+  expect(boundedPtyRecoveryEnd(tail(9))).toBe(4)
+})

--- a/tests/e2e/ssh-docker-transport-drop-recovery.spec.ts
+++ b/tests/e2e/ssh-docker-transport-drop-recovery.spec.ts
@@ -163,8 +163,7 @@ test.describe('SSH transport drop recovery', () => {
     }
   })
 
-  // #18018: local authority-aware recovery still loses the flooded pane's relay channel.
-  test.fixme('stays bounded when a disconnected shell floods its pty', async ({
+  test('stays bounded when a disconnected shell floods its pty', async ({
     orcaPage
   }, testInfo) => {
     test.slow()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

When you're working on a remote machine over SSH and a command prints a huge amount of text, a brief network hiccup could leave that terminal frozen forever. The two sides ended up waiting on each other: the remote side wouldn't release the backlog until your app confirmed it had caught up, and your app couldn't confirm anything until the backlog arrived. The only escape was to close the pane and start over, losing whatever was on screen. Now the remote side hands the backlog over through its normal, steady flow — a chunk at a time, each one confirmed — instead of trying to deliver it all as one block, so the terminal recovers on its own after a reconnect. Terminals that weren't producing much output behave exactly as before.

---

A reconnect during heavy terminal output can leave a live SSH shell permanently frozen: recovery waits for a completion fence before returning credit, but a retained tail larger than the negotiated window cannot reach that fence. Three Docker reproductions stopped after exactly 262,144 source units (`DEFAULT_PTY_SOURCE_WINDOW_SU`) and timed out with `recoveryFenceTimeout`.

For an oversized retained tail, publish the existing recovery fence at the exact accepted checkpoint, then drain all retained output through the ordinary live delivery and credit path. Smaller recoveries retain their existing behavior. Re-enable the previously quarantined flood regression with its original assertions. Ownership validation, retained output, source coordinates, credit limits, and cancellation proofs remain enforced. This uses the existing zero-length recovery representation and introduces no protocol fields or opcodes.

Validation: two regression cases failed before the fix because the completion fence never arrived. They now require the complete remaining output in source order and no more than the negotiated window outstanding. The focused relay and SSH suite passed 232 tests; node typecheck and changed-file lint/format passed. The original 48 MB Docker flood scenario passed all three repetitions on this fix alone: https://github.com/stablyai/orca/actions/runs/34015706902. Pullfrog reviewed the application fix and found no new issues.

Application change: leave open for user review.

Additional relay performance coverage: the original disconnect/reconnect scenario missed its recovery completion marker in two of three executions in https://github.com/stablyai/orca/actions/runs/34038736922. Applying only this PR's two production-file changes to merged base adcc30be passed all five repetitions of that unchanged scenario in 2.9m: https://github.com/stablyai/orca/actions/runs/34039337685 (head 88ae615). The previously unrun relay performance suite therefore has an application prerequisite here before regular CI registration. This PR remains open for user review.

## Mixed-version pairing

Host-only change; no client file is touched, and no wire field or opcode is added. The host simply selects a different legal value for the existing `recoveryEndSu`.

A zero-length recovery (`recoveryEndSu === checkpointSourceEndSu`) is **already reachable and already shipped** on base: any client that reconnects having accepted everything it received produces one today. It is pinned by a pre-existing test — `src/relay/relay-pty-source-publication.test.ts:537` asserts `{ checkpointSourceEndSu: 4, recoveryEndSu: 4 }`, zero `pty.data` frames, and one `pty.recoveryComplete`. All three wire validators reject only `recoveryEndSu < checkpointSourceEndSu`, so equality is explicitly legal (`src/shared/pty-source-receiving-activation.ts:31`, `src/main/providers/ssh-pty-session-reattach.ts:139`, `src/main/ssh/ssh-relay-session.ts:239`). An old client therefore takes a decoding path it already runs, not a new one.

`src/main/ssh/ssh-relay-session.ts` is the only consumer of `pty.recoveryComplete`; there is no mobile or second-client implementation to skew against.

## Tradeoffs

- **Weaker recovery-ordering guarantee for oversized tails.** The retained output now arrives as ordinary live frames after the fence rather than inside a verified contiguous recovery block. Contiguity is still checked (live frames must chain on `sourceStartSu`), but a gap now surfaces as a restore *mid-drain* instead of a single up-front `restoreRequired`.
- **Catch-up is progressive, not instant.** The backlog drains one window at a time (256 KB outstanding) with a client ACK round-trip per window, so on a high-latency link a large tail paints in visible steps. Previously it never painted at all, so this is an improvement — but it is not immediate.
- **Client quarantine pressure between fence and passthrough.** Frames arriving in that gap are charged to the per-PTY recovery budget (256 K SU / 2 MB / 1024 frames). Overflow degrades to `recoveryQuarantineCapacityExceeded` — a full screen resync, which is a visible reset rather than a seamless resume.
- **Very large backlogs are still not made whole.** Relay retention remains capped at 512 K SU / 2 MB per PTY (unchanged here), so a truly enormous tail is still dropped and the pane resyncs. This PR fixes the freeze, not the truncation.
- **CI cost and flake risk.** Re-enables a previously quarantined ~3-minute Docker SSH flood spec. It is the only test covering the real scenario, so it must stay green in the e2e job.
- **Not a tradeoff — memory.** No credit or retention cap is relaxed. Outstanding unacknowledged data is still bounded by the negotiated window at all times, which the regression tests assert directly (`outstandingSourceUnits` never exceeds the window, and reaches 0).

## Visual proof

Not applicable. The change is relay flow-control accounting with no rendered surface of its own; the observable difference is "the pane resumes instead of staying frozen", which the Docker SSH e2e asserts far more precisely (relay RSS growth < 200 MB after a 48 MB flood, plus a post-recovery command round-trip) than a screenshot could. Local Electron launches are also paused for this work.
