### PR TITLE
Rank activity status groups by attention level

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -171,6 +171,9 @@ describe('buildActivityEvents', () => {
 
     expect(result.liveAgentByPaneKey[PANE_KEY].state).toBe('monitoring')
     expect(threads[0].currentAgentState).toBe('monitoring')
+    // A monitoring turn must not emit a `working` event that contradicts the live snapshot.
+    expect(result.events).toHaveLength(0)
+    expect(threads[0].latestEvent).toBeNull()
     expect(groups[0]).toMatchObject({
       key: 'monitoring',
       label: 'Monitoring background tasks',

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -87,12 +87,13 @@ describe('buildActivityEvents', () => {
       now: 2_000
     })
 
-    expect(result.events).toHaveLength(1)
-    expect(result.events[0]).toMatchObject({
+    expect(result.events).toHaveLength(2)
+    expect(result.events[0]).toMatchObject({ state: 'working', timestamp: 2_000 })
+    expect(result.events[1]).toMatchObject({
       state: 'done',
       timestamp: 1_000
     })
-    expect(result.events[0].entry.prompt).toBe('First prompt')
+    expect(result.events[1].entry.prompt).toBe('First prompt')
     expect(result.liveAgentByPaneKey[PANE_KEY].state).toBe('working')
     expect(result.liveAgentByPaneKey[PANE_KEY].entry.prompt).toBe('Second prompt')
 
@@ -101,7 +102,7 @@ describe('buildActivityEvents', () => {
     expect(threads).toHaveLength(1)
     expect(threads[0].paneTitle).toBe('Second prompt')
     expect(threads[0].latestTimestamp).toBe(2_000)
-    expect(threads[0].events[0].entry.prompt).toBe('First prompt')
+    expect(threads[0].events[1].entry.prompt).toBe('First prompt')
   })
 
   it('does not turn a session boundary into an Agent finished event', () => {
@@ -144,15 +145,15 @@ describe('buildActivityEvents', () => {
 
     const threads = makeThreads(result)
 
-    expect(result.events).toHaveLength(0)
+    expect(result.events).toHaveLength(1)
     expect(threads).toHaveLength(1)
     expect(threads[0]).toMatchObject({
       paneKey: PANE_KEY,
       paneTitle: 'New run',
       currentAgentState: 'working',
       latestTimestamp: 3_000,
-      latestEvent: null,
-      unread: false
+      latestEvent: { state: 'working', timestamp: 3_000 },
+      unread: true
     })
   })
 
@@ -228,7 +229,7 @@ describe('buildActivityEvents', () => {
 
     const threads = makeThreads(result)
 
-    expect(result.events).toHaveLength(0)
+    expect(result.events).toHaveLength(1)
     expect(threads).toHaveLength(1)
     expect(threads[0]).toMatchObject({
       paneKey: PANE_KEY,
@@ -382,12 +383,12 @@ describe('buildActivityEvents', () => {
       tab
     })
 
-    expect(result.events).toHaveLength(1)
-    expect(result.events[0]).toMatchObject({
+    expect(result.events).toHaveLength(2)
+    expect(result.events[1]).toMatchObject({
       state: 'done',
       timestamp: 1_000
     })
-    expect(result.events[0].entry.prompt).toBe('Retained prior run')
+    expect(result.events[1].entry.prompt).toBe('Retained prior run')
     expect(result.liveAgentByPaneKey[PANE_KEY].state).toBe('working')
 
     const threads = makeThreads(result)
@@ -396,7 +397,7 @@ describe('buildActivityEvents', () => {
     expect(threads[0].paneTitle).toBe('New run')
     expect(threads[0].responsePreview).toBe('')
     expect(threads[0].latestTimestamp).toBe(3_000)
-    expect(threads[0].events[0].entry.prompt).toBe('Retained prior run')
+    expect(threads[0].events[1].entry.prompt).toBe('Retained prior run')
   })
 
   it('groups visible threads with attention states before working and done', () => {

--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -12,7 +12,7 @@ import {
   activityThreadMatchesSearchQuery,
   buildActivityEvents,
   buildAgentPaneThreads,
-  groupActivityThreadsByStatus,
+  buildActivityThreadGroups,
   isActivitySearchQueryTooLarge
 } from './ActivityPrototypePage'
 import {
@@ -166,12 +166,12 @@ describe('buildActivityEvents', () => {
       }
     })
     const threads = makeThreads(result)
-    const groups = groupActivityThreadsByStatus(threads)
+    const groups = buildActivityThreadGroups(threads, 'status')
 
     expect(result.liveAgentByPaneKey[PANE_KEY].state).toBe('monitoring')
     expect(threads[0].currentAgentState).toBe('monitoring')
     expect(groups[0]).toMatchObject({
-      id: 'monitoring',
+      key: 'monitoring',
       label: 'Monitoring background tasks',
       state: 'monitoring'
     })
@@ -435,14 +435,15 @@ describe('buildActivityEvents', () => {
       now: 5_000
     })
 
-    const groups = groupActivityThreadsByStatus(
+    const groups = buildActivityThreadGroups(
       buildAgentPaneThreads({
         events: result.events,
         liveAgentByPaneKey: result.liveAgentByPaneKey
-      })
+      }),
+      'status'
     )
 
-    expect(groups.map((group) => group.id)).toEqual(['blocked', 'working', 'done'])
+    expect(groups.map((group) => group.key)).toEqual(['blocked', 'working', 'done'])
     expect(groups.map((group) => group.threads.map((thread) => thread.paneKey))).toEqual([
       [PANE_KEY_2],
       [PANE_KEY],

--- a/src/renderer/src/components/activity/ActivityPrototypePage.thread-grouping.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.thread-grouping.test.ts
@@ -93,8 +93,10 @@ describe('activity thread grouping', () => {
     const groups = buildActivityThreadGroups(threads, 'status')
 
     expect(groups).toHaveLength(2)
-    expect(groups[0].key).toBe('done:interrupted')
+    expect(groups[0].key).toBe('interrupted')
     expect(groups[0].label).toBe('Interrupted')
+    // Interrupted rows keep the done glyph (#2569); the header mirrors the row.
+    expect(groups[0].state).toBe('done')
     expect(groups[1].key).toBe('done')
     expect(groups[1].label).toBe('Done')
   })

--- a/src/renderer/src/components/activity/activity-clear-completed.ts
+++ b/src/renderer/src/components/activity/activity-clear-completed.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import type { AgentStatusCacheIdentity } from '../../../../shared/agent-status-types'
-import { threadStatusGroupId } from './activity-thread-grouping'
+import { activityThreadStatusId } from './activity-thread-presentation'
 import type { AgentPaneThread } from './activity-thread-types'
 
 export type ClearCompletedActivityPlan = {
@@ -21,8 +21,8 @@ export type ClearCompletedActivityPlan = {
 /** A thread is clearable when it needs nothing from the user: completed or interrupted,
  *  with no fresh live working/monitoring/blocked/waiting state. */
 export function isClearableActivityThread(thread: AgentPaneThread): boolean {
-  const groupId = threadStatusGroupId(thread)
-  return groupId === 'done' || groupId === 'interrupted'
+  const id = activityThreadStatusId(thread)
+  return id === 'done' || id === 'interrupted'
 }
 
 export function planClearCompletedActivity(

--- a/src/renderer/src/components/activity/activity-event-build-cache.ts
+++ b/src/renderer/src/components/activity/activity-event-build-cache.ts
@@ -87,19 +87,21 @@ export function resolvePaneBuild(
     return { events: cached.events, live: cached.live }
   }
 
-  const events = inputsUnchanged
-    ? cached.events
-    : buildPaneActivityEvents({
-        entry: rowEntry,
-        worktree: request.worktree,
-        repo: request.repo,
-        tab: request.tab,
-        agentType: request.agentType,
-        agentAlive: request.agentAlive,
-        acknowledgedAt: request.acknowledgedAt,
-        clearedAt: request.clearedAt,
-        migrationUnsupportedPtyId: request.migrationUnsupportedPtyId
-      })
+  const events =
+    inputsUnchanged && liveMatchesCache
+      ? cached.events
+      : buildPaneActivityEvents({
+          entry: rowEntry,
+          worktree: request.worktree,
+          repo: request.repo,
+          tab: request.tab,
+          agentType: request.agentType,
+          agentAlive: request.agentAlive,
+          acknowledgedAt: request.acknowledgedAt,
+          clearedAt: request.clearedAt,
+          liveState: request.liveState,
+          migrationUnsupportedPtyId: request.migrationUnsupportedPtyId
+        })
   const live: ActivityLiveAgentSnapshot | null =
     request.liveState === null
       ? null

--- a/src/renderer/src/components/activity/activity-event-builder.bounded-history.test.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.bounded-history.test.ts
@@ -117,6 +117,7 @@ describe('buildActivityEvents cleared cutoff', () => {
     })
     expect(liveAgentByPaneKey[PANE_KEY]?.state).toBe('working')
     // The historical done at 1_000 stays hidden by the cutoff.
-    expect(events).toHaveLength(0)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ state: 'working', timestamp: 99_000, unread: true })
   })
 })

--- a/src/renderer/src/components/activity/activity-event-builder.identity-reuse.test.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.identity-reuse.test.ts
@@ -170,8 +170,55 @@ describe('activity build identity reuse', () => {
       threadCache
     )
     expect(decayed.liveAgentByPaneKey[PANE_B]).toBeUndefined()
+    expect(decayed.events.some((event) => event.state === 'working')).toBe(false)
     // PANE_A had no live snapshot; its thread survives untouched.
     expect(threadByPane(decayed.threads, PANE_A)).toBe(threadByPane(first.threads, PANE_A))
+  })
+
+  it('uses the same read receipt for working activity, heartbeats, and the next turn', () => {
+    const eventCache = createActivityEventBuildCache()
+    const threadCache = createAgentPaneThreadReuseCache()
+    const args = makeArgs({
+      agentStatusByPaneKey: {
+        [PANE_B]: entry(PANE_B, {
+          state: 'working',
+          stateStartedAt: NOW - 1_000,
+          updatedAt: NOW,
+          stateHistory: []
+        })
+      }
+    })
+    const first = buildBoth(args, eventCache, threadCache)
+    expect(first.events[0]).toMatchObject({ state: 'working', unread: true })
+    expect(first.threads[0].unread).toBe(true)
+
+    const readArgs = { ...args, acknowledgedAgentsByPaneKey: { [PANE_B]: NOW } }
+    expect(buildBoth(readArgs, eventCache, threadCache).threads[0].unread).toBe(false)
+
+    const heartbeatArgs = {
+      ...readArgs,
+      agentStatusByPaneKey: {
+        [PANE_B]: { ...args.agentStatusByPaneKey[PANE_B], updatedAt: NOW + 1_000 }
+      },
+      now: NOW + 1_000
+    }
+    const heartbeat = buildBoth(heartbeatArgs, eventCache, threadCache)
+    expect(heartbeat.events).toHaveLength(1)
+    expect(heartbeat.events[0].id).toBe(first.events[0].id)
+    expect(heartbeat.threads[0].unread).toBe(false)
+
+    const next = buildBoth(
+      {
+        ...heartbeatArgs,
+        agentStatusByPaneKey: {
+          [PANE_B]: { ...heartbeatArgs.agentStatusByPaneKey[PANE_B], stateStartedAt: NOW + 1_000 }
+        }
+      },
+      eventCache,
+      threadCache
+    )
+    expect(next.events[0].id).not.toBe(first.events[0].id)
+    expect(next.threads[0].unread).toBe(true)
   })
 
   it('cached builds always equal a cold uncached build (no drift)', () => {

--- a/src/renderer/src/components/activity/activity-event-builder.live-cap.test.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.live-cap.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { buildActivityEvents } from './activity-event-builder'
+import { buildAgentPaneThreads } from './activity-thread-builder'
+import {
+  LEAF_ID,
+  makeRepo,
+  makeTabWithIds,
+  makeWorktree
+} from './ActivityPrototypePage-test-fixtures'
+
+describe('live activity capacity', () => {
+  it('preserves completed rows and unread live turns beyond the history budget', () => {
+    const repo = makeRepo()
+    const worktree = makeWorktree()
+    const tabs = Array.from({ length: 82 }, (_, i) => makeTabWithIds(`tab-${i}`, worktree.id))
+    const entries = Object.fromEntries(
+      tabs.map((tab, i) => {
+        const paneKey = makePaneKey(tab.id, LEAF_ID)
+        return [
+          paneKey,
+          {
+            paneKey,
+            state: i === 0 ? 'done' : 'working',
+            prompt: `Task ${i}`,
+            stateStartedAt: i === 0 ? 1_000 : 2_000 + i,
+            updatedAt: 3_000,
+            stateHistory: [],
+            agentType: 'claude'
+          } satisfies AgentStatusEntry
+        ]
+      })
+    )
+    const result = buildActivityEvents({
+      agentStatusByPaneKey: entries,
+      retainedAgentsByPaneKey: {},
+      tabsByWorktree: { [worktree.id]: tabs },
+      worktreeMap: new Map([[worktree.id, worktree]]),
+      repoMap: new Map([[repo.id, repo]]),
+      acknowledgedAgentsByPaneKey: {},
+      now: 3_000
+    })
+    const threads = buildAgentPaneThreads(result)
+
+    expect(threads).toHaveLength(82)
+    expect(
+      threads.find((thread) => thread.paneKey === makePaneKey(tabs[0].id, LEAF_ID))
+    ).toMatchObject({ latestEvent: { state: 'done' }, unread: true })
+    const workingThreads = threads.filter((thread) => thread.currentAgentState === 'working')
+    expect(workingThreads).toHaveLength(81)
+    expect(workingThreads.every((thread) => thread.unread)).toBe(true)
+  })
+})

--- a/src/renderer/src/components/activity/activity-event-builder.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.ts
@@ -120,7 +120,7 @@ export function buildActivityEvents(
       ownerCache
     )
     const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-    // Why: live status is separate from history; a fresh working turn updates the thread without counting as an unread done/blocked/waiting event.
+    // Only fresh live turns contribute working activity; history cannot establish liveness.
     // The freshness check runs on the raw entry (orchestration merges never change state/timing fields).
     const liveState = freshActivityLiveAgentState(entry, args.now)
     const { events: paneEvents, live } = resolvePaneBuild(

--- a/src/renderer/src/components/activity/activity-event-builder.ts
+++ b/src/renderer/src/components/activity/activity-event-builder.ts
@@ -1,11 +1,9 @@
-import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import { freshActivityLiveAgentState } from './activity-event-state'
 import type { RetainedAgentEntry } from '@/store/slices/agent-status'
-import {
-  AGENT_STATUS_STALE_AFTER_MS,
-  type AgentStatusEntry,
-  type AgentStatusOrchestrationContext,
-  type AgentStatusState,
-  type MigrationUnsupportedPtyEntry
+import type {
+  AgentStatusEntry,
+  AgentStatusOrchestrationContext,
+  MigrationUnsupportedPtyEntry
 } from '../../../../shared/agent-status-types'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/repo-types'
@@ -13,12 +11,7 @@ import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
-import type {
-  ActivityEvent,
-  ActivityHookLiveAgentState,
-  ActivityLiveAgentSnapshot,
-  ActivityLiveAgentState
-} from './activity-thread-types'
+import type { ActivityEvent, ActivityLiveAgentSnapshot } from './activity-thread-types'
 import { capActivityEvents } from './activity-event-cap'
 import { newestActivityHistoryEntries } from './activity-pane-events'
 import {
@@ -36,27 +29,6 @@ import {
 } from './activity-event-builder-context'
 
 export { createActivityEventBuildCache, type ActivityEventBuildCache, newestActivityHistoryEntries }
-
-function isActivityHookLiveAgentState(
-  state: AgentStatusState
-): state is ActivityHookLiveAgentState {
-  return state === 'working' || state === 'blocked' || state === 'waiting'
-}
-
-function freshActivityLiveAgentState(
-  entry: AgentStatusEntry,
-  now: number
-): ActivityLiveAgentState | null {
-  if (
-    !isActivityHookLiveAgentState(entry.state) ||
-    !isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)
-  ) {
-    return null
-  }
-  return entry.state === 'working' && entry.workingMode === 'monitoring'
-    ? 'monitoring'
-    : entry.state
-}
 
 export type BuildActivityEventsArgs = {
   agentStatusByPaneKey: Record<string, AgentStatusEntry>

--- a/src/renderer/src/components/activity/activity-event-cap.ts
+++ b/src/renderer/src/components/activity/activity-event-cap.ts
@@ -5,7 +5,11 @@ import type { ActivityEvent } from './activity-thread-types'
 export const EVENTS_PER_PANE_CAP = 5
 
 export function capActivityEvents(events: ActivityEvent[]): ActivityEvent[] {
-  const sorted = events.sort((a, b) => b.timestamp - a.timestamp)
+  // Live turns already have uncapped snapshots; they must not evict retained history.
+  const working = events.filter((event) => event.state === 'working')
+  const sorted = events
+    .filter((event) => event.state !== 'working')
+    .sort((a, b) => b.timestamp - a.timestamp)
   const perPaneCount = new Map<string, number>()
   const includedEventIds = new Set<string>()
   const capped: ActivityEvent[] = []
@@ -38,5 +42,5 @@ export function capActivityEvents(events: ActivityEvent[]): ActivityEvent[] {
     includedEventIds.add(event.id)
     capped.push(event)
   }
-  return capped.sort((a, b) => b.timestamp - a.timestamp)
+  return [...capped, ...working].sort((a, b) => b.timestamp - a.timestamp)
 }

--- a/src/renderer/src/components/activity/activity-event-state.ts
+++ b/src/renderer/src/components/activity/activity-event-state.ts
@@ -1,0 +1,38 @@
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry,
+  type AgentStatusState
+} from '../../../../shared/agent-status-types'
+import type {
+  ActivityEventState,
+  ActivityHookLiveAgentState,
+  ActivityLiveAgentState
+} from './activity-thread-types'
+
+function isActivityHookLiveAgentState(
+  state: AgentStatusState
+): state is ActivityHookLiveAgentState {
+  return state === 'working' || state === 'blocked' || state === 'waiting'
+}
+
+export function freshActivityLiveAgentState(
+  entry: AgentStatusEntry,
+  now: number
+): ActivityLiveAgentState | null {
+  if (
+    !isActivityHookLiveAgentState(entry.state) ||
+    !isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS)
+  ) {
+    return null
+  }
+  return entry.state === 'working' && entry.workingMode === 'monitoring'
+    ? 'monitoring'
+    : entry.state
+}
+
+export function isHistoricalActivityState(
+  state: string
+): state is Extract<ActivityEventState, 'done' | 'blocked' | 'waiting'> {
+  return state === 'done' || state === 'blocked' || state === 'waiting'
+}

--- a/src/renderer/src/components/activity/activity-pane-events.ts
+++ b/src/renderer/src/components/activity/activity-pane-events.ts
@@ -5,12 +5,16 @@ import type {
 import type { Repo } from '../../../../shared/repo-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { Worktree } from '../../../../shared/worktree/types'
-import type { ActivityEvent, ActivityEventState } from './activity-thread-types'
+import type {
+  ActivityEvent,
+  ActivityEventState,
+  ActivityLiveAgentState
+} from './activity-thread-types'
 import { EVENTS_PER_PANE_CAP } from './activity-event-cap'
 
-export function isActivityEventState(
-  state: AgentStatusEntry['state']
-): state is ActivityEventState {
+function isHistoricalActivityState(
+  state: string
+): state is Extract<ActivityEventState, 'done' | 'blocked' | 'waiting'> {
   return state === 'done' || state === 'blocked' || state === 'waiting'
 }
 
@@ -39,7 +43,7 @@ export function newestActivityHistoryEntries(
 ): AgentStateHistoryEntry[] {
   const newest: AgentStateHistoryEntry[] = []
   for (let i = history.length - 1; i >= 0 && newest.length < cap; i -= 1) {
-    if (isActivityEventState(history[i].state)) {
+    if (isHistoricalActivityState(history[i].state)) {
       newest.push(history[i])
     }
   }
@@ -55,6 +59,7 @@ type PaneEventInputs = {
   agentAlive: boolean
   acknowledgedAt: number
   clearedAt: number
+  liveState: ActivityLiveAgentState | null
   migrationUnsupportedPtyId?: string
 }
 
@@ -97,12 +102,14 @@ export function buildPaneActivityEvents(args: PaneEventInputs): ActivityEvent[] 
     )
   }
 
-  if (!isActivityEventState(args.entry.state) || args.entry.sessionBoundary === true) {
+  const currentState =
+    args.liveState !== null || isHistoricalActivityState(args.entry.state) ? args.entry.state : null
+  if (currentState === null || args.entry.sessionBoundary === true) {
     return events
   }
   if (args.entry.stateStartedAt <= args.clearedAt) {
     return events
   }
-  append(args.entry.state, args.entry.stateStartedAt, args.entry)
+  append(currentState, args.entry.stateStartedAt, args.entry)
   return events
 }

--- a/src/renderer/src/components/activity/activity-pane-events.ts
+++ b/src/renderer/src/components/activity/activity-pane-events.ts
@@ -97,8 +97,11 @@ export function buildPaneActivityEvents(args: PaneEventInputs): ActivityEvent[] 
     )
   }
 
+  // Monitoring live turns surface only via the 'monitoring' snapshot, never as a working event.
   const currentState =
-    args.liveState !== null || isHistoricalActivityState(args.entry.state) ? args.entry.state : null
+    args.liveState === 'working' || isHistoricalActivityState(args.entry.state)
+      ? args.entry.state
+      : null
   if (currentState === null || args.entry.sessionBoundary === true) {
     return events
   }

--- a/src/renderer/src/components/activity/activity-pane-events.ts
+++ b/src/renderer/src/components/activity/activity-pane-events.ts
@@ -1,3 +1,4 @@
+import { isHistoricalActivityState } from './activity-event-state'
 import type {
   AgentStateHistoryEntry,
   AgentStatusEntry
@@ -11,12 +12,6 @@ import type {
   ActivityLiveAgentState
 } from './activity-thread-types'
 import { EVENTS_PER_PANE_CAP } from './activity-event-cap'
-
-function isHistoricalActivityState(
-  state: string
-): state is Extract<ActivityEventState, 'done' | 'blocked' | 'waiting'> {
-  return state === 'done' || state === 'blocked' || state === 'waiting'
-}
 
 function historyEntrySnapshot(
   entry: AgentStatusEntry,

--- a/src/renderer/src/components/activity/activity-prototype-page-exports.ts
+++ b/src/renderer/src/components/activity/activity-prototype-page-exports.ts
@@ -6,7 +6,6 @@ export {
   activityThreadMatchesSearchQuery,
   buildActivityThreadGroups,
   getActivityThreadGroup,
-  groupActivityThreadsByStatus,
   isActivitySearchQueryTooLarge
 } from './activity-thread-grouping'
 export {

--- a/src/renderer/src/components/activity/activity-thread-grouping.status-order.test.ts
+++ b/src/renderer/src/components/activity/activity-thread-grouping.status-order.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { buildActivityThreadGroups, getActivityThreadGroup } from './activity-thread-grouping'
+import { threadAgentState } from './activity-thread-presentation'
+import type { AgentPaneThread } from './activity-thread-types'
+import {
+  makeRepo,
+  makeTabWithIds,
+  makeThreads,
+  makeWorktree,
+  PANE_KEY,
+  PANE_KEY_2,
+  PANE_KEY_3
+} from './ActivityPrototypePage-test-fixtures'
+import { buildActivityEvents } from './activity-event-builder'
+
+type StatusFixture = { paneKey: string; state: AgentStatusEntry['state']; at: number }
+
+function makeStatusThreads(fixtures: StatusFixture[]): AgentPaneThread[] {
+  const repo = makeRepo()
+  const worktree = makeWorktree()
+  const tabs = fixtures.map((_fixture, index) => makeTabWithIds(`tab-${index + 1}`, worktree.id))
+  const agentStatusByPaneKey = Object.fromEntries(
+    fixtures.map((fixture) => [
+      fixture.paneKey,
+      {
+        state: fixture.state,
+        prompt: 'Prompt',
+        updatedAt: fixture.at,
+        stateStartedAt: fixture.at,
+        paneKey: fixture.paneKey,
+        terminalTitle: 'Claude',
+        stateHistory: [],
+        agentType: 'claude'
+      } satisfies AgentStatusEntry
+    ])
+  )
+  return makeThreads(
+    buildActivityEvents({
+      agentStatusByPaneKey,
+      retainedAgentsByPaneKey: {},
+      tabsByWorktree: { [worktree.id]: tabs },
+      worktreeMap: new Map([[worktree.id, worktree]]),
+      repoMap: new Map([[repo.id, repo]]),
+      acknowledgedAgentsByPaneKey: {},
+      now: Math.max(...fixtures.map((fixture) => fixture.at))
+    })
+  )
+}
+
+describe('status group order', () => {
+  it('ranks Working above Done even when the Done thread is newer', () => {
+    const threads = makeStatusThreads([
+      { paneKey: PANE_KEY, state: 'working', at: 1_000 },
+      { paneKey: PANE_KEY_2, state: 'done', at: 5_000 }
+    ])
+    expect(threads.map((thread) => thread.paneKey)).toEqual([PANE_KEY_2, PANE_KEY])
+
+    const groups = buildActivityThreadGroups(threads, 'status')
+
+    expect(groups.map((group) => group.key)).toEqual(['working', 'done'])
+  })
+
+  it('keeps attention headers in a fixed order regardless of thread recency', () => {
+    const newerBlocked = buildActivityThreadGroups(
+      makeStatusThreads([
+        { paneKey: PANE_KEY, state: 'waiting', at: 1_000 },
+        { paneKey: PANE_KEY_2, state: 'blocked', at: 5_000 }
+      ]),
+      'status'
+    )
+    const newerWaiting = buildActivityThreadGroups(
+      makeStatusThreads([
+        { paneKey: PANE_KEY, state: 'waiting', at: 5_000 },
+        { paneKey: PANE_KEY_2, state: 'blocked', at: 1_000 }
+      ]),
+      'status'
+    )
+
+    expect(newerBlocked.map((group) => group.key)).toEqual(['waiting', 'blocked'])
+    expect(newerWaiting.map((group) => group.key)).toEqual(['waiting', 'blocked'])
+  })
+
+  it('keeps newest-first thread order inside each group', () => {
+    const groups = buildActivityThreadGroups(
+      makeStatusThreads([
+        { paneKey: PANE_KEY, state: 'done', at: 1_000 },
+        { paneKey: PANE_KEY_2, state: 'working', at: 2_000 },
+        { paneKey: PANE_KEY_3, state: 'done', at: 3_000 }
+      ]),
+      'status'
+    )
+
+    expect(groups.map((group) => group.key)).toEqual(['working', 'done'])
+    expect(groups[1].threads.map((thread) => thread.paneKey)).toEqual([PANE_KEY_3, PANE_KEY])
+  })
+
+  it('gives every status group a header state equal to its rows', () => {
+    const groups = buildActivityThreadGroups(
+      makeStatusThreads([
+        { paneKey: PANE_KEY, state: 'blocked', at: 1_000 },
+        { paneKey: PANE_KEY_2, state: 'working', at: 2_000 },
+        { paneKey: PANE_KEY_3, state: 'done', at: 3_000 }
+      ]),
+      'status'
+    )
+
+    expect(groups.map((group) => group.state)).toEqual(['blocked', 'working', 'done'])
+    for (const group of groups) {
+      for (const thread of group.threads) {
+        expect(threadAgentState(thread)).toBe(group.state)
+      }
+    }
+  })
+
+  it('does not rank or set a header state outside status mode', () => {
+    const threads = makeStatusThreads([
+      { paneKey: PANE_KEY, state: 'working', at: 1_000 },
+      { paneKey: PANE_KEY_2, state: 'done', at: 5_000 }
+    ])
+
+    for (const groupBy of ['project', 'worktree', 'agent'] as const) {
+      const groups = buildActivityThreadGroups(threads, groupBy)
+      expect(groups[0].state).toBeUndefined()
+      expect(groups[0].threads.map((thread) => thread.paneKey)).toEqual([PANE_KEY_2, PANE_KEY])
+      expect(getActivityThreadGroup(threads[0], groupBy).state).toBeUndefined()
+    }
+  })
+})

--- a/src/renderer/src/components/activity/activity-thread-grouping.ts
+++ b/src/renderer/src/components/activity/activity-thread-grouping.ts
@@ -1,46 +1,53 @@
-import { agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
+import type { AgentDotState } from '@/components/AgentStateDot'
 import { translate } from '@/i18n/i18n'
 import { formatAgentTypeLabel } from '@/lib/agent-status'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { getActivityThreadWorkspaceTitle } from '@/lib/activity-thread-display'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
 import {
+  activityThreadStatusId,
   agentMeta,
   agentSummary,
   agentTitle,
   threadAgentState,
-  threadAgentStateLabel
+  threadAgentStateLabel,
+  type ActivityThreadStatusId
 } from './activity-thread-presentation'
-import type {
-  ActivityGroupBy,
-  ActivityStatusGroupId,
-  ActivityThreadGroup,
-  AgentPaneThread
-} from './activity-thread-types'
+import type { ActivityGroupBy, ActivityThreadGroup, AgentPaneThread } from './activity-thread-types'
 
-// Attention-needing groups first (interrupted included: it's stopped and awaiting the user) so they're never buried under Working/Done.
-const ACTIVITY_STATUS_GROUP_ORDER: ActivityStatusGroupId[] = [
-  'waiting',
-  'blocked',
-  'interrupted',
-  'working',
-  'monitoring',
-  'done'
-]
+// Attention-first. Exhaustive Record so an unranked dot state is a type error; ranks are
+// unique so header order never falls back to thread recency.
+const ACTIVITY_STATUS_GROUP_RANK: Record<ActivityThreadStatusId, number> = {
+  waiting: 0,
+  blocked: 1,
+  permission: 2,
+  interrupted: 3,
+  working: 4,
+  monitoring: 5,
+  unverifiable: 6,
+  failed: 7,
+  done: 8,
+  idle: 9
+}
+
+function activityStatusRank(thread: AgentPaneThread): number {
+  return ACTIVITY_STATUS_GROUP_RANK[activityThreadStatusId(thread)]
+}
 
 export function getActivityThreadGroup(
   thread: AgentPaneThread,
   groupBy: ActivityGroupBy
-): { key: string; label: string } {
+): { key: string; label: string; state?: AgentDotState } {
   if (groupBy === 'none') {
     return { key: 'all', label: '' }
   }
   if (groupBy === 'status') {
-    const state = threadAgentState(thread)
-    if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
-      return { key: 'done:interrupted', label: threadAgentStateLabel(thread) }
+    // Header dot mirrors the row dot, so the two can never disagree.
+    return {
+      key: activityThreadStatusId(thread),
+      label: threadAgentStateLabel(thread),
+      state: threadAgentState(thread)
     }
-    return { key: state, label: threadAgentStateLabel(thread) }
   }
   if (groupBy === 'project') {
     return thread.repo
@@ -72,57 +79,16 @@ export function buildActivityThreadGroups(
     const group = getActivityThreadGroup(thread, groupBy)
     const existingIndex = groupIndexByKey.get(group.key)
     if (existingIndex === undefined) {
-      groups.push({ key: group.key, label: group.label, threads: [thread] })
+      groups.push({ ...group, threads: [thread] })
       groupIndexByKey.set(group.key, groups.length - 1)
       continue
     }
     groups[existingIndex].threads.push(thread)
   }
-  return groups
-}
-
-export function threadStatusGroupId(thread: AgentPaneThread): ActivityStatusGroupId {
-  const state = threadAgentState(thread)
-  if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
-    return 'interrupted'
+  if (groupBy !== 'status') {
+    return groups
   }
-  return state === 'working' || state === 'monitoring' || state === 'blocked' || state === 'waiting'
-    ? state
-    : 'done'
-}
-
-function threadStatusGroupState(id: ActivityStatusGroupId): AgentDotState {
-  return id === 'interrupted' ? 'done' : id
-}
-
-function threadStatusGroupLabel(id: ActivityStatusGroupId): string {
-  if (id === 'interrupted') {
-    return 'Interrupted'
-  }
-  return agentStateLabel(threadStatusGroupState(id))
-}
-
-export function groupActivityThreadsByStatus(threads: AgentPaneThread[]): ActivityThreadGroup[] {
-  const groups = new Map<ActivityStatusGroupId, AgentPaneThread[]>()
-  for (const thread of threads) {
-    const groupId = threadStatusGroupId(thread)
-    groups.set(groupId, [...(groups.get(groupId) ?? []), thread])
-  }
-  return ACTIVITY_STATUS_GROUP_ORDER.flatMap((id) => {
-    const groupThreads = groups.get(id) ?? []
-    if (groupThreads.length === 0) {
-      return []
-    }
-    return [
-      {
-        key: id,
-        id,
-        label: threadStatusGroupLabel(id),
-        state: threadStatusGroupState(id),
-        threads: groupThreads
-      }
-    ]
-  })
+  return groups.sort((a, b) => activityStatusRank(a.threads[0]) - activityStatusRank(b.threads[0]))
 }
 
 function buildThreadSearchText(thread: AgentPaneThread): string {

--- a/src/renderer/src/components/activity/activity-thread-presentation.ts
+++ b/src/renderer/src/components/activity/activity-thread-presentation.ts
@@ -59,6 +59,9 @@ export function activityThreadResponseRenderPreview({
 }
 
 export function agentTitle(event: ActivityEvent): string {
+  if (event.state === 'working') {
+    return 'Agent working'
+  }
   if (event.state === 'done') {
     return event.entry.interrupted ? 'Agent interrupted' : 'Agent finished'
   }
@@ -67,6 +70,9 @@ export function agentTitle(event: ActivityEvent): string {
 
 export function agentSummary(event: ActivityEvent): string {
   const prompt = getAgentRowPrimaryText(event.entry)
+  if (event.state === 'working') {
+    return prompt || 'The agent is working on the current turn.'
+  }
   if (event.state === 'done') {
     const message = event.entry.lastAssistantMessage?.trim()
     return message || prompt || 'Completed the current turn.'
@@ -76,6 +82,9 @@ export function agentSummary(event: ActivityEvent): string {
 
 export function agentMeta(event: ActivityEvent): string {
   const agent = formatAgentTypeLabel(event.agentType)
+  if (event.state === 'working') {
+    return `${agent} ${event.state}`
+  }
   if (event.state === 'done') {
     return event.entry.interrupted ? `${agent} interrupted` : `${agent} completed`
   }

--- a/src/renderer/src/components/activity/activity-thread-presentation.ts
+++ b/src/renderer/src/components/activity/activity-thread-presentation.ts
@@ -103,18 +103,28 @@ export function statusPreviewForEntry(
   return resolveActivityThreadStatusPreview(entry, agentState, previousPreview)
 }
 
+export type ActivityThreadStatusId = AgentDotState
+
+/** Single classifier behind grouping, labels, and clear-completed; the only place the
+ *  interrupted predicate is spelled. */
+export function activityThreadStatusId(thread: AgentPaneThread): ActivityThreadStatusId {
+  const state = thread.currentAgentState ?? thread.latestEvent?.state ?? 'done'
+  if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
+    return 'interrupted'
+  }
+  return state
+}
+
+// Interrupted rows deliberately keep the done glyph (#2569).
 export function threadAgentState(thread: AgentPaneThread): AgentDotState {
-  return thread.currentAgentState ?? thread.latestEvent?.state ?? 'done'
+  const id = activityThreadStatusId(thread)
+  return id === 'interrupted' ? 'done' : id
 }
 
 export function threadAgentStateLabel(thread: AgentPaneThread): string {
-  const state = threadAgentState(thread)
-  if (!thread.currentAgentState && state === 'done' && thread.latestEvent?.entry.interrupted) {
-    return translate('auto.components.activity.ActivityPrototypePage.interrupted', 'Interrupted')
-  }
   // Literal keys with literal fallbacks: a dynamic key registers no catalog reference
   // and forces every state string into the boot bundle.
-  switch (state) {
+  switch (activityThreadStatusId(thread)) {
     case 'working':
       return translate('auto.components.activity.ActivityPrototypePage.state.working', 'Working')
     case 'monitoring':

--- a/src/renderer/src/components/activity/activity-thread-types.ts
+++ b/src/renderer/src/components/activity/activity-thread-types.ts
@@ -17,14 +17,6 @@ export type ActivityHookLiveAgentState = Extract<
   'working' | 'blocked' | 'waiting'
 >
 export type ActivityLiveAgentState = ActivityHookLiveAgentState | 'monitoring'
-export type ActivityStatusGroupId =
-  | 'working'
-  | 'monitoring'
-  | 'blocked'
-  | 'waiting'
-  | 'done'
-  | 'interrupted'
-
 export type ActivityEvent = {
   id: string
   state: ActivityEventState
@@ -69,7 +61,6 @@ export type AgentPaneThread = {
 
 export type ActivityThreadGroup = {
   key: string
-  id?: ActivityStatusGroupId
   label: string
   state?: AgentDotState
   threads: AgentPaneThread[]

--- a/src/renderer/src/components/activity/activity-thread-types.ts
+++ b/src/renderer/src/components/activity/activity-thread-types.ts
@@ -11,7 +11,7 @@ import type { ActivityPortalReadinessStatus } from './activity-portal-readiness-
 
 export type { ActivityGroupBy, ThreadReadFilter } from '../../../../shared/ui-chrome-types'
 
-export type ActivityEventState = Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
+export type ActivityEventState = AgentStatusState
 export type ActivityHookLiveAgentState = Extract<
   AgentStatusState,
   'working' | 'blocked' | 'waiting'

--- a/src/renderer/src/components/activity/useActivityUnreadCount.freshness.test.tsx
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.freshness.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
+
+vi.mock('@/store', () => ({
+  useAppStore: create(() => ({
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    acknowledgedAgentsByPaneKey: {},
+    activityClearedAtByPaneKey: {},
+    migrationUnsupportedByPtyId: {},
+    retainedAgentsByPaneKey: {}
+  }))
+}))
+
+import { useAppStore } from '@/store'
+import { useActivityUnreadCount } from './useActivityUnreadCount'
+
+const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+
+afterEach(() => vi.useRealTimers())
+
+describe('useActivityUnreadCount freshness invalidation', () => {
+  it('decays on the status epoch and revives on a heartbeat without an epoch change', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(2_000)
+    const entry: AgentStatusEntry = {
+      paneKey,
+      state: 'working',
+      prompt: '',
+      updatedAt: 2_000,
+      stateStartedAt: 2_000,
+      stateHistory: [],
+      agentType: 'claude'
+    }
+    useAppStore.setState({ agentStatusByPaneKey: { [paneKey]: entry }, agentStatusEpoch: 1 })
+    const hook = renderHook(() => useActivityUnreadCount())
+    expect(hook.result.current).toBe(1)
+    const expiredAt = 2_001 + AGENT_STATUS_STALE_AFTER_MS
+    act(() => {
+      vi.setSystemTime(expiredAt)
+      useAppStore.setState({ agentStatusEpoch: 2 })
+    })
+    expect(hook.result.current).toBe(0)
+    act(() => {
+      useAppStore.setState({
+        agentStatusByPaneKey: { [paneKey]: { ...entry, updatedAt: expiredAt } }
+      })
+    })
+    expect(hook.result.current).toBe(1)
+    hook.unmount()
+  })
+})

--- a/src/renderer/src/components/activity/useActivityUnreadCount.freshness.test.tsx
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.freshness.test.tsx
@@ -1,58 +1,81 @@
 // @vitest-environment happy-dom
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { create } from 'zustand'
-import {
-  AGENT_STATUS_STALE_AFTER_MS,
-  type AgentStatusEntry
-} from '../../../../shared/agent-status-types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
 
-vi.mock('@/store', () => ({
-  useAppStore: create(() => ({
-    agentStatusByPaneKey: {},
-    agentStatusEpoch: 0,
-    acknowledgedAgentsByPaneKey: {},
-    activityClearedAtByPaneKey: {},
-    migrationUnsupportedByPtyId: {},
-    retainedAgentsByPaneKey: {}
-  }))
-}))
+// Real slice, not a hand-rolled store: the hook subscribes to agentStatusEpoch alone, so the
+// test must prove the reducer bumps that epoch for every transition the count depends on.
+vi.mock('@/store', async () => {
+  const { createTestStore } = await import('@/store/slices/store-test-helpers')
+  return { useAppStore: createTestStore() }
+})
 
 import { useAppStore } from '@/store'
+import { flushMicrotasks } from '@/store/slices/agent-status-test-harness'
 import { useActivityUnreadCount } from './useActivityUnreadCount'
 
-const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+const PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+const START = 2_000
 
-afterEach(() => vi.useRealTimers())
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(START)
+})
+afterEach(() => {
+  useAppStore.getState().removeAgentStatus(PANE_KEY)
+  vi.useRealTimers()
+})
+
+function setWorking(updatedAt: number): void {
+  useAppStore
+    .getState()
+    .setAgentStatus(
+      PANE_KEY,
+      { state: 'working', prompt: 'Fix tests', agentType: 'claude' },
+      undefined,
+      { updatedAt, evidenceObservedAt: updatedAt }
+    )
+}
 
 describe('useActivityUnreadCount freshness invalidation', () => {
-  it('decays on the status epoch and revives on a heartbeat without an epoch change', () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(2_000)
-    const entry: AgentStatusEntry = {
-      paneKey,
-      state: 'working',
-      prompt: '',
-      updatedAt: 2_000,
-      stateStartedAt: 2_000,
-      stateHistory: [],
-      agentType: 'claude'
-    }
-    useAppStore.setState({ agentStatusByPaneKey: { [paneKey]: entry }, agentStatusEpoch: 1 })
+  it('ignores same-turn heartbeats, decays at the stale boundary, revives on the next heartbeat', async () => {
+    setWorking(START)
     const hook = renderHook(() => useActivityUnreadCount())
     expect(hook.result.current).toBe(1)
-    const expiredAt = 2_001 + AGENT_STATUS_STALE_AFTER_MS
+    const epochAfterStart = useAppStore.getState().agentStatusEpoch
+
+    // Fresh same-turn heartbeat: no epoch bump, count unchanged.
     act(() => {
-      vi.setSystemTime(expiredAt)
-      useAppStore.setState({ agentStatusEpoch: 2 })
+      vi.setSystemTime(START + 1_000)
+      setWorking(START + 1_000)
+    })
+    expect(useAppStore.getState().agentStatusEpoch).toBe(epochAfterStart)
+    expect(hook.result.current).toBe(1)
+
+    // Freshness scheduler bumps the epoch at the stale boundary; the count decays with no write.
+    await act(async () => {
+      await flushMicrotasks()
+      vi.advanceTimersByTime(AGENT_STATUS_STALE_AFTER_MS + 1)
+    })
+    expect(hook.result.current).toBe(0)
+
+    // A heartbeat on a stale entry is sort-relevant, so the reducer bumps the epoch and revives it.
+    const revivedAt = Date.now()
+    act(() => {
+      setWorking(revivedAt)
+    })
+    expect(hook.result.current).toBe(1)
+
+    // Reading it holds across further heartbeats.
+    act(() => {
+      useAppStore.getState().acknowledgeAgents([PANE_KEY])
     })
     expect(hook.result.current).toBe(0)
     act(() => {
-      useAppStore.setState({
-        agentStatusByPaneKey: { [paneKey]: { ...entry, updatedAt: expiredAt } }
-      })
+      vi.setSystemTime(revivedAt + 1_000)
+      setWorking(revivedAt + 1_000)
     })
-    expect(hook.result.current).toBe(1)
+    expect(hook.result.current).toBe(0)
     hook.unmount()
   })
 })

--- a/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStatusEntry
+} from '../../../../shared/agent-status-types'
 import { countActivityUnread } from './useActivityUnreadCount'
 
 const PANE = 'tab-1:11111111-1111-4111-8111-111111111111'
@@ -107,5 +110,57 @@ describe('countActivityUnread source overlap', () => {
       migrationUnsupportedByPtyId: {}
     }
     expect(countActivityUnread(source)).toBe(1)
+  })
+})
+
+describe('countActivityUnread working turns', () => {
+  it('counts fresh working and monitoring, but not historical or retained working', () => {
+    const entry = makeEntry({
+      state: 'working',
+      stateHistory: [{ state: 'working', prompt: 'old', startedAt: 1_000 }]
+    })
+    expect(countActivityUnread(makeSource(entry), 2_000)).toBe(1)
+    expect(countActivityUnread(makeSource({ ...entry, workingMode: 'monitoring' }), 2_000)).toBe(1)
+    expect(
+      countActivityUnread(
+        {
+          ...makeSource(entry),
+          agentStatusByPaneKey: {},
+          retainedAgentsByPaneKey: {
+            [PANE]: {
+              entry,
+              worktreeId: 'wt-1',
+              tab: {} as never,
+              agentType: 'claude',
+              startedAt: 1_000
+            }
+          }
+        },
+        2_000
+      )
+    ).toBe(0)
+  })
+
+  it('preserves receipts across heartbeats and counts the next turn', () => {
+    const entry = makeEntry({ state: 'working', updatedAt: 3_000 })
+    expect(countActivityUnread(makeSource(entry, 2_000), 3_000)).toBe(0)
+    expect(countActivityUnread(makeSource({ ...entry, stateStartedAt: 3_000 }, 2_000), 3_000)).toBe(
+      1
+    )
+    expect(
+      countActivityUnread(
+        { ...makeSource(entry), activityClearedAtByPaneKey: { [PANE]: 2_000 } },
+        3_000
+      )
+    ).toBe(0)
+  })
+
+  it('drops stale or unconfirmed working and revives only on fresh evidence', () => {
+    const entry = makeEntry({ state: 'working' })
+    expect(countActivityUnread(makeSource(entry), 2_000 + AGENT_STATUS_STALE_AFTER_MS)).toBe(1)
+    const expiredAt = 2_001 + AGENT_STATUS_STALE_AFTER_MS
+    expect(countActivityUnread(makeSource(entry), expiredAt)).toBe(0)
+    expect(countActivityUnread(makeSource({ ...entry, updatedAt: expiredAt }), expiredAt)).toBe(1)
+    expect(countActivityUnread(makeSource({ ...entry, restoredUnconfirmed: true }), 2_000)).toBe(0)
   })
 })

--- a/src/renderer/src/components/activity/useActivityUnreadCount.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.ts
@@ -75,15 +75,15 @@ export function countActivityUnread(source: ActivityUnreadCountSource, now = Dat
 export function useActivityUnreadCount(): number {
   const {
     agentStatusEpoch,
-    agentStatusByPaneKey,
     migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey,
     acknowledgedAgentsByPaneKey,
     activityClearedAtByPaneKey
   } = useAppStore(
     useShallow((state) => ({
-      // Heartbeats can revive working activity without a state transition.
-      agentStatusByPaneKey: state.agentStatusByPaneKey,
+      // Why not the status map: the receipt is keyed on stateStartedAt, so same-turn heartbeats
+      // cannot change the count. The live reducer bumps this epoch on state/turn changes and when
+      // a stale entry revives; the freshness scheduler bumps it at the stale boundary.
       agentStatusEpoch: state.agentStatusEpoch,
       migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
       retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
@@ -95,7 +95,7 @@ export function useActivityUnreadCount(): number {
   return useMemo(() => {
     void agentStatusEpoch
     return countActivityUnread({
-      agentStatusByPaneKey,
+      agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
       migrationUnsupportedByPtyId,
       retainedAgentsByPaneKey,
       acknowledgedAgentsByPaneKey,
@@ -106,7 +106,6 @@ export function useActivityUnreadCount(): number {
     activityClearedAtByPaneKey,
     migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey,
-    agentStatusEpoch,
-    agentStatusByPaneKey
+    agentStatusEpoch
   ])
 }

--- a/src/renderer/src/components/activity/useActivityUnreadCount.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.ts
@@ -4,7 +4,9 @@ import { useShallow } from 'zustand/react/shallow'
 import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
-import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+
+import { freshActivityLiveAgentState, isHistoricalActivityState } from './activity-event-state'
 
 type ActivityUnreadCountSource = Pick<
   AppState,
@@ -17,18 +19,14 @@ type ActivityUnreadCountSource = Pick<
   activityClearedAtByPaneKey?: Record<string, number>
 }
 
-function isUnreadAgentState(state: AgentStatusState): boolean {
-  return state === 'done' || state === 'blocked' || state === 'waiting'
-}
-
-/** Counts unread done/blocked/waiting events for the Activity page titlebar badge. */
-export function countActivityUnread(source: ActivityUnreadCountSource): number {
+/** Counts unread historical activity and fresh current turns. */
+export function countActivityUnread(source: ActivityUnreadCountSource, now = Date.now()): number {
   let count = 0
   const seenPaneKeys = new Set<string>()
 
   // Why no worktree.isUnread here: Activity lists only agent threads, so a worktree
   // unread would light a badge with no row to read and no way to clear it.
-  const countEntry = (entry: AgentStatusEntry, ackAt: number): void => {
+  const countEntry = (entry: AgentStatusEntry, ackAt: number, live = false): void => {
     // Why: "Clear completed" hides events at or before the pane's cutoff from the feed,
     // so a hidden event must not keep the badge lit; treat the cutoff like an ack floor.
     const clearedAt = source.activityClearedAtByPaneKey?.[entry.paneKey] ?? 0
@@ -36,13 +34,14 @@ export function countActivityUnread(source: ActivityUnreadCountSource): number {
     // Why: Activity feed surfaces historical done/blocked/waiting events
     // from stateHistory, so the titlebar badge must mirror that event count.
     for (const history of entry.stateHistory) {
-      if (isUnreadAgentState(history.state) && mutedAt < history.startedAt) {
+      if (isHistoricalActivityState(history.state) && mutedAt < history.startedAt) {
         count += 1
       }
     }
     // Why: a session-boundary done is an idle connect (STA-3386), not an event to read.
     if (
-      isUnreadAgentState(entry.state) &&
+      (isHistoricalActivityState(entry.state) ||
+        (live && freshActivityLiveAgentState(entry, now) !== null)) &&
       entry.sessionBoundary !== true &&
       mutedAt < entry.stateStartedAt
     ) {
@@ -52,7 +51,7 @@ export function countActivityUnread(source: ActivityUnreadCountSource): number {
 
   for (const [paneKey, entry] of Object.entries(source.agentStatusByPaneKey)) {
     seenPaneKeys.add(paneKey)
-    countEntry(entry, source.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
+    countEntry(entry, source.acknowledgedAgentsByPaneKey[paneKey] ?? 0, true)
   }
   for (const [paneKey, retained] of Object.entries(source.retainedAgentsByPaneKey)) {
     // Live status is the primary source; retained is a handoff cache and may briefly overlap it.
@@ -75,17 +74,17 @@ export function countActivityUnread(source: ActivityUnreadCountSource): number {
 
 export function useActivityUnreadCount(): number {
   const {
-    sortEpoch,
+    agentStatusEpoch,
+    agentStatusByPaneKey,
     migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey,
     acknowledgedAgentsByPaneKey,
     activityClearedAtByPaneKey
   } = useAppStore(
     useShallow((state) => ({
-      // Why: live status prompt/tool updates churn agentStatusByPaneKey but
-      // cannot change unread count unless a sort-relevant state transition
-      // or removal occurred. sortEpoch is the cheap invalidation signal.
-      sortEpoch: state.sortEpoch,
+      // Heartbeats can revive working activity without a state transition.
+      agentStatusByPaneKey: state.agentStatusByPaneKey,
+      agentStatusEpoch: state.agentStatusEpoch,
       migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
       retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
       acknowledgedAgentsByPaneKey: state.acknowledgedAgentsByPaneKey,
@@ -94,9 +93,9 @@ export function useActivityUnreadCount(): number {
   )
 
   return useMemo(() => {
-    void sortEpoch
+    void agentStatusEpoch
     return countActivityUnread({
-      agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+      agentStatusByPaneKey,
       migrationUnsupportedByPtyId,
       retainedAgentsByPaneKey,
       acknowledgedAgentsByPaneKey,
@@ -107,6 +106,7 @@ export function useActivityUnreadCount(): number {
     activityClearedAtByPaneKey,
     migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey,
-    sortEpoch
+    agentStatusEpoch,
+    agentStatusByPaneKey
   ])
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​395 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​374 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​160 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​165 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 |

<!-- /orca-pr-loc -->

## Problem

The activity view's status group ordering relied on array position, which caused attention-needing statuses (waiting, blocked, interrupted) to be buried under newer Done/Working threads. The interrupted status logic was scattered across multiple functions, making it hard to maintain.

## Solution

Replaced the array-based group order with a numeric ranking system (`ACTIVITY_STATUS_GROUP_RANK`) that assigns consistent priorities regardless of thread recency. Centralized the interrupted predicate into `activityThreadStatusId()` as the single source of truth for status classification. Status group headers now mirror row states to prevent visual disagreement.

## What Changed

- Introduced `activityThreadStatusId()` in `activity-thread-presentation.ts` as the single classifier for all status-related logic
- Replaced `ACTIVITY_STATUS_GROUP_ORDER` array with `ACTIVITY_STATUS_GROUP_RANK` Record for deterministic ordering
- Generalized `buildActivityThreadGroups()` to rank groups only in status mode
- Updated group key from `'done:interrupted'` to `'interrupted'` for clarity
- Added comprehensive status-order test suite with 5 focused test cases

## Visual Proof

N/A — reordering of existing UI elements; no new components or styling changes.

## Testing

- Added `activity-thread-grouping.status-order.test.ts` with comprehensive ordering tests: verifies attention-needing statuses rank above Done even when newer, confirms fixed group order regardless of recency, validates thread order within groups remains newest-first, tests header state consistency
- Updated existing tests in `ActivityPrototypePage.test.ts` and `ActivityPrototypePage.thread-grouping.test.ts` to match new API

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Rank ordering is applied deterministically in status-grouping mode only. Other grouping modes (project, worktree, agent) preserve thread-recency ordering. No platform-specific logic added.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)