### PR TITLE
fix(sidebar): stop a missed pointerup from hiding a remote host section

### DIFF
--- a/src/renderer/src/components/sidebar/header-drag-click-swallow.ts
+++ b/src/renderer/src/components/sidebar/header-drag-click-swallow.ts
@@ -1,0 +1,20 @@
+/**
+ * Swallow the click that follows a completed header drag.
+ *
+ * Why: the pointerup that ends a promoted drag is followed by a click on the
+ * drag handle, which would also toggle the section the user just reordered.
+ * The listener removes itself on the first click; the returned timeout handle
+ * is the fallback for a drop that produces no click.
+ */
+export function swallowNextClickOnDragHandle(handleEl: HTMLElement): ReturnType<typeof setTimeout> {
+  const swallow = (event: MouseEvent): void => {
+    const target = event.target as Node | null
+    if (target && handleEl.contains(target)) {
+      event.stopPropagation()
+      event.preventDefault()
+    }
+    window.removeEventListener('click', swallow, true)
+  }
+  window.addEventListener('click', swallow, true)
+  return setTimeout(() => window.removeEventListener('click', swallow, true), 0)
+}

--- a/src/renderer/src/components/sidebar/header-drag-pointer-release.ts
+++ b/src/renderer/src/components/sidebar/header-drag-pointer-release.ts
@@ -1,0 +1,14 @@
+/**
+ * True when a pointermove arrives with no button held, meaning the pointerup
+ * that should have ended the armed drag never reached us.
+ *
+ * Why: the header drag hooks subscribe to window pointer events from an effect
+ * armed by pointerdown state, so a fast click's release can land before that
+ * effect runs (a heavy sidebar render sits between them). The session then
+ * survives the click and the next hover promotes a drag the user is not doing —
+ * for host sections that hides the header outright and force-collapses every
+ * host. A capture-phase listener swallowing pointerup has the same effect.
+ */
+export function hasPointerBeenReleased(event: PointerEvent): boolean {
+  return event.buttons === 0
+}

--- a/src/renderer/src/components/sidebar/host-header-drag.test.tsx
+++ b/src/renderer/src/components/sidebar/host-header-drag.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment happy-dom
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useHostHeaderDrag } from './host-header-drag'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+
+function setup() {
+  const scrollContainer = document.createElement('div')
+  document.body.append(scrollContainer)
+  const controller: { current: ReturnType<typeof useHostHeaderDrag> | null } = { current: null }
+
+  function Harness(): React.JSX.Element {
+    const drag = useHostHeaderDrag({
+      orderedHostIds: ['ssh:host-a', 'ssh:host-b'] as ExecutionHostId[],
+      onCommit: vi.fn(),
+      getScrollContainer: () => scrollContainer
+    })
+    controller.current = drag
+    return (
+      <div
+        data-host-header-drag-id="ssh:host-a"
+        onPointerDown={(event) => drag.onHandlePointerDown(event, 'ssh:host-a')}
+      />
+    )
+  }
+
+  const view = render(<Harness />)
+  const header = view.container.querySelector<HTMLElement>('[data-host-header-drag-id]')!
+  header.setPointerCapture = vi.fn()
+  header.releasePointerCapture = vi.fn()
+  return { controller, header }
+}
+
+function pointer(type: string, init: PointerEventInit): PointerEvent {
+  return new PointerEvent(type, { bubbles: true, pointerId: 1, ...init })
+}
+
+describe('useHostHeaderDrag', () => {
+  it('does not start a drag when the pointer is released before the window listeners attach', () => {
+    const { controller, header } = setup()
+
+    // A click: pointerdown arms the session, pointerup lands before React has
+    // flushed the passive effect that subscribes to window pointer events.
+    act(() => {
+      header.dispatchEvent(pointer('pointerdown', { button: 0, clientX: 10, clientY: 10 }))
+      window.dispatchEvent(pointer('pointerup', { clientX: 10, clientY: 10 }))
+    })
+
+    // Moving the mouse afterwards, with no button held, must not promote a drag.
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', { clientX: 200, clientY: 400, buttons: 0 }))
+    })
+
+    expect(controller.current?.state.draggingHostId).toBeNull()
+  })
+
+  it('clears a session whose pointerup was missed so a later drag still works', () => {
+    const { controller, header } = setup()
+
+    act(() => {
+      header.dispatchEvent(pointer('pointerdown', { button: 0, clientX: 10, clientY: 10 }))
+      window.dispatchEvent(pointer('pointerup', { clientX: 10, clientY: 10 }))
+    })
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', { clientX: 200, clientY: 400, buttons: 0 }))
+    })
+
+    act(() => {
+      header.dispatchEvent(pointer('pointerdown', { button: 0, clientX: 10, clientY: 10 }))
+    })
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', { clientX: 40, clientY: 60, buttons: 1 }))
+    })
+
+    expect(controller.current?.state.draggingHostId).toBe('ssh:host-a')
+  })
+
+  it('still promotes a drag while the pointer stays down', () => {
+    const { controller, header } = setup()
+
+    act(() => {
+      header.dispatchEvent(pointer('pointerdown', { button: 0, clientX: 10, clientY: 10 }))
+    })
+    act(() => {
+      window.dispatchEvent(pointer('pointermove', { clientX: 40, clientY: 60, buttons: 1 }))
+    })
+
+    expect(controller.current?.state.draggingHostId).toBe('ssh:host-a')
+  })
+})

--- a/src/renderer/src/components/sidebar/host-header-drag.ts
+++ b/src/renderer/src/components/sidebar/host-header-drag.ts
@@ -16,6 +16,8 @@ import {
   readHostHeaderRects,
   type HostHeaderRect
 } from './host-header-drag-dom'
+import { hasPointerBeenReleased } from './header-drag-pointer-release'
+import { swallowNextClickOnDragHandle } from './header-drag-click-swallow'
 
 export type HostDragState = {
   draggingHostId: ExecutionHostId | null
@@ -157,17 +159,7 @@ export function useHostHeaderDrag({
       session.preview?.remove()
       setSidebarPointerDragDocumentStyles(false)
       if (session.promoted) {
-        const handleEl = session.handleEl
-        const swallow = (e: MouseEvent): void => {
-          const target = e.target as Node | null
-          if (target && handleEl.contains(target)) {
-            e.stopPropagation()
-            e.preventDefault()
-          }
-          window.removeEventListener('click', swallow, true)
-        }
-        window.addEventListener('click', swallow, true)
-        setTimeout(() => window.removeEventListener('click', swallow, true), 0)
+        swallowNextClickOnDragHandle(session.handleEl)
       }
       const finalIndex =
         commit && session.promoted
@@ -204,6 +196,10 @@ export function useHostHeaderDrag({
     const onPointerMove = (e: PointerEvent): void => {
       const session = dragSessionRef.current
       if (!session || e.pointerId !== session.pointerId) {
+        return
+      }
+      if (hasPointerBeenReleased(e)) {
+        endDrag(false)
         return
       }
       if (!session.promoted) {

--- a/src/renderer/src/components/sidebar/project-group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag.ts
@@ -15,6 +15,8 @@ import {
 } from './project-group-header-drag-contract'
 import { createProjectGroupHeaderDragSession } from './project-group-header-drag-start'
 import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+import { hasPointerBeenReleased } from './header-drag-pointer-release'
+import { swallowNextClickOnDragHandle } from './header-drag-click-swallow'
 
 // Why pointer events instead of HTML5 DnD: Project Group rows are virtualized
 // and may unmount while scrolling; cached row-model indices keep drops stable.
@@ -114,20 +116,7 @@ export function useProjectGroupHeaderDrag({
         // capture may already be released (pointercancel, element unmounted)
       }
       if (session.promoted) {
-        const handleEl = session.handleEl
-        const swallow = (event: MouseEvent): void => {
-          const target = event.target as Node | null
-          if (target && handleEl.contains(target)) {
-            event.stopPropagation()
-            event.preventDefault()
-          }
-          window.removeEventListener('click', swallow, true)
-        }
-        window.addEventListener('click', swallow, true)
-        clickSwallowTimeoutRef.current = setTimeout(() => {
-          window.removeEventListener('click', swallow, true)
-          clickSwallowTimeoutRef.current = null
-        }, 0)
+        clickSwallowTimeoutRef.current = swallowNextClickOnDragHandle(session.handleEl)
       }
       const sidebarDropIndex =
         commit && session.promoted && latestDropIndexRef.current !== null
@@ -197,6 +186,10 @@ export function useProjectGroupHeaderDrag({
     const onPointerMove = (event: PointerEvent): void => {
       const session = dragSessionRef.current
       if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      if (hasPointerBeenReleased(event)) {
+        endDrag(false)
         return
       }
       session.latestPointerY = event.clientY

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -15,6 +15,8 @@ import {
 } from './project-header-drag-contract'
 import { createProjectHeaderDragSession } from './project-header-drag-start'
 import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+import { hasPointerBeenReleased } from './header-drag-pointer-release'
+import { swallowNextClickOnDragHandle } from './header-drag-click-swallow'
 
 // Why pointer events instead of HTML5 DnD: rows are absolutely-positioned by
 // react-virtual and unmount/remount as scroll changes, so DnD enter/leave fire
@@ -124,20 +126,7 @@ export function useRepoHeaderDrag({
         // capture may already be released (pointercancel, element unmounted)
       }
       if (session.promoted) {
-        const handleEl = session.handleEl
-        const swallow = (e: MouseEvent): void => {
-          const target = e.target as Node | null
-          if (target && handleEl.contains(target)) {
-            e.stopPropagation()
-            e.preventDefault()
-          }
-          window.removeEventListener('click', swallow, true)
-        }
-        window.addEventListener('click', swallow, true)
-        clickSwallowTimeoutRef.current = setTimeout(() => {
-          window.removeEventListener('click', swallow, true)
-          clickSwallowTimeoutRef.current = null
-        }, 0)
+        clickSwallowTimeoutRef.current = swallowNextClickOnDragHandle(session.handleEl)
       }
       const sidebarDropIndex =
         commit && session.promoted && latestDropIndexRef.current !== null
@@ -210,6 +199,10 @@ export function useRepoHeaderDrag({
     const onPointerMove = (e: PointerEvent): void => {
       const session = dragSessionRef.current
       if (!session || e.pointerId !== session.pointerId) {
+        return
+      }
+      if (hasPointerBeenReleased(e)) {
+        endDrag(false)
         return
       }
       session.latestPointerY = e.clientY


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## The bug

> I have 2 remote hosts in my filter to show. If I collapse one of them, sometimes it just totally disappears — gone. I have to go to the filter and uncheck + recheck for it to come back. (Status grouping view.)

## Root cause

Not the row model — that always emits both host headers (verified below). It's a **phantom host-header drag**.

`useHostHeaderDrag` arms a drag session on `pointerdown`, but subscribes to window `pointermove`/`pointerup` from a `useEffect` gated on that state — so the listeners attach a render **and a paint** after the press. On a heavy sidebar a quick click's `pointerup` lands inside that window and is never seen. The session survives the click, and the next bare mouse move (no button held) clears the 4px threshold and promotes a drag the user is not doing.

The host tier is the only header that hides itself while dragging:

- `HostSectionHeader` renders the dragged host with `opacity-0` — [`HostSectionHeader.tsx:112`](../blob/nwparker/disappearing-remote-host-group/src/renderer/src/components/sidebar/worktree-list/rows/HostSectionHeader.tsx#L112) (repo / project-group headers just highlight, which is why only remote host groups show this)
- `draggingHostId` also drives `forceCollapseHosts`, collapsing every host section at once — [`use-section-rows.ts:228`](../blob/nwparker/disappearing-remote-host-group/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts#L228)

So the host you just collapsed goes fully invisible. It only clears on a stray later `pointerup` or when `VirtualizedWorktreeViewport` remounts — and its React key includes `visibleWorkspaceHostIds` ([`WorktreeList.tsx:283`](../blob/nwparker/disappearing-remote-host-group/src/renderer/src/components/sidebar/WorktreeList.tsx#L283)), which is exactly why unchecking + rechecking the host in the filter brings it back.

## Proof

New `host-header-drag.test.tsx` replays the sequence: `pointerdown`, then `pointerup` dispatched before React flushes the arming effect, then a bare mouse move.

**Before** (fix reverted, test kept):

```
 ❯ src/renderer/src/components/sidebar/host-header-drag.test.tsx (3 tests | 1 failed)
     × does not start a drag when the pointer is released before the window listeners attach

 FAIL  useHostHeaderDrag > does not start a drag when the pointer is released before the window listeners attach
 AssertionError: expected 'ssh:host-a' to be null

 - Expected:  null
 + Received:  "ssh:host-a"

 Tests  1 failed | 2 passed (3)
```

`draggingHostId === 'ssh:host-a'` with the mouse button up is precisely the stuck state that renders the header at `opacity-0` and force-collapses every host section.

**After:**

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The other two cases guard the fix: a genuine held-button drag still promotes, and a stale session no longer blocks a later real drag.

### Row model ruled out

Before suspecting the view layer I drove `buildRows('workspace-status', …) + addHostSectionRows` through a throwaway harness across every collapse permutation — collapsed host, collapsed status lanes, all lanes collapsed, a host present in only one lane. Both host headers survive in all of them:

```
none collapsed:      HOST ssh:host-a | hdr in-progress | a1 | hdr in-review | a2 | HOST ssh:host-b | hdr in-progress | b1 | hdr in-review | b2
host-a collapsed:    HOST ssh:host-a (collapsed) | HOST ssh:host-b | hdr in-progress | b1 | hdr in-review | b2
all lanes collapsed: HOST ssh:host-a | hdr in-progress | hdr in-review | HOST ssh:host-b | hdr in-progress | hdr in-review
mixed b collapsed:   HOST ssh:host-a | hdr in-progress | a1 | hdr in-review | a2 | HOST ssh:host-b (collapsed)
```

## The fix

`header-drag-pointer-release.ts` (new): a `pointermove` with `buttons === 0` means the `pointerup` never reached us. `host-header-drag.ts` ends the session instead of promoting.

The repo and project-group header drags share the identical race — there it commits an **unintended reorder** on the next click rather than hiding anything — so they get the same guard. Extracting their duplicated click-swallow block into `header-drag-click-swallow.ts` keeps `project-header-drag.ts` under the 300-line `max-lines` ceiling (it sat at exactly 300); its timeout semantics are unchanged, since the effect cleanup must not tear the listener down on disarm.

## Verification

- `pnpm test src/renderer/src/components/sidebar/` — **297 files / 2506 tests pass**
- `pnpm tc` clean, `oxlint` clean

**Not verified in the running app.** Reproducing it live needs two connected remote hosts *and* the timing race to land, which is what made it intermittent in the first place — the repro here is at the hook level.
