### PR TITLE
Bump mobile Android versionCode to 16 to match the 0.0.48 release

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 15
+      "versionCode": 16
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | 0 |

<!-- /orca-pr-loc -->

## Summary
- Set `mobile/app.json` `expo.android.versionCode` to 16, matching what `mobile-android-v0.0.48` actually shipped.

## Why this matters
`main` carried `version: 0.0.48` with `versionCode: 15` — the same versionCode already shipped as 0.0.47. Android refuses to install an APK whose versionCode is not higher than the installed one, so an APK cut from main would not have installed as an upgrade for existing users.

`mobile/scripts/prepare-android-release.mjs` requires both values to be **committed** before tagging: it rejects `MOBILE_ANDROID_VERSION_CODE` / `MOBILE_ANDROID_BUMP_VERSION_CODE` (line 84) and requires the tag version to equal `expo.version` (line 71). Unlike iOS, CI bumps neither.

Note: the `mobile-app-store-release` runbook currently states that `expo.android.versionCode` is "owned by the workflows. Do not hand-edit". That is accurate for iOS `buildNumber` but wrong for Android, and is worth a separate docs fix.

## Verification
- `mobile/app.json` parses; `version` 0.0.48 and `ios.buildNumber` unchanged
- Matches the released tag `mobile-android-v0.0.48` (commit 3d20da9851)