### PR TITLE
feat(mobile/chat): list skills in the slash picker + fuller Claude command catalog

### DIFF
--- a/mobile/src/session/MobileNativeChatComposer.tsx
+++ b/mobile/src/session/MobileNativeChatComposer.tsx
@@ -11,13 +11,18 @@ import {
 } from 'react-native'
 import { ArrowUp, ImagePlus, Mic, Square, X } from 'lucide-react-native'
 import { colors, radii, spacing, typography } from '../theme/mobile-theme'
-import { getVerifiedNativeChatCommands } from '../../../src/shared/native-chat-agent-profiles'
+import {
+  getNativeChatAgentProfile,
+  getVerifiedNativeChatCommands
+} from '../../../src/shared/native-chat-agent-profiles'
 import {
   applyAutocomplete,
   detectAutocompleteTrigger,
+  rankSkillSuggestions,
   rankSlashCommandSuggestions,
   rankSuggestions
 } from './mobile-native-chat-autocomplete'
+import type { MobileNativeChatSkillPicker } from './use-mobile-native-chat-skills'
 import {
   composerSuggestionInsertText,
   MobileNativeChatComposerSuggestions,
@@ -64,6 +69,9 @@ type Props = {
   placeholder?: string
   filePaths?: string[]
   onNeedFiles?: (query: string) => void
+  /** Discovered skills for the slash picker; grouped-slash agents (Claude) list
+   *  them alongside commands. Null on surfaces without skill support. */
+  skillPicker?: MobileNativeChatSkillPicker | null
 }
 
 export function MobileNativeChatComposer({
@@ -87,7 +95,8 @@ export function MobileNativeChatComposer({
   disabled = false,
   placeholder = 'Message, @files, /commands',
   filePaths = NO_FILE_PATHS,
-  onNeedFiles
+  onNeedFiles,
+  skillPicker
 }: Props): React.JSX.Element {
   const [cursor, setCursor] = useState(0)
   // Transiently drives the native caret after a mid-text autocomplete insert,
@@ -128,22 +137,37 @@ export function MobileNativeChatComposer({
       // Why: Codex's catalog is 45 commands and this list is a plain ScrollView
       // (~5 rows visible), so an uncapped `/` would mount every row and
       // re-reconcile them on each streaming tick right above the transcript.
-      return rankSlashCommandSuggestions(commands, trigger.query, 12).map((command) => ({
-        kind: 'command' as const,
-        command
+      const commandRows = rankSlashCommandSuggestions(commands, trigger.query, 12).map(
+        (command) => ({ kind: 'command' as const, command })
+      )
+      // Grouped-slash agents (Claude) invoke skills as `/name`, so list the
+      // discovered skills under `/` right after the commands.
+      const groupedSlash = agent ? getNativeChatAgentProfile(agent)?.groupedSlash === true : false
+      if (!groupedSlash || !skillPicker) {
+        return commandRows
+      }
+      const skillRows = rankSkillSuggestions(skillPicker.skills, trigger.query, 12).map((skill) => ({
+        kind: 'skill' as const,
+        skill
       }))
+      return [...commandRows, ...skillRows]
     }
     return rankSuggestions(filePaths, trigger.query).map((path) => ({
       kind: 'file' as const,
       path
     }))
-  }, [trigger, filePaths, agent])
+  }, [trigger, filePaths, agent, skillPicker])
 
   useEffect(() => {
     if (trigger?.kind === 'file') {
       onNeedFiles?.(trigger.query)
     }
-  }, [onNeedFiles, trigger?.kind, trigger?.query])
+    // A slash picker for a grouped-slash agent lists skills too; kick off the
+    // one-shot debounced scan the first time the picker opens.
+    if (trigger?.kind === 'slash' && agent && getNativeChatAgentProfile(agent)?.groupedSlash) {
+      skillPicker?.onNeed()
+    }
+  }, [onNeedFiles, trigger?.kind, trigger?.query, agent, skillPicker])
 
   useEffect(() => {
     mountedRef.current = true

--- a/mobile/src/session/MobileNativeChatComposerSuggestions.test.ts
+++ b/mobile/src/session/MobileNativeChatComposerSuggestions.test.ts
@@ -1,0 +1,85 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DiscoveredSkill } from '../../../src/shared/skills'
+import {
+  composerSuggestionInsertText,
+  composerSuggestionKey,
+  MobileNativeChatComposerSuggestions,
+  type ComposerSuggestion
+} from './MobileNativeChatComposerSuggestions'
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Text: 'Text',
+  View: 'View'
+}))
+
+function mkSkill(id: string, name: string, description: string | null): DiscoveredSkill {
+  return { id, name, description } as unknown as DiscoveredSkill
+}
+
+const SKILL_SUGGESTION: ComposerSuggestion = {
+  kind: 'skill',
+  skill: mkSkill('s1', 'reviewer', 'Review the diff')
+}
+
+describe('composer suggestion helpers', () => {
+  it('inserts a skill as a slash invocation', () => {
+    expect(composerSuggestionInsertText(SKILL_SUGGESTION)).toBe('/reviewer')
+    expect(composerSuggestionInsertText({ kind: 'command', command: { name: 'clear' } })).toBe(
+      '/clear'
+    )
+    expect(composerSuggestionInsertText({ kind: 'file', path: 'src/app.ts' })).toBe('@src/app.ts')
+  })
+
+  it('keys a skill by its id so two skills with the same name stay distinct', () => {
+    expect(composerSuggestionKey(SKILL_SUGGESTION)).toBe('skill:s1')
+  })
+})
+
+describe('MobileNativeChatComposerSuggestions', () => {
+  let renderer: ReactTestRenderer | null = null
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  function textOf(node: ReactTestInstance): string {
+    return node.children.map((c) => (typeof c === 'string' ? c : textOf(c))).join('')
+  }
+
+  it('renders a skill row with its slash text, a Skill badge, and its description', () => {
+    act(() => {
+      renderer = create(
+        createElement(MobileNativeChatComposerSuggestions, {
+          suggestions: [SKILL_SUGGESTION],
+          onPick: vi.fn()
+        })
+      )
+    })
+    const texts = renderer!.root.findAll((n) => n.type === ('Text' as never)).map(textOf)
+    expect(texts).toContain('/reviewer')
+    expect(texts).toContain('Skill')
+    expect(texts).toContain('Review the diff')
+  })
+
+  it('invokes onPick with the tapped suggestion', () => {
+    const onPick = vi.fn()
+    act(() => {
+      renderer = create(
+        createElement(MobileNativeChatComposerSuggestions, {
+          suggestions: [SKILL_SUGGESTION],
+          onPick
+        })
+      )
+    })
+    const row = renderer!.root.find(
+      (n) => n.type === ('Pressable' as never) && typeof n.props.onPress === 'function'
+    )
+    row.props.onPress()
+    expect(onPick).toHaveBeenCalledWith(SKILL_SUGGESTION)
+  })
+})

--- a/mobile/src/session/MobileNativeChatComposerSuggestions.tsx
+++ b/mobile/src/session/MobileNativeChatComposerSuggestions.tsx
@@ -1,22 +1,48 @@
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native'
 import { colors, spacing, typography } from '../theme/mobile-theme'
 import type { SlashCommandSuggestion } from '../../../src/shared/native-chat-slash-commands'
+import type { DiscoveredSkill } from '../../../src/shared/skills'
 
 /** One row of the composer autocomplete: an agent slash command (with its
- *  catalog description, desktop parity) or a worktree file path. */
+ *  catalog description, desktop parity), a discovered skill (grouped-slash agents
+ *  list these under `/` too), or a worktree file path. */
 export type ComposerSuggestion =
   | { kind: 'command'; command: SlashCommandSuggestion }
+  | { kind: 'skill'; skill: DiscoveredSkill }
   | { kind: 'file'; path: string }
 
 export function composerSuggestionKey(suggestion: ComposerSuggestion): string {
-  return suggestion.kind === 'command'
-    ? `command:${suggestion.command.name}`
-    : `file:${suggestion.path}`
+  switch (suggestion.kind) {
+    case 'command':
+      return `command:${suggestion.command.name}`
+    case 'skill':
+      return `skill:${suggestion.skill.id}`
+    default:
+      return `file:${suggestion.path}`
+  }
 }
 
-/** The text the suggestion inserts at the trigger span. */
+/** The text the suggestion inserts at the trigger span. A skill dispatches like a
+ *  slash command on grouped-slash agents (Claude invokes skills as `/name`). */
 export function composerSuggestionInsertText(suggestion: ComposerSuggestion): string {
-  return suggestion.kind === 'command' ? `/${suggestion.command.name}` : `@${suggestion.path}`
+  switch (suggestion.kind) {
+    case 'command':
+      return `/${suggestion.command.name}`
+    case 'skill':
+      return `/${suggestion.skill.name}`
+    default:
+      return `@${suggestion.path}`
+  }
+}
+
+function composerSuggestionDescription(suggestion: ComposerSuggestion): string | null {
+  if (suggestion.kind === 'command') {
+    return suggestion.command.description ?? null
+  }
+  if (suggestion.kind === 'skill') {
+    return suggestion.skill.description ?? null
+  }
+  return null
 }
 
 export function MobileNativeChatComposerSuggestions({
@@ -36,12 +62,17 @@ export function MobileNativeChatComposerSuggestions({
             style={({ pressed }) => [styles.suggestion, pressed && styles.suggestionPressed]}
             onPress={() => onPick(suggestion)}
           >
-            <Text style={styles.suggestionText} numberOfLines={1}>
-              {composerSuggestionInsertText(suggestion)}
-            </Text>
-            {suggestion.kind === 'command' && suggestion.command.description ? (
+            <View style={styles.suggestionRow}>
+              <Text style={styles.suggestionText} numberOfLines={1}>
+                {composerSuggestionInsertText(suggestion)}
+              </Text>
+              {suggestion.kind === 'skill' ? (
+                <Text style={styles.suggestionBadge}>Skill</Text>
+              ) : null}
+            </View>
+            {composerSuggestionDescription(suggestion) ? (
               <Text style={styles.suggestionDescription} numberOfLines={1}>
-                {suggestion.command.description}
+                {composerSuggestionDescription(suggestion)}
               </Text>
             ) : null}
           </Pressable>
@@ -70,10 +101,21 @@ const styles = StyleSheet.create({
   suggestionPressed: {
     backgroundColor: colors.bgRaised
   },
+  suggestionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs
+  },
   suggestionText: {
     color: colors.textPrimary,
     fontFamily: typography.monoFamily,
     fontSize: typography.metaSize
+  },
+  suggestionBadge: {
+    color: colors.textMuted,
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.4
   },
   suggestionDescription: {
     color: colors.textSecondary,

--- a/mobile/src/session/MobileNativeChatOverlay.tsx
+++ b/mobile/src/session/MobileNativeChatOverlay.tsx
@@ -109,6 +109,7 @@ export function MobileNativeChatOverlay({
         onClearSendError={onClearSendError}
         filePaths={controller.nativeChatFilePaths}
         onNeedFiles={controller.loadNativeChatFiles}
+        skillPicker={controller.nativeChatSkillPicker}
         sessionOptions={controller.nativeChatSessionOptions}
         keyboardInset={keyboardInset}
       />

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -26,6 +26,7 @@ import { MobileNativeChatTurnStatus } from './MobileNativeChatTurnStatus'
 import { MobileAgentWorkingIndicator } from './MobileAgentWorkingIndicator'
 import type { PendingNativeChatImage } from './mobile-native-chat-image-attachment'
 import { MobileNativeChatComposer } from './MobileNativeChatComposer'
+import type { MobileNativeChatSkillPicker } from './use-mobile-native-chat-skills'
 import { MobileNativeChatPromptCard } from './MobileNativeChatPromptCard'
 import type { MobileChatPermission } from './mobile-native-chat-permission'
 import type { MobileChatQuestion } from './mobile-native-chat-question'
@@ -95,6 +96,9 @@ type Props = {
   onClearSendError?: () => void
   filePaths?: string[]
   onNeedFiles?: (query: string) => void
+  /** Skill discovery for the slash picker; grouped-slash agents (Claude) list
+   *  their skills alongside commands. Null on surfaces without skill support. */
+  skillPicker?: MobileNativeChatSkillPicker | null
   /** Model/session-option pickers for the composer action row (desktop parity). */
   sessionOptions?: MobileNativeChatSessionOptionPickersProps | null
   /** A pending agent question/permission detected from live status, shown as a
@@ -157,6 +161,7 @@ export function MobileNativeChatView({
   onClearSendError,
   filePaths,
   onNeedFiles,
+  skillPicker,
   sessionOptions,
   ask,
   askKey,
@@ -463,6 +468,7 @@ export function MobileNativeChatView({
         }
         filePaths={filePaths}
         onNeedFiles={onNeedFiles}
+        skillPicker={skillPicker}
       />
     </View>
   )

--- a/mobile/src/session/mobile-native-chat-autocomplete.test.ts
+++ b/mobile/src/session/mobile-native-chat-autocomplete.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import type { DiscoveredSkill } from '../../../src/shared/skills'
 import {
   applyAutocomplete,
   detectAutocompleteTrigger,
+  rankSkillSuggestions,
   rankSlashCommandSuggestions,
   rankSuggestions
 } from './mobile-native-chat-autocomplete'
@@ -89,5 +91,35 @@ describe('rankSlashCommandSuggestions', () => {
   it('is case-insensitive and drops non-matches', () => {
     expect(rankSlashCommandSuggestions(commands, 'CLE').map((c) => c.name)).toEqual(['clear'])
     expect(rankSlashCommandSuggestions(commands, 'zzz')).toEqual([])
+  })
+})
+
+describe('rankSkillSuggestions', () => {
+  const mkSkill = (name: string): DiscoveredSkill =>
+    ({ id: name, name, description: null }) as unknown as DiscoveredSkill
+  const skills = [mkSkill('reviewer'), mkSkill('release-notes'), mkSkill('deployer')]
+
+  it('lists all skills for a bare query', () => {
+    expect(rankSkillSuggestions(skills, '').map((s) => s.name)).toEqual([
+      'reviewer',
+      'release-notes',
+      'deployer'
+    ])
+  })
+
+  it('ranks prefix matches before substring matches, case-insensitively', () => {
+    expect(rankSkillSuggestions(skills, 're').map((s) => s.name)).toEqual([
+      'reviewer',
+      'release-notes'
+    ])
+    // "e" is a substring of every name, in catalog order.
+    expect(rankSkillSuggestions(skills, 'RE').map((s) => s.name)).toEqual([
+      'reviewer',
+      'release-notes'
+    ])
+  })
+
+  it('drops non-matches', () => {
+    expect(rankSkillSuggestions(skills, 'zzz')).toEqual([])
   })
 })

--- a/mobile/src/session/mobile-native-chat-autocomplete.ts
+++ b/mobile/src/session/mobile-native-chat-autocomplete.ts
@@ -3,6 +3,7 @@
 // unit-testable and the composer stays a thin view over it.
 
 import type { SlashCommandSuggestion } from '../../../src/shared/native-chat-slash-commands'
+import type { DiscoveredSkill } from '../../../src/shared/skills'
 
 export type AutocompleteKind = 'file' | 'slash'
 
@@ -114,6 +115,34 @@ export function rankSlashCommandSuggestions(
       prefix.push(command)
     } else if (lower.includes(q)) {
       substring.push(command)
+    }
+    if (prefix.length >= limit) {
+      break
+    }
+  }
+  return [...prefix, ...substring].slice(0, limit)
+}
+
+/** Rank discovered skills for the slash picker: prefix matches on the skill name
+ *  first, then substring, capped. A bare `/` lists the whole set (after the
+ *  commands the composer places above them). */
+export function rankSkillSuggestions(
+  skills: readonly DiscoveredSkill[],
+  query: string,
+  limit = 50
+): DiscoveredSkill[] {
+  const q = query.toLowerCase()
+  if (q.length === 0) {
+    return skills.slice(0, limit)
+  }
+  const prefix: DiscoveredSkill[] = []
+  const substring: DiscoveredSkill[] = []
+  for (const skill of skills) {
+    const lower = skill.name.toLowerCase()
+    if (lower.startsWith(q)) {
+      prefix.push(skill)
+    } else if (lower.includes(q)) {
+      substring.push(skill)
     }
     if (prefix.length >= limit) {
       break

--- a/mobile/src/session/mobile-native-chat-controller-contract.ts
+++ b/mobile/src/session/mobile-native-chat-controller-contract.ts
@@ -10,6 +10,7 @@ import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
 import type { MobileNativeChatPendingMessage } from './use-mobile-native-chat-drafts'
 import type { useMobileNativeChatSession } from './use-mobile-native-chat-session'
 import type { MobileNativeChatSessionOptionPickersProps } from './MobileNativeChatSessionOptionPickers'
+import type { MobileNativeChatSkillPicker } from './use-mobile-native-chat-skills'
 
 export type MobileNativeChatController = {
   /** Whether a tab's effective view is chat (per-tab override, else the default). */
@@ -51,6 +52,8 @@ export type MobileNativeChatController = {
   handleNativeChatStop: () => void
   nativeChatFilePaths: string[]
   loadNativeChatFiles: (query: string) => void
+  /** Skill discovery for the composer's slash picker (grouped-slash agents). */
+  nativeChatSkillPicker: MobileNativeChatSkillPicker
   handleNativeChatQuestionAnswer: (text: string) => Promise<boolean>
   handleNativeChatSend: (text: string, images?: string[]) => Promise<boolean>
   /** Outcome-preserving send: callers that pasted terminal input beforehand

--- a/mobile/src/session/mobile-native-chat-send-classification.test.ts
+++ b/mobile/src/session/mobile-native-chat-send-classification.test.ts
@@ -10,10 +10,11 @@ describe('classifyMobileNativeChatSend', () => {
   })
 
   it('treats slash tokens outside the agent catalog as unknown, never chat', () => {
-    // `/model` is not a verified Claude command — it still dispatches to the
-    // TUI, so it must not get a chat bubble, but it can't claim a command ran.
+    // `/model` is surfaced by the composer's own session-option picker, not the
+    // Claude slash catalog, and `/diff` is Codex-only — both still dispatch to
+    // the TUI, so they must not get a chat bubble, but can't claim a command ran.
     expect(classifyMobileNativeChatSend('claude', '/model sonnet')).toBe('unknown-token')
-    expect(classifyMobileNativeChatSend('claude', '/cost')).toBe('unknown-token')
+    expect(classifyMobileNativeChatSend('claude', '/notacommand')).toBe('unknown-token')
     expect(classifyMobileNativeChatSend('claude', '/diff')).toBe('unknown-token')
   })
 

--- a/mobile/src/session/mobile-native-chat-send-classification.ts
+++ b/mobile/src/session/mobile-native-chat-send-classification.ts
@@ -15,8 +15,11 @@ import {
 
 export type { NativeChatSendClassification }
 
-/** Classify a mobile chat send for the tab's agent. Mobile has no skill picker,
- *  so there is never a picker-origin token that reclassifies a `/token` as chat. */
+/** Classify a mobile chat send for the tab's agent. The mobile skill picker only
+ *  serves grouped-slash (`/`) agents, whose skills invoke as ordinary `/name`
+ *  slash tokens — they dispatch into the TUI like any command (no optimistic
+ *  bubble), so there is no picker-origin token that reclassifies a `/token` as
+ *  chat (that reclassification is only for the `$`-prefix skill grammar). */
 export function classifyMobileNativeChatSend(
   agent: string | null,
   text: string

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -8,6 +8,7 @@ import { useMobileNativeChatAskDismiss } from './use-mobile-native-chat-ask-dism
 import { useMobileNativeChatCancelAsk } from './use-mobile-native-chat-cancel-ask'
 import { useMobileNativeChatDrafts } from './use-mobile-native-chat-drafts'
 import { useMobileNativeChatFileSearch } from './use-mobile-native-chat-file-search'
+import { useMobileNativeChatSkills } from './use-mobile-native-chat-skills'
 import { useMobileNativeChatMessageSend } from './use-mobile-native-chat-message-send'
 import { mobileNativeChatStreamPreview } from './mobile-native-chat-streaming-gate'
 import { useMobileNativeChatSessionOptionController } from './use-mobile-native-chat-session-option-controller'
@@ -216,6 +217,12 @@ export function useMobileNativeChatController(args: {
     worktreeId
   })
 
+  const nativeChatSkillPicker = useMobileNativeChatSkills({
+    client,
+    worktreeId,
+    agent: activeChatResolution?.agent ?? null
+  })
+
   // Why: the send seam reports outgoing catalog commands to session-option
   // tracking, but the options hook needs the seam's dispatcher — a ref breaks
   // the cycle without re-creating the send callbacks per snapshot.
@@ -315,6 +322,7 @@ export function useMobileNativeChatController(args: {
     handleNativeChatStop: activeChatStructured ? structuredNativeChat.cancel : handleNativeChatStop,
     nativeChatFilePaths,
     loadNativeChatFiles,
+    nativeChatSkillPicker,
     handleNativeChatQuestionAnswer: activeChatStructured
       ? structuredNativeChat.respondQuestion
       : legacyHandleNativeChatQuestionAnswer,

--- a/mobile/src/session/use-mobile-native-chat-skills.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-skills.test.ts
@@ -1,0 +1,130 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../src/shared/skills'
+import { useMobileNativeChatSkills } from './use-mobile-native-chat-skills'
+
+type PickerState = ReturnType<typeof useMobileNativeChatSkills>
+
+function skill(id: string, name: string, rootPath: string): DiscoveredSkill {
+  return {
+    id,
+    name,
+    description: `${name} skill`,
+    providers: ['claude'],
+    sourceKind: 'home',
+    sourceLabel: 'home',
+    rootPath,
+    directoryPath: `${rootPath}/${name}`,
+    skillFilePath: `${rootPath}/${name}/SKILL.md`,
+    installed: true,
+    updatedAt: null
+  }
+}
+
+function rpcSuccess(result: SkillDiscoveryResult): Awaited<ReturnType<RpcClient['sendRequest']>> {
+  return { id: 'skills', ok: true, result, _meta: { runtimeId: 'runtime-1' } }
+}
+
+// A claude-owned root and a shared (owner: null) root are visible; a codex-owned
+// root is not, for a claude agent.
+const DISCOVERY: SkillDiscoveryResult = {
+  skills: [
+    skill('s1', 'reviewer', '/home/.claude/skills'),
+    skill('s2', 'shared-thing', '/shared/skills'),
+    skill('s3', 'codex-only', '/home/.codex/skills')
+  ],
+  sources: [
+    { id: 'a', label: 'claude', path: '/home/.claude/skills', sourceKind: 'home', providers: ['claude'], owner: 'claude', exists: true },
+    { id: 'b', label: 'shared', path: '/shared/skills', sourceKind: 'home', providers: ['agent-skills'], owner: null, exists: true },
+    { id: 'c', label: 'codex', path: '/home/.codex/skills', sourceKind: 'home', providers: ['codex'], owner: 'codex', exists: true }
+  ],
+  scannedAt: 0
+}
+
+describe('useMobileNativeChatSkills', () => {
+  let renderer: ReactTestRenderer | null = null
+  let state: PickerState | null = null
+
+  async function mount(client: RpcClient, agent: string | null = 'claude'): Promise<void> {
+    function Harness(): null {
+      state = useMobileNativeChatSkills({ client, worktreeId: 'wt-1', agent })
+      return null
+    }
+    await act(async () => {
+      renderer = create(createElement(Harness))
+    })
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    state = null
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    vi.useRealTimers()
+  })
+
+  it('discovers once (debounced) and lists only the agent-visible skills', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(rpcSuccess(DISCOVERY))
+    await mount({ sendRequest } as unknown as RpcClient)
+
+    expect(state?.status).toBe('idle')
+    act(() => {
+      state?.onNeed()
+      state?.onNeed()
+    })
+    expect(state?.status).toBe('loading')
+    await act(async () => vi.advanceTimersByTimeAsync(119))
+    expect(sendRequest).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest).toHaveBeenCalledWith('skills.discover', { worktreeId: 'wt-1' }, {
+      timeoutMs: 10_000
+    })
+    expect(state?.status).toBe('ready')
+    // codex-only root is filtered out for a claude agent.
+    expect(state?.skills.map((s) => s.name)).toEqual(['reviewer', 'shared-thing'])
+  })
+
+  it('does not re-scan while the picker stays open', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(rpcSuccess(DISCOVERY))
+    await mount({ sendRequest } as unknown as RpcClient)
+
+    act(() => state?.onNeed())
+    await act(async () => vi.advanceTimersByTimeAsync(120))
+    act(() => state?.onNeed())
+    await act(async () => vi.advanceTimersByTimeAsync(120))
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('surfaces an error and lets the next open retry', async () => {
+    const sendRequest = vi
+      .fn()
+      .mockResolvedValueOnce({ id: 'x', ok: false, error: { code: 'boom', message: 'no' } })
+      .mockResolvedValueOnce(rpcSuccess(DISCOVERY))
+    await mount({ sendRequest } as unknown as RpcClient)
+
+    act(() => state?.onNeed())
+    await act(async () => vi.advanceTimersByTimeAsync(120))
+    expect(state?.status).toBe('error')
+
+    act(() => state?.onNeed())
+    await act(async () => vi.advanceTimersByTimeAsync(120))
+    expect(sendRequest).toHaveBeenCalledTimes(2)
+    expect(state?.status).toBe('ready')
+  })
+
+  it('lists no skills for an agent with no native-chat profile', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(rpcSuccess(DISCOVERY))
+    await mount({ sendRequest } as unknown as RpcClient, 'some-unknown-agent')
+
+    act(() => state?.onNeed())
+    await act(async () => vi.advanceTimersByTimeAsync(120))
+    expect(state?.skills).toEqual([])
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-skills.ts
+++ b/mobile/src/session/use-mobile-native-chat-skills.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { RpcClient } from '../transport/rpc-client'
+import { getNativeChatAgentProfile } from '../../../src/shared/native-chat-agent-profiles'
+import type { AgentType } from '../../../src/shared/agent-status-types'
+import type { DiscoveredSkill, SkillDiscoveryResult } from '../../../src/shared/skills'
+
+const SKILL_DISCOVERY_DEBOUNCE_MS = 120
+const SKILL_DISCOVERY_TIMEOUT_MS = 10_000
+const NO_SKILLS: readonly DiscoveredSkill[] = []
+
+/** Lifecycle of skill discovery: nothing requested yet, a scan in flight
+ *  (debounce + RPC), results applied, or the host scan failed — lets the picker
+ *  tell "still loading" apart from "no skills" and surface a failure row. */
+export type NativeChatSkillSearchStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+/** Single object threaded to the composer so the skill picker adds one prop, not
+ *  three, to the already-dense chat view and composer. */
+export type MobileNativeChatSkillPicker = {
+  skills: readonly DiscoveredSkill[]
+  status: NativeChatSkillSearchStatus
+  onNeed: () => void
+}
+
+/** Debounces one skill scan per scope over the RpcClient and re-derives the
+ *  agent-visible subset without re-fetching when the active agent changes. The
+ *  scan is agent-agnostic (the host returns every provider's skills plus their
+ *  owning sources); visibility is applied here, mirroring the renderer's
+ *  isNativeChatSkillForAgent, which Metro cannot import from src/renderer. */
+export function useMobileNativeChatSkills(args: {
+  client: RpcClient | null
+  worktreeId: string
+  agent: string | null
+}): MobileNativeChatSkillPicker {
+  const { client, worktreeId, agent } = args
+  const [result, setResult] = useState<SkillDiscoveryResult | null>(null)
+  const [nativeChatSkillStatus, setNativeChatSkillStatus] =
+    useState<NativeChatSkillSearchStatus>('idle')
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const sequenceRef = useRef(0)
+  // One scan per scope: guards against the composer re-requesting on every
+  // keystroke while the picker is open, since filtering is client-side.
+  const startedRef = useRef(false)
+
+  useEffect(() => {
+    sequenceRef.current++
+    startedRef.current = false
+    setResult(null)
+    setNativeChatSkillStatus('idle')
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [client, worktreeId])
+
+  const loadNativeChatSkills = useCallback(() => {
+    if (!client || startedRef.current) {
+      return
+    }
+    startedRef.current = true
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+    const sequence = ++sequenceRef.current
+    setNativeChatSkillStatus('loading')
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      void (async () => {
+        const response = await client.sendRequest(
+          'skills.discover',
+          { worktreeId },
+          { timeoutMs: SKILL_DISCOVERY_TIMEOUT_MS }
+        )
+        if (sequenceRef.current !== sequence) {
+          return
+        }
+        if (response.ok) {
+          setResult(response.result as SkillDiscoveryResult)
+          setNativeChatSkillStatus('ready')
+          return
+        }
+        // Let the next time the picker opens retry a failed scan.
+        startedRef.current = false
+        setNativeChatSkillStatus('error')
+      })().catch(() => {
+        if (sequenceRef.current === sequence) {
+          startedRef.current = false
+          setNativeChatSkillStatus('error')
+        }
+      })
+    }, SKILL_DISCOVERY_DEBOUNCE_MS)
+  }, [client, worktreeId])
+
+  const skills = useMemo(() => {
+    if (!result) {
+      return NO_SKILLS
+    }
+    const profile = getNativeChatAgentProfile(agent)
+    if (!profile) {
+      return NO_SKILLS
+    }
+    return result.skills.filter((skill) => isSkillForOwner(skill, profile.skillSourceOwner, result))
+  }, [result, agent])
+
+  return useMemo(
+    () => ({ skills, status: nativeChatSkillStatus, onNeed: loadNativeChatSkills }),
+    [skills, nativeChatSkillStatus, loadNativeChatSkills]
+  )
+}
+
+/** A skill is visible to an agent when any root that reached it is that agent's
+ *  own scope or the shared (owner === null) scope. A symlinked skill can be
+ *  reachable through several roots, so all of them grant visibility. */
+function isSkillForOwner(
+  skill: DiscoveredSkill,
+  owner: AgentType,
+  result: SkillDiscoveryResult
+): boolean {
+  const rootPaths = skill.rootPaths?.length ? skill.rootPaths : [skill.rootPath]
+  return rootPaths.some((rootPath) => {
+    const source = result.sources.find((entry) => entry.path === rootPath)
+    return source?.owner === null || source?.owner === owner
+  })
+}

--- a/src/main/runtime/runtime-rpc/runtime-rpc-mobile-method-allowlist.ts
+++ b/src/main/runtime/runtime-rpc/runtime-rpc-mobile-method-allowlist.ts
@@ -226,6 +226,7 @@ export const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'settings.getTerminalQuickCommands',
   'settings.update',
   'settings.updateTerminalQuickCommands',
+  'skills.discover',
   'ssh.connect',
   'ssh.getState',
   'ssh.listRemovedTargetLabels',

--- a/src/shared/native-chat-slash-commands.ts
+++ b/src/shared/native-chat-slash-commands.ts
@@ -23,11 +23,34 @@ const COMMON_COMMANDS: readonly SlashCommandSuggestion[] = [
 ]
 
 const CLAUDE_COMMANDS: readonly SlashCommandSuggestion[] = [
+  { name: 'add-dir', description: 'Add a working directory' },
+  { name: 'agents', description: 'Manage agent configurations' },
+  { name: 'bug', description: 'Report a bug to Anthropic' },
   { name: 'clear', description: 'Clear conversation history' },
   { name: 'compact', description: 'Summarize and compact the conversation' },
+  { name: 'config', description: 'Open the config panel' },
+  { name: 'cost', description: 'Show token usage and cost' },
+  { name: 'doctor', description: 'Diagnose and check the installation' },
+  { name: 'exit', description: 'Exit the session' },
+  { name: 'export', description: 'Export the conversation' },
+  { name: 'help', description: 'Show available commands' },
+  { name: 'hooks', description: 'Manage hook configurations' },
   { name: 'init', description: 'Initialize a CLAUDE.md' },
+  { name: 'login', description: 'Log in with your account' },
+  { name: 'logout', description: 'Log out of your account' },
+  { name: 'mcp', description: 'Manage MCP servers' },
+  { name: 'memory', description: 'Edit memory files' },
+  // Model selection is surfaced by the composer's own session-option picker on
+  // mobile, so /model is intentionally left out of the Claude slash catalog.
+  { name: 'permissions', description: 'Manage tool permissions' },
+  { name: 'pr-comments', description: 'Get comments from a GitHub PR' },
+  { name: 'release-notes', description: 'View release notes' },
+  { name: 'resume', description: 'Resume a previous conversation' },
   { name: 'review', description: 'Review the current changes' },
-  { name: 'help', description: 'Show available commands' }
+  { name: 'rewind', description: 'Rewind the conversation' },
+  { name: 'status', description: 'Show session status' },
+  { name: 'terminal-setup', description: 'Configure terminal key bindings' },
+  { name: 'vim', description: 'Toggle Vim editing mode' }
 ]
 
 const CODEX_COMMANDS: readonly SlashCommandSuggestion[] = [


### PR DESCRIPTION
## ELI5

On the phone, typing `/` in a Claude chat showed only 5 commands and no skills. Now it shows the full command list *and* your Claude skills, so you can pick a skill from the `/` menu just like on desktop.

## What Changed

**Skills in the `/` picker (grouped-slash agents, i.e. Claude):**
- New `useMobileNativeChatSkills` hook discovers skills over `skills.discover` — debounced, one scan per scope, filtered to the agent-visible owner set (own scope + shared `owner: null`), mirroring the renderer's `isNativeChatSkillForAgent`.
- The controller threads a single `skillPicker` object down through the view to the composer. When the `/` trigger is active for a grouped-slash agent, the composer appends the ranked skills under the commands and kicks off the (one-shot) scan.
- `MobileNativeChatComposerSuggestions` gains a `skill` row (its `/name`, a "Skill" badge, and its description). A picked skill inserts `/name`; it dispatches into the TUI like any slash token, so **no send-classification change is needed** — `/token` already dispatches without an optimistic bubble, which is exactly right for a Claude skill invocation.

**Fuller Claude command catalog:**
- `CLAUDE_COMMANDS` grew from 5 to the real, stable Claude Code set (`add-dir`, `agents`, `config`, `cost`, `doctor`, `hooks`, `mcp`, `memory`, `permissions`, `pr-comments`, `release-notes`, `resume`, `rewind`, `status`, `terminal-setup`, `vim`, and the originals). `/model` is intentionally left out — model selection is surfaced by the composer's own session-option picker on mobile.

**Authorization:**
- `skills.discover` added to the mobile RPC allowlist. It's already registered host-side (`SKILL_METHODS` → `ALL_RPC_METHODS`), so this is the only new grant.

## Why

The desktop already lists commands + skills under `/`; the mobile catalog was a 5-command stub and had no skill surface at all. This reuses the shared agent-profile (`skillPrefix` / `groupedSlash` / `skillSourceOwner`), the shared `skills.discover` RPC, and the shared `DiscoveredSkill` types — no new discovery machinery, and the desktop is untouched.

## Linked Issue

N/A — mobile parity gap found while using the app; no tracking issue.

Fixes #

## Visual Proof

N/A as a static image. Behavior: in a Claude chat, typing `/` now lists the full command set plus your skills (each skill row shows `/name`, a "Skill" tag, and its description); picking one inserts `/name`. Covered by the hook, ranking, and suggestion-row tests below.

## Testing

- New `use-mobile-native-chat-skills.test.ts`: debounced one-shot discovery, owner-visibility filtering (codex-owned root hidden from Claude, shared root shown), no re-scan while open, error + retry, empty for a profile-less agent.
- New `MobileNativeChatComposerSuggestions.test.ts`: skill row renders `/name` + "Skill" badge + description; insert-text and key helpers; `onPick`.
- `mobile-native-chat-autocomplete.test.ts`: added `rankSkillSuggestions` cases (bare query, prefix-before-substring, case-insensitive, drop non-matches).
- Updated `mobile-native-chat-send-classification.test.ts` for the expanded catalog (`/cost` is now a real Claude command; swapped in a genuinely-unknown token).
- Full affected suite green: skills hook, autocomplete, composer, suggestions, controller, overlay, send-classification (84 tests). `tsc --noEmit` clean (only the pre-existing `*.generated` codegen stubs error, unrelated). oxlint deferred to CI.
- The CI-only `mobile-rpc-allowlist.test.ts` is satisfied: `skills.discover` is now allowlisted and was already registered.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platform: mobile (RN); one host allowlist line. No desktop UI touched.

## AI Disclosure

Claude (Opus 4.8) via Claude Code assisted with the implementation.

## Review

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation touched. This consumes the existing `skills.discover` discovery RPC read-only; it installs/shares nothing.

## Notes

Additive and mobile-scoped apart from the one allowlist entry. Skill discovery is a read-only host scan gated behind opening the `/` picker; it's debounced and scanned once per scope. Only grouped-slash (`/`) agents surface skills — Codex's `$`-prefix grammar is untouched. Wire compatibility: an older host without `skills.discover` simply fails the scan and the picker shows commands only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)