### PR TITLE
test: cover SSH reattach replay and enable deterministic Codex CI

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -18206,7 +18206,8 @@
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts",
         "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts --config tests/playwright.config.ts --project=electron-headful --workers=1",
         "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts --config tests/playwright.config.ts --project=electron-headful --workers=1 --repeat-each=10",
-        "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-codex-display-artifacts-repro.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1"
+        "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-codex-display-artifacts-repro.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1",
+        "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/ssh-codex-replay-reply-probe.unit.test.ts"
       ],
       "testFiles": [
         "tests/e2e/ssh-docker-transport-drop-recovery.spec.ts",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -18189,14 +18189,15 @@
       "providers": ["ssh"],
       "coveredPlatforms": ["macos", "linux"],
       "coveredProviders": ["ssh"],
-      "coverageNotes": "A macOS Electron client drives a Linux Docker SSH execution host. The six-spec suite passed ten enabled cases with clean worker exit (5.2m). The formerly skipped frozen-host input case now waits for recovered authority before sending input and passed four separate executions (one initial and three repetitions). The existing flooded-shell fixme remains an explicitly reproduced application gap. The bulk-open freeze reproduction runs in Linux headed CI with SwiftShader on Xvfb: headless Linux schedules idle animation frames about 1s apart, invalidating the foreground interaction measurement. Original uninstrumented five-pane workload passed all ten repetitions with zero retries/skips in 6.6m; bulk-open lag 79.3–147.8ms and interaction 127.1–155.9ms, unchanged 2500ms/5000ms budgets. Run 34037669843, head f25eab3fd7d723509ced026633f80b193a139b76, excludes unmerged replay-input application fix #19075.",
+      "coverageNotes": "A macOS Electron client drives a Linux Docker SSH execution host. The six-spec suite passed ten enabled cases with clean worker exit (5.2m). The formerly skipped frozen-host input case now waits for recovered authority before sending input and passed four separate executions (one initial and three repetitions). The existing flooded-shell fixme remains an explicitly reproduced application gap. The bulk-open freeze reproduction runs in Linux headed CI with SwiftShader on Xvfb: headless Linux schedules idle animation frames about 1s apart, invalidating the foreground interaction measurement. Original uninstrumented five-pane workload passed all ten repetitions with zero retries/skips in 6.6m; bulk-open lag 79.3–147.8ms and interaction 127.1–155.9ms, unchanged 2500ms/5000ms budgets. Run 34037669843, head f25eab3fd7d723509ced026633f80b193a139b76, excludes unmerged replay-input application fix #19075. Deterministic remote Codex fixture validation passed three normal restores and three forced reconnects with zero retries on merged main plus the replay probe correction (run 34050117471). The original forced-reconnect probe missed nonempty replay returned in pty:spawn reattach replies. Routine coverage now includes both modes by default; real Codex service execution remains opt-in.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/18018",
         "https://github.com/stablyai/orca/pull/18546",
         "https://github.com/stablyai/orca/issues/12547",
         "https://github.com/stablyai/orca/issues/16764",
         "https://github.com/stablyai/orca/actions/runs/34037450427",
-        "https://github.com/stablyai/orca/actions/runs/34037669843"
+        "https://github.com/stablyai/orca/actions/runs/34037669843",
+        "https://github.com/stablyai/orca/actions/runs/34050117471"
       ],
       "invariant": "Transport loss and frozen-host silence must preserve the remote session; host relay loss may rebind a pane without accumulating reattachable leases. Reconnects must preserve usable terminal content, bounded PTYs/fds/processes, complete large listings, and independently recoverable watcher processes. Electron test shutdown must release inherited pipes after confirmed root exit without closing live-process pipes.",
       "oracle": "Poll a changed connected SSH authority after injected faults, then require terminal output and appropriate PTY identity. Read remote process/fd state, listFiles replies, and rendered explorer rows. Resolve Playwright cleanup only after the root process exits and its inherited pipes close; live-process pipes remain untouched.",
@@ -18204,7 +18205,8 @@
         "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-transport-drop-recovery.spec.ts tests/e2e/ssh-docker-half-open-link.spec.ts tests/e2e/ssh-docker-quick-open-large-listing.spec.ts tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts tests/e2e/ssh-docker-resource-accumulation.spec.ts tests/e2e/ssh-docker-watcher-isolation.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/helpers/electron-process-shutdown.unit.test.ts",
         "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts --config tests/playwright.config.ts --project=electron-headful --workers=1",
-        "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts --config tests/playwright.config.ts --project=electron-headful --workers=1 --repeat-each=10"
+        "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts --config tests/playwright.config.ts --project=electron-headful --workers=1 --repeat-each=10",
+        "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-codex-display-artifacts-repro.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1"
       ],
       "testFiles": [
         "tests/e2e/ssh-docker-transport-drop-recovery.spec.ts",
@@ -18214,7 +18216,9 @@
         "tests/e2e/ssh-docker-resource-accumulation.spec.ts",
         "tests/e2e/ssh-docker-watcher-isolation.spec.ts",
         "tests/e2e/helpers/electron-process-shutdown.unit.test.ts",
-        "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts"
+        "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts",
+        "tests/e2e/ssh-codex-display-artifacts-repro.spec.ts",
+        "tests/e2e/ssh-codex-replay-reply-probe.unit.test.ts"
       ],
       "assertionRefs": [
         {
@@ -18264,6 +18268,18 @@
           "file": "tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts",
           "assertions": [
             "five flooding SSH panes remain below unchanged 2500ms soft and 5000ms hard freeze budgets during bulk reopen and two double-animation-frame view changes"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-codex-display-artifacts-repro.spec.ts",
+          "assertions": [
+            "normal restore and forced SSH reconnect leave no stale or duplicate status rows; forced reconnect preserves the original PTY and requires nonempty replay from that PTY through an event or reattach reply"
+          ]
+        },
+        {
+          "file": "tests/e2e/ssh-codex-replay-reply-probe.unit.test.ts",
+          "assertions": [
+            "unrelated, replacement, initial-spawn, empty and non-replay replies do not count; original reattach results and failures pass through unchanged"
           ]
         }
       ],
@@ -18322,7 +18338,8 @@
         "Linux headed CI covers the bulk-open freeze reproduction; Windows clients, WSL, folder workspaces, paired runtimes and live agent CLIs are not covered by that result.",
         "Some legacy assertions inspect terminal serialization or backing state rather than rendered DOM; no blanket visual coverage claim.",
         "No p95 CI history or full product mutation proof.",
-        "One headless bulk-open probe reached 6478.6ms in run 34035957303; animation-frame scheduling explains the consistent interaction failures, but does not directly explain that isolated timer-lag outlier. Long-term headed CI soak remains outstanding."
+        "One headless bulk-open probe reached 6478.6ms in run 34035957303; animation-frame scheduling explains the consistent interaction failures, but does not directly explain that isolated timer-lag outlier. Long-term headed CI soak remains outstanding.",
+        "Codex replay artifact evidence uses a deterministic remote TUI on Linux CI; real-service, macOS/Windows clients and cross-version replay remain separate coverage gaps."
       ],
       "demotionRule": "Keep experimental while any recovery reproduction fails or any teardown, identity, resource-count, or rendered oracle flakes; never promote by extending sleeps or retries."
     },

--- a/config/scripts/pr-e2e-gate-contract.test.mjs
+++ b/config/scripts/pr-e2e-gate-contract.test.mjs
@@ -376,13 +376,10 @@ describe('PR E2E gate contract', () => {
     // that no runner names runs nowhere and still reports green — the silent skip this file
     // exists to prevent. Asserting reachability rather than a literal keeps that true when
     // the lanes move.
-    // Why these two are exempt: each needs something CI cannot give it, recorded in
+    // The remaining exemption needs performance validation before routine CI, recorded in
     // run-ssh-docker-e2e.mjs so the gap stays legible rather than looking like coverage.
-    const unreachableSpecs = new Set([
-      'tests/e2e/ssh-docker-relay-perf.spec.ts',
-      'tests/e2e/ssh-codex-display-artifacts-repro.spec.ts'
-    ])
-    // Why comments are stripped: this file's own runner lists the two exempt specs by name in a
+    const unreachableSpecs = new Set(['tests/e2e/ssh-docker-relay-perf.spec.ts'])
+    // Why comments are stripped: the runner documents the exempt spec by name in a
     // prose comment. A substring scan over raw text would count any spec merely *discussed* in a
     // runner as claimed by it -- the silent skip this assertion exists to catch, re-entering
     // through the documentation.

--- a/config/scripts/pr-e2e-source-routing.mjs
+++ b/config/scripts/pr-e2e-source-routing.mjs
@@ -57,6 +57,7 @@ export const PR_E2E_SOURCE_ROUTES = [
     id: 'ssh-terminal-source',
     specs: [
       'tests/e2e/pty-input-write-queue-ssh.spec.ts',
+      'tests/e2e/ssh-codex-display-artifacts-repro.spec.ts',
       'tests/e2e/ssh-cold-activation-restore.spec.ts',
       'tests/e2e/ssh-docker-half-open-link.spec.ts',
       'tests/e2e/ssh-docker-reconnect-pane-restore.spec.ts',

--- a/config/scripts/run-ssh-docker-e2e.mjs
+++ b/config/scripts/run-ssh-docker-e2e.mjs
@@ -33,8 +33,6 @@ if (runtime.status !== 0) {
 //     cost the lane its credibility. NOTE: a runner script test:e2e:ssh-docker-perf exists in
 //     package.json but NO workflow invokes it, so this spec currently runs in no CI lane at
 //     all. Recorded as a real gap, not as coverage living somewhere else.
-//   ssh-codex-display-artifacts-repro.spec.ts — installs a real remote codex binary that CI
-//     runners do not have (observed as `spawn codex ENOENT`). Runs in no CI lane at all.
 // The bulk-open frame probe runs headed: headless Linux compositing schedules idle RAFs
 // roughly 1s apart, so it cannot measure foreground interaction against the same budget.
 //
@@ -62,6 +60,7 @@ const result = spawnSync(
     'tests/e2e/ssh-client-hosted-browser-drop-reconnect.spec.ts',
     'tests/e2e/pty-input-write-queue-ssh.spec.ts',
     'tests/e2e/ssh-ai-vault-session-history.spec.ts',
+    'tests/e2e/ssh-codex-display-artifacts-repro.spec.ts',
     'tests/e2e/ssh-cold-activation-restore.spec.ts',
     'tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts',
     'tests/e2e/ssh-docker-bulk-open-freeze-repro.spec.ts',

--- a/tests/e2e/ssh-codex-display-artifacts-repro.spec.ts
+++ b/tests/e2e/ssh-codex-display-artifacts-repro.spec.ts
@@ -54,146 +54,151 @@ const CAPTURE_WHILE_REMOTE_TUI_RUNNING =
 const HIDE_UNTIL_REMOTE_TUI_DONE = process.env.ORCA_E2E_HIDE_UNTIL_REMOTE_TUI_DONE === '1'
 const CAPTURE_SCROLLBACK_ARTIFACT_REGION =
   process.env.ORCA_E2E_CAPTURE_SCROLLBACK_ARTIFACT_REGION === '1'
-const FORCE_SSH_RECONNECT_DURING_TUI = process.env.ORCA_E2E_FORCE_SSH_RECONNECT_DURING_TUI === '1'
+const reconnectOverride = process.env.ORCA_E2E_FORCE_SSH_RECONNECT_DURING_TUI
+const reconnectModes = reconnectOverride === undefined ? [false, true] : [reconnectOverride === '1']
 const KEEP_SSH_REPRO_TARGET = process.env.ORCA_E2E_KEEP_SSH_REPRO_TARGET === '1'
 
 test.describe('Remote SSH Codex display artifacts repro', () => {
   test.skip(!RUN_DOCKER_SSH, 'Set ORCA_E2E_SSH_DOCKER=1 to run Docker-backed SSH repro.')
   test.skip(process.platform === 'win32', 'Docker SSH repro uses POSIX ssh tooling.')
 
-  test('does not leave duplicated Codex status output after SSH replay', async ({
-    orcaPage
-  }, testInfo: TestInfo) => {
-    test.slow()
-    let target: DockerSshRelayTarget | null = null
-    try {
-      target = startDockerSshRelayTarget(testInfo)
-      installRemoteCodexArtifactTui(target)
-      if (RUN_REAL_REMOTE_CODEX) {
-        installRemoteRealCodex(target)
-      } else {
-        installRemoteCodexFixture(target)
-      }
-      await waitForSessionReady(orcaPage)
-      await waitForActiveWorktree(orcaPage)
-      const remote = await connectDockerRemote(orcaPage, target)
-      expect(remote.targetId).toBeTruthy()
-      expect(remote.worktreeId).toBeTruthy()
-      await ensureTerminalVisible(orcaPage, 45_000)
-      await waitForActiveTerminalManager(orcaPage, 60_000)
-      await enableRiskyTerminalRendererPath(orcaPage)
-      await installPtyReplayProbe(orcaPage)
+  for (const forceReconnect of reconnectModes) {
+    test(`does not leave duplicated Codex status output after SSH replay (${forceReconnect ? 'forced reconnect' : 'normal restore'})`, async ({
+      orcaPage,
+      electronApp
+    }, testInfo: TestInfo) => {
+      test.slow()
+      let target: DockerSshRelayTarget | null = null
+      try {
+        target = startDockerSshRelayTarget(testInfo)
+        installRemoteCodexArtifactTui(target)
+        if (RUN_REAL_REMOTE_CODEX) {
+          installRemoteRealCodex(target)
+        } else {
+          installRemoteCodexFixture(target)
+        }
+        await waitForSessionReady(orcaPage)
+        await waitForActiveWorktree(orcaPage)
+        const remote = await connectDockerRemote(orcaPage, target)
+        expect(remote.targetId).toBeTruthy()
+        expect(remote.worktreeId).toBeTruthy()
+        await ensureTerminalVisible(orcaPage, 45_000)
+        await waitForActiveTerminalManager(orcaPage, 60_000)
+        await enableRiskyTerminalRendererPath(orcaPage)
 
-      const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
-      const doneMarker = RUN_REAL_REMOTE_CODEX
-        ? `ORCA_REAL_REMOTE_CODEX_DONE_${Date.now()}`
-        : REMOTE_TUI_DONE
-      const cleanMarker = RUN_REAL_REMOTE_CODEX
-        ? `ORCA_REAL_REMOTE_CODEX_CLEAN_${Date.now()}`
-        : doneMarker
-      await execInTerminal(
-        orcaPage,
-        ptyId,
-        RUN_REAL_REMOTE_CODEX
-          ? realRemoteCodexCommand(doneMarker)
-          : `codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox ${shellQuote(
-              doneMarker
-            )}`
-      )
-      await orcaPage.waitForTimeout(1_200)
-      if (FORCE_SSH_RECONNECT_DURING_TUI) {
-        dropDockerSshClientSessions(target)
-        await waitForDockerRemoteReconnected(orcaPage, remote.targetId)
-        await orcaPage.waitForTimeout(2_000)
-      }
-      await (RUN_REAL_REMOTE_CODEX
-        ? (async () => {
-            await stressRestoreRemoteTerminalDuringCodex(orcaPage, remote.worktreeId)
-            await waitForRealRemoteCodexCompletion(orcaPage, doneMarker)
-          })()
-        : (async () => {
-            if (CAPTURE_WHILE_REMOTE_TUI_RUNNING) {
-              await orcaPage.waitForTimeout(10_000)
-            } else {
-              await switchToNonRemoteWorktree(orcaPage, remote.worktreeId)
-              await (HIDE_UNTIL_REMOTE_TUI_DONE
-                ? waitForRemoteFixtureCleanFinalInHiddenPane(orcaPage, remote.worktreeId)
-                : orcaPage.waitForTimeout(10_000))
-            }
-            if (CAPTURE_WHILE_REMOTE_TUI_RUNNING) {
-              await orcaPage.waitForTimeout(900)
-              return
-            }
-            await switchToWorktree(orcaPage, remote.worktreeId)
-            await ensureTerminalVisible(orcaPage, 45_000)
-            await waitForActiveTerminalManager(orcaPage, 60_000)
-            await waitForTerminalOutput(
-              orcaPage,
-              REMOTE_CODEX_FIXTURE_CLEAN_FINAL_TEXT,
-              60_000,
-              120_000
-            )
-          })())
-      await orcaPage.waitForTimeout(600)
-      if (CAPTURE_SCROLLBACK_ARTIFACT_REGION) {
-        await scrollActiveTerminalToArtifactHistory(orcaPage)
-      }
-
-      const { analysis, screenshot } = await captureGraySlabAnalysis(orcaPage)
-      analysis.replayDebug = await readReplayProbeSnapshot(orcaPage)
-      analysis.duplicateStatusRows = await readDuplicateStatusRows(orcaPage)
-      const evidenceLabel = RUN_REAL_REMOTE_CODEX
-        ? 'real-remote-codex-reconnect-replay'
-        : 'fixture-codex-reconnect-replay'
-      persistReproEvidence(evidenceLabel, analysis, screenshot)
-      const resetEvidence = await resetWebglAndCaptureGraySlabAnalysis(orcaPage)
-      resetEvidence.analysis.replayDebug = await readReplayProbeSnapshot(orcaPage)
-      resetEvidence.analysis.duplicateStatusRows = await readDuplicateStatusRows(orcaPage)
-      persistReproEvidence(
-        `${evidenceLabel}-after-webgl-reset`,
-        resetEvidence.analysis,
-        resetEvidence.screenshot
-      )
-      await testInfo.attach('remote-codex-artifact-final-screen', {
-        body: screenshot,
-        contentType: 'image/png'
-      })
-      await testInfo.attach('remote-codex-artifact-after-webgl-reset', {
-        body: resetEvidence.screenshot,
-        contentType: 'image/png'
-      })
-      testInfo.annotations.push({
-        type: 'remote-codex-artifact-analysis',
-        description: JSON.stringify(analysis)
-      })
-      testInfo.annotations.push({
-        type: 'remote-codex-artifact-after-webgl-reset-analysis',
-        description: JSON.stringify(resetEvidence.analysis)
-      })
-
-      // Why: this spec supports both repro mode and strict regression mode so
-      // the same harness can prove a failure and lock the fixed behavior.
-      if (EXPECT_NO_ARTIFACTS) {
-        expect(analysis.slabCount).toBeLessThanOrEqual(MAX_FINAL_GRAY_SLABS)
-        expect(analysis.staleStatusGlyphRowCount).toBe(0)
-        expect(analysis.duplicateStatusRows ?? []).toEqual([])
-      } else {
-        expect(analysis.rawSlabCount + analysis.staleStatusGlyphRowCount).toBeGreaterThan(0)
-      }
-      if (FORCE_SSH_RECONNECT_DURING_TUI) {
-        expect(Number(analysis.replayDebug?.replayCount ?? 0)).toBeGreaterThan(0)
-      }
-      if (RUN_REAL_REMOTE_CODEX) {
-        await clearRemoteTerminalAfterCodex(orcaPage, ptyId, cleanMarker)
-      }
-    } finally {
-      if (KEEP_SSH_REPRO_TARGET && target) {
-        console.log(
-          `[ssh-codex-repro] keeping Docker SSH target ${target.containerName} on port ${target.port}`
+        const ptyId = await waitForActivePanePtyId(orcaPage, 60_000)
+        await installPtyReplayProbe(orcaPage, electronApp, ptyId)
+        const doneMarker = RUN_REAL_REMOTE_CODEX
+          ? `ORCA_REAL_REMOTE_CODEX_DONE_${Date.now()}`
+          : REMOTE_TUI_DONE
+        const cleanMarker = RUN_REAL_REMOTE_CODEX
+          ? `ORCA_REAL_REMOTE_CODEX_CLEAN_${Date.now()}`
+          : doneMarker
+        await execInTerminal(
+          orcaPage,
+          ptyId,
+          RUN_REAL_REMOTE_CODEX
+            ? realRemoteCodexCommand(doneMarker)
+            : `codex --no-alt-screen --dangerously-bypass-approvals-and-sandbox ${shellQuote(
+                doneMarker
+              )}`
         )
-      } else {
-        cleanupDockerSshRelayTarget(target)
+        await orcaPage.waitForTimeout(1_200)
+        if (forceReconnect) {
+          dropDockerSshClientSessions(target)
+          await waitForDockerRemoteReconnected(orcaPage, remote.targetId)
+          await orcaPage.waitForTimeout(2_000)
+        }
+        await (RUN_REAL_REMOTE_CODEX
+          ? (async () => {
+              await stressRestoreRemoteTerminalDuringCodex(orcaPage, remote.worktreeId)
+              await waitForRealRemoteCodexCompletion(orcaPage, doneMarker)
+            })()
+          : (async () => {
+              if (CAPTURE_WHILE_REMOTE_TUI_RUNNING) {
+                await orcaPage.waitForTimeout(10_000)
+              } else {
+                await switchToNonRemoteWorktree(orcaPage, remote.worktreeId)
+                await (HIDE_UNTIL_REMOTE_TUI_DONE
+                  ? waitForRemoteFixtureCleanFinalInHiddenPane(orcaPage, remote.worktreeId)
+                  : orcaPage.waitForTimeout(10_000))
+              }
+              if (CAPTURE_WHILE_REMOTE_TUI_RUNNING) {
+                await orcaPage.waitForTimeout(900)
+                return
+              }
+              await switchToWorktree(orcaPage, remote.worktreeId)
+              await ensureTerminalVisible(orcaPage, 45_000)
+              await waitForActiveTerminalManager(orcaPage, 60_000)
+              await waitForTerminalOutput(
+                orcaPage,
+                REMOTE_CODEX_FIXTURE_CLEAN_FINAL_TEXT,
+                60_000,
+                120_000
+              )
+            })())
+        await orcaPage.waitForTimeout(600)
+        if (CAPTURE_SCROLLBACK_ARTIFACT_REGION) {
+          await scrollActiveTerminalToArtifactHistory(orcaPage)
+        }
+
+        const { analysis, screenshot } = await captureGraySlabAnalysis(orcaPage)
+        analysis.replayDebug = await readReplayProbeSnapshot(orcaPage, electronApp)
+        analysis.duplicateStatusRows = await readDuplicateStatusRows(orcaPage)
+        const evidenceLabel = RUN_REAL_REMOTE_CODEX
+          ? 'real-remote-codex-reconnect-replay'
+          : 'fixture-codex-reconnect-replay'
+        persistReproEvidence(evidenceLabel, analysis, screenshot)
+        const resetEvidence = await resetWebglAndCaptureGraySlabAnalysis(orcaPage)
+        resetEvidence.analysis.replayDebug = await readReplayProbeSnapshot(orcaPage, electronApp)
+        resetEvidence.analysis.duplicateStatusRows = await readDuplicateStatusRows(orcaPage)
+        persistReproEvidence(
+          `${evidenceLabel}-after-webgl-reset`,
+          resetEvidence.analysis,
+          resetEvidence.screenshot
+        )
+        await testInfo.attach('remote-codex-artifact-final-screen', {
+          body: screenshot,
+          contentType: 'image/png'
+        })
+        await testInfo.attach('remote-codex-artifact-after-webgl-reset', {
+          body: resetEvidence.screenshot,
+          contentType: 'image/png'
+        })
+        testInfo.annotations.push({
+          type: 'remote-codex-artifact-analysis',
+          description: JSON.stringify(analysis)
+        })
+        testInfo.annotations.push({
+          type: 'remote-codex-artifact-after-webgl-reset-analysis',
+          description: JSON.stringify(resetEvidence.analysis)
+        })
+
+        // Why: this spec supports both repro mode and strict regression mode so
+        // the same harness can prove a failure and lock the fixed behavior.
+        if (EXPECT_NO_ARTIFACTS) {
+          expect(analysis.slabCount).toBeLessThanOrEqual(MAX_FINAL_GRAY_SLABS)
+          expect(analysis.staleStatusGlyphRowCount).toBe(0)
+          expect(analysis.duplicateStatusRows ?? []).toEqual([])
+        } else {
+          expect(analysis.rawSlabCount + analysis.staleStatusGlyphRowCount).toBeGreaterThan(0)
+        }
+        if (forceReconnect) {
+          expect(await waitForActivePanePtyId(orcaPage, 60_000)).toBe(ptyId)
+          expect(Number(analysis.replayDebug?.replayCount ?? 0)).toBeGreaterThan(0)
+        }
+        if (RUN_REAL_REMOTE_CODEX) {
+          await clearRemoteTerminalAfterCodex(orcaPage, ptyId, cleanMarker)
+        }
+      } finally {
+        if (KEEP_SSH_REPRO_TARGET && target) {
+          console.log(
+            `[ssh-codex-repro] keeping Docker SSH target ${target.containerName} on port ${target.port}`
+          )
+        } else {
+          cleanupDockerSshRelayTarget(target)
+        }
       }
-    }
-  })
+    })
+  }
 })

--- a/tests/e2e/ssh-codex-reconnect-replay-driver.ts
+++ b/tests/e2e/ssh-codex-reconnect-replay-driver.ts
@@ -1,5 +1,6 @@
+import { installSshReplayReplyProbe, readSshReplayReplies } from './ssh-codex-replay-reply-probe'
 import { execFileSync } from 'node:child_process'
-import type { Page } from '@stablyai/playwright-test'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
 import { expect } from './helpers/orca-app'
 import {
   DOCKER_SSH_RELAY_REMOTE_REPO_PATH,
@@ -135,8 +136,13 @@ export async function switchToNonRemoteWorktree(
   return otherWorktreeId
 }
 
-export async function installPtyReplayProbe(page: Page): Promise<void> {
-  await page.evaluate(() => {
+export async function installPtyReplayProbe(
+  page: Page,
+  app: ElectronApplication,
+  ptyId: string
+): Promise<void> {
+  await installSshReplayReplyProbe(app, ptyId)
+  await page.evaluate((expectedPtyId) => {
     const api = window.api?.pty
     if (!api || typeof api.onReplay !== 'function') {
       throw new Error('PTY replay API unavailable')
@@ -150,6 +156,9 @@ export async function installPtyReplayProbe(page: Page): Promise<void> {
     holder.__orcaSshCodexReplayProbe?.dispose()
     const payloads: { id: string; length: number; preview: string }[] = []
     const dispose = api.onReplay(({ id, data }) => {
+      if (id !== expectedPtyId) {
+        return
+      }
       payloads.push({
         id,
         length: data.length,
@@ -157,7 +166,7 @@ export async function installPtyReplayProbe(page: Page): Promise<void> {
       })
     })
     holder.__orcaSshCodexReplayProbe = { payloads, dispose }
-  })
+  }, ptyId)
 }
 
 export async function waitForDockerRemoteReconnected(page: Page, targetId: string): Promise<void> {
@@ -182,8 +191,12 @@ export async function waitForDockerRemoteReconnected(page: Page, targetId: strin
     .toBe(true)
 }
 
-export async function readReplayProbeSnapshot(page: Page): Promise<Record<string, unknown>> {
-  return page.evaluate(() => {
+export async function readReplayProbeSnapshot(
+  page: Page,
+  app: ElectronApplication
+): Promise<Record<string, unknown>> {
+  const replies = await readSshReplayReplies(app)
+  return page.evaluate((replies) => {
     const probe = (
       window as unknown as {
         __orcaSshCodexReplayProbe?: {
@@ -192,10 +205,10 @@ export async function readReplayProbeSnapshot(page: Page): Promise<Record<string
       }
     ).__orcaSshCodexReplayProbe
     return {
-      replayCount: probe?.payloads.length ?? 0,
-      replayPayloads: probe?.payloads.slice(-8) ?? []
+      replayCount: (probe?.payloads.length ?? 0) + replies.length,
+      replayPayloads: [...(probe?.payloads ?? []), ...replies].slice(-8)
     }
-  })
+  }, replies)
 }
 
 export async function readDuplicateStatusRows(page: Page): Promise<string[]> {

--- a/tests/e2e/ssh-codex-replay-reply-probe.ts
+++ b/tests/e2e/ssh-codex-replay-reply-probe.ts
@@ -1,0 +1,55 @@
+import type { ElectronApplication } from '@stablyai/playwright-test'
+
+type ReplayPayload = { id: string; length: number; preview: string; source: 'spawn-reply' }
+type SpawnHandler = (event: unknown, args: Record<string, unknown>) => Promise<unknown>
+type ReplayReplyScope = typeof globalThis & {
+  __orcaSshCodexReplayReplies?: ReplayPayload[]
+}
+
+export async function installSshReplayReplyProbe(
+  app: ElectronApplication,
+  ptyId: string
+): Promise<void> {
+  await app.evaluate(({ ipcMain }, expectedPtyId) => {
+    const scope = globalThis as ReplayReplyScope
+    if (scope.__orcaSshCodexReplayReplies) {
+      throw new Error('SSH replay reply probe already installed')
+    }
+    const handlers = (ipcMain as unknown as { _invokeHandlers?: Map<string, SpawnHandler> })
+      ._invokeHandlers
+    const original = handlers?.get('pty:spawn')
+    if (!handlers || !original) {
+      throw new Error('PTY spawn handler unavailable')
+    }
+    const payloads: ReplayPayload[] = []
+    scope.__orcaSshCodexReplayReplies = payloads
+    // SSH reconnect returns its replay with the reattach reply, without a pty:replay push.
+    handlers.set('pty:spawn', async (event, args) => {
+      const result = await original(event, args)
+      if (
+        args.sessionId === expectedPtyId &&
+        result &&
+        typeof result === 'object' &&
+        'id' in result &&
+        result.id === expectedPtyId &&
+        'isReattach' in result &&
+        result.isReattach === true &&
+        'replay' in result &&
+        typeof result.replay === 'string' &&
+        result.replay.length > 0
+      ) {
+        payloads.push({
+          id: expectedPtyId,
+          length: result.replay.length,
+          preview: result.replay.slice(-400),
+          source: 'spawn-reply'
+        })
+      }
+      return result
+    })
+  }, ptyId)
+}
+
+export async function readSshReplayReplies(app: ElectronApplication): Promise<ReplayPayload[]> {
+  return app.evaluate(() => (globalThis as ReplayReplyScope).__orcaSshCodexReplayReplies ?? [])
+}

--- a/tests/e2e/ssh-codex-replay-reply-probe.unit.test.ts
+++ b/tests/e2e/ssh-codex-replay-reply-probe.unit.test.ts
@@ -1,0 +1,52 @@
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { installSshReplayReplyProbe, readSshReplayReplies } from './ssh-codex-replay-reply-probe'
+
+beforeEach(() => vi.stubGlobal('__orcaSshCodexReplayReplies', undefined))
+afterEach(() => vi.unstubAllGlobals())
+
+function harness(result: unknown) {
+  const original = vi.fn().mockResolvedValue(result)
+  const handlers = new Map([['pty:spawn', original]])
+  const app = {
+    evaluate: (fn: (electron: unknown, arg: unknown) => unknown, arg: unknown) =>
+      fn({ ipcMain: { _invokeHandlers: handlers } }, arg)
+  } as unknown as ElectronApplication
+  return { app, original, handlers }
+}
+
+it('records the original PTY reattach reply without changing the handler result', async () => {
+  const result = { id: 'ssh:target@@pty-1', isReattach: true, replay: 'restored output' }
+  const { app, handlers, original } = harness(result)
+  await installSshReplayReplyProbe(app, result.id)
+  const event = {}
+  const args = { sessionId: result.id }
+  expect(await handlers.get('pty:spawn')!(event, args)).toBe(result)
+  expect(original).toHaveBeenCalledWith(event, args)
+  expect(await readSshReplayReplies(app)).toEqual([
+    { id: result.id, length: 15, preview: 'restored output', source: 'spawn-reply' }
+  ])
+})
+
+it.each([
+  [{}, { id: 'wanted', isReattach: true, replay: 'initial' }],
+  [{ sessionId: 'other' }, { id: 'other', isReattach: true, replay: 'other PTY' }],
+  [{ sessionId: 'wanted' }, { id: 'replacement', isReattach: true, replay: 'new PTY' }],
+  [{ sessionId: 'wanted' }, { id: 'wanted', replay: 'no reattach proof' }],
+  [{ sessionId: 'wanted' }, { id: 'wanted', isReattach: true, replay: '' }],
+  [{ sessionId: 'wanted' }, { id: 'wanted', isReattach: true, snapshot: 'not replay' }]
+])('does not count unrelated or unproven replay: %j', async (args, result) => {
+  const { app, handlers } = harness(result)
+  await installSshReplayReplyProbe(app, 'wanted')
+  expect(await handlers.get('pty:spawn')!({}, args)).toBe(result)
+  expect(await readSshReplayReplies(app)).toEqual([])
+})
+
+it('preserves a failed reattach without recording replay', async () => {
+  const { app, handlers, original } = harness(null)
+  const error = new Error('unverifiable')
+  original.mockRejectedValue(error)
+  await installSshReplayReplyProbe(app, 'wanted')
+  await expect(handlers.get('pty:spawn')!({}, { sessionId: 'wanted' })).rejects.toBe(error)
+  expect(await readSshReplayReplies(app)).toEqual([])
+})


### PR DESCRIPTION
Forced SSH reconnect can return terminal replay in the `pty:spawn` reattach reply without emitting a `pty:replay` event. The artifact test watched only events and failed its replay-count assertion despite receiving 46,513 characters of replay for the original PTY. Count both delivery paths, accepting only the original PTY and nonempty reattach replay; preserve the handler result/error and the existing visual assertions.

Run normal restore and forced reconnect as separate default cases using the existing deterministic remote Codex fixture. Add the spec to the Docker SSH runner, SSH source routing, and reliability manifest; remove its stale real-Codex-only exclusion. The real-service mode stays opt-in.

Validation: replay probe and routing contract tests pass (50 tests). Lint passes. CI https://github.com/stablyai/orca/actions/runs/34050117471 passed three normal and three forced reconnect repetitions with zero retries for the probe correction. Final default-case/routing validation is running on this PR head. Local E2E typecheck has existing errors outside the replay files. All rendered testing ran in GitHub CI.

Default-mode rendered CI https://github.com/stablyai/orca/actions/runs/34050757776 passed both normal restore and forced reconnect (2.2m). The follow-up commit adds the missing unit command required by the manifest validator; all 105 gates now validate locally. Final PR CI and review remain pending.
