### PR TITLE
fix(relay): never cache a region hint from a one-region catalog

### DIFF
--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -298,12 +298,13 @@ describe('Relay region preference', () => {
       ).resolves.toBeUndefined()
     }
 
-    const unstable = sampledProbe({ [US]: [15, 10, 20, 400] })
+    // Two-region catalog so the only reason for no hint is the flapping US path.
+    const unstable = sampledProbe({ [US]: [15, 10, 20, 400], [ASIA]: [300, 200, 205, 210] })
     await expect(
       new RelayRegionPreferenceResolver({
         directorUrl: DIRECTOR,
         userDataPath: path,
-        fetch: catalogFetch([{ region: 'us-central1', probeOrigins: [US] }]),
+        fetch: catalogFetch(BOTH_REGIONS),
         probe: unstable.probe,
         now: () => 1_000
       }).resolve()

--- a/src/main/runtime/relay/relay-region-preference.test.ts
+++ b/src/main/runtime/relay/relay-region-preference.test.ts
@@ -313,12 +313,12 @@ describe('Relay region preference', () => {
   it('recovers from corrupt cache and cancels an old directors error response', async () => {
     const path = userDataPath()
     writeFileSync(cachePath(path), '{not-json')
-    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    const healthy = sampledProbe({ [US]: [300, 95, 100, 105], [ASIA]: [90, 30, 32, 34] })
     await expect(
       new RelayRegionPreferenceResolver({
         directorUrl: DIRECTOR,
         userDataPath: path,
-        fetch: catalogFetch([{ region: 'asia-east2', probeOrigins: [ASIA] }]),
+        fetch: catalogFetch(BOTH_REGIONS),
         probe: healthy.probe,
         now: () => 1_000
       }).resolve()
@@ -345,8 +345,27 @@ describe('Relay region preference', () => {
   it('rejects a cache expiry beyond the 24-hour bound', async () => {
     const path = userDataPath()
     writeCache(path, 'us-central1', 10 * 24 * 60 * 60_000)
-    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
+    const healthy = sampledProbe({ [US]: [300, 95, 100, 105], [ASIA]: [90, 30, 32, 34] })
 
+    // The far-future cache is discarded, so Asia wins outright rather than being
+    // held back by an incumbent's switch margin.
+    await expect(
+      new RelayRegionPreferenceResolver({
+        directorUrl: DIRECTOR,
+        userDataPath: path,
+        fetch: catalogFetch(BOTH_REGIONS),
+        probe: healthy.probe,
+        now: () => 1_000
+      }).resolve()
+    ).resolves.toBe('asia-east2')
+  })
+
+  it('withholds the hint when the catalog lists fewer regions than the fleet serves', async () => {
+    // Why: the director lists only regions with a serving cell, so a roll wave
+    // shortens the catalog. A lone healthy region measured against nothing must
+    // not become a day-long hint pinning the desktop there.
+    const path = userDataPath()
+    const healthy = sampledProbe({ [ASIA]: [90, 30, 32, 34] })
     await expect(
       new RelayRegionPreferenceResolver({
         directorUrl: DIRECTOR,
@@ -355,7 +374,11 @@ describe('Relay region preference', () => {
         probe: healthy.probe,
         now: () => 1_000
       }).resolve()
-    ).resolves.toBe('asia-east2')
+    ).resolves.toBeUndefined()
+    expect(JSON.parse(readFileSync(cachePath(path), 'utf8'))).toMatchObject({
+      region: null,
+      expiresAt: 1_000 + 60 * 60_000
+    })
   })
 
   it('uses a valid diagnostic override without network or cache mutation', async () => {

--- a/src/main/runtime/relay/relay-region-preference.ts
+++ b/src/main/runtime/relay/relay-region-preference.ts
@@ -176,10 +176,13 @@ export class RelayRegionPreferenceResolver {
       this.log(relayRegionCatalogFailureEvent(this.options.directorUrl))
     )
     const measurements = measuredRegions(reports)
-    // Why: a region may only win against a measured competitor. With a rejected
-    // or unmeasurable peer, director default placement beats a lone survivor.
+    // Why: a region may only win against a measured competitor. A rejected or
+    // unmeasurable peer, or one the director left out of the catalog because it
+    // has no serving cell right now (a roll wave), means director default
+    // placement beats a lone survivor. Withholding costs one hour; a hint won
+    // against nothing pins the desktop to that region for a day.
     const selected =
-      measurements.length < reports.length
+      measurements.length < reports.length || reports.length < RELAY_REGIONS.length
         ? null
         : selectRegionMeasurement(measurements, previous?.region ?? null)
     const ttlMs = selected ? CACHE_TTL_MS : NO_HINT_TTL_MS


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

Replaces #19322, reduced to the one rule that fixes a reproduced bug. Everything else that PR accumulated over six review rounds (warm-up budgets, incumbent holds, cache markers, self-heal fences, log reason reordering, warning aggregation) is dropped: each of those was a heuristic that invited the next counter-heuristic, and none fixed a reproduced production problem.

## Why

The director lists only regions that currently have a serving cell, so a roll wave shortens the catalog to one entry. On main the resolver requires only every *listed* region to be measured, so that lone region wins against nothing and is cached as a 24 h hint. A US desktop refreshing while US cells roll publishes `asia-east2` for a day, which is exactly the incident #19233 ended. Two tests on main pinned this behaviour.

## What

One condition: fewer listed regions than the fleet serves withholds the hint, the same 1 h no-hint outcome main already uses for an unmeasurable peer. No new state, no new cache fields, no new log reasons. The cost is bounded and known: a desktop that refreshes during the *other* region's roll wave loses its hint for one hour and lands at the director default, which is `us-central1`, the region most desktops want anyway.

## Diff

`relay-region-preference.ts`: +3 lines of condition, one comment. The two tests that asserted a lone-region hint now earn it against both regions; their intent (corrupt-cache recovery, expiry bound) is unchanged. One new test: one-region catalog yields no hint with the 1 h TTL, and fails without the fix.

## Verification

`pnpm vitest run src/main/runtime/relay/` 156/156, `pnpm tc:node`, oxlint and oxfmt clean.