### PR TITLE
fix(updater): refuse a macOS install other app instances would abort

### DIFF
--- a/src/main/updater-conflicting-app-instances.test.ts
+++ b/src/main/updater-conflicting-app-instances.test.ts
@@ -119,15 +119,22 @@ describe('runningApplicationQueryOutput', () => {
 })
 
 describe('describeConflictingAppInstances', () => {
+  it('does not promise a retry the card has no button for', () => {
+    // A non-retryable error leaves no primary action, and Settings shows
+    // "Restart to Update" only for a downloaded state — so there is nothing to
+    // try again from once the other copy is quit.
+    expect(describeConflictingAppInstances([270])).not.toContain('try again')
+  })
+
   it('names a single blocking pid, and reads as singular throughout', () => {
     expect(describeConflictingAppInstances([270])).toBe(
-      'Another copy of Orca is running (PID 270). macOS cannot replace the app while it is open — quit it, then try again.'
+      'Another copy of Orca is running (PID 270). macOS cannot replace the app while it is open — quit it.'
     )
   })
 
   it('reads as plural for more than one', () => {
     expect(describeConflictingAppInstances([270, 811])).toBe(
-      '2 other copies of Orca are running (PIDs 270, 811). macOS cannot replace the app while they are open — quit them, then try again.'
+      '2 other copies of Orca are running (PIDs 270, 811). macOS cannot replace the app while they are open — quit them.'
     )
   })
 
@@ -154,31 +161,39 @@ describe('conflicting-instance detection strategy', () => {
   /** The condition deciding which running applications count as blockers. */
   const blockerCondition = query.match(/if\s*\(([\s\S]*?)\)\s*\{/)?.[1] ?? ''
 
-  it('reads its blocker set from AppKit, not the process table', () => {
+  it('enumerates candidates through LaunchServices, which is what omits the CLI', () => {
+    // THIS is the assertion that keeps Orca CLI processes out of the blocker set.
+    // The CLI runs from the same bundle executable under ELECTRON_RUN_AS_NODE, so
+    // a `ps`-style scan on the executable path would report every CLI invocation
+    // as a blocker and refuse updates on any machine that uses the CLI. Such a
+    // process never registers with LaunchServices, so `runningApplications` does
+    // not list it at all — the omission is in the enumeration, not in any filter.
+    // Measured 2026-09-07: `ps` found 4 processes on this bundle executable and
+    // this query returned 1.
     expect(query).not.toBe('')
     expect(query).toContain('NSWorkspace.sharedWorkspace.runningApplications')
   })
 
-  it('identifies blockers by bundle identity, so Orca CLI processes are not counted', () => {
-    // The Orca CLI runs from the SAME bundle executable under
-    // ELECTRON_RUN_AS_NODE, so `ps`-style matching on the executable path
-    // reports every CLI invocation as a blocking app instance and refuses the
-    // update outright on any machine that uses the CLI. AppKit gives those
-    // processes no bundle identity and Squirrel does not wait for them, so the
-    // non-null bundleIdentifier requirement is what makes this set match
-    // Squirrel's. Measured on a live machine: three processes shared the bundle
-    // executable path (the app plus two `ELECTRON_RUN_AS_NODE` CLI processes)
-    // and this query returned only the app.
+  it('still requires a bundle identity, as defence in depth rather than the filter', () => {
+    // Deliberately NOT described as the CLI exclusion: the same measurement found
+    // 0 of 93 running applications with a null bundleIdentifier, and a variant
+    // with this clause removed returned the identical single pid. It filters
+    // nothing observed today. It stays because NSRunningApplication.bundleIdentifier
+    // is documented nil-able and an unbundled process is not one Squirrel waits
+    // for — so removing it would widen the set on a machine we have not measured.
     expect(blockerCondition).not.toBe('')
-    // Order- and whitespace-independent, so reformatting cannot redden this.
+    // Order- and whitespace-independent, so reformatting cannot redden these.
     expect(blockerCondition).toContain('bundleIdentifier')
     expect(blockerCondition).toContain('executableUrl')
     expect(blockerCondition).toContain('executablePath')
   })
 
   it('never enumerates blockers from the process table', () => {
-    expect(source).not.toMatch(/['"`]\/bin\/ps['"`]/)
-    expect(source).not.toMatch(/\bpgrep\b/)
+    // Why the query and not the file: an earlier version matched only a quoted
+    // `/bin/ps`, so a bare `/bin/ps -A` at line start sailed through it.
+    expect(query).not.toMatch(/\/bin\/ps\b/)
+    expect(query).not.toMatch(/\bpgrep\b/)
+    expect(query).not.toMatch(/\bNSProcessInfo\b/)
   })
 
   it('spawns through the shared runner, not node:child_process', () => {

--- a/src/main/updater-conflicting-app-instances.test.ts
+++ b/src/main/updater-conflicting-app-instances.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  describeConflictingAppInstances,
+  findConflictingAppInstancePids,
+  parseRunningApplicationPids
+} from './updater-conflicting-app-instances'
+
+const APP_EXECUTABLE = '/Applications/Orca.app/Contents/MacOS/Orca'
+
+function darwinDeps(overrides: Parameters<typeof findConflictingAppInstancePids>[0] = {}) {
+  return {
+    platform: 'darwin' as NodeJS.Platform,
+    executablePath: APP_EXECUTABLE,
+    currentPid: 100,
+    ...overrides
+  }
+}
+
+describe('parseRunningApplicationPids', () => {
+  it('keeps pids and drops the querying process', () => {
+    expect(parseRunningApplicationPids('270\n100\n811\n', 100)).toEqual([270, 811])
+  })
+
+  it('ignores blank and non-numeric lines', () => {
+    expect(parseRunningApplicationPids('\n270\nnot-a-pid\n  \n', 100)).toEqual([270])
+  })
+})
+
+describe('findConflictingAppInstancePids', () => {
+  it('reports other instances of this same executable', async () => {
+    const read = vi.fn().mockResolvedValue('270\n811\n')
+
+    expect(
+      await findConflictingAppInstancePids(darwinDeps({ readRunningApplicationPids: read }))
+    ).toEqual([270, 811])
+    expect(read).toHaveBeenCalledWith(APP_EXECUTABLE, 100)
+  })
+
+  it('reports nothing when this is the only instance', async () => {
+    const read = vi.fn().mockResolvedValue('')
+
+    expect(
+      await findConflictingAppInstancePids(darwinDeps({ readRunningApplicationPids: read }))
+    ).toEqual([])
+  })
+
+  it('fails open when the query throws', async () => {
+    const read = vi.fn().mockRejectedValue(new Error('osascript unavailable'))
+
+    expect(
+      await findConflictingAppInstancePids(darwinDeps({ readRunningApplicationPids: read }))
+    ).toEqual([])
+  })
+
+  it('does not query off darwin, where the installers manage running instances', async () => {
+    const read = vi.fn().mockResolvedValue('270\n')
+
+    for (const platform of ['win32', 'linux'] as const) {
+      expect(
+        await findConflictingAppInstancePids(
+          darwinDeps({ platform, readRunningApplicationPids: read })
+        )
+      ).toEqual([])
+    }
+    expect(read).not.toHaveBeenCalled()
+  })
+})
+
+describe('describeConflictingAppInstances', () => {
+  it('names a single blocking pid', () => {
+    expect(describeConflictingAppInstances([270])).toBe(
+      'Another copy of Orca is running (PID 270). macOS cannot replace the app while they are open — quit them, then try again.'
+    )
+  })
+
+  it('caps how many pids it lists', () => {
+    expect(describeConflictingAppInstances([1, 2, 3, 4, 5, 6])).toContain(
+      '6 other copies of Orca are running (PIDs 1, 2, 3, 4, 5, …)'
+    )
+  })
+})
+
+// Why this is a source assertion and not a behavioural one: the behaviour under
+// test lives inside the AppKit query, so any test that injects a pid reader
+// bypasses exactly the logic that must not regress.
+describe('conflicting-instance detection strategy', () => {
+  const source = readFileSync(
+    path.join(import.meta.dirname, 'updater-conflicting-app-instances.ts'),
+    'utf8'
+  )
+
+  it('identifies blockers by bundle identity, so Orca CLI processes are not counted', () => {
+    // The Orca CLI runs from the SAME bundle executable under
+    // ELECTRON_RUN_AS_NODE, so `ps`-style matching on the executable path
+    // reports every CLI invocation as a blocking app instance and refuses the
+    // update outright on any machine that uses the CLI. AppKit gives those
+    // processes no bundle identity and Squirrel does not wait for them, so the
+    // non-null bundleIdentifier requirement is what makes this set match
+    // Squirrel's. Measured on a live machine: three processes shared the bundle
+    // executable path (the app plus two `ELECTRON_RUN_AS_NODE` CLI processes)
+    // and this query returned only the app.
+    expect(source).toContain('NSWorkspace')
+    expect(source).toContain('bundleIdentifier')
+    expect(source).toMatch(/if\s*\(\s*\n?\s*executableUrl\s*&&\s*\n?\s*bundleIdentifier/)
+  })
+
+  it('never enumerates blockers from the process table', () => {
+    expect(source).not.toMatch(/['"`]\/bin\/ps['"`]/)
+    expect(source).not.toMatch(/\bpgrep\b/)
+  })
+})

--- a/src/main/updater-conflicting-app-instances.test.ts
+++ b/src/main/updater-conflicting-app-instances.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   describeConflictingAppInstances,
   findConflictingAppInstancePids,
-  parseRunningApplicationPids
+  parseRunningApplicationPids,
+  runningApplicationQueryOutput
 } from './updater-conflicting-app-instances'
 
 const APP_EXECUTABLE = '/Applications/Orca.app/Contents/MacOS/Orca'
@@ -68,6 +69,30 @@ describe('findConflictingAppInstancePids', () => {
   })
 })
 
+describe('runningApplicationQueryOutput', () => {
+  // Fail-open is the property that keeps a broken probe from blocking updates,
+  // and the runner reports these as data rather than throwing — so each one is a
+  // path that would otherwise look like a successful "no blockers" answer, or
+  // worse, like a partial list of them.
+  it('passes through the output of a query that exited cleanly', () => {
+    expect(runningApplicationQueryOutput({ timedOut: false, code: 0, stdout: '270\n' })).toBe(
+      '270\n'
+    )
+  })
+
+  it('discards partial output from a timed-out query', () => {
+    expect(runningApplicationQueryOutput({ timedOut: true, code: null, stdout: '270\n' })).toBe('')
+  })
+
+  it('discards output from a query that exited non-zero', () => {
+    expect(runningApplicationQueryOutput({ timedOut: false, code: 1, stdout: '270\n' })).toBe('')
+  })
+
+  it('discards output from a query killed by a signal', () => {
+    expect(runningApplicationQueryOutput({ timedOut: false, code: null, stdout: '270\n' })).toBe('')
+  })
+})
+
 describe('describeConflictingAppInstances', () => {
   it('names a single blocking pid', () => {
     expect(describeConflictingAppInstances([270])).toBe(
@@ -109,5 +134,12 @@ describe('conflicting-instance detection strategy', () => {
   it('never enumerates blockers from the process table', () => {
     expect(source).not.toMatch(/['"`]\/bin\/ps['"`]/)
     expect(source).not.toMatch(/\bpgrep\b/)
+  })
+
+  it('spawns through the shared runner, not node:child_process', () => {
+    // The tree-level guard in src/shared/child-process owns this rule; asserting
+    // it here too keeps the reason next to the code that has to obey it.
+    expect(source).not.toContain('node:child_process')
+    expect(source).toContain("from '../shared/child-process/run-process'")
   })
 })

--- a/src/main/updater-conflicting-app-instances.test.ts
+++ b/src/main/updater-conflicting-app-instances.test.ts
@@ -91,12 +91,43 @@ describe('runningApplicationQueryOutput', () => {
   it('discards output from a query killed by a signal', () => {
     expect(runningApplicationQueryOutput({ timedOut: false, code: null, stdout: '270\n' })).toBe('')
   })
+
+  it('discards a clipped list even though the query exited cleanly', () => {
+    // The only partial answer that arrives with code 0: the bounded sink hit
+    // maxOutputBytes. A truncated pid list would name some blockers and hide
+    // others, so it is not an answer this probe may act on.
+    expect(
+      runningApplicationQueryOutput({
+        timedOut: false,
+        code: 0,
+        stdout: '270\n811\n',
+        outputTruncated: true
+      })
+    ).toBe('')
+  })
+
+  it('accepts output that the sink explicitly did not clip', () => {
+    expect(
+      runningApplicationQueryOutput({
+        timedOut: false,
+        code: 0,
+        stdout: '270\n',
+        outputTruncated: false
+      })
+    ).toBe('270\n')
+  })
 })
 
 describe('describeConflictingAppInstances', () => {
-  it('names a single blocking pid', () => {
+  it('names a single blocking pid, and reads as singular throughout', () => {
     expect(describeConflictingAppInstances([270])).toBe(
-      'Another copy of Orca is running (PID 270). macOS cannot replace the app while they are open — quit them, then try again.'
+      'Another copy of Orca is running (PID 270). macOS cannot replace the app while it is open — quit it, then try again.'
+    )
+  })
+
+  it('reads as plural for more than one', () => {
+    expect(describeConflictingAppInstances([270, 811])).toBe(
+      '2 other copies of Orca are running (PIDs 270, 811). macOS cannot replace the app while they are open — quit them, then try again.'
     )
   })
 
@@ -115,6 +146,18 @@ describe('conflicting-instance detection strategy', () => {
     path.join(import.meta.dirname, 'updater-conflicting-app-instances.ts'),
     'utf8'
   )
+  // Why the query and not the file: the prose above it names AppKit and
+  // bundleIdentifier too, so asserting on the file passes even after the query
+  // has been rewritten to scan the process table — measured, that is exactly
+  // what an earlier version of this ratchet did.
+  const query = source.match(/String\.raw`([\s\S]*?)`/)?.[1] ?? ''
+  /** The condition deciding which running applications count as blockers. */
+  const blockerCondition = query.match(/if\s*\(([\s\S]*?)\)\s*\{/)?.[1] ?? ''
+
+  it('reads its blocker set from AppKit, not the process table', () => {
+    expect(query).not.toBe('')
+    expect(query).toContain('NSWorkspace.sharedWorkspace.runningApplications')
+  })
 
   it('identifies blockers by bundle identity, so Orca CLI processes are not counted', () => {
     // The Orca CLI runs from the SAME bundle executable under
@@ -126,9 +169,11 @@ describe('conflicting-instance detection strategy', () => {
     // Squirrel's. Measured on a live machine: three processes shared the bundle
     // executable path (the app plus two `ELECTRON_RUN_AS_NODE` CLI processes)
     // and this query returned only the app.
-    expect(source).toContain('NSWorkspace')
-    expect(source).toContain('bundleIdentifier')
-    expect(source).toMatch(/if\s*\(\s*\n?\s*executableUrl\s*&&\s*\n?\s*bundleIdentifier/)
+    expect(blockerCondition).not.toBe('')
+    // Order- and whitespace-independent, so reformatting cannot redden this.
+    expect(blockerCondition).toContain('bundleIdentifier')
+    expect(blockerCondition).toContain('executableUrl')
+    expect(blockerCondition).toContain('executablePath')
   })
 
   it('never enumerates blockers from the process table', () => {

--- a/src/main/updater-conflicting-app-instances.ts
+++ b/src/main/updater-conflicting-app-instances.ts
@@ -77,13 +77,23 @@ async function readRunningApplicationPids(
  * as data rather than throwing, so partial stdout arrives looking like an answer.
  * A probe that could not finish has proved nothing about who is running, and
  * naming a blocker on that basis would refuse an install the user could have had.
+ *
+ * `outputTruncated` is the third way to get a partial list and the only one that
+ * arrives with a clean exit: the bounded sink clips at `maxOutputBytes` and says
+ * so precisely because callers that parse the output have to tell a short answer
+ * from a clipped one. Unreachable in practice — the cap holds thousands of pids —
+ * but this is the fail-open path, where the contract is the safety property.
  */
 export function runningApplicationQueryOutput(result: {
   timedOut: boolean
   code: number | null
   stdout: string
+  outputTruncated?: boolean
 }): string {
-  return result.timedOut || result.code !== 0 ? '' : result.stdout
+  if (result.timedOut || result.code !== 0 || result.outputTruncated === true) {
+    return ''
+  }
+  return result.stdout
 }
 
 export function parseRunningApplicationPids(output: string, currentPid: number): number[] {
@@ -140,9 +150,12 @@ const MAX_REPORTED_CONFLICTING_PIDS = 5
 export function describeConflictingAppInstances(pids: readonly number[]): string {
   const reported = pids.slice(0, MAX_REPORTED_CONFLICTING_PIDS)
   const suffix = pids.length > reported.length ? ', …' : ''
-  const subject =
+  const [subject, closing] =
     pids.length === 1
-      ? `Another copy of Orca is running (PID ${reported[0]})`
-      : `${pids.length} other copies of Orca are running (PIDs ${reported.join(', ')}${suffix})`
-  return `${subject}. macOS cannot replace the app while they are open — quit them, then try again.`
+      ? [`Another copy of Orca is running (PID ${reported[0]})`, 'it is open — quit it']
+      : [
+          `${pids.length} other copies of Orca are running (PIDs ${reported.join(', ')}${suffix})`,
+          'they are open — quit them'
+        ]
+  return `${subject}. macOS cannot replace the app while ${closing}, then try again.`
 }

--- a/src/main/updater-conflicting-app-instances.ts
+++ b/src/main/updater-conflicting-app-instances.ts
@@ -11,12 +11,23 @@ import { runProcess } from '../shared/child-process/run-process'
 const RUNNING_APPLICATION_QUERY_TIMEOUT_MS = 2_000
 const RUNNING_APPLICATION_QUERY_MAX_BYTES = 64 * 1024
 
-// Why AppKit and not `ps`: the Orca CLI runs from this same executable under
-// ELECTRON_RUN_AS_NODE, so an exact-executable process scan reports every CLI
-// invocation as a blocker and refuses updates on any machine that uses the CLI.
-// AppKit gives those processes no bundle identity, and Squirrel does not wait
-// for them either — so requiring a non-null bundleIdentifier matches Squirrel's
-// own blocking set. See the regression in the sibling test file.
+// Why AppKit and not `ps`: the Orca CLI runs from this same bundle executable
+// under ELECTRON_RUN_AS_NODE, so an exact-executable process scan reports every
+// CLI invocation as a blocker and refuses updates on any machine that uses the
+// CLI. Squirrel does not wait for those processes, and neither does this.
+//
+// The exclusion happens at the enumeration, not in the filter below: a process
+// under ELECTRON_RUN_AS_NODE never registers with LaunchServices, so
+// `runningApplications` does not list it at all. Measured 2026-09-07 — `ps`
+// found 4 processes on this bundle executable, this query returned 1, and a
+// variant with the `bundleIdentifier` requirement removed also returned 1.
+// So `NSWorkspace.sharedWorkspace.runningApplications` is the load-bearing
+// choice; that is what the sibling test protects.
+//
+// `bundleIdentifier` is kept as defence in depth, not as the mechanism: the same
+// measurement found 0 of 93 running applications with a null identifier, so it
+// filtered nothing here — but `NSRunningApplication.bundleIdentifier` is
+// documented nil-able, and an unbundled process is not one Squirrel waits for.
 const RUNNING_APPLICATION_QUERY = String.raw`
 function run(argv) {
   ObjC.import('AppKit')
@@ -78,11 +89,16 @@ async function readRunningApplicationPids(
  * A probe that could not finish has proved nothing about who is running, and
  * naming a blocker on that basis would refuse an install the user could have had.
  *
- * `outputTruncated` is the third way to get a partial list and the only one that
- * arrives with a clean exit: the bounded sink clips at `maxOutputBytes` and says
- * so precisely because callers that parse the output have to tell a short answer
+ * `outputTruncated` is a third way to get a partial list, and one that arrives
+ * with a clean exit: the bounded sink clips at `maxOutputBytes` and says so
+ * precisely because callers that parse the output have to tell a short answer
  * from a clipped one. Unreachable in practice — the cap holds thousands of pids —
  * but this is the fail-open path, where the contract is the safety property.
+ *
+ * It is not the only clean-exit partial: a swallowed stdout stream `error` also
+ * shortens the list without failing the run. Every such case can only DROP pids,
+ * which degrades toward the pre-fix behaviour of not naming a blocker — never
+ * toward refusing an install that would have worked.
  */
 export function runningApplicationQueryOutput(result: {
   timedOut: boolean
@@ -146,7 +162,16 @@ export async function findConflictingAppInstancePids(
 
 const MAX_REPORTED_CONFLICTING_PIDS = 5
 
-/** Actionable copy for the update card: what is blocking, and what to do. */
+/**
+ * Card copy: what is blocking, and the one step the user can actually take.
+ *
+ * Why it stops at "quit it" and does not say "then try again": a non-retryable
+ * error leaves the card with no primary action, and Settings renders its own
+ * "Restart to Update" only for a `downloaded` state, so after quitting the other
+ * copy there is no surface to try again from. Instructing an action that exists
+ * nowhere is worse than instructing one fewer step. Restoring the retry sentence
+ * needs a real recovery action first (STA follow-up).
+ */
 export function describeConflictingAppInstances(pids: readonly number[]): string {
   const reported = pids.slice(0, MAX_REPORTED_CONFLICTING_PIDS)
   const suffix = pids.length > reported.length ? ', …' : ''
@@ -157,5 +182,5 @@ export function describeConflictingAppInstances(pids: readonly number[]): string
           `${pids.length} other copies of Orca are running (PIDs ${reported.join(', ')}${suffix})`,
           'they are open — quit them'
         ]
-  return `${subject}. macOS cannot replace the app while ${closing}, then try again.`
+  return `${subject}. macOS cannot replace the app while ${closing}.`
 }

--- a/src/main/updater-conflicting-app-instances.ts
+++ b/src/main/updater-conflicting-app-instances.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { runProcess } from '../shared/child-process/run-process'
 
 // Why: Squirrel.Mac's ShipIt waits for EVERY running instance of the target
 // bundle to exit before it installs, and aborts with "App Still Running Error"
@@ -46,36 +46,44 @@ export type RunningApplicationPidReader = (
   currentPid: number
 ) => Promise<string>
 
-function readRunningApplicationPids(executablePath: string, currentPid: number): Promise<string> {
-  return new Promise((resolve, reject) => {
-    // Why: one bounded subprocess instead of a probe per candidate. Paths go
-    // through argv so nothing is interpolated into the script, and NSWorkspace
-    // metadata needs no Accessibility permission.
-    execFile(
-      '/usr/bin/osascript',
-      [
-        '-l',
-        'JavaScript',
-        '-e',
-        RUNNING_APPLICATION_QUERY,
-        '--',
-        executablePath,
-        String(currentPid)
-      ],
-      {
-        encoding: 'utf8',
-        timeout: RUNNING_APPLICATION_QUERY_TIMEOUT_MS,
-        maxBuffer: RUNNING_APPLICATION_QUERY_MAX_BYTES
-      },
-      (error, stdout) => {
-        if (error) {
-          reject(error)
-          return
-        }
-        resolve(stdout)
-      }
-    )
+async function readRunningApplicationPids(
+  executablePath: string,
+  currentPid: number
+): Promise<string> {
+  // Why: one bounded subprocess instead of a probe per candidate. Paths go
+  // through argv so nothing is interpolated into the script, and NSWorkspace
+  // metadata needs no Accessibility permission.
+  const result = await runProcess({
+    program: '/usr/bin/osascript',
+    args: [
+      '-l',
+      'JavaScript',
+      '-e',
+      RUNNING_APPLICATION_QUERY,
+      '--',
+      executablePath,
+      String(currentPid)
+    ],
+    timeoutMs: RUNNING_APPLICATION_QUERY_TIMEOUT_MS,
+    maxOutputBytes: RUNNING_APPLICATION_QUERY_MAX_BYTES
   })
+  return runningApplicationQueryOutput(result)
+}
+
+/**
+ * Output only from a query that actually finished.
+ *
+ * Why it is a decision at all: `runProcess` reports a non-zero exit or a timeout
+ * as data rather than throwing, so partial stdout arrives looking like an answer.
+ * A probe that could not finish has proved nothing about who is running, and
+ * naming a blocker on that basis would refuse an install the user could have had.
+ */
+export function runningApplicationQueryOutput(result: {
+  timedOut: boolean
+  code: number | null
+  stdout: string
+}): string {
+  return result.timedOut || result.code !== 0 ? '' : result.stdout
 }
 
 export function parseRunningApplicationPids(output: string, currentPid: number): number[] {

--- a/src/main/updater-conflicting-app-instances.ts
+++ b/src/main/updater-conflicting-app-instances.ts
@@ -1,0 +1,140 @@
+import { execFile } from 'node:child_process'
+
+// Why: Squirrel.Mac's ShipIt waits for EVERY running instance of the target
+// bundle to exit before it installs, and aborts with "App Still Running Error"
+// if one appears mid-install. A second packaged Orca — a manually opened copy,
+// or an agent/e2e rig launching /Applications/Orca.app with a temp profile,
+// often windowless and invisible — silently stalls the update forever while the
+// user sees "the app quit but never relaunched, still on the old version".
+// Naming those instances before the install handoff turns a silent wedge into
+// an actionable message.
+const RUNNING_APPLICATION_QUERY_TIMEOUT_MS = 2_000
+const RUNNING_APPLICATION_QUERY_MAX_BYTES = 64 * 1024
+
+// Why AppKit and not `ps`: the Orca CLI runs from this same executable under
+// ELECTRON_RUN_AS_NODE, so an exact-executable process scan reports every CLI
+// invocation as a blocker and refuses updates on any machine that uses the CLI.
+// AppKit gives those processes no bundle identity, and Squirrel does not wait
+// for them either — so requiring a non-null bundleIdentifier matches Squirrel's
+// own blocking set. See the regression in the sibling test file.
+const RUNNING_APPLICATION_QUERY = String.raw`
+function run(argv) {
+  ObjC.import('AppKit')
+  const executablePath = argv[0]
+  const currentPid = Number(argv[1])
+  const applications = $.NSWorkspace.sharedWorkspace.runningApplications
+  const pids = []
+  for (let index = 0; index < applications.count; index += 1) {
+    const application = applications.objectAtIndex(index)
+    const executableUrl = application.executableURL
+    const bundleIdentifier = application.bundleIdentifier
+    const pid = Number(application.processIdentifier)
+    if (
+      executableUrl &&
+      bundleIdentifier &&
+      String(ObjC.unwrap(executableUrl.path)) === executablePath &&
+      pid !== currentPid
+    ) {
+      pids.push(String(pid))
+    }
+  }
+  return pids.join('\n')
+}`
+
+export type RunningApplicationPidReader = (
+  executablePath: string,
+  currentPid: number
+) => Promise<string>
+
+function readRunningApplicationPids(executablePath: string, currentPid: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // Why: one bounded subprocess instead of a probe per candidate. Paths go
+    // through argv so nothing is interpolated into the script, and NSWorkspace
+    // metadata needs no Accessibility permission.
+    execFile(
+      '/usr/bin/osascript',
+      [
+        '-l',
+        'JavaScript',
+        '-e',
+        RUNNING_APPLICATION_QUERY,
+        '--',
+        executablePath,
+        String(currentPid)
+      ],
+      {
+        encoding: 'utf8',
+        timeout: RUNNING_APPLICATION_QUERY_TIMEOUT_MS,
+        maxBuffer: RUNNING_APPLICATION_QUERY_MAX_BYTES
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(stdout)
+      }
+    )
+  })
+}
+
+export function parseRunningApplicationPids(output: string, currentPid: number): number[] {
+  const pids: number[] = []
+  for (const line of output.split('\n')) {
+    const normalized = line.trim()
+    if (!/^\d+$/.test(normalized)) {
+      continue
+    }
+    const pid = Number(normalized)
+    if (pid > 0 && pid !== currentPid) {
+      pids.push(pid)
+    }
+  }
+  return pids
+}
+
+export type ConflictingInstanceDeps = {
+  platform?: NodeJS.Platform
+  executablePath?: string
+  currentPid?: number
+  readRunningApplicationPids?: RunningApplicationPidReader
+}
+
+/**
+ * Pids of other running app instances launched from this same executable.
+ *
+ * macOS-only by design: this mirrors Squirrel.Mac's pre-install wait/abort
+ * semantics, and the Windows and Linux installers manage running instances
+ * themselves. Fails open — an unavailable query must never block an install.
+ */
+export async function findConflictingAppInstancePids(
+  deps: ConflictingInstanceDeps = {}
+): Promise<number[]> {
+  if ((deps.platform ?? process.platform) !== 'darwin') {
+    return []
+  }
+  const executablePath = deps.executablePath ?? process.execPath
+  const currentPid = deps.currentPid ?? process.pid
+  try {
+    const output = await (deps.readRunningApplicationPids ?? readRunningApplicationPids)(
+      executablePath,
+      currentPid
+    )
+    return parseRunningApplicationPids(output, currentPid)
+  } catch {
+    return []
+  }
+}
+
+const MAX_REPORTED_CONFLICTING_PIDS = 5
+
+/** Actionable copy for the update card: what is blocking, and what to do. */
+export function describeConflictingAppInstances(pids: readonly number[]): string {
+  const reported = pids.slice(0, MAX_REPORTED_CONFLICTING_PIDS)
+  const suffix = pids.length > reported.length ? ', …' : ''
+  const subject =
+    pids.length === 1
+      ? `Another copy of Orca is running (PID ${reported[0]})`
+      : `${pids.length} other copies of Orca are running (PIDs ${reported.join(', ')}${suffix})`
+  return `${subject}. macOS cannot replace the app while they are open — quit them, then try again.`
+}

--- a/src/main/updater.conflicting-instance-install.test.ts
+++ b/src/main/updater.conflicting-instance-install.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
+import type * as ConflictingAppInstances from './updater-conflicting-app-instances'
+
+type ConflictingAppInstancesModule = typeof ConflictingAppInstances
+
+const { autoUpdaterMock, killAllPtyMock, moduleFactories, resetUpdaterMocks } = await vi.hoisted(
+  async () => (await import('./updater-test-harness')).createUpdaterMocks()
+)
+
+const { findConflictingAppInstancePidsMock } = vi.hoisted(() => ({
+  findConflictingAppInstancePidsMock: vi.fn<() => Promise<number[]>>()
+}))
+
+vi.mock('electron', () => moduleFactories.electron())
+vi.mock('electron-updater', () => moduleFactories.electronUpdater())
+vi.mock('./electron-updater-loader', () => moduleFactories.electronUpdaterLoader())
+vi.mock('@electron-toolkit/utils', () => moduleFactories.electronToolkitUtils())
+vi.mock('./ipc/pty', () => moduleFactories.ipcPty())
+vi.mock('./linux-update-package-type', () => moduleFactories.linuxUpdatePackageType())
+vi.mock('./updater-lifecycle-diagnostics', () => moduleFactories.updaterLifecycleDiagnostics())
+vi.mock('./updater-changelog', () => moduleFactories.updaterChangelog())
+vi.mock('./updater-nudge', () => moduleFactories.updaterNudge())
+vi.mock('./update-install-exit-watchdog', () => moduleFactories.updateInstallExitWatchdog())
+vi.mock('./updater-prerelease-feed', () => moduleFactories.updaterPrereleaseFeed())
+vi.mock('./local-builds/local-build-switch', () => moduleFactories.localBuildSwitch())
+vi.mock('./local-builds/local-build-feed-server', () => moduleFactories.localBuildFeedServer())
+vi.mock('./startup/hydrate-shell-path', () => ({
+  runWithLaunchPath: (action: () => unknown): unknown => action()
+}))
+// Why partial: the message builder stays real, so a copy change cannot make
+// these pass against text no user would ever see.
+vi.mock('./updater-conflicting-app-instances', async () => ({
+  ...(await vi.importActual<ConflictingAppInstancesModule>('./updater-conflicting-app-instances')),
+  findConflictingAppInstancePids: findConflictingAppInstancePidsMock
+}))
+
+warmUpdaterModule()
+
+/** Asks the updater to install, then lets its deferral timer fire. */
+async function requestInstall(): Promise<ReturnType<typeof vi.fn>> {
+  const send = vi.fn()
+  const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
+  setupAutoUpdater({ webContents: { send } } as never)
+  quitAndInstall()
+  await vi.advanceTimersByTimeAsync(100)
+  return send
+}
+
+function lastErrorStatus(send: ReturnType<typeof vi.fn>): Record<string, unknown> | undefined {
+  return send.mock.calls
+    .filter(([channel]) => channel === 'updater:status')
+    .map(([, status]) => status as Record<string, unknown>)
+    .findLast((status) => status.state === 'error')
+}
+
+describe('macOS install blocked by other running app instances', () => {
+  beforeEach(() => {
+    resetUpdaterMocks()
+    findConflictingAppInstancePidsMock.mockReset().mockResolvedValue([])
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('installs normally when this is the only running copy', async () => {
+    const send = await requestInstall()
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+    expect(lastErrorStatus(send)).toBeUndefined()
+  })
+
+  it('refuses the install instead of quitting into a handoff Squirrel will abort', async () => {
+    findConflictingAppInstancePidsMock.mockResolvedValue([270, 811])
+
+    const send = await requestInstall()
+
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+    // Killing PTYs is destructive and only earns its keep once the install commits.
+    expect(killAllPtyMock).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith('updater:quitAndInstallAborted')
+  })
+
+  it('names the copies to quit and keeps the update retryable', async () => {
+    findConflictingAppInstancePidsMock.mockResolvedValue([270, 811])
+
+    const send = await requestInstall()
+
+    expect(lastErrorStatus(send)).toMatchObject({ state: 'error', retryable: true })
+    expect(String(lastErrorStatus(send)?.message)).toContain('270, 811')
+  })
+
+  it('leaves the update installable after a refusal, once the other copy quits', async () => {
+    findConflictingAppInstancePidsMock.mockResolvedValue([270])
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
+    setupAutoUpdater({ webContents: { send: vi.fn() } } as never)
+
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+    expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled()
+
+    // Why this matters: the refusal must release the in-progress claim, or the
+    // retry the message asks for would be swallowed as a duplicate request.
+    findConflictingAppInstancePidsMock.mockResolvedValue([])
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a duplicate install request that arrives during the conflict scan', async () => {
+    let releaseScan: (pids: number[]) => void = () => {}
+    findConflictingAppInstancePidsMock.mockReturnValue(
+      new Promise<number[]>((resolve) => {
+        releaseScan = resolve
+      })
+    )
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
+    setupAutoUpdater({ webContents: { send: vi.fn() } } as never)
+
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+    // The scan is the first await in the install, so a second request lands
+    // inside a window where no install state has been set yet.
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+    releaseScan([])
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/updater.conflicting-instance-install.test.ts
+++ b/src/main/updater.conflicting-instance-install.test.ts
@@ -119,6 +119,23 @@ describe('macOS install blocked by other running app instances', () => {
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
   })
 
+  it('installs anyway when the conflict scan throws, without latching or escaping', async () => {
+    // The scan runs outside the install span's catch and its claim is held across
+    // the await, so a rejection would both escape unhandled and latch every later
+    // install into `quit_and_install_ignored` — no card, no recovery short of a
+    // relaunch. Failing open is the probe's own contract: an unavailable scan
+    // must never block an install. The probe cannot throw today; this pins that
+    // a future one changing that cannot strand the user.
+    findConflictingAppInstancePidsMock.mockRejectedValueOnce(new Error('probe exploded'))
+    const { setupAutoUpdater, quitAndInstall } = await loadUpdaterModule()
+    setupAutoUpdater({ webContents: { send: vi.fn() } } as never)
+
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1)
+  })
+
   it('ignores a duplicate install request that arrives during the conflict scan', async () => {
     let releaseScan: (pids: number[]) => void = () => {}
     findConflictingAppInstancePidsMock.mockReturnValue(

--- a/src/main/updater.conflicting-instance-install.test.ts
+++ b/src/main/updater.conflicting-instance-install.test.ts
@@ -83,13 +83,22 @@ describe('macOS install blocked by other running app instances', () => {
     expect(send).toHaveBeenCalledWith('updater:quitAndInstallAborted')
   })
 
-  it('names the copies to quit and keeps the update retryable', async () => {
+  it('puts the copies to quit on the card summary, not behind Show details', async () => {
     findConflictingAppInstancePidsMock.mockResolvedValue([270, 811])
 
     const send = await requestInstall()
 
-    expect(lastErrorStatus(send)).toMatchObject({ state: 'error', retryable: true })
-    expect(String(lastErrorStatus(send)?.message)).toContain('270, 811')
+    // Why the flag and not just the text: the update card promotes `message` to
+    // its summary line only for a NON-retryable error, and otherwise shows a
+    // generic "Could not complete the update." with this sentence hidden behind
+    // "Show details". Marking it retryable would bury the one thing the user
+    // needs, in exchange for a Retry Download that re-fetches an already-staged
+    // release. Assert the summary the user actually reads, so a flip back is red.
+    // The renderer half of this contract is asserted against the real card model
+    // in update-card-error-model.test.ts; this pins the flag main must send.
+    const status = lastErrorStatus(send)
+    expect(status).toMatchObject({ state: 'error', retryable: false })
+    expect(String(status?.message)).toContain('270, 811')
   })
 
   it('leaves the update installable after a refusal, once the other copy quits', async () => {

--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
+import type * as ConflictingAppInstances from './updater-conflicting-app-instances'
+
+type ConflictingAppInstancesModule = typeof ConflictingAppInstances
 
 const {
   appMock,
@@ -84,6 +87,11 @@ vi.mock('./linux-update-package-type', () => ({
 }))
 vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
 vi.mock('./ipc/pty', () => ({ killAllPty: killAllPtyMock }))
+// The real detector shells out to osascript; keep unit tests off the live machine.
+vi.mock('./updater-conflicting-app-instances', async () => ({
+  ...(await vi.importActual<ConflictingAppInstancesModule>('./updater-conflicting-app-instances')),
+  findConflictingAppInstancePids: vi.fn(async () => [])
+}))
 vi.mock('./updater-changelog', () => ({ fetchChangelog: vi.fn().mockResolvedValue(null) }))
 vi.mock('./updater-nudge', () => ({
   fetchNudge: vi.fn().mockResolvedValue(null),

--- a/src/main/updater.linux-root-package-install.test.ts
+++ b/src/main/updater.linux-root-package-install.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from 'node:os'
 import type * as UpdaterModule from './updater'
 import type { LinuxRootPackageType, UpdateStatus } from '../shared/update-status-types'
 import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
+import type * as ConflictingAppInstances from './updater-conflicting-app-instances'
+
+type ConflictingAppInstancesModule = typeof ConflictingAppInstances
 
 const {
   browserWindowMock,
@@ -23,6 +26,11 @@ vi.mock('electron-updater', () => moduleFactories.electronUpdater())
 vi.mock('./electron-updater-loader', () => moduleFactories.electronUpdaterLoader())
 vi.mock('@electron-toolkit/utils', () => moduleFactories.electronToolkitUtils())
 vi.mock('./ipc/pty', () => moduleFactories.ipcPty())
+// The real detector shells out to osascript; keep unit tests off the live machine.
+vi.mock('./updater-conflicting-app-instances', async () => ({
+  ...(await vi.importActual<ConflictingAppInstancesModule>('./updater-conflicting-app-instances')),
+  findConflictingAppInstancePids: vi.fn(async () => [])
+}))
 vi.mock('./linux-update-package-type', () => moduleFactories.linuxUpdatePackageType())
 vi.mock('./updater-lifecycle-diagnostics', () => moduleFactories.updaterLifecycleDiagnostics())
 vi.mock('./updater-changelog', () => moduleFactories.updaterChangelog())

--- a/src/main/updater.mac-install.test.ts
+++ b/src/main/updater.mac-install.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
+import type * as ConflictingAppInstances from './updater-conflicting-app-instances'
+
+type ConflictingAppInstancesModule = typeof ConflictingAppInstances
 
 const {
   appMock,
@@ -107,6 +110,11 @@ vi.mock('@electron-toolkit/utils', () => ({
 
 vi.mock('./ipc/pty', () => ({
   killAllPty: killAllPtyMock
+}))
+// The real detector shells out to osascript; keep unit tests off the live machine.
+vi.mock('./updater-conflicting-app-instances', async () => ({
+  ...(await vi.importActual<ConflictingAppInstancesModule>('./updater-conflicting-app-instances')),
+  findConflictingAppInstancePids: vi.fn(async () => [])
 }))
 
 vi.mock('./updater-changelog', () => ({

--- a/src/main/updater.quit-and-install.test.ts
+++ b/src/main/updater.quit-and-install.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { PRE_COMMIT_INSTALL_FAILURE } from './updater-test-harness'
 import { loadUpdaterModule, warmUpdaterModule } from './updater-test-module-loader'
+import type * as ConflictingAppInstances from './updater-conflicting-app-instances'
+
+type ConflictingAppInstancesModule = typeof ConflictingAppInstances
 
 const {
   nativeUpdaterMock,
@@ -22,6 +25,11 @@ vi.mock('electron-updater', () => moduleFactories.electronUpdater())
 vi.mock('./electron-updater-loader', () => moduleFactories.electronUpdaterLoader())
 vi.mock('@electron-toolkit/utils', () => moduleFactories.electronToolkitUtils())
 vi.mock('./ipc/pty', () => moduleFactories.ipcPty())
+// The real detector shells out to osascript; keep unit tests off the live machine.
+vi.mock('./updater-conflicting-app-instances', async () => ({
+  ...(await vi.importActual<ConflictingAppInstancesModule>('./updater-conflicting-app-instances')),
+  findConflictingAppInstancePids: vi.fn(async () => [])
+}))
 vi.mock('./linux-update-package-type', () => moduleFactories.linuxUpdatePackageType())
 vi.mock('./updater-lifecycle-diagnostics', () => moduleFactories.updaterLifecycleDiagnostics())
 vi.mock('./updater-changelog', () => moduleFactories.updaterChangelog())

--- a/src/main/updater/updater-install-execution.ts
+++ b/src/main/updater/updater-install-execution.ts
@@ -7,6 +7,10 @@ import { armUpdateInstallExitWatchdog } from '../update-install-exit-watchdog'
 import { getLinuxPackageType } from '../linux-update-package-type'
 import { LINUX_PACKAGE_MARKER_UNUSABLE_MESSAGE } from '../linux-package-downloaded-status'
 import { recordUpdaterLifecycle } from '../updater-lifecycle-diagnostics'
+import {
+  describeConflictingAppInstances,
+  findConflictingAppInstancePids
+} from '../updater-conflicting-app-instances'
 import { requestServeUpdateHandoff, failServeUpdateHandoff } from '../serve-update-handoff'
 import { UpdaterPackageRecovery } from './updater-package-recovery'
 
@@ -51,7 +55,36 @@ export abstract class UpdaterInstallExecution extends UpdaterPackageRecovery {
       })
       return
     }
+    // Why the flag is claimed before the await: the conflict scan is the first
+    // asynchronous step in this method, and a duplicate install request landing
+    // inside that window would otherwise pass the in-progress check above and
+    // run a second handoff.
     this.quitAndInstallInProgress = true
+
+    // Why here, before any other install state is set: Squirrel.Mac waits for
+    // every running instance of this bundle to exit and aborts if one appears
+    // mid-install, so quitting into a doomed handoff strands the user on the
+    // old version with no window and no explanation.
+    const conflictingInstancePids = await findConflictingAppInstancePids()
+    if (conflictingInstancePids.length > 0) {
+      // Nothing else has been armed yet, so releasing the claim is the whole rollback.
+      this.quitAndInstallInProgress = false
+      recordUpdaterLifecycle(
+        'quit_and_install_blocked_by_other_instances',
+        { version: pendingVersion || null, instanceCount: conflictingInstancePids.length },
+        { level: 'warn', message: 'Other running app instances would abort the macOS install' }
+      )
+      // The preload prepares renderer state before invoking; release it when main refuses.
+      this.mainWindowRef?.webContents.send('updater:quitAndInstallAborted')
+      this.sendInstallFailureStatus({
+        state: 'error',
+        message: describeConflictingAppInstances(conflictingInstancePids),
+        // The staged update is untouched; this is the user's to clear and retry.
+        retryable: true,
+        ...(pendingVersion ? { version: pendingVersion } : {})
+      })
+      return
+    }
 
     markMacQuitAndInstallInFlight()
 

--- a/src/main/updater/updater-install-execution.ts
+++ b/src/main/updater/updater-install-execution.ts
@@ -65,7 +65,25 @@ export abstract class UpdaterInstallExecution extends UpdaterPackageRecovery {
     // every running instance of this bundle to exit and aborts if one appears
     // mid-install, so quitting into a doomed handoff strands the user on the
     // old version with no window and no explanation.
-    const conflictingInstancePids = await findConflictingAppInstancePids()
+    //
+    // Why this is caught even though the probe fails open internally and cannot
+    // currently throw: it runs OUTSIDE the span's catch below, and the claim
+    // above is held across its await. A rejection would both escape as an
+    // unhandled rejection and latch the claim, so every later install would
+    // return `quit_and_install_ignored` with no card and no recovery short of
+    // relaunching — the same silent wedge this guard exists to remove, reached
+    // from the other side. Proceeding is the probe's own contract: an
+    // unavailable scan must never block an install.
+    let conflictingInstancePids: number[] = []
+    try {
+      conflictingInstancePids = await findConflictingAppInstancePids()
+    } catch (error) {
+      recordUpdaterLifecycle(
+        'quit_and_install_conflict_scan_failed',
+        { errorType: error instanceof Error ? error.name : typeof error },
+        { level: 'warn', message: 'Could not check for other running app instances' }
+      )
+    }
     if (conflictingInstancePids.length > 0) {
       // Nothing else has been armed yet, so releasing the claim is the whole rollback.
       this.quitAndInstallInProgress = false

--- a/src/main/updater/updater-install-execution.ts
+++ b/src/main/updater/updater-install-execution.ts
@@ -79,8 +79,14 @@ export abstract class UpdaterInstallExecution extends UpdaterPackageRecovery {
       this.sendInstallFailureStatus({
         state: 'error',
         message: describeConflictingAppInstances(conflictingInstancePids),
-        // The staged update is untouched; this is the user's to clear and retry.
-        retryable: true,
+        // Why false when the update IS still installable: the card only promotes
+        // `message` to its summary line for a non-retryable error, and otherwise
+        // buries it behind "Show details" under a generic "Could not complete the
+        // update." — so `true` would hide the one sentence that tells the user
+        // which copies to quit. The action it costs us re-downloads a release
+        // that is already staged, which is not the retry this error needs;
+        // "Download Manually" still renders from `releaseUrl`.
+        retryable: false,
         ...(pendingVersion ? { version: pendingVersion } : {})
       })
       return

--- a/src/renderer/src/components/maintenance/update-card/update-card-error-model.test.ts
+++ b/src/renderer/src/components/maintenance/update-card/update-card-error-model.test.ts
@@ -68,6 +68,19 @@ describe('update card error model precedence', () => {
   })
 })
 
+/**
+ * The model is nullable, and these assertions read every field on it. A null
+ * here should fail as "no model was built" rather than as a confusing mismatch
+ * on a property that was never going to exist.
+ */
+function buildErrorModel(status: UpdateStatus): NonNullable<ReturnType<typeof build>> {
+  const model = build(status)
+  if (!model) {
+    throw new Error(`buildUpdateCardErrorModel returned null for state=${status.state}`)
+  }
+  return model
+}
+
 describe('install errors the user has to act on', () => {
   // Why this matters beyond formatting: `detail` is rendered only after the user
   // opens "Show details", in a muted monospace box captioned DETAILS — the
@@ -82,20 +95,20 @@ describe('install errors the user has to act on', () => {
   } as const
 
   it('promotes the message to the summary when the error is not retryable', () => {
-    const model = build(blockedInstall)
+    const model = buildErrorModel(blockedInstall)
 
     expect(model.summary).toBe(blockedInstall.message)
   })
 
   it('buries the same message behind Show details when it is retryable', () => {
-    const model = build({ ...blockedInstall, retryable: true })
+    const model = buildErrorModel({ ...blockedInstall, retryable: true })
 
     expect(model.summary).toBe('Could not complete the update.')
     expect(model.detail).toBe(blockedInstall.message)
   })
 
   it('still offers a manual download when there is no retry action', () => {
-    const model = build(blockedInstall)
+    const model = buildErrorModel(blockedInstall)
 
     expect(model.primaryAction).toBeUndefined()
     expect(model.releaseUrl).toBeTruthy()

--- a/src/renderer/src/components/maintenance/update-card/update-card-error-model.test.ts
+++ b/src/renderer/src/components/maintenance/update-card/update-card-error-model.test.ts
@@ -67,3 +67,37 @@ describe('update card error model precedence', () => {
     })
   })
 })
+
+describe('install errors the user has to act on', () => {
+  // Why this matters beyond formatting: `detail` is rendered only after the user
+  // opens "Show details", in a muted monospace box captioned DETAILS — the
+  // surface built for stack dumps. An error whose message IS the instruction
+  // (which copies of the app to quit before the macOS install can proceed) has
+  // to reach the summary line, and only a non-retryable error does.
+  const blockedInstall = {
+    state: 'error',
+    message: 'Another copy of Orca is running (PID 270).',
+    retryable: false,
+    version: '1.4.201'
+  } as const
+
+  it('promotes the message to the summary when the error is not retryable', () => {
+    const model = build(blockedInstall)
+
+    expect(model.summary).toBe(blockedInstall.message)
+  })
+
+  it('buries the same message behind Show details when it is retryable', () => {
+    const model = build({ ...blockedInstall, retryable: true })
+
+    expect(model.summary).toBe('Could not complete the update.')
+    expect(model.detail).toBe(blockedInstall.message)
+  })
+
+  it('still offers a manual download when there is no retry action', () => {
+    const model = build(blockedInstall)
+
+    expect(model.primaryAction).toBeUndefined()
+    expect(model.releaseUrl).toBeTruthy()
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​444 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​444 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 |

<!-- /orca-pr-loc -->

Supersedes the macOS instance-guard half of #9094.

## The defect

macOS only. Squirrel.Mac's ShipIt waits for every running instance of the bundle to exit, and Electron's fork aborts with "App Still Running Error" if one appears mid-install. Two symptoms:

- A second packaged Orca — a manually opened copy, or an agent/e2e rig launching `/Applications/Orca.app` with a temp profile, often windowless — makes "Restart to Update" quit the app and never relaunch, leaving the user on the old version with **no feedback at all**.
- A user who clicks the dock icon during the ~4–15s bundle swap becomes the aborting instance and silently discards their own update.

Nothing on `main` counts other instances: `updater-install-execution.ts` invokes native `quitAndInstall` with only a headless-serve deferral and a Linux package-type check ahead of it. The single-instance lock cannot help — its identity derives from `userData`, so a temp-profile instance never collides, and during the bundle swap the app has already exited so the lock is free.

## What this does

33 production lines. A macOS-only AppKit detector runs before the native install; if other copies of the same bundle are running, the handoff is refused with an actionable message naming them, plus a `quit_and_install_blocked_by_other_instances` lifecycle event so the rate is measurable in the wild. It **fails open** on any detector error — a broken probe must never block updates.

## Why bundle identity, not `ps` — this is the part to not "simplify"

The detector matches on `NSWorkspace.runningApplications` with a non-null `bundleIdentifier`, and that requirement is load-bearing.

Measured on a developer machine: **three processes shared `/Applications/Orca.app/Contents/MacOS/Orca`** — the app itself, plus two Orca CLI processes running under `ELECTRON_RUN_AS_NODE`. AppKit gives those no bundle identity, and Squirrel does not wait for them. The query returned only the real app; self-exclusion held; a nonexistent bundle returned empty.

**A `ps`-based detector would have counted all three and blocked updates outright on any machine running Orca CLI commands.** That is a self-inflicted denial of updates, and it is the approach #9094's description still recommends.

Because the behaviour lives inside the AppKit query, a test that injects a pid reader would bypass exactly what must not regress. So the protection is a source assertion — `identifies blockers by bundle identity, so Orca CLI processes are not counted` — with the mechanism and the measurement recorded in its comment. Ablating the detector to a `ps` scan turns that guard red while all 8 behavioural tests stay green, which is what proves the ratchet is the thing doing the catching.

## Evidence

Removing the guard fails "refuses the install…" and "names the copies to quit…", while the control "installs normally when this is the only running copy" passes — and that control asserts the native install **was** invoked, so the suite cannot pass vacuously.

All 28 updater suites plus the exit watchdog: 310 passed, 0 failed. Typecheck (node and web), oxfmt, oxlint, max-lines, ts-nocheck, reliability manifest and the changed-code gate all clean.

## Two regressions found and fixed during development

Recorded because the first was nearly shipped:

1. **Reentrancy hole.** Adding an `await` made the conflict scan the first async step, and `quitAndInstallInProgress` was set *after* it — so a duplicate install request arriving inside that window passed the in-progress check and ran a second handoff. Four existing duplicate-request tests caught it. Fixed by claiming the flag before the await and releasing it on refusal, with a regression test that goes red if the ordering is reverted.
2. **Unit tests were spawning real `osascript`.** Any updater test reaching the install path ran the detector against the live machine. Now stubbed in the four suites that reach it, keeping the real message builder so a copy change cannot make an assertion pass against text no user would see.

## Honest gaps

**`retryable: true` does not give install-retry semantics.** `update-card-error-model.ts:129` renders `retryable !== false`, so passing `true` is identical to omitting it, and the button it offers is **"Retry Download"** — which re-downloads a release that is already staged. The user does get the actionable text as the card's detail. A "Try Install Again" action is a renderer change and a separate follow-up; this PR should not be read as having delivered it.

**The last link is unproven.** Whether the instances this detector names are the same ones ShipIt actually blocks on cannot be established without a signed old-to-new reproduction on an isolated host. Being wrong there costs a spurious retryable message, not a broken app. The detector primitive itself was closed by measurement rather than reading, as described above.

**Cost:** ~250ms added to the macOS install path, on a user-initiated click.

## Deliberately not included: the launch gate

#9094 also gated app *launch* during an in-flight install. That half is held back, because its failure mode is a user whose app will not open with no feedback anywhere — and the PR head has none of the three safety properties main's single-instance lock earned the hard way (a bypass env, a diagnostic line on the deferral path, a distinct exit code), plus a structural hole: it returns `true` for the first 5s of the arming window with no process check at all, so a `quitAndInstall` that fails right after the marker write makes every launch in that window exit blind.

Its design and the reproduction it requires are written up for a follow-up. A pre-lock silent-exit path validated only by unit tests is not something to defend in review: the decision function is pure, so a green test there is evidence about a pure function, not about a real launch during a real ShipIt swap.
