### PR TITLE
fix(ui): keep source control headers readable in narrow sidebars

### DIFF
--- a/src/renderer/src/components/right-sidebar/source-control/listing/branch-section.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/branch-section.tsx
@@ -91,8 +91,8 @@ export function SourceControlBranchSection({
           <Button
             type="button"
             variant="ghost"
-            size="sm"
-            className="h-auto px-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground"
+            size="xs"
+            className="px-1.5 text-muted-foreground hover:text-foreground"
             onClick={(e) => {
               e.stopPropagation()
               if (currentWorktreeId && worktreePath && branchSummary) {

--- a/src/renderer/src/components/right-sidebar/source-control/listing/section-header.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/section-header.tsx
@@ -30,7 +30,7 @@ export function SectionHeader({
           type="button"
           variant="ghost"
           size="xs"
-          className="h-auto min-h-6 min-w-0 flex-auto justify-start gap-x-1 gap-y-0 px-0.5 py-0.5 text-left font-semibold uppercase tracking-wider text-foreground/70 group-hover/section:text-accent-foreground"
+          className="h-auto min-h-6 min-w-0 flex-auto justify-start gap-x-1 gap-y-0 py-0.5 text-left font-semibold uppercase tracking-wider text-foreground/70 group-hover/section:text-accent-foreground"
           onClick={onToggle}
           aria-expanded={!isCollapsed}
         >

--- a/src/renderer/src/components/right-sidebar/source-control/listing/section-header.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/section-header.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 
 export function SectionHeader({
@@ -24,33 +25,37 @@ export function SectionHeader({
   // Why: shared rounded container so the hover background spans the whole row instead of clipping around the label.
   return (
     <div className="pl-1 pr-3 pt-3 pb-1">
-      <div className="group/section flex items-center gap-1 rounded-md pr-1 hover:bg-accent hover:text-accent-foreground">
-        <button
+      <div className="group/section flex flex-wrap items-center gap-x-1 rounded-md pr-1 hover:bg-accent hover:text-accent-foreground">
+        <Button
           type="button"
-          className="flex min-w-0 flex-1 items-center gap-1 px-0.5 py-0.5 text-left text-xs font-semibold uppercase tracking-wider text-foreground/70 group-hover/section:text-accent-foreground"
+          variant="ghost"
+          size="xs"
+          className="h-auto min-h-6 min-w-0 flex-auto justify-start gap-x-1 gap-y-0 px-0.5 py-0.5 text-left font-semibold uppercase tracking-wider text-foreground/70 group-hover/section:text-accent-foreground"
           onClick={onToggle}
           aria-expanded={!isCollapsed}
         >
           <ChevronDown
             className={cn('size-3.5 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
           />
-          <span className="truncate" title={label}>
-            {label}
-          </span>
-          {/* Why: no aria-label here — inside the toggle button it would rewrite the
+          <span className="min-w-0">
+            <span className="flex items-center gap-1">
+              <span className="min-w-0 whitespace-normal break-words">{label}</span>
+              {/* Why: no aria-label here — inside the toggle button it would rewrite the
               button's accessible name; the explanation stays a hover-only title. */}
-          <span className="shrink-0 text-[11px] font-medium tabular-nums" title={countTitle}>
-            {count}
-          </span>
-          {conflictCount > 0 && (
-            <span className="truncate text-[11px] font-medium text-destructive/80">
-              · {conflictCount}{' '}
-              {translate('auto.components.right.sidebar.SourceControl.413a3ba113', 'conflict')}
-              {conflictCount === 1 ? '' : 's'}
+              <span className="shrink-0 text-[11px] font-medium tabular-nums" title={countTitle}>
+                {count}
+              </span>
             </span>
-          )}
-        </button>
-        <div className="shrink-0 flex items-center">{actions}</div>
+            {conflictCount > 0 && (
+              <span className="block whitespace-normal text-[11px] font-medium text-destructive/80">
+                {conflictCount}{' '}
+                {translate('auto.components.right.sidebar.SourceControl.413a3ba113', 'conflict')}
+                {conflictCount === 1 ? '' : 's'}
+              </span>
+            )}
+          </span>
+        </Button>
+        <div className="ml-auto flex max-w-full flex-wrap items-center justify-end">{actions}</div>
       </div>
     </div>
   )

--- a/src/renderer/src/components/right-sidebar/source-control/listing/section-header.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/section-header.tsx
@@ -24,23 +24,26 @@ export function SectionHeader({
   // Why: shared rounded container so the hover background spans the whole row instead of clipping around the label.
   return (
     <div className="pl-1 pr-3 pt-3 pb-1">
-      <div className="group/section flex items-center rounded-md pr-1 hover:bg-accent hover:text-accent-foreground">
+      <div className="group/section flex items-center gap-1 rounded-md pr-1 hover:bg-accent hover:text-accent-foreground">
         <button
           type="button"
-          className="flex flex-1 items-center gap-1 px-0.5 py-0.5 text-left text-xs font-semibold uppercase tracking-wider text-foreground/70 group-hover/section:text-accent-foreground"
+          className="flex min-w-0 flex-1 items-center gap-1 px-0.5 py-0.5 text-left text-xs font-semibold uppercase tracking-wider text-foreground/70 group-hover/section:text-accent-foreground"
           onClick={onToggle}
+          aria-expanded={!isCollapsed}
         >
           <ChevronDown
             className={cn('size-3.5 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
           />
-          <span>{label}</span>
+          <span className="truncate" title={label}>
+            {label}
+          </span>
           {/* Why: no aria-label here — inside the toggle button it would rewrite the
               button's accessible name; the explanation stays a hover-only title. */}
-          <span className="text-[11px] font-medium tabular-nums" title={countTitle}>
+          <span className="shrink-0 text-[11px] font-medium tabular-nums" title={countTitle}>
             {count}
           </span>
           {conflictCount > 0 && (
-            <span className="text-[11px] font-medium text-destructive/80">
+            <span className="truncate text-[11px] font-medium text-destructive/80">
               · {conflictCount}{' '}
               {translate('auto.components.right.sidebar.SourceControl.413a3ba113', 'conflict')}
               {conflictCount === 1 ? '' : 's'}

--- a/src/renderer/src/components/right-sidebar/source-control/listing/uncommitted-sections.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/uncommitted-sections.tsx
@@ -169,12 +169,8 @@ export function SourceControlUncommittedSections(props: {
                     <Button
                       type="button"
                       variant="ghost"
-                      size="sm"
-                      className={
-                        items.some((entry) => entry.conflictStatus === 'unresolved')
-                          ? 'h-6 px-1.5 text-[10px] text-muted-foreground hover:text-foreground'
-                          : 'h-auto px-1.5 py-0.5 text-xs text-muted-foreground hover:text-foreground'
-                      }
+                      size="xs"
+                      className="px-1.5 text-muted-foreground hover:text-foreground"
                       onClick={(event) => {
                         event.stopPropagation()
                         props.onViewSection(sectionViewAction)

--- a/src/renderer/src/components/right-sidebar/source-control/listing/uncommitted-sections.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/uncommitted-sections.tsx
@@ -113,8 +113,7 @@ export function SourceControlUncommittedSections(props: {
               onToggle={() => props.toggleSection(id)}
               actions={
                 <>
-                  {/* Why: bulk actions are hover-only, but forced visible on no-hover pointers (touch/SSH; see AGENTS.md "SSH Use Case"). One wrapper so focusing any action reveals all three (else keyboard tabs into an invisible stop). */}
-                  <div className="flex items-center can-hover:opacity-0 transition-opacity group-hover/section:opacity-100 focus-within:opacity-100">
+                  <div className="flex items-center">
                     {canRevertAll && (
                       <ActionButton
                         icon={area === 'untracked' ? Trash : Undo2}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Source Control headers could push “View all” outside a narrow sidebar and crowd their labels and conflict counts. Headers now keep their text readable and move actions onto a second row when needed.

## What Changed

- Let header actions wrap naturally according to available space, with trailing alignment. Long headings wrap without losing words; file counts remain visible.
- Put unresolved-conflict counts on a separate line so they do not compete with the heading or actions.
- Keep bulk actions visible and use the standard 24px `xs` button for “View all” in both uncommitted and committed sections.
- Use the shared Button primitive for section toggles, including its keyboard focus ring, and expose `aria-expanded`.

## Why

Fixed-width actions and headers were competing for the same space. Natural wrapping preserves both the heading and available actions without new breakpoints, color values, or typography tokens. The same layout serves conflicts, changes, staged changes, untracked files, and committed changes.

## Linked Issue

[Slack report](https://stablygroup.slack.com/archives/C0AK2T3JEF4/p1788671272622119)

## Visual Proof

Actual hidden Electron renderer, fixture repository with a real merge conflict, unstaged/staged/untracked files, and committed branch changes. Before images use the pre-PR source; after images use the final implementation. Captures use the same 220px sidebar.

**Dark theme**

| Before | After |
| --- | --- |
| ![Before, dark](https://github.com/user-attachments/assets/fbdcf186-eea0-488d-8262-ea79e6e0c040) | ![After, dark](https://github.com/user-attachments/assets/9d06a45f-9fca-4b1b-8fb6-dd16eb62a2d4) |

**Light theme**

| Before | After |
| --- | --- |
| ![Before, light](https://github.com/user-attachments/assets/739ce14c-8756-4a27-abd7-d14b128ddc76) | ![After, light](https://github.com/user-attachments/assets/627f6b9a-9278-4854-98fe-8070abffd9ca) |

**400px sidebar with keyboard focus on the committed-section toggle:** actions fit on the heading row again.

![Wide sidebar and keyboard focus](https://github.com/user-attachments/assets/4edf5a10-47b7-413f-9d20-312762cef4b9)

## Testing

- [x] macOS Electron validation through Playwright CDP with `ORCA_BACKGROUND_LAUNCH=1`; verified the worktree identity.
- [x] Geometry assertions for all five sections at 220, 240, 320, and 400px in both themes: no header overflow, all action buttons contained.
- [x] Space collapses and Enter expands each section; expanded state checked. Shared focus styling inspected visually.
- [x] “View all” opens the staged-file diff; “Stage all” moves the untracked file into staged changes.
- [x] Existing branch-heading and section-order tests passed (15 tests). No new unit tests for CSS sizing; rendered checks cover the layout.
- `pnpm tc:web`, targeted `oxlint`, formatting, and `git diff --check` passed.
- Windows/Linux and actual SSH were not run. Shared CSS and presentation only; execution, provider, wire, and folder-workspace behavior are unchanged.

## Review

- [x] Small, focused change; self-reviewed.
- [x] Existing design tokens and sibling button sizing reused.
- [x] Visual proof attached outside the source diff.
- [x] Agent skill upstream boundary: not applicable.
- Full build and broader checks left to CI.
