### PR TITLE
test: reconnect after replacing same-ID runtime pairing

### DIFF
--- a/tests/e2e/helpers/nested-runtime-same-id-pairing.ts
+++ b/tests/e2e/helpers/nested-runtime-same-id-pairing.ts
@@ -28,6 +28,10 @@ export async function replaceRuntimePairingInPlace(args: {
     if (!store) {
       throw new Error('Paired desktop store is unavailable during same-ID re-pair')
     }
+    const connection = await window.api.runtimeEnvironments.connect({ selector })
+    if (!connection.ok) {
+      throw new Error(`Same-ID re-pair reconnect failed: ${JSON.stringify(connection.error)}`)
+    }
     const environments = await window.api.runtimeEnvironments.list()
     store.getState().setRuntimeEnvironments(environments)
     if (!(await store.getState().refreshRuntimeEnvironmentStatus(selector))) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

The same-ID pairing test disconnected its client and then tried to use it without reconnecting. Reconnect explicitly so the test reaches its stale-stream isolation assertions.

## What Changed

After replacing pairing credentials on disk, the existing fixture calls `runtimeEnvironments.connect` and reports a failed connection before hydrating the replacement pairing. Production code, assertions, retries, and time limits are unchanged.

## Why

Manual disconnect intentionally survives status checks and RPC calls. The fixture bypasses the normal pairing UI by updating the stored credentials directly, so it must explicitly reconnect. Previously the original scenario failed with `runtime_manually_disconnected` before testing the new pairing.

## Linked Issue

Follow-up to the requested all-tests deflaking audit; no separate issue was supplied.

## Visual Proof

N/A — test fixture correction only; no application UI or behavior change.

## Testing

- [x] Existing pairing IPC unit contracts: 19 passed.
- [x] Original `quarantines an old terminal stream after same-ID HUB re-pair` Electron scenario: [5/5 Linux Docker SSH repetitions](https://github.com/stablyai/orca/actions/runs/34043245432), zero retries/skips. Validation changed only this helper plus its temporary CI workflow.
- [x] Lint/format passed; no E2E typecheck diagnostics in the changed helper. The opt-in E2E typecheck still reports existing errors elsewhere.
- [ ] Local rendered testing: all Electron validation ran in CI to preserve the user's monitor focus.

## Review

The scenario still verifies pairing revision advancement, old-stream quarantine, new terminal traffic, and absence of direct SSH attempts from the paired desktop. The broader nested routing/restart scenarios remain under investigation; this PR claims only the same-ID fixture correction.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material copied.

## Notes

Uses the existing cross-platform runtime API. SSH execution ownership, mixed-version wire formats, and application code are unchanged. The nested suite's routine CI registration remains follow-up work.

## Checklist

- [x] Small, focused, and self-reviewed.
- [x] Changes and reason explained; visual proof N/A.
- [x] Cross-platform and SSH impact considered.
- [x] Focused checks passed; normal PR CI will cover repository checks.
