### PR TITLE
fix(tools): vet the director the bench posts the resume token to, and keep the state file out of /tmp

### DIFF
--- a/tests/tools/relay-bench/README.md
+++ b/tests/tools/relay-bench/README.md
@@ -100,21 +100,21 @@ BENCH=tests/tools/relay-bench/relay-phone-connect-bench.mjs
 
 # One-time: dial the invite, provision a resume credential, save the bundle. The pairing link
 # comes in on stdin so it stays out of your shell history and out of `ps`.
-pbpaste | node $BENCH pair /tmp/relay-bench/state.json
+pbpaste | node $BENCH pair ~/.orca/relay-bench/state.json
 
 # Or from a file you protect yourself, which `pair` requires to be mode 0600:
-umask 077 && printf '%s' '<orca://pair?code=...>' > /tmp/relay-bench/pair.txt
-node $BENCH pair /tmp/relay-bench/state.json --pairing-url-file=/tmp/relay-bench/pair.txt
-rm /tmp/relay-bench/pair.txt
+umask 077 && printf '%s' '<orca://pair?code=...>' > ~/.orca/relay-bench/pair.txt
+node $BENCH pair ~/.orca/relay-bench/state.json --pairing-url-file=~/.orca/relay-bench/pair.txt
+rm ~/.orca/relay-bench/pair.txt
 
 # Steady-state foreground reconnect, 10 times, 2 s apart, re-resolving the cell each time.
-node $BENCH run /tmp/relay-bench/state.json 10 --resolve --gap=2000
+node $BENCH run ~/.orca/relay-bench/state.json 10 --resolve --gap=2000
 
 # Resume after background: connect, idle 45 s, then probe the retained socket.
-node $BENCH foreground /tmp/relay-bench/state.json --hold=45000
+node $BENCH foreground ~/.orca/relay-bench/state.json --hold=45000
 
 # Same, but crossing the relay's ~105 s client silence watchdog.
-node $BENCH foreground /tmp/relay-bench/state.json --hold=120000
+node $BENCH foreground ~/.orca/relay-bench/state.json --hold=120000
 ```
 
 On Linux or Windows, replace `pbpaste` with whatever prints the link to stdout, or use

--- a/tests/tools/relay-bench/README.md
+++ b/tests/tools/relay-bench/README.md
@@ -75,7 +75,7 @@ ORCA_BACKGROUND_LAUNCH=1 \
 REMOTE_DEBUGGING_PORT=9222 \
 ORCA_CLOUD_API_URL=https://login.onorca.dev \
 ORCA_CLOUD_CLIENT_ID=orca-desktop \
-ORCA_DEV_USER_DATA_PATH=/tmp/orca-relay-bench-profile \
+ORCA_DEV_USER_DATA_PATH="$HOME/.orca/relay-bench/profile" \
 ORCA_RELAY_REGION_OVERRIDE=us-central1 \
 pnpm run dev
 ```

--- a/tests/tools/relay-bench/README.md
+++ b/tests/tools/relay-bench/README.md
@@ -104,7 +104,7 @@ pbpaste | node $BENCH pair ~/.orca/relay-bench/state.json
 
 # Or from a file you protect yourself, which `pair` requires to be mode 0600:
 umask 077 && printf '%s' '<orca://pair?code=...>' > ~/.orca/relay-bench/pair.txt
-node $BENCH pair ~/.orca/relay-bench/state.json --pairing-url-file=~/.orca/relay-bench/pair.txt
+node $BENCH pair ~/.orca/relay-bench/state.json --pairing-url-file="$HOME/.orca/relay-bench/pair.txt"
 rm ~/.orca/relay-bench/pair.txt
 
 # Steady-state foreground reconnect, 10 times, 2 s apart, re-resolving the cell each time.

--- a/tests/tools/relay-bench/region-probe-replay.mjs
+++ b/tests/tools/relay-bench/region-probe-replay.mjs
@@ -2,8 +2,9 @@
 // sample count, spread rule, and Node fetch, and prints why each region passed or failed.
 import { pathToFileURL } from 'node:url'
 import {
-  classifyPublicHttpsOrigin,
   LIVE_ENV_VAR,
+  classifyPublicHttpsOrigin,
+  describeUntrustedText,
   parseArgs,
   requireBoundedInteger,
   requireDirector,
@@ -112,7 +113,7 @@ async function main() {
     console.error(
       timedOut
         ? `director ${director}/v1/regions did not answer within ${CATALOG_TIMEOUT_MS} ms`
-        : `director ${director}/v1/regions failed: ${err.message}`
+        : `director ${director}/v1/regions failed: ${describeUntrustedText(err.code ?? err.message)}`
     )
     process.exitCode = 1
     return

--- a/tests/tools/relay-bench/relay-bench-invocation.mjs
+++ b/tests/tools/relay-bench/relay-bench-invocation.mjs
@@ -83,6 +83,24 @@ export function requirePort(value, label, usage) {
   return parsed
 }
 
+// ---------- untrusted text ----------
+// Anything a peer, the desktop, or a stored file chose and that lands in the operator's terminal
+// goes through here: printable ASCII only, bounded, everything else named by count. Bidi and
+// C1 controls are outside the allow-list, so a hostile reason cannot repaint the screen.
+const UNTRUSTED_TEXT = /^[\x20-\x7e]{1,120}$/
+export function describeUntrustedText(value) {
+  if (typeof value !== 'string') {
+    return value === undefined ? 'unknown' : `non-string (${typeof value})`
+  }
+  if (!value) {
+    return 'empty'
+  }
+  if (UNTRUSTED_TEXT.test(value)) {
+    return value
+  }
+  return `unprintable (${value.length} chars)`
+}
+
 // ---------- destinations ----------
 const BLOCKED_IPV4_RANGES = [
   ['0.0.0.0', 8],
@@ -183,6 +201,18 @@ function isPublicIpv6(bytes) {
     // Covers :: and ::1 as well as the deprecated v4-compatible form.
     return false
   }
+  // NAT64 (64:ff9b::/96) reaches the embedded v4 address, so judge that address.
+  if (
+    bytes[0] === 0x00 &&
+    bytes[1] === 0x64 &&
+    bytes[2] === 0xff &&
+    bytes[3] === 0x9b &&
+    bytes.slice(4, 12).every((byte) => byte === 0)
+  ) {
+    return isPublicIpv4(
+      ((bytes[12] << 24) >>> 0) + (bytes[13] << 16) + (bytes[14] << 8) + bytes[15]
+    )
+  }
   if ((bytes[0] & 0xfe) === 0xfc || bytes[0] === 0xff) {
     return false
   }
@@ -225,22 +255,22 @@ export function classifyPublicHttpsOrigin(value) {
   try {
     parsed = new URL(value)
   } catch {
-    return { ok: false, reason: `not a URL: ${value}` }
+    return { ok: false, reason: `not a URL: ${describeUntrustedText(value)}` }
   }
   if (parsed.protocol !== 'https:') {
-    return { ok: false, reason: `must be an https origin: ${value}` }
+    return { ok: false, reason: `must be an https origin: ${describeUntrustedText(value)}` }
   }
   if (parsed.username || parsed.password) {
-    return { ok: false, reason: `must not carry credentials: ${value}` }
+    return { ok: false, reason: `must not carry credentials: ${describeUntrustedText(value)}` }
   }
   const host = normalizeHostname(parsed.hostname)
   if (host === 'localhost' || host.endsWith('.localhost')) {
-    return { ok: false, reason: `refusing a loopback destination: ${value}` }
+    return { ok: false, reason: `refusing a loopback destination: ${describeUntrustedText(value)}` }
   }
   if (isPublicIpAddress(host) === false) {
     return {
       ok: false,
-      reason: `refusing a loopback, link-local, or private destination: ${value}`
+      reason: `refusing a loopback, link-local, or private destination: ${describeUntrustedText(value)}`
     }
   }
   return { ok: true, origin: parsed.origin }
@@ -260,14 +290,20 @@ export async function resolvesToPublicAddress(origin, { lookup = dnsLookup } = {
   try {
     addresses = await lookup(host, { all: true })
   } catch (err) {
-    return { ok: false, reason: `cannot resolve ${host}: ${err.message}` }
+    return {
+      ok: false,
+      reason: `cannot resolve ${describeUntrustedText(host)}: ${err.code ?? 'lookup failed'}`
+    }
   }
   if (!addresses.length) {
-    return { ok: false, reason: `cannot resolve ${host}` }
+    return { ok: false, reason: `cannot resolve ${describeUntrustedText(host)}` }
   }
   const blocked = addresses.find((entry) => isPublicIpAddress(entry.address) === false)
   if (blocked) {
-    return { ok: false, reason: `${host} resolves to a private address ${blocked.address}` }
+    return {
+      ok: false,
+      reason: `${describeUntrustedText(host)} resolves to a private address ${describeUntrustedText(blocked.address)}`
+    }
   }
   return { ok: true }
 }

--- a/tests/tools/relay-bench/relay-bench-invocation.mjs
+++ b/tests/tools/relay-bench/relay-bench-invocation.mjs
@@ -190,28 +190,39 @@ function ipv6ToBytes(host) {
   return bytes
 }
 
+function v4At(bytes, offset) {
+  return (
+    ((bytes[offset] << 24) >>> 0) +
+    (bytes[offset + 1] << 16) +
+    (bytes[offset + 2] << 8) +
+    bytes[offset + 3]
+  )
+}
+
 function isPublicIpv6(bytes) {
   const leadingZeros = bytes.slice(0, 10).every((byte) => byte === 0)
   if (leadingZeros && bytes[10] === 0xff && bytes[11] === 0xff) {
-    return isPublicIpv4(
-      ((bytes[12] << 24) >>> 0) + (bytes[13] << 16) + (bytes[14] << 8) + bytes[15]
-    )
+    return isPublicIpv4(v4At(bytes, 12))
   }
   if (leadingZeros && bytes[10] === 0 && bytes[11] === 0) {
     // Covers :: and ::1 as well as the deprecated v4-compatible form.
     return false
   }
-  // NAT64 (64:ff9b::/96) reaches the embedded v4 address, so judge that address.
+  // Transition prefixes that reach an embedded v4 address: judge that address.
+  // NAT64 64:ff9b::/96 and 64:ff9b:1::/48 (v4 in the last 32 bits), 6to4 2002::/16
+  // (v4 in bits 16-47). Teredo 2001:0::/32 embeds the client v4 inverted, so it is refused.
+  const nat64 = bytes[0] === 0x00 && bytes[1] === 0x64 && bytes[2] === 0xff && bytes[3] === 0x9b
   if (
-    bytes[0] === 0x00 &&
-    bytes[1] === 0x64 &&
-    bytes[2] === 0xff &&
-    bytes[3] === 0x9b &&
-    bytes.slice(4, 12).every((byte) => byte === 0)
+    nat64 &&
+    (bytes.slice(4, 12).every((byte) => byte === 0) || (bytes[4] === 0 && bytes[5] === 1))
   ) {
-    return isPublicIpv4(
-      ((bytes[12] << 24) >>> 0) + (bytes[13] << 16) + (bytes[14] << 8) + bytes[15]
-    )
+    return isPublicIpv4(v4At(bytes, 12))
+  }
+  if (bytes[0] === 0x20 && bytes[1] === 0x02) {
+    return isPublicIpv4(v4At(bytes, 2))
+  }
+  if (bytes[0] === 0x20 && bytes[1] === 0x01 && bytes[2] === 0 && bytes[3] === 0) {
+    return false
   }
   if ((bytes[0] & 0xfe) === 0xfc || bytes[0] === 0xff) {
     return false

--- a/tests/tools/relay-bench/relay-bench-invocation.mjs
+++ b/tests/tools/relay-bench/relay-bench-invocation.mjs
@@ -209,14 +209,16 @@ function isPublicIpv6(bytes) {
     return false
   }
   // Transition prefixes that reach an embedded v4 address: judge that address.
-  // NAT64 64:ff9b::/96 and 64:ff9b:1::/48 (v4 in the last 32 bits), 6to4 2002::/16
-  // (v4 in bits 16-47). Teredo 2001:0::/32 embeds the client v4 inverted, so it is refused.
+  // NAT64 64:ff9b::/96 puts the v4 in the last 32 bits; 6to4 2002::/16 in bits 16-47.
+  // 64:ff9b:1::/48 (NAT64 local) embeds it at a position set by the deployment's prefix
+  // length, which this harness cannot know, so it is refused. Teredo 2001:0::/32 embeds the
+  // client v4 inverted, so it is refused too.
   const nat64 = bytes[0] === 0x00 && bytes[1] === 0x64 && bytes[2] === 0xff && bytes[3] === 0x9b
-  if (
-    nat64 &&
-    (bytes.slice(4, 12).every((byte) => byte === 0) || (bytes[4] === 0 && bytes[5] === 1))
-  ) {
+  if (nat64 && bytes.slice(4, 12).every((byte) => byte === 0)) {
     return isPublicIpv4(v4At(bytes, 12))
+  }
+  if (nat64 && bytes[4] === 0 && bytes[5] === 1) {
+    return false
   }
   if (bytes[0] === 0x20 && bytes[1] === 0x02) {
     return isPublicIpv4(v4At(bytes, 2))

--- a/tests/tools/relay-bench/relay-bench-invocation.test.mjs
+++ b/tests/tools/relay-bench/relay-bench-invocation.test.mjs
@@ -168,6 +168,10 @@ describe('classifyPublicHttpsOrigin', () => {
     ['not a url', 'not a URL'],
     ['https://[64:ff9b::7f00:1]/', 'loopback, link-local, or private'],
     ['https://[64:ff9b::a9fe:a9fe]/', 'loopback, link-local, or private'],
+    ['https://[64:ff9b:1::7f00:1]/', 'loopback, link-local, or private'],
+    ['https://[2002:7f00:1::]/', 'loopback, link-local, or private'],
+    ['https://[2002:c0a8:101::1]/', 'loopback, link-local, or private'],
+    ['https://[2001:0:4136:e378:8000:63bf:3fff:fdd2]/', 'loopback, link-local, or private'],
     ['', 'missing origin']
   ])('refuses %s', (value, reason) => {
     const verdict = classifyPublicHttpsOrigin(value)
@@ -175,8 +179,11 @@ describe('classifyPublicHttpsOrigin', () => {
     expect(verdict.reason).toContain(reason)
   })
 
-  it('accepts a NAT64 address that embeds a public v4 address', () => {
+  it('accepts transition addresses that embed a public v4 address', () => {
     expect(classifyPublicHttpsOrigin('https://[64:ff9b::808:808]/').ok).toBe(true)
+    expect(classifyPublicHttpsOrigin('https://[2002:808:808::]/').ok).toBe(true)
+    // A 2001: address outside the Teredo /32 is ordinary global unicast.
+    expect(classifyPublicHttpsOrigin('https://[2001:db8::1]/').ok).toBe(true)
   })
 
   it('never echoes control bytes from a refused value, since the desktop chose it', () => {

--- a/tests/tools/relay-bench/relay-bench-invocation.test.mjs
+++ b/tests/tools/relay-bench/relay-bench-invocation.test.mjs
@@ -169,6 +169,8 @@ describe('classifyPublicHttpsOrigin', () => {
     ['https://[64:ff9b::7f00:1]/', 'loopback, link-local, or private'],
     ['https://[64:ff9b::a9fe:a9fe]/', 'loopback, link-local, or private'],
     ['https://[64:ff9b:1::7f00:1]/', 'loopback, link-local, or private'],
+    ['https://[64:ff9b:1:808:8:800::]/', 'loopback, link-local, or private'],
+    ['https://[64:ff9b:1:a00:0:100:808:808]/', 'loopback, link-local, or private'],
     ['https://[2002:7f00:1::]/', 'loopback, link-local, or private'],
     ['https://[2002:c0a8:101::1]/', 'loopback, link-local, or private'],
     ['https://[2001:0:4136:e378:8000:63bf:3fff:fdd2]/', 'loopback, link-local, or private'],

--- a/tests/tools/relay-bench/relay-bench-invocation.test.mjs
+++ b/tests/tools/relay-bench/relay-bench-invocation.test.mjs
@@ -4,6 +4,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   classifyPublicHttpsOrigin,
+  describeUntrustedText,
   isPublicIpAddress,
   parseArgs,
   parseBoundedInteger,
@@ -165,15 +166,59 @@ describe('classifyPublicHttpsOrigin', () => {
     ['https://169.254.169.254/latest/meta-data', 'loopback, link-local, or private'],
     ['https://10.1.2.3', 'loopback, link-local, or private'],
     ['not a url', 'not a URL'],
+    ['https://[64:ff9b::7f00:1]/', 'loopback, link-local, or private'],
+    ['https://[64:ff9b::a9fe:a9fe]/', 'loopback, link-local, or private'],
     ['', 'missing origin']
   ])('refuses %s', (value, reason) => {
     const verdict = classifyPublicHttpsOrigin(value)
     expect(verdict.ok).toBe(false)
     expect(verdict.reason).toContain(reason)
   })
+
+  it('accepts a NAT64 address that embeds a public v4 address', () => {
+    expect(classifyPublicHttpsOrigin('https://[64:ff9b::808:808]/').ok).toBe(true)
+  })
+
+  it('never echoes control bytes from a refused value, since the desktop chose it', () => {
+    const verdict = classifyPublicHttpsOrigin('\u001b[2Jnot a url\u0007')
+    expect(verdict.ok).toBe(false)
+    expect(verdict.reason).not.toContain('\u001b')
+    expect(verdict.reason).toContain('unprintable')
+  })
+})
+
+describe('describeUntrustedText', () => {
+  it('passes short printable ASCII through', () => {
+    expect(describeUntrustedText('credential_expired')).toBe('credential_expired')
+  })
+
+  it.each([
+    ['\u001b]0;pwned\u0007', 'ESC'],
+    ['\u202eevil', 'bidi override'],
+    ['\u0085next line', 'C1 control'],
+    ['x'.repeat(121), 'over length']
+  ])('names rather than prints %s (%s)', (value) => {
+    const out = describeUntrustedText(value)
+    expect(out).toMatch(/^unprintable \(\d+ chars\)$/)
+  })
+
+  it('names the type of a non-string', () => {
+    expect(describeUntrustedText({ toString: () => '\u001b[31m' })).toBe('non-string (object)')
+    expect(describeUntrustedText(undefined)).toBe('unknown')
+    expect(describeUntrustedText('')).toBe('empty')
+  })
 })
 
 describe('resolvesToPublicAddress', () => {
+  it('reports a lookup failure by code, never by its message', async () => {
+    const lookup = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('\u001b[2Jbad'), { code: 'ENOTFOUND' }))
+    const verdict = await resolvesToPublicAddress('https://relay.example', { lookup })
+    expect(verdict.ok).toBe(false)
+    expect(verdict.reason).toBe('cannot resolve relay.example: ENOTFOUND')
+  })
+
   it('skips the lookup for a literal address', async () => {
     const lookup = vi.fn()
     await expect(resolvesToPublicAddress('https://8.8.8.8', { lookup })).resolves.toEqual({

--- a/tests/tools/relay-bench/relay-bench-state-file.mjs
+++ b/tests/tools/relay-bench/relay-bench-state-file.mjs
@@ -8,6 +8,7 @@ import {
   fchmodSync,
   constants,
   fstatSync,
+  ftruncateSync,
   lstatSync,
   mkdirSync,
   openSync,
@@ -43,7 +44,9 @@ export function writeSecretFile(path, contents) {
   try {
     fd = openSync(
       path,
-      constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | NOFOLLOW,
+      // No O_TRUNC: truncating happens only after the descriptor passes the checks below, so a
+      // refused file keeps its previous contents.
+      constants.O_WRONLY | constants.O_CREAT | NOFOLLOW,
       SECRET_FILE_MODE
     )
   } catch (err) {
@@ -57,14 +60,15 @@ export function writeSecretFile(path, contents) {
     if (!stats.isFile()) {
       throw new Error(`refusing to write ${path}: not a regular file`)
     }
-    // Before the write, not after: a pre-existing file owned by someone else would take the
-    // token on O_TRUNC and only then fail the chmod, leaving it readable by its owner.
+    // Before the truncate and write, not after: a pre-existing file owned by someone else would
+    // otherwise lose its contents and then fail the chmod, leaving the token readable by its owner.
     if (process.platform !== 'win32' && stats.uid !== process.getuid()) {
       throw new Error(`refusing to write ${path}: owned by another user`)
     }
     if (process.platform !== 'win32' && (stats.mode & GROUP_AND_OTHER_BITS) !== 0) {
       fchmodSync(fd, SECRET_FILE_MODE)
     }
+    ftruncateSync(fd, 0)
     writeFileSync(fd, contents)
   } finally {
     closeSync(fd)

--- a/tests/tools/relay-bench/relay-bench-state-file.mjs
+++ b/tests/tools/relay-bench/relay-bench-state-file.mjs
@@ -4,8 +4,8 @@
 // lives under a directory the operator may not have created yet, so the write would throw ENOENT
 // *after* the desktop already provisioned the credential, losing it.
 import {
-  chmodSync,
   closeSync,
+  fchmodSync,
   constants,
   fstatSync,
   lstatSync,
@@ -36,7 +36,8 @@ function refuseSymlink(path) {
 }
 
 export function writeSecretFile(path, contents) {
-  mkdirSync(dirname(path), { recursive: true })
+  // 0700 so a directory this call creates under a shared parent is not traversable by others.
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
   refuseSymlink(path)
   let fd
   try {
@@ -52,15 +53,22 @@ export function writeSecretFile(path, contents) {
     throw err
   }
   try {
-    if (!fstatSync(fd).isFile()) {
+    const stats = fstatSync(fd)
+    if (!stats.isFile()) {
       throw new Error(`refusing to write ${path}: not a regular file`)
+    }
+    // Before the write, not after: a pre-existing file owned by someone else would take the
+    // token on O_TRUNC and only then fail the chmod, leaving it readable by its owner.
+    if (process.platform !== 'win32' && stats.uid !== process.getuid()) {
+      throw new Error(`refusing to write ${path}: owned by another user`)
+    }
+    if (process.platform !== 'win32' && (stats.mode & GROUP_AND_OTHER_BITS) !== 0) {
+      fchmodSync(fd, SECRET_FILE_MODE)
     }
     writeFileSync(fd, contents)
   } finally {
     closeSync(fd)
   }
-  // Fail closed rather than silently leaving a pre-existing 0644 file readable.
-  chmodSync(path, SECRET_FILE_MODE)
 }
 
 export function readSecretFile(path) {

--- a/tests/tools/relay-bench/relay-bench-state-file.test.mjs
+++ b/tests/tools/relay-bench/relay-bench-state-file.test.mjs
@@ -67,6 +67,20 @@ describe('writeSecretFile', () => {
     expect(modeOf(join(dir, 'nested'))).toBe(0o700)
   })
 
+  it.runIf(posix)('leaves a refused file untouched instead of truncating it first', () => {
+    // A writable file owned by someone else must be refused before its contents are destroyed.
+    const path = join(dir, 'state.json')
+    writeFileSync(path, 'previous contents')
+    const realGetuid = process.getuid
+    process.getuid = () => realGetuid() + 1
+    try {
+      expect(() => writeSecretFile(path, 'secret')).toThrow(/owned by another user/)
+    } finally {
+      process.getuid = realGetuid
+    }
+    expect(readFileSync(path, 'utf8')).toBe('previous contents')
+  })
+
   it('truncates rather than appending to a longer previous file', () => {
     const path = join(dir, 'state.json')
     writeSecretFile(path, '{"a":"aaaaaaaaaaaaaaaaaaaa"}')

--- a/tests/tools/relay-bench/relay-bench-state-file.test.mjs
+++ b/tests/tools/relay-bench/relay-bench-state-file.test.mjs
@@ -61,6 +61,12 @@ describe('writeSecretFile', () => {
     expect(readFileSync(target, 'utf8')).toBe('target contents')
   })
 
+  it.runIf(posix)('creates the parent directory closed to other users', () => {
+    const path = join(dir, 'nested', 'state.json')
+    writeSecretFile(path, 'x')
+    expect(modeOf(join(dir, 'nested'))).toBe(0o700)
+  })
+
   it('truncates rather than appending to a longer previous file', () => {
     const path = join(dir, 'state.json')
     writeSecretFile(path, '{"a":"aaaaaaaaaaaaaaaaaaaa"}')

--- a/tests/tools/relay-bench/relay-hop-latency.mjs
+++ b/tests/tools/relay-bench/relay-hop-latency.mjs
@@ -6,6 +6,7 @@ import { performance } from 'node:perf_hooks'
 import { pathToFileURL } from 'node:url'
 import {
   LIVE_ENV_VAR,
+  describeUntrustedText,
   parseArgs,
   requireBoundedInteger,
   requireDirector,
@@ -46,7 +47,9 @@ async function timeResolve(director, relayHostId) {
     return {
       ms: Math.round(performance.now() - started),
       status: null,
-      error: timedOut ? `timeout after ${RESOLVE_TIMEOUT_MS} ms` : err.message
+      error: timedOut
+        ? `timeout after ${RESOLVE_TIMEOUT_MS} ms`
+        : describeUntrustedText(err.code ?? err.message)
     }
   }
 }
@@ -91,7 +94,7 @@ function timeCellHello(cell, relayHostId) {
     })
     ws.on('message', (message) => done({ hello: message.toString().slice(0, 80) }))
     ws.on('close', (code, reason) => done({ close: code, reason: reason.toString() }))
-    ws.on('error', (err) => done({ error: err.message }))
+    ws.on('error', (err) => done({ error: describeUntrustedText(err.code ?? err.message) }))
   })
 }
 

--- a/tests/tools/relay-bench/relay-phone-connect-bench.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.mjs
@@ -191,13 +191,14 @@ export function dialRelay({
       }
     })
     ws.on('close', (code, reason) => {
+      // Scrubbed where it is stored: the hold row prints this object verbatim.
       handle.closed = {
         code,
-        reason: reason.toString(),
+        reason: describeUntrustedText(reason.toString()),
         atMs: Math.round(performance.now() - timings.start)
       }
       if (!settled) {
-        fail(new Error(`closed ${code} ${describeUntrustedText(reason.toString())}`))
+        fail(new Error(`closed ${code} ${handle.closed.reason}`))
         return
       }
       clearTimeout(dialTimer)
@@ -464,7 +465,7 @@ async function run(statePath, runs, opts) {
     try {
       const dial = await resumeDial(state)
       row.dial = dial.timings
-      row.acceptedAs = dial.hello.acceptedAs
+      row.acceptedAs = describeUntrustedText(dial.hello.acceptedAs)
       const { rpc } = await runConnectedSequence(dial)
       row.rpc = rpc
       row.totalToConnectedMs = connectedMs(dial, rpc)
@@ -519,7 +520,7 @@ async function foreground(statePath, opts) {
   }
   const dial = await resumeDial(state)
   row.dial = dial.timings
-  row.acceptedAs = dial.hello.acceptedAs
+  row.acceptedAs = describeUntrustedText(dial.hello.acceptedAs)
   const { rpc } = await runConnectedSequence(dial)
   row.rpc = rpc
   row.totalToConnectedMs = connectedMs(dial, rpc)

--- a/tests/tools/relay-bench/relay-phone-connect-bench.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.mjs
@@ -18,6 +18,8 @@
 import { createRequire } from 'node:module'
 import { performance } from 'node:perf_hooks'
 import { pathToFileURL } from 'node:url'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { b64url, PhoneE2EE, sha256, utf8 } from './phone-e2ee-v2-session.mjs'
 import {
   classifyPublicHttpsOrigin,
@@ -41,7 +43,9 @@ const RPC_TIMEOUT_MS = 15_000
 // before any dial or RPC deadline has started.
 const RESOLVE_TIMEOUT_MS = 10_000
 const DEFAULT_HOLD_MS = 45_000
-const DEFAULT_STATE_PATH = '/tmp/relay-bench/state.json'
+// Under the operator's home, not /tmp: the file holds a live resume token, and a shared
+// world-writable directory is where another local user can pre-create the path.
+const DEFAULT_STATE_PATH = join(homedir(), '.orca', 'relay-bench', 'state.json')
 const MAX_RUNS = 1000
 const MAX_DELAY_MS = 3_600_000
 
@@ -162,7 +166,8 @@ export function dialRelay({
         if (stage === 'awaiting-authenticated') {
           const msg = JSON.parse(text)
           if (msg.type !== 'e2ee_authenticated') {
-            throw new Error(`auth rejected: ${text.slice(0, 120)}`)
+            // Type only: the plaintext is the desktop's and would land in row.error.
+            throw new Error(`auth rejected: desktop sent ${JSON.stringify(msg.type ?? null)}`)
           }
           mark('e2eeAuthenticated')
           stage = 'ready'
@@ -330,6 +335,20 @@ async function refreshCell(state, row) {
   }
 }
 
+/** Both destinations the resume token is sent to, each through the literal check and DNS. */
+export async function vetRelayEndpoint(relay, deps) {
+  for (const [label, value] of [
+    ['cell', relay?.cellUrl],
+    ['director', relay?.directorUrl]
+  ]) {
+    const verdict = await vetCellUrl(value, deps)
+    if (!verdict.ok) {
+      return { ok: false, reason: `${label}: ${verdict.reason}` }
+    }
+  }
+  return { ok: true }
+}
+
 export async function vetCellUrl(cellUrl, deps) {
   const verdict = classifyPublicHttpsOrigin(cellUrl)
   if (!verdict.ok) {
@@ -339,21 +358,18 @@ export async function vetCellUrl(cellUrl, deps) {
   return resolved.ok ? verdict : resolved
 }
 
-function loadState(statePath) {
+async function loadState(statePath) {
   const state = JSON.parse(readSecretFile(statePath))
   for (const field of ['relayHostId', 'cellUrl', 'directorUrl']) {
     if (!state.relay?.[field]) {
       throw new Error(`${statePath} has no relay.${field}; re-run pair`)
     }
   }
-  for (const [label, value] of [
-    ['relay.cellUrl', state.relay.cellUrl],
-    ['relay.directorUrl', state.relay.directorUrl]
-  ]) {
-    const verdict = classifyPublicHttpsOrigin(value)
-    if (!verdict.ok) {
-      throw new Error(`${statePath} ${label} ${verdict.reason}`)
-    }
+  // A state file is operator-owned, but its destinations came from the desktop and the director
+  // and the resume token goes to both, so they are vetted again on every load.
+  const verdict = await vetRelayEndpoint(state.relay)
+  if (!verdict.ok) {
+    throw new Error(`${statePath} relay ${verdict.reason}`)
   }
   return state
 }
@@ -395,10 +411,19 @@ async function pair(pairingUrl, statePath) {
   const endpoints = await dial.rpc('pairing.getEndpoints', { installReqId })
   const endpointsMs = Math.round(performance.now() - endpointsStarted)
   if (!endpoints.ok || !endpoints.result.relay) {
-    throw new Error(`getEndpoints failed: ${JSON.stringify(endpoints)}`)
+    // Shape only: the reply is peer-supplied and this line lands in the operator's terminal.
+    throw new Error(
+      `getEndpoints failed: ${endpoints.ok ? 'no relay block in result' : `error ${endpoints.error?.code ?? 'unknown'}`}`
+    )
   }
   console.log(`provisionRelay ${provisionMs} ms, getEndpoints ${endpointsMs} ms`)
   dial.close()
+  // The desktop names the cell and the director the resume token will be sent to, so both get
+  // the same two-layer check as every other supplied destination before they are stored.
+  const endpointVerdict = await vetRelayEndpoint(endpoints.result.relay)
+  if (!endpointVerdict.ok) {
+    throw new Error(`desktop named an unusable relay endpoint: ${endpointVerdict.reason}`)
+  }
   const state = {
     relay: endpoints.result.relay,
     deviceToken: offer.deviceToken,
@@ -414,7 +439,7 @@ async function pair(pairingUrl, statePath) {
 }
 
 async function run(statePath, runs, opts) {
-  const state = loadState(statePath)
+  const state = await loadState(statePath)
   const rows = []
   for (let index = 0; index < runs; index++) {
     const row = { run: index }
@@ -473,7 +498,7 @@ async function run(statePath, runs, opts) {
 // retained socket is still usable and what the fallback resume redial costs. The relay's client
 // silence watchdog is ~105 s, so --hold=120000 is the interesting "crossed the watchdog" case.
 async function foreground(statePath, opts) {
-  const state = loadState(statePath)
+  const state = await loadState(statePath)
   const row = { mode: 'foreground', holdMs: opts.holdMs }
   if (opts.resolve) {
     await refreshCell(state, row)

--- a/tests/tools/relay-bench/relay-phone-connect-bench.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.mjs
@@ -170,7 +170,7 @@ export function dialRelay({
           const msg = JSON.parse(text)
           if (msg.type !== 'e2ee_authenticated') {
             // Type only: the plaintext is the desktop's and would land in row.error.
-            throw new Error(`auth rejected: desktop sent ${JSON.stringify(msg.type ?? null)}`)
+            throw new Error(`auth rejected: desktop sent ${describeUntrustedText(msg.type)}`)
           }
           mark('e2eeAuthenticated')
           stage = 'ready'
@@ -401,7 +401,9 @@ async function pair(pairingUrl, statePath) {
   const resumeToken = b64url(nacl.randomBytes(32))
   const resumeTokenHash = b64url(sha256(utf8(resumeToken)))
   const installReqId = `install-${b64url(nacl.randomBytes(12))}`
-  console.log(`pair: dialing ${relay.cellUrl} host=${relay.relayHostId}`)
+  // The offer is operator-pasted text: the vetted origin, not the raw URL, and the host id
+  // through the same scrub as any other peer-chosen string.
+  console.log(`pair: dialing ${verdict.origin} host=${describeUntrustedText(relay.relayHostId)}`)
   const dial = await dialRelay({
     cellUrl: relay.cellUrl,
     relayHostId: relay.relayHostId,

--- a/tests/tools/relay-bench/relay-phone-connect-bench.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.mjs
@@ -52,6 +52,16 @@ const MAX_DELAY_MS = 3_600_000
 
 // ---------- one relay dial, phone-shaped ----------
 // Resolves once e2ee_authenticated lands, with timings and an rpc() bound to the live socket.
+// JSON.parse quotes a fragment of its input in the SyntaxError, and every input here is peer,
+// desktop, or credential text, so the failure names only what was being parsed.
+export function parsePeerJson(text, what) {
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw new Error(`${what}: not valid JSON`)
+  }
+}
+
 export function dialRelay({
   cellUrl,
   relayHostId,
@@ -128,7 +138,7 @@ export function dialRelay({
     ws.on('message', (raw, isBinary) => {
       try {
         if (stage === 'awaiting-hello') {
-          const hello = JSON.parse(raw.toString())
+          const hello = parsePeerJson(raw.toString(), 'relay hello')
           handle.hello = hello
           mark('relayHello')
           if (!hello.ok) {
@@ -145,7 +155,7 @@ export function dialRelay({
           return
         }
         if (stage === 'awaiting-ready') {
-          e2ee.acceptReady(JSON.parse(raw.toString()))
+          e2ee.acceptReady(parsePeerJson(raw.toString(), 'relay ready'))
           mark('e2eeReady')
           stage = 'awaiting-authenticated'
           ws.send(
@@ -167,7 +177,7 @@ export function dialRelay({
         }
         const text = e2ee.openText(raw.toString())
         if (stage === 'awaiting-authenticated') {
-          const msg = JSON.parse(text)
+          const msg = parsePeerJson(text, 'desktop authentication')
           if (msg.type !== 'e2ee_authenticated') {
             // Type only: the plaintext is the desktop's and would land in row.error.
             throw new Error(`auth rejected: desktop sent ${describeUntrustedText(msg.type)}`)
@@ -179,7 +189,7 @@ export function dialRelay({
           resolve(handle)
           return
         }
-        const msg = JSON.parse(text)
+        const msg = parsePeerJson(text, 'desktop frame')
         const waiter = msg.id && pending.get(msg.id)
         if (waiter) {
           clearTimeout(waiter.timer)
@@ -226,7 +236,7 @@ export function decodeOffer(pairingUrl) {
   }
   let offer
   try {
-    offer = JSON.parse(Buffer.from(code, 'base64url').toString('utf8'))
+    offer = parsePeerJson(Buffer.from(code, 'base64url').toString('utf8'), 'pairing offer')
   } catch {
     throw new Error('pairing link code did not decode to JSON')
   }
@@ -239,10 +249,13 @@ export function decodeOffer(pairingUrl) {
 async function resolveCell(relay, resumeToken) {
   const started = performance.now()
   try {
+    // redirect: 'error': the body carries the resume token, and a redirect would replay it
+    // to a destination that was never vetted, possibly over plain http.
     const res = await fetch(`${relay.directorUrl}/v1/resolve`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ v: 1, relayHostId: relay.relayHostId, resumeToken }),
+      redirect: 'error',
       signal: AbortSignal.timeout(RESOLVE_TIMEOUT_MS)
     })
     const body = await res.json().catch(() => null)
@@ -363,7 +376,8 @@ export async function vetCellUrl(cellUrl, deps) {
 }
 
 async function loadState(statePath) {
-  const state = JSON.parse(readSecretFile(statePath))
+  // A fixed message: a SyntaxError quotes the offending text, and this file holds the token.
+  const state = parsePeerJson(readSecretFile(statePath), 'state file')
   for (const field of ['relayHostId', 'cellUrl', 'directorUrl']) {
     if (!state.relay?.[field]) {
       throw new Error(`${statePath} has no relay.${field}; re-run pair`)
@@ -661,7 +675,8 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   // A bad state file or a refused destination is operator input, not a crash; say what is wrong
   // without spilling the credential-bearing stack.
   await main(process.argv.slice(2)).catch((err) => {
-    console.error(err.message)
+    // Our own messages are already scrubbed; a library error (DNS, TLS, ws) is not.
+    console.error(describeUntrustedText(err.message))
     process.exitCode = 1
   })
 }

--- a/tests/tools/relay-bench/relay-phone-connect-bench.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.mjs
@@ -22,8 +22,9 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { b64url, PhoneE2EE, sha256, utf8 } from './phone-e2ee-v2-session.mjs'
 import {
-  classifyPublicHttpsOrigin,
   LIVE_ENV_VAR,
+  classifyPublicHttpsOrigin,
+  describeUntrustedText,
   parseArgs,
   refuse,
   requireBoundedInteger,
@@ -131,10 +132,12 @@ export function dialRelay({
           handle.hello = hello
           mark('relayHello')
           if (!hello.ok) {
-            throw new Error(`relay-hello rejected code=${hello.code}`)
+            throw new Error(`relay-hello rejected code=${describeUntrustedText(hello.code)}`)
           }
           if (hello.credentialKind !== expectedKind) {
-            throw new Error(`credentialKind ${hello.credentialKind} != ${expectedKind}`)
+            throw new Error(
+              `credentialKind ${describeUntrustedText(hello.credentialKind)} != ${expectedKind}`
+            )
           }
           stage = 'awaiting-ready'
           ws.send(JSON.stringify(e2ee.hello))
@@ -194,7 +197,7 @@ export function dialRelay({
         atMs: Math.round(performance.now() - timings.start)
       }
       if (!settled) {
-        fail(new Error(`closed ${code} ${reason.toString()}`))
+        fail(new Error(`closed ${code} ${describeUntrustedText(reason.toString())}`))
         return
       }
       clearTimeout(dialTimer)
@@ -414,7 +417,9 @@ async function pair(pairingUrl, statePath) {
   })
   const provisionMs = Math.round(performance.now() - provisionStarted)
   if (!provision.ok) {
-    throw new Error(`provisionRelay failed: ${JSON.stringify(provision.error)}`)
+    throw new Error(
+      `provisionRelay failed: error ${describeRemoteErrorCode(provision.error?.code)}`
+    )
   }
   const endpointsStarted = performance.now()
   const endpoints = await dial.rpc('pairing.getEndpoints', { installReqId })

--- a/tests/tools/relay-bench/relay-phone-connect-bench.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.mjs
@@ -375,6 +375,15 @@ async function loadState(statePath) {
 }
 
 // ---------- commands ----------
+// The peer picks the code, so only a plain identifier is echoed; anything else is named by kind.
+const REMOTE_ERROR_CODE = /^[A-Za-z0-9_.-]{1,64}$/
+export function describeRemoteErrorCode(code) {
+  if (typeof code !== 'string') {
+    return code === undefined ? 'unknown' : `non-string code (${typeof code})`
+  }
+  return REMOTE_ERROR_CODE.test(code) ? code : `unprintable code (${code.length} chars)`
+}
+
 async function pair(pairingUrl, statePath) {
   const offer = decodeOffer(pairingUrl)
   if (!offer.relay) {
@@ -413,7 +422,7 @@ async function pair(pairingUrl, statePath) {
   if (!endpoints.ok || !endpoints.result.relay) {
     // Shape only: the reply is peer-supplied and this line lands in the operator's terminal.
     throw new Error(
-      `getEndpoints failed: ${endpoints.ok ? 'no relay block in result' : `error ${endpoints.error?.code ?? 'unknown'}`}`
+      `getEndpoints failed: ${endpoints.ok ? 'no relay block in result' : `error ${describeRemoteErrorCode(endpoints.error?.code)}`}`
     )
   }
   console.log(`provisionRelay ${provisionMs} ms, getEndpoints ${endpointsMs} ms`)

--- a/tests/tools/relay-bench/relay-phone-connect-bench.test.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.test.mjs
@@ -2,7 +2,12 @@
 // missing or malformed pairing link surfaced as a stack trace rather than usage. The link is a
 // live credential, so the failure text has to name the problem without echoing the code.
 import { describe, expect, it, vi } from 'vitest'
-import { decodeOffer, vetCellUrl, vetRelayEndpoint } from './relay-phone-connect-bench.mjs'
+import {
+  decodeOffer,
+  describeRemoteErrorCode,
+  vetCellUrl,
+  vetRelayEndpoint
+} from './relay-phone-connect-bench.mjs'
 
 const encode = (offer) => Buffer.from(JSON.stringify(offer), 'utf8').toString('base64url')
 
@@ -84,5 +89,24 @@ describe('vetRelayEndpoint', () => {
         { lookup }
       )
     ).resolves.toEqual({ ok: true })
+  })
+})
+
+describe('describeRemoteErrorCode', () => {
+  it('echoes a plain protocol identifier', () => {
+    expect(describeRemoteErrorCode('invalid_install_req')).toBe('invalid_install_req')
+  })
+
+  it('never echoes terminal control bytes the peer put in the code', () => {
+    const out = describeRemoteErrorCode('\u001b[2J\u001b]0;pwned\u0007')
+    expect(out).not.toContain('\u001b')
+    expect(out).toMatch(/unprintable code/)
+  })
+
+  it('names the type instead of stringifying a non-string code', () => {
+    expect(describeRemoteErrorCode({ toString: () => '\u001b[31m' })).toBe(
+      'non-string code (object)'
+    )
+    expect(describeRemoteErrorCode(undefined)).toBe('unknown')
   })
 })

--- a/tests/tools/relay-bench/relay-phone-connect-bench.test.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.test.mjs
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   decodeOffer,
   describeRemoteErrorCode,
+  parsePeerJson,
   vetCellUrl,
   vetRelayEndpoint
 } from './relay-phone-connect-bench.mjs'
@@ -108,5 +109,21 @@ describe('describeRemoteErrorCode', () => {
       'non-string code (object)'
     )
     expect(describeRemoteErrorCode(undefined)).toBe('unknown')
+  })
+})
+
+describe('parsePeerJson', () => {
+  it('never lets the parser quote the peer bytes in the failure', () => {
+    // JSON.parse's SyntaxError includes a fragment of its input; the relay chose that input.
+    expect(() => parsePeerJson('x\u001b[2J', 'relay hello')).toThrow(
+      /^relay hello: not valid JSON$/
+    )
+    expect(() => parsePeerJson('{"resumeToken":"secret"', 'state file')).toThrow(
+      /^state file: not valid JSON$/
+    )
+  })
+
+  it('parses valid JSON unchanged', () => {
+    expect(parsePeerJson('{"ok":true}', 'relay hello')).toEqual({ ok: true })
   })
 })

--- a/tests/tools/relay-bench/relay-phone-connect-bench.test.mjs
+++ b/tests/tools/relay-bench/relay-phone-connect-bench.test.mjs
@@ -2,7 +2,7 @@
 // missing or malformed pairing link surfaced as a stack trace rather than usage. The link is a
 // live credential, so the failure text has to name the problem without echoing the code.
 import { describe, expect, it, vi } from 'vitest'
-import { decodeOffer, vetCellUrl } from './relay-phone-connect-bench.mjs'
+import { decodeOffer, vetCellUrl, vetRelayEndpoint } from './relay-phone-connect-bench.mjs'
 
 const encode = (offer) => Buffer.from(JSON.stringify(offer), 'utf8').toString('base64url')
 
@@ -55,5 +55,34 @@ describe('vetCellUrl', () => {
       ok: true,
       origin: 'https://cell.example'
     })
+  })
+})
+
+// Why: the desktop's getEndpoints reply names the director every later resolve posts the resume
+// token to. It gets the same two-layer check as the cell, in pair() and again on load.
+describe('vetRelayEndpoint', () => {
+  it('refuses a director that resolves into the operator network even when the cell is fine', async () => {
+    const lookup = vi.fn(async (host) =>
+      host === 'director.example'
+        ? [{ address: '10.0.0.7', family: 4 }]
+        : [{ address: '8.8.8.8', family: 4 }]
+    )
+    const verdict = await vetRelayEndpoint(
+      { cellUrl: 'https://cell.example', directorUrl: 'https://director.example' },
+      { lookup }
+    )
+    expect(verdict.ok).toBe(false)
+    expect(verdict.reason).toContain('director')
+    expect(verdict.reason).toContain('10.0.0.7')
+  })
+
+  it('accepts an endpoint whose cell and director both resolve publicly', async () => {
+    const lookup = vi.fn(async () => [{ address: '8.8.8.8', family: 4 }])
+    await expect(
+      vetRelayEndpoint(
+        { cellUrl: 'https://cell.example', directorUrl: 'https://director.example' },
+        { lookup }
+      )
+    ).resolves.toEqual({ ok: true })
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​326 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​60 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​266 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Follow-up to #19251 from the post-merge adversarial review. Three findings, reproduced against main; the two behavioural ones have failing-first tests.

## Why

- **MEDIUM: the director URL was never DNS-checked, and the resume token is posted to it.** `pair` stored the desktop's `getEndpoints` reply unvetted, and `loadState` applied only the literal-address check to `directorUrl`. Every other supplied destination got both layers. A desktop returning a director hostname that resolves to loopback or RFC 1918 would have the bench post the resume token into the operator's network.
- **LOW: the default state path sat in world-writable `/tmp`, the directory was created world-traversable, and a pre-existing file was truncated and written before the `chmod`.** A file owned by another user would take the token on `O_TRUNC`, then fail the `chmod` with EPERM.
- **LOW: two error paths printed peer-supplied content.** The full `getEndpoints` reply, and 120 bytes of decrypted desktop plaintext.

## What

- New `vetRelayEndpoint(relay)` runs the literal check plus `resolvesToPublicAddress` over both `cellUrl` and `directorUrl`. `pair` calls it before storing the reply; `loadState` calls it on every load. `loadState` is now async; both callers await it.
- Default state path is `~/.orca/relay-bench/state.json`. `writeSecretFile` creates the directory `0700`, refuses a file owned by another user before opening for write, and tightens a loose existing file with `fchmod` on the descriptor before the write rather than a path `chmod` after it. README updated.
- The two error lines report the reply shape or message type only.

## Tests

- `vetRelayEndpoint` refuses a director resolving to `10.0.0.7` with a public cell, and accepts when both resolve publicly (both fail on main: the export does not exist).
- `writeSecretFile` creates the parent `0700` (fails on main).
- `pnpm vitest run tests/tools/relay-bench` 113/113, `oxlint`, `node --check` on every script.
