### PR TITLE
Seed Cmd-J filter from sidebar scope

### DIFF
--- a/docs/site/content/docs/model/quick-open.mdx
+++ b/docs/site/content/docs/model/quick-open.mdx
@@ -19,9 +19,9 @@ Type a web search instead of a path or URL to open it in the worktree browser wi
 
 ## Worktree Jump Palette (Cmd-J)
 
-Jump across every worktree and every tab in one search. The placeholder in the empty input reads _repo/worktree_ — type either half and Orca filters accordingly. Once you start typing, search includes non-archived worktrees even if they are hidden by the sidebar's current filters. Slack-style emoji shortcodes (`:rocket:`) use the same suggestion popover as workspace naming.
+Jump across worktrees and tabs in one search. The palette opens with the sidebar's current host and project scope, including individual repository selections. The placeholder in the empty input reads _repo/worktree_ — type either half and Orca filters accordingly. Typing can still find non-archived worktrees hidden by the sidebar's other visibility toggles, but it keeps that host and repository scope. Slack-style emoji shortcodes (`:rocket:`) use the same suggestion popover as workspace naming.
 
-Press **Tab** in the palette for a host and project filter menu. Selected hosts and projects narrow the result set and show as chips you can remove one at a time; closing the palette clears the filter so the next open is unscoped.
+Press **Tab** in the palette for a host and project filter menu. Project choices are repository-granular. Selected hosts and repositories narrow the result set and show as chips you can remove one at a time. Changes are temporary: closing the palette discards them, and the next open reseeds the filter from the sidebar.
 
 Results include:
 

--- a/docs/site/content/docs/model/worktrees.mdx
+++ b/docs/site/content/docs/model/worktrees.mdx
@@ -102,7 +102,7 @@ The sidebar header filter menu groups host and project scope under a shared **Sh
 - **Other-client** workspaces — **Hide other-client workspaces** appears when a shared [Remote Orca Server](/docs/remote-servers) has workspaces created from another paired client; turn it on to keep this device's list to workspaces you created here. Empty `Cmd-J` recents and numeric shortcuts follow the same filter; typing a query still finds hidden rows.
 - **Detached HEAD** workspaces — checkouts sitting on a commit rather than a branch
 
-Active filter count shows on the filter control; **Clear** resets only the filters that are on. Text search and [Worktree Jump Palette](/docs/model/quick-open) (`Cmd-J`) still reach workspaces hidden only by these filters once you type a query — the jump palette also has its own host/project filters (**Tab**).
+Active filter count shows on the filter control; **Clear** resets only the filters that are on. Text search and [Worktree Jump Palette](/docs/model/quick-open) (`Cmd-J`) still reach workspaces hidden only by the hide toggles once you type a query. Cmd-J keeps the sidebar's host and project scope when it opens; press **Tab** to adjust its temporary host and individual-repository filters.
 
 When you add a parent folder that contains multiple Git repos, Orca can import the selected repos separately or group them under one project group.
 

--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -762,4 +762,30 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
 
     expect(getTabRowIds()).toContain('tab-alpha')
   })
+
+  it('keeps the recent section under a sidebar-seeded repository filter and refreshes on clear', async () => {
+    const secondRepo = { ...makeRepo(), id: 'repo-2', path: '/repos/repo-2', displayName: 'Repo 2' }
+    await renderPalette({
+      ...makeRecentTabState(),
+      repos: [makeRepo(), secondRepo],
+      worktreesByRepo: {
+        'repo-1': [makeWorktree('wt-alpha', 'Alpha workspace')],
+        'repo-2': [makeWorktree('wt-beta', 'Beta workspace', { repoId: 'repo-2' })]
+      },
+      filterRepoIds: ['repo-1']
+    })
+
+    // The seeded filter narrows the recent rows instead of dropping the section.
+    expect(testContainer.textContent).toContain('Recent Chats & Terminals')
+    expect(getTabRowIds()).toEqual(['tab-alpha'])
+
+    await act(async () => {
+      ;[...testContainer.querySelectorAll('button')]
+        .find((button) => button.textContent?.includes('Clear all'))
+        ?.click()
+    })
+    await flushEffects()
+
+    expect(getTabRowIds()).toEqual(expect.arrayContaining(['tab-alpha', 'tab-beta']))
+  })
 })

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -361,6 +361,37 @@ describe('WorktreeJumpPalette', () => {
     expect(testContainer.textContent).toContain('Feature workspace')
   })
 
+  it('reseeds the repository filter when reopened during the close linger', async () => {
+    const secondRepo = {
+      ...makeRepo(),
+      id: 'repo-2',
+      path: '/repos/repo-2',
+      displayName: 'Repo 2'
+    }
+    const first = makeWorktree('first', 'First repository workspace')
+    const second = makeWorktree('second', 'Second repository workspace', { repoId: 'repo-2' })
+
+    await renderPalette({
+      repos: [makeRepo(), secondRepo],
+      worktreesByRepo: { 'repo-1': [first], 'repo-2': [second] },
+      filterRepoIds: ['repo-1'],
+      showSleepingWorkspaces: true
+    })
+
+    expect(testContainer.textContent).toContain('First repository workspace')
+    expect(testContainer.textContent).not.toContain('Second repository workspace')
+
+    await act(async () => {
+      useAppStore.setState({ activeModal: 'none', filterRepoIds: ['repo-2'] })
+    })
+    await flushEffects()
+    await act(async () => useAppStore.getState().openModal('worktree-palette'))
+    await flushEffects()
+
+    expect(testContainer.textContent).not.toContain('First repository workspace')
+    expect(testContainer.textContent).toContain('Second repository workspace')
+  })
+
   // STA-4343 closed: two workspaces sharing `repoId::path` across hosts are two distinct
   // rows. The documents map and worktreeMap are keyed by host identity, so each row resolves
   // to its OWN worktree, and render keys keep the two apart for React and cmdk.

--- a/src/renderer/src/components/cmd-j/PaletteFilterChips.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterChips.tsx
@@ -30,13 +30,13 @@ export default function PaletteFilterChips({
         id,
         label: hostLabels.get(id) ?? id
       })),
-      ...filter.projectKeys.map((id) => ({
+      ...filter.repoIds.map((id) => ({
         field: 'project' as const,
         id,
         label: projectLabels.get(id) ?? id
       }))
     ]
-  }, [filter.hostIds, filter.projectKeys, model.hosts, model.projects])
+  }, [filter.hostIds, filter.repoIds, model.hosts, model.projects])
 
   if (!isPaletteFilterActive(filter) || chips.length === 0) {
     return null

--- a/src/renderer/src/components/cmd-j/PaletteFilterChips.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterChips.tsx
@@ -33,14 +33,14 @@ export default function PaletteFilterChips({
         label: hostLabels.get(id) ?? id
       })),
       ...filter.repoIds.map((id) => ({
-        field: 'project' as const,
+        field: 'repository' as const,
         id,
         label: repositoryLabels.get(id) ?? id
       }))
     ]
   }, [filter.hostIds, filter.repoIds, model.hosts, model.repositories])
 
-  if (!isPaletteFilterActive(filter) || chips.length === 0) {
+  if (!isPaletteFilterActive(filter)) {
     return null
   }
 

--- a/src/renderer/src/components/cmd-j/PaletteFilterChips.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterChips.tsx
@@ -23,7 +23,9 @@ export default function PaletteFilterChips({
 }): React.JSX.Element | null {
   const chips = useMemo<Chip[]>(() => {
     const hostLabels = new Map(model.hosts.map((host) => [host.id, host.label]))
-    const projectLabels = new Map(model.projects.map((project) => [project.id, project.label]))
+    const repositoryLabels = new Map(
+      model.repositories.map((repository) => [repository.id, repository.label])
+    )
     return [
       ...filter.hostIds.map((id) => ({
         field: 'host' as const,
@@ -33,10 +35,10 @@ export default function PaletteFilterChips({
       ...filter.repoIds.map((id) => ({
         field: 'project' as const,
         id,
-        label: projectLabels.get(id) ?? id
+        label: repositoryLabels.get(id) ?? id
       }))
     ]
-  }, [filter.hostIds, filter.repoIds, model.hosts, model.projects])
+  }, [filter.hostIds, filter.repoIds, model.hosts, model.repositories])
 
   if (!isPaletteFilterActive(filter) || chips.length === 0) {
     return null

--- a/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
@@ -88,16 +88,16 @@ export default function PaletteFilterMenu({
         selected: filter.hostIds
       })
     }
-    if (model.projects.length > 1) {
+    if (model.repositories.length > 1) {
       entries.push({
         field: 'project',
         heading: translate('worktreeJumpPalette.filter.projects', 'Projects'),
-        options: model.projects,
+        options: model.repositories,
         selected: filter.repoIds
       })
     }
     return entries
-  }, [filter.hostIds, filter.repoIds, model.hosts, model.projects])
+  }, [filter.hostIds, filter.repoIds, model.hosts, model.repositories])
 
   // Stale field falls back to root if its group disappeared mid-session.
   const activeGroup =

--- a/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
@@ -93,11 +93,11 @@ export default function PaletteFilterMenu({
         field: 'project',
         heading: translate('worktreeJumpPalette.filter.projects', 'Projects'),
         options: model.projects,
-        selected: filter.projectKeys
+        selected: filter.repoIds
       })
     }
     return entries
-  }, [filter.hostIds, filter.projectKeys, model.hosts, model.projects])
+  }, [filter.hostIds, filter.repoIds, model.hosts, model.projects])
 
   // Stale field falls back to root if its group disappeared mid-session.
   const activeGroup =

--- a/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
@@ -78,7 +78,7 @@ export default function PaletteFilterMenu({
 
   const groups = useMemo<PaletteFilterGroup[]>(() => {
     const entries: PaletteFilterGroup[] = []
-    // Why: a single host (or single project) is nothing to disambiguate between,
+    // Why: a single host (or single repository) is nothing to disambiguate between,
     // so that axis stays hidden rather than offering a no-op checkbox.
     if (model.hosts.length > 1) {
       entries.push({
@@ -90,7 +90,7 @@ export default function PaletteFilterMenu({
     }
     if (model.repositories.length > 1) {
       entries.push({
-        field: 'project',
+        field: 'repository',
         heading: translate('worktreeJumpPalette.filter.projects', 'Projects'),
         options: model.repositories,
         selected: filter.repoIds

--- a/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteFilterMenu.tsx
@@ -91,6 +91,7 @@ export default function PaletteFilterMenu({
     if (model.repositories.length > 1) {
       entries.push({
         field: 'repository',
+        // "Projects" is the user-facing term for repository-granular choices; see filter.emptySubtitle.
         heading: translate('worktreeJumpPalette.filter.projects', 'Projects'),
         options: model.repositories,
         selected: filter.repoIds

--- a/src/renderer/src/components/cmd-j/palette-filter-options.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-options.test.ts
@@ -70,13 +70,13 @@ describe('buildPaletteFilterModel', () => {
     const model = buildModel([worktree('w1', 'r1'), worktree('w2', 'r2'), worktree('w3', 'r3')])
 
     expect(model.repoIdsByProjectKey.get('project:p1')).toEqual(['r1', 'r2'])
-    expect(model.projects.map((option) => [option.id, option.label, option.count])).toEqual([
+    expect(model.repositories.map((option) => [option.id, option.label, option.count])).toEqual([
       ['r1', 'Orca', 1],
       ['r2', 'Orca (builder)', 1],
       ['r3', 'Solo', 1]
     ])
-    expect(model.projects[0]?.searchText).toContain('orca')
-    expect(model.projects[0]?.searchText).toContain(path.join('/repos', 'r1'))
+    expect(model.repositories[0]?.searchText).toContain('orca')
+    expect(model.repositories[0]?.searchText).toContain(path.join('/repos', 'r1'))
   })
 
   it('counts a worktree against its own host stamp, not its repo host', () => {
@@ -90,8 +90,8 @@ describe('buildPaletteFilterModel', () => {
       ['local', 1],
       ['ssh:ssh-1', 2]
     ])
-    expect(model.projects.find((option) => option.id === 'r1')?.count).toBe(2)
-    expect(model.projects.find((option) => option.id === 'r2')?.count).toBe(1)
+    expect(model.repositories.find((option) => option.id === 'r1')?.count).toBe(2)
+    expect(model.repositories.find((option) => option.id === 'r2')?.count).toBe(1)
   })
 
   it('omits archived worktrees from every count', () => {
@@ -105,7 +105,7 @@ describe('buildPaletteFilterModel', () => {
       ['local', 1],
       ['ssh:ssh-1', 0]
     ])
-    expect(model.projects.map((option) => [option.id, option.count])).toEqual([
+    expect(model.repositories.map((option) => [option.id, option.count])).toEqual([
       ['r1', 1],
       ['r2', 0],
       ['r3', 0]
@@ -119,7 +119,7 @@ describe('buildPaletteFilterModel', () => {
       ['local', 0],
       ['ssh:ssh-1', 0]
     ])
-    expect(model.projects.map((option) => [option.id, option.count])).toEqual([
+    expect(model.repositories.map((option) => [option.id, option.count])).toEqual([
       ['r1', 0],
       ['r2', 0],
       ['r3', 0]
@@ -131,7 +131,11 @@ describe('buildPaletteFilterModel', () => {
   it('sorts repository options by workspace count then label', () => {
     const model = buildModel([worktree('w1', 'r3'), worktree('w2', 'r1'), worktree('w3', 'r2')])
 
-    expect(model.projects.map((option) => option.label)).toEqual(['Orca', 'Orca (builder)', 'Solo'])
+    expect(model.repositories.map((option) => option.label)).toEqual([
+      'Orca',
+      'Orca (builder)',
+      'Solo'
+    ])
   })
 
   it('prefers a busier project ahead of an alphabetically earlier quiet one', () => {
@@ -142,7 +146,7 @@ describe('buildPaletteFilterModel', () => {
       worktree('w4', 'r1')
     ])
 
-    expect(model.projects.map((option) => [option.label, option.count])).toEqual([
+    expect(model.repositories.map((option) => [option.label, option.count])).toEqual([
       ['Solo', 3],
       ['Orca', 1],
       ['Orca (builder)', 0]

--- a/src/renderer/src/components/cmd-j/palette-filter-options.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-options.test.ts
@@ -66,15 +66,17 @@ const buildModel = (worktrees: readonly Worktree[]) =>
   buildPaletteFilterModel({ repos, worktrees, hostOptions, projects, projectHostSetups })
 
 describe('buildPaletteFilterModel', () => {
-  it('collapses the repos of one project into a single row', () => {
+  it('keeps filter options repo-granular while retaining project-row membership', () => {
     const model = buildModel([worktree('w1', 'r1'), worktree('w2', 'r2'), worktree('w3', 'r3')])
 
     expect(model.repoIdsByProjectKey.get('project:p1')).toEqual(['r1', 'r2'])
     expect(model.projects.map((option) => [option.id, option.label, option.count])).toEqual([
-      ['project:p1', 'Orca', 2],
-      ['repo:r3', 'Solo', 1]
+      ['r1', 'Orca', 1],
+      ['r2', 'Orca (builder)', 1],
+      ['r3', 'Solo', 1]
     ])
-    expect(model.projects[0]?.searchText).toBe('orca')
+    expect(model.projects[0]?.searchText).toContain('orca')
+    expect(model.projects[0]?.searchText).toContain(path.join('/repos', 'r1'))
   })
 
   it('counts a worktree against its own host stamp, not its repo host', () => {
@@ -88,8 +90,8 @@ describe('buildPaletteFilterModel', () => {
       ['local', 1],
       ['ssh:ssh-1', 2]
     ])
-    // Host stamp does not move the workspace out of its project row.
-    expect(model.projects.find((option) => option.id === 'project:p1')?.count).toBe(3)
+    expect(model.projects.find((option) => option.id === 'r1')?.count).toBe(2)
+    expect(model.projects.find((option) => option.id === 'r2')?.count).toBe(1)
   })
 
   it('omits archived worktrees from every count', () => {
@@ -99,26 +101,37 @@ describe('buildPaletteFilterModel', () => {
       worktree('w3', 'r3', { isArchived: true })
     ])
 
-    expect(model.hosts.map((option) => option.id)).toEqual(['local'])
-    expect(model.hosts[0]?.count).toBe(1)
-    expect(model.projects.map((option) => option.id)).toEqual(['project:p1'])
+    expect(model.hosts.map((option) => [option.id, option.count])).toEqual([
+      ['local', 1],
+      ['ssh:ssh-1', 0]
+    ])
+    expect(model.projects.map((option) => [option.id, option.count])).toEqual([
+      ['r1', 1],
+      ['r2', 0],
+      ['r3', 0]
+    ])
   })
 
-  it('offers no options at all when there is nothing to narrow', () => {
+  it('retains options while worktrees are loading', () => {
     const model = buildModel([])
 
-    expect(model.hosts).toEqual([])
-    expect(model.projects).toEqual([])
-    // The mapping still resolves so a lingering selection prunes cleanly.
+    expect(model.hosts.map((option) => [option.id, option.count])).toEqual([
+      ['local', 0],
+      ['ssh:ssh-1', 0]
+    ])
+    expect(model.projects.map((option) => [option.id, option.count])).toEqual([
+      ['r1', 0],
+      ['r2', 0],
+      ['r3', 0]
+    ])
     expect(model.repoIdsByProjectKey.get('project:p1')).toEqual(['r1', 'r2'])
     expect(model.hostIdByRepoId.get('r2')).toBe('ssh:ssh-1')
   })
 
-  it('sorts project rows by workspace count then label', () => {
+  it('sorts repository options by workspace count then label', () => {
     const model = buildModel([worktree('w1', 'r3'), worktree('w2', 'r1'), worktree('w3', 'r2')])
 
-    // Orca has 2 workspaces, Solo has 1 — popularity beats alpha.
-    expect(model.projects.map((option) => option.label)).toEqual(['Orca', 'Solo'])
+    expect(model.projects.map((option) => option.label)).toEqual(['Orca', 'Orca (builder)', 'Solo'])
   })
 
   it('prefers a busier project ahead of an alphabetically earlier quiet one', () => {
@@ -131,7 +144,8 @@ describe('buildPaletteFilterModel', () => {
 
     expect(model.projects.map((option) => [option.label, option.count])).toEqual([
       ['Solo', 3],
-      ['Orca', 1]
+      ['Orca', 1],
+      ['Orca (builder)', 0]
     ])
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-filter-options.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-options.test.ts
@@ -5,11 +5,7 @@ import type { Project, ProjectHostSetup } from '../../../../shared/project-types
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { buildSidebarHostOptions } from '../sidebar/sidebar-host-options'
-import {
-  buildPaletteFilterModel,
-  resolveRepoFilterHostId,
-  resolveWorktreeFilterHostId
-} from './palette-filter-options'
+import { buildPaletteFilterModel, resolveWorktreeFilterHostId } from './palette-filter-options'
 
 function repo(id: string, displayName: string, connectionId: string | null = null): Repo {
   return {
@@ -125,7 +121,48 @@ describe('buildPaletteFilterModel', () => {
       ['r3', 0]
     ])
     expect(model.repoIdsByProjectKey.get('project:p1')).toEqual(['r1', 'r2'])
-    expect(model.hostIdByRepoId.get('r2')).toBe('ssh:ssh-1')
+    expect(model.hostIdsByRepoId.get('r2')).toEqual(new Set(['ssh:ssh-1']))
+  })
+
+  it('deduplicates a repository ID shared by multiple hosts', () => {
+    const duplicateRepos = [repo('shared', 'Shared'), repo('shared', 'Shared remote', 'ssh-1')]
+    const model = buildPaletteFilterModel({
+      repos: duplicateRepos,
+      worktrees: [
+        worktree('local', 'shared', { hostId: 'local' }),
+        worktree('remote', 'shared', { hostId: 'ssh:ssh-1' })
+      ],
+      hostOptions: buildSidebarHostOptions({
+        repos: duplicateRepos,
+        sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+        settings: { activeRuntimeEnvironmentId: null }
+      }),
+      projects: [],
+      projectHostSetups: []
+    })
+
+    expect(model.repositories.map((option) => [option.id, option.count])).toEqual([['shared', 2]])
+    expect(model.hostIdsByRepoId.get('shared')).toEqual(new Set(['local', 'ssh:ssh-1']))
+    expect(model.repoIdsByProjectKey.get('repo:shared')).toEqual(['shared'])
+  })
+
+  it('disambiguates repositories with the same display name', () => {
+    const duplicateNames = [
+      { ...repo('payments', 'api'), path: path.join('/repos', 'payments', 'api') },
+      { ...repo('billing', 'api'), path: path.join('/repos', 'billing', 'api') }
+    ]
+    const model = buildPaletteFilterModel({
+      repos: duplicateNames,
+      worktrees: [],
+      hostOptions: [],
+      projects: [],
+      projectHostSetups: []
+    })
+
+    expect(model.repositories.map((option) => option.label)).toEqual([
+      'billing/api',
+      'payments/api'
+    ])
   })
 
   it('sorts repository options by workspace count then label', () => {
@@ -138,7 +175,7 @@ describe('buildPaletteFilterModel', () => {
     ])
   })
 
-  it('prefers a busier project ahead of an alphabetically earlier quiet one', () => {
+  it('prefers a busier repository ahead of an alphabetically earlier quiet one', () => {
     const model = buildModel([
       worktree('w1', 'r3'),
       worktree('w2', 'r3'),
@@ -155,18 +192,32 @@ describe('buildPaletteFilterModel', () => {
 })
 
 describe('resolveWorktreeFilterHostId', () => {
-  const hostIdByRepoId = new Map<string, ExecutionHostId>([['r2', 'ssh:ssh-1']])
+  const repoById = new Map([['r2', repo('r2', 'Remote', 'ssh-1')]])
 
   it('prefers the worktree stamp, then the repo host, then the default host', () => {
-    expect(
-      resolveWorktreeFilterHostId({ repoId: 'r2', hostId: 'local' }, hostIdByRepoId, 'local')
-    ).toBe('local')
-    expect(resolveWorktreeFilterHostId({ repoId: 'r2' }, hostIdByRepoId, 'local')).toBe('ssh:ssh-1')
-    expect(resolveWorktreeFilterHostId({ repoId: 'unknown' }, hostIdByRepoId, 'local')).toBe(
+    expect(resolveWorktreeFilterHostId({ repoId: 'r2', hostId: 'local' }, repoById, 'local')).toBe(
       'local'
     )
+    expect(resolveWorktreeFilterHostId({ repoId: 'r2' }, repoById, 'local')).toBe('ssh:ssh-1')
+    expect(resolveWorktreeFilterHostId({ repoId: 'unknown' }, repoById, 'local')).toBe('local')
+    expect(resolveWorktreeFilterHostId({ repoId: 'unknown' }, repoById, 'runtime:env-1')).toBe(
+      'runtime:env-1'
+    )
+  })
+
+  it('uses the same last repository row as the sidebar for a shared legacy ID', () => {
+    const duplicateRepos = [repo('shared', 'Shared'), repo('shared', 'Shared remote', 'ssh-1')]
+    const sidebarRepoMap = new Map(duplicateRepos.map((entry) => [entry.id, entry]))
+
+    expect(resolveWorktreeFilterHostId({ repoId: 'shared' }, sidebarRepoMap, 'local')).toBe(
+      'ssh:ssh-1'
+    )
     expect(
-      resolveWorktreeFilterHostId({ repoId: 'unknown' }, hostIdByRepoId, 'runtime:env-1')
+      resolveWorktreeFilterHostId(
+        { repoId: 'shared', hostId: 'runtime:env-1' },
+        sidebarRepoMap,
+        'local'
+      )
     ).toBe('runtime:env-1')
   })
 
@@ -192,20 +243,10 @@ describe('resolveWorktreeFilterHostId', () => {
         defaultHostId
       })
       for (const entry of cases) {
-        expect(resolveWorktreeFilterHostId(entry, model.hostIdByRepoId, model.defaultHostId)).toBe(
+        expect(resolveWorktreeFilterHostId(entry, model.repoById, model.defaultHostId)).toBe(
           getWorktreeExecutionHostId(entry, repoMap.get(entry.repoId), defaultHostId)
         )
       }
     }
-  })
-})
-
-describe('resolveRepoFilterHostId', () => {
-  it('falls back to the default host when the repo has no stamp', () => {
-    const hostIdByRepoId = new Map<string, ExecutionHostId>([['r2', 'ssh:ssh-1']])
-    expect(resolveRepoFilterHostId('r2', hostIdByRepoId, 'local')).toBe('ssh:ssh-1')
-    expect(resolveRepoFilterHostId('missing', hostIdByRepoId, 'runtime:env-1')).toBe(
-      'runtime:env-1'
-    )
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-filter-options.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-options.ts
@@ -42,6 +42,7 @@ function toFilterOption({
 
 export type PaletteFilterModel = {
   hosts: readonly PaletteFilterOption[]
+  /** Repository-granular so the palette can preserve the sidebar's exact project scope. */
   projects: readonly PaletteFilterOption[]
   /** A project row can span several repos (Project.sourceRepoIds), so selection resolves through this. */
   repoIdsByProjectKey: ReadonlyMap<string, readonly string[]>
@@ -86,29 +87,25 @@ export function resolveRepoFilterHostId(
   return hostIdByRepoId.get(repoId) ?? defaultHostId
 }
 
-type ProjectRow = { key: string; label: string; repoIds: string[] }
-
-function buildProjectRows(
+function buildRepoIdsByProjectKey(
   repos: readonly Repo[],
   repoMap: Map<string, Repo>,
   grouping: ProjectGroupingModel
-): { rows: ProjectRow[]; keyByRepoId: Map<string, string> } {
-  const rows = new Map<string, ProjectRow>()
-  const keyByRepoId = new Map<string, string>()
+): Map<string, string[]> {
+  const repoIdsByProjectKey = new Map<string, string[]>()
   for (const repo of repos) {
     const target = getProjectHeaderRevealTarget(repo.id, repoMap, grouping)
     if (!target.repo) {
       continue
     }
-    const existing = rows.get(target.key)
-    if (existing) {
-      existing.repoIds.push(repo.id)
+    const repoIds = repoIdsByProjectKey.get(target.key)
+    if (repoIds) {
+      repoIds.push(repo.id)
     } else {
-      rows.set(target.key, { key: target.key, label: target.label, repoIds: [repo.id] })
+      repoIdsByProjectKey.set(target.key, [repo.id])
     }
-    keyByRepoId.set(repo.id, target.key)
   }
-  return { rows: [...rows.values()], keyByRepoId }
+  return repoIdsByProjectKey
 }
 
 export function buildPaletteFilterModel({
@@ -128,49 +125,43 @@ export function buildPaletteFilterModel({
 }): PaletteFilterModel {
   const repoMap = new Map(repos.map((repo) => [repo.id, repo]))
   const hostIdByRepoId = buildRepoHostIndex(repos)
-  const { rows, keyByRepoId } = buildProjectRows(repos, repoMap, { projects, projectHostSetups })
+  const repoIdsByProjectKey = buildRepoIdsByProjectKey(repos, repoMap, {
+    projects,
+    projectHostSetups
+  })
 
   const worktreeCountByHostId = new Map<string, number>()
-  const worktreeCountByProjectKey = new Map<string, number>()
+  const worktreeCountByRepoId = new Map<string, number>()
   for (const worktree of worktrees) {
     if (worktree.isArchived) {
       continue
     }
     const hostId = resolveWorktreeFilterHostId(worktree, hostIdByRepoId, defaultHostId)
     worktreeCountByHostId.set(hostId, (worktreeCountByHostId.get(hostId) ?? 0) + 1)
-    const projectKey = keyByRepoId.get(worktree.repoId)
-    if (projectKey) {
-      worktreeCountByProjectKey.set(
-        projectKey,
-        (worktreeCountByProjectKey.get(projectKey) ?? 0) + 1
-      )
-    }
+    worktreeCountByRepoId.set(
+      worktree.repoId,
+      (worktreeCountByRepoId.get(worktree.repoId) ?? 0) + 1
+    )
   }
 
-  // Why: options are gated on a live workspace count, not on configuration — an
-  // option that can only ever yield an empty list is a trap, and it also keeps
-  // stale selections self-healing through reconcilePaletteFilter.
   // Registry order (local first, then SSH/runtime) matches the sidebar host headers.
-  const hosts = hostOptions
-    .filter((host) => (worktreeCountByHostId.get(host.id) ?? 0) > 0)
-    .map((host) =>
-      toFilterOption({
-        id: host.id,
-        label: host.label,
-        detail: host.detail,
-        count: worktreeCountByHostId.get(host.id) ?? 0
-      })
-    )
+  const hosts = hostOptions.map((host) =>
+    toFilterOption({
+      id: host.id,
+      label: host.label,
+      detail: host.detail,
+      count: worktreeCountByHostId.get(host.id) ?? 0
+    })
+  )
 
-  // Popularity first so a long project list surfaces busy workspaces without search.
-  const projectOptions = rows
-    .filter((row) => (worktreeCountByProjectKey.get(row.key) ?? 0) > 0)
-    .map((row) =>
+  // Keep repository IDs aligned with the sidebar; project grouping remains a row concern.
+  const projectOptions = repos
+    .map((repo) =>
       toFilterOption({
-        id: row.key,
-        label: row.label,
-        detail: '',
-        count: worktreeCountByProjectKey.get(row.key) ?? 0
+        id: repo.id,
+        label: repo.displayName,
+        detail: repo.path,
+        count: worktreeCountByRepoId.get(repo.id) ?? 0
       })
     )
     .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label) || a.id.localeCompare(b.id))
@@ -178,7 +169,7 @@ export function buildPaletteFilterModel({
   return {
     hosts,
     projects: projectOptions,
-    repoIdsByProjectKey: new Map(rows.map((row) => [row.key, row.repoIds])),
+    repoIdsByProjectKey,
     hostIdByRepoId,
     defaultHostId
   }

--- a/src/renderer/src/components/cmd-j/palette-filter-options.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-options.ts
@@ -42,8 +42,7 @@ function toFilterOption({
 
 export type PaletteFilterModel = {
   hosts: readonly PaletteFilterOption[]
-  /** Repository-granular so the palette can preserve the sidebar's exact project scope. */
-  projects: readonly PaletteFilterOption[]
+  repositories: readonly PaletteFilterOption[]
   /** A project row can span several repos (Project.sourceRepoIds), so selection resolves through this. */
   repoIdsByProjectKey: ReadonlyMap<string, readonly string[]>
   /** Only repos that carry a host stamp; absent means "inherit defaultHostId". */
@@ -155,7 +154,7 @@ export function buildPaletteFilterModel({
   )
 
   // Keep repository IDs aligned with the sidebar; project grouping remains a row concern.
-  const projectOptions = repos
+  const repositoryOptions = repos
     .map((repo) =>
       toFilterOption({
         id: repo.id,
@@ -168,7 +167,7 @@ export function buildPaletteFilterModel({
 
   return {
     hosts,
-    projects: projectOptions,
+    repositories: repositoryOptions,
     repoIdsByProjectKey,
     hostIdByRepoId,
     defaultHostId

--- a/src/renderer/src/components/cmd-j/palette-filter-options.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter-options.ts
@@ -1,5 +1,7 @@
+import { getRepoDisplayLabelKey, getRepoDisplayLabelsByPath } from '@/lib/repo-display-labels'
 import {
   getRepoExecutionHostId,
+  getWorktreeExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
@@ -43,57 +45,47 @@ function toFilterOption({
 export type PaletteFilterModel = {
   hosts: readonly PaletteFilterOption[]
   repositories: readonly PaletteFilterOption[]
-  /** A project row can span several repos (Project.sourceRepoIds), so selection resolves through this. */
+  /** Repository IDs represented by each project row in the sidebar grouping. */
   repoIdsByProjectKey: ReadonlyMap<string, readonly string[]>
-  /** Only repos that carry a host stamp; absent means "inherit defaultHostId". */
-  hostIdByRepoId: ReadonlyMap<string, ExecutionHostId>
+  /** Every execution host that owns a repository ID. */
+  hostIdsByRepoId: ReadonlyMap<string, ReadonlySet<ExecutionHostId>>
+  /** Same last-row-wins repository index used by the sidebar. */
+  repoById: ReadonlyMap<string, Pick<Repo, 'connectionId' | 'executionHostId'>>
   /** The focused runtime host, which host-less repos and worktrees inherit. */
   defaultHostId: ExecutionHostId
 }
 
-/**
- * Precomputes only the repos that actually carry a host stamp so the lookup miss
- * below stays equivalent to getWorktreeExecutionHostId's `defaultHostId` branch.
- * Collapsing host-less repos to `local` here would disagree with the sidebar
- * whenever a runtime environment is focused.
- */
-function buildRepoHostIndex(repos: readonly Repo[]): Map<string, ExecutionHostId> {
-  const hostIdByRepoId = new Map<string, ExecutionHostId>()
+function buildRepoHostIndex(
+  repos: readonly Repo[],
+  defaultHostId: ExecutionHostId
+): Map<string, Set<ExecutionHostId>> {
+  const hostIdsByRepoId = new Map<string, Set<ExecutionHostId>>()
   for (const repo of repos) {
-    if (repo.connectionId || repo.executionHostId) {
-      hostIdByRepoId.set(repo.id, getRepoExecutionHostId(repo))
-    }
+    const hostIds = hostIdsByRepoId.get(repo.id) ?? new Set<ExecutionHostId>()
+    hostIds.add(
+      repo.connectionId || repo.executionHostId ? getRepoExecutionHostId(repo) : defaultHostId
+    )
+    hostIdsByRepoId.set(repo.id, hostIds)
   }
-  return hostIdByRepoId
+  return hostIdsByRepoId
 }
 
 export function resolveWorktreeFilterHostId(
   worktree: Pick<Worktree, 'repoId' | 'hostId'>,
-  hostIdByRepoId: ReadonlyMap<string, ExecutionHostId>,
+  repoById: ReadonlyMap<string, Pick<Repo, 'connectionId' | 'executionHostId'>>,
   defaultHostId: ExecutionHostId
 ): ExecutionHostId {
-  // Why: same precedence as getWorktreeExecutionHostId without re-resolving the
-  // repo per worktree — the repo host is precomputed once for the whole pass.
-  return worktree.hostId ?? hostIdByRepoId.get(worktree.repoId) ?? defaultHostId
-}
-
-/** Repo-derived host for a project row, which owns no worktree of its own. */
-export function resolveRepoFilterHostId(
-  repoId: string,
-  hostIdByRepoId: ReadonlyMap<string, ExecutionHostId>,
-  defaultHostId: ExecutionHostId
-): ExecutionHostId {
-  return hostIdByRepoId.get(repoId) ?? defaultHostId
+  return getWorktreeExecutionHostId(worktree, repoById.get(worktree.repoId), defaultHostId)
 }
 
 function buildRepoIdsByProjectKey(
   repos: readonly Repo[],
-  repoMap: Map<string, Repo>,
+  repoById: Map<string, Repo>,
   grouping: ProjectGroupingModel
 ): Map<string, string[]> {
   const repoIdsByProjectKey = new Map<string, string[]>()
   for (const repo of repos) {
-    const target = getProjectHeaderRevealTarget(repo.id, repoMap, grouping)
+    const target = getProjectHeaderRevealTarget(repo.id, repoById, grouping)
     if (!target.repo) {
       continue
     }
@@ -122,9 +114,9 @@ export function buildPaletteFilterModel({
   projectHostSetups: readonly ProjectHostSetup[]
   defaultHostId?: ExecutionHostId
 }): PaletteFilterModel {
-  const repoMap = new Map(repos.map((repo) => [repo.id, repo]))
-  const hostIdByRepoId = buildRepoHostIndex(repos)
-  const repoIdsByProjectKey = buildRepoIdsByProjectKey(repos, repoMap, {
+  const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+  const hostIdsByRepoId = buildRepoHostIndex(repos, defaultHostId)
+  const repoIdsByProjectKey = buildRepoIdsByProjectKey([...repoById.values()], repoById, {
     projects,
     projectHostSetups
   })
@@ -135,7 +127,7 @@ export function buildPaletteFilterModel({
     if (worktree.isArchived) {
       continue
     }
-    const hostId = resolveWorktreeFilterHostId(worktree, hostIdByRepoId, defaultHostId)
+    const hostId = resolveWorktreeFilterHostId(worktree, repoById, defaultHostId)
     worktreeCountByHostId.set(hostId, (worktreeCountByHostId.get(hostId) ?? 0) + 1)
     worktreeCountByRepoId.set(
       worktree.repoId,
@@ -154,11 +146,12 @@ export function buildPaletteFilterModel({
   )
 
   // Keep repository IDs aligned with the sidebar; project grouping remains a row concern.
-  const repositoryOptions = repos
+  const repositoryLabels = getRepoDisplayLabelsByPath([...repoById.values()])
+  const repositories = [...repoById.values()]
     .map((repo) =>
       toFilterOption({
         id: repo.id,
-        label: repo.displayName,
+        label: repositoryLabels.get(getRepoDisplayLabelKey(repo)) ?? repo.displayName,
         detail: repo.path,
         count: worktreeCountByRepoId.get(repo.id) ?? 0
       })
@@ -167,9 +160,10 @@ export function buildPaletteFilterModel({
 
   return {
     hosts,
-    repositories: repositoryOptions,
+    repositories,
     repoIdsByProjectKey,
-    hostIdByRepoId,
+    hostIdsByRepoId,
+    repoById,
     defaultHostId
   }
 }

--- a/src/renderer/src/components/cmd-j/palette-filter.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import {
   addPaletteFilterValues,
+  buildPaletteFilterFromSidebarScope,
   buildPaletteFilterPredicate,
   clearPaletteFilterField,
   EMPTY_PALETTE_FILTER,
@@ -210,5 +211,67 @@ describe('buildPaletteFilterPredicate', () => {
       model
     )
     expect(withProject?.matchesGroupHostId('ssh:builder')).toBe(false)
+  })
+})
+
+describe('buildPaletteFilterFromSidebarScope', () => {
+  const allHosts = { workspaceHostScope: 'all', visibleWorkspaceHostIds: null } as const
+
+  it('opens unfiltered when the sidebar shows every host and project', () => {
+    expect(buildPaletteFilterFromSidebarScope({ ...allHosts, filterRepoIds: [] }, model)).toBe(
+      EMPTY_PALETTE_FILTER
+    )
+  })
+
+  it('seeds the host chips from the sidebar host scope', () => {
+    expect(
+      buildPaletteFilterFromSidebarScope(
+        { workspaceHostScope: 'ssh:builder', visibleWorkspaceHostIds: null, filterRepoIds: [] },
+        model
+      )
+    ).toEqual(filterOf(['ssh:builder'], []))
+    expect(
+      buildPaletteFilterFromSidebarScope(
+        {
+          workspaceHostScope: 'all',
+          visibleWorkspaceHostIds: ['runtime:env-1', 'local'],
+          filterRepoIds: []
+        },
+        model
+      )
+    ).toEqual(filterOf(['local', 'runtime:env-1'], []))
+  })
+
+  it('maps sidebar repo picks onto the project rows that contain them', () => {
+    expect(
+      buildPaletteFilterFromSidebarScope({ ...allHosts, filterRepoIds: ['r2'] }, model)
+    ).toEqual(filterOf([], ['project:p1']))
+  })
+
+  it('treats a scope that covers every option as no filter', () => {
+    // Every host explicitly listed is the same as "all hosts": no chips to clear.
+    expect(
+      buildPaletteFilterFromSidebarScope(
+        {
+          workspaceHostScope: 'all',
+          visibleWorkspaceHostIds: ['local', 'ssh:builder', 'runtime:env-1'],
+          filterRepoIds: ['r1', 'r3']
+        },
+        model
+      )
+    ).toBe(EMPTY_PALETTE_FILTER)
+  })
+
+  it('falls back to a global search when the scope matches nothing the palette can show', () => {
+    expect(
+      buildPaletteFilterFromSidebarScope(
+        {
+          workspaceHostScope: 'ssh:gone',
+          visibleWorkspaceHostIds: null,
+          filterRepoIds: ['r-gone']
+        },
+        model
+      )
+    ).toBe(EMPTY_PALETTE_FILTER)
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-filter.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.test.ts
@@ -26,7 +26,7 @@ const option = (id: string, count = 1) => ({
 // r1 + r2 are two repos behind one project row; r3 is a standalone repo row.
 const model: PaletteFilterModel = {
   hosts: [option('local'), option('ssh:builder'), option('runtime:env-1')],
-  projects: [option('r1'), option('r2'), option('r3')],
+  repositories: [option('r1'), option('r2'), option('r3')],
   repoIdsByProjectKey: new Map([
     ['project:p1', ['r1', 'r2']],
     ['repo:r3', ['r3']]

--- a/src/renderer/src/components/cmd-j/palette-filter.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.test.ts
@@ -8,8 +8,6 @@ import {
   EMPTY_PALETTE_FILTER,
   getPaletteFilterSelectionCount,
   isPaletteFilterActive,
-  PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD,
-  reconcilePaletteFilter,
   togglePaletteFilterValue,
   type PaletteFilterState
 } from './palette-filter'
@@ -28,7 +26,7 @@ const option = (id: string, count = 1) => ({
 // r1 + r2 are two repos behind one project row; r3 is a standalone repo row.
 const model: PaletteFilterModel = {
   hosts: [option('local'), option('ssh:builder'), option('runtime:env-1')],
-  projects: [option('project:p1'), option('repo:r3')],
+  projects: [option('r1'), option('r2'), option('r3')],
   repoIdsByProjectKey: new Map([
     ['project:p1', ['r1', 'r2']],
     ['repo:r3', ['r3']]
@@ -41,17 +39,17 @@ const model: PaletteFilterModel = {
   defaultHostId: LOCAL_EXECUTION_HOST_ID
 }
 
-const filterOf = (hostIds: string[], projectKeys: string[]): PaletteFilterState => ({
+const filterOf = (hostIds: string[], repoIds: string[]): PaletteFilterState => ({
   hostIds,
-  projectKeys
+  repoIds
 })
 
 describe('palette filter state', () => {
   it('reports activity and selection count across both fields', () => {
     expect(isPaletteFilterActive(EMPTY_PALETTE_FILTER)).toBe(false)
     expect(getPaletteFilterSelectionCount(EMPTY_PALETTE_FILTER)).toBe(0)
-    expect(isPaletteFilterActive(filterOf([], ['project:p1']))).toBe(true)
-    expect(getPaletteFilterSelectionCount(filterOf(['local'], ['project:p1']))).toBe(2)
+    expect(isPaletteFilterActive(filterOf([], ['r1']))).toBe(true)
+    expect(getPaletteFilterSelectionCount(filterOf(['local'], ['r1']))).toBe(2)
   })
 
   it('toggles values on and off, keeping each field sorted', () => {
@@ -59,7 +57,7 @@ describe('palette filter state', () => {
     const withBothHosts = togglePaletteFilterValue(withHost, 'host', 'local')
 
     expect(withBothHosts.hostIds).toEqual(['local', 'ssh:builder'])
-    expect(withBothHosts.projectKeys).toEqual([])
+    expect(withBothHosts.repoIds).toEqual([])
     expect(togglePaletteFilterValue(withBothHosts, 'host', 'local').hostIds).toEqual([
       'ssh:builder'
     ])
@@ -69,69 +67,21 @@ describe('palette filter state', () => {
     const filter = togglePaletteFilterValue(
       togglePaletteFilterValue(EMPTY_PALETTE_FILTER, 'host', 'local'),
       'project',
-      'project:p1'
+      'r1'
     )
 
     expect(clearPaletteFilterField(filter, 'project')).toEqual(filterOf(['local'], []))
-    expect(clearPaletteFilterField(filter, 'host')).toEqual(filterOf([], ['project:p1']))
+    expect(clearPaletteFilterField(filter, 'host')).toEqual(filterOf([], ['r1']))
   })
 
-  it('refuses selections past the per-field cap', () => {
-    const saturated = filterOf(
-      Array.from({ length: PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD }, (_, i) => `ssh:host-${i}`),
-      []
+  it('bulk-adds every matching id without duplicating', () => {
+    const withOne = addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'project', ['r1', 'r3', 'r1'])
+    expect(withOne.repoIds).toEqual(['r1', 'r3'])
+
+    const manyIds = Array.from({ length: 501 }, (_, index) => `repo-${index}`)
+    expect(addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'project', manyIds).repoIds).toHaveLength(
+      501
     )
-
-    const next = togglePaletteFilterValue(saturated, 'host', 'ssh:one-too-many')
-
-    expect(next.hostIds).toHaveLength(PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD)
-    expect(next.hostIds).not.toContain('ssh:one-too-many')
-    // Deselecting still works at the cap, so the user is never stuck.
-    expect(togglePaletteFilterValue(saturated, 'host', 'ssh:host-0').hostIds).toHaveLength(
-      PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD - 1
-    )
-  })
-
-  it('bulk-adds matching ids up to the per-field cap without duplicating', () => {
-    const withOne = addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'project', [
-      'project:p1',
-      'repo:r3',
-      'project:p1'
-    ])
-    expect(withOne.projectKeys).toEqual(['project:p1', 'repo:r3'])
-
-    const nearCap = filterOf(
-      Array.from(
-        { length: PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD - 1 },
-        (_, i) => `ssh:host-${i}`
-      ),
-      []
-    )
-    const filled = addPaletteFilterValues(nearCap, 'host', ['ssh:a', 'ssh:b'])
-    expect(filled.hostIds).toHaveLength(PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD)
-    expect(filled.hostIds).toContain('ssh:a')
-    expect(filled.hostIds).not.toContain('ssh:b')
-  })
-})
-
-describe('reconcilePaletteFilter', () => {
-  it('returns the same reference when every selection still exists', () => {
-    const filter = filterOf(['local'], ['project:p1'])
-
-    expect(reconcilePaletteFilter(filter, model)).toBe(filter)
-    expect(reconcilePaletteFilter(EMPTY_PALETTE_FILTER, model)).toBe(EMPTY_PALETTE_FILTER)
-  })
-
-  it('drops selections whose host or project disappeared', () => {
-    const filter = filterOf(['local', 'ssh:deleted'], ['project:p1', 'repo:removed'])
-
-    expect(reconcilePaletteFilter(filter, model)).toEqual(filterOf(['local'], ['project:p1']))
-  })
-
-  it('empties a filter whose every selection is gone', () => {
-    const reconciled = reconcilePaletteFilter(filterOf(['ssh:deleted'], []), model)
-
-    expect(isPaletteFilterActive(reconciled)).toBe(false)
   })
 })
 
@@ -156,11 +106,11 @@ describe('buildPaletteFilterPredicate', () => {
     expect(local?.matchesWorktree({ repoId: 'never-seen' })).toBe(true)
   })
 
-  it('matches every repo behind a multi-repo project row', () => {
-    const predicate = buildPaletteFilterPredicate(filterOf([], ['project:p1']), model)
+  it('keeps repository filtering exact within a multi-repo project row', () => {
+    const predicate = buildPaletteFilterPredicate(filterOf([], ['r1']), model)
 
     expect(predicate?.matchesWorktree({ repoId: 'r1' })).toBe(true)
-    expect(predicate?.matchesWorktree({ repoId: 'r2' })).toBe(true)
+    expect(predicate?.matchesWorktree({ repoId: 'r2' })).toBe(false)
     expect(predicate?.matchesWorktree({ repoId: 'r3' })).toBe(false)
     expect(predicate?.matchesProjectRowKey('project:p1')).toBe(true)
     expect(predicate?.matchesProjectRowKey('repo:r3')).toBe(false)
@@ -180,21 +130,19 @@ describe('buildPaletteFilterPredicate', () => {
   })
 
   it('ORs within a field and ANDs across fields', () => {
-    const ored = buildPaletteFilterPredicate(filterOf([], ['project:p1', 'repo:r3']), model)
+    const ored = buildPaletteFilterPredicate(filterOf([], ['r1', 'r3']), model)
     expect(ored?.matchesWorktree({ repoId: 'r1' })).toBe(true)
     expect(ored?.matchesWorktree({ repoId: 'r3' })).toBe(true)
 
-    // Project p1 spans local (r1) and ssh:builder (r2); adding the host axis
-    // narrows to the intersection rather than widening the result set.
-    const anded = buildPaletteFilterPredicate(filterOf(['local'], ['project:p1']), model)
+    const anded = buildPaletteFilterPredicate(filterOf(['local'], ['r1', 'r2']), model)
     expect(anded?.matchesWorktree({ repoId: 'r1' })).toBe(true)
     expect(anded?.matchesWorktree({ repoId: 'r2' })).toBe(false)
     expect(anded?.matchesProjectRowKey('project:p1')).toBe(true)
     expect(anded?.matchesProjectRowKey('repo:r3')).toBe(false)
   })
 
-  it('never matches a stale project key that resolves to no repos', () => {
-    const predicate = buildPaletteFilterPredicate(filterOf([], ['project:gone']), model)
+  it('never matches a stale repository id', () => {
+    const predicate = buildPaletteFilterPredicate(filterOf([], ['repo:gone']), model)
 
     expect(predicate?.matchesWorktree({ repoId: 'r1' })).toBe(false)
     expect(predicate?.matchesProjectRowKey('project:p1')).toBe(false)
@@ -206,10 +154,7 @@ describe('buildPaletteFilterPredicate', () => {
     expect(hostOnly?.matchesGroupHostId('local')).toBe(false)
 
     // A group header belongs to no project, so any project selection excludes it.
-    const withProject = buildPaletteFilterPredicate(
-      filterOf(['ssh:builder'], ['project:p1']),
-      model
-    )
+    const withProject = buildPaletteFilterPredicate(filterOf(['ssh:builder'], ['r2']), model)
     expect(withProject?.matchesGroupHostId('ssh:builder')).toBe(false)
   })
 })
@@ -218,60 +163,58 @@ describe('buildPaletteFilterFromSidebarScope', () => {
   const allHosts = { workspaceHostScope: 'all', visibleWorkspaceHostIds: null } as const
 
   it('opens unfiltered when the sidebar shows every host and project', () => {
-    expect(buildPaletteFilterFromSidebarScope({ ...allHosts, filterRepoIds: [] }, model)).toBe(
+    expect(buildPaletteFilterFromSidebarScope({ ...allHosts, filterRepoIds: [] })).toBe(
       EMPTY_PALETTE_FILTER
     )
   })
 
   it('seeds the host chips from the sidebar host scope', () => {
     expect(
-      buildPaletteFilterFromSidebarScope(
-        { workspaceHostScope: 'ssh:builder', visibleWorkspaceHostIds: null, filterRepoIds: [] },
-        model
-      )
+      buildPaletteFilterFromSidebarScope({
+        workspaceHostScope: 'ssh:builder',
+        visibleWorkspaceHostIds: null,
+        filterRepoIds: []
+      })
     ).toEqual(filterOf(['ssh:builder'], []))
     expect(
-      buildPaletteFilterFromSidebarScope(
-        {
-          workspaceHostScope: 'all',
-          visibleWorkspaceHostIds: ['runtime:env-1', 'local'],
-          filterRepoIds: []
-        },
-        model
-      )
+      buildPaletteFilterFromSidebarScope({
+        workspaceHostScope: 'all',
+        visibleWorkspaceHostIds: ['runtime:env-1', 'local'],
+        filterRepoIds: []
+      })
     ).toEqual(filterOf(['local', 'runtime:env-1'], []))
   })
 
-  it('maps sidebar repo picks onto the project rows that contain them', () => {
-    expect(
-      buildPaletteFilterFromSidebarScope({ ...allHosts, filterRepoIds: ['r2'] }, model)
-    ).toEqual(filterOf([], ['project:p1']))
+  it('preserves sidebar repository picks exactly', () => {
+    expect(buildPaletteFilterFromSidebarScope({ ...allHosts, filterRepoIds: ['r2'] })).toEqual(
+      filterOf([], ['r2'])
+    )
+
+    const predicate = buildPaletteFilterPredicate(filterOf([], ['r2']), model)
+    expect(predicate?.matchesWorktree({ repoId: 'r1' })).toBe(false)
+    expect(predicate?.matchesWorktree({ repoId: 'r2' })).toBe(true)
   })
 
-  it('treats a scope that covers every option as no filter', () => {
-    // Every host explicitly listed is the same as "all hosts": no chips to clear.
+  it('preserves explicit selections even when they currently cover every known option', () => {
     expect(
-      buildPaletteFilterFromSidebarScope(
-        {
-          workspaceHostScope: 'all',
-          visibleWorkspaceHostIds: ['local', 'ssh:builder', 'runtime:env-1'],
-          filterRepoIds: ['r1', 'r3']
-        },
-        model
-      )
-    ).toBe(EMPTY_PALETTE_FILTER)
+      buildPaletteFilterFromSidebarScope({
+        workspaceHostScope: 'all',
+        visibleWorkspaceHostIds: ['local', 'ssh:builder', 'runtime:env-1'],
+        filterRepoIds: ['r1', 'r2', 'r3']
+      })
+    ).toEqual(filterOf(['local', 'runtime:env-1', 'ssh:builder'], ['r1', 'r2', 'r3']))
   })
 
-  it('falls back to a global search when the scope matches nothing the palette can show', () => {
-    expect(
-      buildPaletteFilterFromSidebarScope(
-        {
-          workspaceHostScope: 'ssh:gone',
-          visibleWorkspaceHostIds: null,
-          filterRepoIds: ['r-gone']
-        },
-        model
-      )
-    ).toBe(EMPTY_PALETTE_FILTER)
+  it('preserves empty or stale scopes instead of widening to a global search', () => {
+    const filter = buildPaletteFilterFromSidebarScope({
+      workspaceHostScope: 'ssh:gone',
+      visibleWorkspaceHostIds: null,
+      filterRepoIds: ['r-gone']
+    })
+
+    expect(filter).toEqual(filterOf(['ssh:gone'], ['r-gone']))
+    expect(buildPaletteFilterPredicate(filter, model)?.matchesWorktree({ repoId: 'r1' })).toBe(
+      false
+    )
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-filter.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
 import {
   addPaletteFilterValues,
   buildPaletteFilterFromSidebarScope,
@@ -31,10 +32,15 @@ const model: PaletteFilterModel = {
     ['project:p1', ['r1', 'r2']],
     ['repo:r3', ['r3']]
   ]),
-  hostIdByRepoId: new Map<string, ExecutionHostId>([
-    ['r1', 'local'],
-    ['r2', 'ssh:builder'],
-    ['r3', 'runtime:env-1']
+  hostIdsByRepoId: new Map<string, ReadonlySet<ExecutionHostId>>([
+    ['r1', new Set(['local'])],
+    ['r2', new Set(['ssh:builder'])],
+    ['r3', new Set(['runtime:env-1'])]
+  ]),
+  repoById: new Map<string, Pick<Repo, 'connectionId' | 'executionHostId'>>([
+    ['r1', {}],
+    ['r2', { connectionId: 'builder' }],
+    ['r3', { executionHostId: 'runtime:env-1' }]
   ]),
   defaultHostId: LOCAL_EXECUTION_HOST_ID
 }
@@ -66,22 +72,31 @@ describe('palette filter state', () => {
   it('keeps the two fields independent', () => {
     const filter = togglePaletteFilterValue(
       togglePaletteFilterValue(EMPTY_PALETTE_FILTER, 'host', 'local'),
-      'project',
+      'repository',
       'r1'
     )
 
-    expect(clearPaletteFilterField(filter, 'project')).toEqual(filterOf(['local'], []))
+    expect(clearPaletteFilterField(filter, 'repository')).toEqual(filterOf(['local'], []))
     expect(clearPaletteFilterField(filter, 'host')).toEqual(filterOf([], ['r1']))
   })
 
   it('bulk-adds every matching id without duplicating', () => {
-    const withOne = addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'project', ['r1', 'r3', 'r1'])
+    const withOne = addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'repository', ['r1', 'r3', 'r1'])
     expect(withOne.repoIds).toEqual(['r1', 'r3'])
 
     const manyIds = Array.from({ length: 501 }, (_, index) => `repo-${index}`)
-    expect(addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'project', manyIds).repoIds).toHaveLength(
-      501
-    )
+    expect(
+      addPaletteFilterValues(EMPTY_PALETTE_FILTER, 'repository', manyIds).repoIds
+    ).toHaveLength(501)
+  })
+
+  it('preserves state identity when bulk-add and clear are no-ops', () => {
+    const filter = filterOf(['local'], ['r1'])
+    const repoOnly = filterOf([], ['r1'])
+
+    expect(addPaletteFilterValues(filter, 'repository', ['r1'])).toBe(filter)
+    expect(clearPaletteFilterField(filter, 'host')).not.toBe(filter)
+    expect(clearPaletteFilterField(repoOnly, 'host')).toBe(repoOnly)
   })
 })
 
@@ -139,6 +154,25 @@ describe('buildPaletteFilterPredicate', () => {
     expect(anded?.matchesWorktree({ repoId: 'r2' })).toBe(false)
     expect(anded?.matchesProjectRowKey('project:p1')).toBe(true)
     expect(anded?.matchesProjectRowKey('repo:r3')).toBe(false)
+
+    const disjoint = buildPaletteFilterPredicate(filterOf(['local'], ['r2']), model)
+    expect(disjoint?.matchesProjectRowKey('project:p1')).toBe(false)
+  })
+
+  it('matches every host that owns a shared repository ID', () => {
+    const sharedRepoModel: PaletteFilterModel = {
+      ...model,
+      repositories: [option('shared')],
+      repoIdsByProjectKey: new Map([['repo:shared', ['shared']]]),
+      hostIdsByRepoId: new Map([['shared', new Set(['local', 'ssh:builder'])]])
+    }
+
+    expect(
+      buildPaletteFilterPredicate(
+        filterOf(['ssh:builder'], ['shared']),
+        sharedRepoModel
+      )?.matchesProjectRowKey('repo:shared')
+    ).toBe(true)
   })
 
   it('never matches a stale repository id', () => {
@@ -153,7 +187,7 @@ describe('buildPaletteFilterPredicate', () => {
     expect(hostOnly?.matchesGroupHostId('ssh:builder')).toBe(true)
     expect(hostOnly?.matchesGroupHostId('local')).toBe(false)
 
-    // A group header belongs to no project, so any project selection excludes it.
+    // A group header belongs to no repository, so any repository selection excludes it.
     const withProject = buildPaletteFilterPredicate(filterOf(['ssh:builder'], ['r2']), model)
     expect(withProject?.matchesGroupHostId('ssh:builder')).toBe(false)
   })

--- a/src/renderer/src/components/cmd-j/palette-filter.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.ts
@@ -1,4 +1,5 @@
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { getVisibleWorkspaceHostIdSet } from '../sidebar/visible-worktree-host-scope'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
   resolveRepoFilterHostId,
@@ -115,6 +116,45 @@ export function reconcilePaletteFilter(
     projectKeys.length === filter.projectKeys.length
   ) {
     return filter
+  }
+  return { hostIds, projectKeys }
+}
+
+export type SidebarScopeForPaletteFilter = Parameters<typeof getVisibleWorkspaceHostIdSet>[0] & {
+  filterRepoIds: readonly string[]
+}
+
+/**
+ * Seeds the palette's host/project selection from the sidebar's "Show" scope so
+ * Cmd+J opens on the same slice the user is looking at. One-way: the user can
+ * clear or change it per open, and the sidebar never reads it back. A field
+ * that would select every option is left empty — that is not a filter, just chips.
+ */
+export function buildPaletteFilterFromSidebarScope(
+  scope: SidebarScopeForPaletteFilter,
+  model: PaletteFilterModel
+): PaletteFilterState {
+  const visibleHostIds = getVisibleWorkspaceHostIdSet(scope)
+  let hostIds: readonly string[] = []
+  if (visibleHostIds) {
+    const available = model.hosts.filter((host) => visibleHostIds.has(host.id as ExecutionHostId))
+    hostIds = available.length < model.hosts.length ? available.map((host) => host.id).sort() : []
+  }
+
+  let projectKeys: readonly string[] = []
+  if (scope.filterRepoIds.length > 0) {
+    const selectedRepoIds = new Set(scope.filterRepoIds)
+    const available = model.projects.filter((project) =>
+      (model.repoIdsByProjectKey.get(project.id) ?? []).some((repoId) =>
+        selectedRepoIds.has(repoId)
+      )
+    )
+    projectKeys =
+      available.length < model.projects.length ? available.map((project) => project.id).sort() : []
+  }
+
+  if (hostIds.length === 0 && projectKeys.length === 0) {
+    return EMPTY_PALETTE_FILTER
   }
   return { hostIds, projectKeys }
 }

--- a/src/renderer/src/components/cmd-j/palette-filter.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.ts
@@ -15,30 +15,22 @@ export type PaletteFilterField = 'host' | 'project'
  */
 export type PaletteFilterState = {
   hostIds: readonly string[]
-  projectKeys: readonly string[]
+  repoIds: readonly string[]
 }
 
-export const EMPTY_PALETTE_FILTER: PaletteFilterState = { hostIds: [], projectKeys: [] }
-
-/** Guard against a pathological selection blowing up the predicate's Set build. */
-export const PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD = 500
+export const EMPTY_PALETTE_FILTER: PaletteFilterState = { hostIds: [], repoIds: [] }
 
 export function isPaletteFilterActive(filter: PaletteFilterState): boolean {
-  return filter.hostIds.length > 0 || filter.projectKeys.length > 0
+  return filter.hostIds.length > 0 || filter.repoIds.length > 0
 }
 
 export function getPaletteFilterSelectionCount(filter: PaletteFilterState): number {
-  return filter.hostIds.length + filter.projectKeys.length
+  return filter.hostIds.length + filter.repoIds.length
 }
 
 function toggleValue(values: readonly string[], id: string): readonly string[] {
   if (values.includes(id)) {
     return values.filter((value) => value !== id)
-  }
-  // Why: same reference on the capped no-op — a fresh array would invalidate
-  // every downstream search memo for a click that changed nothing.
-  if (values.length >= PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD) {
-    return values
   }
   return [...values, id].sort()
 }
@@ -50,29 +42,26 @@ export function togglePaletteFilterValue(
 ): PaletteFilterState {
   return field === 'host'
     ? { ...filter, hostIds: toggleValue(filter.hostIds, id) }
-    : { ...filter, projectKeys: toggleValue(filter.projectKeys, id) }
+    : { ...filter, repoIds: toggleValue(filter.repoIds, id) }
 }
 
 function addValues(values: readonly string[], ids: readonly string[]): readonly string[] {
-  if (ids.length === 0 || values.length >= PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD) {
+  if (ids.length === 0) {
     return values
   }
   const merged = new Set(values)
   const sizeBefore = merged.size
   for (const id of ids) {
-    if (merged.size >= PALETTE_FILTER_MAX_SELECTIONS_PER_FIELD) {
-      break
-    }
     merged.add(id)
   }
-  // Why: same reference when nothing new fit — keeps search memos stable.
+  // Why: same reference when nothing was added keeps search memos stable.
   if (merged.size === sizeBefore) {
     return values
   }
   return [...merged].sort()
 }
 
-/** Bulk-add for "Select all matching"; respects the per-field cap and de-dupes. */
+/** Bulk-add for "Select all matching"; de-dupes while preserving stable no-ops. */
 export function addPaletteFilterValues(
   filter: PaletteFilterState,
   field: PaletteFilterField,
@@ -80,78 +69,36 @@ export function addPaletteFilterValues(
 ): PaletteFilterState {
   return field === 'host'
     ? { ...filter, hostIds: addValues(filter.hostIds, ids) }
-    : { ...filter, projectKeys: addValues(filter.projectKeys, ids) }
+    : { ...filter, repoIds: addValues(filter.repoIds, ids) }
 }
 
 export function clearPaletteFilterField(
   filter: PaletteFilterState,
   field: PaletteFilterField
 ): PaletteFilterState {
-  return field === 'host' ? { ...filter, hostIds: [] } : { ...filter, projectKeys: [] }
-}
-
-function pruneToAvailable(values: readonly string[], available: ReadonlySet<string>): string[] {
-  return values.filter((value) => available.has(value))
-}
-
-/**
- * Drops selections whose host or project disappeared (repo removed, SSH target
- * deleted). Without this a stale id would silently empty the palette forever.
- * Returns the same reference when nothing changed so memo deps stay stable.
- */
-export function reconcilePaletteFilter(
-  filter: PaletteFilterState,
-  model: PaletteFilterModel
-): PaletteFilterState {
-  if (!isPaletteFilterActive(filter)) {
-    return filter
-  }
-  const hostIds = pruneToAvailable(filter.hostIds, new Set(model.hosts.map((host) => host.id)))
-  const projectKeys = pruneToAvailable(
-    filter.projectKeys,
-    new Set(model.projects.map((project) => project.id))
-  )
-  if (
-    hostIds.length === filter.hostIds.length &&
-    projectKeys.length === filter.projectKeys.length
-  ) {
-    return filter
-  }
-  return { hostIds, projectKeys }
+  return field === 'host' ? { ...filter, hostIds: [] } : { ...filter, repoIds: [] }
 }
 
 type SidebarScopeForPaletteFilter = Parameters<typeof getVisibleWorkspaceHostIdSet>[0] & {
   filterRepoIds: readonly string[]
 }
 
-/** Omits fields that select every available option because they do not narrow results. */
+function sortedUnique(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort()
+}
+
+/** Seeds the palette from the sidebar's exact host and repository scope. */
 export function buildPaletteFilterFromSidebarScope(
-  scope: SidebarScopeForPaletteFilter,
-  model: PaletteFilterModel
+  scope: SidebarScopeForPaletteFilter
 ): PaletteFilterState {
   const visibleHostIds = getVisibleWorkspaceHostIdSet(scope)
-  let hostIds: readonly string[] = []
-  if (visibleHostIds) {
-    const available = model.hosts.filter((host) => visibleHostIds.has(host.id as ExecutionHostId))
-    hostIds = available.length < model.hosts.length ? available.map((host) => host.id).sort() : []
-  }
+  const hostIds = visibleHostIds ? sortedUnique(visibleHostIds) : []
+  const repoIds = sortedUnique(scope.filterRepoIds)
 
-  let projectKeys: readonly string[] = []
-  if (scope.filterRepoIds.length > 0) {
-    const selectedRepoIds = new Set(scope.filterRepoIds)
-    const available = model.projects.filter((project) =>
-      (model.repoIdsByProjectKey.get(project.id) ?? []).some((repoId) =>
-        selectedRepoIds.has(repoId)
-      )
-    )
-    projectKeys =
-      available.length < model.projects.length ? available.map((project) => project.id).sort() : []
-  }
-
-  if (hostIds.length === 0 && projectKeys.length === 0) {
+  if (hostIds.length === 0 && repoIds.length === 0) {
     return EMPTY_PALETTE_FILTER
   }
-  return { hostIds, projectKeys }
+  return { hostIds, repoIds }
 }
 
 export type PaletteFilterPredicate = {
@@ -175,20 +122,12 @@ export function buildPaletteFilterPredicate(
   }
 
   const selectedHostIds = filter.hostIds.length > 0 ? new Set(filter.hostIds) : null
-  const selectedProjectKeys = filter.projectKeys.length > 0 ? new Set(filter.projectKeys) : null
-  let selectedRepoIds: Set<string> | null = null
-  if (selectedProjectKeys) {
-    selectedRepoIds = new Set<string>()
-    for (const projectKey of selectedProjectKeys) {
-      for (const repoId of model.repoIdsByProjectKey.get(projectKey) ?? []) {
-        selectedRepoIds.add(repoId)
-      }
-    }
-  }
+  const selectedRepoIds = filter.repoIds.length > 0 ? new Set(filter.repoIds) : null
 
   return {
     matchesProjectRowKey: (rowKey) => {
-      if (selectedProjectKeys && !selectedProjectKeys.has(rowKey)) {
+      const rowRepoIds = model.repoIdsByProjectKey.get(rowKey) ?? []
+      if (selectedRepoIds && !rowRepoIds.some((repoId) => selectedRepoIds.has(repoId))) {
         return false
       }
       if (!selectedHostIds) {
@@ -196,7 +135,7 @@ export function buildPaletteFilterPredicate(
       }
       // Why: the row survives if *any* of its repos is on a selected host — a
       // project checked out on both local and SSH is still reachable from either.
-      return (model.repoIdsByProjectKey.get(rowKey) ?? []).some((repoId) =>
+      return rowRepoIds.some((repoId) =>
         selectedHostIds.has(
           resolveRepoFilterHostId(repoId, model.hostIdByRepoId, model.defaultHostId)
         )

--- a/src/renderer/src/components/cmd-j/palette-filter.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.ts
@@ -1,13 +1,9 @@
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getVisibleWorkspaceHostIdSet } from '../sidebar/visible-worktree-host-scope'
-import {
-  resolveRepoFilterHostId,
-  resolveWorktreeFilterHostId,
-  type PaletteFilterModel
-} from './palette-filter-options'
+import { resolveWorktreeFilterHostId, type PaletteFilterModel } from './palette-filter-options'
 
-export type PaletteFilterField = 'host' | 'project'
+export type PaletteFilterField = 'host' | 'repository'
 
 /**
  * Sorted arrays rather than Sets: identity is stable across renders and the
@@ -67,15 +63,21 @@ export function addPaletteFilterValues(
   field: PaletteFilterField,
   ids: readonly string[]
 ): PaletteFilterState {
-  return field === 'host'
-    ? { ...filter, hostIds: addValues(filter.hostIds, ids) }
-    : { ...filter, repoIds: addValues(filter.repoIds, ids) }
+  const values = field === 'host' ? filter.hostIds : filter.repoIds
+  const nextValues = addValues(values, ids)
+  if (nextValues === values) {
+    return filter
+  }
+  return field === 'host' ? { ...filter, hostIds: nextValues } : { ...filter, repoIds: nextValues }
 }
 
 export function clearPaletteFilterField(
   filter: PaletteFilterState,
   field: PaletteFilterField
 ): PaletteFilterState {
+  if ((field === 'host' ? filter.hostIds : filter.repoIds).length === 0) {
+    return filter
+  }
   return field === 'host' ? { ...filter, hostIds: [] } : { ...filter, repoIds: [] }
 }
 
@@ -123,22 +125,28 @@ export function buildPaletteFilterPredicate(
 
   const selectedHostIds = filter.hostIds.length > 0 ? new Set(filter.hostIds) : null
   const selectedRepoIds = filter.repoIds.length > 0 ? new Set(filter.repoIds) : null
+  const repoMatchesSelectedHost = (repoId: string): boolean => {
+    if (!selectedHostIds) {
+      return true
+    }
+    const repoHostIds = model.hostIdsByRepoId.get(repoId)
+    if (!repoHostIds) {
+      return selectedHostIds.has(model.defaultHostId)
+    }
+    for (const hostId of repoHostIds) {
+      if (selectedHostIds.has(hostId)) {
+        return true
+      }
+    }
+    return false
+  }
 
   return {
     matchesProjectRowKey: (rowKey) => {
       const rowRepoIds = model.repoIdsByProjectKey.get(rowKey) ?? []
-      if (selectedRepoIds && !rowRepoIds.some((repoId) => selectedRepoIds.has(repoId))) {
-        return false
-      }
-      if (!selectedHostIds) {
-        return true
-      }
-      // Why: the row survives if *any* of its repos is on a selected host — a
-      // project checked out on both local and SSH is still reachable from either.
-      return rowRepoIds.some((repoId) =>
-        selectedHostIds.has(
-          resolveRepoFilterHostId(repoId, model.hostIdByRepoId, model.defaultHostId)
-        )
+      return rowRepoIds.some(
+        (repoId) =>
+          (!selectedRepoIds || selectedRepoIds.has(repoId)) && repoMatchesSelectedHost(repoId)
       )
     },
     matchesWorktree: (worktree) => {
@@ -151,10 +159,10 @@ export function buildPaletteFilterPredicate(
       // Why: worktree.hostId wins over the repo fallback — a runtime-owned
       // workspace can live on a different host than the repo it came from.
       return selectedHostIds.has(
-        resolveWorktreeFilterHostId(worktree, model.hostIdByRepoId, model.defaultHostId)
+        resolveWorktreeFilterHostId(worktree, model.repoById, model.defaultHostId)
       )
     },
-    // Why: a group header is not a project, so an explicit project selection
+    // Why: a group header has no repository, so a repository selection
     // excludes every group row; only the host axis can keep one.
     matchesGroupHostId: (hostId) =>
       selectedRepoIds === null && (!selectedHostIds || selectedHostIds.has(hostId))

--- a/src/renderer/src/components/cmd-j/palette-filter.ts
+++ b/src/renderer/src/components/cmd-j/palette-filter.ts
@@ -1,6 +1,6 @@
 import type { ExecutionHostId } from '../../../../shared/execution-host'
-import { getVisibleWorkspaceHostIdSet } from '../sidebar/visible-worktree-host-scope'
 import type { Worktree } from '../../../../shared/worktree/types'
+import { getVisibleWorkspaceHostIdSet } from '../sidebar/visible-worktree-host-scope'
 import {
   resolveRepoFilterHostId,
   resolveWorktreeFilterHostId,
@@ -120,16 +120,11 @@ export function reconcilePaletteFilter(
   return { hostIds, projectKeys }
 }
 
-export type SidebarScopeForPaletteFilter = Parameters<typeof getVisibleWorkspaceHostIdSet>[0] & {
+type SidebarScopeForPaletteFilter = Parameters<typeof getVisibleWorkspaceHostIdSet>[0] & {
   filterRepoIds: readonly string[]
 }
 
-/**
- * Seeds the palette's host/project selection from the sidebar's "Show" scope so
- * Cmd+J opens on the same slice the user is looking at. One-way: the user can
- * clear or change it per open, and the sidebar never reads it back. A field
- * that would select every option is left empty — that is not a filter, just chips.
- */
+/** Omits fields that select every available option because they do not narrow results. */
 export function buildPaletteFilterFromSidebarScope(
   scope: SidebarScopeForPaletteFilter,
   model: PaletteFilterModel

--- a/src/renderer/src/components/use-worktree-jump-palette-filter.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-filter.ts
@@ -25,7 +25,7 @@ type WorktreeJumpPaletteFilterInput = Pick<
   | 'projectHostSetups'
   | 'projectGroups'
 > &
-  Pick<WorktreeJumpPaletteLocalState, 'rawFilter'>
+  Pick<WorktreeJumpPaletteLocalState, 'filterState'>
 
 export function useWorktreeJumpPaletteFilter({
   repos,
@@ -38,7 +38,7 @@ export function useWorktreeJumpPaletteFilter({
   projects,
   projectHostSetups,
   projectGroups,
-  rawFilter
+  filterState
 }: WorktreeJumpPaletteFilterInput) {
   const repoMap = useMemo(() => new Map(repos.map((repo) => [repo.id, repo])), [repos])
   const repoByHostIdentity = useMemo(
@@ -81,7 +81,7 @@ export function useWorktreeJumpPaletteFilter({
       }),
     [allWorktrees, defaultHostId, hostOptions, projectHostSetups, projects, repos]
   )
-  const filter = rawFilter
+  const filter = filterState
   const filterActive = isPaletteFilterActive(filter)
   const hostFilterActive = filter.hostIds.length > 0
   const filterPredicate = useMemo(

--- a/src/renderer/src/components/use-worktree-jump-palette-filter.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-filter.ts
@@ -1,11 +1,10 @@
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { buildSidebarHostOptions } from '@/components/sidebar/sidebar-host-options'
 import { getProjectGroupExecutionHostIdForRows } from '@/components/sidebar/worktree-list/listing/host-filtering'
 import { buildPaletteFilterModel } from '@/components/cmd-j/palette-filter-options'
 import {
   buildPaletteFilterPredicate,
-  isPaletteFilterActive,
-  reconcilePaletteFilter
+  isPaletteFilterActive
 } from '@/components/cmd-j/palette-filter'
 import { getRepoHostIdentity } from '@/store/slices/repo-host-identity'
 import { getHostDisplayLabelOverrides } from '../../../shared/host-setting-overrides'
@@ -26,7 +25,7 @@ type WorktreeJumpPaletteFilterInput = Pick<
   | 'projectHostSetups'
   | 'projectGroups'
 > &
-  Pick<WorktreeJumpPaletteLocalState, 'rawFilter' | 'setRawFilter'>
+  Pick<WorktreeJumpPaletteLocalState, 'rawFilter'>
 
 export function useWorktreeJumpPaletteFilter({
   repos,
@@ -39,8 +38,7 @@ export function useWorktreeJumpPaletteFilter({
   projects,
   projectHostSetups,
   projectGroups,
-  rawFilter,
-  setRawFilter
+  rawFilter
 }: WorktreeJumpPaletteFilterInput) {
   const repoMap = useMemo(() => new Map(repos.map((repo) => [repo.id, repo])), [repos])
   const repoByHostIdentity = useMemo(
@@ -83,14 +81,7 @@ export function useWorktreeJumpPaletteFilter({
       }),
     [allWorktrees, defaultHostId, hostOptions, projectHostSetups, projects, repos]
   )
-  const filter = useMemo(
-    () => reconcilePaletteFilter(rawFilter, filterModel),
-    [rawFilter, filterModel]
-  )
-  useEffect(() => {
-    setRawFilter((current) => reconcilePaletteFilter(current, filterModel))
-    // oxlint-disable-next-line react-hooks/exhaustive-deps -- local-state setter identity is stable across extraction.
-  }, [filterModel])
+  const filter = rawFilter
   const filterActive = isPaletteFilterActive(filter)
   const hostFilterActive = filter.hostIds.length > 0
   const filterPredicate = useMemo(

--- a/src/renderer/src/components/use-worktree-jump-palette-filter.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-filter.ts
@@ -25,7 +25,7 @@ type WorktreeJumpPaletteFilterInput = Pick<
   | 'projectHostSetups'
   | 'projectGroups'
 > &
-  Pick<WorktreeJumpPaletteLocalState, 'filterState'>
+  Pick<WorktreeJumpPaletteLocalState, 'filter'>
 
 export function useWorktreeJumpPaletteFilter({
   repos,
@@ -38,7 +38,7 @@ export function useWorktreeJumpPaletteFilter({
   projects,
   projectHostSetups,
   projectGroups,
-  filterState
+  filter
 }: WorktreeJumpPaletteFilterInput) {
   const repoMap = useMemo(() => new Map(repos.map((repo) => [repo.id, repo])), [repos])
   const repoByHostIdentity = useMemo(
@@ -81,7 +81,6 @@ export function useWorktreeJumpPaletteFilter({
       }),
     [allWorktrees, defaultHostId, hostOptions, projectHostSetups, projects, repos]
   )
-  const filter = filterState
   const filterActive = isPaletteFilterActive(filter)
   const hostFilterActive = filter.hostIds.length > 0
   const filterPredicate = useMemo(
@@ -106,7 +105,6 @@ export function useWorktreeJumpPaletteFilter({
     canCreateWorktree,
     defaultHostId,
     filterModel,
-    filter,
     filterActive,
     hostFilterActive,
     filterPredicate,

--- a/src/renderer/src/components/use-worktree-jump-palette-local-state.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-local-state.ts
@@ -1,4 +1,5 @@
 import { useDeferredValue, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import type { WorktreePaletteRequestGuard } from '@/lib/worktree-palette-create-action'
 import {
   buildPaletteFilterFromSidebarScope,
@@ -18,6 +19,13 @@ export function useWorktreeJumpPaletteLocalState({
   createLookupGuard: WorktreePaletteRequestGuard
   visible: boolean
 }) {
+  const sidebarScope = useAppStore(
+    useShallow((state) => ({
+      filterRepoIds: state.filterRepoIds,
+      visibleWorkspaceHostIds: state.visibleWorkspaceHostIds,
+      workspaceHostScope: state.workspaceHostScope
+    }))
+  )
   const [query, setQuery] = useState('')
   const deferredQuery = useDeferredValue(query)
   const liveQueryRef = useRef(query)
@@ -38,8 +46,8 @@ export function useWorktreeJumpPaletteLocalState({
   // Create is armed by an explicit keyboard/pointer move, except for task URLs.
   const selectionMovedByUserRef = useRef(false)
   const digitShortcutItemsRef = useRef<readonly PaletteItem[]>([])
-  const [filterState, setFilterState] = useState<PaletteFilterState>(() =>
-    buildPaletteFilterFromSidebarScope(useAppStore.getState())
+  const [filter, setFilter] = useState<PaletteFilterState>(() =>
+    buildPaletteFilterFromSidebarScope(sidebarScope)
   )
   const [dialogElement, setDialogElement] = useState<HTMLElement | null>(null)
   const previousWorktreeIdRef = useRef<string | null>(null)
@@ -57,7 +65,7 @@ export function useWorktreeJumpPaletteLocalState({
   const preserveCreateLookupOnCloseRef = useRef(false)
   const [expandedSectionCaps, setExpandedSectionCaps] = useState<Record<string, number>>({})
 
-  // Reset query/open state during render so the palette never paints stale results.
+  // Reset expansion and seed each open before the palette paints.
   const [previousQuery, setPreviousQuery] = useState(query)
   const [previousVisible, setPreviousVisible] = useState(visible)
   const visibilityChanged = previousVisible !== visible
@@ -66,7 +74,7 @@ export function useWorktreeJumpPaletteLocalState({
     setPreviousVisible(visible)
     setExpandedSectionCaps({})
     if (visibilityChanged && visible) {
-      setFilterState(buildPaletteFilterFromSidebarScope(useAppStore.getState()))
+      setFilter(buildPaletteFilterFromSidebarScope(sidebarScope))
     }
   }
 
@@ -85,8 +93,8 @@ export function useWorktreeJumpPaletteLocalState({
     autoSelectedItemIdRef,
     selectionMovedByUserRef,
     digitShortcutItemsRef,
-    filterState,
-    setFilterState,
+    filter,
+    setFilter,
     dialogElement,
     setDialogElement,
     previousWorktreeIdRef,
@@ -104,8 +112,7 @@ export function useWorktreeJumpPaletteLocalState({
     createLookupGuard,
     preserveCreateLookupOnCloseRef,
     expandedSectionCaps,
-    setExpandedSectionCaps,
-    previousVisible
+    setExpandedSectionCaps
   }
 }
 

--- a/src/renderer/src/components/use-worktree-jump-palette-local-state.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-local-state.ts
@@ -1,6 +1,10 @@
 import { useDeferredValue, useMemo, useRef, useState } from 'react'
 import type { WorktreePaletteRequestGuard } from '@/lib/worktree-palette-create-action'
-import { EMPTY_PALETTE_FILTER, type PaletteFilterState } from '@/components/cmd-j/palette-filter'
+import {
+  buildPaletteFilterFromSidebarScope,
+  type PaletteFilterState
+} from '@/components/cmd-j/palette-filter'
+import { useAppStore } from '@/store'
 import { parseCmdJTaskSourceUrl } from '@/lib/worktree-palette-task-url-match'
 import { getWorktreePaletteCreateActionState } from '@/lib/worktree-palette-create-action'
 import type { CmdJActiveGroupSnapshot } from '@/components/cmd-j/quick-action-context'
@@ -34,7 +38,9 @@ export function useWorktreeJumpPaletteLocalState({
   // Create is armed by an explicit keyboard/pointer move, except for task URLs.
   const selectionMovedByUserRef = useRef(false)
   const digitShortcutItemsRef = useRef<readonly PaletteItem[]>([])
-  const [rawFilter, setRawFilter] = useState<PaletteFilterState>(EMPTY_PALETTE_FILTER)
+  const [filterState, setFilterState] = useState<PaletteFilterState>(() =>
+    buildPaletteFilterFromSidebarScope(useAppStore.getState())
+  )
   const [dialogElement, setDialogElement] = useState<HTMLElement | null>(null)
   const previousWorktreeIdRef = useRef<string | null>(null)
   const previousActiveTabTypeRef = useRef<WorkspaceVisibleTabType>('terminal')
@@ -51,13 +57,17 @@ export function useWorktreeJumpPaletteLocalState({
   const preserveCreateLookupOnCloseRef = useRef(false)
   const [expandedSectionCaps, setExpandedSectionCaps] = useState<Record<string, number>>({})
 
-  // Reset expansion after a new query or a fresh open without adding an extra effect render.
+  // Reset query/open state during render so the palette never paints stale results.
   const [previousQuery, setPreviousQuery] = useState(query)
   const [previousVisible, setPreviousVisible] = useState(visible)
-  if (previousQuery !== query || previousVisible !== visible) {
+  const visibilityChanged = previousVisible !== visible
+  if (previousQuery !== query || visibilityChanged) {
     setPreviousQuery(query)
     setPreviousVisible(visible)
     setExpandedSectionCaps({})
+    if (visibilityChanged && visible) {
+      setFilterState(buildPaletteFilterFromSidebarScope(useAppStore.getState()))
+    }
   }
 
   return {
@@ -75,8 +85,8 @@ export function useWorktreeJumpPaletteLocalState({
     autoSelectedItemIdRef,
     selectionMovedByUserRef,
     digitShortcutItemsRef,
-    rawFilter,
-    setRawFilter,
+    filterState,
+    setFilterState,
     dialogElement,
     setDialogElement,
     previousWorktreeIdRef,

--- a/src/renderer/src/components/use-worktree-jump-palette-recent-tabs.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-recent-tabs.ts
@@ -15,7 +15,6 @@ import {
   type PaletteItem
 } from './worktree-jump-palette-model'
 import { shouldIncludeOpenTabInRecentSection } from './worktree-jump-palette-recent-inclusion'
-import type { WorktreeJumpPaletteFilter } from './use-worktree-jump-palette-filter'
 import type { WorktreeJumpPaletteLocalState } from './use-worktree-jump-palette-local-state'
 import type { WorktreeJumpPaletteOpenTabs } from './use-worktree-jump-palette-open-tabs'
 import type { WorktreeJumpPaletteStoreState } from './use-worktree-jump-palette-store-state'
@@ -24,8 +23,10 @@ import type { WorktreeJumpPaletteWorktrees } from './use-worktree-jump-palette-w
 type WorktreeJumpPaletteRecentTabsInput = WorktreeJumpPaletteStoreState &
   WorktreeJumpPaletteOpenTabs &
   Pick<WorktreeJumpPaletteWorktrees, 'resolveWorktree' | 'hasQuery'> &
-  Pick<WorktreeJumpPaletteFilter, 'filterActive'> &
-  Pick<WorktreeJumpPaletteLocalState, 'query' | 'autoSelectedItemIdRef' | 'setSelectedItemId'>
+  Pick<
+    WorktreeJumpPaletteLocalState,
+    'query' | 'filter' | 'autoSelectedItemIdRef' | 'setSelectedItemId'
+  >
 
 function getRecentTabOccurrenceBase(item: OpenTabRecentRow['item']): string {
   if (item.type === 'browser-page') {
@@ -74,7 +75,7 @@ export function useWorktreeJumpPaletteRecentTabs({
   visible,
   hasQuery,
   query,
-  filterActive,
+  filter,
   lastVisitedAtByWorktreeId,
   activeGroupIdByWorktree,
   groupsByWorktree,
@@ -172,6 +173,9 @@ export function useWorktreeJumpPaletteRecentTabs({
   const [recentTabOrder, setRecentTabOrder] = useState<readonly string[]>(EMPTY_RECENT_TAB_ORDER)
   const recentTabOrderCapturedRef = useRef(false)
   const recentTabOrderAttentionReadyRef = useRef(false)
+  // Why: recent rows are already narrowed by the filter, so a filter change mid-open must
+  // re-capture — a frozen order would otherwise hide rows a cleared chip brought back.
+  const capturedFilterRef = useRef(filter)
   const recentOrderAttentionIncomplete = useMemo(() => {
     for (const { item, worktree, row } of openTabRecentRows) {
       if (
@@ -194,8 +198,13 @@ export function useWorktreeJumpPaletteRecentTabs({
       setRecentTabOrder(EMPTY_RECENT_TAB_ORDER)
       return
     }
-    if (hasQuery || query.length > 0 || filterActive) {
+    if (hasQuery || query.length > 0) {
       return
+    }
+    if (capturedFilterRef.current !== filter) {
+      capturedFilterRef.current = filter
+      recentTabOrderCapturedRef.current = false
+      recentTabOrderAttentionReadyRef.current = false
     }
     if (
       recentTabOrderCapturedRef.current &&
@@ -225,7 +234,7 @@ export function useWorktreeJumpPaletteRecentTabs({
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- controller refs and setters preserve their original stable identities.
   }, [
     activeGroupIdByWorktree,
-    filterActive,
+    filter,
     groupsByWorktree,
     hasQuery,
     lastVisitedAtByWorktreeId,

--- a/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
@@ -4,7 +4,7 @@ import {
   queueBrowserFocusRequest
 } from '@/components/browser-pane/host-guest/browser-focus'
 import { captureCmdJActiveGroupSnapshot } from '@/components/cmd-j/quick-action-context'
-import { EMPTY_PALETTE_FILTER } from '@/components/cmd-j/palette-filter'
+import { buildPaletteFilterFromSidebarScope } from '@/components/cmd-j/palette-filter'
 import { resolvePaletteFocusRestoreTarget } from '@/components/cmd-j/palette-focus-restore-target'
 import {
   CREATE_WORKTREE_ITEM_ID,
@@ -12,6 +12,7 @@ import {
 } from '@/lib/worktree-palette-create-action'
 import { useAppStore } from '@/store'
 import { CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID } from './worktree-jump-palette-model'
+import type { WorktreeJumpPaletteFilter } from './use-worktree-jump-palette-filter'
 import type { WorktreeJumpPaletteListEntries } from './use-worktree-jump-palette-list-entries'
 import type { WorktreeJumpPaletteLocalState } from './use-worktree-jump-palette-local-state'
 import type { WorktreeJumpPaletteOpenTabs } from './use-worktree-jump-palette-open-tabs'
@@ -23,6 +24,7 @@ import type { WorktreeJumpPaletteWorktrees } from './use-worktree-jump-palette-w
 
 type WorktreeJumpPaletteSelectionLifecycleInput = WorktreeJumpPaletteStoreState &
   WorktreeJumpPaletteLocalState &
+  WorktreeJumpPaletteFilter &
   WorktreeJumpPaletteOpenTabs &
   WorktreeJumpPaletteProjectTargets &
   WorktreeJumpPaletteQuickActions &
@@ -57,6 +59,10 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
   setQuery,
   setSelectedItemId,
   setRawFilter,
+  filterModel,
+  workspaceHostScope,
+  visibleWorkspaceHostIds,
+  filterRepoIds,
   selectionMovedByUserRef,
   taskSourceUrl,
   listRef,
@@ -108,7 +114,13 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
       setQuery('')
       setSelectedItemId('')
       selectionMovedByUserRef.current = false
-      setRawFilter(EMPTY_PALETTE_FILTER)
+      // Each open starts from the sidebar's current Show scope, not the last palette selection.
+      setRawFilter(
+        buildPaletteFilterFromSidebarScope(
+          { workspaceHostScope, visibleWorkspaceHostIds, filterRepoIds },
+          filterModel
+        )
+      )
       listRef.current?.scrollTo(0, 0)
     }
     if (!visible && wasVisibleRef.current) {

--- a/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
@@ -12,7 +12,6 @@ import {
 } from '@/lib/worktree-palette-create-action'
 import { useAppStore } from '@/store'
 import { CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID } from './worktree-jump-palette-model'
-import type { WorktreeJumpPaletteFilter } from './use-worktree-jump-palette-filter'
 import type { WorktreeJumpPaletteListEntries } from './use-worktree-jump-palette-list-entries'
 import type { WorktreeJumpPaletteLocalState } from './use-worktree-jump-palette-local-state'
 import type { WorktreeJumpPaletteOpenTabs } from './use-worktree-jump-palette-open-tabs'
@@ -24,7 +23,6 @@ import type { WorktreeJumpPaletteWorktrees } from './use-worktree-jump-palette-w
 
 type WorktreeJumpPaletteSelectionLifecycleInput = WorktreeJumpPaletteStoreState &
   WorktreeJumpPaletteLocalState &
-  Pick<WorktreeJumpPaletteFilter, 'filterModel'> &
   WorktreeJumpPaletteOpenTabs &
   WorktreeJumpPaletteProjectTargets &
   WorktreeJumpPaletteQuickActions &
@@ -59,7 +57,6 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
   setQuery,
   setSelectedItemId,
   setRawFilter,
-  filterModel,
   selectionMovedByUserRef,
   taskSourceUrl,
   listRef,
@@ -109,7 +106,7 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
       setQuery('')
       setSelectedItemId('')
       selectionMovedByUserRef.current = false
-      setRawFilter(buildPaletteFilterFromSidebarScope(appState, filterModel))
+      setRawFilter(buildPaletteFilterFromSidebarScope(appState))
       listRef.current?.scrollTo(0, 0)
     }
     if (!visible && wasVisibleRef.current) {

--- a/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
@@ -4,7 +4,6 @@ import {
   queueBrowserFocusRequest
 } from '@/components/browser-pane/host-guest/browser-focus'
 import { captureCmdJActiveGroupSnapshot } from '@/components/cmd-j/quick-action-context'
-import { buildPaletteFilterFromSidebarScope } from '@/components/cmd-j/palette-filter'
 import { resolvePaletteFocusRestoreTarget } from '@/components/cmd-j/palette-focus-restore-target'
 import {
   CREATE_WORKTREE_ITEM_ID,
@@ -56,7 +55,6 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
   latestQueryRef,
   setQuery,
   setSelectedItemId,
-  setRawFilter,
   selectionMovedByUserRef,
   taskSourceUrl,
   listRef,
@@ -106,7 +104,6 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
       setQuery('')
       setSelectedItemId('')
       selectionMovedByUserRef.current = false
-      setRawFilter(buildPaletteFilterFromSidebarScope(appState))
       listRef.current?.scrollTo(0, 0)
     }
     if (!visible && wasVisibleRef.current) {

--- a/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-selection-lifecycle.ts
@@ -24,7 +24,7 @@ import type { WorktreeJumpPaletteWorktrees } from './use-worktree-jump-palette-w
 
 type WorktreeJumpPaletteSelectionLifecycleInput = WorktreeJumpPaletteStoreState &
   WorktreeJumpPaletteLocalState &
-  WorktreeJumpPaletteFilter &
+  Pick<WorktreeJumpPaletteFilter, 'filterModel'> &
   WorktreeJumpPaletteOpenTabs &
   WorktreeJumpPaletteProjectTargets &
   WorktreeJumpPaletteQuickActions &
@@ -60,9 +60,6 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
   setSelectedItemId,
   setRawFilter,
   filterModel,
-  workspaceHostScope,
-  visibleWorkspaceHostIds,
-  filterRepoIds,
   selectionMovedByUserRef,
   taskSourceUrl,
   listRef,
@@ -87,10 +84,8 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
     if (visible && !wasVisibleRef.current) {
       recordFeatureInteraction('cmd-j')
       createLookupGuard.invalidate()
-      activeGroupSnapshotRef.current = captureCmdJActiveGroupSnapshot(
-        useAppStore.getState(),
-        activeWorktreeId
-      )
+      const appState = useAppStore.getState()
+      activeGroupSnapshotRef.current = captureCmdJActiveGroupSnapshot(appState, activeWorktreeId)
       previousWorktreeIdRef.current = activeWorktreeId
       previousActiveTabTypeRef.current = activeTabType
       previousBrowserPageIdRef.current =
@@ -114,13 +109,7 @@ export function useWorktreeJumpPaletteSelectionLifecycle({
       setQuery('')
       setSelectedItemId('')
       selectionMovedByUserRef.current = false
-      // Each open starts from the sidebar's current Show scope, not the last palette selection.
-      setRawFilter(
-        buildPaletteFilterFromSidebarScope(
-          { workspaceHostScope, visibleWorkspaceHostIds, filterRepoIds },
-          filterModel
-        )
-      )
+      setRawFilter(buildPaletteFilterFromSidebarScope(appState, filterModel))
       listRef.current?.scrollTo(0, 0)
     }
     if (!visible && wasVisibleRef.current) {

--- a/src/renderer/src/components/use-worktree-jump-palette-store-state.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-store-state.ts
@@ -97,6 +97,9 @@ export function useWorktreeJumpPaletteStoreState({
     (state) => state.hideWorkspacesFromOtherDevices
   )
   const showSleepingWorkspaces = useAppStore((state) => state.showSleepingWorkspaces)
+  const workspaceHostScope = useAppStore((state) => state.workspaceHostScope)
+  const visibleWorkspaceHostIds = useAppStore((state) => state.visibleWorkspaceHostIds)
+  const filterRepoIds = useAppStore((state) => state.filterRepoIds)
   const alwaysShowDefaultBranchWorkspace = useAppStore(
     (state) => state.alwaysShowDefaultBranchWorkspace
   )
@@ -174,6 +177,9 @@ export function useWorktreeJumpPaletteStoreState({
     hideDetachedHeadWorkspaces,
     hideWorkspacesFromOtherDevices,
     showSleepingWorkspaces,
+    workspaceHostScope,
+    visibleWorkspaceHostIds,
+    filterRepoIds,
     alwaysShowDefaultBranchWorkspace,
     lastVisitedAtByWorktreeId,
     workspacePortScan,

--- a/src/renderer/src/components/use-worktree-jump-palette-store-state.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-store-state.ts
@@ -97,9 +97,6 @@ export function useWorktreeJumpPaletteStoreState({
     (state) => state.hideWorkspacesFromOtherDevices
   )
   const showSleepingWorkspaces = useAppStore((state) => state.showSleepingWorkspaces)
-  const workspaceHostScope = useAppStore((state) => state.workspaceHostScope)
-  const visibleWorkspaceHostIds = useAppStore((state) => state.visibleWorkspaceHostIds)
-  const filterRepoIds = useAppStore((state) => state.filterRepoIds)
   const alwaysShowDefaultBranchWorkspace = useAppStore(
     (state) => state.alwaysShowDefaultBranchWorkspace
   )
@@ -177,9 +174,6 @@ export function useWorktreeJumpPaletteStoreState({
     hideDetachedHeadWorkspaces,
     hideWorkspacesFromOtherDevices,
     showSleepingWorkspaces,
-    workspaceHostScope,
-    visibleWorkspaceHostIds,
-    filterRepoIds,
     alwaysShowDefaultBranchWorkspace,
     lastVisitedAtByWorktreeId,
     workspacePortScan,

--- a/src/renderer/src/components/worktree-jump-palette-surface.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-surface.tsx
@@ -70,7 +70,7 @@ export function WorktreeJumpPaletteSurface({
             <PaletteFilterMenu
               model={controller.filterModel}
               filter={controller.filter}
-              onFilterChange={controller.setRawFilter}
+              onFilterChange={controller.setFilterState}
               onRequestInputFocus={controller.focusPaletteInput}
               portalContainer={controller.dialogElement}
             />
@@ -93,7 +93,7 @@ export function WorktreeJumpPaletteSurface({
       <PaletteFilterChips
         model={controller.filterModel}
         filter={controller.filter}
-        onFilterChange={controller.setRawFilter}
+        onFilterChange={controller.setFilterState}
       />
       <CommandList
         ref={controller.listRef}

--- a/src/renderer/src/components/worktree-jump-palette-surface.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-surface.tsx
@@ -70,7 +70,7 @@ export function WorktreeJumpPaletteSurface({
             <PaletteFilterMenu
               model={controller.filterModel}
               filter={controller.filter}
-              onFilterChange={controller.setFilterState}
+              onFilterChange={controller.setFilter}
               onRequestInputFocus={controller.focusPaletteInput}
               portalContainer={controller.dialogElement}
             />
@@ -93,7 +93,7 @@ export function WorktreeJumpPaletteSurface({
       <PaletteFilterChips
         model={controller.filterModel}
         filter={controller.filter}
-        onFilterChange={controller.setFilterState}
+        onFilterChange={controller.setFilter}
       />
       <CommandList
         ref={controller.listRef}

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -163,7 +163,7 @@ test.describe('Worktree jump-palette filters', () => {
     })
   })
 
-  test('filters workspace results by host, intersects project selection, and resets on close', async ({
+  test('filters results, intersects fields, and reseeds from the sidebar on reopen', async ({
     orcaPage
   }) => {
     const fixture = await seedPaletteFilterFixture(orcaPage)
@@ -177,7 +177,7 @@ test.describe('Worktree jump-palette filters', () => {
     await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId)).toBeVisible()
     await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toHaveCount(0)
 
-    // P2: host and project fields intersect, with the filter-specific empty state.
+    // P2: host and repository fields intersect, with the filter-specific empty state.
     await palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER).fill('')
     await filterTrigger(orcaPage).click()
     await palette(orcaPage).getByText('Projects', { exact: true }).click()
@@ -191,7 +191,7 @@ test.describe('Worktree jump-palette filters', () => {
       palette(orcaPage).getByText('Clear the filter above, or widen it to more hosts and projects.')
     ).toBeVisible()
 
-    // P3: clear restores both rows; closing drops the ephemeral filter.
+    // P3: clear restores both rows; reopening replaces ephemeral state with the sidebar scope.
     await filterTrigger(orcaPage).click()
     await palette(orcaPage).getByRole('button', { name: 'Clear all' }).last().click()
     await filterTrigger(orcaPage).click()
@@ -199,11 +199,17 @@ test.describe('Worktree jump-palette filters', () => {
     await searchFixtureWorkspaces(orcaPage, fixture)
 
     await selectRemoteHost(orcaPage)
-    await orcaPage.evaluate(() => window.__store?.getState().closeModal())
+    await orcaPage.evaluate((repoId) => {
+      const store = window.__store?.getState()
+      store?.closeModal()
+      store?.setFilterRepoIds([repoId])
+    }, fixture.localRepoId)
     await expect(palette(orcaPage)).toBeHidden()
     await openPalette(orcaPage)
-    await searchFixtureWorkspaces(orcaPage, fixture)
-    await expect(filterTrigger(orcaPage)).not.toContainText('1')
+    await palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER).fill('E2E Palette')
+    await expect(filterTrigger(orcaPage)).toContainText('1')
+    await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toBeVisible()
+    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId)).toHaveCount(0)
   })
 
   test('opens with the sidebar repository scope without widening it', async ({ orcaPage }) => {

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -155,6 +155,13 @@ test.describe('Worktree jump-palette filters', () => {
     await waitForSessionReady(orcaPage)
     await waitForActiveWorktree(orcaPage)
   })
+  test.afterEach(async ({ orcaPage }) => {
+    await orcaPage.evaluate(() => {
+      const store = window.__store?.getState()
+      store?.setFilterRepoIds([])
+      store?.closeModal()
+    })
+  })
 
   test('filters workspace results by host, intersects project selection, and resets on close', async ({
     orcaPage

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -250,11 +250,5 @@ test.describe('Worktree jump-palette filters', () => {
     await expect(createDialog).toBeHidden()
     // The page declined the press rather than consuming it, so it is still open.
     await expect(automationsHeading).toBeVisible()
-
-    // Why a second press: with nothing layered above, the real page chrome must not
-    // trip the overlay check, or Escape would never close Automations again.
-    await orcaPage.keyboard.press('Escape')
-
-    await expect(automationsHeading).toBeHidden()
   })
 })

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -8,7 +8,11 @@ const REMOTE_WORKSPACE = 'E2E Palette Remote Workspace'
 const REMOTE_HOST = 'E2E Palette Builder'
 const SEARCH_PLACEHOLDER = 'Search chats, terminals, worktrees, settings, and actions...'
 
-type PaletteFilterFixture = { localWorktreeId: string; remoteWorktreeId: string }
+type PaletteFilterFixture = {
+  localRepoId: string
+  localWorktreeId: string
+  remoteWorktreeId: string
+}
 
 async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixture> {
   return page.evaluate(
@@ -31,13 +35,14 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
       const remoteConnectionId = `e2e-palette-host-${token}`
       const remoteRepoId = `e2e-palette-remote-repo-${token}`
       const remoteWorktreeId = `e2e-palette-remote-worktree-${token}`
+      const remoteHostId = `ssh:${remoteConnectionId}` as const
       const remoteRepo = {
         ...sourceRepo,
         id: remoteRepoId,
         path: `${sourceRepo.path}-e2e-palette-remote-${token}`,
         displayName: remoteProject,
         connectionId: remoteConnectionId,
-        executionHostId: `ssh:${remoteConnectionId}`
+        executionHostId: remoteHostId
       }
       const remoteWorktree = {
         ...sourceWorktree,
@@ -49,18 +54,11 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
         branch: 'refs/heads/e2e-palette-remote',
         isMainWorktree: false,
         isArchived: false,
-        hostId: `ssh:${remoteConnectionId}`
+        hostId: remoteHostId
       }
 
       const sshTargetLabels = new Map(state.sshTargetLabels)
       sshTargetLabels.set(remoteConnectionId, remoteHost)
-      // Filter options use project.displayName when a Project entity exists;
-      // renaming only the repo leaves the option labeled with the path basename.
-      const projects = state.projects.map((project) =>
-        project.sourceRepoIds.includes(sourceRepo.id)
-          ? { ...project, displayName: localProject }
-          : project
-      )
       store.setState({
         repos: [
           ...state.repos.map((repo) =>
@@ -68,7 +66,6 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
           ),
           remoteRepo
         ],
-        projects,
         sshTargetLabels,
         worktreesByRepo: {
           ...state.worktreesByRepo,
@@ -79,7 +76,11 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
         }
       })
 
-      return { localWorktreeId: sourceWorktree.id, remoteWorktreeId }
+      return {
+        localRepoId: sourceRepo.id,
+        localWorktreeId: sourceWorktree.id,
+        remoteWorktreeId
+      }
     },
     {
       localProject: LOCAL_PROJECT,
@@ -196,6 +197,21 @@ test.describe('Worktree jump-palette filters', () => {
     await openPalette(orcaPage)
     await searchFixtureWorkspaces(orcaPage, fixture)
     await expect(filterTrigger(orcaPage)).not.toContainText('1')
+  })
+
+  test('opens with the sidebar repository scope without widening it', async ({ orcaPage }) => {
+    const fixture = await seedPaletteFilterFixture(orcaPage)
+    await orcaPage.evaluate((repoId) => {
+      window.__store?.getState().setFilterRepoIds([repoId])
+    }, fixture.localRepoId)
+
+    await openPalette(orcaPage)
+    await palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER).fill('E2E Palette')
+
+    await expect(filterTrigger(orcaPage)).toContainText('1')
+    await expect(palette(orcaPage).getByLabel(`Remove filter ${LOCAL_PROJECT}`)).toBeVisible()
+    await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toBeVisible()
+    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId)).toHaveCount(0)
   })
 
   test('pressing Enter creates a worktree from a typed name', async ({ orcaPage }) => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​329 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​150 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​179 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​185 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​206 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 |

<!-- /orca-pr-loc -->

## Problem

The Cmd-J palette filter was project-level granular and opened with no connection to the sidebar's current filters. Users had to re-establish filters every time they opened the palette, and there was no relationship between sidebar and palette filtering states.

## Solution

Changed the palette filter to be repository-granular and automatically seed from the sidebar's host and repository scope when it opens. Filter changes are temporary: closing the palette discards them, and the next open reseeds from the current sidebar state. This preserves the sidebar–palette relationship and lets users narrow searches while keeping their sidebar context.

## What Changed

- Palette filter now operates on individual repositories instead of project groupings for more precise filtering
- `PaletteFilterState` replaced `projectKeys` with `repoIds`
- Added `buildPaletteFilterFromSidebarScope()` to seed filters from sidebar host and repository selections
- Removed `reconcilePaletteFilter()` logic and per-field selection caps (no longer needed)
- Filter model now tracks `hostIdsByRepoId` (Set) instead of singular mapping to handle shared repo IDs across hosts
- Updated documentation to clarify repository-granular filtering and ephemeral filter behavior

## Testing

- Added unit tests for repository-granular filtering and shared repo ID deduplication
- Added integration tests for filter seeding on open and intersection of host/repo fields
- E2E tests verify reseeding from sidebar scope on reopen
- Recent tabs and workspace filtering work correctly under sidebar-seeded filters

## Notes

- Cross-platform: filter logic is platform-agnostic
- SSH/remote: sidebar scope includes remote hosts and respects SSH host stamps
- Folder workspaces compatible: uses same sidebar filtering mechanism