### PR TITLE
fix(native-chat): remember structured chat model and effort picks

### DIFF
--- a/mobile/src/session/mobile-native-chat-session-option-persistence.test.ts
+++ b/mobile/src/session/mobile-native-chat-session-option-persistence.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveStructuredLaunchSeedOptions } from '../../../src/shared/native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from '../../../src/shared/native-chat-session-options'
+import type { RpcClient } from '../transport/rpc-client'
+import { persistMobileStructuredOptionPicks } from './mobile-native-chat-session-option-persistence'
+
+function hostClient(initial?: PersistedNativeChatSessionOptions) {
+  let stored = initial
+  const sendRequest = vi.fn(async (method: string, params?: unknown) => {
+    if (method === 'settings.get') {
+      return {
+        id: '1',
+        ok: true as const,
+        result: { settings: { nativeChatSessionOptions: stored } },
+        _meta: { runtimeId: 'host' }
+      }
+    }
+    stored = (params as { nativeChatSessionOptions: PersistedNativeChatSessionOptions })
+      .nativeChatSessionOptions
+    return { id: '2', ok: true as const, result: null, _meta: { runtimeId: 'host' } }
+  })
+  return { client: { sendRequest } as unknown as RpcClient, sendRequest, read: () => stored }
+}
+
+describe('persistMobileStructuredOptionPicks', () => {
+  it('writes the pick to the host record a later launch seeds from', async () => {
+    const host = hostClient()
+    await persistMobileStructuredOptionPicks({
+      client: host.client,
+      agent: 'codex',
+      picks: [{ modelId: 'gpt-fast', optionId: 'effort', value: 'low' }]
+    })
+    expect(resolveStructuredLaunchSeedOptions(host.read(), 'codex')).toEqual({
+      model: 'gpt-fast',
+      effort: 'low'
+    })
+  })
+
+  it('merges onto the host record instead of replacing another agent', async () => {
+    const host = hostClient({
+      claude: { model: 'opus', valuesByModel: { opus: { effort: 'high' } } }
+    })
+    await persistMobileStructuredOptionPicks({
+      client: host.client,
+      agent: 'codex',
+      picks: [{ modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' }]
+    })
+    expect(resolveStructuredLaunchSeedOptions(host.read(), 'claude')).toEqual({
+      model: 'opus',
+      effort: 'high'
+    })
+  })
+
+  it('serializes overlapping writes so the later pick keeps the earlier one', async () => {
+    const host = hostClient()
+    const first = persistMobileStructuredOptionPicks({
+      client: host.client,
+      agent: 'codex',
+      picks: [{ modelId: 'gpt-fast', optionId: 'effort', value: 'low' }]
+    })
+    const second = persistMobileStructuredOptionPicks({
+      client: host.client,
+      agent: 'claude',
+      picks: [{ modelId: 'opus', optionId: 'effort', value: 'high' }]
+    })
+    await Promise.all([first, second])
+    // A read-modify-write that raced would drop whichever agent read first.
+    expect(resolveStructuredLaunchSeedOptions(host.read(), 'codex')).toEqual({
+      model: 'gpt-fast',
+      effort: 'low'
+    })
+    expect(resolveStructuredLaunchSeedOptions(host.read(), 'claude')).toEqual({
+      model: 'opus',
+      effort: 'high'
+    })
+  })
+
+  it('stays silent without a host or without picks', async () => {
+    const host = hostClient()
+    await persistMobileStructuredOptionPicks({ client: null, agent: 'codex', picks: [] })
+    await persistMobileStructuredOptionPicks({ client: host.client, agent: 'codex', picks: [] })
+    expect(host.sendRequest).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/mobile-native-chat-session-option-persistence.test.ts
+++ b/mobile/src/session/mobile-native-chat-session-option-persistence.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
-import { resolveStructuredLaunchSeedOptions } from '../../../src/shared/native-chat-session-option-defaults'
+import {
+  applyNativeChatSessionOptionSettingsMutation,
+  resolveStructuredLaunchSeedOptions
+} from '../../../src/shared/native-chat-session-option-defaults'
 import type { PersistedNativeChatSessionOptions } from '../../../src/shared/native-chat-session-options'
 import type { RpcClient } from '../transport/rpc-client'
 import { persistMobileStructuredOptionPicks } from './mobile-native-chat-session-option-persistence'
@@ -7,16 +10,12 @@ import { persistMobileStructuredOptionPicks } from './mobile-native-chat-session
 function hostClient(initial?: PersistedNativeChatSessionOptions) {
   let stored = initial
   const sendRequest = vi.fn(async (method: string, params?: unknown) => {
-    if (method === 'settings.get') {
-      return {
-        id: '1',
-        ok: true as const,
-        result: { settings: { nativeChatSessionOptions: stored } },
-        _meta: { runtimeId: 'host' }
-      }
-    }
-    stored = (params as { nativeChatSessionOptions: PersistedNativeChatSessionOptions })
-      .nativeChatSessionOptions
+    expect(method).toBe('settings.mutateNativeChatSessionOptions')
+    const next = applyNativeChatSessionOptionSettingsMutation(
+      stored,
+      params as Parameters<typeof applyNativeChatSessionOptionSettingsMutation>[1]
+    )
+    stored = next ?? stored
     return { id: '2', ok: true as const, result: null, _meta: { runtimeId: 'host' } }
   })
   return { client: { sendRequest } as unknown as RpcClient, sendRequest, read: () => stored }
@@ -51,7 +50,7 @@ describe('persistMobileStructuredOptionPicks', () => {
     })
   })
 
-  it('serializes overlapping writes so the later pick keeps the earlier one', async () => {
+  it('sends concurrent deltas that preserve both picks on the host', async () => {
     const host = hostClient()
     const first = persistMobileStructuredOptionPicks({
       client: host.client,
@@ -64,7 +63,6 @@ describe('persistMobileStructuredOptionPicks', () => {
       picks: [{ modelId: 'opus', optionId: 'effort', value: 'high' }]
     })
     await Promise.all([first, second])
-    // A read-modify-write that raced would drop whichever agent read first.
     expect(resolveStructuredLaunchSeedOptions(host.read(), 'codex')).toEqual({
       model: 'gpt-fast',
       effort: 'low'
@@ -80,5 +78,22 @@ describe('persistMobileStructuredOptionPicks', () => {
     await persistMobileStructuredOptionPicks({ client: null, agent: 'codex', picks: [] })
     await persistMobileStructuredOptionPicks({ client: host.client, agent: 'codex', picks: [] })
     expect(host.sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('uses one targeted host mutation instead of a settings read-modify-write', async () => {
+    const host = hostClient()
+    await persistMobileStructuredOptionPicks({
+      client: host.client,
+      agent: 'codex',
+      picks: [{ modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' }]
+    })
+    expect(host.sendRequest).toHaveBeenCalledExactlyOnceWith(
+      'settings.mutateNativeChatSessionOptions',
+      {
+        type: 'apply-picks',
+        agent: 'codex',
+        picks: [{ modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' }]
+      }
+    )
   })
 })

--- a/mobile/src/session/mobile-native-chat-session-option-persistence.ts
+++ b/mobile/src/session/mobile-native-chat-session-option-persistence.ts
@@ -1,0 +1,50 @@
+import type { AgentType } from '../../../src/shared/agent-status-types'
+import { applyNativeChatSessionOptionPicks } from '../../../src/shared/native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from '../../../src/shared/native-chat-session-options'
+import type { StructuredSessionOptionPick } from '../../../src/shared/structured-agent-session-options'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcSuccess } from '../transport/types'
+
+/**
+ * Why serialized: the host shallow-merges `settings.update`, so the whole
+ * `nativeChatSessionOptions` object goes over the wire and two picks racing on it would
+ * drop the earlier one. Read-modify-write per pick batch, one batch at a time.
+ */
+let write: Promise<unknown> = Promise.resolve()
+
+async function readPersistedSessionOptions(
+  client: RpcClient
+): Promise<PersistedNativeChatSessionOptions | undefined> {
+  const response = await client.sendRequest('settings.get')
+  if (!response.ok) {
+    return undefined
+  }
+  const result = (response as RpcSuccess).result as {
+    settings?: { nativeChatSessionOptions?: PersistedNativeChatSessionOptions }
+  } | null
+  return result?.settings?.nativeChatSessionOptions
+}
+
+/** The host owns the record a later launch seeds from, so a phone-side pick writes there
+ *  rather than to any client-local store. Best-effort: a failed write only costs the
+ *  next session its remembered start. */
+export function persistMobileStructuredOptionPicks(args: {
+  client: RpcClient | null
+  agent: AgentType
+  picks: readonly StructuredSessionOptionPick[]
+}): Promise<void> {
+  const { agent, client, picks } = args
+  if (!client || picks.length === 0) {
+    return Promise.resolve()
+  }
+  write = write
+    .catch(() => undefined)
+    .then(async () => {
+      const persisted = await readPersistedSessionOptions(client)
+      await client.sendRequest('settings.update', {
+        nativeChatSessionOptions: applyNativeChatSessionOptionPicks({ persisted, agent, picks })
+      })
+    })
+    .catch(() => undefined)
+  return write.then(() => undefined)
+}

--- a/mobile/src/session/mobile-native-chat-session-option-persistence.ts
+++ b/mobile/src/session/mobile-native-chat-session-option-persistence.ts
@@ -1,29 +1,6 @@
 import type { AgentType } from '../../../src/shared/agent-status-types'
-import { applyNativeChatSessionOptionPicks } from '../../../src/shared/native-chat-session-option-defaults'
-import type { PersistedNativeChatSessionOptions } from '../../../src/shared/native-chat-session-options'
 import type { StructuredSessionOptionPick } from '../../../src/shared/structured-agent-session-options'
 import type { RpcClient } from '../transport/rpc-client'
-import type { RpcSuccess } from '../transport/types'
-
-/**
- * Why serialized: the host shallow-merges `settings.update`, so the whole
- * `nativeChatSessionOptions` object goes over the wire and two picks racing on it would
- * drop the earlier one. Read-modify-write per pick batch, one batch at a time.
- */
-let write: Promise<unknown> = Promise.resolve()
-
-async function readPersistedSessionOptions(
-  client: RpcClient
-): Promise<PersistedNativeChatSessionOptions | undefined> {
-  const response = await client.sendRequest('settings.get')
-  if (!response.ok) {
-    return undefined
-  }
-  const result = (response as RpcSuccess).result as {
-    settings?: { nativeChatSessionOptions?: PersistedNativeChatSessionOptions }
-  } | null
-  return result?.settings?.nativeChatSessionOptions
-}
 
 /** The host owns the record a later launch seeds from, so a phone-side pick writes there
  *  rather than to any client-local store. Best-effort: a failed write only costs the
@@ -37,14 +14,12 @@ export function persistMobileStructuredOptionPicks(args: {
   if (!client || picks.length === 0) {
     return Promise.resolve()
   }
-  write = write
-    .catch(() => undefined)
-    .then(async () => {
-      const persisted = await readPersistedSessionOptions(client)
-      await client.sendRequest('settings.update', {
-        nativeChatSessionOptions: applyNativeChatSessionOptionPicks({ persisted, agent, picks })
-      })
+  return client
+    .sendRequest('settings.mutateNativeChatSessionOptions', {
+      type: 'apply-picks',
+      agent,
+      picks
     })
+    .then(() => undefined)
     .catch(() => undefined)
-  return write.then(() => undefined)
 }

--- a/mobile/src/session/use-mobile-structured-agent-options.ts
+++ b/mobile/src/session/use-mobile-structured-agent-options.ts
@@ -15,6 +15,7 @@ import {
   commitStructuredAgentSessionOption,
   commitStructuredAgentSessionOptionValues,
   createStructuredAgentSessionOptionState,
+  structuredAgentSessionOptionPicks,
   structuredAgentSessionOptionSnapshot
 } from '../../../src/shared/structured-agent-session-options'
 import type { RpcClient } from '../transport/rpc-client'
@@ -22,6 +23,7 @@ import {
   callAgentSession,
   type StructuredAgentSessionMutate
 } from './mobile-structured-agent-session-rpc'
+import { persistMobileStructuredOptionPicks } from './mobile-native-chat-session-option-persistence'
 
 type StructuredOptionsController = {
   optionSnapshot: SessionOptionDescriptor[]
@@ -101,14 +103,22 @@ export function useMobileStructuredAgentOptions(args: {
           return result.status !== 'rejected'
         }
         if (result.status === 'accepted') {
+          const committed = result.value.options ?? { [id]: value }
           setOptionState((current) =>
             current.record === targetRecord && result.sameFence
-              ? commitStructuredAgentSessionOptionValues(
-                  current,
-                  result.value.options ?? { [id]: value }
-                )
+              ? commitStructuredAgentSessionOptionValues(current, committed)
               : current
           )
+          // Only an accepted pick: an `unknown` outcome commits optimistically to the
+          // visible record, and remembering one the provider refused would seed a
+          // launch the user never chose.
+          if (agent === 'claude' || agent === 'codex') {
+            void persistMobileStructuredOptionPicks({
+              client,
+              agent,
+              picks: structuredAgentSessionOptionPicks(optionState, committed)
+            })
+          }
           return true
         }
         if (result.status === 'unknown') {
@@ -128,7 +138,7 @@ export function useMobileStructuredAgentOptions(args: {
         )
       }
     },
-    [mutate, optionState]
+    [agent, client, mutate, optionState]
   )
 
   const invokeStructuredOption = useCallback(async () => false, [])

--- a/mobile/src/session/use-mobile-structured-agent-session.test.tsx
+++ b/mobile/src/session/use-mobile-structured-agent-session.test.tsx
@@ -138,7 +138,7 @@ function runningStatusItem(): AgentJournalRenderItem {
   }
 }
 
-function defaultSendRequest(method: string, params?: Record<string, unknown>) {
+async function defaultSendRequest(method: string, params?: Record<string, unknown>) {
   if (method === 'agentSession.send') {
     return ok({
       ok: true,
@@ -420,6 +420,11 @@ describe('useMobileStructuredAgentSession', () => {
       }),
       expect.any(Object)
     )
+    expect(sendRequest).toHaveBeenCalledWith('settings.mutateNativeChatSessionOptions', {
+      type: 'apply-picks',
+      agent: 'codex',
+      picks: [{ modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' }]
+    })
 
     await act(async () => {
       expect(await hook.respondPermission(hook.permission!.options[0]!.send)).toBe(true)

--- a/src/main/runtime/orca-runtime-pty-foreground-process-reads.ts
+++ b/src/main/runtime/orca-runtime-pty-foreground-process-reads.ts
@@ -19,6 +19,7 @@ import type { FeatureInteractionId } from '../../shared/feature-interactions'
 import type { RuntimeClientSettingsUpdate } from './runtime-client-settings'
 import type { TerminalQuickCommand } from '../../shared/terminal-quick-command-types'
 import type { TerminalQuickCommandMutation } from '../../shared/terminal-quick-commands'
+import type { NativeChatSessionOptionSettingsMutation } from '../../shared/native-chat-session-options'
 import type { Automation } from '../../shared/automations-types'
 
 export class OrcaRuntimeWithPtyForegroundProcessReads extends OrcaRuntimeWithStateFields {
@@ -212,6 +213,10 @@ export class OrcaRuntimeWithPtyForegroundProcessReads extends OrcaRuntimeWithSta
 
   updateClientPRBotAuthorOverride(args: { author: string; isBot: boolean }) {
     return this.clientSettings.updatePRBotAuthorOverride(args)
+  }
+
+  updateClientNativeChatSessionOptions(mutation: NativeChatSessionOptionSettingsMutation): void {
+    this.clientSettings.updateNativeChatSessionOptions(mutation)
   }
 
   listAutomations(): Automation[] {

--- a/src/main/runtime/orca-runtime-tests/paired-settings.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/paired-settings.spec.ts
@@ -84,6 +84,78 @@ describe('OrcaRuntimeService', () => {
     expect(runtime.getClientSettings()).not.toHaveProperty('terminalQuickCommands')
   })
 
+  it('applies native-chat option deltas atomically on the runtime host', () => {
+    let settings = {
+      ...store.getSettings(),
+      nativeChatSessionOptions: {
+        claude: { model: 'opus', valuesByModel: { opus: { effort: 'high' } } }
+      }
+    }
+    const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
+      settings = { ...settings, ...updates }
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => settings,
+      updateSettings
+    } as never)
+
+    runtime.updateClientNativeChatSessionOptions({
+      type: 'apply-picks',
+      agent: 'codex',
+      picks: [
+        { modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' },
+        { modelId: 'gpt-fast', optionId: 'effort', value: 'low' }
+      ]
+    })
+    runtime.updateClientNativeChatSessionOptions({
+      type: 'apply-picks',
+      agent: 'claude',
+      picks: [{ modelId: 'sonnet', optionId: 'model', value: 'sonnet' }]
+    })
+
+    expect(settings.nativeChatSessionOptions).toEqual({
+      claude: {
+        model: 'sonnet',
+        valuesByModel: { opus: { effort: 'high' } }
+      },
+      codex: {
+        model: 'gpt-fast',
+        valuesByModel: { 'gpt-fast': { effort: 'low' } }
+      }
+    })
+    expect(updateSettings).toHaveBeenCalledTimes(2)
+  })
+
+  it('compares retired models against the host record at mutation time', () => {
+    let settings = {
+      ...store.getSettings(),
+      nativeChatSessionOptions: { grok: { model: 'grok-5' } }
+    }
+    const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
+      settings = { ...settings, ...updates }
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => settings,
+      updateSettings
+    } as never)
+
+    runtime.updateClientNativeChatSessionOptions({
+      type: 'clear-model-if-missing',
+      agent: 'grok',
+      availableModelIds: ['grok-5']
+    })
+    expect(updateSettings).not.toHaveBeenCalled()
+
+    runtime.updateClientNativeChatSessionOptions({
+      type: 'clear-model-if-missing',
+      agent: 'grok',
+      availableModelIds: ['grok-4.5']
+    })
+    expect(settings.nativeChatSessionOptions).toEqual({ grok: {} })
+  })
+
   it('rejects a concurrent add after the quick command limit is reached', () => {
     const terminalQuickCommands = Array.from({ length: MAX_QUICK_COMMANDS }, (_, index) => ({
       id: `command-${index}`,

--- a/src/main/runtime/rpc/methods/client-native-chat-settings.test.ts
+++ b/src/main/runtime/rpc/methods/client-native-chat-settings.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcRequest } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { CLIENT_UI_METHODS } from './client-ui'
+
+const request = (params: unknown): RpcRequest => ({
+  id: 'req-1',
+  authToken: 'tok',
+  method: 'settings.mutateNativeChatSessionOptions',
+  params
+})
+
+describe('native-chat settings RPC', () => {
+  it('routes option deltas to the runtime-owned atomic update', async () => {
+    const updateClientNativeChatSessionOptions = vi.fn()
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateClientNativeChatSessionOptions
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+    const mutation = {
+      type: 'apply-picks' as const,
+      agent: 'codex' as const,
+      picks: [
+        { modelId: 'gpt-fast', optionId: 'model' as const, value: 'gpt-fast' },
+        { modelId: 'gpt-fast', optionId: 'effort' as const, value: 'low' }
+      ]
+    }
+
+    const response = await dispatcher.dispatch(request(mutation))
+
+    expect(updateClientNativeChatSessionOptions).toHaveBeenCalledExactlyOnceWith(mutation)
+    expect(response).toMatchObject({ ok: true, result: { ok: true } })
+  })
+
+  it('rejects malformed option deltas', async () => {
+    const updateClientNativeChatSessionOptions = vi.fn()
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateClientNativeChatSessionOptions
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+    for (const mutation of [
+      { type: 'apply-picks', agent: 'codex', picks: [] },
+      {
+        type: 'apply-picks',
+        agent: 'opencode',
+        picks: [{ modelId: 'model', optionId: 'model', value: 'model' }]
+      },
+      {
+        type: 'apply-picks',
+        agent: 'codex',
+        picks: [{ modelId: 'model', optionId: 'arbitrary', value: 'value' }]
+      },
+      {
+        type: 'apply-picks',
+        agent: 'codex',
+        picks: [{ modelId: 'model', optionId: 'effort', value: true }]
+      },
+      {
+        type: 'apply-picks',
+        agent: 'cursor',
+        picks: [{ modelId: 'model', optionId: 'fastMode', value: 'true' }]
+      },
+      {
+        type: 'clear-model-if-missing',
+        agent: 'grok',
+        availableModelIds: []
+      }
+    ]) {
+      const response = await dispatcher.dispatch(request(mutation))
+      expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    }
+    expect(updateClientNativeChatSessionOptions).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/rpc/methods/client-settings-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-settings-schemas.ts
@@ -18,6 +18,45 @@ export const PRBotAuthorOverrideUpdate = z
   .object({ author: z.string(), isBot: z.boolean() })
   .strict()
 
+const NativeChatSessionOptionPickBase = {
+  modelId: z.string().trim().min(1).max(512),
+  adoptModelAsLaunchDefault: z.boolean().optional()
+}
+
+const NativeChatSessionOptionPick = z.union([
+  z
+    .object({
+      ...NativeChatSessionOptionPickBase,
+      optionId: z.enum(['model', 'effort']),
+      value: z.string().trim().min(1).max(512)
+    })
+    .strict(),
+  z
+    .object({
+      ...NativeChatSessionOptionPickBase,
+      optionId: z.enum(['fastMode', 'thinking']),
+      value: z.boolean()
+    })
+    .strict()
+])
+
+export const NativeChatSessionOptionsMutation = z.discriminatedUnion('type', [
+  z
+    .object({
+      type: z.literal('apply-picks'),
+      agent: z.enum(['claude', 'codex', 'gemini', 'cursor', 'grok']),
+      picks: z.array(NativeChatSessionOptionPick).min(1).max(8)
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('clear-model-if-missing'),
+      agent: z.enum(['claude', 'codex', 'gemini', 'cursor', 'grok']),
+      availableModelIds: z.array(z.string().trim().min(1).max(512)).min(1).max(256)
+    })
+    .strict()
+])
+
 const GitHubProjectRef = z
   .object({
     owner: z.string(),

--- a/src/main/runtime/rpc/methods/client-ui.ts
+++ b/src/main/runtime/rpc/methods/client-ui.ts
@@ -1,7 +1,11 @@
 import { omitPairingLocalUiFields } from '../../../../shared/pairing-local-ui-fields'
 import type { PersistedUIState } from '../../../../shared/persisted-ui-state-types'
 import { defineMethod, type RpcMethod } from '../core'
-import { PRBotAuthorOverrideUpdate, SettingsUpdate } from './client-settings-schemas'
+import {
+  NativeChatSessionOptionsMutation,
+  PRBotAuthorOverrideUpdate,
+  SettingsUpdate
+} from './client-settings-schemas'
 import { FeatureInteractionIdParam, UiUpdate } from './client-ui-schemas'
 // Type-only side effect: keeps the schema/PersistedUIState parity assertions in
 // the typecheck graph so drift fails the build instead of a paired client.
@@ -43,6 +47,14 @@ export const CLIENT_UI_METHODS: RpcMethod[] = [
     handler: (params, { runtime }) => ({
       settings: runtime.updateClientPRBotAuthorOverride(params)
     })
+  }),
+  defineMethod({
+    name: 'settings.mutateNativeChatSessionOptions',
+    params: NativeChatSessionOptionsMutation,
+    handler: (params, { runtime }) => {
+      runtime.updateClientNativeChatSessionOptions(params)
+      return { ok: true as const }
+    }
   }),
   defineMethod({
     name: 'ui.get',

--- a/src/main/runtime/runtime-client-settings.ts
+++ b/src/main/runtime/runtime-client-settings.ts
@@ -10,6 +10,8 @@ import {
 } from '../../shared/terminal-quick-commands'
 import { haveSameDisabledTuiAgents } from '../../shared/tui-agent-selection'
 import type { GlobalSettings } from '../../shared/global-settings-types'
+import { applyNativeChatSessionOptionSettingsMutation } from '../../shared/native-chat-session-option-defaults'
+import type { NativeChatSessionOptionSettingsMutation } from '../../shared/native-chat-session-options'
 import { getHostDisplayLabelOverrides } from '../../shared/host-setting-overrides'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { TerminalQuickCommand } from '../../shared/terminal-quick-command-types'
@@ -170,6 +172,19 @@ export class RuntimeClientSettingsController {
       { notifyListeners: true }
     )
     return this.get()
+  }
+
+  updateNativeChatSessionOptions(mutation: NativeChatSessionOptionSettingsMutation): void {
+    if (!this.store?.getSettings || !this.store.updateSettings) {
+      throw new Error('runtime_unavailable')
+    }
+    const next = applyNativeChatSessionOptionSettingsMutation(
+      this.store.getSettings().nativeChatSessionOptions,
+      mutation
+    )
+    if (next) {
+      this.store.updateSettings({ nativeChatSessionOptions: next }, { notifyListeners: true })
+    }
   }
 
   private reconcileManagedAgentHooks(): Promise<void> {

--- a/src/main/runtime/runtime-rpc-mobile-native-chat-settings.test.ts
+++ b/src/main/runtime/runtime-rpc-mobile-native-chat-settings.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { MOBILE_RPC_METHOD_ALLOWLIST } from './runtime-rpc/runtime-rpc-mobile-method-allowlist'
+
+describe('mobile native-chat settings RPC', () => {
+  it('allows a paired phone to persist a structured option pick', () => {
+    expect(MOBILE_RPC_METHOD_ALLOWLIST.has('settings.mutateNativeChatSessionOptions')).toBe(true)
+  })
+})

--- a/src/main/runtime/runtime-rpc/runtime-rpc-mobile-method-allowlist.ts
+++ b/src/main/runtime/runtime-rpc/runtime-rpc-mobile-method-allowlist.ts
@@ -224,6 +224,7 @@ export const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'nativeChat.unsubscribe',
   'settings.get',
   'settings.getTerminalQuickCommands',
+  'settings.mutateNativeChatSessionOptions',
   'settings.update',
   'settings.updateTerminalQuickCommands',
   'ssh.connect',

--- a/src/main/runtime/runtime-store-contract.ts
+++ b/src/main/runtime/runtime-store-contract.ts
@@ -115,6 +115,7 @@ export type RuntimeStore = {
     worktreeVisibilityDefaults?: GlobalSettings['worktreeVisibilityDefaults']
     hostSettingOverrides?: GlobalSettings['hostSettingOverrides']
     agentSkillSharingEnabled?: GlobalSettings['agentSkillSharingEnabled']
+    nativeChatSessionOptions?: GlobalSettings['nativeChatSessionOptions']
   }
   // Why: narrow to `unknown` return so test mocks can return void without
   // a cast. The runtime never reads the return value — the persisted value

--- a/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
@@ -3,7 +3,6 @@
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CatalogModel } from '../../../../shared/agent-session-option-catalog'
-import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
 import {
   clearNativeChatModelEnrichmentForTests,
   ensureNativeChatModelEnrichment,
@@ -11,15 +10,14 @@ import {
 } from './native-chat-session-option-enrichment'
 
 const mocks = vi.hoisted(() => ({
-  storeState: {
-    settings: {} as { nativeChatSessionOptions?: PersistedNativeChatSessionOptions },
-    updateSettings: vi.fn()
-  },
+  callRuntimeRpc: vi.fn(),
   createNativeChatPtySessionOptions: vi.fn(),
   discoverNativeChatCatalogModels: vi.fn()
 }))
 
-vi.mock('../../store', () => ({ useAppStore: { getState: () => mocks.storeState } }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  callRuntimeRpc: mocks.callRuntimeRpc
+}))
 
 vi.mock('./native-chat-pty-session-options', () => ({
   createNativeChatPtySessionOptions: mocks.createNativeChatPtySessionOptions
@@ -36,79 +34,63 @@ const { retirePersistedModelMissingFromDiscovery, useNativeChatSessionOptions } 
 const models = (...ids: string[]): CatalogModel[] =>
   ids.map((id) => ({ id, label: id, options: [] }))
 
-function persist(options: PersistedNativeChatSessionOptions): void {
-  mocks.storeState.settings = { nativeChatSessionOptions: options }
-}
+const LOCAL_TARGET = { kind: 'local' } as const
 
 /** The persisted model becomes `-m <id>` at every launch site, including ones that
  *  never render the picker, and grok exits fatally on an id it no longer lists. */
 describe('retirePersistedModelMissingFromDiscovery', () => {
   beforeEach(() => {
-    mocks.storeState.updateSettings.mockReset().mockResolvedValue(undefined)
-    mocks.storeState.settings = {}
+    mocks.callRuntimeRpc.mockReset().mockResolvedValue({ ok: true })
   })
 
   it('clears a persisted id the authoritative probe no longer lists', async () => {
-    persist({ grok: { model: 'grok-build', valuesByModel: { 'grok-build': { effort: 'low' } } } })
     await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
-    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
-      // Why keep valuesByModel: the option values are still valid if the user
-      // reselects that model on another host.
-      nativeChatSessionOptions: {
-        grok: { valuesByModel: { 'grok-build': { effort: 'low' } } }
+    expect(mocks.callRuntimeRpc).toHaveBeenCalledWith(
+      LOCAL_TARGET,
+      'settings.mutateNativeChatSessionOptions',
+      {
+        type: 'clear-model-if-missing',
+        agent: 'grok',
+        availableModelIds: ['grok-4.5']
       }
-    })
+    )
   })
 
-  it('keeps a persisted id the probe still lists', async () => {
-    persist({ grok: { model: 'grok-4.5' } })
+  it('lets the host keep a concurrently selected model from the available list', async () => {
     await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5', 'grok-build'))
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+    expect(mocks.callRuntimeRpc).toHaveBeenCalledWith(
+      LOCAL_TARGET,
+      'settings.mutateNativeChatSessionOptions',
+      {
+        type: 'clear-model-if-missing',
+        agent: 'grok',
+        availableModelIds: ['grok-4.5', 'grok-build']
+      }
+    )
   })
 
   it('treats an empty list as a failed probe, not an empty account', async () => {
-    persist({ grok: { model: 'grok-build' } })
     await retirePersistedModelMissingFromDiscovery('grok', [])
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+    expect(mocks.callRuntimeRpc).not.toHaveBeenCalled()
   })
 
   it('leaves additive agents alone, whose lists extend the seed rather than replace it', async () => {
-    // Cursor's probe not listing a model is no evidence the model is gone.
-    persist({ cursor: { model: 'gpt-5.3-codex' } })
     await retirePersistedModelMissingFromDiscovery('cursor', models('auto'))
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+    expect(mocks.callRuntimeRpc).not.toHaveBeenCalled()
   })
 
-  it('does nothing when no model was ever persisted', async () => {
-    persist({ grok: { valuesByModel: { 'grok-4.5': { effort: 'high' } } } })
-    await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
-  })
-
-  it('survives settings that were never written', async () => {
-    mocks.storeState.settings = {}
+  it('does not depend on a client-local settings snapshot', async () => {
     await expect(
       retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
     ).resolves.toBeUndefined()
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+    expect(mocks.callRuntimeRpc).toHaveBeenCalledOnce()
   })
 
-  it('re-reads live settings at apply so a pick landing mid-retirement survives', async () => {
-    // Regression: retirement captured the settings snapshot before its write was
-    // queued, so a pick landing in between was clobbered back to the old shape.
-    persist({ grok: { model: 'grok-build' } })
-    const pending = retirePersistedModelMissingFromDiscovery('grok', models('grok-5'))
-    persist({ grok: { model: 'grok-5' } })
-    await pending
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
-  })
-
-  it('retires only the named agent, leaving other agents’ picks intact', async () => {
-    persist({ grok: { model: 'grok-build' }, claude: { model: 'opus' } })
-    await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
-    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
-      nativeChatSessionOptions: { grok: {}, claude: { model: 'opus' } }
-    })
+  it('swallows a failed best-effort retirement write', async () => {
+    mocks.callRuntimeRpc.mockRejectedValue(new Error('runtime offline'))
+    await expect(
+      retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
+    ).resolves.toBeUndefined()
   })
 })
 
@@ -128,8 +110,7 @@ describe('useNativeChatSessionOptions retirement on mount', () => {
 
   beforeEach(() => {
     clearNativeChatModelEnrichmentForTests()
-    mocks.storeState.updateSettings.mockReset().mockResolvedValue(undefined)
-    mocks.storeState.settings = {}
+    mocks.callRuntimeRpc.mockReset().mockResolvedValue({ ok: true })
     mocks.discoverNativeChatCatalogModels.mockReset().mockResolvedValue(null)
     // A stable snapshot reference: useSyncExternalStore re-renders forever otherwise.
     const emptySnapshot: never[] = []
@@ -143,7 +124,6 @@ describe('useNativeChatSessionOptions retirement on mount', () => {
   })
 
   it('retires a persisted id against models the probe already cached', async () => {
-    persist({ grok: { model: 'grok-build' } })
     ensureNativeChatModelEnrichment({
       agent: 'grok',
       hostKey: 'local',
@@ -154,19 +134,46 @@ describe('useNativeChatSessionOptions retirement on mount', () => {
     mountPane()
 
     await vi.waitFor(() =>
-      expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
-        nativeChatSessionOptions: { grok: {} }
-      })
+      expect(mocks.callRuntimeRpc).toHaveBeenCalledWith(
+        LOCAL_TARGET,
+        'settings.mutateNativeChatSessionOptions',
+        expect.objectContaining({ type: 'clear-model-if-missing', agent: 'grok' })
+      )
     )
   })
 
   it('leaves the persisted id alone while the probe is still in flight', async () => {
-    persist({ grok: { model: 'grok-build' } })
     mocks.discoverNativeChatCatalogModels.mockReturnValue(new Promise(() => {}))
 
     mountPane()
 
     await Promise.resolve()
-    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+    expect(mocks.callRuntimeRpc).not.toHaveBeenCalled()
+  })
+
+  it('keeps PTY picks in the client settings record used by paired launches', async () => {
+    mountPane()
+    const persistSelection = mocks.createNativeChatPtySessionOptions.mock.calls[0]?.[0]
+      ?.persistSelection as
+      | ((pick: {
+          modelId: string
+          optionId: string
+          value: string
+          adoptModelAsLaunchDefault: boolean
+        }) => Promise<void>)
+      | undefined
+
+    await persistSelection?.({
+      modelId: 'grok-4.5',
+      optionId: 'effort',
+      value: 'high',
+      adoptModelAsLaunchDefault: true
+    })
+
+    expect(mocks.callRuntimeRpc).toHaveBeenCalledWith(
+      LOCAL_TARGET,
+      'settings.mutateNativeChatSessionOptions',
+      expect.objectContaining({ type: 'apply-picks', agent: 'grok' })
+    )
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-settings-write.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-settings-write.ts
@@ -1,0 +1,31 @@
+import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
+import { useAppStore } from '../../store'
+
+/**
+ * Why: every nativeChatSessionOptions writer — a pick from any pane, a probe
+ * retirement — serializes on this one chain and re-reads live settings at apply
+ * time. updateSettings shallow-merges the whole object, so an interleaved write
+ * from a snapshot captured earlier would silently clobber a concurrent pick.
+ * The update runs against the settled base and may return null to skip writing.
+ *
+ * Lives outside the PTY hook because the structured surface writes the same key
+ * from a different pane, and two chains would not order against each other.
+ */
+let settingsWrite: Promise<unknown> = Promise.resolve()
+
+export function enqueueSessionOptionSettingsWrite(
+  update: (
+    base: PersistedNativeChatSessionOptions | undefined
+  ) => PersistedNativeChatSessionOptions | null
+): Promise<void> {
+  const write = settingsWrite
+    .catch(() => undefined)
+    .then(() => {
+      const next = update(useAppStore.getState().settings?.nativeChatSessionOptions)
+      return next
+        ? useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
+        : undefined
+    })
+  settingsWrite = write
+  return write.then(() => undefined)
+}

--- a/src/renderer/src/components/native-chat/native-chat-session-option-settings-write.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-settings-write.ts
@@ -1,31 +1,15 @@
-import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
-import { useAppStore } from '../../store'
+import type { NativeChatSessionOptionSettingsMutation } from '../../../../shared/native-chat-session-options'
+import { callRuntimeRpc, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 
 /**
- * Why: every nativeChatSessionOptions writer — a pick from any pane, a probe
- * retirement — serializes on this one chain and re-reads live settings at apply
- * time. updateSettings shallow-merges the whole object, so an interleaved write
- * from a snapshot captured earlier would silently clobber a concurrent pick.
- * The update runs against the settled base and may return null to skip writing.
- *
- * Lives outside the PTY hook because the structured surface writes the same key
- * from a different pane, and two chains would not order against each other.
+ * The executing runtime applies deltas to its latest record. This keeps paired-runtime
+ * choices on their owner and prevents desktop/mobile writes from replacing one another.
  */
-let settingsWrite: Promise<unknown> = Promise.resolve()
-
 export function enqueueSessionOptionSettingsWrite(
-  update: (
-    base: PersistedNativeChatSessionOptions | undefined
-  ) => PersistedNativeChatSessionOptions | null
+  target: RuntimeClientTarget,
+  mutation: NativeChatSessionOptionSettingsMutation
 ): Promise<void> {
-  const write = settingsWrite
+  return callRuntimeRpc(target, 'settings.mutateNativeChatSessionOptions', mutation)
+    .then(() => undefined)
     .catch(() => undefined)
-    .then(() => {
-      const next = update(useAppStore.getState().settings?.nativeChatSessionOptions)
-      return next
-        ? useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
-        : undefined
-    })
-  settingsWrite = write
-  return write.then(() => undefined)
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -4,10 +4,6 @@ import {
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
-import {
-  clearNativeChatSessionOptionModel,
-  updateNativeChatSessionOptionDefaults
-} from '../../../../shared/native-chat-session-option-defaults'
 import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
 import {
   createNativeChatPtySessionOptions,
@@ -29,6 +25,7 @@ import { enqueueSessionOptionSettingsWrite } from './native-chat-session-option-
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
 const subscribeEmpty = (): (() => void) => () => {}
 const getEmptySnapshot = (): SessionOptionDescriptor[] => EMPTY_SNAPSHOT
+const CLIENT_SETTINGS_TARGET = { kind: 'local' } as const
 
 /**
  * Why: the picker drops a retired model, but the persisted default is what launches
@@ -47,11 +44,10 @@ export async function retirePersistedModelMissingFromDiscovery(
   if (models.length === 0) {
     return
   }
-  await enqueueSessionOptionSettingsWrite((persisted) => {
-    const modelId = persisted?.[agent]?.model
-    return typeof modelId === 'string' && modelId && !models.some((model) => model.id === modelId)
-      ? clearNativeChatSessionOptionModel(persisted, agent)
-      : null
+  await enqueueSessionOptionSettingsWrite(CLIENT_SETTINGS_TARGET, {
+    type: 'clear-model-if-missing',
+    agent,
+    availableModelIds: models.map((model) => model.id)
   })
 }
 
@@ -105,16 +101,12 @@ export function useNativeChatSessionOptions(args: {
       dispatchCommand,
       onAgentPicker,
       persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) =>
-        enqueueSessionOptionSettingsWrite((persisted) =>
-          updateNativeChatSessionOptionDefaults({
-            persisted,
-            agent,
-            modelId,
-            optionId,
-            value,
-            adoptModelAsLaunchDefault
-          })
-        )
+        // Paired PTY launches still assemble their launch preferences from client settings.
+        enqueueSessionOptionSettingsWrite(CLIENT_SETTINGS_TARGET, {
+          type: 'apply-picks',
+          agent,
+          picks: [{ modelId, optionId, value, adoptModelAsLaunchDefault }]
+        })
     })
   }, [
     agent,

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -8,11 +8,7 @@ import {
   clearNativeChatSessionOptionModel,
   updateNativeChatSessionOptionDefaults
 } from '../../../../shared/native-chat-session-option-defaults'
-import type {
-  PersistedNativeChatSessionOptions,
-  SessionOptionDescriptor
-} from '../../../../shared/native-chat-session-options'
-import { useAppStore } from '../../store'
+import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
 import {
   createNativeChatPtySessionOptions,
   type NativeChatPtySessionOptionsSurface
@@ -28,35 +24,11 @@ import {
   resolveNativeChatModelDiscoveryContext
 } from './native-chat-session-option-discovery'
 import { readClaudeSessionOptionsFromTerminalScreen } from './claude-terminal-session-options'
+import { enqueueSessionOptionSettingsWrite } from './native-chat-session-option-settings-write'
 
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
 const subscribeEmpty = (): (() => void) => () => {}
 const getEmptySnapshot = (): SessionOptionDescriptor[] => EMPTY_SNAPSHOT
-
-/**
- * Why: every nativeChatSessionOptions writer — a pick from any pane, a probe
- * retirement — serializes on this one chain and re-reads live settings at apply
- * time. updateSettings shallow-merges the whole object, so an interleaved write
- * from a snapshot captured earlier would silently clobber a concurrent pick.
- * The update runs against the settled base and may return null to skip writing.
- */
-let settingsWrite: Promise<unknown> = Promise.resolve()
-function enqueueSessionOptionSettingsWrite(
-  update: (
-    base: PersistedNativeChatSessionOptions | undefined
-  ) => PersistedNativeChatSessionOptions | null
-): Promise<void> {
-  const write = settingsWrite
-    .catch(() => undefined)
-    .then(() => {
-      const next = update(useAppStore.getState().settings?.nativeChatSessionOptions)
-      return next
-        ? useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
-        : undefined
-    })
-  settingsWrite = write
-  return write
-}
 
 /**
  * Why: the picker drops a retired model, but the persisted default is what launches

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
@@ -45,19 +45,22 @@ vi.mock('./use-structured-agent-session-outbox', () => ({
   })
 }))
 
-import { resolveStructuredLaunchSeedOptions } from '../../../../shared/native-chat-session-option-defaults'
+import {
+  applyNativeChatSessionOptionSettingsMutation,
+  resolveStructuredLaunchSeedOptions
+} from '../../../../shared/native-chat-session-option-defaults'
 import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
 import { useStructuredAgentSession } from './use-structured-agent-session'
 
-/** Replay every queued settings update in order, exactly as the real chain would. */
+/** Replay every host mutation in order, exactly as the runtime does. */
 function seededByNextLaunch(): Record<string, string> | undefined {
   let persisted: PersistedNativeChatSessionOptions | undefined
-  for (const [update] of mocks.enqueueSettingsWrite.mock.calls) {
-    persisted = (
-      update as (
-        base: PersistedNativeChatSessionOptions | undefined
-      ) => PersistedNativeChatSessionOptions
-    )(persisted)
+  for (const [, mutation] of mocks.enqueueSettingsWrite.mock.calls) {
+    persisted =
+      applyNativeChatSessionOptionSettingsMutation(
+        persisted,
+        mutation as Parameters<typeof applyNativeChatSessionOptionSettingsMutation>[1]
+      ) ?? persisted
   }
   return resolveStructuredLaunchSeedOptions(persisted, 'codex')
 }
@@ -384,6 +387,44 @@ describe('useStructuredAgentSession options', () => {
     })
 
     expect(seededByNextLaunch()).toEqual({ model: 'gpt-fast', effort: 'low' })
+    expect(mocks.enqueueSettingsWrite).toHaveBeenCalledWith(LOCAL_TARGET, {
+      type: 'apply-picks',
+      agent: 'codex',
+      picks: [
+        { modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' },
+        { modelId: 'gpt-fast', optionId: 'effort', value: 'low' }
+      ]
+    })
+  })
+
+  it('writes through the session runtime target', async () => {
+    const remoteTarget = { kind: 'environment', environmentId: 'remote-1' } as const
+    mocks.call.mockImplementation((_target, method) =>
+      method === 'agentSession.options'
+        ? Promise.resolve(OPTIONS)
+        : Promise.resolve({
+            ok: true,
+            value: { key: 'effort', value: 'high', options: { effort: 'high' } }
+          })
+    )
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        target: remoteTarget,
+        agent: 'codex',
+        isVisible: true
+      })
+    )
+    await waitFor(() => expect(result.current.optionSnapshot).toHaveLength(2))
+
+    await act(async () => {
+      expect(await result.current.setStructuredOption('effort', 'high')).toBe(true)
+    })
+
+    expect(mocks.enqueueSettingsWrite).toHaveBeenCalledWith(
+      remoteTarget,
+      expect.objectContaining({ type: 'apply-picks', agent: 'codex' })
+    )
   })
 
   it('pins the model an effort-only pick was made against', async () => {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.test.tsx
@@ -3,11 +3,19 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const mocks = vi.hoisted(() => ({ call: vi.fn(), operationId: vi.fn() }))
+const mocks = vi.hoisted(() => ({
+  call: vi.fn(),
+  operationId: vi.fn(),
+  enqueueSettingsWrite: vi.fn()
+}))
 let fence = 3
 
 vi.mock('@/runtime/structured-agent-session-client', () => ({
   callStructuredAgentSession: mocks.call
+}))
+
+vi.mock('./native-chat-session-option-settings-write', () => ({
+  enqueueSessionOptionSettingsWrite: mocks.enqueueSettingsWrite
 }))
 
 vi.mock('./use-structured-agent-session-read', () => ({
@@ -37,7 +45,22 @@ vi.mock('./use-structured-agent-session-outbox', () => ({
   })
 }))
 
+import { resolveStructuredLaunchSeedOptions } from '../../../../shared/native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
 import { useStructuredAgentSession } from './use-structured-agent-session'
+
+/** Replay every queued settings update in order, exactly as the real chain would. */
+function seededByNextLaunch(): Record<string, string> | undefined {
+  let persisted: PersistedNativeChatSessionOptions | undefined
+  for (const [update] of mocks.enqueueSettingsWrite.mock.calls) {
+    persisted = (
+      update as (
+        base: PersistedNativeChatSessionOptions | undefined
+      ) => PersistedNativeChatSessionOptions
+    )(persisted)
+  }
+  return resolveStructuredLaunchSeedOptions(persisted, 'codex')
+}
 
 const LOCAL_TARGET = { kind: 'local' } as const
 
@@ -331,5 +354,85 @@ describe('useStructuredAgentSession options', () => {
       scope: 'background-tasks',
       taskId: 'task-2'
     })
+  })
+
+  it('remembers a model pick so the next launch seeds the pair the provider settled on', async () => {
+    mocks.call.mockImplementation((_target, method) =>
+      method === 'agentSession.options'
+        ? Promise.resolve(OPTIONS)
+        : Promise.resolve({
+            ok: true,
+            value: {
+              key: 'model',
+              value: 'gpt-fast',
+              options: { model: 'gpt-fast', effort: 'low' }
+            }
+          })
+    )
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        target: LOCAL_TARGET,
+        agent: 'codex',
+        isVisible: true
+      })
+    )
+    await waitFor(() => expect(result.current.optionSnapshot).toHaveLength(2))
+
+    await act(async () => {
+      expect(await result.current.setStructuredOption('model', 'gpt-fast')).toBe(true)
+    })
+
+    expect(seededByNextLaunch()).toEqual({ model: 'gpt-fast', effort: 'low' })
+  })
+
+  it('pins the model an effort-only pick was made against', async () => {
+    mocks.call.mockImplementation((_target, method) =>
+      method === 'agentSession.options'
+        ? Promise.resolve(OPTIONS)
+        : Promise.resolve({
+            ok: true,
+            value: { key: 'effort', value: 'high', options: { effort: 'high' } }
+          })
+    )
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        target: LOCAL_TARGET,
+        agent: 'codex',
+        isVisible: true
+      })
+    )
+    await waitFor(() => expect(result.current.optionSnapshot).toHaveLength(2))
+
+    await act(async () => {
+      expect(await result.current.setStructuredOption('effort', 'high')).toBe(true)
+    })
+
+    // Without the model the launch resolves nothing, so the remembered effort would be dead.
+    expect(seededByNextLaunch()).toEqual({ model: 'gpt-live', effort: 'high' })
+  })
+
+  it('remembers nothing when the provider refuses the pick', async () => {
+    mocks.call.mockImplementation((_target, method) =>
+      method === 'agentSession.options'
+        ? Promise.resolve(OPTIONS)
+        : Promise.reject(new Error('provider rejected option'))
+    )
+    const { result } = renderHook(() =>
+      useStructuredAgentSession({
+        sessionId: 'session-1',
+        target: LOCAL_TARGET,
+        agent: 'codex',
+        isVisible: true
+      })
+    )
+    await waitFor(() => expect(result.current.optionSnapshot).toHaveLength(2))
+
+    await act(async () => {
+      expect(await result.current.setStructuredOption('model', 'gpt-fast')).toBe(false)
+    })
+
+    expect(mocks.enqueueSettingsWrite).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -16,7 +16,9 @@ import {
   canSetStructuredAgentSessionOption,
   commitStructuredAgentSessionOptionValues,
   createStructuredAgentSessionOptionState,
-  structuredAgentSessionOptionSnapshot
+  structuredAgentSessionOptionPicks,
+  structuredAgentSessionOptionSnapshot,
+  type StructuredSessionOptionPick
 } from '../../../../shared/structured-agent-session-options'
 import { activeStructuredAgentSessionTurnId } from '../../../../shared/structured-agent-session-projection'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
@@ -29,6 +31,8 @@ import { useStructuredAgentSessionHold } from './use-structured-agent-session-ho
 import { useStructuredAgentSessionRead } from './use-structured-agent-session-read'
 import { projectStructuredAgentSessionMessages } from './structured-agent-session-message-projection'
 import { selectStructuredAgentTurnActivity } from './native-chat-turn-activity'
+import { applyNativeChatSessionOptionPicks } from '../../../../shared/native-chat-session-option-defaults'
+import { enqueueSessionOptionSettingsWrite } from './native-chat-session-option-settings-write'
 
 export type StructuredPromptItem = AgentJournalRenderItem & {
   body: Extract<AgentJournalRenderItem['body'], { kind: 'approval' | 'question' }>
@@ -175,6 +179,19 @@ export function useStructuredAgentSession(args: {
     () => structuredAgentSessionOptionSnapshot(optionState),
     [optionState]
   )
+  /** Why: a structured pick is the only record of what the user chose — nothing scrapes
+   *  it back — so the next launch reads it from settings or falls back to the CLI default. */
+  const persistOptionPicks = useCallback(
+    (picks: readonly StructuredSessionOptionPick[]): void => {
+      if (picks.length === 0) {
+        return
+      }
+      void enqueueSessionOptionSettingsWrite((persisted) =>
+        applyNativeChatSessionOptionPicks({ persisted, agent, picks })
+      )
+    },
+    [agent]
+  )
   const setStructuredOption = useCallback(
     async (id: string, value: string | boolean): Promise<boolean> => {
       if (
@@ -192,11 +209,13 @@ export function useStructuredAgentSession(args: {
           { key: id, value }
         )
         if (result && activeOptionRecordRef.current === targetRecord) {
+          const committed = result.options ?? { [id]: value }
           setOptionState((current) =>
             current.record === targetRecord
-              ? commitStructuredAgentSessionOptionValues(current, result.options ?? { [id]: value })
+              ? commitStructuredAgentSessionOptionValues(current, committed)
               : current
           )
+          persistOptionPicks(structuredAgentSessionOptionPicks(optionState, committed))
         }
         return Boolean(result)
       } finally {
@@ -207,7 +226,7 @@ export function useStructuredAgentSession(args: {
         )
       }
     },
-    [mutate, optionState]
+    [mutate, optionState, persistOptionPicks]
   )
   const setOption = useCallback(
     async (id: string, value: string | boolean) => {

--- a/src/renderer/src/components/native-chat/use-structured-agent-session.ts
+++ b/src/renderer/src/components/native-chat/use-structured-agent-session.ts
@@ -17,8 +17,7 @@ import {
   commitStructuredAgentSessionOptionValues,
   createStructuredAgentSessionOptionState,
   structuredAgentSessionOptionPicks,
-  structuredAgentSessionOptionSnapshot,
-  type StructuredSessionOptionPick
+  structuredAgentSessionOptionSnapshot
 } from '../../../../shared/structured-agent-session-options'
 import { activeStructuredAgentSessionTurnId } from '../../../../shared/structured-agent-session-projection'
 import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
@@ -31,7 +30,6 @@ import { useStructuredAgentSessionHold } from './use-structured-agent-session-ho
 import { useStructuredAgentSessionRead } from './use-structured-agent-session-read'
 import { projectStructuredAgentSessionMessages } from './structured-agent-session-message-projection'
 import { selectStructuredAgentTurnActivity } from './native-chat-turn-activity'
-import { applyNativeChatSessionOptionPicks } from '../../../../shared/native-chat-session-option-defaults'
 import { enqueueSessionOptionSettingsWrite } from './native-chat-session-option-settings-write'
 
 export type StructuredPromptItem = AgentJournalRenderItem & {
@@ -179,19 +177,6 @@ export function useStructuredAgentSession(args: {
     () => structuredAgentSessionOptionSnapshot(optionState),
     [optionState]
   )
-  /** Why: a structured pick is the only record of what the user chose — nothing scrapes
-   *  it back — so the next launch reads it from settings or falls back to the CLI default. */
-  const persistOptionPicks = useCallback(
-    (picks: readonly StructuredSessionOptionPick[]): void => {
-      if (picks.length === 0) {
-        return
-      }
-      void enqueueSessionOptionSettingsWrite((persisted) =>
-        applyNativeChatSessionOptionPicks({ persisted, agent, picks })
-      )
-    },
-    [agent]
-  )
   const setStructuredOption = useCallback(
     async (id: string, value: string | boolean): Promise<boolean> => {
       if (
@@ -215,7 +200,14 @@ export function useStructuredAgentSession(args: {
               ? commitStructuredAgentSessionOptionValues(current, committed)
               : current
           )
-          persistOptionPicks(structuredAgentSessionOptionPicks(optionState, committed))
+          const picks = structuredAgentSessionOptionPicks(optionState, committed)
+          if (picks.length > 0) {
+            void enqueueSessionOptionSettingsWrite(target, {
+              type: 'apply-picks',
+              agent,
+              picks
+            })
+          }
         }
         return Boolean(result)
       } finally {
@@ -226,7 +218,7 @@ export function useStructuredAgentSession(args: {
         )
       }
     },
-    [mutate, optionState, persistOptionPicks]
+    [agent, mutate, optionState, target]
   )
   const setOption = useCallback(
     async (id: string, value: string | boolean) => {

--- a/src/shared/native-chat-session-option-defaults.ts
+++ b/src/shared/native-chat-session-option-defaults.ts
@@ -33,7 +33,7 @@ export function resolveNativeChatSessionOptionDefaults(
  *  strings. Claude's `fastMode` is a boolean the durable `Record<string, string>`
  *  record cannot carry, and the providers' remaining keys are settable only
  *  mid-session, never seeded at launch. */
-const STRUCTURED_LAUNCH_SEED_OPTION_IDS = ['model', 'effort'] as const
+export const STRUCTURED_LAUNCH_SEED_OPTION_IDS = ['model', 'effort'] as const
 
 /** The saved selection a structured create seeds into its reservation, narrowed
  *  to the wire-safe string subset the durable record and both providers accept. */
@@ -53,6 +53,21 @@ export function resolveStructuredLaunchSeedOptions(
     }
   }
   return Object.keys(seeded).length > 0 ? seeded : undefined
+}
+
+/** Fold a settled batch of picks onto the durable record. A surface that must send the
+ *  whole object back — rather than merging key by key — applies them in one pass so a
+ *  later pick in the batch cannot drop an earlier one. */
+export function applyNativeChatSessionOptionPicks(args: {
+  persisted: PersistedNativeChatSessionOptions | null | undefined
+  agent: AgentType
+  picks: readonly { modelId: string; optionId: string; value: SessionOptionValue }[]
+}): PersistedNativeChatSessionOptions {
+  let persisted = args.persisted ?? {}
+  for (const pick of args.picks) {
+    persisted = updateNativeChatSessionOptionDefaults({ persisted, agent: args.agent, ...pick })
+  }
+  return persisted
 }
 
 /** Why: an authoritative probe proved this id gone, and a stale `model` is emitted

--- a/src/shared/native-chat-session-option-defaults.ts
+++ b/src/shared/native-chat-session-option-defaults.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from './agent-status-types'
 import { sessionOptionValueIsValid } from './agent-session-option-catalog'
 import type {
+  NativeChatSessionOptionSettingsMutation,
   PersistedNativeChatSessionOptions,
   SessionOptionValue
 } from './native-chat-session-options'
@@ -61,13 +62,33 @@ export function resolveStructuredLaunchSeedOptions(
 export function applyNativeChatSessionOptionPicks(args: {
   persisted: PersistedNativeChatSessionOptions | null | undefined
   agent: AgentType
-  picks: readonly { modelId: string; optionId: string; value: SessionOptionValue }[]
+  picks: Extract<NativeChatSessionOptionSettingsMutation, { type: 'apply-picks' }>['picks']
 }): PersistedNativeChatSessionOptions {
   let persisted = args.persisted ?? {}
   for (const pick of args.picks) {
     persisted = updateNativeChatSessionOptionDefaults({ persisted, agent: args.agent, ...pick })
   }
   return persisted
+}
+
+/** Applies one host-owned delta to the latest record. Returning null means the
+ * authoritative model list found nothing to retire. */
+export function applyNativeChatSessionOptionSettingsMutation(
+  persisted: PersistedNativeChatSessionOptions | null | undefined,
+  mutation: NativeChatSessionOptionSettingsMutation
+): PersistedNativeChatSessionOptions | null {
+  if (mutation.type === 'apply-picks') {
+    return applyNativeChatSessionOptionPicks({
+      persisted,
+      agent: mutation.agent,
+      picks: mutation.picks
+    })
+  }
+  const modelId = persisted?.[mutation.agent]?.model
+  if (!modelId || mutation.availableModelIds.includes(modelId)) {
+    return null
+  }
+  return clearNativeChatSessionOptionModel(persisted, mutation.agent)
 }
 
 /** Why: an authoritative probe proved this id gone, and a stale `model` is emitted

--- a/src/shared/native-chat-session-options.ts
+++ b/src/shared/native-chat-session-options.ts
@@ -1,3 +1,5 @@
+import type { AgentType } from './agent-status-types'
+
 export type SessionOptionValue = string | boolean
 
 export type SessionOptionSelectChoice = {
@@ -74,6 +76,19 @@ export type PersistedNativeChatSessionOptions = Partial<
     }
   >
 >
+
+export type NativeChatSessionOptionSettingsMutation =
+  | {
+      type: 'apply-picks'
+      agent: AgentType
+      picks: readonly {
+        modelId: string
+        optionId: string
+        value: SessionOptionValue
+        adoptModelAsLaunchDefault?: boolean
+      }[]
+    }
+  | { type: 'clear-model-if-missing'; agent: AgentType; availableModelIds: readonly string[] }
 
 export type SessionOptionsSurface = {
   getSnapshot(): SessionOptionDescriptor[]

--- a/src/shared/structured-agent-session-option-picks.test.ts
+++ b/src/shared/structured-agent-session-option-picks.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { CODEX_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-claude-codex'
+import {
+  applyNativeChatSessionOptionPicks,
+  resolveStructuredLaunchSeedOptions,
+  updateNativeChatSessionOptionDefaults
+} from './native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from './native-chat-session-options'
+import {
+  applyStructuredAgentSessionOptions,
+  createStructuredAgentSessionOptionState,
+  structuredAgentSessionOptionPicks
+} from './structured-agent-session-options'
+
+function liveState(current: { model: string; effort?: string }) {
+  return applyStructuredAgentSessionOptions(
+    createStructuredAgentSessionOptionState('codex'),
+    CODEX_SESSION_OPTION_CATALOG,
+    {
+      models: [
+        {
+          id: 'account-model',
+          label: 'Account Model',
+          isDefault: true,
+          defaultEffort: 'medium',
+          efforts: [
+            { value: 'medium', label: 'Medium' },
+            { value: 'high', label: 'High' }
+          ]
+        },
+        {
+          id: 'other-model',
+          label: 'Other Model',
+          isDefault: false,
+          defaultEffort: 'low',
+          efforts: [
+            { value: 'low', label: 'Low' },
+            { value: 'medium', label: 'Medium' }
+          ]
+        }
+      ],
+      current
+    }
+  )
+}
+
+function persist(
+  picks: readonly { modelId: string; optionId: string; value: string }[]
+): PersistedNativeChatSessionOptions {
+  return applyNativeChatSessionOptionPicks({ persisted: undefined, agent: 'codex', picks })
+}
+
+describe('structuredAgentSessionOptionPicks', () => {
+  it('pins the model an effort-only pick was chosen against', () => {
+    const picks = structuredAgentSessionOptionPicks(liveState({ model: 'account-model' }), {
+      effort: 'high'
+    })
+    expect(picks).toEqual([{ modelId: 'account-model', optionId: 'effort', value: 'high' }])
+    // Without the model the launch resolves nothing at all, so the effort would be dead.
+    expect(resolveStructuredLaunchSeedOptions(persist(picks), 'codex')).toEqual({
+      model: 'account-model',
+      effort: 'high'
+    })
+  })
+
+  it('remembers the effort the provider reconciled, not the one in force before', () => {
+    const state = liveState({ model: 'account-model', effort: 'high' })
+    const picks = structuredAgentSessionOptionPicks(state, {
+      model: 'other-model',
+      effort: 'low'
+    })
+    expect(picks).toEqual([
+      { modelId: 'other-model', optionId: 'model', value: 'other-model' },
+      { modelId: 'other-model', optionId: 'effort', value: 'low' }
+    ])
+    expect(resolveStructuredLaunchSeedOptions(persist(picks), 'codex')).toEqual({
+      model: 'other-model',
+      effort: 'low'
+    })
+  })
+
+  it('reads the committed model rather than the record a deferred commit has not settled', () => {
+    // The caller passes pre-commit state: the record still tracks the old model.
+    const state = liveState({ model: 'account-model', effort: 'medium' })
+    expect(structuredAgentSessionOptionPicks(state, { model: 'other-model' })).toEqual([
+      { modelId: 'other-model', optionId: 'model', value: 'other-model' }
+    ])
+  })
+
+  it('keeps a per-model effort so reselecting the old model restores its level', () => {
+    const persisted = persist([
+      ...structuredAgentSessionOptionPicks(liveState({ model: 'account-model' }), {
+        effort: 'high'
+      }),
+      ...structuredAgentSessionOptionPicks(liveState({ model: 'account-model', effort: 'high' }), {
+        model: 'other-model',
+        effort: 'low'
+      })
+    ])
+    const reselected = updateNativeChatSessionOptionDefaults({
+      persisted,
+      agent: 'codex',
+      modelId: 'account-model',
+      optionId: 'model',
+      value: 'account-model'
+    })
+    expect(resolveStructuredLaunchSeedOptions(reselected, 'codex')).toEqual({
+      model: 'account-model',
+      effort: 'high'
+    })
+  })
+
+  it('writes nothing before the provider catalog lands', () => {
+    expect(
+      structuredAgentSessionOptionPicks(createStructuredAgentSessionOptionState('codex'), {
+        effort: 'high'
+      })
+    ).toEqual([])
+  })
+
+  it('drops ids a launch cannot seed back', () => {
+    expect(
+      structuredAgentSessionOptionPicks(liveState({ model: 'account-model' }), {
+        permissionMode: 'plan'
+      })
+    ).toEqual([])
+  })
+})
+
+describe('applyNativeChatSessionOptionPicks', () => {
+  it('keeps a later pick in the batch from dropping an earlier one', () => {
+    const persisted = applyNativeChatSessionOptionPicks({
+      persisted: undefined,
+      agent: 'codex',
+      picks: [
+        { modelId: 'gpt-fast', optionId: 'model', value: 'gpt-fast' },
+        { modelId: 'gpt-fast', optionId: 'effort', value: 'low' }
+      ]
+    })
+    expect(resolveStructuredLaunchSeedOptions(persisted, 'codex')).toEqual({
+      model: 'gpt-fast',
+      effort: 'low'
+    })
+  })
+
+  it('leaves every other agent untouched', () => {
+    const persisted = applyNativeChatSessionOptionPicks({
+      persisted: { claude: { model: 'opus', valuesByModel: { opus: { effort: 'high' } } } },
+      agent: 'codex',
+      picks: [{ modelId: 'gpt-fast', optionId: 'effort', value: 'low' }]
+    })
+    expect(resolveStructuredLaunchSeedOptions(persisted, 'claude')).toEqual({
+      model: 'opus',
+      effort: 'high'
+    })
+    expect(resolveStructuredLaunchSeedOptions(persisted, 'codex')).toEqual({
+      model: 'gpt-fast',
+      effort: 'low'
+    })
+  })
+
+  it('returns the record unchanged for an empty batch', () => {
+    expect(
+      applyNativeChatSessionOptionPicks({ persisted: undefined, agent: 'codex', picks: [] })
+    ).toEqual({})
+  })
+})

--- a/src/shared/structured-agent-session-options.ts
+++ b/src/shared/structured-agent-session-options.ts
@@ -13,6 +13,7 @@ import {
   setTrackedSessionOption,
   type NativeChatSessionOptionRecord
 } from './native-chat-session-option-state'
+import { STRUCTURED_LAUNCH_SEED_OPTION_IDS } from './native-chat-session-option-defaults'
 import type { SessionOptionDescriptor, SessionOptionValue } from './native-chat-session-options'
 import type { AgentSessionOptionsResult } from './agent-session-wire'
 
@@ -147,4 +148,45 @@ export function commitStructuredAgentSessionOptionValues(
     }
   }
   return next
+}
+
+export type StructuredSessionOptionPick = {
+  modelId: string
+  optionId: string
+  value: string
+}
+
+/**
+ * The picks a mutation must remember so the next launch starts where the user left off.
+ * Keyed off the same ids the launch seed reads back, so a pick this surface cannot
+ * re-seed is never written.
+ *
+ * Model and effort travel as a pair: a launch resolves a stored effort only under a
+ * stored model, so an effort-only pick adopts the model it was chosen against. Values
+ * come from what the provider committed, not what was requested — it reconciles an
+ * effort the newly selected model cannot run before reporting back.
+ *
+ * `state` may still be pre-commit: a changed model arrives in `committed`, and an
+ * unchanged one is already what the record tracks, so neither reading depends on the
+ * commit having landed.
+ */
+export function structuredAgentSessionOptionPicks(
+  state: StructuredAgentSessionOptionState,
+  committed: Readonly<Record<string, string>>
+): StructuredSessionOptionPick[] {
+  if (!state.catalog) {
+    return []
+  }
+  const committedModel = committed.model
+  const modelId =
+    typeof committedModel === 'string' && committedModel.trim()
+      ? committedModel
+      : resolveEffectiveNativeChatModelId(state.catalog, state.catalog.models, state.record)
+  if (!modelId) {
+    return []
+  }
+  return STRUCTURED_LAUNCH_SEED_OPTION_IDS.flatMap((optionId) => {
+    const value = committed[optionId]
+    return typeof value === 'string' && value.trim() ? [{ modelId, optionId, value }] : []
+  })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​641 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​61 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​580 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​249 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 |

<!-- /orca-pr-loc -->

## ELI5

Structured chat forgot which model and thinking level you explicitly picked. Change to Sonnet + Low, end the session, and the next one returned to the CLI default. Structured Claude and Codex chats now remember the provider-confirmed pair and seed it into the next session.

## What Changed

Structured Claude and Codex panes now persist settled option picks into `nativeChatSessionOptions`, the durable record every structured launch already reads.

- `structuredAgentSessionOptionPicks` converts the provider's committed option result into the model/effort picks a later launch can actually seed. It never persists a provider readback that the user did not choose.
- Effort remains model-scoped. An explicit effort-only pick also adopts the model it was chosen against; otherwise launch resolution would have no model under which to restore that effort.
- The additive `settings.mutateNativeChatSessionOptions` RPC sends a narrow delta to the execution runtime. The host re-reads its latest record, applies the batch atomically, and preserves other agents and concurrent picks.
- Desktop routes the mutation through the structured session's `RuntimeClientTarget`. Mobile sends the same mutation to its paired host. PTY picker and stale-model retirement writes use the same host-owned mutation.
- RPC input is strict and bounded to known agents, supported option value kinds, at most eight picks, and at most 256 catalog model ids for retirement.

Persistence is best-effort. A new client talking to an older host receives an unknown-method failure, swallows only that preference write, and leaves the live option change working; the next session simply starts from the previous/default saved selection. Old clients remain compatible with new hosts, and the persisted record shape is unchanged.

## Why

The read half already existed: structured creation seeds `{ model, effort }` from saved settings. The write half did not. The prior writer lived only in the terminal-backed picker, while structured panes replace that surface with the structured transport. As a result, structured picks were visible for the current session but were never stored.

The fix writes only after the provider accepts a change and uses the provider-returned reconciled values. This matters when a model switch also changes the valid effort. Mobile deliberately does not persist an `unknown` delivery outcome because the provider may have refused it.

## Linked Issue

No issue — reported directly in conversation.

## Visual Proof

- [Desktop Electron QA: real structured Claude two-session persistence](https://github.com/stablyai/orca/pull/19147#issuecomment-5563256887)
- [Native iOS QA: real structured Codex two-session persistence](https://github.com/stablyai/orca/pull/19147#issuecomment-5563535034)
- Linux direct-SSH compatibility smoke check (connected real SSH workspace; structured chat is intentionally local/paired-runtime only, so SSH uses terminal chat):

![Connected Linux SSH workspace](https://github.com/user-attachments/assets/a35360c5-becc-40fb-bdb2-4edb1834e13d)

## Testing

- `pnpm tc` — passed
- `cd mobile && pnpm run typecheck` — passed
- `pnpm run check:code-quality:changed` — 0 findings across 22 changed files
- Final focused desktop/shared review suite — 75 tests passed
- Final focused mobile integration suite — 21 tests passed
- Runtime atomicity/retirement focus — 2 tests passed
- Broad mobile suite — 4,194 passed, 3 skipped across 515 files
- Electron desktop QA — changed Claude from High + Opus to Low + Sonnet, opened a new session, and saw Low + Sonnet restored from the host record
- Native iOS QA — changed Codex from GPT-6-Astra Medium to GPT-5.6-Sol High, opened a new session, and saw GPT-5.6-Sol High restored from the host record
- Linux SSH smoke QA — real SSH connection, remote repository/file listing, and terminal-backed Codex launch passed; renderer had 0 errors
- CI — green, including root/mobile tests, static analysis, typecheck, macOS packaging, and Windows packaging

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Final adversarial review-until-clean verdict: **CLEAN**. No in-scope correctness, compatibility, security, or performance issues remain.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security:** no secrets or new privilege boundaries; the new RPC is authenticated through the existing runtime dispatcher and strictly validates its bounded mutation payload.
- **Cross-platform:** no path, shell, shortcut, or native-module behavior changed. macOS Electron, native iOS, Linux SSH compatibility, and Windows packaging were exercised.
- **Remote ownership:** structured desktop calls target the execution runtime; mobile writes to its paired host. Direct SSH intentionally remains terminal-backed and does not expose the structured picker.
- **Backward compatibility:** the RPC is additive and best-effort against older hosts; the persisted settings shape is unchanged.
- **Performance:** one bounded mutation per accepted pick, with model + effort batched into one request; no polling, timers, listeners, subprocesses, or new hot-path scans.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Typecheck, targeted tests, changed-file quality, and CI pass
