### PR TITLE
fix(wsl): tree-kill timed-out wsl.exe probes on the execFile path

### DIFF
--- a/src/main/wsl-distro-list-single-flight.test.ts
+++ b/src/main/wsl-distro-list-single-flight.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as childProcess from 'node:child_process'
 
-const { execFileMock, execFileSyncMock } = vi.hoisted(() => ({
-  execFileMock: vi.fn(),
+const { execFileSyncMock } = vi.hoisted(() => ({
   execFileSyncMock: vi.fn()
 }))
 
@@ -10,10 +9,12 @@ vi.mock('child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof childProcess>()
   return {
     ...actual,
-    execFile: execFileMock,
     execFileSync: execFileSyncMock
   }
 })
+
+const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
+vi.mock('../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
 
 import {
   _resetWslCachesForTests,
@@ -21,6 +22,11 @@ import {
   listWslDistros,
   listWslDistrosAsync
 } from './wsl'
+
+/** Default success shape from the async migration: exit 0, no timeout. */
+function ok(stdout: string): unknown {
+  return { code: 0, signal: null, stdout, stderr: '', timedOut: false }
+}
 
 // Why a dedicated file: `listWslDistrosAsync` is single-flighted, so these all turn on how a
 // pending probe interacts with the synchronous twin, the cache and the retry window.
@@ -34,7 +40,7 @@ describe('WSL distro list single-flight', () => {
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
-    execFileMock.mockReset()
+    runProcessMock.mockReset()
     execFileSyncMock.mockReset()
     _resetWslCachesForTests()
   })
@@ -43,12 +49,15 @@ describe('WSL distro list single-flight', () => {
   // result lands. One host-wide answer should cost one physical wsl.exe spawn.
   it('single-flights concurrent asynchronous discovery', async () => {
     let finishProbe: ((output: string) => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      finishProbe = (output) => callback(null, output)
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishProbe = (output) => resolve(ok(output))
+        })
+    )
 
     const pending = [listWslDistrosAsync(), listWslDistrosAsync(), listWslDistrosAsync()]
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(runProcessMock).toHaveBeenCalledTimes(1)
     finishProbe?.('Ubuntu\n')
 
     await expect(Promise.all(pending)).resolves.toEqual([['Ubuntu'], ['Ubuntu'], ['Ubuntu']])
@@ -58,26 +67,27 @@ describe('WSL distro list single-flight', () => {
   it('single-flights a concurrent empty result without hiding a distro installed later', async () => {
     vi.useFakeTimers()
     let finishProbe: ((output: string) => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      finishProbe = (output) => callback(null, output)
-    })
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      callback(null, 'Ubuntu\n')
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishProbe = (output) => resolve(ok(output))
+        })
+    )
+    runProcessMock.mockImplementationOnce(async () => ok('Ubuntu\n'))
 
     try {
       const pending = [listWslDistrosAsync(), listWslDistrosAsync(), listWslDistrosAsync()]
-      expect(execFileMock).toHaveBeenCalledTimes(1)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
       finishProbe?.('')
       await expect(Promise.all(pending)).resolves.toEqual([[], [], []])
 
       // One shared empty answer arms one 15s window, not three doublings.
       vi.advanceTimersByTime(14_999)
       await expect(listWslDistrosAsync()).resolves.toEqual([])
-      expect(execFileMock).toHaveBeenCalledTimes(1)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
       vi.advanceTimersByTime(1)
       await expect(listWslDistrosAsync()).resolves.toEqual(['Ubuntu'])
-      expect(execFileMock).toHaveBeenCalledTimes(2)
+      expect(runProcessMock).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -87,25 +97,26 @@ describe('WSL distro list single-flight', () => {
   it('single-flights a concurrent failure and keeps the retry window bounded', async () => {
     vi.useFakeTimers()
     let failProbe: (() => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      failProbe = () => callback(new Error('transient failure'), '')
-    })
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      callback(null, 'Ubuntu\n')
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          failProbe = () => reject(new Error('transient failure'))
+        })
+    )
+    runProcessMock.mockImplementationOnce(async () => ok('Ubuntu\n'))
 
     try {
       const pending = [listWslDistrosAsync(), listWslDistrosAsync(), listWslDistrosAsync()]
-      expect(execFileMock).toHaveBeenCalledTimes(1)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
       failProbe?.()
       await expect(Promise.all(pending)).resolves.toEqual([[], [], []])
 
       vi.advanceTimersByTime(14_999)
       await expect(listWslDistrosAsync()).resolves.toEqual([])
-      expect(execFileMock).toHaveBeenCalledTimes(1)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
       vi.advanceTimersByTime(1)
       await expect(listWslDistrosAsync()).resolves.toEqual(['Ubuntu'])
-      expect(execFileMock).toHaveBeenCalledTimes(2)
+      expect(runProcessMock).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -116,9 +127,12 @@ describe('WSL distro list single-flight', () => {
   // for the whole window even though the pending probe is about to see the new distro.
   it('lets a caller joining a pending probe see a distro the sync empty result hid', async () => {
     let finishProbe: ((output: string) => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      finishProbe = (output) => callback(null, output)
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishProbe = (output) => resolve(ok(output))
+        })
+    )
     execFileSyncMock.mockReturnValue('')
 
     const pending = listWslDistrosAsync()
@@ -128,21 +142,21 @@ describe('WSL distro list single-flight', () => {
 
     await expect(joined).resolves.toEqual(['Ubuntu'])
     await expect(pending).resolves.toEqual(['Ubuntu'])
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(runProcessMock).toHaveBeenCalledTimes(1)
   })
 
   // Why: joining is only correct while the answer can still improve. A list already found
   // synchronously is lifetime-stable, and waiting on the probe would make an answered
   // question sit out the 5s wsl.exe timeout.
   it('returns a list found synchronously without waiting on the pending probe', async () => {
-    execFileMock.mockImplementationOnce(() => {})
+    runProcessMock.mockImplementationOnce(() => new Promise(() => {}))
     execFileSyncMock.mockReturnValue('Ubuntu\n')
 
     void listWslDistrosAsync()
     expect(listWslDistros()).toEqual(['Ubuntu'])
 
     await expect(listWslDistrosAsync()).resolves.toEqual(['Ubuntu'])
-    expect(execFileMock).toHaveBeenCalledTimes(1)
+    expect(runProcessMock).toHaveBeenCalledTimes(1)
   })
 
   // Synchronous callers stay independent, so the cache sequence guard still has to protect a
@@ -152,9 +166,12 @@ describe('WSL distro list single-flight', () => {
     ['different list', 'Debian\n']
   ])('does not let an older async %s result overwrite a newer sync list', async (_label, late) => {
     let finishProbe: ((output: string) => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      finishProbe = (output) => callback(null, output)
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishProbe = (output) => resolve(ok(output))
+        })
+    )
     execFileSyncMock.mockReturnValue('Ubuntu\n')
 
     const pending = listWslDistrosAsync()
@@ -168,22 +185,25 @@ describe('WSL distro list single-flight', () => {
   // Why: a cache reset retires the pending probe, and the retired one must not clear the
   // slot its successor now owns — that would leak an extra wsl.exe spawn into the next probe.
   it('does not let a probe retired by a cache reset clear the new in-flight slot', async () => {
-    const callbacks: ((error: Error | null, stdout: string) => void)[] = []
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      callbacks.push(callback)
-    })
+    const resolvers: ((output: string) => void)[] = []
+    runProcessMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push((output) => resolve(ok(output)))
+        })
+    )
 
     const retired = listWslDistrosAsync()
     _resetWslCachesForTests()
     const fresh = listWslDistrosAsync()
-    expect(callbacks).toHaveLength(2)
+    expect(resolvers).toHaveLength(2)
 
-    callbacks[0]!(null, '')
+    resolvers[0]!('')
     await expect(retired).resolves.toEqual([])
 
     const joined = listWslDistrosAsync()
-    expect(execFileMock).toHaveBeenCalledTimes(2)
-    callbacks[1]!(null, 'Ubuntu\n')
+    expect(runProcessMock).toHaveBeenCalledTimes(2)
+    resolvers[1]!('Ubuntu\n')
     await expect(Promise.all([fresh, joined])).resolves.toEqual([['Ubuntu'], ['Ubuntu']])
   })
 
@@ -193,9 +213,12 @@ describe('WSL distro list single-flight', () => {
   it('holds the base window when a sync empty result and an async failure overlap', async () => {
     vi.useFakeTimers()
     let failProbe: (() => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      failProbe = () => callback(new Error('transient failure'), '')
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          failProbe = () => reject(new Error('transient failure'))
+        })
+    )
     execFileSyncMock.mockReturnValue('')
 
     try {

--- a/src/main/wsl-exec-utf8.ts
+++ b/src/main/wsl-exec-utf8.ts
@@ -1,0 +1,45 @@
+import { runProcess } from '../shared/child-process/run-process'
+import { resolveWslInteropSpawnCwd } from './wsl-interop-spawn-directory'
+
+/**
+ * Run `wsl.exe` (or any program) to completion and return its stdout, rejecting
+ * on a non-zero exit, a timeout, or a failure to start -- the same contract
+ * `execFile`'s callback gave its callers.
+ *
+ * Why `runProcess` and not `execFile`: without a termination barrier, a timeout
+ * kills only this process's root and leaves whatever holds its console behind
+ * -- the same execFile-timeout defect `runWslProcess` and `probeGuestEnvironment`
+ * were fixed for (see wsl-runner.ts, wsl-guest-environment.ts). `windowsHide`
+ * comes free via run-process.ts's resolveSpawn, fixing the flashed console this
+ * callback-style execFile call never set either.
+ *
+ * Split out of wsl.ts to keep it under the file's line budget.
+ */
+export async function execFileUtf8(
+  command: string,
+  args: string[],
+  env?: NodeJS.ProcessEnv
+): Promise<string> {
+  const result = await runProcess({
+    program: command,
+    args,
+    env,
+    timeoutMs: 5000,
+    cwd: resolveWslInteropSpawnCwd(),
+    terminationBarrier: true
+  })
+  if (result.timedOut) {
+    throw Object.assign(new Error(`${command} timed out`), {
+      code: 'ETIMEDOUT',
+      killed: true,
+      signal: result.signal
+    })
+  }
+  if (result.code !== 0) {
+    throw Object.assign(new Error(`${command} exited with code ${result.code}`), {
+      code: result.code,
+      signal: result.signal
+    })
+  }
+  return result.stdout
+}

--- a/src/main/wsl-running-distros.test.ts
+++ b/src/main/wsl-running-distros.test.ts
@@ -1,12 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type * as childProcess from 'node:child_process'
 
-const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
-
-vi.mock('child_process', async (importOriginal) => ({
-  ...(await importOriginal<typeof childProcess>()),
-  execFile: execFileMock
-}))
+const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
+vi.mock('../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
 
 import {
   _resetWslCachesForTests,
@@ -29,38 +24,44 @@ async function withPlatform<T>(value: NodeJS.Platform, fn: () => Promise<T>): Pr
   }
 }
 
+/** Default success shape from the async migration: exit 0, no timeout. */
+function ok(stdout: string): unknown {
+  return { code: 0, signal: null, stdout, stderr: '', timedOut: false }
+}
+
 describe('running WSL distro discovery', () => {
   afterEach(() => {
-    execFileMock.mockReset()
+    runProcessMock.mockReset()
     _resetWslCachesForTests()
     resetWslTranscriptRunningObserverForTests()
     vi.useRealTimers()
   })
 
   it('lists only running user distros without starting them', async () => {
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      callback(null, 'Ubuntu\u0000\nDocker-Desktop\u0000\n')
-    })
+    runProcessMock.mockImplementation(async () => ok('Ubuntu\u0000\nDocker-Desktop\u0000\n'))
 
     await withPlatform('win32', async () => {
       await expect(listRunningWslDistrosAsync()).resolves.toEqual(['Ubuntu'])
-      expect(execFileMock).toHaveBeenCalledWith(
-        'wsl.exe',
-        ['--list', '--running', '--quiet'],
+      expect(runProcessMock).toHaveBeenCalledWith(
         expect.objectContaining({
+          program: 'wsl.exe',
+          args: ['--list', '--running', '--quiet'],
           env: expect.objectContaining({ WSL_UTF8: '1' }),
-          timeout: 5000,
-          windowsHide: true
-        }),
-        expect.any(Function)
+          timeoutMs: 5000,
+          // Why this matters: without a barrier a timeout here reaps only the
+          // wsl.exe root and leaves whatever holds its console behind -- the
+          // same execFile-timeout defect runWslProcess/probeGuestEnvironment
+          // were fixed for (#19319).
+          terminationBarrier: true
+        })
       )
     })
   })
 
   it('fails closed when running-distro discovery fails', async () => {
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      callback(new Error('wsl unavailable'), '')
-    })
+    runProcessMock.mockRejectedValue(
+      Object.assign(new Error('wsl unavailable'), { code: 'ENOENT' })
+    )
 
     await withPlatform('win32', async () => {
       await expect(listRunningWslDistrosAsync()).resolves.toEqual([])
@@ -68,15 +69,15 @@ describe('running WSL distro discovery', () => {
   })
 
   it('resolves homes only for the running distro set', async () => {
-    execFileMock.mockImplementation((_command, args, _options, callback) => {
-      callback(null, args.includes('--running') ? 'Ubuntu\n' : '/home/ada\n')
-    })
+    runProcessMock.mockImplementation(async (spec: { args: readonly string[] }) =>
+      ok(spec.args.includes('--running') ? 'Ubuntu\n' : '/home/ada\n')
+    )
 
     await withPlatform('win32', async () => {
       await expect(listRunningWslHomeDirsAsync()).resolves.toEqual([
         '\\\\wsl.localhost\\Ubuntu\\home\\ada'
       ])
-      expect(execFileMock.mock.calls.map(([, args]) => args)).toEqual([
+      expect(runProcessMock.mock.calls.map(([spec]) => spec.args)).toEqual([
         ['--list', '--running', '--quiet'],
         ['-d', 'Ubuntu', '--exec', 'bash', '-c', 'echo $HOME']
       ])
@@ -85,9 +86,12 @@ describe('running WSL distro discovery', () => {
 
   it('single-flights concurrent probes without caching the result', async () => {
     let finishProbe: ((output: string) => void) | undefined
-    execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-      finishProbe = (output) => callback(null, output)
-    })
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishProbe = (output) => resolve(ok(output))
+        })
+    )
 
     await withPlatform('win32', async () => {
       const concurrent = [
@@ -95,28 +99,29 @@ describe('running WSL distro discovery', () => {
         listRunningWslDistrosAsync(),
         listRunningWslDistrosAsync()
       ]
-      expect(execFileMock).toHaveBeenCalledTimes(1)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
       finishProbe?.('Ubuntu\n')
       await expect(Promise.all(concurrent)).resolves.toEqual([['Ubuntu'], ['Ubuntu'], ['Ubuntu']])
 
-      execFileMock.mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(null, '')
-      })
+      runProcessMock.mockImplementationOnce(async () => ok(''))
       await expect(listRunningWslDistrosAsync()).resolves.toEqual([])
-      expect(execFileMock).toHaveBeenCalledTimes(2)
+      expect(runProcessMock).toHaveBeenCalledTimes(2)
     })
   })
 
   it('single-flights cold HOME probes across concurrent callers', async () => {
     let finishList: ((output: string) => void) | undefined
     let finishHome: ((output: string) => void) | undefined
-    execFileMock.mockImplementation((_command, args, _options, callback) => {
-      if (args.includes('--running')) {
-        finishList = (output) => callback(null, output)
-      } else {
-        finishHome = (output) => callback(null, output)
-      }
-    })
+    runProcessMock.mockImplementation(
+      (spec: { args: readonly string[] }) =>
+        new Promise((resolve) => {
+          if (spec.args.includes('--running')) {
+            finishList = (output) => resolve(ok(output))
+          } else {
+            finishHome = (output) => resolve(ok(output))
+          }
+        })
+    )
 
     await withPlatform('win32', async () => {
       const concurrent = [
@@ -125,7 +130,7 @@ describe('running WSL distro discovery', () => {
         listRunningWslHomeDirsAsync()
       ]
       finishList?.('Ubuntu\n')
-      await vi.waitFor(() => expect(execFileMock).toHaveBeenCalledTimes(2))
+      await vi.waitFor(() => expect(runProcessMock).toHaveBeenCalledTimes(2))
       finishHome?.('/home/ada\n')
 
       await expect(Promise.all(concurrent)).resolves.toEqual([
@@ -134,15 +139,13 @@ describe('running WSL distro discovery', () => {
         ['\\\\wsl.localhost\\Ubuntu\\home\\ada']
       ])
       expect(
-        execFileMock.mock.calls.filter(([, args]) => args.includes('echo $HOME'))
+        runProcessMock.mock.calls.filter(([spec]) => spec.args.includes('echo $HOME'))
       ).toHaveLength(1)
     })
   })
 
   it('filters stopped-distro UNC paths while preserving host paths', async () => {
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      callback(null, 'Ubuntu\n')
-    })
+    runProcessMock.mockImplementation(async () => ok('Ubuntu\n'))
 
     await withPlatform('win32', async () => {
       await expect(
@@ -158,7 +161,7 @@ describe('running WSL distro discovery', () => {
   it('does not probe WSL on non-Windows hosts', async () => {
     await withPlatform('linux', async () => {
       await expect(listRunningWslDistrosAsync()).resolves.toEqual([])
-      expect(execFileMock).not.toHaveBeenCalled()
+      expect(runProcessMock).not.toHaveBeenCalled()
     })
   })
 
@@ -166,9 +169,9 @@ describe('running WSL distro discovery', () => {
   // a whole polling session, not just a single failed call.
   it('keeps reporting a session running through a sustained wsl.exe outage, without unbounded spawns', async () => {
     let spawnCount = 0
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+    runProcessMock.mockImplementation(async () => {
       spawnCount += 1
-      callback(null, 'Ubuntu\n')
+      return ok('Ubuntu\n')
     })
 
     await withPlatform('win32', async () => {
@@ -177,9 +180,9 @@ describe('running WSL distro discovery', () => {
       expect(spawnCount).toBe(1)
 
       // wsl.exe now fails on every call — a persistent, not transient, break.
-      execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      runProcessMock.mockImplementation(async () => {
         spawnCount += 1
-        callback(new Error('wsl unavailable'), '')
+        throw Object.assign(new Error('wsl unavailable'), { code: 'ENOENT' })
       })
 
       vi.useFakeTimers()

--- a/src/main/wsl-timeout-tree-kill.test.ts
+++ b/src/main/wsl-timeout-tree-kill.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as childProcess from 'node:child_process'
+
+const { spawnSyncMock } = vi.hoisted(() => ({ spawnSyncMock: vi.fn() }))
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof childProcess>()
+  return { ...actual, spawnSync: spawnSyncMock }
+})
+
+const { admitProcessTreeKillMock } = vi.hoisted(() => ({ admitProcessTreeKillMock: vi.fn() }))
+vi.mock('../shared/child-process/process-tree-kill-gate', () => ({
+  admitProcessTreeKill: admitProcessTreeKillMock
+}))
+
+import { killIfTimedOut, killTimedOutWslProcessTree } from './wsl-timeout-tree-kill'
+
+function withPlatform<T>(value: NodeJS.Platform, fn: () => T): T {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value })
+  try {
+    return fn()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+describe('killTimedOutWslProcessTree', () => {
+  afterEach(() => {
+    spawnSyncMock.mockReset()
+    admitProcessTreeKillMock.mockReset()
+  })
+
+  it('taskkills the tree when the gate admits it', () => {
+    admitProcessTreeKillMock.mockReturnValue(true)
+
+    withPlatform('win32', () => killTimedOutWslProcessTree(4242, 'someSite'))
+
+    expect(admitProcessTreeKillMock).toHaveBeenCalledWith({
+      pid: 4242,
+      site: 'someSite',
+      scope: 'win-taskkill-tree'
+    })
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '4242', '/t', '/f'],
+      expect.objectContaining({ stdio: 'ignore', windowsHide: true, shell: false, timeout: 2_000 })
+    )
+  })
+
+  it('does nothing when the gate refuses the kill', () => {
+    admitProcessTreeKillMock.mockReturnValue(false)
+
+    withPlatform('win32', () => killTimedOutWslProcessTree(4242, 'someSite'))
+
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing off Windows', () => {
+    admitProcessTreeKillMock.mockReturnValue(true)
+
+    withPlatform('linux', () => killTimedOutWslProcessTree(4242, 'someSite'))
+
+    expect(admitProcessTreeKillMock).not.toHaveBeenCalled()
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('does nothing without a pid', () => {
+    admitProcessTreeKillMock.mockReturnValue(true)
+
+    withPlatform('win32', () => killTimedOutWslProcessTree(undefined, 'someSite'))
+
+    expect(admitProcessTreeKillMock).not.toHaveBeenCalled()
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('swallows a spawnSync failure', () => {
+    admitProcessTreeKillMock.mockReturnValue(true)
+    spawnSyncMock.mockImplementation(() => {
+      throw new Error('spawnSync exploded')
+    })
+
+    expect(() =>
+      withPlatform('win32', () => killTimedOutWslProcessTree(4242, 'someSite'))
+    ).not.toThrow()
+  })
+})
+
+describe('killIfTimedOut', () => {
+  afterEach(() => {
+    spawnSyncMock.mockReset()
+    admitProcessTreeKillMock.mockReset()
+  })
+
+  it('tree-kills on an ETIMEDOUT error carrying a pid', () => {
+    admitProcessTreeKillMock.mockReturnValue(true)
+    const error = Object.assign(new Error('spawnSync ETIMEDOUT'), {
+      code: 'ETIMEDOUT',
+      pid: 777,
+      status: null,
+      signal: 'SIGTERM'
+    })
+
+    withPlatform('win32', () => killIfTimedOut(error, 'someSite'))
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '777', '/t', '/f'],
+      expect.anything()
+    )
+  })
+
+  it('ignores a non-timeout error', () => {
+    admitProcessTreeKillMock.mockReturnValue(true)
+    const error = Object.assign(new Error('distro unavailable'), { status: 4294967295 })
+
+    withPlatform('win32', () => killIfTimedOut(error, 'someSite'))
+
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores a non-Error thrown value', () => {
+    withPlatform('win32', () => killIfTimedOut('not an error', 'someSite'))
+    withPlatform('win32', () => killIfTimedOut(null, 'someSite'))
+
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/wsl-timeout-tree-kill.ts
+++ b/src/main/wsl-timeout-tree-kill.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from 'node:child_process'
+import { admitProcessTreeKill } from '../shared/child-process/process-tree-kill-gate'
+
+/** Matches `SUBPROCESS_TIMEOUT_MS` in `process-tree-termination.ts` -- the async
+ *  taskkill this mirrors bounds itself the same way. */
+const TASKKILL_TIMEOUT_MS = 2_000
+
+/**
+ * Bounded, synchronous tree-kill for a `wsl.exe` root that `execFileSync`'s own
+ * `timeout` has already terminated.
+ *
+ * Why this exists instead of routing through `runProcess`: `runProcessSync`
+ * (`src/shared/child-process/run-process.ts`) hands `timeoutMs` straight to
+ * Node's `spawnSync`, which has the identical root-only-kill defect this file
+ * works around -- there is no termination barrier on the sync path, so
+ * migrating these call sites to it would fix nothing. `execFileSync` stays the
+ * spawn mechanism at the sync `wsl.exe` probes in `wsl.ts`; this adds, after
+ * the fact, the tree-kill a barrier would have given for free.
+ *
+ * Why bounded and best-effort: by the time `execFileSync` throws `ETIMEDOUT`,
+ * Node has already reaped the root, so its pid is back in Windows' recycling
+ * pool -- the same window `signalProcessTree`
+ * (`src/shared/child-process/process-tree-termination.ts`) guards with
+ * `hasExited(child)` (see #10680). There is no live `ChildProcess` handle here
+ * to re-check exit state against, so `admitProcessTreeKill` is the only guard
+ * available; on refusal this does nothing further, the same fallback shape
+ * `signalProcessTree` uses for a pid it will not walk.
+ */
+export function killTimedOutWslProcessTree(pid: number | undefined, site: string): void {
+  if (process.platform !== 'win32' || !pid) {
+    return
+  }
+  if (!admitProcessTreeKill({ pid, site, scope: 'win-taskkill-tree' })) {
+    return
+  }
+  try {
+    spawnSync('taskkill', ['/pid', String(pid), '/t', '/f'], {
+      stdio: 'ignore',
+      windowsHide: true,
+      shell: false,
+      timeout: TASKKILL_TIMEOUT_MS
+    })
+  } catch {
+    /* Best-effort: the root is already gone either way. */
+  }
+}
+
+/** `execFileSync`'s timeout error shape: `code: 'ETIMEDOUT'` plus the reaped root's pid. */
+export function killIfTimedOut(error: unknown, site: string): void {
+  const failure = error as (NodeJS.ErrnoException & { pid?: number }) | null
+  if (failure?.code !== 'ETIMEDOUT') {
+    return
+  }
+  killTimedOutWslProcessTree(failure.pid, site)
+}

--- a/src/main/wsl.test.ts
+++ b/src/main/wsl.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type * as childProcess from 'node:child_process'
 
-const { execFileMock, execFileSyncMock } = vi.hoisted(() => ({
+const { execFileMock, execFileSyncMock, spawnSyncMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
-  execFileSyncMock: vi.fn()
+  execFileSyncMock: vi.fn(),
+  spawnSyncMock: vi.fn()
 }))
 
 vi.mock('child_process', async (importOriginal) => {
@@ -11,15 +12,25 @@ vi.mock('child_process', async (importOriginal) => {
   return {
     ...actual,
     execFile: execFileMock,
-    execFileSync: execFileSyncMock
+    execFileSync: execFileSyncMock,
+    spawnSync: spawnSyncMock
   }
 })
+
+const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
+vi.mock('../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
+
+/** Default async-migration success shape: exit 0, no timeout. */
+function processResult(stdout: string, overrides: Record<string, unknown> = {}): unknown {
+  return { code: 0, signal: null, stdout, stderr: '', timedOut: false, ...overrides }
+}
 
 import {
   _resetWslCachesForTests,
   _setWslCachesForTests,
   getCachedWslAvailability,
   getCachedWslDistros,
+  getWslHome,
   hasCachedWslAvailability,
   hasCachedWslDistros,
   isWslAvailable,
@@ -57,18 +68,15 @@ describe('WSL distro discovery cache', () => {
   afterEach(() => {
     execFileMock.mockReset()
     execFileSyncMock.mockReset()
+    runProcessMock.mockReset()
     _resetWslCachesForTests()
   })
 
   it('retries asynchronous discovery after a transient wsl.exe failure', async () => {
     vi.useFakeTimers()
-    execFileMock
-      .mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(new Error('transient failure'), '')
-      })
-      .mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(null, 'Ubuntu\n')
-      })
+    runProcessMock
+      .mockResolvedValueOnce(processResult('', { code: 1 }))
+      .mockResolvedValueOnce(processResult('Ubuntu\n'))
 
     try {
       await withPlatformAsync('win32', async () => {
@@ -76,13 +84,33 @@ describe('WSL distro discovery cache', () => {
         expect(getCachedWslDistros()).toBeNull()
         // Brief negative caching bounds the wsl.exe spawn rate between retries.
         await expect(listWslDistrosAsync()).resolves.toEqual([])
-        expect(execFileMock).toHaveBeenCalledTimes(1)
+        expect(runProcessMock).toHaveBeenCalledTimes(1)
         vi.advanceTimersByTime(15_000)
         await expect(listWslDistrosAsync()).resolves.toEqual(['Ubuntu'])
       })
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  // Why: this is the async migration's whole point -- without a termination
+  // barrier a timeout on `listWslDistrosAsync` reaps only the wsl.exe root and
+  // leaves whatever holds its console behind (#19319's sibling defect, on the
+  // execFile-timeout mechanism instead of runProcess's non-barrier path).
+  it('requests a termination barrier for the async distro-list probe', async () => {
+    runProcessMock.mockResolvedValueOnce(processResult('Ubuntu\n'))
+
+    await withPlatformAsync('win32', async () => {
+      await listWslDistrosAsync()
+    })
+
+    expect(runProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        program: 'wsl.exe',
+        args: ['--list', '--quiet'],
+        terminationBarrier: true
+      })
+    )
   })
 
   it('retries synchronous discovery after a transient wsl.exe failure', () => {
@@ -112,13 +140,9 @@ describe('WSL distro discovery cache', () => {
   // and then permanently absent from the terminal picker.
   it('retries asynchronous discovery after wsl.exe reports no distros yet', async () => {
     vi.useFakeTimers()
-    execFileMock
-      .mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(null, '')
-      })
-      .mockImplementationOnce((_command, _args, _options, callback) => {
-        callback(null, 'Ubuntu\n')
-      })
+    runProcessMock
+      .mockResolvedValueOnce(processResult(''))
+      .mockResolvedValueOnce(processResult('Ubuntu\n'))
 
     try {
       await withPlatformAsync('win32', async () => {
@@ -160,14 +184,12 @@ describe('WSL distro discovery cache', () => {
   })
 
   it('bounds the asynchronous spawn rate while no distros are installed', async () => {
-    execFileMock.mockImplementation((_command, _args, _options, callback) => {
-      callback(null, '')
-    })
+    runProcessMock.mockResolvedValue(processResult(''))
 
     await withPlatformAsync('win32', async () => {
       await expect(listWslDistrosAsync()).resolves.toEqual([])
       await expect(listWslDistrosAsync()).resolves.toEqual([])
-      expect(execFileMock).toHaveBeenCalledTimes(1)
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
     })
   })
 
@@ -457,23 +479,33 @@ describe('WSL availability cache', () => {
   })
 
   it('does not restore a failure after distro discovery disproves it mid-probe', async () => {
-    const callbacks = new Map<string, (error: Error | null, stdout: string) => void>()
-    execFileMock.mockImplementation((_command, args, _options, callback) => {
-      callbacks.set(args.join(' '), callback)
+    // `--status` still runs through execFile (wsl-availability.ts); `--list --quiet`
+    // now runs through runProcess (wsl.ts's async migration, see wsl-timeout-tree-kill).
+    const statusCallbacks: ((error: Error | null, stdout: string) => void)[] = []
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      statusCallbacks.push(callback)
     })
+    let resolveDistroList: ((output: string) => void) | undefined
+    runProcessMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDistroList = (output) =>
+            resolve({ code: 0, signal: null, stdout: output, stderr: '', timedOut: false })
+        })
+    )
 
     await withPlatformAsync('win32', async () => {
       const staleAvailability = isWslAvailableAsync()
       const distroProbe = listWslDistrosAsync()
-      callbacks.get('--list --quiet')?.(null, 'Ubuntu\n')
+      resolveDistroList?.('Ubuntu\n')
       await expect(distroProbe).resolves.toEqual(['Ubuntu'])
 
-      callbacks.get('--status')?.(Object.assign(new Error('older failure'), { code: 1 }), '')
+      statusCallbacks[0]?.(Object.assign(new Error('older failure'), { code: 1 }), '')
       await expect(staleAvailability).resolves.toBe(false)
       expect(getCachedWslAvailability()).toBeNull()
 
       const retry = isWslAvailableAsync()
-      callbacks.get('--status')?.(null, '')
+      statusCallbacks[1]?.(null, '')
       await expect(retry).resolves.toBe(true)
     })
   })
@@ -767,44 +799,44 @@ describe('wslUncDirectoryExists', () => {
 
 describe('wslUncDirectoryExistsAsync', () => {
   afterEach(() => {
-    execFileMock.mockReset()
+    runProcessMock.mockReset()
   })
 
   it('returns true when the distro reports the directory exists', async () => {
-    execFileMock.mockImplementation((_command, _args, _options, callback) =>
-      callback(null, '__ORCA_DIRECTORY_EXISTS__')
-    )
+    runProcessMock.mockResolvedValue(processResult('__ORCA_DIRECTORY_EXISTS__'))
 
     await expect(
       withPlatformAsync('win32', () =>
         wslUncDirectoryExistsAsync('\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo')
       )
     ).resolves.toBe(true)
-    expect(execFileMock).toHaveBeenCalledWith(
-      'wsl.exe',
-      [
-        '-d',
-        'Ubuntu',
-        '--exec',
-        'sh',
-        '-c',
-        expect.stringContaining('__ORCA_DIRECTORY_EXISTS__'),
-        'sh',
-        '/home/jin/repo'
-      ],
-      expect.objectContaining({ timeout: 5000 }),
-      expect.any(Function)
+    expect(runProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        program: 'wsl.exe',
+        args: [
+          '-d',
+          'Ubuntu',
+          '--exec',
+          'sh',
+          '-c',
+          expect.stringContaining('__ORCA_DIRECTORY_EXISTS__'),
+          'sh',
+          '/home/jin/repo'
+        ],
+        timeoutMs: 5000,
+        // Why this is the case that matters: without a barrier a timeout here
+        // reaps only the wsl.exe root and leaves whatever holds its console
+        // behind, same as the mechanism runWslProcess/probeGuestEnvironment
+        // were fixed for on the non-barrier runProcess path (#19319).
+        terminationBarrier: true
+      })
     )
   })
 
   it('distinguishes a missing directory from an inconclusive probe', async () => {
-    execFileMock
-      .mockImplementationOnce((_command, _args, _options, callback) =>
-        callback(null, '__ORCA_DIRECTORY_MISSING__')
-      )
-      .mockImplementationOnce((_command, _args, _options, callback) =>
-        callback(Object.assign(new Error('distro unavailable'), { code: 4294967295 }), '')
-      )
+    runProcessMock
+      .mockResolvedValueOnce(processResult('__ORCA_DIRECTORY_MISSING__'))
+      .mockResolvedValueOnce(processResult('', { code: 4294967295 }))
 
     await withPlatformAsync('win32', async () => {
       await expect(
@@ -816,6 +848,18 @@ describe('wslUncDirectoryExistsAsync', () => {
     })
   })
 
+  it('resolves inconclusive rather than throwing when wsl.exe cannot even start', async () => {
+    runProcessMock.mockRejectedValueOnce(
+      Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' })
+    )
+
+    await expect(
+      withPlatformAsync('win32', () =>
+        wslUncDirectoryExistsAsync('\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo')
+      )
+    ).resolves.toBeNull()
+  })
+
   it('returns null without spawning for paths outside WSL or off Windows', async () => {
     await expect(
       withPlatformAsync('win32', () => wslUncDirectoryExistsAsync('C:\\Users\\jin\\repo'))
@@ -825,6 +869,108 @@ describe('wslUncDirectoryExistsAsync', () => {
         wslUncDirectoryExistsAsync('\\\\wsl.localhost\\Ubuntu\\home\\jin')
       )
     ).resolves.toBeNull()
-    expect(execFileMock).not.toHaveBeenCalled()
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+})
+
+// Why these exist: execFileSync's own `timeout` kills only the wsl.exe root and
+// leaves whatever holds its console (and any other Windows-side descendant)
+// behind -- see wsl-timeout-tree-kill.ts. These pin the fallback taskkill for
+// every sync probe in this file; against unmodified `wsl.ts` none of them fire
+// a taskkill at all, which is the red half of red-green for this change.
+describe('sync wsl.exe timeout tree-kill', () => {
+  afterEach(() => {
+    execFileSyncMock.mockReset()
+    spawnSyncMock.mockReset()
+    _resetWslCachesForTests()
+  })
+
+  function timeoutError(
+    pid: number
+  ): Error & { code: string; pid: number; status: null; signal: string } {
+    // Real execFileSync timeout shape on Windows: status null, signal SIGTERM, pid of the reaped root.
+    return Object.assign(new Error('spawnSync ETIMEDOUT'), {
+      code: 'ETIMEDOUT',
+      pid,
+      status: null,
+      signal: 'SIGTERM'
+    })
+  }
+
+  it('tree-kills the reaped root after wslUncDirectoryExists times out', () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw timeoutError(4242)
+    })
+
+    const result = withPlatform('win32', () =>
+      wslUncDirectoryExists('\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo')
+    )
+
+    expect(result).toBeNull()
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '4242', '/t', '/f'],
+      expect.objectContaining({ windowsHide: true, stdio: 'ignore' })
+    )
+  })
+
+  it('tree-kills the reaped root after listWslDistros times out', () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw timeoutError(5150)
+    })
+
+    withPlatform('win32', () => {
+      expect(listWslDistros()).toEqual([])
+    })
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '5150', '/t', '/f'],
+      expect.objectContaining({ windowsHide: true, stdio: 'ignore' })
+    )
+  })
+
+  it('tree-kills the reaped root after getWslHome times out', () => {
+    execFileSyncMock.mockImplementation(() => {
+      throw timeoutError(6161)
+    })
+
+    const result = withPlatform('win32', () => getWslHome('Ubuntu'))
+
+    expect(result).toBeNull()
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '6161', '/t', '/f'],
+      expect.objectContaining({ windowsHide: true, stdio: 'ignore' })
+    )
+  })
+
+  it('does not taskkill a non-timeout failure', () => {
+    execFileSyncMock.mockImplementation(() => {
+      const error = new Error('distro unavailable') as Error & { status: number }
+      error.status = 4294967295
+      throw error
+    })
+
+    withPlatform('win32', () => {
+      expect(getWslHome('Ubuntu')).toBeNull()
+    })
+
+    expect(spawnSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('hides the console window on every sync probe', () => {
+    execFileSyncMock.mockReturnValue('')
+
+    withPlatform('win32', () => {
+      wslUncDirectoryExists('\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo')
+      listWslDistros()
+      getWslHome('Ubuntu')
+    })
+
+    for (const call of execFileSyncMock.mock.calls) {
+      expect(call[2]).toEqual(expect.objectContaining({ windowsHide: true }))
+    }
+    expect(execFileSyncMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -1,5 +1,6 @@
-import { execFile, execFileSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { parseWslUncPath, toWindowsWslPath } from '../shared/wsl-paths'
+import { runProcess } from '../shared/child-process/run-process'
 import { filterUserWslDistros, parseWslDistros } from './wsl-distro-list-output'
 import { wslDistroListRetryDelayMs } from './wsl-distro-retry'
 import {
@@ -16,6 +17,8 @@ import {
   getWslDirectoryProbeArgs,
   parseWslDirectoryProbeOutput
 } from './wsl-directory-probe-command'
+import { killIfTimedOut } from './wsl-timeout-tree-kill'
+import { execFileUtf8 } from './wsl-exec-utf8'
 
 // Why re-exported rather than defined here: the relay bundle needs the path
 // conversion without this module's distro-probing subprocess graph.
@@ -78,29 +81,46 @@ export function wslUncDirectoryExists(uncPath: string): boolean | null {
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
       encoding: 'utf8',
+      windowsHide: true,
       cwd: resolveWslInteropSpawnCwd()
     })
     return parseWslDirectoryProbeOutput(stdout)
-  } catch {
+  } catch (error) {
+    // Why: execFileSync's own `timeout` kills only the wsl.exe root, not its
+    // console host or Windows-side descendants -- see wsl-timeout-tree-kill.ts.
+    killIfTimedOut(error, 'wslUncDirectoryExists')
     return null
   }
 }
 
-export function wslUncDirectoryExistsAsync(uncPath: string): Promise<boolean | null> {
+export async function wslUncDirectoryExistsAsync(uncPath: string): Promise<boolean | null> {
   if (process.platform !== 'win32') {
-    return Promise.resolve(null)
+    return null
   }
   const info = parseWslUncPath(uncPath)
   if (!info) {
-    return Promise.resolve(null)
+    return null
   }
-  return new Promise((resolve) => {
-    const probeOpts = { timeout: 5000, cwd: resolveWslInteropSpawnCwd() }
-    execFile('wsl.exe', getWslDirectoryProbeArgs(info), probeOpts, (_error, stdout) => {
-      // Why: wsl.exe uses numeric exits for both guest results and host failures; only the guest marker is authoritative.
-      resolve(parseWslDirectoryProbeOutput(stdout))
+  try {
+    // Why terminationBarrier: without it a timeout kills only the root, exactly
+    // the execFile defect runWslProcess/probeGuestEnvironment were fixed for
+    // (see wsl-runner.ts, wsl-guest-environment.ts). windowsHide comes free via
+    // run-process.ts's resolveSpawn.
+    const result = await runProcess({
+      program: 'wsl.exe',
+      args: getWslDirectoryProbeArgs(info),
+      timeoutMs: 5000,
+      cwd: resolveWslInteropSpawnCwd(),
+      terminationBarrier: true
     })
-  })
+    // Why: wsl.exe uses numeric exits for both guest results and host failures; only the guest marker is authoritative.
+    return parseWslDirectoryProbeOutput(result.stdout)
+  } catch {
+    // runProcess rejects only when the process could not be started at all
+    // (e.g. wsl.exe missing from PATH) -- inconclusive, same as the old
+    // execFile callback's ignored error.
+    return null
+  }
 }
 
 // ─── WSL home directory resolution ──────────────────────────────────
@@ -185,10 +205,16 @@ export function listWslDistros(): string[] {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      windowsHide: true,
       cwd: resolveWslInteropSpawnCwd()
     })
     return cacheWslDistroList(parseWslDistros(output), probeSequence)
-  } catch {
+  } catch (error) {
+    // Byte-identical option literal to wslUncDirectoryExists/getWslHome above and
+    // below -- no structural reason this probe is exempt from the same defect.
+    // `wsl --list` staying up during the original incident was an empirical
+    // observation about that one wedge, not a property of this code path.
+    killIfTimedOut(error, 'listWslDistros')
     armWslDistroListRetry()
     return wslDistroCache ?? []
   }
@@ -288,6 +314,7 @@ export function getWslHome(distro: string): string | null {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      windowsHide: true,
       cwd: resolveWslInteropSpawnCwd()
     }).trim()
 
@@ -298,7 +325,8 @@ export function getWslHome(distro: string): string | null {
     const uncPath = toWindowsWslPath(home, distro)
     wslHomeCache.set(distro, uncPath)
     return uncPath
-  } catch {
+  } catch (error) {
+    killIfTimedOut(error, 'getWslHome')
     return null
   }
 }
@@ -380,27 +408,4 @@ export function _setWslCachesForTests(args: {
   if (args.distros) {
     cacheWslDistroList(args.distros, ++wslDistroProbeSequence)
   }
-}
-
-function execFileUtf8(command: string, args: string[], env?: NodeJS.ProcessEnv): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      command,
-      args,
-      {
-        encoding: 'utf-8',
-        env,
-        timeout: 5000,
-        windowsHide: true,
-        cwd: resolveWslInteropSpawnCwd()
-      },
-      (error, stdout) => {
-        if (error) {
-          reject(error)
-          return
-        }
-        resolve(stdout)
-      }
-    )
-  })
 }


### PR DESCRIPTION
Same defect class as #19319, different mechanism. #19319 fixed the `runProcess` path (`terminationBarrier`); this fixes the `execFile`/`execFileSync` path in `src/main/wsl.ts`, where Node's timeout kills only the direct child and leaves the console host behind on Windows.

## Sites

- `wslUncDirectoryExists` / `wslUncDirectoryExistsAsync`
- `listWslDistros` (`wsl --list --quiet`)
- `getWslHome` / `getWslHomeAsync`

`windowsHide: true` was also absent on three of these, so the probes could flash a visible console.

## Sync vs async, and why not a single mechanism

The async paths migrate to `runProcess` + `terminationBarrier: true`. The sync paths **cannot**: `runProcessSync` hands `timeoutMs` straight to `spawnSync`, which has the identical root-only-kill defect — there is no termination barrier on the sync path, so migrating them would fix nothing. They instead get a bounded, synchronous `taskkill /pid <pid> /t /f` in the catch block, routed through the same `admitProcessTreeKill` guard `signalProcessTree` uses, because by the time `execFileSync` throws `ETIMEDOUT` the root is already reaped.

## On `listWslDistros`

An earlier draft of this work proposed exempting the `wsl --list` probes, on the grounds that `wsl --list` kept working during the incident that prompted #19316. That is an empirical fact about one wedge, not a structural difference — its option literal is byte-identical to the other two sync sites. It gets the same fix.

## Verification

- Red: source stashed, tests kept → `Test Files 4 failed`, `Tests 25 failed | 41 passed`.
- Green: `src/main/wsl` → **178 passed | 11 skipped**, independently re-run by the author of this PR.
- `oxlint` clean; `oxfmt --check` clean after formatting; `check-max-lines-ratchet.mjs` OK (`execFileUtf8` extracted to `wsl-exec-utf8.ts` to stay inside the 300-line budget).

Note for reviewers: `corepack pnpm` on a Windows checkout currently re-triggers `postinstall` and fails a `node-gyp` rebuild of `@vscode/windows-process-tree`, unrelated to this change; the suite was run via the vitest binary directly.

Relates to #19316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
