### PR TITLE
fix(native-chat): ignore IME confirmation Enter in the AskUserQuestion free-text field

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.ime-enter.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.ime-enter.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NativeChatQuestionCard } from './NativeChatQuestionCard'
+import type { AskPrompt } from './native-chat-interactive-prompt'
+
+// The "Other" free-text row submits on Enter. A CJK IME also uses Enter to
+// confirm a conversion candidate, so that keydown must be ignored or the
+// answer is delivered mid-composition with a half-converted value (#17820).
+
+let container: HTMLDivElement
+let root: ReturnType<typeof createRoot>
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+const tabsOrSpaces: AskPrompt = {
+  questions: [
+    {
+      question: 'Do you prefer tabs or spaces?',
+      header: 'Indent',
+      multiSelect: false,
+      options: [{ label: 'Tabs' }, { label: 'Spaces' }]
+    }
+  ]
+}
+
+function renderCard(onAnswer: (...args: unknown[]) => void): HTMLInputElement {
+  act(() => {
+    root.render(
+      <NativeChatQuestionCard
+        prompt={tabsOrSpaces}
+        onAnswer={onAnswer}
+        onCancel={() => {}}
+        allowOther
+      />
+    )
+  })
+  const input = container.querySelector('input')
+  if (!input) {
+    throw new Error('free-text input not rendered')
+  }
+  return input
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!
+    setter.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+function pressKey(
+  input: HTMLInputElement,
+  type: 'keydown' | 'keyup',
+  init?: KeyboardEventInit & { keyCode?: number }
+): void {
+  const event = new KeyboardEvent(type, {
+    key: 'Enter',
+    bubbles: true,
+    cancelable: true,
+    ...init
+  })
+  Object.defineProperty(event, 'keyCode', { value: init?.keyCode ?? 13 })
+  act(() => {
+    input.dispatchEvent(event)
+  })
+}
+
+// The carry armed by a confirm Enter expires on the next animation frame after keyup.
+async function flushFrame(): Promise<void> {
+  await act(() => new Promise((resolve) => setTimeout(resolve, 30)))
+}
+
+describe('NativeChatQuestionCard free-text IME Enter guard', () => {
+  it('does not submit on the Enter that confirms a CJK IME composition (isComposing)', () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    typeInto(input, '日本語')
+
+    pressKey(input, 'keydown', { isComposing: true })
+
+    expect(onAnswer).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on the macOS-shaped confirm Enter (isComposing and keyCode 229)', () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    typeInto(input, '日本語')
+
+    pressKey(input, 'keydown', { isComposing: true, keyCode: 229 })
+
+    expect(onAnswer).not.toHaveBeenCalled()
+  })
+
+  it('does not submit on an Enter the IME reports only as keyCode 229', () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    typeInto(input, '日本語')
+
+    pressKey(input, 'keydown', { keyCode: 229 })
+
+    expect(onAnswer).not.toHaveBeenCalled()
+  })
+
+  it('swallows the unmarked Enter macOS redispatches right after a confirm', () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    typeInto(input, '日本語')
+
+    pressKey(input, 'keydown', { isComposing: true, keyCode: 229 })
+    pressKey(input, 'keyup', { isComposing: false })
+    pressKey(input, 'keydown', { isComposing: false })
+
+    expect(onAnswer).not.toHaveBeenCalled()
+  })
+
+  it('submits the next deliberate Enter once the confirm gesture has expired', async () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    typeInto(input, '日本語')
+
+    pressKey(input, 'keydown', { isComposing: true, keyCode: 229 })
+    pressKey(input, 'keyup', { isComposing: false })
+    await flushFrame()
+    pressKey(input, 'keydown', { isComposing: false })
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [], other: '日本語' }])
+  })
+
+  it('releases composition ownership on blur even when compositionend is omitted', () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    act(() => {
+      input.dispatchEvent(new Event('compositionstart', { bubbles: true }))
+    })
+    typeInto(input, '日本語')
+    act(() => {
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+
+    pressKey(input, 'keydown', { isComposing: false })
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [], other: '日本語' }])
+  })
+
+  it('still submits the typed text on a plain Enter', () => {
+    const onAnswer = vi.fn()
+    const input = renderCard(onAnswer)
+    typeInto(input, '日本語')
+
+    pressKey(input, 'keydown', { isComposing: false })
+
+    expect(onAnswer).toHaveBeenCalledWith([{ indices: [], other: '日本語' }])
+  })
+})

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
@@ -2,6 +2,10 @@ import { useState, type RefObject } from 'react'
 import { Check, Pencil, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import {
+  isImeCompositionKeyDown,
+  useImeEnterGestureOwnership
+} from '@/lib/ime-composition-keyboard-event'
 import type { AskAnswerSelection, AskPrompt } from './native-chat-interactive-prompt'
 
 export type NativeChatQuestionCardProps = {
@@ -38,6 +42,7 @@ export function NativeChatQuestionCard({
   // unique, while Claude's selector commits the numbered row (STA-1860).
   const [selections, setSelections] = useState<number[][]>(() => prompt.questions.map(() => []))
   const [otherText, setOtherText] = useState<string[]>(() => prompt.questions.map(() => ''))
+  const imeEnter = useImeEnterGestureOwnership()
 
   const total = prompt.questions.length
   const isLast = index === total - 1
@@ -198,11 +203,20 @@ export function NativeChatQuestionCard({
                     value={otherText[index]}
                     onChange={(e) => setOther(index, e.target.value)}
                     onKeyDown={(e) => {
+                      // Why: a CJK confirm Enter arrives twice and only the first is marked, so
+                      // pair the marked check with the gesture carry (#17820).
+                      if (imeEnter.ownsKeyDown(e) || isImeCompositionKeyDown(e)) {
+                        return
+                      }
                       if (e.key === 'Enter') {
                         e.preventDefault()
                         confirm(true)
                       }
                     }}
+                    onKeyUp={imeEnter.onKeyUp}
+                    onBlur={imeEnter.reset}
+                    onCompositionStart={() => imeEnter.setComposing(true)}
+                    onCompositionEnd={() => imeEnter.setComposing(false)}
                     placeholder={translate(
                       'components.native-chat.question.otherPlaceholder',
                       'Type your answer'


### PR DESCRIPTION
## ELI5

Japanese, Chinese and Korean keyboards use Enter to *confirm* a converted word before it is really typed. The "Other" answer box in the AskUserQuestion card treated that confirm-Enter as "send", so the answer was sent while the user was still choosing the word. Now that Enter only confirms the word, and the next Enter sends.

## What Changed

- `NativeChatQuestionCard.tsx`: the free-text ("Other") input's `onKeyDown` now returns early when the keydown belongs to the IME, using the existing helpers `useImeEnterGestureOwnership` + `isImeCompositionKeyDown` from `@/lib/ime-composition-keyboard-event`. The input also wires `onKeyUp` / `onCompositionStart` / `onCompositionEnd` so the gesture carry works, and `onBlur={imeEnter.reset}` so a composition that never sees `compositionend` (paste replaced it, the row unmounted) cannot leave the card swallowing every later Enter. This is the same pairing `ComposerParentWorktreePicker` uses, plus the blur reset `NativeChatComposerField` and the tab-bar search field already do.
- `NativeChatQuestionCard.ime-enter.test.tsx` (new): seven cases. `isComposing` alone, `isComposing` + `keyCode 229`, `keyCode 229` alone, and the macOS "marked Enter → keyup → unmarked Enter" sequence do not submit; the next deliberate Enter after the carry expires does submit; blur without `compositionend` releases ownership; a plain Enter still submits the typed text. Removing `onKeyUp` or `onBlur` from the input fails a test.

No behavior change for non-IME input: a plain Enter submits exactly as before, and an empty-field Enter stays a no-op.

## Why

The handler only checked `e.key === 'Enter'`, so the confirm keystroke and the submit keystroke were indistinguishable. Every other Enter-to-commit input in Orca (workspace name, rename fields, comment composer, search bar) already guards this; the question card was the one left out. Using the shared helpers rather than a bare `isComposing` check also covers macOS, where the confirm redispatches an unmarked Enter after keyup (see the comment in `ime-composition-keyboard-event.ts`).

Note: #17820 is assigned to @nwparker — apologies if this crosses an in-flight branch. It is a small, self-contained change, so I hope it is useful as-is; happy to close it in favor of yours otherwise.

## Linked Issue

Fixes #17820

## Visual Proof

Chat UI, Japanese locale, macOS. In the "Other" field, `にほんご` is typed through the IME and converted to `日本語` (underlined = still composing), then Enter is pressed to confirm the conversion.

**After, with a real IME (Google Japanese Input), by hand:**

| Candidates open | Converted, still composing | After the confirming Enter |
|---|---|---|
| ![candidates](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/06-real-ime-candidates.png) | ![converted](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/07-real-ime-converted-composing.png) | ![stays open](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/08-real-ime-after-confirm-enter-stays.png) |

The confirming Enter commits `日本語` into the field and nothing is sent; the card stays open with "Submit".

**Before vs. after, same scripted input on both builds:**

| | Composing `日本語` | After the confirming Enter |
|---|---|---|
| **Before** (`main`) | ![before: composing](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/01-before-composing.png) | ![before: submitted mid-composition](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/02-before-confirm-enter-submitted.png) <br> Submitted immediately — the card flips to "Sending…" while the IME is still open. |
| **After** (this PR) | ![after: composing](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/03-after-composing.png) | ![after: stays open](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/04-after-confirm-enter-stays.png) <br> Enter only confirms `日本語`; the card stays open with "Submit". |

A second, plain Enter then delivers the answer:

![after: delivered on plain Enter](https://raw.githubusercontent.com/tb-soshiro/orca/visual-proof-17820/05-after-plain-enter-delivered.png)

The before/after pair was captured on a `pnpm dev` build (before = the component hot-swapped to its `main` version). That composition was driven through CDP (`Input.imeSetComposition` + an Enter keydown with keyCode 229 while composing) so both runs are identical; the real-IME screenshots above show the same fixed build by hand.

## Testing

- macOS 26 (arm64), macOS built-in Japanese IME and Google Japanese Input, Claude Code in the Chat UI (terminal-backed path; the structured native chat path renders the same card).
- Reproduced the bug on the released 1.4.197 build, then confirmed the fix on a `pnpm dev` build of this branch.
- `pnpm lint` and `pnpm typecheck` pass locally. `pnpm test`: 7960 files / 73,846 tests pass; the one failing suite is `config/scripts/workflow-ref-reachability.test.mjs`, which needs `git init --ref-format=reftable` (git ≥ 2.45) and my machine has git 2.41 — unrelated to this change. `pnpm build` not run locally; relying on CI.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Code (Claude Fable 5.1) drafted the change and tests; I reviewed the diff and did the manual IME verification.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only change; no platform, SSH/remote, or mobile impact beyond the desktop card. Benefits all CJK IME users (Japanese, Chinese Pinyin/Zhuyin, Korean).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
