### PR TITLE
test: require recorded Git activity in polling regression

### DIFF
--- a/tests/e2e/git-no-upstream-polling-churn.spec.ts
+++ b/tests/e2e/git-no-upstream-polling-churn.spec.ts
@@ -3,6 +3,23 @@ import { existsSync, readFileSync, realpathSync, unlinkSync, writeFileSync } fro
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 
+// This isolated app needs local trace files; network telemetry remains disabled.
+test.use({
+  orcaAppExtraEnv: {
+    CI: '',
+    GITHUB_ACTIONS: '',
+    GITLAB_CI: '',
+    CIRCLECI: '',
+    TRAVIS: '',
+    BUILDKITE: '',
+    JENKINS_URL: '',
+    TEAMCITY_VERSION: '',
+    ORCA_DIAGNOSTICS_DISABLED: '',
+    DO_NOT_TRACK: '1',
+    ORCA_TELEMETRY_DISABLED: '1'
+  }
+})
+
 // Repro command:
 //   SKIP_BUILD=1 pnpm exec playwright test tests/e2e/git-no-upstream-polling-churn.spec.ts --config tests/playwright.config.ts --project electron-headless --reporter=json
 // Trigger: active worktree branch "Initi-Project" has no configured upstream
@@ -21,6 +38,7 @@ type RendererTimerMeasurement = {
 }
 
 type GitProbeFailureCounts = {
+  observedGitCommands: number
   noConfiguredUpstreamFailures: number
   missingSameNameOriginFailures: number
 }
@@ -138,11 +156,11 @@ async function measureRendererDuringPolling(page: Page): Promise<RendererTimerMe
 }
 
 function readGitProbeFailureCounts(traceFilePath: string, repoPath: string): GitProbeFailureCounts {
-  if (!existsSync(traceFilePath)) {
-    return { noConfiguredUpstreamFailures: 0, missingSameNameOriginFailures: 0 }
+  const counts = {
+    observedGitCommands: 0,
+    noConfiguredUpstreamFailures: 0,
+    missingSameNameOriginFailures: 0
   }
-
-  const counts = { noConfiguredUpstreamFailures: 0, missingSameNameOriginFailures: 0 }
   for (const line of readFileSync(traceFilePath, 'utf8').split(/\r?\n/)) {
     if (!line.trim()) {
       continue
@@ -157,11 +175,12 @@ function readGitProbeFailureCounts(traceFilePath: string, repoPath: string): Git
     } catch {
       continue
     }
-    if (
-      record.name !== 'git.exec' ||
-      record.attributes?.cwd !== repoPath ||
-      record.exit?._tag !== 'Failure'
-    ) {
+    if (record.name !== 'git.exec' || record.attributes?.cwd !== repoPath) {
+      continue
+    }
+
+    counts.observedGitCommands += 1
+    if (record.exit?._tag !== 'Failure') {
       continue
     }
 
@@ -185,7 +204,7 @@ function annotatePolling(
     type: 'git-no-upstream-polling-repro',
     description: `elapsed=${measurement.elapsedMs.toFixed(1)}ms maxTimerDrift=${measurement.maxTimerDriftMs.toFixed(
       1
-    )}ms samples=${measurement.samples} noUpstreamFailures=${
+    )}ms samples=${measurement.samples} gitCommands=${counts.observedGitCommands} noUpstreamFailures=${
       counts.noConfiguredUpstreamFailures
     } missingOriginFailures=${counts.missingSameNameOriginFailures}`
   })
@@ -201,7 +220,8 @@ test.describe('Git no-upstream polling churn repro', () => {
     await selectRepoForActivePolling(orcaPage, testRepoPath, repoPath)
 
     const diagnostics = await readDiagnosticsStatus(orcaPage)
-    test.skip(!diagnostics.localFileEnabled, 'local diagnostic traces are disabled')
+    expect(diagnostics.localFileEnabled).toBe(true)
+    expect(diagnostics.bundleEnabled).toBe(false)
 
     clearTraceFile(diagnostics)
     const measurement = await measureRendererDuringPolling(orcaPage)
@@ -209,6 +229,10 @@ test.describe('Git no-upstream polling churn repro', () => {
     const counts = readGitProbeFailureCounts(diagnostics.traceFilePath, repoPath)
     annotatePolling(testInfo, measurement, counts)
 
+    expect(
+      counts.observedGitCommands,
+      'No Git activity was recorded for the measured repo'
+    ).toBeGreaterThan(0)
     expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_RENDERER_TIMER_DRIFT_MS)
     // Why: the #4559 trace showed these stable negative upstream probes being
     // retried every poll. Under parallel e2e load one in-flight refresh can


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The Git no-upstream polling regression always skipped in CI because local diagnostics were disabled. Its parser also returned zero failures when no trace file existed, allowing a vacuous pass.

Enable local diagnostic files only in this test's isolated Electron process, with DO_NOT_TRACK and network telemetry disabled. Require recorded Git activity for the measured repository and fail on a missing trace file. Keep the existing negative-probe counts and renderer-delay limits.

Validation: three CI repetitions passed in run 34018786145 with the recorded-activity assertion engaged. Lint and formatting pass. This PR's CI validates the test-only change on main.
