### PR TITLE
test(ssh): isolate the MFA fixture from the developer's real ~/.ssh

### DIFF
--- a/src/main/ssh/ssh-multi-factor-authentication.test.ts
+++ b/src/main/ssh/ssh-multi-factor-authentication.test.ts
@@ -186,9 +186,19 @@ function connectWithOrcaConfig(
 describe('multi-stage SSH authentication', () => {
   let tempDir: string
   let keyPaths: string[]
+  let homeEnv: { HOME?: string; USERPROFILE?: string }
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'orca-mfa-'))
+    // Why: the cases below pass `resolved: null`, so `resolvePrivateKeys` falls through to
+    // `findDefaultKeyFile`, which reads `~/.ssh/id_*` through `homedir()`. On a developer
+    // machine that picks up a real key, and an encrypted one makes ssh2 reject with
+    // "Cannot parse privateKey" before authentication is exercised at all. Hosted CI has no
+    // key, so this only ever failed locally. Pointing home at the fixture directory keeps
+    // default-key discovery inside the test's control on every machine.
+    homeEnv = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE }
+    process.env.HOME = tempDir
+    process.env.USERPROFILE = tempDir
     keyPaths = ['id_a', 'id_b'].map((name) => {
       const path = join(tempDir, name)
       writeFileSync(path, utils.generateKeyPairSync('ecdsa', { bits: 256 }).private)
@@ -197,6 +207,14 @@ describe('multi-stage SSH authentication', () => {
   })
 
   afterEach(() => {
+    for (const key of ['HOME', 'USERPROFILE'] as const) {
+      const previous = homeEnv[key]
+      if (previous === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = previous
+      }
+    }
     rmSync(tempDir, { recursive: true, force: true })
   })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## The failure

`src/main/ssh/ssh-multi-factor-authentication.test.ts` fails two cases on a developer machine:

```
AssertionError: promise rejected "Error: Cannot parse privateKey: Encrypted…" instead of resolving
Caused by: Error: Cannot parse privateKey: Encrypted private OpenSSH key detected, but no passphrase given
```

## Why it is environment-dependent

Both failing cases pass `resolved: null` to `connectWithOrcaConfig`. With no resolved config and no `identityFile`, `resolvePrivateKeys` (`ssh-auth-resolution.ts:148-158`) falls through to `findDefaultKeyFile`, which walks `DEFAULT_KEY_PATHS` through `resolveSshConfigHomePath` — and that resolves `~` via `homedir()`.

So the test reads the developer's **real** `~/.ssh/id_*`. If that key is encrypted, ssh2 rejects at `client.connect` before any authentication is exercised, and the multi-stage behaviour the test exists to cover never runs.

Hosted CI has no key in `~/.ssh`, so `findDefaultKeyFile` returns nothing there and the suite is green — which is why this never surfaced on a PR. The third case in the same file already passes `makeResolved(server.port, keyPaths)` and is unaffected.

## The fix

Point `HOME` / `USERPROFILE` at the fixture directory the suite already creates, and restore them in `afterEach`. Default-key discovery then looks inside an empty temp dir instead of the developer's home, which is what the two `resolved: null` cases intend.

This is a **test isolation fix, not a product change** — no production file is touched. `findEncryptedPrivateKeyPath` already handles encrypted keys on the real connection path; the test was bypassing that by driving a raw ssh2 `Client` directly.

## Evidence

- Before: 2 failed, 1 passed.
- After: 3 passed.
- Ablated (fix present, the two `process.env` assignments removed): back to 2 failed, 1 passed — so the isolation is what makes it green, not incidental churn.
- Whole `src/main/ssh` directory: 161 files, 2,205 passed, 18 skipped, 0 failed — no collateral.
- Typecheck (node project) exit 0, oxlint and `oxfmt --check` clean.

## Why it is worth fixing rather than tolerating

It reproduced on every main tip built against during an overnight run, and it costs real time in exactly the wrong way: a test failing on an unrelated branch reads as a defect in the branch under development. Two separate lanes had to spend a full-revert cycle proving it pre-existing before they could trust their own results.
