### PR TITLE
fix(journal): preserve original rows in sealed repair generations (STA-6925)

### DIFF
--- a/docs/reference/journal-recovery-generations.md
+++ b/docs/reference/journal-recovery-generations.md
@@ -1,0 +1,68 @@
+# Journal recovery generations
+
+Opening a corrupt journal used to delete its first rejected row and every later
+row. Provider transcripts cannot restore Orca-only submission receipts. Repair
+now seals the original epoch and publishes only the readable prefix in a fresh
+epoch. The suffix remains recovery evidence, never automatically replayed across
+an unknown dependency.
+
+## Ownership and transaction
+
+The execution host owns the SQLite journal and the repair, using the existing
+journal connection and `BEGIN IMMEDIATE` / `synchronous = FULL` transaction. This
+has no Git dependency: folder workspaces and Git worktrees use the same operation.
+No client-side repair, transport fallback, RPC field, or stream opcode is added.
+An old cursor uses the existing `epoch_changed` reset.
+
+Schema v3 adds `journal_recovery_epochs`. Each row records the sealed source
+session/epoch, replacement epoch, rejected sequence, readable prefix boundary,
+seal time, row count, and raw JSON byte count. Original `journal_rows` remain
+in place, preserving their exact sequence, timestamp, epoch, and bytes. Triggers
+refuse inserts, updates, or deletes in sealed epochs and mutation of recovery
+metadata. Ordinary epoch replacement deletes only unsealed rows.
+
+The transaction rechecks the load under the write lock, registers the seal,
+inserts the prefix with the new epoch identity (or an anchor for an empty prefix),
+records the outstanding rebuild marker, and moves the session projection. Only a
+successful commit is adopted in memory. A failure refuses open; rollback leaves
+the original rows and projection intact. An abrupt exit after commit leaves the
+complete new generation and original evidence. Disclosure is a subsequent append;
+its absence after a crash does not remove the repair marker or the evidence.
+
+Existing v1/v2 databases migrate transactionally with the schema version bump.
+Older hosts see v3 as a future database and latch read-only. Database and row
+versions are independent: future row versions, including behind malformed rows,
+are checked before persistent pragmas or migration. No future-version database is
+repaired. A schema-scoped provider reconstruction, where already supported, is a
+separate journal and never authorizes modifying the original.
+
+## Recovery and capacity boundary
+
+Sealed rows are available on the execution host through the existing SQL row
+storage. For byte-exact extraction, use `CAST(row_json AS BLOB)` and select by the
+source session and epoch from `journal_recovery_epochs`; retain `seq` and `ts`.
+A valid-looking receipt behind a rejected row is recoverable evidence, not proof
+that it can safely be applied to the live generation. No recovery UI or automatic
+suffix merge is added here.
+
+The immutable ownership records make recovery occupancy discoverable for the
+coordinated storage budget. `row_bytes` measures logical JSON bytes only; it is
+**not** a physical capacity budget. A future admission policy must count sealed
+rows alongside live rows, database pages, WAL, payloads, staging, and checkpoint
+peak, and must reserve the prefix-copy peak before admitting repair. SQLite
+allocation failure currently refuses repair without deleting the source. There
+is no application quota, reclamation of sealed epochs, payload storage, or bounded
+retention in this change (STA-6924 and STA-6837 remain separate work).
+
+## Validation contract
+
+Shipping-path tests cover byte equality through repair, reopen, and subsequent
+epoch replacement; immutable seals; refusal at transaction stages; SQLite
+`max_page_count` exhaustion; future DB/row versions; and abrupt child-process exit
+before/after commit. Page-limit exhaustion exercises SQLite's real `SQLITE_FULL`
+path without filling the host disk. Process exits exercise recovery of uncommitted
+WAL transactions, not hardware power-loss guarantees.
+
+Run with `pnpm exec vitest run --config config/vitest.config.ts
+src/main/native-chat/agent-session-journal`. Platform, paired-host, and client
+version-skew runtime coverage must be reported explicitly by each validation run.

--- a/docs/reference/journal-recovery-generations.md
+++ b/docs/reference/journal-recovery-generations.md
@@ -31,16 +31,20 @@ its absence after a crash does not remove the repair marker or the evidence.
 
 Existing v1/v2 databases migrate transactionally with the schema version bump.
 Older hosts see v3 as a future database and latch read-only. Database and row
-versions are independent: future row versions, including behind malformed rows,
-are checked before persistent pragmas or migration. No future-version database is
-repaired. A schema-scoped provider reconstruction, where already supported, is a
+versions are independent: future row versions in TEXT or valid UTF-8 BLOBs,
+including behind malformed rows, are checked before persistent pragmas or migration.
+Admission and replay share raw SQLite value decoding. Invalid UTF-8 and unsupported
+value types conservatively latch read-only; supported malformed JSON can be sealed
+and repaired. Decoding never rewrites the original storage type or bytes. No
+future-version database is repaired. A schema-scoped provider reconstruction, where already supported, is a
 separate journal and never authorizes modifying the original.
 
 ## Recovery and capacity boundary
 
 Sealed rows are available on the execution host through the existing SQL row
 storage. For byte-exact extraction, use `CAST(row_json AS BLOB)` and select by the
-source session and epoch from `journal_recovery_epochs`; retain `seq` and `ts`.
+source session and epoch from `journal_recovery_epochs`; retain `seq`, `ts`, and
+`typeof(row_json)` so extraction also preserves the SQLite storage class.
 A valid-looking receipt behind a rejected row is recoverable evidence, not proof
 that it can safely be applied to the live generation. No recovery UI or automatic
 suffix merge is added here.

--- a/src/main/native-chat/agent-session-journal/journal-corruption-repair.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-corruption-repair.test.ts
@@ -1,11 +1,4 @@
-// A repair drops what it cannot replay, and says so.
-//
-// Two things make a suffix unreplayable: a row this build cannot parse, and a
-// sequence gap that makes every later row unanchored. The rejected suffix is
-// DELETED; the load reports `corrupt`, and recovery rebuilds the epoch from
-// provider history. Every case here asserts the same two halves: the live epoch
-// holds only the replayable prefix, AND the epoch stays anchored so nothing
-// replays a repaired journal as a clean timeline.
+// Repair publishes an anchored readable prefix while sealing the original epoch.
 
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -72,9 +65,11 @@ async function withJournalDatabase(run: (db: Database.Database) => void): Promis
 function firstLiveRow(): Promise<JournalRow | null> {
   let row: JournalRow | null = null
   return withJournalDatabase((db) => {
-    const stored = db.prepare('SELECT row_json FROM journal_rows ORDER BY seq LIMIT 1').get() as
-      | { row_json: string }
-      | undefined
+    const stored = db
+      .prepare(
+        'SELECT row_json FROM journal_rows WHERE epoch = (SELECT epoch FROM journal_sessions) ORDER BY seq LIMIT 1'
+      )
+      .get() as { row_json: string } | undefined
     const parsed = stored ? parseJournalRow(stored.row_json) : null
     row = parsed?.ok ? parsed.row : null
   }).then(() => row)
@@ -84,7 +79,11 @@ function liveSequences(): Promise<number[]> {
   let sequences: number[] = []
   return withJournalDatabase((db) => {
     sequences = (
-      db.prepare('SELECT seq FROM journal_rows ORDER BY seq').all() as { seq: number }[]
+      db
+        .prepare(
+          'SELECT seq FROM journal_rows WHERE epoch = (SELECT epoch FROM journal_sessions) ORDER BY seq'
+        )
+        .all() as { seq: number }[]
     ).map((row) => row.seq)
   }).then(() => sequences)
 }
@@ -100,7 +99,7 @@ afterEach(async () => {
 })
 
 describe('a malformed row', () => {
-  it('keeps the readable prefix live and drops the rest of the epoch', async () => {
+  it('keeps the readable prefix live in a new generation', async () => {
     const journal = await open()
     await journal.appendItem(item(0), body('readable'), { fence: 1 })
     await journal.appendItem(item(1), body('unreadable'), { fence: 1 })

--- a/src/main/native-chat/agent-session-journal/journal-database-schema.ts
+++ b/src/main/native-chat/agent-session-journal/journal-database-schema.ts
@@ -10,8 +10,9 @@
  *  body version (`JournalRow.v`): a newer build can change either alone.
  *  v2 added `journal_repairs`; a build without it would replay a partially
  *  repaired journal as clean, so it must latch read-only rather than write. */
-export const JOURNAL_DB_SCHEMA_VERSION = 2
+export const JOURNAL_DB_SCHEMA_VERSION = 3
 
+// v3 seals recovery epochs; older hosts must not delete them during rollover.
 export function createJournalTablesSql(): string {
   return `
 CREATE TABLE IF NOT EXISTS journal_rows (
@@ -33,5 +34,31 @@ CREATE TABLE IF NOT EXISTS journal_repairs (
   content_from INTEGER NOT NULL,
   repaired_at  INTEGER NOT NULL
 );
+CREATE TABLE IF NOT EXISTS journal_recovery_epochs (
+  session_id TEXT NOT NULL,
+  epoch TEXT NOT NULL,
+  replacement_epoch TEXT NOT NULL,
+  rejected_from INTEGER NOT NULL,
+  prefix_through INTEGER NOT NULL,
+  sealed_at INTEGER NOT NULL,
+  row_count INTEGER NOT NULL,
+  row_bytes INTEGER NOT NULL,
+  PRIMARY KEY (session_id, epoch)
+);
+CREATE TRIGGER IF NOT EXISTS journal_sealed_row_insert BEFORE INSERT ON journal_rows
+WHEN EXISTS (SELECT 1 FROM journal_recovery_epochs WHERE session_id = NEW.session_id AND epoch = NEW.epoch)
+BEGIN SELECT RAISE(ABORT, 'journal epoch is sealed'); END;
+CREATE TRIGGER IF NOT EXISTS journal_sealed_row_update BEFORE UPDATE ON journal_rows
+WHEN EXISTS (SELECT 1 FROM journal_recovery_epochs
+  WHERE (session_id = OLD.session_id AND epoch = OLD.epoch)
+     OR (session_id = NEW.session_id AND epoch = NEW.epoch))
+BEGIN SELECT RAISE(ABORT, 'journal epoch is sealed'); END;
+CREATE TRIGGER IF NOT EXISTS journal_sealed_row_delete BEFORE DELETE ON journal_rows
+WHEN EXISTS (SELECT 1 FROM journal_recovery_epochs WHERE session_id = OLD.session_id AND epoch = OLD.epoch)
+BEGIN SELECT RAISE(ABORT, 'journal epoch is sealed'); END;
+CREATE TRIGGER IF NOT EXISTS journal_recovery_epoch_update BEFORE UPDATE ON journal_recovery_epochs
+BEGIN SELECT RAISE(ABORT, 'journal recovery evidence is immutable'); END;
+CREATE TRIGGER IF NOT EXISTS journal_recovery_epoch_delete BEFORE DELETE ON journal_recovery_epochs
+BEGIN SELECT RAISE(ABORT, 'journal recovery evidence is immutable'); END;
 `
 }

--- a/src/main/native-chat/agent-session-journal/journal-database.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-database.test.ts
@@ -12,7 +12,6 @@ import { JOURNAL_DB_SCHEMA_VERSION } from './journal-database-schema'
 import { journalDatabaseFile } from './journal-paths'
 import {
   deleteAllJournalRows,
-  deleteJournalRowSuffix,
   insertJournalRow,
   readJournalEpochRows,
   readJournalRowsAfter,
@@ -103,7 +102,7 @@ describe('journal database open', () => {
 })
 
 describe('journal row statements', () => {
-  it('serves replay, resume, discard and suffix truncation from the primary key', () => {
+  it('serves replay, resume and discard from the primary key', () => {
     const opened = openJournalDatabase(dbPath)
     try {
       const { db } = opened
@@ -123,13 +122,6 @@ describe('journal row statements', () => {
       expect(readJournalRowsAfter(db, 'session-1', 'epoch-1', 3).map((row) => row.seq)).toEqual([
         4, 5
       ])
-
-      // The rejected suffix leaves `journal_rows`, scoped to its own epoch.
-      expect(deleteJournalRowSuffix(db, 'session-1', 'epoch-1', 4)).toBe(2)
-      expect(readJournalEpochRows(db, 'session-1', 'epoch-1').map((row) => row.seq)).toEqual([
-        1, 2, 3
-      ])
-      expect(readJournalEpochRows(db, 'session-1', 'epoch-old')).toHaveLength(1)
 
       deleteAllJournalRows(db)
       expect(readJournalEpochRows(db, 'session-1', 'epoch-1')).toHaveLength(0)

--- a/src/main/native-chat/agent-session-journal/journal-database.ts
+++ b/src/main/native-chat/agent-session-journal/journal-database.ts
@@ -4,7 +4,9 @@
 // persistent pragma and run no DDL: a future-schema database must be left
 // byte-identical, and `journal_mode = WAL` writes the file header.
 
+import { existsSync } from 'node:fs'
 import Database from '../../sqlite/sync-database'
+import { parseJournalRow } from './journal-row-schema'
 import { hardenSqliteDatabaseFiles } from '../../sqlite/harden-database-files'
 import { createJournalTablesSql, JOURNAL_DB_SCHEMA_VERSION } from './journal-database-schema'
 
@@ -21,10 +23,14 @@ export function journalPragmaNumber(db: Database.Database, name: string): number
 }
 
 export function openJournalDatabase(dbPath: string): OpenJournalDatabase {
-  const probe = new Database(dbPath)
+  const probe = new Database(dbPath, { readonly: existsSync(dbPath) })
   let stored: number
   try {
     stored = journalPragmaNumber(probe, 'user_version')
+    if (stored <= JOURNAL_DB_SCHEMA_VERSION && hasFutureJournalRows(probe)) {
+      probe.close()
+      return { db: new Database(dbPath, { readonly: true, fileMustExist: true }), readOnly: true }
+    }
   } catch (error) {
     probe.close()
     throw error
@@ -33,17 +39,19 @@ export function openJournalDatabase(dbPath: string): OpenJournalDatabase {
     probe.close()
     return { db: new Database(dbPath, { readonly: true, fileMustExist: true }), readOnly: true }
   }
+  probe.close()
+  const writable = new Database(dbPath)
   let transferred = false
   try {
-    configureJournalPragmas(probe)
-    createJournalSchema(probe, stored)
+    configureJournalPragmas(writable)
+    createJournalSchema(writable, stored)
     hardenSqliteDatabaseFiles(dbPath)
-    const opened = { db: probe, readOnly: false }
+    const opened = { db: writable, readOnly: false }
     transferred = true
     return opened
   } finally {
     if (!transferred) {
-      probe.close()
+      writable.close()
     }
   }
 }
@@ -77,4 +85,22 @@ function createJournalSchema(db: Database.Database, stored: number): void {
     db.exec('ROLLBACK')
     throw error
   }
+}
+
+/** Check before persistent pragmas or migration, including rows behind a corrupt prefix. */
+function hasFutureJournalRows(db: Database.Database): boolean {
+  if (
+    !db
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'journal_rows'")
+      .get()
+  ) {
+    return false
+  }
+  for (const entry of db.prepare('SELECT row_json FROM journal_rows').iterate()) {
+    const parsed = parseJournalRow(entry.row_json as string)
+    if (!parsed.ok && parsed.unreadable) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/main/native-chat/agent-session-journal/journal-database.ts
+++ b/src/main/native-chat/agent-session-journal/journal-database.ts
@@ -97,7 +97,7 @@ function hasFutureJournalRows(db: Database.Database): boolean {
     return false
   }
   for (const entry of db.prepare('SELECT row_json FROM journal_rows').iterate()) {
-    const parsed = parseJournalRow(entry.row_json as string)
+    const parsed = parseJournalRow(entry.row_json)
     if (!parsed.ok && parsed.unreadable) {
       return true
     }

--- a/src/main/native-chat/agent-session-journal/journal-epoch-replacement.ts
+++ b/src/main/native-chat/agent-session-journal/journal-epoch-replacement.ts
@@ -1,8 +1,4 @@
-// Republishing a live item set into a fresh epoch.
-//
-// One transaction: discard every row, insert the epoch row plus the replacement
-// items, move the session projection, and retire any repair marker — this
-// republished history is exactly what the marker was holding out for.
+// Atomically publish a new live epoch; sealed recovery epochs remain untouched.
 
 import type {
   AgentJournalItemBody,

--- a/src/main/native-chat/agent-session-journal/journal-epoch-rollover.ts
+++ b/src/main/native-chat/agent-session-journal/journal-epoch-rollover.ts
@@ -1,9 +1,4 @@
-// Opening a new epoch.
-//
-// One transaction: discard every row of the superseded epoch, insert the new
-// epoch row at sequence 1, move the session projection onto it, and retire any
-// repair marker the superseded epoch was carrying. Superseded rows are DELETED
-// rather than retained — nothing would ever shed them.
+// Atomically publish a new live epoch; sealed recovery epochs remain untouched.
 
 import { AGENT_SESSION_JOURNAL_SCHEMA_VERSION } from '../../../shared/agent-session-journal-types'
 import type { AgentSessionProviderHandle } from '../../../shared/agent-session-journal-types'

--- a/src/main/native-chat/agent-session-journal/journal-handle-ownership.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-handle-ownership.test.ts
@@ -146,8 +146,15 @@ describe('failure paths inside the open call', () => {
 
     // Replay runs after the connection is open, so a read it cannot serve
     // throws with the handle already held.
-    const exec = vi.spyOn(Database.prototype, 'prepare').mockImplementation(() => {
-      throw new Error('replay cannot read this journal')
+    const prepare = Database.prototype.prepare
+    const exec = vi.spyOn(Database.prototype, 'prepare').mockImplementation(function (
+      this: Database.Database,
+      sql: string
+    ) {
+      if (sql === 'SELECT epoch FROM journal_sessions WHERE session_id = ?') {
+        throw new Error('replay cannot read this journal')
+      }
+      return prepare.call(this, sql)
     })
     try {
       await expect(journals.open({ identity: IDENTITY, journalDir: root })).rejects.toThrow(

--- a/src/main/native-chat/agent-session-journal/journal-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-open.ts
@@ -1,8 +1,7 @@
 // Loading a journal: the session projection names the live epoch, and that
 // epoch's rows are folded through the reducer in sequence order.
 //
-// There is no snapshot to anchor to and no superseded-epoch rows to drop — a
-// roll deletes them in the same transaction that publishes the new epoch. A gap
+// Sealed recovery epochs are excluded by the session projection. A gap
 // in the surviving sequence is corruption, and the caller rolls the epoch
 // rather than rendering a partial timeline.
 
@@ -38,7 +37,7 @@ export type JournalLoad = {
    *  `readOnly`, never counted here). The store discloses these in the timeline. */
   malformedRows: number
   /** Directory-internal: the first sequence of an unusable suffix. The store
-   *  deletes from here before it accepts a write; a probe leaves it alone. */
+   *  seals the source before publishing a writable prefix; a probe leaves it alone. */
   truncateFrom?: number
 }
 
@@ -67,7 +66,10 @@ export function replayJournal(
   const repairedFrom = pendingJournalRepairSequence(db, sessionId, epoch)
   const rows: JournalRow[] = []
   let malformedRows = 0
-  let latched = false
+  let latched = stored.some((entry) => {
+    const parsed = parseJournalRow(entry.rowJson)
+    return !parsed.ok && parsed.unreadable
+  })
   let truncateFrom: number | undefined
   for (const entry of stored) {
     const parsed = parseJournalRow(entry.rowJson)

--- a/src/main/native-chat/agent-session-journal/journal-repair-crash.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-repair-crash.test.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { runProcess } from '../../../shared/child-process/run-process'
+import Database from '../../sqlite/sync-database'
+import { journalDatabaseFile } from './journal-paths'
+import { openAgentSessionJournal } from './journal-store-factory'
+
+const roots: string[] = []
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await rm(root, { recursive: true, force: true })
+  }
+})
+const identity = {
+  sessionId: 'crash-fixture',
+  workspaceId: 'folder',
+  hostId: 'host',
+  agent: 'codex' as const,
+  providerHandle: { kind: 'codex' as const, threadId: 'disposable' }
+}
+const journalModule = './src/main/native-chat/agent-session-journal/journal-store-factory.ts'
+const childScript = `
+const ts = require('typescript-api');
+const fs = require('node:fs');
+require.extensions['.ts'] = (module, filename) => module._compile(ts.transpileModule(
+  fs.readFileSync(filename, 'utf8'), { compilerOptions: { module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ES2022, esModuleInterop: true } }).outputText, filename);
+const Database = require('./src/main/sqlite/sync-database.ts').default;
+const stage = process.argv[2];
+const exec = Database.prototype.exec;
+const prepare = Database.prototype.prepare;
+Database.prototype.prepare = function(sql) {
+  const statement = prepare.call(this, sql);
+  const marker = {seal: 'INSERT INTO journal_recovery_epochs', prefix: 'INSERT INTO journal_rows',
+    publish: 'INSERT INTO journal_sessions'}[stage];
+  if (!marker || !sql.startsWith(marker)) return statement;
+  return new Proxy(statement, { get(target, key) {
+    if (key === 'run') return (...args) => { target.run(...args); process.exit(73); };
+    const value = target[key]; return typeof value === 'function' ? value.bind(target) : value;
+  }});
+};
+Database.prototype.exec = function(sql) {
+  if (stage === 'before-commit' && sql === 'COMMIT') process.exit(73);
+  exec.call(this, sql);
+  if (stage === 'after-commit' && sql === 'COMMIT') process.exit(73);
+};
+require(${JSON.stringify(journalModule)}).openAgentSessionJournal({
+  identity: ${JSON.stringify(identity)}, journalDir: process.argv[1]
+}).then(() => process.exit(74)).catch(error => { console.error(error); process.exit(75); });
+`
+
+it.each(['seal', 'prefix', 'publish', 'before-commit', 'after-commit'])(
+  'survives abrupt process exit after %s with original or complete generation',
+  async (stage) => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-repair-crash-'))
+    roots.push(root)
+    const journal = await openAgentSessionJournal({ identity, journalDir: root })
+    await journal.appendItem(
+      { provider: 'orca', clientMessageId: 'prefix' },
+      { kind: 'status', text: 'prefix' }
+    )
+    await journal.appendItem(
+      { provider: 'orca', clientMessageId: 'fault' },
+      { kind: 'status', text: 'fault' }
+    )
+    await journal.appendItem(
+      { provider: 'orca', clientMessageId: 'suffix' },
+      { kind: 'status', text: 'suffix' }
+    )
+    const epoch = journal.epoch
+    await journal.close()
+    const seeded = new Database(journalDatabaseFile(root))
+    seeded.exec("UPDATE journal_rows SET row_json = '}{' WHERE seq = 3")
+    const source = seeded
+      .prepare('SELECT seq, hex(CAST(row_json AS BLOB)) AS bytes FROM journal_rows ORDER BY seq')
+      .all()
+    seeded.close()
+    const result = await runProcess({
+      program: process.execPath,
+      args: ['-e', childScript, root, stage],
+      cwd: process.cwd(),
+      env: { ...process.env, ORCA_BACKGROUND_LAUNCH: '1' },
+      timeoutMs: 20_000
+    })
+    expect(result, result.stderr).toMatchObject({ code: 73, timedOut: false })
+    const db = new Database(journalDatabaseFile(root))
+    try {
+      expect(
+        db
+          .prepare(
+            'SELECT seq, hex(CAST(row_json AS BLOB)) AS bytes FROM journal_rows WHERE epoch = ? ORDER BY seq'
+          )
+          .all(epoch)
+      ).toEqual(source)
+      const live = db.prepare('SELECT epoch FROM journal_sessions').get() as { epoch: string }
+      const seals = db.prepare('SELECT count(*) AS n FROM journal_recovery_epochs').get()
+      if (stage === 'after-commit') {
+        expect(live.epoch).not.toBe(epoch)
+        expect(seals).toMatchObject({ n: 1 })
+        expect(
+          db.prepare('SELECT seq FROM journal_rows WHERE epoch = ? ORDER BY seq').all(live.epoch)
+        ).toEqual([{ seq: 1 }, { seq: 2 }])
+        expect(db.prepare('SELECT epoch, content_from FROM journal_repairs').get()).toMatchObject({
+          epoch: live.epoch,
+          content_from: 3
+        })
+      } else {
+        expect(live.epoch).toBe(epoch)
+        expect(seals).toMatchObject({ n: 0 })
+      }
+    } finally {
+      db.close()
+    }
+    const reopened = await openAgentSessionJournal({ identity, journalDir: root })
+    expect(
+      reopened
+        .snapshot()
+        .items.some((entry) => entry.body.kind === 'status' && entry.body.text === 'prefix')
+    ).toBe(true)
+    await reopened.close()
+  }
+)

--- a/src/main/native-chat/agent-session-journal/journal-repair-generation.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-repair-generation.test.ts
@@ -1,0 +1,230 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import type { AgentSessionJournalIdentity } from '../../../shared/agent-session-journal-types'
+import Database from '../../sqlite/sync-database'
+import { journalDatabaseFile } from './journal-paths'
+import { openAgentSessionJournal } from './journal-store-factory'
+import { createTrackedJournalOpener } from './journal-store-test-open'
+
+const identity: AgentSessionJournalIdentity = {
+  sessionId: 'repair-fixture',
+  workspaceId: 'folder-or-worktree',
+  hostId: 'execution-host',
+  agent: 'codex',
+  providerHandle: { kind: 'codex', threadId: 'disposable-thread' }
+}
+const journals = createTrackedJournalOpener()
+let root: string
+let source: string
+let original: unknown[]
+const item = (id: string) => ({ provider: 'orca' as const, clientMessageId: id })
+const body = { kind: 'status' as const, text: 'disposable evidence λ' }
+function open() {
+  return journals.open({ identity, journalDir: root })
+}
+function inspect<T>(run: (db: Database.Database) => T): T {
+  const db = new Database(journalDatabaseFile(root))
+  try {
+    return run(db)
+  } finally {
+    db.close()
+  }
+}
+function raw(db: Database.Database, epoch = source) {
+  return db
+    .prepare(`SELECT epoch, seq, ts, hex(CAST(row_json AS BLOB)) AS bytes
+    FROM journal_rows WHERE epoch = ? ORDER BY seq`)
+    .all(epoch)
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-repair-generation-'))
+  const journal = await open()
+  source = journal.epoch
+  await journal.appendItem(item('prefix'), body, { fence: 1 })
+  await journal.appendItem(item('fault'), body, { fence: 1 })
+  await journal.appendSubmission({
+    clientMessageId: 'orca-only-receipt',
+    payloadFingerprint: 'unique',
+    fence: 1,
+    body: { kind: 'message', role: 'user', blocks: [{ type: 'text', text: 'only in Orca' }] }
+  })
+  await journal.resolveDispatch({
+    clientMessageId: 'orca-only-receipt',
+    state: 'accepted',
+    providerIdentity: item('accepted'),
+    fence: 1
+  })
+  await journal.appendItem(item('valid-suffix'), body, { fence: 1 })
+  await journal.close()
+  inspect((db) => {
+    db.prepare('UPDATE journal_rows SET row_json = ? WHERE seq = 3').run('  }{ λ\n')
+    original = raw(db)
+  })
+})
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await journals.closeAll()
+  await rm(root, { recursive: true, force: true })
+})
+
+it('seals exact rejected bytes, Orca-only receipt and suffix across reopen and replacement', async () => {
+  const repaired = await open()
+  expect(repaired.epoch).not.toBe(source)
+  expect(repaired.receiptFor('orca-only-receipt')).toBeNull()
+  expect(repaired.readSince({ epoch: source, sequence: 2 })).toMatchObject({
+    reset: 'epoch_changed'
+  })
+  inspect((db) => {
+    expect(raw(db)).toEqual(original)
+    expect(
+      db
+        .prepare('SELECT row_count, prefix_through, rejected_from FROM journal_recovery_epochs')
+        .get()
+    ).toMatchObject({ row_count: 6, prefix_through: 2, rejected_from: 3 })
+    expect(() => db.prepare('DELETE FROM journal_rows WHERE epoch = ?').run(source)).toThrow(
+      'sealed'
+    )
+    expect(() =>
+      db.prepare('UPDATE journal_rows SET row_json = ? WHERE epoch = ?').run('{}', source)
+    ).toThrow('sealed')
+    expect(() => db.exec('DELETE FROM journal_recovery_epochs')).toThrow('immutable')
+  })
+  await repaired.close()
+  const reopened = await open()
+  expect(reopened.snapshot().items.some((entry) => entry.itemId.includes('valid-suffix'))).toBe(
+    false
+  )
+  await reopened.replaceEpochItems('legacy_import', 2, [{ identity: item('provider'), body }])
+  await reopened.rollEpoch('handle_forked', 3)
+  await reopened.close()
+  await open().then((journal) => journal.close())
+  inspect((db) => expect(raw(db)).toEqual(original))
+})
+
+it.each(['seal', 'prefix', 'publish', 'commit'] as const)(
+  'rolls back repair when %s admission fails',
+  async (boundary) => {
+    const exec = Database.prototype.exec
+    const prepare = Database.prototype.prepare
+    const sqlBoundary = {
+      seal: 'INSERT INTO journal_recovery_epochs',
+      prefix: 'INSERT INTO journal_rows',
+      publish: 'INSERT INTO journal_sessions',
+      commit: undefined
+    }[boundary]
+    vi.spyOn(Database.prototype, 'prepare').mockImplementation(
+      function (this: Database.Database, sql) {
+        if (sqlBoundary && sql.startsWith(sqlBoundary)) {
+          throw new Error('repair admission refused')
+        }
+        return prepare.call(this, sql)
+      }
+    )
+    vi.spyOn(Database.prototype, 'exec').mockImplementation(
+      function (this: Database.Database, sql) {
+        if (boundary === 'commit' && sql === 'COMMIT') {
+          throw new Error('repair admission refused')
+        }
+        return exec.call(this, sql)
+      }
+    )
+    await expect(openAgentSessionJournal({ identity, journalDir: root })).rejects.toThrow(
+      'repair admission refused'
+    )
+    vi.restoreAllMocks()
+    inspect((db) => {
+      expect(raw(db)).toEqual(original)
+      expect(db.prepare('SELECT epoch FROM journal_sessions').get()).toMatchObject({
+        epoch: source
+      })
+      expect(db.prepare('SELECT count(*) AS n FROM journal_recovery_epochs').get()).toMatchObject({
+        n: 0
+      })
+    })
+    await open().then((journal) => journal.close())
+    inspect((db) => expect(raw(db)).toEqual(original))
+  }
+)
+
+it('refuses writable repair on a real SQLite page limit without losing source bytes', async () => {
+  // Fill a bounded replacement beyond the free page budget, not the host filesystem.
+  inspect((db) =>
+    db.prepare('UPDATE journal_rows SET row_json = ? WHERE seq = 2').run(
+      JSON.stringify({
+        v: 1,
+        kind: 'item',
+        epoch: source,
+        seq: 2,
+        fence: 1,
+        ts: 1,
+        itemId: 'large',
+        revision: 1,
+        body: { kind: 'status', text: 'x'.repeat(200_000) }
+      })
+    )
+  )
+  original = inspect((db) => raw(db))
+  const exec = Database.prototype.exec
+  vi.spyOn(Database.prototype, 'exec').mockImplementation(function (this: Database.Database, sql) {
+    if (sql === 'BEGIN IMMEDIATE') {
+      const pages = this.pragma('page_count', { simple: true })
+      this.pragma(`max_page_count = ${pages}`)
+    }
+    return exec.call(this, sql)
+  })
+  await expect(openAgentSessionJournal({ identity, journalDir: root })).rejects.toThrow(/full/i)
+  vi.restoreAllMocks()
+  inspect((db) => {
+    expect(raw(db)).toEqual(original)
+    expect(db.prepare('SELECT epoch FROM journal_sessions').get()).toMatchObject({ epoch: source })
+  })
+})
+
+it.each(['database', 'row', 'v2-row'])(
+  'leaves future %s bytes read-only, including behind corruption',
+  async (axis) => {
+    inspect((db) => {
+      if (axis === 'database') {
+        db.pragma('user_version = 999')
+      } else {
+        db.prepare('UPDATE journal_rows SET row_json = ? WHERE seq = 6').run('{"v":999}')
+        if (axis === 'v2-row') {
+          db.pragma('user_version = 2')
+        }
+      }
+    })
+    const before = await readFile(journalDatabaseFile(root))
+    const journal = await open()
+    expect(journal.isReadOnly).toBe(true)
+    await expect(journal.appendItem(item('refused'), body)).rejects.toMatchObject({
+      code: 'journal_read_only'
+    })
+    await journal.close()
+    expect(await readFile(journalDatabaseFile(root))).toEqual(before)
+  }
+)
+
+it('migrates an actual v2 schema and seals its rows without rewriting them', async () => {
+  inspect((db) => {
+    db.exec(`DROP TRIGGER journal_sealed_row_insert;
+      DROP TRIGGER journal_sealed_row_update;
+      DROP TRIGGER journal_sealed_row_delete;
+      DROP TRIGGER journal_recovery_epoch_update;
+      DROP TRIGGER journal_recovery_epoch_delete;
+      DROP TABLE journal_recovery_epochs;`)
+    db.pragma('user_version = 2')
+  })
+  const journal = await open()
+  expect(journal.isReadOnly).toBe(false)
+  await journal.close()
+  inspect((db) => {
+    expect(raw(db)).toEqual(original)
+    expect(db.pragma('user_version', { simple: true })).toBe(3)
+    expect(db.prepare('SELECT count(*) AS n FROM journal_recovery_epochs').get()).toMatchObject({
+      n: 1
+    })
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-repair-generation.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-repair-generation.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import type { AgentSessionJournalIdentity } from '../../../shared/agent-session-journal-types'
 import Database from '../../sqlite/sync-database'
 import { journalDatabaseFile } from './journal-paths'
+import { replayJournal } from './journal-open'
 import { openAgentSessionJournal } from './journal-store-factory'
 import { createTrackedJournalOpener } from './journal-store-test-open'
 
@@ -34,7 +35,7 @@ function inspect<T>(run: (db: Database.Database) => T): T {
 }
 function raw(db: Database.Database, epoch = source) {
   return db
-    .prepare(`SELECT epoch, seq, ts, hex(CAST(row_json AS BLOB)) AS bytes
+    .prepare(`SELECT epoch, seq, ts, typeof(row_json) AS storage_type, hex(CAST(row_json AS BLOB)) AS bytes
     FROM journal_rows WHERE epoch = ? ORDER BY seq`)
     .all(epoch)
 }
@@ -227,4 +228,68 @@ it('migrates an actual v2 schema and seals its rows without rewriting them', asy
       n: 1
     })
   })
+})
+
+it.each([1, 6])('fences future BLOB at seq %s before replay or migration', async (seq) => {
+  for (const version of [3, 2]) {
+    inspect((db) => {
+      if (version === 2) {
+        db.exec(`DROP TRIGGER journal_sealed_row_insert;
+          DROP TRIGGER journal_sealed_row_update;
+          DROP TRIGGER journal_sealed_row_delete;
+          DROP TRIGGER journal_recovery_epoch_update;
+          DROP TRIGGER journal_recovery_epoch_delete;
+          DROP TABLE journal_recovery_epochs;`)
+      }
+      db.pragma(`user_version = ${version}`)
+      db.prepare('UPDATE journal_rows SET row_json = ? WHERE seq = ?').run(
+        Buffer.from('{"v":999}'),
+        seq
+      )
+      original = raw(db)
+    })
+    const before = await readFile(journalDatabaseFile(root))
+    const journal = await open()
+    expect(journal.isReadOnly).toBe(true)
+    await expect(journal.appendItem(item('refused'), body)).rejects.toMatchObject({
+      code: 'journal_read_only'
+    })
+    await journal.close()
+    expect(await readFile(journalDatabaseFile(root))).toEqual(before)
+    inspect((db) => {
+      expect(raw(db)).toEqual(original)
+      expect(replayJournal(db, false, identity.sessionId)?.readOnly).toBe(true)
+    })
+  }
+})
+
+it('preserves unsupported binary encoding read-only with exact type and file bytes', async () => {
+  inspect((db) => {
+    db.prepare('UPDATE journal_rows SET row_json = ? WHERE seq = 6').run(
+      Buffer.from([0, 255, 123, 195, 40])
+    )
+    expect(replayJournal(db, false, identity.sessionId)?.readOnly).toBe(true)
+    original = raw(db)
+  })
+  const before = await readFile(journalDatabaseFile(root))
+  const journal = await open()
+  expect(journal.isReadOnly).toBe(true)
+  await journal.close()
+  expect(await readFile(journalDatabaseFile(root))).toEqual(before)
+  inspect((db) => expect(raw(db)).toEqual(original))
+})
+
+it('replays supported UTF-8 BLOB prefixes and seals their original storage bytes', async () => {
+  inspect((db) => {
+    db.exec('UPDATE journal_rows SET row_json = CAST(row_json AS BLOB) WHERE seq <= 2')
+    original = raw(db)
+  })
+  const journal = await open()
+  expect(journal.isReadOnly).toBe(false)
+  expect(journal.snapshot().items.some((entry) => entry.itemId.includes('prefix'))).toBe(true)
+  await journal.replaceEpochItems('legacy_import', 2, [{ identity: item('small'), body }])
+  await journal.rollEpoch('handle_forked', 3)
+  await journal.close()
+  await open().then((reopened) => reopened.close())
+  inspect((db) => expect(raw(db)).toEqual(original))
 })

--- a/src/main/native-chat/agent-session-journal/journal-repair-generation.ts
+++ b/src/main/native-chat/agent-session-journal/journal-repair-generation.ts
@@ -1,0 +1,93 @@
+import type { AgentSessionJournalIdentity } from '../../../shared/agent-session-journal-types'
+import type Database from '../../sqlite/sync-database'
+import { replayJournal, type JournalLoad } from './journal-open'
+import { applyJournalRow, createJournalReducerState } from './journal-reducer'
+import { writeJournalRepairMarker } from './journal-repair-marker'
+import { journalRowBase } from './journal-row-builders'
+import { parseJournalRow, type JournalRow } from './journal-row-schema'
+import {
+  insertJournalRow,
+  readJournalEpochRows,
+  upsertJournalSessionRow
+} from './journal-row-table'
+
+/** Sealing, prefix admission, and publication share the journal's FULL-sync transaction. */
+export function repairJournalGeneration(input: {
+  db: Database.Database
+  identity: AgentSessionJournalIdentity
+  loaded: JournalLoad
+  epoch: string
+  now: number
+  onPublished: (loaded: JournalLoad) => void
+}): void {
+  const { db, identity, epoch, now } = input
+  const sessionId = identity.sessionId
+  const state = createJournalReducerState(sessionId, epoch)
+  db.exec('BEGIN IMMEDIATE')
+  try {
+    // Recheck under the write lock: a cached probe cannot authorize repairing another generation.
+    const current = replayJournal(db, false, sessionId)
+    if (
+      !current ||
+      current.readOnly ||
+      epoch === current.state.epoch ||
+      current.state.epoch !== input.loaded.state.epoch ||
+      current.truncateFrom !== input.loaded.truncateFrom ||
+      current.state.lastSequence !== input.loaded.state.lastSequence
+    ) {
+      throw new Error('Journal changed before repair admission')
+    }
+    const sourceEpoch = current.state.epoch
+    const prefixThrough = current.state.lastSequence
+    db.prepare(`INSERT INTO journal_recovery_epochs
+      (session_id, epoch, replacement_epoch, rejected_from, prefix_through, sealed_at, row_count, row_bytes)
+      SELECT ?, ?, ?, ?, ?, ?, count(*), coalesce(sum(length(CAST(row_json AS BLOB))), 0)
+      FROM journal_rows WHERE session_id = ? AND epoch = ?`).run(
+      sessionId,
+      sourceEpoch,
+      epoch,
+      current.truncateFrom ?? 1,
+      prefixThrough,
+      now,
+      sessionId,
+      sourceEpoch
+    )
+    const rows: JournalRow[] = []
+    for (const stored of readJournalEpochRows(db, sessionId, sourceEpoch)) {
+      if (stored.seq > prefixThrough) {
+        break
+      }
+      const parsed = parseJournalRow(stored.rowJson)
+      if (!parsed.ok) {
+        throw new Error('Journal prefix changed before repair admission')
+      }
+      rows.push({ ...parsed.row, epoch })
+    }
+    if (rows.length === 0) {
+      rows.push({
+        kind: 'epoch',
+        reason: 'unreconcilable_prefix',
+        providerHandle: identity.providerHandle,
+        ...journalRowBase(epoch, 1, current.state.highestFence, now)
+      })
+    }
+    for (const row of rows) {
+      insertJournalRow(db, sessionId, row)
+      applyJournalRow(state, row)
+    }
+    writeJournalRepairMarker(db, sessionId, epoch, state.lastSequence + 1, now)
+    upsertJournalSessionRow(db, sessionId, epoch, now)
+    db.exec('COMMIT')
+  } catch (error) {
+    if (db.isTransaction) {
+      db.exec('ROLLBACK')
+    }
+    throw error
+  }
+  input.onPublished({
+    state,
+    readOnly: false,
+    corrupt: true,
+    malformedRows: input.loaded.malformedRows
+  })
+}

--- a/src/main/native-chat/agent-session-journal/journal-repair-marker.ts
+++ b/src/main/native-chat/agent-session-journal/journal-repair-marker.ts
@@ -1,20 +1,7 @@
-// The standing demand for a rebuild that a repair leaves behind.
-//
-// A repair that empties the epoch republishes an `unreconcilable_prefix` anchor,
-// and replay reads that back as history still owed. A repair that KEEPS a prefix
-// has no such anchor to publish and — for a plain sequence gap — no malformed
-// row to disclose either, so nothing on disk would record that the deleted
-// suffix was never reconstructed. This marker is that record, written in the
-// SAME transaction as the deletion: a crash between the two would otherwise
-// leave the rows gone with nothing left asking for them back.
-//
-// It records the first sequence at which the epoch would hold content of its
-// own again, because it retires under exactly the rule the emptied-epoch anchor
-// takes: a fresh epoch carries the rebuild, and a session that writes past that
-// sequence owns the epoch and stops the retry.
+// The live generation still owes reconstruction until it writes content of its own.
+// Recovery evidence has a separate, immutable lifetime in journal_recovery_epochs.
 
 import type Database from '../../sqlite/sync-database'
-import { deleteJournalRowSuffix } from './journal-row-table'
 
 const SELECT_REPAIR = 'SELECT epoch, content_from FROM journal_repairs WHERE session_id = ?'
 const UPSERT_REPAIR = `INSERT INTO journal_repairs (session_id, epoch, content_from, repaired_at)
@@ -45,25 +32,13 @@ export function clearJournalRepairMarker(db: Database.Database, sessionId: strin
   db.prepare(DELETE_REPAIR).run(sessionId)
 }
 
-/** Drop the rejected suffix and record that it is owed, atomically. */
-export function deleteJournalRepairedSuffix(input: {
-  db: Database.Database
-  sessionId: string
-  epoch: string
-  /** First sequence of the rejected suffix. */
-  fromSeq: number
-  /** First sequence left free once the suffix is gone. */
-  contentFrom: number
+/** Record the rebuild demand inside the caller's repair-generation transaction. */
+export function writeJournalRepairMarker(
+  db: Database.Database,
+  sessionId: string,
+  epoch: string,
+  contentFrom: number,
   now: number
-}): number {
-  input.db.exec('BEGIN IMMEDIATE')
-  try {
-    const deleted = deleteJournalRowSuffix(input.db, input.sessionId, input.epoch, input.fromSeq)
-    input.db.prepare(UPSERT_REPAIR).run(input.sessionId, input.epoch, input.contentFrom, input.now)
-    input.db.exec('COMMIT')
-    return deleted
-  } catch (error) {
-    input.db.exec('ROLLBACK')
-    throw error
-  }
+): void {
+  db.prepare(UPSERT_REPAIR).run(sessionId, epoch, contentFrom, now)
 }

--- a/src/main/native-chat/agent-session-journal/journal-row-schema.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-schema.test.ts
@@ -9,6 +9,26 @@ function parse(row: Record<string, unknown>): boolean {
 }
 
 describe('journal row validation', () => {
+  it.each([null, 7, 1n, {}, new Uint8Array([255])])(
+    'fences unrepresentable raw SQLite value %s',
+    (value) => expect(parseJournalRow(value)).toEqual({ ok: false, unreadable: true })
+  )
+
+  it('uses the same version and shape rules for UTF-8 BLOB and TEXT', () => {
+    for (const text of [
+      '{"v":999}',
+      '}{',
+      JSON.stringify({
+        ...BASE,
+        kind: 'epoch',
+        reason: 'session_created',
+        providerHandle: { kind: 'codex', threadId: 'λ' }
+      })
+    ]) {
+      expect(parseJournalRow(new Uint8Array(Buffer.from(text)))).toEqual(parseJournalRow(text))
+    }
+  })
+
   it('upcasts v1 rows to the current schema without changing their body', () => {
     const parsed = parseJournalRow(
       JSON.stringify({

--- a/src/main/native-chat/agent-session-journal/journal-row-schema.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-schema.ts
@@ -111,7 +111,7 @@ export type JournalRowParse =
   | { ok: true; row: JournalRow }
   /** Malformed JSON or a shape this build rejects outright. */
   | { ok: false; unreadable: false }
-  /** A future schema version. The host must not write or compact this journal. */
+  /** A future version or unsupported encoding/type. The host must not write or compact. */
   | { ok: false; unreadable: true }
 
 const ROW_KINDS = new Set([
@@ -131,7 +131,20 @@ export function serializeJournalRow(row: JournalRow): string {
  * Parse one persisted line. Older versions are upcast; newer versions are
  * reported as unreadable so the caller fails closed.
  */
-export function parseJournalRow(line: string): JournalRowParse {
+export function parseJournalRow(value: unknown): JournalRowParse {
+  let line: string
+  if (typeof value === 'string') {
+    line = value
+  } else if (value instanceof Uint8Array) {
+    try {
+      // Decode only for admission/replay; SQLite retains the original storage type and bytes.
+      line = new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(value)
+    } catch {
+      return { ok: false, unreadable: true }
+    }
+  } else {
+    return { ok: false, unreadable: true }
+  }
   let parsed: unknown
   try {
     parsed = JSON.parse(line)

--- a/src/main/native-chat/agent-session-journal/journal-row-table.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-table.ts
@@ -8,7 +8,7 @@
 import type Database from '../../sqlite/sync-database'
 import { serializeJournalRow, type JournalRow } from './journal-row-schema'
 
-export type JournalStoredRow = { epoch: string; seq: number; ts: number; rowJson: string }
+export type JournalStoredRow = { epoch: string; seq: number; ts: number; rowJson: unknown }
 
 const SELECT_SESSION = 'SELECT epoch FROM journal_sessions WHERE session_id = ?'
 const UPSERT_SESSION = `INSERT INTO journal_sessions (session_id, epoch, updated_at)
@@ -72,7 +72,7 @@ export function deleteAllJournalRows(db: Database.Database): void {
 
 function toStoredRows(rows: readonly unknown[]): JournalStoredRow[] {
   return rows.map((entry) => {
-    const record = entry as { epoch: string; seq: number; ts: number; row_json: string }
+    const record = entry as { epoch: string; seq: number; ts: number; row_json: unknown }
     return { epoch: record.epoch, seq: record.seq, ts: record.ts, rowJson: record.row_json }
   })
 }

--- a/src/main/native-chat/agent-session-journal/journal-row-table.ts
+++ b/src/main/native-chat/agent-session-journal/journal-row-table.ts
@@ -20,7 +20,6 @@ const SELECT_EPOCH_ROWS = `SELECT epoch, seq, ts, row_json FROM journal_rows
 WHERE session_id = ? AND epoch = ? ORDER BY seq ASC`
 const SELECT_ROWS_AFTER = `SELECT epoch, seq, ts, row_json FROM journal_rows
 WHERE session_id = ? AND epoch = ? AND seq > ? ORDER BY seq ASC`
-const DELETE_SUFFIX = 'DELETE FROM journal_rows WHERE session_id = ? AND epoch = ? AND seq >= ?'
 
 export function readJournalSessionEpoch(db: Database.Database, sessionId: string): string | null {
   const row = db.prepare(SELECT_SESSION).get(sessionId) as { epoch?: string } | undefined
@@ -63,25 +62,12 @@ export function readJournalRowsAfter(
   return toStoredRows(db.prepare(SELECT_ROWS_AFTER).all(sessionId, epoch, afterSeq))
 }
 
-/**
- * Unqualified on purpose. One database per session means every row here belongs
- * to this session, and the unqualified form takes SQLite's truncate
- * optimization: measured at 0.26% of the database in WAL bytes where the
- * `WHERE session_id = ?` form rewrote every emptied leaf at up to 99%.
- */
+/** Normal rollover may reclaim live history, never sealed recovery evidence. */
 export function deleteAllJournalRows(db: Database.Database): void {
-  db.exec('DELETE FROM journal_rows')
-}
-
-/** Drop the rejected suffix a repair found, from `fromSeq` to the tip. */
-export function deleteJournalRowSuffix(
-  db: Database.Database,
-  sessionId: string,
-  epoch: string,
-  fromSeq: number
-): number {
-  const deleted = db.prepare(DELETE_SUFFIX).run(sessionId, epoch, fromSeq)
-  return Number(deleted.changes ?? 0)
+  db.exec(`DELETE FROM journal_rows WHERE NOT EXISTS (
+    SELECT 1 FROM journal_recovery_epochs AS recovery
+    WHERE recovery.session_id = journal_rows.session_id AND recovery.epoch = journal_rows.epoch
+  )`)
 }
 
 function toStoredRows(rows: readonly unknown[]): JournalStoredRow[] {

--- a/src/main/native-chat/agent-session-journal/journal-store-open.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-open.ts
@@ -32,15 +32,10 @@ export async function openJournalStoreState(input: {
   journalDir: string
   loaded: JournalLoad | null | undefined
   replay: () => JournalLoad | null
-  /** Drops the rejected suffix and records the rebuild it owes, in ONE
-   *  transaction. Corruption is not preserved; replay keeps reporting `corrupt`
-   *  until provider history republishes the epoch or the session writes past
-   *  `contentFrom`, the first sequence the repair left free. */
-  deleteSuffix: (fromSeq: number, contentFrom: number) => number
+  /** Seals the original and publishes a readable generation in one transaction. */
+  repairGeneration: (loaded: JournalLoad) => void
   start: () => void
   adopt: (loaded: JournalLoad) => void
-  /** Republishes an anchor row for an epoch a repair emptied. */
-  publishRepairEpoch: () => void
   appendItem: (
     identity: AgentJournalItemIdentity,
     body: AgentJournalItemBody,
@@ -59,16 +54,8 @@ export async function openJournalStoreState(input: {
     return
   }
   input.adopt(loaded)
-  if (loaded.truncateFrom !== undefined && !loaded.readOnly) {
-    input.deleteSuffix(loaded.truncateFrom, loaded.state.lastSequence + 1)
-  }
-  // A repair that took every live row leaves the epoch with no anchor. Publish
-  // one before anything can append into it: an ordinary row at sequence 1 would
-  // replay as a clean timeline and hide that the history was never rebuilt.
-  if (!loaded.readOnly && loaded.state.lastSequence === 0) {
-    input.publishRepairEpoch()
-    // The replacement epoch adopts a clean load; what this open's repair did is
-    // still the answer `repair` and the disclosure below owe the caller.
+  if (!loaded.readOnly && (loaded.truncateFrom !== undefined || loaded.state.lastSequence === 0)) {
+    input.repairGeneration(loaded)
     input.setMalformedRows(loaded.malformedRows)
   }
   if (input.malformedRows() > 0 && !input.readOnly()) {
@@ -76,17 +63,7 @@ export async function openJournalStoreState(input: {
     await input.appendItem(disclosure.identity, disclosure.body, input.highestFence())
   }
   await settleStaleSubagentRosters(input, loaded)
-  // Founding the epoch and appending the row are two transactions, and a
-  // committed epoch sends every later open down this branch instead. Anything
-  // that interrupts between them — a quit during startup restore, a failed
-  // append — would otherwise lose the message for good. An epoch holding nothing
-  // is exactly the state that append was owed, so offer it again.
-  //
-  // Never onto a repair, though: `loaded.state` is the PRE-repair load, so a
-  // journal this open just emptied looks identical. The repair's epoch is the
-  // marker that its history was deleted and never rebuilt, and any row that is
-  // not the repair's own disclosure retires it — this row would silently stop
-  // the session ever asking the provider for that history again.
+  // Retry a founding disclosure after a crash, but never retire a repair's rebuild marker.
   if (!loaded.corrupt && loaded.state.items.size === 0 && loaded.state.submissions.size === 0) {
     await discloseFileFormatRemnant(input)
   }

--- a/src/main/native-chat/agent-session-journal/journal-store-restore.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store-restore.ts
@@ -10,7 +10,7 @@ import type { JournalEpochController } from './journal-epoch-controller'
 import { replayJournal } from './journal-open'
 import type { JournalStoreHost } from './journal-store-collaborators'
 import { openJournalStoreState } from './journal-store-open'
-import { deleteJournalRepairedSuffix } from './journal-repair-marker'
+import { repairJournalGeneration } from './journal-repair-generation'
 
 export function restoreJournalStore(
   host: JournalStoreHost,
@@ -18,26 +18,21 @@ export function restoreJournalStore(
 ): Promise<void> {
   return openJournalStoreState({
     journalDir: host.journalDir,
-    loaded: host.loaded(),
+    loaded: host.database().readOnly ? undefined : host.loaded(),
     replay: () => {
       const opened = host.database()
       return replayJournal(opened.db, opened.readOnly, host.identity.sessionId)
     },
-    deleteSuffix: (fromSeq, contentFrom) =>
-      deleteJournalRepairedSuffix({
+    repairGeneration: (loaded) =>
+      repairJournalGeneration({
         db: host.database().db,
-        sessionId: host.identity.sessionId,
-        epoch: host.state().epoch,
-        fromSeq,
-        contentFrom,
-        now: host.now()
+        identity: host.identity,
+        loaded,
+        epoch: host.mintEpoch(),
+        now: host.now(),
+        onPublished: host.adopt
       }),
     start: () => collaborators.epochController.start('session_created', 0),
-    // `unreconcilable_prefix` is the durable statement that this epoch exists
-    // because a repair emptied one: replay reads it back and keeps asking for
-    // provider history until the timeline is rebuilt or the session writes.
-    publishRepairEpoch: () =>
-      collaborators.epochController.start('unreconcilable_prefix', host.state().highestFence),
     adopt: host.adopt,
     appendItem: (identity, body, fence) => host.journal().appendItem(identity, body, { fence }),
     agent: host.identity.agent,

--- a/src/main/native-chat/agent-session-journal/journal-store.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.test.ts
@@ -194,7 +194,7 @@ describe('replay', () => {
     expect(reopened.snapshot().items).toHaveLength(0)
   })
 
-  it('keeps the intact prefix and drops the rejected suffix', async () => {
+  it('keeps the intact prefix in a new generation and seals the rejected suffix', async () => {
     const journal = await open()
     for (let index = 0; index < 4; index += 1) {
       await journal.appendItem(item(index), body(`m${index}`), { fence: 1 })
@@ -206,12 +206,17 @@ describe('replay', () => {
     })
 
     const reopened = await open()
-    expect(reopened.epoch).toBe(before)
+    expect(reopened.epoch).not.toBe(before)
     expect(reopened.snapshot().items.map((entry) => entry.body)).toEqual([body('m0')])
     // Sequences 4 and 5 are VALID rows that the gap at 3 made unreplayable.
-    // Nothing preserves them; recovery rebuilds the epoch from provider history.
+    // The sealed epoch preserves them even if provider recovery replaces the live generation.
     await withJournalDatabase(root, (db) => {
-      const rows = db.prepare('SELECT seq FROM journal_rows ORDER BY seq').all()
+      const rows = db
+        .prepare('SELECT seq FROM journal_rows WHERE epoch = ? ORDER BY seq')
+        .all(reopened.epoch)
+      expect(
+        db.prepare('SELECT seq FROM journal_rows WHERE epoch = ? ORDER BY seq').all(before)
+      ).toHaveLength(4)
       expect(rows.map((row) => (row as { seq: number }).seq)).toEqual([1, 2])
     })
     expect(reopened.repair).toEqual({ malformedRows: 0 })

--- a/src/main/native-chat/agent-session-wire/agent-session-journal-recovery.test.ts
+++ b/src/main/native-chat/agent-session-wire/agent-session-journal-recovery.test.ts
@@ -15,6 +15,7 @@ import { openJournalDatabase } from '../agent-session-journal/journal-database'
 import { JOURNAL_DB_SCHEMA_VERSION } from '../agent-session-journal/journal-database-schema'
 import { loadJournal } from '../agent-session-journal/journal-open'
 import { journalDatabaseFile } from '../agent-session-journal/journal-paths'
+import { parseJournalRow } from '../agent-session-journal/journal-row-schema'
 import { readJournalEpochRows } from '../agent-session-journal/journal-row-table'
 import { createTrackedJournalOpener } from '../agent-session-journal/journal-store-test-open'
 import type Database from '../../sqlite/sync-database'
@@ -207,7 +208,9 @@ describe('openAgentSessionJournalWithRecovery', () => {
     // The unreadable journal is left exactly as found; a newer host still owns it.
     await withJournalDatabase(journalDir, (db) => {
       const rows = readJournalEpochRows(db, CODEX_SESSION, epoch)
-      expect(rows.some((entry) => entry.rowJson.includes('"v":99'))).toBe(true)
+      expect(
+        rows.some((entry) => typeof entry.rowJson === 'string' && entry.rowJson.includes('"v":99'))
+      ).toBe(true)
       expect(rows).toHaveLength(3)
     })
     await opened.close()
@@ -390,7 +393,10 @@ describe('openAgentSessionJournalWithRecovery', () => {
     await reopened.journal.close()
     await withJournalDatabase(journalDir, (db) => {
       const rows = readJournalEpochRows(db, CODEX_SESSION, epoch)
-      expect(JSON.parse(rows[0]?.rowJson ?? '{}')).toMatchObject({ kind: 'epoch', seq: 1 })
+      expect(parseJournalRow(rows[0]?.rowJson)).toMatchObject({
+        ok: true,
+        row: { kind: 'epoch', seq: 1 }
+      })
     })
   })
 
@@ -419,10 +425,9 @@ describe('openAgentSessionJournalWithRecovery', () => {
     await first.journal.close()
     await withJournalDatabase(journalDir, (db) => {
       const rows = readJournalEpochRows(db, CODEX_SESSION, epoch)
-      expect(JSON.parse(rows[0]?.rowJson ?? '{}')).toMatchObject({
-        kind: 'epoch',
-        seq: 1,
-        reason: 'unreconcilable_prefix'
+      expect(parseJournalRow(rows[0]?.rowJson)).toMatchObject({
+        ok: true,
+        row: { kind: 'epoch', seq: 1, reason: 'unreconcilable_prefix' }
       })
     })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​385 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​357 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​257 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​117 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​140 |

<!-- /orca-pr-loc -->

## ELI5

Opening a damaged chat journal no longer deletes the unreadable row and everything after it. Orca keeps the original bytes and opens the readable prefix in a new generation, so Orca-only receipts remain available as recovery evidence.

## What Changed

- Schema v3 records and seals original recovery epochs. A single SQLite transaction seals the source, admits the readable prefix, records the rebuild marker, and publishes the replacement epoch.
- Normal epoch replacement preserves sealed rows. SQLite triggers prevent sealed history and recovery metadata from being modified.
- Future database versions and future row versions in TEXT or valid UTF-8 BLOBs remain read-only; all retained rows are checked before migration, including behind corruption. Admission and replay share raw SQLite value decoding; invalid UTF-8 and unsupported value types conservatively refuse writes. Decoding never rewrites source bytes or storage types. Existing epoch-change resets handle held cursors without new wire fields or opcodes.

## Why

The former suffix deletion was irreversible, and provider transcripts cannot reconstruct Orca-only receipts. Sealing removes that destructive repair path while reusing the journal's atomic row/session transaction and FULL-sync durability. Failed admission refuses writable open and preserves the original rows.

## Linked Issue

[STA-6925](https://linear.app/stably/issue/STA-6925)

This is the bounded recovery foundation only. Payload clipping (STA-6924), retention and physical capacity budgeting (STA-6837), and a recovery UI remain separate work. Recovery metadata includes logical row counts/bytes; it does not claim a physical quota or reclaim sealed epochs.

## Visual Proof

N/A — SQLite storage and recovery changes; no layout or interaction surface changed. Validation used disposable journals without real provider sessions or configuration.

## Testing

Validation of the F1 fix at `885bdbb85617ba248c720073678d34e1e14b62b4`:

- Shipping suite: `pnpm exec vitest run --config config/vitest.config.ts src/main/native-chat/agent-session-journal src/main/native-chat/agent-session-wire/agent-session-journal-recovery.test.ts --maxWorkers=2` — 19 files / 216 tests passed after exact ablation restoration.
- Future UTF-8 BLOB at sequence 1 and behind corruption: read-only, append refused, original storage type/bytes and whole-file identity preserved, with schema v3 and actual v2 schema before migration. Direct replay agrees. Unsupported binary encoding remains read-only with whole-file identity.
- Original version probe now passes both baseline-v2-opener/v3 fencing and future-BLOB read-only/file identity. This uses the baseline opener module with the current SQLite adapter, not an old packaged app.
- Manual shipping-factory cases at sequence 1/3/5/6 with malformed JSON in valid UTF-8 BLOBs: two sealed generations, smaller replacement, rollover and reopen preserve type/bytes and matching SHA-256 values. Invalid UTF-8 has a different deliberate result: read-only without repair, covered by the shipping test.
- Post-commit F1 ablation restored the raw type assertion: both targeted shipping tests failed at read-only admission (2 failed / 12 skipped, exit 1). Restored by `cp`; `cmp`, nonzero decoding-code match and empty source diff confirmed exact restoration.
- Final node, web and CLI checks passed sequentially using `npx tsc --noEmit -p config/tsconfig.node.json`, then `config/tsconfig.tc.web.json`, then `config/tsconfig.tc.cli.json`. Initial node failures in three recovery-test assertions were fixed by handling raw values; final checks have no diagnostics. Commit lint/format hooks passed.
- Existing suite also covers five abrupt child-process exits, SQLite `max_page_count` exhaustion, migration, repair markers and immutable evidence. Process exits are not hardware power loss; page limits are not host-volume exhaustion.

No Electron rendering/build, real provider sessions/profiles, Linux, Windows, WSL, live SSH, folder/worktree UI journey, mobile or packaged client/host version pairings were exercised. No transport behavior changed. Main advanced to `588240043e84b1f8e58013298e692e7a57ba8ad5`; merging was prohibited, so integration with that main is unvalidated.

## Review

Draft for a fresh independent architectural and implementation review; no readiness claim. Please challenge whether sealing plus prefix publication removes the data-loss mechanism and whether preservation survives every later epoch replacement.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer material is included.

