### PR TITLE
test: exercise packaged browser compatibility in scheduled CI

### DIFF
--- a/.github/workflows/packaged-browser-e2e.yml
+++ b/.github/workflows/packaged-browser-e2e.yml
@@ -1,6 +1,11 @@
 name: Packaged browser compatibility
 on:
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit SHA or ref to validate (defaults to the selected revision)
+        type: string
+        required: false
   schedule:
     - cron: '20 8 * * 1'
   workflow_call:
@@ -37,11 +42,10 @@ jobs:
           assert base64.b64encode(hashlib.sha512(package.read_bytes()).digest()).decode()==expected
           extracted=root/'extracted'
           subprocess.run(['dpkg-deb','-x',str(package),str(extracted)],check=True)
-          candidates=[extracted/'opt'/'Orca'/'orca-ide']
-          assert candidates[0].is_file() and os.access(candidates[0],os.X_OK)
-          assert len(candidates)==1,candidates
-          with open(os.environ['GITHUB_ENV'],'a') as env: env.write('ORCA_CROSS_VERSION_PACKAGED_EXECUTABLE='+str(candidates[0])+'\n')
-          print('Verified old package:',candidates[0])
+          executable=extracted/'opt'/'Orca'/'orca-ide'
+          assert executable.is_file() and os.access(executable,os.X_OK)
+          with open(os.environ['GITHUB_ENV'],'a') as env: env.write('ORCA_CROSS_VERSION_PACKAGED_EXECUTABLE='+str(executable)+'\n')
+          print('Verified old package:',executable)
           PYVERIFY
       - name: Build current Electron app
         env:

--- a/.github/workflows/packaged-browser-e2e.yml
+++ b/.github/workflows/packaged-browser-e2e.yml
@@ -1,0 +1,70 @@
+name: Packaged browser compatibility
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '20 8 * * 1'
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+permissions:
+  contents: read
+jobs:
+  compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+      - name: Install headless tools
+        run: sudo apt-get update && sudo apt-get install -y build-essential openssh-client python3 ripgrep xvfb zsh openbox x11-utils
+      - uses: ./.github/actions/install-node-dependencies
+        with:
+          native-runtime: electron
+      - name: Download pinned old release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download v1.4.188 --repo stablyai/orca --pattern orca-ide_1.4.188_amd64.deb --dir "$RUNNER_TEMP/old-orca"
+          python3 - <<'PYVERIFY'
+          import base64,hashlib,os,pathlib,subprocess
+          root=pathlib.Path(os.environ['RUNNER_TEMP'])/'old-orca'
+          package=root/'orca-ide_1.4.188_amd64.deb'
+          expected='uGONFUDfinYggxcT9ac72wnnlofLQaqasDDeP0HWOSqarBwTi1Ax3khmzKUY3vUnvuYOpSCEmsH4InzLZ2vg6g=='
+          assert base64.b64encode(hashlib.sha512(package.read_bytes()).digest()).decode()==expected
+          extracted=root/'extracted'
+          subprocess.run(['dpkg-deb','-x',str(package),str(extracted)],check=True)
+          candidates=[extracted/'opt'/'Orca'/'orca-ide']
+          assert candidates[0].is_file() and os.access(candidates[0],os.X_OK)
+          assert len(candidates)==1,candidates
+          with open(os.environ['GITHUB_ENV'],'a') as env: env.write('ORCA_CROSS_VERSION_PACKAGED_EXECUTABLE='+str(candidates[0])+'\n')
+          print('Verified old package:',candidates[0])
+          PYVERIFY
+      - name: Build current Electron app
+        env:
+          VITE_EXPOSE_STORE: 'true'
+        run: |
+          pnpm run build:relay
+          pnpm exec electron-vite build --mode e2e
+          pnpm run build:web-from-renderer
+      - name: Run both mixed-version directions
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/packaged-browser-results.json
+        run: >-
+          xvfb-run --auto-servernum bash .github/scripts/e2e-with-window-manager.sh
+          env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1
+          pnpm exec playwright test --config tests/playwright.config.ts
+          tests/e2e/packaged-mixed-version-browser-placement.spec.ts
+          --project=electron-headless --workers=1 --retries=0 --repeat-each=3 --reporter=list,json
+      - name: Require all six compatibility executions
+        if: always()
+        run: node config/scripts/verify-packaged-browser-participation.mjs test-results/packaged-browser-results.json
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: packaged-mixed-version-audit
+          path: test-results/
+          retention-days: 3

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -18472,6 +18472,107 @@
         "The new PR lane is outside verify until reliability is established."
       ],
       "demotionRule": "Keep experimental if provisioning or an execution flakes; never promote by skipping a case, raising timeouts, or retrying until green."
+    },
+    {
+      "id": "browser.packaged-mixed-version-placement",
+      "title": "Packaged browser placement across versions",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "browser-runtime",
+      "layer": "electron-packaged",
+      "surfaces": [
+        "paired browser placement"
+      ],
+      "platforms": [
+        "linux",
+        "macos",
+        "windows"
+      ],
+      "providers": [
+        "paired-runtime"
+      ],
+      "coveredPlatforms": [
+        "linux"
+      ],
+      "coveredProviders": [
+        "paired-runtime"
+      ],
+      "coverageNotes": "Published Linux 1.4.188 desktop against current source in both directions; scheduled weekly and manually runnable. No required PR check.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/actions/runs/34069063016"
+      ],
+      "invariant": "A paired client and host without client-hosted browser capabilities retain server-hosted browser placement across supported version skew.",
+      "oracle": "Require both existing named browser placement scenarios to pass three times with one attempt, zero skips, zero failures, and no report errors.",
+      "commands": [
+        "gh workflow run packaged-browser-e2e.yml",
+        "pnpm exec playwright test tests/e2e/packaged-mixed-version-browser-placement.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1 --repeat-each=3 --retries=0",
+        "node_modules/.bin/vitest run --config config/vitest.config.ts config/scripts/packaged-browser-lane-contract.test.mjs config/scripts/verify-packaged-browser-participation.test.mjs",
+        "gh run view 34069063016 --log"
+      ],
+      "testFiles": [
+        "tests/e2e/packaged-mixed-version-browser-placement.spec.ts",
+        "config/scripts/packaged-browser-lane-contract.test.mjs",
+        "config/scripts/verify-packaged-browser-participation.test.mjs"
+      ],
+      "assertionRefs": [
+        {
+          "file": "tests/e2e/packaged-mixed-version-browser-placement.spec.ts",
+          "assertions": [
+            "old client and old host lack client-host and browser-tunnel capabilities",
+            "browser contents remain owned by the server and the expected snapshot marker is readable"
+          ]
+        },
+        {
+          "file": "config/scripts/verify-packaged-browser-participation.test.mjs",
+          "assertions": [
+            "reject missing, substituted, skipped and retried scenarios"
+          ]
+        },
+        {
+          "file": "config/scripts/packaged-browser-lane-contract.test.mjs",
+          "assertions": [
+            "verify pinned package checksum before extraction",
+            "require both directions three times and run report verification even on failure"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-07",
+          "runner": "ci",
+          "platform": "linux",
+          "result": "passed",
+          "command": "gh run view 34069063016 --log",
+          "durationSeconds": 120,
+          "summary": "Both unmodified compatibility cases passed three times at 5a99f935 with published1.4.188 and main f7d52160162; retries0. Final permanent workflow verification remains pending."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 1500,
+        "scope": "CI job timeout; not a measured p95"
+      },
+      "flakeHistory": {
+        "status": "soaking",
+        "evidence": "Initial executable discovery matched CLI and desktop and was corrected before any tests ran. Corrected baseline2/2 and repeat6/6 pass."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "Participation unit tests reject missing and retried scenarios; no application mutation proof."
+      },
+      "performanceBudget": {
+        "required": false,
+        "evidence": "Compatibility assertions, not a performance benchmark."
+      },
+      "promotionCriteria": [
+        "Final workflow JSON report proves all six executions.",
+        "Collect repeated scheduled history before making this required."
+      ],
+      "knownGaps": [
+        "Linux1.4.188 only; no macOS or Windows packaged coverage.",
+        "No folder workspace, SSH execution host or live-service coverage.",
+        "Other released version pairs remain untested; not a required PR check."
+      ],
+      "demotionRule": "Keep experimental if any direction skips or fails; do not extend timeouts or retry to green."
     }
   ]
 }

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -18544,7 +18544,7 @@
           "result": "passed",
           "command": "gh run view 34069063016 --log",
           "durationSeconds": 120,
-          "summary": "Both unmodified compatibility cases passed three times at 5a99f935 with published1.4.188 and main f7d52160162; retries0. Final permanent workflow verification remains pending."
+          "summary": "Both unmodified compatibility cases passed three times at 5a99f935 with published1.4.188 and main f7d52160162; retries0. Final workflow34069429156 also passed6/6; its downloaded JSON passed the same participation verifier."
         }
       ],
       "runtimeBudget": {

--- a/config/scripts/packaged-browser-lane-contract.test.mjs
+++ b/config/scripts/packaged-browser-lane-contract.test.mjs
@@ -10,7 +10,9 @@ const steps = workflow.jobs.compatibility.steps
 describe('packaged browser compatibility lane', () => {
   it('runs weekly and supports immutable manual or reusable revisions', () => {
     expect(workflow.on.schedule).toHaveLength(1)
-    expect(workflow.on).toHaveProperty('workflow_dispatch')
+    for (const trigger of ['workflow_dispatch', 'workflow_call']) {
+      expect(workflow.on[trigger].inputs.ref).toMatchObject({ type: 'string', required: false })
+    }
     expect(steps[0].with.ref).toBe('${{ inputs.ref || github.sha }}')
     expect(workflow.permissions).toEqual({ contents: 'read' })
   })

--- a/config/scripts/packaged-browser-lane-contract.test.mjs
+++ b/config/scripts/packaged-browser-lane-contract.test.mjs
@@ -22,6 +22,9 @@ describe('packaged browser compatibility lane', () => {
     expect(download).toContain('gh release download v1.4.188')
     expect(download).toContain('hashlib.sha512(package.read_bytes())')
     expect(download).toContain("extracted/'opt'/'Orca'/'orca-ide'")
+    expect(download).toContain('assert base64.')
+    expect(download).toContain('decode()==expected')
+    expect(download).toContain("['dpkg-deb'")
     expect(download.indexOf('assert base64.')).toBeLessThan(download.indexOf("['dpkg-deb'"))
   })
 

--- a/config/scripts/packaged-browser-lane-contract.test.mjs
+++ b/config/scripts/packaged-browser-lane-contract.test.mjs
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const workflow = parse(
+  readFileSync(new URL('../../.github/workflows/packaged-browser-e2e.yml', import.meta.url), 'utf8')
+)
+const steps = workflow.jobs.compatibility.steps
+
+describe('packaged browser compatibility lane', () => {
+  it('runs weekly and supports immutable manual or reusable revisions', () => {
+    expect(workflow.on.schedule).toHaveLength(1)
+    expect(workflow.on).toHaveProperty('workflow_dispatch')
+    expect(steps[0].with.ref).toBe('${{ inputs.ref || github.sha }}')
+    expect(workflow.permissions).toEqual({ contents: 'read' })
+  })
+
+  it('verifies the pinned package before selecting the desktop executable', () => {
+    const download = steps.find((step) => step.name === 'Download pinned old release').run
+    expect(download).toContain('gh release download v1.4.188')
+    expect(download).toContain('hashlib.sha512(package.read_bytes())')
+    expect(download).toContain("extracted/'opt'/'Orca'/'orca-ide'")
+    expect(download.indexOf('assert base64.')).toBeLessThan(download.indexOf("['dpkg-deb'"))
+  })
+
+  it('requires both directions three times and rejects silent skips', () => {
+    const run = steps.find((step) => step.name === 'Run both mixed-version directions')
+    expect(run.run).toContain('tests/e2e/packaged-mixed-version-browser-placement.spec.ts')
+    expect(run.run).toContain('--repeat-each=3')
+    expect(run.run).toContain('--retries=0')
+    expect(run.run).toContain('--reporter=list,json')
+    const verify = steps.find((step) => step.name === 'Require all six compatibility executions')
+    expect(verify.if).toBe('always()')
+    expect(verify.run).toBe(
+      `node config/scripts/verify-packaged-browser-participation.mjs ${run.env.PLAYWRIGHT_JSON_OUTPUT_FILE}`
+    )
+    expect(steps.at(-1).if).toBe('always()')
+    expect(steps.at(-1).with.path).toBe('test-results/')
+  })
+})

--- a/config/scripts/pr-e2e-source-routing.mjs
+++ b/config/scripts/pr-e2e-source-routing.mjs
@@ -41,7 +41,7 @@ export const PR_E2E_SOURCE_ROUTES = [
     ],
     matches: (file) =>
       isProductSource(file) &&
-      /^(?:config\/scripts\/verify-wsl-e2e-participation\.mjs$|src\/main\/(?:wsl[/-]|pty\/.*wsl|providers\/wsl)|src\/shared\/(?:wsl-|windows-terminal-shell)|src\/renderer\/src\/.*(?:terminal-paste|pty-paste)|tests\/e2e\/(?:golden-tab-bar-agent-launch\.spec|terminal-windows-shell-paste-ownership\.spec|helpers\/(?:wsl-golden-stub-agent|golden-stub-agent))|\.github\/(?:actions\/setup-wsl-test-runtime\/|workflows\/windows-wsl-e2e\.yml))/.test(
+      /^(?:config\/scripts\/(?:verify-wsl-e2e-participation|verify-playwright-participation)\.mjs$|src\/main\/(?:wsl[/-]|pty\/.*wsl|providers\/wsl)|src\/shared\/(?:wsl-|windows-terminal-shell)|src\/renderer\/src\/.*(?:terminal-paste|pty-paste)|tests\/e2e\/(?:golden-tab-bar-agent-launch\.spec|terminal-windows-shell-paste-ownership\.spec|helpers\/(?:wsl-golden-stub-agent|golden-stub-agent))|\.github\/(?:actions\/setup-wsl-test-runtime\/|workflows\/windows-wsl-e2e\.yml))/.test(
         file
       )
   },

--- a/config/scripts/verify-packaged-browser-participation.mjs
+++ b/config/scripts/verify-packaged-browser-participation.mjs
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { pathToFileURL } from 'node:url'
+import { verifyPlaywrightParticipation } from './verify-playwright-participation.mjs'
+
+export const PACKAGED_BROWSER_TEST_TITLES = [
+  'keeps an old packaged client on the current server-hosted path',
+  'keeps a current client on an old packaged server-hosted path'
+]
+
+export function verifyPackagedBrowserParticipation(report) {
+  verifyPlaywrightParticipation(report, {
+    titles: PACKAGED_BROWSER_TEST_TITLES,
+    label: 'Packaged browser'
+  })
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  verifyPackagedBrowserParticipation(JSON.parse(readFileSync(process.argv[2], 'utf8')))
+  console.log('Both packaged browser directions passed three times without skips or retries.')
+}

--- a/config/scripts/verify-packaged-browser-participation.test.mjs
+++ b/config/scripts/verify-packaged-browser-participation.test.mjs
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  verifyPackagedBrowserParticipation,
+  PACKAGED_BROWSER_TEST_TITLES
+} from './verify-packaged-browser-participation.mjs'
+
+function report() {
+  return {
+    stats: { expected: 6, skipped: 0, unexpected: 0, flaky: 0 },
+    suites: [
+      {
+        suites: [
+          {
+            specs: PACKAGED_BROWSER_TEST_TITLES.map((title) => ({
+              title,
+              tests: Array.from({ length: 3 }, () => ({
+                expectedStatus: 'passed',
+                results: [{ status: 'passed' }]
+              }))
+            }))
+          }
+        ]
+      }
+    ]
+  }
+}
+
+describe('Packaged browser participation', () => {
+  it('accepts both named scenarios executed three times', () => {
+    expect(() => verifyPackagedBrowserParticipation(report())).not.toThrow()
+  })
+  it.each(['skipped', 'unexpected', 'flaky'])('rejects a nonzero %s result', (key) => {
+    const value = report()
+    value.stats[key] = 1
+    expect(() => verifyPackagedBrowserParticipation(value)).toThrow('participation failed')
+  })
+  it('rejects missing scenarios even when aggregate counts claim six passes', () => {
+    const value = report()
+    value.suites[0].suites[0].specs.pop()
+    expect(() => verifyPackagedBrowserParticipation(value)).toThrow('requires three executions')
+  })
+  it('rejects an unrelated scenario substituted for an expected scenario', () => {
+    const value = report()
+    value.suites[0].suites[0].specs[0].title = 'native shell passes'
+    expect(() => verifyPackagedBrowserParticipation(value)).toThrow(
+      'Unexpected Packaged browser scenario'
+    )
+  })
+  it('rejects a pass obtained after a failed attempt', () => {
+    const value = report()
+    value.suites[0].suites[0].specs[0].tests[0].results.unshift({ status: 'failed' })
+    expect(() => verifyPackagedBrowserParticipation(value)).toThrow('without retries')
+  })
+  it('rejects missing report content', () => {
+    expect(() => verifyPackagedBrowserParticipation({})).toThrow('participation failed')
+  })
+})

--- a/config/scripts/verify-playwright-participation.mjs
+++ b/config/scripts/verify-playwright-participation.mjs
@@ -1,0 +1,42 @@
+export function verifyPlaywrightParticipation(report, { titles, label, repetitions = 3 }) {
+  const stats = report?.stats
+  if (
+    !stats ||
+    stats.expected !== titles.length * repetitions ||
+    stats.skipped !== 0 ||
+    stats.unexpected !== 0 ||
+    stats.flaky !== 0 ||
+    report.errors?.length
+  ) {
+    throw new Error(`${label} participation failed: ${JSON.stringify(stats)}`)
+  }
+  const counts = new Map(titles.map((title) => [title, 0]))
+  const visit = (suites) => {
+    for (const suite of suites ?? []) {
+      for (const spec of suite.specs ?? []) {
+        if (!counts.has(spec.title)) {
+          throw new Error(`Unexpected ${label} scenario: ${spec.title}`)
+        }
+        for (const test of spec.tests ?? []) {
+          if (
+            test.expectedStatus !== 'passed' ||
+            test.results?.length !== 1 ||
+            test.results[0].status !== 'passed'
+          ) {
+            throw new Error(`${label} scenario did not pass without retries: ${spec.title}`)
+          }
+          counts.set(spec.title, counts.get(spec.title) + 1)
+        }
+      }
+      visit(suite.suites)
+    }
+  }
+  visit(report.suites)
+  for (const [title, count] of counts) {
+    if (count !== repetitions) {
+      throw new Error(
+        `${label} scenario requires ${repetitions === 3 ? 'three' : repetitions} executions: ${title} (${count})`
+      )
+    }
+  }
+}

--- a/config/scripts/verify-wsl-e2e-participation.mjs
+++ b/config/scripts/verify-wsl-e2e-participation.mjs
@@ -1,3 +1,4 @@
+import { verifyPlaywrightParticipation } from './verify-playwright-participation.mjs'
 import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 
@@ -8,44 +9,7 @@ export const WSL_TEST_TITLES = [
 ]
 
 export function verifyWslParticipation(report) {
-  const stats = report?.stats
-  if (
-    !stats ||
-    stats.expected !== 9 ||
-    stats.skipped !== 0 ||
-    stats.unexpected !== 0 ||
-    stats.flaky !== 0 ||
-    report.errors?.length
-  ) {
-    throw new Error(`WSL participation failed: ${JSON.stringify(stats)}`)
-  }
-  const counts = new Map(WSL_TEST_TITLES.map((title) => [title, 0]))
-  const visit = (suites) => {
-    for (const suite of suites ?? []) {
-      for (const spec of suite.specs ?? []) {
-        if (!counts.has(spec.title)) {
-          throw new Error(`Unexpected WSL scenario: ${spec.title}`)
-        }
-        for (const test of spec.tests ?? []) {
-          if (
-            test.expectedStatus !== 'passed' ||
-            test.results?.length !== 1 ||
-            test.results[0].status !== 'passed'
-          ) {
-            throw new Error(`WSL scenario did not pass without retries: ${spec.title}`)
-          }
-          counts.set(spec.title, counts.get(spec.title) + 1)
-        }
-      }
-      visit(suite.suites)
-    }
-  }
-  visit(report.suites)
-  for (const [title, count] of counts) {
-    if (count !== 3) {
-      throw new Error(`WSL scenario requires three executions: ${title} (${count})`)
-    }
-  }
+  verifyPlaywrightParticipation(report, { titles: WSL_TEST_TITLES, label: 'WSL' })
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/config/scripts/wsl-e2e-lane-contract.test.mjs
+++ b/config/scripts/wsl-e2e-lane-contract.test.mjs
@@ -8,6 +8,7 @@ const read = (path) => readFileSync(new URL(`../../${path}`, import.meta.url), '
 describe('real WSL terminal lane', () => {
   it.each([
     'config/scripts/verify-wsl-e2e-participation.mjs',
+    'config/scripts/verify-playwright-participation.mjs',
     'src/main/wsl-availability.ts',
     'src/main/wsl/wsl-runner.ts',
     'src/main/pty/wsl-orca-env.ts',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​240 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 |

<!-- /orca-pr-loc -->

The packaged browser compatibility tests normally skip because no old executable is provided. Add weekly, manual, and reusable Linux CI that verifies and extracts the published Orca 1.4.188 package, then exercises old-client/current-host and current-client/old-host placement three times each.

Require the actual Playwright JSON report to contain all six passes with no skips or retries. Extract the existing WSL participation checker for reuse, preserve its behavior and source routing, and document the limited version/platform coverage in an experimental reliability entry. No application behavior or existing rendered assertions change.

Validation: unmodified baseline 2/2 passed, followed by 6/6 at run 34069063016. All 35 focused verifier/workflow tests and the reliability manifest check pass. Final workflow passed all six cases, and its downloaded JSON passed the participation verifier: https://github.com/stablyai/orca/actions/runs/34069429156.

This lane is advisory; it does not become a required PR check.
