### PR TITLE
fix(test): unbreak main — admit the adoption-replay create fixture through the structured-chat gate

### DIFF
--- a/src/main/runtime/rpc/methods/structured-agent-session-adoption-replay.test.ts
+++ b/src/main/runtime/rpc/methods/structured-agent-session-adoption-replay.test.ts
@@ -138,6 +138,11 @@ describe('committed adopting create RPC replay', () => {
       undefined,
       { prepareCodexStructuredLaunch: selectAccountHome }
     )
+    // The structured surface is settings-gated for every caller, not just mobile; this test
+    // probes durable-identity replay, which only runs once the gate admits the call.
+    vi.spyOn(runtime, 'getClientSettings').mockReturnValue({
+      experimentalStructuredNativeChat: true
+    } as ReturnType<OrcaRuntimeService['getClientSettings']>)
     vi.spyOn(runtime, 'getStructuredAgentSessionCreateSupport').mockResolvedValue({
       supported: true
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## What broke

`src/main/runtime/rpc/methods/structured-agent-session-adoption-replay.test.ts` fails on `origin/main`:

```
AssertionError: expected { id: 'request-1', ok: false, …(2) } to match object { ok: true, …(1) }
  committed adopting create RPC replay > republishes from durable identity after the source
  disappears and account selection drifts
```

The `agentSession.create` call is refused at the RPC envelope level (`ok: false`,
`structured_agent_session_unsupported`) instead of succeeding at the envelope level and
refusing at the result level with `agent_session_operation_unknown`.

## Semantic conflict, not a bad PR

Both sides were green on their own branches; the failure only exists after both landed.

- **#19176** (`1ae7aa8bb4f`, "resume an Agent Session History row into a new structured chat")
  added the test. It passed there.
- **#18700** (`ba4e79c2504`, "fix(runtime): apply the structured-chat setting to every RPC
  caller") broke it. The test passes at its parent `c300913f902`.

Neither branch could see the other, and main runs no typecheck/test gate after merge, so it
landed silently red.

## Root cause

Before #18700, `supportsStructuredAgentSessions` only consulted
`experimentalStructuredNativeChat` when `clientKind === 'mobile'`. A `runtime` client was
admitted on its negotiated `agent-session.structured.v1` capability alone. #18700 made the host
setting one rule for every caller.

The adoption-replay fixture builds a **real** `OrcaRuntimeService` from a settings-service stub
that only supplies `agentDefaultEnv`, so `getClientSettings()` never reports the setting on.
Under the new rule the gate refuses before the create handler runs, and the whole
durable-identity replay body — the thing this test exists to cover — never executes.

## Which side I fixed, and why

**The test.** #18700's rule is the intended product behaviour, and it is documented in the gate
itself: methods that *start, extend, retain or read* work go behind `requireStructuredHost`;
only *stop/retire* methods (`close`, `cancel`, `unsubscribe`, `release`) use the cleanup gate.
`agentSession.create` starts work, so it belongs behind the gate — loosening it would undo the
one-rule-for-every-caller fix and re-open the desktop/mobile asymmetry #18700 removed.

Nothing in #19176's test is about admission; it is about republishing from durable identity
after the transcript disappears and account selection drifts. It just needs an admitted caller.

This is also exactly what #18700 already did for the sibling fixture in the same directory —
`structured-agent-session-precommit-refusal.test.ts` got
`getClientSettings: () => ({ experimentalStructuredNativeChat: true })` with the same rationale.
This test was simply not in that branch's tree to be updated.

The fix is five lines and touches no production code. Every replay assertion (`acquire` called
once, `publishStructuredAgentSessionTab` called twice, `selectAccountHome` called once, the two
`agent_session_identity_required` refusals) is unchanged and now genuinely runs — the test was
previously exiting at its first `expect`.

## Verification

- `pnpm tc` — exit 0
- `npx vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/structured-agent-session-adoption-replay.test.ts` — 1 passed
- `npx vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/ src/main/native-chat/agent-session-wire/ --exclude "**/*.electron.test.ts"` — 2021/2022 passed. The one failure, `structured-agent-session-handoff-options.test.ts > keeps a picked model through a native to TUI to native round trip`, is an unrelated `vi.waitFor` timeout under 233-file parallel load; it passes in isolation and touches none of this code.
- `pnpm run check:code-quality:changed` — 0 new findings
