### PR TITLE
Resolve approved agent secret references at process launch

### DIFF
--- a/src/main/codex/codex-structured-launch-resolution.test.ts
+++ b/src/main/codex/codex-structured-launch-resolution.test.ts
@@ -35,13 +35,18 @@ function record(overrides: Partial<AgentSessionRecord> = {}): AgentSessionRecord
   } as AgentSessionRecord
 }
 
+function storeWith(getRecord: AgentSessionRecordStore['getRecord']): AgentSessionRecordStore {
+  const partial: Partial<AgentSessionRecordStore> = { getRecord }
+  return partial as AgentSessionRecordStore
+}
+
 function resolverFor(
   value: AgentSessionRecord | null,
   resolveWorkspacePath: (workspaceId: string) => Promise<string> = async (id) => `/repos/${id}`,
   resolveRollout: () => Promise<string | null> = async () => null
 ) {
   return createCodexStructuredLaunchResolver({
-    store: { getRecord: () => value } as unknown as AgentSessionRecordStore,
+    store: storeWith(() => value),
     resolveWorkspacePath,
     resolveCommand: () => '/usr/local/bin/codex',
     resolveRollout
@@ -66,7 +71,7 @@ describe('codex structured launch resolution', () => {
 
     await withPlatform('win32', async () => {
       const resolveLaunch = createCodexStructuredLaunchResolver({
-        store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+        store: storeWith(() => record()),
         resolveWorkspacePath: async () => String.raw`C:\workspaces\orca`,
         resolveCommand: () => command
       })
@@ -173,7 +178,7 @@ describe('codex structured launch resolution', () => {
   ])('rejects %s secret references before command resolution', async (_name, environment) => {
     const resolveCommand = vi.fn(() => '/usr/local/bin/codex')
     const resolveLaunch = createCodexStructuredLaunchResolver({
-      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      store: storeWith(() => record()),
       resolveWorkspacePath: async () => '/repos/workspace-1',
       resolveCommand,
       resolveEnvironment: async () => environment
@@ -188,7 +193,7 @@ describe('codex structured launch resolution', () => {
   it('keeps valid reference strings in the launch record', async () => {
     const reference = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
     const resolveLaunch = createCodexStructuredLaunchResolver({
-      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      store: storeWith(() => record()),
       resolveWorkspacePath: async () => '/repos/workspace-1',
       resolveCommand: () => '/usr/local/bin/codex',
       resolveEnvironment: async () => ({ PATH: '/usr/bin', POSTHOG_READ_ONLY: reference })

--- a/src/main/codex/codex-structured-launch-resolution.test.ts
+++ b/src/main/codex/codex-structured-launch-resolution.test.ts
@@ -165,4 +165,38 @@ describe('codex structured launch resolution', () => {
       })({ identity: IDENTITY })
     ).rejects.toThrow('workspace-1 is gone')
   })
+
+  it.each([
+    ['malformed', { POSTHOG_READ_ONLY: 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY?raw' }],
+    ['HOME', { HOME: 'doppler-ref://lets-tango/dev_ops/HOME' }],
+    ['CODEX_HOME', { CODEX_HOME: 'doppler-ref://lets-tango/dev_ops/CODEX_HOME' }]
+  ])('rejects %s secret references before command resolution', async (_name, environment) => {
+    const resolveCommand = vi.fn(() => '/usr/local/bin/codex')
+    const resolveLaunch = createCodexStructuredLaunchResolver({
+      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      resolveWorkspacePath: async () => '/repos/workspace-1',
+      resolveCommand,
+      resolveEnvironment: async () => environment
+    })
+
+    await expect(resolveLaunch({ identity: IDENTITY })).rejects.toMatchObject({
+      code: 'invalid-reference'
+    })
+    expect(resolveCommand).not.toHaveBeenCalled()
+  })
+
+  it('keeps valid reference strings in the launch record', async () => {
+    const reference = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
+    const resolveLaunch = createCodexStructuredLaunchResolver({
+      store: { getRecord: () => record() } as unknown as AgentSessionRecordStore,
+      resolveWorkspacePath: async () => '/repos/workspace-1',
+      resolveCommand: () => '/usr/local/bin/codex',
+      resolveEnvironment: async () => ({ PATH: '/usr/bin', POSTHOG_READ_ONLY: reference })
+    })
+
+    await expect(resolveLaunch({ identity: IDENTITY })).resolves.toMatchObject({
+      env: { PATH: '/usr/bin', POSTHOG_READ_ONLY: reference },
+      codexHome: '/home/work/.codex'
+    })
+  })
 })

--- a/src/main/codex/codex-structured-launch-resolution.ts
+++ b/src/main/codex/codex-structured-launch-resolution.ts
@@ -9,9 +9,11 @@
 import type { AgentSessionJournalIdentity } from '../../shared/agent-session-journal-types'
 import { agentSessionProviderHandleChainHead } from '../../shared/agent-session-provider-handle'
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import { classifyAgentEnvSecretReferences } from '../../shared/secret-reference'
 import { resolveCodexCommand } from '../codex-cli/command'
 import type { AgentSessionRecordStore } from '../runtime/agent-session-record-store'
 import type { CodexStructuredLaunch } from './codex-structured-session-adapter'
+import { SecretReferenceResolutionError } from '../secret-references/resolve-agent-env-secret-references'
 import { resolvePinnedCodexRolloutProof } from './codex-tui-rollout-proof'
 
 export type CodexStructuredLaunchResolverDeps = {
@@ -50,8 +52,21 @@ export function createCodexStructuredLaunchResolver(
       throw new Error(`codex sessions pin CODEX_HOME, not ${accountHome.variable}`)
     }
     const environment = await deps.resolveEnvironment?.()
-    const pathEnv = environment?.PATH ?? environment?.Path ?? null
-    const homePath = environment?.HOME ?? environment?.USERPROFILE
+    const definedEnvironment = environment
+      ? Object.fromEntries(
+          Object.entries(environment).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string'
+          )
+        )
+      : undefined
+    const referenceClassification = definedEnvironment
+      ? classifyAgentEnvSecretReferences(definedEnvironment)
+      : { kind: 'none' as const }
+    if (referenceClassification.kind === 'invalid') {
+      throw new SecretReferenceResolutionError(referenceClassification.keys[0], 'invalid-reference')
+    }
+    const pathEnv = definedEnvironment?.PATH ?? definedEnvironment?.Path ?? null
+    const homePath = definedEnvironment?.HOME ?? definedEnvironment?.USERPROFILE
     const command = (deps.resolveCommand ?? resolveCodexCommand)({
       pathEnv,
       ...(homePath ? { homePath } : {})
@@ -64,7 +79,7 @@ export function createCodexStructuredLaunchResolver(
       args,
       cwd: await deps.resolveWorkspacePath(location.workspaceId),
       codexHome: accountHome.path,
-      ...(environment ? { env: { ...environment } as Record<string, string> } : {}),
+      ...(definedEnvironment ? { env: definedEnvironment } : {}),
       // An empty chain is a session that has never proved a thread, so it
       // starts one; anything else resumes the last link this session proved.
       resumeThreadId,

--- a/src/main/codex/codex-structured-session-acquire.test.ts
+++ b/src/main/codex/codex-structured-session-acquire.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentSessionJournalIdentity } from '../../shared/agent-session-journal-types'
+import { runProcess } from '../../shared/child-process/run-process'
+import type { openCodexAppServerConnection } from './codex-app-server-connection'
+import {
+  CodexStructuredSessionAdapter,
+  type CodexStructuredLaunch
+} from './codex-structured-session-adapter'
+import { CODEX_SPAWN_TOKEN_ENV } from './codex-structured-owner-identity'
+
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+
+const REFERENCE = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
+const SENTINEL = 'sentinel-plaintext-secret'
+const IDENTITY: AgentSessionJournalIdentity = {
+  sessionId: 'session-1',
+  workspaceId: 'workspace-1',
+  hostId: 'host-1',
+  agent: 'codex',
+  providerHandle: { kind: 'codex', threadId: 'thread-1' }
+}
+
+function createOpenConnection(capture: (env: Record<string, string> | undefined) => void) {
+  return (async (launch) => {
+    capture(launch.env)
+    return {
+      pid: 4321,
+      closed: false,
+      request: async (method: string) =>
+        method === 'thread/start'
+          ? { thread: { id: 'thread-1', path: '/rollouts/thread-1.jsonl' } }
+          : {},
+      notify: () => {},
+      respond: () => {},
+      respondWithError: () => {},
+      close: async () => true
+    }
+  }) as typeof openCodexAppServerConnection
+}
+
+describe('structured Codex secret references', () => {
+  beforeEach(() => {
+    vi.mocked(runProcess).mockReset()
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: `${SENTINEL}\n`,
+      stderr: '',
+      timedOut: false,
+      outputTruncated: false
+    })
+  })
+
+  it('passes plaintext only to the child environment and keeps the launch record unchanged', async () => {
+    const durableLaunch: CodexStructuredLaunch = {
+      command: 'codex',
+      args: ['app-server'],
+      cwd: '/work/repo',
+      codexHome: '/pinned/codex-home',
+      resumeThreadId: null,
+      env: { POSTHOG_READ_ONLY: REFERENCE, CODEX_HOME: '/shell/codex-home' }
+    }
+    let childEnv: Record<string, string> | undefined
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => durableLaunch,
+      openConnection: createOpenConnection((env) => {
+        childEnv = env
+      }),
+      readProcessStartTime: async () => 1_700_000_000_000
+    })
+
+    await adapter.acquire({ identity: IDENTITY, fence: 7, spawnToken: 'spawn-token' })
+
+    expect(childEnv).toEqual({
+      POSTHOG_READ_ONLY: SENTINEL,
+      CODEX_HOME: '/pinned/codex-home',
+      [CODEX_SPAWN_TOKEN_ENV]: 'spawn-token'
+    })
+    expect(durableLaunch.env).toEqual({
+      POSTHOG_READ_ONLY: REFERENCE,
+      CODEX_HOME: '/shell/codex-home'
+    })
+  })
+
+  it('aborts before provider spawn without exposing failed process output', async () => {
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 1,
+      signal: null,
+      stdout: SENTINEL,
+      stderr: '',
+      timedOut: false
+    })
+    const openConnection = vi.fn(createOpenConnection(() => {}))
+    const adapter = new CodexStructuredSessionAdapter({
+      resolveLaunch: async () => ({
+        command: 'codex',
+        args: ['app-server'],
+        cwd: '/work/repo',
+        codexHome: '/pinned/codex-home',
+        resumeThreadId: null,
+        env: { POSTHOG_READ_ONLY: REFERENCE }
+      }),
+      openConnection,
+      readProcessStartTime: async () => 1_700_000_000_000
+    })
+
+    const rejection = adapter.acquire({ identity: IDENTITY, fence: 7, spawnToken: 'spawn-token' })
+
+    await expect(rejection).rejects.toThrow('nonzero-exit')
+    await expect(rejection).rejects.not.toThrow(SENTINEL)
+    expect(openConnection).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/codex/codex-structured-session-acquire.ts
+++ b/src/main/codex/codex-structured-session-acquire.ts
@@ -32,6 +32,7 @@ import {
 import type { CodexStructuredTurnCancellation } from './codex-structured-turn-cancellation'
 import type { CodexStructuredNotificationRetry } from './codex-structured-notification-retry'
 import type { deliverCodexServerRequest } from './codex-structured-provider-events'
+import { resolveSecretReferencesIntoChildEnv } from '../secret-references/resolve-agent-env-secret-references'
 
 export async function acquireCodexStructuredSession(input: {
   input: StructuredAgentSessionAcquireInput
@@ -101,12 +102,23 @@ export async function acquireCodexStructuredSession(input: {
         throw new AgentSessionPreSpawnError(error)
       })
     acquisitions.assertCurrent(sessionId, attempt)
+    const childEnv = { ...launch.env }
+    await resolveSecretReferencesIntoChildEnv({
+      childEnv,
+      target: { ssh: false, wsl: false }
+    }).catch((error: unknown) => {
+      throw new AgentSessionPreSpawnError(error)
+    })
+    acquisitions.assertCurrent(sessionId, attempt)
     const connection = await open(
       {
         command: launch.command,
         args: launch.args,
         cwd: launch.cwd,
-        env: buildCodexStructuredChildEnvironment(launch, acquireInput.spawnToken)
+        env: buildCodexStructuredChildEnvironment(
+          { ...launch, env: childEnv },
+          acquireInput.spawnToken
+        )
       },
       {
         onNotification: (method, params) =>

--- a/src/main/codex/codex-structured-session-acquire.ts
+++ b/src/main/codex/codex-structured-session-acquire.ts
@@ -106,7 +106,7 @@ export async function acquireCodexStructuredSession(input: {
     await resolveSecretReferencesIntoChildEnv({
       childEnv,
       target: { ssh: false, wsl: false }
-    }).catch((error: unknown) => {
+    }).catch((error: Error) => {
       throw new AgentSessionPreSpawnError(error)
     })
     acquisitions.assertCurrent(sessionId, attempt)

--- a/src/main/ipc/pty/ipc/spawn-env.ts
+++ b/src/main/ipc/pty/ipc/spawn-env.ts
@@ -6,6 +6,7 @@ import {
 import { isRemoteAgentHooksEnabled } from '../../../../shared/agent-hook-relay'
 import { isOpaqueRemintedPaneKey } from '../../../../shared/pane-key-alias'
 import { isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
+import { classifyAgentEnvSecretReferences } from '../../../../shared/secret-reference'
 import { isClaudeAuthSwitchInProgress } from '../../../claude-accounts/live-pty-gate'
 import {
   CLAUDE_AUTH_ENV_CONFLICT_MESSAGE,
@@ -20,9 +21,14 @@ import { parseValidPaneKey } from '../pane/key-state'
 import { shouldRefreshNativeClaudeAgentTeamsEnv } from '../pane/launch-authority'
 import type { PtyIpcSpawnState } from './spawn-state'
 import { assemblePtyIpcSpawnCodexEnv } from './spawn-env-codex'
+import { SecretReferenceResolutionError } from '../../../secret-references/resolve-agent-env-secret-references'
 
 export async function assemblePtyIpcSpawnEnv(ctx: PtyIpcSpawnState): Promise<void> {
   const args = ctx.args
+  const secretReferences = classifyAgentEnvSecretReferences(args.env ?? {})
+  if (secretReferences.kind === 'invalid') {
+    throw new SecretReferenceResolutionError(secretReferences.keys[0], 'invalid-reference')
+  }
   if (ctx.isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
     throw new Error(CLAUDE_AUTH_SWITCH_IN_PROGRESS_MESSAGE)
   }

--- a/src/main/ipc/pty/ipc/spawn-execute.ts
+++ b/src/main/ipc/pty/ipc/spawn-execute.ts
@@ -63,17 +63,14 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
     const sequenceBeforeProviderSpawn = expectedPtyId
       ? (ctx.deps.runtime?.getPtyOutputSequence?.(expectedPtyId) ?? 0)
       : 0
-    const spawnOptions =
-      ctx.preAdoptedStablePane || stablePaneOwnerCandidate
-        ? ctx.spawnOptions
-        : await resolveChildSpawnOptions(ctx)
     const stablePaneSpawn = ctx.preAdoptedStablePane
       ? ctx.preAdoptedStablePane
       : await spawnForStablePane({
           runtime: ctx.deps.runtime,
           store: ctx.deps.store,
           provider: ctx.provider,
-          spawnOptions,
+          spawnOptions: ctx.spawnOptions,
+          resolveFreshSpawnOptions: () => resolveChildSpawnOptions(ctx),
           owner: stablePaneOwnerCandidate,
           worktreeId: args.worktreeId,
           connectionId: args.connectionId,

--- a/src/main/ipc/pty/ipc/spawn-execute.ts
+++ b/src/main/ipc/pty/ipc/spawn-execute.ts
@@ -14,7 +14,24 @@ import { assertSpawnReplyWasLive } from '../pane/agent-session-owners'
 import { deletePtyOwnership } from '../provider/ownership-state'
 import { ptySizes } from '../delivery/visibility-state'
 import { clearProviderPtyState } from '../provider/state-cleanup'
+import type { PtySpawnOptions } from '../../../providers/types'
+import { resolveSecretReferencesIntoChildEnv } from '../../../secret-references/resolve-agent-env-secret-references'
 import type { PtyIpcSpawnState } from './spawn-state'
+
+async function resolveChildSpawnOptions(ctx: PtyIpcSpawnState): Promise<PtySpawnOptions> {
+  if (!ctx.spawnOptions.env) {
+    return ctx.spawnOptions
+  }
+  const childEnv = { ...ctx.spawnOptions.env }
+  await resolveSecretReferencesIntoChildEnv({
+    childEnv,
+    target: {
+      ssh: Boolean(ctx.args.connectionId),
+      wsl: ctx.expectedWslDistro !== null
+    }
+  })
+  return { ...ctx.spawnOptions, env: childEnv }
+}
 
 export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
   const args = ctx.args
@@ -46,13 +63,17 @@ export async function executePtyIpcSpawn(ctx: PtyIpcSpawnState): Promise<void> {
     const sequenceBeforeProviderSpawn = expectedPtyId
       ? (ctx.deps.runtime?.getPtyOutputSequence?.(expectedPtyId) ?? 0)
       : 0
+    const spawnOptions =
+      ctx.preAdoptedStablePane || stablePaneOwnerCandidate
+        ? ctx.spawnOptions
+        : await resolveChildSpawnOptions(ctx)
     const stablePaneSpawn = ctx.preAdoptedStablePane
       ? ctx.preAdoptedStablePane
       : await spawnForStablePane({
           runtime: ctx.deps.runtime,
           store: ctx.deps.store,
           provider: ctx.provider,
-          spawnOptions: ctx.spawnOptions,
+          spawnOptions,
           owner: stablePaneOwnerCandidate,
           worktreeId: args.worktreeId,
           connectionId: args.connectionId,

--- a/src/main/ipc/pty/ipc/spawn-preflight.ts
+++ b/src/main/ipc/pty/ipc/spawn-preflight.ts
@@ -3,6 +3,7 @@ import {
   resolveLocalWindowsTerminalRuntimeOptions
 } from '../../../../shared/local-windows-terminal-runtime'
 import { isWslUncPath, toWindowsWslPath } from '../../../../shared/wsl-paths'
+import { classifyAgentEnvSecretReferences } from '../../../../shared/secret-reference'
 import { isClaudeAuthSwitchInProgress } from '../../../claude-accounts/live-pty-gate'
 import { CLAUDE_AUTH_SWITCH_IN_PROGRESS_MESSAGE } from '../../../claude-accounts/environment'
 import { mintPtySessionId } from '../../../daemon/pty-session-id'
@@ -18,9 +19,14 @@ import {
 } from '../host-env/fresh-spawn-routing'
 import { getAppPtyId, getProvider, getRelayPtyId } from '../provider/registry'
 import type { PtyIpcSpawnState } from './spawn-state'
+import { SecretReferenceResolutionError } from '../../../secret-references/resolve-agent-env-secret-references'
 
 export async function preparePtyIpcSpawnPreflight(ctx: PtyIpcSpawnState): Promise<void> {
   const args = ctx.args
+  const secretReferences = classifyAgentEnvSecretReferences(args.env ?? {})
+  if (secretReferences.kind === 'invalid') {
+    throw new SecretReferenceResolutionError(secretReferences.keys[0], 'invalid-reference')
+  }
   // Establish daemon identity before the first await so hidden delivery is gated before byte zero.
   ctx.provider = getProvider(args.connectionId)
   ctx.isDaemonHostSpawn =

--- a/src/main/ipc/pty/ipc/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/ipc/spawn-secret-references.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { runProcess } from '../../../../shared/child-process/run-process'
 import { buildSleepingAgentLaunchConfig } from '../../../../shared/sleeping-agent-launch-config'
 import { buildAgentResumeStartupPlan } from '../../../../shared/tui-agent-resume-startup'
-import type { IPtyProvider } from '../../../providers/types'
+import type { IPtyProvider, PtySpawnOptions } from '../../../providers/types'
+import { SessionNotFoundError } from '../../../daemon/daemon-errors'
 import { localProvider } from '../provider/registry'
 import { noCodexResumeLaunch } from '../host-env/codex-resume'
 import { assemblePtyIpcSpawnEnv } from './spawn-env'
@@ -46,6 +47,28 @@ function providerWith(spawn: IPtyProvider['spawn']): IPtyProvider {
   const provider = Object.create(localProvider) as IPtyProvider
   provider.spawn = spawn
   return provider
+}
+
+const LEAF_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+function arrangeStableOwnerPane(ctx: ReturnType<typeof createState>, ptyId: string): void {
+  ctx.args.worktreeId = 'workspace-1'
+  ctx.reservationPaneKey = `tab-1:${LEAF_ID}`
+  let paneRetired = false
+  ctx.deps.runtime = {
+    resolveTerminalPane: () => {
+      if (paneRetired) {
+        throw new Error('terminal_not_found')
+      }
+      return { handle: 'term_stale', ptyId, tabId: 'tab-1', leafId: LEAF_ID, connected: true }
+    },
+    onPtyExit: () => {
+      paneRetired = true
+    }
+  } as unknown as PtySpawnIpcDeps['runtime']
+  ctx.deps.store = {
+    getWorkspaceSession: () => ({})
+  } as unknown as PtySpawnIpcDeps['store']
 }
 
 describe('IPC PTY secret references', () => {
@@ -125,6 +148,86 @@ describe('IPC PTY secret references', () => {
     await expect(executePtyIpcSpawn(ctx)).rejects.toMatchObject({ code: 'remote-target' })
     expect(runProcess).not.toHaveBeenCalled()
     expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('resolves credentials for the fresh spawn after failed stable-owner adoption', async () => {
+    const ctx = createState()
+    arrangeStableOwnerPane(ctx, 'pty-ipc-stale')
+    ctx.spawnOptions = {
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/codex',
+      env: { POSTHOG_READ_ONLY: REFERENCE }
+    }
+    const spawn = vi.fn(async (options: PtySpawnOptions) => {
+      if (options.attachOnly) {
+        throw new SessionNotFoundError('pty-ipc-stale')
+      }
+      return { id: 'pty-ipc-fresh' }
+    })
+    ctx.provider = providerWith(spawn)
+
+    await executePtyIpcSpawn(ctx)
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({
+      attachOnly: true,
+      sessionId: 'pty-ipc-stale',
+      env: { POSTHOG_READ_ONLY: REFERENCE }
+    })
+    expect(spawn.mock.calls[1]?.[0]).toEqual({
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/codex',
+      env: { POSTHOG_READ_ONLY: SENTINEL }
+    })
+    expect(ctx.spawnOptions.env).toEqual({ POSTHOG_READ_ONLY: REFERENCE })
+    expect(ctx.result).toMatchObject({ id: 'pty-ipc-fresh' })
+  })
+
+  it('adopts a live stable owner without any secret lookup', async () => {
+    const ctx = createState()
+    arrangeStableOwnerPane(ctx, 'pty-ipc-live')
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    const spawn = vi.fn(async () => ({ id: 'pty-ipc-live', isReattach: true }))
+    ctx.provider = providerWith(spawn)
+
+    await executePtyIpcSpawn(ctx)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ attachOnly: true, env: { POSTHOG_READ_ONLY: REFERENCE } })
+    )
+    expect(runProcess).not.toHaveBeenCalled()
+    expect(ctx.result).toMatchObject({ id: 'pty-ipc-live' })
+  })
+
+  it('refuses the fresh spawn when resolution fails after failed adoption', async () => {
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+      outputTruncated: false
+    })
+    const ctx = createState()
+    arrangeStableOwnerPane(ctx, 'pty-ipc-gone')
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    const spawn = vi.fn(async (options: PtySpawnOptions) => {
+      if (options.attachOnly) {
+        throw new SessionNotFoundError('pty-ipc-gone')
+      }
+      return { id: 'pty-ipc-must-not-spawn' }
+    })
+    ctx.provider = providerWith(spawn)
+
+    await expect(executePtyIpcSpawn(ctx)).rejects.toMatchObject({
+      code: 'nonzero-exit',
+      envKey: 'POSTHOG_READ_ONLY'
+    })
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({ attachOnly: true })
   })
 
   it('keeps settings, launch config, and resume state reference-only', () => {

--- a/src/main/ipc/pty/ipc/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/ipc/spawn-secret-references.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../../../shared/child-process/run-process'
+import { buildSleepingAgentLaunchConfig } from '../../../../shared/sleeping-agent-launch-config'
+import { buildAgentResumeStartupPlan } from '../../../../shared/tui-agent-resume-startup'
+import type { IPtyProvider } from '../../../providers/types'
+import { localProvider } from '../provider/registry'
+import { noCodexResumeLaunch } from '../host-env/codex-resume'
+import { assemblePtyIpcSpawnEnv } from './spawn-env'
+import { executePtyIpcSpawn } from './spawn-execute'
+import { preparePtyIpcSpawnPreflight } from './spawn-preflight'
+import { createPtyIpcSpawnState } from './spawn-state'
+import type { PtySpawnIpcDeps } from './spawn-types'
+
+vi.mock('../../../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+
+const REFERENCE = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
+const SENTINEL = 'sentinel-plaintext-secret'
+
+function createState(connectionId?: string) {
+  const args = {
+    cols: 100,
+    rows: 30,
+    env: { POSTHOG_READ_ONLY: REFERENCE },
+    ...(connectionId ? { connectionId } : {})
+  }
+  const deps: PtySpawnIpcDeps = {
+    getLocalPtyStartupPromise: () => undefined,
+    adoptStablePane: async () => null,
+    assertFolderWorkspacePtyPathUsable: () => {},
+    resolvePtySpawnStartupCwd: () => undefined,
+    localStartupCwdDirectoryExists: () => true,
+    prepareCodexResumeHome: () => null,
+    noCodexResumeLaunch,
+    resolveCodexResumeLaunch: async (command) => noCodexResumeLaunch(command),
+    reconcileSharedRuntimeResumeHome: async (resumeHome) => resumeHome.codexHomePath,
+    stripSequencedStartupResumeArgv: (env) => env,
+    trustedTerminalHandleEnv: new Set<string>(),
+    transitionSpawnHiddenRendererPtyDeliveryState: vi.fn(),
+    sendPtySpawnedToRenderer: vi.fn(),
+    syncPtyBackgroundedDelivery: vi.fn()
+  }
+  return createPtyIpcSpawnState(deps, args)
+}
+
+function providerWith(spawn: IPtyProvider['spawn']): IPtyProvider {
+  const provider = Object.create(localProvider) as IPtyProvider
+  provider.spawn = spawn
+  return provider
+}
+
+describe('IPC PTY secret references', () => {
+  beforeEach(() => {
+    vi.mocked(runProcess).mockReset()
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: `${SENTINEL}\n`,
+      stderr: '',
+      timedOut: false,
+      outputTruncated: false
+    })
+  })
+
+  it('rejects invalid candidates before account selection', async () => {
+    const ctx = createState()
+    ctx.args.env = { HOME: 'doppler-ref://lets-tango/dev_ops/HOME' }
+    const accountSelection = vi.fn()
+    ctx.deps.getSelectedCodexHomePath = accountSelection
+
+    await expect(assemblePtyIpcSpawnEnv(ctx)).rejects.toMatchObject({
+      code: 'invalid-reference',
+      envKey: 'HOME'
+    })
+    expect(accountSelection).not.toHaveBeenCalled()
+    expect(runProcess).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid candidates before Claude account preparation', async () => {
+    const ctx = createState()
+    ctx.args.command = 'claude'
+    ctx.args.env = { HOME: 'doppler-ref://lets-tango/dev_ops/HOME' }
+    const prepareClaudeAuth = vi.fn()
+    ctx.deps.prepareClaudeAuth = prepareClaudeAuth
+
+    await expect(preparePtyIpcSpawnPreflight(ctx)).rejects.toMatchObject({
+      code: 'invalid-reference',
+      envKey: 'HOME'
+    })
+    expect(prepareClaudeAuth).not.toHaveBeenCalled()
+  })
+
+  it('gives only a fresh local provider clone the resolved value', async () => {
+    const ctx = createState()
+    const authPatch = 'account-auth-patch'
+    ctx.spawnOptions = {
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/codex',
+      env: { POSTHOG_READ_ONLY: REFERENCE, CLAUDE_CONFIG_DIR: authPatch }
+    }
+    const spawn = vi.fn(async () => ({ id: 'pty-1' }))
+    ctx.provider = providerWith(spawn)
+
+    await executePtyIpcSpawn(ctx)
+
+    expect(spawn).toHaveBeenCalledWith({
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/codex',
+      env: { POSTHOG_READ_ONLY: SENTINEL, CLAUDE_CONFIG_DIR: authPatch }
+    })
+    expect(ctx.spawnOptions.env).toEqual({
+      POSTHOG_READ_ONLY: REFERENCE,
+      CLAUDE_CONFIG_DIR: authPatch
+    })
+    expect(ctx.spawnOptions.command).toBe('/usr/local/bin/codex')
+  })
+
+  it('rejects SSH before Doppler or provider spawn', async () => {
+    const ctx = createState('connection-1')
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    const spawn = vi.fn(async () => ({ id: 'pty-remote' }))
+    ctx.provider = providerWith(spawn)
+
+    await expect(executePtyIpcSpawn(ctx)).rejects.toMatchObject({ code: 'remote-target' })
+    expect(runProcess).not.toHaveBeenCalled()
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('keeps settings, launch config, and resume state reference-only', () => {
+    const launchConfig = buildSleepingAgentLaunchConfig({
+      agentArgs: '',
+      agentEnv: { POSTHOG_READ_ONLY: REFERENCE }
+    })
+    const resumed = buildAgentResumeStartupPlan({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'thread-1' },
+      cmdOverrides: { codex: 'codex' },
+      platform: 'darwin',
+      agentArgs: '',
+      agentEnv: launchConfig.agentEnv
+    })
+
+    expect(launchConfig.agentEnv.POSTHOG_READ_ONLY).toBe(REFERENCE)
+    expect(resumed?.launchConfig.agentEnv.POSTHOG_READ_ONLY).toBe(REFERENCE)
+    expect(resumed?.env?.POSTHOG_READ_ONLY).toBe(REFERENCE)
+  })
+})

--- a/src/main/ipc/pty/ipc/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/ipc/spawn-secret-references.test.ts
@@ -65,10 +65,10 @@ function arrangeStableOwnerPane(ctx: ReturnType<typeof createState>, ptyId: stri
     onPtyExit: () => {
       paneRetired = true
     }
-  } as unknown as PtySpawnIpcDeps['runtime']
+  } as Partial<NonNullable<PtySpawnIpcDeps['runtime']>> as PtySpawnIpcDeps['runtime']
   ctx.deps.store = {
     getWorkspaceSession: () => ({})
-  } as unknown as PtySpawnIpcDeps['store']
+  } as Partial<NonNullable<PtySpawnIpcDeps['store']>> as PtySpawnIpcDeps['store']
 }
 
 describe('IPC PTY secret references', () => {

--- a/src/main/ipc/pty/pane/stable-owner.ts
+++ b/src/main/ipc/pty/pane/stable-owner.ts
@@ -166,6 +166,8 @@ export type StablePaneSpawnContext = {
   worktreeId?: string
   connectionId?: string | null
   resolveOwner?: () => StablePaneOwner | null
+  // Why: fresh spawns need launch-time secret resolution; adoption creates no process and must not.
+  resolveFreshSpawnOptions?: () => Promise<PtySpawnOptions>
   onFreshSpawn?: (result: PtySpawnResult) => void
 }
 
@@ -298,7 +300,10 @@ export async function spawnForStablePane(
       return attached
     }
   }
-  const result = await args.provider.spawn(args.spawnOptions)
+  const spawnOptions = args.resolveFreshSpawnOptions
+    ? await args.resolveFreshSpawnOptions()
+    : args.spawnOptions
+  const result = await args.provider.spawn(spawnOptions)
   args.onFreshSpawn?.(result)
   return { result, owner: null }
 }

--- a/src/main/ipc/pty/runtime/spawn-execute.ts
+++ b/src/main/ipc/pty/runtime/spawn-execute.ts
@@ -144,17 +144,14 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
       ctx.result.agentSessionEnsure = ensured
     } else {
       assertClientStillConnected()
-      const spawnOptions =
-        ctx.preAdoptedStablePane || stablePaneOwnerCandidate
-          ? ctx.spawnOptions
-          : await resolveChildSpawnOptions(ctx)
       const stablePaneSpawn = ctx.preAdoptedStablePane
         ? ctx.preAdoptedStablePane
         : await spawnForStablePane({
             runtime: ctx.deps.runtime,
             store: ctx.deps.store,
             provider: ctx.provider,
-            spawnOptions,
+            spawnOptions: ctx.spawnOptions,
+            resolveFreshSpawnOptions: () => resolveChildSpawnOptions(ctx),
             owner: stablePaneOwnerCandidate,
             worktreeId: args.worktreeId,
             connectionId: args.connectionId,

--- a/src/main/ipc/pty/runtime/spawn-execute.ts
+++ b/src/main/ipc/pty/runtime/spawn-execute.ts
@@ -1,4 +1,4 @@
-import type { PtySpawnResult } from '../../../providers/types'
+import type { PtySpawnOptions, PtySpawnResult } from '../../../providers/types'
 import { ptyIncarnationById, deletePtyOwnership } from '../provider/ownership-state'
 import { ptySizes } from '../delivery/visibility-state'
 import { tryGetProviderForAgentSessionOwner } from '../provider/registry'
@@ -17,6 +17,22 @@ import {
   isSshPtyIdentityMismatchError
 } from '../../../providers/ssh-pty-errors'
 import type { RuntimePtySpawnState } from './spawn-state'
+import { resolveSecretReferencesIntoChildEnv } from '../../../secret-references/resolve-agent-env-secret-references'
+
+async function resolveChildSpawnOptions(ctx: RuntimePtySpawnState): Promise<PtySpawnOptions> {
+  if (!ctx.spawnOptions.env) {
+    return ctx.spawnOptions
+  }
+  const childEnv = { ...ctx.spawnOptions.env }
+  await resolveSecretReferencesIntoChildEnv({
+    childEnv,
+    target: {
+      ssh: Boolean(ctx.args.connectionId),
+      wsl: ctx.expectedWslDistro !== null
+    }
+  })
+  return { ...ctx.spawnOptions, env: childEnv }
+}
 
 export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise<void> {
   const args = ctx.args
@@ -82,7 +98,8 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
         surface: args.agentSessionEnsure.surface,
         spawn: async () => {
           assertClientStillConnected()
-          providerResult = await ctx.provider.spawn(ctx.spawnOptions)
+          const spawnOptions = await resolveChildSpawnOptions(ctx)
+          providerResult = await ctx.provider.spawn(spawnOptions)
           ctx.rejectedRegistrationCandidate = providerResult
           // Why: a successful lower-owner return proves physical work committed even if admission sees an early exit.
           ctx.reportPtySpawnCommitted()
@@ -127,13 +144,17 @@ export async function executeRuntimePtySpawn(ctx: RuntimePtySpawnState): Promise
       ctx.result.agentSessionEnsure = ensured
     } else {
       assertClientStillConnected()
+      const spawnOptions =
+        ctx.preAdoptedStablePane || stablePaneOwnerCandidate
+          ? ctx.spawnOptions
+          : await resolveChildSpawnOptions(ctx)
       const stablePaneSpawn = ctx.preAdoptedStablePane
         ? ctx.preAdoptedStablePane
         : await spawnForStablePane({
             runtime: ctx.deps.runtime,
             store: ctx.deps.store,
             provider: ctx.provider,
-            spawnOptions: ctx.spawnOptions,
+            spawnOptions,
             owner: stablePaneOwnerCandidate,
             worktreeId: args.worktreeId,
             connectionId: args.connectionId,

--- a/src/main/ipc/pty/runtime/spawn-preflight.ts
+++ b/src/main/ipc/pty/runtime/spawn-preflight.ts
@@ -39,6 +39,8 @@ import { resolveLocalWindowsTerminalRuntimeOptions } from '../../../../shared/lo
 import { resolveLocalProjectRuntimeForWorktreeId } from '../../../local-project-runtime-resolution'
 import { resolvePathEnvKey } from '../../../pty/windows-environment-path'
 import { stampWslOrchestrationCompatibilityHost } from '../../../pty/wsl-orca-env'
+import { classifyAgentEnvSecretReferences } from '../../../../shared/secret-reference'
+import { SecretReferenceResolutionError } from '../../../secret-references/resolve-agent-env-secret-references'
 import { ensureCodexStateDbBackfillRecoveryStarted } from '../../../codex/codex-state-db-backfill-recovery'
 import { clearProviderPtyState } from '../provider/state-cleanup'
 import type { RuntimePtySpawnState } from './spawn-state'
@@ -47,6 +49,10 @@ export async function prepareRuntimePtySpawn(
   ctx: RuntimePtySpawnState
 ): Promise<PtySpawnResult | null> {
   const args = ctx.args
+  const secretReferences = classifyAgentEnvSecretReferences(args.env ?? {})
+  if (secretReferences.kind === 'invalid') {
+    throw new SecretReferenceResolutionError(secretReferences.keys[0], 'invalid-reference')
+  }
   if (!ctx.preAdoptedStablePane) {
     const pathUsable = ctx.deps.assertFolderWorkspacePtyPathUsable(args.worktreeId)
     if (pathUsable) {

--- a/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
@@ -2,7 +2,11 @@ import type { BrowserWindow } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { runProcess } from '../../../../shared/child-process/run-process'
 import { unregisterPty } from '../../../memory/pty-registry'
-import type { IPtyProvider } from '../../../providers/types'
+import { SessionNotFoundError } from '../../../daemon/daemon-errors'
+import type {
+  IPtyProvider,
+  PtySpawnOptions as PtyProviderSpawnOptions
+} from '../../../providers/types'
 import { noCodexResumeLaunch } from '../host-env/codex-resume'
 import { getLocalPtyProvider, localProvider, setLocalPtyProvider } from '../provider/registry'
 import { agentSessionOwners } from '../pane/agent-session-owners'
@@ -92,6 +96,28 @@ function providerWith(spawn: IPtyProvider['spawn']): IPtyProvider {
   const provider = Object.create(localProvider) as IPtyProvider
   provider.spawn = spawn
   return provider
+}
+
+const LEAF_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+function arrangeStableOwnerPane(ctx: ReturnType<typeof createState>, ptyId: string): void {
+  ctx.args.worktreeId = 'workspace-1'
+  ctx.spawnIdentityPaneKey = `tab-1:${LEAF_ID}`
+  let paneRetired = false
+  ctx.deps.runtime = {
+    resolveTerminalPane: () => {
+      if (paneRetired) {
+        throw new Error('terminal_not_found')
+      }
+      return { handle: 'term_stale', ptyId, tabId: 'tab-1', leafId: LEAF_ID, connected: true }
+    },
+    onPtyExit: () => {
+      paneRetired = true
+    }
+  } as unknown as PtyRuntimeControllerDeps['runtime']
+  ctx.deps.store = {
+    getWorkspaceSession: () => ({})
+  } as unknown as PtyRuntimeControllerDeps['store']
 }
 
 describe('runtime PTY secret references', () => {
@@ -252,6 +278,79 @@ describe('runtime PTY secret references', () => {
       }
     }
   )
+
+  it('resolves credentials for the fresh spawn after failed stable-owner adoption', async () => {
+    const ctx = createState()
+    arrangeStableOwnerPane(ctx, 'pty-runtime-stale')
+    ctx.spawnOptions = {
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/claude',
+      env: { POSTHOG_READ_ONLY: REFERENCE }
+    }
+    const spawn = vi.fn(async (options: PtyProviderSpawnOptions) => {
+      if (options.attachOnly) {
+        throw new SessionNotFoundError('pty-runtime-stale')
+      }
+      return { id: 'pty-runtime-fresh' }
+    })
+    ctx.provider = providerWith(spawn)
+
+    await executeRuntimePtySpawn(ctx)
+
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({
+      attachOnly: true,
+      sessionId: 'pty-runtime-stale',
+      env: { POSTHOG_READ_ONLY: REFERENCE }
+    })
+    expect(spawn.mock.calls[1]?.[0]).toEqual({
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/claude',
+      env: { POSTHOG_READ_ONLY: SENTINEL }
+    })
+    expect(ctx.spawnOptions.env).toEqual({ POSTHOG_READ_ONLY: REFERENCE })
+    expect(ctx.result).toMatchObject({ id: 'pty-runtime-fresh' })
+  })
+
+  it('adopts a live stable owner without any secret lookup', async () => {
+    const ctx = createState()
+    arrangeStableOwnerPane(ctx, 'pty-runtime-live')
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    const spawn = vi.fn(async () => ({ id: 'pty-runtime-live', isReattach: true }))
+    ctx.provider = providerWith(spawn)
+
+    await executeRuntimePtySpawn(ctx)
+
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({ attachOnly: true, env: { POSTHOG_READ_ONLY: REFERENCE } })
+    )
+    expect(runProcess).not.toHaveBeenCalled()
+    expect(ctx.result).toMatchObject({ id: 'pty-runtime-live' })
+  })
+
+  it('refuses the fresh spawn when resolution fails after failed adoption', async () => {
+    vi.mocked(runProcess).mockResolvedValue({ ...OK, code: 1 })
+    const ctx = createState()
+    arrangeStableOwnerPane(ctx, 'pty-runtime-gone')
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    const spawn = vi.fn(async (options: PtyProviderSpawnOptions) => {
+      if (options.attachOnly) {
+        throw new SessionNotFoundError('pty-runtime-gone')
+      }
+      return { id: 'pty-runtime-must-not-spawn' }
+    })
+    ctx.provider = providerWith(spawn)
+
+    await expect(executeRuntimePtySpawn(ctx)).rejects.toMatchObject({
+      code: 'nonzero-exit',
+      envKey: 'POSTHOG_READ_ONLY'
+    })
+    expect(spawn).toHaveBeenCalledTimes(1)
+    expect(spawn.mock.calls[0]?.[0]).toMatchObject({ attachOnly: true })
+  })
 
   it('rejects WSL before Doppler or provider spawn', async () => {
     const ctx = createState()

--- a/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../../../shared/child-process/run-process'
+import type { IPtyProvider } from '../../../providers/types'
+import { getLocalPtyProvider, localProvider, setLocalPtyProvider } from '../provider/registry'
+import { agentSessionOwners } from '../pane/agent-session-owners'
+import { executeRuntimePtySpawn } from './spawn-execute'
+import { prepareRuntimePtySpawn } from './spawn-preflight'
+import { createRuntimePtySpawnState } from './spawn-state'
+import type { PtyRuntimeControllerDeps } from './controller-deps'
+
+vi.mock('../../../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+
+const REFERENCE = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
+const SENTINEL = 'sentinel-plaintext-secret'
+
+function createState() {
+  return createRuntimePtySpawnState(
+    { trustedTerminalHandleEnv: new Set<string>() } as PtyRuntimeControllerDeps,
+    { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+  )
+}
+
+function providerWith(spawn: IPtyProvider['spawn']): IPtyProvider {
+  const provider = Object.create(localProvider) as IPtyProvider
+  provider.spawn = spawn
+  return provider
+}
+
+describe('runtime PTY secret references', () => {
+  beforeEach(() => {
+    vi.mocked(runProcess).mockReset()
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: `${SENTINEL}\n`,
+      stderr: '',
+      timedOut: false,
+      outputTruncated: false
+    })
+  })
+
+  it('rejects invalid candidates before account and environment assembly', async () => {
+    const ctx = createState()
+    ctx.args.env = { CODEX_HOME: 'doppler-ref://lets-tango/dev_ops/CODEX_HOME' }
+    const accountSelection = vi.fn()
+    ctx.deps.getSelectedCodexHomePath = accountSelection
+
+    await expect(prepareRuntimePtySpawn(ctx)).rejects.toMatchObject({
+      code: 'invalid-reference',
+      envKey: 'CODEX_HOME'
+    })
+    expect(accountSelection).not.toHaveBeenCalled()
+    expect(runProcess).not.toHaveBeenCalled()
+  })
+
+  it('resolves only the runtime provider input', async () => {
+    const ctx = createState()
+    ctx.spawnOptions = {
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/claude',
+      env: { POSTHOG_READ_ONLY: REFERENCE, CLAUDE_CONFIG_DIR: '/account/claude' }
+    }
+    const spawn = vi.fn(async () => ({ id: 'pty-runtime' }))
+    ctx.provider = providerWith(spawn)
+
+    await executeRuntimePtySpawn(ctx)
+
+    expect(spawn).toHaveBeenCalledWith({
+      cols: 100,
+      rows: 30,
+      command: '/usr/local/bin/claude',
+      env: {
+        POSTHOG_READ_ONLY: SENTINEL,
+        CLAUDE_CONFIG_DIR: '/account/claude'
+      }
+    })
+    expect(ctx.spawnOptions.env).toEqual({
+      POSTHOG_READ_ONLY: REFERENCE,
+      CLAUDE_CONFIG_DIR: '/account/claude'
+    })
+    expect(ctx.spawnOptions.command).toBe('/usr/local/bin/claude')
+  })
+
+  it('resolves a fresh runtime-controller claim without changing durable input', async () => {
+    const ctx = createState()
+    const claim = {
+      digestVersion: 1 as const,
+      keyId: 'key-1',
+      identityDigest: 'a'.repeat(43),
+      worktreeScopeDigest: 'b'.repeat(43),
+      agent: 'codex' as const
+    }
+    ctx.args.agentSessionEnsure = {
+      claim,
+      surface: {
+        worktreeId: 'workspace-1',
+        tabId: 'tab-1',
+        leafId: 'leaf-1',
+        terminalHandle: 'term_claim'
+      }
+    }
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    let spawned = false
+    const spawn = vi.fn(async () => {
+      spawned = true
+      return { id: 'pty-runtime-claim', incarnationId: 'incarnation-1' }
+    })
+    const provider = providerWith(spawn)
+    provider.listProcesses = async () =>
+      spawned
+        ? [
+            {
+              id: 'pty-runtime-claim',
+              incarnationId: 'incarnation-1',
+              cwd: '/work/repo',
+              title: 'codex'
+            }
+          ]
+        : []
+    ctx.provider = provider
+    const previousProvider = getLocalPtyProvider()
+    setLocalPtyProvider(provider)
+
+    try {
+      await executeRuntimePtySpawn(ctx)
+
+      expect(spawn).toHaveBeenCalledWith({
+        cols: 100,
+        rows: 30,
+        env: { POSTHOG_READ_ONLY: SENTINEL }
+      })
+      expect(ctx.spawnOptions.env?.POSTHOG_READ_ONLY).toBe(REFERENCE)
+      expect(ctx.result.agentSessionEnsure).toMatchObject({ disposition: 'created' })
+    } finally {
+      agentSessionOwners.release('pty-runtime-claim')
+      setLocalPtyProvider(previousProvider)
+    }
+  })
+
+  it('rejects WSL before Doppler or provider spawn', async () => {
+    const ctx = createState()
+    ctx.expectedWslDistro = 'Ubuntu'
+    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+    const spawn = vi.fn(async () => ({ id: 'pty-wsl' }))
+    ctx.provider = providerWith(spawn)
+
+    await expect(executeRuntimePtySpawn(ctx)).rejects.toMatchObject({ code: 'remote-target' })
+    expect(runProcess).not.toHaveBeenCalled()
+    expect(spawn).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
@@ -1,23 +1,91 @@
+import type { BrowserWindow } from 'electron'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { runProcess } from '../../../../shared/child-process/run-process'
+import { unregisterPty } from '../../../memory/pty-registry'
 import type { IPtyProvider } from '../../../providers/types'
+import { noCodexResumeLaunch } from '../host-env/codex-resume'
 import { getLocalPtyProvider, localProvider, setLocalPtyProvider } from '../provider/registry'
 import { agentSessionOwners } from '../pane/agent-session-owners'
+import { rendererSerializerReadiness } from '../pane/serializer-state'
+import { finishPtyShutdown } from '../provider/liveness'
+import { ptyIncarnationById, ptyOwnership } from '../provider/ownership-state'
+import { spawnPtyFromRuntimeController } from './spawn'
 import { executeRuntimePtySpawn } from './spawn-execute'
 import { prepareRuntimePtySpawn } from './spawn-preflight'
-import { createRuntimePtySpawnState } from './spawn-state'
+import { createRuntimePtySpawnState, type RuntimePtySpawnArgs } from './spawn-state'
 import type { PtyRuntimeControllerDeps } from './controller-deps'
 
+const { trackMock } = vi.hoisted(() => ({ trackMock: vi.fn() }))
+
 vi.mock('../../../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+vi.mock('../../../telemetry/client', () => ({ track: trackMock }))
 
 const REFERENCE = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
 const SENTINEL = 'sentinel-plaintext-secret'
+const OK = {
+  code: 0,
+  signal: null,
+  stdout: `${SENTINEL}\n`,
+  stderr: '',
+  timedOut: false,
+  outputTruncated: false
+} as const
+
+function createControllerDeps(): PtyRuntimeControllerDeps {
+  return {
+    getLocalPtyStartupPromise: () => undefined,
+    getLocalPtyProviderStartupPromise: () => undefined,
+    adoptStablePane: async () => null,
+    assertFolderWorkspacePtyPathUsable: () => {},
+    resolvePtySpawnStartupCwd: (_worktreeId, cwd) => cwd,
+    prepareCodexResumeHome: () => null,
+    noCodexResumeLaunch,
+    resolveCodexResumeLaunch: async (command) => noCodexResumeLaunch(command),
+    reconcileSharedRuntimeResumeHome: async (resumeHome) => resumeHome.codexHomePath,
+    stripSequencedStartupResumeArgv: (env) => env,
+    requestSerializedBuffer: async () => null,
+    shutdownProviderAndDetectExit: async () => true,
+    rememberSyntheticKillExit: () => {},
+    rememberRetiredRejectedPty: () => {},
+    sendPtyExitToRenderer: vi.fn(),
+    trustedTerminalHandleEnv: new Set<string>(),
+    sendPtySpawnedToRenderer: vi.fn(),
+    finishPtyShutdown,
+    retiredRejectedPtyIds: new Map<string, NodeJS.Timeout>(),
+    reversibleStopOwnersByPtyId: new Map<string, number>(),
+    mainWindow: {} as BrowserWindow
+  }
+}
 
 function createState() {
-  return createRuntimePtySpawnState(
-    { trustedTerminalHandleEnv: new Set<string>() } as PtyRuntimeControllerDeps,
-    { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
-  )
+  return createRuntimePtySpawnState(createControllerDeps(), {
+    cols: 100,
+    rows: 30,
+    env: { POSTHOG_READ_ONLY: REFERENCE }
+  })
+}
+
+function createClaimArgs(): RuntimePtySpawnArgs {
+  return {
+    cols: 100,
+    rows: 30,
+    env: { POSTHOG_READ_ONLY: REFERENCE },
+    agentSessionEnsure: {
+      claim: {
+        digestVersion: 1,
+        keyId: 'key-1',
+        identityDigest: 'a'.repeat(43),
+        worktreeScopeDigest: 'b'.repeat(43),
+        agent: 'codex'
+      },
+      surface: {
+        worktreeId: 'workspace-1',
+        tabId: 'tab-1',
+        leafId: 'leaf-1',
+        terminalHandle: 'term_claim'
+      }
+    }
+  }
 }
 
 function providerWith(spawn: IPtyProvider['spawn']): IPtyProvider {
@@ -29,14 +97,8 @@ function providerWith(spawn: IPtyProvider['spawn']): IPtyProvider {
 describe('runtime PTY secret references', () => {
   beforeEach(() => {
     vi.mocked(runProcess).mockReset()
-    vi.mocked(runProcess).mockResolvedValue({
-      code: 0,
-      signal: null,
-      stdout: `${SENTINEL}\n`,
-      stderr: '',
-      timedOut: false,
-      outputTruncated: false
-    })
+    vi.mocked(runProcess).mockResolvedValue(OK)
+    trackMock.mockReset()
   })
 
   it('rejects invalid candidates before account and environment assembly', async () => {
@@ -82,25 +144,8 @@ describe('runtime PTY secret references', () => {
     expect(ctx.spawnOptions.command).toBe('/usr/local/bin/claude')
   })
 
-  it('resolves a fresh runtime-controller claim without changing durable input', async () => {
-    const ctx = createState()
-    const claim = {
-      digestVersion: 1 as const,
-      keyId: 'key-1',
-      identityDigest: 'a'.repeat(43),
-      worktreeScopeDigest: 'b'.repeat(43),
-      agent: 'codex' as const
-    }
-    ctx.args.agentSessionEnsure = {
-      claim,
-      surface: {
-        worktreeId: 'workspace-1',
-        tabId: 'tab-1',
-        leafId: 'leaf-1',
-        terminalHandle: 'term_claim'
-      }
-    }
-    ctx.spawnOptions = { cols: 100, rows: 30, env: { POSTHOG_READ_ONLY: REFERENCE } }
+  it('resolves a fresh agent-session claim through the runtime controller entry', async () => {
+    const args = createClaimArgs()
     let spawned = false
     const spawn = vi.fn(async () => {
       spawned = true
@@ -118,25 +163,95 @@ describe('runtime PTY secret references', () => {
             }
           ]
         : []
-    ctx.provider = provider
     const previousProvider = getLocalPtyProvider()
     setLocalPtyProvider(provider)
 
     try {
-      await executeRuntimePtySpawn(ctx)
+      const response = await spawnPtyFromRuntimeController(createControllerDeps(), args)
 
-      expect(spawn).toHaveBeenCalledWith({
-        cols: 100,
-        rows: 30,
-        env: { POSTHOG_READ_ONLY: SENTINEL }
+      expect(spawn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: { POSTHOG_READ_ONLY: SENTINEL },
+          agentSessionEnsure: args.agentSessionEnsure
+        })
+      )
+      expect(args.env).toEqual({ POSTHOG_READ_ONLY: REFERENCE })
+      expect(agentSessionOwners.find(args.agentSessionEnsure!.claim)).toMatchObject({
+        ptyId: 'pty-runtime-claim',
+        claim: args.agentSessionEnsure!.claim,
+        surface: args.agentSessionEnsure!.surface
       })
-      expect(ctx.spawnOptions.env?.POSTHOG_READ_ONLY).toBe(REFERENCE)
-      expect(ctx.result.agentSessionEnsure).toMatchObject({ disposition: 'created' })
+      expect(response).toMatchObject({
+        id: 'pty-runtime-claim',
+        incarnationId: 'incarnation-1',
+        agentSessionEnsure: { disposition: 'created' }
+      })
+      expect(JSON.stringify(response)).not.toContain(SENTINEL)
     } finally {
       agentSessionOwners.release('pty-runtime-claim')
+      ptyOwnership.delete('pty-runtime-claim')
+      ptyIncarnationById.delete('pty-runtime-claim')
+      rendererSerializerReadiness.clear('pty-runtime-claim')
+      unregisterPty('pty-runtime-claim')
       setLocalPtyProvider(previousProvider)
     }
   })
+
+  it.each([
+    ['timeout', () => vi.mocked(runProcess).mockResolvedValue({ ...OK, timedOut: true })],
+    ['truncated', () => vi.mocked(runProcess).mockResolvedValue({ ...OK, outputTruncated: true })],
+    ['nonzero-exit', () => vi.mocked(runProcess).mockResolvedValue({ ...OK, code: 1 })],
+    [
+      'empty-output',
+      () => vi.mocked(runProcess).mockResolvedValue({ ...OK, stdout: '', stderr: SENTINEL })
+    ],
+    ['spawn-failure', () => vi.mocked(runProcess).mockRejectedValue(new Error(SENTINEL))]
+  ] as const)(
+    'keeps secret process output out of the %s controller failure boundary',
+    async (code, arrangeFailure) => {
+      arrangeFailure()
+      const args: RuntimePtySpawnArgs = {
+        cols: 100,
+        rows: 30,
+        env: { POSTHOG_READ_ONLY: REFERENCE },
+        telemetry: {
+          agent_kind: 'codex',
+          launch_source: 'new_workspace_composer',
+          request_kind: 'new'
+        }
+      }
+      const spawn = vi.fn(async () => ({ id: 'pty-must-not-spawn' }))
+      const provider = providerWith(spawn)
+      const previousProvider = getLocalPtyProvider()
+      const consoleSpies = [
+        vi.spyOn(console, 'debug').mockImplementation(() => undefined),
+        vi.spyOn(console, 'error').mockImplementation(() => undefined),
+        vi.spyOn(console, 'info').mockImplementation(() => undefined),
+        vi.spyOn(console, 'log').mockImplementation(() => undefined),
+        vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      ]
+      setLocalPtyProvider(provider)
+
+      try {
+        const rejection = spawnPtyFromRuntimeController(createControllerDeps(), args)
+
+        await expect(rejection).rejects.toMatchObject({ code, envKey: 'POSTHOG_READ_ONLY' })
+        await expect(rejection).rejects.not.toThrow(SENTINEL)
+        expect(args.env).toEqual({ POSTHOG_READ_ONLY: REFERENCE })
+        expect(spawn).not.toHaveBeenCalled()
+        expect(trackMock).not.toHaveBeenCalled()
+        expect(JSON.stringify(consoleSpies.flatMap((spy) => spy.mock.calls))).not.toContain(
+          SENTINEL
+        )
+        expect(JSON.stringify(trackMock.mock.calls)).not.toContain(SENTINEL)
+      } finally {
+        setLocalPtyProvider(previousProvider)
+        for (const spy of consoleSpies) {
+          spy.mockRestore()
+        }
+      }
+    }
+  )
 
   it('rejects WSL before Doppler or provider spawn', async () => {
     const ctx = createState()

--- a/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
+++ b/src/main/ipc/pty/runtime/spawn-secret-references.test.ts
@@ -114,10 +114,12 @@ function arrangeStableOwnerPane(ctx: ReturnType<typeof createState>, ptyId: stri
     onPtyExit: () => {
       paneRetired = true
     }
-  } as unknown as PtyRuntimeControllerDeps['runtime']
+  } as Partial<
+    NonNullable<PtyRuntimeControllerDeps['runtime']>
+  > as PtyRuntimeControllerDeps['runtime']
   ctx.deps.store = {
     getWorkspaceSession: () => ({})
-  } as unknown as PtyRuntimeControllerDeps['store']
+  } as Partial<NonNullable<PtyRuntimeControllerDeps['store']>> as PtyRuntimeControllerDeps['store']
 }
 
 describe('runtime PTY secret references', () => {

--- a/src/main/secret-references/resolve-agent-env-secret-references.test.ts
+++ b/src/main/secret-references/resolve-agent-env-secret-references.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+import {
+  resolveSecretReferencesIntoChildEnv,
+  SecretReferenceResolutionError
+} from './resolve-agent-env-secret-references'
+
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+
+const runProcessMock = vi.mocked(runProcess)
+const REFERENCE = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
+const SENTINEL = 'sentinel-plaintext-secret'
+const OK = {
+  code: 0,
+  signal: null,
+  stdout: `${SENTINEL}\n`,
+  stderr: '',
+  timedOut: false,
+  outputTruncated: false
+} as const
+
+describe('resolveSecretReferencesIntoChildEnv', () => {
+  beforeEach(() => {
+    runProcessMock.mockReset()
+    runProcessMock.mockResolvedValue(OK)
+  })
+
+  it('replaces only approved references after every read succeeds', async () => {
+    const childEnv = { POSTHOG_READ_ONLY: REFERENCE, PATH: '/usr/bin' }
+
+    await resolveSecretReferencesIntoChildEnv({
+      childEnv,
+      target: { ssh: false, wsl: false }
+    })
+
+    expect(childEnv).toEqual({ POSTHOG_READ_ONLY: SENTINEL, PATH: '/usr/bin' })
+    expect(runProcessMock).toHaveBeenCalledWith({
+      program: 'doppler',
+      args: [
+        'secrets',
+        'get',
+        'POSTHOG_READ_ONLY',
+        '--project',
+        'lets-tango',
+        '--config',
+        'dev_ops',
+        '--plain'
+      ],
+      timeoutMs: 10_000,
+      maxOutputBytes: 64 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+  })
+
+  it.each([
+    ['ssh', { ssh: true, wsl: false }],
+    ['wsl', { ssh: false, wsl: true }]
+  ] as const)('rejects a %s target before reading a secret', async (_name, target) => {
+    const childEnv = { POSTHOG_READ_ONLY: REFERENCE }
+
+    await expect(resolveSecretReferencesIntoChildEnv({ childEnv, target })).rejects.toMatchObject({
+      code: 'remote-target',
+      envKey: 'POSTHOG_READ_ONLY'
+    })
+    expect(runProcessMock).not.toHaveBeenCalled()
+    expect(childEnv.POSTHOG_READ_ONLY).toBe(REFERENCE)
+  })
+
+  it.each([
+    ['timeout', { ...OK, timedOut: true }],
+    ['truncated', { ...OK, outputTruncated: true }],
+    ['nonzero-exit', { ...OK, code: 1 }],
+    ['empty-output', { ...OK, stdout: '\n' }]
+  ] as const)('reports %s without exposing process output', async (code, result) => {
+    runProcessMock.mockResolvedValue(result)
+    const childEnv = { POSTHOG_READ_ONLY: REFERENCE }
+
+    const rejection = resolveSecretReferencesIntoChildEnv({
+      childEnv,
+      target: { ssh: false, wsl: false }
+    })
+
+    await expect(rejection).rejects.toMatchObject({ code, envKey: 'POSTHOG_READ_ONLY' })
+    await expect(rejection).rejects.not.toThrow(SENTINEL)
+    expect(childEnv.POSTHOG_READ_ONLY).toBe(REFERENCE)
+  })
+
+  it('reports spawn failure without preserving the cause', async () => {
+    runProcessMock.mockRejectedValue(new Error(SENTINEL))
+    const childEnv = { POSTHOG_READ_ONLY: REFERENCE }
+
+    let error: unknown
+    try {
+      await resolveSecretReferencesIntoChildEnv({
+        childEnv,
+        target: { ssh: false, wsl: false }
+      })
+    } catch (cause) {
+      error = cause
+    }
+
+    expect(error).toBeInstanceOf(SecretReferenceResolutionError)
+    expect(error).toMatchObject({ code: 'spawn-failure', envKey: 'POSTHOG_READ_ONLY' })
+    expect(String(error)).not.toContain(SENTINEL)
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined()
+  })
+
+  it('does not apply partial values when a later read fails', async () => {
+    runProcessMock
+      .mockResolvedValueOnce(OK)
+      .mockResolvedValueOnce({ ...OK, stdout: SENTINEL, code: 1 })
+    const childEnv = {
+      POSTHOG_READ_ONLY: REFERENCE,
+      LINEAR_API_KEY: 'doppler-ref://lets-tango/dev_ops/LINEAR_API_KEY'
+    }
+
+    await expect(
+      resolveSecretReferencesIntoChildEnv({
+        childEnv,
+        target: { ssh: false, wsl: false }
+      })
+    ).rejects.toMatchObject({ code: 'nonzero-exit', envKey: 'LINEAR_API_KEY' })
+    expect(childEnv).toEqual({
+      POSTHOG_READ_ONLY: REFERENCE,
+      LINEAR_API_KEY: 'doppler-ref://lets-tango/dev_ops/LINEAR_API_KEY'
+    })
+  })
+
+  it('rejects invalid candidates before running Doppler', async () => {
+    const childEnv = { HOME: 'doppler-ref://lets-tango/dev_ops/HOME' }
+
+    await expect(
+      resolveSecretReferencesIntoChildEnv({
+        childEnv,
+        target: { ssh: false, wsl: false }
+      })
+    ).rejects.toMatchObject({ code: 'invalid-reference', envKey: 'HOME' })
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a destination-key mismatch before running Doppler', async () => {
+    const childEnv = { LINEAR_API_KEY: REFERENCE }
+
+    await expect(
+      resolveSecretReferencesIntoChildEnv({
+        childEnv,
+        target: { ssh: false, wsl: false }
+      })
+    ).rejects.toMatchObject({ code: 'invalid-reference', envKey: 'LINEAR_API_KEY' })
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/secret-references/resolve-agent-env-secret-references.test.ts
+++ b/src/main/secret-references/resolve-agent-env-secret-references.test.ts
@@ -89,20 +89,20 @@ describe('resolveSecretReferencesIntoChildEnv', () => {
     runProcessMock.mockRejectedValue(new Error(SENTINEL))
     const childEnv = { POSTHOG_READ_ONLY: REFERENCE }
 
-    let error: unknown
+    let error: Error | undefined
     try {
       await resolveSecretReferencesIntoChildEnv({
         childEnv,
         target: { ssh: false, wsl: false }
       })
     } catch (cause) {
-      error = cause
+      error = cause instanceof Error ? cause : new Error(String(cause))
     }
 
     expect(error).toBeInstanceOf(SecretReferenceResolutionError)
     expect(error).toMatchObject({ code: 'spawn-failure', envKey: 'POSTHOG_READ_ONLY' })
     expect(String(error)).not.toContain(SENTINEL)
-    expect((error as Error & { cause?: unknown }).cause).toBeUndefined()
+    expect(error?.cause).toBeUndefined()
   })
 
   it('does not apply partial values when a later read fails', async () => {

--- a/src/main/secret-references/resolve-agent-env-secret-references.ts
+++ b/src/main/secret-references/resolve-agent-env-secret-references.ts
@@ -1,0 +1,87 @@
+import { runProcess } from '../../shared/child-process/run-process'
+import { classifyAgentEnvSecretReferences } from '../../shared/secret-reference'
+
+export type SecretReferenceFailureCode =
+  | 'invalid-reference'
+  | 'remote-target'
+  | 'spawn-failure'
+  | 'timeout'
+  | 'truncated'
+  | 'nonzero-exit'
+  | 'empty-output'
+
+export class SecretReferenceResolutionError extends Error {
+  readonly envKey: string
+  readonly code: SecretReferenceFailureCode
+
+  constructor(envKey: string, code: SecretReferenceFailureCode) {
+    super(`Secret reference resolution failed for ${envKey}: ${code}`)
+    this.name = 'SecretReferenceResolutionError'
+    this.envKey = envKey
+    this.code = code
+  }
+}
+
+export type SecretReferenceResolveTarget = {
+  readonly ssh: boolean
+  readonly wsl: boolean
+}
+
+export async function resolveSecretReferencesIntoChildEnv(input: {
+  readonly childEnv: Record<string, string>
+  readonly target: SecretReferenceResolveTarget
+}): Promise<void> {
+  const classification = classifyAgentEnvSecretReferences(input.childEnv)
+  if (classification.kind === 'invalid') {
+    throw new SecretReferenceResolutionError(classification.keys[0], 'invalid-reference')
+  }
+  if (classification.kind === 'none') {
+    return
+  }
+  if (input.target.ssh || input.target.wsl) {
+    throw new SecretReferenceResolutionError(classification.entries[0].key, 'remote-target')
+  }
+
+  const resolvedEntries: (readonly [string, string])[] = []
+  for (const { key, reference } of classification.entries) {
+    let result
+    try {
+      result = await runProcess({
+        program: 'doppler',
+        args: [
+          'secrets',
+          'get',
+          reference.name,
+          '--project',
+          reference.project,
+          '--config',
+          reference.config,
+          '--plain'
+        ],
+        timeoutMs: 10_000,
+        maxOutputBytes: 64 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore']
+      })
+    } catch {
+      throw new SecretReferenceResolutionError(key, 'spawn-failure')
+    }
+    if (result.timedOut) {
+      throw new SecretReferenceResolutionError(key, 'timeout')
+    }
+    if (result.outputTruncated) {
+      throw new SecretReferenceResolutionError(key, 'truncated')
+    }
+    if (result.code !== 0) {
+      throw new SecretReferenceResolutionError(key, 'nonzero-exit')
+    }
+    const value = result.stdout.replace(/\r?\n$/, '')
+    if (value.length === 0) {
+      throw new SecretReferenceResolutionError(key, 'empty-output')
+    }
+    resolvedEntries.push([key, value])
+  }
+
+  for (const [key, value] of resolvedEntries) {
+    input.childEnv[key] = value
+  }
+}

--- a/src/renderer/src/lib/agent-launch-routing.test.ts
+++ b/src/renderer/src/lib/agent-launch-routing.test.ts
@@ -181,6 +181,69 @@ describe('resolveAgentLaunchRoute', () => {
     ).toBe(false)
   })
 
+  it('keeps approved secret-reference-only environments structured-compatible', () => {
+    expect(
+      hasExplicitTuiLaunchCustomization(
+        {
+          agentCmdOverrides: {},
+          agentDefaultArgs: {},
+          agentDefaultEnv: {
+            codex: {
+              POSTHOG_READ_ONLY: 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY',
+              LINEAR_API_KEY: 'doppler-ref://lets-tango/dev_ops/LINEAR_API_KEY'
+            }
+          }
+        },
+        'codex'
+      )
+    ).toBe(false)
+  })
+
+  it('keeps other environment customization on the terminal-backed route', () => {
+    expect(
+      hasExplicitTuiLaunchCustomization(
+        {
+          agentCmdOverrides: {},
+          agentDefaultArgs: {},
+          agentDefaultEnv: {
+            codex: {
+              POSTHOG_READ_ONLY: 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY',
+              CODEX_PROFILE: 'review'
+            }
+          }
+        },
+        'codex'
+      )
+    ).toBe(true)
+  })
+
+  it('fails closed for malformed and mismatched reference candidates', () => {
+    expect(() =>
+      hasExplicitTuiLaunchCustomization(
+        {
+          agentCmdOverrides: {},
+          agentDefaultArgs: {},
+          agentDefaultEnv: {
+            codex: { POSTHOG_READ_ONLY: 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY?raw' }
+          }
+        },
+        'codex'
+      )
+    ).toThrow('Invalid secret reference for POSTHOG_READ_ONLY')
+    expect(() =>
+      hasExplicitTuiLaunchCustomization(
+        {
+          agentCmdOverrides: {},
+          agentDefaultArgs: {},
+          agentDefaultEnv: {
+            codex: { LINEAR_API_KEY: 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY' }
+          }
+        },
+        'codex'
+      )
+    ).toThrow('Invalid secret reference for LINEAR_API_KEY')
+  })
+
   it('does not classify the resolved default TUI args as customization', () => {
     expect(hasExplicitTuiAgentArgs('codex', '--dangerously-bypass-approvals-and-sandbox')).toBe(
       false

--- a/src/renderer/src/lib/agent-launch-routing.ts
+++ b/src/renderer/src/lib/agent-launch-routing.ts
@@ -7,6 +7,7 @@ import {
   getTuiAgentDefaultArgs,
   getTuiAgentDefaultEnv
 } from '../../../shared/tui-agent-launch-defaults'
+import { classifyAgentEnvSecretReferences } from '../../../shared/secret-reference'
 import {
   decideInitialAgentTabViewMode,
   type NativeChatLaunchPromptDelivery
@@ -47,15 +48,36 @@ export function hasExplicitTuiLaunchCustomization(
   const configuredArgs = settings?.agentDefaultArgs?.[agent]
   const configuredEnv = settings?.agentDefaultEnv?.[agent]
   const defaultEnv = getTuiAgentDefaultEnv(agent)
-  const envIsCustomized =
-    configuredEnv !== undefined &&
-    (Object.keys(configuredEnv).length !== Object.keys(defaultEnv).length ||
-      Object.entries(configuredEnv).some(([key, value]) => defaultEnv[key] !== value))
+  const envIsCustomized = hasNonReferenceEnvironmentCustomization(configuredEnv, defaultEnv)
   return (
     Boolean(settings?.agentCmdOverrides?.[agent]?.trim()) ||
     hasExplicitTuiAgentArgs(agent, configuredArgs) ||
     envIsCustomized
   )
+}
+
+function hasNonReferenceEnvironmentCustomization(
+  configuredEnv: Readonly<Record<string, string>> | undefined,
+  defaultEnv: Readonly<Record<string, string>>
+): boolean {
+  if (configuredEnv === undefined) {
+    return false
+  }
+  const classification = classifyAgentEnvSecretReferences(configuredEnv)
+  if (classification.kind === 'invalid') {
+    throw new Error(`Invalid secret reference for ${classification.keys[0]}`)
+  }
+  const referenceKeys = new Set(
+    classification.kind === 'valid' ? classification.entries.map(({ key }) => key) : []
+  )
+  if (
+    Object.entries(configuredEnv).some(
+      ([key, value]) => defaultEnv[key] !== value && !referenceKeys.has(key)
+    )
+  ) {
+    return true
+  }
+  return Object.entries(defaultEnv).some(([key, value]) => configuredEnv[key] !== value)
 }
 
 export function hasSemanticallyNonEmptyAgentArgs(value: string | null | undefined): boolean {

--- a/src/shared/secret-reference.test.ts
+++ b/src/shared/secret-reference.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyAgentEnvSecretReferences,
+  isSecretReferenceCandidate,
+  validateSecretReference
+} from './secret-reference'
+
+const POSTHOG_REFERENCE = 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY'
+
+describe('secret reference validation', () => {
+  it('parses approved references and classifies their destination keys', () => {
+    expect(validateSecretReference('POSTHOG_READ_ONLY', POSTHOG_REFERENCE)).toEqual({
+      ok: true,
+      reference: {
+        project: 'lets-tango',
+        config: 'dev_ops',
+        name: 'POSTHOG_READ_ONLY'
+      }
+    })
+    expect(
+      classifyAgentEnvSecretReferences({
+        PATH: '/usr/bin',
+        POSTHOG_READ_ONLY: POSTHOG_REFERENCE,
+        LINEAR_API_KEY: 'doppler-ref://lets-tango/dev_ops/LINEAR_API_KEY'
+      })
+    ).toEqual({
+      kind: 'valid',
+      entries: [
+        {
+          key: 'POSTHOG_READ_ONLY',
+          reference: {
+            project: 'lets-tango',
+            config: 'dev_ops',
+            name: 'POSTHOG_READ_ONLY'
+          }
+        },
+        {
+          key: 'LINEAR_API_KEY',
+          reference: {
+            project: 'lets-tango',
+            config: 'dev_ops',
+            name: 'LINEAR_API_KEY'
+          }
+        }
+      ]
+    })
+  })
+
+  it.each([
+    'doppler-ref:',
+    'doppler-ref://',
+    'doppler-ref://lets-tango/dev_ops',
+    'doppler-ref://lets-tango//POSTHOG_READ_ONLY',
+    'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY/extra',
+    'doppler-ref://lets tango/dev_ops/POSTHOG_READ_ONLY',
+    'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY\n',
+    'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY?raw=true',
+    'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY#value'
+  ])('fails closed for malformed candidate %s', (value) => {
+    expect(isSecretReferenceCandidate(value)).toBe(true)
+    expect(validateSecretReference('POSTHOG_READ_ONLY', value)).toEqual({
+      ok: false,
+      code: 'malformed'
+    })
+  })
+
+  it('rejects destination mismatches and names outside the allowlist', () => {
+    expect(validateSecretReference('LINEAR_API_KEY', POSTHOG_REFERENCE)).toEqual({
+      ok: false,
+      code: 'key-name-mismatch'
+    })
+    expect(validateSecretReference('HOME', 'doppler-ref://lets-tango/dev_ops/HOME')).toEqual({
+      ok: false,
+      code: 'name-not-approved'
+    })
+    expect(
+      validateSecretReference('CODEX_HOME', 'doppler-ref://lets-tango/dev_ops/CODEX_HOME')
+    ).toEqual({ ok: false, code: 'name-not-approved' })
+  })
+
+  it('ignores ordinary values and reports every invalid candidate key', () => {
+    expect(classifyAgentEnvSecretReferences({ PATH: '/usr/bin' })).toEqual({ kind: 'none' })
+    expect(
+      classifyAgentEnvSecretReferences({
+        POSTHOG_READ_ONLY: 'doppler-ref://lets-tango/dev_ops/POSTHOG_READ_ONLY?raw=true',
+        HOME: 'doppler-ref://lets-tango/dev_ops/HOME',
+        PATH: '/usr/bin'
+      })
+    ).toEqual({ kind: 'invalid', keys: ['POSTHOG_READ_ONLY', 'HOME'] })
+  })
+})

--- a/src/shared/secret-reference.ts
+++ b/src/shared/secret-reference.ts
@@ -1,0 +1,73 @@
+export const SECRET_REFERENCE_PREFIX = 'doppler-ref:'
+export const APPROVED_SECRET_REFERENCE_NAMES = ['POSTHOG_READ_ONLY', 'LINEAR_API_KEY'] as const
+export type ApprovedSecretReferenceName = (typeof APPROVED_SECRET_REFERENCE_NAMES)[number]
+
+export type SecretReference = {
+  readonly project: string
+  readonly config: string
+  readonly name: ApprovedSecretReferenceName
+}
+
+export type SecretReferenceValidation =
+  | { readonly ok: true; readonly reference: SecretReference }
+  | {
+      readonly ok: false
+      readonly code: 'malformed' | 'key-name-mismatch' | 'name-not-approved'
+    }
+
+export type AgentEnvSecretReferenceClassification =
+  | { readonly kind: 'none' }
+  | {
+      readonly kind: 'valid'
+      readonly entries: readonly { readonly key: string; readonly reference: SecretReference }[]
+    }
+  | { readonly kind: 'invalid'; readonly keys: readonly string[] }
+
+const SECRET_REFERENCE_PATTERN = /^doppler-ref:\/\/([^/\s?#]+)\/([^/\s?#]+)\/([^/\s?#]+)$/
+
+export function isSecretReferenceCandidate(value: string): boolean {
+  return value.startsWith(SECRET_REFERENCE_PREFIX)
+}
+
+export function validateSecretReference(envKey: string, value: string): SecretReferenceValidation {
+  if (/\s/.test(value)) {
+    return { ok: false, code: 'malformed' }
+  }
+  const match = SECRET_REFERENCE_PATTERN.exec(value)
+  if (!match) {
+    return { ok: false, code: 'malformed' }
+  }
+  const [, project, config, name] = match
+  if (envKey !== name) {
+    return { ok: false, code: 'key-name-mismatch' }
+  }
+  if (!(APPROVED_SECRET_REFERENCE_NAMES as readonly string[]).includes(name)) {
+    return { ok: false, code: 'name-not-approved' }
+  }
+  return {
+    ok: true,
+    reference: { project, config, name: name as ApprovedSecretReferenceName }
+  }
+}
+
+export function classifyAgentEnvSecretReferences(
+  env: Readonly<Record<string, string>>
+): AgentEnvSecretReferenceClassification {
+  const entries: { readonly key: string; readonly reference: SecretReference }[] = []
+  const invalidKeys: string[] = []
+  for (const [key, value] of Object.entries(env)) {
+    if (!isSecretReferenceCandidate(value)) {
+      continue
+    }
+    const validation = validateSecretReference(key, value)
+    if (validation.ok) {
+      entries.push({ key, reference: validation.reference })
+    } else {
+      invalidKeys.push(key)
+    }
+  }
+  if (invalidKeys.length > 0) {
+    return { kind: 'invalid', keys: invalidKeys }
+  }
+  return entries.length > 0 ? { kind: 'valid', entries } : { kind: 'none' }
+}


### PR DESCRIPTION
## ELI5

Agent environment values can enter saved resume state. This adds opt-in Doppler references so saved state holds references and each agent process receives the resolved credential.

## What Changed

- Accept `doppler-ref://<project>/<config>/<SECRET_NAME>` for matching `POSTHOG_READ_ONLY` and `LINEAR_API_KEY` environment keys.
- Validate references before account preparation and resolve them into temporary child environments at spawn time.
- Cover both PTY controllers and structured Codex. Approved reference-only environments retain structured routing.
- Reject SSH/WSL targets and malformed references before secret lookup or agent spawn. Bound Doppler lookup and suppress its output in public errors.

## Why

Bootstrap shell exports cannot supply a separately launched agent. Putting credential values into saved agent environment settings also persists them. Spawn-time resolution supplies the credential while preserving the managed account environment.

The execution host needs an authenticated Doppler CLI. Settings contain a reference such as `doppler-ref://my-project/dev_ops/POSTHOG_READ_ONLY`.

## Linked Issue

[DIG-3549](https://linear.app/digital-philosophy/issue/DIG-3549)

## Visual Proof

N/A. This changes process environment handling.

## Testing

Validated head: `88de6c67c3483fa9ad306badcd7ed7d3c92e9840`.

Independent QA passed on macOS: 82 tests across seven targeted Vitest suites, full lint, typecheck, scoped formatting, and `build:electron-vite`. Regression coverage includes a missing saved terminal, successful terminal reuse, and lookup failure before a fresh spawn.

Cross-vendor depth review passed with no remaining findings. The advisory Kimi K3 run timed out without a verdict.

- [ ] Real launch, resume, and account-switch acceptance completed
- [x] Automated tests added for validation, process failures, routing, account preservation, and retained state
- [x] Independent QA and review completed

SSH and WSL refusal have unit coverage. Native remote resolution is unsupported. Live agent/MCP acceptance remains pending. The installed Orca application is unchanged.

The required `$electron` skill is unavailable in this environment. Structured launch, restart/resume, and account-switch checks need that supported UI validation path. No development app was launched for acceptance.

## AI Disclosure

Implementation used GPT-5.6-Sol and Claude Fable. Grok 4.5 performed independent QA. Claude Opus reviewed the initial implementation; GPT-5.6-Terra reviewed the correction.

## Review

Draft pending live operational acceptance and upstream review. Local code checks and independent review are complete.

## Agent skill upstream boundary

- [x] Not applicable. This change copies no upstream skill-installer material.

## Notes

The two-name allowlist limits this first implementation. It adds no secret values to settings, saved sessions, or launch commands.

## Checklist

- [x] This PR is focused on agent credential delivery
- [x] The change and its purpose are explained
- [x] Visual proof marked N/A with a reason
- [x] Independent correctness, security, and performance review completed
- [x] Platform and SSH/WSL behavior considered
- [ ] Full repository test/build and hosted CI completed
