### PR TITLE
feat(runtime): make per-PTY headless mirror scrollback operator-tunable

### DIFF
--- a/src/main/runtime/orca-runtime-create-pty-headless-terminal-state.ts
+++ b/src/main/runtime/orca-runtime-create-pty-headless-terminal-state.ts
@@ -2,6 +2,7 @@
 import { OrcaRuntimeWithMaybeHydrateHeadlessFromRenderer } from './orca-runtime-maybe-hydrate-headless-from-renderer'
 import type { RuntimeHeadlessTerminal } from './runtime-terminal-state-records'
 import { HeadlessEmulator } from '../daemon/headless-emulator'
+import { resolveRuntimeSessionScrollbackRows } from './runtime-session-scrollback-window'
 import { shouldForwardHeadlessTerminalQueryReply } from './headless-terminal-query-reply-policy'
 import { isNativeWindowsConptyPty } from './terminal-model-query-authority'
 import { getTerminalViewAttributes } from './terminal-view-attribute-store'
@@ -20,6 +21,11 @@ export class OrcaRuntimeWithCreatePtyHeadlessTerminalState extends OrcaRuntimeWi
     const emulator = new HeadlessEmulator({
       cols: dims.cols,
       rows: dims.rows,
+      // Why bounded: retained grid is this process's dominant per-PTY heap term;
+      // the daemon twin was OOM-killed at the 5000-row default. Deep desktop
+      // scrollback lives in the renderer, mobile seeds are capped at
+      // MOBILE_SUBSCRIBE_SCROLLBACK_ROWS, rebuilds restore from durable history.
+      scrollback: resolveRuntimeSessionScrollbackRows(),
       pathFlavor,
       remotePosixFileUriAuthority:
         !!this.ptysById.get(ptyId)?.connectionId && pathFlavor !== 'win32',

--- a/src/main/runtime/orca-runtime-create-pty-headless-terminal-state.ts
+++ b/src/main/runtime/orca-runtime-create-pty-headless-terminal-state.ts
@@ -22,9 +22,10 @@ export class OrcaRuntimeWithCreatePtyHeadlessTerminalState extends OrcaRuntimeWi
       cols: dims.cols,
       rows: dims.rows,
       // Why bounded: retained grid is this process's dominant per-PTY heap term;
-      // the daemon twin was OOM-killed at the 5000-row default. Deep desktop
-      // scrollback lives in the renderer, mobile seeds are capped at
-      // MOBILE_SUBSCRIBE_SCROLLBACK_ROWS, rebuilds restore from durable history.
+      // the daemon twin was OOM-killed at full depth. This mirror also serves
+      // desktop hidden-output recovery at the user's configured depth, so the
+      // default covers the desktop default instead of truncating it — the env
+      // override trades recovery depth for memory.
       scrollback: resolveRuntimeSessionScrollbackRows(),
       pathFlavor,
       remotePosixFileUriAuthority:

--- a/src/main/runtime/runtime-session-scrollback-window.test.ts
+++ b/src/main/runtime/runtime-session-scrollback-window.test.ts
@@ -1,0 +1,60 @@
+/**
+ * OOM regression twin of daemon-session-scrollback-window.test.ts: the runtime's
+ * per-PTY headless mirror used the emulator default (5000 rows) while the daemon
+ * had already been OOM-killed at that depth and cut to a flat window — every
+ * live PTY in the runtime process linearly retained grid the desktop renderer
+ * already owns.
+ */
+import { describe, expect, it } from 'vitest'
+import { HeadlessEmulator } from '../daemon/headless-emulator'
+import {
+  resolveRuntimeSessionScrollbackRows,
+  RUNTIME_SESSION_SCROLLBACK_ROWS
+} from './runtime-session-scrollback-window'
+
+describe('resolveRuntimeSessionScrollbackRows', () => {
+  it('defaults to the flat window', () => {
+    expect(resolveRuntimeSessionScrollbackRows({} as NodeJS.ProcessEnv)).toBe(
+      RUNTIME_SESSION_SCROLLBACK_ROWS
+    )
+  })
+
+  it('accepts the inclusive override bounds and rejects everything outside them', () => {
+    for (const raw of ['100', '2500', '5000']) {
+      const env = { ORCA_RUNTIME_SESSION_SCROLLBACK_ROWS: raw } as NodeJS.ProcessEnv
+      expect(resolveRuntimeSessionScrollbackRows(env)).toBe(Number(raw))
+    }
+    // Why bounded: 0 loses the visible screen's context; huge values silently
+    // reintroduce the unbounded retention this window exists to prevent.
+    for (const raw of ['0', '99', '5001', '50000', '-1', '3.5', 'nonsense', '']) {
+      const env = { ORCA_RUNTIME_SESSION_SCROLLBACK_ROWS: raw } as NodeJS.ProcessEnv
+      expect(resolveRuntimeSessionScrollbackRows(env)).toBe(RUNTIME_SESSION_SCROLLBACK_ROWS)
+    }
+  })
+})
+
+describe('runtime headless emulator scrollback window', () => {
+  it('retains only the window of rows while keeping the newest content', async () => {
+    const emulator = new HeadlessEmulator({
+      cols: 80,
+      rows: 24,
+      scrollback: resolveRuntimeSessionScrollbackRows({} as NodeJS.ProcessEnv)
+    })
+    try {
+      const total = RUNTIME_SESSION_SCROLLBACK_ROWS + 500
+      await emulator.write(
+        Array.from(
+          { length: total },
+          (_, index) => `LINE_${String(index + 1).padStart(5, '0')}\r\n`
+        ).join('')
+      )
+      const snapshot = emulator.getSnapshot()
+      const text = `${snapshot.scrollbackAnsi ?? ''}${snapshot.snapshotAnsi ?? ''}`
+      // Newest line always present; the oldest has scrolled past the window.
+      expect(text).toContain(`LINE_${String(total).padStart(5, '0')}`)
+      expect(text).not.toContain('LINE_00001')
+    } finally {
+      emulator.dispose()
+    }
+  })
+})

--- a/src/main/runtime/runtime-session-scrollback-window.test.ts
+++ b/src/main/runtime/runtime-session-scrollback-window.test.ts
@@ -1,12 +1,14 @@
 /**
  * OOM regression twin of daemon-session-scrollback-window.test.ts: the runtime's
- * per-PTY headless mirror used the emulator default (5000 rows) while the daemon
- * had already been OOM-killed at that depth and cut to a flat window — every
- * live PTY in the runtime process linearly retained grid the desktop renderer
- * already owns.
+ * per-PTY headless mirror used the unbounded emulator default while the daemon
+ * had already been OOM-killed at full depth. Unlike the daemon twin, this
+ * mirror also feeds desktop hidden-output recovery (serializeHiddenOutputRecoveryBuffer
+ * serves parked-pane reveals at the user's configured depth), so the default
+ * must cover the desktop default rather than truncate it.
  */
 import { describe, expect, it } from 'vitest'
 import { HeadlessEmulator } from '../daemon/headless-emulator'
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../shared/terminal-scrollback-policy'
 import {
   resolveRuntimeSessionScrollbackRows,
   RUNTIME_SESSION_SCROLLBACK_ROWS
@@ -17,6 +19,12 @@ describe('resolveRuntimeSessionScrollbackRows', () => {
     expect(resolveRuntimeSessionScrollbackRows({} as NodeJS.ProcessEnv)).toBe(
       RUNTIME_SESSION_SCROLLBACK_ROWS
     )
+  })
+
+  it('covers the desktop hidden-output recovery depth by default', () => {
+    // Capping below the desktop default would silently truncate parked-pane
+    // reveals from the configured depth to the mirror's window.
+    expect(RUNTIME_SESSION_SCROLLBACK_ROWS).toBe(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT)
   })
 
   it('accepts the inclusive override bounds and rejects everything outside them', () => {
@@ -53,6 +61,11 @@ describe('runtime headless emulator scrollback window', () => {
       // Newest line always present; the oldest has scrolled past the window.
       expect(text).toContain(`LINE_${String(total).padStart(5, '0')}`)
       expect(text).not.toContain('LINE_00001')
+      // Daemon-twin bounds: catch a future drift in the resolved window, not
+      // just the two endpoints.
+      const retainedMatches = text.match(/LINE_\d{5}/g) ?? []
+      expect(retainedMatches.length).toBeLessThanOrEqual(RUNTIME_SESSION_SCROLLBACK_ROWS + 24)
+      expect(retainedMatches.length).toBeGreaterThan(RUNTIME_SESSION_SCROLLBACK_ROWS - 50)
     } finally {
       emulator.dispose()
     }

--- a/src/main/runtime/runtime-session-scrollback-window.ts
+++ b/src/main/runtime/runtime-session-scrollback-window.ts
@@ -1,13 +1,17 @@
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../shared/terminal-scrollback-policy'
+
 const RUNTIME_SESSION_SCROLLBACK_ENV_VAR = 'ORCA_RUNTIME_SESSION_SCROLLBACK_ROWS'
 
-// Why a flat live window: the runtime's per-PTY headless mirror has the same
-// retained-grid failure mode the daemon already hit (daemon-session-scrollback-window.ts:
-// a host owning 100+ terminals at full depth retained ~1 GB of grid and was OOM-killed).
-// This mirror never feeds the desktop renderer — deep scrollback there is the renderer's
-// live buffer, mobile seeds are already capped at MOBILE_SUBSCRIBE_SCROLLBACK_ROWS, and
-// rebuilds restore from durable history. Keep the default and override bounds in sync
-// with the daemon twin.
-export const RUNTIME_SESSION_SCROLLBACK_ROWS = 1000
+// Why a bounded window: retained grid is this process's dominant per-PTY heap
+// term; the daemon twin (daemon-session-scrollback-window.ts) was OOM-killed at
+// full depth with 100+ terminals. Unlike the daemon, this mirror also serves
+// desktop hidden-output recovery — serializeHiddenOutputRecoveryBuffer prefers
+// it when a parked pane is revealed, at the user's configured depth — so the
+// default must cover the desktop default rather than silently truncate it.
+// Hosts short on RAM trade recovery depth via the env override. Mobile seeds
+// stay capped at MOBILE_SUBSCRIBE_SCROLLBACK_ROWS; rebuilds restore from
+// durable history.
+export const RUNTIME_SESSION_SCROLLBACK_ROWS = DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT
 // Why: keep any override within sane terminal bounds — 0 would lose the visible screen's
 // context and huge values silently reintroduce the unbounded retention this window prevents.
 const MIN_OVERRIDE_ROWS = 100

--- a/src/main/runtime/runtime-session-scrollback-window.ts
+++ b/src/main/runtime/runtime-session-scrollback-window.ts
@@ -1,0 +1,26 @@
+const RUNTIME_SESSION_SCROLLBACK_ENV_VAR = 'ORCA_RUNTIME_SESSION_SCROLLBACK_ROWS'
+
+// Why a flat live window: the runtime's per-PTY headless mirror has the same
+// retained-grid failure mode the daemon already hit (daemon-session-scrollback-window.ts:
+// a host owning 100+ terminals at full depth retained ~1 GB of grid and was OOM-killed).
+// This mirror never feeds the desktop renderer — deep scrollback there is the renderer's
+// live buffer, mobile seeds are already capped at MOBILE_SUBSCRIBE_SCROLLBACK_ROWS, and
+// rebuilds restore from durable history. Keep the default and override bounds in sync
+// with the daemon twin.
+export const RUNTIME_SESSION_SCROLLBACK_ROWS = 1000
+// Why: keep any override within sane terminal bounds — 0 would lose the visible screen's
+// context and huge values silently reintroduce the unbounded retention this window prevents.
+const MIN_OVERRIDE_ROWS = 100
+const MAX_OVERRIDE_ROWS = 5000
+
+export function resolveRuntimeSessionScrollbackRows(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env[RUNTIME_SESSION_SCROLLBACK_ENV_VAR]?.trim()
+  if (!raw || !/^\d+$/.test(raw)) {
+    return RUNTIME_SESSION_SCROLLBACK_ROWS
+  }
+  const parsed = Number(raw)
+  if (!Number.isSafeInteger(parsed) || parsed < MIN_OVERRIDE_ROWS || parsed > MAX_OVERRIDE_ROWS) {
+    return RUNTIME_SESSION_SCROLLBACK_ROWS
+  }
+  return parsed
+}


### PR DESCRIPTION
## ELI5

Every terminal in Orca's runtime process keeps up to 5000 lines of scroll history in a headless mirror, and nothing could tune that down even under memory pressure. This makes the window an explicit, operator-tunable constant. **By default nothing changes**: the mirror also feeds desktop hidden-output recovery, which needs the desktop default depth — so the default stays 5000 and memory reduction is opt-in via an env override.

## What Changed

- New `runtime-session-scrollback-window.ts` (daemon-twin resolver, runtime-specific default): `RUNTIME_SESSION_SCROLLBACK_ROWS = DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT` (5000), `ORCA_RUNTIME_SESSION_SCROLLBACK_ROWS` override clamped to 100–5000.
- `createPtyHeadlessTerminalState` now passes `scrollback: resolveRuntimeSessionScrollbackRows()` explicitly instead of silently falling to `HeadlessEmulator`'s implicit 5000-row default.

## Why this default (and not the daemon's 1000)

The daemon could cut its live window to 1000 because rebuilds restore from durable history at `DAEMON_RESTORE_SCROLLBACK_ROWS` (5000) — a two-depth model. The runtime mirror has no durable backstop: `serializeHiddenOutputRecoveryBuffer` prefers this mirror when a parked pane is revealed, at the user's configured desktop depth (default 5000, up to 50k). An earlier revision of this PR defaulted to the daemon's 1000 and **silently truncated those desktop reveals 5x** (its "never feeds the desktop renderer" justification was wrong for that path); the desktop default is kept instead, and a test pins the coupling.

Consequence, stated plainly: the default is memory-neutral — it equals the emulator's implicit default. The reduction this PR enables is opt-in per host (`ORCA_RUNTIME_SESSION_SCROLLBACK_ROWS=1000`, mirroring the daemon's escape hatch). Dropping the default below 5000 without truncating reveals would require the durable-history backstop first (see open question).

## Linked Issue

Touches the runtime-side driver of #12728 (per-session private-memory growth); does not reduce it by default.

## Open question for maintainers

If default memory reduction is the goal, the prerequisite is a durable-restore backstop for hidden-output recovery (serve reveals beyond the live window from terminal history, as the daemon does). This PR deliberately does not build it — happy to take it on as a follow-up if that's the preferred direction, after which the live window could drop to the daemon's 1000.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `runtime-session-scrollback-window.test.ts`: resolver default/bounds/rejections, a pin that the default equals the desktop recovery depth, and an emulator-level retention test carrying the daemon twin's ±bounds assertions.
- Suite green locally; husky (oxlint/oxfmt) passes on macOS (Darwin 24.6.0, arm64).
