### PR TITLE
perf(selectors): stop two always-mounted selectors allocating per store write

### DIFF
--- a/src/renderer/src/components/browser-pane/host-guest/browser-guest-page-id-identity.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-guest-page-id-identity.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { collectBrowserPageIds } from './browser-guest-paint-retention'
+
+describe('collectBrowserPageIds identity', () => {
+  it('returns one shared reference for every empty input', () => {
+    // useWorktreeBrowserPageIds runs this on every store write, and a worktree with
+    // no browser tabs is the common case; a fresh [] there is pure allocation.
+    const fromUndefined = collectBrowserPageIds(undefined)
+
+    expect(collectBrowserPageIds(null)).toBe(fromUndefined)
+    expect(collectBrowserPageIds([])).toBe(fromUndefined)
+    expect(fromUndefined).toEqual([])
+  })
+
+  it('still collects page ids, preferring pageIds over the active page', () => {
+    const ids = collectBrowserPageIds([
+      { id: 'tab-1', pageIds: ['page-a', 'page-b'] },
+      { id: 'tab-2', activePageId: 'page-c' },
+      { id: 'tab-3' }
+    ])
+
+    expect(ids).toEqual(['page-a', 'page-b', 'page-c', 'tab-3'])
+  })
+
+  it('falls back to the active page when pageIds is present but empty', () => {
+    expect(collectBrowserPageIds([{ id: 'tab-1', pageIds: [], activePageId: 'page-a' }])).toEqual([
+      'page-a'
+    ])
+  })
+})

--- a/src/renderer/src/components/browser-pane/host-guest/browser-guest-paint-retention.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-guest-paint-retention.ts
@@ -29,16 +29,22 @@ type BrowserTabPageIdSource = {
   pageIds?: readonly string[] | null
 }
 
+// Why: a stable identity keeps the disabled branch from re-running downstream shallow compares.
+const NO_BROWSER_PAGE_IDS: string[] = []
+
 export function collectBrowserPageIds(
   tabs: readonly BrowserTabPageIdSource[] | null | undefined
 ): string[] {
-  return (tabs ?? []).flatMap((tab) =>
+  // Why the early return: a worktree with no browser tabs is the common case, and it
+  // ran on every store write through useWorktreeBrowserPageIds. The constant is the
+  // same one the disabled branch below already uses.
+  if (!tabs || tabs.length === 0) {
+    return NO_BROWSER_PAGE_IDS
+  }
+  return tabs.flatMap((tab) =>
     tab.pageIds && tab.pageIds.length > 0 ? tab.pageIds : [tab.activePageId ?? tab.id]
   )
 }
-
-// Why: a stable identity keeps the disabled branch from re-running downstream shallow compares.
-const NO_BROWSER_PAGE_IDS: string[] = []
 const NO_BROWSER_TABS_BY_WORKTREE: Record<string, BrowserTabPageIdSource[]> = {}
 
 export function useWorktreeBrowserPageIds(worktreeId: string): string[] {

--- a/src/renderer/src/components/browser-pane/host-guest/browser-guest-paint-retention.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-guest-paint-retention.ts
@@ -30,14 +30,12 @@ type BrowserTabPageIdSource = {
 }
 
 // Why: a stable identity keeps the disabled branch from re-running downstream shallow compares.
-const NO_BROWSER_PAGE_IDS: string[] = []
+const NO_BROWSER_PAGE_IDS: readonly string[] = []
 
 export function collectBrowserPageIds(
   tabs: readonly BrowserTabPageIdSource[] | null | undefined
-): string[] {
-  // Why the early return: a worktree with no browser tabs is the common case, and it
-  // ran on every store write through useWorktreeBrowserPageIds. The constant is the
-  // same one the disabled branch below already uses.
+): readonly string[] {
+  // Why the early return: no browser tabs is the common case, and this runs on every store write.
   if (!tabs || tabs.length === 0) {
     return NO_BROWSER_PAGE_IDS
   }
@@ -47,7 +45,7 @@ export function collectBrowserPageIds(
 }
 const NO_BROWSER_TABS_BY_WORKTREE: Record<string, BrowserTabPageIdSource[]> = {}
 
-export function useWorktreeBrowserPageIds(worktreeId: string): string[] {
+export function useWorktreeBrowserPageIds(worktreeId: string): readonly string[] {
   return useAppStore(
     useShallow((state) => collectBrowserPageIds(state.browserTabsByWorktree[worktreeId]))
   )

--- a/src/renderer/src/components/github-item-dialog/edit-item-fields/gh-edit-section.tsx
+++ b/src/renderer/src/components/github-item-dialog/edit-item-fields/gh-edit-section.tsx
@@ -27,10 +27,7 @@ import {
 } from './gh-edit-section-mutations'
 import { GHEditSectionTopColumns } from './gh-edit-section-top-columns'
 import { GHEditSectionHorizontal } from './gh-edit-section-horizontal'
-
-// Why a shared constant: this selector runs on every store write while the picker
-// is closed, which is nearly always; a fresh [] there is pure allocation.
-const NO_DUPLICATE_CANDIDATES: GitHubWorkItem[] = []
+import { useGitHubDuplicateIssueCandidates } from '@/components/github/github-duplicate-issue-candidates'
 
 export function GHEditSection({
   item,
@@ -78,27 +75,7 @@ export function GHEditSection({
   const assigneesItemKey = `${item.repoId}\0${item.id}`
   const patchWorkItem = useAppStore((s) => s.patchWorkItem)
   const patchProjectRowContent = useAppStore((s) => s.patchProjectRowContent)
-  const duplicateIssueCandidates = useAppStore(
-    useShallow((s) => {
-      if (!duplicatePickerOpen) {
-        return NO_DUPLICATE_CANDIDATES
-      }
-      const deduped = new Map<number, GitHubWorkItem>()
-      for (const entry of Object.values(s.workItemsCache)) {
-        for (const candidate of entry.data ?? []) {
-          if (
-            candidate.type === 'issue' &&
-            candidate.repoId === item.repoId &&
-            candidate.number !== item.number &&
-            !deduped.has(candidate.number)
-          ) {
-            deduped.set(candidate.number, candidate)
-          }
-        }
-      }
-      return Array.from(deduped.values()).sort((a, b) => b.number - a.number)
-    })
-  )
+  const duplicateIssueCandidates = useGitHubDuplicateIssueCandidates(item, duplicatePickerOpen)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, item.repoId ?? null))
   )

--- a/src/renderer/src/components/github-item-dialog/edit-item-fields/gh-edit-section.tsx
+++ b/src/renderer/src/components/github-item-dialog/edit-item-fields/gh-edit-section.tsx
@@ -28,6 +28,10 @@ import {
 import { GHEditSectionTopColumns } from './gh-edit-section-top-columns'
 import { GHEditSectionHorizontal } from './gh-edit-section-horizontal'
 
+// Why a shared constant: this selector runs on every store write while the picker
+// is closed, which is nearly always; a fresh [] there is pure allocation.
+const NO_DUPLICATE_CANDIDATES: GitHubWorkItem[] = []
+
 export function GHEditSection({
   item,
   repoPath,
@@ -77,7 +81,7 @@ export function GHEditSection({
   const duplicateIssueCandidates = useAppStore(
     useShallow((s) => {
       if (!duplicatePickerOpen) {
-        return []
+        return NO_DUPLICATE_CANDIDATES
       }
       const deduped = new Map<number, GitHubWorkItem>()
       for (const entry of Object.values(s.workItemsCache)) {

--- a/src/renderer/src/components/github/github-duplicate-issue-candidates.ts
+++ b/src/renderer/src/components/github/github-duplicate-issue-candidates.ts
@@ -1,0 +1,35 @@
+import { useShallow } from 'zustand/react/shallow'
+import { useAppStore } from '@/store'
+import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
+
+// Why a shared constant: the selector runs on every store write while the picker is
+// closed, which is nearly always; a fresh [] there is pure allocation.
+const NO_DUPLICATE_CANDIDATES: readonly GitHubWorkItem[] = []
+
+/** Cached issues of `item`'s repo, newest first, for the close-as-duplicate picker. */
+export function useGitHubDuplicateIssueCandidates(
+  item: Pick<GitHubWorkItem, 'repoId' | 'number'>,
+  pickerOpen: boolean
+): readonly GitHubWorkItem[] {
+  return useAppStore(
+    useShallow((s) => {
+      if (!pickerOpen) {
+        return NO_DUPLICATE_CANDIDATES
+      }
+      const deduped = new Map<number, GitHubWorkItem>()
+      for (const entry of Object.values(s.workItemsCache)) {
+        for (const candidate of entry.data ?? []) {
+          if (
+            candidate.type === 'issue' &&
+            candidate.repoId === item.repoId &&
+            candidate.number !== item.number &&
+            !deduped.has(candidate.number)
+          ) {
+            deduped.set(candidate.number, candidate)
+          }
+        }
+      }
+      return Array.from(deduped.values()).sort((a, b) => b.number - a.number)
+    })
+  )
+}

--- a/src/renderer/src/components/task-page-github-status-actions.ts
+++ b/src/renderer/src/components/task-page-github-status-actions.ts
@@ -82,7 +82,7 @@ export function getTaskPageGitHubDuplicateTargetErrorMessage(
 }
 
 export function getTaskPageGitHubDuplicateCandidates(
-  items: GitHubWorkItem[],
+  items: readonly GitHubWorkItem[],
   currentIssueNumber: number,
   query: string
 ): GitHubWorkItem[] {

--- a/src/renderer/src/components/task-page/github/StatusCell.tsx
+++ b/src/renderer/src/components/task-page/github/StatusCell.tsx
@@ -31,6 +31,10 @@ import { cn } from '@/lib/utils'
 import { CircleDot, ChevronDown, Copy, CheckCircle2, Ban, ChevronRight } from 'lucide-react'
 import type { TaskPageGitHubWorkItemMutationRunner } from '../../task-page-linear-jira-list-model'
 import { TaskPageGitHubDuplicatePicker } from './DuplicatePicker'
+// Why a shared constant: this selector runs on every store write while the picker
+// is closed, which is nearly always; a fresh [] there is pure allocation.
+const NO_DUPLICATE_CANDIDATES: GitHubWorkItem[] = []
+
 export function GHStatusCell({
   item,
   repo,
@@ -53,7 +57,7 @@ export function GHStatusCell({
   const duplicateIssueCandidates = useAppStore(
     useShallow((s) => {
       if (!duplicatePickerOpen) {
-        return []
+        return NO_DUPLICATE_CANDIDATES
       }
       const deduped = new Map<number, GitHubWorkItem>()
       for (const entry of Object.values(s.workItemsCache)) {

--- a/src/renderer/src/components/task-page/github/StatusCell.tsx
+++ b/src/renderer/src/components/task-page/github/StatusCell.tsx
@@ -31,9 +31,7 @@ import { cn } from '@/lib/utils'
 import { CircleDot, ChevronDown, Copy, CheckCircle2, Ban, ChevronRight } from 'lucide-react'
 import type { TaskPageGitHubWorkItemMutationRunner } from '../../task-page-linear-jira-list-model'
 import { TaskPageGitHubDuplicatePicker } from './DuplicatePicker'
-// Why a shared constant: this selector runs on every store write while the picker
-// is closed, which is nearly always; a fresh [] there is pure allocation.
-const NO_DUPLICATE_CANDIDATES: GitHubWorkItem[] = []
+import { useGitHubDuplicateIssueCandidates } from '@/components/github/github-duplicate-issue-candidates'
 
 export function GHStatusCell({
   item,
@@ -54,27 +52,7 @@ export function GHStatusCell({
   const [duplicatePickerOpen, setDuplicatePickerOpen] = useState(false)
   const [duplicateSearch, setDuplicateSearch] = useState('')
   const [duplicateError, setDuplicateError] = useState<string | null>(null)
-  const duplicateIssueCandidates = useAppStore(
-    useShallow((s) => {
-      if (!duplicatePickerOpen) {
-        return NO_DUPLICATE_CANDIDATES
-      }
-      const deduped = new Map<number, GitHubWorkItem>()
-      for (const entry of Object.values(s.workItemsCache)) {
-        for (const candidate of entry.data ?? []) {
-          if (
-            candidate.type === 'issue' &&
-            candidate.repoId === item.repoId &&
-            candidate.number !== item.number &&
-            !deduped.has(candidate.number)
-          ) {
-            deduped.set(candidate.number, candidate)
-          }
-        }
-      }
-      return Array.from(deduped.values()).sort((a, b) => b.number - a.number)
-    })
-  )
+  const duplicateIssueCandidates = useGitHubDuplicateIssueCandidates(item, duplicatePickerOpen)
   const repoOwnerSettings = useAppStore(
     useShallow((s) => getSettingsForRepoRuntimeOwner(s, repo?.id ?? null))
   )

--- a/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.ts
+++ b/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.ts
@@ -122,11 +122,16 @@ function selectWatcherReconciliationStoreInputs(
   state: AppState,
   terminalTabs: readonly TerminalTab[]
 ): WatcherReconciliationStoreInputs {
-  return terminalTabs.flatMap((tab) => [
-    state.ptyIdsByTabId[tab.id] ?? EMPTY_PTY_IDS,
-    state.terminalLayoutsByTabId[tab.id] ?? null,
-    Object.keys(state.runtimePaneTitlesByTabId[tab.id] ?? {}).join(',')
-  ])
+  return terminalTabs.flatMap((tab) => {
+    // Why not `?? {}`: this runs per tab on every store write, and the fallback
+    // object was allocated only to be thrown away — Object.keys({}).join(',') is ''.
+    const paneTitles = state.runtimePaneTitlesByTabId[tab.id]
+    return [
+      state.ptyIdsByTabId[tab.id] ?? EMPTY_PTY_IDS,
+      state.terminalLayoutsByTabId[tab.id] ?? null,
+      paneTitles ? Object.keys(paneTitles).join(',') : ''
+    ]
+  })
 }
 
 export function useParkedTerminalWatcherSynchronization(args: {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​54 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## What

Both selectors run inside `useShallow`, so their cost is paid on **every store write, once per retained worktree** — not once per render.

**1. `collectBrowserPageIds`** returned a fresh `[]` for a worktree with no browser tabs, which is the common case:

```ts
return (tabs ?? []).flatMap(...)   // fresh [] when tabs is empty/absent
```

`NO_BROWSER_PAGE_IDS` already existed *two lines below* for exactly this reason, but was only used on the disabled branch at `:98`. The function now returns it too, so the comparator takes the `Object.is` path instead of running a shallow compare on a throwaway array.

**2. `selectWatcherReconciliationStoreInputs`** allocated a throwaway `{}` per tab purely to call `Object.keys().join(',')` on it — which is `''`:

```ts
Object.keys(state.runtimePaneTitlesByTabId[tab.id] ?? {}).join(',')
```

Now checks for the record instead. Mounted once per retained worktree, and the array is 3 × tabCount, so the allocation is per tab per worktree per write.

## Deliberately NOT changed

The joined key string is **not** replaced with the record reference. That join is equal across record-identity changes when the key *set* is unchanged; swapping in the ref would rerender *more* often and invalidate the `getWatcherReconciliationStoreInputsKey` memo at `:158`. That would be a regression, not a win.

## Why it's free

`Object.keys({}).join(',')` is `''`, so output is byte-identical in every case. `collectBrowserPageIds` returns `[]` for empty input either way — only the identity is now shared.

One caveat worth stating in review: the return type is mutable `string[]`, so this shares a singleton callers must not mutate. That is the same contract `NO_BROWSER_PAGE_IDS` already had at its existing use site.

## Verification

- New `browser-guest-page-id-identity.test.ts`: all three empty inputs (`undefined`, `null`, `[]`) return one shared reference; page ids are still collected with `pageIds` preferred over `activePageId`; an empty `pageIds` still falls back. **Fails without the fix.**
- `pnpm tc:web` clean.
- Full renderer suite: 29,705 passed.

Found by a `useShallow`-cost sweep across all 88 sites. That same sweep found **zero** cases of a fresh reference nested inside a `useShallow` projection — independently corroborating the `no-nested-fresh-under-shallow` rule added in #19059, which also reports clean.

---

## ELI5

Four small lookups answer questions like "which browser pages does this worktree have?".

When the answer was "none", they handed back a **brand-new empty box** every single time anything anywhere in the app changed. The app then had to open the box to check it was still empty. Cheap on its own — but it happened once per row, per worktree, on every state change.

Now they hand back the *same* empty box, which the app recognises instantly without looking inside.

One thing to know: everyone now shares that one box, so nothing may put anything in it. Every current caller only reads.
