### PR TITLE
fix(orchestration): preserve takeover and validate remote release evidence

### DIFF
--- a/docs/site/content/docs/cli/orchestration.mdx
+++ b/docs/site/content/docs/cli/orchestration.mdx
@@ -86,6 +86,14 @@ orca orchestration worker-start --task <taskId> --retry-of <dispatchId> --worktr
 
 Do not leave completed worker terminals open just to re-read output — use `worker-read` after `worker-release`. Do not substitute a broad `terminal close` when release returns `release_pending` or `release_unknown`; follow the receipt's recovery action.
 
+User input reported before worker ownership is recorded still counts as user
+takeover: a later ownership claim must not make that terminal automatically
+releasable. This protection survives runtime restarts and task resets.
+
+An inconsistent remote release receipt (for example, `released` with explicit
+`live` process status) returns `release_unknown` and preserves the Run home's
+terminal references for inspection.
+
 ## Federated workers (optional)
 
 ```bash

--- a/src/main/runtime/orchestration/db/reset/orchestration-reset.ts
+++ b/src/main/runtime/orchestration/db/reset/orchestration-reset.ts
@@ -20,6 +20,7 @@ export function runResetTransaction(this: OrchestrationDb, statements: string): 
 
 export function resetAll(this: OrchestrationDb): void {
   // Why: retain mutation receipts so a lost reset response cannot replay as a new mutation.
+  // Keep worker_terminal_user_inputs: resetting orchestration does not retire terminal panes.
   this.runResetTransaction(`
     DELETE FROM coordinator_runs;
     DELETE FROM decision_gates;
@@ -50,6 +51,7 @@ export function resetAll(this: OrchestrationDb): void {
 }
 
 export function resetTasks(this: OrchestrationDb): void {
+  // Keep worker_terminal_user_inputs: resetting Tasks does not retire terminal panes.
   // Why: messages survive this scope, so question threads are closed rather than deleted — an orphaned
   // question message would otherwise answer as a generic reply while legacy acknowledgment rejects it.
   this.runResetTransaction(`

--- a/src/main/runtime/orchestration/db/schema/create-core-tables-sql.ts
+++ b/src/main/runtime/orchestration/db/schema/create-core-tables-sql.ts
@@ -151,6 +151,13 @@ CREATE TABLE IF NOT EXISTS worker_dispatches (
   updated_at             TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- Additive on every open: input can arrive before a resource exists. No historical backfill.
+-- Keep these identity-only latches across Task resets, which do not retire terminal panes.
+CREATE TABLE IF NOT EXISTS worker_terminal_user_inputs (
+  pane_identity  TEXT PRIMARY KEY NOT NULL CHECK(length(pane_identity) = 64),
+  first_input_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 CREATE TABLE IF NOT EXISTS worker_terminal_resources (
   id                       TEXT PRIMARY KEY,
   origin_dispatch_id       TEXT NOT NULL,

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-resource-store.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-resource-store.ts
@@ -5,6 +5,7 @@ import type {
 import { OrchestrationError } from '../../orchestration-error'
 import { generateId } from '../generated-id'
 import type { OrchestrationDb } from '../orchestration-db'
+import { hasWorkerTerminalUserInput } from './worker-terminal-user-input-latch'
 
 // --- Worker terminal resources (schema v23) ---------------------------------------------------
 
@@ -67,13 +68,17 @@ export function createWorkerTerminalResourceStatement(
   }
 ): WorkerTerminalResourceRow {
   const id = generateId('wtr')
+  const userOwned =
+    params.ownership === 'owned' &&
+    params.paneKey !== null &&
+    hasWorkerTerminalUserInput(this, params.paneKey)
   this.db
     .prepare(
       `INSERT INTO worker_terminal_resources (
          id, origin_dispatch_id, owner_dispatch_id, worktree_id, terminal_handle,
          pane_key, process_incarnation, endpoint_id, endpoint_incarnation, host_scope, ownership_state, release_state,
          retained_reason
-       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'not_requested', ?)`
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     )
     .run(
       id,
@@ -86,8 +91,9 @@ export function createWorkerTerminalResourceStatement(
       params.endpointId ?? null,
       params.endpointIncarnation ?? params.processIncarnation,
       params.hostScope ?? null,
-      params.ownership,
-      params.ownership === 'external' ? 'external_terminal' : null
+      userOwned ? 'user_owned' : params.ownership,
+      userOwned ? 'retained' : 'not_requested',
+      userOwned ? 'user_takeover' : params.ownership === 'external' ? 'external_terminal' : null
     )
   return this.getWorkerTerminalResource(id) as WorkerTerminalResourceRow
 }

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-transfer.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-transfer.ts
@@ -2,6 +2,7 @@ import type { WorkerTerminalResourceRow } from '../../worker-terminal-ownership'
 import { OrchestrationError } from '../../orchestration-error'
 import { isEquivalentPaneKey } from '../pane-key-match'
 import type { OrchestrationDb } from '../orchestration-db'
+import { hasWorkerTerminalUserInput } from './worker-terminal-user-input-latch'
 
 // Finds an owned, settled, exact-match resource for an explicitly reused terminal.
 export function findTransferableWorkerTerminalResource(
@@ -40,6 +41,11 @@ export function findTransferableWorkerTerminalResource(
       'terminal_release_in_progress',
       `Terminal ${params.terminalHandle} has a release in progress; wait for cleanup or use another terminal.`
     )
+  }
+  // Input during a committed stop cannot cancel that stop, but forbids later ownership transfer.
+  // Check after the release fence: an external reuse must not bypass cleanup already in progress.
+  if (hasWorkerTerminalUserInput(this, params.paneKey)) {
+    return undefined
   }
   return exact.find(
     (candidate) =>

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-user-input-latch.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-user-input-latch.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto'
+import { parsePaneKey } from '../../../../../shared/stable-pane-id'
+import type { OrchestrationDb } from '../orchestration-db'
+
+function paneIdentity(paneKey: string): string {
+  const parsed = parsePaneKey(paneKey)
+  // Tab IDs can be reminted without changing the terminal. Keep legacy keys exact.
+  const identity = parsed ? `leaf:${parsed.leafId}` : `exact:${paneKey}`
+  return createHash('sha256').update(identity).digest('hex')
+}
+
+// No transaction: the first input and any existing ownership change commit together.
+// Store only a fixed-size identity hash, never the pane credential or input contents.
+export function recordWorkerTerminalUserInputStatement(db: OrchestrationDb, paneKey: string): void {
+  db.db
+    .prepare('INSERT OR IGNORE INTO worker_terminal_user_inputs (pane_identity) VALUES (?)')
+    .run(paneIdentity(paneKey))
+}
+
+export function hasWorkerTerminalUserInput(db: OrchestrationDb, paneKey: string): boolean {
+  return Boolean(
+    db.db
+      .prepare('SELECT 1 FROM worker_terminal_user_inputs WHERE pane_identity = ?')
+      .get(paneIdentity(paneKey))
+  )
+}

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-user-takeover.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-user-takeover.ts
@@ -1,10 +1,12 @@
 import { isEquivalentPaneKey } from '../pane-key-match'
 import type { OrchestrationDb } from '../orchestration-db'
+import { recordWorkerTerminalUserInputStatement } from './worker-terminal-user-input-latch'
 
 // Real user input durably relinquishes orchestration ownership.
 export function markWorkerTerminalUserOwned(this: OrchestrationDb, paneKey: string): number {
   this.db.exec('BEGIN IMMEDIATE')
   try {
+    recordWorkerTerminalUserInputStatement(this, paneKey)
     const exact = this.db
       .prepare(
         `SELECT id, owner_dispatch_id, pane_key FROM worker_terminal_resources

--- a/src/main/runtime/orchestration/worker-terminal-preclaim-user-input.test.ts
+++ b/src/main/runtime/orchestration/worker-terminal-preclaim-user-input.test.ts
@@ -1,0 +1,314 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../shared/protocol-version'
+import { OrchestrationDb } from './db'
+import { SCHEMA_VERSION } from './db/contract-constants'
+
+const PANE = 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const REMINTED = 'tab_reminted:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const IDENTITY = {
+  paneKey: PANE,
+  processIncarnation: 'runtime:pty:1',
+  worktreeId: 'folder_workspace',
+  hostScope: JSON.stringify({ kind: 'local', hostId: 'local' })
+}
+
+describe('user input before worker terminal ownership', () => {
+  let db: OrchestrationDb
+  let directory: string | undefined
+  let sequence: number
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    sequence = 0
+  })
+  afterEach(() => {
+    db.close()
+    if (directory) {
+      rmSync(directory, { recursive: true, force: true })
+      directory = undefined
+    }
+  })
+
+  function worker(
+    kind: 'local' | 'remote',
+    ownership: 'created' | 'external' = 'created',
+    paneKey = PANE
+  ) {
+    const terminalHandle = `term_worker_${++sequence}`
+    const common = {
+      ...IDENTITY,
+      paneKey,
+      terminalOwnership: ownership,
+      effects: [],
+      setupState: 'not_applicable'
+    }
+    if (kind === 'remote') {
+      const dispatchId = `ctx_remote_${sequence}`
+      db.createRemoteDispatchAttachment({
+        dispatchId,
+        taskId: `task_remote_${sequence}`,
+        homePeerFingerprint: 'home_peer',
+        protocolVersion: ORCHESTRATION_CONTRACT_VERSION,
+        runtimeEpoch: 'epoch_worker',
+        mutationReceipt: {
+          callerFingerprint: 'home_peer',
+          requestId: `request_${sequence}`,
+          method: 'orchestration.federationAttachStart',
+          payloadHash: `hash_${sequence}`
+        }
+      })
+      db.prepareRemoteAttachmentAuthority({ dispatchId, terminalHandle, ...common })
+      db.markRemoteAttachmentReady(dispatchId)
+      return { kind, dispatchId, taskId: `task_remote_${sequence}` }
+    }
+    const run = db.createRun({
+      objective: 'bounded worker run',
+      coordinatorHandle: 'term_coordinator',
+      coordinatorPaneKey: 'tab_coordinator:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    const task = db.createTask({ spec: 'bounded worker', runId: run.id })
+    const started = db.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: 1,
+      taskId: task.id,
+      startOptions: {}
+    })
+    db.prepareStartingWorkerAuthority({
+      dispatchId: started.dispatch.id,
+      handle: terminalHandle,
+      ...common
+    })
+    db.markWorkerDispatchReady(started.dispatch.id)
+    return { kind, dispatchId: started.dispatch.id, taskId: task.id }
+  }
+
+  function settle(value: ReturnType<typeof worker>) {
+    if (value.kind === 'remote') {
+      db.recordRemoteAttachmentStage({
+        dispatchId: value.dispatchId,
+        state: 'succeeded',
+        stage: 'worker_reported'
+      })
+    } else {
+      db.settleWorkerReport({
+        taskId: value.taskId,
+        dispatchId: value.dispatchId,
+        outcome: 'succeeded',
+        result: 'done'
+      })
+    }
+  }
+
+  it.each(['local', 'remote'] as const)(
+    'retains a newly claimed %s terminal after earlier input',
+    (kind) => {
+      expect(db.markWorkerTerminalUserOwned(PANE)).toBe(0)
+      const value = worker(kind)
+      settle(value)
+      expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)).toMatchObject({
+        ownership_state: 'user_owned',
+        release_state: 'retained',
+        retained_reason: 'user_takeover'
+      })
+      const release =
+        kind === 'local'
+          ? db.requestWorkerTerminalRelease(value.dispatchId)
+          : db.requestRemoteAttachmentTerminalRelease(value.dispatchId)
+      expect(release).toMatchObject({ disposition: 'retained', reason: 'user_takeover' })
+    }
+  )
+
+  it('recognizes the same stable leaf after tab reminting', () => {
+    db.markWorkerTerminalUserOwned(PANE)
+    const value = worker('remote', 'created', REMINTED)
+    expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)?.ownership_state).toBe(
+      'user_owned'
+    )
+  })
+
+  it('stores one identity hash without the pane credential and keeps the changed count precise', () => {
+    expect(db.markWorkerTerminalUserOwned(PANE)).toBe(0)
+    expect(db.markWorkerTerminalUserOwned(REMINTED)).toBe(0)
+    const rows = db.db.prepare('SELECT * FROM worker_terminal_user_inputs').all()
+    expect(rows).toEqual([
+      { pane_identity: expect.stringMatching(/^[a-f0-9]{64}$/), first_input_at: expect.any(String) }
+    ])
+    expect(JSON.stringify(rows)).not.toContain('bbbbbbbb')
+
+    const otherPane = 'tab_other:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    const value = worker('local', 'created', otherPane)
+    expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)?.ownership_state).toBe('owned')
+    expect(db.markWorkerTerminalUserOwned(otherPane)).toBe(1)
+    expect(db.markWorkerTerminalUserOwned(otherPane)).toBe(0)
+  })
+
+  it.each(['tab_legacy:1', 'unparseable-key'])(
+    'retains an exact legacy key %s without aliasing another key',
+    (paneKey) => {
+      db.markWorkerTerminalUserOwned(paneKey)
+      const same = worker('local', 'created', paneKey)
+      expect(db.getWorkerTerminalResourceByOwner(same.dispatchId)?.ownership_state).toBe(
+        'user_owned'
+      )
+      const other = worker('remote', 'created', `other_${paneKey}`)
+      expect(db.getWorkerTerminalResourceByOwner(other.dispatchId)?.ownership_state).toBe('owned')
+    }
+  )
+
+  it.each(['local', 'remote'] as const)(
+    'preserves ordinary %s ownership without user input',
+    (kind) => {
+      const value = worker(kind)
+      expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)).toMatchObject({
+        ownership_state: 'owned',
+        release_state: 'not_requested'
+      })
+    }
+  )
+
+  it.each(['local', 'remote'] as const)(
+    'does not promote or reclassify an external %s terminal',
+    (kind) => {
+      db.markWorkerTerminalUserOwned(PANE)
+      const value = worker(kind, 'external')
+      expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)).toMatchObject({
+        ownership_state: 'external',
+        retained_reason: 'external_terminal'
+      })
+    }
+  )
+
+  it('preserves exact owned transfer when no input was observed', () => {
+    const first = worker('local')
+    settle(first)
+    const resource = db.getWorkerTerminalResourceByOwner(first.dispatchId)!
+    const next = worker('remote', 'external', REMINTED)
+    expect(db.getWorkerTerminalResourceByOwner(next.dispatchId)).toMatchObject({
+      id: resource.id,
+      ownership_state: 'owned',
+      origin_dispatch_id: first.dispatchId
+    })
+  })
+
+  it('never transfers a stopped owner after input arrived during its committed stop', () => {
+    const first = worker('local')
+    db.beginWorkerStop(first.dispatchId, 'epoch_worker')
+    expect(db.markWorkerTerminalUserOwned(PANE)).toBe(0)
+    db.settleWorkerStop(first.dispatchId)
+    const resource = db.getWorkerTerminalResourceByOwner(first.dispatchId)!
+    const next = worker('remote', 'external', REMINTED)
+    expect(db.getWorkerTerminalResourceByOwner(next.dispatchId)).toMatchObject({
+      ownership_state: 'external'
+    })
+    expect(db.getWorkerTerminalResourceByOwner(first.dispatchId)?.id).toBe(resource.id)
+  })
+
+  it.each(['releasing', 'unknown'] as const)(
+    'still refuses reuse over %s release despite later input',
+    (state) => {
+      const first = worker('local')
+      settle(first)
+      const resource = db.requestWorkerTerminalRelease(first.dispatchId).resource!
+      db.commitWorkerTerminalArchiveForRelease({
+        dispatchId: first.dispatchId,
+        resourceId: resource.id,
+        kind: 'terminal_tail',
+        content: JSON.stringify({ lines: ['output'] }),
+        archiveSource: 'terminal',
+        archiveStatus: 'captured'
+      })
+      if (state === 'unknown') {
+        db.markWorkerTerminalReleaseUnknown(resource.id, 'unverified stop')
+      }
+      expect(db.markWorkerTerminalUserOwned(PANE)).toBe(0)
+      expect(() => worker('remote', 'external', REMINTED)).toThrow('release in progress')
+      expect(db.getWorkerTerminalResource(resource.id)?.release_state).toBe(state)
+    }
+  )
+
+  it('retains failed-start adoption after input before readiness failed', () => {
+    const task = db.createTask({ spec: 'failed readiness' })
+    const started = db.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: 1,
+      taskId: task.id,
+      startOptions: {}
+    })
+    db.recordWorkerStage({
+      dispatchId: started.dispatch.id,
+      stage: 'terminal_readying',
+      terminalHandle: 'term_failed'
+    })
+    db.markWorkerTerminalUserOwned(PANE)
+    db.failWorkerStart(started.dispatch.id, 'agent_readiness', 'not ready', {
+      adoptResidualTerminal: { terminalHandle: 'term_failed', ...IDENTITY }
+    })
+    expect(db.requestWorkerTerminalRelease(started.dispatch.id)).toMatchObject({
+      disposition: 'retained',
+      reason: 'user_takeover'
+    })
+  })
+
+  it('keeps input across database reopen before ownership is recorded', () => {
+    db.close()
+    directory = mkdtempSync(join(tmpdir(), 'orca-preclaim-input-'))
+    const filename = join(directory, 'orchestration.db')
+    db = new OrchestrationDb(filename)
+    db.markWorkerTerminalUserOwned(PANE)
+    db.close()
+    db = new OrchestrationDb(filename)
+    const value = worker('local')
+    expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)?.ownership_state).toBe(
+      'user_owned'
+    )
+  })
+
+  it('adds the latch to an existing schema without a version change, archive rebuild, or ownership backfill', () => {
+    db.close()
+    directory = mkdtempSync(join(tmpdir(), 'orca-preclaim-input-'))
+    const filename = join(directory, 'orchestration.db')
+    db = new OrchestrationDb(filename)
+    const value = worker('local')
+    const resource = db.getWorkerTerminalResourceByOwner(value.dispatchId)!
+    db.storeWorkerTerminalArchive({
+      dispatchId: value.dispatchId,
+      resourceId: resource.id,
+      kind: 'structured_journal',
+      content: '{"version":1}'
+    })
+    const archiveTable = db.db
+      .prepare("SELECT sql, rootpage FROM sqlite_master WHERE name = 'worker_terminal_archives'")
+      .get()
+    // Model a pre-latch schema-39 database, using only this disposable test database.
+    db.db.exec('DROP TABLE worker_terminal_user_inputs')
+    db.close()
+    db = new OrchestrationDb(filename)
+    expect(db.db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION)
+    expect(
+      db.db
+        .prepare("SELECT sql, rootpage FROM sqlite_master WHERE name = 'worker_terminal_archives'")
+        .get()
+    ).toEqual(archiveTable)
+    expect(db.getWorkerTerminalArchive(value.dispatchId)).toMatchObject({
+      kind: 'structured_journal',
+      content: '{"version":1}'
+    })
+    expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)).toEqual(resource)
+    expect(db.db.prepare('SELECT * FROM worker_terminal_user_inputs').all()).toEqual([])
+  })
+
+  it.each(['resetTasks', 'resetAll'] as const)(
+    'keeps input across %s because task reset does not retire panes',
+    (reset) => {
+      db.markWorkerTerminalUserOwned(PANE)
+      db[reset]()
+      const value = worker('local')
+      expect(db.getWorkerTerminalResourceByOwner(value.dispatchId)?.ownership_state).toBe(
+        'user_owned'
+      )
+    }
+  )
+})

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-release-receipt-validation.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-release-receipt-validation.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_FEDERATION_RELEASE_ARCHIVE_RUNTIME_CAPABILITY } from '../../../../../../shared/protocol-version'
+import type { OrcaRuntimeService } from '../../../../orca-runtime'
+import { OrchestrationDb } from '../../../../orchestration/db'
+import { parseRemoteReleaseReceipt, releaseFederatedWorker } from './federated-worker-release'
+
+const DISPATCH_ID = 'dispatch_receipt'
+const TERMINAL_HANDLE = 'term_remote_receipt'
+const server = {
+  environmentId: 'environment-worker',
+  name: 'worker',
+  peerFingerprint: 'peer-worker',
+  pairingRevision: 73
+}
+const released = {
+  dispatchId: DISPATCH_ID,
+  state: 'released',
+  processAction: 'closed_agent_terminal'
+}
+
+describe('federated release receipt consistency', () => {
+  let db: OrchestrationDb
+
+  beforeEach(() => {
+    db = new OrchestrationDb(':memory:')
+    db.db
+      .prepare(
+        `INSERT INTO worker_dispatches (dispatch_id, state, stage, agent_terminal_handle)
+         VALUES (?, 'succeeded', 'worker_reported', ?)`
+      )
+      .run(DISPATCH_ID, TERMINAL_HANDLE)
+    db.db
+      .prepare(
+        `INSERT INTO federated_dispatches
+         (dispatch_id, environment_id, environment_name, peer_fingerprint,
+          remote_runtime_epoch, remote_terminal_handle)
+         VALUES (?, ?, ?, ?, 'epoch-worker', ?)`
+      )
+      .run(DISPATCH_ID, server.environmentId, server.name, server.peerFingerprint, TERMINAL_HANDLE)
+  })
+
+  afterEach(() => db.close())
+
+  async function receive(receipt: unknown) {
+    const callOrchestrationWorkerServer = vi.fn(async (_selector, method: string) =>
+      method === 'status.get'
+        ? {
+            runtimeId: 'epoch-worker',
+            capabilities: [ORCHESTRATION_FEDERATION_RELEASE_ARCHIVE_RUNTIME_CAPABILITY]
+          }
+        : receipt
+    )
+    const runtime = {
+      getOrchestrationDb: () => db,
+      callOrchestrationWorkerServer
+    } as unknown as OrcaRuntimeService
+    const result = await releaseFederatedWorker({
+      runtime,
+      server,
+      federated: db.getFederatedDispatch(DISPATCH_ID)!,
+      dispatchId: DISPATCH_ID,
+      requestId: 'release-original'
+    })
+    expect(callOrchestrationWorkerServer).toHaveBeenLastCalledWith(
+      server.environmentId,
+      'orchestration.federationRelease',
+      { dispatchId: DISPATCH_ID },
+      30_000,
+      { orchestrationRequestId: 'release-original' },
+      { expectedEnvironmentPairingRevision: server.pairingRevision }
+    )
+    return result
+  }
+
+  it.each([
+    { ...released, reason: 'user_takeover' },
+    { ...released, state: 'already_released' },
+    { ...released, output: { status: { liveness: 'live' } } },
+    { ...released, output: { status: { liveness: 'unverifiable' } } },
+    { ...released, output: { status: { terminal: 'running' } } },
+    {
+      ...released,
+      state: 'already_released',
+      processAction: 'none',
+      output: { status: { terminal: 'unknown' } }
+    }
+  ])(
+    'does not clear home ownership for a contradictory affirmative receipt %#',
+    async (receipt) => {
+      const result = await receive(receipt)
+      expect.soft(db.getWorkerDispatch(DISPATCH_ID)).toMatchObject({
+        state: 'succeeded',
+        stage: 'worker_reported',
+        agent_terminal_handle: TERMINAL_HANDLE
+      })
+      expect
+        .soft(db.getFederatedDispatch(DISPATCH_ID)?.remote_terminal_handle)
+        .toBe(TERMINAL_HANDLE)
+      expect(result).toMatchObject({
+        dispatchId: DISPATCH_ID,
+        state: 'release_unknown',
+        processAction: 'none',
+        lastError: expect.stringContaining('invalid release receipt')
+      })
+    }
+  )
+
+  it.each([
+    released,
+    { ...released, archive: null },
+    { ...released, archive: { source: null, status: 'unavailable' } },
+    { ...released, archive: { source: 'structured_journal', status: 'captured' } },
+    {
+      ...released,
+      futureField: { supported: true },
+      output: { source: 'future-source', status: { worker: 'succeeded' } }
+    },
+    {
+      ...released,
+      output: { status: { terminal: 'exited', liveness: 'exited', futureField: true } }
+    },
+    { ...released, state: 'already_released', processAction: 'none' },
+    { ...released, processAction: 'none' }
+  ])('keeps optional/additive release metadata compatible %#', async (receipt) => {
+    expect(parseRemoteReleaseReceipt(receipt, DISPATCH_ID)).toEqual(receipt)
+    expect(await receive(receipt)).toMatchObject({ state: receipt.state })
+    expect(db.getWorkerDispatch(DISPATCH_ID)).toMatchObject({
+      state: 'succeeded',
+      stage: 'released',
+      agent_terminal_handle: null
+    })
+    expect(db.getFederatedDispatch(DISPATCH_ID)?.remote_terminal_handle).toBeNull()
+  })
+
+  it('rejects a retained receipt that claims a process action', () => {
+    expect(() =>
+      parseRemoteReleaseReceipt({ ...released, state: 'retained' }, DISPATCH_ID)
+    ).toThrow('invalid release receipt')
+  })
+
+  it.each(['retained', 'release_pending', 'release_unknown'])(
+    'allows %s to preserve output without claiming exit',
+    (state) => {
+      const receipt = {
+        ...released,
+        state,
+        processAction: 'none',
+        ...(state === 'retained' ? { reason: 'future-retained-reason' } : {}),
+        output: { status: { terminal: 'running', liveness: 'live' } }
+      }
+      expect(parseRemoteReleaseReceipt(receipt, DISPATCH_ID)).toEqual(receipt)
+    }
+  )
+})

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-release.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-release.ts
@@ -37,6 +37,34 @@ const RemoteReleaseReceiptSchema = z
     output: z.unknown().optional()
   })
   .passthrough()
+  .refine((receipt) => {
+    if (
+      ((receipt.state === 'already_released' || receipt.state === 'retained') &&
+        receipt.processAction !== 'none') ||
+      (receipt.state !== 'retained' && receipt.reason !== undefined)
+    ) {
+      return false
+    }
+    return (
+      (receipt.state !== 'released' && receipt.state !== 'already_released') ||
+      !outputContradictsRelease(receipt.output)
+    )
+  })
+
+function outputContradictsRelease(output: unknown): boolean {
+  // Optional output stays optional, but an explicit non-exit cannot certify release.
+  if (!output || typeof output !== 'object' || !('status' in output)) {
+    return false
+  }
+  const status = output.status
+  if (!status || typeof status !== 'object') {
+    return false
+  }
+  return (
+    ('terminal' in status && status.terminal !== undefined && status.terminal !== 'exited') ||
+    ('liveness' in status && status.liveness !== undefined && status.liveness !== 'exited')
+  )
+}
 
 export async function releaseFederatedWorker(args: {
   runtime: OrcaRuntimeService


### PR DESCRIPTION
## ELI5

Worker cleanup should not reclaim a terminal the user already took over, or forget a remote worker because its release reply contradicts itself. This patch remembers early takeover reports and keeps contradictory release outcomes inspectable.

## What Changed

- Record the first reported user input as a fixed-size hash of the stable pane identity, before any terminal resource needs to exist.
- Consult that latch in the shared resource factory, covering local, federated, structured-worker and failed-start claims. A would-be owned claim becomes `user_owned / retained / user_takeover`; external resources remain external.
- Preserve takeover across tab reminting, restart and task resets. Keep release-in-progress rejection ahead of takeover-based transfer refusal.
- Reject inconsistent release receipts before changing the home worker stage or clearing either terminal reference. Explicit non-exit output cannot accompany a successful release; retained/already-released receipts cannot claim a new close.
- Add 37 regression cases and brief CLI documentation. No new RPC, capability, schema-version bump or historical ownership backfill.

## Why

The existing input reporter can successfully report before worker readiness/authority attachment, receive `changed: 0`, and throttle another report for 30 seconds. Updating only existing resources loses that observation. The durable latch stores no keystrokes or plaintext pane credentials, and `changed` still counts actual resource takeovers.

The current remote parser accepts individually valid but contradictory fields. Regression tests use a real isolated orchestration database to prove that these replies previously marked a worker released and cleared both home terminal references.

This extends the implementation merged in #16904 against upstream `9c8f4c39`; it does not reintroduce a parallel federation protocol.

## Linked Issue

Fixes #19276

## Visual Proof

N/A: no visual or layout change. These are backend ownership and receipt-validation safeguards; no renderer/UI input handling is changed.

## Testing

- [ ] Manually exercised installed applications or live remote terminals (not performed).
- [x] Automated regressions added, with red-before/green-after evidence.
- 19 preclaim cases and 18 receipt cases. Initial targeted runs reproduced eight takeover failures and seven receipt failures.
- Broader lifecycle/database/federation gate: **1,673 passed, 10 existing skipped**, across 190 passed files and two skipped files.
- Node, CLI and web TypeScript gates passed.
- Changed-code quality, type-aware quality and React Doctor passed with zero new findings; formatting, diff, max-lines, ts-nocheck and runtime/Electron ratchets passed.

Reproduce the broad source gate:

```sh
ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts --maxWorkers=4 \
  src/main/runtime/orchestration \
  src/main/runtime/rpc/methods/orchestration \
  src/main/runtime/rpc/orchestration-mutation-executor.test.ts \
  src/main/runtime/rpc/orchestration-runtime-update-settlement.test.ts \
  src/shared/orchestration-rpc-contract.test.ts
pnpm tc:node
pnpm tc:cli
pnpm tc:web
pnpm run check:code-quality:changed -- 9c8f4c398c3f8ba267cca14e0b65c3f6f87f2aa4
```

Local verification ran on macOS/Apple Silicon using the installed project executables directly, with `ORCA_BACKGROUND_LAUNCH=1`. No installed app launch/rebuild/restart, live database migration, remote worker or fleet qualification was performed. Full packaging/build, full-repository lint/test and real Linux/Windows/SSH execution remain for upstream CI/maintainer validation.

## AI Disclosure

Implemented with OpenAI Codex and independent agent reviews.

## Review

- **Security/data safety:** occurrence-only SHA-256 identity storage; no input text, credential collection, ownership backfill, runtime mutation or live data reset. Schema addition is non-destructive and preserves existing archives/resources.
- **Cross-platform:** Node crypto and SQLite only; no platform-specific spawn, path, shell or UI behavior added. Actual local test platform is macOS.
- **Local/remote/SSH:** shared local/federated resource entrypoints are covered. Existing capability negotiation, peer identity, pairing-revision fences and transport uncertainty remain unchanged. Optional/archive/additive receipt metadata remains accepted.
- **Agents/integrations/git providers:** provider-neutral changes; the shared factory also serves structured and failed-start resources. No agent/model, GitHub-specific runtime behavior or deployment changes.
- **Performance:** one primary-keyed, fixed-size record per reported pane and indexed lookups; no new polling, background loop or fleet scan. Existing input throttling and takeover-count semantics are unchanged.
- **UI:** no visual change; source tracing confirms normal PTY and structured input can reach the DB before resource claim.

## Agent skill upstream boundary

- [x] Not applicable: no agent skill source or documentation is copied or modified.

## Notes

- Scope is **input reports delivered to the owning runtime**. Previously lost input, failed transport reports, unavailable xterm user-input signals and the separate dashboard-preview producer gap are not reconstructed or fixed here.
- The input ledger deliberately survives task resets because a reset does not retire terminal panes.
- Exact native daemon incarnation-fenced stopping and broader release/retain crash-recovery work remain separate. Receipt consistency is not independent proof that a peer actually stopped its process.
- No workflow, release version, signature, installed app or fleet configuration changes are included. Source checks are developer-local; this fork's Actions are disabled and upstream CI is unchanged.

## Author

GitHub: @karoliang. X/Twitter: not supplied.

## Checklist

- [x] Focused on cleanup ownership and release-evidence safety.
- [x] Explained what changed and why.
- [x] N/A visual proof with reason.
- [x] Self-reviewed and independently reviewed for correctness, security and performance.
- [x] Cross-platform, SSH/remote, agent and integration impact considered.
- [ ] Full canonical `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` matrix completed; targeted local evidence above, remaining coverage requires upstream CI.
