### PR TITLE
perf(workspaces): fold Turkish dotted I without offset maps

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11,6 +11,81 @@
   },
   "gates": [
     {
+      "id": "workspace-performance.unicode-snippet-fold-cache",
+      "title": "Workspace terminal search reuses Unicode offset maps within live metadata",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "workspace-ui",
+      "layer": "renderer-unit",
+      "surfaces": ["workspace jump palette", "local terminal tab search"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local"],
+      "coverageNotes": "Actual production metadata builder/search and pure matcher tests run on macOS. Local and host-filtered workspace searches use the same string matcher. Folder/git identity, execution authority, remote wire content and mobile UI are unchanged; no live remote session was launched.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/blob/main/.agents/skills/perf/SKILL.md"
+      ],
+      "invariant": "Workspace terminal snippet results, source/pane/text priority and exact UTF-16 highlight offsets remain unchanged while each distinct length-expanding Unicode string is folded at most once per live metadata snapshot. Discarded metadata must remain collectable.",
+      "oracle": "Duplicate Unicode history strings normalize once on the first unmatched query and zero times on subsequent queries. Later strings fold only when earlier candidates fail. Replacement snapshots, token coverage, punctuation, provider-only text, Unicode offsets and metadata collection preserve behavior; ASCII performs no folding.",
+      "commands": [
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/workspace-tab-agent-metadata.test.ts src/renderer/src/lib/workspace-tab-palette-search.test.ts src/renderer/src/lib/workspace-tab-palette-results.test.ts"
+      ],
+      "testFiles": [
+        "src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts",
+        "src/renderer/src/lib/workspace-tab-agent-metadata.test.ts",
+        "src/renderer/src/lib/workspace-tab-palette-search.test.ts",
+        "src/renderer/src/lib/workspace-tab-palette-results.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts",
+          "assertions": [
+            "folds each distinct Unicode prompt once across searches of accumulated history",
+            "normalizes later candidates only when earlier candidates fail",
+            "keeps case expansion offsets and merged highlights stable across query edits",
+            "uses rebuilt metadata independently of the previous snapshot with the same pane id",
+            "does not retain metadata after its palette entries are released"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-09-07",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/workspace-tab-agent-metadata.test.ts src/renderer/src/lib/workspace-tab-palette-search.test.ts src/renderer/src/lib/workspace-tab-palette-results.test.ts",
+          "result": "passed",
+          "durationSeconds": 0.462,
+          "summary": "55 tests across four matcher/metadata/search/result files passed. Independent repeat passed the same 55 tests in 720 ms."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 15,
+        "scope": "Focused matcher and production search-contract suites; local runtime budget, not an established p95."
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "Initial local validation; forced-GC oracle remains experimental pending CI soak."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "Baseline fails two normalization budgets: 40 calls instead of 10, and two instead of one when changing the query. Candidate passes both. Implementation differential matched 34,112 exact results; independent comparison matched 14,250, including 5,250 same-array mutation checks and four literal Unicode-offset oracles. Independent GC proves a retained returned match does not pin the metadata key."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Full production search with capped 200-character prompts and 20 history rows: 400 all-Unicode tabs unmatched 189.17 to 6.95 ms warm, 188.38 to 56.64 ms with fresh metadata; 2,000 tabs/10% Unicode 106.75 to 18.04 ms warm, 118.00 to 42.75 ms fresh. Fresh first-prompt match at 400 Unicode tabs 5.43 to 5.53 ms. ASCII full unmatched search 5.567 to 5.505 ms; no ASCII gain claimed and no cache accesses. 400 all-Unicode tabs retain 4,245,152 heap plus 7,075,200 offset-buffer bytes; 2,000 tabs/10% Unicode retain 2,207,456 plus 3,537,600 bytes. All offset buffers release with metadata. Cache is bounded by distinct Unicode text in live immutable metadata, not by query count; no fixed byte cap. Eager preparation was rejected due to cold-query regressions."
+      },
+      "knownGaps": [
+        "No rendered Electron input/frame-latency measurement or live SSH/WSL/Linux/Windows journey. Unicode fixture intentionally includes Turkish uppercase dotted I; prevalence is not production telemetry.",
+        "Caching trades temporary open-palette memory for CPU; future in-place growth of metadata strings would retain old folds until that array is discarded, although current producers publish fresh snapshots."
+      ],
+      "promotionCriteria": [
+        "Complete CI soak with zero unexplained flakes and preserve the observable oracle."
+      ],
+      "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing matching, offset, collection or work-count assertions."
+    },
+    {
       "id": "terminal-performance.padded-fullscreen-redraw",
       "title": "Fullscreen redraw padding does not stall terminal delivery",
       "maturity": "experimental",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -11,8 +11,8 @@
   },
   "gates": [
     {
-      "id": "workspace-performance.unicode-snippet-fold-cache",
-      "title": "Workspace terminal search reuses Unicode offset maps within live metadata",
+      "id": "workspace-performance.dotted-i-offset-free-fold",
+      "title": "Palette case folding stays offset-preserving for Turkish dotted I",
       "maturity": "experimental",
       "protection": "partial",
       "owner": "workspace-ui",
@@ -22,33 +22,33 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local"],
-      "coverageNotes": "Actual production metadata builder/search and pure matcher tests run on macOS. Local and host-filtered workspace searches use the same string matcher. Folder/git identity, execution authority, remote wire content and mobile UI are unchanged; no live remote session was launched.",
+      "coverageNotes": "Pure matcher and query-preparation tests run on macOS. Local, folder/git and host-filtered workspace searches share this string matcher. Execution authority, remote wire content and mobile UI are unchanged.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/blob/main/.agents/skills/perf/SKILL.md"
       ],
-      "invariant": "Workspace terminal snippet results, source/pane/text priority and exact UTF-16 highlight offsets remain unchanged while each distinct length-expanding Unicode string is folded at most once per live metadata snapshot. Discarded metadata must remain collectable.",
-      "oracle": "Duplicate Unicode history strings normalize once on the first unmatched query and zero times on subsequent queries. Later strings fold only when earlier candidates fail. Replacement snapshots, token coverage, punctuation, provider-only text, Unicode offsets and metadata collection preserve behavior; ASCII performs no folding.",
+      "invariant": "U+0130 folds to a single `i`, so palette case folding never changes UTF-16 length and match offsets map back to the original text by identity. `Istanbul`, `istanbul` and `İstanbul` all match an `İstanbul` candidate with the same highlight range.",
+      "oracle": "normalizePaletteText('İstanbul İŞLEM') yields 'istanbul işlem' with null offset maps and identity range mapping; the agent-snippet matcher returns the same candidate and the same literal UTF-16 highlight range for every casing of a dotted-I query, across scripts whose lowercase already preserved offsets.",
       "commands": [
-        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/workspace-tab-agent-metadata.test.ts src/renderer/src/lib/workspace-tab-palette-search.test.ts src/renderer/src/lib/workspace-tab-palette-results.test.ts"
+        "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/palette-match/palette-match-core.test.ts src/renderer/src/components/cmd-j/palette-query-tokens.test.ts"
       ],
       "testFiles": [
         "src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts",
-        "src/renderer/src/lib/workspace-tab-agent-metadata.test.ts",
-        "src/renderer/src/lib/workspace-tab-palette-search.test.ts",
-        "src/renderer/src/lib/workspace-tab-palette-results.test.ts"
+        "src/renderer/src/lib/palette-match/palette-match-core.test.ts",
+        "src/renderer/src/components/cmd-j/palette-query-tokens.test.ts"
       ],
       "assertionRefs": [
         {
           "file": "src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts",
           "assertions": [
-            "folds each distinct Unicode prompt once across searches of accumulated history",
-            "normalizes later candidates only when earlier candidates fail",
-            "keeps case expansion offsets and merged highlights stable across query edits",
-            "uses rebuilt metadata independently of the previous snapshot with the same pane id",
-            "does not retain metadata after its palette entries are released",
-            "does not retain metadata pinned by a match the caller still holds",
-            "skips folding for scripts whose lowercase preserves code-unit offsets"
+            "matches Turkish dotted I from either casing and keeps literal source offsets",
+            "keeps highlight offsets and merged ranges stable across query edits",
+            "folds case for every script without shifting highlight offsets",
+            "reflects in-place candidate edits on the same metadata array"
           ]
+        },
+        {
+          "file": "src/renderer/src/lib/palette-match/palette-match-core.test.ts",
+          "assertions": ["folds Turkish dotted I to a plain i without shifting offsets"]
         }
       ],
       "evidenceRuns": [
@@ -56,36 +56,37 @@
           "date": "2026-09-07",
           "runner": "local",
           "platform": "macos",
-          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/workspace-tab-agent-metadata.test.ts src/renderer/src/lib/workspace-tab-palette-search.test.ts src/renderer/src/lib/workspace-tab-palette-results.test.ts",
+          "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/palette-match/palette-match-core.test.ts src/renderer/src/components/cmd-j/palette-query-tokens.test.ts",
           "result": "passed",
-          "durationSeconds": 2.82,
-          "summary": "57 tests across four matcher/metadata/search/result files passed, including a retained-match GC oracle and a non-expanding-script no-fold oracle. Independent repeat passed the same 57 tests in 720 ms."
+          "durationSeconds": 1.46,
+          "summary": "70 tests across the agent-snippet matcher, palette normalization/matching core and query-token suites passed, covering the dotted-I fold, identity offset mapping and cross-script highlight offsets."
         }
       ],
       "runtimeBudget": {
         "p95Seconds": 15,
-        "scope": "Focused matcher and production search-contract suites; local runtime budget, not an established p95."
+        "scope": "Focused matcher, normalization and query-token suites; local runtime budget, not an established p95."
       },
       "flakeHistory": {
         "status": "not-started",
-        "evidence": "Initial local validation; forced-GC oracle remains experimental pending CI soak."
+        "evidence": "Initial local validation; no CI soak yet. The oracle is deterministic with no timing or GC dependency."
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "Baseline fails two normalization budgets: 40 calls instead of 10, and two instead of one when changing the query. Candidate passes both. Implementation differential matched 34,112 exact results; independent comparison matched 14,250, including 5,250 same-array mutation checks and four literal Unicode-offset oracles. Independent GC proves a retained returned match does not pin the metadata key."
+        "evidence": "Pre-change code fails the dotted-I oracle: candidate `İstanbul Terminal` with query `istanbul` returned null, and normalizePaletteText('İstanbul') produced a 9-code-unit fold with populated Int32Array offset maps. A differential over 295,557 randomized comparisons (ASCII, CJK, Cyrillic, Greek, NFC and NFD Latin, emoji, astral, U+0130) found zero differences from the pre-PR baseline across 118,231 comparisons of dotted-I-free corpora, and differences only in dotted-I cases otherwise. An exhaustive scan of all 1,112,064 non-surrogate code points confirms U+0130 is the only code point whose toLowerCase lengthens a string and that none shrink, so after this fold no palette text can change length.",
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Full production search with capped 200-character prompts and 20 history rows: 400 all-Unicode tabs unmatched 189.17 to 6.95 ms warm, 188.38 to 56.64 ms with fresh metadata; 2,000 tabs/10% Unicode 106.75 to 18.04 ms warm, 118.00 to 42.75 ms fresh. Fresh first-prompt match at 400 Unicode tabs 5.43 to 5.53 ms. ASCII full unmatched search 5.567 to 5.505 ms; no ASCII gain claimed and no cache accesses. 400 all-Unicode tabs retain 4,245,152 heap plus 7,075,200 offset-buffer bytes; 2,000 tabs/10% Unicode retain 2,207,456 plus 3,537,600 bytes. All offset buffers release with metadata. Cache is bounded by distinct Unicode text in live immutable metadata, not by query count; no fixed byte cap. Eager preparation was rejected due to cold-query regressions."
+        "evidence": "Full agent-snippet search over 400 tabs x 21 rows x 200 characters (medians of 15 runs, macOS/Node): 100% dotted-I text with distinct history 1296.48 ms before, 12.27 ms after; the same fixture with duplicated history 925.52 ms before, 15.70 ms after; 10% dotted-I 31.13 ms before, 1.86 ms after; ASCII-only control 0.85 ms before, 0.89 ms after (unchanged, no folding on either side). Retained heap after one search on the 100%-dotted-I fixture drops from 8,052,768 bytes of cached offset maps to zero; this tier now allocates no Int32Array at all. Fixture measurements, not Electron frame times or production language prevalence."
       },
       "knownGaps": [
-        "No rendered Electron input/frame-latency measurement or live SSH/WSL/Linux/Windows journey. Scope is narrow by construction: U+0130 is the only code point whose toLowerCase lengthens, so folding, the cache and its memory are unreachable for ASCII, CJK, Cyrillic, Greek, accented Latin and emoji. The fixture is therefore Turkish/Azerbaijani-specific and its speedup does not generalize; prevalence is not production telemetry.",
-        "Caching trades temporary open-palette memory for CPU; future in-place growth of metadata strings would retain old folds until that array is discarded, although current producers publish fresh snapshots."
+        "No rendered Electron input/frame-latency measurement and no live SSH/WSL/Linux/Windows journey.",
+        "Semantic change: U+0130 now folds to `i` instead of `i` + U+0307 palette-wide, so literal `i` + U+0307 text no longer matches an `İ` query and NFC composition no longer runs over dotted-I agent snippets. Both were previously reachable only because dotted-I text took a different folding path than every other script.",
+        "Structured palette fields still build Int32Array offset maps when NFC composition shrinks text; only case folding is now guaranteed offset-preserving."
       ],
       "promotionCriteria": [
-        "Complete CI soak with zero unexplained flakes and preserve the observable oracle."
+        "Complete CI soak with zero unexplained flakes and preserve the offset and cross-casing oracles."
       ],
-      "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing matching, offset, collection or work-count assertions."
+      "demotionRule": "Keep experimental until CI soak; investigate failures without relaxing matching or offset assertions."
     },
     {
       "id": "terminal-performance.padded-fullscreen-redraw",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -45,7 +45,9 @@
             "normalizes later candidates only when earlier candidates fail",
             "keeps case expansion offsets and merged highlights stable across query edits",
             "uses rebuilt metadata independently of the previous snapshot with the same pane id",
-            "does not retain metadata after its palette entries are released"
+            "does not retain metadata after its palette entries are released",
+            "does not retain metadata pinned by a match the caller still holds",
+            "skips folding for scripts whose lowercase preserves code-unit offsets"
           ]
         }
       ],
@@ -56,8 +58,8 @@
           "platform": "macos",
           "command": "ORCA_BACKGROUND_LAUNCH=1 pnpm test src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts src/renderer/src/lib/workspace-tab-agent-metadata.test.ts src/renderer/src/lib/workspace-tab-palette-search.test.ts src/renderer/src/lib/workspace-tab-palette-results.test.ts",
           "result": "passed",
-          "durationSeconds": 0.462,
-          "summary": "55 tests across four matcher/metadata/search/result files passed. Independent repeat passed the same 55 tests in 720 ms."
+          "durationSeconds": 2.82,
+          "summary": "57 tests across four matcher/metadata/search/result files passed, including a retained-match GC oracle and a non-expanding-script no-fold oracle. Independent repeat passed the same 57 tests in 720 ms."
         }
       ],
       "runtimeBudget": {
@@ -77,7 +79,7 @@
         "evidence": "Full production search with capped 200-character prompts and 20 history rows: 400 all-Unicode tabs unmatched 189.17 to 6.95 ms warm, 188.38 to 56.64 ms with fresh metadata; 2,000 tabs/10% Unicode 106.75 to 18.04 ms warm, 118.00 to 42.75 ms fresh. Fresh first-prompt match at 400 Unicode tabs 5.43 to 5.53 ms. ASCII full unmatched search 5.567 to 5.505 ms; no ASCII gain claimed and no cache accesses. 400 all-Unicode tabs retain 4,245,152 heap plus 7,075,200 offset-buffer bytes; 2,000 tabs/10% Unicode retain 2,207,456 plus 3,537,600 bytes. All offset buffers release with metadata. Cache is bounded by distinct Unicode text in live immutable metadata, not by query count; no fixed byte cap. Eager preparation was rejected due to cold-query regressions."
       },
       "knownGaps": [
-        "No rendered Electron input/frame-latency measurement or live SSH/WSL/Linux/Windows journey. Unicode fixture intentionally includes Turkish uppercase dotted I; prevalence is not production telemetry.",
+        "No rendered Electron input/frame-latency measurement or live SSH/WSL/Linux/Windows journey. Scope is narrow by construction: U+0130 is the only code point whose toLowerCase lengthens, so folding, the cache and its memory are unreachable for ASCII, CJK, Cyrillic, Greek, accented Latin and emoji. The fixture is therefore Turkish/Azerbaijani-specific and its speedup does not generalize; prevalence is not production telemetry.",
         "Caching trades temporary open-palette memory for CPU; future in-place growth of metadata strings would retain old folds until that array is discarded, although current producers publish fresh snapshots."
       ],
       "promotionCriteria": [

--- a/src/renderer/src/lib/palette-match/normalized-text.ts
+++ b/src/renderer/src/lib/palette-match/normalized-text.ts
@@ -23,9 +23,16 @@ function isCombiningMark(codePoint: number): boolean {
   return COMBINING_MARK.test(String.fromCodePoint(codePoint))
 }
 
-function foldChunk(chunk: string): string {
+// U+0130 is the only code point in Unicode whose `toLowerCase` lengthens the string, and
+// none shrink. Folding it to the Turkish-locale 'i' keeps every case fold offset-preserving.
+const DOTTED_CAPITAL_I = 0x130
+
+function foldChunk(chunk: string, codePoint: number): string {
   if (UNICODE_SPACE.test(chunk) && chunk.trim() === '') {
     return ' '
+  }
+  if (codePoint === DOTTED_CAPITAL_I) {
+    return `i${chunk.slice(1).normalize('NFC').toLowerCase()}`
   }
   return chunk.normalize('NFC').toLowerCase()
 }
@@ -61,7 +68,7 @@ export function normalizePaletteText(original: string): NormalizedText {
       end += next > 0xffff ? 2 : 1
     }
 
-    const folded = foldChunk(original.slice(index, end))
+    const folded = foldChunk(original.slice(index, end), codePoint)
     if (folded.length !== end - index) {
       identity = false
     }

--- a/src/renderer/src/lib/palette-match/palette-match-core.test.ts
+++ b/src/renderer/src/lib/palette-match/palette-match-core.test.ts
@@ -130,6 +130,15 @@ describe('normalization and ranges', () => {
     )
   })
 
+  it('folds Turkish dotted I to a plain i without shifting offsets', () => {
+    const text = normalizePaletteText('İstanbul İŞLEM')
+    expect(text.normalized).toBe('istanbul işlem')
+    expect(text.starts).toBeNull()
+    expect(mapNormalizedRange(text, 9, 14)).toEqual({ start: 9, end: 14 })
+    expect(ready('İstanbul').tokens[0].text).toBe('istanbul')
+    expect(ready('istanbul').tokens[0].text).toBe('istanbul')
+  })
+
   it('folds ASCII control whitespace without shifting offsets', () => {
     const text = normalizePaletteText('line one\nline two')
     expect(text.normalized).toBe('line one line two')

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts
@@ -2,7 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as normalizedText from './palette-match/normalized-text'
 import { preparePaletteTabQuery } from './palette-match/tab-match'
 import type { AgentMetadata } from './workspace-tab-agent-metadata'
-import { matchWorkspaceTabAgentSnippet } from './workspace-tab-agent-snippet-match'
+import {
+  matchWorkspaceTabAgentSnippet,
+  type WorkspaceTabAgentSnippetMatch
+} from './workspace-tab-agent-snippet-match'
 
 function metadata(snippetCandidates: string[], textParts: string[] = []): AgentMetadata {
   return { paneKey: 'terminal:leaf', snippetCandidates, textParts, lastActivityAt: 1 }
@@ -14,6 +17,22 @@ function query(text: string) {
     throw new Error(`Invalid test query: ${text}`)
   }
   return prepared
+}
+
+/** Drains microtasks between forced collections so a released array cannot linger on a stack slot. */
+async function collect(reference: WeakRef<AgentMetadata[]>): Promise<AgentMetadata[] | undefined> {
+  const gc = global.gc
+  if (!gc) {
+    throw new Error('This test requires --expose-gc')
+  }
+  for (let i = 0; i < 10; i++) {
+    await new Promise<void>((resolve) => setImmediate(resolve))
+    gc()
+    if (!reference.deref()) {
+      break
+    }
+  }
+  return reference.deref()
 }
 
 afterEach(() => vi.restoreAllMocks())
@@ -100,24 +119,41 @@ describe('workspace terminal agent snippet search', () => {
     expect(matchWorkspaceTabAgentSnippet(previous, query('nebula'))).toBeNull()
   })
 
+  it('skips folding for scripts whose lowercase preserves code-unit offsets', () => {
+    const entries = [
+      metadata([
+        'ЗАПУСТИТЬ ТЕРМИНАЛ СЕЙЧАС',
+        '终端任务调查报告',
+        'ÉCRIRE UN TEST ÀÉÎÔÜ',
+        'ΕΛΛΗΝΙΚΆ ΚΕΊΜΕΝΟ',
+        '🚀 emoji terminal 🎉',
+        'ＦＵＬＬＷＩＤＴＨ ＴＥＸＴ'
+      ])
+    ]
+    const prepared = query('missing')
+    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
+    expect(matchWorkspaceTabAgentSnippet(entries, prepared)).toBeNull()
+    expect(normalize).not.toHaveBeenCalled()
+  })
+
   it('does not retain metadata after its palette entries are released', async () => {
-    const gc = global.gc
-    if (!gc) {
-      throw new Error('This test requires --expose-gc')
-    }
     function searchTransientEntries(): WeakRef<AgentMetadata[]> {
       const entries = [metadata(['Transient Terminal İnvestigation'])]
       matchWorkspaceTabAgentSnippet(entries, query('missing'))
       return new WeakRef(entries)
     }
-    const reference = searchTransientEntries()
-    for (let i = 0; i < 10; i++) {
-      await new Promise<void>((resolve) => setImmediate(resolve))
-      gc()
-      if (!reference.deref()) {
-        break
-      }
+    expect(await collect(searchTransientEntries())).toBeUndefined()
+  })
+
+  it('does not retain metadata pinned by a match the caller still holds', async () => {
+    let retained: WorkspaceTabAgentSnippetMatch | null = null
+    function searchTransientEntries(): WeakRef<AgentMetadata[]> {
+      const entries = [metadata(['Retained İnvestigation atlas'])]
+      retained = matchWorkspaceTabAgentSnippet(entries, query('atlas'))
+      return new WeakRef(entries)
     }
-    expect(reference.deref()).toBeUndefined()
+    const reference = searchTransientEntries()
+    expect(await collect(reference)).toBeUndefined()
+    expect(retained).not.toBeNull()
   })
 })

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts
@@ -1,11 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import * as normalizedText from './palette-match/normalized-text'
+import { describe, expect, it } from 'vitest'
 import { preparePaletteTabQuery } from './palette-match/tab-match'
 import type { AgentMetadata } from './workspace-tab-agent-metadata'
-import {
-  matchWorkspaceTabAgentSnippet,
-  type WorkspaceTabAgentSnippetMatch
-} from './workspace-tab-agent-snippet-match'
+import { matchWorkspaceTabAgentSnippet } from './workspace-tab-agent-snippet-match'
 
 function metadata(snippetCandidates: string[], textParts: string[] = []): AgentMetadata {
   return { paneKey: 'terminal:leaf', snippetCandidates, textParts, lastActivityAt: 1 }
@@ -19,53 +15,7 @@ function query(text: string) {
   return prepared
 }
 
-/** Drains microtasks between forced collections so a released array cannot linger on a stack slot. */
-async function collect(reference: WeakRef<AgentMetadata[]>): Promise<AgentMetadata[] | undefined> {
-  const gc = global.gc
-  if (!gc) {
-    throw new Error('This test requires --expose-gc')
-  }
-  for (let i = 0; i < 10; i++) {
-    await new Promise<void>((resolve) => setImmediate(resolve))
-    gc()
-    if (!reference.deref()) {
-      break
-    }
-  }
-  return reference.deref()
-}
-
-afterEach(() => vi.restoreAllMocks())
-
 describe('workspace terminal agent snippet search', () => {
-  it('folds each distinct Unicode prompt once across searches of accumulated history', () => {
-    const histories = Array.from({ length: 10 }, (_, i) => `Task ${i}: İnvestigate terminal input`)
-    const repeated = histories.flatMap((text) => [text, text])
-    const entries = [metadata(repeated, [...repeated, 'codex', 'working'])]
-    const firstQuery = query('missing')
-    const secondQuery = query('absent')
-    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
-
-    expect(matchWorkspaceTabAgentSnippet(entries, firstQuery)).toBeNull()
-    expect(normalize).toHaveBeenCalledTimes(10)
-    normalize.mockClear()
-    expect(matchWorkspaceTabAgentSnippet(entries, secondQuery)).toBeNull()
-    expect(normalize).not.toHaveBeenCalled()
-  })
-
-  it('normalizes later candidates only when earlier candidates fail', () => {
-    const entries = [metadata(['First İnvestigation', 'Second İnvestigation'])]
-    const firstQuery = query('first')
-    const secondQuery = query('second')
-    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
-
-    expect(matchWorkspaceTabAgentSnippet(entries, firstQuery)?.text).toBe('First İnvestigation')
-    expect(normalize).toHaveBeenCalledTimes(1)
-    normalize.mockClear()
-    expect(matchWorkspaceTabAgentSnippet(entries, secondQuery)?.text).toBe('Second İnvestigation')
-    expect(normalize).toHaveBeenCalledTimes(1)
-  })
-
   it('preserves source, pane, and text priority across duplicate candidates', () => {
     const entries = [
       metadata(['unrelated', 'unrelated'], ['Earlier pane atlas provider']),
@@ -82,7 +32,18 @@ describe('workspace terminal agent snippet search', () => {
     expect(matchWorkspaceTabAgentSnippet(entries, query('sess-unique'))?.text).toBe('sess-unique')
   })
 
-  it('keeps case expansion offsets and merged highlights stable across query edits', () => {
+  it('matches Turkish dotted I from either casing and keeps literal source offsets', () => {
+    const entries = [metadata(['İstanbul Terminal'])]
+    for (const text of ['istanbul', 'İstanbul', 'ISTANBUL']) {
+      expect(matchWorkspaceTabAgentSnippet(entries, query(text))).toMatchObject({
+        text: 'İstanbul Terminal',
+        ranges: [{ start: 0, end: 8 }]
+      })
+    }
+    expect('İstanbul Terminal'.slice(0, 8)).toBe('İstanbul')
+  })
+
+  it('keeps highlight offsets and merged ranges stable across query edits', () => {
     const entries = [metadata(['İstanbul Terminal'])]
     expect(matchWorkspaceTabAgentSnippet(entries, query('terminal'))?.ranges).toEqual([
       { start: 9, end: 17 }
@@ -98,12 +59,9 @@ describe('workspace terminal agent snippet search', () => {
     expect(matchWorkspaceTabAgentSnippet(entries, query('verify input'))?.text).toBe('Verify input')
   })
 
-  it('keeps the cheap path for offset-preserving text and rejects punctuation tokens', () => {
+  it('rejects punctuation-only tokens before scanning candidates', () => {
     const entries = [metadata(['Terminal --- output'])]
-    const prepared = query('terminal ---')
-    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
-    expect(matchWorkspaceTabAgentSnippet(entries, prepared)).toBeNull()
-    expect(normalize).not.toHaveBeenCalled()
+    expect(matchWorkspaceTabAgentSnippet(entries, query('terminal ---'))).toBeNull()
   })
 
   it('uses rebuilt metadata independently of the previous snapshot with the same pane id', () => {
@@ -119,41 +77,31 @@ describe('workspace terminal agent snippet search', () => {
     expect(matchWorkspaceTabAgentSnippet(previous, query('nebula'))).toBeNull()
   })
 
-  it('skips folding for scripts whose lowercase preserves code-unit offsets', () => {
-    const entries = [
-      metadata([
-        'ЗАПУСТИТЬ ТЕРМИНАЛ СЕЙЧАС',
-        '终端任务调查报告',
-        'ÉCRIRE UN TEST ÀÉÎÔÜ',
-        'ΕΛΛΗΝΙΚΆ ΚΕΊΜΕΝΟ',
-        '🚀 emoji terminal 🎉',
-        'ＦＵＬＬＷＩＤＴＨ ＴＥＸＴ'
-      ])
+  it('reflects in-place candidate edits on the same metadata array', () => {
+    const entries = [metadata(['Original atlas prompt İnvestigation'])]
+    expect(matchWorkspaceTabAgentSnippet(entries, query('atlas'))).not.toBeNull()
+    entries[0].snippetCandidates[0] = 'Replaced nebula prompt İnvestigation'
+    expect(matchWorkspaceTabAgentSnippet(entries, query('atlas'))).toBeNull()
+    expect(matchWorkspaceTabAgentSnippet(entries, query('nebula'))?.text).toBe(
+      'Replaced nebula prompt İnvestigation'
+    )
+  })
+
+  it('folds case for every script without shifting highlight offsets', () => {
+    const cases: [string, string, string][] = [
+      ['ЗАПУСТИТЬ ТЕРМИНАЛ СЕЙЧАС', 'терминал', 'ТЕРМИНАЛ'],
+      ['ΕΛΛΗΝΙΚΆ ΚΕΊΜΕΝΟ', 'κείμενο', 'ΚΕΊΜΕΝΟ'],
+      ['ÉCRIRE UN TEST ÀÉÎÔÜ', 'àéîôü', 'ÀÉÎÔÜ'],
+      ['终端任务调查报告', '终端任务', '终端任务'],
+      ['🚀 emoji terminal 🎉', 'terminal', 'terminal'],
+      ['ＦＵＬＬＷＩＤＴＨ ＴＥＸＴ', 'ｔｅｘｔ', 'ＴＥＸＴ'],
+      ['İstanbul İŞLEM', 'işlem', 'İŞLEM']
     ]
-    const prepared = query('missing')
-    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
-    expect(matchWorkspaceTabAgentSnippet(entries, prepared)).toBeNull()
-    expect(normalize).not.toHaveBeenCalled()
-  })
-
-  it('does not retain metadata after its palette entries are released', async () => {
-    function searchTransientEntries(): WeakRef<AgentMetadata[]> {
-      const entries = [metadata(['Transient Terminal İnvestigation'])]
-      matchWorkspaceTabAgentSnippet(entries, query('missing'))
-      return new WeakRef(entries)
+    for (const [text, queryText, expected] of cases) {
+      const match = matchWorkspaceTabAgentSnippet([metadata([text])], query(queryText))
+      expect(match).not.toBeNull()
+      const range = (match as NonNullable<typeof match>).ranges[0]
+      expect(text.slice(range.start, range.end)).toBe(expected)
     }
-    expect(await collect(searchTransientEntries())).toBeUndefined()
-  })
-
-  it('does not retain metadata pinned by a match the caller still holds', async () => {
-    let retained: WorkspaceTabAgentSnippetMatch | null = null
-    function searchTransientEntries(): WeakRef<AgentMetadata[]> {
-      const entries = [metadata(['Retained İnvestigation atlas'])]
-      retained = matchWorkspaceTabAgentSnippet(entries, query('atlas'))
-      return new WeakRef(entries)
-    }
-    const reference = searchTransientEntries()
-    expect(await collect(reference)).toBeUndefined()
-    expect(retained).not.toBeNull()
   })
 })

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as normalizedText from './palette-match/normalized-text'
+import { preparePaletteTabQuery } from './palette-match/tab-match'
+import type { AgentMetadata } from './workspace-tab-agent-metadata'
+import { matchWorkspaceTabAgentSnippet } from './workspace-tab-agent-snippet-match'
+
+function metadata(snippetCandidates: string[], textParts: string[] = []): AgentMetadata {
+  return { paneKey: 'terminal:leaf', snippetCandidates, textParts, lastActivityAt: 1 }
+}
+
+function query(text: string) {
+  const prepared = preparePaletteTabQuery(text)
+  if (!prepared) {
+    throw new Error(`Invalid test query: ${text}`)
+  }
+  return prepared
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('workspace terminal agent snippet search', () => {
+  it('folds each distinct Unicode prompt once across searches of accumulated history', () => {
+    const histories = Array.from({ length: 10 }, (_, i) => `Task ${i}: İnvestigate terminal input`)
+    const repeated = histories.flatMap((text) => [text, text])
+    const entries = [metadata(repeated, [...repeated, 'codex', 'working'])]
+    const firstQuery = query('missing')
+    const secondQuery = query('absent')
+    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
+
+    expect(matchWorkspaceTabAgentSnippet(entries, firstQuery)).toBeNull()
+    expect(normalize).toHaveBeenCalledTimes(10)
+    normalize.mockClear()
+    expect(matchWorkspaceTabAgentSnippet(entries, secondQuery)).toBeNull()
+    expect(normalize).not.toHaveBeenCalled()
+  })
+
+  it('normalizes later candidates only when earlier candidates fail', () => {
+    const entries = [metadata(['First İnvestigation', 'Second İnvestigation'])]
+    const firstQuery = query('first')
+    const secondQuery = query('second')
+    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
+
+    expect(matchWorkspaceTabAgentSnippet(entries, firstQuery)?.text).toBe('First İnvestigation')
+    expect(normalize).toHaveBeenCalledTimes(1)
+    normalize.mockClear()
+    expect(matchWorkspaceTabAgentSnippet(entries, secondQuery)?.text).toBe('Second İnvestigation')
+    expect(normalize).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves source, pane, and text priority across duplicate candidates', () => {
+    const entries = [
+      metadata(['unrelated', 'unrelated'], ['Earlier pane atlas provider']),
+      metadata(['Later pane atlas task', 'Another atlas task'], ['unrelated'])
+    ]
+    expect(matchWorkspaceTabAgentSnippet(entries, query('atlas'))).toMatchObject({
+      text: 'Later pane atlas task',
+      ranges: [{ start: 11, end: 16 }]
+    })
+  })
+
+  it('keeps provider-only text searchable after snippet candidates fail', () => {
+    const entries = [metadata(['Terminal task'], ['Terminal task', 'session_id', 'sess-unique'])]
+    expect(matchWorkspaceTabAgentSnippet(entries, query('sess-unique'))?.text).toBe('sess-unique')
+  })
+
+  it('keeps case expansion offsets and merged highlights stable across query edits', () => {
+    const entries = [metadata(['İstanbul Terminal'])]
+    expect(matchWorkspaceTabAgentSnippet(entries, query('terminal'))?.ranges).toEqual([
+      { start: 9, end: 17 }
+    ])
+    expect(matchWorkspaceTabAgentSnippet(entries, query('İstanbul stan'))?.ranges).toEqual([
+      { start: 0, end: 8 }
+    ])
+  })
+
+  it('requires every token to occur in the same candidate', () => {
+    const entries = [metadata(['Verify input', 'Inspect output'])]
+    expect(matchWorkspaceTabAgentSnippet(entries, query('input output'))).toBeNull()
+    expect(matchWorkspaceTabAgentSnippet(entries, query('verify input'))?.text).toBe('Verify input')
+  })
+
+  it('keeps the cheap path for offset-preserving text and rejects punctuation tokens', () => {
+    const entries = [metadata(['Terminal --- output'])]
+    const prepared = query('terminal ---')
+    const normalize = vi.spyOn(normalizedText, 'normalizePaletteText')
+    expect(matchWorkspaceTabAgentSnippet(entries, prepared)).toBeNull()
+    expect(normalize).not.toHaveBeenCalled()
+  })
+
+  it('uses rebuilt metadata independently of the previous snapshot with the same pane id', () => {
+    const previous = [metadata(['Previous atlas İnvestigation'])]
+    const current = [metadata(['Current nebula İnvestigation'])]
+    expect(matchWorkspaceTabAgentSnippet(previous, query('atlas'))?.text).toBe(
+      'Previous atlas İnvestigation'
+    )
+    expect(matchWorkspaceTabAgentSnippet(current, query('atlas'))).toBeNull()
+    expect(matchWorkspaceTabAgentSnippet(current, query('nebula'))?.text).toBe(
+      'Current nebula İnvestigation'
+    )
+    expect(matchWorkspaceTabAgentSnippet(previous, query('nebula'))).toBeNull()
+  })
+
+  it('does not retain metadata after its palette entries are released', async () => {
+    const gc = global.gc
+    if (!gc) {
+      throw new Error('This test requires --expose-gc')
+    }
+    function searchTransientEntries(): WeakRef<AgentMetadata[]> {
+      const entries = [metadata(['Transient Terminal İnvestigation'])]
+      matchWorkspaceTabAgentSnippet(entries, query('missing'))
+      return new WeakRef(entries)
+    }
+    const reference = searchTransientEntries()
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      gc()
+      if (!reference.deref()) {
+        break
+      }
+    }
+    expect(reference.deref()).toBeUndefined()
+  })
+})

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
@@ -43,6 +43,9 @@ function coverAllTokens(
   tokens: readonly PaletteQueryToken[],
   agentMetadata: readonly AgentMetadata[]
 ): MatchRange[] | null {
+  // Why the cheap path first: this tier scans long agent text for every row the structured
+  // matcher rejected, and U+0130 is the only code point `toLowerCase` lengthens — so folding
+  // (and the cache behind it) stays unreachable for ASCII and every other script.
   const lowered = text.toLowerCase()
   const folded = lowered.length === text.length ? null : getFoldedSnippet(text, agentMetadata)
   const haystack = folded ? folded.normalized : lowered

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
@@ -2,7 +2,8 @@ import {
   mapNormalizedRange,
   mergeMatchRanges,
   normalizePaletteText,
-  type MatchRange
+  type MatchRange,
+  type NormalizedText
 } from './palette-match/normalized-text'
 import {
   createPaletteFallbackRank,
@@ -11,13 +12,11 @@ import {
 import type { PaletteQueryToken } from './palette-match/palette-query'
 import type { AgentMetadata } from './workspace-tab-agent-metadata'
 
-/**
- * Agent prompts and assistant messages are deliberately outside the structured tab
- * matcher — they have no evidence contract and no performance gate yet. This
- * fallback preserves the pre-existing ability to find a terminal by what its agent
- * said, as a strictly last-place tier that never contributes to token coverage.
- */
+// Agent text stays a last-place fallback outside structured token coverage.
 const AGENT_SNIPPET_RANK: PaletteDocumentRank = createPaletteFallbackRank()
+
+// Closing or rebuilding palette entries releases their Unicode offset maps.
+const foldedByMetadata = new WeakMap<readonly AgentMetadata[], Map<string, NormalizedText>>()
 
 export type WorkspaceTabAgentSnippetMatch = {
   text: string
@@ -25,11 +24,27 @@ export type WorkspaceTabAgentSnippetMatch = {
   rank: PaletteDocumentRank
 }
 
-function coverAllTokens(text: string, tokens: readonly PaletteQueryToken[]): MatchRange[] | null {
-  // Why the cheap path first: this tier runs over long agent text for every row the
-  // structured matcher rejected, so full folding is reserved for strings that need it.
+function getFoldedSnippet(text: string, agentMetadata: readonly AgentMetadata[]): NormalizedText {
+  let cache = foldedByMetadata.get(agentMetadata)
+  if (!cache) {
+    cache = new Map()
+    foldedByMetadata.set(agentMetadata, cache)
+  }
+  let folded = cache.get(text)
+  if (!folded) {
+    folded = normalizePaletteText(text)
+    cache.set(text, folded)
+  }
+  return folded
+}
+
+function coverAllTokens(
+  text: string,
+  tokens: readonly PaletteQueryToken[],
+  agentMetadata: readonly AgentMetadata[]
+): MatchRange[] | null {
   const lowered = text.toLowerCase()
-  const folded = lowered.length === text.length ? null : normalizePaletteText(text)
+  const folded = lowered.length === text.length ? null : getFoldedSnippet(text, agentMetadata)
   const haystack = folded ? folded.normalized : lowered
   const ranges: MatchRange[] = []
   for (const token of tokens) {
@@ -53,7 +68,7 @@ export function matchWorkspaceTabAgentSnippet(
   for (const source of ['snippetCandidates', 'textParts'] as const) {
     for (const metadata of agentMetadata) {
       for (const text of metadata[source]) {
-        const ranges = coverAllTokens(text, query.tokens)
+        const ranges = coverAllTokens(text, query.tokens, agentMetadata)
         if (ranges) {
           return { text, ranges, rank: AGENT_SNIPPET_RANK }
         }

--- a/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
+++ b/src/renderer/src/lib/workspace-tab-agent-snippet-match.ts
@@ -1,10 +1,4 @@
-import {
-  mapNormalizedRange,
-  mergeMatchRanges,
-  normalizePaletteText,
-  type MatchRange,
-  type NormalizedText
-} from './palette-match/normalized-text'
+import { mergeMatchRanges, type MatchRange } from './palette-match/normalized-text'
 import {
   createPaletteFallbackRank,
   type PaletteDocumentRank
@@ -12,11 +6,13 @@ import {
 import type { PaletteQueryToken } from './palette-match/palette-query'
 import type { AgentMetadata } from './workspace-tab-agent-metadata'
 
-// Agent text stays a last-place fallback outside structured token coverage.
+/**
+ * Agent prompts and assistant messages are deliberately outside the structured tab
+ * matcher — they have no evidence contract and no performance gate yet. This
+ * fallback preserves the pre-existing ability to find a terminal by what its agent
+ * said, as a strictly last-place tier that never contributes to token coverage.
+ */
 const AGENT_SNIPPET_RANK: PaletteDocumentRank = createPaletteFallbackRank()
-
-// Closing or rebuilding palette entries releases their Unicode offset maps.
-const foldedByMetadata = new WeakMap<readonly AgentMetadata[], Map<string, NormalizedText>>()
 
 export type WorkspaceTabAgentSnippetMatch = {
   text: string
@@ -24,31 +20,10 @@ export type WorkspaceTabAgentSnippetMatch = {
   rank: PaletteDocumentRank
 }
 
-function getFoldedSnippet(text: string, agentMetadata: readonly AgentMetadata[]): NormalizedText {
-  let cache = foldedByMetadata.get(agentMetadata)
-  if (!cache) {
-    cache = new Map()
-    foldedByMetadata.set(agentMetadata, cache)
-  }
-  let folded = cache.get(text)
-  if (!folded) {
-    folded = normalizePaletteText(text)
-    cache.set(text, folded)
-  }
-  return folded
-}
-
-function coverAllTokens(
-  text: string,
-  tokens: readonly PaletteQueryToken[],
-  agentMetadata: readonly AgentMetadata[]
-): MatchRange[] | null {
-  // Why the cheap path first: this tier scans long agent text for every row the structured
-  // matcher rejected, and U+0130 is the only code point `toLowerCase` lengthens — so folding
-  // (and the cache behind it) stays unreachable for ASCII and every other script.
-  const lowered = text.toLowerCase()
-  const folded = lowered.length === text.length ? null : getFoldedSnippet(text, agentMetadata)
-  const haystack = folded ? folded.normalized : lowered
+function coverAllTokens(text: string, tokens: readonly PaletteQueryToken[]): MatchRange[] | null {
+  // U+0130 is the only code point whose `toLowerCase` lengthens text, and none shrink, so
+  // folding it to 'i' first keeps the haystack offset-identical to the original text.
+  const haystack = text.includes('İ') ? text.replaceAll('İ', 'i').toLowerCase() : text.toLowerCase()
   const ranges: MatchRange[] = []
   for (const token of tokens) {
     if (token.isPunctuationOnly) {
@@ -58,8 +33,7 @@ function coverAllTokens(
     if (index === -1) {
       return null
     }
-    const end = index + token.text.length
-    ranges.push(folded ? mapNormalizedRange(folded, index, end) : { start: index, end })
+    ranges.push({ start: index, end: index + token.text.length })
   }
   return mergeMatchRanges(ranges)
 }
@@ -71,7 +45,7 @@ export function matchWorkspaceTabAgentSnippet(
   for (const source of ['snippetCandidates', 'textParts'] as const) {
     for (const metadata of agentMetadata) {
       for (const text of metadata[source]) {
-        const ranges = coverAllTokens(text, query.tokens, agentMetadata)
+        const ranges = coverAllTokens(text, query.tokens)
         if (ranges) {
           return { text, ranges, rank: AGENT_SNIPPET_RANK }
         }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​116 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​116 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​92 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |

<!-- /orca-pr-loc -->

## ELI5

Turkish has a capital `İ` (dotted I). It is the one letter in all of Unicode that gets *longer* when you lowercase it — JavaScript turns it into two characters, `i` plus a separate floating dot. Because of that one letter, palette search kept a side-table recording where every character moved to, so it could still highlight the right part of the original text. This PR lowercases `İ` straight to `i` instead. Nothing changes length any more, the side-table disappears, and searching a screen full of Turkish agent prompts gets about 100x faster. It also fixes a bug: typing `istanbul` now finds a tab whose prompt says `İstanbul`, which it previously did not.

## What changed

This replaces the earlier design in this PR (a `WeakMap` cache of Unicode offset maps) with a smaller one that removes the need for those maps.

1. `normalized-text.ts` — `foldChunk` special-cases code point `U+0130` to `'i'` (this is `'İ'.toLocaleLowerCase('tr')`, the Turkish-locale result) before calling `toLowerCase`. After this, case folding can never change UTF-16 length, so `NormalizedText.starts`/`ends` are only ever populated when NFC composition shrinks a structured field. That path is untouched.
2. `workspace-tab-agent-snippet-match.ts` — deleted the `WeakMap` fold cache, `getFoldedSnippet`, and all `NormalizedText`/`mapNormalizedRange` use. `coverAllTokens` now builds `text.includes('İ') ? text.replaceAll('İ', 'i').toLowerCase() : text.toLowerCase()` and takes `indexOf` offsets directly, because they are identity offsets into the original string.
3. Replaced the `workspace-performance.unicode-snippet-fold-cache` gate (which asserted cache lifecycle) with `workspace-performance.dotted-i-offset-free-fold`, a correctness gate on the fold and its offsets. Removed the cache-lifecycle and forced-GC tests; kept the result/offset/mutation tests.

Net production change against `main`: **-1 line** (`-8` in the matcher, `+7` in the fold).

## Why the previous design did not work

- **The cache could never be warm.** Its `WeakMap` key was the `agentMetadata` array, which `collectAgentMetadataFromIndex` rebuilds on every snapshot, and the snapshot `useMemo` depends on `agentStatusByPaneKey`. Every agent status tick re-paid the cold path.
- **It existed for one character.** An exhaustive scan of all 1,112,064 non-surrogate code points confirms `U+0130` is the only code point whose `toLowerCase` lengthens a string, and that **zero** code points shrink. The `Int32Array` offset maps existed solely to track a `+1` shift caused by that one letter.
- **It did not deliver case-insensitivity.** Candidate `İstanbul Terminal` with query `istanbul` returned `null`. Only the query `İstanbul` matched.

## Semantic change (please read)

`İ` now folds to `i` palette-wide instead of `i` + `U+0307`. Three observable consequences, all measured:

| Case | Before | After |
| --- | --- | --- |
| candidate `İstanbul Terminal`, query `istanbul` | no match | matches, range `{0, 8}` |
| candidate `İstanbul Terminal`, query `İstanbul` | matches, `{0, 8}` | matches, `{0, 8}` (unchanged) |
| candidate `İstanbul Terminal`, query literal `i`+`U+0307` | matched | **no longer matches** |
| candidate `Ivy İstanbul`, query `İ` | highlighted the `İ` | highlights the leading `I` |
| candidate `İstanbul café` (NFD `é`), query `café` (NFC) | matched | **no longer matches** |

The last row is worth calling out: pre-change, a snippet containing `İ` was the *only* kind of snippet that got NFC-composed, because it was the only kind routed through the full folding path. An identical candidate without `İ` (`Istanbul café`) already did not match. The new behaviour is uniform rather than a side effect of which branch ran.

## Measurements (mine, this branch, macOS / Node, medians of 15 runs)

Fixture is the shape this PR was originally justified on: 400 tabs x 21 rows x 200 characters, full agent-snippet search, unmatched query.

| Fixture | pre-PR `main` | PR as previously written (cold = production) | PR as previously written (warm) | **this PR** |
| --- | ---: | ---: | ---: | ---: |
| 100% dotted-I, distinct history | 1296.48 ms | 356.29 ms | 17.98 ms | **12.27 ms** |
| 100% dotted-I, duplicated history | 925.52 ms | 42.91 ms | 13.11 ms | **15.70 ms** |
| 10% dotted-I | 31.13 ms | 4.29 ms | 1.78 ms | **1.86 ms** |
| ASCII only (control) | 0.85 ms | 0.84 ms | 0.80 ms | **0.89 ms** |

"Cold" re-creates the metadata snapshot per call, which is what production does on every agent status tick; "warm" reuses one array identity, which production never sustains. ASCII is unchanged on every implementation — no ASCII gain is claimed.

Retained heap after one search on the 100%-dotted-I fixture: **8,052,768 bytes** of cached offset maps under the previous design, **0 bytes** now. This tier no longer allocates an `Int32Array` at all.

These are fixture measurements of the production functions, not Electron frame times, and not a claim about production language prevalence.

## Differential against pre-PR `main`

Randomized corpora over ASCII, CJK, Cyrillic, Greek, NFC and NFD Latin, emoji, ZWJ sequences, regional indicators, astral plane characters and `U+0130`; comparing candidate choice, matched ranges and highlight offsets.

| Corpus | Compared | Identical | Differing |
| --- | ---: | ---: | ---: |
| No dotted I, NFC only | 59,083 | 59,083 | **0** |
| No dotted I, with NFD | 59,148 | 59,148 | **0** |
| With dotted I, human-typeable queries | 58,837 | 50,880 | 7,957 |
| With dotted I, arbitrary UTF-16 slices | 59,203 | 43,145 | 16,058 |
| With dotted I + NFD, arbitrary slices | 59,286 | 42,929 | 16,357 |

**Zero differences on 118,231 comparisons of dotted-I-free text.** Every difference requires `U+0130`, which is the proof that nothing else reaches the changed path. Every difference falls into exactly four mechanisms, all `U+0130`:

- **query fold** (204 / 166 / 148) — the query itself contained `İ` or `i`+`U+0307` and now tokenizes differently.
- **candidate haystack** (5,995 / 5,704 / 5,778) — the candidate's `İ` no longer inserts a `U+0307` into the haystack, so a plain-`i` query now matches (or a `U+0307` query no longer does). This is the intended fix.
- **cluster-split offsets** (1,159 / 9,767 / 9,830) — offsets only, and only for queries that slice a surrogate pair or a combining sequence in half. The old code snapped such a range out to the enclosing cluster; the new code returns the literal UTF-16 range, matching what every non-dotted-I candidate already did. Not reachable from typed input.
- **NFC composition** (35, NFD corpus only) — the `café` row in the table above.

No `OTHER` category was produced in any run.

## Validation

- 361 tests across 28 files pass (`palette-match/`, agent snippet match, workspace tab palette search/results/metadata, `cmd-j/`, markdown preview search, automation sort).
- `oxlint` clean; `pnpm run check:code-quality:changed` 0 new findings across 4 files; `pnpm tc:web` passes; `node config/scripts/check-reliability-gates.mjs` passes for 110 gates.
- Gate `workspace-performance.dotted-i-offset-free-fold`, experimental, with the differential and code-point scan as red/green evidence.

No remote execution, wire schema, persisted data, mobile UI, chat or diff changes. Folder and git workspaces and host-filtered searches share this matcher. No rendered Electron frame-latency measurement and no live SSH/WSL/Linux/Windows journey were run. Independent of the other performance PRs.
