### PR TITLE
test: reject unsupported app-server in golden agent fixture

### DIFF
--- a/tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js
+++ b/tests/e2e/fixtures/golden-stub-agent/golden-stub-agent.js
@@ -3,6 +3,12 @@
 const READY_MARKER = 'GOLDEN_STUB_AGENT_READY'
 const EXIT_MARKER = 'GOLDEN_STUB_AGENT_EXITED'
 
+// The interactive fixture does not implement Codex's JSONL app-server API.
+if (process.argv[2] === 'app-server') {
+  process.stderr.write("error: unrecognized subcommand 'app-server'\n")
+  process.exit(2)
+}
+
 const ESC = '\x1b'
 const keyboardProtocolMode = process.argv.includes('--keyboard-protocol')
 const keyboardProtocolAgent = process.argv.includes('--grok') ? 'Grok' : 'Codex'


### PR DESCRIPTION
## ELI5
The fake agent should reject a server command it cannot implement instead of opening an interactive terminal.

## What Changed
Return exit code 2 and an explicit unsupported-subcommand error for `app-server` before starting the golden stub TUI. Other invocations retain their existing behavior.

## Why
Codex hook preparation probes `codex app-server`. The golden fixture previously entered its interactive input loop for that invocation, causing trust-session timeouts and repeated native cmd.exe launch failures. Explicit rejection exercises the existing unsupported-capability fallback.

## Linked Issue
User-requested test-deflaking audit; no dedicated issue for this discovered fixture defect.

## Visual Proof
N/A — fixture-only change; no application rendering or behavior changes.

## Testing
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Windows CI [34024213794](https://github.com/stablyai/orca/actions/runs/34024213794): 15 native launch cases passed, including cmd.exe three times; 3 WSL skips. The run failed afterward on global teardown EPERM, so this is not a fully green run. A second matrix [34024816213](https://github.com/stablyai/orca/actions/runs/34024816213) also passed all 15 native cases and failed root cleanup. Isolated cmd validation [34025447299](https://github.com/stablyai/orca/actions/runs/34025447299) passed with clean teardown. Full-matrix cleanup remains a separate tracked investigation. Direct Node fixture invocation verified immediate exit 2, exact unsupported error, and no TUI stdout. Formatting and lint passed. PR CI covers build, typecheck, units, and changed E2E specs. Rendered tests run exclusively in CI at the user's request.

## AI Disclosure

## Review
Self-reviewed against Codex capability error classification. All PR checks and pullfrog passed.

## Agent skill upstream boundary
- [x] Not applicable; no skill source changes.

## Notes
Shared JavaScript fixture preserves POSIX and Windows entry points. No production, SSH execution, wire, or mobile changes. No assertion weakening, retries, or timeout increases.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
