### PR TITLE
fix(relay): rehome hosts to their preferred region in either direction

### DIFF
--- a/.github/workflows/cloud-operate-relay-production-rehome-job.yml
+++ b/.github/workflows/cloud-operate-relay-production-rehome-job.yml
@@ -14,6 +14,7 @@ on:
       not-before: { required: true, type: string }
       rate-per-minute: { required: true, type: string }
       preference-max-age-ms: { required: true, type: string }
+      host-cooldown-ms: { required: true, type: string }
       drain-grace-ms: { required: true, type: string }
       confirmation: { required: true, type: string }
       monitor-run-id: { required: true, type: string }
@@ -54,6 +55,7 @@ jobs:
       NOT_BEFORE: ${{ inputs.not-before }}
       RATE_PER_MINUTE: ${{ inputs.rate-per-minute }}
       PREFERENCE_MAX_AGE_MS: ${{ inputs.preference-max-age-ms }}
+      HOST_COOLDOWN_MS: ${{ inputs.host-cooldown-ms }}
       DRAIN_GRACE_MS: ${{ inputs.drain-grace-ms }}
       CONFIRMATION: ${{ inputs.confirmation }}
       MONITOR_RUN_ID: ${{ inputs.monitor-run-id }}
@@ -128,6 +130,7 @@ jobs:
             --expected-control-generation "${EXPECTED_CONTROL_GENERATION}" \
             --not-before "${NOT_BEFORE}" --rate-per-minute "${RATE_PER_MINUTE}" \
             --preference-max-age-ms "${PREFERENCE_MAX_AGE_MS}" \
+            --host-cooldown-ms "${HOST_COOLDOWN_MS}" \
             --drain-grace-ms "${DRAIN_GRACE_MS}" --confirmation "${CONFIRMATION}" \
             | tee "${RUNNER_TEMP}/relay-rehome-control.json"
 
@@ -299,6 +302,7 @@ jobs:
             --expected-control-generation "${EXPECTED_CONTROL_GENERATION}" \
             --not-before "${NOT_BEFORE}" --rate-per-minute "${RATE_PER_MINUTE}" \
             --preference-max-age-ms "${PREFERENCE_MAX_AGE_MS}" \
+            --host-cooldown-ms "${HOST_COOLDOWN_MS}" \
             --drain-grace-ms "${DRAIN_GRACE_MS}" --confirmation "${CONFIRMATION}" \
             | tee "${RUNNER_TEMP}/relay-rehome-control.json"
 

--- a/.github/workflows/cloud-operate-relay-production-rehome.yml
+++ b/.github/workflows/cloud-operate-relay-production-rehome.yml
@@ -52,6 +52,11 @@ on:
         required: true
         default: '86400000'
         type: string
+      host-cooldown-ms:
+        description: Minimum gap between two rehomes of the same host
+        required: true
+        default: '604800000'
+        type: string
       drain-grace-ms:
         description: Per-host source drain grace
         required: true
@@ -99,6 +104,7 @@ jobs:
       not-before: ${{ inputs.not-before }}
       rate-per-minute: ${{ inputs.rate-per-minute }}
       preference-max-age-ms: ${{ inputs.preference-max-age-ms }}
+      host-cooldown-ms: ${{ inputs.host-cooldown-ms }}
       drain-grace-ms: ${{ inputs.drain-grace-ms }}
       confirmation: ${{ inputs.confirmation }}
       monitor-run-id: ${{ inputs.monitor-run-id }}

--- a/cloud/apps/relay/src/app.ts
+++ b/cloud/apps/relay/src/app.ts
@@ -1413,6 +1413,11 @@ const RegionalRehomeControlSchema = z.discriminatedUnion('action', [
       .int()
       .min(60_000)
       .max(30 * 24 * 60 * 60_000),
+    hostCooldownMs: z
+      .number()
+      .int()
+      .min(60_000)
+      .max(30 * 24 * 60 * 60_000),
     drainGraceMs: z.number().int().min(60_000).max(60 * 60_000),
     confirmation: z.enum([
       'ENABLE_REGIONAL_REHOMING',

--- a/cloud/apps/relay/src/app.ts
+++ b/cloud/apps/relay/src/app.ts
@@ -606,8 +606,9 @@ export function createRelayApp(
       const source = await operations.assignments.cellDeploymentStatus(
         body.data.sourceCellId
       )
+      // Any cell that can be drained can be a rehome source, in either
+      // direction, so the probe is gated on the protocol and not on a region.
       if (
-        source.region !== RELAY_DEFAULT_REGION ||
         !source.runtime ||
         source.runtime.cellIncarnation !== body.data.sourceCellIncarnation ||
         !source.runtime.ready ||

--- a/cloud/apps/relay/src/assignment-inventory-snapshot.ts
+++ b/cloud/apps/relay/src/assignment-inventory-snapshot.ts
@@ -1,3 +1,4 @@
+import { RELAY_DEFAULT_REGION } from '@orca-cloud/relay-contract'
 import type { RelayDatabase, SqlRow } from './database.js'
 
 export type CellInventorySnapshotRow = {
@@ -92,7 +93,7 @@ export async function readAssignmentInventorySnapshot(
   return {
     cells: cellRows.map((row) => ({
       cellId: asText(row, 'cell_id'),
-      region: optionalText(row, 'region') ?? 'us-central1',
+      region: optionalText(row, 'region') ?? RELAY_DEFAULT_REGION,
       admissionState: optionalText(row, 'admission_state') ?? 'unset',
       enabled: asInteger(row, 'enabled') === 1,
       capacityRequests: asInteger(row, 'capacity_requests'),

--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -30,6 +30,9 @@ import {
   ASSIGNMENT_CONNECTION_HEADROOM_QUERY
 } from './assignment-connection-headroom-query.js'
 import { AssignmentIdentityQueue } from './assignment-identity-queue.js'
+import {
+  REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS
+} from './database.js'
 import type { RelayCellConfig } from './config.js'
 import type {
   RelayDatabase,
@@ -151,6 +154,7 @@ export type RegionalRehomeControl = {
   notBefore: number
   ratePerMinute: number
   preferenceMaxAgeMs: number
+  hostCooldownMs: number
   drainGraceMs: number
 }
 
@@ -4921,6 +4925,7 @@ export class RelayAssignmentStore {
     notBefore: number
     ratePerMinute: number
     preferenceMaxAgeMs: number
+    hostCooldownMs: number
     drainGraceMs: number
   }): Promise<RegionalRehomeControl> {
     if (!Number.isSafeInteger(input.expectedGeneration) || input.expectedGeneration < 0) {
@@ -4938,6 +4943,13 @@ export class RelayAssignmentStore {
       input.preferenceMaxAgeMs > 30 * 24 * 60 * 60_000
     ) {
       throw new Error('invalid_regional_rehome_preference_age')
+    }
+    if (
+      !Number.isSafeInteger(input.hostCooldownMs) ||
+      input.hostCooldownMs < 60_000 ||
+      input.hostCooldownMs > 30 * 24 * 60 * 60_000
+    ) {
+      throw new Error('invalid_regional_rehome_host_cooldown')
     }
     if (
       !Number.isSafeInteger(input.drainGraceMs) ||
@@ -4967,14 +4979,15 @@ export class RelayAssignmentStore {
       await transaction.query(
         `UPDATE relay_region_rehome_control
          SET generation = generation + 1, enabled = ?, not_before = ?,
-             rate_per_minute = ?, preference_max_age_ms = ?, drain_grace_ms = ?,
-             updated_at = ?
+             rate_per_minute = ?, preference_max_age_ms = ?, host_cooldown_ms = ?,
+             drain_grace_ms = ?, updated_at = ?
          WHERE control_id = 'global'`,
         [
           input.enabled ? 1 : 0,
           input.notBefore,
           input.ratePerMinute,
           input.preferenceMaxAgeMs,
+          input.hostCooldownMs,
           input.drainGraceMs,
           now
         ]
@@ -5006,10 +5019,17 @@ export class RelayAssignmentStore {
     await database.query(
       `INSERT INTO relay_region_rehome_control
        (control_id, generation, enabled, observation_started_at, not_before,
-        rate_per_minute, preference_max_age_ms, drain_grace_ms, updated_at)
-       VALUES ('global', 0, 0, ?, 0, 10, ?, ?, ?)
+        rate_per_minute, preference_max_age_ms, host_cooldown_ms, drain_grace_ms,
+        updated_at)
+       VALUES ('global', 0, 0, ?, 0, 10, ?, ?, ?, ?)
        ON CONFLICT (control_id) DO NOTHING`,
-      [now, 24 * 60 * 60_000, 60 * 60_000, now]
+      [
+        now,
+        24 * 60 * 60_000,
+        REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS,
+        60 * 60_000,
+        now
+      ]
     )
   }
 
@@ -5119,6 +5139,10 @@ export class RelayAssignmentStore {
       }
       const intervalMs = Math.ceil(60_000 / integer(control, 'rate_per_minute'))
       const preferenceCutoff = now - integer(control, 'preference_max_age_ms')
+      // A host that was rehomed recently is left alone whichever way its
+      // preference now points: a flapping region probe must not walk one host
+      // back and forth across an ocean.
+      const cooldownCutoff = now - integer(control, 'host_cooldown_ms')
       await transaction.query(
         `INSERT INTO relay_region_rehome_worker_state
          (worker_id, next_dispatch_at, paused_until, consecutive_failures, updated_at)
@@ -5305,8 +5329,15 @@ export class RelayAssignmentStore {
                AND migration.relay_host_id = assignment.relay_host_id
                AND migration.completed_at IS NULL AND migration.aborted_at IS NULL
            )
+           AND NOT EXISTS (
+             SELECT 1 FROM relay_region_rehome_attempts recent
+             WHERE recent.user_id = preference.user_id
+               AND recent.relay_host_id = preference.relay_host_id
+               AND recent.created_at > ?
+           )
            AND EXISTS (
              SELECT 1 FROM relay_cell_regions target_region
+             JOIN relay_cells target_cell ON target_cell.cell_id = target_region.cell_id
              JOIN relay_cell_admission target_admission
                ON target_admission.cell_id = target_region.cell_id
              JOIN relay_cell_runtime target_runtime
@@ -5315,6 +5346,7 @@ export class RelayAssignmentStore {
                ON target_capability.cell_id = target_runtime.cell_id
               AND target_capability.cell_incarnation = target_runtime.cell_incarnation
              WHERE target_region.region = preference.preferred_region
+               AND target_cell.enabled = 1
                AND target_admission.admission_state = 'general'
                AND target_runtime.ready = 1
                AND target_runtime.last_heartbeat_at > ?
@@ -5322,7 +5354,13 @@ export class RelayAssignmentStore {
            )
          ORDER BY preference.observed_at, preference.user_id, preference.relay_host_id
          LIMIT 10`,
-        [preferenceCutoff, now - this.heartbeatTtlMs, now, now - this.heartbeatTtlMs]
+        [
+          preferenceCutoff,
+          now - this.heartbeatTtlMs,
+          now,
+          cooldownCutoff,
+          now - this.heartbeatTtlMs
+        ]
       )
       candidatesTotal = candidates.length
       for (const candidate of candidates) {
@@ -5334,6 +5372,7 @@ export class RelayAssignmentStore {
           sourceCellId: text(candidate, 'source_cell_id'),
           assignmentEpoch: integer(candidate, 'assignment_epoch'),
           preferenceCutoff,
+          cooldownCutoff,
           drainGraceMs: integer(control, 'drain_grace_ms'),
           processSafety: effectiveProcessSafety,
           worker,
@@ -5388,6 +5427,7 @@ export class RelayAssignmentStore {
       sourceCellId: string
       assignmentEpoch: number
       preferenceCutoff: number
+      cooldownCutoff: number
       drainGraceMs: number
       processSafety: RegionalRehomeSafetySnapshot
       worker: SqlRow
@@ -5424,6 +5464,18 @@ export class RelayAssignmentStore {
     )
     if (activeMigration.length > 0) {
       input.skips.push({ reason: 'candidate_stale' })
+      return null
+    }
+    // Re-read under the claim: an attempt committed between the scan and here
+    // would otherwise start a second move for the same host.
+    const recentAttempt = await transaction.query(
+      `SELECT 1 FROM relay_region_rehome_attempts
+       WHERE user_id = ? AND relay_host_id = ? AND created_at > ?
+       LIMIT 1`,
+      [input.identity.userId, input.identity.relayHostId, input.cooldownCutoff]
+    )
+    if (recentAttempt.length > 0) {
+      input.skips.push({ reason: 'host_cooldown' })
       return null
     }
     const activityLeases = await this.lockAssignmentActivities(transaction, input.identity)
@@ -8148,6 +8200,7 @@ function regionalRehomeControl(row: SqlRow): RegionalRehomeControl {
     notBefore: integer(row, 'not_before'),
     ratePerMinute: integer(row, 'rate_per_minute'),
     preferenceMaxAgeMs: integer(row, 'preference_max_age_ms'),
+    hostCooldownMs: integer(row, 'host_cooldown_ms'),
     drainGraceMs: integer(row, 'drain_grace_ms')
   }
 }
@@ -8256,6 +8309,7 @@ function regionalRehomeFleetSafetyFailure(
 type RegionalRehomeCandidateSkip = {
   reason:
     | 'candidate_stale'
+    | 'host_cooldown'
     | 'source_ineligible'
     | 'source_unclean'
     | 'source_control_inactive'

--- a/cloud/apps/relay/src/assignment-store.ts
+++ b/cloud/apps/relay/src/assignment-store.ts
@@ -121,7 +121,7 @@ export type RelayAssignmentMigration = AssignmentIdentity & {
 
 export type RegionalRehomeAttempt = AssignmentIdentity & {
   attemptId: string
-  preferredRegion: 'asia-east2'
+  preferredRegion: RelayRegion
   sourceCellId: string
   sourceCellUrl: string
   sourceCellIncarnation: string
@@ -5017,6 +5017,9 @@ export class RelayAssignmentStore {
     return await this.readRegionalRehomeFleetSafety(this.database, this.now())
   }
 
+  // The rehome fleet is every general cell that can be drained: those are the
+  // sources and, because a host must be movable back out again, the only legal
+  // targets. The region join stays so a cell with no region row is excluded.
   private async readRegionalRehomeFleetSafety(
     database: RelayDatabase,
     now: number
@@ -5037,10 +5040,7 @@ export class RelayAssignmentStore {
          ON safety.cell_id = runtime.cell_id
         AND safety.cell_incarnation = runtime.cell_incarnation
        WHERE cell.enabled = 1 AND admission.admission_state = 'general'
-         AND (
-           region.region = 'asia-east2' OR
-           (region.region = 'us-central1' AND capability.regional_rehome_protocol >= 1)
-         )`
+         AND capability.regional_rehome_protocol >= 1`
     )
     const valid = rows.filter(
       (row) =>
@@ -5284,9 +5284,8 @@ export class RelayAssignmentStore {
          JOIN relay_cell_capabilities capability
            ON capability.cell_id = runtime.cell_id
           AND capability.cell_incarnation = runtime.cell_incarnation
-         WHERE preference.preferred_region = 'asia-east2'
+         WHERE preference.preferred_region <> region.region
            AND preference.observed_at >= ?
-           AND region.region = 'us-central1'
            AND admission.admission_state = 'general'
            AND runtime.ready = 1 AND runtime.last_heartbeat_at > ?
            AND capability.regional_rehome_protocol >= 1
@@ -5306,9 +5305,24 @@ export class RelayAssignmentStore {
                AND migration.relay_host_id = assignment.relay_host_id
                AND migration.completed_at IS NULL AND migration.aborted_at IS NULL
            )
+           AND EXISTS (
+             SELECT 1 FROM relay_cell_regions target_region
+             JOIN relay_cell_admission target_admission
+               ON target_admission.cell_id = target_region.cell_id
+             JOIN relay_cell_runtime target_runtime
+               ON target_runtime.cell_id = target_region.cell_id
+             JOIN relay_cell_capabilities target_capability
+               ON target_capability.cell_id = target_runtime.cell_id
+              AND target_capability.cell_incarnation = target_runtime.cell_incarnation
+             WHERE target_region.region = preference.preferred_region
+               AND target_admission.admission_state = 'general'
+               AND target_runtime.ready = 1
+               AND target_runtime.last_heartbeat_at > ?
+               AND target_capability.regional_rehome_protocol >= 1
+           )
          ORDER BY preference.observed_at, preference.user_id, preference.relay_host_id
          LIMIT 10`,
-        [preferenceCutoff, now - this.heartbeatTtlMs, now]
+        [preferenceCutoff, now - this.heartbeatTtlMs, now, now - this.heartbeatTtlMs]
       )
       candidatesTotal = candidates.length
       for (const candidate of candidates) {
@@ -5397,14 +5411,11 @@ export class RelayAssignmentStore {
         [input.identity.userId, input.identity.relayHostId]
       )
     )[0]
-    if (
-      !preference ||
-      text(preference, 'preferred_region') !== 'asia-east2' ||
-      integer(preference, 'observed_at') < input.preferenceCutoff
-    ) {
+    if (!preference || integer(preference, 'observed_at') < input.preferenceCutoff) {
       input.skips.push({ reason: 'candidate_stale' })
       return null
     }
+    const preferredRegion = relayRegion(preference, 'preferred_region')
     const activeMigration = await transaction.queryLocked(
       `SELECT assignment_epoch FROM relay_assignment_migrations
        WHERE user_id = ? AND relay_host_id = ?
@@ -5469,11 +5480,17 @@ export class RelayAssignmentStore {
       )
       return null
     }
+    // The preference read under lock can now agree with the cell the host is
+    // already on: nothing to move, in either direction.
+    if (regions.get(input.sourceCellId) === preferredRegion) {
+      input.skips.push({ reason: 'candidate_stale' })
+      return null
+    }
     if (
       !source ||
       integer(source, 'enabled') !== 1 ||
       admission.get(input.sourceCellId) !== 'general' ||
-      regions.get(input.sourceCellId) !== RELAY_DEFAULT_REGION ||
+      regions.get(input.sourceCellId) === undefined ||
       !sourceRuntime ||
       integer(sourceRuntime, 'ready') !== 1 ||
       integer(sourceRuntime, 'last_heartbeat_at') <= input.now - this.heartbeatTtlMs ||
@@ -5502,17 +5519,25 @@ export class RelayAssignmentStore {
       return null
     }
     const connectionHeadroom = await this.connectionHeadroomByCell(transaction)
+    // A target must be drainable too, or the host lands somewhere it can never
+    // be rehomed out of again -- the trap this bidirectional move exists to undo.
     const eligibleTargets = cells.filter((row) => {
       const cellId = text(row, 'cell_id')
       const runtime = runtimes.find((candidate) => text(candidate, 'cell_id') === cellId)
+      const capability = capabilities.find(
+        (candidate) => text(candidate, 'cell_id') === cellId
+      )
       return (
         cellId !== input.sourceCellId &&
         integer(row, 'enabled') === 1 &&
         admission.get(cellId) === 'general' &&
-        regions.get(cellId) === 'asia-east2' &&
+        regions.get(cellId) === preferredRegion &&
         runtime !== undefined &&
         integer(runtime, 'ready') === 1 &&
-        integer(runtime, 'last_heartbeat_at') > input.now - this.heartbeatTtlMs
+        integer(runtime, 'last_heartbeat_at') > input.now - this.heartbeatTtlMs &&
+        capability !== undefined &&
+        text(capability, 'cell_incarnation') === text(runtime, 'cell_incarnation') &&
+        integer(capability, 'regional_rehome_protocol') >= 1
       )
     })
     const targetIsClean = (row: SqlRow): boolean => {
@@ -5668,12 +5693,13 @@ export class RelayAssignmentStore {
         drain_grace_ms, send_attempts, last_send_attempt_at,
         drain_receipt_at, drain_outcome, completed_at, aborted_at,
         created_at, updated_at)
-       VALUES (?, ?, ?, 'asia-east2', ?, ?, ?, ?, ?, ?, ?, 0, NULL,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL,
          NULL, NULL, NULL, NULL, ?, ?)`,
       [
         attemptId,
         input.identity.userId,
         input.identity.relayHostId,
+        preferredRegion,
         input.sourceCellId,
         text(sourceRuntime, 'cell_incarnation'),
         targetCellId,
@@ -5688,7 +5714,7 @@ export class RelayAssignmentStore {
     return {
       ...input.identity,
       attemptId,
-      preferredRegion: 'asia-east2',
+      preferredRegion,
       sourceCellId: input.sourceCellId,
       sourceCellUrl: text(source, 'cell_url'),
       sourceCellIncarnation: text(sourceRuntime, 'cell_incarnation'),
@@ -8101,7 +8127,7 @@ function regionalRehomeAttempt(row: SqlRow): RegionalRehomeAttempt {
     attemptId: text(row, 'attempt_id'),
     userId: text(row, 'user_id'),
     relayHostId: text(row, 'relay_host_id'),
-    preferredRegion: 'asia-east2',
+    preferredRegion: relayRegion(row, 'preferred_region'),
     sourceCellId: text(row, 'source_cell_id'),
     sourceCellUrl: text(row, 'source_cell_url'),
     sourceCellIncarnation: text(row, 'source_cell_incarnation'),
@@ -8161,10 +8187,9 @@ function regionalRehomeFleetSafetyFromInventory(input: {
     return (
       integer(row, 'enabled') === 1 &&
       input.admission.get(cellId) === 'general' &&
-      (input.regions.get(cellId) === 'asia-east2' ||
-        (input.regions.get(cellId) === RELAY_DEFAULT_REGION &&
-          capability !== undefined &&
-          integer(capability, 'regional_rehome_protocol') >= 1))
+      input.regions.get(cellId) !== undefined &&
+      capability !== undefined &&
+      integer(capability, 'regional_rehome_protocol') >= 1
     )
   })
   const valid = required.flatMap((row) => {

--- a/cloud/apps/relay/src/cell-heartbeat-client.ts
+++ b/cloud/apps/relay/src/cell-heartbeat-client.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { RELAY_DEFAULT_REGION } from '@orca-cloud/relay-contract'
 import type { RelayConfig } from './config.js'
 import { googleMetadataIdentityToken } from './google-metadata-identity-token.js'
 import type { RegionalRehomeSafetySnapshot } from './relay-observability.js'
@@ -57,7 +58,7 @@ export function startCellHeartbeat(
             v: 1,
             cellId: config.cellId,
             cellUrl: config.cellUrl,
-            region: config.region ?? 'us-central1',
+            region: config.region ?? RELAY_DEFAULT_REGION,
             cellIncarnation,
             startedAt,
             ready,

--- a/cloud/apps/relay/src/database-postgres-timeout.test.ts
+++ b/cloud/apps/relay/src/database-postgres-timeout.test.ts
@@ -34,7 +34,11 @@ vi.mock('pg', () => ({
   }
 }))
 
-import { openRelayDatabase, relayPostgresStatementTimeoutMs } from './database.js'
+import {
+  openRelayDatabase,
+  POSTGRES_SCHEMA_MIGRATIONS,
+  relayPostgresStatementTimeoutMs
+} from './database.js'
 import { applyPostgresSchema } from './postgres-schema-startup.js'
 
 const SCHEMA_POOL = {
@@ -118,7 +122,9 @@ describe('PostgreSQL relay deadlines', () => {
     // Statements can open with a leading `--` rationale comment.
     const body = (statement: string): string =>
       statement.replace(/^(?:\s*--[^\n]*\n)*\s*/, '')
-    expect(ddl.every((statement) => /^CREATE\b/i.test(body(statement)))).toBe(true)
+    expect(
+      ddl.every((statement) => /^(?:CREATE|ALTER TABLE)\b/i.test(body(statement)))
+    ).toBe(true)
     // The backfill is DML, so it stays on the deadline-bearing serving pool.
     expect(ddl.some((statement) => statement.includes('INSERT INTO'))).toBe(false)
     await database.close()
@@ -261,6 +267,54 @@ describe('PostgreSQL schema startup', () => {
     await applyPostgresSchema([statement], query, { wait: async () => undefined })
 
     expect(query).toHaveBeenCalledTimes(2)
+  })
+
+  it('treats an existing constraint as an applied ADD CONSTRAINT', async () => {
+    // Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, and a retry would only
+    // repeat 42710, so a re-run and a concurrent startup both move on.
+    const error = Object.assign(new Error('already exists'), { code: '42710' })
+    const query = vi
+      .fn<(statement: string) => Promise<unknown>>()
+      .mockRejectedValueOnce(error)
+      .mockResolvedValue(undefined)
+    const pause = vi.fn(async () => undefined)
+
+    await applyPostgresSchema(
+      ['ALTER TABLE test ADD CONSTRAINT test_check CHECK (id > 0)', 'CREATE TABLE test2'],
+      query,
+      { wait: pause }
+    )
+
+    expect(pause).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledTimes(2)
+    expect(query).toHaveBeenLastCalledWith('CREATE TABLE test2')
+  })
+
+  it('recognises every shipped ADD CONSTRAINT migration as re-runnable', async () => {
+    // Guards the statement text against the pattern that classifies it.
+    const shipped = POSTGRES_SCHEMA_MIGRATIONS.filter((statement) =>
+      statement.includes('ADD CONSTRAINT')
+    )
+    expect(shipped.length).toBeGreaterThan(0)
+    const error = Object.assign(new Error('already exists'), { code: '42710' })
+    const query = vi.fn<(statement: string) => Promise<unknown>>().mockRejectedValue(error)
+
+    await applyPostgresSchema(shipped, query, { wait: async () => undefined })
+
+    expect(query).toHaveBeenCalledTimes(shipped.length)
+  })
+
+  it('still fails an ADD CONSTRAINT that violates existing rows', async () => {
+    const error = Object.assign(new Error('check violation'), { code: '23514' })
+    const query = vi.fn<(statement: string) => Promise<unknown>>().mockRejectedValue(error)
+
+    await expect(
+      applyPostgresSchema(
+        ['ALTER TABLE test ADD CONSTRAINT test_check CHECK (id > 0)'],
+        query,
+        { wait: async () => undefined }
+      )
+    ).rejects.toBe(error)
   })
 
   it.each([

--- a/cloud/apps/relay/src/database.test.ts
+++ b/cloud/apps/relay/src/database.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { openInMemoryRelayDatabase, openRelayDatabase } from './database.js'
+import {
+  openInMemoryRelayDatabase,
+  openRelayDatabase,
+  POSTGRES_SCHEMA_MIGRATIONS,
+  REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS
+} from './database.js'
 
 const temporaryDirectories: string[] = []
 
@@ -140,6 +145,41 @@ describe('relay database', () => {
       ])
     ).toEqual([{ region: 'us-central1' }])
     await second.close()
+  })
+
+  it('renders every region check from the shared region list', async () => {
+    // Derived, not hand-written: a third region must not leave one column
+    // rejecting a value the rest of the relay already accepts.
+    const database = await openInMemoryRelayDatabase()
+    const checked = await database.query(
+      `SELECT name, sql FROM sqlite_master
+       WHERE type = 'table'
+         AND name IN ('relay_assignment_region_preferences', 'relay_cell_regions',
+                      'relay_region_rehome_attempts')
+       ORDER BY name`
+    )
+    const list = `IN ('us-central1', 'asia-east2')`
+    expect(checked.map((row) => row.name)).toEqual([
+      'relay_assignment_region_preferences',
+      'relay_cell_regions',
+      'relay_region_rehome_attempts'
+    ])
+    expect(checked.every((row) => String(row.sql).includes(list))).toBe(true)
+    expect(
+      POSTGRES_SCHEMA_MIGRATIONS.some((statement) => statement.includes(list))
+    ).toBe(true)
+    await database.close()
+  })
+
+  it('indexes rehome attempts by host recency for the per-host cooldown', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const rows = await database.query(
+      `SELECT sql FROM sqlite_master
+       WHERE type = 'index' AND name = 'relay_region_rehome_attempts_host_recency'`
+    )
+    expect(rows[0]?.sql).toContain('(user_id, relay_host_id, created_at)')
+    expect(REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS).toBe(7 * 24 * 60 * 60_000)
+    await database.close()
   })
 
   it('indexes region preference expiry by observation time', async () => {

--- a/cloud/apps/relay/src/database.ts
+++ b/cloud/apps/relay/src/database.ts
@@ -212,7 +212,9 @@ CREATE TABLE IF NOT EXISTS relay_region_rehome_attempts (
   attempt_id TEXT PRIMARY KEY,
   user_id TEXT NOT NULL,
   relay_host_id TEXT NOT NULL,
-  preferred_region TEXT NOT NULL CHECK (preferred_region = 'asia-east2'),
+  preferred_region TEXT NOT NULL
+    CONSTRAINT relay_region_rehome_attempts_preferred_region_valid
+    CHECK (preferred_region IN ('us-central1', 'asia-east2')),
   source_cell_id TEXT NOT NULL,
   source_cell_incarnation TEXT NOT NULL,
   target_cell_id TEXT NOT NULL,
@@ -579,6 +581,18 @@ CREATE TABLE IF NOT EXISTS relay_audit_events (
 );
 CREATE INDEX IF NOT EXISTS relay_audit_events_at ON relay_audit_events(at);
 `
+
+// Rehoming is bidirectional, but tables created before that carry the
+// original single-region column check. The old constraint is the one Postgres
+// auto-named; the replacement is named, so both statements are no-ops on a
+// database the current schema created and neither can drop the other.
+export const POSTGRES_SCHEMA_MIGRATIONS = [
+  `ALTER TABLE relay_region_rehome_attempts
+     DROP CONSTRAINT IF EXISTS relay_region_rehome_attempts_preferred_region_check`,
+  `ALTER TABLE relay_region_rehome_attempts
+     ADD CONSTRAINT relay_region_rehome_attempts_preferred_region_valid
+     CHECK (preferred_region IN ('us-central1', 'asia-east2'))`
+]
 
 function postgresSql(sql: string): string {
   let index = 0
@@ -1009,7 +1023,10 @@ async function applySchemaOnUntimedPool(
   const database = new PostgresDatabase(pool)
   try {
     await applyPostgresSchema(
-      SCHEMA.split(';').filter((statement) => statement.trim()),
+      [
+        ...SCHEMA.split(';').filter((statement) => statement.trim()),
+        ...POSTGRES_SCHEMA_MIGRATIONS
+      ],
       async (statement) => await database.query(statement)
     )
   } finally {

--- a/cloud/apps/relay/src/database.ts
+++ b/cloud/apps/relay/src/database.ts
@@ -3,6 +3,7 @@ import { performance } from 'node:perf_hooks'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import pg from 'pg'
+import { RELAY_REGIONS } from '@orca-cloud/relay-contract'
 import {
   emptyPostgresPoolPressureCounts,
   PostgresPoolPressure,
@@ -23,6 +24,14 @@ function setLocalLockTimeout(milliseconds: number): string {
   }
   return `SET LOCAL lock_timeout = '${milliseconds}ms'`
 }
+
+// Region CHECK lists come from the contract so a new region cannot leave a
+// column rejecting values the rest of the relay already accepts.
+const REGION_LIST = RELAY_REGIONS.map((region) => `'${region}'`).join(', ')
+
+// A host that was just moved is not a candidate again for this long, so a
+// desktop whose region probe flips cannot walk itself back and forth.
+export const REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS = 7 * 24 * 60 * 60_000
 
 export type SqlRow = Record<string, unknown>
 export type RelayLockOptions = {
@@ -181,7 +190,7 @@ CREATE TABLE IF NOT EXISTS relay_assignment_region_preferences (
   user_id TEXT NOT NULL,
   relay_host_id TEXT NOT NULL,
   preferred_region TEXT NOT NULL
-    CHECK (preferred_region IN ('us-central1', 'asia-east2')),
+    CHECK (preferred_region IN (${REGION_LIST})),
   observed_at BIGINT NOT NULL,
   PRIMARY KEY (user_id, relay_host_id)
 );
@@ -204,6 +213,8 @@ CREATE TABLE IF NOT EXISTS relay_region_rehome_control (
   not_before BIGINT NOT NULL,
   rate_per_minute BIGINT NOT NULL,
   preference_max_age_ms BIGINT NOT NULL,
+  host_cooldown_ms BIGINT NOT NULL
+    DEFAULT ${REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS},
   drain_grace_ms BIGINT NOT NULL,
   updated_at BIGINT NOT NULL
 );
@@ -214,7 +225,7 @@ CREATE TABLE IF NOT EXISTS relay_region_rehome_attempts (
   relay_host_id TEXT NOT NULL,
   preferred_region TEXT NOT NULL
     CONSTRAINT relay_region_rehome_attempts_preferred_region_valid
-    CHECK (preferred_region IN ('us-central1', 'asia-east2')),
+    CHECK (preferred_region IN (${REGION_LIST})),
   source_cell_id TEXT NOT NULL,
   source_cell_incarnation TEXT NOT NULL,
   target_cell_id TEXT NOT NULL,
@@ -236,6 +247,8 @@ CREATE TABLE IF NOT EXISTS relay_region_rehome_attempts (
 );
 CREATE INDEX IF NOT EXISTS relay_region_rehome_attempts_pending
   ON relay_region_rehome_attempts(drain_receipt_at, last_send_attempt_at, completed_at, aborted_at);
+CREATE INDEX IF NOT EXISTS relay_region_rehome_attempts_host_recency
+  ON relay_region_rehome_attempts(user_id, relay_host_id, created_at);
 
 CREATE TABLE IF NOT EXISTS relay_cells (
   cell_id TEXT PRIMARY KEY,
@@ -250,7 +263,7 @@ CREATE TABLE IF NOT EXISTS relay_cells (
 
 CREATE TABLE IF NOT EXISTS relay_cell_regions (
   cell_id TEXT PRIMARY KEY,
-  region TEXT NOT NULL CHECK (region IN ('us-central1', 'asia-east2'))
+  region TEXT NOT NULL CHECK (region IN (${REGION_LIST}))
 );
 
 CREATE TABLE IF NOT EXISTS relay_cell_admission (
@@ -591,7 +604,10 @@ export const POSTGRES_SCHEMA_MIGRATIONS = [
      DROP CONSTRAINT IF EXISTS relay_region_rehome_attempts_preferred_region_check`,
   `ALTER TABLE relay_region_rehome_attempts
      ADD CONSTRAINT relay_region_rehome_attempts_preferred_region_valid
-     CHECK (preferred_region IN ('us-central1', 'asia-east2'))`
+     CHECK (preferred_region IN (${REGION_LIST}))`,
+  `ALTER TABLE relay_region_rehome_control
+     ADD COLUMN IF NOT EXISTS host_cooldown_ms BIGINT NOT NULL
+     DEFAULT ${REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS}`
 ]
 
 function postgresSql(sql: string): string {

--- a/cloud/apps/relay/src/postgres-schema-startup.ts
+++ b/cloud/apps/relay/src/postgres-schema-startup.ts
@@ -49,6 +49,20 @@ function concurrentCreateCollision(
   return false
 }
 
+const ALTER_TABLE_ADD_CONSTRAINT =
+  /^\s*ALTER\s+TABLE\s+\S+\s+ADD\s+CONSTRAINT\b/i
+
+// Postgres has no `ADD CONSTRAINT IF NOT EXISTS`, so a re-run and a concurrent
+// startup both land on 42710 once the constraint exists. Unlike a CREATE race
+// this is terminal, not transient: retrying only repeats it, so the statement
+// counts as applied.
+function constraintAlreadyApplied(error: unknown, statement: string): boolean {
+  return (
+    ALTER_TABLE_ADD_CONSTRAINT.test(statement) &&
+    (error as { code?: unknown }).code === '42710'
+  )
+}
+
 function retryableSchemaError(error: unknown, statement: string): boolean {
   const value = error as { code?: unknown; constraint?: unknown }
   return (
@@ -73,6 +87,7 @@ export async function applyPostgresSchema(
         await query(statement)
         break
       } catch (error) {
+        if (constraintAlreadyApplied(error, statement)) break
         const code = String((error as { code?: unknown }).code)
         const remainingMs = deadlineAt - now()
         const retryable = retryableSchemaError(error, statement)

--- a/cloud/apps/relay/src/regional-host-drain-app.test.ts
+++ b/cloud/apps/relay/src/regional-host-drain-app.test.ts
@@ -411,6 +411,78 @@ describe('regional rehome director controls', () => {
     expect(JSON.stringify(responseBody)).not.toContain('rehome-token')
   })
 
+  it('probes a source cell in any region, not only the default one', async () => {
+    // Rehoming moves hosts in both directions, so an asia-east2 cell is a
+    // source too and its trust has to be provable the same way.
+    const cellDeploymentStatus = vi.fn().mockResolvedValue({
+      cellId: 'production-gce-c27',
+      cellUrl: 'https://c27.relay.example.test',
+      region: 'asia-east2',
+      runtime: {
+        cellIncarnation,
+        ready: true,
+        heartbeatFresh: true,
+        regionalRehomeProtocol: 1
+      }
+    })
+    const app = createRelayApp(config({ role: 'director', cellId: 'director' }), {
+      store: {} as never,
+      assignments: { cellDeploymentStatus } as never,
+      drain: vi.fn(),
+      regionalRehomeIdentityToken: vi.fn(async () => 'rehome-token'),
+      regionalRehomeFetch: (async () =>
+        Response.json({
+          v: 1,
+          outcome: 'host-not-connected',
+          sharedRuntimeIdentityRejected: true
+        })) as typeof fetch,
+      ready: vi.fn(async () => true)
+    })
+
+    const response = await postPath(
+      app,
+      '/v1/admin/regional-rehome-trust-probe',
+      'deploy-token',
+      { v: 1, sourceCellId: 'production-gce-c27', sourceCellIncarnation: cellIncarnation }
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ proven: true })
+  })
+
+  it('still refuses a trust probe against a cell without the drain protocol', async () => {
+    const cellDeploymentStatus = vi.fn().mockResolvedValue({
+      cellId: 'production-gce-c27',
+      cellUrl: 'https://c27.relay.example.test',
+      region: 'asia-east2',
+      runtime: {
+        cellIncarnation,
+        ready: true,
+        heartbeatFresh: true,
+        regionalRehomeProtocol: 0
+      }
+    })
+    const sourceFetch = vi.fn<typeof fetch>()
+    const app = createRelayApp(config({ role: 'director', cellId: 'director' }), {
+      store: {} as never,
+      assignments: { cellDeploymentStatus } as never,
+      drain: vi.fn(),
+      regionalRehomeIdentityToken: vi.fn(async () => 'rehome-token'),
+      regionalRehomeFetch: sourceFetch,
+      ready: vi.fn(async () => true)
+    })
+
+    const response = await postPath(
+      app,
+      '/v1/admin/regional-rehome-trust-probe',
+      'deploy-token',
+      { v: 1, sourceCellId: 'production-gce-c27', sourceCellIncarnation: cellIncarnation }
+    )
+
+    expect(response.status).toBe(409)
+    expect(sourceFetch).not.toHaveBeenCalled()
+  })
+
   it('restricts trust probes to deploy authorization and strict input', async () => {
     const app = createRelayApp(config({ role: 'director', cellId: 'director' }), {
       store: {} as never,

--- a/cloud/apps/relay/src/regional-host-drain-app.test.ts
+++ b/cloud/apps/relay/src/regional-host-drain-app.test.ts
@@ -315,6 +315,7 @@ describe('regional rehome director controls', () => {
       notBefore: 100,
       ratePerMinute: 10,
       preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: 7 * 24 * 60 * 60_000,
       drainGraceMs: 60_000,
       confirmation: 'ENABLE_REGIONAL_REHOMING'
     }
@@ -342,6 +343,14 @@ describe('regional rehome director controls', () => {
       '/v1/admin/regional-rehome-control',
       'deploy-token',
       { ...apply, confirmation: 'DISABLE_REGIONAL_REHOMING' }
+    )).status).toBe(400)
+    // The per-host cooldown is part of the durable shape an operator must state.
+    const { hostCooldownMs: _omitted, ...withoutCooldown } = apply
+    expect((await postPath(
+      app,
+      '/v1/admin/regional-rehome-control',
+      'deploy-token',
+      withoutCooldown
     )).status).toBe(400)
   })
 

--- a/cloud/apps/relay/src/regional-rehome-constraint-migration-postgres.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-constraint-migration-postgres.test.ts
@@ -1,0 +1,158 @@
+import pg from 'pg'
+import { afterAll, beforeEach, describe, expect, it } from 'vitest'
+import { openRelayDatabase, type RelayDatabase } from './database.js'
+
+const databaseUrl = process.env.ORCA_RELAY_TEST_POSTGRES_URL
+const describePostgres = databaseUrl ? describe : describe.skip
+const schema = 'relay_rehome_constraint_migration_test'
+
+// The shape shipped before rehoming became bidirectional: a single-region
+// column check that Postgres auto-names.
+const LEGACY_ATTEMPTS_TABLE = `
+CREATE TABLE relay_region_rehome_attempts (
+  attempt_id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  relay_host_id TEXT NOT NULL,
+  preferred_region TEXT NOT NULL CHECK (preferred_region = 'asia-east2'),
+  source_cell_id TEXT NOT NULL,
+  source_cell_incarnation TEXT NOT NULL,
+  target_cell_id TEXT NOT NULL,
+  target_cell_incarnation TEXT NOT NULL,
+  previous_epoch BIGINT NOT NULL,
+  assignment_epoch BIGINT NOT NULL,
+  drain_grace_ms BIGINT NOT NULL,
+  send_attempts BIGINT NOT NULL,
+  last_send_attempt_at BIGINT,
+  drain_receipt_at BIGINT,
+  drain_outcome TEXT CHECK (
+    drain_outcome IN ('accepted', 'already-accepted', 'host-not-connected')
+  ),
+  completed_at BIGINT,
+  aborted_at BIGINT,
+  created_at BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL,
+  UNIQUE (user_id, relay_host_id, assignment_epoch)
+)`
+
+const attemptValues = (attemptId: string, preferredRegion: string): unknown[] => [
+  attemptId,
+  'user-1',
+  'abcdefghijklmnop',
+  preferredRegion,
+  'cell-source',
+  '11111111-1111-4111-8111-111111111111',
+  'cell-target',
+  '22222222-2222-4222-8222-222222222222',
+  1,
+  Number(attemptId.at(-1)),
+  0,
+  0,
+  1_000_000,
+  1_000_000
+]
+
+const INSERT_ATTEMPT = `INSERT INTO relay_region_rehome_attempts
+  (attempt_id, user_id, relay_host_id, preferred_region, source_cell_id,
+   source_cell_incarnation, target_cell_id, target_cell_incarnation,
+   previous_epoch, assignment_epoch, drain_grace_ms, send_attempts,
+   created_at, updated_at)
+ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`
+
+describePostgres('PostgreSQL regional rehome constraint migration', () => {
+  let scopedUrl = ''
+
+  async function withClient(
+    operation: (client: pg.Client) => Promise<void>
+  ): Promise<void> {
+    const client = new pg.Client({ connectionString: databaseUrl })
+    await client.connect()
+    try {
+      await operation(client)
+    } finally {
+      await client.end()
+    }
+  }
+
+  beforeEach(async () => {
+    await withClient(async (client) => {
+      await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+      await client.query(`CREATE SCHEMA ${schema}`)
+      await client.query(`SET search_path = ${schema}`)
+      await client.query(LEGACY_ATTEMPTS_TABLE)
+      // Production data the replacement constraint has to validate.
+      await client.query(INSERT_ATTEMPT, attemptValues('attempt-1', 'asia-east2'))
+    })
+    const url = new URL(databaseUrl!)
+    url.searchParams.set('options', `-c search_path=${schema}`)
+    scopedUrl = url.toString()
+  })
+
+  afterAll(async () => {
+    await withClient(async (client) => {
+      await client.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`)
+    })
+  })
+
+  it('upgrades a legacy single-region constraint in place', async () => {
+    const database = await openRelayDatabase({ databaseUrl: scopedUrl, dataDir: '' })
+    try {
+      await withClient(async (client) => {
+        await client.query(`SET search_path = ${schema}`)
+        await client.query(INSERT_ATTEMPT, attemptValues('attempt-2', 'us-central1'))
+        await expect(
+          client.query(INSERT_ATTEMPT, attemptValues('attempt-3', 'europe-west1'))
+        ).rejects.toMatchObject({ code: '23514' })
+        const constraints = await client.query(
+          `SELECT conname FROM pg_constraint
+           WHERE conrelid = 'relay_region_rehome_attempts'::regclass
+             AND conname LIKE '%preferred_region%'
+           ORDER BY conname`
+        )
+        expect(constraints.rows).toEqual([
+          { conname: 'relay_region_rehome_attempts_preferred_region_valid' }
+        ])
+      })
+    } finally {
+      await database.close()
+    }
+  })
+
+  it('upgrades once across concurrent startups', async () => {
+    const results = await Promise.allSettled(
+      Array.from(
+        { length: 5 },
+        async (): Promise<RelayDatabase> =>
+          await openRelayDatabase({ databaseUrl: scopedUrl, dataDir: '' })
+      )
+    )
+    const databases = results.flatMap((result) =>
+      result.status === 'fulfilled' ? [result.value] : []
+    )
+    await Promise.all(databases.map(async (database) => await database.close()))
+
+    expect(
+      results.flatMap((result) =>
+        result.status === 'rejected'
+          ? [
+              {
+                code: (result.reason as { code?: unknown }).code,
+                message: String(result.reason)
+              }
+            ]
+          : []
+      )
+    ).toEqual([])
+    await withClient(async (client) => {
+      await client.query(`SET search_path = ${schema}`)
+      await client.query(INSERT_ATTEMPT, attemptValues('attempt-4', 'us-central1'))
+      const constraints = await client.query(
+        `SELECT conname FROM pg_constraint
+         WHERE conrelid = 'relay_region_rehome_attempts'::regclass
+           AND conname LIKE '%preferred_region%'`
+      )
+      expect(constraints.rows).toEqual([
+        { conname: 'relay_region_rehome_attempts_preferred_region_valid' }
+      ])
+    })
+  }, 60_000)
+})

--- a/cloud/apps/relay/src/regional-rehome-constraint-migration-postgres.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-constraint-migration-postgres.test.ts
@@ -1,6 +1,10 @@
 import pg from 'pg'
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
-import { openRelayDatabase, type RelayDatabase } from './database.js'
+import {
+  openRelayDatabase,
+  REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS,
+  type RelayDatabase
+} from './database.js'
 
 const databaseUrl = process.env.ORCA_RELAY_TEST_POSTGRES_URL
 const describePostgres = databaseUrl ? describe : describe.skip
@@ -32,6 +36,20 @@ CREATE TABLE relay_region_rehome_attempts (
   created_at BIGINT NOT NULL,
   updated_at BIGINT NOT NULL,
   UNIQUE (user_id, relay_host_id, assignment_epoch)
+)`
+
+// The control row as it shipped before the per-host cooldown existed.
+const LEGACY_CONTROL_TABLE = `
+CREATE TABLE relay_region_rehome_control (
+  control_id TEXT PRIMARY KEY,
+  generation BIGINT NOT NULL,
+  enabled BIGINT NOT NULL,
+  observation_started_at BIGINT NOT NULL,
+  not_before BIGINT NOT NULL,
+  rate_per_minute BIGINT NOT NULL,
+  preference_max_age_ms BIGINT NOT NULL,
+  drain_grace_ms BIGINT NOT NULL,
+  updated_at BIGINT NOT NULL
 )`
 
 const attemptValues = (attemptId: string, preferredRegion: string): unknown[] => [
@@ -79,6 +97,13 @@ describePostgres('PostgreSQL regional rehome constraint migration', () => {
       await client.query(`CREATE SCHEMA ${schema}`)
       await client.query(`SET search_path = ${schema}`)
       await client.query(LEGACY_ATTEMPTS_TABLE)
+      await client.query(LEGACY_CONTROL_TABLE)
+      await client.query(
+        `INSERT INTO relay_region_rehome_control
+         (control_id, generation, enabled, observation_started_at, not_before,
+          rate_per_minute, preference_max_age_ms, drain_grace_ms, updated_at)
+         VALUES ('global', 3, 0, 1, 0, 10, 86400000, 60000, 1)`
+      )
       // Production data the replacement constraint has to validate.
       await client.query(INSERT_ATTEMPT, attemptValues('attempt-1', 'asia-east2'))
     })
@@ -110,6 +135,18 @@ describePostgres('PostgreSQL regional rehome constraint migration', () => {
         )
         expect(constraints.rows).toEqual([
           { conname: 'relay_region_rehome_attempts_preferred_region_valid' }
+        ])
+        // The existing control row keeps its tuning and gains the cooldown.
+        const control = await client.query(
+          `SELECT generation, preference_max_age_ms, host_cooldown_ms
+           FROM relay_region_rehome_control WHERE control_id = 'global'`
+        )
+        expect(control.rows).toEqual([
+          {
+            generation: '3',
+            preference_max_age_ms: '86400000',
+            host_cooldown_ms: String(REGIONAL_REHOME_DEFAULT_HOST_COOLDOWN_MS)
+          }
         ])
       })
     } finally {

--- a/cloud/apps/relay/src/regional-rehome-postgres.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-postgres.test.ts
@@ -166,6 +166,52 @@ describePostgres('PostgreSQL regional rehoming', () => {
     })
   })
 
+  it('leaves a host inside its per-host rehome cooldown, in either direction', async () => {
+    const context = await fixture({ hostCooldownMs: 3 * 24 * 60 * 60_000 })
+    // A move this host already made, whichever way it went.
+    await primary.query(
+      `INSERT INTO relay_region_rehome_attempts
+       (attempt_id, user_id, relay_host_id, preferred_region, source_cell_id,
+        source_cell_incarnation, target_cell_id, target_cell_incarnation,
+        previous_epoch, assignment_epoch, drain_grace_ms, send_attempts,
+        completed_at, created_at, updated_at)
+       VALUES (?, ?, ?, 'us-central1', ?, ?, ?, ?, 0, 1, 0, 0, ?, ?, ?)`,
+      [
+        `pg-rehome-cooldown-${context.identity.relayHostId}`,
+        context.identity.userId,
+        context.identity.relayHostId,
+        context.target.id,
+        '22222222-2222-4222-8222-222222222222',
+        context.source.id,
+        '11111111-1111-4111-8111-111111111111',
+        context.now(),
+        context.now() - 3 * 24 * 60 * 60_000 + 1,
+        context.now()
+      ]
+    )
+
+    await expect(context.store.claimRegionalRehome()).resolves.toBeNull()
+    await expect(context.store.inspectRegionalRehomeControl()).resolves.toMatchObject({
+      generation: 1,
+      enabled: true,
+      hostCooldownMs: 3 * 24 * 60 * 60_000
+    })
+    expect(await attemptAndMigrationCounts(context.identity)).toEqual({
+      attempts: 1,
+      migrations: 0
+    })
+
+    // One millisecond past the window the same host is a candidate again.
+    await primary.query(
+      `UPDATE relay_region_rehome_attempts SET created_at = ? WHERE user_id = ?`,
+      [context.now() - 3 * 24 * 60 * 60_000, context.identity.userId]
+    )
+    await expect(context.store.claimRegionalRehome()).resolves.toMatchObject({
+      sourceCellId: context.source.id,
+      targetCellId: context.target.id
+    })
+  })
+
   it('leaves a host whose preferred region holds no drainable cell', async () => {
     // A cell that cannot be drained cannot be a target: the host would land
     // where no later rehome could move it out again.
@@ -576,6 +622,7 @@ describePostgres('PostgreSQL regional rehoming', () => {
       notBefore: now,
       ratePerMinute: 10,
       preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: options.hostCooldownMs ?? 7 * 24 * 60 * 60_000,
       drainGraceMs: 60_000
     })
     await store.reconcileCells([source, target])
@@ -631,6 +678,7 @@ type FixtureOptions = {
   targetRegion?: Region
   preferredRegion?: Region
   targetProtocol?: number
+  hostCooldownMs?: number
 }
 
 function cell(suffix: string, role: string, region: Region) {

--- a/cloud/apps/relay/src/regional-rehome-postgres.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-postgres.test.ts
@@ -81,6 +81,107 @@ describePostgres('PostgreSQL regional rehoming', () => {
     expect(await context.store.claimRegionalRehome()).not.toBeNull()
   })
 
+  it('moves a us-central1 host onto a cell in its preferred asia-east2 region', async () => {
+    const context = await fixture()
+
+    const attempt = await context.store.claimRegionalRehome()
+    expect(attempt).toMatchObject({
+      preferredRegion: 'asia-east2',
+      sourceCellId: context.source.id,
+      targetCellId: context.target.id
+    })
+    expect(await primary.query(
+      `SELECT preferred_region, source_cell_id, target_cell_id
+       FROM relay_region_rehome_attempts WHERE user_id = ?`,
+      [context.identity.userId]
+    )).toEqual([{
+      preferred_region: 'asia-east2',
+      source_cell_id: context.source.id,
+      target_cell_id: context.target.id
+    }])
+  })
+
+  it('moves an asia-east2 host back onto a cell in its preferred us-central1 region', async () => {
+    const context = await fixture({
+      sourceRegion: 'asia-east2',
+      targetRegion: 'us-central1'
+    })
+
+    const attempt = await context.store.claimRegionalRehome()
+    expect(attempt).toMatchObject({
+      preferredRegion: 'us-central1',
+      sourceCellId: context.source.id,
+      targetCellId: context.target.id
+    })
+    // The durable attempt row must accept the reverse direction too.
+    expect(await primary.query(
+      `SELECT preferred_region, source_cell_id, target_cell_id
+       FROM relay_region_rehome_attempts WHERE user_id = ?`,
+      [context.identity.userId]
+    )).toEqual([{
+      preferred_region: 'us-central1',
+      source_cell_id: context.source.id,
+      target_cell_id: context.target.id
+    }])
+    expect(await primary.query(
+      `SELECT cell_id FROM relay_assignments WHERE user_id = ?`,
+      [context.identity.userId]
+    )).toEqual([{ cell_id: context.target.id }])
+  })
+
+  it('leaves a host whose preference already matches its own region', async () => {
+    const context = await fixture({ preferredRegion: 'us-central1' })
+
+    await expect(context.store.claimRegionalRehome()).resolves.toBeNull()
+    await expect(context.store.inspectRegionalRehomeControl()).resolves.toMatchObject({
+      generation: 1,
+      enabled: true
+    })
+    expect(await attemptAndMigrationCounts(context.identity)).toEqual({
+      attempts: 0,
+      migrations: 0
+    })
+  })
+
+  it('leaves a host whose preference is older than the configured max age', async () => {
+    const context = await fixture()
+    await primary.query(
+      `UPDATE relay_assignment_region_preferences SET observed_at = ?
+       WHERE user_id = ? AND relay_host_id = ?`,
+      [
+        context.now() - 24 * 60 * 60_000 - 1,
+        context.identity.userId,
+        context.identity.relayHostId
+      ]
+    )
+
+    await expect(context.store.claimRegionalRehome()).resolves.toBeNull()
+    await expect(context.store.inspectRegionalRehomeControl()).resolves.toMatchObject({
+      generation: 1,
+      enabled: true
+    })
+    expect(await attemptAndMigrationCounts(context.identity)).toEqual({
+      attempts: 0,
+      migrations: 0
+    })
+  })
+
+  it('leaves a host whose preferred region holds no drainable cell', async () => {
+    // A cell that cannot be drained cannot be a target: the host would land
+    // where no later rehome could move it out again.
+    const context = await fixture({ targetProtocol: 0 })
+
+    await expect(context.store.claimRegionalRehome()).resolves.toBeNull()
+    await expect(context.store.inspectRegionalRehomeControl()).resolves.toMatchObject({
+      generation: 1,
+      enabled: true
+    })
+    expect(await attemptAndMigrationCounts(context.identity)).toEqual({
+      attempts: 0,
+      migrations: 0
+    })
+  })
+
   it('skips an unclean cell without latching the control off', async () => {
     const context = await fixture()
     await primary.query(
@@ -281,7 +382,7 @@ describePostgres('PostgreSQL regional rehoming', () => {
       context.store,
       context.target,
       '22222222-2222-4222-8222-222222222222',
-      0,
+      1,
       900_000,
       2
     )
@@ -322,7 +423,7 @@ describePostgres('PostgreSQL regional rehoming', () => {
       context.store,
       context.target,
       '44444444-4444-4444-8444-444444444444',
-      0,
+      1,
       context.now()
     )
 
@@ -341,7 +442,7 @@ describePostgres('PostgreSQL regional rehoming', () => {
       context.store,
       context.target,
       '22222222-2222-4222-8222-222222222222',
-      0,
+      1,
       900_000,
       2
     )
@@ -414,6 +515,26 @@ describePostgres('PostgreSQL regional rehoming', () => {
     })
   })
 
+  async function attemptAndMigrationCounts(identity: {
+    userId: string
+    relayHostId: string
+  }): Promise<{ attempts: number; migrations: number }> {
+    const attempts = await primary.query(
+      `SELECT COUNT(*) AS count FROM relay_region_rehome_attempts
+       WHERE user_id = ? AND relay_host_id = ?`,
+      [identity.userId, identity.relayHostId]
+    )
+    const migrations = await primary.query(
+      `SELECT COUNT(*) AS count FROM relay_assignment_migrations
+       WHERE user_id = ? AND relay_host_id = ?`,
+      [identity.userId, identity.relayHostId]
+    )
+    return {
+      attempts: Number(attempts[0]!.count),
+      migrations: Number(migrations[0]!.count)
+    }
+  }
+
   async function controlAccounting(identity: {
     userId: string
     relayHostId: string
@@ -436,12 +557,15 @@ describePostgres('PostgreSQL regional rehoming', () => {
     }
   }
 
-  async function fixture() {
+  async function fixture(options: FixtureOptions = {}) {
     sequence++
     let now = 1_000_000
     const suffix = String(sequence)
-    const source = cell(suffix, 'source', 'us-central1')
-    const target = cell(suffix, 'target', 'asia-east2')
+    const sourceRegion = options.sourceRegion ?? 'us-central1'
+    const targetRegion = options.targetRegion ?? 'asia-east2'
+    const preferredRegion = options.preferredRegion ?? targetRegion
+    const source = cell(suffix, 'source', sourceRegion)
+    const target = cell(suffix, 'target', targetRegion)
     const store = new RelayAssignmentStore(primary, () => now, storeOptions)
     const competingStore = new RelayAssignmentStore(secondary, () => now, storeOptions)
     await store.inspectRegionalRehomeControl()
@@ -466,21 +590,22 @@ describePostgres('PostgreSQL regional rehoming', () => {
       store,
       target,
       '22222222-2222-4222-8222-222222222222',
-      0,
+      options.targetProtocol ?? 1,
       900_000
     )
     const identity = {
       userId: `pg-rehome-user-${suffix}`,
       relayHostId: `rehomehost${suffix.padStart(6, '0')}`
     }
-    const assignment = await store.assign(identity, undefined, 'us-central1')
+    const assignment = await store.assign(identity, undefined, sourceRegion)
     const sourceControl = await store.activateControl(identity, {
       cellId: source.id,
       assignmentEpoch: assignment.assignmentEpoch,
       generation: 1
     })
-    await store.assign(identity, 'asia-east2')
+    await store.assign(identity, preferredRegion)
     return {
+      preferredRegion,
       store,
       competingStore,
       identity,
@@ -500,7 +625,15 @@ const storeOptions = {
   heartbeatTtlMs: 45_000
 }
 
-function cell(suffix: string, role: string, region: 'us-central1' | 'asia-east2') {
+type Region = 'us-central1' | 'asia-east2'
+type FixtureOptions = {
+  sourceRegion?: Region
+  targetRegion?: Region
+  preferredRegion?: Region
+  targetProtocol?: number
+}
+
+function cell(suffix: string, role: string, region: Region) {
   return {
     id: `pg-rehome-cell-${suffix}-${role}`,
     url: `https://pg-rehome-${suffix}-${role}.example.test`,

--- a/cloud/apps/relay/src/regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-store.test.ts
@@ -81,6 +81,7 @@ describe('regional rehome assignment state', () => {
       notBefore: context.now(),
       ratePerMinute: 10,
       preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: 7 * 24 * 60 * 60_000,
       drainGraceMs: 60_000
     })).rejects.toThrow('regional_rehome_generation_mismatch')
     await expect(context.store.applyRegionalRehomeControl({
@@ -89,6 +90,7 @@ describe('regional rehome assignment state', () => {
       notBefore: context.now(),
       ratePerMinute: 10,
       preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: 7 * 24 * 60 * 60_000,
       drainGraceMs: 60_000
     })).resolves.toMatchObject({ generation: 3, enabled: true })
     await context.database.close()
@@ -373,15 +375,49 @@ describe('regional rehome assignment state', () => {
     await context.database.close()
   })
 
-  it('names the skip when the preferred region holds no eligible target cell', async () => {
+  it('drops a candidate at scan time when no cell in the preferred region is usable', async () => {
     const context = await setup()
     await activatePreferredSource(context, {
       userId: 'user-1',
       relayHostId: 'abcdefghijklmnop'
     })
+    // A disabled cell is not a target, and the scan must say so: leaving it to
+    // the claim would burn a slot of the candidate batch on a certain skip.
     await context.database.query(`UPDATE relay_cells SET enabled = 0 WHERE cell_id = ?`, [
       target.id
     ])
+
+    const warnings = collectEventWarnings('orca_relay_regional_rehome_candidates_skipped')
+    try {
+      expect(await context.store.claimRegionalRehome()).toBeNull()
+    } finally {
+      warnings.restore()
+    }
+    expect(warnings.entries).toEqual([])
+    expect(
+      await context.database.query(
+        `SELECT next_dispatch_at FROM relay_region_rehome_worker_state`
+      )
+    ).toEqual([{ next_dispatch_at: 0 }])
+    expect(await context.database.query(`SELECT * FROM relay_assignment_migrations`)).toEqual([])
+    await context.database.close()
+  })
+
+  it('names the skip when the last target is lost between scan and claim', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const context = await setup({
+      database,
+      wrap: (delegate) =>
+        hookAfterCandidateScan(delegate, async (transaction) => {
+          await transaction.query(`UPDATE relay_cells SET enabled = 0 WHERE cell_id = ?`, [
+            target.id
+          ])
+        })
+    })
+    await activatePreferredSource(context, {
+      userId: 'user-1',
+      relayHostId: 'abcdefghijklmnop'
+    })
 
     const warnings = collectEventWarnings('orca_relay_regional_rehome_candidates_skipped')
     try {
@@ -396,8 +432,87 @@ describe('regional rehome assignment state', () => {
       generation: 1,
       enabled: true
     })
-    expect(await context.database.query(`SELECT * FROM relay_assignment_migrations`)).toEqual([])
+    expect(await database.query(`SELECT * FROM relay_assignment_migrations`)).toEqual([])
+    await database.close()
+  })
+
+  it('leaves a host alone until its cooldown expires, then moves it back', async () => {
+    const context = await setup({ hostCooldownMs: 3 * 24 * 60 * 60_000 })
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    const targetControl = await completeRehomeToTarget(context, identity)
+    // Past the dispatch interval the earlier claim charged, so the next tick
+    // really does scan and the cooldown is the only thing holding this host.
+    context.advance(10_000)
+    // The desktop's region probe now says us-central1 again.
+    await context.store.assign(identity, 'us-central1')
+
+    const warnings = collectEventWarnings('orca_relay_regional_rehome_candidates_skipped')
+    try {
+      expect(await context.store.claimRegionalRehome()).toBeNull()
+    } finally {
+      warnings.restore()
+    }
+    expect(warnings.entries).toEqual([])
+    expect(await context.store.resolve(identity)).toMatchObject({ cellId: target.id })
+
+    context.advance(3 * 24 * 60 * 60_000)
+    await freshHeartbeats(context)
+    await context.store.renewControlActivity(identity, {
+      activityId: targetControl,
+      cellId: target.id,
+      expiresAt: context.now() + 90_000
+    })
+    await context.store.assign(identity, 'us-central1')
+
+    const attempt = await context.store.claimRegionalRehome()
+    expect(attempt).toMatchObject({
+      preferredRegion: 'us-central1',
+      sourceCellId: target.id,
+      targetCellId: source.id
+    })
     await context.database.close()
+  })
+
+  it('rejects a host whose attempt lands between the scan and the claim', async () => {
+    const database = await openInMemoryRelayDatabase()
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    const context = await setup({
+      database,
+      wrap: (delegate) =>
+        hookAfterCandidateScan(delegate, async (transaction) => {
+          await transaction.query(
+            `INSERT INTO relay_region_rehome_attempts
+             (attempt_id, user_id, relay_host_id, preferred_region, source_cell_id,
+              source_cell_incarnation, target_cell_id, target_cell_incarnation,
+              previous_epoch, assignment_epoch, drain_grace_ms, send_attempts,
+              created_at, updated_at)
+             VALUES ('raced', ?, ?, 'asia-east2', ?, ?, ?, ?, 0, 1, 0, 0, ?, ?)`,
+            [
+              identity.userId,
+              identity.relayHostId,
+              source.id,
+              sourceIncarnation,
+              target.id,
+              targetIncarnation,
+              context.now(),
+              context.now()
+            ]
+          )
+        })
+    })
+    await activatePreferredSource(context, identity)
+
+    const warnings = collectEventWarnings('orca_relay_regional_rehome_candidates_skipped')
+    try {
+      expect(await context.store.claimRegionalRehome()).toBeNull()
+    } finally {
+      warnings.restore()
+    }
+    expect(warnings.entries).toMatchObject([
+      { skips: [{ reason: 'host_cooldown', candidates: 1 }] }
+    ])
+    expect(await database.query(`SELECT * FROM relay_assignment_migrations`)).toEqual([])
+    await database.close()
   })
 
   it('does not scan a candidate whose preferred region has no drainable cell', async () => {
@@ -579,6 +694,7 @@ describe('regional rehome assignment state', () => {
       notBefore: context.now(),
       ratePerMinute: 10,
       preferenceMaxAgeMs: 24 * 60 * 60_000,
+      hostCooldownMs: 7 * 24 * 60 * 60_000,
       drainGraceMs: 60_000
     })
     const retry = await context.store.claimRegionalRehome()
@@ -1654,11 +1770,13 @@ async function setup(
   options: {
     sourceProtocol?: number
     targetProtocol?: number
+    hostCooldownMs?: number
+    database?: RelayDatabase
     wrap?: (database: RelayDatabase) => RelayDatabase
   } = {}
 ) {
   let clock = 1_000_000
-  const database = await openInMemoryRelayDatabase()
+  const database = options.database ?? (await openInMemoryRelayDatabase())
   const store = new RelayAssignmentStore(options.wrap?.(database) ?? database, () => clock, {
     requireLiveCells: true,
     heartbeatTtlMs: 45_000
@@ -1671,6 +1789,7 @@ async function setup(
     notBefore: clock,
     ratePerMinute: 10,
     preferenceMaxAgeMs: 24 * 60 * 60_000,
+    hostCooldownMs: options.hostCooldownMs ?? 7 * 24 * 60 * 60_000,
     drainGraceMs: 60 * 60_000
   })
   await store.reconcileCells([source, target])
@@ -1792,6 +1911,54 @@ async function activatePreferredSource(
   })
   await context.store.assign(identity, 'asia-east2')
   return control
+}
+
+// Runs a hook inside the claim transaction, right after the candidate scan, so
+// a scan-versus-claim race is deterministic instead of timing-dependent.
+function hookAfterCandidateScan(
+  database: RelayDatabase,
+  hook: (transaction: RelayDatabase) => Promise<void>
+): RelayDatabase {
+  let fired = false
+  const decorate = (delegate: RelayDatabase): RelayDatabase => ({
+    query: async (sql, params) => {
+      const rows = await delegate.query(sql, params)
+      if (!fired && sql.includes('FROM relay_assignment_region_preferences preference')) {
+        fired = true
+        await hook(delegate)
+      }
+      return rows
+    },
+    queryLocked: async (sql, params, lockOptions) =>
+      await delegate.queryLocked(sql, params, lockOptions),
+    transaction: async (operation, transactionOptions) =>
+      await delegate.transaction(
+        async (transaction) => await operation(decorate(transaction)),
+        transactionOptions
+      ),
+    close: async () => undefined
+  })
+  return decorate(database)
+}
+
+async function completeRehomeToTarget(
+  context: Context,
+  identity: { userId: string; relayHostId: string }
+): Promise<string> {
+  const sourceControl = await activatePreferredSource(context, identity)
+  const attempt = await context.store.claimRegionalRehome()
+  const targetControl = await context.store.activateControl(identity, {
+    cellId: target.id,
+    assignmentEpoch: attempt!.assignmentEpoch,
+    generation: 1
+  })
+  await context.store.markMigrationTargetRegistered(identity, {
+    cellId: target.id,
+    assignmentEpoch: attempt!.assignmentEpoch
+  })
+  await context.store.releaseActivity(identity, sourceControl)
+  await context.store.completeReadyRegionalRehomes()
+  return targetControl
 }
 
 async function activateReversePreferredSource(

--- a/cloud/apps/relay/src/regional-rehome-store.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-store.test.ts
@@ -207,7 +207,7 @@ describe('regional rehome assignment state', () => {
       databasePoolWaitersMax: 0,
       databasePoolWaitMsMax: 0
     })
-    await heartbeat(context.store, target, targetIncarnation, 0, 2, {
+    await heartbeat(context.store, target, targetIncarnation, 1, 2, {
       observedAt: context.now(),
       sqlFailures: 1,
       reconnects: 3,
@@ -226,6 +226,23 @@ describe('regional rehome assignment state', () => {
     await context.database.close()
   })
 
+  it('counts only drainable cells as the rehome fleet, in every region', async () => {
+    // The fleet whose health gates a rehome is exactly the cells that can be a
+    // source or a target, and both roles require the drain protocol.
+    const context = await setup({ targetProtocol: 0 })
+
+    expect(await context.store.regionalRehomeFleetSafety()).toMatchObject({
+      requiredCells: 1,
+      missingCells: 0
+    })
+    await heartbeat(context.store, target, targetIncarnation, 1, 2)
+    expect(await context.store.regionalRehomeFleetSafety()).toMatchObject({
+      requiredCells: 2,
+      missingCells: 0
+    })
+    await context.database.close()
+  })
+
   it('claims through the measured healthy baseline of pool micro-waits and churn', async () => {
     const context = await setup()
     const baseline = {
@@ -238,7 +255,7 @@ describe('regional rehome assignment state', () => {
       databasePoolWaitMsMax: 1
     }
     await heartbeat(context.store, source, sourceIncarnation, 1, 2, baseline)
-    await heartbeat(context.store, target, targetIncarnation, 0, 2, baseline)
+    await heartbeat(context.store, target, targetIncarnation, 1, 2, baseline)
     await activatePreferredSource(context, {
       userId: 'user-1',
       relayHostId: 'abcdefghijklmnop'
@@ -321,6 +338,91 @@ describe('regional rehome assignment state', () => {
     )
 
     expect(await context.store.claimRegionalRehome()).not.toBeNull()
+    await context.database.close()
+  })
+
+  it('moves a live host on an asia-east2 cell back to its preferred us-central1 cell', async () => {
+    const context = await setup()
+    const identity = { userId: 'user-1', relayHostId: 'abcdefghijklmnop' }
+    await activateReversePreferredSource(context, identity)
+
+    const attempt = await context.store.claimRegionalRehome()
+    expect(attempt).toMatchObject({
+      userId: identity.userId,
+      relayHostId: identity.relayHostId,
+      preferredRegion: 'us-central1',
+      sourceCellId: target.id,
+      sourceCellIncarnation: targetIncarnation,
+      targetCellId: source.id,
+      targetCellIncarnation: sourceIncarnation,
+      previousEpoch: 1,
+      assignmentEpoch: 2,
+      sendAttempts: 1
+    })
+    expect(
+      await context.database.query(
+        `SELECT preferred_region, source_cell_id, target_cell_id
+         FROM relay_region_rehome_attempts`
+      )
+    ).toEqual([{
+      preferred_region: 'us-central1',
+      source_cell_id: target.id,
+      target_cell_id: source.id
+    }])
+    expect(await context.store.resolve(identity)).toMatchObject({ cellId: source.id })
+    await context.database.close()
+  })
+
+  it('names the skip when the preferred region holds no eligible target cell', async () => {
+    const context = await setup()
+    await activatePreferredSource(context, {
+      userId: 'user-1',
+      relayHostId: 'abcdefghijklmnop'
+    })
+    await context.database.query(`UPDATE relay_cells SET enabled = 0 WHERE cell_id = ?`, [
+      target.id
+    ])
+
+    const warnings = collectEventWarnings('orca_relay_regional_rehome_candidates_skipped')
+    try {
+      expect(await context.store.claimRegionalRehome()).toBeNull()
+    } finally {
+      warnings.restore()
+    }
+    expect(warnings.entries).toMatchObject([
+      { skips: [{ reason: 'no_eligible_target', candidates: 1 }] }
+    ])
+    expect(await context.store.inspectRegionalRehomeControl()).toMatchObject({
+      generation: 1,
+      enabled: true
+    })
+    expect(await context.database.query(`SELECT * FROM relay_assignment_migrations`)).toEqual([])
+    await context.database.close()
+  })
+
+  it('does not scan a candidate whose preferred region has no drainable cell', async () => {
+    // A cell without the drain protocol cannot be a target: the host would land
+    // where no later rehome could move it out again. The candidate query drops
+    // it, so the tick stays idle instead of paying for an inventory scan.
+    const context = await setup({ targetProtocol: 0 })
+    await activatePreferredSource(context, {
+      userId: 'user-1',
+      relayHostId: 'abcdefghijklmnop'
+    })
+
+    const warnings = collectEventWarnings('orca_relay_regional_rehome_candidates_skipped')
+    try {
+      expect(await context.store.claimRegionalRehome()).toBeNull()
+    } finally {
+      warnings.restore()
+    }
+    expect(warnings.entries).toEqual([])
+    expect(
+      await context.database.query(
+        `SELECT next_dispatch_at FROM relay_region_rehome_worker_state`
+      )
+    ).toEqual([{ next_dispatch_at: 0 }])
+    expect(await context.database.query(`SELECT * FROM relay_assignment_migrations`)).toEqual([])
     await context.database.close()
   })
 
@@ -457,7 +559,7 @@ describe('regional rehome assignment state', () => {
       databasePoolWaitersMax: 0,
       databasePoolWaitMsMax: 0
     })
-    await heartbeat(context.store, target, targetIncarnation, 0, 2, {
+    await heartbeat(context.store, target, targetIncarnation, 1, 2, {
       observedAt: context.now(),
       sqlFailures: 0,
       reconnects: 0,
@@ -547,7 +649,7 @@ describe('regional rehome assignment state', () => {
     await activatePreferredSource(context, identity)
     await context.store.claimRegionalRehome()
     context.advance(6 * 60_000)
-    await heartbeat(context.store, target, targetIncarnation, 0, 2)
+    await heartbeat(context.store, target, targetIncarnation, 1, 2)
 
     expect(await context.store.refreshRegionalRehomeLeases()).toBe(0)
     expect(await context.store.abortExpiredEvacuations()).toBe(0)
@@ -1549,7 +1651,11 @@ function collectDisableWarnings() {
 }
 
 async function setup(
-  options: { sourceProtocol?: number; wrap?: (database: RelayDatabase) => RelayDatabase } = {}
+  options: {
+    sourceProtocol?: number
+    targetProtocol?: number
+    wrap?: (database: RelayDatabase) => RelayDatabase
+  } = {}
 ) {
   let clock = 1_000_000
   const database = await openInMemoryRelayDatabase()
@@ -1569,7 +1675,7 @@ async function setup(
   })
   await store.reconcileCells([source, target])
   await heartbeat(store, source, sourceIncarnation, options.sourceProtocol ?? 1)
-  await heartbeat(store, target, targetIncarnation, 0)
+  await heartbeat(store, target, targetIncarnation, options.targetProtocol ?? 1)
   return {
     database,
     store,
@@ -1671,7 +1777,7 @@ async function freshHeartbeats(context: Context): Promise<void> {
   }
   // The clock doubles as a strictly-increasing connection inclusion watermark.
   await heartbeat(context.store, source, sourceIncarnation, 1, context.now(), safety)
-  await heartbeat(context.store, target, targetIncarnation, 0, context.now(), safety)
+  await heartbeat(context.store, target, targetIncarnation, 1, context.now(), safety)
 }
 
 async function activatePreferredSource(
@@ -1685,6 +1791,20 @@ async function activatePreferredSource(
     generation: 1
   })
   await context.store.assign(identity, 'asia-east2')
+  return control
+}
+
+async function activateReversePreferredSource(
+  context: Context,
+  identity: { userId: string; relayHostId: string }
+): Promise<string> {
+  const assignment = await context.store.assign(identity, undefined, 'asia-east2')
+  const control = await context.store.activateControl(identity, {
+    cellId: target.id,
+    assignmentEpoch: assignment.assignmentEpoch,
+    generation: 1
+  })
+  await context.store.assign(identity, 'us-central1')
   return control
 }
 

--- a/cloud/apps/relay/src/regional-rehome-target-selection.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-target-selection.test.ts
@@ -36,6 +36,7 @@ async function setup() {
     notBefore: clock,
     ratePerMinute: 10,
     preferenceMaxAgeMs: 24 * 60 * 60_000,
+    hostCooldownMs: 7 * 24 * 60 * 60_000,
     drainGraceMs: 60 * 60_000
   })
   await store.reconcileCells([source, noHeadroom, unclean, highLoad, lowLoad])

--- a/cloud/apps/relay/src/regional-rehome-target-selection.test.ts
+++ b/cloud/apps/relay/src/regional-rehome-target-selection.test.ts
@@ -100,22 +100,22 @@ describe('regional rehome target selection', () => {
       sqlFailures: 0
     })
     // Lowest load but the connection hard cap is exhausted.
-    await context.beat(noHeadroom, 2, 0, {
+    await context.beat(noHeadroom, 2, 1, {
       observedRequests: 0,
       enforcedConnections: 999,
       sqlFailures: 0
     })
-    await context.beat(unclean, 3, 0, {
+    await context.beat(unclean, 3, 1, {
       observedRequests: 0,
       enforcedConnections: 0,
       sqlFailures: UNCLEAN
     })
-    await context.beat(highLoad, 4, 0, {
+    await context.beat(highLoad, 4, 1, {
       observedRequests: 50,
       enforcedConnections: 0,
       sqlFailures: 0
     })
-    await context.beat(lowLoad, 5, 0, {
+    await context.beat(lowLoad, 5, 1, {
       observedRequests: 10,
       enforcedConnections: 0,
       sqlFailures: 0
@@ -134,22 +134,22 @@ describe('regional rehome target selection', () => {
       enforcedConnections: 0,
       sqlFailures: 0
     })
-    await context.beat(noHeadroom, 2, 0, {
+    await context.beat(noHeadroom, 2, 1, {
       observedRequests: 0,
       enforcedConnections: 999,
       sqlFailures: 0
     })
-    await context.beat(unclean, 3, 0, {
+    await context.beat(unclean, 3, 1, {
       observedRequests: 0,
       enforcedConnections: 0,
       sqlFailures: UNCLEAN
     })
-    await context.beat(highLoad, 4, 0, {
+    await context.beat(highLoad, 4, 1, {
       observedRequests: 50,
       enforcedConnections: 0,
       sqlFailures: 0
     })
-    await context.beat(lowLoad, 5, 0, {
+    await context.beat(lowLoad, 5, 1, {
       observedRequests: 10,
       enforcedConnections: 0,
       sqlFailures: UNCLEAN

--- a/cloud/dev/scripts/operate-relay-regional-rehome.mjs
+++ b/cloud/dev/scripts/operate-relay-regional-rehome.mjs
@@ -45,6 +45,7 @@ export function parseRegionalRehomeArguments(argv, environment = process.env) {
     'not-before',
     'rate-per-minute',
     'preference-max-age-ms',
+    'host-cooldown-ms',
     'drain-grace-ms',
     'confirmation'
   ]
@@ -117,6 +118,11 @@ export function parseRegionalRehomeArguments(argv, environment = process.env) {
             '--preference-max-age-ms',
             { minimum: 60_000, maximum: 30 * 24 * 60 * 60_000 }
           ),
+          hostCooldownMs: integer(
+            values['host-cooldown-ms'],
+            '--host-cooldown-ms',
+            { minimum: 60_000, maximum: 30 * 24 * 60 * 60_000 }
+          ),
           drainGraceMs: integer(values['drain-grace-ms'], '--drain-grace-ms', {
             minimum: 60_000,
             maximum: 60 * 60_000
@@ -147,6 +153,7 @@ function assertControl(control, expected) {
     !Number.isSafeInteger(control.notBefore) ||
     !Number.isSafeInteger(control.ratePerMinute) ||
     !Number.isSafeInteger(control.preferenceMaxAgeMs) ||
+    !Number.isSafeInteger(control.hostCooldownMs) ||
     !Number.isSafeInteger(control.drainGraceMs)
   ) throw new Error('director returned an invalid regional rehome control')
   if (expected.enabled !== undefined && control.enabled !== expected.enabled) {
@@ -171,6 +178,7 @@ async function applyDisabledControl(post, before) {
     notBefore: before.notBefore,
     ratePerMinute: before.ratePerMinute,
     preferenceMaxAgeMs: before.preferenceMaxAgeMs,
+    hostCooldownMs: before.hostCooldownMs,
     drainGraceMs: before.drainGraceMs,
     confirmation: 'DISABLE_REGIONAL_REHOMING'
   })).control, { generation: before.generation + 1, enabled: false })
@@ -278,6 +286,7 @@ export async function operateRegionalRehome(config, dependencies = {}) {
     notBefore: config.notBefore,
     ratePerMinute: config.ratePerMinute,
     preferenceMaxAgeMs: config.preferenceMaxAgeMs,
+    hostCooldownMs: config.hostCooldownMs,
     drainGraceMs: config.drainGraceMs,
     confirmation: enabled
       ? 'ENABLE_REGIONAL_REHOMING'

--- a/cloud/dev/scripts/operate-relay-regional-rehome.mjs
+++ b/cloud/dev/scripts/operate-relay-regional-rehome.mjs
@@ -153,13 +153,23 @@ function assertControl(control, expected) {
     !Number.isSafeInteger(control.notBefore) ||
     !Number.isSafeInteger(control.ratePerMinute) ||
     !Number.isSafeInteger(control.preferenceMaxAgeMs) ||
-    !Number.isSafeInteger(control.hostCooldownMs) ||
+    // A director predating the per-host cooldown does not report it. Reading
+    // the control and both emergency brakes must keep working against that
+    // image; only enable requires the field.
+    (control.hostCooldownMs !== undefined &&
+      !Number.isSafeInteger(control.hostCooldownMs)) ||
     !Number.isSafeInteger(control.drainGraceMs)
   ) throw new Error('director returned an invalid regional rehome control')
   if (expected.enabled !== undefined && control.enabled !== expected.enabled) {
     throw new Error('regional rehome enabled state does not match')
   }
   return control
+}
+
+// Echo the cooldown only when the director already reports it: a legacy
+// director rejects the unknown key outright and would refuse every brake.
+function cooldownField(before, value) {
+  return before.hostCooldownMs === undefined ? {} : { hostCooldownMs: value }
 }
 
 async function verifiedDisabledControl(post, generation) {
@@ -178,7 +188,7 @@ async function applyDisabledControl(post, before) {
     notBefore: before.notBefore,
     ratePerMinute: before.ratePerMinute,
     preferenceMaxAgeMs: before.preferenceMaxAgeMs,
-    hostCooldownMs: before.hostCooldownMs,
+    ...cooldownField(before, before.hostCooldownMs),
     drainGraceMs: before.drainGraceMs,
     confirmation: 'DISABLE_REGIONAL_REHOMING'
   })).control, { generation: before.generation + 1, enabled: false })
@@ -278,6 +288,11 @@ export async function operateRegionalRehome(config, dependencies = {}) {
     throw new Error('regional rehome is already paused')
   }
   const enabled = config.mode === 'enable'
+  if (enabled && before.hostCooldownMs === undefined) {
+    throw new Error(
+      'director does not report a per-host rehome cooldown; deploy a director that supports it before enabling'
+    )
+  }
   const applied = await post('/v1/admin/regional-rehome-control', {
     v: 1,
     action: 'apply',
@@ -286,7 +301,7 @@ export async function operateRegionalRehome(config, dependencies = {}) {
     notBefore: config.notBefore,
     ratePerMinute: config.ratePerMinute,
     preferenceMaxAgeMs: config.preferenceMaxAgeMs,
-    hostCooldownMs: config.hostCooldownMs,
+    ...cooldownField(before, config.hostCooldownMs),
     drainGraceMs: config.drainGraceMs,
     confirmation: enabled
       ? 'ENABLE_REGIONAL_REHOMING'

--- a/cloud/dev/scripts/operate-relay-regional-rehome.test.mjs
+++ b/cloud/dev/scripts/operate-relay-regional-rehome.test.mjs
@@ -46,6 +46,24 @@ function control(generation, enabled) {
   }
 }
 
+// The control a director predating the per-host cooldown reports.
+function legacyControl(generation, enabled) {
+  const { hostCooldownMs: _absent, ...rest } = control(generation, enabled)
+  return rest
+}
+
+function legacyDirector(controls) {
+  const requests = []
+  const post = async (path, body) => {
+    requests.push({ path, body })
+    if (path === '/v1/admin/admission-selector/status') {
+      return { selector: { generation: 11, membership } }
+    }
+    return { v: 1, control: controls.shift() }
+  }
+  return { requests, post }
+}
+
 test('parses exact selector and typed control confirmation', () => {
   const parsed = parseRegionalRehomeArguments(
     argumentsFor('enable', 'ENABLE_REGIONAL_REHOMING'),
@@ -110,6 +128,7 @@ test('binds enable to exact selector and durable control generations', async () 
     }
   })
   assert.equal(result.control.generation, 5)
+  assert.equal(result.control.hostCooldownMs, 604_800_000)
   assert.deepEqual(requests[2].body, {
     v: 1,
     action: 'apply',
@@ -122,6 +141,76 @@ test('binds enable to exact selector and durable control generations', async () 
     drainGraceMs: 60_000,
     confirmation: 'ENABLE_REGIONAL_REHOMING'
   })
+})
+
+test('inspects a director that predates the per-host cooldown', async () => {
+  const director = legacyDirector([legacyControl(4, true)])
+  const config = parseRegionalRehomeArguments(
+    argumentsFor('inspect'),
+    { ORCA_RELAY_ADMIN_ID_TOKEN: 'token' }
+  )
+
+  const result = await operateRegionalRehome(config, { post: director.post })
+
+  assert.equal(result.control.generation, 4)
+  assert.equal(result.control.hostCooldownMs, undefined)
+})
+
+for (const [mode, confirmation, enabledBefore] of [
+  ['pause', 'PAUSE_REGIONAL_REHOMING', true],
+  ['disable', 'DISABLE_REGIONAL_REHOMING', false]
+]) {
+  test(`${mode} still brakes a director that predates the cooldown`, async () => {
+    const director = legacyDirector([
+      legacyControl(4, enabledBefore),
+      legacyControl(5, false),
+      legacyControl(5, false)
+    ])
+    const config = parseRegionalRehomeArguments(
+      argumentsFor(mode, confirmation),
+      { ORCA_RELAY_ADMIN_ID_TOKEN: 'token' }
+    )
+
+    const result = await operateRegionalRehome(config, { post: director.post })
+
+    assert.equal(result.control.generation, 5)
+    // The unknown key would be refused by that director's strict schema.
+    assert.equal('hostCooldownMs' in director.requests[2].body, false)
+    assert.equal(director.requests[2].body.confirmation, 'DISABLE_REGIONAL_REHOMING')
+  })
+}
+
+test('failed-enable recovery brakes a director that predates the cooldown', async () => {
+  const requests = []
+  let current = legacyControl(7, true)
+  const result = await recoverRegionalRehomeEnable({
+    mode: 'recover-enable',
+    expectedControlGeneration: 4
+  }, async (_path, body) => {
+    requests.push(body)
+    if (body.action === 'inspect') return { control: current }
+    current = legacyControl(8, false)
+    return { control: current }
+  })
+
+  assert.equal(result.control.generation, 8)
+  assert.equal('hostCooldownMs' in requests[1], false)
+})
+
+test('refuses to enable a director that does not report the cooldown', async () => {
+  const director = legacyDirector([legacyControl(4, false)])
+  const config = parseRegionalRehomeArguments(
+    argumentsFor('enable', 'ENABLE_REGIONAL_REHOMING'),
+    { ORCA_RELAY_ADMIN_ID_TOKEN: 'token' }
+  )
+
+  await assert.rejects(
+    operateRegionalRehome(config, { post: director.post }),
+    /per-host rehome cooldown/
+  )
+  // Read-only: selector status and the control inspect, and nothing else.
+  assert.equal(director.requests.length, 2)
+  assert.equal(director.requests.every(({ body }) => body.action !== 'apply'), true)
 })
 
 test('fails closed on selector drift before reading or mutating control', async () => {

--- a/cloud/dev/scripts/operate-relay-regional-rehome.test.mjs
+++ b/cloud/dev/scripts/operate-relay-regional-rehome.test.mjs
@@ -26,6 +26,7 @@ function argumentsFor(mode, confirmation) {
       '--not-before', '2000000000000',
       '--rate-per-minute', '10',
       '--preference-max-age-ms', '86400000',
+      '--host-cooldown-ms', '604800000',
       '--drain-grace-ms', '60000',
       '--confirmation', confirmation
     ])
@@ -40,6 +41,7 @@ function control(generation, enabled) {
     notBefore: 2_000_000_000_000,
     ratePerMinute: 10,
     preferenceMaxAgeMs: 86_400_000,
+    hostCooldownMs: 604_800_000,
     drainGraceMs: 60_000
   }
 }
@@ -52,6 +54,17 @@ test('parses exact selector and typed control confirmation', () => {
   assert.equal(parsed.expectedSelectorGeneration, 11)
   assert.equal(parsed.expectedControlGeneration, 4)
   assert.equal(parsed.ratePerMinute, 10)
+  assert.equal(parsed.hostCooldownMs, 604_800_000)
+  assert.throws(
+    () => parseRegionalRehomeArguments(
+      argumentsFor('enable', 'ENABLE_REGIONAL_REHOMING').filter(
+        (value, index, all) =>
+          value !== '--host-cooldown-ms' && all[index - 1] !== '--host-cooldown-ms'
+      ),
+      { ORCA_RELAY_ADMIN_ID_TOKEN: 'token' }
+    ),
+    /complete durable control shape/
+  )
   assert.throws(
     () => parseRegionalRehomeArguments(
       argumentsFor('pause', 'DISABLE_REGIONAL_REHOMING'),
@@ -79,6 +92,7 @@ test('binds enable to exact selector and durable control generations', async () 
     notBefore: 0,
     ratePerMinute: 10,
     preferenceMaxAgeMs: 86_400_000,
+    hostCooldownMs: 604_800_000,
     drainGraceMs: 60_000,
     ...control
   }))
@@ -104,6 +118,7 @@ test('binds enable to exact selector and durable control generations', async () 
     notBefore: 2_000_000_000_000,
     ratePerMinute: 10,
     preferenceMaxAgeMs: 86_400_000,
+    hostCooldownMs: 604_800_000,
     drainGraceMs: 60_000,
     confirmation: 'ENABLE_REGIONAL_REHOMING'
   })
@@ -150,6 +165,7 @@ test('failed-enable recovery CAS-disables an advanced enabled generation', async
     notBefore: 2_000_000_000_000,
     ratePerMinute: 10,
     preferenceMaxAgeMs: 86_400_000,
+    hostCooldownMs: 604_800_000,
     drainGraceMs: 60_000,
     confirmation: 'DISABLE_REGIONAL_REHOMING'
   })

--- a/cloud/docs/orca-relay-operations.md
+++ b/cloud/docs/orca-relay-operations.md
@@ -464,6 +464,18 @@ Once a target control is registered, do not force the pre-registration rollback.
 
 After a deployment traffic shift, preserve the old revision/tag until metrics and live reconnect checks pass. If the new revision is unhealthy, shift traffic back only while old controls are still valid, then issue a strictly newer director migration rather than reusing a prior epoch.
 
+## Regional rehoming
+
+Rehoming moves a host to a general cell in the region its desktop last reported, in either
+direction. Both roles need the drain protocol: a cell without it can be neither a source nor a
+target, and it is not part of the fleet whose telemetry gates the worker. Until the asia-east2
+cells run `regionalRehomeProtocol` 1 they are none of the three, so no host is moved into or out
+of Asia and an Asia cell in distress does not pause the worker.
+
+`host-cooldown-ms` is the minimum gap between two rehomes of one host. It bounds the damage from
+a desktop whose region probe flips: without it the host would be dragged back across the ocean on
+every flip, since the preference age never expires while the host keeps reconnecting.
+
 ## Game-day matrix
 
 Run and record each scenario in staging before launch:


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​973 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​944 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​181 |

<!-- /orca-pr-loc -->

## Why

The regional rehome worker only ever moved hosts with `preferred_region = asia-east2` sitting on a us-central1 cell. A desktop bug (fixed in #19233) made US desktops request asia-east2, and the worker moved them to Asia cells where every phone connect pays trans-Pacific Cloud SQL round trips (~10 s to connected instead of ~0.6 s). Assignments are sticky and rehome was one-directional, so those hosts are stuck. A 2026-09-06 census found ~226 non-APAC desktops on the three Asia cells. This makes the worker move a host whenever its fresh preference disagrees with its cell's region, in either direction.

## What

- **Direction generalized.** Candidate scan uses `preference.preferred_region <> region.region` and requires an enabled, general, ready, heartbeating cell with `regional_rehome_protocol >= 1` in the preferred region. Claim-lock re-check compares the preference to the source cell's region. Target selection picks from the preferred region. Fleet safety covers every enabled general protocol≥1 cell. After the change, the only `'asia-east2'` / `'us-central1'` literals in the relay are the schema/catalog lists, now rendered from `RELAY_REGIONS`.
- **Per-host cooldown.** `relay_region_rehome_control.host_cooldown_ms` (default 7 days, bounds 60 s to 30 days), plumbed like `preference_max_age_ms` from the workflow input through the ops script to the durable row. Any attempt row for the host (either direction, completed or aborted) inside the window skips the candidate at scan and, with the named reason `host_cooldown`, under the claim lock. Without this a desktop whose preference flips would be drained across the Pacific on every flip, since the preference row refreshes on each sticky assign.
- **Schema.** `relay_region_rehome_attempts.preferred_region` check relaxed to the region catalog via a named constraint; `host_cooldown_ms` column with a default; recency index on attempts. Postgres migrations run through `POSTGRES_SCHEMA_MIGRATIONS`; 42710 on `ADD CONSTRAINT` is treated as already applied. SQLite keeps the old check on pre-existing files.
- **Ops script rollout safety.** `inspect`, `pause`, `disable`, and `recover-enable` work against a director that predates the cooldown field (the key is validated only when present and omitted on echo-back). `enable` refuses, before any mutation, when the director does not report the field.
- Trust probe no longer region-gated. Ops doc gains a regional rehoming section: a cell without the drain protocol is neither source, target, nor safety-gate member.

## Not live

The durable control is disabled in production (generation 12). Nothing moves until an operator enables it. The Asia cells report protocol 0 today; #19239 (draft) gives them the rehome identity and must roll only after this director is deployed.

## Wire

No phone or desktop change. Desktops follow `relay-moved` as today; protocol-0 desktops are excluded by the existing capability check.

## Verification

- Fresh Postgres on 55440 after rebase on main: relay 72 files / 620 tests; relay-contract build; `pnpm typecheck`; ops-script 17 tests. Workspace dev-script and contract suites passed in the agent run.
- Migration verified against a legacy-shaped table holding a live control row: 3 sequential and 10 concurrent startups, zero rejections, one correct constraint, the row kept its generation and gained the default.
- Independent adversarial review, three rounds: round 1 added the cooldown and the enabled predicate; round 2 fixed the ops script losing inspect and both brakes against an older director; round 3 approved.

Not for merge until the owner gives the go.