### PR TITLE
draft: investigate SSH workspace snapshots crossing relay namespaces

### DIFF
--- a/src/shared/remote-workspace-session-projection.ts
+++ b/src/shared/remote-workspace-session-projection.ts
@@ -1,5 +1,8 @@
 import { getDefaultWorkspaceSession } from './constants'
-import { projectRemoteWorkspaceSshPtyOwner } from './remote-workspace-ssh-pty-owner'
+import {
+  projectRemoteWorkspaceSshPtyOwner,
+  stripRemoteWorkspaceSshPtyOwners
+} from './remote-workspace-ssh-pty-owner'
 import type { RemoteWorkspaceSession, RemoteWorkspaceTerminalTab } from './remote-workspace-types'
 import type { TerminalTab } from './terminal-tab-types'
 import type { WorkspaceSessionState } from './workspace-session-state-types'
@@ -136,7 +139,7 @@ export function exportRemoteWorkspaceSession(
     }
   }
 
-  return {
+  return stripRemoteWorkspaceSshPtyOwners({
     activeWorktreePath,
     activeTabId,
     tabsByWorktreePath,
@@ -159,7 +162,7 @@ export function exportRemoteWorkspaceSession(
       : undefined,
     lastVisitedAtByWorktreePath,
     defaultTerminalTabsAppliedByWorktreePath
-  }
+  })
 }
 
 export function importRemoteWorkspaceSession(

--- a/src/shared/remote-workspace-session-projection.ts
+++ b/src/shared/remote-workspace-session-projection.ts
@@ -1,4 +1,5 @@
 import { getDefaultWorkspaceSession } from './constants'
+import { projectRemoteWorkspaceSshPtyOwner } from './remote-workspace-ssh-pty-owner'
 import type { RemoteWorkspaceSession, RemoteWorkspaceTerminalTab } from './remote-workspace-types'
 import type { TerminalTab } from './terminal-tab-types'
 import type { WorkspaceSessionState } from './workspace-session-state-types'
@@ -165,6 +166,7 @@ export function importRemoteWorkspaceSession(
   remote: RemoteWorkspaceSession,
   options: ImportOptions
 ): WorkspaceSessionState {
+  remote = projectRemoteWorkspaceSshPtyOwner(remote, options.executionHostId)
   const session = getDefaultWorkspaceSession()
   const tabsByWorktree: Record<string, TerminalTab[]> = {}
   const terminalTabIds = new Set<string>()

--- a/src/shared/remote-workspace-session-ssh-owner.test.ts
+++ b/src/shared/remote-workspace-session-ssh-owner.test.ts
@@ -37,6 +37,10 @@ it('imports a retained host session under the receiving client SSH target', () =
     remoteSessionIdsByTabId: { tab: oldPtyId }
   }
   const snapshot = exportRemoteWorkspaceSession(oldSession, { isTargetWorktree: () => true })
+  // Previously published snapshots contain the publishing client's target IDs.
+  snapshot.tabsByWorktreePath['/srv/project'][0].ptyId = oldPtyId
+  snapshot.terminalLayoutsByTabId.tab.ptyIdsByLeafId = { leaf: oldPtyId }
+  snapshot.remoteSessionIdsByTabId = { tab: oldPtyId }
   const imported = importRemoteWorkspaceSession(snapshot, {
     executionHostId: 'ssh:new-client-target',
     resolveWorktreeId: () => 'new-repo::/srv/project'
@@ -85,4 +89,36 @@ it('preserves legacy, runtime, and malformed IDs while rebasing encoded SSH owne
     prior: toAppSshPtyId('new/client', 'pty2:leaf:4')
   })
   expect(snapshot.remoteSessionIdsByTabId.prior).toBe(toAppSshPtyId('old-client', 'pty2:leaf:4'))
+})
+
+it('publishes the same host session after either client imports it', () => {
+  const hostSession = {
+    activeWorktreePath: null,
+    activeTabId: null,
+    tabsByWorktreePath: {
+      '/srv/project': [
+        {
+          id: 'tab',
+          ptyId: toAppSshPtyId('client-a', 'pty-1'),
+          worktreePath: '/srv/project',
+          title: 'Shell',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {},
+    remoteSessionIdsByTabId: { tab: toAppSshPtyId('client-a', 'pty-1') }
+  }
+  const republish = (target: string) =>
+    exportRemoteWorkspaceSession(
+      importRemoteWorkspaceSession(hostSession, {
+        executionHostId: `ssh:${target}`,
+        resolveWorktreeId: () => `${target}::/srv/project`
+      }),
+      { isTargetWorktree: () => true }
+    )
+  expect(republish('client-a')).toEqual(republish('client-b'))
 })

--- a/src/shared/remote-workspace-session-ssh-owner.test.ts
+++ b/src/shared/remote-workspace-session-ssh-owner.test.ts
@@ -1,0 +1,88 @@
+import { expect, it } from 'vitest'
+import { projectRemoteWorkspaceSshPtyOwner } from './remote-workspace-ssh-pty-owner'
+import { getDefaultWorkspaceSession } from './constants'
+import {
+  exportRemoteWorkspaceSession,
+  importRemoteWorkspaceSession
+} from './remote-workspace-session-projection'
+import { toAppSshPtyId, toRelaySshPtyId } from './ssh-pty-id'
+
+it('imports a retained host session under the receiving client SSH target', () => {
+  const oldPtyId = toAppSshPtyId('old-client-target', 'pty2:terminal:1')
+  const oldWorktree = 'old-repo::/srv/project'
+  const oldSession = {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [oldWorktree]: [
+        {
+          id: 'tab',
+          ptyId: oldPtyId,
+          worktreeId: oldWorktree,
+          title: 'Shell',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    },
+    terminalLayoutsByTabId: {
+      tab: {
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { leaf: oldPtyId }
+      }
+    },
+    remoteSessionIdsByTabId: { tab: oldPtyId }
+  }
+  const snapshot = exportRemoteWorkspaceSession(oldSession, { isTargetWorktree: () => true })
+  const imported = importRemoteWorkspaceSession(snapshot, {
+    executionHostId: 'ssh:new-client-target',
+    resolveWorktreeId: () => 'new-repo::/srv/project'
+  })
+  const expected = toAppSshPtyId('new-client-target', 'pty2:terminal:1')
+  expect(imported.tabsByWorktree['new-repo::/srv/project'][0].ptyId).toBe(expected)
+  expect(imported.terminalLayoutsByTabId.tab.ptyIdsByLeafId?.leaf).toBe(expected)
+  expect(imported.remoteSessionIdsByTabId?.tab).toBe(expected)
+  expect(toRelaySshPtyId('new-client-target', expected)).toBe('pty2:terminal:1')
+  expect(snapshot.tabsByWorktreePath['/srv/project'][0].ptyId).toBe(oldPtyId)
+})
+
+it.each([undefined, 'local', 'runtime:paired', 'wsl:Ubuntu'] as const)(
+  'preserves snapshot identities without a direct SSH import owner: %s',
+  (executionHostId) => {
+    const snapshot = {
+      activeWorktreePath: null,
+      activeTabId: null,
+      tabsByWorktreePath: {},
+      terminalLayoutsByTabId: {},
+      remoteSessionIdsByTabId: { tab: toAppSshPtyId('old-target', 'pty-1') }
+    }
+    const imported = projectRemoteWorkspaceSshPtyOwner(snapshot, executionHostId)
+    expect(imported).toBe(snapshot)
+  }
+)
+
+it('preserves legacy, runtime, and malformed IDs while rebasing encoded SSH owners', () => {
+  const ids = {
+    legacy: 'pty-1',
+    runtime: 'remote:paired@@pty-2',
+    malformed: 'ssh:%zz@@pty-3',
+    prior: toAppSshPtyId('old-client', 'pty2:leaf:4'),
+    current: toAppSshPtyId('new/client', 'pty2:leaf:5')
+  }
+  const snapshot = {
+    activeWorktreePath: null,
+    activeTabId: null,
+    tabsByWorktreePath: {},
+    terminalLayoutsByTabId: {},
+    remoteSessionIdsByTabId: ids
+  }
+  const imported = projectRemoteWorkspaceSshPtyOwner(snapshot, 'ssh:new%2Fclient')
+  expect(imported.remoteSessionIdsByTabId).toEqual({
+    ...ids,
+    prior: toAppSshPtyId('new/client', 'pty2:leaf:4')
+  })
+  expect(snapshot.remoteSessionIdsByTabId.prior).toBe(toAppSshPtyId('old-client', 'pty2:leaf:4'))
+})

--- a/src/shared/remote-workspace-session-ssh-owner.test.ts
+++ b/src/shared/remote-workspace-session-ssh-owner.test.ts
@@ -49,7 +49,7 @@ it('imports a retained host session under the receiving client SSH target', () =
   expect(snapshot.tabsByWorktreePath['/srv/project'][0].ptyId).toBe(oldPtyId)
 })
 
-it.each([undefined, 'local', 'runtime:paired', 'wsl:Ubuntu'] as const)(
+it.each([undefined, 'local', 'runtime:paired'] as const)(
   'preserves snapshot identities without a direct SSH import owner: %s',
   (executionHostId) => {
     const snapshot = {

--- a/src/shared/remote-workspace-ssh-pty-owner.ts
+++ b/src/shared/remote-workspace-ssh-pty-owner.ts
@@ -1,0 +1,40 @@
+import { parseExecutionHostId, type ExecutionHostId } from './execution-host'
+import type { RemoteWorkspaceSession } from './remote-workspace-types'
+import { parseAppSshPtyId, toAppSshPtyId } from './ssh-pty-id'
+
+export function projectRemoteWorkspaceSshPtyOwner(
+  session: RemoteWorkspaceSession,
+  executionHostId: ExecutionHostId | undefined
+): RemoteWorkspaceSession {
+  const host = parseExecutionHostId(executionHostId)
+  if (host?.kind !== 'ssh') {
+    return session
+  }
+  // The authenticated host owns the snapshot; target IDs belong to each importing client.
+  const project = (id: string): string => {
+    const parsed = parseAppSshPtyId(id)
+    return parsed ? toAppSshPtyId(host.targetId, parsed.relayPtyId) : id
+  }
+  const projectIds = (ids: Record<string, string>): Record<string, string> =>
+    Object.fromEntries(Object.entries(ids).map(([key, id]) => [key, project(id)]))
+  return {
+    ...session,
+    tabsByWorktreePath: Object.fromEntries(
+      Object.entries(session.tabsByWorktreePath).map(([path, tabs]) => [
+        path,
+        tabs.map((tab) => ({ ...tab, ptyId: tab.ptyId ? project(tab.ptyId) : tab.ptyId }))
+      ])
+    ),
+    terminalLayoutsByTabId: Object.fromEntries(
+      Object.entries(session.terminalLayoutsByTabId).map(([id, layout]) => [
+        id,
+        layout.ptyIdsByLeafId
+          ? { ...layout, ptyIdsByLeafId: projectIds(layout.ptyIdsByLeafId) }
+          : layout
+      ])
+    ),
+    remoteSessionIdsByTabId: session.remoteSessionIdsByTabId
+      ? projectIds(session.remoteSessionIdsByTabId)
+      : undefined
+  }
+}

--- a/src/shared/remote-workspace-ssh-pty-owner.ts
+++ b/src/shared/remote-workspace-ssh-pty-owner.ts
@@ -11,10 +11,22 @@ export function projectRemoteWorkspaceSshPtyOwner(
     return session
   }
   // The authenticated host owns the snapshot; target IDs belong to each importing client.
-  const project = (id: string): string => {
+  return mapSshPtyIds(session, (id) => {
     const parsed = parseAppSshPtyId(id)
     return parsed ? toAppSshPtyId(host.targetId, parsed.relayPtyId) : id
-  }
+  })
+}
+
+export function stripRemoteWorkspaceSshPtyOwners(
+  session: RemoteWorkspaceSession
+): RemoteWorkspaceSession {
+  return mapSshPtyIds(session, (id) => parseAppSshPtyId(id)?.relayPtyId ?? id)
+}
+
+function mapSshPtyIds(
+  session: RemoteWorkspaceSession,
+  project: (id: string) => string
+): RemoteWorkspaceSession {
   const projectIds = (ids: Record<string, string>): Record<string, string> =>
     Object.fromEntries(Object.entries(ids).map(([key, id]) => [key, project(id)]))
   return {


### PR DESCRIPTION
DO NOT MERGE: the current implementation is an invalid approach, retained in draft for investigation and review.

Different SSH target IDs intentionally create different relay socket paths (`ssh-relay-deploy.ts`, target-specific socket contract). However, each relay creates `WorkspaceSessionHandler` with the same default `~/.orca/sessions` directory. A fresh target can therefore read another relay's persisted workspace IDs. Rebasing or stripping their target owner does not make those PTYs belong to the new relay, so this PR's current normalization approach is not an acceptable fix.

Evidence: the two-client diagnostic on main fails with an unbound imported tab; the current candidate fails all three repetitions because the second client has a different relay PTY. Its original same-shell expectation incorrectly assumed different targets share a relay. The earlier `DEAD` probes also checked different target-specific sockets, so they do not establish that the first relay restarted. The diagnostic runs are https://github.com/stablyai/orca/actions/runs/34048394045 and https://github.com/stablyai/orca/actions/runs/34048395319.

A focused release-source projection check passes, but only demonstrates that the serialized IDs can be parsed and routed syntactically. It does not validate relay ownership and cannot justify the implementation. The next investigation is how to preserve PTY ownership across relay instances while retaining intended workspace-metadata synchronization. Do not assume that all shared workspace metadata should be isolated. Any fix must preserve existing same-target sessions and compatibility with independently updated clients and relays.

Application investigation: leave draft for user review. All Electron testing runs in CI. Test-only localhost setup isolation and authoritative hydration are independent of this candidate.

The invalid candidate was removed from the primary worktree after verifying its files exactly matched the saved PR snapshot. Its draft branch and diagnostic logs remain available for review; the primary worktree no longer includes the speculative rebasing/export changes.
