### PR TITLE
perf(terminal): skip plain text between partial escape sequences

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -471,11 +471,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "New ASCII/UTF-16 work budgets failed baseline at 262,160/196,624 inspected code units; candidate inspects 13 in each with exact tails and completion. External differential matched 2,710,126 cases; existing fold fuzz covers 593,468 cases."
+        "evidence": "New ASCII/UTF-16 work budgets failed baseline at 262,160/196,624 inspected code units; candidate inspects 16 code units and 2 native ESC searches in each with exact tails and completion. External differential matched 2,710,126 cases (plus 388,416 hybrid-vs-baseline cases over the full VT alphabet with lone/split surrogates, 0 mismatches); existing fold fuzz covers 593,468 cases."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Production HeadlessEmulator.writeSync CPU for 2 MiB colored logs improves 32.321 to 26.638 ms; sparse ANSI improves 26.757 to 21.982 ms. Agent-redraw CPU improves 402.308 to 394.633 ms. Rotated 100,000-write baseline/identical-control/candidate medians: plain echo 27.340/27.015/27.822 ms, colored echo 36.009/35.556/35.981 ms. Native ESC searches advance only in ground; existing plain-output fast path is unchanged. No new state, allocation, timer, provider call or transport behavior."
+        "evidence": "Production HeadlessEmulator.writeSync CPU for 2 MiB colored logs improves 32.321 to 26.638 ms; sparse ANSI improves 26.757 to 21.982 ms. Agent-redraw CPU improves 402.308 to 394.633 ms. Rotated 100,000-write baseline/identical-control/candidate medians: plain echo 27.340/27.015/27.822 ms, colored echo 36.009/35.556/35.981 ms. Native ESC searches advance only in ground, and only when the current code unit is not already ESC, so dense back-to-back CSI streams do not pay a search per sequence: 0.9 MiB dense SGR/CSI medians are 2.04 ms baseline, 2.56 ms search-always, 1.92 ms shipped. Existing plain-output fast path is unchanged. No new state, allocation, timer, provider call or transport behavior."
       },
       "knownGaps": [
         "No launched Electron or live SSH/WSL/Windows/Linux process, native input or end-to-end UI-latency measurement.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -402,6 +402,91 @@
       "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing fidelity, liveness or resource-count assertions."
     },
     {
+      "id": "terminal-performance.partial-escape-ground-scan",
+      "title": "Terminal snapshots preserve partial escapes with bounded ground-state scan work",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "shared-and-daemon-unit",
+      "surfaces": ["headless terminal output ingestion", "terminal snapshot continuity"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon", "ssh", "remote-runtime"],
+      "coverageNotes": "Shared parser, production emulator and Session contracts cover local/daemon paths; remote snapshot semantics use the existing corruption reproduction without live transport. The scanner has no workspace or host branching; folder/git workspaces, WSL, mobile/relay and platform execution/wire boundaries are unchanged.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/issues/7329"],
+      "invariant": "Partial escape tracking preserves exact pending UTF-16 and completion across chunk/snapshot boundaries while skipping ordinary ground-state text without a JavaScript per-code-unit walk.",
+      "oracle": "Colored ASCII and UTF-16 output retains the exact incomplete CSI tail using fewer than 32 code-unit inspections. Every split of CSI/OSC/DCS/ESC-intermediate controls and CAN/SUB/ESC aborts preserve completion; one-character echo performs zero inspections or native ESC searches. Seeded headless snapshot restore matches a renderer terminal twin.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-partial-escape-tail-ground-scan.test.ts src/shared/terminal-partial-escape-tail.test.ts src/shared/terminal-partial-escape-tail.fuzz.test.ts src/main/daemon/headless-emulator.test.ts",
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-7329-remote-snapshot-corruption.test.ts src/main/daemon/session-shell-recovery.test.ts src/main/daemon/headless-emulator-fidelity.fuzz.test.ts"
+      ],
+      "testFiles": [
+        "src/shared/terminal-partial-escape-tail-ground-scan.test.ts",
+        "src/shared/terminal-partial-escape-tail.test.ts",
+        "src/shared/terminal-partial-escape-tail.fuzz.test.ts",
+        "src/main/daemon/headless-emulator.test.ts",
+        "src/main/daemon/repro-7329-remote-snapshot-corruption.test.ts",
+        "src/main/daemon/session-shell-recovery.test.ts",
+        "src/main/daemon/headless-emulator-fidelity.fuzz.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/shared/terminal-partial-escape-tail-ground-scan.test.ts",
+          "assertions": [
+            "skips ordinary %s text between completed escapes",
+            "preserves %j through every split after ordinary text",
+            "handles aborts before returning to ordinary text",
+            "keeps one-character echo free of per-code-unit scans and escape searches"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-partial-escape-tail-ground-scan.test.ts src/shared/terminal-partial-escape-tail.test.ts src/shared/terminal-partial-escape-tail.fuzz.test.ts src/main/daemon/headless-emulator.test.ts",
+          "result": "passed",
+          "durationSeconds": 2.17,
+          "summary": "82 tests passed across four files including 593,468 fold-fuzz cases."
+        },
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/repro-7329-remote-snapshot-corruption.test.ts src/main/daemon/session-shell-recovery.test.ts src/main/daemon/headless-emulator-fidelity.fuzz.test.ts",
+          "result": "passed",
+          "durationSeconds": 36.24,
+          "summary": "15 tests passed across three files including 300 headless-to-renderer snapshot fidelity streams."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 60,
+        "scope": "Focused unit/provider-contract suite; local runtime budget, not an established p95."
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Initial local validation; no CI soak history."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "New ASCII/UTF-16 work budgets failed baseline at 262,160/196,624 inspected code units; candidate inspects 13 in each with exact tails and completion. External differential matched 2,710,126 cases; existing fold fuzz covers 593,468 cases."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Production HeadlessEmulator.writeSync CPU for 2 MiB colored logs improves 32.321 to 26.638 ms; sparse ANSI improves 26.757 to 21.982 ms. Agent-redraw CPU improves 402.308 to 394.633 ms. Rotated 100,000-write baseline/identical-control/candidate medians: plain echo 27.340/27.015/27.822 ms, colored echo 36.009/35.556/35.981 ms. Native ESC searches advance only in ground; existing plain-output fast path is unchanged. No new state, allocation, timer, provider call or transport behavior."
+      },
+      "knownGaps": [
+        "No launched Electron or live SSH/WSL/Windows/Linux process, native input or end-to-end UI-latency measurement.",
+        "Existing 4,096-code-unit tracking abandonment and idle-death partial-tail behavior are unchanged."
+      ],
+      "promotionCriteria": [
+        "Complete CI soak with zero unexplained flakes and preserve the observable oracle."
+      ],
+      "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing fidelity, liveness or resource-count assertions."
+    },
+    {
       "id": "terminal-performance.padded-fullscreen-redraw",
       "title": "Fullscreen redraw padding does not stall terminal delivery",
       "maturity": "experimental",

--- a/src/shared/terminal-partial-escape-tail-ground-scan.test.ts
+++ b/src/shared/terminal-partial-escape-tail-ground-scan.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import { advancePartialEscapeTail, extractPartialEscapeTail } from './terminal-partial-escape-tail'
+
+describe('partial escape scanning between sequences', () => {
+  it.each([
+    ['ASCII', 'ordinary output '.repeat(8192)],
+    ['UTF-16', '漢字😀 output '.repeat(8192)]
+  ])('skips ordinary %s text between completed escapes', (_name, text) => {
+    const pending = '\x1b[38;5;'
+    const stream = `\x1b[32m${text}\x1b[0m${text}${pending}`
+    const charCodeAt = vi.spyOn(String.prototype, 'charCodeAt')
+    let actual: string
+    let inspectedCodeUnits: number
+    try {
+      actual = extractPartialEscapeTail(stream)
+      inspectedCodeUnits = charCodeAt.mock.calls.length
+    } finally {
+      charCodeAt.mockRestore()
+    }
+
+    expect(actual).toBe(pending)
+    expect(inspectedCodeUnits).toBeLessThan(32)
+    expect(advancePartialEscapeTail(actual, '196mready')).toBe('')
+  })
+
+  it.each([
+    ['\x1b[38;5;', '196m'],
+    ['\x1b]2;building', '\x07'],
+    ['\x1b]2;building\x1b', '\\'],
+    ['\x1bPqpayload', '\x1b\\'],
+    ['\x1bPqpayload\x1b', '\\'],
+    ['\x1b(', 'B']
+  ])('preserves %j through every split after ordinary text', (pending, completion) => {
+    const prefix = `\x1b[32m${'build output '.repeat(128)}\x1b[0m`
+    for (let split = 0; split <= pending.length; split += 1) {
+      const first = advancePartialEscapeTail('', prefix + pending.slice(0, split))
+      const continued = advancePartialEscapeTail(first, pending.slice(split))
+      expect(continued).toBe(pending)
+      expect(advancePartialEscapeTail(continued, `${completion}ready`)).toBe('')
+    }
+  })
+
+  it('handles aborts before returning to ordinary text', () => {
+    const text = 'ordinary text '.repeat(128)
+    for (const abort of ['\x18', '\x1a']) {
+      for (const pending of ['\x1b[38;', '\x1b]2;title', '\x1bPdata', '\x1b(']) {
+        expect(extractPartialEscapeTail(`${pending}${abort}${text}\x1b[1;`)).toBe('\x1b[1;')
+      }
+    }
+    expect(extractPartialEscapeTail(`\x1b]2;title\x1b[32m${text}\x1b[1;`)).toBe('\x1b[1;')
+  })
+
+  it('keeps one-character echo free of per-code-unit scans and escape searches', () => {
+    const charCodeAt = vi.spyOn(String.prototype, 'charCodeAt')
+    const indexOf = vi.spyOn(String.prototype, 'indexOf')
+    let actual: string
+    let inspections: number
+    let searches: number
+    try {
+      actual = advancePartialEscapeTail('', 'x')
+      inspections = charCodeAt.mock.calls.length
+      searches = indexOf.mock.calls.length
+    } finally {
+      charCodeAt.mockRestore()
+      indexOf.mockRestore()
+    }
+
+    expect(actual).toBe('')
+    expect(inspections).toBe(0)
+    expect(searches).toBe(0)
+  })
+})

--- a/src/shared/terminal-partial-escape-tail.ts
+++ b/src/shared/terminal-partial-escape-tail.ts
@@ -61,7 +61,9 @@ export function extractPartialEscapeTail(stream: string): string {
   for (let i = 0; i < stream.length; i++) {
     if (state === 'ground') {
       // Only ESC leaves ground; skip ordinary text without a per-code-unit walk.
-      const escape = stream.indexOf('\x1b', i)
+      // Check the current unit first: on dense escape streams it is usually the
+      // ESC itself, and indexOf's call + SIMD setup costs more than the compare.
+      const escape = stream.charCodeAt(i) === ESC ? i : stream.indexOf('\x1b', i)
       if (escape === -1) {
         return ''
       }

--- a/src/shared/terminal-partial-escape-tail.ts
+++ b/src/shared/terminal-partial-escape-tail.ts
@@ -59,14 +59,18 @@ export function extractPartialEscapeTail(stream: string): string {
   let state: ScanState = 'ground'
   let start = 0
   for (let i = 0; i < stream.length; i++) {
-    const code = stream.charCodeAt(i)
     if (state === 'ground') {
-      if (code === ESC) {
-        start = i
-        state = 'esc'
+      // Only ESC leaves ground; skip ordinary text without a per-code-unit walk.
+      const escape = stream.indexOf('\x1b', i)
+      if (escape === -1) {
+        return ''
       }
+      start = escape
+      i = escape
+      state = 'esc'
       continue
     }
+    const code = stream.charCodeAt(i)
     if (
       code === ESC &&
       state !== 'osc' &&


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |

<!-- /orca-pr-loc -->

## ELI5

When your terminal prints text, Orca has to watch for the special invisible codes that set colors and move the cursor, in case one gets cut in half between two batches of output. Until now it checked every single character one at a time, even the plain words, which is slow when a build log dumps megabytes of colored text. Now it jumps straight to the next special code and skips the plain words in between — same output, less work.


Colored terminal logs made partial-escape tracking inspect every ordinary character in JavaScript. While the parser is in ground state, take the current code unit when it is already ESC and otherwise run a forward native ESC search; retain all escape transitions, completion behavior and the existing plain-output fast path.

Production headless terminal CPU for 2 MiB of output improves from 32.321 to 26.638 ms for colored build logs and 26.757 to 21.982 ms for sparse ANSI. Dense back-to-back SGR/CSI output (0.9 MiB, no plain text between sequences) has medians of 2.04 ms before this PR, 2.56 ms with an unconditional ground-state search and 1.92 ms as shipped, so the search-always regression on dense streams is gone. Tiny-write measurements with an identical-baseline control found no material regression. This measures headless processing, not end-to-end keyboard latency.

Validation: 97 tests across seven files passed, including 593,468 fold-fuzz cases and 300 headless-to-renderer snapshot-fidelity streams. A separate differential corpus matched 2,710,126 exact outputs, and a hybrid-vs-search-always differential over the full VT alphabet (ESC/CAN/SUB/BEL/ST, CSI/OSC/DCS/SOS/PM/APC introducers, intermediates, DEL, NUL, CJK, astral emoji and lone/split surrogates) matched 388,416 cases with 0 mismatches. The new work budget fails baseline at 262,160/196,624 ASCII/UTF-16 inspections and passes with 16 inspections and 2 native searches. Node typecheck, formatting, lint and reliability-manifest validation passed; full typecheck passed earlier in the integration worktree.

Reliability gate: `terminal-performance.partial-escape-ground-scan` (experimental). The invariant is exact pending UTF-16 and snapshot continuation; the oracle combines inspection counts, split/abort fidelity, snapshot recovery and one-character echo isolation. Local/daemon and remote-snapshot contracts are covered on macOS; live Electron, SSH/WSL/Windows/Linux and rendered input-latency remain gaps. Folder/git identity, mobile/relay, execution ownership and wire formats are unchanged. Existing tail caps remain intact. This PR is independent of the other performance fixes.

