### PR TITLE
perf(sidebar): remove repeated timer scans across workspace cards

### DIFF
--- a/src/renderer/src/components/sidebar/prompt-cache-timer-index-invalidation.test.ts
+++ b/src/renderer/src/components/sidebar/prompt-cache-timer-index-invalidation.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  movePaneKeyedRecord,
+  removePaneKeys,
+  removePaneKeysByTabPrefix
+} from '@/store/slices/agent-status-pane-keyed-records'
+import { buildOrphanTerminalCleanupPatch } from '@/store/slices/terminal-orphan-helpers'
+import { createTestStore, makeTab, seedStore } from '@/store/slices/store-test-helpers'
+import { getMostUrgentPromptCacheStartedAt } from './prompt-cache-timer-selection'
+
+// The countdown index is keyed by the cacheTimerByKey record identity, so every
+// producer must publish a fresh record; a mutating writer would show a stale timer.
+const WORKTREE = 'repo1::/repo1'
+const CARD_TABS = [{ id: 'tab-a' }, { id: 'tab-b' }]
+
+function storeWithIdleClaudeTab(): ReturnType<typeof createTestStore> {
+  const store = createTestStore()
+  seedStore(store, {
+    tabsByWorktree: {
+      [WORKTREE]: [makeTab({ id: 'tab-a', worktreeId: WORKTREE, title: '✳ Claude Code' })]
+    }
+  })
+  return store
+}
+
+function urgentStartedAt(store: ReturnType<typeof createTestStore>): number | null {
+  return getMostUrgentPromptCacheStartedAt(CARD_TABS, store.getState().cacheTimerByKey)
+}
+
+describe('prompt cache countdown index invalidation', () => {
+  it('follows every setCacheTimerStartedAt write', () => {
+    const store = storeWithIdleClaudeTab()
+    expect(urgentStartedAt(store)).toBeNull()
+
+    store.getState().setCacheTimerStartedAt('tab-a:pane-1', 1_000)
+    expect(urgentStartedAt(store)).toBe(1_000)
+
+    store.getState().setCacheTimerStartedAt('tab-a:pane-1', 400)
+    expect(urgentStartedAt(store)).toBe(400)
+
+    store.getState().setCacheTimerStartedAt('tab-b:pane-1', 900)
+    expect(urgentStartedAt(store)).toBe(400)
+
+    store.getState().setCacheTimerStartedAt('tab-a:pane-1', null)
+    expect(urgentStartedAt(store)).toBe(900)
+  })
+
+  it('follows seeded timers and the real pane write that clears the seed', () => {
+    const store = storeWithIdleClaudeTab()
+    store.getState().seedCacheTimersForIdleTabs()
+    expect(store.getState().cacheTimerByKey['tab-a:seed']).toEqual(expect.any(Number))
+    expect(urgentStartedAt(store)).toBe(store.getState().cacheTimerByKey['tab-a:seed'])
+
+    store.getState().setCacheTimerStartedAt('tab-a:pane-1', 5)
+    expect(store.getState().cacheTimerByKey['tab-a:seed']).toBeUndefined()
+    expect(urgentStartedAt(store)).toBe(5)
+  })
+
+  it('follows pane retire, pane move, and tab-close cleanup', () => {
+    const record: Record<string, number | null> = {
+      'tab-a:pane-1': 100,
+      'tab-b:pane-1': 200
+    }
+    expect(getMostUrgentPromptCacheStartedAt(CARD_TABS, record)).toBe(100)
+
+    const retired = removePaneKeys(record, new Set(['tab-a:pane-1']))
+    expect(getMostUrgentPromptCacheStartedAt(CARD_TABS, retired)).toBe(200)
+
+    const closed = removePaneKeysByTabPrefix(record, 'tab-a')
+    expect(getMostUrgentPromptCacheStartedAt(CARD_TABS, closed)).toBe(200)
+
+    const moved = movePaneKeyedRecord(record, 'tab-a:pane-1', 'tab-c:pane-1')
+    expect(getMostUrgentPromptCacheStartedAt(CARD_TABS, moved)).toBe(200)
+    expect(getMostUrgentPromptCacheStartedAt([{ id: 'tab-c' }], moved)).toBe(100)
+
+    // No-op writes keep the identity, which is what lets the index be shared.
+    expect(removePaneKeys(record, new Set(['tab-z:pane-1']))).toBe(record)
+    expect(movePaneKeyedRecord(record, 'tab-z:pane-1', 'tab-y:pane-1')).toBe(record)
+  })
+
+  it('follows the orphan-terminal sweep', () => {
+    const store = storeWithIdleClaudeTab()
+    store.getState().setCacheTimerStartedAt('tab-a:pane-1', 42)
+    expect(urgentStartedAt(store)).toBe(42)
+
+    const patch = buildOrphanTerminalCleanupPatch(store.getState(), WORKTREE, new Set(['tab-a']))
+    expect(getMostUrgentPromptCacheStartedAt(CARD_TABS, patch.cacheTimerByKey)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/prompt-cache-timer-selection.test.ts
+++ b/src/renderer/src/components/sidebar/prompt-cache-timer-selection.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import {
   getMostUrgentPromptCacheStartedAt,
@@ -28,6 +28,44 @@ describe('getMostUrgentPromptCacheStartedAt', () => {
     })
 
     expect(startedAt).toBe(300)
+  })
+
+  it('shares one timer inventory pass across visible cards and unrelated store writes', () => {
+    const cards = Array.from({ length: 423 }, (_, index) =>
+      Array.from({ length: 3 }, (_, tab) => ({ id: `tab-${index * 3 + tab}` }))
+    )
+    const inventory = Object.fromEntries(
+      cards.flatMap((tabs) => tabs.map((tab) => [`${tab.id}:seed`, 100]))
+    )
+    const enumerate = vi.fn(Reflect.ownKeys)
+    const timers = new Proxy<Record<string, number | null>>(inventory, { ownKeys: enumerate })
+    let total = 0
+    for (let write = 0; write < 100; write++) {
+      for (const tabs of cards.slice(0, 20)) {
+        total += getMostUrgentPromptCacheStartedAt(tabs, timers) ?? 0
+      }
+    }
+
+    expect(total).toBe(200_000)
+    expect(enumerate).toHaveBeenCalledTimes(1)
+  })
+
+  it('updates minima on timer replacement and tab membership changes', () => {
+    const tabs = [{ id: 'tab-1' }]
+    const original = { 'tab-1:seed': 300, 'tab-1:pane-a': 200, 'tab-2:pane-a': 100 }
+    expect(getMostUrgentPromptCacheStartedAt(tabs, original)).toBe(200)
+    expect(getMostUrgentPromptCacheStartedAt([{ id: 'tab-2' }], original)).toBe(100)
+
+    const cleared = { ...original, 'tab-1:pane-a': null }
+    expect(getMostUrgentPromptCacheStartedAt(tabs, cleared)).toBe(300)
+    const replaced = { ...cleared, 'tab-1:pane-b': 0 }
+    expect(getMostUrgentPromptCacheStartedAt(tabs, replaced)).toBe(0)
+    const removed = { 'tab-2:pane-a': 100 }
+    expect(getMostUrgentPromptCacheStartedAt(tabs, removed)).toBeNull()
+
+    expect(getMostUrgentPromptCacheStartedAt(tabs, original)).toBe(200)
+    expect(getMostUrgentPromptCacheStartedAt([], original)).toBeNull()
+    expect(getMostUrgentPromptCacheStartedAt(undefined, original)).toBeNull()
   })
 })
 

--- a/src/renderer/src/components/sidebar/prompt-cache-timer-selection.ts
+++ b/src/renderer/src/components/sidebar/prompt-cache-timer-selection.ts
@@ -6,9 +6,35 @@ export type PromptCacheCountdownSelection = {
   ttlMs: number
 }
 
+const oldestTimerByTabCache = new WeakMap<Record<string, number | null>, Map<string, number>>()
+
 function getCacheTimerTabId(key: string): string | null {
   const separator = key.indexOf(':')
   return separator > 0 ? key.slice(0, separator) : null
+}
+
+function getOldestTimerByTab(cacheTimerByKey: Record<string, number | null>): Map<string, number> {
+  const cached = oldestTimerByTabCache.get(cacheTimerByKey)
+  if (cached) {
+    return cached
+  }
+  const oldestByTab = new Map<string, number>()
+  for (const [key, startedAt] of Object.entries(cacheTimerByKey)) {
+    if (startedAt == null) {
+      continue
+    }
+    const tabId = getCacheTimerTabId(key)
+    if (!tabId) {
+      continue
+    }
+    const oldest = oldestByTab.get(tabId)
+    if (oldest === undefined || startedAt < oldest) {
+      oldestByTab.set(tabId, startedAt)
+    }
+  }
+  // Timer writes replace the record; share its index across cards and unrelated store updates.
+  oldestTimerByTabCache.set(cacheTimerByKey, oldestByTab)
+  return oldestByTab
 }
 
 export function getMostUrgentPromptCacheStartedAt(
@@ -18,17 +44,11 @@ export function getMostUrgentPromptCacheStartedAt(
   if (!tabs || tabs.length === 0) {
     return null
   }
-  const tabIds = new Set(tabs.map((tab) => tab.id))
+  const oldestByTab = getOldestTimerByTab(cacheTimerByKey)
   let oldest: number | null = null
-  for (const [key, startedAt] of Object.entries(cacheTimerByKey)) {
-    if (startedAt == null) {
-      continue
-    }
-    const tabId = getCacheTimerTabId(key)
-    if (!tabId || !tabIds.has(tabId)) {
-      continue
-    }
-    if (oldest === null || startedAt < oldest) {
+  for (const tab of tabs) {
+    const startedAt = oldestByTab.get(tab.id)
+    if (startedAt !== undefined && (oldest === null || startedAt < oldest)) {
       oldest = startedAt
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​128 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

Orca's sidebar can show a small countdown telling you how long each workspace's prompt cache stays warm. Before this change, every time any terminal updated its title or status, each visible workspace card re-scanned every timer in the whole app — so the more terminals you had open, the more repeated work each update caused. Now the app works that list out once per update and each card just looks up its own tabs, so you see the same countdown with far less work behind it.

When prompt-cache timers are enabled, every store publication makes each visible workspace card enumerate every timer in the app. Terminal title/status traffic therefore repeats work proportional to visible cards × accumulated timers. Index the existing immutable timer record once, then read each card's own tabs. Timer resets, clearing, seed timers, zero timestamps, tab membership, and the countdown clock retain their existing behavior.

Measured with 20 cards, 1,269 timers, and 100 publications: **2,000 full inventory scans → 1**. The selector benchmark fell from 367 ms to 0.2 ms for unchanged timers, and 425 ms to 40 ms when a timer changed on every publication (seven counterbalanced runs; identical result checksums). In a hidden development Electron renderer with 400 fixture workspaces and 25 mounted cards, total synchronous store work across 200 title updates fell from **899 ms to 194 ms**. These are controlled fixtures, not a claim about all typing latency; the prompt-cache timer preference is off by default.

Validation: 69 tests across five relevant selector/subscription/card suites; TypeScript node/CLI/web checks; targeted lint and formatting. CDP verified the intended worktree, rendered countdown reset, immediate disable/hide and re-enable/restore. The index is weakly owned by the timer record; all timer producers and cleanup paths replace that record. This is a renderer-only lookup: no process, provider, workspace routing, or wire change, including folder/SSH workspaces.

Rendered production sidebar with controlled fixture data after resetting its timer:

![Countdown reset to 5:00 in the workspace sidebar](https://github.com/user-attachments/assets/d67d070e-7746-43f3-ac9d-0652300873af)

