### PR TITLE
fix(editor): reuse parked previews across tab groups

### DIFF
--- a/src/renderer/src/store/slices/editor-parked-preview-reuse.test.ts
+++ b/src/renderer/src/store/slices/editor-parked-preview-reuse.test.ts
@@ -1,0 +1,181 @@
+/** Tests parked preview reuse (#11839); split out to keep editor-open-diff.test.ts under max-lines. */
+import { describe, expect, it } from 'vitest'
+import { createEditorTabsStore } from './editor-slice-test-harness'
+
+describe('createEditorSlice parked preview reuse', () => {
+  it('recycles a preview parked in another split group when no target group is given', () => {
+    const store = createEditorTabsStore()
+
+    store.getState().openFile({
+      filePath: '/repo/pinned.ts',
+      relativePath: 'pinned.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+    const groupAId = store.getState().groupsByWorktree['wt-1'][0].id
+    const groupBId = store.getState().createEmptySplitGroup('wt-1', groupAId, 'right')
+    if (!groupBId) {
+      throw new Error('expected split group')
+    }
+    store.getState().openDiff('wt-1', '/repo/a.ts', 'a.ts', 'typescript', false, {
+      preview: true,
+      targetGroupId: groupBId
+    })
+    store.getState().focusGroup('wt-1', groupAId)
+
+    store.getState().openDiff('wt-1', '/repo/b.ts', 'b.ts', 'typescript', false, { preview: true })
+
+    const state = store.getState()
+    expect(state.openFiles).toEqual([
+      expect.objectContaining({ id: '/repo/pinned.ts' }),
+      expect.objectContaining({ id: 'wt-1::diff::unstaged::b.ts', isPreview: true })
+    ])
+    const tabs = state.unifiedTabsByWorktree['wt-1']
+    expect(tabs).toHaveLength(2)
+    expect(tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ groupId: groupAId, entityId: '/repo/pinned.ts' }),
+        expect.objectContaining({
+          groupId: groupBId,
+          entityId: 'wt-1::diff::unstaged::b.ts',
+          isPreview: true
+        })
+      ])
+    )
+  })
+
+  it('recycles a parked preview for file-explorer preview opens from another group', () => {
+    const store = createEditorTabsStore()
+
+    store.getState().openFile({
+      filePath: '/repo/pinned.ts',
+      relativePath: 'pinned.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+    const groupAId = store.getState().groupsByWorktree['wt-1'][0].id
+    const groupBId = store.getState().createEmptySplitGroup('wt-1', groupAId, 'right')
+    if (!groupBId) {
+      throw new Error('expected split group')
+    }
+    store.getState().openDiff('wt-1', '/repo/a.ts', 'a.ts', 'typescript', false, {
+      preview: true,
+      targetGroupId: groupBId
+    })
+    store.getState().focusGroup('wt-1', groupAId)
+
+    store.getState().openFile(
+      {
+        filePath: '/repo/c.ts',
+        relativePath: 'c.ts',
+        worktreeId: 'wt-1',
+        language: 'typescript',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+
+    const state = store.getState()
+    expect(state.openFiles).toEqual([
+      expect.objectContaining({ id: '/repo/pinned.ts' }),
+      expect.objectContaining({ id: '/repo/c.ts', isPreview: true })
+    ])
+    const tabs = state.unifiedTabsByWorktree['wt-1']
+    expect(tabs).toHaveLength(2)
+    expect(tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ groupId: groupAId, entityId: '/repo/pinned.ts' }),
+        expect.objectContaining({ groupId: groupBId, entityId: '/repo/c.ts', isPreview: true })
+      ])
+    )
+  })
+
+  it('re-activates a parked preview tab in place when reopening the same file', () => {
+    const store = createEditorTabsStore()
+
+    store.getState().openFile({
+      filePath: '/repo/pinned.ts',
+      relativePath: 'pinned.ts',
+      worktreeId: 'wt-1',
+      language: 'typescript',
+      mode: 'edit'
+    })
+    const groupAId = store.getState().groupsByWorktree['wt-1'][0].id
+    const groupBId = store.getState().createEmptySplitGroup('wt-1', groupAId, 'right')
+    if (!groupBId) {
+      throw new Error('expected split group')
+    }
+    store.getState().openDiff('wt-1', '/repo/a.ts', 'a.ts', 'typescript', false, {
+      preview: true,
+      targetGroupId: groupBId
+    })
+    store.getState().focusGroup('wt-1', groupAId)
+
+    store.getState().openDiff('wt-1', '/repo/a.ts', 'a.ts', 'typescript', false, { preview: true })
+
+    const state = store.getState()
+    const tabs = state.unifiedTabsByWorktree['wt-1']
+    expect(tabs).toHaveLength(2)
+    expect(tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ groupId: groupAId, entityId: '/repo/pinned.ts' }),
+        expect.objectContaining({
+          groupId: groupBId,
+          entityId: 'wt-1::diff::unstaged::a.ts',
+          isPreview: true
+        })
+      ])
+    )
+  })
+
+  it('leaves a preview parked in the active group behind when the diff column is pinned elsewhere', () => {
+    const store = createEditorTabsStore()
+
+    store.getState().openDiff('wt-1', '/repo/a.ts', 'a.ts', 'typescript', false, { preview: true })
+    const groupAId = store.getState().groupsByWorktree['wt-1'][0].id
+    const groupBId = store.getState().createEmptySplitGroup('wt-1', groupAId, 'right')
+    if (!groupBId) {
+      throw new Error('expected split group')
+    }
+
+    store.getState().openDiff('wt-1', '/repo/b.ts', 'b.ts', 'typescript', false, {
+      preview: true,
+      targetGroupId: groupBId
+    })
+
+    // Why: pinning scopes replacement to the new split, so the parked preview survives once.
+    const tabs = store.getState().unifiedTabsByWorktree['wt-1']
+    expect(tabs).toHaveLength(2)
+    expect(tabs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          groupId: groupAId,
+          entityId: 'wt-1::diff::unstaged::a.ts',
+          isPreview: true
+        }),
+        expect.objectContaining({
+          groupId: groupBId,
+          entityId: 'wt-1::diff::unstaged::b.ts',
+          isPreview: true
+        })
+      ])
+    )
+
+    // Why: once the column is recorded, every later open replaces the split's preview in place.
+    store.getState().openDiff('wt-1', '/repo/c.ts', 'c.ts', 'typescript', false, {
+      preview: true,
+      targetGroupId: groupBId
+    })
+
+    const settled = store.getState().unifiedTabsByWorktree['wt-1']
+    expect(settled).toHaveLength(2)
+    expect(settled).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ groupId: groupAId, entityId: 'wt-1::diff::unstaged::a.ts' }),
+        expect.objectContaining({ groupId: groupBId, entityId: 'wt-1::diff::unstaged::c.ts' })
+      ])
+    )
+  })
+})

--- a/src/renderer/src/store/slices/editor-parked-preview-reuse.test.ts
+++ b/src/renderer/src/store/slices/editor-parked-preview-reuse.test.ts
@@ -179,3 +179,86 @@ describe('createEditorSlice parked preview reuse', () => {
     )
   })
 })
+
+it('prefers the focused group preview', () => {
+  const store = createEditorTabsStore()
+  const open = (name: string, targetGroupId?: string) =>
+    store.getState().openDiff('wt-1', `/repo/${name}`, name, 'typescript', false, {
+      preview: true,
+      targetGroupId
+    })
+  open('a.ts')
+  const a = store.getState().groupsByWorktree['wt-1'][0].id
+  const b = store.getState().createEmptySplitGroup('wt-1', a, 'right')
+  if (!b) {
+    throw new Error('expected split group')
+  }
+  open('b.ts', b)
+  store.getState().focusGroup('wt-1', b)
+  open('c.ts')
+  expect(
+    store.getState().unifiedTabsByWorktree['wt-1'].find((t) => t.entityId.endsWith('c.ts'))?.groupId
+  ).toBe(b)
+})
+it('keeps the backing file for an activated permanent tab', () => {
+  const store = createEditorTabsStore()
+  const open = (name: string) =>
+    store.getState().openFile(
+      {
+        filePath: `/repo/${name}`,
+        relativePath: name,
+        worktreeId: 'wt-1',
+        language: 'typescript',
+        mode: 'edit'
+      },
+      { preview: true }
+    )
+  open('a.ts')
+  const tab = store.getState().unifiedTabsByWorktree['wt-1'][0]
+  store.getState().activateTab(tab.id)
+  expect(store.getState().unifiedTabsByWorktree['wt-1'][0].isPreview).toBe(false)
+  expect(store.getState().openFiles[0].isPreview).toBe(true)
+  open('b.ts')
+  expect(store.getState().openFiles.some((f) => f.id === tab.entityId)).toBe(true)
+})
+
+it('opens a permanent file locally without stealing focus from another group', () => {
+  const store = createEditorTabsStore()
+  const file = {
+    filePath: '/repo/a.ts',
+    relativePath: 'a.ts',
+    worktreeId: 'wt-1',
+    language: 'typescript',
+    mode: 'edit' as const
+  }
+  store.getState().openFile(file)
+  const groupA = store.getState().groupsByWorktree['wt-1'][0].id
+  const groupB = store.getState().createEmptySplitGroup('wt-1', groupA, 'right')
+  if (!groupB) {
+    throw new Error('expected split group')
+  }
+  store.getState().focusGroup('wt-1', groupB)
+  store.getState().openFile(file, { preview: true })
+  const tabs = store.getState().unifiedTabsByWorktree['wt-1']
+  expect(tabs.filter((tab) => tab.entityId === file.filePath).map((tab) => tab.groupId)).toEqual([
+    groupA,
+    groupB
+  ])
+  expect(store.getState().activeGroupIdByWorktree['wt-1']).toBe(groupB)
+})
+
+it('preserves a promoted diff when previewing another diff', () => {
+  const store = createEditorTabsStore()
+  const open = (name: string) =>
+    store.getState().openDiff('wt-1', `/repo/${name}`, name, 'typescript', false, { preview: true })
+  open('a.ts')
+  const tab = store.getState().unifiedTabsByWorktree['wt-1'][0]
+  store.getState().activateTab(tab.id)
+  open('b.ts')
+  expect(store.getState().openFiles.map((file) => file.relativePath)).toEqual(['a.ts', 'b.ts'])
+  expect(store.getState().unifiedTabsByWorktree['wt-1']).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({ id: tab.id, entityId: tab.entityId, isPreview: false })
+    ])
+  )
+})

--- a/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.ts
+++ b/src/renderer/src/store/slices/editor/actions/markdown-preview-actions.ts
@@ -156,8 +156,7 @@ export function createMarkdownPreviewActions(
         file.worktreeId,
         `${file.relativePath} (preview)`,
         'editor',
-        false,
-        options?.targetGroupId
+        { isPreview: false, targetGroupId: options?.targetGroupId }
       )
     },
 

--- a/src/renderer/src/store/slices/editor/actions/open-conflict-file.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-conflict-file.ts
@@ -5,7 +5,7 @@ import type { OpenFile } from '../types/open-file'
 import { toOpenConflictMetadata } from '../git/git-status-reconciliation'
 import { resolveEditorOpenTargetGroupId } from '../tabs/editor-open-target-group'
 import {
-  getReplaceablePreviewFileId,
+  resolveReplaceablePreviewSlot,
   openWorkspaceEditorItem,
   removeEditorStateForReplacedPreview
 } from '../tabs/workspace-editor-item'
@@ -83,16 +83,12 @@ export function createOpenConflictFile(
         }
 
         if (isPreview) {
-          const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
-          const replaceablePreviewIndex = s.openFiles.findIndex(
-            (file) => file.id === replaceablePreviewId
-          )
-          if (replaceablePreviewIndex !== -1) {
+          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          if (slot) {
+            editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {
-              openFiles: s.openFiles.map((file, index) =>
-                index === replaceablePreviewIndex ? newFile : file
-              ),
-              ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex], id),
+              openFiles: s.openFiles.map((file, index) => (index === slot.index ? newFile : file)),
+              ...removeEditorStateForReplacedPreview(s, s.openFiles[slot.index], id),
               activeFileId: id,
               activeTabType: 'editor',
               activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
@@ -121,15 +117,11 @@ export function createOpenConflictFile(
       if (!openedConflictFile) {
         return
       }
-      void openWorkspaceEditorItem(
-        get(),
-        absolutePath,
-        worktreeId,
-        entry.path,
-        'editor',
+      void openWorkspaceEditorItem(get(), absolutePath, worktreeId, entry.path, 'editor', {
         isPreview,
-        editorItemTargetGroupId
-      )
+        targetGroupId: editorItemTargetGroupId,
+        pinnedGroupId: options?.targetGroupId
+      })
     }
   }
 }

--- a/src/renderer/src/store/slices/editor/actions/open-conflict-file.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-conflict-file.ts
@@ -83,7 +83,12 @@ export function createOpenConflictFile(
         }
 
         if (isPreview) {
-          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          const slot = resolveReplaceablePreviewSlot(
+            s,
+            worktreeId,
+            options?.targetGroupId,
+            targetGroupId
+          )
           if (slot) {
             editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {

--- a/src/renderer/src/store/slices/editor/actions/open-conflict-review.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-conflict-review.ts
@@ -98,15 +98,9 @@ export function createOpenConflictReview(
         return
       }
       // Why: the conflict file needs a normal editor backing tab for save/close, but selecting from Conflict Review must keep the review tab visible; restore focus after.
-      void openWorkspaceEditorItem(
-        get(),
-        absolutePath,
-        worktreeId,
-        entry.path,
-        'editor',
-        undefined,
-        reviewTab?.groupId
-      )
+      void openWorkspaceEditorItem(get(), absolutePath, worktreeId, entry.path, 'editor', {
+        targetGroupId: reviewTab?.groupId
+      })
       if (reviewTab) {
         get().activateTab?.(reviewTab.id)
       }

--- a/src/renderer/src/store/slices/editor/actions/open-file-action.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-action.ts
@@ -34,8 +34,11 @@ export function createOpenFileAction(
         editorItemWorktreeId,
         editorItemLabel,
         editorItemContentType,
-        options?.preview ?? false,
-        scratch.editorItemTargetGroupId
+        {
+          isPreview: options?.preview ?? false,
+          targetGroupId: scratch.editorItemTargetGroupId,
+          pinnedGroupId: options?.targetGroupId
+        }
       )
       if (options?.focusEditor) {
         set({

--- a/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
@@ -21,7 +21,7 @@ import {
   resolveEditorOpenTargetGroupId
 } from '../tabs/editor-open-target-group'
 import {
-  getReplaceablePreviewFileId,
+  resolveReplaceablePreviewSlot,
   removeEditorStateForReplacedPreview
 } from '../tabs/workspace-editor-item'
 
@@ -162,12 +162,13 @@ export function applyOpenFileToState(
     }
   }
 
-  // Why: scope preview replacement to worktreeId + targetGroupId so link clicks in group B don't evict group A's previews.
+  // Why: preview replacement is worktree-scoped — recycle the parked preview wherever it lives; an explicit target keeps group scoping.
   let newFiles = s.openFiles
   if (isPreview) {
-    const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
-    const existingPreviewIdx = s.openFiles.findIndex((f) => f.id === replaceablePreviewId)
-    if (existingPreviewIdx !== -1) {
+    const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+    if (slot) {
+      scratch.editorItemTargetGroupId = slot.retargetGroupId ?? scratch.editorItemTargetGroupId
+      const existingPreviewIdx = slot.index
       const replacedPreview = s.openFiles[existingPreviewIdx]
       // Why: reuse the shared eviction helper so per-file cursor/draft/visibility cleanup stays in one place.
       const {

--- a/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-file-apply.ts
@@ -165,7 +165,7 @@ export function applyOpenFileToState(
   // Why: preview replacement is worktree-scoped — recycle the parked preview wherever it lives; an explicit target keeps group scoping.
   let newFiles = s.openFiles
   if (isPreview) {
-    const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+    const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId, targetGroupId)
     if (slot) {
       scratch.editorItemTargetGroupId = slot.retargetGroupId ?? scratch.editorItemTargetGroupId
       const existingPreviewIdx = slot.index

--- a/src/renderer/src/store/slices/editor/actions/open-history-diff.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-history-diff.ts
@@ -7,7 +7,7 @@ import { resolveDiffRuntimeEnvironmentId } from '../git/diff-runtime-owner'
 import { toBranchCompareSnapshot, toCommitCompareSnapshot } from '../git/git-status-reconciliation'
 import { resolveEditorOpenTargetGroupId } from '../tabs/editor-open-target-group'
 import {
-  getReplaceablePreviewFileId,
+  resolveReplaceablePreviewSlot,
   openWorkspaceEditorItem,
   removeEditorStateForReplacedPreview
 } from '../tabs/workspace-editor-item'
@@ -72,16 +72,12 @@ export function createOpenHistoryDiff(
           runtimeEnvironmentId
         }
         if (isPreview) {
-          const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
-          const replaceablePreviewIndex = s.openFiles.findIndex(
-            (file) => file.id === replaceablePreviewId
-          )
-          if (replaceablePreviewIndex !== -1) {
+          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          if (slot) {
+            editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {
-              openFiles: s.openFiles.map((file, index) =>
-                index === replaceablePreviewIndex ? newFile : file
-              ),
-              ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex], id),
+              openFiles: s.openFiles.map((file, index) => (index === slot.index ? newFile : file)),
+              ...removeEditorStateForReplacedPreview(s, s.openFiles[slot.index], id),
               activeFileId: id,
               activeTabType: 'editor',
               activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
@@ -97,15 +93,11 @@ export function createOpenHistoryDiff(
           activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
         }
       })
-      void openWorkspaceEditorItem(
-        get(),
-        id,
-        worktreeId,
-        entry.path,
-        'diff',
+      void openWorkspaceEditorItem(get(), id, worktreeId, entry.path, 'diff', {
         isPreview,
-        editorItemTargetGroupId
-      )
+        targetGroupId: editorItemTargetGroupId,
+        pinnedGroupId: options?.targetGroupId
+      })
     },
 
     openCommitDiff: (worktreeId, worktreePath, entry, compare, language, options) => {
@@ -163,16 +155,12 @@ export function createOpenHistoryDiff(
           runtimeEnvironmentId
         }
         if (isPreview) {
-          const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
-          const replaceablePreviewIndex = s.openFiles.findIndex(
-            (file) => file.id === replaceablePreviewId
-          )
-          if (replaceablePreviewIndex !== -1) {
+          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          if (slot) {
+            editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {
-              openFiles: s.openFiles.map((file, index) =>
-                index === replaceablePreviewIndex ? newFile : file
-              ),
-              ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex], id),
+              openFiles: s.openFiles.map((file, index) => (index === slot.index ? newFile : file)),
+              ...removeEditorStateForReplacedPreview(s, s.openFiles[slot.index], id),
               activeFileId: id,
               activeTabType: 'editor',
               activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
@@ -188,15 +176,11 @@ export function createOpenHistoryDiff(
           activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
         }
       })
-      void openWorkspaceEditorItem(
-        get(),
-        id,
-        worktreeId,
-        entry.path,
-        'diff',
+      void openWorkspaceEditorItem(get(), id, worktreeId, entry.path, 'diff', {
         isPreview,
-        editorItemTargetGroupId
-      )
+        targetGroupId: editorItemTargetGroupId,
+        pinnedGroupId: options?.targetGroupId
+      })
     }
   }
 }

--- a/src/renderer/src/store/slices/editor/actions/open-history-diff.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-history-diff.ts
@@ -72,7 +72,12 @@ export function createOpenHistoryDiff(
           runtimeEnvironmentId
         }
         if (isPreview) {
-          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          const slot = resolveReplaceablePreviewSlot(
+            s,
+            worktreeId,
+            options?.targetGroupId,
+            targetGroupId
+          )
           if (slot) {
             editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {
@@ -155,7 +160,12 @@ export function createOpenHistoryDiff(
           runtimeEnvironmentId
         }
         if (isPreview) {
-          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          const slot = resolveReplaceablePreviewSlot(
+            s,
+            worktreeId,
+            options?.targetGroupId,
+            targetGroupId
+          )
           if (slot) {
             editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {

--- a/src/renderer/src/store/slices/editor/actions/open-unstaged-diff.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-unstaged-diff.ts
@@ -5,7 +5,7 @@ import { buildDiffEditorFileId, withDiffContentReloadRequest } from '../file-ids
 import { resolveDiffRuntimeEnvironmentId } from '../git/diff-runtime-owner'
 import { resolveEditorOpenTargetGroupId } from '../tabs/editor-open-target-group'
 import {
-  getReplaceablePreviewFileId,
+  resolveReplaceablePreviewSlot,
   openWorkspaceEditorItem,
   removeEditorStateForReplacedPreview
 } from '../tabs/workspace-editor-item'
@@ -68,16 +68,12 @@ export function createOpenUnstagedDiff(
           runtimeEnvironmentId
         }
         if (isPreview) {
-          const replaceablePreviewId = getReplaceablePreviewFileId(s, worktreeId, targetGroupId)
-          const replaceablePreviewIndex = s.openFiles.findIndex(
-            (file) => file.id === replaceablePreviewId
-          )
-          if (replaceablePreviewIndex !== -1) {
+          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          if (slot) {
+            editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {
-              openFiles: s.openFiles.map((file, index) =>
-                index === replaceablePreviewIndex ? newFile : file
-              ),
-              ...removeEditorStateForReplacedPreview(s, s.openFiles[replaceablePreviewIndex], id),
+              openFiles: s.openFiles.map((file, index) => (index === slot.index ? newFile : file)),
+              ...removeEditorStateForReplacedPreview(s, s.openFiles[slot.index], id),
               activeFileId: id,
               activeTabType: 'editor',
               activeFileIdByWorktree: { ...s.activeFileIdByWorktree, [worktreeId]: id },
@@ -93,15 +89,11 @@ export function createOpenUnstagedDiff(
           activeTabTypeByWorktree: { ...s.activeTabTypeByWorktree, [worktreeId]: 'editor' }
         }
       })
-      void openWorkspaceEditorItem(
-        get(),
-        editorItemFileId,
-        worktreeId,
-        relativePath,
-        'diff',
+      void openWorkspaceEditorItem(get(), editorItemFileId, worktreeId, relativePath, 'diff', {
         isPreview,
-        editorItemTargetGroupId
-      )
+        targetGroupId: editorItemTargetGroupId,
+        pinnedGroupId: options?.targetGroupId
+      })
     }
   }
 }

--- a/src/renderer/src/store/slices/editor/actions/open-unstaged-diff.ts
+++ b/src/renderer/src/store/slices/editor/actions/open-unstaged-diff.ts
@@ -68,7 +68,12 @@ export function createOpenUnstagedDiff(
           runtimeEnvironmentId
         }
         if (isPreview) {
-          const slot = resolveReplaceablePreviewSlot(s, worktreeId, options?.targetGroupId)
+          const slot = resolveReplaceablePreviewSlot(
+            s,
+            worktreeId,
+            options?.targetGroupId,
+            targetGroupId
+          )
           if (slot) {
             editorItemTargetGroupId = slot.retargetGroupId ?? editorItemTargetGroupId
             return {

--- a/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
+++ b/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
@@ -4,15 +4,33 @@ import type { OpenFile } from '../types/open-file'
 import { resolveEditorOpenTargetGroupId } from './editor-open-target-group'
 import { isEditorTabContentType } from './editor-tab-content-type'
 
+type WorkspaceEditorItemOpen = {
+  isPreview?: boolean
+  /** Where to open; may already be retargeted to a parked preview's group. */
+  targetGroupId?: string
+  /** Group the caller pinned. Absent marks an unpinned open, free to reuse the entity's tab in any group. */
+  pinnedGroupId?: string
+}
+
 export function openWorkspaceEditorItem(
   state: AppState,
   fileId: string,
   worktreeId: string,
   label: string,
   contentType: 'editor' | 'diff' | 'conflict-review' | 'check-details',
-  isPreview?: boolean,
-  targetGroupId?: string
+  open?: WorkspaceEditorItemOpen
 ): string {
+  const { isPreview, targetGroupId, pinnedGroupId } = open ?? {}
+  // Why: unpinned previews re-activate the entity's tab wherever it lives (#11839).
+  if (isPreview && !pinnedGroupId) {
+    const existingAnywhere = (state.unifiedTabsByWorktree?.[worktreeId] ?? []).find(
+      (tab) => tab.entityId === fileId && tab.contentType === contentType
+    )
+    if (existingAnywhere) {
+      state.activateTab?.(existingAnywhere.id, { preservePreview: isPreview })
+      return existingAnywhere.id
+    }
+  }
   const resolvedGroupId = resolveEditorOpenTargetGroupId(state, worktreeId, targetGroupId)
   if (resolvedGroupId) {
     const existing = state.findTabForEntityInGroup?.(
@@ -35,40 +53,54 @@ export function openWorkspaceEditorItem(
   })
   return created?.id ?? fileId
 }
-export function getReplaceablePreviewFileId(
+
+export type ReplaceablePreviewSlot = {
+  /** Index into `openFiles` of the preview entry to overwrite in place. */
+  index: number
+  /** Group holding that preview; undefined when the caller pinned a target group. */
+  retargetGroupId: string | undefined
+}
+
+// Why: unpinned preview reuse is worktree-scoped; pinned opens keep old group scoping.
+export function resolveReplaceablePreviewSlot(
   state: Pick<AppState, 'openFiles' | 'unifiedTabsByWorktree'>,
   worktreeId: string,
-  targetGroupId: string | undefined
-): string | null {
+  pinnedGroupId: string | undefined
+): ReplaceablePreviewSlot | null {
   const tabsForWorktree = state.unifiedTabsByWorktree?.[worktreeId] ?? []
-  if (targetGroupId) {
-    const previewTab = tabsForWorktree.find(
-      (tab) =>
-        tab.groupId === targetGroupId && tab.isPreview && isEditorTabContentType(tab.contentType)
-    )
-    if (!previewTab) {
-      return null
-    }
-    // Why: split groups can share one OpenFile; a group-scoped preview replacement must not mutate it out from under another group's tab.
-    const isSharedEntity = tabsForWorktree.some(
-      (tab) =>
-        tab.id !== previewTab.id &&
-        tab.entityId === previewTab.entityId &&
-        isEditorTabContentType(tab.contentType)
-    )
-    if (isSharedEntity) {
-      return null
-    }
-    return (
-      state.openFiles.find(
-        (file) =>
-          file.id === previewTab.entityId && file.worktreeId === worktreeId && file.isPreview
-      )?.id ?? null
-    )
-  }
-  return (
-    state.openFiles.find((file) => file.worktreeId === worktreeId && file.isPreview)?.id ?? null
+  const previewTab = tabsForWorktree.find(
+    (tab) =>
+      (!pinnedGroupId || tab.groupId === pinnedGroupId) &&
+      tab.isPreview &&
+      isEditorTabContentType(tab.contentType)
   )
+  if (!previewTab) {
+    // Why: without tab-layer state, only unpinned opens may fall back to the worktree preview.
+    if (pinnedGroupId) {
+      return null
+    }
+    const index = state.openFiles.findIndex(
+      (file) => file.worktreeId === worktreeId && file.isPreview
+    )
+    return index === -1 ? null : { index, retargetGroupId: undefined }
+  }
+  // Why: split groups can share one OpenFile; replacing it would mutate it out from under another group's tab.
+  const isSharedEntity = tabsForWorktree.some(
+    (tab) =>
+      tab.id !== previewTab.id &&
+      tab.entityId === previewTab.entityId &&
+      isEditorTabContentType(tab.contentType)
+  )
+  if (isSharedEntity) {
+    return null
+  }
+  const index = state.openFiles.findIndex(
+    (file) => file.id === previewTab.entityId && file.worktreeId === worktreeId && file.isPreview
+  )
+  if (index === -1) {
+    return null
+  }
+  return { index, retargetGroupId: pinnedGroupId ? undefined : previewTab.groupId }
 }
 
 export function removeEditorStateForReplacedPreview(

--- a/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
+++ b/src/renderer/src/store/slices/editor/tabs/workspace-editor-item.ts
@@ -24,7 +24,7 @@ export function openWorkspaceEditorItem(
   // Why: unpinned previews re-activate the entity's tab wherever it lives (#11839).
   if (isPreview && !pinnedGroupId) {
     const existingAnywhere = (state.unifiedTabsByWorktree?.[worktreeId] ?? []).find(
-      (tab) => tab.entityId === fileId && tab.contentType === contentType
+      (tab) => tab.isPreview && tab.entityId === fileId && tab.contentType === contentType
     )
     if (existingAnywhere) {
       state.activateTab?.(existingAnywhere.id, { preservePreview: isPreview })
@@ -65,18 +65,20 @@ export type ReplaceablePreviewSlot = {
 export function resolveReplaceablePreviewSlot(
   state: Pick<AppState, 'openFiles' | 'unifiedTabsByWorktree'>,
   worktreeId: string,
-  pinnedGroupId: string | undefined
+  pinnedGroupId: string | undefined,
+  resolvedGroupId: string | undefined
 ): ReplaceablePreviewSlot | null {
   const tabsForWorktree = state.unifiedTabsByWorktree?.[worktreeId] ?? []
-  const previewTab = tabsForWorktree.find(
-    (tab) =>
-      (!pinnedGroupId || tab.groupId === pinnedGroupId) &&
-      tab.isPreview &&
-      isEditorTabContentType(tab.contentType)
-  )
+  const isPreviewCandidate = (tab: (typeof tabsForWorktree)[number]): boolean =>
+    (!pinnedGroupId || tab.groupId === pinnedGroupId) &&
+    !!tab.isPreview &&
+    isEditorTabContentType(tab.contentType)
+  const previewTab =
+    tabsForWorktree.find((tab) => tab.groupId === resolvedGroupId && isPreviewCandidate(tab)) ??
+    tabsForWorktree.find(isPreviewCandidate)
   if (!previewTab) {
-    // Why: without tab-layer state, only unpinned opens may fall back to the worktree preview.
-    if (pinnedGroupId) {
+    // Tab-layer promotion can leave OpenFile.isPreview stale; only headless state may fall back.
+    if (pinnedGroupId || resolvedGroupId || tabsForWorktree.length > 0) {
       return null
     }
     const index = state.openFiles.findIndex(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​113 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

## ELI5

After focusing a terminal, clicking another changed file now updates the preview parked in a neighboring split instead of opening a second preview over the terminal.

## What Changed / Why

Part 1 of the split of #11866. Unpinned editor and diff previews reuse the existing preview across tab groups within the workspace. Explicitly targeted opens keep group scoping, and previews sharing an editor entity remain protected. Includes the editor open-call contract and parked-preview regression tests.

The optional Source Control side-split setting is isolated in #19182, based on this branch. Merge this fix first, then retarget part 2 to `main`.

Original implementation by **Dan Cieslak (@dcieslak19973)** in #11866; his Git commit authorship is preserved. This PR extracts and rebases his fix onto current `main`.

## Linked Issue

Addresses the parked-preview bug in #11839. Split from #11866.

## Visual Proof

These are the original PR’s Electron/CDP captures, reused as historical evidence; rendered validation was not rerun on this split head.

Before the click: preview parked beside the focused terminal.

![Parked preview](https://github.com/user-attachments/assets/393adc62-abb0-4a65-a9a2-a0c70f0ed838)

After clicking another changed file: the parked preview is reused.

![Preview reused](https://github.com/user-attachments/assets/1f199987-8289-42e5-b0b2-358ae51a2e05)

## Testing

- 56 tests passed on the isolated fix: parked-preview reuse, tab placement, open diff, close-file cleanup, and branch-diff snapshots.
- Web typecheck and targeted oxlint passed.
- Full lint, build, platform matrix, and fresh rendered validation are left to CI/follow-up review.

## Review

Checked explicit group scoping, shared preview entities, per-file cleanup, and workspace isolation. No new platform shortcuts, filesystem operations, Git commands, execution-host assumptions, or remote wire fields. Existing folder/SSH editor paths remain in use.

## Agent skill upstream boundary

- [x] Not applicable.
