### PR TITLE
fix(mobile): stop stream traffic from masking a stalled control channel

### DIFF
--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -362,6 +362,78 @@ describe('useHostClient', () => {
     }
   })
 
+  // Regression (#10385): reopening the socket proves only that the desktop accepted
+  // a connection. Reporting success on a transport that never answers a control RPC
+  // is what left the reporter with a green card and an unusable session.
+  it('does not leave Force Reconnect connected when the reopened host never answers', async () => {
+    const first = makeFakeClient('connected')
+    const second = makeFakeClient('connected')
+    second.sendRequest = vi.fn().mockRejectedValue(new Error('Request timed out: status.get'))
+    connectMock.mockReturnValueOnce(first).mockReturnValueOnce(second)
+    loadHostsMock.mockResolvedValue([HOST])
+
+    const states: ConnectionState[] = []
+    let forceReconnect: ((hostId: string) => Promise<void>) | null = null
+    let renderer: ReactTestRenderer | null = null
+    function Probe(): null {
+      forceReconnect = useForceReconnect()
+      states.push(useHostClient(HOST.id).state)
+      return null
+    }
+    try {
+      await act(async () => {
+        renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        await forceReconnect?.(HOST.id)
+      })
+
+      expect(second.sendRequest).toHaveBeenCalledWith(
+        'status.get',
+        undefined,
+        expect.objectContaining({ timeoutMs: 15_000 })
+      )
+      expect(second.closeMock).toHaveBeenCalled()
+      expect(states.at(-1)).not.toBe('connected')
+    } finally {
+      act(() => renderer?.unmount())
+    }
+  })
+
+  it('keeps Force Reconnect connected once the reopened host answers', async () => {
+    const first = makeFakeClient('connected')
+    const second = makeFakeClient('connected')
+    second.sendRequest = vi.fn().mockResolvedValue({ id: '1', ok: true, result: {} })
+    connectMock.mockReturnValueOnce(first).mockReturnValueOnce(second)
+    loadHostsMock.mockResolvedValue([HOST])
+
+    const states: ConnectionState[] = []
+    let forceReconnect: ((hostId: string) => Promise<void>) | null = null
+    let renderer: ReactTestRenderer | null = null
+    function Probe(): null {
+      forceReconnect = useForceReconnect()
+      states.push(useHostClient(HOST.id).state)
+      return null
+    }
+    try {
+      await act(async () => {
+        renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        await forceReconnect?.(HOST.id)
+      })
+
+      expect(second.closeMock).not.toHaveBeenCalled()
+      expect(states.at(-1)).toBe('connected')
+    } finally {
+      act(() => renderer?.unmount())
+    }
+  })
+
   it('nudges an existing Relay session instead of starting a fresh direct dial', async () => {
     const relayClient = makeFakeClient('disconnected', 'relay')
     connectMock.mockReturnValue(relayClient)

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -19,6 +19,7 @@ import {
 } from './host-client-acquisition-registry'
 import { HostOpenRetryScheduler } from './host-open-retry-scheduler'
 import { openHostClientEntry, type HostClientStoreEntry } from './host-entry-opener'
+import { forceReconnectAnswered } from './force-reconnect-verification'
 import { shouldPreserveActiveRelay } from './relay-reconnect-preservation'
 import { recordConnectionRevival } from './persisted-connection-log-store'
 import {
@@ -273,9 +274,21 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
       }
       // Why: Retry must read amber for the whole reopen, not grey-then-amber.
       notifyHostState(hostId, 'connecting')
-      await openEntry(hostId, true)
+      const reopened = await openEntry(hostId, true)
+      if (!reopened || storeRef.current.get(hostId) !== reopened) {
+        return
+      }
+      if (await forceReconnectAnswered(reopened.client)) {
+        return
+      }
+      // Why: #10385 — a fresh socket that never answers a control RPC must not be
+      // reported as success. Close it so the UI stops claiming connected instead of
+      // leaving the user a green card they cannot use.
+      if (storeRef.current.get(hostId) === reopened) {
+        closeEntry(hostId, { forgetPrimedHost: false, preserveAcquisitions: true })
+      }
     },
-    [openEntry]
+    [closeEntry, openEntry]
   )
 
   const selectors = useMemo(

--- a/mobile/src/transport/direct-connection-log.ts
+++ b/mobile/src/transport/direct-connection-log.ts
@@ -39,7 +39,7 @@ export class DirectConnectionLog {
     this.emit(
       'error',
       'Connection health check failed',
-      `${evidence.reason}; ${evidence.missedProbes}/${evidence.missedProbeLimit} probes missed; last authenticated activity ${evidence.lastInboundAgeMs}ms ago`,
+      `${evidence.reason}; ${evidence.missedProbes}/${evidence.missedProbeLimit} probes missed; last authenticated activity ${evidence.lastInboundAgeMs}ms ago; last control response ${evidence.lastControlResponseAgeMs}ms ago`,
       { code: 'liveness-timeout' }
     )
   }

--- a/mobile/src/transport/direct-rpc-client.ts
+++ b/mobile/src/transport/direct-rpc-client.ts
@@ -96,6 +96,7 @@ export class DirectRpcClient implements RpcClient {
       onRpcResponse: (response) => this.handleRpcResponse(response),
       onBinary: (bytes) => this.streams.handleBinary(bytes),
       onAuthenticatedInbound: (session) => this.liveness.noteAuthenticatedInbound(session),
+      onControlResponseInbound: (session) => this.liveness.noteControlResponse(session),
       onClosed: (session, closeCode) => this.socketClose.handle(session, closeCode),
       onForcedClose: (session) => this.socketClose.forceClose(session)
     })
@@ -177,9 +178,7 @@ export class DirectRpcClient implements RpcClient {
     }
     if (this.getState() === 'connected') {
       console.log('[net] foreground — probing live connection')
-      if (this.livenessSession) {
-        this.liveness.probeNow(this.livenessSession)
-      }
+      this.liveness.probeNow(this.livenessSession)
       return
     }
     const dialing = this.socketSession

--- a/mobile/src/transport/force-reconnect-verification.ts
+++ b/mobile/src/transport/force-reconnect-verification.ts
@@ -1,0 +1,32 @@
+import type { RpcClient } from './rpc-client'
+
+export const FORCE_RECONNECT_VERIFY_TIMEOUT_MS = 15_000
+
+// Why: a reopened socket only proves the desktop accepted a connection. #10385 is
+// exactly the case where that holds while the control channel is dead, so Force
+// Reconnect must not report success until the desktop has actually answered.
+//
+// What is being asked is whether the control channel is alive, not whether the
+// request succeeded, so any answer passes — an `ok:false` error included. The
+// desktop received it, processed it and replied, which settles the question; a
+// transient application error is not a reason to tear down a working channel.
+// Only silence fails.
+//
+// `status.get` is chosen because it is on the mobile method allowlist, so no
+// version gap can masquerade as a failure. A desktop-only method such as
+// `worktree.list` would draw `ok:false` from an older allowlist purely for not
+// being implemented, making a healthy channel indistinguishable from a dead one.
+export async function forceReconnectAnswered(
+  client: Pick<RpcClient, 'sendRequest'>,
+  timeoutMs: number = FORCE_RECONNECT_VERIFY_TIMEOUT_MS
+): Promise<boolean> {
+  try {
+    await client.sendRequest('status.get', undefined, {
+      timeoutMs,
+      budgetSpansConnect: true
+    })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session-liveness.test.ts
@@ -133,7 +133,7 @@ describe('mobile relay RPC session liveness', () => {
         path: 'relay',
         message: 'Relay health check failed',
         detail: expect.stringMatching(
-          /^probe-timeout; 2\/2 probes missed; last authenticated activity \d+ms ago$/
+          /^probe-timeout; 2\/2 probes missed; last authenticated activity \d+ms ago; last control response \d+ms ago$/
         )
       })
     )
@@ -177,6 +177,59 @@ describe('mobile relay RPC session liveness', () => {
     session.notifyForeground('focus')
 
     expect(fakes.sendText).toHaveBeenCalledTimes(2)
+    session.close()
+  })
+
+  // Regression (#10385): relay keeps an idle session silent by design (#14333), so a
+  // stalled application RPC is the only stall signal the user's own work produces.
+  // It must confirm the control channel instead of being swallowed.
+  it('confirms a stalled application request with a control probe', async () => {
+    const session = await authenticateSession()
+
+    const settled = session
+      .sendRequest('worktree.ps', { limit: 1 })
+      .catch((error: Error) => error.message)
+    // sendRequest awaits waitForConnected, so the frame lands a microtask later.
+    await vi.advanceTimersByTimeAsync(0)
+    expect(sentRequests().map(({ method }) => method)).toEqual(['worktree.ps'])
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(await settled).toContain('relay RPC timed out')
+    expect(sentRequests().map(({ method }) => method)).toEqual(['worktree.ps', 'status.get'])
+    session.close()
+  })
+
+  // Terminal output over relay must not stand in for a control response either.
+  it('does not let relay stream traffic satisfy an in-flight probe', async () => {
+    const session = await authenticateSession()
+    session.notifyForeground('focus')
+    expect(sentRequests().map(({ method }) => method)).toEqual(['status.get'])
+
+    for (let elapsed = 0; elapsed < 8_000; elapsed += 500) {
+      fakes.linkOptions!.onBinary(new Uint8Array([1, 2, 3]))
+      await vi.advanceTimersByTimeAsync(500)
+    }
+
+    expect(session.getState()).toBe('disconnected')
+  })
+
+  // The matching false-teardown guard: a still-answering desktop survives the same
+  // stream saturation.
+  it('keeps a stream-saturated relay whose control channel still answers', async () => {
+    const session = await authenticateSession()
+    session.notifyForeground('focus')
+
+    for (let elapsed = 0; elapsed < 16_000; elapsed += 500) {
+      fakes.linkOptions!.onBinary(new Uint8Array([1, 2, 3]))
+      const probe = sentRequests().findLast(({ method }) => method === 'status.get')
+      if (probe) {
+        fakes.linkOptions!.onText(JSON.stringify({ id: probe.id, ok: true, result: {} }))
+      }
+      await vi.advanceTimersByTimeAsync(500)
+    }
+
+    expect(session.getState()).toBe('connected')
     session.close()
   })
 

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -163,7 +163,7 @@ export function connectMobileRelayRpcSession(args: {
         code: 'liveness-timeout',
         path: 'relay',
         message: 'Relay health check failed',
-        detail: `${evidence.reason}; ${evidence.missedProbes}/${evidence.missedProbeLimit} probes missed; last authenticated activity ${evidence.lastInboundAgeMs}ms ago`
+        detail: `${evidence.reason}; ${evidence.missedProbes}/${evidence.missedProbeLimit} probes missed; last authenticated activity ${evidence.lastInboundAgeMs}ms ago; last control response ${evidence.lastControlResponseAgeMs}ms ago`
       })
     },
     terminate: () => fail(new Error('relay session liveness timeout'))
@@ -213,6 +213,10 @@ export function connectMobileRelayRpcSession(args: {
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
         pending.drop(id)
+        // Why: relay runs no idle probe (#14333 keeps an idle session silent), so a
+        // stalled application RPC is the only signal that the control channel died.
+        // Confirm with a probe rather than tearing the session down on one timeout.
+        livenessWatchdog.probeNow(livenessIdentity)
         // Why: the frame was written long ago — the desktop may have processed it.
         reject(markRpcDeliveryUnknown(new Error(`relay RPC timed out: ${method}`)))
       }, timeoutMs)
@@ -238,6 +242,12 @@ export function connectMobileRelayRpcSession(args: {
     }
     if (!isRpcResponse(value)) {
       return
+    }
+    // Why: a `streaming` frame is a subscription push the desktop sends on its own.
+    // Only a non-streaming reply answers a request we sent, so only that proves the
+    // control channel still works.
+    if (!(value.ok && value.streaming === true)) {
+      livenessWatchdog.noteControlResponse(livenessIdentity)
     }
     if (pending.settle(value)) {
       return

--- a/mobile/src/transport/rpc-client-socket-factory.ts
+++ b/mobile/src/transport/rpc-client-socket-factory.ts
@@ -19,6 +19,7 @@ type SocketFactoryOptions = {
   onRpcResponse: (response: RpcResponse) => void
   onBinary: (bytes: Uint8Array) => void
   onAuthenticatedInbound: (session: RpcClientSocketSession) => void
+  onControlResponseInbound: (session: RpcClientSocketSession) => void
   onClosed: (session: RpcClientSocketSession, closeCode?: number) => void
   onForcedClose: (session: RpcClientSocketSession) => void
 }
@@ -70,6 +71,7 @@ export class RpcClientSocketFactory {
       onBinary: this.options.onBinary,
       onAnyInbound: (receivedAt) => (this.lastInboundAt = receivedAt),
       onAuthenticatedInbound: this.options.onAuthenticatedInbound,
+      onControlResponseInbound: this.options.onControlResponseInbound,
       onClosed: this.options.onClosed,
       onForcedClose: this.options.onForcedClose
     })

--- a/mobile/src/transport/rpc-client-socket-session.ts
+++ b/mobile/src/transport/rpc-client-socket-session.ts
@@ -32,6 +32,7 @@ type SocketSessionOptions = {
   onBinary: (bytes: Uint8Array) => void
   onAnyInbound: (receivedAt: number) => void
   onAuthenticatedInbound: (session: RpcClientSocketSession) => void
+  onControlResponseInbound: (session: RpcClientSocketSession) => void
   onClosed: (session: RpcClientSocketSession, closeCode?: number) => void
   onForcedClose: (session: RpcClientSocketSession) => void
 }
@@ -196,6 +197,12 @@ export class RpcClientSocketSession {
       return
     }
     if (isRpcResponse(response)) {
+      // Why: a `streaming` frame is a subscription push the host sends on its own.
+      // Only a non-streaming reply answers a request we sent, so only that proves
+      // the control channel still works.
+      if (!(response.ok && response.streaming === true)) {
+        this.options.onControlResponseInbound(this)
+      }
       this.options.onRpcResponse(response)
     }
   }

--- a/mobile/src/transport/rpc-session-liveness-integration.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-integration.test.ts
@@ -62,6 +62,10 @@ class MockWebSocket {
   }
 }
 
+// Direct transport tolerates LIVENESS_PROBE_TIMEOUT_MS * MISSED_PROBE_LIMIT of
+// control silence (8s x 3) before it gives up on a session.
+const DIRECT_PROBE_BUDGET_MS = 24_000
+
 const sockets: MockWebSocket[] = []
 const originalWebSocket = globalThis.WebSocket
 
@@ -107,24 +111,91 @@ describe('physical session liveness', () => {
     }
   })
 
-  it('counts authenticated terminal binary output as liveness', async () => {
+  // Regression (#10385): a terminal that keeps streaming must not stand in for a
+  // control response. Before the fix the probe was satisfied by these frames, so a
+  // desktop that had stopped answering status.get / worktree.ps stayed 'connected'
+  // indefinitely and Force Reconnect could not recover it.
+  it('does not count terminal binary output as a control response', async () => {
     const client = connect('ws://desktop.invalid', 'token', 'server-key')
     const socket = sockets[0]!
     socket.authenticate()
     client.notifyForeground()
-    socket.onmessage?.({
-      data: encodeTerminalStreamFrame({
-        opcode: TerminalStreamOpcode.Output,
-        streamId: 42,
-        seq: 1,
-        payload: new TextEncoder().encode('hello')
-      })
-    })
-    await Promise.resolve()
-    await vi.advanceTimersByTimeAsync(8_000)
+
+    await streamTerminalOutputFor(socket, DIRECT_PROBE_BUDGET_MS)
+
+    expect(socket.close).toHaveBeenCalled()
+    expect(client.getState()).toBe('reconnecting')
+    client.close()
+  })
+
+  // The other side of the same rule: stream traffic no longer proves health, but a
+  // link busy enough to park a control reply behind queued terminal frames must not
+  // be torn down while the desktop is still answering.
+  it('keeps a stream-saturated session whose control channel still answers', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = sockets[0]!
+    socket.authenticate()
+    client.notifyForeground()
+
+    for (let elapsed = 0; elapsed < DIRECT_PROBE_BUDGET_MS * 2; elapsed += 1_000) {
+      await streamTerminalOutputFor(socket, 1_000)
+      // A reply that lands late, but inside the budget, still counts.
+      answerLatestProbe(socket)
+      await Promise.resolve()
+    }
 
     expect(socket.close).not.toHaveBeenCalled()
     expect(client.getState()).toBe('connected')
+    client.close()
+  })
+
+  // Hole B: the probe response is discarded by handleRpcResponse for routing, so the
+  // watchdog has to be satisfied upstream of that. This proves the probe is a real
+  // round trip — its own reply, with no other traffic at all, keeps the session.
+  it('satisfies the liveness probe with the probe reply itself', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = sockets[0]!
+    socket.authenticate()
+    client.notifyForeground()
+
+    answerLatestProbe(socket)
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(DIRECT_PROBE_BUDGET_MS)
+
+    expect(socket.close).not.toHaveBeenCalled()
+    expect(client.getState()).toBe('connected')
+    client.close()
+  })
+
+  // A `streaming` reply is a host-initiated subscription push, not an answer to
+  // anything we sent, so it must not rescue an in-flight probe either. Without this
+  // the bug survives on the text path in a narrower form.
+  it('does not let a streaming subscription push satisfy an in-flight probe', async () => {
+    const client = connect('ws://desktop.invalid', 'token', 'server-key')
+    const socket = sockets[0]!
+    socket.authenticate()
+    const subscription = client.subscribe('session.tabs.subscribe', {}, vi.fn())
+    const streamId = sentRequests(socket).findLast(
+      ({ method }) => method === 'session.tabs.subscribe'
+    )?.id
+    client.notifyForeground()
+
+    for (let elapsed = 0; elapsed < DIRECT_PROBE_BUDGET_MS; elapsed += 500) {
+      socket.onmessage?.({
+        data: `encrypted:${JSON.stringify({
+          id: streamId,
+          ok: true,
+          streaming: true,
+          result: { type: 'data', chunk: 'push' }
+        })}`
+      })
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(500)
+    }
+
+    expect(socket.close).toHaveBeenCalled()
+    expect(client.getState()).toBe('reconnecting')
+    subscription()
     client.close()
   })
 
@@ -190,3 +261,34 @@ describe('physical session liveness', () => {
     client.close()
   })
 })
+
+function sentRequests(socket: MockWebSocket): { id?: string; method?: string }[] {
+  return socket.sent
+    .map((payload) => payload.replace(/^encrypted:/, ''))
+    .map((payload) => JSON.parse(payload) as { id?: string; method?: string })
+}
+
+function answerLatestProbe(socket: MockWebSocket): void {
+  const probe = sentRequests(socket).findLast(({ method }) => method === 'status.get')
+  if (!probe) {
+    return
+  }
+  socket.onmessage?.({
+    data: `encrypted:${JSON.stringify({ id: probe.id, ok: true, result: {} })}`
+  })
+}
+
+async function streamTerminalOutputFor(socket: MockWebSocket, durationMs: number): Promise<void> {
+  for (let elapsed = 0; elapsed < durationMs; elapsed += 500) {
+    socket.onmessage?.({
+      data: encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.Output,
+        streamId: 42,
+        seq: elapsed,
+        payload: new TextEncoder().encode('hello')
+      })
+    })
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(500)
+  }
+}

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -23,12 +23,12 @@ describe('RpcSessionLivenessWatchdog', () => {
     return { identity, sendProbe, terminate, watchdog }
   }
 
-  it('probes only after authenticated-inbound idle', async () => {
+  it('probes only after control-response idle', async () => {
     const { identity, sendProbe, watchdog } = fixture()
     await vi.advanceTimersByTimeAsync(LIVENESS_IDLE_MS - 1)
     expect(sendProbe).not.toHaveBeenCalled()
 
-    watchdog.noteAuthenticatedInbound(identity)
+    watchdog.noteControlResponse(identity)
     await vi.advanceTimersByTimeAsync(LIVENESS_IDLE_MS - 1)
     expect(sendProbe).not.toHaveBeenCalled()
     await vi.advanceTimersByTimeAsync(1)
@@ -70,23 +70,24 @@ describe('RpcSessionLivenessWatchdog', () => {
       reason: 'probe-timeout',
       missedProbes: 2,
       missedProbeLimit: 2,
-      lastInboundAgeMs: 8_000
+      lastInboundAgeMs: 8_000,
+      lastControlResponseAgeMs: 8_000
     })
     expect(onTimeout.mock.invocationCallOrder[0]).toBeLessThan(
       terminate.mock.invocationCallOrder[0]!
     )
   })
 
-  it('authenticated activity resets suspicion', async () => {
+  it('a control response resets suspicion', async () => {
     const { identity, terminate, watchdog } = fixture()
     watchdog.probeNow(identity)
     await vi.advanceTimersByTimeAsync(LIVENESS_PROBE_TIMEOUT_MS)
-    watchdog.noteAuthenticatedInbound(identity)
+    watchdog.noteControlResponse(identity)
     await vi.advanceTimersByTimeAsync(LIVENESS_IDLE_MS + LIVENESS_PROBE_TIMEOUT_MS * 2)
     expect(terminate).not.toHaveBeenCalled()
   })
 
-  it('does not churn timers during continuous authenticated traffic', async () => {
+  it('does not churn timers during continuous control responses', async () => {
     const setTimer = vi.fn(setTimeout)
     const sendProbe = vi.fn(() => true)
     const watchdog = new RpcSessionLivenessWatchdog({
@@ -101,13 +102,38 @@ describe('RpcSessionLivenessWatchdog', () => {
 
     await vi.advanceTimersByTimeAsync(10_000)
     for (let index = 0; index < 100; index++) {
-      watchdog.noteAuthenticatedInbound(identity)
+      watchdog.noteControlResponse(identity)
     }
     expect(setTimer).toHaveBeenCalledOnce()
 
     await vi.advanceTimersByTimeAsync(10_000)
     expect(sendProbe).not.toHaveBeenCalled()
     expect(setTimer).toHaveBeenCalledTimes(2)
+  })
+
+  // Regression (#10385): a terminal that keeps streaming must not make a dead
+  // control channel look alive. Before the fix, either assertion below failed.
+  it('does not let stream traffic defer the idle probe', async () => {
+    const { identity, sendProbe, watchdog } = fixture()
+
+    for (let elapsed = 0; elapsed < LIVENESS_IDLE_MS; elapsed += 1_000) {
+      watchdog.noteAuthenticatedInbound(identity)
+      await vi.advanceTimersByTimeAsync(1_000)
+    }
+
+    expect(sendProbe).toHaveBeenCalledOnce()
+  })
+
+  it('does not let stream traffic satisfy an in-flight probe', async () => {
+    const { identity, terminate, watchdog } = fixture()
+    watchdog.probeNow(identity)
+
+    for (let elapsed = 0; elapsed < LIVENESS_PROBE_TIMEOUT_MS * 3; elapsed += 500) {
+      watchdog.noteAuthenticatedInbound(identity)
+      await vi.advanceTimersByTimeAsync(500)
+    }
+
+    expect(terminate).toHaveBeenCalledOnce()
   })
 
   it('does not charge a scheduler-stalled probe window', () => {

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -24,6 +24,7 @@ export type LivenessTimeoutEvidence = {
   missedProbes: number
   missedProbeLimit: number
   lastInboundAgeMs: number
+  lastControlResponseAgeMs: number
 }
 
 export class RpcSessionLivenessWatchdog {
@@ -32,6 +33,7 @@ export class RpcSessionLivenessWatchdog {
   private probing = false
   private missedProbes = 0
   private lastInboundAt = 0
+  private lastControlResponseAt = 0
   private lastVoluntaryProbeAt: number | null = null
   private readonly idleProbeMs: number | null
   private readonly probeTimeoutMs: number
@@ -57,6 +59,7 @@ export class RpcSessionLivenessWatchdog {
     this.probing = false
     this.missedProbes = 0
     this.lastInboundAt = this.now()
+    this.lastControlResponseAt = this.lastInboundAt
     this.lastVoluntaryProbeAt = null
     this.armIdle(identity)
   }
@@ -68,11 +71,25 @@ export class RpcSessionLivenessWatchdog {
     return this.lastInboundAt
   }
 
+  // Any authenticated frame, terminal/browser stream traffic included. Records
+  // arrival for diagnostics only: a peer still pushing stream bytes has proved
+  // nothing about whether it can still answer a control request.
   noteAuthenticatedInbound(identity: RpcSessionIdentity): void {
     if (this.identity !== identity) {
       return
     }
     this.lastInboundAt = this.now()
+  }
+
+  // A response the peer had to produce for a request we sent. Only this counts
+  // as liveness — the idle clock and any in-flight probe key off it.
+  noteControlResponse(identity: RpcSessionIdentity): void {
+    if (this.identity !== identity) {
+      return
+    }
+    const now = this.now()
+    this.lastInboundAt = now
+    this.lastControlResponseAt = now
     if (this.missedProbes > 0) {
       console.log('[net] activity-probe recovered', {
         transport: this.options.transport,
@@ -87,8 +104,8 @@ export class RpcSessionLivenessWatchdog {
     this.armIdle(identity)
   }
 
-  probeNow(identity: RpcSessionIdentity): void {
-    if (this.identity !== identity || this.probing) {
+  probeNow(identity: RpcSessionIdentity | null): void {
+    if (identity === null || this.identity !== identity || this.probing) {
       return
     }
     const now = this.now()
@@ -111,6 +128,7 @@ export class RpcSessionLivenessWatchdog {
     this.probing = false
     this.missedProbes = 0
     this.lastInboundAt = 0
+    this.lastControlResponseAt = 0
     this.lastVoluntaryProbeAt = null
   }
 
@@ -124,7 +142,7 @@ export class RpcSessionLivenessWatchdog {
       if (this.identity !== identity) {
         return
       }
-      const idleMs = this.now() - this.lastInboundAt
+      const idleMs = this.now() - this.lastControlResponseAt
       if (this.idleProbeMs !== null && idleMs < this.idleProbeMs) {
         this.armIdle(identity, Math.max(1, this.idleProbeMs - Math.max(0, idleMs)))
       } else {
@@ -201,7 +219,8 @@ export class RpcSessionLivenessWatchdog {
       reason,
       missedProbes: this.missedProbes,
       missedProbeLimit: this.missedProbeLimit,
-      lastInboundAgeMs: Math.max(0, this.now() - this.lastInboundAt)
+      lastInboundAgeMs: Math.max(0, this.now() - this.lastInboundAt),
+      lastControlResponseAgeMs: Math.max(0, this.now() - this.lastControlResponseAt)
     })
     this.options.terminate(identity)
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​271 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |

<!-- /orca-pr-loc -->

Fixes #10385. Supersedes #11596.

## What the user sees

**Before.** On cellular/Tailscale, the app reports `State: connected, reconnect attempts: 0` while `status.get` and `worktree.ps` have stalled. The open terminal keeps working, but returning to the home screen collapses the worktree list to only the last-opened session, which then won't reopen. Force Reconnect reports success and changes nothing. Only toggling Airplane Mode recovers it.

**After.** A stalled control channel demotes the session and enters the existing recovery loop even while terminal output keeps streaming. Force Reconnect resolves only once the reopened transport has actually answered, so the card stops claiming a connection the user cannot use.

## Why it happened — three independent holes, all live on main

1. **Any inbound frame counted as liveness.** `rpc-client-socket-session.ts:183` fired `onAuthenticatedInbound` for decrypted *binary* (terminal/browser) frames, which reset the watchdog's idle clock and cleared an in-flight probe. Streaming terminal output both deferred the probe and rescued one already running.
2. **The probe was never a round trip.** `handleRpcResponse` discards `mobile-liveness-` replies for routing, so the probe was only ever satisfied by hole 1 — meaning the liveness check had never verified that the peer answers. Relay had the same hole by a different route: its probe used `pending.nextId()` without `pending.track()`, so the reply fell through to `streams.handleResponse` and vanished.
3. **A stalled application RPC didn't demote.** `rpc-client-request-tracker.ts` rejects the one request; connection state stays `connected`, and nothing else demotes without a socket close.

#14333 hardened the liveness timer but preserved the stream-frame masking, so it does not supersede this.

## The fix

Liveness now keys off a **control response** — a non-streaming RPC reply, which only arrives because we asked for something — while raw inbound arrival stays as diagnostics. The notification fires upstream of the routing discard, so the probe's own reply satisfies it and the probe becomes a real round trip. Relay gets the same split plus a probe on a stalled application RPC. Force Reconnect awaits one `status.get` under a 15s deadline.

~100 production lines across 12 files, all in `mobile/src/transport/`.

## Deliberate decisions worth reviewing

- **Relay still sends no periodic traffic while idle.** This preserves the invariant #14333 introduced at `mobile-relay-rpc-session-liveness.test.ts:107` (asserting zero sends across 60s idle). Relay detects the stall reactively instead. Adding periodic relay traffic is a battery and data-cost product call, not this PR's to make.
- **The probe is satisfied by any non-streaming reply, not strictly its own id.** A concurrently answered application RPC does prove health, and requiring id-matching would tear down a working channel whenever a single probe reply is lost.
- **A streaming push does not satisfy the probe.** A host-initiated subscription push is not an answer to anything we asked; letting it count would have reopened the same hole on the text path. Pinned by a test that is genuinely red without the guard.
- **Force Reconnect treats any answer as success, including `ok:false`.** The question is whether the control channel is alive, not whether the request succeeded — a reply proves the desktop received, processed and answered, and reconnecting cannot fix an application error. `status.get` is chosen precisely because it is on the mobile allowlist, so no version gap can masquerade as a failure; a desktop-only method such as `worktree.list` would draw `ok:false` from an older allowlist purely for not being implemented. **Changing the method means revisiting this rule.**
- **Two shared test fakes returned bare `vi.fn()` (i.e. `undefined`) from `sendRequest`**, so nothing previously constrained that shape — any test leaning on those fakes was asserting against `undefined`.

## Evidence

Ablating production only (tests kept), 10 red. The four using no new API failed on real behaviour, not missing-method errors:

- **direct**, streaming terminal output across the full 24s budget: `socket.close` expected, **0 calls**; client stays `connected`. That is #10385 exactly.
- **relay**, same scenario: expected `disconnected`, got `connected`.
- **relay**, stalled `worktree.ps`: main sends `['worktree.ps']` and never probes — expected `['worktree.ps', 'status.get']`.
- **Force Reconnect**: `status.get` expected, **0 calls** — main reports success without asking anything.

Both false-teardown guards stream terminal frames across twice the probe budget while control replies arrive late but in-budget, and pass before *and* after — correct for a guard. Existing tolerances are untouched (direct 8s×3, relay 4s×2). No added periodic traffic anywhere. Transport suite: 98 files, 731 passed, 3 skipped. oxlint and `oxfmt --check` clean; no `max-lines` override added.

## Why #11596 is superseded rather than updated

Its core production edit was +140 lines to `rpc-client-activity-probe.ts`, which #14333 deleted; `rpc-client.ts` went 1,193 → 65 lines under the same decomposition, and 157 of 158 transport files at its merge base have since changed. Nothing in its 121-file diff applies. Force-pushing ~100 unrelated lines onto that branch would leave a PR whose title, body, diffstat and four rounds of simulator evidence all describe code that no longer exists.
