### PR TITLE
perf(tabs): keep tab-model identity when reconciliation changed something else

### DIFF
--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch-identity.test.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch-identity.test.ts
@@ -3,8 +3,72 @@ import {
   createWorktreeTabModelReconciliationBatch,
   writeBatchedWorkspaceRecordEntry
 } from './tabs-reconciliation-batch'
+import { projectWorktreeTabModelReconciliation } from './tabs-reconciliation'
+import { createTestStore } from '../store-test-helpers'
 
 const WORKTREE = 'repo::/tmp/app'
+
+describe('projectWorktreeTabModelReconciliation identity', () => {
+  it('keeps every tab-model map when only an orphan runtime terminal changed', () => {
+    const groupId = 'g-1'
+    const store = createTestStore()
+    store.setState({
+      unifiedTabsByWorktree: {
+        [WORKTREE]: [
+          {
+            id: 'sim-1',
+            entityId: 'sim-1',
+            groupId,
+            worktreeId: WORKTREE,
+            contentType: 'simulator',
+            label: 'Simulator',
+            customLabel: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      groupsByWorktree: {
+        [WORKTREE]: [
+          {
+            id: groupId,
+            worktreeId: WORKTREE,
+            activeTabId: 'sim-1',
+            tabOrder: ['sim-1']
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [WORKTREE]: groupId },
+      layoutByWorktree: { [WORKTREE]: { type: 'leaf', groupId } },
+      // Orphan: a runtime terminal with no unified row and no live PTY.
+      tabsByWorktree: {
+        [WORKTREE]: [
+          {
+            id: 'orphan',
+            ptyId: null,
+            worktreeId: WORKTREE,
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      ptyIdsByTabId: { orphan: [] }
+    })
+    const before = store.getState()
+
+    const { patch } = projectWorktreeTabModelReconciliation(before, WORKTREE)
+
+    expect(patch.tabsByWorktree?.[WORKTREE]).toEqual([])
+    expect(patch.unifiedTabsByWorktree).toBe(before.unifiedTabsByWorktree)
+    expect(patch.groupsByWorktree).toBe(before.groupsByWorktree)
+    expect(patch.activeGroupIdByWorktree).toBe(before.activeGroupIdByWorktree)
+    expect(patch.layoutByWorktree).toBeUndefined()
+  })
+})
 
 describe('writeBatchedWorkspaceRecordEntry identity', () => {
   it('returns the same record when the entry already holds that value', () => {

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch-identity.test.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch-identity.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createWorktreeTabModelReconciliationBatch,
+  writeBatchedWorkspaceRecordEntry
+} from './tabs-reconciliation-batch'
+
+const WORKTREE = 'repo::/tmp/app'
+
+describe('writeBatchedWorkspaceRecordEntry identity', () => {
+  it('returns the same record when the entry already holds that value', () => {
+    const groups = [{ id: 'group-1' }]
+    const current = { [WORKTREE]: groups }
+
+    const next = writeBatchedWorkspaceRecordEntry(
+      current,
+      'groupsByWorktree',
+      WORKTREE,
+      groups,
+      undefined
+    )
+
+    // A new reference here rerenders every component selecting the map.
+    expect(next).toBe(current)
+  })
+
+  it('does not claim ownership of a map it never cloned', () => {
+    const groups = [{ id: 'group-1' }]
+    const current = { [WORKTREE]: groups }
+    const batch = createWorktreeTabModelReconciliationBatch({ openFiles: [] })
+
+    const unchanged = writeBatchedWorkspaceRecordEntry(
+      current,
+      'groupsByWorktree',
+      WORKTREE,
+      groups,
+      batch
+    )
+    expect(unchanged).toBe(current)
+    expect(batch.ownedStateKeys.has('groupsByWorktree')).toBe(false)
+
+    // A later real change must therefore still copy rather than mutate the caller's map.
+    const changed = writeBatchedWorkspaceRecordEntry(
+      current,
+      'groupsByWorktree',
+      WORKTREE,
+      [{ id: 'group-2' }],
+      batch
+    )
+    expect(changed).not.toBe(current)
+    expect(current[WORKTREE]).toBe(groups)
+    expect(batch.ownedStateKeys.has('groupsByWorktree')).toBe(true)
+  })
+
+  it('copies when the value differs', () => {
+    const current = { [WORKTREE]: 'group-1' }
+
+    const next = writeBatchedWorkspaceRecordEntry(
+      current,
+      'activeGroupIdByWorktree',
+      WORKTREE,
+      'group-2',
+      undefined
+    )
+
+    expect(next).not.toBe(current)
+    expect(next[WORKTREE]).toBe('group-2')
+  })
+
+  it('still stores an absent key, including an undefined value', () => {
+    const current: Record<string, string | undefined> = { other: 'group-1' }
+
+    const next = writeBatchedWorkspaceRecordEntry(
+      current,
+      'activeGroupIdByWorktree',
+      WORKTREE,
+      undefined,
+      undefined
+    )
+
+    // The spread this replaces added the key; dropping it would change Object.keys.
+    expect(next).not.toBe(current)
+    expect(WORKTREE in next).toBe(true)
+    expect(next[WORKTREE]).toBeUndefined()
+  })
+
+  it('keeps mutating in place once the batch owns the map', () => {
+    const batch = createWorktreeTabModelReconciliationBatch({ openFiles: [] })
+    batch.ownedStateKeys.add('groupsByWorktree')
+    const draft: Record<string, unknown> = { [WORKTREE]: 'old' }
+
+    const next = writeBatchedWorkspaceRecordEntry(draft, 'groupsByWorktree', WORKTREE, 'new', batch)
+
+    expect(next).toBe(draft)
+    expect(draft[WORKTREE]).toBe('new')
+  })
+})

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch.ts
@@ -49,6 +49,14 @@ export function writeBatchedWorkspaceRecordEntry<T>(
     ;(current as Record<string, T | undefined>)[worktreeId] = value
     return current
   }
+  // Why: the reconciliation gate fires when any one of tabs/groups/active-group/
+  // layout/orphans changed, then writes all of them. Spreading a map whose entry
+  // is already this value hands it a new identity for no data change, rerendering
+  // every component selecting it. The key must already exist — the spread also
+  // stored an absent key as undefined, and dropping that would change Object.keys.
+  if (worktreeId in current && Object.is(current[worktreeId], value)) {
+    return current
+  }
   const next = { ...current, [worktreeId]: value } as Record<string, T>
   batch?.ownedStateKeys.add(stateKey)
   return next

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation-batch.ts
@@ -49,11 +49,10 @@ export function writeBatchedWorkspaceRecordEntry<T>(
     ;(current as Record<string, T | undefined>)[worktreeId] = value
     return current
   }
-  // Why: the reconciliation gate fires when any one of tabs/groups/active-group/
-  // layout/orphans changed, then writes all of them. Spreading a map whose entry
-  // is already this value hands it a new identity for no data change, rerendering
-  // every component selecting it. The key must already exist — the spread also
-  // stored an absent key as undefined, and dropping that would change Object.keys.
+  // Why: the reconciliation gate writes every map when any one changed; spreading an
+  // already-equal entry would rerender its selectors for no data change. Nothing was
+  // cloned, so ownership is deliberately not claimed. Absent keys still get stored,
+  // matching the spread (`in` check).
   if (worktreeId in current && Object.is(current[worktreeId], value)) {
     return current
   }

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation.ts
@@ -128,7 +128,11 @@ export function projectWorktreeTabModelReconciliation(
     return liveEditorIds.has(tab.entityId)
   }
 
-  const validTabs = reconciledUnifiedTabs.filter(isRenderableTab)
+  const renderableTabs = reconciledUnifiedTabs.filter(isRenderableTab)
+  // Why: hand the stored array back when nothing was filtered, so an unrelated
+  // change (orphans, layout) does not give `unifiedTabsByWorktree` a new identity.
+  const validTabs =
+    renderableTabs.length === reconciledUnifiedTabs.length ? reconciledUnifiedTabs : renderableTabs
   const validTabIds = new Set(validTabs.map((tab) => tab.id))
   const nextGroupsWithEmpty = reconciledGroups.map((group) => {
     const tabOrder = group.tabOrder.filter((tabId) => validTabIds.has(tabId))
@@ -147,10 +151,14 @@ export function projectWorktreeTabModelReconciliation(
       ? group
       : { ...group, tabOrder, activeTabId, recentTabIds }
   })
-  const nextGroups =
+  const prunedGroups =
     validTabs.length > 0
       ? nextGroupsWithEmpty.filter((group) => group.tabOrder.length > 0)
       : nextGroupsWithEmpty
+  const groupsChanged =
+    prunedGroups.length !== groups.length ||
+    prunedGroups.some((group, index) => group !== groups[index])
+  const nextGroups = groupsChanged ? prunedGroups : groups
   const currentActiveGroupId =
     state.activeGroupIdByWorktree[worktreeId] ??
     ensuredGroupState?.activeGroupIdByWorktree[worktreeId]
@@ -160,10 +168,7 @@ export function projectWorktreeTabModelReconciliation(
     : (nextGroups.find((group) => group.activeTabId !== null)?.id ??
       nextGroups[0]?.id ??
       currentActiveGroupId)
-  const groupsChanged =
-    nextGroups.length !== groups.length ||
-    nextGroups.some((group, index) => group !== groups[index])
-  const tabsChanged = validTabs.length !== unifiedTabs.length || restoredLegacyTabs.length > 0
+  const tabsChanged = validTabs !== unifiedTabs
   const activeGroupChanged = nextActiveGroupId !== currentActiveGroupId
   const baseNextLayout =
     restoredLegacyTabs.length > 0 && reconciliationGroup
@@ -178,13 +183,6 @@ export function projectWorktreeTabModelReconciliation(
     prunedNextLayout ?? (nextGroups[0] ? { type: 'leaf', groupId: nextGroups[0].id } : undefined)
   const currentLayout = state.layoutByWorktree[worktreeId]
   const layoutChanged = nextLayout !== currentLayout
-  // Why: the gate below fires when ANY of tabs/groups/active-group/layout/orphans
-  // changed, and then writes all of them. An unchanged one has to hand back the array
-  // already in the store — an equal copy would rerender everything selecting the map.
-  // Safe because filter and the group mapping above both preserve element identity, so
-  // `!tabsChanged` / `!groupsChanged` mean element-wise identical to what is stored.
-  const storedUnifiedTabs = tabsChanged ? validTabs : unifiedTabs
-  const storedGroups = groupsChanged ? nextGroups : groups
   let patch: Partial<AppState> = {}
 
   if (
@@ -220,14 +218,14 @@ export function projectWorktreeTabModelReconciliation(
         state.unifiedTabsByWorktree,
         'unifiedTabsByWorktree',
         worktreeId,
-        storedUnifiedTabs,
+        validTabs,
         batch
       ),
       groupsByWorktree: writeBatchedWorkspaceRecordEntry(
         state.groupsByWorktree,
         'groupsByWorktree',
         worktreeId,
-        storedGroups,
+        nextGroups,
         batch
       ),
       activeGroupIdByWorktree: writeBatchedWorkspaceRecordEntry(

--- a/src/renderer/src/store/slices/tabs/tabs-reconciliation.ts
+++ b/src/renderer/src/store/slices/tabs/tabs-reconciliation.ts
@@ -178,6 +178,13 @@ export function projectWorktreeTabModelReconciliation(
     prunedNextLayout ?? (nextGroups[0] ? { type: 'leaf', groupId: nextGroups[0].id } : undefined)
   const currentLayout = state.layoutByWorktree[worktreeId]
   const layoutChanged = nextLayout !== currentLayout
+  // Why: the gate below fires when ANY of tabs/groups/active-group/layout/orphans
+  // changed, and then writes all of them. An unchanged one has to hand back the array
+  // already in the store — an equal copy would rerender everything selecting the map.
+  // Safe because filter and the group mapping above both preserve element identity, so
+  // `!tabsChanged` / `!groupsChanged` mean element-wise identical to what is stored.
+  const storedUnifiedTabs = tabsChanged ? validTabs : unifiedTabs
+  const storedGroups = groupsChanged ? nextGroups : groups
   let patch: Partial<AppState> = {}
 
   if (
@@ -213,14 +220,14 @@ export function projectWorktreeTabModelReconciliation(
         state.unifiedTabsByWorktree,
         'unifiedTabsByWorktree',
         worktreeId,
-        validTabs,
+        storedUnifiedTabs,
         batch
       ),
       groupsByWorktree: writeBatchedWorkspaceRecordEntry(
         state.groupsByWorktree,
         'groupsByWorktree',
         worktreeId,
-        nextGroups,
+        storedGroups,
         batch
       ),
       activeGroupIdByWorktree: writeBatchedWorkspaceRecordEntry(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​160 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​160 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

## What

The tab-model reconciliation gate fires when **any** of tabs / groups / active-group / layout / orphans changed — and then writes **all** of them:

```ts
if (tabsChanged || groupsChanged || activeGroupChanged || layoutChanged || orphanTerminalIds.size > 0) {
  patch = {
    unifiedTabsByWorktree: writeBatchedWorkspaceRecordEntry(..., validTabs, batch),
    groupsByWorktree:      writeBatchedWorkspaceRecordEntry(..., nextGroups, batch),
    activeGroupIdByWorktree: writeBatchedWorkspaceRecordEntry(..., nextActiveGroupId, batch),
    ...
```

So an orphan-terminal cleanup alone handed `unifiedTabsByWorktree`, `groupsByWorktree` and `activeGroupIdByWorktree` new identities with unchanged contents, rerendering every component selecting them.

## Two halves

**1. `writeBatchedWorkspaceRecordEntry` spread even when the entry already held that value.** It now returns the map untouched — and, importantly, **does not add the key to `ownedStateKeys`**, since it never cloned. A later real change in the same fold therefore still copies rather than mutating the caller's map. (There is a dedicated test for exactly that ordering; getting it wrong would corrupt store state, not just perf.)

**2. The projection handed over freshly built arrays that were element-wise equal to the stored ones.** It already computes `tabsChanged` and `groupsChanged`, so an unchanged one now passes the stored array back. Safe because `.filter()` and the group mapping above both preserve element identity — `!tabsChanged` means nothing was filtered and nothing restored, so `validTabs` is element-wise identical to `unifiedTabs`.

An absent key is still stored, `undefined` value included; dropping it would change `Object.keys`, which the spread this replaces did not do.

## Measured

Churn probe from #19059, across the store test suite:

| | before | after |
|---|---|---|
| `tabs-session-actions.ts:71` (site) | 1,537 | **912** |
| `activeGroupIdByWorktree` | 517 | 197 |
| `groupsByWorktree` | 347 | 185 |
| `unifiedTabsByWorktree` | 334 | 172 |

Partial rather than zero: the residual at that site is other keys in the same patch (orphan cleanup), and part of the per-field residual comes from the worktree-removal path fixed separately in #19058.

## Verification

- New `tabs-reconciliation-batch-identity.test.ts` — 5 cases covering the unchanged-entry short circuit, the ownership-ordering hazard above, the changed-value path, absent-key storage, and in-place mutation once owned. **Fails without the fix.**
- `pnpm tc:web` clean.
- Full renderer suite: 29,707 passed.

---

## ELI5

The tab bookkeeper watches five things. If **any one** of them changed, it rewrote **all five** — so cleaning up one dead terminal also made the app think your tabs, tab groups and layout had all changed, and everything watching them redrew.

Now it only rewrites the ones that actually changed.

The dangerous bit: this bookkeeper has a rule where, after it has made its own private copy of a list, it's allowed to scribble directly on it. The fix has to take its shortcut *without* claiming it made a copy — otherwise a later step would scribble on the real thing. That's a corruption bug, not a slowness bug, so there's a test pinning it.
