### PR TITLE
fix(automations): honor the saved schedule timezone

### DIFF
--- a/docs/site/content/docs/cli/automations.mdx
+++ b/docs/site/content/docs/cli/automations.mdx
@@ -22,6 +22,8 @@ orca automations create \
 
 `--trigger` accepts presets such as `hourly`, `daily`, `weekdays`, and `weekly`, plus cron expressions or RRULE strings. Use `--timezone <tz>` when the schedule should follow a specific IANA timezone instead of the runtime default.
 
+Cron and RRULE times are evaluated in the saved timezone on the scheduling host, including hourly schedules in zones with fractional-hour offsets. Updating only `--timezone` also recomputes the next run. At a daylight-saving transition, nonexistent local times are skipped and repeated local times match both instants. Invalid timezone names are rejected; an existing invalid timezone pauses the automation when due and records an explanation in run history.
+
 ## Choose where runs happen
 
 Use `--repo <selector>` when each run should create or select work in a repository. Use `--workspace <selector>` when the automation should run inside an existing Orca worktree instead:

--- a/src/main/automations/scheduled-automation-occurrence.ts
+++ b/src/main/automations/scheduled-automation-occurrence.ts
@@ -1,0 +1,43 @@
+import type { Store } from '../persistence'
+import type { Automation } from '../../shared/automations-types'
+import type { PublishAutomationsChanged } from '../../shared/runtime-client-events'
+import { isValidAutomationTimezone } from '../../shared/automation-zoned-occurrences'
+import type { AutomationRunWriter } from './automation-run-writer'
+
+export function prepareScheduledAutomationOccurrence(
+  store: Store,
+  runs: AutomationRunWriter,
+  automation: Automation,
+  now: number,
+  publish: PublishAutomationsChanged | null
+): number | null {
+  if (!isValidAutomationTimezone(automation.timezone)) {
+    const run = runs.createRun(automation, automation.nextRunAt)
+    runs.updateRun({
+      runId: run.id,
+      status: 'skipped_unavailable',
+      error: 'Invalid automation timezone. Update the timezone and re-enable this automation.'
+    })
+    store.updateAutomation(automation.id, { enabled: false })
+    publish?.({ reason: 'definition' })
+    return null
+  }
+  const scheduledFor = store.getLatestAutomationOccurrence(automation, now)
+  if (scheduledFor === null) {
+    store.advanceAutomationNextRun(automation.id, now)
+    return null
+  }
+  const graceMs = automation.missedRunGraceMinutes * 60 * 1000
+  if (now - scheduledFor > graceMs) {
+    const missed = runs.createRun(automation, scheduledFor)
+    runs.updateRun({
+      runId: missed.id,
+      status: 'skipped_missed',
+      workspaceId: automation.workspaceId,
+      error: 'Orca was unavailable during the missed-run grace window.'
+    })
+    store.advanceAutomationNextRun(automation.id, now)
+    return null
+  }
+  return scheduledFor
+}

--- a/src/main/automations/service-invalid-timezone.test.ts
+++ b/src/main/automations/service-invalid-timezone.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { PersistedState } from '../../shared/persisted-state-types'
+import {
+  createStore,
+  makeRepo,
+  readDataFile,
+  testState,
+  writeDataFile
+} from '../persistence-test-harness'
+import { AutomationService } from './service'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(plaintext),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString()
+  }
+}))
+
+beforeEach(() => {
+  testState.dir = mkdtempSync(join(tmpdir(), 'orca-invalid-timezone-'))
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-06T08:59:00'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  rmSync(testState.dir, { recursive: true, force: true })
+})
+
+it('pauses an invalid persisted timezone without blocking another due automation', async () => {
+  const initial = await createStore()
+  initial.addRepo(makeRepo())
+  const input = {
+    name: 'A unsupported',
+    prompt: 'Review',
+    agentId: 'codex' as const,
+    projectId: 'r1',
+    workspaceMode: 'existing' as const,
+    workspaceId: 'wt1',
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+    dtstart: Date.parse('2026-09-01T00:00:00')
+  }
+  const bad = initial.createAutomation(input)
+  const good = initial.createAutomation({ ...input, name: 'B valid' })
+  initial.flush()
+  const state = readDataFile() as PersistedState
+  state.automations.find((entry) => entry.id === bad.id)!.timezone = 'Mars/Olympus_Mons'
+  writeDataFile(state)
+  const store = await createStore()
+  vi.setSystemTime(new Date('2026-09-06T09:01:00'))
+  const send = vi.fn()
+  const service = new AutomationService(store)
+  service.setWebContents({ isDestroyed: () => false, send } as never)
+  service.start()
+  try {
+    service.setRendererReady()
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send.mock.calls[0][1].automation.id).toBe(good.id)
+    expect(store.listAutomations().find((entry) => entry.id === bad.id)?.enabled).toBe(false)
+    expect(store.listAutomationRuns(bad.id)[0]).toMatchObject({
+      status: 'skipped_unavailable',
+      error: expect.stringContaining('Invalid automation timezone')
+    })
+    expect(store.listAutomations().find((entry) => entry.id === bad.id)?.timezone).toBe(
+      'Mars/Olympus_Mons'
+    )
+  } finally {
+    service.stop()
+  }
+})

--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -49,11 +49,13 @@ const makeRepo = (overrides: Partial<Repo> = {}): Repo => ({
 describe('AutomationService', () => {
   beforeEach(() => {
     testState.dir = mkdtempSync(join(tmpdir(), 'orca-automations-test-'))
+    vi.stubEnv('TZ', 'UTC')
     vi.useFakeTimers()
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllEnvs()
     rmSync(testState.dir, { recursive: true, force: true })
   })
 

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -1,5 +1,6 @@
 import type { WebContents } from 'electron'
 import type { Store } from '../persistence'
+import { prepareScheduledAutomationOccurrence } from './scheduled-automation-occurrence'
 import {
   isFinalAutomationRunStatus,
   type Automation,
@@ -244,21 +245,14 @@ export class AutomationService {
   }
 
   private async evaluateAutomation(automation: Automation, now: number): Promise<void> {
-    const scheduledFor = this.store.getLatestAutomationOccurrence(automation, now)
+    const scheduledFor = prepareScheduledAutomationOccurrence(
+      this.store,
+      this.runs,
+      automation,
+      now,
+      this.publish
+    )
     if (scheduledFor === null) {
-      this.store.advanceAutomationNextRun(automation.id, now)
-      return
-    }
-    const graceMs = automation.missedRunGraceMinutes * 60 * 1000
-    if (now - scheduledFor > graceMs) {
-      const missed = this.runs.createRun(automation, scheduledFor)
-      this.runs.updateRun({
-        runId: missed.id,
-        status: 'skipped_missed',
-        workspaceId: automation.workspaceId,
-        error: 'Orca was unavailable during the missed-run grace window.'
-      })
-      this.store.advanceAutomationNextRun(automation.id, now)
       return
     }
 

--- a/src/main/persistence/scheduling-automations/automation-definition-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-definition-operations.ts
@@ -106,7 +106,7 @@ export function createAutomation(
     rrule: input.rrule,
     dtstart: input.dtstart,
     enabled: input.enabled ?? true,
-    nextRunAt: nextAutomationOccurrenceAfter(input.rrule, input.dtstart, now),
+    nextRunAt: nextAutomationOccurrenceAfter(input.rrule, input.dtstart, now, input.timezone),
     missedRunPolicy: 'run_once_within_grace',
     missedRunGraceMinutes: input.missedRunGraceMinutes ?? 720,
     createdAt: now,
@@ -157,7 +157,9 @@ export function updateAutomation(
   const contexts = getAutomationContextsForRepo(repo, operations.state.projectHostSetups ?? [])
   const rrule = updates.rrule ?? current.rrule
   const dtstart = updates.dtstart ?? current.dtstart
-  const scheduleChanged = updates.rrule !== undefined || updates.dtstart !== undefined
+  const timezone = updates.timezone ?? current.timezone
+  const scheduleChanged =
+    updates.rrule !== undefined || updates.dtstart !== undefined || updates.timezone !== undefined
   const workspaceMode = updates.workspaceMode ?? current.workspaceMode
   const merged: Automation = {
     ...current,
@@ -212,7 +214,7 @@ export function updateAutomation(
     rrule,
     dtstart,
     nextRunAt: scheduleChanged
-      ? nextAutomationOccurrenceAfter(rrule, dtstart, Date.now())
+      ? nextAutomationOccurrenceAfter(rrule, dtstart, Date.now(), timezone)
       : current.nextRunAt,
     updatedAt: Date.now()
   }

--- a/src/main/persistence/scheduling-automations/automation-schedule-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-schedule-operations.ts
@@ -16,7 +16,12 @@ export function advanceAutomationNextRun(
     throw new Error('Automation not found.')
   }
   const current = state.automations[index]
-  const nextRunAt = nextAutomationOccurrenceAfter(current.rrule, current.dtstart, now)
+  const nextRunAt = nextAutomationOccurrenceAfter(
+    current.rrule,
+    current.dtstart,
+    now,
+    current.timezone
+  )
   const updated = { ...current, nextRunAt, updatedAt: now }
   // Replaced, not patched in place: the list projection caches on array identity.
   state.automations = state.automations.map((entry) => (entry.id === id ? updated : entry))
@@ -28,5 +33,10 @@ export function getLatestAutomationOccurrence(
   automation: Automation,
   now = Date.now()
 ): number | null {
-  return latestAutomationOccurrenceAtOrBefore(automation.rrule, automation.dtstart, now)
+  return latestAutomationOccurrenceAtOrBefore(
+    automation.rrule,
+    automation.dtstart,
+    now,
+    automation.timezone
+  )
 }

--- a/src/main/persistence/scheduling-automations/automation-timezone-operations.test.ts
+++ b/src/main/persistence/scheduling-automations/automation-timezone-operations.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PersistedState } from '../../../shared/persisted-state-types'
+import {
+  createAutomation,
+  updateAutomation,
+  type AutomationDefinitionOperations
+} from './automation-definition-operations'
+import {
+  advanceAutomationNextRun,
+  getLatestAutomationOccurrence
+} from './automation-schedule-operations'
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllEnvs()
+})
+
+describe('persisted automation timezone', () => {
+  it('uses the timezone for create, timezone-only update, advance and catch-up', () => {
+    vi.stubEnv('TZ', 'UTC')
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-06T00:00:00Z'))
+    const operations: AutomationDefinitionOperations = {
+      state: {
+        repos: [{ id: 'r1', path: '/repo', displayName: 'test', badgeColor: '#fff', addedAt: 1 }],
+        automations: [],
+        projectHostSetups: [],
+        worktreeMeta: {}
+      } as unknown as PersistedState,
+      storageAuthority: 'runtime',
+      flush: vi.fn(),
+      recordCreated: vi.fn()
+    }
+    const automation = createAutomation(operations, {
+      name: 'Morning review',
+      prompt: 'Review',
+      agentId: 'codex',
+      projectId: 'r1',
+      workspaceMode: 'new_per_run',
+      timezone: 'Asia/Shanghai',
+      rrule: '0 9 * * *',
+      dtstart: Date.parse('2026-09-01T00:00:00Z')
+    })
+    expect(automation.nextRunAt).toBe(Date.parse('2026-09-06T01:00:00Z'))
+    const updated = updateAutomation(operations, automation.id, { timezone: 'America/New_York' })
+    expect(updated.nextRunAt).toBe(Date.parse('2026-09-06T13:00:00Z'))
+    const next = advanceAutomationNextRun(
+      operations.state,
+      operations.flush,
+      automation.id,
+      updated.nextRunAt
+    )
+    expect(next.nextRunAt).toBe(Date.parse('2026-09-07T13:00:00Z'))
+    expect(getLatestAutomationOccurrence(next, Date.parse('2026-09-06T14:00:00Z'))).toBe(
+      updated.nextRunAt
+    )
+    expect(() =>
+      updateAutomation(operations, automation.id, { timezone: 'Invalid/Timezone' })
+    ).toThrow()
+    expect(operations.state.automations[0].timezone).toBe('America/New_York')
+  })
+})

--- a/src/main/runtime/rpc/methods/automation-schemas.ts
+++ b/src/main/runtime/rpc/methods/automation-schemas.ts
@@ -1,6 +1,7 @@
 // Why: the automation method table stays readable only if its field-level validation lives beside it rather than inside it.
 import { z } from 'zod'
 import { isValidAutomationSchedule } from '../../../../shared/automation-schedule-parsing'
+import { isValidAutomationTimezone } from '../../../../shared/automation-zoned-occurrences'
 import {
   MAX_AUTOMATION_PRECHECK_TIMEOUT_SECONDS,
   normalizeAutomationPrecheckTimeoutSeconds
@@ -35,6 +36,11 @@ const ExecutionHostId = requiredString('Missing host id').transform((value, ctx)
 const AutomationSchedule = requiredString('Missing trigger').refine(isValidAutomationSchedule, {
   message: 'Invalid automation trigger'
 })
+
+const AutomationTimezone = OptionalString.refine(
+  (value) => value === undefined || isValidAutomationTimezone(value),
+  { message: 'Invalid automation timezone' }
+)
 
 const AutomationPrecheck = z
   .object({
@@ -156,7 +162,7 @@ export const AutomationCreate = z.object({
   baseBranch: OptionalPlainString,
   setupDecision: SetupDecision,
   reuseSession: OptionalBoolean,
-  timezone: OptionalString,
+  timezone: AutomationTimezone,
   rrule: AutomationSchedule,
   dtstart: requiredNumber('Missing trigger start time'),
   enabled: OptionalBoolean,
@@ -178,7 +184,7 @@ const AutomationUpdateFields = z.object({
   baseBranch: OptionalNullablePlainString,
   setupDecision: SetupDecision,
   reuseSession: OptionalBoolean,
-  timezone: OptionalString,
+  timezone: AutomationTimezone,
   rrule: AutomationSchedule.optional(),
   dtstart: requiredNumber('Missing trigger start time').optional(),
   enabled: OptionalBoolean,

--- a/src/main/runtime/rpc/methods/automation-timezone-validation.test.ts
+++ b/src/main/runtime/rpc/methods/automation-timezone-validation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { AutomationCreate, AutomationUpdate } from './automation-schemas'
+
+describe('automation RPC timezone validation', () => {
+  it.each(['Mars/Olympus_Mons', 'Not a timezone'])(
+    'rejects invalid timezones on create and update: %s',
+    (timezone) => {
+      expect(
+        AutomationCreate.safeParse({
+          name: 'Review',
+          prompt: 'Review',
+          agentId: 'codex',
+          timezone,
+          rrule: '0 9 * * *',
+          dtstart: 0
+        }).success
+      ).toBe(false)
+      expect(AutomationUpdate.safeParse({ id: 'auto-1', updates: { timezone } }).success).toBe(
+        false
+      )
+    }
+  )
+
+  it.each([undefined, 'UTC', 'Asia/Shanghai', 'America/New_York'])(
+    'preserves omitted and valid timezones: %s',
+    (timezone) => {
+      expect(
+        AutomationCreate.safeParse({
+          name: 'Review',
+          prompt: 'Review',
+          agentId: 'codex',
+          timezone,
+          rrule: '0 9 * * *',
+          dtstart: 0
+        }).success
+      ).toBe(true)
+      expect(AutomationUpdate.safeParse({ id: 'auto-1', updates: { timezone } }).success).toBe(true)
+    }
+  )
+})

--- a/src/shared/automation-cron-occurrence.ts
+++ b/src/shared/automation-cron-occurrence.ts
@@ -25,11 +25,20 @@ export function cronMatches(rule: ParsedCron, timestamp: number): boolean {
 
 export function cronDateMatches(rule: ParsedCron, timestamp: number): boolean {
   const date = new Date(timestamp)
-  if (!rule.months.has(date.getMonth() + 1)) {
+  return cronCalendarDateMatches(rule, date.getMonth() + 1, date.getDate(), date.getDay())
+}
+
+export function cronCalendarDateMatches(
+  rule: ParsedCron,
+  month: number,
+  dayOfMonth: number,
+  dayOfWeek: number
+): boolean {
+  if (!rule.months.has(month)) {
     return false
   }
-  const dayOfMonthMatches = rule.daysOfMonth.has(date.getDate())
-  const dayOfWeekMatches = rule.daysOfWeek.has(date.getDay())
+  const dayOfMonthMatches = rule.daysOfMonth.has(dayOfMonth)
+  const dayOfWeekMatches = rule.daysOfWeek.has(dayOfWeek)
   if (rule.dayOfMonthRestricted && rule.dayOfWeekRestricted) {
     return dayOfMonthMatches || dayOfWeekMatches
   }

--- a/src/shared/automation-schedule-occurrences.ts
+++ b/src/shared/automation-schedule-occurrences.ts
@@ -1,6 +1,7 @@
 import type { AutomationSchedulePreset } from './automations-types'
 import { parseSchedule, type ParsedRrule } from './automation-schedule-parsing'
 import { cronMatches, floorToMinute, startOfLocalDay } from './automation-cron-occurrence'
+import { zonedAutomationOccurrence } from './automation-zoned-occurrences'
 
 const DAY_MS = 24 * 60 * 60 * 1000
 const HOUR_MS = 60 * 60 * 1000
@@ -85,9 +86,17 @@ export function buildAutomationCronSchedule(args: {
 export function nextAutomationOccurrenceAfter(
   rrule: string,
   dtstart: number,
-  after: number
+  after: number,
+  timezone?: string
 ): number {
   const rule = parseSchedule(rrule)
+  if (timezone !== undefined) {
+    const candidate = zonedAutomationOccurrence(rule, dtstart, after, 1, timezone)
+    if (candidate === null) {
+      throw new Error('Unable to compute next automation run.')
+    }
+    return candidate
+  }
   if (rule.kind === 'cron') {
     let candidate = floorToMinute(Math.max(dtstart, after))
     if (candidate <= after) {
@@ -127,12 +136,16 @@ export function nextAutomationOccurrenceAfter(
 export function latestAutomationOccurrenceAtOrBefore(
   rrule: string,
   dtstart: number,
-  now: number
+  now: number,
+  timezone?: string
 ): number | null {
   if (now < dtstart) {
     return null
   }
   const rule = parseSchedule(rrule)
+  if (timezone !== undefined) {
+    return zonedAutomationOccurrence(rule, dtstart, now, -1, timezone)
+  }
   if (rule.kind === 'cron') {
     let candidate = floorToMinute(now)
     for (let i = 0; i < CRON_SCAN_MINUTES && candidate >= dtstart; i += 1) {

--- a/src/shared/automation-schedule-timezone.test.ts
+++ b/src/shared/automation-schedule-timezone.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  latestAutomationOccurrenceAtOrBefore,
+  nextAutomationOccurrenceAfter
+} from './automation-schedule-occurrences'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('automation occurrence timezones', () => {
+  it.each(['UTC', 'America/Los_Angeles'])('uses the saved timezone on a %s host', (host) => {
+    vi.stubEnv('TZ', host)
+    const start = Date.parse('2026-09-01T00:00:00Z')
+    for (const rule of ['0 9 * * *', 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0']) {
+      expect(
+        nextAutomationOccurrenceAfter(
+          rule,
+          start,
+          Date.parse('2026-09-06T00:00:00Z'),
+          'Asia/Shanghai'
+        )
+      ).toBe(Date.parse('2026-09-06T01:00:00Z'))
+      expect(
+        latestAutomationOccurrenceAtOrBefore(
+          rule,
+          start,
+          Date.parse('2026-09-06T02:00:00Z'),
+          'Asia/Shanghai'
+        )
+      ).toBe(Date.parse('2026-09-06T01:00:00Z'))
+    }
+    expect(process.env.TZ).toBe(host)
+  })
+
+  it('uses local weekdays and fractional-hour offsets', () => {
+    vi.stubEnv('TZ', 'UTC')
+    const now = Date.parse('2026-09-06T20:00:00Z')
+    for (const rule of ['0 9 * * 1', 'FREQ=WEEKLY;BYDAY=MO;BYHOUR=9;BYMINUTE=0']) {
+      expect(nextAutomationOccurrenceAfter(rule, 0, now, 'Asia/Kathmandu')).toBe(
+        Date.parse('2026-09-07T03:15:00Z')
+      )
+    }
+    expect(nextAutomationOccurrenceAfter('FREQ=HOURLY;BYMINUTE=0', 0, now, 'Asia/Kathmandu')).toBe(
+      Date.parse('2026-09-06T20:15:00Z')
+    )
+  })
+
+  it('skips nonexistent spring-forward times', () => {
+    for (const rule of ['30 2 * * *', 'FREQ=DAILY;BYHOUR=2;BYMINUTE=30']) {
+      expect(
+        nextAutomationOccurrenceAfter(
+          rule,
+          0,
+          Date.parse('2026-03-08T00:00:00-05:00'),
+          'America/New_York'
+        )
+      ).toBe(Date.parse('2026-03-09T02:30:00-04:00'))
+    }
+  })
+
+  it('finds both instants of a repeated local minute', () => {
+    const first = Date.parse('2026-11-01T01:30:00-04:00')
+    const second = Date.parse('2026-11-01T01:30:00-05:00')
+    for (const rule of ['30 1 * * *', 'FREQ=DAILY;BYHOUR=1;BYMINUTE=30']) {
+      expect(nextAutomationOccurrenceAfter(rule, 0, first, 'America/New_York')).toBe(second)
+      expect(latestAutomationOccurrenceAtOrBefore(rule, 0, second, 'America/New_York')).toBe(second)
+      expect(
+        latestAutomationOccurrenceAtOrBefore(rule, first + 1, second - 1, 'America/New_York')
+      ).toBeNull()
+    }
+  })
+
+  it('finds a leap day across a non-leap century without scanning every minute', () => {
+    expect(
+      nextAutomationOccurrenceAfter(
+        '0 9 29 2 *',
+        0,
+        Date.parse('2096-03-01T00:00:00Z'),
+        'Asia/Shanghai'
+      )
+    ).toBe(Date.parse('2104-02-29T01:00:00Z'))
+  })
+
+  it('rejects invalid timezones when computing occurrences', () => {
+    const timezone = 'Mars/Olympus_Mons'
+    expect(() => nextAutomationOccurrenceAfter('0 9 * * *', 0, Date.now(), timezone)).toThrow()
+  })
+})

--- a/src/shared/automation-zoned-occurrences.ts
+++ b/src/shared/automation-zoned-occurrences.ts
@@ -1,0 +1,124 @@
+import type { ParsedSchedule } from './automation-schedule-parsing'
+import { cronCalendarDateMatches } from './automation-cron-occurrence'
+
+const MINUTE_MS = 60_000
+const DAY_MS = 24 * 60 * MINUTE_MS
+const DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'] as const
+
+function timezoneFormatter(timezone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hourCycle: 'h23'
+  })
+}
+
+export function isValidAutomationTimezone(timezone: string): boolean {
+  try {
+    timezoneFormatter(timezone)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// UTC getters on this value describe the scheduled wall clock, never the host's timezone.
+function wallTime(formatter: Intl.DateTimeFormat, timestamp: number): number {
+  const fields: Record<string, number> = {}
+  for (const part of formatter.formatToParts(timestamp)) {
+    if (part.type !== 'literal') {
+      fields[part.type] = Number(part.value)
+    }
+  }
+  return Date.UTC(
+    fields.year,
+    fields.month - 1,
+    fields.day,
+    fields.hour,
+    fields.minute,
+    fields.second
+  )
+}
+
+function matchesDay(rule: ParsedSchedule, day: Date): boolean {
+  if (rule.kind === 'cron') {
+    return cronCalendarDateMatches(rule, day.getUTCMonth() + 1, day.getUTCDate(), day.getUTCDay())
+  }
+  return rule.freq !== 'WEEKLY' || rule.byDay.includes(DAY_CODES[day.getUTCDay()])
+}
+
+function dayOccurrences(
+  rule: ParsedSchedule,
+  day: number,
+  formatter: Intl.DateTimeFormat
+): number[] {
+  const hours =
+    rule.kind === 'cron'
+      ? [...rule.hours]
+      : rule.freq === 'HOURLY'
+        ? Array.from({ length: 24 }, (_, hour) => hour)
+        : [rule.byHour]
+  const minutes = rule.kind === 'cron' ? [...rule.minutes] : [rule.byMinute]
+  const offsets = new Set<number>()
+  // Adjacent UTC days cover both sides of a timezone transition, including a skipped local day.
+  for (const delta of [-1, 0, 1, 2]) {
+    const sample = day + delta * DAY_MS
+    offsets.add(wallTime(formatter, sample) - sample)
+  }
+  const candidates: number[] = []
+  for (const hour of hours) {
+    for (const minute of minutes) {
+      const wall = day + (hour * 60 + minute) * MINUTE_MS
+      for (const offset of offsets) {
+        const candidate = wall - offset
+        // A missing local time has no match; a repeated time has two distinct matching instants.
+        if (wallTime(formatter, candidate) === wall) {
+          candidates.push(candidate)
+        }
+      }
+    }
+  }
+  return candidates.sort((left, right) => left - right)
+}
+
+export function zonedAutomationOccurrence(
+  rule: ParsedSchedule,
+  dtstart: number,
+  anchor: number,
+  direction: 1 | -1,
+  timezone: string
+): number | null {
+  const formatter = timezoneFormatter(timezone)
+  if (direction === -1 && anchor < dtstart) {
+    return null
+  }
+  const start = direction === 1 ? Math.max(dtstart, anchor) : anchor
+  const localDay = new Date(wallTime(formatter, start))
+  localDay.setUTCHours(0, 0, 0, 0)
+  const firstDay = new Date(wallTime(formatter, dtstart))
+  firstDay.setUTCHours(0, 0, 0, 0)
+  // Feb 29 can have an eight-year gap across a non-leap century.
+  for (let i = 0; i < 9 * 366; i += 1) {
+    if (direction === -1 && localDay.getTime() < firstDay.getTime()) {
+      return null
+    }
+    if (matchesDay(rule, localDay)) {
+      const candidates = dayOccurrences(rule, localDay.getTime(), formatter)
+      if (direction === -1) {
+        candidates.reverse()
+      }
+      for (const candidate of candidates) {
+        if (candidate >= dtstart && (direction === 1 ? candidate > anchor : candidate <= anchor)) {
+          return candidate
+        }
+      }
+    }
+    localDay.setUTCDate(localDay.getUTCDate() + direction)
+  }
+  return null
+}


### PR DESCRIPTION
## ELI5

A 09:00 automation saved for Shanghai should run at 09:00 in Shanghai even when its scheduling computer is set to UTC. The saved timezone now controls occurrence calculations and catch-up decisions.

## What Changed

- Add an optional timezone argument to shared next/latest occurrence APIs, retaining host-local behavior for callers that omit it.
- Evaluate named-zone calendar dates and clock times with Intl, including fractional-hour offsets, missing times and repeated times. Reuse cron calendar matching and avoid scanning years minute by minute.
- Pass the saved timezone through create, update, advance and catch-up paths; timezone-only edits recompute nextRunAt.
- Validate timezone names at RPC boundaries and pause invalid persisted zones without blocking other due automations.
- Add shared, persistence, RPC and scheduler regressions; make an existing UTC service fixture explicitly run in UTC.

## Why

The timezone property was persisted but never passed into the scheduler. On a UTC host, 0 9 * * * with Asia/Shanghai selected previously computed 09:00Z instead of 01:00Z. The implementation uses per-calculation Intl formatters and never mutates the host process timezone.

## Linked Issue

Reported during a source audit; no separate tracker issue was filed.

## Visual Proof

N/A — this changes shared scheduling/formatting logic, with no new UI components or layout. Observable behavior is covered by the before/after regression cases below.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local macOS arm64, Node 26.0.0, pnpm 12.0.0. The new regressions were run against the original behavior before applying the fix. The final targeted run passes **73 tests**:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=2 src/shared/automation-schedule-timezone.test.ts src/shared/automation-schedules.test.ts src/main/persistence/scheduling-automations/automation-timezone-operations.test.ts src/main/automations/service-invalid-timezone.test.ts src/main/automations/service.test.ts src/main/persistence-automations.test.ts src/main/runtime/rpc/methods/automations.test.ts src/main/runtime/rpc/methods/automation-timezone-validation.test.ts
```

Also passed locally:

```sh
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/run-typecheck-projects-in-parallel.mjs
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/check-changed-code-quality.mjs
```

These run all three TypeScript projects and the changed-file code-quality, type-aware and React Doctor gates. Tests use isolated temporary state and background launch mode. Full application build, the complete repository test suite, real SSH-host execution and Windows/Linux runs were not performed locally; the upstream CI matrix still needs to run. No manual Electron UI session was run.

## AI Disclosure

Codex (GPT-6) assisted with diagnosis, implementation, test design and self-review. The listed local checks were executed; their results are not inferred from the diff.

## Review

Cross-platform: standard Intl/Date APIs and no added dependency. Local/SSH/runtime: the storing scheduling authority evaluates its saved timezone; there is no local fallback for remote execution. Agents/integrations: provider-neutral and no wire shape change. Performance: bounded calendar-day scanning with time candidates only on matching dates; the regression includes the 2096-to-2104 leap-day gap. UI: existing labels and run-history errors. Security: no new process, network, filesystem or secret access; invalid names fail before new schedules are stored.

## Agent skill upstream boundary

- [x] Not applicable; no upstream agent skill content is copied or translated.

## Notes

For explicitly named timezones, nonexistent local clock times are skipped and repeated clock times match both instants. Existing nextRunAt values are recomputed on a schedule/timezone edit or the next scheduling advance; this PR does not rewrite historical runs. No persisted schema or protocol version change.

X/Twitter handle: not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint/typecheck/test/build all pass — targeted tests, full typecheck and changed-code gates pass locally; full CI/build remain pending
