### PR TITLE
test: exercise supported ConPTY keyboard protocol reset

### DIFF
--- a/tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js
+++ b/tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js
@@ -5,6 +5,7 @@ const EXIT_MARKER = 'GOLDEN_STUB_AGENT_EXITED'
 
 const ESC = '\x1b'
 const keyboardProtocolMode = process.argv.includes('--keyboard-protocol')
+const keyboardProtocolAgent = process.argv.includes('--grok') ? 'Grok' : 'Codex'
 // Both match the bytes after ESC, so the control character stays out of the
 // pattern: a CSI/SS3 introducer still missing its final byte, and a complete
 // CSI/SS3 sequence. Shift+Enter is matched before either is consulted.
@@ -20,7 +21,7 @@ function render() {
   const lines = composer.split('\n')
   const renderedComposer = lines.map((line, index) => `${index === 0 ? '> ' : '  '}${line}`)
   process.stdout.write(
-    `${keyboardProtocolMode ? '\x1b]0;\u280b Codex is thinking\x07\x1b[>1u' : '\x1b]0;Golden Stub Agent\x07'}${[
+    `${keyboardProtocolMode ? `\x1b]0;\u280b ${keyboardProtocolAgent} is thinking\x07\x1b[>1u` : '\x1b]0;Golden Stub Agent\x07'}${[
       '\x1b[H\x1b[2JGolden Stub Agent',
       `[${READY_MARKER}]`,
       '',
@@ -40,7 +41,7 @@ function exitCleanly() {
   if (process.stdin.isTTY) {
     process.stdin.setRawMode(false)
   }
-  const idleTitle = keyboardProtocolMode ? '\x1b]0;Codex\x07' : ''
+  const idleTitle = keyboardProtocolMode ? `\x1b]0;${keyboardProtocolAgent}\x07` : ''
   process.stdout.write(`${idleTitle}\x1b[?1049l[${EXIT_MARKER}]\r\n`, () => process.exit(0))
 }
 

--- a/tests/e2e/helpers/golden-stub-agent.ts
+++ b/tests/e2e/helpers/golden-stub-agent.ts
@@ -25,7 +25,7 @@ export function getGoldenStubAgentLaunchEnv(): NodeJS.ProcessEnv {
 export async function configureGoldenStubAgent(
   page: Page,
   options: {
-    agent?: (typeof GOLDEN_STUB_AGENTS)[number]['id']
+    agent?: (typeof GOLDEN_STUB_AGENTS)[number]['id'] | 'grok'
     agentArgs?: string
     /** Windows default shell the launch command must survive; ignored elsewhere. */
     windowsShell?: BuiltInWindowsTerminalShell

--- a/tests/e2e/terminal-windows-conpty-keyboard-reset.spec.ts
+++ b/tests/e2e/terminal-windows-conpty-keyboard-reset.spec.ts
@@ -54,13 +54,19 @@ test('resets standard keyboard bytes after a protocol-mode agent exits on ConPTY
   await waitForSessionReady(orcaPage)
   await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
-  await configureGoldenStubAgent(orcaPage, { agentArgs: '--keyboard-protocol' })
-  await launchGoldenStubAgentFromNewTab(orcaPage)
+  // Grok is the supported native ConPTY exception to Kitty protocol withholding.
+  await configureGoldenStubAgent(orcaPage, {
+    agent: 'grok',
+    agentArgs: '--keyboard-protocol --grok'
+  })
+  await launchGoldenStubAgentFromNewTab(orcaPage, /^Grok(?:\s|$)/i)
 
   const ptyId = await waitForActivePanePtyId(orcaPage)
   await expect.poll(() => getKittyKeyboardFlags(orcaPage), { timeout: 10_000 }).toBe(1)
 
   await clearTerminalPtyWriteLog(electronApp)
+  // Kitty flag 1 preserves plain Enter; modified Enter proves CSI-u input.
+  await orcaPage.keyboard.press('Shift+Enter')
   await orcaPage.keyboard.type('exit')
   await orcaPage.keyboard.press('Enter')
   await waitForTerminalOutput(orcaPage, GOLDEN_STUB_EXIT_MARKER, 15_000)
@@ -68,7 +74,8 @@ test('resets standard keyboard bytes after a protocol-mode agent exits on ConPTY
     .filter((entry) => entry.id === ptyId)
     .map((entry) => entry.data)
     .join('')
-  expect(protocolWrites.includes('\x1b[13u') || protocolWrites.includes('\x1b[13;1u')).toBe(true)
+  expect(protocolWrites).toContain('\x1b[13;2u')
+  expect(protocolWrites).toContain('\r')
   await expect.poll(() => getKittyKeyboardFlags(orcaPage), { timeout: 10_000 }).toBe(0)
 
   await clearTerminalPtyWriteLog(electronApp)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5
Use a supported Windows agent and a key that actually exercises the negotiated keyboard protocol.

## What Changed
The ConPTY reset test launches a Grok-labelled golden stub, verifies flags 1 and Shift+Enter CSI-u, then verifies exit resets flags to 0 and preserves all exact shell typing, arrows, Backspace, Enter, and paste assertions. The helper accepts Grok without expanding the shared golden-agent matrix; the stub defaults remain unchanged.

## Why
Native Windows intentionally withholds Kitty for Codex but permits Grok. Kitty flag 1 also intentionally preserves legacy plain Enter; modified Enter exercises CSI-u. The old fixture and plain-Enter expectation contradicted both contracts.

## Linked Issue
User-requested test-deflaking audit; no dedicated issue for these discovered fixture mismatches.

## Visual Proof
N/A — test-only changes with no application behavior changes.

## Testing
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Windows CI [34023805656](https://github.com/stablyai/orca/actions/runs/34023805656): 3 repeats passed, no skips. Formatting and lint passed. PR CI covers build, typecheck, units, static analysis, and changed E2E specs. Rendered tests run exclusively in CI at the user's request.

## AI Disclosure

## Review
Self-reviewed against native ConPTY policy and xterm Kitty encoding. Pullfrog required before merge.

## Agent skill upstream boundary
- [x] Not applicable; no skill source changes.

## Notes
Native Windows scope; no SSH execution, remote wire, application, or mobile changes. No retries or timeout increases. Existing exact post-exit byte assertions retained.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
