### PR TITLE
fix(native-chat): make structured chat tabs renameable

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/src/main/runtime/orca-runtime-restore-structured-agent-session-tabs-once.ts
+++ b/src/main/runtime/orca-runtime-restore-structured-agent-session-tabs-once.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import { defaultAgentChatLabel } from '../../shared/agent-session-chat-label'
 import { OrcaRuntimeWithResolveRecoveredStructuredTuiTranscript } from './orca-runtime-resolve-recovered-structured-tui-transcript'
 import { getStructuredAgentSessionHost } from '../native-chat/agent-session-wire/structured-agent-session-registry'
 import { collectSavedStructuredAgentSessionIds } from './saved-structured-agent-session-restoration'
@@ -105,7 +106,7 @@ export class OrcaRuntimeWithRestoreStructuredAgentSessionTabsOnce extends OrcaRu
     const tab: RuntimeMobileSessionAgentTab = {
       type: 'agent-session',
       id,
-      title: input.agent === 'claude' ? 'Claude Chat' : 'Codex Chat',
+      title: defaultAgentChatLabel(input.agent),
       sessionId: input.sessionId,
       agent: input.agent,
       isActive: input.activate

--- a/src/renderer/src/app-shell/app-command-handlers-tab-rename.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers-tab-rename.test.ts
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup } from '../../../shared/tab-types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { AppState } from '@/store/types'
+import { createTabsFocusActions } from '../store/slices/tabs/tabs-focus-actions'
+import type { TabsSliceGet, TabsSliceSet } from '../store/slices/tabs/tabs-slice-contract'
+import { buildActiveSurfacePatch } from '../store/slices/tabs/tabs-surface'
 import type { AppShortcutState, ShortcutDispatchInput } from './app-command-handlers'
 
 const mocks = vi.hoisted(() => ({
@@ -25,10 +30,78 @@ vi.mock('@/lib/terminal-shortcut-capture-notification', () => ({
 
 import { createAppCommandHandlers } from './app-command-handlers'
 
+const WORKTREE_ID = 'repo::/feature'
+const GROUP_ID = 'group-1'
+const TERMINAL_ENTITY_ID = 'terminal-1'
+const TERMINAL_UNIFIED_ID = 'unified-terminal'
+const CHAT_UNIFIED_ID = 'unified-chat'
+
+function unifiedTab(overrides: Partial<Tab> & Pick<Tab, 'id' | 'entityId' | 'contentType'>): Tab {
+  return {
+    groupId: GROUP_ID,
+    worktreeId: WORKTREE_ID,
+    label: overrides.id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+/**
+ * Builds the store the real app has when `activeGroupTabId` is focused: the raw group/tab state
+ * plus the active-surface fields derived from it by the same code the store runs. That derivation
+ * is what leaves `activeTabId` pointing at a background terminal while a structured tab is active,
+ * so stubbing those fields instead would hide exactly the half under test.
+ */
+function storeForActiveTab(activeGroupTabId: string): AppState {
+  const groups: TabGroup[] = [
+    {
+      id: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      activeTabId: activeGroupTabId,
+      tabOrder: [TERMINAL_UNIFIED_ID, CHAT_UNIFIED_ID]
+    }
+  ]
+  const rawState = {
+    activeBrowserTabIdByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeGroupIdByWorktree: { [WORKTREE_ID]: GROUP_ID },
+    // The user focused this terminal before switching to the structured tab.
+    activeTabIdByWorktree: { [WORKTREE_ID]: TERMINAL_ENTITY_ID },
+    activeTabTypeByWorktree: {},
+    browserTabsByWorktree: {},
+    groupsByWorktree: { [WORKTREE_ID]: groups },
+    layoutByWorktree: {},
+    openFiles: [],
+    tabsByWorktree: {
+      [WORKTREE_ID]: [{ id: TERMINAL_ENTITY_ID, worktreeId: WORKTREE_ID } as TerminalTab]
+    },
+    unifiedTabsByWorktree: {
+      [WORKTREE_ID]: [
+        unifiedTab({
+          id: TERMINAL_UNIFIED_ID,
+          entityId: TERMINAL_ENTITY_ID,
+          contentType: 'terminal'
+        }),
+        unifiedTab({ id: CHAT_UNIFIED_ID, entityId: 'session-1', contentType: 'agent-session' })
+      ]
+    }
+  } as unknown as AppState
+  const store = {
+    ...rawState,
+    ...buildActiveSurfacePatch(rawState, WORKTREE_ID)
+  } as AppState
+  const noopSet = (() => {}) as unknown as TabsSliceSet
+  store.getActiveTab = createTabsFocusActions(noopSet, (() => store) as TabsSliceGet).getActiveTab
+  return store
+}
+
 function shortcutState(): AppShortcutState {
   return {
     activeView: 'terminal',
-    activeWorktreeId: 'repo::/feature',
+    activeWorktreeId: WORKTREE_ID,
     actions: {} as AppShortcutState['actions'],
     creationLayoutActive: false,
     floatingTerminalEnabled: false,
@@ -47,28 +120,46 @@ function shortcutInput(): ShortcutDispatchInput {
   return { target: null, defaultPrevented: false, preventDefault: vi.fn() }
 }
 
-function runRename(activeTabType: string | null): boolean | undefined {
-  mocks.store = { activeTabType, activeTabId: 'tab-1' } as unknown as AppState
-  return createAppCommandHandlers(shortcutState(), shortcutInput(), 'terminal').get(
-    'tab.rename'
-  )?.()
+function runRename(state: AppShortcutState = shortcutState()): boolean | undefined {
+  return createAppCommandHandlers(state, shortcutInput(), 'terminal').get('tab.rename')?.()
 }
 
 describe('tab.rename shortcut', () => {
   beforeEach(() => vi.clearAllMocks())
 
-  it('opens the rename editor on a structured chat tab', () => {
-    expect(runRename('agent-session')).toBe(true)
-    expect(mocks.requestTerminalTabRename).toHaveBeenCalledWith('tab-1')
+  it('leaves activeTabId on a background terminal while a structured tab is active', () => {
+    // Guards the premise of the test below: without this the structured case proves nothing.
+    mocks.store = storeForActiveTab(CHAT_UNIFIED_ID)
+    expect(mocks.store.activeTabType).toBe('agent-session')
+    expect(mocks.store.activeTabId).toBe(TERMINAL_ENTITY_ID)
   })
 
-  it('still opens the rename editor on a terminal tab', () => {
-    expect(runRename('terminal')).toBe(true)
-    expect(mocks.requestTerminalTabRename).toHaveBeenCalledWith('tab-1')
+  it('renames the structured chat tab, not the stale background terminal', () => {
+    mocks.store = storeForActiveTab(CHAT_UNIFIED_ID)
+    expect(runRename()).toBe(true)
+    expect(mocks.requestTerminalTabRename).toHaveBeenCalledWith(CHAT_UNIFIED_ID)
+    expect(mocks.requestTerminalTabRename).not.toHaveBeenCalledWith(TERMINAL_ENTITY_ID)
+  })
+
+  it('still renames the terminal tab by its backing terminal id', () => {
+    mocks.store = storeForActiveTab(TERMINAL_UNIFIED_ID)
+    expect(mocks.store.activeTabType).toBe('terminal')
+    expect(runRename()).toBe(true)
+    expect(mocks.requestTerminalTabRename).toHaveBeenCalledWith(TERMINAL_ENTITY_ID)
   })
 
   it('does not claim the chord for a tab type that has no inline rename', () => {
-    expect(runRename('browser')).toBe(false)
+    mocks.store = {
+      ...storeForActiveTab(CHAT_UNIFIED_ID),
+      activeTabType: 'browser'
+    } as AppState
+    expect(runRename()).toBe(false)
+    expect(mocks.requestTerminalTabRename).not.toHaveBeenCalled()
+  })
+
+  it('does not claim the chord for a structured tab with no active worktree', () => {
+    mocks.store = storeForActiveTab(CHAT_UNIFIED_ID)
+    expect(runRename({ ...shortcutState(), activeWorktreeId: null })).toBe(false)
     expect(mocks.requestTerminalTabRename).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/app-shell/app-command-handlers-tab-rename.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers-tab-rename.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import type { AppShortcutState, ShortcutDispatchInput } from './app-command-handlers'
+
+const mocks = vi.hoisted(() => ({
+  requestTerminalTabRename: vi.fn(),
+  store: {} as AppState
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: () => mocks.store })
+}))
+
+vi.mock('../components/tab-bar/terminal-tab-rename-request', () => ({
+  requestTerminalTabRename: mocks.requestTerminalTabRename
+}))
+
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  isFloatingWorkspacePanelFocused: () => false
+}))
+
+vi.mock('@/lib/terminal-shortcut-capture-notification', () => ({
+  showTerminalShortcutCaptureNotification: vi.fn()
+}))
+
+import { createAppCommandHandlers } from './app-command-handlers'
+
+function shortcutState(): AppShortcutState {
+  return {
+    activeView: 'terminal',
+    activeWorktreeId: 'repo::/feature',
+    actions: {} as AppShortcutState['actions'],
+    creationLayoutActive: false,
+    floatingTerminalEnabled: false,
+    floatingTerminalOpen: false,
+    floatingVisibleTabCount: 0,
+    keybindings: {},
+    openFloatingWorkspaceMaximized: vi.fn(),
+    pluginCommands: [],
+    setFloatingTerminalOpen: vi.fn(),
+    terminalShortcutPolicy: 'orca-first',
+    workspaceChromeActive: true
+  }
+}
+
+function shortcutInput(): ShortcutDispatchInput {
+  return { target: null, defaultPrevented: false, preventDefault: vi.fn() }
+}
+
+function runRename(activeTabType: string | null): boolean | undefined {
+  mocks.store = { activeTabType, activeTabId: 'tab-1' } as unknown as AppState
+  return createAppCommandHandlers(shortcutState(), shortcutInput(), 'terminal').get(
+    'tab.rename'
+  )?.()
+}
+
+describe('tab.rename shortcut', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('opens the rename editor on a structured chat tab', () => {
+    expect(runRename('agent-session')).toBe(true)
+    expect(mocks.requestTerminalTabRename).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('still opens the rename editor on a terminal tab', () => {
+    expect(runRename('terminal')).toBe(true)
+    expect(mocks.requestTerminalTabRename).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('does not claim the chord for a tab type that has no inline rename', () => {
+    expect(runRename('browser')).toBe(false)
+    expect(mocks.requestTerminalTabRename).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -176,7 +176,9 @@ export function createAppCommandHandlers(
         if (
           !workspaceChromeActive ||
           floatingWorkspaceFocused ||
-          store.activeTabType !== 'terminal' ||
+          // Why: a structured chat tab is renamed through the same inline editor,
+          // so gating on 'terminal' alone left the shortcut a silent no-op there.
+          (store.activeTabType !== 'terminal' && store.activeTabType !== 'agent-session') ||
           !store.activeTabId
         ) {
           return false

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -76,6 +76,24 @@ export function getKeybindingContext(target: EventTarget | null): KeybindingCont
 }
 
 /**
+ * The tab id the inline rename editor listens on, which differs per tab kind: a terminal tab is
+ * addressed by its backing terminal id (`activeTabId`), a structured chat tab by its unified tab
+ * id. `activeTabId` is terminal-only state and never moves for a structured tab, so reading it
+ * there targets whichever terminal was last active. Mirrors TabGroupPanel's tab-strip resolution.
+ */
+function resolveRenameTargetTabId(activeWorktreeId: string | null): string | null {
+  const store = useAppStore.getState()
+  if (store.activeTabType === 'terminal') {
+    return store.activeTabId
+  }
+  if (store.activeTabType !== 'agent-session' || !activeWorktreeId) {
+    return null
+  }
+  const activeTab = store.getActiveTab(activeWorktreeId)
+  return activeTab?.contentType === 'agent-session' ? activeTab.id : null
+}
+
+/**
  * Builds the app-level handlers for every keybindable action. Each returns whether it claimed
  * the chord, so an unavailable surface (settings view, closed floating panel) falls through to
  * the terminal or the next handler instead of silently no-opping.
@@ -172,18 +190,16 @@ export function createAppCommandHandlers(
     [
       'tab.rename',
       () => {
-        const store = useAppStore.getState()
-        if (
-          !workspaceChromeActive ||
-          floatingWorkspaceFocused ||
-          // Why: a structured chat tab is renamed through the same inline editor,
-          // so gating on 'terminal' alone left the shortcut a silent no-op there.
-          (store.activeTabType !== 'terminal' && store.activeTabType !== 'agent-session') ||
-          !store.activeTabId
-        ) {
+        if (!workspaceChromeActive || floatingWorkspaceFocused) {
           return false
         }
-        return claim('tab.rename', () => requestTerminalTabRename(store.activeTabId!))
+        // Why: a structured chat tab is renamed through the same inline editor, so gating on
+        // 'terminal' alone left the shortcut a silent no-op there.
+        const tabId = resolveRenameTargetTabId(activeWorktreeId)
+        if (!tabId) {
+          return false
+        }
+        return claim('tab.rename', () => requestTerminalTabRename(tabId))
       }
     ],
     [

--- a/src/renderer/src/components/tab-bar/tab-bar-item-model.ts
+++ b/src/renderer/src/components/tab-bar/tab-bar-item-model.ts
@@ -234,6 +234,9 @@ export function findActiveVisibleTabId(
       return active.activeTabType === 'simulator' && item.id === active.activeSimulatorTabId
     }
     if (item.type === 'agent-session') {
+      // Reachable only from TabGroupPanel, which passes the structured tab's own id; the store's
+      // `activeTabId` names a background terminal here (cf. TerminalTitlebarTabs, which resolves
+      // `getActiveTab(...)?.id` for 'simulator' and never renders agent-session items).
       return active.activeTabType === 'agent-session' && item.id === active.activeTabId
     }
     return (

--- a/src/renderer/src/components/terminal/tab-type-cycle.ts
+++ b/src/renderer/src/components/terminal/tab-type-cycle.ts
@@ -18,17 +18,30 @@ type GetNextTabWithinActiveTypeParams = {
   direction: number
 }
 
+/**
+ * The backing entity id of the active tab, in the same id domain the cyclable entries use.
+ *
+ * `activeAgentSessionEntityId` is optional because a caller that only compares type-matched
+ * entries stays correct without it; a caller that searches a pre-filtered single-type list must
+ * pass it, or a structured tab resolves to a live background terminal (see the branch below).
+ */
 export function getActiveEntityIdForTabType(
   activeTabType: TabCycleType,
   activeTabId: string | null,
   activeFileId: string | null,
-  activeBrowserTabId: string | null
+  activeBrowserTabId: string | null,
+  activeAgentSessionEntityId: string | null = null
 ): string | null {
   if (activeTabType === 'editor') {
     return activeFileId
   }
   if (activeTabType === 'browser') {
     return activeBrowserTabId
+  }
+  // Why: `activeTabId` is terminal-only state that keeps naming a live background terminal while a
+  // structured tab is active, so falling through here cycles from a tab the user is not on.
+  if (activeTabType === 'agent-session') {
+    return activeAgentSessionEntityId
   }
   if (activeTabType === 'simulator') {
     return activeTabId

--- a/src/renderer/src/hooks/ipc-tab-switch-group-order-hydration.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch-group-order-hydration.test.ts
@@ -9,6 +9,9 @@ const { getStateMock } = vi.hoisted(() => ({ getStateMock: vi.fn() }))
 
 vi.mock('../store', () => ({ useAppStore: { getState: getStateMock } }))
 
+import { createTabsFocusActions } from '../store/slices/tabs/tabs-focus-actions'
+import type { TabsSliceGet, TabsSliceSet } from '../store/slices/tabs/tabs-slice-contract'
+
 import {
   handleSwitchTab,
   handleSwitchTabAcrossAllTypes,
@@ -39,7 +42,7 @@ function stateWithGroupOrder(tabOrder: string[]) {
     terminalTab('tab-2', 'term-2', 1),
     terminalTab('tab-3', 'term-3', 2)
   ]
-  return {
+  const store = {
     activeWorktreeId: WT,
     activeTabType: 'terminal' as const,
     activeTabId: 'term-1',
@@ -58,8 +61,16 @@ function stateWithGroupOrder(tabOrder: string[]) {
     setActiveFile: vi.fn(),
     setActiveBrowserTab: vi.fn(),
     setActiveTabType: vi.fn(),
-    activateTab: vi.fn()
+    activateTab: vi.fn(),
+    getActiveTab: (_worktreeId: string): unknown => null
   }
+  // Why the real resolver: a hand-written stub would decide the group-scoped answer the code
+  // under test is meant to exercise.
+  store.getActiveTab = createTabsFocusActions(
+    (() => {}) as unknown as TabsSliceSet,
+    (() => store) as unknown as TabsSliceGet
+  ).getActiveTab
+  return store
 }
 
 describe('tab-cycle chord against a group whose tabOrder is still hydrating', () => {

--- a/src/renderer/src/hooks/ipc-tab-switch-structured-tab-cycle.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch-structured-tab-cycle.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab, TabGroup } from '../../../shared/tab-types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { AppState } from '@/store/types'
+import { createTabsFocusActions } from '../store/slices/tabs/tabs-focus-actions'
+import type { TabsSliceGet, TabsSliceSet } from '../store/slices/tabs/tabs-slice-contract'
+import { buildActiveSurfacePatch } from '../store/slices/tabs/tabs-surface'
+
+const mocks = vi.hoisted(() => ({ store: {} as AppState }))
+
+vi.mock('../store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: () => mocks.store })
+}))
+
+import { handleSwitchTerminalTab } from './ipc-tab-switch'
+
+const WORKTREE_ID = 'wt-1'
+const GROUP_ID = 'group-1'
+const SESSION_ID = 'sess-1'
+const CHAT_UNIFIED_ID = `structured-agent-session-${SESSION_ID}`
+
+function unifiedTab(overrides: Partial<Tab> & Pick<Tab, 'id' | 'entityId' | 'contentType'>): Tab {
+  return {
+    groupId: GROUP_ID,
+    worktreeId: WORKTREE_ID,
+    label: overrides.id,
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+/**
+ * The store the app really has with a structured tab focused: raw group state plus the
+ * active-surface fields the store derives from it. That derivation is what leaves `activeTabId`
+ * naming a live background terminal, so stubbing it would hide the half under test.
+ */
+function storeWithStructuredTabActive({
+  terminalIds,
+  lastFocusedTerminalId,
+  activeGroupTabId = CHAT_UNIFIED_ID
+}: {
+  terminalIds: string[]
+  lastFocusedTerminalId: string
+  activeGroupTabId?: string
+}): AppState {
+  const terminalTabs = terminalIds.map((id) =>
+    unifiedTab({ id: `unified-${id}`, entityId: id, contentType: 'terminal' })
+  )
+  const chatTab = unifiedTab({
+    id: CHAT_UNIFIED_ID,
+    entityId: SESSION_ID,
+    contentType: 'agent-session'
+  })
+  const groups: TabGroup[] = [
+    {
+      id: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      activeTabId: activeGroupTabId,
+      tabOrder: [...terminalTabs.map((tab) => tab.id), chatTab.id]
+    }
+  ]
+  const rawState = {
+    activeBrowserTabIdByWorktree: {},
+    activeFileIdByWorktree: {},
+    activeGroupIdByWorktree: { [WORKTREE_ID]: GROUP_ID },
+    activeTabIdByWorktree: { [WORKTREE_ID]: lastFocusedTerminalId },
+    activeTabTypeByWorktree: {},
+    activeWorktreeId: WORKTREE_ID,
+    browserTabsByWorktree: {},
+    groupsByWorktree: { [WORKTREE_ID]: groups },
+    layoutByWorktree: {},
+    openFiles: [],
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: {
+      [WORKTREE_ID]: terminalIds.map((id) => ({ id, worktreeId: WORKTREE_ID }) as TerminalTab)
+    },
+    unifiedTabsByWorktree: { [WORKTREE_ID]: [...terminalTabs, chatTab] },
+    setActiveTab: vi.fn(),
+    setActiveTabType: vi.fn(),
+    activateTab: vi.fn(),
+    setActiveFile: vi.fn(),
+    setActiveBrowserTab: vi.fn()
+  } as unknown as AppState
+  const store = {
+    ...rawState,
+    ...buildActiveSurfacePatch(rawState, WORKTREE_ID)
+  } as AppState
+  const noopSet = (() => {}) as unknown as TabsSliceSet
+  store.getActiveTab = createTabsFocusActions(noopSet, (() => store) as TabsSliceGet).getActiveTab
+  return store
+}
+
+describe('handleSwitchTerminalTab with a structured chat tab active', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('leaves activeTabId naming a live background terminal', () => {
+    // Guards the premise: without a stale id that is really in the terminal list, the tests
+    // below would pass with the bug present.
+    mocks.store = storeWithStructuredTabActive({
+      terminalIds: ['term-1', 'term-2', 'term-3'],
+      lastFocusedTerminalId: 'term-2'
+    })
+    expect(mocks.store.activeTabType).toBe('agent-session')
+    expect(mocks.store.activeTabId).toBe('term-2')
+  })
+
+  it('jumps to the first terminal instead of cycling from the background terminal', () => {
+    mocks.store = storeWithStructuredTabActive({
+      terminalIds: ['term-1', 'term-2', 'term-3'],
+      lastFocusedTerminalId: 'term-2'
+    })
+    expect(handleSwitchTerminalTab(1)).toBe(true)
+    // Stepping from the stale 'term-2' would land on 'term-3'.
+    expect(mocks.store.setActiveTab).toHaveBeenCalledWith('term-1')
+    expect(mocks.store.setActiveTab).not.toHaveBeenCalledWith('term-3')
+    expect(mocks.store.setActiveTabType).toHaveBeenCalledWith('terminal')
+  })
+
+  it('still reaches the sole terminal rather than reading as already focused', () => {
+    mocks.store = storeWithStructuredTabActive({
+      terminalIds: ['term-1'],
+      lastFocusedTerminalId: 'term-1'
+    })
+    // The stale id matched the only terminal, so the single-terminal guard swallowed the chord.
+    expect(handleSwitchTerminalTab(1)).toBe(true)
+    expect(mocks.store.setActiveTab).toHaveBeenCalledWith('term-1')
+  })
+
+  it('still cycles normally from a focused terminal tab', () => {
+    mocks.store = storeWithStructuredTabActive({
+      terminalIds: ['term-1', 'term-2', 'term-3'],
+      lastFocusedTerminalId: 'term-2',
+      activeGroupTabId: 'unified-term-2'
+    })
+    expect(mocks.store.activeTabType).toBe('terminal')
+    expect(handleSwitchTerminalTab(1)).toBe(true)
+    expect(mocks.store.setActiveTab).toHaveBeenCalledWith('term-3')
+  })
+})

--- a/src/renderer/src/hooks/ipc-tab-switch.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.test.ts
@@ -15,6 +15,8 @@ vi.mock('@/components/tab-bar/group-tab-order', () => ({
   getActiveTabNavOrder: getActiveTabNavOrderMock
 }))
 
+import { createTabsFocusActions } from '../store/slices/tabs/tabs-focus-actions'
+import type { TabsSliceGet, TabsSliceSet } from '../store/slices/tabs/tabs-slice-contract'
 import {
   handleSwitchRecentTab,
   handleSwitchTab,
@@ -54,10 +56,11 @@ type MockStore = {
   setActiveBrowserTab: ReturnType<typeof vi.fn>
   activateTab: ReturnType<typeof vi.fn>
   setActiveTabType: ReturnType<typeof vi.fn>
+  getActiveTab: (worktreeId: string) => unknown
 }
 
 function makeStore(activeTabType: ActiveTabType, overrides: Partial<MockStore> = {}): MockStore {
-  return {
+  const store: MockStore = {
     activeWorktreeId: 'wt-1',
     activeTabType,
     activeTabId: 'term-1',
@@ -72,8 +75,16 @@ function makeStore(activeTabType: ActiveTabType, overrides: Partial<MockStore> =
     setActiveBrowserTab: vi.fn(),
     activateTab: vi.fn(),
     setActiveTabType: vi.fn(),
+    getActiveTab: () => null,
     ...overrides
   }
+  // Why the real resolver: the group-scoped active tab is what the code under test reads, so a
+  // hand-written stub here would decide the answer instead of exercising it.
+  store.getActiveTab = createTabsFocusActions(
+    (() => {}) as unknown as TabsSliceSet,
+    (() => store) as unknown as TabsSliceGet
+  ).getActiveTab
+  return store
 }
 
 describe('handleSwitchTerminalTab', () => {

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -343,13 +343,18 @@ export function handleSwitchTerminalTab(direction: number): boolean {
   if (terminalTabs.length === 0) {
     return false
   }
+  // Why: this list is pre-filtered to terminals, so the index search below has no type check to
+  // reject a stale terminal id — a structured tab must resolve to its own entity or the chord
+  // cycles from whichever terminal was last active.
+  const activeTab = store.getActiveTab(worktreeId)
   const currentId = getActiveEntityIdForTabType(
     store.activeTabType,
     store.activeTabId,
     store.activeFileId,
-    store.activeBrowserTabId
+    store.activeBrowserTabId,
+    activeTab?.contentType === 'agent-session' ? activeTab.entityId : null
   )
-  // Why: when an editor/browser tab is active, jump to the first terminal on
+  // Why: when an editor/browser/structured tab is active, jump to the first terminal on
   // forward navigation instead of skipping to index 1.
   const idx = terminalTabs.findIndex((t) => t.id === currentId)
   // Why: only no-op when the sole terminal is already focused. With one terminal

--- a/src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import type { Tab } from '../../../../shared/tab-types'
+import { buildMirroredAgentTabs } from './terminal-surfaces'
+
+const WORKTREE = 'repo-1::worktree-1'
+const GROUP = 'group-1'
+
+function snapshotWith(agent: 'claude' | 'codex', title: string): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: WORKTREE,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: GROUP,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: [
+      {
+        type: 'agent-session',
+        id: 'host-tab-1',
+        title,
+        sessionId: `${agent}-1`,
+        agent,
+        isActive: false
+      }
+    ]
+  } as RuntimeMobileSessionTabsResult
+}
+
+function build(
+  snapshot: RuntimeMobileSessionTabsResult,
+  currentUnifiedTabs: readonly Tab[] = []
+): Tab {
+  const [mirrored] = buildMirroredAgentTabs(
+    snapshot,
+    new Map(),
+    GROUP,
+    0,
+    currentUnifiedTabs,
+    1_000
+  )
+  return mirrored.unifiedTab
+}
+
+describe('buildMirroredAgentTabs', () => {
+  it('falls back to the agent-specific placeholder when the host publishes no title', () => {
+    expect(build(snapshotWith('claude', '')).label).toBe('Claude Chat')
+    expect(build(snapshotWith('codex', '   ')).label).toBe('Codex Chat')
+  })
+
+  it('prefers the host title over the placeholder', () => {
+    expect(build(snapshotWith('claude', 'Flaky retry test')).label).toBe('Flaky retry test')
+  })
+
+  it('keeps a manual rename across host snapshots', () => {
+    const snapshot = snapshotWith('codex', 'Codex Chat')
+    const renamed = build(snapshot)
+    const existing: Tab = { ...renamed, customLabel: 'My rename' }
+    expect(build(snapshot, [existing]).customLabel).toBe('My rename')
+  })
+
+  it('leaves customLabel null when the tab was never renamed', () => {
+    expect(build(snapshotWith('codex', 'Codex Chat')).customLabel).toBeNull()
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts
@@ -60,6 +60,18 @@ describe('buildMirroredAgentTabs', () => {
   })
 
   it('leaves customLabel null when the tab was never renamed', () => {
-    expect(build(snapshotWith('codex', 'Codex Chat')).customLabel).toBeNull()
+    // Guard: assert the row is actually built, so this cannot pass on an empty
+    // result the way a bare null-check would.
+    const tab = build(snapshotWith('codex', 'Codex Chat'))
+    expect(tab.label).toBe('Codex Chat')
+    expect(tab.customLabel).toBeNull()
+  })
+
+  it('names an agent this build does not know after itself, not Codex', () => {
+    const snapshot = snapshotWith('codex', '')
+    // Cast: the wire union is claude|codex today, but Tab.agentSessionAgent is
+    // the open AgentType, so a future agent can reach this label.
+    ;(snapshot.tabs[0] as { agent: string }).agent = 'gemini'
+    expect(build(snapshot).label).toBe('Gemini Chat')
   })
 })

--- a/src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts
@@ -67,6 +67,14 @@ describe('buildMirroredAgentTabs', () => {
     expect(tab.customLabel).toBeNull()
   })
 
+  it('degrades to the placeholder when the host violates the string contract', () => {
+    const snapshot = snapshotWith('claude', 'Named')
+    // The wire type says `string`, but a host clearing a name can send null.
+    ;(snapshot.tabs[0] as { title: unknown }).title = null
+    expect(() => build(snapshot)).not.toThrow()
+    expect(build(snapshot).label).toBe('Claude Chat')
+  })
+
   it('names an agent this build does not know after itself, not Codex', () => {
     const snapshot = snapshotWith('codex', '')
     // Cast: the wire union is claude|codex today, but Tab.agentSessionAgent is

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-surfaces.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-surfaces.ts
@@ -74,7 +74,9 @@ export function buildMirroredAgentTabs(
         worktreeId: snapshot.worktree,
         contentType: 'agent-session',
         agentSessionAgent: tab.agent,
-        label: tab.title.trim() || defaultAgentChatLabel(tab.agent),
+        // Why: `title` is wire data typed `string`; a host that violates that must
+        // degrade to the placeholder, not throw inside the snapshot patch.
+        label: tab.title?.trim() || defaultAgentChatLabel(tab.agent),
         // Why: a manual rename lives only on the client; re-nulling it here made
         // every host snapshot silently discard the user's title.
         customLabel: existing?.customLabel ?? null,

--- a/src/renderer/src/runtime/web-session-tabs-sync/terminal-surfaces.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync/terminal-surfaces.ts
@@ -3,6 +3,7 @@ import type {
   RuntimeMobileSessionAgentTab
 } from '../../../../shared/runtime-types'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import { defaultAgentChatLabel } from '../../../../shared/agent-session-chat-label'
 import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-title-sanitization'
 import { resolveTerminalLayoutRoot } from '../remote-terminal-layout-resolution'
 import { getRemoteRuntimePtyEnvironmentId } from '../runtime-terminal-stream'
@@ -73,8 +74,10 @@ export function buildMirroredAgentTabs(
         worktreeId: snapshot.worktree,
         contentType: 'agent-session',
         agentSessionAgent: tab.agent,
-        label: tab.title.trim() || 'Codex Chat',
-        customLabel: null,
+        label: tab.title.trim() || defaultAgentChatLabel(tab.agent),
+        // Why: a manual rename lives only on the client; re-nulling it here made
+        // every host snapshot silently discard the user's title.
+        customLabel: existing?.customLabel ?? null,
         color: tab.color !== undefined ? tab.color : (existing?.color ?? null),
         sortOrder: sortOffset + index,
         createdAt: existing?.createdAt ?? now + sortOffset + index,

--- a/src/renderer/src/store/terminals/renamable-unified-tab.ts
+++ b/src/renderer/src/store/terminals/renamable-unified-tab.ts
@@ -1,0 +1,15 @@
+import type { Tab } from '../../../../shared/tab-types'
+
+/** Resolves the unified tab a per-tab presentation action (rename, color) targets.
+ *  Terminal tabs are addressed by their backing terminal's entityId; a structured
+ *  chat has no TerminalTab record and is addressed by the unified tab id itself. */
+export function findRenamableUnifiedTab(
+  unifiedTabsByWorktree: Record<string, Tab[]>,
+  tabId: string
+): Tab | undefined {
+  const unified = Object.values(unifiedTabsByWorktree).flat()
+  return (
+    unified.find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId) ??
+    unified.find((entry) => entry.contentType === 'agent-session' && entry.id === tabId)
+  )
+}

--- a/src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts
+++ b/src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts
@@ -25,6 +25,24 @@ function structuredTab(): Tab {
   }
 }
 
+const TERMINAL_TAB_ID = 'terminal-1'
+const TERMINAL_UNIFIED_ID = 'unified-terminal-1'
+
+function terminalTab(): Tab {
+  return {
+    id: TERMINAL_UNIFIED_ID,
+    entityId: TERMINAL_TAB_ID,
+    groupId: 'group-1',
+    worktreeId: WORKTREE,
+    contentType: 'terminal',
+    label: 'Terminal',
+    customLabel: null,
+    color: null,
+    sortOrder: 1,
+    createdAt: 2
+  }
+}
+
 function storeWithStructuredTab(): ReturnType<typeof createTestStore> {
   const store = createTestStore()
   seedStore(store, {
@@ -48,6 +66,26 @@ function colorOf(store: ReturnType<typeof createTestStore>): string | null | und
     .getState()
     .unifiedTabsByWorktree[WORKTREE]?.find((tab) => tab.id === STRUCTURED_TAB_ID)?.color
 }
+
+describe('renaming a terminal tab still resolves', () => {
+  it('routes a terminal rename through its entityId, not the unified id', () => {
+    const store = createTestStore()
+    seedStore(store, {
+      repos: [{ id: 'local-repo', path: '/tmp/app', name: 'app' }] as never,
+      worktreesByRepo: {
+        'local-repo': [makeWorktree({ id: WORKTREE, repoId: 'local-repo', path: '/tmp/app' })]
+      },
+      unifiedTabsByWorktree: { [WORKTREE]: [terminalTab(), structuredTab()] }
+    })
+
+    // Keyed by the TERMINAL's entityId — the structured tab must not absorb it.
+    store.getState().setTabCustomTitle(TERMINAL_TAB_ID, 'Build logs')
+
+    const tabs = store.getState().unifiedTabsByWorktree[WORKTREE] ?? []
+    expect(tabs.find((t) => t.id === TERMINAL_UNIFIED_ID)?.customLabel).toBe('Build logs')
+    expect(tabs.find((t) => t.id === STRUCTURED_TAB_ID)?.customLabel).toBeNull()
+  })
+})
 
 describe('recoloring a structured chat tab', () => {
   it('writes the color onto the agent-session tab', () => {

--- a/src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts
+++ b/src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Tab } from '../../../../shared/tab-types'
+import { createTestStore, makeWorktree, seedStore } from '../slices/store-test-helpers'
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn(), warning: vi.fn() }
+}))
+
+const WORKTREE = 'local-repo::/tmp/app'
+const STRUCTURED_TAB_ID = 'structured-agent-session-codex-1'
+
+function structuredTab(): Tab {
+  return {
+    id: STRUCTURED_TAB_ID,
+    entityId: 'codex-1',
+    groupId: 'group-1',
+    worktreeId: WORKTREE,
+    contentType: 'agent-session',
+    agentSessionAgent: 'codex',
+    label: 'Codex Chat',
+    customLabel: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function storeWithStructuredTab(): ReturnType<typeof createTestStore> {
+  const store = createTestStore()
+  seedStore(store, {
+    repos: [{ id: 'local-repo', path: '/tmp/app', name: 'app' }] as never,
+    worktreesByRepo: {
+      'local-repo': [makeWorktree({ id: WORKTREE, repoId: 'local-repo', path: '/tmp/app' })]
+    },
+    unifiedTabsByWorktree: { [WORKTREE]: [structuredTab()] }
+  })
+  return store
+}
+
+function labelOf(store: ReturnType<typeof createTestStore>): string | null | undefined {
+  return store
+    .getState()
+    .unifiedTabsByWorktree[WORKTREE]?.find((tab) => tab.id === STRUCTURED_TAB_ID)?.customLabel
+}
+
+describe('renaming a structured chat tab', () => {
+  it('writes the custom label onto the agent-session tab', () => {
+    const store = storeWithStructuredTab()
+    store.getState().setTabCustomTitle(STRUCTURED_TAB_ID, 'Flaky retry test')
+    expect(labelOf(store)).toBe('Flaky retry test')
+  })
+
+  it('clears the custom label when the rename is emptied', () => {
+    const store = storeWithStructuredTab()
+    store.getState().setTabCustomTitle(STRUCTURED_TAB_ID, 'Flaky retry test')
+    // Guard: without the intermediate assertion this case passes on a rename
+    // that never wrote anything, since the label starts out null too.
+    expect(labelOf(store)).toBe('Flaky retry test')
+    store.getState().setTabCustomTitle(STRUCTURED_TAB_ID, null)
+    expect(labelOf(store)).toBeNull()
+  })
+})

--- a/src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts
+++ b/src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts
@@ -43,6 +43,20 @@ function labelOf(store: ReturnType<typeof createTestStore>): string | null | und
     .unifiedTabsByWorktree[WORKTREE]?.find((tab) => tab.id === STRUCTURED_TAB_ID)?.customLabel
 }
 
+function colorOf(store: ReturnType<typeof createTestStore>): string | null | undefined {
+  return store
+    .getState()
+    .unifiedTabsByWorktree[WORKTREE]?.find((tab) => tab.id === STRUCTURED_TAB_ID)?.color
+}
+
+describe('recoloring a structured chat tab', () => {
+  it('writes the color onto the agent-session tab', () => {
+    const store = storeWithStructuredTab()
+    store.getState().setTabColor(STRUCTURED_TAB_ID, 'red')
+    expect(colorOf(store)).toBe('red')
+  })
+})
+
 describe('renaming a structured chat tab', () => {
   it('writes the custom label onto the agent-session tab', () => {
     const store = storeWithStructuredTab()

--- a/src/renderer/src/store/terminals/terminal-tab-attention.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-attention.ts
@@ -87,9 +87,12 @@ export function createTerminalTabAttentionActions(
         scheduleRuntimeGraphSync()
         return { tabsByWorktree: next }
       })
-      const item = Object.values(get().unifiedTabsByWorktree)
-        .flat()
-        .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
+      const unified = Object.values(get().unifiedTabsByWorktree).flat()
+      // Why: a structured chat tab has no TerminalTab record, and its rename
+      // arrives keyed by the unified tab id rather than a terminal entityId.
+      const item =
+        unified.find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId) ??
+        unified.find((entry) => entry.contentType === 'agent-session' && entry.id === tabId)
       if (item) {
         get().setTabCustomLabel(item.id, title, opts)
       }

--- a/src/renderer/src/store/terminals/terminal-tab-attention.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-attention.ts
@@ -1,6 +1,7 @@
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
+import { findRenamableUnifiedTab } from './renamable-unified-tab'
 
 export function createTerminalTabAttentionActions(
   set: TerminalStoreSet,
@@ -87,12 +88,7 @@ export function createTerminalTabAttentionActions(
         scheduleRuntimeGraphSync()
         return { tabsByWorktree: next }
       })
-      const unified = Object.values(get().unifiedTabsByWorktree).flat()
-      // Why: a structured chat tab has no TerminalTab record, and its rename
-      // arrives keyed by the unified tab id rather than a terminal entityId.
-      const item =
-        unified.find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId) ??
-        unified.find((entry) => entry.contentType === 'agent-session' && entry.id === tabId)
+      const item = findRenamableUnifiedTab(get().unifiedTabsByWorktree, tabId)
       if (item) {
         get().setTabCustomLabel(item.id, title, opts)
       }
@@ -105,9 +101,7 @@ export function createTerminalTabAttentionActions(
         }
         return { tabsByWorktree: next }
       })
-      const item = Object.values(get().unifiedTabsByWorktree)
-        .flat()
-        .find((entry) => entry.contentType === 'terminal' && entry.entityId === tabId)
+      const item = findRenamableUnifiedTab(get().unifiedTabsByWorktree, tabId)
       if (item) {
         get().setUnifiedTabColor(item.id, color)
         // Why: tab color is host-authoritative for remote-server tabs; mirror it so it persists instead of reverting on the next snapshot.

--- a/src/shared/agent-session-chat-label.ts
+++ b/src/shared/agent-session-chat-label.ts
@@ -1,0 +1,4 @@
+/** Placeholder tab label for a structured chat that has no conversation name yet. */
+export function defaultAgentChatLabel(agent: 'claude' | 'codex' | null | undefined): string {
+  return agent === 'claude' ? 'Claude Chat' : 'Codex Chat'
+}

--- a/src/shared/agent-session-chat-label.ts
+++ b/src/shared/agent-session-chat-label.ts
@@ -1,4 +1,9 @@
-/** Placeholder tab label for a structured chat that has no conversation name yet. */
-export function defaultAgentChatLabel(agent: 'claude' | 'codex' | null | undefined): string {
-  return agent === 'claude' ? 'Claude Chat' : 'Codex Chat'
+import type { AgentType } from './agent-status-types'
+import { formatAgentTypeLabel } from './agent-type-label'
+
+/** Placeholder tab label for a structured chat that has no conversation name yet.
+ *  Routed through the shared agent-name table so an agent this build does not
+ *  know reads as itself rather than silently as Codex. */
+export function defaultAgentChatLabel(agent: AgentType | null | undefined): string {
+  return `${formatAgentTypeLabel(agent)} Chat`
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​531 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​528 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |

<!-- /orca-pr-loc -->

## ELI5

You can't rename a native chat tab. You can open the rename box, type a name, and press Enter — the box closes and nothing happens. This makes rename actually work. It also stops a Claude chat from being labelled "Codex Chat".

## What Changed

Two stacked defects, either of which alone breaks rename:

1. **The rename never landed.** `setTabCustomTitle` scanned `tabsByWorktree` (terminal tabs only) and then bridged to the unified tab via `contentType === 'terminal' && entityId === tabId`. A structured chat tab has no `TerminalTab` record, and its rename arrives keyed by the *unified tab id*, so neither lookup matched and the write was dropped silently. It now falls back to matching an `agent-session` tab by id.
2. **A landed rename was clobbered.** `buildMirroredAgentTabs` rebuilt the tab on every host snapshot and hardcoded `customLabel: null`, while preserving `color`, `createdAt`, and `isPinned` from the existing tab. It now preserves `customLabel` too.

Plus one cosmetic fix: both placeholder sites (`orca-runtime-restore-structured-agent-session-tabs-once.ts` and the renderer fallback in `terminal-surfaces.ts`) now route through a single `defaultAgentChatLabel` helper, so a Claude session no longer falls back to `'Codex Chat'`. The renderer fallback previously hardcoded `'Codex Chat'` for both agents.

## Why

The rename UI was already fully wired for these tabs — `tab-bar-item-surface.tsx` builds a synthetic `TerminalTab` for an agent-session tab and passes the same `onSetCustomTitle` the terminal tabs use. Only the store action and the snapshot rebuild were terminal-only, so the feature looked present and did nothing.

## Linked Issue

N/A — found while investigating where native chat tab titles come from.

## Visual Proof

Not attached. The change is a behavior fix behind an existing control with no layout change: before, the rename box discards your input; after, it keeps it. Covered by unit tests at both broken layers, each verified by ablation (see Testing). Happy to attach a recording if wanted.

## Testing

- [x] Automated tests added
- [ ] Manual testing in the app — not run; see Visual Proof

Added:
- `src/renderer/src/store/terminals/structured-chat-tab-rename.test.ts` — rename writes the label, and clearing it resets to null.
- `src/renderer/src/runtime/web-session-tabs-sync/mirrored-agent-tab-label.test.ts` — agent-specific placeholder, host title preferred, and a manual rename surviving a host snapshot.

**Each fix was ablated to confirm the tests bind to it**, not merely to surrounding behavior:
- Reverting the `setTabCustomTitle` fallback → the rename test fails.
- Reverting `customLabel` preservation and the label helper → the rename-survives-snapshot and Claude-placeholder tests fail; the two regression guards stay green, as expected.

One test initially passed under ablation (asserting `null` when the broken code also left `null`); it now asserts the intermediate state so it cannot false-green.

Regression: `local-structured-session-tabs-sync`, `local-structured-session-retired-epoch-repair`, `web-session-tabs-sync`, `local-structured-session-tabs-host-isolation`, `local-structured-session-empty-worktree-visibility`, `tabs-model-reconciliation` — 57 passed.

`pnpm tc`, `oxlint`, `oxfmt`, and `pnpm run check:code-quality:changed` (0 new findings across 6 files) all pass.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Scope — known limitation, deliberately not fixed here.** `customLabel` is a client-side unified-tab field, persisted via `workspace-session-schema.ts`, so a rename survives restart locally. The wire contract `RuntimeMobileSessionAgentTab` carries only `title` and no `customLabel`, so a rename does **not** sync to other clients — rename on desktop and mobile still shows the old label. Fixing that means an additive optional wire field, which is safe but is a separate change with its own compatibility story.
- **Placeholder strings are not localized.** `'Claude Chat'` / `'Codex Chat'` never passed through `translate()` before this PR and still don't; this change only consolidates them. Localizing them is a follow-up (it needs catalog sync).
- Cross-platform: pure renderer/shared string and store logic, no platform branches.
- SSH/remote: no execution-path changes. Remote structured sessions get the same client-local rename, with the sync limitation above.
- Folder workspaces: no worktree assumptions.
- Performance: the added lookup only runs when the first (terminal) lookup misses, i.e. on a structured tab rename.
- `orca-runtime-restore-structured-agent-session-tabs-once.ts` carries `@ts-nocheck`, so typecheck does not validate its new import; the path was checked by hand and the module's existing characterization tests pass.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Lint, typecheck, and targeted tests pass locally; full suite via CI


## End-to-end validation

Validated in the running app against real Claude and Codex structured chat sessions (not just unit tests). Verified: agent-specific placeholders; both providers self-naming after the first message; rename via the tab context menu holding across sustained use; the sidebar agent row matching the tab; and tab color on a structured tab.

That run caught a real defect this PR had missed, now fixed here: the rename **keyboard shortcut** renamed a background terminal instead of the focused chat tab. `deriveActiveSurfaceForWorktree` populates `activeTabId` from the active unified tab only when `contentType === 'terminal'`, so with a structured tab active `activeTabType` is `agent-session` while `activeTabId` is a live, unrelated terminal — a wrong-tab mis-action rather than a harmless no-op. The handler now resolves the target through `getActiveTab(worktreeId)`. The test builds the state the app actually derives (running the real `buildActiveSurfacePatch` and focus actions) rather than stubbing the store fields, plus a premise guard asserting the stale id is still produced, so the assertion cannot silently start passing for the wrong reason.

### Known limitation — follow-up, not fixed here

The rename shortcut does not fire while the **chat composer has focus**. `use-global-keybindings.ts` skips editable targets so a rich-text editor keeps its own chords, and `editable-target.ts` special-cases the terminal's helper textarea to opt back in. Native chat's plain-text composer was never added, so a focused composer loses every app chord — `workspace.rename`, the sidebar toggles and the explorer/search bindings, not just rename.

Deliberately left out of scope. The honest fix is not a rename-only exemption (`workspace.rename` sits three lines away with the identical symptom) and not an `isEditableTarget` special-case, which would become a fourth place keybinding authority lives, after the window handler, the terminal runtime, and native chat's own capture handler. The principled shape is a composer `KeybindingContext` with per-action opt-in, matching how the terminal already works. Filed as follow-up.

### Not verified

Persistence of a custom title across an app restart. The validation run covered sustained use but no restart.
