### PR TITLE
test: canonicalize native Windows paths during repository teardown

### DIFF
--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -10,7 +10,7 @@ import { readFileSync, existsSync, realpathSync, rmSync } from 'node:fs'
 import { TEST_REPO_PATH_FILE } from './global-setup'
 
 export function linkedWorktreePaths(testRepoDir: string): string[] {
-  const root = realpathSync(testRepoDir)
+  const root = realpathSync.native(testRepoDir)
   const output = execFileSync('git', ['-C', testRepoDir, 'worktree', 'list', '--porcelain'], {
     encoding: 'utf8'
   })
@@ -23,7 +23,7 @@ export function linkedWorktreePaths(testRepoDir: string): string[] {
     if (!existsSync(recordedPath)) {
       continue
     }
-    const canonicalPath = realpathSync(recordedPath)
+    const canonicalPath = realpathSync.native(recordedPath)
     if (canonicalPath !== root) {
       linked.add(canonicalPath)
     }
@@ -32,7 +32,7 @@ export function linkedWorktreePaths(testRepoDir: string): string[] {
 }
 
 export function cleanupTestRepository(testRepoDir: string): void {
-  const root = realpathSync(testRepoDir)
+  const root = realpathSync.native(testRepoDir)
   let worktreePaths: string[] = []
   try {
     worktreePaths = linkedWorktreePaths(root)

--- a/tests/e2e/global-teardown.unit.test.ts
+++ b/tests/e2e/global-teardown.unit.test.ts
@@ -39,7 +39,7 @@ describe('E2E global teardown ownership', () => {
     git(repoPath, ['worktree', 'add', '-b', 'second-owned', secondWorktreePath])
 
     expect(new Set(linkedWorktreePaths(repoPath))).toEqual(
-      new Set([realpathSync(firstWorktreePath), realpathSync(secondWorktreePath)])
+      new Set([realpathSync.native(firstWorktreePath), realpathSync.native(secondWorktreePath)])
     )
     cleanupTestRepository(repoPath)
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | 0 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5
Treat Windows short and long names for the same test repository as one path during cleanup.

## What Changed
Use `realpathSync.native` for the repository root and paths returned by `git worktree list`. Update the existing ownership test's expected paths to use the same native canonical form.

## Why
On Windows CI, the temporary root contains `RUNNER~1`, while Git reports `runneradmin`. JavaScript `realpathSync` preserves the short alias, so teardown incorrectly includes the main repository among linked worktrees. Native canonicalization expands the alias and excludes the root correctly.

## Linked Issue
Discovered during the test-deflaking audit.

## Visual Proof
N/A — test cleanup only.

## Testing
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Existing teardown ownership unit test passed (1/1); formatting and lint passed. Windows diagnostic [34024213794](https://github.com/stablyai/orca/actions/runs/34024213794) reproduced root deletion through the linked-worktree loop. With native canonicalization, [34024816213](https://github.com/stablyai/orca/actions/runs/34024816213) passed all 15 native launch cases and reached the correct root cleanup step. That full run still fails due to an independently confirmed surviving Git Bash process lock; this PR does not fix that leak. Isolated cmd run [34025447299](https://github.com/stablyai/orca/actions/runs/34025447299) passed and completed teardown. Remaining checks run in PR CI.

## AI Disclosure

## Review
Self-reviewed; all checks and pullfrog required before merge.

## Agent skill upstream boundary
- [x] Not applicable; no skill source changes.

## Notes
Uses Node's cross-platform native realpath implementation. No changes to Git command options, application behavior, SSH execution, remote wire formats, or folder-workspace behavior. Cleanup remains limited to the test repository and its registered linked worktrees. No retries or swallowed deletion errors added.

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
