### PR TITLE
fix(mobile): close four relay probe and tab-strip cache gaps

### DIFF
--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -279,4 +279,64 @@ describe('session tab strip cache', () => {
 
     expect(lastWrittenFile().workspaces).toEqual([])
   })
+  it('rejects a deletion whose write never landed, rather than reporting it as done', async () => {
+    // A resolved delete over a failed write leaves the forgotten host's tab titles in
+    // plaintext on disk while every caller believes they are gone.
+    const hostA = getSessionTabStripCacheKey('host-a', 'wt-1')
+    saveCachedSessionTabStrip(hostA, preview('tab-a'))
+    await vi.advanceTimersByTimeAsync(300)
+    asyncStorage.setItem.mockRejectedValue(new Error('storage full'))
+
+    await expect(deleteCachedSessionTabStripForHost('host-a')).rejects.toThrow('storage full')
+  })
+
+  it('keeps a debounced save best effort, so one failed write cannot reject unowned', async () => {
+    asyncStorage.setItem.mockRejectedValue(new Error('storage full'))
+    saveCachedSessionTabStrip(getSessionTabStripCacheKey('host-a', 'wt-1'), preview('tab-a'))
+
+    // No throw and no unhandled rejection: the write is fire-and-forget by design.
+    await vi.advanceTimersByTimeAsync(300)
+    expect(asyncStorage.setItem).toHaveBeenCalledOnce()
+  })
+
+  it('refuses a save for the host it is in the middle of forgetting', async () => {
+    const hostA = getSessionTabStripCacheKey('host-a', 'wt-1')
+    saveCachedSessionTabStrip(hostA, preview('tab-a'))
+    await vi.advanceTimersByTimeAsync(300)
+
+    let releaseWrite!: () => void
+    asyncStorage.setItem.mockImplementationOnce(
+      async () =>
+        new Promise<void>((resolve) => {
+          releaseWrite = () => resolve()
+        })
+    )
+    const deletion = deleteCachedSessionTabStripForHost('host-a')
+    // The purge has run and its write is on the wire; a snapshot queued for the
+    // workspace the user just unpaired now lands in that window.
+    await vi.advanceTimersByTimeAsync(0)
+    saveCachedSessionTabStrip(hostA, preview('tab-a2'))
+    releaseWrite()
+    await deletion
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(readCachedSessionTabStrip(hostA)).toBeNull()
+    expect(lastWrittenFile().workspaces).toEqual([])
+  })
+
+  it('cannot be talked back into a host whose deletion write failed', async () => {
+    const hostA = getSessionTabStripCacheKey('host-a', 'wt-1')
+    saveCachedSessionTabStrip(hostA, preview('tab-a'))
+    await vi.advanceTimersByTimeAsync(300)
+    asyncStorage.setItem.mockRejectedValueOnce(new Error('storage full'))
+
+    await expect(deleteCachedSessionTabStripForHost('host-a')).rejects.toThrow('storage full')
+    const writesSoFar = asyncStorage.setItem.mock.calls.length
+
+    saveCachedSessionTabStrip(hostA, preview('tab-a3'))
+    await vi.advanceTimersByTimeAsync(300)
+
+    expect(readCachedSessionTabStrip(hostA)).toBeNull()
+    expect(asyncStorage.setItem).toHaveBeenCalledTimes(writesSoFar)
+  })
 })

--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -339,4 +339,32 @@ describe('session tab strip cache', () => {
     expect(readCachedSessionTabStrip(hostA)).toBeNull()
     expect(asyncStorage.setItem).toHaveBeenCalledTimes(writesSoFar)
   })
+  it('lets a debounced write that already snapshotted the removed host land first', async () => {
+    // The tombstone stops new saves, but a debounced write that fired a moment earlier
+    // built its blob from the map as it was and is still on the wire. Writing over it
+    // concurrently leaves which blob lands last up to storage.
+    const hostA = getSessionTabStripCacheKey('host-a', 'wt-1')
+    const hostB = getSessionTabStripCacheKey('host-b', 'wt-1')
+    saveCachedSessionTabStrip(hostA, preview('tab-a'))
+    saveCachedSessionTabStrip(hostB, preview('tab-b'))
+
+    let releaseDebounced!: () => void
+    asyncStorage.setItem.mockImplementationOnce(
+      async () =>
+        new Promise<void>((resolve) => {
+          releaseDebounced = () => resolve()
+        })
+    )
+    await vi.advanceTimersByTimeAsync(300)
+
+    const deletion = deleteCachedSessionTabStripForHost('host-a')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(asyncStorage.setItem).toHaveBeenCalledOnce()
+
+    releaseDebounced()
+    await deletion
+
+    expect(asyncStorage.setItem).toHaveBeenCalledTimes(2)
+    expect(lastWrittenFile().workspaces.map((w) => w.key)).toEqual([hostB])
+  })
 })

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -33,6 +33,9 @@ type StoredFile = { workspaces: StoredWorkspace[] }
 let memoryCache: Map<string, MobileSessionTabStripPreview> | null = null
 let loadPromise: Promise<Map<string, MobileSessionTabStripPreview>> | null = null
 let writeTimer: ReturnType<typeof setTimeout> | null = null
+// The debounced write already on the wire. It snapshotted the map when it started, so a
+// deletion has to let it land before writing, or the stale blob can be the last word.
+let writeInFlight: Promise<void> | null = null
 // Hosts forgotten this session. A save racing the deletion would re-insert the host and
 // the next debounced write would put its tab titles back on disk, so refuse those saves
 // outright. Re-pairing the same host caches again from the next app launch — the cheap
@@ -123,6 +126,8 @@ export async function deleteCachedSessionTabStripForHost(hostId: string): Promis
     clearTimeout(writeTimer)
     writeTimer = null
   }
+  await writeInFlight
+  writeInFlight = null
   await writeFile(cache)
 }
 
@@ -133,6 +138,7 @@ export function resetSessionTabStripCacheForTests(): void {
   }
   memoryCache = null
   loadPromise = null
+  writeInFlight = null
   forgottenHosts.clear()
 }
 
@@ -202,8 +208,9 @@ function scheduleWrite(cache: Map<string, MobileSessionTabStripPreview>): void {
   writeTimer = setTimeout(() => {
     writeTimer = null
     // Best effort by design: a dropped cache refresh costs one repaint, and the next
-    // save rewrites the whole map. Only the deletion path needs the failure.
-    void writeFile(cache).catch(() => {})
+    // save rewrites the whole map. Only the deletion path needs the failure, and it
+    // needs the handle so it can order itself last.
+    writeInFlight = writeFile(cache).catch(() => {})
   }, WRITE_DEBOUNCE_MS)
 }
 

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -33,6 +33,11 @@ type StoredFile = { workspaces: StoredWorkspace[] }
 let memoryCache: Map<string, MobileSessionTabStripPreview> | null = null
 let loadPromise: Promise<Map<string, MobileSessionTabStripPreview>> | null = null
 let writeTimer: ReturnType<typeof setTimeout> | null = null
+// Hosts forgotten this session. A save racing the deletion would re-insert the host and
+// the next debounced write would put its tab titles back on disk, so refuse those saves
+// outright. Re-pairing the same host caches again from the next app launch — the cheap
+// direction for a deletion the user asked for.
+const forgottenHosts = new Set<string>()
 
 /**
  * A workspace id ends in a filesystem path, so it is digested rather than stored. The host id
@@ -71,7 +76,8 @@ export function saveCachedSessionTabStrip(
   key: string | null,
   preview: MobileSessionTabStripPreview
 ): void {
-  if (!key) {
+  const hostId = key === null ? null : readHostIdFromKey(key)
+  if (!key || (hostId !== null && forgottenHosts.has(hostId))) {
     return
   }
   const redacted = redactPreview(preview)
@@ -97,6 +103,9 @@ export function saveCachedSessionTabStrip(
  * serializes the forgotten host's tabs straight back to disk.
  */
 export async function deleteCachedSessionTabStripForHost(hostId: string): Promise<void> {
+  // Before the first await: a save landing during the load or the write must not
+  // re-insert the host the caller is in the middle of forgetting.
+  forgottenHosts.add(hostId)
   // Load first so the rewrite below preserves other hosts. If storage is unreadable we still
   // rewrite, which can cost another host its rows — the wrong direction for a cache, the right
   // one for a deletion the user asked for.
@@ -121,6 +130,7 @@ export function resetSessionTabStripCacheForTests(): void {
   }
   memoryCache = null
   loadPromise = null
+  forgottenHosts.clear()
 }
 
 function digestWorkspaceId(worktreeId: string): string {
@@ -188,13 +198,17 @@ function scheduleWrite(cache: Map<string, MobileSessionTabStripPreview>): void {
   }
   writeTimer = setTimeout(() => {
     writeTimer = null
-    void writeFile(cache)
+    // Best effort by design: a dropped cache refresh costs one repaint, and the next
+    // save rewrites the whole map. Only the deletion path needs the failure.
+    void writeFile(cache).catch(() => {})
   }, WRITE_DEBOUNCE_MS)
 }
 
 async function writeFile(cache: Map<string, MobileSessionTabStripPreview>): Promise<void> {
   const workspaces: StoredWorkspace[] = [...cache].map(([key, preview]) => ({ key, preview }))
-  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ workspaces })).catch(() => {})
+  // Throws on purpose: a deletion that only removed the in-memory rows must not be
+  // reported as a deletion, or the forgotten host's titles stay in plaintext on disk.
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ workspaces }))
 }
 
 // Rebuilt field by field so a field later added to the live tab type cannot ride into storage

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -76,8 +76,11 @@ export function saveCachedSessionTabStrip(
   key: string | null,
   preview: MobileSessionTabStripPreview
 ): void {
-  const hostId = key === null ? null : readHostIdFromKey(key)
-  if (!key || (hostId !== null && forgottenHosts.has(hostId))) {
+  if (!key) {
+    return
+  }
+  const hostId = readHostIdFromKey(key)
+  if (hostId !== null && forgottenHosts.has(hostId)) {
     return
   }
   const redacted = redactPreview(preview)

--- a/mobile/src/transport/host-removal-lifecycle.test.ts
+++ b/mobile/src/transport/host-removal-lifecycle.test.ts
@@ -32,6 +32,7 @@ describe('host removal lifecycle', () => {
   beforeEach(() => {
     removeHostMock.mockReset()
     asyncStorage.removeItem.mockClear()
+    asyncStorage.setItem.mockReset().mockResolvedValue(undefined)
     resetHostNotificationSessionsForTests()
     resetSessionTabStripCacheForTests()
   })
@@ -115,5 +116,20 @@ describe('host removal lifecycle', () => {
     await vi.waitFor(() => expect(readCachedSessionTabStrip(removed)).toBeNull())
 
     expect(readCachedSessionTabStrip(kept)?.tabs).toHaveLength(1)
+  })
+  it('finishes the removal even when the cached tab strip write fails', async () => {
+    // The metadata removal has already committed and the client is closed by this
+    // point, so a cache write that fails must be reported, not thrown: surfacing it
+    // as a failed removal would leave the user staring at a host that is really gone.
+    removeHostMock.mockResolvedValue(undefined)
+    asyncStorage.setItem.mockRejectedValue(new Error('storage full'))
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const closeHostClient = vi.fn()
+
+    await expect(removeHostAndCloseClient('host-1', closeHostClient)).resolves.toBeUndefined()
+
+    expect(closeHostClient).toHaveBeenCalledWith('host-1')
+    expect(warn).toHaveBeenCalled()
+    warn.mockRestore()
   })
 })

--- a/mobile/src/transport/host-removal-lifecycle.ts
+++ b/mobile/src/transport/host-removal-lifecycle.ts
@@ -19,6 +19,11 @@ export async function removeHostAndCloseClient(
   forgetHostNotificationSession(hostId)
   void clearWatermark(hostId)
   // Why: the cached tab strip is plaintext and host-scoped, so forgetting the host has to drop
-  // it here too — nothing else in the app ever expires an entry.
-  void deleteCachedSessionTabStripForHost(hostId)
+  // it here too — nothing else in the app ever expires an entry. Awaited so a storage failure
+  // is observed rather than swallowed, but never fatal: the metadata removal has already
+  // committed and the client is closed, so failing here would report a finished removal as
+  // failed. The cache refuses further saves for this host either way.
+  await deleteCachedSessionTabStripForHost(hostId).catch((error: unknown) => {
+    console.warn('[host-removal] cached tab strip delete failed', error)
+  })
 }

--- a/mobile/src/transport/mobile-direct-return-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { DirectReturnProbe } from './mobile-direct-return-probe'
+import { MobileEndpointHysteresis } from './mobile-endpoint-hysteresis'
+import { FakeSession, host } from './mobile-endpoint-supervisor-test-fakes'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+
+// A LAN that never answers: every dial sits open until the probe's own 12s budget.
+function fixture() {
+  const opened: FakeSession[] = []
+  const probe = new DirectReturnProbe(
+    {
+      now: Date.now,
+      setTimer: setTimeout,
+      clearTimer: clearTimeout,
+      openDirect: () => {
+        const candidate = new FakeSession('connecting')
+        opened.push(candidate)
+        return candidate
+      }
+    },
+    {
+      hysteresis: new MobileEndpointHysteresis(Date.now(), {
+        directSuccessesRequired: 1,
+        directObservationMs: 60_000,
+        failureCooldownMs: 0,
+        minimumDwellMs: 0
+      }),
+      host: () => host,
+      canSchedule: () => true,
+      canAttempt: () => true,
+      beginOperation: () => {},
+      migrate: async () => {},
+      onDirectMigrated: async () => {},
+      afterProbe: () => {}
+    }
+  )
+  return { opened, probe }
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+it('never opens a second dial while one is still in flight', async () => {
+  const { opened, probe } = fixture()
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(0)
+  expect(opened).toHaveLength(1)
+
+  // A relay drop and a foreground return both ask for an immediate probe while the
+  // first dial is still awaiting authentication.
+  probe.schedule(0)
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(0)
+  expect(opened).toHaveLength(1)
+
+  // Why this is the assertion that matters: a second probe would have overwritten
+  // activeProbe, so stop() would abort only the newest dial and leave this socket
+  // open for the rest of its 12s budget.
+  probe.stop()
+  await vi.advanceTimersByTimeAsync(0)
+  expect(opened[0]!.close).toHaveBeenCalledOnce()
+  expect(vi.getTimerCount()).toBe(0)
+})
+
+it('honors an urgent reprobe asked for mid-dial instead of dropping it on the 15s floor', async () => {
+  const { opened, probe } = fixture()
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(0)
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(0)
+  expect(opened).toHaveLength(1)
+
+  // The deferred ask survives the dial and runs at once when it settles, so holding
+  // the slot does not cost the caller the 15s it was trying to skip.
+  await vi.advanceTimersByTimeAsync(12_000)
+  await vi.advanceTimersByTimeAsync(1)
+  expect(opened).toHaveLength(2)
+  probe.stop()
+})
+
+it('falls back to the ordinary interval when nothing asked for a sooner probe', async () => {
+  const { opened, probe } = fixture()
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(12_000)
+  expect(opened).toHaveLength(1)
+
+  await vi.advanceTimersByTimeAsync(14_999)
+  expect(opened).toHaveLength(1)
+  await vi.advanceTimersByTimeAsync(1)
+  expect(opened).toHaveLength(2)
+  probe.stop()
+})

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -13,6 +13,8 @@ export class DirectReturnProbe {
 
   private stopped = false
   private activeProbe: AbortController | null = null
+  // Soonest delay a caller asked for while a dial was in flight.
+  private deferredDelayMs: number | null = null
 
   constructor(
     private readonly deps: {
@@ -39,7 +41,18 @@ export class DirectReturnProbe {
   ) {}
 
   schedule(delayMs = DIRECT_PROBE_INTERVAL_MS): void {
-    if (this.stopped || !this.hooks.canSchedule() || this.timer) {
+    if (this.stopped || !this.hooks.canSchedule()) {
+      return
+    }
+    // Why: the dial no longer holds the supervisor's mutex, so nothing else stops a
+    // second probe from overwriting activeProbe — stop() would then reach only the
+    // newest socket and leave the earlier one dialing for its full 12s budget. The
+    // in-flight probe owns the next slot and re-arms it on the soonest ask.
+    if (this.activeProbe) {
+      this.deferredDelayMs = Math.min(this.deferredDelayMs ?? delayMs, delayMs)
+      return
+    }
+    if (this.timer) {
       return
     }
     this.timer = this.deps.setTimer(() => {
@@ -49,6 +62,7 @@ export class DirectReturnProbe {
   }
 
   clear(): void {
+    this.deferredDelayMs = null
     if (this.timer) {
       this.deps.clearTimer(this.timer)
       this.timer = null
@@ -126,7 +140,9 @@ export class DirectReturnProbe {
       if (owned) {
         this.hooks.afterProbe()
       }
-      this.schedule()
+      const deferred = this.deferredDelayMs
+      this.deferredDelayMs = null
+      this.schedule(deferred ?? undefined)
     }
   }
 }

--- a/mobile/src/transport/mobile-relay-rpc-session.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.test.ts
@@ -453,4 +453,57 @@ describe('mobile relay RPC session', () => {
       vi.useRealTimers()
     }
   })
+  it('keeps whenResumeConfirmed() pending until the session has an answer', async () => {
+    // The contract callers rely on is "settles when the confirm has answered or the
+    // session is over". A promise already resolved during the dial would let a caller
+    // read getResumeConfirmation() as null and persist that as the answer.
+    const session = openSession()
+    const settled = vi.fn()
+    void session.whenResumeConfirmed().then(settled)
+    receiveHello()
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+
+    fakes.linkOptions!.onAuthenticated()
+    await Promise.resolve()
+    expect(settled).not.toHaveBeenCalled()
+
+    answerConfirm(sentRequests()[0]!)
+    await session.whenResumeConfirmed()
+    expect(settled).toHaveBeenCalled()
+    expect(session.getResumeConfirmation()).toMatchObject({ reqId: 'confirm-1' })
+  })
+
+  it('settles whenResumeConfirmed() when the session dies before authenticating', async () => {
+    const session = openSession()
+    const settled = vi.fn()
+    void session.whenResumeConfirmed().then(settled)
+
+    // A credential-version mismatch fails the session inside onHello, so no confirm
+    // is ever sent. Awaiting the answer must not hang a caller forever.
+    fakes.linkOptions!.onHello({
+      type: 'relay-hello',
+      ok: true,
+      credentialKind: 'resume',
+      leaseExpiresAt: Date.now() + 60_000,
+      acceptedCredentialVersion: 2,
+      acceptedAs: 'current',
+      resumeExpiresAt: Date.now() + 300_000
+    })
+
+    await session.whenResumeConfirmed()
+    expect(settled).toHaveBeenCalled()
+    expect(session.getState()).toBe('disconnected')
+  })
+
+  it('settles whenResumeConfirmed() when a caller closes an unconfirmed session', async () => {
+    const session = openSession()
+    const settled = vi.fn()
+    void session.whenResumeConfirmed().then(settled)
+
+    session.close()
+
+    await session.whenResumeConfirmed()
+    expect(settled).toHaveBeenCalled()
+  })
 })

--- a/mobile/src/transport/mobile-relay-rpc-session.ts
+++ b/mobile/src/transport/mobile-relay-rpc-session.ts
@@ -66,12 +66,19 @@ export function connectMobileRelayRpcSession(args: {
   let attachDeadlineAt: number | null = null
   let resumeExpiresAt: number | null = null
   let resumeConfirmation: DeviceResumeConfirmed | null = null
-  let resumeConfirmed: Promise<void> | null = null
   let failure: Error | null = null
   let closed = false
   let logSequence = 0
   const logSessionId = `${Date.now().toString(36)}-${(++relayRpcSessionSequence).toString(36)}`
   const livenessIdentity = {}
+  // Why created here and not at authentication: handing a pre-auth caller an
+  // already-resolved promise would let it read getResumeConfirmation() as null and
+  // treat that as the answer. Every terminal path settles it — the confirm, fail(),
+  // and close() — so awaiting it can never outlive the session.
+  let settleResumeConfirmed!: () => void
+  const resumeConfirmed = new Promise<void>((resolve) => {
+    settleResumeConfirmed = resolve
+  })
   const dialStage = new RelayDialStageTracker()
   const streams = new MobileRelayRpcStreams({
     nextId: () => pending.nextId(),
@@ -143,23 +150,13 @@ export function connectMobileRelayRpcSession(args: {
         livenessWatchdog.probeNow(livenessIdentity, reason === 'app-resume' ? 'resume' : 'nudge')
       }
     },
-    close() {
-      if (closed) {
-        return
-      }
-      closed = true
-      livenessWatchdog.stop(livenessIdentity)
-      link.close()
-      pending.rejectAll(new Error('Client closed'))
-      streams.clear()
-      publishState('disconnected')
-    },
+    close: () => terminate(new Error('Client closed')),
     getDialStage: () => dialStage.getDialStage(),
     onDialStageChange: (listener) => dialStage.onDialStageChange(listener),
     getAttachDeadlineAt: () => attachDeadlineAt,
     getResumeExpiresAt: () => resumeExpiresAt,
     getResumeConfirmation: () => resumeConfirmation,
-    whenResumeConfirmed: () => resumeConfirmed ?? Promise.resolve(),
+    whenResumeConfirmed: () => resumeConfirmed,
     getFailure: () => failure
   }
   const livenessWatchdog = new RpcSessionLivenessWatchdog({
@@ -197,7 +194,7 @@ export function connectMobileRelayRpcSession(args: {
       return
     }
     dialStage.advance('confirming')
-    resumeConfirmed = confirmResume()
+    void confirmResume().then(settleResumeConfirmed, settleResumeConfirmed)
     // Why: an unanswered advisory says nothing, but a frame that never reached the
     // wire proves the socket cannot carry traffic — that alone still fails.
     void settleMobileRuntimeCapabilities((method, params) =>
@@ -319,17 +316,27 @@ export function connectMobileRelayRpcSession(args: {
     }
   }
 
-  function fail(error: Error): void {
+  // One teardown for both endings; only whether the session is to blame differs, and
+  // recording a failure for a caller's close would make the establisher report a
+  // deliberate teardown as a dial error.
+  function terminate(error: Error): void {
     if (closed) {
       return
     }
     closed = true
-    failure = error
+    settleResumeConfirmed()
     livenessWatchdog.stop(livenessIdentity)
     streams.clear()
     link.close()
     pending.rejectAll(error)
     publishState(error instanceof MobileE2EEAuthenticationError ? 'auth-failed' : 'disconnected')
+  }
+
+  function fail(error: Error): void {
+    if (!closed) {
+      failure = error
+    }
+    terminate(error)
   }
 }
 

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -173,4 +173,61 @@ describe('RpcSessionLivenessWatchdog', () => {
     watchdog.probeNow(identity)
     expect(terminate).toHaveBeenCalledWith(identity)
   })
+  function backgroundableFixture() {
+    const sendProbe = vi.fn(() => true)
+    const terminate = vi.fn()
+    const identity = {}
+    const state = { foreground: true }
+    const watchdog = new RpcSessionLivenessWatchdog({
+      transport: 'relay',
+      sendProbe,
+      terminate,
+      shouldIdleProbe: () => state.foreground,
+      now: Date.now
+    })
+    watchdog.start(identity)
+    return { identity, sendProbe, state, terminate, watchdog }
+  }
+
+  it('stops retrying an idle probe once the app backgrounds under it', async () => {
+    const { sendProbe, state, terminate } = backgroundableFixture()
+    await vi.advanceTimersByTimeAsync(LIVENESS_IDLE_MS)
+    expect(sendProbe).toHaveBeenCalledOnce()
+
+    // iOS suspends the socket in the background, so every further miss is evidence
+    // about the app and not about the peer. Retrying would spend the whole budget on
+    // the suspension and terminate a relay that is fine.
+    state.foreground = false
+    await vi.advanceTimersByTimeAsync(LIVENESS_PROBE_TIMEOUT_MS * 4)
+    expect(sendProbe).toHaveBeenCalledOnce()
+    expect(terminate).not.toHaveBeenCalled()
+  })
+
+  it('re-arms the idle sweep with a clean slate after a backgrounded probe', async () => {
+    const { sendProbe, state, terminate } = backgroundableFixture()
+    await vi.advanceTimersByTimeAsync(LIVENESS_IDLE_MS)
+    state.foreground = false
+    await vi.advanceTimersByTimeAsync(LIVENESS_PROBE_TIMEOUT_MS)
+    state.foreground = true
+
+    // The abandoned probe must not be carried forward as a miss: the sweep needs its
+    // full three fair misses again before it may call the session dead.
+    await vi.advanceTimersByTimeAsync(LIVENESS_IDLE_MS)
+    expect(sendProbe).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(LIVENESS_PROBE_TIMEOUT_MS * 2)
+    expect(terminate).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(LIVENESS_PROBE_TIMEOUT_MS)
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('still reaches a verdict on a caller probe when the app backgrounds', async () => {
+    // The gate covers the idle sweep only. A nudge or resume probe was asked for on
+    // purpose, and abandoning it would leave a genuinely dead socket unreported.
+    const { identity, state, terminate, watchdog } = backgroundableFixture()
+    watchdog.probeNow(identity)
+    state.foreground = false
+
+    await vi.advanceTimersByTimeAsync(LIVENESS_PROBE_TIMEOUT_MS * 3)
+    expect(terminate).toHaveBeenCalledOnce()
+  })
 })

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -38,6 +38,8 @@ export class RpcSessionLivenessWatchdog {
   private identity: RpcSessionIdentity | null = null
   private timer: ReturnType<typeof setTimeout> | null = null
   private probing = false
+  // Whether the probe in flight came from the idle sweep rather than a caller.
+  private idleSweepProbe = false
   private missedProbes = 0
   private lastInboundAt = 0
   private lastVoluntaryProbeAt: number | null = null
@@ -71,6 +73,7 @@ export class RpcSessionLivenessWatchdog {
     this.clearActiveTimer()
     this.identity = identity
     this.probing = false
+    this.idleSweepProbe = false
     this.missedProbes = 0
     this.lastInboundAt = this.now()
     this.lastVoluntaryProbeAt = null
@@ -101,6 +104,7 @@ export class RpcSessionLivenessWatchdog {
     }
     this.missedProbes = 0
     this.probing = false
+    this.idleSweepProbe = false
     this.armIdle(identity)
   }
 
@@ -131,6 +135,7 @@ export class RpcSessionLivenessWatchdog {
     this.clearActiveTimer()
     this.identity = null
     this.probing = false
+    this.idleSweepProbe = false
     this.missedProbes = 0
     this.lastInboundAt = 0
     this.lastVoluntaryProbeAt = null
@@ -155,18 +160,23 @@ export class RpcSessionLivenessWatchdog {
       if (this.idleProbeMs !== null && idleMs < this.idleProbeMs) {
         this.armIdle(identity, Math.max(1, this.idleProbeMs - Math.max(0, idleMs)))
       } else {
-        this.startProbe(identity)
+        this.startProbe(identity, this.ordinaryProfile, true)
       }
     }, delayMs)
   }
 
-  private startProbe(identity: RpcSessionIdentity, profile = this.ordinaryProfile): void {
+  private startProbe(
+    identity: RpcSessionIdentity,
+    profile = this.ordinaryProfile,
+    fromIdleSweep = false
+  ): void {
     if (this.identity !== identity) {
       return
     }
     this.clearActiveTimer()
     this.profile = profile
     this.probing = true
+    this.idleSweepProbe = fromIdleSweep
     const sentAt = this.now()
     let sent = false
     try {
@@ -186,6 +196,16 @@ export class RpcSessionLivenessWatchdog {
     if (this.identity !== identity) {
       return
     }
+    // Why: the idle sweep is foreground-only because iOS suspends sockets in the
+    // background, where a miss is not evidence of a dead peer. Retrying here would
+    // spend the whole miss budget on that suspension and kill a healthy session.
+    if (this.idleSweepProbe && this.options.shouldIdleProbe && !this.options.shouldIdleProbe()) {
+      this.probing = false
+      this.idleSweepProbe = false
+      this.missedProbes = 0
+      this.armIdle(identity)
+      return
+    }
     const profile = this.profile
     const elapsedMs = this.now() - sentAt
     if (elapsedMs < 0 || elapsedMs > profile.timeoutMs * 1.5) {
@@ -194,7 +214,7 @@ export class RpcSessionLivenessWatchdog {
         elapsedMs,
         timeoutMs: profile.timeoutMs
       })
-      this.startProbe(identity, profile)
+      this.startProbe(identity, profile, this.idleSweepProbe)
       return
     }
     this.missedProbes += 1
@@ -207,7 +227,7 @@ export class RpcSessionLivenessWatchdog {
       missedProbes: this.missedProbes,
       missedProbeLimit: profile.missedProbeLimit
     })
-    this.startProbe(identity, profile)
+    this.startProbe(identity, profile, this.idleSweepProbe)
   }
 
   private terminateCurrent(
@@ -220,6 +240,7 @@ export class RpcSessionLivenessWatchdog {
     this.clearActiveTimer()
     this.identity = null
     this.probing = false
+    this.idleSweepProbe = false
     console.log('[net] activity-probe TIMEOUT — forcing reconnect', {
       transport: this.options.transport,
       missedProbes: this.missedProbes,


### PR DESCRIPTION
Review follow-ups on the two merged mobile PRs #19236 and #19258. Each finding was checked against the code with a failing test before any fix. All four turned out to be real, though the third is hardening rather than a live bug.

## A. Overlapping direct probes (#19236, major) — fixed

`DirectReturnProbe.schedule()` guarded only the pending timer, not a dial already in flight. Once #19236 released the supervisor's operation mutex for the dial, nothing serialized probes: `MobileRelayBackgroundGrace.background()` calls `clear()`, which cancels the timer but leaves an in-flight dial running, and the matching `setForeground(true)` then calls `schedule(0)`. The second probe overwrote `activeProbe`, so `stop()` aborted only the newest dial and the earlier socket stayed open for the rest of its 12s budget.

The in-flight probe now owns the next slot. A caller asking while a dial is running records the soonest delay, and the probe's own `finally` arms that instead of the 15s default, so an urgent request is deferred rather than dropped.

## B. Pre-authentication `whenResumeConfirmed()` (#19236, minor) — hardened

No caller could reach the window. `publishAuthenticated()` assigns the promise before `publishState('connected')`, and both call sites, the establisher and `persistResumeConfirmation`, run only after `migrateTo` resolves on `connected`. So the ordering was safe in practice.

It was still a latent trap: the type comment promises a promise that settles when the confirm answers or the session ends, and the implementation only honored that after authentication. The deferred now exists from construction and settles on the confirm, on `fail()`, and on `close()`, which are the only ways the session can end. Making it pending from construction is safe only because every terminal path settles it, so `fail()` and `close()` are now one `terminate()`. They already shared all but the failure bookkeeping, and unifying them kept the file under its 300-line cap without a `max-lines` bump.

## C. Idle-probe retries after backgrounding (#19236, major) — fixed

`handleProbeTimeout` retried on both the unfair-window path and the tolerated-miss path without rechecking `shouldIdleProbe`. An idle-sweep probe that started in the foreground could keep probing after the app backgrounded and terminate a healthy relay after the miss limit, which is exactly the reading the foreground gate exists to prevent: iOS suspends sockets in the background, so a miss there is not evidence of a dead peer.

Probes now carry their origin. An idle-sweep probe that times out while backgrounded clears its state and re-arms the sweep with the miss count reset, so nothing from the suspension is carried into the next foreground probe. Caller probes, `nudge` and `resume`, still retry and reach a verdict, since abandoning those would leave a genuinely dead socket unreported.

## D. Silent deletion failure in the tab strip cache (#19258, major) — fixed

`writeFile` swallowed its own rejection, so `deleteCachedSessionTabStripForHost` resolved successfully while a forgotten host's plaintext tab titles stayed on disk. `removeHostAndCloseClient` also discarded the promise with `void`, so nothing could have observed the failure anyway.

Resolved as suggested, with the constraint that host removal must never fail or hang on a cache write:

- `writeFile` now throws. The debounced save keeps a `.catch(() => {})`, since a dropped cache refresh costs one repaint and the next save rewrites the whole map.
- `removeHostAndCloseClient` awaits the deletion and logs a failure. It never rethrows: the metadata removal has committed and the client is closed by that point, so surfacing a cache failure as a failed removal would be wrong. `createUnpairedHostCredentialDeletion` already awaited it and now sees the rejection, consistent with its sibling credential deletions.
- The cache refuses saves for a host it has been told to forget. Without this, a snapshot landing while the deletion's write is on the wire re-inserts the host and the next debounced save puts the rows back. The tombstone lasts for the process, which means re-pairing the same host id in the same app launch caches again only after a restart. That is the cheap direction for a deletion the user asked for, but it is the one judgment call here worth a second opinion.

## Verification

Every fix has a test that fails on the parent commit `0ba7f8dc8d` and passes here.

| Check | Result |
| --- | --- |
| `npx tsc --noEmit` (mobile) | clean |
| `npx vitest run` (mobile, full) | 520 files, 4258 passed, 3 skipped |
| `pnpm run check:code-quality:changed` | 0 new findings across 10 files |
| `pnpm run check:react-doctor:changed` | 0 new findings |

Pre-fix failures, confirmed by restoring each source file from `HEAD` and rerunning:

- A: 2 of 3 new tests in `mobile-direct-return-probe.test.ts`
- B: 1 of 3 new tests in `mobile-relay-rpc-session.test.ts`
- C: 2 of 3 new tests in `rpc-session-liveness-watchdog.test.ts`
- D: 3 of 4 new tests in `session-tab-strip-cache.test.ts`

Refs #19236, #19258.