### PR TITLE
fix: show named Node services in Live Ports

### DIFF
--- a/src/main/ports/local-workspace-port-attribution.test.ts
+++ b/src/main/ports/local-workspace-port-attribution.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import { enrichPort, normalizeWorkspacePortProbes } from './local-workspace-port-attribution'
+
+const workspace = { id: 'workspace', repoId: 'repo', displayName: 'app', path: '/workspace' }
+
+describe('port process labels', () => {
+  it.each([
+    ['node', 'web-app', 'web-app'],
+    ['node', 'api-server', 'api-server'],
+    ['node', 'docs', 'docs'],
+    ['node', 'Electron', 'node'],
+    ['Electron', 'web-app', 'Electron'],
+    ['node', 'worker.v2_1', 'worker.v2_1'],
+    ['node', 'x'.repeat(64), 'x'.repeat(64)],
+    ['node', 'x'.repeat(65), 'node'],
+    ['node', undefined, 'node'],
+    ['node', '', 'node'],
+    ['node', 'node server.js --token=example', 'node'],
+    ['node', '/usr/local/bin/node', 'node'],
+    ['node', 'C:\\node\\node.exe', 'node'],
+    ['node', '--inspect', 'node'],
+    ['node', 'TOKEN=example', 'node'],
+    ['node', 'web-app\n', 'node'],
+    ['node', 'web-app\t', 'node'],
+    ['node', 'web-app\u0000', 'node'],
+    ['node', 'web-app service', 'node'],
+    ['node.exe', 'web-app', 'node.exe'],
+    ['web-api', 'different-title', 'web-api'],
+    [undefined, 'web-app', undefined]
+  ])('labels %s with command %j as %s', (processName, commandLine, expected) => {
+    const raw = {
+      host: '127.0.0.1',
+      port: 3000,
+      pid: 123,
+      cwd: workspace.path,
+      processName,
+      commandLine
+    }
+    const lookup = vi.fn(() => undefined)
+    const result = enrichPort(raw, normalizeWorkspacePortProbes([workspace]), { lookup })
+
+    expect(result).toEqual({
+      id: '127.0.0.1:3000:123',
+      bindHost: '127.0.0.1',
+      connectHost: '127.0.0.1',
+      port: 3000,
+      pid: 123,
+      processName: expected,
+      protocol: 'http',
+      kind: 'workspace',
+      owner: {
+        worktreeId: workspace.id,
+        repoId: workspace.repoId,
+        displayName: workspace.displayName,
+        path: workspace.path,
+        confidence: 'cwd'
+      }
+    })
+    expect(raw.processName).toBe(processName)
+    expect(lookup).toHaveBeenCalledWith(workspace.id, 3000, 123)
+  })
+})

--- a/src/main/ports/local-workspace-port-attribution.ts
+++ b/src/main/ports/local-workspace-port-attribution.ts
@@ -72,13 +72,24 @@ export function enrichPort(
   urlWatcher: Pick<AdvertisedUrlWatcher, 'lookup'>
 ): WorkspacePort {
   const owner = attributePortToNormalizedWorkspaces(port, worktrees)
+  // Node titles can name a service; never expose full command lines as labels.
+  const title = port.commandLine
+  const processName =
+    port.processName === 'node' &&
+    title &&
+    title !== 'Electron' && // Preserve the UI's protected-process sentinel.
+    title.length <= 64 &&
+    /^[a-zA-Z0-9]/.test(title) &&
+    !/[^a-zA-Z0-9._-]/.test(title)
+      ? title
+      : port.processName
   const base = {
     id: `${port.host}:${port.port}:${port.pid ?? 'unknown'}`,
     bindHost: port.host,
     connectHost: connectHostForBindHost(port.host),
     port: port.port,
     pid: port.pid,
-    processName: port.processName,
+    processName,
     protocol: inferProtocol(port.port)
   }
 

--- a/src/main/ports/local-workspace-port-attribution.ts
+++ b/src/main/ports/local-workspace-port-attribution.ts
@@ -66,6 +66,7 @@ function attributePortToNormalizedWorkspaces(
   )
   return commandMatch ? toOwner(commandMatch.worktree, 'command') : undefined
 }
+/** Projects a listener into a workspace, container, or external port with a safe process label. */
 export function enrichPort(
   port: RawListeningPort,
   worktrees: readonly NormalizedWorkspacePortProbe[],


### PR DESCRIPTION
## ELI5

When several Node services are running, Live Ports should say `web-app` or `docs` instead of calling every service `node`. This uses the name the service already gives itself.

## What Changed

- Prefer an existing short, single-identifier process title for generic `node` listeners.
- Keep the executable name for arguments, paths, missing/long titles, and the reserved `Electron` label.
- Add 22 regression cases. No extra process scans or API fields.

## Why

On macOS, `lsof` reports `node` even when `node --title=web-app` changes the title returned by `ps`. Orca already collects that title as `commandLine`, but drops it from the displayed label. This fixes the projection without parsing or displaying arbitrary command lines.

## Linked Issue

Fixes #19129

## Visual Proof

Actual Orca Electron builds, three real Node HTTP listeners, isolated macOS workspace. Same ports before/after; the third server deliberately has no title. Captured through CDP with all windows hidden.

| Theme | Before | After |
| --- | --- | --- |
| Light | ![Before, light](https://github.com/user-attachments/assets/c0f69899-2a00-4503-ac84-8546e4c55748) | ![After, light](https://github.com/user-attachments/assets/d76f488a-d2b5-4340-b516-7f91afcc2d26) |
| Dark | ![Before, dark](https://github.com/user-attachments/assets/50046d13-06d8-4040-8974-3853b45acc8c) | ![After, dark](https://github.com/user-attachments/assets/a003a26a-0874-456d-89bb-33906d69025a) |

## Testing

- [x] I manually tested these changes locally — agent-driven Electron/CDP smoke check on macOS ARM64.
- [x] Automated tests added/updated.

Passed with `ORCA_BACKGROUND_LAUNCH=1`:

- Focused Vitest run: `src/main/ports` and `src/main/ssh/ssh-port-scanner.test.ts` — **157 tests, 10 files**.
- `pnpm typecheck`
- `pnpm run check:code-quality:changed -- origin/main`
- `pnpm run build:electron-vite` and the `--mode e2e` variant.

Linux, Windows, and live SSH were not manually tested. Full-repository lint/test and the native packaging build are left to CI.

## AI Disclosure

Implementation, tests, local verification, and self-review used OpenAI Codex via pi (model ID: `gpt-6-astra`).

## Review

- **Compatibility:** native scanning and direct SSH relay behavior are unchanged. Workspace ownership remains shared with folder workspaces. Existing clients accept the same optional string field; no protocol change. Agent, integration, Git-provider, and mobile-specific code is untouched.
- **Security:** rejects whitespace, paths, arguments, and control characters. Preserves the `Electron` stop-button sentinel and existing PID/ownership routing.
- **Performance/UI:** bounded checks on already-collected metadata; no new subprocesses. Existing layout and tooltips, verified in both themes.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill changes.

## Notes

Only service labels change. Titles must be 1–64 ASCII letters/digits/dots/underscores/hyphens and start with a letter or digit.

Author: @ParableTyler. X/Twitter: @TylerMills.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — local checks above; full CI pending

