### PR TITLE
fix(codex): distinguish personal and enterprise accounts sharing an email

### DIFF
--- a/src/main/codex-accounts/codex-auth-identity.ts
+++ b/src/main/codex-accounts/codex-auth-identity.ts
@@ -182,15 +182,40 @@ export function readCodexAuthIdentity(contents: string): CodexAuthIdentity | nul
         readStringClaim(authClaims, 'chatgpt_account_id') ??
         readStringClaim(payload, 'chatgpt_account_id')
     ),
-    workspaceLabel: normalizeField(
-      readStringClaim(authClaims, 'workspace_name') ??
-        readStringClaim(profileClaims, 'workspace_name')
-    ),
+    workspaceLabel:
+      normalizeField(readStringClaim(authClaims, 'workspace_name')) ??
+      normalizeField(readStringClaim(profileClaims, 'workspace_name')) ??
+      readPlanWorkspaceLabel(authClaims),
     workspaceAccountId: normalizeField(
       readStringClaim(authClaims, 'workspace_account_id') ??
         tokenAccountId ??
         readStringClaim(payload, 'chatgpt_account_id')
     )
+  }
+}
+
+function readPlanWorkspaceLabel(authClaims: Record<string, unknown> | null): string | null {
+  // Codex tokens commonly omit workspace_name but identify the account's plan.
+  switch (normalizeField(readStringClaim(authClaims, 'chatgpt_plan_type'))?.toLowerCase()) {
+    case 'free':
+      return 'Personal (Free)'
+    case 'go':
+      return 'Personal (Go)'
+    case 'plus':
+      return 'Personal (Plus)'
+    case 'pro':
+      return 'Personal (Pro)'
+    case 'team':
+      return 'Team'
+    case 'business':
+      return 'Business'
+    case 'enterprise':
+      return 'Enterprise'
+    case 'edu':
+      return 'Education'
+    case undefined:
+    default:
+      return null
   }
 }
 

--- a/src/main/codex-accounts/codex-auth-workspace-identity.test.ts
+++ b/src/main/codex-accounts/codex-auth-workspace-identity.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import type { CodexManagedAccount } from '../../shared/managed-account-types'
+import {
+  codexAuthMatchesManagedAccount,
+  codexAuthMatchesSystemDefaultIdentity,
+  readCodexAuthIdentity
+} from './codex-auth-identity'
+
+const email = 'same@example.com'
+
+function auth(
+  accountId: string,
+  claims: Record<string, unknown>,
+  profileClaims: Record<string, unknown> = {}
+): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      email,
+      'https://api.openai.com/auth': { chatgpt_account_id: accountId, ...claims },
+      'https://api.openai.com/profile': profileClaims
+    })
+  ).toString('base64url')
+  return JSON.stringify({
+    tokens: { account_id: accountId, id_token: `header.${payload}.signature` }
+  })
+}
+
+describe('Codex personal and organization workspace identity', () => {
+  it.each([
+    ['free', 'Personal (Free)'],
+    ['go', 'Personal (Go)'],
+    ['plus', 'Personal (Plus)'],
+    ['pro', 'Personal (Pro)'],
+    ['team', 'Team'],
+    ['business', 'Business'],
+    ['enterprise', 'Enterprise'],
+    ['edu', 'Education']
+  ])('uses the %s plan when the token omits the workspace name', (plan, label) => {
+    expect(readCodexAuthIdentity(auth('provider-1', { chatgpt_plan_type: plan }))).toEqual({
+      email,
+      providerAccountId: 'provider-1',
+      workspaceAccountId: 'provider-1',
+      workspaceLabel: label
+    })
+  })
+
+  it.each([undefined, null, '', 'future-plan', 42])(
+    'does not infer personal membership from an unknown plan %s',
+    (plan) => {
+      expect(
+        readCodexAuthIdentity(auth('provider-1', { chatgpt_plan_type: plan }))?.workspaceLabel
+      ).toBeNull()
+    }
+  )
+
+  it('preserves an explicit organization name over the plan label', () => {
+    expect(
+      readCodexAuthIdentity(
+        auth('provider-1', { workspace_name: ' Acme ', chatgpt_plan_type: 'enterprise' })
+      )?.workspaceLabel
+    ).toBe('Acme')
+  })
+
+  it('uses the profile workspace name when the auth workspace name is blank', () => {
+    expect(
+      readCodexAuthIdentity(
+        auth(
+          'provider-1',
+          { workspace_name: ' ', chatgpt_plan_type: 'enterprise' },
+          { workspace_name: 'Acme' }
+        )
+      )?.workspaceLabel
+    ).toBe('Acme')
+  })
+
+  it('keeps same-email personal and enterprise credentials isolated in both directions', () => {
+    const personal = auth('personal-provider', { chatgpt_plan_type: 'plus' })
+    const enterprise = auth('enterprise-provider', { chatgpt_plan_type: 'enterprise' })
+    for (const [selectedAuth, otherAuth] of [
+      [personal, enterprise],
+      [enterprise, personal]
+    ]) {
+      const identity = readCodexAuthIdentity(selectedAuth)!
+      const account: CodexManagedAccount = {
+        ...identity,
+        id: 'orca-account',
+        email,
+        managedHomePath: 'managed-home',
+        createdAt: 1,
+        updatedAt: 1,
+        lastAuthenticatedAt: 1
+      }
+      expect(codexAuthMatchesManagedAccount(selectedAuth, account, selectedAuth)).toBe(true)
+      expect(codexAuthMatchesManagedAccount(otherAuth, account, selectedAuth)).toBe(false)
+      expect(codexAuthMatchesSystemDefaultIdentity(otherAuth, selectedAuth)).toBe(false)
+    }
+    expect(readCodexAuthIdentity(personal)?.workspaceLabel).toBe('Personal (Plus)')
+    expect(readCodexAuthIdentity(enterprise)?.workspaceLabel).toBe('Enterprise')
+  })
+
+  it('does not treat a matching plan label as proof of account ownership', () => {
+    const first = auth('enterprise-a', { chatgpt_plan_type: 'enterprise' })
+    const second = auth('enterprise-b', { chatgpt_plan_type: 'enterprise' })
+    expect(codexAuthMatchesSystemDefaultIdentity(first, second)).toBe(false)
+  })
+})

--- a/src/main/codex-accounts/runtime-home-per-account-homes.test.ts
+++ b/src/main/codex-accounts/runtime-home-per-account-homes.test.ts
@@ -87,64 +87,67 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.getHostCodexHomePathsForSessionDiscovery()).toContain(managedHomePath)
   })
 
-  it('gives two managed accounts distinct homes without racing one auth.json', async () => {
-    writeFileSync(getSystemCodexAuthPath(), '{"account":"system"}\n', 'utf-8')
-    const account1Auth = createCodexAuthJson('one@example.com', 'acct-1', 'one')
-    const account2Auth = createCodexAuthJson('two@example.com', 'acct-2', 'two')
-    const home1 = createManagedAuth(testState.userDataDir, 'account-1', account1Auth)
-    const home2 = createManagedAuth(testState.userDataDir, 'account-2', account2Auth)
-    const settings = createSettings({
-      shellStartupEnvProbeSupported: true,
-      codexManagedAccounts: [
-        {
-          id: 'account-1',
-          email: 'one@example.com',
-          managedHomePath: home1,
-          providerAccountId: 'acct-1',
-          workspaceLabel: null,
-          workspaceAccountId: 'acct-1',
-          createdAt: 1,
-          updatedAt: 1,
-          lastAuthenticatedAt: 1
-        },
-        {
-          id: 'account-2',
-          email: 'two@example.com',
-          managedHomePath: home2,
-          providerAccountId: 'acct-2',
-          workspaceLabel: null,
-          workspaceAccountId: 'acct-2',
-          createdAt: 2,
-          updatedAt: 2,
-          lastAuthenticatedAt: 2
-        }
-      ],
-      activeCodexManagedAccountId: 'account-1',
-      activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
-    })
-    const store = createStore(settings)
-    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-    const service = new CodexRuntimeHomeService(store as never)
-
-    // A pane for account-1 launches, then the user switches and a second pane
-    // for account-2 launches concurrently — each gets its OWN CODEX_HOME.
-    expect(service.prepareForCodexLaunch()).toBe(home1)
-    settings.activeCodexManagedAccountId = 'account-2'
-    settings.activeCodexManagedAccountIdsByRuntime = { host: 'account-2', wsl: {} }
-    expect(service.prepareForCodexLaunch()).toBe(home2)
-    expect(
-      service.prepareForCodexLaunch(undefined, undefined, {
-        unavailableManagedHomePath: home1
+  it.each(['two@example.com', 'one@example.com'])(
+    'isolates account homes when the second email is %s',
+    async (secondEmail) => {
+      writeFileSync(getSystemCodexAuthPath(), '{"account":"system"}\n', 'utf-8')
+      const account1Auth = createCodexAuthJson('one@example.com', 'acct-1', 'one')
+      const account2Auth = createCodexAuthJson(secondEmail, 'acct-2', 'two')
+      const home1 = createManagedAuth(testState.userDataDir, 'account-1', account1Auth)
+      const home2 = createManagedAuth(testState.userDataDir, 'account-2', account2Auth)
+      const settings = createSettings({
+        shellStartupEnvProbeSupported: true,
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'one@example.com',
+            managedHomePath: home1,
+            providerAccountId: 'acct-1',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-1',
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          },
+          {
+            id: 'account-2',
+            email: secondEmail,
+            managedHomePath: home2,
+            providerAccountId: 'acct-2',
+            workspaceLabel: null,
+            workspaceAccountId: 'acct-2',
+            createdAt: 2,
+            updatedAt: 2,
+            lastAuthenticatedAt: 2
+          }
+        ],
+        activeCodexManagedAccountId: 'account-1',
+        activeCodexManagedAccountIdsByRuntime: { host: 'account-1', wsl: {} }
       })
-    ).toBe(home2)
-    expect(store.updateSettings).not.toHaveBeenCalled()
+      const store = createStore(settings)
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
 
-    // Nothing is hot-swapped, so the still-running account-1 pane keeps seeing
-    // account-1's credentials — the single-auth.json race (GAP-5) is gone.
-    expect(readFileSync(join(home1, 'auth.json'), 'utf-8')).toBe(account1Auth)
-    expect(readFileSync(join(home2, 'auth.json'), 'utf-8')).toBe(account2Auth)
-    expect(existsSync(getRuntimeCodexAuthPath())).toBe(false)
-  })
+      // A pane for account-1 launches, then the user switches and a second pane
+      // for account-2 launches concurrently — each gets its OWN CODEX_HOME.
+      expect(service.prepareForCodexLaunch()).toBe(home1)
+      settings.activeCodexManagedAccountId = 'account-2'
+      settings.activeCodexManagedAccountIdsByRuntime = { host: 'account-2', wsl: {} }
+      expect(service.prepareForCodexLaunch()).toBe(home2)
+      expect(
+        service.prepareForCodexLaunch(undefined, undefined, {
+          unavailableManagedHomePath: home1
+        })
+      ).toBe(home2)
+      expect(store.updateSettings).not.toHaveBeenCalled()
+
+      // Nothing is hot-swapped, so the still-running account-1 pane keeps seeing
+      // account-1's credentials — the single-auth.json race (GAP-5) is gone.
+      expect(readFileSync(join(home1, 'auth.json'), 'utf-8')).toBe(account1Auth)
+      expect(readFileSync(join(home2, 'auth.json'), 'utf-8')).toBe(account2Auth)
+      expect(existsSync(getRuntimeCodexAuthPath())).toBe(false)
+    }
+  )
 
   it('materializes resources and config into the per-account home on launch', async () => {
     writeFileSync(getSystemCodexAuthPath(), '{"account":"system"}\n', 'utf-8')

--- a/src/main/codex-accounts/service-add-account-from-home.test.ts
+++ b/src/main/codex-accounts/service-add-account-from-home.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -28,6 +28,74 @@ vi.mock('node:os', async () => {
 
 describe('CodexAccountService.addAccountFromHome', () => {
   registerCodexAccountsTestHomes()
+
+  it('imports and switches personal and enterprise accounts sharing an email independently', async () => {
+    vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))
+    const sourceHomes = [
+      mkdtempSync(join(tmpdir(), 'orca-codex-personal-')),
+      mkdtempSync(join(tmpdir(), 'orca-codex-enterprise-'))
+    ]
+    const email = 'same@example.com'
+    const credentials = ['plus', 'enterprise'].map((plan) => {
+      const parsed = JSON.parse(createCodexAuthJson(email, `provider-${plan}`, `refresh-${plan}`))
+      const payload = Buffer.from(
+        JSON.stringify({
+          email,
+          'https://api.openai.com/auth': {
+            chatgpt_account_id: `provider-${plan}`,
+            chatgpt_plan_type: plan
+          }
+        })
+      ).toString('base64url')
+      parsed.tokens.id_token = `header.${payload}.signature`
+      return JSON.stringify(parsed)
+    })
+
+    try {
+      sourceHomes.forEach((home, index) => {
+        writeFileSync(join(home, 'auth.json'), credentials[index], 'utf-8')
+      })
+      const store = createStore(createSettings())
+      const runtimeHome = createRuntimeHome()
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        createRateLimits() as never,
+        runtimeHome as never
+      )
+
+      await service.addAccountFromHome(sourceHomes[0])
+      const result = await service.addAccountFromHome(sourceHomes[1])
+      const accounts = store.getSettings().codexManagedAccounts
+      expect(result.accounts).toHaveLength(2)
+      expect(new Set(accounts.map((account) => account.id)).size).toBe(2)
+      expect(new Set(accounts.map((account) => account.managedHomePath)).size).toBe(2)
+      expect(accounts.map((account) => account.email)).toEqual([email, email])
+      expect(accounts.map((account) => account.workspaceLabel)).toEqual([
+        'Personal (Plus)',
+        'Enterprise'
+      ])
+      expect(accounts.map((account) => account.providerAccountId)).toEqual([
+        'provider-plus',
+        'provider-enterprise'
+      ])
+
+      for (const account of accounts) {
+        const selected = await service.selectAccount(account.id)
+        expect(selected.activeAccountId).toBe(account.id)
+        expect(store.getSettings().activeCodexManagedAccountIdsByRuntime?.host).toBe(account.id)
+        accounts.forEach((entry, index) => {
+          expect(readFileSync(join(entry.managedHomePath, 'auth.json'), 'utf-8')).toBe(
+            credentials[index]
+          )
+        })
+      }
+      expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalledTimes(4)
+    } finally {
+      sourceHomes.forEach((home) => rmSync(home, { recursive: true, force: true }))
+      vi.doUnmock('../codex-cli/command')
+    }
+  })
 
   it('registers a managed Codex account by importing an authenticated CODEX_HOME', async () => {
     vi.doMock('../codex-cli/command', () => ({ resolveCodexCommand: () => 'codex' }))

--- a/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
@@ -1,6 +1,7 @@
 import { Loader2, RefreshCw, Trash2 } from 'lucide-react'
 import type { CodexRateLimitAccountsState } from '../../../../shared/managed-account-types'
 import { translate } from '@/i18n/i18n'
+import { getCodexAccountDisplayDetail } from '@/lib/codex-account-display-label'
 import { selectCodexProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
 import { Button } from '../ui/button'
@@ -48,6 +49,7 @@ export function renderCodexAccountRow(
         accountId: account.id
       })
   const needsReauthentication = Boolean(accountAuthWarning)
+  const accountDetail = getCodexAccountDisplayDetail(account, codexAccounts.accounts)
   const isReauthing = codexAction === `reauth:${account.id}`
   const isRemoving = codexAction === `remove:${account.id}`
   const isBusy = codexAction !== 'idle' || accountRuntimeUnavailable
@@ -111,6 +113,12 @@ export function renderCodexAccountRow(
               needsReauthentication ? 'text-destructive' : 'text-muted-foreground'
             }`}
           >
+            {accountDetail ? (
+              <>
+                <span className="break-all">{accountDetail}</span>
+                <span className="shrink-0 opacity-50">•</span>
+              </>
+            ) : null}
             {needsReauthentication ? (
               <span className="truncate">
                 {translate(
@@ -118,12 +126,8 @@ export function renderCodexAccountRow(
                   'Codex reported this sign-in is out of date'
                 )}
               </span>
-            ) : account.workspaceLabel ? (
-              <span className="truncate">{account.workspaceLabel}</span>
             ) : null}
-            {needsReauthentication || account.workspaceLabel ? (
-              <span className="shrink-0 opacity-50">•</span>
-            ) : null}
+            {needsReauthentication ? <span className="shrink-0 opacity-50">•</span> : null}
             <span className="shrink-0">{formatAccountTimestamp(account.lastAuthenticatedAt)}</span>
           </div>
         </button>

--- a/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
@@ -115,7 +115,7 @@ export function renderCodexAccountRow(
           >
             {accountDetail ? (
               <>
-                <span className="break-all">{accountDetail}</span>
+                <span className="min-w-0 break-words">{accountDetail}</span>
                 <span className="shrink-0 opacity-50">•</span>
               </>
             ) : null}

--- a/src/renderer/src/components/status-bar/CodexSwitcherMenu.tsx
+++ b/src/renderer/src/components/status-bar/CodexSwitcherMenu.tsx
@@ -239,7 +239,7 @@ export function CodexSwitcherMenu({
                     >
                       <div className="flex w-full min-w-0 flex-col gap-0.5">
                         <div className="flex min-w-0 items-center gap-2">
-                          <span className="min-w-0 flex-1 whitespace-normal break-all">
+                          <span className="min-w-0 flex-1 whitespace-normal break-words">
                             {target.label}
                           </span>
                           {target.active ? (

--- a/src/renderer/src/components/status-bar/CodexSwitcherMenu.tsx
+++ b/src/renderer/src/components/status-bar/CodexSwitcherMenu.tsx
@@ -239,7 +239,9 @@ export function CodexSwitcherMenu({
                     >
                       <div className="flex w-full min-w-0 flex-col gap-0.5">
                         <div className="flex min-w-0 items-center gap-2">
-                          <span className="min-w-0 flex-1 truncate">{target.label}</span>
+                          <span className="min-w-0 flex-1 whitespace-normal break-all">
+                            {target.label}
+                          </span>
                           {target.active ? (
                             <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
                               {translate(

--- a/src/renderer/src/components/status-bar/codex-status-sign-in.test.tsx
+++ b/src/renderer/src/components/status-bar/codex-status-sign-in.test.tsx
@@ -207,6 +207,42 @@ describe('status bar Codex sign-in action', () => {
     cleanup()
   })
 
+  it.each([null, 'Enterprise'])(
+    'selects the exact same-email account when workspace labels collide: %s',
+    async (workspaceLabel) => {
+      storeSettings.codexManagedAccounts = storeSettings.codexManagedAccounts.map((account) => ({
+        ...account,
+        email: 'same@example.com',
+        workspaceLabel
+      }))
+      const { selectCodexProviderAccount } =
+        await import('@/runtime/runtime-provider-accounts-client')
+      vi.mocked(selectCodexProviderAccount).mockResolvedValueOnce({
+        accounts: storeSettings.codexManagedAccounts,
+        activeAccountId: 'account-2',
+        activeAccountIdsByRuntime: { host: 'account-2', wsl: {} }
+      })
+
+      await renderSwitcherAndOpenAccounts('System default')
+      const detail = workspaceLabel ? `${workspaceLabel} · ` : ''
+      expect(screen.getByText(`same@example.com (${detail}account-1)`)).toBeTruthy()
+      fireEvent.click(screen.getByText(`same@example.com (${detail}account-2)`))
+
+      await waitFor(() =>
+        expect(selectCodexProviderAccount).toHaveBeenCalledWith(storeSettings, {
+          accountId: 'account-2',
+          runtime: 'host',
+          wslDistro: null
+        })
+      )
+      expect(markLiveCodexSessionsForRestart).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nextAccountId: 'account-2'
+        })
+      )
+    }
+  )
+
   it('activates the signed-in account and runs the same restart workflow a switch runs', async () => {
     reauthenticate.mockResolvedValue(codexSnapshot('account-2'))
 

--- a/src/renderer/src/components/status-bar/status-bar-codex-accounts.ts
+++ b/src/renderer/src/components/status-bar/status-bar-codex-accounts.ts
@@ -93,7 +93,7 @@ export function buildCodexStatusSwitchGroups(
         },
         ...accountsForTarget.map((account) => ({
           id: account.id,
-          label: getCodexAccountDisplayLabel(account, state.accounts),
+          label: getCodexAccountDisplayLabel(account, accountsForTarget),
           active: account.id === activeId,
           runtimeTarget: target
         }))

--- a/src/renderer/src/components/status-bar/status-bar-codex-accounts.ts
+++ b/src/renderer/src/components/status-bar/status-bar-codex-accounts.ts
@@ -1,6 +1,7 @@
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { CodexRateLimitAccountsState } from '../../../../shared/managed-account-types'
 import { translate } from '@/i18n/i18n'
+import { getCodexAccountDisplayLabel } from '@/lib/codex-account-display-label'
 import {
   getCodexStatusRuntimeKey,
   getCodexStatusRuntimeLabel,
@@ -11,10 +12,6 @@ import {
 } from './status-bar-runtime-targets'
 
 type CodexStatusAccount = CodexRateLimitAccountsState['accounts'][number]
-
-function getCodexAccountDisplayLabel(account: CodexStatusAccount): string {
-  return account.workspaceLabel ? `${account.email} (${account.workspaceLabel})` : account.email
-}
 
 function getSingleConcreteCodexWslDistro(state: CodexRateLimitAccountsState): string | null {
   const keys = new Set<string>()
@@ -96,7 +93,7 @@ export function buildCodexStatusSwitchGroups(
         },
         ...accountsForTarget.map((account) => ({
           id: account.id,
-          label: getCodexAccountDisplayLabel(account),
+          label: getCodexAccountDisplayLabel(account, state.accounts),
           active: account.id === activeId,
           runtimeTarget: target
         }))

--- a/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
@@ -55,6 +55,39 @@ describe('status bar runtime switch groups', () => {
     }
   )
 
+  it('keeps one email plain when its only same-email peer sits in another runtime group', () => {
+    const state: CodexRateLimitAccountsState = {
+      accounts: [
+        {
+          id: 'account-host',
+          email: 'same@example.com',
+          managedHomeRuntime: 'host',
+          wslDistro: null,
+          workspaceLabel: 'Personal (Plus)',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        },
+        {
+          id: 'account-wsl',
+          email: 'same@example.com',
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          workspaceLabel: 'Personal (Plus)',
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ],
+      activeAccountId: null,
+      activeAccountIdsByRuntime: { host: null, wsl: { Ubuntu: null } }
+    }
+    const groups = buildCodexStatusSwitchGroups(state, { runtime: 'host', wslDistro: null })
+    expect(groups.flatMap((group) => group.targets.slice(1).map((target) => target.label))).toEqual(
+      ['same@example.com (Personal (Plus))', 'same@example.com (Personal (Plus))']
+    )
+  })
+
   it('collapses WSL default into the single concrete Codex distro', () => {
     const state: CodexRateLimitAccountsState = {
       accounts: [

--- a/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-runtime-groups.test.ts
@@ -15,6 +15,46 @@ import {
 const hostLabel = navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
 
 describe('status bar runtime switch groups', () => {
+  it.each(['host', 'wsl'] as const)(
+    'keeps same-email accounts independently selectable in the %s runtime',
+    (runtime) => {
+      const state: CodexRateLimitAccountsState = {
+        accounts: ['account-a', 'account-b'].map((id) => ({
+          id,
+          email: 'same@example.com',
+          managedHomeRuntime: runtime,
+          wslDistro: runtime === 'wsl' ? 'Ubuntu' : null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        })),
+        activeAccountId: runtime === 'host' ? 'account-b' : null,
+        activeAccountIdsByRuntime: {
+          host: runtime === 'host' ? 'account-b' : null,
+          wsl: runtime === 'wsl' ? { Ubuntu: 'account-b' } : {}
+        }
+      }
+      const target = { runtime, wslDistro: runtime === 'wsl' ? 'Ubuntu' : null }
+      const group = buildCodexStatusSwitchGroups(state, target).find(
+        (entry) => entry.runtimeTarget.runtime === runtime
+      )!
+      expect(group.targets.slice(1)).toEqual([
+        {
+          id: 'account-a',
+          label: 'same@example.com (account-a)',
+          active: false,
+          runtimeTarget: target
+        },
+        {
+          id: 'account-b',
+          label: 'same@example.com (account-b)',
+          active: true,
+          runtimeTarget: target
+        }
+      ])
+    }
+  )
+
   it('collapses WSL default into the single concrete Codex distro', () => {
     const state: CodexRateLimitAccountsState = {
       accounts: [

--- a/src/renderer/src/lib/codex-account-display-label.test.ts
+++ b/src/renderer/src/lib/codex-account-display-label.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getCodexAccountDisplayLabel,
+  type CodexDisplayAccount
+} from './codex-account-display-label'
+
+const email = 'same@example.com'
+const labels = (accounts: CodexDisplayAccount[]) =>
+  accounts.map((account) => getCodexAccountDisplayLabel(account, accounts))
+
+describe('Codex account display labels', () => {
+  it('names personal and enterprise workspaces sharing an email', () => {
+    expect(
+      labels([
+        { id: 'personal', email, workspaceLabel: 'Personal (Plus)' },
+        { id: 'enterprise', email, workspaceLabel: 'Enterprise' }
+      ])
+    ).toEqual([`${email} (Personal (Plus))`, `${email} (Enterprise)`])
+  })
+
+  it.each([null, 'Enterprise'])(
+    'disambiguates missing or duplicate workspace names: %s',
+    (workspaceLabel) => {
+      const accounts = [
+        { id: '12345678-a', email, workspaceLabel },
+        { id: '12345678-b', email, workspaceLabel }
+      ]
+      const result = labels(accounts)
+      expect(new Set(result).size).toBe(2)
+      expect(result[0]).toContain('12345678-a')
+      expect(result[1]).toContain('12345678-b')
+      expect(labels(accounts.toReversed())).toEqual(result.toReversed())
+    }
+  )
+
+  it('handles legacy and remote summaries without workspace metadata', () => {
+    expect(
+      labels([
+        { id: 'account-a', email },
+        { id: 'account-b', email: email.toUpperCase() }
+      ])
+    ).toEqual([`${email} (account-a)`, `${email.toUpperCase()} (account-b)`])
+  })
+
+  it('keeps unambiguous accounts concise', () => {
+    expect(labels([{ id: 'account-a', email }])).toEqual([email])
+    expect(labels([{ id: 'account-a', email, workspaceLabel: 'Acme' }])).toEqual([
+      `${email} (Acme)`
+    ])
+  })
+
+  it('does not collide with a workspace name that looks like an ID suffix', () => {
+    const result = labels([
+      { id: '12345678-a', email },
+      { id: '87654321-b', email },
+      { id: 'abcdefgh-c', email, workspaceLabel: '12345678' }
+    ])
+    expect(new Set(result).size).toBe(3)
+  })
+})

--- a/src/renderer/src/lib/codex-account-display-label.ts
+++ b/src/renderer/src/lib/codex-account-display-label.ts
@@ -4,15 +4,19 @@ export type CodexDisplayAccount = {
   workspaceLabel?: string | null
 }
 
+// Emails round-trip through persisted settings and remote summaries; tolerate a missing one.
+export function normalizeCodexAccountEmail(email: string | null | undefined): string {
+  return (email ?? '').trim().toLowerCase()
+}
+
 export function getCodexAccountDisplayDetail(
   account: CodexDisplayAccount,
   accounts: readonly CodexDisplayAccount[]
 ): string | null {
   const workspace = account.workspaceLabel?.trim() || null
+  const email = normalizeCodexAccountEmail(account.email)
   const peers = accounts.filter(
-    (entry) =>
-      entry.id !== account.id &&
-      entry.email.trim().toLowerCase() === account.email.trim().toLowerCase()
+    (entry) => entry.id !== account.id && normalizeCodexAccountEmail(entry.email) === email
   )
   const workspaces = [workspace, ...peers.map((entry) => entry.workspaceLabel?.trim() || null)]
   if (

--- a/src/renderer/src/lib/codex-account-display-label.ts
+++ b/src/renderer/src/lib/codex-account-display-label.ts
@@ -1,0 +1,43 @@
+export type CodexDisplayAccount = {
+  id: string
+  email: string
+  workspaceLabel?: string | null
+}
+
+export function getCodexAccountDisplayDetail(
+  account: CodexDisplayAccount,
+  accounts: readonly CodexDisplayAccount[]
+): string | null {
+  const workspace = account.workspaceLabel?.trim() || null
+  const peers = accounts.filter(
+    (entry) =>
+      entry.id !== account.id &&
+      entry.email.trim().toLowerCase() === account.email.trim().toLowerCase()
+  )
+  const workspaces = [workspace, ...peers.map((entry) => entry.workspaceLabel?.trim() || null)]
+  if (
+    peers.length === 0 ||
+    (workspaces.every(Boolean) && new Set(workspaces).size === workspaces.length)
+  ) {
+    return workspace
+  }
+
+  // Extend the stored account ID prefix until even same-prefix accounts are distinguishable.
+  let length = Math.min(8, account.id.length)
+  while (
+    length < account.id.length &&
+    peers.some((entry) => entry.id.slice(0, length) === account.id.slice(0, length))
+  ) {
+    length += 1
+  }
+  const identifier = account.id.slice(0, length)
+  return workspace ? `${workspace} · ${identifier}` : identifier
+}
+
+export function getCodexAccountDisplayLabel(
+  account: CodexDisplayAccount,
+  accounts: readonly CodexDisplayAccount[]
+): string {
+  const detail = getCodexAccountDisplayDetail(account, accounts)
+  return detail ? `${account.email} (${detail})` : account.email
+}

--- a/src/renderer/src/lib/codex-session-restart.ts
+++ b/src/renderer/src/lib/codex-session-restart.ts
@@ -6,6 +6,7 @@ import {
   type RuntimeTerminalProcessInspection
 } from '@/runtime/runtime-terminal-inspection'
 import { translate } from '@/i18n/i18n'
+import { getCodexAccountDisplayLabel } from './codex-account-display-label'
 import { isShellProcess } from '../../../shared/shell-process-detection'
 import {
   isCodexForegroundProcess,
@@ -326,13 +327,7 @@ export async function markRestoredStaleCodexSessionsForRestart(args?: {
   return scans.map((scan) => (notifiedPtyIds.has(scan.ptyId) ? { ...scan, notified: true } : scan))
 }
 
-/**
- * Names an account for the restart prompt.
- *
- * Why the collision check: one OpenAI login added under two ChatGPT workspaces
- * gives both accounts the same email, and "switch from x@y to x@y" names
- * neither. The workspace is appended only when it is what tells them apart.
- */
+// Same-email accounts need the same workspace or ID distinction as the switcher.
 export function resolveCodexRestartPromptAccountLabel(
   accounts: readonly { id: string; email: string; workspaceLabel?: string | null }[],
   accountId: string | null | undefined
@@ -345,11 +340,11 @@ export function resolveCodexRestartPromptAccountLabel(
     return translate('auto.lib.codex.session.restart.9f0b1c2d3e', 'Codex account')
   }
   const sharesEmail = accounts.some(
-    (entry) => entry.id !== account.id && entry.email === account.email
+    (entry) =>
+      entry.id !== account.id &&
+      entry.email.trim().toLowerCase() === account.email.trim().toLowerCase()
   )
-  return sharesEmail && account.workspaceLabel
-    ? `${account.email} (${account.workspaceLabel})`
-    : account.email
+  return sharesEmail ? getCodexAccountDisplayLabel(account, accounts) : account.email
 }
 
 async function createCodexAccountLabelResolver(): Promise<(accountId: string | null) => string> {

--- a/src/renderer/src/lib/codex-session-restart.ts
+++ b/src/renderer/src/lib/codex-session-restart.ts
@@ -6,7 +6,10 @@ import {
   type RuntimeTerminalProcessInspection
 } from '@/runtime/runtime-terminal-inspection'
 import { translate } from '@/i18n/i18n'
-import { getCodexAccountDisplayLabel } from './codex-account-display-label'
+import {
+  getCodexAccountDisplayLabel,
+  normalizeCodexAccountEmail
+} from './codex-account-display-label'
 import { isShellProcess } from '../../../shared/shell-process-detection'
 import {
   isCodexForegroundProcess,
@@ -339,10 +342,9 @@ export function resolveCodexRestartPromptAccountLabel(
   if (!account) {
     return translate('auto.lib.codex.session.restart.9f0b1c2d3e', 'Codex account')
   }
+  const email = normalizeCodexAccountEmail(account.email)
   const sharesEmail = accounts.some(
-    (entry) =>
-      entry.id !== account.id &&
-      entry.email.trim().toLowerCase() === account.email.trim().toLowerCase()
+    (entry) => entry.id !== account.id && normalizeCodexAccountEmail(entry.email) === email
   )
   return sharesEmail ? getCodexAccountDisplayLabel(account, accounts) : account.email
 }

--- a/src/renderer/src/lib/codex-stale-pane-account-identity.test.ts
+++ b/src/renderer/src/lib/codex-stale-pane-account-identity.test.ts
@@ -80,7 +80,7 @@ describe('stale Codex panes are decided by account id, not label', () => {
     }
   })
 
-  it('keeps the prompt when the two accounts resolve to the same label', async () => {
+  it('distinguishes same-email accounts even without workspace names', async () => {
     vi.mocked(window.api.codexAccounts.listStalePanes).mockResolvedValue([
       { ptyId: 'pty-1', launchAccountId: 'account-a', activeAccountId: 'account-b' }
     ])
@@ -88,6 +88,8 @@ describe('stale Codex panes are decided by account id, not label', () => {
     const scans = await markRestoredStaleCodexSessionsForRestart()
 
     expect(noticeFor('pty-1')).toMatchObject({
+      previousAccountLabel: `${SHARED_EMAIL} (account-a)`,
+      nextAccountLabel: `${SHARED_EMAIL} (account-b)`,
       previousAccountId: 'account-a',
       nextAccountId: 'account-b'
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​406 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​348 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |

<!-- /orca-pr-loc -->

## ELI5

Personal and enterprise Codex accounts can share an email address. The switcher now gives them distinct labels so you can tell which account you are selecting.

## What Changed

- Use the token's known ChatGPT plan as a label when OpenAI omits the workspace name (for example, Personal (Plus) or Enterprise). Explicit workspace names take precedence; unknown plans are not guessed.
- When same-email entries lack distinct workspace names, append stable Orca account IDs, extending shared prefixes until they differ. Reuse the distinction in settings and restart prompts.
- Wrap switcher labels so the distinguishing suffix remains visible.

## Why

Accounts already have separate IDs and credential homes; email-only presentation hid that distinction. Regression tests now exercise importing and switching personal/enterprise accounts with the same email, preserving both credentials, rejecting cross-account auth readback, and passing the clicked row's exact account ID.

Existing saved accounts receive ID suffixes immediately. Plan labels are captured on the next reauthentication/import; no account migration or additional credential polling is introduced. Account summaries from older remote hosts remain supported.

## Linked Issue

Fixes #18696

## Visual Proof

Hidden macOS Electron renderer via Playwright CDP, using synthetic same-email accounts with missing workspace names and colliding ID prefixes. Before uses the base switcher source; after uses this change, with identical fixture data.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/a990fe22-6fba-4e0d-899b-1e27fe9e1e6b) | ![After](https://github.com/user-attachments/assets/08376792-2472-4678-bb79-96eec4d4fd7d) |

## Testing

- [x] Tested the rendered switcher locally through Playwright CDP with `ORCA_BACKGROUND_LAUNCH=1` and an isolated profile.
- [x] Automated tests added/updated: 72 tests passed across nine targeted suites, including host/WSL grouping, duplicate/missing labels, actual switcher clicks, import/selection, credential isolation, and API-key identity guards.
- `pnpm tc` passed.
- `pnpm run check:code-quality:changed` passed with zero new findings; commit lint/format hooks passed.
- Electron development main/preload build and renderer startup passed.
- Actual platform: macOS. Native Windows/Linux, a live SSH host, and real personal/enterprise OAuth sign-ins were not exercised. WSL cases use automated fixtures. Production build and full-suite checks are left to CI.

## Review

- [x] Self-reviewed identity matching, legacy account behavior, remote-summary compatibility, and ID prefix collisions.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill material is copied.

## Notes

The test-backed guarantee is distinct choices for same-email managed accounts and selection by account ID. This does not claim end-to-end validation of OpenAI's OAuth workspace picker.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Targeted local validation passed; CI will cover full lint/test/production build checks
