### PR TITLE
perf(store): detect Zustand rerender churn the current audit cannot see

### DIFF
--- a/config/oxlint-performance-audit.json
+++ b/config/oxlint-performance-audit.json
@@ -28,6 +28,7 @@
     "app-store-performance/require-selector": "warn",
     "app-store-performance/no-identity-selector": "warn",
     "app-store-performance/no-fresh-selector-result": "warn",
+    "app-store-performance/no-nested-fresh-under-shallow": "warn",
     "quadratic-buffer-concat/no-loop-carried-concat": "warn",
     "sort-comparator-performance/no-repeated-collator": "warn"
   },

--- a/config/oxlint-plugins/app-store-performance.mjs
+++ b/config/oxlint-plugins/app-store-performance.mjs
@@ -8,6 +8,19 @@ const ALLOCATING_METHODS = new Set([
   'toSpliced',
   'with'
 ])
+const ALLOCATING_OBJECT_STATICS = new Set([
+  'assign',
+  'create',
+  'entries',
+  'fromEntries',
+  'keys',
+  'values'
+])
+const FUNCTION_NODES = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression'
+])
 
 function identifierName(node) {
   return node?.type === 'Identifier' ? node.name : null
@@ -25,8 +38,12 @@ function propertyName(node) {
     : null
 }
 
+function functionNode(node) {
+  return FUNCTION_NODES.has(node?.type) ? node : null
+}
+
 function returnedExpressions(selector) {
-  if (selector?.type !== 'ArrowFunctionExpression' && selector?.type !== 'FunctionExpression') {
+  if (!functionNode(selector)) {
     return []
   }
   if (selector.body.type !== 'BlockStatement') {
@@ -37,10 +54,7 @@ function returnedExpressions(selector) {
     if (!node || typeof node !== 'object') {
       return
     }
-    if (
-      node !== selector.body &&
-      ['ArrowFunctionExpression', 'FunctionDeclaration', 'FunctionExpression'].includes(node.type)
-    ) {
+    if (node !== selector.body && FUNCTION_NODES.has(node.type)) {
       return
     }
     if (node.type === 'ReturnStatement') {
@@ -76,10 +90,7 @@ function unwrapShallowSelector(selector, shallowHooks) {
 }
 
 function isIdentitySelector(selector) {
-  if (selector?.type !== 'ArrowFunctionExpression' && selector?.type !== 'FunctionExpression') {
-    return false
-  }
-  const parameter = selector.params[0]
+  const parameter = functionNode(selector)?.params[0]
   if (parameter?.type !== 'Identifier') {
     return false
   }
@@ -88,14 +99,23 @@ function isIdentitySelector(selector) {
   )
 }
 
-function isAllocatingExpression(expression) {
-  if (expression?.type === 'ConditionalExpression') {
-    return (
-      isAllocatingExpression(expression.consequent) || isAllocatingExpression(expression.alternate)
-    )
-  }
-  if (expression?.type === 'LogicalExpression') {
-    return isAllocatingExpression(expression.left) || isAllocatingExpression(expression.right)
+/**
+ * `everyBranch` decides how a conditional counts. An inline selector is flagged
+ * when ANY branch allocates; a helper the selector delegates to must allocate on
+ * EVERY branch, so the `cache.get(k) ?? build(state)` identity-caching shape is
+ * not a false positive.
+ */
+function allocates(expression, everyBranch) {
+  const branches =
+    expression?.type === 'ConditionalExpression'
+      ? [expression.consequent, expression.alternate]
+      : expression?.type === 'LogicalExpression'
+        ? [expression.left, expression.right]
+        : null
+  if (branches) {
+    return everyBranch
+      ? branches.every((branch) => allocates(branch, true))
+      : branches.some((branch) => allocates(branch, false))
   }
   if (
     expression?.type === 'ArrayExpression' ||
@@ -107,23 +127,16 @@ function isAllocatingExpression(expression) {
   if (expression?.type !== 'CallExpression') {
     return false
   }
-  const method = propertyName(expression.callee)
-  if (method && ALLOCATING_METHODS.has(method)) {
-    return true
-  }
   const callee = expression.callee
+  const method = propertyName(callee)
   return (
-    callee.type === 'MemberExpression' &&
-    identifierName(callee.object) === 'Object' &&
-    ['assign', 'create', 'entries', 'fromEntries', 'keys', 'values'].includes(propertyName(callee))
+    ALLOCATING_METHODS.has(method) ||
+    (identifierName(callee.object) === 'Object' && ALLOCATING_OBJECT_STATICS.has(method))
   )
 }
 
-function importedLocalName(specifier, importedName) {
-  if (specifier.type !== 'ImportSpecifier' || identifierName(specifier.imported) !== importedName) {
-    return null
-  }
-  return identifierName(specifier.local)
+function isAllocatingExpression(expression) {
+  return allocates(expression, false)
 }
 
 // Project-local zustand hooks follow the use<Name>Store convention; React's
@@ -135,29 +148,27 @@ function isLocalModuleSource(source) {
   return typeof source === 'string' && (source.startsWith('.') || source.startsWith('@/'))
 }
 
-function isStoreHookName(name) {
-  return typeof name === 'string' && STORE_HOOK_NAME.test(name) && !NON_STORE_HOOKS.has(name)
-}
-
-function selectorFunction(node) {
-  return node?.type === 'ArrowFunctionExpression' || node?.type === 'FunctionExpression'
-    ? node
-    : null
+/** Module scope only: a component-local helper must not shadow a same-named import. */
+function isModuleScope(node) {
+  const parent = node.parent
+  return (
+    parent?.type === 'Program' ||
+    (parent?.type === 'ExportNamedDeclaration' && parent.parent?.type === 'Program')
+  )
 }
 
 /** Records module-scope `const selectX = (state) => ...` so identifier selectors resolve. */
 function recordNamedSelector(node, state) {
-  if (node.type === 'FunctionDeclaration') {
-    const name = identifierName(node.id)
-    if (name) {
-      state.namedSelectors.set(name, node)
-    }
+  if (!isModuleScope(node)) {
     return
   }
-  for (const declarator of node.declarations ?? []) {
-    const name = identifierName(declarator.id)
-    const initializer = selectorFunction(declarator.init)
-    if (name && initializer) {
+  const declared =
+    node.type === 'FunctionDeclaration'
+      ? [[node.id, node]]
+      : node.declarations.map((declarator) => [declarator.id, declarator.init])
+  for (const [id, initializer] of declared) {
+    const name = identifierName(id)
+    if (name && functionNode(initializer)) {
       state.namedSelectors.set(name, initializer)
     }
   }
@@ -165,51 +176,23 @@ function recordNamedSelector(node, state) {
 
 /** Inline function, or a module-scope selector referenced by name. */
 function resolveSelector(argument, state) {
-  const inline = selectorFunction(argument)
-  if (inline) {
-    return inline
-  }
-  const name = identifierName(argument)
-  return name ? (state.namedSelectors.get(name) ?? null) : null
-}
-
-/**
- * Allocation that happens on EVERY call, used when following a selector into a
- * helper. Deliberately stricter than isAllocatingExpression: a helper that returns
- * a cached reference on one branch and builds a fresh one on another is the normal
- * identity-caching shape, and flagging it would be a false positive.
- */
-function alwaysAllocates(expression) {
-  if (expression?.type === 'ConditionalExpression') {
-    return alwaysAllocates(expression.consequent) && alwaysAllocates(expression.alternate)
-  }
-  if (expression?.type === 'LogicalExpression') {
-    return alwaysAllocates(expression.left) && alwaysAllocates(expression.right)
-  }
-  return (
-    expression?.type === 'ArrayExpression' ||
-    expression?.type === 'ObjectExpression' ||
-    expression?.type === 'NewExpression' ||
-    (expression?.type === 'CallExpression' &&
-      ALLOCATING_METHODS.has(propertyName(expression.callee) ?? ''))
-  )
+  return functionNode(argument) ?? state.namedSelectors.get(identifierName(argument)) ?? null
 }
 
 /**
  * One hop: a selector that delegates to a module-scope helper is the idiomatic
  * shape here, and neither the inline-body check nor a reviewer reading the call
- * site can see what that helper returns.
+ * site can see what that helper returns. An unresolvable helper is left alone.
  */
 function expandThroughNamedHelper(expression, state) {
-  if (expression?.type !== 'CallExpression') {
-    return [expression]
-  }
-  const helper = state.namedSelectors.get(identifierName(expression.callee) ?? '')
-  if (!helper) {
-    return [expression]
-  }
-  const returned = returnedExpressions(helper)
-  return returned.length > 0 && returned.every(alwaysAllocates) ? returned : [expression]
+  const helper =
+    expression?.type === 'CallExpression'
+      ? state.namedSelectors.get(identifierName(expression.callee))
+      : undefined
+  const returned = helper ? returnedExpressions(helper) : []
+  return returned.length > 0 && returned.every((entry) => allocates(entry, true))
+    ? returned
+    : [expression]
 }
 
 function createRuleState() {
@@ -222,32 +205,27 @@ function createRuleState() {
 }
 
 function recordImports(node, state) {
-  if (node.source?.value === 'zustand/react/shallow') {
-    for (const specifier of node.specifiers) {
-      const localName = importedLocalName(specifier, 'useShallow')
-      if (localName) {
-        state.shallowHooks.add(localName)
-      }
-    }
-  }
-  for (const specifier of node.specifiers) {
-    const localName = importedLocalName(specifier, 'useAppStore')
-    if (localName) {
-      state.appStoreHooks.add(localName)
-    }
-  }
-  if (!isLocalModuleSource(node.source?.value)) {
-    return
-  }
+  const source = node.source?.value
   for (const specifier of node.specifiers) {
     if (specifier.type !== 'ImportSpecifier') {
       continue
     }
-    if (isStoreHookName(identifierName(specifier.imported))) {
-      const localName = identifierName(specifier.local)
-      if (localName) {
-        state.appStoreHooks.add(localName)
-      }
+    const imported = identifierName(specifier.imported)
+    const localName = identifierName(specifier.local)
+    if (!imported || !localName) {
+      continue
+    }
+    if (source === 'zustand/react/shallow' && imported === 'useShallow') {
+      state.shallowHooks.add(localName)
+    }
+    // useAppStore is the app store wherever it is re-exported from; sibling
+    // stores are trusted by naming convention only when they come from this codebase.
+    if (
+      STORE_HOOK_NAME.test(imported) &&
+      !NON_STORE_HOOKS.has(imported) &&
+      (imported === 'useAppStore' || isLocalModuleSource(source))
+    ) {
+      state.appStoreHooks.add(localName)
     }
   }
 }
@@ -307,9 +285,7 @@ function deferredSelectorRule(inspect) {
         )
         const report = inspect({
           selector: resolveSelector(argument, state),
-          argument,
           shallow,
-          node,
           state
         })
         if (report) {

--- a/config/oxlint-plugins/app-store-performance.mjs
+++ b/config/oxlint-plugins/app-store-performance.mjs
@@ -126,10 +126,59 @@ function importedLocalName(specifier, importedName) {
   return identifierName(specifier.local)
 }
 
+// Project-local zustand hooks follow the use<Name>Store convention; React's
+// useSyncExternalStore matches that shape but is not a store subscription.
+const STORE_HOOK_NAME = /^use[A-Z][A-Za-z0-9]*Store$/
+const NON_STORE_HOOKS = new Set(['useSyncExternalStore'])
+
+function isLocalModuleSource(source) {
+  return typeof source === 'string' && (source.startsWith('.') || source.startsWith('@/'))
+}
+
+function isStoreHookName(name) {
+  return typeof name === 'string' && STORE_HOOK_NAME.test(name) && !NON_STORE_HOOKS.has(name)
+}
+
+function selectorFunction(node) {
+  return node?.type === 'ArrowFunctionExpression' || node?.type === 'FunctionExpression'
+    ? node
+    : null
+}
+
+/** Records module-scope `const selectX = (state) => ...` so identifier selectors resolve. */
+function recordNamedSelector(node, state) {
+  if (node.type === 'FunctionDeclaration') {
+    const name = identifierName(node.id)
+    if (name) {
+      state.namedSelectors.set(name, node)
+    }
+    return
+  }
+  for (const declarator of node.declarations ?? []) {
+    const name = identifierName(declarator.id)
+    const initializer = selectorFunction(declarator.init)
+    if (name && initializer) {
+      state.namedSelectors.set(name, initializer)
+    }
+  }
+}
+
+/** Inline function, or a module-scope selector referenced by name. */
+function resolveSelector(argument, state) {
+  const inline = selectorFunction(argument)
+  if (inline) {
+    return inline
+  }
+  const name = identifierName(argument)
+  return name ? (state.namedSelectors.get(name) ?? null) : null
+}
+
 function createRuleState() {
   return {
     appStoreHooks: new Set(),
-    shallowHooks: new Set()
+    shallowHooks: new Set(),
+    namedSelectors: new Map(),
+    deferredCalls: []
   }
 }
 
@@ -146,6 +195,20 @@ function recordImports(node, state) {
     const localName = importedLocalName(specifier, 'useAppStore')
     if (localName) {
       state.appStoreHooks.add(localName)
+    }
+  }
+  if (!isLocalModuleSource(node.source?.value)) {
+    return
+  }
+  for (const specifier of node.specifiers) {
+    if (specifier.type !== 'ImportSpecifier') {
+      continue
+    }
+    if (isStoreHookName(identifierName(specifier.imported))) {
+      const localName = identifierName(specifier.local)
+      if (localName) {
+        state.appStoreHooks.add(localName)
+      }
     }
   }
 }
@@ -176,52 +239,104 @@ function requireSelectorRule() {
   }
 }
 
-function noIdentitySelectorRule() {
+/**
+ * Selector arguments are collected during traversal and judged at Program:exit so a
+ * selector hoisted below its call site still resolves.
+ */
+function deferredSelectorRule(inspect) {
   const state = createRuleState()
   return {
     ImportDeclaration(node) {
       recordImports(node, state)
     },
+    FunctionDeclaration(node) {
+      recordNamedSelector(node, state)
+    },
+    VariableDeclaration(node) {
+      recordNamedSelector(node, state)
+    },
     CallExpression(node) {
-      if (!isAppStoreCall(node, state)) {
-        return
+      if (isAppStoreCall(node, state)) {
+        state.deferredCalls.push(node)
       }
-      const { selector } = unwrapShallowSelector(node.arguments[0], state.shallowHooks)
-      if (isIdentitySelector(selector)) {
-        this.report({
-          node: selector,
-          message:
-            'Select the smallest required fields instead of subscribing to the entire app store.'
+    },
+    'Program:exit'() {
+      for (const node of state.deferredCalls) {
+        const { selector: argument, shallow } = unwrapShallowSelector(
+          node.arguments[0],
+          state.shallowHooks
+        )
+        const report = inspect({
+          selector: resolveSelector(argument, state),
+          argument,
+          shallow,
+          node
         })
+        if (report) {
+          this.report(report)
+        }
       }
     }
   }
 }
 
+function noIdentitySelectorRule() {
+  return deferredSelectorRule(({ selector }) =>
+    isIdentitySelector(selector)
+      ? {
+          node: selector,
+          message:
+            'Select the smallest required fields instead of subscribing to the entire app store.'
+        }
+      : null
+  )
+}
+
 function noFreshSelectorResultRule() {
-  const state = createRuleState()
-  return {
-    ImportDeclaration(node) {
-      recordImports(node, state)
-    },
-    CallExpression(node) {
-      if (!isAppStoreCall(node, state)) {
-        return
-      }
-      const { selector, shallow } = unwrapShallowSelector(node.arguments[0], state.shallowHooks)
-      if (shallow) {
-        return
-      }
-      const freshResult = returnedExpressions(selector).find(isAllocatingExpression)
-      if (freshResult) {
-        this.report({
+  return deferredSelectorRule(({ selector, shallow }) => {
+    if (shallow || !selector) {
+      return null
+    }
+    const freshResult = returnedExpressions(selector).find(isAllocatingExpression)
+    return freshResult
+      ? {
           node: freshResult,
           message:
             'This selector returns a fresh reference on every store write; select a stable field, cache the result, or use useShallow.'
-        })
-      }
-    }
+        }
+      : null
+  })
+}
+
+/** useShallow compares one level deep, so a fresh reference nested inside its result never matches. */
+function nestedFreshValues(expression) {
+  if (expression?.type === 'ObjectExpression') {
+    return expression.properties
+      .map((property) => (property.type === 'Property' ? property.value : null))
+      .filter(Boolean)
   }
+  if (expression?.type === 'ArrayExpression') {
+    return expression.elements.filter(Boolean)
+  }
+  return []
+}
+
+function noNestedFreshUnderShallowRule() {
+  return deferredSelectorRule(({ selector, shallow }) => {
+    if (!shallow || !selector) {
+      return null
+    }
+    const nestedFresh = returnedExpressions(selector)
+      .flatMap(nestedFreshValues)
+      .find(isAllocatingExpression)
+    return nestedFresh
+      ? {
+          node: nestedFresh,
+          message:
+            'useShallow compares only one level deep, so this nested fresh reference changes on every store write and defeats the memo; project the primitives the component actually renders.'
+        }
+      : null
+  })
 }
 
 function bindContext(createVisitors) {
@@ -239,6 +354,7 @@ export default {
   rules: {
     'require-selector': { create: bindContext(requireSelectorRule) },
     'no-identity-selector': { create: bindContext(noIdentitySelectorRule) },
-    'no-fresh-selector-result': { create: bindContext(noFreshSelectorResultRule) }
+    'no-fresh-selector-result': { create: bindContext(noFreshSelectorResultRule) },
+    'no-nested-fresh-under-shallow': { create: bindContext(noNestedFreshUnderShallowRule) }
   }
 }

--- a/config/oxlint-plugins/app-store-performance.mjs
+++ b/config/oxlint-plugins/app-store-performance.mjs
@@ -173,6 +173,45 @@ function resolveSelector(argument, state) {
   return name ? (state.namedSelectors.get(name) ?? null) : null
 }
 
+/**
+ * Allocation that happens on EVERY call, used when following a selector into a
+ * helper. Deliberately stricter than isAllocatingExpression: a helper that returns
+ * a cached reference on one branch and builds a fresh one on another is the normal
+ * identity-caching shape, and flagging it would be a false positive.
+ */
+function alwaysAllocates(expression) {
+  if (expression?.type === 'ConditionalExpression') {
+    return alwaysAllocates(expression.consequent) && alwaysAllocates(expression.alternate)
+  }
+  if (expression?.type === 'LogicalExpression') {
+    return alwaysAllocates(expression.left) && alwaysAllocates(expression.right)
+  }
+  return (
+    expression?.type === 'ArrayExpression' ||
+    expression?.type === 'ObjectExpression' ||
+    expression?.type === 'NewExpression' ||
+    (expression?.type === 'CallExpression' &&
+      ALLOCATING_METHODS.has(propertyName(expression.callee) ?? ''))
+  )
+}
+
+/**
+ * One hop: a selector that delegates to a module-scope helper is the idiomatic
+ * shape here, and neither the inline-body check nor a reviewer reading the call
+ * site can see what that helper returns.
+ */
+function expandThroughNamedHelper(expression, state) {
+  if (expression?.type !== 'CallExpression') {
+    return [expression]
+  }
+  const helper = state.namedSelectors.get(identifierName(expression.callee) ?? '')
+  if (!helper) {
+    return [expression]
+  }
+  const returned = returnedExpressions(helper)
+  return returned.length > 0 && returned.every(alwaysAllocates) ? returned : [expression]
+}
+
 function createRuleState() {
   return {
     appStoreHooks: new Set(),
@@ -270,7 +309,8 @@ function deferredSelectorRule(inspect) {
           selector: resolveSelector(argument, state),
           argument,
           shallow,
-          node
+          node,
+          state
         })
         if (report) {
           this.report(report)
@@ -293,11 +333,13 @@ function noIdentitySelectorRule() {
 }
 
 function noFreshSelectorResultRule() {
-  return deferredSelectorRule(({ selector, shallow }) => {
+  return deferredSelectorRule(({ selector, shallow, state }) => {
     if (shallow || !selector) {
       return null
     }
-    const freshResult = returnedExpressions(selector).find(isAllocatingExpression)
+    const freshResult = returnedExpressions(selector)
+      .flatMap((expression) => expandThroughNamedHelper(expression, state))
+      .find(isAllocatingExpression)
     return freshResult
       ? {
           node: freshResult,
@@ -322,12 +364,14 @@ function nestedFreshValues(expression) {
 }
 
 function noNestedFreshUnderShallowRule() {
-  return deferredSelectorRule(({ selector, shallow }) => {
+  return deferredSelectorRule(({ selector, shallow, state }) => {
     if (!shallow || !selector) {
       return null
     }
     const nestedFresh = returnedExpressions(selector)
+      .flatMap((expression) => expandThroughNamedHelper(expression, state))
       .flatMap(nestedFreshValues)
+      .flatMap((expression) => expandThroughNamedHelper(expression, state))
       .find(isAllocatingExpression)
     return nestedFresh
       ? {

--- a/config/scripts/app-store-performance-plugin.test.mjs
+++ b/config/scripts/app-store-performance-plugin.test.mjs
@@ -97,4 +97,34 @@ describe('app store performance Oxlint plugin', () => {
       'app-store-performance(no-nested-fresh-under-shallow)'
     ])
   })
+
+  it('follows a selector one hop into a module-scope helper', () => {
+    const diagnostics = lintSource(`
+      import { useAppStore } from '@/store'
+      import { useShallow } from 'zustand/react/shallow'
+      const buildRows = (state) => state.rows.map((row) => row.id)
+      const Delegating = () => useAppStore((state) => buildRows(state))
+      const NestedDelegating = () => useAppStore(useShallow((state) => ({ ids: buildRows(state) })))
+    `)
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'app-store-performance(no-fresh-selector-result)',
+      'app-store-performance(no-nested-fresh-under-shallow)'
+    ])
+  })
+
+  it('does not flag a helper that returns a cached reference on some branch', () => {
+    const diagnostics = lintSource(`
+      import { useAppStore } from '@/store'
+      import { useShallow } from 'zustand/react/shallow'
+      // The identity-caching shape: fresh only on a miss, cached otherwise.
+      const selectCachedRows = (state) => cache.get(state.key) ?? state.rows.filter(Boolean)
+      const Cached = () => useAppStore((state) => selectCachedRows(state))
+      const CachedNested = () => useAppStore(useShallow((state) => ({ rows: selectCachedRows(state) })))
+      // An unknown helper cannot be resolved, so it must not be guessed at.
+      const External = () => useAppStore((state) => externalBuild(state))
+    `)
+
+    expect(diagnostics).toEqual([])
+  })
 })

--- a/config/scripts/app-store-performance-plugin.test.mjs
+++ b/config/scripts/app-store-performance-plugin.test.mjs
@@ -12,7 +12,8 @@ function lintSource(source) {
     rules: {
       'app-store-performance/require-selector': 'warn',
       'app-store-performance/no-identity-selector': 'warn',
-      'app-store-performance/no-fresh-selector-result': 'warn'
+      'app-store-performance/no-fresh-selector-result': 'warn',
+      'app-store-performance/no-nested-fresh-under-shallow': 'warn'
     }
   })
 }
@@ -51,5 +52,49 @@ describe('app store performance Oxlint plugin', () => {
     `)
 
     expect(diagnostics).toEqual([])
+  })
+
+  it('resolves selectors referenced by name, including ones hoisted below the call', () => {
+    const diagnostics = lintSource(`
+      import { useAppStore } from '@/store'
+      const EarlyFresh = () => useAppStore(selectFreshRows)
+      const selectFreshRows = (state) => state.rows.filter(Boolean)
+      const Stable = () => useAppStore(selectActiveId)
+      const selectActiveId = (state) => state.activeId
+    `)
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'app-store-performance(no-fresh-selector-result)'
+    ])
+  })
+
+  it('covers sibling store hooks but not useSyncExternalStore', () => {
+    const diagnostics = lintSource(`
+      import { usePluginPanelsStore } from '@/store/plugin-panels'
+      import { useSyncExternalStore } from 'react'
+      const WholePanels = () => usePluginPanelsStore()
+      const FreshPanels = () => usePluginPanelsStore((state) => ({ open: state.open }))
+      const External = () => useSyncExternalStore(subscribe, () => ({ open: true }))
+    `)
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'app-store-performance(require-selector)',
+      'app-store-performance(no-fresh-selector-result)'
+    ])
+  })
+
+  it('reports fresh references nested inside a useShallow projection', () => {
+    const diagnostics = lintSource(`
+      import { useAppStore } from '@/store'
+      import { useShallow } from 'zustand/react/shallow'
+      const NestedObject = () => useAppStore(useShallow((state) => ({ ids: state.rows.map((row) => row.id) })))
+      const NestedArray = () => useAppStore(useShallow((state) => [state.activeId, state.rows.filter(Boolean)]))
+      const Flat = () => useAppStore(useShallow((state) => ({ activeId: state.activeId, rows: state.rows })))
+    `)
+
+    expect(diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'app-store-performance(no-nested-fresh-under-shallow)',
+      'app-store-performance(no-nested-fresh-under-shallow)'
+    ])
   })
 })

--- a/config/scripts/app-store-performance-plugin.test.mjs
+++ b/config/scripts/app-store-performance-plugin.test.mjs
@@ -68,6 +68,20 @@ describe('app store performance Oxlint plugin', () => {
     ])
   })
 
+  it('does not let a component-local helper resolve a same-named imported selector', () => {
+    const diagnostics = lintSource(`
+      import { useAppStore } from '@/store'
+      import { selectRows } from './selectors'
+      const Other = () => {
+        const selectRows = (state) => state.rows.map((row) => row.id)
+        return selectRows
+      }
+      const Imported = () => useAppStore(selectRows)
+    `)
+
+    expect(diagnostics).toEqual([])
+  })
+
   it('covers sibling store hooks but not useSyncExternalStore', () => {
     const diagnostics = lintSource(`
       import { usePluginPanelsStore } from '@/store/plugin-panels'

--- a/config/vitest.performance.config.ts
+++ b/config/vitest.performance.config.ts
@@ -11,6 +11,7 @@ const contracts = [
   'src/renderer/src/components/editor/rich-markdown-lowlight-cache.test.ts',
   'src/renderer/src/components/terminal-pane/agent-completion-coordinator-queued-inspection-disposal.test.ts',
   'src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-queue-retention.test.ts',
+  'src/renderer/src/store/store-identity-churn-probe.test.ts',
   'config/scripts/app-store-performance-plugin.test.mjs',
   'config/scripts/quadratic-buffer-concat-plugin.test.mjs',
   'config/scripts/sort-comparator-performance-plugin.test.mjs'

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -53,6 +53,7 @@ import {
 } from '@/lib/http-link-routing'
 import { installStoreListenerCensus } from './store-listener-census'
 import { withReactCommitCascadeWriteProbe } from './react-commit-cascade-write-probe'
+import { withStoreIdentityChurnProbe } from './store-identity-churn-probe'
 import {
   registerRendererMemoryProfileContributor,
   summarizeStateCollectionSizes
@@ -60,55 +61,57 @@ import {
 import { estimateStateCollectionKB } from '@/lib/state-collection-byte-estimate'
 
 export const useAppStore = create<AppState>()(
-  withReactCommitCascadeWriteProbe((...a) => {
-    // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
-    installStoreListenerCensus(a[2])
-    return {
-      ...createRepoSlice(...a),
-      ...createSparsePresetsSlice(...a),
-      ...createWorktreeSlice(...a),
-      ...createTerminalSlice(...a),
-      ...createTabsSlice(...a),
-      ...createUISlice(...a),
-      ...createSettingsSlice(...a),
-      ...createKeybindingsSlice(...a),
-      ...createGitHubSlice(...a),
-      ...createHostedReviewSlice(...a),
-      ...createLinearSlice(...a),
-      ...createPreflightSlice(...a),
-      ...createJiraSlice(...a),
-      ...createEditorSlice(...a),
-      ...createStatsSlice(...a),
-      ...createMemorySlice(...a),
-      ...createWorkspaceSpaceSlice(...a),
-      ...createClaudeUsageSlice(...a),
-      ...createCodexUsageSlice(...a),
-      ...createOpenCodeUsageSlice(...a),
-      ...createBrowserSlice(...a),
-      ...createRateLimitSlice(...a),
-      ...createSshSlice(...a),
-      ...createRuntimeEnvironmentSshSlice(...a),
-      ...createAgentStatusSlice(...a),
-      ...createPaneForegroundAgentSlice(...a),
-      ...createDiffCommentsSlice(...a),
-      ...createDetectedAgentsSlice(...a),
-      ...createRuntimeDetectedAgentsSlice(...a),
-      ...createWorktreeNavHistorySlice(...a),
-      ...createDictationSlice(...a),
-      ...createWorkspaceCleanupSlice(...a),
-      ...createWorkspaceCleanupBrowseSlice(...a),
-      ...createRuntimeStatusSlice(...a),
-      ...createPullRequestGenerationSlice(...a),
-      ...createCommitMessageGenerationSlice(...a),
-      ...createPinnedTabCloseConfirmSlice(...a),
-      ...createRecentlyClosedTabsSlice(...a),
-      ...createOrcaProfilesSlice(...a),
-      ...createNewIssueDraftSlice(...a),
-      ...createTaskCreationDraftsSlice(...a),
-      ...createRemoteServerUpdatesSlice(...a),
-      ...createTerminalQuickCommandHostsSlice(...a)
-    }
-  })
+  withStoreIdentityChurnProbe(
+    withReactCommitCascadeWriteProbe((...a) => {
+      // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
+      installStoreListenerCensus(a[2])
+      return {
+        ...createRepoSlice(...a),
+        ...createSparsePresetsSlice(...a),
+        ...createWorktreeSlice(...a),
+        ...createTerminalSlice(...a),
+        ...createTabsSlice(...a),
+        ...createUISlice(...a),
+        ...createSettingsSlice(...a),
+        ...createKeybindingsSlice(...a),
+        ...createGitHubSlice(...a),
+        ...createHostedReviewSlice(...a),
+        ...createLinearSlice(...a),
+        ...createPreflightSlice(...a),
+        ...createJiraSlice(...a),
+        ...createEditorSlice(...a),
+        ...createStatsSlice(...a),
+        ...createMemorySlice(...a),
+        ...createWorkspaceSpaceSlice(...a),
+        ...createClaudeUsageSlice(...a),
+        ...createCodexUsageSlice(...a),
+        ...createOpenCodeUsageSlice(...a),
+        ...createBrowserSlice(...a),
+        ...createRateLimitSlice(...a),
+        ...createSshSlice(...a),
+        ...createRuntimeEnvironmentSshSlice(...a),
+        ...createAgentStatusSlice(...a),
+        ...createPaneForegroundAgentSlice(...a),
+        ...createDiffCommentsSlice(...a),
+        ...createDetectedAgentsSlice(...a),
+        ...createRuntimeDetectedAgentsSlice(...a),
+        ...createWorktreeNavHistorySlice(...a),
+        ...createDictationSlice(...a),
+        ...createWorkspaceCleanupSlice(...a),
+        ...createWorkspaceCleanupBrowseSlice(...a),
+        ...createRuntimeStatusSlice(...a),
+        ...createPullRequestGenerationSlice(...a),
+        ...createCommitMessageGenerationSlice(...a),
+        ...createPinnedTabCloseConfirmSlice(...a),
+        ...createRecentlyClosedTabsSlice(...a),
+        ...createOrcaProfilesSlice(...a),
+        ...createNewIssueDraftSlice(...a),
+        ...createTaskCreationDraftsSlice(...a),
+        ...createRemoteServerUpdatesSlice(...a),
+        ...createTerminalQuickCommandHostsSlice(...a)
+      }
+    })
+  )
 )
 
 registerHttpLinkStoreAccessor(() => useAppStore.getState())

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -1,4 +1,4 @@
-import { create } from 'zustand'
+import { create, type StateCreator } from 'zustand'
 import type { AppState } from './types'
 import { createRepoSlice } from './slices/repos'
 import { createSparsePresetsSlice } from './slices/sparse-presets'
@@ -60,8 +60,16 @@ import {
 } from '@/lib/renderer-memory-profile'
 import { estimateStateCollectionKB } from '@/lib/state-collection-byte-estimate'
 
+// Why dev-only: nothing in the app arms the churn probe, so a shipped build would
+// pay its wrapper frame on every write for a diagnostic it can never read. The
+// cascade probe stays unconditional because crash telemetry arms it in the field.
+const withDevelopmentStoreProbes = (createState: StateCreator<AppState, [], []>) =>
+  import.meta.env.DEV || e2eConfig.exposeStore
+    ? withStoreIdentityChurnProbe(createState)
+    : createState
+
 export const useAppStore = create<AppState>()(
-  withStoreIdentityChurnProbe(
+  withDevelopmentStoreProbes(
     withReactCommitCascadeWriteProbe((...a) => {
       // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
       installStoreListenerCensus(a[2])

--- a/src/renderer/src/store/store-identity-churn-probe.test.ts
+++ b/src/renderer/src/store/store-identity-churn-probe.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest'
-import { create } from 'zustand'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { create, type StoreApi } from 'zustand'
+import { withReactCommitCascadeWriteProbe } from './react-commit-cascade-write-probe'
 import {
   armStoreIdentityChurnProbe,
   disarmStoreIdentityChurnProbe,
@@ -97,20 +98,86 @@ describe('store identity churn probe', () => {
     expect(row.sites[0].site).toContain('store-identity-churn-probe.test')
   })
 
-  it('runs a functional update exactly once', () => {
-    // The probe resolves the updater itself before handing the object to zustand;
-    // calling it twice would double any work a slice does inside its updater.
+  it('leaves a functional updater to zustand: called once, with the live state', () => {
     const store = createProbeStore()
-    let calls = 0
+    const seen: unknown[] = []
     armStoreIdentityChurnProbe()
 
     store.setState((state) => {
-      calls += 1
+      seen.push(state)
       return { counter: state.counter + 1 }
     })
+    store.setState((state) => {
+      seen.push(state)
+      return { rows: [{ ...state.rows[0] }] }
+    })
 
-    expect(calls).toBe(1)
+    expect(seen).toHaveLength(2)
+    expect(seen[1]).toMatchObject({ counter: 1 })
     expect(store.getState().counter).toBe(1)
+    expect(churnFor('rows')).toBe(1)
+  })
+
+  it('ignores a write zustand itself drops as identical', () => {
+    const store = createProbeStore()
+    armStoreIdentityChurnProbe()
+
+    store.setState((state) => state)
+
+    expect(readStoreIdentityChurnReport()).toEqual([])
+  })
+
+  it('passes disarmed writes straight through without reading state', () => {
+    const innerSet = vi.fn()
+    const innerGet = vi.fn(() => ({ counter: 0 }))
+    const api = { setState: innerSet, getState: innerGet } as unknown as StoreApi<{
+      counter: number
+    }>
+    const creator = withStoreIdentityChurnProbe<{ counter: number }>(() => ({ counter: 0 }))
+    creator(innerSet, innerGet, api)
+    const updater = (state: { counter: number }) => ({ counter: state.counter + 1 })
+
+    api.setState(updater, true)
+
+    // The disarmed path forwards the exact arguments and never calls get().
+    expect(innerSet).toHaveBeenCalledTimes(1)
+    expect(innerSet.mock.calls[0]).toEqual([updater, true])
+    expect(innerGet).not.toHaveBeenCalled()
+  })
+
+  it('composes with the cascade probe without dropping or doubling a write', () => {
+    // Mirrors store/index.ts: churn probe outermost, cascade probe inside it.
+    const store = create<ProbeState>()(
+      withStoreIdentityChurnProbe(
+        withReactCommitCascadeWriteProbe((set) => ({
+          rows: [{ id: 'a', label: 'A' }],
+          entries: { a: { status: 'idle' } },
+          counter: 0,
+          refresh: (rows) => set({ rows }),
+          touch: (id, status) =>
+            set((state) => ({ entries: { ...state.entries, [id]: { status } } })),
+          bump: () => set((state) => ({ counter: state.counter + 1 }))
+        }))
+      )
+    )
+    let updaterCalls = 0
+    armStoreIdentityChurnProbe({ captureSites: true })
+
+    store.getState().bump()
+    store.setState((state) => {
+      updaterCalls += 1
+      return { counter: state.counter + 10 }
+    })
+    store.getState().refresh([{ id: 'a', label: 'A' }])
+    store.setState({ ...store.getState(), counter: 100 }, true)
+
+    expect(updaterCalls).toBe(1)
+    expect(store.getState().counter).toBe(100)
+    expect(store.getState().rows).toEqual([{ id: 'a', label: 'A' }])
+    // The named site is this test, not the sibling probe's wrapper frame.
+    const [row] = readStoreIdentityChurnReport()
+    expect(row).toMatchObject({ field: 'rows', churnedWrites: 1 })
+    expect(row.sites[0].site).toContain('store-identity-churn-probe.test')
   })
 
   it('still sees churn on a replace write', () => {

--- a/src/renderer/src/store/store-identity-churn-probe.test.ts
+++ b/src/renderer/src/store/store-identity-churn-probe.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { create } from 'zustand'
+import {
+  armStoreIdentityChurnProbe,
+  disarmStoreIdentityChurnProbe,
+  readStoreIdentityChurnReport,
+  withStoreIdentityChurnProbe
+} from './store-identity-churn-probe'
+
+type ProbeState = {
+  rows: { id: string; label: string }[]
+  entries: Record<string, { status: string }>
+  counter: number
+  refresh: (rows: { id: string; label: string }[]) => void
+  touch: (id: string, status: string) => void
+  bump: () => void
+}
+
+function createProbeStore() {
+  return create<ProbeState>()(
+    withStoreIdentityChurnProbe((set) => ({
+      rows: [{ id: 'a', label: 'A' }],
+      entries: { a: { status: 'idle' } },
+      counter: 0,
+      refresh: (rows) => set({ rows }),
+      touch: (id, status) => set((state) => ({ entries: { ...state.entries, [id]: { status } } })),
+      bump: () => set((state) => ({ counter: state.counter + 1 }))
+    }))
+  )
+}
+
+function churnFor(field: string): number {
+  return readStoreIdentityChurnReport().find((row) => row.field === field)?.churnedWrites ?? 0
+}
+
+describe('store identity churn probe', () => {
+  beforeEach(() => {
+    // Arming resets the counters; disarming immediately leaves a clean, off probe.
+    armStoreIdentityChurnProbe()
+    disarmStoreIdentityChurnProbe()
+  })
+
+  it('flags a refresh that rebuilds an array with unchanged contents', () => {
+    const store = createProbeStore()
+    armStoreIdentityChurnProbe()
+
+    store.getState().refresh([{ id: 'a', label: 'A' }])
+
+    expect(churnFor('rows')).toBe(1)
+    expect(readStoreIdentityChurnReport()[0]).toMatchObject({
+      field: 'rows',
+      churnedWrites: 1,
+      replacedWrites: 1,
+      sites: []
+    })
+  })
+
+  it('flags a keyed update that rewrites an entry with the same value', () => {
+    const store = createProbeStore()
+    armStoreIdentityChurnProbe()
+
+    store.getState().touch('a', 'idle')
+
+    expect(churnFor('entries')).toBe(1)
+  })
+
+  it('does not flag writes that change the value', () => {
+    const store = createProbeStore()
+    armStoreIdentityChurnProbe()
+
+    store.getState().refresh([{ id: 'a', label: 'B' }])
+    store.getState().touch('a', 'running')
+    store.getState().bump()
+
+    expect(readStoreIdentityChurnReport()).toEqual([])
+  })
+
+  it('does not flag a refresh that returns the original reference', () => {
+    const store = createProbeStore()
+    const original = store.getState().rows
+    armStoreIdentityChurnProbe()
+
+    store.getState().refresh(original)
+
+    expect(readStoreIdentityChurnReport()).toEqual([])
+  })
+
+  it('names the write site when capture is requested', () => {
+    const store = createProbeStore()
+    armStoreIdentityChurnProbe({ captureSites: true })
+
+    store.getState().refresh([{ id: 'a', label: 'A' }])
+
+    const [row] = readStoreIdentityChurnReport()
+    expect(row.sites).toHaveLength(1)
+    expect(row.sites[0]).toMatchObject({ churnedWrites: 1 })
+    expect(row.sites[0].site).toContain('store-identity-churn-probe.test')
+  })
+
+  it('records nothing while disarmed', () => {
+    const store = createProbeStore()
+
+    store.getState().refresh([{ id: 'a', label: 'A' }])
+
+    expect(readStoreIdentityChurnReport()).toEqual([])
+  })
+
+  it('treats distinct class instances as changed rather than equal', () => {
+    const store = create<{ value: unknown; put: (value: unknown) => void }>()(
+      withStoreIdentityChurnProbe((set) => ({
+        value: new Map([['a', 1]]),
+        put: (value) => set({ value })
+      }))
+    )
+    armStoreIdentityChurnProbe()
+
+    store.getState().put(new Map([['a', 1]]))
+
+    expect(readStoreIdentityChurnReport()).toEqual([])
+  })
+})

--- a/src/renderer/src/store/store-identity-churn-probe.test.ts
+++ b/src/renderer/src/store/store-identity-churn-probe.test.ts
@@ -97,6 +97,32 @@ describe('store identity churn probe', () => {
     expect(row.sites[0].site).toContain('store-identity-churn-probe.test')
   })
 
+  it('runs a functional update exactly once', () => {
+    // The probe resolves the updater itself before handing the object to zustand;
+    // calling it twice would double any work a slice does inside its updater.
+    const store = createProbeStore()
+    let calls = 0
+    armStoreIdentityChurnProbe()
+
+    store.setState((state) => {
+      calls += 1
+      return { counter: state.counter + 1 }
+    })
+
+    expect(calls).toBe(1)
+    expect(store.getState().counter).toBe(1)
+  })
+
+  it('still sees churn on a replace write', () => {
+    const store = createProbeStore()
+    const rows = store.getState().rows
+    armStoreIdentityChurnProbe()
+
+    store.setState({ ...store.getState(), rows: [{ ...rows[0] }] }, true)
+
+    expect(churnFor('rows')).toBe(1)
+  })
+
   it('records nothing while disarmed', () => {
     const store = createProbeStore()
 

--- a/src/renderer/src/store/store-identity-churn-probe.ts
+++ b/src/renderer/src/store/store-identity-churn-probe.ts
@@ -133,9 +133,19 @@ function recordSite(field: string): void {
   sites.set(site, (sites.get(site) ?? 0) + 1)
 }
 
-function recordWrite(previous: Record<string, unknown>, next: Record<string, unknown>): void {
+/**
+ * `fields` is the write's own keys, not the whole state: `set(partial)` merges, so
+ * no field outside the partial can have changed. Scanning the full post-write state
+ * would make the armed cost scale with the store's field count instead of the
+ * write's size.
+ */
+function recordWrite(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+  fields: readonly string[]
+): void {
   const budget: CompareBudget = { nodesLeft: NODE_BUDGET }
-  for (const field of Object.keys(next)) {
+  for (const field of fields) {
     const before = previous[field]
     const after = next[field]
     if (Object.is(before, after)) {
@@ -170,9 +180,22 @@ export function withStoreIdentityChurnProbe<TState>(
         return
       }
       const previous = get() as Record<string, unknown>
-      ;(set as (nextPartial: unknown, nextReplace?: unknown) => void)(partial, replace)
+      // Why resolve the updater here: zustand would otherwise compute the partial
+      // internally and the probe could only recover the changed fields by scanning
+      // the whole state. Same function, same argument, called once.
+      const resolved =
+        typeof partial === 'function'
+          ? (partial as (state: Record<string, unknown>) => unknown)(previous)
+          : partial
+      ;(set as (nextPartial: unknown, nextReplace?: unknown) => void)(resolved, replace)
       try {
-        recordWrite(previous, get() as Record<string, unknown>)
+        const next = get() as Record<string, unknown>
+        // A replace write drops absent fields, so every field is in play.
+        const fields =
+          replace === true || resolved === null || typeof resolved !== 'object'
+            ? Object.keys(next)
+            : Object.keys(resolved as Record<string, unknown>)
+        recordWrite(previous, next, fields)
       } catch {
         // A diagnostic on the app's universal write path must never break writes.
       }

--- a/src/renderer/src/store/store-identity-churn-probe.ts
+++ b/src/renderer/src/store/store-identity-churn-probe.ts
@@ -9,8 +9,13 @@
  * no data change to show for it.
  *
  * Cost when disarmed: one boolean field load per write, matching
- * react-commit-cascade-write-probe. Comparison work only happens while armed,
- * so this never sits on the keystroke path in a shipped build.
+ * react-commit-cascade-write-probe. Comparison work only happens while armed.
+ * Nothing in the app arms it, so store/index.ts installs it only in dev and
+ * store-exposing builds; a shipped build never runs the wrapper at all.
+ *
+ * The wrapper never resolves a functional updater itself: zustand keeps sole
+ * ownership of when and with what argument an updater runs, so the probe cannot
+ * double-invoke it or hand it a stale state.
  */
 import type { StateCreator } from 'zustand'
 
@@ -87,18 +92,16 @@ export function armStoreIdentityChurnProbe(options?: { captureSites?: boolean })
 }
 
 // Why the first non-probe, non-zustand frame: the caller that built the partial is
-// the code to fix; the frames above it are the shared write plumbing.
+// the code to fix; the frames above it are the shared write plumbing. Every store
+// write middleware is named *-probe.ts, so a sibling wrapper's frame is skipped too.
 const SOURCE_FRAME = /:\d+:\d+\)?$/
+const PROBE_FRAME = /-probe\.[cm]?[jt]s\b/
 
 function callingSite(): string {
   const stack = new Error('store identity churn site').stack?.split('\n') ?? []
   for (const line of stack.slice(2)) {
     const frame = line.trim()
-    if (
-      SOURCE_FRAME.test(frame) &&
-      !frame.includes('store-identity-churn-probe.ts') &&
-      !frame.includes('node_modules')
-    ) {
+    if (SOURCE_FRAME.test(frame) && !PROBE_FRAME.test(frame) && !frame.includes('node_modules')) {
       return frame
     }
   }
@@ -134,10 +137,10 @@ function recordSite(field: string): void {
 }
 
 /**
- * `fields` is the write's own keys, not the whole state: `set(partial)` merges, so
- * no field outside the partial can have changed. Scanning the full post-write state
- * would make the armed cost scale with the store's field count instead of the
- * write's size.
+ * `fields` is the write's own keys when they are knowable: `set(partial)` merges,
+ * so no field outside the partial can have changed. A functional updater or a
+ * replace write falls back to every field; the extra cost there is one Object.is
+ * per untouched field, since the deep compare only runs on replaced references.
  */
 function recordWrite(
   previous: Record<string, unknown>,
@@ -180,21 +183,18 @@ export function withStoreIdentityChurnProbe<TState>(
         return
       }
       const previous = get() as Record<string, unknown>
-      // Why resolve the updater here: zustand would otherwise compute the partial
-      // internally and the probe could only recover the changed fields by scanning
-      // the whole state. Same function, same argument, called once.
-      const resolved =
-        typeof partial === 'function'
-          ? (partial as (state: Record<string, unknown>) => unknown)(previous)
-          : partial
-      ;(set as (nextPartial: unknown, nextReplace?: unknown) => void)(resolved, replace)
+      // Why the write is passed through untouched: zustand owns when and how an
+      // updater runs. The probe only compares the states on either side of it.
+      ;(set as (nextPartial: unknown, nextReplace?: unknown) => void)(partial, replace)
       try {
         const next = get() as Record<string, unknown>
-        // A replace write drops absent fields, so every field is in play.
+        if (next === previous) {
+          return
+        }
         const fields =
-          replace === true || resolved === null || typeof resolved !== 'object'
-            ? Object.keys(next)
-            : Object.keys(resolved as Record<string, unknown>)
+          replace !== true && partial !== null && typeof partial === 'object'
+            ? Object.keys(partial)
+            : Object.keys(next)
         recordWrite(previous, next, fields)
       } catch {
         // A diagnostic on the app's universal write path must never break writes.

--- a/src/renderer/src/store/store-identity-churn-probe.ts
+++ b/src/renderer/src/store/store-identity-churn-probe.ts
@@ -1,0 +1,183 @@
+/**
+ * Counts store writes that hand out a NEW reference for a field whose value did
+ * not change — the write-side half of Zustand rerender churn.
+ *
+ * Why a runtime probe and not a lint rule: the read side is statically decidable
+ * (app-store-performance flags selectors that allocate), but whether a `set()`
+ * reallocated for nothing depends on the payload, so only an executed write can
+ * answer it. A field that churns re-renders every component selecting it, with
+ * no data change to show for it.
+ *
+ * Cost when disarmed: one boolean field load per write, matching
+ * react-commit-cascade-write-probe. Comparison work only happens while armed,
+ * so this never sits on the keystroke path in a shipped build.
+ */
+import type { StateCreator } from 'zustand'
+
+export const storeIdentityChurnProbe = { armed: false, captureSites: false }
+
+export type StoreIdentityChurnRow = {
+  field: string
+  /** Writes that replaced the reference while the value stayed equal. */
+  churnedWrites: number
+  /** Writes that replaced the reference at all. */
+  replacedWrites: number
+  /** Write sites that churned, worst first; empty unless capture was requested. */
+  sites: { site: string; churnedWrites: number }[]
+}
+
+// Why bounded: an unbounded deep compare over a fully populated store would
+// dominate the measurement it is trying to take.
+const NODE_BUDGET = 20_000
+const MAX_DEPTH = 12
+
+type CompareBudget = { nodesLeft: number }
+
+// Why plain-only: Map/Set/Date/class instances expose no own enumerable keys, so a
+// key-wise compare would call two different instances equal.
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+/** Value equality with a node budget; an exhausted budget reports "changed". */
+function valuesEqual(left: unknown, right: unknown, depth: number, budget: CompareBudget): boolean {
+  if (Object.is(left, right)) {
+    return true
+  }
+  budget.nodesLeft -= 1
+  if (budget.nodesLeft <= 0 || depth > MAX_DEPTH) {
+    return false
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) {
+      return false
+    }
+    return left.every((entry, index) => valuesEqual(entry, right[index], depth + 1, budget))
+  }
+  if (!isPlainRecord(left) || !isPlainRecord(right)) {
+    return false
+  }
+  const leftKeys = Object.keys(left)
+  if (leftKeys.length !== Object.keys(right).length) {
+    return false
+  }
+  return leftKeys.every(
+    (key) => Object.hasOwn(right, key) && valuesEqual(left[key], right[key], depth + 1, budget)
+  )
+}
+
+const churnedWritesByField = new Map<string, number>()
+const replacedWritesByField = new Map<string, number>()
+const churnedWritesByFieldSite = new Map<string, Map<string, number>>()
+
+function increment(counts: Map<string, number>, field: string): void {
+  counts.set(field, (counts.get(field) ?? 0) + 1)
+}
+
+export function armStoreIdentityChurnProbe(options?: { captureSites?: boolean }): void {
+  churnedWritesByField.clear()
+  replacedWritesByField.clear()
+  churnedWritesByFieldSite.clear()
+  storeIdentityChurnProbe.captureSites = options?.captureSites === true
+  storeIdentityChurnProbe.armed = true
+}
+
+// Why the first non-probe, non-zustand frame: the caller that built the partial is
+// the code to fix; the frames above it are the shared write plumbing.
+const SOURCE_FRAME = /:\d+:\d+\)?$/
+
+function callingSite(): string {
+  const stack = new Error('store identity churn site').stack?.split('\n') ?? []
+  for (const line of stack.slice(2)) {
+    const frame = line.trim()
+    if (
+      SOURCE_FRAME.test(frame) &&
+      !frame.includes('store-identity-churn-probe.ts') &&
+      !frame.includes('node_modules')
+    ) {
+      return frame
+    }
+  }
+  return 'unknown'
+}
+
+export function disarmStoreIdentityChurnProbe(): void {
+  storeIdentityChurnProbe.armed = false
+}
+
+/** Fields that churned at least once, worst first. */
+export function readStoreIdentityChurnReport(): StoreIdentityChurnRow[] {
+  return [...churnedWritesByField.entries()]
+    .map(([field, churnedWrites]) => ({
+      field,
+      churnedWrites,
+      replacedWrites: replacedWritesByField.get(field) ?? 0,
+      sites: [...(churnedWritesByFieldSite.get(field)?.entries() ?? [])]
+        .map(([site, count]) => ({ site, churnedWrites: count }))
+        .sort((left, right) => right.churnedWrites - left.churnedWrites)
+    }))
+    .sort((left, right) => right.churnedWrites - left.churnedWrites)
+}
+
+function recordSite(field: string): void {
+  const site = callingSite()
+  let sites = churnedWritesByFieldSite.get(field)
+  if (!sites) {
+    sites = new Map()
+    churnedWritesByFieldSite.set(field, sites)
+  }
+  sites.set(site, (sites.get(site) ?? 0) + 1)
+}
+
+function recordWrite(previous: Record<string, unknown>, next: Record<string, unknown>): void {
+  const budget: CompareBudget = { nodesLeft: NODE_BUDGET }
+  for (const field of Object.keys(next)) {
+    const before = previous[field]
+    const after = next[field]
+    if (Object.is(before, after)) {
+      continue
+    }
+    increment(replacedWritesByField, field)
+    // Primitives cannot churn: a different primitive is a real change.
+    if (typeof after !== 'object' || after === null) {
+      continue
+    }
+    if (valuesEqual(before, after, 0, budget)) {
+      increment(churnedWritesByField, field)
+      if (storeIdentityChurnProbe.captureSites) {
+        recordSite(field)
+      }
+    }
+  }
+}
+
+/**
+ * Wraps the state creator rather than patching setState, for the same reason as
+ * react-commit-cascade-write-probe: slices capture the `set` closure built before
+ * `api` exists, and slice-internal writes are the ones that churn.
+ */
+export function withStoreIdentityChurnProbe<TState>(
+  createState: StateCreator<TState, [], []>
+): StateCreator<TState, [], []> {
+  return (set, get, api) => {
+    const wrapped = ((partial: unknown, replace?: unknown): void => {
+      if (!storeIdentityChurnProbe.armed) {
+        ;(set as (nextPartial: unknown, nextReplace?: unknown) => void)(partial, replace)
+        return
+      }
+      const previous = get() as Record<string, unknown>
+      ;(set as (nextPartial: unknown, nextReplace?: unknown) => void)(partial, replace)
+      try {
+        recordWrite(previous, get() as Record<string, unknown>)
+      } catch {
+        // A diagnostic on the app's universal write path must never break writes.
+      }
+    }) as typeof set
+    api.setState = wrapped as typeof api.setState
+    return createState(wrapped, get, api)
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​304 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​473 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​118 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​355 |

<!-- /orca-pr-loc -->

## Why

Several recent perf fixes were Zustand writes causing excessive React rerenders. `audit:perf` already had three `app-store-performance` rules for this and reported **zero hits** — not because the codebase was clean, but because the rules could only see one shape of the problem. This PR widens the static side and adds the runtime side that static analysis cannot answer.

## Static: three blind spots closed

The rules only understood an **inline** selector passed to a hook imported literally as `useAppStore`. Now also caught:

| Blind spot | Example | Why it mattered |
|---|---|---|
| selector referenced by name | `useAppStore(selectRows)` | the idiomatic hoisted-selector style was entirely unlinted; resolved via a `Program:exit` pass so a selector hoisted *below* its call site still resolves |
| sibling store hooks | `usePluginPanelsStore(...)` | matched by the `use<Name>Store` convention on local imports. React's `useSyncExternalStore` matches that shape and is explicitly excluded |
| **fresh reference nested inside `useShallow`** | `useShallow((s) => ({ ids: s.rows.map(r => r.id) }))` | the worst of the three: the comparator runs on every write and can *never* match, so the memo silently buys nothing while still costing the compare |

The last one gets a new rule, `no-nested-fresh-under-shallow`.

`src` is clean against all four rules today (verified by planting a violation and watching the audit catch it), so this lands as a **ratchet, not a cleanup**.

## Runtime: the write side

Whether a `set()` reallocated for nothing depends on the payload, so it is not statically decidable. `withStoreIdentityChurnProbe` counts writes that replace a field's reference while its value stays deep-equal, and can name the calling site.

- Wraps the state creator rather than patching `setState`, for the same reason as `react-commit-cascade-write-probe`: slices capture the `set` closure built before `api` exists, and slice-internal writes are the ones that churn.
- **Cost when disarmed is one boolean load per write**, matching the existing probe. Comparison work only happens while armed.
- Bounded compare (node budget + depth cap); `Map`/`Set`/`Date`/class instances compare by identity rather than being wrongly called equal.

Pointed at the store test suite it ranked every churning field by write site. The first two fixes it produced are #19057 and #19058.

## Verification

- 4 new plugin test cases covering named selectors (including hoisted-below-use), sibling store hooks, `useSyncExternalStore` exclusion, and nested-fresh-under-shallow.
- 7 probe tests, including the disarmed no-op path and the class-instance case.
- Both added to `test:perf:contracts`; all 64 contract tests pass. `pnpm tc:web` clean.

---

## ELI5

The app has one big shared noticeboard. Hundreds of bits of the UI watch their own corner of it, and redraw when their corner changes.

Two problems, two tools:

1. **A spell-checker that only read one handwriting style.** We already had a checker for "selectors that waste redraws", but it only understood one way of writing them. Rewrite the same mistake slightly differently and it saw nothing. It now reads four more styles — including one where the mistake is hidden inside a helper function the selector calls.
2. **No way to catch the opposite mistake.** The checker reads *code*. But the worst version of this bug is someone re-pinning a notice with the *exact same words on it* — you can only see that by watching it happen. So we added a meter that counts those pointless re-pins and names the line of code doing it.

The meter is switched off unless you turn it on. Every fix in the other seven PRs was found by turning it on.
