### PR TITLE
fix(file-explorer): preserve ignored state when expanding symlinks

### DIFF
--- a/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFileExplorerIgnoredPaths } from './use-file-explorer-ignored-paths'
+
+const getRuntimeGitIgnoredPathsMock = vi.hoisted(() => vi.fn())
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitIgnoredPaths: getRuntimeGitIgnoredPathsMock
+}))
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: () => undefined
+}))
+vi.mock('./file-explorer-runtime-owner', () => ({
+  getRightSidebarWorktreeRuntimeSettings: () => ({ activeRuntimeEnvironmentId: null })
+}))
+
+const initialProps = {
+  activeWorktreeId: 'worktree-1',
+  worktreePath: '/repo',
+  relativePaths: ['.DS_Store', '.agents']
+}
+
+function useIgnoredPaths(props: typeof initialProps) {
+  return useFileExplorerIgnoredPaths({
+    ...props,
+    canLoadIgnoredPaths: true,
+    shouldDebounceIgnoredQuery: false
+  })
+}
+
+describe('file explorer ignored-path query failures', () => {
+  beforeEach(() => {
+    getRuntimeGitIgnoredPathsMock.mockReset()
+  })
+
+  afterEach(cleanup)
+
+  it('preserves decorations after a failed refresh and accepts a later empty success', async () => {
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce(['.DS_Store', '.agents'])
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+    await act(async () => {})
+    expect(hook.result.current).toEqual(['.DS_Store', '.agents'])
+
+    getRuntimeGitIgnoredPathsMock.mockRejectedValueOnce(new Error('Git query failed'))
+    await act(async () => {
+      hook.rerender({ ...initialProps, relativePaths: [...initialProps.relativePaths, 'src'] })
+    })
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(2)
+    expect(hook.result.current).toEqual(['.DS_Store', '.agents'])
+
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce([])
+    await act(async () => {
+      hook.rerender(initialProps)
+    })
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(3)
+    expect(hook.result.current).toEqual([])
+  })
+
+  it.each([
+    { activeWorktreeId: 'worktree-2', worktreePath: '/repo' },
+    { activeWorktreeId: 'worktree-1', worktreePath: '/other-repo' }
+  ])('does not carry decorations into a failing new context: %j', async (context) => {
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce(['.DS_Store'])
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+    await act(async () => {})
+    expect(hook.result.current).toEqual(['.DS_Store'])
+
+    getRuntimeGitIgnoredPathsMock.mockRejectedValueOnce(new Error('Host unavailable'))
+    await act(async () => {
+      hook.rerender({ ...initialProps, ...context })
+    })
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(2)
+    expect(hook.result.current).toEqual([])
+  })
+
+  it('keeps an empty state when the first query fails', async () => {
+    getRuntimeGitIgnoredPathsMock.mockRejectedValueOnce(new Error('Host unavailable'))
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+    await act(async () => {})
+    expect(hook.result.current).toEqual([])
+  })
+
+  it('does not let a late failure replace a newer successful query', async () => {
+    let rejectOldQuery!: (error: Error) => void
+    getRuntimeGitIgnoredPathsMock.mockReturnValueOnce(
+      new Promise<string[]>((_resolve, reject) => {
+        rejectOldQuery = reject
+      })
+    )
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce(['.DS_Store'])
+    await act(async () => {
+      hook.rerender({ ...initialProps, relativePaths: ['.DS_Store'] })
+    })
+    expect(hook.result.current).toEqual(['.DS_Store'])
+
+    await act(async () => {
+      rejectOldQuery(new Error('Late failure'))
+    })
+    expect(hook.result.current).toEqual(['.DS_Store'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
+++ b/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
@@ -75,9 +75,8 @@ export function useFileExplorerIgnoredPaths({
           }
         })
         .catch(() => {
-          if (!canceled) {
-            setIgnoredPathResult({ activeWorktreeId, paths: [], worktreePath })
-          }
+          // A failed query is not an empty result. Keep the last successful
+          // result; getEffectiveFileExplorerIgnoredPaths guards worktree changes.
         })
     }
 

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DirCache, TreeNode } from './file-explorer-types'
+import { isPathIgnored } from './status-display'
 import {
   createVisibleFileExplorerRowProjection,
   getFileExplorerIgnoredQueryRelativePaths
@@ -334,6 +335,64 @@ describe('file explorer visible row projection', () => {
       'collapsed'
     ])
   })
+
+  it.each([false, true])(
+    'inherits the link ignored state (%s) without querying descendants',
+    (ignored) => {
+      const treeInput = input(
+        {
+          '/repo': [row('.DS_Store'), row('config', true)],
+          '/repo/config': [
+            { ...row('config/.agents', true), isSymlink: true },
+            row('config/.agents-extra', true),
+            row('config/.claude', true)
+          ],
+          '/repo/config/.agents': [row('config/.agents/skills', true)],
+          '/repo/config/.agents/skills': [row('config/.agents/skills/SKILL.md')],
+          '/repo/config/.agents-extra': [row('config/.agents-extra/settings.json')],
+          '/repo/config/.claude': [row('config/.claude/settings.json')]
+        },
+        [
+          '/repo/config',
+          '/repo/config/.agents',
+          '/repo/config/.agents/skills',
+          '/repo/config/.agents-extra',
+          '/repo/config/.claude'
+        ]
+      )
+
+      expect(getFileExplorerIgnoredQueryRelativePaths(treeInput, true)).toEqual([
+        '.DS_Store',
+        'config',
+        'config/.agents',
+        'config/.agents-extra',
+        'config/.agents-extra/settings.json',
+        'config/.claude',
+        'config/.claude/settings.json'
+      ])
+
+      const ignoredSet = new Set(['.DS_Store', 'config/.claude/settings.json'])
+      if (ignored) {
+        ignoredSet.add('config/.agents')
+      }
+      const options = { ignoredSet, showDotfiles: true, showGitIgnoredFiles: true }
+      const shown = createVisibleFileExplorerRowProjection(treeInput, options)
+      const childPath = '/repo/config/.agents/skills/SKILL.md'
+      expect(shown.hasPath(childPath)).toBe(true)
+      expect(isPathIgnored(ignoredSet, 'config/.agents/skills/SKILL.md')).toBe(ignored)
+      expect(isPathIgnored(ignoredSet, 'config/.agents-extra/settings.json')).toBe(false)
+      expect(isPathIgnored(ignoredSet, '.DS_Store')).toBe(true)
+
+      const hidden = createVisibleFileExplorerRowProjection(treeInput, {
+        ...options,
+        showGitIgnoredFiles: false
+      })
+      expect(hidden.hasPath('/repo/config/.agents')).toBe(!ignored)
+      expect(hidden.hasPath(childPath)).toBe(!ignored)
+      expect(hidden.hasPath('/repo/.DS_Store')).toBe(false)
+      expect(hidden.hasPath('/repo/config/.agents-extra/settings.json')).toBe(true)
+    }
+  )
 
   it('keeps same-worktree ignored paths while an expanded-folder query is loading', () => {
     expect(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -51,7 +51,8 @@ export function getFileExplorerIgnoredQueryRelativePaths(
         continue
       }
       relativePaths.push(row.relativePath)
-      if (row.isDirectory && expanded.has(row.path)) {
+      // Git checks the link itself; descendants inherit its ignored state.
+      if (row.isDirectory && !row.isSymlink && expanded.has(row.path)) {
         visitChildren(row.path)
       }
     }


### PR DESCRIPTION
## Summary

Expanding a directory symlink such as `.agents -> ./.claude` could clear Git-ignored decorations throughout the file explorer. Descendant paths were included in `git check-ignore`, which rejects them with `fatal: pathspec ... is beyond a symbolic link`; the renderer then replaced the previous ignored-path result with an empty list.

- Query the symlink entry itself without descending into it. Expanded descendants inherit the link's ignored state through the existing ancestor lookup, including when ignored files are hidden.
- Preserve the last successful result when an ignored-path query fails. A successful empty result still clears decorations, and results remain scoped to the current worktree ID and path.

Initial symlink classification, sorting, and click-to-expand behavior are unchanged.

## Screenshots

Visual verification pending. This draft fixes existing ignored-file styling and visibility; it adds no UI controls. The Electron app was not launched for this change.

## Testing

- [ ] `pnpm lint` — full lint not run; targeted checks below passed
- [ ] `pnpm typecheck` — web typecheck passed; full typecheck not run
- [ ] `pnpm test` — targeted suite passed; full suite not run
- [ ] `pnpm build` — not run
- [x] Added regression tests

Validation completed locally on Linux:

- 4 test files, 33 tests passed: `useFileExplorerVisibleRowProjection.test.ts`, `useFileExplorerVisibleRowProjection.debounce.test.tsx`, `use-file-explorer-ignored-paths.test.tsx`, and `status-display.test.ts`.
- `pnpm run typecheck:web`.
- Changed-file `oxlint`, React Doctor lint, and `oxfmt --check`.
- Max-lines ratchet and `git diff --check`.

Tests cover nested symlink descendants, ignored and non-ignored links, similarly named neighboring directories, direct target paths, ignored-file hiding, failed refreshes, recovery to an empty successful result, worktree isolation, and late failures. A separate real-Git reproduction confirmed the symlink-descendant query exits with code 128.

## AI Review Report

Implemented and reviewed with OpenAI Codex. Review checked query traversal separately from visible tree traversal, existing ancestor-based ignored-state inheritance, and failed/stale asynchronous results. Name filtering uses the existing recursive file listing, which deliberately does not follow symlinks.

Cross-platform review covered macOS, Linux, and Windows: the change uses existing node metadata and adds no platform-specific path parsing, shell commands, shortcuts, labels, or Electron behavior. SSH and remote runtime listings also carry symlink metadata and use the same renderer query traversal. Live macOS, Windows, and SSH sessions were not exercised.

## Security Audit

No new commands, IPC endpoints, dependencies, permissions, or target traversal. Existing Git queries receive fewer paths. The query-failure fallback retains only existing worktree-scoped display state and does not authorize filesystem access.

## Notes

No linked issue. PR #7210 handles the normal `check-ignore` exit-1 case; this addresses symlink-descendant errors and preservation of existing decorations after failed queries.

After a failed query, decorations may remain stale until the next successful refresh. This preserves the last known state rather than treating an error as proof that no paths are ignored.
