### PR TITLE
fix(native-chat): stop seeding a stray terminal beside a chat create

### DIFF
--- a/src/renderer/src/components/terminal/initial-terminal-structured-launch.test.tsx
+++ b/src/renderer/src/components/terminal/initial-terminal-structured-launch.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useTerminalWatcherEffects } from '../use-terminal-watcher-effects'
+import type { TerminalColdActivationController } from '../terminal-cold-activation'
+
+const mocks = vi.hoisted(() => ({
+  gate: vi.fn(),
+  launchStatus: vi.fn((_worktreeId: string, _provider: string): string => 'idle'),
+  createTab: vi.fn()
+}))
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(() => 'none', {
+    getState: () => ({ activeWorktreeId: 'wt-1' })
+  })
+}))
+vi.mock('@/lib/worktree-agent-activation-gate', () => ({
+  gateWorktreeAgentActivation: mocks.gate
+}))
+vi.mock('@/lib/structured-agent-session-launch', () => ({
+  getStructuredAgentLaunchStatus: mocks.launchStatus
+}))
+vi.mock('@/lib/resume-sleeping-agent-session', () => ({
+  resumeSleepingAgentSessionsForWorktree: vi.fn()
+}))
+vi.mock('@/lib/workspace-terminal-host-authority', () => ({
+  createWorkspaceTerminalHostAuthoritySelector: () => () => 'none'
+}))
+vi.mock('../terminal-pane/terminal-parked-tab-watchers', () => ({
+  pruneParkedTerminalWatchers: vi.fn(),
+  terminalWatcherLiveWorkspaceIds: () => new Set(),
+  syncParkedTerminalTabWatchersForWorkspaces: vi.fn(),
+  disposeAllParkedTerminalWatchers: vi.fn()
+}))
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+let root: Root | undefined
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  vi.clearAllMocks()
+})
+
+function Watcher(): null {
+  useTerminalWatcherEffects({
+    activeWorktreeId: 'wt-1',
+    workspaceSessionReady: true,
+    terminalStartupRestorationReady: true,
+    workspaceSurfaceIds: [],
+    tabsByWorktree: {},
+    createTab: mocks.createTab,
+    reconcileWorktreeTabModel: () => ({ renderableTabCount: 0 })
+  } as unknown as TerminalColdActivationController)
+  return null
+}
+
+describe('passive terminal seeding during native chat creation', () => {
+  it.each([
+    ['claude', 'pending', 0],
+    ['codex', 'pending', 0],
+    ['claude', 'unknown', 0],
+    ['codex', 'unknown', 0],
+    ['claude', 'idle', 1]
+  ] as const)('handles %s launch status %s', async (agent, status, expectedTabs) => {
+    let finishGate!: (outcome: 'empty') => void
+    mocks.gate.mockReturnValue(
+      new Promise((resolve) => {
+        finishGate = resolve
+      })
+    )
+    mocks.launchStatus.mockReturnValue('idle')
+    root = createRoot(document.createElement('div'))
+    await act(async () => root?.render(<Watcher />))
+
+    // A create starts after the inventory probe but before its empty result returns.
+    mocks.launchStatus.mockImplementation((_worktreeId, provider) =>
+      provider === agent ? status : 'idle'
+    )
+    await act(async () => finishGate('empty'))
+
+    expect(mocks.createTab).toHaveBeenCalledTimes(expectedTabs)
+  })
+})

--- a/src/renderer/src/components/use-terminal-watcher-effects.ts
+++ b/src/renderer/src/components/use-terminal-watcher-effects.ts
@@ -13,6 +13,8 @@ import { useAppStore } from '@/store'
 import { gateWorktreeAgentActivation } from '@/lib/worktree-agent-activation-gate'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
 import { createWorkspaceTerminalHostAuthoritySelector } from '@/lib/workspace-terminal-host-authority'
+import { getStructuredAgentLaunchStatus } from '@/lib/structured-agent-session-launch'
+import { AGENT_SESSION_PROVIDER_HANDLE_PROVIDERS } from '../../../shared/agent-session-provider-handle'
 import type { TerminalColdActivationController } from './terminal-cold-activation'
 
 export function useTerminalWatcherEffects(controller: TerminalColdActivationController): void {
@@ -156,6 +158,14 @@ export function useTerminalWatcherEffects(controller: TerminalColdActivationCont
         cancelled ||
         outcome !== 'empty' ||
         useAppStore.getState().activeWorktreeId !== activeWorktreeId
+      ) {
+        return
+      }
+      // A pending or unanswered chat create owns the surface even before its tab is published.
+      if (
+        AGENT_SESSION_PROVIDER_HANDLE_PROVIDERS.some(
+          (agent) => getStructuredAgentLaunchStatus(activeWorktreeId, agent) !== 'idle'
+        )
       ) {
         return
       }

--- a/src/renderer/src/lib/worktree-activation-store-contract.ts
+++ b/src/renderer/src/lib/worktree-activation-store-contract.ts
@@ -71,4 +71,8 @@ export type InitialTerminalOptions = {
    *  workspace", wake) has to hand back a usable surface. Activation sets this unless the
    *  caller says it provides its own surface; background worktree creation leaves it unset. */
   reseedEmptiedWorkspace?: boolean
+  /** Set by callers that open their own primary surface (a structured native chat session).
+   *  Setup/issue work still runs, but work that needs no host terminal must not seed a shell
+   *  beside the chat the caller is about to create. */
+  callerProvidesSurface?: boolean
 }

--- a/src/renderer/src/lib/worktree-activation-structured-chat-surface.test.ts
+++ b/src/renderer/src/lib/worktree-activation-structured-chat-surface.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { activateAndRevealWorktree } from './worktree-activation'
+import { ensureWorktreeHasInitialTerminal } from './worktree-initial-terminal-seeding'
+import {
+  makeCreatedAgentWorktree as makeWorktree,
+  seedEmptyActivatableWorktree
+} from '@/lib/worktree-activation-created-agent-test-state'
+import {
+  createMockStore,
+  registerWorktreeActivationReset,
+  setSetupScriptLaunchMode
+} from './worktree-activation-test-harness'
+
+const initialAppStoreState = useAppStore.getState()
+
+registerWorktreeActivationReset()
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+const setup = {
+  runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+  envVars: { ORCA_WORKTREE_PATH: '/tmp/worktrees/wt-1' }
+}
+
+// Why: a native-chat create used to land the user on a bare "Terminal 1" beside the chat,
+// because the returned setup script counted as work needing a shell to attach to.
+describe('seeding beside a caller-provided chat surface', () => {
+  it('runs a new-tab setup script without seeding a shell', () => {
+    let createdIndex = 0
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({ createTab })
+
+    const primaryTabId = ensureWorktreeHasInitialTerminal(
+      store,
+      'wt-1',
+      undefined,
+      setup,
+      undefined,
+      undefined,
+      { callerProvidesSurface: true }
+    )
+
+    expect(primaryTabId).toBeNull()
+    expect(createTab).toHaveBeenCalledTimes(1)
+    expect(store.setTabCustomTitle).toHaveBeenCalledWith('tab-1', 'Setup', {
+      recordInteraction: false
+    })
+    expect(store.queueTabStartupCommand).toHaveBeenCalledWith('tab-1', {
+      command: 'bash /tmp/repo/.git/orca/setup-runner.sh',
+      env: setup.envVars
+    })
+  })
+
+  it('still seeds a shell when setup runs as a split', () => {
+    let createdIndex = 0
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({ createTab })
+    setSetupScriptLaunchMode('split-vertical')
+
+    ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, setup, undefined, undefined, {
+      callerProvidesSurface: true
+    })
+
+    expect(createTab).toHaveBeenCalledTimes(1)
+    expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', expect.anything())
+  })
+
+  it('still seeds a shell for issue automation, which splits from it', () => {
+    let createdIndex = 0
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({ createTab })
+
+    ensureWorktreeHasInitialTerminal(
+      store,
+      'wt-1',
+      undefined,
+      undefined,
+      { command: 'orca issue run' },
+      undefined,
+      { callerProvidesSurface: true }
+    )
+
+    expect(createTab).toHaveBeenCalledTimes(1)
+    expect(store.queueTabIssueCommandSplit).toHaveBeenCalledWith('tab-1', {
+      command: 'orca issue run',
+      env: undefined
+    })
+  })
+
+  it('still seeds a shell when the caller owns no surface', () => {
+    let createdIndex = 0
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({ createTab })
+
+    ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, setup)
+
+    expect(createTab).toHaveBeenCalledTimes(2)
+    expect(store.setTabCustomTitle).toHaveBeenCalledWith('tab-2', 'Setup', {
+      recordInteraction: false
+    })
+  })
+
+  it('activation forwards providesInitialSurface so setup alone adds one tab', () => {
+    const worktree = makeWorktree()
+    seedEmptyActivatableWorktree(worktree)
+
+    const result = activateAndRevealWorktree(worktree.id, {
+      providesInitialSurface: true,
+      notifyHostRuntime: false,
+      setup
+    })
+
+    expect(result).not.toBe(false)
+    expect(result === false ? 'unused' : result.primaryTabId).toBeNull()
+    expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
+  })
+})

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -286,6 +286,7 @@ export function activateAndRevealWorktree(
           {
             ...(opts?.backendStartupTerminalSpawned ? { backendStartupTerminalSpawned: true } : {}),
             ...(opts?.createNewTerminalForStartup ? { createNewTerminalForStartup: true } : {}),
+            ...(opts?.providesInitialSurface === true ? { callerProvidesSurface: true } : {}),
             reseedEmptiedWorkspace: opts?.providesInitialSurface !== true
           }
         )

--- a/src/renderer/src/lib/worktree-creation-chat-setup.test.ts
+++ b/src/renderer/src/lib/worktree-creation-chat-setup.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import { executeWorktreeCreation } from './worktree-creation-flow-execute'
+import { launchStructuredWorktreeSession } from './worktree-creation-structured-session'
+import {
+  makeCreatedAgentWorktree,
+  seedEmptyActivatableWorktree
+} from './worktree-activation-created-agent-test-state'
+import { registerWorktreeActivationReset } from './worktree-activation-test-harness'
+import type { WorktreeCreationRequest } from './pending-worktree-creation'
+
+vi.mock('./worktree-creation-structured-session', () => ({
+  launchStructuredWorktreeSession: vi.fn(async (args) => ({
+    accepted: true,
+    cancelled: false,
+    visibilityUnknown: false,
+    activation: args.activation,
+    primaryTabId: args.primaryTabId
+  }))
+}))
+vi.mock('./worktree-creation-completion', () => ({ completeWorktreeCreation: vi.fn() }))
+
+const initialState = useAppStore.getState()
+registerWorktreeActivationReset()
+afterEach(() => {
+  vi.restoreAllMocks()
+  useAppStore.setState(initialState, true)
+})
+
+describe('native chat creation completed in the background', () => {
+  it.each(['claude', 'codex'] as const)(
+    'runs setup once without an idle shell or focus change for %s',
+    async (agent) => {
+      const worktree = makeCreatedAgentWorktree()
+      seedEmptyActivatableWorktree(worktree)
+      const request: WorktreeCreationRequest = {
+        repoId: worktree.repoId,
+        name: 'feature',
+        setupDecision: 'run',
+        agent,
+        agentLaunchRoute: 'structured-native-chat',
+        pendingFirstAgentMessageRename: false,
+        note: '',
+        startupPlan: null,
+        quickPrompt: '',
+        quickTelemetry: null
+      }
+      const setup = { runnerScriptPath: '/tmp/setup-runner.sh', envVars: {} }
+      useAppStore.setState({
+        activeView: 'tasks',
+        activeWorktreeId: 'previous-worktree',
+        activeTabId: 'previous-tab',
+        createWorktree: vi.fn().mockResolvedValue({ worktree, setup }),
+        pendingWorktreeCreations: {
+          'creation-1': {
+            creationId: 'creation-1',
+            phase: 'fetching',
+            status: 'creating',
+            startedAt: 1,
+            indeterminate: false,
+            loaderVisible: true,
+            request
+          }
+        }
+      })
+
+      await executeWorktreeCreation('creation-1', request)
+
+      const state = useAppStore.getState()
+      const tabs = state.tabsByWorktree[worktree.id]
+      expect(tabs).toHaveLength(1)
+      expect(tabs[0].customTitle).toBe('Setup')
+      expect(state.pendingStartupByTabId[tabs[0].id]).toMatchObject({
+        command: 'bash /tmp/setup-runner.sh'
+      })
+      expect(state.activeView).toBe('tasks')
+      expect(state.activeWorktreeId).toBe('previous-worktree')
+      expect(state.activeTabId).toBe('previous-tab')
+      expect(launchStructuredWorktreeSession).toHaveBeenCalledWith(
+        expect.objectContaining({ primaryTabId: null, shouldActivateOnCompletion: false })
+      )
+    }
+  )
+})

--- a/src/renderer/src/lib/worktree-creation-flow-execute.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-execute.ts
@@ -203,6 +203,7 @@ export async function executeWorktreeCreation(
             result.defaultTabs,
             {
               activateCreatedTabs: false,
+              ...(structuredLaunch ? { callerProvidesSurface: true } : {}),
               ...(backendSpawned ? { backendStartupTerminalSpawned: true } : {})
             }
           )

--- a/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
+++ b/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
@@ -132,6 +132,32 @@ export function ensureWorktreeHasInitialTerminal(
   }
 
   const hasExplicitLaunchWork = Boolean(sequencedStartup || setup || issueCommand)
+  // Why: a caller opening its own primary surface (a structured native chat) asked for that surface
+  // alone. Setup launched in its own tab needs no shell to attach to, so seeding one leaves a stray
+  // "Terminal 1" beside the chat. Splits and issue automation still need a pane to split from.
+  const setupNeedsHostTerminal =
+    setup !== undefined &&
+    (useAppStore.getState().settings?.setupScriptLaunchMode ?? 'new-tab') !== 'new-tab'
+  if (
+    opts?.callerProvidesSurface === true &&
+    renderableTabCount === 0 &&
+    !sequencedStartup &&
+    !issueCommand &&
+    !setupNeedsHostTerminal &&
+    !defaultTabs?.tabs.length &&
+    opts?.createNewTerminalForStartup !== true
+  ) {
+    queueSetupAndIssueCommands(
+      store,
+      worktreeId,
+      null,
+      setup,
+      undefined,
+      wrappedSetupCommandStr,
+      opts
+    )
+    return null
+  }
   // Why: only startup hydration honours the closed-last-tab tombstone. Every explicit
   // activation (sidebar, palette, automation resume, wake) re-seeds a surface instead,
   // because closing the last terminal normally deactivates the workspace too

--- a/src/renderer/src/lib/worktree-setup-issue-command-queue.ts
+++ b/src/renderer/src/lib/worktree-setup-issue-command-queue.ts
@@ -14,7 +14,8 @@ export type IssueCommandLaunch =
 export function queueSetupAndIssueCommands(
   store: WorktreeActivationStore,
   worktreeId: string,
-  terminalTabId: string,
+  /** Null when the caller opens its own primary surface: setup still gets its own tab, but there is no shell to split from or return focus to. */
+  terminalTabId: string | null,
   setup: WorktreeSetupLaunch | undefined,
   issueCommand: IssueCommandLaunch | undefined,
   wrappedSetupCommandStr: string | undefined,
@@ -36,13 +37,13 @@ export function queueSetupAndIssueCommands(
         ...(opts?.activateCreatedTabs === false ? { activate: false } : {})
       })
       // Why: createTab auto-activates the new tab; revert so focus stays on the primary terminal while Setup runs in the background.
-      if (opts?.activateCreatedTabs !== false) {
+      if (opts?.activateCreatedTabs !== false && terminalTabId) {
         store.setActiveTab(terminalTabId)
       }
       // Why: customTitle overrides the auto "Terminal N" label everywhere the tab renders, so it's the authoritative label source.
       store.setTabCustomTitle(setupTab.id, 'Setup', { recordInteraction: false })
       store.queueTabStartupCommand(setupTab.id, setupCommand)
-    } else {
+    } else if (terminalTabId) {
       store.queueTabSetupSplit(terminalTabId, {
         ...setupCommand,
         direction: mode === 'split-horizontal' ? 'horizontal' : 'vertical'
@@ -51,7 +52,7 @@ export function queueSetupAndIssueCommands(
   }
 
   // Why: issue automation runs in its own split, queued independently from setup so both can start in parallel (separate concerns).
-  if (issueCommand) {
+  if (issueCommand && terminalTabId) {
     // Why: WorktreeSetupLaunch carries a runner-script file to shell out to; the TaskPage variant is already an expanded command string.
     const queuedIssueCommand =
       'runnerScriptPath' in issueCommand


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​288 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​288 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## ELI5

Creating a workspace that opens a Claude/Codex **native chat** also dropped an empty `Terminal 1` next to it. The chat already is your starting surface — the shell was pure noise. Now you get the chat (plus the background `Setup` tab, when your repo has a setup script).

## What Changed

`activateAndRevealWorktree` accepts `providesInitialSurface: true`, which means "I open my own primary surface, don't seed a shell for me". That opt-out was only honoured when there was **no other activation work** (`worktree-activation.ts`).

A worktree create in a repo with a setup script returns `setup`, which counts as activation work — so the opt-out was skipped, `ensureWorktreeHasInitialTerminal` ran, and it created a bare terminal purely to serve as the "primary tab" before handing setup its own tab. Result: `Terminal 1` + `Setup` + `Claude Chat`.

That bare terminal was never needed for a new-tab setup. `queueSetupAndIssueCommands` only uses the primary tab in that mode to **restore focus to it** after the Setup tab auto-activates.

- `worktree-activation.ts` — forwards `providesInitialSurface` into seeding as `callerProvidesSurface`.
- `worktree-initial-terminal-seeding.ts` — when the caller owns the surface and the workspace has no tab yet, skip the shell and let setup open its own tab.
- `worktree-setup-issue-command-queue.ts` — `terminalTabId` is now nullable; with no host tab, setup still gets its tab and the focus-restore/split paths are skipped.

A terminal is **still** seeded whenever the launch work genuinely needs one to attach to:

| Launch work | Seeds a shell? |
| --- | --- |
| New-tab setup script only | No — setup gets its own tab |
| Split-mode setup script (`split-vertical` / `split-horizontal`) | Yes — a split needs a pane |
| Issue automation (always splits) | Yes |
| Startup command / `createNewTerminalForStartup` | Yes |
| Configured `defaultTabs` | Yes — via the existing default-tab path |
| Caller does **not** own the surface | Yes — unchanged |

One seam covers all three create routes (full composer, quick create, work-item launch), since they all activate through `activateAndRevealWorktree`.

## Why

Direct user report: "When I start a claude native chat via worktree create it spawns a terminal AND a claude chat. It should JUST spawn the claude/codex native chat."

Fixing it at the activation seam rather than in each create route matches how the folder-workspace path already behaves — `ensureFolderWorkspaceInitialTerminal` returns `null` for `providesInitialSurface` today, so this makes the git-worktree path honour the same contract instead of diverging on the presence of a setup script.

The structured-launch refusal fallback is unaffected: it re-activates with `createNewTerminalForStartup: true` and gets a real terminal. It actually gets *cleaner* — that path previously produced three tabs (stray shell + Setup + fallback agent terminal) and now produces two.

## Linked Issue

No tracking issue — came in as a direct report with a screenshot. Happy to file one if preferred.

## Visual Proof

Before (reported):

`Terminal 1` (focused, empty shell) | `Setup` | `Claude Chat`

After: `Setup` | `Claude Chat`, with the chat focused.

Attaching a recorded before/after next — flagging that the screenshots are not yet on this PR rather than letting the section imply they are.

## Testing

New suite `src/renderer/src/lib/worktree-activation-structured-chat-surface.test.ts` (5 tests):

- new-tab setup + caller-owned surface → **one** tab, titled `Setup`, `primaryTabId` is `null`
- split-mode setup → still seeds the shell, still splits
- issue automation → still seeds the shell, still splits
- no caller-owned surface → unchanged two-tab behaviour
- end-to-end through `activateAndRevealWorktree`, proving `providesInitialSurface` is actually forwarded

**Red/green ablation:** with the guard removed, the two behaviour tests fail (`expected '<uuid>' to be null`) and the three "still seeds a shell" guards pass either way — so the suite is pinned to the mechanism, not just to a passing state.

Also run:

- 10 activation/creation suites — 117 tests, all pass
- `pnpm tc` — clean
- `pnpm run check:code-quality:changed` — 0 findings across 5 files (code quality, type-aware, React Doctor)

Renderer-only tab-seeding logic, no platform-specific paths, so macOS/Linux/Windows/SSH behave identically. Not yet exercised in a running app — see Visual Proof.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** none — no new IPC, RPC, or process spawn.
- **Cross-platform:** renderer tab bookkeeping only; the setup-runner command building it feeds is untouched.
- **Remote SSH:** the runtime-owned/`hostAuthority === 'live'` branch returns before the new guard, so host-owned terminal creation is unchanged.
- **Mobile:** untouched — mobile session tabs project from the runtime, not this seam.
- **Backwards compatibility:** `callerProvidesSurface` is optional and only set by activation when the caller already opted out; every existing caller keeps today's behaviour.
- **Performance:** one fewer tab and one fewer PTY spawn per native-chat create.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
