### PR TITLE
fix(mobile/chat): robust tail-follow (no mid-stream un-pin, no expand convulse)

### DIFF
--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -1,13 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import {
-  ActivityIndicator,
-  FlatList,
-  type NativeScrollEvent,
-  type NativeSyntheticEvent,
-  Pressable,
-  Text,
-  View
-} from 'react-native'
+import { ActivityIndicator, FlatList, Pressable, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
 import { ArrowDown, ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
@@ -21,6 +13,7 @@ import {
   type MobileNativeChatPendingItem
 } from './mobile-native-chat-render-data'
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
+import { useMobileNativeChatTailFollow } from './use-mobile-native-chat-tail-follow'
 import { useMobileNativeChatTurnDisclosure } from './use-mobile-native-chat-turn-disclosure'
 import { MobileNativeChatTurnStatus } from './MobileNativeChatTurnStatus'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
@@ -176,9 +169,18 @@ export function MobileNativeChatView({
   // Lift the composer clear of the keyboard, plus the bottom safe-area so it
   // never sits under the home indicator / nav bar (mirrors the terminal dock).
   const bottomPad = keyboardInset > 0 ? keyboardInset + insets.bottom : insets.bottom
-  const [atBottom, setAtBottom] = useState(true)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
+  const {
+    atBottom,
+    repin,
+    maybeFollowTail,
+    onScroll,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollBegin,
+    onMomentumScrollEnd
+  } = useMobileNativeChatTailFollow({ listRef, hasMore, loadingEarlier, onLoadEarlier })
   useEffect(
     () => () => {
       if (sendScrollTimerRef.current) {
@@ -203,18 +205,6 @@ export function MobileNativeChatView({
     [messages, folded, streaming, pending, imagePreviewsByMessageId]
   )
 
-  // Follow the tail as the conversation grows and keep the newest message above
-  // the keyboard when it opens — but only when already pinned to the bottom, so
-  // we don't yank the user away while they read history. (Also fires on keyboard
-  // close, which is harmless while atBottom.)
-  useEffect(() => {
-    if (data.length === 0 || !atBottom) {
-      return
-    }
-    const t = setTimeout(() => listRef.current?.scrollToEnd({ animated: true }), 60)
-    return () => clearTimeout(t)
-  }, [data.length, atBottom, keyboardInset])
-
   const handleSend = useCallback(
     async (text: string): Promise<boolean> => {
       const accepted = await onSend(text)
@@ -225,7 +215,7 @@ export function MobileNativeChatView({
       // or a stale "Message not sent" sits above the delivered message.
       onClearSendError?.()
       // Always jump to the newest message when the user sends.
-      setAtBottom(true)
+      repin()
       if (sendScrollTimerRef.current) {
         clearTimeout(sendScrollTimerRef.current)
       }
@@ -235,20 +225,7 @@ export function MobileNativeChatView({
       }, 60)
       return true
     },
-    [onSend, onClearSendError]
-  )
-
-  const onScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent
-      const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
-      setAtBottom(distanceFromBottom < 80)
-      // Near the top — page in older history.
-      if (contentOffset.y < 60 && hasMore && !loadingEarlier) {
-        onLoadEarlier?.()
-      }
-    },
-    [hasMore, loadingEarlier, onLoadEarlier]
+    [onSend, onClearSendError, repin]
   )
 
   // Align a single message's top to the top of the viewport.
@@ -317,12 +294,12 @@ export function MobileNativeChatView({
               // instead of being swallowed by the dismiss gesture.
               keyboardShouldPersistTaps="handled"
               onScroll={onScroll}
+              onScrollBeginDrag={onScrollBeginDrag}
+              onScrollEndDrag={onScrollEndDrag}
+              onMomentumScrollBegin={onMomentumScrollBegin}
+              onMomentumScrollEnd={onMomentumScrollEnd}
               scrollEventThrottle={32}
-              onContentSizeChange={() => {
-                if (data.length > 0 && atBottom) {
-                  listRef.current?.scrollToEnd({ animated: false })
-                }
-              }}
+              onContentSizeChange={() => maybeFollowTail(data.length)}
               // scrollToIndex can fail before an off-screen row is measured —
               // fall back to an estimated offset, then retry once it's laid out.
               onScrollToIndexFailed={(info) => {
@@ -378,7 +355,13 @@ export function MobileNativeChatView({
             <Pressable
               accessibilityLabel="Scroll to latest"
               style={[styles.fab, styles.fabBottom]}
-              onPress={() => listRef.current?.scrollToEnd({ animated: true })}
+              onPress={() => {
+                // Re-pin before the programmatic scroll: it fires no drag/momentum,
+                // so onScroll never recomputes the pin — without this the FAB sticks
+                // and tail-follow stops tracking new content.
+                repin()
+                listRef.current?.scrollToEnd({ animated: true })
+              }}
             >
               <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
             </Pressable>

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -174,6 +174,7 @@ export function MobileNativeChatView({
   const {
     atBottom,
     repin,
+    unpin,
     maybeFollowTail,
     onScroll,
     onScrollBeginDrag,
@@ -205,6 +206,15 @@ export function MobileNativeChatView({
     [messages, folded, streaming, pending, imagePreviewsByMessageId]
   )
 
+  // Opening the keyboard shrinks the list viewport (via `bottomPad`) without
+  // changing content height, so `onContentSizeChange` never fires — re-follow the
+  // tail on keyboard inset changes to keep the newest message above the composer.
+  const dataLenRef = useRef(data.length)
+  dataLenRef.current = data.length
+  useEffect(() => {
+    maybeFollowTail(dataLenRef.current)
+  }, [keyboardInset, maybeFollowTail])
+
   const handleSend = useCallback(
     async (text: string): Promise<boolean> => {
       const accepted = await onSend(text)
@@ -228,10 +238,16 @@ export function MobileNativeChatView({
     [onSend, onClearSendError, repin]
   )
 
-  // Align a single message's top to the top of the viewport.
-  const onScrollToMessage = useCallback((index: number) => {
-    listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
-  }, [])
+  // Align a single message's top to the top of the viewport. This is an explicit
+  // jump away from the tail, so drop the pin — otherwise the next streaming chunk
+  // re-follows the tail and undoes the user's navigation.
+  const onScrollToMessage = useCallback(
+    (index: number) => {
+      unpin()
+      listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
+    },
+    [unpin]
+  )
 
   // Per-turn "Thinking / Working for N / Worked for N" rows. The structured lane
   // owns them; the bridge lane keeps its three-dot indicator.

--- a/mobile/src/session/use-mobile-native-chat-tail-follow.ts
+++ b/mobile/src/session/use-mobile-native-chat-tail-follow.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
+import type { FlatList, NativeScrollEvent, NativeSyntheticEvent } from 'react-native'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+
+type Options = {
+  listRef: RefObject<FlatList<NativeChatMessage> | null>
+  hasMore?: boolean
+  loadingEarlier?: boolean
+  onLoadEarlier?: () => void
+}
+
+type TailFollow = {
+  /** Mirror of the pin, for the jump-to-latest button. */
+  atBottom: boolean
+  /** Re-pin to the tail (used on send). */
+  repin: () => void
+  /** Instant follow when pinned — the sole tail-follow, driven by content growth. */
+  maybeFollowTail: (dataLength: number) => void
+  onScroll: (e: NativeSyntheticEvent<NativeScrollEvent>) => void
+  onScrollBeginDrag: () => void
+  onScrollEndDrag: () => void
+  onMomentumScrollBegin: () => void
+  onMomentumScrollEnd: () => void
+}
+
+/** Keeps the chat list pinned to the newest message during streaming without the
+ *  animation thrash of a per-tick animated scroll: content growth follows the
+ *  tail instantly, and the pin is dropped only on a genuine user scroll. */
+export function useMobileNativeChatTailFollow({
+  listRef,
+  hasMore,
+  loadingEarlier,
+  onLoadEarlier
+}: Options): TailFollow {
+  // Follow-the-tail flag as a ref, not just state: content-growth handlers read
+  // it synchronously (no stale render closure) and it survives the frame race
+  // where a growth-induced onScroll would otherwise un-pin us mid-stream.
+  const pinnedRef = useRef(true)
+  // Un-pin only on genuine user motion: distanceFromBottom is recomputed from
+  // onScroll solely while a drag or its momentum is in flight, so a programmatic
+  // scrollToEnd (which also fires onScroll) can never flip us off the tail.
+  const userDraggingRef = useRef(false)
+  const momentumRef = useRef(false)
+  const [atBottom, setAtBottom] = useState(true)
+  // Coalesce a burst of content-size changes into one scroll per frame. A bulk
+  // expand (the "Tools" toggle opening every run) or a keyboard reflow fires
+  // onContentSizeChange many times across successive layout passes; calling
+  // scrollToEnd synchronously on each one makes the list convulse. One rAF-gated
+  // scroll per frame tracks the growing tail smoothly instead.
+  const followRafRef = useRef<number | null>(null)
+
+  useEffect(
+    () => () => {
+      if (followRafRef.current !== null) {
+        cancelAnimationFrame(followRafRef.current)
+      }
+    },
+    []
+  )
+
+  const repin = useCallback(() => {
+    pinnedRef.current = true
+    setAtBottom(true)
+  }, [])
+
+  const maybeFollowTail = useCallback(
+    (dataLength: number) => {
+      if (dataLength <= 0 || !pinnedRef.current || followRafRef.current !== null) {
+        return
+      }
+      followRafRef.current = requestAnimationFrame(() => {
+        followRafRef.current = null
+        // Re-check the pin at fire time: a drag between schedule and frame may
+        // have un-pinned us, and we must not yank the user back to the tail.
+        if (pinnedRef.current) {
+          listRef.current?.scrollToEnd({ animated: false })
+        }
+      })
+    },
+    [listRef]
+  )
+
+  const onScroll = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } = e.nativeEvent
+      // Only a user-driven scroll (active drag or its momentum) may change the
+      // pin — a growth-induced onScroll must not, or streaming would un-pin us.
+      if (userDraggingRef.current || momentumRef.current) {
+        const distanceFromBottom = contentSize.height - (contentOffset.y + layoutMeasurement.height)
+        // 120px tolerates a streaming chunk or keyboard reflow landing between a
+        // follow scroll and its settle without dropping the follow.
+        const pinned = distanceFromBottom < 120
+        pinnedRef.current = pinned
+        setAtBottom(pinned)
+      }
+      // Near the top — page in older history (fires regardless of drag state).
+      if (contentOffset.y < 60 && hasMore && !loadingEarlier) {
+        onLoadEarlier?.()
+      }
+    },
+    [hasMore, loadingEarlier, onLoadEarlier]
+  )
+
+  const onScrollBeginDrag = useCallback(() => {
+    userDraggingRef.current = true
+  }, [])
+  const onScrollEndDrag = useCallback(() => {
+    userDraggingRef.current = false
+  }, [])
+  const onMomentumScrollBegin = useCallback(() => {
+    momentumRef.current = true
+  }, [])
+  const onMomentumScrollEnd = useCallback(() => {
+    momentumRef.current = false
+    userDraggingRef.current = false
+  }, [])
+
+  return {
+    atBottom,
+    repin,
+    maybeFollowTail,
+    onScroll,
+    onScrollBeginDrag,
+    onScrollEndDrag,
+    onMomentumScrollBegin,
+    onMomentumScrollEnd
+  }
+}

--- a/mobile/src/session/use-mobile-native-chat-tail-follow.ts
+++ b/mobile/src/session/use-mobile-native-chat-tail-follow.ts
@@ -14,6 +14,9 @@ type TailFollow = {
   atBottom: boolean
   /** Re-pin to the tail (used on send). */
   repin: () => void
+  /** Drop the pin on an explicit user jump away from the tail (per-message
+   *  scroll-to-top), so a later streaming chunk can't yank them back. */
+  unpin: () => void
   /** Instant follow when pinned — the sole tail-follow, driven by content growth. */
   maybeFollowTail: (dataLength: number) => void
   onScroll: (e: NativeSyntheticEvent<NativeScrollEvent>) => void
@@ -63,6 +66,11 @@ export function useMobileNativeChatTailFollow({
     setAtBottom(true)
   }, [])
 
+  const unpin = useCallback(() => {
+    pinnedRef.current = false
+    setAtBottom(false)
+  }, [])
+
   const maybeFollowTail = useCallback(
     (dataLength: number) => {
       if (dataLength <= 0 || !pinnedRef.current || followRafRef.current !== null) {
@@ -93,8 +101,17 @@ export function useMobileNativeChatTailFollow({
         pinnedRef.current = pinned
         setAtBottom(pinned)
       }
-      // Near the top — page in older history (fires regardless of drag state).
-      if (contentOffset.y < 60 && hasMore && !loadingEarlier) {
+      // Near the top — page in older history, but only on genuine user motion
+      // over scrollable content. A programmatic scrollToEnd on a short (sub-
+      // viewport) conversation emits onScroll at offset 0, which would otherwise
+      // auto-request history the user never asked for.
+      if (
+        (userDraggingRef.current || momentumRef.current) &&
+        contentSize.height > layoutMeasurement.height &&
+        contentOffset.y < 60 &&
+        hasMore &&
+        !loadingEarlier
+      ) {
         onLoadEarlier?.()
       }
     },
@@ -118,6 +135,7 @@ export function useMobileNativeChatTailFollow({
   return {
     atBottom,
     repin,
+    unpin,
     maybeFollowTail,
     onScroll,
     onScrollBeginDrag,


### PR DESCRIPTION
## ELI5

On mobile, the chat list kept losing its place while an agent streamed: a new chunk could snap you back to the bottom even after you scrolled up, the **Tools** toggle made the whole list twitch, and the jump-to-latest button would get stuck. This centralizes "stick to the newest message" into one hook that only lets a *real finger scroll* change whether we follow the tail.

## What Changed

Extracts tail-follow into `useMobileNativeChatTailFollow`:
- The pin only changes on a **genuine user drag/momentum** (`onScrollBeginDrag`/`EndDrag`/`Momentum`), so streaming or programmatic scrolls never flip it.
- Tail growth is followed by a **single rAF-coalesced** scroll per frame — kills the storm of synchronous `scrollToEnd` calls the **Tools** bulk-expand used to trigger.
- Send and the jump-to-latest FAB `repin()` before their programmatic scroll so follow resumes.

Follow-up commit addressing review (`fc3b48d4`):
- **Pagination gate:** don't auto-request older history at the tail. A programmatic `scrollToEnd` on a sub-viewport conversation emits `onScroll` at offset 0; `onLoadEarlier` is now gated on genuine user motion over scrollable content.
- **Jump un-pin:** the per-message scroll-to-top arrow (`onScrollToMessage`) now un-pins, so a later streaming chunk no longer yanks the user back to the tail after they navigate away.
- **Keyboard follow:** opening the keyboard shrinks the viewport (via `bottomPad`) without changing content height, so `onContentSizeChange` never fires. A keyboard-inset effect re-follows the tail so the newest message stays above the composer.

## Why

Three coupled auto-scroll bugs made streaming chat unusable on mobile: mid-stream un-pin, convulse-on-expand, and a sticky FAB. Routing every pin change through explicit user-gesture handlers (not offset math on every `onScroll`) is what makes the behavior deterministic.

## Linked Issue

N/A — no tracking issue; this is a self-reported mobile chat regression found while using the app on-device.

## Visual Proof

N/A as static images — these are streaming-scroll timing behaviors (follow / un-pin / re-pin) that a before/after screenshot can't convey. Verified on-device instead (see Testing).

## Testing

Manually verified on a physical Android device (arm64 release APK, `com.stably.orca.mobile`) paired to a desktop Orca over LAN, in chat mode against a live streaming agent session:
- Streaming stays pinned and smoothly follows the tail; no mid-stream un-pin.
- Scrolling up un-pins and stays put; jump-to-latest ↓ FAB appears, re-pins, and disappears.
- **Tools** toggle bulk-expand no longer convulses the list (rAF coalescing).
- Per-message scroll-to-top jump holds position against the next streaming chunk.

- [x] I manually tested these changes locally (on-device, Android)
- [x] Automated tests added/updated, or explained why not below — `mobile/src/session/MobileNativeChatView.test.ts` passes; `tsc --noEmit` clean (only the pre-existing `*.generated` codegen stubs error, unrelated). oxlint deferred to CI.

Tested platform: Android (mobile). No desktop/SSH surface touched.

## AI Disclosure

Claude (Opus 4.8) via Claude Code assisted with the implementation.

## Review

Addressed automated review on the first commit:
- CodeRabbit (major, correctness): auto-pagination at the tail — fixed by the pagination gate.
- pullfrog: user-initiated jump not un-pinning — fixed by `onScrollToMessage` un-pin; keyboard-open follow dropped — fixed by the keyboard-inset effect.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation touched.

## Notes

Mobile-only, additive. No security, cross-platform, remote/SSH, or backwards-compat surface changed; the wire and desktop are untouched. Performance improves (fewer synchronous scrolls; rAF coalescing).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)