### PR TITLE
test: reuse authoritative SSH connection readiness in localhost fixture

### DIFF
--- a/tests/e2e/helpers/docker-ssh-relay-connection.ts
+++ b/tests/e2e/helpers/docker-ssh-relay-connection.ts
@@ -1,3 +1,4 @@
+import { connectSshTestTarget } from './ssh-test-target-connection'
 import { expect, type Page } from '@stablyai/playwright-test'
 
 import {
@@ -30,153 +31,26 @@ export async function connectDockerSshRelayTarget(
   target: DockerSshRelayTarget,
   options: DockerSshRelayConnectionOptions = {}
 ): Promise<ConnectedDockerSshRelayTarget> {
-  return page.evaluate(
-    async ({ target, remotePath, relayGracePeriodSeconds, viaProxyJump, seedInitialTab }) => {
-      const store = window.__store
-      if (!store) {
-        throw new Error('Store unavailable')
-      }
-      const credentialUnsub = window.api.ssh.onCredentialRequest((request) => {
-        void window.api.ssh.submitCredential({ requestId: request.requestId, value: null })
-      })
-      try {
-        const { target: createdTarget, repoReadoptions } = await window.api.ssh.addTarget({
-          target: {
-            label: `${viaProxyJump ? 'Docker SSH ProxyJump' : 'Docker SSH Relay'} E2E ${Date.now()}`,
-            ...(viaProxyJump ? { configHost: 'orca-e2e-destination' } : {}),
-            host: target.host,
-            port: viaProxyJump ? 22 : target.port,
-            username: 'root',
-            identityFile: target.identityFile,
-            identitiesOnly: true,
-            ...(viaProxyJump ? { jumpHost: 'orca-e2e-jump' } : {}),
-            relayGracePeriodSeconds
-          }
-        })
-        store.getState().recordSshRepoReadoptions(repoReadoptions)
-        const state = await window.api.ssh.connect({ targetId: createdTarget.id })
-        if (!state || state.status !== 'connected') {
-          throw new Error(`SSH target did not connect: ${JSON.stringify(state)}`)
-        }
-        if (
-          !state.providerEpoch ||
-          !Number.isSafeInteger(state.connectionGeneration) ||
-          state.connectionGeneration === undefined ||
-          state.connectionGeneration < 0
-        ) {
-          throw new Error(`SSH target returned incomplete authority: ${JSON.stringify(state)}`)
-        }
-        store.getState().setSshConnectionState(createdTarget.id, state)
-        const labels = new Map(store.getState().sshTargetLabels)
-        labels.set(createdTarget.id, createdTarget.label)
-        store.getState().setSshTargetLabels(labels)
-        const executionHostId = `ssh:${encodeURIComponent(createdTarget.id)}` as const
-        const authority = {
-          targetId: createdTarget.id,
-          providerEpoch: state.providerEpoch,
-          connectionGeneration: state.connectionGeneration
-        }
-
-        const result = await window.api.repos.addRemote({
-          connectionId: createdTarget.id,
-          remotePath,
-          displayName: viaProxyJump ? 'Docker SSH ProxyJump E2E' : 'Docker SSH Relay E2E'
-        })
-        if ('error' in result) {
-          throw new Error(result.error)
-        }
-        const hasExpectedRepoOwner = (): boolean =>
-          store
-            .getState()
-            .repos.some(
-              (repo) =>
-                repo.id === result.repo.id &&
-                repo.connectionId === createdTarget.id &&
-                repo.executionHostId === executionHostId
-            )
-        const waitForRepoOwner = async (): Promise<void> => {
-          if (hasExpectedRepoOwner()) {
-            return
-          }
-          await new Promise<void>((resolve, reject) => {
-            const timer = window.setTimeout(() => {
-              unsubscribe()
-              reject(new Error(`Remote repo owner did not hydrate for ${result.repo.path}`))
-            }, 15_000)
-            const unsubscribe = store.subscribe((next) => {
-              if (
-                !next.repos.some(
-                  (repo) =>
-                    repo.id === result.repo.id &&
-                    repo.connectionId === createdTarget.id &&
-                    repo.executionHostId === executionHostId
-                )
-              ) {
-                return
-              }
-              window.clearTimeout(timer)
-              unsubscribe()
-              resolve()
-            })
-          })
-        }
-        await store.getState().fetchRepos()
-        await waitForRepoOwner()
-        const currentState = store.getState().sshConnectionStates.get(createdTarget.id)
-        if (
-          currentState?.providerEpoch !== authority.providerEpoch ||
-          currentState.connectionGeneration !== authority.connectionGeneration
-        ) {
-          throw new Error(`SSH authority rotated before worktree hydration for ${result.repo.path}`)
-        }
-        const worktreeResult = await store.getState().fetchWorktrees(result.repo.id, {
-          executionHostId,
-          directSshAuthority: authority,
-          requireAuthoritative: true
-        })
-        if (
-          worktreeResult.status !== 'complete' ||
-          worktreeResult.repoId !== result.repo.id ||
-          worktreeResult.authority.kind !== 'direct-ssh' ||
-          worktreeResult.authority.executionHostId !== executionHostId ||
-          worktreeResult.authority.targetId !== authority.targetId ||
-          worktreeResult.authority.providerEpoch !== authority.providerEpoch ||
-          worktreeResult.authority.connectionGeneration !== authority.connectionGeneration
-        ) {
-          throw new Error(
-            `Remote worktree hydration was not authoritative: ${JSON.stringify(worktreeResult)}`
-          )
-        }
-        const worktree = (store.getState().worktreesByRepo[result.repo.id] ?? []).find(
-          (candidate) => candidate.hostId === executionHostId
-        )
-        if (!worktree) {
-          throw new Error(`No remote worktree found for ${result.repo.path}`)
-        }
-        store.getState().setActiveWorktree(worktree.id)
-        if (seedInitialTab && (store.getState().tabsByWorktree[worktree.id] ?? []).length === 0) {
-          store.getState().createTab(worktree.id)
-        }
-        store.getState().setActiveTabType('terminal')
-        return {
-          targetId: createdTarget.id,
-          repoId: result.repo.id,
-          worktreeId: worktree.id
-        }
-      } finally {
-        credentialUnsub()
-      }
+  const viaProxyJump = options.viaProxyJump ?? false
+  return connectSshTestTarget(
+    page,
+    {
+      label: `${viaProxyJump ? 'Docker SSH ProxyJump' : 'Docker SSH Relay'} E2E ${Date.now()}`,
+      ...(viaProxyJump ? { configHost: 'orca-e2e-destination' } : {}),
+      host: target.host,
+      port: viaProxyJump ? 22 : target.port,
+      username: 'root',
+      identityFile: target.identityFile,
+      identitiesOnly: true,
+      ...(viaProxyJump ? { jumpHost: 'orca-e2e-jump' } : {}),
+      relayGracePeriodSeconds: options.relayGracePeriodSeconds ?? 1
     },
     {
-      target,
       remotePath:
         options.remotePath ??
-        (options.viaProxyJump
-          ? DOCKER_SSH_PROXY_JUMP_REMOTE_REPO_PATH
-          : DOCKER_SSH_RELAY_REMOTE_REPO_PATH),
-      viaProxyJump: options.viaProxyJump ?? false,
-      seedInitialTab: options.seedInitialTab ?? true,
-      relayGracePeriodSeconds: options.relayGracePeriodSeconds ?? 1
+        (viaProxyJump ? DOCKER_SSH_PROXY_JUMP_REMOTE_REPO_PATH : DOCKER_SSH_RELAY_REMOTE_REPO_PATH),
+      displayName: viaProxyJump ? 'Docker SSH ProxyJump E2E' : 'Docker SSH Relay E2E',
+      seedInitialTab: options.seedInitialTab
     }
   )
 }

--- a/tests/e2e/helpers/ssh-test-target-connection.ts
+++ b/tests/e2e/helpers/ssh-test-target-connection.ts
@@ -1,0 +1,155 @@
+import type { Page } from '@stablyai/playwright-test'
+import type { SshTargetCreateInput } from '../../../src/shared/ssh-types'
+
+export type ConnectedSshTestTarget = {
+  targetId: string
+  repoId: string
+  worktreeId: string
+}
+
+type SshTestConnectionOptions = {
+  remotePath: string
+  displayName: string
+  seedInitialTab?: boolean
+}
+
+export async function connectSshTestTarget(
+  page: Page,
+  target: SshTargetCreateInput,
+  options: SshTestConnectionOptions
+): Promise<ConnectedSshTestTarget> {
+  return page.evaluate(
+    async ({ target, remotePath, displayName, seedInitialTab }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Store unavailable')
+      }
+      const credentialUnsub = window.api.ssh.onCredentialRequest((request) => {
+        void window.api.ssh.submitCredential({ requestId: request.requestId, value: null })
+      })
+      try {
+        const { target: createdTarget, repoReadoptions } = await window.api.ssh.addTarget({
+          target
+        })
+        store.getState().recordSshRepoReadoptions(repoReadoptions)
+        const state = await window.api.ssh.connect({ targetId: createdTarget.id })
+        if (!state || state.status !== 'connected') {
+          throw new Error(`SSH target did not connect: ${JSON.stringify(state)}`)
+        }
+        if (
+          !state.providerEpoch ||
+          !Number.isSafeInteger(state.connectionGeneration) ||
+          state.connectionGeneration === undefined ||
+          state.connectionGeneration < 0
+        ) {
+          throw new Error(`SSH target returned incomplete authority: ${JSON.stringify(state)}`)
+        }
+        store.getState().setSshConnectionState(createdTarget.id, state)
+        const labels = new Map(store.getState().sshTargetLabels)
+        labels.set(createdTarget.id, createdTarget.label)
+        store.getState().setSshTargetLabels(labels)
+        const executionHostId = `ssh:${encodeURIComponent(createdTarget.id)}` as const
+        const authority = {
+          targetId: createdTarget.id,
+          providerEpoch: state.providerEpoch,
+          connectionGeneration: state.connectionGeneration
+        }
+
+        const result = await window.api.repos.addRemote({
+          connectionId: createdTarget.id,
+          remotePath,
+          displayName
+        })
+        if ('error' in result) {
+          throw new Error(result.error)
+        }
+        const hasExpectedRepoOwner = (): boolean =>
+          store
+            .getState()
+            .repos.some(
+              (repo) =>
+                repo.id === result.repo.id &&
+                repo.connectionId === createdTarget.id &&
+                repo.executionHostId === executionHostId
+            )
+        const waitForRepoOwner = async (): Promise<void> => {
+          if (hasExpectedRepoOwner()) {
+            return
+          }
+          await new Promise<void>((resolve, reject) => {
+            const timer = window.setTimeout(() => {
+              unsubscribe()
+              reject(new Error(`Remote repo owner did not hydrate for ${result.repo.path}`))
+            }, 15_000)
+            const unsubscribe = store.subscribe((next) => {
+              if (
+                !next.repos.some(
+                  (repo) =>
+                    repo.id === result.repo.id &&
+                    repo.connectionId === createdTarget.id &&
+                    repo.executionHostId === executionHostId
+                )
+              ) {
+                return
+              }
+              window.clearTimeout(timer)
+              unsubscribe()
+              resolve()
+            })
+          })
+        }
+        await store.getState().fetchRepos()
+        await waitForRepoOwner()
+        const currentState = store.getState().sshConnectionStates.get(createdTarget.id)
+        if (
+          currentState?.providerEpoch !== authority.providerEpoch ||
+          currentState.connectionGeneration !== authority.connectionGeneration
+        ) {
+          throw new Error(`SSH authority rotated before worktree hydration for ${result.repo.path}`)
+        }
+        const worktreeResult = await store.getState().fetchWorktrees(result.repo.id, {
+          executionHostId,
+          directSshAuthority: authority,
+          requireAuthoritative: true
+        })
+        if (
+          worktreeResult.status !== 'complete' ||
+          worktreeResult.repoId !== result.repo.id ||
+          worktreeResult.authority.kind !== 'direct-ssh' ||
+          worktreeResult.authority.executionHostId !== executionHostId ||
+          worktreeResult.authority.targetId !== authority.targetId ||
+          worktreeResult.authority.providerEpoch !== authority.providerEpoch ||
+          worktreeResult.authority.connectionGeneration !== authority.connectionGeneration
+        ) {
+          throw new Error(
+            `Remote worktree hydration was not authoritative: ${JSON.stringify(worktreeResult)}`
+          )
+        }
+        const worktree = (store.getState().worktreesByRepo[result.repo.id] ?? []).find(
+          (candidate) => candidate.hostId === executionHostId
+        )
+        if (!worktree) {
+          throw new Error(`No remote worktree found for ${result.repo.path}`)
+        }
+        store.getState().setActiveWorktree(worktree.id)
+        if (seedInitialTab && (store.getState().tabsByWorktree[worktree.id] ?? []).length === 0) {
+          store.getState().createTab(worktree.id)
+        }
+        store.getState().setActiveTabType('terminal')
+        return {
+          targetId: createdTarget.id,
+          repoId: result.repo.id,
+          worktreeId: worktree.id
+        }
+      } finally {
+        credentialUnsub()
+      }
+    },
+    {
+      target,
+      remotePath: options.remotePath,
+      displayName: options.displayName,
+      seedInitialTab: options.seedInitialTab ?? true
+    }
+  )
+}

--- a/tests/e2e/ssh-localhost.spec.ts
+++ b/tests/e2e/ssh-localhost.spec.ts
@@ -1,3 +1,4 @@
+import { connectSshTestTarget } from './helpers/ssh-test-target-connection'
 import os from 'node:os'
 import { createSeededTestRepo } from './helpers/seeded-test-repo'
 import { cleanupTestRepository } from './global-teardown'
@@ -163,83 +164,10 @@ test.describe('Localhost SSH', () => {
     await waitForActiveWorktree(orcaPage)
 
     const target = readLocalhostSshTarget()
-    const remote = await orcaPage.evaluate(
-      async ({ remotePath, target }) => {
-        const store = window.__store
-        if (!store) {
-          throw new Error('Store unavailable')
-        }
-
-        const credentialUnsub = window.api.ssh.onCredentialRequest((request) => {
-          void window.api.ssh.submitCredential({ requestId: request.requestId, value: null })
-        })
-
-        try {
-          const { target: createdTarget, repoReadoptions } = await window.api.ssh.addTarget({
-            target: {
-              ...target,
-              // Why: local-only E2E should not leave a long-lived relay process
-              // behind if the Electron app is killed between cleanup hooks.
-              relayGracePeriodSeconds: 1
-            }
-          })
-          store.getState().recordSshRepoReadoptions(repoReadoptions)
-
-          let state
-          try {
-            state = await window.api.ssh.connect({ targetId: createdTarget.id })
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err)
-            throw new Error(
-              `Failed to connect to localhost SSH target ${target.username}@${target.host || target.configHost}:${target.port}. ` +
-                `Ensure sshd is running and key/agent auth is non-interactive. ${message}`
-            )
-          }
-
-          if (!state || state.status !== 'connected') {
-            throw new Error(`SSH target did not reach connected state: ${JSON.stringify(state)}`)
-          }
-
-          store.getState().setSshConnectionState(createdTarget.id, state)
-          const labels = new Map(store.getState().sshTargetLabels)
-          labels.set(createdTarget.id, createdTarget.label)
-          store.getState().setSshTargetLabels(labels)
-
-          const result = await window.api.repos.addRemote({
-            connectionId: createdTarget.id,
-            remotePath,
-            displayName: 'Localhost SSH E2E'
-          })
-          if ('error' in result) {
-            throw new Error(result.error)
-          }
-
-          await store.getState().fetchRepos()
-          await store.getState().fetchWorktrees(result.repo.id)
-
-          const worktrees = store.getState().worktreesByRepo[result.repo.id] ?? []
-          const worktree =
-            worktrees.find((candidate) => candidate.path === result.repo.path) ?? worktrees[0]
-          if (!worktree) {
-            throw new Error(`No remote worktree found for ${result.repo.path}`)
-          }
-
-          store.getState().setActiveWorktree(worktree.id)
-          if ((store.getState().tabsByWorktree[worktree.id] ?? []).length === 0) {
-            store.getState().createTab(worktree.id)
-          }
-          store.getState().setActiveTabType('terminal')
-
-          return {
-            targetId: createdTarget.id,
-            repoId: result.repo.id,
-            worktreeId: worktree.id
-          }
-        } finally {
-          credentialUnsub()
-        }
-      },
-      { remotePath: testRepoPath, target }
+    const remote = await connectSshTestTarget(
+      orcaPage,
+      { ...target, relayGracePeriodSeconds: 1 },
+      { remotePath: testRepoPath, displayName: 'Localhost SSH E2E' }
     )
 
     await expect(remote.targetId).toBeTruthy()

--- a/tests/e2e/ssh-localhost.spec.ts
+++ b/tests/e2e/ssh-localhost.spec.ts
@@ -166,9 +166,16 @@ test.describe('Localhost SSH', () => {
     const target = readLocalhostSshTarget()
     const remote = await connectSshTestTarget(
       orcaPage,
+      // Limit orphan relay lifetime if the test app exits before cleanup.
       { ...target, relayGracePeriodSeconds: 1 },
       { remotePath: testRepoPath, displayName: 'Localhost SSH E2E' }
-    )
+    ).catch((error: unknown) => {
+      throw new Error(
+        `Failed to prepare localhost SSH target ${target.username}@${target.host || target.configHost}:${target.port}. ` +
+          `Ensure sshd is running and key/agent auth is non-interactive. ${String(error)}`,
+        { cause: error }
+      )
+    })
 
     await expect(remote.targetId).toBeTruthy()
     await ensureTerminalVisible(orcaPage, 30_000)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​185 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​221 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Localhost SSH setup can read worktrees before the repo has hydrated with its SSH owner, failing with `No remote worktree found`. Reuse the existing Docker SSH connection barrier: wait for the repo owner and require worktree hydration from the connected provider epoch and generation before selecting a workspace.

Extract that implementation into a common SSH target connection function and retain the Docker target settings, ProxyJump options, tab seeding, and recovery operations. Localhost keeps its isolated repository and existing terminal/hook assertions. Only test files change.

Validation: lint and formatting pass. E2E typecheck reports existing errors outside these three files. CI https://github.com/stablyai/orca/actions/runs/34047856132 tests these exact files on merged main, without application fixes: localhost SSH, Docker transport recovery, and direct SSH browser routing, each repeated three times with retries disabled. All 27 rendered cases passed: localhost 3/3, browser routing 9/9, Docker transport recovery 15/15. Regular PR checks and Pullfrog must also pass before merge.
