### PR TITLE
feat(emulator): add standard Android emulator controls

### DIFF
--- a/src/main/emulator/android/android-device-control-capabilities.test.ts
+++ b/src/main/emulator/android/android-device-control-capabilities.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AndroidCommandResult, AndroidCommandRunner } from './android-command-runner'
+import type { AndroidAdbDevice } from './adb-devices'
+import type { AndroidSdkPaths } from './android-sdk-discovery'
+import { inspectAndroidDeviceControlCapabilities } from './android-device-control-capabilities'
+
+const SDK: AndroidSdkPaths = {
+  sdkRoot: '/sdk',
+  adb: '/sdk/adb',
+  emulator: '/sdk/emulator',
+  avdmanager: '/sdk/avdmanager'
+}
+
+const device = (serial = 'emulator-5554', isEmulator = true): AndroidAdbDevice => ({
+  serial,
+  state: 'device',
+  isEmulator
+})
+const result = (stdout: string, code = 0): AndroidCommandResult => ({
+  stdout,
+  stderr: '',
+  code
+})
+
+function probeRunner(responses: Record<string, AndroidCommandResult | Error>): {
+  runner: AndroidCommandRunner
+  calls: ReturnType<typeof vi.fn>
+} {
+  const calls = vi.fn()
+  const runner: AndroidCommandRunner = async (_binary, args, options) => {
+    calls(args, options)
+    const response = responses[args.join(' ')]
+    if (response instanceof Error) {
+      throw response
+    }
+    return response ?? result('')
+  }
+  return { runner, calls }
+}
+
+describe('inspectAndroidDeviceControlCapabilities', () => {
+  it('detects phone, physical shutdown, and multi-state foldable capabilities', async () => {
+    const { runner, calls } = probeRunner({
+      '-s emulator-5554 shell getprop ro.build.characteristics': result('default,phone'),
+      '-s emulator-5554 shell getprop ro.build.version.sdk': result('35'),
+      '-s emulator-5554 shell cmd device_state print-states-simple': result('0: CLOSED\n1: OPEN')
+    })
+    const capabilities = await inspectAndroidDeviceControlCapabilities(runner, SDK, device())
+
+    expect(capabilities).toEqual({
+      shutdown: true,
+      power: true,
+      volume: true,
+      overview: true,
+      foldable: true,
+      wearButton1: false,
+      wearButton2: false
+    })
+    expect(calls).toHaveBeenCalledTimes(3)
+    expect(calls.mock.calls.every(([, options]) => options?.timeoutMs === 2_000)).toBe(true)
+  })
+  it.each([
+    ['27', false],
+    ['28', true],
+    ['29', true],
+    ['30', true],
+    ['35', true]
+  ] as const)('applies Wear API gates for %s', async (api, button1) => {
+    const { runner } = probeRunner({
+      '-s emulator-5554 shell getprop ro.build.characteristics': result('default,watch,phone'),
+      '-s emulator-5554 shell getprop ro.build.version.sdk': result(api),
+      '-s emulator-5554 shell cmd device_state print-states-simple': result('0')
+    })
+    const capabilities = await inspectAndroidDeviceControlCapabilities(runner, SDK, device())
+    expect(capabilities.power).toBe(api === '27')
+    expect(capabilities.volume).toBe(false)
+    expect(capabilities.overview).toBe(false)
+    expect(capabilities.wearButton1).toBe(button1)
+    expect(capabilities.wearButton2).toBe(Number(api) >= 30)
+  })
+
+  it('uses common phone defaults when characteristics fail and hides fold on state failure', async () => {
+    const { runner } = probeRunner({
+      '-s emulator-5554 shell getprop ro.build.characteristics': result('', 1),
+      '-s emulator-5554 shell getprop ro.build.version.sdk': result('35'),
+      '-s emulator-5554 shell cmd device_state print-states-simple': result('', 1)
+    })
+    await expect(
+      inspectAndroidDeviceControlCapabilities(runner, SDK, device())
+    ).resolves.toMatchObject({
+      shutdown: true,
+      power: true,
+      volume: true,
+      overview: true,
+      foldable: false,
+      wearButton1: false,
+      wearButton2: false
+    })
+  })
+
+  it('hides Wear controls and power when the API probe rejects', async () => {
+    const { runner } = probeRunner({
+      '-s emulator-5554 shell getprop ro.build.characteristics': result('watch'),
+      '-s emulator-5554 shell getprop ro.build.version.sdk': new Error('timeout'),
+      '-s emulator-5554 shell cmd device_state print-states-simple': result('0')
+    })
+    await expect(
+      inspectAndroidDeviceControlCapabilities(runner, SDK, device())
+    ).resolves.toMatchObject({
+      power: false,
+      volume: false,
+      overview: false,
+      wearButton1: false,
+      wearButton2: false
+    })
+  })
+})

--- a/src/main/emulator/android/android-device-control-capabilities.ts
+++ b/src/main/emulator/android/android-device-control-capabilities.ts
@@ -1,0 +1,91 @@
+import type { EmulatorDeviceControlCapabilities } from '../../../shared/emulator-device-controls'
+import type { AndroidAdbDevice } from './adb-devices'
+import type { AndroidCommandRunner } from './android-command-runner'
+import type { AndroidSdkPaths } from './android-sdk-discovery'
+import { androidShellArgs } from './android-input-commands'
+
+const PROBE_TIMEOUT_MS = 2_000
+
+type ProbeResult = {
+  stdout: string
+  ok: boolean
+}
+
+export async function inspectAndroidDeviceControlCapabilities(
+  runner: AndroidCommandRunner,
+  sdk: AndroidSdkPaths,
+  device: AndroidAdbDevice
+): Promise<EmulatorDeviceControlCapabilities> {
+  const [characteristics, api, states] = await Promise.all([
+    runProbe(
+      runner,
+      sdk.adb,
+      androidShellArgs(device.serial, ['getprop', 'ro.build.characteristics'])
+    ),
+    runProbe(runner, sdk.adb, androidShellArgs(device.serial, ['getprop', 'ro.build.version.sdk'])),
+    runProbe(
+      runner,
+      sdk.adb,
+      androidShellArgs(device.serial, ['cmd', 'device_state', 'print-states-simple'])
+    )
+  ])
+
+  const isWear = characteristics.ok && parseCharacteristics(characteristics.stdout).has('watch')
+  const apiLevel = api.ok ? parseApiLevel(api.stdout) : null
+  const integerStateIds = states.ok ? parseStateIds(states.stdout) : []
+
+  return {
+    shutdown: device.isEmulator,
+    power: characteristics.ok ? !isWear || (apiLevel !== null && apiLevel < 28) : true,
+    volume: characteristics.ok ? !isWear : true,
+    overview: characteristics.ok ? !isWear : true,
+    foldable: device.isEmulator && states.ok && integerStateIds.length > 1,
+    wearButton1: characteristics.ok && isWear && apiLevel !== null && apiLevel >= 28,
+    wearButton2: characteristics.ok && isWear && apiLevel !== null && apiLevel >= 30
+  }
+}
+
+async function runProbe(
+  runner: AndroidCommandRunner,
+  adb: string,
+  args: readonly string[]
+): Promise<ProbeResult> {
+  try {
+    const result = await runner(adb, args, { timeoutMs: PROBE_TIMEOUT_MS })
+    return { ok: result.code === 0, stdout: result.stdout }
+  } catch {
+    return { ok: false, stdout: '' }
+  }
+}
+
+function parseCharacteristics(stdout: string): Set<string> {
+  return new Set(
+    stdout
+      .split(',')
+      .map((token) => token.trim())
+      .filter(Boolean)
+  )
+}
+
+function parseApiLevel(stdout: string): number | null {
+  const value = stdout.trim()
+  if (!/^\d+$/.test(value)) {
+    return null
+  }
+  const api = Number(value)
+  return Number.isSafeInteger(api) ? api : null
+}
+
+function parseStateIds(stdout: string): number[] {
+  const ids: number[] = []
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = /^\s*(\d+)(?:\s|:|$)/.exec(line)
+    if (match) {
+      const id = Number(match[1])
+      if (Number.isSafeInteger(id)) {
+        ids.push(id)
+      }
+    }
+  }
+  return ids
+}

--- a/src/main/emulator/android/android-device-inventory.ts
+++ b/src/main/emulator/android/android-device-inventory.ts
@@ -3,6 +3,7 @@ import type { AndroidSdkPaths } from './android-sdk-discovery'
 import { adbDevicesArgs, parseAdbDevices, type AndroidAdbDevice } from './adb-devices'
 import { listAvdsArgs, parseAvdList } from './avd-manager'
 import type { EmulatorDevice } from '../backends/emulator-backend'
+import { inspectAndroidDeviceControlCapabilities } from './android-device-control-capabilities'
 
 // Android device discovery: turns raw `adb`/`emulator` output into the
 // cross-backend EmulatorDevice list and resolves AVD names to running serials.
@@ -61,8 +62,24 @@ export async function listAndroidDevices(
     runner(sdk.emulator, listAvdsArgs)
   ])
   const avds = parseAvdList(avdsResult.stdout)
-  const runningAvdBySerial = await resolveRunningAvdNames(runner, sdk, running)
-  return mergeAndroidDevices(running, avds, runningAvdBySerial)
+  const [runningAvdBySerial, controlCapabilities] = await Promise.all([
+    resolveRunningAvdNames(runner, sdk, running),
+    inspectRunningAndroidDeviceCapabilities(runner, sdk, running)
+  ])
+  return mergeAndroidDevices(running, avds, runningAvdBySerial, controlCapabilities)
+}
+async function inspectRunningAndroidDeviceCapabilities(
+  runner: AndroidCommandRunner,
+  sdk: AndroidSdkPaths,
+  running: AndroidAdbDevice[]
+): Promise<Map<string, NonNullable<EmulatorDevice['controlCapabilities']>>> {
+  const entries = await Promise.all(
+    running.map(
+      async (device) =>
+        [device.serial, await inspectAndroidDeviceControlCapabilities(runner, sdk, device)] as const
+    )
+  )
+  return new Map(entries)
 }
 
 // `adb -s <serial> emu avd name` prints the AVD name then a trailing "OK" line.
@@ -79,7 +96,11 @@ function firstNonStatusLine(stdout: string): string | null {
 export function mergeAndroidDevices(
   running: AndroidAdbDevice[],
   avds: string[],
-  runningAvdBySerial: Map<string, string>
+  runningAvdBySerial: Map<string, string>,
+  controlCapabilities: ReadonlyMap<
+    string,
+    NonNullable<EmulatorDevice['controlCapabilities']>
+  > = new Map()
 ): EmulatorDevice[] {
   const devices: EmulatorDevice[] = []
   const bootedAvdNames = new Set(runningAvdBySerial.values())
@@ -92,7 +113,8 @@ export function mergeAndroidDevices(
       name: avdName ?? device.model ?? device.serial,
       state: 'booted',
       detail: device.isEmulator ? 'emulator' : 'device',
-      isAvailable: true
+      isAvailable: true,
+      controlCapabilities: controlCapabilities.get(device.serial)
     })
   }
 

--- a/src/main/emulator/android/android-emulator-input-controller.ts
+++ b/src/main/emulator/android/android-emulator-input-controller.ts
@@ -65,7 +65,9 @@ export class AndroidEmulatorInputController {
   }
 
   async setPosture(deviceId: string, posture: EmulatorPosture): Promise<void> {
-    await androidSetPosture(this.runner, this.sdk(), await this.resolveDeviceId(deviceId), posture)
+    const serial = await this.resolveDeviceId(deviceId)
+    await androidSetPosture(this.runner, this.sdk(), serial, posture)
+    this.invalidateScreenSize(serial)
   }
 
   async rotate(deviceId: string, orientation: string): Promise<void> {

--- a/src/main/emulator/android/android-emulator-input-controller.ts
+++ b/src/main/emulator/android/android-emulator-input-controller.ts
@@ -1,0 +1,94 @@
+import { EmulatorError } from '../emulator-errors'
+import type { EmulatorGesturePoint } from '../emulator-gesture-sender'
+import type {
+  EmulatorButtonOptions,
+  EmulatorPosture
+} from '../../../shared/emulator-device-controls'
+import type { AndroidCommandRunner } from './android-command-runner'
+import {
+  androidButton,
+  androidExec,
+  androidRotate,
+  androidSetPosture,
+  androidSwipe,
+  androidTap,
+  androidTypeText
+} from './android-input-commands'
+import { parseWmSize, wmSizeArgs } from './adb-devices'
+import type { DeviceScreenSize } from './android-input-mapping'
+import type { AndroidSdkPaths } from './android-sdk-discovery'
+
+type AndroidEmulatorInputControllerOptions = {
+  runner: AndroidCommandRunner
+  sdk: () => AndroidSdkPaths
+  resolveDeviceId: (deviceId: string) => Promise<string>
+}
+
+export class AndroidEmulatorInputController {
+  private readonly runner: AndroidCommandRunner
+  private readonly sdk: () => AndroidSdkPaths
+  private readonly resolveDeviceId: (deviceId: string) => Promise<string>
+  private readonly screenSizes = new Map<string, DeviceScreenSize>()
+
+  constructor(options: AndroidEmulatorInputControllerOptions) {
+    this.runner = options.runner
+    this.sdk = options.sdk
+    this.resolveDeviceId = options.resolveDeviceId
+  }
+
+  invalidateScreenSize(serial: string): void {
+    this.screenSizes.delete(serial)
+  }
+
+  async tap(deviceId: string, x: number, y: number): Promise<void> {
+    const serial = await this.resolveDeviceId(deviceId)
+    await androidTap(this.runner, this.sdk(), serial, x, y, await this.getScreenSize(serial))
+  }
+
+  async gesture(deviceId: string, points: EmulatorGesturePoint[]): Promise<void> {
+    const serial = await this.resolveDeviceId(deviceId)
+    await androidSwipe(this.runner, this.sdk(), serial, points, await this.getScreenSize(serial))
+  }
+
+  async type(deviceId: string, text: string): Promise<void> {
+    await androidTypeText(this.runner, this.sdk(), await this.resolveDeviceId(deviceId), text)
+  }
+
+  async button(deviceId: string, name: string, options?: EmulatorButtonOptions): Promise<void> {
+    await androidButton(
+      this.runner,
+      this.sdk(),
+      await this.resolveDeviceId(deviceId),
+      name,
+      options
+    )
+  }
+
+  async setPosture(deviceId: string, posture: EmulatorPosture): Promise<void> {
+    await androidSetPosture(this.runner, this.sdk(), await this.resolveDeviceId(deviceId), posture)
+  }
+
+  async rotate(deviceId: string, orientation: string): Promise<void> {
+    const serial = await this.resolveDeviceId(deviceId)
+    this.invalidateScreenSize(serial)
+    await androidRotate(this.runner, this.sdk(), serial, orientation)
+  }
+
+  async exec(deviceId: string, command: string): Promise<string> {
+    return androidExec(this.runner, this.sdk(), await this.resolveDeviceId(deviceId), command)
+  }
+
+  private async getScreenSize(serial: string): Promise<DeviceScreenSize> {
+    const cached = this.screenSizes.get(serial)
+    if (cached) {
+      return cached
+    }
+    const result = await this.runner(this.sdk().adb, wmSizeArgs(serial))
+    const size = parseWmSize(result.stdout)
+    if (!size) {
+      throw new EmulatorError('emulator_error', `Could not read screen size for ${serial}.`)
+    }
+    this.screenSizes.set(serial, size)
+    return size
+  }
+}

--- a/src/main/emulator/android/android-input-commands.test.ts
+++ b/src/main/emulator/android/android-input-commands.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { AndroidCommandResult, AndroidCommandRunner } from './android-command-runner'
 import type { AndroidSdkPaths } from './android-sdk-discovery'
-import { androidExec, androidTap } from './android-input-commands'
+import { androidButton, androidExec, androidSetPosture, androidTap } from './android-input-commands'
 
 const SDK: AndroidSdkPaths = {
   sdkRoot: '/sdk',
@@ -33,6 +33,46 @@ describe('android input commands', () => {
     await expect(androidExec(failRunner, SDK, 'emulator-5554', 'false')).rejects.toMatchObject({
       code: 'emulator_error',
       message: 'adb exec failed: device offline'
+    })
+  })
+  it('sends posture commands through the emulator console', async () => {
+    const calls: (readonly string[])[] = []
+    const runner: AndroidCommandRunner = async (_command, args) => {
+      calls.push(args)
+      return ok
+    }
+
+    await androidSetPosture(runner, SDK, 'emulator-5554', 'folded')
+    await androidSetPosture(runner, SDK, 'emulator-5554', 'unfolded')
+
+    expect(calls).toEqual([
+      ['-s', 'emulator-5554', 'emu', 'fold'],
+      ['-s', 'emulator-5554', 'emu', 'unfold']
+    ])
+  })
+
+  it('adds long-press only when requested', async () => {
+    const calls: (readonly string[])[] = []
+    const runner: AndroidCommandRunner = async (_command, args) => {
+      calls.push(args)
+      return ok
+    }
+
+    await androidButton(runner, SDK, 'emulator-5554', 'power', { longPress: true })
+    await androidButton(runner, SDK, 'emulator-5554', 'power')
+
+    expect(calls).toEqual([
+      ['-s', 'emulator-5554', 'shell', 'input', 'keyevent', '--longpress', '26'],
+      ['-s', 'emulator-5554', 'shell', 'input', 'keyevent', '26']
+    ])
+  })
+
+  it('propagates non-zero posture errors', async () => {
+    const runner: AndroidCommandRunner = async () => fail
+
+    await expect(androidSetPosture(runner, SDK, 'emulator-5554', 'folded')).rejects.toMatchObject({
+      code: 'emulator_error',
+      message: 'adb posture failed: device offline'
     })
   })
 })

--- a/src/main/emulator/android/android-input-commands.ts
+++ b/src/main/emulator/android/android-input-commands.ts
@@ -6,6 +6,10 @@ import {
   normalizedToDevicePixels,
   type DeviceScreenSize
 } from './android-input-mapping'
+import type {
+  EmulatorButtonOptions,
+  EmulatorPosture
+} from '../../../shared/emulator-device-controls'
 import type { EmulatorGesturePoint } from '../emulator-gesture-sender'
 
 // Android control via `adb shell input`, so it works without the scrcpy server.
@@ -83,14 +87,26 @@ export async function androidButton(
   runner: AndroidCommandRunner,
   sdk: AndroidSdkPaths,
   serial: string,
-  name: string
+  name: string,
+  options?: EmulatorButtonOptions
+): Promise<void> {
+  const keyeventArgs = ['input', 'keyevent']
+  if (options?.longPress) {
+    keyeventArgs.push('--longpress')
+  }
+  keyeventArgs.push(String(androidButtonKeycode(name)))
+  ensureAdbOk(await runner(sdk.adb, androidShellArgs(serial, keyeventArgs)), 'adb button')
+}
+
+export async function androidSetPosture(
+  runner: AndroidCommandRunner,
+  sdk: AndroidSdkPaths,
+  serial: string,
+  posture: EmulatorPosture
 ): Promise<void> {
   ensureAdbOk(
-    await runner(
-      sdk.adb,
-      androidShellArgs(serial, ['input', 'keyevent', String(androidButtonKeycode(name))])
-    ),
-    'adb button'
+    await runner(sdk.adb, ['-s', serial, 'emu', posture === 'folded' ? 'fold' : 'unfold']),
+    'adb posture'
   )
 }
 

--- a/src/main/emulator/android/android-input-mapping.ts
+++ b/src/main/emulator/android/android-input-mapping.ts
@@ -42,7 +42,9 @@ const BUTTON_KEYCODES: Record<string, number> = {
   volume_up: 24,
   volup: 24,
   volume_down: 25,
-  voldown: 25
+  voldown: 25,
+  wear_button_1: 265,
+  wear_button_2: 266
 }
 
 // Accepts the canonical names plus the common aliases above. Throws

--- a/src/main/emulator/backends/android-emulator-backend.test.ts
+++ b/src/main/emulator/backends/android-emulator-backend.test.ts
@@ -88,7 +88,16 @@ describe('AndroidEmulatorBackend', () => {
         name: 'Pixel_7',
         state: 'booted',
         detail: 'emulator',
-        isAvailable: true
+        isAvailable: true,
+        controlCapabilities: {
+          shutdown: true,
+          power: true,
+          volume: true,
+          overview: true,
+          foldable: false,
+          wearButton1: false,
+          wearButton2: false
+        }
       },
       {
         backend: 'android',

--- a/src/main/emulator/backends/android-emulator-backend.test.ts
+++ b/src/main/emulator/backends/android-emulator-backend.test.ts
@@ -139,6 +139,41 @@ describe('AndroidEmulatorBackend', () => {
     ])
   })
 
+  it('refreshes the cached screen size after a successful posture change', async () => {
+    const discoveryRunner = defaultRunner() as unknown as AndroidCommandRunner
+    let screenSize = 'Physical size: 100x200'
+    const statefulRunner = vi.fn(async (binary: string, args: readonly string[]) => {
+      const a = args.join(' ')
+      if (binary === SDK.adb && a === '-s emulator-5554 shell wm size') {
+        return ok(screenSize)
+      }
+      if (binary === SDK.adb && a === '-s emulator-5554 emu fold') {
+        screenSize = 'Physical size: 200x100'
+        return ok('')
+      }
+      return discoveryRunner(binary, args)
+    })
+    const android = backend(statefulRunner)
+
+    await android.tap('emulator-5554', 0.5, 0.5)
+    await android.setPosture('emulator-5554', 'folded')
+    await android.tap('emulator-5554', 0.5, 0.5)
+
+    expect(statefulRunner).toHaveBeenCalledWith(SDK.adb, ['-s', 'emulator-5554', 'emu', 'fold'])
+    const wmSizeCalls = statefulRunner.mock.calls.filter(
+      ([binary, args]) => binary === SDK.adb && args.join(' ') === '-s emulator-5554 shell wm size'
+    )
+    expect(wmSizeCalls).toHaveLength(2)
+    const tapCalls = statefulRunner.mock.calls.filter(
+      ([binary, args]) =>
+        binary === SDK.adb && args.slice(0, 5).join(' ') === '-s emulator-5554 shell input tap'
+    )
+    expect(tapCalls.map(([, args]) => args)).toEqual([
+      ['-s', 'emulator-5554', 'shell', 'input', 'tap', '50', '100'],
+      ['-s', 'emulator-5554', 'shell', 'input', 'tap', '100', '50']
+    ])
+  })
+
   it('types text with spaces encoded and presses hardware buttons by keycode', async () => {
     const android = backend(runner)
     await android.type('emulator-5554', 'hi there')

--- a/src/main/emulator/backends/android-emulator-backend.ts
+++ b/src/main/emulator/backends/android-emulator-backend.ts
@@ -8,17 +8,7 @@ import type {
 } from './emulator-backend'
 import type { AndroidSdkPaths } from '../android/android-sdk-discovery'
 import { AndroidSdkState } from '../android/android-sdk-state'
-import { parseWmSize, wmSizeArgs } from '../android/adb-devices'
 import { emuKillArgs } from '../android/avd-manager'
-import type { DeviceScreenSize } from '../android/android-input-mapping'
-import {
-  androidButton,
-  androidExec,
-  androidRotate,
-  androidSwipe,
-  androidTap,
-  androidTypeText
-} from '../android/android-input-commands'
 import {
   execFileAndroidCommandRunner,
   type AndroidCommandRunner
@@ -29,6 +19,7 @@ import {
   listAndroidDevices,
   listRunningAdbDevices
 } from '../android/android-device-inventory'
+import { AndroidEmulatorInputController } from '../android/android-emulator-input-controller'
 import {
   captureAndroidLogcat,
   dumpAndroidAccessibilityTree,
@@ -46,6 +37,10 @@ import {
 import { AndroidStreamController } from '../android/android-stream-controller'
 import { scrcpyVideoRegistry } from '../scrcpy-video-registry'
 import type { EmulatorGesturePoint } from '../emulator-gesture-sender'
+import type {
+  EmulatorButtonOptions,
+  EmulatorPosture
+} from '../../../shared/emulator-device-controls'
 
 export type AndroidEmulatorBackendOptions = {
   runner?: AndroidCommandRunner
@@ -84,8 +79,8 @@ export class AndroidEmulatorBackend implements EmulatorBackend {
   private readonly ensureJar: () => Promise<string>
   private readonly startStreamSession: StartAndroidStream
   private readonly streamMaxSize: number
-  private readonly screenSizes = new Map<string, DeviceScreenSize>()
   private readonly streams: AndroidStreamController
+  private readonly inputController: AndroidEmulatorInputController
 
   constructor(options: AndroidEmulatorBackendOptions = {}) {
     this.runner = options.runner ?? execFileAndroidCommandRunner
@@ -96,6 +91,11 @@ export class AndroidEmulatorBackend implements EmulatorBackend {
     this.ensureJar = options.ensureJar ?? ensureScrcpyServerJar
     this.startStreamSession = options.startStreamSession ?? startAndroidStreamSession
     this.streamMaxSize = options.streamMaxSize ?? 1280
+    this.inputController = new AndroidEmulatorInputController({
+      runner: this.runner,
+      sdk: () => this.requireSdk(),
+      resolveDeviceId: (deviceId) => this.resolveDeviceId(deviceId)
+    })
     this.streams = new AndroidStreamController({
       runner: this.runner,
       sdk: () => this.requireSdk(),
@@ -195,7 +195,7 @@ export class AndroidEmulatorBackend implements EmulatorBackend {
   async shutdownDevice(deviceId: string): Promise<void> {
     const sdk = this.requireSdk()
     const serial = await this.resolveDeviceId(deviceId)
-    this.screenSizes.delete(serial)
+    this.inputController.invalidateScreenSize(serial)
     ensureAdbOk(await this.runner(sdk.adb, emuKillArgs(serial)), 'adb emulator shutdown')
   }
 
@@ -206,8 +206,7 @@ export class AndroidEmulatorBackend implements EmulatorBackend {
   }
 
   async tap(deviceId: string, x: number, y: number): Promise<void> {
-    const serial = await this.resolveDeviceId(deviceId)
-    await androidTap(this.runner, this.requireSdk(), serial, x, y, await this.getScreenSize(serial))
+    return this.inputController.tap(deviceId, x, y)
   }
 
   async gesture(
@@ -215,42 +214,27 @@ export class AndroidEmulatorBackend implements EmulatorBackend {
     points: EmulatorGesturePoint[],
     _wsUrl: string | null
   ): Promise<void> {
-    const serial = await this.resolveDeviceId(deviceId)
-    await androidSwipe(
-      this.runner,
-      this.requireSdk(),
-      serial,
-      points,
-      await this.getScreenSize(serial)
-    )
+    return this.inputController.gesture(deviceId, points)
   }
 
   async type(deviceId: string, text: string): Promise<void> {
-    await androidTypeText(
-      this.runner,
-      this.requireSdk(),
-      await this.resolveDeviceId(deviceId),
-      text
-    )
+    return this.inputController.type(deviceId, text)
   }
 
-  async button(deviceId: string, name: string): Promise<void> {
-    await androidButton(this.runner, this.requireSdk(), await this.resolveDeviceId(deviceId), name)
+  async button(deviceId: string, name: string, options?: EmulatorButtonOptions): Promise<void> {
+    return this.inputController.button(deviceId, name, options)
+  }
+
+  async setPosture(deviceId: string, posture: EmulatorPosture): Promise<void> {
+    return this.inputController.setPosture(deviceId, posture)
   }
 
   async rotate(deviceId: string, orientation: string): Promise<void> {
-    const serial = await this.resolveDeviceId(deviceId)
-    this.screenSizes.delete(serial)
-    await androidRotate(this.runner, this.requireSdk(), serial, orientation)
+    return this.inputController.rotate(deviceId, orientation)
   }
 
   async exec(deviceId: string, command: string): Promise<unknown> {
-    return androidExec(
-      this.runner,
-      this.requireSdk(),
-      await this.resolveDeviceId(deviceId),
-      command
-    )
+    return this.inputController.exec(deviceId, command)
   }
 
   async installApp(
@@ -309,21 +293,6 @@ export class AndroidEmulatorBackend implements EmulatorBackend {
       pollIntervalMs: this.pollIntervalMs,
       sleep: this.sleep
     })
-  }
-
-  private async getScreenSize(serial: string): Promise<DeviceScreenSize> {
-    const cached = this.screenSizes.get(serial)
-    if (cached) {
-      return cached
-    }
-    const sdk = this.requireSdk()
-    const result = await this.runner(sdk.adb, wmSizeArgs(serial))
-    const size = parseWmSize(result.stdout)
-    if (!size) {
-      throw new EmulatorError('emulator_error', `Could not read screen size for ${serial}.`)
-    }
-    this.screenSizes.set(serial, size)
-    return size
   }
 
   private requireSdk(): AndroidSdkPaths {

--- a/src/main/emulator/backends/emulator-backend.ts
+++ b/src/main/emulator/backends/emulator-backend.ts
@@ -4,6 +4,11 @@ import type {
   EmulatorSessionInfo,
   EmulatorStreamCodec
 } from '../emulator-types'
+import type {
+  EmulatorButtonOptions,
+  EmulatorDeviceControlCapabilities,
+  EmulatorPosture
+} from '../../../shared/emulator-device-controls'
 
 export type { EmulatorBackendKind, EmulatorStreamCodec }
 
@@ -16,6 +21,7 @@ export type EmulatorDevice = {
   state: 'shutdown' | 'booting' | 'booted'
   detail?: string
   isAvailable: boolean
+  controlCapabilities?: EmulatorDeviceControlCapabilities
 }
 
 // Which optional verbs a backend supports. The router uses these to reject
@@ -76,8 +82,9 @@ export type EmulatorBackend = {
   // and drive their own control socket keyed by deviceId.
   gesture(deviceId: string, points: EmulatorGesturePoint[], wsUrl: string | null): Promise<void>
   type(deviceId: string, text: string): Promise<void>
-  button(deviceId: string, name: string): Promise<void>
+  button(deviceId: string, name: string, options?: EmulatorButtonOptions): Promise<void>
   rotate(deviceId: string, orientation: string): Promise<void>
+  setPosture?(deviceId: string, posture: EmulatorPosture): Promise<void>
   exec(deviceId: string, command: string): Promise<unknown>
 
   // Capability-gated verbs. The router checks `capabilities`

--- a/src/main/emulator/emulator-backend-resolver.ts
+++ b/src/main/emulator/emulator-backend-resolver.ts
@@ -1,0 +1,77 @@
+import { platform } from 'node:os'
+import { EmulatorError } from './emulator-errors'
+import type { EmulatorSessionRegistry } from './emulator-session-registry'
+import type {
+  EmulatorBackend,
+  EmulatorBackendKind,
+  EmulatorTargetOpts
+} from './backends/emulator-backend'
+
+export class EmulatorBackendResolver {
+  private readonly backends: EmulatorBackend[]
+  private readonly sessionRegistry: EmulatorSessionRegistry
+
+  constructor(backends: EmulatorBackend[], sessionRegistry: EmulatorSessionRegistry) {
+    this.backends = backends
+    this.sessionRegistry = sessionRegistry
+  }
+
+  forKind(kind: EmulatorBackendKind): EmulatorBackend | null {
+    return this.backends.find((backend) => backend.kind === kind) ?? null
+  }
+
+  forActiveWorktree(worktreeId: string): EmulatorBackend | null {
+    const key = this.sessionRegistry.getActiveSessionKey(worktreeId)
+    if (!key) {
+      return null
+    }
+    const session = this.sessionRegistry.getSession(key)
+    return session ? this.forKind(session.backend) : null
+  }
+
+  async forDevice(device: string): Promise<EmulatorBackend> {
+    for (const backend of this.backends) {
+      if (await backend.ownsDevice(device)) {
+        return backend
+      }
+    }
+    // Why: fall back to a host-supported backend, else the platform-primary one,
+    // so an unrecognized device surfaces the right setup error.
+    return (
+      this.backends.find((backend) => backend.isSupportedOnHost()) ??
+      this.forKind(platform() === 'darwin' ? 'ios' : 'android')!
+    )
+  }
+
+  async resolveTarget(
+    opts?: EmulatorTargetOpts
+  ): Promise<{ backend: EmulatorBackend; device: string }> {
+    const explicit = opts?.device ?? opts?.emulator
+    if (explicit) {
+      return { backend: await this.forDevice(explicit), device: explicit }
+    }
+    if (opts?.worktreeId) {
+      const active = this.sessionRegistry.getActiveForWorktree(opts.worktreeId)
+      const backend = this.forActiveWorktree(opts.worktreeId)
+      if (active && backend) {
+        return { backend, device: active.deviceUdid }
+      }
+    }
+    throw new EmulatorError(
+      'emulator_no_active',
+      'No active emulator for this worktree — use orca emulator attach or open the pane'
+    )
+  }
+
+  async resolveStopTarget(
+    device?: string,
+    worktreeId?: string
+  ): Promise<{ backend: EmulatorBackend; udid: string }> {
+    if (device) {
+      const backend = await this.forDevice(device)
+      return { backend, udid: await backend.resolveDeviceId(device) }
+    }
+    const { backend, device: resolved } = await this.resolveTarget({ worktreeId })
+    return { backend, udid: await backend.resolveDeviceId(resolved) }
+  }
+}

--- a/src/main/emulator/emulator-bridge.test.ts
+++ b/src/main/emulator/emulator-bridge.test.ts
@@ -68,6 +68,7 @@ function session(deviceUdid: string): EmulatorSessionInfo {
     wsUrl: `ws://127.0.0.1:3100/${deviceUdid}`,
     axUrl: `http://127.0.0.1:3100/${deviceUdid}/ax`,
     helperPid: 1234,
+    backend: 'ios',
     // iOS serve-sim sessions round-trip through the registry as mjpeg.
     streamCodec: 'mjpeg'
   }

--- a/src/main/emulator/emulator-bridge.ts
+++ b/src/main/emulator/emulator-bridge.ts
@@ -1,4 +1,3 @@
-import { platform } from 'node:os'
 import { EmulatorError } from './emulator-errors'
 import type { EmulatorSessionInfo } from './emulator-types'
 import type { SimulatorDevice } from './simctl-simulator-devices'
@@ -11,6 +10,7 @@ import {
 } from './emulator-start-lease-registry'
 import { listAvailableEmulatorDevices } from './emulator-device-inventory'
 import { deriveAxUrlFromStreamUrl } from './serve-sim-detached-session'
+import { EmulatorBackendResolver } from './emulator-backend-resolver'
 import { IosEmulatorBackend } from './backends/ios-emulator-backend'
 import { AndroidEmulatorBackend } from './backends/android-emulator-backend'
 import type {
@@ -20,6 +20,7 @@ import type {
   EmulatorDevice,
   EmulatorTargetOpts
 } from './backends/emulator-backend'
+import type { EmulatorButtonOptions, EmulatorPosture } from '../../shared/emulator-device-controls'
 
 // Routes emulator commands to the backend that owns the target device while
 // owning the per-worktree active-session registry and lifecycle orchestration.
@@ -31,6 +32,7 @@ export class EmulatorBridge {
   private readonly backends: EmulatorBackend[]
   private readonly iosBackend: IosEmulatorBackend
   private readonly androidBackend: AndroidEmulatorBackend
+  private readonly backendResolver: EmulatorBackendResolver
 
   constructor(options: EmulatorBridgeOptions = {}) {
     this.iosBackend = new IosEmulatorBackend(options)
@@ -38,6 +40,7 @@ export class EmulatorBridge {
     // Why: backends are always registered (not host-gated) so explicitly targeted
     // commands still reach them; availability reporting handles host support.
     this.backends = [this.iosBackend, this.androidBackend]
+    this.backendResolver = new EmulatorBackendResolver(this.backends, this.sessionRegistry)
   }
 
   listBackends(): EmulatorBackend[] {
@@ -82,7 +85,7 @@ export class EmulatorBridge {
   // On a device switch, keep slow-to-boot Android emulators running for instant
   // switch-back; shut down other backends' devices so they are not leaked.
   async stopActiveForSwitch(worktreeId: string): Promise<string | null> {
-    const keepAlive = this.backendForActiveWorktree(worktreeId)?.kind === 'android'
+    const keepAlive = this.backendResolver.forActiveWorktree(worktreeId)?.kind === 'android'
     return this.stopActiveForWorktreeInternal(worktreeId, { shutdownDevice: !keepAlive })
   }
 
@@ -94,7 +97,7 @@ export class EmulatorBridge {
     if (!active) {
       return null
     }
-    const backend = this.backendForActiveWorktree(worktreeId)
+    const backend = this.backendResolver.forActiveWorktree(worktreeId)
     if (!backend) {
       return null
     }
@@ -139,7 +142,7 @@ export class EmulatorBridge {
     if (this.sessionRegistry.hasActiveWorktreeForSession(key)) {
       return session.deviceUdid
     }
-    const backend = this.backendForKind(session.backend)
+    const backend = this.backendResolver.forKind(session.backend)
     if (!backend) {
       return null
     }
@@ -164,7 +167,7 @@ export class EmulatorBridge {
   }
 
   async tap(x: number, y: number, opts?: EmulatorTargetOpts): Promise<void> {
-    const { backend, device } = await this.resolveTarget(opts)
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
     await backend.tap(device, x, y)
   }
 
@@ -172,29 +175,44 @@ export class EmulatorBridge {
     if (points.length === 0) {
       return
     }
-    const { backend, device } = await this.resolveTarget(opts)
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
     const udid = await backend.resolveDeviceId(device)
     const wsUrl = this.sessionRegistry.getSession(udid)?.wsUrl ?? null
     await backend.gesture(udid, points, wsUrl)
   }
 
   async type(text: string, opts?: EmulatorTargetOpts): Promise<void> {
-    const { backend, device } = await this.resolveTarget(opts)
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
     await backend.type(device, text)
   }
 
-  async button(name: string, opts?: EmulatorTargetOpts): Promise<void> {
-    const { backend, device } = await this.resolveTarget(opts)
-    await backend.button(device, name)
+  async button(
+    name: string,
+    opts?: EmulatorTargetOpts,
+    options?: EmulatorButtonOptions
+  ): Promise<void> {
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
+    await backend.button(device, name, options)
+  }
+
+  async setPosture(posture: EmulatorPosture, opts?: EmulatorTargetOpts): Promise<void> {
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
+    if (!backend.setPosture) {
+      throw new EmulatorError(
+        'emulator_unsupported',
+        `Posture changes are not supported by the ${backend.kind} emulator backend`
+      )
+    }
+    await backend.setPosture(device, posture)
   }
 
   async rotate(orientation: string, opts?: EmulatorTargetOpts): Promise<void> {
-    const { backend, device } = await this.resolveTarget(opts)
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
     await backend.rotate(device, orientation)
   }
 
   async exec(command: string, opts?: EmulatorTargetOpts): Promise<unknown> {
-    const { backend, device } = await this.resolveTarget(opts)
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
     return backend.exec(device, command)
   }
 
@@ -231,7 +249,7 @@ export class EmulatorBridge {
     opts: EmulatorTargetOpts | undefined,
     run: (backend: EmulatorBackend, deviceId: string) => Promise<T>
   ): Promise<T> {
-    const { backend, device } = await this.resolveTarget(opts)
+    const { backend, device } = await this.backendResolver.resolveTarget(opts)
     if (!backend.capabilities[capability]) {
       throw new EmulatorError(
         'emulator_unsupported',
@@ -242,14 +260,14 @@ export class EmulatorBridge {
   }
 
   async acquireHelperForDevice(device: string): Promise<EmulatorStartLease> {
-    const backend = await this.backendForDevice(device)
+    const backend = await this.backendResolver.forDevice(device)
     return this.startLeases.acquire(backend, device, (info) =>
       this.sessionRegistry.hasActiveWorktreeForSession(info.deviceUdid)
     )
   }
 
   async kill(device?: string, worktreeId?: string): Promise<string> {
-    const { backend, udid } = await this.resolveStopTarget(device, worktreeId)
+    const { backend, udid } = await this.backendResolver.resolveStopTarget(device, worktreeId)
     await backend.stopHelperForDevice(udid, {
       helperPid: this.sessionRegistry.getSession(udid)?.pid,
       includeOrphaned: true
@@ -259,7 +277,7 @@ export class EmulatorBridge {
   }
 
   async shutdown(device?: string, worktreeId?: string): Promise<string> {
-    const { backend, udid } = await this.resolveStopTarget(device, worktreeId)
+    const { backend, udid } = await this.backendResolver.resolveStopTarget(device, worktreeId)
     await backend.stopHelperForDevice(udid, {
       helperPid: this.sessionRegistry.getSession(udid)?.pid,
       includeOrphaned: true
@@ -275,7 +293,7 @@ export class EmulatorBridge {
       if (!session.managed) {
         continue
       }
-      const backend = this.backendForKind(session.backend)
+      const backend = this.backendResolver.forKind(session.backend)
       if (!backend) {
         continue
       }
@@ -292,65 +310,5 @@ export class EmulatorBridge {
 
   async onAppQuit(): Promise<void> {
     await this.destroyAllSessions()
-  }
-
-  private async resolveTarget(
-    opts?: EmulatorTargetOpts
-  ): Promise<{ backend: EmulatorBackend; device: string }> {
-    const explicit = opts?.device ?? opts?.emulator
-    if (explicit) {
-      return { backend: await this.backendForDevice(explicit), device: explicit }
-    }
-    if (opts?.worktreeId) {
-      const active = this.getActiveForWorktree(opts.worktreeId)
-      const backend = this.backendForActiveWorktree(opts.worktreeId)
-      if (active && backend) {
-        return { backend, device: active.deviceUdid }
-      }
-    }
-    throw new EmulatorError(
-      'emulator_no_active',
-      'No active emulator for this worktree — use orca emulator attach or open the pane'
-    )
-  }
-
-  private async resolveStopTarget(
-    device?: string,
-    worktreeId?: string
-  ): Promise<{ backend: EmulatorBackend; udid: string }> {
-    if (device) {
-      const backend = await this.backendForDevice(device)
-      return { backend, udid: await backend.resolveDeviceId(device) }
-    }
-    const { backend, device: resolved } = await this.resolveTarget({ worktreeId })
-    return { backend, udid: await backend.resolveDeviceId(resolved) }
-  }
-
-  private backendForKind(kind: EmulatorBackendKind): EmulatorBackend | null {
-    return this.backends.find((backend) => backend.kind === kind) ?? null
-  }
-
-  private backendForActiveWorktree(worktreeId: string): EmulatorBackend | null {
-    const key = this.sessionRegistry.getActiveSessionKey(worktreeId)
-    if (!key) {
-      return null
-    }
-    const session = this.sessionRegistry.getSession(key)
-    return session ? this.backendForKind(session.backend) : null
-  }
-
-  private async backendForDevice(device: string): Promise<EmulatorBackend> {
-    for (const backend of this.backends) {
-      if (await backend.ownsDevice(device)) {
-        return backend
-      }
-    }
-    // Why: fall back to a host-supported backend, else the platform-primary one,
-    // so an unrecognized device (e.g. no SDK yet) surfaces the right setup error
-    // — Android on Windows/Linux, iOS/CoreSimulator on macOS — not iOS-on-Windows.
-    return (
-      this.backends.find((backend) => backend.isSupportedOnHost()) ??
-      (platform() === 'darwin' ? this.iosBackend : this.androidBackend)
-    )
   }
 }

--- a/src/main/emulator/emulator-session-registry.test.ts
+++ b/src/main/emulator/emulator-session-registry.test.ts
@@ -22,7 +22,7 @@ describe('EmulatorSessionRegistry backend tagging', () => {
     expect(session?.streamCodec).toBe('mjpeg')
   })
 
-  it('carries streamCodec back through getActiveForWorktree', () => {
+  it('carries backend and streamCodec back through getActiveForWorktree', () => {
     const registry = new EmulatorSessionRegistry()
     registry.registerActive(
       'wt1',
@@ -30,6 +30,7 @@ describe('EmulatorSessionRegistry backend tagging', () => {
       { backend: 'android' }
     )
     const info = registry.getActiveForWorktree('wt1')
+    expect(info?.backend).toBe('android')
     expect(info?.streamCodec).toBe('h264')
   })
 })

--- a/src/main/emulator/emulator-session-registry.ts
+++ b/src/main/emulator/emulator-session-registry.ts
@@ -85,6 +85,7 @@ function toSessionInfo(session: EmulatorSessionState): EmulatorSessionInfo {
     streamUrl: session.streamUrl,
     axUrl: session.axUrl,
     helperPid: session.pid,
+    backend: session.backend,
     streamCodec: session.streamCodec
   }
 }

--- a/src/main/runtime/orca-runtime-emulator.ts
+++ b/src/main/runtime/orca-runtime-emulator.ts
@@ -12,6 +12,7 @@ import type { EmulatorSessionInfo } from '../emulator/emulator-types'
 import type { SimulatorDevice } from '../emulator/simctl-simulator-devices'
 import type { EmulatorDevice } from '../emulator/backends/emulator-backend'
 import type { GlobalSettings } from '../../shared/global-settings-types'
+import type { EmulatorButtonOptions, EmulatorPosture } from '../../shared/emulator-device-controls'
 
 // Settings slice the emulator surface needs; keeps the host contract honest (no widening cast).
 type EmulatorHostSettings = Pick<
@@ -29,6 +30,13 @@ export type RuntimeEmulatorCommandHost = {
 }
 
 type EmulatorTargetParams = { device?: string; emulator?: string; worktree?: string }
+type EmulatorGestureParams = EmulatorTargetParams & { points: EmulatorGesturePoint[] }
+type EmulatorTypeParams = EmulatorTargetParams & { text: string }
+type EmulatorButtonParams = EmulatorTargetParams & { name: string; longPress?: boolean }
+type EmulatorPostureParams = EmulatorTargetParams & { posture: EmulatorPosture }
+type EmulatorRotateParams = EmulatorTargetParams & { orientation: string }
+type EmulatorExecParams = EmulatorTargetParams & { command: string }
+type EmulatorShutdownParams = EmulatorTargetParams & { managedOnly?: boolean }
 
 export class RuntimeEmulatorCommands {
   constructor(private readonly host: RuntimeEmulatorCommandHost) {}
@@ -56,48 +64,45 @@ export class RuntimeEmulatorCommands {
     return RuntimeEmulatorCommands.OK
   }
 
-  async emulatorGesture(params: {
-    points: EmulatorGesturePoint[]
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<{ ok: true }> {
+  async emulatorGesture(params: EmulatorGestureParams): Promise<{ ok: true }> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveWorktreeId(params.worktree)
     await bridge.gesture(params.points, { device: params.device ?? params.emulator, worktreeId })
     return RuntimeEmulatorCommands.OK
   }
 
-  async emulatorType(params: {
-    text: string
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<{ ok: true }> {
+  async emulatorType(params: EmulatorTypeParams): Promise<{ ok: true }> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveWorktreeId(params.worktree)
     await bridge.type(params.text, { device: params.device ?? params.emulator, worktreeId })
     return RuntimeEmulatorCommands.OK
   }
 
-  async emulatorButton(params: {
-    name: string
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<{ ok: true }> {
+  async emulatorButton(params: EmulatorButtonParams): Promise<{ ok: true }> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveWorktreeId(params.worktree)
-    await bridge.button(params.name, { device: params.device ?? params.emulator, worktreeId })
+    const options: EmulatorButtonOptions | undefined = params.longPress
+      ? { longPress: true }
+      : undefined
+    await bridge.button(
+      params.name,
+      { device: params.device ?? params.emulator, worktreeId },
+      options
+    )
     return RuntimeEmulatorCommands.OK
   }
 
-  async emulatorRotate(params: {
-    orientation: string
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<{ ok: true }> {
+  async emulatorPosture(params: EmulatorPostureParams): Promise<{ ok: true }> {
+    const bridge = this.requireEmulatorBridge()
+    const worktreeId = await this.resolveWorktreeId(params.worktree)
+    await bridge.setPosture(params.posture, {
+      device: params.device ?? params.emulator,
+      worktreeId
+    })
+    return RuntimeEmulatorCommands.OK
+  }
+
+  async emulatorRotate(params: EmulatorRotateParams): Promise<{ ok: true }> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveWorktreeId(params.worktree)
     await bridge.rotate(params.orientation, {
@@ -107,12 +112,7 @@ export class RuntimeEmulatorCommands {
     return RuntimeEmulatorCommands.OK
   }
 
-  async emulatorExec(params: {
-    command: string
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<unknown> {
+  async emulatorExec(params: EmulatorExecParams): Promise<unknown> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveWorktreeId(params.worktree)
     return bridge.exec(params.command, {
@@ -294,23 +294,16 @@ export class RuntimeEmulatorCommands {
     )
   }
 
-  async emulatorKill(params: {
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<{ ok: true; deviceUdid: string }> {
+  async emulatorKill(params: EmulatorTargetParams): Promise<{ ok: true; deviceUdid: string }> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveCleanupWorktreeId(params.worktree)
     const killedUdid = await bridge.kill(params.device ?? params.emulator, worktreeId)
     return { ok: true, deviceUdid: killedUdid }
   }
 
-  async emulatorShutdown(params: {
-    device?: string
-    emulator?: string
-    worktree?: string
-    managedOnly?: boolean
-  }): Promise<{ ok: true; deviceUdid?: string }> {
+  async emulatorShutdown(
+    params: EmulatorShutdownParams
+  ): Promise<{ ok: true; deviceUdid?: string }> {
     const bridge = this.requireEmulatorBridge()
     const worktreeId = await this.resolveCleanupWorktreeId(params.worktree)
     if (params.managedOnly && worktreeId && !params.device && !params.emulator) {
@@ -340,12 +333,7 @@ export class RuntimeEmulatorCommands {
   }
 
   // Raw for extensibility.
-  async emulatorExecRaw(params: {
-    command: string
-    device?: string
-    emulator?: string
-    worktree?: string
-  }): Promise<unknown> {
+  async emulatorExecRaw(params: EmulatorExecParams): Promise<unknown> {
     return this.emulatorExec(params)
   }
 }

--- a/src/main/runtime/rpc/methods/emulator.test.ts
+++ b/src/main/runtime/rpc/methods/emulator.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { EMULATOR_METHODS } from './emulator'
+
+const method = (name: string) => {
+  const found = EMULATOR_METHODS.find((candidate) => candidate.name === name)
+  if (!found) {
+    throw new Error(`Missing ${name}`)
+  }
+  return found
+}
+
+describe('emulator control RPC methods', () => {
+  it('accepts optional longPress and routes it without loss', async () => {
+    const emulatorButton = vi.fn().mockResolvedValue({ ok: true })
+    const button = method('emulator.button')
+
+    const params = button.params?.parse({
+      name: 'power',
+      longPress: true,
+      device: 'emulator-5554',
+      worktree: 'wt-1'
+    })
+    await button.handler(params, { runtime: { emulatorButton } } as never)
+
+    expect(emulatorButton).toHaveBeenCalledWith({
+      name: 'power',
+      longPress: true,
+      device: 'emulator-5554',
+      worktree: 'wt-1'
+    })
+    expect(button.params?.safeParse({ name: 'power', longPress: 'yes' }).success).toBe(false)
+  })
+
+  it('accepts only folded and unfolded posture values and routes targets', async () => {
+    const emulatorPosture = vi.fn().mockResolvedValue({ ok: true })
+    const posture = method('emulator.posture')
+
+    const params = posture.params?.parse({
+      posture: 'folded',
+      emulator: 'foldable-api-35',
+      worktree: 'wt-2'
+    })
+    await posture.handler(params, { runtime: { emulatorPosture } } as never)
+
+    expect(emulatorPosture).toHaveBeenCalledWith({
+      posture: 'folded',
+      emulator: 'foldable-api-35',
+      worktree: 'wt-2'
+    })
+    expect(posture.params?.safeParse({ posture: 'half-open' }).success).toBe(false)
+  })
+})

--- a/src/main/runtime/rpc/methods/emulator.ts
+++ b/src/main/runtime/rpc/methods/emulator.ts
@@ -36,6 +36,14 @@ const TypeParams = z.object({
 
 const ButtonParams = z.object({
   name: z.string(),
+  longPress: z.boolean().optional(),
+  device: z.string().optional(),
+  emulator: z.string().optional(),
+  worktree: z.string().optional()
+})
+
+const PostureParams = z.object({
+  posture: z.enum(['folded', 'unfolded']),
   device: z.string().optional(),
   emulator: z.string().optional(),
   worktree: z.string().optional()
@@ -185,6 +193,11 @@ export const EMULATOR_METHODS: RpcMethod[] = [
     name: 'emulator.button',
     params: ButtonParams,
     handler: async (params, { runtime }) => runtime.emulatorButton(params)
+  }),
+  defineMethod({
+    name: 'emulator.posture',
+    params: PostureParams,
+    handler: async (params, { runtime }) => runtime.emulatorPosture(params)
   }),
   defineMethod({
     name: 'emulator.rotate',

--- a/src/renderer/src/components/browser-pane/annotate/markup-screenshot-compose.ts
+++ b/src/renderer/src/components/browser-pane/annotate/markup-screenshot-compose.ts
@@ -9,7 +9,7 @@
 
 import { scaleShape, type MarkupShape } from './markup-drawing-model'
 import { drawShapes } from './markup-shape-render'
-
+import { canvasToPngDataUrl } from '@/lib/canvas-png-data-url'
 export type MarkupComposeResult = {
   dataUrl: string
   // Why: PNG only — the clipboard:writeImage handler accepts a PNG data URL and
@@ -141,27 +141,7 @@ function downscaleCanvas(source: HTMLCanvasElement, factor: number): HTMLCanvasE
   return next
 }
 
-// Encodes a canvas to a PNG data URL. Prefers toBlob because Chromium encodes it
-// off the main thread — a multi-megapixel toData('image/png') is synchronous and
-// freezes the renderer. Falls back to the sync encode if toBlob yields no blob.
-function canvasToPngDataUrl(canvas: HTMLCanvasElement): Promise<string> {
-  return new Promise((resolve, reject) => {
-    canvas.toBlob((blob) => {
-      if (!blob) {
-        try {
-          resolve(canvas.toDataURL('image/png'))
-        } catch (error) {
-          reject(error instanceof Error ? error : new Error('markup compose: toDataURL failed'))
-        }
-        return
-      }
-      const reader = new FileReader()
-      reader.onload = () => resolve(reader.result as string)
-      reader.onerror = () => reject(reader.error ?? new Error('markup compose: blob read failed'))
-      reader.readAsDataURL(blob)
-    }, 'image/png')
-  })
-}
+// PNG encoding is shared with the raw emulator framebuffer export.
 
 // Encodes a PNG within budget: full size, then progressively smaller. Always
 // returns a PNG (best effort at the smallest step) so the clipboard handler

--- a/src/renderer/src/components/emulator-pane/EmulatorPane.test.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPane.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import EmulatorPane from './EmulatorPane'
+import type { EmulatorDeviceControlCapabilities } from '../../../../shared/emulator-device-controls'
 import type {
   EmulatorZoomAction,
   EmulatorZoomMetrics,
@@ -14,14 +15,27 @@ type CapturedFrameProps = {
 }
 
 type CapturedToolbarProps = {
+  onRotate?: () => void
   androidControls?: {
+    capabilities?: EmulatorDeviceControlCapabilities
     onZoomChange?: (action: EmulatorZoomAction) => void
   }
 }
 
+const androidControlCapabilities: EmulatorDeviceControlCapabilities = {
+  shutdown: false,
+  power: true,
+  volume: false,
+  overview: true,
+  foldable: true,
+  wearButton1: false,
+  wearButton2: true
+}
+
 const mocks = vi.hoisted(() => ({
   frameProps: { current: null as CapturedFrameProps | null },
-  toolbarProps: { current: null as CapturedToolbarProps | null }
+  toolbarProps: { current: null as CapturedToolbarProps | null },
+  sendRotate: vi.fn()
 }))
 
 vi.mock('./use-emulator-pane-session', () => ({
@@ -33,7 +47,7 @@ vi.mock('./use-emulator-pane-session', () => ({
         state: 'Booted',
         runtime: 'emulator',
         backend: 'android',
-        controlCapabilities: { power: true, volume: true, overview: true, shutdown: true }
+        controlCapabilities: androidControlCapabilities
       }
     ],
     selectedUdid: 'emulator-5554',
@@ -45,7 +59,7 @@ vi.mock('./use-emulator-pane-session', () => ({
     sendTap: vi.fn(),
     sendButton: vi.fn(),
     sendGesture: vi.fn(),
-    sendRotate: vi.fn(),
+    sendRotate: mocks.sendRotate,
     sendPosture: vi.fn(),
     displayCommandPending: false,
     displayName: 'Pixel 9 Pro',
@@ -60,7 +74,7 @@ vi.mock('./use-emulator-pane-session', () => ({
       state: 'Booted',
       runtime: 'emulator',
       backend: 'android',
-      controlCapabilities: { power: true, volume: true, overview: true, shutdown: true }
+      controlCapabilities: androidControlCapabilities
     },
     session: { attached: true, info: { backend: 'android', deviceUdid: 'emulator-5554' } }
   })
@@ -88,6 +102,7 @@ afterEach(() => {
   cleanup()
   mocks.frameProps.current = null
   mocks.toolbarProps.current = null
+  mocks.sendRotate.mockReset()
 })
 
 describe('EmulatorPane zoom integration', () => {
@@ -119,5 +134,28 @@ describe('EmulatorPane zoom integration', () => {
     })
 
     expect(mocks.frameProps.current?.zoomState).toEqual({ mode: 'fixed', scale: 0.5 })
+  })
+})
+
+describe('EmulatorPane Android controls integration', () => {
+  it('forwards selected device control capabilities to the toolbar', () => {
+    render(<EmulatorPane worktreeId="worktree-1" />)
+
+    expect(mocks.toolbarProps.current?.androidControls?.capabilities).toEqual(
+      androidControlCapabilities
+    )
+  })
+
+  it('uses the legacy no-argument rotation callback for the pane toolbar', () => {
+    render(<EmulatorPane worktreeId="worktree-1" />)
+
+    const onRotate = mocks.toolbarProps.current?.onRotate
+    expect(onRotate).toEqual(expect.any(Function))
+
+    act(() => {
+      onRotate?.()
+    })
+
+    expect(mocks.sendRotate).toHaveBeenCalledWith()
   })
 })

--- a/src/renderer/src/components/emulator-pane/EmulatorPane.test.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPane.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment happy-dom
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import EmulatorPane from './EmulatorPane'
+import type {
+  EmulatorZoomAction,
+  EmulatorZoomMetrics,
+  EmulatorZoomState
+} from './emulator-pane-zoom'
+
+type CapturedFrameProps = {
+  onZoomMetrics?: (metrics: EmulatorZoomMetrics | null) => void
+  zoomState?: EmulatorZoomState
+}
+
+type CapturedToolbarProps = {
+  androidControls?: {
+    onZoomChange?: (action: EmulatorZoomAction) => void
+  }
+}
+
+const mocks = vi.hoisted(() => ({
+  frameProps: { current: null as CapturedFrameProps | null },
+  toolbarProps: { current: null as CapturedToolbarProps | null }
+}))
+
+vi.mock('./use-emulator-pane-session', () => ({
+  useEmulatorPaneSession: () => ({
+    devices: [
+      {
+        name: 'Pixel 9 Pro',
+        udid: 'emulator-5554',
+        state: 'Booted',
+        runtime: 'emulator',
+        backend: 'android',
+        controlCapabilities: { power: true, volume: true, overview: true, shutdown: true }
+      }
+    ],
+    selectedUdid: 'emulator-5554',
+    setSelectedUdid: vi.fn(),
+    loading: false,
+    error: null,
+    attach: vi.fn(),
+    shutdown: vi.fn(),
+    sendTap: vi.fn(),
+    sendButton: vi.fn(),
+    sendGesture: vi.fn(),
+    sendRotate: vi.fn(),
+    sendPosture: vi.fn(),
+    displayCommandPending: false,
+    displayName: 'Pixel 9 Pro',
+    previewUrl: undefined,
+    wsUrl: 'ws://emulator',
+    streamKey: 'stream-1',
+    isLive: true,
+    visualOrientation: 'portrait',
+    selectedDevice: {
+      name: 'Pixel 9 Pro',
+      udid: 'emulator-5554',
+      state: 'Booted',
+      runtime: 'emulator',
+      backend: 'android',
+      controlCapabilities: { power: true, volume: true, overview: true, shutdown: true }
+    },
+    session: { attached: true, info: { backend: 'android', deviceUdid: 'emulator-5554' } }
+  })
+}))
+
+vi.mock('./emulator-pane-toolbar', () => ({
+  EmulatorPaneToolbar: (props: CapturedToolbarProps) => {
+    mocks.toolbarProps.current = props
+    return null
+  }
+}))
+
+vi.mock('./emulator-device-frame', () => ({
+  EmulatorDeviceFrame: (props: CapturedFrameProps) => {
+    mocks.frameProps.current = props
+    return null
+  }
+}))
+
+vi.mock('./MobileEmulatorAgentSetupGuideLayer', () => ({
+  MobileEmulatorAgentSetupGuideLayer: ({ children }: { children: unknown }) => children
+}))
+
+afterEach(() => {
+  cleanup()
+  mocks.frameProps.current = null
+  mocks.toolbarProps.current = null
+})
+
+describe('EmulatorPane zoom integration', () => {
+  it('passes frame metrics into zoom state and sends Zoom In through the toolbar', () => {
+    render(<EmulatorPane worktreeId="worktree-1" />)
+
+    const frameProps = mocks.frameProps.current
+    const toolbarProps = mocks.toolbarProps.current
+    const onZoomMetrics = frameProps?.onZoomMetrics
+    expect(onZoomMetrics).toEqual(expect.any(Function))
+    expect(toolbarProps?.androidControls?.onZoomChange).toEqual(expect.any(Function))
+    if (!onZoomMetrics) {
+      throw new Error('Expected frame zoom metrics callback')
+    }
+
+    act(() => {
+      onZoomMetrics({
+        fitScale: 0.4,
+        fitDisplayScale: 0.3
+      })
+    })
+    const onZoomChange = mocks.toolbarProps.current?.androidControls?.onZoomChange
+    expect(onZoomChange).toEqual(expect.any(Function))
+    if (!onZoomChange) {
+      throw new Error('Expected toolbar zoom callback')
+    }
+    act(() => {
+      onZoomChange('in')
+    })
+
+    expect(mocks.frameProps.current?.zoomState).toEqual({ mode: 'fixed', scale: 0.5 })
+  })
+})

--- a/src/renderer/src/components/emulator-pane/EmulatorPane.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPane.tsx
@@ -1,9 +1,14 @@
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
 import type { Tab } from '../../../../shared/tab-types'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { translate } from '@/i18n/i18n'
 import { EmulatorPaneToolbar } from './emulator-pane-toolbar'
 import { EmulatorDeviceFrame } from './emulator-device-frame'
 import { MobileEmulatorAgentSetupGuideLayer } from './MobileEmulatorAgentSetupGuideLayer'
 import { useEmulatorPaneSession } from './use-emulator-pane-session'
-import { translate } from '@/i18n/i18n'
+import { saveEmulatorScreenshot } from './save-emulator-screenshot'
+import { useEmulatorPaneZoom } from './emulator-pane-zoom'
 
 type EmulatorPaneProps = {
   tab?: Tab
@@ -13,6 +18,9 @@ type EmulatorPaneProps = {
 }
 
 export default function EmulatorPane({ tab, worktreeId, isActive = true }: EmulatorPaneProps) {
+  const screenshotCanvasRef = useRef<HTMLCanvasElement | null>(null)
+  const [screenshotAvailable, setScreenshotAvailable] = useState(false)
+  const [savingScreenshot, setSavingScreenshot] = useState(false)
   const {
     devices,
     selectedUdid,
@@ -25,17 +33,52 @@ export default function EmulatorPane({ tab, worktreeId, isActive = true }: Emula
     sendButton,
     sendGesture,
     sendRotate,
+    sendPosture,
+    displayCommandPending,
     displayName,
     previewUrl,
     wsUrl,
     streamKey,
     isLive,
-    visualOrientation
+    visualOrientation,
+    selectedDevice,
+    session
   } = useEmulatorPaneSession({
     worktreeId,
     tabId: tab?.id,
     autoAttachOnMount: isActive
   })
+  const zoom = useEmulatorPaneZoom(selectedUdid)
+  const saveScreenshot = async (): Promise<void> => {
+    const canvas = screenshotCanvasRef.current
+    if (!canvas || savingScreenshot) {
+      return
+    }
+    setSavingScreenshot(true)
+    try {
+      const result = await saveEmulatorScreenshot(canvas, new Date())
+      if (!result.canceled) {
+        toast.success(
+          translate(
+            'auto.components.emulator.pane.EmulatorPane.savedScreenshot',
+            'Saved emulator screenshot'
+          )
+        )
+      }
+    } catch (error) {
+      toast.error(
+        extractIpcErrorMessage(
+          error,
+          translate(
+            'auto.components.emulator.pane.EmulatorPane.saveScreenshotFailed',
+            'Could not save emulator screenshot'
+          )
+        )
+      )
+    } finally {
+      setSavingScreenshot(false)
+    }
+  }
 
   return (
     <div
@@ -55,7 +98,20 @@ export default function EmulatorPane({ tab, worktreeId, isActive = true }: Emula
         onAttach={() => void attach(selectedUdid ?? undefined)}
         onShutdown={() => void shutdown(selectedUdid ?? undefined)}
         onHome={() => void sendButton('home')}
-        onRotate={() => void sendRotate()}
+        onRotate={() => void sendRotate('left')}
+        backend={session?.info?.backend ?? selectedDevice?.backend}
+        androidControls={{
+          displayCommandPending,
+          screenshotAvailable,
+          savingScreenshot,
+          zoomPercentage: zoom.percentage,
+          zoomAvailability: zoom.availability,
+          onButton: (name, options) => void sendButton(name, options),
+          onPosture: (posture) => void sendPosture(posture),
+          onRotate: (direction) => void sendRotate(direction),
+          onScreenshot: () => void saveScreenshot(),
+          onZoomChange: (action) => zoom.zoom(action)
+        }}
       />
 
       {error ? (
@@ -85,6 +141,12 @@ export default function EmulatorPane({ tab, worktreeId, isActive = true }: Emula
             isActive={isActive}
             onTap={(x, y) => void sendTap(x, y)}
             onGesture={(points) => void sendGesture(points)}
+            onScreenshotCanvasChange={(canvas) => {
+              screenshotCanvasRef.current = canvas
+              setScreenshotAvailable(canvas !== null)
+            }}
+            zoomState={zoom.state}
+            onZoomMetrics={zoom.setMetrics}
           />
         </MobileEmulatorAgentSetupGuideLayer>
       </div>

--- a/src/renderer/src/components/emulator-pane/EmulatorPane.tsx
+++ b/src/renderer/src/components/emulator-pane/EmulatorPane.tsx
@@ -98,9 +98,10 @@ export default function EmulatorPane({ tab, worktreeId, isActive = true }: Emula
         onAttach={() => void attach(selectedUdid ?? undefined)}
         onShutdown={() => void shutdown(selectedUdid ?? undefined)}
         onHome={() => void sendButton('home')}
-        onRotate={() => void sendRotate('left')}
+        onRotate={() => void sendRotate()}
         backend={session?.info?.backend ?? selectedDevice?.backend}
         androidControls={{
+          capabilities: selectedDevice?.controlCapabilities,
           displayCommandPending,
           screenshotAvailable,
           savingScreenshot,

--- a/src/renderer/src/components/emulator-pane/android-emulator-toolbar-action-components.tsx
+++ b/src/renderer/src/components/emulator-pane/android-emulator-toolbar-action-components.tsx
@@ -1,0 +1,254 @@
+import { FoldHorizontal, UnfoldHorizontal, Watch, ZoomIn } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import type { EmulatorZoomAction } from './emulator-pane-zoom'
+import type { AndroidEmulatorToolbarControlsProps } from './android-emulator-toolbar-controls'
+
+export const label = (text: string): string =>
+  translate(`auto.components.emulator.pane.androidToolbar.${text}`, text)
+
+type ControlButtonProps = {
+  label: string
+  disabled: boolean
+  onClick: () => void
+  onPointerDown?: () => void
+  onPointerUp?: () => void
+  onPointerCancel?: () => void
+  children: React.ReactNode
+}
+
+export function ControlButton({
+  label: text,
+  disabled,
+  onClick,
+  onPointerDown,
+  onPointerUp,
+  onPointerCancel,
+  children
+}: ControlButtonProps) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          size="icon-xs"
+          className="size-7 shrink-0"
+          aria-label={text}
+          disabled={disabled}
+          onClick={onClick}
+          onPointerDown={onPointerDown}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerCancel}
+        >
+          {children}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {text}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+export function ZoomMenu({
+  disabled,
+  percentage,
+  availability,
+  onChange
+}: {
+  disabled: boolean
+  percentage: number
+  availability: Record<EmulatorZoomAction, boolean>
+  onChange: (action: EmulatorZoomAction) => void
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="secondary"
+          size="icon-xs"
+          className="size-7 shrink-0"
+          aria-label={label('Zoom')}
+          disabled={disabled}
+        >
+          <ZoomIn className="size-3.5" />
+          <span className="sr-only">{percentage}%</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <ZoomItems availability={availability} onChange={onChange} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export function ZoomItems({
+  availability,
+  onChange
+}: {
+  availability: Record<EmulatorZoomAction, boolean>
+  onChange: (action: EmulatorZoomAction) => void
+}) {
+  const items: [EmulatorZoomAction, string][] = [
+    ['in', 'Zoom In'],
+    ['out', 'Zoom Out'],
+    ['actual', 'Zoom to Actual Size (100%)'],
+    ['fit', 'Zoom to Fit in Window'],
+    ['fit-display', 'Zoom to Fit Display in Window']
+  ]
+  return items.map(([action, text]) => (
+    <DropdownMenuItem
+      key={action}
+      disabled={!availability[action]}
+      onSelect={(event) => {
+        if (action === 'in' || action === 'out') {
+          event.preventDefault()
+        }
+        onChange(action)
+      }}
+    >
+      {label(text)}
+    </DropdownMenuItem>
+  ))
+}
+
+export function SpecificControls({
+  capabilities,
+  disabled,
+  onButton,
+  onPosture
+}: Pick<AndroidEmulatorToolbarControlsProps, 'capabilities' | 'onButton' | 'onPosture'> & {
+  disabled: boolean
+}) {
+  return (
+    <>
+      {capabilities?.foldable ? (
+        <>
+          <ControlButton
+            label={label('Fold')}
+            disabled={disabled}
+            onClick={() => onPosture('folded')}
+          >
+            <FoldHorizontal className="size-3.5" />
+          </ControlButton>
+          <ControlButton
+            label={label('Unfold')}
+            disabled={disabled}
+            onClick={() => onPosture('unfolded')}
+          >
+            <UnfoldHorizontal className="size-3.5" />
+          </ControlButton>
+        </>
+      ) : null}
+      {capabilities?.wearButton1 ? (
+        <ControlButton
+          label={label('Button 1')}
+          disabled={disabled}
+          onClick={() => onButton('wear_button_1')}
+        >
+          <Watch className="size-3.5" />
+        </ControlButton>
+      ) : null}
+      {capabilities?.wearButton2 ? (
+        <ControlButton
+          label={label('Button 2')}
+          disabled={disabled}
+          onClick={() => onButton('wear_button_2')}
+        >
+          <Watch className="size-3.5" />
+        </ControlButton>
+      ) : null}
+    </>
+  )
+}
+
+export function SpecificMenuItems({
+  capabilities,
+  disabled,
+  onButton,
+  onPosture
+}: Pick<AndroidEmulatorToolbarControlsProps, 'capabilities' | 'onButton' | 'onPosture'> & {
+  disabled: boolean
+}) {
+  return (
+    <>
+      {capabilities?.foldable ? (
+        <>
+          <MenuItem label={label('Fold')} onSelect={() => onPosture('folded')} disabled={disabled}>
+            <FoldHorizontal className="size-3.5" />
+          </MenuItem>
+          <MenuItem
+            label={label('Unfold')}
+            onSelect={() => onPosture('unfolded')}
+            disabled={disabled}
+          >
+            <UnfoldHorizontal className="size-3.5" />
+          </MenuItem>
+        </>
+      ) : null}
+      {capabilities?.wearButton1 ? (
+        <MenuItem
+          label={label('Button 1')}
+          onSelect={() => onButton('wear_button_1')}
+          disabled={disabled}
+        >
+          <Watch className="size-3.5" />
+        </MenuItem>
+      ) : null}
+      {capabilities?.wearButton2 ? (
+        <MenuItem
+          label={label('Button 2')}
+          onSelect={() => onButton('wear_button_2')}
+          disabled={disabled}
+        >
+          <Watch className="size-3.5" />
+        </MenuItem>
+      ) : null}
+    </>
+  )
+}
+
+export function MenuItem({
+  label: text,
+  disabled,
+  onSelect,
+  onPointerDown,
+  onPointerUp,
+  onPointerCancel,
+  children
+}: {
+  label: string
+  disabled: boolean
+  onSelect: (event: Event) => void
+  onPointerDown?: () => void
+  onPointerUp?: () => void
+  onPointerCancel?: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <DropdownMenuItem
+      disabled={disabled}
+      onSelect={onSelect}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+    >
+      {children}
+      {text}
+    </DropdownMenuItem>
+  )
+}
+
+export function keepMenuOpen(event: Event, action: () => void): void {
+  event.preventDefault()
+  action()
+}

--- a/src/renderer/src/components/emulator-pane/android-emulator-toolbar-action-components.tsx
+++ b/src/renderer/src/components/emulator-pane/android-emulator-toolbar-action-components.tsx
@@ -21,6 +21,7 @@ type ControlButtonProps = {
   onPointerDown?: () => void
   onPointerUp?: () => void
   onPointerCancel?: () => void
+  onPointerLeave?: () => void
   children: React.ReactNode
 }
 
@@ -31,6 +32,7 @@ export function ControlButton({
   onPointerDown,
   onPointerUp,
   onPointerCancel,
+  onPointerLeave,
   children
 }: ControlButtonProps) {
   return (
@@ -47,6 +49,7 @@ export function ControlButton({
           onPointerDown={onPointerDown}
           onPointerUp={onPointerUp}
           onPointerCancel={onPointerCancel}
+          onPointerLeave={onPointerLeave}
         >
           {children}
         </Button>
@@ -224,6 +227,7 @@ export function MenuItem({
   onPointerDown,
   onPointerUp,
   onPointerCancel,
+  onPointerLeave,
   children
 }: {
   label: string
@@ -232,6 +236,7 @@ export function MenuItem({
   onPointerDown?: () => void
   onPointerUp?: () => void
   onPointerCancel?: () => void
+  onPointerLeave?: () => void
   children: React.ReactNode
 }) {
   return (
@@ -241,6 +246,7 @@ export function MenuItem({
       onPointerDown={onPointerDown}
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerCancel}
+      onPointerLeave={onPointerLeave}
     >
       {children}
       {text}

--- a/src/renderer/src/components/emulator-pane/android-emulator-toolbar-controls.tsx
+++ b/src/renderer/src/components/emulator-pane/android-emulator-toolbar-controls.tsx
@@ -1,0 +1,339 @@
+import { useEffect, useRef } from 'react'
+import {
+  ArrowLeft,
+  Camera,
+  Home,
+  MoreHorizontal,
+  Power,
+  RotateCcw,
+  RotateCw,
+  SquareStack,
+  Volume1,
+  Volume2,
+  ZoomIn
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import type {
+  EmulatorButtonOptions,
+  EmulatorDeviceControlCapabilities,
+  EmulatorPosture
+} from '../../../../shared/emulator-device-controls'
+import type { EmulatorZoomAction } from './emulator-pane-zoom'
+import {
+  ControlButton,
+  label,
+  MenuItem,
+  SpecificControls,
+  SpecificMenuItems,
+  ZoomItems,
+  ZoomMenu,
+  keepMenuOpen
+} from './android-emulator-toolbar-action-components'
+
+export type AndroidEmulatorToolbarControlsProps = {
+  capabilities?: EmulatorDeviceControlCapabilities
+  disabled: boolean
+  displayCommandPending: boolean
+  screenshotAvailable: boolean
+  savingScreenshot: boolean
+  zoomPercentage: number
+  zoomAvailability: Record<EmulatorZoomAction, boolean>
+  onButton: (
+    name:
+      | 'back'
+      | 'home'
+      | 'recents'
+      | 'power'
+      | 'volume_up'
+      | 'volume_down'
+      | 'wear_button_1'
+      | 'wear_button_2',
+    options?: EmulatorButtonOptions
+  ) => void
+  onPosture: (posture: EmulatorPosture) => void
+  onRotate: (direction: 'left' | 'right') => void
+  onScreenshot: () => void
+  onZoomChange: (action: EmulatorZoomAction) => void
+}
+
+export const POWER_LONG_PRESS_MS = 500
+
+export function AndroidEmulatorToolbarControls({
+  capabilities,
+  disabled,
+  displayCommandPending,
+  screenshotAvailable,
+  savingScreenshot,
+  zoomPercentage,
+  zoomAvailability,
+  onButton,
+  onPosture,
+  onRotate,
+  onScreenshot,
+  onZoomChange
+}: AndroidEmulatorToolbarControlsProps) {
+  const powerLongPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const powerLongPressTriggeredRef = useRef(false)
+  const suppressPowerClickRef = useRef(false)
+  const commonDisabled = disabled
+  const specificEntriesVisible = Boolean(
+    capabilities?.foldable || capabilities?.wearButton1 || capabilities?.wearButton2
+  )
+  const visible = {
+    power: capabilities?.power !== false,
+    volume: capabilities?.volume !== false,
+    overview: capabilities?.overview !== false,
+    foldable: capabilities?.foldable === true,
+    wearButton1: capabilities?.wearButton1 === true,
+    wearButton2: capabilities?.wearButton2 === true
+  }
+
+  const clearPowerTimer = (): void => {
+    if (powerLongPressTimerRef.current !== null) {
+      clearTimeout(powerLongPressTimerRef.current)
+      powerLongPressTimerRef.current = null
+    }
+  }
+  useEffect(
+    () => () => {
+      clearPowerTimer()
+    },
+    []
+  )
+  const handlePowerPointerDown = (): void => {
+    powerLongPressTriggeredRef.current = false
+    suppressPowerClickRef.current = false
+    clearPowerTimer()
+    powerLongPressTimerRef.current = setTimeout(() => {
+      powerLongPressTriggeredRef.current = true
+      onButton('power', { longPress: true })
+    }, POWER_LONG_PRESS_MS)
+  }
+  const handlePowerPointerUp = (): void => {
+    clearPowerTimer()
+    if (!powerLongPressTriggeredRef.current) {
+      onButton('power')
+    }
+    suppressPowerClickRef.current = true
+  }
+  const handlePowerPointerCancel = (): void => {
+    clearPowerTimer()
+    suppressPowerClickRef.current = true
+  }
+  const handlePowerClick = (): void => {
+    if (suppressPowerClickRef.current) {
+      suppressPowerClickRef.current = false
+      return
+    }
+    onButton('power')
+  }
+
+  const power = visible.power ? (
+    <ControlButton
+      label={label('Power')}
+      disabled={commonDisabled}
+      onClick={handlePowerClick}
+      onPointerDown={handlePowerPointerDown}
+      onPointerUp={handlePowerPointerUp}
+      onPointerCancel={handlePowerPointerCancel}
+    >
+      <Power className="size-3.5" />
+    </ControlButton>
+  ) : null
+  const powerMenuItem = visible.power ? (
+    <MenuItem
+      label={label('Power')}
+      disabled={commonDisabled}
+      onSelect={() => handlePowerClick()}
+      onPointerDown={handlePowerPointerDown}
+      onPointerUp={handlePowerPointerUp}
+      onPointerCancel={handlePowerPointerCancel}
+    >
+      <Power className="size-3.5" />
+    </MenuItem>
+  ) : null
+  const volumeUp = visible.volume ? (
+    <ControlButton
+      label={label('Volume Up')}
+      disabled={commonDisabled}
+      onClick={() => onButton('volume_up')}
+    >
+      <Volume2 className="size-3.5" />
+    </ControlButton>
+  ) : null
+  const volumeDown = visible.volume ? (
+    <ControlButton
+      label={label('Volume Down')}
+      disabled={commonDisabled}
+      onClick={() => onButton('volume_down')}
+    >
+      <Volume1 className="size-3.5" />
+    </ControlButton>
+  ) : null
+  const rotateLeft = (
+    <ControlButton
+      label={label('Rotate Left')}
+      disabled={commonDisabled || displayCommandPending}
+      onClick={() => onRotate('left')}
+    >
+      <RotateCcw className="size-3.5" />
+    </ControlButton>
+  )
+  const rotateRight = (
+    <ControlButton
+      label={label('Rotate Right')}
+      disabled={commonDisabled || displayCommandPending}
+      onClick={() => onRotate('right')}
+    >
+      <RotateCw className="size-3.5" />
+    </ControlButton>
+  )
+  const screenshot = (
+    <ControlButton
+      label={label('Take Screenshot')}
+      disabled={commonDisabled || !screenshotAvailable || savingScreenshot}
+      onClick={onScreenshot}
+    >
+      <Camera className="size-3.5" />
+    </ControlButton>
+  )
+  const zoom = (
+    <ZoomMenu
+      disabled={commonDisabled || !Object.values(zoomAvailability).some(Boolean)}
+      percentage={zoomPercentage}
+      availability={zoomAvailability}
+      onChange={onZoomChange}
+    />
+  )
+  const back = (
+    <ControlButton label={label('Back')} disabled={commonDisabled} onClick={() => onButton('back')}>
+      <ArrowLeft className="size-3.5" />
+    </ControlButton>
+  )
+  const home = (
+    <ControlButton label={label('Home')} disabled={commonDisabled} onClick={() => onButton('home')}>
+      <Home className="size-3.5" />
+    </ControlButton>
+  )
+  const overview = visible.overview ? (
+    <ControlButton
+      label={label('Overview')}
+      disabled={commonDisabled}
+      onClick={() => onButton('recents')}
+    >
+      <SquareStack className="size-3.5" />
+    </ControlButton>
+  ) : null
+
+  return (
+    <div className="contents">
+      <div className="hidden items-center gap-1 [@container(min-width:960px)]:flex">
+        {power}
+        {volumeUp}
+        {volumeDown}
+        {rotateLeft}
+        {rotateRight}
+        {screenshot}
+        {zoom}
+        {back}
+        {home}
+        {overview}
+        {specificEntriesVisible ? (
+          <SpecificControls
+            capabilities={capabilities}
+            disabled={commonDisabled || displayCommandPending}
+            onButton={onButton}
+            onPosture={onPosture}
+          />
+        ) : null}
+      </div>
+      <div className="flex min-w-0 flex-1 items-center gap-1 [@container(min-width:960px)]:hidden">
+        {back}
+        {home}
+        {overview}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="secondary"
+              size="icon-xs"
+              className="size-7"
+              disabled={commonDisabled}
+              aria-label={label('More')}
+            >
+              <MoreHorizontal className="size-3.5" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            {powerMenuItem}
+            {visible.volume ? (
+              <>
+                <MenuItem
+                  label={label('Volume Up')}
+                  onSelect={(event) => keepMenuOpen(event, () => onButton('volume_up'))}
+                  disabled={commonDisabled}
+                >
+                  <Volume2 className="size-3.5" />
+                </MenuItem>
+                <MenuItem
+                  label={label('Volume Down')}
+                  onSelect={(event) => keepMenuOpen(event, () => onButton('volume_down'))}
+                  disabled={commonDisabled}
+                >
+                  <Volume1 className="size-3.5" />
+                </MenuItem>
+              </>
+            ) : null}
+            <MenuItem
+              label={label('Rotate Left')}
+              onSelect={(event) => keepMenuOpen(event, () => onRotate('left'))}
+              disabled={commonDisabled || displayCommandPending}
+            >
+              <RotateCcw className="size-3.5" />
+            </MenuItem>
+            <MenuItem
+              label={label('Rotate Right')}
+              onSelect={(event) => keepMenuOpen(event, () => onRotate('right'))}
+              disabled={commonDisabled || displayCommandPending}
+            >
+              <RotateCw className="size-3.5" />
+            </MenuItem>
+            <MenuItem
+              label={label('Take Screenshot')}
+              onSelect={() => onScreenshot()}
+              disabled={commonDisabled || !screenshotAvailable || savingScreenshot}
+            >
+              <Camera className="size-3.5" />
+            </MenuItem>
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger
+                disabled={commonDisabled || !Object.values(zoomAvailability).some(Boolean)}
+              >
+                <ZoomIn className="size-3.5" />
+                {label('Zoom')}
+                <span className="ml-auto text-muted-foreground">{zoomPercentage}%</span>
+              </DropdownMenuSubTrigger>
+              <DropdownMenuSubContent>
+                <ZoomItems availability={zoomAvailability} onChange={onZoomChange} />
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+            <SpecificMenuItems
+              capabilities={capabilities}
+              disabled={commonDisabled || displayCommandPending}
+              onButton={onButton}
+              onPosture={onPosture}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/emulator-pane/android-emulator-toolbar-controls.tsx
+++ b/src/renderer/src/components/emulator-pane/android-emulator-toolbar-controls.tsx
@@ -128,6 +128,9 @@ export function AndroidEmulatorToolbarControls({
     clearPowerTimer()
     suppressPowerClickRef.current = true
   }
+  const handlePowerPointerLeave = (): void => {
+    clearPowerTimer()
+  }
   const handlePowerClick = (): void => {
     if (suppressPowerClickRef.current) {
       suppressPowerClickRef.current = false
@@ -144,6 +147,7 @@ export function AndroidEmulatorToolbarControls({
       onPointerDown={handlePowerPointerDown}
       onPointerUp={handlePowerPointerUp}
       onPointerCancel={handlePowerPointerCancel}
+      onPointerLeave={handlePowerPointerLeave}
     >
       <Power className="size-3.5" />
     </ControlButton>
@@ -156,6 +160,7 @@ export function AndroidEmulatorToolbarControls({
       onPointerDown={handlePowerPointerDown}
       onPointerUp={handlePowerPointerUp}
       onPointerCancel={handlePowerPointerCancel}
+      onPointerLeave={handlePowerPointerLeave}
     >
       <Power className="size-3.5" />
     </MenuItem>
@@ -235,7 +240,7 @@ export function AndroidEmulatorToolbarControls({
 
   return (
     <div className="contents">
-      <div className="hidden items-center gap-1 [@container(min-width:960px)]:flex">
+      <div className="hidden shrink-0 items-center gap-1 [@container(min-width:960px)]:flex">
         {power}
         {volumeUp}
         {volumeDown}
@@ -255,7 +260,7 @@ export function AndroidEmulatorToolbarControls({
           />
         ) : null}
       </div>
-      <div className="flex min-w-0 flex-1 items-center gap-1 [@container(min-width:960px)]:hidden">
+      <div className="flex w-fit shrink-0 items-center gap-1 [@container(min-width:960px)]:hidden">
         {back}
         {home}
         {overview}

--- a/src/renderer/src/components/emulator-pane/emulator-device-frame-layout.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-device-frame-layout.ts
@@ -105,10 +105,51 @@ function measureChrome(screenSize: PaneSize, kind: DeviceFrameKind) {
   const hardwareOutset = kind === 'phone' ? clamp(shortSide * 0.012, 3, 7) : 0
   const sideButtonThickness = kind === 'phone' ? clamp(shortSide * 0.01, 3, 6) : 0
 
+  return { bezel, hardwareOutset, sideButtonThickness }
+}
+
+export function layoutDeviceFrameAtScreenSize(
+  screenSize: PaneSize,
+  kind: DeviceFrameKind
+): DeviceFrameLayout {
+  const { bezel, hardwareOutset, sideButtonThickness } = measureChrome(screenSize, kind)
+  const shellWidth = screenSize.width + bezel * 2
+  const shellHeight = screenSize.height + bezel * 2
+  const shortSide = Math.min(screenSize.width, screenSize.height)
+  const outerRadius =
+    kind === 'phone' ? clamp(shortSide * 0.135, 44, 92) : clamp(shortSide * 0.065, 24, 56)
+  const innerRadius =
+    kind === 'phone' ? clamp(outerRadius - bezel, 34, 82) : clamp(outerRadius - bezel * 0.7, 18, 48)
+
   return {
-    bezel,
+    kind,
+    width: shellWidth + hardwareOutset * 2,
+    height: shellHeight,
+    shellWidth,
+    shellHeight,
     hardwareOutset,
+    bezel,
+    outerRadius,
+    innerRadius,
     sideButtonThickness
+  }
+}
+
+export function scaleDeviceFrameLayout(
+  layout: DeviceFrameLayout,
+  scale: number
+): DeviceFrameLayout {
+  return {
+    ...layout,
+    width: layout.width * scale,
+    height: layout.height * scale,
+    shellWidth: layout.shellWidth * scale,
+    shellHeight: layout.shellHeight * scale,
+    hardwareOutset: layout.hardwareOutset * scale,
+    bezel: layout.bezel * scale,
+    outerRadius: layout.outerRadius * scale,
+    innerRadius: layout.innerRadius * scale,
+    sideButtonThickness: layout.sideButtonThickness * scale
   }
 }
 
@@ -135,37 +176,10 @@ export function fitDeviceFrameToPane(
     )
     const availableHeight = Math.max(1, paneSize.height - chrome.bezel * 2 - FIT_MARGIN_PX)
     screenSize = fitScreenToPane(
-      {
-        width: availableWidth,
-        height: availableHeight
-      },
+      { width: availableWidth, height: availableHeight },
       screenAspectRatio
     )
   }
 
-  if (!screenSize) {
-    return null
-  }
-
-  const { bezel, hardwareOutset, sideButtonThickness } = measureChrome(screenSize, kind)
-  const shellWidth = screenSize.width + bezel * 2
-  const shellHeight = screenSize.height + bezel * 2
-  const shortSide = Math.min(screenSize.width, screenSize.height)
-  const outerRadius =
-    kind === 'phone' ? clamp(shortSide * 0.135, 44, 92) : clamp(shortSide * 0.065, 24, 56)
-  const innerRadius =
-    kind === 'phone' ? clamp(outerRadius - bezel, 34, 82) : clamp(outerRadius - bezel * 0.7, 18, 48)
-
-  return {
-    kind,
-    width: shellWidth + hardwareOutset * 2,
-    height: shellHeight,
-    shellWidth,
-    shellHeight,
-    hardwareOutset,
-    bezel,
-    outerRadius,
-    innerRadius,
-    sideButtonThickness
-  }
+  return screenSize ? layoutDeviceFrameAtScreenSize(screenSize, kind) : null
 }

--- a/src/renderer/src/components/emulator-pane/emulator-device-frame.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-device-frame.tsx
@@ -8,12 +8,14 @@ import {
   type WheelEvent
 } from 'react'
 import {
-  fitDeviceFrameToPane,
   resolveVisualStreamGeometry,
   resolveDeviceFrameKind,
   type EmulatorDeviceVisualOrientation,
   type StreamSize
 } from './emulator-device-frame-layout'
+import type { EmulatorZoomMetrics, EmulatorZoomState } from './emulator-pane-zoom'
+import { useCenterAnchoredEmulatorScroll } from './use-center-anchored-emulator-scroll'
+import { useEmulatorDeviceFrameLayout } from './use-emulator-device-frame-layout'
 import {
   buildWheelGesturePoints,
   clampEmulatorScreenPoint,
@@ -45,7 +47,12 @@ type EmulatorDeviceFrameProps = {
   isActive: boolean
   onTap: (x: number, y: number) => void
   onGesture: (points: EmulatorGesturePoint[]) => void
+  onScreenshotCanvasChange?: (canvas: HTMLCanvasElement | null) => void
+  zoomState?: EmulatorZoomState
+  onZoomMetrics?: (metrics: EmulatorZoomMetrics | null) => void
 }
+
+const noopScreenshotCanvasChange = (): void => {}
 
 const MAX_GESTURE_SAMPLES = 32,
   WHEEL_GESTURE_IDLE_MS = 80
@@ -71,7 +78,10 @@ export function EmulatorDeviceFrame({
   visualOrientation,
   isActive,
   onTap,
-  onGesture
+  onGesture,
+  onScreenshotCanvasChange = noopScreenshotCanvasChange,
+  zoomState,
+  onZoomMetrics
 }: EmulatorDeviceFrameProps) {
   const { paneRef, paneSize } = useEmulatorPaneSize()
   const pointerSamplesRef = useRef<PointerSample[] | null>(null)
@@ -324,18 +334,13 @@ export function EmulatorDeviceFrame({
     },
     [canInteract, flushWheelGesture, sendTouch, visualStreamGeometry]
   )
-
   const handleStreamSize = useCallback((size: NonNullable<StreamSize>) => {
     setStreamError(false)
     setStreamSize((current) =>
       current?.width === size.width && current.height === size.height ? current : size
     )
   }, [])
-
-  const handleStreamError = useCallback(() => {
-    setStreamError(true)
-  }, [])
-
+  const handleStreamError = useCallback(() => setStreamError(true), [])
   // Why: a hidden/occluded window (or a background tab) still receives emulator
   // frames, including over SSH; parking the stream avoids background decode/IPC
   // churn while staying attached. isActive covers the background-tab case;
@@ -347,22 +352,30 @@ export function EmulatorDeviceFrame({
   // Why: serve-sim may keep portrait-sized pixels for portrait-locked apps; the
   // physical frame still follows the last successful rotate request.
   const screenAspectRatio = visualStreamGeometry.aspectRatio
-  const frameKind = useMemo(
-    () => resolveDeviceFrameKind(deviceName, streamAspectRatio),
-    [deviceName, streamAspectRatio]
-  )
-  const frameLayout = useMemo(
-    () => fitDeviceFrameToPane(paneSize, screenAspectRatio, frameKind),
-    [frameKind, screenAspectRatio, paneSize]
+  const frameKind = resolveDeviceFrameKind(deviceName, streamAspectRatio)
+  const frameLayout = useEmulatorDeviceFrameLayout({
+    paneSize,
+    frameKind,
+    screenAspectRatio,
+    visualStreamSize: visualStreamGeometry.size,
+    zoomState,
+    onZoomMetrics
+  })
+  const centerScrollRef = useCenterAnchoredEmulatorScroll(
+    paneSize,
+    frameLayout ? { width: frameLayout.width, height: frameLayout.height } : null
   )
 
   return (
     <div
-      ref={paneRef}
-      className="flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-muted"
+      ref={(node) => {
+        paneRef.current = node
+        centerScrollRef.current = node
+      }}
+      className="scrollbar-sleek flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted"
     >
       <div
-        className="relative"
+        className="relative m-auto shrink-0"
         style={{
           width: frameLayout ? `${frameLayout.width}px` : '100%',
           maxWidth: frameLayout ? undefined : '460px',
@@ -393,6 +406,7 @@ export function EmulatorDeviceFrame({
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}
+            onScreenshotCanvasChange={onScreenshotCanvasChange}
             onStreamError={handleStreamError}
             onStreamSize={handleStreamSize}
             onWheel={handleWheel}

--- a/src/renderer/src/components/emulator-pane/emulator-device-row-mapping.test.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-device-row-mapping.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { toSimulatorDeviceRows, type RawEmulatorDevice } from './emulator-device-row-mapping'
+
+const capabilities = {
+  shutdown: true,
+  power: true,
+  volume: true,
+  overview: true,
+  foldable: false,
+  wearButton1: false,
+  wearButton2: false
+}
+
+describe('toSimulatorDeviceRows', () => {
+  it('preserves backend and Android control capabilities', () => {
+    const raw: RawEmulatorDevice[] = [
+      {
+        id: 'emulator-5554',
+        name: 'Pixel 7',
+        state: 'booted',
+        detail: 'emulator',
+        isAvailable: true,
+        backend: 'android',
+        controlCapabilities: capabilities
+      }
+    ]
+
+    expect(toSimulatorDeviceRows(raw)[0]).toEqual({
+      name: 'Pixel 7',
+      udid: 'emulator-5554',
+      state: 'Booted',
+      runtime: 'emulator',
+      isAvailable: true,
+      backend: 'android',
+      controlCapabilities: capabilities
+    })
+  })
+
+  it('leaves optional fields undefined for legacy inventory entries', () => {
+    expect(
+      toSimulatorDeviceRows([{ id: 'simulator', name: 'iPhone', state: 'shutdown' }])[0]
+    ).toEqual({
+      name: 'iPhone',
+      udid: 'simulator',
+      state: 'Shutdown',
+      runtime: undefined,
+      isAvailable: undefined,
+      backend: undefined,
+      controlCapabilities: undefined
+    })
+  })
+})

--- a/src/renderer/src/components/emulator-pane/emulator-device-row-mapping.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-device-row-mapping.ts
@@ -1,3 +1,4 @@
+import type { EmulatorDeviceControlCapabilities } from '../../../../shared/emulator-device-controls'
 import type { SimulatorDeviceRow } from './emulator-pane-types'
 
 // Raw shape returned by the unified `emulator.listDevices` RPC (iOS simulators + Android AVDs).
@@ -7,6 +8,8 @@ export type RawEmulatorDevice = {
   state: string
   detail?: string
   isAvailable?: boolean
+  backend?: 'ios' | 'android'
+  controlCapabilities?: EmulatorDeviceControlCapabilities
 }
 
 export function toSimulatorDeviceRows(raw: RawEmulatorDevice[]): SimulatorDeviceRow[] {
@@ -15,6 +18,8 @@ export function toSimulatorDeviceRows(raw: RawEmulatorDevice[]): SimulatorDevice
     udid: device.id,
     state: device.state === 'booted' ? 'Booted' : 'Shutdown',
     runtime: device.detail,
-    isAvailable: device.isAvailable
+    isAvailable: device.isAvailable,
+    backend: device.backend,
+    controlCapabilities: device.controlCapabilities
   }))
 }

--- a/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.test.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.test.tsx
@@ -105,6 +105,22 @@ describe('AndroidEmulatorToolbarControls', () => {
     expect(onButton).toHaveBeenLastCalledWith('power')
   })
 
+  it('cancels a Power long press when the pointer leaves before the timeout', () => {
+    const { onButton } = renderControls()
+    const power = screen.getAllByRole('button', { name: 'Power' })[0]
+
+    fireEvent.pointerDown(power, { pointerId: 1 })
+    fireEvent.pointerLeave(power, { pointerId: 1 })
+    vi.advanceTimersByTime(POWER_LONG_PRESS_MS)
+
+    expect(onButton).not.toHaveBeenCalled()
+
+    fireEvent.click(power)
+
+    expect(onButton).toHaveBeenCalledTimes(1)
+    expect(onButton).toHaveBeenLastCalledWith('power')
+  })
+
   it('gates Wear and foldable controls by capabilities', () => {
     renderControls({
       capabilities: {

--- a/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.test.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.test.tsx
@@ -1,0 +1,172 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { EmulatorPaneToolbar } from './emulator-pane-toolbar'
+import {
+  AndroidEmulatorToolbarControls,
+  POWER_LONG_PRESS_MS
+} from './android-emulator-toolbar-controls'
+
+const capabilities = {
+  shutdown: true,
+  power: true,
+  volume: true,
+  overview: true,
+  foldable: true,
+  wearButton1: true,
+  wearButton2: true
+} as const
+
+function renderControls(
+  overrides: Partial<React.ComponentProps<typeof AndroidEmulatorToolbarControls>> = {}
+) {
+  const onButton = vi.fn()
+  const onPosture = vi.fn()
+  const onRotate = vi.fn()
+  const onScreenshot = vi.fn()
+  const onZoomChange = vi.fn()
+  render(
+    <TooltipProvider>
+      <AndroidEmulatorToolbarControls
+        capabilities={capabilities}
+        disabled={false}
+        displayCommandPending={false}
+        screenshotAvailable
+        savingScreenshot={false}
+        zoomPercentage={100}
+        zoomAvailability={{ in: true, out: true, actual: true, fit: true, 'fit-display': true }}
+        onButton={onButton}
+        onPosture={onPosture}
+        onRotate={onRotate}
+        onScreenshot={onScreenshot}
+        onZoomChange={onZoomChange}
+        {...overrides}
+      />
+    </TooltipProvider>
+  )
+  return { onButton, onPosture, onRotate, onScreenshot, onZoomChange }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe('AndroidEmulatorToolbarControls', () => {
+  it('exposes the standard labels and disables every action before live session', () => {
+    renderControls({ disabled: true })
+
+    for (const name of [
+      'Power',
+      'Volume Up',
+      'Volume Down',
+      'Rotate Left',
+      'Rotate Right',
+      'Take Screenshot',
+      'Zoom',
+      'Back',
+      'Home',
+      'Overview',
+      'Fold',
+      'Unfold',
+      'Button 1',
+      'Button 2'
+    ]) {
+      expect(
+        screen.getAllByRole('button', { name }).every((button) => button.hasAttribute('disabled'))
+      ).toBe(true)
+    }
+  })
+
+  it('keeps Power short and long press mutually exclusive and supports keyboard short press', () => {
+    const { onButton } = renderControls()
+    const power = screen.getAllByRole('button', { name: 'Power' })[0]
+
+    fireEvent.pointerDown(power, { pointerId: 1 })
+    vi.advanceTimersByTime(POWER_LONG_PRESS_MS - 1)
+    fireEvent.pointerUp(power, { pointerId: 1 })
+    expect(onButton).toHaveBeenLastCalledWith('power')
+    expect(onButton).toHaveBeenCalledTimes(1)
+
+    fireEvent.pointerDown(power, { pointerId: 1 })
+    vi.advanceTimersByTime(POWER_LONG_PRESS_MS)
+    expect(onButton).toHaveBeenLastCalledWith('power', { longPress: true })
+    fireEvent.pointerUp(power, { pointerId: 1 })
+    expect(onButton).toHaveBeenCalledTimes(2)
+    fireEvent.click(power)
+    expect(onButton).toHaveBeenCalledTimes(2)
+    fireEvent.click(power)
+    expect(onButton).toHaveBeenCalledTimes(3)
+    expect(onButton).toHaveBeenLastCalledWith('power')
+  })
+
+  it('gates Wear and foldable controls by capabilities', () => {
+    renderControls({
+      capabilities: {
+        ...capabilities,
+        power: false,
+        volume: false,
+        overview: false,
+        foldable: false,
+        wearButton1: true,
+        wearButton2: false
+      }
+    })
+
+    expect(screen.queryAllByRole('button', { name: 'Power' })).toHaveLength(0)
+    expect(screen.queryAllByRole('button', { name: 'Volume Up' })).toHaveLength(0)
+    expect(screen.queryAllByRole('button', { name: 'Overview' })).toHaveLength(0)
+    expect(screen.queryAllByRole('button', { name: 'Fold' })).toHaveLength(0)
+    expect(screen.queryAllByRole('button', { name: 'Button 1' })).not.toHaveLength(0)
+    expect(screen.queryAllByRole('button', { name: 'Button 2' })).toHaveLength(0)
+  })
+})
+
+describe('EmulatorPaneToolbar Android shutdown fallback', () => {
+  function renderToolbar(runtime: string) {
+    render(
+      <TooltipProvider>
+        <EmulatorPaneToolbar
+          displayName="Pixel"
+          isLive
+          loading={false}
+          devices={[{ name: 'Pixel', udid: 'emulator-5554', state: 'Booted', runtime }]}
+          selectedUdid="emulator-5554"
+          backend="android"
+          androidControls={{
+            displayCommandPending: false,
+            screenshotAvailable: true,
+            savingScreenshot: false,
+            zoomPercentage: 100,
+            zoomAvailability: { in: true, out: true, actual: true, fit: true, 'fit-display': true },
+            onButton: vi.fn(),
+            onPosture: vi.fn(),
+            onRotate: vi.fn(),
+            onScreenshot: vi.fn(),
+            onZoomChange: vi.fn()
+          }}
+          onSelectDevice={vi.fn()}
+          onAttach={vi.fn()}
+          onShutdown={vi.fn()}
+          onHome={vi.fn()}
+          onRotate={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+  }
+
+  it('hides shutdown for physical-device rows', () => {
+    renderToolbar('device')
+    expect(screen.queryByRole('button', { name: 'Shut down emulator' })).toBeNull()
+  })
+
+  it('shows shutdown for legacy emulator rows', () => {
+    renderToolbar('emulator')
+    expect(screen.getByRole('button', { name: 'Shut down emulator' })).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.tsx
@@ -1,4 +1,4 @@
-import { Home, Power, RotateCw, Smartphone } from 'lucide-react'
+import { Home, PowerOff, RotateCw, Smartphone } from 'lucide-react'
 import {
   Select,
   SelectContent,
@@ -11,6 +11,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils'
 import type { SimulatorDeviceRow } from './emulator-pane-types'
 import { translate } from '@/i18n/i18n'
+import {
+  AndroidEmulatorToolbarControls,
+  type AndroidEmulatorToolbarControlsProps
+} from './android-emulator-toolbar-controls'
 
 type EmulatorPaneToolbarProps = {
   displayName: string
@@ -18,6 +22,8 @@ type EmulatorPaneToolbarProps = {
   loading: boolean
   devices: SimulatorDeviceRow[]
   selectedUdid: string | null
+  backend?: 'ios' | 'android'
+  androidControls?: Omit<AndroidEmulatorToolbarControlsProps, 'disabled'>
   onSelectDevice: (udid: string) => void
   onAttach: () => void
   onShutdown: () => void
@@ -31,6 +37,8 @@ export function EmulatorPaneToolbar({
   loading,
   devices,
   selectedUdid,
+  backend,
+  androidControls,
   onSelectDevice,
   onAttach,
   onShutdown,
@@ -44,27 +52,34 @@ export function EmulatorPaneToolbar({
   const statusClassName = subtleStatus
     ? 'text-muted-foreground'
     : 'border-border bg-muted text-muted-foreground'
+  const isAndroid = backend === 'android'
+  const selectedDevice = devices.find((device) => device.udid === selectedUdid)
+  const canShutdown =
+    !isAndroid ||
+    (androidControls?.capabilities?.shutdown ?? selectedDevice?.runtime === 'emulator')
+  const controlsDisabled = !isLive || loading
 
   return (
-    <div className="flex items-center gap-2 border-b border-border px-3 py-2">
-      <Smartphone className="size-4 shrink-0 text-primary" />
-      <span className="truncate font-medium">{displayName}</span>
+    <div className="@container/emulator-toolbar flex min-w-0 items-center gap-2 border-b border-border px-3 py-2">
+      <Smartphone className="size-4 shrink-0 text-primary [@container(max-width:519px)]:hidden" />
+      <span className="truncate font-medium [@container(max-width:519px)]:hidden">
+        {displayName}
+      </span>
       <span
         className={cn(
-          'shrink-0 text-[11px]',
+          'shrink-0 text-[11px] [@container(max-width:519px)]:hidden',
           !subtleStatus && 'rounded border px-1.5 py-0.5 text-[10px]',
           statusClassName
         )}
       >
         {statusLabel}
       </span>
-      <div className="flex-1" />
       <Select
         value={selectedUdid ?? ''}
         onValueChange={onSelectDevice}
         disabled={loading || devices.length === 0}
       >
-        <SelectTrigger className="h-7 w-[180px] text-xs">
+        <SelectTrigger className="h-7 min-w-0 flex-1 text-xs [@container(min-width:520px)]:max-w-[180px]">
           <SelectValue
             placeholder={translate(
               'auto.components.emulator.pane.emulator.pane.toolbar.3d836b879c',
@@ -80,22 +95,95 @@ export function EmulatorPaneToolbar({
           ))}
         </SelectContent>
       </Select>
+
+      {isAndroid && androidControls ? (
+        <AndroidEmulatorToolbarControls {...androidControls} disabled={controlsDisabled} />
+      ) : (
+        <LegacyIosControls disabled={controlsDisabled} onHome={onHome} onRotate={onRotate} />
+      )}
+
+      {isLive && canShutdown ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground hover:text-destructive"
+              onClick={onShutdown}
+              disabled={loading}
+              aria-label={translate(
+                'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
+                'Shut down emulator'
+              )}
+            >
+              <PowerOff className="size-3.5" />
+              <span className="hidden [@container(min-width:768px)]:inline">
+                {translate(
+                  'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
+                  'Shut down emulator'
+                )}
+              </span>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" sideOffset={4}>
+            {translate(
+              'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
+              'Shut down emulator'
+            )}
+          </TooltipContent>
+        </Tooltip>
+      ) : !isLive ? (
+        <Button
+          type="button"
+          size="sm"
+          variant={loading ? 'ghost' : 'default'}
+          className={cn('h-7 shrink-0 px-2 text-xs', loading && 'text-muted-foreground')}
+          onClick={onAttach}
+          disabled={loading || devices.length === 0}
+        >
+          {loading
+            ? translate(
+                'auto.components.emulator.pane.emulator.pane.toolbar.868c0f2938',
+                'Working…'
+              )
+            : translate(
+                'auto.components.emulator.pane.emulator.pane.toolbar.81b3571a07',
+                'Connect'
+              )}
+        </Button>
+      ) : null}
+    </div>
+  )
+}
+
+function LegacyIosControls({
+  disabled,
+  onHome,
+  onRotate
+}: {
+  disabled: boolean
+  onHome: () => void
+  onRotate: () => void
+}) {
+  return (
+    <>
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
             type="button"
             variant="secondary"
             size="sm"
-            className="h-7 gap-1 px-2 text-xs"
+            className="h-7 shrink-0 gap-1 px-2 text-xs"
             onClick={onRotate}
-            disabled={!isLive || loading}
+            disabled={disabled}
             aria-label={translate(
               'auto.components.emulator.pane.emulator.pane.toolbar.6bd8dff42a',
               'Rotate'
             )}
           >
             <RotateCw className="size-3.5" />
-            <span className="hidden sm:inline">
+            <span className="hidden [@container(min-width:520px)]:inline">
               {translate(
                 'auto.components.emulator.pane.emulator.pane.toolbar.6bd8dff42a',
                 'Rotate'
@@ -113,9 +201,9 @@ export function EmulatorPaneToolbar({
             type="button"
             variant="secondary"
             size="icon-xs"
-            className="size-7"
+            className="size-7 shrink-0"
             onClick={onHome}
-            disabled={!isLive || loading}
+            disabled={disabled}
             aria-label={translate(
               'auto.components.emulator.pane.emulator.pane.toolbar.e7a0d1897e',
               'Home'
@@ -128,51 +216,6 @@ export function EmulatorPaneToolbar({
           {translate('auto.components.emulator.pane.emulator.pane.toolbar.e7a0d1897e', 'Home')}
         </TooltipContent>
       </Tooltip>
-      {isLive ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              size="icon-xs"
-              className="size-7 text-muted-foreground hover:text-destructive"
-              onClick={onShutdown}
-              disabled={loading}
-              aria-label={translate(
-                'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
-                'Shut down emulator'
-              )}
-            >
-              <Power className="size-3.5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={4}>
-            {translate(
-              'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
-              'Shut down emulator'
-            )}
-          </TooltipContent>
-        </Tooltip>
-      ) : (
-        <Button
-          type="button"
-          size="sm"
-          variant={loading ? 'ghost' : 'default'}
-          className={cn('h-7 px-2 text-xs', loading && 'text-muted-foreground')}
-          onClick={onAttach}
-          disabled={loading || devices.length === 0}
-        >
-          {loading
-            ? translate(
-                'auto.components.emulator.pane.emulator.pane.toolbar.868c0f2938',
-                'Working…'
-              )
-            : translate(
-                'auto.components.emulator.pane.emulator.pane.toolbar.81b3571a07',
-                'Connect'
-              )}
-        </Button>
-      )}
-    </div>
+    </>
   )
 }

--- a/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-toolbar.tsx
@@ -58,18 +58,85 @@ export function EmulatorPaneToolbar({
     !isAndroid ||
     (androidControls?.capabilities?.shutdown ?? selectedDevice?.runtime === 'emulator')
   const controlsDisabled = !isLive || loading
+  const trailingAction =
+    isLive && canShutdown ? (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              'ml-auto h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground hover:text-destructive',
+              isAndroid &&
+                'w-7 !px-0 [@container(min-width:520px)]:!w-auto [@container(min-width:520px)]:!px-2.5'
+            )}
+            onClick={onShutdown}
+            disabled={loading}
+            aria-label={translate(
+              'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
+              'Shut down emulator'
+            )}
+          >
+            <PowerOff className="size-3.5" />
+            <span className="hidden [@container(min-width:768px)]:inline">
+              {translate(
+                'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
+                'Shut down emulator'
+              )}
+            </span>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={4}>
+          {translate(
+            'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
+            'Shut down emulator'
+          )}
+        </TooltipContent>
+      </Tooltip>
+    ) : !isLive ? (
+      <Button
+        type="button"
+        size="sm"
+        variant={loading ? 'ghost' : 'default'}
+        className={cn('ml-auto h-7 shrink-0 px-2 text-xs', loading && 'text-muted-foreground')}
+        onClick={onAttach}
+        disabled={loading || devices.length === 0}
+      >
+        {loading
+          ? translate('auto.components.emulator.pane.emulator.pane.toolbar.868c0f2938', 'Working…')
+          : translate('auto.components.emulator.pane.emulator.pane.toolbar.81b3571a07', 'Connect')}
+      </Button>
+    ) : null
 
   return (
-    <div className="@container/emulator-toolbar flex min-w-0 items-center gap-2 border-b border-border px-3 py-2">
-      <Smartphone className="size-4 shrink-0 text-primary [@container(max-width:519px)]:hidden" />
-      <span className="truncate font-medium [@container(max-width:519px)]:hidden">
+    <div className="@container/emulator-toolbar flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 border-b border-border px-3 py-2">
+      <Smartphone
+        className={cn(
+          'size-4 shrink-0 text-primary',
+          isAndroid
+            ? 'hidden [@container(min-width:520px)]:block'
+            : '[@container(max-width:519px)]:hidden'
+        )}
+      />
+      <span
+        className={cn(
+          'truncate font-medium',
+          isAndroid
+            ? 'hidden [@container(min-width:520px)]:inline'
+            : '[@container(max-width:519px)]:hidden'
+        )}
+      >
         {displayName}
       </span>
       <span
         className={cn(
-          'shrink-0 text-[11px] [@container(max-width:519px)]:hidden',
+          'shrink-0 text-[11px]',
           !subtleStatus && 'rounded border px-1.5 py-0.5 text-[10px]',
-          statusClassName
+          statusClassName,
+          isAndroid
+            ? 'hidden [@container(min-width:520px)]:inline'
+            : '[@container(max-width:519px)]:hidden'
         )}
       >
         {statusLabel}
@@ -79,7 +146,14 @@ export function EmulatorPaneToolbar({
         onValueChange={onSelectDevice}
         disabled={loading || devices.length === 0}
       >
-        <SelectTrigger className="h-7 min-w-0 flex-1 text-xs [@container(min-width:520px)]:max-w-[180px]">
+        <SelectTrigger
+          className={cn(
+            'h-7 text-xs [@container(min-width:520px)]:max-w-[180px]',
+            isAndroid
+              ? 'min-w-32 flex-[999_1_0] [@container(min-width:520px)]:min-w-0 [@container(min-width:520px)]:flex-1'
+              : 'min-w-0 flex-1'
+          )}
+        >
           <SelectValue
             placeholder={translate(
               'auto.components.emulator.pane.emulator.pane.toolbar.3d836b879c',
@@ -97,62 +171,21 @@ export function EmulatorPaneToolbar({
       </Select>
 
       {isAndroid && androidControls ? (
-        <AndroidEmulatorToolbarControls {...androidControls} disabled={controlsDisabled} />
-      ) : (
-        <LegacyIosControls disabled={controlsDisabled} onHome={onHome} onRotate={onRotate} />
-      )}
-
-      {isLive && canShutdown ? (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 shrink-0 gap-1 px-2 text-xs text-muted-foreground hover:text-destructive"
-              onClick={onShutdown}
-              disabled={loading}
-              aria-label={translate(
-                'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
-                'Shut down emulator'
-              )}
-            >
-              <PowerOff className="size-3.5" />
-              <span className="hidden [@container(min-width:768px)]:inline">
-                {translate(
-                  'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
-                  'Shut down emulator'
-                )}
-              </span>
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={4}>
-            {translate(
-              'auto.components.emulator.pane.emulator.pane.toolbar.06e10d7356',
-              'Shut down emulator'
-            )}
-          </TooltipContent>
-        </Tooltip>
-      ) : !isLive ? (
-        <Button
-          type="button"
-          size="sm"
-          variant={loading ? 'ghost' : 'default'}
-          className={cn('h-7 shrink-0 px-2 text-xs', loading && 'text-muted-foreground')}
-          onClick={onAttach}
-          disabled={loading || devices.length === 0}
+        <div
+          className={cn(
+            'flex min-w-0 flex-[1_1_max-content] items-center [@container(min-width:520px)]:contents',
+            isLive && canShutdown ? 'flex-nowrap gap-1' : 'flex-wrap gap-2'
+          )}
         >
-          {loading
-            ? translate(
-                'auto.components.emulator.pane.emulator.pane.toolbar.868c0f2938',
-                'Working…'
-              )
-            : translate(
-                'auto.components.emulator.pane.emulator.pane.toolbar.81b3571a07',
-                'Connect'
-              )}
-        </Button>
-      ) : null}
+          <AndroidEmulatorToolbarControls {...androidControls} disabled={controlsDisabled} />
+          {trailingAction}
+        </div>
+      ) : (
+        <>
+          <LegacyIosControls disabled={controlsDisabled} onHome={onHome} onRotate={onRotate} />
+          {trailingAction}
+        </>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/components/emulator-pane/emulator-pane-types.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-types.ts
@@ -1,9 +1,13 @@
+import type { EmulatorDeviceControlCapabilities } from '../../../../shared/emulator-device-controls'
+
 export type SimulatorDeviceRow = {
   name: string
   udid: string
   state: string
   runtime?: string
   isAvailable?: boolean
+  backend?: 'ios' | 'android'
+  controlCapabilities?: EmulatorDeviceControlCapabilities
 }
 
 export type EmulatorStreamInfo = {
@@ -14,6 +18,7 @@ export type EmulatorStreamInfo = {
   url?: string
   wsUrl?: string
   state?: string
+  backend?: 'ios' | 'android'
 }
 
 export type EmulatorPaneSession = {

--- a/src/renderer/src/components/emulator-pane/emulator-pane-zoom.test.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-zoom.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EMULATOR_ZOOM_LEVELS,
+  resolveEmulatorZoomAvailability,
+  resolveEmulatorZoomState,
+  type EmulatorZoomMetrics
+} from './emulator-pane-zoom'
+
+const metrics: EmulatorZoomMetrics = { fitScale: 0.3, fitDisplayScale: 0.5 }
+
+describe('emulator zoom', () => {
+  it('uses the Android Studio discrete levels', () => {
+    expect(EMULATOR_ZOOM_LEVELS).toEqual([0.0625, 0.125, 0.25, 0.5, 1, 2, 4])
+  })
+
+  it('crosses from Fit to the next discrete level and returns to Fit below it', () => {
+    expect(resolveEmulatorZoomState({ mode: 'fit' }, 'in', metrics)).toEqual({
+      mode: 'fixed',
+      scale: 0.5
+    })
+    expect(resolveEmulatorZoomState({ mode: 'fixed', scale: 0.5 }, 'out', metrics)).toEqual({
+      mode: 'fit'
+    })
+  })
+
+  it('handles actual, display fit, and boundaries', () => {
+    expect(resolveEmulatorZoomState({ mode: 'fit' }, 'actual', metrics)).toEqual({
+      mode: 'fixed',
+      scale: 1
+    })
+    expect(resolveEmulatorZoomState({ mode: 'fit' }, 'fit-display', metrics)).toEqual({
+      mode: 'fit-display'
+    })
+    expect(resolveEmulatorZoomAvailability({ mode: 'fixed', scale: 4 }, metrics).in).toBe(false)
+    expect(resolveEmulatorZoomAvailability({ mode: 'fixed', scale: 0.0625 }, metrics).out).toBe(
+      false
+    )
+  })
+})

--- a/src/renderer/src/components/emulator-pane/emulator-pane-zoom.test.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-zoom.test.ts
@@ -23,6 +23,22 @@ describe('emulator zoom', () => {
     })
   })
 
+  it('disables Zoom Out at Fit when the previous level is below Fit scale', () => {
+    expect(resolveEmulatorZoomAvailability({ mode: 'fit' }, metrics).out).toBe(false)
+  })
+
+  it('decreases fixed zoom when Fit grows beyond the current fixed scale', () => {
+    const resizedMetrics = { fitScale: 0.8, fitDisplayScale: 0.5 }
+
+    expect(resolveEmulatorZoomAvailability({ mode: 'fixed', scale: 0.5 }, resizedMetrics).out).toBe(
+      true
+    )
+    expect(resolveEmulatorZoomState({ mode: 'fixed', scale: 0.5 }, 'out', resizedMetrics)).toEqual({
+      mode: 'fixed',
+      scale: 0.25
+    })
+  })
+
   it('handles actual, display fit, and boundaries', () => {
     expect(resolveEmulatorZoomState({ mode: 'fit' }, 'actual', metrics)).toEqual({
       mode: 'fixed',

--- a/src/renderer/src/components/emulator-pane/emulator-pane-zoom.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-zoom.ts
@@ -33,7 +33,7 @@ export function resolveEmulatorZoomState(
   if (previous === undefined) {
     return state
   }
-  if (previous < metrics.fitScale) {
+  if (state.mode !== 'fit' && previous < metrics.fitScale && metrics.fitScale < currentScale) {
     return { mode: 'fit' }
   }
   return { mode: 'fixed', scale: previous }
@@ -61,7 +61,7 @@ export function resolveEmulatorZoomAvailability(
   const previous = EMULATOR_ZOOM_LEVELS.toReversed().find((level) => level < effectiveScale)
   return {
     in: next !== undefined,
-    out: previous !== undefined,
+    out: previous !== undefined && !(state.mode === 'fit' && previous < metrics.fitScale),
     actual: state.mode !== 'fixed' || state.scale !== 1,
     fit: state.mode !== 'fit',
     'fit-display': state.mode !== 'fit-display'

--- a/src/renderer/src/components/emulator-pane/emulator-pane-zoom.ts
+++ b/src/renderer/src/components/emulator-pane/emulator-pane-zoom.ts
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
+
+export const EMULATOR_ZOOM_LEVELS = [0.0625, 0.125, 0.25, 0.5, 1, 2, 4] as const
+
+export type EmulatorZoomAction = 'in' | 'out' | 'actual' | 'fit' | 'fit-display'
+
+export type EmulatorZoomState = { mode: 'fit' | 'fit-display' } | { mode: 'fixed'; scale: number }
+
+export type EmulatorZoomMetrics = {
+  fitScale: number
+  fitDisplayScale: number
+}
+
+export function resolveEmulatorZoomState(
+  state: EmulatorZoomState,
+  action: EmulatorZoomAction,
+  metrics: EmulatorZoomMetrics
+): EmulatorZoomState {
+  if (action === 'actual') {
+    return { mode: 'fixed', scale: 1 }
+  }
+  if (action === 'fit' || action === 'fit-display') {
+    return { mode: action }
+  }
+
+  const currentScale = resolveEffectiveScale(state, metrics)
+  if (action === 'in') {
+    const next = EMULATOR_ZOOM_LEVELS.find((level) => level > currentScale)
+    return next === undefined ? state : { mode: 'fixed', scale: next }
+  }
+
+  const previous = EMULATOR_ZOOM_LEVELS.toReversed().find((level) => level < currentScale)
+  if (previous === undefined) {
+    return state
+  }
+  if (previous < metrics.fitScale) {
+    return { mode: 'fit' }
+  }
+  return { mode: 'fixed', scale: previous }
+}
+
+export function resolveEffectiveScale(
+  state: EmulatorZoomState,
+  metrics: EmulatorZoomMetrics
+): number {
+  if (state.mode === 'fixed') {
+    return state.scale
+  }
+  return state.mode === 'fit' ? metrics.fitScale : metrics.fitDisplayScale
+}
+
+export function resolveEmulatorZoomAvailability(
+  state: EmulatorZoomState,
+  metrics: EmulatorZoomMetrics | null
+): Record<EmulatorZoomAction, boolean> {
+  if (!metrics) {
+    return { in: false, out: false, actual: false, fit: false, 'fit-display': false }
+  }
+  const effectiveScale = resolveEffectiveScale(state, metrics)
+  const next = EMULATOR_ZOOM_LEVELS.find((level) => level > effectiveScale)
+  const previous = EMULATOR_ZOOM_LEVELS.toReversed().find((level) => level < effectiveScale)
+  return {
+    in: next !== undefined,
+    out: previous !== undefined,
+    actual: state.mode !== 'fixed' || state.scale !== 1,
+    fit: state.mode !== 'fit',
+    'fit-display': state.mode !== 'fit-display'
+  }
+}
+
+export type EmulatorPaneZoom = {
+  state: EmulatorZoomState
+  effectiveScale: number
+  percentage: number
+  availability: Record<EmulatorZoomAction, boolean>
+  zoom: (action: EmulatorZoomAction) => void
+  setMetrics: Dispatch<SetStateAction<EmulatorZoomMetrics | null>>
+}
+
+type DeviceZoomState = {
+  deviceId: string | null
+  state: EmulatorZoomState
+  metrics: EmulatorZoomMetrics | null
+}
+
+const initialDeviceZoomState: DeviceZoomState = {
+  deviceId: null,
+  state: { mode: 'fit' },
+  metrics: null
+}
+
+export function useEmulatorPaneZoom(deviceId: string | null): EmulatorPaneZoom {
+  const [deviceZoom, setDeviceZoom] = useState(initialDeviceZoomState)
+  const activeZoom =
+    deviceZoom.deviceId === deviceId
+      ? deviceZoom
+      : { deviceId, state: { mode: 'fit' as const }, metrics: null }
+  const setMetrics = useCallback<Dispatch<SetStateAction<EmulatorZoomMetrics | null>>>(
+    (value) => {
+      setDeviceZoom((current) => {
+        const base =
+          current.deviceId === deviceId
+            ? current
+            : { deviceId, state: { mode: 'fit' as const }, metrics: null }
+        const metrics = typeof value === 'function' ? value(base.metrics) : value
+        if (
+          base.deviceId === current.deviceId &&
+          base.metrics?.fitScale === metrics?.fitScale &&
+          base.metrics?.fitDisplayScale === metrics?.fitDisplayScale
+        ) {
+          return current
+        }
+        return { ...base, metrics }
+      })
+    },
+    [deviceId]
+  )
+  const effectiveScale = activeZoom.metrics
+    ? resolveEffectiveScale(activeZoom.state, activeZoom.metrics)
+    : 1
+  const availability = useMemo(
+    () => resolveEmulatorZoomAvailability(activeZoom.state, activeZoom.metrics),
+    [activeZoom.metrics, activeZoom.state]
+  )
+  const zoom = useCallback(
+    (action: EmulatorZoomAction) => {
+      const metrics = activeZoom.metrics
+      if (!metrics || !availability[action]) {
+        return
+      }
+      setDeviceZoom((current) => {
+        const base =
+          current.deviceId === deviceId
+            ? current
+            : { deviceId, state: { mode: 'fit' as const }, metrics: null }
+        return { ...base, state: resolveEmulatorZoomState(base.state, action, metrics) }
+      })
+    },
+    [activeZoom.metrics, availability, deviceId]
+  )
+
+  return {
+    state: activeZoom.state,
+    effectiveScale,
+    percentage: Math.round(effectiveScale * 100),
+    availability,
+    zoom,
+    setMetrics
+  }
+}

--- a/src/renderer/src/components/emulator-pane/emulator-screen-stream-content.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-screen-stream-content.tsx
@@ -12,6 +12,7 @@ type StreamSize = {
 
 type EmulatorScreenStreamContentProps = {
   loading: boolean
+  onScreenshotCanvasChange?: (canvas: HTMLCanvasElement | null) => void
   onStreamError: () => void
   onStreamSize: (size: StreamSize) => void
   previewUrl?: string
@@ -24,9 +25,11 @@ type EmulatorScreenStreamContentProps = {
 
 // Android sessions stream H.264 over scrcpy://<serial>; iOS uses an MJPEG http URL.
 const SCRCPY_PREFIX = 'scrcpy://'
+const noopScreenshotCanvasChange = (): void => {}
 
 export function EmulatorScreenStreamContent({
   loading,
+  onScreenshotCanvasChange = noopScreenshotCanvasChange,
   onStreamError,
   onStreamSize,
   previewUrl,
@@ -45,7 +48,8 @@ export function EmulatorScreenStreamContent({
     androidDeviceId ?? undefined,
     streamKey,
     showStream && Boolean(androidDeviceId),
-    onStreamSize
+    onStreamSize,
+    onScreenshotCanvasChange
   )
   const frameStream = useEmulatorFrameStream(
     androidDeviceId ? undefined : previewUrl,

--- a/src/renderer/src/components/emulator-pane/emulator-screen-surface.tsx
+++ b/src/renderer/src/components/emulator-pane/emulator-screen-surface.tsx
@@ -26,6 +26,7 @@ type EmulatorScreenSurfaceProps = {
   onPointerDown: PointerEventHandler<HTMLDivElement>
   onPointerMove: PointerEventHandler<HTMLDivElement>
   onPointerUp: PointerEventHandler<HTMLDivElement>
+  onScreenshotCanvasChange: (canvas: HTMLCanvasElement | null) => void
   onStreamError: () => void
   onStreamSize: (size: StreamSize) => void
   onWheel: WheelEventHandler<HTMLDivElement>
@@ -49,6 +50,7 @@ export function EmulatorScreenSurface({
   onPointerDown,
   onPointerMove,
   onPointerUp,
+  onScreenshotCanvasChange,
   onStreamError,
   onStreamSize,
   onWheel,
@@ -89,6 +91,7 @@ export function EmulatorScreenSurface({
           doubles up with iOS's real status bar and makes bezels lie. */}
       <EmulatorScreenStreamContent
         loading={loading}
+        onScreenshotCanvasChange={onScreenshotCanvasChange}
         onStreamError={onStreamError}
         onStreamSize={onStreamSize}
         previewUrl={previewUrl}

--- a/src/renderer/src/components/emulator-pane/save-emulator-screenshot.test.ts
+++ b/src/renderer/src/components/emulator-pane/save-emulator-screenshot.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { canvasToPngDataUrl } from '@/lib/canvas-png-data-url'
+import { saveEmulatorScreenshot } from './save-emulator-screenshot'
+
+vi.mock('@/lib/canvas-png-data-url', () => ({
+  canvasToPngDataUrl: vi.fn()
+}))
+
+const encode = vi.mocked(canvasToPngDataUrl)
+const saveDownloadedFile = vi.fn()
+const canvas = {} as HTMLCanvasElement
+const now = new Date('2026-01-02T03:04:05.006Z')
+
+beforeEach(() => {
+  encode.mockReset()
+  saveDownloadedFile.mockReset()
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { api: { fs: { saveDownloadedFile } } }
+  })
+})
+
+describe('saveEmulatorScreenshot', () => {
+  it('strips the PNG data URL prefix and uses a portable filename', async () => {
+    encode.mockResolvedValue('data:image/png;base64,AAE=')
+    saveDownloadedFile.mockResolvedValue({ canceled: false, destinationPath: '/tmp/screen.png' })
+
+    await expect(saveEmulatorScreenshot(canvas, now)).resolves.toEqual({
+      canceled: false,
+      destinationPath: '/tmp/screen.png'
+    })
+    expect(saveDownloadedFile).toHaveBeenCalledWith({
+      suggestedName: 'emulator-screenshot-2026-01-02T03-04-05-006Z.png',
+      content: 'AAE=',
+      encoding: 'base64'
+    })
+  })
+
+  it('passes native dialog cancellation through without writing content', async () => {
+    encode.mockResolvedValue('data:image/png;base64,AAE=')
+    saveDownloadedFile.mockResolvedValue({ canceled: true })
+
+    await expect(saveEmulatorScreenshot(canvas, now)).resolves.toEqual({ canceled: true })
+  })
+
+  it('rejects non-PNG encodings', async () => {
+    encode.mockResolvedValue('data:image/jpeg;base64,AAE=')
+
+    await expect(saveEmulatorScreenshot(canvas, now)).rejects.toThrow('PNG')
+    expect(saveDownloadedFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/emulator-pane/save-emulator-screenshot.ts
+++ b/src/renderer/src/components/emulator-pane/save-emulator-screenshot.ts
@@ -1,0 +1,18 @@
+import { canvasToPngDataUrl } from '@/lib/canvas-png-data-url'
+
+const PNG_DATA_URL_PREFIX = 'data:image/png;base64,'
+
+export async function saveEmulatorScreenshot(
+  canvas: HTMLCanvasElement,
+  now: Date
+): Promise<{ canceled: true } | { canceled: false; destinationPath: string }> {
+  const dataUrl = await canvasToPngDataUrl(canvas)
+  if (!dataUrl.startsWith(PNG_DATA_URL_PREFIX)) {
+    throw new Error('Emulator screenshot was not encoded as a PNG.')
+  }
+  return window.api.fs.saveDownloadedFile({
+    suggestedName: `emulator-screenshot-${now.toISOString().replace(/[:.]/g, '-')}.png`,
+    content: dataUrl.slice(PNG_DATA_URL_PREFIX.length),
+    encoding: 'base64'
+  })
+}

--- a/src/renderer/src/components/emulator-pane/use-center-anchored-emulator-scroll.test.tsx
+++ b/src/renderer/src/components/emulator-pane/use-center-anchored-emulator-scroll.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useCenterAnchoredEmulatorScroll } from './use-center-anchored-emulator-scroll'
+import type { PaneSize } from './emulator-device-frame-layout'
+
+type ScrollHarnessProps = {
+  viewportSize: PaneSize
+  contentSize: PaneSize
+}
+
+function ScrollHarness({ viewportSize, contentSize }: ScrollHarnessProps) {
+  const scrollRef = useCenterAnchoredEmulatorScroll(viewportSize, contentSize)
+  return <div ref={scrollRef} />
+}
+
+function setScrollGeometry(
+  node: HTMLDivElement,
+  geometry: { clientWidth: number; clientHeight: number; scrollWidth: number; scrollHeight: number }
+): void {
+  Object.defineProperties(node, {
+    clientWidth: { configurable: true, value: geometry.clientWidth },
+    clientHeight: { configurable: true, value: geometry.clientHeight },
+    scrollWidth: { configurable: true, value: geometry.scrollWidth },
+    scrollHeight: { configurable: true, value: geometry.scrollHeight }
+  })
+}
+
+describe('useCenterAnchoredEmulatorScroll', () => {
+  it('centers an axis that starts fitted while preserving the overflowing axis center', () => {
+    const viewportSize = { width: 100, height: 100 }
+    const initialContentSize = { width: 80, height: 200 }
+    const nextContentSize = { width: 300, height: 300 }
+    const view = render(
+      <ScrollHarness viewportSize={viewportSize} contentSize={initialContentSize} />
+    )
+    const node = view.container.firstChild as HTMLDivElement
+
+    setScrollGeometry(node, {
+      clientWidth: viewportSize.width,
+      clientHeight: viewportSize.height,
+      scrollWidth: initialContentSize.width,
+      scrollHeight: initialContentSize.height
+    })
+    node.scrollTop = 30
+    setScrollGeometry(node, {
+      clientWidth: viewportSize.width,
+      clientHeight: viewportSize.height,
+      scrollWidth: nextContentSize.width,
+      scrollHeight: nextContentSize.height
+    })
+
+    view.rerender(<ScrollHarness viewportSize={viewportSize} contentSize={nextContentSize} />)
+
+    expect((node.scrollLeft + viewportSize.width / 2) / nextContentSize.width).toBe(0.5)
+    expect((node.scrollTop + viewportSize.height / 2) / nextContentSize.height).toBe(0.4)
+  })
+})

--- a/src/renderer/src/components/emulator-pane/use-center-anchored-emulator-scroll.ts
+++ b/src/renderer/src/components/emulator-pane/use-center-anchored-emulator-scroll.ts
@@ -1,0 +1,43 @@
+import { useLayoutEffect, useRef } from 'react'
+import type { PaneSize } from './emulator-device-frame-layout'
+
+export function useCenterAnchoredEmulatorScroll(
+  viewportSize: PaneSize | null,
+  contentSize: PaneSize | null
+): React.RefObject<HTMLDivElement | null> {
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const previousContentSizeRef = useRef<PaneSize | null>(null)
+
+  useLayoutEffect(() => {
+    const node = scrollRef.current
+    const previous = previousContentSizeRef.current
+    previousContentSizeRef.current = contentSize
+    if (!node || !contentSize || !viewportSize) {
+      return
+    }
+    if (!previous) {
+      return
+    }
+
+    const centerX =
+      previous.width > 0 ? (node.scrollLeft + viewportSize.width / 2) / previous.width : 0.5
+    const centerY =
+      previous.height > 0 ? (node.scrollTop + viewportSize.height / 2) / previous.height : 0.5
+    node.scrollLeft = clamp(
+      centerX * contentSize.width - viewportSize.width / 2,
+      0,
+      node.scrollWidth - node.clientWidth
+    )
+    node.scrollTop = clamp(
+      centerY * contentSize.height - viewportSize.height / 2,
+      0,
+      node.scrollHeight - node.clientHeight
+    )
+  }, [contentSize, viewportSize])
+
+  return scrollRef
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}

--- a/src/renderer/src/components/emulator-pane/use-center-anchored-emulator-scroll.ts
+++ b/src/renderer/src/components/emulator-pane/use-center-anchored-emulator-scroll.ts
@@ -20,9 +20,13 @@ export function useCenterAnchoredEmulatorScroll(
     }
 
     const centerX =
-      previous.width > 0 ? (node.scrollLeft + viewportSize.width / 2) / previous.width : 0.5
+      previous.width <= viewportSize.width
+        ? 0.5
+        : (node.scrollLeft + viewportSize.width / 2) / previous.width
     const centerY =
-      previous.height > 0 ? (node.scrollTop + viewportSize.height / 2) / previous.height : 0.5
+      previous.height <= viewportSize.height
+        ? 0.5
+        : (node.scrollTop + viewportSize.height / 2) / previous.height
     node.scrollLeft = clamp(
       centerX * contentSize.width - viewportSize.width / 2,
       0,

--- a/src/renderer/src/components/emulator-pane/use-emulator-device-frame-layout.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-device-frame-layout.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo } from 'react'
+import {
+  fitDeviceFrameToPane,
+  layoutDeviceFrameAtScreenSize,
+  scaleDeviceFrameLayout,
+  type DeviceFrameKind,
+  type DeviceFrameLayout,
+  type PaneSize,
+  type StreamSize
+} from './emulator-device-frame-layout'
+import {
+  resolveEffectiveScale,
+  type EmulatorZoomMetrics,
+  type EmulatorZoomState
+} from './emulator-pane-zoom'
+
+type UseEmulatorDeviceFrameLayoutOptions = {
+  paneSize: PaneSize | null
+  frameKind: DeviceFrameKind
+  screenAspectRatio: number
+  visualStreamSize: StreamSize | null
+  zoomState?: EmulatorZoomState
+  onZoomMetrics?: (metrics: EmulatorZoomMetrics | null) => void
+}
+
+export function useEmulatorDeviceFrameLayout({
+  paneSize,
+  frameKind,
+  screenAspectRatio,
+  visualStreamSize,
+  zoomState,
+  onZoomMetrics
+}: UseEmulatorDeviceFrameLayoutOptions): DeviceFrameLayout | null {
+  const naturalFrameLayout = useMemo(
+    () => (visualStreamSize ? layoutDeviceFrameAtScreenSize(visualStreamSize, frameKind) : null),
+    [frameKind, visualStreamSize]
+  )
+  const zoomMetrics = useMemo<EmulatorZoomMetrics | null>(() => {
+    if (!paneSize || !naturalFrameLayout || !visualStreamSize) {
+      return null
+    }
+    return {
+      fitScale: Math.min(
+        paneSize.width / naturalFrameLayout.width,
+        paneSize.height / naturalFrameLayout.height
+      ),
+      fitDisplayScale: Math.min(
+        paneSize.width / visualStreamSize.width,
+        paneSize.height / visualStreamSize.height
+      )
+    }
+  }, [naturalFrameLayout, paneSize, visualStreamSize])
+
+  useEffect(() => {
+    onZoomMetrics?.(zoomMetrics)
+  }, [onZoomMetrics, zoomMetrics])
+
+  return useMemo(() => {
+    if (!naturalFrameLayout || !zoomState || !zoomMetrics) {
+      return fitDeviceFrameToPane(paneSize, screenAspectRatio, frameKind)
+    }
+    return scaleDeviceFrameLayout(naturalFrameLayout, resolveEffectiveScale(zoomState, zoomMetrics))
+  }, [frameKind, naturalFrameLayout, paneSize, screenAspectRatio, zoomMetrics, zoomState])
+}

--- a/src/renderer/src/components/emulator-pane/use-emulator-device-inventory.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-device-inventory.ts
@@ -1,0 +1,67 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction
+} from 'react'
+import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { emulatorPaneErrorMessage } from './emulator-pane-error-message'
+import { markSimulatorDeviceBooted } from './emulator-device-state'
+import { toSimulatorDeviceRows, type RawEmulatorDevice } from './emulator-device-row-mapping'
+import type { SimulatorDeviceRow } from './emulator-pane-types'
+
+export type EmulatorDeviceInventory = {
+  devices: SimulatorDeviceRow[]
+  setDevices: Dispatch<SetStateAction<SimulatorDeviceRow[]>>
+  deviceRefreshErrorRef: RefObject<unknown>
+  refreshDevices: (bootedTarget?: string | null) => Promise<SimulatorDeviceRow[]>
+}
+
+type UseEmulatorDeviceInventoryOptions = {
+  mountedRef: RefObject<boolean>
+  setError: Dispatch<SetStateAction<string | null>>
+}
+
+export function useEmulatorDeviceInventory({
+  mountedRef,
+  setError
+}: UseEmulatorDeviceInventoryOptions): EmulatorDeviceInventory {
+  const [devices, setDevices] = useState<SimulatorDeviceRow[]>([])
+  const deviceRefreshErrorRef = useRef<unknown>(null)
+  const refreshDevices = useCallback(
+    async (bootedTarget?: string | null) => {
+      try {
+        // Unified list so Android devices/AVDs appear alongside iOS simulators.
+        const raw = (await callRuntimeRpc(
+          { kind: 'local' },
+          'emulator.listDevices',
+          {}
+        )) as RawEmulatorDevice[]
+        const list = toSimulatorDeviceRows(raw)
+        const next = markSimulatorDeviceBooted(list, bootedTarget)
+        if (!mountedRef.current) {
+          return next
+        }
+        const hadRefreshError = deviceRefreshErrorRef.current !== null
+        deviceRefreshErrorRef.current = null
+        setDevices(next)
+        if (hadRefreshError) {
+          setError(null)
+        }
+        return next
+      } catch (error) {
+        deviceRefreshErrorRef.current = error
+        if (mountedRef.current) {
+          setDevices([])
+          setError(emulatorPaneErrorMessage(error, 'Could not list emulator devices.'))
+        }
+        return []
+      }
+    },
+    [mountedRef, setError]
+  )
+
+  return { devices, setDevices, deviceRefreshErrorRef, refreshDevices }
+}

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-controls.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-controls.ts
@@ -1,58 +1,175 @@
 import { useCallback, useRef, useState } from 'react'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import type {
+  EmulatorButtonOptions,
+  EmulatorPosture
+} from '../../../../shared/emulator-device-controls'
 import type { EmulatorDeviceVisualOrientation } from './emulator-device-frame-layout'
 import type { EmulatorGesturePoint } from './emulator-screen-gesture'
 
-export function useEmulatorPaneControls(worktreeId: string, onRotateSettled?: () => void) {
-  const nextRotateOrientationRef = useRef<'landscape_left' | 'portrait'>('landscape_left')
-  const visualOrientationEpochRef = useRef(0)
+type UseEmulatorPaneControlsArgs = {
+  worktreeId: string
+  onControlError: (error: unknown) => void
+  onControlSuccess: () => void
+  onDisplaySettled: () => void
+}
+
+const ROTATION_SEQUENCE = [
+  'portrait',
+  'landscape_left',
+  'portrait_upside_down',
+  'landscape_right'
+] as const
+
+type Rotation = (typeof ROTATION_SEQUENCE)[number]
+
+export function useEmulatorPaneControls({
+  worktreeId,
+  onControlError,
+  onControlSuccess,
+  onDisplaySettled
+}: UseEmulatorPaneControlsArgs) {
+  const orientationEpochRef = useRef(0)
+  const rotationRef = useRef<Rotation>('portrait')
+  const displayCommandPendingRef = useRef(false)
   const [visualOrientation, setVisualOrientation] =
     useState<EmulatorDeviceVisualOrientation>('portrait')
-
+  const [displayCommandPending, setDisplayCommandPending] = useState(false)
   const sendTap = useCallback(
     async (x: number, y: number) => {
-      await callRuntimeRpc({ kind: 'local' }, 'emulator.tap', { x, y, worktree: worktreeId })
+      try {
+        await callRuntimeRpc({ kind: 'local' }, 'emulator.tap', { x, y, worktree: worktreeId })
+        onControlSuccess()
+      } catch (error) {
+        onControlError(error)
+      }
     },
-    [worktreeId]
+    [onControlError, onControlSuccess, worktreeId]
   )
 
   const sendButton = useCallback(
-    async (name: string) => {
-      await callRuntimeRpc({ kind: 'local' }, 'emulator.button', { name, worktree: worktreeId })
+    async (name: string, options?: EmulatorButtonOptions): Promise<void> => {
+      try {
+        await callRuntimeRpc({ kind: 'local' }, 'emulator.button', {
+          name,
+          worktree: worktreeId,
+          ...options
+        })
+        onControlSuccess()
+      } catch (error) {
+        onControlError(error)
+      }
     },
-    [worktreeId]
+    [onControlError, onControlSuccess, worktreeId]
   )
-
   const sendGesture = useCallback(
     async (points: EmulatorGesturePoint[]) => {
-      await callRuntimeRpc({ kind: 'local' }, 'emulator.gesture', { points, worktree: worktreeId })
+      try {
+        await callRuntimeRpc({ kind: 'local' }, 'emulator.gesture', {
+          points,
+          worktree: worktreeId
+        })
+        onControlSuccess()
+      } catch (error) {
+        onControlError(error)
+      }
     },
-    [worktreeId]
+    [onControlError, onControlSuccess, worktreeId]
   )
 
-  const sendRotate = useCallback(async () => {
-    const orientation = nextRotateOrientationRef.current
-    const epoch = visualOrientationEpochRef.current
-    await callRuntimeRpc({ kind: 'local' }, 'emulator.rotate', {
-      orientation,
-      worktree: worktreeId
-    })
-    if (visualOrientationEpochRef.current !== epoch) {
-      return null
-    }
-    const nextVisualOrientation = orientation === 'landscape_left' ? 'landscape' : 'portrait'
-    setVisualOrientation(nextVisualOrientation)
-    nextRotateOrientationRef.current =
-      orientation === 'landscape_left' ? 'portrait' : 'landscape_left'
-    onRotateSettled?.()
-    return nextVisualOrientation
-  }, [onRotateSettled, worktreeId])
+  const sendDisplayCommand = useCallback(
+    async (run: () => Promise<void>, epoch: number, onSuccess: () => void): Promise<void> => {
+      if (displayCommandPendingRef.current) {
+        return
+      }
+      displayCommandPendingRef.current = true
+      setDisplayCommandPending(true)
+      try {
+        await run()
+        if (orientationEpochRef.current !== epoch) {
+          return
+        }
+        onSuccess()
+        onControlSuccess()
+        onDisplaySettled()
+      } catch (error) {
+        if (orientationEpochRef.current === epoch) {
+          onControlError(error)
+        }
+      } finally {
+        if (orientationEpochRef.current === epoch) {
+          displayCommandPendingRef.current = false
+          setDisplayCommandPending(false)
+        }
+      }
+    },
+    [onControlError, onControlSuccess, onDisplaySettled]
+  )
+
+  const sendRotate = useCallback(
+    async (direction: 'left' | 'right' = 'left'): Promise<void> => {
+      if (displayCommandPendingRef.current) {
+        return
+      }
+      const epoch = orientationEpochRef.current
+      const currentIndex = ROTATION_SEQUENCE.indexOf(rotationRef.current)
+      const offset = direction === 'left' ? 1 : ROTATION_SEQUENCE.length - 1
+      const next = ROTATION_SEQUENCE[(currentIndex + offset) % ROTATION_SEQUENCE.length]
+      await sendDisplayCommand(
+        async () => {
+          await callRuntimeRpc({ kind: 'local' }, 'emulator.rotate', {
+            orientation: next,
+            worktree: worktreeId
+          })
+        },
+        epoch,
+        () => {
+          rotationRef.current = next
+          setVisualOrientation(
+            next === 'portrait' || next === 'portrait_upside_down' ? 'portrait' : 'landscape'
+          )
+        }
+      )
+    },
+    [sendDisplayCommand, worktreeId]
+  )
+
+  const sendPosture = useCallback(
+    async (posture: EmulatorPosture): Promise<void> => {
+      if (displayCommandPendingRef.current) {
+        return
+      }
+      const epoch = orientationEpochRef.current
+      await sendDisplayCommand(
+        async () => {
+          await callRuntimeRpc({ kind: 'local' }, 'emulator.posture', {
+            posture,
+            worktree: worktreeId
+          })
+        },
+        epoch,
+        () => {}
+      )
+    },
+    [sendDisplayCommand, worktreeId]
+  )
 
   const resetVisualOrientation = useCallback(() => {
-    visualOrientationEpochRef.current += 1
-    nextRotateOrientationRef.current = 'landscape_left'
+    orientationEpochRef.current += 1
+    rotationRef.current = 'portrait'
+    displayCommandPendingRef.current = false
     setVisualOrientation('portrait')
+    setDisplayCommandPending(false)
   }, [])
 
-  return { sendTap, sendButton, sendGesture, sendRotate, visualOrientation, resetVisualOrientation }
+  return {
+    sendTap,
+    sendButton,
+    sendGesture,
+    sendRotate,
+    sendPosture,
+    visualOrientation,
+    displayCommandPending,
+    resetVisualOrientation
+  }
 }

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-controls.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-controls.ts
@@ -107,14 +107,19 @@ export function useEmulatorPaneControls({
   )
 
   const sendRotate = useCallback(
-    async (direction: 'left' | 'right' = 'left'): Promise<void> => {
+    async (direction?: 'left' | 'right'): Promise<void> => {
       if (displayCommandPendingRef.current) {
         return
       }
       const epoch = orientationEpochRef.current
       const currentIndex = ROTATION_SEQUENCE.indexOf(rotationRef.current)
-      const offset = direction === 'left' ? 1 : ROTATION_SEQUENCE.length - 1
-      const next = ROTATION_SEQUENCE[(currentIndex + offset) % ROTATION_SEQUENCE.length]
+      let next: Rotation
+      if (direction === undefined) {
+        next = rotationRef.current === 'portrait' ? 'landscape_left' : 'portrait'
+      } else {
+        const offset = direction === 'left' ? 1 : ROTATION_SEQUENCE.length - 1
+        next = ROTATION_SEQUENCE[(currentIndex + offset) % ROTATION_SEQUENCE.length]
+      }
       await sendDisplayCommand(
         async () => {
           await callRuntimeRpc({ kind: 'local' }, 'emulator.rotate', {

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-session.test.tsx
@@ -2,7 +2,7 @@
 
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { useAppStore } from '@/store'
 import {
   consumePrelaunchedSimulatorSession,
@@ -50,6 +50,7 @@ const deviceList = devices.map((device) => ({
 
 let attachDeferred: Deferred<AttachResult>
 let rotateDeferred: Deferred<void>
+let runtimeCall: Mock<(request: RuntimeCallRequest) => Promise<unknown>>
 let container: HTMLDivElement
 let root: Root
 let latest: ReturnType<typeof useEmulatorPaneSession> | null = null
@@ -108,6 +109,23 @@ async function flushEffects(): Promise<void> {
   })
 }
 
+function readRotateOrientations(calls: RuntimeCallRequest[][]): string[] {
+  return calls
+    .filter(([request]) => request.method === 'emulator.rotate')
+    .map(([request]) => {
+      const params = request.params
+      if (
+        !params ||
+        typeof params !== 'object' ||
+        !('orientation' in params) ||
+        typeof params.orientation !== 'string'
+      ) {
+        throw new Error('Expected emulator.rotate orientation')
+      }
+      return params.orientation
+    })
+}
+
 describe('useEmulatorPaneSession', () => {
   beforeEach(() => {
     ;(
@@ -124,25 +142,26 @@ describe('useEmulatorPaneSession', () => {
       wsUrl: 'ws://127.0.0.1:3100/ws'
     })
     useAppStore.setState({ settings: null })
+    runtimeCall = vi.fn(async ({ method }: RuntimeCallRequest) => {
+      if (method === 'emulator.listDevices') {
+        return runtimeSuccess(deviceList)
+      }
+      if (method === 'emulator.attach') {
+        return runtimeSuccess(await attachDeferred.promise)
+      }
+      if (method === 'emulator.rotate') {
+        return runtimeSuccess(await rotateDeferred.promise)
+      }
+      if (method === 'emulator.shutdown') {
+        return runtimeSuccess({ deviceUdid: 'device-b' })
+      }
+      throw new Error(`Unexpected RPC method: ${method}`)
+    })
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
         runtime: {
-          call: vi.fn(async ({ method }: RuntimeCallRequest) => {
-            if (method === 'emulator.listDevices') {
-              return runtimeSuccess(deviceList)
-            }
-            if (method === 'emulator.attach') {
-              return runtimeSuccess(await attachDeferred.promise)
-            }
-            if (method === 'emulator.rotate') {
-              return runtimeSuccess(await rotateDeferred.promise)
-            }
-            if (method === 'emulator.shutdown') {
-              return runtimeSuccess({ deviceUdid: 'device-b' })
-            }
-            throw new Error(`Unexpected RPC method: ${method}`)
-          })
+          call: runtimeCall
         }
       }
     })
@@ -239,8 +258,59 @@ describe('useEmulatorPaneSession', () => {
       await attachDeferred.promise
       await Promise.resolve()
     })
-
     expect(latest?.visualOrientation).toBe('portrait')
+  })
+
+  it('alternates legacy no-argument rotation between portrait and landscape', async () => {
+    await act(async () => {
+      root.render(<Probe />)
+    })
+    await flushEffects()
+
+    for (let index = 0; index < 3; index += 1) {
+      let rotatePromise: Promise<void> = Promise.resolve()
+      await act(async () => {
+        rotatePromise = latest?.sendRotate() ?? Promise.resolve()
+        await Promise.resolve()
+      })
+      await act(async () => {
+        rotateDeferred.resolve()
+        await rotatePromise
+        await Promise.resolve()
+      })
+    }
+
+    expect(readRotateOrientations(runtimeCall.mock.calls)).toEqual([
+      'landscape_left',
+      'portrait',
+      'landscape_left'
+    ])
+  })
+
+  it('keeps explicit directional rotation on the four-position sequence', async () => {
+    await act(async () => {
+      root.render(<Probe />)
+    })
+    await flushEffects()
+
+    for (const direction of ['left', 'left', 'left'] as const) {
+      let rotatePromise: Promise<void> = Promise.resolve()
+      await act(async () => {
+        rotatePromise = latest?.sendRotate(direction) ?? Promise.resolve()
+        await Promise.resolve()
+      })
+      await act(async () => {
+        rotateDeferred.resolve()
+        await rotatePromise
+        await Promise.resolve()
+      })
+    }
+
+    expect(readRotateOrientations(runtimeCall.mock.calls)).toEqual([
+      'landscape_left',
+      'portrait_upside_down',
+      'landscape_right'
+    ])
   })
 
   it('keeps simulator discovery setup errors during auto attach', async () => {

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-session.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-session.ts
@@ -4,11 +4,9 @@ import { useAppStore } from '@/store'
 import {
   deviceLabel,
   simulatorPreviewStreamUrl,
-  type EmulatorPaneSession,
-  type SimulatorDeviceRow
+  type EmulatorPaneSession
 } from './emulator-pane-types'
 import { markSimulatorDeviceBooted, markSimulatorDeviceShutdown } from './emulator-device-state'
-import { toSimulatorDeviceRows, type RawEmulatorDevice } from './emulator-device-row-mapping'
 import { useEmulatorPaneControls } from './use-emulator-pane-controls'
 import { useEmulatorPaneSessionEvents } from './use-emulator-pane-session-events'
 import {
@@ -22,6 +20,7 @@ import { buildEmulatorPaneSessionView } from './emulator-pane-session-view'
 import { resolveEmulatorAttachTarget } from './emulator-attach-target'
 import { useEmulatorPaneLifecycle } from './use-emulator-pane-lifecycle'
 import { useEmulatorPaneShutdown } from './use-emulator-pane-shutdown'
+import { useEmulatorDeviceInventory } from './use-emulator-device-inventory'
 import { emulatorPaneErrorMessage } from './emulator-pane-error-message'
 
 type UseEmulatorPaneSessionArgs = {
@@ -35,7 +34,6 @@ export function useEmulatorPaneSession({
   tabId,
   autoAttachOnMount
 }: UseEmulatorPaneSessionArgs) {
-  const [devices, setDevices] = useState<SimulatorDeviceRow[]>([])
   const configuredDefaultUdid = useAppStore(
     (state) => state.settings?.mobileEmulatorDefaultDeviceUdid ?? null
   )
@@ -57,47 +55,36 @@ export function useEmulatorPaneSession({
   const [streamKey, setStreamKey] = useState<string | null>(prelaunchedState.streamKey)
   const mountedRef = useRef(true)
   const liveTargetRef = useRef<string | null>(prelaunchedState.liveTarget)
-  const deviceRefreshErrorRef = useRef<unknown>(null)
   const suppressAutoAttachRef = useRef(false)
+  const { devices, setDevices, deviceRefreshErrorRef, refreshDevices } = useEmulatorDeviceInventory(
+    { mountedRef, setError }
+  )
   const refreshStreamKey = useCallback(() => setStreamKey(String(Date.now())), [])
+  const onControlError = useCallback((controlError: unknown) => {
+    if (mountedRef.current) {
+      setError(emulatorPaneErrorMessage(controlError, 'Could not control emulator.'))
+    }
+  }, [])
+  const onControlSuccess = useCallback(() => {
+    if (mountedRef.current) {
+      setError(null)
+    }
+  }, [])
   const {
     sendTap,
     sendButton,
     sendGesture,
     sendRotate,
+    sendPosture,
     visualOrientation,
+    displayCommandPending,
     resetVisualOrientation
-  } = useEmulatorPaneControls(worktreeId, refreshStreamKey)
-
-  const refreshDevices = useCallback(async (bootedTarget?: string | null) => {
-    try {
-      // Unified list so Android devices/AVDs appear alongside iOS simulators.
-      const raw = (await callRuntimeRpc(
-        { kind: 'local' },
-        'emulator.listDevices',
-        {}
-      )) as RawEmulatorDevice[]
-      const list = toSimulatorDeviceRows(raw)
-      const next = markSimulatorDeviceBooted(list, bootedTarget)
-      if (!mountedRef.current) {
-        return next
-      }
-      const hadRefreshError = deviceRefreshErrorRef.current !== null
-      deviceRefreshErrorRef.current = null
-      setDevices(next)
-      if (hadRefreshError) {
-        setError(null)
-      }
-      return next
-    } catch (error) {
-      deviceRefreshErrorRef.current = error
-      if (mountedRef.current) {
-        setDevices([])
-        setError(emulatorPaneErrorMessage(error, 'Could not list emulator devices.'))
-      }
-      return []
-    }
-  }, [])
+  } = useEmulatorPaneControls({
+    worktreeId,
+    onControlError,
+    onControlSuccess,
+    onDisplaySettled: refreshStreamKey
+  })
 
   const applySession = useCallback(
     (info: EmulatorPaneSession['info'], attached = true, deviceRows = devices) => {
@@ -132,7 +119,7 @@ export function useEmulatorPaneSession({
         useAppStore.getState().setTabLabel(tabId, displayName)
       }
     },
-    [devices, resetVisualOrientation, tabId]
+    [devices, resetVisualOrientation, setDevices, tabId]
   )
 
   const clearSessionAfterShutdown = useCallback(
@@ -154,7 +141,7 @@ export function useEmulatorPaneSession({
         useAppStore.getState().setTabLabel(tabId, row?.name || 'Mobile Emulator')
       }
     },
-    [devices, resetVisualOrientation, selectedUdid, session, tabId]
+    [devices, resetVisualOrientation, selectedUdid, session, setDevices, tabId]
   )
 
   const attach = useCallback(
@@ -243,11 +230,13 @@ export function useEmulatorPaneSession({
     [
       applySession,
       configuredDefaultUdid,
+      deviceRefreshErrorRef,
       devices,
       loading,
       refreshDevices,
       resetVisualOrientation,
       selectedUdid,
+      setDevices,
       tabId,
       worktreeId
     ]
@@ -310,6 +299,8 @@ export function useEmulatorPaneSession({
     sendButton,
     sendGesture,
     sendRotate,
+    sendPosture,
+    displayCommandPending,
     visualOrientation,
     displayName: view.displayName,
     previewUrl: view.previewUrl,

--- a/src/renderer/src/components/emulator-pane/use-emulator-pane-zoom.test.tsx
+++ b/src/renderer/src/components/emulator-pane/use-emulator-pane-zoom.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useEmulatorPaneZoom } from './emulator-pane-zoom'
+
+describe('useEmulatorPaneZoom', () => {
+  it('keeps zoom across stream metrics updates and resets only for a new device', () => {
+    const view = renderHook(({ deviceId }) => useEmulatorPaneZoom(deviceId), {
+      initialProps: { deviceId: 'phone-1' }
+    })
+    const metrics = { fitScale: 0.4, fitDisplayScale: 0.3 }
+
+    act(() => view.result.current.setMetrics(metrics))
+    act(() => view.result.current.zoom('in'))
+    expect(view.result.current).toMatchObject({
+      state: { mode: 'fixed', scale: 0.5 },
+      percentage: 50
+    })
+
+    act(() => view.result.current.setMetrics({ ...metrics }))
+    expect(view.result.current.state).toEqual({ mode: 'fixed', scale: 0.5 })
+
+    view.rerender({ deviceId: 'phone-2' })
+    expect(view.result.current).toMatchObject({
+      state: { mode: 'fit' },
+      percentage: 100,
+      availability: { in: false, out: false, actual: false, fit: false, 'fit-display': false }
+    })
+  })
+})

--- a/src/renderer/src/components/emulator-pane/use-emulator-video-stream.ts
+++ b/src/renderer/src/components/emulator-pane/use-emulator-video-stream.ts
@@ -35,27 +35,40 @@ function newVideoStreamId(): string {
   return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`
 }
 
+function scheduleFirstFrameTimeout(onTimeout: () => void): ReturnType<typeof setTimeout> {
+  return setTimeout(onTimeout, 10_000)
+}
+
 export function useEmulatorVideoStream(
   deviceId: string | undefined,
   streamKey: string | undefined,
   enabled: boolean,
-  onSize?: (size: StreamSize) => void
-): { canvasRef: React.RefObject<HTMLCanvasElement | null>; error: string | null } {
+  onSize?: (size: StreamSize) => void,
+  onScreenshotCanvasChange?: (canvas: HTMLCanvasElement | null) => void
+): {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>
+  error: string | null
+} {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [error, setError] = useState<string | null>(null)
   const onSizeRef = useRef(onSize)
+  const onScreenshotCanvasChangeRef = useRef(onScreenshotCanvasChange)
   onSizeRef.current = onSize
+  onScreenshotCanvasChangeRef.current = onScreenshotCanvasChange
 
   useEffect(() => {
     const api = (window as { api?: { emulator?: EmulatorVideoApi } }).api?.emulator
     if (!enabled || !deviceId) {
       setError(null)
+      onScreenshotCanvasChangeRef.current?.(null)
       return
     }
     if (!api?.startVideoStream) {
+      onScreenshotCanvasChangeRef.current?.(null)
       return
     }
     setError(null)
+    onScreenshotCanvasChangeRef.current?.(null)
     const DecoderCtor = (globalThis as { VideoDecoder?: typeof VideoDecoder }).VideoDecoder
     const ChunkCtor = (globalThis as { EncodedVideoChunk?: typeof EncodedVideoChunk })
       .EncodedVideoChunk
@@ -66,6 +79,7 @@ export function useEmulatorVideoStream(
 
     let disposed = false
     let configured = false
+    let screenshotCanvasPublished = false
     let timestamp = 0
     let configBytes: Uint8Array | null = null
     const currentStreamId = newVideoStreamId()
@@ -79,6 +93,15 @@ export function useEmulatorVideoStream(
       context?.clearRect(0, 0, canvas.width, canvas.height)
     }
 
+    let firstFrameTimeout: ReturnType<typeof setTimeout> | null = null
+
+    const clearFirstFrameTimeout = (): void => {
+      if (firstFrameTimeout) {
+        clearTimeout(firstFrameTimeout)
+        firstFrameTimeout = null
+      }
+    }
+
     const decoder = new DecoderCtor({
       output: (frame) => {
         if (!disposed && ctx && canvas) {
@@ -89,23 +112,20 @@ export function useEmulatorVideoStream(
             canvas.width = frame.displayWidth
             canvas.height = frame.displayHeight
           }
-          ctx.drawImage(frame, 0, 0)
+          try {
+            ctx.drawImage(frame, 0, 0)
+            if (!screenshotCanvasPublished) {
+              screenshotCanvasPublished = true
+              onScreenshotCanvasChangeRef.current?.(canvas)
+            }
+          } catch (error) {
+            fatal(error instanceof Error ? error.message : 'Failed to draw an Android video frame.')
+          }
         }
         frame.close()
       },
       error: (err) => fatal(err.message)
     })
-
-    let firstFrameTimeout: ReturnType<typeof setTimeout> | null = setTimeout(() => {
-      fatal('Android video stream did not deliver a frame.')
-    }, 10_000)
-
-    const clearFirstFrameTimeout = (): void => {
-      if (firstFrameTimeout) {
-        clearTimeout(firstFrameTimeout)
-        firstFrameTimeout = null
-      }
-    }
 
     const stopStream = (): void => {
       if (streamId) {
@@ -125,6 +145,7 @@ export function useEmulatorVideoStream(
       unsubMeta = undefined
       unsubFrame = undefined
       stopStream()
+      onScreenshotCanvasChangeRef.current?.(null)
       if (decoder.state !== 'closed') {
         decoder.close()
       }
@@ -137,6 +158,9 @@ export function useEmulatorVideoStream(
       setError(message)
       cleanup()
     }
+    firstFrameTimeout = scheduleFirstFrameTimeout(() => {
+      fatal('Android video stream did not deliver a frame.')
+    })
 
     unsubMeta = api.onVideoStreamMeta?.((msg) => {
       if (!disposed && msg.streamId === streamId && msg.deviceId === deviceId) {
@@ -166,10 +190,7 @@ export function useEmulatorVideoStream(
         configBytes = data
         return
       }
-      if (!configured) {
-        return
-      }
-      if (decoder.state === 'closed') {
+      if (!configured || decoder.state === 'closed') {
         return
       }
       let chunkData = data

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14311,7 +14311,31 @@
       "emulator": {
         "pane": {
           "EmulatorPane": {
-            "59b08fa031": "No emulator connected"
+            "59b08fa031": "No emulator connected",
+            "savedScreenshot": "Saved emulator screenshot",
+            "saveScreenshotFailed": "Could not save emulator screenshot"
+          },
+          "androidToolbar": {
+            "Power": "Power",
+            "Volume Up": "Volume Up",
+            "Volume Down": "Volume Down",
+            "Rotate Left": "Rotate Left",
+            "Rotate Right": "Rotate Right",
+            "Take Screenshot": "Take Screenshot",
+            "Zoom": "Zoom",
+            "Back": "Back",
+            "Home": "Home",
+            "Overview": "Overview",
+            "Fold": "Fold",
+            "Unfold": "Unfold",
+            "Button 1": "Button 1",
+            "Button 2": "Button 2",
+            "More": "More",
+            "Zoom In": "Zoom In",
+            "Zoom Out": "Zoom Out",
+            "Zoom to Actual Size (100%)": "Zoom to Actual Size (100%)",
+            "Zoom to Fit in Window": "Zoom to Fit in Window",
+            "Zoom to Fit Display in Window": "Zoom to Fit Display in Window"
           },
           "emulator": {
             "device": {

--- a/src/renderer/src/lib/canvas-png-data-url.ts
+++ b/src/renderer/src/lib/canvas-png-data-url.ts
@@ -1,0 +1,18 @@
+export function canvasToPngDataUrl(canvas: HTMLCanvasElement): Promise<string> {
+  const { promise, resolve, reject } = Promise.withResolvers<string>()
+  canvas.toBlob((blob) => {
+    if (!blob) {
+      try {
+        resolve(canvas.toDataURL('image/png'))
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error('PNG canvas encoding failed'))
+      }
+      return
+    }
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(reader.error ?? new Error('PNG blob reading failed'))
+    reader.readAsDataURL(blob)
+  }, 'image/png')
+  return promise
+}

--- a/src/shared/emulator-device-controls.ts
+++ b/src/shared/emulator-device-controls.ts
@@ -1,0 +1,15 @@
+export type EmulatorPosture = 'folded' | 'unfolded'
+
+export type EmulatorButtonOptions = {
+  longPress?: boolean
+}
+
+export type EmulatorDeviceControlCapabilities = {
+  shutdown: boolean
+  power: boolean
+  volume: boolean
+  overview: boolean
+  foldable: boolean
+  wearButton1: boolean
+  wearButton2: boolean
+}


### PR DESCRIPTION
## ELI5

The embedded Android emulator now has the everyday controls people expect from the standalone emulator, without confusing Android Power with shutting down the AVD.

## What Changed

- Added an Android-specific responsive toolbar with Power, volume, rotate-left/right, screenshot, zoom, Back, Home, and Overview controls.
- Kept Back, Home, and Overview visible in narrow panes and moved lower-frequency actions into More.
- Added capability-gated Fold/Unfold and Wear buttons, while keeping emulator shutdown as a separate lifecycle action.
- Added host-to-renderer capability metadata, Power long-press, posture commands, PNG screenshot saving, centered zoom, and focused tests.

## Why

Basic Android emulator use previously required CLI commands or the standalone Android Emulator window. The embedded pane should provide the same everyday controls without overloading Android Power as AVD shutdown.

## Linked Issue

Fixes #18452

## Visual Proof

| Before (`origin/main`) | After 1 | After 2 | After 3 |
| --- | --- | --- | --- |
| ![Android emulator toolbar before](https://github.com/ZiraiMode/orca/releases/download/android-emulator-controls-pr-assets/android-emulator-before-safe.png) | ![Android emulator toolbar after 1](https://github.com/ZiraiMode/orca/releases/download/android-emulator-controls-pr-assets/11.png) | ![Android emulator toolbar after 2](https://github.com/ZiraiMode/orca/releases/download/android-emulator-controls-pr-assets/22.png) | ![Android emulator toolbar after 3](https://github.com/ZiraiMode/orca/releases/download/android-emulator-controls-pr-assets/33.png) |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated
- macOS with the `Pixel_9_Pro` AVD: Back/Home/Overview, Power short/long press, volume, both rotation directions, screenshot save/cancel, zoom modes and centered scrolling, responsive overflow, and separate shutdown.
- Fold/Wear capability variants: covered by focused automated tests; no matching local AVD was available.
- Passed the focused emulator/runtime/renderer Vitest command.
- Passed `pnpm tc`.
- Passed `pnpm run check:code-quality:changed`.
- Passed localization catalog, extraction, and coverage verification.
- Passed `pnpm run build:electron-vite`.
- Passed `git diff --check origin/main...HEAD`.
- Full repository lint/test/build: covered by PR CI.
- Linux/Windows/SSH were not manually exercised. Device control stays on the existing emulator runtime boundary; new inventory fields are optional so older consumers ignore them and missing fields use conservative UI fallbacks.

## AI Disclosure

## Review

Self-reviewed the Power-versus-shutdown separation, capability fallbacks, ADB argument construction, renderer frame hot path, cross-platform paths, mixed-version optional fields, and performance.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

No repository assets were added for visual proof.

## Checklist

- [ ] This PR is small and focused — it is focused on #18452, but the end-to-end runtime/UI/test change is not small
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots are included
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Local focused checks pass; full `pnpm lint`, `pnpm test`, and `pnpm build` are covered by CI
