### PR TITLE
fix: restore the full sidebar agent row for structured native chat

### DIFF
--- a/src/main/native-chat/agent-session-wire/structured-agent-session-option-settlement.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-option-settlement.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { computeAgentSessionPayloadFingerprint } from '../../../shared/agent-session-mutation-envelope'
-import type { AgentSessionMutationEnvelope } from '../../../shared/agent-session-wire'
+import type {
+  AgentSessionMutationEnvelope,
+  AgentSessionStatusEvent
+} from '../../../shared/agent-session-wire'
 import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
 import { AgentSessionOptionRejectedError } from './structured-agent-session-option-error'
@@ -212,6 +215,39 @@ afterEach(async () => {
 })
 
 describe('structured session options and close', () => {
+  it('publishes an acknowledged model without waiting for journal traffic', async () => {
+    const body = {
+      kind: 'message' as const,
+      role: 'user' as const,
+      blocks: [{ type: 'text' as const, text: 'first task' }]
+    }
+    await host.send(CALLER, {
+      envelope: envelope('agentSession.send', { body }),
+      body
+    })
+    const events: AgentSessionStatusEvent[] = []
+    host.subscribeStatus({ id: 'session-list', emit: (event) => events.push(event) })
+    expect(events).toEqual([
+      {
+        type: 'snapshot',
+        sessions: [expect.objectContaining({ status: 'idle', model: DEFAULT_MODEL })]
+      }
+    ])
+    const fields = { key: 'model', value: PICKED_MODEL }
+
+    await host.setOption(CALLER, {
+      envelope: envelope('agentSession.setOption', fields),
+      ...fields
+    })
+
+    expect(events.slice(1)).toEqual([
+      {
+        type: 'status',
+        session: expect.objectContaining({ sessionId: SESSION, model: PICKED_MODEL })
+      }
+    ])
+  })
+
   it('settles a pre-mutation rejection so a fresh retry can succeed', async () => {
     optionFailure = new AgentSessionOptionRejectedError('model list unavailable')
     const fields = { key: 'model', value: PICKED_MODEL }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import type { AgentSessionRecord } from '../../../shared/agent-session-record'
 import type { AgentSessionStatusEvent } from '../../../shared/agent-session-wire'
 import { createTrackedJournalOpener } from '../agent-session-journal/journal-store-test-open'
 import { StructuredAgentSessionStatusFeed } from './structured-agent-session-status-feed'
@@ -52,7 +53,10 @@ function indexed(session: { journal: Awaited<ReturnType<typeof openJournal>> }) 
   }
 }
 
-function feedFor(sessions: Map<string, { journal: Awaited<ReturnType<typeof openJournal>> }>) {
+function feedFor(
+  sessions: Map<string, { journal: Awaited<ReturnType<typeof openJournal>> }>,
+  record: Partial<AgentSessionRecord> | null = null
+) {
   let now = 1_000
   const feed = new StructuredAgentSessionStatusFeed({
     sessions: {
@@ -66,7 +70,7 @@ function feedFor(sessions: Map<string, { journal: Awaited<ReturnType<typeof open
         }
       }
     } as unknown as ReadonlyMap<string, ReturnType<typeof indexed>>,
-    getRecord: () => null,
+    getRecord: () => record as AgentSessionRecord | null,
     now: () => (now += 1)
   })
   const events: AgentSessionStatusEvent[] = []
@@ -130,6 +134,43 @@ describe('StructuredAgentSessionStatusFeed', () => {
       session: expect.objectContaining({ sessionId: SESSION, status: 'idle' })
     })
     expect(events).toHaveLength(3)
+  })
+
+  it('carries the record model and the running tool line the sidebar row shows', async () => {
+    const journal = await openJournal()
+    const { feed, events } = feedFor(new Map([[SESSION, { journal }]]), {
+      options: { model: 'gpt-5-codex' },
+      providerHandleChain: []
+    })
+    await journal.appendItem(
+      USER_IDENTITY,
+      { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'run the tests' }] },
+      { fence: 1 }
+    )
+    await journal.appendItem(
+      TURN_IDENTITY,
+      { kind: 'status', text: 'Working', turnLifecycle: { turnId: 'turn-1', state: 'running' } },
+      { fence: 1 }
+    )
+    feed.publish(SESSION)
+    expect(events.at(-1)).toEqual({
+      type: 'status',
+      session: expect.objectContaining({ status: 'working', model: 'gpt-5-codex' })
+    })
+
+    await journal.appendItem(
+      { ...USER_IDENTITY, ordinal: 2 },
+      { kind: 'tool-call', name: 'shell', input: { command: 'pnpm test' }, state: 'running' },
+      { fence: 1 }
+    )
+    feed.publish(SESSION)
+
+    // A tool boundary changes nothing else about the session, so only comparing the new
+    // fields keeps it from being deduped away as an unchanged projection.
+    expect(events.at(-1)).toEqual({
+      type: 'status',
+      session: expect.objectContaining({ toolName: 'shell', toolInput: 'pnpm test' })
+    })
   })
 
   it('reports a pending approval as attention', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
@@ -12,6 +12,8 @@
 
 import { agentProviderSessionsEqual } from '../../../shared/agent-session-resume'
 import type { AgentSessionRecord } from '../../../shared/agent-session-record'
+import { normalizeOptionalField } from '../../../shared/agent-status-field-normalization'
+import { AGENT_MODEL_MAX_LENGTH } from '../../../shared/agent-status-types'
 import type {
   AgentSessionStatusEvent,
   AgentSessionStatusSummary
@@ -42,6 +44,10 @@ function summariesEqual(a: AgentSessionStatusSummary, b: AgentSessionStatusSumma
     a.agent === b.agent &&
     a.status === b.status &&
     a.latestPrompt === b.latestPrompt &&
+    a.model === b.model &&
+    a.toolName === b.toolName &&
+    a.toolInput === b.toolInput &&
+    a.lastAssistantMessage === b.lastAssistantMessage &&
     agentProviderSessionsEqual(undefined, a.providerSession, b.providerSession)
   )
 }
@@ -99,14 +105,17 @@ export class StructuredAgentSessionStatusFeed {
   ): AgentSessionStatusSummary {
     // An unreadable journal projects as "no turn": the chat itself shows the reset.
     const items = journal.isReadOnly ? [] : journal.snapshot().items
-    const providerSession = structuredAgentSessionProviderSessionMetadata(
-      this.deps.getRecord(sessionId)
-    )
+    const record = this.deps.getRecord(sessionId)
+    const providerSession = structuredAgentSessionProviderSessionMetadata(record)
+    // The journal has no model: the record's acknowledged options are where an owner
+    // handoff or a mid-session switch lands, so the row follows whichever is in force.
+    const model = normalizeOptionalField(record?.options?.model, AGENT_MODEL_MAX_LENGTH)
     return {
       sessionId,
       workspaceId: session.params.location.workspaceId,
       agent: session.params.provider,
       ...projectStructuredAgentSessionStatusSummary(items),
+      ...(model ? { model } : {}),
       ...(providerSession ? { providerSession } : {}),
       updatedAt: this.deps.now()
     }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-turns-options.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-turns-options.ts
@@ -23,5 +23,6 @@ export async function performSetOption(
     throw error
   }
   await ctx.persistOptions(applied ?? { [input.key]: input.value })
+  ctx.publish()
   return { ok: true, value: { ...input, ...(applied ? { options: { ...applied } } : {}) } }
 }

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.test.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.test.tsx
@@ -226,6 +226,71 @@ describe('StructuredAgentSessionStatusBridge', () => {
     expect(statuses()).toEqual([expect.objectContaining({ state: 'blocked' })])
   })
 
+  it('carries the model, the running tool line, and the last assistant message', async () => {
+    render(<StructuredAgentSessionStatusBridge />)
+    await waitFor(() => expect(mocks.subscribeStatus).toHaveBeenCalledOnce())
+
+    act(() =>
+      feed().emit({
+        type: 'snapshot',
+        sessions: [
+          summary({
+            model: 'gpt-5-codex',
+            toolName: 'shell',
+            toolInput: 'pnpm test',
+            lastAssistantMessage: 'Running the suite now.'
+          })
+        ]
+      })
+    )
+    expect(statuses()).toEqual([
+      expect.objectContaining({
+        model: 'gpt-5-codex',
+        toolName: 'shell',
+        toolInput: 'pnpm test',
+        lastAssistantMessage: 'Running the suite now.'
+      })
+    ])
+
+    // The tool line describes live work, so a settled turn that omits it must clear it.
+    act(() =>
+      feed().emit({
+        type: 'status',
+        session: summary({
+          status: 'idle',
+          updatedAt: 2,
+          model: 'gpt-5-codex',
+          lastAssistantMessage: 'Suite is green.'
+        })
+      })
+    )
+    expect(statuses()).toEqual([
+      expect.objectContaining({
+        state: 'done',
+        model: 'gpt-5-codex',
+        lastAssistantMessage: 'Suite is green.'
+      })
+    ])
+    expect(statuses()[0]?.toolName).toBeUndefined()
+    expect(statuses()[0]?.toolInput).toBeUndefined()
+
+    // Only the message moves here, so the row updates only if the guard compares it.
+    act(() =>
+      feed().emit({
+        type: 'status',
+        session: summary({
+          status: 'idle',
+          updatedAt: 3,
+          model: 'gpt-5-codex',
+          lastAssistantMessage: 'Suite is green — 412 passed.'
+        })
+      })
+    )
+    expect(statuses()).toEqual([
+      expect.objectContaining({ lastAssistantMessage: 'Suite is green — 412 passed.' })
+    ])
+  })
+
   it('shows no status before a persisted turn', async () => {
     render(<StructuredAgentSessionStatusBridge />)
     await waitFor(() => expect(mocks.subscribeStatus).toHaveBeenCalledOnce())

--- a/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.tsx
+++ b/src/renderer/src/components/native-chat/StructuredAgentSessionStatusBridge.tsx
@@ -75,6 +75,12 @@ function projectStatus(tab: StructuredTab, summary: AgentSessionStatusSummary | 
           : 'done',
     prompt: summary.latestPrompt,
     agentType: tab.agentSessionAgent,
+    // The host projects these from the journal so the row reads like a hook-reported one:
+    // the running tool while a turn is live, the agent's last words once it settles.
+    ...(summary.model ? { model: summary.model } : {}),
+    ...(summary.toolName ? { toolName: summary.toolName } : {}),
+    ...(summary.toolInput ? { toolInput: summary.toolInput } : {}),
+    ...(summary.lastAssistantMessage ? { lastAssistantMessage: summary.lastAssistantMessage } : {}),
     sessionBoundary: summary.status === 'idle'
   } as const
   const current = store.agentStatusByPaneKey?.[paneKey]
@@ -82,6 +88,11 @@ function projectStatus(tab: StructuredTab, summary: AgentSessionStatusSummary | 
     current?.state === desired.state &&
     current.prompt === desired.prompt &&
     current.agentType === desired.agentType &&
+    // A row keeps the last model it was told about, so only a reported one can differ.
+    (summary.model === undefined || current.model === summary.model) &&
+    current.toolName === summary.toolName &&
+    current.toolInput === summary.toolInput &&
+    current.lastAssistantMessage === summary.lastAssistantMessage &&
     current.sessionBoundary === desired.sessionBoundary &&
     current.terminalTitle === tab.label &&
     current.tabId === tab.id &&

--- a/src/shared/agent-session-wire.ts
+++ b/src/shared/agent-session-wire.ts
@@ -178,6 +178,13 @@ export type AgentSessionStatusSummary = {
   /** Null until the journal holds a persisted user or assistant message. */
   status: StructuredAgentSessionProjectedStatus | null
   latestPrompt: string
+  /** Provider model in force for the next turn; absent until the host has read the options. */
+  model?: string
+  /** The tool the running turn is inside. Absent unless `status` is 'working'. */
+  toolName?: string
+  toolInput?: string
+  /** Preview of the newest assistant prose, so a settled row says what the agent said. */
+  lastAssistantMessage?: string
   providerSession?: AgentProviderSessionMetadata
   updatedAt: number
 }

--- a/src/shared/structured-agent-session-projection.test.ts
+++ b/src/shared/structured-agent-session-projection.test.ts
@@ -86,15 +86,15 @@ describe('structured agent session status projection', () => {
       role: 'user',
       blocks: [{ type: 'text', text: 'look at the sidebar' }]
     })
-    const said = item('said', 2, {
-      kind: 'message',
-      role: 'assistant',
-      blocks: [{ type: 'text', text: 'Reading the card first.' }]
-    })
-    const running = item('running', 3, {
+    const running = item('running', 2, {
       kind: 'status',
       text: 'Working',
       turnLifecycle: { turnId: 'turn-1', state: 'running' }
+    })
+    const said = item('said', 3, {
+      kind: 'message',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'Reading the card first.' }]
     })
     const tool = item('tool', 4, {
       kind: 'tool-call',
@@ -103,13 +103,37 @@ describe('structured agent session status projection', () => {
       state: 'running'
     })
 
-    expect(projectStructuredAgentSessionStatusSummary([ask, said, running, tool])).toEqual({
+    expect(projectStructuredAgentSessionStatusSummary([ask, running, said, tool])).toEqual({
       status: 'working',
       latestPrompt: 'look at the sidebar',
       toolName: 'Read',
       toolInput: '/repo/src/WorktreeCard.tsx',
       lastAssistantMessage: 'Reading the card first.'
     })
+  })
+
+  it('clears the previous answer as soon as the next prompt is persisted', () => {
+    const firstAsk = item('first-ask', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'first task' }]
+    })
+    const previousAnswer = item('previous-answer', 2, {
+      kind: 'message',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'The first task is done.' }]
+    })
+    const nextAsk = item('next-ask', 3, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'second task' }]
+    })
+    expect(projectStructuredAgentSessionStatusSummary([firstAsk, previousAnswer, nextAsk])).toEqual(
+      {
+        status: 'idle',
+        latestPrompt: 'second task'
+      }
+    )
   })
 
   it('reports no tool line once the turn settles, even with an abandoned running call', () => {

--- a/src/shared/structured-agent-session-projection.test.ts
+++ b/src/shared/structured-agent-session-projection.test.ts
@@ -80,6 +80,120 @@ describe('structured agent session status projection', () => {
     })
   })
 
+  it('carries the running tool and the newest assistant prose the sidebar row shows', () => {
+    const ask = item('ask', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'look at the sidebar' }]
+    })
+    const said = item('said', 2, {
+      kind: 'message',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'Reading the card first.' }]
+    })
+    const running = item('running', 3, {
+      kind: 'status',
+      text: 'Working',
+      turnLifecycle: { turnId: 'turn-1', state: 'running' }
+    })
+    const tool = item('tool', 4, {
+      kind: 'tool-call',
+      name: 'Read',
+      input: { file_path: '/repo/src/WorktreeCard.tsx' },
+      state: 'running'
+    })
+
+    expect(projectStructuredAgentSessionStatusSummary([ask, said, running, tool])).toEqual({
+      status: 'working',
+      latestPrompt: 'look at the sidebar',
+      toolName: 'Read',
+      toolInput: '/repo/src/WorktreeCard.tsx',
+      lastAssistantMessage: 'Reading the card first.'
+    })
+  })
+
+  it('reports no tool line once the turn settles, even with an abandoned running call', () => {
+    const ask = item('ask', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'go' }]
+    })
+    const abandoned = item('abandoned', 2, {
+      kind: 'tool-call',
+      name: 'Bash',
+      input: { command: 'sleep 600' },
+      state: 'running'
+    })
+
+    expect(projectStructuredAgentSessionStatusSummary([ask, abandoned])).toEqual({
+      status: 'idle',
+      latestPrompt: 'go'
+    })
+  })
+
+  it('never adopts a running call from a turn older than the live one', () => {
+    const ask = item('ask', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'go' }]
+    })
+    const abandoned = item('abandoned', 2, {
+      kind: 'tool-call',
+      name: 'Bash',
+      input: { command: 'sleep 600' },
+      state: 'running'
+    })
+    const running = item('running', 3, {
+      kind: 'status',
+      text: 'Working',
+      turnLifecycle: { turnId: 'turn-2', state: 'running' }
+    })
+
+    expect(projectStructuredAgentSessionStatusSummary([ask, abandoned, running])).toEqual({
+      status: 'working',
+      latestPrompt: 'go'
+    })
+  })
+
+  it('skips a tool-only assistant item to reach the newest prose', () => {
+    const ask = item('ask', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'go' }]
+    })
+    const said = item('said', 2, {
+      kind: 'message',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'Done — the card now aligns.' }]
+    })
+    const wordless = item('wordless', 3, {
+      kind: 'message',
+      role: 'assistant',
+      blocks: [{ type: 'tool-call', name: 'Read', input: {} }]
+    })
+
+    expect(
+      projectStructuredAgentSessionStatusSummary([ask, said, wordless]).lastAssistantMessage
+    ).toBe('Done — the card now aligns.')
+  })
+
+  it('bounds the assistant preview at the shared agent-status preview cap', () => {
+    const ask = item('ask', 1, {
+      kind: 'message',
+      role: 'user',
+      blocks: [{ type: 'text', text: 'go' }]
+    })
+    const rambled = item('rambled', 2, {
+      kind: 'message',
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'y'.repeat(AGENT_STATUS_MAX_FIELD_LENGTH * 40) }]
+    })
+
+    expect(
+      projectStructuredAgentSessionStatusSummary([ask, rambled]).lastAssistantMessage
+    ).toHaveLength(AGENT_STATUS_MAX_FIELD_LENGTH)
+  })
+
   it('bounds the wire prompt at the shared agent-status preview cap', () => {
     const pasted = item('pasted', 1, {
       kind: 'message',

--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -1,5 +1,17 @@
-import { normalizePromptField } from './agent-status-field-normalization'
-import type { AgentJournalRenderItem } from './agent-session-journal-types'
+import {
+  AGENT_STATUS_MAX_FIELD_LENGTH,
+  normalizeOptionalField,
+  normalizePromptField
+} from './agent-status-field-normalization'
+import type {
+  AgentJournalRenderItem,
+  AgentJournalToolCallItem
+} from './agent-session-journal-types'
+import {
+  AGENT_STATUS_TOOL_INPUT_MAX_LENGTH,
+  AGENT_STATUS_TOOL_NAME_MAX_LENGTH
+} from './agent-status-types'
+import { describeToolInput } from './native-chat-tool-summary'
 import type { NativeChatBlock, NativeChatMessage } from './native-chat-types'
 import { sha256 } from './sha256'
 
@@ -163,6 +175,10 @@ export function projectStructuredAgentSessionStatus(
   return activeStructuredAgentSessionTurnId(items) ? 'working' : 'idle'
 }
 
+function messageProse(blocks: readonly NativeChatBlock[]): string {
+  return blocks.flatMap((block) => (block.type === 'text' ? [block.text] : [])).join('\n')
+}
+
 /** The newest user prompt, as the sidebar quotes it. */
 export function latestStructuredAgentSessionPrompt(
   items: readonly AgentJournalRenderItem[]
@@ -170,24 +186,92 @@ export function latestStructuredAgentSessionPrompt(
   for (let index = items.length - 1; index >= 0; index -= 1) {
     const body = items[index]?.body
     if (body?.kind === 'message' && body.role === 'user') {
-      return body.blocks.flatMap((block) => (block.type === 'text' ? [block.text] : [])).join('\n')
+      return messageProse(body.blocks)
     }
   }
   return ''
 }
 
+/** The newest assistant prose. Tool-only assistant items are skipped — they carry
+ *  no words, and stopping at one would blank a row that has something to say. */
+export function latestStructuredAgentSessionAssistantMessage(
+  items: readonly AgentJournalRenderItem[]
+): string {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const body = items[index]?.body
+    if (body?.kind === 'message' && body.role === 'assistant') {
+      const prose = messageProse(body.blocks)
+      if (prose.trim()) {
+        return prose
+      }
+    }
+  }
+  return ''
+}
+
+/** The tool call the newest turn is still inside, or null when nothing is running.
+ *  Scanning stops at the turn's own lifecycle row so an abandoned `running` call
+ *  from an earlier crashed turn can never be reported as live work. */
+export function activeStructuredAgentSessionToolCall(
+  items: readonly AgentJournalRenderItem[]
+): AgentJournalToolCallItem | null {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const body = items[index]?.body
+    if (body?.kind === 'status' && body.turnLifecycle) {
+      return null
+    }
+    if (body?.kind === 'tool-call' && body.state === 'running') {
+      return body
+    }
+  }
+  return null
+}
+
+/** The activity fields a sidebar row shows beside the prompt, named as the agent-status
+ *  entry names them so the client can hand them straight to a row. */
+export type StructuredAgentSessionStatusProjection = {
+  status: StructuredAgentSessionProjectedStatus | null
+  latestPrompt: string
+  /** Present only while a turn is running — see showsAgentToolPreview, which reads
+   *  these on any state that carries them. */
+  toolName?: string
+  toolInput?: string
+  lastAssistantMessage?: string
+}
+
 /** One projection shared by host and client: null status means "no turn yet", not idle.
- *  The prompt is bounded to the same preview every other agent-status row carries — a send
- *  admits 256 KB, and one status frame carries every retained session at once. */
+ *  Every text field is bounded to the same preview an agent-status row carries — a send
+ *  admits 256 KB, and one status frame carries every retained session at once. The
+ *  assistant line is bounded harder than the hook field it stands in for (a preview, not
+ *  the 8 KB body): a streamed reply re-projects on every journal checkpoint, so the frame
+ *  has to stay small even though the row only ever renders one line of it. */
 export function projectStructuredAgentSessionStatusSummary(
   items: readonly AgentJournalRenderItem[]
-): { status: StructuredAgentSessionProjectedStatus | null; latestPrompt: string } {
+): StructuredAgentSessionStatusProjection {
   if (!hasPersistedStructuredAgentSessionTurn(items)) {
     return { status: null, latestPrompt: '' }
   }
+  const status = projectStructuredAgentSessionStatus(items)
+  const activeToolCall = status === 'working' ? activeStructuredAgentSessionToolCall(items) : null
+  const toolName = activeToolCall
+    ? normalizeOptionalField(activeToolCall.name, AGENT_STATUS_TOOL_NAME_MAX_LENGTH)
+    : undefined
+  const toolInput = activeToolCall
+    ? normalizeOptionalField(
+        describeToolInput(activeToolCall.input),
+        AGENT_STATUS_TOOL_INPUT_MAX_LENGTH
+      )
+    : undefined
+  const lastAssistantMessage = normalizeOptionalField(
+    latestStructuredAgentSessionAssistantMessage(items),
+    AGENT_STATUS_MAX_FIELD_LENGTH
+  )
   return {
-    status: projectStructuredAgentSessionStatus(items),
-    latestPrompt: normalizePromptField(latestStructuredAgentSessionPrompt(items))
+    status,
+    latestPrompt: normalizePromptField(latestStructuredAgentSessionPrompt(items)),
+    ...(toolName ? { toolName } : {}),
+    ...(toolInput ? { toolInput } : {}),
+    ...(lastAssistantMessage ? { lastAssistantMessage } : {})
   }
 }
 

--- a/src/shared/structured-agent-session-projection.ts
+++ b/src/shared/structured-agent-session-projection.ts
@@ -192,13 +192,16 @@ export function latestStructuredAgentSessionPrompt(
   return ''
 }
 
-/** The newest assistant prose. Tool-only assistant items are skipped — they carry
- *  no words, and stopping at one would blank a row that has something to say. */
+/** The newest assistant prose in the latest user turn. Tool-only assistant items
+ *  are skipped; the user boundary clears prose from the preceding turn. */
 export function latestStructuredAgentSessionAssistantMessage(
   items: readonly AgentJournalRenderItem[]
 ): string {
   for (let index = items.length - 1; index >= 0; index -= 1) {
     const body = items[index]?.body
+    if (body?.kind === 'message' && body.role === 'user') {
+      return ''
+    }
     if (body?.kind === 'message' && body.role === 'assistant') {
       const prose = messageProse(body.blocks)
       if (prose.trim()) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​283 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​280 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 |

<!-- /orca-pr-loc -->

## What

The worktree sidebar row for a structured Claude/Codex chat showed far less than the equivalent hook-reported row. It read `Claude Chat - Claude` — the tab title, then the agent-type label the row falls back to when it has nothing else — with no model badge and no sign of what the agent was doing.

## Why

`projectStructuredAgentSessionStatusSummary` fed the sidebar only three things: `status`, `latestPrompt`, and (client-side) the agent type. A hook-reported row also carries `model`, `toolName`/`toolInput`, and `lastAssistantMessage`, which is what `getCompactAgentSecondary` and `DashboardAgentRow` render in the secondary slot and the model badge. With none of them present, every structured row degraded to `formatAgentTypeLabel(agentType)`.

## How

- **`src/shared/structured-agent-session-projection.ts`** — the shared projection now also derives from the journal:
  - `toolName` / `toolInput` from the tool call the live turn is inside, previewed with `describeToolInput` (the same previewer native chat's "Running …" line uses). The backward scan stops at the turn's own lifecycle row, and the fields are only emitted while `status === 'working'` — the rule `showsAgentToolPreview` already enforces on the render side — so an abandoned `running` call from a crashed turn can never be reported as live work.
  - `lastAssistantMessage` from the newest assistant item that has prose; tool-only assistant items are skipped rather than blanking the row.
- **`src/shared/agent-session-wire.ts`** — four additive optional fields on `AgentSessionStatusSummary`.
- **`structured-agent-session-status-feed.ts`** — `model` comes from the record's acknowledged options (the journal has none), and `summariesEqual` compares the new fields; without that a tool boundary is deduped away as an unchanged projection.
- **`StructuredAgentSessionStatusBridge.tsx`** — passes all four into the agent-status entry, with the write guard extended to match. The model check reads "only a reported model can differ", because the entry builder carries the last known model forward.

A working structured chat now reads `<title> - Read: src/foo.ts` with a model badge; a settled one reads `<title> - <what the agent said>`.

### Bound on the assistant line

It is capped at the shared 200-char preview rather than the hook field's 8 KB body. A streamed reply re-projects the summary on every journal checkpoint (geometric gate + 60 ms coalescer, so tens of publications per long turn), and the row only ever renders one line of it — the frame has to stay small. Structured sessions are local-only today, so this is a client-side row preview, not a remote-bandwidth question, but the publication rate is the same either way.

## Verification

- `pnpm tc` green
- `pnpm run check:code-quality:changed` — 0 new findings across 7 files (incl. React Doctor)
- `pnpm run audit:code-quality:native` green; oxfmt clean
- 41 tests green across the 5 affected files, plus a 65-test sweep of `WorktreeCardAgents` / `DashboardAgentRow` / `local-structured-session-tabs-sync`
- Both non-obvious edits ablation-verified red: removing the `summariesEqual` comparison, and removing the bridge's guard comparison, each turn a new test red — the tests pin the mechanism, not just the shape

## Deliberately out of scope

Two pre-existing gaps on this surface, both separate from the projection:

1. **Background tasks read as Done.** Claude's tracker reports `monitoring` only when no foreground turn is running, which is exactly when the feed projects `idle` — so during a background task the sidebar contradicts the chat. Fixing it needs a `backgroundTaskState` dep on the feed plus its own publication edge at `publishBackgroundTaskState` (background-task changes deliberately don't fire the journal hook, so today they reach no status edge at all).
2. **No subagent child rows.** Hook rows render indented children from `entry.subagents`; structured sessions would need `Task` tool calls tracked as lifecycle children. That's a feature, not a field.

Known minor wart: switching the model mid-session doesn't publish the status feed (`performSetOption` doesn't call `ctx.publish()`), so the badge refreshes on the next journal event rather than instantly.

