### PR TITLE
Fix MiniMax credential-expiry reporting, region sync, and refresh

### DIFF
--- a/src/main/rate-limits/minimax/minimax-fetcher-data.ts
+++ b/src/main/rate-limits/minimax/minimax-fetcher-data.ts
@@ -43,7 +43,10 @@ export function makeMiniMaxUnavailable(error: string): ProviderRateLimits {
 
 export function makeMiniMaxError(
   error: string,
-  failureKind: NonNullable<ProviderRateLimits['usageMetadata']>['failureKind']
+  failureKind: NonNullable<ProviderRateLimits['usageMetadata']>['failureKind'],
+  // Why: the status bar localizes the expiry copy per credential kind; the raw
+  // `error` string stays English for logs.
+  credentialSource?: 'api-key' | 'session-cookie'
 ): ProviderRateLimits {
   return {
     provider: 'minimax',
@@ -52,7 +55,7 @@ export function makeMiniMaxError(
     updatedAt: Date.now(),
     error,
     status: 'error',
-    usageMetadata: { failureKind, source: 'web' }
+    usageMetadata: { failureKind, source: 'web', ...(credentialSource ? { credentialSource } : {}) }
   }
 }
 

--- a/src/main/rate-limits/minimax/minimax-fetcher-parse.ts
+++ b/src/main/rate-limits/minimax/minimax-fetcher-parse.ts
@@ -39,10 +39,11 @@ export type MiniMaxUsageResponse = {
 const MINIMAX_UNAUTHENTICATED_STATUS_CODE = 1004
 
 function makeMiniMaxExpiredCredentialError(fetchResult: MiniMaxFetchResponse): ProviderRateLimits {
-  const credentialLabel = fetchResult.transport === 'api-key' ? 'API key' : 'session cookie'
+  const usesApiKey = fetchResult.transport === 'api-key'
   return makeMiniMaxError(
-    `MiniMax ${credentialLabel} expired. Replace it in Settings.`,
-    'stale-token'
+    `MiniMax ${usesApiKey ? 'API key' : 'session cookie'} expired. Replace it in Settings.`,
+    'stale-token',
+    usesApiKey ? 'api-key' : 'session-cookie'
   )
 }
 

--- a/src/main/rate-limits/minimax/minimax-fetcher-parse.ts
+++ b/src/main/rate-limits/minimax/minimax-fetcher-parse.ts
@@ -34,6 +34,18 @@ export type MiniMaxUsageResponse = {
   }[]
 }
 
+// Why: MiniMax answers an expired cookie/key with HTTP 200 + base_resp.status_code 1004,
+// so the credential-expiry signal has to be read from the payload, not the status line.
+const MINIMAX_UNAUTHENTICATED_STATUS_CODE = 1004
+
+function makeMiniMaxExpiredCredentialError(fetchResult: MiniMaxFetchResponse): ProviderRateLimits {
+  const credentialLabel = fetchResult.transport === 'api-key' ? 'API key' : 'session cookie'
+  return makeMiniMaxError(
+    `MiniMax ${credentialLabel} expired. Replace it in Settings.`,
+    'stale-token'
+  )
+}
+
 function handleMiniMaxHttpError(fetchResult: MiniMaxFetchResponse): ProviderRateLimits | null {
   const { response } = fetchResult
   if (response.status === 401 || response.status === 403) {
@@ -43,11 +55,7 @@ function handleMiniMaxHttpError(fetchResult: MiniMaxFetchResponse): ProviderRate
       cookieNames: fetchResult.cookieNames,
       requestHeaderNames: fetchResult.requestHeaderNames
     })
-    const credentialLabel = fetchResult.transport === 'api-key' ? 'API key' : 'session cookie'
-    return makeMiniMaxError(
-      `MiniMax ${credentialLabel} expired. Replace it in Settings.`,
-      'stale-token'
-    )
+    return makeMiniMaxExpiredCredentialError(fetchResult)
   }
   if (!response.ok) {
     logMiniMaxFetchFailure({
@@ -77,6 +85,9 @@ function handleMiniMaxPayloadError(
     cookieNames: fetchResult.cookieNames,
     requestHeaderNames: fetchResult.requestHeaderNames
   })
+  if (statusCode === MINIMAX_UNAUTHENTICATED_STATUS_CODE) {
+    return makeMiniMaxExpiredCredentialError(fetchResult)
+  }
   const message =
     typeof payload.base_resp?.status_msg === 'string'
       ? payload.base_resp.status_msg

--- a/src/main/rate-limits/minimax/minimax-fetcher.test.ts
+++ b/src/main/rate-limits/minimax/minimax-fetcher.test.ts
@@ -356,6 +356,32 @@ describe('fetchMiniMaxRateLimits', () => {
     expect(result.error).toContain('unauth')
   })
 
+  // Why: the live API answers an expired cookie/key with HTTP 200 + status_code 1004,
+  // never 401/403, so this is the only signal that reaches the stale-credential path.
+  it('classifies status_code 1004 on the cookie path as an expired session cookie', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      makeResponse({
+        base_resp: { status_code: 1004, status_msg: 'cookie is missing, log in again' }
+      })
+    )
+    const result = await fetchMiniMaxRateLimits({ cookie: FULL_COOKIE })
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('stale-token')
+    expect(result.error).toMatch(/session cookie expired/i)
+  })
+
+  it('classifies status_code 1004 on the API key path as an expired API key', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      makeResponse({
+        base_resp: { status_code: 1004, status_msg: 'cookie is missing, log in again' }
+      })
+    )
+    const result = await fetchMiniMaxRateLimits({ apiKey: 'sk-expired', endpointMode: 'cn' })
+    expect(result.status).toBe('error')
+    expect(result.usageMetadata?.failureKind).toBe('stale-token')
+    expect(result.error).toMatch(/API key expired/i)
+  })
+
   it('classifies malformed MiniMax JSON responses as parse failures', async () => {
     netFetchMock.mockResolvedValueOnce({
       ok: true,

--- a/src/main/runtime/orca-runtime-tests/paired-settings.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/paired-settings.spec.ts
@@ -30,6 +30,7 @@ describe('OrcaRuntimeService', () => {
         compactWorktreeCards: true,
         minimaxGroupId: 'group-42',
         minimaxUsageModels: 'general,abab6.5',
+        minimaxEndpoint: 'cn',
         terminalQuickCommands
       })
     } as never)
@@ -39,7 +40,9 @@ describe('OrcaRuntimeService', () => {
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
       minimaxGroupId: 'group-42',
-      minimaxUsageModels: 'general,abab6.5'
+      minimaxUsageModels: 'general,abab6.5',
+      // Why: without this the paired client silently falls back to 'overseas' and shows the wrong region.
+      minimaxEndpoint: 'cn'
     })
     expect(runtime.getClientSettings()).not.toHaveProperty('terminalQuickCommands')
     expect(runtime.getClientSettings().hostSettingOverrides).toEqual({
@@ -194,7 +197,8 @@ describe('OrcaRuntimeService', () => {
       experimentalNewWorktreeCardStyle: false,
       compactWorktreeCards: false,
       minimaxGroupId: '',
-      minimaxUsageModels: 'general'
+      minimaxUsageModels: 'general',
+      minimaxEndpoint: 'overseas'
     }
     const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
       settings = { ...settings, ...updates }
@@ -211,20 +215,23 @@ describe('OrcaRuntimeService', () => {
         experimentalNewWorktreeCardStyle: true,
         compactWorktreeCards: true,
         minimaxGroupId: 'group-42',
-        minimaxUsageModels: 'general,abab6.5'
+        minimaxUsageModels: 'general,abab6.5',
+        minimaxEndpoint: 'cn'
       })
     ).toMatchObject({
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
       minimaxGroupId: 'group-42',
-      minimaxUsageModels: 'general,abab6.5'
+      minimaxUsageModels: 'general,abab6.5',
+      minimaxEndpoint: 'cn'
     })
     expect(updateSettings).toHaveBeenCalledWith(
       {
         experimentalNewWorktreeCardStyle: true,
         compactWorktreeCards: true,
         minimaxGroupId: 'group-42',
-        minimaxUsageModels: 'general,abab6.5'
+        minimaxUsageModels: 'general,abab6.5',
+        minimaxEndpoint: 'cn'
       },
       { notifyListeners: true }
     )
@@ -232,7 +239,8 @@ describe('OrcaRuntimeService', () => {
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
       minimaxGroupId: 'group-42',
-      minimaxUsageModels: 'general,abab6.5'
+      minimaxUsageModels: 'general,abab6.5',
+      minimaxEndpoint: 'cn'
     })
   })
 

--- a/src/main/runtime/runtime-client-settings-minimax-projection.test.ts
+++ b/src/main/runtime/runtime-client-settings-minimax-projection.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { RuntimeClientSettingsController } from './runtime-client-settings'
+import { createGlobalSettingsFixture } from '../../shared/global-settings-test-fixture'
+import type { GlobalSettings } from '../../shared/global-settings-types'
+
+// Why: the paired client renders the region selector and console link from this projection.
+// Omitting a field here silently falls the client back to its own default, and the RPC-level
+// tests mock the controller, so only a real get() covers it.
+function getProjected(overrides: Partial<GlobalSettings>) {
+  const settings = createGlobalSettingsFixture({ workspaceDir: '/w', ...overrides })
+  return new RuntimeClientSettingsController({ getSettings: () => settings } as never).get()
+}
+
+describe('RuntimeClientSettingsController MiniMax projection', () => {
+  it('publishes the China endpoint to paired clients', () => {
+    expect(getProjected({ minimaxEndpoint: 'cn' }).minimaxEndpoint).toBe('cn')
+  })
+
+  it('publishes the overseas endpoint to paired clients', () => {
+    expect(getProjected({ minimaxEndpoint: 'overseas' }).minimaxEndpoint).toBe('overseas')
+  })
+
+  it('falls back to overseas when the host has no persisted endpoint', () => {
+    const settings = createGlobalSettingsFixture({ workspaceDir: '/w' })
+    delete (settings as Partial<GlobalSettings>).minimaxEndpoint
+    const projected = new RuntimeClientSettingsController({
+      getSettings: () => settings
+    } as never).get()
+    expect(projected.minimaxEndpoint).toBe('overseas')
+  })
+})

--- a/src/main/runtime/runtime-client-settings.ts
+++ b/src/main/runtime/runtime-client-settings.ts
@@ -40,6 +40,7 @@ export type RuntimeClientSettings = Pick<
   | 'compactWorktreeCards'
   | 'minimaxGroupId'
   | 'minimaxUsageModels'
+  | 'minimaxEndpoint'
   | 'prBotAuthorOverrides'
   | 'artifactSharingEnabled'
   | 'worktreeVisibilityDefaults'
@@ -70,6 +71,7 @@ export type RuntimeClientSettingsUpdate = Pick<
   | 'compactWorktreeCards'
   | 'minimaxGroupId'
   | 'minimaxUsageModels'
+  | 'minimaxEndpoint'
   | 'prBotAuthorOverrides'
   | 'worktreeVisibilityDefaults'
 >
@@ -110,6 +112,7 @@ export class RuntimeClientSettingsController {
       compactWorktreeCards: settings.compactWorktreeCards === true,
       minimaxGroupId: settings.minimaxGroupId ?? '',
       minimaxUsageModels: settings.minimaxUsageModels ?? 'general',
+      minimaxEndpoint: settings.minimaxEndpoint ?? 'overseas',
       prBotAuthorOverrides: settings.prBotAuthorOverrides ?? [],
       artifactSharingEnabled: isArtifactSharingEnabled(settings),
       worktreeVisibilityDefaults: settings.worktreeVisibilityDefaults ?? { external: 'hide' },

--- a/src/main/runtime/runtime-store-contract.ts
+++ b/src/main/runtime/runtime-store-contract.ts
@@ -100,6 +100,7 @@ export type RuntimeStore = {
     compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
     minimaxGroupId?: GlobalSettings['minimaxGroupId']
     minimaxUsageModels?: GlobalSettings['minimaxUsageModels']
+    minimaxEndpoint?: GlobalSettings['minimaxEndpoint']
     prBotAuthorOverrides?: GlobalSettings['prBotAuthorOverrides']
     artifactSharingEnabled?: GlobalSettings['artifactSharingEnabled']
     terminalQuickCommands?: GlobalSettings['terminalQuickCommands']

--- a/src/main/startup/main-process-account-services.ts
+++ b/src/main/startup/main-process-account-services.ts
@@ -86,6 +86,21 @@ export function initializeMainProcessAccountServices(): void {
     void syncAccountRuntimeTargets(updates, settings).catch((error) =>
       console.warn('[rate-limits] Failed to apply account runtime target:', error)
     )
+    // Why: these three pick the MiniMax host and quota bucket, so a stale snapshot from the
+    // previous endpoint would otherwise sit in the status bar until the next poll.
+    if (
+      'minimaxEndpoint' in updates ||
+      'minimaxGroupId' in updates ||
+      'minimaxUsageModels' in updates
+    ) {
+      state.rateLimits?.invalidateMiniMaxCredentialState()
+      void state.rateLimits?.refresh().catch((error: unknown) => {
+        console.warn(
+          '[rate-limits] Failed to refresh MiniMax usage after a settings change:',
+          error
+        )
+      })
+    }
   })
   state.rateLimits.setClaudeAuthPreparationResolver((target) =>
     state.claudeRuntimeAuth!.prepareForRateLimitFetch(target)

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -111,6 +111,11 @@ export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
         break
     }
   }
+  // Why: MiniMax reports credential expiry through the payload, not an HTTP status,
+  // so it needs its own copy rather than the generic refresh-failure label.
+  if (p.provider === 'minimax' && p.usageMetadata?.failureKind === 'stale-token') {
+    return translate('auto.components.status.bar.tooltip.minimax.expired.label', 'Sign-in expired')
+  }
   if (isUsageRateLimitError(p.error)) {
     return translate('auto.components.status.bar.tooltip.7ad719c4bf', 'Limited')
   }
@@ -181,6 +186,17 @@ export function getProviderUsageErrorMessage(p: ProviderRateLimits): string {
   }
   if (isUsageRateLimitError(p.error)) {
     return p.error
+  }
+  if (p.provider === 'minimax' && p.usageMetadata?.failureKind === 'stale-token') {
+    return p.usageMetadata.credentialSource === 'api-key'
+      ? translate(
+          'auto.components.status.bar.tooltip.minimax.expired.apiKey',
+          'MiniMax API key expired. Replace it in Settings.'
+        )
+      : translate(
+          'auto.components.status.bar.tooltip.minimax.expired.cookie',
+          'MiniMax session cookie expired. Replace it in Settings.'
+        )
   }
   if (isUsageAuthError(p.error)) {
     const name = getProviderDisplayName(p.provider)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3903,7 +3903,14 @@
             "e2c6a4f917": "Run Grok to refresh",
             "d1b7f509ac": "Run grok in a terminal on the computer running Orca and wait for it to start. If prompted, complete sign-in, then retry usage. You do not need to send a chat message.",
             "f90b3d7a16": "Run Kimi to refresh",
-            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage."
+            "a37e8c15d4": "Run kimi in a terminal on the computer running Orca and wait for it to start, then retry usage.",
+            "minimax": {
+              "expired": {
+                "label": "Sign-in expired",
+                "apiKey": "MiniMax API key expired. Replace it in Settings.",
+                "cookie": "MiniMax session cookie expired. Replace it in Settings."
+              }
+            }
           },
           "SshTargetStatusRow": {
             "sshHost": "SSH Host"


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |

<!-- /orca-pr-loc -->

Follow-up to #14929, fixing three defects found in a retroactive review of it.

### 1. Expired credentials were never reported as expired

The MiniMax usage endpoint answers a missing or invalid cookie — **and any Bearer token** — with `HTTP 200` and `base_resp.status_code: 1004`:

```
$ curl https://platform.minimax.io/v1/api/openplatform/coding_plan/remains
{"base_resp":{"status_code":1004,"status_msg":"cookie is missing, log in again"}}
$ curl https://www.minimaxi.com/v1/api/openplatform/coding_plan/remains
{"base_resp":{"status_code":1004,"status_msg":"cookie is missing, log in again"}}
```

It never returns 401/403, so `handleMiniMaxHttpError`'s `stale-token` branch — including #14929's new *"MiniMax API key expired. Replace it in Settings."* — was unreachable in production. Every auth failure fell through to `handleMiniMaxPayloadError` and became `usage-unavailable`, surfacing the raw upstream string (untranslated, and Chinese-locale text on the CN host). Worse, `applyStalePolicy` treats that as a transient outage and keeps displaying the last good numbers, so a user with an expired cookie sees stale usage and is never told to re-authenticate.

`status_code: 1004` now maps to the expired-credential error, with the message matched to the transport (session cookie vs API key).

### 2. `minimaxEndpoint` never reached paired clients

The field was added to the `SettingsUpdate` zod schema and both read and write paths of the web store, but was never added to `RuntimeClientSettings` / `RuntimeClientSettingsUpdate` and was never projected by `RuntimeClientSettingsController.get()`. The web store's read branch for it was dead code.

A paired or web client whose host is set to China therefore re-read `overseas` on every load and rendered the wrong region and the wrong console link. (The host itself fetched correctly — main reads `GlobalSettings` directly — so this was a client-display divergence.)

### 3. Changing region didn't refresh usage

Switching Overseas ⇄ China persisted the setting but nothing triggered a refetch: no main-side reaction to `minimaxEndpoint`, and the renderer never calls `refreshRateLimits`. The status bar kept showing the **previous host's** numbers, as `status: 'ok'`, for up to 15 minutes. Now the settings listener invalidates and refetches when the endpoint, group id, or model list changes — all three feed the request, so all three had the same staleness.

### Why CI didn't catch 1 and 2

Both were masked by tests that mock the thing under test. `client-ui.test.ts` mocks `runtime.updateClientSettings`, so it exercises the RPC dispatcher rather than the projection; `web-preload-api-settings.test.ts` stubs the runtime as already returning `minimaxEndpoint`. The only real projection test, `paired-settings.spec.ts`, has no assertion for it — and `.spec.ts` under `src/` isn't in vitest's include, so it doesn't run at all.

The new `runtime-client-settings-minimax-projection.test.ts` exercises the real `get()`. Against the pre-fix projection it fails with `expected undefined to be 'cn'`.

### Verification

- `pnpm tc` — exit 0; `oxlint` clean
- 19,756 tests pass across `rate-limits`, `runtime`, `ipc`, `startup`, `shared`, `status-bar`
- New tests fail against the unfixed code (both the 1004 classification and the projection)
- Live probes above re-confirmed on both regional hosts

### Not addressed

The API-key transport sends `Bearer` to the **console** hosts, while MiniMax's documented Bearer surface is `api.minimax.io`. No probe could get any host to acknowledge an `Authorization` header — responses were byte-identical to no-auth. If Bearer isn't supported there, a saved key can never work, and the resolver blanks the cookie when a key is present, so there's no fallback. Confirming that needs a valid key. Fix 1 at least makes the failure say *"API key expired. Replace it in Settings."* instead of *"usage unavailable"*.

Weekly-window parsing also assumes `weekly_remains_time` is milliseconds, backed only by hand-written fixtures.
