### PR TITLE
fix(native-chat): honor structured routing with saved options

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-acquisition-options.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-acquisition-options.test.ts
@@ -28,7 +28,8 @@ afterEach(async () => {
 
 function attachParams(
   operationId: string,
-  expectedRuntimeFence: number | null
+  expectedRuntimeFence: number | null,
+  options?: Readonly<Record<string, string>>
 ): AgentSessionAttachParams {
   const params: AgentSessionAttachParams = {
     envelope: {
@@ -47,6 +48,7 @@ function attachParams(
     agent: 'codex',
     accountHome: { variable: 'CODEX_HOME', path: '/home/dev/.codex' },
     runtimeKind: 'native',
+    ...(options ? { options } : {}),
     providerHandle: { kind: 'codex', threadId: 'legacy-thread' }
   }
   return {
@@ -101,6 +103,36 @@ function expectSettledAttachLease(record: AgentSessionRecord | null): void {
 }
 
 describe('structured session acquisition options', () => {
+  it('persists create defaults before the first provider acquisition', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-create-options-'))
+    const store = await AgentSessionRecordStore.open({
+      directory: join(root, 'store'),
+      hostId: 'local'
+    })
+    const sessionAdapter = adapter({ origin: 'created' })
+    const options = { model: 'gpt-5.6-sol', effort: 'medium' }
+
+    const created = await performAttach({
+      store,
+      adapter: sessionAdapter,
+      journalRoot: root,
+      authority: {
+        spawnToken: 'spawn-a',
+        claimKeyId: 'key-1',
+        handoffOperationId: CREATE_OPERATION,
+        probe: { outcome: 'reservation-unused' }
+      },
+      callerKey: 'client-1',
+      params: attachParams(CREATE_OPERATION, null, options),
+      now: () => NOW,
+      onAttached: () => {}
+    })
+
+    expect(created).toMatchObject({ ok: true })
+    expect(sessionAdapter.acquire).toHaveBeenCalledWith(expect.objectContaining({ options }))
+    expect(store.getRecord(SESSION)?.options).toEqual(options)
+  })
+
   it('persists provider options before proving a resumed legacy record', async () => {
     root = await mkdtemp(join(tmpdir(), 'orca-acquisition-options-'))
     const storeDir = join(root, 'store')

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-acquisition-options.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-acquisition-options.test.ts
@@ -133,6 +133,40 @@ describe('structured session acquisition options', () => {
     expect(store.getRecord(SESSION)?.options).toEqual(options)
   })
 
+  it('replays a create retried after the host re-resolved different options', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-create-retry-'))
+    const store = await AgentSessionRecordStore.open({
+      directory: join(root, 'store'),
+      hostId: 'local'
+    })
+    const sessionAdapter = adapter({ origin: 'created' })
+    const attempt = async (options: Readonly<Record<string, string>>, spawnToken: string) =>
+      performAttach({
+        store,
+        adapter: sessionAdapter,
+        journalRoot: root!,
+        authority: {
+          spawnToken,
+          claimKeyId: 'key-1',
+          handoffOperationId: CREATE_OPERATION,
+          probe: { outcome: 'reservation-unused' }
+        },
+        callerKey: 'client-1',
+        params: attachParams(CREATE_OPERATION, null, options),
+        now: () => NOW,
+        onAttached: () => {}
+      })
+
+    const created = await attempt({ model: 'gpt-5.6-sol', effort: 'medium' }, 'spawn-a')
+    // Why: the user may reselect a model between an unknown-outcome create and the
+    // retry that reuses its operation id; the retry must replay, not conflict.
+    const retried = await attempt({ model: 'gpt-5.5', effort: 'high' }, 'spawn-b')
+
+    expect(created).toMatchObject({ ok: true })
+    expect(retried).toMatchObject({ ok: true })
+    expect(store.getRecord(SESSION)?.options).toEqual({ model: 'gpt-5.6-sol', effort: 'medium' })
+  })
+
   it('persists provider options before proving a resumed legacy record', async () => {
     root = await mkdtemp(join(tmpdir(), 'orca-acquisition-options-'))
     const storeDir = join(root, 'store')

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
@@ -72,7 +72,10 @@ export type AgentSessionAttachAuthority = {
 
 /** The fields that define WHICH session this call would attach to. Deliberately
  *  excludes the spawn token and the probe: those differ between a first attempt
- *  and its retry, and a retry must replay rather than conflict. */
+ *  and its retry, and a retry must replay rather than conflict. `options` is
+ *  excluded for the same reason — it is the session's initial state, not its
+ *  identity, and the host re-resolves it from settings the user may have changed
+ *  between an unknown-outcome attempt and its retry. */
 export function attachFingerprintFields(params: AgentSessionAttachParams): Record<string, unknown> {
   return {
     location: params.location,
@@ -80,7 +83,6 @@ export function attachFingerprintFields(params: AgentSessionAttachParams): Recor
     agent: params.agent,
     accountHome: params.accountHome,
     runtimeKind: params.runtimeKind,
-    options: params.options,
     providerHandle: params.providerHandle,
     expectedRuntimeFence: params.envelope.expectedRuntimeFence
   }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-attach.ts
@@ -54,6 +54,8 @@ export type AgentSessionAttachParams = {
   agent: AgentSessionHandleProvider
   accountHome: AgentSessionAccountHome
   runtimeKind: AgentSessionOwnerRuntimeKind
+  /** Host-resolved defaults for a create-by-intent; remote attach schemas do not accept them. */
+  options?: Readonly<Record<string, string>>
   /** Omitted only for create-by-intent; the adapter proves the durable handle. */
   providerHandle?: Exclude<AgentSessionProviderHandle, { kind: 'opaque' }>
 }
@@ -78,6 +80,7 @@ export function attachFingerprintFields(params: AgentSessionAttachParams): Recor
     agent: params.agent,
     accountHome: params.accountHome,
     runtimeKind: params.runtimeKind,
+    options: params.options,
     providerHandle: params.providerHandle,
     expectedRuntimeFence: params.envelope.expectedRuntimeFence
   }
@@ -191,6 +194,7 @@ export function reserveRequestFor(input: {
     location: params.location,
     provider: params.provider,
     accountHome: params.accountHome,
+    ...(params.options ? { options: params.options } : {}),
     ...(authority.launchArgs ? { launchArgs: authority.launchArgs } : {}),
     ...(authority.launchEnv ? { launchEnv: authority.launchEnv } : {}),
     runtimeKind: params.runtimeKind,

--- a/src/main/runtime/agent-session-reservation-admission.ts
+++ b/src/main/runtime/agent-session-reservation-admission.ts
@@ -21,6 +21,7 @@ import {
   agentSessionExecutionLocationsEqual,
   isAgentSessionLaunchArgs,
   isAgentSessionLaunchEnv,
+  isAgentSessionOptions,
   type AgentSessionAccountHome,
   type AgentSessionExecutionLocation,
   type AgentSessionLaunchArgs,
@@ -43,6 +44,8 @@ export type AgentSessionReserveRequest = {
   launchArgs?: AgentSessionLaunchArgs
   /** Current launch input validated here but never written to the durable record. */
   launchEnv?: AgentSessionLaunchEnv
+  /** Initial provider options persisted before the first process is acquired. */
+  options?: Readonly<Record<string, string>>
   runtimeKind: AgentSessionReservation['runtimeKind']
   /** Null when the session does not exist yet; otherwise the fence the caller last observed. */
   expectedFence: number | null
@@ -131,6 +134,9 @@ export function applyAgentSessionReservation(
   if (request.launchArgs && !isAgentSessionLaunchArgs(request.launchArgs)) {
     throw new Error('agent_session_launch_args_invalid')
   }
+  if (request.options && !isAgentSessionOptions(request.options)) {
+    throw new Error('agent_session_options_invalid')
+  }
   const reservation: AgentSessionReservation = {
     runtimeKind: request.runtimeKind,
     spawnToken:
@@ -186,6 +192,7 @@ function createAgentSessionRecord(
     provider: request.provider,
     providerHandleChain: [],
     accountHome: request.accountHome,
+    ...(request.options ? { options: { ...request.options } } : {}),
     ...(request.launchArgs ? { launchArgs: [...request.launchArgs] } : {}),
     createdAt: request.now,
     updatedAt: request.now,

--- a/src/main/runtime/orca-runtime-resolve-recovered-structured-tui-transcript.ts
+++ b/src/main/runtime/orca-runtime-resolve-recovered-structured-tui-transcript.ts
@@ -13,7 +13,7 @@ import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-option
 import type { AgentSessionAttachParams } from '../native-chat/agent-session-wire/structured-agent-session-attach'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { resolveTuiAgentLaunchEnv } from '../../shared/tui-agent-launch-defaults'
-import { resolveNativeChatSessionOptionDefaults } from '../../shared/native-chat-session-option-defaults'
+import { resolveStructuredLaunchSeedOptions } from '../../shared/native-chat-session-option-defaults'
 import { hasPersistedStructuredAgentSessionStore as hasPersistedStructuredAgentSessionStoreOnDisk } from './structured-agent-session-runtime'
 import { getProfileUserDataPath } from '../orca-profiles/profile-storage-paths'
 import { homedir } from 'node:os'
@@ -162,17 +162,10 @@ export class OrcaRuntimeWithResolveRecoveredStructuredTuiTranscript extends Orca
     }
     const settings = this.requireStore().getSettings()
     const launchEnv = resolveTuiAgentLaunchEnv(input.agent, settings.agentDefaultEnv)
-    const defaults = resolveNativeChatSessionOptionDefaults(
+    const options = resolveStructuredLaunchSeedOptions(
       settings.nativeChatSessionOptions,
       input.agent
     )
-    const options = defaults
-      ? Object.fromEntries(
-          ['model', 'effort'].flatMap((key) =>
-            typeof defaults[key] === 'string' ? [[key, defaults[key]]] : []
-          )
-        )
-      : undefined
     const location = await this.resolveStructuredAgentSessionLocation(input.worktree)
     const workspacePath = (await this.resolveRuntimeFileTarget(input.worktree)).worktree.path
     return {
@@ -189,7 +182,7 @@ export class OrcaRuntimeWithResolveRecoveredStructuredTuiTranscript extends Orca
         variable: input.agent === 'claude' ? 'CLAUDE_CONFIG_DIR' : 'CODEX_HOME',
         path: await resolveAccountHomePath({ workspacePath, launchEnv, location })
       },
-      ...(options && Object.keys(options).length > 0 ? { options } : {}),
+      ...(options ? { options } : {}),
       runtimeKind: 'native'
     }
   }

--- a/src/main/runtime/orca-runtime-resolve-recovered-structured-tui-transcript.ts
+++ b/src/main/runtime/orca-runtime-resolve-recovered-structured-tui-transcript.ts
@@ -13,6 +13,7 @@ import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-option
 import type { AgentSessionAttachParams } from '../native-chat/agent-session-wire/structured-agent-session-attach'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { resolveTuiAgentLaunchEnv } from '../../shared/tui-agent-launch-defaults'
+import { resolveNativeChatSessionOptionDefaults } from '../../shared/native-chat-session-option-defaults'
 import { hasPersistedStructuredAgentSessionStore as hasPersistedStructuredAgentSessionStoreOnDisk } from './structured-agent-session-runtime'
 import { getProfileUserDataPath } from '../orca-profiles/profile-storage-paths'
 import { homedir } from 'node:os'
@@ -161,6 +162,17 @@ export class OrcaRuntimeWithResolveRecoveredStructuredTuiTranscript extends Orca
     }
     const settings = this.requireStore().getSettings()
     const launchEnv = resolveTuiAgentLaunchEnv(input.agent, settings.agentDefaultEnv)
+    const defaults = resolveNativeChatSessionOptionDefaults(
+      settings.nativeChatSessionOptions,
+      input.agent
+    )
+    const options = defaults
+      ? Object.fromEntries(
+          ['model', 'effort'].flatMap((key) =>
+            typeof defaults[key] === 'string' ? [[key, defaults[key]]] : []
+          )
+        )
+      : undefined
     const location = await this.resolveStructuredAgentSessionLocation(input.worktree)
     const workspacePath = (await this.resolveRuntimeFileTarget(input.worktree)).worktree.path
     return {
@@ -177,6 +189,7 @@ export class OrcaRuntimeWithResolveRecoveredStructuredTuiTranscript extends Orca
         variable: input.agent === 'claude' ? 'CLAUDE_CONFIG_DIR' : 'CODEX_HOME',
         path: await resolveAccountHomePath({ workspacePath, launchEnv, location })
       },
+      ...(options && Object.keys(options).length > 0 ? { options } : {}),
       runtimeKind: 'native'
     }
   }

--- a/src/main/runtime/orca-runtime-structured-agent-session-create-intent.test.ts
+++ b/src/main/runtime/orca-runtime-structured-agent-session-create-intent.test.ts
@@ -7,7 +7,15 @@ describe('structured agent-session create intent', () => {
     const runtime = new OrcaRuntimeService(
       {
         getSettings: () => ({
-          agentDefaultEnv: { codex: { CODEX_HOME: '/configured/home' } }
+          agentDefaultEnv: { codex: { CODEX_HOME: '/configured/home' } },
+          nativeChatSessionOptions: {
+            codex: {
+              model: 'gpt-5.6-sol',
+              valuesByModel: {
+                'gpt-5.6-sol': { effort: 'medium', fastMode: true, personality: 'concise' }
+              }
+            }
+          }
         })
       } as never,
       undefined,
@@ -51,6 +59,7 @@ describe('structured agent-session create intent', () => {
       variable: 'CODEX_HOME',
       path: '/accounts/selected/home'
     })
+    expect(intent.options).toEqual({ model: 'gpt-5.6-sol', effort: 'medium' })
   })
 
   it('pins the configured Claude launch home without Codex launch preparation', async () => {
@@ -60,6 +69,12 @@ describe('structured agent-session create intent', () => {
         getSettings: () => ({
           agentDefaultEnv: {
             claude: { CLAUDE_CONFIG_DIR: '/configured/claude-home' }
+          },
+          nativeChatSessionOptions: {
+            claude: {
+              model: 'opus',
+              valuesByModel: { opus: { effort: 'high', fastMode: true } }
+            }
           }
         })
       } as never,
@@ -101,6 +116,7 @@ describe('structured agent-session create intent', () => {
       variable: 'CLAUDE_CONFIG_DIR',
       path: '/configured/claude-home'
     })
+    expect(intent.options).toEqual({ model: 'opus', effort: 'high' })
   })
 
   it('uses the managed Claude launch home before falling back to ~/.claude', async () => {

--- a/src/main/runtime/rpc/methods/structured-agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.test.ts
@@ -193,6 +193,10 @@ function dispatcher(runtimeOverrides: Record<string, unknown> = {}): RpcDispatch
         variable: params.agent === 'claude' ? 'CLAUDE_CONFIG_DIR' : 'CODEX_HOME',
         path: params.agent === 'claude' ? '/host/.claude' : '/host/.codex'
       },
+      options:
+        params.agent === 'claude'
+          ? { model: 'opus', effort: 'high' }
+          : { model: 'gpt-5.6-sol', effort: 'medium' },
       runtimeKind: 'native'
     })),
     publishStructuredAgentSessionTab: vi.fn()
@@ -388,7 +392,8 @@ describe('method routing', () => {
     expect(hostCalls.attach).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
-        accountHome: { variable: 'CODEX_HOME', path: '/host/.codex' }
+        accountHome: { variable: 'CODEX_HOME', path: '/host/.codex' },
+        options: { model: 'gpt-5.6-sol', effort: 'medium' }
       })
     )
     expect(hostCalls.attach.mock.calls[0]?.[1]).not.toHaveProperty('providerHandle')

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -18,7 +18,10 @@ import {
   structuredCallerFor as callerFor,
   supportsStructuredSessions
 } from './structured-agent-session-gate'
-import type { AgentSessionAttachParams } from '../../../native-chat/agent-session-wire/structured-agent-session-attach'
+import {
+  attachFingerprintFields,
+  type AgentSessionAttachParams
+} from '../../../native-chat/agent-session-wire/structured-agent-session-attach'
 import { STRUCTURED_AGENT_SESSION_HOLD_METHODS } from './structured-agent-session-hold'
 import { resolveUncommittedStructuredCreate } from './structured-agent-session-precommit-refusal'
 import {
@@ -110,14 +113,7 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
           const hostFingerprint = computeAgentSessionPayloadFingerprint({
             method: 'agentSession.attach',
             sessionId: params.envelope.sessionId,
-            fields: {
-              location: resolved.location,
-              provider: resolved.provider,
-              agent: resolved.agent,
-              accountHome: resolved.accountHome,
-              runtimeKind: resolved.runtimeKind,
-              expectedRuntimeFence: null
-            }
+            fields: attachFingerprintFields(resolved)
           })
           await ensureHostInstalled(ctx)
           const { agent: _resolvedAgent, provider: _resolvedProvider, ...resolvedAttach } = resolved

--- a/src/main/runtime/rpc/methods/structured-agent-session.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session.ts
@@ -113,7 +113,7 @@ export const STRUCTURED_AGENT_SESSION_METHODS: RpcAnyMethod[] = [
           const hostFingerprint = computeAgentSessionPayloadFingerprint({
             method: 'agentSession.attach',
             sessionId: params.envelope.sessionId,
-            fields: attachFingerprintFields(resolved)
+            fields: attachFingerprintFields({ ...resolved, envelope: params.envelope })
           })
           await ensureHostInstalled(ctx)
           const { agent: _resolvedAgent, provider: _resolvedProvider, ...resolvedAttach } = resolved

--- a/src/renderer/src/lib/agent-launch-routing.test.ts
+++ b/src/renderer/src/lib/agent-launch-routing.test.ts
@@ -31,6 +31,9 @@ describe('resolveAgentLaunchRoute', () => {
     'routes a supported local %s launch to structured native chat',
     (agent) => {
       expect(route({ agent })).toBe('structured-native-chat')
+      expect(route({ agent, initialSessionOptions: { model: 'gpt-5.6-sol' } })).toBe(
+        'structured-native-chat'
+      )
       expect(
         route({ agent, launchText: 'explain this change', promptDelivery: 'auto-submit' })
       ).toBe('structured-native-chat')
@@ -118,7 +121,6 @@ describe('resolveAgentLaunchRoute', () => {
     expect(route({ agent: 'openclaude' })).toBe('legacy-native-chat')
     expect(route({ agent: 'grok' })).toBe('legacy-native-chat')
     expect(route({ requiresTuiLaunchCustomization: true })).toBe('legacy-native-chat')
-    expect(route({ initialSessionOptions: { model: 'gpt-5.6-sol' } })).toBe('legacy-native-chat')
   })
 
   it.each([

--- a/src/renderer/src/lib/agent-launch-routing.ts
+++ b/src/renderer/src/lib/agent-launch-routing.ts
@@ -89,15 +89,11 @@ export function resolveAgentLaunchRoute(input: AgentLaunchRoutingInput): AgentLa
   const projectRuntime = input.projectRuntime
   const runtimeRefused =
     projectRuntime?.status === 'repair-required' || projectRuntime?.runtime.kind === 'wsl'
-  const hasInitialSessionOptions = Boolean(
-    input.initialSessionOptions && Object.keys(input.initialSessionOptions).length > 0
-  )
   const structuredSupported =
     isAgentSessionHandleProvider(input.agent) &&
     input.promptDelivery !== 'draft' &&
     input.workspaceKind !== 'floating' &&
     input.requiresTuiLaunchCustomization !== true &&
-    !hasInitialSessionOptions &&
     input.executionHostId === 'local' &&
     // Codex's Windows refusal is deliberate and settled elsewhere, so it stays a client-side
     // answer. Claude's is measured by the executing host at create time (agentSession.createSupport)

--- a/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
+++ b/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
@@ -43,7 +43,13 @@ const store = {
     activeRuntimeEnvironmentId: null,
     experimentalNativeChat: true,
     experimentalStructuredNativeChat: true,
-    openAgentTabsInChatByDefault: true
+    openAgentTabsInChatByDefault: true,
+    nativeChatSessionOptions: undefined as
+      | Record<
+          string,
+          { model?: string; valuesByModel?: Record<string, Record<string, string | boolean>> }
+        >
+      | undefined
   },
   projects: [{ id: 'repo-1', localWindowsRuntimePreference: { kind: 'inherit-global' as const } }],
   repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/repo' }],
@@ -153,6 +159,7 @@ describe('structured chat adoption guard on the launch path', () => {
     mockToastError.mockReset()
     hostCapabilities = STRUCTURED_HOST_CAPABILITIES
     store.settings.openAgentTabsInChatByDefault = true
+    store.settings.nativeChatSessionOptions = undefined
   })
 
   it('takes the structured path when the chat-default view is selected', async () => {
@@ -173,6 +180,22 @@ describe('structured chat adoption guard on the launch path', () => {
     )
     expect(mockCreateTab).not.toHaveBeenCalled()
     expect(mockWaitForAgentReady).not.toHaveBeenCalled()
+  })
+
+  it('keeps a saved Codex model and effort on the structured path', async () => {
+    store.settings.nativeChatSessionOptions = {
+      codex: {
+        model: 'gpt-5.6-sol',
+        valuesByModel: { 'gpt-5.6-sol': { effort: 'medium' } }
+      }
+    }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
+
+    expect(result).toMatchObject({ tabId: null, focusAfterMenuClose: 'structured-session' })
+    expect(mockCreateStructuredCodexSessionLaunchIntent).toHaveBeenCalledWith('wt-1', 'codex')
+    expect(mockCreateTab).not.toHaveBeenCalled()
   })
 
   it('takes the structured path for Claude, naming Claude as the create provider', async () => {

--- a/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
+++ b/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
@@ -182,7 +182,8 @@ describe('structured chat adoption guard on the launch path', () => {
     expect(mockWaitForAgentReady).not.toHaveBeenCalled()
   })
 
-  it('keeps a saved Codex model and effort on the structured path', async () => {
+  // Routing only: the host seeds the saved values, so preservation is pinned there.
+  it('takes the structured path when a Codex model and effort are already saved', async () => {
     store.settings.nativeChatSessionOptions = {
       codex: {
         model: 'gpt-5.6-sol',

--- a/src/shared/agent-session-record.ts
+++ b/src/shared/agent-session-record.ts
@@ -221,7 +221,7 @@ function isAgentSessionAccountHome(value: unknown): value is AgentSessionAccount
   )
 }
 
-function isAgentSessionOptions(value: unknown): value is Record<string, string> {
+export function isAgentSessionOptions(value: unknown): value is Record<string, string> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return false
   }

--- a/src/shared/native-chat-session-option-defaults.test.ts
+++ b/src/shared/native-chat-session-option-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   clearNativeChatSessionOptionModel,
   resolveNativeChatSessionOptionDefaults,
+  resolveStructuredLaunchSeedOptions,
   updateNativeChatSessionOptionDefaults
 } from './native-chat-session-option-defaults'
 import type { PersistedNativeChatSessionOptions } from './native-chat-session-options'
@@ -72,5 +73,58 @@ describe('resolveNativeChatSessionOptionDefaults', () => {
     expect(resolveNativeChatSessionOptionDefaults(persistedGrok('grok-build'), 'grok')).toEqual({
       model: 'grok-build'
     })
+  })
+})
+
+describe('resolveStructuredLaunchSeedOptions', () => {
+  const persistedCodex = (
+    valuesByModel: Record<string, Record<string, string | boolean>>
+  ): PersistedNativeChatSessionOptions =>
+    ({ codex: { model: 'gpt-5.6-sol', valuesByModel } }) as PersistedNativeChatSessionOptions
+
+  it('seeds the saved model and effort a structured create must apply', () => {
+    expect(
+      resolveStructuredLaunchSeedOptions(
+        persistedCodex({ 'gpt-5.6-sol': { effort: 'medium' } }),
+        'codex'
+      )
+    ).toEqual({ model: 'gpt-5.6-sol', effort: 'medium' })
+  })
+
+  it('drops ids the providers only accept mid-session', () => {
+    // `fastMode` is a boolean and `personality` is settable only mid-session;
+    // neither belongs in the reservation's Record<string, string>.
+    expect(
+      resolveStructuredLaunchSeedOptions(
+        persistedCodex({
+          'gpt-5.6-sol': { effort: 'high', fastMode: true, personality: 'concise' }
+        }),
+        'codex'
+      )
+    ).toEqual({ model: 'gpt-5.6-sol', effort: 'high' })
+  })
+
+  it('drops a seeded id whose persisted value is not a usable string', () => {
+    // settings.json is user-writable, so a non-string `effort` must not reach a
+    // record typed Record<string, string> and be emitted as a turn option.
+    expect(
+      resolveStructuredLaunchSeedOptions(
+        persistedCodex({ 'gpt-5.6-sol': { effort: true } }),
+        'codex'
+      )
+    ).toEqual({ model: 'gpt-5.6-sol' })
+    expect(
+      resolveStructuredLaunchSeedOptions(
+        persistedCodex({ 'gpt-5.6-sol': { effort: '  ' } }),
+        'codex'
+      )
+    ).toEqual({ model: 'gpt-5.6-sol' })
+  })
+
+  it('seeds nothing until a model is picked, so the CLI default survives', () => {
+    expect(resolveStructuredLaunchSeedOptions(undefined, 'codex')).toBeUndefined()
+    expect(
+      resolveStructuredLaunchSeedOptions({ codex: { valuesByModel: {} } }, 'codex')
+    ).toBeUndefined()
   })
 })

--- a/src/shared/native-chat-session-option-defaults.test.ts
+++ b/src/shared/native-chat-session-option-defaults.test.ts
@@ -121,6 +121,16 @@ describe('resolveStructuredLaunchSeedOptions', () => {
     ).toEqual({ model: 'gpt-5.6-sol' })
   })
 
+  it('seeds nothing when the stored values empty the model out', () => {
+    // `valuesByModel` is merged over the resolved model, so a stored `model` key
+    // can blank it. Emitting `{ model: '' }` fails the record's bounded-string
+    // guard, and that throw is not a wire refusal code — it escapes as a raw
+    // error the client reads as unknown, stranding the launch with no fallback.
+    expect(
+      resolveStructuredLaunchSeedOptions(persistedCodex({ 'gpt-5.6-sol': { model: '' } }), 'codex')
+    ).toBeUndefined()
+  })
+
   it('seeds nothing until a model is picked, so the CLI default survives', () => {
     expect(resolveStructuredLaunchSeedOptions(undefined, 'codex')).toBeUndefined()
     expect(

--- a/src/shared/native-chat-session-option-defaults.ts
+++ b/src/shared/native-chat-session-option-defaults.ts
@@ -28,6 +28,33 @@ export function resolveNativeChatSessionOptionDefaults(
   return values
 }
 
+/** Why only these two: they are the only ids the picker persists into
+ *  `nativeChatSessionOptions` that both structured providers also accept as
+ *  strings. Claude's `fastMode` is a boolean the durable `Record<string, string>`
+ *  record cannot carry, and the providers' remaining keys are settable only
+ *  mid-session, never seeded at launch. */
+const STRUCTURED_LAUNCH_SEED_OPTION_IDS = ['model', 'effort'] as const
+
+/** The saved selection a structured create seeds into its reservation, narrowed
+ *  to the wire-safe string subset the durable record and both providers accept. */
+export function resolveStructuredLaunchSeedOptions(
+  persisted: PersistedNativeChatSessionOptions | null | undefined,
+  agent: AgentType
+): Record<string, string> | undefined {
+  const defaults = resolveNativeChatSessionOptionDefaults(persisted, agent)
+  if (!defaults) {
+    return undefined
+  }
+  const seeded: Record<string, string> = {}
+  for (const id of STRUCTURED_LAUNCH_SEED_OPTION_IDS) {
+    const value = defaults[id]
+    if (typeof value === 'string' && value.trim()) {
+      seeded[id] = value
+    }
+  }
+  return Object.keys(seeded).length > 0 ? seeded : undefined
+}
+
 /** Why: an authoritative probe proved this id gone, and a stale `model` is emitted
  *  verbatim as a launch flag — grok exits fatally on an unknown one. Dropping only
  *  `model` keeps the per-model option values for a later reselect. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​182 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## ELI5

Turning on structured chat now reliably opens structured Codex/Claude chats even when a model or effort was previously selected, and that selection is applied to the new chat.

## What Changed

- removed saved session options from the legacy-routing conditions
- resolved persisted model/effort on the execution host and persisted them atomically with a new structured session reservation
- passed the persisted values to provider acquisition before a first prompt can be sent
- kept boolean and unsupported legacy-only options out of the structured provider contract
- added routing, create-intent, RPC, and acquisition regression coverage

## Why

A recent routing guard treated any saved model/effort as a reason to fall back to legacy native chat. Removing that guard exposed a second gap: the structured path did not seed those saved values. Persisting them during reservation preserves the selected behavior without a post-create race.

## Regression Point

Introduced by [#18248 — feat(native-chat): unify local agent entrypoint routing](https://github.com/stablyai/orca/pull/18248), commit `c4f335b49d`.

## Linked Issue

Reported directly; no linked tracker issue.

## Visual Proof

Before: New tab → Codex opened a terminal-backed legacy chat when saved options existed.

After: the same flow renders a structured Codex Chat with the saved Medium / GPT-5.6-Sol selection.

![Structured Codex chat with saved model and effort](https://github.com/user-attachments/assets/419ba81d-e5a7-460d-a57e-7457a6acb7f0)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local macOS verification:

- 5 focused test files, 87 tests
- node and web TypeScript checks
- changed-code quality gate
- Electron build
- background Electron CDP: verified the rendered structured chat, `agent-session` tab state, no terminal-backed tab, and durable `{ model: "gpt-5.6-sol", effort: "medium" }` session record

CI covers the full test matrix and macOS/Windows packaging.

## AI Disclosure

## Review

Please focus on structured create idempotency and ensuring initial options are durable before provider acquisition.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The option seeding is host-side and does not change the remote RPC schema. Location resolution remains shared across local, SSH, WSL, git worktree, and folder workspace flows.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

