### PR TITLE
fix(terminal): preserve configured scrollback through restore and log rotation

### DIFF
--- a/src/main/daemon/daemon-configured-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-configured-scrollback-depth.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX } from '../../shared/terminal-scrollback-policy'
+import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
+import { HeadlessEmulator } from './headless-emulator'
+import { HistoryManager } from './history-manager'
+import { HistoryReader } from './history-reader'
+
+describe('configured scrollback survives durable replay', () => {
+  let dir: string
+  let manager: HistoryManager
+  let reader: HistoryReader
+  let live: HeadlessEmulator
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-configured-scrollback-'))
+    manager = new HistoryManager(dir)
+    reader = new HistoryReader(dir)
+    live = new HeadlessEmulator({ cols: 80, rows: 24, scrollback: 1000 })
+    await manager.openSession('pane', { cwd: dir, cols: 80, rows: 24 })
+  })
+
+  afterEach(async () => {
+    live.dispose()
+    await manager.dispose()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('retains 50,000 requested rows through checkpoint plus incremental replay', async () => {
+    const output = Array.from(
+      { length: DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX },
+      (_, i) => `history-${String(i).padStart(5, '0')}\r\n`
+    ).join('')
+    live.writeSync(output)
+    await manager.appendIncrements('pane', 1, [{ kind: 'output', data: output }])
+    const restored = await reader.detectColdRestore('pane')
+    expect(restored?.snapshotAnsi).toContain('history-00000')
+    const checkpoint = await buildDurableCheckpointSnapshot({
+      liveSnapshot: live.getSnapshot(),
+      restoreInfo: restored,
+      pendingRecords: [{ kind: 'output', data: 'after-checkpoint\r\n' }],
+      scrollbackRows: DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX
+    })
+    expect(checkpoint.snapshotAnsi).toContain('history-00000')
+    expect(await manager.checkpoint('pane', checkpoint, { pendingOutputSeq: 2 })).toBe('committed')
+    await manager.appendIncrements('pane', 3, [{ kind: 'output', data: 'after-restart\r\n' }])
+    const restarted = await new HistoryReader(dir).detectColdRestore('pane')
+    expect(restarted?.snapshotAnsi).toContain('history-00000')
+    expect(restarted?.snapshotAnsi).toContain('after-checkpoint')
+    expect(restarted?.snapshotAnsi).toContain('after-restart')
+    expect(restarted?.scrollbackLines).toBeLessThanOrEqual(DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX)
+  })
+
+  it('still trims a snapshot to the requested smaller depth', async () => {
+    const output = Array.from({ length: 12000 }, (_, i) => `history-${i}\r\n`).join('')
+    live.writeSync(output)
+    await manager.appendIncrements('pane', 1, [{ kind: 'output', data: output }])
+    const snapshot = await buildDurableCheckpointSnapshot({
+      liveSnapshot: live.getSnapshot(),
+      restoreInfo: await reader.detectColdRestore('pane'),
+      scrollbackRows: 2000
+    })
+    expect(snapshot.snapshotAnsi).not.toContain('history-1000\r\n')
+    expect(snapshot.snapshotAnsi).toContain('history-11999')
+    expect(snapshot.scrollbackLines).toBe(2000)
+  })
+})

--- a/src/main/daemon/daemon-log-rotation-retention.test.ts
+++ b/src/main/daemon/daemon-log-rotation-retention.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { HeadlessEmulator } from './headless-emulator'
+import { HistoryReader } from './history-reader'
+import type { PendingOutputRecord } from './types'
+
+type CheckpointAccess = {
+  client: { request: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }
+  writeSessionCheckpoint: (
+    id: string,
+    opts: { final: boolean; teardown: boolean }
+  ) => Promise<'done' | 'deferred'>
+  lastFullCheckpointAt: Map<string, number>
+}
+
+describe('log rotation retains durable history beyond the live window', () => {
+  let dir: string
+  let adapter: DaemonPtyAdapter
+  let access: CheckpointAccess
+  let live: HeadlessEmulator
+  let pending: PendingOutputRecord[]
+  let seq: number
+  let includeDrainedRecords: boolean
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-log-rotation-'))
+    adapter = new DaemonPtyAdapter({
+      socketPath: join(dir, 'unused.sock'),
+      tokenPath: join(dir, 'unused.token'),
+      historyPath: dir
+    })
+    access = adapter as unknown as CheckpointAccess
+    pending = []
+    seq = 0
+    includeDrainedRecords = true
+    live = new HeadlessEmulator({ cols: 80, rows: 24, scrollback: 1000 })
+    access.client = {
+      disconnect: vi.fn(),
+      request: vi.fn(async (_method, params) => {
+        const records = pending
+        pending = []
+        const snapshot = params.includeSnapshot ? live.getSnapshot() : null
+        return {
+          seq: ++seq,
+          overflowed: false,
+          snapshot,
+          records: snapshot ? [] : records,
+          ...(snapshot && includeDrainedRecords ? { drainedRecords: records } : {})
+        }
+      })
+    }
+    const manager = adapter.getHistoryManager()!
+    await manager.openSession('pane', { cwd: dir, cols: 80, rows: 24 })
+    const initial = new HeadlessEmulator({ cols: 80, rows: 24, scrollback: 10000 })
+    try {
+      const output = Array.from({ length: 6000 }, (_, i) => `original-${i}\r\n`).join('')
+      initial.writeSync(output)
+      live.writeSync(output)
+      await manager.checkpoint('pane', initial.getSnapshot(), { pendingOutputSeq: 0 })
+    } finally {
+      initial.dispose()
+    }
+  })
+
+  afterEach(async () => {
+    live.dispose()
+    await adapter.getHistoryManager()!.dispose()
+    adapter.dispose()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('preserves a rejected batch when an older writer left a nearly full log', async () => {
+    const manager = adapter.getHistoryManager()!
+    const padding = '\x1b[0m'.repeat(1250000)
+    live.writeSync(padding)
+    expect(await manager.appendIncrements('pane', ++seq, [{ kind: 'output', data: padding }])).toBe(
+      'checkpoint-needed'
+    )
+    const data = `${'\x1b[0m'.repeat(140000)}rejected-batch\r\n`
+    live.writeSync(data)
+    pending.push({ kind: 'output', data })
+    access.lastFullCheckpointAt.set('pane', Date.now())
+    expect(await access.writeSessionCheckpoint('pane', { final: false, teardown: false })).toBe(
+      'done'
+    )
+    const restored = await new HistoryReader(dir).detectColdRestore('pane')
+    expect(restored?.snapshotAnsi.includes('original-0\r\n')).toBe(true)
+    expect(restored?.snapshotAnsi.split('rejected-batch').length).toBe(2)
+  })
+
+  it.each([
+    { cooldown: false, snapshotContract: 'current' },
+    { cooldown: true, snapshotContract: 'current' },
+    { cooldown: true, snapshotContract: 'sequence-gap' },
+    { cooldown: true, snapshotContract: 'older-daemon' }
+  ])(
+    'rotates with $snapshotContract and cooldown=$cooldown',
+    async ({ cooldown, snapshotContract }) => {
+      if (cooldown) {
+        access.lastFullCheckpointAt.set('pane', Date.now())
+      }
+      const checkpoint = vi.spyOn(adapter.getHistoryManager()!, 'checkpoint')
+      const write = () => access.writeSessionCheckpoint('pane', { final: false, teardown: false })
+      for (let batch = 0; batch < 5; batch++) {
+        const data = `${'\x1b[0m'.repeat(140000)}batch-${batch}\r\n`
+        live.writeSync(data)
+        pending.push({ kind: 'output', data })
+        const result = await write()
+        expect(result).toBe(cooldown && batch === 4 ? 'deferred' : 'done')
+      }
+      if (cooldown) {
+        expect(checkpoint).not.toHaveBeenCalled()
+        const beforeRotation = await new HistoryReader(dir).detectColdRestore('pane')
+        expect(beforeRotation?.snapshotAnsi.includes('original-0\r\n')).toBe(true)
+        expect(beforeRotation?.snapshotAnsi).toContain('batch-4')
+        const data = 'during-cooldown\r\n'
+        live.writeSync(data)
+        pending.push({ kind: 'output', data })
+        if (snapshotContract === 'sequence-gap') {
+          seq++
+        }
+        if (snapshotContract === 'older-daemon') {
+          includeDrainedRecords = false
+        }
+        access.lastFullCheckpointAt.set('pane', Date.now() - 46000)
+        expect(await write()).toBe('done')
+      }
+      expect(checkpoint).toHaveBeenCalledTimes(1)
+      const restored = await new HistoryReader(dir).detectColdRestore('pane')
+      expect(restored?.snapshotAnsi.includes('original-0\r\n')).toBe(snapshotContract === 'current')
+      for (let batch = 0; batch < 5; batch++) {
+        expect(restored?.snapshotAnsi.split(`batch-${batch}`).length).toBe(2)
+      }
+      if (cooldown) {
+        expect(restored?.snapshotAnsi).toContain('during-cooldown')
+      }
+      expect(live.getSnapshot().snapshotAnsi).not.toContain('original-0\r\n')
+    }
+  )
+})

--- a/src/main/daemon/daemon-pty-adapter-history-checkpoints.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-history-checkpoints.test.ts
@@ -410,7 +410,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
 
       function makeCooldownHarness(takeResult: {
         overflowed: boolean
-        appendResult?: 'ok' | 'needs-checkpoint'
+        appendResult?: 'ok' | 'checkpoint-needed' | 'needs-checkpoint'
         checkpointResult?: 'committed' | 'retryable' | 'unavailable'
         snapshotRecords?: PendingOutputRecord[]
       }): CooldownInternals {
@@ -480,10 +480,10 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         expect(internals.historyManager.checkpoint).toHaveBeenCalledTimes(2)
       })
 
-      it('defers log-cap (needs-checkpoint) snapshots inside the cooldown', async () => {
+      it('defers accepted-batch rotation inside the cooldown', async () => {
         const internals = makeCooldownHarness({
           overflowed: false,
-          appendResult: 'needs-checkpoint'
+          appendResult: 'checkpoint-needed'
         })
         internals.lastFullCheckpointAt.set('capped', Date.now())
 

--- a/src/main/daemon/daemon-pty-checkpoint-persistence.ts
+++ b/src/main/daemon/daemon-pty-checkpoint-persistence.ts
@@ -46,6 +46,7 @@ export abstract class DaemonPtyCheckpointPersistence extends DaemonPtyCheckpoint
     }
     if (take.overflowed) {
       // Why: overflow dropped records (log has a hole); only a full snapshot can re-anchor it.
+      this.sessionsNeedingLiveCheckpoint.add(sessionId)
       if (this.isFullCheckpointCoolingDown(sessionId)) {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
@@ -71,15 +72,18 @@ export abstract class DaemonPtyCheckpointPersistence extends DaemonPtyCheckpoint
       take.seq,
       take.records
     )
-    if (appendResult === 'needs-checkpoint') {
-      // Why dropping take.records is lossless: applied to the emulator before the take, so the snapshot below contains them.
-      if (this.isFullCheckpointCoolingDown(sessionId)) {
+    if (appendResult !== 'ok') {
+      const rejectedBatch = appendResult === 'needs-checkpoint'
+      this.sessionsNeedingContinuityCheckpoint.add(sessionId)
+      // A pre-upgrade log can already be full; compact now while its rejected batch is still available.
+      if (!rejectedBatch && this.isFullCheckpointCoolingDown(sessionId)) {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
         return 'deferred'
       }
       const checkpoint = await this.takeSnapshotAndCheckpoint(sessionId, {
         teardown: false,
-        forceLiveSnapshot: true
+        requireContinuityProof: true,
+        ...(rejectedBatch ? { precedingTake: take } : {})
       })
       if (checkpoint.checkpoint === 'retryable') {
         this.sessionsNeedingFullCheckpoint.add(sessionId)
@@ -95,6 +99,7 @@ export abstract class DaemonPtyCheckpointPersistence extends DaemonPtyCheckpoint
       teardown: boolean
       forceLiveSnapshot?: boolean
       requireContinuityProof?: boolean
+      precedingTake?: Pick<TakePendingOutputResult, 'seq' | 'records'>
     }
   ): Promise<SnapshotCheckpointResult> {
     const take = await this.client.request<TakePendingOutputResult | null>('takePendingOutput', {
@@ -103,20 +108,24 @@ export abstract class DaemonPtyCheckpointPersistence extends DaemonPtyCheckpoint
       teardownSnapshot: opts.teardown
     })
     if (take?.snapshot && this.historyManager) {
+      const firstSeq = opts.precedingTake?.seq ?? take.seq
       // Why require drainedRecords: an older daemon still empties the pending
       // queue on includeSnapshot but omits the field. Treating absence as []
       // would compact stale disk history and reset the log.
       const snapshot =
-        take.drainedRecords === undefined || opts.forceLiveSnapshot === true || take.overflowed
+        take.drainedRecords === undefined ||
+        opts.forceLiveSnapshot === true ||
+        take.overflowed ||
+        (opts.precedingTake !== undefined && take.seq !== firstSeq + 1)
           ? take.snapshot
           : await this.buildDurableHistorySnapshot(
               sessionId,
               take.snapshot,
-              [...take.drainedRecords, ...take.records],
+              [...(opts.precedingTake?.records ?? []), ...take.drainedRecords, ...take.records],
               {
-                pendingRecordsAreComplete: take.seq === 1,
+                pendingRecordsAreComplete: firstSeq === 1,
                 ...(opts.requireContinuityProof === true
-                  ? { requiredPreviousPendingOutputSeq: take.seq - 1 }
+                  ? { requiredPreviousPendingOutputSeq: firstSeq - 1 }
                   : {})
               }
             )

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -2,7 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../shared/terminal-scrollback-policy'
+import {
+  DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,
+  DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX
+} from '../../shared/terminal-scrollback-policy'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonServer } from './daemon-server'
 import { buildDurableCheckpointSnapshot } from './daemon-durable-history-snapshot'
@@ -156,7 +159,7 @@ describe('STA-4091 previously recoverable restore depth', () => {
         expect(text).toContain(NEWEST_WRITTEN_LINE)
         expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
         expect(text).toContain(OLDEST_WRITTEN_LINE)
-        expect(DAEMON_RESTORE_SCROLLBACK_ROWS).toBe(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT)
+        expect(DAEMON_RESTORE_SCROLLBACK_ROWS).toBe(DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX)
       } finally {
         live.dispose()
       }
@@ -305,22 +308,25 @@ describe('STA-4091 previously recoverable restore depth', () => {
       rmSync(dir, { recursive: true, force: true })
     })
 
-    it('restores the previously recoverable depth on remount snapshot', async () => {
-      const { id } = await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        sessionId: 'remount-depth',
-        cwd: '/tmp'
-      })
-      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+    it.each([DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT, DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX])(
+      'restores the previously recoverable depth on remount snapshot (%i rows)',
+      async (depth) => {
+        const { id } = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: 'remount-depth',
+          cwd: '/tmp'
+        })
+        lastSubprocess.emitData(numberedOutput(depth))
 
-      const snapshot = await adapter.getBufferSnapshot(id)
-      const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
-      expect(text).toContain(NEWEST_WRITTEN_LINE)
-      expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
-      expect(text).toContain(OLDEST_WRITTEN_LINE)
-      expect(text.split(OLDEST_WRITTEN_LINE)).toHaveLength(2)
-    })
+        const snapshot = await adapter.getBufferSnapshot(id)
+        const text = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+        expect(text).toContain(NEWEST_WRITTEN_LINE)
+        expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(text).toContain(OLDEST_WRITTEN_LINE)
+        expect(text.split(OLDEST_WRITTEN_LINE)).toHaveLength(2)
+      }
+    )
 
     it('honors a bounded remount snapshot depth', async () => {
       const { id } = await adapter.spawn({
@@ -338,74 +344,83 @@ describe('STA-4091 previously recoverable restore depth', () => {
       expect(text).not.toContain(OLDEST_WRITTEN_LINE)
     })
 
-    it('restores that depth after a keepHistory restart compact', async () => {
-      const { id } = await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        sessionId: 'restart-depth',
-        cwd: '/tmp'
-      })
-      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+    it.each([DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT, DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX])(
+      'restores that depth after a keepHistory restart compact (%i rows)',
+      async (depth) => {
+        const { id } = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: 'restart-depth',
+          cwd: '/tmp'
+        })
+        lastSubprocess.emitData(numberedOutput(depth))
 
-      await adapter.shutdown(id, { immediate: true, keepHistory: true })
+        await adapter.shutdown(id, { immediate: true, keepHistory: true })
 
-      const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
-        ignoreCleanEnd: true
-      })
-      const text = snapshotText(restore ?? {})
-      expect(text).toContain(NEWEST_WRITTEN_LINE)
-      expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
-      expect(text).toContain(OLDEST_WRITTEN_LINE)
-    })
+        const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+          ignoreCleanEnd: true
+        })
+        const text = snapshotText(restore ?? {})
+        expect(text).toContain(NEWEST_WRITTEN_LINE)
+        expect(text).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(text).toContain(OLDEST_WRITTEN_LINE)
+      }
+    )
 
-    it('restores that depth on warm reattach', async () => {
-      const { id } = await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        sessionId: 'reattach-depth',
-        cwd: '/tmp'
-      })
-      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+    it.each([DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT, DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX])(
+      'restores that depth on warm reattach (%i rows)',
+      async (depth) => {
+        const { id } = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: 'reattach-depth',
+          cwd: '/tmp'
+        })
+        lastSubprocess.emitData(numberedOutput(depth))
 
-      const reattach = await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        sessionId: id,
-        cwd: '/tmp'
-      })
-      expect(reattach.isReattach).toBe(true)
-      expect(reattach.snapshot).toContain(NEWEST_WRITTEN_LINE)
-      expect(reattach.snapshot).toContain(PREVIOUSLY_RECOVERABLE_LINE)
-      expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
-    })
+        const reattach = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: id,
+          cwd: '/tmp'
+        })
+        expect(reattach.isReattach).toBe(true)
+        expect(reattach.snapshot).toContain(NEWEST_WRITTEN_LINE)
+        expect(reattach.snapshot).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
+      }
+    )
 
-    it('preserves durable depth across an adapter reconnect', async () => {
-      const { id } = await adapter.spawn({
-        cols: 80,
-        rows: 24,
-        sessionId: 'adapter-reconnect-depth',
-        cwd: '/tmp'
-      })
-      lastSubprocess.emitData(numberedOutput(DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT))
+    it.each([DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT, DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX])(
+      'preserves durable depth across an adapter reconnect (%i rows)',
+      async (depth) => {
+        const { id } = await adapter.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: 'adapter-reconnect-depth',
+          cwd: '/tmp'
+        })
+        lastSubprocess.emitData(numberedOutput(depth))
 
-      await adapter.disconnectOnly()
-      adapter = new DaemonPtyAdapter({
-        socketPath: getDaemonSocketPath(dir),
-        tokenPath: join(dir, 'test.token'),
-        historyPath: historyDir
-      })
+        await adapter.disconnectOnly()
+        adapter = new DaemonPtyAdapter({
+          socketPath: getDaemonSocketPath(dir),
+          tokenPath: join(dir, 'test.token'),
+          historyPath: historyDir
+        })
 
-      const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
-      expect(reattach.isReattach).toBe(true)
-      expect(reattach.snapshot).toContain(NEWEST_WRITTEN_LINE)
-      expect(reattach.snapshot).toContain(PREVIOUSLY_RECOVERABLE_LINE)
-      expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
+        const reattach = await adapter.spawn({ cols: 80, rows: 24, sessionId: id, cwd: '/tmp' })
+        expect(reattach.isReattach).toBe(true)
+        expect(reattach.snapshot).toContain(NEWEST_WRITTEN_LINE)
+        expect(reattach.snapshot).toContain(PREVIOUSLY_RECOVERABLE_LINE)
+        expect(reattach.snapshot).toContain(OLDEST_WRITTEN_LINE)
 
-      const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
-        ignoreCleanEnd: true
-      })
-      expect(snapshotText(restore ?? {})).toContain(OLDEST_WRITTEN_LINE)
-    })
+        const restore = await new HistoryReader(historyDir).detectColdRestore(id, {
+          ignoreCleanEnd: true
+        })
+        expect(snapshotText(restore ?? {})).toContain(OLDEST_WRITTEN_LINE)
+      }
+    )
 
     it('uses the live window when durable history disappears after a prior drain', async () => {
       const { id } = await adapter.spawn({

--- a/src/main/daemon/daemon-restore-scrollback-depth.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.ts
@@ -1,5 +1,4 @@
-import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../shared/terminal-scrollback-policy'
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX } from '../../shared/terminal-scrollback-policy'
 
-// Why this number: it is the desktop default that rebuilds restored before the live
-// daemon window was flattened. Durable history keeps this depth; live RAM stays smaller.
-export const DAEMON_RESTORE_SCROLLBACK_ROWS = DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT
+// Disk replay must preserve every supported client depth; the live daemon keeps its smaller window.
+export const DAEMON_RESTORE_SCROLLBACK_ROWS = DESKTOP_TERMINAL_SCROLLBACK_ROWS_MAX

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -14,6 +14,7 @@ import {
   schedulePendingSessionTreeRemovals
 } from './terminal-history-session-tombstone'
 import { TerminalHistorySessionWriter } from './terminal-history-session-writer'
+import type { TerminalHistoryAppendResult } from './terminal-history-session-writer'
 import {
   readTerminalHistoryMetaFromDir,
   updateTerminalHistoryMeta,
@@ -195,12 +196,12 @@ export class HistoryManager {
     this.disabledSessions.delete(sessionId)
   }
 
-  /** Appends one batch to the incremental log; returns 'needs-checkpoint' at capacity, signalling the caller to checkpoint() (which resets the log). */
+  /** 'checkpoint-needed' saved the batch; 'needs-checkpoint' refused it at the hard cap. */
   appendIncrements(
     sessionId: string,
     seq: number,
     records: PendingOutputRecord[]
-  ): Promise<'ok' | 'needs-checkpoint'> {
+  ): Promise<TerminalHistoryAppendResult> {
     return this.mutations.track(sessionId, this.appendIncrementsUntracked(sessionId, seq, records))
   }
 
@@ -208,12 +209,9 @@ export class HistoryManager {
     sessionId: string,
     seq: number,
     records: PendingOutputRecord[]
-  ): Promise<'ok' | 'needs-checkpoint'> {
-    if (this.disabledSessions.has(sessionId) || records.length === 0) {
-      return 'ok'
-    }
+  ): Promise<TerminalHistoryAppendResult> {
     const writer = this.writers.get(sessionId)
-    if (!writer) {
+    if (!writer || this.disabledSessions.has(sessionId) || records.length === 0) {
       return 'ok'
     }
     try {
@@ -282,8 +280,7 @@ export class HistoryManager {
     this.disabledSessions.delete(sessionId)
     this.recoveryFreezes.delete(sessionId)
     await this.mutations.wait(sessionId)
-    // Why tombstoned: writer handles are closed by here, so the trees only have to become unreachable —
-    // they reach hundreds of MB and every terminal a worktree delete tears down awaits this.
+    // Tombstone first so terminal teardown need not wait for hundreds of MB to be reclaimed.
     await removeTerminalHistorySessionTrees(this.basePath, sessionId)
   }
 

--- a/src/main/daemon/terminal-history-incremental-restore.test.ts
+++ b/src/main/daemon/terminal-history-incremental-restore.test.ts
@@ -218,7 +218,7 @@ describe('incremental terminal history restore', () => {
       data: 'x'.repeat(2 * 1024 * 1024)
     }
     expect(await manager.appendIncrements(SESSION_ID, 1, [bigRecord])).toBe('ok')
-    expect(await manager.appendIncrements(SESSION_ID, 2, [bigRecord])).toBe('ok')
+    expect(await manager.appendIncrements(SESSION_ID, 2, [bigRecord])).toBe('checkpoint-needed')
     expect(await manager.appendIncrements(SESSION_ID, 3, [bigRecord])).toBe('needs-checkpoint')
     // Why: the rejected batch is subsumed by the snapshot the caller takes
     // next; checkpoint() resets the log for the new generation.

--- a/src/main/daemon/terminal-history-session-writer.ts
+++ b/src/main/daemon/terminal-history-session-writer.ts
@@ -16,11 +16,16 @@ import {
 import type { SessionMeta } from './terminal-history-metadata'
 import { clearTerminalHistoryRecoveryProtection } from './terminal-history-recovery-quarantine'
 import type { PendingOutputRecord, TerminalSnapshot } from './types'
-import { TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES } from './terminal-history-file-limits'
+import {
+  TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES,
+  TERMINAL_HISTORY_LOG_MAX_BYTES
+} from './terminal-history-file-limits'
 import { serializeTerminalCheckpointWithinLimit } from './terminal-checkpoint-serializer'
 
-// Why 5MB: bounds cold-restore replay time and per-session disk; hitting the cap triggers one checkpoint that resets the log.
-const LOG_MAX_BYTES = 5 * 1024 * 1024
+// Leave headroom for the daemon's next 2MiB batch before the hard reader/writer cap.
+const LOG_CHECKPOINT_BYTES = TERMINAL_HISTORY_LOG_MAX_BYTES / 2
+
+export type TerminalHistoryAppendResult = 'ok' | 'checkpoint-needed' | 'needs-checkpoint'
 
 export class TerminalHistorySessionWriter {
   readonly checkpointPath: string
@@ -42,11 +47,11 @@ export class TerminalHistorySessionWriter {
   async appendIncrements(
     seq: number,
     records: PendingOutputRecord[]
-  ): Promise<'ok' | 'needs-checkpoint'> {
+  ): Promise<TerminalHistoryAppendResult> {
     this.resolveLogState()
     const batch = encodeLogBatch(seq, records)
     const projectedBytes = Math.max(this.logBytes ?? 0, LOG_HEADER_BYTES) + batch.length
-    if (projectedBytes > LOG_MAX_BYTES) {
+    if (projectedBytes > TERMINAL_HISTORY_LOG_MAX_BYTES) {
       return 'needs-checkpoint'
     }
     if (this.logBytes === 0) {
@@ -55,7 +60,7 @@ export class TerminalHistorySessionWriter {
     }
     await fsPromises.appendFile(this.logPath, batch)
     this.logBytes = (this.logBytes ?? LOG_HEADER_BYTES) + batch.length
-    return 'ok'
+    return this.logBytes >= LOG_CHECKPOINT_BYTES ? 'checkpoint-needed' : 'ok'
   }
 
   async checkpoint(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​310 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​83 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​227 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

## ELI5

Selecting 50,000 terminal rows should not silently become 5,000 after reopening a pane, or 1,000 when the history log rotates. Durable replay now retains the supported 50,000-row ceiling, and normal log rotation rebuilds from saved history.

## What Changed

- Keep the live daemon window at 1,000 rows; raise the disk replay ceiling to the supported desktop maximum.
- Request rotation after a successfully appended batch crosses half the 5MiB log budget. That preserves the batch through the existing checkpoint cooldown without retaining another memory buffer.
- For an already-full log, include the refused batch in immediate compaction and prove sequence continuity. Preserve the live fallback for actual overflow, missing continuity, and older daemons that omit drained records.
- Add 50k disk replay coverage; exercise remount, restart, warm reattach, and adapter reconnect at both 5k and 50k. Add real-file rotation tests for cooldown, full legacy logs, sequence gaps, and older daemon responses.

## Why

The renderer accepts 50k rows, but durable reconstruction was capped at the 5k default. Separately, log rotation forced a snapshot from the smaller live buffer, replacing deeper saved history with that window.

## Linked Issue

Addresses #11560, #12864, and #17114.

## Visual Proof

The stacked follow-up #19383 includes hidden Electron restore screenshots and a [full investigation report](https://github.com/stablyai/orca/blob/OrcaWin/np-scrollback-memory/docs/reference/terminal-scrollback-investigation.md). Its 75k-output test reveals the earliest row after switching workspace. The baseline retention failure is recorded by a failing real-file regression; no baseline screenshot is claimed.

## Testing

- macOS: Node typecheck and changed-code quality checks passed; staged lint/format hooks passed.
- 105 relevant retention, history-manager, checkpoint-bound, and adapter tests passed before the final legacy-log case; the final rotation/adapter/restore run passed 52 tests, including that case.
- Mixed-version terminal wire suite passed alongside the 50k adapter tests.
- Regression test initially failed on the baseline because the first of 50k lines was absent after disk replay.
- All runs used `ORCA_BACKGROUND_LAUNCH=1`; no app window was shown.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Retention correctness can be reviewed independently of the stacked memory/settings candidate #19383. This PR does not claim a memory reduction or remove synchronous serialization. The follow-up bounds both reconstruction paths with one admission semaphore and reports actual browser cell-storage savings plus the dense resize regression. Original PR CI checks passed; the follow-up has its own checks.

## Agent skill upstream boundary

- [x] Not applicable: no skill implementation changes.

## Notes

No new RPC fields or opcodes. This affects local and paired-runtime daemon-backed terminals; direct SSH relay terminals use a different replay path. Parked-SSH and renderer-fallback tests passed in #19383, but no live SSH host was exercised. History tests use ordinary temporary folders without Git. Windows/Linux native runs remain untested; hidden macOS rendering checks passed on the stacked changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


## Regression hardening follow-up

#19383 now includes two additional deep-snapshot fallback fixes, 1,874 passing daemon/retention/remote tests, 350 further SSH/replay/compaction tests, and a 1,315-test runtime run. Hidden rendered checks passed for a six-workspace paired client and for terminal I/O/agent-hook status over a real throwaway loopback SSH server. The retention code in this PR did not require a further production change. Details and scope limits are in the linked report.
