### PR TITLE
fix(cask): remove deprecated verified url parameter (stable + RC)

### DIFF
--- a/Casks/orca.rb
+++ b/Casks/orca.rb
@@ -5,8 +5,7 @@ cask "orca" do
   sha256 arm:   "fc707f290ff3b631b7b7947bf339885b61a43d2e89475997c125b61268ed4966",
          intel: "5f677c13a08f7a5740442e29d388285a86488c8c1f7aa5f10a8721a2c6ede8e4"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"

--- a/Casks/orca@rc.rb
+++ b/Casks/orca@rc.rb
@@ -5,8 +5,7 @@ cask "orca@rc" do
   sha256 arm:   "563b6b14323fc9d5489299c82442d514bc12cabffc9d06d3964ed572af4b3955",
          intel: "457088c7021f07de1a419197f7b2bd00092741ad4727d4fef3d86af38a6831e7"
 
-  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg",
-      verified: "github.com/stablyai/orca/"
+  url "https://github.com/stablyai/orca/releases/download/v#{version}/orca-macos-#{arch}.dmg"
   name "Orca RC"
   desc "IDE for orchestrating AI coding agents across terminals and worktrees"
   homepage "https://onorca.dev/"


### PR DESCRIPTION
## ELI5

Homebrew deprecated a cask option we still pass, so every brew command touching Orca prints a warning. This drops that option from both the stable and RC casks. No download URL changes, no behavior change.

## What Changed

- `Casks/orca.rb`: removed the deprecated `verified: "github.com/stablyai/orca/"` parameter from the `url` stanza.
- `Casks/orca@rc.rb`: same one-line removal (sibling RC cask carried the identical deprecated parameter).

## Why

Homebrew 6 deprecated the `verified` parameter in the `url` stanza — every `brew` command touching either cask prints:

> Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.

The download host matches the verified host in both files, so default URL verification already covers them; dropping the parameter is behavior-preserving. Both files are templated verbatim into `stablyai/homebrew-orca` by `homebrew-bump.yml`, so the next release sync carries the fix to both tap casks automatically.

## Linked Issue

N/A — trivial two-line deprecation cleanup, no behavior change, no existing issue covers it.

## Visual Proof

N/A — no UI or interaction change; this only silences a CLI warning.

## Testing

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

Loaded both casks via `brew ruby` + `Cask::CaskLoader::FromPathLoader` — both load with zero deprecation warnings (the warning reproduced on the pre-fix files). `ruby -c` passes on both. No automated tests apply (cask DSL file, no code path). Tested on macOS (arm64); change is platform-independent.

## AI Disclosure

Muse Spark (Meta) via OpenCode assisted with the investigation and the edit; a human reviewed the diff before pushing.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, cross-platform, SSH/remote, mobile, backwards-compatibility, or performance impact — URL strings are byte-identical, only the deprecated keyword is removed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)