### PR TITLE
test: reject unsupported app-server in WSL golden stub

### DIFF
--- a/tests/e2e/helpers/wsl-golden-stub-agent.ts
+++ b/tests/e2e/helpers/wsl-golden-stub-agent.ts
@@ -41,7 +41,7 @@ const BACKUP_EXISTING_STUB_SCRIPT =
 // The marker is written first so stale-lock recovery only removes a stub this helper wrote.
 const STAGE_SCRIPT =
   `mkdir -p /usr/local/bin && : > ${WSL_STUB_STAGED_MARKER} && ` +
-  `printf '#!/bin/sh\\necho GOLDEN_STUB_AGENT_READY\\nexec sleep 3600\\n' > ${WSL_STUB_PATH} && ` +
+  `printf '#!/bin/sh\\nif [ "$1" = app-server ]; then echo "error: unrecognized subcommand app-server" >&2; exit 2; fi\\necho GOLDEN_STUB_AGENT_READY\\nexec sleep 3600\\n' > ${WSL_STUB_PATH} && ` +
   `chmod 0755 ${WSL_STUB_PATH}`
 
 // The marker is written before the link so a crashed run over-reports rather than leaks a link.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5
The WSL fake agent now rejects a server command it does not implement instead of sleeping for an hour.

## What Changed
The staged WSL shell stub returns exit 2 and an unsupported-subcommand error for `app-server` before emitting the ready marker or entering its sleep loop. Interactive launches retain the existing marker and lifetime.

## Why
The staged `codex` symlink is also probed during hook preparation. Previously that invocation entered the sleeping fixture, delaying the real agent launch until the test failed. This matches the native golden fixture correction in #19056.

## Linked Issue
Related fixture correction: #19056. Discovered during the test-deflaking audit.

## Visual Proof
N/A — fixture-only change; no application UI behavior change.

## Testing
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Before: [34026029842](https://github.com/stablyai/orca/actions/runs/34026029842), all three WSL agent-launch repeats failed readiness. After: [34026441370](https://github.com/stablyai/orca/actions/runs/34026441370), all three passed, no skips, with an actual Ubuntu WSL1 guest. Generated shell script direct check exits 2 with the expected error and no ready marker. Formatting/lint passed. PR CI covers remaining checks. Rendered testing runs exclusively in CI at the user's request. WSL2 is unverified.

## AI Disclosure

## Review
Self-reviewed; checks and pullfrog required before merge.

## Agent skill upstream boundary
- [x] Not applicable; no skill source changes.

## Notes
WSL fixture only; no application, SSH execution, wire, or mobile changes. No retries or timeout increases. Existing staged-path ownership and cleanup remain intact.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
