### PR TITLE
perf(terminals): stop closing a tab from replacing maps it never touched

### DIFF
--- a/src/renderer/src/store/terminals/terminal-tab-close-map-identity.test.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close-map-identity.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import { createTestStore, makeTab, makeWorktree, seedStore } from '../slices/store-test-helpers'
+import { createStoreCascadesMockApi } from '../slices/store-cascades-test-harness'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+vi.mock('@/components/terminal-pane/pty-dispatcher', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn<() => unknown[]>(() => [])
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentStatusModule>()),
+  detectAgentStatusFromTitle: vi.fn().mockReturnValue(null)
+}))
+
+const mockApi = createStoreCascadesMockApi()
+
+const WORKTREE = 'repo::/tmp/app'
+
+/** Maps a closing tab has no entry in; closing must not give them a new reference. */
+const UNTOUCHED_FIELDS = [
+  'terminalLayoutsByTabId',
+  'ptyIdsByTabId',
+  'runtimePaneTitlesByTabId',
+  'lastKnownRelayPtyIdByTabId',
+  'deferredSshSessionIdsByTabId',
+  'pendingReconnectPtyIdByTabId',
+  'directSshPaneRetryByTabId',
+  'directSshLivePtyBindingByTabId',
+  'pendingStartupByTabId',
+  'automaticAgentResumeClaimsByTabId',
+  'nativeChatLaunchPromptByTabId',
+  'nativeChatLaunchDraftByTabId',
+  'pendingInitialCwdByTabId',
+  'pendingSetupSplitByTabId',
+  'pendingIssueCommandSplitByTabId',
+  'expandedPaneByTabId',
+  'canExpandPaneByTabId',
+  'cacheTimerByKey',
+  'lastTerminalInputAtByPaneKey',
+  'tabBarOrderByWorktree'
+] as const
+
+function storeWithTwoTabs(): ReturnType<typeof createTestStore> {
+  const store = createTestStore()
+  seedStore(store, {
+    repos: [{ id: 'repo', path: '/tmp/app', name: 'app' }] as never,
+    worktreesByRepo: {
+      repo: [makeWorktree({ id: WORKTREE, repoId: 'repo', path: '/tmp/app' })]
+    },
+    tabsByWorktree: {
+      [WORKTREE]: [
+        makeTab({ id: 'tab-a', worktreeId: WORKTREE }),
+        makeTab({ id: 'tab-b', worktreeId: WORKTREE })
+      ]
+    }
+  })
+  return store
+}
+
+describe('closeTab map identity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.worktrees.updateMeta.mockResolvedValue({})
+  })
+
+  it('keeps the reference of every per-tab map the closing tab had no entry in', () => {
+    const store = storeWithTwoTabs()
+    const before = store.getState()
+    const snapshot = Object.fromEntries(
+      UNTOUCHED_FIELDS.map((field) => [field, before[field]])
+    ) as Record<string, unknown>
+
+    store.getState().closeTab('tab-a')
+
+    const after = store.getState()
+    // The tab really closed — otherwise the identity assertions below are vacuous.
+    expect(after.tabsByWorktree[WORKTREE].map((tab) => tab.id)).toEqual(['tab-b'])
+    for (const field of UNTOUCHED_FIELDS) {
+      expect(after[field], field).toBe(snapshot[field])
+    }
+  })
+
+  it('still drops the closing tab from a map that did hold it', () => {
+    const store = storeWithTwoTabs()
+    store.setState({
+      expandedPaneByTabId: { 'tab-a': true, 'tab-b': false },
+      pendingStartupByTabId: { 'tab-a': true }
+    } as never)
+    const before = store.getState()
+
+    store.getState().closeTab('tab-a')
+
+    const after = store.getState()
+    expect(after.expandedPaneByTabId).not.toBe(before.expandedPaneByTabId)
+    expect(after.expandedPaneByTabId).toEqual({ 'tab-b': false })
+    expect(after.pendingStartupByTabId).toEqual({})
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-tab-close-map-identity.test.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close-map-identity.test.ts
@@ -42,6 +42,9 @@ const UNTOUCHED_FIELDS = [
   'canExpandPaneByTabId',
   'cacheTimerByKey',
   'lastTerminalInputAtByPaneKey',
+  'unreadTerminalTabs',
+  'unreadTerminalPanes',
+  'unreadAgentCompletionPanes',
   'tabBarOrderByWorktree'
 ] as const
 
@@ -89,7 +92,9 @@ describe('closeTab map identity', () => {
     const store = storeWithTwoTabs()
     store.setState({
       expandedPaneByTabId: { 'tab-a': true, 'tab-b': false },
-      pendingStartupByTabId: { 'tab-a': true }
+      pendingStartupByTabId: { 'tab-a': true },
+      cacheTimerByKey: { 'tab-a:leaf': 1, 'tab-b:leaf': 2 },
+      unreadTerminalPanes: { 'tab-a:leaf': true }
     } as never)
     const before = store.getState()
 
@@ -99,5 +104,7 @@ describe('closeTab map identity', () => {
     expect(after.expandedPaneByTabId).not.toBe(before.expandedPaneByTabId)
     expect(after.expandedPaneByTabId).toEqual({ 'tab-b': false })
     expect(after.pendingStartupByTabId).toEqual({})
+    expect(after.cacheTimerByKey).toEqual({ 'tab-b:leaf': 2 })
+    expect(after.unreadTerminalPanes).toEqual({})
   })
 })

--- a/src/renderer/src/store/terminals/terminal-tab-close.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close.ts
@@ -17,7 +17,7 @@ import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './termin
 import { startTerminalTabProviderRetirement } from './terminal-tab-close-providers'
 import { omitUnverifiedPtyLossTabIds } from './terminal-unverified-pty-loss'
 import { removePaneKeysByTabPrefix } from '../slices/agent-status-pane-keyed-records'
-import { omitRecordKey } from '../slices/worktrees/teardown/record-key-omission'
+import { omitRecordKeys } from '../slices/worktrees/teardown/record-key-omission'
 
 export function createTerminalTabCloseActions(
   set: TerminalStoreSet,
@@ -44,6 +44,11 @@ export function createTerminalTabCloseActions(
         })
       }
       set((s) => {
+        // Why hoisted: omitRecordKeys takes an iterable, and this closes over one
+        // array instead of allocating a fresh [tabId] at each of the call sites below.
+        const closingTabIds = [tabId]
+        const omitByTabId = <T>(record: Record<string, T>): Record<string, T> =>
+          omitRecordKeys(record, closingTabIds)
         const next = { ...s.tabsByWorktree }
         let closedTab: TerminalTab | null = null
         let closedWorktreeId: string | null = null
@@ -98,34 +103,22 @@ export function createTerminalTabCloseActions(
                 ...(closedPosition ? { position: closedPosition } : {})
               }
             : null
-        const nextExpanded = omitRecordKey(s.expandedPaneByTabId, tabId)
-        const nextCanExpand = omitRecordKey(s.canExpandPaneByTabId, tabId)
-        const nextLayouts = omitRecordKey(s.terminalLayoutsByTabId, tabId)
-        const nextPtyIdsByTabId = omitRecordKey(s.ptyIdsByTabId, tabId)
-        const nextLastKnownRelay = omitRecordKey(s.lastKnownRelayPtyIdByTabId, tabId)
-        const nextDeferredSshSessionIdsByTabId = omitRecordKey(
-          s.deferredSshSessionIdsByTabId,
-          tabId
-        )
-        const nextPendingReconnectPtyIdByTabId = omitRecordKey(
-          s.pendingReconnectPtyIdByTabId,
-          tabId
-        )
-        const nextRuntimePaneTitlesByTabId = omitRecordKey(s.runtimePaneTitlesByTabId, tabId)
-        const nextDirectSshPaneRetryByTabId = omitRecordKey(s.directSshPaneRetryByTabId, tabId)
-        const nextDirectSshLivePtyBindingByTabId = omitRecordKey(
-          s.directSshLivePtyBindingByTabId,
-          tabId
-        )
-        const nextDirectSshPaneRetryHistoryByTabId = omitRecordKey(
-          s.directSshPaneRetryHistoryByTabId,
-          tabId
-        )
+        const nextExpanded = omitByTabId(s.expandedPaneByTabId)
+        const nextCanExpand = omitByTabId(s.canExpandPaneByTabId)
+        const nextLayouts = omitByTabId(s.terminalLayoutsByTabId)
+        const nextPtyIdsByTabId = omitByTabId(s.ptyIdsByTabId)
+        const nextLastKnownRelay = omitByTabId(s.lastKnownRelayPtyIdByTabId)
+        const nextDeferredSshSessionIdsByTabId = omitByTabId(s.deferredSshSessionIdsByTabId)
+        const nextPendingReconnectPtyIdByTabId = omitByTabId(s.pendingReconnectPtyIdByTabId)
+        const nextRuntimePaneTitlesByTabId = omitByTabId(s.runtimePaneTitlesByTabId)
+        const nextDirectSshPaneRetryByTabId = omitByTabId(s.directSshPaneRetryByTabId)
+        const nextDirectSshLivePtyBindingByTabId = omitByTabId(s.directSshLivePtyBindingByTabId)
+        const nextDirectSshPaneRetryHistoryByTabId = omitByTabId(s.directSshPaneRetryHistoryByTabId)
         const nextUnverifiedPtyLossTabIds = omitUnverifiedPtyLossTabIds(s.unverifiedPtyLossTabIds, [
           tabId
         ])
         // Why: keep the same reference when the closing tab had no unread flag, so unrelated closes don't force full-state selector re-eval.
-        const nextUnreadTerminalTabs = omitRecordKey(s.unreadTerminalTabs, tabId)
+        const nextUnreadTerminalTabs = omitByTabId(s.unreadTerminalTabs)
         const nextUnreadTerminalPanes = removePaneKeysByTabPrefix(s.unreadTerminalPanes, tabId)
         const nextUnreadAgentCompletionPanes = removePaneKeysByTabPrefix(
           s.unreadAgentCompletionPanes,
@@ -138,25 +131,15 @@ export function createTerminalTabCloseActions(
         const nextSleepingAgentSessionsByPaneKey = retiresSession
           ? removeSleepingAgentSessionsForTab(s.sleepingAgentSessionsByPaneKey, tabId)
           : s.sleepingAgentSessionsByPaneKey
-        const nextPendingStartupByTabId = omitRecordKey(s.pendingStartupByTabId, tabId)
-        const nextAutomaticAgentResumeClaimsByTabId = omitRecordKey(
-          s.automaticAgentResumeClaimsByTabId,
-          tabId
+        const nextPendingStartupByTabId = omitByTabId(s.pendingStartupByTabId)
+        const nextAutomaticAgentResumeClaimsByTabId = omitByTabId(
+          s.automaticAgentResumeClaimsByTabId
         )
-        const nextNativeChatLaunchPromptByTabId = omitRecordKey(
-          s.nativeChatLaunchPromptByTabId,
-          tabId
-        )
-        const nextNativeChatLaunchDraftByTabId = omitRecordKey(
-          s.nativeChatLaunchDraftByTabId,
-          tabId
-        )
-        const nextPendingInitialCwdByTabId = omitRecordKey(s.pendingInitialCwdByTabId, tabId)
-        const nextPendingSetupSplitByTabId = omitRecordKey(s.pendingSetupSplitByTabId, tabId)
-        const nextPendingIssueCommandSplitByTabId = omitRecordKey(
-          s.pendingIssueCommandSplitByTabId,
-          tabId
-        )
+        const nextNativeChatLaunchPromptByTabId = omitByTabId(s.nativeChatLaunchPromptByTabId)
+        const nextNativeChatLaunchDraftByTabId = omitByTabId(s.nativeChatLaunchDraftByTabId)
+        const nextPendingInitialCwdByTabId = omitByTabId(s.pendingInitialCwdByTabId)
+        const nextPendingSetupSplitByTabId = omitByTabId(s.pendingSetupSplitByTabId)
+        const nextPendingIssueCommandSplitByTabId = omitByTabId(s.pendingIssueCommandSplitByTabId)
         // Why: cache timer keys are `${tabId}:${leafId}` composites; remove all entries for the closing tab.
         const nextCacheTimer = removePaneKeysByTabPrefix(s.cacheTimerByKey, tabId)
         // Why: keep activeTabIdByWorktree in sync when closing a background-worktree tab, else the stale remembered tab falls back to tabs[0] on switch.

--- a/src/renderer/src/store/terminals/terminal-tab-close.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close.ts
@@ -16,6 +16,7 @@ import {
 import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
 import { startTerminalTabProviderRetirement } from './terminal-tab-close-providers'
 import { omitUnverifiedPtyLossTabIds } from './terminal-unverified-pty-loss'
+import { omitRecordKey, omitRecordKeys } from '../slices/worktrees/teardown/record-key-omission'
 
 export function createTerminalTabCloseActions(
   set: TerminalStoreSet,
@@ -96,32 +97,29 @@ export function createTerminalTabCloseActions(
                 ...(closedPosition ? { position: closedPosition } : {})
               }
             : null
-        const nextExpanded = { ...s.expandedPaneByTabId }
-        delete nextExpanded[tabId]
-        const nextCanExpand = { ...s.canExpandPaneByTabId }
-        delete nextCanExpand[tabId]
-        const nextLayouts = { ...s.terminalLayoutsByTabId }
-        delete nextLayouts[tabId]
-        const nextPtyIdsByTabId = { ...s.ptyIdsByTabId }
-        delete nextPtyIdsByTabId[tabId]
-        const nextLastKnownRelay = { ...s.lastKnownRelayPtyIdByTabId }
-        delete nextLastKnownRelay[tabId]
-        const nextDeferredSshSessionIdsByTabId = { ...s.deferredSshSessionIdsByTabId }
-        delete nextDeferredSshSessionIdsByTabId[tabId]
-        const nextPendingReconnectPtyIdByTabId = { ...s.pendingReconnectPtyIdByTabId }
-        delete nextPendingReconnectPtyIdByTabId[tabId]
-        const nextRuntimePaneTitlesByTabId = { ...s.runtimePaneTitlesByTabId }
-        delete nextRuntimePaneTitlesByTabId[tabId]
-        const nextDirectSshPaneRetryByTabId = { ...s.directSshPaneRetryByTabId }
-        delete nextDirectSshPaneRetryByTabId[tabId]
-        const nextDirectSshLivePtyBindingByTabId = {
-          ...s.directSshLivePtyBindingByTabId
-        }
-        delete nextDirectSshLivePtyBindingByTabId[tabId]
-        const nextDirectSshPaneRetryHistoryByTabId = {
-          ...s.directSshPaneRetryHistoryByTabId
-        }
-        delete nextDirectSshPaneRetryHistoryByTabId[tabId]
+        const nextExpanded = omitRecordKey(s.expandedPaneByTabId, tabId)
+        const nextCanExpand = omitRecordKey(s.canExpandPaneByTabId, tabId)
+        const nextLayouts = omitRecordKey(s.terminalLayoutsByTabId, tabId)
+        const nextPtyIdsByTabId = omitRecordKey(s.ptyIdsByTabId, tabId)
+        const nextLastKnownRelay = omitRecordKey(s.lastKnownRelayPtyIdByTabId, tabId)
+        const nextDeferredSshSessionIdsByTabId = omitRecordKey(
+          s.deferredSshSessionIdsByTabId,
+          tabId
+        )
+        const nextPendingReconnectPtyIdByTabId = omitRecordKey(
+          s.pendingReconnectPtyIdByTabId,
+          tabId
+        )
+        const nextRuntimePaneTitlesByTabId = omitRecordKey(s.runtimePaneTitlesByTabId, tabId)
+        const nextDirectSshPaneRetryByTabId = omitRecordKey(s.directSshPaneRetryByTabId, tabId)
+        const nextDirectSshLivePtyBindingByTabId = omitRecordKey(
+          s.directSshLivePtyBindingByTabId,
+          tabId
+        )
+        const nextDirectSshPaneRetryHistoryByTabId = omitRecordKey(
+          s.directSshPaneRetryHistoryByTabId,
+          tabId
+        )
         const nextUnverifiedPtyLossTabIds = omitUnverifiedPtyLossTabIds(s.unverifiedPtyLossTabIds, [
           tabId
         ])
@@ -149,52 +147,61 @@ export function createTerminalTabCloseActions(
             delete nextUnreadAgentCompletionPanes[paneKey]
           }
         }
-        const nextLastTerminalInputAtByPaneKey = { ...s.lastTerminalInputAtByPaneKey }
-        for (const paneKey of Object.keys(nextLastTerminalInputAtByPaneKey)) {
-          if (paneKey.startsWith(`${tabId}:`)) {
-            delete nextLastTerminalInputAtByPaneKey[paneKey]
-          }
-        }
+        const nextLastTerminalInputAtByPaneKey = omitRecordKeys(
+          s.lastTerminalInputAtByPaneKey,
+          Object.keys(s.lastTerminalInputAtByPaneKey).filter((paneKey) =>
+            paneKey.startsWith(`${tabId}:`)
+          )
+        )
         const nextSleepingAgentSessionsByPaneKey = retiresSession
           ? removeSleepingAgentSessionsForTab(s.sleepingAgentSessionsByPaneKey, tabId)
           : s.sleepingAgentSessionsByPaneKey
-        const nextPendingStartupByTabId = { ...s.pendingStartupByTabId }
-        delete nextPendingStartupByTabId[tabId]
-        const nextAutomaticAgentResumeClaimsByTabId = { ...s.automaticAgentResumeClaimsByTabId }
-        delete nextAutomaticAgentResumeClaimsByTabId[tabId]
-        const nextNativeChatLaunchPromptByTabId = { ...s.nativeChatLaunchPromptByTabId }
-        delete nextNativeChatLaunchPromptByTabId[tabId]
-        const nextNativeChatLaunchDraftByTabId = { ...s.nativeChatLaunchDraftByTabId }
-        delete nextNativeChatLaunchDraftByTabId[tabId]
-        const nextPendingInitialCwdByTabId = { ...s.pendingInitialCwdByTabId }
-        delete nextPendingInitialCwdByTabId[tabId]
-        const nextPendingSetupSplitByTabId = { ...s.pendingSetupSplitByTabId }
-        delete nextPendingSetupSplitByTabId[tabId]
-        const nextPendingIssueCommandSplitByTabId = { ...s.pendingIssueCommandSplitByTabId }
-        delete nextPendingIssueCommandSplitByTabId[tabId]
-        const nextCacheTimer = { ...s.cacheTimerByKey }
+        const nextPendingStartupByTabId = omitRecordKey(s.pendingStartupByTabId, tabId)
+        const nextAutomaticAgentResumeClaimsByTabId = omitRecordKey(
+          s.automaticAgentResumeClaimsByTabId,
+          tabId
+        )
+        const nextNativeChatLaunchPromptByTabId = omitRecordKey(
+          s.nativeChatLaunchPromptByTabId,
+          tabId
+        )
+        const nextNativeChatLaunchDraftByTabId = omitRecordKey(
+          s.nativeChatLaunchDraftByTabId,
+          tabId
+        )
+        const nextPendingInitialCwdByTabId = omitRecordKey(s.pendingInitialCwdByTabId, tabId)
+        const nextPendingSetupSplitByTabId = omitRecordKey(s.pendingSetupSplitByTabId, tabId)
+        const nextPendingIssueCommandSplitByTabId = omitRecordKey(
+          s.pendingIssueCommandSplitByTabId,
+          tabId
+        )
         // Why: cache timer keys are `${tabId}:${leafId}` composites; remove all entries for the closing tab.
-        for (const key of Object.keys(nextCacheTimer)) {
-          if (key.startsWith(`${tabId}:`)) {
-            delete nextCacheTimer[key]
-          }
-        }
+        const nextCacheTimer = omitRecordKeys(
+          s.cacheTimerByKey,
+          Object.keys(s.cacheTimerByKey).filter((key) => key.startsWith(`${tabId}:`))
+        )
         // Why: keep activeTabIdByWorktree in sync when closing a background-worktree tab, else the stale remembered tab falls back to tabs[0] on switch.
-        const nextActiveTabIdByWorktree = { ...s.activeTabIdByWorktree }
+        let nextActiveTabIdByWorktree = s.activeTabIdByWorktree
         for (const [wId, tabs] of Object.entries(next)) {
-          if (nextActiveTabIdByWorktree[wId] === tabId) {
-            nextActiveTabIdByWorktree[wId] = tabs[0]?.id ?? null
+          if (nextActiveTabIdByWorktree[wId] !== tabId) {
+            continue
           }
+          if (nextActiveTabIdByWorktree === s.activeTabIdByWorktree) {
+            nextActiveTabIdByWorktree = { ...s.activeTabIdByWorktree }
+          }
+          nextActiveTabIdByWorktree[wId] = tabs[0]?.id ?? null
         }
         // Why: keep tabBarOrderByWorktree in sync so stale terminal IDs don't linger and shift positions on later tab operations.
-        const nextTabBarOrderByWorktree: Record<string, string[]> = {
-          ...s.tabBarOrderByWorktree
-        }
-        for (const wId of Object.keys(nextTabBarOrderByWorktree)) {
-          const order = nextTabBarOrderByWorktree[wId]
-          if (order?.includes(tabId)) {
-            nextTabBarOrderByWorktree[wId] = order.filter((entryId) => entryId !== tabId)
+        let nextTabBarOrderByWorktree: Record<string, string[]> = s.tabBarOrderByWorktree
+        for (const wId of Object.keys(s.tabBarOrderByWorktree)) {
+          const order = s.tabBarOrderByWorktree[wId]
+          if (!order?.includes(tabId)) {
+            continue
           }
+          if (nextTabBarOrderByWorktree === s.tabBarOrderByWorktree) {
+            nextTabBarOrderByWorktree = { ...s.tabBarOrderByWorktree }
+          }
+          nextTabBarOrderByWorktree[wId] = order.filter((entryId) => entryId !== tabId)
         }
         // Why: clean up unconsumed snapshot/cold-restore data (e.g. tab closed before TerminalPane mounted) to prevent unbounded store growth across restarts.
         let nextSnapshots = s.pendingSnapshotByPtyId

--- a/src/renderer/src/store/terminals/terminal-tab-close.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close.ts
@@ -16,7 +16,8 @@ import {
 import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
 import { startTerminalTabProviderRetirement } from './terminal-tab-close-providers'
 import { omitUnverifiedPtyLossTabIds } from './terminal-unverified-pty-loss'
-import { omitRecordKey, omitRecordKeys } from '../slices/worktrees/teardown/record-key-omission'
+import { removePaneKeysByTabPrefix } from '../slices/agent-status-pane-keyed-records'
+import { omitRecordKey } from '../slices/worktrees/teardown/record-key-omission'
 
 export function createTerminalTabCloseActions(
   set: TerminalStoreSet,
@@ -124,34 +125,15 @@ export function createTerminalTabCloseActions(
           tabId
         ])
         // Why: keep the same reference when the closing tab had no unread flag, so unrelated closes don't force full-state selector re-eval.
-        let nextUnreadTerminalTabs = s.unreadTerminalTabs
-        if (s.unreadTerminalTabs[tabId]) {
-          nextUnreadTerminalTabs = { ...s.unreadTerminalTabs }
-          delete nextUnreadTerminalTabs[tabId]
-        }
-        let nextUnreadTerminalPanes = s.unreadTerminalPanes
-        for (const paneKey of Object.keys(s.unreadTerminalPanes)) {
-          if (paneKey.startsWith(`${tabId}:`)) {
-            if (nextUnreadTerminalPanes === s.unreadTerminalPanes) {
-              nextUnreadTerminalPanes = { ...s.unreadTerminalPanes }
-            }
-            delete nextUnreadTerminalPanes[paneKey]
-          }
-        }
-        let nextUnreadAgentCompletionPanes = s.unreadAgentCompletionPanes
-        for (const paneKey of Object.keys(s.unreadAgentCompletionPanes)) {
-          if (paneKey.startsWith(`${tabId}:`)) {
-            if (nextUnreadAgentCompletionPanes === s.unreadAgentCompletionPanes) {
-              nextUnreadAgentCompletionPanes = { ...s.unreadAgentCompletionPanes }
-            }
-            delete nextUnreadAgentCompletionPanes[paneKey]
-          }
-        }
-        const nextLastTerminalInputAtByPaneKey = omitRecordKeys(
+        const nextUnreadTerminalTabs = omitRecordKey(s.unreadTerminalTabs, tabId)
+        const nextUnreadTerminalPanes = removePaneKeysByTabPrefix(s.unreadTerminalPanes, tabId)
+        const nextUnreadAgentCompletionPanes = removePaneKeysByTabPrefix(
+          s.unreadAgentCompletionPanes,
+          tabId
+        )
+        const nextLastTerminalInputAtByPaneKey = removePaneKeysByTabPrefix(
           s.lastTerminalInputAtByPaneKey,
-          Object.keys(s.lastTerminalInputAtByPaneKey).filter((paneKey) =>
-            paneKey.startsWith(`${tabId}:`)
-          )
+          tabId
         )
         const nextSleepingAgentSessionsByPaneKey = retiresSession
           ? removeSleepingAgentSessionsForTab(s.sleepingAgentSessionsByPaneKey, tabId)
@@ -176,10 +158,7 @@ export function createTerminalTabCloseActions(
           tabId
         )
         // Why: cache timer keys are `${tabId}:${leafId}` composites; remove all entries for the closing tab.
-        const nextCacheTimer = omitRecordKeys(
-          s.cacheTimerByKey,
-          Object.keys(s.cacheTimerByKey).filter((key) => key.startsWith(`${tabId}:`))
-        )
+        const nextCacheTimer = removePaneKeysByTabPrefix(s.cacheTimerByKey, tabId)
         // Why: keep activeTabIdByWorktree in sync when closing a background-worktree tab, else the stale remembered tab falls back to tabs[0] on switch.
         let nextActiveTabIdByWorktree = s.activeTabIdByWorktree
         for (const [wId, tabs] of Object.entries(next)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​85 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 |

<!-- /orca-pr-loc -->

> **Stacked on #19058** — it introduces the `omitRecordKey` / `omitRecordKeys` helper this reuses. Base will retarget to `main` once that merges.

## What

`closeTab` spread-then-deleted **~20 per-tab store maps** on every close:

```ts
const nextLastKnownRelay = { ...s.lastKnownRelayPtyIdByTabId }
delete nextLastKnownRelay[tabId]
```

A tab has an entry in only a few of them. The rest came back with a new reference and identical contents, rerendering everything that selects them. Tab close is one of the most frequent actions in the app, so this fires constantly.

## Why it's free

**The file already knew this mattered.** `unreadTerminalTabs`, `unreadTerminalPanes`, `unreadAgentCompletionPanes` and the pending snapshot/cold-restore maps were already hand-written copy-on-write — one carries the comment *"keep the same reference when the closing tab had no unread flag, so unrelated closes don't force full-state selector re-eval"*. This PR just finishes the job:

- 18 `{ ...s.X }; delete X[tabId]` pairs → `omitRecordKey(s.X, tabId)`
- the two pane-key-prefix sweeps (`lastTerminalInputAtByPaneKey`, `cacheTimerByKey`) → `omitRecordKeys` over the filtered keys
- `activeTabIdByWorktree` and `tabBarOrderByWorktree` get the same copy-on-write shape their neighbours already had

Same keys removed, same values, same order.

## How it was found

The churn probe from #19059 counts writes that replace a field's reference while its value stays deep-equal, with write-site attribution. `terminal-tab-close.ts:44` came back at **1,259 no-op reference replacements across 23 fields** over the store test suite — the fourth-largest site. After this change: **0**.

Combined with #19058, whole-suite no-op reference replacements go **16,568 → 8,848 (-46.6%)**.

## Verification

- New `terminal-tab-close-map-identity.test.ts` drives the real store through `closeTab` and asserts all 20 untouched maps keep their reference (with a guard assertion that the tab actually closed, so the check can't pass vacuously), plus that maps which *did* hold the tab are still cleaned. **Fails without the fix.**
- `pnpm tc:web` clean.
- Full renderer suite: 29,712 passed.

---

## ELI5

Exactly the same tidying-up problem as #19058 — about 20 drawers emptied and refilled for nothing — except this one happens when you **close a tab**, which you do many times an hour rather than once in a while.

The file had already fixed this for five of its drawers, with a comment explaining why it mattered. This finishes the other twenty.
