### PR TITLE
fix(ci): stop Android release notes exceeding the GitHub body limit

### DIFF
--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -111,15 +111,19 @@ jobs:
             notes_file="$RUNNER_TEMP/android-release-notes.md"
             previous_tag="$(
               gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName --jq '.[].tagName' \
-                | grep '^mobile-android-v' | grep -v "^$tag$" | sort -V | tail -1 || true
+                | grep '^mobile-android-v' | grep -Fxv "$tag" | sort -V | tail -1 || true
             )"
 
             if [ -n "$previous_tag" ]; then
-              gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" -X POST \
+              # Why: gh writes the JSON error body to stdout on an HTTP error, so a
+              # non-empty file is not proof of success — gate on exit status.
+              if ! gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" -X POST \
                 -f tag_name="$tag" \
                 -f target_commitish="$GITHUB_SHA" \
                 -f previous_tag_name="$previous_tag" \
-                --jq .body > "$notes_file" || true
+                --jq .body > "$notes_file"; then
+                : > "$notes_file"
+              fi
             fi
             if [ ! -s "$notes_file" ]; then
               printf 'Orca Mobile Android %s\n' "$tag" > "$notes_file"

--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -128,11 +128,17 @@ jobs:
             if [ ! -s "$notes_file" ]; then
               printf 'Orca Mobile Android %s\n' "$tag" > "$notes_file"
             fi
-            if [ "$(wc -c < "$notes_file")" -gt 120000 ]; then
-              head -c 120000 "$notes_file" > "$notes_file.trimmed"
-              printf '\n\n_Notes truncated; see the full changelog._\n' >> "$notes_file.trimmed"
-              mv "$notes_file.trimmed" "$notes_file"
-            fi
+            # Why: reuse the desktop release path's character-safe truncation so a
+            # multi-byte character cannot be split at the cap.
+            NOTES_FILE="$notes_file" \
+            NOTES_MODULE="$GITHUB_WORKSPACE/config/scripts/create-draft-release.mjs" \
+            node --input-type=module -e '
+              const { readFileSync, writeFileSync } = await import("node:fs")
+              const { pathToFileURL } = await import("node:url")
+              const { truncateReleaseBody } = await import(pathToFileURL(process.env.NOTES_MODULE).href)
+              const file = process.env.NOTES_FILE
+              writeFileSync(file, truncateReleaseBody(readFileSync(file, "utf8")))
+            '
 
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -104,11 +104,37 @@ jobs:
               --clobber \
               android/app/build/outputs/apk/release/*.apk
           else
+            # Why: release tags live on side branches, so GitHub's automatic
+            # previous-tag detection reaches back several releases; that body
+            # already exceeds the 125000-character API limit and grows each
+            # release. Pin the comparison base and cap the size.
+            notes_file="$RUNNER_TEMP/android-release-notes.md"
+            previous_tag="$(
+              gh release list --repo "$GITHUB_REPOSITORY" --limit 200 --json tagName --jq '.[].tagName' \
+                | grep '^mobile-android-v' | grep -v "^$tag$" | sort -V | tail -1 || true
+            )"
+
+            if [ -n "$previous_tag" ]; then
+              gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" -X POST \
+                -f tag_name="$tag" \
+                -f target_commitish="$GITHUB_SHA" \
+                -f previous_tag_name="$previous_tag" \
+                --jq .body > "$notes_file" || true
+            fi
+            if [ ! -s "$notes_file" ]; then
+              printf 'Orca Mobile Android %s\n' "$tag" > "$notes_file"
+            fi
+            if [ "$(wc -c < "$notes_file")" -gt 120000 ]; then
+              head -c 120000 "$notes_file" > "$notes_file.trimmed"
+              printf '\n\n_Notes truncated; see the full changelog._\n' >> "$notes_file.trimmed"
+              mv "$notes_file.trimmed" "$notes_file"
+            fi
+
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \
               --title "Orca Mobile Android $tag" \
               --prerelease \
               --latest=false \
-              --generate-notes \
+              --notes-file "$notes_file" \
               android/app/build/outputs/apk/release/*.apk
           fi


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## Summary
`Create GitHub Release` used `gh release create --generate-notes`, letting GitHub choose the previous tag. Release tags live on side branches, so `mobile-android-v0.0.46` and `v0.0.47` are not ancestors of main's tip and detection reached back to `v0.0.44` — generating four releases' worth of notes.

That body was **130,413 characters against GitHub's 125,000 limit**, so the API returned `HTTP 422: body is too long` and the publish failed *after* a full Gradle build. The APK built fine; only the release step died. **The span grows every release, so this gets worse, not better.**

## Fix
- Pin the comparison base to the previous `mobile-android-v*` release instead of GitHub's auto-detection.
- Hard-cap the body so an unexpected span can never fail the publish again.
- Fall back to a minimal body if notes generation fails, so a notes problem can never block shipping a built APK.

## Verification (measured against this repo)
- Auto-detected base `v0.0.44`: **130,413 chars** → over limit, 422.
- Pinned base `v0.0.47`: **81,862 chars** → well under.
- Previous-tag resolution dry-run returns `mobile-android-v0.0.47`.
- Workflow YAML parses; step retains `--notes-file` and no longer passes `--generate-notes`.

Observed live in run [34047881523](https://github.com/stablyai/orca/actions/runs/34047881523) (build succeeded, publish 422'd).