### PR TITLE
fix(ephemeral-vm): rehydrate runtime SSH after restart

### DIFF
--- a/src/main/ephemeral-vm-runtime-ssh.test.ts
+++ b/src/main/ephemeral-vm-runtime-ssh.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
+
+const {
+  connectRegisteredSshTargetMock,
+  getSshConnectionStoreMock,
+  upsertRuntimeOwnedTargetMock,
+  disconnectRegisteredSshTargetMock,
+  removeRegisteredSshTargetMock,
+  getSshGitProviderMock,
+  getSshFilesystemProviderMock,
+  getSshPtyProviderMock
+} = vi.hoisted(() => ({
+  connectRegisteredSshTargetMock: vi.fn(),
+  getSshConnectionStoreMock: vi.fn(),
+  upsertRuntimeOwnedTargetMock: vi.fn(),
+  disconnectRegisteredSshTargetMock: vi.fn(),
+  removeRegisteredSshTargetMock: vi.fn(),
+  getSshGitProviderMock: vi.fn(),
+  getSshFilesystemProviderMock: vi.fn(),
+  getSshPtyProviderMock: vi.fn()
+}))
+
+vi.mock('./ipc/ssh', () => ({
+  connectRegisteredSshTarget: connectRegisteredSshTargetMock,
+  getSshConnectionStore: getSshConnectionStoreMock
+}))
+
+vi.mock('./ipc/ssh-session-teardown', () => ({
+  disconnectRegisteredSshTarget: disconnectRegisteredSshTargetMock,
+  removeRegisteredSshTarget: removeRegisteredSshTargetMock
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: getSshFilesystemProviderMock
+}))
+
+vi.mock('./ipc/pty/provider/registry', () => ({
+  getSshPtyProvider: getSshPtyProviderMock
+}))
+
+import { ensureRuntimeOwnedSshConnection } from './ephemeral-vm-runtime-ssh'
+
+const TARGET_ID = 'runtime-ssh-instance-1'
+
+function runningSshRuntime(): EphemeralVmRuntimeRecord {
+  return {
+    id: 'instance-1',
+    recipeId: 'agent-sandbox',
+    repoId: 'repo-1',
+    workspaceId: 'workspace-1',
+    status: 'running',
+    cleanupStatus: 'not_started',
+    connectionMode: 'ssh',
+    sshTargetId: TARGET_ID,
+    createdAt: 1,
+    updatedAt: 1,
+    recipeResult: {
+      schemaVersion: 1,
+      connection: {
+        type: 'ssh',
+        projectRoot: '/workspace/repo',
+        target: { label: 'Agent Sandbox', host: '127.0.0.1', port: 2222, username: 'orca' }
+      }
+    }
+  }
+}
+
+describe('ensureRuntimeOwnedSshConnection', () => {
+  beforeEach(() => {
+    connectRegisteredSshTargetMock.mockReset()
+    connectRegisteredSshTargetMock.mockResolvedValue({ status: 'connected' })
+    upsertRuntimeOwnedTargetMock.mockReset()
+    upsertRuntimeOwnedTargetMock.mockImplementation((runtimeId: string) => ({
+      id: `runtime-ssh-${runtimeId}`,
+      label: 'Agent Sandbox',
+      host: '127.0.0.1',
+      port: 2222,
+      username: 'orca'
+    }))
+    getSshConnectionStoreMock.mockReset()
+    getSshConnectionStoreMock.mockReturnValue({
+      upsertRuntimeOwnedTarget: upsertRuntimeOwnedTargetMock
+    })
+    disconnectRegisteredSshTargetMock.mockReset()
+    removeRegisteredSshTargetMock.mockReset()
+    removeRegisteredSshTargetMock.mockResolvedValue(undefined)
+    // A connect registers all three providers together, so the readiness wait resolves.
+    getSshGitProviderMock.mockReset()
+    getSshGitProviderMock.mockReturnValue({})
+    getSshFilesystemProviderMock.mockReset()
+    getSshFilesystemProviderMock.mockReturnValue({})
+    getSshPtyProviderMock.mockReset()
+  })
+
+  it('does not reconnect a target whose PTY provider is already registered', async () => {
+    // Why: a redundant connect disposes the runtime layer's live relay session.
+    getSshPtyProviderMock.mockReturnValue({})
+
+    const targetId = await ensureRuntimeOwnedSshConnection({ runtime: runningSshRuntime() })
+
+    expect(targetId).toBe(TARGET_ID)
+    expect(connectRegisteredSshTargetMock).not.toHaveBeenCalled()
+    expect(upsertRuntimeOwnedTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('reconnects from the persisted recipe result when this process has no PTY provider', async () => {
+    // The relay registers all three providers together, so the provider appears once connect lands.
+    getSshPtyProviderMock.mockImplementation(() =>
+      connectRegisteredSshTargetMock.mock.calls.length > 0 ? {} : undefined
+    )
+
+    const targetId = await ensureRuntimeOwnedSshConnection({ runtime: runningSshRuntime() })
+
+    expect(targetId).toBe(TARGET_ID)
+    expect(upsertRuntimeOwnedTargetMock).toHaveBeenCalledWith('instance-1', {
+      label: 'Agent Sandbox',
+      host: '127.0.0.1',
+      port: 2222,
+      username: 'orca'
+    })
+    expect(connectRegisteredSshTargetMock).toHaveBeenCalledWith(TARGET_ID)
+  })
+
+  it('keeps the persisted target when the reconnect fails', async () => {
+    // Why: removing the target disposes remote PTYs and drops their leases. A failed
+    // reconnect is `unverifiable`, never evidence the remote runtime exited, so the
+    // route must stay intact and retryable.
+    getSshPtyProviderMock.mockReturnValue(undefined)
+    connectRegisteredSshTargetMock.mockResolvedValue({
+      status: 'error',
+      error: 'connect ECONNREFUSED 127.0.0.1:2222'
+    })
+
+    await expect(ensureRuntimeOwnedSshConnection({ runtime: runningSshRuntime() })).rejects.toThrow(
+      'connect ECONNREFUSED 127.0.0.1:2222'
+    )
+    expect(removeRegisteredSshTargetMock).not.toHaveBeenCalled()
+    expect(disconnectRegisteredSshTargetMock).not.toHaveBeenCalled()
+  })
+
+  it('does not report readiness while only the git and filesystem providers are registered', async () => {
+    // Why: the ensure gate keys on the PTY provider, so a connect that returns before it is
+    // registered would satisfy the gate while `pty:spawn` still rejects with "No PTY provider".
+    vi.useFakeTimers()
+    try {
+      getSshPtyProviderMock.mockReturnValue(undefined)
+
+      const pending = ensureRuntimeOwnedSshConnection({ runtime: runningSshRuntime() })
+      const settled = pending.then(
+        () => 'resolved' as const,
+        () => 'rejected' as const
+      )
+      await vi.advanceTimersByTimeAsync(9_000)
+      expect(connectRegisteredSshTargetMock).toHaveBeenCalledWith(TARGET_ID)
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await expect(settled).resolves.toBe('rejected')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('ignores a runtime that is not SSH-backed', async () => {
+    const runtime: EphemeralVmRuntimeRecord = {
+      ...runningSshRuntime(),
+      connectionMode: 'orca-server',
+      sshTargetId: undefined,
+      recipeResult: {
+        schemaVersion: 1,
+        pairingCode: 'pairing-code',
+        projectRoot: '/workspace/repo'
+      }
+    }
+
+    const targetId = await ensureRuntimeOwnedSshConnection({ runtime })
+
+    expect(targetId).toBeNull()
+    expect(connectRegisteredSshTargetMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ephemeral-vm-runtime-ssh.ts
+++ b/src/main/ephemeral-vm-runtime-ssh.ts
@@ -1,11 +1,17 @@
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import { getSshPtyProvider } from './ipc/pty/provider/registry'
 import { connectRegisteredSshTarget, getSshConnectionStore } from './ipc/ssh'
 import {
   disconnectRegisteredSshTarget,
   removeRegisteredSshTarget
 } from './ipc/ssh-session-teardown'
-import type { EphemeralVmRecipeConnection } from '../shared/ephemeral-vm-recipes'
+import { getRuntimeOwnedSshTargetId } from './ssh/ssh-connection-store'
+import {
+  getEphemeralVmRecipeResultConnection,
+  type EphemeralVmRecipeConnection
+} from '../shared/ephemeral-vm-recipes'
+import type { EphemeralVmRuntimeRecord } from '../shared/ephemeral-vm-runtimes'
 import type { SshTarget } from '../shared/ssh-types'
 
 const SSH_PROVIDER_READY_TIMEOUT_MS = 10_000
@@ -16,29 +22,60 @@ export type RuntimeOwnedSshConnectionResult = {
   target: SshTarget
 }
 
-export async function connectRuntimeOwnedSshTarget(args: {
+type RuntimeOwnedSshConnectArgs = {
   runtimeId: string
   connection: Extract<EphemeralVmRecipeConnection, { type: 'ssh' }>
   signal?: AbortSignal
-}): Promise<RuntimeOwnedSshConnectionResult> {
-  const store = getSshConnectionStore()
-  if (!store) {
-    throw new Error('SSH handlers are not registered.')
-  }
-  const target = store.upsertRuntimeOwnedTarget(args.runtimeId, args.connection.target)
+}
+
+export async function connectRuntimeOwnedSshTarget(
+  args: RuntimeOwnedSshConnectArgs
+): Promise<RuntimeOwnedSshConnectionResult> {
   try {
-    const state = await connectRegisteredSshTarget(target.id)
-    if (state.status !== 'connected') {
-      throw new Error(state.error || `SSH target did not connect: ${state.status}`)
-    }
-    await waitForRuntimeSshProviders(target.id, args.signal)
+    return await openRuntimeOwnedSshTransport(args)
   } catch (error) {
     // The target is persisted at upsert, so a failed connect/provider-wait would
     // orphan it; remove it (idempotent) before rethrowing so cleanup is complete.
-    await removeRuntimeOwnedSshTarget(target.id).catch(() => undefined)
+    await removeRuntimeOwnedSshTarget(getRuntimeOwnedSshTargetId(args.runtimeId)).catch(
+      () => undefined
+    )
     throw error
   }
-  return { targetId: target.id, target }
+}
+
+/**
+ * Restore the transport an SSH-backed runtime needs in *this* process, without touching the
+ * runtime's lifecycle. Provider registration is process-local while the runtime record and its
+ * SSH target row are durable, so a persisted runtime routinely outlives the connection that
+ * served it (app restart, host restart, a resume the recipe skipped). Idempotent: a target that
+ * still has a PTY provider is left alone, because redialing it would dispose the live relay
+ * session the runtime layer owns.
+ *
+ * Returns the runtime-owned target id, or null when the runtime is not SSH-backed.
+ *
+ * Deliberately not routed through `connectRuntimeOwnedSshTarget`: that path removes the target on
+ * failure, which disposes remote PTYs and drops their leases. For a runtime that is still alive
+ * that would destroy the route on evidence we do not hold — a failed reconnect is `unverifiable`
+ * (docs/reference/ssh-execution-boundary.md).
+ */
+export async function ensureRuntimeOwnedSshConnection(args: {
+  runtime: EphemeralVmRuntimeRecord
+  signal?: AbortSignal
+}): Promise<string | null> {
+  const connection = getEphemeralVmRecipeResultConnection(args.runtime.recipeResult)
+  if (connection.type !== 'ssh') {
+    return null
+  }
+  const targetId = getRuntimeOwnedSshTargetId(args.runtime.id)
+  if (getSshPtyProvider(targetId)) {
+    return targetId
+  }
+  const result = await openRuntimeOwnedSshTransport({
+    runtimeId: args.runtime.id,
+    connection,
+    ...(args.signal ? { signal: args.signal } : {})
+  })
+  return result.targetId
 }
 
 export async function disconnectRuntimeOwnedSshTarget(targetId: string | undefined): Promise<void> {
@@ -55,13 +92,35 @@ export async function removeRuntimeOwnedSshTarget(targetId: string | undefined):
   await removeRegisteredSshTarget(targetId)
 }
 
+async function openRuntimeOwnedSshTransport(
+  args: RuntimeOwnedSshConnectArgs
+): Promise<RuntimeOwnedSshConnectionResult> {
+  const store = getSshConnectionStore()
+  if (!store) {
+    throw new Error('SSH handlers are not registered.')
+  }
+  const target = store.upsertRuntimeOwnedTarget(args.runtimeId, args.connection.target)
+  const state = await connectRegisteredSshTarget(target.id)
+  if (state.status !== 'connected') {
+    throw new Error(state.error || `SSH target did not connect: ${state.status}`)
+  }
+  await waitForRuntimeSshProviders(target.id, args.signal)
+  return { targetId: target.id, target }
+}
+
 async function waitForRuntimeSshProviders(targetId: string, signal?: AbortSignal): Promise<void> {
   const startedAt = Date.now()
   while (Date.now() - startedAt < SSH_PROVIDER_READY_TIMEOUT_MS) {
     if (signal?.aborted) {
       throw new Error(`SSH provider wait aborted for target "${targetId}".`)
     }
-    if (getSshGitProvider(targetId) && getSshFilesystemProvider(targetId)) {
+    // The PTY provider is what terminal and agent work routes through; readiness that omits it
+    // can report a target usable while `pty:spawn` still rejects with "No PTY provider".
+    if (
+      getSshPtyProvider(targetId) &&
+      getSshGitProvider(targetId) &&
+      getSshFilesystemProvider(targetId)
+    ) {
       return
     }
     await new Promise((resolve) => setTimeout(resolve, SSH_PROVIDER_READY_INTERVAL_MS))

--- a/src/main/ipc/ephemeral-vm-runtime-handlers.ts
+++ b/src/main/ipc/ephemeral-vm-runtime-handlers.ts
@@ -4,7 +4,10 @@ import {
   listEphemeralVmRuntimes,
   updateEphemeralVmRuntimeStatus
 } from '../../shared/ephemeral-vm-runtime-store'
-import type { EphemeralVmRuntimeRecord } from '../../shared/ephemeral-vm-runtimes'
+import {
+  mayReconnectEphemeralVmRuntimeTransport,
+  type EphemeralVmRuntimeRecord
+} from '../../shared/ephemeral-vm-runtimes'
 import {
   getEphemeralVmRecipeResultConnection,
   getEphemeralVmRecipeResultPairingCode
@@ -27,6 +30,7 @@ import {
 import {
   connectRuntimeOwnedSshTarget,
   disconnectRuntimeOwnedSshTarget,
+  ensureRuntimeOwnedSshConnection,
   removeRuntimeOwnedSshTarget
 } from '../ephemeral-vm-runtime-ssh'
 import { getRuntimeRecipeContext } from './ephemeral-vm-recipe-context'
@@ -203,6 +207,13 @@ export function registerEphemeralVmRuntimeHandlers(store: Store): void {
         return null
       }
       if (runtime.status !== 'suspended' && runtime.status !== 'resume_failed') {
+        // The sandbox never stopped, so the recipe must not re-run; only this process's
+        // transport can be missing (a restart drops the PTY provider but not the record).
+        // Statuses with no reachable sandbox stay untouched, or activating a failed runtime
+        // would raise a connection error for something that was never up.
+        if (mayReconnectEphemeralVmRuntimeTransport(runtime.status)) {
+          await ensureRuntimeOwnedSshConnection({ runtime })
+        }
         return runtime
       }
       const recipeContext = getRuntimeRecipeContext(store, userDataPath, runtime.id)
@@ -226,24 +237,36 @@ export function registerEphemeralVmRuntimeHandlers(store: Store): void {
         invalidateRuntimeEnvironmentTransport(runtime.runtimeEnvironmentId)
       }
       const connection = getEphemeralVmRecipeResultConnection(result.runtime.recipeResult)
-      if (!result.skipped && connection.type === 'ssh') {
-        try {
-          const ssh = await connectRuntimeOwnedSshTarget({
-            runtimeId: result.runtime.id,
-            connection
-          })
-          return updateEphemeralVmRuntimeStatus(userDataPath, result.runtime.id, {
-            connectionMode: 'ssh',
-            sshTargetId: ssh.targetId
-          })
-        } catch (error) {
-          updateEphemeralVmRuntimeStatus(userDataPath, result.runtime.id, {
-            status: 'resume_failed'
-          })
-          throw error
-        }
+      if (connection.type !== 'ssh') {
+        return result.runtime
       }
-      return result.runtime
+      if (result.skipped) {
+        // No resume ran, so a transport failure is `unverifiable` and must not be recorded as
+        // 'resume_failed'; the record stays running and the next activation retries.
+        const targetId = await ensureRuntimeOwnedSshConnection({ runtime: result.runtime })
+        return targetId && targetId !== result.runtime.sshTargetId
+          ? updateEphemeralVmRuntimeStatus(userDataPath, result.runtime.id, {
+              connectionMode: 'ssh',
+              sshTargetId: targetId
+            })
+          : result.runtime
+      }
+      try {
+        // A re-run resume may have moved the endpoint, so this reconnects unconditionally.
+        const ssh = await connectRuntimeOwnedSshTarget({
+          runtimeId: result.runtime.id,
+          connection
+        })
+        return updateEphemeralVmRuntimeStatus(userDataPath, result.runtime.id, {
+          connectionMode: 'ssh',
+          sshTargetId: ssh.targetId
+        })
+      } catch (error) {
+        updateEphemeralVmRuntimeStatus(userDataPath, result.runtime.id, {
+          status: 'resume_failed'
+        })
+        throw error
+      }
     }
   )
 

--- a/src/main/ipc/ephemeral-vm-runtime-ssh-rehydration.test.ts
+++ b/src/main/ipc/ephemeral-vm-runtime-ssh-rehydration.test.ts
@@ -1,0 +1,274 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { upsertEphemeralVmRuntime } from '../../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRuntimeRecord } from '../../shared/ephemeral-vm-runtimes'
+
+const handlers = new Map<string, (_event: unknown, args: never) => unknown>()
+const {
+  handleMock,
+  removeHandlerMock,
+  getPathMock,
+  connectRegisteredSshTargetMock,
+  getSshConnectionStoreMock,
+  upsertRuntimeOwnedTargetMock,
+  disconnectRegisteredSshTargetMock,
+  removeRegisteredSshTargetMock,
+  getSshGitProviderMock,
+  getSshFilesystemProviderMock,
+  getSshPtyProviderMock,
+  invalidateRuntimeEnvironmentTransportMock
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  getPathMock: vi.fn(),
+  connectRegisteredSshTargetMock: vi.fn(),
+  getSshConnectionStoreMock: vi.fn(),
+  upsertRuntimeOwnedTargetMock: vi.fn(),
+  disconnectRegisteredSshTargetMock: vi.fn(),
+  removeRegisteredSshTargetMock: vi.fn(),
+  getSshGitProviderMock: vi.fn(),
+  getSshFilesystemProviderMock: vi.fn(),
+  getSshPtyProviderMock: vi.fn(),
+  invalidateRuntimeEnvironmentTransportMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: getPathMock },
+  ipcMain: { handle: handleMock, removeHandler: removeHandlerMock }
+}))
+
+// The real ephemeral-vm-runtime-ssh module runs; only the SSH stack under it is stubbed,
+// so these cases exercise the handler → ensure → provider-registry path end to end.
+vi.mock('./ssh', () => ({
+  connectRegisteredSshTarget: connectRegisteredSshTargetMock,
+  getSshConnectionStore: getSshConnectionStoreMock
+}))
+
+vi.mock('./ssh-session-teardown', () => ({
+  disconnectRegisteredSshTarget: disconnectRegisteredSshTargetMock,
+  removeRegisteredSshTarget: removeRegisteredSshTargetMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: getSshFilesystemProviderMock
+}))
+
+vi.mock('./pty/provider/registry', () => ({
+  getSshPtyProvider: getSshPtyProviderMock
+}))
+
+vi.mock('./runtime-environments', () => ({
+  invalidateRuntimeEnvironmentTransport: invalidateRuntimeEnvironmentTransportMock
+}))
+
+import { registerEphemeralVmRuntimeHandlers } from './ephemeral-vm-runtime-handlers'
+
+const TARGET_ID = 'runtime-ssh-instance-1'
+const tempDirs: string[] = []
+
+function makeDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+function makeStore(repoPath: string) {
+  const repo = {
+    id: 'repo-1',
+    path: repoPath,
+    displayName: 'Repo',
+    badgeColor: '#000',
+    addedAt: 0
+  }
+  return {
+    getRepo: vi.fn((repoId: string) => (repoId === 'repo-1' ? repo : null)),
+    getRepos: vi.fn(() => [repo]),
+    getSettings: vi.fn(() => ({ activeRuntimeEnvironmentId: null })),
+    updateSettings: vi.fn()
+  }
+}
+
+/** A script that records that it ran, so a test can prove the recipe was not re-run. */
+function markerScript(repoPath: string, name: string): string {
+  const scriptPath = join(repoPath, 'scripts', `${name}.js`)
+  mkdirSync(join(repoPath, 'scripts'), { recursive: true })
+  writeFileSync(
+    scriptPath,
+    [
+      "const fs = require('fs')",
+      "process.stdin.resume().on('data', () => {})",
+      `fs.writeFileSync(${JSON.stringify(join(repoPath, `${name}-ran.txt`))}, 'ran')`,
+      'console.log(JSON.stringify({',
+      '  schemaVersion: 1,',
+      '  connection: {',
+      "    type: 'ssh',",
+      "    projectRoot: '/workspace/repo',",
+      "    target: { label: 'Agent Sandbox', host: '127.0.0.1', port: 2222, username: 'orca' }",
+      '  }',
+      '}))'
+    ].join('\n')
+  )
+  return `"${process.execPath}" "${scriptPath}"`
+}
+
+function seedRuntime(
+  userDataPath: string,
+  overrides: Partial<EphemeralVmRuntimeRecord> & {
+    recipe: EphemeralVmRuntimeRecord['recipe']
+  }
+): void {
+  upsertEphemeralVmRuntime(userDataPath, {
+    id: 'instance-1',
+    recipeId: 'agent-sandbox',
+    repoId: 'repo-1',
+    workspaceId: 'workspace-1',
+    status: 'running',
+    cleanupStatus: 'not_started',
+    connectionMode: 'ssh',
+    sshTargetId: TARGET_ID,
+    createdAt: 1,
+    updatedAt: 1,
+    recipeResult: {
+      schemaVersion: 1,
+      connection: {
+        type: 'ssh',
+        projectRoot: '/workspace/repo',
+        target: { label: 'Agent Sandbox', host: '127.0.0.1', port: 2222, username: 'orca' }
+      }
+    },
+    ...overrides
+  })
+}
+
+describe('runtime-owned SSH rehydration on workspace activation (#19173)', () => {
+  beforeEach(() => {
+    handlers.clear()
+    handleMock.mockReset()
+    handleMock.mockImplementation((channel: string, handler: never) => {
+      handlers.set(channel, handler)
+    })
+    removeHandlerMock.mockReset()
+    getPathMock.mockReset()
+    connectRegisteredSshTargetMock.mockReset()
+    connectRegisteredSshTargetMock.mockResolvedValue({ status: 'connected' })
+    upsertRuntimeOwnedTargetMock.mockReset()
+    upsertRuntimeOwnedTargetMock.mockImplementation((runtimeId: string) => ({
+      id: `runtime-ssh-${runtimeId}`
+    }))
+    getSshConnectionStoreMock.mockReset()
+    getSshConnectionStoreMock.mockReturnValue({
+      upsertRuntimeOwnedTarget: upsertRuntimeOwnedTargetMock
+    })
+    disconnectRegisteredSshTargetMock.mockReset()
+    disconnectRegisteredSshTargetMock.mockResolvedValue(undefined)
+    removeRegisteredSshTargetMock.mockReset()
+    removeRegisteredSshTargetMock.mockResolvedValue(undefined)
+    getSshGitProviderMock.mockReset()
+    getSshGitProviderMock.mockReturnValue({})
+    getSshFilesystemProviderMock.mockReset()
+    getSshFilesystemProviderMock.mockReturnValue({})
+    getSshPtyProviderMock.mockReset()
+    // The relay registers all three providers together, so the provider appears once connect lands.
+    getSshPtyProviderMock.mockImplementation(() =>
+      connectRegisteredSshTargetMock.mock.calls.length > 0 ? {} : undefined
+    )
+    invalidateRuntimeEnvironmentTransportMock.mockReset()
+  })
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('reconnects a persisted running runtime without re-running the resume recipe', async () => {
+    const userDataPath = makeDir('orca-rehydrate-user-data-')
+    const repoPath = makeDir('orca-rehydrate-repo-')
+    getPathMock.mockReturnValue(userDataPath)
+    const resumeCommand = markerScript(repoPath, 'resume')
+    seedRuntime(userDataPath, {
+      status: 'running',
+      recipe: {
+        id: 'agent-sandbox',
+        name: 'Agent Sandbox',
+        create: 'noop',
+        resume: resumeCommand
+      }
+    })
+    registerEphemeralVmRuntimeHandlers(makeStore(repoPath) as never)
+
+    const resumed = await handlers.get('ephemeralVm:resumeWorkspace')?.(null, {
+      workspaceId: 'workspace-1'
+    } as never)
+
+    expect(connectRegisteredSshTargetMock).toHaveBeenCalledWith(TARGET_ID)
+    // The sandbox never stopped; only this process lost its transport.
+    expect(existsSync(join(repoPath, 'resume-ran.txt'))).toBe(false)
+    expect(resumed).toEqual(expect.objectContaining({ status: 'running' }))
+  })
+
+  it('reconnects the transport when the recipe has no resume command to run', async () => {
+    const userDataPath = makeDir('orca-rehydrate-skip-user-data-')
+    const repoPath = makeDir('orca-rehydrate-skip-repo-')
+    getPathMock.mockReturnValue(userDataPath)
+    seedRuntime(userDataPath, {
+      status: 'suspended',
+      recipe: { id: 'agent-sandbox', name: 'Agent Sandbox', create: 'noop' }
+    })
+    registerEphemeralVmRuntimeHandlers(makeStore(repoPath) as never)
+
+    const resumed = await handlers.get('ephemeralVm:resumeWorkspace')?.(null, {
+      workspaceId: 'workspace-1'
+    } as never)
+
+    expect(connectRegisteredSshTargetMock).toHaveBeenCalledWith(TARGET_ID)
+    expect(resumed).toEqual(expect.objectContaining({ status: 'running' }))
+  })
+
+  it('does not dial a runtime whose provisioning failed', async () => {
+    // Why: activating a failed runtime used to be inert; it must not start raising connection
+    // errors for a sandbox that was never up.
+    const userDataPath = makeDir('orca-rehydrate-failed-user-data-')
+    const repoPath = makeDir('orca-rehydrate-failed-repo-')
+    getPathMock.mockReturnValue(userDataPath)
+    seedRuntime(userDataPath, {
+      status: 'failed',
+      recipe: { id: 'agent-sandbox', name: 'Agent Sandbox', create: 'noop' }
+    })
+    registerEphemeralVmRuntimeHandlers(makeStore(repoPath) as never)
+
+    const resumed = await handlers.get('ephemeralVm:resumeWorkspace')?.(null, {
+      workspaceId: 'workspace-1'
+    } as never)
+
+    expect(connectRegisteredSshTargetMock).not.toHaveBeenCalled()
+    expect(resumed).toEqual(expect.objectContaining({ status: 'failed' }))
+  })
+
+  it('does not redial a runtime whose PTY provider is still registered', async () => {
+    const userDataPath = makeDir('orca-rehydrate-live-user-data-')
+    const repoPath = makeDir('orca-rehydrate-live-repo-')
+    getPathMock.mockReturnValue(userDataPath)
+    // A live relay session in this process already owns the target.
+    getSshPtyProviderMock.mockReturnValue({})
+    seedRuntime(userDataPath, {
+      status: 'running',
+      recipe: { id: 'agent-sandbox', name: 'Agent Sandbox', create: 'noop', resume: 'noop' }
+    })
+    registerEphemeralVmRuntimeHandlers(makeStore(repoPath) as never)
+
+    const resumed = await handlers.get('ephemeralVm:resumeWorkspace')?.(null, {
+      workspaceId: 'workspace-1'
+    } as never)
+
+    expect(connectRegisteredSshTargetMock).not.toHaveBeenCalled()
+    expect(disconnectRegisteredSshTargetMock).not.toHaveBeenCalled()
+    expect(resumed).toEqual(expect.objectContaining({ status: 'running' }))
+  })
+})

--- a/src/main/ipc/ephemeral-vm.test.ts
+++ b/src/main/ipc/ephemeral-vm.test.ts
@@ -13,6 +13,7 @@ const {
   getPathMock,
   connectRuntimeOwnedSshTargetMock,
   disconnectRuntimeOwnedSshTargetMock,
+  ensureRuntimeOwnedSshConnectionMock,
   removeRuntimeOwnedSshTargetMock,
   invalidateRuntimeEnvironmentTransportMock
 } = vi.hoisted(() => ({
@@ -21,6 +22,7 @@ const {
   getPathMock: vi.fn(),
   connectRuntimeOwnedSshTargetMock: vi.fn(),
   disconnectRuntimeOwnedSshTargetMock: vi.fn(),
+  ensureRuntimeOwnedSshConnectionMock: vi.fn(),
   removeRuntimeOwnedSshTargetMock: vi.fn(),
   invalidateRuntimeEnvironmentTransportMock: vi.fn()
 }))
@@ -38,6 +40,7 @@ vi.mock('electron', () => ({
 vi.mock('../ephemeral-vm-runtime-ssh', () => ({
   connectRuntimeOwnedSshTarget: connectRuntimeOwnedSshTargetMock,
   disconnectRuntimeOwnedSshTarget: disconnectRuntimeOwnedSshTargetMock,
+  ensureRuntimeOwnedSshConnection: ensureRuntimeOwnedSshConnectionMock,
   removeRuntimeOwnedSshTarget: removeRuntimeOwnedSshTargetMock
 }))
 
@@ -113,6 +116,8 @@ describe('registerEphemeralVmHandlers', () => {
     getPathMock.mockReset()
     connectRuntimeOwnedSshTargetMock.mockReset()
     disconnectRuntimeOwnedSshTargetMock.mockReset()
+    ensureRuntimeOwnedSshConnectionMock.mockReset()
+    ensureRuntimeOwnedSshConnectionMock.mockResolvedValue('runtime-ssh-orca-instance-1')
     removeRuntimeOwnedSshTargetMock.mockReset()
     invalidateRuntimeEnvironmentTransportMock.mockReset()
     connectRuntimeOwnedSshTargetMock.mockResolvedValue({

--- a/src/main/startup/main-process-ipc-bootstrap-runtime-ssh.test.ts
+++ b/src/main/startup/main-process-ipc-bootstrap-runtime-ssh.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+const { getPathMock, rehydrateRuntimeOwnedSshForRestoredWorkspacesMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn(() => '/user-data'),
+  rehydrateRuntimeOwnedSshForRestoredWorkspacesMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: getPathMock },
+  ipcMain: {
+    handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler)
+    })
+  }
+}))
+
+vi.mock('./runtime-owned-ssh-startup-rehydration', () => ({
+  rehydrateRuntimeOwnedSshForRestoredWorkspaces: rehydrateRuntimeOwnedSshForRestoredWorkspacesMock
+}))
+
+vi.mock('./legacy-worker-renderer-recovery', () => ({
+  recoverLegacyWorkerTerminalsForRendererStartup: vi.fn()
+}))
+
+vi.mock('./startup-diagnostics', () => ({ logStartupMilestone: vi.fn() }))
+
+import { mainProcessState } from './main-process-state'
+import { registerMainProcessIpcHandlers } from './main-process-ipc-bootstrap'
+
+describe('app:prepareTerminalStartupRestoration', () => {
+  beforeEach(() => {
+    handlers.clear()
+    rehydrateRuntimeOwnedSshForRestoredWorkspacesMock.mockReset()
+    rehydrateRuntimeOwnedSshForRestoredWorkspacesMock.mockResolvedValue(undefined)
+    mainProcessState.store = { getWorkspaceSessionHostIds: () => [] } as never
+    mainProcessState.runtime = null
+  })
+
+  it('rehydrates runtime-owned SSH connections before terminals are restored', async () => {
+    // Why here: the renderer awaits this barrier before any pty spawn/attach, and it must
+    // never dial a runtime-owned target itself.
+    registerMainProcessIpcHandlers()
+
+    await handlers.get('app:prepareTerminalStartupRestoration')?.()
+
+    expect(rehydrateRuntimeOwnedSshForRestoredWorkspacesMock).toHaveBeenCalledWith({
+      store: mainProcessState.store,
+      userDataPath: '/user-data'
+    })
+  })
+
+  it('still prepares terminal restoration when the rehydration fails', async () => {
+    // A failed reconnect is `unverifiable`; it must not block startup.
+    rehydrateRuntimeOwnedSshForRestoredWorkspacesMock.mockRejectedValue(new Error('unreachable'))
+    registerMainProcessIpcHandlers()
+
+    await expect(handlers.get('app:prepareTerminalStartupRestoration')?.()).resolves.toBeUndefined()
+  })
+})

--- a/src/main/startup/main-process-ipc-bootstrap.ts
+++ b/src/main/startup/main-process-ipc-bootstrap.ts
@@ -1,8 +1,9 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import { recoverLegacyWorkerTerminalsForRendererStartup } from './legacy-worker-renderer-recovery'
 import { logStartupMilestone } from './startup-diagnostics'
 import { mainProcessState as state } from './main-process-state'
 import { resolveOpenedMarkdownDocuments } from './os-opened-markdown-files'
+import { rehydrateRuntimeOwnedSshForRestoredWorkspaces } from './runtime-owned-ssh-startup-rehydration'
 
 export function registerMainProcessIpcHandlers(): void {
   ipcMain.handle('app:awaitFirstWindowStartupServices', async () => {
@@ -23,6 +24,16 @@ export function registerMainProcessIpcHandlers(): void {
       state.firstWindowStartupServicesReady,
       state.managedWslCliStartupBarrierReady
     ])
+    if (state.store) {
+      // Runtime-owned SSH transports are process-local and the renderer never dials them, so they
+      // are restored here — before any pane spawns against their host (#19173).
+      await rehydrateRuntimeOwnedSshForRestoredWorkspaces({
+        store: state.store,
+        userDataPath: app.getPath('userData')
+      }).catch((error) => {
+        console.warn('[ephemeral-vm] runtime-owned SSH startup rehydration failed', error)
+      })
+    }
     await state.runtime?.prepareStructuredAgentSessionStartupRestoration()
   })
   ipcMain.handle('app:recoverLegacyWorkerTerminalsForRendererStartup', () =>

--- a/src/main/startup/runtime-owned-ssh-startup-rehydration.test.ts
+++ b/src/main/startup/runtime-owned-ssh-startup-rehydration.test.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  listEphemeralVmRuntimes,
+  upsertEphemeralVmRuntime
+} from '../../shared/ephemeral-vm-runtime-store'
+import type { EphemeralVmRuntimeRecord } from '../../shared/ephemeral-vm-runtimes'
+
+const { ensureRuntimeOwnedSshConnectionMock } = vi.hoisted(() => ({
+  ensureRuntimeOwnedSshConnectionMock: vi.fn()
+}))
+
+vi.mock('../ephemeral-vm-runtime-ssh', () => ({
+  ensureRuntimeOwnedSshConnection: ensureRuntimeOwnedSshConnectionMock
+}))
+
+import {
+  rehydrateRuntimeOwnedSshForRestoredWorkspaces,
+  STARTUP_SSH_REHYDRATION_BARRIER_BUDGET_MS
+} from './runtime-owned-ssh-startup-rehydration'
+
+const tempDirs: string[] = []
+
+function makeDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+/** A store whose persisted sessions name the workspaces startup will restore. */
+function makeStore(activeWorkspaceIdsByHostId: Record<string, string[]>) {
+  return {
+    getWorkspaceSessionHostIds: vi.fn(() => Object.keys(activeWorkspaceIdsByHostId)),
+    getWorkspaceSession: vi.fn((hostId?: string | null) => {
+      const ids = activeWorkspaceIdsByHostId[hostId ?? 'local'] ?? []
+      return {
+        activeWorktreeId: ids[0] ?? null,
+        activeWorktreeIdsOnShutdown: ids
+      }
+    })
+  }
+}
+
+function seedRuntime(
+  userDataPath: string,
+  overrides: Partial<EphemeralVmRuntimeRecord> & { id: string }
+): void {
+  upsertEphemeralVmRuntime(userDataPath, {
+    recipeId: 'agent-sandbox',
+    repoId: 'repo-1',
+    workspaceId: 'workspace-1',
+    status: 'running',
+    cleanupStatus: 'not_started',
+    connectionMode: 'ssh',
+    sshTargetId: `runtime-ssh-${overrides.id}`,
+    createdAt: 1,
+    updatedAt: 1,
+    recipeResult: {
+      schemaVersion: 1,
+      connection: {
+        type: 'ssh',
+        projectRoot: '/workspace/repo',
+        target: { label: 'Agent Sandbox', host: '127.0.0.1', port: 2222, username: 'orca' }
+      }
+    },
+    ...overrides
+  })
+}
+
+describe('rehydrateRuntimeOwnedSshForRestoredWorkspaces', () => {
+  beforeEach(() => {
+    ensureRuntimeOwnedSshConnectionMock.mockReset()
+    ensureRuntimeOwnedSshConnectionMock.mockResolvedValue('runtime-ssh-instance-1')
+  })
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('ensures the SSH connection for a runtime-owned workspace startup restores as active', async () => {
+    const userDataPath = makeDir('orca-startup-rehydrate-')
+    seedRuntime(userDataPath, { id: 'instance-1', workspaceId: 'workspace-1' })
+
+    await rehydrateRuntimeOwnedSshForRestoredWorkspaces({
+      store: makeStore({ 'ssh:runtime-ssh-instance-1': ['workspace-1'] }) as never,
+      userDataPath
+    })
+
+    expect(ensureRuntimeOwnedSshConnectionMock).toHaveBeenCalledTimes(1)
+    expect(ensureRuntimeOwnedSshConnectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: expect.objectContaining({ id: 'instance-1' }) })
+    )
+  })
+
+  it('leaves a runtime alone when no restored session names its workspace', async () => {
+    const userDataPath = makeDir('orca-startup-rehydrate-idle-')
+    seedRuntime(userDataPath, { id: 'instance-1', workspaceId: 'workspace-1' })
+
+    await rehydrateRuntimeOwnedSshForRestoredWorkspaces({
+      store: makeStore({ local: ['some-other-workspace'] }) as never,
+      userDataPath
+    })
+
+    expect(ensureRuntimeOwnedSshConnectionMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a runtime retryable when its reconnect fails', async () => {
+    // Why: an unreachable endpoint is `unverifiable`, never evidence the sandbox exited.
+    // Startup must neither throw nor downgrade the record.
+    const userDataPath = makeDir('orca-startup-rehydrate-fail-')
+    seedRuntime(userDataPath, { id: 'instance-1', workspaceId: 'workspace-1' })
+    ensureRuntimeOwnedSshConnectionMock.mockRejectedValue(new Error('connect ECONNREFUSED'))
+
+    await expect(
+      rehydrateRuntimeOwnedSshForRestoredWorkspaces({
+        store: makeStore({ 'ssh:runtime-ssh-instance-1': ['workspace-1'] }) as never,
+        userDataPath
+      })
+    ).resolves.toBeUndefined()
+
+    const runtime = listEphemeralVmRuntimes(userDataPath).find((entry) => entry.id === 'instance-1')
+    expect(runtime).toEqual(
+      expect.objectContaining({ status: 'running', cleanupStatus: 'not_started' })
+    )
+  })
+
+  it('releases the startup barrier instead of waiting out an unreachable sandbox', async () => {
+    // Why: this gates every restored terminal, local ones included, and an SSH connect can take
+    // 30s before it even reaches the provider wait.
+    const userDataPath = makeDir('orca-startup-rehydrate-slow-')
+    seedRuntime(userDataPath, { id: 'instance-1', workspaceId: 'workspace-1' })
+    ensureRuntimeOwnedSshConnectionMock.mockImplementation(() => new Promise(() => {}))
+    vi.useFakeTimers()
+    try {
+      const pending = rehydrateRuntimeOwnedSshForRestoredWorkspaces({
+        store: makeStore({ 'ssh:runtime-ssh-instance-1': ['workspace-1'] }) as never,
+        userDataPath
+      })
+      const settled = pending.then(() => 'released' as const)
+      await vi.advanceTimersByTimeAsync(STARTUP_SSH_REHYDRATION_BARRIER_BUDGET_MS + 1)
+
+      await expect(settled).resolves.toBe('released')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('skips runtimes that are already cleaned up', async () => {
+    const userDataPath = makeDir('orca-startup-rehydrate-cleaned-')
+    seedRuntime(userDataPath, {
+      id: 'instance-1',
+      workspaceId: 'workspace-1',
+      status: 'cleaned',
+      cleanupStatus: 'succeeded'
+    })
+
+    await rehydrateRuntimeOwnedSshForRestoredWorkspaces({
+      store: makeStore({ 'ssh:runtime-ssh-instance-1': ['workspace-1'] }) as never,
+      userDataPath
+    })
+
+    expect(ensureRuntimeOwnedSshConnectionMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/startup/runtime-owned-ssh-startup-rehydration.ts
+++ b/src/main/startup/runtime-owned-ssh-startup-rehydration.ts
@@ -1,0 +1,94 @@
+import { listEphemeralVmRuntimes } from '../../shared/ephemeral-vm-runtime-store'
+import { mayReconnectEphemeralVmRuntimeTransport } from '../../shared/ephemeral-vm-runtimes'
+import { ensureRuntimeOwnedSshConnection } from '../ephemeral-vm-runtime-ssh'
+import type { Store } from '../persistence'
+
+/**
+ * How long startup waits on these reconnects before releasing the terminal-restoration barrier.
+ * A reachable sandbox lands well inside this; an unreachable one must not hold the barrier — and
+ * with it every restored terminal, local ones included — for the SSH connect timeout (30s) plus
+ * the provider wait. Reconnects that overrun keep running; only the waiting stops.
+ */
+export const STARTUP_SSH_REHYDRATION_BARRIER_BUDGET_MS = 4_000
+
+/**
+ * Reconnect the runtime-owned SSH transports for the workspaces this launch restores as active.
+ *
+ * Runtime-owned targets are hidden from the renderer and are never dialed by it, so after a
+ * desktop or host restart nothing else re-establishes them: the runtime record and its SSH target
+ * row survive while the PTY provider does not, and the first terminal or agent operation fails
+ * with "No PTY provider for connection" (#19173).
+ *
+ * Scoped to restored-active workspaces so a large runtime store cannot turn startup into a fan-out
+ * of connects, run in parallel with per-target failure isolation, and bounded: this sits on the
+ * barrier that gates every restored terminal, local ones included, so an unreachable sandbox must
+ * not hold it. Resolves when the reconnects settle or the budget elapses, whichever comes first.
+ */
+export async function rehydrateRuntimeOwnedSshForRestoredWorkspaces(args: {
+  store: Store
+  userDataPath: string
+}): Promise<void> {
+  const restoredWorkspaceIds = collectRestoredWorkspaceIds(args.store)
+  if (restoredWorkspaceIds.size === 0) {
+    return
+  }
+  const runtimes = listEphemeralVmRuntimes(args.userDataPath).filter(
+    (runtime) =>
+      runtime.connectionMode === 'ssh' &&
+      runtime.workspaceId !== undefined &&
+      restoredWorkspaceIds.has(runtime.workspaceId) &&
+      mayReconnectEphemeralVmRuntimeTransport(runtime.status)
+  )
+  if (runtimes.length === 0) {
+    return
+  }
+  const rehydrated = Promise.all(
+    runtimes.map(async (runtime) => {
+      try {
+        await ensureRuntimeOwnedSshConnection({ runtime })
+      } catch (error) {
+        // Why not a status write: a transport failure is `unverifiable`, never evidence the
+        // sandbox exited (docs/reference/ssh-execution-boundary.md). The record stays as it is,
+        // and the next workspace activation retries.
+        console.warn(
+          `[ephemeral-vm] Could not restore the SSH transport for runtime ${runtime.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+    })
+  )
+  await releaseBarrierAfterBudget(rehydrated)
+}
+
+async function releaseBarrierAfterBudget(rehydrated: Promise<unknown>): Promise<void> {
+  let releaseTimer: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      rehydrated,
+      new Promise<void>((resolve) => {
+        releaseTimer = setTimeout(resolve, STARTUP_SSH_REHYDRATION_BARRIER_BUDGET_MS)
+        // Why unref'd: a pending release must never be the reason the process stays alive.
+        releaseTimer.unref?.()
+      })
+    ])
+  } finally {
+    clearTimeout(releaseTimer)
+  }
+}
+
+function collectRestoredWorkspaceIds(store: Store): Set<string> {
+  const ids = new Set<string>()
+  // Sessions are partitioned per execution host, and a runtime-owned workspace lives under its
+  // own host partition, so the active set has to be unioned across all of them.
+  for (const hostId of store.getWorkspaceSessionHostIds()) {
+    const session = store.getWorkspaceSession(hostId)
+    if (session.activeWorktreeId) {
+      ids.add(session.activeWorktreeId)
+    }
+    for (const worktreeId of session.activeWorktreeIdsOnShutdown ?? []) {
+      ids.add(worktreeId)
+    }
+  }
+  return ids
+}

--- a/src/shared/ephemeral-vm-runtimes.ts
+++ b/src/shared/ephemeral-vm-runtimes.ts
@@ -19,6 +19,17 @@ export const EphemeralVmRuntimeStatusSchema = z.enum([
 
 export type EphemeralVmRuntimeStatus = z.infer<typeof EphemeralVmRuntimeStatusSchema>
 
+/**
+ * Whether a runtime in this status may still have a reachable sandbox whose transport is worth
+ * re-establishing without running any lifecycle command. `running` is the ordinary case; a failed
+ * suspend leaves the sandbox up. Everything else either never finished provisioning, is
+ * deliberately down (`suspended` / `resume_failed` are the resume recipe's job), or is past
+ * cleanup — dialing those would surface a connection error for a sandbox that is not there.
+ */
+export function mayReconnectEphemeralVmRuntimeTransport(status: EphemeralVmRuntimeStatus): boolean {
+  return status === 'running' || status === 'suspend_failed'
+}
+
 export const EphemeralVmCleanupStatusSchema = z.enum([
   'not_started',
   'disabled',


### PR DESCRIPTION
## ELI5

If you made a workspace inside an SSH-backed sandbox and then restarted your computer, Orca would
still show that workspace as `running` — but every terminal or agent you tried to start in it failed
with `No PTY provider for connection "runtime-ssh-orca-…"`. The sandbox was fine the whole time;
Orca just never dialled back into it. The connection lives only in memory, while the workspace
record lives on disk, so after a restart the record outlived the thing that made it usable. This
adds one small, idempotent "make sure this workspace's SSH connection exists" step and calls it from
the two places a workspace becomes usable: when startup restores it, and when you click it.

## What Changed

- **`src/main/ephemeral-vm-runtime-ssh.ts`** — new `ensureRuntimeOwnedSshConnection(...)`. Returns
  early when the target already has a PTY provider, otherwise reconnects from the persisted
  `recipeResult`. Never runs a lifecycle command. The upsert+connect+wait is factored into
  `openRuntimeOwnedSshTransport` so the ensure path can reuse it *without*
  `connectRuntimeOwnedSshTarget`'s remove-on-failure arm (see Why). `waitForRuntimeSshProviders`
  now also requires the PTY provider, so readiness matches the signal the gate keys on.
- **`src/main/startup/runtime-owned-ssh-startup-rehydration.ts`** (new) — reconnects the runtime-owned
  SSH transports for the workspaces this launch restores as active. Scoped, parallel, per-target
  failure isolation, and time-bounded.
- **`src/main/startup/main-process-ipc-bootstrap.ts`** — `app:prepareTerminalStartupRestoration`
  runs that rehydration before terminals restore.
- **`src/main/ipc/ephemeral-vm-runtime-handlers.ts`** — `ephemeralVm:resumeWorkspace` ensures the
  transport on the `running` early return, and routes a skipped recipe resume through the same
  ensure. A re-run resume still reconnects unconditionally (its endpoint may have moved).
- **`src/shared/ephemeral-vm-runtimes.ts`** — `mayReconnectEphemeralVmRuntimeTransport`
  (`running` / `suspend_failed`), shared by both call sites.

No new runtime statuses, no persisted-schema change, no wire change. Ownership stays in
main/runtime; the renderer still never dials a runtime-owned target.

## Why

`sshProviders` (`src/main/ipc/pty/provider/registry.ts`) is process-local. The runtime record, its
SSH target row, and `repo.connectionId` are durable. Nothing reconciled the two:
`connectRuntimeOwnedSshTarget` had only two call sites — create and resume — and
`resumeWorkspace` returned early for a `running` runtime. Runtime-owned targets are deliberately
excluded from every renderer reconnect path
(`use-app-startup-hydration.ts`, `workspace-session-reconnect-targets.ts`,
`ssh-pane-connect-gate.ts`), and `ipc-pty-connect.ts` even suppresses the error toast for them, so
the pane failed silently with no route to recovery.

Two things worth calling out for reviewers:

1. **The issue's own diagnosis does not hold.** #19173 suggests `waitForRuntimeSshProviders` omitting
   the PTY provider is the cause. It isn't: `ssh-relay-session.ts` registers PTY (`:1159`) *before*
   filesystem (`:1191`) and git (`:1198`) in one synchronous block, and all three unregister together
   (`:1696-1698`) — so the incumbent git+fs check was already strictly stronger. The PTY addition here
   is for coherence with the new gate, and it has its own test; it is not the fix.
2. **The ensure deliberately does not reuse `connectRuntimeOwnedSshTarget`.** That function removes
   the target on failure → `removeRegisteredSshTarget` → `disposeAndPersist` ("dispose so remote PTYs
   cannot reattach") plus `removeSshRemotePtyLeases`. Correct orphan cleanup for a *create*; on a
   *reconnect* of a live runtime it would destroy the route to still-running remote PTYs on evidence
   we do not hold. Per `docs/reference/ssh-execution-boundary.md` a failed reconnect is
   `unverifiable`, so the record is left untouched and retryable — never `failed`/`cleaned`, never
   `exited`.

There is also a second path to the same symptom that needs no restart: a recipe with `suspend` but no
`resume`. Suspend tore down the relay, resume was `skipped`, status flipped back to `running`, and the
SSH reconnect was gated on `!result.skipped`. Covered by its own regression test.

## Linked Issue

Fixes #19173

## Visual Proof

N/A — no visual UI implementation change; behavioral verification is documented in Testing.

## Testing

**Manual — full host reboot, Linux, SSH-backed environment recipe (Podman-hosted sandbox):**

Verified:

- Full host reboot, not merely an Orca restart, with the sandbox configured to return on the same
  SSH endpoint.
- The persisted runtime-owned SSH workspace restored successfully.
- A fresh terminal opened immediately after the reboot.
- The `No PTY provider` failure did not reproduce.
- Startup diagnostic (`ORCA_STARTUP_DIAGNOSTICS=1`):
  `renderer-prepare-terminal-startup-restoration-done durationMs=1120`
- No `[ephemeral-vm]` errors were logged.

Not verified by hand in that run, and covered by the automated tests below instead:

- "the resume recipe is not re-run"
- "an already-live connection is not redundantly redialled"

No pre-patch startup log was retained, so this PR carries no locally captured before/after log pair;
the "before" is the failure as reported in #19173.

That 1120 ms is the cost of the new step on the barrier that gates *every* restored terminal, local
ones included — well inside the 4 s budget, and far below the ~40 s an unbounded reconnect could
have taken (`CONNECT_TIMEOUT_MS` 30 s + the 10 s provider wait). The bound is enforced by a test that
hangs for 30 s if removed.

**Automated — 16 new tests across 4 files, all written before the fix and watched fail:**

- `src/main/ephemeral-vm-runtime-ssh.test.ts` (5) — idempotence when a provider is live; reconnect
  uses the persisted target fields; a failed reconnect leaves the target un-removed; readiness does
  not resolve on git+fs alone; non-SSH runtimes are a no-op.
- `src/main/ipc/ephemeral-vm-runtime-ssh-rehydration.test.ts` (4) — cold restart reconnects *and*
  the resume recipe does not re-run; skipped resume still reconnects; a `failed` runtime is never
  dialled; a live provider is never redialled.
- `src/main/startup/runtime-owned-ssh-startup-rehydration.test.ts` (5) — ensures for a restored-active
  workspace; two distinct exclusion rules; a failed reconnect keeps the record retryable; the barrier
  releases on budget.
- `src/main/startup/main-process-ipc-bootstrap-runtime-ssh.test.ts` (2) — wiring, and the barrier
  tolerating a failure.

Each guard added after self-review was mutation-checked: removing it makes exactly its own test fail.

Platforms: manually verified on **Linux** with a real SSH-backed recipe. Not manually run on macOS or
Windows — the change is main-process lifecycle only, with no shell, path, platform branch, or child
process involved.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 (Claude Code) was used for codebase investigation, regression-test design,
implementation, and review.

ChatGPT (GPT-5.6 Sol) was used for independent repository investigation, contribution planning, and
review of the proposed fix and test strategy.

## Author

No X (Twitter) account.

## Review

Cross-platform: no platform-specific code; no paths, shells, or child processes. SSH/remote: the
core concern — a failed reconnect is reported as `unverifiable` and never downgrades the runtime
record or destroys remote PTYs; the client still never dials a runtime-owned target. Agent /
integration: provider-neutral; the container backend behind the recipe (Podman here) is invisible to
Orca — this is purely the SSH connection contract. Performance: the startup step is scoped to
restored-active workspaces, runs in parallel, and is bounded at 4 s; measured 1120 ms on a real
reboot. Backwards compatibility: no new statuses, no persisted-schema change, no wire change, so
mixed client/host versions are unaffected. Security: no new credential handling — reconnect reuses
the persisted target the recipe already produced. UI: none.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Known limitation, deliberately not addressed here: if the sandbox returns on a *different* endpoint
than the persisted `recipeResult` records, the reconnect fails. That is correct behaviour under the
execution-boundary rule — the runtime is left `running` and retryable rather than being declared
dead — but the user only learns about it through the existing "Failed to wake ephemeral VM workspace"
toast. A richer "reconnecting" representation would need a new status and therefore wire-compat work,
so it is out of scope.

## Local verification baseline

During local verification, `upstream/main` at `bf4e270504` had unrelated
baseline failures.

`pnpm lint`, `pnpm typecheck`, and `pnpm build` failed on duplicate
`lastActivityAt` keys in
`src/main/agent-hooks/first-work-branch-rename.test.ts`.

`pnpm test` failed in 19 files / 29 tests. Every failing suite reproduced
on a clean worktree at that same commit, with none of this PR's changes
present.

The duplicate-key regression has since been fixed on `main`. The suites
added or modified by this PR passed locally.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
