### PR TITLE
test: return paired browser state from the successful poll

### DIFF
--- a/tests/e2e/paired-client-hosted-browser.spec.ts
+++ b/tests/e2e/paired-client-hosted-browser.spec.ts
@@ -151,13 +151,19 @@ async function waitForMirroredBrowserPage(
   worktreeId: string,
   url: string
 ): Promise<MirroredBrowserPage> {
+  let mirrored: MirroredBrowserPage | null = null
   await expect
-    .poll(() => findMirroredBrowserPage(page, worktreeId, url), {
-      timeout: 20_000,
-      message: `paired client never materialized ${url}`
-    })
+    .poll(
+      async () => {
+        mirrored = await findMirroredBrowserPage(page, worktreeId, url)
+        return mirrored
+      },
+      {
+        timeout: 20_000,
+        message: `paired client never materialized ${url}`
+      }
+    )
     .not.toBeNull()
-  const mirrored = await findMirroredBrowserPage(page, worktreeId, url)
   if (!mirrored) {
     throw new Error(`Mirrored browser page disappeared for ${url}`)
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

The paired-browser journey polls until a mirrored page exists, then performs a second independent read. Integrated main CI failed in that second read with “Mirrored browser page disappeared” even though the poll had succeeded. Return the page value observed by the successful poll instead.

Retain the timeout, non-null requirement, placement checks, guest-content checks, server/client ownership checks, and kill-switch assertions. This removes the extra read race; subsequent assertions still validate the returned page end to end. Lint passed. Both desktop-host and headless-host journeys are running three times each with retries disabled: https://github.com/stablyai/orca/actions/runs/34078208663. Baseline failure: https://github.com/stablyai/orca/actions/runs/34076345792/job/101603262702.
