### PR TITLE
fix(pi): report extension prompts as blocked

### DIFF
--- a/src/main/pi/agent-status-extension-source.test.ts
+++ b/src/main/pi/agent-status-extension-source.test.ts
@@ -48,6 +48,23 @@ describe('getPiAgentStatusExtensionSource', () => {
     })
   })
 
+  it('forwards Pi UI prompt lifecycle events', async () => {
+    const harness = createHarness({ kind: 'pi' })
+
+    expect(harness.handlers.ui_prompt_start).toBeTypeOf('function')
+    expect(harness.handlers.ui_prompt_end).toBeTypeOf('function')
+
+    await harness.callHook('ui_prompt_start', undefined, { isIdle: () => false })
+    await harness.callHook('ui_prompt_end', undefined, { isIdle: () => true })
+
+    await vi.waitFor(() => expect(harness.fetchMock).toHaveBeenCalledTimes(2))
+    expect(
+      harness.fetchMock.mock.calls.map(
+        ([_event, init]) => JSON.parse(String(init?.body)).payload.hook_event_name
+      )
+    ).toEqual(['ui_prompt_start', 'ui_prompt_end'])
+  })
+
   it('includes the session id and file path in Pi status posts after session_start', async () => {
     const harness = createHarness({
       kind: 'pi',

--- a/src/main/pi/agent-status-handler-source.ts
+++ b/src/main/pi/agent-status-handler-source.ts
@@ -57,6 +57,22 @@ export function getPiAgentStatusHandlerSourceLines(kind: PiAgentKind): string[] 
           '  })',
           ''
         ]
+  const uiPromptHandlers =
+    kind === 'pi'
+      ? [
+          `  pi.on('ui_prompt_start', (_event${ctxParam}) => {`,
+          ...captureSessionMetadata,
+          '    if (ctx?.isIdle?.()) return',
+          "    post('ui_prompt_start')",
+          '  })',
+          '',
+          `  pi.on('ui_prompt_end', (_event${ctxParam}) => {`,
+          ...captureSessionMetadata,
+          "    post('ui_prompt_end')",
+          '  })',
+          ''
+        ]
+      : []
 
   return [
     '// Why: pi assistant messages carry content as an array of parts',
@@ -131,6 +147,7 @@ export function getPiAgentStatusHandlerSourceLines(kind: PiAgentKind): string[] 
     '  })',
     '',
     ...approvalHandlers,
+    ...uiPromptHandlers,
     "  // Why: capture the assistant's final text on each completed message",
     '  // so the dashboard preview reflects the most recent reply even before',
     '  // agent_end fires. message_end is the right hook because pi guarantees',

--- a/src/shared/agent-hook-listener-pi-compatible.test.ts
+++ b/src/shared/agent-hook-listener-pi-compatible.test.ts
@@ -347,6 +347,32 @@ describe('shared agent-hook-listener', () => {
     expect(tool?.payload.interactivePrompt).toBe(JSON.stringify(questions))
   })
 
+  it('blocks a Pi pane while extension UI waits for user input', () => {
+    const requested = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'ui_prompt_start' }
+      },
+      'production'
+    )
+
+    expect(requested?.payload).toMatchObject({ state: 'blocked', agentType: 'pi' })
+
+    const resolved = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'ui_prompt_end' }
+      },
+      'production'
+    )
+
+    expect(resolved?.payload).toMatchObject({ state: 'working', agentType: 'pi' })
+  })
+
   it('blocks an OMP pane on a tool approval request and clears it on resolution', () => {
     const requested = normalizeHookPayload(
       state,

--- a/src/shared/agent-hook-listener/providers/pi-family-events.ts
+++ b/src/shared/agent-hook-listener/providers/pi-family-events.ts
@@ -30,11 +30,14 @@ export function normalizePiCompatibleEvent(
     (eventName === 'tool_call' || eventName === 'tool_execution_start')
   const isOmpApprovalRequest = agentType === 'omp' && eventName === 'tool_approval_requested'
   const isOmpApprovalResolution = agentType === 'omp' && eventName === 'tool_approval_resolved'
+  const isPiUiPromptStart = agentType === 'pi' && eventName === 'ui_prompt_start'
+  const isPiUiPromptEnd = agentType === 'pi' && eventName === 'ui_prompt_end'
 
   const stateName =
-    isPiCompatibleAsk || isOmpApprovalRequest
+    isPiCompatibleAsk || isOmpApprovalRequest || isPiUiPromptStart
       ? 'blocked'
       : isOmpApprovalResolution ||
+          isPiUiPromptEnd ||
           eventName === 'before_agent_start' ||
           eventName === 'agent_start' ||
           eventName === 'tool_call' ||


### PR DESCRIPTION
## ELI5

When Pi pauses to ask the user for input, Orca currently keeps saying that Pi is working. This change forwards Pi's built-in prompt lifecycle so Orca shows the existing blocked state while Pi waits, then returns to working when the prompt closes.

## What Changed

- Forward Pi `ui_prompt_start` and `ui_prompt_end` events through the managed status extension.
- Ignore prompt starts outside an active agent turn so idle extension dialogs do not create agent work.
- Treat prompt end as the authoritative unblock signal, even if Pi has already become idle.
- Normalize the new Pi events to the existing blocked/working states.
- Add extension-forwarding and listener state-transition regression tests.

## Why

Pi documents `ui_prompt_start` and `ui_prompt_end` specifically for host/status integrations. Using those lifecycle events covers MCP approvals, elicitation, and other blocking extension UI without coupling Orca to `pi-mcp-adapter` or individual tools.

The end event is forwarded unconditionally so an idle-state race cannot leave a pane permanently blocked.

## Linked Issue

Fixes #19257

## Visual Proof

N/A — this changes status-event plumbing and reuses Orca's existing blocked presentation; it adds no renderer, layout, or styling changes. Before the fix, the live Pi terminal remained `Working` with `agentWait: null` during an MCP approval prompt. The added integration test verifies `ui_prompt_start → blocked` and `ui_prompt_end → working`.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Commands run:

```text
pnpm test src/main/pi/agent-status-extension-source.test.ts src/shared/agent-hook-listener-pi-compatible.test.ts
pnpm run check:code-quality:changed
pnpm tc:node
pnpm lint
pnpm typecheck
pnpm test
pnpm build
```

Focused tests, changed-file quality checks, Node typecheck, full lint, full typecheck, and full build passed. The full Linux-container test run passed 75,313 tests and failed 23 tests across 17 unrelated environment-sensitive files (Electron display/network isolation plus a missing `lsof`); neither changed test file failed. Exact failures are retained in the run evidence rather than reported as a clean full-suite pass.

Observed the original failure on macOS with Orca 1.4.197 and an approval-gated Lightpanda MCP call. Automated coverage exercises platform-neutral generated extension and listener code. Linux was exercised in a clean `node:22-bookworm` container; Windows and SSH were not manually exercised.

## AI Disclosure

Implementation and review were assisted by OpenAI Codex (`gpt-5.6-sol`, medium reasoning). A multi-agent PR audit used OpenAI Codex `gpt-5.4-mini`.

Author X handle: N/A — no X handle is listed on my GitHub profile.

## Review

- **Correctness:** Prompt start blocks only during an active Pi turn; prompt end always clears the hold. Tests cover forwarding and both status transitions.
- **Security:** No prompt contents, tool arguments, credentials, or new external data are forwarded.
- **Performance:** Adds at most two existing loopback status posts per blocking Pi UI prompt; delivery remains latest-only and off Pi's critical path.
- **Cross-platform:** No platform-specific APIs or paths. Same generated extension and listener run on macOS, Linux, Windows, WSL, and SSH.
- **Remote/SSH/local:** Reuses the existing endpoint discovery and WSL fallback transport; no wire shape or execution-host ownership changes.
- **Agent/integration compatibility:** Scoped to genuine Pi runtime events. Existing OMP approval handlers and Prime Agent behavior remain unchanged.
- **UI quality:** Reuses Orca's current blocked/working presentation; no new UI primitives or styles.
- **Backwards compatibility:** Older Pi versions that do not emit these events keep their previous behavior.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No release/version changes. No mobile or git-provider impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` visual proof includes reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and agent/integration impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — lint, typecheck, and build pass; full test has 23 unrelated container-environment failures noted above
