### PR TITLE
fix(browser): select full URL on initial address bar click

### DIFF
--- a/src/renderer/src/components/browser-pane/assemble-chrome/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/BrowserAddressBar.tsx
@@ -424,6 +424,13 @@ export default function BrowserAddressBar({
               ref={inputRef}
               value={value}
               onFocus={handleFocus}
+              onMouseDown={(event) => {
+                if (event.button === 0 && document.activeElement !== event.currentTarget) {
+                  // Keep the initial click from overriding the focus handler's full selection.
+                  event.preventDefault()
+                  event.currentTarget.focus()
+                }
+              }}
               onBlur={handleBlur}
               onKeyDown={handleKeyDown}
               data-orca-browser-address-bar="true"

--- a/src/renderer/src/components/browser-pane/assemble-chrome/BrowserAddressBar.tsx
+++ b/src/renderer/src/components/browser-pane/assemble-chrome/BrowserAddressBar.tsx
@@ -53,6 +53,7 @@ export default function BrowserAddressBar({
   const browserDefaultSearchEngine = useAppStore((s) => s.browserDefaultSearchEngine)
   const browserKagiSessionLink = useAppStore((s) => s.browserKagiSessionLink)
   const closingRef = useRef(false)
+  const initialMouseDownRef = useRef(false)
   const openedAtRef = useRef(0)
   const blurCloseTimerRef = useRef<number | null>(null)
   const closingResetTimerRef = useRef<number | null>(null)
@@ -241,12 +242,15 @@ export default function BrowserAddressBar({
       window.clearTimeout(blurCloseTimerRef.current)
       blurCloseTimerRef.current = null
     }
-    inputRef.current?.select()
+    if (!initialMouseDownRef.current) {
+      inputRef.current?.select()
+    }
     openedAtRef.current = Date.now()
     setOpen(true)
   }, [inputRef])
 
   const handleBlur = useCallback(() => {
+    initialMouseDownRef.current = false
     // Why: delay close so that clicking a suggestion item registers before
     // the popover unmounts. Without this, onSelect never fires because the
     // mousedown on PopoverContent triggers input blur first.
@@ -425,11 +429,16 @@ export default function BrowserAddressBar({
               value={value}
               onFocus={handleFocus}
               onMouseDown={(event) => {
-                if (event.button === 0 && document.activeElement !== event.currentTarget) {
-                  // Keep the initial click from overriding the focus handler's full selection.
-                  event.preventDefault()
-                  event.currentTarget.focus()
+                initialMouseDownRef.current =
+                  event.button === 0 && document.activeElement !== event.currentTarget
+              }}
+              onClick={(event) => {
+                const input = event.currentTarget
+                // Preserve native drag selection; only expand a collapsed initial click.
+                if (initialMouseDownRef.current && input.selectionStart === input.selectionEnd) {
+                  input.select()
                 }
+                initialMouseDownRef.current = false
               }}
               onBlur={handleBlur}
               onKeyDown={handleKeyDown}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5
Clicking the browser address bar for the first time now selects the entire URL, ready to replace.

## What Changed
Track whether a left mouse-down begins on an unfocused input. Let native focus and drag selection run, then select all on click only if the selection is collapsed. Keyboard focus still selects all. The change stays in the shared address-bar component.

## Why
The mouse's default action could overwrite the full selection made by the focus handler.

## Linked Issue
User-reported URL selection bug (screenshot supplied in the task); no existing issue linked.

## Visual Proof
Before:
![Before](https://github.com/user-attachments/assets/52ac61ae-0436-4cb4-a187-d66a12b51f0c)

After:
![After](https://github.com/user-attachments/assets/573908bf-96f2-4530-a60e-f1cd2b9e30e5)

Drag selection starting on an unfocused bar:
![Unfocused drag](https://github.com/user-attachments/assets/32022f11-5a73-4109-a065-fd8a779395fa)

## Testing
- [x] Tested locally through Playwright CDP in hidden macOS Electron, with `ORCA_BACKGROUND_LAUNCH=1` and the worktree identity verified.
- [x] Existing automated tests pass; no new test added for this small change. Real Chromium mouse behavior was checked directly because DOM-only focus tests do not reproduce the default mouse selection.

Initial click selects all 49 characters; second click places a caret; dragging from either an unfocused or focused bar selects characters 11–25; programmatic focus and clicking after blur still select all. Repeating the initial click on the original implementation left a caret instead of selecting all. Screenshots show the real app; the example destination was unreachable, which does not affect this address-bar check.

`pnpm tc:web`, both local and remote address-bar test files (11 tests), oxlint, React Doctor lint, and formatting checks pass. Full build and broader checks left to CI. Windows, Linux, and live SSH were not exercised; the shared component changes no platform-specific behavior, workspace handling, or remote protocol.

## Agent skill upstream boundary
- [x] Not applicable.

## Checklist
- [x] This PR is small and focused
- [x] Explained what changed and why
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint, typecheck, test, and build (CI)
