### PR TITLE
fix(sidebar): label pinned rows with their host on a multi-host sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-groups-pinned-host-labels.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups-pinned-host-labels.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #18472: a pinned worktree on a multi-host sidebar lost its host badge. Under
+ * the default pinned policy it renders only in the Pinned section, so that was
+ * its only chance at host attribution.
+ */
+import { describe, expect, it } from 'vitest'
+import { buildRows } from './worktree-list/grouping/build-rows'
+import type { Row } from './worktree-list/grouping/row-types'
+import {
+  LOCAL_HOST_LABEL,
+  repo,
+  worktree,
+  remoteRepo,
+  remoteWorktree
+} from './worktree-list-groups-test-fixtures'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+const hostLabelById = new Map([
+  ['local', LOCAL_HOST_LABEL],
+  ['ssh:gpu-vm', 'gpu-vm']
+])
+
+function buildPinnedRows(
+  worktrees: Worktree[],
+  groupBy: 'none' | 'repo' | 'workspace-status' = 'repo',
+  showPinnedWorktreesInGroups = false
+): Row[] {
+  return buildRows(
+    groupBy,
+    worktrees,
+    new Map([
+      [repo.id, repo],
+      [remoteRepo.id, remoteRepo]
+    ]),
+    null,
+    new Set(),
+    undefined,
+    undefined,
+    undefined,
+    {},
+    new Map(worktrees.map((candidate) => [candidate.id, candidate])),
+    false,
+    { showPinnedWorktreesInGroups } as never,
+    [],
+    new Set(),
+    new Map(),
+    new Map(),
+    [],
+    undefined,
+    [],
+    hostLabelById
+  )
+}
+
+function itemRows(rows: Row[]): { id: string; sectionKey: string; hostContextLabel?: string }[] {
+  return rows.flatMap((row) =>
+    row.type === 'item'
+      ? [
+          {
+            id: row.worktree.id,
+            sectionKey: row.sectionKey,
+            hostContextLabel: row.hostContextLabel
+          }
+        ]
+      : []
+  )
+}
+
+describe('pinned rows on a multi-host sidebar', () => {
+  it.each(['repo', 'workspace-status', 'none'] as const)(
+    'labels a pinned remote worktree in the Pinned section (%s grouping)',
+    (groupBy) => {
+      const pinnedRemote: Worktree = { ...remoteWorktree, isPinned: true }
+      const rows = itemRows(buildPinnedRows([worktree, pinnedRemote], groupBy))
+
+      // Default policy: the pinned row is the only row for that worktree.
+      expect(rows.filter((row) => row.id === pinnedRemote.id)).toEqual([
+        { id: pinnedRemote.id, sectionKey: 'pinned', hostContextLabel: 'gpu-vm' }
+      ])
+      expect(rows.find((row) => row.id === worktree.id)?.hostContextLabel).toBe(LOCAL_HOST_LABEL)
+    }
+  )
+
+  it('labels pinned rows when the only other host is itself pinned', () => {
+    // Why: the natural lane holds one host here, so a map scoped to it would say
+    // "not mixed" even though the sidebar shows two hosts.
+    const pinnedLocal: Worktree = { ...worktree, isPinned: true }
+    const pinnedRemote: Worktree = { ...remoteWorktree, isPinned: true }
+    const localOnly: Worktree = { ...worktree, id: 'wt-local-2', displayName: 'local-2' }
+    const rows = itemRows(buildPinnedRows([pinnedLocal, pinnedRemote, localOnly]))
+
+    expect(rows).toEqual([
+      { id: pinnedLocal.id, sectionKey: 'pinned', hostContextLabel: LOCAL_HOST_LABEL },
+      { id: pinnedRemote.id, sectionKey: 'pinned', hostContextLabel: 'gpu-vm' },
+      { id: localOnly.id, sectionKey: 'repo:repo-1', hostContextLabel: LOCAL_HOST_LABEL }
+    ])
+  })
+
+  it('labels both copies when pinned worktrees also show in their groups', () => {
+    const pinnedRemote: Worktree = { ...remoteWorktree, isPinned: true }
+    const rows = itemRows(buildPinnedRows([worktree, pinnedRemote], 'repo', true))
+
+    expect(rows.filter((row) => row.id === pinnedRemote.id)).toEqual([
+      { id: pinnedRemote.id, sectionKey: 'pinned', hostContextLabel: 'gpu-vm' },
+      { id: pinnedRemote.id, sectionKey: 'repo:repo-remote', hostContextLabel: 'gpu-vm' }
+    ])
+  })
+
+  it('draws no badge on a single-host sidebar even with a pinned row', () => {
+    const pinnedLocal: Worktree = { ...worktree, isPinned: true }
+    const localOnly: Worktree = { ...worktree, id: 'wt-local-2', displayName: 'local-2' }
+    const rows = itemRows(buildPinnedRows([pinnedLocal, localOnly]))
+
+    expect(rows).toHaveLength(2)
+    for (const row of rows) {
+      expect(row.hostContextLabel).toBeUndefined()
+    }
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -105,8 +105,11 @@ export function buildRows(
     pinnedDisplayPolicy === 'duplicate-in-groups'
       ? worktrees
       : worktrees.filter((worktree) => !pinnedSectionIds.has(getWorktreeHostIdentity(worktree)))
+  // Why the full set: under the default pinned policy a pinned worktree exists
+  // only in the Pinned section, and its host is part of whether the sidebar is
+  // mixed at all. Scoping to naturalWorktrees left pinned remotes unlabelled.
   const mixedWorktreeHostContextLabels = getMixedWorktreeHostContextLabels(
-    naturalWorktrees,
+    worktrees,
     repoMap,
     hostLabelById,
     defaultHostId
@@ -145,7 +148,8 @@ export function buildRows(
     worktreeMap,
     nestLineage,
     cyclicLineageIds,
-    noticeHostContextLabelByRepoId
+    noticeHostContextLabelByRepoId,
+    mixedWorktreeHostContextLabels
   )
   if (groupBy === 'none') {
     // Why folder workspaces gate this too: an account with only folder

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
@@ -27,7 +27,8 @@ export function emitPinnedGroup(
   worktreeMap: Map<string, Worktree>,
   nestLineage: boolean,
   cyclicLineageIds: ReadonlySet<string>,
-  noticeHostContextLabelByRepoId?: ReadonlyMap<string, NoticeHostContext>
+  noticeHostContextLabelByRepoId?: ReadonlyMap<string, NoticeHostContext>,
+  hostContextLabelByWorktreeIdentity?: ReadonlyMap<string, string>
 ): void {
   if (pinnedSectionWorktrees.length === 0) {
     return
@@ -81,6 +82,7 @@ export function emitPinnedGroup(
     collapsedGroups,
     groupDepth: 0,
     sectionKey: PINNED_GROUP_KEY,
+    hostContextLabelByWorktreeIdentity,
     cyclicLineageIds
   })
   if (!allowImportedFallback) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

When your sidebar mixes hosts (say, your Windows machine plus a remote Orca server), every workspace card gets a little "which computer is this on" badge. Cards in the **Pinned** section never got one. Because pinned workspaces are, by default, shown *only* in Pinned, a pinned remote workspace had no host attribution anywhere in the sidebar. This threads the same host-label map every other section already uses into the Pinned section, and computes it over the full workspace set so pinned rows count toward "is this sidebar mixed?".

## What Changed

- `src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts`: `mixedWorktreeHostContextLabels` is now computed over `worktrees` (the full set) instead of `naturalWorktrees` (which, under the default `showPinnedWorktreesInGroups: false` policy, has the pinned worktrees filtered out). The map is passed to `emitPinnedGroup`.
- `src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts`: `emitPinnedGroup` accepts `hostContextLabelByWorktreeIdentity` and forwards it to `appendWorktreeRows`, matching the All lane and every grouped lane.
- New test `src/renderer/src/components/sidebar/worktree-list-groups-pinned-host-labels.test.ts`.

## Why

`appendWorktreeRows` (`row-builders.ts:138`, `:208`) is the only writer of `hostContextLabel` on item rows, and `emitPinnedGroup` was the only section emitter calling it without the identity-keyed map. Two arms, both required:

1. **Plumbing gap**: Pinned rows were emitted with no map at all, so `hostContextLabel` was always `undefined` for them.
2. **Map scope**: simply forwarding the existing map is not enough. Under the default pinned policy the map was built from `naturalWorktrees`, which excludes pinned worktrees. A pinned remote's identity was never a key in it, and if the pinned worktrees were the *only* thing making the sidebar multi-host, the map was `undefined` entirely.

The "only badge when hosts are mixed" rule is unchanged: `getMixedHostContextLabels` still returns `undefined` for a single unique host, so single-host setups draw no new badge.

Row-to-badge hop verified as an unconditional pass-through: `worktree-list/rows/item-row.tsx:217` -> `WorktreeCard` -> `worktree-card-presentation.tsx:80` (`showHostContextBadge = !compactCards && !!hostContextLabel`). The row model is the deciding layer.

Remote wire compatibility: no wire change (renderer-only row model). SSH execution boundary: no verdicts, no process control touched. Folder workspaces: unaffected (they are not pinned worktrees; `getRenderableFolderWorkspaces` path unchanged). Not GitHub/GitLab specific.

## Linked Issue

Fixes #18472

## Visual Proof

Row-model before/after (the deciding layer; the badge is a pass-through of `row.hostContextLabel`). Input: local repo `repo-1` + SSH repo `repo-remote` (`ssh:gpu-vm`), remote worktree pinned, default pinned policy, `hostLabelById = { local -> "This computer" label, ssh:gpu-vm -> "gpu-vm" }`.

**Before (origin/main `bcd4076dd12`)** — pinned remote row has no label; it also appears nowhere else:

```
{ id: 'wt-remote', sectionKey: 'pinned', hostContextLabel: undefined }
{ id: 'wt-1',      sectionKey: 'repo:repo-1', hostContextLabel: undefined }   // map was undefined: natural lane had one host
```

**After** — same input:

```
{ id: 'wt-remote', sectionKey: 'pinned',      hostContextLabel: 'gpu-vm' }
{ id: 'wt-1',      sectionKey: 'repo:repo-1', hostContextLabel: <local label> }
```

Holds for `repo`, `workspace-status`, and `none` grouping, and for `showPinnedWorktreesInGroups: true` (both copies labelled). Single-host sidebar with a pinned row: no label on any row, before and after.

## Testing

- `pnpm test src/renderer/src/components/sidebar/worktree-list-groups-pinned-host-labels.test.ts`: 6/6 pass with the fix; 5/6 fail on origin/main behaviour (both arms reverted).
- Per-arm mutation testing, each arm reverted independently while the other is kept:
  - Revert arm 1 only (drop the map from `emitPinnedGroup`): 5 of 6 fail.
  - Revert arm 2 only (map over `naturalWorktrees`): 4 of 6 fail (the `showPinnedWorktreesInGroups: true` case survives, as expected: under that policy the natural set already contains the pinned rows).
  - Neither mutation is inert; the single-host negative control passes in every configuration.
- `pnpm test src/renderer/src/components/sidebar/`: 299 files / 2515 tests pass.
- `pnpm tc:web` clean; `oxlint` and `oxfmt` clean on changed files; `pnpm run check:code-quality:changed` 0 findings.
- Platforms: macOS (row model is platform-independent; the reporter's setup is Windows + remote Orca server, and the same code path builds the rows there).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Left as-is on purpose: `ImportedWorktreesVisibilityLine.tsx:159` suppresses the host label for `placement === 'pinned-fallback'`. That is a notice row, not a worktree card, and looks deliberate.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
