### PR TITLE
perf(terminals): keep shutdown maps' identity when there is nothing to clear

### DIFF
--- a/src/renderer/src/store/copy-on-write-record.test.ts
+++ b/src/renderer/src/store/copy-on-write-record.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { copyOnWriteRecord } from './copy-on-write-record'
+
+describe('copyOnWriteRecord', () => {
+  it('returns the source untouched when nothing is written', () => {
+    const source = { a: 1 }
+    const record = copyOnWriteRecord(source)
+    record.delete('missing')
+    expect(record.read()).toBe(source)
+    expect(source).toEqual({ a: 1 })
+  })
+
+  it('clones once and never mutates the source', () => {
+    const source = { a: 1, b: 2 }
+    const record = copyOnWriteRecord(source)
+    record.set('c', 3)
+    const afterFirstWrite = record.read()
+    record.delete('a')
+    expect(record.read()).toBe(afterFirstWrite)
+    expect(record.read()).toEqual({ b: 2, c: 3 })
+    expect(source).toEqual({ a: 1, b: 2 })
+  })
+
+  it('deletes a key added after the clone', () => {
+    const record = copyOnWriteRecord<number>({})
+    record.set('a', 1)
+    record.delete('a')
+    expect(record.read()).toEqual({})
+  })
+})

--- a/src/renderer/src/store/copy-on-write-record.ts
+++ b/src/renderer/src/store/copy-on-write-record.ts
@@ -1,0 +1,32 @@
+export type CopyOnWriteRecord<T> = {
+  /** The source until the first write, then the one clone every later write reuses. */
+  read: () => Record<string, T>
+  /** No-op for an absent key, so deleting nothing never clones. */
+  delete: (key: string) => void
+  set: (key: string, value: T) => void
+}
+
+/**
+ * Lets a store patch touch a record only when it has something to change: an untouched
+ * source keeps its identity, so identity-keyed selectors and persist gates stay quiet.
+ */
+export function copyOnWriteRecord<T>(source: Record<string, T>): CopyOnWriteRecord<T> {
+  let next = source
+  const mutable = (): Record<string, T> => {
+    if (next === source) {
+      next = { ...source }
+    }
+    return next
+  }
+  return {
+    read: () => next,
+    delete: (key) => {
+      if (key in next) {
+        delete mutable()[key]
+      }
+    },
+    set: (key, value) => {
+      mutable()[key] = value
+    }
+  }
+}

--- a/src/renderer/src/store/terminals/terminal-shutdown-map-identity.test.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-map-identity.test.ts
@@ -58,7 +58,8 @@ function commit(state: AppState, exitGuardPtyIds: readonly string[] = []): AppSt
     keepIdentifiers: true,
     retainedCompletionEvidence: [],
     set: ((update: unknown) => {
-      const patch = typeof update === 'function' ? (update as (s: AppState) => object)(current) : update
+      const patch =
+        typeof update === 'function' ? (update as (s: AppState) => object)(current) : update
       current = { ...current, ...(patch as object) }
     }) as never,
     shutdownReason: 'manual-sleep',

--- a/src/renderer/src/store/terminals/terminal-shutdown-map-identity.test.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-map-identity.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import { commitTerminalShutdownState } from './terminal-shutdown-state'
+
+const WORKTREE = 'repo::/tmp/app'
+const TAB_ID = 'tab-a'
+
+const tab = { id: TAB_ID, worktreeId: WORKTREE } as unknown as TerminalTab
+
+/** Maps a shutdown with nothing left to clear must not re-reference. */
+const UNTOUCHED_FIELDS = [
+  'ptyIdsByTabId',
+  'suppressedPtyExitIds',
+  'pendingPtyShutdownIds',
+  'pendingCodexPaneRestartIds',
+  'codexRestartNoticeByPtyId',
+  'pendingSetupSplitByTabId',
+  'pendingIssueCommandSplitByTabId',
+  'terminalLayoutsByTabId',
+  'runtimePaneTitlesByTabId',
+  'lastKnownRelayPtyIdByTabId'
+] as const
+
+function buildState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    tabsByWorktree: { [WORKTREE]: [tab] },
+    // The tab already exited: its pty list is present and empty.
+    ptyIdsByTabId: { [TAB_ID]: [] },
+    suppressedPtyExitIds: {},
+    pendingPtyShutdownIds: {},
+    pendingCodexPaneRestartIds: {},
+    codexRestartNoticeByPtyId: {},
+    pendingSetupSplitByTabId: {},
+    pendingIssueCommandSplitByTabId: {},
+    terminalLayoutsByTabId: {},
+    runtimePaneTitlesByTabId: {},
+    lastKnownRelayPtyIdByTabId: {},
+    unreadTerminalTabs: {},
+    unreadTerminalPanes: {},
+    unreadAgentCompletionPanes: {},
+    lastTerminalInputAtByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {},
+    // Post-write actions this helper calls; irrelevant to the identity contract.
+    dropAgentStatusByWorktree: () => undefined,
+    clearPaneForegroundAgentByWorktree: () => undefined,
+    clearSleepingAgentSessionsByWorktree: () => undefined,
+    isPtyShutdownPending: () => false,
+    ...overrides
+  } as unknown as AppState
+}
+
+function commit(state: AppState, exitGuardPtyIds: readonly string[] = []): AppState {
+  let current = state
+  commitTerminalShutdownState({
+    exitGuardPtyIds,
+    get: (() => current) as never,
+    keepIdentifiers: true,
+    retainedCompletionEvidence: [],
+    set: ((update: unknown) => {
+      const patch = typeof update === 'function' ? (update as (s: AppState) => object)(current) : update
+      current = { ...current, ...(patch as object) }
+    }) as never,
+    shutdownReason: 'manual-sleep',
+    sleepingAgentSessionRecords: {},
+    tabs: [tab],
+    worktreeId: WORKTREE
+  })
+  return current
+}
+
+describe('terminal shutdown map identity', () => {
+  it('keeps every map reference when the panes already exited', () => {
+    const before = buildState()
+
+    const after = commit(before)
+
+    for (const field of UNTOUCHED_FIELDS) {
+      expect(after[field], field).toBe(before[field])
+    }
+  })
+
+  it('creates an absent pty-id entry rather than skipping it', () => {
+    // An absent key is not an empty array: the spread this replaces created the key.
+    const before = buildState({ ptyIdsByTabId: {} } as Partial<AppState>)
+
+    const after = commit(before)
+
+    expect(after.ptyIdsByTabId).not.toBe(before.ptyIdsByTabId)
+    expect(TAB_ID in after.ptyIdsByTabId).toBe(true)
+    expect(after.ptyIdsByTabId[TAB_ID]).toEqual([])
+  })
+
+  it('still clears a live pty list and drops the exit-guard bookkeeping', () => {
+    const before = buildState({
+      ptyIdsByTabId: { [TAB_ID]: ['pty-1'] },
+      pendingPtyShutdownIds: { 'pty-1': 1 },
+      codexRestartNoticeByPtyId: { 'pty-1': { reason: 'x' } }
+    } as unknown as Partial<AppState>)
+
+    const after = commit(before, ['pty-1'])
+
+    expect(after.ptyIdsByTabId[TAB_ID]).toEqual([])
+    expect(after.suppressedPtyExitIds['pty-1']).toBe(true)
+    expect('pty-1' in after.pendingPtyShutdownIds).toBe(false)
+    expect('pty-1' in after.codexRestartNoticeByPtyId).toBe(false)
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-shutdown-state.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-state.ts
@@ -12,6 +12,7 @@ import {
   type RetainedAgentEntry
 } from '../slices/agent-status'
 import type { TerminalStoreGet, TerminalStoreSet } from './terminal-state'
+import { copyOnWriteRecord } from '../copy-on-write-record'
 
 export function commitTerminalShutdownState({
   exitGuardPtyIds,
@@ -50,169 +51,97 @@ export function commitTerminalShutdownState({
     // identity for no data change. ptyIdsByTabId is the costly one — six components
     // select it whole, and selectLivePtyIdsForWorktree memoizes per sidebar card on
     // its identity, so churning it rebuilds that record once per card.
-    // The four unread/input maps below already use this shape; this matches them.
-    let ptyIdsByTabId = state.ptyIdsByTabId
+    const ptyIdsByTabId = copyOnWriteRecord(state.ptyIdsByTabId)
     for (const tab of tabs) {
-      const current = ptyIdsByTabId[tab.id]
       // Why `!== undefined`: an absent key is not an empty array, and the spread this
       // replaces created the key. Only an already-empty entry can be skipped.
-      if (current !== undefined && current.length === 0) {
-        continue
+      const current = state.ptyIdsByTabId[tab.id]
+      if (current === undefined || current.length > 0) {
+        ptyIdsByTabId.set(tab.id, [])
       }
-      if (ptyIdsByTabId === state.ptyIdsByTabId) {
-        ptyIdsByTabId = { ...state.ptyIdsByTabId }
-      }
-      ptyIdsByTabId[tab.id] = []
     }
-    let runtimePaneTitlesByTabId = state.runtimePaneTitlesByTabId
-    let suppressedPtyExitIds = state.suppressedPtyExitIds
+    const suppressedPtyExitIds = copyOnWriteRecord(state.suppressedPtyExitIds)
+    const pendingPtyShutdownIds = copyOnWriteRecord(state.pendingPtyShutdownIds)
+    const pendingCodexPaneRestartIds = copyOnWriteRecord(state.pendingCodexPaneRestartIds)
+    const codexRestartNoticeByPtyId = copyOnWriteRecord(state.codexRestartNoticeByPtyId)
     for (const ptyId of exitGuardPtyIds) {
-      if (suppressedPtyExitIds[ptyId] === true) {
-        continue
+      if (state.suppressedPtyExitIds[ptyId] !== true) {
+        suppressedPtyExitIds.set(ptyId, true)
       }
-      if (suppressedPtyExitIds === state.suppressedPtyExitIds) {
-        suppressedPtyExitIds = { ...state.suppressedPtyExitIds }
-      }
-      suppressedPtyExitIds[ptyId] = true
-    }
-    let pendingPtyShutdownIds = state.pendingPtyShutdownIds
-    for (const ptyId of exitGuardPtyIds) {
       // An absent owner count meant `delete` of a missing key, which changed nothing.
-      if (!(ptyId in pendingPtyShutdownIds)) {
-        continue
+      if (ptyId in state.pendingPtyShutdownIds) {
+        const remainingOwners = (state.pendingPtyShutdownIds[ptyId] ?? 0) - 1
+        if (remainingOwners > 0) {
+          pendingPtyShutdownIds.set(ptyId, remainingOwners)
+        } else {
+          pendingPtyShutdownIds.delete(ptyId)
+        }
       }
-      const remainingOwners = (pendingPtyShutdownIds[ptyId] ?? 0) - 1
-      if (pendingPtyShutdownIds === state.pendingPtyShutdownIds) {
-        pendingPtyShutdownIds = { ...state.pendingPtyShutdownIds }
+      // Sleeping terminals retain restart intent, but a wake can receive a different live PTY id.
+      if (!keepIdentifiers) {
+        pendingCodexPaneRestartIds.delete(ptyId)
       }
-      if (remainingOwners > 0) {
-        pendingPtyShutdownIds[ptyId] = remainingOwners
-      } else {
-        delete pendingPtyShutdownIds[ptyId]
-      }
+      codexRestartNoticeByPtyId.delete(ptyId)
     }
 
-    // Sleeping terminals retain restart intent, but a wake can receive a different live PTY id.
-    let pendingCodexPaneRestartIds = state.pendingCodexPaneRestartIds
-    let codexRestartNoticeByPtyId = state.codexRestartNoticeByPtyId
-    for (const ptyId of exitGuardPtyIds) {
-      if (!keepIdentifiers && ptyId in pendingCodexPaneRestartIds) {
-        if (pendingCodexPaneRestartIds === state.pendingCodexPaneRestartIds) {
-          pendingCodexPaneRestartIds = { ...state.pendingCodexPaneRestartIds }
-        }
-        delete pendingCodexPaneRestartIds[ptyId]
-      }
-      if (ptyId in codexRestartNoticeByPtyId) {
-        if (codexRestartNoticeByPtyId === state.codexRestartNoticeByPtyId) {
-          codexRestartNoticeByPtyId = { ...state.codexRestartNoticeByPtyId }
-        }
-        delete codexRestartNoticeByPtyId[ptyId]
-      }
-    }
-
-    let pendingSetupSplitByTabId = state.pendingSetupSplitByTabId
-    let pendingIssueCommandSplitByTabId = state.pendingIssueCommandSplitByTabId
-    let terminalLayoutsByTabId = state.terminalLayoutsByTabId
-    let unreadTerminalTabs = state.unreadTerminalTabs
-    let unreadTerminalPanes = state.unreadTerminalPanes
-    let unreadAgentCompletionPanes = state.unreadAgentCompletionPanes
-    let lastTerminalInputAtByPaneKey = state.lastTerminalInputAtByPaneKey
+    const runtimePaneTitlesByTabId = copyOnWriteRecord(state.runtimePaneTitlesByTabId)
+    const pendingSetupSplitByTabId = copyOnWriteRecord(state.pendingSetupSplitByTabId)
+    const pendingIssueCommandSplitByTabId = copyOnWriteRecord(state.pendingIssueCommandSplitByTabId)
+    const terminalLayoutsByTabId = copyOnWriteRecord(state.terminalLayoutsByTabId)
+    const lastKnownRelayPtyIdByTabId = copyOnWriteRecord(state.lastKnownRelayPtyIdByTabId)
+    const unreadTerminalTabs = copyOnWriteRecord(state.unreadTerminalTabs)
+    const unreadTerminalPanes = copyOnWriteRecord(state.unreadTerminalPanes)
+    const unreadAgentCompletionPanes = copyOnWriteRecord(state.unreadAgentCompletionPanes)
+    const lastTerminalInputAtByPaneKey = copyOnWriteRecord(state.lastTerminalInputAtByPaneKey)
 
     for (const tab of tabs) {
-      if (!keepIdentifiers && tab.id in runtimePaneTitlesByTabId) {
-        if (runtimePaneTitlesByTabId === state.runtimePaneTitlesByTabId) {
-          runtimePaneTitlesByTabId = { ...state.runtimePaneTitlesByTabId }
-        }
-        delete runtimePaneTitlesByTabId[tab.id]
-      }
-      if (tab.id in pendingSetupSplitByTabId) {
-        if (pendingSetupSplitByTabId === state.pendingSetupSplitByTabId) {
-          pendingSetupSplitByTabId = { ...state.pendingSetupSplitByTabId }
-        }
-        delete pendingSetupSplitByTabId[tab.id]
-      }
-      if (tab.id in pendingIssueCommandSplitByTabId) {
-        if (pendingIssueCommandSplitByTabId === state.pendingIssueCommandSplitByTabId) {
-          pendingIssueCommandSplitByTabId = { ...state.pendingIssueCommandSplitByTabId }
-        }
-        delete pendingIssueCommandSplitByTabId[tab.id]
-      }
-      if (unreadTerminalTabs[tab.id]) {
-        if (unreadTerminalTabs === state.unreadTerminalTabs) {
-          unreadTerminalTabs = { ...state.unreadTerminalTabs }
-        }
-        delete unreadTerminalTabs[tab.id]
-      }
-      for (const paneKey of Object.keys(unreadTerminalPanes)) {
-        if (paneKey.startsWith(`${tab.id}:`)) {
-          if (unreadTerminalPanes === state.unreadTerminalPanes) {
-            unreadTerminalPanes = { ...unreadTerminalPanes }
-          }
-          delete unreadTerminalPanes[paneKey]
+      pendingSetupSplitByTabId.delete(tab.id)
+      pendingIssueCommandSplitByTabId.delete(tab.id)
+      unreadTerminalTabs.delete(tab.id)
+      const panePrefix = `${tab.id}:`
+      for (const paneKey of Object.keys(state.unreadTerminalPanes)) {
+        if (paneKey.startsWith(panePrefix)) {
+          unreadTerminalPanes.delete(paneKey)
         }
       }
-      for (const paneKey of Object.keys(unreadAgentCompletionPanes)) {
-        if (paneKey.startsWith(`${tab.id}:`)) {
-          if (unreadAgentCompletionPanes === state.unreadAgentCompletionPanes) {
-            unreadAgentCompletionPanes = { ...unreadAgentCompletionPanes }
-          }
-          delete unreadAgentCompletionPanes[paneKey]
+      for (const paneKey of Object.keys(state.unreadAgentCompletionPanes)) {
+        if (paneKey.startsWith(panePrefix)) {
+          unreadAgentCompletionPanes.delete(paneKey)
         }
       }
-      for (const paneKey of Object.keys(lastTerminalInputAtByPaneKey)) {
-        if (paneKey.startsWith(`${tab.id}:`)) {
-          if (lastTerminalInputAtByPaneKey === state.lastTerminalInputAtByPaneKey) {
-            lastTerminalInputAtByPaneKey = { ...lastTerminalInputAtByPaneKey }
-          }
-          delete lastTerminalInputAtByPaneKey[paneKey]
+      for (const paneKey of Object.keys(state.lastTerminalInputAtByPaneKey)) {
+        if (paneKey.startsWith(panePrefix)) {
+          lastTerminalInputAtByPaneKey.delete(paneKey)
         }
       }
       if (!keepIdentifiers) {
-        const layout = terminalLayoutsByTabId[tab.id]
+        runtimePaneTitlesByTabId.delete(tab.id)
+        lastKnownRelayPtyIdByTabId.delete(tab.id)
+        const layout = state.terminalLayoutsByTabId[tab.id]
         // Why the emptiness check: replacing an already-empty map with a fresh {} is
         // the same value with a new identity.
         if (layout?.ptyIdsByLeafId && Object.keys(layout.ptyIdsByLeafId).length > 0) {
-          if (terminalLayoutsByTabId === state.terminalLayoutsByTabId) {
-            terminalLayoutsByTabId = { ...state.terminalLayoutsByTabId }
-          }
-          terminalLayoutsByTabId[tab.id] = { ...layout, ptyIdsByLeafId: {} }
+          terminalLayoutsByTabId.set(tab.id, { ...layout, ptyIdsByLeafId: {} })
         }
-      }
-    }
-
-    let lastKnownRelayPtyIdByTabId = state.lastKnownRelayPtyIdByTabId
-    if (!keepIdentifiers) {
-      for (const tab of tabs) {
-        if (!(tab.id in lastKnownRelayPtyIdByTabId)) {
-          continue
-        }
-        if (lastKnownRelayPtyIdByTabId === state.lastKnownRelayPtyIdByTabId) {
-          lastKnownRelayPtyIdByTabId = { ...state.lastKnownRelayPtyIdByTabId }
-        }
-        delete lastKnownRelayPtyIdByTabId[tab.id]
       }
     }
 
     return {
       tabsByWorktree,
-      ptyIdsByTabId,
-      lastKnownRelayPtyIdByTabId,
-      runtimePaneTitlesByTabId,
-      suppressedPtyExitIds,
-      pendingPtyShutdownIds,
-      pendingCodexPaneRestartIds,
-      codexRestartNoticeByPtyId,
-      pendingSetupSplitByTabId,
-      pendingIssueCommandSplitByTabId,
-      terminalLayoutsByTabId,
-      ...(unreadTerminalTabs !== state.unreadTerminalTabs ? { unreadTerminalTabs } : {}),
-      ...(unreadTerminalPanes !== state.unreadTerminalPanes ? { unreadTerminalPanes } : {}),
-      ...(unreadAgentCompletionPanes !== state.unreadAgentCompletionPanes
-        ? { unreadAgentCompletionPanes }
-        : {}),
-      ...(lastTerminalInputAtByPaneKey !== state.lastTerminalInputAtByPaneKey
-        ? { lastTerminalInputAtByPaneKey }
-        : {})
+      ptyIdsByTabId: ptyIdsByTabId.read(),
+      lastKnownRelayPtyIdByTabId: lastKnownRelayPtyIdByTabId.read(),
+      runtimePaneTitlesByTabId: runtimePaneTitlesByTabId.read(),
+      suppressedPtyExitIds: suppressedPtyExitIds.read(),
+      pendingPtyShutdownIds: pendingPtyShutdownIds.read(),
+      pendingCodexPaneRestartIds: pendingCodexPaneRestartIds.read(),
+      codexRestartNoticeByPtyId: codexRestartNoticeByPtyId.read(),
+      pendingSetupSplitByTabId: pendingSetupSplitByTabId.read(),
+      pendingIssueCommandSplitByTabId: pendingIssueCommandSplitByTabId.read(),
+      terminalLayoutsByTabId: terminalLayoutsByTabId.read(),
+      unreadTerminalTabs: unreadTerminalTabs.read(),
+      unreadTerminalPanes: unreadTerminalPanes.read(),
+      unreadAgentCompletionPanes: unreadAgentCompletionPanes.read(),
+      lastTerminalInputAtByPaneKey: lastTerminalInputAtByPaneKey.read()
     }
   })
 
@@ -228,7 +157,10 @@ export function commitTerminalShutdownState({
             ).records
           : state.sleepingAgentSessionsByPaneKey
       return {
-        sleepingAgentSessionsByPaneKey: { ...base, ...sleepingAgentSessionRecords }
+        sleepingAgentSessionsByPaneKey: {
+          ...base,
+          ...sleepingAgentSessionRecords
+        }
       }
     })
   } else {

--- a/src/renderer/src/store/terminals/terminal-shutdown-state.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-state.ts
@@ -45,20 +45,46 @@ export function commitTerminalShutdownState({
             clearTransientTerminalState(tab, index)
           )
         }
-    const ptyIdsByTabId = {
-      ...state.ptyIdsByTabId,
-      ...Object.fromEntries(tabs.map((tab) => [tab.id, [] as string[]] as const))
+    // Why copy-on-write everywhere below: a worktree whose panes already exited hits
+    // this with nothing to clear, and unconditional spreads then hand every map a new
+    // identity for no data change. ptyIdsByTabId is the costly one — six components
+    // select it whole, and selectLivePtyIdsForWorktree memoizes per sidebar card on
+    // its identity, so churning it rebuilds that record once per card.
+    // The four unread/input maps below already use this shape; this matches them.
+    let ptyIdsByTabId = state.ptyIdsByTabId
+    for (const tab of tabs) {
+      const current = ptyIdsByTabId[tab.id]
+      // Why `!== undefined`: an absent key is not an empty array, and the spread this
+      // replaces created the key. Only an already-empty entry can be skipped.
+      if (current !== undefined && current.length === 0) {
+        continue
+      }
+      if (ptyIdsByTabId === state.ptyIdsByTabId) {
+        ptyIdsByTabId = { ...state.ptyIdsByTabId }
+      }
+      ptyIdsByTabId[tab.id] = []
     }
-    const runtimePaneTitlesByTabId = keepIdentifiers
-      ? state.runtimePaneTitlesByTabId
-      : { ...state.runtimePaneTitlesByTabId }
-    const suppressedPtyExitIds = {
-      ...state.suppressedPtyExitIds,
-      ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
-    }
-    const pendingPtyShutdownIds = { ...state.pendingPtyShutdownIds }
+    let runtimePaneTitlesByTabId = state.runtimePaneTitlesByTabId
+    let suppressedPtyExitIds = state.suppressedPtyExitIds
     for (const ptyId of exitGuardPtyIds) {
+      if (suppressedPtyExitIds[ptyId] === true) {
+        continue
+      }
+      if (suppressedPtyExitIds === state.suppressedPtyExitIds) {
+        suppressedPtyExitIds = { ...state.suppressedPtyExitIds }
+      }
+      suppressedPtyExitIds[ptyId] = true
+    }
+    let pendingPtyShutdownIds = state.pendingPtyShutdownIds
+    for (const ptyId of exitGuardPtyIds) {
+      // An absent owner count meant `delete` of a missing key, which changed nothing.
+      if (!(ptyId in pendingPtyShutdownIds)) {
+        continue
+      }
       const remainingOwners = (pendingPtyShutdownIds[ptyId] ?? 0) - 1
+      if (pendingPtyShutdownIds === state.pendingPtyShutdownIds) {
+        pendingPtyShutdownIds = { ...state.pendingPtyShutdownIds }
+      }
       if (remainingOwners > 0) {
         pendingPtyShutdownIds[ptyId] = remainingOwners
       } else {
@@ -67,31 +93,50 @@ export function commitTerminalShutdownState({
     }
 
     // Sleeping terminals retain restart intent, but a wake can receive a different live PTY id.
-    const pendingCodexPaneRestartIds = keepIdentifiers
-      ? state.pendingCodexPaneRestartIds
-      : { ...state.pendingCodexPaneRestartIds }
-    const codexRestartNoticeByPtyId = { ...state.codexRestartNoticeByPtyId }
+    let pendingCodexPaneRestartIds = state.pendingCodexPaneRestartIds
+    let codexRestartNoticeByPtyId = state.codexRestartNoticeByPtyId
     for (const ptyId of exitGuardPtyIds) {
-      if (!keepIdentifiers) {
+      if (!keepIdentifiers && ptyId in pendingCodexPaneRestartIds) {
+        if (pendingCodexPaneRestartIds === state.pendingCodexPaneRestartIds) {
+          pendingCodexPaneRestartIds = { ...state.pendingCodexPaneRestartIds }
+        }
         delete pendingCodexPaneRestartIds[ptyId]
       }
-      delete codexRestartNoticeByPtyId[ptyId]
+      if (ptyId in codexRestartNoticeByPtyId) {
+        if (codexRestartNoticeByPtyId === state.codexRestartNoticeByPtyId) {
+          codexRestartNoticeByPtyId = { ...state.codexRestartNoticeByPtyId }
+        }
+        delete codexRestartNoticeByPtyId[ptyId]
+      }
     }
 
-    const pendingSetupSplitByTabId = { ...state.pendingSetupSplitByTabId }
-    const pendingIssueCommandSplitByTabId = { ...state.pendingIssueCommandSplitByTabId }
-    const terminalLayoutsByTabId = { ...state.terminalLayoutsByTabId }
+    let pendingSetupSplitByTabId = state.pendingSetupSplitByTabId
+    let pendingIssueCommandSplitByTabId = state.pendingIssueCommandSplitByTabId
+    let terminalLayoutsByTabId = state.terminalLayoutsByTabId
     let unreadTerminalTabs = state.unreadTerminalTabs
     let unreadTerminalPanes = state.unreadTerminalPanes
     let unreadAgentCompletionPanes = state.unreadAgentCompletionPanes
     let lastTerminalInputAtByPaneKey = state.lastTerminalInputAtByPaneKey
 
     for (const tab of tabs) {
-      if (!keepIdentifiers) {
+      if (!keepIdentifiers && tab.id in runtimePaneTitlesByTabId) {
+        if (runtimePaneTitlesByTabId === state.runtimePaneTitlesByTabId) {
+          runtimePaneTitlesByTabId = { ...state.runtimePaneTitlesByTabId }
+        }
         delete runtimePaneTitlesByTabId[tab.id]
       }
-      delete pendingSetupSplitByTabId[tab.id]
-      delete pendingIssueCommandSplitByTabId[tab.id]
+      if (tab.id in pendingSetupSplitByTabId) {
+        if (pendingSetupSplitByTabId === state.pendingSetupSplitByTabId) {
+          pendingSetupSplitByTabId = { ...state.pendingSetupSplitByTabId }
+        }
+        delete pendingSetupSplitByTabId[tab.id]
+      }
+      if (tab.id in pendingIssueCommandSplitByTabId) {
+        if (pendingIssueCommandSplitByTabId === state.pendingIssueCommandSplitByTabId) {
+          pendingIssueCommandSplitByTabId = { ...state.pendingIssueCommandSplitByTabId }
+        }
+        delete pendingIssueCommandSplitByTabId[tab.id]
+      }
       if (unreadTerminalTabs[tab.id]) {
         if (unreadTerminalTabs === state.unreadTerminalTabs) {
           unreadTerminalTabs = { ...state.unreadTerminalTabs }
@@ -124,17 +169,26 @@ export function commitTerminalShutdownState({
       }
       if (!keepIdentifiers) {
         const layout = terminalLayoutsByTabId[tab.id]
-        if (layout?.ptyIdsByLeafId) {
+        // Why the emptiness check: replacing an already-empty map with a fresh {} is
+        // the same value with a new identity.
+        if (layout?.ptyIdsByLeafId && Object.keys(layout.ptyIdsByLeafId).length > 0) {
+          if (terminalLayoutsByTabId === state.terminalLayoutsByTabId) {
+            terminalLayoutsByTabId = { ...state.terminalLayoutsByTabId }
+          }
           terminalLayoutsByTabId[tab.id] = { ...layout, ptyIdsByLeafId: {} }
         }
       }
     }
 
-    const lastKnownRelayPtyIdByTabId = keepIdentifiers
-      ? state.lastKnownRelayPtyIdByTabId
-      : { ...state.lastKnownRelayPtyIdByTabId }
+    let lastKnownRelayPtyIdByTabId = state.lastKnownRelayPtyIdByTabId
     if (!keepIdentifiers) {
       for (const tab of tabs) {
+        if (!(tab.id in lastKnownRelayPtyIdByTabId)) {
+          continue
+        }
+        if (lastKnownRelayPtyIdByTabId === state.lastKnownRelayPtyIdByTabId) {
+          lastKnownRelayPtyIdByTabId = { ...state.lastKnownRelayPtyIdByTabId }
+        }
         delete lastKnownRelayPtyIdByTabId[tab.id]
       }
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​111 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​93 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

## What

`commitTerminalShutdownState` spread **nine maps unconditionally**. Sleeping a worktree whose panes already exited is the normal case and clears nothing, so every map came back with a new identity and identical contents.

`ptyIdsByTabId` is the costly one:

- **six components select it whole** (`use-visible-worktrees.ts:69`, `use-visible-workspace-kanban-worktree-ids.ts:50`, `StatusBarAccountControls.tsx:9`, `useLiveDashboardSnapshot.ts:27`, `ManageSessionsSection.tsx:33`, `use-automations-page-store-state.ts:23`) — sidebar and status bar are always mounted
- `selectLivePtyIdsForWorktree` lists it in `readSources`, so it **memoizes per sidebar card on that map's identity** — churning it rebuilt that record once per card
- it wrote a fresh `[]` for every tab even when the entry was already an empty array

Every map now uses the copy-on-write shape the four unread/input maps **in this same function** already had — including one carrying the comment about not forcing full-state selector re-eval.

## Correctness points the guards encode

- **an absent `ptyIdsByTabId` key is not an empty array.** The spread this replaces created the key, so only an *already-empty* entry may be skipped. Guard is `current !== undefined && current.length === 0`, not `current?.length === 0`.
- an absent `pendingPtyShutdownIds` owner count meant `delete` of a missing key, which changed nothing — skipped rather than copied.
- a layout whose `ptyIdsByLeafId` is already empty keeps its entry instead of getting a fresh `{}` with the same value.

Nothing observes these maps' identity as a signal: `commitTerminalShutdownState` is followed only by imperative `get()` reads, and no subscriber uses them as a version counter or effect dep.

## How it was found

The churn probe from #19059 ranked `terminal-shutdown-state.ts:39` at **1,441 no-op reference replacements across 11 fields** — the second-largest remaining site.

## Verification

- New `terminal-shutdown-map-identity.test.ts`: all ten maps keep their reference when panes already exited; an **absent** pty-id entry is still created (the guard above, tested directly); a live pty list is still cleared and exit-guard bookkeeping still dropped. **Fails without the fix.**
- `pnpm tc:web` clean.
- Store + terminal-pane suites: 7,387 passed.

---

## ELI5

When a terminal goes to sleep, the app clears nine lists belonging to it.

Usually those lists are *already* empty — the terminal finished a while ago. But it replaced each empty list with a **different** empty list, and the app can't tell "same nothing" from "new nothing": it only checks whether the list was swapped, not what's in it. So the sidebar rebuilt itself, once per card, every time.

Now it leaves an already-empty list alone.

The subtle bit: "no list at all" and "an empty list" are genuinely different things here, and the old code quietly turned the first into the second. The fix keeps doing that, on purpose.
