### PR TITLE
fix(mobile): report a failed direct cutover instead of leaking it as an unhandled rejection

### DIFF
--- a/mobile/src/transport/mobile-direct-return-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.test.ts
@@ -6,8 +6,11 @@ import { FakeSession, host } from './mobile-endpoint-supervisor-test-fakes'
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
 
 // A LAN that never answers: every dial sits open until the probe's own 12s budget.
-function fixture() {
+function fixture(
+  overrides: { migrate?: () => Promise<void>; adoptsOutright?: () => boolean } = {}
+) {
   const opened: FakeSession[] = []
+  const cutoverFailures: Error[] = []
   const probe = new DirectReturnProbe(
     {
       now: Date.now,
@@ -31,14 +34,15 @@ function fixture() {
       canDial: () => true,
       canAttempt: () => true,
       // These cases model a live relay session, so hysteresis still arbitrates.
-      adoptsOutright: () => false,
+      adoptsOutright: overrides.adoptsOutright ?? (() => false),
       beginOperation: () => {},
-      migrate: async () => {},
+      migrate: overrides.migrate ?? (async () => {}),
       onDirectMigrated: async () => {},
-      afterProbe: () => {}
+      afterProbe: () => {},
+      onCutoverFailure: (error) => cutoverFailures.push(error)
     }
   )
-  return { opened, probe }
+  return { opened, probe, cutoverFailures }
 }
 
 beforeEach(() => vi.useFakeTimers())
@@ -92,5 +96,54 @@ it('falls back to the ordinary interval when nothing asked for a sooner probe', 
   expect(opened).toHaveLength(1)
   await vi.advanceTimersByTimeAsync(1)
   expect(opened).toHaveLength(2)
+  probe.stop()
+})
+
+it('reports a cutover that fails after authentication instead of rejecting unhandled', async () => {
+  // Why: probe() runs from a timer that discards its promise. During a reconnect
+  // race the abort predicate stays false while nothing is connected, so a candidate
+  // that drops between authentication and the swap used to escape as an unhandled
+  // rejection on every such reconnect.
+  const unhandled = vi.fn()
+  process.on('unhandledRejection', unhandled)
+  try {
+    const { opened, probe, cutoverFailures } = fixture({
+      adoptsOutright: () => true,
+      migrate: async () => {
+        throw new Error('direct session dropped before cutover')
+      }
+    })
+    probe.schedule(0)
+    await vi.advanceTimersByTimeAsync(0)
+    opened[0]!.publishState('connected')
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(cutoverFailures.map((error) => error.message)).toEqual([
+      'direct session dropped before cutover'
+    ])
+    expect(unhandled).not.toHaveBeenCalled()
+    probe.stop()
+  } finally {
+    process.off('unhandledRejection', unhandled)
+  }
+})
+
+it('stays quiet when the cutover was withdrawn because relay won the race', async () => {
+  let relayWon = false
+  const { opened, probe, cutoverFailures } = fixture({
+    adoptsOutright: () => !relayWon,
+    migrate: async () => {
+      relayWon = true
+      throw new Error('migration superseded')
+    }
+  })
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(0)
+  opened[0]!.publishState('connected')
+  await vi.advanceTimersByTimeAsync(0)
+  await vi.advanceTimersByTimeAsync(0)
+
+  expect(cutoverFailures).toEqual([])
   probe.stop()
 })

--- a/mobile/src/transport/mobile-direct-return-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.test.ts
@@ -11,12 +11,14 @@ function fixture(
     migrate?: () => Promise<void>
     adoptsOutright?: () => boolean
     onCutoverFailure?: (error: Error) => void
+    onBookkeepingError?: (error: Error) => void
     onDirectMigrated?: () => Promise<void>
     hysteresis?: MobileEndpointHysteresis
   } = {}
 ) {
   const opened: FakeSession[] = []
   const cutoverFailures: Error[] = []
+  const bookkeepingErrors: Error[] = []
   const probe = new DirectReturnProbe(
     {
       now: Date.now,
@@ -47,10 +49,11 @@ function fixture(
       migrate: overrides.migrate ?? (async () => {}),
       onDirectMigrated: overrides.onDirectMigrated ?? (async () => {}),
       afterProbe: () => {},
-      onCutoverFailure: overrides.onCutoverFailure ?? ((error) => cutoverFailures.push(error))
+      onCutoverFailure: overrides.onCutoverFailure ?? ((error) => cutoverFailures.push(error)),
+      onBookkeepingError: overrides.onBookkeepingError ?? ((error) => bookkeepingErrors.push(error))
     }
   )
-  return { opened, probe, cutoverFailures }
+  return { opened, probe, cutoverFailures, bookkeepingErrors }
 }
 
 beforeEach(() => vi.useFakeTimers())
@@ -215,7 +218,7 @@ it('contains a post-migration bookkeeping failure instead of rejecting the timer
   const unhandled = vi.fn()
   process.on('unhandledRejection', unhandled)
   try {
-    const { opened, probe, cutoverFailures } = fixture({
+    const { opened, probe, cutoverFailures, bookkeepingErrors } = fixture({
       adoptsOutright: () => true,
       onDirectMigrated: async () => {
         throw new Error('credential bookkeeping failed')
@@ -226,7 +229,11 @@ it('contains a post-migration bookkeeping failure instead of rejecting the timer
     opened[0]!.publishState('connected')
     await vi.advanceTimersByTimeAsync(0)
     await vi.advanceTimersByTimeAsync(0)
-    expect(cutoverFailures.map((error) => error.message)).toEqual(['credential bookkeeping failed'])
+    // Reported as bookkeeping, not as a failed cutover: the cutover landed.
+    expect(bookkeepingErrors.map((error) => error.message)).toEqual([
+      'credential bookkeeping failed'
+    ])
+    expect(cutoverFailures).toEqual([])
     expect(unhandled).not.toHaveBeenCalled()
     probe.stop()
   } finally {

--- a/mobile/src/transport/mobile-direct-return-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.test.ts
@@ -11,6 +11,8 @@ function fixture(
     migrate?: () => Promise<void>
     adoptsOutright?: () => boolean
     onCutoverFailure?: (error: Error) => void
+    onDirectMigrated?: () => Promise<void>
+    hysteresis?: MobileEndpointHysteresis
   } = {}
 ) {
   const opened: FakeSession[] = []
@@ -27,12 +29,14 @@ function fixture(
       }
     },
     {
-      hysteresis: new MobileEndpointHysteresis(Date.now(), {
-        directSuccessesRequired: 1,
-        directObservationMs: 60_000,
-        failureCooldownMs: 0,
-        minimumDwellMs: 0
-      }),
+      hysteresis:
+        overrides.hysteresis ??
+        new MobileEndpointHysteresis(Date.now(), {
+          directSuccessesRequired: 1,
+          directObservationMs: 60_000,
+          failureCooldownMs: 0,
+          minimumDwellMs: 0
+        }),
       host: () => host,
       canSchedule: () => true,
       canDial: () => true,
@@ -41,7 +45,7 @@ function fixture(
       adoptsOutright: overrides.adoptsOutright ?? (() => false),
       beginOperation: () => {},
       migrate: overrides.migrate ?? (async () => {}),
-      onDirectMigrated: async () => {},
+      onDirectMigrated: overrides.onDirectMigrated ?? (async () => {}),
       afterProbe: () => {},
       onCutoverFailure: overrides.onCutoverFailure ?? ((error) => cutoverFailures.push(error))
     }
@@ -171,6 +175,58 @@ it('contains a reporter that throws, so the timer promise still settles cleanly'
     await vi.advanceTimersByTimeAsync(0)
     await vi.advanceTimersByTimeAsync(0)
 
+    expect(unhandled).not.toHaveBeenCalled()
+    probe.stop()
+  } finally {
+    process.off('unhandledRejection', unhandled)
+  }
+})
+
+it('books a direct failure on a genuine cutover failure, so the next tick honors the cooldown', async () => {
+  // Why: the success streak is credited before migrate runs. Without a booked failure the
+  // next probe re-dials, passes the streak instantly, and fails the same way every tick.
+  const hysteresis = new MobileEndpointHysteresis(Date.now(), {
+    directSuccessesRequired: 1,
+    directObservationMs: 0,
+    failureCooldownMs: 60_000,
+    minimumDwellMs: 0
+  })
+  const { opened, probe, cutoverFailures } = fixture({
+    hysteresis,
+    migrate: async () => {
+      throw new Error('direct session dropped before cutover')
+    }
+  })
+  probe.schedule(0)
+  await vi.advanceTimersByTimeAsync(0)
+  opened[0]!.publishState('connected')
+  await vi.advanceTimersByTimeAsync(0)
+  await vi.advanceTimersByTimeAsync(0)
+  expect(cutoverFailures).toHaveLength(1)
+  expect(hysteresis.canProbe(Date.now())).toBe(false)
+
+  // The 15s tick sees the cooldown and does not dial again.
+  await vi.advanceTimersByTimeAsync(15_000)
+  expect(opened).toHaveLength(1)
+  probe.stop()
+})
+
+it('contains a post-migration bookkeeping failure instead of rejecting the timer promise', async () => {
+  const unhandled = vi.fn()
+  process.on('unhandledRejection', unhandled)
+  try {
+    const { opened, probe, cutoverFailures } = fixture({
+      adoptsOutright: () => true,
+      onDirectMigrated: async () => {
+        throw new Error('credential bookkeeping failed')
+      }
+    })
+    probe.schedule(0)
+    await vi.advanceTimersByTimeAsync(0)
+    opened[0]!.publishState('connected')
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(cutoverFailures.map((error) => error.message)).toEqual(['credential bookkeeping failed'])
     expect(unhandled).not.toHaveBeenCalled()
     probe.stop()
   } finally {

--- a/mobile/src/transport/mobile-direct-return-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.test.ts
@@ -7,7 +7,11 @@ vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
 
 // A LAN that never answers: every dial sits open until the probe's own 12s budget.
 function fixture(
-  overrides: { migrate?: () => Promise<void>; adoptsOutright?: () => boolean } = {}
+  overrides: {
+    migrate?: () => Promise<void>
+    adoptsOutright?: () => boolean
+    onCutoverFailure?: (error: Error) => void
+  } = {}
 ) {
   const opened: FakeSession[] = []
   const cutoverFailures: Error[] = []

--- a/mobile/src/transport/mobile-direct-return-probe.test.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.test.ts
@@ -39,7 +39,7 @@ function fixture(
       migrate: overrides.migrate ?? (async () => {}),
       onDirectMigrated: async () => {},
       afterProbe: () => {},
-      onCutoverFailure: (error) => cutoverFailures.push(error)
+      onCutoverFailure: overrides.onCutoverFailure ?? ((error) => cutoverFailures.push(error))
     }
   )
   return { opened, probe, cutoverFailures }
@@ -146,4 +146,30 @@ it('stays quiet when the cutover was withdrawn because relay won the race', asyn
 
   expect(cutoverFailures).toEqual([])
   probe.stop()
+})
+
+it('contains a reporter that throws, so the timer promise still settles cleanly', async () => {
+  const unhandled = vi.fn()
+  process.on('unhandledRejection', unhandled)
+  try {
+    const { opened, probe } = fixture({
+      adoptsOutright: () => true,
+      migrate: async () => {
+        throw new Error('direct session dropped before cutover')
+      },
+      onCutoverFailure: () => {
+        throw new Error('reporter exploded')
+      }
+    })
+    probe.schedule(0)
+    await vi.advanceTimersByTimeAsync(0)
+    opened[0]!.publishState('connected')
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(unhandled).not.toHaveBeenCalled()
+    probe.stop()
+  } finally {
+    process.off('unhandledRejection', unhandled)
+  }
 })

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -98,6 +98,14 @@ export class DirectReturnProbe {
     this.activeProbe?.abort()
   }
 
+  private reportCutoverFailure(error: unknown): void {
+    try {
+      this.hooks.onCutoverFailure(error instanceof Error ? error : new Error(String(error)))
+    } catch {
+      // The reporter is diagnostics; it must not turn into the rejection it exists to avoid.
+    }
+  }
+
   private async probe(): Promise<void> {
     if (this.stopped) {
       return
@@ -169,11 +177,10 @@ export class DirectReturnProbe {
         // caught: a genuine failure is reported to the supervisor's log instead,
         // and the finally reschedules the probe either way.
         if (!this.stopped && !abortCutover()) {
-          try {
-            this.hooks.onCutoverFailure(error instanceof Error ? error : new Error(String(error)))
-          } catch {
-            // The reporter is diagnostics; it must not turn into the rejection it exists to avoid.
-          }
+          // Why: the streak was already credited above, so without a booked failure the
+          // next tick re-dials, promotes on the spot, and fails the same way every 15s.
+          this.hooks.hysteresis.recordDirectFailure(this.deps.now())
+          this.reportCutoverFailure(error)
         }
         return
       }
@@ -181,7 +188,12 @@ export class DirectReturnProbe {
         return
       }
       this.hooks.hysteresis.recordMigration(this.deps.now())
-      await this.hooks.onDirectMigrated()
+      try {
+        await this.hooks.onDirectMigrated()
+      } catch (error) {
+        // The cutover already landed; post-migration bookkeeping must not reject the timer promise.
+        this.reportCutoverFailure(error)
+      }
     } finally {
       this.activeProbe = null
       successful?.client.close()

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -50,6 +50,9 @@ export class DirectReturnProbe {
       // candidate dropped between authentication and the swap, or the logical
       // client closed. Nothing above this can handle it, so it is reported here.
       onCutoverFailure: (error: Error) => void
+      // The cutover landed; the bookkeeping after it (credential refresh) failed.
+      // Kept apart from a failed cutover so a field log does not read as a fallback.
+      onBookkeepingError: (error: Error) => void
     }
   ) {}
 
@@ -98,9 +101,9 @@ export class DirectReturnProbe {
     this.activeProbe?.abort()
   }
 
-  private reportCutoverFailure(error: unknown): void {
+  private report(hook: 'onCutoverFailure' | 'onBookkeepingError', error: unknown): void {
     try {
-      this.hooks.onCutoverFailure(error instanceof Error ? error : new Error(String(error)))
+      this.hooks[hook](error instanceof Error ? error : new Error(String(error)))
     } catch {
       // The reporter is diagnostics; it must not turn into the rejection it exists to avoid.
     }
@@ -180,7 +183,7 @@ export class DirectReturnProbe {
           // Why: the streak was already credited above, so without a booked failure the
           // next tick re-dials, promotes on the spot, and fails the same way every 15s.
           this.hooks.hysteresis.recordDirectFailure(this.deps.now())
-          this.reportCutoverFailure(error)
+          this.report('onCutoverFailure', error)
         }
         return
       }
@@ -192,7 +195,7 @@ export class DirectReturnProbe {
         await this.hooks.onDirectMigrated()
       } catch (error) {
         // The cutover already landed; post-migration bookkeeping must not reject the timer promise.
-        this.reportCutoverFailure(error)
+        this.report('onBookkeepingError', error)
       }
     } finally {
       this.activeProbe = null

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -169,7 +169,11 @@ export class DirectReturnProbe {
         // caught: a genuine failure is reported to the supervisor's log instead,
         // and the finally reschedules the probe either way.
         if (!this.stopped && !abortCutover()) {
-          this.hooks.onCutoverFailure(error instanceof Error ? error : new Error(String(error)))
+          try {
+            this.hooks.onCutoverFailure(error instanceof Error ? error : new Error(String(error)))
+          } catch {
+            // The reporter is diagnostics; it must not turn into the rejection it exists to avoid.
+          }
         }
         return
       }

--- a/mobile/src/transport/mobile-direct-return-probe.ts
+++ b/mobile/src/transport/mobile-direct-return-probe.ts
@@ -46,6 +46,10 @@ export class DirectReturnProbe {
       ) => Promise<void>
       onDirectMigrated: () => Promise<void>
       afterProbe: () => void
+      // A cutover that failed for a reason other than losing the race: the
+      // candidate dropped between authentication and the swap, or the logical
+      // client closed. Nothing above this can handle it, so it is reported here.
+      onCutoverFailure: (error: Error) => void
     }
   ) {}
 
@@ -161,12 +165,13 @@ export class DirectReturnProbe {
       } catch (error) {
         // Why: a withdrawn cutover is the ordinary end of a lost race, and
         // migrateTo has already closed the candidate. Only the timer calls this
-        // method, and it discards the promise, so rethrowing here would surface
-        // a routine loss as an unhandled rejection.
-        if (this.stopped || abortCutover()) {
-          return
+        // method, and it discards the promise, so nothing thrown here is ever
+        // caught: a genuine failure is reported to the supervisor's log instead,
+        // and the finally reschedules the probe either way.
+        if (!this.stopped && !abortCutover()) {
+          this.hooks.onCutoverFailure(error instanceof Error ? error : new Error(String(error)))
         }
-        throw error
+        return
       }
       if (this.stopped) {
         return

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -157,7 +157,9 @@ export class MobileEndpointSupervisor {
         }
       },
       onCutoverFailure: (error) =>
-        this.logRelay('direct cutover failed after authentication', error.message.slice(0, 80))
+        this.logRelay('direct cutover failed after authentication', error.message.slice(0, 80)),
+      onBookkeepingError: (error) =>
+        this.logRelay('direct bookkeeping failed after migration', error.message.slice(0, 80))
     })
     this.backgroundGrace = new MobileRelayBackgroundGrace(
       dependencies,

--- a/mobile/src/transport/mobile-endpoint-supervisor.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor.ts
@@ -155,7 +155,9 @@ export class MobileEndpointSupervisor {
         if (queued || this.relayRotationPending || this.logical.getState() !== 'connected') {
           void this.recoverRelay(this.relayRotationPending)
         }
-      }
+      },
+      onCutoverFailure: (error) =>
+        this.logRelay('direct cutover failed after authentication', error.message.slice(0, 80))
     })
     this.backgroundGrace = new MobileRelayBackgroundGrace(
       dependencies,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 |

<!-- /orca-pr-loc -->

Follow-up to #19308 from the post-merge adversarial review.

## Why

`DirectReturnProbe.probe()` is only ever reached from a timer that discards its promise. The cutover catch swallowed a withdrawn race (`stopped || abortCutover()`) but rethrew every other failure, so nothing could catch it. During a reconnect race `abortCutover` is `stopped || !adoptsOutright()`, and with nothing connected `adoptsOutright()` stays true, so a direct candidate that drops between authentication and the swap (or a logical client closed without stopping the supervisor) surfaced as an unhandled rejection. Before #19308 this path only ran against a live relay after a hysteresis streak; it now runs on every reconnect.

Recovery was never affected (the `finally` reschedules), but the rejection is log noise and a spurious error in crash reporters.

## What

- New `onCutoverFailure(error)` hook on the probe. A cutover that fails for a reason other than losing the race is reported through it and the probe returns normally.
- The supervisor wires it to the existing relay recovery log: `direct cutover failed after authentication` with the first 80 chars of the message.

## Tests

- New: with `adoptsOutright` true and `migrate` rejecting, the failure is reported through the hook and `process` sees no `unhandledRejection` (fails on main).
- New: a cutover withdrawn because relay won stays quiet.
- Full mobile `vitest` (4324), `tsc`, `oxlint`, `oxfmt --check` clean.
