### PR TITLE
perf(store): keep the repo list's identity through workspace hydration

### DIFF
--- a/src/renderer/src/store/terminals/workspace-terminal-placeholders.test.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-placeholders.test.ts
@@ -3,6 +3,7 @@ import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../../../shared/constants'
 import { buildRuntimeSessionPlaceholders } from './workspace-terminal-placeholders'
+import { addHydratedSshWorktreePlaceholders } from './workspace-terminal-ssh-placeholders'
 
 const repo: Repo = {
   id: 'repo-1',
@@ -79,5 +80,42 @@ describe('buildRuntimeSessionPlaceholders', () => {
     expect(result.repos.map((entry) => entry.id)).toEqual(['repo-1', 'repo-2'])
     // The caller's array must not be mutated in place.
     expect(repos).toHaveLength(1)
+  })
+})
+
+describe('addHydratedSshWorktreePlaceholders', () => {
+  it('returns the original map when no SSH placeholder is needed', () => {
+    const worktreesByRepo = { 'repo-1': [worktree] }
+
+    const result = addHydratedSshWorktreePlaceholders([repo], worktreesByRepo, {
+      'repo-1::/repos/one': []
+    })
+
+    expect(result).toBe(worktreesByRepo)
+  })
+
+  it('returns the original map when the SSH worktree is already present', () => {
+    const sshRepo: Repo = { ...repo, id: 'ssh-repo', connectionId: 'ssh-1' }
+    const sshWorktree: Worktree = { ...worktree, id: 'ssh-repo::/repos/ssh', repoId: 'ssh-repo' }
+    const worktreesByRepo = { 'ssh-repo': [sshWorktree] }
+
+    const result = addHydratedSshWorktreePlaceholders([sshRepo], worktreesByRepo, {
+      'ssh-repo::/repos/ssh': []
+    })
+
+    expect(result).toBe(worktreesByRepo)
+  })
+
+  it('still adds a placeholder for an SSH worktree with no row, without mutating the caller', () => {
+    const sshRepo: Repo = { ...repo, id: 'ssh-repo', connectionId: 'ssh-1' }
+    const worktreesByRepo = { 'ssh-repo': [] as Worktree[] }
+
+    const result = addHydratedSshWorktreePlaceholders([sshRepo], worktreesByRepo, {
+      'ssh-repo::/repos/ssh': []
+    })
+
+    expect(result).not.toBe(worktreesByRepo)
+    expect(result['ssh-repo'].map((entry) => entry.id)).toEqual(['ssh-repo::/repos/ssh'])
+    expect(worktreesByRepo['ssh-repo']).toHaveLength(0)
   })
 })

--- a/src/renderer/src/store/terminals/workspace-terminal-placeholders.test.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-placeholders.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { DEFAULT_REPO_BADGE_COLOR } from '../../../../shared/constants'
+import { buildRuntimeSessionPlaceholders } from './workspace-terminal-placeholders'
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repos/one',
+  displayName: 'one',
+  badgeColor: DEFAULT_REPO_BADGE_COLOR,
+  addedAt: 0,
+  connectionId: null,
+  executionHostId: 'local'
+}
+
+const worktree: Worktree = {
+  id: 'repo-1::/repos/one',
+  repoId: 'repo-1',
+  hostId: 'local',
+  displayName: 'main',
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  linkedGitLabMR: null,
+  linkedGitLabIssue: null,
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 0,
+  path: '/repos/one',
+  head: '',
+  branch: '',
+  isBare: false,
+  isMainWorktree: true
+}
+
+describe('buildRuntimeSessionPlaceholders', () => {
+  it('returns the original repos array when no placeholder repo is needed', () => {
+    const repos = [repo]
+    const worktreesByRepo = { 'repo-1': [worktree] }
+
+    const result = buildRuntimeSessionPlaceholders({
+      repos,
+      runtimeHostIdByWorkspaceSessionKey: {},
+      worktreesByRepo
+    })
+
+    // Hydration writes these straight to the store; a fresh array would rerender
+    // every component selecting the whole repo list for no data change.
+    expect(result.repos).toBe(repos)
+    expect(result.worktreesByRepo).toBe(worktreesByRepo)
+  })
+
+  it('keeps the original repos array when the session only references known repos', () => {
+    const repos = [repo]
+
+    const result = buildRuntimeSessionPlaceholders({
+      repos,
+      runtimeHostIdByWorkspaceSessionKey: { 'repo-1::/repos/one': 'runtime:host-1' },
+      worktreesByRepo: { 'repo-1': [worktree] }
+    })
+
+    expect(result.repos).toBe(repos)
+  })
+
+  it('still appends a placeholder repo for an unknown runtime workspace', () => {
+    const repos = [repo]
+
+    const result = buildRuntimeSessionPlaceholders({
+      repos,
+      runtimeHostIdByWorkspaceSessionKey: { 'repo-2::/repos/two': 'runtime:host-1' },
+      worktreesByRepo: { 'repo-1': [worktree] }
+    })
+
+    expect(result.repos).not.toBe(repos)
+    expect(result.repos.map((entry) => entry.id)).toEqual(['repo-1', 'repo-2'])
+    // The caller's array must not be mutated in place.
+    expect(repos).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/store/terminals/workspace-terminal-placeholders.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-placeholders.ts
@@ -20,10 +20,15 @@ export function buildRuntimeSessionPlaceholders({
   runtimeHostIdByWorkspaceSessionKey: Record<string, ExecutionHostId>
   worktreesByRepo: Record<string, Worktree[]>
 }): {
-  repos: Repo[]
+  repos: readonly Repo[]
   worktreesByRepo: Record<string, Worktree[]>
 } {
-  let nextRepos = repos.slice()
+  // Why not `repos.slice()`: hydration writes this array straight back to the store, and
+  // sessions that add no placeholder repo are the common case. Copying unconditionally
+  // gave `repos` a new identity on every workspace hydration, rerendering every component
+  // that selects the whole array. Appends below already build a new array, as
+  // nextWorktreesByRepo does for its own copy-on-write.
+  let nextRepos: readonly Repo[] = repos
   let nextWorktreesByRepo = worktreesByRepo
   for (const workspaceSessionKey of Object.keys(runtimeHostIdByWorkspaceSessionKey)) {
     const hostId = runtimeHostIdByWorkspaceSessionKey[workspaceSessionKey]

--- a/src/renderer/src/store/terminals/workspace-terminal-placeholders.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-placeholders.ts
@@ -23,11 +23,8 @@ export function buildRuntimeSessionPlaceholders({
   repos: readonly Repo[]
   worktreesByRepo: Record<string, Worktree[]>
 } {
-  // Why not `repos.slice()`: hydration writes this array straight back to the store, and
-  // sessions that add no placeholder repo are the common case. Copying unconditionally
-  // gave `repos` a new identity on every workspace hydration, rerendering every component
-  // that selects the whole array. Appends below already build a new array, as
-  // nextWorktreesByRepo does for its own copy-on-write.
+  // Why copy-on-write: hydration writes both straight to the store, and an unconditional copy
+  // rerendered every whole-array/map selector on every hydration with no data change.
   let nextRepos: readonly Repo[] = repos
   let nextWorktreesByRepo = worktreesByRepo
   for (const workspaceSessionKey of Object.keys(runtimeHostIdByWorkspaceSessionKey)) {

--- a/src/renderer/src/store/terminals/workspace-terminal-ssh-placeholders.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-ssh-placeholders.ts
@@ -12,7 +12,11 @@ export function addHydratedSshWorktreePlaceholders(
   tabsByWorktree: Record<string, TerminalTab[]>
 ): Record<string, Worktree[]> {
   const sshRepoIds = new Set(repos.filter((repo) => repo.connectionId).map((repo) => repo.id))
-  const worktreesByRepo = { ...sourceWorktreesByRepo }
+  // Why copy-on-write: hydration writes this map straight to the store, and a session
+  // that needs no SSH placeholder is the common case. Copying unconditionally gave
+  // worktreesByRepo a new identity on every hydration, rerendering the sidebar and
+  // everything else selecting the whole map for no data change.
+  let worktreesByRepo = sourceWorktreesByRepo
   for (const worktreeId of Object.keys(tabsByWorktree)) {
     const repoId = getRepoIdFromWorktreeId(worktreeId)
     if (!sshRepoIds.has(repoId)) {
@@ -44,6 +48,9 @@ export function addHydratedSshWorktreePlaceholders(
       branch: '',
       isBare: false,
       isMainWorktree: false
+    }
+    if (worktreesByRepo === sourceWorktreesByRepo) {
+      worktreesByRepo = { ...sourceWorktreesByRepo }
     }
     worktreesByRepo[repoId] = [...(worktreesByRepo[repoId] ?? []), placeholder]
   }

--- a/src/renderer/src/store/terminals/workspace-terminal-ssh-placeholders.ts
+++ b/src/renderer/src/store/terminals/workspace-terminal-ssh-placeholders.ts
@@ -12,10 +12,8 @@ export function addHydratedSshWorktreePlaceholders(
   tabsByWorktree: Record<string, TerminalTab[]>
 ): Record<string, Worktree[]> {
   const sshRepoIds = new Set(repos.filter((repo) => repo.connectionId).map((repo) => repo.id))
-  // Why copy-on-write: hydration writes this map straight to the store, and a session
-  // that needs no SSH placeholder is the common case. Copying unconditionally gave
-  // worktreesByRepo a new identity on every hydration, rerendering the sidebar and
-  // everything else selecting the whole map for no data change.
+  // Why copy-on-write: hydration writes this map straight to the store; an unconditional copy
+  // rerendered every whole-map selector on every hydration with no data change.
   let worktreesByRepo = sourceWorktreesByRepo
   for (const worktreeId of Object.keys(tabsByWorktree)) {
     const repoId = getRepoIdFromWorktreeId(worktreeId)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## What

`buildRuntimeSessionPlaceholders` opened with `repos.slice()`, so **every workspace session hydration handed the store a brand-new `repos` array** — including the common case where the session referenced no unknown runtime workspace and the contents were byte-for-byte identical.

`s.repos` is selected *whole* at 46 call sites, so each hydration invalidated all of them and rerendered for no data change.

## Why it's free

- The appends below already build a new array (`nextRepos = [...nextRepos, placeholder]`) rather than mutating, so nothing depended on the copy.
- The sibling `nextWorktreesByRepo` **in the same function** was already copy-on-write; this just gives `repos` the same treatment.
- No consumer of the returned array mutates it in place (checked `degraded-repo-worktree-validity`, `workspace-terminal-reconnect-plan`, `workspace-terminal-ssh-placeholders`).
- `AppState['repos']` is already `readonly Repo[]`, so the narrowed return type needed no ripple.

Identical values, identical rendered output, no timing change.

## How it was found

A runtime probe wrapped around the store counts writes that replace a field's reference while its value stays deep-equal, with write-site attribution. Run across the store test suite, `workspace-terminal-hydration.ts:42` came back as the top churn site for `repos`.

## Verification

- New `workspace-terminal-placeholders.test.ts` asserts the array reference survives when no placeholder is needed, and still appends (without mutating the caller's array) when one is. **Fails without the fix**, passes with it.
- `pnpm tc:web` clean.
- Full renderer suite: 29,710 passed.

---

## ELI5

When the app restores your workspace, it checks whether the saved session mentions any repos it doesn't know about yet, and adds placeholders for them.

Almost always there are none to add — but it handed back a **fresh copy** of the repo list regardless. 47 different places watch that list, so all of them redrew every time you restored a workspace, for a list that hadn't changed.

Now it hands back the original list unless it genuinely added something. Same fix, twice: once for the repo list, once for the worktree list next to it.
