### PR TITLE
feat(source-control): add Push/Publish (Skip Hooks) to bypass pre-push hooks

### DIFF
--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -301,6 +301,18 @@ describe('git remote operations', () => {
     )
   })
 
+  it('passes --no-verify when requested', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('no branch'), { code: 1 }))
+
+    await gitPush('/repo', true, undefined, { noVerify: true })
+
+    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
+      ['push', '--no-verify', '--set-upstream', 'origin', 'HEAD'],
+      { cwd: '/repo' }
+    )
+  })
+
   it('maps non-fast-forward push failures to an actionable message', async () => {
     gitExecFileAsyncMock
       .mockRejectedValueOnce(new Error('no branch'))

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -27,7 +27,7 @@ export async function gitPush(
   worktreePath: string,
   _publish = false,
   pushTarget?: GitPushTarget,
-  options: { forceWithLease?: boolean } & GitRuntimeOptions = {}
+  options: { forceWithLease?: boolean; noVerify?: boolean } & GitRuntimeOptions = {}
 ): Promise<void> {
   try {
     if (pushTarget) {
@@ -51,6 +51,7 @@ export async function gitPush(
     const args = [
       'push',
       ...(options.forceWithLease ? ['--force-with-lease'] : []),
+      ...(options.noVerify ? ['--no-verify'] : []),
       '--set-upstream',
       ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
     ]

--- a/src/main/ipc/filesystem/git-remote/branch-mutation-handlers.ts
+++ b/src/main/ipc/filesystem/git-remote/branch-mutation-handlers.ts
@@ -27,6 +27,7 @@ export function registerGitRemoteBranchMutationHandlers(context: FilesystemHandl
         worktreeId?: string
         publish?: boolean
         forceWithLease?: boolean
+        noVerify?: boolean
         connectionId?: string
         pushTarget?: GitPushTarget
       }
@@ -53,7 +54,8 @@ export function registerGitRemoteBranchMutationHandlers(context: FilesystemHandl
             )
           : undefined
         return provider.pushBranch(args.worktreePath, publish, materializedPushTarget, {
-          forceWithLease: args.forceWithLease === true
+          forceWithLease: args.forceWithLease === true,
+          noVerify: args.noVerify === true
         })
       }
       const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
@@ -80,6 +82,7 @@ export function registerGitRemoteBranchMutationHandlers(context: FilesystemHandl
       }
       await gitPush(worktreePath, publish, materializedPushTarget, {
         forceWithLease: args.forceWithLease === true,
+        noVerify: args.noVerify === true,
         ...gitOptions,
         admissionTier: 'interactive'
       })

--- a/src/main/providers/ssh-git-remote-sync-provider.ts
+++ b/src/main/providers/ssh-git-remote-sync-provider.ts
@@ -8,14 +8,15 @@ export class SshGitRemoteSyncProvider extends SshGitWorkingTreeProvider {
     worktreePath: string,
     publish = false,
     pushTarget?: GitPushTarget,
-    options: { forceWithLease?: boolean } = {}
+    options: { forceWithLease?: boolean; noVerify?: boolean } = {}
   ): Promise<void> {
     await this.runWithGitReadInvalidation(async () => {
       await this.mux.request('git.push', {
         worktreePath,
         publish,
         pushTarget,
-        ...(options.forceWithLease === true ? { forceWithLease: true } : {})
+        ...(options.forceWithLease === true ? { forceWithLease: true } : {}),
+        ...(options.noVerify === true ? { noVerify: true } : {})
       })
     })
   }

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -216,6 +216,7 @@ const GitPushTargetParam = z.object({
 export const GitPush = WorktreeSelector.extend({
   publish: z.boolean().optional(),
   forceWithLease: z.boolean().optional(),
+  noVerify: z.boolean().optional(),
   pushTarget: GitPushTargetParam.optional()
 })
 

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -169,7 +169,8 @@ export const GIT_METHODS: RpcMethod[] = [
         params.worktree,
         params.publish,
         params.pushTarget,
-        params.forceWithLease
+        params.forceWithLease,
+        params.noVerify
       )
   }),
   defineMethod({

--- a/src/main/runtime/runtime-git-sync-commands.ts
+++ b/src/main/runtime/runtime-git-sync-commands.ts
@@ -198,7 +198,8 @@ export class RuntimeGitSyncCommands {
     worktreeSelector: string,
     publish?: boolean,
     pushTarget?: GitPushTarget,
-    forceWithLease?: boolean
+    forceWithLease?: boolean,
+    noVerify?: boolean
   ): Promise<{ ok: true }> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const provider = requireRuntimeGitProvider(target)
@@ -208,7 +209,8 @@ export class RuntimeGitSyncCommands {
         : undefined
       this.persistMaterializedPushTargetIfCreated(target, materializedPushTarget)
       await provider.pushBranch(target.worktree.path, publish === true, materializedPushTarget, {
-        forceWithLease: forceWithLease === true
+        forceWithLease: forceWithLease === true,
+        noVerify: noVerify === true
       })
       return { ok: true }
     }
@@ -224,6 +226,7 @@ export class RuntimeGitSyncCommands {
     this.persistMaterializedPushTargetIfCreated(target, materializedPushTarget)
     await gitPush(target.worktree.path, publish === true, materializedPushTarget, {
       forceWithLease: forceWithLease === true,
+      noVerify: noVerify === true,
       ...localGitOptionsForTarget(target),
       admissionTier: 'interactive'
     })

--- a/src/preload/api/git-bridge.ts
+++ b/src/preload/api/git-bridge.ts
@@ -81,6 +81,7 @@ export const gitApi = {
     worktreeId?: string
     publish?: boolean
     forceWithLease?: boolean
+    noVerify?: boolean
     connectionId?: string
     pushTarget?: unknown
   }): Promise<void> => ipcRenderer.invoke('git:push', args),

--- a/src/relay/git-handler-sync-operations.ts
+++ b/src/relay/git-handler-sync-operations.ts
@@ -31,6 +31,7 @@ export class GitHandlerSyncOperations extends GitHandlerOperationContext {
         const args = [
           'push',
           ...(params.forceWithLease === true ? ['--force-with-lease'] : []),
+          ...(params.noVerify === true ? ['--no-verify'] : []),
           '--set-upstream',
           ...(target ? [target.remote, target.refspec] : ['origin', 'HEAD'])
         ]

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-item-types.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-item-types.ts
@@ -26,6 +26,7 @@ export type DropdownActionKind =
   | 'rebase_base'
   | 'fetch'
   | 'publish'
+  | 'publish_no_verify'
 
 export type DropdownItem = {
   kind: DropdownActionKind

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-item-types.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-item-types.ts
@@ -19,6 +19,7 @@ export type DropdownActionKind =
   | 'create_pr'
   | 'push_create_pr'
   | 'push'
+  | 'push_no_verify'
   | 'force_push'
   | 'pull'
   | 'fast_forward'

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -39,6 +39,7 @@ describe('resolveDropdownItems', () => {
       'commit_sync',
       'separator',
       'push',
+      'push_no_verify',
       'force_push',
       'create_pr',
       'push_create_pr',
@@ -95,6 +96,8 @@ describe('resolveDropdownItems', () => {
       items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
     expect(byKind.push.disabled).toBe(false)
+    expect(byKind.push_no_verify.disabled).toBe(false)
+    expect(byKind.push_no_verify.label).toBe('Push (Skip Hooks)')
     expect(byKind.force_push.disabled).toBe(false)
     expect(byKind.commit_push.disabled).toBe(true)
     expect(byKind.publish.disabled).toBe(false)
@@ -115,6 +118,7 @@ describe('resolveDropdownItems', () => {
       items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
     expect(byKind.push.title).toBe('Check out a branch before pushing commits')
+    expect(byKind.push_no_verify.title).toBe('Check out a branch before pushing commits')
     expect(byKind.publish.label).toBe('No Branch')
     expect(byKind.publish.title).toBe('Check out a branch before publishing commits')
     expect(byKind.publish.disabled).toBe(true)

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.test.ts
@@ -47,7 +47,8 @@ describe('resolveDropdownItems', () => {
       'sync',
       'rebase_base',
       'fetch',
-      'publish'
+      'publish',
+      'publish_no_verify'
     ])
   })
 
@@ -97,6 +98,8 @@ describe('resolveDropdownItems', () => {
     expect(byKind.force_push.disabled).toBe(false)
     expect(byKind.commit_push.disabled).toBe(true)
     expect(byKind.publish.disabled).toBe(false)
+    expect(byKind.publish_no_verify.disabled).toBe(false)
+    expect(byKind.publish_no_verify.label).toBe('Publish Branch (Skip Hooks)')
     expect(byKind.fetch.disabled).toBe(false)
   })
 
@@ -115,6 +118,8 @@ describe('resolveDropdownItems', () => {
     expect(byKind.publish.label).toBe('No Branch')
     expect(byKind.publish.title).toBe('Check out a branch before publishing commits')
     expect(byKind.publish.disabled).toBe(true)
+    expect(byKind.publish_no_verify.label).toBe('No Branch')
+    expect(byKind.publish_no_verify.disabled).toBe(true)
   })
 
   it('disables Publish Branch when branch already has an upstream', () => {
@@ -127,6 +132,7 @@ describe('resolveDropdownItems', () => {
       items.filter((e) => e.kind !== 'separator').map((e) => [e.kind, e])
     )
     expect(byKind.publish.disabled).toBe(true)
+    expect(byKind.publish_no_verify.disabled).toBe(true)
   })
 
   it('renders counts on action labels when > 0', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -14,8 +14,18 @@ import { buildHostedReviewDropdownItems } from './source-control-dropdown-review
 export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntry[] {
   const ctx = deriveDropdownActionContext(inputs)
   const { commit, commitPush, commitSync } = buildCommitDropdownItems(ctx)
-  const { push, forcePush, pull, fastForward, sync, rebase, fetch, publish, publishNoVerify } =
-    buildRemoteDropdownItems(ctx)
+  const {
+    push,
+    pushNoVerify,
+    forcePush,
+    pull,
+    fastForward,
+    sync,
+    rebase,
+    fetch,
+    publish,
+    publishNoVerify
+  } = buildRemoteDropdownItems(ctx)
   const { createPR, pushCreatePR } = buildHostedReviewDropdownItems(ctx)
   const { conflictOperation, isPullRequestOperationActive, globalBusy } = ctx
 
@@ -25,6 +35,7 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     commitSync,
     { kind: 'separator', id: 'before-remote' },
     push,
+    pushNoVerify,
     forcePush,
     createPR,
     pushCreatePR,

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-items.ts
@@ -14,7 +14,7 @@ import { buildHostedReviewDropdownItems } from './source-control-dropdown-review
 export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntry[] {
   const ctx = deriveDropdownActionContext(inputs)
   const { commit, commitPush, commitSync } = buildCommitDropdownItems(ctx)
-  const { push, forcePush, pull, fastForward, sync, rebase, fetch, publish } =
+  const { push, forcePush, pull, fastForward, sync, rebase, fetch, publish, publishNoVerify } =
     buildRemoteDropdownItems(ctx)
   const { createPR, pushCreatePR } = buildHostedReviewDropdownItems(ctx)
   const { conflictOperation, isPullRequestOperationActive, globalBusy } = ctx
@@ -33,7 +33,8 @@ export function resolveDropdownItems(inputs: DropdownActionInputs): DropdownEntr
     sync,
     rebase,
     fetch,
-    publish
+    publish,
+    publishNoVerify
   ]
   if (conflictOperation === 'merge' || conflictOperation === 'rebase') {
     const isRebase = conflictOperation === 'rebase'

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
@@ -18,6 +18,7 @@ import {
 
 export type RemoteDropdownItems = {
   push: DropdownItem
+  pushNoVerify: DropdownItem
   forcePush: DropdownItem
   pull: DropdownItem
   fastForward: DropdownItem
@@ -72,6 +73,24 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
                     ? `Nothing to push${upstreamStatus?.upstreamName ? ` to ${upstreamStatus.upstreamName}` : ''}`
                     : describePushCount(ahead),
     // Why: Push stays available without an upstream (git resolves --set-upstream) and under force-with-lease; only detached HEAD and unknown review targets block.
+    disabled: globalBusy || publishBlockedByDetachedHead || pushBlockedByOpenHostedReviewTarget
+  }
+
+  const pushNoVerify: DropdownItem = {
+    kind: 'push_no_verify',
+    label: translate(
+      'auto.components.right.sidebar.source.control.dropdown.items.push.no.verify.label',
+      'Push (Skip Hooks)'
+    ),
+    title: publishBlockedByDetachedHead
+      ? 'Check out a branch before pushing commits'
+      : pushBlockedByOpenHostedReviewTarget
+        ? 'Linked review branch target is unavailable'
+        : translate(
+            'auto.components.right.sidebar.source.control.dropdown.items.push.no.verify.title',
+            'Push this branch without running pre-push hooks'
+          ),
+    // Why: same availability as Push — noVerify only changes the git argv, not when the row is usable.
     disabled: globalBusy || publishBlockedByDetachedHead || pushBlockedByOpenHostedReviewTarget
   }
 
@@ -271,5 +290,16 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
       publishBlockedByDetachedHead
   }
 
-  return { push, forcePush, pull, fastForward, sync, rebase, fetch, publish, publishNoVerify }
+  return {
+    push,
+    pushNoVerify,
+    forcePush,
+    pull,
+    fastForward,
+    sync,
+    rebase,
+    fetch,
+    publish,
+    publishNoVerify
+  }
 }

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-remote-items.ts
@@ -25,6 +25,7 @@ export type RemoteDropdownItems = {
   rebase: DropdownItem
   fetch: DropdownItem
   publish: DropdownItem
+  publishNoVerify: DropdownItem
 }
 
 export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDropdownItems {
@@ -229,5 +230,46 @@ export function buildRemoteDropdownItems(ctx: DropdownActionContext): RemoteDrop
       publishBlockedByDetachedHead
   }
 
-  return { push, forcePush, pull, fastForward, sync, rebase, fetch, publish }
+  const publishNoVerify: DropdownItem = {
+    kind: 'publish_no_verify',
+    label:
+      publishBlockedByMergedPR || publishBlockedByPRLoading
+        ? 'PR Status'
+        : publishBlockedByOpenHostedReview
+          ? 'Linked Review'
+          : publishBlockedByDetachedHead
+            ? 'No Branch'
+            : translate(
+                'auto.components.right.sidebar.source.control.dropdown.items.publish.no.verify.label',
+                'Publish Branch (Skip Hooks)'
+              ),
+    title: upstreamLoading
+      ? 'Checking branch status…'
+      : publishBlockedByPRLoading
+        ? 'Checking PR status…'
+        : publishBlockedByMergedPR
+          ? 'PR is already merged'
+          : publishBlockedByOpenHostedReview
+            ? canPushLinkedReviewWithoutUpstream
+              ? 'Linked review branch already exists'
+              : 'Linked review branch target is unavailable'
+            : publishBlockedByDetachedHead
+              ? 'Check out a branch before publishing commits'
+              : hasUpstream
+                ? 'Branch is already published'
+                : translate(
+                    'auto.components.right.sidebar.source.control.dropdown.items.publish.no.verify.title',
+                    'Publish this branch to origin without running pre-push hooks'
+                  ),
+    disabled:
+      globalBusy ||
+      upstreamLoading ||
+      hasUpstream ||
+      publishBlockedByPRLoading ||
+      publishBlockedByMergedPR ||
+      publishBlockedByOpenHostedReview ||
+      publishBlockedByDetachedHead
+  }
+
+  return { push, forcePush, pull, fastForward, sync, rebase, fetch, publish, publishNoVerify }
 }

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-action-dispatch.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-action-dispatch.ts
@@ -83,6 +83,7 @@ export function useSourceControlActionDispatch({
         case 'sync':
         case 'fetch':
         case 'publish':
+        case 'publish_no_verify':
         case 'rebase_base':
           void runRemoteAction(kind === 'rebase_base' ? 'rebase' : kind)
       }

--- a/src/renderer/src/components/right-sidebar/source-control/review/use-action-dispatch.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/use-action-dispatch.ts
@@ -77,6 +77,7 @@ export function useSourceControlActionDispatch({
           void runCreatePrIntent()
           return
         case 'push':
+        case 'push_no_verify':
         case 'force_push':
         case 'pull':
         case 'fast_forward':

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-remote-action-runner.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-remote-action-runner.ts
@@ -18,6 +18,7 @@ import type { SourceControlStatusRefresh } from './use-status-refresh'
 
 export type SourceControlRemoteActionKind =
   | 'push'
+  | 'push_no_verify'
   | 'force_push'
   | 'pull'
   | 'fast_forward'
@@ -120,48 +121,25 @@ export function useSourceControlRemoteActionRunner({
       const failureBranchName = targetIsActiveWorktree ? branchName || null : null
       setRemoteActionErrors((prev) => ({ ...prev, [target.worktreeId]: null }))
       try {
-        if (kind === 'publish') {
-          await pushBranch(
-            target.worktreeId,
-            target.worktreePath,
-            true,
-            target.connectionId,
-            target.pushTarget,
-            { runtimeTargetSettings: target.settings }
-          )
-          return { status: 'ok' }
-        }
-        if (kind === 'publish_no_verify') {
-          await pushBranch(
-            target.worktreeId,
-            target.worktreePath,
-            true,
-            target.connectionId,
-            target.pushTarget,
-            { noVerify: true, runtimeTargetSettings: target.settings }
-          )
-          return { status: 'ok' }
-        }
-        if (kind === 'push') {
+        if (
+          kind === 'publish' ||
+          kind === 'publish_no_verify' ||
+          kind === 'push' ||
+          kind === 'push_no_verify' ||
+          kind === 'force_push'
+        ) {
           // Why: kind 'push' must stay a regular push; auto-upgrading made the always-enabled dropdown Push row silently force-push against its tooltip.
           await pushBranch(
             target.worktreeId,
             target.worktreePath,
-            false,
+            kind === 'publish' || kind === 'publish_no_verify',
             target.connectionId,
             target.pushTarget,
-            { runtimeTargetSettings: target.settings }
-          )
-          return { status: 'ok' }
-        }
-        if (kind === 'force_push') {
-          await pushBranch(
-            target.worktreeId,
-            target.worktreePath,
-            false,
-            target.connectionId,
-            target.pushTarget,
-            { forceWithLease: true, runtimeTargetSettings: target.settings }
+            {
+              forceWithLease: kind === 'force_push',
+              noVerify: kind === 'publish_no_verify' || kind === 'push_no_verify',
+              runtimeTargetSettings: target.settings
+            }
           )
           return { status: 'ok' }
         }
@@ -232,10 +210,12 @@ export function useSourceControlRemoteActionRunner({
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] !== sequence) {
           return { status: 'superseded' }
         }
-        // Why: 'publish_no_verify' is a Publish variant at the dropdown/dispatch layer only —
-        // it reports and refreshes as a plain 'publish' failure, matching the messaging Force Push
-        // gets for 'force_push' vs. its own 'push' primary kind.
-        const errorKind = kind === 'publish_no_verify' ? 'publish' : kind
+        // Why: 'publish_no_verify' / 'push_no_verify' are Publish/Push variants at the
+        // dropdown/dispatch layer only — they report and refresh as plain 'publish'/'push'
+        // failures, matching the messaging Force Push gets for 'force_push' vs. its own
+        // 'push' primary kind.
+        const errorKind =
+          kind === 'publish_no_verify' ? 'publish' : kind === 'push_no_verify' ? 'push' : kind
         const actionError: SourceControlActionError = {
           kind: errorKind,
           message: resolveRemoteActionError(errorKind, error),

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-remote-action-runner.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-remote-action-runner.ts
@@ -24,6 +24,7 @@ export type SourceControlRemoteActionKind =
   | 'sync'
   | 'fetch'
   | 'publish'
+  | 'publish_no_verify'
   | 'rebase'
 
 // Why: statuses distinguish real failures from supersession and no-ops; collapsing to { ok: false } made Create PR treat supersession as a destructive failure.
@@ -130,6 +131,17 @@ export function useSourceControlRemoteActionRunner({
           )
           return { status: 'ok' }
         }
+        if (kind === 'publish_no_verify') {
+          await pushBranch(
+            target.worktreeId,
+            target.worktreePath,
+            true,
+            target.connectionId,
+            target.pushTarget,
+            { noVerify: true, runtimeTargetSettings: target.settings }
+          )
+          return { status: 'ok' }
+        }
         if (kind === 'push') {
           // Why: kind 'push' must stay a regular push; auto-upgrading made the always-enabled dropdown Push row silently force-push against its tooltip.
           await pushBranch(
@@ -220,9 +232,13 @@ export function useSourceControlRemoteActionRunner({
         if (remoteActionErrorSequenceByWorktreeRef.current[target.worktreeId] !== sequence) {
           return { status: 'superseded' }
         }
+        // Why: 'publish_no_verify' is a Publish variant at the dropdown/dispatch layer only —
+        // it reports and refreshes as a plain 'publish' failure, matching the messaging Force Push
+        // gets for 'force_push' vs. its own 'push' primary kind.
+        const errorKind = kind === 'publish_no_verify' ? 'publish' : kind
         const actionError: SourceControlActionError = {
-          kind,
-          message: resolveRemoteActionError(kind, error),
+          kind: errorKind,
+          message: resolveRemoteActionError(errorKind, error),
           rawError: error instanceof Error ? error.message : String(error),
           syncPushStage: kind === 'sync' ? isSyncPushStageError(error) : false,
           branchName: failureBranchName,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12807,6 +12807,14 @@
                         "title": "Publish this branch to origin without running pre-push hooks"
                       }
                     }
+                  },
+                  "push": {
+                    "no": {
+                      "verify": {
+                        "label": "Push (Skip Hooks)",
+                        "title": "Push this branch without running pre-push hooks"
+                      }
+                    }
                   }
                 }
               },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12799,7 +12799,15 @@
                   "226b85a3a7": "Fetch",
                   "323bb614aa": "Commit & Sync",
                   "2b8e6595fd": "Commit",
-                  "04d709801d": "Fetch from remote without merging"
+                  "04d709801d": "Fetch from remote without merging",
+                  "publish": {
+                    "no": {
+                      "verify": {
+                        "label": "Publish Branch (Skip Hooks)",
+                        "title": "Publish this branch to origin without running pre-push hooks"
+                      }
+                    }
+                  }
                 }
               },
               "primary": {

--- a/src/renderer/src/runtime/runtime-git-sync-client.ts
+++ b/src/renderer/src/runtime/runtime-git-sync-client.ts
@@ -181,7 +181,12 @@ export async function rebaseRuntimeGitFromBase(
 
 export async function pushRuntimeGit(
   context: RuntimeGitContext,
-  args: { publish?: boolean; pushTarget?: GitPushTarget; forceWithLease?: boolean } = {}
+  args: {
+    publish?: boolean
+    pushTarget?: GitPushTarget
+    forceWithLease?: boolean
+    noVerify?: boolean
+  } = {}
 ): Promise<void> {
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind === 'local' || !context.worktreeId) {
@@ -191,7 +196,8 @@ export async function pushRuntimeGit(
       ...(context.worktreeId ? { worktreeId: context.worktreeId } : {}),
       ...(args.publish !== undefined ? { publish: args.publish } : {}),
       ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
-      ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {})
+      ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {}),
+      ...(args.noVerify !== undefined ? { noVerify: args.noVerify } : {})
     })
     return
   }
@@ -202,7 +208,8 @@ export async function pushRuntimeGit(
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       ...(args.publish !== undefined ? { publish: args.publish } : {}),
       ...(args.pushTarget !== undefined ? { pushTarget: args.pushTarget } : {}),
-      ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {})
+      ...(args.forceWithLease !== undefined ? { forceWithLease: args.forceWithLease } : {}),
+      ...(args.noVerify !== undefined ? { noVerify: args.noVerify } : {})
     },
     { timeoutMs: 30_000 }
   )

--- a/src/renderer/src/store/slices/editor-remote-branch-actions.test.ts
+++ b/src/renderer/src/store/slices/editor-remote-branch-actions.test.ts
@@ -364,6 +364,23 @@ describe('createEditorSlice remote branch actions', () => {
     expect(store.getState().isRemoteOperationActive).toBe(false)
   })
 
+  it('pushes with --no-verify when requested on an already-published branch', async () => {
+    const store = createEditorStore()
+
+    await store.getState().pushBranch('wt-1', '/repo', false, undefined, undefined, {
+      noVerify: true
+    })
+
+    expect(gitPushMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      publish: false,
+      connectionId: undefined,
+      worktreeId: 'wt-1',
+      noVerify: true
+    })
+    expect(store.getState().isRemoteOperationActive).toBe(false)
+  })
+
   it('preserves actionable publish errors and refreshes upstream after rejection', async () => {
     const store = createEditorStore()
     const publishError = new Error(

--- a/src/renderer/src/store/slices/editor-remote-branch-actions.test.ts
+++ b/src/renderer/src/store/slices/editor-remote-branch-actions.test.ts
@@ -347,6 +347,23 @@ describe('createEditorSlice remote branch actions', () => {
     expect(store.getState().isRemoteOperationActive).toBe(false)
   })
 
+  it('publishes with --no-verify when requested', async () => {
+    const store = createEditorStore()
+
+    await store.getState().pushBranch('wt-1', '/repo', true, undefined, undefined, {
+      noVerify: true
+    })
+
+    expect(gitPushMock).toHaveBeenCalledWith({
+      worktreePath: '/repo',
+      publish: true,
+      connectionId: undefined,
+      worktreeId: 'wt-1',
+      noVerify: true
+    })
+    expect(store.getState().isRemoteOperationActive).toBe(false)
+  })
+
   it('preserves actionable publish errors and refreshes upstream after rejection', async () => {
     const store = createEditorStore()
     const publishError = new Error(

--- a/src/renderer/src/store/slices/editor/actions/git-remote-push-pull.ts
+++ b/src/renderer/src/store/slices/editor/actions/git-remote-push-pull.ts
@@ -34,7 +34,12 @@ export function createGitRemotePushPull(
       try {
         await pushRuntimeGit(
           { settings: runtimeSettings, worktreeId, worktreePath, connectionId },
-          { publish, pushTarget, forceWithLease: options.forceWithLease }
+          {
+            publish,
+            pushTarget,
+            forceWithLease: options.forceWithLease,
+            noVerify: options.noVerify
+          }
         )
       } catch (error) {
         shouldRefreshAfterRejectedPush = isNonFastForwardRemoteError(error)

--- a/src/renderer/src/store/slices/editor/types/editor-git-slice.ts
+++ b/src/renderer/src/store/slices/editor/types/editor-git-slice.ts
@@ -59,7 +59,7 @@ export type EditorGitSlice = {
     publish?: boolean,
     connectionId?: string,
     pushTarget?: GitPushTarget,
-    options?: GitRuntimeOperationOptions & { forceWithLease?: boolean }
+    options?: GitRuntimeOperationOptions & { forceWithLease?: boolean; noVerify?: boolean }
   ) => Promise<void>
   pullBranch: (
     worktreeId: string,


### PR DESCRIPTION
Add "Push (Skip Hooks)" and "Publish Branch (Skip Hooks)" dropdown entries that publish/push with --no-verify, so an intentional push isn't blocked by a rejecting pre-push hook. Threads a new noVerify flag end to end alongside the existing forceWithLease flag: dropdown -> dispatch -> remote action runner -> store pushBranch action -> runtime client -> preload bridge -> main IPC handler / SSH provider / runtime commands -> RPC method and schema -> relay handler -> the git push argv.

## ELI5

Sometimes a repo has a "pre-push hook" — a script that runs automatically and can block your `git push` (e.g. a lint or test gate). This adds two buttons in the Source Control panel's dropdown — "Push (Skip Hooks)" and "Publish Branch (Skip Hooks)" — that push/publish anyway by skipping that check, the same as running `git push --no-verify` in a terminal, just from the UI.

## What Changed

Added two new rows to the Source Control panel's "more actions" dropdown: "Push (Skip Hooks)" (next to Push, available whenever Push is) and "Publish Branch (Skip Hooks)" (next to Publish Branch, available only before the branch has an upstream). Both publish with git's `--no-verify` flag. The new `noVerify` flag is threaded consistently through every push transport the app supports — local IPC, SSH-connected worktrees, and relay-connected remote sessions — mirroring the exact pattern already used for the existing Force Push (`forceWithLease`) flag.

## Why

There was previously no way to push/publish from the UI when a pre-push hook rejected it — the user had to drop to a terminal and run `git push --no-verify` manually. Publish Branch only covers the very first push (before an upstream exists); a hook can just as easily block a lah variants are needed. This reuses the Force Push wiring  consistent across local/SSH/relay worktrees ins one-off mechanism. 

## Linked Issue Fixes #19303 

## Visual Proof 
Screenshot of the Source Contwn showing the two new rows: "Push (Skip Hooks)" (next to  (Skip Hooks)" (next to Publish Branch).

<img width="338" height="477" alt="image" src="https://github.com/user-attachments/assets/45f898b4-9c04-4873-b418-c439a4b37b6c" />

## Testing

Ran automated tests, typechect click through the new
dropdown items in the running app myself (screenshot above was captured manually).
Tested on macOS only (dev envws/SSH verification performed.

- `tsc -p config/tsconfig.tc.
- `oxlint` / `oxfmt --check` on changed files — clean
- `vitest run src/main/git/re
src/renderer/src/components/rol-dropdown-items.test.ts
src/renderer/src/store/slicesions.test.ts` — 149 passed

- [x] I manually tested these
- [x] Automated tests added/unot below

## AI Disclosure
This PR was implemented with Claude Code (Claude Sonnet 5) — AI-assisted code generation with human review and testing before submission.

## Review

## Agent skill upstream boundary
 - [x] Not applicable, or this change follows
`docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically
translates no upstream skill-installer source, tests, fixtures, registry entries,
path tables, comments, or documentation.

## Notes

- **Security**: `--no-verify` is only applied when the user explicitly selects one of
these new, separate menu item Push/Publish Branch paths
are unchanged and still run hooks normally.
- **Cross-platform**: change is a single conditional argv flag (`--no-verify`),
mirrored identically across tush code paths — noOS-specific behavior introduced.
- **Remote SSH**: covered — the flag is threaded through the SSH provider             (`ssh-git-remote-sync-provider.ts`) and the relay handler
(`git-handler-sync-operations.ts`) the same way as the existing `forceWithLease`
flag.
- **Mobile**: not applicable — this is a desktop Source Control panel change only.
- **Backwards compatibility**onal field on the `git.push`
RPC params — safe for mixed client/host versions (older peers simply ignore the
unknown field).
- **Performance**: negligible — one extra conditional array entry in an already-built argv array.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)