### PR TITLE
fix(renderer): drop duplicated unifiedTabsByWorktree entries in worktree palette

### DIFF
--- a/src/renderer/src/components/use-worktree-jump-palette-open-tabs.ts
+++ b/src/renderer/src/components/use-worktree-jump-palette-open-tabs.ts
@@ -97,8 +97,7 @@ export function useWorktreeJumpPaletteOpenTabs({
       activeBrowserTabId,
       activeWorktreeId,
       activeWorkspaceExecutionHostId,
-      activeTabType,
-      unifiedTabsByWorktree
+      activeTabType
     })
   }, [
     paletteStatusInputsActive,
@@ -113,7 +112,6 @@ export function useWorktreeJumpPaletteOpenTabs({
     unifiedTabsByWorktree,
     repoByHostIdentity,
     repoMap,
-    unifiedTabsByWorktree,
     worktreeOrder
   ])
   const browserMatches = useMemo(


### PR DESCRIPTION
## Summary

- `main` currently fails `pnpm run typecheck` with TS1117 (duplicate property) in `use-worktree-jump-palette-open-tabs.ts`: #18925 and #19005 each added `unifiedTabsByWorktree` to the same options object, and it also appears twice in the memo's dependency array.
- This drops the redundant occurrences (keeping the one grouped with the other tab/workspace maps). No behavior change — both entries referenced the same value.

## Validation

- `pnpm run typecheck` passes on this branch (fails on `main`).
- Worktree palette suites pass (interleaved sections, status inputs, quick-action availability, browser ownership, sleeping filter — 25 tests).

ELI5: two recent changes each added the same line to the same spot; TypeScript refuses the double entry, so `main`'s typecheck is red until one copy is removed.