### PR TITLE
test(relay): prove the pending-conn capability header reaches acceptControl

### DIFF
--- a/cloud/apps/relay/src/relay.blackbox.test.ts
+++ b/cloud/apps/relay/src/relay.blackbox.test.ts
@@ -9,7 +9,9 @@ import { fileURLToPath } from 'node:url'
 import { exportJWK, generateKeyPair, jwtVerify, SignJWT } from 'jose'
 import {
   buildHostProofMacInput,
-  HOST_CHALLENGE_PLAINTEXT_DOMAIN
+  HOST_CHALLENGE_PLAINTEXT_DOMAIN,
+  RELAY_HOST_CAPABILITIES_HEADER,
+  RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS
 } from '@orca-cloud/relay-contract'
 import nacl from 'tweetnacl'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
@@ -282,11 +284,17 @@ async function openHostControl(input?: {
   previousGeneration?: number
   keyPair?: nacl.BoxKeyPair
   assignmentEpoch?: number
+  capabilities?: string
 }): Promise<{ socket: WebSocket; ack: Record<string, unknown>; keyPair: nacl.BoxKeyPair }> {
   const keyPair = input?.keyPair ?? nacl.box.keyPair()
   const hostId = createHash('sha256').update(keyPair.publicKey).digest('base64url').slice(0, 16)
   const socket = new WebSocket(`${relayUrl.replace('http:', 'ws:')}/v1/host/control`, {
-    headers: { authorization: `Bearer ${await relayToken('orca-relay', hostId)}` },
+    headers: {
+      authorization: `Bearer ${await relayToken('orca-relay', hostId)}`,
+      ...(input?.capabilities
+        ? { [RELAY_HOST_CAPABILITIES_HEADER]: input.capabilities }
+        : {})
+    },
     perMessageDeflate: false
   })
   await new Promise<void>((resolveOpen, reject) => {
@@ -651,6 +659,69 @@ describe('served relay URL', () => {
     const result = await closed
     expect(result.code).toBe(4409)
     expect(result.reason).not.toContain('http')
+  })
+
+  it('restates a pending connection to the rebound control, detailed only when advertised', async () => {
+    // The one link the unit tests cannot reach: an upgrade that really carries
+    // x-orca-host-capabilities must reach acceptControl and change the ack. A
+    // typo in the header name here passes every other test in the suite.
+    const host = await openHostControl()
+    const hostId = createHash('sha256')
+      .update(host.keyPair.publicKey)
+      .digest('base64url')
+      .slice(0, 16)
+    const inviteResponse = nextMessage(host.socket)
+    host.socket.send(
+      JSON.stringify({
+        type: 'invite-create',
+        reqId: 'capability-invite',
+        relayDeviceId: 'capability-device'
+      })
+    )
+    const invite = await inviteResponse
+    const phone = new WebSocket(`${relayUrl.replace('http:', 'ws:')}/v1/connect/${hostId}`, {
+      headers: forwardedHeaders()
+    })
+    await new Promise<void>((resolveOpen, reject) => {
+      phone.once('open', resolveOpen)
+      phone.once('error', reject)
+    })
+    const connectionPromise = nextMessage(host.socket)
+    phone.send(
+      JSON.stringify({ type: 'relay-auth', v: 1, mode: 'connect', credential: invite.inviteToken })
+    )
+    // Never attached: the connection stays pending, which is what the ack restates.
+    const connection = await connectionPromise
+    expect(connection.type).toBe('conn-open')
+
+    const capable = await openHostControl({
+      keyPair: host.keyPair,
+      controlResumeSecret: String(host.ack.controlResumeSecret),
+      previousGeneration: 1,
+      capabilities: RELAY_HOST_CAPABILITY_PENDING_CONN_DETAILS
+    })
+    expect(capable.ack.pendingConns).toEqual([
+      {
+        connId: connection.connId,
+        connTicket: connection.connTicket,
+        kind: 'invite',
+        relayDeviceId: 'capability-device'
+      }
+    ])
+
+    const legacy = await openHostControl({
+      keyPair: host.keyPair,
+      controlResumeSecret: String(capable.ack.controlResumeSecret),
+      previousGeneration: 1
+    })
+    // A shipped host parses these entries strictly, so an unannounced key would
+    // fail the whole ack and kill a control that was working.
+    expect(legacy.ack.pendingConns).toEqual([
+      { connId: connection.connId, connTicket: connection.connTicket }
+    ])
+
+    phone.close()
+    legacy.socket.close()
   })
 
   it('keeps a pending attach usable after a bad ticket and rejects ticket replay', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

#19266 taught the relay to send extra detail about a waiting connection, but only to a desktop that asked for it by setting a header. Every piece of that was tested on its own, and nothing tested them joined together. If someone mistyped the header name the relay reads, all the tests still passed and the feature would just quietly stop working. This adds the one test that would catch that.

## What Changed

Test-only. One case added to `cloud/apps/relay/src/relay.blackbox.test.ts`, plus an optional `capabilities` argument on that file's existing `openHostControl` helper so a case can set the upgrade header.

The case drives a real control upgrade against a real relay process, creates an invite, connects a phone and never attaches a data socket so the connection stays pending, then rebinds the control twice and asserts the ack:

- rebound with `x-orca-host-capabilities: pending-conn-details` — `pendingConns` is `[{connId, connTicket, kind: 'invite', relayDeviceId: 'capability-device'}]`
- rebound without the header — `[{connId, connTicket}]`

## Why

Follow-up to #19266, from a review finding on that PR:

> The header → `acceptControl` wiring here is the one link with no test: `parseRelayHostCapabilities` is unit-tested, `acceptControl`/`sendHelloAck` gating is unit-tested, and the header/constant literals are pinned, but nothing asserts that a real control upgrade carrying `x-orca-host-capabilities` yields a detailed ack. A typo here (e.g. indexing a differently-spelled header) would pass the whole suite.

That is accurate. The finding arrived after #19266 had already merged, so it lands here instead.

This matters more than a normal coverage gap because the failure mode is silent. A mistyped header name does not error. The relay simply never sees any host as capable, always emits the legacy ack, and the desktop half falls back to its observed `conn-open` path. Nothing fails, and the fix for the connection-straddling bug is inert.

## Linked Issue

N/A. Follow-up to #19266.

## Visual Proof

`N/A` — test-only change.

## Testing

Mutation-checked, which is the point of the test. Renaming the header the server reads from `RELAY_HOST_CAPABILITIES_HEADER` to `'x-orca-host-capability'` fails it:

```
-     "kind": "invite",
-     "relayDeviceId": "capability-device",

 Test Files  1 failed (1)
      Tests  1 failed | 28 passed (29)
```

Reverted, then re-verified on this branch against current `main`:

- `npx vitest run src/relay.blackbox.test.ts` — 29 passed
- `npx vitest run` in `apps/relay` — 54 files, 535 passed, 95 skipped
- `pnpm typecheck` clean

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Internal contributor.

## Review

Raised by Pullfrog on #19266. Addressed here rather than rebutted.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

No production code changes, so no security, cross-platform, SSH, mobile, performance, or backwards-compatibility impact. The blackbox suite spawns a real relay process and this case adds roughly one second to it.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)