### PR TITLE
fix(clipboard): route runtime-owned SSH image paste through the runtime

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -55,8 +55,16 @@ async function saveClipboardImageBufferForTarget(
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
   const runtimeEnvironmentId = args?.runtimeEnvironmentId?.trim()
-  if (runtimeEnvironmentId && !args?.connectionId) {
-    return saveClipboardImageBufferInRuntime(app.getPath('userData'), runtimeEnvironmentId, buffer)
+  // Why (#17679): with a runtime owner, a connectionId names one of the RUNTIME's SSH
+  // connections (nested Remote Server -> SSH), not one this process dialed. Looking it up
+  // in the local provider registry can only miss, so the runtime must perform the save.
+  if (runtimeEnvironmentId) {
+    return saveClipboardImageBufferInRuntime(
+      app.getPath('userData'),
+      runtimeEnvironmentId,
+      buffer,
+      args?.connectionId ?? null
+    )
   }
   return saveClipboardImageBufferAsTempFile(buffer, args)
 }

--- a/src/main/window/clipboard-runtime-image-upload.ts
+++ b/src/main/window/clipboard-runtime-image-upload.ts
@@ -27,13 +27,14 @@ async function callRuntimeClipboardMethod<TResult>(
 async function saveClipboardImageBase64InRuntime(
   userDataPath: string,
   runtimeEnvironmentId: string,
-  contentBase64: string
+  contentBase64: string,
+  connectionId: string | null
 ): Promise<string> {
   const startResponse = await callRuntimeEnvironment(
     userDataPath,
     runtimeEnvironmentId,
     'clipboard.startImageUpload',
-    { expectedBase64Length: contentBase64.length, connectionId: null },
+    { expectedBase64Length: contentBase64.length, connectionId },
     CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS
   )
   if (!startResponse.ok) {
@@ -45,7 +46,7 @@ async function saveClipboardImageBase64InRuntime(
         userDataPath,
         runtimeEnvironmentId,
         'clipboard.saveImageAsTempFile',
-        { contentBase64, connectionId: null }
+        { contentBase64, connectionId }
       )
     }
     throw new Error(startResponse.error.message)
@@ -104,15 +105,19 @@ async function saveClipboardImageBase64InRuntime(
   }
 }
 
+// connectionId: the runtime-side SSH target that holds the workspace, or null for
+// the runtime host itself. The runtime resolves it in its own provider registry.
 export function saveClipboardImageBufferInRuntime(
   userDataPath: string,
   runtimeEnvironmentId: string,
-  buffer: Buffer
+  buffer: Buffer,
+  connectionId: string | null = null
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
   return saveClipboardImageBase64InRuntime(
     userDataPath,
     runtimeEnvironmentId,
-    buffer.toString('base64')
+    buffer.toString('base64'),
+    connectionId
   )
 }

--- a/src/main/window/clipboard-runtime-owned-ssh-paste.test.ts
+++ b/src/main/window/clipboard-runtime-owned-ssh-paste.test.ts
@@ -1,0 +1,223 @@
+// Nested Remote Orca Server -> SSH image paste (#17679). The REAL ssh-filesystem-dispatch registry
+// is used on purpose: the runtime's SSH target is never registered in the client process, so any
+// route that consults the local registry fails exactly the way the report did.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { installFakeAppEnvironment } from '../../../config/scripts/vitest-host-ports-setup'
+
+const { handleMock, callRuntimeEnvironmentMock, fsWriteFileMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  callRuntimeEnvironmentMock: vi.fn(),
+  fsWriteFileMock: vi.fn()
+}))
+
+const PNG = Buffer.from([0, 1, 2, 3])
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp') },
+  clipboard: {
+    readImage: () => ({
+      getSize: () => ({ height: 1, width: 1 }),
+      isEmpty: () => false,
+      toPNG: () => PNG
+    }),
+    readText: vi.fn(),
+    readBuffer: vi.fn(),
+    writeText: vi.fn(),
+    writeImage: vi.fn(),
+    writeBuffer: vi.fn()
+  },
+  ipcMain: { removeHandler: vi.fn(), handle: handleMock },
+  nativeImage: { createFromBuffer: vi.fn() }
+}))
+vi.mock('node:fs/promises', () => ({
+  access: vi.fn(),
+  lstat: vi.fn(),
+  mkdir: vi.fn(),
+  opendir: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+  rm: vi.fn(),
+  open: vi.fn(),
+  stat: vi.fn(),
+  realpath: vi.fn(),
+  writeFile: fsWriteFileMock,
+  default: { writeFile: fsWriteFileMock }
+}))
+vi.mock('../ipc/filesystem-auth', () => ({
+  PATH_ACCESS_DENIED_MESSAGE: 'denied',
+  resolveAuthorizedPath: vi.fn(),
+  authorizeExternalPath: vi.fn()
+}))
+vi.mock('../ipc/runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+vi.mock('./dashboard-popout-window', () => ({ isDashboardPopoutRenderer: () => false }))
+
+import { registerClipboardHandlers } from './clipboard-ipc-handlers'
+import {
+  getSshFilesystemProvider,
+  registerSshFilesystemProvider,
+  SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE,
+  unregisterSshFilesystemProvider
+} from '../providers/ssh-filesystem-dispatch'
+
+type SaveImageHandler = (event: unknown, args?: unknown) => Promise<string | null>
+
+const RUNTIME_ID = 'ubuntu-server'
+const RUNTIME_SSH_TARGET = 'jetson'
+const CLIENT_SSH_TARGET = 'client-dialed'
+
+const rendererEvent = {
+  sender: {
+    id: 1,
+    getType: () => 'window',
+    getURL: () => 'file:///orca/index.html',
+    isDestroyed: () => false
+  }
+}
+
+function saveImageHandler(): SaveImageHandler {
+  handleMock.mockClear()
+  registerClipboardHandlers({} as never)
+  const call = handleMock.mock.calls.find((c) => c[0] === 'clipboard:saveImageAsTempFile')
+  if (!call) {
+    throw new Error('clipboard:saveImageAsTempFile not registered')
+  }
+  return call[1] as SaveImageHandler
+}
+
+function mockRuntimeUpload(
+  overrides: Record<string, { ok: boolean; result?: unknown; error?: unknown }> = {}
+): void {
+  callRuntimeEnvironmentMock.mockImplementation(async (_userData, _env, method) => {
+    if (method in overrides) {
+      return { ...overrides[method], _meta: { runtimeId: 'r' } }
+    }
+    switch (method) {
+      case 'clipboard.startImageUpload':
+        return { ok: true, result: { uploadId: 'upload-1' }, _meta: { runtimeId: 'r' } }
+      case 'clipboard.appendImageUploadChunk':
+        return { ok: true, result: { receivedBase64Length: 8 }, _meta: { runtimeId: 'r' } }
+      case 'clipboard.commitImageUpload':
+        return { ok: true, result: '/tmp/on-runtime-target.png', _meta: { runtimeId: 'r' } }
+      case 'clipboard.abortImageUpload':
+        return { ok: true, result: { aborted: true }, _meta: { runtimeId: 'r' } }
+      default:
+        throw new Error(`unexpected runtime method ${method}`)
+    }
+  })
+}
+
+function runtimeCall(method: string): unknown[] | undefined {
+  return callRuntimeEnvironmentMock.mock.calls.find((c) => c[2] === method)
+}
+
+describe('clipboard image paste for a runtime-owned SSH workspace', () => {
+  beforeEach(() => {
+    installFakeAppEnvironment({ getPath: () => '/tmp' })
+    callRuntimeEnvironmentMock.mockReset()
+    fsWriteFileMock.mockReset()
+    unregisterSshFilesystemProvider(RUNTIME_SSH_TARGET)
+    unregisterSshFilesystemProvider(CLIENT_SSH_TARGET)
+  })
+
+  it('sends the paste to the runtime and names the runtime SSH target, never this registry', async () => {
+    mockRuntimeUpload()
+    expect(getSshFilesystemProvider(RUNTIME_SSH_TARGET)).toBeUndefined()
+    // Built the way the renderer builds it: both owner ids, verbatim.
+    const nestedArgs = { connectionId: RUNTIME_SSH_TARGET, runtimeEnvironmentId: RUNTIME_ID }
+
+    await expect(saveImageHandler()(rendererEvent, nestedArgs)).resolves.toBe(
+      '/tmp/on-runtime-target.png'
+    )
+
+    const start = runtimeCall('clipboard.startImageUpload')
+    expect(start?.[1]).toBe(nestedArgs.runtimeEnvironmentId)
+    expect(start?.[3]).toEqual({
+      expectedBase64Length: PNG.toString('base64').length,
+      connectionId: nestedArgs.connectionId
+    })
+    expect(fsWriteFileMock).not.toHaveBeenCalled()
+  })
+
+  it('names the runtime SSH target on the single-frame fallback for older runtimes', async () => {
+    mockRuntimeUpload({
+      'clipboard.startImageUpload': {
+        ok: false,
+        error: { code: 'method_not_found', message: 'no such method' }
+      },
+      'clipboard.saveImageAsTempFile': { ok: true, result: '/tmp/on-runtime-target.png' }
+    })
+    const nestedArgs = { connectionId: RUNTIME_SSH_TARGET, runtimeEnvironmentId: RUNTIME_ID }
+
+    await expect(saveImageHandler()(rendererEvent, nestedArgs)).resolves.toBe(
+      '/tmp/on-runtime-target.png'
+    )
+
+    expect(runtimeCall('clipboard.saveImageAsTempFile')?.[3]).toEqual({
+      contentBase64: PNG.toString('base64'),
+      connectionId: nestedArgs.connectionId
+    })
+  })
+
+  it('surfaces the runtime verdict instead of the local Reconnect advice when the runtime fails', async () => {
+    mockRuntimeUpload({
+      'clipboard.startImageUpload': {
+        ok: false,
+        error: { code: 'runtime_error', message: 'Unknown environment' }
+      }
+    })
+
+    await expect(
+      saveImageHandler()(rendererEvent, {
+        connectionId: RUNTIME_SSH_TARGET,
+        runtimeEnvironmentId: 'missing-env'
+      })
+    ).rejects.toThrow('Unknown environment')
+    expect(fsWriteFileMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a runtime-host paste (no SSH target) addressed to the runtime itself', async () => {
+    mockRuntimeUpload()
+
+    await expect(
+      saveImageHandler()(rendererEvent, { runtimeEnvironmentId: RUNTIME_ID })
+    ).resolves.toBe('/tmp/on-runtime-target.png')
+
+    expect(runtimeCall('clipboard.startImageUpload')?.[3]).toEqual({
+      expectedBase64Length: PNG.toString('base64').length,
+      connectionId: null
+    })
+  })
+
+  it('keeps a client-dialed SSH paste on this process registry without touching the runtime', async () => {
+    const writeFileBase64 = vi.fn().mockResolvedValue(undefined)
+    registerSshFilesystemProvider(CLIENT_SSH_TARGET, {
+      getTempDir: async () => '/var/tmp',
+      writeFileBase64
+    } as never)
+
+    await expect(
+      saveImageHandler()(rendererEvent, { connectionId: CLIENT_SSH_TARGET })
+    ).resolves.toMatch(/^\/var\/tmp\/orca-paste-.*\.png$/)
+
+    expect(writeFileBase64).toHaveBeenCalledTimes(1)
+    expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('still reports the dropped-connection verdict for a client-dialed SSH target that is gone', async () => {
+    await expect(
+      saveImageHandler()(rendererEvent, { connectionId: CLIENT_SSH_TARGET })
+    ).rejects.toThrow(SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE)
+    expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps a plain local paste on the local temp dir', async () => {
+    fsWriteFileMock.mockResolvedValue(undefined)
+
+    await expect(saveImageHandler()(rendererEvent, undefined)).resolves.toMatch(
+      /orca-paste-.*\.png$/
+    )
+
+    expect(fsWriteFileMock).toHaveBeenCalledTimes(1)
+    expect(callRuntimeEnvironmentMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​223 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​223 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

Fixes #17679

> Note: #17787 (community fork) targets the same issue with the same core routing change plus a shared-protocol refactor across desktop main and the web preload. This PR is the minimal, in-repo version of the routing fix only, with the regression pinned at the IPC seam against the real SSH provider registry. Either can land; if #17787 is preferred, this one should be closed.

## ELI5

You have three machines in a row: your laptop, an Ubuntu box running Orca Server, and a Jetson that the Ubuntu box reaches over SSH. You copy a screenshot on the laptop and paste it into a terminal on the Jetson.

The laptop's job is only to hand the image to the Ubuntu box and say "put this on *your* Jetson connection." Instead, when the laptop saw the word "Jetson" in the request it went looking for a Jetson SSH connection in its *own* pocket. It never had one (the Ubuntu box dialed that connection, not the laptop), so it gave up with "Remote connection dropped. Click Reconnect" — advice that cannot help, because there is nothing on the laptop to reconnect.

Now the laptop hands the image to the Ubuntu box whenever the Ubuntu box owns the workspace, and tells it which of its SSH targets should receive the file.

## Root cause

`src/main/window/clipboard-ipc-handlers.ts` `saveClipboardImageBufferForTarget` routed to the paired runtime only when `runtimeEnvironmentId && !connectionId`. It read "has an SSH connectionId" as "is a client-local SSH target". In the nested topology the renderer legitimately supplies **both** ids (`terminal-clipboard-paste.ts` forwards them verbatim; `getRepoSshConnectionId` documents that a `connectionId` beside a `runtime:` host names the *runtime's* nested target). So the runtime was skipped and control fell to `clipboard-image-temp-file.ts`, which called `requireSshFilesystemProvider` on a registry (`src/main/providers/ssh-filesystem-dispatch.ts`) that only holds connections **this process** established. The nested connection lives in the Ubuntu server's process; the lookup missed and threw `SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE` — the reported string verbatim.

Second arm of the same defect: `clipboard-runtime-image-upload.ts` hardcoded `connectionId: null` on both the chunked `startImageUpload` and the single-frame `saveImageAsTempFile` fallback, so even after relaxing the guard the runtime would have saved the file on the Ubuntu host rather than the Jetson. Relaxing the guard alone would move the failure, not remove it.

## Fix (one change, both arms)

- `clipboard-ipc-handlers.ts`: route to the runtime whenever a `runtimeEnvironmentId` is present, forwarding the `connectionId` (or `null`).
- `clipboard-runtime-image-upload.ts`: thread `connectionId` through `startImageUpload` and the single-frame fallback.

Unchanged and pinned: plain client-local SSH (`connectionId` only) still uses this process's provider registry; plain local paste (no args) still writes to the OS temp dir; a client-dialed target that really is gone still reports the dropped-connection verdict.

## Boundaries

- **Wire compatibility — Rule 1 (safe).** No new field, opcode, or method. `clipboard.startImageUpload` / `clipboard.saveImageAsTempFile` have accepted `connectionId: string | null` since they were introduced, and the server already honours it on commit (`src/main/runtime/rpc/methods/clipboard.ts`). The web client has forwarded it all along (`web-clipboard-api.ts`). This PR only makes the desktop client send a value the server already understands.
- **SSH execution boundary.** The execution host (the runtime) now performs the save on its own SSH connection; the client no longer treats "not in my registry" as evidence about the remote connection's state.
- Not a git-worktree-only path: `getRuntimeEnvironmentIdForWorktree` / `getConnectionId` resolve folder workspaces too, and the main-process change is shape-only.
- Cross-platform: the reporter hit this on Windows and macOS clients; the change is in host-neutral routing.

## Reproduction

1. Orca Server on an Ubuntu box; desktop client paired to it as a Remote Orca Server.
2. From the Ubuntu server, add an SSH target (the reporter used a Jetson) and open a project on it.
3. Open a terminal in that project, copy an image on the client, paste.
4. Before: `Image paste failed: ... Remote connection dropped. Click Reconnect on the SSH target before retrying.`

## Before / after proof (#17679)

Probe at the IPC seam, `clipboard:saveImageAsTempFile`, with only `electron` and the runtime transport mocked; the **real** `ssh-filesystem-dispatch` registry is used, with one client-dialed connection registered and the nested target deliberately absent (as in the real client process). Same instrument that reproduced the reported string.

| arg shape (built the way the renderer builds it) | origin/main | this PR |
|---|---|---|
| A nested: `{connectionId:'jetson', runtimeEnvironmentId:'ubuntu-server'}` | `ERR Remote connection dropped. Click Reconnect on the SSH target before retrying.` — runtime calls=**0** | `OK /tmp/on-runtime-target.png` — runtime calls=3, `startImageUpload {connectionId:'jetson'}` |
| B runtime only: `{runtimeEnvironmentId:'ubuntu-server'}` | OK, `startImageUpload {connectionId:null}` | OK, `startImageUpload {connectionId:null}` (unchanged) |
| C both ids, unknown env | `ERR Remote connection dropped ...` (runtime never consulted) | `ERR Unknown environment` (runtime's own verdict, runtime calls=1) |
| D client-local SSH: `{connectionId:'client-dialed'}` | OK `/var/tmp/orca-paste-...png`, runtime calls=0 | OK, runtime calls=0 (unchanged) |
| E plain local: `undefined` | OK `/tmp/orca-paste-...png` | OK (unchanged) |

Symptom map: (a) the paste failure — row A; (b) the misleading Reconnect advice — row A/C now surface the runtime's own verdict; (c) hardcoded `connectionId:null` — row A's `startImageUpload` params now name the target; (d) client-local SSH and plain local keep working — rows D/E.

Not yet measured on a real three-machine stack; the nested arg shape is established from the renderer selectors against the repo's own fixtures (`connection-context.test.ts` "keeps a runtime host nested SSH target"). An end-to-end confirmation on real nested hardware is worth doing once this lands.

## Verification bar

New `src/main/window/clipboard-runtime-owned-ssh-paste.test.ts` (7 tests, real SSH registry, nested args passed as one object and asserted from the same object the handler received). Per-regression mutation results — each mutation re-introduces exactly one defect:

| mutation | failing tests |
|---|---|
| M0 origin/main production files | 3 (nested chunked, nested fallback, runtime verdict) |
| M1 restore `&& !args?.connectionId` guard only | 3 |
| M2 `startImageUpload` hardcodes `connectionId: null` | 1 (nested chunked only) |
| M3 single-frame fallback hardcodes `connectionId: null` | 1 (nested fallback only) |
| M4 handler drops the 4th arg | 2 (both nested) |
| M5 over-correction: any `connectionId` goes to the runtime | 2 (client-dialed SSH, dropped client target) |
| restored | 0 |

Also green: `clipboard-ipc-handlers.test.ts` (23), `runtime/rpc/methods/clipboard.test.ts`, `web-preload-api-clipboard.test.ts`, `terminal-clipboard-paste.test.ts`, `clipboard-dashboard-popout-access.test.ts`; `pnpm tc:node`; `pnpm run check:code-quality:changed`; oxfmt.
