### PR TITLE
fix(agent-hooks): clear a bare-Escape inferred interrupt when the Claude turn completes cleanly

### DIFF
--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -628,6 +628,34 @@ describe('shared agent-hook-listener', () => {
       expect(done?.payload.interrupted).toBe(true)
     })
 
+    it('keeps an inference-only interrupt on a StopFailure error boundary', () => {
+      // Why: only a clean Stop proves clean completion. A StopFailure is an error boundary,
+      // so it must not clear a provisional interrupt.
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'cancel this' })
+      markClaudeLeadTurnInterrupted(state, PANE_KEY)
+
+      const failed = claudeEvent({ hook_event_name: 'StopFailure' })
+      expect(failed?.payload.state).toBe('done')
+      expect(failed?.payload.interrupted).toBe(true)
+    })
+
+    it('clears an inference-only interrupt even while a subagent still holds the pane working', () => {
+      // Why: a subagent spawned between the Escape and the clean Stop keeps the pane 'working'
+      // (that gate ignores interrupt), so the clean lead Stop must still drop the provisional
+      // flag — otherwise the false red returns once the child drains.
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'keep working' })
+      markClaudeLeadTurnInterrupted(state, PANE_KEY)
+      claudeEvent({ hook_event_name: 'SubagentStart', agent_id: 'achild-1', agent_type: 'probe' })
+
+      const stillWorking = claudeEvent({ hook_event_name: 'Stop' })
+      expect(stillWorking?.payload.state).toBe('working')
+      expect(stillWorking?.payload.interrupted).toBeUndefined()
+
+      const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'achild-1' })
+      expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.interrupted).toBeUndefined()
+    })
+
     it('does not resurrect persisted idle child rows after a restart', () => {
       // Why: the roster tracks only working children now. A persisted idle
       // snapshot (from a build that kept idle rows) is a finished child, so

--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -599,6 +599,35 @@ describe('shared agent-hook-listener', () => {
       expect(idled?.payload.interrupted).toBe(true)
     })
 
+    it('clears an inference-only interrupt when the turn completes with a clean Stop', () => {
+      // Why: the renderer infers an interrupt from a bare Escape keystroke, which cannot
+      // be told apart from an Escape that only dismisses a /model or /btw overlay. When
+      // the turn was never really interrupted, its own clean completion Stop (no
+      // is_interrupt) must clear the optimistic red, not inherit it.
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'keep working' })
+      claudeEvent({
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'sleep 5' }
+      })
+      markClaudeLeadTurnInterrupted(state, PANE_KEY)
+
+      const done = claudeEvent({ hook_event_name: 'Stop' })
+      expect(done?.payload.state).toBe('done')
+      expect(done?.payload.interrupted).toBeUndefined()
+    })
+
+    it('keeps a hook-confirmed interrupt terminal even though the inference also fired', () => {
+      // Why: a real single-Escape interrupt trips the same inference, but Claude also
+      // emits Stop with is_interrupt. That confirmed interrupt must survive.
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'cancel this' })
+      markClaudeLeadTurnInterrupted(state, PANE_KEY)
+
+      const done = claudeEvent({ hook_event_name: 'Stop', is_interrupt: true })
+      expect(done?.payload.state).toBe('done')
+      expect(done?.payload.interrupted).toBe(true)
+    })
+
     it('does not resurrect persisted idle child rows after a restart', () => {
       // Why: the roster tracks only working children now. A persisted idle
       // snapshot (from a build that kept idle rows) is a finished child, so

--- a/src/shared/agent-hook-listener/listener-state.ts
+++ b/src/shared/agent-hook-listener/listener-state.ts
@@ -40,6 +40,10 @@ export type HookListenerState = {
 export type ClaudeLeadTurnState = {
   state: AgentStatusState
   interrupted?: true
+  /** The `interrupted` above came from the renderer's keystroke inference, not a hook `is_interrupt`.
+   *  A bare Escape can also just dismiss a /model or /btw overlay, so this optimistic interrupt is
+   *  provisional: the turn's own clean completion Stop clears it instead of carrying it forward. */
+  interruptedInferred?: true
   /** Subagent that induced the wait; only its next tool activity may clear it, so other children's churn can't dismiss a pending human-input card. */
   waitingAgentId?: string
   /** Tool call that owns the wait; late completions from parallel sibling tools must not dismiss its card. */
@@ -47,7 +51,10 @@ export type ClaudeLeadTurnState = {
   /** End time of the lead turn closed while background inventory kept the pane `working`. Repeated on the later all-clear `done`. */
   turnCompletedAt?: number
   /** Lead state a child-induced wait displaced, restored when the wait clears; can't invent 'working' since the done-gate only downgrades done→working, never back. */
-  stateBeforeWait?: Pick<ClaudeLeadTurnState, 'state' | 'interrupted' | 'turnCompletedAt'>
+  stateBeforeWait?: Pick<
+    ClaudeLeadTurnState,
+    'state' | 'interrupted' | 'interruptedInferred' | 'turnCompletedAt'
+  >
 }
 
 export type CodexLeadTurnState = {

--- a/src/shared/agent-hook-listener/providers/claude-events.ts
+++ b/src/shared/agent-hook-listener/providers/claude-events.ts
@@ -262,17 +262,18 @@ export function normalizeClaudeEvent(
   // resolver with one that also reports workingMode, so bridge rather than resolve twice.
   const effectiveState = resolvedStatus.stateName
   // Why: the renderer infers an interrupt from a bare Escape, which it can't tell apart from an Escape
-  // that only dismisses a /model or /btw overlay. Claude emits NO Stop hook on a real interrupt, so a
-  // completion Stop that winds the turn all the way down to a clean `done` proves it was never
-  // interrupted — drop the provisional flag. It stays engaged through the monitoring gate above (so an
-  // interrupt with a running background shell still settles `done`, not monitoring) and a hook-confirmed
-  // interrupt is never provisional.
+  // that only dismisses a /model or /btw overlay. Claude emits NO hook on a real interrupt, so a clean
+  // lead-turn completion — only `Stop`, never a `StopFailure` error boundary — proves the turn was
+  // never interrupted, and drops the provisional flag. It clears even while a subagent still holds the
+  // pane `working` (that gate ignores `interrupted`), but stays engaged while a background shell/cron
+  // drives monitoring, so the interrupt-suppresses-monitoring behavior (#16201) is intact. A
+  // hook-confirmed `is_interrupt` is never provisional.
   const clearsInferredInterrupt =
-    isTurnBoundary &&
+    eventName === 'Stop' &&
     eventAgentId === undefined &&
     !hookConfirmedInterrupt &&
     previousLead?.interruptedInferred === true &&
-    resolvedStatus.stateName === 'done'
+    resolvedStatus.workingMode !== 'monitoring'
   const finalInterrupted = clearsInferredInterrupt ? undefined : interrupted
   // Why: the lead already ended — the pane stays `working` only because background inventory is still registered. `stateStartedAt` is pinned for that whole run, so this end time is the per-turn identity and the later all-clear's pair key.
   const turnCompletedAt =

--- a/src/shared/agent-hook-listener/providers/claude-events.ts
+++ b/src/shared/agent-hook-listener/providers/claude-events.ts
@@ -72,10 +72,9 @@ export function normalizeClaudeEvent(
   const previousLead = state.claudeLeadStateByPaneKey.get(paneKey)
   // Why: only a turn boundary may declare an interrupt or carry a prior one forward; any other event starts a fresh turn and drops it.
   const isTurnBoundary = eventName === 'Stop' || eventName === 'StopFailure'
+  const hookConfirmedInterrupt = eventAgentId === undefined && hookPayload['is_interrupt'] === true
   const interrupted =
-    isTurnBoundary &&
-    ((eventAgentId === undefined && hookPayload['is_interrupt'] === true) ||
-      previousLead?.interrupted === true)
+    isTurnBoundary && (hookConfirmedInterrupt || previousLead?.interrupted === true)
       ? true
       : undefined
   const backgroundTasks = readClaudeBackgroundAgentTasks(hookPayload)
@@ -224,6 +223,8 @@ export function normalizeClaudeEvent(
         : {
             state: previousLead.state,
             ...(previousLead.interrupted ? { interrupted: true as const } : {}),
+            // Why: keep the inference provenance so a clean Stop after the wait clears still drops the provisional interrupt.
+            ...(previousLead.interruptedInferred ? { interruptedInferred: true as const } : {}),
             // Why: a child's permission pause displaces an already-finished lead; keep the end time so the later drain is still that turn's tail.
             ...(previousLead.turnCompletedAt !== undefined
               ? { turnCompletedAt: previousLead.turnCompletedAt }
@@ -260,19 +261,32 @@ export function normalizeClaudeEvent(
   // Why: #15202's compact-completion guard reads the resolved state; this branch replaced the
   // resolver with one that also reports workingMode, so bridge rather than resolve twice.
   const effectiveState = resolvedStatus.stateName
+  // Why: the renderer infers an interrupt from a bare Escape, which it can't tell apart from an Escape
+  // that only dismisses a /model or /btw overlay. Claude emits NO Stop hook on a real interrupt, so a
+  // completion Stop that winds the turn all the way down to a clean `done` proves it was never
+  // interrupted — drop the provisional flag. It stays engaged through the monitoring gate above (so an
+  // interrupt with a running background shell still settles `done`, not monitoring) and a hook-confirmed
+  // interrupt is never provisional.
+  const clearsInferredInterrupt =
+    isTurnBoundary &&
+    eventAgentId === undefined &&
+    !hookConfirmedInterrupt &&
+    previousLead?.interruptedInferred === true &&
+    resolvedStatus.stateName === 'done'
+  const finalInterrupted = clearsInferredInterrupt ? undefined : interrupted
   // Why: the lead already ended — the pane stays `working` only because background inventory is still registered. `stateStartedAt` is pinned for that whole run, so this end time is the per-turn identity and the later all-clear's pair key.
   const turnCompletedAt =
     eventAgentId === undefined &&
     isTurnBoundary &&
     reportedStateName === 'done' &&
     resolvedStatus.stateName === 'working' &&
-    interrupted !== true
+    finalInterrupted !== true
       ? Date.now()
       : undefined
 
   state.claudeLeadStateByPaneKey.set(paneKey, {
     state: reportedStateName,
-    ...(interrupted ? { interrupted } : {}),
+    ...(finalInterrupted ? { interrupted: finalInterrupted } : {}),
     ...(isWaitingInducing && eventAgentId ? { waitingAgentId: eventAgentId } : {}),
     ...(isAskUserQuestionWait && waitingToolUseId !== undefined ? { waitingToolUseId } : {}),
     ...(stateBeforeWait ? { stateBeforeWait } : {}),
@@ -305,7 +319,7 @@ export function normalizeClaudeEvent(
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     ...resolvedStatus,
     updateToolSnapshot: true,
-    interrupted,
+    interrupted: finalInterrupted,
     // Why: a finished compact is a session-shaped boundary, not a completed turn. Without this the
     // clearing `done` would fire completion notifications, unread counts and automation-run
     // completion evidence for work nobody did.

--- a/src/shared/agent-hook-listener/providers/claude-roster-state.ts
+++ b/src/shared/agent-hook-listener/providers/claude-roster-state.ts
@@ -146,7 +146,11 @@ export function resolveClaudePaneStatus(
 }
 /** Sync the Claude lead-turn record when the SERVER infers an interrupt outside the hook stream (Ctrl+C with a missed Stop); else a later child lifecycle event resurrects the cancelled pane. */
 export function markClaudeLeadTurnInterrupted(state: HookListenerState, paneKey: string): void {
-  state.claudeLeadStateByPaneKey.set(paneKey, { state: 'done', interrupted: true })
+  state.claudeLeadStateByPaneKey.set(paneKey, {
+    state: 'done',
+    interrupted: true,
+    interruptedInferred: true
+  })
   state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
   state.claudeActiveSessionCronPaneKeys.delete(paneKey)
 }


### PR DESCRIPTION
## What

Dismissing a Claude slash-command overlay (`/model`, `/btw`, the `/` autocomplete) with Escape while a turn is running can leave that worktree showing a red interrupted status even though the turn was never interrupted and finishes normally.

## Why it happens

The renderer infers a Claude interrupt from a plain Escape sent to the PTY while the pane is `working` (`agent-interrupt-inference.ts` -> `server-status-inference.ts` -> `markClaudeLeadTurnInterrupted`). A bare Escape is ambiguous: it also just closes an overlay without touching the running turn. When the overlay-dismiss Escape lands and Claude then stays quiet past the 500ms settle window (mid-thought, or during a long tool call), the inference fires and marks the pane interrupted. The inferred flag was then carried onto the turn's own completion `Stop`, so a turn that ended cleanly showed a permanent red.

Verified against the real hook stream: a genuine interrupt of a live Claude turn emits **no `Stop` hook at all**, and a normal completion emits a `Stop` with **no `is_interrupt` field**. So a completion `Stop` arriving after an inferred interrupt is proof the turn was never interrupted.

## The fix

Tag inference-sourced interrupts as provisional (`interruptedInferred`) and drop the flag when the turn winds all the way down to a clean `done`. Guardrails:

- A hook-confirmed `is_interrupt: true` is never provisional and always carries, including across a gated working window.
- The provisional flag stays engaged through the monitoring gate, so an interrupt with a running background shell still settles `done` rather than flipping to monitoring (existing behavior preserved).
- A real interrupt (which emits no `Stop`) is never cleared, since nothing arrives to clear it.

## Tests

- New: an inference-only interrupt is cleared by the turn's clean completion `Stop`; a hook-confirmed interrupt survives even though the inference also fired.
- Full `src/shared/agent-hook-listener` and `src/shared/claude` suites pass (293 tests), including the existing interrupt-suppresses-monitoring case. `pnpm tc` and `oxlint` clean.