### PR TITLE
fix: eliminate quadratic whitespace trimming during fullscreen scrolling

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11,6 +11,75 @@
   },
   "gates": [
     {
+      "id": "terminal-performance.padded-fullscreen-redraw",
+      "title": "Fullscreen redraw padding does not stall terminal delivery",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "runtime-unit-and-electron-cdp",
+      "surfaces": ["terminal transcript preview", "fullscreen TUI scrolling"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon"],
+      "coverageNotes": "The trim operation is platform-independent and preserves the same spaces/tabs policy for all providers. Real Pi 0.84.2 was exercised in a hidden macOS Electron renderer through CDP using a folder workspace.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/issues/14770"],
+      "invariant": "Transcript preview trimming preserves internal whitespace and terminal read contents without quadratic main-process work on padded fullscreen redraws.",
+      "oracle": "Preserve 32,000 spaces before a marker while trimming trailing spaces/tabs in both retained-row and carried-prefix redraw paths; four redraws must finish within 500 ms. Existing tail equivalence tests preserve cursor, retention, and pagination behavior.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/runtime/terminal-tail-whitespace.test.ts src/main/runtime/terminal-tail-buffer.test.ts src/main/runtime/retained-tail-redraw-window.equivalence.test.ts"
+      ],
+      "testFiles": [
+        "src/main/runtime/terminal-tail-whitespace.test.ts",
+        "src/main/runtime/terminal-tail-buffer.test.ts",
+        "src/main/runtime/retained-tail-redraw-window.equivalence.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/runtime/terminal-tail-whitespace.test.ts",
+          "assertions": [
+            "handles padded redraws across %i retained rows without stalling",
+            "preserves terminal text while trimming spaces and tabs: %j"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-06",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/runtime/terminal-tail-whitespace.test.ts src/main/runtime/terminal-tail-buffer.test.ts src/main/runtime/retained-tail-redraw-window.equivalence.test.ts",
+          "result": "passed",
+          "durationSeconds": 3.96,
+          "summary": "17 tests passed. Before the fix both padding budget cases failed, taking approximately 1.7 seconds each."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "Three unit test files; padding cases allow 500 ms for four redraws."
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Initial local red/green validation; no CI soak history yet."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "Both padding budget cases fail with regex trimming and pass with the existing linear trim. A 60-event CDP wheel stream in Pi fullscreen had about 2.1 seconds of output tail before the fix and 14 ms after rebuilding."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The main CPU profile attributed 3.1 seconds to redraw-row whitespace trimming. Reusing the linear trim adds no timers, caches, provider calls, or output dropping."
+      },
+      "knownGaps": [
+        "The user manually compared the fixed dev app with production and confirmed improved responsiveness. A live Terminal.app comparison was not exercised; timing measurements used CDP wheel events.",
+        "Linux, Windows, and live SSH rendering were not exercised; the shared trimming behavior is covered by unit tests."
+      ],
+      "promotionCriteria": [
+        "Complete CI soak requirements and retain the padding budget and tail equivalence oracles."
+      ],
+      "demotionRule": "Keep experimental until CI soak is stable; investigate any budget failure without weakening transcript preservation."
+    },
+    {
       "id": "ssh.localhost-terminal-agent-hooks",
       "title": "Localhost SSH terminal and agent hooks reach the owning pane",
       "maturity": "experimental",

--- a/src/main/runtime/terminal-tail-buffer.ts
+++ b/src/main/runtime/terminal-tail-buffer.ts
@@ -293,7 +293,7 @@ function appendNormalizedToMultilineTailBuffer(
       const line = rewritten[index]!
       const lastChar = line.charCodeAt(line.length - 1)
       if (lastChar === 32 || lastChar === 9) {
-        rewritten[index] = line.replace(/[ \t]+$/g, '')
+        rewritten[index] = trimTerminalLineRight(line)
       }
     }
     for (const line of windowed.lines) {

--- a/src/main/runtime/terminal-tail-redraw-buffer.ts
+++ b/src/main/runtime/terminal-tail-redraw-buffer.ts
@@ -185,7 +185,7 @@ function finalizeRetainedTerminalRows(
   newlyCompletedLines: string[]
 } {
   let truncated = initialTruncated
-  let retainedRows = rows.map((row) => ({ ...row, text: row.text.replace(/[ \t]+$/g, '') }))
+  let retainedRows = rows.map((row) => ({ ...row, text: trimTerminalLineRight(row.text) }))
 
   if (retainedRows.length > MAX_TAIL_LINES + 1) {
     const removeCount = retainedRows.length - (MAX_TAIL_LINES + 1)

--- a/src/main/runtime/terminal-tail-whitespace.test.ts
+++ b/src/main/runtime/terminal-tail-whitespace.test.ts
@@ -1,0 +1,32 @@
+import { performance } from 'node:perf_hooks'
+import { describe, expect, it } from 'vitest'
+import { appendNormalizedToTailBuffer } from './terminal-tail-buffer'
+import { trimTerminalLineRight } from './terminal-tail-line-controls'
+
+describe('terminal redraw whitespace', () => {
+  it.each([
+    ['hello \t', 'hello'],
+    [' \thello \t world \t', ' \thello \t world'],
+    [' \t', ''],
+    ['hello\u00a0 \t', 'hello\u00a0'],
+    ['hello\n', 'hello\n']
+  ])('preserves terminal text while trimming spaces and tabs: %j', (input, expected) => {
+    expect(trimTerminalLineRight(input)).toBe(expected)
+  })
+
+  it.each([2, 20])('handles padded redraws across %i retained rows without stalling', (rows) => {
+    const padded = `${' '.repeat(32_000)}marker \t`
+    const previousLines = Array.from({ length: rows }, (_, index) =>
+      index === 0 ? padded : `row ${index}`
+    )
+    const start = performance.now()
+    let result: ReturnType<typeof appendNormalizedToTailBuffer> | undefined
+    for (let frame = 0; frame < 4; frame += 1) {
+      result = appendNormalizedToTailBuffer(previousLines, 'footer', '\x1b[1A\rupdated')
+    }
+    const elapsedMs = performance.now() - start
+    expect(result?.lines[0]).toBe(`${' '.repeat(32_000)}marker`)
+    // Interior padding made the trailing-whitespace regex backtrack quadratically.
+    expect(elapsedMs).toBeLessThan(500)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |

<!-- /orca-pr-loc -->

## ELI5

Scrolling Pi in fullscreen could leave Orca catching up for seconds. This removes expensive whitespace cleanup that blocked terminal output, making scrolling more responsive.

## What Changed

Replace two trailing-whitespace regex calls with the existing linear `trimTerminalLineRight` implementation. Add regression coverage for retained-row and carried-prefix redraws plus the experimental `terminal-performance.padded-fullscreen-redraw` reliability gate.

## Why

Long internal runs of spaces caused quadratic regex backtracking. A main-process CPU profile attributed 3.087 seconds to redraw-row trimming during one wheel gesture. The existing trim preserves internal whitespace and removes only trailing spaces/tabs; terminal contents, retention, cursors, and pagination semantics stay intact.

## Linked Issue

Fixes #14770

## Visual Proof

Before and after captures of the Pi fullscreen reproduction (same dimensions). These show the rendered scenario; static screenshots cannot demonstrate latency. The baseline includes a historical failed model request from the saved session.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/2143dd23-2924-4099-a523-ab3e37f6c55c) | ![After](https://github.com/user-attachments/assets/134439df-e38e-4bdf-ad3c-ad58571fd73b) |

Pi 0.84.2, macOS, isolated folder workspace, saved ~1,200-line transcript, 60 requested CDP wheel events:

| Measurement | Before | After |
| --- | ---: | ---: |
| Wheel dispatch completion | 1,116 ms | 523 ms |
| Final output parsed after dispatch | 2,127 ms | 14 ms |

An alternating-direction stream finished output 5.5 ms after dispatch. CDP coalescing and existing wheel acceleration produce different report counts, so these measure output backlog, not fixed-report throughput. The user also compared the fixed dev app with production and confirmed improved responsiveness.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Regression and tail-equivalence suites: 17 passed. Both new padded-redraw budget cases failed before the fix (~1.7 seconds each) and pass afterward; four redraws with 32,000 internal spaces must complete within 500 ms while preserving content.
- Full runtime suite: 1,257 passed, 1 skipped.
- Node typecheck, changed-code quality checks, reliability manifest validation, and diff whitespace checks passed.
- Rendered validation and user comparison on macOS. Linux, Windows, live SSH rendering, and Terminal.app comparison were not exercised. Full lint/build and remaining platform checks are left to CI.

Run the focused regression checks:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm test src/main/runtime/terminal-tail-whitespace.test.ts src/main/runtime/terminal-tail-buffer.test.ts src/main/runtime/retained-tail-redraw-window.equivalence.test.ts
```

To compare manually, open the same long Pi transcript in fullscreen on this branch and production, hide the fullscreen scrollbar, and scroll repeatedly in both directions. Check that output catches up promptly and typing remains responsive.

## Review

The change reuses existing trimming logic and adds no timers, caches, output dropping, execution-host behavior, or wire changes.

## Agent skill upstream boundary

- [x] Not applicable; no agent skill code or content changed.

## Notes

Platform-independent string handling applies to all providers. Folder workspaces were exercised. No path, shortcut, mobile, security, or remote protocol changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
