### PR TITLE
fix(windows): stop string stdin throwing in the sync child-process chokepoint

### DIFF
--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -7,6 +7,11 @@ import { WINDOWS_ARGUMENT_CORPUS } from './__fixtures__/windows-argument-corpus'
 
 const SPEC = { program: 'C:\\bin\\agent.cmd', args: ['--prompt', 'hi'] }
 
+const ECHO_STDIN =
+  'process.stdin.on("data", (c) => process.stdout.write(c)); process.stdin.resume()'
+const COUNT_STDIN_BYTES =
+  'const c = []; process.stdin.on("data", (d) => c.push(d)); process.stdin.on("end", () => process.stdout.write(String(Buffer.concat(c).length)))'
+
 describe('resolveSpawn', () => {
   it('always hides the console and never uses a shell', () => {
     for (const platform of ['win32', 'darwin', 'linux'] as const) {
@@ -96,6 +101,27 @@ describe('runProcessSync', () => {
     })
     expect(result.stdout).toBe('hi')
     expect(result.code).toBe(3)
+  })
+
+  // Why these two: `encoding: 'buffer'` decodes string stdin as well as shaping stdout, and the
+  // sync path had no `input` coverage at all -- so it shipped a stdin that threw (#18670).
+  it('writes string input to the child stdin', () => {
+    const result = runProcessSync({
+      program: process.execPath,
+      args: ['-e', ECHO_STDIN],
+      input: 'piped-payload'
+    })
+    expect(result.stdout).toBe('piped-payload')
+    expect(result.code).toBe(0)
+  })
+
+  it('encodes non-ASCII stdin as utf8', () => {
+    const result = runProcessSync({
+      program: process.execPath,
+      args: ['-e', COUNT_STDIN_BYTES],
+      input: 'h\u00e9llo'
+    })
+    expect(result.stdout).toBe('6')
   })
 })
 

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -327,7 +327,11 @@ export function runProcessSync(spec: ProcessSpec): ProcessResult {
   const resolved = resolveSpawn(spec, process.platform)
   const result = nodeSpawnSync(resolved.file, [...resolved.args], {
     ...resolved.options,
-    input: spec.input,
+    // Why encode here: `encoding` governs stdin as well as stdout -- spawnSync decodes a string
+    // `input` with it, and 'buffer' names a shape rather than a decoder, so string stdin throws
+    // ERR_UNKNOWN_ENCODING before the child starts. Passing bytes leaves 'buffer' meaning only
+    // what the reads below rely on: stdout and stderr arrive as Buffers.
+    input: spec.input === undefined ? undefined : Buffer.from(spec.input, 'utf8'),
     timeout: spec.timeoutMs === null ? undefined : (spec.timeoutMs ?? DEFAULT_PROCESS_TIMEOUT_MS),
     maxBuffer: spec.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
     encoding: 'buffer'


### PR DESCRIPTION
Fixes STA-6700. Also unblocks STA-3706 — see below, because it is **not** the same cause.

## The defect

`src/shared/child-process/run-process.ts` passes `encoding: 'buffer'` to `spawnSync`. That is documented and valid for spawnSync's *output* — but when `input` is a **string**, node does `pipe.input = Buffer.from(input, options.encoding)`, and `Buffer.from(str, 'buffer')` throws `ERR_UNKNOWN_ENCODING`.

Reproduced directly (node v26.5.0, macOS — this is Node semantics, not Windows behaviour):

| input | encoding | result |
|---|---|---|
| `'hello'` | `'buffer'` | **throws** `ERR_UNKNOWN_ENCODING: Unknown encoding: buffer` |
| `Buffer` | `'buffer'` | ok |
| `'hello'` | omitted | ok |
| none | `'buffer'` | ok |

So `runProcessSync` throws for **any** caller passing a string `input` — and `ProcessSpec.input` is typed `input?: string`, so the API actively invites the broken usage.

**Blast radius is one call site today.** Across `src/`, `config/`, `tests/` and `scripts/` — including the untyped `.mjs` callers — `src/main/browser/browser-cookie-key.ts:150` is the **only** caller that passes `input` — the PowerShell DPAPI master-key decrypt. The throw is caught, logged, and returned as `null`, which the Chromium prepare step renders as *"Could not access **Brave** encryption key. The OS may have denied access."*

**That message is wrong, and that is the real user cost.** The OS denied nothing. Windows users see a permissions error for what is a string-encoding bug, and every Chromium cookie import aborts before it starts.

**Introduced** by `b7e79b7ca6` (#15746, "one chokepoint for every child process"). `run-process.test.ts` had three `runProcessSync` tests and **none passed `input`**, so the consolidation shipped a regression through the exact path it was consolidating.

## The fix — at the chokepoint, not the call site

```ts
input: spec.input === undefined ? undefined : Buffer.from(spec.input, 'utf8'),
```

`encoding: 'buffer'` stays, and the reason is symmetry rather than necessity: `runProcess` (the async path) already writes stdin via `child.stdin?.end(spec.input)`, which defaults to utf8. Converting here makes the **sync path match the async one** instead of quietly diverging from it — that, not the stdout shape, is the argument for `'utf8'`.

Dropping `encoding: 'buffer'` would also have worked; the Buffer-returning default is documented in the overload set (`SpawnSyncOptionsWithBufferEncoding`). Keeping it simply leaves `'buffer'` meaning one thing. The code comment names the surprise that caused this — that `encoding` governs stdin decoding *and* stdout shape.

`browser-cookie-key.ts` is untouched.

## The missing test is the headline

- **`writes string input to the child stdin`** — writes string stdin to a child and asserts it arrived. Uses `process.execPath`, so it runs on every OS: **this would have caught #15746 in CI on Linux, with no Windows host needed.**
- **`encodes non-ASCII stdin as utf8`** — asserts the child receives 6 bytes for `héllo`, pinning the encoding choice (latin1 would report 5).

One edge checked by measurement rather than reasoning: converting to a Buffer flips the truthiness of an empty-string input, since node gates on `if (options.input)` and a zero-length Buffer is truthy. All three cases — empty string, empty Buffer, `undefined` — produce `eof:0` and status 0, so they are observationally identical and no special case was added. No caller passes `''` today regardless.

## Evidence

| stage | result |
|---|---|
| Red, at unmodified `a87a19c996` | 2 failed / 16 passed, `TypeError: Unknown encoding: buffer` |
| Green, after fix | 18 / 18 |
| Ablation (`input: spec.input` restored on the committed fix) | exactly 2 failed / 16 passed, same production error |
| Restored, re-verified | 18 / 18 |

The ablation threw at runtime rather than at import, so it exercised the code rather than failing to compile. Both new tests are discriminating — only they flip, and only on this line.

Wider sweep across `src/shared/child-process` and `src/main/browser`: 189 files, **1,785 passed, 0 failed**, 48 skipped. Typecheck clean on all three projects (node, web, cli).

## Why this closes STA-3706 too — and why that is not a grouping

**These are two sequential stages, not one cause.** The timeline settles it: STA-3706 was filed 2026-08-08 at v1.4.176-rc.1, *before* this regression; STA-6700 is v1.4.197, *after*. They were never observed together because 6700 now aborts the import one stage earlier than 3706 ever ran.

STA-3706's fix is **already on `main`** — `isAppBoundEncryptedCookie`, the `v20` classification before decrypt, and the "app-bound encryption / import from a file instead" toast, with 28 green tests. None of it is touched here.

So fixing 6700 **unmasks** 3706's landed fix: Chrome/Edge 140+ Windows users go from a false "key access denied" error to the correct actionable app-bound toast, and Brave (still v10) gets a real import.

## Boundary, stated not buried

The mechanism is Node semantics and is reproduced above on macOS. The **end-to-end Windows cookie import is unproven** — that needs a Windows host with a real Chrome profile. No real browser profile was read at any point; the fixtures are `piped-payload` and `héllo`, and the change contains no cookie values, host keys or decryption keys.
