### PR TITLE
fix(automations): wait for process exit and final capture before completion

### DIFF
--- a/src/main/automations/automation-final-settlement.test.ts
+++ b/src/main/automations/automation-final-settlement.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type {
+  Automation,
+  AutomationDispatchResult,
+  AutomationRun
+} from '../../shared/automations-types'
+import { AutomationService } from './service'
+import { createRuntimeAutomationRunTerminalObserver } from './runtime-terminal-run-observer'
+import type { AutomationRunTerminalHost } from './runtime-terminal-run-observer'
+
+const FINAL = 'CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14\nSTATUS: DONE'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+
+function fixture() {
+  let run = {
+    id: 'ad7d4a06-af46-4d55-ad59-0126cc32c1e1',
+    automationId: 'health-watch',
+    status: 'dispatching',
+    reuseSession: false,
+    workspaceId: 'folder:health',
+    terminalSessionId: 'tab-health',
+    terminalPaneKey: 'tab-health:11111111-2222-4333-8444-555555555555',
+    terminalPtyId: 'term_1f32446b-e714-408e-af14-5b346d7e6e2d',
+    outputSnapshot: null,
+    usage: { status: 'unavailable' }
+  } as AutomationRun
+  const automation = { id: run.automationId, reuseSession: false } as Automation
+  const published: AutomationRun[] = []
+  const exit = deferred<Awaited<ReturnType<AutomationRunTerminalHost['waitForTerminal']>>>()
+  const capture = deferred<{ tail: string[] }>()
+  const runtime = {
+    subscribeToPtyExit: vi.fn(() => () => {}),
+    resolveTerminalPane: () => ({ handle: 'terminal-health', ptyId: run.terminalPtyId }),
+    // A startup-only done is already present; the process has not exited.
+    waitForTerminal: vi.fn((_handle, options) =>
+      options?.condition === 'exit' ? exit.promise : Promise.resolve({ satisfied: true })
+    ),
+    readTerminal: vi.fn(() => capture.promise)
+  } satisfies AutomationRunTerminalHost
+  const store = {
+    listAutomations: () => [automation],
+    listAutomationRuns: () => [run],
+    updateAutomationRun: (result: AutomationDispatchResult) => {
+      run = { ...run, ...result }
+      return run
+    },
+    automationChangeSelector: () => ({ kind: 'self' })
+  } as unknown as Store
+  const service = new AutomationService(store, {
+    terminalObserver: createRuntimeAutomationRunTerminalObserver(runtime),
+    onAutomationsChanged: () => published.push(structuredClone(run))
+  })
+  return { service, runtime, exit, capture, published, automation, run: () => run }
+}
+
+describe('automation final settlement (ROB-1925)', () => {
+  it('rejects startup completion while live and publishes final capture with cleared identity', async () => {
+    const f = fixture()
+    try {
+      await f.service.markDispatchResult({ runId: f.run().id, status: 'dispatched' })
+      await f.service.markDispatchResult({
+        runId: f.run().id,
+        status: 'completed',
+        outputSnapshot: {
+          format: 'plain_text',
+          content: 'echoed prompt fragments',
+          capturedAt: 5_000,
+          truncated: false
+        }
+      })
+      expect(f.run().status).toBe('dispatched')
+      expect(f.published.some((run) => run.status === 'completed')).toBe(false)
+      expect(f.runtime.readTerminal).not.toHaveBeenCalled()
+
+      f.exit.resolve({ satisfied: true, exitCode: 0 })
+      await vi.waitFor(() => expect(f.runtime.readTerminal).toHaveBeenCalledOnce())
+      expect(f.run().status).toBe('dispatched')
+      f.capture.resolve({ tail: [FINAL] })
+      await vi.waitFor(() => expect(f.run().status).toBe('completed'))
+      expect(f.run()).toMatchObject({
+        terminalSessionId: null,
+        terminalPaneKey: null,
+        terminalPtyId: null,
+        outputSnapshot: { content: FINAL, truncated: false }
+      })
+      expect(f.published.filter((run) => run.status === 'completed')).toEqual([f.run()])
+      // A delayed old-client completion must not replace the authoritative final.
+      await f.service.markDispatchResult({
+        runId: f.run().id,
+        status: 'completed',
+        outputSnapshot: null
+      })
+      expect(f.run().outputSnapshot?.content).toBe(FINAL)
+    } finally {
+      f.service.stop()
+    }
+  })
+
+  it('does not weaken the active run exit fence when session reuse is enabled later', async () => {
+    const f = fixture()
+    try {
+      await f.service.markDispatchResult({ runId: f.run().id, status: 'dispatched' })
+      f.automation.reuseSession = true
+      await f.service.markDispatchResult({ runId: f.run().id, status: 'completed' })
+      expect(f.run().status).toBe('dispatched')
+    } finally {
+      f.service.stop()
+    }
+  })
+
+  it('does not publish a capture that resolves after the watcher is stopped', async () => {
+    const f = fixture()
+    await f.service.markDispatchResult({ runId: f.run().id, status: 'dispatched' })
+    f.exit.resolve({ satisfied: true, exitCode: 0 })
+    await vi.waitFor(() => expect(f.runtime.readTerminal).toHaveBeenCalledOnce())
+    f.service.stop()
+    f.capture.resolve({ tail: [FINAL] })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(f.run().status).toBe('dispatched')
+    expect(f.published.some((run) => run.status === 'completed')).toBe(false)
+  })
+
+  it.each([-1, undefined])(
+    'does not interpret remote exit code %s as success',
+    async (exitCode) => {
+      const f = fixture()
+      try {
+        await f.service.markDispatchResult({ runId: f.run().id, status: 'dispatched' })
+        f.exit.resolve({ satisfied: true, exitCode })
+        f.capture.resolve({ tail: ['partial work'] })
+        await vi.waitFor(() => expect(f.run().status).toBe('dispatch_failed'))
+        expect(f.run().error).not.toMatch(/exited with code/)
+        expect(f.published.some((run) => run.status === 'completed')).toBe(false)
+        expect(f.run().terminalPtyId).not.toBeNull()
+      } finally {
+        f.service.stop()
+      }
+    }
+  )
+
+  it('cannot complete when the final capture fails after proven exit', async () => {
+    const f = fixture()
+    try {
+      await f.service.markDispatchResult({ runId: f.run().id, status: 'dispatched' })
+      f.exit.resolve({ satisfied: true, exitCode: 0 })
+      await vi.waitFor(() => expect(f.runtime.readTerminal).toHaveBeenCalledOnce())
+      f.capture.reject(new Error('remote capture unavailable'))
+      await vi.waitFor(() => expect(f.run().status).toBe('dispatch_failed'))
+      expect(f.published.some((run) => run.status === 'completed')).toBe(false)
+    } finally {
+      f.service.stop()
+    }
+  })
+})

--- a/src/main/automations/automation-final-settlement.test.ts
+++ b/src/main/automations/automation-final-settlement.test.ts
@@ -64,6 +64,52 @@ function fixture() {
 }
 
 describe('automation final settlement (ROB-1925)', () => {
+  it.each([false, true])(
+    'reconciles a fresh missing terminal after dispatch (pane returns: %s)',
+    async (paneReturns) => {
+      vi.useFakeTimers()
+      const f = fixture()
+      const resolvePane = vi.spyOn(f.runtime, 'resolveTerminalPane').mockImplementation(() => {
+        throw new Error('terminal_not_found')
+      })
+      try {
+        f.service.setRendererReady()
+        await vi.advanceTimersByTimeAsync(10 * 60_000)
+        await f.service.markDispatchResult({ runId: f.run().id, status: 'dispatched' })
+        await f.service.markDispatchResult({ runId: f.run().id, status: 'completed' })
+        await vi.advanceTimersByTimeAsync(5_000)
+        expect(f.run().status).toBe('dispatched')
+        expect(f.runtime.waitForTerminal).not.toHaveBeenCalled()
+
+        if (paneReturns) {
+          resolvePane.mockRestore()
+          await vi.advanceTimersByTimeAsync(2_000)
+          expect(f.runtime.waitForTerminal).toHaveBeenCalledOnce()
+          f.exit.resolve({ satisfied: true, exitCode: 0 })
+          f.capture.resolve({ tail: [FINAL] })
+        }
+        await vi.advanceTimersByTimeAsync(2 * 60_000)
+        expect(f.run().status).toBe(paneReturns ? 'completed' : 'dispatch_failed')
+        if (paneReturns) {
+          expect(f.run()).toMatchObject({
+            terminalPtyId: null,
+            outputSnapshot: { content: FINAL }
+          })
+        } else {
+          expect(f.run().error).toBe(
+            'Orca lost the terminal for this run before it reported completion.'
+          )
+          expect(f.run().terminalPtyId).not.toBeNull()
+          expect(f.published.some((run) => run.status === 'completed')).toBe(false)
+        }
+      } finally {
+        f.service.stop()
+        resolvePane.mockRestore()
+        vi.useRealTimers()
+      }
+    }
+  )
+
   it('rejects startup completion while live and publishes final capture with cleared identity', async () => {
     const f = fixture()
     try {

--- a/src/main/automations/retained-run-reconciliation.test.ts
+++ b/src/main/automations/retained-run-reconciliation.test.ts
@@ -201,6 +201,8 @@ describe('reconciling retained runs against a graph that has not published yet',
       ...LAUNCH_TARGET,
       error: null
     })
+    expect(readRun(store, automation.id, retained.id).status).toBe('dispatched')
+    surface.settleObservation({ status: 'completed', error: null })
     await vi.advanceTimersByTimeAsync(AFTER_SETTLE_MS)
 
     expect(transitions).toEqual(['completed'])

--- a/src/main/automations/retained-run-reconciliation.ts
+++ b/src/main/automations/retained-run-reconciliation.ts
@@ -1,6 +1,6 @@
 import type { AutomationRun } from '../../shared/automations-types'
 
-/** Cadence for re-checking a retained run whose pane has not remounted yet. */
+/** Cadence for re-checking a run whose pane has not mounted yet. */
 const RETRY_INTERVAL_MS = 2_000
 /** Grace after the terminal surface reports ready before an unresolvable run is
  *  called lost. Covers restored-pane remount and SSH/WSL reattach, and matches
@@ -16,7 +16,7 @@ export type RetainedRunReconcilerDeps = {
 }
 
 /**
- * Startup reconciliation of retained non-terminal runs.
+ * Reconciliation of non-terminal runs awaiting an observable pane.
  *
  * Why staged rather than one synchronous pass: at authority startup no window
  * graph has published yet, so "this pane has no terminal" means "not known yet",
@@ -26,7 +26,7 @@ export type RetainedRunReconcilerDeps = {
  */
 export class RetainedRunReconciler {
   private readonly deps: RetainedRunReconcilerDeps
-  private readonly pending = new Map<string, AutomationRun>()
+  private readonly pending = new Map<string, { run: AutomationRun; stagedAt: number }>()
   private timer: ReturnType<typeof setInterval> | null = null
   private surfaceReadyAt: number | null = null
   private disposed = false
@@ -41,7 +41,10 @@ export class RetainedRunReconciler {
     }
     for (const run of runs) {
       if (!this.deps.attach(run)) {
-        this.pending.set(run.id, run)
+        this.pending.set(run.id, {
+          run,
+          stagedAt: this.pending.get(run.id)?.stagedAt ?? Date.now()
+        })
       }
     }
     this.sweep()
@@ -63,14 +66,18 @@ export class RetainedRunReconciler {
   }
 
   private sweep(): void {
-    const strandAt = this.surfaceReadyAt === null ? null : this.surfaceReadyAt + SURFACE_SETTLE_MS
     // Deleting the current entry mid-iteration is defined for Map; nothing here
     // re-enters the reconciler, so no snapshot is needed.
-    for (const [runId, run] of this.pending) {
+    for (const [runId, { run, stagedAt }] of this.pending) {
       if (!this.deps.stillRetained(run) || this.deps.attach(run)) {
         this.pending.delete(runId)
         continue
       }
+      // A fresh dispatch gets its own grace even when the surface has long been ready.
+      const strandAt =
+        this.surfaceReadyAt === null
+          ? null
+          : Math.max(this.surfaceReadyAt, stagedAt) + SURFACE_SETTLE_MS
       if (strandAt !== null && Date.now() >= strandAt) {
         this.pending.delete(runId)
         this.deps.strand(run)

--- a/src/main/automations/run-completion-watcher.test.ts
+++ b/src/main/automations/run-completion-watcher.test.ts
@@ -234,7 +234,7 @@ describe('authority-owned automation run completion', () => {
     service.stop()
   })
 
-  it('persists the terminal status once when the renderer wins the race', async () => {
+  it('defers a renderer completion to the authority exit observation', async () => {
     const store = await createStore()
     const automation = createAutomation(store)
     let resolveObservation: ((value: AutomationRunCompletionObservation) => void) | null = null
@@ -258,18 +258,14 @@ describe('authority-owned automation run completion', () => {
       ...LAUNCH_TARGET,
       error: null
     })
-    const afterRenderer = readRun(store, automation.id, run.id)
-    const writeSpy = vi.spyOn(store, 'updateAutomationRun')
+    expect(readRun(store, automation.id, run.id).status).toBe('dispatched')
 
     resolveObservation!({ status: 'dispatch_failed', error: 'watcher lost the terminal' })
     await new Promise((resolve) => setTimeout(resolve, 0))
     await new Promise((resolve) => setTimeout(resolve, 0))
-    expect(writeSpy).not.toHaveBeenCalled()
     const afterWatcher = readRun(store, automation.id, run.id)
-    expect(afterWatcher.status).toBe('completed')
-    expect(afterWatcher.error).toBeNull()
-    expect(afterWatcher.usage).toEqual(afterRenderer.usage)
-    writeSpy.mockRestore()
+    expect(afterWatcher.status).toBe('dispatch_failed')
+    expect(afterWatcher.error).toBe('watcher lost the terminal')
     service.stop()
   })
 

--- a/src/main/automations/run-completion-watcher.ts
+++ b/src/main/automations/run-completion-watcher.ts
@@ -5,6 +5,7 @@ import {
   type AutomationRunOutputSnapshot
 } from '../../shared/automations-types'
 import { RetainedRunReconciler } from './retained-run-reconciliation'
+import type { Store } from '../persistence'
 
 export type AutomationRunCompletionObservation = {
   status: 'completed' | 'dispatch_failed'
@@ -18,7 +19,7 @@ export type AutomationRunTerminalObserver = {
   resolveRunTerminal: (run: AutomationRun) => string | null
   observeCompletion: (
     handle: string,
-    options: { signal: AbortSignal }
+    options: { signal: AbortSignal; terminalPtyId?: string | null }
   ) => Promise<AutomationRunCompletionObservation>
 }
 
@@ -83,6 +84,19 @@ export class AutomationRunCompletionWatcher {
     }
   }
 
+  deferReportedCompletion(runId: string, store: Store): AutomationRun | null {
+    const run = store.listAutomationRuns().find((entry) => entry.id === runId)
+    const automation = store.listAutomations().find((entry) => entry.id === run?.automationId)
+    // Reused sessions are borrowed across turns; fresh runs own their process through exit.
+    if (!run || (run.reuseSession ?? automation?.reuseSession)) {
+      return null
+    }
+    if (!isFinalAutomationRunStatus(run.status)) {
+      this.watch(run)
+    }
+    return run
+  }
+
   private attachRetainedRun(run: AutomationRun): boolean {
     if (this.disposed) {
       return false
@@ -115,12 +129,18 @@ export class AutomationRunCompletionWatcher {
   ): Promise<void> {
     let observation: AutomationRunCompletionObservation
     try {
-      observation = await this.observer.observeCompletion(handle, { signal: controller.signal })
+      observation = await this.observer.observeCompletion(handle, {
+        signal: controller.signal,
+        terminalPtyId: run.terminalPtyId
+      })
     } catch (error) {
       if (controller.signal.aborted) {
         return
       }
       observation = { status: 'dispatch_failed', error: describeObservationError(error) }
+    }
+    if (controller.signal.aborted) {
+      return
     }
     try {
       await this.finalize(run, observation)
@@ -172,9 +192,9 @@ export class AutomationRunCompletionWatcher {
       runId: run.id,
       status: observation.status,
       workspaceId: current.workspaceId,
-      terminalSessionId: current.terminalSessionId,
-      terminalPaneKey: current.terminalPaneKey,
-      terminalPtyId: current.terminalPtyId,
+      terminalSessionId: observation.status === 'completed' ? null : current.terminalSessionId,
+      terminalPaneKey: observation.status === 'completed' ? null : current.terminalPaneKey,
+      terminalPtyId: observation.status === 'completed' ? null : current.terminalPtyId,
       outputSnapshot: observation.outputSnapshot ?? null,
       error: observation.error ?? null
     })

--- a/src/main/automations/run-completion-watcher.ts
+++ b/src/main/automations/run-completion-watcher.ts
@@ -72,16 +72,12 @@ export class AutomationRunCompletionWatcher {
     })
   }
 
-  /** Observes a just-dispatched run. A run whose terminal is not resolvable yet
-   *  is left alone; startup reconciliation is what resolves stranded runs. */
+  /** Fresh runs use the same remount grace and recovery path as retained runs. */
   watch(run: AutomationRun): void {
-    if (this.disposed || this.watching.has(run.id)) {
+    if (this.disposed || this.watching.has(run.id) || isFinalAutomationRunStatus(run.status)) {
       return
     }
-    const handle = this.observer.resolveRunTerminal(run)
-    if (handle) {
-      this.startWatch(run, handle)
-    }
+    this.reconciler.reconcile([run])
   }
 
   deferReportedCompletion(runId: string, store: Store): AutomationRun | null {

--- a/src/main/automations/run-usage-collection.ts
+++ b/src/main/automations/run-usage-collection.ts
@@ -1,3 +1,5 @@
+import type { Store } from '../persistence'
+import type { AutomationRunWriter } from './automation-run-writer'
 import type { Automation, AutomationRun, AutomationRunUsage } from '../../shared/automations-types'
 import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
@@ -96,4 +98,42 @@ export async function collectAutomationRunUsage({
     })
   }
   return unavailable(null, 'provider_unsupported', 'This agent does not report usage to Orca yet.')
+}
+
+export async function persistAutomationRunUsage({
+  store,
+  runs,
+  run,
+  priorSessionId,
+  claudeUsage,
+  codexUsage
+}: {
+  store: Store
+  runs: AutomationRunWriter
+  run: AutomationRun
+  priorSessionId: string | null | undefined
+  claudeUsage: ClaudeUsageStore | null
+  codexUsage: CodexUsageStore | null
+}): Promise<AutomationRun> {
+  // A repeated completion must not advance the usage attribution window.
+  if (run.usage) {
+    return run
+  }
+  const usage = await collectAutomationRunUsage({
+    automation: store.listAutomations().find((entry) => entry.id === run.automationId),
+    run: priorSessionId ? { ...run, terminalSessionId: priorSessionId } : run,
+    claudeUsage,
+    codexUsage
+  })
+  // Retention can remove the final run while usage collection is in flight.
+  const current = store.listAutomationRuns(run.automationId).find((entry) => entry.id === run.id)
+  if (!current) {
+    return run
+  }
+  return runs.updateRun({
+    runId: run.id,
+    status: current.status,
+    usage,
+    error: current.error
+  })
 }

--- a/src/main/automations/runtime-terminal-run-observer.test.ts
+++ b/src/main/automations/runtime-terminal-run-observer.test.ts
@@ -1,195 +1,114 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createRuntimeAutomationRunTerminalObserver } from './runtime-terminal-run-observer'
-import type { AutomationRunTerminalHost } from './runtime-terminal-run-observer'
-import type { AutomationRunCompletionObservation } from './run-completion-watcher'
+import { OrcaRuntimeService } from '../runtime/orca-runtime'
 
-const HANDLE = 'terminal-1'
-const RUNTIME_TUI_IDLE_TIMEOUT_MS = 5 * 60 * 1000
+const PTY_ID = 'pty-automation'
+const PANE_KEY = 'tab-automation:11111111-2222-4333-8444-555555555555'
+const FINAL = 'CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14\r\nSTATUS: DONE\r\n'
 
-/** The three shapes the runtime satisfies tui-idle from. `lastAgentStatus` is the
- *  sticky pty record, `paneTitle` the leaf branch's inlined title read, `preview`
- *  the ready-shell-prompt match. All three are level, none require an edge. */
-type FakePane = {
-  lastAgentStatus: 'idle' | 'working' | 'permission' | null
-  paneTitle: string | null
-  preview: string
-}
-
-type FakeWaiter = {
-  resolve: (value: { satisfied: boolean; blockedReason?: string }) => void
-  reject: (error: Error) => void
-  timer: ReturnType<typeof setTimeout>
-}
-
-function createFakeRuntime(initial: Partial<FakePane>) {
-  const pane: FakePane = {
-    lastAgentStatus: null,
-    paneTitle: null,
-    preview: '',
-    ...initial
-  }
-  const waiters = new Set<FakeWaiter>()
-  let waitCalls = 0
-
-  // Mirrors the runtime's tui-idle satisfaction: sticky status, idle title, or a
-  // ready shell prompt — whichever is true at the instant of the read.
-  const satisfiedNow = (): boolean =>
-    pane.lastAgentStatus === 'idle' ||
-    (pane.paneTitle?.toLowerCase().includes('idle') ?? false) ||
-    pane.preview.trimEnd().endsWith('$')
-
-  const runtime: AutomationRunTerminalHost & {
-    setPane: (next: Partial<FakePane>) => void
-    waitCalls: () => number
-  } = {
-    getTerminalHandleForPaneKey: () => HANDLE,
-    readTerminal: async () => ({ tail: ['previous run output'] }),
-    waitForTerminal: (_handle, options) => {
-      waitCalls += 1
-      if (options?.signal?.aborted) {
-        return Promise.reject(new Error('request_aborted'))
-      }
-      if (satisfiedNow()) {
-        return Promise.resolve({ satisfied: true })
-      }
-      return new Promise((resolve, reject) => {
-        const waiter: FakeWaiter = {
-          resolve,
-          reject,
-          timer: setTimeout(() => {
-            waiters.delete(waiter)
-            reject(new Error('timeout'))
-          }, options?.timeoutMs ?? RUNTIME_TUI_IDLE_TIMEOUT_MS)
-        }
-        waiters.add(waiter)
-      })
-    },
-    setPane: (next) => {
-      Object.assign(pane, next)
-      if (!satisfiedNow()) {
-        return
-      }
-      for (const waiter of waiters) {
-        waiters.delete(waiter)
-        clearTimeout(waiter.timer)
-        waiter.resolve({ satisfied: true })
-      }
-    },
-    waitCalls: () => waitCalls
-  }
-  return runtime
-}
-
-function observe(runtime: AutomationRunTerminalHost) {
-  const controller = new AbortController()
-  const settled: AutomationRunCompletionObservation[] = []
-  const errors: unknown[] = []
+function observe(connectionId: string | null = null) {
+  const runtime = new OrcaRuntimeService()
+  runtime.registerPty(PTY_ID, 'folder:automation', connectionId, {
+    tabId: 'tab-automation',
+    leafId: '11111111-2222-4333-8444-555555555555',
+    incarnationId: 'incarnation-automation'
+  })
   const observer = createRuntimeAutomationRunTerminalObserver(runtime)
-  const promise = observer
-    .observeCompletion(HANDLE, { signal: controller.signal })
-    .then((observation) => {
-      settled.push(observation)
-    })
-    .catch((error: unknown) => {
-      errors.push(error)
-    })
-  return { controller, settled, errors, promise }
+  const handle = observer.resolveRunTerminal({ terminalPaneKey: PANE_KEY } as never)!
+  expect(handle).toBeTruthy()
+  const controller = new AbortController()
+  const settled = vi.fn()
+  const promise = observer.observeCompletion(handle, {
+    signal: controller.signal,
+    terminalPtyId: PTY_ID
+  })
+  void promise.then(settled, () => {})
+  return { runtime, handle, controller, settled, promise }
 }
 
-describe('createRuntimeAutomationRunTerminalObserver', () => {
-  beforeEach(() => {
-    vi.useFakeTimers()
+describe('authority automation terminal exit observation', () => {
+  it.each([null, 'ssh-automation'])(
+    'waits for the owned %s process and captures before transcript retirement',
+    async (connectionId) => {
+      const run = observe(connectionId)
+      try {
+        run.runtime.onPtyData(PTY_ID, 'echoed prompt fragments\r\n', Date.now())
+        run.runtime.onPtyData(PTY_ID, '\x1b]0;Claude — idle\x07', Date.now())
+        await Promise.resolve()
+        expect(run.settled).not.toHaveBeenCalled()
+        run.runtime.onPtyData(PTY_ID, FINAL, Date.now())
+        run.runtime.onPtyExit(PTY_ID, 0, 'incarnation-automation')
+        const result = await run.promise
+        expect(result.status).toBe('completed')
+        expect(result.outputSnapshot?.content).toContain(FINAL.replaceAll('\r', '').trim())
+        // The runtime intentionally frees this transcript during the same exit callback.
+        expect((await run.runtime.readTerminal(run.handle)).tail).toEqual([])
+      } finally {
+        run.controller.abort()
+      }
+    }
+  )
+
+  it('rejects a stale incarnation exit while the owned process continues', async () => {
+    const run = observe()
+    run.runtime.onPtyExit(PTY_ID, 0, 'older-incarnation')
+    await Promise.resolve()
+    expect(run.settled).not.toHaveBeenCalled()
+    run.runtime.onPtyData(PTY_ID, FINAL, Date.now())
+    run.runtime.onPtyExit(PTY_ID, 0, 'incarnation-automation')
+    expect((await run.promise).status).toBe('completed')
   })
 
-  afterEach(() => {
-    vi.useRealTimers()
+  it('refuses a pane that now belongs to a different PTY', () => {
+    const runtime = new OrcaRuntimeService()
+    runtime.registerPty('replacement-pty', 'folder:automation', null, {
+      tabId: 'tab-automation',
+      leafId: '11111111-2222-4333-8444-555555555555',
+      incarnationId: 'replacement-incarnation'
+    })
+    const observer = createRuntimeAutomationRunTerminalObserver(runtime)
+    expect(
+      observer.resolveRunTerminal({
+        workspaceId: 'folder:automation',
+        terminalPaneKey: PANE_KEY,
+        terminalPtyId: PTY_ID
+      } as never)
+    ).toBeNull()
   })
 
-  it('does not complete a reused run from the previous run idle status', async () => {
-    const runtime = createFakeRuntime({ lastAgentStatus: 'idle' })
-    const run = observe(runtime)
-
-    await vi.advanceTimersByTimeAsync(10_000)
-    expect(run.settled).toEqual([])
-    expect(run.errors).toEqual([])
-
-    runtime.setPane({ lastAgentStatus: 'working' })
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled).toEqual([])
-
-    runtime.setPane({ lastAgentStatus: 'idle' })
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled[0]?.status).toBe('completed')
-    await run.promise
+  it('reports a real nonzero exit as failure with captured output', async () => {
+    const run = observe()
+    run.runtime.onPtyData(PTY_ID, 'launch failed\r\n', Date.now())
+    run.runtime.onPtyExit(PTY_ID, 9, 'incarnation-automation')
+    await expect(run.promise).resolves.toMatchObject({
+      status: 'dispatch_failed',
+      error: 'Automation process exited with code 9.',
+      outputSnapshot: { content: 'launch failed' }
+    })
   })
 
-  it('does not complete from a stale idle pane title (leaf branch shape)', async () => {
-    const runtime = createFakeRuntime({ lastAgentStatus: null, paneTitle: '✳ Claude — idle' })
-    const run = observe(runtime)
-
-    await vi.advanceTimersByTimeAsync(10_000)
-    expect(run.settled).toEqual([])
-
-    runtime.setPane({ paneTitle: '✳ Claude — working' })
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled).toEqual([])
-
-    runtime.setPane({ paneTitle: '✳ Claude — idle' })
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled[0]?.status).toBe('completed')
-    await run.promise
+  it('never turns an unconfirmed SSH stop into success', async () => {
+    const run = observe('ssh-automation')
+    run.runtime.onPtyExit(PTY_ID, -1, 'incarnation-automation')
+    await expect(run.promise).resolves.toMatchObject({
+      status: 'dispatch_failed',
+      error: expect.stringContaining('could be verified')
+    })
   })
 
-  it('does not complete from a ready shell prompt left over at dispatch', async () => {
-    const runtime = createFakeRuntime({ preview: 'user@host repo %\n$' })
-    const run = observe(runtime)
-
-    await vi.advanceTimersByTimeAsync(10_000)
-    expect(run.settled).toEqual([])
-
-    runtime.setPane({ preview: 'claude is thinking…' })
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled).toEqual([])
-
-    runtime.setPane({ lastAgentStatus: 'idle' })
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled[0]?.status).toBe('completed')
-    await run.promise
-  })
-
-  it('fails the run truthfully when the pane never leaves its pre-dispatch state', async () => {
-    const runtime = createFakeRuntime({ lastAgentStatus: 'idle' })
-    const run = observe(runtime)
-
-    await vi.advanceTimersByTimeAsync(2 * 60 * 1000 + 1_000)
-    expect(run.settled[0]?.status).toBe('dispatch_failed')
-    expect(run.settled[0]?.error).toContain('never started')
-    await run.promise
-  })
-
-  it('completes a fresh launch that was never idle at dispatch', async () => {
-    const runtime = createFakeRuntime({ lastAgentStatus: 'working' })
-    const run = observe(runtime)
-
-    await vi.advanceTimersByTimeAsync(1_000)
-    expect(run.settled).toEqual([])
-
-    runtime.setPane({ lastAgentStatus: 'idle' })
-    await vi.advanceTimersByTimeAsync(10)
-    expect(run.settled[0]?.status).toBe('completed')
-    expect(run.settled[0]?.outputSnapshot?.content).toContain('previous run output')
-    await run.promise
-  })
-
-  it('stops re-arming the tui-idle wait instead of looping for the process lifetime', async () => {
-    const runtime = createFakeRuntime({ lastAgentStatus: 'working' })
-    const run = observe(runtime)
-
-    await vi.advanceTimersByTimeAsync(6 * 60 * 60 * 1000 + RUNTIME_TUI_IDLE_TIMEOUT_MS)
-    expect(run.settled[0]?.status).toBe('dispatch_failed')
-    expect(run.settled[0]?.error).toContain('without a completion signal')
-    // 6h of 5-minute waits, not an unbounded re-arm.
-    expect(runtime.waitCalls()).toBeLessThanOrEqual(80)
-    await run.promise
+  it('releases both exit subscriptions when watching is aborted', async () => {
+    const run = observe()
+    const unsubscribe = vi.fn()
+    const subscribe = vi.spyOn(run.runtime, 'subscribeToPtyExit').mockReturnValue(unsubscribe)
+    const observer = createRuntimeAutomationRunTerminalObserver(run.runtime)
+    const promise = observer.observeCompletion(run.handle, {
+      signal: run.controller.signal,
+      terminalPtyId: PTY_ID
+    })
+    run.controller.abort()
+    await expect(promise).rejects.toThrow('request_aborted')
+    await expect(run.promise).rejects.toThrow('request_aborted')
+    expect(subscribe).toHaveBeenCalledWith(PTY_ID, expect.any(Function))
+    expect(unsubscribe).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/automations/runtime-terminal-run-observer.test.ts
+++ b/src/main/automations/runtime-terminal-run-observer.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createRuntimeAutomationRunTerminalObserver } from './runtime-terminal-run-observer'
 import { OrcaRuntimeService } from '../runtime/orca-runtime'
+import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
 const PTY_ID = 'pty-automation'
 const PANE_KEY = 'tab-automation:11111111-2222-4333-8444-555555555555'
@@ -92,9 +93,36 @@ describe('authority automation terminal exit observation', () => {
     run.runtime.onPtyExit(PTY_ID, -1, 'incarnation-automation')
     await expect(run.promise).resolves.toMatchObject({
       status: 'dispatch_failed',
-      error: expect.stringContaining('could be verified')
+      error: 'Agent process stop was requested but never confirmed'
     })
   })
+
+  it('reports an operator close instead of completing from its zero exit code', async () => {
+    const run = observe()
+    run.runtime.onPtyData(PTY_ID, 'partial work\r\n', Date.now())
+    run.runtime.markPtyStopRequested(PTY_ID)
+    run.runtime.onPtyExit(PTY_ID, 0, 'incarnation-automation')
+    await expect(run.promise).resolves.toMatchObject({
+      status: 'dispatch_failed',
+      error: 'Terminal closed by operator request',
+      outputSnapshot: { content: 'partial work' }
+    })
+  })
+
+  it.each([
+    [{ kind: 'signaled', signal: 15 }, 'Agent process killed by signal 15'],
+    [
+      { kind: 'unknown', reason: 'stop_unverified' },
+      'Agent process stop was requested but never confirmed'
+    ]
+  ] satisfies [TerminalExitCause, string][])(
+    'does not let a zero code override explicit cause %j',
+    async (cause, error) => {
+      const run = observe('ssh-automation')
+      run.runtime.onPtyExit(PTY_ID, 0, 'incarnation-automation', { cause })
+      await expect(run.promise).resolves.toMatchObject({ status: 'dispatch_failed', error })
+    }
+  )
 
   it('releases both exit subscriptions when watching is aborted', async () => {
     const run = observe()

--- a/src/main/automations/runtime-terminal-run-observer.ts
+++ b/src/main/automations/runtime-terminal-run-observer.ts
@@ -1,6 +1,10 @@
 import { createHeadlessAutomationOutputSnapshotBuffer } from './headless-dispatch'
 import type { AutomationRunTerminalObserver } from './run-completion-watcher'
-import { isProvenProcessExit } from '../../shared/terminal-exit-cause'
+import {
+  describeTerminalExitCause,
+  isProvenProcessExit,
+  type TerminalExitCause
+} from '../../shared/terminal-exit-cause'
 
 const TERMINAL_SNAPSHOT_LIMIT = 2_000
 
@@ -13,7 +17,12 @@ export type AutomationRunTerminalHost = {
   waitForTerminal(
     handle: string,
     options?: { condition?: 'exit' | 'tui-idle'; timeoutMs?: number; signal?: AbortSignal }
-  ): Promise<{ satisfied: boolean; exitCode?: number | null; blockedReason?: string }>
+  ): Promise<{
+    satisfied: boolean
+    exitCode?: number | null
+    exitCause?: TerminalExitCause
+    blockedReason?: string
+  }>
   subscribeToPtyExit(ptyId: string, listener: () => void): () => void
   readTerminal(
     handle: string,
@@ -52,10 +61,20 @@ export function createRuntimeAutomationRunTerminalObserver(
       try {
         // Agent idle is a turn signal, never proof that this run's process exited.
         const wait = await runtime.waitForTerminal(handle, { condition: 'exit', signal })
-        if (!wait.satisfied || wait.exitCode == null || !isProvenProcessExit(wait.exitCode)) {
+        const cause = wait.exitCause
+        const stopUnverified = cause?.kind === 'unknown' && cause.reason === 'stop_unverified'
+        if (
+          !wait.satisfied ||
+          wait.exitCode == null ||
+          !isProvenProcessExit(wait.exitCode) ||
+          stopUnverified
+        ) {
           return {
             status: 'dispatch_failed',
-            error: 'Orca lost contact with this run before its process exit could be verified.'
+            error:
+              cause && (stopUnverified || cause.kind === 'operator_close')
+                ? describeTerminalExitCause(cause)
+                : 'Orca lost contact with this run before its process exit could be verified.'
           }
         }
         // Capture must finish before the watcher can publish a terminal run status.
@@ -66,11 +85,17 @@ export function createRuntimeAutomationRunTerminalObserver(
         if (outputSnapshot && (read.truncated || read.limited)) {
           outputSnapshot.truncated = true
         }
+        // Legacy hosts omit the cause; explicit teardown evidence still overrides a zero.
+        const interrupted = cause?.kind === 'operator_close' || cause?.kind === 'signaled'
+        const completed = wait.exitCode === 0 && !interrupted
         return {
-          status: wait.exitCode === 0 ? 'completed' : 'dispatch_failed',
+          status: completed ? 'completed' : 'dispatch_failed',
           outputSnapshot,
-          error:
-            wait.exitCode === 0 ? null : `Automation process exited with code ${wait.exitCode}.`
+          error: interrupted
+            ? describeTerminalExitCause(cause)
+            : completed
+              ? null
+              : `Automation process exited with code ${wait.exitCode}.`
         }
       } finally {
         unsubscribe()

--- a/src/main/automations/runtime-terminal-run-observer.ts
+++ b/src/main/automations/runtime-terminal-run-observer.ts
@@ -1,197 +1,79 @@
 import { createHeadlessAutomationOutputSnapshotBuffer } from './headless-dispatch'
-import type {
-  AutomationRunCompletionObservation,
-  AutomationRunTerminalObserver
-} from './run-completion-watcher'
-import type { AutomationRunOutputSnapshot } from '../../shared/automations-types'
+import type { AutomationRunTerminalObserver } from './run-completion-watcher'
+import { isProvenProcessExit } from '../../shared/terminal-exit-cause'
 
 const TERMINAL_SNAPSHOT_LIMIT = 2_000
 
-/** Cadence for re-probing a pane that already satisfied tui-idle at dispatch. */
-const AGENT_START_POLL_INTERVAL_MS = 250
-/** Kept under the runtime's 2s tui-idle fallback poll so a probe waiter is torn
- *  down before it can start a foreground-process poll of its own. */
-const AGENT_START_PROBE_TIMEOUT_MS = 250
-/** How long a pane may stay in its pre-dispatch state before we stop believing
- *  the prompt reached an agent. Covers the deliberate pre-Enter delay plus agent
- *  spin-up over SSH; past that, silence is not evidence of work. */
-const AGENT_START_DEADLINE_MS = 2 * 60 * 1000
-/** Total observation budget. Each tui-idle wait expires on the runtime's own
- *  5-minute schedule and a live agent legitimately outlives many of them, so the
- *  bound is wall-clock and generous; it exists so a pane whose agent is never
- *  detected stops re-arming for the process lifetime with its run stuck at
- *  `dispatched`. Startup reconciliation re-attaches, so this is not a hard cap on
- *  how long a surviving run may be watched across restarts. */
-const OBSERVE_DEADLINE_MS = 6 * 60 * 60 * 1000
-
 /** The runtime surface an authority uses to observe its own terminals. */
 export type AutomationRunTerminalHost = {
-  getTerminalHandleForPaneKey(paneKey: string): string | null
+  resolveTerminalPane(
+    paneKey: string,
+    expectedWorktreeId?: string
+  ): { handle: string; ptyId: string | null }
   waitForTerminal(
     handle: string,
-    options?: { condition?: 'tui-idle'; timeoutMs?: number; signal?: AbortSignal }
-  ): Promise<{ satisfied: boolean; blockedReason?: string }>
-  readTerminal(handle: string, opts?: { limit?: number }): Promise<{ tail: string[] }>
-}
-
-function isTerminalWaitTimeout(error: unknown): boolean {
-  return error instanceof Error && error.message === 'timeout'
-}
-
-async function sleep(ms: number, signal: AbortSignal): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    if (signal.aborted) {
-      reject(new Error('request_aborted'))
-      return
-    }
-    const onAbort = (): void => {
-      clearTimeout(timer)
-      reject(new Error('request_aborted'))
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve()
-    }, ms)
-    signal.addEventListener('abort', onAbort, { once: true })
-  })
-}
-
-/** Whether tui-idle is satisfiable from evidence the pane holds RIGHT NOW.
- *  Why a real wait with a short timeout rather than a status read: the runtime
- *  satisfies tui-idle from a sticky agent status, an idle pane title, or a ready
- *  shell prompt, across two different code shapes (pty vs leaf). Asking it the
- *  question it already answers keeps every one of those in scope. */
-async function isTuiIdleSatisfiedNow(
-  runtime: AutomationRunTerminalHost,
-  handle: string,
-  signal: AbortSignal
-): Promise<boolean> {
-  try {
-    const wait = await runtime.waitForTerminal(handle, {
-      condition: 'tui-idle',
-      timeoutMs: AGENT_START_PROBE_TIMEOUT_MS,
-      signal
-    })
-    // A blocked pane is not "already finished"; let the real wait report it.
-    return wait.satisfied
-  } catch (error) {
-    if (isTerminalWaitTimeout(error)) {
-      return false
-    }
-    throw error
-  }
-}
-
-/** Polls until the pane stops satisfying tui-idle — the edge that proves this
- *  run's agent, not the previous one, owns the pane. */
-async function waitForAgentStart(
-  runtime: AutomationRunTerminalHost,
-  handle: string,
-  signal: AbortSignal,
-  deadlineAt: number
-): Promise<boolean> {
-  while (Date.now() < deadlineAt) {
-    await sleep(AGENT_START_POLL_INTERVAL_MS, signal)
-    if (!(await isTuiIdleSatisfiedNow(runtime, handle, signal))) {
-      return true
-    }
-  }
-  return false
-}
-
-async function readTerminalSnapshot(
-  runtime: AutomationRunTerminalHost,
-  handle: string
-): Promise<AutomationRunOutputSnapshot | null> {
-  const snapshotBuffer = createHeadlessAutomationOutputSnapshotBuffer()
-  try {
-    const read = await runtime.readTerminal(handle, { limit: TERMINAL_SNAPSHOT_LIMIT })
-    snapshotBuffer.append(read.tail.join('\n'))
-  } catch {
-    // Why: the terminal can exit between the wait resolving and the tail read;
-    // a missing snapshot must not turn a satisfied wait into a failure.
-  }
-  return snapshotBuffer.snapshot()
-}
-
-async function buildObservation(
-  runtime: AutomationRunTerminalHost,
-  handle: string,
-  wait: { satisfied: boolean; blockedReason?: string }
-): Promise<AutomationRunCompletionObservation> {
-  const outputSnapshot = await readTerminalSnapshot(runtime, handle)
-  if (wait.satisfied) {
-    return { status: 'completed', outputSnapshot, error: null }
-  }
-  return {
-    status: 'dispatch_failed',
-    outputSnapshot,
-    error: wait.blockedReason
-      ? `Automation agent is blocked: ${wait.blockedReason}.`
-      : 'Automation agent did not report completion.'
-  }
-}
-
-/** Closes a run out without claiming a completion nobody observed. */
-async function buildUnobservedObservation(
-  runtime: AutomationRunTerminalHost,
-  handle: string,
-  error: string
-): Promise<AutomationRunCompletionObservation> {
-  return {
-    status: 'dispatch_failed',
-    outputSnapshot: await readTerminalSnapshot(runtime, handle),
-    error
-  }
+    options?: { condition?: 'exit' | 'tui-idle'; timeoutMs?: number; signal?: AbortSignal }
+  ): Promise<{ satisfied: boolean; exitCode?: number | null; blockedReason?: string }>
+  subscribeToPtyExit(ptyId: string, listener: () => void): () => void
+  readTerminal(
+    handle: string,
+    opts?: { limit?: number }
+  ): Promise<{ tail: string[]; truncated?: boolean; limited?: boolean }>
 }
 
 export function createRuntimeAutomationRunTerminalObserver(
   runtime: AutomationRunTerminalHost
 ): AutomationRunTerminalObserver {
   return {
-    resolveRunTerminal: (run) =>
-      run.terminalPaneKey ? runtime.getTerminalHandleForPaneKey(run.terminalPaneKey) : null,
-    observeCompletion: async (handle, { signal }) => {
-      const startedAt = Date.now()
-      // Why: tui-idle is level-triggered, so a reused pane still idle from the
-      // PREVIOUS run satisfies it before this run's agent has typed a character.
-      // Evidence that predates dispatch proves nothing about this run, so require
-      // the pane to leave that state first — the busy edge the renderer's own
-      // dispatch observer requires on reuse (requireWorkingAfterStart).
-      if (await isTuiIdleSatisfiedNow(runtime, handle, signal)) {
-        const started = await waitForAgentStart(
-          runtime,
-          handle,
-          signal,
-          startedAt + AGENT_START_DEADLINE_MS
-        )
-        if (!started) {
-          return await buildUnobservedObservation(
-            runtime,
-            handle,
-            'Automation agent never started after the prompt was submitted.'
-          )
-        }
+    resolveRunTerminal: (run) => {
+      if (!run.terminalPaneKey) {
+        return null
       }
-      const deadlineAt = startedAt + OBSERVE_DEADLINE_MS
-      for (;;) {
-        try {
-          const wait = await runtime.waitForTerminal(handle, { condition: 'tui-idle', signal })
-          return await buildObservation(runtime, handle, wait)
-        } catch (error) {
-          // Why: tui-idle waits expire on their own schedule; an agent still
-          // working past that window is live, so re-arm rather than fail it.
-          if (signal.aborted || !isTerminalWaitTimeout(error)) {
-            throw error
-          }
-          if (Date.now() >= deadlineAt) {
-            return await buildUnobservedObservation(
-              runtime,
-              handle,
-              'Orca stopped watching this run after 6h without a completion signal.'
-            )
+      try {
+        const terminal = runtime.resolveTerminalPane(
+          run.terminalPaneKey,
+          run.workspaceId ?? undefined
+        )
+        return !run.terminalPtyId || terminal.ptyId === run.terminalPtyId ? terminal.handle : null
+      } catch {
+        return null
+      }
+    },
+    observeCompletion: async (handle, { signal, terminalPtyId }) => {
+      const capture = () => runtime.readTerminal(handle, { limit: TERMINAL_SNAPSHOT_LIMIT })
+      let finalCapture: ReturnType<typeof capture> | undefined
+      const unsubscribe = terminalPtyId
+        ? runtime.subscribeToPtyExit(terminalPtyId, () => {
+            // Exit subscribers run before the runtime releases its bounded transcript.
+            finalCapture = capture()
+            void finalCapture.catch(() => {})
+          })
+        : () => {}
+      try {
+        // Agent idle is a turn signal, never proof that this run's process exited.
+        const wait = await runtime.waitForTerminal(handle, { condition: 'exit', signal })
+        if (!wait.satisfied || wait.exitCode == null || !isProvenProcessExit(wait.exitCode)) {
+          return {
+            status: 'dispatch_failed',
+            error: 'Orca lost contact with this run before its process exit could be verified.'
           }
         }
+        // Capture must finish before the watcher can publish a terminal run status.
+        const read = await (finalCapture ?? capture())
+        const snapshotBuffer = createHeadlessAutomationOutputSnapshotBuffer()
+        snapshotBuffer.append(read.tail.join('\n'))
+        const outputSnapshot = snapshotBuffer.snapshot()
+        if (outputSnapshot && (read.truncated || read.limited)) {
+          outputSnapshot.truncated = true
+        }
+        return {
+          status: wait.exitCode === 0 ? 'completed' : 'dispatch_failed',
+          outputSnapshot,
+          error:
+            wait.exitCode === 0 ? null : `Automation process exited with code ${wait.exitCode}.`
+        }
+      } finally {
+        unsubscribe()
       }
     }
   }

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -12,7 +12,7 @@ import type { ClaudeUsageStore } from '../claude-usage/store'
 import type { CodexUsageStore } from '../codex-usage/store'
 import { runAutomationPrecheck } from './precheck-runner'
 import { resolveAutomationRunTarget, type AutomationRunTargetResult } from './run-target-resolution'
-import { collectAutomationRunUsage } from './run-usage-collection'
+import { persistAutomationRunUsage } from './run-usage-collection'
 import type { HeadlessAutomationDispatcher } from './headless-dispatch'
 import { clearAutomationDispatchTokens, createAutomationDispatchToken } from './dispatch-tokens'
 import { runHeadlessAutomationDispatch } from './headless-dispatch-runner'
@@ -77,7 +77,7 @@ export class AutomationService {
           observer: opts.terminalObserver,
           readRun: (automationId, runId) =>
             this.store.listAutomationRuns(automationId).find((entry) => entry.id === runId) ?? null,
-          markDispatchResult: (result) => this.markDispatchResult(result)
+          markDispatchResult: (result) => this.persistDispatchResult(result)
         })
       : null
   }
@@ -188,6 +188,19 @@ export class AutomationService {
   }
 
   async markDispatchResult(result: AutomationDispatchResult): Promise<AutomationRun> {
+    const deferred =
+      result.status === 'completed'
+        ? this.completionWatcher?.deferReportedCompletion(result.runId, this.store)
+        : null
+    return deferred ?? (await this.persistDispatchResult(result))
+  }
+
+  private async persistDispatchResult(result: AutomationDispatchResult): Promise<AutomationRun> {
+    const priorSessionId =
+      result.status === 'completed' && result.terminalSessionId === null
+        ? this.store.listAutomationRuns().find((entry) => entry.id === result.runId)
+            ?.terminalSessionId
+        : null
     const run = this.runs.updateRun(result)
     clearAutomationDispatchTokens(run.automationId, run.id)
     if (!isFinalAutomationRunStatus(run.status)) {
@@ -197,31 +210,13 @@ export class AutomationService {
       return run
     }
     this.completionWatcher?.forget(run.id)
-    // Why: the renderer's mark-completed effect can re-fire for the same run
-    // before refresh() flips its status snapshot off 'dispatched'. Re-running
-    // collectRunUsage advances the attribution window and can rewrite an
-    // already-collected 'known' usage to 'unavailable'/'ambiguous_session'.
-    if (run.usage) {
-      return run
-    }
-    const usage = await collectAutomationRunUsage({
-      automation: this.store.listAutomations().find((entry) => entry.id === run.automationId),
+    return await persistAutomationRunUsage({
+      store: this.store,
+      runs: this.runs,
       run,
+      priorSessionId,
       claudeUsage: this.claudeUsage,
       codexUsage: this.codexUsage
-    })
-    // Why: the run is final during the await above, so a concurrent create-time
-    // retention prune may have evicted it — the usage write must not throw then.
-    if (!this.store.listAutomationRuns(run.automationId).some((entry) => entry.id === run.id)) {
-      return run
-    }
-    return this.runs.updateRun({
-      runId: run.id,
-      status: run.status,
-      workspaceId: run.workspaceId,
-      terminalSessionId: run.terminalSessionId,
-      usage,
-      error: run.error
     })
   }
 

--- a/src/main/persistence-automations.test.ts
+++ b/src/main/persistence-automations.test.ts
@@ -383,13 +383,18 @@ describe('Store', () => {
     })
 
     const run = store.createAutomationRun(automation, new Date('2026-05-13T09:00:00Z').getTime())
-    store.updateAutomation(automation.id, { sourceContext: null, runContext: null })
+    store.updateAutomation(automation.id, {
+      sourceContext: null,
+      runContext: null,
+      reuseSession: true
+    })
 
     expect(run.runContext).toEqual(automation.runContext)
     expect(run.sourceContext).toEqual(automation.sourceContext)
     expect(store.listAutomationRuns(automation.id)[0]).toMatchObject({
       runContext: automation.runContext,
-      sourceContext: automation.sourceContext
+      sourceContext: automation.sourceContext,
+      reuseSession: false
     })
   })
 

--- a/src/main/persistence/scheduling-automations/automation-run-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-run-operations.ts
@@ -94,6 +94,7 @@ export function createAutomationRun(
     workspaceId: automation.workspaceId,
     workspaceDisplayName: operations.getWorkspaceDisplayName(automation.workspaceId),
     sessionKind: 'terminal',
+    reuseSession: automation.reuseSession,
     chatSessionId: null,
     terminalSessionId: null,
     terminalPaneKey: null,

--- a/src/main/startup/main-process-automations.ts
+++ b/src/main/startup/main-process-automations.ts
@@ -1,5 +1,4 @@
 import { AutomationService } from '../automations/service'
-import { createHeadlessAutomationOutputSnapshotBuffer } from '../automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from '../automations/headless-workspace-create'
 import { createRuntimeAutomationRunTerminalObserver } from '../automations/runtime-terminal-run-observer'
 import { mainProcessState as state } from './main-process-state'
@@ -21,7 +20,6 @@ export function initializeMainProcessAutomations(): AutomationService {
     allowRemoteHostScheduling: state.isServeMode,
     headlessDispatcher: state.isServeMode
       ? async ({ automation, run, target }) => {
-          const terminalSnapshotLimit = 2_000
           let terminalHandle: string
           let terminalSessionId: string | null = null
           let terminalPaneKey: string | null = null
@@ -61,35 +59,12 @@ export function initializeMainProcessAutomations(): AutomationService {
             const worktree = await runtime.showManagedWorktree(`id:${workspaceId}`)
             workspaceDisplayName = worktree.displayName ?? null
           }
-          const completion = (async () => {
-            const wait = await runtime.waitForTerminal(terminalHandle, { condition: 'tui-idle' })
-            const read = await runtime.readTerminal(terminalHandle, {
-              limit: terminalSnapshotLimit
-            })
-            const snapshotBuffer = createHeadlessAutomationOutputSnapshotBuffer()
-            snapshotBuffer.append(read.tail.join('\n'))
-            if (wait.satisfied) {
-              return {
-                status: 'completed' as const,
-                outputSnapshot: snapshotBuffer.snapshot(),
-                error: null
-              }
-            }
-            return {
-              status: 'dispatch_failed' as const,
-              outputSnapshot: snapshotBuffer.snapshot(),
-              error: wait.blockedReason
-                ? `Automation agent is blocked: ${wait.blockedReason}.`
-                : 'Automation agent did not report completion.'
-            }
-          })()
           return {
             workspaceId,
             workspaceDisplayName,
             terminalSessionId,
             terminalPaneKey,
-            terminalPtyId,
-            completion
+            terminalPtyId
           }
         }
       : undefined

--- a/src/renderer/src/hooks/automation-dispatch-completion.ts
+++ b/src/renderer/src/hooks/automation-dispatch-completion.ts
@@ -20,6 +20,7 @@ type MarkDispatchResult = (result: AutomationDispatchResult) => Promise<void>
 
 export function createAutomationDispatchCompletion(args: {
   run: AutomationRun
+  requireProcessExit?: boolean
   worktree: Worktree
   precheckResult: AutomationPrecheckResult | null
   markDispatchResult: MarkDispatchResult
@@ -34,6 +35,7 @@ export function createAutomationDispatchCompletion(args: {
   let pendingExitCode: number | null = null
   let pendingDone = false
   let completionMarked = false
+  let retirementRequested = false
   let contactLost = false
   let unsubscribeAgentStatus = (): void => {}
   let unsubscribeSessionObserver = (): void => {}
@@ -48,6 +50,13 @@ export function createAutomationDispatchCompletion(args: {
   }
   const markCompletionResult = async (): Promise<void> => {
     if (completionMarked) {
+      return
+    }
+    if (args.requireProcessExit !== false) {
+      if (!retirementRequested && !contactLost) {
+        retirementRequested = true
+        args.finalizeTerminalOwnership()
+      }
       return
     }
     completionMarked = true
@@ -65,26 +74,6 @@ export function createAutomationDispatchCompletion(args: {
     } catch (error) {
       args.releaseTerminalOwnership()
       throw error
-    }
-    if (args.finalizeTerminalOwnership()) {
-      await clearRetiredRunTerminalIdentity()
-    }
-  }
-  const clearRetiredRunTerminalIdentity = async (): Promise<void> => {
-    // Why: the owned terminal was just retired, so the run's pane/pty
-    // pointers now reference a closed tab. Drop them (best-effort) so
-    // "View run" resolves to the workspace/snapshot instead of dead-ending
-    // on an unavailable terminal.
-    try {
-      await args.markDispatchResult({
-        runId: args.run.id,
-        status: 'completed',
-        terminalSessionId: null,
-        terminalPaneKey: null,
-        terminalPtyId: null
-      })
-    } catch (error) {
-      console.error('[automations] Failed to clear retired terminal identity:', error)
     }
   }
   /**
@@ -119,10 +108,17 @@ export function createAutomationDispatchCompletion(args: {
     }
     completionMarked = true
     cleanupRunObservers()
+    if (code === 0 && !retirementRequested) {
+      retirementRequested = true
+      args.finalizeTerminalOwnership()
+    }
     try {
       await args.markDispatchResult({
         runId: args.run.id,
         status: code === 0 ? 'completed' : 'dispatch_failed',
+        ...(code === 0
+          ? { terminalSessionId: null, terminalPaneKey: null, terminalPtyId: null }
+          : {}),
         workspaceId: args.worktree.id,
         workspaceDisplayName: args.worktree.displayName,
         outputSnapshot: getOutputSnapshot(),
@@ -133,11 +129,7 @@ export function createAutomationDispatchCompletion(args: {
       args.releaseTerminalOwnership()
       throw error
     }
-    if (code === 0) {
-      if (args.finalizeTerminalOwnership()) {
-        await clearRetiredRunTerminalIdentity()
-      }
-    } else {
+    if (code !== 0) {
       args.releaseTerminalOwnership()
     }
   }
@@ -166,7 +158,7 @@ export function createAutomationDispatchCompletion(args: {
       pendingExitCode = code
       return
     }
-    settleLateResult(markExitResult(code))
+    settleLateResult(Promise.resolve().then(() => markExitResult(code)))
   }
   const observeAgentStatus = (
     targetPaneKey: string,
@@ -253,10 +245,10 @@ export function createAutomationDispatchCompletion(args: {
     },
     settlePendingAfterDispatch: async () => {
       dispatchMarked = true
-      if (pendingDone) {
-        await markCompletionResult()
-      } else if (pendingExitCode !== null) {
+      if (pendingExitCode !== null) {
         await markExitResult(pendingExitCode)
+      } else if (pendingDone) {
+        await markCompletionResult()
       }
     }
   }

--- a/src/renderer/src/hooks/automation-dispatch-completion.ts
+++ b/src/renderer/src/hooks/automation-dispatch-completion.ts
@@ -35,7 +35,6 @@ export function createAutomationDispatchCompletion(args: {
   let pendingExitCode: number | null = null
   let pendingDone = false
   let completionMarked = false
-  let retirementRequested = false
   let contactLost = false
   let unsubscribeAgentStatus = (): void => {}
   let unsubscribeSessionObserver = (): void => {}
@@ -53,10 +52,7 @@ export function createAutomationDispatchCompletion(args: {
       return
     }
     if (args.requireProcessExit !== false) {
-      if (!retirementRequested && !contactLost) {
-        retirementRequested = true
-        args.finalizeTerminalOwnership()
-      }
+      // A turn can finish before the process; closing here would kill its final capture.
       return
     }
     completionMarked = true
@@ -108,8 +104,7 @@ export function createAutomationDispatchCompletion(args: {
     }
     completionMarked = true
     cleanupRunObservers()
-    if (code === 0 && !retirementRequested) {
-      retirementRequested = true
+    if (code === 0) {
       args.finalizeTerminalOwnership()
     }
     try {

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -26,6 +26,10 @@ function acquireReuseDispatchTab(tabId: string): (() => void) | null {
   return () => activeReuseDispatchTabIds.delete(tabId)
 }
 
+/**
+ * Dispatches one automation run into a background agent session and persists
+ * completion only after the submitted prompt reaches its own working state.
+ */
 export async function handleAutomationDispatchRequest({
   automation,
   run,
@@ -181,11 +185,7 @@ export async function handleAutomationDispatchRequest({
         // Why: fresh launches can replay a stale non-boundary done before the
         // submitted automation prompt reaches working. Completion requires the
         // prompt's own working edge, just like reuse-session dispatches.
-        if (
-          payload.state !== 'done' ||
-          payload.sessionBoundary === true ||
-          !backgroundSawWorking
-        ) {
+        if (payload.state !== 'done' || payload.sessionBoundary === true || !backgroundSawWorking) {
           return
         }
         completion.handleAgentDone()

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -164,6 +164,7 @@ export async function handleAutomationDispatchRequest({
         }
       }
     }
+    let backgroundSawWorking = false
     const result = await launchAgentBackgroundSession({
       agent: automation.agentId,
       worktreeId: worktree.id,
@@ -173,8 +174,18 @@ export async function handleAutomationDispatchRequest({
       onData: completion.appendOutput,
       onAgentStatus: (payload) => {
         completion.captureAssistantMessage(payload.lastAssistantMessage)
-        // Why: session-boundary done = launch connect, not run completion (see observeAgentStatus).
-        if (payload.state !== 'done' || payload.sessionBoundary === true) {
+        if (payload.state === 'working') {
+          backgroundSawWorking = true
+          return
+        }
+        // Why: fresh launches can replay a stale non-boundary done before the
+        // submitted automation prompt reaches working. Completion requires the
+        // prompt's own working edge, just like reuse-session dispatches.
+        if (
+          payload.state !== 'done' ||
+          payload.sessionBoundary === true ||
+          !backgroundSawWorking
+        ) {
           return
         }
         completion.handleAgentDone()
@@ -193,7 +204,9 @@ export async function handleAutomationDispatchRequest({
       releaseTerminalOwnership()
     }
     const launchedTabId = result.tabId
-    completion.observeAgentStatus(result.paneKey, dispatchStartedAt)
+    completion.observeAgentStatus(result.paneKey, dispatchStartedAt, {
+      requireWorkingAfterStart: true
+    })
     try {
       await markDispatchResult({
         runId: run.id,

--- a/src/renderer/src/hooks/automation-dispatch-handler.ts
+++ b/src/renderer/src/hooks/automation-dispatch-handler.ts
@@ -41,6 +41,7 @@ export async function handleAutomationDispatchRequest({
     // here would arrive second and invalidate every host in the catalog.
     await window.api.automations.markDispatchResult(result)
   }
+  const reuseSession = run.reuseSession ?? automation.reuseSession
   const state = useAppStore.getState()
   const focusBeforeDispatch = {
     activeView: state.activeView,
@@ -89,6 +90,7 @@ export async function handleAutomationDispatchRequest({
     }
     const completion = createAutomationDispatchCompletion({
       run,
+      requireProcessExit: !reuseSession,
       worktree,
       precheckResult: resolved.context.precheckResult,
       markDispatchResult,
@@ -96,7 +98,7 @@ export async function handleAutomationDispatchRequest({
       finalizeTerminalOwnership
     })
     const dispatchStartedAt = Date.now()
-    if (automation.reuseSession) {
+    if (reuseSession) {
       const reusableSession = findReusableAutomationSession({
         automationId: automation.id,
         agentId: automation.agentId,
@@ -198,7 +200,7 @@ export async function handleAutomationDispatchRequest({
       throw new Error('Unable to build an agent launch plan.')
     }
     terminalOwnership = result.terminalOwnership
-    if (automation.reuseSession) {
+    if (reuseSession) {
       // Why: the first fresh launch is the seed for later reuse and must
       // survive completion under the same policy as an already-reused tab.
       releaseTerminalOwnership()

--- a/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
@@ -85,7 +85,7 @@ describe('automation dispatch completion on an unverifiable loss', () => {
     expect(finalizeTerminalOwnership).not.toHaveBeenCalled()
   })
 
-  it('lets a later done still complete a run whose contact was lost', async () => {
+  it('requires a proven exit even if a later done arrives after contact loss', async () => {
     // The loss withheld a verdict rather than settling one, so positive
     // evidence arriving afterwards must still be able to close the run.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
@@ -94,6 +94,10 @@ describe('automation dispatch completion on an unverifiable loss', () => {
     completion.handleExit(-1)
     await vi.waitFor(() => expect(releaseTerminalOwnership).toHaveBeenCalledOnce())
     completion.handleAgentDone()
+    await Promise.resolve()
+    expect(markDispatchResult).not.toHaveBeenCalled()
+    expect(finalizeTerminalOwnership).not.toHaveBeenCalled()
+    completion.handleExit(0)
 
     await vi.waitFor(() =>
       expect(markDispatchResult).toHaveBeenCalledWith(

--- a/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
+++ b/src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts
@@ -69,6 +69,34 @@ describe('automation dispatch completion on an unverifiable loss', () => {
     expect(releaseTerminalOwnership).not.toHaveBeenCalled()
   })
 
+  it('does not force-close a live process on done before its final output and natural exit', async () => {
+    const completion = await createCompletion()
+    finalizeTerminalOwnership.mockImplementation(() => {
+      completion.handleExit(-1)
+      return true
+    })
+    completion.appendOutput('mid-work sentence\n')
+    completion.handleAgentDone()
+    await Promise.resolve()
+    expect(finalizeTerminalOwnership).not.toHaveBeenCalled()
+    expect(markDispatchResult).not.toHaveBeenCalled()
+
+    completion.appendOutput('CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14\nSTATUS: DONE')
+    completion.handleExit(0)
+    await vi.waitFor(() => expect(markDispatchResult).toHaveBeenCalledOnce())
+    expect(markDispatchResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'completed',
+        terminalPtyId: null,
+        outputSnapshot: expect.objectContaining({
+          content: expect.stringContaining('STATUS: DONE')
+        })
+      })
+    )
+    expect(finalizeTerminalOwnership).toHaveBeenCalledOnce()
+    expect(releaseTerminalOwnership).not.toHaveBeenCalled()
+  })
+
   it('still reports a real automation failure as dispatch_failed', async () => {
     const completion = await createCompletion()
 

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -876,6 +876,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
       .mockRejectedValueOnce(new Error('completion persistence unavailable'))
       .mockResolvedValueOnce(undefined)
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
+      args.onAgentStatus?.({ state: 'working' })
       args.onAgentStatus?.({ state: 'done' })
       return {
         tabId: 'agent-tab',
@@ -918,6 +919,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     })
 
     await registerAndDispatch()
+    onAgentStatus?.({ state: 'working' })
     onAgentStatus?.({ state: 'done' })
     onAgentStatus?.({ state: 'done' })
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce())

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -572,6 +572,10 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
     await registerAndDispatch()
     launchArgs.onAgentStatus?.({ state: 'done' })
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    launchArgs.onAgentStatus?.({ state: 'working' })
+    launchArgs.onAgentStatus?.({ state: 'done' })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
 
     expect(order).toEqual([
@@ -618,6 +622,53 @@ describe('useAutomationDispatchEvents setup launch', () => {
     expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
 
     launchArgs.onAgentStatus?.({ state: 'done' })
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    launchArgs.onAgentStatus?.({ state: 'working' })
+    launchArgs.onAgentStatus?.({ state: 'done' })
+    await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
+  })
+
+  it('ignores stale done in the fresh status-store observer until working', async () => {
+    const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
+    await registerAndDispatch()
+    if (!latestStoreSubscriber) {
+      throw new Error('agent status observer was not registered')
+    }
+    const startedAt = Date.now() + 1
+    state.agentStatusByPaneKey = {
+      [paneKey]: {
+        paneKey,
+        state: 'done',
+        prompt: 'stale',
+        updatedAt: startedAt,
+        stateStartedAt: startedAt,
+        stateHistory: []
+      }
+    }
+    latestStoreSubscriber()
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+
+    state.agentStatusByPaneKey[paneKey] = {
+      paneKey,
+      state: 'working',
+      prompt: 'automation',
+      updatedAt: startedAt + 1,
+      stateStartedAt: startedAt + 1,
+      stateHistory: []
+    }
+    latestStoreSubscriber()
+    state.agentStatusByPaneKey[paneKey] = {
+      paneKey,
+      state: 'done',
+      prompt: 'automation',
+      updatedAt: startedAt + 2,
+      stateStartedAt: startedAt + 2,
+      stateHistory: []
+    }
+    latestStoreSubscriber()
+
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
   })
 

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -214,6 +214,9 @@ describe('useAutomationDispatchEvents setup launch', () => {
         release: mockReleaseTerminalOwnership
       }
     })
+    mockMarkDispatchResult.mockResolvedValue(undefined)
+    mockFinalizeTerminalOwnership.mockReturnValue(false)
+    mockFindReusableAutomationSession.mockReturnValue(null)
     mockOnDispatchRequested.mockReturnValue(() => {})
     mockSshNeedsPassphrasePrompt.mockResolvedValue(false)
     mockSshGetState.mockResolvedValue({ status: 'connected' })
@@ -538,62 +541,45 @@ describe('useAutomationDispatchEvents setup launch', () => {
     )
   })
 
-  it('finalizes a fresh non-reuse terminal only after completed result persistence', async () => {
+  it('retires a fresh terminal before publishing one final result after exit', async () => {
     const order: string[] = []
-    let launchArgs: { onAgentStatus?: (payload: { state: string }) => void } = {}
-    mockMarkDispatchResult.mockImplementation(
-      async (result: { status: string; terminalPaneKey?: string | null }) => {
-        // The retirement clear reuses status 'completed' but nulls the terminal
-        // identity; label it distinctly so ordering stays legible.
-        order.push(
-          result.status === 'completed' && result.terminalPaneKey === null
-            ? 'clear-terminal-identity'
-            : `persist:${result.status}`
-        )
-      }
-    )
+    mockMarkDispatchResult.mockImplementation(async (result) => {
+      order.push(`persist:${result.status}`)
+    })
     mockFinalizeTerminalOwnership.mockImplementation(() => {
-      order.push('finalize')
+      order.push('retire')
       return true
     })
-    mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      launchArgs = args
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
-    })
-
     await registerAndDispatch()
-    launchArgs.onAgentStatus?.({ state: 'done' })
+    const launch = mockLaunchAgentBackgroundSession.mock.calls[0][0]
+    launch.onAgentStatus({ state: 'done', lastAssistantMessage: 'echoed prompt fragments' })
     await Promise.resolve()
-    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
-    launchArgs.onAgentStatus?.({ state: 'working' })
-    launchArgs.onAgentStatus?.({ state: 'done' })
-    await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
+    expect(order).toEqual(['persist:dispatched'])
 
-    expect(order).toEqual([
-      'persist:dispatched',
-      'persist:completed',
-      'finalize',
-      'clear-terminal-identity'
-    ])
-    expect(mockReleaseTerminalOwnership).not.toHaveBeenCalled()
-    // Why: the retired terminal is gone; the run must drop its pane/pty pointers
-    // so "View run" resolves to the workspace/snapshot, not an unavailable terminal.
-    expect(mockMarkDispatchResult).toHaveBeenLastCalledWith({
-      runId: expect.any(String),
-      status: 'completed',
-      terminalSessionId: null,
-      terminalPaneKey: null,
-      terminalPtyId: null
+    launch.onAgentStatus({ state: 'working' })
+    launch.onAgentStatus({ state: 'done', lastAssistantMessage: 'mid-work sentence' })
+    await Promise.resolve()
+    expect(order).toEqual(['persist:dispatched', 'retire'])
+    launch.onAgentStatus({
+      state: 'done',
+      lastAssistantMessage: 'CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14\nSTATUS: DONE'
     })
+    launch.onExit('agent-pty', 0)
+    await vi.waitFor(() => expect(mockMarkDispatchResult).toHaveBeenCalledTimes(2))
+    expect(order).toEqual(['persist:dispatched', 'retire', 'persist:completed'])
+    expect(mockReleaseTerminalOwnership).not.toHaveBeenCalled()
+    expect(mockMarkDispatchResult).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        status: 'completed',
+        terminalSessionId: null,
+        terminalPaneKey: null,
+        terminalPtyId: null,
+        outputSnapshot: expect.objectContaining({
+          content: 'CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14\nSTATUS: DONE',
+          truncated: false
+        })
+      })
+    )
   })
 
   it('ignores a session-boundary done so a connecting agent cannot complete the run (STA-3386)', async () => {
@@ -675,7 +661,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
   it('skips unchanged status and persists batched working→done→working output', async () => {
     const paneKey = 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d'
 
-    await registerAndDispatch()
+    await registerAndDispatch(makeAutomation({ reuseSession: true }))
     expect(countUnchangedObserverHistoryReads(state, latestStoreSubscriber)).toBe(0)
     const transitionStartedAt = Date.now() + 1
     state.agentStatusByPaneKey = {
@@ -698,7 +684,11 @@ describe('useAutomationDispatchEvents setup launch', () => {
     }
     latestStoreSubscriber()
 
-    await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
+    await vi.waitFor(() =>
+      expect(mockMarkDispatchResult).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'completed' })
+      )
+    )
     expect(mockMarkDispatchResult).toHaveBeenCalledWith(
       expect.objectContaining({
         runId: 'run-1',
@@ -800,55 +790,22 @@ describe('useAutomationDispatchEvents setup launch', () => {
   })
 
   it('consumes duplicate done and zero-exit completion through one finalizer', async () => {
-    let launchArgs: {
-      onAgentStatus?: (payload: { state: string }) => void
-      onExit?: (ptyId: string, code: number) => void
-    } = {}
-    mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      launchArgs = args
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
-    })
-
     await registerAndDispatch()
+    const launchArgs = mockLaunchAgentBackgroundSession.mock.calls[0][0]
     launchArgs.onAgentStatus?.({ state: 'done' })
     launchArgs.onExit?.('agent-pty', 0)
     launchArgs.onAgentStatus?.({ state: 'done' })
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
 
     expect(
-      mockMarkDispatchResult.mock.calls.filter(
-        ([result]) => result.status === 'completed' && result.terminalPaneKey !== null
-      )
+      mockMarkDispatchResult.mock.calls.filter(([result]) => result.status === 'completed')
     ).toHaveLength(1)
     expect(mockReleaseTerminalOwnership).not.toHaveBeenCalled()
   })
 
   it('releases ownership on nonzero exit without finalizing the tab', async () => {
-    let onExit: ((ptyId: string, code: number) => void) | undefined
-    mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      onExit = args.onExit
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
-    })
-
     await registerAndDispatch()
+    const onExit = mockLaunchAgentBackgroundSession.mock.calls[0][0].onExit
     onExit?.('agent-pty', 9)
     await vi.waitFor(() => expect(mockReleaseTerminalOwnership).toHaveBeenCalledOnce())
 
@@ -876,8 +833,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
       .mockRejectedValueOnce(new Error('completion persistence unavailable'))
       .mockResolvedValueOnce(undefined)
     mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      args.onAgentStatus?.({ state: 'working' })
-      args.onAgentStatus?.({ state: 'done' })
+      args.onExit?.('agent-pty', 0)
       return {
         tabId: 'agent-tab',
         paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
@@ -892,48 +848,31 @@ describe('useAutomationDispatchEvents setup launch', () => {
 
     await registerAndDispatch()
 
-    expect(mockReleaseTerminalOwnership).toHaveBeenCalledOnce()
-    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    expect(mockReleaseTerminalOwnership).not.toHaveBeenCalled()
+    expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce()
     expect(mockMarkDispatchResult).toHaveBeenLastCalledWith(
       expect.objectContaining({ status: 'dispatch_failed' })
     )
   })
 
-  it('diagnoses a late completed-persistence rejection once without terminal cleanup', async () => {
-    let onAgentStatus: ((payload: { state: string }) => void) | undefined
+  it('diagnoses a late exit-persistence rejection once', async () => {
     const persistenceError = new Error('late completion persistence unavailable')
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
     mockMarkDispatchResult.mockResolvedValueOnce(undefined).mockRejectedValueOnce(persistenceError)
-    mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      onAgentStatus = args.onAgentStatus
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
-    })
-
     await registerAndDispatch()
-    onAgentStatus?.({ state: 'working' })
-    onAgentStatus?.({ state: 'done' })
-    onAgentStatus?.({ state: 'done' })
+    const onExit = mockLaunchAgentBackgroundSession.mock.calls[0][0].onExit
+    onExit?.('agent-pty', 0)
+    onExit?.('agent-pty', 0)
     await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledOnce())
 
     expect(errorSpy).toHaveBeenCalledWith(
       '[automations] Failed to persist late automation result:',
       persistenceError
     )
-    expect(mockReleaseTerminalOwnership).toHaveBeenCalledOnce()
-    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    expect(mockReleaseTerminalOwnership).not.toHaveBeenCalled()
+    expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce()
     expect(
-      mockMarkDispatchResult.mock.calls.filter(
-        ([result]) => result.status === 'completed' && result.terminalPaneKey !== null
-      )
+      mockMarkDispatchResult.mock.calls.filter(([result]) => result.status === 'completed')
     ).toHaveLength(1)
     errorSpy.mockRestore()
   })

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -541,7 +541,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     )
   })
 
-  it('retires a fresh terminal before publishing one final result after exit', async () => {
+  it('waits for natural exit before retiring a fresh terminal and publishing its final result', async () => {
     const order: string[] = []
     mockMarkDispatchResult.mockImplementation(async (result) => {
       order.push(`persist:${result.status}`)
@@ -559,7 +559,7 @@ describe('useAutomationDispatchEvents setup launch', () => {
     launch.onAgentStatus({ state: 'working' })
     launch.onAgentStatus({ state: 'done', lastAssistantMessage: 'mid-work sentence' })
     await Promise.resolve()
-    expect(order).toEqual(['persist:dispatched', 'retire'])
+    expect(order).toEqual(['persist:dispatched'])
     launch.onAgentStatus({
       state: 'done',
       lastAssistantMessage: 'CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14\nSTATUS: DONE'
@@ -583,24 +583,8 @@ describe('useAutomationDispatchEvents setup launch', () => {
   })
 
   it('ignores a session-boundary done so a connecting agent cannot complete the run (STA-3386)', async () => {
-    let launchArgs: {
-      onAgentStatus?: (payload: { state: string; sessionBoundary?: boolean }) => void
-    } = {}
-    mockLaunchAgentBackgroundSession.mockImplementation(async (args) => {
-      launchArgs = args
-      return {
-        tabId: 'agent-tab',
-        paneKey: 'agent-tab:7c6fb4e5-3bf1-4ff4-8259-03f7ae81c40d',
-        ptyId: 'agent-pty',
-        startupPlan: {},
-        terminalOwnership: {
-          finalize: mockFinalizeTerminalOwnership,
-          release: mockReleaseTerminalOwnership
-        }
-      }
-    })
-
     await registerAndDispatch()
+    const launchArgs = mockLaunchAgentBackgroundSession.mock.calls[0][0]
     // Why: Claude fires SessionStart (a sessionBoundary done) at launch, before the argv
     // prompt submits — treating it as run completion would close the tab on an empty run.
     launchArgs.onAgentStatus?.({ state: 'done', sessionBoundary: true })
@@ -612,6 +596,9 @@ describe('useAutomationDispatchEvents setup launch', () => {
     expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
     launchArgs.onAgentStatus?.({ state: 'working' })
     launchArgs.onAgentStatus?.({ state: 'done' })
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    launchArgs.onExit?.('agent-pty', 0)
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
   })
 
@@ -655,6 +642,9 @@ describe('useAutomationDispatchEvents setup launch', () => {
     }
     latestStoreSubscriber()
 
+    await Promise.resolve()
+    expect(mockFinalizeTerminalOwnership).not.toHaveBeenCalled()
+    mockLaunchAgentBackgroundSession.mock.calls[0][0].onExit?.('agent-pty', 0)
     await vi.waitFor(() => expect(mockFinalizeTerminalOwnership).toHaveBeenCalledOnce())
   })
 

--- a/src/shared/automations-types.ts
+++ b/src/shared/automations-types.ts
@@ -146,6 +146,8 @@ export type AutomationRun = {
    *  is deleted and its live metadata is gone. */
   workspaceDisplayName?: string | null
   sessionKind: 'terminal'
+  /** Session reuse is fixed for this run even if the automation is edited later. */
+  reuseSession?: boolean
   chatSessionId: string | null
   terminalSessionId: string | null
   /** Why: a terminal tab can later point at a different pane/PTY. Automation


### PR DESCRIPTION
## ELI5

Orca could mark an automation finished while its agent was still working, saving only the startup prompt or a partial sentence. Fresh runs now stay dispatched until their execution host confirms process exit and final output capture finishes. The completed result and cleared terminal identifiers are published together.

## What Changed

- Build on #18087's provider-neutral fresh working-edge guard, preserving Jun's three commits and authorship.
- Make `AutomationRunCompletionWatcher` the completion authority for fresh runs, including older renderer reports and headless dispatch. Reuse the runtime's exit waiter and exit subscription instead of polling `tui-idle`.
- Start final capture before runtime transcript retirement, await it before publication, and preserve truncation information. Reject mismatched pane/PTY ownership and unverifiable exit evidence.
- Keep reusable sessions' existing turn contract, snapshot that choice when creating the run, and preserve usage attribution without restoring retired terminal IDs.
- Reconcile unresolved fresh terminals through the existing retained-run reconciler, with a per-run remount grace. A missing terminal never falls back to accepting a renderer completion.
- Retire fresh terminals only after process exit. Honor explicit operator-close, signal, and unverified-stop causes instead of treating a zero code as success despite contrary evidence.

## Why

On Orca 1.4.197, Automation Health Watch run `ad7d4a06-af46-4d55-ad59-0126cc32c1e1` was recorded `completed` approximately five seconds after dispatch with echoed prompt fragments. Its exact terminal `term_1f32446b-e714-408e-af14-5b346d7e6e2d` remained connected and working for over two minutes. Only after terminal exit did the snapshot become a non-truncated final starting `CONFIG_STAMP: ORCA-HEALTH-2026-09-04-R14` and `STATUS: DONE`, with `terminalSessionId` cleared. Abstraction Police run `e3c427b8-0dd9-4103-aac0-892112eb9807` similarly completed with only a mid-work sentence.

The regression against unchanged main settlement code (`f952f1ac96dce3d2f92c0aacf548f1ec6c53da69`) failed with **Expected: dispatched; Received: completed**. The new test also holds capture pending after exit, then checks that every completed publication contains the final snapshot and null terminal identifiers.

## Linked Issue

External product-fix context: [RobinReturn ROB-1925](https://linear.app/robinretunr/issue/ROB-1925/stop-orca-scheduled-jobs-from-false-completing-at-startup-and-reduce).

Related upstream reports: #18131 and #17658. This builds on #18087; #16801 addresses related Codex turn ordering. This contribution adds the process-exit/final-capture settlement boundary rather than replacing those authors' branches.

## Visual Proof

N/A — No visual change. The change affects background run lifecycle and persistence; no layout, styling, controls, or shortcuts change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Validation performed on macOS arm64 with Node 24 and `ORCA_BACKGROUND_LAUNCH=1`. Real runtime objects exercise local and SSH-tagged terminal lifecycles without launching agents or touching live automation configuration. Linux, Windows, WSL, and a live SSH/paired-runtime journey were not run locally.

- Regression before the settlement fix: `pnpm test src/main/automations/automation-final-settlement.test.ts -t 'rejects startup completion'` — failed: expected `dispatched`, received `completed`.
- `pnpm test src/main/automations src/main/persistence-automations.test.ts src/main/headless-automation-dispatcher-source-boundary.test.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts src/renderer/src/lib/automation-terminal-ownership.test.ts src/renderer/src/lib/automation-session-observer.test.ts` — **31 files, 266 tests passed** (final review revision).
- `pnpm tc` — passed all three projects.
- `pnpm run check:code-quality:changed` — passed native, type-aware, and React Doctor scans with **0 new findings**.
- `pnpm lint` — passed, including reliability gates, max-lines/ts-nocheck/runtime-electron ratchets, bundled skill checks, and localization checks (existing warnings remain).
- `pnpm run build:desktop` — passed desktop, CLI, renderer, and web build; 518 skill CLI closure files/5 commands verified. The build's global `orca-dev` symlink write was blocked to keep changes checkout-local.
- `pnpm build` / `pnpm run build:native` — native packaging cannot finish with this host's Swift 6.4 Command Line Tools: x86_64 Swift compatibility archives are absent when linking the keyboard-layout helper. Computer-use helper compilation succeeds after prebuilding both triples with SwiftPM's native build engine; no build-script or release changes are included.
- Cross-version retry after fetching required tags: `pnpm test tests/e2e/cross-version-wire/release-checkout.unit.test.ts tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts src/main/daemon/repro-13767-shell-ready-marker-lost-to-exec.test.ts --maxWorkers=1` — both cross-version files passed; aggregate **32 passed, 2 failed, 2 skipped**. The two remaining failures are unchanged shell-ready real-process tests timing out waiting for PTY output.
- `git diff --check HEAD~1 HEAD` — passed.
- Review regressions against `03050d0dcc`: `pnpm test src/main/automations/automation-final-settlement.test.ts src/main/automations/runtime-terminal-run-observer.test.ts src/renderer/src/hooks/automation-dispatch-unverifiable-loss.test.ts src/renderer/src/hooks/useAutomationDispatchEvents.test.ts` — **10 failed, 36 passed** before the fixes. They reproduce missing-pane stranding, eager terminal retirement, and exit-cause misclassification; all are covered by the passing 266-test suite above.
- Final review revision `0a9fdb3f8`: reran the targeted suite, typechecking through `build:desktop`, full lint, changed-code quality, desktop/CLI/web build, and all commit lint/React Doctor/format checks successfully. The initial full-suite/native-toolchain limitations below remain documented; those broad checks were not rerun for this focused review follow-up.
- Full `pnpm test --maxWorkers=4` at initial revision `03050d0dcc` — **73,839 passed, 9 failed, 380 skipped**; **7,958 files passed, 4 failed, 58 skipped**; one unhandled rejection. Six failed assertions, the suite setup failure, and the unhandled rejection were caused by the initially missing `v1.4.190` tag; both affected cross-version files pass on the retry above. Remaining local limitations: two unchanged shell-ready PTY-output timeouts and the real Claude resume integration stopping at its workspace-trust prompt. No live CLI trust settings were changed.
- The commit-hook lint/React Doctor/format checks were also run directly on all 17 changed source/test files, without the hook's automatic stash, to honor checkout ownership.

## AI Disclosure

Implemented and self-reviewed with OpenAI Codex (GPT-6).

## Author

X (Twitter): N/A — the authenticated GitHub profile (`mincce`) has no `twitter_username`.

## Review

- Cross-platform: no new OS commands, paths, shortcuts, or platform branches. Uses existing terminal exit classification and lifecycle APIs.
- Local/SSH/remote: the execution authority owns settlement; negative/missing exit evidence and transport loss cannot produce success. Workspace, pane, and PTY identity are checked. Existing folder workspaces remain supported.
- Agents/integrations/providers: no provider-specific status text, stamp parsing, GitHub behavior, or new dependencies. Reusable sessions remain borrowed across turns. A live interactive headless agent remains dispatched until it exits.
- Performance: removes startup/idle polling and redundant headless observation; one existing exit waiter and one exit subscription per active run, cleaned up on settlement or abort. Output capture stays bounded. Unresolved panes reuse the existing reconciliation timer and receive their own grace period even after a long-running authority startup.
- UI/backward compatibility: no visual change or terminal protocol changes. The run's optional `reuseSession` snapshot is safe for old readers; legacy rows fall back to the definition. Old renderer completion reports cannot bypass the authority fence.
- Security: no additional execution authority, network endpoints, secrets, or destructive operations. Terminal shutdown stays with the existing ownership/close path after proven exit and retains user-takeover checks.

## Agent skill upstream boundary

- [x] Not applicable. No skill installer source or bundled skill content changes.

## Notes

Release versions are unchanged. This PR is not merged by this contribution.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

