### PR TITLE
fix(terminal): remove host-retired ghost panes in paired remote splits (#17770)

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   isHostAuthoritativeLayout,
-  planTerminalLiveLayoutInsertions
+  planTerminalLiveLayoutInsertions,
+  planTerminalLiveLayoutRemovals,
+  selectRetiredPaneIds,
+  trackRetiredLeafIds
 } from './terminal-live-layout-reconciliation'
 import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
 
@@ -230,5 +233,173 @@ describe('planTerminalLiveLayoutInsertions', () => {
     }
 
     expect(planTerminalLiveLayoutInsertions(layout, [])).toEqual([])
+  })
+})
+
+describe('planTerminalLiveLayoutRemovals', () => {
+  // Every mounted leaf counted as retired: the layout alone must veto removals.
+  const BOTH = new Set(['leaf-a', 'leaf-b'])
+
+  it('plans the mounted leaf a host-retired layout no longer names', () => {
+    // Why: closing one pane of a remote-server split kills its PTY on the host,
+    // which retires the leaf and republishes a one-leaf layout; the pane mounted
+    // for the retired leaf must go too, or it lingers as a blank ghost.
+    const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
+
+    expect(
+      planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'], new Set(['leaf-b']))
+    ).toEqual(['leaf-b'])
+  })
+
+  it('plans nothing when every mounted leaf is still in the layout', () => {
+    const layout: TerminalPaneLayoutNode = {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: 'leaf-a' },
+      second: { type: 'leaf', leafId: 'leaf-b' }
+    }
+
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-b'], BOTH)).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a'], BOTH)).toEqual([])
+  })
+
+  it('plans nothing for an empty layout', () => {
+    expect(planTerminalLiveLayoutRemovals(null, ['leaf-a'], BOTH)).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(undefined, ['leaf-a'], BOTH)).toEqual([])
+  })
+
+  it('leaves a mounted leaf the host has never named alone', () => {
+    // Why: a pane the client just split is still spawning, so its transport has
+    // no PTY yet, and a host snapshot that lands mid-spawn does not name it.
+    // Only a leaf the host named before can be one the host retired.
+    const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
+
+    expect(
+      planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-new'], new Set(['leaf-a']))
+    ).toEqual([])
+    expect(planTerminalLiveLayoutRemovals(layout, ['leaf-a', 'leaf-new'], new Set())).toEqual([])
+  })
+})
+
+describe('selectRetiredPaneIds', () => {
+  const view = (ptyIdsByPane: Record<number, string | null | undefined>) => ({
+    paneCount: Object.keys(ptyIdsByPane).length,
+    paneIdForLeaf: (leafId: string) => (leafId === 'leaf-b' ? 2 : leafId === 'leaf-c' ? 3 : null),
+    ptyIdForPane: (paneId: number) => ptyIdsByPane[paneId]
+  })
+
+  it('closes the pane whose transport lost its PTY', () => {
+    // Why: the host retired the leaf because its PTY ended, so a pane that no
+    // longer has one is exactly the blank ghost the layout stopped naming.
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 1: 'pty-a', 2: null }))).toEqual([2])
+  })
+
+  it('keeps a pane still bound to a PTY or not yet attached to a transport', () => {
+    // A stale snapshot may simply not name a live pane yet; a pane with no
+    // transport is still mounting. Neither is evidence of a retired leaf.
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 1: 'pty-a', 2: 'pty-b' }))).toEqual([])
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 1: 'pty-a', 2: undefined }))).toEqual([])
+  })
+
+  it('never removes the last pane on the tab', () => {
+    expect(selectRetiredPaneIds(['leaf-b'], view({ 2: null }))).toEqual([])
+    expect(selectRetiredPaneIds(['leaf-b', 'leaf-c'], view({ 2: null, 3: null }))).toEqual([2])
+  })
+
+  it('skips a leaf that has no mounted pane', () => {
+    expect(selectRetiredPaneIds(['leaf-x'], view({ 1: 'pty-a', 2: null }))).toEqual([])
+  })
+})
+
+describe('trackRetiredLeafIds', () => {
+  it('retires a mounted leaf the host dropped from its layout', () => {
+    expect(
+      trackRetiredLeafIds({
+        retiredLeafIds: new Set(),
+        previousLayoutLeafIds: new Set(['leaf-a', 'leaf-b']),
+        layoutLeafIds: new Set(['leaf-a']),
+        mountedLeafIds: ['leaf-a', 'leaf-b']
+      })
+    ).toEqual(new Set(['leaf-b']))
+  })
+
+  it('keeps a retired leaf until its pane is gone', () => {
+    // Why: the removal may have been skipped while the transport still held its
+    // PTY; the next reconciliation must still see the leaf as retired.
+    const args = {
+      retiredLeafIds: new Set(['leaf-b']),
+      previousLayoutLeafIds: new Set(['leaf-a']),
+      layoutLeafIds: new Set(['leaf-a'])
+    }
+    expect(trackRetiredLeafIds({ ...args, mountedLeafIds: ['leaf-a', 'leaf-b'] })).toEqual(
+      new Set(['leaf-b'])
+    )
+    expect(trackRetiredLeafIds({ ...args, mountedLeafIds: ['leaf-a'] })).toEqual(new Set())
+  })
+
+  it('forgets a retired leaf the host names again', () => {
+    expect(
+      trackRetiredLeafIds({
+        retiredLeafIds: new Set(['leaf-b']),
+        previousLayoutLeafIds: new Set(['leaf-a']),
+        layoutLeafIds: new Set(['leaf-a', 'leaf-b']),
+        mountedLeafIds: ['leaf-a', 'leaf-b']
+      })
+    ).toEqual(new Set())
+  })
+
+  it('never retires a leaf the host has not named', () => {
+    expect(
+      trackRetiredLeafIds({
+        retiredLeafIds: new Set(),
+        previousLayoutLeafIds: new Set(['leaf-a']),
+        layoutLeafIds: new Set(['leaf-a']),
+        mountedLeafIds: ['leaf-a', 'leaf-new']
+      })
+    ).toEqual(new Set())
+  })
+})
+
+describe('host retirement that lands before the transport teardown', () => {
+  it('removes the pane on the reconciliation after its PTY clears', () => {
+    // Why: the host drops the leaf and ends its PTY in one step, but the two
+    // reach the client separately. If the layout arrives first the pane still
+    // holds its PTY and must not be closed yet; once the exit lands and rewrites
+    // the layout bindings, the effect runs again and must close it then.
+    const layout: TerminalPaneLayoutNode = { type: 'leaf', leafId: 'leaf-a' }
+    const mounted = ['leaf-a', 'leaf-b']
+    const paneIdForLeaf = (leafId: string) =>
+      leafId === 'leaf-a' ? 1 : leafId === 'leaf-b' ? 2 : null
+
+    let retired = trackRetiredLeafIds({
+      retiredLeafIds: new Set(),
+      previousLayoutLeafIds: new Set(mounted),
+      layoutLeafIds: new Set(['leaf-a']),
+      mountedLeafIds: mounted
+    })
+    let removals = planTerminalLiveLayoutRemovals(layout, mounted, retired)
+    expect(removals).toEqual(['leaf-b'])
+    expect(
+      selectRetiredPaneIds(removals, {
+        paneCount: 2,
+        paneIdForLeaf,
+        ptyIdForPane: (paneId) => (paneId === 2 ? 'pty-b' : 'pty-a')
+      })
+    ).toEqual([])
+
+    retired = trackRetiredLeafIds({
+      retiredLeafIds: retired,
+      previousLayoutLeafIds: new Set(['leaf-a']),
+      layoutLeafIds: new Set(['leaf-a']),
+      mountedLeafIds: mounted
+    })
+    removals = planTerminalLiveLayoutRemovals(layout, mounted, retired)
+    expect(
+      selectRetiredPaneIds(removals, {
+        paneCount: 2,
+        paneIdForLeaf,
+        ptyIdForPane: (paneId) => (paneId === 2 ? null : 'pty-a')
+      })
+    ).toEqual([2])
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-live-layout-reconciliation.ts
@@ -3,6 +3,7 @@ import type {
   TerminalPaneSplitDirection
 } from '../../../../shared/terminal-tab-types'
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
+import { collectLeafIds } from './terminal-pane-layout-tree'
 
 /**
  * Whether a tab's split layout is owned by a host (web/mobile clients, or a
@@ -85,6 +86,29 @@ function mountedLeafIdsIn(
   ]
 }
 
+/**
+ * Mounted leaves the host layout no longer names. The host retires a leaf when
+ * its PTY ends, so a pane still mounted for it is a ghost: it renders nothing
+ * and, once it is the only pane left, absorbs the tab's next close. An empty
+ * layout plans nothing — absence of a tree is not evidence about any pane.
+ */
+export function planTerminalLiveLayoutRemovals(
+  root: TerminalPaneLayoutNode | null | undefined,
+  currentLeafIds: Iterable<string>,
+  retiredLeafIds: ReadonlySet<string>
+): string[] {
+  if (!root) {
+    return []
+  }
+  const layoutLeafIds = new Set(collectLeafIds(root))
+  // Why: a mounted leaf the layout stopped naming is a removal only once the
+  // host is known to have retired it (trackRetiredLeafIds). A snapshot landing
+  // while the client is still starting a pane must not read as a retirement.
+  return [...currentLeafIds].filter(
+    (leafId) => !layoutLeafIds.has(leafId) && retiredLeafIds.has(leafId)
+  )
+}
+
 export function planTerminalLiveLayoutInsertions(
   root: TerminalPaneLayoutNode | null | undefined,
   currentLeafIds: Iterable<string>
@@ -155,4 +179,53 @@ export function planTerminalLiveLayoutInsertions(
 
   ensureSubtree(root)
   return insertions
+}
+
+/** Panes to close for leaves the host retired. Only a pane whose transport has
+ *  no PTY any more is a ghost; a pane with no transport yet, or still bound to
+ *  a PTY, may simply not be named by a stale snapshot. The last pane on the tab
+ *  is never removed. */
+export function selectRetiredPaneIds(
+  retiredLeafIds: readonly string[],
+  view: {
+    paneCount: number
+    paneIdForLeaf: (leafId: string) => number | null
+    ptyIdForPane: (paneId: number) => string | null | undefined
+  }
+): number[] {
+  const paneIds: number[] = []
+  for (const leafId of retiredLeafIds) {
+    if (view.paneCount - paneIds.length <= 1) {
+      break
+    }
+    const paneId = view.paneIdForLeaf(leafId)
+    if (paneId === null || view.ptyIdForPane(paneId) !== null) {
+      continue
+    }
+    paneIds.push(paneId)
+  }
+  return paneIds
+}
+
+/**
+ * Leaves the host dropped from its layout whose panes are still mounted. Only a
+ * leaf the host named before can be retired: a leaf it has never named belongs
+ * to a pane the client is still starting. A retired leaf stays retired until
+ * its pane is gone or the host names it again, so a removal skipped while the
+ * transport still held its PTY is planned again once that PTY clears.
+ */
+export function trackRetiredLeafIds(args: {
+  retiredLeafIds: ReadonlySet<string>
+  previousLayoutLeafIds: ReadonlySet<string>
+  layoutLeafIds: ReadonlySet<string>
+  mountedLeafIds: Iterable<string>
+}): ReadonlySet<string> {
+  const mounted = new Set(args.mountedLeafIds)
+  const next = new Set<string>()
+  for (const leafId of [...args.retiredLeafIds, ...args.previousLayoutLeafIds]) {
+    if (mounted.has(leafId) && !args.layoutLeafIds.has(leafId)) {
+      next.add(leafId)
+    }
+  }
+  return next
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-hook-order-parity.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-hook-order-parity.test.ts
@@ -16,8 +16,10 @@ const TERMINAL_PANE_HOOK_SOURCE_PATTERN =
 // toggle in projection (208 hooks, still 8 useMemo).
 // Then chat-state's orchestration dispatch-status subscription went with the
 // paused notice that read it (207 hooks, still 8 useMemo).
+// Then host-authoritative layout removal added two `useRef`s in reconciliation
+// (last host layout leaf set, retired leaf set) (209 hooks, still 8 useMemo).
 const PRE_REFACTOR_HOOK_ORDER_SHA256 =
-  '2bbb42427b61e3722114ac37c407230cb7daffbf9b899090c7a635f15731ccad'
+  'f6de13ab7d6d130444c50fec2cfe097851ee1b7ecf0f3a2cbdc082c2e8e8838b'
 
 const sourceFiles = readdirSync(__dirname)
   .filter((name) => TERMINAL_PANE_HOOK_SOURCE_PATTERN.test(name))
@@ -82,7 +84,7 @@ function readFlattenedHookOrder(): string[] {
 describe('TerminalPane refactor hook parity', () => {
   it('preserves the recursively flattened render hook order', () => {
     const hooks = readFlattenedHookOrder()
-    expect(hooks).toHaveLength(207)
+    expect(hooks).toHaveLength(209)
     expect(hooks.filter((hook) => hook === 'useMemo')).toHaveLength(8)
     expect(createHash('sha256').update(hooks.join('\n')).digest('hex')).toBe(
       PRE_REFACTOR_HOOK_ORDER_SHA256

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect } from 'react'
+import { useEffect, useLayoutEffect, useRef } from 'react'
 import {
   applyExpandedLayoutTo,
   cancelPendingPaneSizeRefreshFrames,
@@ -8,8 +8,12 @@ import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 import { resolvePaneKeyForManager } from '@/lib/pane-manager/pane-key-resolution'
 import {
   isHostAuthoritativeLayout,
-  planTerminalLiveLayoutInsertions
+  planTerminalLiveLayoutInsertions,
+  planTerminalLiveLayoutRemovals,
+  selectRetiredPaneIds,
+  trackRetiredLeafIds
 } from './terminal-live-layout-reconciliation'
+import { collectLeafIds } from './terminal-pane-layout-tree'
 import { useTerminalPaneProcessExitActions } from './use-terminal-pane-process-exit-actions'
 import type { TerminalPaneCloseController } from './use-terminal-pane-close-actions'
 
@@ -18,17 +22,25 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     activityIsolationSnapshotRef,
     closeTerminalLinkActions,
     containerRef,
+    executeClosePane,
     isActive,
     isRendererVisible,
     isolatedPaneKey,
     managerRef,
     paneCount,
     paneLayoutRevision,
+    paneTransportsRef,
     pendingPaneSizeRefreshFrameIdsRef,
     persistLayoutSnapshot,
+    ptyRecoveryStatesByPaneId,
     restoredLayout,
     tabId
   } = controller
+  // Leaves the last host-authoritative layout named, and the ones it has since
+  // dropped whose panes are still mounted; a removal needs the host to have
+  // named the leaf before it dropped it, and may have to wait for the PTY exit.
+  const hostLayoutLeafIdsRef = useRef<ReadonlySet<string>>(new Set())
+  const retiredLeafIdsRef = useRef<ReadonlySet<string>>(new Set())
 
   useEffect(() => {
     closeTerminalLinkActions()
@@ -47,11 +59,23 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     ) {
       return
     }
-    const insertions = planTerminalLiveLayoutInsertions(
+    const layoutLeafIds = new Set(collectLeafIds(restoredLayout.root))
+    const mountedLeafIds = manager.getPanes().map((pane) => pane.leafId)
+    const retiredLeafIds = trackRetiredLeafIds({
+      retiredLeafIds: retiredLeafIdsRef.current,
+      previousLayoutLeafIds: hostLayoutLeafIdsRef.current,
+      layoutLeafIds,
+      mountedLeafIds
+    })
+    hostLayoutLeafIdsRef.current = layoutLeafIds
+    retiredLeafIdsRef.current = retiredLeafIds
+    const insertions = planTerminalLiveLayoutInsertions(restoredLayout.root, mountedLeafIds)
+    const removals = planTerminalLiveLayoutRemovals(
       restoredLayout.root,
-      manager.getPanes().map((pane) => pane.leafId)
+      mountedLeafIds,
+      retiredLeafIds
     )
-    if (insertions.length === 0) {
+    if (insertions.length === 0 && removals.length === 0) {
       return
     }
     let appliedInsertion = false
@@ -82,6 +106,21 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
         appliedInsertion = true
       }
     }
+    // Why: the host retired these leaves (its PTY for them ended), so their panes
+    // would otherwise outlive the layout as blank ghosts and take the tab's next
+    // close for themselves. selectRetiredPaneIds closes only a pane whose PTY has
+    // already cleared, so this never kills a still-live remote terminal; a leaf
+    // whose PTY is still ending is kept retired and removed on the re-run the
+    // transport's recovery-state change (ptyRecoveryStatesByPaneId) triggers.
+    // executeClosePane runs the same cleanup a user close does.
+    const retiredPaneIds = selectRetiredPaneIds(removals, {
+      paneCount: manager.getPanes().length,
+      paneIdForLeaf: (leafId) => manager.getNumericIdForLeaf(leafId),
+      ptyIdForPane: (paneId) => paneTransportsRef.current.get(paneId)?.getPtyId()
+    })
+    for (const paneId of retiredPaneIds) {
+      executeClosePane(paneId)
+    }
     if (appliedInsertion) {
       persistLayoutSnapshot()
     }
@@ -93,8 +132,18 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
     if (nextActivePaneId !== null) {
       manager.setActivePane(nextActivePaneId, { focus: isActive })
     }
+    // Why ptyRecoveryStatesByPaneId: a host-retired pane whose PTY has not yet
+    // finished ending is kept until this re-run, when its transport reports a new
+    // recovery state and its PTY has cleared.
     // oxlint-disable-next-line react-hooks/exhaustive-deps -- Preserve the pre-split dependency contract.
-  }, [isActive, paneCount, persistLayoutSnapshot, restoredLayout])
+  }, [
+    executeClosePane,
+    isActive,
+    paneCount,
+    persistLayoutSnapshot,
+    ptyRecoveryStatesByPaneId,
+    restoredLayout
+  ])
 
   useLayoutEffect(() => {
     const snapshots = activityIsolationSnapshotRef.current

--- a/tests/e2e/paired-remote-split-pane-host-retired-ghost.spec.ts
+++ b/tests/e2e/paired-remote-split-pane-host-retired-ghost.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Reproduction for #17770: closing one pane of a split terminal in a paired
+ * remote-server workspace must not leave the other pane mounted as a blank,
+ * dead ghost.
+ *
+ * Topology: a headless paired Orca runtime host + a paired Orca desktop client.
+ * The host owns the pane layout; the client mirrors it. The host splits a
+ * terminal (two leaves, two remote PTYs, each a login shell), then the user
+ * quits the second shell with `exit`. The host retires that leaf and
+ * republishes a one-leaf layout.
+ *
+ * Before the fix, the host-authoritative reconciler planned insertions only, so
+ * the client kept the retired leaf's pane mounted forever — a blank ghost with
+ * no exit overlay and no restart control. The refutation-proof shape (verified
+ * here) is that the client's store layout shrinks to one leaf while its DOM
+ * keeps two panes. After the fix the client removes the retired pane and store
+ * + DOM agree at exactly the surviving leaf.
+ *
+ * Run:
+ *   pnpm exec playwright test tests/e2e/paired-remote-split-pane-host-retired-ghost.spec.ts \
+ *     --config tests/playwright.config.ts --project electron-headless --workers=1
+ */
+import type { Page } from '@stablyai/playwright-test'
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import { expect, test } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import { launchPairedElectronClient } from './helpers/paired-electron-client'
+import { findPairedWorktreeId } from './helpers/paired-browser-placement-fixture'
+
+async function mountedPaneCount(page: Page, webTabId: string): Promise<number> {
+  return page.evaluate(
+    (tabId) => window.__paneManagers?.get(tabId)?.getPanes().length ?? -1,
+    webTabId
+  )
+}
+
+async function mountedLeafPtyIds(
+  page: Page,
+  webTabId: string
+): Promise<{ leafId: string; ptyId: string | null }[]> {
+  return page.evaluate(
+    (tabId) =>
+      (window.__paneManagers?.get(tabId)?.getPanes() ?? []).map((pane) => ({
+        leafId: pane.leafId,
+        ptyId: pane.container.dataset.ptyId ?? null
+      })),
+    webTabId
+  )
+}
+
+/** Leaves the host-authoritative layout the client currently holds for this tab. */
+async function hostLayoutLeafIds(page: Page, webTabId: string): Promise<string[]> {
+  return page.evaluate((tabId) => {
+    const layout = window.__store?.getState().terminalLayoutsByTabId[tabId]
+    return layout ? Object.keys(layout.ptyIdsByLeafId ?? {}) : []
+  }, webTabId)
+}
+
+test('removes the pane a paired remote host retired instead of leaving a dead ghost', async ({
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost()
+  let client: Awaited<ReturnType<typeof launchPairedElectronClient>> | null = null
+  try {
+    await host.client.call('repo.add', { path: testRepoPath, kind: 'git' })
+    const created = await host.client.call<{ terminal: { handle: string } }>('terminal.create', {
+      worktree: `path:${testRepoPath}`,
+      title: 'Ghost Repro'
+    })
+    const firstHandle = created.result.terminal.handle
+
+    client = await launchPairedElectronClient(host.offer, testInfo, '#17770 host-retired ghost')
+    const worktreeId = await findPairedWorktreeId(client.page, testRepoPath)
+    await client.page.evaluate(
+      ({ environmentId, worktreeId }) => {
+        window.__store?.getState().setActiveWorktree(worktreeId, `runtime:${environmentId}`)
+      },
+      { environmentId: client.environmentId, worktreeId }
+    )
+
+    // Host splits the terminal: a second leaf with its own remote login shell.
+    const split = await host.client.call<{ split: { handle: string; tabId: string } }>(
+      'terminal.split',
+      { terminal: firstHandle, direction: 'horizontal' }
+    )
+    const secondHandle = split.result.split.handle
+    const webTabId = toWebTerminalSurfaceTabId(split.result.split.tabId)
+
+    // The client mirrors the split as two mounted panes, each PTY-bound.
+    await expect
+      .poll(() => mountedPaneCount(client!.page, webTabId), {
+        timeout: 90_000,
+        message: 'paired client never materialized both split panes'
+      })
+      .toBe(2)
+    await expect
+      .poll(async () => (await mountedLeafPtyIds(client!.page, webTabId)).every((p) => p.ptyId), {
+        timeout: 30_000,
+        message: 'split panes never settled with PTY bindings'
+      })
+      .toBe(true)
+    const beforeExit = await mountedLeafPtyIds(client.page, webTabId)
+
+    // The user quits the second shell — the host retires that leaf and
+    // republishes a one-leaf layout.
+    await host.client.call('terminal.send', { terminal: secondHandle, text: 'exit', enter: true })
+
+    // The host-authoritative layout the client holds shrinks to one leaf
+    // (confirms the retirement). This is the refutation-proof signal: before the
+    // fix the store layout shrinks here while the DOM keeps a ghost; after the
+    // fix the DOM follows and both agree at one leaf.
+    await expect
+      .poll(() => hostLayoutLeafIds(client!.page, webTabId).then((ids) => ids.length), {
+        timeout: 60_000,
+        message: 'host never retired the exited split leaf from its published layout'
+      })
+      .toBe(1)
+
+    // The client must drop the retired pane and keep exactly the surviving one.
+    await expect
+      .poll(() => mountedPaneCount(client!.page, webTabId), {
+        timeout: 60_000,
+        message: 'paired client kept the retired pane mounted as a dead ghost'
+      })
+      .toBe(1)
+
+    const afterExit = await mountedLeafPtyIds(client.page, webTabId)
+    const exitedLeafId = beforeExit.find(
+      (p) => !afterExit.some((a) => a.leafId === p.leafId)
+    )?.leafId
+    expect(afterExit).toHaveLength(1)
+    expect(afterExit[0]?.leafId).toBeTruthy()
+    expect(afterExit[0]?.ptyId).toBeTruthy()
+    expect(exitedLeafId).toBeTruthy()
+    // The pane that survives is the one the host still names.
+    await expect(hostLayoutLeafIds(client.page, webTabId)).resolves.toEqual([afterExit[0]?.leafId])
+  } finally {
+    await client?.dispose()
+    await host.dispose()
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​318 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​315 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 |

<!-- /orca-pr-loc -->

Fixes #17770

> **Attribution:** the diagnosis and the three planner functions in this PR are @ylcn91's work from #18387, opened four days earlier. Two of the three shared files are byte-identical between the branches. See [Relationship to #18387](#relationship-to-18387-community-pr) below — that section is the honest accounting, and it includes a recommendation that maintainers may prefer over merging this branch.

## ELI5

When you have a terminal split into two panes on a "remote server" (paired) workspace and you type `exit` in one of them, that pane's shell dies. The remote host notices, removes that half from the layout, and tells your app "this tab now has one pane." But your app only knew how to *add* panes to match the host's layout — it never learned how to *remove* one. So the dead pane just sat there: a blank rectangle you couldn't type into, with no "process exited" message and no restart button. Worse, if you then closed the still-working pane, the tab was left showing only the dead one — so it looked like closing one pane killed your whole split session.

This PR teaches the layout reconciler to remove a pane once the host has dropped its leaf **and** that pane's connection is confirmed gone — so the ghost disappears and the tab settles on the pane that's actually alive.

## The bug (#17770)

In a paired remote-server workspace, the host owns the pane layout. When a split pane's process exits, `OrcaRuntimeService.onPtyExit` retires that leaf and republishes a one-leaf layout. On the client, `useTerminalPaneReconciliation` ran `planTerminalLiveLayoutInsertions` and returned early when there were no insertions — there was **no removal path**. The retired leaf's pane stayed mounted forever as a blank, unresponsive ghost with no exit overlay and no restart control.

This is exclusively a paired-runtime/web defect: the reconciler branch is gated by `isHostAuthoritativeLayout`, which only admits web clients or `remote:`-prefixed PTYs. Direct-SSH tabs (`ssh:…@@pty2:…`) never take this branch, which is why local splits and "Add SSH host" tabs were unaffected.

A subtlety this fix accounts for: for a paired (web-surface) tab, the per-pane transport treats its own stream ending as **unverifiable** (attachment loss, per the SSH execution boundary) and deliberately keeps the pane — it cannot tell retirement from a partition. Only the host's authoritative layout knows the leaf was truly retired, so removal must be driven from the layout reconciler, not the per-pane exit path.

## The fix

`terminal-live-layout-reconciliation.ts` gains a removal side:

- **`trackRetiredLeafIds`** — a leaf counts as retired only if the host named it in a prior layout and has since dropped it while its pane is still mounted. A leaf the host never named (a pane the client is still spawning) is never treated as retired; a leaf the host names again is forgotten.
- **`planTerminalLiveLayoutRemovals`** — mounted leaves the current layout no longer names *and* that are in the retired set.
- **`selectRetiredPaneIds`** — closes a retired pane only once its transport PTY has cleared (`getPtyId() === null`), and never the last pane on the tab. This is the boundary-safety guard: a pane whose PTY is still live is left alone, so `executeClosePane` can never kill a still-running remote terminal.

`use-terminal-pane-reconciliation.ts` wires these in and closes retired panes through `executeClosePane` (the same cleanup a user close runs). Because a retired pane's PTY often clears just *after* the layout shrinks, the reconciliation effect now also re-runs on transport recovery-state changes (`ptyRecoveryStatesByPaneId`), so a pane whose PTY is still ending is removed on the next run once it clears.

### Boundary / wire notes
- **SSH execution boundary:** removal is driven by positive host evidence (the host dropped the leaf from its published layout) combined with a confirmed-cleared local PTY. Loss of contact alone never removes a pane, and a still-live PTY is never closed — the safe direction is leak, not kill.
- **Remote wire compatibility:** no wire change. This is entirely client-side reconciliation of what the host already publishes.

## Reproduction & before/after proof

Added `tests/e2e/paired-remote-split-pane-host-retired-ghost.spec.ts`: a headless paired runtime host + a paired desktop client. The host splits a terminal into two login-shell leaves; the second shell is quit with `exit`. The test asserts the host-authoritative layout the client holds shrinks to one leaf (confirming retirement) and that the client's DOM then settles at exactly the surviving pane.

Verified on that instrument (`electron-headless`):

- **Before the fix** (insertion-only reconciler): the client store layout shrinks to 1 leaf while the DOM keeps **2** panes — `Error: paired client kept the retired pane mounted as a dead ghost … Expected: 1 Received: 2`. This is the exact refutation-proof shape (store = 1 leaf, DOM = 2 panes).
- **A straight removal planner without the recovery-state re-trigger still failed** the same way: at the moment the layout shrank, the ghost pane's `getPtyId()` was still non-null, so the safety guard correctly skipped it — and nothing re-ran the effect once the PTY cleared. This is what motivated the `ptyRecoveryStatesByPaneId` dependency.
- **After the fix**: `1 passed` — the retired pane is removed and the tab settles on the live pane. Green across 3 consecutive runs (12–17s each).

This resolves every observed symptom in #17770: the ghost after `exit` (a); its survival across workspace switches (b, moot once removed); and "closing one pane terminates the whole split session" (c) — the ghost never becomes the sole pane. The click-close path on a live pane (d) is unaffected, and local splits / unsplit remote tabs (e) don't regress (gated by `isHostAuthoritativeLayout` and the never-last-pane guard).

### Unit coverage & mutation testing
`terminal-live-layout-reconciliation.test.ts` covers the three new pure functions (25 tests pass). Each guard was mutation-tested by reverting the specific behavior it protects:
- drop the `getPtyId() === null` guard → "keeps a pane still bound to a PTY…" fails;
- allow removing the last pane (`<= 1` → `< 1`) → "never removes the last pane" fails;
- remove on layout-absence alone (drop the retired gate) → "leaves a mounted leaf the host has never named alone" fails;
- retire leaves never named before → "never retires a leaf the host has not named" fails.

The recovery-state re-trigger is proven by the e2e differential above (removal planner alone fails; adding the dependency passes).

### Review follow-up (CI-red blocker)

`test / tests node 24 6/8` failed on `cf2839e` with `terminal-pane-hook-order-parity.test.ts`: `expected [ Array(209) ] to have a length of 207`. The two `useRef`s this PR adds to `useTerminalPaneReconciliation` (last host layout leaf set, retired leaf set) are render hooks and shift the flattened count from 207 to 209. No hook order changed otherwise -- the flattened order was diffed against `main` and only the two `useRef` entries were inserted (`useTerminalPaneController>useTerminalPaneReconciliation>useRef` x2). Resolved in `5f81ca2` by repinning the count/hash with a changelog comment matching the file's convention.

Mutation control on the repin: replacing one `useRef` with a plain `{ current }` object makes the test fail with `Expected 209, Received 208`; restoring it passes.

## Visual Proof

Captured with an assertion-free variant of the shipped e2e (`paired-remote-split-pane-host-retired-ghost-visual.spec.ts`, **not committed to this branch** — it drops the pane-count assertions and adds screenshotting so the same script runs to completion on **both** trees; happy to push it if a reviewer wants to re-run the capture). Instrument: `electron-headless`, a headless paired Orca runtime host plus a paired Electron client, window pinned to 1440×900, identical steps, and an identical 20 s settle window on both sides.

- **BEFORE** = this branch with `use-terminal-pane-reconciliation.ts` reverted to `main` (single-file revert; the planners stay, only the wiring is removed).
- **AFTER** = this branch at `5f81ca2`, unmodified.

Annotations are drawn by the harness: **red frame = the leaf the host retired**, green frame = the leaf the host still names. Both shells are switched to a neutral `orca-demo$` prompt before the first capture, so the frames carry no capturing-machine `user@host`.

### 1. Split, both panes live

Both trees are identical here: two panes, two remote PTYs, host layout names two leaves.

| BEFORE | AFTER |
| --- | --- |
| ![before-01](https://github.com/user-attachments/assets/3c0ba411-ec5f-478b-b3a2-1fe32dca3779) | ![after-01](https://github.com/user-attachments/assets/72aefc70-069d-4b85-b953-828fe8916cec) |

### 2. The host retires one leaf (`exit` in the lower shell)

Also identical, and that is correct: at the instant the layout shrinks the retired pane's PTY has not cleared yet, so `selectRetiredPaneIds` deliberately declines to close it. Look at the **host layout**, not the DOM — it is already down to one leaf in both. Store = 1 leaf, DOM = 2 panes on both sides.

| BEFORE | AFTER |
| --- | --- |
| ![before-02](https://github.com/user-attachments/assets/efcdf722-465d-4e92-91be-2950f0bf8bf8) | ![after-02](https://github.com/user-attachments/assets/1d516678-d7c3-4c04-b664-8b23e1fd37fa) |

### 3. After the settle window — this is the difference

**BEFORE keeps the ghost**: the red-framed pane is still mounted, showing the dead shell's `exit` echo, with no exit overlay and no restart control. Store = 1 leaf, DOM = 2 panes (`ghostStillMounted: true`). **AFTER has removed it** and the surviving pane fills the tab (`ghostStillMounted: false`).

| BEFORE — ghost still mounted | AFTER — ghost gone |
| --- | --- |
| ![before-03](https://github.com/user-attachments/assets/10e8db65-cd1f-4920-8925-ef10acd20461) | ![after-03](https://github.com/user-attachments/assets/de61f997-2cb3-4609-be6f-36f6511e9a67) |

### 4. The surviving pane is still usable — the tab was not killed

`echo ORCA_PANE_ALIVE_<ts>` is sent to the *first* terminal and its output is read back out of that pane's xterm buffer. It succeeds on both sides, which is the point: the fix removes a dead pane without touching the live one. BEFORE still carries the ghost underneath — that is the state where #17770 (c) bites, because closing the live pane then leaves the ghost as the only pane.

| BEFORE — live pane works, ghost persists | AFTER — live pane works, sole pane |
| --- | --- |
| ![before-04](https://github.com/user-attachments/assets/d3a766e5-9f39-478f-b4a2-a9f5b3aca395) | ![after-04](https://github.com/user-attachments/assets/ff320d72-500a-41ad-a591-87378cf1942e) |

The harness also writes machine-readable per-step facts (pane ids, PTY ids, host leaves, `ghostStillMounted`) to `facts.json` beside the screenshots; those are the numbers quoted above.

## Root cause or symptom?

**The removal side is a genuine repair, not a sweep.** `useTerminalPaneReconciliation`'s contract is to make mounted panes match the host-authoritative layout; it only ever implemented insertions. The host is behaving correctly — `OrcaRuntimeService.onPtyExit` retires the leaf and republishes. So "why is a retired pane still mounted at all?" answers to "the client reconciler has no removal path", and adding one completes the contract. The decision rule is also boundary-correct: removal needs positive host evidence (the host named the leaf, then dropped it) **and** a locally confirmed-cleared PTY, and never touches the last pane, so the safe direction stays leak-not-kill.

**The retry *scheduling* is the soft spot.** `selectRetiredPaneIds` correctly defers when the ghost's PTY is still bound, and the deferred retry is scheduled off `ptyRecoveryStatesByPaneId` — a state whose actual job is driving the reconnect overlay, and whose updater is *deliberately identity-stable*: `updateTerminalRemoteRuntimeRecoveryUiState` returns `previous` unchanged when the phase is not one of `recovering` / `backoff` / `disconnected` and the pane has no prior entry. So the effect only re-runs if the ghost passes through a **visible** recovery phase.

On the paired path it always does, and the reason is worth writing down because nothing in these files says it:

1. Every host-published terminal layout is keyed by a `web-terminal-`-prefixed tab id (`web-session-tabs-sync/terminal-build.ts:73`), so every tab that can reach the removal branch satisfies `isWebTerminalSurfaceTabId`.
2. `RemoteRuntimePtyTransport`'s `onEnd` takes its *first* branch unconditionally for such tabs (`remote-runtime-pty-transport.ts:2052`) — it treats the stream end as attachment loss, keeps the PTY, and schedules a resubscribe → phase `recovering`.
3. That adds a visible entry, and the later retirement (`'ended'`) deletes it. Two identity changes, two re-runs, and the ghost is removed on one of them.

That is measured, not inferred. Driving the transport directly and recording every `onRecoveryStateChange`:

| case | tab id | stream end | phases emitted | `getPtyId()` after |
| --- | --- | --- | --- | --- |
| A | `web-terminal-…` | `verdict: 'exited'` | `recovering` | **retained** |
| B | `tab-1` | `verdict: 'exited'` | `ended` | **cleared** |

**A** is the load-bearing one: on a paired tab even a *certified* exit keeps the PTY and routes through a visible phase, so the retry trigger always fires. **B** shows the no-visible-phase clear is real at transport level — it is simply unreachable from the removal branch, because every host-published layout is keyed `web-terminal-…` (point 1 above), so a tab in state B never takes that branch.

The other candidate — `handleRemoteTerminalError` → `isRemoteTerminalGoneMessage` → `retireRemoteTerminalId()` (`remote-runtime-pty-transport.ts:1678`), which clears the PTY straight from `connected` — is gated too: it hangs off the `terminal.send` RPC failing, and `sendUnacknowledgedInput` (`:1446`) only falls back to that RPC when no multiplexed stream is live. With a live stream the write never reaches it (measured: the RPC is not called), and a *closed* stream is exactly the state that has already emitted `recovering`.

So this is **hardening, not a live gap**. But the protection is three independent structural gates in three modules, none of which states the dependency — and `isHostAuthoritativeLayout`'s own doc comment describes a desktop, non-`web-terminal-` case as in scope. A future change that gives a normal-tab-id remote-runtime tab a host-published layout reopens the ghost with no failing test.

**Assessment:** correct fix, fragile trigger. The durable version drives the retry off the PTY-exit signal the transport already emits on *every* clearing path (`onPtyExit`, called at `remote-runtime-pty-transport.ts:1568`, `:2077`, `:2538`) rather than off recovery-phase object identity, which also drops the coupling to an unrelated overlay state. I did not make that change here — it is a real refactor of the effect's trigger and belongs in review, not in a silent amend. Flagging it as the follow-up this PR should not ship without a decision on.

## Relationship to #18387 (community PR)

@ylcn91 opened #18387 for this same issue on 2026-09-03, four days before this PR. The two are **not independent work**: two of the three shared files are byte-identical between the branches (blob `814ca8d974f` for `terminal-live-layout-reconciliation.test.ts`, blob `859f6c97168` for `terminal-live-layout-reconciliation.ts`). The design — `trackRetiredLeafIds` / `planTerminalLiveLayoutRemovals` / `selectRetiredPaneIds`, the retired-set gate, the `getPtyId() === null` guard, the never-last-pane guard, and their unit tests — is @ylcn91's.

**Same root cause?** Identical. Both identify that the host-authoritative reconciler planned insertions only.

**Do they conflict?** Yes — same three files, same functions. They cannot both merge.

**What this PR adds** (the complete delta):

1. `ptyRecoveryStatesByPaneId` in the reconciliation effect's dependency array.
2. `tests/e2e/paired-remote-split-pane-host-retired-ghost.spec.ts` — end-to-end reproduction against a real paired host and client.
3. The `terminal-pane-hook-order-parity.test.ts` repin (207 → 209).
4. Two expanded comments.

**Does #18387 miss a case?** One, and it is load-bearing. Its comment states that a removal skipped while the transport still held its PTY "is retried after the exit … once the exit lands and rewrites the layout bindings". That rewrite does not happen: `clearExitedPanePtyLayoutBindingForLeaf` (`use-terminal-pane-layout-bindings.ts:104`) early-returns when `existingBindings[leafId] !== exitedPtyId`, and the host already dropped that leaf's binding when it shrank the layout. Nothing re-runs the effect, so on the ordering where the layout shrink arrives before the PTY clears, the ghost stays. This is not theoretical — the e2e in this PR fails with #18387's planners and wiring alone.

**#18387 is also CI-red, latently.** It adds the same two `useRef`s to `useTerminalPaneReconciliation` without repinning the hook-order parity test, which then fails `expected [ Array(209) ] to have a length of 207`. Reproduced locally by running that test at `main`'s expectations against this branch's hook file. #18387 has no check runs at all (fork workflows were never approved), so nothing ever reported it.

**Does this PR miss anything #18387 catches?** No — this branch is a strict superset of #18387's changes.

**Recommendation.** This PR is #18387 plus the one missing re-trigger and the CI repin, so on merits it is the more complete change — but the substance is @ylcn91's and the delta is four lines plus tests. The cleanest outcome is to push that delta onto **#18387** and land *their* branch, closing this one; that gets the better fix and the right authorship in one move. If this branch lands instead, it should carry `Co-authored-by: ylcn91`, and #18387 should be closed with a comment that credits the diagnosis and links here. Either way #18387 should not simply be closed as superseded.

## DO NOT MERGE without explicit approval.


