### PR TITLE
fix(github-project): order number-field groups by value, not by label

### DIFF
--- a/src/renderer/src/components/github-project/group-sort.test.ts
+++ b/src/renderer/src/components/github-project/group-sort.test.ts
@@ -54,6 +54,13 @@ const textField: GitHubProjectField = {
   dataType: 'TEXT'
 }
 
+const numberField: GitHubProjectField = {
+  kind: 'field',
+  id: 'F_points',
+  name: 'Story Points',
+  dataType: 'NUMBER'
+}
+
 function makeRow(
   id: string,
   position: number,
@@ -324,6 +331,50 @@ describe('groupRows', () => {
       ['alice', ['alice']],
       ['No Assignees', ['empty-list', 'no-value']]
     ])
+  })
+
+  it('orders number-field groups by value, not by the rendered label', () => {
+    // Why: the group label is `String(value.number)`, so ordering groups by
+    // label alone puts 10 before 2 — while sortRows already orders number rows
+    // numerically. Grouping and sorting must agree on the same field.
+    const view = { ...makeView(numberField), groupByFields: [numberField] }
+    const rows = [8, 10, 2, 1, 13].map((points, index) =>
+      makeRow(`p${points}`, index, {
+        F_points: { kind: 'number', fieldId: 'F_points', number: points }
+      })
+    )
+
+    const groups = groupRows(makeTable(view, rows), rows)
+
+    expect(groups.map((group) => group.label)).toEqual(['1', '2', '8', '10', '13'])
+  })
+
+  it('orders negative number-field groups by value', () => {
+    // Why: the collator treats the minus sign as ignorable punctuation, so by
+    // label `-10` sorts next to `-1` rather than below `-2`.
+    const view = { ...makeView(numberField), groupByFields: [numberField] }
+    const rows = [10, -2, 2, -10, -1].map((points, index) =>
+      makeRow(`p${index}`, index, {
+        F_points: { kind: 'number', fieldId: 'F_points', number: points }
+      })
+    )
+
+    const groups = groupRows(makeTable(view, rows), rows)
+
+    expect(groups.map((group) => group.label)).toEqual(['-10', '-2', '-1', '2', '10'])
+  })
+
+  it('keeps the empty group last for a number field', () => {
+    const view = { ...makeView(numberField), groupByFields: [numberField] }
+    const rows = [
+      makeRow('none', 0, {}),
+      makeRow('p10', 1, { F_points: { kind: 'number', fieldId: 'F_points', number: 10 } }),
+      makeRow('p2', 2, { F_points: { kind: 'number', fieldId: 'F_points', number: 2 } })
+    ]
+
+    const groups = groupRows(makeTable(view, rows), rows)
+
+    expect(groups.map((group) => group.key)).toEqual(['raw:2', 'raw:10', '__empty__'])
   })
 
   it('places the empty group last', () => {

--- a/src/shared/github/project-group-sort.ts
+++ b/src/shared/github/project-group-sort.ts
@@ -89,7 +89,14 @@ function getFieldValueForGrouping(
     }
   }
   const label = deriveStringValue(value)
-  return { key: `raw:${label}`, label, orderHint: 0, iteration: null }
+  return {
+    key: `raw:${label}`,
+    label,
+    // Why: a number's label sorts as text — 10 before 2, and -10 between -1 and
+    // -2 because the collator ignores the minus. compareSort already uses the value.
+    orderHint: value.kind === 'number' ? value.number : 0,
+    iteration: null
+  }
 }
 
 function labelForEmpty(field: GitHubProjectField): string {
@@ -152,6 +159,14 @@ export function groupRows(
     }
     if (groupField.kind === 'iteration' || groupField.kind === 'single-select') {
       return a[1].orderHint - b[1].orderHint
+    }
+    if (groupField.dataType === 'NUMBER') {
+      const byValue = a[1].orderHint - b[1].orderHint
+      // Why: a cached value that is not a number (field retyped in GitHub) hints 0;
+      // fall through to the label rather than tie or return NaN.
+      if (byValue !== 0 && Number.isFinite(byValue)) {
+        return byValue
+      }
     }
     return a[1].label.localeCompare(b[1].label)
   })


### PR DESCRIPTION
## ELI5

If you group a GitHub Projects table by a number field — Story Points, Estimate, Priority — the group headers come out in the wrong order: `1, 10, 13, 2, 8` instead of `1, 2, 8, 10, 13`. Orca was sorting those headers as *words* rather than as numbers. This makes them sort as numbers, which is what the rows inside each group were already doing.

## What Changed

`getFieldValueForGrouping` funnels every non-iteration, non-single-select value down one "raw" path that keeps only the rendered string and pins `orderHint` to `0`:

```ts
const label = deriveStringValue(value)
return { key: `raw:${label}`, label, orderHint: 0, iteration: null }
```

`groupRows` reads `orderHint` only for iteration and single-select fields, so everything else falls to `a[1].label.localeCompare(b[1].label)`.

The raw branch now carries the number as its order hint, and `groupRows` consults it when the group field's `dataType` is `NUMBER`:

- ties, or a non-finite subtraction, fall through to the existing label comparison — so a cached value that isn't a number (the field was retyped in GitHub) still orders deterministically instead of returning `NaN`, matching the concern `UNKNOWN_INDEX_SENTINEL` already exists for in this file;
- **text, date, labels and users are deliberately untouched.** A date is `YYYY-MM-DD`, so lexicographic order already *is* chronological, and the other three are genuinely alphabetical. Number is the one kind whose display string doesn't sort like its value.

16 lines of source; the rest is tests.

## Why

`compareSort`, in the same file, already orders number rows by value:

```ts
} else if (aValue.kind === 'number' && bValue.kind === 'number') {
  cmp = aValue.number - bValue.number
```

So grouping and sorting disagreed about the same field: rows *inside* each group were ordered numerically while the groups *around* them were ordered as text.

Negative values are the sharper case — the collator treats the minus sign as ignorable punctuation, so `-10` lands between `-1` and `-2`:

```
before   -1   -10  -2   10  2
after    -10  -2   -1   2   10
```

This is reachable through normal data: `groupByFields` comes straight from the view config GitHub returns, `normalizeField` maps a number field to `{ kind: 'field', dataType: 'NUMBER' }`, and `normalizeFieldValue` guards on `typeof raw.number === 'number'`, so the value is always a real number. Nothing filters number fields out of group-by.

Same neighbourhood as #15358 / 3f5c543, but a distinct defect: that one was about *empty* values sorting to the wrong end; this is about the ordering of present ones.

## Linked Issue

Fixes #19395

## Visual Proof

`N/A` — no rendering change. The group headers and rows are unchanged; only the order of the `ProjectGroup[]` that `groupRows` returns differs. The behavior change is fully expressed by the assertions below.

## Testing

`group-sort.test.ts` had no number-field grouping case, which is likely why this went unnoticed. Three added, all in `describe('groupRows')`:

- `orders number-field groups by value, not by the rendered label` — `[8, 10, 2, 1, 13]` → headers `1, 2, 8, 10, 13`
- `orders negative number-field groups by value` — `[10, -2, 2, -10, -1]` → `-10, -2, -1, 2, 10` (this is the one the collator's minus-sign handling breaks)
- `keeps the empty group last for a number field` — the empty-group invariant from #15358 still holds once the numeric branch is in play

Red/green, reverting **only** `project-group-sort.ts` and keeping the tests:

```
without the fix   3 failed | 10 passed
                  expected [ '1', '10', '13', '2', '8' ] to deeply equal [ '1', '2', '8', '10', '13' ]
                  expected [ '-1', '-10', '-2', '10', '2' ] to deeply equal [ '-10', '-2', '-1', '2', '10' ]
                  expected [ 'raw:10', 'raw:2', '__empty__' ] to deeply equal [ 'raw:2', 'raw:10', '__empty__' ]
with the fix      13 passed
```

The 10 pre-existing tests pass either way, so nothing already covered changed behavior. `tsc --strict` clean and `oxfmt --check` clean (against the repo's own `.oxfmtrc.json`) on both files.

To be precise about what I ran: cloning the repo failed repeatedly here (`fatal: early EOF` on the pack, and the blobless clone couldn't fetch from the promisor remote), so I ran `group-sort.test.ts` **unmodified except for the three added cases**, against the real `project-group-sort.ts` and `project-types.ts` at their real paths, in a standalone vitest project — the module's only import is type-only, so it runs faithfully in isolation.

Also run locally against the repo's own configs, on both changed files:

- `oxlint --config .oxlintrc.json` → exit 0, no warnings, with the five `jsPlugins` present (including `sort-comparator-performance`, whose `no-repeated-collator` rule targets exactly this kind of code — it does not fire, because the change leaves the existing bare `localeCompare` call alone and adds no `Intl.Collator`)
- `oxfmt --check` against `.oxfmtrc.json` → clean
- `tsc --noEmit --strict` on the two `src/shared/github` modules → clean

What did **not** run anywhere yet is the full monorepo suite: not locally, and not in CI, since `pr.yml` is held behind *Approve and run workflows* for outside contributors. Happy to push a fixup if it surfaces anything.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Opus 5 via Claude Code. The bug was found by reading `project-group-sort.ts` after #15358, reproduced with a failing test before any fix, and verified by reverting the source alone to confirm only the three new assertions fail.

## Review

- **Cross-platform:** pure comparator logic in `src/shared/`, no platform, path, or shortcut surface. Unaffected on macOS / Linux / Windows.
- **Remote / SSH:** none. `groupRows` runs on already-normalized rows on whichever side renders them; no IPC, RPC, or wire shape changes, so no client/host version skew.
- **Mobile:** `mobile/src/tasks/use-mobile-tasks-project-projection.tsx` imports the same `groupRows`, so mobile gets the identical fix. There is only one implementation of `deriveStringValue` in the tree — no mirror to keep in sync.
- **Backwards compatibility:** `orderHint` is module-private and never leaves `groupRows`; the exported `ProjectGroup` shape is unchanged.
- **Agents / integrations / git providers:** not applicable — GitHub Projects view config only.
- **Performance:** one subtraction and a `Number.isFinite` on the group-count comparator, which runs over distinct groups rather than rows. Strictly cheaper than the `localeCompare` it replaces on the numeric path.
- **Security:** no new inputs, no parsing, no I/O.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see the note in Testing: the affected test file, typecheck and format were verified locally; the full monorepo suite is left to CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
