### PR TITLE
test: wait for board pointer readiness before marquee selection

### DIFF
--- a/tests/e2e/workspace-board-lane-virtualization.spec.ts
+++ b/tests/e2e/workspace-board-lane-virtualization.spec.ts
@@ -307,7 +307,6 @@ test.describe('Workspace board lane virtualization', () => {
   })
 
   test('selects the full lane across a single large marquee scroll jump', async ({ orcaPage }) => {
-    test.skip(true, 'Quarantined by https://github.com/stablyai/orca/issues/12415')
     const statusId = 'virtual-marquee'
     const emptyStatusId = 'virtual-marquee-start'
     await orcaPage.evaluate(
@@ -380,32 +379,36 @@ test.describe('Workspace board lane virtualization', () => {
     }
 
     // Why: CI can overlay individual lane pixels, so choose a live board-owned point.
-    const startPoint = await emptyLaneScroll.evaluate((element) => {
-      const ignored = [
-        '[data-workspace-board-card-id]',
-        'a',
-        'button',
-        'input',
-        'select',
-        'textarea',
-        '[role="button"]',
-        '[role="menu"]',
-        '[role="menuitem"]'
-      ].join(',')
-      const rect = element.getBoundingClientRect()
-      for (let y = Math.ceil(rect.top) + 6; y <= Math.floor(rect.top) + 40; y += 6) {
-        for (let x = Math.ceil(rect.left) + 8; x <= Math.floor(rect.right) - 8; x += 8) {
-          const target = document.elementFromPoint(x, y)
-          if (
-            target?.closest('[data-workspace-board-selection-surface]') &&
-            !target.closest(ignored)
-          ) {
-            return { x, y }
+    const findStartPoint = () =>
+      emptyLaneScroll.evaluate((element) => {
+        const ignored = [
+          '[data-workspace-board-card-id]',
+          'a',
+          'button',
+          'input',
+          'select',
+          'textarea',
+          '[role="button"]',
+          '[role="menu"]',
+          '[role="menuitem"]'
+        ].join(',')
+        const rect = element.getBoundingClientRect()
+        for (let y = Math.ceil(rect.top) + 6; y <= Math.floor(rect.top) + 40; y += 6) {
+          for (let x = Math.ceil(rect.left) + 8; x <= Math.floor(rect.right) - 8; x += 8) {
+            const target = document.elementFromPoint(x, y)
+            if (
+              target?.closest('[data-workspace-board-selection-surface]') &&
+              !target.closest(ignored)
+            ) {
+              return { x, y }
+            }
           }
         }
-      }
-      return null
-    })
+        return null
+      })
+    // The board's clip animation can expose cards before the empty lane accepts pointer hits.
+    await expect.poll(findStartPoint).not.toBeNull()
+    const startPoint = await findStartPoint()
     expect(startPoint, 'the empty start lane must expose board-owned space').not.toBeNull()
     if (!startPoint) {
       throw new Error('Expected empty board space for the marquee start')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The quarantined board marquee test could inspect card visibility while the board's opening clip animation still exposed the terminal underneath to pointer hits. Its one-shot search for empty board space returned null before the drag began.

Wait until the same hit-test finds board-owned space, then perform the original drag and full-lane selection assertions. Remove the quarantine. The drag, scroll stabilization, 102-card expectation, and existing timeouts remain unchanged.

Validation: all four board virtualization tests passed three repetitions on main with this test-only fix (12/12), including all three full-lane marquee journeys: https://github.com/stablyai/orca/actions/runs/34016500968. The diagnostic before the fix reproduced hits on the terminal underlay while the board animation was at 0 ms. Changed-file lint and format pass.
