### PR TITLE
test: isolate source-control generation repositories per scenario

### DIFF
--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -279,6 +279,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
   // Default: dismiss the onboarding overlay so it doesn't intercept clicks.
   dismissOnboarding: [true, { option: true }],
   seedTestRepo: [true, { option: true }],
+  // Test-scoped so generation scenarios can isolate Git indexes and remotes.
   seededRepoPath: async ({ testRepoPath }, provideFixture) => {
     await provideFixture(testRepoPath)
   },

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -48,6 +48,7 @@ type OrcaTestFixtures = {
   // Why: most E2E specs need a ready project before assertions start. Golden
   // first-run specs opt out so they can prove the zero-project onboarding path.
   seedTestRepo: boolean
+  seededRepoPath: string
   // Synthetic-list specs need only the primary checkout; switching specs keep the two-row default.
   minimumSeededWorktreeCount: number
   // Why: spec-scoped launch env. Mutating process.env at spec module scope
@@ -278,6 +279,9 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
   // Default: dismiss the onboarding overlay so it doesn't intercept clicks.
   dismissOnboarding: [true, { option: true }],
   seedTestRepo: [true, { option: true }],
+  seededRepoPath: async ({ testRepoPath }, provideFixture) => {
+    await provideFixture(testRepoPath)
+  },
   minimumSeededWorktreeCount: [2, { option: true }],
   launchEnv: [{}, { option: true }],
   orcaAppExtraEnv: [{}, { option: true }],
@@ -286,7 +290,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
   // Test-scoped: grab the first BrowserWindow, add the test repo, and wait
   // until the session is fully ready with a worktree active.
   sharedPage: async (
-    { electronApp, minimumSeededWorktreeCount, seedTestRepo, testRepoPath },
+    { electronApp, minimumSeededWorktreeCount, seedTestRepo, seededRepoPath },
     provideFixture
   ) => {
     // Why: the Electron app may take a while to create the first window,
@@ -308,7 +312,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
       return
     }
 
-    const repoPath = isValidGitRepo(testRepoPath) ? testRepoPath : createSeededTestRepo()
+    const repoPath = isValidGitRepo(seededRepoPath) ? seededRepoPath : createSeededTestRepo()
 
     // Add the test repo via the IPC bridge
     // Why: calling window.api.repos.add() goes through the same code path as

--- a/tests/e2e/helpers/source-control-generation-app.ts
+++ b/tests/e2e/helpers/source-control-generation-app.ts
@@ -5,17 +5,10 @@ import { cleanupTestRepository } from '../global-teardown'
 export { expect }
 
 export const test = base.extend({
-  testRepoPath: [
-    // oxlint-disable-next-line no-empty-pattern -- Playwright requires destructured fixture arguments.
-    async ({}, provideFixture) => {
-      // Generation must not fetch external remotes installed by unrelated specs.
-      const repoPath = createSeededTestRepo({ publishPath: false })
-      try {
-        await provideFixture(repoPath)
-      } finally {
-        cleanupTestRepository(repoPath)
-      }
-    },
-    { scope: 'worker' }
-  ]
+  seededRepoPath: async ({ registerPostElectronShutdownCleanup }, provideFixture) => {
+    // Git indexes and remotes must not survive between generation scenarios.
+    const repoPath = createSeededTestRepo({ publishPath: false })
+    registerPostElectronShutdownCleanup(async () => cleanupTestRepository(repoPath))
+    await provideFixture(repoPath)
+  }
 })

--- a/tests/e2e/source-control-create-pr-intent-switch.spec.ts
+++ b/tests/e2e/source-control-create-pr-intent-switch.spec.ts
@@ -3,7 +3,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
-import { test, expect } from './helpers/orca-app'
+import { test, expect } from './helpers/source-control-generation-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import {
   createStagedCommitMessageChange,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The Create PR intent test can inherit a staged `e2e-commit-message-generation.txt` from an earlier scenario. The application then requests a commit message before pushing, so the test never reaches its push assertion.

Add a test-scoped repository path to the existing app fixture and use a fresh seeded repository for each source-control generation/intent scenario. Cleanup runs after Electron shutdown. The default shared repository behavior and all existing UI assertions remain intact.

Validation: lint and formatting pass. E2E typecheck still reports existing errors, including the unchanged eligibility mock in the intent spec. CI https://github.com/stablyai/orca/actions/runs/34050472957 passed all 13 tests in 4.7 minutes: the commit-message predecessor plus the intent, generation-switch, and linked-issue suites on merged main with this three-file test-only change.
