### PR TITLE
fix(explorer): let the git-ignored toggle govern node_modules

### DIFF
--- a/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.test.ts
@@ -10,7 +10,51 @@ vi.mock('./file-explorer-operation-owner', () => ({
   getFileExplorerOwnerUnresolvedMessage: () => 'unresolved'
 }))
 
-import { readFileExplorerDirectory } from './file-explorer-directory-listing'
+import {
+  fileExplorerEntriesToTreeNodes,
+  readFileExplorerDirectory
+} from './file-explorer-directory-listing'
+import { createVisibleFileExplorerRowProjection } from './useFileExplorerVisibleRowProjection'
+
+describe('fileExplorerEntriesToTreeNodes', () => {
+  // Why: issue #19198 — node_modules was dropped here, upstream of every toggle, so
+  // "Show Git Ignored Files" could never restore it on any route (local, SSH, paired).
+  it('keeps node_modules in the tree so the git-ignored toggle decides its visibility', async () => {
+    readRuntimeDirectory.mockResolvedValueOnce([
+      { name: 'node_modules', isDirectory: true, isSymlink: false },
+      { name: '.git', isDirectory: true, isSymlink: false },
+      { name: 'package.json', isDirectory: false, isSymlink: false }
+    ])
+    const listing = await readFileExplorerDirectory('wt-1', '/w', '/w')
+    const children = fileExplorerEntriesToTreeNodes(
+      listing.entries,
+      '/w',
+      -1,
+      '/w',
+      listing.operationOwner
+    )
+    expect(children.map((node) => node.relativePath)).toEqual(['node_modules', 'package.json'])
+
+    const input = {
+      dirCache: { '/w': { children } },
+      expanded: new Set<string>(),
+      worktreePath: '/w'
+    }
+    const ignoredSet = new Set(['node_modules'])
+    const visible = (showGitIgnoredFiles: boolean): string[] => {
+      const projection = createVisibleFileExplorerRowProjection(input, {
+        ignoredSet,
+        showDotfiles: true,
+        showGitIgnoredFiles
+      })
+      return projection
+        .getVisibleSlice(0, projection.getVisibleCount() - 1)
+        .map((row) => row.relativePath)
+    }
+    expect(visible(true)).toEqual(['node_modules', 'package.json'])
+    expect(visible(false)).toEqual(['package.json'])
+  })
+})
 
 describe('readFileExplorerDirectory', () => {
   it('re-sorts backend order — remote-runtime and paired-web routes return the host order verbatim', async () => {

--- a/src/renderer/src/components/right-sidebar/file-explorer-entries.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-entries.test.ts
@@ -20,7 +20,7 @@ describe('shouldIncludeFileExplorerEntry', () => {
     ).toBe(true)
   })
 
-  it('still excludes internal and bulky directories', () => {
+  it('excludes only .git — node_modules stays loadable so the git-ignored toggle governs it', () => {
     expect(
       shouldIncludeFileExplorerEntry({
         name: '.git',
@@ -35,7 +35,7 @@ describe('shouldIncludeFileExplorerEntry', () => {
         isDirectory: true,
         isSymlink: false
       })
-    ).toBe(false)
+    ).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/right-sidebar/file-explorer-entries.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-entries.ts
@@ -1,7 +1,10 @@
 import type { DirEntry } from '../../../../shared/filesystem-entry-types'
 
+// Why: `.git` is the only listing-time exclusion — `git check-ignore` never reports it,
+// so no toggle could govern it downstream. Everything else (node_modules included) must
+// stay loadable so the "Show Git Ignored Files" toggle actually decides its visibility.
 export function shouldIncludeFileExplorerEntry(entry: DirEntry): boolean {
-  return entry.name !== '.git' && entry.name !== 'node_modules'
+  return entry.name !== '.git'
 }
 
 function isDotfileSegment(segment: string): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

Fixes #19198

## ELI5

The file explorer had a hard-coded rule: "never show a folder called `node_modules`". That rule ran the moment a directory was read, before the "Show Git Ignored Files" checkbox ever got a look at the rows. So the checkbox was telling the truth about every other ignored file (e.g. `debug.log` showed up dimmed and went away when unchecked) but silently lied about `node_modules`, which never appeared on any host. This PR removes that hard-coded rule so `node_modules` is treated like any other git-ignored folder: visible and dimmed when the toggle is on, hidden when it is off.

`.git` is deliberately still excluded at listing time. `git check-ignore` never reports `.git`, so no visibility toggle could ever govern it; showing it would only add an un-hideable internal directory to every repo.

## Root cause

`src/renderer/src/components/right-sidebar/file-explorer-entries.ts` — `shouldIncludeFileExplorerEntry` unconditionally dropped `node_modules` (and `.git`). It is applied inside `fileExplorerEntriesToTreeNodes` (`file-explorer-directory-listing.ts`), the only builder of explorer tree rows, which runs at listing time upstream of `createVisibleFileExplorerRowProjection` where the dotfile / git-ignored toggles live. Every route (local, SSH, paired runtime) feeds `readRuntimeDirectory` output through the same filter, which is why the symptom is route-independent and why the host does return `node_modules` over the wire.

This is a renderer-only change. No RPC params, stream frames, or host-published content change (remote wire compatibility: no rule engaged). No SSH execution-boundary verdicts are touched. Folder workspaces are unaffected: without git the ignored projection is empty and `node_modules` now simply lists like any other folder.

## Reproduction (issue #19198)

1. Repo with `.gitignore` containing `node_modules/` and `debug.log`, plus a populated `node_modules/` on disk.
2. Open it in Orca (local or via SSH), open the Files sidebar, "Show Git Ignored Files" checked.
3. Expected: `node_modules` listed, dimmed/italic as ignored. Actual: absent; `debug.log` behaves correctly.

## Before / after proof

Measured in the dev Electron app (this worktree, CDP-driven), reading the rendered explorer rows from the DOM (`[data-index] button span.truncate`, `italic` = ignored decoration) while flipping the setting on -> off -> on. Same fixture repo on both routes.

**Local route** (`/private/tmp/orca-19198/local-repo`, macOS):

| toggle | before | after |
| --- | --- | --- |
| on | `src, .gitignore, debug.log(italic), package.json` | `node_modules(italic), src, .gitignore, debug.log(italic), package.json` |
| off | `src, .gitignore, package.json` | `src, .gitignore, package.json` |
| on again | `src, .gitignore, debug.log(italic), package.json` | `node_modules(italic), src, .gitignore, debug.log(italic), package.json` |

**SSH route** (`openclaw` Ubuntu host, `/tmp/orca-19198-repo`, relay connected):

| toggle | before | after |
| --- | --- | --- |
| on | `src, .gitignore, debug.log(italic), package.json` | `node_modules(italic), src, .gitignore, debug.log(italic), package.json` |
| off | `src, .gitignore, package.json` | `src, .gitignore, package.json` |
| on again | `src, .gitignore, debug.log(italic), package.json` | `node_modules(italic), src, .gitignore, debug.log(italic), package.json` |

Symptoms covered: (a) `node_modules` now appears on the SSH host; (b) the toggle now governs it (hidden when off); (c) identical result on the local route; (d) no host/transport change; (e) `.git` stays excluded, deliberately, per above.

## Tests

- `file-explorer-entries.test.ts`: the pin that previously asserted `node_modules` is excluded now asserts it is included and `.git` is not.
- `file-explorer-directory-listing.test.ts`: new test feeds `node_modules` / `.git` / `package.json` through `readFileExplorerDirectory` -> `fileExplorerEntriesToTreeNodes` -> `createVisibleFileExplorerRowProjection`, asserting the row survives listing and is governed by `showGitIgnoredFiles`.
- Mutation check: re-adding `&& entry.name !== 'node_modules'` to the predicate fails exactly these two tests (`expected false to be true`; `expected ['package.json'] to deeply equal ['node_modules','package.json']`).
- `vitest run src/renderer/src/components/right-sidebar`: 228 files / 1998 tests pass. `pnpm tc:web`, `oxlint`, `oxfmt`, `check:code-quality:changed` clean.

## Not changed

- `.git` remains hidden (see ELI5).
- Watcher exclusions (`filesystem-watcher-ignore.ts`) still skip `node_modules` for churn reasons; the explorer refreshes it on expand/manual refresh like before for other ignored dirs.
