### PR TITLE
fix: fail fast when terminal worktree has no renderable surface

### DIFF
--- a/src/main/runtime/orca-runtime-create-terminal-desktop.test.ts
+++ b/src/main/runtime/orca-runtime-create-terminal-desktop.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { BrowserWindow, IpcMainEvent } from 'electron'
+import type { TerminalTabCreateReply } from '../../shared/terminal-reveal-identity'
+import type { OrcaRuntimeWithCreateTerminal } from './orca-runtime-create-terminal'
+import { createDesktopTerminal } from './orca-runtime-create-terminal-desktop'
+import { mapRuntimeError } from './rpc/errors'
+
+const desktop = vi.hoisted(() => ({ onIpc: vi.fn(), removeIpcListener: vi.fn() }))
+vi.mock('./orca-runtime-create-terminal-dependencies', () => ({
+  randomUUID: () => 'request-1',
+  getRuntimeDesktopSurface: () => desktop,
+  ownerSurfacing: () => ({})
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+describe('desktop terminal creation replies', () => {
+  it.each([
+    { errorCode: 'worktree_not_renderable', rpcCode: 'worktree_not_renderable' },
+    { errorCode: undefined, rpcCode: 'runtime_error' }
+  ])('rejects before waiting for a handle with code $errorCode', async ({ errorCode, rpcCode }) => {
+    vi.useFakeTimers()
+    const send = vi.fn((_channel: string, request: { requestId: string }) => {
+      const handler = desktop.onIpc.mock.calls[0][1] as (
+        event: IpcMainEvent,
+        reply: TerminalTabCreateReply
+      ) => void
+      handler({ sender: win.webContents } as IpcMainEvent, {
+        requestId: request.requestId,
+        error: 'Show this worktree in the sidebar before creating a terminal.',
+        ...(errorCode ? { errorCode } : {})
+      })
+    })
+    const win = { webContents: { send } } as unknown as BrowserWindow
+    const waitForTerminalHandle = vi.fn()
+    const runtime = {
+      assertGraphReady: vi.fn(),
+      resolveTerminalWorkspaceLaunchScope: vi.fn().mockResolvedValue({ id: 'wt-hidden' }),
+      resolveAgentTerminalCreateOptions: vi.fn().mockResolvedValue({ command: 'claude' }),
+      resolveWorkspaceTerminalStartupCwd: vi.fn().mockReturnValue('/repo/hidden'),
+      waitForTerminalHandle
+    } as unknown as OrcaRuntimeWithCreateTerminal
+
+    const error = await createDesktopTerminal(runtime, 'wt-hidden', {}, 'focused', win).catch(
+      (error: unknown) => error
+    )
+
+    expect(error).toBeInstanceOf(Error)
+    expect(mapRuntimeError('rpc-1', { runtimeId: 'runtime-1' }, error)).toMatchObject({
+      ok: false,
+      error: {
+        code: rpcCode,
+        message: 'Show this worktree in the sidebar before creating a terminal.'
+      }
+    })
+    expect(waitForTerminalHandle).not.toHaveBeenCalled()
+    expect(desktop.removeIpcListener).toHaveBeenCalledWith(
+      'terminal:tabCreateReply',
+      desktop.onIpc.mock.calls[0][1]
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/runtime/orca-runtime-create-terminal-desktop.ts
+++ b/src/main/runtime/orca-runtime-create-terminal-desktop.ts
@@ -2,6 +2,7 @@
 import * as dependencies from './orca-runtime-create-terminal-dependencies'
 import type { OrcaRuntimeWithCreateTerminal } from './orca-runtime-create-terminal'
 import type { RuntimeTerminalPresentation } from '../../shared/runtime-types'
+import type { TerminalTabCreateReply } from '../../shared/terminal-reveal-identity'
 
 export async function createDesktopTerminal(
   runtime: OrcaRuntimeWithCreateTerminal,
@@ -28,22 +29,18 @@ export async function createDesktopTerminal(
       dependencies.getRuntimeDesktopSurface().removeIpcListener('terminal:tabCreateReply', handler)
       reject(new Error('Terminal creation timed out'))
     }, 10000)
-    const handler = (
-      event: dependencies.IpcMainEvent,
-      response: {
-        requestId: string
-        tabId?: string
-        title?: string
-        error?: string
-      }
-    ): void => {
+    const handler = (event: dependencies.IpcMainEvent, response: TerminalTabCreateReply): void => {
       if (event.sender !== win.webContents || response.requestId !== requestId) {
         return
       }
       clearTimeout(timer)
       dependencies.getRuntimeDesktopSurface().removeIpcListener('terminal:tabCreateReply', handler)
       if (response.error) {
-        reject(new Error(response.error))
+        const error = new Error(response.error)
+        if (response.errorCode) {
+          Object.assign(error, { code: response.errorCode })
+        }
+        reject(error)
       } else {
         resolve({ tabId: response.tabId!, title: response.title ?? launchOpts.title ?? '' })
       }

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -80,6 +80,7 @@ const COMPUTER_PASSTHROUGH_CODES: ReadonlySet<string> = new Set(Object.values(CO
 const LINEAR_PASSTHROUGH_CODES: ReadonlySet<string> = new Set(LINEAR_ERROR_CODES)
 const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'worktree_id_requires_full_path',
+  'worktree_not_renderable',
   'run_not_found',
   'run_required',
   'stable_pane_required',

--- a/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.test.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore, makeWorktree, seedStore } from '../../store/slices/store-test-helpers'
+import { buildTerminalCreateWindow } from '../ipc-events-terminal-create-window-test-fixtures'
+import type * as TerminalCommandState from './terminal-command-state'
+import type { TerminalTabCreateReply } from '../../../../shared/terminal-reveal-identity'
+
+const WORKTREE_ID = 'repo1::/path/visible'
+const HIDDEN_ID = 'repo1::/path/hidden'
+const DUPLICATE_ID = 'repo2::/path/visible'
+let store: ReturnType<typeof createTestStore>
+const reply = vi.fn<(data: TerminalTabCreateReply) => void>()
+const mount = vi.fn()
+const activate = vi.fn()
+
+vi.mock('../../store', () => ({ useAppStore: { getState: () => store.getState() } }))
+vi.mock('@/components/terminal/background-terminal-worktree-mount', () => ({
+  requestBackgroundTerminalWorktreeMount: (...args: unknown[]) => mount(...args)
+}))
+vi.mock('./terminal-command-state', async (importOriginal) => ({
+  ...(await importOriginal<typeof TerminalCommandState>()),
+  activateTerminalInitiatedWorktree: (...args: unknown[]) => activate(...args),
+  focusTerminalInitiatedTab: vi.fn()
+}))
+
+import { registerTerminalRequestIpcBridge } from './terminal-request-ipc-bridge'
+
+type Request = Parameters<Parameters<typeof window.api.ui.onRequestTerminalCreate>[0]>[0]
+let request: (data: Request) => void
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  store = createTestStore()
+  seedStore(store, {
+    worktreesByRepo: { repo1: [makeWorktree({ id: WORKTREE_ID, repoId: 'repo1' })] },
+    detectedWorktreesByRepo: {
+      repo1: {
+        repoId: 'repo1',
+        source: 'git',
+        authoritative: true,
+        worktrees: [
+          {
+            ...makeWorktree({ id: HIDDEN_ID, repoId: 'repo1', path: '/path/hidden' }),
+            ownership: 'external',
+            selectedCheckout: false,
+            visible: false
+          }
+        ]
+      }
+    }
+  })
+  store.setState({
+    repos: [...store.getState().repos, { ...store.getState().repos[0], id: 'repo2' }]
+  })
+  const listener = { current: null as unknown }
+  vi.stubGlobal(
+    'window',
+    buildTerminalCreateWindow({
+      dispatchEvent: vi.fn(),
+      replyTerminalCreate: reply,
+      requestTerminalCreateListenerRef: listener,
+      createTerminalListenerRef: { current: null },
+      focusTerminalListenerRef: { current: null },
+      newTerminalTabListenerRef: { current: null }
+    })
+  )
+  registerTerminalRequestIpcBridge([])
+  request = listener.current as typeof request
+})
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('renderer terminal create admission', () => {
+  it.each([
+    [HIDDEN_ID, 'background'],
+    [HIDDEN_ID, 'focused'],
+    [DUPLICATE_ID, 'background'],
+    [DUPLICATE_ID, 'focused']
+  ] as const)(
+    'refuses %s (%s) without creating or queueing anything',
+    (worktreeId, presentation) => {
+      const createTab = vi.spyOn(store.getState(), 'createTab')
+      const queue = vi.spyOn(store.getState(), 'queueTabStartupCommand')
+      const before = store.getState()
+
+      request({ requestId: 'hidden', worktreeId, presentation, command: 'codex' })
+
+      expect(reply).toHaveBeenCalledExactlyOnceWith({
+        requestId: 'hidden',
+        errorCode: 'worktree_not_renderable',
+        error: expect.stringContaining('Show it in Non-Orca worktrees')
+      })
+      expect(createTab).not.toHaveBeenCalled()
+      expect(queue).not.toHaveBeenCalled()
+      expect(mount).not.toHaveBeenCalled()
+      expect(activate).not.toHaveBeenCalled()
+      expect(store.getState()).toBe(before)
+    }
+  )
+
+  it('creates a visible background tab with its startup command', () => {
+    request({
+      requestId: 'visible',
+      worktreeId: WORKTREE_ID,
+      presentation: 'background',
+      command: 'codex'
+    })
+    const tab = store.getState().tabsByWorktree[WORKTREE_ID][0]
+    expect(reply).toHaveBeenCalledExactlyOnceWith({
+      requestId: 'visible',
+      tabId: tab.id,
+      title: tab.title
+    })
+    expect(store.getState().pendingStartupByTabId[tab.id]).toEqual({ command: 'codex' })
+    expect(mount).toHaveBeenCalledWith({ worktreeId: WORKTREE_ID, tabIds: [tab.id] })
+  })
+
+  it('retires the new tab and queued command if the success reply throws', () => {
+    const sibling = store.getState().createTab(WORKTREE_ID)
+    store.getState().queueTabStartupCommand(sibling.id, { command: 'keep me' })
+    const close = vi.spyOn(store.getState(), 'closeTab')
+    reply.mockImplementationOnce(() => {
+      throw new Error('Reply transport failed')
+    })
+
+    request({
+      requestId: 'failed',
+      worktreeId: WORKTREE_ID,
+      presentation: 'background',
+      command: 'codex'
+    })
+
+    expect(close).toHaveBeenCalledWith(expect.any(String), {
+      reason: 'cleanup',
+      recordInteraction: false
+    })
+    expect(store.getState().tabsByWorktree[WORKTREE_ID]).toEqual([sibling])
+    expect(store.getState().pendingStartupByTabId).toEqual({ [sibling.id]: { command: 'keep me' } })
+    expect(store.getState().unifiedTabsByWorktree[WORKTREE_ID]).toHaveLength(1)
+    expect(store.getState().recentlyClosedTerminalTabsByWorktree[WORKTREE_ID] ?? []).toEqual([])
+    expect(reply).toHaveBeenLastCalledWith({ requestId: 'failed', error: 'Reply transport failed' })
+  })
+
+  it('cleans up when creation fails after allocating the tab but before queueing', () => {
+    vi.spyOn(store.getState(), 'setTabCustomTitle').mockImplementationOnce(() => {
+      throw new Error('Title failed')
+    })
+    request({
+      requestId: 'failed',
+      worktreeId: WORKTREE_ID,
+      presentation: 'background',
+      title: 'Agent',
+      command: 'codex'
+    })
+    expect(store.getState().tabsByWorktree[WORKTREE_ID]).toEqual([])
+    expect(store.getState().pendingStartupByTabId).toEqual({})
+    expect(reply).toHaveBeenLastCalledWith({ requestId: 'failed', error: 'Title failed' })
+  })
+})

--- a/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
@@ -2,7 +2,10 @@ import { requestBackgroundTerminalWorktreeMount } from '@/components/terminal/ba
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { initialAgentTabViewModeProps } from '@/lib/native-chat-initial-view-mode'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
-import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
+import {
+  hasRenderableTerminalWorktreeSurface,
+  resolveTerminalWorktreeRoute
+} from '@/lib/terminal-worktree-route'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '../../store'
 import {
@@ -14,6 +17,7 @@ import {
 export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
   unsubs.push(
     window.api.ui.onRequestTerminalCreate((data) => {
+      let createdTabId: string | undefined
       try {
         const store = useAppStore.getState()
         const worktreeId = data.worktreeId ?? store.activeWorktreeId
@@ -43,6 +47,16 @@ export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
               'auto.hooks.useIpcEvents.7a64b31991',
               'Local terminal creation is unavailable while a remote runtime is active'
             )
+          })
+          return
+        }
+        // Why: routing can accept repo metadata without a row that can mount the new pane.
+        if (!hasRenderableTerminalWorktreeSurface(store, worktreeId)) {
+          window.api.ui.replyTerminalCreate({
+            requestId: data.requestId,
+            errorCode: 'worktree_not_renderable',
+            error:
+              'This window has no terminal surface for the worktree. Show it in Non-Orca worktrees or select a visible workspace, then retry.'
           })
           return
         }
@@ -78,6 +92,7 @@ export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
                 ...(data.cwd ? { startupCwd: data.cwd } : {})
               }
         const tab = store.createTab(worktreeId, data.targetGroupId, undefined, tabOptions)
+        createdTabId = tab.id
         if (!shouldActivate) {
           // Why: renderer-backed Codex startup must mount its new TerminalPane without switching UI or connecting every saved tab.
           requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [tab.id] })
@@ -142,6 +157,13 @@ export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
           title: data.title ?? tab.title
         })
       } catch (err) {
+        if (createdTabId) {
+          // Why: failed creates must not leave a tab whose startup command can run later.
+          useAppStore.getState().closeTab(createdTabId, {
+            reason: 'cleanup',
+            recordInteraction: false
+          })
+        }
         window.api.ui.replyTerminalCreate({
           requestId: data.requestId,
           error: err instanceof Error ? err.message : 'Terminal creation failed'

--- a/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/terminal-request-ipc-bridge.ts
@@ -55,8 +55,10 @@ export function registerTerminalRequestIpcBridge(unsubs: (() => void)[]): void {
           window.api.ui.replyTerminalCreate({
             requestId: data.requestId,
             errorCode: 'worktree_not_renderable',
-            error:
+            error: translate(
+              'auto.hooks.useIpcEvents.worktreeNotRenderable',
               'This window has no terminal surface for the worktree. Show it in Non-Orca worktrees or select a visible workspace, then retry.'
+            )
           })
           return
         }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1029,7 +1029,8 @@
         "ef223fbb6b": "A device tried to connect but is not paired",
         "11992d0337": "If this was your phone or another Orca client, re-pair it from Settings → Mobile.",
         "6573cfe955": "Open Mobile Settings",
-        "unresolvedTerminalWorktreeOwner": "Terminal creation is unavailable because the worktree owner could not be resolved"
+        "unresolvedTerminalWorktreeOwner": "Terminal creation is unavailable because the worktree owner could not be resolved",
+        "worktreeNotRenderable": "This window has no terminal surface for the worktree. Show it in Non-Orca worktrees or select a visible workspace, then retry."
       },
       "useSettingsNavigationMetadata": {
         "4a728cd56b": "New features that are still taking shape. Give them a try.",

--- a/src/renderer/src/lib/terminal-worktree-route.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.ts
@@ -3,6 +3,7 @@ import { isEphemeralSetupTerminalWorktreeId } from '../../../shared/ephemeral-se
 import { parseExecutionHostId } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import type { AppState } from '@/store/types'
+import { getIndexedWorktreeMap } from '../store/worktree-repo-index'
 import {
   getExplicitRuntimeEnvironmentIdForWorktree,
   getRuntimeEnvironmentIdForWorktree,
@@ -13,6 +14,28 @@ import { getSingleFocusedRuntimeEnvironmentId } from './single-runtime-legacy-ow
 
 export type TerminalWorktreeRoute = {
   runtimeEnvironmentId: string | null
+}
+
+export function hasRenderableTerminalWorktreeSurface(
+  state: Pick<AppState, 'worktreesByRepo' | 'folderWorkspaces'>,
+  worktreeId: string | null | undefined
+): boolean {
+  if (!worktreeId) {
+    return false
+  }
+  if (worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+    return true
+  }
+  const scope = parseWorkspaceKey(worktreeId)
+  if (scope?.type === 'folder') {
+    return (
+      state.folderWorkspaces?.some((workspace) => workspace.id === scope.folderWorkspaceId) ?? false
+    )
+  }
+  // Only the workbench's row index can host new tabs; detected rows and inline setup ids cannot.
+  return state.worktreesByRepo
+    ? getIndexedWorktreeMap(state.worktreesByRepo).has(worktreeId)
+    : false
 }
 
 /**

--- a/src/renderer/src/lib/terminal-worktree-surface.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-surface.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store/types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
+import { brandEphemeralSetupTerminalWorktreeId } from '../../../shared/ephemeral-setup-terminal-worktree-id'
+import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { hasRenderableTerminalWorktreeSurface } from './terminal-worktree-route'
+
+function state(overrides: Partial<AppState> = {}): AppState {
+  return {
+    repos: [{ id: 'repo-1', executionHostId: 'local' }],
+    worktreesByRepo: {
+      'repo-1': [{ id: 'repo-1::/workspace', repoId: 'repo-1', path: '/workspace' }]
+    },
+    folderWorkspaces: [],
+    ...overrides
+  } as unknown as AppState
+}
+
+describe('hasRenderableTerminalWorktreeSurface', () => {
+  it('accepts an exact workbench row for local, SSH, and paired runtime worktrees', () => {
+    for (const hostId of ['local', 'ssh:connection', 'runtime:hub']) {
+      const store = state({
+        worktreesByRepo: {
+          'repo-1': [{ id: 'repo-1::/workspace', repoId: 'repo-1', hostId }]
+        }
+      } as unknown as Partial<AppState>)
+      expect(hasRenderableTerminalWorktreeSurface(store, 'repo-1::/workspace')).toBe(true)
+    }
+  })
+
+  it('rejects a hidden detected worktree even when its repo is registered', () => {
+    const store = state({
+      detectedWorktreesByRepo: {
+        'repo-1': { worktrees: [{ id: 'repo-1::/external', repoId: 'repo-1' }] }
+      }
+    } as unknown as Partial<AppState>)
+    expect(hasRenderableTerminalWorktreeSurface(store, 'repo-1::/external')).toBe(false)
+  })
+
+  it('rejects a duplicate repo registration id that shares a rendered path', () => {
+    const store = state({
+      repos: [{ id: 'repo-1' }, { id: 'duplicate-repo' }]
+    } as unknown as Partial<AppState>)
+    expect(hasRenderableTerminalWorktreeSurface(store, 'duplicate-repo::/workspace')).toBe(false)
+  })
+
+  it('accepts an imported worktree once its exact row reaches the workbench catalog', () => {
+    const store = state()
+    const worktreeId = 'repo-1::/external'
+    expect(hasRenderableTerminalWorktreeSurface(store, worktreeId)).toBe(false)
+    const imported = state({
+      worktreesByRepo: {
+        ...store.worktreesByRepo,
+        'repo-1': [...store.worktreesByRepo['repo-1'], { id: worktreeId, repoId: 'repo-1' }]
+      }
+    } as unknown as Partial<AppState>)
+    expect(hasRenderableTerminalWorktreeSurface(imported, worktreeId)).toBe(true)
+  })
+
+  it('requires a real folder workspace rather than a syntactically valid key', () => {
+    const store = state({
+      folderWorkspaces: [{ id: 'folder-1', folderPath: '/folder' }]
+    } as unknown as Partial<AppState>)
+    expect(hasRenderableTerminalWorktreeSurface(store, folderWorkspaceKey('folder-1'))).toBe(true)
+    expect(hasRenderableTerminalWorktreeSurface(store, folderWorkspaceKey('missing'))).toBe(false)
+  })
+
+  it('preserves the separately hosted floating terminal surface', () => {
+    expect(hasRenderableTerminalWorktreeSurface(state(), FLOATING_TERMINAL_WORKTREE_ID)).toBe(true)
+  })
+
+  it('rejects inline setup ids whose components only render their own created tab', () => {
+    const id = brandEphemeralSetupTerminalWorktreeId('settings-cli-skill-terminal')
+    expect(hasRenderableTerminalWorktreeSurface(state(), id)).toBe(false)
+  })
+
+  it('fails closed for missing ids or unhydrated catalogs', () => {
+    for (const id of [null, undefined, '', 'repo-1::/workspace']) {
+      expect(hasRenderableTerminalWorktreeSurface({} as AppState, id)).toBe(false)
+    }
+  })
+})

--- a/src/shared/terminal-reveal-identity.ts
+++ b/src/shared/terminal-reveal-identity.ts
@@ -11,4 +11,5 @@ export type TerminalTabCreateReply = {
   title?: string
   identity?: TerminalRevealIdentity
   error?: string
+  errorCode?: string
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​306 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​306 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |

<!-- /orca-pr-loc -->

## ELI5

Creating an agent terminal in a hidden worktree could wait 10 seconds and leave an invisible tab. It now fails immediately with `worktree_not_renderable` and instructions to show the worktree or select a visible workspace.

## What Changed

- Check the renderer's exact worktree/folder surface catalog before activation, tab creation, or startup-command queuing, for both focused and background requests. Reuse the existing worktree index; preserve floating terminal hosting and host ownership routing.
- Retire a newly allocated tab through existing cleanup if a subsequent creation step throws, removing its queued command and unified-tab state without adding reopen history.
- Carry an optional error code through the existing reply and RPC error mapping. Legacy message-only replies still work.

## Why

A registered repository or detected worktree proves routing ownership, but does not prove a TerminalPane can mount. Rejecting before mutation prevents the missing-surface timeout and orphan without importing hidden worktrees implicitly. The general handle timeout is unchanged; catalog hydration that has not yet supplied a row requires a retry. STA-6846's navigation flow is outside this change.

## Linked Issue

Fixes STA-6470: https://linear.app/stably/issue/STA-6470

## Visual Proof

N/A — this changes the CLI/IPC admission and error result, with no new rendered UI. The real-store bridge regression tests verify no activation, no tab, and no queued command for rejected focused/background requests. Main-side fake-timer tests verify immediate rejection before the handle wait.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

On macOS with `ORCA_BACKGROUND_LAUNCH=1`: 70 tests passed across the renderer bridge, terminal-create surfacing, worktree route/surface, desktop create reply, and RPC error suites. Covers hidden external worktrees, duplicate repo IDs, folder rows, local/SSH/paired runtime surface membership, cleanup with a surviving sibling, and legacy reply compatibility. No native windows were opened; SSH/Windows execution was not exercised live.

`pnpm typecheck` and the full `pnpm lint` passed. Build left to CI.

## Review

- [x] Small, focused change; self-reviewed for correctness and compatibility.
- [x] Cross-platform and SSH ownership considered; no path, process, or transport opcode changes.
- [x] Agent skill upstream boundary: not applicable.
