### PR TITLE
test: refresh palette identities and structured-session journal fixtures

### DIFF
--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -101,6 +101,7 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
       })
       const items: AgentJournalRenderItem[] = []
       const journal = {
+        lastActivityAt: () => 0,
         snapshot: () => ({ items }),
         isReadOnly: false
       } as unknown as AgentSessionJournal
@@ -172,6 +173,7 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
       getRepo: () => ({ id: REPO_ID, kind: 'folder', path: '/workspace/platform' }) as Repo
     })
     const journal = {
+      lastActivityAt: () => 0,
       isReadOnly: false,
       snapshot: () => ({
         items: [

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -1,4 +1,7 @@
 import type { Locator, Page } from '@stablyai/playwright-test'
+import type { ExecutionHostId } from '../../src/shared/execution-host'
+import { getPaletteWorktreeIdentity } from '../../src/renderer/src/lib/palette-repo-resolution'
+import { encodePaletteIdentity } from '../../src/renderer/src/lib/palette-match/palette-ranking'
 import { expect, test } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
@@ -12,6 +15,7 @@ type PaletteFilterFixture = {
   localRepoId: string
   localWorktreeId: string
   remoteWorktreeId: string
+  remoteHostId: ExecutionHostId
 }
 
 async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixture> {
@@ -80,7 +84,8 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
       return {
         localRepoId: sourceRepo.id,
         localWorktreeId: sourceWorktree.id,
-        remoteWorktreeId
+        remoteWorktreeId,
+        remoteHostId
       }
     },
     {
@@ -92,8 +97,12 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
   )
 }
 
-function worktreeRow(page: Page, worktreeId: string) {
-  return palette(page).locator(`[cmdk-item][data-value="worktree:${worktreeId}"]`)
+function worktreeRow(page: Page, worktreeId: string, hostId: ExecutionHostId = 'local') {
+  const rowId = encodePaletteIdentity([
+    'worktree',
+    getPaletteWorktreeIdentity({ id: worktreeId, hostId })
+  ])
+  return palette(page).locator(`[cmdk-item][data-value=${JSON.stringify(rowId)}]`)
 }
 
 function palette(page: Page) {
@@ -113,7 +122,7 @@ async function searchFixtureWorkspaces(page: Page, fixture: PaletteFilterFixture
   const input = palette(page).getByPlaceholder(SEARCH_PLACEHOLDER)
   await input.fill('E2E Palette')
   await expect(worktreeRow(page, fixture.localWorktreeId)).toBeVisible()
-  await expect(worktreeRow(page, fixture.remoteWorktreeId)).toBeVisible()
+  await expect(worktreeRow(page, fixture.remoteWorktreeId, fixture.remoteHostId)).toBeVisible()
 }
 
 async function selectRemoteHost(page: Page, useKeyboard = false): Promise<void> {
@@ -175,7 +184,9 @@ test.describe('Worktree jump-palette filters', () => {
     await selectRemoteHost(orcaPage, true)
     await expect(filterTrigger(orcaPage)).toContainText('1')
     await expect(palette(orcaPage).getByLabel(`Remove filter ${REMOTE_HOST}`)).toBeVisible()
-    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId)).toBeVisible()
+    await expect(
+      worktreeRow(orcaPage, fixture.remoteWorktreeId, fixture.remoteHostId)
+    ).toBeVisible()
     await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toHaveCount(0)
 
     // P2: host and repository fields intersect, with the filter-specific empty state.
@@ -210,7 +221,9 @@ test.describe('Worktree jump-palette filters', () => {
     await palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER).fill('E2E Palette')
     await expect(filterTrigger(orcaPage)).toContainText('1')
     await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toBeVisible()
-    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId)).toHaveCount(0)
+    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId, fixture.remoteHostId)).toHaveCount(
+      0
+    )
   })
 
   test('opens with the sidebar repository scope without widening it', async ({ orcaPage }) => {
@@ -225,7 +238,9 @@ test.describe('Worktree jump-palette filters', () => {
     await expect(filterTrigger(orcaPage)).toContainText('1')
     await expect(palette(orcaPage).getByLabel(`Remove filter ${LOCAL_PROJECT}`)).toBeVisible()
     await expect(worktreeRow(orcaPage, fixture.localWorktreeId)).toBeVisible()
-    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId)).toHaveCount(0)
+    await expect(worktreeRow(orcaPage, fixture.remoteWorktreeId, fixture.remoteHostId)).toHaveCount(
+      0
+    )
   })
 
   test('pressing Enter creates a worktree from a typed name', async ({ orcaPage }) => {

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -16,14 +16,20 @@ type PaletteFilterFixture = {
 
 async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixture> {
   return page.evaluate(
-    ({ localProject, remoteHost, remoteProject, remoteWorkspace }) => {
+    async ({ localProject, remoteHost, remoteProject, remoteWorkspace }) => {
       const store = window.__store
       if (!store) {
         throw new Error('window.__store is unavailable')
       }
 
+      const sourceRepo = store.getState().repos[0]
+      if (
+        !sourceRepo ||
+        !(await store.getState().updateRepo(sourceRepo.id, { displayName: localProject }))
+      ) {
+        throw new Error('Failed to persist the local palette fixture name')
+      }
       const state = store.getState()
-      const sourceRepo = state.repos[0]
       const sourceWorktree = Object.values(state.worktreesByRepo)
         .flat()
         .find((worktree) => worktree.repoId === sourceRepo?.id && !worktree.isArchived)
@@ -60,12 +66,7 @@ async function seedPaletteFilterFixture(page: Page): Promise<PaletteFilterFixtur
       const sshTargetLabels = new Map(state.sshTargetLabels)
       sshTargetLabels.set(remoteConnectionId, remoteHost)
       store.setState({
-        repos: [
-          ...state.repos.map((repo) =>
-            repo.id === sourceRepo.id ? { ...repo, displayName: localProject } : repo
-          ),
-          remoteRepo
-        ],
+        repos: [...state.repos, remoteRepo],
         sshTargetLabels,
         worktreesByRepo: {
           ...state.worktreesByRepo,


### PR DESCRIPTION
Two stale test-fixture contracts broke CI:

- Palette filter tests used bare-worktree row IDs after the renderer adopted host-qualified identities. Reuse the identity helpers and explicitly scope the simulated SSH row. Persist the local project name with `updateRepo` so inventory refreshes retain the searchable fixture name.
- Two branch-rename journal doubles omitted `lastActivityAt()`, which the status feed now reads. Supply the zero-activity clock so the existing fake `now` remains the fallback.

Every filter, scope, Escape, branch-rename, replay, deduplication, and folder-workspace assertion remains intact. No application behavior changes.

Validation: the two palette failures were reproduced on current main; the corrected complete palette spec passed in PR CI run 34071657632. That run exposed five branch-rename failures from the missing journal method. Lint and formatting pass. Three complete palette repetitions passed 12/12 with zero skips/retries in [run 34072047272](https://github.com/stablyai/orca/actions/runs/34072047272); the downloaded JSON passed exact-title participation verification. All eight final unit shards, rendered E2E, typecheck, static analysis, Node 18 managed-hook checks, and final-head Pullfrog review passed; aggregate verification passed in [run 34072318662](https://github.com/stablyai/orca/actions/runs/34072318662).
