### PR TITLE
fix(deps): update desktop parsers for security and bounded resource use

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3513,8 +3513,8 @@ packages:
   '@vscode/windows-process-tree@0.8.0':
     resolution: {integrity: sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
 
   '@xterm/addon-fit@0.12.0-beta.300':
@@ -3677,8 +3677,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.27:
-    resolution: {integrity: sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==}
+  baseline-browser-mapping@2.11.21:
+    resolution: {integrity: sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3715,8 +3715,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.28.2:
-    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+  browserslist@4.28.9:
+    resolution: {integrity: sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -3779,8 +3779,8 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001810:
+    resolution: {integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4306,8 +4306,8 @@ packages:
   electron-publish@26.15.3:
     resolution: {integrity: sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==}
 
-  electron-to-chromium@1.5.351:
-    resolution: {integrity: sha512-9D7Iqx8RImSvCnOsj86rCH6eQjZFQoM04Jn6HnZVM0Nu/G58/gmKYQ1d12MZTbjQbQSTGI8nwEy07ErsA2slLA==}
+  electron-to-chromium@1.5.422:
+    resolution: {integrity: sha512-UvA/32XqrLDdZSn7Jllo1AYNcWji/G0d5M0GTViE7KoGBiMunw3a34Sb2KO4ZZyrSEhqsxFoVhWWJshdyfKqJA==}
 
   electron-updater@6.8.9:
     resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
@@ -4525,8 +4525,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -5563,8 +5563,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5600,8 +5600,9 @@ packages:
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
-  node-releases@2.0.38:
-    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+  node-releases@2.0.54:
+    resolution: {integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==}
+    engines: {node: '>=18'}
 
   nopt@9.0.0:
     resolution: {integrity: sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==}
@@ -5856,8 +5857,8 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  postcss-selector-parser@7.1.1:
-    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+  postcss-selector-parser@7.1.6:
+    resolution: {integrity: sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw==}
     engines: {node: '>=4'}
 
   postcss@8.5.25:
@@ -5977,8 +5978,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -6392,8 +6393,8 @@ packages:
     resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
     engines: {node: '>= 0.4'}
 
-  side-channel@1.1.0:
-    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -6755,8 +6756,8 @@ packages:
   unzipper@0.12.5:
     resolution: {integrity: sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==}
 
-  update-browserslist-db@1.2.3:
-    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+  update-browserslist-db@1.3.2:
+    resolution: {integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -7119,7 +7120,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -7739,7 +7740,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
       express: 5.2.1(supports-color@7.2.0)
-      express-rate-limit: 8.5.2(express@5.2.1(supports-color@7.2.0))
+      express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -7761,7 +7762,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
       express: 5.2.1(supports-color@7.2.0)
-      express-rate-limit: 8.5.2(express@5.2.1(supports-color@7.2.0))
+      express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.13.0
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -9826,7 +9827,7 @@ snapshots:
       node-addon-api: 7.1.0
     optional: true
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
   '@xterm/addon-fit@0.12.0-beta.300(@xterm/xterm@6.1.0-beta.303(patch_hash=98756bcedc402bcdb7c6ab7b015d2e59cd18e97b03a2c06a27e95bb3ba429d9d))':
     dependencies:
@@ -9882,7 +9883,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -9994,7 +9995,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.27: {}
+  baseline-browser-mapping@2.11.21: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -10014,7 +10015,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -10040,13 +10041,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.2:
+  browserslist@4.28.9:
     dependencies:
-      baseline-browser-mapping: 2.10.27
-      caniuse-lite: 1.0.30001791
-      electron-to-chromium: 1.5.351
-      node-releases: 2.0.38
-      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+      baseline-browser-mapping: 2.11.21
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.422
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.9)
 
   buffer-from@1.1.2: {}
 
@@ -10119,7 +10120,7 @@ snapshots:
 
   camelcase@5.3.1: {}
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -10647,7 +10648,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-to-chromium@1.5.351: {}
+  electron-to-chromium@1.5.422: {}
 
   electron-updater@6.8.9(supports-color@7.2.0):
     dependencies:
@@ -10862,7 +10863,7 @@ snapshots:
 
   exponential-backoff@3.1.3: {}
 
-  express-rate-limit@8.5.2(express@5.2.1(supports-color@7.2.0)):
+  express-rate-limit@8.5.2(express@5.2.1):
     dependencies:
       express: 5.2.1(supports-color@7.2.0)
       ip-address: 10.4.0
@@ -10889,7 +10890,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.2.1
       router: 2.2.0(supports-color@7.2.0)
       send: 1.2.1(supports-color@7.2.0)
@@ -10922,7 +10923,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -12250,7 +12251,7 @@ snapshots:
   nan@2.26.2:
     optional: true
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -12289,7 +12290,7 @@ snapshots:
     dependencies:
       node-addon-api: 7.1.1
 
-  node-releases@2.0.38: {}
+  node-releases@2.0.54: {}
 
   nopt@9.0.0:
     dependencies:
@@ -12575,7 +12576,7 @@ snapshots:
 
   plist@3.1.0:
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -12590,14 +12591,14 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-selector-parser@7.1.1:
+  postcss-selector-parser@7.1.6:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12743,9 +12744,10 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
-      side-channel: 1.1.0
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
 
@@ -13222,7 +13224,7 @@ snapshots:
       '@dotenvx/dotenvx': 1.66.0
       '@modelcontextprotocol/sdk': 1.30.0(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       commander: 14.0.3
       cosmiconfig: 9.0.1(typescript@7.0.2)
       dedent: 1.7.2
@@ -13236,7 +13238,7 @@ snapshots:
       open: 11.0.0
       ora: 8.2.0
       postcss: 8.5.25
-      postcss-selector-parser: 7.1.1
+      postcss-selector-parser: 7.1.6
       prompts: 2.4.2
       recast: 0.23.11
       stringify-object: 5.0.0
@@ -13296,7 +13298,7 @@ snapshots:
       object-inspect: 1.13.4
       side-channel-map: 1.0.1
 
-  side-channel@1.1.0:
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -13668,9 +13670,9 @@ snapshots:
       graceful-fs: 4.2.11
       node-int64: 0.4.0
 
-  update-browserslist-db@1.2.3(browserslist@4.28.2):
+  update-browserslist-db@1.3.2(browserslist@4.28.9):
     dependencies:
-      browserslist: 4.28.2
+      browserslist: 4.28.9
       escalade: 3.2.0
       picocolors: 1.1.1
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​54 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

**Ready for review, with baseline golden-test failures disclosed.** [Final evidence and unchanged-base comparison](https://github.com/stablyai/orca/pull/19361#issuecomment-5576426602): 75,654 tests pass; Linux/Windows packaging passes. Both extra golden failure modes reproduce on unchanged dependencies.

## ELI5

Update a small set of dependencies with documented security, performance and correctness fixes. Keep incompatible migrations and native runtime changes out of this update group.

## What Changed / Why

# Dependency review — 2026-09-07

Reviewed the desktop, cloud, mobile and docs-site manifests and lockfiles against npm metadata, audit advisories and upstream release notes/source comparisons. Installed versions can differ from manifest ranges; the versions below are lockfile versions. The docs site must be audited with `pnpm --ignore-workspace audit` from `docs/site` to avoid accidentally auditing the desktop workspace.

## Desktop updates selected

These are transitive updates within their parents' existing ranges. Direct dependencies, native binaries, local patches, package-manager version and remote protocol remain unchanged. No new override forces an incompatible dependency major.

| Dependency              | Locked change   | Concrete benefit and upstream evidence                                                                                                                                                                                            | Compatibility assessment                                                                                                                                                                                                                                                                                      |
| ----------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| qs                      | 6.15.2 → 6.16.0 | [Changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md): fixes bracket/comma array-limit bypass and attacker-controlled non-callable `isBuffer`; the intervening release makes compaction O(n).                          | Used through Express/body-parser in the MCP SDK. Same major and accepted parent range; ordinary nested queries and adversarial array-limit/constructor cases checked. The new stringify depth option defaults to Infinity, preserving the default. Malformed/over-limit input intentionally changes behavior. |
| fast-uri                | 3.1.5 → 3.1.7   | [Source comparison](https://github.com/fastify/fast-uri/compare/v3.1.5...v3.1.7): fixes host/scheme/IPv6 canonicalization confusion, reserved-character corruption and URI validation.                                            | Stays on the 3.x backport line consumed by Ajv. Includes the follow-up unterminated-bracket compatibility repair after 3.1.6. Checked reserved path characters and IPv6 equivalence. No claim that Orca directly exposes an SSRF endpoint.                                                                    |
| @xmldom/xmldom          | 0.8.13 → 0.8.15 | [Changelog](https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md): XML-name injection checks and linear-time/memory parsing improvements for hostile documents.                                                              | Stays on the 0.8 LTS line used by plist/Electron packaging. Ordinary plist round-trip and invalid entity-name rejection checked. Well-formed document behavior is preserved; malformed names are deliberately rejected/reported more strictly.                                                                |
| postcss-selector-parser | 7.1.1 → 7.1.6   | [Changelog](https://github.com/postcss/postcss-selector-parser/blob/master/CHANGELOG.md): bounds recursive AST work and fixes quadratic flat-selector parsing; repairs malformed selectors and namespace whitespace.              | Build/scaffolding dependency through shadcn, same major. Includes 7.1.4's serialization follow-up instead of stopping at the first security fix. Checked selector round-trip and malformed input.                                                                                                             |
| browserslist            | 4.28.2 → 4.28.9 | [Source comparison](https://github.com/browserslist/browserslist/compare/4.28.2...4.28.9): bounds query caching, prevents unsafe stats writes, improves query parsing and correctly compares Electron multi-digit minor versions. | Build-time Babel/shadcn dependency, same major. Explicit Electron range query and production build pass. Updated browser data can legitimately change selected compilation targets.                                                                                                                           |
| nanoid                  | 3.3.17 → 3.3.18 | [Source comparison](https://github.com/ai/nanoid/compare/3.3.17...3.3.18): completes the zero/negative-size custom-generator fix in the native entry point.                                                                       | Stays on CommonJS-compatible 3.x; does not migrate to 6.x. PostCSS calls the normal positive-size generator, so this is defense in depth rather than a demonstrated Orca exploit. Zero-size Node smoke check passes; the native entry fix was source-reviewed, not device-tested.                             |

Required companion resolutions from the selected parents:

| Dependency               | Locked change               | Reason and risk                                                                                                                                                |
| ------------------------ | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| baseline-browser-mapping | 2.10.27 → 2.11.21           | Browserslist's updated baseline dataset/range. Browser target data can change; production build passed.                                                        |
| caniuse-lite             | 1.0.30001791 → 1.0.30001810 | Browserslist's browser support dataset; same package line.                                                                                                     |
| electron-to-chromium     | 1.5.351 → 1.5.422           | Browserslist's Electron version mapping, needed for current Electron query correctness.                                                                        |
| node-releases            | 2.0.38 → 2.0.54             | Browserslist's Node release dataset; same major.                                                                                                               |
| update-browserslist-db   | 1.2.3 → 1.3.2               | Browserslist's declared updater dependency. No updater command or external data refresh is added to Orca runtime.                                              |
| side-channel             | 1.1.0 → 1.1.1               | qs 6.16.0's declared dependency; retains existing map/weak-map API. qs also uses the already-locked es-define-property 1.0.1 for safe own-property assignment. |

## Verification

Executed on macOS arm64, Node 26.6.0, pnpm 12.0.0, with `ORCA_BACKGROUND_LAUNCH=1` for installs/builds/tests:

- Frozen-lockfile install with lifecycle scripts disabled; native dependencies were not changed.
- `pnpm tc`: passed.
- `pnpm run build:electron-vite`: passed, including renderer boot-graph validation. Existing large-chunk warnings remain.
- Targeted Vitest run: `src/main/claude`, both Linear MCP issue-list suites, `src/shared/mcp-config.test.ts`, and `src/main/runtime/rpc/schemas.test.ts`: 734 passed, 5 skipped, 1 failed across 83 files.
- The failure is `claude-structured-real-cli.test.ts:177`, where the locally installed Claude CLI omits the current effort setting. Reinstalled the original lockfile and reran that file: the identical assertion fails (4 pass, 1 fail). Restored and reinstalled the updated lockfile afterwards.
- Eleven direct smoke assertions passed for query parsing/limits, hostile constructors, URI reserved characters/IPv6, CSS selectors, plist/XML, Electron target queries and zero-length IDs.
- Desktop audit: 12 findings → 1 (Tiptap, below). Audit counts describe known advisories, not proof of exploitability or complete security.
- Reviewed the final lockfile package delta; discarded unrelated resolver churn, including optional bundled Claude CLI entries. Existing ignored optional-dependency policy and patch hashes remain intact.

No rendered interaction, Linux/Windows packaging, native mobile, or live SSH validation was performed. Desktop declares Node 24; CI must cover that supported runtime. These changes do not alter host execution ownership, Git commands, folder/worktree assumptions, wire frames or provider-specific behavior.

## Deliberate holds and remaining work

This review does not claim every available upgrade is useful or safe. The desktop is already recent: React 19.2.8, Electron 43.4.1, ws 8.21.3, DOMPurify 3.4.13, PDF.js 6.3.289 and Zod 4.5.4 are already selected. Keep patched xterm, node-pty, Windows process-tree and lint-staged versions until their local patches are reconciled with upstream. Electron 44, Vitest 5, Vite 8, marked 18, Linear SDK 89 and icon-library major migrations do not belong in this security patch group without product-specific evidence and migration testing.

- **Tiptap: high-priority separate editor change.** 3.30.4 fixes prototype mutation, 3.30.5 fixes Markdown attribute CPU exhaustion, 3.30.6 improves nested-list serialization and React node-view overhead, and 3.31.2 raises ProseMirror View for a paste-XSS fix. [Release notes](https://github.com/ueberdosis/tiptap/releases). Do not bump only `@tiptap/core`: the coordinated extensions currently span 3.22.4/3.22.5. 3.30 changes Tab/list behavior and 3.31 changes node-view selection semantics. Validate table editing, pasted HTML, Markdown round trips, node views and remote file saves together before selecting a coordinated version. The required Electron skill was not available in either installed skill directory, so rendered editor validation was not performed. The remaining audit finding is intentionally disclosed, not suppressed.
- **Cloud:** separate PR selects Hono 4.13.7, its 1.x Node adapter 1.19.17, ws 8.21.3, PostCSS 8.5.28 and nanoid 3.3.18. See that PR's focused review and full cloud verification.
- **Mobile:** audit reports five findings: image-size 1.2.1 (two, no patched version offered), decode-uri-component 0.2.2 (requires a 0.5.x migration), and xmldom 0.8.13/0.9.10. The xmldom maintenance updates 0.8.15/0.9.12 are good follow-up candidates, but must be checked through Expo config/plist consumers in the separate workspace. Do not force image-size 2.x or an Expo 57/React Native 0.87 migration to quiet the audit; React Native and WebView have local patches and the native package set is coupled. Reanimated/worklets/screens/storage majors/minors require native-device coverage. Zod 4.4→4.5 also warrants mixed-client validation before changing shared parsing behavior.
- **Docs site:** independent audit reports 21 findings, largely from development/deployment tooling: the explicit `@vercel/node>undici: 5.29.0` override is on an unfixed major; other findings include Ajv, smol-toml, path-to-regexp and brace-expansion. Research the Vercel parent upgrade/override removal together on the declared Node 22 runtime instead of forcing Undici 6 into a 5.x consumer. The small same-major parser fixes are follow-up candidates for that independent install/build. Do not mistake the desktop audit for this site's audit. React 19.2.4 is older than desktop, but a client React bump alone does not establish Next.js/RSC security.

Terraform provider and Ruby lockfiles were located but not audited by the npm advisory service. Their release/security status is outside the validated npm update groups here. Further native/editor/deployment changes should have separate PRs and corresponding platform/build checks; there is no zero-regression guarantee from semver or a clean audit.

## Linked Issue

User-requested dependency review; no existing issue linked.

## Visual Proof

N/A — dependency lockfile/manifest maintenance; no UI implementation changes.

## Testing

See the command outcomes and explicit limitations above. Existing integration tests and direct API smoke checks were used; no implementation-mirroring tests were added.

## Review

- [x] Self-reviewed each resolved package delta and upstream fixes.
- [x] Cross-platform and SSH/remote compatibility considered.
- [x] No upstream skill-installer code or assets copied (agent skill upstream boundary is not applicable).
- [ ] Supported-platform and database-backed CI complete.
