### PR TITLE
fix: retain MSYS shell descendants in their terminal job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -852,6 +852,7 @@ jobs:
           src/main/agent-hooks/windows-hook-payload-delivery.test.ts
           src/main/agent-hooks/windows-direct-cmd-hook-command.test.ts
           src/main/windows/windows-pty-job.win32.test.ts
+          src/main/windows/windows-msys-job.win32.test.ts
           src/main/windows/windows-host-job.win32.test.ts
           src/main/windows/windows-process-tree-command-line-patch.test.ts
           src/main/windows-live-tree-kill.win32.test.ts

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -613,7 +613,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  #include <vector>
  #include <Windows.h>
  #include <strsafe.h>
-@@ -44,12 +45,40 @@
+@@ -44,12 +45,40 @@ struct pty_baton {
    HANDLE hOut;
    HPCON hpc;
  
@@ -655,7 +655,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  static volatile LONG ptyCounter;
  
  static pty_baton* get_pty_baton(int id) {
-@@ -102,8 +131,31 @@
+@@ -102,8 +131,31 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
      // Get process exit code.
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
@@ -716,7 +716,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
    } else {
      throw Napi::Error::New(env, "Cannot launch conpty");
    }
-@@ -409,6 +474,15 @@
+@@ -409,6 +474,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "UpdateProcThreadAttribute failed");
    }
  
@@ -732,7 +732,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
    PROCESS_INFORMATION piClient{};
    fSuccess = !!CreateProcessW(
        nullptr,
-@@ -416,7 +490,10 @@
+@@ -416,7 +490,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -744,7 +744,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,8 +503,48 @@
+@@ -426,8 +503,48 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -795,7 +795,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
    if (useConptyDll && fLoadedDll)
    {
      PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
-@@ -440,6 +557,8 @@
+@@ -440,6 +557,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -804,7 +804,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -544,27 +663,213 @@
+@@ -544,27 +663,213 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    int id = info[0].As<Napi::Number>().Int32Value();
    const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
  
@@ -1034,7 +1034,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  }
  
  /**
-@@ -577,6 +882,9 @@
+@@ -577,6 +882,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -603,6 +603,7 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..2ae787c5bd4f3eba470584dc658a01a5
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
+index 7b286d3d644c26141df516929703aa6e129df4b2..4b06d18576c807c3d1181a7bd714140c6678cf86 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -603,7 +603,6 @@ index 7b4b9e1f990fbf95b51528bb56dc9717f5b87532..2ae787c5bd4f3eba470584dc658a01a5
  }
  #endif
 diff --git a/src/win/conpty.cc b/src/win/conpty.cc
-index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c97209248e 100644
 --- a/src/win/conpty.cc
 +++ b/src/win/conpty.cc
 @@ -18,6 +18,7 @@
@@ -614,7 +613,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
  #include <vector>
  #include <Windows.h>
  #include <strsafe.h>
-@@ -44,12 +45,39 @@ struct pty_baton {
+@@ -44,12 +45,40 @@
    HANDLE hOut;
    HPCON hpc;
  
@@ -630,6 +629,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
 +  // refused to create or assign one (an outer job without breakaway rights),
 +  // in which case callers fall back to their pre-job behaviour.
 +  HANDLE hJob = nullptr;
++  bool allowJobBreakaway = true;
 +
 +  // Orca: teardown needs BOTH the shell's death and an explicit kill() before
 +  // the baton can be freed, so each side records that it has run. Whichever
@@ -655,7 +655,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
  static volatile LONG ptyCounter;
  
  static pty_baton* get_pty_baton(int id) {
-@@ -102,8 +130,31 @@ void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+@@ -102,8 +131,31 @@
      // Get process exit code.
      GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
      // Clean up handles
@@ -689,7 +689,34 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -409,6 +460,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -242,6 +294,18 @@
+   return HRESULT_FROM_WIN32(GetLastError());
+ }
+ 
++// MSYS automatically escapes any job that advertises breakaway support.
++static bool isMsysShell(const std::wstring& shellpath) {
++  const size_t separator = shellpath.find_last_of(L"\\/");
++  if (separator == std::wstring::npos) return false;
++  const std::wstring name = shellpath.substr(separator + 1);
++  if (_wcsicmp(name.c_str(), L"bash.exe") != 0 &&
++      _wcsicmp(name.c_str(), L"sh.exe") != 0) return false;
++  const std::wstring directory = shellpath.substr(0, separator + 1);
++  return path_util::file_exists(directory + L"msys-2.0.dll") ||
++         path_util::file_exists(directory + L"..\\usr\\bin\\msys-2.0.dll");
++}
++
+ static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+   Napi::Env env(info.Env());
+   Napi::HandleScope scope(env);
+@@ -303,6 +367,7 @@
+     marshal.Set("pty", Napi::Number::New(env, ptyId));
+     ptyHandles.emplace_back(
+         std::make_unique<pty_baton>(ptyId, hIn, hOut, hpc));
++    ptyHandles.back()->allowJobBreakaway = !isMsysShell(shellpath);
+   } else {
+     throw Napi::Error::New(env, "Cannot launch conpty");
+   }
+@@ -409,6 +474,15 @@
      throw errorWithCode(info, "UpdateProcThreadAttribute failed");
    }
  
@@ -705,7 +732,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
    PROCESS_INFORMATION piClient{};
    fSuccess = !!CreateProcessW(
        nullptr,
-@@ -416,7 +476,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -416,7 +490,10 @@
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -717,7 +744,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,8 +489,47 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,8 +503,48 @@
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -735,13 +762,14 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
 +  // EXPLICIT teardown exact, not to redefine what a clean exit means.
 +  HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
 +  if (hJob != nullptr) {
-+    // Why BREAKAWAY_OK and not a bare job: with no limits set, a child asking
-+    // for CREATE_BREAKAWAY_FROM_JOB is refused with ERROR_ACCESS_DENIED.
-+    // Installers, msiexec and some updater and service-control paths spawn that
-+    // way deliberately, so a bare job breaks them ONLY inside an Orca terminal.
-+    // With this flag a child has to ask, so ordinary descendants stay owned.
++    // Native shells retain explicit breakaway for installers and updaters.
++    // MSYS requests breakaway automatically for ordinary children whenever
++    // this flag is present, so its shells need strict per-PTY membership.
++    // Explicit breakaway requests inside an MSYS pane are consequently denied;
++    // ordinary backgrounding and clean shell exit remain supported.
 +    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimits{};
-+    jobLimits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_BREAKAWAY_OK;
++    jobLimits.BasicLimitInformation.LimitFlags =
++        handle->allowJobBreakaway ? JOB_OBJECT_LIMIT_BREAKAWAY_OK : 0;
 +    if (!SetInformationJobObject(hJob, JobObjectExtendedLimitInformation, &jobLimits, sizeof(jobLimits)) ||
 +        !AssignProcessToJobObject(hJob, piClient.hProcess)) {
 +      // Why tolerate failure: an outer job without JOB_OBJECT_LIMIT_BREAKAWAY_OK
@@ -767,7 +795,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
    if (useConptyDll && fLoadedDll)
    {
      PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
-@@ -440,6 +542,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +557,8 @@
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -776,11 +804,16 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -544,29 +648,215 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -544,27 +663,213 @@
    int id = info[0].As<Napi::Number>().Int32Value();
    const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
  
 -  const pty_baton* handle = get_pty_baton(id);
+-
+-  if (handle != nullptr) {
+-    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+-    bool fLoadedDll = hLibrary != nullptr;
+-    if (fLoadedDll)
 +  // Orca: resolve the DLL BEFORE touching any baton state, for the same reason
 +  // PtyConnect does it before creating anything. LoadConptyDll throws when
 +  // conpty.dll is missing, and a throw after consoleClosed was set would strand
@@ -794,18 +827,7 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
 +      (HMODULE)hLibrary,
 +      useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
 +  }
- 
--  if (handle != nullptr) {
--    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
--    bool fLoadedDll = hLibrary != nullptr;
--    if (fLoadedDll)
--    {
--      PFNCLOSEPSEUDOCONSOLE const pfnClosePseudoConsole = (PFNCLOSEPSEUDOCONSOLE)GetProcAddress(
--        (HMODULE)hLibrary,
--        useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
--      if (pfnClosePseudoConsole)
--      {
--        pfnClosePseudoConsole(handle->hpc);
++
 +  // Orca: the baton now outlives the shell, so this runs on a self-exited pty
 +  // too -- that is the whole point. Take what we need under the lock: the
 +  // watcher thread nulls hShell the moment the shell dies, and TerminateProcess
@@ -841,18 +863,26 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
 +        const bool removed = remove_pty_baton(id);
 +        assert(removed);
 +        (void)removed;
-       }
++      }
 +      // Else the shell is still running and the watcher frees the baton.
-     }
--    if (useConptyDll) {
--      TerminateProcess(handle->hShell, 1);
++    }
 +  }
 +
 +  // Why outside the lock: ClosePseudoConsole blocks until the conout side has
 +  // drained, and the watcher must be able to take the lock while it does.
 +  if (owed) {
 +    if (pfnClosePseudoConsole)
-+    {
+     {
+-      PFNCLOSEPSEUDOCONSOLE const pfnClosePseudoConsole = (PFNCLOSEPSEUDOCONSOLE)GetProcAddress(
+-        (HMODULE)hLibrary,
+-        useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
+-      if (pfnClosePseudoConsole)
+-      {
+-        pfnClosePseudoConsole(handle->hpc);
+-      }
+-    }
+-    if (useConptyDll) {
+-      TerminateProcess(handle->hShell, 1);
 +      pfnClosePseudoConsole(hpc);
 +    }
 +    if (hShellDup != nullptr) {
@@ -862,8 +892,8 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
    }
  
    return env.Undefined();
- }
- 
++}
++
 +/**
 + * Orca: confirm a baton really is the pty the caller means.
 + *
@@ -1001,12 +1031,10 @@ index 7b286d3d644c26141df516929703aa6e129df4b2..4aed260dd68e6a171dcfd349e9a7c5c9
 +  }
 +  hHostJob = job;
 +  return Napi::Boolean::New(env, true);
-+}
-+
+ }
+ 
  /**
- * Init
- */
-@@ -577,6 +867,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +882,9 @@
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/patches/node-pty@1.1.0.patch
+++ b/config/patches/node-pty@1.1.0.patch
@@ -689,34 +689,36 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  
      auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
      switch (status) {
-@@ -242,6 +294,18 @@
+@@ -242,6 +294,20 @@
    return HRESULT_FROM_WIN32(GetLastError());
  }
  
-+// MSYS automatically escapes any job that advertises breakaway support.
-+static bool isMsysShell(const std::wstring& shellpath) {
++// Cygwin and MSYS request breakaway for every child whenever the job allows it,
++// so their shells need one that does not. The runtime DLL on the exe's search
++// path is the signal; Git for Windows ships bash.exe in bin\ beside usr\bin\.
++static bool usesCygwinRuntime(const std::wstring& shellpath) {
 +  const size_t separator = shellpath.find_last_of(L"\\/");
 +  if (separator == std::wstring::npos) return false;
-+  const std::wstring name = shellpath.substr(separator + 1);
-+  if (_wcsicmp(name.c_str(), L"bash.exe") != 0 &&
-+      _wcsicmp(name.c_str(), L"sh.exe") != 0) return false;
 +  const std::wstring directory = shellpath.substr(0, separator + 1);
-+  return path_util::file_exists(directory + L"msys-2.0.dll") ||
-+         path_util::file_exists(directory + L"..\\usr\\bin\\msys-2.0.dll");
++  for (const wchar_t* dll : {L"msys-2.0.dll", L"cygwin1.dll"}) {
++    if (path_util::file_exists(directory + dll) ||
++        path_util::file_exists(directory + L"..\\usr\\bin\\" + dll)) return true;
++  }
++  return false;
 +}
 +
  static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
    Napi::Env env(info.Env());
    Napi::HandleScope scope(env);
-@@ -303,6 +367,7 @@
+@@ -303,6 +369,7 @@
      marshal.Set("pty", Napi::Number::New(env, ptyId));
      ptyHandles.emplace_back(
          std::make_unique<pty_baton>(ptyId, hIn, hOut, hpc));
-+    ptyHandles.back()->allowJobBreakaway = !isMsysShell(shellpath);
++    ptyHandles.back()->allowJobBreakaway = !usesCygwinRuntime(shellpath);
    } else {
      throw Napi::Error::New(env, "Cannot launch conpty");
    }
-@@ -409,6 +474,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -409,6 +476,15 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "UpdateProcThreadAttribute failed");
    }
  
@@ -732,7 +734,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
    PROCESS_INFORMATION piClient{};
    fSuccess = !!CreateProcessW(
        nullptr,
-@@ -416,7 +490,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -416,7 +492,10 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
        nullptr,                      // lpProcessAttributes
        nullptr,                      // lpThreadAttributes
        false,                        // bInheritHandles VERY IMPORTANT that this is false
@@ -744,7 +746,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
        envArg,                       // lpEnvironment
        mutableCwd.get(),             // lpCurrentDirectory
        &siEx.StartupInfo,            // lpStartupInfo
-@@ -426,8 +503,48 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -426,8 +505,48 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
      throw errorWithCode(info, "Cannot create process");
    }
  
@@ -763,9 +765,9 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
 +  HANDLE hJob = CreateJobObjectW(nullptr, nullptr);
 +  if (hJob != nullptr) {
 +    // Native shells retain explicit breakaway for installers and updaters.
-+    // MSYS requests breakaway automatically for ordinary children whenever
-+    // this flag is present, so its shells need strict per-PTY membership.
-+    // Explicit breakaway requests inside an MSYS pane are consequently denied;
++    // Cygwin/MSYS shells take it automatically for ordinary children whenever
++    // this flag is present, so they get strict per-PTY membership instead.
++    // Explicit breakaway requests inside such a pane are consequently denied;
 +    // ordinary backgrounding and clean shell exit remain supported.
 +    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobLimits{};
 +    jobLimits.BasicLimitInformation.LimitFlags =
@@ -795,7 +797,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
    if (useConptyDll && fLoadedDll)
    {
      PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
-@@ -440,6 +557,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+@@ -440,6 +559,8 @@ static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
  
    // Update handle
    handle->hShell = piClient.hProcess;
@@ -804,7 +806,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  
    // Close the thread handle to avoid resource leak
    CloseHandle(piClient.hThread);
-@@ -544,27 +663,213 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+@@ -544,27 +665,213 @@ static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
    int id = info[0].As<Napi::Number>().Int32Value();
    const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
  
@@ -1034,7 +1036,7 @@ diff --git a/src/win/conpty.cc b/src/win/conpty.cc
  }
  
  /**
-@@ -577,6 +882,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
+@@ -577,6 +884,9 @@ Napi::Object init(Napi::Env env, Napi::Object exports) {
    exports.Set("resize", Napi::Function::New(env, PtyResize));
    exports.Set("clear", Napi::Function::New(env, PtyClear));
    exports.Set("kill", Napi::Function::New(env, PtyKill));

--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -222,6 +222,7 @@ const WINDOWS_PACKAGE_TESTS = [
   'src/main/agent-hooks/windows-hook-payload-delivery.test.ts',
   'src/main/agent-hooks/windows-direct-cmd-hook-command.test.ts',
   'src/main/windows/windows-pty-job.win32.test.ts',
+  'src/main/windows/windows-msys-job.win32.test.ts',
   'src/main/windows/windows-host-job.win32.test.ts',
   'src/main/windows/windows-process-tree-command-line-patch.test.ts',
   'src/main/windows-live-tree-kill.win32.test.ts',

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -547,6 +547,14 @@ running, so typing `exit` in a pane reaped a `start /b` server that used to
 survive. The job exists to make an _explicit_ teardown exact, not to redefine
 what a clean exit means.
 
+Git Bash needs one additional restriction: MSYS automatically requests
+`CREATE_BREAKAWAY_FROM_JOB` for ordinary children whenever the job permits it.
+The per-PTY job therefore omits `BREAKAWAY_OK` for `bash.exe` and `sh.exe`
+with an adjacent MSYS runtime, including Git's `bin` launcher beside `usr/bin`.
+Native shells retain explicit breakaway support. Inside an MSYS pane, a native
+program explicitly requesting breakaway can receive `ERROR_ACCESS_DENIED`;
+ordinary backgrounding remains supported. The daemon's host job is unchanged.
+
 Reaping a dead daemon's shells (#9195, #10415) is therefore a **second, nested
 job**, not this one. The terminal daemon assigns itself to a kill-on-close job
 at startup (`assignHostProcessToKillOnCloseJob`); children inherit membership,

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -547,13 +547,19 @@ running, so typing `exit` in a pane reaped a `start /b` server that used to
 survive. The job exists to make an _explicit_ teardown exact, not to redefine
 what a clean exit means.
 
-Git Bash needs one additional restriction: MSYS automatically requests
-`CREATE_BREAKAWAY_FROM_JOB` for ordinary children whenever the job permits it.
-The per-PTY job therefore omits `BREAKAWAY_OK` for `bash.exe` and `sh.exe`
-with an adjacent MSYS runtime, including Git's `bin` launcher beside `usr/bin`.
-Native shells retain explicit breakaway support. Inside an MSYS pane, a native
-program explicitly requesting breakaway can receive `ERROR_ACCESS_DENIED`;
-ordinary backgrounding remains supported. The daemon's host job is unchanged.
+Git Bash needs one additional restriction. The Cygwin runtime — and the MSYS2
+fork of it that Git for Windows ships — reads `JOB_OBJECT_LIMIT_BREAKAWAY_OK`
+off its own job and then adds `CREATE_BREAKAWAY_FROM_JOB` to **every** child it
+spawns when that flag is set (`spawn.cc`, there since 2011), so offering
+breakaway hands the whole tree its escape. The per-PTY job therefore omits
+`BREAKAWAY_OK` whenever `msys-2.0.dll` or `cygwin1.dll` sits on the shell's DLL
+search path — beside the executable, or under `usr/bin` for Git's `bin`
+launcher. Native shells keep explicit breakaway. Denying it costs Cygwin
+nothing, because it *pre-checks* the limit rather than retrying, so no spawn
+fails; but a *native* program that passes `CREATE_BREAKAWAY_FROM_JOB` itself
+inside such a pane now gets `ERROR_ACCESS_DENIED`. `nohup` and `disown` are
+unaffected — they are Cygwin signal/session concepts, unrelated to job
+membership. The daemon's host job is unchanged.
 
 Reaping a dead daemon's shells (#9195, #10415) is therefore a **second, nested
 job**, not this one. The terminal daemon assigns itself to a kill-on-close job

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: 7cc9d45f3d2c38f142490d0805e75db55f0eef5174ad41c4b52abc5fbe079ad1
+  node-pty@1.1.0: 155b782b095e46af704d5bb4808c98aa76452ae874dad745ca096e63a8184d52
 
 importers:
 
@@ -160,7 +160,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=7cc9d45f3d2c38f142490d0805e75db55f0eef5174ad41c4b52abc5fbe079ad1)
+        version: 1.1.0(patch_hash=155b782b095e46af704d5bb4808c98aa76452ae874dad745ca096e63a8184d52)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12285,7 +12285,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=7cc9d45f3d2c38f142490d0805e75db55f0eef5174ad41c4b52abc5fbe079ad1):
+  node-pty@1.1.0(patch_hash=155b782b095e46af704d5bb4808c98aa76452ae874dad745ca096e63a8184d52):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: d82c0be8c2fa503d7fa5039aefc67324c2b613bfafb4f0f18fd0a75e6682fd5c
+  node-pty@1.1.0: 842f7d3b383c20cedc70ba6f48942abba7a7c73225015645609bff87d41ffade
 
 importers:
 
@@ -160,7 +160,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=d82c0be8c2fa503d7fa5039aefc67324c2b613bfafb4f0f18fd0a75e6682fd5c)
+        version: 1.1.0(patch_hash=842f7d3b383c20cedc70ba6f48942abba7a7c73225015645609bff87d41ffade)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12285,7 +12285,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=d82c0be8c2fa503d7fa5039aefc67324c2b613bfafb4f0f18fd0a75e6682fd5c):
+  node-pty@1.1.0(patch_hash=842f7d3b383c20cedc70ba6f48942abba7a7c73225015645609bff87d41ffade):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: 155b782b095e46af704d5bb4808c98aa76452ae874dad745ca096e63a8184d52
+  node-pty@1.1.0: d82c0be8c2fa503d7fa5039aefc67324c2b613bfafb4f0f18fd0a75e6682fd5c
 
 importers:
 
@@ -160,7 +160,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=155b782b095e46af704d5bb4808c98aa76452ae874dad745ca096e63a8184d52)
+        version: 1.1.0(patch_hash=d82c0be8c2fa503d7fa5039aefc67324c2b613bfafb4f0f18fd0a75e6682fd5c)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12285,7 +12285,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=155b782b095e46af704d5bb4808c98aa76452ae874dad745ca096e63a8184d52):
+  node-pty@1.1.0(patch_hash=d82c0be8c2fa503d7fa5039aefc67324c2b613bfafb4f0f18fd0a75e6682fd5c):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,7 +116,7 @@ patchedDependencies:
   '@xterm/addon-webgl@0.20.0-beta.299': 94687e89a0115e6e6aa102837f986debdc029c091527ee5eb4a4e17ceaf9473e
   '@xterm/xterm@6.1.0-beta.303': 98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d
   lint-staged@16.4.0: 7333b3837f80a7fbd045964db6d76ba4fc118e49134bdbabb00585b6b7b60673
-  node-pty@1.1.0: 842f7d3b383c20cedc70ba6f48942abba7a7c73225015645609bff87d41ffade
+  node-pty@1.1.0: bac3a53fb15efc9b3b944fbe3c4718b5174a0b3bd6ead84e21975edad4bc6615
 
 importers:
 
@@ -160,7 +160,7 @@ importers:
         version: 3.3.1
       node-pty:
         specifier: ^1.1.0
-        version: 1.1.0(patch_hash=842f7d3b383c20cedc70ba6f48942abba7a7c73225015645609bff87d41ffade)
+        version: 1.1.0(patch_hash=bac3a53fb15efc9b3b944fbe3c4718b5174a0b3bd6ead84e21975edad4bc6615)
       posthog-node:
         specifier: ^5.33.3
         version: 5.33.3
@@ -12285,7 +12285,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-pty@1.1.0(patch_hash=842f7d3b383c20cedc70ba6f48942abba7a7c73225015645609bff87d41ffade):
+  node-pty@1.1.0(patch_hash=bac3a53fb15efc9b3b944fbe3c4718b5174a0b3bd6ead84e21975edad4bc6615):
     dependencies:
       node-addon-api: 7.1.1
 

--- a/src/main/windows/windows-msys-job.win32.test.ts
+++ b/src/main/windows/windows-msys-job.win32.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { resolveGitBashPath } from '../git-bash'
+import { quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { listPtyJobProcessIds, terminatePtyJob } from './windows-pty-job'
+
+const describeOnWindows = process.platform === 'win32' ? describe : describe.skip
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+describeOnWindows('MSYS terminal job ownership', () => {
+  it('retains and terminates a child across Git Bash shell replacement', async () => {
+    const shell = resolveGitBashPath()
+    expect(shell, 'Git for Windows must be installed on the native test runner').not.toBeNull()
+    const directory = mkdtempSync(join(tmpdir(), 'orca-msys-job-'))
+    const script = join(directory, 'owned-child.js')
+    writeFileSync(
+      script,
+      "console.log('MSYS_OWNED_CHILD=' + process.pid); setInterval(() => {}, 1000)\n"
+    )
+    const pty = await import('node-pty')
+    const proc = pty.spawn(shell!, ['-c', 'exec "$BASH" --noprofile --norc -i'], {
+      cwd: tmpdir(),
+      cols: 120,
+      rows: 30,
+      useConptyDll: true
+    })
+    let output = ''
+    let childPid: number | undefined
+    proc.onData((chunk) => {
+      output += chunk
+      const match = /MSYS_OWNED_CHILD=(\d+)/.exec(output)
+      if (match) {
+        childPid = Number(match[1])
+      }
+    })
+    try {
+      proc.write(
+        `${quotePosixShell(process.execPath.replace(/\\/g, '/'))} ${quotePosixShell(script.replace(/\\/g, '/'))}\r`
+      )
+      await vi.waitFor(() => expect(childPid).toBeDefined(), { timeout: 15_000 })
+      expect(isAlive(childPid!)).toBe(true)
+      expect(listPtyJobProcessIds(proc)).toContain(childPid)
+      expect(terminatePtyJob(proc)).toBe('terminated')
+      await vi.waitFor(() => expect(isAlive(childPid!)).toBe(false), { timeout: 5_000 })
+    } finally {
+      // The failing baseline can leave this exact fixture child outside the job.
+      if (childPid && isAlive(childPid)) {
+        process.kill(childPid)
+      }
+      proc.kill()
+      rmSync(directory, { recursive: true, force: true })
+    }
+  }, 30_000)
+})

--- a/src/main/windows/windows-msys-job.win32.test.ts
+++ b/src/main/windows/windows-msys-job.win32.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
+import { removeTreeSync } from '../../shared/windows-transient-lock-removal'
 import { resolveGitBashPath } from '../git-bash'
 import { quotePosixShell } from '../../shared/wsl-login-shell-command'
 import { listPtyJobProcessIds, terminatePtyJob } from './windows-pty-job'
@@ -58,7 +59,7 @@ describeOnWindows('MSYS terminal job ownership', () => {
         process.kill(childPid)
       }
       proc.kill()
-      rmSync(directory, { recursive: true, force: true })
+      removeTreeSync(directory)
     }
   }, 30_000)
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, Orca keeps each terminal's programs in a labelled bundle so it can stop all of them together later. Git Bash was quietly taking every program it started _out_ of that bundle, because Windows offers an opt-out and Git Bash takes it whenever it is offered. So when Orca tried to shut a terminal down, some of those programs just kept running — and because they still had the project folder open, Orca could not delete or clean up that folder afterwards. What you saw was a workspace that refused to go away, or an agent that looked stopped but was not. Now Orca stops offering the opt-out to Git Bash terminals, so what a terminal starts stays with the terminal and really does stop when you close it.

## What Changed

The node-pty native patch omits `JOB_OBJECT_LIMIT_BREAKAWAY_OK` from the per-PTY job when the shell ships the Cygwin/MSYS runtime — decided by probing for `msys-2.0.dll` or `cygwin1.dll` on the shell's own DLL search path (beside the executable, or under `usr/bin` for Git's `bin` launcher). Native shells and the daemon's host job keep their existing policy. The patch hash is updated, and a Windows regression test verifies job membership and termination across shell replacement.

## Why

Cygwin — and the MSYS2 fork of it that Git for Windows ships — reads `JOB_OBJECT_LIMIT_BREAKAWAY_OK` off its own job and then adds `CREATE_BREAKAWAY_FROM_JOB` to **every** child it spawns when that flag is set. This is in `winsup/cygwin/spawn.cc` and has been since 2011; it is a pre-check, not a retry, so denying breakaway never fails a spawn. Offering breakaway therefore handed the entire Git Bash tree its escape. CI captured Git Bash's interactive shell and golden Node stub outside the otherwise successfully assigned job. The stub's intermediate parent exited, so process-tree cleanup also missed it, leaving the test repository locked.

## Tradeoffs

Real, user-facing costs of this change — not "none":

1. **Background work in a Git Bash tab now dies when you close that tab.** `pty:kill` uses `immediate: true`, which routes to job termination. A `npm run dev &` or a `start /b` server launched in a Git Bash pane used to escape the job and survive a tab close; it no longer does. Mitigating context: `cmd.exe` and PowerShell panes have always behaved this way, and `local-pty-provider-state.ts` already documents the contract as "plain terminals preserve nohup children **except on immediate win32 shutdown**" — Git Bash was the accidental exception. A clean `exit`, normal app quit, and update-install quit are all still unaffected, because the per-PTY job deliberately has no `KILL_ON_JOB_CLOSE`.
2. **Installers/updaters that explicitly request breakaway can fail inside a Git Bash pane** with `ERROR_ACCESS_DENIED`. Nothing Orca ships does this, and UAC-elevated children get a different parent anyway, but a user pasting such a command into a Git Bash tab is a real path. Native shells are unaffected.
3. **Forward-compat, silent:** Cygwin ≥ 3.7 assigns processes to a per-user job object for rlimits at DLL init. Inside a job that forbids breakaway that assignment fails; Cygwin logs and continues, so nothing breaks loudly, but `ulimit`-style limits would quietly stop being enforced in Git Bash panes.
4. **Still shell-of-record only.** The policy is chosen once, from the PTY's shell executable. Typing `bash` inside a PowerShell or `cmd.exe` pane still gets a breakaway-permitting job, so that path can still orphan processes. This is a pre-existing gap this change does not close.
5. **Native patch surface.** This lives in a patched node-pty, so every node-pty upgrade must re-apply and re-validate it on Windows CI.

Checked and found _not_ to be tradeoffs: no new EDR-scored pattern (only a `LimitFlags` bit on a `SetInformationJobObject` call that already ran every spawn — no new process, interpreter, `-ExecutionPolicy`, `Add-Type`, or `cmd.exe /c`); killing a per-PTY job cannot reach the app or the daemon, and the ConPTY console host is not a job member because `CreatePseudoConsole` runs before the job exists; nested jobs are Windows 8+ and Orca's floor is Windows 10, with assignment failure degrading to pre-job behaviour; `nohup` and `disown` are Cygwin signal/session concepts, unrelated to job membership.

## Review follow-up applied

Review widened the detector. It originally probed only `msys-2.0.dll` and only for basenames `bash.exe`/`sh.exe`, which left two reachable gaps: Cygwin ships the identical `spawn.cc` breakaway logic under `cygwin1.dll`, and an MSYS2 `zsh.exe` escapes exactly like its `bash.exe` does. `terminalWindowsShell` is a bare string and an unrecognized value is spawned verbatim, so both are reachable. Probing the runtime DLL on the shell's own search path is the property that actually decides whether the runtime will ask for breakaway, and it removes the shell-name special-casing.

## Linked Issue

Discovered during the test-deflaking audit; related native ownership bugs #9045 and #10475.

## Visual Proof

N/A — process ownership change with no rendered surface. Local Electron launches are paused for this task; rendered launch validation runs exclusively in CI.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

- Native patch contract tests: 5 passed locally; new regression lint passed.
- Baseline [34027657422](https://github.com/stablyai/orca/actions/runs/34027657422): three Git Bash launches passed, but teardown failed with surviving stub processes and incomplete job membership.
- Causal experiment [34028324769](https://github.com/stablyai/orca/actions/runs/34028324769): strict per-PTY jobs with unchanged host policy produced three passing launches, full membership and clean teardown. That experiment applied to every shell; this candidate scopes the policy to the Cygwin/MSYS runtime.
- Full native Windows Electron launch matrix [34028935900](https://github.com/stablyai/orca/actions/runs/34028935900): **15 passed, 3 WSL skips, clean global teardown**, with no surviving stub processes. WSL was not provisioned in this run.
- Native candidate regression and existing job contracts [34028890229](https://github.com/stablyai/orca/actions/runs/34028890229): patched job **8 passed**. Separate unchanged-baseline run [34028967625](https://github.com/stablyai/orca/actions/runs/34028967625): **7 passed, only the new MSYS regression failed**, because the live child was absent from the job. The original combined baseline job failed during setup and is not used as regression evidence.
- Current-main Windows golden validation [34051368861](https://github.com/stablyai/orca/actions/runs/34051368861): 15 tests, clean repository teardown after every batch. Matching unpatched main run [34049582426](https://github.com/stablyai/orca/actions/runs/34049582426) failed with EPERM during repository cleanup immediately after the Git Bash agent-launch batch.
- CI integration corrections: all **45 focused checks passed** after restoring native patch hunk labels, registering the new test in the Windows path selector, and using the existing Windows tree-removal helper. Application code is unchanged by these corrections.
- Detector-widening commit: verified the regenerated patch applies cleanly to a pristine `node-pty@1.1.0`, compiled the detector standalone against stubbed `path_util` (warning-free) and asserted 9 path cases — Git `bin\` launcher, Git `usr\bin\`, MSYS2 `zsh.exe`, Cygwin `bash.exe`, forward-slash form all detected; `cmd.exe`, `wsl.exe`, `mingw64\gdb.exe`, bare relative name all rejected. `pnpm tc`, the changed-code quality gate, and the related unit suites pass.

Ready for review; do not merge automatically. No launch retries, timeout increases, or weakened assertions added.

## AI Disclosure

## Review

Self-reviewed with native and rendered before/after evidence; final CI and pullfrog passed. Additionally reviewed against the upstream Cygwin/msys2-runtime source and by a multi-model severity counsel: no release-blocking findings; the items above are recorded as tradeoffs and residual risk. Do not merge automatically.

## Agent skill upstream boundary

- [x] Not applicable; no skill source changes.

## Notes

Windows-only native implementation; no new RPC fields, SSH execution changes, or filesystem cleanup scope. The resolved shell executable determines the policy for worktree and folder terminals alike.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Validation complete
