### PR TITLE
fix(wsl): tree-kill a timed-out wsl.exe instead of only its root (#19316)

### DIFF
--- a/src/main/wsl/wsl-guest-environment.ts
+++ b/src/main/wsl/wsl-guest-environment.ts
@@ -92,7 +92,15 @@ async function probeGuestEnvironment(
     // and the NUL-separated payload below is read through NUL-riddled text.
     env: { ...process.env, WSL_UTF8: '1' },
     timeoutMs: Math.min(PROBE_TIMEOUT_MS, budgetMs),
-    maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
+    maxOutputBytes: PROBE_MAX_OUTPUT_BYTES,
+    // Same reason as the runner's own spawn: without a barrier the timeout kills
+    // only the root and leaves whatever holds the console behind. This probe is
+    // the one that matters most on a wedged distro -- it is what fails FIRST, and
+    // it is what pushes every later call onto the shell-free lane, so it runs on
+    // the critical path of every occurrence. `TRANSIENT_RETRY_MS` throttles it to
+    // roughly one attempt per 5s per distro, which is a standing residue for as
+    // long as the wedge lasts.
+    terminationBarrier: true
   })
   if (result.timedOut) {
     return { kind: 'transient' }

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -153,6 +153,30 @@ describe('scripts', () => {
     expect(spec.args).toContain('ssh -T git@github.com || true\npnpm install')
   })
 
+  it('kills the whole tree on timeout, not just the wsl.exe root', async () => {
+    // The regression this pins: `terminate()` on the non-barrier path is a bare
+    // `child.kill()`, so a timeout reaped the wsl.exe client and left what it
+    // started behind -- on Windows the console host outlives it. Against a wedged
+    // distro (`wsl --list` reports Running while every `--exec` hangs) that is one
+    // orphaned conhost per probe: measured 8,731 orphans / 9,073 processes / 1.38M
+    // handles over two days, at which point process creation itself cost tens of
+    // seconds. The git runner already passes this flag; the WSL runner did not.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ loginPath: 'preferred', shell: 'bash', script: 'true' })
+    const spec = runProcessMock.mock.calls.at(-1)?.[0]
+    expect(spec.terminationBarrier).toBe(true)
+  })
+
+  it('kills the tree on the shell-free lane too, where the probe never resolved', async () => {
+    // Why a second case: the degraded lane (`loginPath: 'none'`) is the one a
+    // wedged distro actually takes, since the environment probe is what fails
+    // first. A barrier wired only into the happy path would miss every real
+    // occurrence of the leak.
+    await runWslProcess({ loginPath: 'none', shell: 'bash', script: 'true' })
+    const spec = runProcessMock.mock.calls.at(-1)?.[0]
+    expect(spec.terminationBarrier).toBe(true)
+  })
+
   it('falls back to stdin for a script too large for a command line', async () => {
     // A user hook is the one unbounded script here (`run-both` concatenates two
     // orca.yaml scripts, and a vendored installer is ~15KB). Windows caps the

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -247,7 +247,24 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
     env: buildHostEnv(spec.env),
     input: delivery === 'stdin' ? spec.script : undefined,
     timeoutMs: remainingMs,
-    maxOutputBytes: spec.maxOutputBytes
+    maxOutputBytes: spec.maxOutputBytes,
+    // Why: without this a timeout kills only the root. `terminate()` on the
+    // non-barrier path is a bare `child.kill()`, so whatever still holds the
+    // console is never reaped; the barrier issues `taskkill /pid <root> /t /f`
+    // while the root is still alive, which reaps it. Orca already tree-kills
+    // `wsl.exe` in production -- git's WSL lane threads the same flag
+    // (`git/command-runner/wsl-command-resolution.ts`) -- so this is wiring, not
+    // new machinery or a new risk.
+    //
+    // Observed: a wedged distro (`wsl --list` reports Running while every
+    // `--exec` hangs) accumulated 8,731 orphaned conhosts / 9,073 processes /
+    // 1.38M handles over two days on Windows 10 19045, after which process
+    // creation itself cost tens of seconds. Stated as an observation, not as the
+    // proven mechanism: a root-only kill against a HEALTHY distro does NOT leak
+    // (measured, conhost died in 6/6 attributed cases), so something wedge-
+    // specific holds the console open. Scope: this reaps Windows-side
+    // descendants only, never the hung guest-side process inside the distro.
+    terminationBarrier: true
   })
 
   return {


### PR DESCRIPTION
Fixes #19316.

**Orca already tree-kills `wsl.exe` in production** — git's WSL lane threads `terminationBarrier` through all four `binary: 'wsl.exe'` call sites in `src/main/git/command-runner/wsl-command-resolution.ts` (lines 101, 132, 144, 156). The WSL *runner* does not. That asymmetry is this report.

## The two sites

Both spawn `wsl.exe` via `runProcess` with a `timeoutMs` and no `terminationBarrier`:

| site | what it is |
|---|---|
| `src/main/wsl/wsl-runner.ts:240` (`runWslProcess`) | the single place Orca runs a program inside WSL |
| `src/main/wsl/wsl-guest-environment.ts:87` (`probeGuestEnvironment`) | the login-PATH probe |

On the non-barrier path `terminate()` (`src/shared/child-process/run-process.ts:310`) is a bare `child.kill(signal)`, so a timeout reaps the `wsl.exe` root and nothing else. With a barrier, `stopAndSettle` calls `signalBarrierTree()` **before** any `terminate(child)` (`run-process.ts:184-186`), so `taskkill /pid <root> /t /f` runs while the root is still alive and reaps the Windows-side descendants with it.

The probe site matters more than its size suggests: on a wedged distro it is what fails **first**, and it is what pushes every later call onto the shell-free lane. `TRANSIENT_RETRY_MS = 5_000` throttles it to roughly one attempt per 5s per distro, which is a standing residue for as long as the wedge lasts.

Note this is **not** the `wsl.exe` timeout being absent — `runWslProcess` computes `deadline = Date.now() + (spec.timeoutMs ?? DEFAULT_WSL_TIMEOUT_MS)` with `DEFAULT_WSL_TIMEOUT_MS = 30_000`. Adding a timeout would be a no-op. The defect is what the timeout kills.

## What was observed

Windows 10 Pro 19045. A WSL Ubuntu distro wedged — `wsl --list` reported it "Running" while every `wsl -d Ubuntu --exec ...` hung indefinitely. Over ~2 days:

- **8,731 orphaned `conhost.exe`**, 9,073 total processes, **1.38M handles**
- Accumulation: 12 (Sep 4) → 2,483 (Sep 5) → 6,231 (Sep 6)
- Process creation itself then cost tens of seconds; `claude` would not launch from a terminal
- 31 stuck `wsl.exe`, oldest 56 hours

Sampling process creation over 151s during the leak: `wsl.exe` 26 new / 11 conhosts, `git.exe` 10 / 6, `taskkill.exe` 7. That `taskkill` traffic is the git lane tree-killing correctly — both behaviours were visible side by side in one measurement.

## Honest limits on the mechanism claim

I am **not** claiming "one orphaned conhost per probe" as a proven mechanism, and the numbers argue against the simple version: 8,731 conhosts against only 31 stuck `wsl.exe` means the root died in the overwhelming majority of cases and the console host outlived it anyway.

I tried to reproduce it on a healthy distro and **failed to**: spawning `wsl -d Ubuntu --exec sleep 1000`, then killing the root two ways and tracking each conhost by PID + creation time, the conhost died in **6/6 attributed cases under both** root-only `TerminateProcess` and `taskkill /t /f`. (An earlier before/after *count* comparison appeared to show a difference; that was background churn — repeat runs produced negative "leaks". Discard it.)

So: something wedge-specific holds the console open, and I could not isolate it on a healthy box. What the code alone supports is narrower and still sufficient — **a root-only kill cannot reap whatever holds the console; a tree-kill issued while the root is alive can.** The 8,731 figure is the observation that prompted the search, not proof of the mechanism.

## Patch

Both sites, identical one-liner:

```ts
    timeoutMs: remainingMs,
    maxOutputBytes: spec.maxOutputBytes,
+   terminationBarrier: true
```

Tests added in `src/main/wsl/wsl-runner.test.ts` asserting `spec.terminationBarrier === true` on both the `loginPath: 'preferred'` and `loginPath: 'none'` lanes — the latter because that degraded lane is the one a wedged distro actually takes. Same seam-contract shape the repo already uses for git (`runner-wsl-direct-read.test.ts:290`, `:323`).

Verified locally: `src/main/wsl` → **153 passed, 11 skipped**; oxlint and oxfmt clean. Reverting the source and keeping the tests → **2 fail** (`expected undefined to be true`), so they guard the behaviour rather than restate it. I could not run the full CI gate on this box.

## Disclosures

- **Scope.** `taskkill /t` is a Windows PPID walk. It reaps `conhost.exe` and Windows-side descendants, **not** the hung guest-side process inside the distro. It also will not reap an already kernel-wedged `wsl.exe` — the 31 stale ones needed a distro restart.
- **Latency.** Where taskkill cannot verify termination, the call now settles up to 12s later (`PROCESS_EXIT_GRACE_MS = 2_000` + `BARRIER_UNVERIFIED_EXIT_GRACE_MS = 10_000`) versus timeout + 2s unconditionally before. On win32 taskkill normally verifies and settles immediately, so this is a note rather than a regression.
- **No spawn-side change on Windows.** `spawn-resolution.ts:40` adds `detached: true` only when `platform !== 'win32'`; behaviour is identical up to the moment of termination.
- **The admission gate cannot refuse this.** `own-chromium-tree-kill-guard.ts:44-45` refuses only pids in `readOrcaChromiumProcessPids()`; a live `wsl.exe` child handle is never one. `signalProcessTree` already guards recycled pids via `hasExited(child)` before any taskkill.
- **The relay is unaffected.** `spawnWslRelayProcess` (`wsl-hook-relay-launch.ts:138`) uses raw `spawn`, never `runProcess`, and is a sibling of the probes rather than a descendant, so no probe tree-kill can reach it.

## Same class, not fixed here

`src/main/wsl/wsl.ts` uses `execFile`/`execFileSync` timeouts, which also root-kill: `:77`/`:99` (`wslUncDirectoryExists[Async]`) and `:287`/`:321` (`getWslHome[Async]`). The host-level `wsl --list` probes at `:226`/`:249` are likely innocent — `wsl --list` kept working throughout this incident. Unrelated, but adjacent: `wsl.ts:98` passes no `windowsHide`, so that probe can flash a visible console.

## Suggested poka-yoke

An invariant over `src/main/wsl/` requiring every `runProcess` spawn of `wsl.exe` to carry a barrier. `wsl-guest-environment.ts` escaped `wsl-invocation-boundary.test.ts` only because that guard exempts its own owner directory (line 33), so it was on no allowlist and nothing tracked it. The repo already likes this shape — that boundary test is exactly it.

**Verification in this PR:** `src/main/wsl` → 153 passed, 11 skipped; oxlint and oxfmt clean. Reverting the source and keeping the tests → 2 fail (`expected undefined to be true`). I could not run the full `pnpm lint/typecheck/test/build` gate on this box, so CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
