### PR TITLE
fix: keep live agent checkpoints from unparking terminal panes

### DIFF
--- a/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.test.ts
+++ b/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
 import { selectSleepingRecordParkExemptTabIds } from './sleeping-record-park-exemption'
 
+const NO_LIVE_PANES = { ptyIdsByTabId: {}, terminalLayoutsByTabId: {} }
+
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
+/** Builds a resumable checkpoint with only the fields relevant to parking ownership. */
 function sleepingRecord(
   overrides: Partial<SleepingAgentSessionRecord> & Pick<SleepingAgentSessionRecord, 'paneKey'>
 ): SleepingAgentSessionRecord {
@@ -26,14 +29,18 @@ describe('selectSleepingRecordParkExemptTabIds', () => {
   ])('derives the owner from a valid pane key (%s)', (paneKey, tabId) => {
     const records = { [paneKey]: sleepingRecord({ paneKey }) }
 
-    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1')]).toEqual([tabId])
+    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', NO_LIVE_PANES)]).toEqual([
+      tabId
+    ])
   })
 
   it('prefers the persisted tab id over the pane key owner', () => {
     const paneKey = `tab-stale:${LEAF_ID}`
     const records = { [paneKey]: sleepingRecord({ paneKey, tabId: 'tab-current' }) }
 
-    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1')]).toEqual(['tab-current'])
+    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', NO_LIVE_PANES)]).toEqual([
+      'tab-current'
+    ])
   })
 
   it('does not invent an owner for a delimiter-less pane key', () => {
@@ -41,6 +48,83 @@ describe('selectSleepingRecordParkExemptTabIds', () => {
       'orphan-pane-key': sleepingRecord({ paneKey: 'orphan-pane-key' })
     }
 
-    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1')]).toEqual([])
+    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', NO_LIVE_PANES)]).toEqual([])
+  })
+  it('skips records from other worktrees and passive completed records', () => {
+    const records = {
+      [`tab-other:${LEAF_ID}`]: sleepingRecord({
+        paneKey: `tab-other:${LEAF_ID}`,
+        worktreeId: 'wt-2'
+      }),
+      [`tab-done:${LEAF_ID}`]: sleepingRecord({ paneKey: `tab-done:${LEAF_ID}`, state: 'done' })
+    }
+
+    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', NO_LIVE_PANES)]).toEqual([])
+  })
+  it.each(['working', 'waiting', 'done'] as const)(
+    'does not unpark a live checkpoint in state %s with an owned PTY',
+    (state) => {
+      const paneKey = `tab-1:${LEAF_ID}`
+      const records = {
+        [paneKey]: sleepingRecord({ paneKey, origin: 'live', state, interrupted: true })
+      }
+      const livePanes = {
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: { type: 'leaf' as const, leafId: LEAF_ID },
+            activeLeafId: LEAF_ID,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [LEAF_ID]: 'pty-1' }
+          }
+        }
+      }
+      expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', livePanes)]).toEqual([])
+    }
+  )
+
+  it.each(['live', 'quit', 'worktree-sleep'] as const)(
+    'keeps %s recovery eligible when only a saved PTY remains',
+    (origin) => {
+      const paneKey = `tab-1:${LEAF_ID}`
+      const records = { [paneKey]: sleepingRecord({ paneKey, origin }) }
+      const livePanes = {
+        ptyIdsByTabId: {},
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            root: { type: 'leaf' as const, leafId: LEAF_ID },
+            activeLeafId: LEAF_ID,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [LEAF_ID]: 'stale-pty' }
+          }
+        }
+      }
+      expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', livePanes)]).toEqual([
+        'tab-1'
+      ])
+    }
+  )
+
+  it('does not let a live sibling suppress recovery of a missing split pane', () => {
+    const paneKey = `tab-1:${LEAF_ID}`
+    const records = { [paneKey]: sleepingRecord({ paneKey, origin: 'live' }) }
+    const livePanes = {
+      ptyIdsByTabId: { 'tab-1': ['sibling-pty'] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split' as const,
+            direction: 'horizontal' as const,
+            ratio: 0.5,
+            first: { type: 'leaf' as const, leafId: LEAF_ID },
+            second: { type: 'leaf' as const, leafId: '22222222-2222-4222-8222-222222222222' }
+          },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: 'missing-pty' }
+        }
+      }
+    }
+    expect([...selectSleepingRecordParkExemptTabIds(records, 'wt-1', livePanes)]).toEqual(['tab-1'])
   })
 })

--- a/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.ts
+++ b/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.ts
@@ -1,6 +1,10 @@
 import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
-import { isPassiveCompletedHibernationEvidence } from '../../lib/sleeping-agent-pane-ownership'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import {
+  isPassiveCompletedHibernationEvidence,
+  stablePaneHasLivePty
+} from '../../lib/sleeping-agent-pane-ownership'
 
 const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
 
@@ -13,7 +17,11 @@ const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
  *  `Object.values` would allocate every record on every store write. */
 export function selectSleepingRecordParkExemptTabIds(
   sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord> | undefined,
-  worktreeId: string
+  worktreeId: string,
+  livePanes: {
+    ptyIdsByTabId: Record<string, string[]>
+    terminalLayoutsByTabId: Record<string, TerminalLayoutSnapshot | undefined>
+  }
 ): ReadonlySet<string> {
   if (!sleepingAgentSessionsByPaneKey) {
     return EMPTY_TAB_IDS
@@ -28,10 +36,23 @@ export function selectSleepingRecordParkExemptTabIds(
       continue
     }
     // Why: malformed pane keys must yield no owner instead of a truncated tab id.
+    const stablePane = parsePaneKey(record.paneKey)
     const tabId =
-      record.tabId ??
-      parsePaneKey(record.paneKey)?.tabId ??
-      parseLegacyNumericPaneKey(record.paneKey)?.tabId
+      record.tabId ?? stablePane?.tabId ?? parseLegacyNumericPaneKey(record.paneKey)?.tabId
+    // A live checkpoint needs no restore while its exact pane still owns a PTY.
+    if (
+      record.origin === 'live' &&
+      stablePane &&
+      stablePane.tabId === tabId &&
+      stablePaneHasLivePty(
+        tabId,
+        stablePane.leafId,
+        livePanes.ptyIdsByTabId,
+        livePanes.terminalLayoutsByTabId[tabId]
+      )
+    ) {
+      continue
+    }
     if (tabId) {
       owned ??= new Set()
       owned.add(tabId)

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-subscription-narrowing.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-subscription-narrowing.react185.test.tsx
@@ -10,7 +10,7 @@ import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 const WORKTREE_ID = 'repo::/cold-park-narrowing'
 const OTHER_WORKTREE_ID = 'repo::/cold-park-narrowing-other'
 
-const harness = vi.hoisted(() => ({ renders: 0 }))
+const harness = vi.hoisted(() => ({ renders: 0, parked: [] as string[] }))
 
 vi.mock('../../store', async () => {
   const { create } = await import('zustand')
@@ -44,6 +44,7 @@ const terminalTabs = ['tab-1', 'tab-2'].map(
 )
 const assignments = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
 
+/** Builds a checkpoint whose worktree and pane ownership can vary per subscription case. */
 function sleepingRecord(
   paneKey: string,
   worktreeId: string,
@@ -53,19 +54,22 @@ function sleepingRecord(
 }
 const activityTerminalPortals: never[] = []
 
+/** Records each rendered parking result so store updates can be checked without UI coupling. */
 function ColdParkingHarness(): null {
   harness.renders += 1
-  useTerminalTabColdParking({
-    worktreeId: WORKTREE_ID,
-    terminalTabs,
-    assignments,
-    isWorktreeActive: false,
-    activeTerminalTabId: null,
-    coldParkTerminalPanes: false,
-    shouldMeasureHiddenWorktree: false,
-    activityTerminalPortals,
-    activationDeferredMountTabIds: null
-  })
+  harness.parked = [
+    ...useTerminalTabColdParking({
+      worktreeId: WORKTREE_ID,
+      terminalTabs,
+      assignments,
+      isWorktreeActive: false,
+      activeTerminalTabId: null,
+      coldParkTerminalPanes: false,
+      shouldMeasureHiddenWorktree: false,
+      activityTerminalPortals,
+      activationDeferredMountTabIds: null
+    })
+  ]
   return null
 }
 
@@ -74,8 +78,14 @@ describe('cold-park store subscription narrowing', () => {
   let root: Root | undefined
 
   beforeEach(() => {
+    vi.useFakeTimers()
     harness.renders = 0
-    useAppStore.setState({ pendingStartupByTabId: {}, sleepingAgentSessionsByPaneKey: {} })
+    useAppStore.setState({
+      pendingStartupByTabId: {},
+      sleepingAgentSessionsByPaneKey: {},
+      ptyIdsByTabId: {},
+      terminalLayoutsByTabId: {}
+    })
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -89,6 +99,7 @@ describe('cold-park store subscription narrowing', () => {
     act(() => root?.unmount())
     root = undefined
     container.remove()
+    vi.useRealTimers()
   })
 
   // Why: these two maps are app-global, so before narrowing any write re-rendered
@@ -130,4 +141,55 @@ describe('cold-park store subscription narrowing', () => {
     })
     expect(harness.renders).toBeGreaterThan(0)
   })
+  /** Verifies checkpoint churn preserves parking until runtime PTY ownership is lost. */
+  async function verifyLiveCheckpointParking(): Promise<void> {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const paneKey = `tab-2:${leafId}`
+    const record = sleepingRecord(paneKey, WORKTREE_ID, {
+      tabId: 'tab-2',
+      origin: 'live',
+      state: 'done',
+      agent: 'codex'
+    })
+    act(() => {
+      useAppStore.setState({
+        sleepingAgentSessionsByPaneKey: { [paneKey]: record },
+        ptyIdsByTabId: { 'tab-2': [terminalTabs[1].ptyId!] },
+        terminalLayoutsByTabId: {
+          'tab-2': {
+            root: { type: 'leaf', leafId },
+            activeLeafId: leafId,
+            expandedLeafId: null,
+            ptyIdsByLeafId: { [leafId]: terminalTabs[1].ptyId! }
+          }
+        }
+      })
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6 * 60_000)
+    })
+    expect(harness.parked).toContain('tab-2')
+    for (const state of ['working', 'done', 'working'] as const) {
+      act(() => {
+        useAppStore.setState({
+          sleepingAgentSessionsByPaneKey: {
+            [paneKey]: { ...record, state }
+          }
+        })
+      })
+      expect(harness.parked).toContain('tab-2')
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000)
+      })
+    }
+    act(() => {
+      useAppStore.setState({ ptyIdsByTabId: {} })
+    })
+    expect(harness.parked).not.toContain('tab-2')
+  }
+
+  it(
+    'keeps a live parked pane parked across agent turns, but mounts when its PTY is lost',
+    verifyLiveCheckpointParking
+  )
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -55,6 +55,7 @@ type TerminalOverlayTabAssignment = {
 
 const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
 
+/** Keep parking decisions and background watchers in sync so hidden live terminals remain usable. */
 export function useTerminalTabColdParking(args: {
   worktreeId: string
   terminalTabs: readonly TerminalTab[]
@@ -120,7 +121,7 @@ export function useTerminalTabColdParking(args: {
   // subscribing to it re-rendered this worktree on every other worktree's write.
   const sleepingRecordOwnedTabIds = useAppStore(
     useShallow((state) =>
-      selectSleepingRecordParkExemptTabIds(state.sleepingAgentSessionsByPaneKey, worktreeId)
+      selectSleepingRecordParkExemptTabIds(state.sleepingAgentSessionsByPaneKey, worktreeId, state)
     )
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -88,13 +88,8 @@ function hasRestorableStablePanePty(
   )
 }
 
-// Why: a pane whose PTY is live *right now* already owns its running session
-// — e.g. a Pi TUI that finished a turn but stays alive in a background tab.
-// Resume must never fork such a pane into a duplicate tab, even when it isn't
-// the pane that reconnects on activation. Liveness comes from the runtime
-// live-PTY map (ptyIdsByTabId), not the layout's ptyIdsByLeafId snapshot, which
-// persists stale across sleep/restart.
-function stablePaneHasLivePty(
+/** Prevent duplicate restores by checking runtime PTY ownership; saved layout bindings can be stale. */
+export function stablePaneHasLivePty(
   tabId: string,
   leafId: string,
   ptyIdsByTabId: Record<string, string[]>,

--- a/tests/e2e/host-parked-pane-remote-viewer.spec.ts
+++ b/tests/e2e/host-parked-pane-remote-viewer.spec.ts
@@ -34,7 +34,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import os from 'node:os'
 import path from 'node:path'
-import type { Page } from '@stablyai/playwright-test'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
 import {
   HOST_TERMINAL_SURFACE_SEPARATOR,
   toWebTerminalSurfaceTabId
@@ -146,9 +146,11 @@ async function waitForPaneMarker(
   return false
 }
 
-test('a cold-parked host pane keeps serving its paired remote viewer', async ({
-  orcaPage
-}, testInfo) => {
+/** Verifies that a paired client keeps full terminal I/O while the host pane stays parked. */
+async function verifyColdParkedHostPane(
+  { orcaPage }: { orcaPage: Page },
+  testInfo: TestInfo
+): Promise<void> {
   test.setTimeout(600_000)
   const offer = await createRuntimeDesktopPairingOffer(orcaPage)
   const previousParkDelay = process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS
@@ -313,6 +315,32 @@ test('a cold-parked host pane keeps serving its paired remote viewer', async ({
     )
     console.log(`[sta2854] handle-probe=${JSON.stringify(handleProbe)}`)
 
+    // A new remote agent turn must not wake the host just to consume its live checkpoint.
+    await orcaPage.evaluate(
+      ({ hostTabId, worktreeId }) => {
+        const state = window.__store!.getState()
+        const layout = state.terminalLayoutsByTabId[hostTabId]
+        const leafId = Object.keys(layout?.ptyIdsByLeafId ?? {})[0]
+        if (!leafId) {
+          throw new Error('Parked host pane has no saved PTY')
+        }
+        const paneKey = `${hostTabId}:${leafId}`
+        state.setAgentStatus(
+          paneKey,
+          { state: 'working', prompt: 'continue the parked session', agentType: 'codex' },
+          'Codex',
+          undefined,
+          { worktreeId },
+          { providerSession: { key: 'session_id', id: 'host-park-live-checkpoint' } }
+        )
+        const checkpoint = window.__store!.getState().sleepingAgentSessionsByPaneKey[paneKey]
+        if (checkpoint?.origin !== 'live' || checkpoint.state !== 'working') {
+          throw new Error('Agent turn did not publish a live working checkpoint')
+        }
+      },
+      { hostTabId, worktreeId }
+    )
+
     // Type the moment the host parks — a user driving the pane does not wait
     // for a banner. Input accepted here must reach the host PTY.
     const token = `sta2854-${randomUUID().slice(0, 8)}`
@@ -365,9 +393,10 @@ test('a cold-parked host pane keeps serving its paired remote viewer', async ({
       .split('\n')
       .filter((line) => line.startsWith('READY:'))
     expect(readyLines, 'host PTY was replaced across the park').toHaveLength(1)
-    // Intentionally not asserted: whether the host pane stays parked is part of
-    // what the timeline above reports (a recovery-driven remount would show as
-    // H+ samples), not a precondition of the invariant.
+    expect(
+      timeline.every((entry) => entry.startsWith('H-')),
+      'live checkpoint unparked the host pane'
+    ).toBe(true)
   } finally {
     if (previousParkDelay === undefined) {
       delete process.env.ORCA_E2E_TERMINAL_PARKING_DELAY_MS
@@ -381,4 +410,6 @@ test('a cold-parked host pane keeps serving its paired remote viewer', async ({
     }
     await client.dispose()
   }
-})
+}
+
+test('a cold-parked host pane keeps serving its paired remote viewer', verifyColdParkedHostPane)


### PR DESCRIPTION
## ELI5

Sending another prompt from a paired client can make the host unnecessarily remount a hidden terminal. During that remount, the client briefly loses its terminal handle and shows the retry banner even though the process is still running. Keep the hidden pane parked when its live session checkpoint still belongs to a runtime-owned PTY.

## What Changed

- Check exact stable-pane PTY ownership before granting a parking exemption to an `origin: live` session checkpoint. Reuse `stablePaneHasLivePty`, which already handles per-leaf and single-leaf ownership.
- Subscribe to the existing runtime PTY and layout state through the worktree-scoped selector. A persisted PTY alone does not suppress recovery. Other checkpoint origins retain their existing behavior.
- Extend the existing host-parked remote-viewer E2E test to publish a checkpoint through `setAgentStatus`, then require that the host stays parked and client I/O continues.
- Extend the real cold-parking hook test with repeated `done → working → done → working` updates followed by loss of the runtime PTY. Add selector coverage for interrupted live checkpoints, stale saved bindings, quit/sleep recovery, and split-pane ownership.

## Why

On two Macs running 1.4.197, host logpoints captured a live checkpoint making a cold-parked tab mount. Its new registration published a null PTY before reconnecting to the same PTY 55 ms later (107 ms in another capture). That graph update invalidated the terminal handle; the exit waiter rejected with `terminal_handle_stale`, and the client received `unverifiable` and entered recovery.

The checkpoint identifies an existing running session; it does not require a cold restore while that exact pane still owns its PTY. Fixing the parking decision removes the observed trigger without changing general handle invalidation or the remote protocol.

## Linked Issue

Fixes #19076

## Visual Proof

Captured with Playwright CDP across **two physical Macs**: the installed Orca 1.4.197 client on MacBook Air connects over Tailscale to an isolated host build on Mac mini. Both sides use disposable profiles. The host uses the production 30-second parking delay, a real PTY, and an echo fixture; input is typed into the Air client's terminal. The probe injects the live working checkpoint at the store boundary to isolate the reported trigger; it does not call a live Codex service.

| Before: Air shows retry; input never reaches mini | After: Air remains connected and paints the echo |
| --- | --- |
| ![Before: Air retry banner](https://github.com/user-attachments/assets/fb9d1465-073d-425c-ac3c-f7cff3ab92ce) | ![After: Air terminal echo succeeds](https://github.com/user-attachments/assets/5a8e69d9-b843-4295-81cb-ac2f890fbad8) |

Before video (about 12 seconds):

https://github.com/user-attachments/assets/e6be3e87-79e2-49f6-a51b-7fc88e1af483

After video (about 12 seconds):

https://github.com/user-attachments/assets/5cfb5b39-c5eb-47a7-a148-3db72e683a77

The before host build removes only the parking-selector fix. All 35 observed samples showed a mounted host and recovering client; the typed line did not reach the host sink or return to client xterm. The fixed host kept the pane parked and client connected in all 44 samples; both input and echo succeeded and the fixture retained its original process. Air's established TCP connections to the mini test runtime were also verified. CDP frame timestamps preserve capture timing. The screenshots contain only synthetic test data.

An earlier same-machine run with two isolated Electron processes independently reproduced the same before/after result. The fixed two-machine run passed twice. All test processes, disposable profiles, temporary SSH forwarding, and the login session were cleaned up; installed applications were not changed.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated
- [x] Rendered Electron host/client verification via Playwright CDP, including physical Air/mini pairing

Full local checks were run on the behaviorally identical pre-squash source, using **Node 24.20.0 and pnpm 12.0.0** with isolated dependencies installed from the frozen root and mobile lockfiles:

| Command | Result |
| --- | --- |
| `pnpm lint` | **Failed** in `audit:code-quality:native`: existing `import(no-cycle)` warnings at `mobile/src/transport/client-context.tsx:44` and `mobile/src/transport/host-client-hooks.ts:5`. Both files are identical to base `f952f1ac96`; their direct import/re-export cycle predates this PR (commit `7106101ed2`). The same failure reproduces when checking just those files. Later chained lint stages did not run. |
| `pnpm typecheck` | **Passed** for all three configured projects: main, CLI, and renderer. |
| `pnpm test` | **Passed**: 7,959 files passed and 60 skipped; 73,852 tests passed and 376 skipped. Duration: 836.58 seconds. |
| `pnpm build` | **Passed**, including desktop typecheck, relay, CLI, Electron bundles, built-skill CLI verification, web projection, and macOS native modules. |

Baseline lint disposition and final review follow-up:

- The author accepts the existing mobile cycle as outside this PR's scope. Both affected files are unchanged from the PR base. The cycle was introduced by PR #16239; its mobile-only CI skipped root static analysis, while Mobile Checks did not run the focused `import/no-cycle` rule. No lint rule was disabled and no successful GitHub check was fabricated.
- All 11 later lint stages that the original command could not reach were run separately and passed: type-aware audit, reliability gates, max-lines ratchet, ts-nocheck ratchet, runtime/Electron ratchet, bundled skill guides, skill manifest, localization catalog, runtime catalog, extraction, and coverage.
- The final source includes concise function documentation for runtime PTY ownership and parking synchronization. Basic lint, React Doctor lint, focused native lint, formatting, and diff whitespace checks passed for those documentation changes.
- Upstream workflow approval is still required. The contributor account has read access but no push, maintain, or admin permission on `stablyai/orca`; it cannot approve those runs. Before the final history squash, CodeRabbit's full reassessment reported 80% docstring coverage, all five pre-merge checks passed, and no actionable comments. The final commit contains the same six-file patch and retriggers external checks.

Additional regression validation:

- Human manual verification: the author paired the installed Air client with the mini desktop development instance running the behaviorally identical pre-squash source and confirmed that terminal input no longer showed the reported error. This is separate from the automated fixture checks below.

- The new hook regression failed before the selector change: the first `working` checkpoint removed the live pane from the parked set.
- Updated `host-parked-pane-remote-viewer.spec.ts` passed with the production 30-second parking delay. It publishes a checkpoint through `setAgentStatus`, verifies the resulting live record, and observes 90 seconds of uninterrupted pairing: all 45 samples kept the host parked and client connected, input reached the host sink, client xterm painted the echo, and the fixture retained one process.
- Rendered physical Air/mini before/after checks are shown above; the fixed two-machine run passed twice.
- Changed-file code-quality checks passed with zero new findings, including type-aware and React Doctor checks.
- After updating to current `origin/main`, both focused regression files passed (17 tests), `pnpm tc` passed, and the changed-file quality gate passed again with zero findings. Full E2E typecheck still reports 197 existing diagnostics outside this PR's E2E file; `host-parked-pane-remote-viewer.spec.ts` reports none. The final history squash preserves the exact six-file patch.
- `git diff --check` passed. No source, lockfile, or lint-rule changes were made to obtain these results.

The original local pnpm 12 launcher was an uninstalled placeholder, and the system's `node@24` path actually resolved to Node 26. The full checks above use a verified standalone Node 24 installation and a working pnpm 12 installation instead. Frozen-lockfile installation succeeded against the npm registry without relaxing the release-age policy.

Build warnings: existing CSS/Swift deprecation warnings were non-fatal. The optional global `orca-dev` symlink could not be installed due to `/usr/local/bin` permissions; the build script explicitly handles that condition and exited successfully.

Linux, Windows, and SSH-hosted workspaces were not exercised. SSH only controlled the Air test instance; runtime pairing used Tailscale TCP. Optional broader follow-up is to run a live Codex service through multiple turns and check genuine sleep/quit recovery; this PR verifies the checkpoint trigger with a controlled fixture and recovery eligibility with unit/hook tests.

## AI Disclosure

Implemented and reviewed with OpenAI Codex (GPT-6). The agent examined live debugger evidence, reused the existing ownership predicate, added a regression that fails before the fix, and ran the checks above.

## Review

- **Cross-platform:** no OS-specific code, filesystem operations, or shortcuts. The selector uses existing pane identity and PTY maps.
- **Local, paired, and SSH:** no host process inspection, liveness verdict changes, RPC fields, or wire changes. The runtime ownership map remains the input; saved layout data alone is insufficient. Loss of contact is not classified as process exit.
- **Agents and integrations:** the production condition is agent-neutral. No Codex-only branch, provider API, or git-provider behavior is introduced. Folder workspaces use the same worktree-scoped selector without Git assumptions.
- **Performance:** preserves the existing worktree-scoped, shallow-compared set subscription. Adds an ownership lookup only for matching live checkpoints; no timers, listeners, or network calls.
- **UI and security:** no visual styling or permission changes. The behavior change is limited to avoiding unnecessary mounts. Exact pane ownership prevents a live split sibling from suppressing another pane's recovery.
- **Scope:** other causes of renderer reattachment can still invalidate a handle; this change fixes the live-checkpoint parking trigger captured in the issue.

## Agent skill upstream boundary

- [x] Not applicable; no skill content is added or copied.

## Author

GitHub: @xungua. X (Twitter): not provided.

## Notes

Ready for review with physical Air/mini before/after evidence attached. All four full local commands have run; the existing mobile lint cycle is the only failed command, as detailed above. No version bump or installed-app changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Local verification completed with an author-accepted baseline exception: typecheck, test, and build passed; full lint exits nonzero only for the documented pre-existing mobile import cycle. This is not a claim that `pnpm lint` passed; maintainer acceptance and upstream CI remain pending.

