### PR TITLE
test: align Windows shell icons with project runtime ownership

### DIFF
--- a/tests/e2e/windows-terminal-env-icons.spec.ts
+++ b/tests/e2e/windows-terminal-env-icons.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from './helpers/orca-app'
+import { getFirstWslDistro, useWslRuntimeForActiveProject } from './helpers/wsl-golden-stub-agent'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
   execInTerminal,
@@ -27,7 +28,9 @@ test.describe('Windows terminal env and shell identity', () => {
     await waitForTerminalOutput(orcaPage, marker, 15_000)
   })
 
-  test('Windows tab icons stay pinned to the shell used at tab creation', async ({ orcaPage }) => {
+  test('native Windows tab icons stay pinned to the effective shell at tab creation', async ({
+    orcaPage
+  }) => {
     test.skip(process.platform !== 'win32', 'Windows shell icons only render on Windows')
 
     const tabIds = await orcaPage.evaluate(() => {
@@ -41,10 +44,11 @@ test.describe('Windows terminal env and shell identity', () => {
         throw new Error('No active worktree')
       }
 
+      // Native project ownership makes a global WSL shell fall back to PowerShell.
       store.setState({
         settings: { ...state.settings!, terminalWindowsShell: 'wsl.exe' }
       })
-      const wslTab = store.getState().createTab(worktreeId, undefined, undefined, {
+      const fallbackTab = store.getState().createTab(worktreeId, undefined, undefined, {
         activate: false
       })
 
@@ -55,33 +59,68 @@ test.describe('Windows terminal env and shell identity', () => {
         activate: false
       })
 
-      return { wslTabId: wslTab.id, cmdTabId: cmdTab.id }
+      return { fallbackTabId: fallbackTab.id, cmdTabId: cmdTab.id }
     })
 
-    const tabSnapshot = await orcaPage.evaluate(({ wslTabId, cmdTabId }) => {
+    const tabSnapshot = await orcaPage.evaluate(({ fallbackTabId, cmdTabId }) => {
       const state = window.__store!.getState()
       const tabs = Object.values(state.tabsByWorktree).flat()
       return {
-        wslShell: tabs.find((tab) => tab.id === wslTabId)?.shellOverride,
+        fallbackShell: tabs.find((tab) => tab.id === fallbackTabId)?.shellOverride,
         cmdShell: tabs.find((tab) => tab.id === cmdTabId)?.shellOverride
       }
     }, tabIds)
 
     expect(tabSnapshot).toEqual({
-      wslShell: 'wsl.exe',
+      fallbackShell: 'powershell.exe',
       cmdShell: 'cmd.exe'
     })
 
-    const wslTab = orcaPage.locator(
-      `[data-testid="sortable-tab"][data-tab-id="${tabIds.wslTabId}"]`
+    const fallbackTab = orcaPage.locator(
+      `[data-testid="sortable-tab"][data-tab-id="${tabIds.fallbackTabId}"]`
     )
     const cmdTab = orcaPage.locator(
       `[data-testid="sortable-tab"][data-tab-id="${tabIds.cmdTabId}"]`
     )
-    await expect(wslTab).toBeVisible()
+    await expect(fallbackTab).toBeVisible()
     await expect(cmdTab).toBeVisible()
 
-    await expect(wslTab.locator('[data-shell-icon]')).toHaveAttribute('data-shell-icon', 'wsl.exe')
+    await expect(fallbackTab.locator('[data-shell-icon]')).toHaveAttribute(
+      'data-shell-icon',
+      'powershell.exe'
+    )
     await expect(cmdTab.locator('[data-shell-icon]')).toHaveAttribute('data-shell-icon', 'cmd.exe')
+  })
+
+  test('WSL project tab icons retain runtime ownership across global shell changes', async ({
+    orcaPage
+  }) => {
+    test.skip(process.platform !== 'win32', 'WSL shell icons require Windows')
+    const distro = await getFirstWslDistro(orcaPage)
+    test.skip(!distro, 'WSL icon coverage requires an installed distro')
+    await useWslRuntimeForActiveProject(orcaPage, distro!)
+
+    const tabIds = await orcaPage.evaluate(async () => {
+      const store = window.__store!
+      const worktreeId = store.getState().activeWorktreeId!
+      const ids: string[] = []
+      for (const shell of ['powershell.exe', 'cmd.exe'] as const) {
+        await store.getState().updateSettings({ terminalWindowsShell: shell })
+        ids.push(
+          store.getState().createTab(worktreeId, undefined, undefined, { activate: false }).id
+        )
+      }
+      return ids
+    })
+    const shells = await orcaPage.evaluate((ids) => {
+      const tabs = Object.values(window.__store!.getState().tabsByWorktree).flat()
+      return ids.map((id) => tabs.find((tab) => tab.id === id)?.shellOverride)
+    }, tabIds)
+    expect(shells).toEqual(['wsl.exe', 'wsl.exe'])
+    for (const id of tabIds) {
+      const tab = orcaPage.locator(`[data-testid="sortable-tab"][data-tab-id="${id}"]`)
+      await expect(tab).toBeVisible()
+      await expect(tab.locator('[data-shell-icon]')).toHaveAttribute('data-shell-icon', 'wsl.exe')
+    }
   })
 })


### PR DESCRIPTION
## ELI5
The test now expects the shell that Windows projects actually use.

## What Changed
Assert native PowerShell fallback when the global shell is WSL, preserving cmd and icon lifetime assertions. Add a separate WSL-project case for ownership across global shell changes.

## Why
Native projects intentionally fall back to PowerShell; the previous WSL expectation contradicted that behavior.

## Linked Issue
Part of the user-requested test-deflaking audit; no dedicated issue for this discovered fixture mismatch.

## Visual Proof
N/A — test-only change; application rendering and behavior are unchanged.

## Testing
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Windows CI [34023338161](https://github.com/stablyai/orca/actions/runs/34023338161): three repeats, 6 passed and 3 skipped. All skips are the added WSL case because no distro is installed; WSL coverage remains unverified. Formatting and lint passed. PR CI covers static analysis, typecheck, build, units, and changed E2E specs. Rendered validation runs exclusively in CI at the user's request.

## AI Disclosure

## Review
Self-reviewed against the effective runtime selection contract. CodeRabbit found no actionable code comments; pullfrog is pending.

## Agent skill upstream boundary
- [x] Not applicable; no skill source changes.

## Notes
Windows-specific tests preserve explicit platform guards. No application, SSH execution, wire, mobile, or Git behavior changes. No retries or timeout increases.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
