### PR TITLE
fix(windows): pin generated artifacts and source to LF so a Windows checkout can pass its own gates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,3 +34,9 @@
 # Generated runtime English subset: compared byte-for-byte by
 # verify:localization-runtime-catalog, so a CRLF checkout would fail the gate.
 /src/renderer/src/i18n/en-runtime-required.json linguist-generated=true text eol=lf
+# Generated skill bundle artifacts: verify:skill-bundle-manifest compares them
+# byte-for-byte against a fresh generation, so a CRLF checkout fails the gate.
+/resources/skills/*.json linguist-generated=true text eol=lf
+# Vitest writes snapshots with LF, so a CRLF checkout makes every local test run
+# report them as modified with an empty content diff.
+**/__snapshots__/*.snap text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -40,3 +40,11 @@
 # Vitest writes snapshots with LF, so a CRLF checkout makes every local test run
 # report them as modified with an empty content diff.
 **/__snapshots__/*.snap text eol=lf
+# Source read back as bytes: 29 test files load repo source through `readFileSync`
+# and assert on `\n`-joined text, so a CRLF checkout fails them. Pinning the source
+# tree keeps that class of test honest on every platform. `.mjs` stays out: the
+# `config/scripts` pin is already scoped, and `shebang-script-line-ending-pin`
+# guards that scoping. Windows script files (.cmd/.ps1/.nsh) are deliberately
+# left to the platform default.
+*.ts text eol=lf
+*.tsx text eol=lf


### PR DESCRIPTION
## ELI5

Git for Windows converts line endings on checkout by default. Two things in this repo compare file
bytes against text they generate with `\n`, so on a stock Windows clone they can never match:
`pnpm lint` fails on artifacts that are byte-identical, and one test fails on source that is
byte-identical. Neither is visible to CI, which runs on Linux. This tells Git to leave those files
alone.

## What Changed

Two `.gitattributes` additions, one per symptom in #14479.

**Generated artifacts.** `verify:skill-bundle-manifest` reads the committed
`resources/skills/*.json`, regenerates them, and compares as exact text. The generator emits `\n`;
a `core.autocrlf=true` checkout holds `\r\n`. The comparison cannot succeed, so `pnpm lint` reports
the artifacts stale on a tree whose `git diff` is empty — and the remedy it prints
(`pnpm generate:skill-bundle-manifest`) leaves three files dirty with no content change, inviting a
commit of pure line-ending churn.

```
/resources/skills/*.json linguist-generated=true text eol=lf
**/__snapshots__/*.snap text eol=lf
```

`__snapshots__/*.snap` is the same defect one step removed: Vitest writes LF, so *any* local
`pnpm test` on Windows left the worktree modified with a zero-content diff. Same phantom-change
trap, same fix.

**Source read back as bytes.**

```
*.ts text eol=lf
*.tsx text eol=lf
```

29 test files load repo source through `readFileSync` and assert on `\n`-joined text.
`SourceControl.host-context-boundary.test.ts` is the one that asserts across a line break today, so
it is the one that fails; the rest are one multi-line assertion away from joining it.

Two deliberate exclusions:

- **`.mjs`** — `config/scripts/**/*.mjs` is already pinned for the Vite shebang bug, and
  `shebang-script-line-ending-pin.test.mjs` asserts that pin stays narrow (`config/scripts-extra/`
  and `vendor/config/scripts/` must resolve to `unspecified`). A blanket `*.mjs` rule fails that
  guard, which is the guard doing its job — I took it as the answer rather than as an obstacle, and
  no test currently needs `.mjs` pinned.
- **`.cmd` / `.ps1` / `.nsh`** — these run through Windows interpreters and no test reads them back,
  so they keep the platform default.

## Why

`.gitattributes` already carries `/resources/plugins/** text eol=lf` (*"byte-hashed; CRLF checkout
would break the pinned hash"*) and `/src/renderer/src/i18n/en-runtime-required.json` (*"compared
byte-for-byte … so a CRLF checkout would fail the gate"*). This is the same class of file and the
same reasoning, applied to the two places that were missed.

The alternative for the second symptom — normalizing `readFileSync` results inside the failing test
— fixes one file and leaves 28 with the same latent break. Pinning the source addresses the class.

CONTRIBUTING asks contributors to run `pnpm lint` before opening a PR. On Windows that instruction
could not be followed on a fresh clone.

## Linked Issue

Fixes #14479

Not addressed here, from the same issue's "anything else" note: `ensure-native-runtime` requiring
Visual Studio Build Tools for an optional dependency behind a lazy loader. That is a separate change
and deserves its own issue.

## Visual Proof

`N/A` — no runtime code changes. The only behavior that changes is what Git writes to disk on
checkout.

## Testing

Windows 11 (26200), Git 2.54, `core.autocrlf=true`, Node 24.

Before, on this tree:

```
$ pnpm lint
Generated skill artifacts are stale:
resources\skills\current-manifest.json
resources\skills\snapshot-registry.json
resources\skills\release-mapping.json
 ELIFECYCLE  Command failed with exit code 1

$ pnpm test src/renderer/src/components/right-sidebar/SourceControl.host-context-boundary.test.ts
 Tests  1 failed | 2 passed (3)
```

After (`git rm --cached -r . && git reset --hard` to re-materialize the tree under the new
attributes):

```
$ pnpm lint      → exit 0     # first time this completes on a Windows checkout
$ pnpm typecheck → exit 0
$ pnpm test src/renderer/.../SourceControl.host-context-boundary.test.ts
 Tests  3 passed (3)
```

Attribute resolution verified rather than assumed:

```
$ git ls-files --eol resources/skills/current-manifest.json src/main/index.ts
i/lf  w/lf  attr/text eol=lf   resources/skills/current-manifest.json
i/lf  w/lf  attr/text eol=lf   src/main/index.ts

$ git ls-files --eol '*.cmd' '*.ps1' '*.nsh'   # exclusions still on platform default
i/lf  w/crlf  attr/            resources/win32/bin/orca.cmd
...
```

**Regression check.** `config/scripts` + `src/shared` + `right-sidebar`, run on `main` alone with
the tree re-materialized as CRLF, then on this branch as LF — same machine, same command:

| | files failed | tests failed |
|---|---|---|
| `main` alone (CRLF tree) | 18 | 48 |
| this branch (LF tree) | 16 | 46 |

Two fewer, and only one is mine: `SourceControl.host-context-boundary.test.ts`. The other,
`src/shared/wsl-exec-mode-separator.test.ts`, timed out at 50.8 s on the baseline run and passes
2/2 on re-run — timing, not line endings, so I am not counting it. No test fails on this branch that
does not also fail on `main`.

The remaining 46 are this machine's pre-existing Windows-local failures — WSL distro dependencies
and `C:/` vs `C:\` path assertions — unrelated to this change and present on `main` alone.

Not exercised on macOS/Linux: those checkouts are already LF, so these attributes are a no-op there.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

No new test. The repo already has the right guards and they now pass instead of failing:
`verify:skill-bundle-manifest` is the gate for the first symptom,
`SourceControl.host-context-boundary.test.ts` for the second, and
`shebang-script-line-ending-pin.test.mjs` is what kept the `.mjs` rule honest.

## AI Disclosure

Written with Claude Opus 5 (Claude Code), driven and reviewed by me.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **One-time renormalization for Windows contributors.** After this merges, an existing Windows
  worktree keeps its CRLF files until refreshed — `git rm --cached -r . && git reset --hard` on a
  clean tree, or simply a fresh clone. macOS and Linux see nothing.
- **Security / performance / mobile / SSH:** no runtime code path changes.
- **Backwards compatibility:** the committed bytes are unchanged — every file was already LF in the
  index. This only stops the checkout filter from translating them on the way out.
- **Cross-platform:** the exclusions above are the whole cross-platform surface; Windows script
  files and patch files keep their current handling.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
  — `pnpm lint` and `pnpm typecheck` pass locally (exit 0). `pnpm test` was run scoped, not whole:
  the full suite does not pass on this Windows machine for the pre-existing reasons noted above, so
  the numbers I report are before/after on the same scoped set. `pnpm build` not run locally; CI
  covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lc8yzNit7nZ6uPawXS63h
