### PR TITLE
test: align worker recovery fixture with ownership policy

### DIFF
--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -284,6 +284,42 @@ test('compiled CLI rejects false completion then reconciles the dead retained wo
     db.close()
   }
 
+  const retained = invokeCompiledCli(userDataDir, [
+    'orchestration',
+    'worker-release',
+    '--dispatch',
+    dispatch.result.dispatch!.id,
+    '--json'
+  ])
+  expect(retained.status).toBe(0)
+  expect(JSON.parse(retained.stdout)).toMatchObject({
+    ok: true,
+    result: { state: 'retained', reason: 'external_terminal', processAction: 'none' }
+  })
+  const recovery = new Database(path.join(userDataDir, 'orchestration.db'))
+  try {
+    expect(
+      recovery
+        .prepare(
+          'SELECT ownership_state, release_state FROM worker_terminal_resources WHERE owner_dispatch_id = ?'
+        )
+        .get(dispatch.result.dispatch!.id)
+    ).toEqual({ ownership_state: 'external', release_state: 'retained' })
+    // Seed the owned, abandoned recovery state after separately proving completion and external retention.
+    recovery
+      .prepare(
+        "UPDATE worker_terminal_resources SET ownership_state = 'owned', retained_reason = 'user_requested' WHERE owner_dispatch_id = ?"
+      )
+      .run(dispatch.result.dispatch!.id)
+    recovery
+      .prepare(
+        "UPDATE worker_dispatches SET state = 'abandoned', stage = 'abandoned' WHERE dispatch_id = ?"
+      )
+      .run(dispatch.result.dispatch!.id)
+  } finally {
+    recovery.close()
+  }
+
   const released = invokeCompiledCli(userDataDir, [
     'orchestration',
     'worker-release',


### PR DESCRIPTION
The compiled worker-release journey marks a dead resource `external` and expects it to be released, contradicting the current ownership policy and its unit tests. It fails consistently even when the execution host proves the process exited.

First assert through the compiled CLI and database that external ownership stays retained. Then explicitly seed the owned, retained, recovery-abandoned fixture state and retain the original release receipt, released database state, false-completion rejection, valid completion, and coordinator-survival assertions. This mirrors existing worker-release ownership-guard coverage without changing application policy.

Validation: baseline diagnostic reproduced 3/3 with `exited` host verdicts; database diagnostics confirmed settled dispatches and matching incarnation, while the ownership table intentionally rejects `external`. Lint passed. Candidate journey passed three times with zero skips or retries, including both external-retention and owned-release assertions; downloaded JSON participation verified: https://github.com/stablyai/orca/actions/runs/34078522738. Fixture database edits are confined to the disposable E2E profile.
