### PR TITLE
fix(macos): block passkey provisioning and gate signed app launches

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -205,6 +205,18 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
+      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
+      # that only an embedded Developer ID provisioning profile can authorise. Without
+      # the profile the packager keeps the plain entitlements and passkeys stay off.
+      - name: Materialize macOS provisioning profile
+        if: env.MAC_PROVISIONING_PROFILE_BASE64 != ''
+        shell: bash
+        run: |
+          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
+          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
+        env:
+          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+
       # Why: signing is what makes an adhoc build installable over an existing
       # Orca, so a missing cert must fail here rather than after a 20-minute build.
       - name: Verify macOS signing environment

--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -205,18 +205,6 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
-      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
-      # that only an embedded Developer ID provisioning profile can authorise. Without
-      # the profile the packager keeps the plain entitlements and passkeys stay off.
-      - name: Materialize macOS provisioning profile
-        if: env.MAC_PROVISIONING_PROFILE_BASE64 != ''
-        shell: bash
-        run: |
-          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
-          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
-        env:
-          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
-
       # Why: signing is what makes an adhoc build installable over an existing
       # Orca, so a missing cert must fail here rather than after a 20-minute build.
       - name: Verify macOS signing environment
@@ -337,7 +325,8 @@ jobs:
           timeout_minutes: 45
           max_attempts: 2
           retry_wait_seconds: 30
-          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_MAC_ADHOC=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
+          # afterSign rejects passkey entitlements/profiles and proves the signed app launches before any upload.
+          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_BACKGROUND_LAUNCH=1 ORCA_MAC_ADHOC=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
         env:
           # Why: electron-builder's github publisher targets the repo named in the
           # config; the token must therefore carry write access to orca-adhoc.

--- a/.github/workflows/daily-mac-build.yml
+++ b/.github/workflows/daily-mac-build.yml
@@ -176,6 +176,18 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
+      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
+      # that only an embedded Developer ID provisioning profile can authorise. Without
+      # the profile the packager keeps the plain entitlements and passkeys stay off.
+      - name: Materialize macOS provisioning profile
+        if: steps.freshness.outputs.should_build == 'true' && env.MAC_PROVISIONING_PROFILE_BASE64 != ''
+        shell: bash
+        run: |
+          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
+          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
+        env:
+          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+
       # Why: signing is what makes a daily installable over an existing Orca, so
       # a missing cert must fail here rather than after a 20-minute build.
       - name: Verify macOS signing environment

--- a/.github/workflows/daily-mac-build.yml
+++ b/.github/workflows/daily-mac-build.yml
@@ -176,18 +176,6 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
-      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
-      # that only an embedded Developer ID provisioning profile can authorise. Without
-      # the profile the packager keeps the plain entitlements and passkeys stay off.
-      - name: Materialize macOS provisioning profile
-        if: steps.freshness.outputs.should_build == 'true' && env.MAC_PROVISIONING_PROFILE_BASE64 != ''
-        shell: bash
-        run: |
-          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
-          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
-        env:
-          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
-
       # Why: signing is what makes a daily installable over an existing Orca, so
       # a missing cert must fail here rather than after a 20-minute build.
       - name: Verify macOS signing environment
@@ -331,7 +319,8 @@ jobs:
           timeout_minutes: 45
           max_attempts: 2
           retry_wait_seconds: 30
-          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_MAC_DAILY=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
+          # afterSign rejects passkey entitlements/profiles and proves the signed app launches before any upload.
+          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_BACKGROUND_LAUNCH=1 ORCA_MAC_DAILY=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
         env:
           # Why: electron-builder's github publisher targets the repo named in the
           # config; the token must therefore carry write access to orca-daily.

--- a/.github/workflows/hourly-mac-build.yml
+++ b/.github/workflows/hourly-mac-build.yml
@@ -182,18 +182,6 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
-      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
-      # that only an embedded Developer ID provisioning profile can authorise. Without
-      # the profile the packager keeps the plain entitlements and passkeys stay off.
-      - name: Materialize macOS provisioning profile
-        if: env.MAC_PROVISIONING_PROFILE_BASE64 != ''
-        shell: bash
-        run: |
-          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
-          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
-        env:
-          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
-
       # Why: signing is what makes an hourly installable over an existing Orca, so
       # a missing cert must fail here rather than after a 20-minute build.
       - name: Verify macOS signing environment
@@ -323,7 +311,8 @@ jobs:
           timeout_minutes: 45
           max_attempts: 2
           retry_wait_seconds: 30
-          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_MAC_HOURLY=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
+          # afterSign rejects passkey entitlements/profiles and proves the signed app launches before any upload.
+          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_BACKGROUND_LAUNCH=1 ORCA_MAC_HOURLY=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
         env:
           # Why: electron-builder's github publisher targets the repo named in the
           # config; the token must therefore carry write access to orca-hourly.

--- a/.github/workflows/hourly-mac-build.yml
+++ b/.github/workflows/hourly-mac-build.yml
@@ -182,6 +182,18 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
+      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
+      # that only an embedded Developer ID provisioning profile can authorise. Without
+      # the profile the packager keeps the plain entitlements and passkeys stay off.
+      - name: Materialize macOS provisioning profile
+        if: env.MAC_PROVISIONING_PROFILE_BASE64 != ''
+        shell: bash
+        run: |
+          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
+          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
+        env:
+          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+
       # Why: signing is what makes an hourly installable over an existing Orca, so
       # a missing cert must fail here rather than after a 20-minute build.
       - name: Verify macOS signing environment

--- a/.github/workflows/release-mac-build.yml
+++ b/.github/workflows/release-mac-build.yml
@@ -72,18 +72,6 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
-      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
-      # that only an embedded Developer ID provisioning profile can authorise. Without
-      # the profile the packager keeps the plain entitlements and passkeys stay off.
-      - name: Materialize macOS provisioning profile
-        if: env.MAC_PROVISIONING_PROFILE_BASE64 != ''
-        shell: bash
-        run: |
-          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
-          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
-        env:
-          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
-
       - name: Verify macOS signing environment
         run: node config/scripts/verify-macos-release-env.mjs
         env:
@@ -151,7 +139,8 @@ jobs:
           timeout_minutes: 45
           max_attempts: 3
           retry_wait_seconds: 30
-          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_MAC_RELEASE=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
+          # afterSign rejects passkey entitlements/profiles and proves the signed app launches before any upload.
+          command: node config/scripts/ensure-native-runtime.mjs --runtime=electron && ORCA_BACKGROUND_LAUNCH=1 ORCA_MAC_RELEASE=1 pnpm exec electron-builder --config config/electron-builder.config.cjs --mac --publish always
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.MAC_CERTS }}

--- a/.github/workflows/release-mac-build.yml
+++ b/.github/workflows/release-mac-build.yml
@@ -72,6 +72,18 @@ jobs:
           retry_wait_seconds: 30
           command: pnpm install --frozen-lockfile
 
+      # Why: the Touch ID passkey authenticator needs a restricted keychain entitlement
+      # that only an embedded Developer ID provisioning profile can authorise. Without
+      # the profile the packager keeps the plain entitlements and passkeys stay off.
+      - name: Materialize macOS provisioning profile
+        if: env.MAC_PROVISIONING_PROFILE_BASE64 != ''
+        shell: bash
+        run: |
+          printf '%s' "$MAC_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$RUNNER_TEMP/orca.provisionprofile"
+          echo "ORCA_MAC_PROVISIONING_PROFILE=$RUNNER_TEMP/orca.provisionprofile" >> "$GITHUB_ENV"
+        env:
+          MAC_PROVISIONING_PROFILE_BASE64: ${{ secrets.MAC_PROVISIONING_PROFILE }}
+
       - name: Verify macOS signing environment
         run: node config/scripts/verify-macos-release-env.mjs
         env:

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -20,7 +20,7 @@ const {
 const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.cjs')
 const { verifyStaticAppImagePackage } = require('./scripts/static-appimage-package-contract.cjs')
 const { signWindowsUninstallerViaSignPath } = require('./scripts/windows-uninstaller-signing.cjs')
-const { resolveMacWebAuthnSigning } = require('./scripts/mac-webauthn-signing.cjs')
+const { assertMacPasskeySigningDisabled } = require('./scripts/mac-webauthn-signing.cjs')
 
 // Why: dev-channel builds must carry the *release* identity — same bundle id,
 // Developer ID signature, and notarization ticket — or Squirrel.Mac refuses to
@@ -66,14 +66,16 @@ const devChannelRepo = isHourlyChannel
       : null
 const appId = 'com.stablyai.orca'
 const MAC_BASE_ENTITLEMENTS = 'resources/build/entitlements.mac.plist'
-// Why: the Touch ID passkey authenticator needs a restricted keychain entitlement that
-// only a provisioning profile can authorise; see scripts/mac-webauthn-signing.cjs.
-const macWebAuthnSigning = resolveMacWebAuthnSigning({
-  repoRoot: resolve(__dirname, '..'),
-  isMacRelease,
-  appId,
-  baseEntitlementsPath: MAC_BASE_ENTITLEMENTS
-})
+// Profile expiry can stop installed apps launching, so no distributed channel may opt in.
+if (isMacRelease) {
+  assertMacPasskeySigningDisabled({
+    repoRoot: resolve(__dirname, '..'),
+    entitlementsPaths: [
+      MAC_BASE_ENTITLEMENTS,
+      'resources/build/entitlements.computer-use.mac.plist'
+    ]
+  })
+}
 const featureWallResources = {
   from: 'resources/onboarding/feature-wall',
   to: 'onboarding/feature-wall'
@@ -288,6 +290,12 @@ module.exports = {
       verifyStaticAppImagePackage(file, arch)
     }
   },
+  afterSign: async (context) => {
+    if (isMacRelease && context.electronPlatformName === 'darwin') {
+      const { verifyMacSignedApp } = await import('./scripts/verify-macos-signed-app.mjs')
+      await verifyMacSignedApp(context)
+    }
+  },
   afterPack: async (context) => {
     // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node
     // requiring GLIBC_2.34, crashing the app on startup on Ubuntu 20.04 (#9902).
@@ -470,9 +478,8 @@ module.exports = {
       rank: 'Alternate'
     })),
     icon: 'resources/build/icon.icns',
-    entitlements: macWebAuthnSigning?.entitlements ?? MAC_BASE_ENTITLEMENTS,
+    entitlements: MAC_BASE_ENTITLEMENTS,
     entitlementsInherit: MAC_BASE_ENTITLEMENTS,
-    ...(macWebAuthnSigning ? { provisioningProfile: macWebAuthnSigning.provisioningProfile } : {}),
     extendInfo: {
       NSAppleEventsUsageDescription:
         'Orca allows terminal-launched developer tools to automate local apps when you request it.',

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -20,6 +20,7 @@ const {
 const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.cjs')
 const { verifyStaticAppImagePackage } = require('./scripts/static-appimage-package-contract.cjs')
 const { signWindowsUninstallerViaSignPath } = require('./scripts/windows-uninstaller-signing.cjs')
+const { resolveMacWebAuthnSigning } = require('./scripts/mac-webauthn-signing.cjs')
 
 // Why: dev-channel builds must carry the *release* identity — same bundle id,
 // Developer ID signature, and notarization ticket — or Squirrel.Mac refuses to
@@ -64,6 +65,15 @@ const devChannelRepo = isHourlyChannel
       ? 'orca-adhoc'
       : null
 const appId = 'com.stablyai.orca'
+const MAC_BASE_ENTITLEMENTS = 'resources/build/entitlements.mac.plist'
+// Why: the Touch ID passkey authenticator needs a restricted keychain entitlement that
+// only a provisioning profile can authorise; see scripts/mac-webauthn-signing.cjs.
+const macWebAuthnSigning = resolveMacWebAuthnSigning({
+  repoRoot: resolve(__dirname, '..'),
+  isMacRelease,
+  appId,
+  baseEntitlementsPath: MAC_BASE_ENTITLEMENTS
+})
 const featureWallResources = {
   from: 'resources/onboarding/feature-wall',
   to: 'onboarding/feature-wall'
@@ -460,8 +470,9 @@ module.exports = {
       rank: 'Alternate'
     })),
     icon: 'resources/build/icon.icns',
-    entitlements: 'resources/build/entitlements.mac.plist',
-    entitlementsInherit: 'resources/build/entitlements.mac.plist',
+    entitlements: macWebAuthnSigning?.entitlements ?? MAC_BASE_ENTITLEMENTS,
+    entitlementsInherit: MAC_BASE_ENTITLEMENTS,
+    ...(macWebAuthnSigning ? { provisioningProfile: macWebAuthnSigning.provisioningProfile } : {}),
     extendInfo: {
       NSAppleEventsUsageDescription:
         'Orca allows terminal-launched developer tools to automate local apps when you request it.',

--- a/config/scripts/electron-builder-mac-channel-config.test.mjs
+++ b/config/scripts/electron-builder-mac-channel-config.test.mjs
@@ -150,3 +150,73 @@ describe('electron-builder mac channel config', () => {
     })
   })
 })
+
+describe('electron-builder mac passkey signing', () => {
+  const PROFILE_ENV = ['ORCA_MAC_PROVISIONING_PROFILE', 'APPLE_TEAM_ID']
+
+  function withProfileEnv(env, assert) {
+    const original = Object.fromEntries(PROFILE_ENV.map((key) => [key, process.env[key]]))
+    try {
+      for (const key of PROFILE_ENV) {
+        delete process.env[key]
+      }
+      withEnv(env, assert)
+    } finally {
+      for (const [key, value] of Object.entries(original)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+  }
+
+  // Why: keychain-access-groups is a restricted entitlement, and a binary that claims
+  // it without an embedded profile is killed at launch. No profile means no claim.
+  it('keeps the plain entitlements when no provisioning profile is supplied', () => {
+    withProfileEnv({ ORCA_MAC_RELEASE: '1', APPLE_TEAM_ID: 'ABCDE12345' }, (config) => {
+      expect(config.mac.entitlements).toBe('resources/build/entitlements.mac.plist')
+      expect(config.mac.provisioningProfile).toBeUndefined()
+    })
+  })
+
+  it('signs release builds with the webauthn keychain group and embeds the profile', async () => {
+    const { mkdtemp, readFile, writeFile } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = await mkdtemp(join(tmpdir(), 'orca-profile-'))
+    const profile = join(dir, 'orca.provisionprofile')
+    await writeFile(profile, 'profile')
+    let rendered
+    withProfileEnv(
+      {
+        ORCA_MAC_RELEASE: '1',
+        APPLE_TEAM_ID: 'ABCDE12345',
+        ORCA_MAC_PROVISIONING_PROFILE: profile
+      },
+      (config) => {
+        expect(config.mac.provisioningProfile).toBe(profile)
+        expect(config.mac.entitlementsInherit).toBe('resources/build/entitlements.mac.plist')
+        rendered = config.mac.entitlements
+      }
+    )
+    expect(await readFile(rendered, 'utf8')).toContain('ABCDE12345.com.stablyai.orca.webauthn')
+  })
+
+  it('never claims the keychain group on local builds', async () => {
+    const { mkdtemp, writeFile } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const dir = await mkdtemp(join(tmpdir(), 'orca-profile-'))
+    const profile = join(dir, 'orca.provisionprofile')
+    await writeFile(profile, 'profile')
+    withProfileEnv(
+      { APPLE_TEAM_ID: 'ABCDE12345', ORCA_MAC_PROVISIONING_PROFILE: profile },
+      (config) => {
+        expect(config.mac.entitlements).toBe('resources/build/entitlements.mac.plist')
+        expect(config.mac.provisioningProfile).toBeUndefined()
+      }
+    )
+  })
+})

--- a/config/scripts/electron-builder-mac-channel-config.test.mjs
+++ b/config/scripts/electron-builder-mac-channel-config.test.mjs
@@ -5,6 +5,7 @@ const require = createRequire(import.meta.url)
 const electronBuilderConfig = require('../electron-builder.config.cjs')
 
 const MUTABLE_BUILD_ENV = [
+  'ORCA_MAC_PROVISIONING_PROFILE',
   'ORCA_MAC_HOURLY',
   'ORCA_MAC_DAILY',
   'ORCA_MAC_ADHOC',
@@ -152,71 +153,34 @@ describe('electron-builder mac channel config', () => {
 })
 
 describe('electron-builder mac passkey signing', () => {
-  const PROFILE_ENV = ['ORCA_MAC_PROVISIONING_PROFILE', 'APPLE_TEAM_ID']
-
-  function withProfileEnv(env, assert) {
-    const original = Object.fromEntries(PROFILE_ENV.map((key) => [key, process.env[key]]))
-    try {
-      for (const key of PROFILE_ENV) {
-        delete process.env[key]
-      }
-      withEnv(env, assert)
-    } finally {
-      for (const [key, value] of Object.entries(original)) {
-        if (value === undefined) {
-          delete process.env[key]
-        } else {
-          process.env[key] = value
-        }
-      }
+  it.each(['ORCA_MAC_RELEASE', 'ORCA_MAC_HOURLY', 'ORCA_MAC_DAILY', 'ORCA_MAC_ADHOC'])(
+    'keeps %s free of profile-dependent entitlements',
+    (channel) => {
+      withEnv({ [channel]: '1' }, (config) => {
+        expect(config.mac.entitlements).toBe('resources/build/entitlements.mac.plist')
+        expect(config.mac.entitlementsInherit).toBe('resources/build/entitlements.mac.plist')
+        expect(config.mac.provisioningProfile).toBeUndefined()
+        expect(config.afterSign).toBeTypeOf('function')
+      })
     }
-  }
+  )
 
-  // Why: keychain-access-groups is a restricted entitlement, and a binary that claims
-  // it without an embedded profile is killed at launch. No profile means no claim.
-  it('keeps the plain entitlements when no provisioning profile is supplied', () => {
-    withProfileEnv({ ORCA_MAC_RELEASE: '1', APPLE_TEAM_ID: 'ABCDE12345' }, (config) => {
+  it.each(['ORCA_MAC_RELEASE', 'ORCA_MAC_HOURLY', 'ORCA_MAC_DAILY', 'ORCA_MAC_ADHOC'])(
+    'rejects the retired profile opt-in on %s',
+    (channel) => {
+      expect(() =>
+        withEnv(
+          { [channel]: '1', ORCA_MAC_PROVISIONING_PROFILE: 'expired.provisionprofile' },
+          () => {}
+        )
+      ).toThrow(/unsupported/)
+    }
+  )
+
+  it('leaves local builds unchanged even with the retired opt-in', () => {
+    withEnv({ ORCA_MAC_PROVISIONING_PROFILE: 'missing.provisionprofile' }, (config) => {
       expect(config.mac.entitlements).toBe('resources/build/entitlements.mac.plist')
       expect(config.mac.provisioningProfile).toBeUndefined()
     })
-  })
-
-  it('signs release builds with the webauthn keychain group and embeds the profile', async () => {
-    const { mkdtemp, readFile, writeFile } = await import('node:fs/promises')
-    const { tmpdir } = await import('node:os')
-    const { join } = await import('node:path')
-    const dir = await mkdtemp(join(tmpdir(), 'orca-profile-'))
-    const profile = join(dir, 'orca.provisionprofile')
-    await writeFile(profile, 'profile')
-    let rendered
-    withProfileEnv(
-      {
-        ORCA_MAC_RELEASE: '1',
-        APPLE_TEAM_ID: 'ABCDE12345',
-        ORCA_MAC_PROVISIONING_PROFILE: profile
-      },
-      (config) => {
-        expect(config.mac.provisioningProfile).toBe(profile)
-        expect(config.mac.entitlementsInherit).toBe('resources/build/entitlements.mac.plist')
-        rendered = config.mac.entitlements
-      }
-    )
-    expect(await readFile(rendered, 'utf8')).toContain('ABCDE12345.com.stablyai.orca.webauthn')
-  })
-
-  it('never claims the keychain group on local builds', async () => {
-    const { mkdtemp, writeFile } = await import('node:fs/promises')
-    const { tmpdir } = await import('node:os')
-    const { join } = await import('node:path')
-    const dir = await mkdtemp(join(tmpdir(), 'orca-profile-'))
-    const profile = join(dir, 'orca.provisionprofile')
-    await writeFile(profile, 'profile')
-    withProfileEnv(
-      { APPLE_TEAM_ID: 'ABCDE12345', ORCA_MAC_PROVISIONING_PROFILE: profile },
-      (config) => {
-        expect(config.mac.entitlements).toBe('resources/build/entitlements.mac.plist')
-        expect(config.mac.provisioningProfile).toBeUndefined()
-      }
-    )
   })
 })

--- a/config/scripts/mac-webauthn-signing.cjs
+++ b/config/scripts/mac-webauthn-signing.cjs
@@ -1,0 +1,90 @@
+const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+
+// Why this exists: the Touch ID WebAuthn authenticator only works when the signed
+// binary carries a `keychain-access-groups` entry for `<TEAM>.<bundle>.webauthn`,
+// which `codesign` refuses to templatize (`$(TeamIdentifierPrefix)` is left
+// verbatim), so the group is spliced in here from the team id at packaging time.
+// The entry is restricted: macOS kills at launch any binary that claims it
+// without an embedded provisioning profile authorising the group. Both inputs
+// therefore travel together, and a build with neither keeps the base
+// entitlements and simply never offers the authenticator.
+
+const WEBAUTHN_KEYCHAIN_GROUP_SUFFIX = '.webauthn'
+
+/** Inserts the identity and keychain-group keys before the closing `</dict>`. */
+function renderWebAuthnEntitlements(baseEntitlementsXml, { teamId, appId }) {
+  if (!/^[A-Z0-9]{10}$/.test(teamId)) {
+    throw new Error(
+      `APPLE_TEAM_ID must be a 10-character Apple team id, got ${JSON.stringify(teamId)}`
+    )
+  }
+  if (baseEntitlementsXml.includes('keychain-access-groups')) {
+    throw new Error('base macOS entitlements must not already declare keychain-access-groups')
+  }
+  const closingIndex = baseEntitlementsXml.lastIndexOf('</dict>')
+  if (closingIndex === -1) {
+    throw new Error('base macOS entitlements plist has no closing </dict>')
+  }
+  const inserted = [
+    '\t<key>com.apple.application-identifier</key>',
+    `\t<string>${teamId}.${appId}</string>`,
+    '\t<key>com.apple.developer.team-identifier</key>',
+    `\t<string>${teamId}</string>`,
+    '\t<key>keychain-access-groups</key>',
+    '\t<array>',
+    `\t\t<string>${teamId}.${appId}${WEBAUTHN_KEYCHAIN_GROUP_SUFFIX}</string>`,
+    '\t</array>',
+    ''
+  ].join('\n')
+  return (
+    baseEntitlementsXml.slice(0, closingIndex) + inserted + baseEntitlementsXml.slice(closingIndex)
+  )
+}
+
+/**
+ * Resolves the mac signing inputs for one packaging run.
+ * Returns `null` when the build is not a signed release or the provisioning
+ * profile is absent, which keeps local and ad-hoc builds launchable.
+ */
+function resolveMacWebAuthnSigning({
+  repoRoot,
+  isMacRelease,
+  appId,
+  baseEntitlementsPath,
+  env = process.env,
+  outputDir = join(repoRoot, 'out', 'mac-signing')
+}) {
+  if (!isMacRelease) {
+    return null
+  }
+  const profilePath = env.ORCA_MAC_PROVISIONING_PROFILE
+  const teamId = env.APPLE_TEAM_ID
+  if (!profilePath || !teamId) {
+    return null
+  }
+  const absoluteProfilePath = resolve(repoRoot, profilePath)
+  if (!existsSync(absoluteProfilePath)) {
+    throw new Error(
+      `ORCA_MAC_PROVISIONING_PROFILE points at a missing file: ${absoluteProfilePath}`
+    )
+  }
+  const entitlementsXml = renderWebAuthnEntitlements(
+    readFileSync(resolve(repoRoot, baseEntitlementsPath), 'utf8'),
+    { teamId, appId }
+  )
+  mkdirSync(outputDir, { recursive: true })
+  const entitlementsPath = join(outputDir, 'entitlements.mac.webauthn.plist')
+  writeFileSync(entitlementsPath, entitlementsXml, 'utf8')
+  return {
+    entitlements: entitlementsPath,
+    provisioningProfile: absoluteProfilePath,
+    keychainAccessGroup: `${teamId}.${appId}${WEBAUTHN_KEYCHAIN_GROUP_SUFFIX}`
+  }
+}
+
+module.exports = {
+  WEBAUTHN_KEYCHAIN_GROUP_SUFFIX,
+  renderWebAuthnEntitlements,
+  resolveMacWebAuthnSigning
+}

--- a/config/scripts/mac-webauthn-signing.cjs
+++ b/config/scripts/mac-webauthn-signing.cjs
@@ -1,90 +1,26 @@
-const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('node:fs')
-const { join, resolve } = require('node:path')
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
 
-// Why this exists: the Touch ID WebAuthn authenticator only works when the signed
-// binary carries a `keychain-access-groups` entry for `<TEAM>.<bundle>.webauthn`,
-// which `codesign` refuses to templatize (`$(TeamIdentifierPrefix)` is left
-// verbatim), so the group is spliced in here from the team id at packaging time.
-// The entry is restricted: macOS kills at launch any binary that claims it
-// without an embedded provisioning profile authorising the group. Both inputs
-// therefore travel together, and a build with neither keeps the base
-// entitlements and simply never offers the authenticator.
+const RESTRICTED_PASSKEY_KEYS = [
+  'keychain-access-groups',
+  'com.apple.application-identifier',
+  'com.apple.developer.team-identifier'
+]
 
-const WEBAUTHN_KEYCHAIN_GROUP_SUFFIX = '.webauthn'
-
-/** Inserts the identity and keychain-group keys before the closing `</dict>`. */
-function renderWebAuthnEntitlements(baseEntitlementsXml, { teamId, appId }) {
-  if (!/^[A-Z0-9]{10}$/.test(teamId)) {
+function assertMacPasskeySigningDisabled({ repoRoot, entitlementsPaths, env = process.env }) {
+  if (env.ORCA_MAC_PROVISIONING_PROFILE) {
     throw new Error(
-      `APPLE_TEAM_ID must be a 10-character Apple team id, got ${JSON.stringify(teamId)}`
+      'ORCA_MAC_PROVISIONING_PROFILE is unsupported: provisioning profiles can prevent Orca from launching'
     )
   }
-  if (baseEntitlementsXml.includes('keychain-access-groups')) {
-    throw new Error('base macOS entitlements must not already declare keychain-access-groups')
-  }
-  const closingIndex = baseEntitlementsXml.lastIndexOf('</dict>')
-  if (closingIndex === -1) {
-    throw new Error('base macOS entitlements plist has no closing </dict>')
-  }
-  const inserted = [
-    '\t<key>com.apple.application-identifier</key>',
-    `\t<string>${teamId}.${appId}</string>`,
-    '\t<key>com.apple.developer.team-identifier</key>',
-    `\t<string>${teamId}</string>`,
-    '\t<key>keychain-access-groups</key>',
-    '\t<array>',
-    `\t\t<string>${teamId}.${appId}${WEBAUTHN_KEYCHAIN_GROUP_SUFFIX}</string>`,
-    '\t</array>',
-    ''
-  ].join('\n')
-  return (
-    baseEntitlementsXml.slice(0, closingIndex) + inserted + baseEntitlementsXml.slice(closingIndex)
-  )
-}
-
-/**
- * Resolves the mac signing inputs for one packaging run.
- * Returns `null` when the build is not a signed release or the provisioning
- * profile is absent, which keeps local and ad-hoc builds launchable.
- */
-function resolveMacWebAuthnSigning({
-  repoRoot,
-  isMacRelease,
-  appId,
-  baseEntitlementsPath,
-  env = process.env,
-  outputDir = join(repoRoot, 'out', 'mac-signing')
-}) {
-  if (!isMacRelease) {
-    return null
-  }
-  const profilePath = env.ORCA_MAC_PROVISIONING_PROFILE
-  const teamId = env.APPLE_TEAM_ID
-  if (!profilePath || !teamId) {
-    return null
-  }
-  const absoluteProfilePath = resolve(repoRoot, profilePath)
-  if (!existsSync(absoluteProfilePath)) {
-    throw new Error(
-      `ORCA_MAC_PROVISIONING_PROFILE points at a missing file: ${absoluteProfilePath}`
-    )
-  }
-  const entitlementsXml = renderWebAuthnEntitlements(
-    readFileSync(resolve(repoRoot, baseEntitlementsPath), 'utf8'),
-    { teamId, appId }
-  )
-  mkdirSync(outputDir, { recursive: true })
-  const entitlementsPath = join(outputDir, 'entitlements.mac.webauthn.plist')
-  writeFileSync(entitlementsPath, entitlementsXml, 'utf8')
-  return {
-    entitlements: entitlementsPath,
-    provisioningProfile: absoluteProfilePath,
-    keychainAccessGroup: `${teamId}.${appId}${WEBAUTHN_KEYCHAIN_GROUP_SUFFIX}`
+  for (const path of entitlementsPaths) {
+    const xml = readFileSync(resolve(repoRoot, path), 'utf8')
+    for (const key of RESTRICTED_PASSKEY_KEYS) {
+      if (xml.includes(key)) {
+        throw new Error(`${path}: restricted passkey entitlement ${key} must not ship`)
+      }
+    }
   }
 }
 
-module.exports = {
-  WEBAUTHN_KEYCHAIN_GROUP_SUFFIX,
-  renderWebAuthnEntitlements,
-  resolveMacWebAuthnSigning
-}
+module.exports = { assertMacPasskeySigningDisabled }

--- a/config/scripts/mac-webauthn-signing.test.mjs
+++ b/config/scripts/mac-webauthn-signing.test.mjs
@@ -1,0 +1,134 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const {
+  renderWebAuthnEntitlements,
+  resolveMacWebAuthnSigning
+} = require('./mac-webauthn-signing.cjs')
+
+const BASE_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+\t<key>com.apple.security.cs.allow-jit</key>
+\t<true/>
+</dict>
+</plist>
+`
+
+const tempDirs = []
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function makeRepo() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-mac-signing-'))
+  tempDirs.push(root)
+  await writeFile(join(root, 'entitlements.mac.plist'), BASE_PLIST)
+  await writeFile(join(root, 'orca.provisionprofile'), 'profile-bytes')
+  return root
+}
+
+describe('renderWebAuthnEntitlements', () => {
+  it('adds the team-scoped identity and webauthn keychain group to the base plist', () => {
+    const xml = renderWebAuthnEntitlements(BASE_PLIST, {
+      teamId: 'ABCDE12345',
+      appId: 'com.stablyai.orca'
+    })
+    expect(xml).toContain('<key>com.apple.security.cs.allow-jit</key>')
+    expect(xml).toContain(
+      '<key>com.apple.application-identifier</key>\n\t<string>ABCDE12345.com.stablyai.orca</string>'
+    )
+    expect(xml).toContain(
+      '<key>com.apple.developer.team-identifier</key>\n\t<string>ABCDE12345</string>'
+    )
+    expect(xml).toContain('<string>ABCDE12345.com.stablyai.orca.webauthn</string>')
+    expect(xml.trimEnd().endsWith('</plist>')).toBe(true)
+  })
+
+  it('rejects a team id that is not a 10-character Apple team id', () => {
+    expect(() =>
+      renderWebAuthnEntitlements(BASE_PLIST, { teamId: 'Lovecast LLC', appId: 'com.stablyai.orca' })
+    ).toThrow(/APPLE_TEAM_ID/)
+  })
+
+  it('refuses to double-declare keychain-access-groups', () => {
+    const xml = renderWebAuthnEntitlements(BASE_PLIST, { teamId: 'ABCDE12345', appId: 'x' })
+    expect(() => renderWebAuthnEntitlements(xml, { teamId: 'ABCDE12345', appId: 'x' })).toThrow(
+      /already declare/
+    )
+  })
+})
+
+describe('resolveMacWebAuthnSigning', () => {
+  const baseOptions = (repoRoot, env) => ({
+    repoRoot,
+    isMacRelease: true,
+    appId: 'com.stablyai.orca',
+    baseEntitlementsPath: 'entitlements.mac.plist',
+    outputDir: join(repoRoot, 'out'),
+    env
+  })
+
+  it('writes a rendered entitlements file and resolves the profile path', async () => {
+    const root = await makeRepo()
+    const signing = resolveMacWebAuthnSigning(
+      baseOptions(root, {
+        APPLE_TEAM_ID: 'ABCDE12345',
+        ORCA_MAC_PROVISIONING_PROFILE: 'orca.provisionprofile'
+      })
+    )
+    expect(signing).toEqual({
+      entitlements: join(root, 'out', 'entitlements.mac.webauthn.plist'),
+      provisioningProfile: join(root, 'orca.provisionprofile'),
+      keychainAccessGroup: 'ABCDE12345.com.stablyai.orca.webauthn'
+    })
+    expect(await readFile(signing.entitlements, 'utf8')).toContain(
+      'ABCDE12345.com.stablyai.orca.webauthn'
+    )
+  })
+
+  // Why: the restricted entitlement without its profile is a launch-time SIGKILL,
+  // so a release missing the profile must fall back to the plain entitlements.
+  it('returns null when the profile env is absent', async () => {
+    const root = await makeRepo()
+    expect(resolveMacWebAuthnSigning(baseOptions(root, { APPLE_TEAM_ID: 'ABCDE12345' }))).toBeNull()
+  })
+
+  it('returns null when the team id env is absent', async () => {
+    const root = await makeRepo()
+    expect(
+      resolveMacWebAuthnSigning(
+        baseOptions(root, { ORCA_MAC_PROVISIONING_PROFILE: 'orca.provisionprofile' })
+      )
+    ).toBeNull()
+  })
+
+  it('returns null for non-release builds even with every input present', async () => {
+    const root = await makeRepo()
+    expect(
+      resolveMacWebAuthnSigning({
+        ...baseOptions(root, {
+          APPLE_TEAM_ID: 'ABCDE12345',
+          ORCA_MAC_PROVISIONING_PROFILE: 'orca.provisionprofile'
+        }),
+        isMacRelease: false
+      })
+    ).toBeNull()
+  })
+
+  it('fails loudly when the profile path points nowhere', async () => {
+    const root = await makeRepo()
+    expect(() =>
+      resolveMacWebAuthnSigning(
+        baseOptions(root, {
+          APPLE_TEAM_ID: 'ABCDE12345',
+          ORCA_MAC_PROVISIONING_PROFILE: 'missing.provisionprofile'
+        })
+      )
+    ).toThrow(/missing file/)
+  })
+})

--- a/config/scripts/mac-webauthn-signing.test.mjs
+++ b/config/scripts/mac-webauthn-signing.test.mjs
@@ -1,134 +1,59 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
-const {
-  renderWebAuthnEntitlements,
-  resolveMacWebAuthnSigning
-} = require('./mac-webauthn-signing.cjs')
-
-const BASE_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
-<plist version="1.0">
-<dict>
-\t<key>com.apple.security.cs.allow-jit</key>
-\t<true/>
-</dict>
-</plist>
-`
-
+const { assertMacPasskeySigningDisabled } = require('./mac-webauthn-signing.cjs')
 const tempDirs = []
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
-async function makeRepo() {
-  const root = await mkdtemp(join(tmpdir(), 'orca-mac-signing-'))
-  tempDirs.push(root)
-  await writeFile(join(root, 'entitlements.mac.plist'), BASE_PLIST)
-  await writeFile(join(root, 'orca.provisionprofile'), 'profile-bytes')
-  return root
+async function options(xml) {
+  const repoRoot = await mkdtemp(join(tmpdir(), 'orca-mac-signing-'))
+  tempDirs.push(repoRoot)
+  await writeFile(join(repoRoot, 'entitlements.plist'), xml)
+  return { repoRoot, entitlementsPaths: ['entitlements.plist'], env: {} }
 }
 
-describe('renderWebAuthnEntitlements', () => {
-  it('adds the team-scoped identity and webauthn keychain group to the base plist', () => {
-    const xml = renderWebAuthnEntitlements(BASE_PLIST, {
-      teamId: 'ABCDE12345',
-      appId: 'com.stablyai.orca'
-    })
-    expect(xml).toContain('<key>com.apple.security.cs.allow-jit</key>')
-    expect(xml).toContain(
-      '<key>com.apple.application-identifier</key>\n\t<string>ABCDE12345.com.stablyai.orca</string>'
+describe('assertMacPasskeySigningDisabled', () => {
+  it('allows the ordinary unrestricted entitlements', async () => {
+    const input = await options(
+      '<plist><dict><key>com.apple.security.cs.allow-jit</key><true/></dict></plist>'
     )
-    expect(xml).toContain(
-      '<key>com.apple.developer.team-identifier</key>\n\t<string>ABCDE12345</string>'
-    )
-    expect(xml).toContain('<string>ABCDE12345.com.stablyai.orca.webauthn</string>')
-    expect(xml.trimEnd().endsWith('</plist>')).toBe(true)
+    expect(() => assertMacPasskeySigningDisabled(input)).not.toThrow()
   })
 
-  it('rejects a team id that is not a 10-character Apple team id', () => {
-    expect(() =>
-      renderWebAuthnEntitlements(BASE_PLIST, { teamId: 'Lovecast LLC', appId: 'com.stablyai.orca' })
-    ).toThrow(/APPLE_TEAM_ID/)
+  it.each([
+    'keychain-access-groups',
+    'com.apple.application-identifier',
+    'com.apple.developer.team-identifier'
+  ])('rejects %s before signing regardless of its value', async (key) => {
+    const input = await options(`<plist><dict><key>${key}</key><array/></dict></plist>`)
+    expect(() => assertMacPasskeySigningDisabled(input)).toThrow(/must not ship/)
   })
 
-  it('refuses to double-declare keychain-access-groups', () => {
-    const xml = renderWebAuthnEntitlements(BASE_PLIST, { teamId: 'ABCDE12345', appId: 'x' })
-    expect(() => renderWebAuthnEntitlements(xml, { teamId: 'ABCDE12345', appId: 'x' })).toThrow(
-      /already declare/
-    )
-  })
-})
-
-describe('resolveMacWebAuthnSigning', () => {
-  const baseOptions = (repoRoot, env) => ({
-    repoRoot,
-    isMacRelease: true,
-    appId: 'com.stablyai.orca',
-    baseEntitlementsPath: 'entitlements.mac.plist',
-    outputDir: join(repoRoot, 'out'),
-    env
+  it('checks every entitlement input, including helper entitlements', async () => {
+    const input = await options('<plist><dict/></plist>')
+    await writeFile(join(input.repoRoot, 'helper.plist'), '<key>keychain-access-groups</key>')
+    input.entitlementsPaths.push('helper.plist')
+    expect(() => assertMacPasskeySigningDisabled(input)).toThrow(/helper.plist/)
   })
 
-  it('writes a rendered entitlements file and resolves the profile path', async () => {
-    const root = await makeRepo()
-    const signing = resolveMacWebAuthnSigning(
-      baseOptions(root, {
-        APPLE_TEAM_ID: 'ABCDE12345',
-        ORCA_MAC_PROVISIONING_PROFILE: 'orca.provisionprofile'
-      })
-    )
-    expect(signing).toEqual({
-      entitlements: join(root, 'out', 'entitlements.mac.webauthn.plist'),
-      provisioningProfile: join(root, 'orca.provisionprofile'),
-      keychainAccessGroup: 'ABCDE12345.com.stablyai.orca.webauthn'
-    })
-    expect(await readFile(signing.entitlements, 'utf8')).toContain(
-      'ABCDE12345.com.stablyai.orca.webauthn'
-    )
-  })
+  it.each(['missing.provisionprofile', 'expired.provisionprofile', 'valid.provisionprofile'])(
+    'rejects retired profile opt-in %s instead of silently enabling or falling back',
+    async (profile) => {
+      const input = await options('<plist><dict/></plist>')
+      input.env = { ORCA_MAC_PROVISIONING_PROFILE: profile, APPLE_TEAM_ID: 'ABCDE12345' }
+      expect(() => assertMacPasskeySigningDisabled(input)).toThrow(/unsupported/)
+    }
+  )
 
-  // Why: the restricted entitlement without its profile is a launch-time SIGKILL,
-  // so a release missing the profile must fall back to the plain entitlements.
-  it('returns null when the profile env is absent', async () => {
-    const root = await makeRepo()
-    expect(resolveMacWebAuthnSigning(baseOptions(root, { APPLE_TEAM_ID: 'ABCDE12345' }))).toBeNull()
-  })
-
-  it('returns null when the team id env is absent', async () => {
-    const root = await makeRepo()
-    expect(
-      resolveMacWebAuthnSigning(
-        baseOptions(root, { ORCA_MAC_PROVISIONING_PROFILE: 'orca.provisionprofile' })
-      )
-    ).toBeNull()
-  })
-
-  it('returns null for non-release builds even with every input present', async () => {
-    const root = await makeRepo()
-    expect(
-      resolveMacWebAuthnSigning({
-        ...baseOptions(root, {
-          APPLE_TEAM_ID: 'ABCDE12345',
-          ORCA_MAC_PROVISIONING_PROFILE: 'orca.provisionprofile'
-        }),
-        isMacRelease: false
-      })
-    ).toBeNull()
-  })
-
-  it('fails loudly when the profile path points nowhere', async () => {
-    const root = await makeRepo()
-    expect(() =>
-      resolveMacWebAuthnSigning(
-        baseOptions(root, {
-          APPLE_TEAM_ID: 'ABCDE12345',
-          ORCA_MAC_PROVISIONING_PROFILE: 'missing.provisionprofile'
-        })
-      )
-    ).toThrow(/missing file/)
+  it('fails closed on unreadable entitlements', async () => {
+    const input = await options('<plist><dict/></plist>')
+    input.entitlementsPaths.push('missing.plist')
+    expect(() => assertMacPasskeySigningDisabled(input)).toThrow()
   })
 })

--- a/config/scripts/macos-signed-app-workflow.test.mjs
+++ b/config/scripts/macos-signed-app-workflow.test.mjs
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+import { parse } from 'yaml'
+
+const require = createRequire(import.meta.url)
+
+describe('macOS signed launch gate publication boundary', () => {
+  it.each(['release', 'hourly', 'daily', 'adhoc'])(
+    '%s builds cannot materialize profiles and use the gated signing config',
+    (channel) => {
+      const source = readFileSync(
+        new URL(`../../.github/workflows/${channel}-mac-build.yml`, import.meta.url),
+        'utf8'
+      )
+      expect(source).not.toMatch(/MAC_PROVISIONING_PROFILE|provisionprofile/)
+      const workflow = parse(source)
+      const steps = Object.values(workflow.jobs).flatMap((job) => job.steps ?? [])
+      const publishers = steps.filter((step) => step.with?.command?.includes('electron-builder'))
+      expect(publishers).toHaveLength(1)
+      const publisher = publishers[0]
+      expect(publisher.with.command).toContain(
+        `ORCA_BACKGROUND_LAUNCH=1 ORCA_MAC_${channel.toUpperCase()}=1`
+      )
+      expect(publisher.with.command).toContain(
+        '--config config/electron-builder.config.cjs --mac --publish always'
+      )
+      expect(publisher.with.command).not.toContain('--prepackaged')
+      expect(steps.findIndex((step) => step.run === 'pnpm build:release')).toBeLessThan(
+        steps.indexOf(publisher)
+      )
+    }
+  )
+
+  it('awaits the signed-app gate from afterSign with no environment bypass', () => {
+    const config = require('../electron-builder.config.cjs')
+    const hook = config.afterSign.toString()
+    expect(hook).toContain('isMacRelease')
+    expect(hook).toContain("context.electronPlatformName === 'darwin'")
+    expect(hook).toContain("import('./scripts/verify-macos-signed-app.mjs')")
+    expect(hook).toContain('await verifyMacSignedApp(context)')
+    expect(hook).not.toContain('process.env')
+  })
+
+  it('the installed packager stops before distributable creation when signed packing rejects', async () => {
+    const { MacPackager } = require('app-builder-lib')
+    const createArtifacts = vi.fn()
+    const packager = {
+      appInfo: { productFilename: 'Orca' },
+      computeAppOutDir: () => '/signed',
+      getPlatformConfig: () => ({ platformName: 'darwin', config: {} }),
+      doPack: vi.fn(async () => {
+        throw new Error('launch gate rejected')
+      }),
+      packageInDistributableFormat: createArtifacts
+    }
+    await expect(
+      MacPackager.prototype.packMacTargets.call(packager, '/out', 3, [], null, {})
+    ).rejects.toThrow('launch gate rejected')
+    expect(createArtifacts).not.toHaveBeenCalled()
+  })
+})

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -172,7 +172,7 @@ describe('Electron runtime package contract', () => {
         command.indexOf('electron-builder')
       )
     }
-    expect(macReleaseCommand).toContain(' && ORCA_MAC_RELEASE=1 ')
+    expect(macReleaseCommand).toContain(' && ORCA_BACKGROUND_LAUNCH=1 ORCA_MAC_RELEASE=1 ')
     expect(releaseCommands.get('linux-x64')).toContain(' && pnpm exec electron-builder ')
     expect(releaseCommands.get('linux-x64')).toContain('--linux AppImage deb rpm --x64')
     expect(releaseCommands.get('linux-arm64')).toContain('ORCA_LINUX_ARM64_RELEASE=1')

--- a/config/scripts/verify-macos-signed-app.mjs
+++ b/config/scripts/verify-macos-signed-app.mjs
@@ -1,0 +1,193 @@
+import { open, readdir, mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const require = createRequire(import.meta.url)
+const machoMagic = new Set([
+  'feedface',
+  'cefaedfe',
+  'feedfacf',
+  'cffaedfe',
+  'cafebabe',
+  'bebafeca',
+  'cafebabf',
+  'bfbafeca'
+])
+
+function defaultRunner() {
+  // The release build emits the same process boundary used by the app and CLI.
+  return require('../../out/shared/child-process/run-process.js').runProcess
+}
+
+function defaultTermination() {
+  return require('../../out/shared/child-process/process-tree-termination.js')
+}
+
+async function checked(run, program, args, input) {
+  const result = await run({ program, args, input, maxOutputBytes: 1024 * 1024 })
+  if (result.code !== 0 || result.timedOut || result.outputTruncated) {
+    throw new Error(`${program} ${args.join(' ')} failed: ${result.stderr}`)
+  }
+  return result.stdout
+}
+
+async function readPlist(run, args) {
+  const json = await checked(run, '/usr/bin/plutil', ['-convert', 'json', '-o', '-', ...args])
+  return JSON.parse(json)
+}
+
+async function collectSignedCode(directory, files = []) {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    if (/\.provisionprofile$|^embedded\.mobileprovision$/i.test(entry.name)) {
+      throw new Error(`Provisioning profiles are forbidden in distributable macOS apps: ${path}`)
+    }
+    if (entry.isDirectory()) {
+      await collectSignedCode(path, files)
+    } else if (entry.isFile()) {
+      const handle = await open(path, 'r')
+      try {
+        const magic = Buffer.alloc(4)
+        const { bytesRead } = await handle.read(magic, 0, 4, 0)
+        if (bytesRead === 4 && machoMagic.has(magic.toString('hex'))) {
+          files.push(path)
+        }
+      } finally {
+        await handle.close()
+      }
+    }
+  }
+  return files
+}
+
+export async function verifyMacAppSignature(appPath, { run = defaultRunner() } = {}) {
+  const files = await collectSignedCode(appPath)
+  if (files.length === 0) {
+    throw new Error(`No Mach-O code found in ${appPath}`)
+  }
+  await checked(run, '/usr/bin/codesign', [
+    '--verify',
+    '--deep',
+    '--strict',
+    '--all-architectures',
+    appPath
+  ])
+  for (const file of files) {
+    await checked(run, '/usr/bin/codesign', ['--verify', '--strict', '--all-architectures', file])
+    const architectures = (await checked(run, '/usr/bin/lipo', ['-archs', file]))
+      .trim()
+      .split(/\s+/)
+    if (architectures.some((arch) => !/^(arm64e?|x86_64h?|i386)$/.test(arch))) {
+      throw new Error(`Unrecognized Mach-O architectures in ${file}: ${architectures.join(', ')}`)
+    }
+    for (const arch of architectures) {
+      const xml = await checked(run, '/usr/bin/codesign', [
+        '-d',
+        '--arch',
+        arch,
+        '--entitlements',
+        ':-',
+        file
+      ])
+      if (!xml.trim()) {
+        continue
+      }
+      const json = await checked(run, '/usr/bin/plutil', ['-convert', 'json', '-o', '-', '-'], xml)
+      const entitlements = JSON.parse(json)
+      if (
+        [
+          'keychain-access-groups',
+          'com.apple.application-identifier',
+          'com.apple.developer.team-identifier'
+        ].some((key) => Object.hasOwn(entitlements, key))
+      ) {
+        throw new Error(`Restricted passkey entitlement is forbidden: ${file} (${arch})`)
+      }
+    }
+  }
+}
+
+export async function verifyMacAppLaunch(
+  appPath,
+  { run = defaultRunner(), survivalMs = 10_000, termination = defaultTermination() } = {}
+) {
+  const plist = await readPlist(run, [join(appPath, 'Contents', 'Info.plist')])
+  const executable = plist.CFBundleExecutable
+  if (
+    typeof executable !== 'string' ||
+    !executable ||
+    /[/\\]/.test(executable) ||
+    executable === '..'
+  ) {
+    throw new Error(`Invalid CFBundleExecutable in ${appPath}`)
+  }
+  const isolatedRoot = await mkdtemp(join(tmpdir(), 'orca-mac-launch-'))
+  const isolatedHome = join(isolatedRoot, 'home')
+  await mkdir(isolatedHome)
+  const env = { ...process.env }
+  for (const key of [
+    'ELECTRON_RUN_AS_NODE',
+    'NODE_OPTIONS',
+    'ORCA_E2E_FOREGROUND',
+    'CODEX_HOME',
+    'ORCA_CODEX_HOME'
+  ]) {
+    delete env[key]
+  }
+  Object.assign(env, {
+    HOME: isolatedHome,
+    USERPROFILE: isolatedHome,
+    ORCA_E2E_HOME_DIR: isolatedHome,
+    ORCA_E2E_USER_DATA_DIR: join(isolatedRoot, 'user-data'),
+    ORCA_BACKGROUND_LAUNCH: '1',
+    ORCA_E2E_HEADLESS: '1'
+  })
+  let survived = false
+  let terminated = false
+  try {
+    const result = await run({
+      program: join(appPath, 'Contents', 'MacOS', executable),
+      args: [],
+      env,
+      cwd: isolatedHome,
+      timeoutMs: survivalMs,
+      detached: true,
+      terminationBarrier: {
+        signal: (child, signal) => {
+          // An exited root can leave inherited output pipes open until the timeout.
+          survived = child.exitCode === null && child.signalCode === null && !!child.pid
+          return termination.signalProcessTree(child, signal)
+        },
+        force: async (child) => {
+          terminated = await termination.forceTerminateProcessTree(child)
+          return terminated
+        }
+      },
+      maxOutputBytes: 1024 * 1024
+    })
+    // A timeout is success only here: the runner observed a live app for the full interval.
+    if (!result.timedOut || !survived) {
+      throw new Error(
+        `Signed app exited before ${survivalMs}ms (code=${result.code}, signal=${result.signal}): ${result.stderr}`
+      )
+    }
+    if (!terminated) {
+      throw new Error('Could not verify launch-probe process tree termination')
+    }
+  } finally {
+    await rm(isolatedRoot, { recursive: true, force: true })
+  }
+}
+
+export async function verifyMacSignedApp(context, options = {}) {
+  if (context.electronPlatformName !== 'darwin') {
+    return
+  }
+  const appPath = join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
+  await verifyMacAppSignature(appPath, options)
+  await verifyMacAppLaunch(appPath, options)
+  console.log(
+    `[verify-macos-signed-app] ${appPath}: signature, entitlement policy and background launch passed`
+  )
+}

--- a/config/scripts/verify-macos-signed-app.test.mjs
+++ b/config/scripts/verify-macos-signed-app.test.mjs
@@ -1,0 +1,182 @@
+import { mkdtemp, mkdir, writeFile, rm, access } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  verifyMacAppLaunch,
+  verifyMacAppSignature,
+  verifyMacSignedApp
+} from './verify-macos-signed-app.mjs'
+
+const roots = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+  vi.unstubAllEnvs()
+})
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'orca-signed-gate-test-'))
+  roots.push(root)
+  const app = join(root, 'Orca.app')
+  const main = join(app, 'Contents', 'MacOS', 'Orca')
+  const helper = join(
+    app,
+    'Contents',
+    'Frameworks',
+    'Orca Helper.app',
+    'Contents',
+    'MacOS',
+    'Orca Helper'
+  )
+  for (const file of [main, helper]) {
+    await mkdir(join(file, '..'), { recursive: true })
+    await writeFile(file, Buffer.from('cffaedfe00000000', 'hex'))
+  }
+  return { root, app, main, helper }
+}
+
+function success(stdout = '') {
+  return { code: 0, signal: null, timedOut: false, stdout, stderr: '' }
+}
+
+function signatureRunner(entitlements = () => ({})) {
+  return vi.fn(async ({ program, args, input }) => {
+    if (program.endsWith('/lipo')) {
+      return success('arm64 x86_64')
+    }
+    if (program.endsWith('/codesign') && args[0] === '-d') {
+      return success(JSON.stringify(entitlements(args.at(-1), args[2])))
+    }
+    if (program.endsWith('/plutil')) {
+      return success(input)
+    }
+    return success()
+  })
+}
+
+describe('signed macOS app policy', () => {
+  it('checks the main and nested helpers in every architecture', async () => {
+    const { app, main, helper } = await fixture()
+    const run = signatureRunner()
+    await verifyMacAppSignature(app, { run })
+    for (const file of [main, helper]) {
+      expect(run).toHaveBeenCalledWith(
+        expect.objectContaining({ args: ['--verify', '--strict', '--all-architectures', file] })
+      )
+      for (const arch of ['arm64', 'x86_64']) {
+        expect(run).toHaveBeenCalledWith(
+          expect.objectContaining({ args: ['-d', '--arch', arch, '--entitlements', ':-', file] })
+        )
+      }
+    }
+  })
+
+  it.each([
+    'keychain-access-groups',
+    'com.apple.application-identifier',
+    'com.apple.developer.team-identifier'
+  ])('rejects %s even in the other helper architecture', async (key) => {
+    const { app, helper } = await fixture()
+    const run = signatureRunner((file, arch) =>
+      file === helper && arch === 'x86_64' ? { [key]: [] } : {}
+    )
+    await expect(verifyMacAppSignature(app, { run })).rejects.toThrow(
+      'Restricted passkey entitlement'
+    )
+  })
+
+  it('rejects embedded profiles before a launch or certificate can make them look safe', async () => {
+    const { app } = await fixture()
+    await writeFile(join(app, 'Contents', 'embedded.provisionprofile'), 'expired or valid alike')
+    const run = signatureRunner()
+    await expect(verifyMacAppSignature(app, { run })).rejects.toThrow(
+      'Provisioning profiles are forbidden'
+    )
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('propagates signature verification failures before launch', async () => {
+    const { root } = await fixture()
+    const run = vi.fn(async () => ({ ...success(), code: 1, stderr: 'invalid signature' }))
+    await expect(
+      verifyMacSignedApp(
+        {
+          electronPlatformName: 'darwin',
+          appOutDir: root,
+          packager: { appInfo: { productFilename: 'Orca' } }
+        },
+        { run }
+      )
+    ).rejects.toThrow('invalid signature')
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})
+
+function launchRunner(outcome) {
+  const termination = {
+    signalProcessTree: vi.fn(async () => true),
+    forceTerminateProcessTree: vi.fn(async () => true)
+  }
+  const run = vi.fn(async (spec) => {
+    if (spec.program.endsWith('/plutil')) {
+      return success('{"CFBundleExecutable":"Orca"}')
+    }
+    if (outcome === 'killed') {
+      return { ...success(), code: null, signal: 'SIGKILL' }
+    }
+    if (outcome === 'error') {
+      throw new Error('spawn failed')
+    }
+    await spec.terminationBarrier.signal({
+      pid: 123,
+      exitCode: outcome === 'exited-with-open-pipes' ? 0 : null,
+      signalCode: null
+    })
+    await spec.terminationBarrier.force({ pid: 123 })
+    return { ...success(), timedOut: true, signal: 'SIGTERM' }
+  })
+  return { run, termination }
+}
+
+describe('signed app launch survival', () => {
+  it('launches the exact signed executable hidden with disposable home and profile, then cleans up', async () => {
+    vi.stubEnv('ELECTRON_RUN_AS_NODE', '1')
+    vi.stubEnv('ORCA_E2E_FOREGROUND', '1')
+    const { app, main } = await fixture()
+    const deps = launchRunner('alive')
+    await verifyMacAppLaunch(app, deps)
+    const spec = deps.run.mock.calls[1][0]
+    expect(spec.program).toBe(main)
+    expect(spec.timeoutMs).toBe(10_000)
+    expect(spec.detached).toBe(true)
+    expect(spec.env).toMatchObject({
+      ORCA_BACKGROUND_LAUNCH: '1',
+      ORCA_E2E_HEADLESS: '1',
+      HOME: spec.env.ORCA_E2E_HOME_DIR
+    })
+    expect(spec.env.ELECTRON_RUN_AS_NODE).toBeUndefined()
+    expect(spec.env.ORCA_E2E_FOREGROUND).toBeUndefined()
+    expect(spec.env.ORCA_E2E_USER_DATA_DIR).toBe(join(spec.cwd, '..', 'user-data'))
+    expect(deps.termination.forceTerminateProcessTree).toHaveBeenCalled()
+    await expect(access(spec.cwd)).rejects.toThrow()
+  })
+
+  it.each(['killed', 'error', 'exited-with-open-pipes'])(
+    'fails for %s and cleans its profile',
+    async (outcome) => {
+      const { app } = await fixture()
+      const deps = launchRunner(outcome)
+      await expect(verifyMacAppLaunch(app, deps)).rejects.toThrow(
+        outcome === 'error' ? 'spawn failed' : 'Signed app exited'
+      )
+      await expect(access(deps.run.mock.calls[1][0].cwd)).rejects.toThrow()
+    }
+  )
+
+  it('fails if the probe tree could not be terminated', async () => {
+    const { app } = await fixture()
+    const deps = launchRunner('alive')
+    deps.termination.forceTerminateProcessTree.mockResolvedValue(false)
+    await expect(verifyMacAppLaunch(app, deps)).rejects.toThrow('Could not verify')
+  })
+})

--- a/docs/reference/macos-passkey-signing.md
+++ b/docs/reference/macos-passkey-signing.md
@@ -1,0 +1,105 @@
+# macOS passkey signing
+
+Touch ID passkeys are disabled in every Orca build channel, including release,
+hourly, daily, and adhoc. Packaging must not add `keychain-access-groups`, the
+passkey identity entitlements, or an embedded provisioning profile. Local and
+unsigned builds keep the existing base entitlements and launcher behavior.
+
+## Why the shipping path was removed
+
+Electron's macOS Touch ID authenticator requires a signed keychain group such as
+`<TEAM_ID>.com.stablyai.orca.webauthn` and `app.configureWebAuthn` after `ready`.
+`keychain-access-groups` is restricted: macOS can kill the app before its main
+process starts when the embedded provisioning profile does not authorize it.
+Runtime error handling cannot protect an app that never reaches its own code.
+A local reproduction of the entitlement without an authorizing profile exited
+137 (`SIGKILL`).
+
+Even a correctly signed build that launches in CI can stop launching later.
+Apple's [Developer ID certificate documentation](https://developer.apple.com/help/account/certificates/create-developer-id-certificates),
+under **Manage Developer ID certificate and provisioning profile expiration**,
+states that the profile is evaluated at installation and every app launch:
+
+> However, if your Developer ID provisioning profile expires, the app will no
+> longer launch.
+
+Apple also states that Developer ID profiles created after February 22, 2017 are
+valid for 18 years. That long lifetime does not remove the failure: an installed
+app can outlive its profile, and an app that cannot launch cannot receive an
+updater repair. Certificate expiration is different; Apple says a Developer ID
+app can continue running after its signing certificate expires if the certificate
+was valid when the app was compiled. This finding is based on Apple's published
+policy, checked September 7, 2026; no system-clock expiry experiment was needed.
+
+Therefore a valid profile, a future expiration date, notarization, and a successful
+CI launch are insufficient to meet the requirement that this feature never make
+an installed Orca fail to launch. Provisioning and the restricted entitlement are
+removed from every shipping channel. Setting the previous profile secrets must
+not re-enable them.
+
+## Build safeguards
+
+The packaging policy keeps the base macOS entitlements and rejects attempts to
+supply the former passkey provisioning configuration. The signed-app entitlement
+verifier also rejects `keychain-access-groups` or an embedded profile,
+including in nested app bundles. This check runs in the job that signs the app.
+It enforces absence instead of accepting profiles that happen to be valid today.
+
+Every macOS build workflow gates artifact upload on launching the freshly signed
+app in the background and observing it survive startup. Launch checks set
+`ORCA_BACKGROUND_LAUNCH=1`, use isolated app data, and never show or focus a window.
+A launch failure fails the job. The launch gate catches immediate signing and
+startup failures; removing the profile dependency prevents this feature's later
+profile-expiry failure.
+
+## Local failure reproduction
+
+On September 7, 2026, the launch gate was exercised on two copies of the same
+packaged Orca app on Apple silicon. The bundle's compiled main process was first
+checked for the background activation policy and isolated E2E data paths.
+
+- A copy signed with the restricted entitlement and no embedded profile failed
+  the gate with `code=null, signal=SIGKILL` before the ten-second survival window.
+- The same app carrying the authorizing Development profile survived that window
+  and passed the launch gate. The gate then terminated its own process group.
+- The static gate rejected both: the missing-profile copy for its restricted
+  entitlement, and the working copy for its embedded profile.
+
+Both launches used `ORCA_BACKGROUND_LAUNCH=1` and disposable app data; no window
+was revealed. This proves the launch gate distinguishes an immediate entitlement
+kill from a locally working profile. The working profile was a Development
+profile, not a production Developer ID profile. It does not establish future
+profile validity or replace the freshly signed CI artifact checks. Expiration
+behavior above is established by Apple documentation, not this experiment.
+
+## Requirements before reconsidering Touch ID
+
+Do not re-enable provisioning by adding a secret or restricting it to a channel.
+First establish, with Apple documentation and an appropriate experiment, a design
+whose credentials can expire without preventing an installed Orca from launching.
+Moving an entitlement behind a runtime condition cannot solve a pre-launch kill.
+
+Any future design that signs an executable with a provisioning profile must also:
+
+- Decode it with `security cms -D -i` before signing and fail on invalid input.
+- Match the team, application identifier and identifier prefix, and authorized
+  keychain access group against the intended signature.
+- Match the actual signing certificate against `DeveloperCertificates` and require
+  a Developer ID profile (`ProvisionsAllDevices`), with an explicit minimum
+  remaining lifetime for `ExpirationDate`.
+- Cross-check the finished executable's signature and embedded profile in the
+  signing job, then launch that exact signed executable before uploading it.
+- Cover mismatched, missing, malformed, expired, and soon-expiring profiles in
+  automated tests, and prove immediate launch failures with a real signed app.
+
+These checks are necessary for a future provisioned executable, but are not a
+solution to the installed-app expiration problem. The current policy rejects all
+profiles, so certificate/profile matching cannot create an exception to it.
+
+## Browser behavior
+
+Shipped macOS builds continue to support USB security keys. They do not provide a
+Touch ID platform authenticator or offer existing iCloud Keychain passkeys. Sites
+may still report partial passkey support or wait for a security key; use another
+sign-in method when needed. The original platform-passkey sign-in issue remains
+unresolved by this safety change. Windows and Linux behavior is unchanged.

--- a/docs/site/content/docs/browser/profiles.mdx
+++ b/docs/site/content/docs/browser/profiles.mdx
@@ -15,7 +15,15 @@ Browser-use profiles let you run the Orca browser with a specific identity — a
 
 Import cookies from Chrome or Edge (or from a cookie file) into a profile from Settings or the browser toolbar. Orca replaces existing cookies only for domains included in the import, so sign-ins for unrelated sites in the same profile stay intact. Google cookies are excluded — import menus show **Google logins aren't imported** and tell you to **Sign in to Google directly in Orca.** After an import that skipped Google cookies, a separate warning names the host that ran the import: open a browser in Orca on that host with the same profile, then sign in.
 
-When a site requests a discoverable passkey from a USB security key and the key offers multiple accounts, Orca opens an account picker instead of silently canceling the sign-in. Choose the account you want or cancel the request. Platform passkeys stored by the operating system are not available in Orca yet; this flow is for external FIDO security keys.
+## Passkeys
+
+Sites can sign you in with a passkey inside Orca's browser. What is available depends on the platform:
+
+- **macOS**: signed Orca builds offer a Touch ID passkey authenticator. When a site asks you to register a passkey, macOS shows the Touch ID sheet and stores the passkey in this Mac's Secure Enclave, scoped to the browser profile that created it. These passkeys are device-bound: they do not sync through iCloud Keychain, and passkeys you already keep in iCloud Keychain, Safari, or a password manager are not offered to sites in Orca. Register a new passkey for the site in Orca when it offers to, or use the site's other sign-in method.
+- **Windows**: Windows handles passkey requests natively, so Windows Hello, security keys, and a phone via QR code all work as they do in other browsers.
+- **Linux**: USB security keys only.
+
+USB security keys work on every platform. When a security key or Touch ID offers more than one account for a site, Orca opens an account picker instead of silently canceling the sign-in. Choose the account you want or cancel the request.
 
 ## Use a profile
 

--- a/docs/site/content/docs/browser/profiles.mdx
+++ b/docs/site/content/docs/browser/profiles.mdx
@@ -19,11 +19,11 @@ Import cookies from Chrome or Edge (or from a cookie file) into a profile from S
 
 Sites can sign you in with a passkey inside Orca's browser. What is available depends on the platform:
 
-- **macOS**: signed Orca builds offer a Touch ID passkey authenticator. When a site asks you to register a passkey, macOS shows the Touch ID sheet and stores the passkey in this Mac's Secure Enclave, scoped to the browser profile that created it. These passkeys are device-bound: they do not sync through iCloud Keychain, and passkeys you already keep in iCloud Keychain, Safari, or a password manager are not offered to sites in Orca. Register a new passkey for the site in Orca when it offers to, or use the site's other sign-in method.
+- **macOS**: USB security keys are supported. Touch ID passkeys are disabled in all Orca builds because the required signing profile can prevent the app from launching when it expires. Passkeys stored in iCloud Keychain or a password manager are not offered to sites in Orca. Use a security key or the site's other sign-in method.
 - **Windows**: Windows handles passkey requests natively, so Windows Hello, security keys, and a phone via QR code all work as they do in other browsers.
 - **Linux**: USB security keys only.
 
-USB security keys work on every platform. When a security key or Touch ID offers more than one account for a site, Orca opens an account picker instead of silently canceling the sign-in. Choose the account you want or cancel the request.
+USB security keys work on every platform. When an authenticator offers more than one account for a site, Orca opens an account picker instead of silently canceling the sign-in. Choose the account you want or cancel the request.
 
 ## Use a profile
 

--- a/src/main/browser/browser-platform-passkeys-macos.test.ts
+++ b/src/main/browser/browser-platform-passkeys-macos.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  enablePlatformPasskeys,
+  readWebAuthnKeychainAccessGroup
+} from './browser-platform-passkeys-macos'
+
+const SIGNED_ENTITLEMENTS = `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+<key>com.apple.application-identifier</key><string>TEAM123456.com.stablyai.orca</string>
+<key>keychain-access-groups</key>
+<array>
+  <string>TEAM123456.com.stablyai.orca</string>
+  <string>TEAM123456.com.stablyai.orca.webauthn</string>
+</array>
+<key>com.apple.security.cs.allow-jit</key><true/>
+</dict></plist>`
+
+type ConfigureWebAuthn = (options: {
+  touchID: { keychainAccessGroup: string; promptReason?: string }
+}) => void
+
+function packagedApp(): {
+  isPackaged: boolean
+  configureWebAuthn: ReturnType<typeof vi.fn<ConfigureWebAuthn>>
+} {
+  return { isPackaged: true, configureWebAuthn: vi.fn<ConfigureWebAuthn>() }
+}
+
+describe('readWebAuthnKeychainAccessGroup', () => {
+  it('returns the group ending in .webauthn from a signed entitlement plist', () => {
+    expect(readWebAuthnKeychainAccessGroup(SIGNED_ENTITLEMENTS)).toBe(
+      'TEAM123456.com.stablyai.orca.webauthn'
+    )
+  })
+
+  it('returns null when the array holds no webauthn group', () => {
+    const xml = SIGNED_ENTITLEMENTS.replace(
+      '<string>TEAM123456.com.stablyai.orca.webauthn</string>',
+      ''
+    )
+    expect(readWebAuthnKeychainAccessGroup(xml)).toBeNull()
+  })
+
+  it('returns null for an unsigned binary whose entitlement dump is empty', () => {
+    expect(readWebAuthnKeychainAccessGroup('')).toBeNull()
+  })
+})
+
+describe('enablePlatformPasskeys', () => {
+  it('configures the Touch ID authenticator with the signed group and a prompt reason', () => {
+    const app = packagedApp()
+    const outcome = enablePlatformPasskeys(app, {
+      platform: 'darwin',
+      execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+      readEntitlements: () => SIGNED_ENTITLEMENTS
+    })
+    expect(outcome).toEqual({
+      status: 'enabled',
+      keychainAccessGroup: 'TEAM123456.com.stablyai.orca.webauthn'
+    })
+    expect(app.configureWebAuthn).toHaveBeenCalledWith({
+      touchID: {
+        keychainAccessGroup: 'TEAM123456.com.stablyai.orca.webauthn',
+        promptReason: 'sign in to $1'
+      }
+    })
+  })
+
+  it('reads the entitlements of the running executable', () => {
+    const readEntitlements = vi.fn(() => SIGNED_ENTITLEMENTS)
+    enablePlatformPasskeys(packagedApp(), {
+      platform: 'darwin',
+      execPath: '/Applications/Orca.app/Contents/MacOS/Orca',
+      readEntitlements
+    })
+    expect(readEntitlements).toHaveBeenCalledWith('/Applications/Orca.app/Contents/MacOS/Orca')
+  })
+
+  it.each(['win32', 'linux'] as const)('does nothing on %s', (platform) => {
+    const app = packagedApp()
+    const readEntitlements = vi.fn(() => SIGNED_ENTITLEMENTS)
+    expect(enablePlatformPasskeys(app, { platform, readEntitlements })).toEqual({
+      status: 'skipped',
+      reason: 'not-macos'
+    })
+    expect(readEntitlements).not.toHaveBeenCalled()
+    expect(app.configureWebAuthn).not.toHaveBeenCalled()
+  })
+
+  it('skips unpackaged runs without inspecting the shared Electron binary', () => {
+    const app = { ...packagedApp(), isPackaged: false }
+    const readEntitlements = vi.fn(() => SIGNED_ENTITLEMENTS)
+    expect(enablePlatformPasskeys(app, { platform: 'darwin', readEntitlements })).toEqual({
+      status: 'skipped',
+      reason: 'unpackaged'
+    })
+    expect(readEntitlements).not.toHaveBeenCalled()
+    expect(app.configureWebAuthn).not.toHaveBeenCalled()
+  })
+
+  // Why: a build signed without the group would make Chromium log an entitlement
+  // error on every request; leaving the authenticator unconfigured keeps today's behavior.
+  it('skips a signed build that lacks the webauthn keychain group', () => {
+    const app = packagedApp()
+    expect(
+      enablePlatformPasskeys(app, {
+        platform: 'darwin',
+        readEntitlements: () => '<plist version="1.0"><dict></dict></plist>'
+      })
+    ).toEqual({ status: 'skipped', reason: 'no-entitlement' })
+    expect(app.configureWebAuthn).not.toHaveBeenCalled()
+  })
+
+  it('skips when the running Electron has no configureWebAuthn', () => {
+    const app = { isPackaged: true }
+    expect(
+      enablePlatformPasskeys(app, {
+        platform: 'darwin',
+        readEntitlements: () => SIGNED_ENTITLEMENTS
+      })
+    ).toEqual({ status: 'skipped', reason: 'api-unavailable' })
+  })
+
+  it('reports a codesign read failure without throwing', () => {
+    const app = packagedApp()
+    expect(
+      enablePlatformPasskeys(app, {
+        platform: 'darwin',
+        readEntitlements: () => {
+          throw new Error('codesign exited 1')
+        }
+      })
+    ).toEqual({ status: 'failed', error: 'codesign exited 1' })
+    expect(app.configureWebAuthn).not.toHaveBeenCalled()
+  })
+
+  it('reports a configureWebAuthn failure without throwing', () => {
+    const app = packagedApp()
+    app.configureWebAuthn.mockImplementation(() => {
+      throw new TypeError('bad options')
+    })
+    expect(
+      enablePlatformPasskeys(app, {
+        platform: 'darwin',
+        readEntitlements: () => SIGNED_ENTITLEMENTS
+      })
+    ).toEqual({ status: 'failed', error: 'bad options' })
+  })
+})
+
+describe('startup wiring', () => {
+  // Why: configureWebAuthn is process-wide and must land before the first guest can
+  // issue a passkey request, so it sits ahead of browser session initialization.
+  it('enables platform passkeys before browser sessions initialize', async () => {
+    const { readFileSync } = await import('node:fs')
+    const { join } = await import('node:path')
+    const source = readFileSync(
+      join(import.meta.dirname, '../startup/main-process-ready-foundation.ts'),
+      'utf8'
+    )
+    const enableIndex = source.indexOf('enablePlatformPasskeys(app)')
+    const sessionsIndex = source.indexOf('initializeBrowserSessionsForApp({')
+    expect(enableIndex).toBeGreaterThan(-1)
+    expect(sessionsIndex).toBeGreaterThan(enableIndex)
+  })
+})

--- a/src/main/browser/browser-platform-passkeys-macos.ts
+++ b/src/main/browser/browser-platform-passkeys-macos.ts
@@ -1,0 +1,97 @@
+import { runProcessSync } from '../../shared/child-process/run-process'
+
+// Why: GitHub and other relying parties gate passkey sign-in on
+// PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable(). Electron
+// reports false until the app opts into the Touch ID authenticator, and a
+// discoverable-credential request then waits on USB security keys for the
+// three-minute Chromium floor. Opting in makes the check true, shows the Touch
+// ID sheet, and lets a request with no matching passkey fail promptly.
+
+export const ORCA_WEBAUTHN_KEYCHAIN_GROUP_SUFFIX = '.webauthn'
+
+type PlatformPasskeyApp = {
+  isPackaged: boolean
+  configureWebAuthn?: (options: {
+    touchID: { keychainAccessGroup: string; promptReason?: string }
+  }) => void
+}
+
+export type PlatformPasskeyOutcome =
+  | { status: 'enabled'; keychainAccessGroup: string }
+  | { status: 'skipped'; reason: 'not-macos' | 'unpackaged' | 'api-unavailable' | 'no-entitlement' }
+  | { status: 'failed'; error: string }
+
+/**
+ * Picks the WebAuthn keychain group out of the executable's signed entitlements.
+ * Why read the signature and not a build constant: the Touch ID authenticator only
+ * works when the running binary actually carries the group, so the signature is the
+ * single source of truth and unsigned local builds stay inert automatically.
+ */
+export function readWebAuthnKeychainAccessGroup(entitlementsXml: string): string | null {
+  const groupsMatch = /<key>keychain-access-groups<\/key>\s*<array>([\s\S]*?)<\/array>/.exec(
+    entitlementsXml
+  )
+  if (!groupsMatch) {
+    return null
+  }
+  for (const match of groupsMatch[1].matchAll(/<string>([^<]*)<\/string>/g)) {
+    const group = match[1].trim()
+    if (group.endsWith(ORCA_WEBAUTHN_KEYCHAIN_GROUP_SUFFIX)) {
+      return group
+    }
+  }
+  return null
+}
+
+function readSignedEntitlements(execPath: string): string {
+  // Why: `codesign -d --entitlements :-` prints the signed entitlement plist to stdout.
+  const result = runProcessSync({
+    program: 'codesign',
+    args: ['-d', '--entitlements', ':-', execPath],
+    timeoutMs: 10_000
+  })
+  if (result.code !== 0) {
+    throw new Error(`codesign exited ${result.code ?? result.signal}: ${result.stderr.trim()}`)
+  }
+  return result.stdout
+}
+
+export function enablePlatformPasskeys(
+  app: PlatformPasskeyApp,
+  options: {
+    platform?: NodeJS.Platform
+    execPath?: string
+    readEntitlements?: (execPath: string) => string
+  } = {}
+): PlatformPasskeyOutcome {
+  if ((options.platform ?? process.platform) !== 'darwin') {
+    return { status: 'skipped', reason: 'not-macos' }
+  }
+  if (!app.isPackaged) {
+    return { status: 'skipped', reason: 'unpackaged' }
+  }
+  if (typeof app.configureWebAuthn !== 'function') {
+    return { status: 'skipped', reason: 'api-unavailable' }
+  }
+  let keychainAccessGroup: string | null
+  try {
+    keychainAccessGroup = readWebAuthnKeychainAccessGroup(
+      (options.readEntitlements ?? readSignedEntitlements)(options.execPath ?? process.execPath)
+    )
+  } catch (error) {
+    return { status: 'failed', error: error instanceof Error ? error.message : String(error) }
+  }
+  if (!keychainAccessGroup) {
+    return { status: 'skipped', reason: 'no-entitlement' }
+  }
+  try {
+    // Why the explicit reason: Electron's default reads from a locale pak that can be
+    // missing, and an empty reason crashes the LAContext prompt (electron#53185).
+    app.configureWebAuthn({
+      touchID: { keychainAccessGroup, promptReason: 'sign in to $1' }
+    })
+  } catch (error) {
+    return { status: 'failed', error: error instanceof Error ? error.message : String(error) }
+  }
+  return { status: 'enabled', keychainAccessGroup }
+}

--- a/src/main/startup/main-process-ready-foundation.ts
+++ b/src/main/startup/main-process-ready-foundation.ts
@@ -39,6 +39,7 @@ import {
 import { installDocPreviewProtocolHandler } from '../browser/doc-preview-protocol'
 import { registerDocPreviewGrantHandlers } from '../ipc/doc-preview-grant-ipc'
 import { initializeBrowserSessionsForApp } from '../browser/browser-session-startup'
+import { enablePlatformPasskeys } from '../browser/browser-platform-passkeys-macos'
 import { browserSessionRegistry } from '../browser/browser-session-registry'
 import { logStartupMilestone } from './startup-diagnostics'
 import { writeHttp1CompatibilityMarker } from './http1-compatibility-marker'
@@ -267,6 +268,13 @@ export async function initializeReadyFoundation(): Promise<void> {
   // Why: the preview session is protocol-scoped, so the handler must exist before any preview webview attaches.
   installDocPreviewProtocolHandler()
   registerDocPreviewGrantHandlers()
+  // Why here: configureWebAuthn is process-wide and must run after `ready`; before any guest can issue a passkey request.
+  const platformPasskeys = enablePlatformPasskeys(app)
+  if (platformPasskeys.status === 'failed') {
+    console.warn('[browser] Touch ID passkey authenticator unavailable:', platformPasskeys.error)
+  } else if (platformPasskeys.status === 'enabled') {
+    console.log('[browser] Touch ID passkey authenticator enabled')
+  }
   // Why: browser sessions serve desktop webviews and runtime profile commands, so init at app startup rather than via a renderer IPC path.
   initializeBrowserSessionsForApp({
     orcaProfileId: profile.profile.id,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​504 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​503 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​466 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​459 |

<!-- /orca-pr-loc -->

## Problem and scope

The proposed macOS Touch ID passkey entitlement could make Orca be killed before its own code runs. A valid profile at build time does not solve this: [Apple documents](https://developer.apple.com/help/account/certificates/create-developer-id-certificates) that **an installed app will no longer launch when its Developer ID provisioning profile expires**. This can also prevent updater recovery.

**Touch ID passkeys do not ship in any channel: release, hourly, daily, or adhoc.** This PR retains entitlement-aware runtime groundwork but removes the profile/entitlement shipping path. The original passkey sign-in problem remains unresolved; this does not close #15064.

## Safeguards

- Removed profile-secret materialization from all four macOS workflows and removed generated passkey entitlements and `mac.provisioningProfile` from packaging. Repository secrets cannot enable Touch ID.
- Before signing distributed builds, reject the retired `ORCA_MAC_PROVISIONING_PROFILE` opt-in and restricted passkey keys in the main/helper entitlement inputs. Local and unsigned packaging retains its existing entitlements and launcher behavior.
- An awaited `afterSign` gate inspects the actual signed bundle before distributable creation/upload. It rejects embedded profiles, verifies bundle and individual Mach-O signatures, and checks every architecture for the keychain group and both passkey identity entitlements. Static command failures fail closed.
- The gate launches the exact signed main executable with `ORCA_BACKGROUND_LAUNCH=1` and disposable home/app data, requires ten seconds of survival, then verifies termination of its own process tree. Early exit, SIGKILL, spawn failure, and a dead main process leaving child output pipes open all fail the gate. It never reveals or focuses a window.
- The signing reference documents Apple's expiry policy and the requirements for any future design. Profile/certificate matching is deliberately not an acceptance path: **all profiles are rejected**, including currently valid ones. There is no supported profile-signing mode needing conditional team/certificate/group/expiration approval.

## Evidence and validation

On macOS Apple silicon, using two copies of the same packaged Orca app:

| Case | Result |
| --- | --- |
| Restricted entitlement, missing profile | Launch gate failed with `SIGKILL` in about 3.1 seconds |
| Same app with authorizing Development profile | Survived ten seconds; launch gate passed and cleaned up |
| Static policy on both copies | Rejected restricted entitlement / embedded profile respectively |
| Existing unrestricted packaged app | Full signature/entitlement policy passed |

All launches used isolated data and background launch. Profile expiry is established by Apple documentation, not a system-clock experiment.

Passed:

- `pnpm tc:node`
- `pnpm run check:code-quality:changed`
- Vitest: mac channel config, passkey signing policy, signed-app verification, workflow/publication boundary, runtime passkey tests, and child-process import boundary

The tests cover all distributed channels, rejection of the retired opt-in, helper/other-architecture entitlements, profiles, invalid signatures, early process death, inherited pipes, and failed cleanup. Publication-boundary tests cover the workflows and installed packager ordering.

## Limits

No production Developer ID signing/notarization run was performed locally. Freshly signed CI artifacts must pass the new gate. The local working profile was a Development profile and is not shipping evidence. A ten-second launch test is an immediate-startup check, not a guarantee against unrelated future crashes; removing the restricted entitlement/profile dependency addresses this feature's launch-kill and expiry risk.

No merge requested or performed.
