### PR TITLE
fix(mobile): re-ask a refused status probe, fresh miss budget per resume probe, persist endpoint before booking a refresh

### DIFF
--- a/mobile/src/transport/mobile-relay-credential-refresh.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-refresh.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MobileRelayCredentialRefresh } from './mobile-relay-credential-refresh'
+import type { MobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+
+vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'when-unlocked' }))
+vi.mock('expo-crypto', () => ({ getRandomBytes: (length: number) => new Uint8Array(length) }))
+
+const rotated = {
+  bundle: { v: 1, hostId: 'host-1' } as unknown as MobileRelayCredentialBundle,
+  relay: { v: 1, directorUrl: 'https://relay.example', cellUrl: 'https://c1.relay.example' }
+}
+const rotate = vi.hoisted(() => vi.fn())
+vi.mock('./mobile-relay-credential-rotation', () => ({
+  mobileRelayCredentialNeedsRotation: () => true,
+  rotateMobileRelayCredential: rotate
+}))
+
+function fixture(overrides: { persistResolvedRelay?: () => Promise<void> } = {}) {
+  rotate.mockReset().mockResolvedValue(rotated)
+  const order: string[] = []
+  const refresh = new MobileRelayCredentialRefresh({
+    logical: { getActivePath: () => 'direct' } as unknown as StableLogicalRpcClient,
+    now: () => 1_000,
+    randomBytes: (length) => new Uint8Array(length),
+    writeBundle: async () => {},
+    bundle: () => ({ v: 1, hostId: 'host-1' }) as unknown as MobileRelayCredentialBundle,
+    adoptBundle: () => order.push('adopt'),
+    persistResolvedRelay:
+      overrides.persistResolvedRelay ??
+      (async () => {
+        order.push('persist')
+      }),
+    isStopped: () => false,
+    completeRefresh: () => order.push('complete'),
+    onRefreshed: () => order.push('refreshed')
+  })
+  return { refresh, order }
+}
+
+describe('MobileRelayCredentialRefresh', () => {
+  it('lifts the gate and starts the relay race only after the endpoint is durable', async () => {
+    const { refresh, order } = fixture()
+    await refresh.run(true)
+    expect(order).toEqual(['adopt', 'persist', 'complete', 'refreshed'])
+  })
+
+  it('keeps the gate closed when the endpoint write fails, so nothing dials the old cell', async () => {
+    // Why: the adopted credential is durable, the endpoint is not. Lifting the gate here would
+    // dial the pre-rotation cell with the post-rotation credential.
+    const { refresh, order } = fixture({
+      persistResolvedRelay: async () => {
+        throw new Error('disk full')
+      }
+    })
+    await expect(refresh.run(true)).resolves.toBeUndefined()
+    expect(order).toEqual(['adopt'])
+  })
+
+  it('runs again after a failed persist instead of staying wedged in flight', async () => {
+    let fail = true
+    const { refresh, order } = fixture({
+      persistResolvedRelay: async () => {
+        if (fail) {
+          throw new Error('disk full')
+        }
+        order.push('persist')
+      }
+    })
+    await refresh.run(true)
+    fail = false
+    await refresh.run(true)
+    expect(order).toEqual(['adopt', 'adopt', 'persist', 'complete', 'refreshed'])
+  })
+})

--- a/mobile/src/transport/mobile-relay-credential-refresh.test.ts
+++ b/mobile/src/transport/mobile-relay-credential-refresh.test.ts
@@ -12,8 +12,9 @@ const rotated = {
   relay: { v: 1, directorUrl: 'https://relay.example', cellUrl: 'https://c1.relay.example' }
 }
 const rotate = vi.hoisted(() => vi.fn())
+const needsRotation = vi.hoisted(() => vi.fn(() => true))
 vi.mock('./mobile-relay-credential-rotation', () => ({
-  mobileRelayCredentialNeedsRotation: () => true,
+  mobileRelayCredentialNeedsRotation: needsRotation,
   rotateMobileRelayCredential: rotate
 }))
 
@@ -40,6 +41,14 @@ function fixture(overrides: { persistResolvedRelay?: () => Promise<void> } = {})
 }
 
 describe('MobileRelayCredentialRefresh', () => {
+  it('does nothing unforced while the credential is still fresh', async () => {
+    needsRotation.mockReturnValueOnce(false)
+    const { refresh, order } = fixture()
+    await refresh.run(false)
+    expect(order).toEqual([])
+    expect(rotate).not.toHaveBeenCalled()
+  })
+
   it('lifts the gate and starts the relay race only after the endpoint is durable', async () => {
     const { refresh, order } = fixture()
     await refresh.run(true)

--- a/mobile/src/transport/mobile-relay-credential-refresh.ts
+++ b/mobile/src/transport/mobile-relay-credential-refresh.ts
@@ -52,9 +52,11 @@ export class MobileRelayCredentialRefresh {
         randomBytes: args.randomBytes
       })
       args.adoptBundle(result.bundle)
-      // Why: a scheduled rotation can finish after the old credential enters the rejection gate.
-      refreshed = true
       await args.persistResolvedRelay(result.relay)
+      // Why after the persist: lifting the gate and dialing on a rotation whose endpoint
+      // write failed would dial the pre-rotation cell. The credential itself is already
+      // durable, so a failed write leaves a retry, not a lost credential.
+      refreshed = true
     } catch {
       // Why: pending material remains durable; the next authenticated direct
       // opportunity must reconcile it before creating another install key.

--- a/mobile/src/transport/relay-dial-stage.ts
+++ b/mobile/src/transport/relay-dial-stage.ts
@@ -96,14 +96,16 @@ export class RelayDialStageTracker implements RelayDialStageSource {
 
 // Budget per stage once the cell holds the dial. awaiting-hello covers the cell's
 // assignment/reservation transactions (observed 14–16s under lock contention) plus its
-// 10s host-attach deadline; handshaking is two E2EE round trips; confirming is bounded
-// by the session's own 30s resume-confirmation request, with slack so that error wins.
+// 10s host-attach deadline; handshaking is two E2EE round trips. confirming is kept for
+// the bound's own completeness: the live session publishes 'connected' in the same turn
+// it enters the stage and bounds the resume confirm itself at 12 s, so this entry is
+// only reachable by a session that times the stage without publishing, never in production.
 const RELAY_DIAL_STAGE_BUDGET_MS: Record<Exclude<RelayDialStage, 'opening'>, number> = {
   'awaiting-hello': 30_000,
   handshaking: 12_000,
   confirming: 35_000
 }
 
-export function relayDialStageBudgetMs(stage: Exclude<RelayDialStage, 'opening'>): number {
+export function relayDialStageBudgetMs(stage: keyof typeof RELAY_DIAL_STAGE_BUDGET_MS): number {
   return RELAY_DIAL_STAGE_BUDGET_MS[stage]
 }

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -276,14 +276,13 @@ describe('RpcSessionLivenessWatchdog', () => {
     })
     watchdog.start(identity)
 
+    // Resumes every 1.5 s on a black-holed socket: each lands inside the 2 s urgent
+    // window, so none may re-arm the deadline or the verdict never comes.
     watchdog.probeNow(identity, 'resume')
-    await vi.advanceTimersByTimeAsync(2_000)
-    expect(terminate).not.toHaveBeenCalled()
-    // The second resume restarts the 2 s clock on the miss already booked.
-    watchdog.probeNow(identity, 'resume')
-    await vi.advanceTimersByTimeAsync(1_000)
-    watchdog.probeNow(identity, 'resume')
-    await vi.advanceTimersByTimeAsync(2_000)
+    for (let elapsed = 0; elapsed < 6_000; elapsed += 1_500) {
+      await vi.advanceTimersByTimeAsync(1_500)
+      watchdog.probeNow(identity, 'resume')
+    }
     expect(terminate).toHaveBeenCalledOnce()
   })
 

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -277,13 +277,41 @@ describe('RpcSessionLivenessWatchdog', () => {
     watchdog.start(identity)
 
     // Resumes every 1.5 s on a black-holed socket: each lands inside the 2 s urgent
-    // window, so none may re-arm the deadline or the verdict never comes.
+    // window. A miss buys at most one re-arm, so the verdict lands by 2 s (miss 1)
+    // + 1.5 s (re-arm at 3.5 s) + 2 s = 5.5 s, not never.
     watchdog.probeNow(identity, 'resume')
-    for (let elapsed = 0; elapsed < 6_000; elapsed += 1_500) {
+    for (let elapsed = 0; elapsed < 9_000; elapsed += 1_500) {
       await vi.advanceTimersByTimeAsync(1_500)
       watchdog.probeNow(identity, 'resume')
     }
     expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('gives a resume that follows a tolerated miss a fresh window, not the last 100 ms', async () => {
+    // Why: resume at t=0, miss at 2 s, second probe sent; the app flaps and resumes at 3.9 s
+    // with the radio recovering and traffic at 4.1 s. That is a live socket main tolerates.
+    const terminate = vi.fn()
+    const identity = {}
+    const watchdog = new RpcSessionLivenessWatchdog({
+      transport: 'relay',
+      idleProbeMs: 20_000,
+      probeTimeoutMs: 4_000,
+      missedProbeLimit: 2,
+      urgentProbeTimeoutMs: 2_000,
+      urgentMissedProbeLimit: 2,
+      shouldIdleProbe: () => true,
+      sendProbe: () => true,
+      terminate,
+      now: Date.now
+    })
+    watchdog.start(identity)
+    watchdog.probeNow(identity, 'resume')
+    await vi.advanceTimersByTimeAsync(3_900)
+    watchdog.probeNow(identity, 'resume')
+    await vi.advanceTimersByTimeAsync(200)
+    watchdog.noteAuthenticatedInbound(identity)
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(terminate).not.toHaveBeenCalled()
   })
 
   it('does not let a resume that follows the ordinary profile inherit its miss', async () => {

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -256,6 +256,36 @@ describe('RpcSessionLivenessWatchdog', () => {
     expect(terminate).toHaveBeenCalledOnce()
   })
 
+  it('gives a second resume probe a fresh miss budget too', async () => {
+    // Why: two app-resume nudges ~2 s apart on a cold radio are one observation each, not a
+    // shared budget; otherwise the second inherits the first's miss and one more slow answer
+    // kills a healthy socket.
+    const terminate = vi.fn()
+    const identity = {}
+    const watchdog = new RpcSessionLivenessWatchdog({
+      transport: 'relay',
+      idleProbeMs: 20_000,
+      probeTimeoutMs: 4_000,
+      missedProbeLimit: 2,
+      urgentProbeTimeoutMs: 2_000,
+      urgentMissedProbeLimit: 2,
+      shouldIdleProbe: () => true,
+      sendProbe: () => true,
+      terminate,
+      now: Date.now
+    })
+    watchdog.start(identity)
+
+    watchdog.probeNow(identity, 'resume')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(terminate).not.toHaveBeenCalled()
+    watchdog.probeNow(identity, 'resume')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(terminate).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
   it('still reaches a verdict on a caller probe when the app backgrounds', async () => {
     // The gate covers the idle sweep only. A nudge or resume probe was asked for on
     // purpose, and abandoning it would leave a genuinely dead socket unreported.

--- a/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.test.ts
@@ -256,10 +256,10 @@ describe('RpcSessionLivenessWatchdog', () => {
     expect(terminate).toHaveBeenCalledOnce()
   })
 
-  it('gives a second resume probe a fresh miss budget too', async () => {
-    // Why: two app-resume nudges ~2 s apart on a cold radio are one observation each, not a
-    // shared budget; otherwise the second inherits the first's miss and one more slow answer
-    // kills a healthy socket.
+  it('still reaches a verdict under repeated resumes on a dead socket', async () => {
+    // Why: a resume replaces the urgent probe in flight but keeps its miss; a burst of
+    // resumes (AppState flaps, a user tapping reconnect) must not zero the budget each time,
+    // or a dead relay socket is never terminated while the user keeps trying.
     const terminate = vi.fn()
     const identity = {}
     const watchdog = new RpcSessionLivenessWatchdog({
@@ -279,6 +279,32 @@ describe('RpcSessionLivenessWatchdog', () => {
     watchdog.probeNow(identity, 'resume')
     await vi.advanceTimersByTimeAsync(2_000)
     expect(terminate).not.toHaveBeenCalled()
+    // The second resume restarts the 2 s clock on the miss already booked.
+    watchdog.probeNow(identity, 'resume')
+    await vi.advanceTimersByTimeAsync(1_000)
+    watchdog.probeNow(identity, 'resume')
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(terminate).toHaveBeenCalledOnce()
+  })
+
+  it('does not let a resume that follows the ordinary profile inherit its miss', async () => {
+    // The profile switch, not the resume itself, is what grants the clean budget.
+    const terminate = vi.fn()
+    const identity = {}
+    const watchdog = new RpcSessionLivenessWatchdog({
+      transport: 'relay',
+      idleProbeMs: 20_000,
+      probeTimeoutMs: 4_000,
+      missedProbeLimit: 2,
+      urgentProbeTimeoutMs: 2_000,
+      urgentMissedProbeLimit: 2,
+      shouldIdleProbe: () => true,
+      sendProbe: () => true,
+      terminate,
+      now: Date.now
+    })
+    watchdog.start(identity)
+    await vi.advanceTimersByTimeAsync(24_000)
     watchdog.probeNow(identity, 'resume')
     await vi.advanceTimersByTimeAsync(2_000)
     expect(terminate).not.toHaveBeenCalled()

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -41,6 +41,8 @@ export class RpcSessionLivenessWatchdog {
   // Whether the probe in flight came from the idle sweep rather than a caller.
   private idleSweepProbe = false
   private missedProbes = 0
+  // Miss count at which a resume last re-armed the urgent deadline; one re-arm per miss.
+  private rearmedAtMiss = 0
   private lastInboundAt = 0
   private lastVoluntaryProbeAt: number | null = null
   private profile: ProbeProfile
@@ -103,6 +105,7 @@ export class RpcSessionLivenessWatchdog {
       return
     }
     this.missedProbes = 0
+    this.rearmedAtMiss = 0
     this.probing = false
     this.idleSweepProbe = false
     this.armIdle(identity)
@@ -127,11 +130,17 @@ export class RpcSessionLivenessWatchdog {
     this.lastVoluntaryProbeAt = now
     // Why: a resume is a new observation on a cold radio, so it starts the urgent window
     // with a clean budget (startProbe zeroes the count on a profile switch). A resume that
-    // lands while an urgent probe is already in flight keeps that probe's deadline and
-    // count: re-arming the 2 s clock on every tap would let a user tapping reconnect, or
-    // an AppState flap, hold a dead socket open for as long as they keep tapping.
+    // lands while an urgent probe is in flight keeps its count, and keeps its deadline too
+    // unless a miss has been booked since the probe was sent: re-arming the 2 s clock on
+    // every tap would let a user tapping reconnect hold a dead socket open indefinitely,
+    // while a resume after a tolerated miss is a genuinely new observation that must not
+    // inherit the last 100 ms of the previous one. Each booked miss buys one re-arm, so the
+    // verdict is bounded at (limit × timeout) plus one window per miss.
     if (urgent && this.probing && this.profile === this.urgentProfile) {
-      return
+      if (this.missedProbes === this.rearmedAtMiss) {
+        return
+      }
+      this.rearmedAtMiss = this.missedProbes
     }
     this.startProbe(identity, urgent ? this.urgentProfile : this.ordinaryProfile)
   }
@@ -187,6 +196,7 @@ export class RpcSessionLivenessWatchdog {
     // exists to give a cold radio, so the first 2s miss would kill a healthy socket.
     if (profile !== this.profile) {
       this.missedProbes = 0
+      this.rearmedAtMiss = 0
     }
     this.profile = profile
     this.probing = true

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -125,12 +125,11 @@ export class RpcSessionLivenessWatchdog {
       return
     }
     this.lastVoluntaryProbeAt = now
-    // Why: a second resume inside the urgent window (iOS active/inactive/active on a
-    // control-centre swipe) is a new observation on the same cold radio; inheriting the
-    // first resume probe's miss would spend the tolerated slow answer before it is sent.
-    if (urgent) {
-      this.missedProbes = 0
-    }
+    // Why: a resume is a new observation on a cold radio, so it starts the urgent window
+    // with a clean budget (startProbe zeroes the count on a profile switch). A resume that
+    // lands while an urgent probe is already in flight restarts the clock but keeps the
+    // count: otherwise repeated resumes, or a user tapping reconnect on a dead socket,
+    // zero the budget on every tap and the verdict never lands.
     this.startProbe(identity, urgent ? this.urgentProfile : this.ordinaryProfile)
   }
 

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -125,6 +125,12 @@ export class RpcSessionLivenessWatchdog {
       return
     }
     this.lastVoluntaryProbeAt = now
+    // Why: a second resume inside the urgent window (iOS active/inactive/active on a
+    // control-centre swipe) is a new observation on the same cold radio; inheriting the
+    // first resume probe's miss would spend the tolerated slow answer before it is sent.
+    if (urgent) {
+      this.missedProbes = 0
+    }
     this.startProbe(identity, urgent ? this.urgentProfile : this.ordinaryProfile)
   }
 

--- a/mobile/src/transport/rpc-session-liveness-watchdog.ts
+++ b/mobile/src/transport/rpc-session-liveness-watchdog.ts
@@ -127,9 +127,12 @@ export class RpcSessionLivenessWatchdog {
     this.lastVoluntaryProbeAt = now
     // Why: a resume is a new observation on a cold radio, so it starts the urgent window
     // with a clean budget (startProbe zeroes the count on a profile switch). A resume that
-    // lands while an urgent probe is already in flight restarts the clock but keeps the
-    // count: otherwise repeated resumes, or a user tapping reconnect on a dead socket,
-    // zero the budget on every tap and the verdict never lands.
+    // lands while an urgent probe is already in flight keeps that probe's deadline and
+    // count: re-arming the 2 s clock on every tap would let a user tapping reconnect, or
+    // an AppState flap, hold a dead socket open for as long as they keep tapping.
+    if (urgent && this.probing && this.profile === this.urgentProfile) {
+      return
+    }
     this.startProbe(identity, urgent ? this.urgentProfile : this.ordinaryProfile)
   }
 

--- a/mobile/src/transport/runtime-status-probe.test.ts
+++ b/mobile/src/transport/runtime-status-probe.test.ts
@@ -129,10 +129,11 @@ describe('startRuntimeCapabilityProbe', () => {
     cancel()
   })
 
-  // Was: an ok:false response was retried like a timeout. The probe now backs the gate that sits
-  // above every /h/ route, so polling a host that already answered would run for the life of the
-  // connection. A reply is an answer; only an unanswered request is retried.
-  it('settles once on an ok:false response rather than polling the host', async () => {
+  // Why the ceiling and not a stop: the probe backs the gate above every /h/ route, and
+  // worktree.activate plus every capability wait on its verdict. One error reply, from a
+  // transient host failure or an error frame the relay surfaced, must not withhold those
+  // for the life of the connection; but a host that keeps saying no is not polled fast.
+  it('re-asks an ok:false response at the slow ceiling instead of stopping for good', async () => {
     const failure: RpcResponse = {
       ok: false,
       id: '1',
@@ -147,12 +148,15 @@ describe('startRuntimeCapabilityProbe', () => {
       onUnavailable: (isRetrying) => retrying.push(isRetrying)
     })
     await flushMicrotasks()
-    expect(retrying).toEqual([false])
+    expect(retrying).toEqual([true])
     expect(seen).toEqual([])
 
-    await vi.advanceTimersByTimeAsync(60_000)
+    await vi.advanceTimersByTimeAsync(14_999)
     expect(calls()).toBe(1)
-    expect(seen).toEqual([])
+    await vi.advanceTimersByTimeAsync(1)
+    await flushMicrotasks()
+    expect(calls()).toBe(2)
+    expect(seen).toEqual([['a.v1']])
     cancel()
   })
 

--- a/mobile/src/transport/runtime-status-probe.ts
+++ b/mobile/src/transport/runtime-status-probe.ts
@@ -11,11 +11,10 @@ const FAILURE_RETRY_MAX_DELAY_MS = 15_000
 
 export type RuntimeStatusProbeHandlers = {
   onStatus: (status: Record<string, unknown>) => void
-  // Fires once per attempt that produced no status. `retrying` is false when the host itself
-  // answered with an error: that is a definitive reply, so the probe stops rather than polling a
-  // host that has already said no. It is true when nothing reached us and a retry is armed, which
-  // lets a caller that must not stay blocked fail open on the first miss and be upgraded later.
-  onUnavailable?: (retrying: boolean) => void
+  // Fires once per attempt that produced no status, with a retry always armed: an unanswered
+  // request backs off from 1 s, an answered error re-asks at the 15 s ceiling. Either way a
+  // caller that must not stay blocked can fail open on the first miss and be upgraded later.
+  onUnavailable?: (retrying: true) => void
 }
 
 // Single status.get producer for a connected client: one request, retried until it
@@ -35,9 +34,11 @@ export function startRuntimeStatusProbe(
           return
         }
         if (!response.ok) {
-          // Why not retry: the desktop replied. Re-asking every 15 s for the life of a connection
-          // from a probe mounted above every /h/ route buys nothing a reconnect would not.
-          handlers.onUnavailable?.(false)
+          // Why retry: an error reply is a definitive answer for this attempt, not for the
+          // connection. A transient host failure or an error frame surfaced by the relay must
+          // not withhold worktree.activate and every capability until the socket is replaced.
+          // Backed off to the 15 s ceiling so a host that keeps saying no is not hammered.
+          scheduleRetry(false, true)
           return
         }
         const result = (response as RpcSuccess).result
@@ -54,12 +55,16 @@ export function startRuntimeStatusProbe(
     )
   }
 
-  function scheduleRetry(cutover: boolean): void {
+  function scheduleRetry(cutover: boolean, answered = false): void {
     // Why: cutover means the replacement transport is already authenticated —
     // re-ask promptly; other failures back off so a wedged host isn't hammered.
+    // An answered error skips straight to the ceiling: the host is reachable and
+    // said no, so only a slow re-ask is worth anything.
     const delay = cutover
       ? CUTOVER_RETRY_DELAY_MS
-      : Math.min(FAILURE_RETRY_BASE_DELAY_MS * 2 ** failureRetries++, FAILURE_RETRY_MAX_DELAY_MS)
+      : answered
+        ? FAILURE_RETRY_MAX_DELAY_MS
+        : Math.min(FAILURE_RETRY_BASE_DELAY_MS * 2 ** failureRetries++, FAILURE_RETRY_MAX_DELAY_MS)
     retryTimer = setTimeout(attempt, delay)
     handlers.onUnavailable?.(true)
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​179 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

Follow-ups to #19260, #19280, and #19308 from the post-merge adversarial review. Four findings, each reproduced against main; the two behavioural ones have failing-first tests.

## Why

- **MEDIUM (#19260): one `status.get` error reply withheld `worktree.activate` and every capability for the life of the connection.** The status probe stopped outright on `ok:false`, the gate then failed open with `compatVerified: false`, and nothing ever upgraded it. Before #19260 activation fired unconditionally and the old capability probe retried an error reply with backoff. After it, an internal host failure, an older host that does not know the method, or an error frame the relay surfaced meant a headless host never hydrated its tabs and screencast, quick commands, agent history, and query-reply input stayed off until the socket was replaced.
- **LOW (#19280): two app-resume probes in the urgent window shared one miss budget.** The reset keyed on the profile object changing, so urgent-to-urgent inherited the first probe's miss and one further 2 s timeout killed a live session. iOS active/inactive/active on a control-centre swipe delivers exactly that pair.
- **MEDIUM (pre-existing, trigger widened by #19308): credential refresh booked success before the relay endpoint was persisted.** A failed `saveHost` still lifted the fresh-credential gate and fired `onRefreshed`, which now dials relay in any non-connected state against the pre-rotation cell. The credential itself was already durable, so the blast radius was one dial against a stale cell.
- **LOW (#19245 + #19280): the `confirming` stage budget comment was wrong.** It described a 30 s bound; the session bounds the confirm at 12 s and publishes `connected` in the same turn it enters the stage. Comment corrected; the entry stays so the bound's stage table remains total.

## What

- `runtime-status-probe.ts`: an `ok:false` reply re-asks at the 15 s ceiling instead of stopping. Unanswered requests still back off from 1 s; cutover still re-asks at 250 ms. `onUnavailable` always reports a retry armed.
- `rpc-session-liveness-watchdog.ts`: `probeNow(…, 'resume')` resets the miss count before starting the urgent probe.
- `mobile-relay-credential-refresh.ts`: `refreshed = true` moves below `await persistResolvedRelay(...)`.
- `relay-dial-stage.ts`: comment only.

## Tests

- Status probe: an error reply is re-asked at 15 s and the next `ok` lands (fails on main, which asserted the probe stopped).
- Watchdog: two resume probes each tolerate one miss; termination needs the second miss of the second probe (fails on main).
- Full mobile `vitest` (4323), `tsc`, `oxlint`, `oxfmt --check` clean.
