### PR TITLE
fix(automations): reject unsupported RRULE fields

### DIFF
--- a/docs/site/content/docs/cli/automations.mdx
+++ b/docs/site/content/docs/cli/automations.mdx
@@ -22,6 +22,8 @@ orca automations create \
 
 `--trigger` accepts presets such as `hourly`, `daily`, `weekdays`, and `weekly`, plus cron expressions or RRULE strings. Use `--timezone <tz>` when the schedule should follow a specific IANA timezone instead of the runtime default.
 
+RRULE support is limited to `FREQ=HOURLY` with an optional `BYMINUTE`, `FREQ=DAILY` with optional `BYHOUR` and `BYMINUTE`, and `FREQ=WEEKLY` with a required `BYDAY` list plus optional `BYHOUR` and `BYMINUTE`. Hours and minutes must be single integers; weekly days use `SU,MO,TU,WE,TH,FR,SA`. The defaults are hour 9 and minute 0. Other fields, including `INTERVAL`, `COUNT`, and `UNTIL`, are rejected instead of silently ignored. Existing invalid schedules are paused when due, with an explanation in run history; edit the trigger and re-enable the automation to resume it.
+
 ## Choose where runs happen
 
 Use `--repo <selector>` when each run should create or select work in a repository. Use `--workspace <selector>` when the automation should run inside an existing Orca worktree instead:

--- a/src/cli/index-automation-schedule.test.ts
+++ b/src/cli/index-automation-schedule.test.ts
@@ -88,6 +88,11 @@ describe('orca cli worktree awareness', () => {
 
   it.each([
     {
+      name: 'unsupported RRULE interval',
+      args: ['--trigger', 'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU'],
+      message: 'Invalid automation trigger'
+    },
+    {
       name: 'day on daily preset',
       args: ['--trigger', 'daily', '--day', '2'],
       message: '--day can only be used with the weekly automation preset'

--- a/src/main/automations/evaluate-due-automations.ts
+++ b/src/main/automations/evaluate-due-automations.ts
@@ -1,0 +1,32 @@
+import type { Store } from '../persistence'
+import type { Automation } from '../../shared/automations-types'
+import type { PublishAutomationsChanged } from '../../shared/runtime-client-events'
+import { isValidAutomationSchedule } from '../../shared/automation-schedule-parsing'
+import type { AutomationRunWriter } from './automation-run-writer'
+
+export async function evaluateDueAutomations(
+  store: Store,
+  runs: AutomationRunWriter,
+  evaluate: (automation: Automation, now: number) => Promise<void>,
+  publish: PublishAutomationsChanged | null
+): Promise<void> {
+  const now = Date.now()
+  for (const automation of store.listAutomations()) {
+    if (!automation.enabled || automation.nextRunAt > now) {
+      continue
+    }
+    // Older clients could persist fields that the scheduler never implemented.
+    if (!isValidAutomationSchedule(automation.rrule)) {
+      const run = runs.createRun(automation, automation.nextRunAt)
+      runs.updateRun({
+        runId: run.id,
+        status: 'skipped_unavailable',
+        error: 'Invalid automation schedule. Update the trigger and re-enable this automation.'
+      })
+      store.updateAutomation(automation.id, { enabled: false })
+      publish?.({ reason: 'definition' })
+      continue
+    }
+    await evaluate(automation, now)
+  }
+}

--- a/src/main/automations/service-invalid-recurrence.test.ts
+++ b/src/main/automations/service-invalid-recurrence.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { PersistedState } from '../../shared/persisted-state-types'
+import {
+  createStore,
+  makeRepo,
+  readDataFile,
+  testState,
+  writeDataFile
+} from '../persistence-test-harness'
+import { AutomationService } from './service'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(plaintext),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString()
+  }
+}))
+
+beforeEach(() => {
+  testState.dir = mkdtempSync(join(tmpdir(), 'orca-invalid-recurrence-'))
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-06T08:59:00'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  rmSync(testState.dir, { recursive: true, force: true })
+})
+
+it('pauses an unsupported persisted RRULE without blocking another due automation', async () => {
+  const initial = await createStore()
+  initial.addRepo(makeRepo())
+  const input = {
+    name: 'A unsupported',
+    prompt: 'Review',
+    agentId: 'codex' as const,
+    projectId: 'r1',
+    workspaceMode: 'existing' as const,
+    workspaceId: 'wt1',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+    dtstart: Date.parse('2026-09-01T00:00:00')
+  }
+  const bad = initial.createAutomation(input)
+  const good = initial.createAutomation({ ...input, name: 'B valid' })
+  initial.flush()
+  const state = readDataFile() as PersistedState
+  state.automations.find((entry) => entry.id === bad.id)!.rrule += ';COUNT=1'
+  writeDataFile(state)
+  const store = await createStore()
+  vi.setSystemTime(new Date('2026-09-06T09:01:00'))
+  const send = vi.fn()
+  const service = new AutomationService(store)
+  service.setWebContents({ isDestroyed: () => false, send } as never)
+  service.start()
+  try {
+    service.setRendererReady()
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send.mock.calls[0][1].automation.id).toBe(good.id)
+    expect(store.listAutomations().find((entry) => entry.id === bad.id)?.enabled).toBe(false)
+    expect(store.listAutomationRuns(bad.id)[0]).toMatchObject({
+      status: 'skipped_unavailable',
+      error: expect.stringContaining('Invalid automation schedule')
+    })
+    expect(store.listAutomations().find((entry) => entry.id === bad.id)?.rrule).toContain('COUNT=1')
+  } finally {
+    service.stop()
+  }
+})

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -1,5 +1,6 @@
 import type { WebContents } from 'electron'
 import type { Store } from '../persistence'
+import { evaluateDueAutomations } from './evaluate-due-automations'
 import {
   isFinalAutomationRunStatus,
   type Automation,
@@ -231,13 +232,12 @@ export class AutomationService {
     }
     this.evaluating = true
     try {
-      const now = Date.now()
-      for (const automation of this.store.listAutomations()) {
-        if (!automation.enabled || automation.nextRunAt > now) {
-          continue
-        }
-        await this.evaluateAutomation(automation, now)
-      }
+      await evaluateDueAutomations(
+        this.store,
+        this.runs,
+        (automation, now) => this.evaluateAutomation(automation, now),
+        this.publish
+      )
     } finally {
       this.evaluating = false
     }

--- a/src/main/runtime/rpc/methods/automation-rrule-validation.test.ts
+++ b/src/main/runtime/rpc/methods/automation-rrule-validation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { AutomationCreate, AutomationUpdate } from './automation-schemas'
+
+describe('automation RPC recurrence validation', () => {
+  it.each([
+    'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU',
+    'FREQ=DAILY;COUNT=1',
+    'FREQ=DAILY;UNTIL=20260906T090000Z'
+  ])('rejects unsupported RRULE fields on create and update: %s', (rrule) => {
+    expect(
+      AutomationCreate.safeParse({
+        name: 'Review',
+        prompt: 'Review changes',
+        agentId: 'codex',
+        rrule,
+        dtstart: 0
+      }).success
+    ).toBe(false)
+    expect(AutomationUpdate.safeParse({ id: 'auto-1', updates: { rrule } }).success).toBe(false)
+  })
+})

--- a/src/shared/automation-rrule-fields.ts
+++ b/src/shared/automation-rrule-fields.ts
@@ -1,0 +1,16 @@
+export function parseRruleEntries(rrule: string): Map<string, string> {
+  const entries = new Map<string, string>()
+  for (const part of rrule.split(';')) {
+    const terms = part.split('=')
+    const [key, value] = terms
+    if (terms.length !== 2 || !key || !value || entries.has(key.toUpperCase())) {
+      throw new Error('Invalid recurrence field.')
+    }
+    const normalizedKey = key.toUpperCase()
+    if (!['FREQ', 'BYHOUR', 'BYMINUTE', 'BYDAY'].includes(normalizedKey)) {
+      throw new Error(`Unsupported recurrence field: ${key}.`)
+    }
+    entries.set(normalizedKey, value)
+  }
+  return entries
+}

--- a/src/shared/automation-rrule-validation.test.ts
+++ b/src/shared/automation-rrule-validation.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { isValidAutomationSchedule, parseSchedule } from './automation-schedule-parsing'
+import {
+  buildAutomationRrule,
+  nextAutomationOccurrenceAfter
+} from './automation-schedule-occurrences'
+
+describe('supported automation RRULE subset', () => {
+  it.each([
+    'FREQ=WEEKLY;INTERVAL=2;BYDAY=SU',
+    'FREQ=DAILY;COUNT=1',
+    'FREQ=DAILY;UNTIL=20260906T090000Z',
+    'FREQ=DAILY;BYMONTH=9',
+    'FREQ=WEEKLY;BYDAY=MO;WKST=SU',
+    'FREQ=DAILY;BYSECOND=30',
+    'FREQ=DAILY;BYDAY=MO',
+    'FREQ=HOURLY;BYHOUR=9',
+    'FREQ=HOURLY;BYDAY=MO',
+    'FREQ=DAILY;FREQ=HOURLY',
+    'FREQ=DAILY;BYHOUR=9;byhour=10',
+    'FREQ=DAILY;BYMINUTE=',
+    'FREQ=DAILY;BYHOUR=9=10',
+    'FREQ=DAILY;garbage',
+    'FREQ=DAILY;',
+    'FREQ=DAILY;BYHOUR= ',
+    'FREQ=DAILY;BYMINUTE=0x10',
+    'FREQ=WEEKLY;BYDAY=MO,,TU'
+  ])('rejects unsupported or malformed recurrence: %s', (rrule) => {
+    expect(isValidAutomationSchedule(rrule)).toBe(false)
+    expect(() => parseSchedule(rrule)).toThrow()
+    expect(() => nextAutomationOccurrenceAfter(rrule, 0, Date.now())).toThrow()
+  })
+
+  it.each(['hourly', 'daily', 'weekdays', 'weekly'] as const)(
+    'accepts generated %s schedules',
+    (preset) => {
+      expect(isValidAutomationSchedule(buildAutomationRrule({ preset, hour: 9, minute: 15 }))).toBe(
+        true
+      )
+    }
+  )
+
+  it('keeps multi-day weekly rules and optional time defaults', () => {
+    expect(parseSchedule('FREQ=WEEKLY;BYDAY=MO,WE')).toMatchObject({
+      freq: 'WEEKLY',
+      byDay: ['MO', 'WE'],
+      byHour: 9,
+      byMinute: 0
+    })
+    expect(isValidAutomationSchedule('FREQ=DAILY')).toBe(true)
+    expect(isValidAutomationSchedule('15 9 * * 1-5')).toBe(true)
+  })
+})

--- a/src/shared/automation-schedule-parsing.ts
+++ b/src/shared/automation-schedule-parsing.ts
@@ -1,5 +1,6 @@
 import type { AutomationSchedulePreset } from './automations-types'
 import { cronHasPossibleOccurrence } from './automation-cron-occurrence'
+import { parseRruleEntries } from './automation-rrule-fields'
 
 import { isClipboardTextByteLengthOverLimit } from './clipboard-text'
 
@@ -58,26 +59,25 @@ const DAY_NAMES: Record<string, number> = {
 }
 
 function parseRrule(rrule: string): ParsedRrule {
-  const entries = new Map<string, string>()
-  for (const part of rrule.split(';')) {
-    const [key, value] = part.split('=')
-    if (key && value) {
-      entries.set(key.toUpperCase(), value)
-    }
-  }
+  const entries = parseRruleEntries(rrule)
   const freq = entries.get('FREQ')
   if (freq !== 'HOURLY' && freq !== 'DAILY' && freq !== 'WEEKLY') {
     throw new Error('Unsupported automation recurrence.')
   }
-  const byHour = Number(entries.get('BYHOUR') ?? '9')
-  const byMinute = Number(entries.get('BYMINUTE') ?? '0')
-  if (!Number.isInteger(byHour) || byHour < 0 || byHour > 23) {
+  if ((freq !== 'WEEKLY' && entries.has('BYDAY')) || (freq === 'HOURLY' && entries.has('BYHOUR'))) {
+    throw new Error('Unsupported recurrence field for this frequency.')
+  }
+  const hour = entries.get('BYHOUR') ?? '9'
+  const minute = entries.get('BYMINUTE') ?? '0'
+  const byHour = Number(hour)
+  const byMinute = Number(minute)
+  if (!/^\d{1,2}$/.test(hour) || byHour > 23) {
     throw new Error('Invalid recurrence hour.')
   }
-  if (!Number.isInteger(byMinute) || byMinute < 0 || byMinute > 59) {
+  if (!/^\d{1,2}$/.test(minute) || byMinute > 59) {
     throw new Error('Invalid recurrence minute.')
   }
-  const byDay = (entries.get('BYDAY') ?? '').split(',').filter(Boolean)
+  const byDay = entries.get('BYDAY')?.split(',') ?? []
   if (
     freq === 'WEEKLY' &&
     (byDay.length === 0 ||


### PR DESCRIPTION
## ELI5

An automation that asks for every other week, one run only, or an end date should not silently run forever at a different cadence. Orca now rejects recurrence fields it cannot execute and pauses previously saved invalid schedules with a recoverable explanation.

## What Changed

- Validate RRULE fields and separators, reject duplicate keys, and reject fields the selected frequency ignores. Keep generated hourly/daily/weekly presets and supported multi-day weekly rules.
- Pause invalid persisted schedules when due, record the reason in run history, and continue evaluating healthy siblings. Preserve the original trigger so it can be edited and re-enabled.
- Document the supported RRULE subset; cover shared parsing, CLI and RPC validation, and persisted schedule recovery.

## Why

For example, FREQ=WEEKLY;INTERVAL=2;BYDAY=SU previously validated but ran every week. COUNT and UNTIL were also ignored. Rejecting unsupported semantics keeps the existing scheduler contract small. The due-run loop is extracted to stay within the existing max-lines limit.

## Linked Issue

Reported during a source audit; no separate tracker issue was filed.

## Visual Proof

N/A — this changes shared scheduling/formatting logic, with no new UI components or layout. Observable behavior is covered by the before/after regression cases below.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local macOS arm64, Node 26.0.0, pnpm 12.0.0. The new regressions were run against the original behavior before applying the fix. The final targeted run passes **74 tests**:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=2 src/shared/automation-rrule-validation.test.ts src/shared/automation-schedules.test.ts src/main/automations/service-invalid-recurrence.test.ts src/main/automations/service.test.ts src/cli/index-automation-schedule.test.ts src/main/runtime/rpc/methods/automations.test.ts src/main/runtime/rpc/methods/automation-rrule-validation.test.ts
```

Also passed locally:

```sh
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/run-typecheck-projects-in-parallel.mjs
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/check-changed-code-quality.mjs
```

These run all three TypeScript projects and the changed-file code-quality, type-aware and React Doctor gates. Tests use isolated temporary state and background launch mode. Full application build, the complete repository test suite, real SSH-host execution and Windows/Linux runs were not performed locally; the upstream CI matrix still needs to run. No manual Electron UI session was run.

## AI Disclosure

Codex (GPT-6) assisted with diagnosis, implementation, test design and self-review. The listed local checks were executed; their results are not inferred from the diff.

## Review

Cross-platform: shared TypeScript validation with no platform APIs. Local/SSH/runtime: validation follows the same shared parser and the scheduling authority keeps ownership. Agents/integrations: provider-neutral; RPC shapes are unchanged, while unsupported input now returns an error. Performance: bounded field parsing and the existing due-run pass; invalid rows are paused once. UI: existing run-history and schedule labels, with no new components. Security: no new filesystem, process, network or credential access.

## Agent skill upstream boundary

- [x] Not applicable; no upstream agent skill content is copied or translated.

## Notes

Related: #15902 also isolates malformed schedules, but targets cron step ranges. This PR addresses unsupported RRULE semantics and pauses invalid saved rows instead of executing a guessed recurrence. No protocol version or persisted schema change.

X/Twitter handle: not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint/typecheck/test/build all pass — targeted tests, full typecheck and changed-code gates pass locally; full CI/build remain pending
