### PR TITLE
perf(worktrees): stop worktree teardown replacing arrays and maps it never touched

### DIFF
--- a/src/renderer/src/store/slices/browser/browser-close-actions.ts
+++ b/src/renderer/src/store/slices/browser/browser-close-actions.ts
@@ -12,6 +12,7 @@ import { getFallbackTabTypeForWorktree, isLocalBrowserPageOwner } from './browse
 import { closeRemoteBrowserPageInOwningEnvironment } from './browser-remote-close'
 import { releaseDocPreviewGrant } from '@/lib/doc-preview-grants'
 import { destroyWorkspaceWebviews } from '../browser-webview-cleanup'
+import { omitRecordKeys } from '../worktrees/teardown/record-key-omission'
 
 export function createBrowserCloseActions(
   set: BrowserSliceSet,
@@ -231,10 +232,15 @@ export function createBrowserCloseActions(
         destroyWorkspaceWebviews(browserPagesByWorkspace, workspace.id)
       }
       set((s) => {
-        const nextBrowserTabsByWorktree = { ...s.browserTabsByWorktree }
-        delete nextBrowserTabsByWorktree[worktreeId]
-        const nextActiveBrowserTabIdByWorktree = { ...s.activeBrowserTabIdByWorktree }
-        delete nextActiveBrowserTabIdByWorktree[worktreeId]
+        const removedWorktreeIds = [worktreeId]
+        const nextBrowserTabsByWorktree = omitRecordKeys(
+          s.browserTabsByWorktree,
+          removedWorktreeIds
+        )
+        const nextActiveBrowserTabIdByWorktree = omitRecordKeys(
+          s.activeBrowserTabIdByWorktree,
+          removedWorktreeIds
+        )
         // Why: reset the global browser surface only when the shut-down worktree is the active one AND had tabs.
         const shouldResetGlobalBrowser = s.activeWorktreeId === worktreeId && hadBrowserTabs
         return {

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree-store-cleanup.ts
@@ -35,6 +35,12 @@ export function applyRemoveWorktreeSuccessState(
       }
     }
     const omitByFileId = <T>(m: Record<string, T> | undefined) => omitRecordKeys(m, removedFileIds)
+    // Why guarded: a removed worktree usually has no open file, and an unconditional
+    // filter would hand openFiles a new identity anyway — the sibling purge path
+    // already does this.
+    const nextOpenFiles = s.openFiles.some((f) => f.worktreeId === worktreeId)
+      ? s.openFiles.filter((f) => f.worktreeId !== worktreeId)
+      : s.openFiles
     // If the active file belonged to the removed worktree, clear it
     const activeFileCleared = s.activeFileId
       ? s.openFiles.some((f) => f.id === s.activeFileId && f.worktreeId === worktreeId)
@@ -79,7 +85,7 @@ export function applyRemoveWorktreeSuccessState(
         ? null
         : s.activeWorkspaceExecutionHostId,
       activeTabId: s.activeTabId && tabIds.has(s.activeTabId) ? null : s.activeTabId,
-      openFiles: s.openFiles.filter((f) => f.worktreeId !== worktreeId),
+      openFiles: nextOpenFiles,
       browserTabsByWorktree: omitByWorktree(s.browserTabsByWorktree),
       // Why: closeBrowserTab records a Cmd+Shift+T undo snapshot, but a deleted worktree's tabs can't be restored; purge it.
       recentlyClosedBrowserTabsByWorktree: omitByWorktree(s.recentlyClosedBrowserTabsByWorktree),

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-teardown-array-identity.test.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-teardown-array-identity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../../../types'
+import type { OpenFile } from '../../../../../../shared/editor-types'
+import { applyRemoveWorktreeSuccessState } from './remove-worktree-store-cleanup'
+
+const REMOVED = 'repo-1::/repos/one/removed'
+const KEPT = 'repo-1::/repos/one/kept'
+
+function fileFor(worktreeId: string, id: string): OpenFile {
+  return { id, worktreeId, path: `${worktreeId}/f.ts`, name: 'f.ts' } as unknown as OpenFile
+}
+
+function buildState(openFiles: OpenFile[]): AppState {
+  return {
+    worktreesByRepo: { 'repo-1': [] },
+    tabsByWorktree: { [KEPT]: [] },
+    openFiles,
+    everActivatedWorktreeIds: new Set<string>(),
+    lastVisitedAtByWorktreeId: {},
+    deleteStateByWorktreeId: {},
+    sortEpoch: 0
+  } as unknown as AppState
+}
+
+function removeWorktree(state: AppState): AppState {
+  let current = state
+  applyRemoveWorktreeSuccessState(
+    (update) => {
+      const patch = typeof update === 'function' ? update(current) : update
+      current = { ...current, ...patch }
+    },
+    REMOVED,
+    new Set<string>()
+  )
+  return current
+}
+
+describe('worktree removal openFiles identity', () => {
+  it('keeps the openFiles reference when the removed worktree had no open file', () => {
+    // openFiles is selected whole by the editor panel, file explorer and git-status
+    // polling, so a fresh array here rerenders all of them for no data change.
+    const before = buildState([fileFor(KEPT, 'kept-file')])
+
+    const after = removeWorktree(before)
+
+    expect(after.openFiles).toBe(before.openFiles)
+  })
+
+  it('still drops the removed worktree files', () => {
+    const before = buildState([fileFor(KEPT, 'kept-file'), fileFor(REMOVED, 'gone-file')])
+
+    const after = removeWorktree(before)
+
+    expect(after.openFiles).not.toBe(before.openFiles)
+    expect(after.openFiles.map((f) => f.id)).toEqual(['kept-file'])
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-teardown-array-identity.test.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-teardown-array-identity.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { AppState } from '../../../types'
-import type { OpenFile } from '../../../../../../shared/editor-types'
 import { applyRemoveWorktreeSuccessState } from './remove-worktree-store-cleanup'
+
+type OpenFile = AppState['openFiles'][number]
 
 const REMOVED = 'repo-1::/repos/one/removed'
 const KEPT = 'repo-1::/repos/one/kept'

--- a/src/renderer/src/store/terminals/terminal-shutdown-guards-identity.test.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-guards-identity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import { createTerminalShutdownGuardController } from './terminal-shutdown-guards'
+
+vi.mock('@/components/terminal-pane/pty-transport', () => ({
+  restorePtyDataHandlersAfterFailedShutdown: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn(() => [])
+}))
+vi.mock('@/components/terminal-pane/terminal-parked-watcher-registry', () => ({
+  disposeParkedTerminalWatchersForPtyIds: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/pty-shutdown-exit-deferral', () => ({
+  clearCommittedPtyShutdownSettlements: vi.fn(),
+  hasCommittedPtyShutdownSettlement: vi.fn(() => false),
+  markCommittedPtyShutdowns: vi.fn(),
+  noteCommittedPtyShutdownSettlements: vi.fn(),
+  settleDeferredPtyShutdownExits: vi.fn()
+}))
+
+function harness(initial: Partial<AppState>, exitGuardPtyIds: readonly string[]) {
+  let current = initial as AppState
+  const set = vi.fn((update: unknown) => {
+    const patch =
+      typeof update === 'function' ? (update as (s: AppState) => object)(current) : update
+    current = { ...current, ...(patch as object) }
+  })
+  const guards = createTerminalShutdownGuardController({
+    exitGuardPtyIds,
+    get: (() => current) as never,
+    keepIdentifiers: false,
+    rendererShutdownPtyIds: exitGuardPtyIds,
+    runtimeEnvironmentId: null,
+    set: set as never,
+    tabs: []
+  })
+  return { guards, set, state: () => current }
+}
+
+describe('markShutdownPending identity', () => {
+  it('does not write the store when there is nothing to guard', () => {
+    const { guards, set } = harness({ suppressedPtyExitIds: {}, pendingPtyShutdownIds: {} }, [])
+
+    guards.markShutdownPending()
+
+    expect(set).not.toHaveBeenCalled()
+  })
+
+  it('still counts a pending owner when every id is already suppressed', () => {
+    const suppressedPtyExitIds: Record<string, true> = { 'pty-1': true }
+    const { guards, state } = harness(
+      { suppressedPtyExitIds, pendingPtyShutdownIds: { 'pty-1': 1 } },
+      ['pty-1']
+    )
+
+    guards.markShutdownPending()
+
+    expect(state().suppressedPtyExitIds).toBe(suppressedPtyExitIds)
+    expect(state().pendingPtyShutdownIds).toEqual({ 'pty-1': 2 })
+  })
+
+  it('suppresses the ids that were not yet suppressed', () => {
+    const { guards, state } = harness(
+      { suppressedPtyExitIds: { 'pty-1': true }, pendingPtyShutdownIds: {} },
+      ['pty-1', 'pty-2']
+    )
+
+    guards.markShutdownPending()
+
+    expect(state().suppressedPtyExitIds).toEqual({ 'pty-1': true, 'pty-2': true })
+    expect(state().pendingPtyShutdownIds).toEqual({ 'pty-1': 1, 'pty-2': 1 })
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-shutdown-guards.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-guards.ts
@@ -48,16 +48,27 @@ export function createTerminalShutdownGuardController({
   let partialRendererStopSettled = false
 
   const markShutdownPending = (): void => {
+    // Why the early return: tearing down a worktree whose panes already exited passes
+    // no guard ids, and the spreads below would still hand both maps a new identity.
+    if (exitGuardPtyIds.length === 0) {
+      return
+    }
     set((state) => {
       const pendingPtyShutdownIds = { ...state.pendingPtyShutdownIds }
       for (const ptyId of exitGuardPtyIds) {
         pendingPtyShutdownIds[ptyId] = (pendingPtyShutdownIds[ptyId] ?? 0) + 1
       }
+      // Why conditional: re-guarding an already-suppressed pty writes the same `true`.
+      const alreadySuppressed = exitGuardPtyIds.every(
+        (ptyId) => state.suppressedPtyExitIds[ptyId] === true
+      )
       return {
-        suppressedPtyExitIds: {
-          ...state.suppressedPtyExitIds,
-          ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
-        },
+        suppressedPtyExitIds: alreadySuppressed
+          ? state.suppressedPtyExitIds
+          : {
+              ...state.suppressedPtyExitIds,
+              ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
+            },
         pendingPtyShutdownIds
       }
     })

--- a/src/renderer/src/store/terminals/terminal-shutdown-guards.ts
+++ b/src/renderer/src/store/terminals/terminal-shutdown-guards.ts
@@ -13,6 +13,7 @@ import {
   settleDeferredPtyShutdownExits
 } from '@/components/terminal-pane/pty-shutdown-exit-deferral'
 import type { TerminalStoreGet, TerminalStoreSet } from './terminal-state'
+import { copyOnWriteRecord } from '../copy-on-write-record'
 
 export type TerminalShutdownGuardController = {
   commitHandlerSnapshots: () => void
@@ -55,22 +56,15 @@ export function createTerminalShutdownGuardController({
     }
     set((state) => {
       const pendingPtyShutdownIds = { ...state.pendingPtyShutdownIds }
+      // Why copy-on-write: re-guarding an already-suppressed pty writes the same `true`.
+      const suppressedPtyExitIds = copyOnWriteRecord(state.suppressedPtyExitIds)
       for (const ptyId of exitGuardPtyIds) {
         pendingPtyShutdownIds[ptyId] = (pendingPtyShutdownIds[ptyId] ?? 0) + 1
+        if (state.suppressedPtyExitIds[ptyId] !== true) {
+          suppressedPtyExitIds.set(ptyId, true)
+        }
       }
-      // Why conditional: re-guarding an already-suppressed pty writes the same `true`.
-      const alreadySuppressed = exitGuardPtyIds.every(
-        (ptyId) => state.suppressedPtyExitIds[ptyId] === true
-      )
-      return {
-        suppressedPtyExitIds: alreadySuppressed
-          ? state.suppressedPtyExitIds
-          : {
-              ...state.suppressedPtyExitIds,
-              ...Object.fromEntries(exitGuardPtyIds.map((ptyId) => [ptyId, true] as const))
-            },
-        pendingPtyShutdownIds
-      }
+      return { suppressedPtyExitIds: suppressedPtyExitIds.read(), pendingPtyShutdownIds }
     })
   }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## What

Removing a worktree fires three store writes through `removed-worktree-renderer-teardown.ts`. Each handed back a fresh reference even when it removed nothing:

| Site | Was | Selected whole by |
|---|---|---|
| `remove-worktree-store-cleanup.ts:82` | `openFiles: s.openFiles.filter(...)`, always a new array | EditorPanel, FileExplorer, `useGitStatusPolling` (7 whole-array selectors) |
| `browser-close-actions.ts:233` | spread-then-delete on `browserTabsByWorktree` + `activeBrowserTabIdByWorktree` | 3 whole + 28 shallow |
| `terminal-shutdown-guards.ts:51` | rebuilt `suppressedPtyExitIds` + `pendingPtyShutdownIds` **even with no guard ids at all** | — |

**The `openFiles` one is a gap I left in #19058.** That PR gave the ~50 record maps in this file identity preservation via `omitRecordKeys` and missed the single plain array — while the sibling purge path in the same directory (`worktree-purge-state.ts:39`) already had exactly the `.some()` guard this copies. So every worktree removal still churned `openFiles`.

`markShutdownPending`'s empty-`exitGuardPtyIds` case is the "worktree whose panes already exited" path, which is the normal one — worth ~291 measured no-op writes on its own.

## Measurement

From a fresh churn-probe run over the store suite on current `main`, ranked by churn × whole-map selector count rather than raw churn:

| Site | Churned writes |
|---|---|
| `terminal-shutdown-guards.ts:51` | 291 |
| `browser-close-actions.ts:233` | 245 |
| `remove-worktree-store-cleanup.ts` (`openFiles`) | 146 |

Worth noting what that ranking *demoted*: `prRefreshStates` is the raw-churn leader at 692, but scores **zero** priority because every reader indexes `prRefreshStates[key]` — churning that map re-runs selectors but never re-renders. Raw churn is the wrong signal on its own.

## Why it's free

Same contents, same keys removed, same order — only the reference is reused when nothing changed. `omitRecordKeys` is the helper #19058 introduced and is already used cross-directory by `terminal-tab-close.ts`. The `suppressedPtyExitIds` skip only fires when every id is already `true`, so it writes nothing it wasn't already writing.

## Verification

- New `worktree-teardown-array-identity.test.ts`: `openFiles` keeps its reference when the removed worktree had no open file, and is still filtered when it did. **Fails without the fix** (verified by reverting the source and re-running).
- `tsc` clean · store + terminal-pane suites **7439 tests pass** · `oxlint` clean · `oxfmt --check` clean.

---

## ELI5

When you delete a worktree, the app tidies up three separate piles of state.

All three handed back a *brand-new* pile even when they'd removed nothing from it — and the app can't tell "same stuff" from "new pile", it only checks whether the pile was swapped. So the editor, the file explorer and the git-status poller all redrew every time you deleted a worktree, whether or not any of their files were involved.

The most embarrassing one: an earlier PR of mine fixed about fifty of these piles in this exact file and missed the one that wasn't a map — even though the near-identical file next door already did it right.

The third case is the funniest: a function whose whole job is "mark these terminals as shutting down" rebuilt two lists even when handed *no terminals at all*, which is the usual situation because they'd already exited.