### PR TITLE
fix(deps): harden cloud HTTP, WebSocket and build dependencies

### DIFF
--- a/cloud/apps/relay-fence-broker/package.json
+++ b/cloud/apps/relay-fence-broker/package.json
@@ -14,8 +14,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.14",
-    "hono": "^4.12.27",
+    "@hono/node-server": "^1.19.17",
+    "hono": "^4.13.7",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/cloud/apps/relay-ops/package.json
+++ b/cloud/apps/relay-ops/package.json
@@ -16,8 +16,8 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.14",
-    "hono": "^4.12.27",
+    "@hono/node-server": "^1.19.17",
+    "hono": "^4.13.7",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/cloud/apps/relay/package.json
+++ b/cloud/apps/relay/package.json
@@ -15,13 +15,13 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.14",
+    "@hono/node-server": "^1.19.17",
     "@orca-cloud/relay-contract": "workspace:*",
-    "hono": "^4.12.27",
+    "hono": "^4.13.7",
     "jose": "^6.1.3",
     "pg": "^8.22.0",
     "tweetnacl": "^1.0.3",
-    "ws": "^8.18.3",
+    "ws": "^8.21.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/cloud/pnpm-lock.yaml
+++ b/cloud/pnpm-lock.yaml
@@ -24,14 +24,14 @@ importers:
   apps/relay:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^1.19.17
+        version: 1.19.17(hono@4.13.7)
       '@orca-cloud/relay-contract':
         specifier: workspace:*
         version: link:../../packages/relay-contract
       hono:
-        specifier: ^4.12.27
-        version: 4.12.27
+        specifier: ^4.13.7
+        version: 4.13.7
       jose:
         specifier: ^6.1.3
         version: 6.2.3
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       ws:
-        specifier: ^8.18.3
-        version: 8.21.0
+        specifier: ^8.21.3
+        version: 8.21.3
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -70,11 +70,11 @@ importers:
   apps/relay-fence-broker:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^1.19.17
+        version: 1.19.17(hono@4.13.7)
       hono:
-        specifier: ^4.12.27
-        version: 4.12.27
+        specifier: ^4.13.7
+        version: 4.13.7
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -95,11 +95,11 @@ importers:
   apps/relay-ops:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.27)
+        specifier: ^1.19.17
+        version: 1.19.17(hono@4.13.7)
       hono:
-        specifier: ^4.12.27
-        version: 4.12.27
+        specifier: ^4.13.7
+        version: 4.13.7
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -300,8 +300,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+  '@hono/node-server@1.19.17':
+    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -507,8 +507,8 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.13.7:
+    resolution: {integrity: sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==}
     engines: {node: '>=16.9.0'}
 
   jose@6.2.3:
@@ -587,8 +587,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  nanoid@3.3.13:
-    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -640,8 +640,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.28:
+    resolution: {integrity: sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -805,8 +805,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  ws@8.21.0:
-    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -920,9 +920,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@1.19.17(hono@4.13.7)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.13.7
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -1109,7 +1109,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  hono@4.12.27: {}
+  hono@4.13.7: {}
 
   jose@6.2.3: {}
 
@@ -1166,7 +1166,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  nanoid@3.3.13: {}
+  nanoid@3.3.18: {}
 
   obug@2.1.3: {}
 
@@ -1211,9 +1211,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.28:
     dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1288,7 +1288,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.28
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -1329,7 +1329,7 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  ws@8.21.0: {}
+  ws@8.21.3: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​39 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​39 | 0 |

<!-- /orca-pr-loc -->

**Ready for review.** [Validation evidence](https://github.com/stablyai/orca/pull/19362#issuecomment-5576260657): 1,455 cloud tests pass including PostgreSQL 16 integration; builds/types pass; audit 9 → 0.

## ELI5

Update a small set of dependencies with documented security, performance and correctness fixes. Keep incompatible migrations and native runtime changes out of this update group.

## What Changed / Why

# Cloud dependency review — 2026-09-07

This independent update group changes only five resolved packages in `cloud/pnpm-lock.yaml` and the corresponding direct dependency floors in the three cloud apps. The runtime still supports Node >=24 <27; Zod 3 and the relay contract remain unchanged.

| Dependency        | Locked change     | Concrete benefit                                                                                                                                                                                                                                                                     | Why this version / compatibility risk                                                                                                                                                                                                                                                                                                                                                                                                                                           |
| ----------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| hono              | 4.12.27 → 4.13.7  | [4.13 release series](https://github.com/honojs/hono/releases): reduces hot-path request/context allocations; repairs wildcard routing, cloned request bodies and query parsing past URL fragments; includes CORS/language DoS, SSR disclosure and boundary escaping security fixes. | Same major, compatible with the retained adapter 1.x. Includes follow-up router/body fixes after 4.13.0 and the September 4 escaping fix. The performance improvements affect ordinary HTTP requests, but no Orca throughput gain is claimed without a benchmark. Orca does not import the affected CORS/language/SSR/proxy modules; those fixes are defense in depth. Query and router semantics are the main compatibility risks, covered by the cloud HTTP/auth/route tests. |
| @hono/node-server | 1.19.14 → 1.19.17 | [1.x source comparison](https://github.com/honojs/node-server/compare/v1.19.14...v1.19.17): includes the Windows encoded-backslash static path-traversal fix.                                                                                                                        | Retains adapter 1.x and its Hono ^4 peer range. 1.19.16/17 are publishing/CI follow-ups rather than the 2.x request/WebSocket changes. Orca's cloud apps do not import serve-static, so this is defense in depth, not evidence of an exposed traversal route.                                                                                                                                                                                                                   |
| ws                | 8.21.0 → 8.21.3   | [8.21.1](https://github.com/websockets/ws/releases/tag/8.21.1) counts empty fragments toward limits and reduces default fragment/buffer limits; [8.21.3](https://github.com/websockets/ws/releases/tag/8.21.3) fixes deflate negotiation.                                            | Same patch line as desktop/mobile. The relay disables perMessageDeflate, so the valuable runtime change is fragment-limit hardening, not compression speed. Lower limits could disconnect unusually fragmented clients; relay WebSocket black-box and reconnect tests pass. Normal frames/wire vocabulary are unchanged.                                                                                                                                                        |
| postcss           | 8.5.15 → 8.5.28   | [Changelog](https://github.com/postcss/postcss/blob/main/CHANGELOG.md): restricts source-map loading and fixes CSS parsing/visitor behavior.                                                                                                                                         | Dev-only through Vite/Vitest. Includes the follow-up visitor, split and type regression repairs, rather than stopping at first patched 8.5.23. Same 8.5 release line; cloud tests pass.                                                                                                                                                                                                                                                                                         |
| nanoid            | 3.3.13 → 3.3.18   | [3.x comparison](https://github.com/ai/nanoid/compare/3.3.13...3.3.18): fixes non-secure/custom-generator loops for invalid sizes, including the native entry point follow-up.                                                                                                       | Dev-only through PostCSS; remains on 3.x. No CommonJS/ESM major migration. PostCSS's normal positive-size call is unchanged.                                                                                                                                                                                                                                                                                                                                                    |

## Validation

On macOS arm64, Node 26.6.0 (inside the cloud engine range), pnpm 10.24.0, with `ORCA_BACKGROUND_LAUNCH=1`:

- `pnpm install --frozen-lockfile`: passed after removing unrelated transitive resolver churn.
- `pnpm build`: all four packages/apps passed.
- `pnpm typecheck`: all packages/apps passed.
- `pnpm test`: passed. Pretest scripts: 153 tests; package suites: 669 passed / 95 skipped; subsequent deployment/operations scripts: 536 tests. Total 1,358 passed, 95 skipped.
- The relay suite accounts for 535 passed / 95 skipped. PostgreSQL-gated coverage needs `ORCA_RELAY_TEST_POSTGRES_URL` in CI; no production database or infrastructure was contacted.
- `pnpm audit --json`: 9 findings before, 0 after, using the independent cloud lockfile.
- Final package delta contains exactly the five listed packages; unrelated lightningcss/WASM runtime upgrades were removed. No new native package, override or lifecycle script was introduced.

These are compatibility arguments and test evidence, not a guarantee of no regressions. Linux deployment and database-backed CI must still pass. No new RPC fields/opcodes, execution ownership rules, schemas, authentication rules, Git commands, folder/worktree assumptions or provider-specific behavior are introduced. Existing relay black-box tests exercise host/client connectivity; a live SSH deployment and cross-version desktop session were not run.

## Linked Issue

User-requested dependency review; no existing issue linked.

## Visual Proof

N/A — dependency lockfile/manifest maintenance; no UI implementation changes.

## Testing

See the command outcomes and explicit limitations above. Existing integration tests and direct API smoke checks were used; no implementation-mirroring tests were added.

## Review

- [x] Self-reviewed each resolved package delta and upstream fixes.
- [x] Cross-platform and SSH/remote compatibility considered.
- [x] No upstream skill-installer code or assets copied (agent skill upstream boundary is not applicable).
- [ ] Supported-platform and database-backed CI complete.
