### PR TITLE
fix(codex-usage): deduplicate fork-copied token events across timestamp rewrites

### DIFF
--- a/src/main/codex-usage/codex-usage-provider.ts
+++ b/src/main/codex-usage/codex-usage-provider.ts
@@ -2,10 +2,10 @@ import type { UsageProvider } from '../usage/usage-provider-contract'
 import { scanCodexUsageFiles } from './scanner'
 import type { CodexUsageDailyAggregate, CodexUsagePersistedFile, CodexUsageSession } from './types'
 
-// Why: v5 keys Codex ownership on raw token_count identity without session id
-// so forks that rewrite session_meta still match. Older caches used session-
-// scoped keys and can double-count after fork/resume (#8006).
-export const CODEX_USAGE_SCHEMA_VERSION = 5
+// Why: v6 keys Codex event ownership on root thread identity + token usage tuples
+// without raw timestamp. Codex rewrites copied token_count timestamps to the fork
+// creation time, so timestamp-based keys bypassed deduplication on session forks (#19139).
+export const CODEX_USAGE_SCHEMA_VERSION = 6
 
 export const codexUsageProvider = {
   id: 'codex',

--- a/src/main/codex-usage/codex-usage-record-identity.test.ts
+++ b/src/main/codex-usage/codex-usage-record-identity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { parseCodexUsageRecord, type CodexUsageParseContext } from './codex-usage-record-parser'
+
+function key(id: string, root?: string, turn?: string, timestamp = '2026-09-01T00:00:00Z') {
+  const context: CodexUsageParseContext = {
+    sessionId: id,
+    sessionCwd: null,
+    currentCwd: null,
+    currentModel: null,
+    previousTotals: null
+  }
+  parseCodexUsageRecord(
+    JSON.stringify({ type: 'session_meta', payload: { id, session_id: root } }),
+    context
+  )
+  parseCodexUsageRecord(
+    JSON.stringify({ type: 'turn_context', payload: { turn_id: turn } }),
+    context
+  )
+  const usage = { input_tokens: 10, total_tokens: 10 }
+  return parseCodexUsageRecord(
+    JSON.stringify({
+      type: 'event_msg',
+      timestamp,
+      payload: {
+        type: 'token_count',
+        info: { total_token_usage: usage, last_token_usage: usage }
+      }
+    }),
+    context
+  )?.eventKey
+}
+
+describe('Codex usage ownership identity', () => {
+  it('counts repeated last-only requests separately', () => {
+    const context: CodexUsageParseContext = {
+      sessionId: 'a',
+      sessionCwd: null,
+      currentCwd: null,
+      currentModel: null,
+      previousTotals: null
+    }
+    const line = JSON.stringify({
+      type: 'event_msg',
+      timestamp: '2026-09-01T00:00:00Z',
+      payload: {
+        type: 'token_count',
+        info: { last_token_usage: { input_tokens: 10, total_tokens: 10 } }
+      }
+    })
+    const first = parseCodexUsageRecord(line, context)
+    const second = parseCodexUsageRecord(line, context)
+    expect(first?.eventKey).not.toBe(second?.eventKey)
+    expect(first?.totalTokens).toBe(10)
+    expect(second?.totalTokens).toBe(10)
+  })
+
+  it('retains unrelated legacy sessions with identical timestamps and usage', () => {
+    expect(key('a')).not.toBe(key('b'))
+  })
+  it('retains independent fork turns with identical usage', () => {
+    expect(key('a', 'root', 'turn-a')).not.toBe(key('b', 'root', 'turn-b'))
+  })
+  it('deduplicates a copied turn whose timestamp and file session id changed', () => {
+    expect(key('a', 'root', 'turn')).toBe(key('b', 'root', 'turn', '2026-09-02T00:00:00Z'))
+  })
+})

--- a/src/main/codex-usage/codex-usage-record-parser.ts
+++ b/src/main/codex-usage/codex-usage-record-parser.ts
@@ -148,7 +148,7 @@ export function parseCodexUsageRecord(
   return {
     sessionId: context.sessionId,
     timestamp: parsed.timestamp,
-    eventKey: buildCodexUsageEventKey(parsed.timestamp, totalUsage, lastUsage),
+    eventKey: buildCodexUsageEventKey(totalUsage, lastUsage),
     cwd: context.currentCwd ?? context.sessionCwd,
     model: resolvedModel,
     hasInferredPricing,

--- a/src/main/codex-usage/codex-usage-record-parser.ts
+++ b/src/main/codex-usage/codex-usage-record-parser.ts
@@ -15,6 +15,7 @@ type CodexUsageRawRecord = {
 
 export type CodexUsageParseContext = {
   sessionId: string
+  rootThreadId?: string | null
   sessionCwd: string | null
   currentCwd: string | null
   currentModel: string | null
@@ -77,6 +78,10 @@ export function parseCodexUsageRecord(
 
   if (parsed.type === 'session_meta') {
     context.sessionId = extractString(parsed.payload.id) ?? context.sessionId
+    const rootThreadId = extractString(parsed.payload.session_id)
+    if (rootThreadId) {
+      context.rootThreadId = rootThreadId
+    }
     context.sessionCwd = extractString(parsed.payload.cwd)
     if (!context.currentCwd && context.sessionCwd) {
       context.currentCwd = context.sessionCwd
@@ -148,7 +153,7 @@ export function parseCodexUsageRecord(
   return {
     sessionId: context.sessionId,
     timestamp: parsed.timestamp,
-    eventKey: buildCodexUsageEventKey(totalUsage, lastUsage),
+    eventKey: buildCodexUsageEventKey(context.rootThreadId, totalUsage, lastUsage),
     cwd: context.currentCwd ?? context.sessionCwd,
     model: resolvedModel,
     hasInferredPricing,

--- a/src/main/codex-usage/codex-usage-record-parser.ts
+++ b/src/main/codex-usage/codex-usage-record-parser.ts
@@ -16,6 +16,8 @@ type CodexUsageRawRecord = {
 export type CodexUsageParseContext = {
   sessionId: string
   rootThreadId?: string | null
+  currentTurnId?: string | null
+  usageEventIndex?: number
   sessionCwd: string | null
   currentCwd: string | null
   currentModel: string | null
@@ -78,7 +80,10 @@ export function parseCodexUsageRecord(
 
   if (parsed.type === 'session_meta') {
     context.sessionId = extractString(parsed.payload.id) ?? context.sessionId
-    const rootThreadId = extractString(parsed.payload.session_id)
+    const rootThreadId =
+      extractString(parsed.payload.session_id) ??
+      extractString(parsed.payload.forked_from_id) ??
+      context.sessionId
     if (rootThreadId) {
       context.rootThreadId = rootThreadId
     }
@@ -90,6 +95,7 @@ export function parseCodexUsageRecord(
   }
 
   if (parsed.type === 'turn_context') {
+    context.currentTurnId = extractString(parsed.payload.turn_id)
     context.currentCwd =
       extractString(parsed.payload.cwd) ?? context.currentCwd ?? context.sessionCwd
     context.currentModel = extractModel(parsed.payload) ?? context.currentModel
@@ -111,6 +117,7 @@ export function parseCodexUsageRecord(
   const record = info as Record<string, unknown>
   const totalUsage = normalizeRawUsage(record.total_token_usage)
   const lastUsage = normalizeRawUsage(record.last_token_usage)
+  context.usageEventIndex = (context.usageEventIndex ?? 0) + 1
   if (context.totalOnlyBaselinePending) {
     context.totalOnlyBaselinePending = false
     if (totalUsage && !lastUsage && !context.previousTotals) {
@@ -153,7 +160,16 @@ export function parseCodexUsageRecord(
   return {
     sessionId: context.sessionId,
     timestamp: parsed.timestamp,
-    eventKey: buildCodexUsageEventKey(context.rootThreadId, totalUsage, lastUsage),
+    eventKey: buildCodexUsageEventKey(
+      JSON.stringify([
+        context.rootThreadId ?? context.sessionId,
+        context.currentTurnId ?? null,
+        // Without cumulative totals, equal deltas can be independent requests.
+        totalUsage ? null : [context.sessionId, parsed.timestamp, context.usageEventIndex]
+      ]),
+      totalUsage,
+      lastUsage
+    ),
     cwd: context.currentCwd ?? context.sessionCwd,
     model: resolvedModel,
     hasInferredPricing,

--- a/src/main/codex-usage/codex-usage-token-delta.ts
+++ b/src/main/codex-usage/codex-usage-token-delta.ts
@@ -156,13 +156,15 @@ export function resolveCodexUsageDelta(
 }
 
 export function buildCodexUsageEventKey(
+  rootThreadId: string | null | undefined,
   totalUsage: CodexUsageRawUsage | null,
   lastUsage: CodexUsageRawUsage | null
 ): string {
   // Why: fork/resume rollouts copy token_count records into new files, but Codex
   // rewrites copied record timestamps to the fork creation time while preserving
-  // monotonic token usage snapshots and deltas. Key only on the usage tuples so
-  // copied history dedupes across forks even when timestamps are rewritten (#19139).
+  // monotonic token usage snapshots and deltas. Key on root thread identity and
+  // token usage tuples so copied history dedupes across forks even when timestamps
+  // are rewritten (#19139), while preventing collisions between unrelated sessions.
   const tupleOf = (usage: CodexUsageRawUsage | null): string =>
     usage
       ? [
@@ -173,5 +175,5 @@ export function buildCodexUsageEventKey(
           usage.totalTokens
         ].join(',')
       : ''
-  return [tupleOf(totalUsage), tupleOf(lastUsage)].join('|')
+  return [rootThreadId ?? '', tupleOf(totalUsage), tupleOf(lastUsage)].join('|')
 }

--- a/src/main/codex-usage/codex-usage-token-delta.ts
+++ b/src/main/codex-usage/codex-usage-token-delta.ts
@@ -156,14 +156,13 @@ export function resolveCodexUsageDelta(
 }
 
 export function buildCodexUsageEventKey(
-  timestamp: string,
   totalUsage: CodexUsageRawUsage | null,
   lastUsage: CodexUsageRawUsage | null
 ): string {
-  // Why: fork/resume copies token_count records byte-for-byte into a new
-  // rollout file, but session_meta.id is often rewritten to the new session.
-  // Key only on the raw record fields (timestamp + usage tuples) so the copy
-  // matches the original regardless of surrounding parse context / session id.
+  // Why: fork/resume rollouts copy token_count records into new files, but Codex
+  // rewrites copied record timestamps to the fork creation time while preserving
+  // monotonic token usage snapshots and deltas. Key only on the usage tuples so
+  // copied history dedupes across forks even when timestamps are rewritten (#19139).
   const tupleOf = (usage: CodexUsageRawUsage | null): string =>
     usage
       ? [
@@ -174,5 +173,5 @@ export function buildCodexUsageEventKey(
           usage.totalTokens
         ].join(',')
       : ''
-  return [timestamp, tupleOf(totalUsage), tupleOf(lastUsage)].join('|')
+  return [tupleOf(totalUsage), tupleOf(lastUsage)].join('|')
 }

--- a/src/main/codex-usage/scanner-paths.test.ts
+++ b/src/main/codex-usage/scanner-paths.test.ts
@@ -515,6 +515,45 @@ describe('listCodexSessionFiles', () => {
     ).toBe(22)
   })
 
+  it('dedupes fork-copied token events when Codex rewrites timestamps to fork creation time', async () => {
+    const sessionsDir = join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const originalPath = join(sessionsDir, 'aaaa-original.jsonl')
+    const forkPath = join(sessionsDir, 'bbbb-fork.jsonl')
+    const originalContent = [
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: { session_id: 'root-thread', id: 'session-1', cwd: join(fakeHomeDir, 'repo') }
+      })}\n`,
+      usageRecord('2026-05-26T12:00:00.000Z', 10),
+      usageRecord('2026-05-26T12:01:00.000Z', 5, 15)
+    ].join('')
+    // Codex rewrites copied records to the fork timestamp (12:02:00) instead of preserving 12:00/12:01
+    const forkContent = [
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: {
+          session_id: 'root-thread',
+          id: 'session-2',
+          forked_from_id: 'session-1',
+          cwd: join(fakeHomeDir, 'repo')
+        }
+      })}\n`,
+      usageRecord('2026-05-26T12:02:00.000Z', 10),
+      usageRecord('2026-05-26T12:02:00.000Z', 5, 15),
+      usageRecord('2026-05-26T12:02:05.000Z', 7, 22)
+    ].join('')
+    writeFileSync(originalPath, originalContent, 'utf-8')
+    writeFileSync(forkPath, forkContent, 'utf-8')
+
+    const result = await scanCodexUsageFiles([], [])
+    expect(
+      result.dailyAggregates.reduce((total, aggregate) => total + aggregate.totalTokens, 0)
+    ).toBe(22)
+    expect(result.processedFiles[0]?.ownedEventKeys).toHaveLength(2)
+    expect(result.processedFiles[1]?.ownedEventKeys).toHaveLength(1)
+  })
+
   it('reclaims copied token events when the owning original file is deleted', async () => {
     const sessionsDir = join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
     mkdirSync(sessionsDir, { recursive: true })

--- a/src/main/codex-usage/scanner-paths.test.ts
+++ b/src/main/codex-usage/scanner-paths.test.ts
@@ -554,6 +554,38 @@ describe('listCodexSessionFiles', () => {
     expect(result.processedFiles[1]?.ownedEventKeys).toHaveLength(1)
   })
 
+  it('does not collide identical usage events from unrelated root sessions', async () => {
+    const sessionsDir = join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const session1Path = join(sessionsDir, 'aaaa-session-1.jsonl')
+    const session2Path = join(sessionsDir, 'bbbb-session-2.jsonl')
+    const session1Content = [
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: { session_id: 'thread-1', id: 'session-1', cwd: join(fakeHomeDir, 'repo') }
+      })}\n`,
+      usageRecord('2026-05-26T12:00:00.000Z', 10)
+    ].join('')
+    // Completely unrelated session with identical token usage (e.g. standard system prompt)
+    const session2Content = [
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: { session_id: 'thread-2', id: 'session-2', cwd: join(fakeHomeDir, 'repo') }
+      })}\n`,
+      usageRecord('2026-05-26T12:00:00.000Z', 10)
+    ].join('')
+    writeFileSync(session1Path, session1Content, 'utf-8')
+    writeFileSync(session2Path, session2Content, 'utf-8')
+
+    const result = await scanCodexUsageFiles([], [])
+    expect(
+      result.dailyAggregates.reduce((total, aggregate) => total + aggregate.totalTokens, 0)
+    ).toBe(20)
+    expect(result.processedFiles[0]?.ownedEventKeys).toHaveLength(1)
+    expect(result.processedFiles[1]?.ownedEventKeys).toHaveLength(1)
+    expect(result.processedFiles[1]?.hasDeferredClaims).toBe(false)
+  })
+
   it('reclaims copied token events when the owning original file is deleted', async () => {
     const sessionsDir = join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
     mkdirSync(sessionsDir, { recursive: true })

--- a/src/main/codex-usage/scanner-paths.test.ts
+++ b/src/main/codex-usage/scanner-paths.test.ts
@@ -429,7 +429,11 @@ describe('listCodexSessionFiles', () => {
     const forkBody = [
       `${JSON.stringify({
         type: 'session_meta',
-        payload: { id: 'session-fork', cwd: join(fakeHomeDir, 'repo') }
+        payload: {
+          id: 'session-fork',
+          forked_from_id: 'session-original',
+          cwd: join(fakeHomeDir, 'repo')
+        }
       })}\n`,
       usageRecord('2026-05-26T12:00:00.000Z', 10),
       usageRecord('2026-05-26T12:01:00.000Z', 5, 15),
@@ -571,6 +575,38 @@ describe('listCodexSessionFiles', () => {
       `${JSON.stringify({
         type: 'session_meta',
         payload: { session_id: 'thread-2', id: 'session-2', cwd: join(fakeHomeDir, 'repo') }
+      })}\n`,
+      usageRecord('2026-05-26T12:00:00.000Z', 10)
+    ].join('')
+    writeFileSync(session1Path, session1Content, 'utf-8')
+    writeFileSync(session2Path, session2Content, 'utf-8')
+
+    const result = await scanCodexUsageFiles([], [])
+    expect(
+      result.dailyAggregates.reduce((total, aggregate) => total + aggregate.totalTokens, 0)
+    ).toBe(20)
+    expect(result.processedFiles[0]?.ownedEventKeys).toHaveLength(1)
+    expect(result.processedFiles[1]?.ownedEventKeys).toHaveLength(1)
+    expect(result.processedFiles[1]?.hasDeferredClaims).toBe(false)
+  })
+
+  it('does not collide identical usage events from unrelated legacy sessions without a root id', async () => {
+    const sessionsDir = join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
+    mkdirSync(sessionsDir, { recursive: true })
+    const session1Path = join(sessionsDir, 'aaaa-session-1.jsonl')
+    const session2Path = join(sessionsDir, 'bbbb-session-2.jsonl')
+    const session1Content = [
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: { id: 'session-1', cwd: join(fakeHomeDir, 'repo') }
+      })}\n`,
+      usageRecord('2026-05-26T12:00:00.000Z', 10)
+    ].join('')
+    // Completely unrelated session with identical token usage (e.g. standard system prompt)
+    const session2Content = [
+      `${JSON.stringify({
+        type: 'session_meta',
+        payload: { id: 'session-2', cwd: join(fakeHomeDir, 'repo') }
       })}\n`,
       usageRecord('2026-05-26T12:00:00.000Z', 10)
     ].join('')

--- a/src/main/codex-usage/scanner.ts
+++ b/src/main/codex-usage/scanner.ts
@@ -80,6 +80,7 @@ export async function parseCodexUsageFile(
   const events: CodexUsageAttributedEvent[] = []
   const context: CodexUsageParseContext = {
     sessionId: basename(filePath, '.jsonl'),
+    rootThreadId: null,
     sessionCwd: null,
     currentCwd: null,
     currentModel: null,

--- a/src/main/codex-usage/store-persistence.test.ts
+++ b/src/main/codex-usage/store-persistence.test.ts
@@ -26,7 +26,7 @@ describe('CodexUsageStore', () => {
 
   it('adapts Codex scans to compact cache persistence', async () => {
     const store = createStoreWithState({
-      schemaVersion: 5,
+      schemaVersion: 6,
       scanState: {
         enabled: true,
         lastScanStartedAt: null,
@@ -81,7 +81,7 @@ describe('CodexUsageStore', () => {
     } as unknown as CodexUsagePersistedState)
 
     expect(normalized).toEqual({
-      schemaVersion: 5,
+      schemaVersion: 6,
       worktreeFingerprint: null,
       processedFiles: [],
       sessions: [],


### PR DESCRIPTION
## ELI5

Forking a Codex conversation can copy its token events with new timestamps. Count copied history once while keeping unrelated conversations and independent turns separate.

## What Changed

Use the recorded shared root and turn identity with the cumulative/last usage tuples, without the rewritten event timestamp. Fall back to an explicit parent ID or the session's own ID for older logs. Last-only records receive an occurrence identity so equal successive deltas remain countable. Invalidate the old usage cache (schema 6).

## Why

The original tuple-only fix could undercount independent sessions. This follow-up addresses that review finding and adds scanner and parser regression coverage. Logs with neither stable lineage nor turn identity cannot prove that two histories are copies; legacy histories without that evidence may remain counted separately.

## Linked Issue

Fixes #19139

## Visual Proof

N/A — this changes usage event ownership and cache invalidation, not rendered layout. Synthetic scanner fixtures assert exact totals before and after fork copying.

## Testing

- [x] Automated tests added/updated: 33 passed across scanner-paths, scanner, store-persistence and record-identity tests on Windows.
- [x] Targeted oxlint and oxfmt checks passed.
- [ ] Manual provider-billing reconciliation (not performed; these are local transcript estimates).

## AI Disclosure

Developed and reviewed with Codex (GPT-6).

## Review

Follow-up isolates unrelated roots, legacy session IDs, independent turns, and repeated last-only events. Cache ownership/deletion regression tests also pass.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer code or material changed.
