### PR TITLE
fix: avoid duplicate repository groups during catalog refresh

### DIFF
--- a/src/renderer/src/store/project-groups/project-group-mutations.ts
+++ b/src/renderer/src/store/project-groups/project-group-mutations.ts
@@ -51,7 +51,7 @@ export function createProjectGroupMutationActions(
         const ownedGroup = projectGroupWithFetchedOwner(group, target)
         const ownerHostId = getProjectGroupHostId(ownedGroup)
         set((s) => {
-          // The change notification can load this group before the create response arrives.
+          // An overlapping catalog refresh may have already inserted a newer copy.
           if (
             s.projectGroups.some(
               (existing) =>

--- a/src/renderer/src/store/project-groups/project-group-mutations.ts
+++ b/src/renderer/src/store/project-groups/project-group-mutations.ts
@@ -5,6 +5,7 @@ import type { Repo } from '../../../../shared/repo-types'
 import { selectProjectGroupRemovalTargets } from '../slices/project-group-removal-targets'
 import {
   catalogOwnsHost,
+  getProjectGroupHostId,
   projectGroupMatchesOwnerHost,
   resolveProjectGroupOwnerHostId,
   settingsForProjectGroupOwner
@@ -48,10 +49,22 @@ export function createProjectGroupMutationActions(
                 )
               ).group
         const ownedGroup = projectGroupWithFetchedOwner(group, target)
-        set((s) => ({
-          projectGroups: [...s.projectGroups, ownedGroup],
-          folderWorkspacePathStatuses: {}
-        }))
+        const ownerHostId = getProjectGroupHostId(ownedGroup)
+        set((s) => {
+          // The change notification can load this group before the create response arrives.
+          if (
+            s.projectGroups.some(
+              (existing) =>
+                existing.id === ownedGroup.id && getProjectGroupHostId(existing) === ownerHostId
+            )
+          ) {
+            return s
+          }
+          return {
+            projectGroups: [...s.projectGroups, ownedGroup],
+            folderWorkspacePathStatuses: {}
+          }
+        })
         return ownedGroup
       } catch (err) {
         console.error('Failed to create project group:', err)

--- a/src/renderer/src/store/slices/repos-project-group-create-race.test.ts
+++ b/src/renderer/src/store/slices/repos-project-group-create-race.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { createTestStore } from './store-test-helpers'
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+})
+
+it.each([null, 'env-1'])(
+  'keeps one group when catalog refresh wins the create response on host %s',
+  async (runtimeEnvironmentId) => {
+    const projectGroup: ProjectGroup = {
+      id: 'group-1',
+      name: 'Platform',
+      parentPath: null,
+      parentGroupId: null,
+      createdFrom: 'manual',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const created = Promise.withResolvers<ProjectGroup>()
+    const refreshedGroup = { ...projectGroup, name: 'Renamed after creation', updatedAt: 2 }
+    const otherHostGroup = { ...projectGroup, executionHostId: 'runtime:other' }
+    vi.stubGlobal('window', {
+      api: {
+        projectGroups: {
+          create: () => created.promise,
+          list: async () => [refreshedGroup]
+        },
+        runtimeEnvironments: {
+          call: async (request: RuntimeEnvironmentCallRequest) =>
+            createCompatibleRuntimeStatusResponseIfNeeded(request) ?? {
+              id: 'rpc-project-group',
+              ok: true,
+              result:
+                request.method === 'projectGroup.create'
+                  ? { group: await created.promise }
+                  : { groups: [refreshedGroup] }
+            }
+        }
+      }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: runtimeEnvironmentId } as never,
+      projectGroups: [otherHostGroup]
+    })
+
+    const pendingCreate = store.getState().createProjectGroup('Platform')
+    await store.getState().fetchProjectGroups()
+    created.resolve(projectGroup)
+    await pendingCreate
+
+    expect(store.getState().projectGroups).toEqual([
+      otherHostGroup,
+      {
+        ...refreshedGroup,
+        executionHostId: runtimeEnvironmentId ? `runtime:${runtimeEnvironmentId}` : 'local'
+      }
+    ])
+  }
+)

--- a/src/renderer/src/store/slices/repos-project-group-create-race.test.ts
+++ b/src/renderer/src/store/slices/repos-project-group-create-race.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 import {
@@ -7,64 +8,163 @@ import {
 } from '../../runtime/runtime-compatibility-test-fixture'
 import { createTestStore } from './store-test-helpers'
 
+const projectGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Platform',
+  parentPath: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+const refreshedGroup = { ...projectGroup, name: 'Renamed after creation', updatedAt: 2 }
+const otherHostGroup = { ...projectGroup, executionHostId: 'runtime:other' }
+
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
 })
 
-it.each([null, 'env-1'])(
-  'keeps one group when catalog refresh wins the create response on host %s',
-  async (runtimeEnvironmentId) => {
-    const projectGroup: ProjectGroup = {
-      id: 'group-1',
-      name: 'Platform',
-      parentPath: null,
-      parentGroupId: null,
-      createdFrom: 'manual',
-      tabOrder: 0,
-      isCollapsed: false,
-      color: null,
-      createdAt: 1,
-      updatedAt: 1
-    }
-    const created = Promise.withResolvers<ProjectGroup>()
-    const refreshedGroup = { ...projectGroup, name: 'Renamed after creation', updatedAt: 2 }
-    const otherHostGroup = { ...projectGroup, executionHostId: 'runtime:other' }
-    vi.stubGlobal('window', {
-      api: {
-        projectGroups: {
-          create: () => created.promise,
-          list: async () => [refreshedGroup]
-        },
-        runtimeEnvironments: {
-          call: async (request: RuntimeEnvironmentCallRequest) =>
-            createCompatibleRuntimeStatusResponseIfNeeded(request) ?? {
-              id: 'rpc-project-group',
-              ok: true,
-              result:
-                request.method === 'projectGroup.create'
-                  ? { group: await created.promise }
-                  : { groups: [refreshedGroup] }
-            }
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+function setup(runtimeEnvironmentId: string | null) {
+  const created = Promise.withResolvers<ProjectGroup>()
+  const createStarted = Promise.withResolvers<void>()
+  const create = vi.fn(() => {
+    createStarted.resolve()
+    return created.promise
+  })
+  const list = vi.fn(async () => [refreshedGroup])
+  vi.stubGlobal('window', {
+    api: {
+      projectGroups: { create, list },
+      runtimeEnvironments: {
+        call: async (request: RuntimeEnvironmentCallRequest) => {
+          const compatibility = createCompatibleRuntimeStatusResponseIfNeeded(request)
+          if (compatibility) {
+            return compatibility
+          }
+          expect(request).toMatchObject({ selector: runtimeEnvironmentId })
+          switch (request.method) {
+            case 'projectGroup.create':
+              return { id: 'create', ok: true, result: { group: await create() } }
+            case 'projectGroup.list':
+              return { id: 'list', ok: true, result: { groups: await list() } }
+            default:
+              throw new Error(`Unexpected RPC: ${request.method}`)
+          }
         }
       }
-    })
-    const store = createTestStore()
-    store.setState({
-      settings: { activeRuntimeEnvironmentId: runtimeEnvironmentId } as never,
-      projectGroups: [otherHostGroup]
-    })
+    }
+  })
+  const store = createTestStore()
+  store.setState({
+    settings: { ...getDefaultSettings('/test'), activeRuntimeEnvironmentId: runtimeEnvironmentId },
+    projectGroups: [otherHostGroup]
+  })
+  const ownerHostId = runtimeEnvironmentId ? `runtime:${runtimeEnvironmentId}` : 'local'
+  return { store, created, createStarted, ownerHostId }
+}
 
+describe.each([null, 'env-1'])('project group creation on host %s', (runtimeEnvironmentId) => {
+  it('keeps the refreshed row without notifying subscribers when refresh finishes first', async () => {
+    const { store, created, createStarted, ownerHostId } = setup(runtimeEnvironmentId)
     const pendingCreate = store.getState().createProjectGroup('Platform')
+    await createStarted.promise
     await store.getState().fetchProjectGroups()
+    const refreshedState = store.getState()
+    const listener = vi.fn()
+    const unsubscribe = store.subscribe(listener)
+    try {
+      created.resolve(projectGroup)
+      await expect(pendingCreate).resolves.toEqual({
+        ...projectGroup,
+        executionHostId: ownerHostId
+      })
+      expect(store.getState()).toBe(refreshedState)
+      expect(listener).not.toHaveBeenCalled()
+      expect(store.getState().projectGroups).toEqual([
+        otherHostGroup,
+        { ...refreshedGroup, executionHostId: ownerHostId }
+      ])
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('inserts beside another host with the same ID, then accepts the later refresh', async () => {
+    const { store, created, ownerHostId } = setup(runtimeEnvironmentId)
+    const pendingCreate = store.getState().createProjectGroup('Platform')
     created.resolve(projectGroup)
     await pendingCreate
-
     expect(store.getState().projectGroups).toEqual([
       otherHostGroup,
-      {
-        ...refreshedGroup,
-        executionHostId: runtimeEnvironmentId ? `runtime:${runtimeEnvironmentId}` : 'local'
-      }
+      { ...projectGroup, executionHostId: ownerHostId }
     ])
-  }
-)
+    await store.getState().fetchProjectGroups()
+    expect(store.getState().projectGroups).toEqual([
+      otherHostGroup,
+      { ...refreshedGroup, executionHostId: ownerHostId }
+    ])
+    const groups = store.getState().projectGroups
+    await store.getState().fetchProjectGroups()
+    expect(store.getState().projectGroups).toBe(groups)
+  })
+
+  it('keeps the original owner when the focused host changes during creation', async () => {
+    const { store, created, createStarted, ownerHostId } = setup(runtimeEnvironmentId)
+    const pendingCreate = store.getState().createProjectGroup('Platform')
+    await createStarted.promise
+    store.setState({
+      settings: { ...getDefaultSettings('/test'), activeRuntimeEnvironmentId: 'other' }
+    })
+    await store.getState().fetchProjectGroups({ runtimeEnvironmentId })
+    created.resolve(projectGroup)
+    await pendingCreate
+    expect(store.getState().projectGroups).toEqual([
+      otherHostGroup,
+      { ...refreshedGroup, executionHostId: ownerHostId }
+    ])
+  })
+
+  it('does not roll back a successful refresh if the create response fails', async () => {
+    const { store, created, createStarted } = setup(runtimeEnvironmentId)
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const pendingCreate = store.getState().createProjectGroup('Platform')
+    await createStarted.promise
+    await store.getState().fetchProjectGroups()
+    const refreshedState = store.getState()
+    created.reject(new Error('Create response lost'))
+    await expect(pendingCreate).resolves.toBeNull()
+    expect(store.getState()).toBe(refreshedState)
+  })
+})
+
+it('recognizes an unstamped local group without conflating an SSH catalog row', async () => {
+  const { store, created } = setup(null)
+  const sshGroup = { ...projectGroup, connectionId: 'server' }
+  store.setState({ projectGroups: [sshGroup, refreshedGroup] })
+  const state = store.getState()
+  const pendingCreate = state.createProjectGroup('Platform')
+  created.resolve(projectGroup)
+  await pendingCreate
+  expect(store.getState()).toBe(state)
+})
+
+it('does not suppress a local group whose ID matches a direct SSH group', async () => {
+  const { store, created } = setup(null)
+  const sshGroup = { ...projectGroup, connectionId: 'server' }
+  store.setState({ projectGroups: [sshGroup] })
+  const pendingCreate = store.getState().createProjectGroup('Platform')
+  created.resolve(projectGroup)
+  await pendingCreate
+  expect(store.getState().projectGroups).toEqual([
+    sshGroup,
+    { ...projectGroup, executionHostId: 'local' }
+  ])
+})

--- a/tests/e2e/project-group-creation-visibility.spec.ts
+++ b/tests/e2e/project-group-creation-visibility.spec.ts
@@ -1,0 +1,158 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test('created repo groups survive expanding other repos when catalog refresh arrives first', async ({
+  orcaPage,
+  electronApp,
+  registerPostElectronShutdownCleanup
+}, testInfo) => {
+  await waitForSessionReady(orcaPage)
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-group-visibility-')))
+  registerPostElectronShutdownCleanup(async () => {
+    rmSync(root, { recursive: true, force: true })
+  })
+  const paths = Array.from({ length: 30 }, (_, index) =>
+    path.join(root, `repo-${String(index).padStart(2, '0')}`)
+  )
+  for (const repoPath of paths) {
+    mkdirSync(repoPath)
+    execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })
+    writeFileSync(path.join(repoPath, 'seed.txt'), 'seed\n')
+    execFileSync('git', ['add', '.'], { cwd: repoPath, stdio: 'pipe' })
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=Test',
+        '-c',
+        'user.email=test@example.com',
+        '-c',
+        'commit.gpgsign=false',
+        'commit',
+        '-m',
+        'seed'
+      ],
+      {
+        cwd: repoPath,
+        stdio: 'pipe'
+      }
+    )
+  }
+  const repoIds = await orcaPage.evaluate(async (paths) => {
+    const store = window.__store!
+    for (const repoPath of paths) {
+      await window.api.repos.add({ path: repoPath })
+    }
+    await store.getState().awaitLocalRepoCatalogSettlement()
+    const repos = store.getState().repos.filter((repo) => paths.includes(repo.path))
+    for (const repo of repos) {
+      await store.getState().fetchWorktrees(repo.id)
+    }
+    store.getState().setGroupBy('repo')
+    store.getState().setProjectOrderBy('manual')
+    return repos.map((repo) => repo.id)
+  }, paths)
+  expect(repoIds).toHaveLength(paths.length)
+
+  // Let the real repos:changed refresh land before releasing the real create response.
+  await electronApp.evaluate(({ ipcMain }) => {
+    if (!('_invokeHandlers' in ipcMain) || !(ipcMain._invokeHandlers instanceof Map)) {
+      throw new Error('Electron invoke handlers unavailable')
+    }
+    const create = ipcMain._invokeHandlers.get('projectGroups:create')
+    if (typeof create !== 'function') {
+      throw new Error('Group create handler unavailable')
+    }
+    const gate = Promise.withResolvers<void>()
+    Reflect.set(globalThis, '__releaseGroupCreateResponse', gate.resolve)
+    ipcMain.removeHandler('projectGroups:create')
+    ipcMain.handle('projectGroups:create', async (...args) => {
+      const group = await create(...args)
+      await gate.promise
+      return group
+    })
+  })
+  const creation = orcaPage.evaluate(() =>
+    window.__store!.getState().createProjectGroup('Crowded group')
+  )
+  await expect
+    .poll(() =>
+      orcaPage.evaluate(() =>
+        window.__store!.getState().projectGroups.some((group) => group.name === 'Crowded group')
+      )
+    )
+    .toBe(true)
+  await electronApp.evaluate(() => {
+    const release = Reflect.get(globalThis, '__releaseGroupCreateResponse')
+    if (typeof release !== 'function') {
+      throw new Error('Group create response gate unavailable')
+    }
+    release()
+    Reflect.deleteProperty(globalThis, '__releaseGroupCreateResponse')
+  })
+  const createdGroup = await creation
+  if (!createdGroup) {
+    throw new Error('Group creation failed')
+  }
+  await orcaPage.evaluate(
+    async ({ repoIds, groupId }) => {
+      const store = window.__store!
+      for (const repoId of repoIds.slice(0, 2)) {
+        await store.getState().moveProjectToGroup(repoId, groupId)
+      }
+      const collapsedGroups = store
+        .getState()
+        .projectHostSetups.map((setup) => `project:${setup.projectId}`)
+      await window.api.ui.set({ groupBy: 'repo', collapsedGroups })
+      store.setState({ collapsedGroups: new Set(collapsedGroups) })
+    },
+    { repoIds, groupId: createdGroup.id }
+  )
+
+  const scroller = orcaPage.locator('[data-worktree-sidebar]')
+  const group = scroller.locator(`[data-project-group-header-id="${createdGroup.id}"]`)
+  const groupedRepos = repoIds
+    .slice(0, 2)
+    .map((id) => scroller.locator(`[data-repo-header-id="${id}"]`))
+  for (const repo of groupedRepos) {
+    await expect(repo).toBeVisible()
+  }
+  await orcaPage.screenshot({ path: testInfo.outputPath('before-expansion.png') })
+  for (const repoId of repoIds.slice(2, 12)) {
+    const repo = scroller.locator(`[data-repo-header-id="${repoId}"]`)
+    await expect
+      .poll(async () => {
+        if (await repo.count()) {
+          return true
+        }
+        await scroller.evaluate((element) => {
+          element.scrollTop += element.clientHeight / 2
+        })
+        return false
+      })
+      .toBe(true)
+    await repo.scrollIntoViewIfNeeded()
+    await expect(repo).toHaveAttribute('aria-expanded', 'false')
+    await repo.click()
+    await scroller.evaluate((element) => {
+      element.scrollTop = 0
+    })
+    for (const groupedRepo of groupedRepos) {
+      await expect(groupedRepo).toBeVisible()
+    }
+  }
+  await expect(group).toHaveCount(1)
+  await group.click()
+  for (const repo of groupedRepos) {
+    await expect(repo).toHaveCount(0)
+  }
+  await group.click()
+  for (const repo of groupedRepos) {
+    await expect(repo).toBeVisible()
+  }
+  await orcaPage.screenshot({ path: testInfo.outputPath('after-expansion.png') })
+})

--- a/tests/e2e/project-group-creation-visibility.spec.ts
+++ b/tests/e2e/project-group-creation-visibility.spec.ts
@@ -1,158 +1,173 @@
-import { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
+import { runProcess } from '../../src/shared/child-process/run-process'
 
-test('created repo groups survive expanding other repos when catalog refresh arrives first', async ({
-  orcaPage,
-  electronApp,
-  registerPostElectronShutdownCleanup
-}, testInfo) => {
-  await waitForSessionReady(orcaPage)
-  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-group-visibility-')))
-  registerPostElectronShutdownCleanup(async () => {
-    rmSync(root, { recursive: true, force: true })
-  })
-  const paths = Array.from({ length: 30 }, (_, index) =>
-    path.join(root, `repo-${String(index).padStart(2, '0')}`)
-  )
-  for (const repoPath of paths) {
-    mkdirSync(repoPath)
-    execFileSync('git', ['init'], { cwd: repoPath, stdio: 'pipe' })
-    writeFileSync(path.join(repoPath, 'seed.txt'), 'seed\n')
-    execFileSync('git', ['add', '.'], { cwd: repoPath, stdio: 'pipe' })
-    execFileSync(
-      'git',
-      [
-        '-c',
-        'user.name=Test',
-        '-c',
-        'user.email=test@example.com',
-        '-c',
-        'commit.gpgsign=false',
-        'commit',
-        '-m',
-        'seed'
-      ],
-      {
-        cwd: repoPath,
-        stdio: 'pipe'
-      }
+test.use({ seedTestRepo: false })
+
+for (const delayCreateResponse of [false, true]) {
+  test(`created groups survive sidebar expansion (${delayCreateResponse ? 'refresh first' : 'ordinary timing'})`, async ({
+    orcaPage,
+    electronApp,
+    registerPostElectronShutdownCleanup
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-group-visibility-')))
+    registerPostElectronShutdownCleanup(async () => {
+      rmSync(root, { recursive: true, force: true })
+    })
+    const paths = Array.from({ length: 30 }, (_, index) =>
+      path.join(root, `repo-${String(index).padStart(2, '0')}`)
     )
-  }
-  const repoIds = await orcaPage.evaluate(async (paths) => {
-    const store = window.__store!
     for (const repoPath of paths) {
-      await window.api.repos.add({ path: repoPath })
-    }
-    await store.getState().awaitLocalRepoCatalogSettlement()
-    const repos = store.getState().repos.filter((repo) => paths.includes(repo.path))
-    for (const repo of repos) {
-      await store.getState().fetchWorktrees(repo.id)
-    }
-    store.getState().setGroupBy('repo')
-    store.getState().setProjectOrderBy('manual')
-    return repos.map((repo) => repo.id)
-  }, paths)
-  expect(repoIds).toHaveLength(paths.length)
-
-  // Let the real repos:changed refresh land before releasing the real create response.
-  await electronApp.evaluate(({ ipcMain }) => {
-    if (!('_invokeHandlers' in ipcMain) || !(ipcMain._invokeHandlers instanceof Map)) {
-      throw new Error('Electron invoke handlers unavailable')
-    }
-    const create = ipcMain._invokeHandlers.get('projectGroups:create')
-    if (typeof create !== 'function') {
-      throw new Error('Group create handler unavailable')
-    }
-    const gate = Promise.withResolvers<void>()
-    Reflect.set(globalThis, '__releaseGroupCreateResponse', gate.resolve)
-    ipcMain.removeHandler('projectGroups:create')
-    ipcMain.handle('projectGroups:create', async (...args) => {
-      const group = await create(...args)
-      await gate.promise
-      return group
-    })
-  })
-  const creation = orcaPage.evaluate(() =>
-    window.__store!.getState().createProjectGroup('Crowded group')
-  )
-  await expect
-    .poll(() =>
-      orcaPage.evaluate(() =>
-        window.__store!.getState().projectGroups.some((group) => group.name === 'Crowded group')
-      )
-    )
-    .toBe(true)
-  await electronApp.evaluate(() => {
-    const release = Reflect.get(globalThis, '__releaseGroupCreateResponse')
-    if (typeof release !== 'function') {
-      throw new Error('Group create response gate unavailable')
-    }
-    release()
-    Reflect.deleteProperty(globalThis, '__releaseGroupCreateResponse')
-  })
-  const createdGroup = await creation
-  if (!createdGroup) {
-    throw new Error('Group creation failed')
-  }
-  await orcaPage.evaluate(
-    async ({ repoIds, groupId }) => {
-      const store = window.__store!
-      for (const repoId of repoIds.slice(0, 2)) {
-        await store.getState().moveProjectToGroup(repoId, groupId)
+      mkdirSync(repoPath)
+      writeFileSync(path.join(repoPath, 'seed.txt'), 'seed\n')
+      for (const args of [
+        ['init'],
+        ['add', '.'],
+        [
+          '-c',
+          'user.name=Test',
+          '-c',
+          'user.email=test@example.com',
+          '-c',
+          'commit.gpgsign=false',
+          'commit',
+          '-m',
+          'seed'
+        ]
+      ]) {
+        const result = await runProcess({ program: 'git', args, cwd: repoPath, timeoutMs: 10_000 })
+        expect(result.code, result.stderr).toBe(0)
       }
-      const collapsedGroups = store
-        .getState()
-        .projectHostSetups.map((setup) => `project:${setup.projectId}`)
-      await window.api.ui.set({ groupBy: 'repo', collapsedGroups })
-      store.setState({ collapsedGroups: new Set(collapsedGroups) })
-    },
-    { repoIds, groupId: createdGroup.id }
-  )
-
-  const scroller = orcaPage.locator('[data-worktree-sidebar]')
-  const group = scroller.locator(`[data-project-group-header-id="${createdGroup.id}"]`)
-  const groupedRepos = repoIds
-    .slice(0, 2)
-    .map((id) => scroller.locator(`[data-repo-header-id="${id}"]`))
-  for (const repo of groupedRepos) {
-    await expect(repo).toBeVisible()
-  }
-  await orcaPage.screenshot({ path: testInfo.outputPath('before-expansion.png') })
-  for (const repoId of repoIds.slice(2, 12)) {
-    const repo = scroller.locator(`[data-repo-header-id="${repoId}"]`)
-    await expect
-      .poll(async () => {
-        if (await repo.count()) {
-          return true
-        }
-        await scroller.evaluate((element) => {
-          element.scrollTop += element.clientHeight / 2
-        })
-        return false
-      })
-      .toBe(true)
-    await repo.scrollIntoViewIfNeeded()
-    await expect(repo).toHaveAttribute('aria-expanded', 'false')
-    await repo.click()
-    await scroller.evaluate((element) => {
-      element.scrollTop = 0
-    })
-    for (const groupedRepo of groupedRepos) {
-      await expect(groupedRepo).toBeVisible()
     }
-  }
-  await expect(group).toHaveCount(1)
-  await group.click()
-  for (const repo of groupedRepos) {
-    await expect(repo).toHaveCount(0)
-  }
-  await group.click()
-  for (const repo of groupedRepos) {
-    await expect(repo).toBeVisible()
-  }
-  await orcaPage.screenshot({ path: testInfo.outputPath('after-expansion.png') })
-})
+    const repoIds = await orcaPage.evaluate(async (paths) => {
+      const store = window.__store!
+      for (const repoPath of paths) {
+        await window.api.repos.add({ path: repoPath })
+      }
+      await store.getState().awaitLocalRepoCatalogSettlement()
+      const repos = store.getState().repos.filter((repo) => paths.includes(repo.path))
+      for (const repo of repos) {
+        await store.getState().fetchWorktrees(repo.id)
+      }
+      store.getState().setGroupBy('repo')
+      store.getState().setProjectOrderBy('manual')
+      return repos.map((repo) => repo.id)
+    }, paths)
+    expect(repoIds).toHaveLength(paths.length)
+
+    // Force the adverse ordering separately from the ordinary IPC path.
+    if (delayCreateResponse) {
+      await electronApp.evaluate(({ ipcMain }) => {
+        if (!('_invokeHandlers' in ipcMain) || !(ipcMain._invokeHandlers instanceof Map)) {
+          throw new Error('Electron invoke handlers unavailable')
+        }
+        const create = ipcMain._invokeHandlers.get('projectGroups:create')
+        if (typeof create !== 'function') {
+          throw new Error('Group create handler unavailable')
+        }
+        const gate = Promise.withResolvers<void>()
+        Reflect.set(globalThis, '__releaseGroupCreateResponse', gate.resolve)
+        ipcMain.removeHandler('projectGroups:create')
+        ipcMain.handle('projectGroups:create', async (...args) => {
+          ipcMain.removeHandler('projectGroups:create')
+          ipcMain.handle('projectGroups:create', create)
+          const group = await create(...args)
+          await gate.promise
+          return group
+        })
+      })
+    }
+    const creation = orcaPage.evaluate(() =>
+      window.__store!.getState().createProjectGroup('Crowded group')
+    )
+    if (delayCreateResponse) {
+      try {
+        await expect
+          .poll(() =>
+            orcaPage.evaluate(() =>
+              window
+                .__store!.getState()
+                .projectGroups.some((group) => group.name === 'Crowded group')
+            )
+          )
+          .toBe(true)
+      } finally {
+        await electronApp.evaluate(() => {
+          const release = Reflect.get(globalThis, '__releaseGroupCreateResponse')
+          if (typeof release !== 'function') {
+            throw new Error('Group create response gate unavailable')
+          }
+          release()
+          Reflect.deleteProperty(globalThis, '__releaseGroupCreateResponse')
+        })
+      }
+    }
+    const createdGroup = await creation
+    if (!createdGroup) {
+      throw new Error('Group creation failed')
+    }
+    await orcaPage.evaluate(
+      async ({ repoIds, groupId }) => {
+        const store = window.__store!
+        for (const repoId of repoIds.slice(0, 2)) {
+          await store.getState().moveProjectToGroup(repoId, groupId)
+        }
+        const collapsedGroups = store
+          .getState()
+          .projectHostSetups.map((setup) => `project:${setup.projectId}`)
+        await window.api.ui.set({ groupBy: 'repo', collapsedGroups })
+        store.setState({ collapsedGroups: new Set(collapsedGroups) })
+      },
+      { repoIds, groupId: createdGroup.id }
+    )
+
+    const scroller = orcaPage.locator('[data-worktree-sidebar]')
+    const group = scroller.locator(`[data-project-group-header-id="${createdGroup.id}"]`)
+    const groupedRepos = repoIds
+      .slice(0, 2)
+      .map((id) => scroller.locator(`[data-repo-header-id="${id}"]`))
+    for (const repo of groupedRepos) {
+      await expect(repo).toBeVisible()
+    }
+    await orcaPage.screenshot({ path: testInfo.outputPath('before-expansion.png') })
+    for (const repoId of repoIds.slice(2, 12)) {
+      const repo = scroller.locator(`[data-repo-header-id="${repoId}"]`)
+      await expect
+        .poll(async () => {
+          if (await repo.count()) {
+            return true
+          }
+          await scroller.evaluate((element) => {
+            element.scrollTop += element.clientHeight / 2
+          })
+          return false
+        })
+        .toBe(true)
+      await repo.scrollIntoViewIfNeeded()
+      await expect(repo).toHaveAttribute('aria-expanded', 'false')
+      await repo.click()
+      await scroller.evaluate((element) => {
+        element.scrollTop = 0
+      })
+      for (const groupedRepo of groupedRepos) {
+        await expect(groupedRepo).toBeVisible()
+      }
+    }
+    await expect(group).toHaveCount(1)
+    await orcaPage.evaluate(() => window.__store!.getState().fetchProjectGroups())
+    await expect(group).toHaveCount(1)
+    await group.click()
+    for (const repo of groupedRepos) {
+      await expect(repo).toHaveCount(0)
+    }
+    await group.click()
+    for (const repo of groupedRepos) {
+      await expect(repo).toBeVisible()
+    }
+    await orcaPage.screenshot({ path: testInfo.outputPath('after-expansion.png') })
+  })
+}


### PR DESCRIPTION
## Problem and fix

A create response and an overlapping catalog refresh can each insert the same repository group into renderer state. Later catalog merges preserve those duplicate entries, and the sidebar gives them identical React/virtualizer keys. Expanding and scrolling unrelated repositories then exposes repeated empty group headers and missing or obscured member rows.

Make the create continuation insert only when the same normalized owning host + group ID is absent. Keep an already-fetched row intact, including newer metadata, and return the existing state without notifying subscribers. This prevents the duplicate at the insertion boundary; no extra fetch, rendering workaround, or persistence migration is needed.

Fixes #19168.

## Root-cause evidence and its limit

The main handler emits `repos:changed` before returning, but its notification starts another IPC roundtrip. That fact alone does **not** establish that this particular refresh normally beats the create response.

An independent before/after run of the improved real-Electron regression found:

| Implementation | Ordinary timing | Forced refresh before create response |
| --- | --- | --- |
| Original unconditional append | Passed | Failed: 3 rendered headers for one group; members missing/obscured in the screenshot |
| Host-aware insertion guard | Passed | Passed: one header and both members visible |

The response gate deliberately forces the adverse ordering. It proves the corruption mechanism and the fix, not the natural frequency or exclusive cause of every disappearing-sidebar report. Both original store race regressions also failed before the fix.

## Takeover improvements

- Expanded creation coverage from 2 to 10 cases: both orderings on local/runtime hosts, newer metadata, zero subscriber notifications on duplicate delivery, host switch during creation, response loss after a successful refresh, legacy unstamped local identity, and direct-SSH identity isolation.
- Replaced the permissive remote mock with explicit RPC method handling and host assertions; removed the settings cast and cleaned up mocks/subscriptions.
- Exercise both ordinary timing and forced ordering in the crowded-sidebar E2E. Each uses 30 real temporary Git repositories, expands 10 unrelated repositories, scrolls, refreshes, and collapses/reopens the group with DOM assertions.
- Restore the original IPC handler on first use and release the response gate in `finally`.
- Use the existing bounded, Windows-safe process runner for Git fixture commands; omit the extra fixture repository.
- Retain the small production guard and correct its causal comment.

## Validation

- 70 unique focused/adjacent tests across 8 files passed. The 4 IPC-hook tests passed with `--testTimeout=120000`; imports/execution took about 56 seconds on this machine. Initial default 30-second timeout failures are acknowledged.
- Hidden Electron: both fixed scenarios passed; original logic passed ordinary timing and failed the forced race. Before/after screenshots inspected.
- `pnpm tc`, targeted Oxlint, formatting, and whitespace checks passed.
- Changed-code quality gate passed with zero findings across all 3 files, using `ORCA_CODE_QUALITY_BASE=2e8fa3fe9b5` (the actual PR parent; the current checkout's `origin/main` has no merge base).
- Electron E2E builds passed for the fixed and original implementations.
- **Not green:** repository-wide `typecheck:e2e` reports 190 diagnostics in 96 other files, none in this spec. The complete test suite was not rerun during takeover. The contributor's earlier full run also reported unrelated failures; this PR does not claim full-suite green.

All automated app launches use `ORCA_BACKGROUND_LAUNCH=1`; no test window was revealed or focused.

## Readiness review

No remaining candidate findings in the final diff; findings-severity counsel skipped under the checklist's zero-candidate rule. Reviewed ownership/concurrency, failure and cleanup, bounded work, security/supply chain, persistence and wire compatibility, platform behavior, and module organization.

Production adds one short-circuit linear lookup per create, with no polling, listeners, timers, extra requests, or retained cache. No schema, dependency, binary, RPC, protocol, or UI style changes. No mobile-facing surface touched. Group insertion is independent of Git vs folder workspaces and GitHub vs GitLab.

Actual rendered validation was macOS only. Runtime ownership and response-loss cases use unit mocks; live SSH disconnect/reconnect, Windows/Linux, and mobile were not exercised. Host-scoped store identity tests do not claim full UI support for cloned catalogs with identical UUIDs. Existing in-memory corruption is not migrated; a fresh renderer reloads the persisted catalog.

## Original contributor visual proof

These attachments are from the contributor's initial run; takeover verification independently reproduced the same failure class, with three rather than five rendered headers.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/34d14674-d476-47d8-83ac-3a9a83848502) | ![After](https://github.com/user-attachments/assets/4098eedf-d239-45c4-81de-8392116b5ebc) |

## Attribution

Original implementation and reproduction by @kiendle, AI-assisted. Maintainer-requested takeover review, stronger tests, harness cleanup, and independent before/after verification were AI-assisted with Codex.

## Checklist

- [x] Focused change with root-cause explanation and limitations
- [x] Automated state and rendered regressions
- [x] Cross-platform, SSH/runtime, folder-workspace, and provider impact reviewed
- [x] No upstream skill-sharing/installer source or artifacts copied
- [ ] All repository-wide checks green (limitations recorded above)
