### PR TITLE
fix(relay-ops): let the rehome trust probe approve the asia-east2 cells

### DIFF
--- a/cloud/dev/scripts/probe-relay-rehome-trust.mjs
+++ b/cloud/dev/scripts/probe-relay-rehome-trust.mjs
@@ -1,7 +1,9 @@
 import { pathToFileURL } from 'node:url'
 import { fetchAdminOnceMore } from './relay-admin-transient-retry.mjs'
 
-const PRODUCTION_CELL = /^production-gce-c(?:7|8|9|10|13|14|15|16|19|20|21|22|23|24|25|26)$/
+// Every general cell that carries the rehome identity: the sixteen US cells and the
+// three asia-east2 cells that drain mis-homed hosts back the other way.
+const PRODUCTION_CELL = /^production-gce-c(?:7|8|9|10|13|14|15|16|19|20|21|22|23|24|25|26|27|28|29)$/
 const DIRECTOR_ORIGIN = 'https://relay.onorca.dev'
 
 export function parseRehomeTrustProbeArguments(argv, environment = process.env) {

--- a/cloud/dev/scripts/probe-relay-rehome-trust.test.mjs
+++ b/cloud/dev/scripts/probe-relay-rehome-trust.test.mjs
@@ -111,3 +111,23 @@ test('fails when both trust-probe attempts return a transient 503', async () => 
   )
   assert.equal(calls, 2)
 })
+
+test('approves the asia-east2 rehome sources and still rejects unlisted cells', () => {
+  for (const cellId of ['production-gce-c27', 'production-gce-c28', 'production-gce-c29']) {
+    const parsed = parseRehomeTrustProbeArguments(
+      argv.map((value) => (value === 'production-gce-c7' ? cellId : value)),
+      environment
+    )
+    assert.equal(parsed.cellId, cellId)
+  }
+  for (const cellId of ['production-gce-c1', 'production-gce-c17', 'production-gce-c30']) {
+    assert.throws(
+      () =>
+        parseRehomeTrustProbeArguments(
+          argv.map((value) => (value === 'production-gce-c7' ? cellId : value)),
+          environment
+        ),
+      /--cell-id is not approved/
+    )
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

The same-cap canary for production-gce-c27 (run 34105613162) rolled the cell to the new image at rehome protocol 1 and passed every verification, then failed at "Prove exact per-host trust" with `--cell-id is not approved`: `probe-relay-rehome-trust.mjs` hardcodes an allow-list of the sixteen US cells. #19241 removed the director's region gate and #19239 gave c27–c29 the rehome identity, but this operator-side list was missed.

## What
- Add c27, c28, c29 to `PRODUCTION_CELL`.
- Test: the three Asia cells parse; c1 (existing-only), c17 (migration-only), c30 (nonexistent) still throw.

## Verification
`node --test dev/scripts/probe-relay-rehome-trust.test.mjs dev/scripts/relay-same-cap-script-census.test.mjs`: 13 pass.

c27 is currently serving on the new image, isolated at migration-only (selector 187) by the failsafe; the no-restart rollback-resume path re-runs the probe and restores it once this lands.