### PR TITLE
fix(native-chat): settle a structured send whose replay lands after the timeout

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11,6 +11,84 @@
   },
   "gates": [
     {
+      "id": "agent-session.submission-settlement",
+      "title": "Late Claude delivery proof settles the original unknown submission",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "native-chat",
+      "layer": "runtime-integration-and-mutation-contract",
+      "surfaces": ["Claude structured chat", "submission journal", "shared structured outbox"],
+      "platforms": ["macos", "linux", "windows", "ios", "android"],
+      "providers": ["local", "remote-runtime", "relay"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local"],
+      "coverageNotes": "Production runtime, host, journal, subscription and shared outbox with scripted Claude transport and process identity probe on macOS; folder workspace exercised. Other native hosts and paired clients are relevant but not covered by this run. Direct SSH/WSL structured Claude execution remains unsupported by existing location checks.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/pull/19141"],
+      "invariant": "A correlated late user echo settles only its original unknown submission accepted, clears its unconfirmed outbox state, suppresses stale retry delivery and preserves a newer active turn.",
+      "oracle": "Timeout the first send, accept a newer send, deliver the first user echo, then require accepted journal/subscription state, removed outbox entry, two provider sends despite explicit retry, and successful newer-turn cancellation. Mutation contracts require serialization behind unknown persistence and one write/publication across repeated settlement.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/native-chat/agent-session-wire/structured-agent-session-late-dispatch.test.ts src/main/runtime/claude-late-dispatch-integration.test.ts"
+      ],
+      "testFiles": [
+        "src/main/native-chat/agent-session-wire/structured-agent-session-late-dispatch.test.ts",
+        "src/main/runtime/claude-late-dispatch-integration.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/native-chat/agent-session-wire/structured-agent-session-late-dispatch.test.ts",
+          "assertions": [
+            "waits for the send to persist unknown before accepting and publishing once",
+            "ignores delivery proof after the host session has closed"
+          ]
+        },
+        {
+          "file": "src/main/runtime/claude-late-dispatch-integration.test.ts",
+          "assertions": [
+            "settles a timed-out unknown through the runtime, publishes outbox removal and fences retries"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-06",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/native-chat/agent-session-wire/structured-agent-session-late-dispatch.test.ts src/main/runtime/claude-late-dispatch-integration.test.ts",
+          "result": "passed",
+          "durationSeconds": 15.45,
+          "summary": "7/7 passed after correcting the scripted PID lease-probe fixture; product source at 88d478071a. Earlier broad runs had a process-inspection failure and the fixture failure; no wholly green final broad run claimed."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "Target for this focused two-file command; observed run 15.45 seconds, measured p95 not established."
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "One corrected focused 7/7 run; sustained soak history missing. Earlier fixture lease-probe failure was corrected, not retried away."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "Removing onLateDispatchAccepted runtime adapter forwarding fails the integrated journal assertion with unknown/accepted instead of accepted/accepted; restoring forwarding passes. PR 19141 review artifacts retain ablation and restored-run logs."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Mutation contract counts one write/publication across repeated settlement; integration counts two provider sends despite retry. No added polling/timers/processes; exceptional settlement copies/scans session submissions. Large-journal latency and subscriber fanout are unmeasured."
+      },
+      "promotionCriteria": [
+        "Collect the policy-required soak runs and days without unexplained flakes.",
+        "Retain forwarding ablation sensitivity, send/write/publication counts and newer-turn cancellation assertions.",
+        "Establish native host and paired-client coverage before claiming those platforms protected."
+      ],
+      "knownGaps": [
+        "Scripted provider integration does not itself prove rendered Electron behavior or live Claude ordering.",
+        "No native Windows/Linux, native iOS/Android, pinned mixed-version client, or paired transport reconnect run for this oracle.",
+        "No settlement-write failure/restart fault injection or release-scale journal performance measurement.",
+        "Existing oldest-unconfirmed Retry targeting is outside this fix."
+      ],
+      "demotionRule": "Remain experimental on unexplained failures or lost ablation sensitivity; do not mask failures with retries, skips or longer timeouts."
+    },
+    {
       "id": "ssh.localhost-terminal-agent-hooks",
       "title": "Localhost SSH terminal and agent hooks reach the owning pane",
       "maturity": "experimental",

--- a/src/main/claude/claude-structured-dispatch.test.ts
+++ b/src/main/claude/claude-structured-dispatch.test.ts
@@ -65,6 +65,49 @@ describe('Claude structured dispatch image limits', () => {
     expect(session.activeTurnSequence).toBe(session.dispatchSequence)
   })
 
+  it('reports the settled submission when a timed-out replay arrives late', async () => {
+    const session = sessionFor()
+    const accepted: { clientMessageId: string; uuid: string }[] = []
+    session.onLateDispatchAccepted = (input) => accepted.push(input)
+    const dispatched = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
+      500
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    const sentUuid = (session.dispatchWaiters[0] as { sentUuid?: string }).sentUuid
+    // The send gave up waiting, so the host has already recorded this submission `unknown`.
+    await expect(dispatched).resolves.toMatchObject({ state: 'unknown' })
+
+    resolveClaudeReplayWaiter(session, userReplayFrame(sentUuid!, 'one'))
+
+    expect(accepted).toEqual([{ clientMessageId: 'client-1', uuid: sentUuid }])
+  })
+
+  it('reports a late replay even after a newer dispatch has started', async () => {
+    const session = sessionFor()
+    const accepted: { clientMessageId: string; uuid: string }[] = []
+    session.onLateDispatchAccepted = (input) => accepted.push(input)
+    const first = dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-1', body: userMessage([{ type: 'text', text: 'one' }]) },
+      500
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+    const firstUuid = (session.dispatchWaiters[0] as { sentUuid?: string }).sentUuid
+    await expect(first).resolves.toMatchObject({ state: 'unknown' })
+    dispatchClaudeTurn(
+      session,
+      { clientMessageId: 'client-2', body: userMessage([{ type: 'text', text: 'two' }]) },
+      100
+    )
+    await vi.waitFor(() => expect(session.dispatchWaiters).toHaveLength(1))
+
+    // Turn identity must stay with dispatch B, but message A still provably landed.
+    expect(resolveClaudeReplayWaiter(session, userReplayFrame(firstUuid!, 'one'))).toBe(false)
+    expect(accepted).toEqual([{ clientMessageId: 'client-1', uuid: firstUuid }])
+  })
+
   it('never lets a late replay for dispatch A resolve dispatch B', async () => {
     const session = sessionFor()
     const first = dispatchClaudeTurn(

--- a/src/main/claude/claude-structured-dispatch.ts
+++ b/src/main/claude/claude-structured-dispatch.ts
@@ -147,6 +147,12 @@ function recoverLateIdentity(
     session.activeTurnId = uuid
     session.activeTurnSequence = waiter.dispatchSequence
   }
+  // The waiter is retired, so its send already returned `unknown`. A user replay is Claude
+  // echoing the message, which proves delivery — regardless of whether a newer dispatch has
+  // since started, so this is deliberately not gated on `dispatchSequence`.
+  if (isUserReplay) {
+    session.onLateDispatchAccepted?.({ clientMessageId: waiter.clientMessageId, uuid })
+  }
   return isUserReplay && waiter.dispatchSequence === session.dispatchSequence
 }
 
@@ -155,12 +161,14 @@ function waitForReplay(
   timeoutMs: number,
   acceptsResult: boolean,
   sentUuid: string,
-  replayContentKey: string
+  replayContentKey: string,
+  clientMessageId: string
 ): { waiter: ClaudeDispatchWaiter; promise: Promise<string | null> } {
   let waiter!: ClaudeDispatchWaiter
   const promise = new Promise<string | null>((resolve) => {
     waiter = {
       acceptsResult,
+      clientMessageId,
       sentUuid,
       dispatchSequence: session.dispatchSequence,
       replayContentKey,
@@ -220,7 +228,8 @@ export async function dispatchClaudeTurn(
     timeoutMs,
     acceptsResult,
     sentUuid,
-    claudeDispatchContentKey(content)
+    claudeDispatchContentKey(content),
+    input.clientMessageId
   )
   const replayed = replay.promise
   try {

--- a/src/main/claude/claude-structured-session-acquisition.ts
+++ b/src/main/claude/claude-structured-session-acquisition.ts
@@ -265,6 +265,12 @@ export async function acquireClaudeSession({
     })
     const acquired: AgentSessionAcquisition = publication.acquisition
     liveSession = publication.session
+    if (deps.onLateDispatchAccepted) {
+      const notify = deps.onLateDispatchAccepted
+      const bound = publication.session
+      bound.onLateDispatchAccepted = ({ clientMessageId, uuid }) =>
+        notify({ sessionId, clientMessageId, uuid, providerSessionId: bound.providerSessionId })
+    }
     await restoreClaudeStructuredSessionOptions(liveSession, deps.requestTimeoutMs)
     acquisitions.assertCurrent(sessionId, attempt)
     acquisitions.deleteIfCurrent(sessionId, attempt)

--- a/src/main/claude/claude-structured-session-state.ts
+++ b/src/main/claude/claude-structured-session-state.ts
@@ -60,6 +60,15 @@ export type ClaudeStructuredSessionAdapterDeps = {
     sessionId: string,
     state: AgentSessionBackgroundTaskState | null
   ) => void
+  /** A replay that lands after its dispatch timed out proves the message reached Claude, so the
+   *  submission the host already recorded `unknown` can still be settled `accepted`. */
+  onLateDispatchAccepted?: (input: {
+    sessionId: string
+    clientMessageId: string
+    uuid: string
+    /** Claude's own session id — the journal identity is provider-scoped, not Orca-scoped. */
+    providerSessionId: string
+  }) => void
   openConnection?: typeof openClaudeStreamJsonConnection
   readProcessStartTime?: (pid: number) => Promise<number | null>
   mintLinkId?: () => string
@@ -87,6 +96,8 @@ export type ClaudeDispatchWaiter = {
   resolve: (uuid: string | null) => void
   timer: ReturnType<typeof setTimeout>
   acceptsResult: boolean
+  /** The submission this dispatch belongs to, so a late replay can settle its journal row. */
+  clientMessageId: string
   /** Client uuid echoed by Claude so a replay is tied to its own dispatch. */
   sentUuid: string
   /** Sequence used to fence a late identity from a newer dispatch. */
@@ -100,6 +111,8 @@ export type ClaudeDispatchWaiter = {
 }
 
 export type ClaudeSession = {
+  /** Set by the adapter; see `onLateDispatchAccepted` on the adapter deps. */
+  onLateDispatchAccepted?: (input: { clientMessageId: string; uuid: string }) => void
   connection: ClaudeStreamJsonConnection
   providerSessionId: string
   /** Durable transcript files live under this account's `projects` directory. */

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host-mutations.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host-mutations.ts
@@ -5,7 +5,10 @@
 // they share one path here rather than five copies in the host. The host keeps attach, holds and
 // teardown; this is the surface that assumes those already happened.
 
-import type { AgentJournalMessageItem } from '../../../shared/agent-session-journal-types'
+import type {
+  AgentJournalItemIdentity,
+  AgentJournalMessageItem
+} from '../../../shared/agent-session-journal-types'
 import type {
   AgentSessionCancelResult,
   AgentSessionMutationEnvelope,
@@ -116,5 +119,33 @@ export function readStructuredAgentSessionOptions(
       throw new Error('structured_agent_session_options_unsupported')
     }
     return context.deps.adapter.readOptions({ sessionId, fence: session.fence })
+  })
+}
+
+/** Provider delivery proof is serialized behind the send that records its unknown outcome. */
+export function settleLateDispatch(
+  context: StructuredAgentSessionMutationContext,
+  input: {
+    sessionId: string
+    clientMessageId: string
+    providerIdentity: AgentJournalItemIdentity
+  }
+): Promise<void> {
+  return context.serialize(input.sessionId, async () => {
+    const session = context.sessions.get(input.sessionId)
+    const submission = session?.journal
+      .submissions()
+      .find((entry) => entry.clientMessageId === input.clientMessageId)
+    if (!session || submission?.dispatchState !== 'unknown') {
+      return
+    }
+    await session.journal.resolveDispatch({
+      clientMessageId: input.clientMessageId,
+      state: 'accepted',
+      providerIdentity: input.providerIdentity,
+      fence: session.fence,
+      recovered: true
+    })
+    context.publish(input.sessionId, session.journal)
   })
 }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.test.ts
@@ -338,6 +338,54 @@ describe('send', () => {
     expect(result).toMatchObject({ ok: true, value: { submission: { dispatchState: 'unknown' } } })
   })
 
+  it('settles an unknown submission accepted when its replay lands late', async () => {
+    await attach()
+    dispatch.mockResolvedValueOnce({ state: 'unknown', reason: 'no replay in time' })
+    const body = hostTestMessage('add a retry')
+    const result = await host.send(CALLER, {
+      envelope: envelope('agentSession.send', { body }),
+      body
+    })
+    if (!result.ok) {
+      throw new Error(`expected a send, got ${result.refusal.code}`)
+    }
+    expect(result.value.submission.dispatchState).toBe('unknown')
+
+    await host.settleLateDispatch({
+      sessionId: SESSION,
+      clientMessageId: result.value.clientMessageId,
+      providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-late', ordinal: 0 }
+    })
+
+    const page = host.history({ sessionId: SESSION, direction: 'tail' })
+    const settled = (page.ok ? page.page.submissions : []).find(
+      (entry) => entry.clientMessageId === result.value.clientMessageId
+    )
+    expect(settled?.dispatchState).toBe('accepted')
+    // The message was already delivered; a late settlement must never re-dispatch it.
+    expect(dispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves an already accepted submission alone when a late replay arrives', async () => {
+    await attach()
+    const body = hostTestMessage('add a retry')
+    const result = await host.send(CALLER, {
+      envelope: envelope('agentSession.send', { body }),
+      body
+    })
+    if (!result.ok) {
+      throw new Error(`expected a send, got ${result.refusal.code}`)
+    }
+    const before = host.history({ sessionId: SESSION, direction: 'tail' })
+    await host.settleLateDispatch({
+      sessionId: SESSION,
+      clientMessageId: result.value.clientMessageId,
+      providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-late', ordinal: 0 }
+    })
+    const after = host.history({ sessionId: SESSION, direction: 'tail' })
+    expect(after.ok && after.page.fence).toBe(before.ok && before.page.fence)
+  })
+
   it('replays a retried send from the journal without dispatching twice', async () => {
     await attach()
     const body = hostTestMessage('add a retry')

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.test.ts
@@ -338,54 +338,6 @@ describe('send', () => {
     expect(result).toMatchObject({ ok: true, value: { submission: { dispatchState: 'unknown' } } })
   })
 
-  it('settles an unknown submission accepted when its replay lands late', async () => {
-    await attach()
-    dispatch.mockResolvedValueOnce({ state: 'unknown', reason: 'no replay in time' })
-    const body = hostTestMessage('add a retry')
-    const result = await host.send(CALLER, {
-      envelope: envelope('agentSession.send', { body }),
-      body
-    })
-    if (!result.ok) {
-      throw new Error(`expected a send, got ${result.refusal.code}`)
-    }
-    expect(result.value.submission.dispatchState).toBe('unknown')
-
-    await host.settleLateDispatch({
-      sessionId: SESSION,
-      clientMessageId: result.value.clientMessageId,
-      providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-late', ordinal: 0 }
-    })
-
-    const page = host.history({ sessionId: SESSION, direction: 'tail' })
-    const settled = (page.ok ? page.page.submissions : []).find(
-      (entry) => entry.clientMessageId === result.value.clientMessageId
-    )
-    expect(settled?.dispatchState).toBe('accepted')
-    // The message was already delivered; a late settlement must never re-dispatch it.
-    expect(dispatch).toHaveBeenCalledTimes(1)
-  })
-
-  it('leaves an already accepted submission alone when a late replay arrives', async () => {
-    await attach()
-    const body = hostTestMessage('add a retry')
-    const result = await host.send(CALLER, {
-      envelope: envelope('agentSession.send', { body }),
-      body
-    })
-    if (!result.ok) {
-      throw new Error(`expected a send, got ${result.refusal.code}`)
-    }
-    const before = host.history({ sessionId: SESSION, direction: 'tail' })
-    await host.settleLateDispatch({
-      sessionId: SESSION,
-      clientMessageId: result.value.clientMessageId,
-      providerIdentity: { provider: 'codex', threadId: THREAD, turnId: 'turn-late', ordinal: 0 }
-    })
-    const after = host.history({ sessionId: SESSION, direction: 'tail' })
-    expect(after.ok && after.page.fence).toBe(before.ok && before.page.fence)
-  })
-
   it('replays a retried send from the journal without dispatching twice', async () => {
     await attach()
     const body = hostTestMessage('add a retry')

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -1,6 +1,7 @@
 // Structured agent-session host: where the lease, journal, and provider adapter meet.
 // Mutations share one durable admission path and serialize per session.
 
+import type { AgentJournalItemIdentity } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionExecutionLocation } from '../../../shared/agent-session-record'
 import type * as SessionWire from '../../../shared/agent-session-wire'
 import type { AgentSessionAttachParams } from './structured-agent-session-attach'
@@ -336,6 +337,37 @@ export class StructuredAgentSessionHost {
     state
   ) => this.backgroundTasks.publish(sessionId, state)
   unsubscribe = (sessionId: string, id: string): void => this.subscribers.close(sessionId, id)
+
+  /** A provider replay that arrived after its dispatch timed out. The send already recorded
+   *  `unknown`, which is terminal for the outbox — the client shows "delivery is unconfirmed"
+   *  forever and its Retry redelivers a message the agent already has. The replay proves
+   *  delivery, so settle the submission the host was unsure about. */
+  settleLateDispatch = (input: {
+    sessionId: string
+    clientMessageId: string
+    providerIdentity: AgentJournalItemIdentity
+  }): Promise<void> =>
+    this.serialize(input.sessionId, async () => {
+      const session = this.sessions.get(input.sessionId)
+      if (!session) {
+        return
+      }
+      // Only an `unknown` row is ours to move; anything else is already the truth.
+      const submission = session.journal
+        .submissions()
+        .find((entry) => entry.clientMessageId === input.clientMessageId)
+      if (submission?.dispatchState !== 'unknown') {
+        return
+      }
+      await session.journal.resolveDispatch({
+        clientMessageId: input.clientMessageId,
+        state: 'accepted',
+        providerIdentity: input.providerIdentity,
+        fence: session.fence,
+        recovered: true
+      })
+      this.subscribers.publish(input.sessionId, session.journal)
+    })
 
   /** Every session's projected status for session lists; unlike `subscribe`, retains nothing. */
   subscribeStatus = (

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-host.ts
@@ -1,7 +1,6 @@
 // Structured agent-session host: where the lease, journal, and provider adapter meet.
 // Mutations share one durable admission path and serialize per session.
 
-import type { AgentJournalItemIdentity } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionExecutionLocation } from '../../../shared/agent-session-record'
 import type * as SessionWire from '../../../shared/agent-session-wire'
 import type { AgentSessionAttachParams } from './structured-agent-session-attach'
@@ -39,6 +38,7 @@ import {
   respondToStructuredAgentSessionPrompt,
   sendStructuredAgentSessionTurn,
   setStructuredAgentSessionOption,
+  settleLateDispatch,
   type StructuredAgentSessionMutationContext
 } from './structured-agent-session-host-mutations'
 import { tearDownStructuredAgentSessionHost } from './structured-agent-session-host-teardown'
@@ -338,36 +338,8 @@ export class StructuredAgentSessionHost {
   ) => this.backgroundTasks.publish(sessionId, state)
   unsubscribe = (sessionId: string, id: string): void => this.subscribers.close(sessionId, id)
 
-  /** A provider replay that arrived after its dispatch timed out. The send already recorded
-   *  `unknown`, which is terminal for the outbox — the client shows "delivery is unconfirmed"
-   *  forever and its Retry redelivers a message the agent already has. The replay proves
-   *  delivery, so settle the submission the host was unsure about. */
-  settleLateDispatch = (input: {
-    sessionId: string
-    clientMessageId: string
-    providerIdentity: AgentJournalItemIdentity
-  }): Promise<void> =>
-    this.serialize(input.sessionId, async () => {
-      const session = this.sessions.get(input.sessionId)
-      if (!session) {
-        return
-      }
-      // Only an `unknown` row is ours to move; anything else is already the truth.
-      const submission = session.journal
-        .submissions()
-        .find((entry) => entry.clientMessageId === input.clientMessageId)
-      if (submission?.dispatchState !== 'unknown') {
-        return
-      }
-      await session.journal.resolveDispatch({
-        clientMessageId: input.clientMessageId,
-        state: 'accepted',
-        providerIdentity: input.providerIdentity,
-        fence: session.fence,
-        recovered: true
-      })
-      this.subscribers.publish(input.sessionId, session.journal)
-    })
+  settleLateDispatch = (input: Parameters<typeof settleLateDispatch>[1]): Promise<void> =>
+    settleLateDispatch(this.mutationContext(), input)
 
   /** Every session's projected status for session lists; unlike `subscribe`, retains nothing. */
   subscribeStatus = (

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-late-dispatch.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-late-dispatch.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import { StructuredAgentSessionTaskQueue } from './structured-agent-session-task-queue'
+import {
+  settleLateDispatch,
+  type StructuredAgentSessionMutationContext
+} from './structured-agent-session-host-mutations'
+
+describe('late dispatch journal settlement', () => {
+  it('waits for the send to persist unknown before accepting and publishing once', async () => {
+    const queue = new StructuredAgentSessionTaskQueue()
+    let dispatchState = 'pending'
+    let releaseSend!: () => void
+    const writeBarrier = new Promise<void>((resolve) => {
+      releaseSend = resolve
+    })
+    const send = queue.serialize('session', async () => {
+      await writeBarrier
+      dispatchState = 'unknown'
+    })
+    const resolveDispatch = vi.fn(async () => {
+      dispatchState = 'accepted'
+    })
+    const publish = vi.fn()
+    const context = {
+      serialize: queue.serialize.bind(queue),
+      sessions: new Map([
+        [
+          'session',
+          {
+            fence: 1,
+            journal: {
+              submissions: () => [{ clientMessageId: 'first', dispatchState }],
+              resolveDispatch
+            }
+          }
+        ]
+      ]),
+      publish
+    } as unknown as StructuredAgentSessionMutationContext
+    const input = {
+      sessionId: 'session',
+      clientMessageId: 'first',
+      providerIdentity: { provider: 'claude' as const, sessionId: 'provider', uuid: 'first' }
+    }
+    const settle = settleLateDispatch(context, input)
+    expect(resolveDispatch).not.toHaveBeenCalled()
+    releaseSend()
+    await Promise.all([send, settle])
+    expect(dispatchState).toBe('accepted')
+    await settleLateDispatch(context, input)
+    expect(resolveDispatch).toHaveBeenCalledOnce()
+    expect(publish).toHaveBeenCalledOnce()
+  })
+
+  it.each(['accepted', 'rejected', 'pending', 'absent'] as const)(
+    'does not rewrite a %s submission or publish redundant state',
+    async (dispatchState) => {
+      const resolveDispatch = vi.fn()
+      const publish = vi.fn()
+      const context = {
+        serialize: async (_sessionId: string, task: () => Promise<void>) => task(),
+        sessions: new Map([
+          [
+            'session',
+            {
+              fence: 1,
+              journal: {
+                submissions: () =>
+                  dispatchState === 'absent' ? [] : [{ clientMessageId: 'first', dispatchState }],
+                resolveDispatch
+              }
+            }
+          ]
+        ]),
+        publish
+      } as unknown as StructuredAgentSessionMutationContext
+      await settleLateDispatch(context, {
+        sessionId: 'session',
+        clientMessageId: 'first',
+        providerIdentity: { provider: 'claude', sessionId: 'provider', uuid: 'first' }
+      })
+      expect(resolveDispatch).not.toHaveBeenCalled()
+      expect(publish).not.toHaveBeenCalled()
+    }
+  )
+
+  it('ignores delivery proof after the host session has closed', async () => {
+    const publish = vi.fn()
+    const context = {
+      serialize: async (_sessionId: string, task: () => Promise<void>) => task(),
+      sessions: new Map(),
+      publish
+    } as unknown as StructuredAgentSessionMutationContext
+    await settleLateDispatch(context, {
+      sessionId: 'session',
+      clientMessageId: 'first',
+      providerIdentity: { provider: 'claude', sessionId: 'provider', uuid: 'first' }
+    })
+    expect(publish).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/claude-late-dispatch-integration.test.ts
+++ b/src/main/runtime/claude-late-dispatch-integration.test.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'node:crypto'
+import type * as ProcessIdentityProbe from './agent-session-process-identity-probe'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it, vi } from 'vitest'
+import { computeAgentSessionPayloadFingerprint } from '../../shared/agent-session-mutation-envelope'
+import type { AgentJournalSubmission } from '../../shared/agent-session-journal-types'
+import {
+  createStructuredAgentSessionOutboxEntry,
+  reconcileStructuredAgentSessionOutbox
+} from '../../shared/structured-agent-session-outbox'
+import type { AgentSessionSubscribeEvent } from '../../shared/agent-session-wire'
+import { fakeClaude } from '../claude/claude-structured-session-test-support'
+import { claudeSessionIdForOrcaSession } from '../claude/claude-structured-launch-resolution'
+import {
+  HOST_TEST_SESSION as SESSION,
+  hostTestAttachParams,
+  hostTestMessage
+} from '../native-chat/agent-session-wire/structured-agent-session-host-test-data'
+import {
+  ensureStructuredAgentSessionHost,
+  stopStructuredAgentSessionRuntime
+} from './structured-agent-session-runtime'
+
+vi.mock('../native-chat/session-file-resolver', () => ({
+  readClaudeTranscriptLeafUuid: vi.fn(async () => null),
+  resolveSessionFilePath: vi.fn(async () => null)
+}))
+
+// The scripted child must remain live when the real lease-renewal timer probes its fake PID.
+vi.mock('./agent-session-process-identity-probe', async (importOriginal) => ({
+  ...(await importOriginal<typeof ProcessIdentityProbe>()),
+  probeAgentSessionProcessIdentities: async ({ identities }: { identities: unknown[] }) =>
+    identities.map(() => ({ outcome: 'identity-matched', matchedOn: ['process-start-time'] }))
+}))
+
+let root: string
+
+afterEach(async () => {
+  await stopStructuredAgentSessionRuntime()
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+it('settles a timed-out unknown through the runtime, publishes outbox removal and fences retries', async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-late-dispatch-'))
+  const providerSessionId = claudeSessionIdForOrcaSession(SESSION)
+  const claude = fakeClaude({ initSessionId: providerSessionId, replayUuids: [null, 'second'] })
+  const onError = vi.fn()
+  const operationId = () => `${Date.now()}-${randomUUID().replaceAll('-', '')}`
+  const host = await ensureStructuredAgentSessionHost({
+    stateDirectory: root,
+    hostId: 'local',
+    claimKeyId: 'key-1',
+    resolveWorkspacePath: async () => root,
+    resolveClaudeCommand: () => 'claude',
+    resolveCodexCommand: () => 'codex',
+    resolveEnvironment: async () => ({}),
+    resolveClaudeLaunchEnv: () => ({}),
+    resolveClaudeAuthPolicy: () => ({ stripAuthEnv: false }),
+    openClaudeConnection: claude.openConnection,
+    readProcessStartTime: async () => 100,
+    onError
+  })
+  const caller = { callerKey: 'client-1' }
+  const attachParams = hostTestAttachParams(null, {
+    provider: 'claude',
+    agent: 'claude',
+    providerHandle: undefined,
+    location: {
+      executionHostId: 'local',
+      wslDistro: null,
+      workspaceId: 'folder-1',
+      workspaceKind: 'folder'
+    },
+    accountHome: { variable: 'CLAUDE_CONFIG_DIR', path: root }
+  })
+  attachParams.envelope.clientOperationId = operationId()
+  const attached = await host.attach(caller, attachParams)
+  const { handlers, sent, calls } = claude.connections[0]!
+  expect(attached, JSON.stringify(attached)).toMatchObject({ ok: true })
+  if (!attached.ok) {
+    throw new Error(attached.refusal.message)
+  }
+  const fence = attached.value.fence
+  const envelope = (method: string, fields: Record<string, unknown>) => ({
+    sessionId: SESSION,
+    clientOperationId: operationId(),
+    expectedRuntimeFence: fence,
+    payloadFingerprint: computeAgentSessionPayloadFingerprint({
+      method,
+      sessionId: SESSION,
+      fields
+    })
+  })
+  const frames: AgentSessionSubscribeEvent[] = []
+  const unsubscribe = host.subscribe({
+    sessionId: SESSION,
+    id: 'late-replay',
+    emit: (frame) => frames.push(frame)
+  })
+  const body = hostTestMessage('first')
+  const params = { envelope: envelope('agentSession.send', { body }), body }
+  const first = await host.send(caller, params)
+  expect(first).toMatchObject({ ok: true, value: { submission: { dispatchState: 'unknown' } } })
+  if (!first.ok) {
+    throw new Error(first.refusal.message)
+  }
+  const outbox = [
+    createStructuredAgentSessionOutboxEntry({
+      sessionId: SESSION,
+      clientMessageId: first.value.clientMessageId,
+      text: 'first',
+      attachments: [],
+      queuedAt: 1
+    })
+  ]
+  expect(reconcileStructuredAgentSessionOutbox(outbox, [first.value.submission])[0]?.state).toBe(
+    'unconfirmed'
+  )
+  claude.connections[0]!.send = async (message) => {
+    sent.push(message)
+    handlers.onMessage?.(message)
+  }
+  const secondBody = hostTestMessage('second')
+  await host.send(caller, {
+    envelope: envelope('agentSession.send', { body: secondBody }),
+    body: secondBody
+  })
+  const submissions = (): AgentJournalSubmission[] => {
+    const page = host.history({ sessionId: SESSION, direction: 'tail' })
+    return page.ok ? page.page.submissions : []
+  }
+  handlers.onMessage?.(sent[0]!)
+  await vi.waitFor(() =>
+    expect(submissions().map((row) => row.dispatchState)).toEqual(['accepted', 'accepted'])
+  )
+  expect(reconcileStructuredAgentSessionOutbox(outbox, submissions())).toEqual([])
+  expect(
+    frames.some(
+      (frame) =>
+        frame.type === 'batch' &&
+        frame.batch.submissions.some(
+          (row) =>
+            row.clientMessageId === first.value.clientMessageId && row.dispatchState === 'accepted'
+        )
+    )
+  ).toBe(true)
+  const beforeRepeat = submissions()
+  handlers.onMessage?.(sent[0]!)
+  const retry = await host.send(caller, { ...params, retryUnknown: true })
+  expect(retry).toMatchObject({ ok: true, value: { submission: { dispatchState: 'accepted' } } })
+  expect(submissions()).toEqual(beforeRepeat)
+  expect(sent).toHaveLength(2)
+  const turnId = sent[1]!.uuid as string
+  const cancelled = await host.cancel(caller, {
+    envelope: envelope('agentSession.cancel', { turnId }),
+    turnId
+  })
+  expect(cancelled).toMatchObject({ ok: true })
+  expect(calls.filter((call) => call.subtype === 'interrupt')).toHaveLength(1)
+  unsubscribe()
+  expect(onError).not.toHaveBeenCalled()
+}, 20_000)

--- a/src/main/runtime/structured-agent-session-runtime.ts
+++ b/src/main/runtime/structured-agent-session-runtime.ts
@@ -260,6 +260,17 @@ async function install(deps: StructuredAgentSessionRuntimeDeps): Promise<Install
       },
       onBackgroundTasksChanged: (sessionId, state) =>
         host?.publishBackgroundTaskState(sessionId, state),
+      onLateDispatchAccepted: ({ sessionId, clientMessageId, uuid, providerSessionId }) => {
+        void host
+          ?.settleLateDispatch({
+            sessionId,
+            clientMessageId,
+            providerIdentity: { provider: 'claude', sessionId: providerSessionId, uuid }
+          })
+          .catch((error) =>
+            deps.onError?.({ scope: `structured-agent-session-late-dispatch:${sessionId}`, error })
+          )
+      },
       ...(deps.openClaudeConnection ? { openClaudeConnection: deps.openClaudeConnection } : {}),
       ...(deps.readProcessStartTime ? { readProcessStartTime: deps.readProcessStartTime } : {})
     })

--- a/src/main/runtime/structured-claude-runtime-adapter.ts
+++ b/src/main/runtime/structured-claude-runtime-adapter.ts
@@ -34,6 +34,7 @@ export type StructuredClaudeRuntimeAdapterDeps = {
     sessionId: string,
     state: AgentSessionBackgroundTaskState | null
   ) => void
+  onLateDispatchAccepted?: ClaudeStructuredSessionAdapterDeps['onLateDispatchAccepted']
 }
 
 export function createStructuredClaudeRuntimeAdapter(
@@ -100,6 +101,7 @@ export function createStructuredClaudeRuntimeAdapter(
     ...(deps.onBackgroundTasksChanged
       ? { onBackgroundTasksChanged: deps.onBackgroundTasksChanged }
       : {}),
+    ...(deps.onLateDispatchAccepted ? { onLateDispatchAccepted: deps.onLateDispatchAccepted } : {}),
     ...(deps.openClaudeConnection ? { openConnection: deps.openClaudeConnection } : {}),
     ...(deps.readProcessStartTime ? { readProcessStartTime: deps.readProcessStartTime } : {})
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​310 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​310 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 |

<!-- /orca-pr-loc -->

Sending a message during an active Claude structured-chat turn can time out before Claude echoes it. The submission then stays `unknown` even after the message was delivered, leaving “Message delivery is unconfirmed” visible and allowing Retry to duplicate the send.

Carry the original client message ID with its replay waiter and forward a matched late user echo to the owning runtime. The host serializes settlement behind the send, changes only that original `unknown` submission to `accepted`, and publishes the existing journal state. A newer dispatch retains its active-turn identity. Settlement lives in the existing host mutations module so the implementation and tests satisfy the repository line limits.

The regression covers the runtime adapter, acquisition, journal, subscription, outbox removal, stale Retry suppression, and newer-turn cancellation. Removing the runtime notification forwarding makes it fail; restoring it passes. Focused mutation tests check serialization, no-op states, and one write/publication for repeated settlement.

Validation: the final affected tests pass 7/7; full typechecking, full-file lint/commit hooks, and changed-code quality pass. An earlier broad run hit a real-Claude process-inspection failure under load; the isolated pair and reduced-concurrency real-Claude run passed. The reduced-concurrency run also exposed a scripted-process test-fixture problem, which was corrected and reverified in the final focused run. These are not reported as a wholly green final broad run.

Reliability gate: `agent-session.submission-settlement` in `config/reliability-gates.jsonc`, experimental, with the forwarding ablation as its oracle. Settlement adds no polling, timers, subprocesses, or retained cache; deterministic tests count provider sends and journal writes/publications. The runtime error scope is `structured-agent-session-late-dispatch:<sessionId>`.

Compatibility: no new wire fields, opcodes, or dispatch-state meanings. Existing clients already consume `accepted`; older hosts retain the previous behavior. Automated integration covers a local macOS folder workspace. Live Claude Electron QA reproduced the timeout and late settlement on the original head and rebuilt final product source; the banner cleared without Retry and the marker appeared once. [Final-build screenshots and backing-state evidence](https://github.com/stablyai/orca/pull/19141#issuecomment-5562901801). Native Windows/Linux/mobile, mixed-version paired transport, reconnect, and large-journal performance were not independently exercised. Direct SSH/WSL structured Claude execution remains unsupported by the existing capability gate.

Scope stays Claude late-delivery settlement. The existing oldest-unconfirmed Retry targeting is unchanged.
