### PR TITLE
feat(terminal): render inline images (SIXEL / iTerm2 IIP) via @xterm/addon-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
     "@types/ws": "^8.18.1",
     "@vitejs/plugin-react": "^5.2.0",
     "@xterm/addon-fit": "0.12.0-beta.300",
+    "@xterm/addon-image": "0.10.0-beta.300",
     "@xterm/addon-ligatures": "0.11.0-beta.300",
     "@xterm/addon-search": "0.17.0-beta.300",
     "@xterm/addon-unicode11": "0.10.0-beta.300",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.300
         version: 0.12.0-beta.300(@xterm/xterm@6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4))
+      '@xterm/addon-image':
+        specifier: 0.10.0-beta.300
+        version: 0.10.0-beta.300(@xterm/xterm@6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4))
       '@xterm/addon-ligatures':
         specifier: 0.11.0-beta.300
         version: 0.11.0-beta.300(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4))
@@ -3519,6 +3522,11 @@ packages:
 
   '@xterm/addon-fit@0.12.0-beta.300':
     resolution: {integrity: sha512-geBeBBKqHe0Dmf+rT79wU/rglFJFja1QmKfcgmnQQhJTvAlrP+yHT2s+yy5PBeP8CtGPDvh5UcoWmunR9fBCuQ==}
+    peerDependencies:
+      '@xterm/xterm': ^6.1.0-beta.303
+
+  '@xterm/addon-image@0.10.0-beta.300':
+    resolution: {integrity: sha512-eF19wskh7io1KIFMHkJW0yMSTrDdvALp0ZjI4A27czpdTLquyB8LN0w+wNnpOU7D+B4CZp/8LxNta/LGMRIdCg==}
     peerDependencies:
       '@xterm/xterm': ^6.1.0-beta.303
 
@@ -9826,6 +9834,10 @@ snapshots:
   '@xmldom/xmldom@0.8.15': {}
 
   '@xterm/addon-fit@0.12.0-beta.300(@xterm/xterm@6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4))':
+    dependencies:
+      '@xterm/xterm': 6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4)
+
+  '@xterm/addon-image@0.10.0-beta.300(@xterm/xterm@6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4))':
     dependencies:
       '@xterm/xterm': 6.1.0-beta.303(patch_hash=1f36ce689bc50c703ae09aeda0e064f107e18e4a5ecba19e746fa5edc4b02ef4)
 

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -134,6 +134,7 @@ export function createPaneDOM(
     webLinksAddon,
     webglAddon: null,
     ligaturesAddon: null,
+    imageAddon: null,
     panePointerDownHandler,
     paneMouseEnterHandler,
     paneDragCleanup,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -19,6 +19,7 @@ import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-web
 import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 import { configureLazyArabicShapingJoiner } from './terminal-arabic-shaping-joiner'
 import { TerminalLigaturesAddon } from './terminal-ligatures-addon'
+import { attachInlineImages, disposeInlineImages } from './terminal-inline-image-addon'
 import { installTerminalImeCandidateAnchor } from './terminal-ime-candidate-anchor'
 
 // ---------------------------------------------------------------------------
@@ -54,6 +55,10 @@ export function openTerminal(pane: ManagedPaneInternal, ligaturesEnabled = false
   terminal.loadAddon(serializeAddon)
   terminal.loadAddon(unicode11Addon)
   terminal.loadAddon(webLinksAddon)
+  // Why after open(): the addon draws onto its own overlay canvas inside
+  // terminal.element, so it needs the DOM to exist. It is renderer-agnostic
+  // (DOM and WebGL), so it does not participate in the WebGL ordering below.
+  attachInlineImages(pane)
   attachTerminalMouseWheelMultiplier(terminal, {
     getTuiMouseWheelMultiplier: terminalTuiScrollSensitivity
   })
@@ -230,6 +235,7 @@ export function disposePane(
     /* ignore */
   }
   disposeWebgl(pane)
+  disposeInlineImages(pane)
   try {
     pane.searchAddon.dispose()
   } catch {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -6,6 +6,7 @@ import type { Unicode11Addon } from '@xterm/addon-unicode11'
 import type { WebLinksAddon } from '@xterm/addon-web-links'
 import type { WebglAddon } from '@xterm/addon-webgl'
 import type { SerializeAddon } from '@xterm/addon-serialize'
+import type { ImageAddon } from '@xterm/addon-image'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import type { TerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
@@ -114,6 +115,11 @@ export type ManagedPane = {
   fitAddon: FitAddon
   searchAddon: SearchAddon
   serializeAddon: SerializeAddon
+  // Why optional/nullable: the inline-image addon chunk loads lazily after
+  // open(), so the instance only exists once that resolves — and never for a
+  // pane disposed before it did. Exposed so callers (and e2e probes) can read
+  // decoded images by buffer cell.
+  imageAddon?: ImageAddon | null
 }
 
 export type PaneRenderingDiagnostics = {
@@ -167,6 +173,8 @@ export type ManagedPaneInternal = {
   // so the addon instance only exists while the feature is active. A null
   // value means "currently disabled".
   ligaturesAddon: LigaturesAddon | null
+  // Bumped by disposePane so an in-flight addon load can tell the pane is gone.
+  inlineImageAttachToken?: number
   fitResizeObserver: ResizeObserver | null
   // Why: fit-element pixel size at the last successful fit; the reveal fit compares
   // against it to tell a real hidden-time resize from a transient cell-metric wobble.

--- a/src/renderer/src/lib/pane-manager/pane-public-view.ts
+++ b/src/renderer/src/lib/pane-manager/pane-public-view.ts
@@ -10,7 +10,8 @@ export function toPublicPane(pane: ManagedPaneInternal): ManagedPane {
     linkTooltip: pane.linkTooltip,
     fitAddon: pane.fitAddon,
     searchAddon: pane.searchAddon,
-    serializeAddon: pane.serializeAddon
+    serializeAddon: pane.serializeAddon,
+    imageAddon: pane.imageAddon ?? null
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-public-view.ts
+++ b/src/renderer/src/lib/pane-manager/pane-public-view.ts
@@ -11,7 +11,12 @@ export function toPublicPane(pane: ManagedPaneInternal): ManagedPane {
     fitAddon: pane.fitAddon,
     searchAddon: pane.searchAddon,
     serializeAddon: pane.serializeAddon,
-    imageAddon: pane.imageAddon ?? null
+    // Why a getter: the inline-image addon attaches after the chunk resolves,
+    // so a view handed out earlier (onPaneCreated, a retained getActivePane
+    // result) must still observe the addon once it exists.
+    get imageAddon() {
+      return pane.imageAddon ?? null
+    }
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import {
+  attachInlineImages,
+  disposeInlineImages,
+  resetTerminalInlineImageAddonForTests,
+  TERMINAL_INLINE_IMAGE_OPTIONS
+} from './terminal-inline-image-addon'
+
+const imageMock = vi.hoisted(() => ({
+  dispose: vi.fn(),
+  constructed: [] as unknown[]
+}))
+
+vi.mock('@xterm/addon-image', () => ({
+  ImageAddon: vi.fn().mockImplementation(function ImageAddon(options: unknown) {
+    imageMock.constructed.push(options)
+    return { dispose: imageMock.dispose }
+  })
+}))
+
+function createPane(): ManagedPaneInternal {
+  return {
+    id: 7,
+    terminal: { loadAddon: vi.fn() } as never,
+    imageAddon: null
+  } as never
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('terminal inline image addon', () => {
+  beforeEach(() => {
+    resetTerminalInlineImageAddonForTests()
+    imageMock.dispose.mockClear()
+    imageMock.constructed.length = 0
+  })
+
+  it('loads the addon once the chunk resolves and reuses it for later panes', async () => {
+    const first = createPane()
+    attachInlineImages(first)
+    expect(first.imageAddon).toBeNull()
+
+    await flushMicrotasks()
+    expect(first.imageAddon).not.toBeNull()
+    expect(first.terminal.loadAddon).toHaveBeenCalledWith(first.imageAddon)
+    expect(imageMock.constructed[0]).toEqual(TERMINAL_INLINE_IMAGE_OPTIONS)
+
+    // Why: after the first resolve the constructor is memoised, so the next
+    // pane must attach synchronously — no frame without image parsing.
+    const second = createPane()
+    attachInlineImages(second)
+    expect(second.imageAddon).not.toBeNull()
+    expect(imageMock.constructed).toHaveLength(2)
+  })
+
+  it('does not attach to a pane disposed while the chunk was loading', async () => {
+    const pane = createPane()
+    attachInlineImages(pane)
+    disposeInlineImages(pane)
+
+    await flushMicrotasks()
+    expect(pane.imageAddon).toBeNull()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+  })
+
+  it('disposes the addon and clears the pane reference', async () => {
+    const pane = createPane()
+    attachInlineImages(pane)
+    await flushMicrotasks()
+
+    disposeInlineImages(pane)
+    expect(imageMock.dispose).toHaveBeenCalledTimes(1)
+    expect(pane.imageAddon).toBeNull()
+  })
+
+  it('is idempotent for a pane that already has the addon', async () => {
+    const pane = createPane()
+    attachInlineImages(pane)
+    await flushMicrotasks()
+    attachInlineImages(pane)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves the pane without images and allows a retry when the chunk fails to load', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    // Why a fresh module instance: the loader memoises the constructor, so the
+    // failure path needs its own copy that has never resolved the chunk.
+    vi.resetModules()
+    vi.doMock('@xterm/addon-image', () => {
+      throw new Error('chunk missing')
+    })
+    const loader = await import('./terminal-inline-image-addon')
+    const pane = createPane()
+    loader.attachInlineImages(pane)
+    await flushMicrotasks()
+
+    expect(pane.imageAddon).toBeNull()
+    expect(pane.terminal.loadAddon).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('inline image addon failed to load'),
+      expect.anything()
+    )
+
+    // Why: the failed promise must not be memoised, otherwise every later pane
+    // in the session silently loses images after one transient failure.
+    vi.doUnmock('@xterm/addon-image')
+    vi.resetModules()
+    expect(await loader.primeTerminalInlineImageAddon()).not.toBeNull()
+    warn.mockRestore()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.test.ts
@@ -3,9 +3,11 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 import {
   attachInlineImages,
   disposeInlineImages,
+  primeTerminalInlineImageAddon,
   resetTerminalInlineImageAddonForTests,
   TERMINAL_INLINE_IMAGE_OPTIONS
 } from './terminal-inline-image-addon'
+import { toPublicPane } from './pane-public-view'
 
 const imageMock = vi.hoisted(() => ({
   dispose: vi.fn(),
@@ -54,6 +56,28 @@ describe('terminal inline image addon', () => {
     attachInlineImages(second)
     expect(second.imageAddon).not.toBeNull()
     expect(imageMock.constructed).toHaveLength(2)
+  })
+
+  // Why: the addon is a parser hook — output parsed before it attaches loses
+  // its images for good — so the boot-time prime must make even the *first*
+  // pane attach synchronously inside openTerminal.
+  it('attaches the first pane synchronously once the boot prime has resolved', async () => {
+    await primeTerminalInlineImageAddon()
+    const pane = createPane()
+    attachInlineImages(pane)
+    expect(pane.imageAddon).not.toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets a retained public pane view observe the addon after a lazy attach', async () => {
+    const pane = createPane()
+    const view = toPublicPane(pane)
+    expect(view.imageAddon).toBeNull()
+    attachInlineImages(pane)
+    await flushMicrotasks()
+    expect(view.imageAddon).toBe(pane.imageAddon)
+    disposeInlineImages(pane)
+    expect(view.imageAddon).toBeNull()
   })
 
   it('does not attach to a pane disposed while the chunk was loading', async () => {

--- a/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.ts
@@ -17,6 +17,16 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 // from the memoised constructor, and the async branch in attachInlineImages is
 // only the fallback for a pane that somehow opens before the prime settled.
 
+// DA1 identity: the addon registers its own primary-DA (`CSI c`) reply
+// (`\x1b[?62;4;9;22c`, advertising SIXEL). xterm dispatches CSI handlers
+// most-recently-registered first, and Orca installs its own DA1 responder
+// (installTerminalCapabilityReplyHandlers, with the replay guard and the
+// ConPTY variant) at PTY connect — after openTerminal attached this addon —
+// so Orca's `\x1b[?1;2c` keeps winning and the terminal identity does not
+// change. Consequence: TUIs that autodetect SIXEL purely from DA1 (yazi,
+// chafa) still see no SIXEL flag; advertising it means updating every DA1
+// responder and reply-echo filter (renderer, daemon startup, ConPTY) in one
+// coherent change, which is a follow-up, not something to leak from here.
 export const TERMINAL_INLINE_IMAGE_OPTIONS: Partial<IImageAddonOptions> = {
   sixelSupport: true,
   iipSupport: true,

--- a/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.ts
@@ -1,0 +1,107 @@
+import type { IImageAddonOptions, ImageAddon } from '@xterm/addon-image'
+import type { ManagedPaneInternal } from './pane-manager-types'
+
+// Why this exists: the embedded terminal parsed no image protocol at all, so
+// yazi/chafa/timg fell back to block art and agents that emit screenshots
+// (pi, Kimi, OpenCode) left a blank gap (#11668, #13336, #18414, #18481).
+// `@xterm/addon-image` is the xterm.js-org addon that handles SIXEL, the
+// iTerm2 inline-image protocol (OSC 1337) and part of the kitty graphics
+// protocol, and it answers DA1/CSI t size probes so TUIs can detect support.
+//
+// Why deferred: the addon is ~80 KB and only matters once a terminal opens, so
+// keep it off the boot chunk the same way the WebGL addon is. The load stays
+// eager — openTerminal kicks it off — but the constructor is memoised so every
+// pane after the first attaches synchronously.
+
+export const TERMINAL_INLINE_IMAGE_OPTIONS: Partial<IImageAddonOptions> = {
+  sixelSupport: true,
+  iipSupport: true,
+  // Why 64 MB (default 128): images are held as unpacked RGBA canvases and a
+  // long agent session can stream many screenshots. FIFO eviction keeps the
+  // renderer bounded; evicted images leave the addon's placeholder in
+  // scrollback rather than a silent gap.
+  storageLimit: 64
+}
+
+type ImageAddonConstructor = new (options?: Partial<IImageAddonOptions>) => ImageAddon
+
+let imageAddonConstructor: ImageAddonConstructor | null = null
+let imageAddonLoad: Promise<ImageAddonConstructor | null> | null = null
+
+export function primeTerminalInlineImageAddon(): Promise<ImageAddonConstructor | null> {
+  if (imageAddonConstructor) {
+    return Promise.resolve(imageAddonConstructor)
+  }
+  if (!imageAddonLoad) {
+    imageAddonLoad = import('@xterm/addon-image').then(
+      (module) => {
+        imageAddonConstructor = module.ImageAddon
+        return imageAddonConstructor
+      },
+      (error) => {
+        // Why clear the memo: a transient chunk failure must not strand every
+        // later pane without images for the whole session.
+        imageAddonLoad = null
+        console.warn('[terminal] inline image addon failed to load — images disabled:', error)
+        return null
+      }
+    )
+  }
+  return imageAddonLoad
+}
+
+function loadInlineImageAddon(pane: ManagedPaneInternal, Ctor: ImageAddonConstructor): void {
+  if (pane.imageAddon) {
+    return
+  }
+  try {
+    const imageAddon = new Ctor(TERMINAL_INLINE_IMAGE_OPTIONS)
+    pane.terminal.loadAddon(imageAddon)
+    pane.imageAddon = imageAddon
+  } catch (err) {
+    console.warn('[terminal] inline image addon failed to attach for pane', pane.id, err)
+    pane.imageAddon = null
+  }
+}
+
+/** Attach inline-image decoding to an opened terminal. Safe to call before the
+ *  addon chunk has loaded: the attach completes once it resolves, unless the
+ *  pane was disposed in the meantime. */
+export function attachInlineImages(pane: ManagedPaneInternal): void {
+  if (pane.imageAddon) {
+    return
+  }
+  if (imageAddonConstructor) {
+    loadInlineImageAddon(pane, imageAddonConstructor)
+    return
+  }
+  const attachToken = (pane.inlineImageAttachToken ?? 0) + 1
+  pane.inlineImageAttachToken = attachToken
+  void primeTerminalInlineImageAddon().then((Ctor) => {
+    // Why the token: disposePane bumps it, so a load that resolves after the
+    // pane closed must not push an addon into a disposed terminal.
+    if (!Ctor || pane.inlineImageAttachToken !== attachToken) {
+      return
+    }
+    loadInlineImageAddon(pane, Ctor)
+  })
+}
+
+export function disposeInlineImages(pane: ManagedPaneInternal): void {
+  pane.inlineImageAttachToken = (pane.inlineImageAttachToken ?? 0) + 1
+  if (!pane.imageAddon) {
+    return
+  }
+  try {
+    pane.imageAddon.dispose()
+  } catch {
+    /* ignore */
+  }
+  pane.imageAddon = null
+}
+
+/** Test seam: forget the memoised constructor so a spec can exercise the load path again. */
+export function resetTerminalInlineImageAddonForTests(): void {
+  imageAddonConstructor = null
+  imageAddonLoad = null
+}

--- a/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-inline-image-addon.ts
@@ -9,9 +9,13 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 // protocol, and it answers DA1/CSI t size probes so TUIs can detect support.
 //
 // Why deferred: the addon is ~80 KB and only matters once a terminal opens, so
-// keep it off the boot chunk the same way the WebGL addon is. The load stays
-// eager — openTerminal kicks it off — but the constructor is memoised so every
-// pane after the first attaches synchronously.
+// keep it off the boot chunk the same way the WebGL addon is. Unlike WebGL it
+// hooks the *parser*: an image sequence parsed before the addon attaches is
+// consumed and cannot be replayed. So both renderer entry points prime the
+// load right after first render (see main.tsx / web/main.tsx), which resolves
+// long before the first pane opens; openTerminal then attaches synchronously
+// from the memoised constructor, and the async branch in attachInlineImages is
+// only the fallback for a pane that somehow opens before the prime settled.
 
 export const TERMINAL_INLINE_IMAGE_OPTIONS: Partial<IImageAddonOptions> = {
   sixelSupport: true,
@@ -28,6 +32,9 @@ type ImageAddonConstructor = new (options?: Partial<IImageAddonOptions>) => Imag
 let imageAddonConstructor: ImageAddonConstructor | null = null
 let imageAddonLoad: Promise<ImageAddonConstructor | null> | null = null
 
+/** Start (or reuse) the deferred addon chunk load. Resolves to the constructor,
+ *  or null when the chunk failed — a failure is not memoised so a later call
+ *  retries. Called at renderer boot and, as a fallback, by attachInlineImages. */
 export function primeTerminalInlineImageAddon(): Promise<ImageAddonConstructor | null> {
   if (imageAddonConstructor) {
     return Promise.resolve(imageAddonConstructor)
@@ -50,6 +57,7 @@ export function primeTerminalInlineImageAddon(): Promise<ImageAddonConstructor |
   return imageAddonLoad
 }
 
+/** Construct the addon with Orca's limits and load it into the pane's terminal. */
 function loadInlineImageAddon(pane: ManagedPaneInternal, Ctor: ImageAddonConstructor): void {
   if (pane.imageAddon) {
     return
@@ -87,6 +95,7 @@ export function attachInlineImages(pane: ManagedPaneInternal): void {
   })
 }
 
+/** Release the pane's image storage and invalidate any attach still in flight. */
 export function disposeInlineImages(pane: ManagedPaneInternal): void {
   pane.inlineImageAttachToken = (pane.inlineImageAttachToken ?? 0) + 1
   if (!pane.imageAddon) {

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -22,6 +22,7 @@ import { I18nProvider } from './i18n/I18nProvider'
 import { translate } from './i18n/i18n'
 import { getOrCreateRendererRoot } from './lib/react-renderer-root'
 import { primeTerminalWebglAddon } from './lib/pane-manager/pane-webgl-renderer'
+import { primeTerminalInlineImageAddon } from './lib/pane-manager/terminal-inline-image-addon'
 import { SkillWarningPreviewLauncher } from './components/skills/SkillWarningPreviewLauncher'
 import { installBrowserClientPageRenderer } from './components/browser-pane/browser-client-page-renderer-installation'
 
@@ -83,3 +84,9 @@ recordRendererCrashBreadcrumb('renderer_bootstrap_rendered')
 // Starting the load after the first render keeps it off the boot graph while
 // leaving it resolved long before any pane can attach.
 void primeTerminalWebglAddon()
+// Why here too: the inline-image addon is a *parser* hook, not just a renderer.
+// An OSC 1337 / SIXEL sequence that reaches xterm before the addon is loaded
+// is consumed as an unknown sequence and cannot be replayed once the addon
+// attaches. Starting the load right after first render leaves it resolved
+// before the first pane can open, so openTerminal attaches it synchronously.
+void primeTerminalInlineImageAddon()

--- a/src/renderer/src/web/main.tsx
+++ b/src/renderer/src/web/main.tsx
@@ -102,3 +102,6 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 void import('../lib/pane-manager/pane-webgl-renderer').then((module) =>
   module.primeTerminalWebglAddon()
 )
+void import('../lib/pane-manager/terminal-inline-image-addon').then((module) =>
+  module.primeTerminalInlineImageAddon()
+)

--- a/src/renderer/src/web/main.tsx
+++ b/src/renderer/src/web/main.tsx
@@ -102,6 +102,11 @@ ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
 void import('../lib/pane-manager/pane-webgl-renderer').then((module) =>
   module.primeTerminalWebglAddon()
 )
-void import('../lib/pane-manager/terminal-inline-image-addon').then((module) =>
-  module.primeTerminalInlineImageAddon()
+void import('../lib/pane-manager/terminal-inline-image-addon').then(
+  (module) => module.primeTerminalInlineImageAddon(),
+  (error) => {
+    // Why: a missing loader chunk must degrade to "no inline images", not an
+    // unhandled rejection; the first pane's attach will retry the load itself.
+    console.warn('[terminal] inline image loader failed to load — images disabled:', error)
+  }
 )

--- a/tests/e2e/terminal-inline-image.spec.ts
+++ b/tests/e2e/terminal-inline-image.spec.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { deflateSync } from 'node:zlib'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForSessionReady } from './helpers/store'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { nodeTerminalCommand } from './terminal-node-command'
+import { waitForPtyShellEcho } from './terminal-pty-readiness'
+
+// Why a hand-built PNG: the spec must not depend on a binary fixture or an
+// image library — a 16×16 solid red square is enough to prove the sequence was
+// decoded and placed into the buffer.
+const IMAGE_SIZE = 16
+const IMAGE_ROWS = 4
+const IMAGE_COLS = 8
+
+function crc32(bytes: Uint8Array): number {
+  let crc = -1
+  for (const byte of bytes) {
+    crc ^= byte
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1))
+    }
+  }
+  return (crc ^ -1) >>> 0
+}
+
+function pngChunk(type: string, data: Uint8Array): Buffer {
+  const typeBytes = Buffer.from(type, 'ascii')
+  const length = Buffer.alloc(4)
+  length.writeUInt32BE(data.length)
+  const crc = Buffer.alloc(4)
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])))
+  return Buffer.concat([length, typeBytes, data, crc])
+}
+
+function solidRedPngBase64(): string {
+  const header = Buffer.alloc(13)
+  header.writeUInt32BE(IMAGE_SIZE, 0)
+  header.writeUInt32BE(IMAGE_SIZE, 4)
+  header[8] = 8 // bit depth
+  header[9] = 2 // RGB
+  const raw = Buffer.alloc((1 + IMAGE_SIZE * 3) * IMAGE_SIZE)
+  for (let y = 0; y < IMAGE_SIZE; y += 1) {
+    const rowStart = y * (1 + IMAGE_SIZE * 3)
+    raw[rowStart] = 0 // filter: none
+    for (let x = 0; x < IMAGE_SIZE; x += 1) {
+      raw[rowStart + 1 + x * 3] = 0xff
+    }
+  }
+  return Buffer.concat([
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+    pngChunk('IHDR', header),
+    pngChunk('IDAT', deflateSync(raw)),
+    pngChunk('IEND', Buffer.alloc(0))
+  ]).toString('base64')
+}
+
+type ImageProbe = {
+  imageAddonLoaded: boolean
+  markerRow: number | null
+  imageCellsHit: number
+  redPixelFound: boolean
+}
+
+async function probeInlineImage(page: Page, marker: string): Promise<ImageProbe> {
+  return page.evaluate(
+    ({ marker, rows, cols }) => {
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? (state.activeTabId ?? null)
+          : worktreeId
+            ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      if (!pane) {
+        throw new Error('active terminal pane unavailable')
+      }
+      const buffer = pane.terminal.buffer.active
+      let markerRow: number | null = null
+      for (let row = 0; row < buffer.length; row += 1) {
+        if (buffer.getLine(row)?.translateToString(true).includes(marker)) {
+          markerRow = row
+        }
+      }
+      const addon = pane.imageAddon ?? null
+      let imageCellsHit = 0
+      let redPixelFound = false
+      if (addon && markerRow !== null) {
+        for (let row = markerRow - rows; row < markerRow; row += 1) {
+          for (let col = 0; col < cols; col += 1) {
+            const canvas = addon.getImageAtBufferCell(col, row)
+            if (!canvas) {
+              continue
+            }
+            imageCellsHit += 1
+            const pixel = canvas.getContext('2d')?.getImageData(1, 1, 1, 1).data
+            if (
+              pixel &&
+              pixel[0] === 0xff &&
+              pixel[1] === 0 &&
+              pixel[2] === 0 &&
+              pixel[3] === 0xff
+            ) {
+              redPixelFound = true
+            }
+          }
+        }
+      }
+      return { imageAddonLoaded: addon !== null, markerRow, imageCellsHit, redPixelFound }
+    },
+    { marker, rows: IMAGE_ROWS, cols: IMAGE_COLS }
+  )
+}
+
+async function captureProof(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ path: testInfo.outputPath(name), animations: 'disabled' })
+}
+
+test.describe('terminal inline images', () => {
+  test('decodes an iTerm2 inline image sequence into the terminal buffer', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyShellEcho(orcaPage, ptyId, 15_000)
+
+    const marker = `ORCA_INLINE_IMAGE_${randomUUID().slice(0, 8)}`
+    const scriptDir = mkdtempSync(path.join(os.tmpdir(), 'orca-inline-image-'))
+    const scriptPath = path.join(scriptDir, 'print-inline-image.js')
+    // Why a script rather than printf: the sequence must reach the PTY byte for
+    // byte on every platform's shell, and Windows has no printf.
+    writeFileSync(
+      scriptPath,
+      [
+        `const image = ${JSON.stringify(solidRedPngBase64())}`,
+        `process.stdout.write('\\x1b]1337;File=inline=1;width=${IMAGE_COLS};height=${IMAGE_ROWS};preserveAspectRatio=0:' + image + '\\x07\\n')`,
+        `process.stdout.write(${JSON.stringify(marker)} + '\\n')`
+      ].join('\n')
+    )
+    try {
+      await sendToTerminal(orcaPage, ptyId, `${nodeTerminalCommand([scriptPath])}\r`)
+      await waitForTerminalOutput(orcaPage, marker)
+
+      await expect
+        .poll(() => probeInlineImage(orcaPage, marker), {
+          timeout: 10_000,
+          message: 'inline image was not decoded into the terminal buffer'
+        })
+        .toMatchObject({
+          imageAddonLoaded: true,
+          imageCellsHit: IMAGE_ROWS * IMAGE_COLS,
+          redPixelFound: true
+        })
+      await captureProof(orcaPage, testInfo, 'terminal-inline-image-after.png')
+    } finally {
+      rmSync(scriptDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## ELI5

Programs running inside Orca's terminal can now show pictures. When a tool like yazi, chafa, timg, or a coding agent (pi, Kimi, OpenCode) prints an image using the standard terminal image sequences, Orca draws the image in the terminal instead of leaving a blank gap.

## What Changed

- Added `@xterm/addon-image` (the xterm.js-org addon, `0.10.0-beta.300`, whose peer range is exactly the `@xterm/xterm 6.1.0-beta.303` Orca already ships). It handles SIXEL and the iTerm2 inline image protocol (OSC 1337), plus part of the kitty graphics protocol.
  - **DA1 identity is unchanged.** The addon registers its own primary-DA reply (`\x1b[?62;4;9;22c`, advertising SIXEL), but xterm dispatches CSI handlers most-recently-registered first and Orca installs its own DA1 responder (`installTerminalCapabilityReplyHandlers`, with the replay guard and ConPTY variant) at PTY connect, after `openTerminal` attached the addon — so Orca's `\x1b[?1;2c` keeps winning (verified against `@xterm/headless`). Consequence: TUIs that autodetect SIXEL purely from DA1 (yazi, chafa) still see no SIXEL flag in this PR; IIP/kitty emitters (pi, Kimi, OpenCode, OMP with a forced protocol) and explicitly configured SIXEL work. Advertising SIXEL means updating every DA1 responder and reply-echo filter (renderer, daemon startup, ConPTY) coherently, which is a follow-up.
- New `terminal-inline-image-addon.ts` loads the addon with a dynamic `import()` so the ~80 KB chunk stays off the boot path (same reasoning as the WebGL addon loader). The constructor is memoised, so only the first pane pays the async hop; later panes attach synchronously. A failed chunk load is warned and not memoised, so one transient failure does not disable images for the session.
- `openTerminal` attaches it after `terminal.open()`; `disposePane` disposes it. A pane closed while the chunk is still loading bumps a token so the late resolve is dropped instead of loading into a disposed terminal.
- Storage cap set to 64 MB (addon default 128 MB). Images are held as unpacked RGBA canvases and agent sessions can stream many screenshots; FIFO eviction keeps the renderer bounded and leaves the addon's placeholder in scrollback.
- `ManagedPane` (public view) exposes `imageAddon` so callers and probes can read decoded images by buffer cell via `getImageAtBufferCell`.

Not in this PR (follow-ups): advertising SIXEL in DA1 (see above); a settings toggle to turn images off (as #13336 suggested, mirroring the GPU/ligature precedent); image persistence across remote reattach, because `@xterm/addon-serialize` does not serialise images, so a paired remote terminal restored from a snapshot shows the placeholder for images received before the reattach.

## Why

Fixes the most-requested terminal gap on the tracker: #11668 (pi / Kimi inline images), with #13336 (yazi / chafa detection, closed as duplicate), #18414 (broken image rendering vs Ghostty), #18481 (SSH remote images) and #6880 (capability detection) all describing the same missing feature. Every image-capable TUI already speaks SIXEL or IIP, and the xterm.js org maintains a first-party addon for exactly this, so adopting it is far cheaper and safer than a bespoke decoder.

## Linked Issue

Fixes #11668
Refs #13336, #18414, #18481, #6880

## Visual Proof

Same script (`node print-inline-image.js`, which writes an OSC 1337 sequence with a PNG) run in the embedded terminal.

**Before** (main): the sequence is silently consumed, nothing is drawn.

![before: blank gap where the image should be](https://raw.githubusercontent.com/lmsh7/orca/02d6577e1da91baa6fe9d303e5ec318f673d6806/inline-images-before.png)

**After** (this branch): the image renders inline at the requested cell size and the cursor advances past it.

![after: crest rendered inline](https://raw.githubusercontent.com/lmsh7/orca/02d6577e1da91baa6fe9d303e5ec318f673d6806/inline-images-after.png)

## Testing

- `pnpm typecheck`, `pnpm exec oxlint src tests`, `audit:code-quality:*`, `check:*-ratchet`, `check:reliability-gates` — pass (the only typecheck errors are the two pre-existing duplicate-key errors in `src/main/agent-hooks/first-work-branch-rename.test.ts` on main).
- `vitest run src/renderer/src/lib/pane-manager src/renderer/src/components/terminal-pane` — 5075 passed.
- New unit spec `terminal-inline-image-addon.test.ts`: lazy load + memoised reuse, dispose-before-load drops the late attach, dispose clears the addon, idempotent attach, failed chunk load warns and allows retry.
- New e2e spec `tests/e2e/terminal-inline-image.spec.ts` (electron-headless): builds a 16×16 PNG in-test, prints it through the PTY via `nodeTerminalCommand` (no printf, so it runs on Windows shells too), then asserts every cell of the 8×4 image area resolves through `getImageAtBufferCell` and reads back the red pixel. Passes locally on macOS (Apple Silicon).
- Platforms actually tested: macOS 26 (arm64). Linux/Windows: no platform-specific code paths, the addon is pure renderer-side JS on top of xterm.js; CI e2e should cover.
- Remote/SSH: rendering happens in the renderer on the received byte stream, so remote shells get images too (#18481). Reattach from a serialised snapshot loses images received earlier (placeholder), see "Not in this PR".

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Claude Fable 5.1); the author reviewed, ran the checks, and captured the screenshots.

## Review

Agent review summary:
- Cross-platform: no `process.platform` branches, no paths; the addon is renderer-only JS on top of xterm.js and the e2e uses `nodeTerminalCommand` so it does not rely on `printf`.
- SSH/remote/local: renderer-side decode of the incoming stream, independent of where the PTY lives. Known limitation: images are not part of `@xterm/addon-serialize` output, so snapshot-based reattach shows a placeholder.
- Agents/integrations: provider-neutral; benefits any TUI or agent emitting SIXEL/IIP.
- Performance: chunk is deferred off boot; parser hooks are inert without image sequences; memory bounded by `storageLimit: 64` MB FIFO plus the addon's `pixelLimit` (16 M px) decode guard. `enableSizeReports` stays at the addon default so `CSI 14/16/18 t` size queries answer, which image TUIs need for layout.
- UI: no new UI.
- Security: the addon only decodes PNG/JPEG/GIF via the browser's `Image`/canvas path and SIXEL via its own decoder; no file download support (IIP `inline=0` is ignored), no network.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- `pnpm-lock.yaml` gains only the `@xterm/addon-image` entry.
- `0.10.0-beta.300` was published 2026-08-24, clearing the workspace's 3-day `minimumReleaseAge`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Author X handle: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

