### PR TITLE
fix(orchestration): avoid full message scans on working terminal titles

### DIFF
--- a/src/main/runtime/orchestration/db/schema/migrate.ts
+++ b/src/main/runtime/orchestration/db/schema/migrate.ts
@@ -30,6 +30,7 @@ export function migrate(this: OrchestrationDb): void {
     migrateV37.call(this, current)
     migrateV38.call(this, current)
     migrateV39.call(this, current)
+    this.createMailboxDeliveryIndexesIfPossible()
     this.db.pragma(`user_version = ${SCHEMA_VERSION}`)
     this.db.exec('COMMIT')
   } catch (err) {

--- a/src/main/runtime/orchestration/db/schema/schema-column-probes.ts
+++ b/src/main/runtime/orchestration/db/schema/schema-column-probes.ts
@@ -27,6 +27,13 @@ export function createMailboxDeliveryIndexesIfPossible(this: OrchestrationDb): v
         ON messages(to_handle, sequence)
         WHERE read = 0 AND pointer_enter_pending > 0;
     `)
+    if (this.hasColumn('messages', 'pointer_pty_id')) {
+      // Working-title frames release one PTY's reservations, including already-read rows.
+      this.db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_messages_pending_pointer_pty
+          ON messages(pointer_pty_id) WHERE pointer_enter_pending > 0;
+      `)
+    }
   }
 
   if (

--- a/src/main/runtime/orchestration/mailbox-pointer-release-query.test.ts
+++ b/src/main/runtime/orchestration/mailbox-pointer-release-query.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+
+function assertTargetedRelease(db: OrchestrationDb): void {
+  const prepare = vi.spyOn(db.db, 'prepare')
+  db.releasePendingMailboxPointerForPty('absent-pty')
+  const sql = prepare.mock.calls.find(([query]) => query.startsWith('UPDATE messages'))?.[0]
+  prepare.mockRestore()
+  expect(sql).toBeDefined()
+  const plan = db.db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(1, 'absent-pty') as {
+    detail: string
+  }[]
+  expect(plan.some(({ detail }) => detail.includes('SCAN messages'))).toBe(false)
+  expect(plan.some(({ detail }) => detail.includes('idx_messages_pending_pointer_pty'))).toBe(true)
+}
+
+describe('PTY mailbox reservation cleanup', () => {
+  it('uses a PTY lookup and preserves reservation settlement semantics', () => {
+    const db = new OrchestrationDb(':memory:')
+    try {
+      const seed = db.db.prepare(`INSERT INTO messages
+        (id, from_handle, to_handle, subject, read, pointer_enter_pending,
+         pointer_pty_id, pointer_process_incarnation, delivered_at)
+        VALUES (?, 'sender', 'recipient', 'test', ?, ?, ?, 'incarnation', ?)`)
+      db.db.exec('BEGIN')
+      for (let i = 0; i < 1000; i++) {
+        seed.run(`history-${i}`, 1, 0, null, null)
+      }
+      seed.run('reserved', 0, 1, 'target', '2026-01-01 00:00:00')
+      seed.run('written', 0, 2, 'target', null)
+      seed.run('entered', 0, 3, 'target', null)
+      seed.run('read', 1, 2, 'target', '2026-01-01 00:00:00')
+      seed.run('other', 0, 1, 'other-pty', null)
+      db.db.exec('COMMIT')
+      assertTargetedRelease(db)
+      db.releasePendingMailboxPointerForPty('target')
+      const read = (id: string) => db.db.prepare('SELECT * FROM messages WHERE id = ?').get(id)
+      for (const id of ['reserved', 'written', 'entered', 'read']) {
+        expect(read(id)).toMatchObject({
+          pointer_enter_pending: 0,
+          pointer_pty_id: null,
+          pointer_process_incarnation: null
+        })
+      }
+      expect(read('reserved')).toMatchObject({ delivered_at: null, read: 0 })
+      expect(read('written')).toMatchObject({ delivered_at: expect.any(String), read: 0 })
+      expect(read('entered')).toMatchObject({ delivered_at: expect.any(String), read: 0 })
+      expect(read('read')).toMatchObject({ delivered_at: '2026-01-01 00:00:00', read: 1 })
+      expect(read('other')).toMatchObject({ pointer_enter_pending: 1, pointer_pty_id: 'other-pty' })
+      expect(read('history-0')).toMatchObject({ read: 1, delivered_at: null })
+    } finally {
+      db.close()
+    }
+  })
+
+  it.each(['current', 'before-pointer-columns'])(
+    'installs the lookup on first open of an existing %s database',
+    (version) => {
+      const dir = mkdtempSync(join(tmpdir(), 'orca-pointer-release-'))
+      const path = join(dir, 'orchestration.db')
+      try {
+        new OrchestrationDb(path).close()
+        const raw = new Database(path)
+        try {
+          raw.exec('DROP INDEX idx_messages_pending_pointer_pty')
+          if (version === 'before-pointer-columns') {
+            raw.exec(`DROP INDEX idx_messages_pending_pointer_enter;
+              ALTER TABLE messages DROP COLUMN pointer_enter_pending;
+              ALTER TABLE messages DROP COLUMN pointer_pty_id;
+              ALTER TABLE messages DROP COLUMN pointer_process_incarnation;`)
+            raw.pragma('user_version = 32')
+          }
+        } finally {
+          raw.close()
+        }
+        const reopened = new OrchestrationDb(path)
+        try {
+          assertTargetedRelease(reopened)
+        } finally {
+          reopened.close()
+        }
+      } finally {
+        rmSync(dir, { recursive: true, force: true })
+      }
+    }
+  )
+})

--- a/src/main/runtime/orchestration/orchestration-version-skew-migration.test.ts
+++ b/src/main/runtime/orchestration/orchestration-version-skew-migration.test.ts
@@ -431,7 +431,9 @@ describe('OrchestrationDb version-skew migration', () => {
 
     const raw = new Database(dbPath)
     raw.exec(
-      'DROP INDEX IF EXISTS idx_messages_pending_pointer_enter; ALTER TABLE messages DROP COLUMN pointer_enter_pending;'
+      `DROP INDEX IF EXISTS idx_messages_pending_pointer_enter;
+       DROP INDEX IF EXISTS idx_messages_pending_pointer_pty;
+       ALTER TABLE messages DROP COLUMN pointer_enter_pending;`
     )
     raw.pragma('user_version = 33')
     expect(resolveOrchestrationMigrationStartVersion(raw, 33, SCHEMA_VERSION)).toBe(6)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​94 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5

An agent's working-title updates repeatedly scanned the entire message history, blocking Orca's main thread. Give the cleanup query a direct lookup for the terminal it is cleaning.

## What Changed

- Add a partial index on `messages(pointer_pty_id) WHERE pointer_enter_pending > 0` through existing index initialization.
- Initialize indexes after migration so databases predating pointer columns receive the index on their first open.
- Add query-plan, settlement-semantics, and existing-database regression coverage; update the old-schema fixture for the new dependent index.

## Why

`applyTrackedPtyTitle` → `observeAgentWorking` → `releasePendingMailboxPointerForPty` runs even for repeated working titles with no reservations. On a database with approximately 45,400 messages, SQLite chose `SCAN messages`; the no-op UPDATE took 13–17 ms. The existing mailbox index excludes read rows and cannot serve this cleanup, which intentionally includes them.

The partial PTY index removes history-sized work without changing delivery behavior, status-transition handling, retention, or the schema version. Both the caller and query originated in #16904 (`06a607a1d71`).

## Linked Issue

Fixes #19389

## Visual Proof

N/A — database access-path change; no UI layout or interaction semantics change. Live macOS profiling provides the performance evidence:

| Measurement | Before | After index |
| --- | --- | --- |
| Copied-database no-op UPDATE, three runs | 12.675 / 16.951 / 12.687 ms | 0.027 / 0.006 / 0.003 ms |
| Main-thread samples in SQLite StatementSync::Run | 390/452 and 408/457 | 2/452 |
| Live main-process interval CPU | 65.7 / 106.2 / 99.6% | 14.3 / 11.9 / 15.1% in later samples |

Applied the same additive index to the running installed profile without restarting processes or deleting data. CPU figures are supporting observations under a changing workload, not a controlled throughput benchmark. Raw samples and the private database copy remain local.

## Testing

- [x] I manually tested these changes locally: query plan/timing on a consistent database copy, then live index application and pre/post stack/CPU sampling on macOS.
- [x] Automated tests added/updated: 34 tests pass across cleanup query, pointer stage/submit, version-skew, and all-start-version migration suites.
- `pnpm tc:node`, changed-file oxlint, formatting, and `git diff --check` pass. Commit hooks also pass.
- Linux/Windows/SSH and full build are left to CI. The SQL is platform-independent and runs in the database-owning runtime; no wire fields or remote execution behavior change. Rendered UI latency was not measured.

## Review

The index covers already-read reservations as required. Tests retain reserved/write-attempted/enter-attempted settlement behavior and leave other PTYs/history unchanged. No TTL, status-only gate, process cleanup, or new cache is introduced.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill content copied.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after evidence provided, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH/remote impact considered
- [ ] Full lint/typecheck/test/build matrix: CI to cover; targeted local checks above pass
