### PR TITLE
chore(docs): patch brace expansion resource exhaustion fixes

### DIFF
--- a/docs/site/pnpm-lock.yaml
+++ b/docs/site/pnpm-lock.yaml
@@ -2321,11 +2321,11 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -6854,12 +6854,12 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -8764,11 +8764,11 @@ snapshots:
 
   minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | 0 |

<!-- /orca-pr-loc -->

**Ready for review.** [Final validation evidence](https://github.com/stablyai/orca/pull/19382#issuecomment-5576448372): Node 22 CI passes all 13 tests, types/lint and production generation of 119 pages. Audit 21 → 18; remaining pinned tooling advisories disclosed.

## ELI5

Patch the documentation site's two brace-expansion dependency lines: **1.1.16 → 1.1.18** and **5.0.8 → 5.0.9**. This prevents oversized brace patterns from exhausting memory or blocking the event loop in build/deployment glob tooling.

## Why each bump is worthwhile and compatible

| Change | Reason / safety |
| --- | --- |
| 1.1.16 → 1.1.18 | Includes total-length limits and the subsequent intermediate-array bypass repair, [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895). Remains in minimatch 3.1.5's existing `^1.1.7` range. |
| 5.0.8 → 5.0.9 | Repairs the first mitigation's unbounded comma-alternative arrays and wasted padded-sequence work. Includes empty-alternative compatibility repairs; see [upstream comparison](https://github.com/juliangruber/brace-expansion/compare/v5.0.8...v5.0.9). Remains in minimatch 10.2.6's `^5.0.8` range and supports the site's Node 22 runtime. |

Only two lockfile resolutions and their consumer references change. No forced overrides, parent updates or deployment configuration changes. Ordinary patterns preserve their output; enormous patterns intentionally truncate at the library's documented resource limits. This protects tooling, not a claimed production HTTP exploit.

## Testing

Local macOS arm64, Node 26.6, pnpm 10.24, `ORCA_BACKGROUND_LAUNCH=1`:

- Frozen install, **13 package tests**, lint (zero errors, four existing image warnings), typecheck and complete Next.js production build: passed.
- Both installed parser lines: exact ordinary glob output, empty-alternative regression cases and bounded adversarial expansion passed. The reported 400-alternative/padded-sequence input completed in **93 ms / 60 ms**, respectively, under a 128 MB heap and produced at most 4 million characters. These are smoke timings, not a cross-platform benchmark.
- Actual minimatch 3.1.5 and 10.2.6 consumers both match expected docs paths and reject unrelated paths.
- `git diff --check`: passed.
- Node 22 Linux site CI passed; linked above. No production deployment performed.

## Deferred dependencies

Ajv 8.6.3, smol-toml and path-to-regexp are pinned by Vercel consumers; the attempted compatible update correctly retained those versions. smol-toml also has a newer EOF-comment infinite-loop advisory fixed in 1.7.1, so 1.6.1 alone is not an adequate target. These require a coordinated Vercel parent update and deployment-tool validation. The explicit Undici 5 override likewise remains an unresolved parent-migration issue. This PR does not claim a clean docs audit or suppress those advisories.

## Linked Issue

User-requested careful dependency review.

## Visual Proof

N/A — build-tool lockfile patch only.

## Review

Independent of all desktop, Electron, cloud, editor and mobile dependency PRs. No runtime source, remote-wire, SSH or folder-workspace change.
