### PR TITLE
fix(relay): bound control RTT samples per ping and per flush window

### DIFF
--- a/cloud/apps/relay/src/host-session-client-accept.test.ts
+++ b/cloud/apps/relay/src/host-session-client-accept.test.ts
@@ -413,6 +413,17 @@ describe('successful client accept timing', () => {
   })
 })
 
+// Fires one heartbeat and returns the `t` of the ping it sent, which is the only
+// echo the registry will time.
+async function advanceToPing(control: FakeSocket, clock: { now: number }): Promise<number> {
+  clock.now += RELAY_PROTOCOL_LIMITS.controlPingIntervalMs
+  await vi.advanceTimersByTimeAsync(RELAY_PROTOCOL_LIMITS.controlPingIntervalMs)
+  const ping = control.send.mock.calls
+    .filter((call) => String(call[0]).includes('"type":"ping"'))
+    .at(-1)!
+  return (JSON.parse(String(ping[0])) as { t: number }).t
+}
+
 describe('control round-trip sampling', () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => {
@@ -421,8 +432,8 @@ describe('control round-trip sampling', () => {
   })
 
   it('logs a host once at the fourth sample and not again within the hour', async () => {
-    let now = 1_700_000_000_000
-    const h = harness({ now: () => now })
+    const clock = { now: 1_700_000_000_000 }
+    const h = harness({ now: () => clock.now })
     const control = await activeHost(h)
     const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
     const rttLines = (): string[] =>
@@ -431,17 +442,9 @@ describe('control round-trip sampling', () => {
         .filter((entry) => entry.includes('orca_relay_host_control_rtt'))
     // One heartbeat, then the desktop's echo of that ping's own `t` 40 ms later.
     const roundTrip = async (): Promise<void> => {
-      now += RELAY_PROTOCOL_LIMITS.controlPingIntervalMs
-      await vi.advanceTimersByTimeAsync(RELAY_PROTOCOL_LIMITS.controlPingIntervalMs)
-      const ping = JSON.parse(
-        String(
-          control.send.mock.calls
-            .filter((call) => String(call[0]).includes('"type":"ping"'))
-            .at(-1)![0]
-        )
-      ) as { t: number }
-      now += 40
-      control.emit('message', JSON.stringify({ type: 'pong', t: ping.t }), false)
+      const pingAt = await advanceToPing(control, clock)
+      clock.now += 40
+      control.emit('message', JSON.stringify({ type: 'pong', t: pingAt }), false)
     }
     try {
       for (let round = 0; round < 3; round++) await roundTrip()
@@ -466,8 +469,8 @@ describe('control round-trip sampling', () => {
       expect(h.observer.recordControlRtt).toHaveBeenCalledTimes(12)
       expect(rttLines()).toHaveLength(1)
 
-      const elapsedStart = now
-      while (now - elapsedStart < 60 * 60 * 1000) await roundTrip()
+      const elapsedStart = clock.now
+      while (clock.now - elapsedStart < 60 * 60 * 1000) await roundTrip()
       expect(rttLines()).toHaveLength(2)
     } finally {
       log.mockRestore()
@@ -476,21 +479,54 @@ describe('control round-trip sampling', () => {
     }
   })
 
-  it('ignores a pong whose echoed timestamp is missing or implausible', async () => {
-    let now = 1_700_000_000_000
-    const h = harness({ now: () => now })
+  it('ignores a pong that answers no outstanding ping', async () => {
+    const clock = { now: 1_700_000_000_000 }
+    const h = harness({ now: () => clock.now })
     const control = await activeHost(h)
     try {
+      // Nothing has been pinged yet, so even a plausible echo is not a round trip.
       control.emit('message', JSON.stringify({ type: 'pong' }), false)
       control.emit('message', JSON.stringify({ type: 'pong', t: 'later' }), false)
-      control.emit('message', JSON.stringify({ type: 'pong', t: now + 5_000 }), false)
-      control.emit('message', JSON.stringify({ type: 'pong', t: now - 600_000 }), false)
+      control.emit('message', JSON.stringify({ type: 'pong', t: clock.now }), false)
+      control.emit('message', JSON.stringify({ type: 'pong', t: clock.now - 10 }), false)
       expect(h.observer.recordControlRtt).not.toHaveBeenCalled()
-      // The silence watchdog still sees every one of them as proof of life.
-      now += 10
-      control.emit('message', JSON.stringify({ type: 'pong', t: now - 10 }), false)
+
+      const pingAt = await advanceToPing(control, clock)
+      // A guessed timestamp is not the outstanding ping's `t`, so it is dropped.
+      control.emit('message', JSON.stringify({ type: 'pong', t: pingAt - 1 }), false)
+      control.emit('message', JSON.stringify({ type: 'pong', t: pingAt + 1 }), false)
+      expect(h.observer.recordControlRtt).not.toHaveBeenCalled()
+
+      clock.now += 10
+      control.emit('message', JSON.stringify({ type: 'pong', t: pingAt }), false)
       expect(h.observer.recordControlRtt).toHaveBeenCalledWith(10)
     } finally {
+      h.registry.drain(0)
+      vi.advanceTimersByTime(0)
+    }
+  })
+
+  it('records one sample per ping however many pongs a host floods', async () => {
+    const clock = { now: 1_700_000_000_000 }
+    const h = harness({ now: () => clock.now })
+    const control = await activeHost(h)
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    try {
+      const pingAt = await advanceToPing(control, clock)
+      clock.now += 12
+      for (let flood = 0; flood < 5_000; flood++) {
+        control.emit('message', JSON.stringify({ type: 'pong', t: pingAt }), false)
+        control.emit('message', JSON.stringify({ type: 'pong', t: clock.now }), false)
+      }
+      // One answered ping is one process-wide sample and one per-session sample, so
+      // neither the metric window nor the hourly log line can be flooded.
+      expect(h.observer.recordControlRtt).toHaveBeenCalledTimes(1)
+      expect(h.observer.recordControlRtt).toHaveBeenCalledWith(12)
+      expect(
+        log.mock.calls.filter((call) => String(call[0]).includes('orca_relay_host_control_rtt'))
+      ).toHaveLength(0)
+    } finally {
+      log.mockRestore()
       h.registry.drain(0)
       vi.advanceTimersByTime(0)
     }

--- a/cloud/apps/relay/src/host-session-registry.ts
+++ b/cloud/apps/relay/src/host-session-registry.ts
@@ -89,6 +89,8 @@ export type HostSession = {
   orphanTimer: ReturnType<typeof setTimeout> | null
   heartbeatTimer: ReturnType<typeof setInterval> | null
   lastPongAt: number
+  // The `t` of the ping still waiting for its echo; null once one has answered it.
+  pendingPingAt: number | null
   controlRttSamplesMs: number[]
   controlRttLoggedAt: number | null
   activityRenewalDueAt: number
@@ -519,10 +521,13 @@ export class HostSessionRegistry {
     }
   }
 
-  // Every desktop build already echoes the ping's `t`; anything else is dropped
-  // rather than trusted, so no new wire field is required.
+  // Every desktop build already echoes the ping's `t`, so a pong is only timed when
+  // it answers the outstanding ping: at most one sample per ping this cell sent,
+  // however many a host floods. A pong that lost the race to the next ping is
+  // dropped here but still counts as proof of life for the silence watchdog.
   private recordControlRtt(session: HostSession, echoedPingAt: unknown): void {
-    if (typeof echoedPingAt !== 'number' || !Number.isFinite(echoedPingAt)) return
+    if (typeof echoedPingAt !== 'number' || echoedPingAt !== session.pendingPingAt) return
+    session.pendingPingAt = null
     const now = this.now()
     const rttMs = now - echoedPingAt
     if (rttMs < 0 || rttMs > CONTROL_RTT_MAX_PLAUSIBLE_MS) return
@@ -912,6 +917,7 @@ export class HostSessionRegistry {
       existing.appVersion = appVersion
       existing.leaseExpiresAt = this.controlLeaseExpiresAt()
       existing.lastPongAt = this.now()
+      existing.pendingPingAt = null
       existing.activityRenewalDueAt =
         this.now() + RELAY_PROTOCOL_LIMITS.controlPingIntervalMs
       this.wireActiveControl(existing)
@@ -965,6 +971,7 @@ export class HostSessionRegistry {
       orphanTimer: null,
       heartbeatTimer: null,
       lastPongAt: this.now(),
+      pendingPingAt: null,
       controlRttSamplesMs: [],
       controlRttLoggedAt: null,
       activityRenewalDueAt: this.now() + RELAY_PROTOCOL_LIMITS.controlPingIntervalMs,
@@ -1172,6 +1179,7 @@ export class HostSessionRegistry {
       session.socket.close(RELAY_CLOSE_CODE.DRAINING, 'control lease expired')
       return
     }
+    session.pendingPingAt = now
     send(session.socket, 'ping', { t: now })
   }
 

--- a/cloud/apps/relay/src/relay-observability.test.ts
+++ b/cloud/apps/relay/src/relay-observability.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { RelayDatabase } from './database.js'
 import { observeRelayDatabase } from './observed-relay-database.js'
 import {
+  CONTROL_RTT_RESERVOIR_LIMIT,
   observedRelayRequests,
   RelayObservability,
   type RelayProcessCounts
@@ -22,10 +23,35 @@ const counts: RelayProcessCounts = {
   databasePoolWaitMsMax: 1_250
 }
 
-// An accept stage is named `credential`, so the leak guard has to see past the
-// bucket name to the values it exists to police.
-function scrubStageNames(entries: Array<Record<string, unknown>>): string {
-  return JSON.stringify(entries).replaceAll('"credential":', '"stage":')
+// Two schema keys legitimately spell a policed word: the abandoned-accept bucket
+// is keyed by stage name and one stage is `credential`. Rename those exact keys in
+// a clone instead of rewriting the JSON, so a stray raw field or value anywhere
+// else still trips the guard below.
+const SCHEMA_KEY_ALIASES: Record<string, string> = {
+  clientAcceptCredentialMsP95: 'clientAcceptStageTwoMsP95'
+}
+
+function scrubSchemaKeys(entries: Array<Record<string, unknown>>): string {
+  return JSON.stringify(
+    entries.map((entry) =>
+      Object.fromEntries(
+        Object.entries(entry).map(([key, value]) => [
+          SCHEMA_KEY_ALIASES[key] ?? key,
+          key === 'clientAcceptsAbandonedByStageDelta' ? renameStageKeys(value) : value
+        ])
+      )
+    )
+  )
+}
+
+function renameStageKeys(bucket: unknown): unknown {
+  if (bucket === null || typeof bucket !== 'object') return bucket
+  return Object.fromEntries(
+    Object.entries(bucket).map(([stage, count]) => [
+      stage === 'credential' ? 'stageTwo' : stage,
+      count
+    ])
+  )
 }
 
 describe('relay observability', () => {
@@ -187,7 +213,7 @@ describe('relay observability', () => {
       controlActivityRecoveryFailuresDelta: 0,
       httpLatencyMsMax: 0
     })
-    expect(scrubStageNames(entries)).not.toMatch(/token|credential|userId|relayHostId/)
+    expect(scrubSchemaKeys(entries)).not.toMatch(/token|credential|userId|relayHostId/i)
   })
 
   it('aggregates control and splice closes as bounded per-reason deltas', () => {
@@ -282,7 +308,36 @@ describe('relay observability', () => {
       expect(entries[1]).not.toHaveProperty(omitted)
       expect(entries[0]).toHaveProperty(omitted)
     }
-    expect(scrubStageNames(entries)).not.toMatch(/token|credential|userId|relayHostId/)
+    expect(scrubSchemaKeys(entries)).not.toMatch(/token|credential|userId|relayHostId/i)
+  })
+
+  it('caps the control round-trip reservoir and reports what it dropped', () => {
+    const entries: Array<Record<string, unknown>> = []
+    const observability = new RelayObservability(
+      { role: 'cell', cellId: 'production-gce-c28', region: 'asia-east2' },
+      (entry) => entries.push(entry)
+    )
+    const flooded = CONTROL_RTT_RESERVOIR_LIMIT * 20
+    for (let sample = 0; sample < flooded; sample++) {
+      observability.recordControlRtt(10 + (sample % 40))
+    }
+    observability.flush(counts)
+
+    // Dropped is observed minus retained, so this pins the retained window at the cap.
+    expect(entries[0]).toMatchObject({
+      controlRttSamplesDelta: flooded,
+      controlRttSamplesDroppedDelta: flooded - CONTROL_RTT_RESERVOIR_LIMIT
+    })
+    // The kept samples are real observations, not a truncated or synthesised window.
+    expect(entries[0]!.controlRttMsP50 as number).toBeGreaterThanOrEqual(10)
+    expect(entries[0]!.controlRttMsMax as number).toBeLessThanOrEqual(49)
+
+    observability.flush(counts)
+    expect(entries[1]).toMatchObject({
+      controlRttSamplesDelta: 0,
+      controlRttSamplesDroppedDelta: 0
+    })
+    expect(entries[1]).not.toHaveProperty('controlRttMsP50')
   })
 
   it('observes successful and failed database calls including transactions', async () => {

--- a/cloud/apps/relay/src/relay-observability.test.ts
+++ b/cloud/apps/relay/src/relay-observability.test.ts
@@ -340,6 +340,24 @@ describe('relay observability', () => {
     expect(entries[1]).not.toHaveProperty('controlRttMsP50')
   })
 
+  it('samples the whole flooded window rather than its first samples', () => {
+    const entries: Array<Record<string, unknown>> = []
+    const observability = new RelayObservability(
+      { role: 'cell', cellId: 'production-gce-c28', region: 'asia-east2' },
+      (entry) => entries.push(entry)
+    )
+    const half = CONTROL_RTT_RESERVOIR_LIMIT * 10
+    for (let sample = 0; sample < half; sample++) observability.recordControlRtt(10)
+    for (let sample = 0; sample < half; sample++) observability.recordControlRtt(900)
+    observability.flush(counts)
+
+    // Keeping the first N instead would publish a window of nothing but 10s. Each
+    // reservoir slot ends up drawn from the late half with ~1/2 probability, so
+    // fewer than the 5% the p95 needs is out of reach of this suite.
+    expect(entries[0]!.controlRttMsP95).toBe(900)
+    expect(entries[0]!.controlRttMsMax).toBe(900)
+  })
+
   it('observes successful and failed database calls including transactions', async () => {
     const recordSql = vi.fn()
     const underlying: RelayDatabase = {

--- a/cloud/apps/relay/src/relay-observability.ts
+++ b/cloud/apps/relay/src/relay-observability.ts
@@ -116,11 +116,16 @@ type RelayMetricDeltas = {
   clientAcceptTotalsMs: number[]
   clientAcceptStageSamplesMs: Record<RelayClientAcceptTimedStage, number[]>
   controlRttSamplesMs: number[]
+  controlRttObserved: number
   controlRenewalLatenciesMs: number[]
   controlRenewalsByOutcome: Record<string, number>
   controlActivityRecoveries: number
   controlActivityRecoveryFailures: number
 }
+
+// A host chooses how often it answers a ping, so the process-wide window is a
+// reservoir: the heap cost of a flood is capped and the percentiles stay unbiased.
+export const CONTROL_RTT_RESERVOIR_LIMIT = 1024
 
 type MetricWriter = (entry: Record<string, unknown>) => void
 
@@ -156,6 +161,7 @@ const emptyDeltas = (): RelayMetricDeltas => ({
     basis: []
   },
   controlRttSamplesMs: [],
+  controlRttObserved: 0,
   controlRenewalLatenciesMs: [],
   controlRenewalsByOutcome: {},
   controlActivityRecoveries: 0,
@@ -298,7 +304,15 @@ export class RelayObservability implements RelayRuntimeObserver {
   }
 
   recordControlRtt(rttMs: number): void {
-    this.deltas.controlRttSamplesMs.push(rttMs)
+    const samples = this.deltas.controlRttSamplesMs
+    const observedBefore = this.deltas.controlRttObserved++
+    if (samples.length < CONTROL_RTT_RESERVOIR_LIMIT) {
+      samples.push(rttMs)
+      return
+    }
+    // Algorithm R: every round trip in the window keeps an equal chance of being kept.
+    const slot = Math.floor(Math.random() * (observedBefore + 1))
+    if (slot < CONTROL_RTT_RESERVOIR_LIMIT) samples[slot] = rttMs
   }
 
   start(readCounts: () => RelayProcessCounts, intervalMs = 30_000): void {
@@ -384,7 +398,10 @@ export class RelayObservability implements RelayRuntimeObserver {
             clientAcceptAttachMsP95: acceptStageP95('attach'),
             clientAcceptBasisMsP95: acceptStageP95('basis')
           }),
-      controlRttSamplesDelta: deltas.controlRttSamplesMs.length,
+      // Every round trip observed in the window, including the ones the reservoir
+      // above declined to keep; the percentiles summarise only what it kept.
+      controlRttSamplesDelta: deltas.controlRttObserved,
+      controlRttSamplesDroppedDelta: deltas.controlRttObserved - deltas.controlRttSamplesMs.length,
       ...(deltas.controlRttSamplesMs.length === 0
         ? {}
         : {

--- a/cloud/infra/terraform/relay-observability.tf
+++ b/cloud/infra/terraform/relay-observability.tf
@@ -68,7 +68,8 @@ locals {
     control_rtt_ms_p50                 = { field = "controlRttMsP50", description = "Control-socket ping round trip p50 in the interval. The desktop echoes the pong on its main thread, so only the median reads as distance; the p95 and max below are dominated by desktop stalls." }
     control_rtt_ms_p95                 = { field = "controlRttMsP95", description = "Control-socket ping round trip p95 in the interval; a desktop-stall signal, not a distance one." }
     control_rtt_ms_max                 = { field = "controlRttMsMax", description = "Maximum control-socket ping round trip in the interval; a desktop-stall signal, not a distance one." }
-    control_rtt_samples                = { field = "controlRttSamplesDelta", description = "Control-socket round-trip samples in the interval; the percentiles above are omitted when this is zero." }
+    control_rtt_samples                = { field = "controlRttSamplesDelta", description = "Control-socket round trips observed in the interval, one per ping answered; the percentiles above are omitted when this is zero." }
+    control_rtt_samples_dropped        = { field = "controlRttSamplesDroppedDelta", description = "Observed round trips the bounded percentile reservoir did not keep; non-zero means the percentiles above summarise a uniform sample of the interval." }
     client_accepts_completed           = { field = "clientAcceptCompletedDelta", description = "Phone accepts that reached relay-hello in the interval; the percentiles below are omitted when this is zero." }
     client_accept_total_ms_p50         = { field = "clientAcceptTotalMsP50", description = "Successful phone-accept duration p50, dial to relay-hello." }
     client_accept_total_ms_p95         = { field = "clientAcceptTotalMsP95", description = "Successful phone-accept duration p95, dial to relay-hello." }


### PR DESCRIPTION
## ELI5

The relay times how long a desktop takes to answer its heartbeat. It used to time *any* reply, so a desktop could send a million replies and make the relay hold a million measurements in memory until the next 30-second metrics flush. Now the relay only times the reply that answers the heartbeat it actually sent, and it never keeps more than 1024 measurements per window.

## What Changed

Follow-up to #19232 (merged as ecfcc0d833), addressing two CodeRabbit findings on that PR.

- `cloud/apps/relay/src/host-session-registry.ts`: each session tracks `pendingPingAt`, the `t` of the ping still awaiting an echo. A pong is timed only when it echoes that exact value, and the slot is cleared on use, on rebind, and on a fresh session. One sample per ping the cell actually sent, whatever a host floods. A pong that lost the race to the next ping is dropped for timing but still updates `lastPongAt`, so control-silence liveness is unchanged.
- `cloud/apps/relay/src/relay-observability.ts`: the process-wide window is now a 1024-sample reservoir (Algorithm R), so a flood cannot grow the heap and the percentiles stay unbiased rather than truncated to the first N. `controlRttSamplesDelta` keeps its meaning, round trips observed in the interval, and the new `controlRttSamplesDroppedDelta` reports what the reservoir did not keep, so a non-zero value says the percentiles summarise a uniform sample.
- `cloud/infra/terraform/relay-observability.tf`: descriptor for the new field, plus a clarified description on `control_rtt_samples`.
- `cloud/apps/relay/src/relay-observability.test.ts`: the leak guard now clones the entries and renames only `clientAcceptsAbandonedByStageDelta.credential` and `clientAcceptCredentialMsP95`, both path- or key-exact, so a stray raw field or value elsewhere still trips it. The regex is case-insensitive now that nothing legitimate matches.

## Why

**1. A host could choose how many RTT samples a cell recorded (major).** `recordControlRtt` timed every `pong` whose echoed `t` was a finite number within 120s of now. Nothing required that pong to answer a ping the cell had sent, so an authenticated host could stream pongs with fresh timestamps and push one sample per frame into the process-wide `controlRttSamplesMs` array. That array was only reset by the 30s flush, which copies and sorts it twice for the p50/p95. Heap growth and flush CPU were both attacker-chosen. The per-session window was already capped at 8, but it was capped *after* the process-wide forward.

Requiring the echo to match the outstanding ping removes the attack surface at the source rather than clamping its symptom. The reservoir is the second line: it bounds any future caller of `recordControlRtt` too, and it keeps percentiles honest where a plain "drop beyond N" would bias every busy window toward its first samples.

**2. The leak guard could mask a real leak (minor).** `scrubStageNames` ran `JSON.stringify(entries).replaceAll('"credential":', '"stage":')` over the whole serialized event to exempt the `credential` accept stage. Any accidental raw `"credential"` field anywhere in a future event would have been scrubbed the same way.

## Linked Issue

No issue; this is direct follow-up review feedback on #19232.

## Visual Proof

`N/A` — relay server-side sampling and log-based metric fields only, no UI surface.

## Testing

Four new tests, each confirmed to fail against the pre-fix source and pass after:

- a host flooding 10,000 pongs against one outstanding ping yields exactly one sample and no per-session log line (was 10,000);
- a pong that answers no outstanding ping, or guesses a nearby timestamp, is not timed;
- flooding 20,480 samples publishes `controlRttSamplesDelta: 20480` with `controlRttSamplesDroppedDelta: 19456`, which pins the retained window at the 1024 cap;
- flooding 10,240 fast samples then 10,240 slow ones publishes the slow value at p95, so the reservoir provably samples the whole window. A truncating implementation fails this test.

```
cd cloud/apps/relay && npx vitest run                    # 54 files, 530 passed, 95 skipped
cd cloud && pnpm --filter @orca-cloud/relay typecheck    # clean
terraform fmt -check cloud/infra/terraform/relay-observability.tf   # clean
```

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Relay-only change. No wire-format change: the ping and pong frames are byte-identical to before, so an old desktop paired with a new cell behaves exactly as it does today, and a new cell paired with any desktop build that echoes `t` keeps producing samples. Hosts that never echo `t` produced no samples before this change either.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: this is the fix. An authenticated host can no longer drive relay heap or flush CPU through pong volume.
- **Cross-platform / SSH / mobile**: relay-side only, no client change, no path or shell handling.
- **Backwards compatibility**: `controlRttSamplesDelta` keeps its published meaning; `controlRttSamplesDroppedDelta` is additive and defaults to 0.
- **Performance**: the flush now sorts at most 1024 samples for the RTT percentiles instead of an unbounded array.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)