### PR TITLE
Stabilize scrollbar gutter to prevent message list layout shift

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -342,7 +342,7 @@ export function NativeChatMessageList({
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="scrollbar-sleek h-full overflow-y-auto [scrollbar-gutter:stable] pr-3 pl-[calc(theme(spacing.3)+12px)] pt-10 pb-4 sm:pr-4 sm:pl-[calc(theme(spacing.4)+12px)]"
+        className="scrollbar-sleek h-full overflow-y-auto [scrollbar-gutter:stable_both-edges] px-3 pt-10 pb-4 sm:px-4"
       >
         <div
           ref={contentRef}

--- a/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatMessageList.tsx
@@ -342,13 +342,13 @@ export function NativeChatMessageList({
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="scrollbar-sleek h-full overflow-y-auto px-3 pt-10 pb-4 sm:px-4"
+        className="scrollbar-sleek h-full overflow-y-auto [scrollbar-gutter:stable] pr-3 pl-[calc(theme(spacing.3)+12px)] pt-10 pb-4 sm:pr-4 sm:pl-[calc(theme(spacing.4)+12px)]"
       >
         <div
           ref={contentRef}
-          // Why: same max width as the composer column; horizontal inset comes
-          // from the scroll container so content aligns with the composer field.
-          className="mx-auto flex w-full max-w-4xl flex-col gap-5"
+          // Why: matches composer column (max-w-4xl) with 5px horizontal inset
+          // on each side so content is slightly narrower than the input box.
+          className="mx-auto flex w-full max-w-4xl flex-col gap-5 px-[5px]"
           // Why: `zoom` scales the chat transcript's text and layout together,
           // scoped to this container so the rest of the app is untouched. It's
           // the desktop analog of the mobile pinch-zoom (Chromium/Electron only).


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | 0 |

<!-- /orca-pr-loc -->

## Problem

The native chat message list experiences layout shift when the scrollbar appears and disappears, causing content to reflow horizontally. This happens because the scrollbar takes up space, changing the available width.

## Solution

Use CSS `scrollbar-gutter: stable` to reserve scrollbar space consistently, preventing layout shifts. Adjust padding to account for the reserved space while maintaining alignment with the composer field.

## ELI5

When scrolling messages, the scrollbar appears/disappears on the right, making text shift left and right. We now reserve that space always, so nothing moves.

## What Changed

- Added `[scrollbar-gutter:stable]` to scroll container to reserve scrollbar space
- Updated padding from `px-3/sm:px-4` to `pr-3/pl-[calc(theme(spacing.3)+12px)]` and responsive `sm:pr-4/sm:pl-[calc(theme(spacing.4)+12px)]` to account for gutter
- Added `px-[5px]` horizontal inset to message content for slight narrowing vs. composer width
- Clarified layout comments

## Why

Layout shifts harm UX and break selections. `scrollbar-gutter: stable` is the modern CSS standard for this problem.

## Linked Issue

N/A

## Visual Proof

TODO: Add before/after video showing scrolling behavior without layout shift

## Testing

- [ ] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [ ] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md`

## Notes

CSS change only; no platform, SSH, or compatibility impact.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)