### PR TITLE
fix(relay): emit pending-conn details to hosts that advertise the capability (cell side)

### DIFF
--- a/cloud/apps/relay/src/host-session-registry.test.ts
+++ b/cloud/apps/relay/src/host-session-registry.test.ts
@@ -3,6 +3,7 @@ import {
   ASSIGNMENT_LIMITS,
   CONTROL_CONTINUITY_LIMITS,
   RELAY_CLOSE_CODE,
+  RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS,
   RELAY_PROTOCOL_LIMITS
 } from '@orca-cloud/relay-contract'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1003,5 +1004,117 @@ describe('control lease recovery after the session is gone', () => {
       registry.drain(0)
       vi.advanceTimersByTime(0)
     }
+  })
+})
+
+describe('host hello ack pending connections', () => {
+  const DETAILS = new Set([RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS])
+  const LEGACY_ENTRY = { connId: 'conn-1', connTicket: 'T'.repeat(43) }
+  const DETAILED_ENTRY = { ...LEGACY_ENTRY, kind: 'invite', relayDeviceId: 'device-1' }
+
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  function newRegistry(): ReturnType<typeof createRegistry> {
+    return createRegistry(
+      vi
+        .fn<RelayAssignmentStore['activateControl']>()
+        .mockResolvedValue('control:production-gce-c3:1')
+    )
+  }
+
+  function addPendingConnection(session: HostSession): void {
+    session.pendingConns.set('conn-1', {
+      ...LEGACY_ENTRY,
+      reservation: {
+        userId: identity.sub,
+        relayHostId: identity.relayHostId,
+        credentialKind: 'invite',
+        relayDeviceId: 'device-1'
+      },
+      client: new FakeSocket() as unknown as WebSocket,
+      attachTimer: setTimeout(() => {}, 60_000),
+      credentialActivityId: null
+    } as unknown as Parameters<typeof session.pendingConns.set>[1])
+  }
+
+  function sentAck(socket: FakeSocket): Record<string, unknown> {
+    const acks = socket.send.mock.calls
+      .map((call) => JSON.parse(String(call[0])) as Record<string, unknown>)
+      .filter((message) => message.type === 'host-hello-ack')
+    return acks.at(-1)!
+  }
+
+  function sessionOf(registry: HostSessionRegistry): HostSession {
+    return registry.get({ userId: identity.sub, relayHostId: identity.relayHostId })!
+  }
+
+  async function ackFor(capabilities?: ReadonlySet<string>): Promise<Record<string, unknown>> {
+    const { registry, activate } = newRegistry()
+    const socket = new FakeSocket()
+    registry.acceptControl(
+      socket as unknown as WebSocket,
+      identity,
+      undefined,
+      capabilities ?? new Set()
+    )
+    await activate(socket as unknown as WebSocket, identity, null, 1, false, 1)
+    const session = sessionOf(registry)
+    addPendingConnection(session)
+    socket.send.mockClear()
+    ;(registry as unknown as { sendHelloAck(session: HostSession): void }).sendHelloAck(session)
+    return sentAck(socket)
+  }
+
+  async function ackAfterRebind(
+    first: ReadonlySet<string>,
+    successor: ReadonlySet<string>
+  ): Promise<{ opening: Record<string, unknown>; rebound: Record<string, unknown> }> {
+    const { registry, activate } = newRegistry()
+    const opening = new FakeSocket()
+    registry.acceptControl(opening as unknown as WebSocket, identity, undefined, first)
+    await activate(opening as unknown as WebSocket, identity, null, 1, false, 1)
+    const session = sessionOf(registry)
+    addPendingConnection(session)
+    opening.send.mockClear()
+    ;(registry as unknown as { sendHelloAck(session: HostSession): void }).sendHelloAck(session)
+
+    const rebound = new FakeSocket()
+    registry.acceptControl(rebound as unknown as WebSocket, identity, undefined, successor)
+    await activate(rebound as unknown as WebSocket, identity, session, 1, true, 1)
+    return { opening: sentAck(opening), rebound: sentAck(rebound) }
+  }
+
+  it('states the pending kind and device to a host that advertised it can read them', async () => {
+    const ack = await ackFor(DETAILS)
+
+    expect(ack.pendingConns).toEqual([DETAILED_ENTRY])
+  })
+
+  it('restates only the identifiers to a host that never advertised the capability', async () => {
+    // A shipped host parses these entries strictly, so an unannounced key fails
+    // the whole ack parse and kills a control that was working.
+    const ack = await ackFor()
+
+    expect(ack.pendingConns).toEqual([LEGACY_ENTRY])
+  })
+
+  it('downgrades the restated entry when the successor control drops the capability', async () => {
+    // The capability belongs to the socket, not the session: a rebind can land a
+    // control whose decoder is older than the one that opened the session.
+    const { opening, rebound } = await ackAfterRebind(DETAILS, new Set())
+
+    expect(opening.pendingConns).toEqual([DETAILED_ENTRY])
+    expect(rebound.pendingConns).toEqual([LEGACY_ENTRY])
+  })
+
+  it('upgrades the restated entry when the successor control adds the capability', async () => {
+    const { opening, rebound } = await ackAfterRebind(new Set(), DETAILS)
+
+    expect(opening.pendingConns).toEqual([LEGACY_ENTRY])
+    expect(rebound.pendingConns).toEqual([DETAILED_ENTRY])
   })
 })

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -14,6 +14,7 @@ import {
   HostChallengeAckSchema,
   HostHelloSchema,
   InviteCreateSchema,
+  RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS,
   RELAY_PROTOCOL_LIMITS,
   RELAY_CLOSE_CODE,
   type RelayHostCloseReason,
@@ -178,6 +179,7 @@ export class HostSessionRegistry {
   // but a signed-out desktop never comes back, so the phone that asks minutes
   // later would otherwise find nothing to explain its rejection with.
   private readonly hostCloseReasons = new HostCloseReasonMemory(() => this.now())
+  private readonly hostCapabilities = new WeakMap<WebSocket, ReadonlySet<string>>()
   private draining = false
 
   constructor(
@@ -552,8 +554,12 @@ export class HostSessionRegistry {
   acceptControl(
     socket: WebSocket,
     identity: RelayTokenClaims,
-    connectionInclusionWatermark?: number
+    connectionInclusionWatermark?: number,
+    hostCapabilities?: ReadonlySet<string>
   ): void {
+    // Keyed by socket, not session: a rebind swaps the session's socket, and the
+    // successor's own advertisement is the only one that describes its decoder.
+    if (hostCapabilities?.size) this.hostCapabilities.set(socket, hostCapabilities)
     if (this.draining) {
       socket.close(RELAY_CLOSE_CODE.DRAINING, 'relay draining')
       return
@@ -1177,6 +1183,12 @@ export class HostSessionRegistry {
 
   private sendHelloAck(session: HostSession): void {
     if (!session.socket) return
+    // Without these a host that missed the conn-open cannot dial the pending
+    // connection: it would have to guess the pairing kind and the device the
+    // relay authorized. Only sent to a host that said it can read them.
+    const details = this.hostCapabilities
+      .get(session.socket)
+      ?.has(RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS)
     send(session.socket, 'host-hello-ack', {
       v: 1,
       generation: session.generation,
@@ -1185,7 +1197,13 @@ export class HostSessionRegistry {
       activeConnIds: [...session.activeConnIds],
       pendingConns: [...session.pendingConns.values()].map((pending) => ({
         connId: pending.connId,
-        connTicket: pending.connTicket
+        connTicket: pending.connTicket,
+        ...(details
+          ? {
+              kind: pending.reservation.credentialKind,
+              relayDeviceId: pending.reservation.relayDeviceId
+            }
+          : {})
       }))
     })
   }

--- a/cloud/apps/relay/src/relay-server.ts
+++ b/cloud/apps/relay/src/relay-server.ts
@@ -2,7 +2,9 @@ import { createAdaptorServer } from '@hono/node-server'
 import {
   hasAdmissionCapacity,
   HostDataAuthSchema,
+  parseRelayHostCapabilities,
   RELAY_ADMISSION_BUDGETS,
+  RELAY_HOST_CAPABILITIES_HEADER,
   RELAY_CLOSE_CODE,
   RELAY_DEFAULT_REGION,
   RELAY_PROTOCOL_LIMITS,
@@ -486,7 +488,8 @@ export function createRelayServer(
           sessions.acceptControl(
             webSocket,
             identity,
-            controlUpgrade?.inclusionWatermark
+            controlUpgrade?.inclusionWatermark,
+            parseRelayHostCapabilities(request.headers[RELAY_HOST_CAPABILITIES_HEADER])
           )
         })
       } catch {

--- a/cloud/packages/relay-contract/src/contract.test.ts
+++ b/cloud/packages/relay-contract/src/contract.test.ts
@@ -6,7 +6,10 @@ import {
   HostChallengeSchema,
   HostDataAuthSchema,
   HostHelloAckSchema,
-  HostHelloSchema
+  HostHelloSchema,
+  parseRelayHostCapabilities,
+  RELAY_HOST_CAPABILITIES_HEADER,
+  RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS
 } from './control-messages.js'
 import {
   DeviceCredentialInstallSchema,
@@ -343,5 +346,49 @@ describe('relay protocol contract', () => {
         acceptedCredentialVersion: 99
       }).success
     ).toBe(false)
+  })
+})
+
+describe('pending connection details capability', () => {
+  it('reads a pending entry with or without the stated kind and device', () => {
+    const ack = {
+      v: 1 as const,
+      generation: 3,
+      controlResumeSecret: 'R'.repeat(43),
+      leaseExpiresAt: 1_800_000_000_000,
+      activeConnIds: []
+    }
+    const identifiers = { connId: 'conn-1', connTicket: 'T'.repeat(43) }
+    expect(HostHelloAckSchema.safeParse({ ...ack, pendingConns: [identifiers] }).success).toBe(true)
+    expect(
+      HostHelloAckSchema.safeParse({
+        ...ack,
+        pendingConns: [{ ...identifiers, kind: 'resume', relayDeviceId: 'device-1' }]
+      }).success
+    ).toBe(true)
+    // Still strict otherwise: an unannounced key must not slip through as data.
+    expect(
+      HostHelloAckSchema.safeParse({
+        ...ack,
+        pendingConns: [{ ...identifiers, reservationId: 'injected' }]
+      }).success
+    ).toBe(false)
+  })
+
+  it('pins the header and token the desktop mirrors by hand', () => {
+    // The desktop cannot import this package; drift silently disables the
+    // feature, so both literals are asserted on each side.
+    expect(RELAY_HOST_CAPABILITIES_HEADER).toBe('x-orca-host-capabilities')
+    expect(RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS).toBe('pending-conn-details')
+  })
+
+  it('reads the advertised capabilities from a control upgrade header', () => {
+    expect(
+      parseRelayHostCapabilities(` ${RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS} , future-thing`)
+    ).toEqual(new Set([RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS, 'future-thing']))
+    // A host that predates the header sends nothing; absence is never capable.
+    expect(parseRelayHostCapabilities(undefined).size).toBe(0)
+    expect(parseRelayHostCapabilities('').size).toBe(0)
+    expect(parseRelayHostCapabilities('x'.repeat(65)).size).toBe(0)
   })
 })

--- a/cloud/packages/relay-contract/src/control-messages.ts
+++ b/cloud/packages/relay-contract/src/control-messages.ts
@@ -44,8 +44,35 @@ export const HostChallengeAckSchema = z
   .object({ challengeId: OpaqueIdSchema, proofB64: Base6432ByteSchema })
   .strict()
 
+// Advertised on the control upgrade rather than in host-hello: HostHelloSchema
+// is strict, so a new hello key is refused by every already-deployed cell.
+export const RELAY_HOST_CAPABILITIES_HEADER = 'x-orca-host-capabilities'
+// The host accepts kind/relayDeviceId on a pendingConns entry. A host that does
+// not advertise this parses those entries strictly and would drop the whole ack.
+export const RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS = 'pending-conn-details'
+
+export function parseRelayHostCapabilities(
+  header: string | string[] | undefined
+): ReadonlySet<string> {
+  const raw = Array.isArray(header) ? header.join(',') : (header ?? '')
+  return new Set(
+    raw
+      .split(',')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0 && token.length <= 64)
+      .slice(0, 16)
+  )
+}
+
+// kind/relayDeviceId are optional so an entry stays readable by a host that
+// predates them; the cell only emits them to a host that advertised support.
 const PendingConnectionSchema = z
-  .object({ connId: OpaqueIdSchema, connTicket: Base64Url32ByteSchema })
+  .object({
+    connId: OpaqueIdSchema,
+    connTicket: Base64Url32ByteSchema,
+    kind: ConnectionKindSchema.optional(),
+    relayDeviceId: OpaqueIdSchema.optional()
+  })
   .strict()
 
 export const HostHelloAckSchema = z


### PR DESCRIPTION
## ELI5

A phone connecting through the relay is announced to your desktop exactly once. If your desktop's control connection happens to rotate at that moment, the announcement is lost and the phone sits there until it gives up. The relay already re-lists those waiting connections when the desktop reconnects, but it only says "connection 5, here's a ticket", which is not enough to actually pick it up. This teaches the relay to also say what kind of connection it is and which device it belongs to, but only to a desktop that first said it can understand those extra words.

## What Changed

- `relay-contract`: added `RELAY_HOST_CAPABILITIES_HEADER` (`x-orca-host-capabilities`) and the `pending-conn-details` token, plus `parseRelayHostCapabilities` to read the header off a control upgrade. `PendingConnectionSchema` gains optional `kind` and `relayDeviceId` and stays `.strict()` otherwise.
- `relay-server`: parses the upgrade header and passes the capability set to `acceptControl`.
- `host-session-registry`: remembers the capability set in a `WeakMap` keyed by the control socket, and includes `kind`/`relayDeviceId` on each `pendingConns` entry of `host-hello-ack` only when that socket advertised the capability.

Keyed by socket, not by session, on purpose: a rebind can land a successor control whose decoder is older or newer than the one that opened the session, so the ack must follow the socket that will actually read it.

**Split note:** this is the cell half of #19238. The owner asked for the cloud change to land now and the desktop change to be reviewed separately. Deploy order is cell first anyway, so this PR is correct and mergeable on its own with no capable desktop in the fleet.

## Why

The cell announces a connection with a single `conn-open`. When the desktop's control socket dies mid-accept, the phone waits out the 10s attach deadline and is closed `HOST_OFFLINE` even though the desktop is online. Desktop lease rotations happen fleet-wide in roughly 54-minute waves, so this recurs.

`host-hello-ack` already restates the mid-accept connections in `pendingConns`, but only by `connId` and `connTicket`. That is not enough for a desktop to dial. `kind` decides the pairing authority a connection carries and `relayDeviceId` is the E2EE device binding, so neither may be guessed.

Why a capability rather than just adding the fields: a shipped host parses `pendingConns` entries strictly, so an unannounced key fails the whole ack parse and kills a control that was working. Why an upgrade header rather than `host-hello`: `HostHelloSchema` is strict on the cell too, so any new hello key is refused by every already-deployed cell.

## Linked Issue

N/A. Found while investigating relay connection latency, not filed as an issue.

## Visual Proof

`N/A` — server-side wire behavior with no user-visible surface in this PR.

## Testing

Ran in `cloud/`:

- `apps/relay`: `npx vitest run src/host-session-registry.test.ts src/host-session-client-accept.test.ts` — 2 files, 40 passed.
- `packages/relay-contract`: `npx vitest run` — 2 files, 23 passed.
- `pnpm typecheck` clean in both packages.
- CI `test`, `build`, `terraform`, `Secret scan` all pass on this branch.

Backwards compatibility is the load-bearing claim and is tested directly. With no host advertising the capability the emitted entry is byte-identical to today's, because the optional keys are spread from an empty object, so key order and content are unchanged:

```
legacy: {"connId":"c","connTicket":"t"}
now   : {"connId":"c","connTicket":"t"}
```

Four registry tests pin it: detailed shape to a capable socket, legacy shape to a socket that never advertised, and both directions of a rebind that changes the successor's advertisement. Latching the capability per session instead of per socket fails the last two.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor.

## Review

Reviewed by Pullfrog on the combined branch: no new issues. Its one informational note, that the desktop's hand-mirrored attach-deadline constant was not cross-pinned, is addressed on the desktop half; the cloud side already pins `hostAttachDeadlineMs: 10_000` in `contract.test.ts`. CodeRabbit: no actionable comments, merge risk minimal.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security**: the capability header only widens what the cell tells a host about that host's own pending connections. Tokens are trimmed, capped at 64 chars and 16 entries, so a hostile header cannot grow the set without bound.
- **Backwards compatibility**: covered above. All three version mixes are safe. Old desktop plus new cell gets the legacy ack. New desktop plus old cell gets the legacy ack and falls back to the `conn-open` it observed. New plus new replays from the ack.
- **Cross-platform / SSH / mobile**: cell-side only, no platform-dependent code.
- **Performance**: one `WeakMap` write per control accept, decays with the socket.
- **Not proven from the repo**: that the production external load balancer forwards the `x-orca-host-capabilities` upgrade header. A stripped header degrades to the legacy path, so this PR is still safe, but it is worth one live probe against staging at deploy time before the desktop half ships.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)