### PR TITLE
fix(runtime): stop a first status publication retiring in-flight worktree scans

### DIFF
--- a/src/renderer/src/store/slices/runtime-status-first-publication.test.ts
+++ b/src/renderer/src/store/slices/runtime-status-first-publication.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import {
+  clearRuntimeEnvironmentConnectionGenerationsForTests,
+  createRuntimeStatusSlice,
+  getRuntimeEnvironmentConnectionGeneration,
+  type RuntimeStatusSlice
+} from './runtime-status'
+
+vi.mock('sonner', () => ({
+  toast: { warning: vi.fn(), dismiss: vi.fn() }
+}))
+
+function createSliceStore() {
+  return create<RuntimeStatusSlice>()((...a) => ({
+    ...createRuntimeStatusSlice(...(a as unknown as Parameters<typeof createRuntimeStatusSlice>))
+  }))
+}
+
+function makeStatus(runtimeId: string): RuntimeStatus {
+  return {
+    runtimeId,
+    rendererGraphEpoch: 0,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    runtimeProtocolVersion: 3,
+    minCompatibleRuntimeClientVersion: 3
+  } as RuntimeStatus
+}
+
+beforeEach(() => {
+  clearRuntimeEnvironmentConnectionGenerationsForTests()
+  vi.stubGlobal('window', { api: {}, dispatchEvent: vi.fn() })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('first runtime status publication', () => {
+  it('does not advance the connection generation when no entry existed', () => {
+    // Regression (#19241): the first status for a paired environment counted as a
+    // connection change, so the generation fence retired worktree scans already in
+    // flight against that same connection. Those repos stayed absent from the sidebar
+    // until an unrelated refresh happened to run.
+    const store = createSliceStore()
+    const before = getRuntimeEnvironmentConnectionGeneration('env-a')
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')).toBeUndefined()
+
+    store
+      .getState()
+      .setRuntimeEnvironmentStatus('env-a', { status: makeStatus('runtime-a'), checkedAt: 1 })
+
+    expect(getRuntimeEnvironmentConnectionGeneration('env-a')).toBe(before)
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(
+      before
+    )
+  })
+
+  it('still advances when a recorded-unreachable host comes back', () => {
+    // The other reading of the old `previous?.status == null`: this one IS a reconnect.
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 1 })
+    const before = getRuntimeEnvironmentConnectionGeneration('env-a')
+
+    store
+      .getState()
+      .setRuntimeEnvironmentStatus('env-a', { status: makeStatus('runtime-a'), checkedAt: 2 })
+
+    expect(getRuntimeEnvironmentConnectionGeneration('env-a')).toBe(before + 1)
+  })
+})

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -181,7 +181,8 @@ describe('runtime-status slice', () => {
 
     const map = store.getState().runtimeStatusByEnvironmentId
     expect(map.size).toBe(1)
-    expect(map.get('env-a')).toEqual({ status: null, checkedAt: 5, connectionGeneration: 1 })
+    // Generation 0: a first publication is not a reconnect, and going offline never bumps.
+    expect(map.get('env-a')).toEqual({ status: null, checkedAt: 5, connectionGeneration: 0 })
   })
 
   it('retains a learned paired device id after disconnecting a legacy environment', () => {
@@ -302,7 +303,8 @@ describe('runtime-status slice', () => {
     })
 
     expect(store.getState().runtimeStatusByEnvironmentId).not.toBe(before)
-    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(2)
+    // The first publication holds 0; only the runtime-id change advances it.
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(1)
   })
 
   it('does not toast when the first probe finds a saved server offline', () => {
@@ -525,14 +527,16 @@ describe('runtime-status slice', () => {
       status: makeStatus({ runtimeId: 'runtime-a' }),
       checkedAt: 2
     })
-    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(1)
+    // Neither the first publication nor a stable re-poll is a connection change.
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(0)
 
     store.getState().setRuntimeEnvironmentStatus('env-a', { status: null, checkedAt: 3 })
     store.getState().setRuntimeEnvironmentStatus('env-a', {
       status: makeStatus({ runtimeId: 'runtime-a' }),
       checkedAt: 4
     })
-    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(2)
+    // Offline -> online is a real reconnect, so recovery still advances.
+    expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(1)
   })
 
   it('keeps stored and canonical generations aligned after same-id re-pairing', () => {
@@ -552,7 +556,9 @@ describe('runtime-status slice', () => {
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(
       getRuntimeEnvironmentConnectionGeneration('env-a')
     )
-    expect(getRuntimeEnvironmentConnectionGeneration('env-a')).toBe(3)
+    // The re-pair itself advanced the generation and dropped the entry; the first
+    // publication under the new pairing must not advance it a second time.
+    expect(getRuntimeEnvironmentConnectionGeneration('env-a')).toBe(1)
   })
 
   it('invalidates provider state only when the active runtime session changes', () => {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -173,9 +173,17 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
     }
     set((s) => {
       const sessionEnded = status.status === null && previous?.status != null
-      const connectionChanged =
+      // A reachable answer where we held none (never asked, or recorded unreachable) or
+      // where the runtime id moved starts a runtime session.
+      const runtimeSessionStarted =
         status.status !== null &&
         (previous?.status == null || previous.status.runtimeId !== status.status.runtimeId)
+      // Why narrower than the session start: a first publication has no prior connection to
+      // differ from, so it is not a reconnect. Advancing the generation there retires reads
+      // already issued against this very connection — a startup worktree scan that had
+      // already answered was discarded, leaving those repos absent until an unrelated
+      // refresh (#19241).
+      const connectionChanged = runtimeSessionStarted && previous !== undefined
       const activeEnvironmentId = s.settings?.activeRuntimeEnvironmentId?.trim()
       const connectionGeneration = connectionChanged
         ? runtimeStatusConnectionGeneration.advanceRuntimeEnvironmentConnectionGeneration(
@@ -186,7 +194,9 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
           runtimeStatusConnectionGeneration.getRuntimeEnvironmentConnectionGeneration(
             environmentId
           ))
-      if (activeEnvironmentId === environmentId && (sessionEnded || connectionChanged)) {
+      // Why the session flag and not `connectionChanged`: integration-readiness caches key
+      // off the runtime session, for which a first publication is a real transition.
+      if (activeEnvironmentId === environmentId && (sessionEnded || runtimeSessionStarted)) {
         bumpProviderRuntimeSessionGeneration()
       }
       const nextEntry = { ...status, connectionGeneration }

--- a/src/renderer/src/store/slices/worktrees-runtime-connection-generation-fence.test.ts
+++ b/src/renderer/src/store/slices/worktrees-runtime-connection-generation-fence.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import type { RuntimeEnvironmentCallRequest } from '../../runtime/runtime-compatibility-test-fixture'
+import { advanceRuntimeEnvironmentConnectionGeneration } from './runtime-status-connection-generation'
+import { makeDetectedResult } from './worktrees-detected-listing-fixtures'
+import { makeWorktree } from './worktrees-slice-test-fixtures'
+import {
+  createTestStore,
+  resetRemoteRuntimeMocks,
+  resetWorktreeSliceModuleMemory,
+  runtimeEnvironmentCall
+} from './worktrees-slice-test-harness'
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+const ENV = 'env-remote'
+const REPO_IDS = ['repo1', 'repo2', 'repo3', 'repo4', 'repo5'] as const
+
+function seedRuntimeRepos(store: ReturnType<typeof createTestStore>) {
+  store.setState({
+    repos: REPO_IDS.map((id) => ({
+      id,
+      path: `C:/remote/${id}`,
+      executionHostId: `runtime:${ENV}`
+    })),
+    settings: { activeRuntimeEnvironmentId: ENV },
+    hasHydratedWorktreePurge: true
+  } as unknown as Partial<AppState>)
+}
+
+function detectedFor(repoId: string) {
+  return makeDetectedResult(repoId, [
+    makeWorktree({
+      id: `${repoId}::/remote/${repoId}/wt`,
+      repoId,
+      path: `/remote/${repoId}/wt`,
+      branch: 'refs/heads/main'
+    })
+  ])
+}
+
+function repoOf(args: RuntimeEnvironmentCallRequest): string {
+  return (args.params as { repo: string }).repo
+}
+
+function detectedListReply(repoId: string) {
+  return {
+    id: 'rpc',
+    ok: true,
+    result: detectedFor(repoId),
+    _meta: { runtimeId: 'runtime-remote' }
+  }
+}
+
+beforeEach(() => {
+  resetWorktreeSliceModuleMemory()
+  vi.clearAllMocks()
+  resetRemoteRuntimeMocks()
+})
+
+describe('fetchAllWorktrees across a runtime connection-generation change', () => {
+  it('publishes every repo when nothing perturbs the connection', async () => {
+    const store = createTestStore()
+    seedRuntimeRepos(store)
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) =>
+      detectedListReply(repoOf(args))
+    )
+
+    await store.getState().fetchAllWorktrees()
+
+    expect(Object.keys(store.getState().worktreesByRepo).sort()).toEqual([...REPO_IDS])
+  })
+
+  it('re-reads instead of dropping the repos still in flight when the generation moves', async () => {
+    // Regression (#19241): scans run concurrently across a host's repos, so one generation
+    // bump discarded every repo still outstanding. Their rows then never reached the
+    // sidebar — a strict subset of the host's worktrees, stable until an unrelated refresh.
+    const store = createTestStore()
+    seedRuntimeRepos(store)
+    const parked = new Map<string, () => void>()
+    let bumped = false
+    runtimeEnvironmentCall.mockImplementation(async (args: RuntimeEnvironmentCallRequest) => {
+      const repo = repoOf(args)
+      // Park every repo but the first, so the bump lands with four scans outstanding.
+      if (repo !== 'repo1' && !bumped) {
+        await new Promise<void>((resolve) => parked.set(repo, resolve))
+      }
+      return detectedListReply(repo)
+    })
+
+    const fetching = store.getState().fetchAllWorktrees()
+    await vi.waitFor(() => expect(parked.size).toBe(REPO_IDS.length - 1))
+    bumped = true
+    advanceRuntimeEnvironmentConnectionGeneration(ENV)
+    for (const release of parked.values()) {
+      release()
+    }
+    await fetching
+
+    expect(Object.keys(store.getState().worktreesByRepo).sort()).toEqual([...REPO_IDS])
+    for (const repoId of REPO_IDS) {
+      expect(store.getState().worktreesByRepo[repoId]).toHaveLength(1)
+    }
+  })
+
+  it('gives up after one re-read so a churning connection cannot stall the caller', async () => {
+    const store = createTestStore()
+    seedRuntimeRepos(store)
+    const attemptsByRepo = new Map<string, number>()
+    runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+      const repo = repoOf(args)
+      attemptsByRepo.set(repo, (attemptsByRepo.get(repo) ?? 0) + 1)
+      // Bump on every answer: the retried read is stale again the moment it lands.
+      advanceRuntimeEnvironmentConnectionGeneration(ENV)
+      return detectedListReply(repo)
+    })
+
+    await store.getState().fetchAllWorktrees()
+
+    expect(Object.keys(store.getState().worktreesByRepo)).toEqual([])
+    for (const repoId of REPO_IDS) {
+      expect(attemptsByRepo.get(repoId)).toBe(2)
+    }
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/listing/detected-worktree-refresh.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/detected-worktree-refresh.ts
@@ -35,6 +35,15 @@ const runtimeDetectedWorktreeRefreshesInFlight = new Map<
   Promise<DetectedWorktreeListResult>
 >()
 
+const STALE_RUNTIME_GENERATION_ERROR = 'runtime_environment_generation_changed'
+// Why exactly one: a second stale answer means the connection is still churning, and
+// retrying into that would stall the caller instead of letting it fail visibly.
+const STALE_RUNTIME_GENERATION_RETRIES = 1
+
+export function isStaleRuntimeGenerationError(error: unknown): boolean {
+  return error instanceof Error && error.message === STALE_RUNTIME_GENERATION_ERROR
+}
+
 export const detectedWorktreeRefreshLeaseRegistry = createDetectedWorktreeRefreshLeaseRegistry({
   startProviderRequest: startDetectedWorktreeProviderRequest,
   cancelProviderRequest: async (request) => {
@@ -133,57 +142,82 @@ export function normalizeNotAdmittedProviderResult(
   }
 }
 
+async function listDetectedWorktreesForRuntimeRepoOnce(
+  settings: AppState['settings'],
+  repoId: string,
+  options: DetectedWorktreeRefreshOptions,
+  environmentId: string
+): Promise<DetectedWorktreeRefreshOutcome> {
+  // Why recomputed per attempt: the key embeds both generations, so a retry after a
+  // reconnect must not join the superseded connection's in-flight scan.
+  const key = detectedWorktreeRefreshKey(settings, repoId, options)
+  const connectionGeneration = getEnvironmentSshStateGeneration(environmentId)
+  const runtimeConnectionGeneration = getRuntimeEnvironmentConnectionGeneration(environmentId)
+  let refresh = runtimeDetectedWorktreeRefreshesInFlight.get(key)
+  if (!refresh) {
+    refresh = listDetectedWorktreesForRepo(settings, repoId, {
+      reuseRecentCompatibilityFailure: options.reuseRecentCompatibilityFailure
+    })
+    runtimeDetectedWorktreeRefreshesInFlight.set(key, refresh)
+  }
+  try {
+    const result = await refresh
+    if (
+      getEnvironmentSshStateGeneration(environmentId) !== connectionGeneration ||
+      getRuntimeEnvironmentConnectionGeneration(environmentId) !== runtimeConnectionGeneration
+    ) {
+      throw new Error(STALE_RUNTIME_GENERATION_ERROR)
+    }
+    // Why (#10562): the scan coalesces, but teardown must not — each caller carries
+    // its own known-id snapshot and purges its own state, so a caller that joined
+    // an in-flight scan would otherwise purge without ever stopping those terminals.
+    await teardownMissingWorktreeTerminalsBestEffort(
+      settings,
+      repoId,
+      options.connectionId,
+      options.knownWorktreeIds,
+      result
+    )
+    return {
+      status: 'admitted',
+      result,
+      executionHostId: options.executionHostId,
+      runtimeAuthority: {
+        environmentId,
+        connectionGeneration,
+        runtimeConnectionGeneration
+      }
+    }
+  } finally {
+    if (runtimeDetectedWorktreeRefreshesInFlight.get(key) === refresh) {
+      runtimeDetectedWorktreeRefreshesInFlight.delete(key)
+    }
+  }
+}
+
 export async function listDetectedWorktreesForRepoCoalesced(
   settings: AppState['settings'],
   repoId: string,
   options: DetectedWorktreeRefreshOptions
 ): Promise<DetectedWorktreeRefreshOutcome> {
-  const key = detectedWorktreeRefreshKey(settings, repoId, options)
   const target = getActiveRuntimeTarget(settings)
   if (target.kind === 'environment') {
-    const connectionGeneration = getEnvironmentSshStateGeneration(target.environmentId)
-    const runtimeConnectionGeneration = getRuntimeEnvironmentConnectionGeneration(
-      target.environmentId
-    )
-    let refresh = runtimeDetectedWorktreeRefreshesInFlight.get(key)
-    if (!refresh) {
-      refresh = listDetectedWorktreesForRepo(settings, repoId, {
-        reuseRecentCompatibilityFailure: options.reuseRecentCompatibilityFailure
-      })
-      runtimeDetectedWorktreeRefreshesInFlight.set(key, refresh)
-    }
-    try {
-      const result = await refresh
-      if (
-        getEnvironmentSshStateGeneration(target.environmentId) !== connectionGeneration ||
-        getRuntimeEnvironmentConnectionGeneration(target.environmentId) !==
-          runtimeConnectionGeneration
-      ) {
-        throw new Error('runtime_environment_generation_changed')
-      }
-      // Why (#10562): the scan coalesces, but teardown must not — each caller carries
-      // its own known-id snapshot and purges its own state, so a caller that joined
-      // an in-flight scan would otherwise purge without ever stopping those terminals.
-      await teardownMissingWorktreeTerminalsBestEffort(
-        settings,
-        repoId,
-        options.connectionId,
-        options.knownWorktreeIds,
-        result
-      )
-      return {
-        status: 'admitted',
-        result,
-        executionHostId: options.executionHostId,
-        runtimeAuthority: {
-          environmentId: target.environmentId,
-          connectionGeneration,
-          runtimeConnectionGeneration
+    for (let attempt = 0; ; attempt += 1) {
+      try {
+        return await listDetectedWorktreesForRuntimeRepoOnce(
+          settings,
+          repoId,
+          options,
+          target.environmentId
+        )
+      } catch (err) {
+        // Why re-read instead of surfacing: the fence proves this answer predates the
+        // current connection, not that the repo has no worktrees. Callers drop the repo
+        // on any throw, so a discarded scan left those rows absent until an unrelated
+        // refresh happened to run (#19241).
+        if (attempt >= STALE_RUNTIME_GENERATION_RETRIES || !isStaleRuntimeGenerationError(err)) {
+          throw err
         }
-      }
-    } finally {
-      if (runtimeDetectedWorktreeRefreshesInFlight.get(key) === refresh) {
-        runtimeDetectedWorktreeRefreshesInFlight.delete(key)
       }
     }
   }


### PR DESCRIPTION
## ELI5

You connect your Mac to a remote Orca machine. The sidebar shows a few of that machine's worktrees — but not all of them. Nothing you click brings the rest back. Then you create a new worktree over there, and suddenly the missing handful appears.

Here's what was happening. When the app asks a remote host "what worktrees do you have?", it asks about every repo at once, in parallel. While those questions are still out, the app separately gets its **first** "yes, I'm here" heartbeat from that host. The app treated that first heartbeat as *"the connection changed"* — and its rule for a changed connection is "throw away any answer that came back over the old one."

But nothing had changed. It was the same connection the questions were sent on. So every repo that hadn't answered yet got its perfectly good answer thrown in the bin, silently, with no retry. Whichever repos happened to answer first survived. That's your partial list. It stayed partial because nothing ever asks again — until creating a worktree triggers a fresh sweep, which is why that fixed it.

Two things were wrong, and both are fixed:

1. **A first hello is not a reconnect.** There was no earlier connection for it to differ from.
2. **A discarded answer should be re-asked, not dropped.** Even with a correct rule, a *real* reconnect mid-flight still silently deleted finished work.

## Root cause

`src/renderer/src/store/slices/runtime-status.ts` — `connectionChanged` was:

```ts
status.status !== null &&
(previous?.status == null || previous.status.runtimeId !== status.status.runtimeId)
```

`previous?.status == null` conflates two different states:

- `previous === undefined` — no entry yet. **Cold start.** Not a connection change.
- `previous.status === null` — we recorded the host unreachable, and it now answers. **A genuine reconnect.**

Only the second should advance the connection generation. Measured on the real store action: a cold-start publish moved the generation `0 -> 1`.

That generation is a fence. `src/renderer/src/store/slices/worktrees/listing/detected-worktree-refresh.ts` re-checks it *after* a `worktree.detectedList` has already resolved successfully and throws `runtime_environment_generation_changed`. `fetch-all-worktrees.ts:77` (and `:140`) catches that, `console.error`s, and moves on — the repo's rows never merge.

`fetchAllWorktrees` scans all of a host's repos concurrently via `mapReposForWorktreeRefresh`, so **one bump discards every repo still outstanding at that instant**. Whole repos at a time, arbitrary which — hence "a few, but not all" rather than a clean split. See [Confirmed prediction](#confirmed-prediction): the reporter independently confirmed that granularity.

Nothing re-reads afterwards: `src/renderer/src/components/sidebar/index.tsx:118-125` only re-runs `fetchAllWorktrees()` when `repoCount` changes. The recovery the user saw comes from `reposChanged`, which triggers `refreshRuntimeProjectWorktreesAndLineage` over *all* of that environment's repos (`runtime-client-ipc-bridge.ts:61-80`).

## The fix

**1. A first publication is not a connection change** (`runtime-status.ts`). Split the predicate in two:

```ts
const runtimeSessionStarted = status.status !== null &&
  (previous?.status == null || previous.status.runtimeId !== status.status.runtimeId)
const connectionChanged = runtimeSessionStarted && previous !== undefined
```

The provider-session bump deliberately keeps the **broader** predicate — integration-readiness caches key off the runtime session, for which a first publication *is* a real transition. That distinction is pinned by a mutation test (below).

**2. A stale-generation scan is re-read, not dropped** (`detected-worktree-refresh.ts`). The environment branch is extracted to `listDetectedWorktreesForRuntimeRepoOnce` and retried once against the new generation. The coalescing key embeds both generations and is recomputed per attempt, so a retry cannot join the superseded connection's in-flight scan. Bounded at exactly one retry: a second stale answer means the connection is still churning, and retrying into that would stall the caller instead of failing visibly.

I fixed **both** halves deliberately. Fixing only the predicate would leave a genuine mid-flight reconnect still silently deleting completed scans.

## Reproduction

`src/renderer/src/store/slices/worktrees-runtime-connection-generation-fence.test.ts` drives the real slice: 5 repos on one runtime host, one answers immediately, the generation moves while the other four are in flight.

**Before** (the fence discards them):

```
Failed to fetch worktrees for repo repo2: Error: runtime_environment_generation_changed
Failed to fetch worktrees for repo repo3: Error: runtime_environment_generation_changed
Failed to fetch worktrees for repo repo4: Error: runtime_environment_generation_changed
Failed to fetch worktrees for repo repo5: Error: runtime_environment_generation_changed
PUBLISHED: [ 'repo1' ]
```

**After**: all five publish, each with its row. The control case (nothing perturbs the connection) publishes all five before and after, so the test is not merely asserting "the happy path works".

Cold-start generation, measured through `setRuntimeEnvironmentStatus`: `0 -> 1` before, `0 -> 0` after.

## Mutation testing

Each assertion was checked against the specific defect it claims to catch — mutated one at a time, never a wholesale revert:

| Mutation | Test that failed |
|---|---|
| `connectionChanged = runtimeSessionStarted` (restore the first-publish bump) | `does not advance the connection generation when no entry existed` + 4 generation assertions in `runtime-status.test.ts` |
| Retry disabled (`attempt >= 0`) | `re-reads instead of dropping the repos still in flight` — reproduced `[ 'repo1' ]` exactly |
| Retry bound loosened to 2 | `gives up after one re-read so a churning connection cannot stall the caller` (`expected 3 to be 2`) |
| Provider bump narrowed to `connectionChanged` | existing `invalidates provider state only when the active runtime session changes` |

Four assertions in `runtime-status.test.ts` were updated rather than added to: they encoded the old first-publish off-by-one. Each still asserts its real invariant — that recovery advances, that stable re-polls don't, that a runtime-id change does, and that stored and canonical generations stay aligned after a re-pair. Only the numbers moved.

## Confirmed prediction

This mechanism makes a specific, falsifiable prediction about what the user should have seen. Because the scans run concurrently *per repo* and the fence discards a whole repo's result at a time, the missing worktrees must be absent in **whole-repo groups** — never scattered within a repo. Nothing else about the report constrains that: a partial list is equally consistent with rows going missing individually.

The reporter was asked which pattern they saw, without being told which answer the theory needed. **Whole repos at a time.**

A scattered-within-repo pattern would have falsified this fix and sent the investigation back to the visibility filter or the merge path. The answer could have gone either way, and it went the way the mechanism required. That is a successful prediction rather than a post-hoc fit, and it is stronger evidence than any amount of further code reading — it closes the one link between the mechanism and the user's actual session that code alone could not establish.

## Two traps for the next person

**The CLI is not the sidebar's reader.** `orca worktree list --json` reports *every* runtime host in `omittedHostIds`, including the one you're investigating. It cannot reproduce this, and reaching for it first leads straight to "not reproducible".

**`externalWorktreeVisibility: 'hide'` is a red herring here, ruled out with numbers.** On the host I measured, one repo returns 59 detected / 19 visible — 11 `external` + 29 `agent-scratch` rows suppressed by that repo's configured visibility. That is stable across both `worktree.detectedList` and `worktree.list`, and unchanged by creating a worktree, so it is not the disappearance being reported. Hidden rows and missing rows look identical in the output; this trap has nearly produced a false finding twice.

## Verification

- `pnpm tc` — clean
- `oxlint` — 0 errors (the new test lives in its own file rather than pushing `runtime-status.test.ts` past `max-lines`; no disable added)
- `pnpm run check:code-quality:changed` — 0 new findings across 5 changed files
- `pnpm format`
- `pnpm vitest run src/renderer/src/store src/renderer/src/hooks` — 504 files, 4243 tests, all passing

## Limitation, stated plainly

**I reproduced the mechanism on real slice code, not the user's session end-to-end.** The packaged app does not expose the renderer store (`__store` is build-gated on `VITE_EXPOSE_STORE`; no match in `app.asar`), the running instance has no CDP port, and renderer `console.error` is not forwarded to any log file — so the user's actual session left no readable trace. Restarting the app or pairing a second device to the shared host would have disturbed teammates actively using it, so I did neither.

The whole-repo granularity signature is **confirmed** by the reporter (above) — that gap is closed. What remains **inferred, not measured** is narrower: whether the status publish overlapped `fetchAllWorktrees` specifically *in their session*. The publisher is `probeRuntimeStatus`, fired when the runtime client-events subscription becomes ready (`runtime-client-ipc-bridge.ts:274,292`), concurrent with and independent of the deferred startup chain at `use-app-startup-hydration.ts:312-324`.

The experiment that would settle it: instrument a client at both sites and confirm the bump lands between the first and last `detectedList` of the startup batch. If the status publish reliably precedes `fetchAllWorktrees`, the race is unreachable at startup and the trigger is a genuine mid-session reconnect instead — narrower, and the same fix applies either way.

Separately, a hypothesis worth recording as **refuted**: this is not partition precedence. `repoWithFetchedOwner` (`src/renderer/src/store/repos/owner-routing.ts`) unconditionally stamps every repo fetched from a runtime target with `executionHostId: runtime:<envId>`, so remote rows arriving as `executionHostId: 'local'` or with none at all cannot collide with the client's local partition.
