### PR TITLE
test: canonicalize Windows fresh-profile fixture path

### DIFF
--- a/tests/e2e/golden-fresh-profile-terminal.spec.ts
+++ b/tests/e2e/golden-fresh-profile-terminal.spec.ts
@@ -16,7 +16,7 @@ import {
 test.use({ dismissOnboarding: false, seedTestRepo: false })
 
 async function createGitRepo(): Promise<string> {
-  const root = realpathSync(await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-golden-fresh-')))
+  const root = realpathSync.native(await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-golden-fresh-')))
   const repoPath = path.join(root, 'golden-fresh-project')
   mkdirSync(repoPath)
   execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })


### PR DESCRIPTION
The fresh-profile golden test failed on Windows because its fixture path retained the RUNNER~1 short alias while Git correctly reported the runneradmin long path. Canonicalize the fixture with realpathSync.native, matching the existing golden source-control fixture, so the unchanged working-directory assertion compares the same path.

Validation: reproduced in Windows job 101455072341 (run 34021593604); formatting passed. Native Windows fresh-profile validation passed 3/3 in run 34022233893 (the separate cmd.exe launch case failed 3/3). All PR checks and pullfrog passed.
