### PR TITLE
fix(relay): never cache a region hint from a one-region catalog

### DIFF
--- a/src/main/runtime/relay/relay-control-origin.test.ts
+++ b/src/main/runtime/relay/relay-control-origin.test.ts
@@ -203,7 +203,13 @@ describe('RelayControlOrigin pending-connection replay', () => {
     // both the pairing authority and the E2EE device binding.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     fakes.controlConnect.mockResolvedValue(
-      ack({ pendingConns: [{ connId: 'conn-unknown', connTicket: TICKET }] })
+      ack({
+        pendingConns: [
+          { connId: 'conn-unknown', connTicket: TICKET },
+          { connId: 'conn-unknown-2', connTicket: TICKET },
+          { connId: 'conn-unknown-3', connTicket: TICKET }
+        ]
+      })
     )
     const { origin, owned } = createOrigin()
 
@@ -211,7 +217,11 @@ describe('RelayControlOrigin pending-connection replay', () => {
 
     expect(fakes.transports[0]!.openConnection).not.toHaveBeenCalled()
     expect(owned).toEqual([])
+    // One aggregated line per ack, not one per entry.
     expect(warn).toHaveBeenCalledOnce()
+    expect(warn.mock.calls[0]![0]).toBe(
+      '[relay] 3 pending connection(s) not replayable: relay stated no kind/device'
+    )
     warn.mockRestore()
   })
 

--- a/src/main/runtime/relay/relay-control-origin.ts
+++ b/src/main/runtime/relay/relay-control-origin.ts
@@ -260,17 +260,25 @@ export class RelayControlOrigin {
   // the phone waits out its attach deadline and is closed as if the host were offline.
   private replayPendingConnections(ack: RelayHostHelloAckMessage): void {
     const active = new Set(ack.activeConnIds)
+    let unreplayable = 0
     for (const pending of ack.pendingConns) {
       if (active.has(pending.connId) || this.transport.hasConnection(pending.connId)) {
         continue
       }
       const message = this.pendingConnectionOpen(pending)
       if (!message) {
-        console.warn('[relay] pending connection not replayable: relay stated no kind/device')
+        unreplayable += 1
         continue
       }
       // Not remembered: a replay must not extend the observed entry's own life.
       this.dialConnection(message)
+    }
+    // One line, not one per entry: a cell that predates the capability states no
+    // details for any of them, and that is the common case until the fleet rolls.
+    if (unreplayable > 0) {
+      console.warn(
+        `[relay] ${unreplayable} pending connection(s) not replayable: relay stated no kind/device`
+      )
     }
   }
 

--- a/src/main/runtime/relay/relay-region-catalog-fetch.ts
+++ b/src/main/runtime/relay/relay-region-catalog-fetch.ts
@@ -60,5 +60,9 @@ function isCanonicalDirectorOrigin(value: string): boolean {
 }
 
 export function isProbeOriginForDirector(origin: string, directorUrl: string): boolean {
-  return new URL(origin).hostname.endsWith(`.${new URL(directorUrl).hostname}`)
+  try {
+    return new URL(origin).hostname.endsWith(`.${new URL(directorUrl).hostname}`)
+  } catch {
+    return false
+  }
 }

--- a/src/main/runtime/relay/relay-region-catalog-fetch.ts
+++ b/src/main/runtime/relay/relay-region-catalog-fetch.ts
@@ -59,6 +59,6 @@ function isCanonicalDirectorOrigin(value: string): boolean {
   }
 }
 
-function isProbeOriginForDirector(origin: string, directorUrl: string): boolean {
+export function isProbeOriginForDirector(origin: string, directorUrl: string): boolean {
   return new URL(origin).hostname.endsWith(`.${new URL(directorUrl).hostname}`)
 }

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -589,6 +589,8 @@ describe('Relay region cache self-heal', () => {
     const { calls, fetch, resolver } = resolverFor(path, [800, 700, 710, 720])
 
     await resolver.invalidateIfAssignedCellIsFar('https://cell-7.attacker.example')
+    // Malformed input is refused the same way, without rejecting the best-effort call.
+    await resolver.invalidateIfAssignedCellIsFar('not a url')
     expect(fetch).not.toHaveBeenCalled()
     expect(calls).toHaveLength(0)
     expect(existsSync(cachePath(path))).toBe(true)

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -313,16 +313,16 @@ describe('Relay region preference', () => {
   it('recovers from corrupt cache and cancels an old directors error response', async () => {
     const path = userDataPath()
     writeFileSync(cachePath(path), '{not-json')
-    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    const healthy = sampledProbe({ [US]: [300, 36, 38, 40], [ASIA]: [400, 218, 220, 222] })
     await expect(
       new RelayRegionPreferenceResolver({
         directorUrl: DIRECTOR,
         userDataPath: path,
-        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        fetch: catalogFetch(BOTH_REGIONS),
         probe: healthy.probe,
         now: () => 1_000
       }).resolve()
-    ).resolves.toBe('asia-east2')
+    ).resolves.toBe('us-central1')
 
     rmSync(cachePath(path), { force: true })
     let cancelled = 0
@@ -345,17 +345,43 @@ describe('Relay region preference', () => {
   it('rejects a cache expiry beyond the 24-hour bound', async () => {
     const path = userDataPath()
     writeCache(path, 'us-central1', 10 * 24 * 60 * 60_000)
-    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    const healthy = sampledProbe({ [US]: [300, 236, 238, 240], [ASIA]: [90, 30, 32, 34] })
 
     await expect(
       new RelayRegionPreferenceResolver({
         directorUrl: DIRECTOR,
         userDataPath: path,
-        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        fetch: catalogFetch(BOTH_REGIONS),
         probe: healthy.probe,
         now: () => 1_000
       }).resolve()
     ).resolves.toBe('asia-east2')
+  })
+
+  it('withholds the hint for the short TTL when the catalog is missing a region', async () => {
+    // Why: the director lists only regions with a general cell, so a roll wave
+    // or a heartbeat stall shortens the catalog. A lone healthy region measured
+    // against nothing must not become a day-long hint pinning the desktop there.
+    const path = userDataPath()
+    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    const events: unknown[] = []
+    const resolver = new RelayRegionPreferenceResolver({
+      directorUrl: DIRECTOR,
+      userDataPath: path,
+      fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+      probe: healthy.probe,
+      now: () => 1_000,
+      logEvent: (event) => events.push(event)
+    })
+
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
+      region: null,
+      expiresAt: 1_000 + 60 * 60_000
+    })
+    expect(events).toEqual([
+      expect.objectContaining({ chosenRegion: 'no-hint', reason: 'catalog-incomplete' })
+    ])
   })
 
   it('uses a valid diagnostic override without network or cache mutation', async () => {
@@ -410,6 +436,32 @@ describe('Relay region preference', () => {
       }).resolve()
     ).resolves.toBeUndefined()
     expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it('gives the warm-up request three times the sample budget', async () => {
+    // Why: the warm-up pays the TLS setup the samples are meant to skip; a lossy
+    // far link that fails only the warm-up must not lose the whole region.
+    const budgets: number[] = []
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms) => {
+      budgets.push(ms)
+      return new AbortController().signal
+    })
+    try {
+      await new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: userDataPath(),
+        fetch: async (url) =>
+          String(url).endsWith('/v1/regions')
+            ? Response.json({ v: 1, regions: BOTH_REGIONS })
+            : cancelTrackingResponse(200, () => {}),
+        now: () => 1_000
+      }).resolve()
+    } finally {
+      timeout.mockRestore()
+    }
+    // One catalog request, then per origin one warm-up and three samples.
+    expect(budgets.filter((ms) => ms === 4_500)).toHaveLength(2)
+    expect(budgets.filter((ms) => ms === 1_500)).toHaveLength(7)
   })
 
   it('probes only the canonical health path and cancels its body', async () => {
@@ -529,6 +581,17 @@ describe('Relay region cache self-heal', () => {
         reason: 'catalog-unavailable'
       })
     ])
+  })
+
+  it('never probes an assigned cell that is not under the director', async () => {
+    const path = userDataPath()
+    writeCache(path, 'asia-east2', LIVE_EXPIRY)
+    const { calls, fetch, resolver } = resolverFor(path, [800, 700, 710, 720])
+
+    await resolver.invalidateIfAssignedCellIsFar('https://cell-7.attacker.example')
+    expect(fetch).not.toHaveBeenCalled()
+    expect(calls).toHaveLength(0)
+    expect(existsSync(cachePath(path))).toBe(true)
   })
 
   it('probes a given cell only once per process', async () => {

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -55,10 +55,17 @@ function cachePath(path: string): string {
   return join(path, 'orca-relay-region-preference.json')
 }
 
-function writeCache(path: string, region: string, expiresAt = 999): void {
+function writeCache(path: string, region: string, expiresAt = 999, fullCatalog = true): void {
   writeFileSync(
     cachePath(path),
-    JSON.stringify({ v: 1, directorUrl: DIRECTOR, region, latencyMs: 100, expiresAt })
+    JSON.stringify({
+      v: 1,
+      directorUrl: DIRECTOR,
+      region,
+      latencyMs: 100,
+      expiresAt,
+      ...(fullCatalog ? { fullCatalog: true } : {})
+    })
   )
 }
 
@@ -407,6 +414,49 @@ describe('Relay region preference', () => {
       expiresAt: 1_000 + 24 * 60 * 60_000
     })
     expect(events).toEqual([expect.objectContaining({ chosenRegion: 'asia-east2' })])
+  })
+
+  it('does not hold an incumbent an older build cached without the full-catalog marker', async () => {
+    // Why: a cache written before this rule may hold a lone survivor. Without the
+    // marker there is no proof it won against the other region, so it is re-earned.
+    const path = userDataPath()
+    writeCache(path, 'asia-east2', 999, false)
+    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        probe: healthy.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({ region: null })
+  })
+
+  it('marks a hint earned against a full catalog, and never a no-hint entry', async () => {
+    const path = userDataPath()
+    const both = sampledProbe({ [US]: [300, 95, 100, 105], [ASIA]: [300, 55, 60, 65] })
+    await new RelayRegionPreferenceResolver({
+      directorUrl: DIRECTOR,
+      userDataPath: path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe: both.probe,
+      now: () => 1_000
+    }).resolve()
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
+      region: 'asia-east2',
+      fullCatalog: true
+    })
+
+    const lone = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    await new RelayRegionPreferenceResolver({
+      directorUrl: DIRECTOR,
+      userDataPath: userDataPath(),
+      fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+      probe: lone.probe,
+      now: () => 1_000
+    }).resolve()
   })
 
   it('does not promote a lone survivor that is not the incumbent', async () => {

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -384,6 +384,47 @@ describe('Relay region preference', () => {
     ])
   })
 
+  it('holds a still-measured incumbent through an incomplete catalog', async () => {
+    // Why: an Asia desktop whose 24 h hint expires during a US roll wave sees a
+    // one-region catalog. Withholding the hint would place it at the director
+    // default for an hour; the incumbent was earned against a full catalog.
+    const path = userDataPath()
+    writeCache(path, 'asia-east2')
+    const events: unknown[] = []
+    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        probe: healthy.probe,
+        now: () => 1_000,
+        logEvent: (event) => events.push(event)
+      }).resolve()
+    ).resolves.toBe('asia-east2')
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
+      region: 'asia-east2',
+      expiresAt: 1_000 + 24 * 60 * 60_000
+    })
+    expect(events).toEqual([expect.objectContaining({ chosenRegion: 'asia-east2' })])
+  })
+
+  it('does not promote a lone survivor that is not the incumbent', async () => {
+    const path = userDataPath()
+    writeCache(path, 'us-central1')
+    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        probe: healthy.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({ region: null })
+  })
+
   it('uses a valid diagnostic override without network or cache mutation', async () => {
     const path = userDataPath()
     const fetch = vi.fn<typeof globalThis.fetch>()

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -409,11 +409,29 @@ describe('Relay region preference', () => {
         logEvent: (event) => events.push(event)
       }).resolve()
     ).resolves.toBe('asia-east2')
-    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
-      region: 'asia-east2',
-      expiresAt: 1_000 + 24 * 60 * 60_000
-    })
-    expect(events).toEqual([expect.objectContaining({ chosenRegion: 'asia-east2' })])
+    const held = JSON.parse(readFileSync(cachePath(path), 'utf8'))
+    expect(held).toMatchObject({ region: 'asia-east2', expiresAt: 1_000 + 24 * 60 * 60_000 })
+    // One hold per proven hint: the held entry carries no marker, so the next expiry
+    // must re-earn the region against a full catalog rather than chain holds forever.
+    expect(held.fullCatalog).toBeUndefined()
+    expect(events).toEqual([
+      expect.objectContaining({ chosenRegion: 'asia-east2', reason: 'held-previous' })
+    ])
+  })
+
+  it('cannot chain holds: a held hint that expires during a second roll wave is not held again', async () => {
+    const path = userDataPath()
+    writeCache(path, 'asia-east2', 999, false)
+    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        probe: healthy.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBeUndefined()
   })
 
   it('does not hold an incumbent an older build cached without the full-catalog marker', async () => {
@@ -710,6 +728,45 @@ describe('Relay region cache self-heal', () => {
     expect(fetch).not.toHaveBeenCalled()
     expect(calls).toHaveLength(0)
     expect(existsSync(cachePath(path))).toBe(true)
+  })
+
+  it('does not delete a cache a concurrent refresh rewrote while the self-heal probed', async () => {
+    // Why: self-heal snapshots the cache before its probes. A refresh that finishes in
+    // between may have written a different, correct region; the stale verdict must not
+    // delete it and force yet another probe.
+    const path = userDataPath()
+    writeCache(path, 'asia-east2', 999)
+    const events: unknown[] = []
+    let release: () => void = () => {}
+    const gate = new Promise<void>((resolve) => (release = resolve))
+    const samples: Record<string, number[]> = {
+      [US]: [300, 30, 32, 34],
+      [ASIA]: [300, 200, 205, 210],
+      [CELL]: [300, 200, 205, 210]
+    }
+    const probe = async (origin: string): Promise<number | null> => {
+      await gate
+      return samples[origin]?.shift() ?? null
+    }
+    const resolver = new RelayRegionPreferenceResolver({
+      directorUrl: DIRECTOR,
+      userDataPath: path,
+      fetch: catalogFetch(BOTH_REGIONS),
+      probe,
+      now: () => 500,
+      logEvent: (event) => events.push(event)
+    })
+    const heal = resolver.invalidateIfAssignedCellIsFar(CELL)
+    // The refresh lands first and writes us-central1 against a full catalog.
+    writeCache(path, 'us-central1', 999)
+    release()
+    await heal
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
+      region: 'us-central1'
+    })
+    expect(events).toContainEqual(
+      expect.objectContaining({ decision: 'kept', reason: 'superseded-by-refresh' })
+    )
   })
 
   it('probes a given cell only once per process', async () => {

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -459,9 +459,34 @@ describe('Relay region preference', () => {
     } finally {
       timeout.mockRestore()
     }
-    // One catalog request, then per origin one warm-up and three samples.
-    expect(budgets.filter((ms) => ms === 4_500)).toHaveLength(2)
-    expect(budgets.filter((ms) => ms === 1_500)).toHaveLength(7)
+    // The catalog request, then per origin one warm-up and three samples. The catalog
+    // and the warm-ups are the cold requests; only the samples run on the short clock.
+    // Regions measure in parallel, so the two warm-ups are issued before any sample.
+    expect(budgets).toEqual([4_500, 4_500, 4_500, 1_500, 1_500, 1_500, 1_500, 1_500, 1_500])
+  })
+
+  it('lets requestTimeoutMs override every budget, including the warm-up', async () => {
+    const budgets: number[] = []
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockImplementation((ms) => {
+      budgets.push(ms)
+      return new AbortController().signal
+    })
+    try {
+      await new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: userDataPath(),
+        fetch: async (url) =>
+          String(url).endsWith('/v1/regions')
+            ? Response.json({ v: 1, regions: BOTH_REGIONS })
+            : cancelTrackingResponse(200, () => {}),
+        requestTimeoutMs: 250,
+        now: () => 1_000
+      }).resolve()
+    } finally {
+      timeout.mockRestore()
+    }
+    expect(budgets).toHaveLength(9)
+    expect(new Set(budgets)).toEqual(new Set([250]))
   })
 
   it('probes only the canonical health path and cancels its body', async () => {

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -183,13 +183,19 @@ export class RelayRegionPreferenceResolver {
       this.log(relayRegionCatalogFailureEvent(this.options.directorUrl))
     )
     const measurements = measuredRegions(reports)
+    const previousRegion = previous?.region ?? null
     // Why: a region may only win against a measured competitor. An unmeasured
     // peer, or one the catalog dropped for having no general cell (a roll wave
     // or heartbeat stall), means director default placement beats a lone survivor.
-    const selected =
-      measurements.length < reports.length || reports.length < RELAY_REGIONS.length
-        ? null
-        : selectRegionMeasurement(measurements, previous?.region ?? null)
+    // The exception is the incumbent: a hint that was earned against a full
+    // catalog and still measures is held, not discarded, or an expiry that lands
+    // during the other region's roll wave would send the desktop to the default.
+    const complete =
+      measurements.length === reports.length && reports.length === RELAY_REGIONS.length
+    const incumbent = measurements.find((measurement) => measurement.region === previousRegion)
+    const selected = complete
+      ? selectRegionMeasurement(measurements, previousRegion)
+      : (incumbent ?? null)
     const ttlMs = selected ? CACHE_TTL_MS : NO_HINT_TTL_MS
     this.log(
       relayRegionRefreshEvent({

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -3,7 +3,11 @@ import { join } from 'node:path'
 import { performance } from 'node:perf_hooks'
 import { z } from 'zod'
 import { hardenExistingSecureFile, writeSecureJsonFile } from '../../../shared/secure-file'
-import { fetchRelayRegionCatalog, relayDirectorHost } from './relay-region-catalog-fetch'
+import {
+  fetchRelayRegionCatalog,
+  isProbeOriginForDirector,
+  relayDirectorHost
+} from './relay-region-catalog-fetch'
 import {
   logRelayRegionEvent,
   relayRegionCacheHitEvent,
@@ -14,15 +18,15 @@ import {
   type RelayRegionLogSink,
   type RelayRegionSelfHealLogEvent
 } from './relay-region-probe-log'
+import { bestMeasurement, measuredRegions, selectRegionMeasurement } from './relay-region-selection'
 import {
   measureOriginLatency,
   RELAY_REGIONS,
   measureRegion,
   probeRelayOrigin,
   PROBE_TIMEOUT_MS,
-  regionMeasurement,
+  WARMUP_TIMEOUT_MS,
   RelayRegionSchema,
-  type RegionMeasurement,
   type RelayProbe,
   type RelayRegion,
   type RelayRegionCatalog,
@@ -37,8 +41,6 @@ const CACHE_TTL_MS = 24 * 60 * 60_000
 // A withheld hint is cheap to revisit but expensive to re-measure on every
 // reconnect, so it is remembered for far less time than a chosen region.
 const NO_HINT_TTL_MS = 60 * 60_000
-const SWITCH_MINIMUM_MS = 25
-const SWITCH_RATIO = 0.8
 const FAR_CELL_RATIO = 3
 
 const RelayRegionCacheSchema = z
@@ -111,7 +113,12 @@ export class RelayRegionPreferenceResolver {
   // Why: a cache written from a bad measurement pins the desktop to a distant
   // cell for a full day. Probing the cell we actually landed on catches that.
   async invalidateIfAssignedCellIsFar(assignedCellOrigin: string): Promise<void> {
-    if (this.overrideRegion() || this.selfHealedCells.has(assignedCellOrigin)) {
+    // Same ownership rule as a catalog probe origin: an unauthenticated GET.
+    if (
+      this.overrideRegion() ||
+      this.selfHealedCells.has(assignedCellOrigin) ||
+      !isProbeOriginForDirector(assignedCellOrigin, this.options.directorUrl)
+    ) {
       return
     }
     const now = (this.options.now ?? Date.now)()
@@ -176,10 +183,11 @@ export class RelayRegionPreferenceResolver {
       this.log(relayRegionCatalogFailureEvent(this.options.directorUrl))
     )
     const measurements = measuredRegions(reports)
-    // Why: a region may only win against a measured competitor. With a rejected
-    // or unmeasurable peer, director default placement beats a lone survivor.
+    // Why: a region may only win against a measured competitor. An unmeasured
+    // peer, or one the catalog dropped for having no general cell (a roll wave
+    // or heartbeat stall), means director default placement beats a lone survivor.
     const selected =
-      measurements.length < reports.length
+      measurements.length < reports.length || reports.length < RELAY_REGIONS.length
         ? null
         : selectRegionMeasurement(measurements, previous?.region ?? null)
     const ttlMs = selected ? CACHE_TTL_MS : NO_HINT_TTL_MS
@@ -255,12 +263,13 @@ export class RelayRegionPreferenceResolver {
   private createProbe(fetch: typeof globalThis.fetch): RelayProbe {
     return (
       this.options.probe ??
-      ((origin: string) =>
+      ((origin: string, phase?: 'warmup' | 'sample') =>
         probeRelayOrigin(
           origin,
           fetch,
           this.options.measureNow ?? (() => performance.now()),
-          this.options.requestTimeoutMs ?? PROBE_TIMEOUT_MS
+          this.options.requestTimeoutMs ??
+            (phase === 'warmup' ? WARMUP_TIMEOUT_MS : PROBE_TIMEOUT_MS)
         ))
     )
   }
@@ -281,40 +290,6 @@ export function createRelayRegionPreferenceReader(input: {
     resolvePreferredRegion: () => resolver.resolve(),
     noteAssignedCell: (cellUrl) => void resolver.invalidateIfAssignedCellIsFar(cellUrl)
   }
-}
-
-function measuredRegions(reports: RelayRegionProbeReport[]): RegionMeasurement[] {
-  return reports
-    .map(regionMeasurement)
-    .filter((measurement): measurement is RegionMeasurement => measurement !== null)
-}
-
-function bestMeasurement(measurements: RegionMeasurement[]): RegionMeasurement | null {
-  const order = new Map(RELAY_REGIONS.map((region, index) => [region, index]))
-  return (
-    [...measurements].sort(
-      (left, right) =>
-        left.latencyMs - right.latencyMs || order.get(left.region)! - order.get(right.region)!
-    )[0] ?? null
-  )
-}
-
-function selectRegionMeasurement(
-  measurements: RegionMeasurement[],
-  previousRegion: RelayRegion | null
-): RegionMeasurement | null {
-  const best = bestMeasurement(measurements)
-  if (!best || !previousRegion || best.region === previousRegion) {
-    return best
-  }
-  const current = measurements.find((measurement) => measurement.region === previousRegion)
-  if (!current) {
-    return best
-  }
-  const meaningful =
-    current.latencyMs - best.latencyMs >= SWITCH_MINIMUM_MS &&
-    best.latencyMs <= current.latencyMs * SWITCH_RATIO
-  return meaningful ? best : current
 }
 
 function readRelayRegionCache(path: string, directorUrl: string, now: number) {

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -215,10 +215,12 @@ export class RelayRegionPreferenceResolver {
   ): Promise<RelayRegionProbeReport[]> {
     let catalog: RelayRegionCatalog
     try {
+      // The catalog request is the coldest of the sequence: it pays DNS, TCP,
+      // and TLS to the director, so it gets the warm-up budget, not the sample one.
       catalog = await fetchRelayRegionCatalog(
         this.options.directorUrl,
         fetch,
-        this.options.requestTimeoutMs ?? PROBE_TIMEOUT_MS
+        this.options.requestTimeoutMs ?? WARMUP_TIMEOUT_MS
       )
     } catch (error) {
       onCatalogFailure?.()

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -163,7 +163,15 @@ export class RelayRegionPreferenceResolver {
       outcome.decision = far ? 'deleted' : 'kept'
       outcome.reason = far ? 'assigned-cell-far' : 'assigned-cell-near'
       if (far) {
-        rmSync(this.cachePath(), { force: true })
+        // Reread first: a refresh that finished during the probes may have
+        // written a different, correct region that this stale verdict must not delete.
+        const latest = readRelayRegionCache(this.cachePath(), this.options.directorUrl, now)
+        if (latest?.region === cache.region) {
+          rmSync(this.cachePath(), { force: true })
+        } else {
+          outcome.decision = 'kept'
+          outcome.reason = 'superseded-by-refresh'
+        }
       }
       this.logSelfHeal(outcome)
     } catch {
@@ -210,12 +218,21 @@ export class RelayRegionPreferenceResolver {
         reports,
         best: bestMeasurement(measurements),
         selected,
+        held: !complete && selected !== null,
         ttlMs
       })
     )
+    // A held incumbent is written without the marker: one roll wave may extend
+    // a proven hint by a day, but the next expiry must re-earn it against a full
+    // catalog, so a hint can never be renewed indefinitely on partial evidence.
     this.writeCache(
       selected
-        ? { region: selected.region, latencyMs: selected.latencyMs, ttlMs, fullCatalog: true }
+        ? {
+            region: selected.region,
+            latencyMs: selected.latencyMs,
+            ttlMs,
+            ...(complete ? { fullCatalog: true as const } : {})
+          }
         : { region: null, ttlMs },
       now
     )

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -50,6 +50,9 @@ const RelayRegionCacheSchema = z
     // Null records a deliberate "no hint"; the field is absent only for a region.
     region: RelayRegionSchema.nullable(),
     latencyMs: z.number().finite().nonnegative().max(60_000).optional(),
+    // True only for a region that won against every region the fleet serves.
+    // Absent on caches an older build wrote, which may hold a lone survivor.
+    fullCatalog: z.literal(true).optional(),
     expiresAt: z.number().int().positive().max(Number.MAX_SAFE_INTEGER)
   })
   .strict()
@@ -192,7 +195,11 @@ export class RelayRegionPreferenceResolver {
     // during the other region's roll wave would send the desktop to the default.
     const complete =
       measurements.length === reports.length && reports.length === RELAY_REGIONS.length
-    const incumbent = measurements.find((measurement) => measurement.region === previousRegion)
+    // Only a hint earned against a full catalog may be held through an
+    // incomplete one; a cache without the marker is treated as unverified.
+    const incumbent = previous?.fullCatalog
+      ? measurements.find((measurement) => measurement.region === previousRegion)
+      : undefined
     const selected = complete
       ? selectRegionMeasurement(measurements, previousRegion)
       : (incumbent ?? null)
@@ -208,7 +215,7 @@ export class RelayRegionPreferenceResolver {
     )
     this.writeCache(
       selected
-        ? { region: selected.region, latencyMs: selected.latencyMs, ttlMs }
+        ? { region: selected.region, latencyMs: selected.latencyMs, ttlMs, fullCatalog: true }
         : { region: null, ttlMs },
       now
     )
@@ -241,7 +248,7 @@ export class RelayRegionPreferenceResolver {
   }
 
   private writeCache(
-    entry: { region: RelayRegion | null; latencyMs?: number; ttlMs: number },
+    entry: { region: RelayRegion | null; latencyMs?: number; ttlMs: number; fullCatalog?: true },
     now: number
   ): void {
     try {
@@ -250,6 +257,7 @@ export class RelayRegionPreferenceResolver {
         directorUrl: this.options.directorUrl,
         region: entry.region,
         ...(entry.latencyMs === undefined ? {} : { latencyMs: entry.latencyMs }),
+        ...(entry.fullCatalog ? { fullCatalog: true } : {}),
         expiresAt: now + entry.ttlMs
       } satisfies RelayRegionCache)
     } catch {

--- a/src/main/runtime/relay/relay-region-probe-log.test.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.test.ts
@@ -185,6 +185,16 @@ describe('Relay region probe log', () => {
     expect(probeEvents(events)[0]!.reason).toBe('all-unreachable')
   })
 
+  it('reports an empty catalog as catalog-incomplete, since nothing was probed', async () => {
+    const { resolver, events } = resolverWithLog({
+      path: userDataPath(),
+      fetch: catalogFetch([]),
+      probe: sampledProbe({})
+    })
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+    expect(probeEvents(events)[0]).toMatchObject({ reason: 'catalog-incomplete', regions: [] })
+  })
+
   it('reports a lone flapping region as all-rejected, and a lone healthy one as catalog-incomplete', async () => {
     const path = userDataPath()
     const flapping = resolverWithLog({

--- a/src/main/runtime/relay/relay-region-probe-log.test.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.test.ts
@@ -172,6 +172,38 @@ describe('Relay region probe log', () => {
     ])
   })
 
+  it('reports a lone unreachable region as all-unreachable, not catalog-incomplete', async () => {
+    // Why: a support census counts all-unreachable to spot client-side network breakage;
+    // a roll wave that shortens the catalog must not hide those runs.
+    const path = userDataPath()
+    const { resolver, events } = resolverWithLog({
+      path,
+      fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+      probe: sampledProbe({})
+    })
+    await expect(resolver.resolve()).resolves.toBeUndefined()
+    expect(probeEvents(events)[0]!.reason).toBe('all-unreachable')
+  })
+
+  it('reports a lone flapping region as all-rejected, and a lone healthy one as catalog-incomplete', async () => {
+    const path = userDataPath()
+    const flapping = resolverWithLog({
+      path,
+      fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+      probe: sampledProbe({ [ASIA]: [90, 30, 40, 900] })
+    })
+    await expect(flapping.resolver.resolve()).resolves.toBeUndefined()
+    expect(probeEvents(flapping.events)[0]!.reason).toBe('all-rejected')
+
+    const healthy = resolverWithLog({
+      path: userDataPath(),
+      fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+      probe: sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    })
+    await expect(healthy.resolver.resolve()).resolves.toBeUndefined()
+    expect(probeEvents(healthy.events)[0]!.reason).toBe('catalog-incomplete')
+  })
+
   it('names a held incumbent apart from a fresh measurement', async () => {
     const path = userDataPath()
     writeCache(path, 'us-central1', 500)

--- a/src/main/runtime/relay/relay-region-probe-log.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.ts
@@ -131,7 +131,12 @@ function refreshReason(
     return best && selected.region !== best.region ? 'held-previous' : 'measured'
   }
   // Reachability first: a support census counting all-unreachable to spot
-  // client-side network breakage must not lose those runs to a roll wave.
+  // client-side network breakage must not lose those runs to a roll wave. An
+  // empty catalog (every region drained at once) probed nothing, so it is the
+  // catalog that is incomplete, not the network.
+  if (reports.length === 0) {
+    return 'catalog-incomplete'
+  }
   if (reports.every((report) => report.verdict === 'unreachable')) {
     return 'all-unreachable'
   }

--- a/src/main/runtime/relay/relay-region-probe-log.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.ts
@@ -1,5 +1,10 @@
 import { relayDirectorHost } from './relay-region-catalog-fetch'
-import type { RegionMeasurement, RelayRegion, RelayRegionProbeReport } from './relay-region-probe'
+import {
+  RELAY_REGIONS,
+  type RegionMeasurement,
+  type RelayRegion,
+  type RelayRegionProbeReport
+} from './relay-region-probe'
 
 export const RELAY_REGION_PROBE_EVENT = 'relay_region_probe'
 export const RELAY_REGION_SELF_HEAL_EVENT = 'relay_region_self_heal'
@@ -9,6 +14,7 @@ export type RelayRegionChoiceReason =
   | 'measured'
   | 'held-previous'
   | 'sole-survivor-forbidden'
+  | 'catalog-incomplete'
   | 'all-unreachable'
   | 'all-rejected'
   | 'catalog-unavailable'
@@ -123,6 +129,9 @@ function refreshReason(
     // The resolver keeps the incumbent unless a rival wins by a real margin, so
     // a selection that is not the fastest reading is a deliberate hold.
     return best && selected.region !== best.region ? 'held-previous' : 'measured'
+  }
+  if (reports.length < RELAY_REGIONS.length) {
+    return 'catalog-incomplete'
   }
   if (reports.some((report) => report.verdict === 'measured')) {
     return 'sole-survivor-forbidden'

--- a/src/main/runtime/relay/relay-region-probe-log.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.ts
@@ -130,13 +130,13 @@ function refreshReason(
     // a selection that is not the fastest reading is a deliberate hold.
     return best && selected.region !== best.region ? 'held-previous' : 'measured'
   }
-  if (reports.length < RELAY_REGIONS.length) {
-    return 'catalog-incomplete'
+  // Reachability first: a support census counting all-unreachable to spot
+  // client-side network breakage must not lose those runs to a roll wave.
+  if (reports.every((report) => report.verdict === 'unreachable')) {
+    return 'all-unreachable'
   }
-  if (reports.some((report) => report.verdict === 'measured')) {
-    return 'sole-survivor-forbidden'
+  if (!reports.some((report) => report.verdict === 'measured')) {
+    return 'all-rejected'
   }
-  return reports.every((report) => report.verdict === 'unreachable')
-    ? 'all-unreachable'
-    : 'all-rejected'
+  return reports.length < RELAY_REGIONS.length ? 'catalog-incomplete' : 'sole-survivor-forbidden'
 }

--- a/src/main/runtime/relay/relay-region-probe-log.ts
+++ b/src/main/runtime/relay/relay-region-probe-log.ts
@@ -48,6 +48,7 @@ export type RelayRegionSelfHealLogEvent = {
     | 'catalog-unavailable'
     | 'assigned-cell-near'
     | 'assigned-cell-far'
+    | 'superseded-by-refresh'
 }
 
 export type RelayRegionLogEvent = RelayRegionProbeLogEvent | RelayRegionSelfHealLogEvent
@@ -107,6 +108,8 @@ export function relayRegionRefreshEvent(input: {
   reports: RelayRegionProbeReport[]
   best: RegionMeasurement | null
   selected: RegionMeasurement | null
+  /** The incumbent was kept through an incomplete catalog rather than measured against a rival. */
+  held?: boolean
   ttlMs: number
 }): RelayRegionProbeLogEvent {
   return {
@@ -114,7 +117,7 @@ export function relayRegionRefreshEvent(input: {
     directorHost: relayDirectorHost(input.directorUrl),
     regions: input.reports,
     chosenRegion: input.selected?.region ?? 'no-hint',
-    reason: refreshReason(input.reports, input.best, input.selected),
+    reason: input.held ? 'held-previous' : refreshReason(input.reports, input.best, input.selected),
     cached: false,
     ttlMs: input.ttlMs
   }

--- a/src/main/runtime/relay/relay-region-probe.ts
+++ b/src/main/runtime/relay/relay-region-probe.ts
@@ -6,6 +6,10 @@ export const RELAY_REGIONS = ['us-central1', 'asia-east2'] as const
 export type RelayRegion = (typeof RELAY_REGIONS)[number]
 
 export const PROBE_TIMEOUT_MS = 1_500
+// The warm-up pays DNS, TCP, and TLS on a cold path; on a lossy far link that
+// alone can pass the sample budget, and a warm-up that times out drops the
+// whole region, which withholds the hint for an hour. Give it room.
+export const WARMUP_TIMEOUT_MS = 3 * PROBE_TIMEOUT_MS
 const PROBE_SAMPLES = 3
 // Absolute floor for the flap check: a warmed keep-alive path still jitters, and
 // a floor below TLS-scale noise rejects healthy regions on nearly every run.
@@ -56,7 +60,8 @@ export const RelayRegionCatalogSchema = z
 export type RelayRegionCatalog = z.infer<typeof RelayRegionCatalogSchema>
 export type RelayRegionCatalogEntry = RelayRegionCatalog['regions'][number]
 export type RegionMeasurement = { region: RelayRegion; latencyMs: number }
-export type RelayProbe = (origin: string) => Promise<number | null>
+/** `warmup` marks the discarded first request, which gets a larger timeout. */
+export type RelayProbe = (origin: string, phase?: 'warmup' | 'sample') => Promise<number | null>
 
 export async function probeRelayOrigin(
   origin: string,
@@ -105,7 +110,7 @@ export type RelayRegionProbeReport = {
 // The first request of a process pays TCP and TLS setup, which can exceed the
 // round trip it is meant to measure, so it is discarded before sampling.
 async function sampleMinLatencies(origins: string[], probe: RelayProbe): Promise<LatencySamples> {
-  const warmupMs = await Promise.all(origins.map(probe))
+  const warmupMs = await Promise.all(origins.map((origin) => probe(origin, 'warmup')))
   // An origin that failed its warm-up would spend one probe timeout per round
   // to report nothing, so the sampling rounds skip it entirely.
   const live = origins.filter((_origin, index) => warmupMs[index] !== null)
@@ -114,7 +119,7 @@ async function sampleMinLatencies(origins: string[], probe: RelayProbe): Promise
   }
   const keptMs: number[] = []
   for (let sample = 0; sample < PROBE_SAMPLES; sample++) {
-    const latencies = (await Promise.all(live.map(probe))).filter(
+    const latencies = (await Promise.all(live.map((origin) => probe(origin, 'sample')))).filter(
       (latency): latency is number => latency !== null
     )
     if (latencies.length === 0) {

--- a/src/main/runtime/relay/relay-region-selection.ts
+++ b/src/main/runtime/relay/relay-region-selection.ts
@@ -1,0 +1,46 @@
+import {
+  RELAY_REGIONS,
+  regionMeasurement,
+  type RegionMeasurement,
+  type RelayRegion,
+  type RelayRegionProbeReport
+} from './relay-region-probe'
+
+// A rival must beat the incumbent by both an absolute and a relative margin, so
+// two regions within noise of each other do not flip the hint every refresh.
+const SWITCH_MINIMUM_MS = 25
+const SWITCH_RATIO = 0.8
+
+export function measuredRegions(reports: RelayRegionProbeReport[]): RegionMeasurement[] {
+  return reports
+    .map(regionMeasurement)
+    .filter((measurement): measurement is RegionMeasurement => measurement !== null)
+}
+
+export function bestMeasurement(measurements: RegionMeasurement[]): RegionMeasurement | null {
+  const order = new Map(RELAY_REGIONS.map((region, index) => [region, index]))
+  return (
+    [...measurements].sort(
+      (left, right) =>
+        left.latencyMs - right.latencyMs || order.get(left.region)! - order.get(right.region)!
+    )[0] ?? null
+  )
+}
+
+export function selectRegionMeasurement(
+  measurements: RegionMeasurement[],
+  previousRegion: RelayRegion | null
+): RegionMeasurement | null {
+  const best = bestMeasurement(measurements)
+  if (!best || !previousRegion || best.region === previousRegion) {
+    return best
+  }
+  const current = measurements.find((measurement) => measurement.region === previousRegion)
+  if (!current) {
+    return best
+  }
+  const meaningful =
+    current.latencyMs - best.latencyMs >= SWITCH_MINIMUM_MS &&
+    best.latencyMs <= current.latencyMs * SWITCH_RATIO
+  return meaningful ? best : current
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​297 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​290 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​153 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​65 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |

<!-- /orca-pr-loc -->

Follow-up to #19233 from the post-merge adversarial review. Three findings on the desktop region probe, all reproduced against main.

## Why

- **HIGH: a one-region catalog cached a 24 h hint.** The director lists only regions that have a general, ready, heartbeating cell (`assignment-store.ts` `regionCatalog`), so a roll wave or heartbeat stall shortens the catalog. The resolver only required every *listed* region to be measured, so a lone healthy region won against nothing and was written as a day-long hint. Two existing tests pinned that behaviour. An Asia desktop refreshing while the Asia cells drained would publish `us-central1` for a day; a US desktop refreshing while US cells were absent would publish `asia-east2`, the exact incident #19233 was written to end.
- **MEDIUM: the warm-up shared the 1.5 s sample budget.** The warm-up exists because the first request pays DNS, TCP, and TLS. A warm-up timeout drops the region as unreachable, which withholds the hint for an hour and places the desktop at the director default. On a lossy far link that is the region the desktop most needs measured.
- **LOW: the self-heal probe skipped the director-ownership check.** Catalog probe origins must be under the director's hostname; the assigned-cell probe had no such fence, so a director could point an unauthenticated GET carrying the desktop's address at any https host.

## What

- `refresh()` withholds the hint (1 h no-hint TTL) when `reports.length < RELAY_REGIONS.length`, logged with the new reason `catalog-incomplete`.
- `WARMUP_TIMEOUT_MS = 3 × PROBE_TIMEOUT_MS`; `RelayProbe` takes an optional `'warmup' | 'sample'` phase and `createProbe` picks the budget from it. An explicit `requestTimeoutMs` option still overrides both, as before.
- `invalidateIfAssignedCellIsFar` returns early unless the cell origin passes `isProbeOriginForDirector`, now exported from `relay-region-catalog-fetch.ts`.
- `measuredRegions` / `bestMeasurement` / `selectRegionMeasurement` and the switch margins moved to `relay-region-selection.ts` to keep the resolver under the line budget. No behaviour change.

## Tests

- New: lone-region catalog → no hint, 1 h TTL, `catalog-incomplete` reason (fails without the fix).
- New: warm-up requests get 4 500 ms and samples 1 500 ms, counted through `AbortSignal.timeout`.
- New: a cell origin outside the director's domain is never probed and the cache is untouched.
- The two tests that asserted a lone-region hint now use a two-region catalog; their intent (corrupt cache recovery, expiry bound) is preserved.
- `pnpm vitest run src/main/runtime/relay` 159/159, `pnpm tc:node`, `oxlint` clean.

## Also

- **LOW from #19238 review:** `replayPendingConnections` logged one warning per pending entry the cell stated without details. Against a cell that predates the capability that is every entry on every straddling rebind, up to the eight-connection cap. Now one aggregated line per ack.

## Review round 3 (Opus sweep)

- The catalog request now gets the warm-up budget (4.5 s): it is the coldest request in the sequence and a timeout withheld the hint for an hour.
- Reason ordering: a lone region that is unreachable or flapping logs `all-unreachable` / `all-rejected`; `catalog-incomplete` is reserved for a lone healthy region, so a support census of client-side breakage is not hidden by a roll wave.
- Tests pin the exact budget sequence, the `requestTimeoutMs` override, and the aggregated unreplayable warning text and count.

## Cost and compatibility notes

- Worst-case cold `resolve()` grows from 7.5 s to 13.5 s (catalog 4.5 s, then warm-up 4.5 s, then three 1.5 s sample rounds, all sequential; regions run in parallel within each phase). The drain grace floor is 60 s, so a drain rotation still fits, and the no-hint case re-enters it hourly rather than daily. The drain-rotation path awaits it serially; if the roll-wave frequency makes that hourly cost visible, a wall-clock deadline around `resolvePreferredRegion` is the next step.
- `RELAY_REGIONS.length` is now load-bearing: a desktop on this build withholds the hint permanently (and re-probes hourly) in any environment that serves fewer regions than the constant lists. Retiring a region needs a desktop release that shrinks the constant first; adding one is safe (the catalog schema caps at the constant, so an unknown region fails the schema as before).

## Review round 4 (second Opus pass)

- An incomplete catalog no longer discards a correct incumbent. A hint earned against a full catalog that still measures is held with the 24 h TTL; a lone survivor that is not the incumbent is still never promoted. Without this, an expiry landing during the other region's roll wave sent a correctly homed desktop to the director default for an hour.
- An empty catalog (every region draining at once) is classified `catalog-incomplete`, not `all-unreachable`.

## Review round 5 (Codex)

- The cache records `fullCatalog: true` only on a hint that won against every served region. Only a marked hint is held through an incomplete catalog, and the held entry is written without the marker, so one roll wave can extend a proven hint by a day but the next expiry must re-earn it. A legacy cache or a lone survivor is never renewed on partial evidence.
- The hold is logged as `held-previous`, not `measured`.
- Self-heal rereads the cache before deleting it, so a refresh that landed during its probes is not deleted on a stale verdict (`superseded-by-refresh`). This race predates the PR.

