### PR TITLE
Show native chat message timestamps on hover

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageRow.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageRow.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { MessageRow } from './NativeChatMessageRow'
+
+afterEach(cleanup)
+
+function renderMessage(role: NativeChatMessage['role'], timestamp: number | null = 0) {
+  return render(
+    <MessageRow
+      message={{
+        id: 'message',
+        role,
+        timestamp,
+        source: 'transcript',
+        blocks: [{ type: 'text', text: 'Message text' }]
+      }}
+      expandSignal={false}
+      onScrollMessageToTop={vi.fn()}
+    />
+  )
+}
+
+describe('MessageRow hover timestamps', () => {
+  it('appends time to the existing agent controls and inherits their reveal', () => {
+    renderMessage('assistant')
+    const copy = screen.getByRole('button', { name: 'Copy message' })
+    const scroll = screen.getByRole('button', { name: 'Scroll this message to top' })
+    const time = screen.getByRole('time')
+    expect(Array.from(copy.parentElement!.children)).toEqual([copy, scroll, time])
+    expect(copy.parentElement).toHaveClass(
+      'opacity-0',
+      'group-hover:opacity-100',
+      'group-focus-within:opacity-100'
+    )
+    expect(time).not.toHaveAttribute('tabindex')
+    copy.focus()
+    expect(copy).toHaveFocus()
+  })
+
+  it('gives user bubbles only a hover/focus timestamp', () => {
+    renderMessage('user')
+    const time = screen.getByRole('time')
+    expect(screen.queryByRole('button')).toBeNull()
+    expect(time).toHaveClass(
+      'opacity-0',
+      'group-hover:opacity-100',
+      'group-focus-within:opacity-100'
+    )
+    expect(time.parentElement).toHaveClass('group')
+    time.focus()
+    expect(time).toHaveFocus()
+  })
+
+  it.each(['assistant', 'user'] as const)('omits unknown timestamps on %s rows', (role) => {
+    renderMessage(role, null)
+    expect(screen.queryByRole('time')).toBeNull()
+    expect(screen.getByText('Message text')).toBeInTheDocument()
+    expect(screen.queryAllByRole('button')).toHaveLength(role === 'assistant' ? 2 : 0)
+  })
+
+  it.each(['reasoning', 'system'] as const)('preserves chrome-free %s rows', (role) => {
+    renderMessage(role)
+    expect(screen.queryByRole('time')).toBeNull()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageRow.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageRow.tsx
@@ -7,6 +7,7 @@ import { translate } from '@/i18n/i18n'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 import { splitNativeChatBlocks } from './native-chat-tool-fold'
 import { NativeChatToolRun } from './NativeChatToolRun'
+import { NativeChatMessageTimestamp } from './NativeChatMessageTimestamp'
 import { nativeChatProseToMarkdown } from './native-chat-prose'
 import {
   NativeChatAgentControls,
@@ -83,7 +84,7 @@ export const MessageRow = memo(function MessageRow({
 
   if (isUser) {
     return (
-      <div ref={rowRef} className="flex flex-col items-end gap-0.5">
+      <div ref={rowRef} className="group relative flex flex-col items-end gap-0.5">
         {/* User turns get a distinct muted fill (not the card/canvas color) so
             the prompt reads apart from the assistant's body copy. */}
         <div className="max-w-[85%] rounded-lg rounded-tr-sm bg-muted px-3.5 py-2.5 text-sm text-foreground">
@@ -110,6 +111,11 @@ export const MessageRow = memo(function MessageRow({
             />
           )}
         </div>
+        <NativeChatMessageTimestamp
+          timestamp={message.timestamp}
+          focusable
+          className="pointer-events-none select-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+        />
         {deliveryFailed ? (
           <div className="max-w-[85%] text-[11px] text-destructive/80">
             {translate(
@@ -163,6 +169,7 @@ export const MessageRow = memo(function MessageRow({
       {showControls ? (
         <NativeChatAgentControls
           markdown={markdown}
+          timestamp={message.timestamp}
           onScrollToTop={scrollToTop}
           className="pointer-events-none mt-1 -mb-5 w-fit select-none opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100"
         />

--- a/src/renderer/src/components/native-chat/NativeChatMessageTimestamp.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageTimestamp.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { i18n } from '@/i18n/i18n'
+import { NativeChatMessageTimestamp } from './NativeChatMessageTimestamp'
+
+afterEach(async () => {
+  cleanup()
+  await i18n.changeLanguage('en')
+})
+
+describe('NativeChatMessageTimestamp', () => {
+  it.each([null, Number.NaN, Infinity, -Infinity, 8.64e15 + 1])(
+    'omits missing or invalid time %s',
+    (timestamp) => {
+      const { container } = render(<NativeChatMessageTimestamp timestamp={timestamp} focusable />)
+      expect(container).toBeEmptyDOMElement()
+    }
+  )
+
+  it.each([0, Date.parse('2026-09-06T19:04:05Z')])(
+    'renders absolute time and full metadata for %s',
+    (timestamp) => {
+      render(<NativeChatMessageTimestamp timestamp={timestamp} />)
+      const time = screen.getByRole('time')
+      expect(time).toHaveAttribute('datetime', new Date(timestamp).toISOString())
+      expect(time).toHaveTextContent(
+        new Intl.DateTimeFormat('en', { hour: 'numeric', minute: '2-digit' }).format(timestamp)
+      )
+      expect(time).toHaveAccessibleName(
+        new Intl.DateTimeFormat('en', { dateStyle: 'full', timeStyle: 'long' }).format(timestamp)
+      )
+      expect(time).not.toHaveAttribute('tabindex')
+    }
+  )
+
+  it('provides a focus target only when requested for user metadata', () => {
+    render(<NativeChatMessageTimestamp timestamp={0} focusable />)
+    const time = screen.getByRole('time')
+    time.focus()
+    expect(time).toHaveFocus()
+    expect(time).toHaveAttribute('tabindex', '0')
+  })
+
+  it('updates settled time when the UI language changes without a parent rerender', async () => {
+    const timestamp = Date.parse('2026-09-06T19:04:05Z')
+    render(<NativeChatMessageTimestamp timestamp={timestamp} />)
+    await act(async () => {
+      await i18n.changeLanguage('fr')
+    })
+    const time = screen.getByRole('time')
+    expect(time).toHaveTextContent(
+      new Intl.DateTimeFormat('fr', { hour: 'numeric', minute: '2-digit' }).format(timestamp)
+    )
+    expect(time).toHaveAccessibleName(
+      new Intl.DateTimeFormat('fr', { dateStyle: 'full', timeStyle: 'long' }).format(timestamp)
+    )
+    expect(time).toHaveAttribute('datetime', new Date(timestamp).toISOString())
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatMessageTimestamp.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageTimestamp.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next'
+import { getIntlLocale } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+
+let cached: {
+  locale: string
+  time: Intl.DateTimeFormat
+  full: Intl.DateTimeFormat
+} | null = null
+
+function getTimestampFormatters(): NonNullable<typeof cached> {
+  const locale = getIntlLocale()
+  if (!cached || cached.locale !== locale) {
+    cached = {
+      locale,
+      time: new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' }),
+      full: new Intl.DateTimeFormat(locale, { dateStyle: 'full', timeStyle: 'long' })
+    }
+  }
+  return cached
+}
+
+export function NativeChatMessageTimestamp({
+  timestamp,
+  focusable = false,
+  className
+}: {
+  timestamp: number | null
+  focusable?: boolean
+  className?: string
+}): React.JSX.Element | null {
+  useTranslation()
+  if (timestamp === null) {
+    return null
+  }
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  const formatters = getTimestampFormatters()
+
+  return (
+    <time
+      dateTime={date.toISOString()}
+      aria-label={formatters.full.format(date)}
+      tabIndex={focusable ? 0 : undefined}
+      className={cn(
+        'rounded-md text-xs whitespace-nowrap text-muted-foreground tabular-nums focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        className
+      )}
+    >
+      {formatters.time.format(date)}
+    </time>
+  )
+}

--- a/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatTranscriptChrome.tsx
@@ -5,6 +5,7 @@ import { translate } from '@/i18n/i18n'
 import { basename } from '@/lib/path'
 import type { NativeChatBlock } from '../../../../shared/native-chat-types'
 import { NativeChatCopyButton } from './NativeChatCopyButton'
+import { NativeChatMessageTimestamp } from './NativeChatMessageTimestamp'
 import { nativeChatProviderFrameSummary } from '../../../../shared/native-chat-provider-frame-summary'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import {
@@ -244,10 +245,12 @@ export function NativeChatImageAttachments({
 
 export function NativeChatAgentControls({
   markdown,
+  timestamp,
   onScrollToTop,
   className
 }: {
   markdown: string
+  timestamp: number | null
   onScrollToTop: () => void
   className?: string
 }): React.JSX.Element {
@@ -266,6 +269,7 @@ export function NativeChatAgentControls({
       >
         <ArrowUp className="size-3.5" />
       </button>
+      <NativeChatMessageTimestamp timestamp={timestamp} />
     </div>
   )
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |

<!-- /orca-pr-loc -->

## What this does, in plain terms

The chat never told you *when* anything happened. Scrolling back, every message looked equally recent — you couldn't tell if the agent answered two minutes ago or two hours ago.

Now: **hover a message, see its time.** Move away, it's gone.

Hover-only is deliberate. A permanent timestamp on every row is noise on a surface you read all day; but when you do need it ("did this run before or after I changed that file?") you really need it.

### Before → After

| | Before | After |
| --- | --- | --- |
| "When did it say that?" | No answer anywhere | Hover the message |
| At rest | — | Identical to today — nothing added |
| Your own messages | No hover controls at all | Just the time |
| Keyboard users | — | Tab to a message, time appears on focus |

Screen readers get the full date and time, not the shortened clock string. No date library was added; times follow your system's regional format.

---

## Technical detail

## ELI5

Native chat shows each message's time when you hover over it or navigate to it with the keyboard.

## What Changed

Agent messages display the time after copy and scroll-to-top in the existing hover controls. User bubbles get only a timestamp, with a keyboard focus target. Unknown or invalid timestamps render nothing.

## Why

This makes message times available without adding persistent transcript clutter. Formatting uses Intl and the UI locale, with semantic ISO dateTime metadata and a full localized accessible label. No date dependency, timer, relative time, shared schema, or wire change.

## Linked Issue

Coordinator-dispatched native chat hover timestamp task; no issue number supplied.

## Visual Proof

Full hidden Electron renderer, seeded transcript, macOS. Before hover:

![Idle](https://github.com/user-attachments/assets/87e0e45f-059b-484f-8e0c-125a777e93f5)

After hovering the user bubble:

![User hover](https://github.com/user-attachments/assets/b640dd74-8d9b-4f7b-8348-a42b62100702)

After hovering the agent message:

![Agent hover](https://github.com/user-attachments/assets/2af9e22e-0cf6-4bc1-9642-39118e2a9927)

## Testing

- [x] 32 focused tests passed across timestamp, message-row, transcript-chrome, and message-list suites with ORCA_BACKGROUND_LAUNCH=1.
- [x] Oxlint, React Doctor lint, formatting, and git diff --check passed on the changed files.
- [x] Hidden Electron CDP: asserted both timestamps hidden at rest, user and agent hover reveal, user focus reveal, and Tab into agent controls; inspected full-app screenshots.
- Typechecking remains assigned to the coordinator. Windows, Linux, and SSH were not run locally; this change only reads existing renderer timestamp data and changes no execution or transport behavior.

## Review

Self-reviewed for null and invalid dates, epoch zero, live locale changes, semantic accessibility, and preserving existing control eligibility. Agent timestamps add no tab stop; user timestamps do.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small and focused; what changed and why explained.
- [x] Hover state screenshots attached.
- [x] Cross-platform, SSH, folder workspace, mobile, and wire impact considered.
- [ ] Central typecheck and CI complete.
