### PR TITLE
fix(source-control): stack the Create PR notice's settings link below its message

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control/commit/commit-notices.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/commit/commit-notices.tsx
@@ -113,20 +113,20 @@ export function CommitNotices({
           role={createPrIntentNotice.tone === 'destructive' ? 'alert' : 'status'}
           aria-live="polite"
           className={cn(
-            'mt-1 flex min-w-0 items-center gap-1.5 text-[11px]',
+            'mt-1 flex min-w-0 flex-col items-start gap-1 text-[11px]',
             createPrIntentNotice.tone === 'destructive'
               ? 'text-destructive'
               : 'text-muted-foreground'
           )}
         >
           {/* Why: Create Review blockers carry recovery steps; truncating hides the action the user needs in a narrow sidebar. */}
-          <span className="min-w-0 flex-1 break-words leading-4 [overflow-wrap:anywhere]">
+          <span className="min-w-0 self-stretch break-words leading-4 [overflow-wrap:anywhere]">
             {createPrIntentNotice.message}
           </span>
           {createPrIntentNotice.action === 'settings' && onOpenSourceControlAiSettings ? (
             <button
               type="button"
-              className="shrink-0 font-medium text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground"
+              className="text-left font-medium text-foreground underline decoration-border underline-offset-2 hover:decoration-foreground"
               onClick={() => onOpenSourceControlAiSettings()}
             >
               {translate(

--- a/tests/e2e/source-control-create-pr-intent-notice-layout.spec.ts
+++ b/tests/e2e/source-control-create-pr-intent-notice-layout.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * The Create PR intent notice pairs a wrapping sentence with a "Source Control
+ * AI settings" link. In a minimum-width sidebar the link must not share the
+ * message's row, or it squeezes the sentence into a one-word-per-line column.
+ */
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  createStagedCommitMessageChange,
+  openSourceControl,
+  seedCreatePrComposer
+} from './helpers/source-control-ai-generation'
+import { RIGHT_SIDEBAR_MIN_WIDTH } from '../../src/renderer/src/components/right-sidebar/right-sidebar-width'
+
+test.describe('Source Control Create PR intent notice layout', () => {
+  test('keeps the settings link off the message row at the minimum sidebar width', async ({
+    orcaPage
+  }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    const { prWorktreeId, prWorktreePath, primaryBranch } = await seedCreatePrComposer(orcaPage)
+    // A real staged change with no commit draft is what routes the intent run
+    // into the "configure Source Control AI" notice, which carries the link.
+    createStagedCommitMessageChange(prWorktreePath)
+
+    await orcaPage.evaluate(
+      ({ prWorktreeId, primaryBranch }) => {
+        const store = window.__store
+        if (!store) {
+          throw new Error('window.__store is not available')
+        }
+        store.setState((current) => ({
+          // Unconfigured Source Control AI is what routes the run into the
+          // "configure Source Control AI" notice rather than a failure notice.
+          settings: current.settings
+            ? { ...current.settings, sourceControlAi: undefined, commitMessageAi: undefined }
+            : current.settings,
+          repos: current.repos.map((repo) => ({ ...repo, sourceControlAi: undefined })),
+          // Blocked-on-push keeps "Create PR" running the intent flow instead of
+          // opening the composer form.
+          getHostedReviewCreationEligibility: async () => ({
+            provider: 'github' as const,
+            review: null,
+            reviewLookupOutcome: 'not_found' as const,
+            canCreate: false,
+            blockedReason: 'needs_push' as const,
+            nextAction: 'push' as const,
+            defaultBaseRef: primaryBranch,
+            head: 'e2e-secondary'
+          }),
+          fetchHostedReviewForBranch: async () => null,
+          fetchPRForBranch: async () => null,
+          pushBranch: async (worktreeId: string) => {
+            if (worktreeId !== prWorktreeId) {
+              throw new Error(`Create PR intent pushed unexpected worktree ${worktreeId}`)
+            }
+          }
+        }))
+      },
+      { prWorktreeId, primaryBranch }
+    )
+
+    await openSourceControl(orcaPage, prWorktreeId)
+    await orcaPage.evaluate((minWidth) => {
+      window.__store?.getState().setRightSidebarWidth(minWidth)
+    }, RIGHT_SIDEBAR_MIN_WIDTH)
+
+    const createPr = orcaPage.getByRole('button', { name: 'Create PR' }).first()
+    await expect(createPr).toBeVisible({ timeout: 10_000 })
+    await expect(createPr).toBeEnabled()
+    await createPr.click()
+
+    const notice = orcaPage.locator('#commit-area-create-pr-intent')
+    const settingsLink = notice.getByRole('button', { name: 'Source Control AI settings' })
+    await expect(settingsLink).toBeVisible({ timeout: 20_000 })
+
+    if (process.env.ORCA_PR_INTENT_NOTICE_SCREENSHOT_PATH) {
+      await orcaPage.evaluate(() => document.documentElement.classList.add('dark'))
+      await notice.screenshot({ path: process.env.ORCA_PR_INTENT_NOTICE_SCREENSHOT_PATH })
+    }
+
+    // The layout contract: the link starts below the message's last line.
+    const messageBox = await notice.locator('span').first().boundingBox()
+    const linkBox = await settingsLink.boundingBox()
+    expect(messageBox).not.toBeNull()
+    expect(linkBox).not.toBeNull()
+    expect(linkBox!.y).toBeGreaterThanOrEqual(messageBox!.y + messageBox!.height)
+    // A squeezed message wraps far taller than the ~4 lines this sentence needs.
+    expect(messageBox!.height).toBeLessThan(70)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | 0 |

<!-- /orca-pr-loc -->

Follow-up sweep after #19037: audited every sidebar notice/banner for the same "action button shares a row with wrapping prose" bug. Found one more real instance.

## Problem

`CommitNotices` renders the Create PR intent notice as a single row: a wrapping sentence plus a `shrink-0` **Source Control AI settings** link. That link's label is longer than the "Retry" button from #19037, so at the 220px sidebar floor it eats the row and collapses the sentence to **one word per line**.

## Fix

Stack the link below the message (`flex-col items-start`), left-aligned under the prose it belongs to. Visual proof and the full audit are in the comment below.

## Verification

- New e2e `tests/e2e/source-control-create-pr-intent-notice-layout.spec.ts` — passes on the fix, **fails on the old layout** (message wrapped 80px tall, link landed above the message's last line)
- `pnpm test …/source-control-create-pr-intent-flow.test.ts` — 14 passed
- `pnpm tc` — clean