### PR TITLE
chore(mobile): remove stale max-lines exceptions

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -9,8 +9,3 @@ inline src/main/ssh/ssh-relay-deploy.ts
 inline src/main/ssh/ssh-relay-session.ts
 inline src/relay/pty-handler.ts
 inline src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
-mobile-config app/h/*/files/*.tsx
-mobile-config app/h/*/source-control/*.tsx
-mobile-config app/index.tsx
-mobile-config scripts/mock-server.ts
-mobile-config src/transport/rpc-client.ts

--- a/mobile/.oxlintrc.json
+++ b/mobile/.oxlintrc.json
@@ -20,36 +20,6 @@
       "rules": {
         "max-lines": ["error", { "max": 379, "skipBlankLines": true, "skipComments": true }]
       }
-    },
-    {
-      "files": ["app/h/*/source-control/*.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 2152, "skipBlankLines": true, "skipComments": true }]
-      }
-    },
-    {
-      "files": ["app/index.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 1422, "skipBlankLines": true, "skipComments": true }]
-      }
-    },
-    {
-      "files": ["src/transport/rpc-client.ts"],
-      "rules": {
-        "max-lines": ["error", { "max": 1074, "skipBlankLines": true, "skipComments": true }]
-      }
-    },
-    {
-      "files": ["scripts/mock-server.ts"],
-      "rules": {
-        "max-lines": ["error", { "max": 407, "skipBlankLines": true, "skipComments": true }]
-      }
-    },
-    {
-      "files": ["app/h/*/files/*.tsx"],
-      "rules": {
-        "max-lines": ["error", { "max": 402, "skipBlankLines": true, "skipComments": true }]
-      }
     }
   ]
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | 0 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​35 |

<!-- /orca-pr-loc -->

## ELI5

Restore the normal mobile file-size limits now that the five formerly oversized targets have already been split into smaller modules.

## What Changed

Remove five stale overrides from `mobile/.oxlintrc.json` and their matching entries in `config/max-lines-baseline.txt`:

- `app/h/*/files/*.tsx`
- `app/h/*/source-control/*.tsx`
- `app/index.tsx`
- `scripts/mock-server.ts`
- `src/transport/rpc-client.ts`

## Why

These targets already fit the default 300-line TypeScript / 400-line TSX budgets. Removing the exceptions prevents them from growing past those limits again. Runtime source and exports are unchanged.

## Linked Issue

No issue supplied; this worktree has no linked Linear issue.

## Visual Proof

N/A — only lint configuration and its baseline changed.

## Testing

Validated on macOS:

- Targeted oxlint passed for the five targets and their existing UI, RPC, and mock-server modules.
- `pnpm run check:max-lines-ratchet` passed.
- `ORCA_BACKGROUND_LAUNCH=1 node_modules/.bin/vitest run --config config/vitest.config.ts config/scripts/check-max-lines-ratchet.test.mjs` passed: 15 tests.
- Formatting and `git diff --check` passed.
- Mobile test collection was blocked by missing mobile dependencies (`expo/tsconfig.base.json` could not resolve); no mobile test assertions ran.

No new tests added for this configuration-only removal. Full lint, typecheck, build, and platform runs were not run locally.

## Review

Independent parallel audits confirmed the exceptions are stale and runtime source is unchanged.

## Agent skill upstream boundary

- [x] Not applicable; no agent skill content changed.

## Checklist

- [x] This PR is small and focused.
- [x] Explained what changed and why, including ELI5.
- [x] Visual proof is N/A with reason.
- [x] Reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered: runtime behavior is unchanged.
- [ ] Full lint, typecheck, test, and build pass; only targeted local validation was run as documented above.
