### PR TITLE
fix(native-chat): stop an unanswered host from reading as one that refuses structured chat

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-worker-start-mode.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-mode.ts
@@ -88,7 +88,10 @@ const BLOCKER_REASON: Record<
   'tui-launch-customization': 'tui_launch_customization',
   'remote-execution-host': 'remote_execution_host',
   'project-runtime': 'wsl_execution_runtime',
-  'runtime-capability': 'structured_sessions_unavailable'
+  'runtime-capability': 'structured_sessions_unavailable',
+  // Orchestration passes its own host's list, so this is unreachable there; the map is
+  // exhaustive by type and must still name it.
+  'runtime-capability-unknown': 'structured_sessions_unavailable'
 }
 
 /** The host's own create-support verdict (`agentSession.createSupport`) in this vocabulary. */

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume-in-chat-workspace.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume-in-chat-workspace.ts
@@ -4,7 +4,10 @@ import {
 } from '@/lib/agent-launch-routing'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import {
+  readLocalRuntimeCapabilities,
+  readLocalRuntimeCapabilitiesOrUnknown
+} from '@/runtime/local-runtime-capabilities'
 import { useAppStore } from '@/store'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import { isAgentSessionHandleProvider } from '../../../../shared/agent-session-provider-handle'
@@ -46,7 +49,7 @@ export function resolveAiVaultSessionResumeInChatForWorkspace(args: {
           useAppStore.getState(),
           targetWorkspaceId as string
         ),
-        hostCapabilities: readLocalRuntimeCapabilities(),
+        hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
         workspaceKind: (targetWorkspaceId as string).startsWith('folder:')
           ? 'folder'
           : 'git-worktree',

--- a/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-composer-submit.ts
@@ -23,7 +23,7 @@ import {
   hasExplicitTuiAgentArgs,
   resolveAgentLaunchRoute
 } from '@/lib/agent-launch-routing'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import { readLocalRuntimeCapabilitiesOrUnknown } from '@/runtime/local-runtime-capabilities'
 import { startStructuredAgentLaunch } from '@/lib/structured-agent-session-launch'
 import { isAgentSessionHandleProvider } from '../../../../shared/agent-session-provider-handle'
 import { StructuredAgentSessionCreateRefusalError } from '@/lib/launch-structured-agent-session'
@@ -147,7 +147,7 @@ export async function submitFolderWorkspaceCreate({
         executionHostId: runtimeEnvironmentId
           ? `runtime:${encodeURIComponent(runtimeEnvironmentId)}`
           : (projectGroup.connectionId ?? 'local'),
-        hostCapabilities: readLocalRuntimeCapabilities(),
+        hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
         workspaceKind: 'folder',
         promptDelivery: launchDraftPrompt ? 'draft' : 'auto-submit',
         launchText: launchDraftPrompt ?? note,

--- a/src/renderer/src/hooks/composer-state/full-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/full-creation-execution.ts
@@ -42,7 +42,7 @@ import {
   hasExplicitTuiLaunchCustomization,
   resolveAgentLaunchRoute
 } from '@/lib/agent-launch-routing'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import { readLocalRuntimeCapabilitiesOrUnknown } from '@/runtime/local-runtime-capabilities'
 import { settleFullCreationStructuredLaunch } from './full-creation-structured-launch'
 import { finalizeFullCreation } from './full-creation-finalization'
 import { buildFullCreationIssueCommand } from './full-creation-issue-command'
@@ -140,7 +140,7 @@ export function useFullCreationExecution(input: FullCreationExecutionInput) {
         agent: tuiAgent,
         settings,
         executionHostId: selectedRepoExecutionHostId ?? 'local',
-        hostCapabilities: readLocalRuntimeCapabilities(),
+        hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
         workspaceKind: selectedRepoIsGit ? 'git-worktree' : 'folder',
         promptDelivery: startupPlan?.draftPrompt ? 'draft' : 'auto-submit',
         launchText: startupPlan?.draftPrompt ?? submitStartupPrompt,

--- a/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
+++ b/src/renderer/src/hooks/composer-state/quick-creation-execution.ts
@@ -50,7 +50,7 @@ import {
   hasExplicitTuiLaunchCustomization,
   resolveAgentLaunchRoute
 } from '@/lib/agent-launch-routing'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import { readLocalRuntimeCapabilitiesOrUnknown } from '@/runtime/local-runtime-capabilities'
 
 export function useQuickCreationExecution(input: QuickCreationExecutionInput) {
   const {
@@ -205,7 +205,7 @@ export function useQuickCreationExecution(input: QuickCreationExecutionInput) {
             executionHostId: ephemeralVmRecipe
               ? 'runtime:pending-ephemeral-vm'
               : (workspaceRunContext?.hostId ?? selectedRepoExecutionHostId ?? 'local'),
-            hostCapabilities: readLocalRuntimeCapabilities(),
+            hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
             workspaceKind: selectedRepoIsGit ? 'git-worktree' : 'folder',
             promptDelivery: quickDraftPrompt ? 'draft' : 'auto-submit',
             launchText: quickDraftPrompt ?? quickPrompt,

--- a/src/renderer/src/lib/agent-launch-routing.test.ts
+++ b/src/renderer/src/lib/agent-launch-routing.test.ts
@@ -76,6 +76,7 @@ describe('resolveAgentLaunchRoute', () => {
 
   it('fails closed for missing capability, unsupported providers, and explicit TUI options', () => {
     expect(route({ hostCapabilities: [] })).toBe('legacy-native-chat')
+    expect(route({ hostCapabilities: null })).toBe('legacy-native-chat')
     // openclaude and grok render native chat but have no structured adapter.
     expect(route({ agent: 'openclaude' })).toBe('legacy-native-chat')
     expect(route({ agent: 'grok' })).toBe('legacy-native-chat')

--- a/src/renderer/src/lib/agent-launch-routing.ts
+++ b/src/renderer/src/lib/agent-launch-routing.ts
@@ -30,7 +30,8 @@ export type AgentLaunchRoutingInput = {
     | null
     | undefined
   executionHostId: string
-  hostCapabilities: readonly string[]
+  /** Capabilities of the target host; `null` = not yet established. */
+  hostCapabilities: readonly string[] | null
   workspaceKind?: 'git-worktree' | 'folder' | 'floating'
   projectRuntime?: ProjectExecutionRuntimeResolution | null
   promptDelivery?: NativeChatLaunchPromptDelivery

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -38,7 +38,7 @@ import {
   hasExplicitTuiAgentArgs,
   resolveAgentLaunchRoute
 } from '@/lib/agent-launch-routing'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import { readLocalRuntimeCapabilitiesOrUnknown } from '@/runtime/local-runtime-capabilities'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 
 export type LaunchAgentInNewTabArgs = {
@@ -213,7 +213,7 @@ function launchAgentInNewTabInternal(
         agent,
         settings: store.settings,
         executionHostId: getExecutionHostIdForWorktree(store, worktreeId),
-        hostCapabilities: readLocalRuntimeCapabilities(),
+        hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
         workspaceKind,
         projectRuntime: getLocalProjectExecutionRuntimeContext(store, worktreeId),
         promptDelivery: viewModePromptDelivery,

--- a/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
+++ b/src/renderer/src/lib/launch-agent-structured-chat-guard.test.ts
@@ -14,7 +14,7 @@ const mockRefreshLocalStructuredSessionTabs = vi.fn()
 const mockToastError = vi.fn()
 const mockCallStructuredAgentSession = vi.fn()
 const STRUCTURED_HOST_CAPABILITIES = ['agent-session.structured.v1']
-let hostCapabilities: readonly string[] = STRUCTURED_HOST_CAPABILITIES
+let hostCapabilities: readonly string[] | null = STRUCTURED_HOST_CAPABILITIES
 
 function structuredLaunchIntent(worktreeId: string, sessionId = 'codex-session-1') {
   return {
@@ -113,7 +113,7 @@ vi.mock('@/runtime/local-structured-session-tabs-sync', () => ({
   LOCAL_STRUCTURED_SESSION_OWNER: 'local-structured-session'
 }))
 vi.mock('@/runtime/local-runtime-capabilities', () => ({
-  readLocalRuntimeCapabilities: () => hostCapabilities
+  readLocalRuntimeCapabilitiesOrUnknown: () => hostCapabilities
 }))
 vi.mock('@/lib/worktree-runtime-owner', () => ({
   getExecutionHostIdForWorktree: () =>
@@ -233,16 +233,19 @@ describe('structured chat adoption guard on the launch path', () => {
     expect(mockToastError).not.toHaveBeenCalled()
   })
 
-  it('routes every structured launch through the shared host capability gate', async () => {
-    hostCapabilities = []
-    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+  it.each([[], null])(
+    'preserves terminal-backed launches with capability answer %s',
+    async (capabilities) => {
+      hostCapabilities = capabilities
+      const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
 
-    launchAgentInNewTab({ agent: 'claude', worktreeId: 'wt-1' })
-    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
+      launchAgentInNewTab({ agent: 'claude', worktreeId: 'wt-1' })
+      launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1' })
 
-    expect(mockCreateStructuredCodexSessionLaunchIntent).not.toHaveBeenCalled()
-    expect(mockCreateTab).toHaveBeenCalledTimes(2)
-  })
+      expect(mockCreateStructuredCodexSessionLaunchIntent).not.toHaveBeenCalled()
+      expect(mockCreateTab).toHaveBeenCalledTimes(2)
+    }
+  )
 
   /** The toggle is hidden under Terminal chat but its persisted value survives, so the launch
    *  path must re-check the default view rather than trust a stale opt-in. */

--- a/src/renderer/src/lib/launch-work-item-direct-route-preparation.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-route-preparation.ts
@@ -10,7 +10,7 @@ import {
   type AgentLaunchRoute,
   type AgentLaunchRoutingInput
 } from '@/lib/agent-launch-routing'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import { readLocalRuntimeCapabilitiesOrUnknown } from '@/runtime/local-runtime-capabilities'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import {
   buildDirectWorkItemStartup,
@@ -97,7 +97,7 @@ export async function prepareDirectWorkItemAgentLaunch(args: {
       agent: effectiveAgent,
       settings: args.settings,
       executionHostId: getExecutionHostIdForWorktree(args.latestStore, args.worktreeId),
-      hostCapabilities: readLocalRuntimeCapabilities(),
+      hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
       workspaceKind: 'git-worktree',
       projectRuntime: getLocalProjectExecutionRuntimeContext(
         args.latestStore,

--- a/src/renderer/src/lib/onboarding-folder-agent-startup.ts
+++ b/src/renderer/src/lib/onboarding-folder-agent-startup.ts
@@ -18,7 +18,7 @@ import {
   resolveAgentLaunchRoute,
   type AgentLaunchRoute
 } from '@/lib/agent-launch-routing'
-import { readLocalRuntimeCapabilities } from '@/runtime/local-runtime-capabilities'
+import { readLocalRuntimeCapabilitiesOrUnknown } from '@/runtime/local-runtime-capabilities'
 
 export type OnboardingFolderAgentStartup = {
   command: string
@@ -135,7 +135,7 @@ export function resolveDismissedOnboardingFolderAgentLaunch(args: {
     agent,
     settings: args.settings,
     executionHostId: args.executionHostId,
-    hostCapabilities: readLocalRuntimeCapabilities(),
+    hostCapabilities: readLocalRuntimeCapabilitiesOrUnknown(),
     workspaceKind: 'folder',
     nativeChatTranscriptIsLocalReadable: args.nativeChatTranscriptIsLocalReadable,
     requiresTuiLaunchCustomization: hasExplicitTuiLaunchCustomization(args.settings, agent),

--- a/src/renderer/src/runtime/local-runtime-capabilities.test.ts
+++ b/src/renderer/src/runtime/local-runtime-capabilities.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   readLocalRuntimeCapabilities,
+  readLocalRuntimeCapabilitiesOrUnknown,
   refreshLocalRuntimeCapabilities,
   setLocalRuntimeCapabilitiesForTests
 } from './local-runtime-capabilities'
@@ -11,6 +12,22 @@ describe('local runtime capabilities', () => {
   beforeEach(() => {
     setLocalRuntimeCapabilitiesForTests([])
   })
+
+  it('starts unknown while the array reader stays compatible', async () => {
+    vi.resetModules()
+    const fresh = await import('./local-runtime-capabilities')
+    expect(fresh.readLocalRuntimeCapabilitiesOrUnknown()).toBeNull()
+    expect(fresh.readLocalRuntimeCapabilities()).toEqual([])
+  })
+
+  it.each([{}, { capabilities: [] }])(
+    'treats a successful legacy or empty response as known denial: %j',
+    async (status) => {
+      Object.assign(window, { api: { runtime: { getStatus: vi.fn(async () => status) } } })
+      await expect(refreshLocalRuntimeCapabilities()).resolves.toEqual([])
+      expect(readLocalRuntimeCapabilitiesOrUnknown()).toEqual([])
+    }
+  )
 
   it('fails closed until the live host advertises support', async () => {
     const getStatus = vi.fn(async () => ({ capabilities: ['agent-session.structured.v1'] }))
@@ -21,6 +38,7 @@ describe('local runtime capabilities', () => {
       'agent-session.structured.v1'
     ])
     expect(readLocalRuntimeCapabilities()).toEqual(['agent-session.structured.v1'])
+    expect(readLocalRuntimeCapabilitiesOrUnknown()).toEqual(['agent-session.structured.v1'])
   })
 
   it('coalesces concurrent live status reads', async () => {
@@ -38,6 +56,7 @@ describe('local runtime capabilities', () => {
       ['agent-session.structured.v1'],
       ['agent-session.structured.v1']
     ])
+    expect(first).toBe(second)
     expect(getStatus).toHaveBeenCalledOnce()
   })
 
@@ -55,5 +74,12 @@ describe('local runtime capabilities', () => {
 
     await expect(refreshLocalRuntimeCapabilities()).resolves.toEqual([])
     expect(readLocalRuntimeCapabilities()).toEqual([])
+    expect(readLocalRuntimeCapabilitiesOrUnknown()).toBeNull()
+
+    window.api.runtime.getStatus = vi
+      .fn()
+      .mockResolvedValue({ capabilities: ['agent-session.structured.v1'] })
+    await refreshLocalRuntimeCapabilities()
+    expect(readLocalRuntimeCapabilitiesOrUnknown()).toEqual(['agent-session.structured.v1'])
   })
 })

--- a/src/renderer/src/runtime/local-runtime-capabilities.ts
+++ b/src/renderer/src/runtime/local-runtime-capabilities.ts
@@ -1,9 +1,17 @@
 import type { RuntimeCapability } from '../../../shared/protocol-version'
 
-let localRuntimeCapabilities: readonly RuntimeCapability[] = []
+// `null` while no successful probe has landed. "Not asked yet" and "host says no" are
+// different answers, and a caller that routes on them must be able to tell them apart.
+let localRuntimeCapabilities: readonly RuntimeCapability[] | null = null
 let refreshPromise: Promise<readonly RuntimeCapability[]> | null = null
 
 export function readLocalRuntimeCapabilities(): readonly RuntimeCapability[] {
+  return localRuntimeCapabilities ?? []
+}
+
+/** `null` when the local runtime has not answered yet, so a routing decision can wait
+ *  instead of reading an unprobed host as unsupported. */
+export function readLocalRuntimeCapabilitiesOrUnknown(): readonly RuntimeCapability[] | null {
   return localRuntimeCapabilities
 }
 
@@ -15,8 +23,10 @@ export function refreshLocalRuntimeCapabilities(): Promise<readonly RuntimeCapab
       return localRuntimeCapabilities
     })
     .catch(() => {
-      localRuntimeCapabilities = []
-      return localRuntimeCapabilities
+      // Stays unknown rather than becoming an empty (== unsupported) list: a failed probe
+      // is not evidence about the host.
+      localRuntimeCapabilities = null
+      return []
     })
     .finally(() => {
       refreshPromise = null

--- a/src/shared/structured-native-chat-launch-route.test.ts
+++ b/src/shared/structured-native-chat-launch-route.test.ts
@@ -63,7 +63,8 @@ describe('per-launch structured feasibility', () => {
     ['a floating workspace', { workspaceKind: 'floating' }, 'floating-workspace'],
     ['a custom TUI launch', { requiresTuiLaunchCustomization: true }, 'tui-launch-customization'],
     ['an SSH host', { executionHostId: 'ssh:host-a' }, 'remote-execution-host'],
-    ['a missing capability', { hostCapabilities: [] }, 'runtime-capability']
+    ['a missing capability', { hostCapabilities: [] }, 'runtime-capability'],
+    ['an unanswered host', { hostCapabilities: null }, 'runtime-capability-unknown']
   ] as [string, Partial<StructuredNativeChatSupportInput>, string][])(
     'names %s as the blocker',
     (_name, overrides, blocker) => {

--- a/src/shared/structured-native-chat-launch-route.ts
+++ b/src/shared/structured-native-chat-launch-route.ts
@@ -28,6 +28,9 @@ export type StructuredNativeChatBlocker =
   | 'remote-execution-host'
   | 'project-runtime'
   | 'runtime-capability'
+  /** The owning host has not answered yet. Distinct from `runtime-capability`, which is the
+   *  host saying no: an unestablished answer must not read as a refusal. */
+  | 'runtime-capability-unknown'
 
 export type StructuredNativeChatSupport =
   | { supported: true }
@@ -36,7 +39,8 @@ export type StructuredNativeChatSupport =
 export type StructuredNativeChatSupportInput = {
   agent: TuiAgent
   executionHostId: string
-  hostCapabilities: readonly string[]
+  /** Capabilities of the host this launch would run on. `null` = not yet established. */
+  hostCapabilities: readonly string[] | null
   workspaceKind?: 'git-worktree' | 'folder' | 'floating'
   projectRuntime?: ProjectExecutionRuntimeResolution | null
   /** A draft stays terminal-backed: the composer, not a turn, owns unsent text. */
@@ -83,6 +87,9 @@ export function resolveStructuredNativeChatSupport(
   const projectRuntime = input.projectRuntime
   if (projectRuntime?.status === 'repair-required' || projectRuntime?.runtime.kind === 'wsl') {
     return { supported: false, blocker: 'project-runtime' }
+  }
+  if (input.hostCapabilities === null) {
+    return { supported: false, blocker: 'runtime-capability-unknown' }
   }
   if (!input.hostCapabilities.includes(STRUCTURED_AGENT_SESSION_RUNTIME_CAPABILITY)) {
     return { supported: false, blocker: 'runtime-capability' }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |

<!-- /orca-pr-loc -->

## What

`readLocalRuntimeCapabilities()` returned `[]` in two different situations — before the first status probe landed, and after one failed. Every structured-chat launch route consumes that value, so an **unprobed** host was routed to legacy chat in exactly the same way as a host that genuinely **refuses** structured sessions.

This keeps the two apart:

- the capability cache holds `null` until a probe succeeds
- a failed probe leaves it `null` rather than emptying it — a failed probe is not evidence about the host
- `resolveStructuredNativeChatSupport` names the case with its own blocker, `runtime-capability-unknown`, instead of borrowing `runtime-capability`

`readLocalRuntimeCapabilities()` keeps its existing `readonly RuntimeCapability[]` contract for callers that just want a list; the new `readLocalRuntimeCapabilitiesOrUnknown()` is what the launch routes use.

## Why now

This is groundwork for letting a structured chat session launch against a runtime peer rather than only the local host. Once capabilities come from *the host the launch would actually run on*, the difference matters a great deal: that host is a different machine on a different version, its answer arrives asynchronously, and "hasn't answered yet" must not be indistinguishable from "says no" — otherwise a capable remote silently downgrades to legacy chat on a slow probe.

Landing it separately keeps that change reviewable on its own.

## Behaviour

**No routing outcome changes.** Both cases still decline structured chat and fall back to legacy native chat. Only the stated reason changes, and only where it was previously untrue.

`hostCapabilities` still resolves to the *local* runtime at every call site — which remains correct today, because the route also still refuses any non-local `executionHostId`. A per-target resolver replaces it in the follow-up that teaches the route to reach a peer.

## Not in scope

`ai-vault-session-resume-in-chat-workspace.ts` has a second, separate gate that reads the resume-history capability from local capabilities while its `executionHostId` may resolve to a runtime peer. That is the same bug class but needs the async per-environment check to fix properly, so it is deliberately left for the routing change rather than half-fixed here.

## Test plan

- `pnpm test src/shared/structured-native-chat-launch-route.test.ts` — 18 pass, including a new table row asserting `hostCapabilities: null` names `runtime-capability-unknown`
- `pnpm test` on `local-runtime-capabilities`, `orchestration-worker-start-mode`, `agent-launch-routing` — 44 pass
- `pnpm tc` — exit 0
- `pnpm run check:code-quality:changed` — 0 new findings across 12 files (code quality, type-aware, React Doctor)

`BLOCKER_REASON` in `orchestration-worker-start-mode.ts` is an exhaustive `Record` over the blocker union, so the new member is compiler-enforced rather than silently unmapped. Orchestration always passes its own host's capability list, so the unknown branch is unreachable there.