### PR TITLE
fix(file-explorer): preserve ignored state when expanding symlinks

### DIFF
--- a/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFileExplorerIgnoredPaths } from './use-file-explorer-ignored-paths'
+
+const getRuntimeGitIgnoredPathsMock = vi.hoisted(() => vi.fn())
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitIgnoredPaths: getRuntimeGitIgnoredPathsMock
+}))
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: () => undefined
+}))
+vi.mock('./file-explorer-runtime-owner', () => ({
+  getRightSidebarWorktreeRuntimeSettings: () => ({ activeRuntimeEnvironmentId: null })
+}))
+
+const initialProps = {
+  activeWorktreeId: 'worktree-1',
+  worktreePath: '/repo',
+  relativePaths: ['.DS_Store', '.agents']
+}
+
+function useIgnoredPaths(props: typeof initialProps) {
+  return useFileExplorerIgnoredPaths({
+    ...props,
+    canLoadIgnoredPaths: true,
+    shouldDebounceIgnoredQuery: false
+  })
+}
+
+describe('file explorer ignored-path query failures', () => {
+  beforeEach(() => {
+    getRuntimeGitIgnoredPathsMock.mockReset()
+  })
+
+  afterEach(cleanup)
+
+  it('preserves decorations after a failed refresh and accepts a later empty success', async () => {
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce(['.DS_Store', '.agents'])
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+    await act(async () => {})
+    expect(hook.result.current).toEqual(['.DS_Store', '.agents'])
+
+    getRuntimeGitIgnoredPathsMock.mockRejectedValueOnce(new Error('Git query failed'))
+    await act(async () => {
+      hook.rerender({ ...initialProps, relativePaths: [...initialProps.relativePaths, 'src'] })
+    })
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(2)
+    expect(hook.result.current).toEqual(['.DS_Store', '.agents'])
+
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce([])
+    await act(async () => {
+      hook.rerender(initialProps)
+    })
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(3)
+    expect(hook.result.current).toEqual([])
+  })
+
+  it.each([
+    { activeWorktreeId: 'worktree-2', worktreePath: '/repo' },
+    { activeWorktreeId: 'worktree-1', worktreePath: '/other-repo' }
+  ])('does not carry decorations into a failing new context: %j', async (context) => {
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce(['.DS_Store'])
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+    await act(async () => {})
+    expect(hook.result.current).toEqual(['.DS_Store'])
+
+    getRuntimeGitIgnoredPathsMock.mockRejectedValueOnce(new Error('Host unavailable'))
+    await act(async () => {
+      hook.rerender({ ...initialProps, ...context })
+    })
+    expect(getRuntimeGitIgnoredPathsMock).toHaveBeenCalledTimes(2)
+    expect(hook.result.current).toEqual([])
+  })
+
+  it('keeps an empty state when the first query fails', async () => {
+    getRuntimeGitIgnoredPathsMock.mockRejectedValueOnce(new Error('Host unavailable'))
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+    await act(async () => {})
+    expect(hook.result.current).toEqual([])
+  })
+
+  it('does not let a late failure replace a newer successful query', async () => {
+    let rejectOldQuery!: (error: Error) => void
+    getRuntimeGitIgnoredPathsMock.mockReturnValueOnce(
+      new Promise<string[]>((_resolve, reject) => {
+        rejectOldQuery = reject
+      })
+    )
+    const hook = renderHook(useIgnoredPaths, { initialProps })
+
+    getRuntimeGitIgnoredPathsMock.mockResolvedValueOnce(['.DS_Store'])
+    await act(async () => {
+      hook.rerender({ ...initialProps, relativePaths: ['.DS_Store'] })
+    })
+    expect(hook.result.current).toEqual(['.DS_Store'])
+
+    await act(async () => {
+      rejectOldQuery(new Error('Late failure'))
+    })
+    expect(hook.result.current).toEqual(['.DS_Store'])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
+++ b/src/renderer/src/components/right-sidebar/use-file-explorer-ignored-paths.ts
@@ -75,9 +75,8 @@ export function useFileExplorerIgnoredPaths({
           }
         })
         .catch(() => {
-          if (!canceled) {
-            setIgnoredPathResult({ activeWorktreeId, paths: [], worktreePath })
-          }
+          // A failed query is not an empty result. Keep the last successful
+          // result; getEffectiveFileExplorerIgnoredPaths guards worktree changes.
         })
     }
 

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { DirCache, TreeNode } from './file-explorer-types'
+import { isPathIgnored } from './status-display'
 import {
   createVisibleFileExplorerRowProjection,
   getFileExplorerIgnoredQueryRelativePaths
@@ -334,6 +335,64 @@ describe('file explorer visible row projection', () => {
       'collapsed'
     ])
   })
+
+  it.each([false, true])(
+    'inherits the link ignored state (%s) without querying descendants',
+    (ignored) => {
+      const treeInput = input(
+        {
+          '/repo': [row('.DS_Store'), row('config', true)],
+          '/repo/config': [
+            { ...row('config/.agents', true), isSymlink: true },
+            row('config/.agents-extra', true),
+            row('config/.claude', true)
+          ],
+          '/repo/config/.agents': [row('config/.agents/skills', true)],
+          '/repo/config/.agents/skills': [row('config/.agents/skills/SKILL.md')],
+          '/repo/config/.agents-extra': [row('config/.agents-extra/settings.json')],
+          '/repo/config/.claude': [row('config/.claude/settings.json')]
+        },
+        [
+          '/repo/config',
+          '/repo/config/.agents',
+          '/repo/config/.agents/skills',
+          '/repo/config/.agents-extra',
+          '/repo/config/.claude'
+        ]
+      )
+
+      expect(getFileExplorerIgnoredQueryRelativePaths(treeInput, true)).toEqual([
+        '.DS_Store',
+        'config',
+        'config/.agents',
+        'config/.agents-extra',
+        'config/.agents-extra/settings.json',
+        'config/.claude',
+        'config/.claude/settings.json'
+      ])
+
+      const ignoredSet = new Set(['.DS_Store', 'config/.claude/settings.json'])
+      if (ignored) {
+        ignoredSet.add('config/.agents')
+      }
+      const options = { ignoredSet, showDotfiles: true, showGitIgnoredFiles: true }
+      const shown = createVisibleFileExplorerRowProjection(treeInput, options)
+      const childPath = '/repo/config/.agents/skills/SKILL.md'
+      expect(shown.hasPath(childPath)).toBe(true)
+      expect(isPathIgnored(ignoredSet, 'config/.agents/skills/SKILL.md')).toBe(ignored)
+      expect(isPathIgnored(ignoredSet, 'config/.agents-extra/settings.json')).toBe(false)
+      expect(isPathIgnored(ignoredSet, '.DS_Store')).toBe(true)
+
+      const hidden = createVisibleFileExplorerRowProjection(treeInput, {
+        ...options,
+        showGitIgnoredFiles: false
+      })
+      expect(hidden.hasPath('/repo/config/.agents')).toBe(!ignored)
+      expect(hidden.hasPath(childPath)).toBe(!ignored)
+      expect(hidden.hasPath('/repo/.DS_Store')).toBe(false)
+      expect(hidden.hasPath('/repo/config/.agents-extra/settings.json')).toBe(true)
+    }
+  )
 
   it('keeps same-worktree ignored paths while an expanded-folder query is loading', () => {
     expect(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerVisibleRowProjection.ts
@@ -51,7 +51,8 @@ export function getFileExplorerIgnoredQueryRelativePaths(
         continue
       }
       relativePaths.push(row.relativePath)
-      if (row.isDirectory && expanded.has(row.path)) {
+      // Git checks the link itself; descendants inherit its ignored state.
+      if (row.isDirectory && !row.isSymlink && expanded.has(row.path)) {
         visitChildren(row.path)
       }
     }


### PR DESCRIPTION
## ELI5

Opening a linked folder should not remove the ignored-file markings elsewhere in the file explorer. This keeps those markings intact and lets the linked folder's contents inherit the link's ignored state.

## What Changed

- Include the symlink entry in Git ignored-path queries, but stop query traversal at that entry.
- Keep the existing ancestor lookup for descendant styling and ignored-file hiding.
- Preserve the last successful ignored-path result after a failed query. A later successful empty result still clears the markings.
- Add regression tests for traversal, inheritance, failed refreshes, recovery, and worktree isolation.

## Why

With `.agents -> ./.claude`, expanding `.agents` previously sent paths such as `.agents/settings.json` to `git check-ignore`. Git rejects paths beyond a symbolic link with exit code 128. The renderer then replaced all ignored paths with an empty list.

Git manages the link entry rather than its target contents. Querying that entry and inheriting its ignored state avoids the invalid descendant query. Keeping the last successful result also prevents unrelated query failures from clearing existing decorations.

## Linked Issue

No tracking issue yet; pending before this draft is ready for review.

Related: #7210 handles normal `check-ignore` exit code 1, not the symlink-descendant error addressed here.

## Visual Proof

Before/after recordings from manual testing on macOS.

**Before**

https://github.com/user-attachments/assets/aed9b375-eee0-4167-8a89-ca86de295de6

**After**

https://github.com/user-attachments/assets/c51b7c7c-5ff9-4702-9d13-c0de2a044533

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual testing on macOS: opened the affected workspace and expanded `.agents -> ./.claude`; before/after recordings are attached above.

Automated validation completed on Linux:

- `pnpm lint` — passed.
- `pnpm typecheck` — passed (node, CLI, and web).
- Full `pnpm test` — 2,798 test files passed, 9 skipped; 29,625 tests passed, 55 skipped.
- `pnpm build` — passed, including desktop and web builds and web artifact verification.
- Focused regression suite: 4 files, 33 tests passed.
- Changed-file React Doctor lint, `oxfmt --check`, and `git diff --check` passed.

Test environment: the first full run had 10 failures because the server's personal `~/.config/git/ignore` ignores `*.log`, affecting Git test fixtures. The complete suite passed when rerun with `XDG_CONFIG_HOME` set to an empty temporary directory. Personal Git settings and repository code were not changed to obtain this result.

Regression coverage includes nested symlinks, ignored/non-ignored links, similarly named neighboring directories, direct target paths, ignored-file hiding, query failure and recovery, worktree changes, and late failures. A separate real-Git reproduction confirmed that querying a symlink descendant fails with exit code 128.

Live Windows and SSH verification were not performed.

## AI Disclosure

OpenAI Codex (GPT-6) assisted with implementation, regression tests, code review, and this description.

## Review

Reviewed ignored-query traversal separately from visible-tree traversal: linked contents remain expandable, while Git receives only the link entry. Verified existing ancestor-based ignore inheritance and preservation of successful results without carrying decorations into a different worktree ID or path. Name filtering retains its existing file listing, which does not follow symlinks.

Checked macOS, Linux, Windows, and SSH/remote compatibility in code. The shared renderer consumes existing symlink metadata. No new path parsing, shell commands, shortcuts, labels, or Electron-specific behavior was introduced. Live platform coverage is limited as stated above.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: no new IPC endpoints, permissions, dependencies, or target traversal. Existing Git commands receive fewer paths.

Scope: desktop file explorer; no mobile code changes. Initial link classification, sorting, and activation remain unchanged. Local and remote queries use the same renderer traversal. Skipping descendants reduces query work.

After a failed query, markings can remain stale until the next successful refresh. Results remain scoped to the active worktree.

Replaces #19067 using the current upstream main PR template. The implementation is unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
