### PR TITLE
re-authorize replacement agent after crash via dispatch-show recapability

### DIFF
--- a/src/cli/handlers/orchestration/dispatch-handlers.ts
+++ b/src/cli/handlers/orchestration/dispatch-handlers.ts
@@ -44,7 +44,7 @@ export const ORCHESTRATION_DISPATCH_INSPECTION_HANDLERS: Record<string, CommandH
     const showPreamble = flags.has('preamble') ? true : undefined
     const recapability = flags.has('recapability') ? true : undefined
     // Why: a preview must embed the same real coordinator handle as an actual dispatch.
-    const from = showPreamble
+    const from = showPreamble || recapability
       ? await resolveCoordinatorTerminalHandle(flags, cwd, client)
       : undefined
     const result = await client.call<{

--- a/src/cli/handlers/orchestration/dispatch-handlers.ts
+++ b/src/cli/handlers/orchestration/dispatch-handlers.ts
@@ -42,6 +42,7 @@ export const ORCHESTRATION_DISPATCH_HANDLER: Record<string, CommandHandler> = {
 export const ORCHESTRATION_DISPATCH_INSPECTION_HANDLERS: Record<string, CommandHandler> = {
   'orchestration dispatch-show': async ({ flags, client, cwd, json }) => {
     const showPreamble = flags.has('preamble') ? true : undefined
+    const recapability = flags.has('recapability') ? true : undefined
     // Why: a preview must embed the same real coordinator handle as an actual dispatch.
     const from = showPreamble
       ? await resolveCoordinatorTerminalHandle(flags, cwd, client)
@@ -51,12 +52,13 @@ export const ORCHESTRATION_DISPATCH_INSPECTION_HANDLERS: Record<string, CommandH
       preamble?: string
     }>('orchestration.dispatchShow', {
       task: getRequiredStringFlag(flags, 'task'),
-      preamble: showPreamble,
+      preamble: showPreamble || recapability,
+      recapability,
       from,
       devMode: isDevCliInvocation()
     })
     printResult(result, json, (value) => {
-      if (value.preamble && showPreamble) {
+      if (value.preamble && (showPreamble || recapability)) {
         return value.preamble
       }
       if (!value.dispatch) {

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -192,8 +192,8 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     path: ['orchestration', 'dispatch-show'],
     summary: 'Show dispatch context for a task',
     usage:
-      'orca orchestration dispatch-show --task <task_id> [--preamble] [--from <handle>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'task', 'preamble', 'from']
+      'orca orchestration dispatch-show --task <task_id> [--preamble] [--recapability] [--from <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'task', 'preamble', 'recapability', 'from']
   },
   {
     path: ['orchestration', 'ask'],

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
@@ -165,6 +165,35 @@ export const ORCHESTRATION_DISPATCH_METHODS: RpcMethod[] = [
         if (!task) {
           throw new Error(`Task not found: ${params.task}`)
         }
+        // Why: a crashed agent takes its capability to the grave; the replacement
+        // agent in the same terminal needs fresh authority, minted against the
+        // CURRENT pane/incarnation (not the dead one stored at dispatch time).
+        // Minting rotates the old secret, so a zombie holding it loses authority.
+        let dispatchCapability: string | undefined
+        if (params.recapability) {
+          if (!ctx || (ctx.status !== 'pending' && ctx.status !== 'dispatched')) {
+            throw new OrchestrationError(
+              'dispatch_not_active',
+              `Task ${params.task} has no active dispatch to re-authorize.`
+            )
+          }
+          const workerHandle = ctx.assignee_handle
+          const authority = runtime.getOrchestrationDispatchAuthority(workerHandle)
+          const paneKey = authority?.paneKey ?? runtime.getTerminalPaneKey(workerHandle) ?? undefined
+          const incarnation =
+            authority?.paneKey && authority.processIncarnation ? authority.processIncarnation : undefined
+          if (!paneKey || !incarnation) {
+            throw new OrchestrationError(
+              'stable_pane_required',
+              `Terminal ${workerHandle} has no stable pane/process incarnation for lifecycle authority.`
+            )
+          }
+          dispatchCapability = db.mintDispatchCapability({
+            dispatchId: ctx.id,
+            paneKey,
+            processIncarnation: incarnation
+          })
+        }
         const workerHandle = ctx?.assignee_handle ?? 'worker'
         const preamble = buildDispatchPreamble({
           taskId: task.id,
@@ -174,6 +203,7 @@ export const ORCHESTRATION_DISPATCH_METHODS: RpcMethod[] = [
           taskSpec: task.spec,
           coordinatorHandle: params.from ?? 'coordinator',
           workerHandle,
+          dispatchCapability,
           devMode: params.devMode,
           ...(ctx ? { cliCommand: runtime.getTerminalOrchestrationCliCommand(workerHandle) } : {})
         })

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
@@ -152,15 +152,21 @@ export const ORCHESTRATION_DISPATCH_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'orchestration.dispatchShow',
     params: DispatchShowParams,
-    handler: (params, { runtime }) => {
+    handler: (
+      params,
+      { orchestrationCompatibilityEvidence, runtime, legacyCoordinatorRunId }
+    ) => {
       const db = runtime.getOrchestrationDb()
       if (!params.task) {
         throw new Error('Missing --task')
       }
       const ctx = db.getDispatchContext(params.task)
+      // Why: recapability implies preamble — the minted secret has nowhere
+      // to go except embedded in a regenerated preamble.
+      const wantPreamble = params.preamble || params.recapability
 
       // Why: the preamble is derived from the current task spec, so it can be regenerated deterministically even after dispatch completes.
-      if (params.preamble) {
+      if (wantPreamble) {
         const task = db.getTask(params.task)
         if (!task) {
           throw new Error(`Task not found: ${params.task}`)
@@ -171,6 +177,28 @@ export const ORCHESTRATION_DISPATCH_METHODS: RpcMethod[] = [
         // Minting rotates the old secret, so a zombie holding it loses authority.
         let dispatchCapability: string | undefined
         if (params.recapability) {
+          if (!ctx || (ctx.status !== 'pending' && ctx.status !== 'dispatched')) {
+            throw new OrchestrationError(
+              'dispatch_not_active',
+              `Task ${params.task} has no active dispatch to re-authorize.`
+            )
+          }
+          // Why: same gate as orchestration.dispatch — only a terminal bound
+          // to the task's run may rotate its capability. Otherwise any
+          // terminal could DoS workers or un-fence deliberately fenced work.
+          const run = resolveRunScope(runtime, {
+            runId: task.run_id,
+            callerTerminalHandle: params.from,
+            requireCurrentConsumer: true,
+            legacyCoordinatorRunId,
+            callerEvidence: orchestrationCompatibilityEvidence
+          })
+          if (task.run_id !== run.id) {
+            throw taskNotFoundError(`Task ${task.id} was not found in Run ${run.id}.`, {
+              taskId: task.id,
+              runId: run.id
+            })
+          }
           if (!ctx || (ctx.status !== 'pending' && ctx.status !== 'dispatched')) {
             throw new OrchestrationError(
               'dispatch_not_active',

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-methods.ts
@@ -199,12 +199,6 @@ export const ORCHESTRATION_DISPATCH_METHODS: RpcMethod[] = [
               runId: run.id
             })
           }
-          if (!ctx || (ctx.status !== 'pending' && ctx.status !== 'dispatched')) {
-            throw new OrchestrationError(
-              'dispatch_not_active',
-              `Task ${params.task} has no active dispatch to re-authorize.`
-            )
-          }
           const workerHandle = ctx.assignee_handle
           const authority = runtime.getOrchestrationDispatchAuthority(workerHandle)
           const paneKey = authority?.paneKey ?? runtime.getTerminalPaneKey(workerHandle) ?? undefined

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-recapability.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-recapability.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+// Why: a crashed agent takes its capability to the grave. The coordinator
+// must be able to re-authorize the replacement agent in the same terminal
+// without fencing the dispatch and losing its history.
+describe('dispatch recapability after agent crash', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => db?.close())
+
+  function harness(incarnation: string) {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_worker:leaf_worker')
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
+      terminalHandle: 'term_worker',
+      paneKey: 'tab_worker:leaf_worker',
+      processIncarnation: incarnation
+    } as never)
+    vi.spyOn(runtime, 'getNestedWorkerMaxDepth').mockReturnValue(3)
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    const run = db.createRun({ objective: 'recap', coordinatorHandle: 'term_coord', coordinatorPaneKey: 'tab_coord:leaf_coord' })
+    const task = db.createTask({ spec: 'crash me', runId: run.id })
+    const find = (name: string) => {
+      const m = ORCHESTRATION_METHODS.find((c) => c.name === name)
+      if (!m) throw new Error(`Missing method ${name}`)
+      return m
+    }
+    return { runtime, run, task, find }
+  }
+
+  it('re-mints capability against the current incarnation and embeds it', async () => {
+    const { runtime, run, task, find } = harness('runtime_test:term_worker:1')
+    const dispatch = find('orchestration.dispatch')
+    await dispatch.handler(
+      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
+      { runtime } as never
+    )
+    // Crash: the incarnation recorded at dispatch time is now dead; the
+    // replacement agent runs under a new one.
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
+      terminalHandle: 'term_worker',
+      paneKey: 'tab_worker:leaf_worker',
+      processIncarnation: 'runtime_test:term_worker:2'
+    } as never)
+    const show = find('orchestration.dispatchShow')
+    const result = (await show.handler(
+      show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+      { runtime } as never
+    )) as { preamble: string }
+    expect(result.preamble).toContain('--dispatch-capability dcap_')
+    expect(result.preamble).toContain('--from term_worker')
+  })
+
+  it('refuses recapability once the dispatch settled', async () => {
+    const { runtime, run, task, find } = harness('runtime_test:term_worker:1')
+    const dispatch = find('orchestration.dispatch')
+    const created = (await dispatch.handler(
+      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
+      { runtime } as never
+    )) as { dispatch: { id: string } }
+    db!.completeDispatch(created.dispatch.id)
+    const show = find('orchestration.dispatchShow')
+    await expect(
+      show.handler(
+        show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+        { runtime } as never
+      )
+    ).rejects.toMatchObject({ code: 'dispatch_not_active' })
+  })
+
+  it('refuses recapability without a stable pane', async () => {
+    const { runtime, run, task, find } = harness('runtime_test:term_worker:1')
+    const dispatch = find('orchestration.dispatch')
+    await dispatch.handler(
+      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
+      { runtime } as never
+    )
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(undefined)
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue(undefined as never)
+    const show = find('orchestration.dispatchShow')
+    await expect(
+      show.handler(
+        show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+        { runtime } as never
+      )
+    ).rejects.toMatchObject({ code: 'stable_pane_required' })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-recapability.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-recapability.test.ts
@@ -11,13 +11,15 @@ describe('dispatch recapability after agent crash', () => {
 
   afterEach(() => db?.close())
 
-  function harness(incarnation: string) {
+  function harness(incarnation: string, withSecondRun = false) {
     db = new OrchestrationDb(':memory:')
+    const paneFor = (handle: string) =>
+      handle === 'term_coord' ? 'tab_coord:leaf_coord'
+      : withSecondRun && handle === 'term_other' ? 'tab_other:leaf_other'
+      : 'tab_worker:leaf_worker'
     const runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
-    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
-      handle === 'term_coord' ? 'tab_coord:leaf_coord' : 'tab_worker:leaf_worker'
-    )
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation(paneFor)
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
       terminalHandle: 'term_worker',
       paneKey: 'tab_worker:leaf_worker',
@@ -32,6 +34,9 @@ describe('dispatch recapability after agent crash', () => {
     vi.spyOn(runtime, 'getNestedWorkerMaxDepth').mockReturnValue(3)
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
     const run = db.createRun({ objective: 'recap', coordinatorHandle: 'term_coord', coordinatorPaneKey: 'tab_coord:leaf_coord' })
+    if (withSecondRun) {
+      db.createRun({ objective: 'other', coordinatorHandle: 'term_other', coordinatorPaneKey: 'tab_other:leaf_other' })
+    }
     const task = db.createTask({ spec: 'crash me', runId: run.id })
     const find = (name: string) => {
       const m = ORCHESTRATION_METHODS.find((c) => c.name === name)
@@ -127,6 +132,30 @@ describe('dispatch recapability after agent crash', () => {
         )
       } catch (e) { err = e }
       expect(err).toMatchObject({ code: 'stable_pane_required' })
+    })
+  })
+
+  it('refuses recapability from a terminal bound to another run', () => {
+    // Second run owned by another coordinator terminal: the caller is
+    // bound, but not to THIS task's run.
+    const { runtime, run, task, find } = harness('runtime_test:term_worker:1', true)
+    const dispatch = find('orchestration.dispatch')
+    const runFlow = async () => {
+      await dispatch.handler(
+        dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
+        { runtime } as never
+      )
+    }
+    return runFlow().then(() => {
+      const show = find('orchestration.dispatchShow')
+      let err: unknown
+      try {
+        show.handler(
+          show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_other' }),
+          { runtime } as never
+        )
+      } catch (e) { err = e }
+      expect(err).toMatchObject({ code: 'consumer_fenced' })
     })
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-dispatch-recapability.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-dispatch-recapability.test.ts
@@ -15,12 +15,20 @@ describe('dispatch recapability after agent crash', () => {
     db = new OrchestrationDb(':memory:')
     const runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
-    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_worker:leaf_worker')
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_coord' ? 'tab_coord:leaf_coord' : 'tab_worker:leaf_worker'
+    )
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
       terminalHandle: 'term_worker',
       paneKey: 'tab_worker:leaf_worker',
       processIncarnation: incarnation
     } as never)
+    vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
     vi.spyOn(runtime, 'getNestedWorkerMaxDepth').mockReturnValue(3)
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
     const run = db.createRun({ objective: 'recap', coordinatorHandle: 'term_coord', coordinatorPaneKey: 'tab_coord:leaf_coord' })
@@ -33,15 +41,24 @@ describe('dispatch recapability after agent crash', () => {
     return { runtime, run, task, find }
   }
 
-  it('re-mints capability against the current incarnation and embeds it', async () => {
+  function tokenOf(preamble: string): string {
+    const m = /--dispatch-capability (dcap_\S+)/.exec(preamble)
+    if (!m) throw new Error('preamble carries no capability')
+    return m[1]
+  }
+
+  it('rotates the secret so the zombie loses authority and the replacement gains it', async () => {
     const { runtime, run, task, find } = harness('runtime_test:term_worker:1')
     const dispatch = find('orchestration.dispatch')
-    await dispatch.handler(
-      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
+    const created = (await dispatch.handler(
+      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: true, returnPreamble: true }),
       { runtime } as never
-    )
-    // Crash: the incarnation recorded at dispatch time is now dead; the
-    // replacement agent runs under a new one.
+    )) as { dispatch: { id: string }; preamble: string }
+    const oldToken = tokenOf(created.preamble)
+    expect(
+      db!.verifyDispatchCapability({ dispatchId: created.dispatch.id, capability: oldToken, paneKey: 'tab_worker:leaf_worker', processIncarnation: 'runtime_test:term_worker:1' })
+    ).toEqual({ valid: true })
+    // Crash: replacement agent runs under a new incarnation.
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
       terminalHandle: 'term_worker',
       paneKey: 'tab_worker:leaf_worker',
@@ -52,42 +69,64 @@ describe('dispatch recapability after agent crash', () => {
       show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
       { runtime } as never
     )) as { preamble: string }
-    expect(result.preamble).toContain('--dispatch-capability dcap_')
-    expect(result.preamble).toContain('--from term_worker')
+    const newToken = tokenOf(result.preamble)
+    expect(newToken).not.toBe(oldToken)
+    expect(
+      db!.verifyDispatchCapability({ dispatchId: created.dispatch.id, capability: oldToken, paneKey: 'tab_worker:leaf_worker', processIncarnation: 'runtime_test:term_worker:1' })
+    ).toMatchObject({ valid: false })
+    expect(
+      db!.verifyDispatchCapability({ dispatchId: created.dispatch.id, capability: newToken, paneKey: 'tab_worker:leaf_worker', processIncarnation: 'runtime_test:term_worker:2' })
+    ).toEqual({ valid: true })
   })
 
-  it('refuses recapability once the dispatch settled', async () => {
+  it('refuses recapability once the dispatch settled', () => {
     const { runtime, run, task, find } = harness('runtime_test:term_worker:1')
     const dispatch = find('orchestration.dispatch')
-    const created = (await dispatch.handler(
-      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
-      { runtime } as never
-    )) as { dispatch: { id: string } }
-    db!.completeDispatch(created.dispatch.id)
-    const show = find('orchestration.dispatchShow')
-    await expect(
-      show.handler(
-        show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+    let created: { dispatch: { id: string } } | undefined
+    const runFlow = async () => {
+      created = (await dispatch.handler(
+        dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
         { runtime } as never
-      )
-    ).rejects.toMatchObject({ code: 'dispatch_not_active' })
+      )) as { dispatch: { id: string } }
+    }
+    return runFlow().then(() => {
+      db!.completeDispatch(created!.dispatch.id)
+      const show = find('orchestration.dispatchShow')
+      let err: unknown
+      try {
+        show.handler(
+          show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+          { runtime } as never
+        )
+      } catch (e) { err = e }
+      expect(err).toMatchObject({ code: 'dispatch_not_active' })
+    })
   })
 
-  it('refuses recapability without a stable pane', async () => {
+  it('refuses recapability without a stable pane', () => {
     const { runtime, run, task, find } = harness('runtime_test:term_worker:1')
     const dispatch = find('orchestration.dispatch')
-    await dispatch.handler(
-      dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
-      { runtime } as never
-    )
-    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(undefined)
-    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue(undefined as never)
-    const show = find('orchestration.dispatchShow')
-    await expect(
-      show.handler(
-        show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+    let done = false
+    const runFlow = async () => {
+      await dispatch.handler(
+        dispatch.params?.parse({ task: task.id, to: 'term_worker', from: 'term_coord', run: run.id, inject: false }),
         { runtime } as never
       )
-    ).rejects.toMatchObject({ code: 'stable_pane_required' })
+      done = true
+    }
+    return runFlow().then(() => {
+      expect(done).toBe(true)
+      vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(undefined)
+      vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue(undefined as never)
+      const show = find('orchestration.dispatchShow')
+      let err: unknown
+      try {
+        show.handler(
+          show.params?.parse({ task: task.id, preamble: true, recapability: true, from: 'term_coord' }),
+          { runtime } as never
+        )
+      } catch (e) { err = e }
+      expect(err).toMatchObject({ code: 'stable_pane_required' })
+    })
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-schemas.ts
+++ b/src/main/runtime/rpc/methods/orchestration-schemas.ts
@@ -228,6 +228,7 @@ export const DispatchParams = z.object({
 export const DispatchShowParams = z.object({
   task: OptionalString,
   preamble: OptionalBoolean,
+  recapability: OptionalBoolean,
   from: OptionalString,
   devMode: OptionalBoolean
 })


### PR DESCRIPTION
A crashed agent takes its dispatch capability to the grave: the replacement agent in the same terminal cannot report worker_done, and today the only recovery is fencing the dispatch and losing its history.

This adds an opt-in `--recapability` to `dispatch-show --preamble`: the coordinator re-mints a fresh capability bound to the CURRENT pane/process incarnation (not the dead one stored at dispatch time) and embeds it in a regenerated preamble. Minting rotates the old secret, so a zombie holding it loses authority. Refuses on settled tasks (`dispatch_not_active`), without a stable pane (`stable_pane_required`), and from terminals not bound to the task's run (`consumer_fenced`), mirroring dispatch-time rules.

Evidence: field incident running 9 parallel workers — 1 crash-restart, 2x rejected worker_done, manual close required. Replayed live 2026-09-06 on stock runtime: dispatch, kill terminal, replacement gets capability-less preamble, work done, report rejected, manual close. New test file covers rotation (old token dies, new lives), settled-refusal, no-pane-refusal, cross-run refusal.

Note: not run locally — this box has no MSVC toolchain (node-gyp rebuild fails) — requesting CI. Mirrors existing lifecycle test patterns.