### PR TITLE
test: restore snapshot path before draining hydration FIFO

### DIFF
--- a/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
+++ b/tests/e2e/ssh-cold-hydration-gap-tab-seeding.spec.ts
@@ -128,8 +128,16 @@ function unblockRemoteWorkspaceGet(
   snapshotPath: string,
   saved: string
 ): void {
-  // Detached: a FIFO write blocks until the reader drains it, which must not stall the test.
-  spawnSync('docker', [
+  const replacementPath = `${snapshotPath}.release`
+  const releaseScript = [
+    `printf '%s' ${shellQuote(saved)} > ${shellQuote(replacementPath)}`,
+    `exec 3> ${shellQuote(snapshotPath)}`,
+    // Publish the complete file before the held reader can issue another snapshot read.
+    `mv -f ${shellQuote(replacementPath)} ${shellQuote(snapshotPath)}`,
+    `printf '%s' ${shellQuote(saved)} >&3`,
+    'exec 3>&-'
+  ].join(' && ')
+  const release = spawnSync('docker', [
     'exec',
     '-d',
     target.containerName,
@@ -137,8 +145,10 @@ function unblockRemoteWorkspaceGet(
     '--noprofile',
     '--norc',
     '-c',
-    `printf '%s' ${shellQuote(saved)} > ${snapshotPath} && rm -f ${snapshotPath} && printf '%s' ${shellQuote(saved)} > ${snapshotPath}`
+    releaseScript
   ])
+  expect(release.error, 'failed to launch the snapshot release writer').toBeUndefined()
+  expect(release.status, release.stderr?.toString()).toBe(0)
 }
 
 async function connectAndSeedTabs(


### PR DESCRIPTION
The cold-hydration fixture drains its held FIFO before replacing the path, allowing the relay's next synchronous snapshot read to reopen the FIFO with no writer. Prepare the complete snapshot, open the held FIFO descriptor, atomically replace the path, then drain that descriptor. Check detached Docker writer launch success. Original snapshot bytes, hydration timeout, and tab-identity assertions are preserved.

A deterministic filesystem-only interleaving demonstrated that the original sequence exposes the FIFO to the next reader while replacement-before-drain exposes a regular file. The observed CI hydration timeout is consistent with this race but lacks writer receipts, so its cause is not conclusively established. Baseline diagnostics passed 3/3 with complete release receipts; candidate rendered CI passed the original scenario3/3 with zero skips or retries; exact report participation verified: https://github.com/stablyai/orca/actions/runs/34077702477. Lint passed. No application changes.
