### PR TITLE
fix(relay): attach a phone whose accept straddles a control rebind (desktop side)

### DIFF
--- a/src/main/runtime/relay/relay-control-client.test.ts
+++ b/src/main/runtime/relay/relay-control-client.test.ts
@@ -185,17 +185,21 @@ describe('RelayControlClient', () => {
       .update(hostKeys.publicKey)
       .digest('base64url')
       .slice(0, 16)
-    const accepted = new Promise<{ socket: WebSocket; authorization: string; path: string }>(
-      (resolve) => {
-        server.once('connection', (socket, request) =>
-          resolve({
-            socket,
-            authorization: String(request.headers.authorization),
-            path: request.url ?? ''
-          })
-        )
-      }
-    )
+    const accepted = new Promise<{
+      socket: WebSocket
+      authorization: string
+      capabilities: string
+      path: string
+    }>((resolve) => {
+      server.once('connection', (socket, request) =>
+        resolve({
+          socket,
+          authorization: String(request.headers.authorization),
+          capabilities: String(request.headers['x-orca-host-capabilities']),
+          path: request.url ?? ''
+        })
+      )
+    })
     const onConnectionOpen = vi.fn()
     const onDrain = vi.fn()
     const onClose = vi.fn()
@@ -213,8 +217,11 @@ describe('RelayControlClient', () => {
     })
     clients.push(client)
     const connecting = client.connect()
-    const { socket, authorization, path } = await accepted
+    const { socket, authorization, capabilities, path } = await accepted
     expect(authorization).toBe('Bearer scoped-token')
+    // Advertised on the upgrade, never in host-hello: a cell that predates the
+    // capability parses host-hello strictly and would refuse the handshake.
+    expect(capabilities).toBe('pending-conn-details')
     expect(path).toBe('/v1/host/control')
     const hello = await nextJson(socket)
     expect(hello).toMatchObject({
@@ -411,6 +418,7 @@ class FakeControlSocket extends EventEmitter {
 function scriptedControl(options: { closeWithAck?: boolean; issuedAtOffsetMs?: number } = {}): {
   client: RelayControlClient
   socket: FakeControlSocket
+  onConnectionOpen: ReturnType<typeof vi.fn>
   onClose: ReturnType<typeof vi.fn>
 } {
   const hostKeys = nacl.box.keyPair()
@@ -478,6 +486,7 @@ function scriptedControl(options: { closeWithAck?: boolean; issuedAtOffsetMs?: n
     }
   }
   const onClose = vi.fn()
+  const onConnectionOpen = vi.fn()
   const client = new RelayControlClient({
     cellUrl: origin,
     relayJwt: 'scoped-token',
@@ -486,13 +495,13 @@ function scriptedControl(options: { closeWithAck?: boolean; issuedAtOffsetMs?: n
     identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
     keypair,
     appVersion: '1.2.3',
-    onConnectionOpen: vi.fn(),
+    onConnectionOpen,
     onDrain: vi.fn(),
     onClose,
     createSocket: () => socket as unknown as WebSocket
   })
   queueMicrotask(() => socket.emit('open'))
-  return { client, socket, onClose }
+  return { client, socket, onConnectionOpen, onClose }
 }
 
 describe('RelayControlClient scripted-socket lifecycle', () => {
@@ -583,6 +592,29 @@ describe('RelayControlClient scripted-socket lifecycle', () => {
     expect(socket.readyState).toBe(1)
     expect(onClose).not.toHaveBeenCalled()
     warn.mockRestore()
+  })
+
+  it('still opens a connection the relay handed over before it asked us to drain', async () => {
+    const { client, socket, onConnectionOpen } = scriptedControl()
+    await client.connect()
+    socket.deliver({ type: 'drain', graceMs: 5_000, recovery: 'resolve-director' })
+
+    // A drain-only cell refuses new phones, so this conn-open was issued before
+    // the drain and only this cell holds the phone waiting on it.
+    socket.deliver({
+      type: 'conn-open',
+      connId: 'conn-1',
+      connTicket: 'T'.repeat(43),
+      kind: 'resume',
+      relayDeviceId: 'device-1',
+      attachDeadlineMs: 10_000
+    })
+
+    expect(onConnectionOpen).toHaveBeenCalledOnce()
+    expect(onConnectionOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ connId: 'conn-1', connTicket: 'T'.repeat(43) })
+    )
+    expect(client.isLive()).toBe(true)
   })
 
   it('still tears down a malformed (non-JSON) control frame', async () => {

--- a/src/main/runtime/relay/relay-control-client.ts
+++ b/src/main/runtime/relay/relay-control-client.ts
@@ -9,6 +9,7 @@ import {
   RelayHostChallengeMessageSchema,
   RelayHostHelloAckMessageSchema,
   RelayPingMessageSchema,
+  RELAY_HOST_CAPABILITY_HEADERS,
   encodeRelayHostHello,
   parseRelayControlMessage,
   type RelayConnectionOpenMessage,
@@ -74,7 +75,7 @@ export class RelayControlClient {
       options.createSocket ??
       ((url, token) =>
         new WebSocket(url, {
-          headers: { authorization: `Bearer ${token}` },
+          headers: { authorization: `Bearer ${token}`, ...RELAY_HOST_CAPABILITY_HEADERS },
           perMessageDeflate: false,
           maxPayload: 64 * 1024
         }))
@@ -215,7 +216,10 @@ export class RelayControlClient {
       return
     }
     const connection = RelayConnectionOpenMessageSchema.safeParse(message)
-    if (connection.success && this.state === 'active') {
+    if (connection.success) {
+      // Also while draining: a drain-only cell refuses new phones, so a conn-open
+      // arriving after drain was issued before it and only this cell holds that
+      // pending connection. Dropping it stranded the phone until its attach deadline.
       this.options.onConnectionOpen(connection.data)
       return
     }

--- a/src/main/runtime/relay/relay-control-origin.test.ts
+++ b/src/main/runtime/relay/relay-control-origin.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
-import type { RelayConnectionOpenMessage, RelayHostHelloAckMessage } from './relay-control-protocol'
+import {
+  RELAY_HOST_ATTACH_DEADLINE_MS,
+  type RelayConnectionOpenMessage,
+  type RelayHostHelloAckMessage
+} from './relay-control-protocol'
 import type { RelayAssignment } from './relay-http-client'
 
 const fakes = vi.hoisted(() => ({
@@ -116,6 +120,13 @@ describe('RelayControlOrigin pending-connection replay', () => {
     fakes.controls.length = 0
     fakes.transports.length = 0
     fakes.controlConnect.mockReset()
+  })
+
+  it('pins the attach deadline this file mirrors from the relay contract', () => {
+    // Hand-mirrored from RELAY_PROTOCOL_LIMITS.hostAttachDeadlineMs, which the
+    // contract suite pins to the same literal. Drift would silently shorten the
+    // observed-open eviction window and the deadline a replayed dial states.
+    expect(RELAY_HOST_ATTACH_DEADLINE_MS).toBe(10_000)
   })
 
   it('dials a pending connection the ack restates in full, without waiting on a timer', async () => {

--- a/src/main/runtime/relay/relay-control-origin.test.ts
+++ b/src/main/runtime/relay/relay-control-origin.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import nacl from 'tweetnacl'
+import type { RelayConnectionOpenMessage, RelayHostHelloAckMessage } from './relay-control-protocol'
+import type { RelayAssignment } from './relay-http-client'
+
+const fakes = vi.hoisted(() => ({
+  controls: [] as {
+    options: {
+      previousGeneration?: number
+      controlResumeSecret?: string
+      onConnectionOpen(message: RelayConnectionOpenMessage): void
+      onDrain(message: { type: 'drain'; graceMs: number; recovery: 'resolve-director' }): void
+      onClose(code: number): void
+    }
+  }[],
+  transports: [] as {
+    openConnections: Set<string>
+    openConnection: ReturnType<typeof vi.fn>
+    hasConnection: ReturnType<typeof vi.fn>
+  }[],
+  controlConnect: vi.fn()
+}))
+
+vi.mock('./relay-control-client', () => ({
+  RelayControlClient: class {
+    connect = fakes.controlConnect
+    closeNow = vi.fn()
+    isLive = vi.fn(() => true)
+    pendingRequestCount = 0
+
+    constructor(readonly options: (typeof fakes.controls)[number]['options']) {
+      fakes.controls.push(this)
+    }
+  }
+}))
+
+vi.mock('../rpc/relay-transport', () => ({
+  CloudRelayTransport: class {
+    readonly openConnections = new Set<string>()
+    start = vi.fn().mockResolvedValue(undefined)
+    stop = vi.fn().mockResolvedValue(undefined)
+    setGeneration = vi.fn()
+    metadataFor = vi.fn()
+    hasConnection = vi.fn((connectionId: string) => this.openConnections.has(connectionId))
+    openConnection = vi.fn(async (connection: RelayConnectionOpenMessage) => {
+      this.openConnections.add(connection.connId)
+    })
+
+    constructor() {
+      fakes.transports.push(this)
+    }
+  }
+}))
+
+import { RelayControlOrigin } from './relay-control-origin'
+
+const ASSIGNMENT: RelayAssignment = {
+  v: 1,
+  cellUrl: 'https://relay.example.test',
+  assignmentEpoch: 1,
+  lease: 'lease-token'
+}
+const TICKET = 'T'.repeat(43)
+
+function ack(overrides: Partial<RelayHostHelloAckMessage> = {}): RelayHostHelloAckMessage {
+  return {
+    type: 'host-hello-ack',
+    v: 1,
+    generation: 7,
+    controlResumeSecret: 'R'.repeat(43),
+    leaseExpiresAt: 1_000_000,
+    activeConnIds: [],
+    pendingConns: [],
+    ...overrides
+  }
+}
+
+function connOpen(overrides: Partial<RelayConnectionOpenMessage> = {}): RelayConnectionOpenMessage {
+  return {
+    type: 'conn-open',
+    connId: 'conn-1',
+    connTicket: TICKET,
+    kind: 'resume',
+    relayDeviceId: 'device-1',
+    attachDeadlineMs: 10_000,
+    ...overrides
+  }
+}
+
+function createOrigin(): {
+  origin: RelayControlOrigin
+  owned: string[]
+  released: string[]
+} {
+  const keypair = nacl.box.keyPair()
+  const owned: string[] = []
+  const released: string[] = []
+  const origin = new RelayControlOrigin({
+    assignment: ASSIGNMENT,
+    relayJwt: 'relay-jwt',
+    relayHostId: 'host-1',
+    identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
+    keypair: { ...keypair, publicKeyB64: Buffer.from(keypair.publicKey).toString('base64') },
+    appVersion: '1.0.0',
+    mobileSocketWiring: { attachTransport: vi.fn(() => () => {}) } as never,
+    onConnectionOwned: (connectionId) => owned.push(connectionId),
+    onConnectionReleased: (connectionId) => released.push(connectionId),
+    onDrain: vi.fn(),
+    onClose: vi.fn()
+  })
+  return { origin, owned, released }
+}
+
+describe('RelayControlOrigin pending-connection replay', () => {
+  beforeEach(() => {
+    fakes.controls.length = 0
+    fakes.transports.length = 0
+    fakes.controlConnect.mockReset()
+  })
+
+  it('dials a pending connection the ack restates in full, without waiting on a timer', async () => {
+    fakes.controlConnect.mockResolvedValue(
+      ack({
+        pendingConns: [
+          { connId: 'conn-1', connTicket: TICKET, kind: 'invite', relayDeviceId: 'device-1' }
+        ]
+      })
+    )
+    const { origin, owned } = createOrigin()
+
+    await origin.open()
+
+    expect(fakes.transports[0]!.openConnection).toHaveBeenCalledOnce()
+    expect(fakes.transports[0]!.openConnection).toHaveBeenCalledWith({
+      type: 'conn-open',
+      connId: 'conn-1',
+      connTicket: TICKET,
+      kind: 'invite',
+      relayDeviceId: 'device-1',
+      attachDeadlineMs: 10_000
+    })
+    expect(owned).toEqual(['conn-1'])
+  })
+
+  it('replays a pending connection the relay only identified, reusing the observed conn-open', async () => {
+    fakes.controlConnect
+      .mockResolvedValueOnce(ack())
+      .mockResolvedValueOnce(ack({ pendingConns: [{ connId: 'conn-1', connTicket: TICKET }] }))
+    const { origin } = createOrigin()
+    await origin.open()
+    fakes.controls[0]!.options.onConnectionOpen(connOpen())
+    // The blip that costs the control also kills the in-flight data socket.
+    fakes.transports[0]!.openConnections.delete('conn-1')
+
+    await origin.rebind('relay-jwt', ASSIGNMENT)
+
+    expect(fakes.transports[0]!.openConnection).toHaveBeenCalledTimes(2)
+    expect(fakes.transports[0]!.openConnection).toHaveBeenLastCalledWith({
+      type: 'conn-open',
+      connId: 'conn-1',
+      connTicket: TICKET,
+      kind: 'resume',
+      relayDeviceId: 'device-1',
+      attachDeadlineMs: 10_000
+    })
+  })
+
+  it('never re-dials a pending connection that is already owned or open', async () => {
+    fakes.controlConnect.mockResolvedValueOnce(ack()).mockResolvedValueOnce(
+      ack({
+        activeConnIds: ['conn-active'],
+        pendingConns: [
+          { connId: 'conn-active', connTicket: TICKET, kind: 'resume', relayDeviceId: 'device-1' },
+          { connId: 'conn-1', connTicket: TICKET, kind: 'resume', relayDeviceId: 'device-1' }
+        ]
+      })
+    )
+    const { origin } = createOrigin()
+    await origin.open()
+    fakes.controls[0]!.options.onConnectionOpen(connOpen())
+    expect(fakes.transports[0]!.openConnection).toHaveBeenCalledOnce()
+
+    await origin.rebind('relay-jwt', ASSIGNMENT)
+
+    // conn-active is spliced already and conn-1 still holds its data socket.
+    expect(fakes.transports[0]!.openConnection).toHaveBeenCalledOnce()
+  })
+
+  it('skips a pending connection no control ever described', async () => {
+    // Documents the contract gap: pendingConns entries carry only the
+    // identifiers, and a dial without the relay's kind/device would guess at
+    // both the pairing authority and the E2EE device binding.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    fakes.controlConnect.mockResolvedValue(
+      ack({ pendingConns: [{ connId: 'conn-unknown', connTicket: TICKET }] })
+    )
+    const { origin, owned } = createOrigin()
+
+    await origin.open()
+
+    expect(fakes.transports[0]!.openConnection).not.toHaveBeenCalled()
+    expect(owned).toEqual([])
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('dials nothing once the origin is closed', async () => {
+    fakes.controlConnect.mockResolvedValue(ack())
+    const { origin, owned } = createOrigin()
+    await origin.open()
+    await origin.close()
+
+    // A conn-open still in flight when teardown ran must not open a data socket
+    // that nothing is left to close.
+    fakes.controls[0]!.options.onConnectionOpen(connOpen({ connId: 'conn-late' }))
+
+    expect(fakes.transports[0]!.openConnection).not.toHaveBeenCalled()
+    expect(owned).toEqual([])
+  })
+
+  it('releases a replayed connection whose dial fails', async () => {
+    fakes.controlConnect.mockResolvedValue(
+      ack({
+        pendingConns: [
+          { connId: 'conn-1', connTicket: TICKET, kind: 'resume', relayDeviceId: 'device-1' }
+        ]
+      })
+    )
+    const { origin, released } = createOrigin()
+    fakes.transports[0]!.openConnection.mockRejectedValue(new Error('relay_transport_stopped'))
+
+    await origin.open()
+
+    await vi.waitFor(() => expect(released).toEqual(['conn-1']))
+  })
+})

--- a/src/main/runtime/relay/relay-control-origin.ts
+++ b/src/main/runtime/relay/relay-control-origin.ts
@@ -3,14 +3,18 @@ import type { E2EEKeypair } from '../e2ee-keypair'
 import { CloudRelayTransport } from '../rpc/relay-transport'
 import type { MobileSocketWiring } from '../rpc/mobile-socket-wiring'
 import { RelayControlClient } from './relay-control-client'
+import { RELAY_HOST_ATTACH_DEADLINE_MS } from './relay-control-protocol'
 import type {
   RelayConnectionOpenMessage,
   RelayDrainMessage,
-  RelayHostHelloAckMessage
+  RelayHostHelloAckMessage,
+  RelayPendingConnection
 } from './relay-control-protocol'
 import type { RelayHostCloseReason } from '../../../shared/relay-host-close-reason'
 import type { RelayIdentity } from './relay-session-broker-contract'
 import type { RelayAssignment } from './relay-http-client'
+
+const OBSERVED_OPEN_LIMIT = 16
 
 type RelayControlOriginOptions = {
   assignment: RelayAssignment
@@ -41,8 +45,14 @@ export class RelayControlOrigin {
   private generation = 0
   private controlResumeSecret: string | null = null
   private leaseExpiresAt = 0
-  private acceptingConnections = true
   private closed = false
+  // conn-opens seen on any control of this origin, kept for the cell's attach
+  // window so a replayed pending connection keeps the relay's own kind/device
+  // when the ack does not restate it (a cell that predates that field).
+  private readonly observedOpens = new Map<
+    string,
+    { message: RelayConnectionOpenMessage; seenAt: number }
+  >()
   private readonly detachMobileSocketTransport: () => void
 
   constructor(options: RelayControlOriginOptions) {
@@ -114,7 +124,6 @@ export class RelayControlOrigin {
       controlResumeSecret: this.controlResumeSecret
     })
     this.activate(control, ack)
-    this.acceptingConnections = true
     // Why: the resumed control owns the same server generation and splices;
     // the predecessor remains only long enough for any idempotent reply in flight.
     if (previous && previous.pendingRequestCount === 0) {
@@ -127,12 +136,6 @@ export class RelayControlOrigin {
         setTimeout(() => this.closeRetiredControl(previous), 10_100)
       )
     }
-  }
-
-  markDraining(): void {
-    // The relay changes the control's protocol state when it sends drain. This
-    // marker exists for the broker's ownership policy, not a second wire event.
-    this.acceptingConnections = false
   }
 
   refreshAuthorization(relayJwt: string): void {
@@ -159,6 +162,7 @@ export class RelayControlOrigin {
     }
     this.controls.clear()
     this.activeControl = null
+    this.observedOpens.clear()
     try {
       await this.transport.stop()
     } finally {
@@ -248,15 +252,84 @@ export class RelayControlOrigin {
     for (const connectionId of ack.activeConnIds) {
       this.options.onConnectionOwned(connectionId, this)
     }
+    this.replayPendingConnections(ack)
+  }
+
+  // The cell sends conn-open once. A control that rotates or rebinds mid-accept
+  // restates the still-waiting connections here instead, and without this replay
+  // the phone waits out its attach deadline and is closed as if the host were offline.
+  private replayPendingConnections(ack: RelayHostHelloAckMessage): void {
+    const active = new Set(ack.activeConnIds)
+    for (const pending of ack.pendingConns) {
+      if (active.has(pending.connId) || this.transport.hasConnection(pending.connId)) {
+        continue
+      }
+      const message = this.pendingConnectionOpen(pending)
+      if (!message) {
+        console.warn('[relay] pending connection not replayable: relay stated no kind/device')
+        continue
+      }
+      // Not remembered: a replay must not extend the observed entry's own life.
+      this.dialConnection(message)
+    }
+  }
+
+  private pendingConnectionOpen(
+    pending: RelayPendingConnection
+  ): RelayConnectionOpenMessage | null {
+    // A pending entry may restate only the identifiers. kind and relayDeviceId
+    // decide local pairing authority and E2EE device binding, so they are taken
+    // from the relay — the ack itself, or the conn-open this process already saw.
+    const observed = this.observedOpens.get(pending.connId)?.message
+    const kind = pending.kind ?? observed?.kind
+    const relayDeviceId = pending.relayDeviceId ?? observed?.relayDeviceId
+    if (!kind || !relayDeviceId) {
+      return null
+    }
+    return {
+      type: 'conn-open',
+      connId: pending.connId,
+      connTicket: pending.connTicket,
+      kind,
+      relayDeviceId,
+      // The cell's attach timer started before this control existed, so the real
+      // remaining budget is unknown and never longer than the contract deadline.
+      attachDeadlineMs: RELAY_HOST_ATTACH_DEADLINE_MS
+    }
   }
 
   private openConnection(message: RelayConnectionOpenMessage): void {
-    if (!this.acceptingConnections) {
+    if (this.closed) {
       return
     }
+    this.rememberOpen(message)
+    this.dialConnection(message)
+  }
+
+  private dialConnection(message: RelayConnectionOpenMessage): void {
     this.options.onConnectionOwned(message.connId, this)
     void this.transport.openConnection(message).catch(() => {
       this.options.onConnectionReleased(message.connId, this)
     })
+  }
+
+  private rememberOpen(message: RelayConnectionOpenMessage): void {
+    const now = Date.now()
+    for (const [connId, entry] of this.observedOpens) {
+      // Past the attach deadline the cell has already failed the connection.
+      if (now - entry.seenAt > RELAY_HOST_ATTACH_DEADLINE_MS) {
+        this.observedOpens.delete(connId)
+      }
+    }
+    // The contract caps a session at 8 connections; the surplus is a clock that
+    // never advanced, so drop oldest-first rather than growing without bound.
+    while (this.observedOpens.size >= OBSERVED_OPEN_LIMIT) {
+      const oldest = this.observedOpens.keys().next()
+      if (oldest.done) {
+        break
+      }
+      this.observedOpens.delete(oldest.value)
+    }
+    this.observedOpens.set(message.connId, { message, seenAt: now })
   }
 }

--- a/src/main/runtime/relay/relay-control-protocol.ts
+++ b/src/main/runtime/relay/relay-control-protocol.ts
@@ -26,8 +26,28 @@ export const RelayHostChallengeMessageSchema = z
   })
   .strict()
 
+const ConnectionKindSchema = z.enum(['invite', 'resume'])
+
+// Mirrors RELAY_HOST_CAPABILITIES_HEADER in the relay contract. It rides the
+// control upgrade rather than host-hello because the cell parses host-hello
+// strictly: a new hello key is refused by every already-deployed cell.
+export const RELAY_HOST_CAPABILITY_HEADERS = {
+  'x-orca-host-capabilities': 'pending-conn-details'
+} as const
+
+// Mirrors RELAY_PROTOCOL_LIMITS.hostAttachDeadlineMs in the relay contract: the
+// window the cell keeps a phone waiting for the host's data socket.
+export const RELAY_HOST_ATTACH_DEADLINE_MS = 10_000
+
+// kind/relayDeviceId are accepted but not required: today's cells restate only
+// the identifiers, and a strict schema would make adding them a breaking change.
 const PendingConnectionSchema = z
-  .object({ connId: OpaqueIdSchema, connTicket: Base64Url32ByteSchema })
+  .object({
+    connId: OpaqueIdSchema,
+    connTicket: Base64Url32ByteSchema,
+    kind: ConnectionKindSchema.optional(),
+    relayDeviceId: OpaqueIdSchema.optional()
+  })
   .strict()
 
 export const RelayHostHelloAckMessageSchema = z
@@ -47,7 +67,7 @@ export const RelayConnectionOpenMessageSchema = z
     type: z.literal('conn-open'),
     connId: OpaqueIdSchema,
     connTicket: Base64Url32ByteSchema,
-    kind: z.enum(['invite', 'resume']),
+    kind: ConnectionKindSchema,
     relayDeviceId: OpaqueIdSchema,
     attachDeadlineMs: z.number().int().positive().max(60_000)
   })
@@ -119,6 +139,7 @@ export const RelayControlErrorMessageSchema = z
   })
   .strict()
 
+export type RelayPendingConnection = z.infer<typeof PendingConnectionSchema>
 export type RelayHostHelloAckMessage = z.infer<typeof RelayHostHelloAckMessageSchema>
 export type RelayConnectionOpenMessage = z.infer<typeof RelayConnectionOpenMessageSchema>
 export type RelayDrainMessage = z.infer<typeof RelayDrainMessageSchema>

--- a/src/main/runtime/relay/relay-origin-pool.ts
+++ b/src/main/runtime/relay/relay-origin-pool.ts
@@ -144,7 +144,6 @@ export class RelayOriginPool {
     if (!this.isCurrent() || origin !== this.activeOrigin) {
       return
     }
-    origin.markDraining()
     this.drainingOrigins.add(origin)
     this.options.onStatus('draining')
     if (!this.rotationPromise && !this.drainRetry.pending) {

--- a/src/main/runtime/relay/relay-session-broker.test.ts
+++ b/src/main/runtime/relay/relay-session-broker.test.ts
@@ -79,6 +79,7 @@ vi.mock('../rpc/relay-transport', () => ({
     stop = vi.fn().mockResolvedValue(undefined)
     setGeneration = vi.fn()
     metadataFor = vi.fn()
+    hasConnection = vi.fn(() => false)
     openConnection = vi.fn().mockResolvedValue(undefined)
 
     constructor() {
@@ -344,6 +345,60 @@ describe('RelaySessionBroker lifecycle ownership', () => {
     })
     await vi.waitFor(() => expect(onAssignedCellActive).toHaveBeenCalledTimes(2))
     expect(onAssignedCellActive).toHaveBeenLastCalledWith('https://cell-b.relay.example.test')
+  })
+
+  it('attaches a phone whose accept straddles a control rebind', async () => {
+    const ack: RelayHostHelloAckMessage = {
+      type: 'host-hello-ack',
+      v: 1,
+      generation: 7,
+      controlResumeSecret: 'R'.repeat(43),
+      leaseExpiresAt: 1_000_000,
+      activeConnIds: [],
+      pendingConns: []
+    }
+    fakes.controlConnect.mockResolvedValueOnce(ack).mockResolvedValueOnce({
+      ...ack,
+      leaseExpiresAt: 2_000_000,
+      // The cell restates the connection it already announced once; without the
+      // replay the phone waits out its 10s attach deadline and is closed 4404.
+      pendingConns: [{ connId: 'straddling-basis', connTicket: 'T'.repeat(43) }]
+    })
+    fakes.assign.mockResolvedValue({
+      cellUrl: 'https://relay.example.test',
+      assignmentEpoch: 1,
+      leaseExpiresAt: 2_000_000
+    })
+    const broker = await RelaySessionBroker.connect(brokerOptions())
+    fakes.controls[0]!.options.onConnectionOpen({
+      connId: 'straddling-basis',
+      connTicket: 'T'.repeat(43),
+      kind: 'invite',
+      relayDeviceId: 'device-1',
+      attachDeadlineMs: 10_000
+    })
+    // The blip that costs the control also kills the in-flight data socket.
+    fakes.transports[0]!.openConnection.mockClear()
+
+    fakes.controls[0]!.options.onDrain({
+      type: 'drain',
+      graceMs: 5_000,
+      recovery: 'resolve-director'
+    })
+    await vi.waitFor(() => expect(fakes.controls).toHaveLength(2))
+
+    expect(fakes.transports).toHaveLength(1)
+    await vi.waitFor(() =>
+      expect(fakes.transports[0]!.openConnection).toHaveBeenCalledWith({
+        type: 'conn-open',
+        connId: 'straddling-basis',
+        connTicket: 'T'.repeat(43),
+        kind: 'invite',
+        relayDeviceId: 'device-1',
+        attachDeadlineMs: 10_000
+      })
+    )
+    expect(brokerBasisIds(broker)).toEqual(['straddling-basis'])
   })
 
   it('opens a fresh same-cell generation when process-local rebind state is lost', async () => {

--- a/src/main/runtime/rpc/relay-transport.ts
+++ b/src/main/runtime/rpc/relay-transport.ts
@@ -104,6 +104,10 @@ export class CloudRelayTransport implements RpcTransport, MobileSocketTransport 
     this.generation = generation
   }
 
+  hasConnection(connectionId: string): boolean {
+    return this.socketsByConnectionId.has(connectionId)
+  }
+
   terminateClientConnections(clientId: string): number {
     const sockets = Array.from(this.clientIds.entries())
       .filter(([, candidate]) => candidate === clientId)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​348 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​334 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​116 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |

<!-- /orca-pr-loc -->

> **Split:** this is the **desktop half** only. The cell and contract half is #19266, and this PR is based on that branch. **Held for the desktop review pass; depends on #19266 and must not land before it.** After #19266 merges, retarget this to `main` and rebase.

## ELI5

A phone connecting through the relay is announced to your desktop exactly once. If your desktop's control connection rotates at that moment, the announcement is lost and the phone sits there until it gives up, even though your desktop is online the whole time. The relay already re-lists those waiting connections when the desktop reconnects. Your desktop was reading that list and throwing it away. Now it picks them up.

## What Changed

- On activation, `RelayControlOrigin` dials a data socket for each `pendingConns` entry it is not already serving. Entries already spliced, or already holding a data socket, are skipped, so a rebind never double-dials.
- The `kind` and `relayDeviceId` a dial needs come only from the relay, in this order: the ack entry when the cell states them (needs #19266), otherwise a `conn-open` this process already observed. `observedOpens` is capped at 16, evicted past the attach deadline, and cleared on close. An entry described by neither source is skipped with a warning, never dialed with guessed values, because `kind` decides pairing authority and `relayDeviceId` is the E2EE device binding.
- `conn-open` is now forwarded while the control is draining. `markDraining` on the origin is removed; the pool's drain deadline still bounds the origin.
- The desktop advertises `x-orca-host-capabilities: pending-conn-details` on the control WebSocket upgrade.
- `CloudRelayTransport.hasConnection` exposes the already-open check the replay guard needs.

The header name and token are duplicated by hand because the desktop cannot import the relay contract. Both sides assert the literals, so drift fails a test instead of silently disabling the feature. The same is now true of `RELAY_HOST_ATTACH_DEADLINE_MS`, which mirrors `RELAY_PROTOCOL_LIMITS.hostAttachDeadlineMs`.

## Why

The cell announces a connection with a single `conn-open`. When the desktop's control socket dies mid-accept, the phone waits out the 10s attach deadline and is closed `HOST_OFFLINE` even though the desktop is online. Desktop lease rotations happen fleet-wide in roughly 54-minute waves, so this recurs.

`host-hello-ack` already restates those connections in `pendingConns`. The desktop parsed the field and never acted on it, and separately dropped a `conn-open` that arrived while the control was draining. A draining cell cannot start a new accept, so such a frame predates the drain and only that cell holds the waiting phone.

## Linked Issue

N/A. Found while investigating relay connection latency, not filed as an issue.

## Visual Proof

`N/A` — transport-layer behavior with no rendered surface. The user-visible effect is a phone that attaches instead of timing out.

## Testing

- `pnpm vitest run src/main/runtime/relay src/main/runtime/rpc` — 278 files, 2384 passed, 1 skipped.
- `pnpm run check:code-quality:changed` — 0 new findings across 7 changed files; type-aware 0; React Doctor 0.
- Cell-side suites and typecheck are verified on #19266.
- Mutation checks: removing the replay kills 5 tests; latching the capability per session instead of per socket fails the rebind-downgrade test on the cell half.
- Platforms: the changed code is platform-independent Node in the main process, exercised by the unit suites above. Not separately smoke-tested on Windows or Linux.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor.

## Review

Independent adversarial review, two rounds plus a nit round. Pullfrog: no new issues, one informational note that `RELAY_HOST_ATTACH_DEADLINE_MS` was not cross-pinned, now fixed with a test in this PR. CodeRabbit: no actionable comments.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Backwards compatibility**: all three version mixes are safe. Old desktop plus new cell gets the legacy ack. New desktop plus old cell gets the legacy ack and falls back to the observed `conn-open`, which works against every deployed cell. New plus new replays from the ack. Deploy the cell first.
- **Security**: a replayed dial never invents `kind` or `relayDeviceId`; an entry the relay did not describe is skipped rather than dialed with a guess.
- **Cross-platform / SSH**: no platform-dependent code paths touched.
- **Performance**: `observedOpens` is bounded at 16 entries with deadline-based eviction and is cleared on origin close.
- **Not proven from the repo**: that the production external load balancer forwards the `x-orca-host-capabilities` upgrade header. A stripped header degrades to the observed-`conn-open` path rather than failing. Worth one live probe against staging at deploy time.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)