### PR TITLE
feat(relay): log the region probe and name the assigned cell

### DIFF
--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -742,9 +742,26 @@ describe('registerMobileHandlers', () => {
   })
 
   it('reports the current relay broker status without exposing a toggle', () => {
-    registerMobileHandlers({} as never, { getRelayStatus: () => 'registered' })
+    registerMobileHandlers({} as never, { getRelayStatus: () => ({ status: 'registered' }) })
 
     expect(handlers.get('mobile:getRelayStatus')?.()).toEqual({ status: 'registered' })
+  })
+
+  it('reports the assigned relay cell alongside the status', () => {
+    registerMobileHandlers({} as never, {
+      getRelayStatus: () => ({ status: 'registered', cellUrl: 'https://c27.relay.example.com' })
+    })
+
+    expect(handlers.get('mobile:getRelayStatus')?.()).toEqual({
+      status: 'registered',
+      cellUrl: 'https://c27.relay.example.com'
+    })
+  })
+
+  it('falls back to offline with no cell when no relay status provider is wired', () => {
+    registerMobileHandlers({} as never, {})
+
+    expect(handlers.get('mobile:getRelayStatus')?.()).toEqual({ status: 'offline' })
   })
 
   it('consumes a pending auth-failure notification only from a window renderer', () => {

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -13,7 +13,7 @@ import {
 } from '../runtime/pairing-network-interfaces'
 import { resolveAdvertisedPairingHostname } from '../runtime/pairing-endpoint'
 import type { OrcaRuntimeRpcServer } from '../runtime/runtime-rpc'
-import type { RelayBrokerStatus } from '../runtime/relay/relay-session-broker'
+import type { MobileRelayStatusDetail } from '../../shared/mobile-relay-status'
 import { encodeMobilePairingQr, type MobilePairingQrResult } from '../runtime/mobile-pairing-qr'
 import { getWindowsDefaultRouteInterfaceNames } from '../runtime/windows-default-route-interfaces'
 import {
@@ -51,7 +51,7 @@ function toRuntimeAccessGrant(device: DeviceEntry): RuntimeAccessGrant {
 export type MobileHandlerDependencies = {
   firewallEnvironment?: WindowsMobileFirewallEnvironment
   openWindowsNetworkSettings?: () => Promise<void>
-  getRelayStatus?: () => RelayBrokerStatus
+  getRelayStatus?: () => MobileRelayStatusDetail
   consumePendingUnpairedDeviceAuthFailure?: (webContentsId: number) => boolean
   encodePairingQr?: (pairingUrl: string) => Promise<MobilePairingQrResult>
   getDefaultRouteInterfaceNames?: DefaultRouteInterfaceLookup
@@ -287,9 +287,10 @@ export function registerMobileHandlers(
     return true
   })
 
-  ipcMain.handle('mobile:getRelayStatus', () => ({
-    status: dependencies.getRelayStatus?.() ?? 'offline'
-  }))
+  ipcMain.handle(
+    'mobile:getRelayStatus',
+    (): MobileRelayStatusDetail => dependencies.getRelayStatus?.() ?? { status: 'offline' }
+  )
 
   ipcMain.handle('mobile:consumePendingUnpairedDeviceAuthFailure', (event) => {
     if (!isWindowRenderer(event)) {

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -26,7 +26,7 @@ type DesktopRelayServiceOptions = {
   userDataPath: string
   appVersion: string
   runtimeRpc: OrcaRuntimeRpcServer
-  onStatus: (status: RelayBrokerStatus) => void
+  onStatus: (status: RelayBrokerStatus, cellUrl?: string) => void
 }
 
 export function pairingAuthorizationForContext(

--- a/src/main/runtime/relay/relay-auth-coordinator.test.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator.test.ts
@@ -31,6 +31,50 @@ describe('RelayAuthCoordinator', () => {
     expect(statuses.at(-1)).toBe('standby')
   })
 
+  it('republishes the owned broker cell instead of blanking what the broker set', async () => {
+    const broker = { closeNow: vi.fn(), endpoint: { cellUrl: 'https://c27.relay.example.test' } }
+    const onStatus = vi.fn()
+    const coordinator = new RelayAuthCoordinator({
+      readContext: async () => context,
+      openBroker: async () => broker,
+      onStatus
+    })
+    coordinator.reconcile()
+    await coordinator.waitForLiveBroker()
+
+    // Why: the broker announces its cell, then the coordinator republishes the
+    // same status; a republish without the cell would erase it immediately.
+    expect(onStatus).toHaveBeenLastCalledWith('registered', 'https://c27.relay.example.test')
+
+    coordinator.reconcile()
+    await coordinator.waitForLiveBroker()
+    expect(onStatus).toHaveBeenLastCalledWith('registered', 'https://c27.relay.example.test')
+  })
+
+  it('drops the cell from every status the host is not served on', async () => {
+    let demanded = true
+    const broker = { closeNow: vi.fn(), endpoint: { cellUrl: 'https://c27.relay.example.test' } }
+    const onStatus = vi.fn()
+    const coordinator = new RelayAuthCoordinator({
+      readContext: async () => context,
+      hasDemand: () => demanded,
+      openBroker: async () => broker,
+      onStatus,
+      lingerMs: 0
+    })
+    coordinator.reconcile()
+    await coordinator.waitForLiveBroker()
+    demanded = false
+    coordinator.reconcile()
+    await vi.waitFor(() => expect(onStatus).toHaveBeenLastCalledWith('standby', undefined))
+
+    coordinator.fenceAndCloseNow()
+    expect(onStatus).toHaveBeenLastCalledWith('offline', undefined)
+    for (const [status, cellUrl] of onStatus.mock.calls) {
+      expect(status === 'registered' || cellUrl === undefined).toBe(true)
+    }
+  })
+
   it('opens on demand and lingers before closing the last control', async () => {
     let demanded = false
     const broker = { closeNow: vi.fn() }

--- a/src/main/runtime/relay/relay-auth-coordinator.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator.ts
@@ -2,6 +2,7 @@ import {
   RELAY_HOST_CLOSE_REASON,
   type RelayHostCloseReason
 } from '../../../shared/relay-host-close-reason'
+import { relayStatusCellUrl } from '../../../shared/mobile-relay-status'
 import type { RelayBrokerStatus } from './relay-session-broker'
 import { RelayHttpError, shouldRetryRelayConnectionError } from './relay-http-client'
 
@@ -20,6 +21,7 @@ export type RelayAuthContext = {
 export type CoordinatedRelayBroker = {
   closeNow(hostCloseReason?: RelayHostCloseReason): void
   isLive?(): boolean
+  readonly endpoint?: { cellUrl: string } | null
 }
 
 type RelayAuthCoordinatorOptions = {
@@ -30,7 +32,7 @@ type RelayAuthCoordinatorOptions = {
     isCurrent: () => boolean
     refreshAccessToken: () => Promise<string | null>
   }) => Promise<CoordinatedRelayBroker>
-  onStatus: (status: RelayBrokerStatus) => void
+  onStatus: (status: RelayBrokerStatus, cellUrl?: string) => void
   lingerMs?: number
   random?: () => number
 }
@@ -92,7 +94,17 @@ export class RelayAuthCoordinator {
     this.retryAttempt = 0
     this.invalidatePendingOwnerships()
     this.invalidateOwnership(hostCloseReason)
-    this.options.onStatus('offline')
+    this.publish('offline')
+  }
+
+  // Why derived rather than passed in: the coordinator republishes `registered`
+  // after the broker already announced its cell, so a call site that forgot the
+  // cell would silently blank it moments after the broker set it.
+  private publish(status: RelayBrokerStatus): void {
+    this.options.onStatus(
+      status,
+      relayStatusCellUrl(status, this.ownership?.broker?.endpoint?.cellUrl)
+    )
   }
 
   // Raw ownership handle for identity matching (revoke routing); control work uses getLiveBroker.
@@ -158,13 +170,13 @@ export class RelayAuthCoordinator {
         // by a 401). A present-but-unentitled context is still a signed-in
         // desktop, and "sign in to reconnect" would be wrong advice for it.
         this.invalidateOwnership(context ? undefined : RELAY_HOST_CLOSE_REASON.SIGNED_OUT)
-        this.options.onStatus('offline')
+        this.publish('offline')
         return
       }
       const nextIdentityKey = identityKey(context.identity)
       if (expectedIdentityKey && nextIdentityKey !== expectedIdentityKey) {
         this.retryAttempt = 0
-        this.options.onStatus('offline')
+        this.publish('offline')
         return
       }
       if (!(this.options.hasDemand?.(context) ?? true)) {
@@ -175,7 +187,7 @@ export class RelayAuthCoordinator {
         } else if (this.ownership?.valid) {
           this.scheduleLinger(context, this.ownership)
         }
-        this.options.onStatus('standby')
+        this.publish('standby')
         return
       }
       this.cancelLinger()
@@ -187,12 +199,12 @@ export class RelayAuthCoordinator {
         (this.ownership.broker?.isLive?.() ?? true)
       ) {
         this.retryAttempt = 0
-        this.options.onStatus('registered')
+        this.publish('registered')
         return
       }
       retryIdentityKey = nextIdentityKey
       this.invalidateOwnership()
-      this.options.onStatus('connecting')
+      this.publish('connecting')
       const ownership: BrokerOwnership = {
         identityKey: nextIdentityKey,
         broker: null,
@@ -220,7 +232,7 @@ export class RelayAuthCoordinator {
       }
       this.ownership = ownership
       this.retryAttempt = 0
-      this.options.onStatus('registered')
+      this.publish('registered')
     } catch (error) {
       if (this.isEpochCurrent(epoch)) {
         // Why: silent broker-open failures made a dead relay look like standby
@@ -229,7 +241,7 @@ export class RelayAuthCoordinator {
           '[relay] broker reconcile failed:',
           error instanceof Error ? error.message : String(error)
         )
-        this.options.onStatus('offline')
+        this.publish('offline')
         if (shouldRetryRelayConnectionError(error)) {
           const retryAfterMs = error instanceof RelayHttpError ? (error.retryAfterMs ?? 0) : 0
           this.scheduleRetry(epoch, retryIdentityKey, retryAfterMs)
@@ -304,7 +316,7 @@ export class RelayAuthCoordinator {
         !(this.options.hasDemand?.(context) ?? true)
       ) {
         this.invalidateOwnership()
-        this.options.onStatus('standby')
+        this.publish('standby')
       }
     }, lingerMs)
   }

--- a/src/main/runtime/relay/relay-region-catalog-fetch.ts
+++ b/src/main/runtime/relay/relay-region-catalog-fetch.ts
@@ -1,0 +1,64 @@
+import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../../../shared/fetch-response-body'
+import { RelayRegionCatalogSchema, type RelayRegionCatalog } from './relay-region-probe'
+
+const CATALOG_MAX_BYTES = 16 * 1024
+
+export async function fetchRelayRegionCatalog(
+  directorUrl: string,
+  fetch: typeof globalThis.fetch,
+  timeoutMs: number
+): Promise<RelayRegionCatalog> {
+  if (!isCanonicalDirectorOrigin(directorUrl)) {
+    throw new Error('invalid relay director origin')
+  }
+  const response = await fetch(`${directorUrl}/v1/regions`, {
+    method: 'GET',
+    cache: 'no-store',
+    redirect: 'error',
+    signal: AbortSignal.timeout(timeoutMs)
+  })
+  if (!response.ok) {
+    await cancelUnreadResponseBody(response)
+    throw new Error(`relay region catalog failed (${response.status})`)
+  }
+  const body = await readFetchResponseJsonWithinLimit<unknown>(response, CATALOG_MAX_BYTES, {
+    structuralTokens: 64,
+    nestingDepth: 8
+  })
+  const catalog = RelayRegionCatalogSchema.parse(body)
+  if (
+    catalog.regions.some((entry) =>
+      entry.probeOrigins.some((origin) => !isProbeOriginForDirector(origin, directorUrl))
+    )
+  ) {
+    throw new Error('relay probe origin does not belong to the director')
+  }
+  return catalog
+}
+
+// Logs name the director by host so staging and production lines stay
+// distinguishable without carrying a full URL through every event.
+export function relayDirectorHost(directorUrl: string): string {
+  try {
+    return new URL(directorUrl).hostname
+  } catch {
+    return 'invalid'
+  }
+}
+
+function isCanonicalDirectorOrigin(value: string): boolean {
+  try {
+    const url = new URL(value)
+    const loopback = ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname)
+    return (
+      url.origin === value && (url.protocol === 'https:' || (url.protocol === 'http:' && loopback))
+    )
+  } catch {
+    return false
+  }
+}
+
+function isProbeOriginForDirector(origin: string, directorUrl: string): boolean {
+  return new URL(origin).hostname.endsWith(`.${new URL(directorUrl).hostname}`)
+}

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -2,28 +2,37 @@ import { existsSync, readFileSync, rmSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { z } from 'zod'
-import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
-import { readFetchResponseJsonWithinLimit } from '../../../shared/fetch-response-body'
 import { hardenExistingSecureFile, writeSecureJsonFile } from '../../../shared/secure-file'
+import { fetchRelayRegionCatalog, relayDirectorHost } from './relay-region-catalog-fetch'
+import {
+  logRelayRegionEvent,
+  relayRegionCacheHitEvent,
+  relayRegionCatalogFailureEvent,
+  relayRegionOverrideEvent,
+  relayRegionRefreshEvent,
+  RELAY_REGION_SELF_HEAL_EVENT,
+  type RelayRegionLogSink,
+  type RelayRegionSelfHealLogEvent
+} from './relay-region-probe-log'
 import {
   measureOriginLatency,
   RELAY_REGIONS,
   measureRegion,
   probeRelayOrigin,
   PROBE_TIMEOUT_MS,
-  RelayRegionCatalogSchema,
+  regionMeasurement,
   RelayRegionSchema,
   type RegionMeasurement,
   type RelayProbe,
   type RelayRegion,
-  type RelayRegionCatalog
+  type RelayRegionCatalog,
+  type RelayRegionProbeReport
 } from './relay-region-probe'
 
 export { RELAY_REGIONS, type RelayRegion } from './relay-region-probe'
 
 const RELAY_REGION_CACHE_FILENAME = 'orca-relay-region-preference.json'
 const CACHE_MAX_BYTES = 8 * 1024
-const CATALOG_MAX_BYTES = 16 * 1024
 const CACHE_TTL_MS = 24 * 60 * 60_000
 // A withheld hint is cheap to revisit but expensive to re-measure on every
 // reconnect, so it is remembered for far less time than a chosen region.
@@ -54,6 +63,7 @@ type RelayRegionPreferenceOptions = {
   diagnosticOverride?: string
   probe?: RelayProbe
   requestTimeoutMs?: number
+  logEvent?: RelayRegionLogSink
 }
 
 export class RelayRegionPreferenceResolver {
@@ -68,12 +78,22 @@ export class RelayRegionPreferenceResolver {
   async resolve(): Promise<RelayRegion | undefined> {
     const override = this.overrideRegion()
     if (override) {
+      this.log(
+        relayRegionOverrideEvent({ directorUrl: this.options.directorUrl, region: override })
+      )
       return override
     }
 
     const now = (this.options.now ?? Date.now)()
     const cache = readRelayRegionCache(this.cachePath(), this.options.directorUrl, now)
     if (cache && cache.expiresAt > now) {
+      this.log(
+        relayRegionCacheHitEvent({
+          directorUrl: this.options.directorUrl,
+          region: cache.region,
+          ttlMs: cache.expiresAt - now
+        })
+      )
       return cache.region ?? undefined
     }
     if (this.pending) {
@@ -103,21 +123,41 @@ export class RelayRegionPreferenceResolver {
     this.selfHealedCells.add(assignedCellOrigin)
     try {
       const fetch = this.options.fetch ?? globalThis.fetch
-      const catalog = await this.fetchCatalog(fetch)
       const probe = this.createProbe(fetch)
-      const best = bestMeasurement(await measureCatalogRegions(catalog, probe))
+      const reports = await this.probeCatalog(fetch)
+      const best = bestMeasurement(measuredRegions(reports))
+      const outcome: Omit<RelayRegionSelfHealLogEvent, 'directorHost'> = {
+        event: RELAY_REGION_SELF_HEAL_EVENT,
+        cachedRegion: cache.region,
+        bestRegion: best?.region ?? null,
+        bestLatencyMs: best?.latencyMs ?? null,
+        assignedCellUrl: assignedCellOrigin,
+        assignedLatencyMs: null,
+        decision: 'kept',
+        reason: best ? 'best-matches-cache' : 'no-region-measured'
+      }
       // A far cell under a cache that still names the best region is the
       // director declining the hint; deleting it would only re-probe.
       if (!best || best.region === cache.region) {
+        this.logSelfHeal(outcome)
         return
       }
       const assignedMs = await measureOriginLatency(assignedCellOrigin, probe)
-      if (assignedMs !== null && assignedMs > best.latencyMs * FAR_CELL_RATIO) {
+      outcome.assignedLatencyMs = assignedMs
+      const far = assignedMs !== null && assignedMs > best.latencyMs * FAR_CELL_RATIO
+      outcome.decision = far ? 'deleted' : 'kept'
+      outcome.reason = far ? 'assigned-cell-far' : 'assigned-cell-near'
+      if (far) {
         rmSync(this.cachePath(), { force: true })
       }
+      this.logSelfHeal(outcome)
     } catch {
       // Self-heal is best effort; a failed probe must never disturb the session.
     }
+  }
+
+  private logSelfHeal(outcome: Omit<RelayRegionSelfHealLogEvent, 'directorHost'>): void {
+    this.log({ ...outcome, directorHost: relayDirectorHost(this.options.directorUrl) })
   }
 
   private async refresh(
@@ -125,21 +165,54 @@ export class RelayRegionPreferenceResolver {
     now: number
   ): Promise<RelayRegion | undefined> {
     const fetch = this.options.fetch ?? globalThis.fetch
-    const catalog = await this.fetchCatalog(fetch)
-    const measurements = await measureCatalogRegions(catalog, this.createProbe(fetch))
+    // Only a refresh withholds a hint, so only a refresh reports a director that
+    // could not list its regions; the self-heal path stays silent on failure.
+    const reports = await this.probeCatalog(fetch, () =>
+      this.log(relayRegionCatalogFailureEvent(this.options.directorUrl))
+    )
+    const measurements = measuredRegions(reports)
     // Why: a region may only win against a measured competitor. With a rejected
     // or unmeasurable peer, director default placement beats a lone survivor.
     const selected =
-      measurements.length < catalog.regions.length
+      measurements.length < reports.length
         ? null
         : selectRegionMeasurement(measurements, previous?.region ?? null)
+    const ttlMs = selected ? CACHE_TTL_MS : NO_HINT_TTL_MS
+    this.log(
+      relayRegionRefreshEvent({
+        directorUrl: this.options.directorUrl,
+        reports,
+        best: bestMeasurement(measurements),
+        selected,
+        ttlMs
+      })
+    )
     this.writeCache(
       selected
-        ? { region: selected.region, latencyMs: selected.latencyMs, ttlMs: CACHE_TTL_MS }
-        : { region: null, ttlMs: NO_HINT_TTL_MS },
+        ? { region: selected.region, latencyMs: selected.latencyMs, ttlMs }
+        : { region: null, ttlMs },
       now
     )
     return selected?.region
+  }
+
+  private async probeCatalog(
+    fetch: typeof globalThis.fetch,
+    onCatalogFailure?: () => void
+  ): Promise<RelayRegionProbeReport[]> {
+    let catalog: RelayRegionCatalog
+    try {
+      catalog = await this.fetchCatalog(fetch)
+    } catch (error) {
+      onCatalogFailure?.()
+      throw error
+    }
+    const probe = this.createProbe(fetch)
+    return await Promise.all(catalog.regions.map((entry) => measureRegion(entry, probe)))
+  }
+
+  private log(event: Parameters<RelayRegionLogSink>[0]): void {
+    ;(this.options.logEvent ?? logRelayRegionEvent)(event)
   }
 
   private writeCache(
@@ -209,45 +282,10 @@ export function createRelayRegionPreferenceReader(input: {
   }
 }
 
-async function measureCatalogRegions(
-  catalog: RelayRegionCatalog,
-  probe: RelayProbe
-): Promise<RegionMeasurement[]> {
-  const measured = await Promise.all(catalog.regions.map((entry) => measureRegion(entry, probe)))
-  return measured.filter((measurement): measurement is RegionMeasurement => measurement !== null)
-}
-
-async function fetchRelayRegionCatalog(
-  directorUrl: string,
-  fetch: typeof globalThis.fetch,
-  timeoutMs: number
-): Promise<RelayRegionCatalog> {
-  if (!isCanonicalDirectorOrigin(directorUrl)) {
-    throw new Error('invalid relay director origin')
-  }
-  const response = await fetch(`${directorUrl}/v1/regions`, {
-    method: 'GET',
-    cache: 'no-store',
-    redirect: 'error',
-    signal: AbortSignal.timeout(timeoutMs)
-  })
-  if (!response.ok) {
-    await cancelUnreadResponseBody(response)
-    throw new Error(`relay region catalog failed (${response.status})`)
-  }
-  const body = await readFetchResponseJsonWithinLimit<unknown>(response, CATALOG_MAX_BYTES, {
-    structuralTokens: 64,
-    nestingDepth: 8
-  })
-  const catalog = RelayRegionCatalogSchema.parse(body)
-  if (
-    catalog.regions.some((entry) =>
-      entry.probeOrigins.some((origin) => !isProbeOriginForDirector(origin, directorUrl))
-    )
-  ) {
-    throw new Error('relay probe origin does not belong to the director')
-  }
-  return catalog
+function measuredRegions(reports: RelayRegionProbeReport[]): RegionMeasurement[] {
+  return reports
+    .map(regionMeasurement)
+    .filter((measurement): measurement is RegionMeasurement => measurement !== null)
 }
 
 function bestMeasurement(measurements: RegionMeasurement[]): RegionMeasurement | null {
@@ -296,20 +334,4 @@ function readRelayRegionCache(path: string, directorUrl: string, now: number) {
   } catch {
     return null
   }
-}
-
-function isCanonicalDirectorOrigin(value: string): boolean {
-  try {
-    const url = new URL(value)
-    const loopback = ['127.0.0.1', 'localhost', '[::1]'].includes(url.hostname)
-    return (
-      url.origin === value && (url.protocol === 'https:' || (url.protocol === 'http:' && loopback))
-    )
-  } catch {
-    return false
-  }
-}
-
-function isProbeOriginForDirector(origin: string, directorUrl: string): boolean {
-  return new URL(origin).hostname.endsWith(`.${new URL(directorUrl).hostname}`)
 }

--- a/src/main/runtime/relay/relay-region-probe-log.test.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.test.ts
@@ -1,0 +1,358 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RelayRegionPreferenceResolver } from './relay-region-preference'
+import {
+  logRelayRegionEvent,
+  RELAY_REGION_PROBE_EVENT,
+  RELAY_REGION_SELF_HEAL_EVENT,
+  type RelayRegionLogEvent,
+  type RelayRegionProbeLogEvent,
+  type RelayRegionSelfHealLogEvent
+} from './relay-region-probe-log'
+
+const DIRECTOR = 'https://relay.example.test'
+const US = 'https://us-c1.relay.example.test'
+const ASIA = 'https://asia-c1.relay.example.test'
+const CELL = 'https://cell-7.relay.example.test'
+const BOTH_REGIONS = [
+  { region: 'us-central1', probeOrigins: [US] },
+  { region: 'asia-east2', probeOrigins: [ASIA] }
+]
+const tempPaths: string[] = []
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  for (const path of tempPaths.splice(0)) {
+    rmSync(path, { recursive: true, force: true })
+  }
+})
+
+function userDataPath(): string {
+  const path = mkdtempSync(join(tmpdir(), 'orca-relay-region-log-'))
+  tempPaths.push(path)
+  return path
+}
+
+function catalogFetch(regions: unknown) {
+  return vi.fn<typeof globalThis.fetch>(async () => Response.json({ v: 1, regions }))
+}
+
+// Each list starts with the discarded warm-up probe, then the three kept samples.
+function sampledProbe(samples: Record<string, number[]>) {
+  return async (origin: string): Promise<number | null> => samples[origin]?.shift() ?? null
+}
+
+function writeCache(path: string, region: string | null, expiresAt: number): void {
+  writeFileSync(
+    join(path, 'orca-relay-region-preference.json'),
+    JSON.stringify({ v: 1, directorUrl: DIRECTOR, region, expiresAt })
+  )
+}
+
+function resolverWithLog(options: {
+  path: string
+  fetch: typeof globalThis.fetch
+  probe?: (origin: string) => Promise<number | null>
+  now?: () => number
+}) {
+  const events: RelayRegionLogEvent[] = []
+  const resolver = new RelayRegionPreferenceResolver({
+    directorUrl: DIRECTOR,
+    userDataPath: options.path,
+    fetch: options.fetch,
+    probe: options.probe,
+    now: options.now ?? (() => 1_000),
+    logEvent: (event) => events.push(event)
+  })
+  return { resolver, events }
+}
+
+function probeEvents(events: RelayRegionLogEvent[]): RelayRegionProbeLogEvent[] {
+  return events.filter(
+    (event): event is RelayRegionProbeLogEvent => event.event === RELAY_REGION_PROBE_EVENT
+  )
+}
+
+describe('Relay region probe log', () => {
+  it('records every probed origin, the discarded warm-up, and the kept samples', async () => {
+    const path = userDataPath()
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: sampledProbe({ [US]: [400, 160, 170, 150], [ASIA]: [90, 35, 40, 30] })
+    })
+
+    await expect(resolver.resolve()).resolves.toBe('asia-east2')
+
+    const [event] = probeEvents(events)
+    expect(event).toMatchObject({
+      event: 'relay_region_probe',
+      directorHost: 'relay.example.test',
+      chosenRegion: 'asia-east2',
+      reason: 'measured',
+      cached: false,
+      ttlMs: 24 * 60 * 60_000
+    })
+    expect(JSON.stringify(event)).not.toMatch(/token|jwt|secret|authorization|bearer|eyJ/i)
+    expect(event.regions).toEqual([
+      {
+        region: 'us-central1',
+        origins: [US],
+        warmupMs: [400],
+        keptMs: [150, 160, 170],
+        minMs: 150,
+        spreadMs: 20,
+        verdict: 'measured'
+      },
+      {
+        region: 'asia-east2',
+        origins: [ASIA],
+        warmupMs: [90],
+        keptMs: [30, 35, 40],
+        minMs: 30,
+        spreadMs: 10,
+        verdict: 'measured'
+      }
+    ])
+  })
+
+  it('reports a flapping region as rejected-spread and withholds the hint', async () => {
+    const path = userDataPath()
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: sampledProbe({ [US]: [400, 160, 170, 150], [ASIA]: [90, 30, 40, 900] })
+    })
+
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+
+    const [event] = probeEvents(events)
+    expect(event.regions.map((region) => region.verdict)).toEqual(['measured', 'rejected-spread'])
+    expect(event).toMatchObject({
+      chosenRegion: 'no-hint',
+      reason: 'sole-survivor-forbidden',
+      ttlMs: 60 * 60_000
+    })
+  })
+
+  it('separates an unreachable region from a rejected one', async () => {
+    const path = userDataPath()
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: sampledProbe({})
+    })
+
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+
+    const [event] = probeEvents(events)
+    expect(event.reason).toBe('all-unreachable')
+    expect(event.regions).toEqual([
+      {
+        region: 'us-central1',
+        origins: [US],
+        warmupMs: [null],
+        keptMs: [],
+        minMs: null,
+        spreadMs: null,
+        verdict: 'unreachable'
+      },
+      {
+        region: 'asia-east2',
+        origins: [ASIA],
+        warmupMs: [null],
+        keptMs: [],
+        minMs: null,
+        spreadMs: null,
+        verdict: 'unreachable'
+      }
+    ])
+  })
+
+  it('names a held incumbent apart from a fresh measurement', async () => {
+    const path = userDataPath()
+    writeCache(path, 'us-central1', 500)
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: sampledProbe({ [US]: [400, 100, 100, 100], [ASIA]: [90, 90, 90, 90] })
+    })
+
+    await expect(resolver.resolve()).resolves.toBe('us-central1')
+
+    expect(probeEvents(events)[0]).toMatchObject({
+      chosenRegion: 'us-central1',
+      reason: 'held-previous'
+    })
+  })
+
+  it('logs a cache hit with the remaining TTL and no probe rounds', async () => {
+    const path = userDataPath()
+    writeCache(path, 'asia-east2', 5_000)
+    const fetch = catalogFetch(BOTH_REGIONS)
+    const { resolver, events } = resolverWithLog({ path, fetch })
+
+    await expect(resolver.resolve()).resolves.toBe('asia-east2')
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(events).toEqual([
+      {
+        event: 'relay_region_probe',
+        directorHost: 'relay.example.test',
+        regions: [],
+        chosenRegion: 'asia-east2',
+        reason: 'cached',
+        cached: true,
+        ttlMs: 4_000
+      }
+    ])
+  })
+
+  it('logs a cached no-hint as no-hint rather than an absent region', async () => {
+    const path = userDataPath()
+    writeCache(path, null, 5_000)
+    const { resolver, events } = resolverWithLog({ path, fetch: catalogFetch(BOTH_REGIONS) })
+
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+
+    expect(probeEvents(events)[0]).toMatchObject({ chosenRegion: 'no-hint', reason: 'cached' })
+  })
+
+  it('logs a diagnostic override without probing', async () => {
+    const path = userDataPath()
+    const events: RelayRegionLogEvent[] = []
+    const resolver = new RelayRegionPreferenceResolver({
+      directorUrl: DIRECTOR,
+      userDataPath: path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      diagnosticOverride: 'asia-east2',
+      logEvent: (event) => events.push(event)
+    })
+
+    await expect(resolver.resolve()).resolves.toBe('asia-east2')
+
+    expect(probeEvents(events)[0]).toMatchObject({
+      chosenRegion: 'asia-east2',
+      reason: 'override',
+      cached: false
+    })
+  })
+
+  it('logs a director that cannot list its regions instead of going silent', async () => {
+    const path = userDataPath()
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: vi.fn<typeof globalThis.fetch>(async () => new Response('nope', { status: 503 }))
+    })
+
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+
+    expect(probeEvents(events)[0]).toMatchObject({
+      chosenRegion: 'no-hint',
+      reason: 'catalog-unavailable',
+      regions: []
+    })
+  })
+
+  it('logs the self-heal decision that deletes a cache pinning a far cell', async () => {
+    const path = userDataPath()
+    writeCache(path, 'us-central1', 5_000)
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: sampledProbe({
+        [US]: [400, 300, 300, 300],
+        [ASIA]: [90, 30, 30, 30],
+        [CELL]: [400, 300, 300, 300]
+      })
+    })
+
+    await resolver.invalidateIfAssignedCellIsFar(CELL)
+
+    const selfHeal = events.find(
+      (event): event is RelayRegionSelfHealLogEvent => event.event === RELAY_REGION_SELF_HEAL_EVENT
+    )
+    expect(selfHeal).toEqual({
+      event: 'relay_region_self_heal',
+      directorHost: 'relay.example.test',
+      cachedRegion: 'us-central1',
+      bestRegion: 'asia-east2',
+      bestLatencyMs: 30,
+      assignedCellUrl: CELL,
+      assignedLatencyMs: 300,
+      decision: 'deleted',
+      reason: 'assigned-cell-far'
+    })
+  })
+
+  it('logs a kept cache when the assigned cell is not far from the best region', async () => {
+    const path = userDataPath()
+    writeCache(path, 'us-central1', 5_000)
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: sampledProbe({
+        [US]: [400, 300, 300, 300],
+        [ASIA]: [90, 200, 200, 200],
+        [CELL]: [400, 300, 300, 300]
+      })
+    })
+
+    await resolver.invalidateIfAssignedCellIsFar(CELL)
+
+    expect(events.at(-1)).toMatchObject({
+      event: 'relay_region_self_heal',
+      decision: 'kept',
+      reason: 'assigned-cell-near',
+      assignedLatencyMs: 300
+    })
+  })
+
+  it('stays silent when the self-heal probe cannot reach the catalog', async () => {
+    const path = userDataPath()
+    writeCache(path, 'us-central1', 5_000)
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: vi.fn<typeof globalThis.fetch>(async () => new Response('nope', { status: 503 }))
+    })
+
+    await resolver.invalidateIfAssignedCellIsFar(CELL)
+
+    // A self-heal that never chose a region must not log one withholding a hint.
+    expect(events).toEqual([])
+  })
+
+  it('emits one credential-free line per event', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {})
+
+    logRelayRegionEvent({
+      event: RELAY_REGION_PROBE_EVENT,
+      directorHost: 'relay.example.test',
+      regions: [
+        {
+          region: 'asia-east2',
+          origins: [ASIA],
+          warmupMs: [90],
+          keptMs: [30, 35, 40],
+          minMs: 30,
+          spreadMs: 10,
+          verdict: 'measured'
+        }
+      ],
+      chosenRegion: 'asia-east2',
+      reason: 'measured',
+      cached: false,
+      ttlMs: 1_000
+    })
+
+    expect(info).toHaveBeenCalledTimes(1)
+    const [tag, line] = info.mock.calls[0] as [string, string]
+    expect(tag).toBe('[relay-region]')
+    expect(line).not.toContain('\n')
+    expect(JSON.parse(line)).toMatchObject({ event: 'relay_region_probe' })
+    expect(line).not.toMatch(/token|jwt|secret|authorization|bearer|relayHostId|eyJ/i)
+  })
+})

--- a/src/main/runtime/relay/relay-region-probe-log.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.ts
@@ -1,0 +1,128 @@
+import { relayDirectorHost } from './relay-region-catalog-fetch'
+import type { RegionMeasurement, RelayRegion, RelayRegionProbeReport } from './relay-region-probe'
+
+export const RELAY_REGION_PROBE_EVENT = 'relay_region_probe'
+export const RELAY_REGION_SELF_HEAL_EVENT = 'relay_region_self_heal'
+
+/** Why the resolver ended up with the region it returned, or with no hint. */
+export type RelayRegionChoiceReason =
+  | 'measured'
+  | 'held-previous'
+  | 'sole-survivor-forbidden'
+  | 'all-unreachable'
+  | 'all-rejected'
+  | 'catalog-unavailable'
+  | 'override'
+  | 'cached'
+
+export type RelayRegionProbeLogEvent = {
+  event: typeof RELAY_REGION_PROBE_EVENT
+  directorHost: string
+  regions: RelayRegionProbeReport[]
+  chosenRegion: RelayRegion | 'no-hint'
+  reason: RelayRegionChoiceReason
+  cached: boolean
+  ttlMs: number
+}
+
+export type RelayRegionSelfHealDecision = 'kept' | 'deleted'
+
+export type RelayRegionSelfHealLogEvent = {
+  event: typeof RELAY_REGION_SELF_HEAL_EVENT
+  directorHost: string
+  cachedRegion: RelayRegion
+  bestRegion: RelayRegion | null
+  bestLatencyMs: number | null
+  assignedCellUrl: string
+  assignedLatencyMs: number | null
+  decision: RelayRegionSelfHealDecision
+  reason: 'best-matches-cache' | 'no-region-measured' | 'assigned-cell-near' | 'assigned-cell-far'
+}
+
+export type RelayRegionLogEvent = RelayRegionProbeLogEvent | RelayRegionSelfHealLogEvent
+export type RelayRegionLogSink = (event: RelayRegionLogEvent) => void
+
+// JSON rather than an object argument: Node pretty-prints nested objects across
+// many lines, and a support log census needs one grep-able line per event.
+export function logRelayRegionEvent(event: RelayRegionLogEvent): void {
+  console.info('[relay-region]', JSON.stringify(event))
+}
+
+export function relayRegionCacheHitEvent(input: {
+  directorUrl: string
+  region: RelayRegion | null
+  ttlMs: number
+}): RelayRegionProbeLogEvent {
+  return {
+    event: RELAY_REGION_PROBE_EVENT,
+    directorHost: relayDirectorHost(input.directorUrl),
+    regions: [],
+    chosenRegion: input.region ?? 'no-hint',
+    reason: 'cached',
+    cached: true,
+    ttlMs: input.ttlMs
+  }
+}
+
+export function relayRegionOverrideEvent(input: {
+  directorUrl: string
+  region: RelayRegion
+}): RelayRegionProbeLogEvent {
+  return {
+    event: RELAY_REGION_PROBE_EVENT,
+    directorHost: relayDirectorHost(input.directorUrl),
+    regions: [],
+    chosenRegion: input.region,
+    reason: 'override',
+    cached: false,
+    ttlMs: 0
+  }
+}
+
+export function relayRegionCatalogFailureEvent(directorUrl: string): RelayRegionProbeLogEvent {
+  return {
+    event: RELAY_REGION_PROBE_EVENT,
+    directorHost: relayDirectorHost(directorUrl),
+    regions: [],
+    chosenRegion: 'no-hint',
+    reason: 'catalog-unavailable',
+    cached: false,
+    ttlMs: 0
+  }
+}
+
+export function relayRegionRefreshEvent(input: {
+  directorUrl: string
+  reports: RelayRegionProbeReport[]
+  best: RegionMeasurement | null
+  selected: RegionMeasurement | null
+  ttlMs: number
+}): RelayRegionProbeLogEvent {
+  return {
+    event: RELAY_REGION_PROBE_EVENT,
+    directorHost: relayDirectorHost(input.directorUrl),
+    regions: input.reports,
+    chosenRegion: input.selected?.region ?? 'no-hint',
+    reason: refreshReason(input.reports, input.best, input.selected),
+    cached: false,
+    ttlMs: input.ttlMs
+  }
+}
+
+function refreshReason(
+  reports: RelayRegionProbeReport[],
+  best: RegionMeasurement | null,
+  selected: RegionMeasurement | null
+): RelayRegionChoiceReason {
+  if (selected) {
+    // The resolver keeps the incumbent unless a rival wins by a real margin, so
+    // a selection that is not the fastest reading is a deliberate hold.
+    return best && selected.region !== best.region ? 'held-previous' : 'measured'
+  }
+  if (reports.some((report) => report.verdict === 'measured')) {
+    return 'sole-survivor-forbidden'
+  }
+  return reports.every((report) => report.verdict === 'unreachable')
+    ? 'all-unreachable'
+    : 'all-rejected'
+}

--- a/src/main/runtime/relay/relay-region-probe.ts
+++ b/src/main/runtime/relay/relay-region-probe.ts
@@ -83,51 +83,77 @@ export async function probeRelayOrigin(
   }
 }
 
+type LatencySamples = {
+  /** Discarded first round per origin; it pays TCP and TLS setup. */
+  warmupMs: (number | null)[]
+  /** Ascending per-round minimums across the live origins; empty means unreachable. */
+  keptMs: number[]
+}
+
+export type RelayRegionProbeVerdict = 'measured' | 'rejected-spread' | 'unreachable'
+
+export type RelayRegionProbeReport = {
+  region: RelayRegion
+  origins: string[]
+  warmupMs: (number | null)[]
+  keptMs: number[]
+  minMs: number | null
+  spreadMs: number | null
+  verdict: RelayRegionProbeVerdict
+}
+
 // The first request of a process pays TCP and TLS setup, which can exceed the
 // round trip it is meant to measure, so it is discarded before sampling.
-async function sampleMinLatencies(origins: string[], probe: RelayProbe): Promise<number[] | null> {
-  const warmup = await Promise.all(origins.map(probe))
+async function sampleMinLatencies(origins: string[], probe: RelayProbe): Promise<LatencySamples> {
+  const warmupMs = await Promise.all(origins.map(probe))
   // An origin that failed its warm-up would spend one probe timeout per round
   // to report nothing, so the sampling rounds skip it entirely.
-  const live = origins.filter((_origin, index) => warmup[index] !== null)
+  const live = origins.filter((_origin, index) => warmupMs[index] !== null)
   if (live.length === 0) {
-    return null
+    return { warmupMs, keptMs: [] }
   }
-  const samples: number[] = []
+  const keptMs: number[] = []
   for (let sample = 0; sample < PROBE_SAMPLES; sample++) {
     const latencies = (await Promise.all(live.map(probe))).filter(
       (latency): latency is number => latency !== null
     )
     if (latencies.length === 0) {
-      return null
+      return { warmupMs, keptMs: [] }
     }
-    samples.push(Math.min(...latencies))
+    keptMs.push(Math.min(...latencies))
   }
-  return samples.sort((left, right) => left - right)
+  keptMs.sort((left, right) => left - right)
+  return { warmupMs, keptMs }
 }
 
 export async function measureOriginLatency(
   origin: string,
   probe: RelayProbe
 ): Promise<number | null> {
-  return (await sampleMinLatencies([origin], probe))?.[0] ?? null
+  return (await sampleMinLatencies([origin], probe)).keptMs[0] ?? null
 }
 
 export async function measureRegion(
   entry: RelayRegionCatalogEntry,
   probe: RelayProbe
-): Promise<RegionMeasurement | null> {
-  const samples = await sampleMinLatencies(entry.probeOrigins, probe)
-  if (!samples) {
-    return null
+): Promise<RelayRegionProbeReport> {
+  const { warmupMs, keptMs } = await sampleMinLatencies(entry.probeOrigins, probe)
+  const probed = { region: entry.region, origins: entry.probeOrigins, warmupMs, keptMs }
+  if (keptMs.length === 0) {
+    return { ...probed, minMs: null, spreadMs: null, verdict: 'unreachable' }
   }
-  const [min, median, max] = samples as [number, number, number]
+  const [min, median, max] = keptMs as [number, number, number]
+  const spreadMs = max - min
   // Regions compare by their best round trip; the spread check only rejects a
   // path that is genuinely flapping, not one that warmed up.
-  if (max - min > Math.max(SPREAD_FLOOR_MS, median)) {
-    return null
-  }
-  return { region: entry.region, latencyMs: min }
+  const verdict = spreadMs > Math.max(SPREAD_FLOOR_MS, median) ? 'rejected-spread' : 'measured'
+  return { ...probed, minMs: min, spreadMs, verdict }
+}
+
+export function regionMeasurement(report: RelayRegionProbeReport): RegionMeasurement | null {
+  return report.verdict === 'measured' && report.minMs !== null
+    ? { region: report.region, latencyMs: report.minMs }
+    : null
 }
 
 function isCanonicalHttpsOrigin(value: string): boolean {

--- a/src/main/runtime/relay/relay-session-broker-contract.ts
+++ b/src/main/runtime/relay/relay-session-broker-contract.ts
@@ -24,7 +24,8 @@ export type RelaySessionBrokerOptions = {
   refreshAccessToken: () => Promise<string | null>
   resolvePreferredRegion?: () => Promise<RelayRegion | undefined>
   onAssignedCellActive?: (cellUrl: string) => void
-  onStatus: (status: RelayBrokerStatus) => void
+  /** `cellUrl` is absent whenever the host holds no active assignment. */
+  onStatus: (status: RelayBrokerStatus, cellUrl?: string) => void
   fetch?: typeof globalThis.fetch
   createControlSocket?: (url: string, relayJwt: string) => WebSocket
   createDataSocket?: (url: string) => WebSocket

--- a/src/main/runtime/relay/relay-session-broker.test.ts
+++ b/src/main/runtime/relay/relay-session-broker.test.ts
@@ -111,6 +111,26 @@ describe('RelaySessionBroker lifecycle ownership', () => {
     })
   })
 
+  it('publishes the assigned cell with the status and drops it on close', async () => {
+    fakes.controlConnect.mockResolvedValue({
+      type: 'host-hello-ack',
+      v: 1,
+      generation: 1,
+      controlResumeSecret: 'A'.repeat(43),
+      leaseExpiresAt: 1_000_000,
+      activeConnIds: [],
+      pendingConns: []
+    } satisfies RelayHostHelloAckMessage)
+    const onStatus = vi.fn()
+
+    const broker = await RelaySessionBroker.connect(brokerOptions({ onStatus }))
+
+    expect(onStatus.mock.calls).toContainEqual(['connecting', undefined])
+    expect(onStatus).toHaveBeenLastCalledWith('registered', 'https://relay.example.test')
+    broker.closeNow()
+    expect(onStatus).toHaveBeenLastCalledWith('offline')
+  })
+
   it('closes partially opened resources without publishing stale state', async () => {
     const controlAck = deferred<RelayHostHelloAckMessage>()
     fakes.controlConnect.mockReturnValue(controlAck.promise)
@@ -387,7 +407,9 @@ describe('RelaySessionBroker lifecycle ownership', () => {
     expect(fakes.controls[2]!.options.previousGeneration).toBeUndefined()
     expect(fakes.controls[2]!.options.controlResumeSecret).toBeUndefined()
     expect(fakes.transports).toHaveLength(2)
-    await vi.waitFor(() => expect(onStatus).toHaveBeenLastCalledWith('registered'))
+    await vi.waitFor(() =>
+      expect(onStatus).toHaveBeenLastCalledWith('registered', 'https://relay.example.test')
+    )
     expect(broker.endpoint?.cellUrl).toBe('https://relay.example.test')
   })
 

--- a/src/main/runtime/relay/relay-session-broker.test.ts
+++ b/src/main/runtime/relay/relay-session-broker.test.ts
@@ -127,6 +127,13 @@ describe('RelaySessionBroker lifecycle ownership', () => {
 
     expect(onStatus.mock.calls).toContainEqual(['connecting', undefined])
     expect(onStatus).toHaveBeenLastCalledWith('registered', 'https://relay.example.test')
+
+    // Why: the pool publishes offline while it still holds the assignment it is
+    // about to rotate; forwarding that cell leaves the UI naming a dead one.
+    fakes.controls[0]!.options.onClose(1006)
+    expect(onStatus.mock.calls).toContainEqual(['offline', undefined])
+    expect(onStatus.mock.calls).toContainEqual(['draining', 'https://relay.example.test'])
+
     broker.closeNow()
     expect(onStatus).toHaveBeenLastCalledWith('offline')
   })

--- a/src/main/runtime/relay/relay-session-broker.ts
+++ b/src/main/runtime/relay/relay-session-broker.ts
@@ -296,8 +296,8 @@ export class RelaySessionBroker {
     if (!this.isCurrent()) {
       return
     }
-    this.options.onStatus(status)
     const cellUrl = this.originPool.activeAssignment?.cellUrl
+    this.options.onStatus(status, cellUrl)
     if (status === 'registered' && cellUrl) {
       // Fire-and-forget: the listener may probe this cell, and nothing about the
       // live session is allowed to wait on that.

--- a/src/main/runtime/relay/relay-session-broker.ts
+++ b/src/main/runtime/relay/relay-session-broker.ts
@@ -1,3 +1,4 @@
+import { relayStatusCellUrl } from '../../../shared/mobile-relay-status'
 import type { PairingRelay } from '../../../shared/mobile-relay-pairing-offer'
 import type {
   DeviceCredentialInstalled,
@@ -297,7 +298,7 @@ export class RelaySessionBroker {
       return
     }
     const cellUrl = this.originPool.activeAssignment?.cellUrl
-    this.options.onStatus(status, cellUrl)
+    this.options.onStatus(status, relayStatusCellUrl(status, cellUrl))
     if (status === 'registered' && cellUrl) {
       // Fire-and-forget: the listener may probe this cell, and nothing about the
       // live session is allowed to wait on that.

--- a/src/main/startup/main-process-runtime-launch.ts
+++ b/src/main/startup/main-process-runtime-launch.ts
@@ -13,6 +13,7 @@ import { LocalPtyProvider } from '../providers/local-pty-provider'
 import { HEADLESS_RUNTIME_WINDOW_ID } from '../../shared/runtime-types'
 import { OffscreenBrowserBackend } from '../browser/offscreen-browser-backend'
 import { browserManager } from '../browser/browser-manager'
+import type { MobileRelayStatusDetail } from '../../shared/mobile-relay-status'
 import { DesktopRelayService } from '../runtime/relay/desktop-relay-service'
 import { getServeOptions, getBundledWebClientRoot, printServeReady } from './main-process-serve'
 import {
@@ -91,7 +92,10 @@ function installRuntimeRpc(
   })
   state.runtimeRpc = runtimeRpc
   registerMobileHandlers(runtimeRpc, {
-    getRelayStatus: () => state.desktopRelayStatus,
+    getRelayStatus: () => ({
+      status: state.desktopRelayStatus,
+      ...(state.desktopRelayCellUrl === undefined ? {} : { cellUrl: state.desktopRelayCellUrl })
+    }),
     consumePendingUnpairedDeviceAuthFailure: (webContentsId) => {
       if (
         !state.mainWindow ||
@@ -249,9 +253,13 @@ async function launchDesktopMode(
         userDataPath: getProfileUserDataPath(),
         appVersion: app.getVersion(),
         runtimeRpc,
-        onStatus: (status) => {
+        onStatus: (status, cellUrl) => {
           state.desktopRelayStatus = status
-          state.mainWindow?.webContents.send('mobile:relayStatusChanged', status)
+          state.desktopRelayCellUrl = cellUrl
+          state.mainWindow?.webContents.send('mobile:relayStatusChanged', {
+            status,
+            ...(cellUrl === undefined ? {} : { cellUrl })
+          } satisfies MobileRelayStatusDetail)
         }
       })
       state.desktopRelayService = relayService

--- a/src/main/startup/main-process-state.ts
+++ b/src/main/startup/main-process-state.ts
@@ -66,6 +66,7 @@ export const mainProcessState = {
   serveReadinessPublisher: new ServeReadinessPublisher(),
   desktopRelayService: null as DesktopRelayService | null,
   desktopRelayStatus: 'offline' as RelayBrokerStatus,
+  desktopRelayCellUrl: undefined as string | undefined,
   pendingUnpairedDeviceAuthFailure: false,
   // Why: gates whether headless serve installs the offscreen browser backend (and advertises browser pane support).
   headlessBrowserDisplayAvailable: false,

--- a/src/preload/api/mobile-api.ts
+++ b/src/preload/api/mobile-api.ts
@@ -1,4 +1,4 @@
-import type { MobileRelayStatus } from '../../shared/mobile-relay-status'
+import type { MobileRelayStatusDetail } from '../../shared/mobile-relay-status'
 import type { MobilePairingConnectionMode } from '../../shared/mobile-pairing-connection-mode'
 import type { RuntimePairingReach } from '../../shared/runtime-pairing-reach'
 import type { MobileRelayMintFailure } from '../../shared/mobile-relay-mint-failure'
@@ -79,8 +79,8 @@ export type MobileApi = {
   listRuntimeAccessGrants: () => Promise<{ grants: RuntimeAccessGrant[] }>
   revokeRuntimeAccess: (args: { deviceId: string }) => Promise<{ revoked: boolean }>
   isWebSocketReady: () => Promise<{ ready: boolean; endpoint: string | null }>
-  getRelayStatus: () => Promise<{ status: MobileRelayStatus }>
-  onRelayStatusChanged: (callback: (status: MobileRelayStatus) => void) => () => void
+  getRelayStatus: () => Promise<MobileRelayStatusDetail>
+  onRelayStatusChanged: (callback: (detail: MobileRelayStatusDetail) => void) => () => void
   /** Consumes an auth-failure notification that arrived before the renderer listener mounted. */
   consumePendingUnpairedDeviceAuthFailure?: () => Promise<boolean>
   /** Fires (throttled, once per session) when an unpaired phone repeatedly fails direct-transport auth. */

--- a/src/preload/api/mobile-bridge.ts
+++ b/src/preload/api/mobile-bridge.ts
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron'
-import type { MobileRelayStatus } from '../../shared/mobile-relay-status'
+import type { MobileRelayStatusDetail } from '../../shared/mobile-relay-status'
 import type { MobilePairingConnectionMode } from '../../shared/mobile-pairing-connection-mode'
 import type { RuntimePairingReach } from '../../shared/runtime-pairing-reach'
 import type { MobileRelayMintFailure } from '../../shared/mobile-relay-mint-failure'
@@ -74,12 +74,12 @@ export const mobileApi = {
   isWebSocketReady: (): Promise<{ ready: boolean; endpoint: string | null }> =>
     ipcRenderer.invoke('mobile:isWebSocketReady'),
 
-  getRelayStatus: (): Promise<{ status: MobileRelayStatus }> =>
+  getRelayStatus: (): Promise<MobileRelayStatusDetail> =>
     ipcRenderer.invoke('mobile:getRelayStatus'),
 
-  onRelayStatusChanged: (callback: (status: MobileRelayStatus) => void): (() => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, status: MobileRelayStatus) =>
-      callback(status)
+  onRelayStatusChanged: (callback: (detail: MobileRelayStatusDetail) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, detail: MobileRelayStatusDetail) =>
+      callback(detail)
     ipcRenderer.on('mobile:relayStatusChanged', listener)
     return () => ipcRenderer.removeListener('mobile:relayStatusChanged', listener)
   },

--- a/src/renderer/src/components/settings/MobilePairingConnectionOptions.test.tsx
+++ b/src/renderer/src/components/settings/MobilePairingConnectionOptions.test.tsx
@@ -6,7 +6,7 @@ import { StrictMode, useSyncExternalStore } from 'react'
 import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { MobileRelayStatus } from '../../../../shared/mobile-relay-status'
+import type { MobileRelayStatusDetail } from '../../../../shared/mobile-relay-status'
 import type { OrcaProfileAuthStatus } from '../../../../shared/orca-profiles'
 import { MobilePairingConnectionOptions } from './MobilePairingConnectionOptions'
 
@@ -45,7 +45,7 @@ vi.mock('../../i18n/i18n', () => ({
 }))
 
 describe('MobilePairingConnectionOptions', () => {
-  let statusListener: ((status: MobileRelayStatus) => void) | null
+  let statusListener: ((detail: MobileRelayStatusDetail) => void) | null
   const connect = vi.fn().mockResolvedValue(null)
   const fetchAuthStatus = vi.fn().mockResolvedValue(null)
 
@@ -58,7 +58,7 @@ describe('MobilePairingConnectionOptions', () => {
       value: {
         mobile: {
           getRelayStatus: vi.fn().mockResolvedValue({ status: 'registered' }),
-          onRelayStatusChanged: vi.fn((listener: (status: MobileRelayStatus) => void) => {
+          onRelayStatusChanged: vi.fn((listener: (detail: MobileRelayStatusDetail) => void) => {
             statusListener = listener
             return vi.fn()
           })
@@ -235,7 +235,35 @@ describe('MobilePairingConnectionOptions', () => {
 
     await user.click(screen.getByRole('radio', { name: /^LAN\b/i }))
     expect(onChange).toHaveBeenCalledWith('local-only')
-    statusListener?.('standby')
+    statusListener?.({ status: 'standby' })
+  })
+
+  it('names the assigned relay cell by host once the status carries one', async () => {
+    mocks.state = {
+      ...mocks.state,
+      orcaProfileAuthStatus: {
+        activeProfileId: 'profile-1',
+        configured: true,
+        state: 'connected',
+        persistence: 'encrypted'
+      }
+    }
+    render(<MobilePairingConnectionOptions value="automatic" onChange={vi.fn()} />)
+
+    expect(screen.queryByTestId('relay-cell-line')).toBeNull()
+
+    statusListener?.({ status: 'registered', cellUrl: 'https://c27.relay.example.test' })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('relay-cell-line')).toHaveTextContent(
+        'Relay cell: c27.relay.example.test'
+      )
+    )
+    // Why: the line is a diagnostic, not an option; it must not join the group.
+    expect(within(screen.getByRole('radiogroup')).getAllByRole('radio')).toHaveLength(2)
+
+    statusListener?.({ status: 'offline' })
+    await waitFor(() => expect(screen.queryByTestId('relay-cell-line')).toBeNull())
   })
 
   it('keeps LAN available while Relay is retrying', async () => {

--- a/src/renderer/src/components/settings/MobilePairingConnectionOptions.tsx
+++ b/src/renderer/src/components/settings/MobilePairingConnectionOptions.tsx
@@ -6,7 +6,10 @@ import { translate } from '../../i18n/i18n'
 import { useAppStore } from '../../store'
 import { useOrcaProfileAuthStatusRefresh } from '@/hooks/use-orca-profile-auth-status-refresh'
 import { cn } from '@/lib/utils'
-import type { MobileRelayStatus } from '../../../../shared/mobile-relay-status'
+import type {
+  MobileRelayStatus,
+  MobileRelayStatusDetail
+} from '../../../../shared/mobile-relay-status'
 import type { MobilePairingConnectionMode } from '../../../../shared/mobile-pairing-connection-mode'
 import { MobilePairingPathOption } from './MobilePairingPathOption'
 
@@ -38,6 +41,16 @@ function relayStatusLabel(status: MobileRelayStatus): string {
   )
 }
 
+// Support needs the cell a slow session actually landed on; the scheme adds
+// nothing a reader can act on, so only the host is shown.
+function relayCellLabel(cellUrl: string): string | null {
+  try {
+    return new URL(cellUrl).host || null
+  } catch {
+    return null
+  }
+}
+
 export function MobilePairingConnectionOptions({
   value,
   onChange,
@@ -56,6 +69,7 @@ export function MobilePairingConnectionOptions({
   const connecting = useAppStore((state) => state.orcaProfileConnecting)
   const connect = useAppStore((state) => state.connectCurrentOrcaProfile)
   const [relayStatus, setRelayStatus] = useState<MobileRelayStatus>('offline')
+  const [relayCellUrl, setRelayCellUrl] = useState<string | undefined>(undefined)
   const signedIn = authStatus?.state === 'connected'
   const reconnectRequired = authStatus?.state === 'reconnect-required'
   // Why: an unconfigured build has no Relay endpoint to sign into, so a Sign in
@@ -93,22 +107,28 @@ export function MobilePairingConnectionOptions({
     optionRefs.current[next]?.focus()
   }
 
+  const relayCell = relayCellUrl ? relayCellLabel(relayCellUrl) : null
+
   useOrcaProfileAuthStatusRefresh()
 
   useEffect(() => {
     let receivedEvent = false
     let active = true
-    const unsubscribe = window.api.mobile.onRelayStatusChanged((status) => {
+    const apply = (detail: MobileRelayStatusDetail): void => {
+      setRelayStatus(detail.status)
+      setRelayCellUrl(detail.cellUrl)
+    }
+    const unsubscribe = window.api.mobile.onRelayStatusChanged((detail) => {
       receivedEvent = true
       if (active) {
-        setRelayStatus(status)
+        apply(detail)
       }
     })
     void window.api.mobile
       .getRelayStatus()
-      .then(({ status }) => {
+      .then((detail) => {
         if (active && !receivedEvent) {
-          setRelayStatus(status)
+          apply(detail)
         }
       })
       .catch(() => {})
@@ -225,6 +245,18 @@ export function MobilePairingConnectionOptions({
                   )}
             </Button>
           </div>
+        ) : null}
+        {value === 'automatic' && relayCell ? (
+          <p
+            className="border-t border-border/60 py-2 pl-10 pr-3 text-xs text-muted-foreground"
+            data-testid="relay-cell-line"
+          >
+            {translate(
+              'auto.components.settings.MobilePairingConnectionOptions.relayCell',
+              'Relay cell'
+            )}
+            {`: ${relayCell}`}
+          </p>
         ) : null}
         <div className="border-t border-border" />
         <MobilePairingPathOption

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11100,7 +11100,8 @@
           "signInAgain": "Sign in again for Relay",
           "localTitle": "LAN",
           "localDescription": "Phone must be on this Wi‑Fi or connected through Tailscale. No account needed.",
-          "retrying": "Retrying"
+          "retrying": "Retrying",
+          "relayCell": "Relay cell"
         },
         "MobilePairingSetupSection": {
           "title": "Pair a phone",

--- a/src/shared/mobile-relay-status.ts
+++ b/src/shared/mobile-relay-status.ts
@@ -7,3 +7,13 @@ export const MOBILE_RELAY_STATUSES = [
 ] as const
 
 export type MobileRelayStatus = (typeof MOBILE_RELAY_STATUSES)[number]
+
+/**
+ * Relay status plus the assignment behind it. `cellUrl` is optional because the
+ * host holds no assignment while offline, and because paired web clients answer
+ * this call from a local stub that never has one.
+ */
+export type MobileRelayStatusDetail = {
+  status: MobileRelayStatus
+  cellUrl?: string
+}

--- a/src/shared/mobile-relay-status.ts
+++ b/src/shared/mobile-relay-status.ts
@@ -17,3 +17,15 @@ export type MobileRelayStatusDetail = {
   status: MobileRelayStatus
   cellUrl?: string
 }
+
+// A cell only describes a host that is actually reachable on it. A connecting or
+// offline host can still hold the assignment object it is about to reuse, and
+// forwarding that leaves the UI naming a cell nothing is being served from.
+const STATUSES_SERVED_FROM_A_CELL: readonly MobileRelayStatus[] = ['registered', 'draining']
+
+export function relayStatusCellUrl(
+  status: MobileRelayStatus,
+  cellUrl: string | undefined
+): string | undefined {
+  return cellUrl !== undefined && STATUSES_SERVED_FROM_A_CELL.includes(status) ? cellUrl : undefined
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​482 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​476 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​440 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​121 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 |

<!-- /orca-pr-loc -->

## Stacked on #19233

Base is `relay/region-probe-warm-up`. Retarget to `main` after #19233 merges.

## Why

A desktop silently picked a far relay region for a day and every phone connect paid ~10 s. Nothing in the desktop logs said which regions were probed, what the samples were, why a region was rejected, or which cell the host ended up on. Diagnosing it took a bench harness.

## What

- One-line `[relay-region]` JSON events in the main process:
  - `relay_region_probe` per refresh: per region the origins, discarded warm-up sample, kept samples, min, spread, verdict (`measured` / `rejected-spread` / `unreachable`), then the chosen region or no hint with a reason (`measured`, `held-previous`, `sole-survivor-forbidden`, `all-rejected`, `all-unreachable`, `catalog-unavailable`, `override`, `cached`), whether the outcome was cached, and its TTL.
  - `relay_region_self_heal` per check: cached region, best measured region and latency, assigned cell URL and latency, decision, reason.
- `MobileRelayStatusDetail.cellUrl` (optional) on the relay status IPC, rendered in the pairing panel as a muted line. A shared rule keeps the cell only for `registered` and `draining`, applied in the broker and the auth coordinator so an offline or reconnecting status never shows a stale cell.
- Catalog fetching moved into `relay-region-catalog-fetch.ts` (max-lines).

No secrets reach either log line: fields are hostnames, catalog-validated origins, region names, latencies, enums, booleans. The status payload travels only over Electron IPC (main, preload, renderer ship together); the event shape changed from a bare string to an object, so do not cherry-pick one half.

## Verification

- `pnpm tc` (node, cli, web), relay + mobile IPC + panel tests (18 files, 199 tests), `check:code-quality:changed` 0 across 21 files, react-doctor 0 new, oxlint clean, no max-lines disables.
- Independent adversarial review: lane A selection, cache, and self-heal behaviour byte-equivalent by replay; log cardinality one event per refresh / per check; the nit round found and fixed a second publisher that would have blanked the cell in the real flow.

Not for merge until the owner gives the go.