### PR TITLE
fix(child-process): stop passing encoding buffer to spawnSync

### DIFF
--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -99,11 +99,12 @@ describe('runProcessSync', () => {
   })
 
   it('returns string stdout/stderr without passing encoding buffer to spawnSync', () => {
-    // `encoding: 'buffer'` is not a valid spawnSync encoding and throws
-    // ERR_UNKNOWN_ENCODING before the child runs — this is the Windows DPAPI path.
+    // `encoding: 'buffer'` with a string `input` throws ERR_UNKNOWN_ENCODING
+    // before the child runs — this mirrors the Windows DPAPI path.
     const result = runProcessSync({
       program: process.execPath,
-      args: ['-e', 'process.stdout.write("out"); process.stderr.write("err")']
+      args: ['-e', 'process.stdout.write("out"); process.stderr.write("err")'],
+      input: 'dpapi-data'
     })
     expect(typeof result.stdout).toBe('string')
     expect(typeof result.stderr).toBe('string')

--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -97,6 +97,20 @@ describe('runProcessSync', () => {
     expect(result.stdout).toBe('hi')
     expect(result.code).toBe(3)
   })
+
+  it('returns string stdout/stderr without passing encoding buffer to spawnSync', () => {
+    // `encoding: 'buffer'` is not a valid spawnSync encoding and throws
+    // ERR_UNKNOWN_ENCODING before the child runs — this is the Windows DPAPI path.
+    const result = runProcessSync({
+      program: process.execPath,
+      args: ['-e', 'process.stdout.write("out"); process.stderr.write("err")']
+    })
+    expect(typeof result.stdout).toBe('string')
+    expect(typeof result.stderr).toBe('string')
+    expect(result.stdout).toBe('out')
+    expect(result.stderr).toBe('err')
+    expect(result.code).toBe(0)
+  })
 })
 
 describe('bounded output', () => {

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -329,8 +329,7 @@ export function runProcessSync(spec: ProcessSpec): ProcessResult {
     ...resolved.options,
     input: spec.input,
     timeout: spec.timeoutMs === null ? undefined : (spec.timeoutMs ?? DEFAULT_PROCESS_TIMEOUT_MS),
-    maxBuffer: spec.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
-    encoding: 'buffer'
+    maxBuffer: spec.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES
   })
   if (result.error && (result.error as NodeJS.ErrnoException).code !== 'ETIMEDOUT') {
     throw result.error


### PR DESCRIPTION
## Problem

On Windows, browser cookie import fails before DPAPI key extraction with:

```
TypeError [ERR_UNKNOWN_ENCODING]: Unknown encoding: buffer
```

User-facing message: **Could not access Brave/Chrome encryption key.**

## Root cause

`runProcessSync` in `src/shared/child-process/run-process.ts` passes `encoding: 'buffer'` into `node:child_process.spawnSync`. Node rejects `'buffer'` as an encoding, so the sync PowerShell DPAPI helper in `src/main/browser/browser-cookie-key.ts` (`getWindowsEncryptionKey`) throws before decryption completes.

Callers already convert stdout/stderr with `.toString('utf8')`, so the option is unnecessary.

## Fix

Remove `encoding: 'buffer'` from the `spawnSync` options so stdout/stderr return as Buffers (Node default) and existing `.toString('utf8')` conversion keeps working.

## Test plan

- [x] `pnpm test src/shared/child-process/run-process.test.ts` — all 17 tests pass
- [x] New test asserts `runProcessSync` returns string stdout/stderr and would fail with `ERR_UNKNOWN_ENCODING` if `encoding: 'buffer'` were reintroduced

Fixes #18670