### PR TITLE
perf(agent-status): stop no-op retirements rebuilding the retired-pane-key map

### DIFF
--- a/src/renderer/src/store/slices/agent-pane-authority.test.ts
+++ b/src/renderer/src/store/slices/agent-pane-authority.test.ts
@@ -74,6 +74,20 @@ describe('agent pane authority', () => {
     expect(retirePaneAuthority).toHaveBeenCalledWith(TARGET)
   })
 
+  it('re-retiring an already-retired pane keeps the retired-key map identity and epochs', () => {
+    const store = createTestStore()
+    store.getState().setAgentStatus(TARGET, { state: 'working', prompt: 'target' })
+    store.getState().retireAgentPaneAuthority(TARGET)
+    const before = store.getState()
+
+    store.getState().retireAgentPaneAuthority(TARGET)
+
+    const after = store.getState()
+    expect(after.recentlyRetiredAgentStatusPaneKeys).toBe(before.recentlyRetiredAgentStatusPaneKeys)
+    expect(after.agentStatusEpoch).toBe(before.agentStatusEpoch)
+    expect(after.sortEpoch).toBe(before.sortEpoch)
+  })
+
   it('retires the pane activity cutoff with the rest of its pane-owned state', () => {
     const store = createTestStore()
     store.setState({

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX,
+  RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX,
+  boundRecentlyClosedAgentStatusTabIds,
+  boundRecentlyRetiredAgentStatusPaneKeys
+} from './agent-status-pane-keyed-records'
+
+function keyRecord(keys: readonly string[]): Record<string, true> {
+  const record: Record<string, true> = {}
+  for (const key of keys) {
+    record[key] = true
+  }
+  return record
+}
+
+function fullRecord(max: number, prefix: string): Record<string, true> {
+  return keyRecord(Array.from({ length: max }, (_, i) => `${prefix}${i}`))
+}
+
+describe('boundRecentlyRetiredAgentStatusPaneKeys', () => {
+  it('returns the existing record when there is nothing to add', () => {
+    const existing = keyRecord(['a', 'b'])
+    expect(boundRecentlyRetiredAgentStatusPaneKeys(existing, [])).toBe(existing)
+    const empty = keyRecord([])
+    expect(boundRecentlyRetiredAgentStatusPaneKeys(empty, [])).toBe(empty)
+  })
+
+  it('returns the existing record when the additions already form its tail in order', () => {
+    const existing = keyRecord(['a', 'b', 'c'])
+    expect(boundRecentlyRetiredAgentStatusPaneKeys(existing, ['c'])).toBe(existing)
+    expect(boundRecentlyRetiredAgentStatusPaneKeys(existing, ['b', 'c'])).toBe(existing)
+    expect(boundRecentlyRetiredAgentStatusPaneKeys(existing, ['a', 'b', 'c'])).toBe(existing)
+  })
+
+  // Why: LRU order decides which key the cap evicts next. A key-set match is not a
+  // no-op when the re-added key is not already at the tail — it must move there.
+  it('re-retiring an existing non-tail key changes identity and moves it to the tail', () => {
+    const existing = keyRecord(['a', 'b', 'c'])
+    const next = boundRecentlyRetiredAgentStatusPaneKeys(existing, ['a'])
+    expect(next).not.toBe(existing)
+    expect(Object.keys(next)).toEqual(['b', 'c', 'a'])
+    expect(Object.keys(existing)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('tail keys re-added in a different relative order are rebuilt in the new order', () => {
+    const existing = keyRecord(['a', 'b', 'c'])
+    const next = boundRecentlyRetiredAgentStatusPaneKeys(existing, ['c', 'b'])
+    expect(next).not.toBe(existing)
+    expect(Object.keys(next)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('appends new keys after the existing ones', () => {
+    const existing = keyRecord(['a'])
+    const next = boundRecentlyRetiredAgentStatusPaneKeys(existing, ['b', 'c'])
+    expect(next).not.toBe(existing)
+    expect(Object.keys(next)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('evicts the oldest keys once the cap is exceeded', () => {
+    const full = fullRecord(RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX, 'k')
+    const next = boundRecentlyRetiredAgentStatusPaneKeys(full, ['fresh'])
+    const keys = Object.keys(next)
+    expect(keys).toHaveLength(RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX)
+    expect(keys[0]).toBe('k1')
+    expect(keys.at(-1)).toBe('fresh')
+    expect(next.k0).toBeUndefined()
+  })
+
+  it('re-retiring the oldest key at the cap keeps it fenced and evicts the next oldest', () => {
+    const full = fullRecord(RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX, 'k')
+    const bumped = boundRecentlyRetiredAgentStatusPaneKeys(full, ['k0'])
+    expect(bumped).not.toBe(full)
+    expect(Object.keys(bumped).at(-1)).toBe('k0')
+    const afterFresh = boundRecentlyRetiredAgentStatusPaneKeys(bumped, ['fresh'])
+    expect(afterFresh.k0).toBe(true)
+    expect(afterFresh.k1).toBeUndefined()
+  })
+
+  it('never returns an over-cap record unchanged', () => {
+    const over = fullRecord(RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX + 1, 'k')
+    const last = `k${RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX}`
+    const next = boundRecentlyRetiredAgentStatusPaneKeys(over, [last])
+    expect(next).not.toBe(over)
+    expect(Object.keys(next)).toHaveLength(RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX)
+    expect(next.k0).toBeUndefined()
+  })
+})
+
+describe('boundRecentlyClosedAgentStatusTabIds', () => {
+  it('returns the existing record when the tab is already the most recent', () => {
+    const existing = keyRecord(['t1', 't2'])
+    expect(boundRecentlyClosedAgentStatusTabIds(existing, 't2')).toBe(existing)
+  })
+
+  it('moves a re-closed tab to the tail', () => {
+    const existing = keyRecord(['t1', 't2'])
+    const next = boundRecentlyClosedAgentStatusTabIds(existing, 't1')
+    expect(next).not.toBe(existing)
+    expect(Object.keys(next)).toEqual(['t2', 't1'])
+  })
+
+  it('evicts the oldest tab once the cap is exceeded', () => {
+    const full = fullRecord(RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX, 't')
+    const next = boundRecentlyClosedAgentStatusTabIds(full, 'fresh')
+    expect(Object.keys(next)).toHaveLength(RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX)
+    expect(next.t0).toBeUndefined()
+    expect(next.fresh).toBe(true)
+  })
+})

--- a/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
+++ b/src/renderer/src/store/slices/agent-status-pane-keyed-records.ts
@@ -3,45 +3,64 @@ export const RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX = 1024
 
 // delete-then-set for LRU recency, then evict oldest keys past the cap (Record iterates
 // insertion order); safe because a status for a tab closed >MAX tabs ago cannot still arrive.
-export function boundRecentlyClosedAgentStatusTabIds(
+function boundLruKeyRecord(
   existing: Record<string, true>,
-  tabId: string
+  additions: ReadonlySet<string>,
+  max: number
 ): Record<string, true> {
-  const next: Record<string, true> = {}
-  for (const key of Object.keys(existing)) {
-    if (key !== tabId) {
-      next[key] = true
-    }
+  if (isLruKeyRecordUnchanged(existing, additions, max)) {
+    return existing
   }
-  next[tabId] = true
-  const keys = Object.keys(next)
-  if (keys.length > RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX) {
-    for (const stale of keys.slice(0, keys.length - RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX)) {
-      delete next[stale]
-    }
-  }
-  return next
-}
-
-export function boundRecentlyRetiredAgentStatusPaneKeys(
-  existing: Record<string, true>,
-  paneKeys: readonly string[]
-): Record<string, true> {
-  const additions = new Set(paneKeys)
   const next: Record<string, true> = {}
   for (const key of Object.keys(existing)) {
     if (!additions.has(key)) {
       next[key] = true
     }
   }
-  for (const paneKey of additions) {
-    next[paneKey] = true
+  for (const key of additions) {
+    next[key] = true
   }
   const keys = Object.keys(next)
-  for (const stale of keys.slice(0, -RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX)) {
+  for (const stale of keys.slice(0, -max)) {
     delete next[stale]
   }
   return next
+}
+
+// The rebuild is a no-op only when nothing would be evicted and the additions are
+// already the tail of `existing` in that same relative order. A matching key SET is
+// not enough: re-adding a key moves it to the tail, and that order decides which key
+// the cap evicts next, so a stale-order hit would un-fence a recently retired pane.
+function isLruKeyRecordUnchanged(
+  existing: Record<string, true>,
+  additions: ReadonlySet<string>,
+  max: number
+): boolean {
+  const keys = Object.keys(existing)
+  if (keys.length > max || additions.size > keys.length) {
+    return false
+  }
+  let index = keys.length - additions.size
+  for (const key of additions) {
+    if (keys[index++] !== key) {
+      return false
+    }
+  }
+  return true
+}
+
+export function boundRecentlyClosedAgentStatusTabIds(
+  existing: Record<string, true>,
+  tabId: string
+): Record<string, true> {
+  return boundLruKeyRecord(existing, new Set([tabId]), RECENTLY_CLOSED_AGENT_STATUS_TAB_IDS_MAX)
+}
+
+export function boundRecentlyRetiredAgentStatusPaneKeys(
+  existing: Record<string, true>,
+  paneKeys: readonly string[]
+): Record<string, true> {
+  return boundLruKeyRecord(existing, new Set(paneKeys), RECENTLY_RETIRED_AGENT_STATUS_PANE_KEYS_MAX)
 }
 
 export function movePaneKeyedRecord<T>(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## What

`boundRecentlyRetiredAgentStatusPaneKeys` always rebuilt its record, even when the rebuild produced the identical map. A runtime probe measured **1,099 writes that replaced `recentlyRetiredAgentStatusPaneKeys`'s reference while its value stayed deep-equal** — the largest remaining write-side churn site in the renderer after the previous eight PRs.

**The dominant caller is not the obvious one.** `agent-status-drop-reducer.ts:88` accounts for 1,101 of them, passing an **empty** `retiredAliasPaneKeys` — the tab has no aliases, which is the normal case. `retireAgentPaneAuthority` contributed 7, all genuine changes. (I originally blamed `retireAgentPaneAuthority`; measurement corrected that.)

## The trap this avoids

The obvious fix — "all added keys already present → return input" — is **wrong**. Line 4 says so: *"delete-then-set for LRU recency, then evict oldest keys past the cap"*. Re-adding a key deliberately moves it to the tail, and that order decides which key the 1024-cap evicts next. Short-circuiting on a key-set match would freeze a key's recency and evict it early, **un-fencing a pane that should stay fenced**.

The implemented condition is narrower and exact: return `existing` only when nothing would be evicted **and** the additions already form its tail in that same relative order. That subsumes the empty-additions case. Both LRU records (`recentlyRetiredAgentStatusPaneKeys` and `recentlyClosedAgentStatusTabIds`) now share one helper.

## Why it's safe

An independent reader audit found every consumer is contents-only except one, and that one is provably redundant:

- `shouldRetryPendingAgentStatusesAfterStoreUpdate` ORs eight `!==` identity checks including this field, feeding `flushPendingAgentStatuses()`. The retired map's only role in a retry is the "already retired → drop" check; if contents are identical that check returns the same answer, so the flush is a wasted `transactAgentStatuses` + routing-index rebuild. Suppressing it matches the gate's own comment: *"unrelated store writes cannot change attribution and must not rebuild its routing index."* A 100 ms timer fallback and `PENDING_AGENT_STATUS_TTL_MS` cover the queue regardless.
- Events for an already-retired key are dropped before they can be enqueued, so nothing can be stranded by the suppressed flush.
- The field is **not persisted** — absent from `SESSION_RELEVANT_FIELDS`, so no serialized output changes.
- No selector, `useShallow` projection, `readSources` list, or store subscriber takes this map whole.
- `agentStatusEpoch`/`sortEpoch` are gated on `hadLive` in separate patch fields and are unaffected.

So this also removes a spurious routing-index rebuild per duplicate retire — a bonus, not just avoided re-renders.

## Verification

- 11 new tests in `agent-status-pane-keyed-records.test.ts` plus one store-level test. **Swapping in the naive key-set condition fails exactly 4 of them**, including *"re-retiring the oldest key at the cap keeps it fenced and evicts the next oldest"* — the un-fencing bug above is pinned.
- Measured after: **1,099 → 0** deep-equal rebuilds; the remaining rebuilds are all real content changes.
- `tsc` clean · store suite **3230 tests pass** · `oxlint` clean · `oxfmt --check` clean.

Honest caveat: the "additions already at tail" branch has **zero hits** in the test suite — the whole measured bulk is the empty-additions case. It's kept because it's free and covers re-retiring a live pane at runtime, which the suite doesn't exercise.

---

## ELI5

The app keeps a list of "panes we recently retired", so late-arriving status messages for a dead pane get ignored instead of reviving it. It's a most-recently-used list capped at 1024.

Every time anything retired a pane, the app rebuilt that whole list from scratch — **including the very common case where it was asked to retire nothing at all**. A rebuilt list looks brand-new to everything watching it, so a pile of work ran to discover nothing had changed.

Now it hands back the same list when the rebuild wouldn't have altered it.

The catch worth knowing: re-retiring a pane deliberately moves it to the *back* of the queue, so it survives longer before being forgotten. Skipping the rebuild whenever the names all matched would have quietly frozen that, letting a pane be forgotten too early — and a forgotten pane can be revived by a stale message. So the shortcut only fires when the order genuinely wouldn't have moved. There's a test that fails if someone later "simplifies" it.