### PR TITLE
perf(workspaces): skip unchanged heartbeat subscriber work

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -166,6 +166,82 @@
       "demotionRule": "Keep experimental until CI soak; investigate output, offset, carry or search-budget failures without relaxing the oracle."
     },
     {
+      "id": "workspace-performance.ai-vault-title-input-guard",
+      "title": "Title synchronization skips unchanged session collections on live heartbeats",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "renderer-unit",
+      "surfaces": ["workspace title synchronization", "terminal heartbeat store subscribers"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local"],
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/blob/main/.agents/skills/perf/SKILL.md"
+      ],
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Initial local validation; no CI soak history."
+      },
+      "promotionCriteria": [
+        "Complete CI soak with zero unexplained flakes and preserve the observable oracle."
+      ],
+      "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing fidelity or resource-count assertions.",
+      "coverageNotes": "Actual title-sync subscriber and Zustand publications are covered on macOS. Existing fixtures include SSH/runtime owner invalidation and folder workspaces; no live remote transport was launched. The guard has no platform branches, remote execution, liveness verdict or wire change.",
+      "invariant": "Title-sync publications must not enumerate unchanged session collections, while title identity, provider availability, active pane, stored title and effective execution-host changes retain their previous invalidation decisions.",
+      "oracle": "Fifty live heartbeat publications with 500 retained and 500 sleeping records cause zero unchanged-map enumerations and no extra scheduled reconciliations. Provider identity, additions/removals, agent/pane ownership, effective host, active pane and stored title changes still invalidate.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts src/renderer/src/lib/ai-vault-tab-title-sync.test.ts src/renderer/src/store/slices/agent-status-batch.test.ts src/renderer/src/store/slices/agent-status-provider-session.test.ts src/renderer/src/store/slices/agent-status-retained-leak.test.ts src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts",
+        "src/renderer/src/lib/ai-vault-tab-title-sync.test.ts",
+        "src/renderer/src/store/slices/agent-status-batch.test.ts",
+        "src/renderer/src/store/slices/agent-status-provider-session.test.ts",
+        "src/renderer/src/store/slices/agent-status-retained-leak.test.ts",
+        "src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts",
+          "assertions": [
+            "does not enumerate unchanged retained and sleeping maps during live status writes",
+            "still detects provider changes in %s with other maps reused",
+            "still checks workspace ownership after unchanged record collections",
+            "still checks active panes and stored titles after unchanged record collections"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts src/renderer/src/lib/ai-vault-tab-title-sync.test.ts src/renderer/src/store/slices/agent-status-batch.test.ts src/renderer/src/store/slices/agent-status-provider-session.test.ts src/renderer/src/store/slices/agent-status-retained-leak.test.ts src/renderer/src/store/slices/agent-status-manual-sleep-capture.test.ts",
+          "result": "passed",
+          "durationSeconds": 5.35,
+          "summary": "69 tests passed across six files, including actual subscriber scheduling and producer identity contracts."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 30,
+        "scope": "Focused unit/subscriber suite; local runtime budget, not an established p95."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The actual subscriber regression fails baseline with 200 unchanged-map enumerations and passes with zero. Frozen source differential matched 13,002 decisions over 6,501 transitions. Four actual producer checks passed against deeply frozen inputs."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Actual bundled production title subscriber plus Zustand, CPU per 1,000 writes, baseline to candidate: 25 live/100 retained/100 sleeping 41.642 to 0.699 ms; 100/500/500 251.076 to 5.350 ms; 500/500/500 343.025 to 59.897 ms. Zero extra title reads or schedules. Only same-reference collections skip comparisons; no new allocation, cache, timer, IO or scheduling."
+      },
+      "knownGaps": [
+        "No launched Electron/native-focus latency test or live external title lookup.",
+        "No live SSH/WSL/Linux/Windows session; production heartbeat incidence and whole-renderer latency are not established by the fixture."
+      ]
+    },
+    {
       "id": "terminal-performance.status-heartbeat-projection-budget",
       "title": "Unchanged status heartbeats reuse the aggregate workspace projection",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -166,6 +166,80 @@
       "demotionRule": "Keep experimental until CI soak; investigate output, offset, carry or search-budget failures without relaxing the oracle."
     },
     {
+      "id": "terminal-performance.status-heartbeat-projection-budget",
+      "title": "Unchanged status heartbeats reuse the aggregate workspace projection",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "workspace-runtime",
+      "layer": "shared-and-renderer-unit",
+      "surfaces": ["desktop runtime graph subscriber", "terminal status heartbeat projection"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon", "ssh", "remote-runtime"],
+      "coverageNotes": "The always-mounted desktop subscriber is covered through pure projection/reference and graph-sync contracts. All providers use the same serialized fields. WSL, platform launch, liveness, transport and mobile rendering are unaffected.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/blob/main/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts"
+      ],
+      "invariant": "The desktop agent-status comparison projection remains identical for every serialized field, key membership and freshness bucket while avoiding a full aggregate join when per-entry serialized content is unchanged.",
+      "oracle": "500 statuses with accumulated assistant previews receive 50 same-bucket heartbeat replacements with zero aggregate joins. A bucket boundary and assistant-detail change invalidate the projection. Existing reference comparisons cover field content, ordering, insertion/removal and subscriber decisions.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts src/renderer/src/runtime/sync-runtime-graph-projection-hot-path.test.ts src/renderer/src/runtime/sync-runtime-graph.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts",
+        "src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts",
+        "src/renderer/src/runtime/sync-runtime-graph-projection-hot-path.test.ts",
+        "src/renderer/src/runtime/sync-runtime-graph.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts",
+          "assertions": [
+            "does not rejoin accumulated previews for timestamp-only heartbeats",
+            "still rebuilds when an entry changes",
+            "still rebuilds when a pane is removed, even though every survivor is reused",
+            "still rebuilds when a pane is added"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts src/renderer/src/runtime/sync-runtime-graph-agent-status-projection.test.ts src/renderer/src/runtime/sync-runtime-graph-projection-hot-path.test.ts src/renderer/src/runtime/sync-runtime-graph.test.ts",
+          "result": "passed",
+          "summary": "38 tests passed across four projection and graph-sync files; renderer typecheck passed.",
+          "durationSeconds": 2.7
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 60,
+        "scope": "Focused unit/provider-contract suite; local runtime budget, not an established p95."
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Initial local validation; no CI soak history."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The new heartbeat fixture failed on baseline with 50 aggregate joins; candidate performs zero and still invalidates on the next freshness bucket and new assistant detail."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "50 redundant aggregate joins fall to zero. Paired production projection/equality benchmark: 500 agents with 8 KB previews improves 1.716 to 0.089 ms/update; 1000 improves 3.601 to 0.123 ms/update. Avoids rebuilding 5.06/10.11 million-character aggregate strings. Entry serialization and sorting remain bounded by the current status map; no new cache, polling or asynchronous work."
+      },
+      "knownGaps": [
+        "Measured production projection self-time excludes store updates and rendering; no whole-app input-latency claim.",
+        "Native platforms, live SSH/relay and older clients were not launched. This changes only equality-preserving cache reuse, with no wire or persisted schema change."
+      ],
+      "promotionCriteria": [
+        "Complete CI soak with zero unexplained flakes and preserve the observable oracle."
+      ],
+      "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing fidelity, liveness or resource-count assertions."
+    },
+    {
       "id": "terminal-performance.padded-fullscreen-redraw",
       "title": "Fullscreen redraw padding does not stall terminal delivery",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -178,7 +178,7 @@
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local"],
       "motivatingLinks": [
-        "https://github.com/stablyai/orca/blob/main/.agents/skills/perf/SKILL.md"
+        "https://github.com/stablyai/orca/blob/main/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.ts"
       ],
       "flakeHistory": {
         "status": "not-started",
@@ -275,6 +275,7 @@
             "does not rejoin accumulated previews for timestamp-only heartbeats",
             "still rebuilds when an entry changes",
             "still rebuilds when a pane is removed, even though every survivor is reused",
+            "still rebuilds when key membership swaps at a constant entry count",
             "still rebuilds when a pane is added"
           ]
         }

--- a/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts
+++ b/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.test.ts
@@ -1,0 +1,252 @@
+import { createStore } from 'zustand/vanilla'
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import type { AgentProviderSessionMetadata } from '../../../shared/agent-session-resume'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import { aiVaultTitleSyncInputsChanged } from './ai-vault-tab-title-sync-inputs'
+import { startAiVaultTabTitleSync } from './ai-vault-tab-title-sync'
+
+const COLLECTIONS = [
+  'agentStatusByPaneKey',
+  'retainedAgentsByPaneKey',
+  'sleepingAgentSessionsByPaneKey'
+] as const
+type Collection = (typeof COLLECTIONS)[number]
+
+function makeState(count = 1): AppState {
+  const live: AppState['agentStatusByPaneKey'] = {}
+  const retained: AppState['retainedAgentsByPaneKey'] = {}
+  const sleeping: AppState['sleepingAgentSessionsByPaneKey'] = {}
+  const tabs: TerminalTab[] = []
+  for (let index = 0; index < count * 3; index++) {
+    const tab: TerminalTab = {
+      id: `tab-${index}`,
+      worktreeId: 'wt-title',
+      ptyId: null,
+      title: 'Agent',
+      customTitle: null,
+      color: null,
+      sortOrder: index,
+      createdAt: 1
+    }
+    const entry = {
+      paneKey: `${tab.id}:00000000-0000-4000-8000-000000000001`,
+      tabId: tab.id,
+      worktreeId: tab.worktreeId,
+      agentType: 'codex' as const,
+      providerSession: { key: 'session_id' as const, id: `session-${index}` },
+      state: 'done' as const,
+      prompt: '',
+      updatedAt: 1,
+      stateStartedAt: 1,
+      stateHistory: []
+    }
+    tabs.push(tab)
+    if (index < count) {
+      live[entry.paneKey] = entry
+    } else if (index < count * 2) {
+      retained[entry.paneKey] = {
+        entry,
+        tab,
+        worktreeId: tab.worktreeId,
+        agentType: 'codex',
+        startedAt: 1
+      }
+    } else {
+      sleeping[entry.paneKey] = {
+        ...entry,
+        agent: 'codex',
+        capturedAt: 1,
+        origin: 'worktree-sleep'
+      }
+    }
+  }
+  return {
+    agentStatusByPaneKey: live,
+    retainedAgentsByPaneKey: retained,
+    sleepingAgentSessionsByPaneKey: sleeping,
+    tabsByWorktree: { 'wt-title': tabs },
+    terminalLayoutsByTabId: {},
+    activeWorktreeId: 'wt-title',
+    activeWorkspaceExecutionHostId: 'local',
+    worktreesByRepo: { fixture: [{ id: 'wt-title', repoId: 'fixture', hostId: 'local' }] },
+    detectedWorktreesByRepo: {},
+    folderWorkspaces: [],
+    repos: [],
+    settings: {}
+  } as unknown as AppState
+}
+
+function replaceProvider(
+  state: AppState,
+  collection: Collection,
+  providerSession: AgentProviderSessionMetadata
+): AppState {
+  const paneKey = Object.keys(state[collection])[0]
+  const existing = state[collection][paneKey]
+  const next =
+    collection === 'retainedAgentsByPaneKey'
+      ? { ...existing, entry: { ...state.retainedAgentsByPaneKey[paneKey].entry, providerSession } }
+      : { ...existing, providerSession }
+  return { ...state, [collection]: { ...state[collection], [paneKey]: next } }
+}
+
+describe('AI Vault title subscription inputs', () => {
+  it('does not enumerate unchanged retained and sleeping maps during live status writes', () => {
+    const state = makeState(500)
+    let unchangedEnumerations = 0
+    const observeEnumerations = <T extends object>(records: T): T =>
+      new Proxy(records, {
+        ownKeys(target) {
+          unchangedEnumerations++
+          return Reflect.ownKeys(target)
+        }
+      })
+    state.retainedAgentsByPaneKey = observeEnumerations(state.retainedAgentsByPaneKey)
+    state.sleepingAgentSessionsByPaneKey = observeEnumerations(state.sleepingAgentSessionsByPaneKey)
+    const store = createStore<AppState>(() => state)
+    const scheduleReconcile = vi.fn(() => () => {})
+    const stop = startAiVaultTabTitleSync({
+      getState: store.getState,
+      subscribe: store.subscribe,
+      scheduleReconcile,
+      resolveSessionTitles: vi.fn()
+    })
+    try {
+      const paneKey = Object.keys(state.agentStatusByPaneKey)[0]
+      for (let index = 0; index < 50; index++) {
+        store.setState((current) => ({
+          agentStatusByPaneKey: {
+            ...current.agentStatusByPaneKey,
+            [paneKey]: { ...current.agentStatusByPaneKey[paneKey], updatedAt: index + 2 }
+          }
+        }))
+      }
+      expect(unchangedEnumerations).toBe(0)
+      expect(scheduleReconcile).toHaveBeenCalledTimes(1)
+    } finally {
+      stop()
+    }
+  })
+
+  it.each(COLLECTIONS)(
+    'still detects provider changes in %s with other maps reused',
+    (collection) => {
+      const state = makeState()
+      const paneKey = Object.keys(state[collection])[0]
+      const provider =
+        collection === 'retainedAgentsByPaneKey'
+          ? state.retainedAgentsByPaneKey[paneKey].entry.providerSession!
+          : (state[collection][paneKey] as { providerSession: AgentProviderSessionMetadata })
+              .providerSession
+      for (const patch of [
+        { id: 'changed' },
+        { key: 'conversation_id' as const },
+        { transcriptPath: '/changed/session' }
+      ]) {
+        expect(
+          aiVaultTitleSyncInputsChanged(
+            replaceProvider(state, collection, { ...provider, ...patch }),
+            state
+          )
+        ).toBe(true)
+      }
+      expect(
+        aiVaultTitleSyncInputsChanged(replaceProvider(state, collection, { ...provider }), state)
+      ).toBe(false)
+    }
+  )
+
+  it.each(COLLECTIONS)('detects additions and removals in %s', (collection) => {
+    const state = makeState()
+    const records = state[collection]
+    const empty = { ...state, [collection]: {} }
+    expect(aiVaultTitleSyncInputsChanged(empty, state)).toBe(true)
+    expect(aiVaultTitleSyncInputsChanged(state, empty)).toBe(true)
+    expect(aiVaultTitleSyncInputsChanged({ ...state, [collection]: { ...records } }, state)).toBe(
+      false
+    )
+  })
+
+  it.each(COLLECTIONS)('detects agent and pane ownership changes in %s', (collection) => {
+    const state = makeState()
+    const records = state[collection]
+    const paneKey = Object.keys(records)[0]
+    const record = records[paneKey]
+    const entry =
+      collection === 'retainedAgentsByPaneKey'
+        ? state.retainedAgentsByPaneKey[paneKey].entry
+        : record
+    const agentField = collection === 'sleepingAgentSessionsByPaneKey' ? 'agent' : 'agentType'
+    const changedRecords = [
+      { ...record, [agentField]: 'claude' },
+      { ...record, [agentField]: 'gemini' },
+      { ...record, worktreeId: 'other' },
+      ...['paneKey', 'tabId'].map((field) =>
+        collection === 'retainedAgentsByPaneKey'
+          ? { ...record, entry: { ...entry, [field]: 'other' } }
+          : { ...record, [field]: 'other' }
+      )
+    ]
+    for (const changed of changedRecords) {
+      expect(
+        aiVaultTitleSyncInputsChanged(
+          { ...state, [collection]: { ...records, [paneKey]: changed } },
+          state
+        )
+      ).toBe(true)
+    }
+  })
+
+  it('still checks workspace ownership after unchanged record collections', () => {
+    const state = makeState()
+    for (const host of ['ssh:host-1', 'runtime:server-1'] as const) {
+      expect(
+        aiVaultTitleSyncInputsChanged(
+          {
+            ...state,
+            agentStatusByPaneKey: { ...state.agentStatusByPaneKey },
+            activeWorkspaceExecutionHostId: host
+          },
+          state
+        )
+      ).toBe(true)
+    }
+  })
+
+  it('still checks active panes and stored titles after unchanged record collections', () => {
+    const state = makeState()
+    const agentStatusByPaneKey = { ...state.agentStatusByPaneKey }
+    expect(
+      aiVaultTitleSyncInputsChanged(
+        {
+          ...state,
+          agentStatusByPaneKey,
+          terminalLayoutsByTabId: {
+            'tab-0': { root: null, activeLeafId: 'other', expandedLeafId: null }
+          }
+        },
+        state
+      )
+    ).toBe(true)
+    const tabs = state.tabsByWorktree['wt-title']
+    expect(
+      aiVaultTitleSyncInputsChanged(
+        {
+          ...state,
+          agentStatusByPaneKey,
+          tabsByWorktree: {
+            'wt-title': [
+              {
+                ...tabs[0],
+                aiVaultTitle: { agent: 'codex', sessionId: 'session-0', title: 'New title' }
+              },
+              ...tabs.slice(1)
+            ]
+          }
+        },
+        state
+      )
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.ts
+++ b/src/renderer/src/lib/ai-vault-tab-title-sync-inputs.ts
@@ -22,6 +22,9 @@ function relevantRecordEqual<T>(
   relevant: (entry: T) => boolean,
   equal: (current: T, previous: T) => boolean
 ): boolean {
+  if (current === previous) {
+    return true
+  }
   let currentCount = 0
   let previousCount = 0
   for (const [key, entry] of Object.entries(current)) {

--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
@@ -167,6 +167,20 @@ describe('agent-status projection join short circuit', () => {
     )
   })
 
+  it('still rebuilds when key membership swaps at a constant entry count', () => {
+    // The entry-count check cannot see a same-size swap; only the per-key lookup does.
+    resetRuntimeMobileAgentStatusProjectionCacheForTests()
+    const map = mapOf([0, 1])
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+
+    const swapped = { 'tab-0:leaf-0': map['tab-0:leaf-0'], 'tab-9:leaf-0': makeEntry(9) }
+    const result = buildRuntimeMobileAgentStatusProjectionForTests(swapped)
+
+    expect(result).not.toBe(first)
+    expect(result).toContain('tab-9:leaf-0')
+    expect(result).not.toContain('tab-1:leaf-0')
+  })
+
   it('still rebuilds when a pane is added', () => {
     resetRuntimeMobileAgentStatusProjectionCacheForTests()
     const map = mapOf([0])

--- a/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph-agent-status-projection-join.test.ts
@@ -30,7 +30,7 @@ function mapOf(indices: readonly number[]): AppState['agentStatusByPaneKey'] {
   return map
 }
 
-/** Re-spread with the same entry objects, as a status ping does. */
+/** A collection refresh can replace its container while preserving the rows. */
 function respread(map: AppState['agentStatusByPaneKey']): AppState['agentStatusByPaneKey'] {
   return { ...map }
 }
@@ -76,7 +76,7 @@ describe('agent-status projection join short circuit', () => {
     const map = mapOf([0, 1, 2])
     const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
 
-    // A new map identity with identical entry references — the common ping shape.
+    // A new map identity with identical entry references.
     const { result, joins, sorts } = countJoins(() =>
       buildRuntimeMobileAgentStatusProjectionForTests(respread(map))
     )
@@ -99,6 +99,41 @@ describe('agent-status projection join short circuit', () => {
     )
     expect(joins).toBe(0)
     expect(sorts).toBe(0)
+  })
+
+  it('does not rejoin accumulated previews for timestamp-only heartbeats', () => {
+    let map = mapOf(Array.from({ length: 500 }, (_, index) => index))
+    for (const paneKey of Object.keys(map)) {
+      map[paneKey] = {
+        ...map[paneKey],
+        updatedAt: 30_000_000,
+        lastAssistantMessage: 'answer '.repeat(1_000)
+      }
+    }
+    const first = buildRuntimeMobileAgentStatusProjectionForTests(map)
+
+    const { result, joins } = countJoins(() => {
+      let projection = first
+      for (let index = 0; index < 50; index++) {
+        const paneKey = `tab-${index}:leaf-0`
+        map = { ...map, [paneKey]: { ...map[paneKey], updatedAt: 30_000_001 + index } }
+        projection = buildRuntimeMobileAgentStatusProjectionForTests(map)
+      }
+      return projection
+    })
+
+    expect(result).toBe(first)
+    expect(joins).toBe(0)
+
+    const paneKey = 'tab-0:leaf-0'
+    const nextBucket = { ...map, [paneKey]: { ...map[paneKey], updatedAt: 30_030_000 } }
+    expect(buildRuntimeMobileAgentStatusProjectionForTests(nextBucket)).not.toBe(first)
+    expect(
+      buildRuntimeMobileAgentStatusProjectionForTests({
+        ...map,
+        [paneKey]: { ...map[paneKey], lastAssistantMessage: 'A new answer' }
+      })
+    ).not.toBe(first)
   })
 
   it('still rebuilds when an entry changes', () => {

--- a/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph/agent-status-projection.ts
@@ -60,6 +60,7 @@ export function buildRuntimeMobileAgentStatusProjection(
   // A status ping replaces one entry and re-spreads the map; reuse every other entry.
   const entries = new Map<string, AgentStatusProjectionCacheEntry>()
   const parts: string[] = []
+  let projectionUnchanged = cached != null && nextEntries.length === cached.entries.size
   // Code-unit order, not `localeCompare`: this projection is only ever compared with `===`, so it
   // must be deterministic, not locale-correct — and an ICU collator per comparison is ~4.5k calls
   // per ping at the 500-entry cap.
@@ -71,8 +72,10 @@ export function buildRuntimeMobileAgentStatusProjection(
         : { entry, projection: serializeAgentStatusEntry(paneKey, entry) }
     entries.set(paneKey, entryCache)
     parts.push(entryCache.projection)
+    projectionUnchanged &&= previous?.projection === entryCache.projection
   }
-  const projection = `[${parts.join(',')}]`
+  // Same-bucket heartbeats must not rejoin every pane's accumulated preview text.
+  const projection = projectionUnchanged && cached ? cached.projection : `[${parts.join(',')}]`
   graphState.cachedAgentStatusProjection = {
     source: agentStatusByPaneKey,
     entries,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​301 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 |

<!-- /orca-pr-loc -->

## ELI5

Orca constantly gets tiny "still alive" pings from your terminals, and until now every ping made the app re-scan and re-assemble the full picture of every agent, tab and title — even when nothing had actually changed. This PR teaches those two checks to recognise "this is the same data I already looked at" and reuse the previous answer instead. Nothing you see changes; the app just stops repeating the same expensive busywork hundreds of times a minute, so it stays snappier when you have a lot of agents open.

Timestamp-only terminal heartbeats caused two always-mounted desktop subscribers to revisit accumulated workspace data: the runtime graph rebuilt an unchanged aggregate status string, and title synchronization enumerated retained/sleeping session maps whose references had not changed. Reuse equal per-entry projections and skip same-reference title collections. Changed fields, freshness buckets, key membership, title identity and execution-owner changes still invalidate normally.

Measured production paths:
- At 500 agents with 8 KB previews, projection/equality work falls from 1.716 to 0.089 ms per update; 50 unchanged heartbeats perform zero aggregate joins instead of 50.
- The actual title subscriber plus Zustand at 100 live / 500 retained / 500 sleeping records falls from 251.076 to 5.350 ms CPU per 1,000 writes. Fifty writes enumerate unchanged maps zero times instead of 200, with no extra title reads or scheduled reconciliations.

These measure the affected processing paths, not rendered frame time. Title changes and projection publications preserve their existing content.

Validation: 38 projection/graph tests and 69 title/subscriber/producer tests passed. Frozen differentials matched 10,910 projection strings and 13,002 title invalidation decisions. Independent Codex review checked real immutable producers, host ownership, provider identity, active panes and stored titles. Full `ORCA_BACKGROUND_LAUNCH=1 pnpm tc`, changed-code quality and the reliability manifest passed in the integration worktree.

Experimental gates: `terminal-performance.status-heartbeat-projection-budget` and `workspace-performance.ai-vault-title-input-guard`. They record count oracles, measurements, coverage and gaps. No schema, wire content, persisted data, execution authority or mobile UI changes. Folder workspaces and SSH/runtime invalidation are covered by unit contracts; no live SSH/WSL/Linux/Windows or rendered Electron latency test was run. This PR is independent of the other performance PRs.

