### PR TITLE
fix(test): give federation tests a real read-after-write sync barrier

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-control-mail.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-control-mail.test.ts
@@ -8,6 +8,7 @@ import type { RpcRequest } from '../../../core'
 import { RpcDispatcher } from '../../../dispatcher'
 import { fingerprintAuthenticatedPairingCredential } from '../../../orchestration-mutation-executor'
 import { ORCHESTRATION_METHODS } from '../../orchestration'
+import { syncFederationBarrier } from './federation-sync-barrier.test-support'
 
 describe('orchestration federation control mail', () => {
   const homeToken = 'run-home-device-token'
@@ -160,7 +161,7 @@ describe('orchestration federation control mail', () => {
     })
     expect(homeDb.listPendingFederationRelay(dispatchId, 'to_worker')).toHaveLength(1)
 
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
     const checked = await workerDispatcher.dispatch(checkRequest('check-imported'))
 
     expect(checked).toMatchObject({
@@ -252,7 +253,7 @@ describe('orchestration federation control mail', () => {
       settleRemoteOutcome: 'succeeded'
     })
 
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
 
     expect(homeDb.getWorkerDispatch(dispatchId)?.state).toBe('succeeded')
     expect(workerDb.getUnreadMessages(`dispatch:${dispatchId}`)).toHaveLength(0)

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-sync-barrier.test-support.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-sync-barrier.test-support.ts
@@ -1,0 +1,17 @@
+import type { OrcaRuntimeService } from '../../../../orca-runtime'
+import type { OrchestrationDb } from '../../../../orchestration/db'
+
+// A run-wide sync coalesces onto whatever relay tick is already in flight, and that tick may have
+// read the peer before the test's latest mutation existed. Chain past the current round instead so
+// awaiting the barrier really means "everything enqueued before this call has been exchanged".
+export async function syncFederationBarrier(
+  runtime: OrcaRuntimeService,
+  db: OrchestrationDb
+): Promise<void> {
+  const dispatches = db.listActiveFederatedDispatches()
+  await Promise.allSettled(
+    dispatches.map((dispatch) =>
+      runtime.syncOrchestrationFederatedDispatchAfterCurrent(dispatch.dispatch_id)
+    )
+  )
+}

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation.test.ts
@@ -11,6 +11,7 @@ import { RpcDispatcher } from '../../../dispatcher'
 import { ORCHESTRATION_METHODS } from '../../orchestration'
 import { createFederationWorkerStartRequest as startRequest } from './federation-request.test-support'
 import { configureFederationWorkerRuntime } from './federation-runtime.test-support'
+import { syncFederationBarrier } from './federation-sync-barrier.test-support'
 
 describe('orchestration federation', () => {
   const databases: OrchestrationDb[] = []
@@ -310,7 +311,7 @@ describe('orchestration federation', () => {
     expect(sent).toMatchObject({ ok: true, result: { lifecycle: { action: 'completed' } } })
     expect(homeDb.getTask(task.id)?.status).toBe('completed')
 
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
 
     expect(homeDb.getTask(task.id)?.status).toBe('completed')
     expect(homeDb.getWorkerDispatch(dispatch.id)?.state).toBe('succeeded')
@@ -362,7 +363,7 @@ describe('orchestration federation', () => {
       ).toHaveLength(1)
     )
 
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
     const question = homeDb
       .getRunMailboxHistory(task.run_id, 10)
       .find((message) => message.type === 'question')
@@ -383,7 +384,7 @@ describe('orchestration federation', () => {
       }
     })
     expect(reply).toMatchObject({ ok: true, result: { question: { status: 'answered' } } })
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
 
     await expect(ask).resolves.toMatchObject({
       ok: true,
@@ -426,8 +427,8 @@ describe('orchestration federation', () => {
     })
     const questionId = (timedOut as { result: { messageId: string } }).result.messageId
 
-    await homeRuntime.syncOrchestrationFederation()
-    await homeDispatcher.dispatch({
+    await syncFederationBarrier(homeRuntime, homeDb)
+    const lateReply = await homeDispatcher.dispatch({
       id: 'rpc_home_late_reply',
       authToken: 'coordinator-token',
       orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION,
@@ -435,6 +436,8 @@ describe('orchestration federation', () => {
       method: 'orchestration.reply',
       params: { id: questionId, body: 'yes', from: 'term_coord' }
     })
+    // A rejected reply enqueues no relay, which would only surface as the resume timing out.
+    expect(lateReply).toMatchObject({ ok: true, result: { question: { status: 'answered' } } })
     restartWorkerRuntime()
     const resumed = workerDispatcher.dispatch({
       id: 'rpc_remote_ask_resume',
@@ -445,7 +448,7 @@ describe('orchestration federation', () => {
       method: 'orchestration.ask',
       params: { from: 'term_windows_worker', resume: questionId, timeoutMs: 5_000 }
     })
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
 
     await expect(resumed).resolves.toMatchObject({
       ok: true,
@@ -476,8 +479,8 @@ describe('orchestration federation', () => {
     loseNextAckResponse = true
     const remoteCall = vi.spyOn(homeRuntime, 'callOrchestrationWorkerServer')
 
-    await expect(homeRuntime.syncOrchestrationFederation()).resolves.toBeUndefined()
-    await homeRuntime.syncOrchestrationFederation()
+    await expect(syncFederationBarrier(homeRuntime, homeDb)).resolves.toBeUndefined()
+    await syncFederationBarrier(homeRuntime, homeDb)
 
     expect(
       homeDb
@@ -612,7 +615,7 @@ describe('orchestration federation', () => {
   it('treats a worker runtime ID change as an epoch, not a new server', async () => {
     const task = createHomeTask()
     await homeDispatcher.dispatch(startRequest(task.id))
-    await homeRuntime.syncOrchestrationFederation()
+    await syncFederationBarrier(homeRuntime, homeDb)
     vi.spyOn(homeRuntime, 'ensureOrchestrationFederationRelay').mockImplementation(() => {})
     const dispatch = homeDb.getDispatchContext(task.id)!
     const oldEpoch = homeDb.getFederatedDispatch(dispatch.id)?.remote_runtime_epoch


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

Fixes the CI failure at `src/main/runtime/rpc/methods/orchestration/federation/federation.test.ts:450` (`keeps a timed-out remote question resumable`).

## Root cause

The defect is in the tests, not in production.

`RuntimeOrchestrationFederation.syncDispatch()` coalesces: if a sync for the same dispatch + db is already in flight, it returns that promise. `ensureRelay()` starts a 1s interval and fires a tick immediately, so there is almost always one in flight. A test that calls `syncOrchestrationFederation()` as a barrier can therefore be handed a sync that already pulled from the peer *before* the test's latest mutation existed.

In the failing test that meant home never imported the worker's question. The subsequent `orchestration.reply` returned `ok: false` with ``Message not found: relay_…`` — a response the test never asserted — so the `to_worker` reply relay was never enqueued, and the resume ask timed out 5s later returning `{ answer: null, timedOut: true }`. That is byte-for-byte the CI failure.

Production is unaffected: `syncOrchestrationFederation` has no production callers, real read-after-write paths already use `syncOrchestrationFederatedDispatchAfterCurrent`, and relay ticks retry every second, so production self-heals a missed sync within ~1s.

## Change

- New `federation-sync-barrier.test-support.ts` exporting `syncFederationBarrier()`, which chains each active federated dispatch past the current round via `syncOrchestrationFederatedDispatchAfterCurrent`. Awaiting it really means "everything enqueued before this call has been exchanged".
- `federation.test.ts`: 8 barrier-purpose sync sites converted. The two tests whose subject *is* the sync machinery (`coalesces overlapping relay polls for the same Dispatch`, `warns once while a federated Dispatch remains unreachable`) keep the raw call deliberately.
- `federation.test.ts`: the reply response is now captured and asserted `{ ok: true, result: { question: { status: 'answered' } } }`, so a rejected reply fails at the reply instead of masquerading as a resume timeout.
- `federation-control-mail.test.ts`: same latent race at 2 sites.

## Verification

- Reproduced the original failure deterministically with a 25ms response-side transport delay plus a background in-flight sync.
- With the fix, that adversarial harness passes 19/19; reverting only the barrier in the target test fails at the new reply assertion. Clean A/B.
- `vitest run .../orchestration/federation/` — 16 files / 109 tests pass.
- `pnpm tc` and `typecheck:tsc:node` pass; `oxlint` clean; `pnpm run check:code-quality:changed` reports 0 new findings across 3 files.