### PR TITLE
test: repair Windows paste setup and newline expectations

### DIFF
--- a/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
+++ b/tests/e2e/terminal-windows-codex-multiline-paste.spec.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
+import { attachRepoAndOpenTerminal } from './helpers/orca-restart'
 import {
   focusActiveTerminalInput,
   getTerminalContent,
@@ -54,33 +55,8 @@ async function activateTestRepository(
   page: Parameters<typeof focusActiveTerminalInput>[0],
   repoPath: string
 ): Promise<void> {
-  await page.evaluate(async (targetRepoPath) => {
-    const normalizePath = (value: string): string => value.replaceAll('\\', '/').toLowerCase()
-    await window.api.repos.add({ path: targetRepoPath })
-    const store = window.__store
-    if (!store) {
-      throw new Error('Orca store unavailable')
-    }
-    await store.getState().fetchRepos()
-    const repo = store
-      .getState()
-      .repos.find((candidate) => normalizePath(candidate.path) === normalizePath(targetRepoPath))
-    if (!repo) {
-      throw new Error('Seeded repository unavailable')
-    }
-    await store.getState().updateRepo(repo.id, { externalWorktreeVisibility: 'show' })
-    await store.getState().fetchWorktrees(repo.id)
-    const worktree = store
-      .getState()
-      .worktreesByRepo[repo.id]?.find(
-        (candidate) => normalizePath(candidate.path) === normalizePath(targetRepoPath)
-      )
-    if (!worktree) {
-      throw new Error('Seeded worktree unavailable')
-    }
-    store.getState().setActiveWorktree(worktree.id)
-    store.getState().createTab(worktree.id)
-  }, repoPath)
+  const worktreeId = await attachRepoAndOpenTerminal(page, repoPath)
+  await page.evaluate((id) => window.__store!.getState().createTab(id), worktreeId)
 }
 
 function pasteCollectorScript(

--- a/tests/e2e/terminal-windows-shell-paste-ownership.spec.ts
+++ b/tests/e2e/terminal-windows-shell-paste-ownership.spec.ts
@@ -221,7 +221,8 @@ test.describe('Windows terminal shell paste ownership', () => {
       `mixed-newline-before\r\nlf-line\ncrlf-line\r\n${sentinel}`
     ].join('\n')
     const scriptPath = path.join(testRepoPath, `.orca-paste-powershell-shell-${runId}.mjs`)
-    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, payload))
+    const expectedText = payload.replace(/\r?\n/g, '\r')
+    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, expectedText))
     let scriptStarted = false
 
     try {
@@ -237,7 +238,7 @@ test.describe('Windows terminal shell paste ownership', () => {
       await waitForTerminalOutput(orcaPage, `PASTE_COMPLETE_${runId}:MATCH`, 10_000, 12_000)
 
       const writes = (await readTerminalPtyWrites(electronApp)).join('')
-      expect(countOccurrences(writes, payload), 'PowerShell payload PTY write count').toBe(1)
+      expect(countOccurrences(writes, expectedText), 'PowerShell payload PTY write count').toBe(1)
     } finally {
       if (scriptStarted) {
         await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
@@ -271,7 +272,8 @@ test.describe('Windows terminal shell paste ownership', () => {
       `mixed-newline-before\r\nlf-line\ncrlf-line\r\n${sentinel}`
     ].join('\n')
     const scriptPath = path.join(testRepoPath, `.orca-paste-cmd-shell-${runId}.mjs`)
-    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, payload))
+    const expectedText = payload.replace(/\r?\n/g, '\r')
+    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, expectedText))
     let scriptStarted = false
 
     try {
@@ -287,7 +289,7 @@ test.describe('Windows terminal shell paste ownership', () => {
       await waitForTerminalOutput(orcaPage, `PASTE_COMPLETE_${runId}:MATCH`, 10_000, 12_000)
 
       const writes = (await readTerminalPtyWrites(electronApp)).join('')
-      expect(countOccurrences(writes, payload), 'cmd.exe payload PTY write count').toBe(1)
+      expect(countOccurrences(writes, expectedText), 'cmd.exe payload PTY write count').toBe(1)
     } finally {
       if (scriptStarted) {
         await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
@@ -322,7 +324,8 @@ test.describe('Windows terminal shell paste ownership', () => {
       `mixed-newline-before\r\nlf-line\ncrlf-line\r\n${sentinel}`
     ].join('\n')
     const scriptPath = path.join(testRepoPath, `.orca-paste-git-bash-shell-${runId}.mjs`)
-    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, payload))
+    const expectedText = payload.replace(/\r?\n/g, '\r')
+    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, expectedText))
     let scriptStarted = false
 
     try {
@@ -338,7 +341,7 @@ test.describe('Windows terminal shell paste ownership', () => {
       await waitForTerminalOutput(orcaPage, `PASTE_COMPLETE_${runId}:MATCH`, 10_000, 12_000)
 
       const writes = (await readTerminalPtyWrites(electronApp)).join('')
-      expect(countOccurrences(writes, payload), 'Git Bash payload PTY write count').toBe(1)
+      expect(countOccurrences(writes, expectedText), 'Git Bash payload PTY write count').toBe(1)
     } finally {
       if (scriptStarted) {
         await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
@@ -376,7 +379,8 @@ test.describe('Windows terminal shell paste ownership', () => {
       `mixed-newline-before\r\nlf-line\ncrlf-line\r\n${sentinel}`
     ].join('\n')
     const scriptPath = path.join(testRepoPath, `.orca-paste-wsl-shell-${runId}.mjs`)
-    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, payload))
+    const expectedText = payload.replace(/\r?\n/g, '\r')
+    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, expectedText))
     let scriptStarted = false
 
     try {
@@ -396,7 +400,7 @@ test.describe('Windows terminal shell paste ownership', () => {
       await waitForTerminalOutput(orcaPage, `PASTE_COMPLETE_${runId}:MATCH`, 10_000, 12_000)
 
       const writes = (await readTerminalPtyWrites(electronApp)).join('')
-      expect(countOccurrences(writes, payload), 'WSL payload PTY write count').toBe(1)
+      expect(countOccurrences(writes, expectedText), 'WSL payload PTY write count').toBe(1)
     } finally {
       if (scriptStarted) {
         await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
@@ -437,7 +441,8 @@ test.describe('Windows terminal shell paste ownership', () => {
       `mixed-newline-before\r\nlf-line\ncrlf-line\r\n${sentinel}`
     ].join('\n')
     const scriptPath = path.join(testRepoPath, `.orca-paste-wsl-retention-${runId}.mjs`)
-    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, payload))
+    const expectedText = payload.replace(/\r?\n/g, '\r')
+    writeFileSync(scriptPath, pasteCollectScript(runId, sentinel, expectedText))
     let scriptStarted = false
 
     try {
@@ -457,7 +462,7 @@ test.describe('Windows terminal shell paste ownership', () => {
       await waitForTerminalOutput(orcaPage, `PASTE_COMPLETE_${runId}:MATCH`, 10_000, 12_000)
 
       const writes = (await readTerminalPtyWrites(electronApp)).join('')
-      expect(countOccurrences(writes, payload), 'retained WSL payload PTY write count').toBe(1)
+      expect(countOccurrences(writes, expectedText), 'retained WSL payload PTY write count').toBe(1)
     } finally {
       if (scriptStarted) {
         await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)


### PR DESCRIPTION
The Windows paste audit failed before large-paste collection because its duplicated repository setup relied on an immediate path-string match. Reuse the existing repository-ID setup helper, which handles concurrent refreshes and Windows path canonicalization.

The shell paste collectors also compared mixed clipboard newlines against the terminal byte stream, although terminal paste intentionally normalizes every newline to CR. Compare the exact normalized payload in both the collector and the single-write assertion; preserve all payload characters, metacharacters, and original timeouts.

Validation: Windows audit run 34022123477 reproduced the failures; the cmd collector received 304 bytes versus an expected 306 before CRLF normalization. Formatting and lint passed. Native Windows run 34022681884 passed all 12 targeted cases (large paste, PowerShell, cmd.exe, and Git Bash, three each); 9 repeated WSL/real-Codex opt-ins skipped. All PR checks and pullfrog passed. WSL remains an explicit coverage gap on runners without a distro.
