### PR TITLE
fix(native-chat): close a structured session whose provider child is gone

### DIFF
--- a/src/main/claude/claude-structured-session-close.ts
+++ b/src/main/claude/claude-structured-session-close.ts
@@ -75,6 +75,16 @@ async function finalizeClaudePublishedSession(
     prompt.settle(null)
   }
   if ((await session.connection.close()) !== true) {
+    // Report what the ladder observed rather than a bare `false`, which conflates "root still
+    // alive" with "root exited, descendants unknowable". Only a genuinely unproven exit stays a
+    // retryable `false`; the classes the owner can act on are raised so it can decide.
+    const reported = claudeAcquisitionCleanupError(
+      session.connection,
+      new Error('provider close unproven')
+    )
+    if (!(reported instanceof AgentSessionAcquisitionExitUnprovenError)) {
+      throw reported
+    }
     return false
   }
   if (session.backgroundTasks.clear()) {
@@ -239,6 +249,13 @@ export async function closeClaudeSession(input: {
 }): Promise<boolean> {
   const attempt = input.acquisitions.get(input.sessionId)
   if (!(await cancelClaudeAcquisitionAttempt(attempt))) {
+    const reported = claudeAcquisitionCleanupError(
+      attempt?.connection,
+      new Error('acquisition cancel unproven')
+    )
+    if (!(reported instanceof AgentSessionAcquisitionExitUnprovenError)) {
+      throw reported
+    }
     return false
   }
   if (attempt) {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-eviction.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-eviction.ts
@@ -18,6 +18,7 @@
 // session in place is what makes the next close a real retry instead of a no-op.
 
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
+import { AgentSessionAcquisitionRootExitObservedError } from './structured-agent-session-adapter'
 import type { DeferredStructuredAgentSessionEventSink } from './structured-agent-session-event-sink'
 
 export type StructuredAgentSessionEvictionContext = {
@@ -52,7 +53,16 @@ export const STRUCTURED_AGENT_SESSION_EVICTION_STEPS: readonly StructuredAgentSe
         // An adapter with no close has nothing to stop; anything else must PROVE the exit.
         const stop = context.adapter.disposeSession ?? context.adapter.closeSession
         if (stop) {
-          const stopped = await stop.call(context.adapter, context.sessionId)
+          let stopped: boolean
+          try {
+            stopped = await stop.call(context.adapter, context.sessionId)
+          } catch (error) {
+            // Root-exit proof releases the writer; the adapter retains unverifiable descendant cleanup.
+            if (!(error instanceof AgentSessionAcquisitionRootExitObservedError)) {
+              throw error
+            }
+            stopped = true
+          }
           if (stopped !== true) {
             throw new Error('provider child exit was not proven')
           }

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-eviction.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-eviction.ts
@@ -18,7 +18,10 @@
 // session in place is what makes the next close a real retry instead of a no-op.
 
 import type { StructuredAgentSessionAdapter } from './structured-agent-session-adapter'
-import { AgentSessionAcquisitionRootExitObservedError } from './structured-agent-session-adapter'
+import {
+  AgentSessionAcquisitionRootExitObservedError,
+  AgentSessionPreSpawnError
+} from './structured-agent-session-adapter'
 import type { DeferredStructuredAgentSessionEventSink } from './structured-agent-session-event-sink'
 
 export type StructuredAgentSessionEvictionContext = {
@@ -53,12 +56,18 @@ export const STRUCTURED_AGENT_SESSION_EVICTION_STEPS: readonly StructuredAgentSe
         // An adapter with no close has nothing to stop; anything else must PROVE the exit.
         const stop = context.adapter.disposeSession ?? context.adapter.closeSession
         if (stop) {
+          // The adapter reports what it observed; deciding whether that frees the session is
+          // this owner's call. A root proven gone releases the writer even when its descendants
+          // are unknowable — the adapter keeps that cleanup — and a session that never spawned
+          // has nothing to stop. Anything else, exit genuinely unproven included, still aborts.
           let stopped: boolean
           try {
             stopped = await stop.call(context.adapter, context.sessionId)
           } catch (error) {
-            // Root-exit proof releases the writer; the adapter retains unverifiable descendant cleanup.
-            if (!(error instanceof AgentSessionAcquisitionRootExitObservedError)) {
+            if (
+              !(error instanceof AgentSessionAcquisitionRootExitObservedError) &&
+              !(error instanceof AgentSessionPreSpawnError)
+            ) {
               throw error
             }
             stopped = true

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-expired-claude.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-expired-claude.test.ts
@@ -133,6 +133,25 @@ describe('expired native Claude lease and close', () => {
     expect(fixture.close).not.toHaveBeenCalled()
   })
 
+  it('reclaims a proven-dead native owner before its lease deadline', async () => {
+    const fixture = await capturedSession({ root: 'exited', tree: 'unverifiable' })
+    const beforeDeadline = NOW + 1_000
+    expect(fixture.store.getRecord('session-1')!.lease.leaseDeadlineAt).toBeGreaterThan(
+      beforeDeadline
+    )
+    const renewer = new StructuredAgentSessionLeaseRenewer({
+      store: fixture.store,
+      probe: async () => ({ outcome: 'pid-absent' }) as AgentSessionOwnerProbe,
+      now: () => beforeDeadline
+    })
+    await renewer.renewNow()
+    expect(fixture.store.getRecord('session-1')?.lease).toMatchObject({
+      claimStatus: 'released',
+      ownerProcess: null,
+      deathEvidence: { kind: 'pid-absent' }
+    })
+  })
+
   it.each(['pid-absent', 'indeterminate', 'identity-matched'] as const)(
     'periodically reconciles an expired lease using %s host evidence',
     async (outcome) => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-expired-claude.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-expired-claude.test.ts
@@ -1,0 +1,168 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  adapterFor,
+  fakeClaude,
+  identityFor
+} from '../../claude/claude-structured-session-test-support'
+import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
+import { evictHeldStructuredAgentSession } from './structured-agent-session-host-lifetime'
+import { StructuredAgentSessionHostRuntimeState } from './structured-agent-session-host-runtime-state'
+import { StructuredAgentSessionLeaseRenewer } from './structured-agent-session-lease-renewer'
+import type { StructuredAgentSessionHostSession } from './structured-agent-session-host-types'
+import type { AgentSessionOwnerProbe } from '../../../shared/agent-session-lease-adjudication'
+
+const NOW = 1_788_727_031_330
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+async function capturedSession(verdict: {
+  root: 'exited' | 'live'
+  tree: 'unverifiable' | 'live'
+}) {
+  const root = await mkdtemp(join(tmpdir(), 'orca-expired-claude-'))
+  roots.push(root)
+  const store = await AgentSessionRecordStore.open({ directory: root, hostId: 'local' })
+  const claude = fakeClaude({ unprovenCloseVerdict: verdict })
+  const adapter = adapterFor(claude)
+  const reservation = await store.reserveOwner({
+    sessionId: 'session-1',
+    location: {
+      executionHostId: 'local',
+      workspaceId: 'folder-1',
+      workspaceKind: 'folder',
+      wslDistro: null
+    },
+    provider: 'claude',
+    accountHome: { variable: 'CLAUDE_CONFIG_DIR', path: root },
+    runtimeKind: 'native',
+    expectedFence: null,
+    spawnToken: 'spawn-1',
+    claimKeyId: 'key-1',
+    handoffOperationId: null,
+    probe: { outcome: 'reservation-unused' },
+    operation: {
+      callerKey: 'test',
+      operationId: `${NOW}-00000000000000000000000000000001`,
+      fingerprint: 'create'
+    },
+    now: NOW
+  })
+  const fence = reservation.record.lease.runtimeFence
+  const acquisition = await adapter.acquire({
+    identity: { ...identityFor(), hostId: 'local', workspaceId: 'folder-1' },
+    fence,
+    spawnToken: 'spawn-1'
+  })
+  await store.commitProcessIdentity({
+    sessionId: 'session-1',
+    fence,
+    process: acquisition.process,
+    now: NOW
+  })
+  await store.proveOwner({ sessionId: 'session-1', fence, link: acquisition.link, now: NOW })
+  const close = vi.fn(async () => undefined)
+  const sessions = new Map<string, StructuredAgentSessionHostSession>([
+    [
+      'session-1',
+      {
+        journal: { close } as unknown as StructuredAgentSessionHostSession['journal'],
+        params: {} as StructuredAgentSessionHostSession['params'],
+        fence,
+        hasProviderChild: true,
+        acquisitionGeneration: acquisition.acquisitionGeneration ?? null
+      }
+    ]
+  ])
+  const deps = { store, adapter, journalRoot: root, claimKeyId: 'key-1' }
+  const runtimeState = new StructuredAgentSessionHostRuntimeState(deps)
+  const now = () => NOW + 30 * 60_000
+  return {
+    store,
+    adapter,
+    claude,
+    close,
+    sessions,
+    context: { deps, runtimeState, sessions, now },
+    now
+  }
+}
+
+describe('expired native Claude lease and close', () => {
+  it('closes the captured live claim after root exit even without a descendant snapshot', async () => {
+    const fixture = await capturedSession({ root: 'exited', tree: 'unverifiable' })
+    expect(fixture.store.getRecord('session-1')?.lease).toMatchObject({
+      claimStatus: 'live',
+      unreconciled: false,
+      deathEvidence: null,
+      processlessAt: null,
+      leaseDeadlineAt: NOW + 30_000
+    })
+    fixture.claude.connections[0].handlers.onExit?.(new Error('provider exited'))
+    await expect(
+      evictHeldStructuredAgentSession(fixture.context, 'session-1')
+    ).resolves.toBeUndefined()
+    expect(fixture.store.getRecord('session-1')?.lease).toMatchObject({
+      claimStatus: 'released',
+      ownerProcess: null,
+      deathEvidence: { kind: 'exit-observed' }
+    })
+    expect(fixture.sessions.size).toBe(0)
+    expect(fixture.close).toHaveBeenCalledOnce()
+    // Cleanup retains its uncertainty instead of claiming that descendants were stopped.
+    await expect(fixture.adapter.closeSession('session-1')).rejects.toThrow('provider exited')
+  })
+
+  it.each([
+    { root: 'live', tree: 'unverifiable' },
+    { root: 'exited', tree: 'live' }
+  ] as const)('retains the surface when the process verdict is $root / $tree', async (verdict) => {
+    const fixture = await capturedSession(verdict)
+    if (verdict.root === 'exited') {
+      fixture.claude.connections[0].handlers.onExit?.(new Error('descendant remains'))
+    }
+    await expect(
+      evictHeldStructuredAgentSession(fixture.context, 'session-1')
+    ).rejects.toMatchObject({ step: 'stop-provider-child' })
+    expect(fixture.store.getRecord('session-1')?.lease.claimStatus).toBe('live')
+    expect(fixture.sessions.size).toBe(1)
+    expect(fixture.close).not.toHaveBeenCalled()
+  })
+
+  it.each(['pid-absent', 'indeterminate', 'identity-matched'] as const)(
+    'periodically reconciles an expired lease using %s host evidence',
+    async (outcome) => {
+      const fixture = await capturedSession({ root: 'exited', tree: 'unverifiable' })
+      const probe: AgentSessionOwnerProbe =
+        outcome === 'identity-matched'
+          ? { outcome, matchedOn: ['process-start-time'] }
+          : outcome === 'indeterminate'
+            ? { outcome, reason: 'host unavailable' }
+            : { outcome }
+      const renewer = new StructuredAgentSessionLeaseRenewer({
+        store: fixture.store,
+        probe: async () => probe,
+        now: fixture.now
+      })
+      await renewer.renewNow()
+      expect(fixture.store.getRecord('session-1')?.lease.claimStatus).toBe(
+        outcome === 'pid-absent' ? 'released' : 'live'
+      )
+      if (outcome === 'pid-absent') {
+        expect(fixture.store.getRecord('session-1')?.lease).toMatchObject({
+          ownerProcess: null,
+          deathEvidence: { kind: 'pid-absent' }
+        })
+        fixture.claude.connections[0].handlers.onExit?.(new Error('provider exited'))
+        await expect(
+          evictHeldStructuredAgentSession(fixture.context, 'session-1')
+        ).resolves.toBeUndefined()
+        expect(fixture.sessions.size).toBe(0)
+      }
+    }
+  )
+})

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-expired-claude.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-expired-claude.test.ts
@@ -133,6 +133,19 @@ describe('expired native Claude lease and close', () => {
     expect(fixture.close).not.toHaveBeenCalled()
   })
 
+  it('closes a published session whose close reports root exit without descendant proof', async () => {
+    // The live-session path returns false rather than throwing; before this was classified the
+    // tab stayed permanently unclosable with an eviction failure at stop-provider-child.
+    const fixture = await capturedSession({ root: 'exited', tree: 'unverifiable' })
+    fixture.claude.connections[0].close = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValue(false) as unknown as (typeof fixture.claude.connections)[0]['close']
+    await expect(
+      evictHeldStructuredAgentSession(fixture.context, 'session-1')
+    ).resolves.toBeUndefined()
+    expect(fixture.sessions.size).toBe(0)
+  })
+
   it('reclaims a proven-dead native owner before its lease deadline', async () => {
     const fixture = await capturedSession({ root: 'exited', tree: 'unverifiable' })
     const beforeDeadline = NOW + 1_000

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.test.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.test.ts
@@ -6,6 +6,7 @@ import {
   agentSessionLeaseFixture,
   agentSessionRecordFixture
 } from '../../../shared/agent-session-record.test-fixture'
+import { stopStoredAgentSessionOwnerForHandoff } from '../../runtime/agent-session-handoff-record-transitions'
 import { AgentSessionRecordStore } from '../../runtime/agent-session-record-store'
 import { StructuredAgentSessionLeaseRenewer } from './structured-agent-session-lease-renewer'
 
@@ -262,6 +263,58 @@ describe('structured agent-session lease renewal', () => {
 
     expect(probe).not.toHaveBeenCalled()
     expect(store.getRecord('session-renewal')?.lease.lastRenewedAt).toBe(NOW)
+  })
+
+  it('does not preempt a native owner handoff after the child stops', async () => {
+    const store = await liveStore()
+    const initialFence = store.getRecord('session-renewal')!.lease.runtimeFence
+    const probeStarted = Promise.withResolvers<void>()
+    const deadProbe = Promise.withResolvers<{ outcome: 'pid-absent' }>()
+    const onError = vi.fn()
+    const renewer = new StructuredAgentSessionLeaseRenewer({
+      store,
+      probe: async () => {
+        probeStarted.resolve()
+        return deadProbe.promise
+      },
+      now: () => NOW + 10_000,
+      onError
+    })
+    const renewal = renewer.renewNow()
+    await probeStarted.promise
+    await store.transitionHandoff('session-renewal', (record) => ({
+      ...record,
+      lease: {
+        ...record.lease,
+        handoffStage: 'preparing',
+        handoffOperationId: 'handoff-1'
+      }
+    }))
+    deadProbe.resolve({ outcome: 'pid-absent' })
+    await renewal
+
+    expect(store.getRecord('session-renewal')?.lease).toMatchObject({
+      runtimeFence: initialFence,
+      handoffStage: 'preparing',
+      handoffOperationId: 'handoff-1',
+      claimStatus: 'live'
+    })
+    expect(onError).toHaveBeenCalledWith({
+      sessionId: 'session-renewal',
+      error: expect.objectContaining({ message: 'agent_session_checkpoint_stale' })
+    })
+    const stopped = await stopStoredAgentSessionOwnerForHandoff(store, {
+      sessionId: 'session-renewal',
+      expectedFence: initialFence,
+      operationId: 'handoff-1',
+      now: NOW + 10_001
+    })
+    expect(stopped.lease).toMatchObject({
+      runtimeFence: initialFence + 1,
+      handoffStage: 'old-owner-stopped',
+      handoffOperationId: 'handoff-1',
+      claimStatus: 'released'
+    })
   })
 
   it('routes a proven dead TUI owner into handoff recovery', async () => {

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts
@@ -77,6 +77,23 @@ export class StructuredAgentSessionLeaseRenewer {
           continue
         }
         if (
+          record.lease.runtimeKind === 'native' &&
+          record.lease.leaseDeadlineAt <= now &&
+          isProvenDeadProbe(probe)
+        ) {
+          try {
+            await this.input.store.evictProvenDeadOwner({
+              sessionId: record.sessionId,
+              expectedFence: record.lease.runtimeFence,
+              probe,
+              now
+            })
+          } catch (error) {
+            this.input.onError?.({ sessionId: record.sessionId, error })
+          }
+          continue
+        }
+        if (
           record.lease.runtimeKind === 'tui' &&
           isProvenDeadProbe(probe) &&
           this.input.onDeadTuiOwner

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts
@@ -76,11 +76,9 @@ export class StructuredAgentSessionLeaseRenewer {
         if (!probe) {
           continue
         }
-        if (
-          record.lease.runtimeKind === 'native' &&
-          record.lease.leaseDeadlineAt <= now &&
-          isProvenDeadProbe(probe)
-        ) {
+        // Positive death evidence settles it; the deadline only guards a live owner that has not
+        // renewed yet. Matches the dead-TUI-owner branch below, which never waits for expiry.
+        if (record.lease.runtimeKind === 'native' && isProvenDeadProbe(probe)) {
           try {
             await this.input.store.evictProvenDeadOwner({
               sessionId: record.sessionId,

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-lease-renewer.ts
@@ -76,13 +76,18 @@ export class StructuredAgentSessionLeaseRenewer {
         if (!probe) {
           continue
         }
-        // Positive death evidence settles it; the deadline only guards a live owner that has not
-        // renewed yet. Matches the dead-TUI-owner branch below, which never waits for expiry.
-        if (record.lease.runtimeKind === 'native' && isProvenDeadProbe(probe)) {
+        // Positive death evidence settles an idle owner without waiting for expiry. An active
+        // handoff owns its stop transition and fence; the renewer must not preempt it.
+        if (
+          record.lease.runtimeKind === 'native' &&
+          record.lease.handoffStage === null &&
+          isProvenDeadProbe(probe)
+        ) {
           try {
             await this.input.store.evictProvenDeadOwner({
               sessionId: record.sessionId,
               expectedFence: record.lease.runtimeFence,
+              expectedHandoffStage: null,
               probe,
               now
             })

--- a/src/main/runtime/agent-session-lease-transitions.ts
+++ b/src/main/runtime/agent-session-lease-transitions.ts
@@ -203,15 +203,25 @@ export function renewAgentSessionLease(args: {
 }
 
 /** Proven eviction — the only other thing besides acquisition that may move the fence. */
-export function evictAgentSessionOwner(args: {
+export type EvictAgentSessionOwnerInput = {
   record: AgentSessionRecord
   expectedFence: number
+  /** Compare-and-swap guard: a stage that drifted since the scan must not be clobbered. */
+  expectedHandoffStage?: AgentSessionRecord['lease']['handoffStage']
   probe: AgentSessionOwnerProbe
   now: number
   journalSettlement: 'required' | 'not-required'
-}): AgentSessionRecord {
+}
+
+export function evictAgentSessionOwner(args: EvictAgentSessionOwnerInput): AgentSessionRecord {
   const { record } = args
   assertFence(record.lease, args.expectedFence)
+  if (
+    args.expectedHandoffStage !== undefined &&
+    record.lease.handoffStage !== args.expectedHandoffStage
+  ) {
+    throw new Error('agent_session_checkpoint_stale')
+  }
   if (record.lease.settlementRetryRequired) {
     throw new Error('agent_session_ownership_unknown')
   }

--- a/src/main/runtime/agent-session-record-store.ts
+++ b/src/main/runtime/agent-session-record-store.ts
@@ -13,7 +13,6 @@ import {
   admitAgentSessionOperationRow,
   type AgentSessionOperationAdmission
 } from './agent-session-operation-admission'
-import type { AgentSessionOwnerProbe } from '../../shared/agent-session-lease-adjudication'
 import { classifyObservedAgentSessionSpawnToken } from '../../shared/agent-session-lease-adjudication'
 import type { AgentSessionProviderHandleLink } from '../../shared/agent-session-provider-handle'
 import {
@@ -28,7 +27,8 @@ import {
   evictAgentSessionOwner,
   proveAgentSessionOwner,
   setAgentSessionJournalCheckpoint,
-  type AgentSessionProcessIdentityCommit
+  type AgentSessionProcessIdentityCommit,
+  type EvictAgentSessionOwnerInput
 } from './agent-session-lease-transitions'
 import {
   settleFailedAgentSessionAcquisition,
@@ -248,12 +248,9 @@ export class AgentSessionRecordStore {
     )
   }
 
-  async evictProvenDeadOwner(args: {
-    sessionId: string
-    expectedFence: number
-    probe: AgentSessionOwnerProbe
-    now: number
-  }): Promise<AgentSessionRecord> {
+  async evictProvenDeadOwner(
+    args: Omit<EvictAgentSessionOwnerInput, 'record' | 'journalSettlement'> & { sessionId: string }
+  ): Promise<AgentSessionRecord> {
     return this.mutate(args.sessionId, (record) =>
       evictAgentSessionOwner({ ...args, record, journalSettlement: 'required' })
     )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -828,7 +828,7 @@
           "flow": {
             "structured": {
               "launch": {
-                "unknown": "Could not confirm whether Codex chat opened. Retry to check again."
+                "unknownAgent": "Could not confirm whether {{agent}} chat opened. Retry to check again."
               }
             }
           }

--- a/src/renderer/src/lib/pending-worktree-creation.ts
+++ b/src/renderer/src/lib/pending-worktree-creation.ts
@@ -1,4 +1,5 @@
 import type { TuiAgent } from '../../../shared/tui-agent'
+import { TUI_AGENT_DISPLAY_NAMES } from '../../../shared/tui-agent-display-names'
 import type { WorkspaceSource as WorkspaceCreateTelemetrySource } from '../../../shared/workspace-source'
 import type {
   CreateSparseCheckoutRequest,
@@ -137,6 +138,7 @@ export type PendingWorktreeCreation = {
   provisioningLog?: string
   /** Existing worktree whose uncertain structured launch must be reconciled instead of recreated. */
   structuredLaunchRecoveryWorktreeId?: string
+  startingChatAgent?: 'claude' | 'codex'
   request: WorktreeCreationRequest
 }
 
@@ -167,8 +169,11 @@ export function findPendingLinkedWorkItemCreationId(
  *  loader and the sidebar row so the two never drift. Caller handles the error
  *  case; this only covers the in-progress states. */
 export function getCreationProgressLabel(
-  entry: Pick<PendingWorktreeCreation, 'phase' | 'indeterminate'>
+  entry: Pick<PendingWorktreeCreation, 'phase' | 'indeterminate' | 'startingChatAgent'>
 ): string {
+  if (entry.startingChatAgent) {
+    return `Starting ${TUI_AGENT_DISPLAY_NAMES[entry.startingChatAgent] ?? entry.startingChatAgent} chat…`
+  }
   if (entry.phase === 'provisioning-vm') {
     return 'Provisioning VM…'
   }

--- a/src/renderer/src/lib/worktree-activation-structured-commands.test.ts
+++ b/src/renderer/src/lib/worktree-activation-structured-commands.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ensureWorktreeHasInitialTerminal } from './worktree-initial-terminal-seeding'
+import {
+  createMockStore,
+  registerWorktreeActivationReset,
+  setSetupScriptLaunchMode
+} from './worktree-activation-test-harness'
+
+registerWorktreeActivationReset()
+
+describe('structured creation terminal work', () => {
+  it('preserves explicit default tabs and their setup splits in the background', () => {
+    setSetupScriptLaunchMode('split-horizontal')
+    let index = 0
+    const store = createMockStore({ createTab: vi.fn(() => ({ id: `tab-${++index}` })) })
+    ensureWorktreeHasInitialTerminal(
+      store,
+      'wt-1',
+      undefined,
+      { runnerScriptPath: '/tmp/setup.sh', command: 'run-setup', envVars: {} },
+      undefined,
+      { tabs: [{ title: 'Server', command: 'run-server' }], runCommands: true },
+      { callerProvidesSurface: true, activateCreatedTabs: false }
+    )
+    expect(store.createTab).toHaveBeenCalledTimes(1)
+    expect(store.queueTabStartupCommand).toHaveBeenCalledWith('tab-1', { command: 'run-server' })
+    expect(store.queueTabSetupSplit).toHaveBeenCalledWith('tab-1', {
+      command: 'run-setup',
+      env: {},
+      direction: 'horizontal'
+    })
+    expect(store.setActiveTab).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
+++ b/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
@@ -17,7 +17,7 @@ const SURFACE_PROVIDING_CALLERS = [
   'src/renderer/src/hooks/composer-state/full-creation-execution.ts',
   'src/renderer/src/lib/fix-checks-agent-launch.ts',
   'src/renderer/src/lib/launch-work-item-direct.ts',
-  'src/renderer/src/lib/worktree-creation-flow-execute.ts',
+  'src/renderer/src/lib/worktree-creation-structured-session.ts',
   'src/renderer/src/lib/workspace-port-actions.ts',
   'src/renderer/src/store/repos/repo-add-actions.ts'
 ]

--- a/src/renderer/src/lib/worktree-creation-chat-setup.test.ts
+++ b/src/renderer/src/lib/worktree-creation-chat-setup.test.ts
@@ -7,7 +7,7 @@ import {
   seedEmptyActivatableWorktree
 } from './worktree-activation-created-agent-test-state'
 import { registerWorktreeActivationReset } from './worktree-activation-test-harness'
-import type { WorktreeCreationRequest } from './pending-worktree-creation'
+import { getCreationProgressLabel, type WorktreeCreationRequest } from './pending-worktree-creation'
 
 vi.mock('./worktree-creation-structured-session', () => ({
   launchStructuredWorktreeSession: vi.fn(async (args) => ({
@@ -27,10 +27,11 @@ afterEach(() => {
   useAppStore.setState(initialState, true)
 })
 
-describe('native chat creation completed in the background', () => {
+describe.each(['terminal', 'tasks'] as const)('native chat creation from %s', (activeView) => {
   it.each(['claude', 'codex'] as const)(
-    'runs setup once without an idle shell or focus change for %s',
+    'runs new-tab setup once without an idle shell or premature focus change for %s',
     async (agent) => {
+      vi.clearAllMocks()
       const worktree = makeCreatedAgentWorktree()
       seedEmptyActivatableWorktree(worktree)
       const request: WorktreeCreationRequest = {
@@ -47,7 +48,8 @@ describe('native chat creation completed in the background', () => {
       }
       const setup = { runnerScriptPath: '/tmp/setup-runner.sh', envVars: {} }
       useAppStore.setState({
-        activeView: 'tasks',
+        activeView,
+        activePendingCreationId: 'creation-1',
         activeWorktreeId: 'previous-worktree',
         activeTabId: 'previous-tab',
         createWorktree: vi.fn().mockResolvedValue({ worktree, setup }),
@@ -64,7 +66,11 @@ describe('native chat creation completed in the background', () => {
         }
       })
 
-      await executeWorktreeCreation('creation-1', request)
+      const launch =
+        Promise.withResolvers<Awaited<ReturnType<typeof launchStructuredWorktreeSession>>>()
+      vi.mocked(launchStructuredWorktreeSession).mockReturnValueOnce(launch.promise)
+      const creation = executeWorktreeCreation('creation-1', request)
+      await vi.waitFor(() => expect(launchStructuredWorktreeSession).toHaveBeenCalled())
 
       const state = useAppStore.getState()
       const tabs = state.tabsByWorktree[worktree.id]
@@ -73,12 +79,29 @@ describe('native chat creation completed in the background', () => {
       expect(state.pendingStartupByTabId[tabs[0].id]).toMatchObject({
         command: 'bash /tmp/setup-runner.sh'
       })
-      expect(state.activeView).toBe('tasks')
+      expect(state.settings?.setupScriptLaunchMode).toBe('new-tab')
+      expect(state.activeView).toBe(activeView)
+      expect(state.activePendingCreationId).toBe('creation-1')
+      expect(getCreationProgressLabel(state.pendingWorktreeCreations['creation-1'])).toBe(
+        `Starting ${agent === 'claude' ? 'Claude' : 'Codex'} chat…`
+      )
       expect(state.activeWorktreeId).toBe('previous-worktree')
       expect(state.activeTabId).toBe('previous-tab')
       expect(launchStructuredWorktreeSession).toHaveBeenCalledWith(
-        expect.objectContaining({ primaryTabId: null, shouldActivateOnCompletion: false })
+        expect.objectContaining({
+          primaryTabId: null,
+          shouldActivateOnCompletion: activeView === 'terminal'
+        })
       )
+      launch.resolve({
+        accepted: true,
+        cancelled: false,
+        visibilityUnknown: false,
+        activation: false,
+        primaryTabId: null
+      })
+      await creation
+      expect(useAppStore.getState().tabsByWorktree[worktree.id]).toHaveLength(1)
     }
   )
 })

--- a/src/renderer/src/lib/worktree-creation-flow-execute.ts
+++ b/src/renderer/src/lib/worktree-creation-flow-execute.ts
@@ -173,21 +173,18 @@ export async function executeWorktreeCreation(
 
   let activation: ActivateAndRevealResult | false = false
   let primaryTabId: string | null
-  if (shouldActivateOnCompletion) {
+  if (shouldActivateOnCompletion && !structuredLaunch) {
     activation = activateAndRevealWorktree(worktree.id, {
       sidebarRevealBehavior: 'auto',
       ...(result.setup ? { setup: result.setup } : {}),
       ...(result.defaultTabs ? { defaultTabs: result.defaultTabs } : {}),
       ...(startupOpt ? { startup: startupOpt } : {}),
       ...(preparedRequest.issueCommand ? { issueCommand: preparedRequest.issueCommand } : {}),
-      ...(backendSpawned ? { backendStartupTerminalSpawned: true } : {}),
-      ...(structuredLaunch ? { providesInitialSurface: true } : {})
+      ...(backendSpawned ? { backendStartupTerminalSpawned: true } : {})
     })
     primaryTabId = activation === false ? null : activation.primaryTabId
   } else {
-    // The user moved on. Seed the worktree's terminal + setup in the background
-    // (setActiveTab only writes global focus for the active worktree, so this is
-    // safe) without yanking them back to it.
+    // Structured launches retain the pending panel while explicit terminal work runs in the background.
     const hasExplicitTerminalWork = Boolean(
       startupOpt || result.setup || preparedRequest.issueCommand || result.defaultTabs
     )
@@ -211,6 +208,9 @@ export async function executeWorktreeCreation(
 
   let structuredLaunchAccepted = structuredLaunch
   if (structuredLaunch && isAgentSessionHandleProvider(preparedRequest.agent)) {
+    useAppStore.getState().updatePendingWorktreeCreation(creationId, {
+      startingChatAgent: preparedRequest.agent
+    })
     const structuredSession = await launchStructuredWorktreeSession({
       creationId,
       request: preparedRequest,
@@ -227,7 +227,7 @@ export async function executeWorktreeCreation(
       return
     }
     if (structuredSession.visibilityUnknown) {
-      markStructuredWorktreeLaunchUnconfirmed(creationId, worktree.id)
+      markStructuredWorktreeLaunchUnconfirmed(creationId, worktree.id, preparedRequest.agent)
       return
     }
   }

--- a/src/renderer/src/lib/worktree-creation-structured-recovery.ts
+++ b/src/renderer/src/lib/worktree-creation-structured-recovery.ts
@@ -1,4 +1,5 @@
 import { translate } from '@/i18n/i18n'
+import { TUI_AGENT_DISPLAY_NAMES } from '../../../shared/tui-agent-display-names'
 import { useAppStore } from '@/store'
 import type { WorktreeCreationRequest } from '@/lib/pending-worktree-creation'
 import { completeWorktreeCreation } from '@/lib/worktree-creation-completion'
@@ -7,13 +8,15 @@ import { launchStructuredWorktreeSession } from '@/lib/worktree-creation-structu
 
 export function markStructuredWorktreeLaunchUnconfirmed(
   creationId: string,
-  worktreeId: string
+  worktreeId: string,
+  agent: WorktreeCreationRequest['agent']
 ): void {
   useAppStore.getState().updatePendingWorktreeCreation(creationId, {
     status: 'error',
     error: translate(
-      'auto.lib.worktree.creation.flow.structured.launch.unknown',
-      'Could not confirm whether Codex chat opened. Retry to check again.'
+      'auto.lib.worktree.creation.flow.structured.launch.unknownAgent',
+      'Could not confirm whether {{agent}} chat opened. Retry to check again.',
+      { agent: agent === null ? 'agent' : (TUI_AGENT_DISPLAY_NAMES[agent] ?? agent) }
     ),
     structuredLaunchRecoveryWorktreeId: worktreeId
   })
@@ -41,7 +44,7 @@ export async function retryStructuredWorktreeLaunch(
     return
   }
   if (structuredSession.visibilityUnknown) {
-    markStructuredWorktreeLaunchUnconfirmed(creationId, worktreeId)
+    markStructuredWorktreeLaunchUnconfirmed(creationId, worktreeId, request.agent)
     return
   }
   await completeWorktreeCreation({

--- a/src/renderer/src/lib/worktree-creation-structured-session.test.ts
+++ b/src/renderer/src/lib/worktree-creation-structured-session.test.ts
@@ -1,27 +1,35 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ActivateAndRevealResult } from './worktree-activation'
+
+type SelectionState = {
+  pendingWorktreeCreations: Record<string, unknown>
+  activeView?: string
+  activeRepoId?: string
+  activeWorktreeId?: string
+  activeWorkspaceExecutionHostId?: string
+  activePendingCreationId?: string
+}
 
 const mocks = vi.hoisted(() => ({
-  state: {
-    pendingWorktreeCreations: { 'creation-1': {} } as Record<string, unknown>
-  },
-  listener: null as ((state: { pendingWorktreeCreations: Record<string, unknown> }) => void) | null,
+  state: { pendingWorktreeCreations: { 'creation-1': {} } } as SelectionState,
+  listener: null as ((state: SelectionState) => void) | null,
   unsubscribe: vi.fn(),
   startStructuredAgentLaunch: vi.fn(),
   cancelStructuredAgentLaunch: vi.fn(),
   closeStructuredAgentSession: vi.fn(),
   callRuntimeRpc: vi.fn(),
-  activateStructuredAgentSessionById: vi.fn()
+  activateStructuredAgentSessionById: vi.fn(),
+  activateAndRevealWorktree: vi.fn(),
+  ensureWorktreeHasInitialTerminal: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: Object.assign(vi.fn(), {
     getState: () => mocks.state,
-    subscribe: vi.fn(
-      (listener: (state: { pendingWorktreeCreations: Record<string, unknown> }) => void) => {
-        mocks.listener = listener
-        return mocks.unsubscribe
-      }
-    )
+    subscribe: vi.fn((listener: (state: SelectionState) => void) => {
+      mocks.listener = listener
+      return mocks.unsubscribe
+    })
   })
 }))
 
@@ -47,11 +55,11 @@ vi.mock('@/lib/structured-agent-session-tab-activation', () => ({
 }))
 
 vi.mock('@/lib/worktree-initial-terminal-seeding', () => ({
-  ensureWorktreeHasInitialTerminal: vi.fn()
+  ensureWorktreeHasInitialTerminal: mocks.ensureWorktreeHasInitialTerminal
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
-  activateAndRevealWorktree: vi.fn()
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
 }))
 
 vi.mock('@/lib/agent-trust-preflight', () => ({
@@ -125,7 +133,75 @@ describe('launchStructuredWorktreeSession', () => {
       reason: 'user'
     })
     expect(mocks.activateStructuredAgentSessionById).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
     expect(mocks.unsubscribe).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    'unchanged',
+    'already-activated',
+    'background',
+    'activeView',
+    'activeRepoId',
+    'activeWorktreeId',
+    'activeWorkspaceExecutionHostId',
+    'activePendingCreationId',
+    'navigate-away-and-back'
+  ] as const)('respects selection at successful receipt: %s', async (scenario) => {
+    const launch = Promise.withResolvers<{ sessionId: string; fence: number }>()
+    const activation = { primaryTabId: null } as ActivateAndRevealResult
+    mocks.activateAndRevealWorktree.mockReturnValue(activation)
+    mocks.startStructuredAgentLaunch.mockReturnValue({
+      sessionId: 'session-1',
+      launchResult: launch.promise,
+      claimDefinitiveRefusalFallback: vi.fn(() => Promise.resolve(false))
+    })
+    const result = launchStructuredWorktreeSession({
+      creationId: 'creation-1',
+      request: {
+        repoId: 'repo-1',
+        name: 'routing-recovery',
+        setupDecision: 'run',
+        agent: 'codex',
+        pendingFirstAgentMessageRename: false,
+        note: '',
+        startupPlan: null,
+        quickPrompt: '',
+        quickTelemetry: null
+      },
+      worktreeId: 'worktree-1',
+      shouldActivateOnCompletion: scenario !== 'background',
+      fallbackStartupOpt: undefined,
+      activation: scenario === 'already-activated' ? activation : false,
+      primaryTabId: null
+    })
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    if (scenario.startsWith('active') || scenario === 'navigate-away-and-back') {
+      const initialState = mocks.state
+      const field = scenario === 'navigate-away-and-back' ? 'activeWorktreeId' : scenario
+      mocks.state = { ...mocks.state, [field]: 'other-selection' }
+      mocks.listener?.(mocks.state)
+      if (scenario === 'navigate-away-and-back') {
+        mocks.state = initialState
+        mocks.listener?.(mocks.state)
+      }
+    }
+    launch.resolve({ sessionId: 'session-1', fence: 1 })
+    await result
+    if (scenario === 'unchanged') {
+      expect(mocks.activateAndRevealWorktree).toHaveBeenCalledExactlyOnceWith('worktree-1', {
+        providesInitialSurface: true
+      })
+      expect(mocks.activateAndRevealWorktree.mock.invocationCallOrder[0]).toBeLessThan(
+        mocks.activateStructuredAgentSessionById.mock.invocationCallOrder[0]
+      )
+    } else {
+      expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    }
+    expect(mocks.activateStructuredAgentSessionById).toHaveBeenCalledTimes(
+      scenario === 'unchanged' || scenario === 'already-activated' ? 1 : 0
+    )
+    expect(mocks.ensureWorktreeHasInitialTerminal).not.toHaveBeenCalled()
   })
 
   it('reports an unknown launch without claiming a visible surface', async () => {

--- a/src/renderer/src/lib/worktree-creation-structured-session.ts
+++ b/src/renderer/src/lib/worktree-creation-structured-session.ts
@@ -57,6 +57,8 @@ export async function launchStructuredWorktreeSession(args: {
     return { accepted, cancelled: true, visibilityUnknown, activation, primaryTabId }
   }
 
+  const initialSelection = useAppStore.getState()
+  let shouldActivate = args.shouldActivateOnCompletion
   const launch = startStructuredAgentLaunch(
     args.worktreeId,
     agent,
@@ -73,6 +75,15 @@ export async function launchStructuredWorktreeSession(args: {
     cancelStructuredAgentLaunch(args.worktreeId, launch.sessionId)
   }
   const unsubscribe = useAppStore.subscribe((state) => {
+    if (
+      state.activeView !== initialSelection.activeView ||
+      state.activeRepoId !== initialSelection.activeRepoId ||
+      state.activeWorktreeId !== initialSelection.activeWorktreeId ||
+      state.activeWorkspaceExecutionHostId !== initialSelection.activeWorkspaceExecutionHostId ||
+      state.activePendingCreationId !== initialSelection.activePendingCreationId
+    ) {
+      shouldActivate = false
+    }
     if (!state.pendingWorktreeCreations[args.creationId]) {
       cancelLaunch()
     }
@@ -111,7 +122,7 @@ export async function launchStructuredWorktreeSession(args: {
     if (cancelled) {
       return
     }
-    if (args.shouldActivateOnCompletion) {
+    if (shouldActivate) {
       const fallbackActivation = activateAndRevealWorktree(args.worktreeId, {
         sidebarRevealBehavior: 'auto',
         createNewTerminalForStartup: true,
@@ -138,7 +149,10 @@ export async function launchStructuredWorktreeSession(args: {
       await retireCancelledStructuredSession(args.worktreeId, launch.sessionId)
       return { accepted, cancelled, visibilityUnknown, activation, primaryTabId }
     }
-    if (args.shouldActivateOnCompletion) {
+    if (shouldActivate) {
+      if (!activation) {
+        activation = activateAndRevealWorktree(args.worktreeId, { providesInitialSurface: true })
+      }
       activateStructuredAgentSessionById({
         worktreeId: args.worktreeId,
         sessionId: receipt.sessionId

--- a/src/renderer/src/lib/worktree-creation-structured-unknown-outcome.test.ts
+++ b/src/renderer/src/lib/worktree-creation-structured-unknown-outcome.test.ts
@@ -94,11 +94,14 @@ vi.mock('sonner', () => ({
 }))
 
 vi.mock('@/i18n/i18n', () => ({
-  translate: (_key: string, fallback: string) => fallback
+  translate: (_key: string, fallback: string, options?: { agent: string }) =>
+    options ? fallback.replace('{{agent}}', options.agent) : fallback
 }))
 
 import { executeWorktreeCreation } from './worktree-creation-flow-execute'
 import { retryBackgroundWorktreeCreation } from './worktree-creation-flow'
+import { getCreationProgressLabel } from './pending-worktree-creation'
+import { markStructuredWorktreeLaunchUnconfirmed } from './worktree-creation-structured-recovery'
 
 describe('structured worktree creation unknown outcome', () => {
   beforeEach(() => {
@@ -137,6 +140,69 @@ describe('structured worktree creation unknown outcome', () => {
     })
     expect(store.removePendingWorktreeCreation).not.toHaveBeenCalled()
     expect(mocks.ensureWorktreeHasInitialTerminal).not.toHaveBeenCalled()
+  })
+
+  it('keeps the creation panel visible and names the agent throughout a delayed launch', async () => {
+    const setup = { runnerScriptPath: '/tmp/setup.sh', command: 'run-setup', envVars: {} }
+    store.createWorktree.mockResolvedValueOnce({
+      worktree: { id: 'worktree-1', repoId: 'repo-1' },
+      setup
+    })
+    const launch =
+      Promise.withResolvers<Awaited<ReturnType<typeof mocks.launchStructuredWorktreeSession>>>()
+    mocks.launchStructuredWorktreeSession.mockReturnValueOnce(launch.promise)
+    const creation = executeWorktreeCreation('creation-1', request)
+    await vi.waitFor(() => expect(mocks.launchStructuredWorktreeSession).toHaveBeenCalled())
+    expect(store.activePendingCreationId).toBe('creation-1')
+    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.ensureWorktreeHasInitialTerminal).toHaveBeenCalledWith(
+      store,
+      'worktree-1',
+      undefined,
+      setup,
+      undefined,
+      undefined,
+      { activateCreatedTabs: false, callerProvidesSurface: true }
+    )
+    expect(store.removePendingWorktreeCreation).not.toHaveBeenCalled()
+    expect(getCreationProgressLabel(store.pendingWorktreeCreations['creation-1'])).toBe(
+      'Starting Codex chat…'
+    )
+    launch.resolve({
+      accepted: true,
+      cancelled: false,
+      visibilityUnknown: false,
+      activation: false,
+      primaryTabId: null
+    })
+    await creation
+    expect(store.removePendingWorktreeCreation).toHaveBeenCalled()
+  })
+
+  it('uses Claude in the unconfirmed-launch copy and progress label', () => {
+    markStructuredWorktreeLaunchUnconfirmed('creation-1', 'worktree-1', 'claude')
+    expect(store.pendingWorktreeCreations['creation-1'].error).toBe(
+      'Could not confirm whether Claude chat opened. Retry to check again.'
+    )
+    expect(
+      getCreationProgressLabel({
+        phase: 'creating',
+        indeterminate: false,
+        startingChatAgent: 'claude'
+      })
+    ).toBe('Starting Claude chat…')
+  })
+
+  it.each([
+    [null, 'agent'],
+    ['openclaude', 'OpenClaude'],
+    ['grok', 'Grok'],
+    ['omp', 'OMP']
+  ] as const)('does not mislabel %s as Codex in recovery copy', (agent, label) => {
+    markStructuredWorktreeLaunchUnconfirmed('creation-1', 'worktree-1', agent)
+    expect(store.pendingWorktreeCreations['creation-1'].error).toBe(
+      `Could not confirm whether ${label} chat opened. Retry to check again.`
+    )
   })
 
   it('reconciles the created worktree on retry without creating another one', async () => {

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -222,6 +222,7 @@ export type WorktreeSlice = {
       request?: PendingWorktreeCreation['request']
       provisioningLog?: string
       structuredLaunchRecoveryWorktreeId?: string
+      startingChatAgent?: 'claude' | 'codex'
     }
   ) => void
   /** Drop a pending entry, clearing the active surface if it pointed at this


### PR DESCRIPTION
## ELI5

If a Claude chat's underlying process died at the wrong moment, Orca refused to close its tab — permanently, until you restarted the app. Orca already knew enough to close it safely; it just threw that knowledge away at one boundary. This makes every close path report what it saw, and lets the session owner decide.

## What Changed

**Every provider close path now reports its verdict.** The exit ladder computes a three-valued observation — root `exited`/`live`/`processless`, and a descendant tree `exited`/`unverifiable`/`live`. The acquisition path already classified it, but the published-session close and the acquisition-cancel path returned a bare `false` regardless. A `false` conflates "root still alive" with "root exited, descendants unknowable", so the owner could not tell a retryable refusal from a session it was free to release — and the tab stayed unclosable. Both paths now report through the same classifier. Only the classes the owner can act on are raised; a genuinely unproven exit stays a retryable `false`, which the published-session cleanup contract depends on.

**Eviction, as the owner, decides.** A root proven gone releases the writer even when its descendants are unknowable — the adapter keeps that cleanup — and a session that never spawned has nothing to stop. Exit genuinely unproven, or a descendant proven live, still aborts the eviction.

**A dead native owner is reconciled.** The periodic lease renewer only handled `runtimeKind: 'tui'`, so a dead native owner was renewed and refused forever. It now reclaims through the existing fence-checked `evictProvenDeadOwner` on positive death evidence, without waiting out the deadline — matching the dead-TUI branch beside it. It never preempts an in-flight handoff: a suspend parks a live owner at `handoffStage: 'preparing'`, so the renewer skips those and the eviction write is a compare-and-swap that raises `agent_session_checkpoint_stale` rather than clobbering a handoff.

**A slow structured launch no longer looks like nothing happening** — the creation panel is retained with an agent-specific "Starting Claude chat…" label, activation is skipped if you navigated away mid-launch, and it cannot activate twice.

**Recovery copy no longer hardcodes one provider** — it resolves through the existing exhaustive `TUI_AGENT_DISPLAY_NAMES` map.

## Why

The descendant snapshot is armed lazily and latches to `null` when the root exits before an admissible walk completes:

```js
if (!rootPid || exited()) { snapshot = exited() ? null : snapshot; return }
const rootExited = exited()
const tree = admissibleTree(captured, platform, rootExited)
if (tree) { snapshot = tree } else if (rootExited) { snapshot = null }
```

Once null, the posix gate returns `'unverifiable'`, the ladder refuses to prove exit, and eviction fails at `stop-provider-child` on every retry. Nothing self-heals it: the unexpected-exit lifecycle only publishes on a successful tree proof, the lease renewer only handled TUI owners, and in-process reconciliation is gated on `unreconciled`, which the affected record does not have.

The trigger is a **race** — the child must die before an admissible descendant walk lands. It is not "the child wrote no stderr"; stderr matters only because the first byte arms the walk.

This reuses vocabulary the codebase already has: the verdict type is documented as one that "is never collapsed into either neighbour", the classifier already existed, and the restart adjudicator already returns `evicted` for a pid-absent probe.

## Linked Issue

Fixes #19154

## Visual Proof

Screenshots from rendered-Electron QA are attached in PR comments: structured chat as the sole initial surface, the transient "Starting Claude chat…" pending panel, and tab-close behaviour.

## Testing

Red/green by ablation on this base, not merely green — each fix has a test that fails when that fix alone is removed:

- remove the published-close verdict report → `closes a published session whose close reports root exit without descendant proof` fails
- remove the eviction catch → the captured-shape test fails with the reported `stop-provider-child` error
- remove the handoff compare-and-swap → `does not preempt a native owner handoff after the child stops` fails
- remove the deadline fast-path → `reclaims a proven-dead native owner before its lease deadline` fails
- restore the hardcoded provider → 4 parameterized label cases fail

`structured-agent-session-expired-claude.test.ts` reconstructs the captured production record shape — native live claim, `unreconciled: false`, null death evidence and processless timestamp, expired deadline, leaf-less handle — against the real Claude adapter and record store, and asserts a live root and a known-live descendant are still rejected.

Gates on this head: 137 tests across the directly affected suites, `pnpm tc` exit 0, changed-code quality 0 new findings across 17 files, `pnpm-lock.yaml` unchanged.

### Live instrumentation — the race, observed

A dev build with temporary logging on the exit ladder showed both branches in a real app; kills within ~139ms of the child appearing latch `unverifiable`, and by ~267ms the walk wins and exit proves cleanly.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Honest limits.** A previous QA pass at `909c747cda` reproduced a permanently unclosable tab whose `deathEvidence.kind` was `pid-absent`; that is the case the close-verdict commit addresses, and a re-run against this head is in progress. Platforms exercised: macOS only.

## AI Disclosure

<!-- internal contributor -->

## Review

The load-bearing judgement is the owner/killer split: the adapter reports what it observed, and eviction decides whether that frees the session. Check that fail-closed genuinely survives for a live root and a proven-live descendant, and that the retryable `false` contract for a genuinely unproven close is intact — an earlier attempt made every path throw and broke it. Second place to look is the lease-renewer branch: it must not release on expiry alone, and must not preempt a handoff.

Scope notes: the stray-terminal half of the original report was fixed separately by #19123 and this branch keeps main's narrower condition. #19122 was checked and does not cover this bug.

## Agent skill upstream boundary

N/A — no agent skill or skill-runner behavior changed.
