### PR TITLE
fix(deps): update DOMPurify for sanitizer and document-context fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "dompurify": "^3.4.13",
+    "dompurify": "3.4.14",
     "electron": "^43.4.1",
     "electron-builder": "^26.15.3",
     "electron-builder-squirrel-windows": "^26.15.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,7 +106,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  monaco-editor>dompurify: 3.4.13
+  monaco-editor>dompurify: 3.4.14
 
 patchedDependencies:
   '@vscode/windows-process-tree@0.8.0': e66202cc623996d02040c93449eb9ae353fddadf426cb53202a59ee710ee6fe7
@@ -346,8 +346,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       dompurify:
-        specifier: ^3.4.13
-        version: 3.4.13
+        specifier: 3.4.14
+        version: 3.4.14
       electron:
         specifier: ^43.4.1
         version: 43.4.1(supports-color@7.2.0)
@@ -4261,8 +4261,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dompurify@3.4.13:
-    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -10573,7 +10573,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dompurify@3.4.13:
+  dompurify@3.4.14:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -11929,7 +11929,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.23
-      dompurify: 3.4.13
+      dompurify: 3.4.14
       es-toolkit: 1.46.1
       fastdom: 1.0.12
       katex: 0.16.47
@@ -12214,7 +12214,7 @@ snapshots:
 
   monaco-editor@0.55.1:
     dependencies:
-      dompurify: 3.4.13
+      dompurify: 3.4.14
       marked: 14.0.0
 
   ms@2.1.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,7 +52,7 @@ allowBuilds:
   windows-native-registry: false
 
 overrides:
-  monaco-editor>dompurify: 3.4.13
+  monaco-editor>dompurify: 3.4.14
 
 patchedDependencies:
   node-pty@1.1.0: config/patches/node-pty@1.1.0.patch


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | 0 |

<!-- /orca-pr-loc -->

**Ready for review.** [Final validation evidence](https://github.com/stablyai/orca/pull/19377#issuecomment-5576483785): 75,654 tests and Linux/Windows packaging pass; 17 rendered editor E2E tests pass; six real-browser sanitizer checks pass.

## ELI5

Update DOMPurify 3.4.13 → 3.4.14 for sanitizer bypass and mixed-document-context fixes used by notebook HTML, Mermaid SVG and Monaco. Keep the direct dependency and Monaco override aligned; exactly one resolved package changes.

## What Changed / Why

[3.4.14 release](https://github.com/cure53/DOMPurify/releases/tag/3.4.14) and [source comparison](https://github.com/cure53/DOMPurify/compare/3.4.13...3.4.14): repairs risky allow-listed tag bypasses and case-preserved attributes in mixed HTML/XML DOM contexts; adds SVG pointer-events/vector-effect attributes. Orca sanitizes notebook output using HTML/SVG/SVG-filter profiles and Mermaid with the SVG profile. The same maintained patch is consumed by Mermaid and the pinned Monaco dependency.

Keep exact 3.4.14 for this review. 3.4.15 was published September 6 and remains inside the workspace's three-day release-age gate; the gate is not bypassed. The update has source refactoring as well as fixes, so integration tests matter; no zero-regression guarantee is implied by the patch version.

## Testing

On macOS arm64 with ORCA_BACKGROUND_LAUNCH=1:

- Frozen install: passed. One resolved package version changed; no Tiptap, Electron or native module changes.
- Entire editor Vitest directory: **208 files passed / 1 skipped; 1,410 tests passed / 2 skipped**. Includes Markdown round trips, HTML/source handling, tables, links and editor consumers.
- `pnpm tc`: passed.
- `pnpm run build:electron-vite`: passed, including renderer boot-graph gate. Existing large-chunk warnings remain.
- The separately tested Tiptap upgrade introduced Markdown regressions; it is isolated in #19376 and is not included here.
- CI/rendered evidence will be posted against this PR's exact commit before marking ready.

No changes to sanitizer configuration, visual layout, remote wire frames, saved-file protocols, Git behavior or workspace assumptions. Sanitizer output tightening is intentional for hostile input; legitimate SVG behavior needs rendered coverage. Shared dependencies may reach remote-served content, so source filtering cannot be considered local-only.

## Linked Issue

User-requested dependency review and full validation.

## Visual Proof

N/A — dependency maintenance with no UI implementation change. Rendered checks are pending; no screenshot is claimed.

## Review

- [x] Upstream fixes and exact package delta reviewed.
- [x] Local type/build/editor checks passed.
- [ ] CI and rendered checks complete.
- [x] Agent skill upstream boundary not applicable.
