### PR TITLE
Add persistent turn-scoped chat activity indicator

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -84,6 +84,166 @@ describe('NativeChatMessageList assistant messages', () => {
     expect(document.querySelector('.text-destructive')).toBeNull()
   })
 
+  it('keeps a reduced-motion-safe spinner activity line at the tail of a no-tool Codex turn', () => {
+    render(
+      <NativeChatMessageList
+        session={{
+          ...session,
+          status: 'working',
+          messages: [
+            {
+              id: 'user-prose',
+              role: 'user',
+              blocks: [{ type: 'text', text: 'Write a long answer' }],
+              timestamp: 1,
+              source: 'transcript'
+            },
+            {
+              id: 'assistant-prose',
+              role: 'assistant',
+              blocks: [{ type: 'text', text: 'The answer is still streaming.' }],
+              timestamp: 2,
+              source: 'transcript'
+            }
+          ]
+        }}
+        isWorking
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    const activity = screen.getByText('Working…')
+    const row = activity.closest('[data-native-chat-turn-activity]')
+    const spinner = row?.querySelector('svg')
+    expect(activity).not.toHaveClass('animate-pulse', 'animate-spin')
+    expect(spinner).toHaveClass('size-4', 'animate-spin', 'motion-reduce:animate-none')
+    expect(row).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByText('The answer is still streaming.').compareDocumentPosition(row!)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  })
+
+  it('animates the running tool and the tail spinner without pulsing the activity text', () => {
+    render(
+      <NativeChatMessageList
+        session={{
+          ...session,
+          status: 'working',
+          messages: [
+            {
+              id: 'assistant-running-tool',
+              role: 'assistant',
+              blocks: [
+                {
+                  type: 'tool-call',
+                  name: 'shell',
+                  input: { command: 'pnpm test' },
+                  state: 'running'
+                }
+              ],
+              timestamp: 1,
+              source: 'transcript'
+            }
+          ]
+        }}
+        isWorking
+        turnActivity={{ kind: 'description', text: 'Verifying the change' }}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    expect(screen.getByText('Running pnpm test')).toHaveClass('animate-pulse')
+    const activity = screen.getByText('Verifying the change')
+    const spinner = activity.closest('[data-native-chat-turn-activity]')?.querySelector('svg')
+    expect(activity).not.toHaveClass('animate-pulse', 'animate-spin')
+    expect(spinner).toHaveClass('animate-spin', 'motion-reduce:animate-none')
+  })
+
+  it('restates a completed tool without claiming that it is still running', () => {
+    render(
+      <NativeChatMessageList
+        session={{ ...session, status: 'working' }}
+        isWorking
+        turnActivity={{
+          kind: 'tool',
+          call: {
+            type: 'tool-call',
+            name: 'shell',
+            input: { command: 'pnpm test' },
+            state: 'completed'
+          }
+        }}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    const activity = screen.getByText('Continuing after pnpm test…')
+    expect(activity).not.toHaveClass('animate-pulse', 'animate-spin')
+    expect(activity.closest('[data-native-chat-turn-activity]')?.querySelector('svg')).toHaveClass(
+      'animate-spin'
+    )
+    expect(screen.queryByText('Running pnpm test')).toBeNull()
+  })
+
+  it('keeps a completed tool row static while the turn tail spins, then removes the tail', () => {
+    const workingSession: NativeChatLiveSession = {
+      ...session,
+      status: 'working',
+      messages: [
+        {
+          id: 'assistant-settled-tool',
+          role: 'assistant',
+          blocks: [
+            {
+              type: 'tool-call',
+              name: 'shell',
+              input: { command: 'pnpm test' },
+              state: 'completed'
+            },
+            { type: 'tool-result', output: 'passed' }
+          ],
+          timestamp: 1,
+          source: 'transcript'
+        }
+      ]
+    }
+    const { container, rerender } = render(
+      <NativeChatMessageList
+        session={workingSession}
+        isWorking
+        turnActivity={{ kind: 'description', text: 'Preparing the answer' }}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    const settledTool = screen.getByText('shell pnpm test')
+    expect(settledTool.closest('button')?.querySelector('.animate-pulse')).toBeNull()
+    expect(settledTool.closest('button')?.querySelector('.lucide-check')).toBeInTheDocument()
+    const activity = screen.getByText('Preparing the answer')
+    expect(activity).not.toHaveClass('animate-pulse', 'animate-spin')
+    expect(activity.closest('[data-native-chat-turn-activity]')?.querySelector('svg')).toHaveClass(
+      'animate-spin'
+    )
+
+    rerender(
+      <NativeChatMessageList
+        session={{ ...workingSession, status: 'ready' }}
+        isWorking={false}
+        turnActivity={{ kind: 'description', text: 'Preparing the answer' }}
+        expandSignal={false}
+        fontScale={1}
+      />
+    )
+
+    expect(container.querySelector('[data-native-chat-turn-activity]')).toBeNull()
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+    expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+
   it('keeps bridge chats on the legacy activity chrome', () => {
     render(
       <NativeChatMessageList

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.test.tsx
@@ -124,7 +124,7 @@ describe('NativeChatMessageList assistant messages', () => {
     )
   })
 
-  it('animates the running tool and the tail spinner without pulsing the activity text', () => {
+  it('keeps the broad fallback distinct from the running tool row', () => {
     render(
       <NativeChatMessageList
         session={{
@@ -148,44 +148,62 @@ describe('NativeChatMessageList assistant messages', () => {
           ]
         }}
         isWorking
-        turnActivity={{ kind: 'description', text: 'Verifying the change' }}
         expandSignal={false}
         fontScale={1}
       />
     )
 
-    expect(screen.getByText('Running pnpm test')).toHaveClass('animate-pulse')
-    const activity = screen.getByText('Verifying the change')
+    const toolLabel = screen.getByText('Running pnpm test')
+    expect(toolLabel).toHaveClass('animate-pulse')
+    expect(screen.getAllByText('Running pnpm test')).toHaveLength(1)
+    const activity = screen.getByText('Working…')
+    expect(activity.textContent).not.toBe(toolLabel.textContent)
+    expect(activity).not.toHaveTextContent('shell')
+    expect(activity).not.toHaveTextContent('pnpm test')
     const spinner = activity.closest('[data-native-chat-turn-activity]')?.querySelector('svg')
     expect(activity).not.toHaveClass('animate-pulse', 'animate-spin')
     expect(spinner).toHaveClass('animate-spin', 'motion-reduce:animate-none')
   })
 
-  it('restates a completed tool without claiming that it is still running', () => {
+  it('uses the broad fallback after a tool settles', () => {
     render(
       <NativeChatMessageList
-        session={{ ...session, status: 'working' }}
-        isWorking
-        turnActivity={{
-          kind: 'tool',
-          call: {
-            type: 'tool-call',
-            name: 'shell',
-            input: { command: 'pnpm test' },
-            state: 'completed'
-          }
+        session={{
+          ...session,
+          status: 'working',
+          messages: [
+            {
+              id: 'assistant-completed-tool',
+              role: 'assistant',
+              blocks: [
+                {
+                  type: 'tool-call',
+                  name: 'shell',
+                  input: { command: 'pnpm test' },
+                  state: 'completed'
+                },
+                { type: 'tool-result', output: 'passed' }
+              ],
+              timestamp: 1,
+              source: 'transcript'
+            }
+          ]
         }}
+        isWorking
         expandSignal={false}
         fontScale={1}
       />
     )
 
-    const activity = screen.getByText('Continuing after pnpm test…')
+    const settledTool = screen.getByText('shell pnpm test')
+    const activity = screen.getByText('Working…')
+    expect(activity.textContent).not.toBe(settledTool.textContent)
+    expect(activity).not.toHaveTextContent('shell')
+    expect(activity).not.toHaveTextContent('pnpm test')
     expect(activity).not.toHaveClass('animate-pulse', 'animate-spin')
     expect(activity.closest('[data-native-chat-turn-activity]')?.querySelector('svg')).toHaveClass(
       'animate-spin'
     )
-    expect(screen.queryByText('Running pnpm test')).toBeNull()
   })
 
   it('keeps a completed tool row static while the turn tail spins, then removes the tail', () => {

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -13,6 +13,8 @@ import { NativeChatWorkingStatus } from './NativeChatWorkingStatus'
 import { useNativeChatTurnStatus } from './use-native-chat-turn-status'
 import { NativeChatTypingIndicatorRow } from './NativeChatTypingIndicatorRow'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
+import type { NativeChatTurnActivity } from './native-chat-turn-activity'
+import { NativeChatTurnActivityLine } from './NativeChatTurnActivityLine'
 
 export { ProviderFrameRow } from './NativeChatTranscriptChrome'
 
@@ -32,6 +34,7 @@ export function NativeChatMessageList({
   workingStartedAt,
   failedDeliveryMessageIds,
   showTurnStatus = true,
+  turnActivity,
   runtimeContext
 }: {
   session: NativeChatLiveSession
@@ -46,6 +49,7 @@ export function NativeChatMessageList({
   failedDeliveryMessageIds?: ReadonlySet<string>
   /** Turn timing and disclosure are available on structured agent sessions. */
   showTurnStatus?: boolean
+  turnActivity?: NativeChatTurnActivity | null
   runtimeContext?: RuntimeFileOperationArgs | null
 }): React.JSX.Element {
   const scrollRef = useRef<HTMLDivElement | null>(null)
@@ -271,6 +275,9 @@ export function NativeChatMessageList({
               thinking={turnStatuses.active.thinking}
               workedSeconds={turnStatuses.active.workedSeconds}
             />
+          ) : null}
+          {showTurnStatus && isWorking ? (
+            <NativeChatTurnActivityLine activity={turnActivity} />
           ) : null}
           {!showTurnStatus && showTypingIndicator ? <NativeChatTypingIndicatorRow /> : null}
         </div>

--- a/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatStructuredSession.tsx
@@ -180,6 +180,7 @@ export function NativeChatStructuredSession(
             fontScale={fontScale.scale}
             workingStartedAt={null}
             showTurnStatus
+            turnActivity={controller.turnActivity}
             onLinkClick={fileLinkClick}
             allowFileUriLinks={fileLinkClick !== undefined}
             runtimeContext={imageRuntimeContext}

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.test.tsx
@@ -311,6 +311,24 @@ describe('NativeChatToolRun', () => {
     expect(screen.getByText('shell sleep 1')).toBeInTheDocument()
   })
 
+  it('never animates a settled tool row with its completion check', () => {
+    const { container } = render(
+      <NativeChatToolRun
+        blocks={[
+          { type: 'tool-call', name: 'shell', input: { command: 'pnpm test' }, state: 'completed' },
+          { type: 'tool-result', output: 'passed' }
+        ]}
+        expandSignal={false}
+        activeTurnIsWorking
+      />
+    )
+
+    const settledRow = screen.getByText('shell pnpm test').closest('button')
+    expect(settledRow?.querySelector('.lucide-check')).toBeInTheDocument()
+    expect(settledRow?.querySelector('.animate-pulse')).toBeNull()
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
   it('keeps failed tool runs visually neutral while collapsed', () => {
     const blocks: NativeChatBlock[] = [
       { type: 'tool-call', name: 'shell', input: { command: 'false' }, state: 'failed' },

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -22,25 +22,13 @@ import {
   truncateToolDetail
 } from './native-chat-tool-summary'
 import {
-  describeActiveToolCall,
   NATIVE_CHAT_TOOL_ACTIVITY_COPY,
   selectActiveToolCall
 } from '../../../../shared/native-chat-tool-activity'
 import { nativeChatToolRunIconName } from '../../../../shared/native-chat-tool-icon'
 import { NativeChatDiffView } from './NativeChatDiffView'
 import { NativeChatToolIcon, NativeChatToolRunIcon } from './NativeChatToolIcon'
-
-function activeToolLabel(call: Extract<NativeChatBlock, { type: 'tool-call' }>): string {
-  const { key, toolName, preview } = describeActiveToolCall(call)
-  const copy = NATIVE_CHAT_TOOL_ACTIVITY_COPY[key]
-  return key === 'runningPreview'
-    ? translate('components.native-chat.tool.runningPreview', copy, { preview })
-    : key === 'runningCommand'
-      ? translate('components.native-chat.tool.runningCommand', copy)
-      : key === 'runningNamedPreview'
-        ? translate('components.native-chat.tool.runningNamedPreview', copy, { toolName, preview })
-        : translate('components.native-chat.tool.runningNamed', copy, { toolName })
-}
+import { nativeChatToolActivityLabel } from './native-chat-tool-activity-label'
 
 /** A single inline tool line — `▸ ToolName  preview` — that expands in place to
  *  show the call's diff/input or the result's body. Tool calls read as flat
@@ -267,7 +255,7 @@ export function NativeChatToolRun({
         >
           <NativeChatToolIcon rowWord={latestActiveCall.name} className="text-muted-foreground" />
           <span className="min-w-0 flex-1 animate-pulse truncate text-foreground/85 motion-reduce:animate-none">
-            {activeToolLabel(latestActiveCall)}
+            {nativeChatToolActivityLabel(latestActiveCall)}
           </span>
           {open ? <ChevronRight className="size-3.5 rotate-90 text-muted-foreground" /> : null}
         </button>

--- a/src/renderer/src/components/native-chat/NativeChatTurnActivityLine.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTurnActivityLine.tsx
@@ -1,0 +1,41 @@
+import { Loader2 } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import type { NativeChatTurnActivity } from './native-chat-turn-activity'
+import { nativeChatToolActivityLabel } from './native-chat-tool-activity-label'
+import { describeActiveToolCall } from '../../../../shared/native-chat-tool-activity'
+
+function completedToolActivityLabel(activity: Extract<NativeChatTurnActivity, { kind: 'tool' }>) {
+  const { preview, toolName } = describeActiveToolCall(activity.call)
+  return translate(
+    'components.native-chat.activity.continuingAfter',
+    'Continuing after {{activity}}…',
+    { activity: preview || toolName }
+  )
+}
+
+export function NativeChatTurnActivityLine({
+  activity
+}: {
+  activity?: NativeChatTurnActivity | null
+}): React.JSX.Element {
+  const label =
+    activity?.kind === 'description'
+      ? activity.text
+      : activity?.kind === 'tool'
+        ? activity.call.state === 'running'
+          ? nativeChatToolActivityLabel(activity.call)
+          : completedToolActivityLabel(activity)
+        : translate('components.native-chat.status.working', 'Working…')
+
+  return (
+    <div
+      className="flex min-h-6 items-center gap-1.5 text-sm leading-relaxed text-muted-foreground"
+      data-native-chat-turn-activity="true"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      <Loader2 aria-hidden className="size-4 shrink-0 animate-spin motion-reduce:animate-none" />
+      <span className="min-w-0 flex-1 truncate text-foreground/85">{label}</span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/native-chat/NativeChatTurnActivityLine.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTurnActivityLine.tsx
@@ -1,31 +1,13 @@
 import { Loader2 } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import type { NativeChatTurnActivity } from './native-chat-turn-activity'
-import { nativeChatToolActivityLabel } from './native-chat-tool-activity-label'
-import { describeActiveToolCall } from '../../../../shared/native-chat-tool-activity'
-
-function completedToolActivityLabel(activity: Extract<NativeChatTurnActivity, { kind: 'tool' }>) {
-  const { preview, toolName } = describeActiveToolCall(activity.call)
-  return translate(
-    'components.native-chat.activity.continuingAfter',
-    'Continuing after {{activity}}…',
-    { activity: preview || toolName }
-  )
-}
 
 export function NativeChatTurnActivityLine({
   activity
 }: {
   activity?: NativeChatTurnActivity | null
 }): React.JSX.Element {
-  const label =
-    activity?.kind === 'description'
-      ? activity.text
-      : activity?.kind === 'tool'
-        ? activity.call.state === 'running'
-          ? nativeChatToolActivityLabel(activity.call)
-          : completedToolActivityLabel(activity)
-        : translate('components.native-chat.status.working', 'Working…')
+  const label = activity?.text ?? translate('components.native-chat.status.working', 'Working…')
 
   return (
     <div

--- a/src/renderer/src/components/native-chat/native-chat-tool-activity-label.ts
+++ b/src/renderer/src/components/native-chat/native-chat-tool-activity-label.ts
@@ -1,0 +1,20 @@
+import { translate } from '@/i18n/i18n'
+import {
+  describeActiveToolCall,
+  NATIVE_CHAT_TOOL_ACTIVITY_COPY
+} from '../../../../shared/native-chat-tool-activity'
+import type { NativeChatBlock } from '../../../../shared/native-chat-types'
+
+type ToolCall = Extract<NativeChatBlock, { type: 'tool-call' }>
+
+export function nativeChatToolActivityLabel(call: ToolCall): string {
+  const { key, toolName, preview } = describeActiveToolCall(call)
+  const copy = NATIVE_CHAT_TOOL_ACTIVITY_COPY[key]
+  return key === 'runningPreview'
+    ? translate('components.native-chat.tool.runningPreview', copy, { preview })
+    : key === 'runningCommand'
+      ? translate('components.native-chat.tool.runningCommand', copy)
+      : key === 'runningNamedPreview'
+        ? translate('components.native-chat.tool.runningNamedPreview', copy, { toolName, preview })
+        : translate('components.native-chat.tool.runningNamed', copy, { toolName })
+}

--- a/src/renderer/src/components/native-chat/native-chat-turn-activity.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-turn-activity.test.ts
@@ -34,7 +34,7 @@ describe('selectStructuredAgentTurnActivity', () => {
     expect(activity).toEqual({ kind: 'description', text: 'Preparing the answer' })
   })
 
-  it('returns the latest tool for a safe present-tense restatement', () => {
+  it('ignores active and settled tools so the tail can use a broad fallback', () => {
     const activity = selectStructuredAgentTurnActivity(
       [
         turnStart,
@@ -42,16 +42,19 @@ describe('selectStructuredAgentTurnActivity', () => {
           kind: 'tool-call',
           name: 'shell',
           input: { command: 'pnpm test' },
+          state: 'running'
+        }),
+        item(3, {
+          kind: 'tool-call',
+          name: 'shell',
+          input: { command: 'pnpm lint' },
           state: 'completed'
         })
       ],
       'turn-1'
     )
 
-    expect(activity).toMatchObject({
-      kind: 'tool',
-      call: { name: 'shell', input: { command: 'pnpm test' }, state: 'completed' }
-    })
+    expect(activity).toBeNull()
   })
 
   it('ignores diagnostic provider frames and returns nothing after the turn settles', () => {

--- a/src/renderer/src/components/native-chat/native-chat-turn-activity.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-turn-activity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  AgentJournalItemBody,
+  AgentJournalRenderItem
+} from '../../../../shared/agent-session-journal-types'
+import { selectStructuredAgentTurnActivity } from './native-chat-turn-activity'
+
+function item(sequence: number, body: AgentJournalItemBody): AgentJournalRenderItem {
+  return { itemId: `item-${sequence}`, revision: 1, sequence, observedAt: sequence, body }
+}
+
+const turnStart = item(1, {
+  kind: 'status',
+  text: 'Codex is working…',
+  turnLifecycle: { turnId: 'turn-1', state: 'running' }
+})
+
+describe('selectStructuredAgentTurnActivity', () => {
+  it('prefers the latest provider-authored activity line in the active turn', () => {
+    const activity = selectStructuredAgentTurnActivity(
+      [
+        turnStart,
+        item(2, {
+          kind: 'tool-call',
+          name: 'shell',
+          input: { command: 'pnpm test' },
+          state: 'completed'
+        }),
+        item(3, { kind: 'status', text: 'Checking the results\nPreparing the answer' })
+      ],
+      'turn-1'
+    )
+
+    expect(activity).toEqual({ kind: 'description', text: 'Preparing the answer' })
+  })
+
+  it('returns the latest tool for a safe present-tense restatement', () => {
+    const activity = selectStructuredAgentTurnActivity(
+      [
+        turnStart,
+        item(2, {
+          kind: 'tool-call',
+          name: 'shell',
+          input: { command: 'pnpm test' },
+          state: 'completed'
+        })
+      ],
+      'turn-1'
+    )
+
+    expect(activity).toMatchObject({
+      kind: 'tool',
+      call: { name: 'shell', input: { command: 'pnpm test' }, state: 'completed' }
+    })
+  })
+
+  it('ignores diagnostic provider frames and returns nothing after the turn settles', () => {
+    const diagnostic = item(2, {
+      kind: 'status',
+      text: 'codex · notification:new/event',
+      providerFrame: {
+        provider: 'codex',
+        kind: 'notification:new/event',
+        payload: {
+          head: '{}',
+          byteLength: 2,
+          digest: 'a'.repeat(64),
+          truncated: false
+        }
+      }
+    })
+
+    expect(selectStructuredAgentTurnActivity([turnStart, diagnostic], 'turn-1')).toBeNull()
+    expect(selectStructuredAgentTurnActivity([turnStart, diagnostic], null)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-turn-activity.ts
+++ b/src/renderer/src/components/native-chat/native-chat-turn-activity.ts
@@ -1,0 +1,61 @@
+import type { AgentJournalRenderItem } from '../../../../shared/agent-session-journal-types'
+import { normalizePromptField } from '../../../../shared/agent-status-field-normalization'
+import type { NativeChatBlock } from '../../../../shared/native-chat-types'
+
+type ToolCall = Extract<NativeChatBlock, { type: 'tool-call' }>
+
+export type NativeChatTurnActivity =
+  | { kind: 'description'; text: string }
+  | { kind: 'tool'; call: ToolCall }
+
+function activityLine(text: string): string | null {
+  const lines = text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const latest = lines.at(-1)
+  return latest ? normalizePromptField(latest) || null : null
+}
+
+/** Prefer provider-authored activity copy, then restate the latest tool in present tense. */
+export function selectStructuredAgentTurnActivity(
+  items: readonly AgentJournalRenderItem[],
+  turnId: string | null
+): NativeChatTurnActivity | null {
+  if (!turnId) {
+    return null
+  }
+  const turnStartIndex = items.findLastIndex(
+    (item) =>
+      item.body.kind === 'status' &&
+      item.body.turnLifecycle?.turnId === turnId &&
+      item.body.turnLifecycle.state === 'running'
+  )
+  const turnItems = items.slice(Math.max(0, turnStartIndex))
+  for (let index = turnItems.length - 1; index >= 0; index -= 1) {
+    const body = turnItems[index]?.body
+    if (body?.kind !== 'status' || body.turnLifecycle || body.providerFrame) {
+      continue
+    }
+    const text = activityLine(body.text)
+    if (text) {
+      return { kind: 'description', text }
+    }
+  }
+  for (let index = turnItems.length - 1; index >= 0; index -= 1) {
+    const body = turnItems[index]?.body
+    if (body?.kind === 'tool-call') {
+      return {
+        kind: 'tool',
+        call: { type: 'tool-call', name: body.name, input: body.input, state: body.state }
+      }
+    }
+    if (body?.kind === 'diff') {
+      return {
+        kind: 'tool',
+        call: { type: 'tool-call', name: 'Diff', input: { path: body.path } }
+      }
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/native-chat/native-chat-turn-activity.ts
+++ b/src/renderer/src/components/native-chat/native-chat-turn-activity.ts
@@ -1,12 +1,7 @@
 import type { AgentJournalRenderItem } from '../../../../shared/agent-session-journal-types'
 import { normalizePromptField } from '../../../../shared/agent-status-field-normalization'
-import type { NativeChatBlock } from '../../../../shared/native-chat-types'
 
-type ToolCall = Extract<NativeChatBlock, { type: 'tool-call' }>
-
-export type NativeChatTurnActivity =
-  | { kind: 'description'; text: string }
-  | { kind: 'tool'; call: ToolCall }
+export type NativeChatTurnActivity = { kind: 'description'; text: string }
 
 function activityLine(text: string): string | null {
   const lines = text
@@ -17,7 +12,7 @@ function activityLine(text: string): string | null {
   return latest ? normalizePromptField(latest) || null : null
 }
 
-/** Prefer provider-authored activity copy, then restate the latest tool in present tense. */
+/** Prefer provider-authored activity copy; callers provide the broad fallback. */
 export function selectStructuredAgentTurnActivity(
   items: readonly AgentJournalRenderItem[],
   turnId: string | null
@@ -40,21 +35,6 @@ export function selectStructuredAgentTurnActivity(
     const text = activityLine(body.text)
     if (text) {
       return { kind: 'description', text }
-    }
-  }
-  for (let index = turnItems.length - 1; index >= 0; index -= 1) {
-    const body = turnItems[index]?.body
-    if (body?.kind === 'tool-call') {
-      return {
-        kind: 'tool',
-        call: { type: 'tool-call', name: body.name, input: body.input, state: body.state }
-      }
-    }
-    if (body?.kind === 'diff') {
-      return {
-        kind: 'tool',
-        call: { type: 'tool-call', name: 'Diff', input: { path: body.path } }
-      }
     }
   }
   return null

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -28,6 +28,7 @@ import {
 import { useStructuredAgentSessionHold } from './use-structured-agent-session-hold'
 import { useStructuredAgentSessionRead } from './use-structured-agent-session-read'
 import { projectStructuredAgentSessionMessages } from './structured-agent-session-message-projection'
+import { selectStructuredAgentTurnActivity } from './native-chat-turn-activity'
 
 export type StructuredPromptItem = AgentJournalRenderItem & {
   body: Extract<AgentJournalRenderItem['body'], { kind: 'approval' | 'question' }>
@@ -140,6 +141,10 @@ export function useStructuredAgentSession(args: {
   // on the frame that opens each one, so re-read the options as a turn changes
   // rather than leaving the last write unconfirmed for the life of the session.
   const turnId = activeStructuredAgentSessionTurnId(state.items)
+  const turnActivity = useMemo(
+    () => selectStructuredAgentTurnActivity(state.items, turnId),
+    [state.items, turnId]
+  )
   const isMonitoringBackgroundTasks =
     turnId === null && state.backgroundTasks?.state === 'monitoring'
 
@@ -243,6 +248,7 @@ export function useStructuredAgentSession(args: {
     send: outboxController.send,
     retry: outboxController.retry,
     isWorking: turnId !== null,
+    turnActivity,
     isMonitoringBackgroundTasks,
     backgroundTasks: state.backgroundTasks?.tasks ?? [],
     supportsBackgroundTaskStop: state.backgroundTasks?.supportsTaskStop === true,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​100 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |

<!-- /orca-pr-loc -->

## Summary

- add a persistent tail activity line for the full lifetime of a structured agent turn
- use the existing `Loader2` spinner with static activity text and reduced-motion gating
- keep running tool rows pulsing, completed tool rows static with their check, and remove all turn activity when the turn settles
- select tail copy from a provider-authored activity status when one reaches the structured journal, otherwise show the broad `Working…` fallback; the tail never derives copy from a tool name or command

## Provider measurements

I live-tested real structured no-tool turns in both providers to measure the activity status that survives Orca's provider-frame filtering and reaches the journal:

- **Codex:** sampled a real no-tool turn for more than 60 seconds. The journal contained one lifecycle status (`Codex is working…`, revision 1) and no usable non-lifecycle activity status during the gap, so the tail displays the approved spinner + `Working…` fallback.
- **Claude:** sampled a real 81.8-second no-tool turn 316 times at roughly 250 ms intervals. The journal contained one lifecycle status (`Claude is working…`, revision 1) and no usable non-lifecycle activity status during the gap, so the tail likewise displays spinner + `Working…`.

Both providers do send richer underlying progress traffic. Orca currently classifies relevant Codex progress/reasoning frames and Claude status/tool/task-progress frames as status chrome or streams them into existing items before the structured journal is built, so no provider-authored activity status reaches `AgentJournalStatusItem` today. Deriving richer broad activity copy from that traffic is possible follow-up work; this change deliberately uses `Working…` until such a status reaches the journal.

## Validation

- `npx oxlint` on all corrective paths
- focused native-chat tests: 47 passed, including active- and settled-tool non-duplication regressions
- `pnpm tc:web`
- real Electron/CDP validation for running and completed tool states, turn settlement, and reduced motion; the unchanged no-tool provider captures were rechecked

## Visual proof

### Codex — genuine no-tool gap (fallback)

A real Codex prose-only turn with no tool calls. No provider-authored activity status reaches the journal, so the tail shows the broad fallback: a spinning `Loader2` plus static `Working…` text; CDP measured `spin` on the glyph and `none` on the label.

![Codex no-tool turn showing the spinner and Working fallback](https://github.com/user-attachments/assets/a97c6921-60c2-4892-bdc0-12fd6eea8987)

### Claude — genuine no-tool gap (fallback)

A real Claude prose-only turn with no tool calls. No provider-authored activity status reaches the journal, so the tail visibly uses spinner + `Working…`; CDP measured the glyph spinning and the label static.

![Claude no-tool turn showing the spinner and Working fallback](https://github.com/user-attachments/assets/74bcafa0-91cd-4770-a9c7-157ddd33795f)

### Running tool and tail together

During a real Codex `sleep 20` tool call, the specific tool row and broad tail are two distinct lines: `Running /bin/zsh -lc 'sleep 20'` pulses above a separate spinner + `Working…` tail. CDP measured `pulse` on the tool label, `spin` on the tail glyph, and `none` on the tail text; the specific `Running …` copy appeared only once.

![Specific running tool row above a distinct broad Working tail](https://github.com/user-attachments/assets/9c9136d1-e28a-4b4b-876d-556fb9b3269f)

### Completed tool remains static

After the command completed, its row settled with a check and zero animated descendants while the turn-scoped tail continued below it as the broad spinner + `Working…` state. The tail contains no tool name or command string.

![Completed tool row static with check above the broad Working tail](https://github.com/user-attachments/assets/84350605-338b-4c7c-b5f8-2183b8f76868)

### Turn finished

When the real turn settled, the tool activity row and tail disappeared. CDP found no remaining turn activity line, running tool row, or visible turn-scoped `aria-live` row.

![Finished turn with no turn-scoped activity animation](https://github.com/user-attachments/assets/7a5440f1-6c92-42b5-b11a-1f2994c5296a)

### Reduced motion

With `prefers-reduced-motion: reduce` emulated during a live tool call, the specific `Running …` row and separate broad `Working…` tail remained visible while CDP measured `animation-name: none` for both the tool pulse and tail spinner.

![Reduced-motion tool row above a distinct broad Working tail](https://github.com/user-attachments/assets/d4b8c874-bc7b-42de-8170-79740939d3aa)
