### PR TITLE
relay: give the asia-east2 cells the regional rehome identity

### DIFF
--- a/cloud/dev/scripts/relay-same-cap-script-census.test.mjs
+++ b/cloud/dev/scripts/relay-same-cap-script-census.test.mjs
@@ -179,9 +179,10 @@ describe('same-cap roll scripts accept every same-cap cell', () => {
 
   it('validates a correct plan for every wave cell at that cell\'s rehome protocol', () => {
     for (const cellId of SAME_CAP_CELLS) {
-      const [region, cap] = resolveCellShape(cellId).stdout.trim().split(' ')
+      const [, cap] = resolveCellShape(cellId).stdout.trim().split(' ')
       const protocol = REHOME_SOURCE_CELLS.has(cellId) ? 1 : 0
-      assert.equal(protocol, region === 'us-central1' ? 1 : 0, cellId)
+      // Every reviewed serving cell carries rehome trust now, in either region.
+      assert.equal(protocol, 1, cellId)
       const config = {
         mode: 'same-cap-cell',
         cellId,
@@ -209,6 +210,29 @@ describe('same-cap roll scripts accept every same-cap cell', () => {
         cellId
       )
     }
+  })
+
+  it('validates a protocol-0 plan for a cell outside the rehome source list', () => {
+    const cellId = 'production-gce-c17'
+    assert.equal(REHOME_SOURCE_CELLS.has(cellId), false)
+    const config = {
+      mode: 'same-cap-cell',
+      cellId,
+      hardCap: 1000,
+      unobservedBound: 60,
+      image: TARGET_IMAGE,
+      rollbackImage: ROLLBACK_IMAGE,
+      rehomeDirectorServiceAccount: DIRECTOR_IDENTITY,
+      rehomeAudience: AUDIENCE,
+      regionalRehomeProtocol: '0'
+    }
+    const plan = rollPlan({ cellId, cap: 1000, protocol: 0 })
+    assert.deepEqual(validateCapacityPlan(plan, config), { mode: 'same-cap-cell', changes: 2 })
+    // Protocol 1 must reject a plan with no rehome lines, or the absent-line rule decides nothing.
+    assert.throws(
+      () => validateCapacityPlan(plan, { ...config, regionalRehomeProtocol: '1' }),
+      /reviewed image and capacity/
+    )
   })
 
   it('leaves the US-only capacity job on the default allowlist', () => {

--- a/cloud/infra/terraform/environments/production.tfvars
+++ b/cloud/infra/terraform/environments/production.tfvars
@@ -402,7 +402,11 @@ relay_region_rehome_source_cell_ids = [
   "production-gce-c23",
   "production-gce-c24",
   "production-gce-c25",
-  "production-gce-c26"
+  "production-gce-c26",
+  # Asia cells carry the same trust so mis-homed hosts can be drained back off them.
+  "production-gce-c27",
+  "production-gce-c28",
+  "production-gce-c29"
 ]
 
 # Slack #orca-relay-alerts, created out of band on 2026-08-05. Declared here because an apply

--- a/cloud/infra/terraform/relay-gce-cells.tf
+++ b/cloud/infra/terraform/relay-gce-cells.tf
@@ -82,14 +82,15 @@ check "relay_gce_fixed_one_topology" {
 
   assert {
     condition = alltrue([
+      # Region is not asserted here: the director's own rehome source and target predicates
+      # own eligibility, so this pins only cell shape.
       for cell_id in var.relay_region_rehome_source_cell_ids : try(
-        var.relay_gce_cells[cell_id].region == var.region &&
         var.relay_gce_cells[cell_id].connection_hard_cap != null &&
         !contains(var.relay_gce_fenced_cells, cell_id),
         false
       )
     ])
-    error_message = "Regional rehome sources must be configured, unfenced primary-region GCE cells with explicit connection limits."
+    error_message = "Regional rehome sources must be configured, unfenced GCE cells with explicit connection limits."
   }
 
   assert {

--- a/cloud/infra/terraform/variables.tf
+++ b/cloud/infra/terraform/variables.tf
@@ -245,7 +245,7 @@ variable "relay_regional_placement_enabled" {
 
 variable "relay_region_rehome_source_cell_ids" {
   type        = set(string)
-  description = "Reviewed US Relay cells allowed to advertise and accept the regional rehome source protocol."
+  description = "Reviewed Relay cells, in any configured region, allowed to advertise and accept the regional rehome source protocol."
   default     = []
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

## DRAFT: do not merge before the bidirectional rehome director is deployed

The asia-east2 cells (production-gce-c27, c28, c29) report `regional_rehome_protocol` 0 because `relay_region_rehome_source_cell_ids` lists only the 16 US cells, and membership in that list is what sets `ORCA_RELAY_REHOME_DIRECTOR_SERVICE_ACCOUNT` and `ORCA_RELAY_REHOME_AUDIENCE` in the GCE startup template. A cell reports protocol 1 only with both present. At protocol 0 a cell is neither a rehome source, a target, nor a fleet-safety member, so ~226 mis-homed desktops on those cells cannot be moved back.

## What

- `production.tfvars`: add the three Asia cell ids to `relay_region_rehome_source_cell_ids`.
- `variables.tf`: the check assert that required every rehome source to sit in the primary region is relaxed to "configured, unfenced, explicit connection limit". Region eligibility now belongs to the director's own source and target predicates. The assert was advisory (a Terraform check warns rather than fails).
- `relay-same-cap-script-census.test.mjs`: the census cross-check keys on protocol 1 for every reviewed serving cell, with a protocol-0 case kept on a cell outside the list.

## Plan evidence

Read-only plan with a process-local token, `-lock=false`, no `-out`. Totals are identical with and without this change (the drift backlog the Terraform README documents). A targeted plan for c27's instance template shows 1 add / 1 destroy, and the only attributable delta is the two rehome env lines. The director service account and audience are global constants shared with the US cells, so no new IAM binding is needed.

## Hard ordering

On current main two director gates reject Asia cells: the trust probe returns 409 for a source cell outside the default region, and source selection skips it as `source_ineligible`. The same-cap deploy job runs the trust probe after isolate/drain and after its targeted apply, so rolling an Asia cell at protocol 1 today would leave it serving-but-isolated. After this tfvars change lands, protocol-0 rolls of c27–c29 are also not dispatchable (the capacity-plan validator requires the rehome lines absent at protocol 0).

Safe sequence:
1. Deploy the director with the bidirectional rehome change (removes both gates).
2. Merge this PR. Never an untargeted root apply.
3. `Deploy Relay Production Same-Cap` canary-apply for ONE Asia cell with target-rehome-protocol 1 / rollback-rehome-protocol 0 (it does its own targeted template + MIG apply).
4. Batch-apply the remaining two.
5. Confirm protocol 1 on fresh incarnations before enabling the rehome control.

## Verification

`terraform fmt -check -recursive`, `terraform validate`, cloud dev-script suites (148 pretest, 530 main). Independent adversarial review, two rounds; round 2 approved.