### PR TITLE
fix(sidebar): recover a runtime host recorded unreachable

### DIFF
--- a/src/renderer/src/components/sidebar/NoticeHostGlyph.test.tsx
+++ b/src/renderer/src/components/sidebar/NoticeHostGlyph.test.tsx
@@ -83,12 +83,24 @@ describe('NoticeHostGlyph', () => {
     )
   })
 
-  it('marks a paired runtime with no live status as disconnected', async () => {
+  it('marks a paired runtime a probe found unreachable as disconnected', async () => {
+    runtimeStatusByEnvironmentId.set('openclaw-env', { status: null })
     const container = await render('runtime:openclaw-env')
 
     expect(container.querySelector('[data-testid="tooltip"]')?.textContent).toBe(
       'openclaw disconnected'
     )
+  })
+
+  it('does not call a host disconnected before its first probe answers', async () => {
+    // No entry means "not asked yet", not "asked and unreachable" — collapsing the two
+    // painted every remote row destructive between launch and the first probe.
+    const container = await render('runtime:openclaw-env')
+
+    expect(container.querySelector('[data-testid="tooltip"]')?.textContent).toBe(
+      'Project on openclaw'
+    )
+    expect(container.querySelector('svg')?.getAttribute('class')).not.toContain('text-destructive')
   })
 
   it('gives the local host the monitor glyph the run-target rows use', async () => {

--- a/src/renderer/src/components/sidebar/NoticeHostGlyph.tsx
+++ b/src/renderer/src/components/sidebar/NoticeHostGlyph.tsx
@@ -5,6 +5,10 @@ import { HostRowIcon } from '../host-row-icon'
 import { useAppStore } from '@/store'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
+import {
+  isDisconnectedRuntimeHostState,
+  runtimeHostConnectionStateForEntry
+} from '@/runtime/runtime-host-connection-state'
 
 type NoticeHostGlyphProps = {
   hostId: ExecutionHostId
@@ -26,11 +30,15 @@ export default function NoticeHostGlyph({
   keyboardFocusable
 }: NoticeHostGlyphProps): React.JSX.Element | null {
   const host = parseExecutionHostId(hostId)
+  // Why the shared derivation, not raw truthiness: an absent entry means "not probed yet",
+  // which is not the same verdict as a probe that came back unreachable.
   const isDisconnected = useAppStore((s) => {
     if (host?.kind !== 'runtime') {
       return false
     }
-    return !s.runtimeStatusByEnvironmentId.get(host.environmentId)?.status
+    return isDisconnectedRuntimeHostState(
+      runtimeHostConnectionStateForEntry(s.runtimeStatusByEnvironmentId.get(host.environmentId))
+    )
   })
 
   if (!host) {

--- a/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.ssh-reconnect-prompt.test.tsx
@@ -218,18 +218,35 @@ describe('WorktreeCard SSH reconnect prompt', () => {
     expect(markup).not.toContain('Retry SSH connection')
   })
 
-  it('marks a runtime-host worktree disconnected when its environment has no status', () => {
+  it('marks a runtime-host worktree disconnected once a probe finds it unreachable', () => {
+    runtimeEnvironments = [{ id: 'env-1', name: 'Remote Mac' }]
+    runtimeStatusByEnvironmentId.set('env-1', { status: null })
+    const runtimeRepo: Repo = {
+      ...makeRepo(),
+      connectionId: undefined,
+      executionHostId: 'runtime:env-1'
+    }
+    const markup = renderToStaticMarkup(
+      <WorktreeCard worktree={makeWorktree()} repo={runtimeRepo} isActive={false} />
+    )
+    expect(markup).toContain('Remote Mac disconnected')
+  })
+
+  // Why: "not probed yet" is not "probed and unreachable" — collapsing them painted every
+  // remote card destructive and dimmed between launch and the first probe answering.
+  it('leaves a runtime-host worktree undimmed before its first probe answers', () => {
     runtimeEnvironments = [{ id: 'env-1', name: 'Remote Mac' }]
     const runtimeRepo: Repo = {
       ...makeRepo(),
       connectionId: undefined,
       executionHostId: 'runtime:env-1'
     }
-    // No status entry for env-1 → host is disconnected.
     const markup = renderToStaticMarkup(
       <WorktreeCard worktree={makeWorktree()} repo={runtimeRepo} isActive={false} />
     )
-    expect(markup).toContain('Remote Mac disconnected')
+    expect(markup).not.toContain('Remote Mac disconnected')
+    expect(markup).toContain('Project on Remote Mac')
+    expect(markup).not.toContain('opacity-60')
   })
 
   it('distinguishes connected worktrees on different Orca servers', () => {

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -10,6 +10,10 @@ import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-ov
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { hydrateRuntimeEnvironmentSshState } from '@/runtime/runtime-environment-ssh-state'
+import {
+  isDisconnectedRuntimeHostState,
+  runtimeHostConnectionStateForEntry
+} from '@/runtime/runtime-host-connection-state'
 import { useAppStore } from '@/store'
 import {
   selectRuntimeAwareSshStatus,
@@ -177,12 +181,17 @@ export function useWorktreeCardFoundation({
   const runtimeHostLabel = runtimeHostId
     ? (getHostDisplayLabelOverrides(settings).get(runtimeHostId) ?? runtimeEnvironmentName)
     : null
-  // Why: runtime ("Orca server") hosts get the same disconnected dimming as SSH when their environment has no live status.
+  // Why the shared derivation, not raw truthiness: an absent entry means "not probed yet",
+  // which is not the same verdict as a probe that came back unreachable.
   const isRuntimeDisconnected = useAppStore((s) => {
     if (!runtimeOwnerEnvironmentId) {
       return false
     }
-    return !s.runtimeStatusByEnvironmentId.get(runtimeOwnerEnvironmentId)?.status
+    return isDisconnectedRuntimeHostState(
+      runtimeHostConnectionStateForEntry(
+        s.runtimeStatusByEnvironmentId.get(runtimeOwnerEnvironmentId)
+      )
+    )
   })
   const [titleRenaming, setTitleRenaming] = useState(false)
   const [showRenameErrorDialog, setShowRenameErrorDialog] = useState(false)

--- a/src/renderer/src/runtime/runtime-host-connection-state.test.ts
+++ b/src/renderer/src/runtime/runtime-host-connection-state.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import type { RuntimeStatus } from '../../../shared/runtime-types'
 import {
   isConnectedRuntimeHostState,
+  isDisconnectedRuntimeHostState,
   runtimeHostConnectionState,
+  runtimeHostConnectionStateForEntry,
   runtimeStatusForOverall
 } from './runtime-host-connection-state'
 
@@ -177,3 +179,55 @@ describe('runtime host connection state', () => {
     ).toBe('disconnected')
   })
 })
+
+describe('runtime host connection state for a recorded status entry', () => {
+  it('separates a host that was never probed from one a probe found unreachable', () => {
+    // The sidebar read raw truthiness, which collapsed these two into the same red glyph.
+    expect(runtimeHostConnectionStateForEntry(undefined)).toBe('checking')
+    expect(runtimeHostConnectionStateForEntry({ status: null })).toBe('disconnected')
+  })
+
+  it('reads the remote-control diagnostics recorded beside a failed probe', () => {
+    expect(
+      runtimeHostConnectionStateForEntry({
+        status: null,
+        remoteControl: remoteControl('reconnecting')
+      })
+    ).toBe('reconnecting')
+  })
+
+  it('agrees with the status bar that a closed control channel is disconnected', () => {
+    expect(
+      runtimeHostConnectionStateForEntry({
+        status: makeStatus({ remoteControl: remoteControl('closed') })
+      })
+    ).toBe('disconnected')
+  })
+
+  it('names only the disconnected verdict as disconnected', () => {
+    expect(isDisconnectedRuntimeHostState('disconnected')).toBe(true)
+    for (const state of [
+      'connected',
+      'checking',
+      'reconnecting',
+      'runtime-unavailable',
+      'workspace-window-closed'
+    ] as const) {
+      expect(isDisconnectedRuntimeHostState(state)).toBe(false)
+    }
+  })
+})
+
+function remoteControl(
+  state: NonNullable<RuntimeStatus['remoteControl']>['state']
+): NonNullable<RuntimeStatus['remoteControl']> {
+  return {
+    state,
+    pendingRequestCount: 0,
+    subscriptionCount: 0,
+    reconnectAttempt: 1,
+    lastConnectedAt: null,
+    lastClose: null,
+    lastError: null
+  }
+}

--- a/src/renderer/src/runtime/runtime-host-connection-state.ts
+++ b/src/renderer/src/runtime/runtime-host-connection-state.ts
@@ -97,3 +97,26 @@ export function isConnectedRuntimeHostState(state: RuntimeHostConnectionState): 
     state === 'connected' || state === 'runtime-unavailable' || state === 'workspace-window-closed'
   )
 }
+
+// Why: only this verdict earns the destructive glyph. 'checking' and 'reconnecting' are
+// unverifiable, not down, per docs/reference/ssh-execution-boundary.md.
+export function isDisconnectedRuntimeHostState(state: RuntimeHostConnectionState): boolean {
+  return state === 'disconnected'
+}
+
+/** The same derivation, read straight off a recorded status entry. */
+export function runtimeHostConnectionStateForEntry(
+  entry:
+    | {
+        status: RuntimeStatus | null
+        remoteControl?: RuntimeStatus['remoteControl'] | null
+      }
+    | null
+    | undefined
+): RuntimeHostConnectionState {
+  return runtimeHostConnectionState({
+    hasStatusEntry: Boolean(entry),
+    status: entry?.status ?? null,
+    remoteControl: entry?.remoteControl ?? entry?.status?.remoteControl ?? null
+  })
+}

--- a/src/renderer/src/runtime/runtime-host-connection-state.ts
+++ b/src/renderer/src/runtime/runtime-host-connection-state.ts
@@ -98,8 +98,10 @@ export function isConnectedRuntimeHostState(state: RuntimeHostConnectionState): 
   )
 }
 
-// Why: only this verdict earns the destructive glyph. 'checking' and 'reconnecting' are
-// unverifiable, not down, per docs/reference/ssh-execution-boundary.md.
+/**
+ * Only this verdict earns the destructive glyph. 'checking' and 'reconnecting' are
+ * unverifiable, not down, per docs/reference/ssh-execution-boundary.md.
+ */
 export function isDisconnectedRuntimeHostState(state: RuntimeHostConnectionState): boolean {
   return state === 'disconnected'
 }

--- a/src/renderer/src/store/slices/runtime-status-recheck.test.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.test.ts
@@ -66,7 +66,7 @@ describe('runtime status recheck', () => {
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.checkedAt).toBe(1)
   })
 
-  it('cancels on removal, capability loss, and null without probing again', async () => {
+  it('cancels on removal and capability loss without probing again', async () => {
     const getStatus = vi.fn()
     const store = createStore(getStatus)
     store.getState().setRuntimeEnvironmentStatus('env-a', {

--- a/src/renderer/src/store/slices/runtime-status-recheck.test.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.test.ts
@@ -148,6 +148,56 @@ describe('runtime status recheck', () => {
     })
   })
 
+  it('re-probes a host recorded unreachable until it answers again', async () => {
+    // A boot probe that failed while the host was asleep must not outlive the outage:
+    // nothing else re-asks, because the client-event subscription set is gated on a truthy status.
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce(unavailableResponse())
+      .mockResolvedValue(response(status('ready')))
+    const store = createStore(getStatus)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 1 })
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(getStatus).toHaveBeenCalledWith({
+      selector: 'env-a',
+      timeoutMs: 10_000,
+      observeOnly: true
+    })
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status).toBeNull()
+
+    await vi.advanceTimersByTimeAsync(6_000)
+    expect(
+      store.getState().runtimeStatusByEnvironmentId.get('env-a')?.status?.remoteControl
+    ).toMatchObject({ state: 'ready' })
+
+    const callsAtRecovery = getStatus.mock.calls.length
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(getStatus).toHaveBeenCalledTimes(callsAtRecovery)
+  })
+
+  it('stops re-probing a manually disconnected host', async () => {
+    // The probe short-circuits locally for these, so retrying only burns a timer forever.
+    const getStatus = vi.fn().mockResolvedValue({
+      id: 'runtime.manualDisconnect',
+      ok: false,
+      error: {
+        code: 'runtime_manually_disconnected',
+        message: 'Runtime environment is manually disconnected.'
+      },
+      _meta: { runtimeId: 'rt' }
+    })
+    const store = createStore(getStatus)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 1 })
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(getStatus).toHaveBeenCalledOnce()
+    await vi.advanceTimersByTimeAsync(300_000)
+    expect(getStatus).toHaveBeenCalledOnce()
+  })
+
   it('keeps setter side effects when a recheck discovers disconnection', async () => {
     const getStatus = vi.fn().mockResolvedValue({
       id: 'status.get',
@@ -210,6 +260,15 @@ function status(
       lastError: null
     }
   } as RuntimeStatus
+}
+
+function unavailableResponse() {
+  return {
+    id: 'status.get',
+    ok: false as const,
+    error: { code: 'runtime_unavailable', message: 'offline' },
+    _meta: { runtimeId: 'rt' }
+  }
 }
 
 function response(result: RuntimeStatus) {

--- a/src/renderer/src/store/slices/runtime-status-recheck.test.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.test.ts
@@ -177,6 +177,19 @@ describe('runtime status recheck', () => {
     expect(getStatus).toHaveBeenCalledTimes(callsAtRecovery)
   })
 
+  it('does not re-toast while the ladder keeps confirming the same outage', async () => {
+    // The ladder republishes null on every failed retry; only a real truthy -> null
+    // transition is news, so the warning must not pop once per retry.
+    const getStatus = vi.fn().mockResolvedValue(unavailableResponse())
+    const store = createStore(getStatus)
+
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 1 })
+    await vi.advanceTimersByTimeAsync(3_000 + 6_000 + 12_000 + 30_000)
+
+    expect(getStatus).toHaveBeenCalledTimes(4)
+    expect(toast.warning).not.toHaveBeenCalled()
+  })
+
   it('stops re-probing a manually disconnected host', async () => {
     // The probe short-circuits locally for these, so retrying only burns a timer forever.
     const getStatus = vi.fn().mockResolvedValue({

--- a/src/renderer/src/store/slices/runtime-status-recheck.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.ts
@@ -101,10 +101,14 @@ export function clearRuntimeStatusRechecksForTests(): void {
   cancelRuntimeStatusRechecks([...rechecks.keys()])
 }
 
+/**
+ * Whether this recorded verdict is one the ladder must keep re-asking.
+ *
+ * Null qualifies because a host recorded unreachable is excluded from the client-event
+ * subscription set (that set is gated on a truthy status), so no reconnect signal can
+ * ever clear it and one failed boot probe otherwise outlives the outage. #16516
+ */
 function shouldRecheck(status: RuntimeStatus | null): boolean {
-  // Why null: a host recorded unreachable is excluded from the client-event subscription
-  // set (that set is gated on a truthy status), so no reconnect signal can ever clear it
-  // and one failed boot probe otherwise outlives the outage for the whole session. #16516
   if (status === null) {
     return true
   }

--- a/src/renderer/src/store/slices/runtime-status-recheck.ts
+++ b/src/renderer/src/store/slices/runtime-status-recheck.ts
@@ -1,6 +1,6 @@
 import { REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY } from '../../../../shared/protocol-version'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
-import { unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
+import { hasRuntimeRpcErrorCode, unwrapRuntimeRpcResult } from '@/runtime/runtime-rpc-client'
 import { extractRuntimeTransportDiagnostics } from '@/runtime/runtime-status-probe-diagnostics'
 import type { RuntimeEnvironmentStatus } from './runtime-status'
 
@@ -102,8 +102,14 @@ export function clearRuntimeStatusRechecksForTests(): void {
 }
 
 function shouldRecheck(status: RuntimeStatus | null): boolean {
+  // Why null: a host recorded unreachable is excluded from the client-event subscription
+  // set (that set is gated on a truthy status), so no reconnect signal can ever clear it
+  // and one failed boot probe otherwise outlives the outage for the whole session. #16516
+  if (status === null) {
+    return true
+  }
   return Boolean(
-    status?.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY) &&
+    status.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY) &&
     status.remoteControl &&
     status.remoteControl.state !== 'ready'
   )
@@ -147,6 +153,12 @@ async function fireRuntimeStatusRecheck(
     })
     nextEntry = { status: unwrapRuntimeRpcResult<RuntimeStatus>(response), checkedAt: Date.now() }
   } catch (error: unknown) {
+    // The probe short-circuits locally for a manually disconnected host, so retrying only
+    // burns a timer against an answer the user already chose.
+    if (hasRuntimeRpcErrorCode(error, 'runtime_manually_disconnected')) {
+      cancelRuntimeStatusRecheck(environmentId)
+      return
+    }
     const remoteControl = extractRuntimeTransportDiagnostics(error)
     nextEntry = {
       status: null,

--- a/tests/e2e/sidebar-runtime-host-disconnected-glyph.spec.ts
+++ b/tests/e2e/sidebar-runtime-host-disconnected-glyph.spec.ts
@@ -1,0 +1,124 @@
+import type { Locator, Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const ENVIRONMENT_ID = 'e2e-remote-host'
+const HOST_LABEL = 'Remote Mac'
+
+type RecordedState = 'no-entry' | 'probed-unreachable' | 'probed-reachable'
+
+/** Put the seeded worktree's repo on a runtime host and record one status verdict for it. */
+async function seedRuntimeHost(page: Page, recorded: RecordedState): Promise<string> {
+  return page.evaluate(
+    ({ environmentId, hostLabel, recorded }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const state = store.getState()
+      const worktree = Object.values(state.worktreesByRepo).flat()[0]
+      if (!worktree) {
+        throw new Error('no seeded worktree to place on a runtime host')
+      }
+      state.setRuntimeEnvironments([
+        {
+          id: environmentId,
+          name: hostLabel,
+          createdAt: 1,
+          updatedAt: 1,
+          lastUsedAt: null,
+          runtimeId: 'e2e-runtime',
+          endpoints: [
+            { id: 'ws', kind: 'websocket', label: 'WebSocket', endpoint: 'ws://127.0.0.1:1' }
+          ],
+          preferredEndpointId: 'ws'
+        }
+      ])
+      store.setState({
+        repos: state.repos.map((repo) =>
+          repo.id === worktree.repoId
+            ? { ...repo, connectionId: undefined, executionHostId: `runtime:${environmentId}` }
+            : repo
+        )
+      })
+      if (recorded === 'probed-unreachable') {
+        state.setRuntimeEnvironmentStatus(environmentId, { status: null, checkedAt: Date.now() })
+      }
+      if (recorded === 'probed-reachable') {
+        state.setRuntimeEnvironmentStatus(environmentId, {
+          status: {
+            runtimeId: 'e2e-runtime',
+            rendererGraphEpoch: 1,
+            graphStatus: 'ready',
+            authoritativeWindowId: 1,
+            desktopWindowStatus: 'available',
+            liveTabCount: 0,
+            liveLeafCount: 0
+          },
+          checkedAt: Date.now()
+        })
+      }
+      return worktree.id
+    },
+    { environmentId: ENVIRONMENT_ID, hostLabel: HOST_LABEL, recorded }
+  )
+}
+
+async function captureCard(card: Locator, testInfo: TestInfo, name: string): Promise<void> {
+  const shot = testInfo.outputPath(name)
+  await card.screenshot({ path: shot, animations: 'disabled' })
+  await testInfo.attach(name, { path: shot, contentType: 'image/png' })
+}
+
+test.describe('sidebar runtime host glyph', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  // Why: an absent entry means "not probed yet". Painting it destructive made every
+  // remote card red and dimmed between launch and the first probe answering.
+  test('does not call a runtime host disconnected before its first probe answers', async ({
+    orcaPage
+  }, testInfo) => {
+    await seedRuntimeHost(orcaPage, 'no-entry')
+    const card = orcaPage.locator(`[data-worktree-card-surface="true"]`).first()
+    await expect(card).toBeVisible()
+
+    // Captured before the assertions so a regression run still yields the evidence image.
+    await captureCard(card, testInfo, 'runtime-host-glyph-before-probe.png')
+
+    await expect(card.locator('svg.lucide-server')).toBeVisible()
+    await expect(card.locator('svg.lucide-server-off')).toHaveCount(0)
+    await expect(card).not.toHaveClass(/opacity-60/)
+  })
+
+  // The deliberate no-change case: a probe actually reported this host unreachable.
+  test('still marks a runtime host disconnected once a probe finds it unreachable', async ({
+    orcaPage
+  }, testInfo) => {
+    await seedRuntimeHost(orcaPage, 'probed-unreachable')
+    const card = orcaPage.locator(`[data-worktree-card-surface="true"]`).first()
+    await expect(card).toBeVisible()
+
+    await captureCard(card, testInfo, 'runtime-host-glyph-disconnected.png')
+
+    await expect(card.locator('svg.lucide-server-off')).toBeVisible()
+    await expect(card).toHaveClass(/opacity-60/)
+  })
+
+  test('clears the disconnected glyph when a later probe reaches the host', async ({
+    orcaPage
+  }, testInfo) => {
+    await seedRuntimeHost(orcaPage, 'probed-unreachable')
+    const card = orcaPage.locator(`[data-worktree-card-surface="true"]`).first()
+    await expect(card.locator('svg.lucide-server-off')).toBeVisible()
+
+    await seedRuntimeHost(orcaPage, 'probed-reachable')
+    await captureCard(card, testInfo, 'runtime-host-glyph-recovered.png')
+
+    await expect(card.locator('svg.lucide-server')).toBeVisible()
+    await expect(card.locator('svg.lucide-server-off')).toHaveCount(0)
+    await expect(card).not.toHaveClass(/opacity-60/)
+  })
+})


### PR DESCRIPTION
## ELI5

Orca remembered "I couldn't reach that server" from the moment it started up, and then never asked again. So if your remote machine happened to be asleep — or its tunnel wasn't up yet — when Orca launched, its workspaces stayed dimmed with a red "disconnected" icon for the rest of the day, even while you were happily running agents and terminals on that exact server.

This makes Orca ask again on a slow retry timer, and stops it calling a host "disconnected" before it has actually asked once.

## What Changed

**The recovery gap.** `shouldRecheck` in `runtime-status-recheck.ts` now covers a `status: null` entry. That reuses the ladder already in that module — 3s doubling to a 60s cap, per-host, with its connection-generation guards, in-flight collapse, and `observeOnly: true` probe — instead of adding a second retry mechanism. A host whose transport recovers on its own is re-asked; the probe's answer is what decides, never an inference.

A manually disconnected host cancels the ladder on `runtime_manually_disconnected` rather than looping against a probe that short-circuits locally in `registerPassiveStatusHandler`.

**The sidebar verdict.** `use-worktree-card-foundation.ts` and `NoticeHostGlyph.tsx` read raw truthiness (`!entry?.status`), which collapsed "no entry — not probed yet" into "entry with `status: null` — probed and unreachable". Both now use the shared `runtimeHostConnectionState` derivation that the status bar and Settings › Available Hosts already use, via two new helpers: `runtimeHostConnectionStateForEntry(entry)` and `isDisconnectedRuntimeHostState(state)`.

## Why

`runtimeStatusByEnvironmentId` is written only by explicit probes: boot hydration, the status-bar host dropdown, the settings pane, and the connect/disconnect actions. Nothing fed a transport that recovered on its own back into it.

It was self-reinforcing. `getRuntimeClientEventEnvironmentIds` subscribes client events only for the active environment plus environments with a truthy status. All three existing recovery paths hang off that subscription:

- `invalidateRuntimeClientEventReplay` (runs on a replay gap),
- the post-subscribe `isRuntimeStatusRecordedUnreachable` → `probeRuntimeStatus('recordedUnreachable')`,
- `shouldProbeRuntimeStatus`'s retry chain.

A **non-active** environment stuck on `null` is excluded from that set, so it never gets the subscription that could have reported its own reconnect — and `shouldRecheck(null)` returned `false`, so the backoff ladder skipped it too. Every route out was gated on the very state the host was stuck in.

**Why re-probe rather than infer.** These surfaces read the whole `RuntimeStatus` — capabilities, `remoteControl`, workspace-window availability — so "we exchanged a message, therefore connected" would be its own lie. This is the `live` / `unverifiable` / `exited` rule from `docs/reference/ssh-execution-boundary.md` applied in both directions: the old behaviour asserted `exited` on `unverifiable` evidence and never revisited it, and the fix must not overcorrect into asserting `live`. The ladder only re-runs the existing `status.get` and lets its answer stand.

Adopting the shared derivation changes one case deliberately: a host with `remoteControl.state === 'closed'` has a truthy status, so the old sidebar drew it normally while the status bar and Settings already called it disconnected. The sidebar was the outlier. It is not red-and-forgotten either — a truthy status with a non-ready `remoteControl` was already on the ladder.

Every state the sidebar now paints red is retried: `disconnected` arises either from `status: null` (covered by the new null branch) or from a truthy status with `remoteControl.state === 'closed'` (already covered).

No wire change: no new RPC params, stream frames, or published content, so mixed client/host versions are unaffected. Folder workspaces and git worktrees reach the glyph through the same repo `executionHostId`, so both are covered.

## Linked Issue

Fixes #16516

## Visual Proof

Generated by `tests/e2e/sidebar-runtime-host-disconnected-glyph.spec.ts`. The screenshot in each test is taken *before* its assertions, so a regression run still produces the evidence image. Artifacts land in `test-results/…-electron-headless/`.

| Recorded state | Artifact | Before | After |
| :--- | :--- | :--- | :--- |
| No entry (not probed yet) | `runtime-host-glyph-before-probe.png` | red `ServerOff`, card at `opacity-60` | plain `Server` glyph, full opacity |
| `status: null` (probe said unreachable) | `runtime-host-glyph-disconnected.png` | red `ServerOff`, dimmed | **unchanged** — red `ServerOff`, dimmed |
| Truthy status (probe said reachable) | `runtime-host-glyph-recovered.png` | plain `Server` glyph | **unchanged** |

Running that spec against `main` (sidebar change reverted) fails exactly one test — `does not call a runtime host disconnected before its first probe answers` — and the other two pass unchanged, which is the intended blast radius.

## Testing

Reproduced on a real pairing before writing any code: two saved servers, app up 28h, `orca status --environment <name>` reporting `state: ready, reachable: true, connectionState: connected` for both, `activeRuntimeEnvironmentId: null` (so neither was the active environment, hence neither was subscribed), while every sidebar card for those hosts drew the red glyph. Opening Settings › Remote Orca Servers re-probed and showed both **Connected**, which is what made the two surfaces disagree.

Re-run in full after rebasing onto current `main` (`bba68b1bd`, v1.4.197); the rebased net diff is byte-identical to the original.

- `pnpm tc` — clean
- `oxlint` on changed files — clean
- `pnpm test src/renderer/src/store/slices/ src/renderer/src/runtime/ src/renderer/src/hooks/ipc-events/` — 4675 passed
- `pnpm test src/renderer/src/components/sidebar/ .../status-bar/ .../settings/` — 4003 passed
- `pnpm exec playwright test tests/e2e/sidebar-runtime-host-disconnected-glyph.spec.ts --project electron-headless` — 3 passed

New/updated tests:
- `runtime-status-recheck.test.ts` — re-probes a recorded-unreachable host until it answers, then stops; stops on a manually disconnected host.
- `runtime-host-connection-state.test.ts` — separates "never probed" from "probed unreachable"; reads the diagnostics recorded beside a failed probe; agrees with the status bar on a closed control channel.
- `NoticeHostGlyph.test.tsx` / `WorktreeCard.ssh-reconnect-prompt.test.tsx` — the two conflated assertions split into "not probed yet" (not disconnected, not dimmed) and "probed unreachable" (disconnected, dimmed).

Platforms: developed and tested on macOS. The change is renderer-only store/derivation logic with no platform-dependent behaviour, no path handling, and no shortcut handling.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 (Claude Code) was used for the investigation, the fix, and the tests.

## Review

Prior art: #16518 is an earlier, unmerged attempt at the same issue (last commit 2026-08-26, no maintainer review, currently merge-conflicting). This PR is an independent, smaller fix written against current `main`. It reuses the existing recheck ladder instead of adding a new recovery module, so it does not carry that PR's `runtime-status-recovery-probe.ts` / `use-remote-runtime-recovery-triggers.ts`. Happy to close this in favour of that one if a maintainer prefers its shape.

## Agent skill upstream boundary

- [x] Not applicable — this change touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: no new surface; the probe is the existing `status.get` with `observeOnly: true`, which neither establishes a shared-control connection nor marks the environment used.
- **Performance**: at most one in-flight probe per host, backing off to one per 60s, and only for a host the sidebar is actively painting as down. A manually disconnected host is cancelled off the ladder entirely.
- **Backwards compatibility**: no wire change, so mixed client/host versions are unaffected.
- **Remote SSH / mobile**: SSH hosts go through `sshConnectionStates`, untouched. Web/mobile clients read the same store slice and get the same corrected verdict.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AE9frpcYCKdr6gw1ARjBPA

