### PR TITLE
fix(deps): update react-i18next for TypeScript 7 and translation parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "proper-lockfile": "4.1.2",
     "psl": "1.15.0",
     "qrcode": "^1.5.4",
-    "react-i18next": "^17.0.8",
+    "react-i18next": "17.0.13",
     "serve-sim": "^0.1.40",
     "sherpa-onnx": "1.12.37",
     "ssh2": "^1.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,8 +174,8 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4
       react-i18next:
-        specifier: ^17.0.8
-        version: 17.0.8(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        specifier: 17.0.13
+        version: 17.0.13(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       serve-sim:
         specifier: ^0.1.40
         version: 0.1.40(typescript@7.0.2)
@@ -4794,8 +4794,8 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
-  html-parse-stringify@3.0.1:
-    resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+  html-parse-stringify@4.0.1:
+    resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
 
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
@@ -6029,14 +6029,14 @@ packages:
       react:
         optional: true
 
-  react-i18next@17.0.8:
-    resolution: {integrity: sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==}
+  react-i18next@17.0.13:
+    resolution: {integrity: sha512-Cc1PscmblIHA1kljTqDwrcVMI21ydgmUzw0UAeQBe7pAOgfuRLfzXze4EUBQoeDiICzFIXXhHFoZxuetNg5D0Q==}
     peerDependencies:
       i18next: '>= 26.2.0'
       react: '>= 16.8.0'
       react-dom: '*'
       react-native: '*'
-      typescript: ^5 || ^6
+      typescript: ^5 || ^6 || ^7
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -6853,10 +6853,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  void-elements@3.1.0:
-    resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
-    engines: {node: '>=0.10.0'}
 
   vscode-oniguruma@2.0.1:
     resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
@@ -11299,9 +11295,7 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  html-parse-stringify@3.0.1:
-    dependencies:
-      void-elements: 3.1.0
+  html-parse-stringify@4.0.1: {}
 
   html-to-image@1.11.13: {}
 
@@ -11361,7 +11355,7 @@ snapshots:
       minimatch: 10.2.5
       ora: 9.4.0
       react: 19.2.8
-      react-i18next: 17.0.8(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+      react-i18next: 17.0.13(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       yaml: 2.9.0
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -12840,10 +12834,10 @@ snapshots:
     optionalDependencies:
       react: 19.2.8
 
-  react-i18next@17.0.8(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
+  react-i18next@17.0.13(i18next@26.3.1(typescript@7.0.2))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@babel/runtime': 7.29.7
-      html-parse-stringify: 3.0.1
+      html-parse-stringify: 4.0.1
       i18next: 26.3.1(typescript@7.0.2)
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)
@@ -13746,8 +13740,6 @@ snapshots:
       happy-dom: 20.11.8
     transitivePeerDependencies:
       - msw
-
-  void-elements@3.1.0: {}
 
   vscode-oniguruma@2.0.1: {}
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 |

<!-- /orca-pr-loc -->

**Ready for review.** [Final validation evidence](https://github.com/stablyai/orca/pull/19378#issuecomment-5576470939): 75,654 tests and Linux/Windows packaging pass; five rendered app E2E tests and five real React translation checks pass.

## ELI5

Update react-i18next 17.0.8 → 17.0.13 so Orca's TypeScript 7 toolchain is supported and translation markup gets parser/typing fixes. Pin the reviewed version; keep i18next and React unchanged.

## What Changed / Why

[Upstream changelog](https://github.com/i18next/react-i18next/blob/master/CHANGELOG.md): 17.0.9 adds TypeScript 7 to the peer range and fixes Trans inference; 17.0.11 adopts the maintained HTML parser and repairs literal less-than, quoted attributes and comment handling; 17.0.12 repairs keyless ICU translations; 17.0.13 fixes strict selector key-prefix typing.

The required companion `html-parse-stringify` moves 3.0.1 → 4.0.1 and removes its obsolete `void-elements` dependency. This is an upstream-integrated parser major, not a forced override. Because Trans parsing changed, validation includes rendered translation text and markup. No claim is made that Orca uses the ICU/strict-selector paths; TypeScript 7 compatibility and translation parsing are the relevant benefits.

## Testing

- Frozen-lockfile install: passed; resolved changes limited to react-i18next, html-parse-stringify and removal of void-elements.
- All 20 existing localization/i18n test files: **189 passed**. Covers provider startup/settings races, lazy language catalogs, locale formatting and translated UI text contracts.
- Five additional real React server-rendering assertions passed: strong-tag component mapping, literal less-than preservation, escaping hostile interpolated markup, treating unknown script markup as literal text, and switching English → Spanish. No browser globals/mocks are needed for these React render checks.
- `pnpm tc`: passed with the actual TypeScript 7 toolchain.
- `pnpm run build:electron-vite`: passed including renderer boot graph; existing chunk warnings remain.
- CI and rendered application checks passed at the exact commit; see final evidence above.

All automated commands use `ORCA_BACKGROUND_LAUNCH=1`. No layout, locale catalogs, schemas, wire frames, execution ownership or native dependency changes. Translation rendering reaches both local and remotely connected UIs; no local-worktree assumptions added.

## Linked Issue

User-requested dependency review and validation.

## Visual Proof

N/A — dependency-only change. Rendered application and React text/markup checks passed; see evidence above.

## Review

- [x] Upstream and resolved dependency delta reviewed.
- [x] Local type/build/localization checks passed.
- [x] CI and application E2E complete; see final evidence above.
- [x] Agent skill upstream boundary not applicable.
