### PR TITLE
fix(packaging): ship Claude agent SDK with desktop builds

### DIFF
--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -238,7 +238,7 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     // backslashes, and extractFile expects that same host-style path.
     const internalPath = entry.replace(/^[\\/]+/, '')
     const source = asar.extractFile(asarPath, internalPath).toString('utf8')
-    for (const match of source.matchAll(/\b(?:require|import)\(\s*(["'`])([^"'`$]+)\1\s*\)/g)) {
+    for (const match of source.matchAll(/\b(?:require|import)\s*\(\s*(["'`])([^"'`$]+)\1\s*\)/g)) {
       const specifier = match[2]
       if (!isPackagedExternalSpecifier(specifier)) {
         continue

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -251,12 +251,15 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     const source = asar.extractFile(asarPath, internalPath).toString('utf8')
     // Why the lookbehind: Orca has its own registry methods named `require`, so a
     // minified `registry.require('some-id')` must not read as a bare specifier.
+    // Why it readmits `...`: a dot that ends a spread is not member access, and
+    // the two error directions are not symmetric -- a false positive fails the
+    // release build loudly, a false negative is this guard going blind.
     // Known limit: a specifier inside an embedded source string counts too, and
     // ssh-relay-deploy's remote probe names node-pty that way. A remote-only
     // dependency added to that script would fail desktop packaging here; telling
     // the two apart needs a parser, not a wider pattern.
     for (const match of source.matchAll(
-      /(?<![.\w])(?:require|import)\s*\(\s*(["'`])([^"'`$]+)\1\s*\)/g
+      /(?:(?<![.\w])|(?<=\.\.\.))(?:require|import)\s*\(\s*(["'`])([^"'`$]+)\1\s*\)/g
     )) {
       const specifier = match[2]
       if (!isPackagedExternalSpecifier(specifier)) {

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -14,6 +14,7 @@ const projectDir = resolve(__dirname, '..')
 const requireFromProject = createRequire(join(projectDir, 'package.json'))
 
 const PACKAGED_RUNTIME_PACKAGE_ROOTS = [
+  '@anthropic-ai/claude-agent-sdk',
   '@electron-toolkit/utils',
   '@linear/sdk',
   '@parcel/watcher',
@@ -237,8 +238,8 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     // backslashes, and extractFile expects that same host-style path.
     const internalPath = entry.replace(/^[\\/]+/, '')
     const source = asar.extractFile(asarPath, internalPath).toString('utf8')
-    for (const match of source.matchAll(/require\(["']([^"']+)["']\)/g)) {
-      const specifier = match[1]
+    for (const match of source.matchAll(/\b(?:require|import)\(\s*(["'`])([^"'`$]+)\1\s*\)/g)) {
+      const specifier = match[2]
       if (!isPackagedExternalSpecifier(specifier)) {
         continue
       }

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -251,6 +251,10 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     const source = asar.extractFile(asarPath, internalPath).toString('utf8')
     // Why the lookbehind: Orca has its own registry methods named `require`, so a
     // minified `registry.require('some-id')` must not read as a bare specifier.
+    // Known limit: a specifier inside an embedded source string counts too, and
+    // ssh-relay-deploy's remote probe names node-pty that way. A remote-only
+    // dependency added to that script would fail desktop packaging here; telling
+    // the two apart needs a parser, not a wider pattern.
     for (const match of source.matchAll(
       /(?<![.\w])(?:require|import)\s*\(\s*(["'`])([^"'`$]+)\1\s*\)/g
     )) {

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -57,6 +57,11 @@ const ELECTRON_ARCHITECTURE_BY_ENUM = {
   4: 'universal'
 }
 const PACKAGED_NATIVE_ARCHITECTURES = new Set(['ia32', 'x64', 'arm', 'arm64'])
+const PACKAGED_MAIN_REQUIRED_FILES = [
+  'out/main/index.js',
+  'out/main/agent-hooks/managed-agent-hook-controls.js'
+]
+const PACKAGED_MAIN_SOURCE_RE = /^out\/main\/.+\.js$/
 const TYPE_DECLARATION_ARTIFACT_RE = /\.d\.(?:c|m)?ts(?:\.map)?$/
 const JS_SOURCE_MAP_ARTIFACT_RE = /\.(?:c|m)?js\.map$/
 const VERSIONED_ONNXRUNTIME_DYLIB_RE = /^libonnxruntime\.\d[\d.]*\.dylib$/
@@ -224,21 +229,31 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     return
   }
 
-  const mainFiles = ['out/main/index.js', 'out/main/agent-hooks/managed-agent-hook-controls.js']
   const entries = asar.listPackage(asarPath)
-  const missing = new Set()
-
-  for (const file of mainFiles) {
-    const entry = findAsarEntry(entries, file)
-    if (!entry) {
+  for (const file of PACKAGED_MAIN_REQUIRED_FILES) {
+    if (!findAsarEntry(entries, file)) {
       throw new Error(`Packaged main file ${file} was not found in ${asarPath}`)
+    }
+  }
+
+  const missing = new Set()
+  // Why every emitted main file rather than the entry points alone: rolldown hoists
+  // modules shared by two entries into out/main/chunks, so an entry's own bare imports
+  // move out from under a fixed file list and silently stop being checked.
+  for (const entry of entries) {
+    if (!PACKAGED_MAIN_SOURCE_RE.test(normalizeAsarEntryPath(entry))) {
+      continue
     }
 
     // Why: @electron/asar lists entries with host separators; Windows returns
     // backslashes, and extractFile expects that same host-style path.
     const internalPath = entry.replace(/^[\\/]+/, '')
     const source = asar.extractFile(asarPath, internalPath).toString('utf8')
-    for (const match of source.matchAll(/\b(?:require|import)\s*\(\s*(["'`])([^"'`$]+)\1\s*\)/g)) {
+    // Why the lookbehind: Orca has its own registry methods named `require`, so a
+    // minified `registry.require('some-id')` must not read as a bare specifier.
+    for (const match of source.matchAll(
+      /(?<![.\w])(?:require|import)\s*\(\s*(["'`])([^"'`$]+)\1\s*\)/g
+    )) {
       const specifier = match[2]
       if (!isPackagedExternalSpecifier(specifier)) {
         continue

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -71,6 +71,53 @@ describe('packaged runtime resources', () => {
     }
   })
 
+  it('verifies bare imports that rolldown hoisted into a shared main chunk', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-chunk-imports-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+
+      // The entry points themselves carry no specifier; only the shared chunk does.
+      const sources = new Map([
+        ['out/main/index.js', ''],
+        ['out/main/agent-hooks/managed-agent-hook-controls.js', ''],
+        ['out/main/chunks/managed-agent-hook-controls-CWf8D-KR.js', 'require(`jsonc-parser`)']
+      ])
+      const asar = {
+        listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),
+        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).toThrow(/jsonc-parser/)
+
+      await mkdir(join(resourcesDir, 'node_modules', 'jsonc-parser'), { recursive: true })
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('ignores member calls onto Orca methods that are themselves named require', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-member-require-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+
+      // electron-sidecar-tab-registry and browser-execution-host-grant-registry both
+      // expose require(key); a literal key must never read as a packaged specifier.
+      const sources = new Map([
+        ['out/main/index.js', 'registry.require("public-a");grants.require(`host-key`)'],
+        ['out/main/agent-hooks/managed-agent-hook-controls.js', 'state.import("android-sdk")']
+      ])
+      const asar = {
+        listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),
+        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
   it('normalizes host-specific asar entry separators', () => {
     expect(findAsarEntry(['\\out\\main\\index.js'], 'out/main/index.js')).toBe(
       '\\out\\main\\index.js'

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -50,7 +50,7 @@ describe('packaged runtime resources', () => {
       await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
 
       const sources = new Map([
-        ['out/main/index.js', 'import(`@anthropic-ai/claude-agent-sdk`)'],
+        ['out/main/index.js', 'import (`@anthropic-ai/claude-agent-sdk`)'],
         ['out/main/agent-hooks/managed-agent-hook-controls.js', '']
       ])
       const asar = {

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -49,9 +49,17 @@ describe('packaged runtime resources', () => {
     try {
       await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
 
+      // The first is the exact shape oxc emits for the memoized SDK import in a
+      // shipped build; the second is the spaced variant the pattern also accepts.
       const sources = new Map([
-        ['out/main/index.js', 'import (`@anthropic-ai/claude-agent-sdk`)'],
-        ['out/main/agent-hooks/managed-agent-hook-controls.js', '']
+        [
+          'out/main/index.js',
+          'let p=null;function q(){return p??=import(`@anthropic-ai/claude-agent-sdk`),p}'
+        ],
+        [
+          'out/main/agent-hooks/managed-agent-hook-controls.js',
+          'import (`@anthropic-ai/claude-agent-sdk`)'
+        ]
       ])
       const asar = {
         listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -71,6 +71,24 @@ describe('packaged runtime resources', () => {
     }
   })
 
+  it('still fails when a required packaged main entry is missing entirely', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-missing-entry-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+
+      const asar = {
+        listPackage: () => ['/out/main/index.js'],
+        extractFile: () => Buffer.from('', 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).toThrow(
+        /managed-agent-hook-controls\.js was not found/
+      )
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
   it('verifies bare imports that rolldown hoisted into a shared main chunk', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-chunk-imports-'))
     try {

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -108,15 +108,44 @@ describe('packaged runtime resources', () => {
         ['out/main/agent-hooks/managed-agent-hook-controls.js', ''],
         ['out/main/chunks/managed-agent-hook-controls-CWf8D-KR.js', 'require(`jsonc-parser`)']
       ])
+      // Real listPackage emits directory nodes too, and extractFile throws on them,
+      // so the `.js` anchor is load-bearing -- keep the mock able to catch that.
+      const directories = ['/out', '/out/main', '/out/main/chunks']
       const asar = {
-        listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),
-        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+        listPackage: () => [...directories, ...[...sources.keys()].map((entry) => `/${entry}`)],
+        extractFile: (_asarPath, internalPath) => {
+          const source = sources.get(internalPath)
+          if (source === undefined) {
+            throw new Error(`Expected to find file at: ${internalPath} but found a directory`)
+          }
+          return Buffer.from(source, 'utf8')
+        }
       }
 
       expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).toThrow(/jsonc-parser/)
 
       await mkdir(join(resourcesDir, 'node_modules', 'jsonc-parser'), { recursive: true })
       expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('reads a spread require, whose leading dots are not member access', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-spread-require-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+
+      const sources = new Map([
+        ['out/main/index.js', 'const all=[...require("jsonc-parser")]'],
+        ['out/main/agent-hooks/managed-agent-hook-controls.js', '']
+      ])
+      const asar = {
+        listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),
+        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).toThrow(/jsonc-parser/)
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }

--- a/config/scripts/electron-builder-runtime-resources.test.mjs
+++ b/config/scripts/electron-builder-runtime-resources.test.mjs
@@ -44,6 +44,33 @@ describe('packaged runtime resources', () => {
     }
   })
 
+  it('verifies literal dynamic imports from the packaged main bundle', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-runtime-dynamic-imports-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+
+      const sources = new Map([
+        ['out/main/index.js', 'import(`@anthropic-ai/claude-agent-sdk`)'],
+        ['out/main/agent-hooks/managed-agent-hook-controls.js', '']
+      ])
+      const asar = {
+        listPackage: () => [...sources.keys()].map((entry) => `/${entry}`),
+        extractFile: (_asarPath, internalPath) => Buffer.from(sources.get(internalPath), 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).toThrow(
+        /@anthropic-ai\/claude-agent-sdk/
+      )
+
+      await mkdir(join(resourcesDir, 'node_modules', '@anthropic-ai', 'claude-agent-sdk'), {
+        recursive: true
+      })
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).not.toThrow()
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
   it('normalizes host-specific asar entry separators', () => {
     expect(findAsarEntry(['\\out\\main\\index.js'], 'out/main/index.js')).toBe(
       '\\out\\main\\index.js'
@@ -132,6 +159,15 @@ describe('packaged runtime resources', () => {
       )
     ).toBe(true)
     expect(packagedTargets).toContain(join('node_modules', 'proper-lockfile'))
+  })
+
+  it('includes the Claude agent SDK in every desktop package plan', () => {
+    for (const platform of ['darwin', 'linux', 'win32']) {
+      const packagedTargets = createPackagedRuntimeNodeModuleResources(platform).map(
+        (resource) => resource.to
+      )
+      expect(packagedTargets).toContain(join('node_modules', '@anthropic-ai', 'claude-agent-sdk'))
+    }
   })
 
   it('prunes non-target @parcel/watcher architecture subpackages', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​138 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​138 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## ELI5

Packaged Orca builds now include the SDK that structured Claude chats need, and packaging fails early if a literal runtime import is missing again.

## What Changed

- added `@anthropic-ai/claude-agent-sdk` to the explicit packaged runtime roots for macOS, Linux, and Windows
- extended the packaged-main verifier to scan literal dynamic imports as well as CommonJS requires
- accepted valid whitespace before import/require call parentheses
- added missing-package and all-platform resource-plan regression coverage

## Why

Structured Claude loads its SDK lazily from the Electron main bundle. Development had the dependency available, but packaged runtime resources omitted it. The verifier only recognized `require(...)`, so packaging passed and the chat failed at runtime.

## Regression Point

Introduced by [#18560 — feat(claude): move structured native chat onto the Claude Agent SDK and enable it on macOS and Linux](https://github.com/stablyai/orca/pull/18560), commit `a65332a8bd`.

## Linked Issue

Reported directly; no linked tracker issue.

## Visual Proof

Independent packaged-runtime validation (Grok + Electron CDP) at head `a1dac60c116e92904c88843a7a433aae153d1ba9`. Uncropped full-window screenshots of the shipped macOS unpack (`dist/mac-arm64/Orca.app`, `isDev: false`), not a development `node_modules` run. Full write-up: https://github.com/stablyai/orca/pull/19042#issuecomment-5558313074

Empty packaged app:

![01-packaged-empty.png](https://github.com/user-attachments/assets/83051c0b-6e0d-40cf-8870-e3660956d646)

Structured Claude session (New tab → Claude):

![02-structured-claude-empty.png](https://github.com/user-attachments/assets/c931e81f-fcc0-47be-b37f-b384266d2093)

Same session after send — assistant replied `pong`; no missing-module error:

![03-structured-claude-pong.png](https://github.com/user-attachments/assets/d0c392b4-9fd4-43ad-8b2c-0633bb40ffb2)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- packaged runtime resource suite: 16 tests
- node TypeScript check
- changed-code quality gate
- Electron build
- built main verifier fails without the SDK and passes after staging it
- staged ESM import resolves and exposes the SDK query entry point

CI covers the full test matrix and macOS/Windows packaging.

## AI Disclosure

## Review

Please focus on runtime dependency detection and package-resource completeness.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The package plan is platform-neutral. No runtime protocol, SSH behavior, workspace model, or renderer behavior changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

