### PR TITLE
fix(terminal): paste Finder/Explorer-copied files as full shell-escaped paths

### DIFF
--- a/src/main/window/clipboard-file-read.test.ts
+++ b/src/main/window/clipboard-file-read.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { readClipboardFilePaths } from './clipboard-file-read'
+
+function deps(platform: NodeJS.Platform, formats: Record<string, Buffer | string>) {
+  return {
+    platform,
+    readBuffer: (format: string): Buffer => {
+      const value = formats[format]
+      if (value === undefined) {
+        return Buffer.alloc(0)
+      }
+      return typeof value === 'string' ? Buffer.from(value, 'utf8') : value
+    }
+  }
+}
+
+function filenamesPlist(paths: string[]): string {
+  const entries = paths.map((path) => `\t<string>${path}</string>`).join('\n')
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<array>\n${entries}\n</array>\n</plist>\n`
+}
+
+function fileNameW(filePath: string): Buffer {
+  return Buffer.from(`${filePath}\0`, 'utf16le')
+}
+
+function shellIdListArray(itemCount: number): Buffer {
+  const value = Buffer.alloc(4 + 4 * (itemCount + 1))
+  value.writeUInt32LE(itemCount)
+  return value
+}
+
+describe('readClipboardFilePaths', () => {
+  it('reads every Finder-copied path from NSFilenamesPboardType, decoding XML entities', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('darwin', {
+          NSFilenamesPboardType: filenamesPlist([
+            '/Users/me/sub dir/a &amp; b.txt',
+            '/Users/me/plain.txt'
+          ]),
+          'public.file-url': 'file:///Users/me/sub%20dir/a%20%26%20b.txt'
+        })
+      )
+    ).toEqual(['/Users/me/sub dir/a & b.txt', '/Users/me/plain.txt'])
+  })
+
+  it('falls back to the percent-encoded public.file-url without a filename list', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('darwin', { 'public.file-url': 'file:///Users/me/sub%20dir/hello%20world.txt' })
+      )
+    ).toEqual(['/Users/me/sub dir/hello world.txt'])
+  })
+
+  it('returns no paths for a text-only macOS clipboard', () => {
+    expect(readClipboardFilePaths(deps('darwin', {}))).toEqual([])
+  })
+
+  it('decodes a single Explorer-copied FileNameW path on Windows', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('win32', {
+          FileNameW: fileNameW('C:\\Users\\me\\report.pdf'),
+          'Shell IDList Array': shellIdListArray(1)
+        })
+      )
+    ).toEqual(['C:\\Users\\me\\report.pdf'])
+  })
+
+  it('leaves Explorer-copied image files to the clipboard image flow', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('win32', {
+          FileNameW: fileNameW('C:\\Users\\me\\shot.png'),
+          'Shell IDList Array': shellIdListArray(1)
+        })
+      )
+    ).toEqual([])
+  })
+
+  it('fails closed when Explorer copied several items', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('win32', {
+          FileNameW: fileNameW('C:\\Users\\me\\report.pdf'),
+          'Shell IDList Array': shellIdListArray(2)
+        })
+      )
+    ).toEqual([])
+  })
+
+  it('parses text/uri-list on Linux, skipping comments and blank lines', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('linux', {
+          'text/uri-list': 'file:///home/me/a%20b.txt\r\n# comment\r\n\r\nfile:///home/me/c.txt\r\n'
+        })
+      )
+    ).toEqual(['/home/me/a b.txt', '/home/me/c.txt'])
+  })
+
+  it('ignores non-file URIs and unparsable entries', () => {
+    expect(
+      readClipboardFilePaths(
+        deps('linux', { 'text/uri-list': 'https://example.com/x\nnot a uri\n' })
+      )
+    ).toEqual([])
+  })
+
+  it('returns no paths when the clipboard format cannot be read', () => {
+    expect(
+      readClipboardFilePaths({
+        platform: 'darwin',
+        readBuffer: () => {
+          throw new Error('format unavailable')
+        }
+      })
+    ).toEqual([])
+  })
+})

--- a/src/main/window/clipboard-file-read.ts
+++ b/src/main/window/clipboard-file-read.ts
@@ -1,0 +1,74 @@
+import { fileUriToFilesystemPath } from '../../shared/file-uri-path'
+import {
+  decodeWindowsClipboardFilePath,
+  isWindowsClipboardImageFile
+} from './clipboard-windows-image-file'
+
+// Injected so the platform branching is unit-testable without the real OS clipboard.
+export type ClipboardFileReadDeps = {
+  platform: NodeJS.Platform
+  readBuffer: (format: string) => Buffer
+}
+
+const PLIST_STRING_RE = /<string>([^<]*)<\/string>/g
+const XML_ENTITY_RE = /&(amp|lt|gt|quot|apos);/g
+const XML_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'"
+}
+
+// Counterpart of writeFileToClipboard: read the file references a file-manager
+// copy (Finder / Explorer / Nautilus) leaves on the clipboard. Their text flavor
+// is only the display name, so the path has to come from the OS file flavor.
+// Returns [] when the clipboard holds no file reference and never throws.
+export function readClipboardFilePaths(deps: ClipboardFileReadDeps): string[] {
+  const readBuffer = (format: string): Buffer => {
+    try {
+      return deps.readBuffer(format)
+    } catch {
+      return Buffer.alloc(0)
+    }
+  }
+  const readUtf8 = (format: string): string => readBuffer(format).toString('utf8')
+
+  if (deps.platform === 'darwin') {
+    // Why: NSFilenamesPboardType lists every copied path; public.file-url only the first.
+    const listedPaths = [...readUtf8('NSFilenamesPboardType').matchAll(PLIST_STRING_RE)]
+      .map(([, value]) => value.replace(XML_ENTITY_RE, (entity) => XML_ENTITIES[entity]))
+      .filter(Boolean)
+    return listedPaths.length > 0 ? listedPaths : fileUrisToPaths([readUtf8('public.file-url')])
+  }
+
+  if (deps.platform === 'win32') {
+    const filePath = decodeWindowsClipboardFilePath({
+      fileNameW: readBuffer('FileNameW'),
+      shellIdListArray: readBuffer('Shell IDList Array')
+    })
+    // Why: Explorer-copied PNG/JPEG files keep the clipboard image attachment flow (#9640).
+    return filePath && !isWindowsClipboardImageFile(filePath) ? [filePath] : []
+  }
+
+  return fileUrisToPaths(readUtf8('text/uri-list').split(/\r?\n/))
+}
+
+function fileUrisToPaths(uris: string[]): string[] {
+  const paths: string[] = []
+  for (const uri of uris) {
+    const trimmed = uri.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
+    }
+    try {
+      const filePath = fileUriToFilesystemPath(new URL(trimmed))
+      if (filePath) {
+        paths.push(filePath)
+      }
+    } catch {
+      // not a URL
+    }
+  }
+  return paths
+}

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -296,6 +296,9 @@ describe('registerClipboardHandlers', () => {
     expect(() =>
       handlers.get('clipboard:writeFile')?.(untrustedEvent, '/tmp/copied-file.txt')
     ).toThrow('Unauthorized clipboard IPC sender')
+    expect(() => handlers.get('clipboard:readFilePaths')?.(untrustedEvent)).toThrow(
+      'Unauthorized clipboard IPC sender'
+    )
     expect(() =>
       handlers.get('clipboard:writeImage')?.(untrustedEvent, 'data:image/png;base64,AAAA')
     ).toThrow('Unauthorized clipboard IPC sender')
@@ -546,12 +549,27 @@ describe('registerClipboardHandlers', () => {
 
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readSelectionText')
+    expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readFilePaths')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeSelectionText')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeImage')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:writeFile')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:saveImageAsTempFile')
     expect(removeHandlerMock).toHaveBeenCalledWith('clipboard:readImageThumbnail')
+  })
+
+  it('reads copied file paths from the OS file flavor', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    clipboardReadBufferMock.mockImplementation((format: string) =>
+      format === 'public.file-url'
+        ? Buffer.from('file:///Users/me/sub%20dir/hello%20world.txt', 'utf8')
+        : Buffer.alloc(0)
+    )
+    registerClipboardHandlers({} as never)
+
+    expect(getRegisteredHandlers().get('clipboard:readFilePaths')?.(makeClipboardEvent())).toEqual([
+      '/Users/me/sub dir/hello world.txt'
+    ])
   })
 
   it('does not inspect FileNameW when an empty image clipboard is read outside Windows', async () => {

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -31,6 +31,7 @@ import {
   type ClipboardFileDeps,
   type ClipboardFileResult
 } from './clipboard-file-copy'
+import { readClipboardFilePaths } from './clipboard-file-read'
 import {
   cleanupExpiredRemoteClipboardFiles,
   scheduleLegacyRemoteClipboardFileCleanup,
@@ -81,6 +82,7 @@ function runCommand(command: string, args: string[], stdin?: string): Promise<vo
 export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:readText')
   ipcMain.removeHandler('clipboard:readSelectionText')
+  ipcMain.removeHandler('clipboard:readFilePaths')
   ipcMain.removeHandler('clipboard:writeText')
   ipcMain.removeHandler('clipboard:writeTerminalText')
   ipcMain.removeHandler('clipboard:writeSelectionText')
@@ -103,6 +105,15 @@ export function registerClipboardHandlers(store: Store): void {
       return assertClipboardTextWithinLimitWithYield(clipboard.readText('selection'), options)
     }
   )
+  // Why: a file copied in Finder/Explorer reads back as its display name in the
+  // text flavor; terminals need the real path from the OS file flavor.
+  ipcMain.handle('clipboard:readFilePaths', (event): string[] => {
+    assertTrustedClipboardSender(event)
+    return readClipboardFilePaths({
+      platform: process.platform,
+      readBuffer: (format) => clipboard.readBuffer(format)
+    })
+  })
   // Why: an unanswered paste reads as a dropped paste, so the composer probes
   // the clipboard in memory before the (slower) save lands.
   ipcMain.handle('clipboard:readImageThumbnail', (event): ClipboardImageThumbnail | null => {

--- a/src/main/window/clipboard-windows-image-file.test.ts
+++ b/src/main/window/clipboard-windows-image-file.test.ts
@@ -3,7 +3,10 @@ import {
   CLIPBOARD_IMAGE_MAX_PIXELS,
   CLIPBOARD_IMAGE_MAX_SOURCE_BYTES
 } from '../../shared/clipboard-image'
-import { readWindowsClipboardImageFileAsPng } from './clipboard-windows-image-file'
+import {
+  decodeWindowsClipboardFilePath,
+  readWindowsClipboardImageFileAsPng
+} from './clipboard-windows-image-file'
 
 function fileNameW(filePath: string): Buffer {
   return Buffer.from(`${filePath}\0`, 'utf16le')
@@ -278,5 +281,23 @@ describe('readWindowsClipboardImageFileAsPng', () => {
         openFile: vi.fn().mockResolvedValue(oversizedPng)
       })
     ).rejects.toThrow('Clipboard image is too large')
+  })
+})
+
+describe('decodeWindowsClipboardFilePath', () => {
+  it('returns any fully qualified single-item path, not only images', () => {
+    expect(decodeWindowsClipboardFilePath(clipboardFormats('C:\\Users\\me\\report.pdf'))).toBe(
+      'C:\\Users\\me\\report.pdf'
+    )
+  })
+
+  it('fails closed for multi-item copies and malformed FileNameW', () => {
+    expect(decodeWindowsClipboardFilePath(clipboardFormats('C:\\a.txt', 2))).toBeNull()
+    expect(
+      decodeWindowsClipboardFilePath({
+        fileNameW: Buffer.from('relative.txt\0', 'utf16le'),
+        shellIdListArray: Buffer.alloc(0)
+      })
+    ).toBeNull()
   })
 })

--- a/src/main/window/clipboard-windows-image-file.ts
+++ b/src/main/window/clipboard-windows-image-file.ts
@@ -65,7 +65,11 @@ function decodeFileNameW(value: Buffer): string | null {
   if (!filePath || filePath.includes('\0') || !isFullyQualifiedWindowsPath(filePath)) {
     return null
   }
-  return IMAGE_FILE_EXTENSION_SET.has(win32.extname(filePath).toLowerCase()) ? filePath : null
+  return filePath
+}
+
+export function isWindowsClipboardImageFile(filePath: string): boolean {
+  return IMAGE_FILE_EXTENSION_SET.has(win32.extname(filePath).toLowerCase())
 }
 
 function hasAtMostOneShellItem(value: Buffer): boolean {
@@ -152,15 +156,23 @@ async function readStableFile(
   return bytesRead === expectedSize ? buffer.subarray(0, bytesRead) : null
 }
 
-export async function readWindowsClipboardImageFileAsPng(
-  { fileNameW, shellIdListArray }: WindowsClipboardImageFileFormats,
-  { createImageFromBuffer, openFile }: WindowsClipboardImageFileDeps
-): Promise<Buffer | null> {
+// Why: Explorer exposes a copied file only through FileNameW (first item) plus the CIDA item count.
+export function decodeWindowsClipboardFilePath({
+  fileNameW,
+  shellIdListArray
+}: WindowsClipboardImageFileFormats): string | null {
   if (!hasAtMostOneShellItem(shellIdListArray)) {
     return null
   }
-  const filePath = decodeFileNameW(fileNameW)
-  if (!filePath) {
+  return decodeFileNameW(fileNameW)
+}
+
+export async function readWindowsClipboardImageFileAsPng(
+  formats: WindowsClipboardImageFileFormats,
+  { createImageFromBuffer, openFile }: WindowsClipboardImageFileDeps
+): Promise<Buffer | null> {
+  const filePath = decodeWindowsClipboardFilePath(formats)
+  if (!filePath || !isWindowsClipboardImageFile(filePath)) {
     return null
   }
 

--- a/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
+++ b/src/preload/api/ui-bridge-clipboard-and-window-controls.ts
@@ -90,6 +90,7 @@ export const uiClipboardAndWindowControlsApi = {
     ipcRenderer.invoke('clipboard:readText', options),
   readSelectionClipboardText: (options?: ReadClipboardTextOptions): Promise<string> =>
     ipcRenderer.invoke('clipboard:readSelectionText', options),
+  readClipboardFilePaths: (): Promise<string[]> => ipcRenderer.invoke('clipboard:readFilePaths'),
   saveClipboardImageAsTempFile: (args?: {
     connectionId?: string | null
     runtimeEnvironmentId?: string | null

--- a/src/preload/api/ui-window-api.ts
+++ b/src/preload/api/ui-window-api.ts
@@ -9,6 +9,7 @@ import type {
 export type UiWindowApi = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
   readSelectionClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+  readClipboardFilePaths: () => Promise<string[]>
   saveClipboardImageAsTempFile: (args?: {
     connectionId?: string | null
     runtimeEnvironmentId?: string | null

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-file-paste.ts
@@ -1,0 +1,29 @@
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { NATIVE_FILE_DROP_TARGET } from '../../../../shared/native-file-drop'
+import type { PtyTransport } from './pty-transport'
+import { handleNativeTerminalFileDrop } from './terminal-native-file-drop'
+
+// Why: a copied file pastes exactly like a dropped one — shell-escaped for local
+// worktrees, uploaded first for SSH and runtime worktrees.
+export function pasteClipboardFilePathsToPane(args: {
+  manager: PaneManager | null
+  paneTransports: Map<number, PtyTransport>
+  worktreeId: string
+  tabId: string
+  cwd: string | undefined
+  pane: ManagedPane
+}): ((paths: string[]) => Promise<void>) | undefined {
+  const { manager, paneTransports, worktreeId, tabId, cwd, pane } = args
+  if (!manager) {
+    return undefined
+  }
+  return (paths) =>
+    handleNativeTerminalFileDrop({
+      manager,
+      paneTransports,
+      worktreeId,
+      tabId,
+      cwd,
+      data: { paths, target: NATIVE_FILE_DROP_TARGET.terminal, paneLeafId: pane.leafId }
+    })
+}

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.test.ts
@@ -388,4 +388,55 @@ describe('terminal clipboard paste', () => {
     expect(observedIgnoreBracketedPasteMode).toEqual([true])
     expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
   })
+
+  it('pastes copied file paths through the drop pipeline instead of the display-name text', async () => {
+    const pasteText = vi.fn()
+    const pasteFilePaths = vi.fn().mockResolvedValue(undefined)
+    const saveClipboardImageAsTempFile = vi.fn().mockResolvedValue(null)
+
+    const result = await pasteTerminalClipboard({
+      // Why: Finder exposes a copied file as its bare name in the text flavor.
+      readClipboardText: vi.fn().mockResolvedValue('hello world.txt'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue(['/Users/me/sub dir/hello world.txt']),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile,
+      pasteText
+    })
+
+    expect(pasteFilePaths).toHaveBeenCalledWith(['/Users/me/sub dir/hello world.txt'])
+    expect(pasteText).not.toHaveBeenCalled()
+    expect(saveClipboardImageAsTempFile).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'pasted', kind: 'file-path' })
+  })
+
+  it('keeps text paste when the clipboard holds no file reference', async () => {
+    const pasteText = vi.fn()
+    const pasteFilePaths = vi.fn()
+
+    const result = await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('plain text'),
+      readClipboardFilePaths: vi.fn().mockResolvedValue([]),
+      pasteFilePaths,
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue(null),
+      pasteText
+    })
+
+    expect(pasteFilePaths).not.toHaveBeenCalled()
+    expect(pasteText).toHaveBeenCalledWith('plain text')
+    expect(result).toEqual({ status: 'pasted', kind: 'text' })
+  })
+
+  it('keeps text paste when reading file references fails', async () => {
+    const pasteText = vi.fn()
+
+    await pasteTerminalClipboard({
+      readClipboardText: vi.fn().mockResolvedValue('plain text'),
+      readClipboardFilePaths: vi.fn().mockRejectedValue(new Error('clipboard unavailable')),
+      pasteFilePaths: vi.fn(),
+      saveClipboardImageAsTempFile: vi.fn().mockResolvedValue(null),
+      pasteText
+    })
+
+    expect(pasteText).toHaveBeenCalledWith('plain text')
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-clipboard-paste.ts
@@ -14,6 +14,8 @@ type SaveClipboardImageAsTempFile = (args?: {
 
 type PasteTerminalClipboardDeps = {
   readClipboardText: (options?: ReadClipboardTextOptions) => Promise<string>
+  readClipboardFilePaths?: () => Promise<string[]>
+  pasteFilePaths?: (paths: string[]) => Promise<void>
   saveClipboardImageAsTempFile: SaveClipboardImageAsTempFile
   pasteText: (
     text: string,
@@ -28,7 +30,7 @@ type PasteTerminalClipboardDeps = {
 }
 
 export type TerminalClipboardPasteResult =
-  | { status: 'pasted'; kind: 'image-path' | 'text' }
+  | { status: 'pasted'; kind: 'file-path' | 'image-path' | 'text' }
   | {
       status: 'skipped'
       reason:
@@ -42,6 +44,8 @@ export type TerminalClipboardPasteResult =
 
 export async function pasteTerminalClipboard({
   readClipboardText,
+  readClipboardFilePaths,
+  pasteFilePaths,
   saveClipboardImageAsTempFile,
   pasteText,
   connectionId,
@@ -51,6 +55,21 @@ export async function pasteTerminalClipboard({
   onTextPasteError,
   onImagePasteError
 }: PasteTerminalClipboardDeps): Promise<TerminalClipboardPasteResult> {
+  // Why: a file copied in Finder/Explorer exposes only its display name as text,
+  // so copied files must be resolved before the text flavor is consulted.
+  if (readClipboardFilePaths && pasteFilePaths) {
+    let filePaths: string[] = []
+    try {
+      filePaths = await readClipboardFilePaths()
+    } catch {
+      // Why: an unreadable file flavor must not block ordinary text paste.
+    }
+    if (filePaths.length > 0) {
+      await pasteFilePaths(filePaths)
+      return { status: 'pasted', kind: 'file-path' }
+    }
+  }
+
   let text = ''
   try {
     text = await readClipboardText({ maxBytes: TERMINAL_PASTE_MAX_BYTES })

--- a/src/renderer/src/components/terminal-pane/terminal-pane-menu-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-menu-paste.ts
@@ -4,6 +4,7 @@ import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { pasteTerminalText } from './terminal-bracketed-paste'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteClipboardFilePathsToPane } from './terminal-clipboard-file-paste'
 import {
   executeTerminalPastePlan,
   planTerminalPasteWithYield,
@@ -26,6 +27,7 @@ export type TerminalPaneMenuPasteContext = {
   paneTransportsRef: React.RefObject<Map<number, PtyTransport>>
   tabId: string
   worktreeId: string
+  cwd?: string
   forceBracketedMultilineTextPaste: boolean
   onPasteError: (message: string) => void
 }
@@ -121,6 +123,15 @@ export const pasteTerminalPaneMenuClipboard = async (
   const transport = context.paneTransportsRef.current.get(pane.id) ?? null
   const result = await pasteTerminalClipboard({
     readClipboardText: window.api.ui.readClipboardText,
+    readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+    pasteFilePaths: pasteClipboardFilePathsToPane({
+      manager: context.managerRef.current,
+      paneTransports: context.paneTransportsRef.current,
+      worktreeId,
+      tabId,
+      cwd: context.cwd,
+      pane
+    }),
     saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
     connectionId,
     runtimeEnvironmentId,

--- a/src/renderer/src/components/terminal-pane/terminal-pane-paste-execution.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-paste-execution.ts
@@ -21,6 +21,7 @@ import { formatTerminalPasteExecutionError } from './terminal-paste-errors'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { scheduleImagePasteWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteClipboardFilePathsToPane } from './terminal-clipboard-file-paste'
 import type { ReadClipboardTextOptions } from '../../../../shared/clipboard-text'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
 
@@ -36,6 +37,7 @@ export function createTerminalPanePasteExecution(
   shortcutPlatform: NodeJS.Platform
 ) {
   const {
+    cwd,
     forceBracketedMultilineTextPaste,
     managerRef,
     paneTransportsRef,
@@ -132,6 +134,15 @@ export function createTerminalPanePasteExecution(
     const activeElementAtDispatch = document.activeElement
     void pasteTerminalClipboard({
       readClipboardText,
+      readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+      pasteFilePaths: pasteClipboardFilePathsToPane({
+        manager: managerRef.current,
+        paneTransports: paneTransportsRef.current,
+        worktreeId,
+        tabId,
+        cwd,
+        pane
+      }),
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,

--- a/src/renderer/src/components/terminal-pane/terminal-pane-paste-listeners.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-paste-listeners.ts
@@ -9,6 +9,7 @@ import {
 } from './terminal-clipboard-event-paste'
 import { assertClipboardTextWithinLimitWithYield } from '../../../../shared/clipboard-text'
 import { pasteTerminalClipboard } from './terminal-clipboard-paste'
+import { pasteClipboardFilePathsToPane } from './terminal-clipboard-file-paste'
 import { APP_MENU_PASTE_EVENT } from '@/lib/app-menu-paste'
 import {
   APP_MENU_SELECTION_ACTION_EVENT,
@@ -42,10 +43,13 @@ export function registerTerminalPanePasteListeners({
   shortcutPlatform: NodeJS.Platform
 }): () => void {
   const {
+    cwd,
     forceBracketedMultilineTextPaste,
     keybindings,
     managerRef,
+    paneTransportsRef,
     setTerminalError,
+    tabId,
     worktreeId
   } = controller
   const { executePanePasteText, pasteFromClipboard } = execution
@@ -186,6 +190,15 @@ export function registerTerminalPanePasteListeners({
     )
     void pasteTerminalClipboard({
       readClipboardText: window.api.ui.readClipboardText,
+      readClipboardFilePaths: window.api.ui.readClipboardFilePaths,
+      pasteFilePaths: pasteClipboardFilePathsToPane({
+        manager,
+        paneTransports: paneTransportsRef.current,
+        worktreeId,
+        tabId,
+        cwd,
+        pane
+      }),
       saveClipboardImageAsTempFile: window.api.ui.saveClipboardImageAsTempFile,
       connectionId,
       runtimeEnvironmentId,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -122,6 +122,7 @@ export function useTerminalPaneContextMenu({
         paneTransportsRef,
         tabId,
         worktreeId,
+        cwd: fallbackCwd || undefined,
         forceBracketedMultilineTextPaste,
         onPasteError
       },

--- a/src/renderer/src/web/preload-api/web-ui-api.ts
+++ b/src/renderer/src/web/preload-api/web-ui-api.ts
@@ -119,6 +119,8 @@ export function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
       ),
     readSelectionClipboardText: () =>
       Promise.reject(new Error('Selection clipboard is unavailable in the web client')),
+    // Why: browsers never expose OS file references from the clipboard.
+    readClipboardFilePaths: async () => [],
     saveClipboardImageAsTempFile: async (args?: {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null


### PR DESCRIPTION
## ELI5

Thank you @hongdroid94 for the precise report and source walk-through in #7777, and @gatsby74 for carrying #7786 forward in #15521. Both made this much easier to pin down.

When you copy a file in Finder and press Cmd+V in a terminal pane, Orca pastes just `hello world.txt`. The file's real path is on the clipboard too, only in a different "flavor" that Orca never read. This PR reads that flavor and hands the path to the same code that already handles dragging a file onto a terminal, so paste and drop behave identically.

## What Changed

- `src/main/window/clipboard-file-read.ts` (new): reads file references straight off the OS clipboard with Electron's `clipboard.readBuffer`. macOS: `NSFilenamesPboardType` (every copied path) with `public.file-url` fallback. Windows: `FileNameW` + `Shell IDList Array`. Linux: `text/uri-list`. It is the read-side mirror of `writeFileToClipboard`, with the same injected-deps shape, and spawns no processes.
- `clipboard-windows-image-file.ts`: the `FileNameW` decoding from #9640 is exported as `decodeWindowsClipboardFilePath` (the image-extension filter moved to its call site) so both readers share one decoder. The image-file paste flow itself is unchanged.
- New `clipboard:readFilePaths` IPC + preload/web bridge (`readClipboardFilePaths`; the web client returns `[]`).
- `pasteTerminalClipboard` now checks copied files first, then text, then image. Copied files go through `handleNativeTerminalFileDrop`, the existing native-drop pipeline, via a small `terminal-clipboard-file-paste.ts` adapter. Wired into all three paste entry points (Cmd/Ctrl+V, Edit ▸ Paste, context menu).

## Why

`clipboard.readText()` on a Finder-copied file returns only the display name, so the text-first paste flow inserts `hello world.txt`. Drag-and-drop already resolves and shell-escapes local paths, uploads for SSH and runtime worktrees, and handles WSL. Reusing that pipeline keeps paste and drop consistent and keeps this diff small.

#7786 and #15521 solve the same issue by spawning `osascript` / PowerShell / `xclip` from the main process. This one stays inside Electron's clipboard API, which `writeFileToClipboard` and the Windows image-file reader already use. If you would rather land one of those, I am glad to close this.

## Linked Issue

Fixes #7777

## Visual Proof

Same harness (the `tests/e2e` Electron fixture, headless, macOS, plain `ksh` so the prompt is just `$`), same clipboard contents (a file reference plus its display name as text, which is what Finder puts on the pasteboard), same keystrokes (`cat `, Cmd+V, Enter), one variable: the code.

| | Terminal after `cat `, Cmd+V, Enter |
|---|---|
| Before (`main` @ 6fd03a74): only the display name is pasted, so `cat` fails | ![before](https://raw.githubusercontent.com/kimnamu/orca/assets/terminal-paste-copied-file/before-terminal-v3.png) |
| After (this PR): the quoted full path is pasted and `cat` prints the file | ![after](https://raw.githubusercontent.com/kimnamu/orca/assets/terminal-paste-copied-file/after-terminal-v3.png) |

Bytes written to the PTY, captured with the e2e `pty:write` spy:

| Case | Before | After |
|---|---|---|
| Finder-copied file, Cmd+V | `\x1b[200~hello world.txt\x1b[201~` | `'/tmp/orca-paste-test/sub dir/hello world.txt' ` |
| Plain text / screenshot paste | unchanged | unchanged (file flavor empty, falls through to today's flow) |
| Windows Explorer-copied PNG/JPEG | #9640 temp-PNG flow | unchanged (#9640 flow still wins) |
| Web client | text only | unchanged (`readClipboardFilePaths` returns `[]`) |

What Electron sees for a Finder-style copy (Electron 43, macOS), which is why text-first cannot work:

```
availableFormats: ["text/uri-list"]
readText():                        "hello world.txt"
readBuffer('public.file-url'):     "file:///tmp/orca-paste-test/sub%20dir/hello%20world.txt"
readBuffer('NSFilenamesPboardType'): <plist> ... <string>/tmp/orca-paste-test/sub dir/hello world.txt</string>
```

## Testing

Platforms actually tested: **macOS** (real app through the e2e fixture, plus unit tests). The Windows and Linux branches are unit-tested against the clipboard byte formats only; I do not have those machines, so a smoke test there would be appreciated.

- `pnpm test` over `src/main/window`, `src/preload`, `src/renderer/src/web` and the terminal-pane paste/drop specs: 940 passed
- `pnpm run typecheck:tsc:node`, `typecheck:tsc:web`, `check:code-quality:changed`, `check:max-lines-ratchet`, `check:reliability-gates`: pass; `electron-vite build` ran as part of the e2e fixture
- Mutation check: with `terminal-clipboard-paste.ts` reverted to `main` and the new tests kept, `pastes copied file paths through the drop pipeline instead of the display-name text` fails with `expected "vi.fn()" to be called with arguments: [ Array(1) ]`; restored, 22/22 pass.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude (via Claude Code) assisted with the investigation, implementation and tests; I reviewed everything before opening.

## Review

- Cross-platform: platform branches sit behind `process.platform`; an empty or unsupported flavor returns `[]` and falls through to the existing text/image flow.
- SSH / remote / runtime: paths go through `handleNativeTerminalFileDrop`, so SSH and runtime worktrees upload first and paste the remote path, exactly like drop. WSL worktrees use the same distro-aware resolver.
- Performance: one extra synchronous `clipboard.readBuffer` per paste; no process spawn, no file I/O.
- Security: the handler uses the same `assertTrustedClipboardSender` gate as the other clipboard IPC; paths reach the PTY only after the drop pipeline's shell escaping.
- Backwards compatibility: `readClipboardFilePaths` / `pasteFilePaths` are optional deps, so existing `pasteTerminalClipboard` callers and tests are untouched.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Known limits: on Windows a multi-file Explorer copy falls through unchanged (Explorer's `FileNameW` only exposes the first item; same rule as #9640). File Explorer paste-into-folder (#12929) is a separate feature and not touched here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred): changed-file lint gates, typecheck, tests and the electron-vite build pass locally; full `pnpm lint` left to CI


