### PR TITLE
fix(automations): reuse a provably live idle pane when its agent status row is gone

### DIFF
--- a/src/renderer/src/lib/automation-session-reuse.test.ts
+++ b/src/renderer/src/lib/automation-session-reuse.test.ts
@@ -212,4 +212,96 @@ describe('automation session reuse', () => {
 
     expect(session).toBeNull()
   })
+
+  // Why: a long-idle seed can outlive its status row, and requiring the row made
+  // reuse fail forever for slow-cadence automations while #9493 kept every
+  // un-reused session resident (#19193).
+  it('reuses a provably live pane whose agent status row is absent', () => {
+    const session = findReusableAutomationSession({
+      automationId: 'auto-1',
+      agentId: 'claude',
+      worktreeId: 'wt-1',
+      currentRunId: 'run-current',
+      runs: [run({ id: 'run-new', terminalSessionId: 'tab-1', createdAt: 2 })],
+      state: {
+        agentStatusByPaneKey: {},
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        terminalLayoutsByTabId: { 'tab-1': { ptyIdsByLeafId: { [leafId]: 'pty-1' } } },
+        unifiedTabsByWorktree: {
+          'wt-1': [{ contentType: 'terminal', entityId: 'tab-1' }]
+        }
+      } as never
+    })
+
+    expect(session).toEqual({ tabId: 'tab-1', ptyId: 'pty-1', paneKey })
+  })
+
+  it('still rejects a missing status row when the pane itself is not live', () => {
+    const session = findReusableAutomationSession({
+      automationId: 'auto-1',
+      agentId: 'claude',
+      worktreeId: 'wt-1',
+      currentRunId: 'run-current',
+      runs: [run({ id: 'run-new', terminalSessionId: 'tab-1', createdAt: 2 })],
+      state: {
+        agentStatusByPaneKey: {},
+        ptyIdsByTabId: { 'tab-1': ['pty-other'] },
+        terminalLayoutsByTabId: { 'tab-1': { ptyIdsByLeafId: { [leafId]: 'pty-1' } } },
+        unifiedTabsByWorktree: {
+          'wt-1': [{ contentType: 'terminal', entityId: 'tab-1' }]
+        }
+      } as never
+    })
+
+    expect(session).toBeNull()
+  })
+
+  it('does not reuse a pane whose live status row belongs to another agent', () => {
+    const session = findReusableAutomationSession({
+      automationId: 'auto-1',
+      agentId: 'claude',
+      worktreeId: 'wt-1',
+      currentRunId: 'run-current',
+      runs: [run({ id: 'run-new', terminalSessionId: 'tab-1', createdAt: 2 })],
+      state: {
+        agentStatusByPaneKey: { [paneKey]: status({ agentType: 'codex' }) },
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        terminalLayoutsByTabId: { 'tab-1': { ptyIdsByLeafId: { [leafId]: 'pty-1' } } },
+        unifiedTabsByWorktree: {
+          'wt-1': [{ contentType: 'terminal', entityId: 'tab-1' }]
+        }
+      } as never
+    })
+
+    expect(session).toBeNull()
+  })
+
+  // Why: without a status row a sibling leaf may be the one holding the agent, so
+  // a split tab is not proof and must not be reused blind.
+  it('does not reuse a split tab when the status row is absent', () => {
+    const session = findReusableAutomationSession({
+      automationId: 'auto-1',
+      agentId: 'claude',
+      worktreeId: 'wt-1',
+      currentRunId: 'run-current',
+      runs: [run({ id: 'run-new', terminalSessionId: 'tab-1', createdAt: 2 })],
+      state: {
+        agentStatusByPaneKey: {},
+        ptyIdsByTabId: { 'tab-1': ['pty-1', 'pty-right'] },
+        terminalLayoutsByTabId: {
+          'tab-1': {
+            ptyIdsByLeafId: {
+              [leafId]: 'pty-1',
+              [splitLeafId]: 'pty-right'
+            }
+          }
+        },
+        unifiedTabsByWorktree: {
+          'wt-1': [{ contentType: 'terminal', entityId: 'tab-1' }]
+        }
+      } as never
+    })
+
+    expect(session).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/automation-session-reuse.ts
+++ b/src/renderer/src/lib/automation-session-reuse.ts
@@ -65,8 +65,20 @@ function findReusableExactRunPane({
   if (!parsed || !terminalTabIds.has(parsed.tabId)) {
     return null
   }
+  // Why: a status row proves what the agent is doing, but its absence proves
+  // nothing — rows are dropped/aged independently of pane lifetime, so a
+  // long-idle seed can outlive its row. Requiring one made reuse depend on the
+  // agent having finished *recently*, which is backwards: the longer a pane sits
+  // idle, the better a reuse target it is (#19193). Accept a missing row only
+  // when this tab is a single-pane layout, so the run's leaf is provably the only
+  // place the agent can be; in a split tab a sibling leaf may hold the agent and
+  // submitting there would type into the wrong pane.
   const entry = state.agentStatusByPaneKey[run.terminalPaneKey]
-  if (!entry || !isReusableAgentStatus(entry, agentId)) {
+  if (entry) {
+    if (!isReusableAgentStatus(entry, agentId)) {
+      return null
+    }
+  } else if (!isSoleLeafInTab(state, parsed.tabId, parsed.leafId)) {
     return null
   }
   if (!isRunPtyLiveInPane(state, parsed.tabId, parsed.leafId, run.terminalPtyId)) {
@@ -93,4 +105,16 @@ function isRunPtyLiveInPane(
   }
   const layoutPtyId = state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId]
   return layoutPtyId === undefined || layoutPtyId === ptyId
+}
+
+// Why: without a status row, only a single-leaf tab proves the run's pane is the
+// one holding the agent. A known layout must list this leaf and nothing else; an
+// unknown layout is not proof, so it does not qualify.
+function isSoleLeafInTab(
+  state: Pick<AppState, 'terminalLayoutsByTabId'>,
+  tabId: string,
+  leafId: string
+): boolean {
+  const leafIds = Object.keys(state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId ?? {})
+  return leafIds.length === 1 && leafIds[0] === leafId
 }


### PR DESCRIPTION
Fixes the reuse half of #19193.

## Problem

`findReusableAutomationSession` required a live `agentStatusByPaneKey` entry for the candidate pane:

```ts
const entry = state.agentStatusByPaneKey[run.terminalPaneKey]
if (!entry || !isReusableAgentStatus(entry, agentId)) {
  return null
}
```

Status rows are dropped/aged independently of pane lifetime, so a long-idle reuse seed outlives its row. Requiring the row effectively required *"the agent finished recently"*, which is backwards for reuse — the longer a pane sits idle, the better a reuse target it is.

Observed on 1.4.195 desktop with an `existing`-workspace automation, `reuseSession: true`, cron `*/30 * * * *`:

```
total runs:                 101
runs with a sessionId:      101
DISTINCT sessions:          101
run-to-run switches:        100 / 100
sessions used exactly once: 101
statuses:                   Counter({'completed': 101})
```

0% reuse across 101 successful runs. The prior runs' terminal identities were all still live and valid (tabId / leafId / ptyId each resolved against `orca terminal list`), so this was not `clearRetiredRunTerminalIdentity()` nulling them — every other gate in the function passed, leaving the status-row lookup as the only failing condition.

The agent finished in ~12s and the pane then sat idle ~29.8 min before the next fire, so by dispatch time the row was gone.

**Why it leaked.** #9493 deliberately exempts `reuseSession` runs from retirement (`useAutomationDispatchEvents.ts:550-555`), keeping the fresh launch as a future reuse seed. That is correct *if* reuse works — you keep one resident seed. Combined with reuse never succeeding, every run created a session that was then explicitly protected from cleanup: 48/day at `*/30`, measured at 32 live terminals and ~15 GB RSS across 58 agent processes. `reuseSession: false` automations are unaffected because they finalize and close.

## Change

Treat a missing status row as *unknown* rather than disqualifying, and fall through to the pane/PTY liveness proof (`isRunPtyLiveInPane`) that already exists and is authoritative.

A row that positively reports a busy pane, or one belonging to a different agent, still rejects — that path is unchanged.

**Safety narrowing:** a missing row is accepted only for a single-leaf tab. My first attempt omitted this and correctly broke the existing `does not reuse an unrelated split pane for a run with exact pane identity` test: in a split tab a sibling leaf may hold the agent, and submitting there would type the prompt into the wrong pane. `isSoleLeafInTab` requires a known layout listing this leaf and nothing else, so an unknown layout does not qualify either.

## Tests

Four new cases in `automation-session-reuse.test.ts`:

- reuses a provably live pane whose agent status row is absent (the bug)
- still rejects a missing status row when the pane itself is not live
- does not reuse a pane whose live status row belongs to another agent
- does not reuse a split tab when the status row is absent (the narrowing)

All pre-existing cases pass unchanged, including the split-pane and not-idle guards, and the `preserves a fresh reuse-enabled session as the future reuse seed` assertion in `useAutomationDispatchEvents.test.ts`.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/automation-session-reuse.test.ts \
  src/renderer/src/hooks/useAutomationDispatchEvents.test.ts \
  src/renderer/src/lib/automation-terminal-ownership.test.ts
→ Test Files 3 passed (3) | Tests 42 passed (42)
```

`oxlint` and `oxfmt` are clean on both files. See the CI note at the end for three pre-existing signals in this checkout that are unrelated to this change.

## Scope / what this does not do

This addresses reuse failing outright. It does not attempt:

- the round-robin-across-stale-sessions behavior in #16209 (reuse partially working, then churning across a pool) — plausibly the same root cause once reuse converges, but not verified here;
- reaping the sessions already leaked, or the question in #19193 of whether a `reuseSession` automation whose reuse *failed* should still be exempt from retirement. If maintainers prefer belt-and-braces, bounding the exemption to the single most-recent seed would stop the leak even when reuse cannot succeed.

Two hypotheses I investigated and ruled out, recorded so nobody re-treads them:

- **Not** #9493 breaking reuse — that commit added the explicit release guard protecting it.
- **Not** the live-status cap — `capLiveAgentStatusesInPlace` early-returns below `MAX_LIVE_AGENT_STATUSES` (500), and only ~32 entries existed.

---

### Branch hygiene (addressed)

The first push accidentally included two unrelated dashboard commits (`e0febd41f3`, `a35ae08ac0`) because the branch was cut from `fix/dashboard-remote-session-reveal` instead of `main`, which also made the PR conflict. Thanks to the reviewer for catching the undocumented scope. The branch has been rebuilt by cherry-picking onto fresh `origin/main` and force-pushed: it is now **1 commit, 2 files** (`automation-session-reuse.ts` + its test), and mergeable. The dashboard commits are not part of this PR.

Re-verified on the new base: 42/42 tests across `automation-session-reuse.test.ts`, `useAutomationDispatchEvents.test.ts`, and `automation-terminal-ownership.test.ts`.

For maintainers triaging CI on this PR, three signals are pre-existing and not from this change:
- the `pullfrog` check failed on infrastructure (GitHub returned 401 for its MCP token, then `agent run timed out after 1h`);
- `tsc --noEmit -p config/tsconfig.tc.web.json` reports `TS2307: Cannot find module 'psl'` in `src/renderer/src/components/tab-bar/tab-create-entry-url-classification.ts`, reproducible on `main` with nothing staged;
- `lint-staged`'s react-doctor step emits `Rule ... not found in plugin 'react'`, reproducible on an unrelated `main` commit and absent when oxlint runs directly on the two files here.
