### PR TITLE
test: follow retained Activity sidebar during pane selection

### DIFF
--- a/tests/e2e/activity-agent-pane-isolation.spec.ts
+++ b/tests/e2e/activity-agent-pane-isolation.spec.ts
@@ -251,8 +251,9 @@ test.describe('Activity Agent Pane Isolation', () => {
         activeLeafId: first.leafId
       })
 
-    // Revealing a workspace returns the sidebar to its workspace list.
-    await agentsSidebarButton(orcaPage).click()
+    await expect(
+      orcaPage.getByRole('button', { name: 'Turn off activity view', exact: true })
+    ).toHaveAttribute('aria-pressed', 'true')
     await orcaPage.getByRole('button').filter({ hasText: second.prompt }).first().click()
     await expect
       .poll(async () => readActivePaneSelection(orcaPage), {


### PR DESCRIPTION
Main now activates Activity agent rows with `revealInSidebar: false`, keeping the Activity sidebar open. The pane-isolation test still waits for a `View activity` button after selecting the first row; main-suite CI fails because the visible button is `Turn off activity view`.

Assert that Activity remains active, then select the second agent row directly. Preserve the original stable-leaf pane-focus assertions for both selections. This updates only the test.

Validation: lint and formatting pass. Dedicated rendered CI is running on merged main plus this change. Baseline evidence: https://github.com/stablyai/orca/actions/runs/34049291444 (shard 1, failure at the obsolete second toggle click).

Rendered CI https://github.com/stablyai/orca/actions/runs/34050804585 passed all four pane-isolation tests (1.8m) on the exact test change. Final PR CI and review remain pending.
