### PR TITLE
fix(mobile): reattach restored runtime-owned terminals before activation

### DIFF
--- a/src/main/runtime/mobile-restored-terminal-reattach.test.ts
+++ b/src/main/runtime/mobile-restored-terminal-reattach.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../shared/stable-pane-id'
+import { OrcaRuntimeService } from './orca-runtime'
+import {
+  HEADLESS_LEAF_ID,
+  TEST_REPO_ID,
+  TEST_WORKTREE_ID,
+  TEST_WORKTREE_PATH,
+  makeHeadlessTerminalLayout,
+  makeRuntimeStoreWithWorkspaceSession,
+  makeWorkspaceSessionWithHeadlessTerminal,
+  store
+} from './orca-runtime-test-fixtures.spec'
+
+const TAB_ID = 'host-tab'
+const RELAY_PTY_ID = 'ssh:ssh-1@@relay-pty'
+const INCARNATION_ID = 'inc-1'
+
+/**
+ * A runtime that restarted while its SSH pane survived: the persisted session still
+ * names the pane's PTY and the provider inventory still lists it, but this runtime
+ * generation has never attached to it.
+ */
+function makeRestartedRuntime(): {
+  runtime: OrcaRuntimeService
+  spawn: ReturnType<typeof vi.fn>
+} {
+  const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+    makeWorkspaceSessionWithHeadlessTerminal({
+      tabsByWorktree: {
+        [TEST_WORKTREE_ID]: [
+          {
+            id: TAB_ID,
+            ptyId: RELAY_PTY_ID,
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Remote Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 1
+          }
+        ]
+      },
+      terminalLayoutsByTabId: {
+        [TAB_ID]: makeHeadlessTerminalLayout({ [HEADLESS_LEAF_ID]: RELAY_PTY_ID })
+      },
+      terminalPtyIncarnationsByPaneKey: {
+        [makePaneKey(TAB_ID, HEADLESS_LEAF_ID)]: INCARNATION_ID
+      }
+    }),
+    'ssh:ssh-1'
+  )
+  const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
+  const spawn = vi.fn().mockResolvedValue({ id: RELAY_PTY_ID, isReattach: true })
+  const runtime = new OrcaRuntimeService({
+    ...runtimeStore,
+    getRepos: () => [remoteRepo],
+    getRepo: (id: string) => (id === TEST_REPO_ID ? remoteRepo : undefined)
+  } as never)
+  runtime.setPtyController({
+    spawn,
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    // The surviving pane is still in the provider's session map after the restart.
+    listProcesses: async () => [
+      {
+        id: RELAY_PTY_ID,
+        worktreeId: TEST_WORKTREE_ID,
+        cwd: TEST_WORKTREE_PATH,
+        incarnationId: INCARNATION_ID,
+        title: 'Remote Terminal'
+      }
+    ]
+  } as never)
+  runtime.syncWindowGraph(0, { tabs: [], leaves: [] } as never)
+  return { runtime, spawn }
+}
+
+function restoredPty(
+  runtime: OrcaRuntimeService
+): { connected: boolean; runtimeSessionOwned: boolean } | undefined {
+  return (
+    runtime as unknown as {
+      ptysById: Map<string, { connected: boolean; runtimeSessionOwned: boolean }>
+    }
+  ).ptysById.get(RELAY_PTY_ID)
+}
+
+describe('restored runtime-owned terminal reattachment', () => {
+  it('records an inventory-restored PTY as connected without owning it', async () => {
+    const { runtime } = makeRestartedRuntime()
+
+    const result = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    // Inventory presence alone makes the tab look usable to the client.
+    expect(result.tabs[0]).toMatchObject({ status: 'ready' })
+    expect(restoredPty(runtime)).toMatchObject({ connected: true, runtimeSessionOwned: false })
+  })
+
+  it('reattaches the restored session on activation instead of trusting inventory', async () => {
+    const { runtime, spawn } = makeRestartedRuntime()
+    await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, TAB_ID)
+
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connectionId: 'ssh-1',
+        tabId: TAB_ID,
+        leafId: HEADLESS_LEAF_ID,
+        sessionId: RELAY_PTY_ID
+      })
+    )
+  })
+
+  it('reattaches once, not on every activation', async () => {
+    const { runtime, spawn } = makeRestartedRuntime()
+    await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, TAB_ID)
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, TAB_ID)
+
+    expect(spawn).toHaveBeenCalledOnce()
+  })
+
+  it('leaves an inventory-restored local tab alone', async () => {
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal({
+        terminalPtyIncarnationsByPaneKey: {
+          [makePaneKey(TAB_ID, HEADLESS_LEAF_ID)]: INCARNATION_ID
+        }
+      })
+    )
+    const spawn = vi.fn().mockResolvedValue({ id: 'persisted-pty' })
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: 'persisted-pty',
+          worktreeId: TEST_WORKTREE_ID,
+          cwd: TEST_WORKTREE_PATH,
+          incarnationId: INCARNATION_ID
+        }
+      ]
+    } as never)
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] } as never)
+    const listed = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    expect(listed.tabs[0]).toMatchObject({ status: 'ready' })
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, TAB_ID)
+
+    // A plain local PTY is renderer-owned; inventory presence must not respawn it.
+    expect(spawn).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/mobile-restored-terminal-reattach.test.ts
+++ b/src/main/runtime/mobile-restored-terminal-reattach.test.ts
@@ -21,7 +21,7 @@ const INCARNATION_ID = 'inc-1'
  * names the pane's PTY and the provider inventory still lists it, but this runtime
  * generation has never attached to it.
  */
-function makeRestartedRuntime(): {
+function makeRestartedRuntime(opts: { publishedByRenderer?: boolean } = {}): {
   runtime: OrcaRuntimeService
   spawn: ReturnType<typeof vi.fn>
 } {
@@ -73,7 +73,34 @@ function makeRestartedRuntime(): {
       }
     ]
   } as never)
-  runtime.syncWindowGraph(0, { tabs: [], leaves: [] } as never)
+  if (opts.publishedByRenderer) {
+    // A desktop-created SSH terminal: the renderer graph lists the tab, so this
+    // runtime is not the only thing that could be attached to the session.
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: TAB_ID,
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Remote Terminal',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: TAB_ID,
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: 1,
+          ptyId: RELAY_PTY_ID,
+          paneTitle: null
+        }
+      ]
+    } as never)
+  } else {
+    runtime.syncWindowGraph(0, { tabs: [], leaves: [] } as never)
+  }
   return { runtime, spawn }
 }
 
@@ -122,6 +149,20 @@ describe('restored runtime-owned terminal reattachment', () => {
     await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, TAB_ID)
 
     expect(spawn).toHaveBeenCalledOnce()
+  })
+
+  it('focuses a renderer-published SSH tab instead of reattaching it', async () => {
+    const { runtime, spawn } = makeRestartedRuntime({ publishedByRenderer: true })
+    const focusTerminal = vi.fn()
+    runtime.setNotifier({ focusTerminal } as never)
+    await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    await runtime.activateMobileSessionTab(`id:${TEST_WORKTREE_ID}`, TAB_ID)
+
+    // The renderer graph lists this tab, so the desktop is already attached.
+    // Reattaching would take a live session away from it.
+    expect(spawn).not.toHaveBeenCalled()
+    expect(focusTerminal).toHaveBeenCalled()
   })
 
   it('leaves an inventory-restored local tab alone', async () => {

--- a/src/main/runtime/orca-runtime-perform-mobile-session-pty-records-refresh.ts
+++ b/src/main/runtime/orca-runtime-perform-mobile-session-pty-records-refresh.ts
@@ -142,9 +142,15 @@ export class OrcaRuntimeWithPerformMobileSessionPtyRecordsRefresh extends OrcaRu
       // inventory as connected, so the projection already reports `ready` — but
       // nothing attached it, and its writes go nowhere. Inventory presence is not
       // ownership; only a runtime-owned live binding proves this runtime attached.
+      // The id shape and `runtimeSessionOwned` cannot tell "never attached" from
+      // "the desktop owns it": every SSH PTY gets an `ssh:` id whoever made it,
+      // and a renderer-published PTY is recorded with the field defaulted false.
+      // Renderer-graph membership is the discriminator, as in
+      // `isRuntimeOwnedHeadlessMobileTab`.
       const needsRestoredRuntimeReattach =
         this.hasServeOrSshOwnedBinding(tab) &&
-        !this.hasLiveRuntimeSessionOwnedPtyBinding(worktreeId, tab)
+        !this.hasLiveRuntimeSessionOwnedPtyBinding(worktreeId, tab) &&
+        !this.tabs.has(tab.parentTabId)
       const shouldMaterializePendingTerminal =
         publicTab?.type === 'terminal' &&
         (publicTab.status !== 'ready' || needsRestoredRuntimeReattach) &&

--- a/src/main/runtime/orca-runtime-perform-mobile-session-pty-records-refresh.ts
+++ b/src/main/runtime/orca-runtime-perform-mobile-session-pty-records-refresh.ts
@@ -138,9 +138,16 @@ export class OrcaRuntimeWithPerformMobileSessionPtyRecordsRefresh extends OrcaRu
       // their tab id, so focusing the renderer would silently no-op.
       // Phone-local activation also needs this path for inactive restored tabs:
       // desktop focus is intentionally suppressed, but the PTY still must exist.
+      // Why: a restarted runtime records a surviving serve/SSH PTY from provider
+      // inventory as connected, so the projection already reports `ready` — but
+      // nothing attached it, and its writes go nowhere. Inventory presence is not
+      // ownership; only a runtime-owned live binding proves this runtime attached.
+      const needsRestoredRuntimeReattach =
+        this.hasServeOrSshOwnedBinding(tab) &&
+        !this.hasLiveRuntimeSessionOwnedPtyBinding(worktreeId, tab)
       const shouldMaterializePendingTerminal =
         publicTab?.type === 'terminal' &&
-        publicTab.status !== 'ready' &&
+        (publicTab.status !== 'ready' || needsRestoredRuntimeReattach) &&
         // Why: opening a tab is the documented wake gesture for a slept pane
         // (#11598), so only a background probe may be refused for one.
         (!isAutomaticTabActivation(opts.intent) ||


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

Supersedes #11868.

## What the user sees

**Before.** On Orca Mobile, a terminal tab restored after a runtime restart or SSH reconnect renders with its scrollback and reports ready — but typing goes nowhere. The runtime discovered the surviving PTY through inventory and never attached to it, so the tab looks healthy while its writes land nowhere.

**After.** Activating such a tab reattaches it first, so input reaches the process it appears to be connected to.

## Root cause

**Inventory presence was treated as ownership.** `orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts:217-218` records an inventory-listed session as `connected: true` without ever setting `runtimeSessionOwned`. The projection therefore issues a handle and stamps `status: 'ready'` (`runtime-mobile-session-projection.ts:87,214-224,271-273`), and the activation gate skips materialization because the tab already claims to be ready.

Attachment is an operation distinct from process existence: seeing a process in restored state is not the same as having attached to it.

## The fix

Nine lines at `orca-runtime-perform-mobile-session-pty-records-refresh.ts:145-150`. A restored serve/SSH-owned binding with no live runtime-owned binding now also triggers materialization, folded into the existing condition so the parked-pane and host-focus guards still apply to both arms.

## Evidence

Red-then-green, with the ablation re-run independently:

- `reattaches the restored session on activation instead of trusting inventory` — **red on unmodified main** (zero spawn, zero attach), green after.
- `reattaches once, not on every activation` — **red on main**, green after.
- `records an inventory-restored PTY as connected without owning it` — passes on main; this is the mechanism, not a regression test.
- `leaves an inventory-restored local tab alone` — negative control, green in both states.

Reverting just the predicate fails exactly the two regression tests and leaves the mechanism test and negative control passing.

`src/main/runtime` suite: 7,269 passed, 15 skipped, 1 failure (`structured-agent-session-adoption-replay.test.ts`) confirmed pre-existing on unmodified main. Lint, format, max-lines, ts-nocheck ratchet, reliability and changed-code gates all clean.

## Scope notes

- The fix covers serve **and** SSH bindings. The strictly-proven live case is an SSH/relay restored PTY reached by activation; serve is covered on the same invariant, since leaving a restored serve PTY un-owned also distorts later teardown and preservation decisions. The one local self-healing path (`registerRemote` → `ensureProviderAttach`) is local-only by construction and never covers SSH ids.
- #14844's relay sweep does not cover this: `reattachKnownPtys` runs on relay session connect, not on the activation path for a PTY discovered this runtime generation via `listProcesses`.
- **Typecheck is not evidence for this file** — it carries `@ts-nocheck` (as do 175 files in `src/main/runtime`), so the test suite is the only real safety here.

## What was deliberately dropped from #11868

Four of its five sub-defects landed independently over the past month: folder-scope host resolution and hydration targets (#11832, extended by #17486), same-path folder PTY identity (#12474), reattach-across-reconnect for the relay-connect path (#14844), and folder-deletion pruning (now the `worktreeInstanceId` fence plus #17779). Its tombstone/overflow-bucket persistence, pane-spawn reservations, `stable-pane-id` additions, materialization-freshness key and host-aware reservation path flavor are superseded or unexercised, and its new `PersistedState` fields are not worth the cost.

A separate latent issue was found and deliberately **not** fixed here: `getKnownWorktreeIds()` (`runtime-workspace-session-controller.ts:116-134`) cannot admit a `folder:` key and enumerates only local + repo hosts, while its sibling `getHydrationTargets()` (`:159-165`) also reads `getWorkspaceSessionHostIds()`. It has no current user impact — the hydration path masks it — and no red test can be written for it today, so it is filed rather than patched.
