### PR TITLE
fix(automations): label supported multi-day RRULEs as custom schedules

### DIFF
--- a/src/cli/automation-format.test.ts
+++ b/src/cli/automation-format.test.ts
@@ -36,6 +36,12 @@ function automation(overrides: Partial<Automation> = {}): Automation {
 // removal untouched, so printing only those renders a dead automation byte-for-byte
 // like a healthy one and the named recovery step cannot be completed.
 describe('formatAutomationShow reports the host the authority projects', () => {
+  it('shows a supported multi-day weekly recurrence as a custom schedule', () => {
+    const scheduled = automation({ rrule: 'FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=9;BYMINUTE=0' })
+    expect(formatAutomationShow({ automation: scheduled })).toContain('schedule: Custom schedule')
+    expect(formatAutomationList({ automations: [scheduled] })).toContain('Custom schedule')
+  })
+
   it('distinguishes a live SSH host from a replaced one by its incarnation', () => {
     const live = formatAutomationShow({
       automation: automation(),

--- a/src/shared/automation-rrule-labels.test.ts
+++ b/src/shared/automation-rrule-labels.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { describeAutomationSchedule, formatAutomationSchedule } from './automation-schedules'
+import { isValidAutomationSchedule } from './automation-schedule-parsing'
+
+describe('valid RRULEs outside the simple editor presets', () => {
+  it.each(['MO,WE', 'SA,SU', 'FR,TH,WE,TU,MO', 'SU,MO,TU,WE,TH,FR,SA'])(
+    'describes a valid weekly rule for %s as custom',
+    (days) => {
+      const schedule = `FREQ=WEEKLY;BYDAY=${days};BYHOUR=9;BYMINUTE=0`
+      expect(isValidAutomationSchedule(schedule)).toBe(true)
+      expect(describeAutomationSchedule(schedule)).toEqual({ kind: 'custom' })
+      expect(formatAutomationSchedule(schedule)).toBe('Custom schedule')
+    }
+  )
+
+  it.each(['FREQ=WEEKLY;BYDAY=NO', 'FREQ=WEEKLY', 'FREQ=YEARLY'])(
+    'still reports malformed or unsupported rules as invalid: %s',
+    (schedule) => {
+      expect(describeAutomationSchedule(schedule)).toEqual({ kind: 'invalid' })
+      expect(formatAutomationSchedule(schedule)).toBe('Invalid schedule')
+    }
+  )
+})

--- a/src/shared/automation-schedules.ts
+++ b/src/shared/automation-schedules.ts
@@ -1,5 +1,5 @@
 import {
-  parseAutomationRrule,
+  tryParseAutomationRrule,
   parseCronExpression,
   parseSchedule,
   type ParsedCron
@@ -74,7 +74,9 @@ function setContainsRange(values: Set<number>, min: number, max: number): boolea
   return true
 }
 
-function formatParsedRruleSchedule(schedule: ReturnType<typeof parseAutomationRrule>): string {
+function formatParsedRruleSchedule(
+  schedule: NonNullable<ReturnType<typeof tryParseAutomationRrule>>
+): string {
   if (schedule.preset === 'hourly') {
     return `Hourly at :${String(schedule.minute).padStart(2, '0')}`
   }
@@ -149,7 +151,8 @@ export function formatAutomationSchedule(scheduleExpression: string): string {
     if (schedule.kind === 'cron') {
       return classifyParsedCronSchedule(schedule).label
     }
-    return formatParsedRruleSchedule(parseAutomationRrule(trimmed))
+    const preset = tryParseAutomationRrule(trimmed)
+    return preset ? formatParsedRruleSchedule(preset) : 'Custom schedule'
   } catch {
     return 'Invalid schedule'
   }
@@ -175,7 +178,10 @@ export function describeAutomationSchedule(
     if (schedule.kind === 'cron') {
       return toScheduleDescriptor(classifyParsedCronSchedule(schedule))
     }
-    const rrule = parseAutomationRrule(trimmed)
+    const rrule = tryParseAutomationRrule(trimmed)
+    if (rrule === null) {
+      return { kind: 'custom' }
+    }
     if (rrule.preset === 'hourly') {
       return { kind: 'hourly', minute: rrule.minute }
     }


### PR DESCRIPTION
## ELI5

A valid automation scheduled for Monday and Wednesday should not be labeled Invalid schedule. Orca now displays the existing Custom schedule label when a supported rule does not fit a simple editor preset.

## What Changed

- Separate recurrence validity from whether the RRULE maps to an hourly/daily/weekday/single-weekday preset.
- Return the existing custom descriptor and CLI label for supported multi-day rules.
- Keep malformed/unsupported rules invalid and preserve all simple preset labels. Add shared descriptor and CLI list/show regressions.

## Why

parseSchedule accepted multi-day weekly rules, but the later preset-only parse threw for them. The formatter treated that preset conversion failure as an invalid recurrence. The shared parser still validates first; only the preset fallback changes.

## Linked Issue

Reported during a source audit; no separate tracker issue was filed.

## Visual Proof

N/A — this changes shared scheduling/formatting logic, with no new UI components or layout. Observable behavior is covered by the before/after regression cases below.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local macOS arm64, Node 26.0.0, pnpm 12.0.0. The new regressions were run against the original behavior before applying the fix. The final targeted run passes **37 tests**:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=2 src/shared/automation-rrule-labels.test.ts src/shared/automation-schedules.test.ts src/cli/automation-format.test.ts
```

Also passed locally:

```sh
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/run-typecheck-projects-in-parallel.mjs
ORCA_BACKGROUND_LAUNCH=1 node config/scripts/check-changed-code-quality.mjs
```

These run all three TypeScript projects and the changed-file code-quality, type-aware and React Doctor gates. Tests use isolated temporary state and background launch mode. Full application build, the complete repository test suite, real SSH-host execution and Windows/Linux runs were not performed locally; the upstream CI matrix still needs to run. No manual Electron UI session was run.

## AI Disclosure

Codex (GPT-6) assisted with diagnosis, implementation, test design and self-review. The listed local checks were executed; their results are not inferred from the diff.

## Review

Cross-platform: shared TypeScript with existing locale-independent descriptors. Local/SSH/runtime: presentation only; execution and host ownership are unchanged. Agents/integrations: the common CLI/renderer formatters remain provider-neutral. Performance: the same parsing path and a null fallback. UI: reuse the existing localized Custom schedule label; no new catalog strings, components or layout. Security: no new I/O, privileges or input execution.

## Agent skill upstream boundary

- [x] Not applicable; no upstream agent skill content is copied or translated.

## Notes

Example: FREQ=WEEKLY;BYDAY=MO,WE;BYHOUR=9;BYMINUTE=0 is valid before and after. Its descriptor changes from invalid to custom, and the CLI label changes from Invalid schedule to Custom schedule. The RRULE and next occurrence are preserved.

X/Twitter handle: not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint/typecheck/test/build all pass — targeted tests, full typecheck and changed-code gates pass locally; full CI/build remain pending
