### PR TITLE
perf(history): probe checkpoint generation from the file head

### DIFF
--- a/src/main/daemon/terminal-checkpoint-serializer.test.ts
+++ b/src/main/daemon/terminal-checkpoint-serializer.test.ts
@@ -44,6 +44,9 @@ describe('terminal checkpoint serializer', () => {
       oscLinks: [{ row: 0, startCol: 0, endCol: 1, uri: 'https://example.com/😀\n' }]
     })
     const expected = JSON.stringify({
+      // Why first: the writer emits generation first so warm-reattach generation
+      // reads can probe the checkpoint head instead of parsing the full body.
+      generation: metadata.generation,
       snapshotAnsi: input.snapshotAnsi,
       scrollbackAnsi: input.scrollbackAnsi,
       oscLinks: input.oscLinks,
@@ -53,7 +56,6 @@ describe('terminal checkpoint serializer', () => {
       rows: input.rows,
       modes: input.modes,
       scrollbackLines: input.scrollbackLines,
-      generation: metadata.generation,
       checkpointedAt: metadata.checkpointedAt
     })
     const exactBytes = Buffer.byteLength(expected, 'utf8')
@@ -69,6 +71,9 @@ describe('terminal checkpoint serializer', () => {
       scrollbackLines: 100
     })
     const expected = JSON.stringify({
+      // Why first: the writer emits generation first so warm-reattach generation
+      // reads can probe the checkpoint head instead of parsing the full body.
+      generation: metadata.generation,
       snapshotAnsi: input.snapshotAnsi,
       scrollbackAnsi: input.scrollbackAnsi,
       oscLinks: input.oscLinks,
@@ -78,7 +83,6 @@ describe('terminal checkpoint serializer', () => {
       rows: input.rows,
       modes: input.modes,
       scrollbackLines: input.scrollbackLines,
-      generation: metadata.generation,
       checkpointedAt: metadata.checkpointedAt
     })
     const maxBytes = expected.length + 1

--- a/src/main/daemon/terminal-checkpoint-serializer.ts
+++ b/src/main/daemon/terminal-checkpoint-serializer.ts
@@ -14,6 +14,10 @@ function checkpointFile(
   metadata: CheckpointMetadata
 ): TerminalCheckpointFile {
   return {
+    // Why first: warm reattach only needs the generation number, and probing it
+    // from the file head lets TerminalHistorySessionWriter skip parsing a body
+    // that can reach TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES.
+    generation: metadata.generation,
     snapshotAnsi: snapshot.snapshotAnsi,
     scrollbackAnsi: snapshot.scrollbackAnsi,
     oscLinks: snapshot.oscLinks,
@@ -28,7 +32,6 @@ function checkpointFile(
     scrollbackLines: snapshot.scrollbackLines,
     ...(snapshot.lastTitle ? { lastTitle: snapshot.lastTitle } : {}),
     ...(snapshot.terminalOwner ? { terminalOwner: snapshot.terminalOwner } : {}),
-    generation: metadata.generation,
     ...(metadata.pendingOutputSeq !== undefined
       ? { pendingOutputSeq: metadata.pendingOutputSeq }
       : {}),

--- a/src/main/daemon/terminal-checkpoint-writer-bounds.test.ts
+++ b/src/main/daemon/terminal-checkpoint-writer-bounds.test.ts
@@ -171,8 +171,9 @@ describe('bounded terminal checkpoint writer', () => {
     writeFileSync(join(sessionDir, 'checkpoint.json'), '{"generation":123456789')
     expect(probeCheckpointGenerationHead(join(sessionDir, 'checkpoint.json'))).toBeNull()
 
-    // A malformed head must fall back to the full parse, which still fails to
-    // yield a number here (truncated JSON) — so the writer treats it as absent.
+    // A head whose digits are closed by a valid boundary (`,` next key) resolves
+    // directly from the probe even though the body is truncated — boundary
+    // validity, not body completeness, is what the probe certifies.
     writeFileSync(join(sessionDir, 'checkpoint.json'), '{"generation":12,"snapshotAnsi"')
     expect(probeCheckpointGenerationHead(join(sessionDir, 'checkpoint.json'))).toBe(12)
     expect(probeCheckpointGenerationHead(join(dir, 'missing', 'checkpoint.json'))).toBeNull()

--- a/src/main/daemon/terminal-checkpoint-writer-bounds.test.ts
+++ b/src/main/daemon/terminal-checkpoint-writer-bounds.test.ts
@@ -162,4 +162,19 @@ describe('bounded terminal checkpoint writer', () => {
       closeSync(logFd)
     }
   })
+
+  it('rejects digit prefixes without a JSON token boundary and falls back to the full parse', async () => {
+    const sessionDir = join(dir, getHistorySessionDirName(SESSION_ID))
+    mkdirSync(sessionDir, { recursive: true })
+    // Truncated head: a digit run with no closing token — the probe must not
+    // accept "12" out of "123456789..." as a generation.
+    writeFileSync(join(sessionDir, 'checkpoint.json'), '{"generation":123456789')
+    expect(probeCheckpointGenerationHead(join(sessionDir, 'checkpoint.json'))).toBeNull()
+
+    // A malformed head must fall back to the full parse, which still fails to
+    // yield a number here (truncated JSON) — so the writer treats it as absent.
+    writeFileSync(join(sessionDir, 'checkpoint.json'), '{"generation":12,"snapshotAnsi"')
+    expect(probeCheckpointGenerationHead(join(sessionDir, 'checkpoint.json'))).toBe(12)
+    expect(probeCheckpointGenerationHead(join(dir, 'missing', 'checkpoint.json'))).toBeNull()
+  })
 })

--- a/src/main/daemon/terminal-checkpoint-writer-bounds.test.ts
+++ b/src/main/daemon/terminal-checkpoint-writer-bounds.test.ts
@@ -1,10 +1,26 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { HistoryManager } from './history-manager'
 import { HistoryReader } from './history-reader'
 import { getHistorySessionDirName } from './history-paths'
+import { decodeLogHeader, LOG_HEADER_BYTES } from './terminal-history-log'
+import {
+  probeCheckpointGenerationHead,
+  TerminalHistorySessionWriter
+} from './terminal-history-session-writer'
 import type { TerminalSnapshot } from './types'
 
 const SESSION_ID = 'bounded-checkpoint'
@@ -103,5 +119,47 @@ describe('bounded terminal checkpoint writer', () => {
     const restored = await new HistoryReader(dir).detectColdRestore(SESSION_ID)
 
     expect(restored?.snapshotAnsi).toContain('\x1b[31mRED')
+  })
+
+  it('emits generation first so warm reattach can probe the checkpoint head', async () => {
+    const manager = new HistoryManager(dir)
+    await manager.openSession(SESSION_ID, { cwd: '/workspace', cols: 80, rows: 24 })
+    await expect(manager.checkpoint(SESSION_ID, snapshot('first'))).resolves.toBe('committed')
+    const checkpointPath = join(dir, getHistorySessionDirName(SESSION_ID), 'checkpoint.json')
+    expect(probeCheckpointGenerationHead(checkpointPath)).toBe(1)
+    await expect(manager.checkpoint(SESSION_ID, snapshot('second'))).resolves.toBe('committed')
+    expect(probeCheckpointGenerationHead(checkpointPath)).toBe(2)
+  })
+
+  it('falls back to a full parse for legacy checkpoints without a leading generation', async () => {
+    const sessionDir = join(dir, getHistorySessionDirName(SESSION_ID))
+    mkdirSync(sessionDir, { recursive: true })
+    const legacyCheckpoint = {
+      snapshotAnsi: 'body',
+      scrollbackAnsi: 'x'.repeat(4096),
+      oscLinks: [],
+      rehydrateSequences: '',
+      cwd: null,
+      cols: 80,
+      rows: 24,
+      modes: snapshot('modes-only').modes,
+      scrollbackLines: 0,
+      generation: 7
+    }
+    writeFileSync(join(sessionDir, 'checkpoint.json'), JSON.stringify(legacyCheckpoint))
+
+    expect(probeCheckpointGenerationHead(join(sessionDir, 'checkpoint.json'))).toBeNull()
+
+    const writer = new TerminalHistorySessionWriter(sessionDir, false)
+    await writer.appendIncrements(0, [{ kind: 'output', data: 'warm' }])
+
+    const logFd = openSync(join(sessionDir, 'output.log'), 'r')
+    try {
+      const logHeader = Buffer.alloc(LOG_HEADER_BYTES)
+      readSync(logFd, logHeader, 0, LOG_HEADER_BYTES, 0)
+      expect(decodeLogHeader(logHeader)).toBe(7)
+    } finally {
+      closeSync(logFd)
+    }
   })
 })

--- a/src/main/daemon/terminal-history-session-writer.ts
+++ b/src/main/daemon/terminal-history-session-writer.ts
@@ -33,7 +33,10 @@ export function probeCheckpointGenerationHead(path: string): number | null {
     fd = openSync(path, 'r')
     const head = Buffer.alloc(GENERATION_HEAD_PROBE_BYTES)
     const read = readSync(fd, head, 0, GENERATION_HEAD_PROBE_BYTES, 0)
-    const match = head.toString('utf8', 0, read).match(/^\{"generation":(\d+)/)
+    // The token boundary after the digits (`,"` next key, or `}` sole key) must
+    // close the match, or a truncated/corrupt head could accept a digit prefix
+    // of something that is not this file's generation.
+    const match = head.toString('utf8', 0, read).match(/^\{"generation":(\d+)(?:"|,|})/)
     return match ? Number(match[1]) : null
   } catch {
     return null

--- a/src/main/daemon/terminal-history-session-writer.ts
+++ b/src/main/daemon/terminal-history-session-writer.ts
@@ -27,16 +27,21 @@ const LOG_MAX_BYTES = 5 * 1024 * 1024
 // emits generation as the first JSON key, so the number is provably in the head.
 const GENERATION_HEAD_PROBE_BYTES = 128
 
+/**
+ * Read the generation from the head of a checkpoint file without parsing the
+ * body. Returns null for missing/unreadable files, legacy layouts, or any head
+ * that is not exactly `{"generation":<digits>` closed by a JSON token boundary.
+ */
 export function probeCheckpointGenerationHead(path: string): number | null {
   let fd: number | undefined
   try {
     fd = openSync(path, 'r')
     const head = Buffer.alloc(GENERATION_HEAD_PROBE_BYTES)
     const read = readSync(fd, head, 0, GENERATION_HEAD_PROBE_BYTES, 0)
-    // The token boundary after the digits (`,"` next key, or `}` sole key) must
+    // The token boundary after the digits (`,` next key, or `}` sole key) must
     // close the match, or a truncated/corrupt head could accept a digit prefix
     // of something that is not this file's generation.
-    const match = head.toString('utf8', 0, read).match(/^\{"generation":(\d+)(?:"|,|})/)
+    const match = head.toString('utf8', 0, read).match(/^\{"generation":(\d+)(?:,|})/)
     return match ? Number(match[1]) : null
   } catch {
     return null
@@ -151,6 +156,10 @@ export class TerminalHistorySessionWriter {
     this.logGeneration = this.readCheckpointGeneration() ?? 0
   }
 
+  /**
+   * Resolve the persisted checkpoint generation: head probe first, full parse
+   * only for legacy layouts the probe cannot certify.
+   */
   private readCheckpointGeneration(): number | null {
     const probed = probeCheckpointGenerationHead(this.checkpointPath)
     if (probed !== null) {

--- a/src/main/daemon/terminal-history-session-writer.ts
+++ b/src/main/daemon/terminal-history-session-writer.ts
@@ -22,6 +22,28 @@ import { serializeTerminalCheckpointWithinLimit } from './terminal-checkpoint-se
 // Why 5MB: bounds cold-restore replay time and per-session disk; hitting the cap triggers one checkpoint that resets the log.
 const LOG_MAX_BYTES = 5 * 1024 * 1024
 
+// Why a head probe: warm reattach only needs the generation number, but
+// checkpoint.json can reach TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES; the writer
+// emits generation as the first JSON key, so the number is provably in the head.
+const GENERATION_HEAD_PROBE_BYTES = 128
+
+export function probeCheckpointGenerationHead(path: string): number | null {
+  let fd: number | undefined
+  try {
+    fd = openSync(path, 'r')
+    const head = Buffer.alloc(GENERATION_HEAD_PROBE_BYTES)
+    const read = readSync(fd, head, 0, GENERATION_HEAD_PROBE_BYTES, 0)
+    const match = head.toString('utf8', 0, read).match(/^\{"generation":(\d+)/)
+    return match ? Number(match[1]) : null
+  } catch {
+    return null
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd)
+    }
+  }
+}
+
 export class TerminalHistorySessionWriter {
   readonly checkpointPath: string
   readonly logPath: string
@@ -127,6 +149,11 @@ export class TerminalHistorySessionWriter {
   }
 
   private readCheckpointGeneration(): number | null {
+    const probed = probeCheckpointGenerationHead(this.checkpointPath)
+    if (probed !== null) {
+      return probed
+    }
+    // Legacy checkpoints keep generation late in the JSON; only they pay the full parse.
     try {
       const checkpoint = JSON.parse(readFileSync(this.checkpointPath, 'utf-8'))
       return typeof checkpoint.generation === 'number' ? checkpoint.generation : null


### PR DESCRIPTION
## ELI5

When Orca re-attaches to a terminal session after a restart, it needs one small number ("which revision is this checkpoint?") out of a file that can be up to 200 MB. The old code read and parsed the whole file to get it. Now the number is written at the very front of the file, so we read the first 128 bytes and stop.

## What Changed

- `checkpointFile()` now emits `generation` as the **first JSON key** of `checkpoint.json`.
- `TerminalHistorySessionWriter.readCheckpointGeneration()` probes the file head with a bounded 128-byte `readSync` (`probeCheckpointGenerationHead`) instead of reading + `JSON.parse`ing up to `TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES` (200 MB).
- The probe requires a JSON token boundary after the digits (`"`, `,`, or `}`) so a truncated/corrupt head can never yield a fabricated generation; anything else returns null and falls through to the legacy full-parse path.
- Legacy checkpoints whose layout keeps `generation` late still resolve via the unchanged full-parse fallback.

## Why

A warm reattach with no `output.log` header only needs the generation integer, but the old path materialized up to 200 MB of `snapshotAnsi`/`scrollbackAnsi` on the heap and blocked the daemon main thread on a full parse — repeated for every session on every `registerWriter` in a daemon restart loop. Head-probing turns that into a 128-byte read. Key-order-only change; JSON consumers are order-insensitive, so there is no wire or on-disk schema change.

## Linked Issue

Related memory-pressure background: #12728 (terminal-daemon private memory growth). This removes one of the worst per-reattach heap transients in that area.

## Visual Proof

N/A — no UI or behavior change; this is an internal read-path optimization with identical outputs.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- New tests in `terminal-checkpoint-writer-bounds.test.ts`: committed checkpoints probe their generation from the head across two commits; legacy checkpoints (generation late in the JSON) fall back to a full parse and still resolve; truncated digit runs without a token boundary are rejected.
- `terminal-checkpoint-serializer.test.ts` byte-exactness expectations updated to the new canonical key order.
- Local runs: full checkpoint-path regression suite (104 tests across `terminal-checkpoint-writer-bounds` / `terminal-checkpoint-serializer` / `daemon-pty-adapter-history-checkpoints` / `history-manager` / `history-reader` / `terminal-history-large-checkpoint-cold-restore`), `pnpm run typecheck:node`, `pnpm run check:code-quality:changed` — all green on macOS (Darwin 24.6.0, arm64).
