### PR TITLE
feat(mobile/chat): syntax-highlight fenced code blocks in markdown

### DIFF
--- a/mobile/src/components/MobileMarkdown.code-highlight.test.ts
+++ b/mobile/src/components/MobileMarkdown.code-highlight.test.ts
@@ -1,0 +1,69 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer, type ReactTestInstance } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileMarkdown } from './MobileMarkdown'
+import { colors } from '../theme/mobile-theme'
+
+vi.mock('react-native', () => ({
+  Linking: { openURL: vi.fn() },
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Text: 'Text',
+  View: 'View'
+}))
+vi.mock('./pr-sidebar/MermaidDiagram', () => ({ MermaidDiagram: 'MermaidDiagram' }))
+
+function flattenText(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === 'string' ? child : flattenText(child)))
+    .join('')
+}
+
+function textLeafColors(renderer: ReactTestRenderer): unknown[] {
+  return renderer.root
+    .findAll((node) => node.type === ('Text' as never))
+    .map((node) => (Array.isArray(node.props.style) ? node.props.style : [node.props.style]))
+    .flat()
+    .map((style) => (style as { color?: unknown } | undefined)?.color)
+}
+
+describe('MobileMarkdown code highlighting', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  function render(content: string): ReactTestRenderer {
+    act(() => {
+      renderer = create(createElement(MobileMarkdown, { content }))
+    })
+    return renderer!
+  }
+
+  it('preserves the code text of a highlighted fence', () => {
+    const rendered = render('```ts\nconst answer = 42\n```')
+    // The concatenation of the segment Text runs equals the original code.
+    const codeRun = rendered.root
+      .findAll((node) => node.type === ('Text' as never) && node.props.selectable === true)
+      .map(flattenText)
+      .join('')
+    expect(codeRun).toContain('const answer = 42')
+  })
+
+  it('colors a keyword differently from plain text (highlighting is wired)', () => {
+    const rendered = render('```ts\nconst answer = 42\n```')
+    expect(textLeafColors(rendered)).toContain(colors.syntaxKeyword)
+  })
+
+  it('renders an unknown/blank language fence as plain code without crashing', () => {
+    const rendered = render('```\njust text\n```')
+    const codeRun = rendered.root
+      .findAll((node) => node.type === ('Text' as never) && node.props.selectable === true)
+      .map(flattenText)
+      .join('')
+    expect(codeRun).toContain('just text')
+  })
+})

--- a/mobile/src/components/MobileMarkdown.tsx
+++ b/mobile/src/components/MobileMarkdown.tsx
@@ -13,6 +13,7 @@ import {
   trimAutolinkTrailingPunctuation
 } from './markdown-inline-token-rules'
 import { isMobileMermaidLanguage } from './mobile-mermaid-language'
+import { MobileMarkdownCodeBlock } from './MobileMarkdownCodeBlock'
 import { parseMobileMarkdown } from './mobile-markdown-parser'
 import { MermaidDiagram } from './pr-sidebar/MermaidDiagram'
 
@@ -224,12 +225,7 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
             )
           }
           return (
-            <View key={index} style={styles.codeBlock}>
-              {block.language ? <Text style={styles.codeLanguage}>{block.language}</Text> : null}
-              <Text selectable style={styles.codeText}>
-                {block.text}
-              </Text>
-            </View>
+            <MobileMarkdownCodeBlock key={index} code={block.text} language={block.language} />
           )
         }
         if (block.type === 'image') {

--- a/mobile/src/components/MobileMarkdownCodeBlock.tsx
+++ b/mobile/src/components/MobileMarkdownCodeBlock.tsx
@@ -1,0 +1,32 @@
+import { memo, useMemo } from 'react'
+import { Text, View } from 'react-native'
+import { highlightMobileCode } from '../session/mobile-file-syntax'
+import { MobileSyntaxSegments } from './MobileSyntaxSegments'
+import { styles } from './mobile-markdown-styles'
+
+/** A fenced code block with lowlight syntax highlighting. Memoized so only the
+ *  block whose text actually changed re-tokenizes — during streaming that's just
+ *  the growing tail block, not every earlier one. The mono font/size comes from
+ *  the wrapping Text; each segment only overrides color. */
+function MobileMarkdownCodeBlockImpl({
+  code,
+  language
+}: {
+  code: string
+  language?: string
+}): React.JSX.Element {
+  const { segments } = useMemo(
+    () => highlightMobileCode(code, language ?? ''),
+    [code, language]
+  )
+  return (
+    <View style={styles.codeBlock}>
+      {language ? <Text style={styles.codeLanguage}>{language}</Text> : null}
+      <Text selectable style={styles.codeText}>
+        <MobileSyntaxSegments segments={segments} />
+      </Text>
+    </View>
+  )
+}
+
+export const MobileMarkdownCodeBlock = memo(MobileMarkdownCodeBlockImpl)


### PR DESCRIPTION
## ELI5

Code blocks the agent sends now get colored keywords/strings/comments like a real editor, instead of one flat gray monospace wall of text.

## What Changed

Wires the existing mobile syntax tokenizer into markdown fenced code blocks.
- New `MobileMarkdownCodeBlock` renders a fence through `highlightMobileCode` + `MobileSyntaxSegments` (the same tokenizer already used for file and diff views).
- It's `React.memo` + `useMemo` on `[code, language]`, so only the block whose text actually changed re-tokenizes — during streaming that's just the growing tail block, not every earlier one.
- Mono font/size come from the wrapping `Text`; each segment only overrides color.
- Unknown/blank-language and over-long fences fall back to plain text via the tokenizer's own guards. Mermaid fences are untouched (still WebView diagrams).

## Why

`highlightMobileCode` / `MobileSyntaxSegments` already exist and are used elsewhere, but markdown code blocks rendered as flat `<Text>`. This is a reuse of that tokenizer, not a new highlighter, so agent code reads consistently with file/diff views.

## Linked Issue

N/A — small self-contained polish; no tracking issue.

Fixes #

## Visual Proof

N/A as a static diff of behavior, but it is a visual change: a fenced `ts`/`bash`/`json` block now shows token colors (keyword/string/number/comment) instead of uniform text. Verified by the render test below asserting a keyword segment gets `colors.syntaxKeyword`.

## Testing

- New `MobileMarkdown.code-highlight.test.ts` (react-test-renderer): a `ts` fence preserves its code text, a keyword segment is colored (highlighting is wired), and a blank-language fence renders plain without crashing.
- `pnpm test` for the markdown + syntax suites passes (`MobileMarkdown.test.ts`, `MobileMarkdown.file-links.test.ts`, `mobile-file-syntax.test.ts`, plus the new file) — 37 tests.
- `tsc --noEmit` clean (only the pre-existing `*.generated` codegen stubs error, unrelated). oxlint deferred to CI.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platform: mobile (RN). No desktop/SSH/native surface touched.

## AI Disclosure

Claude (Opus 4.8) via Claude Code assisted with the implementation.

## Review

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation touched.

## Notes

Mobile-only, additive. No security, cross-platform, remote/SSH, wire, or backwards-compat surface changed. Performance-conscious: memoized per block so streaming re-tokenizes only the changing tail, and the tokenizer's existing char/segment caps bound worst-case work.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)