### PR TITLE
cli: keep privileged macOS command symlink readable under umask 077

### DIFF
--- a/src/main/cli/cli-command-filesystem-transaction.ts
+++ b/src/main/cli/cli-command-filesystem-transaction.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from 'node:crypto'
 import { lstat, mkdir, readFile, readlink, rename, rmdir } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import type { CliInstallStatus } from '../../shared/cli-install-types'
-import { isMissingError } from './cli-install-errors'
+import { isMissingError, isPermissionError } from './cli-install-errors'
 import { quoteShell } from './cli-install-path-format'
 
 export type EntryIdentity = {
@@ -96,8 +96,13 @@ export async function inspectStableCommand(
       } else if (afterInspection && status.state !== 'conflict') {
         fileSha256 = await hashCommandFile(commandPath)
       }
-    } catch {
-      continue
+    } catch (error) {
+      // Why: macOS readlink() of a 0700 root-owned symlink is EACCES, not a mutation race.
+      if (afterInspection?.isSymbolicLink && isPermissionError(error)) {
+        rawSymlinkTarget = null
+      } else {
+        continue
+      }
     }
     const afterEvidence = await readEntrySnapshot(commandPath)
     if (hasSameSnapshot(afterInspection, afterEvidence)) {
@@ -198,9 +203,11 @@ export function buildMacPrivilegedSymlinkTransaction(
   const rollback =
     `/bin/rm -f ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)} 2>/dev/null || :; ` +
     `if [ "$captured" -eq 1 ]; then ${restoreOrPreserve}; else /bin/rmdir ${quoteShell(transactionDirectory)}; fi; exit 73`
+  // Why: macOS honors symlink mode; umask 077 would publish lrwx------ and break readlink.
   return (
     `${capture}if /bin/mkdir ${quoteShell(publishDirectory)} && ` +
     `/bin/ln -s ${quoteShell(args.launcherPath)} ${quoteShell(publishPath)} && ` +
+    `/bin/chmod -h 755 ${quoteShell(publishPath)} && ` +
     `/bin/ln -P ${quoteShell(publishPath)} ${quoteShell(commandDirectory)}; then ` +
     `/bin/rm ${quoteShell(publishPath)}; /bin/rmdir ${quoteShell(publishDirectory)}; ` +
     `if [ "$captured" -eq 1 ]; then /bin/rm ${quoteShell(heldPath)}; fi; ` +

--- a/src/main/cli/cli-command-inspection.ts
+++ b/src/main/cli/cli-command-inspection.ts
@@ -5,7 +5,7 @@ import type { CliInstallMethod, CliInstallStatus } from '../../shared/cli-instal
 import { isAppImageExtractedLauncherPath } from './appimage-extracted-root'
 import { DEV_COMMAND_NAME, DEV_LAUNCHER_DIR } from './cli-install-constants'
 import { buildWindowsForwarder, extractManagedUnixLauncherTarget } from './cli-dev-launcher'
-import { isMissingError } from './cli-install-errors'
+import { isMissingError, isPermissionError } from './cli-install-errors'
 import { CliInstallLocation } from './cli-install-location'
 import { isPathInsideOrEqual, samePathEntry } from './cli-install-path-format'
 import { extractLegacyAppImageCliWrapperTarget } from './legacy-appimage-cli-wrapper'
@@ -52,7 +52,24 @@ export class CliCommandInspection extends CliInstallLocation {
         })
       }
 
-      const currentTarget = await readlink(commandPath)
+      let currentTarget: string
+      try {
+        currentTarget = await readlink(commandPath)
+      } catch (error) {
+        // Why: macOS enforces symlink mode on readlink; a 0700 root-owned CLI link crashes Settings.
+        if (isPermissionError(error)) {
+          return this.buildStatus({
+            commandPath,
+            launcherPath,
+            installMethod: 'symlink',
+            supported: true,
+            state: 'stale',
+            currentTarget: null,
+            detail: `${commandPath} exists but cannot be read. Re-register the CLI to replace it.`
+          })
+        }
+        throw error
+      }
       const resolvedCurrentTarget = resolve(dirname(commandPath), currentTarget)
       const resolvedLauncher = resolve(launcherPath)
       const isInstalled = resolvedCurrentTarget === resolvedLauncher && existsSync(resolvedLauncher)

--- a/src/main/cli/cli-command-privileged-transaction.test.ts
+++ b/src/main/cli/cli-command-privileged-transaction.test.ts
@@ -24,8 +24,9 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { CliInstaller } from './cli-installer'
+import { buildMacPrivilegedSymlinkTransaction } from './cli-command-filesystem-transaction'
 import { buildUnixDevLauncher } from './cli-dev-launcher'
+import { CliInstaller } from './cli-installer'
 
 const createdRoots: string[] = []
 const protectedDirectories: string[] = []
@@ -74,6 +75,21 @@ function fixtureInstallerOptions(fixture: Awaited<ReturnType<typeof createPrivil
   }
 }
 
+describe('buildMacPrivilegedSymlinkTransaction', () => {
+  it('publishes a world-readable symlink after private umask 077 staging', () => {
+    const command = buildMacPrivilegedSymlinkTransaction({
+      action: 'install',
+      commandPath: '/usr/local/bin/orca',
+      launcherPath: '/Applications/Orca.app/Contents/Resources/bin/orca',
+      expected: null,
+      expectedFileSha256: null,
+      expectedRawSymlinkTarget: null
+    })
+    expect(command.startsWith('umask 077;')).toBe(true)
+    expect(command).toMatch(/\/bin\/ln -s .+ && \/bin\/chmod -h 755 .+ && \/bin\/ln -P /)
+  })
+})
+
 describe.skipIf(process.platform !== 'darwin' || process.getuid?.() === 0)(
   'macOS privileged CLI command transaction',
   () => {
@@ -93,6 +109,8 @@ describe.skipIf(process.platform !== 'darwin' || process.getuid?.() === 0)(
       const installed = await installer.install()
       expect(installed.state).toBe('installed')
       await expect(readlink(fixture.commandPath)).resolves.toBe(installed.launcherPath)
+      expect((await lstat(fixture.commandPath)).mode & 0o777).toBe(0o755)
+      expect(commands[0]).toContain('/bin/chmod -h 755 ')
 
       await chmod(fixture.protectedDirectory, 0o500)
       await expect(installer.remove()).resolves.toMatchObject({ state: 'not_installed' })
@@ -162,6 +180,34 @@ describe.skipIf(process.platform !== 'darwin' || process.getuid?.() === 0)(
       expect(
         (await readdir(fixture.protectedDirectory)).some((name) => name.startsWith('.orca-cli-'))
       ).toBe(false)
+    })
+
+    it('reports an unreadable command symlink as stale and replaces it', async () => {
+      const fixture = await createPrivilegedFixture()
+      const installer = new CliInstaller({
+        ...fixtureInstallerOptions(fixture),
+        privilegedRunner: async (command) => {
+          await chmod(fixture.protectedDirectory, 0o700)
+          await executePrivilegedShell(command)
+        }
+      })
+
+      const installed = await installer.install()
+      expect(installed.state).toBe('installed')
+      const chmodLink = await runProcess({
+        program: '/bin/chmod',
+        args: ['-h', '000', fixture.commandPath]
+      })
+      expect(chmodLink.code).toBe(0)
+      await expect(readlink(fixture.commandPath)).rejects.toMatchObject({ code: 'EACCES' })
+
+      await expect(installer.getStatus()).resolves.toMatchObject({ state: 'stale' })
+
+      await chmod(fixture.protectedDirectory, 0o500)
+      const repaired = await installer.install()
+      expect(repaired.state).toBe('installed')
+      await expect(readlink(fixture.commandPath)).resolves.toBe(installed.launcherPath)
+      expect((await lstat(fixture.commandPath)).mode & 0o777).toBe(0o755)
     })
 
     it('restores the displaced command when publication setup fails', async () => {


### PR DESCRIPTION
## ELI5

On macOS, registering the Orca CLI into `/usr/local/bin` created a symlink that only root could `readlink()`. Settings then crashed, and `orca` on PATH could not find Orca.app. This publishes that symlink as world-readable and treats an already-unreadable one as stale so re-registering can replace it.

## What Changed

- Privileged macOS CLI registration still uses `umask 077` for the private staging directory, then `chmod -h 755` on the published symlink before hardlinking it into `/usr/local/bin`.
- `inspectSymlink` no longer throws `EACCES` on an unreadable command symlink. It reports `stale` so Settings can load and re-registration can replace the link.
- `inspectStableCommand` no longer treats that `readlink` `EACCES` as a mutation race.
- Tests cover the generated `chmod -h 755` sequence, the published mode (`0755`), and recovery from a `chmod -h 000` command symlink.

## Why

macOS enforces symlink mode on `readlink(2)`. The privileged installer set `umask 077` so the staging dir stayed `0700`, and `ln -s` inherited that umask. The published `/usr/local/bin/orca` became `lrwx------` owned by root. The unprivileged app then failed:

```
Error invoking remote method 'cli:getInstallStatus': Error: EACCES: permission denied, readlink '/usr/local/bin/orca'
```

The launcher also does `readlink` on itself, so `orca` on PATH printed `Unable to determine Orca.app path from symlink`. Following the symlink (open/exec) still worked; only reading the target failed.

Keeping `umask 077` for staging and chmod'ing only the published link is the smallest fix: the temp dir stays private, the public command matches neighboring `/usr/local/bin` shims (`code`, `docker`, …).

## Linked Issue

Fixes #19120

## Visual Proof

N/A — no UI or interaction change. Settings currently dies in IPC before CLI status can render; this is a filesystem-permission and inspection-error-handling fix.

## Testing

Reproduced on macOS with Orca 1.4.197: `/usr/local/bin/orca` was `lrwx------` root, Settings showed the IPC error, and `orca status` via PATH failed. `sudo chmod -h 755 /usr/local/bin/orca` unblocked the installed app.

Locally on this change:

- `pnpm test src/main/cli/cli-command-privileged-transaction.test.ts src/main/cli/cli-command-installation-races.test.ts src/main/cli/cli-installer.test.ts src/main/cli/cli-installer-macos-command-path.test.ts` — 38 passed
- Darwin privileged tests assert published mode `0755` and recover an unreadable symlink via re-install
- Shell-sequence smoke: `umask 077; ln -s …; chmod -h 755; ln -P` yields `lrwxr-xr-x` and a working `readlink`

Platforms: macOS (unit + live repro). Linux/Windows CLI registration paths are unchanged (`buildMacPrivilegedSymlinkTransaction` is macOS-only). SSH/remote not involved.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Grok 4.6 (xAI). The failure was reproduced on a local macOS host running packaged Orca 1.4.197; the privileged transaction, `inspectSymlink`, and tests were patched in a fork of this repo.

## Review

- **Cross-platform:** `chmod -h` and symlink-mode `readlink` behavior are macOS-only and stay inside `buildMacPrivilegedSymlinkTransaction` / the existing darwin privileged tests. Linux ignores symlink mode; Windows uses a wrapper file, not this transaction.
- **SSH/remote/local:** CLI registration is a local desktop install path. No remote wire, SSH, or worktree changes.
- **Agents/integrations:** No agent or git-provider behavior. The public `orca` command becomes usable again after registration.
- **Performance:** One extra `/bin/chmod -h` in a rare privileged install/remove path. `getStatus` still does one `readlink`; on `EACCES` it returns stale instead of throwing.
- **UI:** No renderer change. Settings stops crashing because the IPC handler no longer receives an uncaught `EACCES`.
- **Security:** Staging directory remains `umask 077` / mode `0700`. Only the public command symlink is opened to `755`, which is the intended mode for `/usr/local/bin` shims. An unreadable symlink at the Orca command path is treated as stale (replaceable), not as a foreign conflict, because that path is the registration target and the `0700` mode is what this installer previously published.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

macOS-only privileged CLI registration. Existing `0700` symlinks stay broken until the user re-registers the CLI or runs `sudo chmod -h 755 /usr/local/bin/orca`. After this ships, re-registering repairs them.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Locally ran targeted unit tests, oxlint, and oxfmt on the changed files. Full `pnpm lint` / `pnpm typecheck` / `pnpm build` left to CI.