### PR TITLE
fix: forward Cmd+E dictation chord when voice is on but no STT model is set

### DIFF
--- a/src/main/window/createMainWindow-terminal-focus-shortcuts.test.ts
+++ b/src/main/window/createMainWindow-terminal-focus-shortcuts.test.ts
@@ -118,6 +118,75 @@ describe('createMainWindow', () => {
     expect(webContents.send).not.toHaveBeenCalled()
   })
 
+  it('still forwards the toggle-mode dictation chord when no STT model is selected (#18691)', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(() => Promise.resolve()),
+      loadURL: vi.fn(() => Promise.resolve())
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    // Voice is on, but the user never downloaded/selected an STT model —
+    // the renderer's startDictation() is responsible for surfacing that.
+    const voice = { enabled: true, sttModel: '', dictationMode: 'toggle' as const }
+    createMainWindow({
+      getUI: () => ({}) as never,
+      getSettings: () => ({ windowBackgroundBlur: false, voice }) as never,
+      updateUI: vi.fn()
+    } as never)
+
+    const isDarwin = process.platform === 'darwin'
+    const dictationInput = {
+      type: 'keyDown',
+      code: 'KeyE',
+      key: 'e',
+      meta: isDarwin,
+      control: !isDarwin,
+      alt: false,
+      shift: false
+    }
+
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event']({ preventDefault } as never, dictationInput as never)
+    expect(preventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.send).toHaveBeenCalledWith('ui:dictationKeyDown')
+
+    // Voice fully disabled must still be a no-op, model or not.
+    webContents.send.mockClear()
+    voice.enabled = false
+    const disabledPreventDefault = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault: disabledPreventDefault } as never,
+      dictationInput as never
+    )
+    expect(disabledPreventDefault).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalled()
+  })
+
   it('only intercepts double-tap dictation when enabled toggle mode can handle it', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/main-window-shortcut-routing.ts
+++ b/src/main/window/main-window-shortcut-routing.ts
@@ -71,7 +71,9 @@ export function installMainWindowShortcutRouting(args: {
     // Why: hold-mode dictation needs renderer keyup events, so main only consumes single-keydown dictation toggles.
     if (action.type === 'dictationKeyDown') {
       const voiceSettings = store?.getSettings().voice
-      if (!voiceSettings?.enabled || !voiceSettings.sttModel) {
+      // Why: forward the chord even without a selected model — the renderer's
+      // startDictation() is what surfaces the "No speech model selected" toast.
+      if (!voiceSettings?.enabled) {
         return false
       }
       const dictationMode = voiceSettings.dictationMode ?? 'toggle'

--- a/src/renderer/src/components/dictation/DictationController.tsx
+++ b/src/renderer/src/components/dictation/DictationController.tsx
@@ -287,11 +287,9 @@ export function DictationController() {
     }
 
     const handleKeyDown = (): void => {
-      if (
-        !settings?.voice?.enabled ||
-        !settings.voice.sttModel ||
-        dictationStateRef.current === 'stopping'
-      ) {
+      // Why: no early-return on a missing sttModel — startDictation() below is what
+      // owns the "No speech model selected" toast, so it must still get called.
+      if (!settings?.voice?.enabled || dictationStateRef.current === 'stopping') {
         return
       }
       if (dictationStateRef.current === 'listening' || dictationStateRef.current === 'starting') {
@@ -312,7 +310,9 @@ export function DictationController() {
   ])
 
   useEffect(() => {
-    const canDictate = (): boolean => Boolean(settings?.voice?.enabled && settings.voice.sttModel)
+    // Why: same as handleKeyDown above — don't gate on sttModel here, or
+    // startDictation()'s "No speech model selected" toast never gets a chance to fire.
+    const canDictate = (): boolean => Boolean(settings?.voice?.enabled)
     const handleControl = (event: Event): void => {
       if (!canDictate() || dictationStateRef.current === 'stopping') {
         return


### PR DESCRIPTION
## ELI5

Turning on voice dictation but not picking a speech model made `Cmd+E` completely dead — no toast, no error, nothing. This restores the existing "pick a model" toast for that case.

## What Changed

- `src/main/window/main-window-shortcut-routing.ts`: the `dictationKeyDown` chord handler no longer bails out when `voiceSettings.sttModel` is empty — it only checks `voiceSettings.enabled` now, so the chord still gets consumed and forwarded to the renderer.
- `src/renderer/src/components/dictation/DictationController.tsx`: the toggle-mode `handleKeyDown` (fed by the IPC event above) and the `handleControl`/`canDictate()` path used by the mic button in native chat had the *same* `!sttModel` early-return, which would have silently swallowed the event again even after the main-process fix. Removed both so they fall through to `startDictation()`, which already owns the "No speech model selected. Download one in Settings > Voice." toast.

## Why

`startDictation()` already implements the correct toast + "Open Settings" action for a missing model. The bug wasn't a missing toast — it was three separate call sites (main-process router, renderer keydown listener, renderer control-event listener) that all independently short-circuited on `!sttModel` *before* that function ever got a chance to run. Fixing only the reported main-process spot would not have been enough, since the renderer's own listener has the identical guard and would still have swallowed the forwarded event.

Hold-mode dictation (`use-hold-dictation-gesture.ts`) has the same `!sttModel` early-return, but it's a separate keyboard-only code path unrelated to this issue's repro steps (toggle mode), so I left it out of this PR to keep the diff focused — happy to send a follow-up if that's wanted.

## Linked Issue

Fixes #18691

## Visual Proof

N/A — I don't have a way to run the full Electron app with a display in this environment to capture a screenshot/video. Verified instead with a deterministic unit test exercising the exact `before-input-event` → `webContents.send` path (see Testing below). A reviewer can confirm visually by: Settings → Voice → enable, don't select a model → press Cmd+E → toast should now appear instead of nothing happening.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally (no display available in this environment — see note above)

Added a new case to `createMainWindow-terminal-focus-shortcuts.test.ts`: `voice = { enabled: true, sttModel: '', dictationMode: 'toggle' }` now asserts `preventDefault` **is** called and `webContents.send('ui:dictationKeyDown')` **is** called (previously neither fired), plus keeps a case confirming `enabled: false` is still a no-op regardless of model.

Ran the full existing suite for the touched areas to check for regressions (all green, 134/134): `createMainWindow-terminal-focus-shortcuts.test.ts`, `createMainWindow-zoom-and-tab-switch-shortcuts.test.ts`, `createMainWindow.test.ts`, everything under `src/renderer/src/components/dictation/`, `NativeChatComposer.test.tsx`, `native-chat-structured-send-composition-clear.test.tsx`, `dictation-model-state-stabilisation.test.ts`.

`oxlint` clean on touched files. `tsc --noEmit` for both the node and web projects shows zero new errors introduced by this change (pre-existing unrelated errors from a missing `@anthropic-ai/claude-agent-sdk` type declaration exist on `upstream/main` before this change too).

## AI Disclosure

Claude (Anthropic) was used to investigate the report, reproduce it with a failing-then-passing test, and implement/verify the fix.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Scoped to macOS/Windows/Linux equally — the changed code is the shared cross-platform shortcut router and a shared React component, no platform-specific branching touched. No SSH/remote/mobile surface involved (dictation is local-input only).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran targeted lint/typecheck/test for touched files locally; full `pnpm build` not run locally, deferring to CI
