### PR TITLE
fix(terminal): leave standalone IME keydowns to xterm

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-native-text-forwarder.ts
@@ -62,6 +62,7 @@ export type ImeNativeTextKeyEvent = {
   type: string
   key: string
   code?: string
+  keyCode?: number
   metaKey: boolean
   ctrlKey: boolean
   altKey: boolean
@@ -118,6 +119,7 @@ function isNativeTextKeydown(event: ImeNativeTextKeyEvent, compositionActive: bo
     // terminal-ime-forwarder-space-claim.test.ts.
     event.key.length === 1 &&
     // Composing keystrokes already belong to xterm's composition helper.
+    event.keyCode !== 229 &&
     event.isComposing !== true &&
     !compositionActive
   )

--- a/src/renderer/src/components/terminal-pane/terminal-ime-standalone-229.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-standalone-229.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment happy-dom
+import { createRequire } from 'node:module'
+import { Terminal as EsmTerminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installTerminalImeNativeTextForwarder } from './terminal-ime-native-text-forwarder'
+import { shouldSuppressTerminalImeKeyboardEvent } from './xterm-bypass-policy'
+
+const requireFromHere = createRequire(import.meta.url)
+const { Terminal: CjsTerminal } = requireFromHere('@xterm/xterm') as {
+  Terminal: typeof EsmTerminal
+}
+
+describe.each([
+  ['ESM', EsmTerminal],
+  ['CJS', CjsTerminal]
+])('standalone macOS IME keydown (%s)', (_format, TerminalType) => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it.each(
+    [0, 1, 9, 31].flatMap((flags) => [
+      { flags, startsComposition: false },
+      { flags, startsComposition: true }
+    ])
+  )(
+    'preserves IME input: $flags, composition=$startsComposition',
+    async ({ flags, startsComposition }) => {
+      const container = document.createElement('div')
+      document.body.appendChild(container)
+      const terminal = new TerminalType()
+      terminal.open(container)
+      const textarea = terminal.textarea!
+      const emitted: string[] = []
+      terminal.onData((data) => emitted.push(data))
+      const forwarder = installTerminalImeNativeTextForwarder({
+        terminalElement: terminal.element,
+        isComposing: () => false,
+        sendInput: (data) => terminal.input(data),
+        getKittyKeyboardFlags: () => flags
+      })
+      terminal.attachCustomKeyEventHandler((event) => {
+        if (
+          shouldSuppressTerminalImeKeyboardEvent(event, {
+            compositionActive: false,
+            candidateKeyGuardActive: false,
+            pendingCandidateKeyReleaseActive: false,
+            isMac: true,
+            isLinux: false
+          })
+        ) {
+          return false
+        }
+        return !forwarder.claimKeyEvent(event)
+      })
+
+      try {
+        await new Promise<void>((resolve) => terminal.write(`\x1b[>${flags}u`, resolve))
+        const event = new KeyboardEvent('keydown', {
+          key: 'ㅎ',
+          code: 'KeyG',
+          isComposing: false,
+          bubbles: true,
+          cancelable: true
+        })
+        Object.defineProperty(event, 'keyCode', { value: 229 })
+        textarea.dispatchEvent(event)
+        if (startsComposition) {
+          textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+          for (const data of ['ㅎ', '하', '한']) {
+            textarea.dispatchEvent(
+              new CompositionEvent('compositionupdate', { data, bubbles: true })
+            )
+            textarea.value = data
+            textarea.setSelectionRange(1, 1)
+            textarea.dispatchEvent(
+              new InputEvent('input', {
+                data,
+                inputType: 'insertCompositionText',
+                isComposing: true,
+                bubbles: true
+              })
+            )
+          }
+          textarea.dispatchEvent(
+            new CompositionEvent('compositionend', { data: '한', bubbles: true })
+          )
+        } else {
+          // The standalone-229 fallback observes native textarea changes without a composition session.
+          textarea.value = 'ㅎ'
+          textarea.setSelectionRange(1, 1)
+        }
+        await new Promise((resolve) => setTimeout(resolve, 0))
+
+        expect(event.defaultPrevented).toBe(false)
+        expect(emitted.join('')).toBe(startsComposition ? '한' : 'ㅎ')
+      } finally {
+        forwarder.dispose()
+        terminal.dispose()
+      }
+    }
+  )
+})


### PR DESCRIPTION
## ELI5

An IME can mark the first key as IME-owned before a composition session starts. Orca's ordinary text forwarder currently intercepts that key, preventing xterm from recovering text from its helper textarea. Leave these keys to the existing IME handler.

## What Changed

- Add optional `keyCode` to the forwarder's keyboard event type and decline keydown 229.
- Add 16 regression cases using the installed ESM/CJS xterm bundles and kitty flags 0/1/9/31, covering both standalone textarea changes and an immediately following composition session.

## Why

The macOS bypass policy deliberately lets standalone 229 keydowns reach xterm, but the native text forwarder subsequently claims them when `key` is one character and `isComposing` is false. That prevents xterm's textarea-diff fallback from being scheduled. The regression emitted an empty string instead of `ㅎ` before the fix; it now emits the character once. Following composition still emits `한` once, without leaking preedit.

## Linked Issue

Related to #19156. This fixes a demonstrated input-loss path; it does not yet establish the root cause of every symptom in the report. In particular, the synthetic failure also occurs with kitty flags 0, while the reporter's brief ordinary-shell comparison appeared unaffected.

## Visual Proof

Pending native macOS verification; no before/after recording is attached. This is intentionally a draft. The current evidence is synthetic DOM-event regression testing, not an end-to-end recording of Korean typing.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

On macOS with Node 24.15.0 and pnpm 12.0.0:

- Before fix: all 8 standalone textarea-diff cases failed (empty output instead of `ㅎ`).
- After fix: 36 related test files / 505 tests passed, including all 16 new cases.
- `pnpm run tc:web`: passed.
- `oxlint` on both changed files and `git diff --check`: passed.

Test command:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-ime- src/renderer/src/components/terminal-pane/keyboard-handlers-ime src/renderer/src/components/terminal-pane/xterm-bypass-policy --maxWorkers 2
```

Full lint/typecheck/test/build and native IME checks have not been run; broader CI validation is pending. The installed Orca application has not been changed.

## AI Disclosure

Prepared with OpenAI Codex (GPT-6 Astra), including code investigation, the patch, and regression tests. The reporter supplied the observed typing symptoms and terminal comparisons.

## Review

Self-review: this forwarder is installed only for macOS desktop, excluding iOS. Ordinary printable keys retain their existing path. No Windows/Linux policy, SSH/local routing, remote wire format, agent-specific handling, or git-provider behavior is changed. The extra numeric comparison is constant time on the existing keydown path. No new dependencies, permissions, or external data handling. Native macOS IME compatibility and the reported UI symptom remain unverified; automated tests alone do not establish visual correctness.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer content is included.

## Author

GitHub: @Dae-Jeong. X handle not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint, typecheck, test, and build validation completed
