### PR TITLE
fix(kimi): bound orphaned managed-block recovery to installer-shaped tables

### DIFF
--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -213,6 +213,28 @@ describe('kimi managed hooks TOML block', () => {
     })
   })
 
+  it('recovers an orphaned block whose user TOML starts after a blank line (#18861)', () => {
+    for (const nl of ['\n', '\r\n']) {
+      const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+      // A blank line separates the last orphaned table from the user's
+      // appended section: recovery must still strip the orphan instead of
+      // leaving it behind for reinstall to duplicate.
+      const orphaned = installed
+        .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, nl)
+        .concat(nl, `[tools]${nl}`, `name = "user-tool"${nl}`)
+
+      const removed = removeManagedKimiHooks(orphaned)
+      expect(removed.changed).toBe(true)
+      expect(removed.text).toContain('[tools]')
+      expect(removed.text).toContain('name = "user-tool"')
+      expect(removed.text).not.toContain(COMMAND)
+      expect(readManagedKimiHookEvents(removed.text, isManaged).size).toBe(0)
+
+      const reinstalled = applyManagedKimiHooks(orphaned, COMMAND)
+      expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
+    }
+  })
+
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"

--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -132,6 +132,30 @@ describe('kimi managed hooks TOML block', () => {
     expect(reinstalled).toContain('node my-own-hook.mjs')
   })
 
+  it('recovers a CRLF-saved orphaned block and keeps the user tail (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    // The BLOCK_END hand-edit happened before an editor resaved the file with
+    // Windows line endings.
+    const orphanedCrlf = installed
+      .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\r\n')
+      .concat(
+        '[[hooks]]\r\n',
+        'event = "SessionStart"\r\n',
+        'command = "node my-own-hook.mjs"\r\n',
+        '\r\n',
+        '[[tools]]\r\n',
+        'name = "user-tool"\r\n'
+      )
+
+    const removed = removeManagedKimiHooks(orphanedCrlf)
+    expect(removed.changed).toBe(true)
+    expect(removed.text).toContain('node my-own-hook.mjs')
+    expect(removed.text).toContain('[[tools]]')
+    expect(removed.text).not.toContain(COMMAND)
+    // Orphaned installer tables behind CRLF are still recognized as managed.
+    expect(readManagedKimiHookEvents(orphanedCrlf, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
+  })
+
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"

--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -156,6 +156,63 @@ describe('kimi managed hooks TOML block', () => {
     expect(readManagedKimiHookEvents(orphanedCrlf, isManaged)).toEqual(new Set(KIMI_HOOK_EVENTS))
   })
 
+  it('keeps a user hook table that extends the installer shape intact (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    // A user table reusing the installer field order (event/command/timeout)
+    // but carrying extra keys must not be read as installer-shaped: recovery
+    // would otherwise delete its header and known fields and detach the rest.
+    const orphanedWithExtendedTable = installed
+      .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+      .concat(
+        '[[hooks]]\n',
+        'event = "SessionStart"\n',
+        'command = "node my-own-hook.mjs"\n',
+        'timeout = 120\n',
+        'priority = 1\n'
+      )
+
+    const removed = removeManagedKimiHooks(orphanedWithExtendedTable)
+    expect(removed.changed).toBe(true)
+    // The orphaned installer-shaped tables are still stripped...
+    expect(removed.text).not.toContain(COMMAND)
+    expect(removed.text).not.toContain('orca-managed-kimi-hooks')
+    // ...while the extended user table survives complete, header included.
+    expect(removed.text).toContain('[[hooks]]')
+    expect(removed.text).toContain('event = "SessionStart"')
+    expect(removed.text).toContain('command = "node my-own-hook.mjs"')
+    expect(removed.text).toContain('timeout = 120')
+    expect(removed.text).toContain('priority = 1')
+    expect(readManagedKimiHookEvents(removed.text, isManaged).size).toBe(0)
+
+    // Reinstall still converges to one block beside the extended user table.
+    const reinstalled = applyManagedKimiHooks(orphanedWithExtendedTable, COMMAND)
+    expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
+    expect(reinstalled).toContain('priority = 1')
+  })
+
+  it('declines orphan recovery when the first table after the marker extends the installer shape (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    // With no fully installer-shaped table after the orphaned marker, recovery
+    // must decline entirely rather than delete an extended table's prefix.
+    const blockStart = installed.match(/# >>> orca-managed-kimi-hooks[^\n]*/)?.[0] ?? ''
+    const orphanedExtendedOnly = [
+      'default_model = "x"',
+      '',
+      blockStart,
+      '[[hooks]]',
+      'event = "SessionStart"',
+      'command = "node my-own-hook.mjs"',
+      'timeout = 120',
+      'priority = 1',
+      ''
+    ].join('\n')
+
+    expect(removeManagedKimiHooks(orphanedExtendedOnly)).toEqual({
+      text: orphanedExtendedOnly,
+      changed: false
+    })
+  })
+
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"

--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -235,6 +235,67 @@ describe('kimi managed hooks TOML block', () => {
     }
   })
 
+  it('recovers an orphaned block followed by a comment line and keeps the comment intact (#18861)', () => {
+    for (const nl of ['\n', '\r\n']) {
+      const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+      // A `#` comment ahead of the user's appended TOML must not strand the
+      // last orphaned table: partial removal reports changed=true while
+      // leaving a live managed hook command behind.
+      const orphaned = installed
+        .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+        .concat(
+          `# my own hooks${nl}`,
+          `[[hooks]]${nl}`,
+          `event = "SessionStart"${nl}`,
+          `command = "node my-own-hook.mjs"${nl}`,
+          `timeout = 120${nl}`,
+          `priority = 1${nl}`
+        )
+
+      const removed = removeManagedKimiHooks(orphaned)
+      expect(removed.changed).toBe(true)
+      expect(removed.text).toContain('# my own hooks')
+      expect(removed.text).toContain('priority = 1')
+      expect(removed.text).not.toContain(COMMAND)
+      expect(readManagedKimiHookEvents(removed.text, isManaged).size).toBe(0)
+
+      const reinstalled = applyManagedKimiHooks(orphaned, COMMAND)
+      expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
+      expect(reinstalled).toContain('# my own hooks')
+      expect(reinstalled).toContain('priority = 1')
+    }
+  })
+
+  it('recovers an orphaned block whose only trailing content is a comment (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    const orphaned = installed
+      .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+      .concat('# trailing note')
+
+    const removed = removeManagedKimiHooks(orphaned)
+    expect(removed.changed).toBe(true)
+    expect(removed.text).toContain('# trailing note')
+    expect(removed.text).not.toContain(COMMAND)
+    expect(readManagedKimiHookEvents(removed.text, isManaged).size).toBe(0)
+  })
+
+  it('keeps a hook table extended behind a comment line intact (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    // A comment does not close a TOML table: `priority` below extends the
+    // installer-shaped table above it, so recovery must leave it alone rather
+    // than strip its header and detach the key.
+    const orphaned = installed
+      .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+      .concat('# knob\n', 'priority = 1\n', '[tools]\n', 'name = "user-tool"\n')
+
+    const removed = removeManagedKimiHooks(orphaned)
+    expect(removed.changed).toBe(true)
+    expect(removed.text).not.toContain('orca-managed-kimi-hooks')
+    expect(removed.text).toContain('# knob')
+    expect(removed.text).toContain('priority = 1')
+    expect(removed.text).toContain('[tools]')
+  })
+
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"

--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -296,6 +296,27 @@ describe('kimi managed hooks TOML block', () => {
     expect(removed.text).toContain('[tools]')
   })
 
+  it('recovers an orphaned block whose last table ends at EOF without a trailing newline (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    // A hand-trimmed file can end directly on the `timeout` line; requiring a
+    // line ending before the EOF branch strands that table (partial removal
+    // or a full decline).
+    const orphanedNoNewline = installed
+      .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+      .replace(/\n$/, '')
+    expect(orphanedNoNewline).not.toMatch(/\n$/)
+
+    const removed = removeManagedKimiHooks(orphanedNoNewline)
+    expect(removed.changed).toBe(true)
+    expect(removed.text).toBe('default_model = "x"\n')
+    expect(readManagedKimiHookEvents(orphanedNoNewline, isManaged)).toEqual(
+      new Set(KIMI_HOOK_EVENTS)
+    )
+
+    const reinstalled = applyManagedKimiHooks(orphanedNoNewline, COMMAND)
+    expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
+  })
+
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"

--- a/src/main/kimi/kimi-hook-config-toml.test.ts
+++ b/src/main/kimi/kimi-hook-config-toml.test.ts
@@ -100,6 +100,38 @@ describe('kimi managed hooks TOML block', () => {
     expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
   })
 
+  it('preserves user TOML appended after an orphaned block (#18861)', () => {
+    const installed = applyManagedKimiHooks('default_model = "x"\n', COMMAND)
+    // User appends their own hook table and tool table after the block, then
+    // the trailing BLOCK_END marker is lost to a hand-edit.
+    const orphanedWithUserTail = installed
+      .replace(/\n# <<< orca-managed-kimi-hooks <<<\n?/, '\n')
+      .concat(
+        '[[hooks]]\n',
+        'event = "SessionStart"\n',
+        'command = "node my-own-hook.mjs"\n',
+        '\n',
+        '[[tools]]\n',
+        'name = "user-tool"\n'
+      )
+
+    // Remove strips the orphaned installer-shaped tables and nothing else.
+    const removed = removeManagedKimiHooks(orphanedWithUserTail)
+    expect(removed.changed).toBe(true)
+    expect(removed.text).toContain('event = "SessionStart"')
+    expect(removed.text).toContain('node my-own-hook.mjs')
+    expect(removed.text).toContain('[[tools]]')
+    expect(removed.text).toContain('name = "user-tool"')
+    expect(removed.text).not.toContain('orca-managed-kimi-hooks')
+    expect(removed.text).not.toContain(COMMAND)
+
+    // Reinstall still converges to one block and keeps the user tail intact.
+    const reinstalled = applyManagedKimiHooks(orphanedWithUserTail, COMMAND)
+    expect((reinstalled.match(/orca-managed-kimi-hooks \(/g) ?? []).length).toBe(1)
+    expect(reinstalled).toContain('name = "user-tool"')
+    expect(reinstalled).toContain('node my-own-hook.mjs')
+  })
+
   it('treats stale managed entries pointing at a moved script path as managed', () => {
     const staleCommand =
       "if [ -x '/old/userData/agent-hooks/kimi-hook.sh' ]; then /bin/sh '/old/userData/agent-hooks/kimi-hook.sh'; fi"

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -32,10 +32,10 @@ const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
 //    bounded to the contiguous installer-shaped `[[hooks]]` tables (header +
 //    event/command/timeout lines), so user TOML appended after the orphaned
 //    tables survives remove/reinstall instead of being swallowed to EOF (#18861).
-//    Each recovered table must be followed by the next table header or EOF, so
-//    a user table that reuses the installer field order but carries extra keys
-//    ends recovery with the table intact instead of being truncated to its
-//    installer-shaped prefix.
+//    Each recovered table must be followed — apart from blank lines — by the
+//    next table header or EOF, so a user table that reuses the installer field
+//    order but carries extra keys ends recovery with the table intact instead
+//    of being truncated to its installer-shaped prefix.
 //    Line boundaries accept CRLF: an editor saving the config with Windows
 //    endings after deleting BLOCK_END must still be recoverable.
 //    A user table that mirrors the exact installer shape remains
@@ -47,7 +47,7 @@ const MANAGED_HOOK_TABLE =
   'command\\s*=\\s*"(?:[^"\\\\]|\\\\.)*"\\r?\\n' +
   'timeout\\s*=\\s*\\d+'
 const MANAGED_BLOCK_RE = new RegExp(
-  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n(?:${MANAGED_HOOK_TABLE}(?:\\r?\\n(?=\\[)|\\r?\\n*$))+)`,
+  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n(?:${MANAGED_HOOK_TABLE}(?:(?:\\r?\\n)+(?=\\[)|(?:\\r?\\n)*$))+)`,
   'g'
 )
 

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -26,13 +26,22 @@ const BLOCK_START = '# >>> orca-managed-kimi-hooks (managed by Orca; do not edit
 const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
 
 // Matches the managed block plus any blank lines immediately preceding it so
-// repeated install/remove cycles do not accumulate whitespace. The `|$`
-// fallback also matches from BLOCK_START to end-of-file when the trailing
-// BLOCK_END marker is missing (e.g. a hand-edit deleted it): the managed block
-// is always written last, so this recovers orphaned hook tables and lets
-// install re-converge in one step instead of appending a duplicate block.
+// repeated install/remove cycles do not accumulate whitespace. Two shapes:
+// 1. The complete block, from BLOCK_START through the trailing BLOCK_END line.
+// 2. An orphaned block whose trailing BLOCK_END was hand-deleted: recovery is
+//    bounded to the contiguous installer-shaped `[[hooks]]` tables (header +
+//    event/command/timeout lines), so user TOML appended after the orphaned
+//    tables survives remove/reinstall instead of being swallowed to EOF (#18861).
+//    A user table that happens to mirror the exact installer shape remains
+//    indistinguishable by form alone — stopping at the first non-managed table
+//    is the accepted bound of orphan recovery.
+const MANAGED_HOOK_TABLE =
+  '\\[\\[hooks\\]\\]\\n' +
+  'event\\s*=\\s*"[^"\\n]*"\\n' +
+  'command\\s*=\\s*"(?:[^"\\\\]|\\\\.)*"\\n' +
+  'timeout\\s*=\\s*\\d+'
 const MANAGED_BLOCK_RE = new RegExp(
-  `\\n*${escapeRegex(BLOCK_START)}[\\s\\S]*?(?:${escapeRegex(BLOCK_END)}[^\\n]*|$)`,
+  `\\n*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\n(?:${MANAGED_HOOK_TABLE}(?:\\n|$))+)`,
   'g'
 )
 

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -51,12 +51,13 @@ const MANAGED_HOOK_TABLE =
 // Consumed only BETWEEN recovered tables; the last table keeps its trailing
 // newline so removal never glues the surviving neighbors together.
 const RECOVERED_TABLE_SEPARATOR = '\\r?\\n(?:[ \\t]*\\r?\\n)*'
-// Zero-width end-of-recovery check: past the last recovered table's line
-// ending, blank and comment lines may intervene, but the next content must be
-// a `[` header or EOF — anything else (a key/value continuation, even behind a
-// comment) extends the table and ends recovery with the table left intact.
+// Zero-width end-of-recovery check: either EOF directly (the file may end on
+// the `timeout` line with no trailing newline), or past the last table's line
+// ending blank and comment lines may intervene before a `[` header or EOF —
+// anything else (a key/value continuation, even behind a comment) extends the
+// table and ends recovery with the table left intact.
 const RECOVERED_TABLE_BOUNDARY =
-  '(?=\\r?\\n(?:[ \\t]*(?:#[^\\r\\n]*)?\\r?\\n)*(?:\\[|(?:[ \\t]*#[^\\r\\n]*)?$))'
+  '(?=(?:$|\\r?\\n(?:[ \\t]*(?:#[^\\r\\n]*)?\\r?\\n)*(?:\\[|(?:[ \\t]*#[^\\r\\n]*)?$)))'
 const MANAGED_BLOCK_RE = new RegExp(
   `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n${MANAGED_HOOK_TABLE}(?:${RECOVERED_TABLE_SEPARATOR}${MANAGED_HOOK_TABLE})*${RECOVERED_TABLE_BOUNDARY})`,
   'g'

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -32,9 +32,13 @@ const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
 //    bounded to the contiguous installer-shaped `[[hooks]]` tables (header +
 //    event/command/timeout lines), so user TOML appended after the orphaned
 //    tables survives remove/reinstall instead of being swallowed to EOF (#18861).
+//    Each recovered table must be followed by the next table header or EOF, so
+//    a user table that reuses the installer field order but carries extra keys
+//    ends recovery with the table intact instead of being truncated to its
+//    installer-shaped prefix.
 //    Line boundaries accept CRLF: an editor saving the config with Windows
 //    endings after deleting BLOCK_END must still be recoverable.
-//    A user table that happens to mirror the exact installer shape remains
+//    A user table that mirrors the exact installer shape remains
 //    indistinguishable by form alone — stopping at the first non-managed table
 //    is the accepted bound of orphan recovery.
 const MANAGED_HOOK_TABLE =
@@ -43,7 +47,7 @@ const MANAGED_HOOK_TABLE =
   'command\\s*=\\s*"(?:[^"\\\\]|\\\\.)*"\\r?\\n' +
   'timeout\\s*=\\s*\\d+'
 const MANAGED_BLOCK_RE = new RegExp(
-  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n(?:${MANAGED_HOOK_TABLE}(?:\\r?\\n|$))+)`,
+  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n(?:${MANAGED_HOOK_TABLE}(?:\\r?\\n(?=\\[)|\\r?\\n*$))+)`,
   'g'
 )
 

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -32,16 +32,18 @@ const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
 //    bounded to the contiguous installer-shaped `[[hooks]]` tables (header +
 //    event/command/timeout lines), so user TOML appended after the orphaned
 //    tables survives remove/reinstall instead of being swallowed to EOF (#18861).
+//    Line boundaries accept CRLF: an editor saving the config with Windows
+//    endings after deleting BLOCK_END must still be recoverable.
 //    A user table that happens to mirror the exact installer shape remains
 //    indistinguishable by form alone — stopping at the first non-managed table
 //    is the accepted bound of orphan recovery.
 const MANAGED_HOOK_TABLE =
-  '\\[\\[hooks\\]\\]\\n' +
-  'event\\s*=\\s*"[^"\\n]*"\\n' +
-  'command\\s*=\\s*"(?:[^"\\\\]|\\\\.)*"\\n' +
+  '\\[\\[hooks\\]\\]\\r?\\n' +
+  'event\\s*=\\s*"[^"\\n]*"\\r?\\n' +
+  'command\\s*=\\s*"(?:[^"\\\\]|\\\\.)*"\\r?\\n' +
   'timeout\\s*=\\s*\\d+'
 const MANAGED_BLOCK_RE = new RegExp(
-  `\\n*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\n(?:${MANAGED_HOOK_TABLE}(?:\\n|$))+)`,
+  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n(?:${MANAGED_HOOK_TABLE}(?:\\r?\\n|$))+)`,
   'g'
 )
 

--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -32,10 +32,12 @@ const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
 //    bounded to the contiguous installer-shaped `[[hooks]]` tables (header +
 //    event/command/timeout lines), so user TOML appended after the orphaned
 //    tables survives remove/reinstall instead of being swallowed to EOF (#18861).
-//    Each recovered table must be followed — apart from blank lines — by the
-//    next table header or EOF, so a user table that reuses the installer field
-//    order but carries extra keys ends recovery with the table intact instead
-//    of being truncated to its installer-shaped prefix.
+//    Each recovered table must be followed — apart from blank lines and `#`
+//    comments, which never extend a TOML table — by the next `[` table header
+//    or EOF, so a user table that reuses the installer field order but carries
+//    extra keys ends recovery with the table intact instead of being truncated
+//    to its installer-shaped prefix. A key/value line, even behind a comment,
+//    extends the table and likewise ends recovery.
 //    Line boundaries accept CRLF: an editor saving the config with Windows
 //    endings after deleting BLOCK_END must still be recoverable.
 //    A user table that mirrors the exact installer shape remains
@@ -46,8 +48,17 @@ const MANAGED_HOOK_TABLE =
   'event\\s*=\\s*"[^"\\n]*"\\r?\\n' +
   'command\\s*=\\s*"(?:[^"\\\\]|\\\\.)*"\\r?\\n' +
   'timeout\\s*=\\s*\\d+'
+// Consumed only BETWEEN recovered tables; the last table keeps its trailing
+// newline so removal never glues the surviving neighbors together.
+const RECOVERED_TABLE_SEPARATOR = '\\r?\\n(?:[ \\t]*\\r?\\n)*'
+// Zero-width end-of-recovery check: past the last recovered table's line
+// ending, blank and comment lines may intervene, but the next content must be
+// a `[` header or EOF — anything else (a key/value continuation, even behind a
+// comment) extends the table and ends recovery with the table left intact.
+const RECOVERED_TABLE_BOUNDARY =
+  '(?=\\r?\\n(?:[ \\t]*(?:#[^\\r\\n]*)?\\r?\\n)*(?:\\[|(?:[ \\t]*#[^\\r\\n]*)?$))'
 const MANAGED_BLOCK_RE = new RegExp(
-  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n(?:${MANAGED_HOOK_TABLE}(?:(?:\\r?\\n)+(?=\\[)|(?:\\r?\\n)*$))+)`,
+  `(?:\\r?\\n)*${escapeRegex(BLOCK_START)}(?:[\\s\\S]*?${escapeRegex(BLOCK_END)}[^\\n]*|\\r?\\n${MANAGED_HOOK_TABLE}(?:${RECOVERED_TABLE_SEPARATOR}${MANAGED_HOOK_TABLE})*${RECOVERED_TABLE_BOUNDARY})`,
   'g'
 )
 


### PR DESCRIPTION
## ELI5

If a user deletes one comment line (the block's end marker) and later adds their own settings after Orca's managed block, the cleanup regex used to delete their settings too. Now it only ever removes the settings Orca itself wrote.

## What Changed

- `MANAGED_BLOCK_RE` orphan recovery (a `BLOCK_START` whose `BLOCK_END` was hand-deleted) no longer matches to end-of-file: it now matches only the contiguous **installer-shaped** tables — an `[[hooks]]` header followed by `event`/`command`/`timeout` lines — and stops at the first line that does not mirror that shape.
- The complete-block branch (`BLOCK_START … BLOCK_END`) is unchanged.
- `readManagedKimiHookEvents` still recognizes orphaned tables; reinstall still converges to a single block.

## Why

Fixes #18861: anything the user appended after installation — their own `[[hooks]]` tables included — was silently deleted by `removeManagedKimiHooks` or swallowed by the `applyManagedKimiHooks` rewrite whenever the trailing marker was lost. A user table that happens to mirror the exact installer shape remains indistinguishable by form alone; stopping at the first non-matching table is the accepted bound, as the issue describes.

## Linked Issue

Fixes #18861

## Visual Proof

N/A — no UI change; this alters TOML text manipulation only.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- New regression test per the issue's required outcome: user hook (`SessionStart` + custom command) and tool tables appended after an orphaned block survive `removeManagedKimiHooks` untouched, and `applyManagedKimiHooks` still converges to a single managed block while keeping them.
- Full `src/main/kimi/` suite green (22 tests, including `hook-service` integration), `pnpm run typecheck:node` and `pnpm run check:code-quality:changed` clean on macOS (Darwin 24.6.0, arm64).

## Note on the vibe twin

`vibe/hook-config-toml.ts` does not exist on `main` yet — it arrives with #18813, which the issue says must stay lockstep-identical. The same change should be applied there when that PR lands; happy to rebase or follow up on top of #18813 if maintainers prefer.
