### PR TITLE
feat(mobile/chat): turn-jump outline for long threads

### DIFF
--- a/mobile/src/session/MobileNativeChatScrollControls.tsx
+++ b/mobile/src/session/MobileNativeChatScrollControls.tsx
@@ -1,0 +1,48 @@
+import { Pressable } from 'react-native'
+import { ArrowDown, List } from 'lucide-react-native'
+import { colors, spacing } from '../theme/mobile-theme'
+import { styles } from './mobile-native-chat-view-styles'
+
+type Props = {
+  /** Whether the list is pinned to the newest message (hides jump-to-latest). */
+  atBottom: boolean
+  /** Show the turn-jump button; the view gates this on the outline size. */
+  canJumpToTurn: boolean
+  onScrollToLatest: () => void
+  onOpenOutline: () => void
+}
+
+/** The floating controls overlaid on the chat list: jump-to-latest and the
+ *  turn-jump outline opener. The outline button sits above the jump-to-latest
+ *  slot so the two never overlap. */
+export function MobileNativeChatScrollControls({
+  atBottom,
+  canJumpToTurn,
+  onScrollToLatest,
+  onOpenOutline
+}: Props): React.JSX.Element {
+  return (
+    <>
+      {/* The scroll-to-top affordance now lives per-message (the up-arrow in
+          each agent message's controls). */}
+      {!atBottom ? (
+        <Pressable
+          accessibilityLabel="Scroll to latest"
+          style={[styles.fab, styles.fabBottom]}
+          onPress={onScrollToLatest}
+        >
+          <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
+        </Pressable>
+      ) : null}
+      {canJumpToTurn ? (
+        <Pressable
+          accessibilityLabel="Jump to a turn"
+          style={[styles.fab, { bottom: atBottom ? spacing.md : spacing.md + 46 }]}
+          onPress={onOpenOutline}
+        >
+          <List size={18} color={colors.textPrimary} strokeWidth={2.2} />
+        </Pressable>
+      ) : null}
+    </>
+  )
+}

--- a/mobile/src/session/MobileNativeChatTurnJumpSheet.tsx
+++ b/mobile/src/session/MobileNativeChatTurnJumpSheet.tsx
@@ -1,0 +1,127 @@
+import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native'
+import { colors, spacing, typography } from '../theme/mobile-theme'
+import { BottomDrawer } from '../components/BottomDrawer'
+import type { MobileNativeChatOutlineItem } from './mobile-native-chat-render-data'
+
+type Props = {
+  visible: boolean
+  onClose: () => void
+  items: MobileNativeChatOutlineItem[]
+  /** Jump the list to a `data` index; the view maps it onto its FlatList. */
+  onJump: (index: number) => void
+}
+
+/** Conversation outline: the user turns of the thread, tap one to jump. Lets a
+ *  long thread be navigated by turn instead of dragging through every message. */
+export function MobileNativeChatTurnJumpSheet({ visible, onClose, items, onJump }: Props) {
+  return (
+    <BottomDrawer visible={visible} onClose={onClose} dragContentToDismiss={false}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Jump to turn</Text>
+      </View>
+      <FlatList
+        data={items}
+        keyExtractor={(item) => String(item.index)}
+        style={styles.list}
+        contentContainerStyle={items.length === 0 ? styles.emptyContent : undefined}
+        keyboardShouldPersistTaps="handled"
+        nestedScrollEnabled
+        ItemSeparatorComponent={TurnSeparator}
+        ListEmptyComponent={<Text style={styles.empty}>No turns to jump to yet.</Text>}
+        renderItem={({ item, index }) => (
+          <Pressable
+            style={({ pressed }) => [styles.item, pressed && styles.itemPressed]}
+            accessibilityLabel={`Jump to turn ${index + 1}`}
+            onPress={() => {
+              onClose()
+              onJump(item.index)
+            }}
+          >
+            <Text style={styles.ordinal}>{index + 1}</Text>
+            <View style={styles.copy}>
+              <Text style={styles.itemTitle} numberOfLines={2}>
+                {item.title}
+              </Text>
+              {item.subtitle ? (
+                <Text style={styles.itemSubtitle} numberOfLines={2}>
+                  {item.subtitle}
+                </Text>
+              ) : null}
+            </View>
+          </Pressable>
+        )}
+      />
+    </BottomDrawer>
+  )
+}
+
+function TurnSeparator() {
+  return <View style={styles.separator} />
+}
+
+const styles = StyleSheet.create({
+  header: {
+    paddingHorizontal: spacing.xs,
+    paddingBottom: spacing.sm
+  },
+  title: {
+    fontSize: 13,
+    fontWeight: '500',
+    color: colors.textMuted
+  },
+  list: {
+    backgroundColor: colors.bgPanel,
+    borderRadius: 12,
+    overflow: 'hidden',
+    maxHeight: 460,
+    flexGrow: 0
+  },
+  emptyContent: {
+    minHeight: spacing.xl,
+    justifyContent: 'center'
+  },
+  empty: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    textAlign: 'center',
+    paddingVertical: spacing.md
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginHorizontal: spacing.md
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md
+  },
+  itemPressed: {
+    backgroundColor: colors.bgRaised
+  },
+  ordinal: {
+    color: colors.textMuted,
+    fontSize: typography.metaSize,
+    fontWeight: '700',
+    minWidth: 18,
+    textAlign: 'right',
+    // Nudge the ordinal onto the title's first-line baseline.
+    marginTop: 1
+  },
+  copy: {
+    flex: 1,
+    minWidth: 0
+  },
+  itemTitle: {
+    fontSize: typography.bodySize,
+    color: colors.textPrimary,
+    fontWeight: '600'
+  },
+  itemSubtitle: {
+    fontSize: typography.metaSize,
+    color: colors.textMuted,
+    marginTop: 2
+  }
+})

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -44,6 +44,14 @@ vi.mock('./MobileNativeChatQuestion', () => ({ MobileNativeChatQuestion: 'ChatQu
 vi.mock('./MobileAgentWorkingIndicator', () => ({
   MobileAgentWorkingIndicator: 'WorkingIndicator'
 }))
+// Stub the scroll/turn-jump overlays; the turn-jump sheet pulls reanimated via
+// BottomDrawer, which these banner tests don't need.
+vi.mock('./MobileNativeChatScrollControls', () => ({
+  MobileNativeChatScrollControls: 'ScrollControls'
+}))
+vi.mock('./MobileNativeChatTurnJumpSheet', () => ({
+  MobileNativeChatTurnJumpSheet: 'TurnJumpSheet'
+}))
 
 // Stand-in composer: exposes the view's `handleSend` through a pressable, which is
 // the only composer behaviour these banner tests exercise.

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -10,16 +10,19 @@ import {
 } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler'
-import { ArrowDown, ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
+import { ChevronsDownUp, ChevronsUpDown, Square } from 'lucide-react-native'
 import type { AskAnswerSelection, AskPrompt } from '../../../src/shared/native-chat-ask'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 import { colors } from '../theme/mobile-theme'
 import { styles } from './mobile-native-chat-view-styles'
 import {
   buildMobileNativeChatTransientData,
+  deriveMobileNativeChatOutline,
   mobileNativeChatEmptyState,
   type MobileNativeChatPendingItem
 } from './mobile-native-chat-render-data'
+import { MobileNativeChatScrollControls } from './MobileNativeChatScrollControls'
+import { MobileNativeChatTurnJumpSheet } from './MobileNativeChatTurnJumpSheet'
 import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
 import { useMobileNativeChatTurnDisclosure } from './use-mobile-native-chat-turn-disclosure'
 import { MobileNativeChatTurnStatus } from './MobileNativeChatTurnStatus'
@@ -177,6 +180,7 @@ export function MobileNativeChatView({
   // never sits under the home indicator / nav bar (mirrors the terminal dock).
   const bottomPad = keyboardInset > 0 ? keyboardInset + insets.bottom : insets.bottom
   const [atBottom, setAtBottom] = useState(true)
+  const [outlineOpen, setOutlineOpen] = useState(false)
   const sendScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const { fontScale, pinchGesture } = useMobileNativeChatPinchGesture()
   useEffect(
@@ -202,6 +206,10 @@ export function MobileNativeChatView({
       }),
     [messages, folded, streaming, pending, imagePreviewsByMessageId]
   )
+
+  // One outline entry per user turn, for the turn-jump sheet. Same source and
+  // deps as `data`, so a tapped entry's index addresses the live list.
+  const outline = useMemo(() => deriveMobileNativeChatOutline(data), [data])
 
   // Follow the tail as the conversation grows and keep the newest message above
   // the keyboard when it opens — but only when already pinned to the bottom, so
@@ -372,17 +380,12 @@ export function MobileNativeChatView({
               }
             />
           </GestureDetector>
-          {/* Jump-to-latest control. The scroll-to-top affordance now lives
-              per-message (the up-arrow in each agent message's controls). */}
-          {!atBottom ? (
-            <Pressable
-              accessibilityLabel="Scroll to latest"
-              style={[styles.fab, styles.fabBottom]}
-              onPress={() => listRef.current?.scrollToEnd({ animated: true })}
-            >
-              <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
-            </Pressable>
-          ) : null}
+          <MobileNativeChatScrollControls
+            atBottom={atBottom}
+            canJumpToTurn={outline.length >= 2}
+            onScrollToLatest={() => listRef.current?.scrollToEnd({ animated: true })}
+            onOpenOutline={() => setOutlineOpen(true)}
+          />
         </GestureHandlerRootView>
       )}
       <MobileNativeChatPromptCard
@@ -463,6 +466,12 @@ export function MobileNativeChatView({
         }
         filePaths={filePaths}
         onNeedFiles={onNeedFiles}
+      />
+      <MobileNativeChatTurnJumpSheet
+        visible={outlineOpen}
+        onClose={() => setOutlineOpen(false)}
+        items={outline}
+        onJump={onScrollToMessage}
       />
     </View>
   )

--- a/mobile/src/session/mobile-native-chat-outline.test.ts
+++ b/mobile/src/session/mobile-native-chat-outline.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
+import { deriveMobileNativeChatOutline } from './mobile-native-chat-render-data'
+
+function user(id: string, text: string): NativeChatMessage {
+  return { id, role: 'user', blocks: [{ type: 'text', text }], timestamp: 0, source: 'transcript' }
+}
+
+function assistant(id: string, text: string): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text }],
+    timestamp: 0,
+    source: 'transcript'
+  }
+}
+
+describe('deriveMobileNativeChatOutline', () => {
+  it('emits one entry per user turn, carrying its data index', () => {
+    const data = [
+      user('u1', 'first question'),
+      assistant('a1', 'first answer'),
+      user('u2', 'second question'),
+      assistant('a2', 'second answer')
+    ]
+    expect(deriveMobileNativeChatOutline(data)).toEqual([
+      { index: 0, title: 'first question', subtitle: 'first answer' },
+      { index: 2, title: 'second question', subtitle: 'second answer' }
+    ])
+  })
+
+  it('uses the final assistant text of the turn as the subtitle', () => {
+    // Intervening assistant/tool rows don't reset the subtitle; the last one wins.
+    const data = [
+      user('u1', 'go'),
+      assistant('a1', 'starting'),
+      assistant('a2', 'still working'),
+      assistant('a3', 'all done'),
+      user('u2', 'next')
+    ]
+    const [first] = deriveMobileNativeChatOutline(data)
+    expect(first).toEqual({ index: 0, title: 'go', subtitle: 'all done' })
+  })
+
+  it('takes only the first non-blank line of a multi-line prompt', () => {
+    const data = [user('u1', '\n\nrefactor the parser\nand add tests\nplease')]
+    expect(deriveMobileNativeChatOutline(data)[0].title).toBe('refactor the parser')
+  })
+
+  it('truncates a long prompt line with an ellipsis', () => {
+    const long = 'x'.repeat(200)
+    const title = deriveMobileNativeChatOutline([user('u1', long)])[0].title
+    expect(title.length).toBe(80)
+    expect(title.endsWith('…')).toBe(true)
+  })
+
+  it('omits the subtitle for a turn with no assistant reply yet', () => {
+    const data = [user('u1', 'first'), assistant('a1', 'reply'), user('u2', 'latest')]
+    const items = deriveMobileNativeChatOutline(data)
+    expect(items[1]).toEqual({ index: 2, title: 'latest' })
+    expect(items[1]).not.toHaveProperty('subtitle')
+  })
+
+  it('labels an image-only user turn so it stays reachable', () => {
+    const data: NativeChatMessage[] = [
+      {
+        id: 'u1',
+        role: 'user',
+        blocks: [{ type: 'image-ref', url: 'file:///a.jpg' }],
+        timestamp: 0,
+        source: 'transcript'
+      }
+    ]
+    expect(deriveMobileNativeChatOutline(data)).toEqual([{ index: 0, title: 'Image' }])
+  })
+
+  it('makes no outline entry for the streaming bubble or pre-prompt history', () => {
+    // Only user turns anchor entries; the assistant banter before the first
+    // prompt and the synthetic streaming reply are never their own rows.
+    const data: NativeChatMessage[] = [
+      assistant('a0', 'pre-prompt banter'),
+      user('u1', 'hi'),
+      {
+        id: 'streaming',
+        role: 'assistant',
+        blocks: [{ type: 'text', text: 'live reply' }],
+        timestamp: 0,
+        source: 'hook'
+      }
+    ]
+    expect(deriveMobileNativeChatOutline(data)).toEqual([
+      { index: 1, title: 'hi', subtitle: 'live reply' }
+    ])
+  })
+
+  it('returns nothing for a thread with no user turns', () => {
+    expect(deriveMobileNativeChatOutline([assistant('a1', 'hello')])).toEqual([])
+  })
+})

--- a/mobile/src/session/mobile-native-chat-render-data.ts
+++ b/mobile/src/session/mobile-native-chat-render-data.ts
@@ -10,6 +10,7 @@ import {
   isImageSourceUserTurn,
   normalizeImageTranscriptMessages
 } from './mobile-native-chat-image-transcript-markers'
+import { nativeChatMessageText } from './mobile-native-chat-message-text'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 
 /** The centered empty-state copy for a chat with no messages, mirroring the
@@ -190,4 +191,73 @@ export function buildMobileNativeChatTransientData({
   }
   data.push(...trailingPending)
   return { folded: renderedFolded, streaming, data }
+}
+
+/** One navigable turn in the conversation outline: a user prompt and, when the
+ *  agent has replied, a snippet of that turn's final assistant text. `index` is
+ *  the position in the assembled `data` list, which is exactly what
+ *  `FlatList.scrollToIndex` addresses (the "Load earlier" header is separate). */
+export type MobileNativeChatOutlineItem = {
+  index: number
+  title: string
+  subtitle?: string
+}
+
+const OUTLINE_TITLE_MAX_LENGTH = 80
+const OUTLINE_SUBTITLE_MAX_LENGTH = 120
+
+function compactOutlineLine(text: string, maxLength: number): string {
+  // First non-blank line only: a long paste's later lines add noise, not a label.
+  const firstLine = text.split('\n').find((line) => line.trim().length > 0) ?? ''
+  const compact = firstLine.replace(/\s+/g, ' ').trim()
+  if (compact.length <= maxLength) {
+    return compact
+  }
+  return `${compact.slice(0, maxLength - 1).trimEnd()}…`
+}
+
+/** The trailing assistant prose of the turn a user row opens: scan forward to the
+ *  next user row, keeping the last non-empty assistant text (mirrors t3's
+ *  `resolveFinalAssistantTextForTurn`). */
+function resolveOutlineTurnReply(data: NativeChatMessage[], userIndex: number): string {
+  let reply = ''
+  for (let index = userIndex + 1; index < data.length; index += 1) {
+    const message = data[index]
+    if (message.role === 'user') {
+      break
+    }
+    if (message.role === 'assistant') {
+      const text = nativeChatMessageText(message.blocks)
+      if (text) {
+        reply = text
+      }
+    }
+  }
+  return reply
+}
+
+/** Build the turn-jump outline: one entry per user turn in `data`, so tapping an
+ *  entry scrolls the list straight to that prompt. Pure — the view memoizes it. */
+export function deriveMobileNativeChatOutline(
+  data: NativeChatMessage[]
+): MobileNativeChatOutlineItem[] {
+  const items: MobileNativeChatOutlineItem[] = []
+  for (let index = 0; index < data.length; index += 1) {
+    const message = data[index]
+    if (message.role !== 'user') {
+      continue
+    }
+    const prose = compactOutlineLine(nativeChatMessageText(message.blocks), OUTLINE_TITLE_MAX_LENGTH)
+    // An image-only send has no prose; still list it so the turn stays reachable.
+    const title = prose || (message.blocks.some(isImageRefBlock) ? 'Image' : '')
+    if (!title) {
+      continue
+    }
+    const subtitle = compactOutlineLine(
+      resolveOutlineTurnReply(data, index),
+      OUTLINE_SUBTITLE_MAX_LENGTH
+    )
+    items.push(subtitle ? { index, title, subtitle } : { index, title })
+  }
+  return items
 }


### PR DESCRIPTION
## ELI5

Long chats are a pain to scroll. This adds a little list button that pops up an outline of every question you asked; tap one and it jumps you right to that turn.

## What Changed

- `deriveMobileNativeChatOutline` (pure, in `mobile-native-chat-render-data`): one entry per user turn, titled by the prompt's first non-blank line, subtitled by that turn's final assistant reply. Its `index` addresses the assembled `data` list, so it reuses the existing `onScrollToMessage` → `FlatList.scrollToIndex` path directly.
- `MobileNativeChatScrollControls`: extracts the floating buttons (existing jump-to-latest + the new turn-jump opener) out of the view so it stays under the `max-lines` ceiling. The turn-jump button is gated on `>= 2` turns and sits above the jump-to-latest slot so they never overlap.
- `MobileNativeChatTurnJumpSheet`: renders the outline in the existing `BottomDrawer`; tapping an item closes the sheet and jumps.

## Why

Turn-by-turn navigation is the one thing a phone-sized transcript really needs and the desktop has (its message list is navigable); dragging through a long thread to find an earlier prompt is slow. This reuses the outline-from-transcript idea and the view's existing scroll-to-index path rather than adding new scrolling machinery.

## Linked Issue

N/A — self-contained mobile UX addition; no tracking issue.

Fixes #

## Visual Proof

N/A as a static image (it's a new control + sheet). Behavior: with >= 2 user turns, a List button appears bottom-right; tapping opens a "Jump to turn" sheet listing each prompt (with its reply snippet); tapping an entry scrolls the list to that turn. Covered by the outline unit test.

## Testing

- New `mobile-native-chat-outline.test.ts`: 8 cases — one entry per user turn with its data index, final-assistant-reply subtitle, first-line/ellipsis title compaction, image-only turn labeling, no entry for streaming/pre-prompt rows, empty thread.
- Existing `MobileNativeChatView.test.ts` still passes (the two new overlays are stubbed there, matching how the file already stubs sibling components; the turn-jump sheet pulls reanimated via `BottomDrawer` which those banner tests don't need).
- `pnpm test` for the session render-data/outline/view suites passes; `tsc --noEmit` clean (only the pre-existing `*.generated` codegen stubs error, unrelated). oxlint deferred to CI.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platform: mobile (RN). No desktop/SSH/native surface touched.

## AI Disclosure

Claude (Opus 4.8) via Claude Code assisted with the implementation.

## Review

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation touched.

## Notes

Mobile-only, additive. No security, cross-platform, remote/SSH, wire, or backwards-compat surface changed. The outline is memoized on the same deps as `data`, so it recomputes only when the transcript changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)