### PR TITLE
fix(worktree-scan): serve the reusable cache when the admin fingerprint probe expires

### DIFF
--- a/docs/reference/worktree-scan-fingerprint.md
+++ b/docs/reference/worktree-scan-fingerprint.md
@@ -5,8 +5,10 @@
 Adopted for the main-process worktree resolution cache
 (`OrcaRuntimeService.listRepoWorktreesForResolution`). It keeps the existing
 30-second freshness contract for externally created, removed, moved, locked, and
-re-checked-out worktrees while removing the `git worktree list` subprocess that
-previously ran for every registered repository every 30 seconds.
+re-checked-out worktrees — whenever the probe answers, with the reconciliation
+interval as the ceiling when it does not — while removing the
+`git worktree list` subprocess that previously ran for every registered
+repository every 30 seconds.
 
 ## Context
 
@@ -60,7 +62,10 @@ subprocess.
   converges.
 - Change nothing for SSH repos, WSL-routed repos, folder workspaces, bare repos,
   or hosts where the probe cannot resolve Git's admin layout.
-- Fail open: any probe error must behave exactly like today (run the real scan).
+- Fail open: any probe that answers something the fingerprint cannot vouch for —
+  a read error, an unresolvable Git layout — must behave exactly like today (run
+  the real scan). A probe that never answers is a separate case; see
+  "Probe expiry is not a mismatch".
 
 ## Non-goals
 
@@ -197,19 +202,26 @@ the TTL alone would have refreshed.
 
 ## Freshness budget
 
-| Change                                                                | Before            | After             |
-| --------------------------------------------------------------------- | ----------------- | ----------------- |
-| Orca-initiated create/remove/rename/sparse/repo edit                  | immediate (event) | immediate (event) |
-| SSH reconnect / provider generation bump                              | immediate (event) | immediate (event) |
-| External `worktree add/remove/move/prune/lock`                        | ≤ 30 s            | ≤ 30 s            |
-| External `git checkout` / `commit` / `reset` in any worktree          | ≤ 30 s            | ≤ 30 s            |
-| External `rm -rf <worktree>`                                          | ≤ 30 s            | ≤ 30 s            |
-| External sparse-checkout pattern edit                                 | ≤ 30 s            | ≤ 5 min           |
-| Packed/reftable tip moved within one mtime tick at an equal file size | ≤ 30 s            | ≤ 5 min           |
-| SSH / WSL repos, folder workspaces                                    | unchanged         | unchanged         |
+| Change                                                                | Before            | After                     |
+| --------------------------------------------------------------------- | ----------------- | ------------------------- |
+| Orca-initiated create/remove/rename/sparse/repo edit                  | immediate (event) | immediate (event)         |
+| SSH reconnect / provider generation bump                              | immediate (event) | immediate (event)         |
+| External `worktree add/remove/move/prune/lock`                        | ≤ 30 s            | ≤ 30 s (see note)         |
+| External `git checkout` / `commit` / `reset` in any worktree          | ≤ 30 s            | ≤ 30 s (see note)         |
+| External `rm -rf <worktree>`                                          | ≤ 30 s            | ≤ 30 s (see note)         |
+| External sparse-checkout pattern edit                                 | ≤ 30 s            | ≤ 5 min                   |
+| Packed/reftable tip moved within one mtime tick at an equal file size | ≤ 30 s            | ≤ 5 min                   |
+| SSH / WSL repos, folder workspaces                                    | unchanged         | unchanged                 |
 
-The two regressions are bounded by the reconciliation interval and are both
-changes Orca does not make itself.
+The two unconditional regressions — sparse-checkout pattern edits and a tip
+moved within one mtime tick at an equal file size — are bounded by the
+reconciliation interval and are both changes Orca does not make itself.
+
+The "see note" rows are changes the probe *does* observe, so 30 s is their bound
+whenever it answers. Only a host slow enough to blow the probe deadline delays
+them, and then by the same ceiling: age is measured from the last real scan, so
+a run of expiries stretches detection toward 5 min and no further, and the first
+probe that answers restores the 30 s bound.
 
 ### Main-thread cost
 
@@ -301,6 +313,11 @@ gain no longer justifies the risk. Tracked as follow-up, not in this change.
 - the 5-minute reconciliation forces a rescan while the fingerprint is unchanged
 - `notifyBranchRenamed` (event invalidation) still forces an immediate rescan
 - a `null` fingerprint (probe failure) falls back to scanning
+- an expired probe serves the reusable cache within the caller's budget instead
+  of rescanning, and its late answer is never adopted as the confirmed
+  fingerprint
+- a run of expiries still reconciles on schedule, because age keeps being
+  measured from the last real scan
 - SSH repos never consult the probe
 - a failed scan is never extended
 - concurrent callers share one probe and one scan

--- a/docs/reference/worktree-scan-fingerprint.md
+++ b/docs/reference/worktree-scan-fingerprint.md
@@ -124,16 +124,47 @@ the caller treats as "cannot prove unchanged".
 cached entry exists, same generation + runtimeKey, TTL expired
   └─ probe eligible? (no connectionId, no wslDistro, fingerprint recorded)
        ├─ no  → real scan (today's behaviour)
-       └─ yes → read fingerprint now
-            ├─ null or different              → real scan
-            ├─ equal, last real scan < 5 min  → extend TTL, no subprocess
-            └─ equal, last real scan ≥ 5 min  → real scan (bounded reconcile)
+       └─ yes → read fingerprint now, bounded by the probe deadline
+            ├─ expired before answering        → serve the cached scan unchanged
+            ├─ null or different               → real scan
+            ├─ equal, last real scan < 5 min   → extend TTL, no subprocess
+            └─ equal, last real scan ≥ 5 min   → real scan (bounded reconcile)
 ```
 
 `WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS` is 5 min, matching the existing
 `WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS` precedent. A cached result whose scan
 failed (`ok: false`) is never extended, so a transient Git failure still retries
 on the 30 s TTL.
+
+### Probe expiry is not a mismatch
+
+The expiry branch above is the one place the two "cannot prove unchanged"
+outcomes have to be told apart. A mismatch proves the cache is stale. An expiry
+proves nothing at all: the entry is still inside the reconcile interval, so it is
+exactly as reusable as it was a millisecond before the deadline.
+
+Treating expiry as a mismatch was self-sustaining. Only a loaded host makes the
+probe miss a 3.5 s budget, and the response was to queue a full `git worktree
+list` behind the git-admission scheduler — adding the load that slows the next
+probe. Serving the cache removes that feedback path.
+
+Nothing is stamped as confirmed on this branch. The entry keeps the `scannedAt`
+and `adminFingerprint` of the last *real* scan, so:
+
+- the reconcile interval keeps measuring from that scan, and any run of
+  consecutive expiries still reconciles on its original schedule — an unconfirmed
+  entry can never outlive the 5-minute ceiling;
+- the next probe compares against the last confirmed fingerprint, so a repo that
+  really did change is rescanned on the first probe that answers.
+
+The abandoned probe is deliberately **not** adopted when it finally settles: it
+was taken after the cached scan, so its value would stamp a later state onto an
+earlier result and mask any mutation in between until the reconcile deadline.
+
+A probe that is still outstanding from a previous refresh is a different case
+again — `startRepoWorktreeAdminFingerprintProbe` returns `null` rather than
+piling a second read onto a wedged mount, the awaited branch is never entered,
+and the refresh takes the real scan.
 
 ### Git version compatibility
 

--- a/docs/reference/worktree-scan-fingerprint.md
+++ b/docs/reference/worktree-scan-fingerprint.md
@@ -122,13 +122,14 @@ the caller treats as "cannot prove unchanged".
 
 ```text
 cached entry exists, same generation + runtimeKey, TTL expired
-  └─ probe eligible? (no connectionId, no wslDistro, fingerprint recorded)
-       ├─ no  → real scan (today's behaviour)
-       └─ yes → read fingerprint now, bounded by the probe deadline
-            ├─ expired before answering        → serve the cached scan unchanged
-            ├─ null or different               → real scan
-            ├─ equal, last real scan < 5 min   → extend TTL, no subprocess
-            └─ equal, last real scan ≥ 5 min   → real scan (bounded reconcile)
+  └─ successful scan less than 5 min old at refresh start?
+       ├─ no  → real scan (bounded reconcile)
+       └─ yes → local fingerprint probe available?
+            ├─ no  → real scan
+            └─ yes → await fingerprint, bounded by the probe deadline
+                 ├─ expired before answering → serve the cached scan unchanged
+                 ├─ null or different        → real scan
+                 └─ equal                    → extend TTL, no subprocess
 ```
 
 `WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS` is 5 min, matching the existing
@@ -140,20 +141,21 @@ on the 30 s TTL.
 
 The expiry branch above is the one place the two "cannot prove unchanged"
 outcomes have to be told apart. A mismatch proves the cache is stale. An expiry
-proves nothing at all: the entry is still inside the reconcile interval, so it is
-exactly as reusable as it was a millisecond before the deadline.
+proves nothing at all: the entry was inside the reconcile interval when the
+refresh started, so expiry alone does not establish that it changed.
 
-Treating expiry as a mismatch was self-sustaining. Only a loaded host makes the
-probe miss a 3.5 s budget, and the response was to queue a full `git worktree
-list` behind the git-admission scheduler — adding the load that slows the next
-probe. Serving the cache removes that feedback path.
+Treating expiry as a mismatch could feed host overload. A slow filesystem probe
+would queue a full `git worktree list` behind the git-admission scheduler, adding
+load that could slow the next probe. Serving the cache removes that feedback path
+for the refresh whose probe expires.
 
 Nothing is stamped as confirmed on this branch. The entry keeps the `scannedAt`
 and `adminFingerprint` of the last *real* scan, so:
 
-- the reconcile interval keeps measuring from that scan, and any run of
-  consecutive expiries still reconciles on its original schedule — an unconfirmed
-  entry can never outlive the 5-minute ceiling;
+- the reconcile interval keeps measuring from that scan. The next refresh that
+  starts at least 5 minutes after the scan runs a real scan. This is a refresh
+  threshold, not a wall-clock expiry: a refresh begun just before it may finish
+  after it, and the caller caches that result for another 30-second TTL;
 - the next probe compares against the last confirmed fingerprint, so a repo that
   really did change is rescanned on the first probe that answers.
 

--- a/src/main/runtime/orca-runtime-postlude.ts
+++ b/src/main/runtime/orca-runtime-postlude.ts
@@ -46,7 +46,8 @@ export const WORKTREE_SCAN_FALLBACK_ALLOWANCE_MS = 1500
 // on every TTL expiry. Subtracting keeps that invariant true by construction if either side moves.
 // Why not smaller: the probe reads a subset of what the fallback scan reads, so a probe too slow to
 // fit is a scan that will not fit either — waiting is strictly better right up to the budget.
-// Expiring yields `null`, the existing "cannot prove unchanged" sentinel, so a real scan runs.
+// Expiring is "unknown", not "changed": the reusable cache is served as-is, still stamped with the
+// last confirmed scan, so the reconcile interval bounds how long that can go unverified.
 export const WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS =
   RESOLVED_WORKTREE_REPO_TIMEOUT_MS - WORKTREE_SCAN_FALLBACK_ALLOWANCE_MS
 

--- a/src/main/runtime/orca-runtime-postlude.ts
+++ b/src/main/runtime/orca-runtime-postlude.ts
@@ -35,9 +35,11 @@ export const RESOLVED_WORKTREE_CACHE_TTL_MS = 1000
 // stamp, so a real scan still runs on this interval even while the probe reports "unchanged".
 export const WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS = 5 * 60_000
 
-// Why reserved rather than spent on the probe: when the probe expires the caller still has to run
-// `git worktree list` and answer inside the same budget, so the fallback needs its own room. Sized
-// for a healthy Git on a busy host, well above the tens of milliseconds a warm list costs.
+// Why reserved rather than spent on the probe: a probe that answers "unavailable" or "different"
+// just before the deadline still leaves `git worktree list` to run and answer inside the same
+// caller budget, so the fallback needs its own room. An expiry no longer costs a scan — the
+// reusable cache is served as-is — but every answering path still can. Sized for a healthy Git on
+// a busy host, well above the tens of milliseconds a warm list costs.
 export const WORKTREE_SCAN_FALLBACK_ALLOWANCE_MS = 1500
 
 // Why derived from the caller's budget instead of a generous absolute: this wait runs *inside*

--- a/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
+++ b/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
@@ -52,7 +52,8 @@ export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListK
       // caller must never wait on it, or every cold read pays filesystem latency it cannot use.
       const probed = await withTimeoutResult(probe, WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
       if (!probed.ok) {
-        // Timeout proves no change; avoid adding scan load and preserve the last confirmed baseline.
+        // Timeout proves nothing, so it is no evidence the repo changed: serve the cache without
+        // adding scan load, and preserve the last confirmed baseline.
         // Ignore the late probe: it could describe a mutation these cached rows predate.
         console.warn('[worktree-scan] admin fingerprint probe expired; serving the cached scan', {
           repoId: repo.id,

--- a/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
+++ b/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
@@ -52,18 +52,8 @@ export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListK
       // caller must never wait on it, or every cold read pays filesystem latency it cannot use.
       const probed = await withTimeoutResult(probe, WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
       if (!probed.ok) {
-        // Why serve the cache instead of scanning: expiry means "unknown", not "changed". This
-        // entry is still inside the reconcile interval, so it is exactly as reusable as it was a
-        // millisecond before the deadline — and the only thing that makes a probe miss a 3.5s
-        // budget is a loaded host, where a fallback `git worktree list` queued behind the git
-        // admission scheduler is the one cost that feeds the next probe's slowness.
-        // Why it cannot go stale forever: `scannedAt` and `adminFingerprint` stay at the last
-        // *confirmed* values, so the reconcile interval keeps measuring from the last real scan
-        // and any run of expiries still reconciles on its original schedule.
-        // Why not thread the abandoned probe through: it may settle after a mutation this cached
-        // result predates, and stamping that fingerprint here would mask the mutation until the
-        // reconcile deadline. The last confirmed value is the only baseline the next probe can
-        // compare against honestly.
+        // Timeout proves no change; avoid adding scan load and preserve the last confirmed baseline.
+        // Ignore the late probe: it could describe a mutation these cached rows predate.
         console.warn('[worktree-scan] admin fingerprint probe expired; serving the cached scan', {
           repoId: repo.id,
           timeoutMs: WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS

--- a/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
+++ b/src/main/runtime/orca-runtime-refresh-repo-worktree-scan.ts
@@ -52,14 +52,32 @@ export class OrcaRuntimeWithRefreshRepoWorktreeScan extends OrcaRuntimeWithListK
       // caller must never wait on it, or every cold read pays filesystem latency it cannot use.
       const probed = await withTimeoutResult(probe, WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
       if (!probed.ok) {
-        // Why log: expiry and "fingerprint unavailable" both surface as `null`, so a wedged mount is
-        // otherwise indistinguishable from a repo that simply cannot be fingerprinted.
-        console.warn('[worktree-scan] admin fingerprint probe expired; running a full scan', {
+        // Why serve the cache instead of scanning: expiry means "unknown", not "changed". This
+        // entry is still inside the reconcile interval, so it is exactly as reusable as it was a
+        // millisecond before the deadline — and the only thing that makes a probe miss a 3.5s
+        // budget is a loaded host, where a fallback `git worktree list` queued behind the git
+        // admission scheduler is the one cost that feeds the next probe's slowness.
+        // Why it cannot go stale forever: `scannedAt` and `adminFingerprint` stay at the last
+        // *confirmed* values, so the reconcile interval keeps measuring from the last real scan
+        // and any run of expiries still reconciles on its original schedule.
+        // Why not thread the abandoned probe through: it may settle after a mutation this cached
+        // result predates, and stamping that fingerprint here would mask the mutation until the
+        // reconcile deadline. The last confirmed value is the only baseline the next probe can
+        // compare against honestly.
+        console.warn('[worktree-scan] admin fingerprint probe expired; serving the cached scan', {
           repoId: repo.id,
           timeoutMs: WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS
         })
+        return {
+          result: reusable.result,
+          adminFingerprint: reusable.adminFingerprint,
+          adminFingerprintProbe: null,
+          scannedAt: reusable.scannedAt
+        }
       }
-      const current = probed.ok ? probed.value : null
+      // A `null` value is the other story: the probe answered that it cannot describe this repo,
+      // so nothing is proven and a real scan is the only way to know.
+      const current = probed.value
       if (current !== null && current === reusable.adminFingerprint) {
         return {
           result: reusable.result,

--- a/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+++ b/src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
@@ -466,7 +466,7 @@ describe('worktree scan admin-fingerprint gate', () => {
     }
   })
 
-  it('scans when the awaited probe outlives its deadline', async () => {
+  it('waits for the awaited probe to its deadline, then serves the reusable cache', async () => {
     vi.useFakeTimers()
     try {
       const { list } = makeRuntime()
@@ -485,8 +485,81 @@ describe('worktree scan admin-fingerprint gate', () => {
 
       await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
       await drainMicrotasks()
-      expect(scanCount()).toBe(2)
+      // Was `toBe(2)`: expiry used to share the `null` sentinel with a fingerprint mismatch and
+      // fall into a full scan. It is a different epistemic state — a mismatch proves the cache is
+      // stale, an expiry proves nothing — and the entry is still inside the reconcile interval,
+      // so it is served as-is. What this test still pins is unchanged: the wait is bounded by the
+      // probe's own deadline and the refresh settles there, not at the caller's budget.
+      expect(scanCount()).toBe(1)
+      expect(secondSettled()).toBe(true)
       await second
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('serves the cached rows on an expired probe without trusting the late answer', async () => {
+    vi.useFakeTimers()
+    try {
+      const { list } = makeRuntime()
+
+      const firstHeads = heads(await list())
+      expect(scanCount()).toBe(1)
+
+      const releaseExpiredProbe = stallProbeOnce()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      const second = list()
+      await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
+      await drainMicrotasks()
+
+      // The caller gets the cached scan's own rows, not persisted placeholders and not a rescan.
+      expect(scanCount()).toBe(1)
+      expect(heads(await second)).toEqual(firstHeads)
+
+      // The abandoned read finally lands. It was taken after the cached scan, so adopting it as
+      // the entry's fingerprint would stamp a later state onto an earlier result and mask any
+      // mutation in between until the reconcile deadline. The last *confirmed* fingerprint stays
+      // the baseline, so this unchanged repo still gates on the next poll instead of rescanning.
+      releaseExpiredProbe('fp-taken-after-the-cached-scan')
+      await drainMicrotasks()
+      vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+      await list()
+      expect(scanCount()).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('still reconciles on schedule when every probe keeps expiring', async () => {
+    vi.useFakeTimers()
+    try {
+      const { list } = makeRuntime()
+      await list()
+      expect(scanCount()).toBe(1)
+
+      const STEP_MS = SCAN_TTL_MS + 1_000 + WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS
+      for (
+        let elapsed = STEP_MS;
+        elapsed < WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS;
+        elapsed += STEP_MS
+      ) {
+        const releaseExpiredProbe = stallProbeOnce()
+        vi.advanceTimersByTime(SCAN_TTL_MS + 1_000)
+        const pending = list()
+        await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
+        await pending
+        // The wedged read lands too late to have gated this refresh; releasing it lets the next
+        // poll issue a probe of its own instead of hitting the still-outstanding-probe gate.
+        releaseExpiredProbe('fp-1')
+        await drainMicrotasks()
+      }
+      expect(scanCount()).toBe(1)
+
+      vi.advanceTimersByTime(WORKTREE_SCAN_ADMIN_RECONCILE_INTERVAL_MS)
+      await list()
+      // Serving an unconfirmed cache must not disarm the ceiling: age is still measured from the
+      // last real scan, so no run of timeouts can keep a repo stale past the reconcile interval.
+      expect(scanCount()).toBe(2)
     } finally {
       vi.useRealTimers()
     }
@@ -521,7 +594,7 @@ describe('worktree scan admin-fingerprint gate', () => {
     }
   })
 
-  it('still returns scanned rows within the per-repo budget when the probe stalls', async () => {
+  it('still returns real rows within the per-repo budget when the probe stalls', async () => {
     vi.useFakeTimers()
     try {
       const { list } = makeRuntime()
@@ -537,7 +610,11 @@ describe('worktree scan admin-fingerprint gate', () => {
       await vi.advanceTimersByTimeAsync(WORKTREE_SCAN_ADMIN_FINGERPRINT_TIMEOUT_MS)
       await drainMicrotasks()
       expect(secondSettled()).toBe(true)
-      expect(scanCount()).toBe(2)
+      // Was `toBe(2)`: an expired probe no longer means "changed", so the answer inside the budget
+      // is now the cached scan rather than a fresh one. The property this test exists for is
+      // unchanged — the caller is answered in time with the repo's real rows, never stranded on
+      // the persisted-row fallback — and the rows themselves are byte-identical either way.
+      expect(scanCount()).toBe(1)
       expect(heads(await second)).toEqual(['abc', 'def'])
     } finally {
       vi.useRealTimers()


### PR DESCRIPTION
## ELI5

Orca checks whether a repository's cached worktree list changed before doing an expensive rescan. If that quick check takes too long, this change reuses the previous successful list instead of adding another expensive scan to an already slow host. A detected change still triggers a scan.

The five-minute reconciliation interval is a refresh threshold, not a hard wall-clock expiry: a refresh started at least five minutes after the last real scan rescans. A refresh started just before that point can finish after it, and the normal 30-second cache TTL can delay the next refresh.

Fixes #19312.

## Behavior

- A timed-out awaited fingerprint probe returns the successful cached scan without changing its confirmed scan time or fingerprint.
- A late answer is ignored because it could describe a mutation that the cached scan predates.
- A fingerprint mismatch or an answered `null` still rescans.
- Explicit invalidation still forces a fresh generation.
- A previous probe that remains outstanding still takes the existing full-scan path on a subsequent refresh. This change does not eliminate scans for permanently wedged filesystems.
- SSH/WSL routing, cache schemas, Git commands and RPC fields remain unchanged. Host-local repositories on a headless remote Orca server benefit from the same logic as desktop-local repositories.

## Review verification

Contributor head: `e0a939fffeb677ff76ee686411c22b8be4c9d31e`. Editorial clarification: `3f0f7fa065e` (documentation/comments only).

- macOS: fingerprint gate, execution-host routing, real-Git fingerprint and runtime suites: **1303 passed, 1 skipped**.
- Linux (openclaw via Orca CLI): gate, execution-host routing and real-Git fingerprint suites: **44 passed**.
- Windows (awin via Orca CLI): the same three suites: **44 passed**.
- Two additional adversarial scenarios passed: invalidation during an expiring probe forces fresh rows; mutation after expiry triggers a scan on the next successful probe. Repro patches/logs retained in review evidence.
- A boundary scenario confirmed the reconciliation timing above; documentation and comments were corrected without changing behavior.
- Touched-file oxlint passes. `pnpm tc:node` passes with `NODE_OPTIONS=--max-old-space-size=8192`; the default 4GB heap ran out of memory.
- All review tests used `ORCA_BACKGROUND_LAUNCH=1`.

These focused checks verify the changed behavior and adjacent runtime paths; they do not claim a complete production overload soak or full repository test run.

## Visual proof

N/A — backend cache logic with no rendered UI change. Test assertions measure returned worktree rows, scan counts, timing, invalidation and late results directly.

## AI disclosure

The original contribution was AI-assisted (Anthropic Claude) and reviewed by Lesley Murfin, as disclosed in the original PR. Independent review, adversarial checks and documentation corrections were AI-assisted (OpenAI Codex).
