### PR TITLE
test(relay): pin the desktop region list to the relay contract

### DIFF
--- a/src/main/runtime/relay/relay-region-probe.test.ts
+++ b/src/main/runtime/relay/relay-region-probe.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { RELAY_REGIONS } from './relay-region-probe'
+
+// Read as text, not imported: `cloud/` is a separate pnpm workspace on a different zod major that
+// the desktop build never installs, so a TS import would not resolve here.
+const CONTRACT_SOURCE = readFileSync(
+  new URL('../../../../cloud/packages/relay-contract/src/relay-regions.ts', import.meta.url),
+  'utf8'
+)
+
+describe('RELAY_REGIONS', () => {
+  it('matches the relay contract exactly, region for region and in order', () => {
+    const declaration = /^export const RELAY_REGIONS = \[([^\]]+)\] as const$/m.exec(
+      CONTRACT_SOURCE
+    )
+    expect(
+      declaration,
+      'relay-regions.ts no longer declares RELAY_REGIONS as an inline array'
+    ).not.toBeNull()
+    const contractRegions = [...declaration![1].matchAll(/'([^']+)'/g)].map(([, region]) => region)
+    expect(contractRegions.length).toBeGreaterThan(0)
+
+    // A longer desktop list withholds the region hint fleet-wide (the catalog can never reach
+    // RELAY_REGIONS.length); a shorter one caches a hint won against an incomplete catalog. Order
+    // is pinned too because bestMeasurement breaks latency ties on the RELAY_REGIONS index.
+    expect([...RELAY_REGIONS]).toEqual(contractRegions)
+  })
+})

--- a/src/main/runtime/relay/relay-region-probe.test.ts
+++ b/src/main/runtime/relay/relay-region-probe.test.ts
@@ -9,17 +9,32 @@ const CONTRACT_SOURCE = readFileSync(
   'utf8'
 )
 
+const DECLARATION = /^export const RELAY_REGIONS = \[([^\]]+)\] as const(?: satisfies .+)?$/m
+const QUOTED_REGION = /^(['"])([^'"]+)\1$/
+
 describe('RELAY_REGIONS', () => {
   it('matches the relay contract exactly, region for region and in order', () => {
-    const declaration = /^export const RELAY_REGIONS = \[([^\]]+)\] as const$/m.exec(
-      CONTRACT_SOURCE
-    )
+    const declaration = DECLARATION.exec(CONTRACT_SOURCE)
     expect(
       declaration,
       'relay-regions.ts no longer declares RELAY_REGIONS as an inline array'
     ).not.toBeNull()
-    const contractRegions = [...declaration![1].matchAll(/'([^']+)'/g)].map(([, region]) => region)
-    expect(contractRegions.length).toBeGreaterThan(0)
+
+    const elements = declaration![1].split(',').map((element) => element.trim())
+    if (elements.at(-1) === '') {
+      elements.pop() // trailing comma
+    }
+    expect(elements.length).toBeGreaterThan(0)
+    const contractRegions = elements.map((element) => {
+      const quoted = QUOTED_REGION.exec(element)
+      // Every element must parse: silently skipping one would hide a contract region from the
+      // comparison below and let the two lists diverge while this test stayed green.
+      expect(
+        quoted,
+        `relay-regions.ts element is not a quoted string literal: ${element}`
+      ).not.toBeNull()
+      return quoted![2]
+    })
 
     // A longer desktop list withholds the region hint fleet-wide (the catalog can never reach
     // RELAY_REGIONS.length); a shorter one caches a hint won against an incomplete catalog. Order


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Why

\`src/main/runtime/relay/relay-region-probe.ts\` hand-copies \`RELAY_REGIONS\` from \`cloud/packages/relay-contract/src/relay-regions.ts\` because \`cloud/\` is a separate pnpm workspace the desktop build never installs. After #19349 the desktop withholds its region hint whenever the director catalog lists fewer regions than the desktop's list, so a desktop list longer than the contract's would withhold hints fleet-wide, and a shorter one would cache hints won against an incomplete catalog. Order matters too: latency ties break on the list index.

## What

One test that reads the contract file as text and asserts exact, ordered equality with the desktop constant. Fails on an addition, removal, or reorder on either side. Read as text rather than imported because the contract pins zod 3 and the desktop root is on zod 4.

## Verification

- Failing-first: adding \`europe-west1\` to the desktop list fails with the expected diff.
- \`pnpm test src/main/runtime/relay/relay-region-probe.test.ts\`, \`pnpm tc:node\`, \`pnpm run check:code-quality:changed\` all green.

Test-only, no runtime change.