### PR TITLE
fix(mobile): keep tab ids, basenames, and hook agent text out of the cached tab strip

### DIFF
--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -275,6 +275,26 @@ describe('session tab strip cache', () => {
     expect(asyncStorage.removeItem).toHaveBeenCalledWith(LEGACY_STORAGE_KEY)
   })
 
+  it('retries a failed legacy removal on a later load, even with no write in between', async () => {
+    // Why: an offline session only ever loads; the memoized file read must not be the
+    // only place the retry lives.
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    asyncStorage.removeItem.mockRejectedValueOnce(new Error('bridge down'))
+    await loadCachedSessionTabStrip(key)
+    expect(asyncStorage.removeItem).toHaveBeenCalledTimes(1)
+    await loadCachedSessionTabStrip(key)
+    expect(asyncStorage.removeItem).toHaveBeenCalledTimes(2)
+    await loadCachedSessionTabStrip(key)
+    expect(asyncStorage.removeItem).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not report a host forgotten while its legacy blob is still on disk', async () => {
+    asyncStorage.removeItem.mockRejectedValue(new Error('bridge down'))
+    await expect(deleteCachedSessionTabStripForHost('host-1')).rejects.toThrow(/bridge down/)
+    asyncStorage.removeItem.mockResolvedValue(undefined)
+    await expect(deleteCachedSessionTabStripForHost('host-1')).resolves.toBeUndefined()
+  })
+
   it('retries a failed legacy removal on the next write, and stops once it lands', async () => {
     const key = getSessionTabStripCacheKey('host-1', 'wt-1')
     asyncStorage.removeItem.mockRejectedValueOnce(new Error('bridge down'))

--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -27,6 +27,19 @@ function preview(...ids: string[]): MobileSessionTabStripPreview {
   }
 }
 
+// Stored ids are digests: they are stable, prefixed, and never the wire id.
+function expectDigestedIds(ids: (string | undefined)[], count: number): void {
+  expect(ids).toHaveLength(count)
+  for (const id of ids) {
+    expect(id).toMatch(/^cached:[0-9a-f]{32}$/)
+  }
+}
+
+function readAfterSave(key: string | null, id: string): string {
+  saveCachedSessionTabStrip(key, preview(id))
+  return readCachedSessionTabStrip(key)!.tabs[0]!.id
+}
+
 function lastWrittenFile(): { workspaces: { key: string }[] } {
   const call = asyncStorage.setItem.mock.calls.at(-1)
   return JSON.parse(String(call?.[1]))
@@ -73,7 +86,7 @@ describe('session tab strip cache', () => {
     const key = getSessionTabStripCacheKey('host-1', 'wt-1')
     saveCachedSessionTabStrip(key, preview('tab-1', 'tab-2'))
 
-    expect(readCachedSessionTabStrip(key)?.tabs.map((tab) => tab.id)).toEqual(['tab-1', 'tab-2'])
+    expectDigestedIds(readCachedSessionTabStrip(key)?.tabs.map((tab) => tab.id) ?? [], 2)
     expect(asyncStorage.setItem).not.toHaveBeenCalled()
 
     await vi.advanceTimersByTimeAsync(300)
@@ -89,7 +102,7 @@ describe('session tab strip cache', () => {
     )
 
     expect(readCachedSessionTabStrip(key)).toBeNull()
-    expect((await loadCachedSessionTabStrip(key))?.tabs.map((tab) => tab.id)).toEqual(['tab-1'])
+    expectDigestedIds((await loadCachedSessionTabStrip(key))?.tabs.map((tab) => tab.id) ?? [], 1)
     expect(readCachedSessionTabStrip(key)?.tabs).toHaveLength(1)
   })
 
@@ -137,11 +150,9 @@ describe('session tab strip cache', () => {
     expect(readCachedSessionTabStrip(key)).toEqual({ tabs: [], activeTabId: null })
   })
 
-  it('caps tabs per workspace and title length, and drops an unmatched active id', async () => {
+  it('caps tabs per workspace and drops an active id that fell past the cap', async () => {
     const key = getSessionTabStripCacheKey('host-1', 'wt-1')
     saveCachedSessionTabStrip(key, {
-      // A file tab, because the titles that survive redaction at all are the ones the cap has
-      // to bound.
       tabs: Array.from({ length: 30 }, (_, i) => ({
         id: `tab-${i}`,
         type: 'file' as const,
@@ -153,8 +164,89 @@ describe('session tab strip cache', () => {
 
     const stored = readCachedSessionTabStrip(key)
     expect(stored?.tabs).toHaveLength(24)
-    expect(stored?.tabs[0]?.title).toHaveLength(64)
     expect(stored?.activeTabId).toBeNull()
+  })
+
+  it('maps the active id onto the digested row it names', async () => {
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    saveCachedSessionTabStrip(key, preview('tab-1', 'tab-2'))
+
+    const stored = readCachedSessionTabStrip(key)
+    expect(stored?.activeTabId).toBe(stored?.tabs[0]?.id)
+    expect(stored?.activeTabId).toMatch(/^cached:/)
+  })
+
+  it('never writes a tab id, because an editor id embeds the absolute file path', async () => {
+    // The desktop builds an editor tab's id as editor:<worktree>:<runtime>:<encoded path>, and
+    // publishes it unchanged when the file has no unified tab row.
+    const id = `editor:${encodeURIComponent('/Users/someone/clients/acme')}:local:${encodeURIComponent('/Users/someone/clients/acme/term-sheet.md')}`
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    saveCachedSessionTabStrip(key, {
+      tabs: [{ id, type: 'file', title: 'term-sheet.md', agentId: null }],
+      activeTabId: id
+    })
+    await vi.advanceTimersByTimeAsync(300)
+
+    const written = String(asyncStorage.setItem.mock.calls.at(-1)?.[1])
+    expect(written).not.toContain('acme')
+    expect(written).not.toContain('term-sheet')
+    expect(written).not.toContain('Users')
+    expect(readCachedSessionTabStrip(key)?.tabs[0]?.title).toBe('File')
+  })
+
+  it('digests a raw id an older build stored, and leaves an already digested one alone', async () => {
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    const digested = readAfterSave(key, 'tab-1')
+    asyncStorage.getItem.mockResolvedValue(
+      JSON.stringify({
+        workspaces: [
+          {
+            key,
+            preview: {
+              tabs: [
+                { id: '/Users/someone/old-build-raw-id', type: 'file', title: 'x', agentId: null },
+                { id: digested, type: 'terminal', title: 'x', agentId: null }
+              ],
+              activeTabId: digested
+            }
+          }
+        ]
+      })
+    )
+    resetSessionTabStripCacheForTests()
+
+    const loaded = await loadCachedSessionTabStrip(key)
+    expectDigestedIds(loaded?.tabs.map((tab) => tab.id) ?? [], 2)
+    expect(loaded?.tabs[1]?.id).toBe(digested)
+    expect(loaded?.activeTabId).toBe(digested)
+  })
+
+  it('keeps only a known agent id, since the hook-reported one is free text', async () => {
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    saveCachedSessionTabStrip(key, {
+      tabs: [
+        { id: 'tab-1', type: 'terminal', title: 'x', agentId: 'claude' },
+        { id: 'tab-2', type: 'terminal', title: 'x', agentId: 'export TOKEN=abc123' },
+        { id: 'tab-3', type: 'agent-session', title: 'refactor the billing job', agentId: 'codex' },
+        { id: 'tab-4', type: 'agent-session', title: 'x', agentId: 'not-an-agent' },
+        { id: 'tab-5', type: 'markdown', title: 'severance-draft.md', agentId: null }
+      ],
+      activeTabId: 'tab-1'
+    })
+    await vi.advanceTimersByTimeAsync(300)
+
+    const stored = readCachedSessionTabStrip(key)
+    expect(stored?.tabs.map((tab) => [tab.agentId, tab.title])).toEqual([
+      ['claude', 'Claude'],
+      [null, 'Terminal'],
+      ['codex', 'Codex'],
+      [null, 'Agent'],
+      [null, 'Markdown']
+    ])
+    const written = String(asyncStorage.setItem.mock.calls.at(-1)?.[1])
+    expect(written).not.toContain('abc123')
+    expect(written).not.toContain('billing')
+    expect(written).not.toContain('severance')
   })
 
   it('drops fields a future tab type might smuggle into storage', async () => {
@@ -186,7 +278,7 @@ describe('session tab strip cache', () => {
       activeTabId: 'tab-2'
     })
 
-    expect(readCachedSessionTabStrip(key)?.tabs.map((tab) => tab.id)).toEqual(['tab-2'])
+    expectDigestedIds(readCachedSessionTabStrip(key)?.tabs.map((tab) => tab.id) ?? [], 1)
   })
 
   it('never writes a shell-controlled terminal title, however it arrives', async () => {

--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -275,6 +275,22 @@ describe('session tab strip cache', () => {
     expect(asyncStorage.removeItem).toHaveBeenCalledWith(LEGACY_STORAGE_KEY)
   })
 
+  it('retries a failed legacy removal on the next write, and stops once it lands', async () => {
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    asyncStorage.removeItem.mockRejectedValueOnce(new Error('bridge down'))
+    await loadCachedSessionTabStrip(key)
+    expect(asyncStorage.removeItem).toHaveBeenCalledTimes(1)
+
+    saveCachedSessionTabStrip(key, preview('tab-1'))
+    await vi.advanceTimersByTimeAsync(300)
+    expect(asyncStorage.removeItem).toHaveBeenCalledTimes(2)
+    expect(asyncStorage.removeItem).toHaveBeenLastCalledWith(LEGACY_STORAGE_KEY)
+
+    saveCachedSessionTabStrip(key, preview('tab-2'))
+    await vi.advanceTimersByTimeAsync(300)
+    expect(asyncStorage.removeItem).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps only a known agent id, since the hook-reported one is free text', async () => {
     const key = getSessionTabStripCacheKey('host-1', 'wt-1')
     saveCachedSessionTabStrip(key, {

--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -18,7 +18,8 @@ import {
 } from './session-tab-strip-cache'
 import type { MobileSessionTabStripPreview } from '../session/mobile-session-tab-strip-entries'
 
-const STORAGE_KEY = 'orca:session-tab-strip:v1'
+const STORAGE_KEY = 'orca:session-tab-strip:v2'
+const LEGACY_STORAGE_KEY = 'orca:session-tab-strip:v1'
 
 function preview(...ids: string[]): MobileSessionTabStripPreview {
   return {
@@ -49,6 +50,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   asyncStorage.getItem.mockReset().mockResolvedValue(null)
   asyncStorage.setItem.mockReset().mockResolvedValue(undefined)
+  asyncStorage.removeItem.mockReset().mockResolvedValue(undefined)
   resetSessionTabStripCacheForTests()
 })
 
@@ -232,6 +234,45 @@ describe('session tab strip cache', () => {
 
     expectDigestedIds(readCachedSessionTabStrip(key)?.tabs.map((tab) => tab.id) ?? [], 1)
     expect(String(asyncStorage.setItem.mock.calls.at(-1)?.[1])).not.toContain('private-file')
+  })
+
+  it('digests a wire id even when the host shaped it like a stored key', async () => {
+    // "Every stored id is a digest" must not be something the host can satisfy by choosing ids.
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    const hostChosen = `cached:${'a'.repeat(32)}`
+    expect(readAfterSave(key, hostChosen)).not.toBe(hostChosen)
+    expectDigestedIds([readCachedSessionTabStrip(key)?.tabs[0]?.id], 1)
+  })
+
+  it('stores under a new key and removes the blob an older build wrote in plaintext', async () => {
+    // v1 blobs hold raw editor ids and shell-set titles, and a load alone never rewrote them.
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    asyncStorage.getItem.mockImplementation(async (storageKey: string) =>
+      storageKey === LEGACY_STORAGE_KEY
+        ? JSON.stringify({
+            workspaces: [
+              {
+                key,
+                preview: {
+                  tabs: [
+                    {
+                      id: '/Users/someone/secret.md',
+                      type: 'file',
+                      title: 'secret.md',
+                      agentId: null
+                    }
+                  ],
+                  activeTabId: null
+                }
+              }
+            ]
+          })
+        : null
+    )
+
+    expect(await loadCachedSessionTabStrip(key)).toBeNull()
+    expect(asyncStorage.getItem).not.toHaveBeenCalledWith(LEGACY_STORAGE_KEY)
+    expect(asyncStorage.removeItem).toHaveBeenCalledWith(LEGACY_STORAGE_KEY)
   })
 
   it('keeps only a known agent id, since the hook-reported one is free text', async () => {

--- a/mobile/src/cache/session-tab-strip-cache.test.ts
+++ b/mobile/src/cache/session-tab-strip-cache.test.ts
@@ -221,6 +221,19 @@ describe('session tab strip cache', () => {
     expect(loaded?.activeTabId).toBe(digested)
   })
 
+  it('digests a wire id that merely starts with the digest prefix', async () => {
+    const key = getSessionTabStripCacheKey('host-1', 'wt-1')
+    const id = 'cached:/Users/someone/private-file.md'
+    saveCachedSessionTabStrip(key, {
+      tabs: [{ id, type: 'file', title: 'x', agentId: null }],
+      activeTabId: id
+    })
+    await vi.advanceTimersByTimeAsync(300)
+
+    expectDigestedIds(readCachedSessionTabStrip(key)?.tabs.map((tab) => tab.id) ?? [], 1)
+    expect(String(asyncStorage.setItem.mock.calls.at(-1)?.[1])).not.toContain('private-file')
+  })
+
   it('keeps only a known agent id, since the hook-reported one is free text', async () => {
     const key = getSessionTabStripCacheKey('host-1', 'wt-1')
     saveCachedSessionTabStrip(key, {

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -79,6 +79,9 @@ export async function loadCachedSessionTabStrip(
   if (!key) {
     return null
   }
+  // Every load, not just the first file read: a removal that failed on launch must be
+  // retried by an offline session that only ever loads.
+  removeLegacyBlobsBestEffort()
   const cache = await loadFile()
   return cache.get(key) ?? null
 }
@@ -136,6 +139,9 @@ export async function deleteCachedSessionTabStripForHost(hostId: string): Promis
   }
   // Queued, not raced: the purge is the last write, and its failure is the caller's.
   await enqueueWrite(cache)
+  // The forgotten host's titles may still sit in the blob an older build wrote. A deletion
+  // the user asked for is not done until that is gone too, so this one is awaited and thrown.
+  await removeLegacyBlobs()
 }
 
 export function resetSessionTabStripCacheForTests(): void {
@@ -193,19 +199,24 @@ async function loadFile(): Promise<Map<string, MobileSessionTabStripPreview>> {
   return loadPromise
 }
 
-// Not awaited: the plaintext left by an older build must go, but a failed removal is no reason
-// to withhold the strip this build can draw. A failure keeps the key queued for the next try.
-function removeLegacyBlobs(): void {
-  for (const key of pendingLegacyRemovals) {
-    void AsyncStorage.removeItem(key).then(
-      () => pendingLegacyRemovals.delete(key),
-      () => {}
+// Loads and ordinary writes do not await this: the plaintext left by an older build must go,
+// but a failed removal is no reason to withhold the strip this build can draw. A failure keeps
+// the key queued for the next try. A host deletion does await it, and throws on failure.
+function removeLegacyBlobs(): Promise<void> {
+  return Promise.all(
+    [...pendingLegacyRemovals].map((key) =>
+      AsyncStorage.removeItem(key).then(() => {
+        pendingLegacyRemovals.delete(key)
+      })
     )
-  }
+  ).then(() => {})
+}
+
+function removeLegacyBlobsBestEffort(): void {
+  void removeLegacyBlobs().catch(() => {})
 }
 
 async function readStoredFile(): Promise<StoredWorkspace[]> {
-  removeLegacyBlobs()
   try {
     const raw = await AsyncStorage.getItem(STORAGE_KEY)
     if (!raw) {
@@ -250,7 +261,7 @@ function enqueueWrite(cache: Map<string, MobileSessionTabStripPreview>): Promise
 }
 
 async function writeFile(cache: Map<string, MobileSessionTabStripPreview>): Promise<void> {
-  removeLegacyBlobs()
+  removeLegacyBlobsBestEffort()
   const workspaces: StoredWorkspace[] = [...cache].map(([key, preview]) => ({ key, preview }))
   // Throws on purpose: a deletion that only removed the in-memory rows must not be
   // reported as a deletion, or the forgotten host's titles stay in plaintext on disk.

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -23,6 +23,9 @@ import {
 // v1 blobs hold raw editor-tab ids (absolute paths) and shell-set titles written by older
 // builds, and a load alone never rewrites them. The key change makes the first load drop them.
 const LEGACY_STORAGE_KEYS = ['orca:session-tab-strip:v1']
+// Keys whose removal has not yet succeeded this process. Retried on every load and write so a
+// bridge hiccup on the first launch does not leave the plaintext blob for the process's life.
+const pendingLegacyRemovals = new Set(LEGACY_STORAGE_KEYS)
 const STORAGE_KEY = 'orca:session-tab-strip:v2'
 // A phone realistically revisits a handful of workspaces; the caps bound both the stored blob
 // and the cost of a single write.
@@ -136,6 +139,9 @@ export async function deleteCachedSessionTabStripForHost(hostId: string): Promis
 }
 
 export function resetSessionTabStripCacheForTests(): void {
+  for (const key of LEGACY_STORAGE_KEYS) {
+    pendingLegacyRemovals.add(key)
+  }
   if (writeTimer) {
     clearTimeout(writeTimer)
     writeTimer = null
@@ -187,12 +193,19 @@ async function loadFile(): Promise<Map<string, MobileSessionTabStripPreview>> {
   return loadPromise
 }
 
-async function readStoredFile(): Promise<StoredWorkspace[]> {
-  // Best effort, and not awaited: the plaintext left by an older build must go, but a failed
-  // removal is no reason to withhold the strip this build can draw.
-  for (const key of LEGACY_STORAGE_KEYS) {
-    void AsyncStorage.removeItem(key).catch(() => {})
+// Not awaited: the plaintext left by an older build must go, but a failed removal is no reason
+// to withhold the strip this build can draw. A failure keeps the key queued for the next try.
+function removeLegacyBlobs(): void {
+  for (const key of pendingLegacyRemovals) {
+    void AsyncStorage.removeItem(key).then(
+      () => pendingLegacyRemovals.delete(key),
+      () => {}
+    )
   }
+}
+
+async function readStoredFile(): Promise<StoredWorkspace[]> {
+  removeLegacyBlobs()
   try {
     const raw = await AsyncStorage.getItem(STORAGE_KEY)
     if (!raw) {
@@ -237,6 +250,7 @@ function enqueueWrite(cache: Map<string, MobileSessionTabStripPreview>): Promise
 }
 
 async function writeFile(cache: Map<string, MobileSessionTabStripPreview>): Promise<void> {
+  removeLegacyBlobs()
   const workspaces: StoredWorkspace[] = [...cache].map(([key, preview]) => ({ key, preview }))
   // Throws on purpose: a deletion that only removed the in-memory rows must not be
   // reported as a deletion, or the forgotten host's titles stay in plaintext on disk.

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -7,7 +7,6 @@
 // rebuilt field by field on the way in, and shell-controlled titles are replaced with fixed
 // labels here rather than trusted to have been scrubbed upstream.
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { sha256 } from '@noble/hashes/sha256'
 import {
   getPersistableTabStripAgentId,
   getPersistableTabStripTitle,
@@ -15,20 +14,22 @@ import {
   type MobileSessionTabStripEntry,
   type MobileSessionTabStripPreview
 } from '../session/mobile-session-tab-strip-entries'
+import {
+  digestHex,
+  isMobileSessionTabStripRowKey,
+  toMobileSessionTabStripRowKey
+} from '../session/mobile-session-tab-strip-row-key'
 
-const STORAGE_KEY = 'orca:session-tab-strip:v1'
+// v1 blobs hold raw editor-tab ids (absolute paths) and shell-set titles written by older
+// builds, and a load alone never rewrites them. The key change makes the first load drop them.
+const LEGACY_STORAGE_KEYS = ['orca:session-tab-strip:v1']
+const STORAGE_KEY = 'orca:session-tab-strip:v2'
 // A phone realistically revisits a handful of workspaces; the caps bound both the stored blob
 // and the cost of a single write.
 const MAX_WORKSPACES = 12
 const MAX_TABS_PER_WORKSPACE = 24
 const MAX_TITLE_LENGTH = 64
 const WRITE_DEBOUNCE_MS = 250
-// 128 bits of a digest: far past collision range for a dozen workspaces, and short enough that
-// the stored blob stays small.
-const WORKSPACE_DIGEST_LENGTH = 32
-const TAB_DIGEST_PREFIX = 'cached:'
-// The whole shape, not the prefix: a wire id that merely starts with the prefix is still wire text.
-const DIGESTED_TAB_ID = /^cached:[0-9a-f]{32}$/
 
 type StoredWorkspace = { key: string; preview: MobileSessionTabStripPreview }
 type StoredFile = { workspaces: StoredWorkspace[] }
@@ -90,7 +91,7 @@ export function saveCachedSessionTabStrip(
   if (hostId !== null && forgottenHosts.has(hostId)) {
     return
   }
-  const redacted = redactPreview(preview)
+  const redacted = redactPreview(preview, 'wire')
   const cache = memoryCache ?? new Map()
   memoryCache = cache
   // Map.set on an existing key keeps its original iteration position, so delete first to make
@@ -149,19 +150,13 @@ function digestWorkspaceId(worktreeId: string): string {
   return digestHex(worktreeId)
 }
 
-// Prefixed so a raw id can never be mistaken for one already digested, and so a live tab's
-// id can never collide with a stored row's by construction.
-function digestTabId(tabId: string): string {
-  return DIGESTED_TAB_ID.test(tabId) ? tabId : `${TAB_DIGEST_PREFIX}${digestHex(tabId)}`
-}
-
-function digestHex(value: string): string {
-  const digest = sha256(new TextEncoder().encode(value))
-  let hex = ''
-  for (const byte of digest) {
-    hex += byte.toString(16).padStart(2, '0')
-  }
-  return hex.slice(0, WORKSPACE_DIGEST_LENGTH)
+// A wire id is always digested, even one shaped like a key: "every stored id is a digest" must
+// not be something the host can satisfy by choosing its ids. A stored key is left alone so a
+// re-read stays idempotent; a raw id an older build stored is digested on the way back out.
+function toStoredTabId(tabId: string, source: 'wire' | 'storage'): string {
+  return source === 'storage' && isMobileSessionTabStripRowKey(tabId)
+    ? tabId
+    : toMobileSessionTabStripRowKey(tabId)
 }
 
 function readHostIdFromKey(key: string): string | null {
@@ -193,6 +188,11 @@ async function loadFile(): Promise<Map<string, MobileSessionTabStripPreview>> {
 }
 
 async function readStoredFile(): Promise<StoredWorkspace[]> {
+  // Best effort, and not awaited: the plaintext left by an older build must go, but a failed
+  // removal is no reason to withhold the strip this build can draw.
+  for (const key of LEGACY_STORAGE_KEYS) {
+    void AsyncStorage.removeItem(key).catch(() => {})
+  }
   try {
     const raw = await AsyncStorage.getItem(STORAGE_KEY)
     if (!raw) {
@@ -206,7 +206,7 @@ async function readStoredFile(): Promise<StoredWorkspace[]> {
       if (typeof workspace?.key !== 'string' || !Array.isArray(workspace.preview?.tabs)) {
         return []
       }
-      return [{ key: workspace.key, preview: redactPreview(workspace.preview) }]
+      return [{ key: workspace.key, preview: redactPreview(workspace.preview, 'storage') }]
     })
   } catch {
     return []
@@ -249,7 +249,10 @@ async function writeFile(cache: Map<string, MobileSessionTabStripPreview>): Prom
 // and to mark the active row, both of which a digest serves. A stored entry written by an
 // older build carries a raw id and is digested again here on the way back out; a digest of a
 // digest is still a stable key.
-function redactPreview(preview: MobileSessionTabStripPreview): MobileSessionTabStripPreview {
+function redactPreview(
+  preview: MobileSessionTabStripPreview,
+  source: 'wire' | 'storage'
+): MobileSessionTabStripPreview {
   const tabs: MobileSessionTabStripEntry[] = []
   const ids = new Map<string, string>()
   for (const tab of preview.tabs ?? []) {
@@ -259,7 +262,7 @@ function redactPreview(preview: MobileSessionTabStripPreview): MobileSessionTabS
     const agentId = getPersistableTabStripAgentId(
       typeof tab.agentId === 'string' ? tab.agentId : null
     )
-    const id = digestTabId(tab.id)
+    const id = toStoredTabId(tab.id, source)
     ids.set(tab.id, id)
     tabs.push({
       id,

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -27,6 +27,8 @@ const WRITE_DEBOUNCE_MS = 250
 // the stored blob stays small.
 const WORKSPACE_DIGEST_LENGTH = 32
 const TAB_DIGEST_PREFIX = 'cached:'
+// The whole shape, not the prefix: a wire id that merely starts with the prefix is still wire text.
+const DIGESTED_TAB_ID = /^cached:[0-9a-f]{32}$/
 
 type StoredWorkspace = { key: string; preview: MobileSessionTabStripPreview }
 type StoredFile = { workspaces: StoredWorkspace[] }
@@ -150,7 +152,7 @@ function digestWorkspaceId(worktreeId: string): string {
 // Prefixed so a raw id can never be mistaken for one already digested, and so a live tab's
 // id can never collide with a stored row's by construction.
 function digestTabId(tabId: string): string {
-  return tabId.startsWith(TAB_DIGEST_PREFIX) ? tabId : `${TAB_DIGEST_PREFIX}${digestHex(tabId)}`
+  return DIGESTED_TAB_ID.test(tabId) ? tabId : `${TAB_DIGEST_PREFIX}${digestHex(tabId)}`
 }
 
 function digestHex(value: string): string {

--- a/mobile/src/cache/session-tab-strip-cache.ts
+++ b/mobile/src/cache/session-tab-strip-cache.ts
@@ -9,6 +9,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { sha256 } from '@noble/hashes/sha256'
 import {
+  getPersistableTabStripAgentId,
   getPersistableTabStripTitle,
   isDrawableTabStripType,
   type MobileSessionTabStripEntry,
@@ -25,6 +26,7 @@ const WRITE_DEBOUNCE_MS = 250
 // 128 bits of a digest: far past collision range for a dozen workspaces, and short enough that
 // the stored blob stays small.
 const WORKSPACE_DIGEST_LENGTH = 32
+const TAB_DIGEST_PREFIX = 'cached:'
 
 type StoredWorkspace = { key: string; preview: MobileSessionTabStripPreview }
 type StoredFile = { workspaces: StoredWorkspace[] }
@@ -142,7 +144,17 @@ export function resetSessionTabStripCacheForTests(): void {
 }
 
 function digestWorkspaceId(worktreeId: string): string {
-  const digest = sha256(new TextEncoder().encode(worktreeId))
+  return digestHex(worktreeId)
+}
+
+// Prefixed so a raw id can never be mistaken for one already digested, and so a live tab's
+// id can never collide with a stored row's by construction.
+function digestTabId(tabId: string): string {
+  return tabId.startsWith(TAB_DIGEST_PREFIX) ? tabId : `${TAB_DIGEST_PREFIX}${digestHex(tabId)}`
+}
+
+function digestHex(value: string): string {
+  const digest = sha256(new TextEncoder().encode(value))
   let hex = ''
   for (const byte of digest) {
     hex += byte.toString(16).padStart(2, '0')
@@ -230,22 +242,27 @@ async function writeFile(cache: Map<string, MobileSessionTabStripPreview>): Prom
 }
 
 // Rebuilt field by field so a field later added to the live tab type cannot ride into storage
-// without someone deciding it belongs there.
+// without someone deciding it belongs there. The id is digested: an editor tab's id embeds the
+// worktree and the URL-encoded absolute file path, and the strip only needs it as a React key
+// and to mark the active row, both of which a digest serves. A stored entry written by an
+// older build carries a raw id and is digested again here on the way back out; a digest of a
+// digest is still a stable key.
 function redactPreview(preview: MobileSessionTabStripPreview): MobileSessionTabStripPreview {
   const tabs: MobileSessionTabStripEntry[] = []
+  const ids = new Map<string, string>()
   for (const tab of preview.tabs ?? []) {
     if (typeof tab?.id !== 'string' || !isDrawableTabStripType(tab.type)) {
       continue
     }
-    const agentId = typeof tab.agentId === 'string' ? tab.agentId : null
-    const title = typeof tab.title === 'string' ? tab.title : ''
+    const agentId = getPersistableTabStripAgentId(
+      typeof tab.agentId === 'string' ? tab.agentId : null
+    )
+    const id = digestTabId(tab.id)
+    ids.set(tab.id, id)
     tabs.push({
-      id: tab.id,
+      id,
       type: tab.type,
-      title: getPersistableTabStripTitle({ type: tab.type, title, agentId }).slice(
-        0,
-        MAX_TITLE_LENGTH
-      ),
+      title: getPersistableTabStripTitle({ type: tab.type, agentId }).slice(0, MAX_TITLE_LENGTH),
       agentId
     })
     if (tabs.length === MAX_TABS_PER_WORKSPACE) {
@@ -253,8 +270,6 @@ function redactPreview(preview: MobileSessionTabStripPreview): MobileSessionTabS
     }
   }
   const activeTabId =
-    typeof preview.activeTabId === 'string' && tabs.some((tab) => tab.id === preview.activeTabId)
-      ? preview.activeTabId
-      : null
+    typeof preview.activeTabId === 'string' ? (ids.get(preview.activeTabId) ?? null) : null
   return { tabs, activeTabId }
 }

--- a/mobile/src/session/MobileSessionHeader.tsx
+++ b/mobile/src/session/MobileSessionHeader.tsx
@@ -28,7 +28,6 @@ export function MobileSessionHeader({ controller }: { controller: MobileSessionC
     forceReconnectHost,
     worktreeName,
     activePanel,
-    activeSessionTabIdRef,
     tabStripRef,
     tabStripOffsetRef,
     tabStripViewportWidthRef,
@@ -53,6 +52,7 @@ export function MobileSessionHeader({ controller }: { controller: MobileSessionC
     handlePanelTap,
     showHeaderMoreButton
   } = controller
+  const activeTabStripRowKey = tabStripRows.find((row) => row.isActive)?.key ?? null
   return (
     <SafeAreaView style={styles.sessionChrome} edges={['top']}>
       <View style={styles.sessionTopBar}>
@@ -128,16 +128,16 @@ export function MobileSessionHeader({ controller }: { controller: MobileSessionC
             }}
             onLayout={(e) => {
               tabStripViewportWidthRef.current = e.nativeEvent.layout.width
-              scrollActiveTabIntoView(activeSessionTabIdRef.current, false)
+              scrollActiveTabIntoView(activeTabStripRowKey, false)
             }}
             onContentSizeChange={(width) => {
               tabStripContentWidthRef.current = width
-              scrollActiveTabIntoView(activeSessionTabIdRef.current, false)
+              scrollActiveTabIntoView(activeTabStripRowKey, false)
             }}
           >
-            {tabStripRows.map(({ entry, isActive, tab }) => (
+            {tabStripRows.map(({ key, entry, isActive, tab }) => (
               <Pressable
-                key={entry.id}
+                key={key}
                 style={[
                   styles.tab,
                   isActive && styles.tabActive,
@@ -145,9 +145,9 @@ export function MobileSessionHeader({ controller }: { controller: MobileSessionC
                 ]}
                 onLayout={(e) => {
                   const { x, width } = e.nativeEvent.layout
-                  tabLayoutsRef.current.set(entry.id, { x, width })
-                  if (entry.id === activeSessionTabIdRef.current) {
-                    scrollActiveTabIntoView(entry.id, false)
+                  tabLayoutsRef.current.set(key, { x, width })
+                  if (isActive) {
+                    scrollActiveTabIntoView(key, false)
                   }
                 }}
                 // A cached preview row has no live tab behind it, so both gestures need the

--- a/mobile/src/session/mobile-session-reconnect-view-state.test.ts
+++ b/mobile/src/session/mobile-session-reconnect-view-state.test.ts
@@ -6,17 +6,24 @@ import {
   type MobileSessionTabStripPreview
 } from './mobile-session-tab-strip-entries'
 import type { MobileSessionTab } from './mobile-session-route-types'
+import { toMobileSessionTabStripRowKey } from './mobile-session-tab-strip-row-key'
 
 function terminalTab(id: string, title: string, isActive = false): MobileSessionTab {
   return { type: 'terminal', id, title, terminal: `h-${id}`, isActive }
 }
 
+// A cached preview carries row keys (digests of the live ids), never the ids themselves.
 const cachedPreview: MobileSessionTabStripPreview = {
   tabs: [
-    { id: 'tab-1', type: 'terminal', title: 'claude', agentId: 'claude' },
-    { id: 'tab-2', type: 'terminal', title: 'shell', agentId: null }
+    {
+      id: toMobileSessionTabStripRowKey('tab-1'),
+      type: 'terminal',
+      title: 'claude',
+      agentId: 'claude'
+    },
+    { id: toMobileSessionTabStripRowKey('tab-2'), type: 'terminal', title: 'shell', agentId: null }
   ],
-  activeTabId: 'tab-1'
+  activeTabId: toMobileSessionTabStripRowKey('tab-1')
 }
 
 const base = {
@@ -104,7 +111,10 @@ describe('getMobileSessionTabStripRows', () => {
       preview: preview.kind === 'reconnecting-with-cache' ? preview.preview : null
     })
 
-    expect(previewRows.map((row) => row.entry.id)).toEqual(['tab-1', 'tab-2'])
+    expect(previewRows.map((row) => row.key)).toEqual([
+      toMobileSessionTabStripRowKey('tab-1'),
+      toMobileSessionTabStripRowKey('tab-2')
+    ])
     expect(previewRows.map((row) => row.tab)).toEqual([null, null])
     expect(previewRows.map((row) => row.isActive)).toEqual([true, false])
 
@@ -115,7 +125,9 @@ describe('getMobileSessionTabStripRows', () => {
       preview: null
     })
 
-    expect(liveRows.map((row) => row.entry.id)).toEqual(previewRows.map((row) => row.entry.id))
+    // Same React keys across the swap: the preview id is the live row's digest, so no remount.
+    expect(liveRows.map((row) => row.key)).toEqual(previewRows.map((row) => row.key))
+    expect(liveRows.map((row) => row.entry.id)).toEqual(['tab-1', 'tab-2'])
     expect(liveRows.map((row) => row.isActive)).toEqual(previewRows.map((row) => row.isActive))
     expect(liveRows.every((row) => row.tab !== null)).toBe(true)
   })

--- a/mobile/src/session/mobile-session-route-parity.test.ts
+++ b/mobile/src/session/mobile-session-route-parity.test.ts
@@ -67,8 +67,8 @@ const HEAD_MAIN_HOOK_SHA256 = 'e22e7d3a1147ef19c747f0e216b778e794a73e027e96cf84f
 const HEAD_HOOK_BINDING_SHA256 = '531fe06cf2c261b1346bbc949c9ceba5aea8b8ace2dcb8a1898e9759745e013c'
 const HEAD_CALLBACK_IDENTITY_SHA256 =
   'e5df1043256bcb0b3813bf89161d91f5e65c00749fbb6d98176bca82e878d061'
-const HEAD_CALLBACK_BODY_SHA256 = '6d9ed614ed139aef5cc911c33ea4220cc1fc5f888a1a564ef85e6910cc118bc3'
-const HEAD_EFFECT_SHA256 = 'a6d4d5cb573926f40faa7701cef7885a0f2c7e7c5cfaa91f4e480c29aba44d79'
+const HEAD_CALLBACK_BODY_SHA256 = '591e569482ddcdfcf6aaf576851acef62c93b17b70e5b3528a04ce69f1c5d3b1'
+const HEAD_EFFECT_SHA256 = '21b34c4111f8c52872a0356b3b80f39cb9f63d5b2b5de7a5118d7d12411606e0'
 const HEAD_CONTENT_HOOK_SHA256 = '9c3b612fef3f370d66873aefdbe1d701f20cb64ded31fef5cc45fde6f8189581'
 const HEAD_NESTED_FUNCTION_SHA256 =
   '0e553eb5ec7aeda8f8336b8da85ff87eb3657a21fa32d3c75c9cc32e36860244'
@@ -77,11 +77,11 @@ const HEAD_NATIVE_REGISTRATION_SHA256 =
 const HEAD_NATIVE_REMOVAL_SHA256 =
   '4c994574675a2a0f9c607b3ea89ab7a2ed5a83f7c72fa42342ddcb5f00fc3f4f'
 const HEAD_TIMER_CREATION_SHA256 =
-  '36c3ccef371698e25cd2eb239df7a8dea6dcc674d9da43cc38cabfa3a8f64929'
+  '7034ff8be89e2594694e78efdd64bf0ac6d3e659bd5f051dcb9cc2ccda875709'
 const HEAD_TIMER_CLEANUP_SHA256 = '2f41ddc30d0e9c1b6d1d6b5e09d96d1b3facd3133acae1ff7436bb40e4ef39dc'
 const HEAD_RUNTIME_STRING_SHA256 =
-  '694a22ed924ebc2a7d380089ff2cfd3e27f5d72d3c4d4b7b06aa3006db93c053'
-const HEAD_HOST_JSX_SHA256 = '0aca9fe4b6738228020fe20334fe2716471a2fdf57e4feea6a2a92cac1c04c58'
+  '574d0631e710eb6d4c3172d7ac948769302f880d20df118cc6028cf1a535e47a'
+const HEAD_HOST_JSX_SHA256 = '4d8d5c30a5868ddc5441c79be24d9d8ec546091bbdcd2f0533eea6e121c75396'
 const HEAD_LEAF_JSX_SHA256 = '2c38e19ffbcaae14f9df2fdb44751546d2b936f9a4b2c5e90727a5f74f3c2665'
 const HEAD_STYLE_REFERENCE_SHA256 =
   'da81d6065c5c1ebafbbd721321023cddd0bfc1afa0325749f736bb97898f9556'
@@ -523,7 +523,7 @@ describe('mobile session route extraction parity', () => {
 
   it('preserves runtime strings, styles, and the expanded JSX tree', () => {
     const strings = readRuntimeStrings()
-    expect(strings).toHaveLength(545)
+    expect(strings).toHaveLength(551)
     expect(hash(strings)).toBe(HEAD_RUNTIME_STRING_SHA256)
     const jsx = readJsxFacts(readDefinitions())
     expect(jsx.host).toHaveLength(127)

--- a/mobile/src/session/mobile-session-route-source-family.test-support.ts
+++ b/mobile/src/session/mobile-session-route-source-family.test-support.ts
@@ -34,6 +34,7 @@ export const MOBILE_SESSION_ROUTE_SOURCE_FILES = [
   './use-mobile-session-close-actions.ts',
   './use-mobile-session-bulk-close.ts',
   './use-mobile-session-tab-strip-cache.ts',
+  './mobile-session-tab-strip-row-key.ts',
   './use-mobile-session-presentation.ts',
   './use-mobile-session-panel-route-actions.tsx',
   './MobileSessionMarkdownReader.tsx',

--- a/mobile/src/session/mobile-session-tab-strip-entries.ts
+++ b/mobile/src/session/mobile-session-tab-strip-entries.ts
@@ -7,7 +7,9 @@ import {
 
 /**
  * The only session-tab fields the tab strip draws. Everything else the live tab carries (unsent
- * launch drafts, absolute file paths, browser URLs, agent session ids) stays on the wire.
+ * launch drafts, absolute file paths, browser URLs, agent session ids) stays on the wire. The id
+ * itself is wire-supplied too: an editor tab's id embeds its absolute path, so the cache stores
+ * a digest of it, never the id.
  */
 export type MobileSessionTabStripEntry = {
   id: string
@@ -61,27 +63,36 @@ export function isDrawableTabStripType(type: string): type is MobileSessionTabTy
 
 const agentDisplayNames: Readonly<Record<string, string>> = TUI_AGENT_DISPLAY_NAMES
 
+/** An agent id is only kept on disk when it names a known agent; anything else is hook text. */
+export function getPersistableTabStripAgentId(agentId: string | null): string | null {
+  return agentId !== null && Object.hasOwn(agentDisplayNames, agentId) ? agentId : null
+}
+
 /**
- * The title a strip entry may be written to disk under.
+ * The title a strip entry may be written to disk under. Nothing wire-supplied passes through.
  *
  * A terminal's title is whatever the shell last set, which is routinely the command line —
- * `psql postgres://user:password@host/db`, `curl -H "Authorization: Bearer ..."`. None of that
- * belongs in plaintext storage, and a browser tab's page title is no better. Both collapse to a
- * fixed label, so what survives is the shape of the strip, not its contents. A resolved agent
- * still names itself, because that lookup is a closed enum: an unrecognised id yields the
- * generic label rather than passing text through.
+ * `psql postgres://user:password@host/db`, `curl -H "Authorization: Bearer ..."`. A browser
+ * tab's page title, a file or markdown tab's basename, and an agent session's title are no
+ * better: each names what the user was working on. Every type collapses to a fixed label, so
+ * what survives is the shape of the strip, not its contents. A resolved agent still names
+ * itself, because that lookup is a closed enum.
  */
 export function getPersistableTabStripTitle(
-  entry: Pick<MobileSessionTabStripEntry, 'type' | 'title' | 'agentId'>
+  entry: Pick<MobileSessionTabStripEntry, 'type' | 'agentId'>
 ): string {
-  if (entry.type === 'terminal') {
-    const agentLabel = entry.agentId === null ? undefined : agentDisplayNames[entry.agentId]
-    return agentLabel ?? 'Terminal'
+  const agentLabel = agentDisplayNames[getPersistableTabStripAgentId(entry.agentId) ?? '']
+  switch (entry.type) {
+    case 'terminal':
+    case 'agent-session':
+      return agentLabel ?? (entry.type === 'terminal' ? 'Terminal' : 'Agent')
+    case 'browser':
+      return 'Browser'
+    case 'markdown':
+      return 'Markdown'
+    case 'file':
+      return 'File'
   }
-  if (entry.type === 'browser') {
-    return 'Browser'
-  }
-  return entry.title
 }
 
 export function toMobileSessionTabStripPreview(

--- a/mobile/src/session/mobile-session-tab-strip-entries.ts
+++ b/mobile/src/session/mobile-session-tab-strip-entries.ts
@@ -4,6 +4,7 @@ import {
   getMobileSessionTabTitle,
   resolveMobileTerminalTabAgentId
 } from './mobile-terminal-tab-agent'
+import { toMobileSessionTabStripRowKey } from './mobile-session-tab-strip-row-key'
 
 /**
  * The only session-tab fields the tab strip draws. Everything else the live tab carries (unsent
@@ -24,6 +25,8 @@ export type MobileSessionTabStripPreview = {
 }
 
 export type MobileSessionTabStripRow = {
+  /** React key. A digest of the tab id, so a preview row and its live successor share one. */
+  key: string
   entry: MobileSessionTabStripEntry
   isActive: boolean
   /** null on a preview row: switching to that tab needs a live connection. */
@@ -104,7 +107,8 @@ export function toMobileSessionTabStripPreview(
 
 /**
  * Rows for the header strip. Live tabs always win; the preview only fills a strip that has no
- * live rows yet, and its ids are the live ids, so the swap reuses the same React keys.
+ * live rows yet. A preview id is already a row key, and a live row keys under the digest of its
+ * id, so the swap reuses the same React keys.
  */
 export function getMobileSessionTabStripRows(args: {
   liveTabs: readonly MobileSessionTab[]
@@ -114,12 +118,14 @@ export function getMobileSessionTabStripRows(args: {
   const { liveTabs, activeSessionTabId, preview } = args
   if (liveTabs.length > 0 || !preview) {
     return liveTabs.map((tab) => ({
+      key: toMobileSessionTabStripRowKey(tab.id),
       entry: toMobileSessionTabStripEntry(tab),
       isActive: tab.id === activeSessionTabId,
       tab
     }))
   }
   return preview.tabs.map((entry) => ({
+    key: entry.id,
     entry,
     isActive: entry.id === preview.activeTabId,
     tab: null

--- a/mobile/src/session/mobile-session-tab-strip-row-key.ts
+++ b/mobile/src/session/mobile-session-tab-strip-row-key.ts
@@ -1,0 +1,31 @@
+import { sha256 } from '@noble/hashes/sha256'
+
+// 128 bits of a digest: far past collision range for a strip of tabs, and short enough that the
+// stored blob stays small.
+const DIGEST_HEX_LENGTH = 32
+const ROW_KEY_PREFIX = 'cached:'
+// The whole shape, not the prefix: a wire id that merely starts with the prefix is still wire text.
+const ROW_KEY = /^cached:[0-9a-f]{32}$/
+
+/**
+ * The React key a strip row draws under. A cached preview row and the live row that replaces it
+ * on reconnect must share a key, or the swap remounts every row and blinks the strip the cache
+ * exists to keep still. The key is a digest because an editor tab's id embeds its absolute file
+ * path, and the key is what the cache persists.
+ */
+export function toMobileSessionTabStripRowKey(tabId: string): string {
+  return `${ROW_KEY_PREFIX}${digestHex(tabId)}`
+}
+
+export function isMobileSessionTabStripRowKey(value: string): boolean {
+  return ROW_KEY.test(value)
+}
+
+export function digestHex(value: string): string {
+  const digest = sha256(new TextEncoder().encode(value))
+  let hex = ''
+  for (const byte of digest) {
+    hex += byte.toString(16).padStart(2, '0')
+  }
+  return hex.slice(0, DIGEST_HEX_LENGTH)
+}

--- a/mobile/src/session/use-mobile-session-keyboard-state.ts
+++ b/mobile/src/session/use-mobile-session-keyboard-state.ts
@@ -5,6 +5,7 @@ import { useTerminalViewportRefit } from '../terminal/terminal-viewport-refit'
 import { saveCustomKeys, type CustomKey } from '../components/CustomKeyModal'
 import { LAST_VISITED_WORKTREE_STORAGE_KEY } from '../worktree/last-visited-worktree-repo'
 import { resolveTabStripScrollOffset } from './tab-strip-scroll'
+import { toMobileSessionTabStripRowKey } from './mobile-session-tab-strip-row-key'
 import type { MobileSessionLifecycleModel } from './use-mobile-session-lifecycle'
 
 export function useMobileSessionKeyboardState(scope: MobileSessionLifecycleModel) {
@@ -76,11 +77,13 @@ export function useMobileSessionKeyboardState(scope: MobileSessionLifecycleModel
     }
   }, [notifyKeyboardVisibility])
 
-  const scrollActiveTabIntoView = useCallback((tabId: string | null, animated: boolean) => {
-    if (!tabId) {
+  // Layouts are recorded under the strip's row key (a digest of the tab id), so a cached preview
+  // row and the live row that replaces it share one entry.
+  const scrollActiveTabIntoView = useCallback((rowKey: string | null, animated: boolean) => {
+    if (!rowKey) {
       return
     }
-    const layout = tabLayoutsRef.current.get(tabId)
+    const layout = tabLayoutsRef.current.get(rowKey)
     if (!layout) {
       return
     }
@@ -99,7 +102,12 @@ export function useMobileSessionKeyboardState(scope: MobileSessionLifecycleModel
 
   // Reveal the active tab on change; defer one frame so freshly mounted tab layouts are recorded.
   useEffect(() => {
-    const id = requestAnimationFrame(() => scrollActiveTabIntoView(activeSessionTabId, true))
+    const id = requestAnimationFrame(() =>
+      scrollActiveTabIntoView(
+        activeSessionTabId === null ? null : toMobileSessionTabStripRowKey(activeSessionTabId),
+        true
+      )
+    )
     return () => cancelAnimationFrame(id)
   }, [activeSessionTabId, scrollActiveTabIntoView])
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​194 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​53 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 |

<!-- /orca-pr-loc -->

Follow-up to #19281 from the post-merge adversarial review. Three privacy findings on the cached tab strip, all reproduced against main with failing-first tests.

## Why

The cache's contract is that only the shape of the strip reaches plaintext AsyncStorage. Three wire-supplied fields still passed through:

- **HIGH: the tab `id`.** The desktop builds an editor tab's id as `editor:<worktreeId>:<runtimeKey>:<encodeURIComponent(filePath)>` (`buildOwnedEditorFileId`) and publishes it unchanged when the file has no unified tab row. The cache copied it verbatim, so up to 12 workspaces × 24 tabs of worktree paths and absolute file paths persisted across launches. The same commit digested the workspace id for exactly this reason.
- **MEDIUM: file, markdown, and agent-session titles.** Only terminal and browser titles were rewritten. An editor tab's title is its basename; an agent session's title is the task. Both name what the user was working on.
- **LOW: `agentId`.** Any string was kept. Its source is the hook-reported agent type, free text on the wire and only length-normalized by the host, so ~40 characters of hook-controlled text per tab reached disk.

## What

- Every stored id is `cached:` + a 128-bit SHA-256 prefix of the wire id. The strip only needs the id as a React key and to mark the active row; both still work, and `activeTabId` is mapped through the same digest. A raw id written by an older build is digested on the way back out; an already-digested one is left alone. Live rows still replace preview rows wholesale, so there is no key continuity to lose.
- `getPersistableTabStripTitle` is now an exhaustive switch over the tab type with a fixed label per type (`Terminal`/`Agent` or the agent's display name, `Browser`, `Markdown`, `File`). It no longer takes a title at all.
- `getPersistableTabStripAgentId` keeps an agent id only when it is a key of `TUI_AGENT_DISPLAY_NAMES`; everything else becomes `null` and the title falls back to the generic label.

## Tests

- New: an editor id carrying a client path is never written and the row is titled `File`.
- New: a raw id from an older build is digested on load, a digested one is stable, and the active id follows the digest.
- New: known agent ids survive, hook text and unknown ids become `null`, and no title, basename, or agent-session task reaches the written blob.
- Existing tests that asserted raw ids now assert the digest shape. All 7 new or changed cases fail against main's scrub.
- `tsc`, full mobile `vitest` (4326), `oxlint`, `oxfmt --check` clean.
