### PR TITLE
feat(codex): import usage credentials from Pi

### DIFF
--- a/docs/site/content/docs/agents/codex.mdx
+++ b/docs/site/content/docs/agents/codex.mdx
@@ -38,6 +38,8 @@ When Codex exits, the restart chip relaunches the agent with the same account. I
 
 Orca reads local Codex usage state for the active account and surfaces it in the status bar. See [Usage & rate-limit tracking](/docs/agents/usage-tracking).
 
+If [Pi](https://pi.dev) already owns your OpenAI Codex login, use **Settings → Accounts → Codex → Import from Pi**. Orca asks Pi for a current bearer token and reads usage directly, so this usage-only account does not require Codex CLI. Sign in again through Pi if it can no longer refresh the credential; if Pi switches to a different OpenAI account, import that account separately.
+
 ## Codex on Windows (WSL)
 
 On Windows, Orca can run Codex either from your host install or from a WSL distro. Add a WSL-hosted Codex account from the account switcher — Orca creates an isolated account home inside the distro (under `~/.local/share/orca/codex-accounts/<id>/home`), maps it back to the host as a `\\wsl.localhost\<distro>\...` path for auth reads, and routes launches, hot-swap, and rate-limit fetches through the selected distro. If Codex isn't installed in the target distro, the **Add account** dialog fails with an actionable message telling you which distro is missing the binary.

--- a/src/main/codex-accounts/codex-account-registration.ts
+++ b/src/main/codex-accounts/codex-account-registration.ts
@@ -16,6 +16,7 @@ import type { CodexAccountSelection } from './codex-account-selection'
 import type { CodexConfigMirror } from './codex-config-mirror'
 import type { CodexManagedHomeLifecycle } from './codex-managed-home-lifecycle'
 import type { CodexManagedHomePath } from './codex-managed-home-path'
+import { getPiCodexCredential, type PiCodexCredential } from './pi-codex-auth'
 import {
   getCodexSelectionTargetForAccount,
   getSelectedCodexAccountIdForTarget,
@@ -37,6 +38,7 @@ type CodexAccountRegistrationDependencies = {
   managedHomePaths: CodexManagedHomePath
   managedHomes: CodexManagedHomeLifecycle
   login: (managedHomePath: string) => Promise<void>
+  getPiCredential?: () => Promise<PiCodexCredential>
 }
 
 export class CodexAccountRegistration {
@@ -69,6 +71,39 @@ export class CodexAccountRegistration {
       return await this.persistCapturedAccount(accountId, managedHome)
     } catch (error) {
       this.dependencies.managedHomes.removeUnlessUnproven(error, managedHomePath, accountId)
+      throw error
+    }
+  }
+
+  async addFromPi(): Promise<CodexRateLimitAccountsState> {
+    const credential = await (this.dependencies.getPiCredential ?? getPiCodexCredential)()
+    const settings = this.dependencies.store.getSettings()
+    if (
+      settings.codexManagedAccounts.some(
+        (account) =>
+          (account.managedHomeRuntime ?? 'host') === 'host' &&
+          account.providerAccountId === credential.providerAccountId
+      )
+    ) {
+      throw new Error(`The Pi Codex account ${credential.email} is already imported.`)
+    }
+
+    const accountId = randomUUID()
+    const managedHome = await this.dependencies.managedHomes.create(accountId, { runtime: 'host' })
+    try {
+      this.prepareManagedHomeForLogin(managedHome.managedHomePath, accountId)
+      this.dependencies.managedHomes.importAuthFromPi(
+        credential,
+        managedHome.managedHomePath,
+        accountId
+      )
+      return await this.persistCapturedAccount(accountId, managedHome, 'pi')
+    } catch (error) {
+      this.dependencies.managedHomes.removeUnlessUnproven(
+        error,
+        managedHome.managedHomePath,
+        accountId
+      )
       throw error
     }
   }
@@ -145,7 +180,8 @@ export class CodexAccountRegistration {
 
   private async persistCapturedAccount(
     accountId: string,
-    managedHome: ManagedCodexHomeLocation
+    managedHome: ManagedCodexHomeLocation,
+    credentialSource?: 'pi'
   ): Promise<CodexRateLimitAccountsState> {
     const identity = this.dependencies.readIdentityFromHome(managedHome.managedHomePath, accountId)
     if (!identity.email) {
@@ -160,6 +196,7 @@ export class CodexAccountRegistration {
       wslDistro: managedHome.wslDistro,
       wslLinuxHomePath: managedHome.wslLinuxHomePath,
       providerAccountId: identity.providerAccountId,
+      credentialSource,
       workspaceLabel: identity.workspaceLabel,
       workspaceAccountId: identity.workspaceAccountId,
       createdAt: now,

--- a/src/main/codex-accounts/codex-account-service-types.ts
+++ b/src/main/codex-accounts/codex-account-service-types.ts
@@ -68,6 +68,7 @@ export function toCodexManagedAccountSummary(
     managedHomeRuntime: account.managedHomeRuntime ?? 'host',
     wslDistro: account.wslDistro ?? null,
     providerAccountId: account.providerAccountId ?? null,
+    credentialSource: account.credentialSource,
     workspaceLabel: account.workspaceLabel ?? null,
     workspaceAccountId: account.workspaceAccountId ?? null,
     createdAt: account.createdAt,

--- a/src/main/codex-accounts/codex-managed-home-lifecycle.ts
+++ b/src/main/codex-accounts/codex-managed-home-lifecycle.ts
@@ -13,6 +13,12 @@ import type { CodexAccountAddTarget, ManagedCodexHomeLocation } from './codex-ac
 import { writeFileAtomically } from './fs-utils'
 import { ManagedCodexHomeTemporarilyUnavailableError } from './host-codex-managed-home-ownership'
 import type { CodexManagedHomePath } from './codex-managed-home-path'
+import {
+  createCodexAuthJsonFromPiCredential,
+  PI_CODEX_AUTH_SOURCE_FILENAME,
+  serializePiCodexAuthSource,
+  type PiCodexCredential
+} from './pi-codex-auth'
 
 const WSL_MANAGED_HOME_TIMEOUT_MS = 5_000
 
@@ -77,6 +83,24 @@ export class CodexManagedHomeLifecycle {
     }
     const trustedHome = this.paths.assert(managedHomePath, accountId)
     writeFileAtomically(join(trustedHome, 'auth.json'), sourceAuthContents, { mode: 0o600 })
+  }
+
+  importAuthFromPi(
+    credential: PiCodexCredential,
+    managedHomePath: string,
+    accountId: string
+  ): void {
+    const trustedHome = this.paths.assert(managedHomePath, accountId)
+    writeFileAtomically(
+      join(trustedHome, 'auth.json'),
+      createCodexAuthJsonFromPiCredential(credential),
+      { mode: 0o600 }
+    )
+    writeFileAtomically(
+      join(trustedHome, PI_CODEX_AUTH_SOURCE_FILENAME),
+      serializePiCodexAuthSource({ providerAccountId: credential.providerAccountId }),
+      { mode: 0o600 }
+    )
   }
 
   /**

--- a/src/main/codex-accounts/pi-codex-auth.test.ts
+++ b/src/main/codex-accounts/pi-codex-auth.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readCodexAuthIdentity } from './codex-auth-identity'
+import {
+  createCodexAuthJsonFromPiCredential,
+  getPiCodexCredential,
+  parsePiCodexBearerToken
+} from './pi-codex-auth'
+
+function jwt(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`
+}
+
+const identityClaims = {
+  email: 'user@example.com',
+  exp: Math.floor(Date.now() / 1_000) + 3_600,
+  'https://api.openai.com/auth': { chatgpt_account_id: 'account-123' }
+}
+
+describe('Pi Codex auth', () => {
+  it('reads identity from the bearer token returned by Pi', async () => {
+    const accessToken = jwt(identityClaims)
+    const run = vi.fn().mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: `${accessToken}\n`,
+      stderr: '',
+      timedOut: false
+    })
+
+    await expect(
+      getPiCodexCredential(undefined, { resolveCommand: () => '/usr/local/bin/pi', run })
+    ).resolves.toEqual({
+      accessToken,
+      providerAccountId: 'account-123',
+      email: 'user@example.com'
+    })
+    expect(run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        program: '/usr/local/bin/pi',
+        args: ['auth', 'print-bearer-token', '--provider', 'openai-codex'],
+        timeoutMs: 15_000
+      })
+    )
+  })
+
+  it('creates Codex-shaped auth that preserves the Pi account identity', () => {
+    const accessToken = jwt(identityClaims)
+    expect(
+      readCodexAuthIdentity(
+        createCodexAuthJsonFromPiCredential({
+          accessToken,
+          providerAccountId: 'account-123',
+          email: 'user@example.com'
+        })
+      )
+    ).toMatchObject({ email: 'user@example.com', providerAccountId: 'account-123' })
+  })
+
+  it('rejects malformed and expired credentials', () => {
+    expect(() => parsePiCodexBearerToken('not-a-jwt')).toThrow(/without account identity/)
+    expect(() =>
+      parsePiCodexBearerToken(jwt({ ...identityClaims, exp: Math.floor(Date.now() / 1_000) - 1 }))
+    ).toThrow(/expired/)
+  })
+
+  it('reports a missing or signed-out Pi CLI without exposing command output', async () => {
+    await expect(
+      getPiCodexCredential(undefined, {
+        resolveCommand: () => 'pi',
+        run: vi
+          .fn()
+          .mockRejectedValue(Object.assign(new Error('spawn pi ENOENT'), { code: 'ENOENT' }))
+      })
+    ).rejects.toThrow(/Pi CLI was not found/)
+
+    await expect(
+      getPiCodexCredential(undefined, {
+        resolveCommand: () => 'pi',
+        run: vi.fn().mockResolvedValue({
+          code: 1,
+          signal: null,
+          stdout: '',
+          stderr: 'secret provider diagnostic',
+          timedOut: false
+        })
+      })
+    ).rejects.toThrow(/no usable OpenAI Codex login/)
+  })
+})

--- a/src/main/codex-accounts/pi-codex-auth.ts
+++ b/src/main/codex-accounts/pi-codex-auth.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { runProcess, type ProcessResult } from '../../shared/child-process/run-process'
+import { resolveCliCommand, withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
+
+export const PI_CODEX_AUTH_SOURCE_FILENAME = '.orca-pi-codex-auth.json'
+const PI_AUTH_TIMEOUT_MS = 15_000
+const OPENAI_AUTH_CLAIM = 'https://api.openai.com/auth'
+const OPENAI_PROFILE_CLAIM = 'https://api.openai.com/profile'
+
+type JsonRecord = Record<string, unknown>
+
+export type PiCodexAuthSource = {
+  providerAccountId: string
+}
+
+export type PiCodexCredential = {
+  accessToken: string
+  providerAccountId: string
+  email: string
+}
+
+type PiCodexAuthDependencies = {
+  resolveCommand?: () => string
+  run?: (args: Parameters<typeof runProcess>[0]) => Promise<ProcessResult>
+}
+
+function record(value: unknown): JsonRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as JsonRecord) : null
+}
+
+function stringClaim(value: JsonRecord | null, key: string): string | null {
+  const claim = value?.[key]
+  return typeof claim === 'string' && claim.trim() ? claim.trim() : null
+}
+
+function decodeJwtPayload(token: string): JsonRecord | null {
+  const payload = token.split('.')[1]
+  if (!payload) {
+    return null
+  }
+  try {
+    return record(JSON.parse(Buffer.from(payload, 'base64url').toString('utf8')))
+  } catch {
+    return null
+  }
+}
+
+export function parsePiCodexBearerToken(accessToken: string): PiCodexCredential {
+  const token = accessToken.trim()
+  const payload = decodeJwtPayload(token)
+  const auth = record(payload?.[OPENAI_AUTH_CLAIM])
+  const profile = record(payload?.[OPENAI_PROFILE_CLAIM])
+  const providerAccountId =
+    stringClaim(auth, 'chatgpt_account_id') ?? stringClaim(payload, 'chatgpt_account_id')
+  const email = stringClaim(payload, 'email') ?? stringClaim(profile, 'email')
+  const expiresAt = payload?.exp
+  if (typeof expiresAt === 'number' && expiresAt <= Date.now() / 1_000) {
+    throw new Error('Pi returned an expired Codex credential. Sign in again in Pi.')
+  }
+  if (!token || !providerAccountId || !email) {
+    throw new Error('Pi returned a Codex credential without account identity. Sign in again in Pi.')
+  }
+  return { accessToken: token, providerAccountId, email }
+}
+
+export async function getPiCodexCredential(
+  signal?: AbortSignal,
+  dependencies: PiCodexAuthDependencies = {}
+): Promise<PiCodexCredential> {
+  const command = (dependencies.resolveCommand ?? (() => resolveCliCommand('pi')))()
+  let result: ProcessResult
+  try {
+    result = await (dependencies.run ?? runProcess)({
+      program: command,
+      args: ['auth', 'print-bearer-token', '--provider', 'openai-codex'],
+      env: withCliRuntimeOnPath(command, { ...process.env }),
+      timeoutMs: PI_AUTH_TIMEOUT_MS,
+      maxOutputBytes: 64 * 1024,
+      signal
+    })
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    throw new Error(
+      code === 'ENOENT'
+        ? 'Pi CLI was not found. Install Pi and sign in to OpenAI Codex first.'
+        : 'Pi could not provide the OpenAI Codex credential.',
+      { cause: error }
+    )
+  }
+  if (signal?.aborted) {
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error('Pi credential request aborted.')
+  }
+  if (result.timedOut) {
+    throw new Error('Pi took too long to provide the OpenAI Codex credential.')
+  }
+  if (result.code !== 0) {
+    throw new Error(
+      'Pi has no usable OpenAI Codex login. Open Pi and run /login for ChatGPT Plus/Pro.'
+    )
+  }
+  return parsePiCodexBearerToken(result.stdout)
+}
+
+export function createCodexAuthJsonFromPiCredential(credential: PiCodexCredential): string {
+  return JSON.stringify(
+    {
+      auth_mode: 'chatgpt',
+      tokens: {
+        // Why: Orca's managed-account identity reader follows Codex's id_token
+        // slot, while Pi exposes only a bearer token. OpenAI's access JWT carries
+        // the same account/profile claims needed for local identity attribution.
+        id_token: credential.accessToken,
+        access_token: credential.accessToken,
+        account_id: credential.providerAccountId
+      },
+      last_refresh: new Date().toISOString()
+    },
+    null,
+    2
+  )
+}
+
+export function serializePiCodexAuthSource(source: PiCodexAuthSource): string {
+  return `${JSON.stringify(source)}\n`
+}
+
+export function hasPiCodexAuthSource(codexHomePath: string): boolean {
+  return existsSync(join(codexHomePath, PI_CODEX_AUTH_SOURCE_FILENAME))
+}
+
+export function readPiCodexAuthSource(codexHomePath: string): PiCodexAuthSource | null {
+  const markerPath = join(codexHomePath, PI_CODEX_AUTH_SOURCE_FILENAME)
+  if (!existsSync(markerPath)) {
+    return null
+  }
+  try {
+    const parsed = record(JSON.parse(readFileSync(markerPath, 'utf8')))
+    const providerAccountId = stringClaim(parsed, 'providerAccountId')
+    return providerAccountId ? { providerAccountId } : null
+  } catch {
+    return null
+  }
+}

--- a/src/main/codex-accounts/service-add-account-from-pi.test.ts
+++ b/src/main/codex-accounts/service-add-account-from-pi.test.ts
@@ -1,0 +1,108 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createRateLimits,
+  createRuntimeHome,
+  createSettings,
+  createStore,
+  registerCodexAccountsTestHomes,
+  testState
+} from './service-test-harness'
+
+const { getPiCodexCredentialMock } = vi.hoisted(() => ({
+  getPiCodexCredentialMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.userDataDir
+  }
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return {
+    ...actual,
+    homedir: () => testState.fakeHomeDir
+  }
+})
+
+vi.mock('./pi-codex-auth', async () => {
+  const actual = await vi.importActual<typeof import('./pi-codex-auth')>('./pi-codex-auth') // eslint-disable-line @typescript-eslint/consistent-type-imports -- vi.importActual requires inline import()
+  return { ...actual, getPiCodexCredential: getPiCodexCredentialMock }
+})
+
+import { CodexAccountService } from './service'
+import { PI_CODEX_AUTH_SOURCE_FILENAME } from './pi-codex-auth'
+
+function jwt(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`
+}
+
+describe('CodexAccountService.addAccountFromPi', () => {
+  registerCodexAccountsTestHomes()
+
+  it('registers a Pi-linked account without starting Codex login', async () => {
+    const credential = {
+      accessToken: jwt({
+        email: 'pi@example.com',
+        exp: Math.floor(Date.now() / 1_000) + 3_600,
+        'https://api.openai.com/auth': { chatgpt_account_id: 'pi-account' }
+      }),
+      providerAccountId: 'pi-account',
+      email: 'pi@example.com'
+    }
+    getPiCodexCredentialMock.mockResolvedValue(credential)
+    const settings = createSettings()
+    const store = createStore(settings)
+    const runtimeHome = createRuntimeHome()
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      runtimeHome as never
+    )
+
+    const result = await service.addAccountFromPi()
+
+    expect(result.accounts).toHaveLength(1)
+    expect(result.accounts[0]).toMatchObject({
+      email: 'pi@example.com',
+      providerAccountId: 'pi-account',
+      credentialSource: 'pi'
+    })
+    const managedHome = store.getSettings().codexManagedAccounts[0]!.managedHomePath
+    expect(existsSync(`${managedHome}/auth.json`)).toBe(true)
+    expect(
+      JSON.parse(readFileSync(`${managedHome}/${PI_CODEX_AUTH_SOURCE_FILENAME}`, 'utf8'))
+    ).toEqual({ providerAccountId: 'pi-account' })
+    expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
+  })
+
+  it('rejects a duplicate provider account before creating another home', async () => {
+    getPiCodexCredentialMock.mockResolvedValue({
+      accessToken: 'unused',
+      providerAccountId: 'existing-provider-account',
+      email: 'pi@example.com'
+    })
+    const settings = createSettings()
+    settings.codexManagedAccounts.push({
+      id: 'existing',
+      email: 'pi@example.com',
+      managedHomePath: `${testState.userDataDir}/codex-accounts/existing/home`,
+      managedHomeRuntime: 'host',
+      providerAccountId: 'existing-provider-account',
+      createdAt: 1,
+      updatedAt: 1,
+      lastAuthenticatedAt: 1
+    })
+    const store = createStore(settings)
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      createRuntimeHome() as never
+    )
+
+    await expect(service.addAccountFromPi()).rejects.toThrow(/already imported/)
+    expect(store.getSettings().codexManagedAccounts).toHaveLength(1)
+  })
+})

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -177,10 +177,18 @@ export class CodexAccountService {
     return this.serializeMutation(() => this.registration.addFromHome(sourceHome, target))
   }
 
+  async addAccountFromPi(): Promise<CodexRateLimitAccountsState> {
+    return this.serializeMutation(() => this.registration.addFromPi())
+  }
+
   async reauthenticateAccount(
     accountId: string,
     options?: CodexAccountReauthenticateOptions
   ): Promise<CodexRateLimitAccountsState> {
+    const account = this.listAccounts().accounts.find((entry) => entry.id === accountId)
+    if (account?.credentialSource === 'pi') {
+      throw new Error('This account is managed by Pi. Sign in again through Pi instead.')
+    }
     return this.serializeMutation(() => this.registration.reauthenticate(accountId, options))
   }
 

--- a/src/main/ipc/codex-accounts.ts
+++ b/src/main/ipc/codex-accounts.ts
@@ -38,6 +38,7 @@ export function registerCodexAccountHandlers(
   ipcMain.handle('codexAccounts:add', (_event, args?: CodexAccountAddTarget) =>
     codexAccounts.addAccount(args)
   )
+  ipcMain.handle('codexAccounts:importPi', () => codexAccounts.addAccountFromPi())
   ipcMain.handle(
     'codexAccounts:reauthenticate',
     (_event, args: { accountId: string; activateIfSelectionWasEmpty?: boolean }) =>

--- a/src/main/rate-limits/codex-backend-auth.ts
+++ b/src/main/rate-limits/codex-backend-auth.ts
@@ -6,6 +6,11 @@ import {
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
 import type { CodexRateLimitFetchOptions } from './codex-rate-limit-fetch-options'
+import {
+  getPiCodexCredential,
+  hasPiCodexAuthSource,
+  readPiCodexAuthSource
+} from '../codex-accounts/pi-codex-auth'
 
 const BACKEND_TIMEOUT_MS = 10_000
 
@@ -78,8 +83,27 @@ export async function getCodexBackendAuthHeaders(
   if (signal.aborted) {
     return null
   }
-  const authPath = join(getCodexHomePath(options?.codexHomePath), 'auth.json')
-  const auth = JSON.parse(await readBackendAuth(authPath, signal)) as CodexAuthFile
+  const codexHomePath = getCodexHomePath(options?.codexHomePath)
+  const piSource = readPiCodexAuthSource(codexHomePath)
+  if (hasPiCodexAuthSource(codexHomePath) && !piSource) {
+    throw new Error('The Pi-linked Codex account metadata is invalid. Import the account again.')
+  }
+  const authPath = join(codexHomePath, 'auth.json')
+  const auth = piSource
+    ? await getPiCodexCredential(signal).then((credential): CodexAuthFile => {
+        if (credential.providerAccountId !== piSource.providerAccountId) {
+          throw new Error(
+            'Pi is signed in to a different Codex account. Remove this account and import it again.'
+          )
+        }
+        return {
+          tokens: {
+            access_token: credential.accessToken,
+            account_id: credential.providerAccountId
+          }
+        }
+      })
+    : (JSON.parse(await readBackendAuth(authPath, signal)) as CodexAuthFile)
   const accessToken = auth.tokens?.access_token
   if (!accessToken) {
     return null

--- a/src/main/rate-limits/codex-fetcher-pi.test.ts
+++ b/src/main/rate-limits/codex-fetcher-pi.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, getPiCodexCredentialMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  getPiCodexCredentialMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
+vi.mock('node-pty', () => ({ spawn: ptySpawnMock }))
+vi.mock('../codex-accounts/pi-codex-auth', () => ({
+  hasPiCodexAuthSource: () => true,
+  readPiCodexAuthSource: () => ({ providerAccountId: 'account-123' }),
+  getPiCodexCredential: getPiCodexCredentialMock
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+describe('Pi-linked Codex rate-limit requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getPiCodexCredentialMock.mockResolvedValue({
+      accessToken: 'pi-access-token',
+      providerAccountId: 'account-123',
+      email: 'user@example.com'
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses Pi auth and the direct backend without launching Codex', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          plan_type: 'plus',
+          rate_limit: {
+            primary_window: { used_percent: 12, limit_window_seconds: 18_000 },
+            secondary_window: { used_percent: 34, limit_window_seconds: 604_800 }
+          },
+          rate_limit_reset_credits: { available_count: 0, credits: [] }
+        })
+      } as Response)
+    )
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '/managed/pi/home' })
+    ).resolves.toMatchObject({
+      status: 'ok',
+      planType: 'plus',
+      session: { usedPercent: 12 },
+      weekly: { usedPercent: 34 }
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://chatgpt.com/backend-api/wham/usage',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer pi-access-token',
+          'ChatGPT-Account-Id': 'account-123'
+        })
+      })
+    )
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a different Pi account without falling back to Codex', async () => {
+    getPiCodexCredentialMock.mockResolvedValue({
+      accessToken: 'other-access-token',
+      providerAccountId: 'other-account',
+      email: 'other@example.com'
+    })
+    vi.stubGlobal('fetch', vi.fn())
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '/managed/pi/home' })
+    ).resolves.toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('different Codex account')
+    })
+    expect(fetch).not.toHaveBeenCalled()
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to Codex on backend 401', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 401, body: { cancel: vi.fn() } } as never)
+    )
+
+    await expect(
+      fetchCodexRateLimits({ codexHomePath: '/managed/pi/home' })
+    ).resolves.toMatchObject({
+      status: 'error',
+      error: expect.stringContaining('Pi Codex usage is unavailable')
+    })
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -38,6 +38,7 @@ import {
   resolveHiddenRateLimitPtyCwd
 } from './hidden-rate-limit-pty-cwd'
 import { quoteHiddenRateLimitShellValue } from './hidden-rate-limit-shell'
+import { hasPiCodexAuthSource } from '../codex-accounts/pi-codex-auth'
 
 const RPC_TIMEOUT_MS = 10_000
 const WSL_RPC_TIMEOUT_MS = 25_000
@@ -189,6 +190,25 @@ export async function fetchCodexRateLimits(
 ): Promise<ProviderRateLimits> {
   if (options?.signal?.aborted) {
     return abortedCodexRateLimitResult()
+  }
+  if (options?.codexHomePath && hasPiCodexAuthSource(options.codexHomePath)) {
+    try {
+      const result = await fetchCodexRateLimitsViaBackend(fetchCodexUsage, options)
+      if (options.signal?.aborted) {
+        return abortedCodexRateLimitResult()
+      }
+      return result
+        ? supplementCodexRateLimitResetCredits(result, fetchCodexResetCredits, options)
+        : codexUnavailable('Pi Codex usage is unavailable. Check your Pi login.', 'error')
+    } catch (error) {
+      if (options.signal?.aborted) {
+        return abortedCodexRateLimitResult()
+      }
+      return codexUnavailable(
+        error instanceof Error ? error.message : 'Pi Codex usage is unavailable',
+        'error'
+      )
+    }
   }
   const authPresence = await probeCodexAuthPresence(options?.codexHomePath, {
     signal: options?.signal

--- a/src/preload/api/agent-account-api.ts
+++ b/src/preload/api/agent-account-api.ts
@@ -11,6 +11,7 @@ export type CodexAccountsApi = {
     runtime?: 'host' | 'wsl'
     wslDistro?: string | null
   }) => Promise<CodexRateLimitAccountsState>
+  importPi: () => Promise<CodexRateLimitAccountsState>
   reauthenticate: (args: {
     accountId: string
     /** Local-only: activate the re-authed account when its runtime lane had no selection. */

--- a/src/preload/api/codex-accounts-bridge.ts
+++ b/src/preload/api/codex-accounts-bridge.ts
@@ -5,6 +5,7 @@ export const codexAccountsApi = {
   list: () => ipcRenderer.invoke('codexAccounts:list'),
   add: (args?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null }) =>
     ipcRenderer.invoke('codexAccounts:add', args),
+  importPi: () => ipcRenderer.invoke('codexAccounts:importPi'),
   reauthenticate: (args: { accountId: string; activateIfSelectionWasEmpty?: boolean }) =>
     ipcRenderer.invoke('codexAccounts:reauthenticate', args),
   remove: (args: { accountId: string }) => ipcRenderer.invoke('codexAccounts:remove', args),

--- a/src/renderer/src/components/settings/accounts-pane-account-actions.ts
+++ b/src/renderer/src/components/settings/accounts-pane-account-actions.ts
@@ -72,6 +72,14 @@ export function createCodexAccountActionRunner(
       const next = await operation()
       await syncCodexAccounts(next)
       recordFeatureInteraction('codex-account-switching')
+      if (action === 'importing-pi') {
+        toast.success(
+          translate(
+            'auto.components.settings.AccountsPane.piImportSuccess',
+            'Imported Codex usage from Pi.'
+          )
+        )
+      }
       const nextActiveAccountId = getProviderAccountActiveIdForView(next, actionRuntime)
       const shouldPromptRestart =
         action === 'adding' ||

--- a/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-account-row.tsx
@@ -91,6 +91,22 @@ export function renderCodexAccountRow(
             >
               {getCodexAccountRuntimeLabel(account, accountRuntime.label)}
             </Badge>
+            {account.credentialSource === 'pi' ? (
+              <>
+                <Badge
+                  variant="outline"
+                  className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/70"
+                >
+                  {translate('auto.components.settings.AccountsPane.piLinked', 'Pi-linked')}
+                </Badge>
+                <Badge
+                  variant="outline"
+                  className="h-4 shrink-0 rounded px-1.5 text-[10px] font-medium leading-none text-foreground/70"
+                >
+                  {translate('auto.components.settings.AccountsPane.usageOnly', 'Usage only')}
+                </Badge>
+              </>
+            ) : null}
             {isActive ? (
               <Badge
                 variant="outline"
@@ -121,13 +137,27 @@ export function renderCodexAccountRow(
             ) : null}
             {needsReauthentication ? (
               <span className="truncate">
+                {account.credentialSource === 'pi'
+                  ? translate(
+                      'auto.components.settings.AccountsPane.piSignInOutOfDate',
+                      'Pi could not refresh this sign-in'
+                    )
+                  : translate(
+                      'auto.components.settings.AccountsPane.3d245ef7d9',
+                      'Codex reported this sign-in is out of date'
+                    )}
+              </span>
+            ) : account.credentialSource === 'pi' ? (
+              <span className="truncate">
                 {translate(
-                  'auto.components.settings.AccountsPane.3d245ef7d9',
-                  'Codex reported this sign-in is out of date'
+                  'auto.components.settings.AccountsPane.piUsageDescription',
+                  'Usage refreshes through Pi; Codex CLI is not used'
                 )}
               </span>
             ) : null}
-            {needsReauthentication ? <span className="shrink-0 opacity-50">•</span> : null}
+            {needsReauthentication || account.credentialSource === 'pi' ? (
+              <span className="shrink-0 opacity-50">•</span>
+            ) : null}
             <span className="shrink-0">{formatAccountTimestamp(account.lastAuthenticatedAt)}</span>
           </div>
         </button>
@@ -136,30 +166,32 @@ export function renderCodexAccountRow(
           {/* Why: selecting an account is the primary action in this row.
           Keeping maintenance actions visually lighter prevents re-auth/remove
           controls from overpowering the selection affordance in a dense list. */}
-          <Button
-            variant="ghost"
-            size="xs"
-            onClick={(event) => {
-              event.stopPropagation()
-              void runCodexAccountAction(
-                `reauth:${account.id}`,
-                () =>
-                  window.api.codexAccounts.reauthenticate({
-                    accountId: account.id
-                  }),
-                getProviderAccountRuntime(account)
-              )
-            }}
-            disabled={isRemoteAccountScope || isBusy}
-            className="h-6 px-2 text-muted-foreground hover:text-foreground"
-          >
-            {isReauthing ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <RefreshCw className="size-3" />
-            )}
-            {translate('auto.components.settings.AccountsPane.8a0f870153', 'Re-authenticate')}
-          </Button>
+          {account.credentialSource !== 'pi' ? (
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={(event) => {
+                event.stopPropagation()
+                void runCodexAccountAction(
+                  `reauth:${account.id}`,
+                  () =>
+                    window.api.codexAccounts.reauthenticate({
+                      accountId: account.id
+                    }),
+                  getProviderAccountRuntime(account)
+                )
+              }}
+              disabled={isRemoteAccountScope || isBusy}
+              className="h-6 px-2 text-muted-foreground hover:text-foreground"
+            >
+              {isReauthing ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3" />
+              )}
+              {translate('auto.components.settings.AccountsPane.8a0f870153', 'Re-authenticate')}
+            </Button>
+          ) : null}
           <Button
             variant="ghost"
             size="xs"

--- a/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
+++ b/src/renderer/src/components/settings/accounts-pane-codex-section.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Loader2, Plus } from 'lucide-react'
+import { AlertTriangle, Download, Loader2, Plus } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
 import { selectCodexProviderAccount } from '@/runtime/runtime-provider-accounts-client'
 import { Badge } from '../ui/badge'
@@ -18,6 +18,7 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
     accountRuntimeUnavailable,
     activeCodexAccountId,
     activeCodexAuthWarning,
+    codexAccounts,
     codexAction,
     codexConfigSync,
     codexConfigSyncWarning,
@@ -32,6 +33,9 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
     visibleCodexAccounts,
     wslCapabilitiesLoading
   } = model
+  const activeCodexAccountIsPi = codexAccounts.accounts.some(
+    (account) => account.id === activeCodexAccountId && account.credentialSource === 'pi'
+  )
   return (
     <section key="codex-accounts" id="accounts-codex" className="space-y-4 scroll-mt-6">
       <div className="space-y-1">
@@ -92,10 +96,15 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
                     { value0: accountRuntimeSentenceLabel }
                   )
                 : activeCodexAccountId
-                  ? translate(
-                      'auto.components.settings.AccountsPane.75ca9b718e',
-                      'Codex reported that the active account needs a fresh sign-in. Re-authenticate it before starting new Codex sessions.'
-                    )
+                  ? activeCodexAccountIsPi
+                    ? translate(
+                        'auto.components.settings.AccountsPane.piActiveSignInOutOfDate',
+                        'Pi could not refresh this Codex sign-in. Sign in again through Pi to restore usage updates.'
+                      )
+                    : translate(
+                        'auto.components.settings.AccountsPane.75ca9b718e',
+                        'Codex reported that the active account needs a fresh sign-in. Re-authenticate it before starting new Codex sessions.'
+                      )
                   : translate(
                       'auto.components.settings.AccountsPane.e4a28e8894',
                       'Codex reported that the {{value0}} login needs a fresh sign-in. Sign in again before starting new Codex sessions.',
@@ -152,34 +161,61 @@ export function renderCodexAccountsSection(model: AccountsPaneSectionModel): Rea
                   )}
             </p>
           </div>
-          <Button
-            variant="outline"
-            size="xs"
-            onClick={() =>
-              void runCodexAccountAction('adding', () =>
-                window.api.codexAccounts.add({
-                  runtime: accountRuntime.runtime,
-                  wslDistro: accountRuntime.wslDistro
-                })
-              )
-            }
-            disabled={
-              // Why: interactive `codex login` needs a desktop browser and
-              // would authenticate against this device, not the server.
-              isRemoteAccountScope ||
-              codexAction !== 'idle' ||
-              wslCapabilitiesLoading ||
-              accountRuntimeUnavailable
-            }
-            className="gap-1.5"
-          >
-            {codexAction === 'adding' ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <Plus className="size-3" />
-            )}
-            {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
-          </Button>
+          <div className="flex shrink-0 items-center gap-2">
+            {accountRuntime.runtime === 'host' ? (
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() =>
+                  void runCodexAccountAction('importing-pi', () =>
+                    window.api.codexAccounts.importPi()
+                  )
+                }
+                disabled={
+                  isRemoteAccountScope || codexAction !== 'idle' || accountRuntimeUnavailable
+                }
+                className="gap-1.5"
+              >
+                {codexAction === 'importing-pi' ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Download className="size-3" />
+                )}
+                {translate(
+                  'auto.components.settings.AccountsPane.importCodexFromPi',
+                  'Import from Pi'
+                )}
+              </Button>
+            ) : null}
+            <Button
+              variant="outline"
+              size="xs"
+              onClick={() =>
+                void runCodexAccountAction('adding', () =>
+                  window.api.codexAccounts.add({
+                    runtime: accountRuntime.runtime,
+                    wslDistro: accountRuntime.wslDistro
+                  })
+                )
+              }
+              disabled={
+                // Why: interactive `codex login` needs a desktop browser and
+                // would authenticate against this device, not the server.
+                isRemoteAccountScope ||
+                codexAction !== 'idle' ||
+                wslCapabilitiesLoading ||
+                accountRuntimeUnavailable
+              }
+              className="gap-1.5"
+            >
+              {codexAction === 'adding' ? (
+                <Loader2 className="size-3 animate-spin" />
+              ) : (
+                <Plus className="size-3" />
+              )}
+              {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
+            </Button>
+          </div>
         </div>
         {remoteAccountScopeNotice}
 

--- a/src/renderer/src/components/settings/accounts-pane-types.ts
+++ b/src/renderer/src/components/settings/accounts-pane-types.ts
@@ -31,6 +31,7 @@ export type LocalAccountRuntime = {
 export type CodexAccountAction =
   | 'idle'
   | 'adding'
+  | 'importing-pi'
   | `reauth:${string}`
   | `remove:${string}`
   | `select:${string}`

--- a/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
+++ b/src/renderer/src/components/status-bar/StatusBarVisibilityMenu.tsx
@@ -18,6 +18,7 @@ export function StatusBarVisibilityMenu({
   controller: StatusBarController
 }): React.JSX.Element {
   const {
+    codexUsageAvailable,
     detectedAgentIds,
     menuOpen,
     menuPoint,
@@ -50,7 +51,7 @@ export function StatusBarVisibilityMenu({
             {translate('auto.components.status.bar.StatusBar.3885eb74d8', 'Claude Usage')}
           </DropdownMenuCheckboxItem>
         )}
-        {isStatusBarItemAvailable('codex', detectedAgentIds) && (
+        {codexUsageAvailable && (
           <DropdownMenuCheckboxItem
             checked={statusBarItems.includes('codex')}
             onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.test.ts
@@ -30,6 +30,10 @@ describe('isStatusBarItemAvailable', () => {
     expect(isStatusBarItemAvailable('grok', ['claude', 'kimi'])).toBe(false)
   })
 
+  it('shows a credential-backed provider without its CLI on PATH', () => {
+    expect(isStatusBarItemAvailable('codex', [], true)).toBe(true)
+  })
+
   it('shows CLI items detected on PATH', () => {
     expect(isStatusBarItemAvailable('claude', ['claude'])).toBe(true)
     expect(isStatusBarItemAvailable('codex', ['codex', 'claude'])).toBe(true)

--- a/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
+++ b/src/renderer/src/components/status-bar/status-bar-agent-gating.ts
@@ -18,9 +18,12 @@ const CLI_GATED_ITEMS: ReadonlySet<StatusBarItem> = new Set([
 
 export function isStatusBarItemAvailable(
   id: StatusBarItem,
-  detectedAgentIds: TuiAgent[] | null
+  detectedAgentIds: TuiAgent[] | null,
+  hasCredentialBackedUsage = false
 ): boolean {
-  if (!CLI_GATED_ITEMS.has(id)) {
+  // Why: Pi-linked Codex accounts query usage directly and deliberately do not
+  // install Codex CLI. Their durable credential route earns the same UI slot.
+  if (hasCredentialBackedUsage || !CLI_GATED_ITEMS.has(id)) {
     return true
   }
   if (detectedAgentIds === null) {

--- a/src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts
+++ b/src/renderer/src/components/status-bar/use-available-status-bar-toggles.ts
@@ -8,5 +8,15 @@ export function useAvailableStatusBarToggles<T extends { id: StatusBarItem }>(
   toggles: readonly T[]
 ): T[] {
   const detectedAgentIds = useAppStore((s) => s.detectedAgentIds)
-  return toggles.filter((t) => isStatusBarItemAvailable(t.id, detectedAgentIds))
+  const hasPiLinkedCodexAccount = useAppStore(
+    (s) =>
+      s.settings?.codexManagedAccounts.some((account) => account.credentialSource === 'pi') === true
+  )
+  return toggles.filter((toggle) =>
+    isStatusBarItemAvailable(
+      toggle.id,
+      detectedAgentIds,
+      toggle.id === 'codex' && hasPiLinkedCodexAccount
+    )
+  )
 }

--- a/src/renderer/src/components/status-bar/use-status-bar-controller.ts
+++ b/src/renderer/src/components/status-bar/use-status-bar-controller.ts
@@ -117,6 +117,8 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   }
   const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
   const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)
+  const hasPiLinkedCodexAccount =
+    settings?.codexManagedAccounts.some((account) => account.credentialSource === 'pi') === true
   const visibleGemini = getVisibleUsageProvider('gemini', gemini, usageSettings)
   const visibleKimi = getVisibleUsageProvider('kimi', kimi, usageSettings)
   const visibleAntigravity = getVisibleUsageProvider('antigravity', antigravity, usageSettings)
@@ -129,7 +131,7 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
   const showCodex =
     visibleCodex !== null &&
     statusBarItems.includes('codex') &&
-    isStatusBarItemAvailable('codex', detectedAgentIds)
+    isStatusBarItemAvailable('codex', detectedAgentIds, hasPiLinkedCodexAccount)
   const showGemini =
     visibleGemini !== null &&
     statusBarItems.includes('gemini') &&
@@ -236,6 +238,11 @@ export function useStatusBarController(floatingTerminalOpen: boolean) {
     anyVisible,
     compact,
     containerRefCallback,
+    codexUsageAvailable: isStatusBarItemAvailable(
+      'codex',
+      detectedAgentIds,
+      hasPiLinkedCodexAccount
+    ),
     detectedAgentIds,
     floatingTerminalActionLabel,
     floatingTerminalShortcut,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6489,7 +6489,14 @@
           "4e32e030b2": "Stored locally. Orca sends it only to platform.minimax.io for usage refreshes.",
           "5e08b0fe57": "Stored locally and sent only to platform.minimax.io for usage refreshes.",
           "79418c782a": "Open platform.minimax.io/console/usage in your browser, sign in, then copy the Cookie request header from DevTools (Network → any remains request → Cookie).",
-          "f5d8d2a6a1": "Open platform.minimax.io/console/usage in your browser and sign in."
+          "f5d8d2a6a1": "Open platform.minimax.io/console/usage in your browser and sign in.",
+          "piImportSuccess": "Imported Codex usage from Pi.",
+          "piLinked": "Pi-linked",
+          "usageOnly": "Usage only",
+          "piSignInOutOfDate": "Pi could not refresh this sign-in",
+          "piUsageDescription": "Usage refreshes through Pi; Codex CLI is not used",
+          "importCodexFromPi": "Import from Pi",
+          "piActiveSignInOutOfDate": "Pi could not refresh this Codex sign-in. Sign in again through Pi to restore usage updates."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",

--- a/src/renderer/src/web/preload-api/web-agent-accounts-api.ts
+++ b/src/renderer/src/web/preload-api/web-agent-accounts-api.ts
@@ -36,6 +36,7 @@ export function createAccountsApi(): never {
   return {
     list: () => Promise.resolve(empty),
     add: () => Promise.resolve(empty),
+    importPi: () => Promise.reject(new Error('Pi import is only available in the desktop app.')),
     cancelPendingLogin: () => Promise.resolve(false),
     reauthenticate: () => Promise.resolve(empty),
     remove: () => Promise.resolve(empty),

--- a/src/shared/managed-account-types.ts
+++ b/src/shared/managed-account-types.ts
@@ -6,6 +6,7 @@ export type CodexManagedAccount = {
   wslDistro?: string | null
   wslLinuxHomePath?: string | null
   providerAccountId?: string | null
+  credentialSource?: 'pi'
   workspaceLabel?: string | null
   workspaceAccountId?: string | null
   createdAt: number
@@ -19,6 +20,7 @@ export type CodexManagedAccountSummary = {
   managedHomeRuntime?: 'host' | 'wsl'
   wslDistro?: string | null
   providerAccountId?: string | null
+  credentialSource?: 'pi'
   workspaceLabel?: string | null
   workspaceAccountId?: string | null
   createdAt: number


### PR DESCRIPTION
## ELI5

If Pi is already signed in to ChatGPT for Codex, Orca can now import that account for usage tracking. Codex CLI does not need to be installed or launched.

## What Changed

- Added a desktop-local **Import from Pi** action under Settings → AI Provider Accounts → Codex.
- Uses Pi's supported `pi auth print-bearer-token --provider openai-codex` command so Pi remains responsible for refreshing its OAuth login.
- Stores only a Codex-shaped bearer-token snapshot and a source marker in Orca's existing protected managed-account home.
- Refreshes Pi-linked usage through Orca's direct ChatGPT backend client and never falls back to Codex RPC or a hidden PTY.
- Marks imported accounts as **Pi-linked** and **Usage only**, disables Codex reauthentication for them, and verifies that Pi still represents the imported OpenAI account.
- Keeps Codex visible in the status bar when a Pi-linked account exists even if Codex CLI is absent.
- Rejects remote/web imports and does not accept a caller-provided credential path.
- Documents the flow in the Codex guide.

## Why

Some managed machines cannot install or launch Codex CLI, while Pi already owns a valid `openai-codex` OAuth login. Reusing Orca's direct backend usage client avoids coupling usage tracking to Codex process startup and avoids taking ownership of Pi's refresh token.

The existing plugin API cannot contribute account sources, credential brokers, native usage providers, IPC methods, or status-bar providers, so this is implemented through Orca's existing native account and rate-limit architecture rather than fragile plugin monkey-patching.

## Linked Issue

Fixes #19285

## Visual Proof

**Before import**

![Import from Pi action](https://github.com/user-attachments/assets/01775039-d132-48f0-9766-ac06568c714c)

**After import**

![Pi-linked usage-only Codex account](https://github.com/user-attachments/assets/3d34b4e4-fc7e-4c58-ac83-f57a78b459eb)

## Testing

Manually tested on macOS arm64 with Pi signed into a ChatGPT Plus account and Codex absent from `PATH`:

1. Imported the account from Settings without starting Codex login.
2. Confirmed the account is active and labeled Pi-linked / Usage only.
3. Confirmed direct backend usage refresh succeeds and Codex remains visible in the status-bar usage UI.
4. Confirmed Pi account mismatch and backend 401 paths do not launch Codex RPC or PTY fallbacks.

Automated validation on current upstream `main`:

- `pnpm lint` — passed (existing comparator-performance warnings only)
- `pnpm typecheck` — passed
- `pnpm build` — passed
- Focused tests — 50 passed across Pi auth, account service, direct backend, and status-bar gating
- `pnpm test` — attempted locally before the final upstream rebase: 75,478 passed; 21 unrelated real-process/timing/cross-version harness tests failed in this host environment. CI should run the authoritative full suite.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

OpenAI `gpt-5.6-sol` via Pi was used for implementation assistance, test authoring, and review. The implementation was manually exercised and all changes were reviewed before submission.

## Review

Self-reviewed for credential ownership, token disclosure, trusted-path writes, cancellation, direct-backend-only polling, account identity mismatch, local/remote boundaries, migration compatibility, and Codex-absent status-bar behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- The import is host-only on every platform; WSL imports remain tied to their existing runtime flow.
- Windows command resolution uses Orca's shared CLI resolver (`pi.cmd` support included).
- SSH/remote and web clients cannot initiate Pi import.
- Existing account data remains backward-compatible because `credentialSource` is optional.
- Pi is invoked only for Pi-linked account import/refresh; regular Codex accounts are unchanged.
- X (Twitter) handle: none.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
