### PR TITLE
feat(relay): time successful client accepts and control round trips

### DIFF
--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { RELAY_CLOSE_CODE } from '@orca-cloud/relay-contract'
+import { RELAY_CLOSE_CODE, RELAY_PROTOCOL_LIMITS } from '@orca-cloud/relay-contract'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type WebSocket from 'ws'
 import type { RelayAssignmentStore } from './assignment-store.js'
@@ -102,7 +102,9 @@ function harness(options: { random?: () => number; now?: () => number } = {}) {
   const store = {
     resolveResume: vi.fn().mockResolvedValue({ userId: identity.sub }),
     reserveCredential: vi.fn().mockResolvedValue(reservation),
-    failReservation: vi.fn().mockResolvedValue(undefined)
+    failReservation: vi.fn().mockResolvedValue(undefined),
+    recordConnectionBasis: vi.fn().mockResolvedValue(undefined),
+    deactivateBasis: vi.fn().mockResolvedValue(undefined)
   }
   const observer = {
     recordAuth: vi.fn(),
@@ -110,7 +112,9 @@ function harness(options: { random?: () => number; now?: () => number } = {}) {
     recordHttp: vi.fn(),
     recordReconnect: vi.fn(),
     recordSql: vi.fn(),
-    recordClientAcceptAbandoned: vi.fn()
+    recordClientAcceptAbandoned: vi.fn(),
+    recordClientAcceptCompleted: vi.fn(),
+    recordControlRtt: vi.fn()
   } satisfies RelayRuntimeObserver
   const registry = new HostSessionRegistry(
     config,
@@ -322,6 +326,164 @@ describe('client accept abandoned mid-DB-phase', () => {
     expect(client.close).not.toHaveBeenCalled()
     h.registry.drain(0)
     vi.advanceTimersByTime(0)
+  })
+})
+
+describe('successful client accept timing', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('times every serialized stage plus the attach window once relay-hello lands', async () => {
+    let now = 1_700_000_000_000
+    const h = harness({ now: () => now })
+    const control = await activeHost(h)
+    h.store.resolveResume.mockImplementationOnce(async () => {
+      now += 5
+      return { userId: identity.sub }
+    })
+    h.store.reserveCredential.mockImplementationOnce(async () => {
+      now += 7
+      return reservation
+    })
+    h.acquireActivity.mockImplementationOnce(async () => {
+      now += 11
+    })
+    h.store.recordConnectionBasis.mockImplementationOnce(async () => {
+      now += 3
+    })
+    const client = new FakeSocket()
+    const hostData = new FakeSocket()
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    try {
+      await h.registry.acceptClient(client as unknown as WebSocket, identity.relayHostId, 'cred')
+      const connOpen = JSON.parse(
+        String(control.send.mock.calls.find((call) => String(call[0]).includes('conn-open'))![0])
+      ) as { connId: string; connTicket: string }
+      // The desktop's data leg is the attach window this is meant to expose.
+      now += 23
+      const accepted = await h.registry.acceptHostData(
+        hostData as unknown as WebSocket,
+        connOpen.connId,
+        connOpen.connTicket,
+        1
+      )
+
+      expect(accepted).toBe(true)
+      expect(h.observer.recordClientAcceptCompleted).toHaveBeenCalledWith({
+        totalMs: 49,
+        stageMs: { assignment: 5, credential: 7, activity: 11, attach: 23 }
+      })
+      const line = log.mock.calls
+        .map((call) => String(call[0]))
+        .find((entry) => entry.includes('orca_relay_client_accept_completed'))
+      expect(line).toBeDefined()
+      const event = JSON.parse(line!) as {
+        credentialKind: string
+        stageMs: Record<string, number>
+        totalMs: number
+        relayHostIdDigest: string
+      }
+      expect(event.credentialKind).toBe('resume')
+      expect(Object.keys(event.stageMs).sort()).toEqual([
+        'activity',
+        'assignment',
+        'attach',
+        'credential'
+      ])
+      for (const stage of Object.values(event.stageMs)) expect(stage).toBeGreaterThanOrEqual(0)
+      const summed = Object.values(event.stageMs).reduce((total, stage) => total + stage, 0)
+      expect(event.totalMs).toBeGreaterThanOrEqual(summed)
+      expect(event.relayHostIdDigest).toMatch(/^[0-9a-f]{12}$/)
+      expect(line).not.toContain(identity.relayHostId)
+    } finally {
+      log.mockRestore()
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+})
+
+describe('control round-trip sampling', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('logs a host once at the fourth sample and not again within the hour', async () => {
+    let now = 1_700_000_000_000
+    const h = harness({ now: () => now })
+    const control = await activeHost(h)
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    const rttLines = (): string[] =>
+      log.mock.calls
+        .map((call) => String(call[0]))
+        .filter((entry) => entry.includes('orca_relay_host_control_rtt'))
+    // One heartbeat, then the desktop's echo of that ping's own `t` 40 ms later.
+    const roundTrip = async (): Promise<void> => {
+      now += RELAY_PROTOCOL_LIMITS.controlPingIntervalMs
+      await vi.advanceTimersByTimeAsync(RELAY_PROTOCOL_LIMITS.controlPingIntervalMs)
+      const ping = JSON.parse(
+        String(
+          control.send.mock.calls
+            .filter((call) => String(call[0]).includes('"type":"ping"'))
+            .at(-1)![0]
+        )
+      ) as { t: number }
+      now += 40
+      control.emit('message', JSON.stringify({ type: 'pong', t: ping.t }), false)
+    }
+    try {
+      for (let round = 0; round < 3; round++) await roundTrip()
+      expect(h.observer.recordControlRtt).toHaveBeenCalledTimes(3)
+      expect(rttLines()).toHaveLength(0)
+
+      await roundTrip()
+      expect(h.observer.recordControlRtt).toHaveBeenLastCalledWith(40)
+      expect(rttLines()).toHaveLength(1)
+      expect(JSON.parse(rttLines()[0]!)).toMatchObject({
+        event: 'orca_relay_host_control_rtt',
+        rttMsMedian: 40,
+        sampleCount: 4
+      })
+      expect(rttLines()[0]).not.toContain(identity.relayHostId)
+
+      // Later samples keep feeding the fleet metric, but stay silent for an hour.
+      for (let round = 0; round < 8; round++) await roundTrip()
+      expect(h.observer.recordControlRtt).toHaveBeenCalledTimes(12)
+      expect(rttLines()).toHaveLength(1)
+
+      const elapsedStart = now
+      while (now - elapsedStart < 60 * 60 * 1000) await roundTrip()
+      expect(rttLines()).toHaveLength(2)
+    } finally {
+      log.mockRestore()
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+
+  it('ignores a pong whose echoed timestamp is missing or implausible', async () => {
+    let now = 1_700_000_000_000
+    const h = harness({ now: () => now })
+    const control = await activeHost(h)
+    try {
+      control.emit('message', JSON.stringify({ type: 'pong' }), false)
+      control.emit('message', JSON.stringify({ type: 'pong', t: 'later' }), false)
+      control.emit('message', JSON.stringify({ type: 'pong', t: now + 5_000 }), false)
+      control.emit('message', JSON.stringify({ type: 'pong', t: now - 600_000 }), false)
+      expect(h.observer.recordControlRtt).not.toHaveBeenCalled()
+      // The silence watchdog still sees every one of them as proof of life.
+      now += 10
+      control.emit('message', JSON.stringify({ type: 'pong', t: now - 10 }), false)
+      expect(h.observer.recordControlRtt).toHaveBeenCalledWith(10)
+    } finally {
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
   })
 })
 

--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -374,28 +374,35 @@ describe('successful client accept timing', () => {
       expect(accepted).toBe(true)
       expect(h.observer.recordClientAcceptCompleted).toHaveBeenCalledWith({
         totalMs: 49,
-        stageMs: { assignment: 5, credential: 7, activity: 11, attach: 23 }
+        stageMs: { assignment: 5, credential: 7, activity: 11, attach: 23, basis: 3 }
       })
       const line = log.mock.calls
         .map((call) => String(call[0]))
         .find((entry) => entry.includes('orca_relay_client_accept_completed'))
       expect(line).toBeDefined()
       const event = JSON.parse(line!) as {
+        role: string
+        cellId: string
+        region: string
         credentialKind: string
         stageMs: Record<string, number>
         totalMs: number
         relayHostIdDigest: string
       }
       expect(event.credentialKind).toBe('resume')
+      // Joins the line back to the emitting process, like the runtime metrics event.
+      expect(event).toMatchObject({ role: 'cell', cellId: config.cellId, region: 'us-central1' })
       expect(Object.keys(event.stageMs).sort()).toEqual([
         'activity',
         'assignment',
         'attach',
+        'basis',
         'credential'
       ])
       for (const stage of Object.values(event.stageMs)) expect(stage).toBeGreaterThanOrEqual(0)
+      // The stages tile the accept end to end: every millisecond is attributed.
       const summed = Object.values(event.stageMs).reduce((total, stage) => total + stage, 0)
-      expect(event.totalMs).toBeGreaterThanOrEqual(summed)
+      expect(summed).toBe(event.totalMs)
       expect(event.relayHostIdDigest).toMatch(/^[0-9a-f]{12}$/)
       expect(line).not.toContain(identity.relayHostId)
     } finally {
@@ -446,6 +453,9 @@ describe('control round-trip sampling', () => {
       expect(rttLines()).toHaveLength(1)
       expect(JSON.parse(rttLines()[0]!)).toMatchObject({
         event: 'orca_relay_host_control_rtt',
+        role: 'cell',
+        cellId: config.cellId,
+        region: 'us-central1',
         rttMsMedian: 40,
         sampleCount: 4
       })

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -29,7 +29,12 @@ import {
 import { HostCloseReasonMemory } from './host-close-reason-memory.js'
 import { relayHostLogDigest } from './relay-host-log-digest.js'
 import type { RelayTokenClaims } from './relay-token-verifier.js'
-import type { RelayClientAcceptStage, RelayRuntimeObserver } from './relay-observability.js'
+import {
+  percentile,
+  type RelayClientAcceptStage,
+  type RelayClientAcceptTimedStage,
+  type RelayRuntimeObserver
+} from './relay-observability.js'
 import type { PendingHostDataReservation } from './relay-connection-ledger.js'
 import { closeRelayWebSocket } from './relay-websocket-close.js'
 import { ProcessQueuedByteBudget, wireSplice } from './splice-forwarder.js'
@@ -44,6 +49,14 @@ function printableCloseReason(reason: Buffer | string): string {
 
 type VerifyRelayToken = (token: string) => Promise<RelayTokenClaims | null>
 type HostState = 'proving' | 'active' | 'orphaned' | 'drain-only' | 'closed'
+
+// A host's distance to its cell moves on the scale of a rehome, not a heartbeat,
+// so a short window is enough to ride out one stalled ping.
+const CONTROL_RTT_WINDOW = 8
+const CONTROL_RTT_LOG_SAMPLE_THRESHOLD = 4
+const CONTROL_RTT_LOG_INTERVAL_MS = 60 * 60 * 1000
+// A pong claiming a multi-minute round trip is clock skew, not distance.
+const CONTROL_RTT_MAX_PLAUSIBLE_MS = 120_000
 
 const CONTROL_ACTIVITY_RENEWAL_INTERVAL_MS = RELAY_PROTOCOL_LIMITS.controlPingIntervalMs * 2
 // Preserve the existing 75s renewal runway after doubling the successful-call interval.
@@ -68,6 +81,8 @@ export type HostSession = {
   orphanTimer: ReturnType<typeof setTimeout> | null
   heartbeatTimer: ReturnType<typeof setInterval> | null
   lastPongAt: number
+  controlRttSamplesMs: number[]
+  controlRttLoggedAt: number | null
   activityRenewalDueAt: number
   activityRenewalAttempt: number
   activityRenewalCompletedAttempt: number
@@ -95,6 +110,15 @@ type PendingConnection = {
   attachTimer: ReturnType<typeof setTimeout>
   credentialActivityId: string | null
   capacityReservation?: PendingHostDataReservation
+  timing: ClientAcceptTiming
+}
+
+// Carries the phone-side accept clock across to the desktop's data leg, which
+// lands in a separate call and is the only place the accept is known to succeed.
+type ClientAcceptTiming = {
+  startedAt: number
+  connOpenAt: number
+  stageMs: Record<RelayClientAcceptStage, number>
 }
 
 function decodeCanonicalBase64(value: string, bytes: number): Uint8Array | null {
@@ -192,6 +216,17 @@ export class HostSessionRegistry {
       )
       return true
     }
+    const stageMs: Record<RelayClientAcceptStage, number> = {
+      assignment: 0,
+      credential: 0,
+      activity: 0
+    }
+    let stageCursor = acceptStartedAt
+    const markStage = (stage: RelayClientAcceptStage): void => {
+      const at = this.now()
+      stageMs[stage] = at - stageCursor
+      stageCursor = at
+    }
     if (this.config.role === 'cell') {
       // Each lookup is its own pooled round trip; stop between them once the phone
       // has left instead of running the rest of the chain for nobody.
@@ -212,6 +247,7 @@ export class HostSessionRegistry {
       }
       if (abandonedByClient('assignment')) return
     }
+    markStage('assignment')
     const reservation = await this.store.reserveCredential(hostId, credential)
     if (!reservation) {
       capacityReservation?.release()
@@ -221,6 +257,7 @@ export class HostSessionRegistry {
     }
     this.observer.recordAuth(true)
     if (abandonedByClient('credential', () => this.failReservationBestEffort(reservation))) return
+    markStage('credential')
     const sessionKey = this.key(reservation.userId, hostId)
     const session = this.sessions.get(sessionKey)
     if (
@@ -275,6 +312,7 @@ export class HostSessionRegistry {
     ) {
       return
     }
+    markStage('activity')
     const attachTimer = setTimeout(() => {
       session.pendingConns.delete(connId)
       capacityReservation?.release()
@@ -289,7 +327,8 @@ export class HostSessionRegistry {
       client: socket,
       attachTimer,
       credentialActivityId,
-      capacityReservation
+      capacityReservation,
+      timing: { startedAt: acceptStartedAt, connOpenAt: this.now(), stageMs }
     }
     capacityReservation?.bind(connId)
     session.pendingConns.set(connId, pending)
@@ -336,6 +375,7 @@ export class HostSessionRegistry {
       return false
     }
     this.observer.recordAuth(true)
+    const attachedAt = this.now()
     clearTimeout(pending.attachTimer)
     session.pendingConns.delete(connId)
     session.activeConnIds.add(connId)
@@ -424,7 +464,59 @@ export class HostSessionRegistry {
           }
         : {})
     })
+    this.recordClientAcceptCompleted(session, pending, attachedAt)
     return true
+  }
+
+  private recordClientAcceptCompleted(
+    session: HostSession,
+    pending: PendingConnection,
+    attachedAt: number
+  ): void {
+    const stageMs: Record<RelayClientAcceptTimedStage, number> = {
+      ...pending.timing.stageMs,
+      attach: attachedAt - pending.timing.connOpenAt
+    }
+    const totalMs = this.now() - pending.timing.startedAt
+    this.observer.recordClientAcceptCompleted?.({ totalMs, stageMs })
+    console.log(
+      JSON.stringify({
+        event: 'orca_relay_client_accept_completed',
+        credentialKind: pending.reservation.credentialKind,
+        stageMs,
+        totalMs,
+        relayHostIdDigest: relayHostLogDigest(session.relayHostId)
+      })
+    )
+  }
+
+  // Every desktop build already echoes the ping's `t`; anything else is dropped
+  // rather than trusted, so no new wire field is required.
+  private recordControlRtt(session: HostSession, echoedPingAt: unknown): void {
+    if (typeof echoedPingAt !== 'number' || !Number.isFinite(echoedPingAt)) return
+    const now = this.now()
+    const rttMs = now - echoedPingAt
+    if (rttMs < 0 || rttMs > CONTROL_RTT_MAX_PLAUSIBLE_MS) return
+    this.observer.recordControlRtt?.(rttMs)
+    const samples = session.controlRttSamplesMs
+    samples.push(rttMs)
+    if (samples.length > CONTROL_RTT_WINDOW) samples.shift()
+    if (samples.length < CONTROL_RTT_LOG_SAMPLE_THRESHOLD) return
+    if (
+      session.controlRttLoggedAt !== null &&
+      now - session.controlRttLoggedAt < CONTROL_RTT_LOG_INTERVAL_MS
+    ) {
+      return
+    }
+    session.controlRttLoggedAt = now
+    console.log(
+      JSON.stringify({
+        event: 'orca_relay_host_control_rtt',
+        relayHostIdDigest: relayHostLogDigest(session.relayHostId),
+        rttMsMedian: percentile(samples, 0.5),
+        sampleCount: samples.length
+      })
+    )
   }
 
   acceptControl(
@@ -843,6 +935,8 @@ export class HostSessionRegistry {
       orphanTimer: null,
       heartbeatTimer: null,
       lastPongAt: this.now(),
+      controlRttSamplesMs: [],
+      controlRttLoggedAt: null,
       activityRenewalDueAt: this.now() + RELAY_PROTOCOL_LIMITS.controlPingIntervalMs,
       activityRenewalAttempt: 0,
       activityRenewalCompletedAttempt: 0,
@@ -900,6 +994,7 @@ export class HostSessionRegistry {
         const parsed = JSON.parse(raw.toString()) as Record<string, unknown>
         if (parsed.type === 'pong') {
           session.lastPongAt = this.now()
+          this.recordControlRtt(session, parsed.t)
           return
         }
         if (parsed.type === 'auth-refresh') {

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
 import {
   ASSIGNMENT_LIMITS,
+  RELAY_DEFAULT_REGION,
   AuthRefreshSchema,
   buildHostChallengePlaintext,
   buildHostProofMacInput,
@@ -15,7 +16,8 @@ import {
   InviteCreateSchema,
   RELAY_PROTOCOL_LIMITS,
   RELAY_CLOSE_CODE,
-  type RelayHostCloseReason
+  type RelayHostCloseReason,
+  type RelayRegion
 } from '@orca-cloud/relay-contract'
 import nacl from 'tweetnacl'
 import type WebSocket from 'ws'
@@ -57,6 +59,12 @@ const CONTROL_RTT_LOG_SAMPLE_THRESHOLD = 4
 const CONTROL_RTT_LOG_INTERVAL_MS = 60 * 60 * 1000
 // A pong claiming a multi-minute round trip is clock skew, not distance.
 const CONTROL_RTT_MAX_PLAUSIBLE_MS = 120_000
+
+// Wall clock can step backwards mid-accept; a negative latency would poison the
+// percentiles it feeds.
+function nonNegativeMs(elapsedMs: number): number {
+  return Math.max(0, elapsedMs)
+}
 
 const CONTROL_ACTIVITY_RENEWAL_INTERVAL_MS = RELAY_PROTOCOL_LIMITS.controlPingIntervalMs * 2
 // Preserve the existing 75s renewal runway after doubling the successful-call interval.
@@ -328,7 +336,9 @@ export class HostSessionRegistry {
       attachTimer,
       credentialActivityId,
       capacityReservation,
-      timing: { startedAt: acceptStartedAt, connOpenAt: this.now(), stageMs }
+      // Attach starts where the activity stage ended, so the conn-open send is
+      // charged to it and no wall-clock gap goes unattributed.
+      timing: { startedAt: acceptStartedAt, connOpenAt: stageCursor, stageMs }
     }
     capacityReservation?.bind(connId)
     session.pendingConns.set(connId, pending)
@@ -449,6 +459,7 @@ export class HostSessionRegistry {
       close()
       return false
     }
+    const helloAt = this.now()
     send(pending.client, 'relay-hello', {
       ok: true,
       credentialKind: pending.reservation.credentialKind,
@@ -464,30 +475,48 @@ export class HostSessionRegistry {
           }
         : {})
     })
-    this.recordClientAcceptCompleted(session, pending, attachedAt)
+    this.recordClientAcceptCompleted(session, pending, attachedAt, helloAt)
     return true
   }
 
+  // The stages tile the whole accept, so their sum is the total minus only the
+  // clamping above: `basis` is the splice lease and connection-basis writes that
+  // land between the host data leg and relay-hello.
   private recordClientAcceptCompleted(
     session: HostSession,
     pending: PendingConnection,
-    attachedAt: number
+    attachedAt: number,
+    helloAt: number
   ): void {
     const stageMs: Record<RelayClientAcceptTimedStage, number> = {
-      ...pending.timing.stageMs,
-      attach: attachedAt - pending.timing.connOpenAt
+      assignment: nonNegativeMs(pending.timing.stageMs.assignment),
+      credential: nonNegativeMs(pending.timing.stageMs.credential),
+      activity: nonNegativeMs(pending.timing.stageMs.activity),
+      attach: nonNegativeMs(attachedAt - pending.timing.connOpenAt),
+      basis: nonNegativeMs(helloAt - attachedAt)
     }
-    const totalMs = this.now() - pending.timing.startedAt
+    const totalMs = nonNegativeMs(helloAt - pending.timing.startedAt)
     this.observer.recordClientAcceptCompleted?.({ totalMs, stageMs })
     console.log(
       JSON.stringify({
         event: 'orca_relay_client_accept_completed',
+        ...this.logIdentity(),
         credentialKind: pending.reservation.credentialKind,
         stageMs,
         totalMs,
         relayHostIdDigest: relayHostLogDigest(session.relayHostId)
       })
     )
+  }
+
+  // Matches the runtime metrics event so a log line and a metric point can be
+  // joined back to the process that emitted them.
+  private logIdentity(): { role: string; cellId: string; region: RelayRegion } {
+    return {
+      role: this.config.role,
+      cellId: this.config.cellId,
+      region: this.config.region ?? RELAY_DEFAULT_REGION
+    }
   }
 
   // Every desktop build already echoes the ping's `t`; anything else is dropped
@@ -512,6 +541,7 @@ export class HostSessionRegistry {
     console.log(
       JSON.stringify({
         event: 'orca_relay_host_control_rtt',
+        ...this.logIdentity(),
         relayHostIdDigest: relayHostLogDigest(session.relayHostId),
         rttMsMedian: percentile(samples, 0.5),
         sampleCount: samples.length

--- a/cloud/apps/relay/src/relay-observability.test.ts
+++ b/cloud/apps/relay/src/relay-observability.test.ts
@@ -22,6 +22,12 @@ const counts: RelayProcessCounts = {
   databasePoolWaitMsMax: 1_250
 }
 
+// An accept stage is named `credential`, so the leak guard has to see past the
+// bucket name to the values it exists to police.
+function scrubStageNames(entries: Array<Record<string, unknown>>): string {
+  return JSON.stringify(entries).replaceAll('"credential":', '"stage":')
+}
+
 describe('relay observability', () => {
   it('emits safe readiness dependency outcomes', () => {
     const entries: Array<Record<string, unknown>> = []
@@ -181,12 +187,7 @@ describe('relay observability', () => {
       controlActivityRecoveryFailuresDelta: 0,
       httpLatencyMsMax: 0
     })
-    expect(JSON.stringify(entries)).not.toMatch(/token|userId|relayHostId/)
-    // `credential` survives only as an accept-stage latency name; a leaked credential
-    // would be a string, so pinning the type is what the guard is actually for.
-    expect(entries[0]).toMatchObject({
-      clientAcceptStageMsP95: { credential: expect.any(Number) }
-    })
+    expect(scrubStageNames(entries)).not.toMatch(/token|credential|userId|relayHostId/)
   })
 
   it('aggregates control and splice closes as bounded per-reason deltas', () => {
@@ -228,11 +229,11 @@ describe('relay observability', () => {
     )
     observability.recordClientAcceptCompleted({
       totalMs: 812.4567,
-      stageMs: { assignment: 120, credential: 90, activity: 40, attach: 500 }
+      stageMs: { assignment: 120, credential: 90, activity: 40, attach: 500, basis: 62 }
     })
     observability.recordClientAcceptCompleted({
       totalMs: 6_400,
-      stageMs: { assignment: 4_100, credential: 95, activity: 60, attach: 2_000 }
+      stageMs: { assignment: 4_100, credential: 95, activity: 60, attach: 2_000, basis: 145 }
     })
     observability.recordControlRtt(28)
     observability.recordControlRtt(240)
@@ -245,12 +246,11 @@ describe('relay observability', () => {
       clientAcceptTotalMsP50: 812.457,
       clientAcceptTotalMsP95: 6_400,
       clientAcceptTotalMsMax: 6_400,
-      clientAcceptStageMsP95: {
-        assignment: 4_100,
-        credential: 95,
-        activity: 60,
-        attach: 2_000
-      },
+      clientAcceptAssignmentMsP95: 4_100,
+      clientAcceptCredentialMsP95: 95,
+      clientAcceptActivityMsP95: 60,
+      clientAcceptAttachMsP95: 2_000,
+      clientAcceptBasisMsP95: 145,
       controlRttSamplesDelta: 3,
       controlRttMsP50: 31,
       controlRttMsP95: 240,
@@ -263,18 +263,26 @@ describe('relay observability', () => {
       clientAcceptsAbandonedByStageDelta: {},
       clientAcceptAbandonedMsMax: 0
     })
-    expect(entries[1]).toMatchObject({
-      clientAcceptCompletedDelta: 0,
-      clientAcceptTotalMsP50: 0,
-      clientAcceptTotalMsP95: 0,
-      clientAcceptTotalMsMax: 0,
-      clientAcceptStageMsP95: { assignment: 0, credential: 0, activity: 0, attach: 0 },
-      controlRttSamplesDelta: 0,
-      controlRttMsP50: 0,
-      controlRttMsP95: 0,
-      controlRttMsMax: 0
-    })
-    expect(JSON.stringify(entries)).not.toMatch(/token|userId|relayHostId/)
+    // An empty window publishes counts only: a zero percentile point is
+    // indistinguishable from a real zero once Cloud Logging aggregates it.
+    expect(entries[1]).toMatchObject({ clientAcceptCompletedDelta: 0, controlRttSamplesDelta: 0 })
+    for (const omitted of [
+      'clientAcceptTotalMsP50',
+      'clientAcceptTotalMsP95',
+      'clientAcceptTotalMsMax',
+      'clientAcceptAssignmentMsP95',
+      'clientAcceptCredentialMsP95',
+      'clientAcceptActivityMsP95',
+      'clientAcceptAttachMsP95',
+      'clientAcceptBasisMsP95',
+      'controlRttMsP50',
+      'controlRttMsP95',
+      'controlRttMsMax'
+    ]) {
+      expect(entries[1]).not.toHaveProperty(omitted)
+      expect(entries[0]).toHaveProperty(omitted)
+    }
+    expect(scrubStageNames(entries)).not.toMatch(/token|credential|userId|relayHostId/)
   })
 
   it('observes successful and failed database calls including transactions', async () => {

--- a/cloud/apps/relay/src/relay-observability.test.ts
+++ b/cloud/apps/relay/src/relay-observability.test.ts
@@ -181,7 +181,12 @@ describe('relay observability', () => {
       controlActivityRecoveryFailuresDelta: 0,
       httpLatencyMsMax: 0
     })
-    expect(JSON.stringify(entries)).not.toMatch(/token|credential|userId|relayHostId/)
+    expect(JSON.stringify(entries)).not.toMatch(/token|userId|relayHostId/)
+    // `credential` survives only as an accept-stage latency name; a leaked credential
+    // would be a string, so pinning the type is what the guard is actually for.
+    expect(entries[0]).toMatchObject({
+      clientAcceptStageMsP95: { credential: expect.any(Number) }
+    })
   })
 
   it('aggregates control and splice closes as bounded per-reason deltas', () => {
@@ -213,6 +218,63 @@ describe('relay observability', () => {
       clientAcceptsAbandonedByStageDelta: {},
       clientAcceptAbandonedMsMax: 0
     })
+  })
+
+  it('summarises completed client accepts and control round trips per window', () => {
+    const entries: Array<Record<string, unknown>> = []
+    const observability = new RelayObservability(
+      { role: 'cell', cellId: 'production-gce-c28', region: 'asia-east2' },
+      (entry) => entries.push(entry)
+    )
+    observability.recordClientAcceptCompleted({
+      totalMs: 812.4567,
+      stageMs: { assignment: 120, credential: 90, activity: 40, attach: 500 }
+    })
+    observability.recordClientAcceptCompleted({
+      totalMs: 6_400,
+      stageMs: { assignment: 4_100, credential: 95, activity: 60, attach: 2_000 }
+    })
+    observability.recordControlRtt(28)
+    observability.recordControlRtt(240)
+    observability.recordControlRtt(31)
+    observability.flush(counts)
+    observability.flush(counts)
+
+    expect(entries[0]).toMatchObject({
+      clientAcceptCompletedDelta: 2,
+      clientAcceptTotalMsP50: 812.457,
+      clientAcceptTotalMsP95: 6_400,
+      clientAcceptTotalMsMax: 6_400,
+      clientAcceptStageMsP95: {
+        assignment: 4_100,
+        credential: 95,
+        activity: 60,
+        attach: 2_000
+      },
+      controlRttSamplesDelta: 3,
+      controlRttMsP50: 31,
+      controlRttMsP95: 240,
+      controlRttMsMax: 240
+    })
+    // Only-add: the pre-existing fields still read the same after the extension.
+    expect(entries[0]).toMatchObject({
+      event: 'orca_relay_runtime_metrics',
+      metricVersion: 2,
+      clientAcceptsAbandonedByStageDelta: {},
+      clientAcceptAbandonedMsMax: 0
+    })
+    expect(entries[1]).toMatchObject({
+      clientAcceptCompletedDelta: 0,
+      clientAcceptTotalMsP50: 0,
+      clientAcceptTotalMsP95: 0,
+      clientAcceptTotalMsMax: 0,
+      clientAcceptStageMsP95: { assignment: 0, credential: 0, activity: 0, attach: 0 },
+      controlRttSamplesDelta: 0,
+      controlRttMsP50: 0,
+      controlRttMsP95: 0,
+      controlRttMsMax: 0
+    })
+    expect(JSON.stringify(entries)).not.toMatch(/token|userId|relayHostId/)
   })
 
   it('observes successful and failed database calls including transactions', async () => {

--- a/cloud/apps/relay/src/relay-observability.ts
+++ b/cloud/apps/relay/src/relay-observability.ts
@@ -65,10 +65,28 @@ export interface RelayRuntimeObserver {
   recordControlClose?(code: number): void
   recordSpliceClose?(trigger: string): void
   recordClientAcceptAbandoned?(stage: RelayClientAcceptStage, elapsedMs: number): void
+  recordClientAcceptCompleted?(sample: RelayClientAcceptSample): void
+  recordControlRtt?(rttMs: number): void
 }
 
 // Which serialized accept step the phone had already hung up behind.
 export type RelayClientAcceptStage = 'assignment' | 'credential' | 'activity'
+
+// The attach window is only measurable once the host data leg lands, so it joins
+// the serialized pre-attach steps on completed accepts only.
+export type RelayClientAcceptTimedStage = RelayClientAcceptStage | 'attach'
+
+export const RELAY_CLIENT_ACCEPT_TIMED_STAGES = [
+  'assignment',
+  'credential',
+  'activity',
+  'attach'
+] as const satisfies readonly RelayClientAcceptTimedStage[]
+
+export type RelayClientAcceptSample = {
+  totalMs: number
+  stageMs: Record<RelayClientAcceptTimedStage, number>
+}
 
 type RelayMetricDeltas = {
   forwardedBytes: number
@@ -93,6 +111,9 @@ type RelayMetricDeltas = {
   spliceClosesByTrigger: Record<string, number>
   clientAcceptsAbandonedByStage: Record<string, number>
   clientAcceptAbandonedMsMax: number
+  clientAcceptTotalsMs: number[]
+  clientAcceptStageSamplesMs: Record<RelayClientAcceptTimedStage, number[]>
+  controlRttSamplesMs: number[]
   controlRenewalLatenciesMs: number[]
   controlRenewalsByOutcome: Record<string, number>
   controlActivityRecoveries: number
@@ -124,16 +145,31 @@ const emptyDeltas = (): RelayMetricDeltas => ({
   spliceClosesByTrigger: {},
   clientAcceptsAbandonedByStage: {},
   clientAcceptAbandonedMsMax: 0,
+  clientAcceptTotalsMs: [],
+  clientAcceptStageSamplesMs: { assignment: [], credential: [], activity: [], attach: [] },
+  controlRttSamplesMs: [],
   controlRenewalLatenciesMs: [],
   controlRenewalsByOutcome: {},
   controlActivityRecoveries: 0,
   controlActivityRecoveryFailures: 0
 })
 
-function percentile(values: number[], percentileRank: number): number {
+export function percentile(values: number[], percentileRank: number): number {
   if (values.length === 0) return 0
   const sorted = [...values].sort((left, right) => left - right)
   return sorted[Math.ceil(percentileRank * sorted.length) - 1] ?? 0
+}
+
+function roundMs(value: number): number {
+  return Number(value.toFixed(3))
+}
+
+function latencySummary(samples: number[]): { p50: number; p95: number; max: number } {
+  return {
+    p50: roundMs(percentile(samples, 0.5)),
+    p95: roundMs(percentile(samples, 0.95)),
+    max: roundMs(Math.max(0, ...samples))
+  }
 }
 
 export class RelayObservability implements RelayRuntimeObserver {
@@ -244,6 +280,17 @@ export class RelayObservability implements RelayRuntimeObserver {
     )
   }
 
+  recordClientAcceptCompleted(sample: RelayClientAcceptSample): void {
+    this.deltas.clientAcceptTotalsMs.push(sample.totalMs)
+    for (const stage of RELAY_CLIENT_ACCEPT_TIMED_STAGES) {
+      this.deltas.clientAcceptStageSamplesMs[stage].push(sample.stageMs[stage])
+    }
+  }
+
+  recordControlRtt(rttMs: number): void {
+    this.deltas.controlRttSamplesMs.push(rttMs)
+  }
+
   start(readCounts: () => RelayProcessCounts, intervalMs = 30_000): void {
     if (this.timer) return
     this.eventLoop.enable()
@@ -277,6 +324,9 @@ export class RelayObservability implements RelayRuntimeObserver {
       controlActivityRecoveryFailures: deltas.controlActivityRecoveryFailures
     }
     this.deltas = emptyDeltas()
+    const acceptTotals = latencySummary(deltas.clientAcceptTotalsMs)
+    const controlRtt = latencySummary(deltas.controlRttSamplesMs)
+    const controlRenewal = latencySummary(deltas.controlRenewalLatenciesMs)
     const memory = process.memoryUsage()
     const p99 = this.eventLoop.count === 0 ? 0 : this.eventLoop.percentile(99) / 1_000_000
     this.eventLoop.reset()
@@ -306,10 +356,24 @@ export class RelayObservability implements RelayRuntimeObserver {
       controlClosesByCodeDelta: deltas.controlClosesByCode,
       spliceClosesByTriggerDelta: deltas.spliceClosesByTrigger,
       clientAcceptsAbandonedByStageDelta: deltas.clientAcceptsAbandonedByStage,
-      clientAcceptAbandonedMsMax: Number(deltas.clientAcceptAbandonedMsMax.toFixed(3)),
+      clientAcceptAbandonedMsMax: roundMs(deltas.clientAcceptAbandonedMsMax),
+      clientAcceptCompletedDelta: deltas.clientAcceptTotalsMs.length,
+      clientAcceptTotalMsP50: acceptTotals.p50,
+      clientAcceptTotalMsP95: acceptTotals.p95,
+      clientAcceptTotalMsMax: acceptTotals.max,
+      clientAcceptStageMsP95: {
+        assignment: roundMs(percentile(deltas.clientAcceptStageSamplesMs.assignment, 0.95)),
+        credential: roundMs(percentile(deltas.clientAcceptStageSamplesMs.credential, 0.95)),
+        activity: roundMs(percentile(deltas.clientAcceptStageSamplesMs.activity, 0.95)),
+        attach: roundMs(percentile(deltas.clientAcceptStageSamplesMs.attach, 0.95))
+      },
+      controlRttSamplesDelta: deltas.controlRttSamplesMs.length,
+      controlRttMsP50: controlRtt.p50,
+      controlRttMsP95: controlRtt.p95,
+      controlRttMsMax: controlRtt.max,
       sqlQueriesDelta: deltas.sqlQueries,
       sqlFailuresDelta: deltas.sqlFailures,
-      sqlLatencyMsMax: Number(deltas.sqlLatencyMsMax.toFixed(3)),
+      sqlLatencyMsMax: roundMs(deltas.sqlLatencyMsMax),
       controlRenewalsByOutcomeDelta: deltas.controlRenewalsByOutcome,
       controlRenewalsDelta: deltas.controlRenewalLatenciesMs.length,
       controlRenewalSuccessesDelta: deltas.controlRenewalsByOutcome.renewed ?? 0,
@@ -317,16 +381,10 @@ export class RelayObservability implements RelayRuntimeObserver {
         deltas.controlRenewalsByOutcome.control_activity_not_found ?? 0,
       controlActivityRecoveriesDelta: deltas.controlActivityRecoveries,
       controlActivityRecoveryFailuresDelta: deltas.controlActivityRecoveryFailures,
-      controlRenewalLatencyMsP50: Number(
-        percentile(deltas.controlRenewalLatenciesMs, 0.5).toFixed(3)
-      ),
-      controlRenewalLatencyMsP95: Number(
-        percentile(deltas.controlRenewalLatenciesMs, 0.95).toFixed(3)
-      ),
-      controlRenewalLatencyMsMax: Number(
-        Math.max(0, ...deltas.controlRenewalLatenciesMs).toFixed(3)
-      ),
-      httpLatencyMsMax: Number(deltas.httpLatencyMsMax.toFixed(3)),
+      controlRenewalLatencyMsP50: controlRenewal.p50,
+      controlRenewalLatencyMsP95: controlRenewal.p95,
+      controlRenewalLatencyMsMax: controlRenewal.max,
+      httpLatencyMsMax: roundMs(deltas.httpLatencyMsMax),
       heapUsedBytes: memory.heapUsed,
       heapTotalBytes: memory.heapTotal,
       eventLoopDelayMsP99: Number(p99.toFixed(3))

--- a/cloud/apps/relay/src/relay-observability.ts
+++ b/cloud/apps/relay/src/relay-observability.ts
@@ -72,15 +72,17 @@ export interface RelayRuntimeObserver {
 // Which serialized accept step the phone had already hung up behind.
 export type RelayClientAcceptStage = 'assignment' | 'credential' | 'activity'
 
-// The attach window is only measurable once the host data leg lands, so it joins
-// the serialized pre-attach steps on completed accepts only.
-export type RelayClientAcceptTimedStage = RelayClientAcceptStage | 'attach'
+// The attach window and the basis writes that follow it are only measurable once
+// the host data leg lands, so they join the serialized pre-attach steps on
+// completed accepts only.
+export type RelayClientAcceptTimedStage = RelayClientAcceptStage | 'attach' | 'basis'
 
 export const RELAY_CLIENT_ACCEPT_TIMED_STAGES = [
   'assignment',
   'credential',
   'activity',
-  'attach'
+  'attach',
+  'basis'
 ] as const satisfies readonly RelayClientAcceptTimedStage[]
 
 export type RelayClientAcceptSample = {
@@ -146,7 +148,13 @@ const emptyDeltas = (): RelayMetricDeltas => ({
   clientAcceptsAbandonedByStage: {},
   clientAcceptAbandonedMsMax: 0,
   clientAcceptTotalsMs: [],
-  clientAcceptStageSamplesMs: { assignment: [], credential: [], activity: [], attach: [] },
+  clientAcceptStageSamplesMs: {
+    assignment: [],
+    credential: [],
+    activity: [],
+    attach: [],
+    basis: []
+  },
   controlRttSamplesMs: [],
   controlRenewalLatenciesMs: [],
   controlRenewalsByOutcome: {},
@@ -164,11 +172,13 @@ function roundMs(value: number): number {
   return Number(value.toFixed(3))
 }
 
+// Spreading a window into Math.max blows the stack once a busy cell samples
+// enough of it, so the maximum is folded instead.
 function latencySummary(samples: number[]): { p50: number; p95: number; max: number } {
   return {
     p50: roundMs(percentile(samples, 0.5)),
     p95: roundMs(percentile(samples, 0.95)),
-    max: roundMs(Math.max(0, ...samples))
+    max: roundMs(samples.reduce((highest, sample) => Math.max(highest, sample), 0))
   }
 }
 
@@ -325,6 +335,8 @@ export class RelayObservability implements RelayRuntimeObserver {
     }
     this.deltas = emptyDeltas()
     const acceptTotals = latencySummary(deltas.clientAcceptTotalsMs)
+    const acceptStageP95 = (stage: RelayClientAcceptTimedStage): number =>
+      roundMs(percentile(deltas.clientAcceptStageSamplesMs[stage], 0.95))
     const controlRtt = latencySummary(deltas.controlRttSamplesMs)
     const controlRenewal = latencySummary(deltas.controlRenewalLatenciesMs)
     const memory = process.memoryUsage()
@@ -358,19 +370,28 @@ export class RelayObservability implements RelayRuntimeObserver {
       clientAcceptsAbandonedByStageDelta: deltas.clientAcceptsAbandonedByStage,
       clientAcceptAbandonedMsMax: roundMs(deltas.clientAcceptAbandonedMsMax),
       clientAcceptCompletedDelta: deltas.clientAcceptTotalsMs.length,
-      clientAcceptTotalMsP50: acceptTotals.p50,
-      clientAcceptTotalMsP95: acceptTotals.p95,
-      clientAcceptTotalMsMax: acceptTotals.max,
-      clientAcceptStageMsP95: {
-        assignment: roundMs(percentile(deltas.clientAcceptStageSamplesMs.assignment, 0.95)),
-        credential: roundMs(percentile(deltas.clientAcceptStageSamplesMs.credential, 0.95)),
-        activity: roundMs(percentile(deltas.clientAcceptStageSamplesMs.activity, 0.95)),
-        attach: roundMs(percentile(deltas.clientAcceptStageSamplesMs.attach, 0.95))
-      },
+      // Accepts are sparse: publishing a zero percentile for every empty window
+      // would pin the p50 at 0 forever and collapse the p95 at low accept rates.
+      ...(deltas.clientAcceptTotalsMs.length === 0
+        ? {}
+        : {
+            clientAcceptTotalMsP50: acceptTotals.p50,
+            clientAcceptTotalMsP95: acceptTotals.p95,
+            clientAcceptTotalMsMax: acceptTotals.max,
+            clientAcceptAssignmentMsP95: acceptStageP95('assignment'),
+            clientAcceptCredentialMsP95: acceptStageP95('credential'),
+            clientAcceptActivityMsP95: acceptStageP95('activity'),
+            clientAcceptAttachMsP95: acceptStageP95('attach'),
+            clientAcceptBasisMsP95: acceptStageP95('basis')
+          }),
       controlRttSamplesDelta: deltas.controlRttSamplesMs.length,
-      controlRttMsP50: controlRtt.p50,
-      controlRttMsP95: controlRtt.p95,
-      controlRttMsMax: controlRtt.max,
+      ...(deltas.controlRttSamplesMs.length === 0
+        ? {}
+        : {
+            controlRttMsP50: controlRtt.p50,
+            controlRttMsP95: controlRtt.p95,
+            controlRttMsMax: controlRtt.max
+          }),
       sqlQueriesDelta: deltas.sqlQueries,
       sqlFailuresDelta: deltas.sqlFailures,
       sqlLatencyMsMax: roundMs(deltas.sqlLatencyMsMax),

--- a/cloud/infra/terraform/relay-observability.tf
+++ b/cloud/infra/terraform/relay-observability.tf
@@ -65,17 +65,19 @@ locals {
     control_renewal_lease_misses       = { field = "controlRenewalLeaseMissesDelta", description = "Control renewals that found their activity lease missing." }
     control_activity_recoveries        = { field = "controlActivityRecoveriesDelta", description = "Control activity leases recovered after a renewal miss." }
     control_activity_recovery_failures = { field = "controlActivityRecoveryFailuresDelta", description = "Control activity lease recovery attempts that failed." }
-    control_rtt_ms_p50                 = { field = "controlRttMsP50", description = "Control-socket ping round trip p50 in the interval; the fleet signal for hosts sitting on a distant cell." }
-    control_rtt_ms_p95                 = { field = "controlRttMsP95", description = "Control-socket ping round trip p95 in the interval." }
-    control_rtt_ms_max                 = { field = "controlRttMsMax", description = "Maximum control-socket ping round trip in the interval." }
-    client_accepts_completed           = { field = "clientAcceptCompletedDelta", description = "Phone accepts that reached relay-hello in the interval." }
+    control_rtt_ms_p50                 = { field = "controlRttMsP50", description = "Control-socket ping round trip p50 in the interval. The desktop echoes the pong on its main thread, so only the median reads as distance; the p95 and max below are dominated by desktop stalls." }
+    control_rtt_ms_p95                 = { field = "controlRttMsP95", description = "Control-socket ping round trip p95 in the interval; a desktop-stall signal, not a distance one." }
+    control_rtt_ms_max                 = { field = "controlRttMsMax", description = "Maximum control-socket ping round trip in the interval; a desktop-stall signal, not a distance one." }
+    control_rtt_samples                = { field = "controlRttSamplesDelta", description = "Control-socket round-trip samples in the interval; the percentiles above are omitted when this is zero." }
+    client_accepts_completed           = { field = "clientAcceptCompletedDelta", description = "Phone accepts that reached relay-hello in the interval; the percentiles below are omitted when this is zero." }
     client_accept_total_ms_p50         = { field = "clientAcceptTotalMsP50", description = "Successful phone-accept duration p50, dial to relay-hello." }
     client_accept_total_ms_p95         = { field = "clientAcceptTotalMsP95", description = "Successful phone-accept duration p95, dial to relay-hello." }
     client_accept_total_ms_max         = { field = "clientAcceptTotalMsMax", description = "Maximum successful phone-accept duration in the interval." }
-    client_accept_assignment_ms_p95    = { field = "clientAcceptStageMsP95.assignment", description = "Accept stage p95: resume/invite lookup plus assignment resolve." }
-    client_accept_credential_ms_p95    = { field = "clientAcceptStageMsP95.credential", description = "Accept stage p95: outer credential reservation." }
-    client_accept_activity_ms_p95      = { field = "clientAcceptStageMsP95.activity", description = "Accept stage p95: credential activity lease acquisition." }
-    client_accept_attach_ms_p95        = { field = "clientAcceptStageMsP95.attach", description = "Accept stage p95: conn-open sent until the desktop's data leg authenticated." }
+    client_accept_assignment_ms_p95    = { field = "clientAcceptAssignmentMsP95", description = "Accept stage p95: resume/invite lookup plus assignment resolve." }
+    client_accept_credential_ms_p95    = { field = "clientAcceptCredentialMsP95", description = "Accept stage p95: outer credential reservation." }
+    client_accept_activity_ms_p95      = { field = "clientAcceptActivityMsP95", description = "Accept stage p95: credential activity lease acquisition." }
+    client_accept_attach_ms_p95        = { field = "clientAcceptAttachMsP95", description = "Accept stage p95: conn-open sent until the desktop's data leg authenticated." }
+    client_accept_basis_ms_p95         = { field = "clientAcceptBasisMsP95", description = "Accept stage p95: splice lease and connection-basis writes between the data leg and relay-hello." }
     heap_used_bytes                    = { field = "heapUsedBytes", description = "Node.js heap bytes used by the relay process." }
     event_loop_ms_p99                  = { field = "eventLoopDelayMsP99", description = "Node.js event-loop delay p99 in milliseconds." }
     forwarded_bytes                    = { field = "forwardedBytesDelta", description = "Ciphertext bytes admitted for forwarding." }
@@ -222,14 +224,14 @@ resource "google_logging_metric" "relay_snapshot" {
   label_extractors = {
     role    = "EXTRACT(jsonPayload.role)"
     cell_id = "EXTRACT(jsonPayload.cellId)"
-    # No region label: adding one replaces all 21 live metrics (label change = delete+create),
+    # No region label: adding one replaces all 42 live metrics (label change = delete+create),
     # which resets history and blanks the relay alert policies during the swap.
   }
 
   metric_descriptor {
     metric_kind = "DELTA"
     value_type  = "DISTRIBUTION"
-    unit        = contains(["sql_latency_ms", "control_rtt_ms_p50", "control_rtt_ms_p95", "control_rtt_ms_max", "client_accept_total_ms_p50", "client_accept_total_ms_p95", "client_accept_total_ms_max", "client_accept_assignment_ms_p95", "client_accept_credential_ms_p95", "client_accept_activity_ms_p95", "client_accept_attach_ms_p95", "control_renewal_latency_ms_p50", "control_renewal_latency_ms_p95", "control_renewal_latency_ms_max", "http_latency_ms", "event_loop_ms_p99", "db_oldest_wait_ms", "db_wait_ms_max"], each.key) ? "ms" : each.key == "queued_bytes" || each.key == "heap_used_bytes" || each.key == "forwarded_bytes" ? "By" : "1"
+    unit        = contains(["sql_latency_ms", "control_rtt_ms_p50", "control_rtt_ms_p95", "control_rtt_ms_max", "client_accept_total_ms_p50", "client_accept_total_ms_p95", "client_accept_total_ms_max", "client_accept_assignment_ms_p95", "client_accept_credential_ms_p95", "client_accept_activity_ms_p95", "client_accept_attach_ms_p95", "client_accept_basis_ms_p95", "control_renewal_latency_ms_p50", "control_renewal_latency_ms_p95", "control_renewal_latency_ms_max", "http_latency_ms", "event_loop_ms_p99", "db_oldest_wait_ms", "db_wait_ms_max"], each.key) ? "ms" : each.key == "queued_bytes" || each.key == "heap_used_bytes" || each.key == "forwarded_bytes" ? "By" : "1"
 
     labels {
       key         = "role"

--- a/cloud/infra/terraform/relay-observability.tf
+++ b/cloud/infra/terraform/relay-observability.tf
@@ -65,6 +65,17 @@ locals {
     control_renewal_lease_misses       = { field = "controlRenewalLeaseMissesDelta", description = "Control renewals that found their activity lease missing." }
     control_activity_recoveries        = { field = "controlActivityRecoveriesDelta", description = "Control activity leases recovered after a renewal miss." }
     control_activity_recovery_failures = { field = "controlActivityRecoveryFailuresDelta", description = "Control activity lease recovery attempts that failed." }
+    control_rtt_ms_p50                 = { field = "controlRttMsP50", description = "Control-socket ping round trip p50 in the interval; the fleet signal for hosts sitting on a distant cell." }
+    control_rtt_ms_p95                 = { field = "controlRttMsP95", description = "Control-socket ping round trip p95 in the interval." }
+    control_rtt_ms_max                 = { field = "controlRttMsMax", description = "Maximum control-socket ping round trip in the interval." }
+    client_accepts_completed           = { field = "clientAcceptCompletedDelta", description = "Phone accepts that reached relay-hello in the interval." }
+    client_accept_total_ms_p50         = { field = "clientAcceptTotalMsP50", description = "Successful phone-accept duration p50, dial to relay-hello." }
+    client_accept_total_ms_p95         = { field = "clientAcceptTotalMsP95", description = "Successful phone-accept duration p95, dial to relay-hello." }
+    client_accept_total_ms_max         = { field = "clientAcceptTotalMsMax", description = "Maximum successful phone-accept duration in the interval." }
+    client_accept_assignment_ms_p95    = { field = "clientAcceptStageMsP95.assignment", description = "Accept stage p95: resume/invite lookup plus assignment resolve." }
+    client_accept_credential_ms_p95    = { field = "clientAcceptStageMsP95.credential", description = "Accept stage p95: outer credential reservation." }
+    client_accept_activity_ms_p95      = { field = "clientAcceptStageMsP95.activity", description = "Accept stage p95: credential activity lease acquisition." }
+    client_accept_attach_ms_p95        = { field = "clientAcceptStageMsP95.attach", description = "Accept stage p95: conn-open sent until the desktop's data leg authenticated." }
     heap_used_bytes                    = { field = "heapUsedBytes", description = "Node.js heap bytes used by the relay process." }
     event_loop_ms_p99                  = { field = "eventLoopDelayMsP99", description = "Node.js event-loop delay p99 in milliseconds." }
     forwarded_bytes                    = { field = "forwardedBytesDelta", description = "Ciphertext bytes admitted for forwarding." }
@@ -218,7 +229,7 @@ resource "google_logging_metric" "relay_snapshot" {
   metric_descriptor {
     metric_kind = "DELTA"
     value_type  = "DISTRIBUTION"
-    unit        = contains(["sql_latency_ms", "control_renewal_latency_ms_p50", "control_renewal_latency_ms_p95", "control_renewal_latency_ms_max", "http_latency_ms", "event_loop_ms_p99", "db_oldest_wait_ms", "db_wait_ms_max"], each.key) ? "ms" : each.key == "queued_bytes" || each.key == "heap_used_bytes" || each.key == "forwarded_bytes" ? "By" : "1"
+    unit        = contains(["sql_latency_ms", "control_rtt_ms_p50", "control_rtt_ms_p95", "control_rtt_ms_max", "client_accept_total_ms_p50", "client_accept_total_ms_p95", "client_accept_total_ms_max", "client_accept_assignment_ms_p95", "client_accept_credential_ms_p95", "client_accept_activity_ms_p95", "client_accept_attach_ms_p95", "control_renewal_latency_ms_p50", "control_renewal_latency_ms_p95", "control_renewal_latency_ms_max", "http_latency_ms", "event_loop_ms_p99", "db_oldest_wait_ms", "db_wait_ms_max"], each.key) ? "ms" : each.key == "queued_bytes" || each.key == "heap_used_bytes" || each.key == "forwarded_bytes" ? "By" : "1"
 
     labels {
       key         = "role"


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​246 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​235 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​217 |

<!-- /orca-pr-loc -->

## Why

A phone connect through a cell in a region far from the relay database takes ~10 s instead of ~0.6 s, and nothing in the relay metrics showed it: only the abandoned accept path was timed, and control-socket ping RTT was never recorded. This adds the two signals that make a mis-homed host visible without a manual log query.

## What

- `orca_relay_client_accept_completed`: one log line per successful accept with `stageMs.{assignment,credential,activity,attach,basis}` (the stages tile the accept exactly, `sum == totalMs` asserted), `totalMs`, `credentialKind`, host digest, `role`/`cellId`/`region`.
- `orca_relay_host_control_rtt`: rolling median of the last 8 control-socket pong RTTs per host session, logged at the 4th sample then at most hourly; survives control rebind.
- `orca_relay_runtime_metrics` (metricVersion unchanged): `clientAcceptCompletedDelta`, `controlRttSamplesDelta` always; `clientAcceptTotalMsP50/P95/Max`, per-stage `clientAccept<Stage>MsP95`, `controlRttMsP50/P95/Max` only when the window has samples, so sparse windows do not publish zeros into the distributions.
- Terraform: 13 additive log-based metrics in `relay-observability.tf` (flat extractors). Not applied.
- `latencySummary()` replaces three inlined percentile calls; control-renewal output is byte-identical.

## Notes

- Wire: no change. The desktop has echoed `{type:'pong', t}` since the original transport; the cell reads only `t`, ignores missing/negative, drops >120 s.
- Control RTT p95/max include desktop main-thread scheduling; only the per-host median and fleet p50 read as distance (Terraform descriptions say so).
- Post-`conn-open` accept failures (phone close, attach deadline) are still not timed; follow-up.

## Verification

- `cloud/apps/relay`: `pnpm typecheck`, `pnpm test` (54 files, 513 tests) after rebase on main.
- `cloud`: `pnpm lint`; `terraform fmt -check`; terraform script node tests (45).
- Independent adversarial review, two rounds; round 2 approved.

Not for merge until the owner gives the go.