### PR TITLE
Fix push deployment source archive path

### DIFF
--- a/.github/workflows/cloud-push-deploy.yml
+++ b/.github/workflows/cloud-push-deploy.yml
@@ -70,7 +70,8 @@ jobs:
           git fetch --no-tags origin "${SOURCE_SHA}"
           test "$(git rev-parse FETCH_HEAD)" = "${SOURCE_SHA}"
           mkdir -p "${RUNNER_TEMP}/push-source"
-          git archive "${SOURCE_SHA}" cloud | tar -x -C "${RUNNER_TEMP}/push-source"
+          git -C "${GITHUB_WORKSPACE}" archive "${SOURCE_SHA}" cloud \
+            | tar -x -C "${RUNNER_TEMP}/push-source"
 
       - uses: google-github-actions/auth@v2
         with:


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

The push deploy job runs shell commands from cloud/. Its git archive path was therefore resolved as cloud/cloud and failed before authentication or any deployment. Anchor git archive to GITHUB_WORKSPACE so the reviewed source SHA exports cloud/ from the repository root.

Validation: executed the corrected archive from cloud/ and verified the extracted cloud/apps/push/Dockerfile; actionlint passes with the existing custom runner label accounted for. Production was unchanged by the failed run.
