### PR TITLE
fix(windows): reject stale parent PID links in shutdown snapshots

### DIFF
--- a/src/main/windows-descendant-exit-verification.test.ts
+++ b/src/main/windows-descendant-exit-verification.test.ts
@@ -53,6 +53,47 @@ describe('captureWindowsDescendantSnapshot', () => {
     ])
   })
 
+  it('keeps the root when its own parent PID was reused by a newer process', async () => {
+    // The root's retained ppid now names a process created after it. Pruning the
+    // root drops the whole snapshot, so its own link is never evidence about it.
+    const captured = await captureWindowsDescendantSnapshot(100, {
+      readTable: async () => [
+        { pid: 100, ppid: 900, creationTimeMs: 5 },
+        { pid: 900, ppid: 1, creationTimeMs: 50 },
+        { pid: 200, ppid: 100, creationTimeMs: 7 }
+      ],
+      now: () => 42
+    })
+
+    expect(captured).toEqual({
+      root: { pid: 100, creationTimeMs: 5 },
+      descendants: [{ pid: 200, creationTimeMs: 7 }],
+      unidentifiedCount: 0,
+      capturedAtMs: 42
+    })
+  })
+
+  it('bounds a link by the root when the claimed parent denied its creation time', async () => {
+    // 300 has no creation time to compare a child against, so the root's start is
+    // the only bound left: 350 could be its child, 360 predates the tree entirely.
+    const captured = await captureWindowsDescendantSnapshot(100, {
+      readTable: async () => [
+        { pid: 100, ppid: 1, creationTimeMs: 5 },
+        { pid: 300, ppid: 100 },
+        { pid: 350, ppid: 300, creationTimeMs: 9 },
+        { pid: 360, ppid: 300, creationTimeMs: 2 }
+      ],
+      now: () => 42
+    })
+
+    expect(captured).toEqual({
+      root: { pid: 100, creationTimeMs: 5 },
+      descendants: [{ pid: 350, creationTimeMs: 9 }],
+      unidentifiedCount: 1,
+      capturedAtMs: 42
+    })
+  })
+
   it('walks the whole subtree and keeps only rows a later read can re-identify', async () => {
     const captured = await captureWindowsDescendantSnapshot(100, {
       // 400 is a grandchild; 300 denied a creation-time query, so no later read

--- a/src/main/windows-descendant-exit-verification.test.ts
+++ b/src/main/windows-descendant-exit-verification.test.ts
@@ -19,6 +19,40 @@ function snapshot(
 }
 
 describe('captureWindowsDescendantSnapshot', () => {
+  it('does not claim an older process whose former parent PID was reused by the root', async () => {
+    const olderProcess = { pid: 50244, ppid: 36084, creationTimeMs: 1788659167395 }
+    const captured = await captureWindowsDescendantSnapshot(36084, {
+      readTable: async () => [
+        { pid: 36084, ppid: 60976, creationTimeMs: 1788733587893 },
+        olderProcess
+      ]
+    })
+
+    expect(captured?.descendants).toEqual([])
+    await expect(
+      verifyWindowsDescendantSnapshotExit(captured!, { readTable: async () => [olderProcess] })
+    ).resolves.toBe('exited')
+  })
+
+  it('prunes a stale parent link and its subtree at any depth', async () => {
+    const captured = await captureWindowsDescendantSnapshot(100, {
+      readTable: async () => [
+        { pid: 100, ppid: 1, creationTimeMs: 5 },
+        { pid: 200, ppid: 100, creationTimeMs: 10 },
+        { pid: 300, ppid: 200, creationTimeMs: 7 },
+        { pid: 400, ppid: 300, creationTimeMs: 12 },
+        { pid: 500, ppid: 100, creationTimeMs: 4 },
+        { pid: 600, ppid: 500, creationTimeMs: 13 },
+        { pid: 700, ppid: 200, creationTimeMs: 10 }
+      ]
+    })
+
+    expect(captured?.descendants).toEqual([
+      { pid: 700, creationTimeMs: 10 },
+      { pid: 200, creationTimeMs: 10 }
+    ])
+  })
+
   it('walks the whole subtree and keeps only rows a later read can re-identify', async () => {
     const captured = await captureWindowsDescendantSnapshot(100, {
       // 400 is a grandchild; 300 denied a creation-time query, so no later read

--- a/src/main/windows-descendant-exit-verification.test.ts
+++ b/src/main/windows-descendant-exit-verification.test.ts
@@ -74,13 +74,14 @@ describe('captureWindowsDescendantSnapshot', () => {
   })
 
   it('bounds a link by the root when the claimed parent denied its creation time', async () => {
-    // 300 has no creation time to compare a child against, so the root's start is
-    // the only bound left: 350 could be its child, 360 predates the tree entirely.
+    // 300 has no creation time for a child to be compared against, so the root's
+    // start is the only bound left: 350 ties with it, which a same-millisecond
+    // spawn does routinely, while 360 predates the whole tree.
     const captured = await captureWindowsDescendantSnapshot(100, {
       readTable: async () => [
         { pid: 100, ppid: 1, creationTimeMs: 5 },
         { pid: 300, ppid: 100 },
-        { pid: 350, ppid: 300, creationTimeMs: 9 },
+        { pid: 350, ppid: 300, creationTimeMs: 5 },
         { pid: 360, ppid: 300, creationTimeMs: 2 }
       ],
       now: () => 42
@@ -88,10 +89,29 @@ describe('captureWindowsDescendantSnapshot', () => {
 
     expect(captured).toEqual({
       root: { pid: 100, creationTimeMs: 5 },
-      descendants: [{ pid: 350, creationTimeMs: 9 }],
+      descendants: [{ pid: 350, creationTimeMs: 5 }],
       unidentifiedCount: 1,
       capturedAtMs: 42
     })
+  })
+
+  it('drops an unidentified row whose parent link was pruned', async () => {
+    // 250 denied its creation time, but 200's claim on the root is impossible, so
+    // 250 was never in this tree: counting it would cap the verdict at
+    // unverifiable over a process the root does not own.
+    const captured = await captureWindowsDescendantSnapshot(100, {
+      readTable: async () => [
+        { pid: 100, ppid: 1, creationTimeMs: 10 },
+        { pid: 200, ppid: 100, creationTimeMs: 5 },
+        { pid: 250, ppid: 200 }
+      ]
+    })
+
+    expect(captured?.descendants).toEqual([])
+    expect(captured?.unidentifiedCount).toBe(0)
+    await expect(
+      verifyWindowsDescendantSnapshotExit(captured!, { readTable: async () => [] })
+    ).resolves.toBe('exited')
   })
 
   it('walks the whole subtree and keeps only rows a later read can re-identify', async () => {

--- a/src/main/windows-descendant-exit-verification.ts
+++ b/src/main/windows-descendant-exit-verification.ts
@@ -69,11 +69,23 @@ export async function captureWindowsDescendantSnapshot(
   // One table read, not a walk plus an identity read: each is bounded in
   // seconds, and this runs inside the close ladder's budget.
   const table = await (deps.readTable ?? readWindowsProcessTableFresh)().catch(() => null)
-  const descendants = table && windowsDescendantsFromRows(table, rootPid)
   const root = table?.find((row) => row.pid === rootPid)
-  if (!descendants || typeof root?.creationTimeMs !== 'number') {
+  if (!table || typeof root?.creationTimeMs !== 'number') {
     return null
   }
+  const rootCreationTimeMs = root.creationTimeMs
+  const creationTimes = new Map(table.map((row) => [row.pid, row.creationTimeMs]))
+  // Windows retains the original parent PID after exit; a reused PID is not ancestry.
+  const currentRows = table.filter((row) => {
+    const parentCreationTimeMs = creationTimes.get(row.ppid)
+    return (
+      row.pid === rootPid ||
+      row.creationTimeMs === undefined ||
+      (row.creationTimeMs >= rootCreationTimeMs &&
+        (parentCreationTimeMs === undefined || row.creationTimeMs >= parentCreationTimeMs))
+    )
+  })
+  const descendants = windowsDescendantsFromRows(currentRows, rootPid)!
   return {
     root: { pid: root.pid, creationTimeMs: root.creationTimeMs },
     descendants: descendants.flatMap((row) =>

--- a/src/main/windows-descendant-exit-verification.ts
+++ b/src/main/windows-descendant-exit-verification.ts
@@ -58,6 +58,9 @@ function delay(ms: number): Promise<void> {
  * Snapshot a Windows root's descendants while it is still alive. Resolves null
  * (never rejects) when the table is unreadable or the root is absent — the same
  * contract as the POSIX walk, because "cannot see" is never "nothing is there".
+ *
+ * Stale parent links are pruned by creation time, so a backwards clock step
+ * between two spawns can drop a live descendant — accepted over a certain stall.
  */
 export async function captureWindowsDescendantSnapshot(
   rootPid: number,
@@ -83,18 +86,14 @@ export async function captureWindowsDescendantSnapshot(
   const rootCreationTimeMs = root.creationTimeMs
   // Windows keeps a process's original parent PID after that parent exits, so a
   // reused PID is not ancestry: no real child predates the parent it claims.
-  // The root's start is the floor for a chain through a row that denied its
-  // creation time, since such a row is admitted unchecked and its children find
-  // no parent time to compare against. Ties pass -- these are FILETIMEs
-  // truncated to ms, so a parent and child spawned in the same millisecond
-  // collide exactly and `>` would drop true descendants. The root itself is
-  // never pruned: its own ppid can be recycled too, and a pruned root loses the
-  // snapshot outright. Monotonicity along a real chain is assumed; a backwards
-  // clock step between two spawns would drop a live descendant, which is
-  // accepted over the certain stall a retained stale link causes.
+  // The root's start backstops the undefined-time bypass, which admits a row
+  // unchecked and leaves its children no parent time to compare against. Ties
+  // pass -- FILETIMEs truncated to ms make a same-millisecond parent and child
+  // collide exactly, so `>` would drop true descendants.
   const currentRows = table.filter((row) => {
     const parentCreationTimeMs = rowsByPid.get(row.ppid)?.creationTimeMs
     return (
+      // Its own ppid can be recycled too, and a pruned root loses the snapshot.
       row.pid === rootPid ||
       row.creationTimeMs === undefined ||
       (row.creationTimeMs >= rootCreationTimeMs &&

--- a/src/main/windows-descendant-exit-verification.ts
+++ b/src/main/windows-descendant-exit-verification.ts
@@ -1,3 +1,4 @@
+import { getProcessTableIndex } from '../shared/process-table-index'
 import type { DescendantTreeVerdict } from './pty-descendant-exit-verification'
 import { windowsDescendantsFromRows } from './providers/windows-foreground-process-rows'
 import { readWindowsProcessTableFresh } from './windows/windows-process-table'
@@ -69,15 +70,24 @@ export async function captureWindowsDescendantSnapshot(
   // One table read, not a walk plus an identity read: each is bounded in
   // seconds, and this runs inside the close ladder's budget.
   const table = await (deps.readTable ?? readWindowsProcessTableFresh)().catch(() => null)
-  const root = table?.find((row) => row.pid === rootPid)
-  if (!table || typeof root?.creationTimeMs !== 'number') {
+  if (!table) {
+    return null
+  }
+  // The same index the walk below builds, so a table that repeats a pid resolves
+  // a parent link to the row the walk will actually traverse.
+  const rowsByPid = getProcessTableIndex(table).byPid
+  const root = rowsByPid.get(rootPid)
+  if (typeof root?.creationTimeMs !== 'number') {
     return null
   }
   const rootCreationTimeMs = root.creationTimeMs
-  const creationTimes = new Map(table.map((row) => [row.pid, row.creationTimeMs]))
-  // Windows retains the original parent PID after exit; a reused PID is not ancestry.
+  // Windows keeps a process's original parent PID after that parent exits, so a
+  // reused PID is not ancestry: no real child predates the parent it claims, and
+  // the root's own start bounds the subtree when a parent denied its time. The
+  // root is never pruned by its own link -- its ppid can be recycled too, and a
+  // pruned root loses the snapshot outright.
   const currentRows = table.filter((row) => {
-    const parentCreationTimeMs = creationTimes.get(row.ppid)
+    const parentCreationTimeMs = rowsByPid.get(row.ppid)?.creationTimeMs
     return (
       row.pid === rootPid ||
       row.creationTimeMs === undefined ||
@@ -85,7 +95,10 @@ export async function captureWindowsDescendantSnapshot(
         (parentCreationTimeMs === undefined || row.creationTimeMs >= parentCreationTimeMs))
     )
   })
-  const descendants = windowsDescendantsFromRows(currentRows, rootPid)!
+  const descendants = windowsDescendantsFromRows(currentRows, rootPid)
+  if (!descendants) {
+    return null
+  }
   return {
     root: { pid: root.pid, creationTimeMs: root.creationTimeMs },
     descendants: descendants.flatMap((row) =>

--- a/src/main/windows-descendant-exit-verification.ts
+++ b/src/main/windows-descendant-exit-verification.ts
@@ -73,8 +73,8 @@ export async function captureWindowsDescendantSnapshot(
   if (!table) {
     return null
   }
-  // The same index the walk below builds, so a table that repeats a pid resolves
-  // a parent link to the row the walk will actually traverse.
+  // Indexed the way the walk indexes, so a repeated pid resolves a parent link
+  // first-wins -- to the row the walk traverses, not the last one a Map would keep.
   const rowsByPid = getProcessTableIndex(table).byPid
   const root = rowsByPid.get(rootPid)
   if (typeof root?.creationTimeMs !== 'number') {

--- a/src/main/windows-descendant-exit-verification.ts
+++ b/src/main/windows-descendant-exit-verification.ts
@@ -73,8 +73,8 @@ export async function captureWindowsDescendantSnapshot(
   if (!table) {
     return null
   }
-  // Indexed the way the walk indexes, so a repeated pid resolves a parent link
-  // first-wins -- to the row the walk traverses, not the last one a Map would keep.
+  // One index for both lookups, so a repeated pid resolves to the same row for
+  // the root and for a parent link: `byPid` is first-wins, a Map is not.
   const rowsByPid = getProcessTableIndex(table).byPid
   const root = rowsByPid.get(rootPid)
   if (typeof root?.creationTimeMs !== 'number') {

--- a/src/main/windows-descendant-exit-verification.ts
+++ b/src/main/windows-descendant-exit-verification.ts
@@ -82,10 +82,16 @@ export async function captureWindowsDescendantSnapshot(
   }
   const rootCreationTimeMs = root.creationTimeMs
   // Windows keeps a process's original parent PID after that parent exits, so a
-  // reused PID is not ancestry: no real child predates the parent it claims, and
-  // the root's own start bounds the subtree when a parent denied its time. The
-  // root is never pruned by its own link -- its ppid can be recycled too, and a
-  // pruned root loses the snapshot outright.
+  // reused PID is not ancestry: no real child predates the parent it claims.
+  // The root's start is the floor for a chain through a row that denied its
+  // creation time, since such a row is admitted unchecked and its children find
+  // no parent time to compare against. Ties pass -- these are FILETIMEs
+  // truncated to ms, so a parent and child spawned in the same millisecond
+  // collide exactly and `>` would drop true descendants. The root itself is
+  // never pruned: its own ppid can be recycled too, and a pruned root loses the
+  // snapshot outright. Monotonicity along a real chain is assumed; a backwards
+  // clock step between two spawns would drop a live descendant, which is
+  // accepted over the certain stall a retained stale link causes.
   const currentRows = table.filter((row) => {
     const parentCreationTimeMs = rowsByPid.get(row.ppid)?.creationTimeMs
     return (


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |

<!-- /orca-pr-loc -->

## ELI5

Windows can recycle a stopped parent's process ID. Orca could then mistake an older, unrelated process for a new Claude session's child and refuse to finish closing the session.

## What Changed

Filter impossible creation-time order before traversing Windows shutdown snapshots, including stale links below the root. Preserve equal timestamps and the existing conservative handling of missing identities. Add regressions for the captured real-world PID reuse and stale subtrees.

## Why

A Windows reproduction captured a node.exe created about 20 hours before the Claude process incorrectly named as its parent. Acquisition succeeded and Claude exited, but shutdown continued waiting for that unrelated process.

## Linked Issue

Fixes #19148

## Visual Proof

Validated commit `933adf43d2` in an isolated Windows Electron dev instance through Playwright CDP. Verified the app identity, exercised actual structured Claude chat through UI controls, and inspected full-window screenshots.

| Launch | Visible result | Process evidence after UI close |
| --- | --- | --- |
| Native Claude 2.1.263 | `WINDOWS_NATIVE_OK`, Done, then tab removed | Root 36160 and captured child 60556 exited |
| npm `.cmd` Claude 2.1.223 | `WINDOWS_NPM_SHIM_OK`; a second real shell-tool turn showed Working then `WINDOWS_TOOL_OK`/Done; tab removed | Root 54700 and captured child 61992 exited |

Both roots were matched to their provider session IDs and executable paths. Fresh Windows process reads verified PID + creation-time identities; both captured descendant snapshots returned `exited`. Backing agent state matched Working/Done and cleared after close. No shutdown assertion occurred. Both owned dev instances were closed afterward.

<details>
<summary>Native response and session close</summary>

![Native real Claude response](https://github.com/user-attachments/assets/a7eed948-bd2b-43e5-b14f-cbcb3493ebcb)
![Native session closed](https://github.com/user-attachments/assets/76f4494b-f915-48dd-b6ee-2406d2a6cc64)

</details>

<details>
<summary>npm shim response, real tool turn working, and session close</summary>

![npm shim real Claude response](https://github.com/user-attachments/assets/0f2a97c9-49af-486a-9ce5-7994933ce7e7)
![Real tool turn working](https://github.com/user-attachments/assets/d2d85172-0b69-44f3-a86f-de3f0d7d7bf6)
![npm shim session closed](https://github.com/user-attachments/assets/05acc778-710a-4d26-8914-dd924596dbbc)

</details>

## Testing

- [x] Manually exercised real Claude provider sessions on both connected Windows hosts against main plus this fix: native, npm-direct, resolved shim, and legacy shim launches.
- [x] 94 focused tests passed on each Windows host; 51 focused tests passed on macOS.
- [x] Node typecheck, targeted lint, and formatting passed.
- [x] Regression tests failed before the fix and passed afterward.
- [x] Exact PR commit rendered Windows Electron validation with real Claude agents; 94 focused Windows tests passed again on that commit.

Low-spec startup/close diagnostics required a 20-second acquisition budget rather than the test's original five seconds. Older npm versions skip the unsupported transcript-location check. The JavaScript-based CLI 2.1.50 refused the existing sign-in, so its authenticated flow remains unverified. Missing process identities continue to produce `unverifiable`. These UI runs cover normal completion and close, not permission prompts or interrupted turns; the PID-reuse regression itself is reproduced deterministically by the captured-data tests, not by forcing PID reuse in the UI.

## Review

The change is confined to Windows snapshot ancestry. It changes no wire contract or UI and runs on the host that owns execution; it does not depend on Git worktrees or provider-specific APIs. Existing conservative exit-proof behavior is preserved.

## Agent skill upstream boundary

- [x] Not applicable; no skill implementation is changed.

## Checklist

- [x] Small, focused code and regression-test change only.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and folder-workspace impact considered.
- [x] Windows Electron evidence attached.
- [x] CI static analysis, typecheck, all eight test shards, packaging (including Windows), and aggregate verify passed.
