### PR TITLE
fix(native-chat): suppress provider user echoes in Claude and Codex

### DIFF
--- a/src/main/claude/claude-structured-content-parts.test.ts
+++ b/src/main/claude/claude-structured-content-parts.test.ts
@@ -47,6 +47,92 @@ const BASE64_IMAGE = {
 }
 
 describe('Claude message content parts', () => {
+  it.each(['isMeta', 'isSynthetic', 'isCompactSummary'])(
+    'consumes %s skill context without a user bubble, fallback, or new turn',
+    (flag) => {
+      const state = sinkState()
+      const translator = createClaudeJournalTranslator({ sink: state.sink })
+      const event = userMessageWith({ type: 'text', text: '# Skill instructions' })
+      translator.handle({ ...event, message: { ...event.message, [flag]: true } })
+      expect(state.items).toEqual([])
+      expect(state.sink.publish).not.toHaveBeenCalled()
+    }
+  )
+
+  it('keeps tool results in an injected skill message', () => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+    const event = userMessageWith({
+      type: 'tool_result',
+      tool_use_id: 'skill-call',
+      content: 'Skill loaded'
+    })
+    translator.handle({ ...event, message: { ...event.message, isMeta: true } })
+    expect(state.items.map((item) => item.body)).toEqual([
+      expect.objectContaining({
+        kind: 'tool-call',
+        state: 'completed',
+        output: expect.objectContaining({ head: 'Skill loaded', truncated: false })
+      })
+    ])
+  })
+
+  it.each([
+    { content: '# Skill instructions' },
+    { content: [{ type: 'future_context', text: '# Skill instructions' }] },
+    {
+      content: [
+        { type: 'text', text: '[Image: source: /tmp/pasted.png]' },
+        { type: 'text', text: '# Skill instructions' }
+      ]
+    }
+  ])('does not surface injected content as text or a provider fallback: %j', ({ content }) => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+    const event = userMessageWith(null)
+    translator.handle({
+      ...event,
+      message: { ...event.message, isMeta: true, message: { role: 'user', content } }
+    })
+    expect(state.items).toEqual([])
+  })
+
+  it('does not render user echoes even without metadata flags', () => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+    for (const content of ['/example-skill', '# Skill instructions']) {
+      const event = userMessageWith(null)
+      translator.handle({
+        ...event,
+        message: { ...event.message, message: { role: 'user', content } }
+      })
+    }
+    expect(state.items.flatMap(({ body }) => (body.kind === 'message' ? body.blocks : []))).toEqual(
+      []
+    )
+  })
+
+  it('silently consumes unmarked user context with unknown content parts', () => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+    const event = userMessageWith({ type: 'future_context', text: 'Expanded instructions' })
+    translator.handle({ ...event, startsTurn: undefined })
+    expect(state.items).toEqual([])
+    expect(state.sink.publish).not.toHaveBeenCalled()
+  })
+
+  it('does not render injected image companions or start a turn', () => {
+    const state = sinkState()
+    const translator = createClaudeJournalTranslator({ sink: state.sink })
+    const event = userMessageWith(null)
+    const content = [{ type: 'text', text: '[Image: source: /tmp/pasted.png]' }]
+    translator.handle({
+      ...event,
+      message: { ...event.message, isMeta: true, message: { role: 'user', content } }
+    })
+    expect(state.items).toEqual([])
+  })
+
   it('does not leak a wire kind for a locally attached image', () => {
     const state = sinkState()
     const translator = createClaudeJournalTranslator({ sink: state.sink })
@@ -56,7 +142,7 @@ describe('Claude message content parts', () => {
     expect(providerRows(state.items)).toEqual([])
   })
 
-  it('still renders an image the CLI sends by url', () => {
+  it('does not render echoed image URLs', () => {
     const state = sinkState()
     const translator = createClaudeJournalTranslator({ sink: state.sink })
 
@@ -67,21 +153,29 @@ describe('Claude message content parts', () => {
     expect(providerRows(state.items)).toEqual([])
     expect(
       state.items.flatMap((item) => (item.body.kind === 'message' ? item.body.blocks : []))
-    ).toContainEqual({ type: 'image-ref', url: 'https://x.test/a.png' })
+    ).toEqual([])
   })
 
   it('says what is true for a content part it cannot render, not the wire kind', () => {
     const state = sinkState()
     const translator = createClaudeJournalTranslator({ sink: state.sink })
 
-    translator.handle(userMessageWith({ type: 'some_future_part', payload: { a: 1 } }))
+    const event = userMessageWith(null)
+    translator.handle({
+      ...event,
+      message: {
+        ...event.message,
+        type: 'assistant',
+        message: { role: 'assistant', content: [{ type: 'some_future_part', payload: { a: 1 } }] }
+      }
+    })
 
     const rows = providerRows(state.items)
     expect(rows).toHaveLength(1)
     // The kind stays on the row for debugging, behind the disclosure.
-    expect(rows[0].kind).toBe('message:user:content:some_future_part')
+    expect(rows[0].kind).toBe('message:assistant:content:some_future_part')
     // ...but the visible text is a sentence, not the opcode.
-    expect(rows[0].text).not.toContain('message:user:content')
+    expect(rows[0].text).not.toContain('message:assistant:content')
     expect(rows[0].text.toLowerCase()).toContain('claude')
   })
 
@@ -89,9 +183,18 @@ describe('Claude message content parts', () => {
     const state = sinkState()
     const translator = createClaudeJournalTranslator({ sink: state.sink })
 
-    translator.handle(
-      userMessageWith({ type: 'some_future_part', message: 'the server refused the upload' })
-    )
+    const event = userMessageWith(null)
+    translator.handle({
+      ...event,
+      message: {
+        ...event.message,
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'some_future_part', message: 'the server refused the upload' }]
+        }
+      }
+    })
 
     expect(providerRows(state.items)[0].text).toBe('the server refused the upload')
   })

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -49,6 +49,28 @@ function userReplayFrame(uuid: string, text: string): Record<string, unknown> {
 }
 
 describe('Claude structured dispatch image limits', () => {
+  it.each(['isMeta', 'isSynthetic', 'isCompactSummary'])(
+    'does not acknowledge a dispatch with %s context even when the client uuid matches',
+    async (flag) => {
+      const session = sessionFor()
+      const dispatched = dispatchClaudeTurn(
+        session,
+        { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: '/example' }]) },
+        1000
+      )
+      await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+      const sentUuid = session.dispatchWaiters[0]!.sentUuid
+      const replay = userReplayFrame(sentUuid, '/example')
+      expect(resolveClaudeReplayWaiter(session, { ...replay, [flag]: true })).toBe(false)
+      expect(session.dispatchWaiters).toHaveLength(1)
+      expect(resolveClaudeReplayWaiter(session, replay)).toBe(true)
+      await expect(dispatched).resolves.toMatchObject({
+        state: 'accepted',
+        providerIdentity: { uuid: sentUuid }
+      })
+    }
+  )
+
   it('recovers the active identity when a timed-out replay arrives late', async () => {
     const session = sessionFor()
     const dispatched = dispatchClaudeTurn(

--- a/src/main/claude/claude-structured-item-translation.ts
+++ b/src/main/claude/claude-structured-item-translation.ts
@@ -17,6 +17,7 @@ export type ClaudeMessageEnvelope = {
   /** Messages API id shared by every frame of one streamed assistant message. */
   messageId: string | null
   parentToolUseId: string | null
+  isInjectedUserTurn?: boolean
 }
 
 export type ClaudeToolUse = { id: string; name: string; input: unknown }
@@ -42,12 +43,16 @@ export function readClaudeMessageEnvelope(
   const sessionId = claudeText(frame.session_id)
   const uuid = claudeText(frame.uuid)
   const role = message?.role
+  const isInjectedUserTurn =
+    frame.type === 'user' &&
+    (frame.isMeta === true || frame.isSynthetic === true || frame.isCompactSummary === true)
   return sessionId && uuid && (role === 'assistant' || role === 'user')
     ? {
         sessionId,
         uuid,
         role,
         content: messageContent(message?.content),
+        isInjectedUserTurn,
         messageId: claudeText(message?.id),
         parentToolUseId: claudeText(frame.parent_tool_use_id)
       }
@@ -93,6 +98,9 @@ export function claudeMessageBody(envelope: ClaudeMessageEnvelope): AgentJournal
 }
 
 export function claudeHasReplayContent(envelope: ClaudeMessageEnvelope): boolean {
+  if (envelope.isInjectedUserTurn) {
+    return false
+  }
   return envelope.content.some((value) => {
     const part = claudeRecord(value)
     return part !== null && part.type !== 'tool_result'

--- a/src/main/claude/claude-structured-journal-translation.test.ts
+++ b/src/main/claude/claude-structured-journal-translation.test.ts
@@ -342,10 +342,7 @@ describe('Claude structured journal translation', () => {
       state.items.flatMap((item) =>
         item.body.kind === 'message' && item.body.role === 'user' ? [item.body.blocks] : []
       )
-    ).toEqual([
-      [{ type: 'text', text: 'Reply with exactly PROBE_OK_1 and nothing else.' }],
-      [{ type: 'text', text: '[Request interrupted by user]' }]
-    ])
+    ).toEqual([])
     expect(
       state.items.some((item) => item.body.kind === 'status' && !item.body.turnLifecycle)
     ).toBe(false)
@@ -521,10 +518,7 @@ describe('Claude structured journal translation', () => {
     const keyed = new Map(
       state.items.map((item) => [agentJournalItemKey(item.identity), item.body])
     )
-    expect(keyed.get('claude:claude-session:user-1')).toMatchObject({
-      kind: 'message',
-      role: 'user'
-    })
+    expect(keyed.has('claude:claude-session:user-1')).toBe(false)
     expect(keyed.get('orca:claude-tool%3Aclaude-session%3Atool-1')).toMatchObject({
       kind: 'tool-call',
       name: 'Bash',
@@ -683,7 +677,6 @@ describe('Claude structured journal translation', () => {
         'message:system:local_command_output',
         'message:system:command_started',
         'message:result',
-        'message:user:content:document',
         'control_request:future_control'
       ])
     )

--- a/src/main/claude/claude-structured-journal-translation.ts
+++ b/src/main/claude/claude-structured-journal-translation.ts
@@ -130,7 +130,15 @@ export function createClaudeJournalTranslator(
       return false
     }
     let changed = false
-    const body = claudeMessageBody(envelope)
+    // User bubbles belong to the submitted message; SDK user frames carry echoes and tool results.
+    const outputEnvelope =
+      envelope.role === 'user'
+        ? {
+            ...envelope,
+            content: envelope.content.filter((part) => claudeRecord(part)?.type === 'tool_result')
+          }
+        : envelope
+    const body = claudeMessageBody(outputEnvelope)
     // The final frame of a streamed block lands on the block's identity, not its own uuid.
     const identity =
       (body && envelope.role === 'assistant' ? streamedBlocks.reconcile(envelope) : null) ??
@@ -140,7 +148,7 @@ export function createClaudeJournalTranslator(
       deps.sink.appendItem(identity, body)
       changed = true
     }
-    for (const tool of claudeToolUses(envelope)) {
+    for (const tool of claudeToolUses(outputEnvelope)) {
       tools.set(tool.id, tool)
       deps.sink.appendItem(
         claudeToolIdentity(envelope.sessionId, tool.id),
@@ -162,7 +170,7 @@ export function createClaudeJournalTranslator(
       tools.delete(result.toolUseId)
       changed = true
     }
-    const thinking = claudeThinkingText(envelope)
+    const thinking = claudeThinkingText(outputEnvelope)
     if (thinking) {
       deps.sink.appendItem(claudeThinkingIdentity(envelope.sessionId, envelope.uuid), {
         kind: 'status',
@@ -170,7 +178,7 @@ export function createClaudeJournalTranslator(
       })
       changed = true
     }
-    const unhandledContent = envelope.content.filter((part) => !isModeledClaudeContent(part))
+    const unhandledContent = outputEnvelope.content.filter((part) => !isModeledClaudeContent(part))
     for (const part of unhandledContent) {
       const partType = claudeText(claudeRecord(part)?.type) ?? 'unknown'
       providerFallback.append(

--- a/src/main/codex/codex-structured-journal-items.ts
+++ b/src/main/codex/codex-structured-journal-items.ts
@@ -60,7 +60,10 @@ export class CodexJournalItems {
     return this.details.get(codexStructuredItemKey(threadId, itemId)) ?? null
   }
 
-  handle(event: { threadId: string; method: string; params: unknown }): CodexItemTranslation {
+  handle(
+    event: { threadId: string; method: string; params: unknown },
+    source: 'live' | 'history' = 'live'
+  ): CodexItemTranslation {
     const params =
       typeof event.params === 'object' && event.params !== null
         ? (event.params as Record<string, unknown>)
@@ -71,6 +74,10 @@ export class CodexJournalItems {
     }
     const turnId = readCodexTurnId(event.params) ?? this.activeTurn(event.threadId)
     const identity = this.identityFor(event.threadId, turnId, item)
+    // Count echoes for stable resume ordinals, but user bubbles come from submissions.
+    if (source === 'live' && item.type === 'userMessage') {
+      return { handled: true, admission: CODEX_JOURNAL_ADMITTED }
+    }
     const translated = codexJournalItem(item)
     const command = readCodexJournalString(item, 'command')
     if (command) {

--- a/src/main/codex/codex-structured-journal-translation-settlement.test.ts
+++ b/src/main/codex/codex-structured-journal-translation-settlement.test.ts
@@ -652,7 +652,7 @@ describe('codex journal translation', () => {
 
     translator.handle(TURN_STARTED)
     translator.handle(
-      notification('item/completed', { item: { type: 'userMessage', id: 'item-0', text: 'one' } })
+      notification('item/completed', { item: { type: 'agentMessage', id: 'item-0', text: 'one' } })
     )
     translator.handle(notification('turn/completed', { turn: { id: TURN_ID } }))
     translator.handle(
@@ -662,7 +662,7 @@ describe('codex journal translation', () => {
     )
     translator.handle(notification('turn/started', { turn: { id: 'turn-2' } }))
     translator.handle(
-      notification('item/completed', { item: { type: 'userMessage', id: 'item-2', text: 'two' } })
+      notification('item/completed', { item: { type: 'agentMessage', id: 'item-2', text: 'two' } })
     )
 
     expect(tap.rows.map((row) => row.key)).toEqual([
@@ -679,7 +679,7 @@ describe('codex journal translation', () => {
     translator.handle(
       notification('item/completed', {
         turnId: 'turn-9',
-        item: { type: 'userMessage', id: 'item-0', text: 'late' }
+        item: { type: 'agentMessage', id: 'item-0', text: 'late' }
       })
     )
 

--- a/src/main/codex/codex-structured-journal-translation-streams.test.ts
+++ b/src/main/codex/codex-structured-journal-translation-streams.test.ts
@@ -157,7 +157,7 @@ describe('codex journal translation', () => {
 
     translator.handle(TURN_STARTED)
     translator.handle(
-      notification('item/completed', { item: { type: 'userMessage', id: 'item-0', text: 'hi' } })
+      notification('item/completed', { item: { type: 'agentMessage', id: 'item-0', text: 'hi' } })
     )
 
     expect(tap.publishes()).toBe(1)
@@ -520,7 +520,7 @@ describe('codex journal translation', () => {
     expect(timeline).toEqual([])
   })
 
-  it('projects only user and assistant content for a complete turn with hooks', () => {
+  it('projects assistant content without provider user echoes for a complete turn with hooks', () => {
     const { translator, tap } = translatorWith()
 
     translator.handle(notification('thread/started', { thread: { id: THREAD_ID } }))
@@ -552,7 +552,6 @@ describe('codex journal translation', () => {
       }))
     )
     expect(timeline.map(({ role, blocks }) => ({ role, blocks }))).toEqual([
-      { role: 'user', blocks: [{ type: 'text', text: 'hi' }] },
       { role: 'assistant', blocks: [{ type: 'text', text: 'hello' }] }
     ])
   })

--- a/src/main/codex/codex-structured-journal-translation.test.ts
+++ b/src/main/codex/codex-structured-journal-translation.test.ts
@@ -302,7 +302,7 @@ describe('codex journal translation', () => {
     ).toBe('idle')
   })
 
-  it('journals a user turn and the assistant answer under durable codex keys', () => {
+  it('counts a user echo without rendering it and preserves the assistant ordinal', () => {
     const { translator, tap } = translatorWith()
 
     translator.handle(TURN_STARTED)
@@ -317,15 +317,35 @@ describe('codex journal translation', () => {
       })
     )
 
-    expect(tap.rows.map((row) => row.key)).toEqual([
-      'codex:thread-abc:turn-1:0',
-      'codex:thread-abc:turn-1:1'
-    ])
-    expect(tap.rows[1]?.body).toEqual({
+    expect(tap.rows.map((row) => row.key)).toEqual(['codex:thread-abc:turn-1:1'])
+    expect(tap.rows[0]?.body).toEqual({
       kind: 'message',
       role: 'assistant',
       blocks: [{ type: 'text', text: 'hello' }]
     })
+  })
+
+  it('suppresses both echo lifecycle frames, including skill and unknown parts', () => {
+    const { translator, tap } = translatorWith()
+    translator.handle(TURN_STARTED)
+    const item = {
+      type: 'userMessage',
+      id: 'echo',
+      content: [
+        { type: 'text', text: 'Expanded instructions' },
+        { type: 'skill', name: 'example', path: '/tmp/SKILL.md' },
+        { type: 'future_context', text: 'More context' }
+      ]
+    }
+    translator.handle(notification('item/started', { item }))
+    translator.handle(notification('item/completed', { item }))
+    expect(tap.rows).toEqual([])
+    translator.handle(
+      notification('item/completed', {
+        item: { type: 'agentMessage', id: 'answer', text: 'Done' }
+      })
+    )
+    expect(tap.rows.map((row) => row.key)).toEqual(['codex:thread-abc:turn-1:1'])
   })
 
   it('folds streamed deltas into one snapshot row on the same key the item started under', () => {

--- a/src/main/codex/codex-structured-journal-translation.ts
+++ b/src/main/codex/codex-structured-journal-translation.ts
@@ -64,7 +64,7 @@ export function createCodexJournalTranslator(
         currentTurnIds: activeTurns.byThread,
         ordinals: items.ordinals,
         handleItem: (event) => {
-          const translated = items.handle(event)
+          const translated = items.handle(event, 'history')
           return translated.handled
             ? translated.admission
             : { accepted: false, reason: 'untranslated' }

--- a/src/main/codex/codex-structured-session-adapter.test.ts
+++ b/src/main/codex/codex-structured-session-adapter.test.ts
@@ -285,7 +285,7 @@ describe('CodexStructuredSessionAdapter.acquire', () => {
     })
 
     codex.connections[0].handlers.onNotification?.('item/completed', {
-      item: { type: 'userMessage', id: 'message-1', text: 'hello' }
+      item: { type: 'agentMessage', id: 'message-1', text: 'hello' }
     })
 
     await vi.waitFor(() => {

--- a/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.test.ts
@@ -207,10 +207,45 @@ describe('submission and dispatch state machine', () => {
     const items = renderJournalState(state).items
     expect(items).toHaveLength(1)
     expect(items[0]?.itemId).toBe(agentJournalSubmissionKey('cm_1'))
-    // The echo updates content in place; the bubble keeps its original slot.
+    // The echo advances the revision; the submitted bubble keeps its original slot.
     expect(items[0]?.sequence).toBe(1)
     expect(items[0]?.revision).toBe(1)
   })
+
+  it.each(['codex:thread-1:turn-1:0', 'claude:session-1:user-1'])(
+    'preserves submitted text and attachments when %s is restored',
+    (providerItemId) => {
+      const body: AgentJournalMessageItem = {
+        kind: 'message',
+        role: 'user',
+        blocks: [
+          { type: 'text', text: '/example-skill inspect this' },
+          { type: 'image-ref', path: '/tmp/original.png' }
+        ]
+      }
+      const state = fold([
+        { ...submission, body, payloadFingerprint: sendFingerprint(body) },
+        {
+          kind: 'dispatch',
+          clientMessageId: 'cm_1',
+          state: 'accepted',
+          providerItemId,
+          reason: null,
+          ...base(2)
+        },
+        {
+          kind: 'item',
+          itemId: providerItemId,
+          revision: 1,
+          body: userText('# Expanded skill instructions'),
+          ...base(3)
+        }
+      ])
+      expect(renderJournalState(state).items).toEqual([
+        expect.objectContaining({ itemId: agentJournalSubmissionKey('cm_1'), body, revision: 1 })
+      ])
+    }
+  )
 
   it('adopts a provider echo that arrives before dispatch settles', () => {
     const body = userText('early echo')

--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -190,7 +190,17 @@ function upsertItem(
   // so letting a revision advance it makes the row jump past everything that
   // landed in between — the provider's own echo of a send revises the submission
   // row, which relocated the user's bubble below later rows.
-  state.items.set(itemId, { ...next, sequence: existing.sequence, observedAt: existing.observedAt })
+  const submitted =
+    existing.body.kind === 'message' &&
+    existing.body.role === 'user' &&
+    parseAgentJournalItemKey(itemId)?.provider === 'orca'
+  state.items.set(itemId, {
+    ...next,
+    // Provider history may normalize text or omit local attachments from the original send.
+    body: submitted ? existing.body : next.body,
+    sequence: existing.sequence,
+    observedAt: existing.observedAt
+  })
   state.tombstones.delete(itemId)
 }
 

--- a/src/main/native-chat/transcript-line-decoders-codex-skill-context.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex-skill-context.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
+
+describe('Codex transcript skill context', () => {
+  it.each(['<skill>', ' \n<SKILL>'])(
+    'drops expanded skill response items beginning with %j',
+    (prefix) => {
+      const message = {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'text', text: `${prefix}\n<name>example</name>\nInstructions\n</skill>` }]
+      }
+      for (const record of [message, { type: 'response_item', payload: message }]) {
+        expect(decodeCodexTranscriptLine(JSON.stringify(record), 'context')).toBeNull()
+      }
+    }
+  )
+
+  it.each(['$example', 'Explain <skill> tags', '<skillset>user XML</skillset>'])(
+    'preserves the actual user prompt %j',
+    (text) => {
+      expect(
+        decodeCodexTranscriptLine(
+          JSON.stringify({
+            type: 'response_item',
+            payload: {
+              type: 'message',
+              role: 'user',
+              content: [{ type: 'text', text }]
+            }
+          }),
+          'user'
+        )?.blocks
+      ).toEqual([{ type: 'text', text }])
+    }
+  )
+
+  it('preserves assistant explanations containing the skill wrapper', () => {
+    expect(
+      decodeCodexTranscriptLine(
+        JSON.stringify({
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'text', text: '<skill>example</skill>' }]
+          }
+        }),
+        'assistant'
+      )?.role
+    ).toBe('assistant')
+  })
+})

--- a/src/main/native-chat/transcript-line-decoders-codex-skill-context.test.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex-skill-context.test.ts
@@ -2,6 +2,36 @@ import { describe, expect, it } from 'vitest'
 import { decodeCodexTranscriptLine } from './transcript-line-decoders-codex'
 
 describe('Codex transcript skill context', () => {
+  it.each(['message', 'response_item'])(
+    'preserves prompt text and images beside a skill expansion in %s',
+    (type) => {
+      const message = {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Inspect this image' },
+          { type: 'text', text: '<skill>\nInstructions\n</skill>' },
+          { type: 'image', url: 'https://example.test/image.png' }
+        ]
+      }
+      const record = type === 'message' ? message : { type, payload: message }
+      expect(decodeCodexTranscriptLine(JSON.stringify(record), 'mixed')?.blocks).toEqual([
+        { type: 'text', text: 'Inspect this image' },
+        { type: 'image-ref', url: 'https://example.test/image.png' }
+      ])
+    }
+  )
+
+  it('preserves an authoritative user event containing a literal skill wrapper', () => {
+    const text = '<skill>Explain this XML</skill>'
+    expect(
+      decodeCodexTranscriptLine(
+        JSON.stringify({ type: 'event_msg', payload: { type: 'user_message', message: text } }),
+        'submitted'
+      )?.blocks
+    ).toEqual([{ type: 'text', text }])
+  })
+
   it.each(['<skill>', ' \n<SKILL>'])(
     'drops expanded skill response items beginning with %j',
     (prefix) => {

--- a/src/main/native-chat/transcript-line-decoders-codex.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex.ts
@@ -48,10 +48,9 @@ function codexUnwrappedResponseItem(
     return codexResponseItem(record, id, timestamp)
   }
   const role = record.role === 'assistant' ? 'assistant' : record.role === 'user' ? 'user' : null
-  const blocks = codexTurnItemBlocks(record.content)
-  if (role === 'user' && isSkillContext(blocks)) {
-    return null
-  }
+  const decodedBlocks = codexTurnItemBlocks(record.content)
+  const blocks =
+    role === 'user' ? decodedBlocks.filter((block) => !isSkillContext(block)) : decodedBlocks
   return role && blocks.length > 0 ? { id, role, blocks, timestamp, source: 'transcript' } : null
 }
 
@@ -66,10 +65,9 @@ function codexResponseItem(
     if (!role) {
       return null
     }
-    const blocks = claudeContentBlocks(payload.content)
-    if (role === 'user' && isSkillContext(blocks)) {
-      return null
-    }
+    const decodedBlocks = claudeContentBlocks(payload.content)
+    const blocks =
+      role === 'user' ? decodedBlocks.filter((block) => !isSkillContext(block)) : decodedBlocks
     if (blocks.length === 0) {
       return null
     }
@@ -115,11 +113,8 @@ function codexResponseItem(
 }
 
 // Explicit skill expansions are model context, not the user's recorded prompt.
-function isSkillContext(blocks: NativeChatBlock[]): boolean {
-  return blocks.some(
-    (block) =>
-      block.type === 'text' && block.text.trimStart().slice(0, 7).toLowerCase() === '<skill>'
-  )
+function isSkillContext(block: NativeChatBlock): boolean {
+  return block.type === 'text' && block.text.trimStart().slice(0, 7).toLowerCase() === '<skill>'
 }
 
 function codexEventMessage(

--- a/src/main/native-chat/transcript-line-decoders-codex.ts
+++ b/src/main/native-chat/transcript-line-decoders-codex.ts
@@ -49,6 +49,9 @@ function codexUnwrappedResponseItem(
   }
   const role = record.role === 'assistant' ? 'assistant' : record.role === 'user' ? 'user' : null
   const blocks = codexTurnItemBlocks(record.content)
+  if (role === 'user' && isSkillContext(blocks)) {
+    return null
+  }
   return role && blocks.length > 0 ? { id, role, blocks, timestamp, source: 'transcript' } : null
 }
 
@@ -64,6 +67,9 @@ function codexResponseItem(
       return null
     }
     const blocks = claudeContentBlocks(payload.content)
+    if (role === 'user' && isSkillContext(blocks)) {
+      return null
+    }
     if (blocks.length === 0) {
       return null
     }
@@ -106,6 +112,14 @@ function codexResponseItem(
     }
   }
   return null
+}
+
+// Explicit skill expansions are model context, not the user's recorded prompt.
+function isSkillContext(blocks: NativeChatBlock[]): boolean {
+  return blocks.some(
+    (block) =>
+      block.type === 'text' && block.text.trimStart().slice(0, 7).toLowerCase() === '<skill>'
+  )
 }
 
 function codexEventMessage(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​286 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​255 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |

<!-- /orca-pr-loc -->

## ELI5

Loading a skill could make native chat display its full instructions as though the user had typed them. Claude and Codex now use Orca's saved submissions for live user bubbles.

## What Changed

- Consume Claude user frames for tool results and turn bookkeeping without displaying echoed text, images, or unknown context parts.
- Suppress live Codex user echoes while preserving message ordinals and historical user messages on resume.
- Preserve submitted text and attachments when provider history updates an accepted submission.
- Exclude expanded skill context from raw Codex response-item history.

## Why

Provider user-role frames can contain injected instructions rather than human input. Orca already persists each submission before dispatch, so those frames should not create or replace user bubbles.

## Linked Issue

Fixes #19135

## Visual Proof

Electron QA on isolated profile, CDP-only hidden renderer, head `80635b02f8707f6a6a56a87623b2c64f7a1fd25f` (`stonefish @ brennanb2025/fix-native-chat-skill`). Throwaway folder workspace. No Dock/Accessibility. Screenshots not committed.

### Claude native chat — skill load
Composer sent `/qa-echo-skill inspect the attached image and README.md. Marker QA-CLAUDE-PROMPT-19135.` plus a pasted image. User bubble kept that prompt and attachment. Expanded marker `EXPANDED-SKILL-INSTRUCTIONS-QA-MARKER-19135` never appeared. Skill + Bash tool activity stayed visible. Remount via Show terminal → Show chat view preserved the same history.

![01-claude-empty-chat.png](https://github.com/user-attachments/assets/d821810a-364a-4df9-8611-4f7ba670618b)
![02-claude-skill-picker.png](https://github.com/user-attachments/assets/7eac146f-62c7-464e-9c56-119081fd8a27)
![03-claude-composer-prompt-attachment.png](https://github.com/user-attachments/assets/de1486a2-7454-4d04-b800-3aeb7a6fbcfa)
![04-claude-transcript-skill-load.png](https://github.com/user-attachments/assets/1ab4586b-9254-4588-aef6-561741606912)
![05-claude-history-after-toggle.png](https://github.com/user-attachments/assets/088a2e20-ef97-4d59-9c56-be21907e45f8)

### Codex native chat — skill load
Composer sent `$qa-echo-skill inspect the attached image and README.md. Marker QA-CODEX-PROMPT-19135.` plus a pasted image. User bubble kept that prompt and attachment. No expanded instructions and no `<skill>` user bubble. `exec` tool activity stayed visible. Remount preserved history.

![06-codex-empty-chat.png](https://github.com/user-attachments/assets/e4b1914f-6bf6-42d1-ad6d-9832dd9ef6ab)
![07-codex-skill-picker.png](https://github.com/user-attachments/assets/b8a962b6-3462-40fb-9db6-c6774fd46c13)
![08-codex-composer-prompt-attachment.png](https://github.com/user-attachments/assets/7a7a380a-eacc-4be1-8c88-f5b7c1f8d380)
![09-codex-transcript-skill-load.png](https://github.com/user-attachments/assets/e21a5a65-fa58-4c58-874e-934c853aed6b)
![10-codex-history-after-toggle.png](https://github.com/user-attachments/assets/8f5cb3f8-821e-4799-bfdd-e40c35fa08bf)



### Full restart QA — final head 80635b02f8

A fresh isolated profile with a persistently registered folder-backed group (`parentPath` set) passes full app/provider stop and relaunch for Claude and Codex. Both resume the same provider session/thread on new processes, accept follow-ups through the real composer, and recall the prior README marker and image colors. The earlier missing-folder/no-live-owner result came from an invalid fixture and is superseded by this run.

Each original user submission still has exactly one text block and one image reference, with identical SHA-256 body hashes before restart and after follow-up; each journal has exactly the original submission plus one follow-up. Claude's registered Skill tool completed successfully. No expanded skill instructions or duplicate original user bubbles appeared.

**Remaining baseline limitation:** pasted-image thumbnails become “Pasted image” placeholders after full restart, although the files and journal image references persist. The local clipboard temp-file grant lives in an in-memory filesystem authorization set; those paths are unchanged from the merge-base. This run does not claim thumbnail restoration passed.

Before restart (Claude):
![claude-before-restart.png](https://github.com/user-attachments/assets/e3371bf8-623d-4b1b-ae1a-f68be21f8bcd)

After full restart and successful composer follow-ups:
![claude-after-followup.png](https://github.com/user-attachments/assets/d7323853-4aeb-4ca3-8062-e61446670154)

![codex-after-followup.png](https://github.com/user-attachments/assets/342fad97-266a-4e2d-aa7c-42d8dee22611)

### Coverage limits

Paired remote/older-client and Windows/Linux/mobile UI flows were not manually exercised. Platform and wire boundaries were reviewed; cross-version wire and Windows packaging checks passed in CI. These limits do not identify an additional blocker for this platform-neutral change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

At reviewed head `80635b02f8`:
- 348 focused tests across 36 files passed. Two new regression tests fail against the initial PR decoder and pass with block-level skill filtering.
- All 5 real-Claude integration tests passed. The earlier startup timeouts did not recur; no claim is made that they were baseline failures.
- `pnpm tc:node`, changed-code quality, commit lint/format hooks, and `git diff --check` passed. Full `pnpm tc` passed before the two-file review fix.
- Opening readiness also passed 233 focused/boundary tests; these overlap the focused suite above.
- Real local Claude and Codex skill loads passed through the hidden Electron renderer, including original prompt/attachment presence, tool activity, and terminal/chat remount history. Screenshots above are from the final head, not before/after builds.

Full app/provider restart and composer follow-ups passed for both providers, with the baseline thumbnail limitation documented above. [Final-head CI](https://github.com/stablyai/orca/actions/runs/34064387626) passed, including all eight test shards, typecheck, static analysis, cross-version wire checks, and packaging including Windows.

## Review

Two review/fix rounds completed at the same model and effort; the second pass is clean. One focused fix preserves genuine text and images beside a skill-context block in Codex history. Opening and closing readiness audits completed; closing readiness passes for the reviewed local flows with no remaining code or performance findings. The validation limits above remain explicit.

## Agent skill upstream boundary

- [x] This change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new RPC fields or opcodes. Filtering runs in the provider host, including remote hosts; an older remote host retains its existing behavior until updated. No platform-specific execution or workspace-path assumptions were introduced. Previously saved standalone erroneous bubbles are not migrated.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Final-head rendered screenshots attached; pre-fix behavior reproduced by regression tests
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Final-head CI passed: static analysis, typecheck, full test shards, wire compatibility, and packaging
