### PR TITLE
perf(mobile): skip the agent-status projection join when nothing changed

### DIFF
--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
@@ -35,19 +35,34 @@ function respread(map: AppState['agentStatusByPaneKey']): AppState['agentStatusB
   return { ...map }
 }
 
-function countJoins(run: () => string): { result: string; joins: number } {
-  const original = Array.prototype.join
+function countJoins(run: () => string): {
+  result: string
+  joins: number
+  sorts: number
+} {
+  const originalJoin = Array.prototype.join
+  const originalSort = Array.prototype.sort
   let joins = 0
-  const spy = vi
-    .spyOn(Array.prototype, 'join')
-    .mockImplementation(function (this: unknown[], separator?: string) {
-      joins += 1
-      return original.call(this, separator)
-    })
+  let sorts = 0
+  const joinSpy = vi.spyOn(Array.prototype, 'join').mockImplementation(function (
+    this: unknown[],
+    separator?: string
+  ) {
+    joins += 1
+    return originalJoin.call(this, separator)
+  })
+  const sortSpy = vi.spyOn(Array.prototype, 'sort').mockImplementation(function (
+    this: unknown[],
+    compare?: (a: unknown, b: unknown) => number
+  ) {
+    sorts += 1
+    return originalSort.call(this, compare)
+  })
   try {
-    return { result: run(), joins }
+    return { result: run(), joins, sorts }
   } finally {
-    spy.mockRestore()
+    joinSpy.mockRestore()
+    sortSpy.mockRestore()
   }
 }
 
@@ -62,12 +77,28 @@ describe('agent-status projection join short circuit', () => {
     const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
 
     // A new map identity with identical entry references — the common ping shape.
-    const { result, joins } = countJoins(() =>
+    const { result, joins, sorts } = countJoins(() =>
       buildRuntimeMobileAgentStatusProjectionForTests(respread(map))
     )
 
     expect(result).toBe(first)
     expect(joins).toBe(0)
+    expect(sorts).toBe(0)
+  })
+
+  it('caches the new map identity on the short-circuit path', () => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const map = mapOf([0, 1])
+    buildRuntimeMobileAgentStatusProjectionForTests(map)
+    const again = respread(map)
+    buildRuntimeMobileAgentStatusProjectionForTests(again)
+
+    // A repeat call with the same identity must hit the identity early-out, not re-walk the keys.
+    const { joins, sorts } = countJoins(() =>
+      buildRuntimeMobileAgentStatusProjectionForTests(again)
+    )
+    expect(joins).toBe(0)
+    expect(sorts).toBe(0)
   })
 
   it('still rebuilds when an entry changes', () => {
@@ -95,7 +126,9 @@ describe('agent-status projection join short circuit', () => {
 
     expect(result).not.toBe(first)
     expect(result).toBe(
-      buildRuntimeMobileAgentStatusProjectionForTests({ 'tab-0:leaf-0': map['tab-0:leaf-0'] })
+      buildRuntimeMobileAgentStatusProjectionForTests({
+        'tab-0:leaf-0': map['tab-0:leaf-0']
+      })
     )
   })
 

--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  buildRuntimeMobileAgentStatusProjectionForTests,
+  resetRuntimeMobileAgentStatusProjectionCacheForTests
+} from './sync-runtime-graph'
+
+function makeEntry(index: number, overrides: Record<string, unknown> = {}): never {
+  return {
+    paneKey: `tab-${index}:leaf-0`,
+    state: 'working',
+    prompt: `prompt ${index}`,
+    updatedAt: 1740000000000 + index * 17,
+    stateStartedAt: 1740000000000,
+    agentType: 'claude',
+    terminalTitle: `agent ${index}`,
+    stateHistory: [{ state: 'working', prompt: 'step', startedAt: 1740000000000 }],
+    toolName: 'shell_command',
+    toolInput: 'ls -la',
+    lastAssistantMessage: 'answer',
+    ...overrides
+  } as never
+}
+
+function mapOf(indices: readonly number[]): AppState['agentStatusByPaneKey'] {
+  const map: AppState['agentStatusByPaneKey'] = {}
+  for (const index of indices) {
+    map[`tab-${index}:leaf-0`] = makeEntry(index)
+  }
+  return map
+}
+
+/** Re-spread with the same entry objects, as a status ping does. */
+function respread(map: AppState['agentStatusByPaneKey']): AppState['agentStatusByPaneKey'] {
+  return { ...map }
+}
+
+function countJoins(run: () => string): { result: string; joins: number } {
+  const original = Array.prototype.join
+  let joins = 0
+  const spy = vi
+    .spyOn(Array.prototype, 'join')
+    .mockImplementation(function (this: unknown[], separator?: string) {
+      joins += 1
+      return original.call(this, separator)
+    })
+  try {
+    return { result: run(), joins }
+  } finally {
+    spy.mockRestore()
+  }
+}
+
+describe('agent-status projection join short circuit', () => {
+  afterEach(() => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+  })
+
+  it('skips the join when a re-spread reuses every entry', () => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const map = mapOf([0, 1, 2])
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+
+    // A new map identity with identical entry references — the common ping shape.
+    const { result, joins } = countJoins(() =>
+      buildRuntimeMobileAgentStatusProjectionForTests(respread(map))
+    )
+
+    expect(result).toBe(first)
+    expect(joins).toBe(0)
+  })
+
+  it('still rebuilds when an entry changes', () => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const map = mapOf([0, 1])
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+
+    const changed = { ...map, 'tab-1:leaf-0': makeEntry(1, { state: 'idle' }) }
+    const { result, joins } = countJoins(() =>
+      buildRuntimeMobileAgentStatusProjectionForTests(changed)
+    )
+
+    expect(result).not.toBe(first)
+    expect(joins).toBeGreaterThan(0)
+  })
+
+  it('still rebuilds when a pane is removed, even though every survivor is reused', () => {
+    // The reuse check alone cannot see a removal; only the entry-count check does.
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const map = mapOf([0, 1])
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+
+    const removed = { 'tab-0:leaf-0': map['tab-0:leaf-0'] }
+    const result = buildRuntimeMobileAgentStatusProjectionForTests(removed)
+
+    expect(result).not.toBe(first)
+    expect(result).toBe(
+      buildRuntimeMobileAgentStatusProjectionForTests({ 'tab-0:leaf-0': map['tab-0:leaf-0'] })
+    )
+  })
+
+  it('still rebuilds when a pane is added', () => {
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const map = mapOf([0])
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+
+    const added = { ...map, 'tab-9:leaf-0': makeEntry(9) }
+    const result = buildRuntimeMobileAgentStatusProjectionForTests(added)
+
+    expect(result).not.toBe(first)
+    expect(result).toContain('tab-9:leaf-0')
+  })
+})

--- a/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
@@ -40,34 +40,39 @@ export function buildRuntimeMobileAgentStatusProjection(
     return cached.projection
   }
 
+  const nextEntries = Object.entries(agentStatusByPaneKey)
+  // Same key set, same entry objects: the sorted join would be character-identical to the cached
+  // string, so skip the O(N log N) sort and the O(bytes) join. Equal sizes plus every next key
+  // present in the cache proves the key sets match; a removal fails the size check and an addition
+  // fails the lookup. The cached Map is exactly what a rebuild would produce, so reuse it too.
+  if (
+    cached != null &&
+    nextEntries.length === cached.entries.size &&
+    nextEntries.every(([paneKey, entry]) => cached.entries.get(paneKey)?.entry === entry)
+  ) {
+    graphState.cachedAgentStatusProjection = {
+      ...cached,
+      source: agentStatusByPaneKey
+    }
+    return cached.projection
+  }
+
   // A status ping replaces one entry and re-spreads the map; reuse every other entry.
   const entries = new Map<string, AgentStatusProjectionCacheEntry>()
   const parts: string[] = []
-  // Why tracked: if every entry was reused and the key set is unchanged, the joined
-  // string is character-identical to the cached one by construction, so the join —
-  // which is O(total serialized bytes of every live agent status) — can be skipped.
-  let everyEntryReused = cached != null
   // Code-unit order, not `localeCompare`: this projection is only ever compared with `===`, so it
   // must be deterministic, not locale-correct — and an ICU collator per comparison is ~4.5k calls
   // per ping at the 500-entry cap.
-  for (const [paneKey, entry] of Object.entries(agentStatusByPaneKey).sort(([a], [b]) =>
-    a < b ? -1 : a > b ? 1 : 0
-  )) {
+  for (const [paneKey, entry] of nextEntries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
     const previous = cached?.entries.get(paneKey)
-    const reused = previous?.entry === entry
-    const entryCache = reused
-      ? previous
-      : { entry, projection: serializeAgentStatusEntry(paneKey, entry) }
-    everyEntryReused &&= reused
+    const entryCache =
+      previous?.entry === entry
+        ? previous
+        : { entry, projection: serializeAgentStatusEntry(paneKey, entry) }
     entries.set(paneKey, entryCache)
     parts.push(entryCache.projection)
   }
-  // The size check covers removals; an addition already fails the reuse test above,
-  // and the sort makes a matching key set imply a matching order.
-  const projection =
-    everyEntryReused && cached != null && entries.size === cached.entries.size
-      ? cached.projection
-      : `[${parts.join(',')}]`
+  const projection = `[${parts.join(',')}]`
   graphState.cachedAgentStatusProjection = {
     source: agentStatusByPaneKey,
     entries,

--- a/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
@@ -43,6 +43,10 @@ export function buildRuntimeMobileAgentStatusProjection(
   // A status ping replaces one entry and re-spreads the map; reuse every other entry.
   const entries = new Map<string, AgentStatusProjectionCacheEntry>()
   const parts: string[] = []
+  // Why tracked: if every entry was reused and the key set is unchanged, the joined
+  // string is character-identical to the cached one by construction, so the join —
+  // which is O(total serialized bytes of every live agent status) — can be skipped.
+  let everyEntryReused = cached != null
   // Code-unit order, not `localeCompare`: this projection is only ever compared with `===`, so it
   // must be deterministic, not locale-correct — and an ICU collator per comparison is ~4.5k calls
   // per ping at the 500-entry cap.
@@ -50,14 +54,20 @@ export function buildRuntimeMobileAgentStatusProjection(
     a < b ? -1 : a > b ? 1 : 0
   )) {
     const previous = cached?.entries.get(paneKey)
-    const entryCache =
-      previous?.entry === entry
-        ? previous
-        : { entry, projection: serializeAgentStatusEntry(paneKey, entry) }
+    const reused = previous?.entry === entry
+    const entryCache = reused
+      ? previous
+      : { entry, projection: serializeAgentStatusEntry(paneKey, entry) }
+    everyEntryReused &&= reused
     entries.set(paneKey, entryCache)
     parts.push(entryCache.projection)
   }
-  const projection = `[${parts.join(',')}]`
+  // The size check covers removals; an addition already fails the reuse test above,
+  // and the sort makes a matching key set imply a matching order.
+  const projection =
+    everyEntryReused && cached != null && entries.size === cached.entries.size
+      ? cached.projection
+      : `[${parts.join(',')}]`
   graphState.cachedAgentStatusProjection = {
     source: agentStatusByPaneKey,
     entries,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |

<!-- /orca-pr-loc -->

## What

An agent-status ping replaces one entry and re-spreads `agentStatusByPaneKey`. `buildRuntimeMobileAgentStatusProjection` already reuses every unchanged entry's cached serialization — then joined them all anyway:

```ts
const projection = `[${parts.join(',')}]`
```

That join is **O(total serialized bytes of every live agent status)**. At the `MAX_LIVE_AGENT_STATUSES = 500` cap with 20 history rows and a 200-char field limit that is ~5-6 KB/entry; at a realistic 20-50 active agents it is **40-100 KB of string rebuilt per ping**, to produce a string that is only ever `===`-compared.

When every entry was reused **and** the entry count matches, the joined string is character-identical to the cached one by construction, so the cached string is returned outright.

The three cases the two conditions cover between them:
- **entry changed** → fails the reuse test → rebuild
- **pane added** → `previous` is undefined, so it also fails the reuse test → rebuild
- **pane removed** → every survivor is reused, so *only* the count check catches it → rebuild

The sort is a code-unit compare, so a matching key set implies a matching order.

## Why not a hash

The obvious "just hash it" is **not** free. The string feeds `a.agentStatusProjection === b.agentStatusProjection`, which gates `scheduleRuntimeGraphSync()`. A collision returns "equal" for genuinely different agent state, so a mobile publication is silently skipped — and on a quiet board there is no later write to heal it. That trades a correctness risk for speed. This change is exact.

## Scope

Only the "map re-spread, no entry content changed" case, which is a large share of pings. A genuinely changed entry still rebuilds; making *that* incremental is a design change, not a free win.

## Verification

New `sync-runtime-graph-agent-status-projection-join.test.ts` spies on `Array.prototype.join` to assert the join count is **0** on a reuse ping and **>0** when an entry changes, plus explicit add/remove cases. The removal case is the one a naive "all reused?" check would get wrong. **Fails without the fix.**

`pnpm tc:web` clean. Existing projection-equivalence suites (which compare against a reference whole-array serialization) unchanged and passing. Full renderer suite: 29,706 passed.

---

## ELI5

To keep your phone up to date, the app writes one long summary of what every agent is doing, then compares it to the last one to decide whether anything is worth sending.

Agents ping constantly. Most pings change nothing. But the app rebuilt the entire summary from scratch every time — up to ~100KB of text — just to discover it was identical.

Now, when nothing changed, it reuses the summary it already has.

Why not just use a short fingerprint instead of the whole text? Because two different summaries could produce the same fingerprint, and the app would conclude "nothing changed" and never tell your phone. On a quiet day nothing would come along later to fix it. So this stays exact.
