### PR TITLE
chore(mobile): patch XML parser security in plist tooling

### DIFF
--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -3075,12 +3075,12 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
-  '@xmldom/xmldom@0.8.13':
-    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
     engines: {node: '>=10.0.0'}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
 
   '@xterm/addon-unicode11@0.10.0-beta.300':
@@ -9072,13 +9072,13 @@ snapshots:
 
   '@expo/plist@0.5.3':
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
   '@expo/plist@0.5.4':
     dependencies:
-      '@xmldom/xmldom': 0.8.13
+      '@xmldom/xmldom': 0.8.15
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -10574,9 +10574,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@xmldom/xmldom@0.8.13': {}
+  '@xmldom/xmldom@0.8.15': {}
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   '@xterm/addon-unicode11@0.10.0-beta.300(@xterm/xterm@6.1.0-beta.303)':
     dependencies:
@@ -14451,7 +14451,7 @@ snapshots:
 
   plist@3.1.1:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | 0 |

<!-- /orca-pr-loc -->

**Ready for review.** [Final validation evidence](https://github.com/stablyai/orca/pull/19380#issuecomment-5576409853): 4,204 mobile tests and 15 Ruby release-tooling tests pass in CI; all three local production exports and actual plist/security checks pass.

## ELI5

Update only the two transitive XML parsers used by mobile plist tooling: `@xmldom/xmldom` 0.8.13 → 0.8.15 and 0.9.10 → 0.9.12. This closes the creation-time EntityReference injection vector in [GHSA-6gmq-8vp8-gcm6](https://github.com/advisories/GHSA-6gmq-8vp8-gcm6). Mobile audit findings decrease from 5 to 3.

## What Changed

Only `mobile/pnpm-lock.yaml`: both maintained xmldom patch lines, with registry integrity hashes. Expo plist 0.5.3/0.5.4 and plist 3.1.1 retain their existing compatible dependency ranges. No Expo, React Native, native module, protocol or application code changes.

## Why / safety assessment

Upstream [0.8.15](https://github.com/xmldom/xmldom/releases/tag/0.8.15) and [0.9.12](https://github.com/xmldom/xmldom/releases/tag/0.9.12) reject invalid names at `createEntityReference()` and validate mutated names when well-formed serialization is requested. Ordinary plist values, nested dictionaries, arrays, booleans, numbers, Unicode and escaped XML text are covered by actual consumer roundtrips.

This is defense in depth for tooling, not a claim of an exposed Orca exploit. Serializer protection for a subsequently mutated `nodeName` remains opt-in: 0.8 uses `serializeToString(node, false, undefined, {requireWellFormed:true})`; 0.9 uses `serializeToString(node, {requireWellFormed:true})`. The creation-time check is automatic. Both forms were exercised against installed packages.

Remaining audit findings are two image-size advisories with no published patched version and decode-uri-component requiring a separate 0.5 migration. They are not hidden with incompatible overrides.

## Testing

Local macOS arm64, `ORCA_BACKGROUND_LAUNCH=1`:

- Frozen install including terminal and Mermaid webview generation: passed.
- `pnpm --dir mobile typecheck`: passed.
- Complete mobile suite: **516 files, 4,204 passed, 3 skipped**.
- `pnpm --dir mobile lint`: passed.
- `expo config --type prebuild --json`: passed, without writing native projects.
- Plist roundtrip through **all three actual consumers** (@expo/plist 0.5.3, 0.5.4; plist 3.1.1): passed.
- Each xmldom line rejects invalid EntityReference creation, serializes valid references, and rejects post-creation injection under its supported well-formed API: **6 assertions passed**.
- `git diff --check`: passed; exactly two resolved packages changed.
- Audit: **5 → 3** findings, both xmldom findings removed.

CI and all-platform JS export evidence is linked above. No native device/emulator run is claimed; no native dependency changes.

## Linked Issue

User-requested dependency security review.

## Visual Proof

N/A — lockfile-only tooling update.

## Review

Independent of the desktop, cloud, Electron and editor dependency PRs. No SSH, folder workspace, remote-wire or provider behavior changes.
