### PR TITLE
fix(automations): scan calendar days across daylight saving changes

### DIFF
--- a/src/shared/automation-cron-occurrence.ts
+++ b/src/shared/automation-cron-occurrence.ts
@@ -1,6 +1,5 @@
 import type { ParsedCron } from './automation-schedule-parsing'
 
-const DAY_MS = 24 * 60 * 60 * 1000
 const CRON_SCAN_DAYS = 9 * 366
 
 export function startOfLocalDay(timestamp: number): number {
@@ -42,7 +41,9 @@ export function cronHasPossibleOccurrence(rule: ParsedCron, anchor: number): boo
     if (cronDateMatches(rule, day)) {
       return true
     }
-    day += DAY_MS
+    const nextDay = new Date(day)
+    nextDay.setDate(nextDay.getDate() + 1)
+    day = startOfLocalDay(nextDay.getTime())
   }
   return false
 }

--- a/src/shared/automation-schedule-dst.test.ts
+++ b/src/shared/automation-schedule-dst.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  latestAutomationOccurrenceAtOrBefore,
+  nextAutomationOccurrenceAfter
+} from './automation-schedule-occurrences'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('automation calendar-day iteration across DST', () => {
+  it.each([
+    {
+      timezone: 'America/New_York',
+      now: '2026-03-09T00:30:00-04:00',
+      expected: '2026-03-08T23:30:00-04:00'
+    },
+    {
+      timezone: 'Australia/Lord_Howe',
+      now: '2026-10-05T00:15:00+11:00',
+      expected: '2026-10-04T23:30:00+11:00'
+    }
+  ])(
+    'finds the previous calendar day after spring-forward in $timezone',
+    ({ timezone, now, expected }) => {
+      vi.stubEnv('TZ', timezone)
+      for (const rrule of [
+        'FREQ=DAILY;BYHOUR=23;BYMINUTE=30',
+        'FREQ=WEEKLY;BYDAY=SU;BYHOUR=23;BYMINUTE=30'
+      ]) {
+        expect(
+          latestAutomationOccurrenceAtOrBefore(
+            rrule,
+            Date.parse('2026-01-01T00:00:00Z'),
+            Date.parse(now)
+          )
+        ).toBe(Date.parse(expected))
+      }
+    }
+  )
+
+  it('finds the next calendar day across fall-back and respects dtstart', () => {
+    vi.stubEnv('TZ', 'America/New_York')
+    const rrule = 'FREQ=DAILY;BYHOUR=23;BYMINUTE=30'
+    const start = Date.parse('2026-11-01T23:45:00-05:00')
+    const expected = Date.parse('2026-11-02T23:30:00-05:00')
+    expect(nextAutomationOccurrenceAfter(rrule, start, start)).toBe(expected)
+    expect(latestAutomationOccurrenceAtOrBefore(rrule, start, expected - 1)).toBeNull()
+    expect(latestAutomationOccurrenceAtOrBefore(rrule, start, expected)).toBe(expected)
+  })
+})

--- a/src/shared/automation-schedule-occurrences.ts
+++ b/src/shared/automation-schedule-occurrences.ts
@@ -2,7 +2,6 @@ import type { AutomationSchedulePreset } from './automations-types'
 import { parseSchedule, type ParsedRrule } from './automation-schedule-parsing'
 import { cronMatches, floorToMinute, startOfLocalDay } from './automation-cron-occurrence'
 
-const DAY_MS = 24 * 60 * 60 * 1000
 const HOUR_MS = 60 * 60 * 1000
 const MINUTE_MS = 60 * 1000
 // Why: valid cron expressions like Feb 29 can have an 8-year gap across non-leap centuries.
@@ -35,7 +34,9 @@ function scanDayCandidates(rule: ParsedRrule, anchor: number, direction: 1 | -1)
         return candidate
       }
     }
-    day += direction * DAY_MS
+    const nextDay = new Date(day)
+    nextDay.setDate(nextDay.getDate() + direction)
+    day = startOfLocalDay(nextDay.getTime())
   }
   return null
 }


### PR DESCRIPTION
## ELI5

An automation due late Sunday could look a whole day older after the spring clock change, causing Orca to skip a valid catch-up run. Walking calendar dates keeps the latest occurrence on the correct day.

## What Changed

- Advance and retreat by local calendar dates when scanning daily/weekly RRULE candidates, and normalize each day boundary.
- Apply the same calendar-day iteration to cron date feasibility checks.
- Add New York one-hour and Lord Howe half-hour spring-forward regressions, plus fall-back and dtstart boundary coverage.

## Why

In America/New_York at 2026-03-09 00:30, a daily 23:30 rule previously returned March 7 instead of March 8. Subtracting 24 hours from local midnight crosses a 23-hour day and skips the intended calendar date. Date.setDate preserves the calendar boundary.

## Linked Issue

Reported during a source audit; no separate tracker issue was filed.

## Visual Proof

N/A — this changes shared scheduling/formatting logic, with no new UI components or layout. Observable behavior is covered by the before/after regression cases below.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local macOS arm64, Node 26.0.0, pnpm 12.0.0. The new regressions were run against the original behavior before applying the fix. The final targeted run passes **26 tests**:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=2 src/shared/automation-schedule-dst.test.ts src/shared/automation-schedules.test.ts
```

Also passed locally:

```sh
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/run-typecheck-projects-in-parallel.mjs
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/check-changed-code-quality.mjs
```

These run all three TypeScript projects and the changed-file code-quality, type-aware and React Doctor gates. Tests use isolated temporary state and background launch mode. Full application build, the complete repository test suite, real SSH-host execution and Windows/Linux runs were not performed locally; the upstream CI matrix still needs to run. No manual Electron UI session was run.

## AI Disclosure

Codex (GPT-6) assisted with diagnosis, implementation, test design and self-review. The listed local checks were executed; their results are not inferred from the diff.

## Review

Cross-platform: standard Date calendar operations, exercised with explicit test timezones. Local/SSH/runtime: shared occurrence computation remains on the scheduling host. Agents/integrations: no provider or transport changes. Performance: the same bounded scans and constant work per day. UI: no renderer change. Security: no new I/O or privileges; tests restore their TZ environment.

## Agent skill upstream boundary

- [x] Not applicable; no upstream agent skill content is copied or translated.

## Notes

This PR fixes calendar-day traversal. It preserves the existing behavior for a scheduled clock time that itself falls in a missing or repeated hour; explicit named-timezone handling is a separate PR.

X/Twitter handle: not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint/typecheck/test/build all pass — targeted tests, full typecheck and changed-code gates pass locally; full CI/build remain pending
