### PR TITLE
fix(terminal): preserve claimed writer placement across workspaces

### DIFF
--- a/src/main/daemon/terminal-host-agent-session.test.ts
+++ b/src/main/daemon/terminal-host-agent-session.test.ts
@@ -74,8 +74,8 @@ describe('TerminalHost agent-session claims', () => {
       rows: 24,
       streamClient: { onData: vi.fn(), onExit: vi.fn() },
       agentSessionEnsure: {
-        claim,
-        surface: { ...surface, terminalHandle: 'term_retry' }
+        claim: { ...claim, worktreeScopeDigest: 'other-worktree-scope' },
+        surface: { ...surface, worktreeId: 'other-worktree', terminalHandle: 'term_retry' }
       }
     })
 

--- a/src/main/runtime/orca-runtime-adopt-terminal-orphans-from-inventory.ts
+++ b/src/main/runtime/orca-runtime-adopt-terminal-orphans-from-inventory.ts
@@ -57,6 +57,12 @@ export class OrcaRuntimeWithAdoptTerminalOrphansFromInventory extends OrcaRuntim
       worktreeWslDistro,
       currentRevision: this.getTerminalTopologyRevision(workspace.id),
       ports: {
+        bindPtySurface: (ptyId, tabId, paneKey) => {
+          const pty = this.ptysById.get(ptyId)
+          if (pty) {
+            this.recordPtyWorktree(ptyId, pty.worktreeId, { tabId, paneKey })
+          }
+        },
         getPty: (handle) => this.getLivePtyForHandle(handle)?.pty ?? null,
         getLeaves: (ptyId) => this.getLeavesForPty(ptyId),
         getLeaf: (tabId, leafId) => this.leaves.get(this.getLeafKey(tabId, leafId)),

--- a/src/main/runtime/orca-runtime-bind-pty-incarnation-handle.ts
+++ b/src/main/runtime/orca-runtime-bind-pty-incarnation-handle.ts
@@ -11,6 +11,7 @@ export class OrcaRuntimeWithBindPtyIncarnationHandle extends OrcaRuntimeWithBuil
   ): void {
     const leafKey = this.getLeafKey(leaf.tabId, leaf.leafId)
     if (retained.leafKey !== leafKey) {
+      this.ptyOwnershipRevisions.advance(leaf.ptyId)
       if (this.handleByLeafKey.get(retained.leafKey) === retained.handle) {
         this.handleByLeafKey.delete(retained.leafKey)
       }
@@ -30,6 +31,7 @@ export class OrcaRuntimeWithBindPtyIncarnationHandle extends OrcaRuntimeWithBuil
   }
 
   protected invalidatePtyIncarnationHandle(ptyId: string): void {
+    this.ptyOwnershipRevisions.advance(ptyId)
     const retained = this.handleByPtyIncarnation.get(ptyId)
     if (!retained) {
       return
@@ -44,6 +46,7 @@ export class OrcaRuntimeWithBindPtyIncarnationHandle extends OrcaRuntimeWithBuil
   }
 
   protected clearPtyIncarnationHandles(): void {
+    this.ptyOwnershipRevisions.clear()
     for (const retained of this.handleByPtyIncarnation.values()) {
       this.syntheticTerminalHandles.delete(retained.handle)
     }
@@ -107,6 +110,7 @@ export class OrcaRuntimeWithBindPtyIncarnationHandle extends OrcaRuntimeWithBuil
 
     const handle = existingHandle ?? `term_${randomUUID()}`
     if (!existingHandle) {
+      this.ptyOwnershipRevisions.advance(pty.ptyId)
       this.syntheticTerminalHandles.add(handle)
     }
     const syntheticId = `pty:${pty.ptyId}`
@@ -149,6 +153,9 @@ export class OrcaRuntimeWithBindPtyIncarnationHandle extends OrcaRuntimeWithBuil
       return
     }
     const record = this.handles.get(handle)
+    if (record?.ptyId) {
+      this.ptyOwnershipRevisions.advance(record.ptyId)
+    }
     if (record?.ptyId && this.handleByPtyIncarnation.get(record.ptyId)?.handle === handle) {
       this.handleByPtyIncarnation.delete(record.ptyId)
     }

--- a/src/main/runtime/orca-runtime-create-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-terminal.ts
@@ -239,6 +239,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           }
           pty.tabId = tabId
           pty.paneKey = paneKey
+          this.ptyOwnershipRevisions.advance(result.id, pty.incarnationId)
         }
         const ownerTabs = this.mobileSessionTabsByWorktree.get(ownerWorktreeId)?.tabs
         const incumbentMetadata = pty

--- a/src/main/runtime/orca-runtime-create-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-terminal.ts
@@ -3,6 +3,10 @@ import { OrcaRuntimeWithTerminalCreateDeduplication } from './orca-runtime-termi
 import * as dependencies from './orca-runtime-create-terminal-dependencies'
 import { createDesktopTerminal } from './orca-runtime-create-terminal-desktop'
 import { buildRuntimeAgentTeamsLaunchPlan } from './orca-runtime-agent-teams-launch-plan'
+import {
+  getIncumbentTerminalMetadata,
+  recordTerminalLaunchSurface
+} from './runtime-incumbent-terminal-metadata'
 import { createPtySpawnCommitReporter } from './orca-runtime-report-pty-spawn-commit'
 
 export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreateDeduplication {
@@ -216,6 +220,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
         if (pty) {
           pty.runtimeSessionOwned = true
           if (!adoptedOwner) {
+            recordTerminalLaunchSurface(pty, cwd, workspace.path, launchOpts.viewMode)
             if (launchOpts.title) {
               const observedAt = this.nextTitleObservationSequence()
               pty.title = launchOpts.title
@@ -235,16 +240,19 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           pty.tabId = tabId
           pty.paneKey = paneKey
         }
+        const ownerTabs = this.mobileSessionTabsByWorktree.get(ownerWorktreeId)?.tabs
+        const incumbentMetadata = pty
+          ? getIncumbentTerminalMetadata(pty, ownerTabs, tabId, leafId)
+          : {}
         const handle = pty ? this.issuePtyHandle(pty) : preAllocatedHandle
         if (pty && !result.stablePaneOwner && launchOpts.deferMobileSessionPublish !== true) {
           this.publishPtyBackedMobileSessionTerminal(ownerWorktreeId, pty, {
             tabId,
             leafId,
-            title: adoptedOwner ? (pty?.title ?? null) : (launchOpts.title ?? null),
+            title: adoptedOwner ? (incumbentMetadata.title ?? null) : (launchOpts.title ?? null),
             activate: presentation === 'focused',
             selectIfNoActiveTab: presentation !== 'background',
-            ...(!adoptedOwner && launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
-            ...(!adoptedOwner && cwd !== workspace.path ? { startupCwd: cwd } : {})
+            ...(incumbentMetadata.viewMode ? { viewMode: incumbentMetadata.viewMode } : {})
           })
         }
         let surface: dependencies.RuntimeTerminalCreate['surface'] = 'background'
@@ -253,14 +261,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           try {
             await this.notifier.revealTerminalSession(ownerWorktreeId, {
               ptyId: result.id,
-              title: adoptedOwner ? (pty?.title ?? null) : (launchOpts.title ?? null),
-              ...(!adoptedOwner && {
-                cwd: cwd !== workspace.path ? cwd : undefined,
-                launchConfig: effectiveLaunchConfig,
-                launchToken,
-                launchAgent: launchOpts.launchAgent,
-                viewMode: launchOpts.viewMode
-              }),
+              ...incumbentMetadata,
               activate: presentation === 'focused',
               ...(presentation ? { presentation } : {}),
               ...dependencies.ownerSurfacing(opts.surfaceOwner !== false),
@@ -281,7 +282,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           paneKey,
           ptyId: result.id,
           worktreeId: ownerWorktreeId,
-          title: pty?.title ?? launchOpts.title ?? null,
+          title: incumbentMetadata.title ?? null,
           ...this.getPtyExecutionHostMetadata(result.id),
           surface,
           ...(result.pid ? { processId: result.pid } : {}),

--- a/src/main/runtime/orca-runtime-create-terminal.ts
+++ b/src/main/runtime/orca-runtime-create-terminal.ts
@@ -81,29 +81,24 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
         let agentTeamsPlan: Awaited<ReturnType<typeof dependencies.buildClaudeAgentTeamsLaunchPlan>>
         let sequencedStartupCommand: string | undefined
         let effectiveLaunchConfig = launchOpts.launchConfig
-        try {
-          const agentTeams = await buildRuntimeAgentTeamsLaunchPlan({
-            launchConfig: launchOpts.launchConfig,
-            command: launchOpts.command,
-            claudeAgentTeamsSourceCommand: launchOpts.claudeAgentTeamsSourceCommand,
-            claudeAgentTeamsMode,
-            baseEnv: { ...process.env, ...baseEnv },
-            adoptedBeforeLaunch,
-            createTeamEnv: (shimDir, shimBin) =>
-              this.claudeAgentTeams.createLaunchEnv({
-                leaderHandle: preAllocatedHandle,
-                baseEnv: { ...process.env, ...baseEnv },
-                shimDir,
-                shimBin
-              }).env
-          })
-          agentTeamsPlan = agentTeams.plan
-          sequencedStartupCommand = agentTeams.sequencedStartupCommand
-          effectiveLaunchConfig = agentTeams.effectiveLaunchConfig
-        } catch (error) {
-          releaseStablePaneCreate?.()
-          throw error
-        }
+        const agentTeams = await buildRuntimeAgentTeamsLaunchPlan({
+          launchConfig: launchOpts.launchConfig,
+          command: launchOpts.command,
+          claudeAgentTeamsSourceCommand: launchOpts.claudeAgentTeamsSourceCommand,
+          claudeAgentTeamsMode,
+          baseEnv: { ...process.env, ...baseEnv },
+          adoptedBeforeLaunch,
+          createTeamEnv: (shimDir, shimBin) =>
+            this.claudeAgentTeams.createLaunchEnv({
+              leaderHandle: preAllocatedHandle,
+              baseEnv: { ...process.env, ...baseEnv },
+              shimDir,
+              shimBin
+            }).env
+        })
+        agentTeamsPlan = agentTeams.plan
+        sequencedStartupCommand = agentTeams.sequencedStartupCommand
+        effectiveLaunchConfig = agentTeams.effectiveLaunchConfig
         const env = this.buildTerminalWorkspaceEnv(
           workspace,
           {
@@ -178,7 +173,9 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
         if (!result.stablePaneOwner) {
           reportPtySpawnCommitted()
         }
-        const adoptedStablePane = Boolean(result.stablePaneOwner)
+        const adoptedOwner =
+          Boolean(result.stablePaneOwner) || result.agentSessionEnsure?.disposition === 'adopted'
+        const ownerWorktreeId = result.agentSessionEnsure?.owner.surface.worktreeId ?? workspace.id
         if (result.agentSessionEnsure) {
           const canonicalSurface = result.agentSessionEnsure.owner.surface
           preAllocatedHandle = canonicalSurface.terminalHandle
@@ -203,7 +200,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
         if (result.wslDistro) {
           this.preparePtyExecutionContext(result.id, result.wslDistro)
         }
-        this.registerPty(result.id, workspace.id, workspace.connectionId, {
+        this.registerPty(result.id, ownerWorktreeId, workspace.connectionId, {
           tabId,
           leafId,
           terminalHandle: preAllocatedHandle,
@@ -218,7 +215,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
         const pty = this.getOrCreatePtyWorktreeRecord(result.id)
         if (pty) {
           pty.runtimeSessionOwned = true
-          if (!adoptedStablePane) {
+          if (!adoptedOwner) {
             if (launchOpts.title) {
               const observedAt = this.nextTitleObservationSequence()
               pty.title = launchOpts.title
@@ -239,29 +236,31 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           pty.paneKey = paneKey
         }
         const handle = pty ? this.issuePtyHandle(pty) : preAllocatedHandle
-        if (pty && !adoptedStablePane && launchOpts.deferMobileSessionPublish !== true) {
-          this.publishPtyBackedMobileSessionTerminal(workspace.id, pty, {
+        if (pty && !result.stablePaneOwner && launchOpts.deferMobileSessionPublish !== true) {
+          this.publishPtyBackedMobileSessionTerminal(ownerWorktreeId, pty, {
             tabId,
             leafId,
-            title: launchOpts.title ?? null,
+            title: adoptedOwner ? (pty?.title ?? null) : (launchOpts.title ?? null),
             activate: presentation === 'focused',
             selectIfNoActiveTab: presentation !== 'background',
-            ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
-            ...(cwd !== workspace.path ? { startupCwd: cwd } : {})
+            ...(!adoptedOwner && launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
+            ...(!adoptedOwner && cwd !== workspace.path ? { startupCwd: cwd } : {})
           })
         }
         let surface: dependencies.RuntimeTerminalCreate['surface'] = 'background'
         let warning: string | undefined
         if (presentation !== 'background' && this.notifier?.revealTerminalSession) {
           try {
-            await this.notifier.revealTerminalSession(workspace.id, {
+            await this.notifier.revealTerminalSession(ownerWorktreeId, {
               ptyId: result.id,
-              title: launchOpts.title ?? null,
-              ...(cwd !== workspace.path ? { cwd } : {}),
-              ...(effectiveLaunchConfig ? { launchConfig: effectiveLaunchConfig } : {}),
-              ...(launchToken ? { launchToken } : {}),
-              ...(launchOpts.launchAgent ? { launchAgent: launchOpts.launchAgent } : {}),
-              ...(launchOpts.viewMode ? { viewMode: launchOpts.viewMode } : {}),
+              title: adoptedOwner ? (pty?.title ?? null) : (launchOpts.title ?? null),
+              ...(!adoptedOwner && {
+                cwd: cwd !== workspace.path ? cwd : undefined,
+                launchConfig: effectiveLaunchConfig,
+                launchToken,
+                launchAgent: launchOpts.launchAgent,
+                viewMode: launchOpts.viewMode
+              }),
               activate: presentation === 'focused',
               ...(presentation ? { presentation } : {}),
               ...dependencies.ownerSurfacing(opts.surfaceOwner !== false),
@@ -281,7 +280,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           tabId,
           paneKey,
           ptyId: result.id,
-          worktreeId: workspace.id,
+          worktreeId: ownerWorktreeId,
           title: pty?.title ?? launchOpts.title ?? null,
           ...this.getPtyExecutionHostMetadata(result.id),
           surface,
@@ -289,7 +288,7 @@ export class OrcaRuntimeWithCreateTerminal extends OrcaRuntimeWithTerminalCreate
           ...(result.agentSessionEnsure
             ? { agentSessionDisposition: result.agentSessionEnsure.disposition }
             : {}),
-          ...(adoptedStablePane ? { isReattach: true as const } : {}),
+          ...(adoptedOwner ? { isReattach: true as const } : {}),
           ...(warning ? { warning } : {})
         }
       } finally {

--- a/src/main/runtime/orca-runtime-fit-override-listeners.ts
+++ b/src/main/runtime/orca-runtime-fit-override-listeners.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
+import { RuntimePtyOwnershipRevisions } from './runtime-pty-ownership-revisions'
 import { OrcaRuntimeWithStopRequestedPtyIds } from './orca-runtime-stop-requested-pty-ids'
 import { RuntimeSubscriptionRegistry } from './runtime-subscription-registry'
 import { RuntimeMobileNotificationController } from './runtime-mobile-notification-controller'
@@ -73,6 +74,8 @@ export class OrcaRuntimeWithFitOverrideListeners extends OrcaRuntimeWithStopRequ
   protected providerVisibleRetryAtByPtyId = new Map<string, number>()
 
   protected providerSnapshotsWithLiveModeTransition = new WeakSet<PtyProviderBufferSnapshot>()
+
+  protected ptyOwnershipRevisions = new RuntimePtyOwnershipRevisions()
 
   protected ptyLifecycleGenerationById = new Map<string, number>()
 

--- a/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
+++ b/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
@@ -96,6 +96,7 @@ export class OrcaRuntimeWithGetOrchestrationDispatchAuthority extends OrcaRuntim
   }
 
   protected retirePtyAgentLaunchAuthority(ptyId: string): void {
+    this.ptyOwnershipRevisions.advance(ptyId)
     const pty = this.ptysById.get(ptyId)
     if (!pty) {
       return

--- a/src/main/runtime/orca-runtime-get-status.ts
+++ b/src/main/runtime/orca-runtime-get-status.ts
@@ -128,6 +128,7 @@ export class OrcaRuntimeWithGetStatus extends OrcaRuntimeWithGetRuntimeId {
     // Why: CLI terminal writes must go through the main-owned PTY registry
     // instead of tunneling back through renderer IPC, or live handles could
     // drift from the process they are supposed to control during reloads.
+    this.ptyOwnershipRevisions.clear()
     this.ptyController = controller
   }
 

--- a/src/main/runtime/orca-runtime-has-exact-persisted-terminal-surface-identity.ts
+++ b/src/main/runtime/orca-runtime-has-exact-persisted-terminal-surface-identity.ts
@@ -56,6 +56,7 @@ export class OrcaRuntimeWithHasExactPersistedTerminalSurfaceIdentity extends Orc
   protected rollbackLegacyWorkerTerminalSurface(
     candidate: LegacyWorkerTerminalRecoveryPlan['candidates'][number]
   ): void {
+    this.ptyOwnershipRevisions.advance(candidate.ptyId)
     const snapshot = this.mobileSessionTabsByWorktree.get(candidate.worktreeId)
     if (snapshot) {
       const retired = retireTerminalSurfacesFromSnapshot({
@@ -95,8 +96,7 @@ export class OrcaRuntimeWithHasExactPersistedTerminalSurfaceIdentity extends Orc
       }
     }
     if (pty?.tabId === candidate.tabId) {
-      pty.tabId = null
-      pty.paneKey = null
+      this.recordPtyWorktree(pty.ptyId, pty.worktreeId, { tabId: null, paneKey: null })
     }
     this.notifier?.resolveLegacyWorkerTerminalRecovery?.(
       candidate.paneKey,

--- a/src/main/runtime/orca-runtime-invalidate-all-handles-for-pty.ts
+++ b/src/main/runtime/orca-runtime-invalidate-all-handles-for-pty.ts
@@ -141,9 +141,7 @@ export class OrcaRuntimeWithInvalidateAllHandlesForPty extends OrcaRuntimeWithRe
     this.terminalViewSubscribers.markSpawnPublished(ptyId)
     const pty = this.getOrCreatePtyWorktreeRecord(ptyId)
     if (pty) {
-      if (incarnationId) {
-        pty.incarnationId = incarnationId
-      }
+      this.transitionPtyIncarnation(pty, incarnationId ?? null)
       pty.connected = true
       pty.disconnectedAt = null
     }

--- a/src/main/runtime/orca-runtime-invalidate-all-handles-for-pty.ts
+++ b/src/main/runtime/orca-runtime-invalidate-all-handles-for-pty.ts
@@ -4,6 +4,7 @@ import type { PtyIncarnationId } from '../../shared/pty-incarnation'
 
 export class OrcaRuntimeWithInvalidateAllHandlesForPty extends OrcaRuntimeWithResolveKnownWorkspaceFileTarget {
   protected invalidateAllHandlesForPty(ptyId: string, preserveHandle?: string): Set<string> {
+    this.ptyOwnershipRevisions.advance(ptyId)
     const incarnationHandle = this.handleByPtyIncarnation.get(ptyId)?.handle
     const preallocatedHandle = this.handleByPtyId.get(ptyId)
     const invalidated = new Set<string>()
@@ -115,6 +116,7 @@ export class OrcaRuntimeWithInvalidateAllHandlesForPty extends OrcaRuntimeWithRe
     incarnationId?: PtyIncarnationId,
     options: { awaitsRegistration?: boolean } = {}
   ): void {
+    this.ptyOwnershipRevisions.advance(ptyId)
     const existingPty = this.ptysById.get(ptyId)
     if (
       existingPty &&
@@ -150,5 +152,6 @@ export class OrcaRuntimeWithInvalidateAllHandlesForPty extends OrcaRuntimeWithRe
       leaf.writable = this.graphStatus === 'ready'
       this.adoptPreAllocatedHandle(leaf)
     }
+    this.ptyOwnershipRevisions.advance(ptyId, incarnationId ?? null)
   }
 }

--- a/src/main/runtime/orca-runtime-prepare-pty-execution-context.ts
+++ b/src/main/runtime/orca-runtime-prepare-pty-execution-context.ts
@@ -17,6 +17,9 @@ export class OrcaRuntimeWithPreparePtyExecutionContext extends OrcaRuntimeWithRe
       return false
     }
 
+    if (options.resetIncarnation || (this.wslDistroByPtyId.get(ptyId) ?? null) !== wslDistro) {
+      this.ptyOwnershipRevisions.advance(ptyId)
+    }
     if (options.resetIncarnation) {
       // Why: an explicit new lifecycle supersedes an unidentifiable exit from the reused PTY id.
       this.earlyExitedPtyIncarnations.delete(ptyId)

--- a/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
@@ -2,7 +2,7 @@
 import { OrcaRuntimeWithHasLiveOrPersistedServeOrSshOwnedPtyBinding } from './orca-runtime-has-live-or-persisted-serve-or-ssh-owned-pty-binding'
 import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
 import { normalizeCompatibleAgentTitleForOwner } from '../../shared/agent-title-owner'
-import { getLatestPtyTitle } from './runtime-worktree-status-projection'
+import { getIncumbentTerminalMetadata } from './runtime-incumbent-terminal-metadata'
 import type {
   RuntimeMobileSessionTabsSnapshot,
   RuntimeMobileSessionTerminalTab
@@ -42,9 +42,15 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
       return
     }
     const existing = this.mobileSessionTabsByWorktree.get(worktreeId)
+    const incumbentMetadata = getIncumbentTerminalMetadata(
+      pty,
+      existing?.tabs,
+      args.tabId,
+      args.leafId
+    )
     const ownerAgent = pty.launchAgent ?? pty.foregroundAgent
     const title = normalizeCompatibleAgentTitleForOwner(
-      args.title ?? getLatestPtyTitle(pty) ?? 'Terminal',
+      args.title ?? incumbentMetadata.title ?? 'Terminal',
       ownerAgent,
       { ownerIsLaunch: Boolean(pty.launchAgent) }
     )
@@ -74,6 +80,7 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
     // host's explicit tab mode before the renderer graph catches up.
     const viewMode =
       args.viewMode ??
+      incumbentMetadata.viewMode ??
       existingTab?.viewMode ??
       existing?.tabs.find(
         (candidate): candidate is RuntimeMobileSessionTerminalTab =>
@@ -81,6 +88,10 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
           candidate.parentTabId === args.tabId &&
           candidate.viewMode !== undefined
       )?.viewMode
+    const startupCwd =
+      pty.launchSurface?.incarnationId === pty.incarnationId
+        ? incumbentMetadata.cwd
+        : (incumbentMetadata.cwd ?? args.startupCwd)
     const tab: RuntimeMobileSessionTerminalTab = {
       type: 'terminal',
       id: `${args.tabId}::${args.leafId}`,
@@ -90,7 +101,7 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
       incarnationId: pty.incarnationId,
       title,
       ...(pty.launchAgent ? { launchAgent: pty.launchAgent } : {}),
-      ...(args.startupCwd ? { startupCwd: args.startupCwd } : {}),
+      ...(startupCwd ? { startupCwd } : {}),
       ...(viewMode ? { viewMode } : {}),
       parentLayout,
       isActive:

--- a/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
+++ b/src/main/runtime/orca-runtime-publish-pty-backed-mobile-session-terminal.ts
@@ -81,17 +81,17 @@ export class OrcaRuntimeWithPublishPtyBackedMobileSessionTerminal extends OrcaRu
     const viewMode =
       args.viewMode ??
       incumbentMetadata.viewMode ??
-      existingTab?.viewMode ??
       existing?.tabs.find(
         (candidate): candidate is RuntimeMobileSessionTerminalTab =>
           candidate.type === 'terminal' &&
           candidate.parentTabId === args.tabId &&
+          candidate.leafId !== args.leafId &&
+          candidate.ptyId !== pty.ptyId &&
           candidate.viewMode !== undefined
       )?.viewMode
-    const startupCwd =
-      pty.launchSurface?.incarnationId === pty.incarnationId
-        ? incumbentMetadata.cwd
-        : (incumbentMetadata.cwd ?? args.startupCwd)
+    const startupCwd = pty.launchSurface
+      ? incumbentMetadata.cwd
+      : (incumbentMetadata.cwd ?? args.startupCwd)
     const tab: RuntimeMobileSessionTerminalTab = {
       type: 'terminal',
       id: `${args.tabId}::${args.leafId}`,

--- a/src/main/runtime/orca-runtime-record-agent-prompt-lifecycle-state.ts
+++ b/src/main/runtime/orca-runtime-record-agent-prompt-lifecycle-state.ts
@@ -81,6 +81,7 @@ export class OrcaRuntimeWithRecordAgentPromptLifecycleState extends OrcaRuntimeW
   }
 
   protected advancePtyLifecycleGeneration(ptyId: string): void {
+    this.ptyOwnershipRevisions.advance(ptyId)
     this.ptyLifecycleGenerationById.set(ptyId, this.nextPtyLifecycleGeneration++)
     this.clearAgentPromptCorrelationForPty(ptyId)
     // A stop intent belongs to one process incarnation; never let it label a

--- a/src/main/runtime/orca-runtime-record-pty-worktree.ts
+++ b/src/main/runtime/orca-runtime-record-pty-worktree.ts
@@ -106,18 +106,8 @@ export class OrcaRuntimeWithRecordPtyWorktree extends OrcaRuntimeWithRefreshRepo
     }
 
     pty.worktreeId = worktreeId
-    if (
-      state.incarnationId !== undefined &&
-      pty.incarnationId !== null &&
-      state.incarnationId !== pty.incarnationId
-    ) {
-      pty.agentSessionOwners = []
-    }
     if (state.incarnationId !== undefined) {
-      if (pty.incarnationId && state.incarnationId && pty.incarnationId !== state.incarnationId) {
-        this.invalidatePtyIncarnationHandle(ptyId)
-      }
-      pty.incarnationId = state.incarnationId
+      this.transitionPtyIncarnation(pty, state.incarnationId)
     }
     if (state.agentSessionOwners !== undefined) {
       pty.agentSessionOwners = state.agentSessionOwners.map(cloneAgentSessionOwnerBinding)
@@ -168,6 +158,34 @@ export class OrcaRuntimeWithRecordPtyWorktree extends OrcaRuntimeWithRefreshRepo
     // Why: recordPtyWorktree is the common lifecycle point for every path that resolves a PTY's worktree (renderer restore, controller list).
     advertisedUrlWatcher.bindPty(ptyId, worktreeId)
     return pty
+  }
+
+  protected transitionPtyIncarnation(
+    pty: RuntimePtyWorktreeRecord,
+    incarnationId: RuntimePtyWorktreeRecord['incarnationId']
+  ): void {
+    // Only positive identity equality authorizes retaining process metadata.
+    if (incarnationId !== null && pty.incarnationId === incarnationId) {
+      return
+    }
+    this.retirePtyAgentLaunchAuthority(pty.ptyId)
+    this.ptyForegroundAgent.resetIncarnation(pty.ptyId)
+    this.resetTrackedTerminalStateForProviderGeneration(pty.ptyId)
+    this.invalidatePtyIncarnationHandle(pty.ptyId)
+    this.terminalCwdByPtyId.delete(pty.ptyId)
+    this.terminalFileUriHostnameByPtyId.delete(pty.ptyId)
+    this.terminalSpawnCommandsByPtyId.delete(pty.ptyId)
+    pty.launchConfig = null
+    pty.launchToken = null
+    pty.launchIncarnationId = null
+    pty.launchAgent = null
+    pty.launchSurface = undefined
+    pty.agentSessionOwners = []
+    pty.foregroundAgent = null
+    pty.title = null
+    pty.titleUpdatedAt = null
+    pty.controllerTitle = null
+    pty.incarnationId = incarnationId
   }
 
   protected makeRuntimePaneKey(

--- a/src/main/runtime/orca-runtime-record-pty-worktree.ts
+++ b/src/main/runtime/orca-runtime-record-pty-worktree.ts
@@ -34,6 +34,15 @@ export class OrcaRuntimeWithRecordPtyWorktree extends OrcaRuntimeWithRefreshRepo
     > = {}
   ): RuntimePtyWorktreeRecord {
     let pty = this.ptysById.get(ptyId)
+    if (
+      !pty ||
+      pty.worktreeId !== worktreeId ||
+      ['connectionId', 'tabId', 'paneKey', 'connected', 'runtimeSessionOwned'].some(
+        (key) => state[key] !== undefined && state[key] !== pty?.[key]
+      )
+    ) {
+      this.ptyOwnershipRevisions.advance(ptyId)
+    }
     if (!pty) {
       const titleObservedAt = state.title ? this.nextTitleObservationSequence() : null
       const connectionId = state.connectionId ?? parseAppSshPtyId(ptyId)?.connectionId ?? null
@@ -164,6 +173,7 @@ export class OrcaRuntimeWithRecordPtyWorktree extends OrcaRuntimeWithRefreshRepo
     pty: RuntimePtyWorktreeRecord,
     incarnationId: RuntimePtyWorktreeRecord['incarnationId']
   ): void {
+    this.ptyOwnershipRevisions.advance(pty.ptyId)
     // Only positive identity equality authorizes retaining process metadata.
     if (incarnationId !== null && pty.incarnationId === incarnationId) {
       return

--- a/src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts
+++ b/src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts
@@ -21,10 +21,7 @@ import {
   inferWorktreeIdFromPtyId,
   runtimeWorktreeIdsEqual
 } from './runtime-worktree-path-identity'
-import {
-  indexPersistedPtySurfaceBindings,
-  indexPersistedPtyWorktreeBindings
-} from './runtime-worktree-binding-index'
+import { createPersistedPtyBindingLookup } from './runtime-worktree-binding-index'
 import { parseAppSshPtyId } from '../../shared/ssh-pty-id'
 import { NO_OBSERVING_PROVIDER_REASON } from '../../shared/pty-liveness-verdict'
 import { buildControllerTerminalIdentities } from './orca-runtime-build-controller-terminal-identities'
@@ -73,7 +70,9 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
       deadlineMs: Date.now() + Math.max(1, listBudgetMs - PTY_CONTROLLER_LIST_PROVIDER_MARGIN_MS),
       ...(inventoryOptions?.includeForegroundProcessEvidence === undefined
         ? {}
-        : { includeForegroundProcessEvidence: inventoryOptions.includeForegroundProcessEvidence })
+        : {
+            includeForegroundProcessEvidence: inventoryOptions.includeForegroundProcessEvidence
+          })
     }
     const processInventory =
       connectionId === undefined && this.ptyController.listProcessesWithHostScope
@@ -127,26 +126,9 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
     }
     const { controllerIdentityByPtyId } = buildControllerTerminalIdentities(sessions)
     const findResolvedWorktree = createIncrementalResolvedWorktreeLookup(resolvedWorktrees)
-    const persistedIndexesByHostId = new Map<
-      ExecutionHostId,
-      {
-        worktreeIdByPtyId: ReadonlyMap<string, string>
-        surfaceByPtyId: ReturnType<typeof indexPersistedPtySurfaceBindings>
-      }
-    >()
-    const getPersistedIndexes = (hostId: ExecutionHostId) => {
-      const existing = persistedIndexesByHostId.get(hostId)
-      if (existing) {
-        return existing
-      }
-      const persistedSession = this.store?.getWorkspaceSession?.(hostId)
-      const indexes = {
-        worktreeIdByPtyId: indexPersistedPtyWorktreeBindings(persistedSession),
-        surfaceByPtyId: indexPersistedPtySurfaceBindings(persistedSession)
-      }
-      persistedIndexesByHostId.set(hostId, indexes)
-      return indexes
-    }
+    const getPersistedIndexes = createPersistedPtyBindingLookup((hostId) =>
+      this.store?.getWorkspaceSession?.(hostId)
+    )
     const allLivePtyIds = new Set(sessions.map((session) => session.id))
     const selectedLivePtyIds = new Set<string>()
     for (const session of sessions) {
@@ -194,7 +176,9 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
         session.id,
         controllerIdentity?.handle ?? session.terminalHandle,
         controllerIdentity?.incarnationId ?? session.incarnationId,
-        { exactRestoredSurface: Boolean(restoresExactSurface && controllerIdentity) }
+        {
+          exactRestoredSurface: Boolean(restoresExactSurface && controllerIdentity)
+        }
       )
       if (
         !targetWorktreeId ||
@@ -216,13 +200,19 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
       if (worktreeId) {
         const pty = this.recordPtyWorktree(session.id, worktreeId, {
           connected: true,
-          ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
+          incarnationId: session.incarnationId ?? null,
           agentSessionOwners: session.incarnationId ? (session.agentSessionOwners ?? []) : [],
           ...(session.wslDistro !== undefined
-            ? { isWsl: Boolean(session.wslDistro), wslDistro: session.wslDistro }
+            ? {
+                isWsl: Boolean(session.wslDistro),
+                wslDistro: session.wslDistro
+              }
             : {}),
           ...(restoresExactSurface
-            ? { tabId: persistedSurface.tabId, paneKey: persistedSurface.paneKey }
+            ? {
+                tabId: persistedSurface.tabId,
+                paneKey: persistedSurface.paneKey
+              }
             : {})
         })
         if (restoresExactSurface && controllerIdentity) {

--- a/src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts
+++ b/src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts
@@ -50,8 +50,7 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
     if (!this.ptyController?.listProcesses) {
       return null
     }
-    const inventoryGeneration = this.ptyControllerInventorySequence + 1
-    this.ptyControllerInventorySequence = inventoryGeneration
+    const inventoryGeneration = ++this.ptyControllerInventorySequence
     const providerKey = typeof connectionId === 'string' ? `ssh:${connectionId}` : 'local'
     const livenessObservationAtStart = this.ptyLivenessObservationSequence
     if (connectionId === undefined) {
@@ -74,17 +73,20 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
             includeForegroundProcessEvidence: inventoryOptions.includeForegroundProcessEvidence
           })
     }
-    const processInventory =
-      connectionId === undefined && this.ptyController.listProcessesWithHostScope
-        ? this.ptyController.listProcessesWithHostScope(providerListOpts)
-        : this.ptyController.listProcesses(connectionId, providerListOpts).then((processes) => {
-            const hostId: ExecutionHostId =
-              connectionId === undefined || connectionId === null
-                ? LOCAL_EXECUTION_HOST_ID
-                : toSshExecutionHostId(connectionId)
-            return { processes, hostIds: [hostId] }
-          })
-    const sessionsResult = await withTimeoutResult(processInventory, listBudgetMs)
+    const { observation: ownershipObservation, result: sessionsResult } =
+      await this.ptyOwnershipRevisions.observe(() => {
+        const processInventory =
+          connectionId === undefined && this.ptyController.listProcessesWithHostScope
+            ? this.ptyController.listProcessesWithHostScope(providerListOpts)
+            : this.ptyController.listProcesses(connectionId, providerListOpts).then((processes) => {
+                const hostId: ExecutionHostId =
+                  connectionId === undefined || connectionId === null
+                    ? LOCAL_EXECUTION_HOST_ID
+                    : toSshExecutionHostId(connectionId)
+                return { processes, hostIds: [hostId] }
+              })
+        return withTimeoutResult(processInventory, listBudgetMs)
+      })
     if (!sessionsResult.ok) {
       // Why: a transient controller failure is not evidence that retained PTYs exited.
       return null
@@ -115,6 +117,17 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
       return null
     }
     const sessions = sessionsResult.value.processes
+    if (
+      !this.ptyOwnershipRevisions.admits(
+        ownershipObservation,
+        sessions,
+        this.ptysById,
+        this.handleByPtyId,
+        connectionId
+      )
+    ) {
+      return null
+    }
     const queriedHostIds = new Set<ExecutionHostId>(sessionsResult.value.hostIds)
     if (connectionId === undefined) {
       for (const session of sessions) {

--- a/src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts
+++ b/src/main/runtime/orca-runtime-refresh-pty-worktree-records-with-controller-inventory.ts
@@ -73,251 +73,250 @@ export class OrcaRuntimeWithRefreshPtyWorktreeRecordsWithControllerInventory ext
             includeForegroundProcessEvidence: inventoryOptions.includeForegroundProcessEvidence
           })
     }
-    const { observation: ownershipObservation, result: sessionsResult } =
-      await this.ptyOwnershipRevisions.observe(() => {
-        const processInventory =
-          connectionId === undefined && this.ptyController.listProcessesWithHostScope
-            ? this.ptyController.listProcessesWithHostScope(providerListOpts)
-            : this.ptyController.listProcesses(connectionId, providerListOpts).then((processes) => {
-                const hostId: ExecutionHostId =
-                  connectionId === undefined || connectionId === null
-                    ? LOCAL_EXECUTION_HOST_ID
-                    : toSshExecutionHostId(connectionId)
-                return { processes, hostIds: [hostId] }
-              })
-        return withTimeoutResult(processInventory, listBudgetMs)
-      })
-    if (!sessionsResult.ok) {
-      // Why: a transient controller failure is not evidence that retained PTYs exited.
-      return null
-    }
-    const isCurrentInventory =
-      connectionId === undefined
-        ? this.ptyControllerAggregateInventoryGeneration === inventoryGeneration &&
-          ![...this.ptyControllerInventoryGenerationByProvider.values()].some(
-            (generation) => generation > inventoryGeneration
+    return this.ptyOwnershipRevisions.withObservation(async (ownershipObservation) => {
+      const processInventory =
+        connectionId === undefined && this.ptyController.listProcessesWithHostScope
+          ? this.ptyController.listProcessesWithHostScope(providerListOpts)
+          : this.ptyController.listProcesses(connectionId, providerListOpts).then((processes) => {
+              const hostId: ExecutionHostId =
+                connectionId === undefined || connectionId === null
+                  ? LOCAL_EXECUTION_HOST_ID
+                  : toSshExecutionHostId(connectionId)
+              return { processes, hostIds: [hostId] }
+            })
+      const sessionsResult = await withTimeoutResult(processInventory, listBudgetMs)
+      if (!sessionsResult.ok) {
+        // Why: a transient controller failure is not evidence that retained PTYs exited.
+        return null
+      }
+      const isCurrentInventory =
+        connectionId === undefined
+          ? this.ptyControllerAggregateInventoryGeneration === inventoryGeneration &&
+            ![...this.ptyControllerInventoryGenerationByProvider.values()].some(
+              (generation) => generation > inventoryGeneration
+            )
+          : this.ptyControllerInventoryGenerationByProvider.get(providerKey) ===
+              inventoryGeneration &&
+            this.ptyControllerAggregateInventoryGeneration <= inventoryGeneration
+      if (!isCurrentInventory) {
+        // A fleet census that began after this targeted poll must not turn a
+        // user-driven open into an empty result. Re-query the owning provider;
+        // the second generation is then fenced against both operations.
+        if (targetWorktreeId !== null && !retryStale) {
+          return this.refreshPtyWorktreeRecordsWithControllerInventory(
+            resolvedWorktrees,
+            targetWorktreeId,
+            deadline,
+            connectionId,
+            true,
+            inventoryOptions
           )
-        : this.ptyControllerInventoryGenerationByProvider.get(providerKey) ===
-            inventoryGeneration &&
-          this.ptyControllerAggregateInventoryGeneration <= inventoryGeneration
-    if (!isCurrentInventory) {
-      // A fleet census that began after this targeted poll must not turn a
-      // user-driven open into an empty result. Re-query the owning provider;
-      // the second generation is then fenced against both operations.
-      if (targetWorktreeId !== null && !retryStale) {
-        return this.refreshPtyWorktreeRecordsWithControllerInventory(
-          resolvedWorktrees,
-          targetWorktreeId,
-          deadline,
-          connectionId,
-          true,
-          inventoryOptions
+        }
+        return null
+      }
+      const sessions = sessionsResult.value.processes
+      if (
+        !this.ptyOwnershipRevisions.admits(
+          ownershipObservation,
+          sessions,
+          this.ptysById,
+          this.handleByPtyId,
+          connectionId
         )
+      ) {
+        return null
       }
-      return null
-    }
-    const sessions = sessionsResult.value.processes
-    if (
-      !this.ptyOwnershipRevisions.admits(
-        ownershipObservation,
-        sessions,
-        this.ptysById,
-        this.handleByPtyId,
-        connectionId
+      const queriedHostIds = new Set<ExecutionHostId>(sessionsResult.value.hostIds)
+      if (connectionId === undefined) {
+        for (const session of sessions) {
+          const hostId = getPtyExecutionHost(session.id)
+          if (hostId && hostId !== 'foreign' && parseExecutionHostId(hostId)?.kind === 'ssh') {
+            queriedHostIds.add(hostId)
+          }
+        }
+      }
+      const { controllerIdentityByPtyId } = buildControllerTerminalIdentities(sessions)
+      const findResolvedWorktree = createIncrementalResolvedWorktreeLookup(resolvedWorktrees)
+      const getPersistedIndexes = createPersistedPtyBindingLookup((hostId) =>
+        this.store?.getWorkspaceSession?.(hostId)
       )
-    ) {
-      return null
-    }
-    const queriedHostIds = new Set<ExecutionHostId>(sessionsResult.value.hostIds)
-    if (connectionId === undefined) {
+      const allLivePtyIds = new Set(sessions.map((session) => session.id))
+      const selectedLivePtyIds = new Set<string>()
       for (const session of sessions) {
-        const hostId = getPtyExecutionHost(session.id)
-        if (hostId && hostId !== 'foreign' && parseExecutionHostId(hostId)?.kind === 'ssh') {
-          queriedHostIds.add(hostId)
-        }
-      }
-    }
-    const { controllerIdentityByPtyId } = buildControllerTerminalIdentities(sessions)
-    const findResolvedWorktree = createIncrementalResolvedWorktreeLookup(resolvedWorktrees)
-    const getPersistedIndexes = createPersistedPtyBindingLookup((hostId) =>
-      this.store?.getWorkspaceSession?.(hostId)
-    )
-    const allLivePtyIds = new Set(sessions.map((session) => session.id))
-    const selectedLivePtyIds = new Set<string>()
-    for (const session of sessions) {
-      // The owning inventory positively observed this PTY again, so this is host evidence of life,
-      // not merely the absence of doubt.
-      this.markPtyLivenessLive(session.id, livenessObservationAtStart)
-      const sessionConnectionId =
-        parseAppSshPtyId(session.id)?.connectionId ??
-        (typeof connectionId === 'string' ? connectionId : null)
-      const persistedIndexes = getPersistedIndexes(
-        sessionConnectionId ? toSshExecutionHostId(sessionConnectionId) : LOCAL_EXECUTION_HOST_ID
-      )
-      const controllerIdentity = controllerIdentityByPtyId.get(session.id)
-      const persistedWorktreeId = persistedIndexes.worktreeIdByPtyId.get(session.id)
-      const providerWorktree = session.worktreeId
-        ? findResolvedWorktree(session.worktreeId)
-        : undefined
-      const inferredWorktreeId = inferWorktreeIdFromPtyId(session.id)
-      const persistedWorktree = persistedWorktreeId
-        ? findResolvedWorktree(persistedWorktreeId)
-        : undefined
-      const hasMigrationEvidence =
-        Boolean(session.worktreeId) &&
-        !providerWorktree &&
-        Boolean(persistedWorktree) &&
-        Boolean(inferredWorktreeId) &&
-        runtimeWorktreeIdsEqual(session.worktreeId as string, inferredWorktreeId as string)
-      // Why: an unresolved explicit provider owner remains authoritative unless the session id proves it was frozen before a persisted rename migration.
-      const worktreeId = providerWorktree
-        ? providerWorktree.id
-        : hasMigrationEvidence
-          ? (persistedWorktree?.id ?? null)
-          : (session.worktreeId ??
-            persistedWorktree?.id ??
-            inferredWorktreeId ??
-            findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd, targetWorktreeId))
-      const persistedSurface = persistedIndexes.surfaceByPtyId.get(session.id)
-      const restoresExactSurface =
-        persistedSurface &&
-        session.incarnationId &&
-        persistedSurface.incarnationId === session.incarnationId &&
-        Boolean(worktreeId) &&
-        runtimeWorktreeIdsEqual(persistedSurface.worktreeId, worktreeId as string)
-      this.adoptControllerTerminalHandle(
-        session.id,
-        controllerIdentity?.handle ?? session.terminalHandle,
-        controllerIdentity?.incarnationId ?? session.incarnationId,
-        {
-          exactRestoredSurface: Boolean(restoresExactSurface && controllerIdentity)
-        }
-      )
-      if (
-        !targetWorktreeId ||
-        (worktreeId && runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
-      ) {
-        selectedLivePtyIds.add(session.id)
-      }
-      if (
-        targetWorktreeId &&
-        (!worktreeId || !runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
-      ) {
-        const receipt = this.restoredOrchestrationAuthorityByPtyId.get(session.id)
-        if (receipt && runtimeWorktreeIdsEqual(receipt.worktreeId, targetWorktreeId)) {
-          this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
-        }
-        continue
-      }
-      this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
-      if (worktreeId) {
-        const pty = this.recordPtyWorktree(session.id, worktreeId, {
-          connected: true,
-          incarnationId: session.incarnationId ?? null,
-          agentSessionOwners: session.incarnationId ? (session.agentSessionOwners ?? []) : [],
-          ...(session.wslDistro !== undefined
-            ? {
-                isWsl: Boolean(session.wslDistro),
-                wslDistro: session.wslDistro
-              }
-            : {}),
-          ...(restoresExactSurface
-            ? {
-                tabId: persistedSurface.tabId,
-                paneKey: persistedSurface.paneKey
-              }
-            : {})
-        })
-        if (restoresExactSurface && controllerIdentity) {
-          this.rememberRestoredOrchestrationAuthority(
-            pty,
-            controllerIdentity.handle,
-            controllerIdentity.incarnationId
-          )
-        } else {
-          this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
-        }
-        pty.controllerTitle = session.title?.trim() || null
-        this.reconcileSubscriberDrivenProviderAttach(session.id)
-      }
-      // Why: fire-and-forget so this listing hot path doesn't serialize a relay round-trip per session and a throw can't abort the sweep below.
-      this.refreshPtyForegroundAgent(session.id)
-    }
-    for (const pty of this.ptysById.values()) {
-      if (connectionId !== undefined && pty.connectionId !== connectionId) {
-        continue
-      }
-      const encodedHostId = getPtyExecutionHost(pty.ptyId)
-      const ptyHostId =
-        encodedHostId === 'foreign'
-          ? null
-          : (encodedHostId ??
-            (pty.connectionId ? toSshExecutionHostId(pty.connectionId) : LOCAL_EXECUTION_HOST_ID))
-      if (!ptyHostId) {
-        continue
-      }
-      // An inventory can prove absence only for hosts that actually answered.
-      if (!queriedHostIds.has(ptyHostId)) {
-        if (this.isSshOwnedPtyId(pty.ptyId) && this.ptyController.hasPty?.(pty.ptyId) == null) {
-          this.markPtyLivenessUnverifiable(pty.ptyId, NO_OBSERVING_PROVIDER_REASON)
-        }
-        continue
-      }
-      if (!allLivePtyIds.has(pty.ptyId) && !this.leafExistsForPty(pty.ptyId)) {
-        const currentVerdict = this.ptyLivenessVerdictByPtyId.get(pty.ptyId)
+        // The owning inventory positively observed this PTY again, so this is host evidence of life,
+        // not merely the absence of doubt.
+        this.markPtyLivenessLive(session.id, livenessObservationAtStart)
+        const sessionConnectionId =
+          parseAppSshPtyId(session.id)?.connectionId ??
+          (typeof connectionId === 'string' ? connectionId : null)
+        const persistedIndexes = getPersistedIndexes(
+          sessionConnectionId ? toSshExecutionHostId(sessionConnectionId) : LOCAL_EXECUTION_HOST_ID
+        )
+        const controllerIdentity = controllerIdentityByPtyId.get(session.id)
+        const persistedWorktreeId = persistedIndexes.worktreeIdByPtyId.get(session.id)
+        const providerWorktree = session.worktreeId
+          ? findResolvedWorktree(session.worktreeId)
+          : undefined
+        const inferredWorktreeId = inferWorktreeIdFromPtyId(session.id)
+        const persistedWorktree = persistedWorktreeId
+          ? findResolvedWorktree(persistedWorktreeId)
+          : undefined
+        const hasMigrationEvidence =
+          Boolean(session.worktreeId) &&
+          !providerWorktree &&
+          Boolean(persistedWorktree) &&
+          Boolean(inferredWorktreeId) &&
+          runtimeWorktreeIdsEqual(session.worktreeId as string, inferredWorktreeId as string)
+        // Why: an unresolved explicit provider owner remains authoritative unless the session id proves it was frozen before a persisted rename migration.
+        const worktreeId = providerWorktree
+          ? providerWorktree.id
+          : hasMigrationEvidence
+            ? (persistedWorktree?.id ?? null)
+            : (session.worktreeId ??
+              persistedWorktree?.id ??
+              inferredWorktreeId ??
+              findResolvedWorktreeIdForPath(resolvedWorktrees, session.cwd, targetWorktreeId))
+        const persistedSurface = persistedIndexes.surfaceByPtyId.get(session.id)
+        const restoresExactSurface =
+          persistedSurface &&
+          session.incarnationId &&
+          persistedSurface.incarnationId === session.incarnationId &&
+          Boolean(worktreeId) &&
+          runtimeWorktreeIdsEqual(persistedSurface.worktreeId, worktreeId as string)
+        this.adoptControllerTerminalHandle(
+          session.id,
+          controllerIdentity?.handle ?? session.terminalHandle,
+          controllerIdentity?.incarnationId ?? session.incarnationId,
+          {
+            exactRestoredSurface: Boolean(restoresExactSurface && controllerIdentity)
+          }
+        )
         if (
-          currentVerdict &&
-          currentVerdict.observedAt > livenessObservationAtStart &&
-          currentVerdict.verdict.status === 'unverifiable'
+          !targetWorktreeId ||
+          (worktreeId && runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
         ) {
+          selectedLivePtyIds.add(session.id)
+        }
+        if (
+          targetWorktreeId &&
+          (!worktreeId || !runtimeWorktreeIdsEqual(worktreeId, targetWorktreeId))
+        ) {
+          const receipt = this.restoredOrchestrationAuthorityByPtyId.get(session.id)
+          if (receipt && runtimeWorktreeIdsEqual(receipt.worktreeId, targetWorktreeId)) {
+            this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
+          }
+          continue
+        }
+        this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
+        if (worktreeId) {
+          const pty = this.recordPtyWorktree(session.id, worktreeId, {
+            connected: true,
+            incarnationId: session.incarnationId ?? null,
+            agentSessionOwners: session.incarnationId ? (session.agentSessionOwners ?? []) : [],
+            ...(session.wslDistro !== undefined
+              ? {
+                  isWsl: Boolean(session.wslDistro),
+                  wslDistro: session.wslDistro
+                }
+              : {}),
+            ...(restoresExactSurface
+              ? {
+                  tabId: persistedSurface.tabId,
+                  paneKey: persistedSurface.paneKey
+                }
+              : {})
+          })
+          if (restoresExactSurface && controllerIdentity) {
+            this.rememberRestoredOrchestrationAuthority(
+              pty,
+              controllerIdentity.handle,
+              controllerIdentity.incarnationId
+            )
+          } else {
+            this.restoredOrchestrationAuthorityByPtyId.delete(session.id)
+          }
+          pty.controllerTitle = session.title?.trim() || null
+          this.reconcileSubscriberDrivenProviderAttach(session.id)
+        }
+        // Why: fire-and-forget so this listing hot path doesn't serialize a relay round-trip per session and a throw can't abort the sweep below.
+        this.refreshPtyForegroundAgent(session.id)
+      }
+      for (const pty of this.ptysById.values()) {
+        if (connectionId !== undefined && pty.connectionId !== connectionId) {
+          continue
+        }
+        const encodedHostId = getPtyExecutionHost(pty.ptyId)
+        const ptyHostId =
+          encodedHostId === 'foreign'
+            ? null
+            : (encodedHostId ??
+              (pty.connectionId ? toSshExecutionHostId(pty.connectionId) : LOCAL_EXECUTION_HOST_ID))
+        if (!ptyHostId) {
+          continue
+        }
+        // An inventory can prove absence only for hosts that actually answered.
+        if (!queriedHostIds.has(ptyHostId)) {
+          if (this.isSshOwnedPtyId(pty.ptyId) && this.ptyController.hasPty?.(pty.ptyId) == null) {
+            this.markPtyLivenessUnverifiable(pty.ptyId, NO_OBSERVING_PROVIDER_REASON)
+          }
+          continue
+        }
+        if (!allLivePtyIds.has(pty.ptyId) && !this.leafExistsForPty(pty.ptyId)) {
+          const currentVerdict = this.ptyLivenessVerdictByPtyId.get(pty.ptyId)
+          if (
+            currentVerdict &&
+            currentVerdict.observedAt > livenessObservationAtStart &&
+            currentVerdict.verdict.status === 'unverifiable'
+          ) {
+            pty.connected = false
+            pty.disconnectedAt ??= Date.now()
+            continue
+          }
+          const observed = this.ptyController.hasPty?.(pty.ptyId)
+          if (observed === true) {
+            // Why: an SSH spawn can become addressable before an overlapping relay list includes it.
+            allLivePtyIds.add(pty.ptyId)
+            if (
+              !targetWorktreeId ||
+              (pty.worktreeId && runtimeWorktreeIdsEqual(pty.worktreeId, targetWorktreeId))
+            ) {
+              selectedLivePtyIds.add(pty.ptyId)
+            }
+            pty.connected = true
+            pty.disconnectedAt = null
+            this.markPtyLivenessLive(pty.ptyId, livenessObservationAtStart)
+            continue
+          }
           pty.connected = false
           pty.disconnectedAt ??= Date.now()
-          continue
-        }
-        const observed = this.ptyController.hasPty?.(pty.ptyId)
-        if (observed === true) {
-          // Why: an SSH spawn can become addressable before an overlapping relay list includes it.
-          allLivePtyIds.add(pty.ptyId)
-          if (
-            !targetWorktreeId ||
-            (pty.worktreeId && runtimeWorktreeIdsEqual(pty.worktreeId, targetWorktreeId))
-          ) {
-            selectedLivePtyIds.add(pty.ptyId)
+          pty.agentSessionOwners = []
+          // Why: this list only enumerates registered providers, so a dropped relay
+          // clears `connected` for every one of its PTYs at once. Only `false` here
+          // is an observed absence; `null` means no provider could be asked.
+          if (observed === false) {
+            // Drops the doubt without asserting a death: `pty.listProcesses` returns the relay's
+            // CURRENT session map, so a restarted relay omits every id the previous one minted
+            // whether or not those shells died. That is the same union as pty.attach's not-found,
+            // and neither earns `exited` (docs/reference/ssh-execution-boundary.md).
+            this.forgetPtyLivenessVerdict(pty.ptyId)
+          } else if (observed === null && this.isSshOwnedPtyId(pty.ptyId)) {
+            this.markPtyLivenessUnverifiable(pty.ptyId, NO_OBSERVING_PROVIDER_REASON)
           }
-          pty.connected = true
-          pty.disconnectedAt = null
-          this.markPtyLivenessLive(pty.ptyId, livenessObservationAtStart)
-          continue
-        }
-        pty.connected = false
-        pty.disconnectedAt ??= Date.now()
-        pty.agentSessionOwners = []
-        // Why: this list only enumerates registered providers, so a dropped relay
-        // clears `connected` for every one of its PTYs at once. Only `false` here
-        // is an observed absence; `null` means no provider could be asked.
-        if (observed === false) {
-          // Drops the doubt without asserting a death: `pty.listProcesses` returns the relay's
-          // CURRENT session map, so a restarted relay omits every id the previous one minted
-          // whether or not those shells died. That is the same union as pty.attach's not-found,
-          // and neither earns `exited` (docs/reference/ssh-execution-boundary.md).
-          this.forgetPtyLivenessVerdict(pty.ptyId)
-        } else if (observed === null && this.isSshOwnedPtyId(pty.ptyId)) {
-          this.markPtyLivenessUnverifiable(pty.ptyId, NO_OBSERVING_PROVIDER_REASON)
         }
       }
-    }
-    // Why: runs after the hasPty rescue so a still-addressable pane keeps its receipt.
-    retireOrchestrationAuthorityAbsentFromInventory(this.restoredOrchestrationAuthorityByPtyId, {
-      queriedHostIds,
-      allLivePtyIds,
-      connectionId
+      // Why: runs after the hasPty rescue so a still-addressable pane keeps its receipt.
+      retireOrchestrationAuthorityAbsentFromInventory(this.restoredOrchestrationAuthorityByPtyId, {
+        queriedHostIds,
+        allLivePtyIds,
+        connectionId
+      })
+      this.pruneDisconnectedPtyRecords()
+      return {
+        livePtyIds: targetWorktreeId ? selectedLivePtyIds : allLivePtyIds,
+        allLivePtyIds,
+        terminalIdentityByPtyId: controllerIdentityByPtyId,
+        queriedHostIds
+      }
     })
-    this.pruneDisconnectedPtyRecords()
-    return {
-      livePtyIds: targetWorktreeId ? selectedLivePtyIds : allLivePtyIds,
-      allLivePtyIds,
-      terminalIdentityByPtyId: controllerIdentityByPtyId,
-      queriedHostIds
-    }
   }
 }

--- a/src/main/runtime/orca-runtime-register-pty.ts
+++ b/src/main/runtime/orca-runtime-register-pty.ts
@@ -78,7 +78,7 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
         : {}),
       ...(isWsl !== undefined ? { isWsl } : {}),
       ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {}),
-      ...(binding?.incarnationId ? { incarnationId: binding.incarnationId } : {})
+      incarnationId: binding?.incarnationId ?? null
     })
     const agentLaunchAuthority = binding?.agentLaunchAuthority
     if (
@@ -162,7 +162,7 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
     const pty = this.ptysById.get(ptyId)
     if (pty) {
       // Why: a reconnect attach reply can prove the exit generation after stale local proof was cleared.
-      pty.incarnationId = incarnationId
+      this.transitionPtyIncarnation(pty, incarnationId)
     }
   }
 

--- a/src/main/runtime/orca-runtime-register-pty.ts
+++ b/src/main/runtime/orca-runtime-register-pty.ts
@@ -26,6 +26,7 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
     isWsl?: boolean
   ): void {
     this.assertPtyDidNotExitBeforeRegistration(ptyId, binding?.incarnationId)
+    this.ptyOwnershipRevisions.advance(ptyId)
     const existingPty = this.ptysById.get(ptyId)
     const replacementHandle = binding?.terminalHandle?.trim()
     const pendingReplacement = this.pendingPtyHandleReplacementFences.get(ptyId)
@@ -128,6 +129,7 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
     if (binding && paneKey) {
       this.ensurePtyBackedMobileSurfaceForRendererTab(worktreeId, binding.tabId)
     }
+    this.ptyOwnershipRevisions.advance(ptyId, binding?.incarnationId ?? null)
   }
 
   assertPtyRegistrationAllowed(ptyId: string, incarnationId?: PtyIncarnationId): void {
@@ -149,12 +151,14 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
       exitedIncarnation === candidateIncarnation
     ) {
       // Why: the rejected spawn call was the fence's sole late publisher; retaining it leaks fresh PTY ids.
+      this.ptyOwnershipRevisions.advance(ptyId)
       this.earlyExitedPtyIncarnations.delete(ptyId)
       this.pendingPtyRegistrationIncarnations.delete(ptyId)
     }
   }
 
   beginPtyRegistration(ptyId: string, incarnationId?: PtyIncarnationId): void {
+    this.ptyOwnershipRevisions.advance(ptyId)
     this.pendingPtyRegistrationIncarnations.set(ptyId, incarnationId ?? null)
   }
 
@@ -174,6 +178,7 @@ export class OrcaRuntimeWithRegisterPty extends OrcaRuntimeWithInvalidateAllHand
     ) {
       return
     }
+    this.ptyOwnershipRevisions.advance(ptyId)
     this.pendingPtyRegistrationIncarnations.delete(ptyId)
     const exited = this.earlyExitedPtyIncarnations.get(ptyId)
     if (

--- a/src/main/runtime/orca-runtime-resolve-known-workspace-file-target.ts
+++ b/src/main/runtime/orca-runtime-resolve-known-workspace-file-target.ts
@@ -118,6 +118,7 @@ export class OrcaRuntimeWithResolveKnownWorkspaceFileTarget extends OrcaRuntimeW
     if (existing) {
       return existing
     }
+    this.ptyOwnershipRevisions.advance(ptyId)
     const handle = this.createPreAllocatedTerminalHandle()
     this.handleByPtyId.set(ptyId, handle)
     return handle
@@ -160,6 +161,7 @@ export class OrcaRuntimeWithResolveKnownWorkspaceFileTarget extends OrcaRuntimeW
       // incarnation. Never let that predecessor alias be reintroduced.
       return
     }
+    this.ptyOwnershipRevisions.advance(ptyId)
     const retained = this.handleByPtyIncarnation.get(ptyId)
     if (retained?.handle === handle) {
       this.handleByPtyIncarnation.delete(ptyId)

--- a/src/main/runtime/orca-runtime-tests/mobile-creation-and-orchestration-part-03.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/mobile-creation-and-orchestration-part-03.spec.ts
@@ -188,7 +188,7 @@ describe('OrcaRuntimeService', () => {
       ).leaves
       expect(leaves.size).toBeGreaterThan(0)
       const rebuilt = [...leaves.values()][0]
-      expect(rebuilt.lastAgentStatus).toBe('idle')
+      expect(rebuilt.lastAgentStatus).toBeNull()
       expect(rebuilt.lastAgentStatusObservedLive).toBe(false)
 
       setInMemoryOrchestrationMessages(runtime, db)

--- a/src/main/runtime/orca-runtime-tests/pty-title-status.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/pty-title-status.spec.ts
@@ -32,6 +32,7 @@ describe('OrcaRuntimeService', () => {
     })
     runtime.attachWindow(1)
     runtime.markGraphReady(1)
+    await runtime.listTerminals()
 
     const terminals = await runtime.listTerminals()
 
@@ -56,10 +57,13 @@ describe('OrcaRuntimeService', () => {
       write: () => true,
       kill: () => true,
       getForegroundProcess: async () => null,
-      listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+      listProcesses: async () => [
+        { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+      ]
     })
     runtime.attachWindow(1)
     runtime.markGraphReady(1)
+    await runtime.listTerminals()
 
     expect((await runtime.listTerminals()).terminals[0]).toMatchObject({
       title: null
@@ -103,10 +107,13 @@ describe('OrcaRuntimeService', () => {
       write: () => true,
       kill: () => true,
       getForegroundProcess: async () => null,
-      listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+      listProcesses: async () => [
+        { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+      ]
     })
     runtime.attachWindow(1)
     runtime.markGraphReady(1)
+    await runtime.listTerminals()
 
     runtime.onPtyData(ptyId, '\x1b]0;⠋ Cursor Agent\x07', 100)
     // cursor-agent re-emits its bare native title on internal redraws while still working; it must not stomp the synthesized working title.
@@ -132,10 +139,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => null,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       // Live from cursor-agent: dropped, never recorded.
       runtime.onPtyData(ptyId, '\x1b]0;Cursor Agent\x07', 100)
@@ -164,10 +174,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => null,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyId, '\x1b]0;⠋ Cursor Agent\x07', 100)
       runtime.onPtyData(ptyId, 'streaming output with no title\r\n', 101)
@@ -196,10 +209,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => foreground,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyId, '\x1b]0;⠋ Cursor Agent\x07', 100)
       runtime.onPtyData(ptyId, 'agent exited; back at the shell\r\n', 101)
@@ -233,10 +249,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => foreground,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyId, '\x1b]0;⠋ Cursor Agent\x07', 100)
       runtime.onPtyData(ptyId, 'streaming output with no title\r\n', 101)
@@ -262,10 +281,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => 'cursor-agent',
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyId, '\x1b]0;⠋ Cursor Agent\x07', 100)
       runtime.onPtyData(ptyId, 'streaming output with no title\r\n', 101)
@@ -288,10 +310,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => null,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyId, '\x1b]0;Codex working\x07', 100)
       runtime.onPtyData(ptyId, 'output without a title\r\n', 101)
@@ -318,10 +343,13 @@ describe('OrcaRuntimeService', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => null,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyId, '\x1b]0;Codex working\x07', 100)
       runtime.onPtyData(ptyId, 'output without a title\r\n', 101)
@@ -349,12 +377,13 @@ describe('OrcaRuntimeService', () => {
         kill: () => true,
         getForegroundProcess: async () => null,
         listProcesses: async () => [
-          { id: ptyA, cwd: '/tmp/worktree-a', title: 'shell' },
-          { id: ptyB, cwd: '/tmp/worktree-a', title: 'shell' }
+          { id: ptyA, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' },
+          { id: ptyB, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
         ]
       })
       runtime.attachWindow(1)
       runtime.markGraphReady(1)
+      await runtime.listTerminals()
 
       runtime.onPtyData(ptyA, '\x1b]0;Codex working\x07', 100)
       runtime.onPtyData(ptyB, '\x1b]0;Aider working\x07', 100)

--- a/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status-part-02.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status-part-02.spec.ts
@@ -635,11 +635,18 @@ describe('OrcaRuntimeService', () => {
   it('keeps Claude agents management evidence when controller refresh reports a Claude process title', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
-      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg', incarnationId: 'synthetic-stable' }),
       write: () => true,
       kill: () => true,
       getForegroundProcess: async () => 'claude',
-      listProcesses: async () => [{ id: 'pty-bg', cwd: TEST_WORKTREE_PATH, title: 'claude' }]
+      listProcesses: async () => [
+        {
+          id: 'pty-bg',
+          incarnationId: 'synthetic-stable',
+          cwd: TEST_WORKTREE_PATH,
+          title: 'claude'
+        }
+      ]
     })
     runtime.attachWindow(1)
     runtime.syncWindowGraph(1, { tabs: [], leaves: [] })

--- a/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status-part-04.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-handles-and-agent-status-part-04.spec.ts
@@ -495,6 +495,7 @@ describe('OrcaRuntimeService', () => {
       opts.adoptedStablePane
         ? {
             id: 'pty-stable-owner',
+            incarnationId: 'synthetic-stable',
             isReattach: true,
             stablePaneOwner: {
               handle: opts.adoptedStablePane.owner.handle!,
@@ -502,7 +503,7 @@ describe('OrcaRuntimeService', () => {
               leafId: HEADLESS_LEAF_ID
             }
           }
-        : { id: 'pty-stable-owner' }
+        : { id: 'pty-stable-owner', incarnationId: 'synthetic-stable' }
     )
     const runtimeStore = {
       ...store,
@@ -526,7 +527,7 @@ describe('OrcaRuntimeService', () => {
       launchAgent: 'claude'
     })
     adoptStablePane.mockResolvedValueOnce({
-      result: { id: 'pty-stable-owner', isReattach: true },
+      result: { id: 'pty-stable-owner', incarnationId: 'synthetic-stable', isReattach: true },
       owner: {
         handle: first.handle,
         tabId: 'stable-owner-tab',

--- a/src/main/runtime/orca-runtime-tests/terminal-side-effect-facts.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-side-effect-facts.spec.ts
@@ -168,7 +168,9 @@ describe('terminal side-effect fact channel', () => {
         write: () => true,
         kill: () => true,
         getForegroundProcess: async () => null,
-        listProcesses: async () => [{ id: ptyId, cwd: '/tmp/worktree-a', title: 'shell' }]
+        listProcesses: async () => [
+          { id: ptyId, incarnationId: 'synthetic-stable', cwd: '/tmp/worktree-a', title: 'shell' }
+        ]
       })
       runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID, { tabs: [], leaves: [] })
       runtime.onClientEvent((event) => mobileEvents.push(event), {
@@ -176,6 +178,7 @@ describe('terminal side-effect fact channel', () => {
       })
       const unsubscribeDesktop = runtime.onClientEvent(() => {})
 
+      await runtime.listTerminals()
       runtime.onPtyData(ptyId, '\x1b]0;Codex working\x07', 100)
       runtime.onPtyData(ptyId, 'output without a title\r\n', 101)
       // The phone is still subscribed: disposing trackers on this edge would cancel

--- a/src/main/runtime/remote-agent-session-host-authority.integration.test.ts
+++ b/src/main/runtime/remote-agent-session-host-authority.integration.test.ts
@@ -138,6 +138,7 @@ describe('remote agent-session host authority integration', () => {
           })
           return {
             id: result.agentSessionEnsure?.owner.ptyId ?? resolvedSessionId,
+            incarnationId: result.incarnationId,
             ...(result.agentSessionEnsure ? { agentSessionEnsure: result.agentSessionEnsure } : {})
           }
         },

--- a/src/main/runtime/remote-agent-session-host-authority.integration.test.ts
+++ b/src/main/runtime/remote-agent-session-host-authority.integration.test.ts
@@ -70,7 +70,7 @@ describe('remote agent-session host authority integration', () => {
   })
 
   it(
-    'deduplicates racing remote resumes, adopts retries, and retires exited surfaces',
+    'returns one incumbent across racing workspace requests and lost-reply retries',
     { timeout: TEST_TIMEOUT_MS },
     async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-agent-authority-repro-'))
@@ -104,6 +104,15 @@ describe('remote agent-session host authority integration', () => {
         getProjects: () => []
       }
       const runtime = new OrcaRuntimeService(store as never)
+      Object.assign(runtime, {
+        resolveTerminalWorkspaceLaunchScope: async (selector: string) => ({
+          id: selector.replace(/^id:/, ''),
+          path: userDataPath,
+          connectionId: null,
+          repo: null,
+          folderWorkspace: null
+        })
+      })
       let nextRequestedSession = 0
       runtime.setPtyController({
         spawn: async (options) => {
@@ -168,7 +177,7 @@ describe('remote agent-session host authority integration', () => {
         ),
         secondClient.request<RuntimeEnsureAgentSessionResult>(
           'terminal.ensureAgentSession',
-          request,
+          { ...request, worktree: 'id:second-workspace' },
           REQUEST_TIMEOUT_MS
         )
       ])
@@ -183,19 +192,31 @@ describe('remote agent-session host authority integration', () => {
         'created'
       ])
       expect(second.result.terminal).toMatchObject({
+        worktreeId: first.result.terminal.worktreeId,
         handle: first.result.terminal.handle,
         tabId: first.result.terminal.tabId,
         paneKey: first.result.terminal.paneKey,
         ptyId: first.result.terminal.ptyId
       })
+      expect(first.result.terminal.worktreeId).toBe(FLOATING_TERMINAL_WORKTREE_ID)
       expect(spawnSubprocess).toHaveBeenCalledOnce()
       expect(host.listSessions()).toHaveLength(1)
 
       // Why: a retry cannot prove whether its previous response arrived, so
       // the provider identity—not a new client operation—must recover the owner.
+      const incumbentPtyId = first.result.terminal.ptyId
+      if (!incumbentPtyId) {
+        throw new Error('incumbent PTY missing')
+      }
+      const runtimeRecords = runtime as unknown as {
+        getOrCreatePtyWorktreeRecord: (ptyId: string) => { launchToken: string | null } | null
+      }
+      const incumbentRecord = runtimeRecords.getOrCreatePtyWorktreeRecord(incumbentPtyId)
+      const incumbentLaunchToken = incumbentRecord?.launchToken
+      expect(incumbentLaunchToken).toBeTruthy()
       const retry = await retryClient.request<RuntimeEnsureAgentSessionResult>(
         'terminal.ensureAgentSession',
-        request,
+        { ...request, worktree: 'id:second-workspace' },
         REQUEST_TIMEOUT_MS
       )
       expect(retry).toMatchObject({
@@ -211,6 +232,16 @@ describe('remote agent-session host authority integration', () => {
         }
       })
       expect(spawnSubprocess).toHaveBeenCalledOnce()
+
+      expect(runtimeRecords.getOrCreatePtyWorktreeRecord(incumbentPtyId)?.launchToken).toBe(
+        incumbentLaunchToken
+      )
+      const otherTabs = await secondClient.request<RuntimeMobileSessionTabsResult>(
+        'session.tabs.list',
+        { worktree: 'id:second-workspace' },
+        REQUEST_TIMEOUT_MS
+      )
+      expect(otherTabs).toMatchObject({ ok: true, result: { tabs: [] } })
 
       subprocesses[0]?.exit(0)
       await vi.waitFor(async () => {

--- a/src/main/runtime/runtime-incumbent-terminal-metadata.test.ts
+++ b/src/main/runtime/runtime-incumbent-terminal-metadata.test.ts
@@ -1,0 +1,154 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { ClaimedAgentPtyOwnerRegistry } from '../../shared/claimed-agent-pty-owner'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+import { getIncumbentTerminalMetadata } from './runtime-incumbent-terminal-metadata'
+import { OrcaRuntimeService } from './orca-runtime'
+
+function fixture() {
+  const runtime = new OrcaRuntimeService({
+    getSettings: () => ({
+      disabledTuiAgents: [],
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {}
+    }),
+    getRepos: () => [],
+    getRepo: () => undefined,
+    getAllWorktreeMeta: () => ({}),
+    getWorktreeMeta: () => undefined,
+    getProjects: () => []
+  } as never)
+  Object.assign(runtime, {
+    resolveTerminalWorkspaceLaunchScope: async (selector: string) => ({
+      id: selector.replace(/^id:/, ''),
+      path: process.cwd(),
+      connectionId: null,
+      repo: null,
+      folderWorkspace: null
+    })
+  })
+  const registry = new ClaimedAgentPtyOwnerRegistry()
+  let spawns = 0
+  runtime.setPtyController({
+    spawn: async (options) => {
+      const ensured = await registry.ensure({
+        ...options.agentSessionEnsure!,
+        spawn: async () => ({ ptyId: `synthetic-${++spawns}` })
+      })
+      return { id: ensured.owner.ptyId, agentSessionEnsure: ensured }
+    },
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => 'claude'
+  })
+  const reveal = vi.fn(async () => {})
+  runtime.setNotifier({ revealTerminalSession: reveal } as never)
+  const internals = runtime as unknown as {
+    mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+    ptysById: Map<string, RuntimePtyWorktreeRecord>
+  }
+  const claim = {
+    digestVersion: 1 as const,
+    keyId: 'synthetic-key',
+    agent: 'claude' as const,
+    identityDigest: 'writer',
+    worktreeScopeDigest: 'a'
+  }
+  return { runtime, internals, claim, reveal, spawns: () => spawns }
+}
+
+describe('incumbent terminal publication metadata', () => {
+  it.each([false, true])(
+    'preserves launch provenance through adoption and reveal (deferred=%s)',
+    async (deferred) => {
+      const { runtime, internals, claim, reveal, spawns } = fixture()
+      const cwd = join(process.cwd(), 'incumbent-subdirectory')
+      const first = await runtime.createTerminal('id:a', {
+        agentSessionClaim: claim,
+        cwd,
+        presentation: 'background',
+        title: 'incumbent',
+        viewMode: 'chat',
+        deferMobileSessionPublish: deferred
+      })
+      const second = await runtime.createTerminal('id:b', {
+        agentSessionClaim: { ...claim, worktreeScopeDigest: 'b' },
+        cwd: join(process.cwd(), 'requester'),
+        presentation: 'focused',
+        title: 'requester',
+        viewMode: 'terminal'
+      })
+      expect(second).toMatchObject({ ptyId: first.ptyId, worktreeId: 'a', title: 'incumbent' })
+      expect(spawns()).toBe(1)
+      expect(internals.mobileSessionTabsByWorktree.get('a')?.tabs[0]).toMatchObject({
+        startupCwd: cwd,
+        title: 'incumbent',
+        viewMode: 'chat',
+        ptyId: first.ptyId
+      })
+      expect((await runtime.listMobileSessionTabs('id:a')).tabs[0]).toMatchObject({
+        startupCwd: cwd,
+        title: 'incumbent',
+        viewMode: 'chat'
+      })
+      expect(internals.mobileSessionTabsByWorktree.has('b')).toBe(false)
+      expect(reveal).toHaveBeenLastCalledWith(
+        'a',
+        expect.objectContaining({ cwd, title: 'incumbent', viewMode: 'chat' })
+      )
+    }
+  )
+
+  it('does not invent requester title or cwd for an incumbent with no launch metadata', async () => {
+    const { runtime, internals, claim } = fixture()
+    const first = await runtime.createTerminal('id:a', {
+      agentSessionClaim: claim,
+      presentation: 'background'
+    })
+    const record = internals.ptysById.get(first.ptyId!)!
+    delete record.launchSurface
+    const surface = internals.mobileSessionTabsByWorktree.get('a')!.tabs[0]
+    if (surface.type !== 'terminal') {
+      throw new Error('missing terminal')
+    }
+    surface.startupCwd = join(process.cwd(), 'recovered')
+    const second = await runtime.createTerminal('id:b', {
+      agentSessionClaim: { ...claim, worktreeScopeDigest: 'b' },
+      presentation: 'background',
+      title: 'requester',
+      cwd: join(process.cwd(), 'requester')
+    })
+    expect(second.title).not.toBe('requester')
+    expect(internals.mobileSessionTabsByWorktree.get('a')?.tabs[0]).toMatchObject({
+      startupCwd: surface.startupCwd
+    })
+  })
+  it('fences prior incarnation metadata and preserves explicit root launch intent', async () => {
+    const { runtime, internals, claim } = fixture()
+    const first = await runtime.createTerminal('id:a', {
+      agentSessionClaim: claim,
+      presentation: 'background'
+    })
+    const record = internals.ptysById.get(first.ptyId!)!
+    const tabs = internals.mobileSessionTabsByWorktree.get('a')!.tabs
+    const surface = tabs[0]
+    if (surface.type !== 'terminal') {
+      throw new Error('missing terminal')
+    }
+    surface.startupCwd = join(process.cwd(), 'stale')
+    expect(
+      getIncumbentTerminalMetadata(record, tabs, surface.parentTabId, surface.leafId).cwd
+    ).toBeUndefined()
+    record.launchSurface = {
+      incarnationId: 'old',
+      startupCwd: join(process.cwd(), 'old'),
+      viewMode: 'chat'
+    }
+    surface.incarnationId = 'old'
+    expect(
+      getIncumbentTerminalMetadata(record, tabs, surface.parentTabId, surface.leafId)
+    ).toMatchObject({ cwd: undefined, viewMode: undefined })
+  })
+})

--- a/src/main/runtime/runtime-incumbent-terminal-metadata.test.ts
+++ b/src/main/runtime/runtime-incumbent-terminal-metadata.test.ts
@@ -37,7 +37,11 @@ function fixture() {
         ...options.agentSessionEnsure!,
         spawn: async () => ({ ptyId: `synthetic-${++spawns}` })
       })
-      return { id: ensured.owner.ptyId, agentSessionEnsure: ensured }
+      return {
+        id: ensured.owner.ptyId,
+        incarnationId: 'incumbent-incarnation',
+        agentSessionEnsure: ensured
+      }
     },
     write: () => true,
     kill: () => true,
@@ -80,7 +84,11 @@ describe('incumbent terminal publication metadata', () => {
         title: 'requester',
         viewMode: 'terminal'
       })
-      expect(second).toMatchObject({ ptyId: first.ptyId, worktreeId: 'a', title: 'incumbent' })
+      expect(second).toMatchObject({
+        ptyId: first.ptyId,
+        worktreeId: 'a',
+        title: 'incumbent'
+      })
       expect(spawns()).toBe(1)
       expect(internals.mobileSessionTabsByWorktree.get('a')?.tabs[0]).toMatchObject({
         startupCwd: cwd,
@@ -141,11 +149,11 @@ describe('incumbent terminal publication metadata', () => {
     expect(
       getIncumbentTerminalMetadata(record, tabs, surface.parentTabId, surface.leafId).cwd
     ).toBeUndefined()
-    record.launchSurface = {
-      incarnationId: 'old',
-      startupCwd: join(process.cwd(), 'old'),
-      viewMode: 'chat'
-    }
+    runtime.registerPty(first.ptyId!, 'a', null, {
+      tabId: surface.parentTabId,
+      leafId: surface.leafId,
+      incarnationId: 'replacement'
+    })
     surface.incarnationId = 'old'
     expect(
       getIncumbentTerminalMetadata(record, tabs, surface.parentTabId, surface.leafId)

--- a/src/main/runtime/runtime-incumbent-terminal-metadata.ts
+++ b/src/main/runtime/runtime-incumbent-terminal-metadata.ts
@@ -10,6 +10,7 @@ export function getIncumbentTerminalMetadata(
 ) {
   const surface = tabs?.find(
     (tab) =>
+      pty.incarnationId !== null &&
       tab.type === 'terminal' &&
       tab.parentTabId === tabId &&
       tab.leafId === leafId &&
@@ -17,8 +18,7 @@ export function getIncumbentTerminalMetadata(
       (tab.incarnationId ?? null) === pty.incarnationId
   )
   const terminal = surface?.type === 'terminal' ? surface : undefined
-  const launch =
-    pty.launchSurface?.incarnationId === pty.incarnationId ? pty.launchSurface : undefined
+  const launch = pty.launchSurface
   return {
     title: getLatestPtyTitle(pty) ?? terminal?.title ?? null,
     // An explicit root launch must not inherit a prior surface's subdirectory.
@@ -37,7 +37,6 @@ export function recordTerminalLaunchSurface(
   viewMode?: 'terminal' | 'chat'
 ): void {
   pty.launchSurface = {
-    incarnationId: pty.incarnationId,
     ...(cwd !== workspacePath ? { startupCwd: cwd } : {}),
     ...(viewMode ? { viewMode } : {})
   }

--- a/src/main/runtime/runtime-incumbent-terminal-metadata.ts
+++ b/src/main/runtime/runtime-incumbent-terminal-metadata.ts
@@ -1,0 +1,44 @@
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+import { getLatestPtyTitle } from './runtime-worktree-status-projection'
+
+export function getIncumbentTerminalMetadata(
+  pty: RuntimePtyWorktreeRecord,
+  tabs: RuntimeMobileSessionTabsSnapshot['tabs'] | undefined,
+  tabId: string,
+  leafId: string
+) {
+  const surface = tabs?.find(
+    (tab) =>
+      tab.type === 'terminal' &&
+      tab.parentTabId === tabId &&
+      tab.leafId === leafId &&
+      tab.ptyId === pty.ptyId &&
+      (tab.incarnationId ?? null) === pty.incarnationId
+  )
+  const terminal = surface?.type === 'terminal' ? surface : undefined
+  const launch =
+    pty.launchSurface?.incarnationId === pty.incarnationId ? pty.launchSurface : undefined
+  return {
+    title: getLatestPtyTitle(pty) ?? terminal?.title ?? null,
+    // An explicit root launch must not inherit a prior surface's subdirectory.
+    cwd: launch ? launch.startupCwd : terminal?.startupCwd,
+    viewMode: terminal?.viewMode ?? launch?.viewMode,
+    launchConfig: pty.launchConfig ?? undefined,
+    launchToken: pty.launchToken ?? undefined,
+    launchAgent: pty.launchAgent ?? undefined
+  }
+}
+
+export function recordTerminalLaunchSurface(
+  pty: RuntimePtyWorktreeRecord,
+  cwd: string,
+  workspacePath: string,
+  viewMode?: 'terminal' | 'chat'
+): void {
+  pty.launchSurface = {
+    incarnationId: pty.incarnationId,
+    ...(cwd !== workspacePath ? { startupCwd: cwd } : {}),
+    ...(viewMode ? { viewMode } : {})
+  }
+}

--- a/src/main/runtime/runtime-pty-foreground-agent-incarnation.test.ts
+++ b/src/main/runtime/runtime-pty-foreground-agent-incarnation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RuntimePtyForegroundAgent } from './runtime-pty-foreground-agent'
+import type { RuntimePtyController } from './runtime-pty-controller-contract'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+
+describe('foreground process observation ownership', () => {
+  it('retires pending predecessor reads and independently observes the replacement', async () => {
+    let resolvePredecessor!: (value: string) => void
+    const predecessor = new Promise<string>((resolve) => {
+      resolvePredecessor = resolve
+    })
+    const controller = {
+      getForegroundProcess: vi.fn().mockReturnValueOnce(predecessor).mockResolvedValue('codex')
+    } as unknown as RuntimePtyController
+    const pty = {
+      connected: true,
+      launchAgent: null,
+      foregroundAgent: null
+    } as RuntimePtyWorktreeRecord
+    const touchSnapshot = vi.fn()
+    const observer = new RuntimePtyForegroundAgent({
+      getController: () => controller,
+      getPty: () => pty,
+      touchSnapshot,
+      finishDelayedSnapshot: vi.fn()
+    })
+    const oldRefresh = observer.refresh('synthetic')
+    observer.resetIncarnation('synthetic')
+    expect(await observer.refresh('synthetic')).toBe(true)
+    expect(pty.foregroundAgent).toBe('codex')
+    resolvePredecessor('claude')
+    expect(await oldRefresh).toBe(false)
+    expect(pty.foregroundAgent).toBe('codex')
+    expect(touchSnapshot).toHaveBeenCalledTimes(1)
+    expect(controller.getForegroundProcess).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/runtime/runtime-pty-foreground-agent.ts
+++ b/src/main/runtime/runtime-pty-foreground-agent.ts
@@ -51,7 +51,11 @@ export class RuntimePtyForegroundAgent {
     }
     let entry: PtyForegroundProcessReadEntry
     const promise = processRead
-      .then((process) => ({ controller, process, available: true }))
+      .then((process) => ({
+        controller,
+        process,
+        available: this.reads.get(ptyId) === entry
+      }))
       .catch(() => unavailable)
       .finally(() => this.deleteRead(ptyId, entry))
     entry = { controller, startedAfterTitleObservation: afterTitle, promise }
@@ -114,6 +118,12 @@ export class RuntimePtyForegroundAgent {
   }
 
   clearDelayedSnapshot(ptyId: string): void {
+    this.delayedTitles.delete(ptyId)
+  }
+
+  resetIncarnation(ptyId: string): void {
+    this.reads.delete(ptyId)
+    this.refreshes.delete(ptyId)
     this.delayedTitles.delete(ptyId)
   }
 

--- a/src/main/runtime/runtime-pty-inventory-ownership.test.ts
+++ b/src/main/runtime/runtime-pty-inventory-ownership.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+import type { PtyControllerInventory } from './runtime-pty-controller-contract'
+
+const PTY = 'synthetic-pty'
+const WORKSPACE = 'folder:synthetic'
+const binding = { tabId: 'tab-terminal', leafId: '11111111-1111-4111-8111-111111111111' }
+
+function fixture() {
+  const runtime = new OrcaRuntimeService(null)
+  const pending: ((value: PtyProcessInfo[]) => void)[] = []
+  const controller = {
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    listProcesses: vi.fn(() => new Promise<PtyProcessInfo[]>((resolve) => pending.push(resolve)))
+  }
+  runtime.setPtyController(controller)
+  const internal = runtime as unknown as {
+    ptysById: Map<string, RuntimePtyWorktreeRecord>
+    handleByPtyId: Map<string, string>
+    refreshPtyWorktreeRecordsWithControllerInventory: (
+      worktrees: [],
+      target?: null,
+      deadline?: undefined,
+      connectionId?: string | null
+    ) => Promise<PtyControllerInventory | null>
+    recordPtyWorktree: (id: string, workspace: string, state?: object) => void
+    dropDisconnectedPtyRecord: (id: string) => void
+    clearPtyIncarnationHandles: () => void
+    invalidateAllHandlesForPty: (id: string) => void
+    retirePtyAgentLaunchAuthority: (id: string) => void
+    rollbackLegacyWorkerTerminalSurface: (candidate: object) => void
+  }
+  function register(incarnationId: string, id = PTY, workspace = WORKSPACE) {
+    runtime.registerPty(id, workspace, null, {
+      ...binding,
+      incarnationId,
+      agentLaunchAuthority: { launchToken: `synthetic-${incarnationId}`, launchAgent: 'codex' }
+    })
+  }
+  function session(incarnationId: string, id = PTY): PtyProcessInfo {
+    return { id, worktreeId: WORKSPACE, incarnationId, cwd: '', title: `title-${incarnationId}` }
+  }
+  return {
+    runtime,
+    internal,
+    controller,
+    register,
+    session,
+    record: () => internal.ptysById.get(PTY)!,
+    start: (connectionId?: string | null) =>
+      internal.refreshPtyWorktreeRecordsWithControllerInventory([], null, undefined, connectionId),
+    finish: (sessions: PtyProcessInfo[], index = 0) => pending[index](sessions)
+  }
+}
+
+describe('inventory ownership revision admission', () => {
+  it.each(['old', 'unknown', 'absent'])(
+    'rejects delayed %s observation after replacement registration',
+    async (reply) => {
+      const f = fixture()
+      f.register('a')
+      const pending = f.start()
+      f.register('b')
+      f.runtime.registerPreAllocatedHandleForPty(PTY, 'term_replacement')
+      const before = { ...f.record() }
+      f.finish(
+        reply === 'absent'
+          ? []
+          : [
+              {
+                ...f.session('a'),
+                incarnationId: reply === 'unknown' ? undefined : 'a',
+                terminalHandle: 'term_predecessor'
+              }
+            ]
+      )
+      expect(await pending).toBeNull()
+      expect(f.record()).toEqual(before)
+      expect(f.internal.handleByPtyId.get(PTY)).toBe('term_replacement')
+    }
+  )
+
+  it('accepts positive current-B evidence without discarding B metadata', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    f.register('b')
+    f.record().launchConfig = { agentCommand: 'codex', agentArgs: 'synthetic', agentEnv: {} }
+    f.finish([f.session('b')])
+    expect(await pending).not.toBeNull()
+    expect(f.record()).toMatchObject({
+      incarnationId: 'b',
+      launchToken: 'synthetic-b',
+      launchAgent: 'codex',
+      controllerTitle: 'title-b',
+      launchConfig: { agentArgs: 'synthetic' }
+    })
+  })
+
+  it('admits a genuine replacement observed by a request begun after B registered', async () => {
+    const f = fixture()
+    f.register('b')
+    const pending = f.start()
+    f.finish([f.session('c')])
+    expect(await pending).not.toBeNull()
+    expect(f.record()).toMatchObject({
+      incarnationId: 'c',
+      launchToken: null,
+      launchAgent: null,
+      controllerTitle: 'title-c'
+    })
+  })
+
+  it.each(['old', 'absent'])(
+    'does not lose a newly registered owner to %s inventory',
+    async (reply) => {
+      const f = fixture()
+      const pending = f.start()
+      f.register('b')
+      f.finish(reply === 'absent' ? [] : [f.session('a')])
+      expect(await pending).toBeNull()
+      expect(f.record()).toMatchObject({
+        incarnationId: 'b',
+        launchToken: 'synthetic-b',
+        connected: true
+      })
+    }
+  )
+
+  it.each([
+    'spawn',
+    'pending-registration',
+    'exit-identity',
+    'exit',
+    'drop',
+    'clear',
+    'invalidate',
+    'retire',
+    'rebind',
+    'controller'
+  ])('fences an inventory crossing %s before any metadata mutation', async (writer) => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    if (writer === 'spawn') {
+      f.runtime.onPtySpawned(PTY, 'b')
+    }
+    if (writer === 'pending-registration') {
+      f.runtime.beginPtyRegistration(PTY, 'b')
+    }
+    if (writer === 'exit-identity') {
+      f.runtime.acceptPtyIncarnationForExit(PTY, 'b')
+    }
+    if (writer === 'exit') {
+      f.runtime.onPtyExit(PTY, 0, 'a')
+    }
+    if (writer === 'drop') {
+      f.internal.dropDisconnectedPtyRecord(PTY)
+    }
+    if (writer === 'clear') {
+      f.internal.clearPtyIncarnationHandles()
+    }
+    if (writer === 'invalidate') {
+      f.internal.invalidateAllHandlesForPty(PTY)
+    }
+    if (writer === 'retire') {
+      f.internal.retirePtyAgentLaunchAuthority(PTY)
+    }
+    if (writer === 'rebind') {
+      f.internal.recordPtyWorktree(PTY, 'folder:new')
+    }
+    if (writer === 'controller') {
+      f.runtime.setPtyController(f.controller)
+    }
+    const before = f.record() ? { ...f.record() } : undefined
+    f.finish([f.session('a')])
+    expect(await pending).toBeNull()
+    expect(f.record()).toEqual(before)
+  })
+
+  it.each(['clear', 'exit', 'rebind'])('positive equality cannot override %s', async (writer) => {
+    const f = fixture()
+    f.register('b')
+    const pending = f.start()
+    if (writer === 'clear') {
+      f.internal.clearPtyIncarnationHandles()
+    }
+    if (writer === 'exit') {
+      f.runtime.onPtyExit(PTY, 0, 'b')
+    }
+    if (writer === 'rebind') {
+      f.internal.recordPtyWorktree(PTY, 'folder:new')
+    }
+    const before = { ...f.record() }
+    f.finish([f.session('b')])
+    expect(await pending).toBeNull()
+    expect(f.record()).toEqual(before)
+  })
+
+  it('does not resurrect an ID created then removed during inventory', async () => {
+    const f = fixture()
+    const pending = f.start()
+    f.register('b')
+    f.internal.dropDisconnectedPtyRecord(PTY)
+    f.finish([f.session('b')])
+    expect(await pending).toBeNull()
+    expect(f.record()).toBeUndefined()
+  })
+
+  it('preserves inventory ordering across parallel requests and owner changes', async () => {
+    const f = fixture()
+    f.register('a')
+    const first = f.start()
+    f.register('b')
+    const second = f.start()
+    f.finish([f.session('b')], 1)
+    expect(await second).not.toBeNull()
+    f.finish([f.session('a')])
+    expect(await first).toBeNull()
+    expect(f.record()).toMatchObject({ incarnationId: 'b', launchToken: 'synthetic-b' })
+  })
+
+  it('ignores unrelated SSH ownership changes during a local census', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start(null)
+    f.runtime.registerPty('ssh:other@@pty', 'folder:remote', 'other', {
+      ...binding,
+      incarnationId: 'remote-b'
+    })
+    f.finish([f.session('a')])
+    expect(await pending).not.toBeNull()
+    expect(f.record().controllerTitle).toBe('title-a')
+  })
+
+  it('does not let a local observation revert a new SSH binding', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start(null)
+    f.runtime.registerPty(PTY, 'folder:remote', 'other', { ...binding, incarnationId: 'b' })
+    f.finish([f.session('a')])
+    expect(await pending).toBeNull()
+    expect(f.record()).toMatchObject({
+      incarnationId: 'b',
+      connectionId: 'other',
+      worktreeId: 'folder:remote'
+    })
+  })
+
+  it('rejects a matching incarnation with a predecessor binding or exported handle', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    f.register('b', PTY, 'folder:new')
+    f.finish([{ ...f.session('b'), terminalHandle: 'term_predecessor' }])
+    expect(await pending).toBeNull()
+    expect(f.record()).toMatchObject({
+      incarnationId: 'b',
+      launchToken: 'synthetic-b',
+      worktreeId: 'folder:new'
+    })
+  })
+
+  it('releases rejected inventory observations before a later valid census', async () => {
+    const f = fixture()
+    f.register('a')
+    const first = f.start()
+    f.internal.clearPtyIncarnationHandles()
+    f.finish([f.session('a')])
+    expect(await first).toBeNull()
+    const second = f.start()
+    f.finish([f.session('a')], 1)
+    expect(await second).not.toBeNull()
+    expect(f.record().launchToken).toBe('synthetic-a')
+  })
+
+  it('fences observations crossing cancellation of a pending registration', async () => {
+    const f = fixture()
+    f.register('a')
+    f.runtime.beginPtyRegistration(PTY, 'b')
+    const pending = f.start()
+    f.runtime.cancelPendingPtyRegistration(PTY, 'b')
+    f.finish([])
+    expect(await pending).toBeNull()
+    expect(f.record().connected).toBe(true)
+  })
+
+  it.each(['present', 'absent'])('fences %s inventory across recovery rollback', async (reply) => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    f.internal.rollbackLegacyWorkerTerminalSurface({
+      ptyId: PTY,
+      worktreeId: WORKSPACE,
+      tabId: binding.tabId,
+      leafId: binding.leafId,
+      paneKey: f.record().paneKey
+    })
+    const before = { ...f.record() }
+    f.finish(reply === 'present' ? [f.session('a')] : [])
+    expect(await pending).toBeNull()
+    expect(f.record()).toEqual(before)
+    expect(f.record().paneKey).toBeNull()
+  })
+
+  it('reconciles absence from a current inventory', async () => {
+    const f = fixture()
+    f.register('b')
+    const pending = f.start()
+    f.finish([])
+    expect(await pending).not.toBeNull()
+    expect(f.record().connected).toBe(false)
+  })
+
+  it('preserves metadata on unchanged and renewed same-incarnation ownership', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    f.register('a')
+    f.finish([f.session('a')])
+    expect(await pending).not.toBeNull()
+    expect(f.record()).toMatchObject({
+      launchToken: 'synthetic-a',
+      launchAgent: 'codex',
+      controllerTitle: 'title-a'
+    })
+  })
+})

--- a/src/main/runtime/runtime-pty-observation-custody.test.ts
+++ b/src/main/runtime/runtime-pty-observation-custody.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { RuntimePtyOwnershipRevisions } from './runtime-pty-ownership-revisions'
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+import type { PtyControllerInventory } from './runtime-pty-controller-contract'
+
+function fixture() {
+  const runtime = new OrcaRuntimeService(null)
+  const pending: ((sessions: PtyProcessInfo[]) => void)[] = []
+  const controller = {
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    listProcesses: vi.fn(() => new Promise<PtyProcessInfo[]>((resolve) => pending.push(resolve)))
+  }
+  runtime.setPtyController(controller)
+  const internal = runtime as unknown as {
+    ptysById: Map<string, RuntimePtyWorktreeRecord>
+    ptyOwnershipRevisions: { observations: Set<unknown> }
+    refreshPtyWorktreeRecordsWithControllerInventory: (
+      worktrees: [],
+      target?: string | null,
+      deadline?: number
+    ) => Promise<PtyControllerInventory | null>
+  }
+  const register = (incarnationId: string, id = 'synthetic-pty') =>
+    runtime.registerPty(id, 'folder:synthetic', null, {
+      tabId: 'tab-terminal',
+      leafId: '11111111-1111-4111-8111-111111111111',
+      incarnationId,
+      agentLaunchAuthority: { launchToken: `synthetic-${incarnationId}`, launchAgent: 'codex' }
+    })
+  const session = (incarnationId = 'a'): PtyProcessInfo => ({
+    id: 'synthetic-pty',
+    worktreeId: 'folder:synthetic',
+    incarnationId,
+    cwd: '',
+    title: 'inventory-title'
+  })
+  return {
+    runtime,
+    controller,
+    register,
+    session,
+    start: (target?: string | null, deadline?: number) =>
+      internal.refreshPtyWorktreeRecordsWithControllerInventory([], target, deadline),
+    finish: (sessions: PtyProcessInfo[], index = 0) => pending[index](sessions),
+    active: () => internal.ptyOwnershipRevisions.observations.size,
+    record: () => internal.ptysById.get('synthetic-pty')!
+  }
+}
+
+describe('inventory observation custody', () => {
+  const schedules = [false, true].flatMap((absent) =>
+    Array.from({ length: 11 }, (_, ticks) => ({ absent, ticks }))
+  )
+  it.each(schedules)(
+    'preserves replacement at offset $ticks, absent=$absent',
+    async ({ ticks, absent }) => {
+      const f = fixture()
+      f.register('a')
+      const pending = f.start()
+      f.finish(absent ? [] : [f.session()])
+      for (let i = 0; i < ticks; i++) {
+        await Promise.resolve()
+      }
+      f.register('b')
+      await pending
+      expect(f.record()).toMatchObject({
+        incarnationId: 'b',
+        launchToken: 'synthetic-b',
+        connected: true
+      })
+      expect(f.active()).toBe(0)
+    }
+  )
+
+  it('releases successful and rejected censuses', async () => {
+    const f = fixture()
+    f.register('a')
+    const success = f.start()
+    expect(f.active()).toBe(1)
+    f.finish([f.session()])
+    expect(await success).not.toBeNull()
+    expect(f.active()).toBe(0)
+    const rejected = f.start()
+    f.register('b')
+    f.finish([], 1)
+    expect(await rejected).toBeNull()
+    expect(f.active()).toBe(0)
+  })
+
+  it.each(['throw', 'reject'])(
+    'releases a provider %s and admits the next census',
+    async (mode) => {
+      const f = fixture()
+      f.register('a')
+      f.controller.listProcesses.mockImplementationOnce(() => {
+        if (mode === 'throw') {
+          throw new Error('synthetic read failure')
+        }
+        return Promise.reject(new Error('synthetic read failure'))
+      })
+      if (mode === 'throw') {
+        await expect(f.start()).rejects.toThrow('synthetic read failure')
+      } else {
+        expect(await f.start()).toBeNull()
+      }
+      expect(f.active()).toBe(0)
+      const next = f.start()
+      f.finish([f.session()])
+      expect(await next).not.toBeNull()
+      expect(f.active()).toBe(0)
+    }
+  )
+
+  it('releases a timeout without applying its late response', async () => {
+    const f = fixture()
+    f.register('a')
+    expect(await f.start(null, Date.now())).toBeNull()
+    expect(f.active()).toBe(0)
+    f.register('b')
+    f.finish([f.session()])
+    const next = f.start()
+    f.finish([f.session('b')], 1)
+    expect(await next).not.toBeNull()
+    expect(f.active()).toBe(0)
+    expect(f.record().launchToken).toBe('synthetic-b')
+  })
+
+  it('releases when synchronous application throws', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    const invalid = f.session()
+    Object.defineProperty(invalid, 'title', {
+      get: () => {
+        throw new Error('synthetic application failure')
+      }
+    })
+    f.finish([invalid])
+    await expect(pending).rejects.toThrow('synthetic application failure')
+    expect(f.active()).toBe(0)
+    const next = f.start()
+    f.finish([f.session()], 1)
+    expect(await next).not.toBeNull()
+    expect(f.active()).toBe(0)
+  })
+
+  it('releases cancellation-invalidated inventory', async () => {
+    const f = fixture()
+    f.register('a')
+    f.runtime.beginPtyRegistration('synthetic-pty', 'b')
+    const pending = f.start()
+    f.runtime.cancelPendingPtyRegistration('synthetic-pty', 'b')
+    f.finish([])
+    expect(await pending).toBeNull()
+    expect(f.active()).toBe(0)
+    expect(f.record().connected).toBe(true)
+  })
+
+  it('releases a stale generation and its targeted retry', async () => {
+    const f = fixture()
+    f.register('a')
+    const first = f.start('folder:synthetic')
+    const second = f.start()
+    f.finish([f.session()], 1)
+    expect(await second).not.toBeNull()
+    f.controller.listProcesses.mockResolvedValueOnce([f.session()])
+    f.finish([f.session()])
+    expect(await first).not.toBeNull()
+    expect(f.controller.listProcesses).toHaveBeenCalledTimes(3)
+    expect(f.active()).toBe(0)
+  })
+
+  it('defers unrelated same-host rows until a census without conflicting churn', async () => {
+    const f = fixture()
+    f.register('a')
+    const pending = f.start()
+    f.register('b', 'unrelated-pty')
+    f.finish([f.session()])
+    expect(await pending).toBeNull()
+    expect(f.record().controllerTitle).toBeNull()
+    const next = f.start()
+    f.finish([f.session()], 1)
+    expect(await next).not.toBeNull()
+    expect(f.record().controllerTitle).toBe('inventory-title')
+    expect(f.active()).toBe(0)
+  })
+
+  it('retains custody through consumer awaits and refuses escaped observations', async () => {
+    const revisions = new RuntimePtyOwnershipRevisions()
+    let escaped!: Parameters<typeof revisions.admits>[0]
+    await revisions.withObservation(async (observation) => {
+      escaped = observation
+      await Promise.resolve()
+      revisions.advance('new-owner')
+      expect(revisions.admits(observation, [], new Map(), new Map())).toBe(false)
+    })
+    expect(revisions.admits(escaped, [], new Map(), new Map())).toBe(false)
+    await revisions.withObservation(async (observation) => {
+      expect(revisions.admits(observation, [], new Map(), new Map())).toBe(true)
+    })
+  })
+})

--- a/src/main/runtime/runtime-pty-ownership-revisions.ts
+++ b/src/main/runtime/runtime-pty-ownership-revisions.ts
@@ -11,24 +11,28 @@ type OwnershipObservation = {
   cleared: boolean
 }
 
-// Revisions live only as long as outstanding observations, including removed/new PTY IDs.
+// Custody spans reading, admission and application, including removed/new PTY IDs.
 export class RuntimePtyOwnershipRevisions {
   private revision = 0
   private observations = new Set<OwnershipObservation>()
 
-  async observe<T>(
-    read: () => Promise<T>
-  ): Promise<{ observation: OwnershipObservation; result: T }> {
+  async withObservation<T>(
+    operation: (observation: OwnershipObservation) => Promise<T>
+  ): Promise<T> {
     const observation = this.capture()
     try {
-      return { observation, result: await read() }
+      return await operation(observation)
     } finally {
       this.release(observation)
     }
   }
 
   private capture(): OwnershipObservation {
-    const observation = { revision: this.revision, changes: new Map(), cleared: false }
+    const observation = {
+      revision: this.revision,
+      changes: new Map(),
+      cleared: false
+    }
     this.observations.add(observation)
     return observation
   }
@@ -58,7 +62,7 @@ export class RuntimePtyOwnershipRevisions {
     handles: ReadonlyMap<string, string>,
     connectionId?: string | null
   ): boolean {
-    if (observation.cleared) {
+    if (!this.observations.has(observation) || observation.cleared) {
       return false
     }
     const sessionsById = new Map(sessions.map((session) => [session.id, session]))

--- a/src/main/runtime/runtime-pty-ownership-revisions.ts
+++ b/src/main/runtime/runtime-pty-ownership-revisions.ts
@@ -1,0 +1,91 @@
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+
+type OwnershipChange = {
+  revision: number
+  incarnationId: string | null
+}
+type OwnershipObservation = {
+  revision: number
+  changes: Map<string, OwnershipChange>
+  cleared: boolean
+}
+
+// Revisions live only as long as outstanding observations, including removed/new PTY IDs.
+export class RuntimePtyOwnershipRevisions {
+  private revision = 0
+  private observations = new Set<OwnershipObservation>()
+
+  async observe<T>(
+    read: () => Promise<T>
+  ): Promise<{ observation: OwnershipObservation; result: T }> {
+    const observation = this.capture()
+    try {
+      return { observation, result: await read() }
+    } finally {
+      this.release(observation)
+    }
+  }
+
+  private capture(): OwnershipObservation {
+    const observation = { revision: this.revision, changes: new Map(), cleared: false }
+    this.observations.add(observation)
+    return observation
+  }
+
+  private release(observation: OwnershipObservation): void {
+    this.observations.delete(observation)
+  }
+
+  advance(ptyId: string, incarnationId: string | null = null): void {
+    const change = { revision: ++this.revision, incarnationId }
+    for (const observation of this.observations) {
+      observation.changes.set(ptyId, change)
+    }
+  }
+
+  clear(): void {
+    this.revision++
+    for (const observation of this.observations) {
+      observation.cleared = true
+    }
+  }
+
+  admits(
+    observation: OwnershipObservation,
+    sessions: readonly PtyProcessInfo[],
+    records: ReadonlyMap<string, RuntimePtyWorktreeRecord>,
+    handles: ReadonlyMap<string, string>,
+    connectionId?: string | null
+  ): boolean {
+    if (observation.cleared) {
+      return false
+    }
+    const sessionsById = new Map(sessions.map((session) => [session.id, session]))
+    for (const [ptyId, change] of observation.changes) {
+      const current = records.get(ptyId)
+      if (
+        current &&
+        connectionId !== undefined &&
+        current.connectionId !== connectionId &&
+        !sessionsById.has(ptyId)
+      ) {
+        continue
+      }
+      const observed = sessionsById.get(ptyId)
+      // A newer explicit owner can corroborate a positive reply, never absence or invalidation.
+      if (
+        change.revision > observation.revision &&
+        (!change.incarnationId ||
+          !current?.connected ||
+          current.incarnationId !== change.incarnationId ||
+          observed?.incarnationId !== change.incarnationId ||
+          observed.worktreeId !== current.worktreeId ||
+          (observed.terminalHandle !== undefined && observed.terminalHandle !== handles.get(ptyId)))
+      ) {
+        return false
+      }
+    }
+    return true
+  }
+}

--- a/src/main/runtime/runtime-terminal-incarnation-metadata.test.ts
+++ b/src/main/runtime/runtime-terminal-incarnation-metadata.test.ts
@@ -1,0 +1,306 @@
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { ClaimedAgentPtyOwnerRegistry } from '../../shared/claimed-agent-pty-owner'
+import type { RuntimeMobileSessionTabsSnapshot } from '../../shared/runtime-types'
+import type { RuntimePtyWorktreeRecord } from './runtime-terminal-state-records'
+import { OrcaRuntimeService } from './orca-runtime'
+
+async function fixture(initialIncarnation: string | null = 'incarnation-a') {
+  const runtime = new OrcaRuntimeService({
+    getSettings: () => ({
+      disabledTuiAgents: [],
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {}
+    }),
+    getRepos: () => [],
+    getRepo: () => undefined,
+    getAllWorktreeMeta: () => ({}),
+    getWorktreeMeta: () => undefined,
+    getProjects: () => []
+  } as never)
+  Object.assign(runtime, {
+    resolveTerminalWorkspaceLaunchScope: async (selector: string) => ({
+      id: selector.replace(/^id:/, ''),
+      path: process.cwd(),
+      connectionId: null,
+      repo: null,
+      folderWorkspace: null
+    })
+  })
+  const registry = new ClaimedAgentPtyOwnerRegistry()
+  let incarnationId: string | undefined = initialIncarnation ?? undefined
+  let spawns = 0
+  runtime.setPtyController({
+    spawn: async (options) => {
+      const ensured = await registry.ensure({
+        ...options.agentSessionEnsure!,
+        spawn: async () => ({ ptyId: `synthetic-${++spawns}` })
+      })
+      return {
+        id: ensured.owner.ptyId,
+        incarnationId,
+        agentSessionEnsure: ensured
+      }
+    },
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => 'claude'
+  })
+  const reveals: Record<string, unknown>[] = []
+  runtime.setNotifier({
+    revealTerminalSession: vi.fn(async (_worktree, value) => {
+      reveals.push(value)
+    })
+  } as never)
+  const internals = runtime as unknown as {
+    mobileSessionTabsByWorktree: Map<string, RuntimeMobileSessionTabsSnapshot>
+    ptysById: Map<string, RuntimePtyWorktreeRecord>
+    recordPtyWorktree: (
+      ptyId: string,
+      worktreeId: string,
+      state: { incarnationId?: string | null }
+    ) => void
+  }
+  const claim = {
+    digestVersion: 1 as const,
+    keyId: 'synthetic-key',
+    agent: 'claude' as const,
+    identityDigest: 'writer',
+    worktreeScopeDigest: 'a'
+  }
+  const cwd = join(process.cwd(), 'incumbent-subdirectory')
+  const launchConfig = { agentCommand: 'claude', agentArgs: '', agentEnv: {} }
+  const first = await runtime.createTerminal('id:a', {
+    agentSessionClaim: claim,
+    cwd,
+    presentation: 'background',
+    title: 'incumbent',
+    viewMode: 'chat',
+    launchConfig,
+    launchToken: 'synthetic-predecessor-token',
+    launchAgent: 'claude'
+  })
+  const ptyId = first.ptyId!
+  const owner = registry.list()[0]
+  return {
+    runtime,
+    internals,
+    first,
+    ptyId,
+    owner,
+    cwd,
+    launchConfig,
+    reveals,
+    record: internals.ptysById.get(ptyId)!,
+    replace: (next: string | undefined) => {
+      incarnationId = next
+      registry.reconcileAuthoritative([
+        { ...owner, generation: `replacement-${next ?? 'unknown'}` }
+      ])
+    },
+    adopt: (workspace: string) =>
+      runtime.createTerminal(`id:${workspace}`, {
+        agentSessionClaim: { ...claim, worktreeScopeDigest: workspace },
+        presentation: 'focused',
+        title: 'requester',
+        cwd: join(process.cwd(), 'requester'),
+        viewMode: 'terminal',
+        launchConfig: { ...launchConfig, agentArgs: 'requester' },
+        launchToken: 'synthetic-requester-token',
+        launchAgent: 'claude'
+      }),
+    spawns: () => spawns
+  }
+}
+
+describe('terminal process metadata lifetime', () => {
+  it('publishes a fresh unknown-identity launch without trusting a later unknown adoption', async () => {
+    const f = await fixture(null)
+    expect(f.internals.mobileSessionTabsByWorktree.get('a')!.tabs[0]).toMatchObject({
+      startupCwd: f.cwd,
+      viewMode: 'chat',
+      title: 'incumbent'
+    })
+    await f.adopt('b')
+    expect(f.reveals.at(-1)).toMatchObject({
+      cwd: undefined,
+      viewMode: undefined,
+      launchToken: undefined,
+      title: null
+    })
+  })
+
+  it.each(['a', 'b'])(
+    'preserves proven incumbent metadata on adoption from workspace %s',
+    async (workspace) => {
+      const f = await fixture()
+      f.runtime.registerPty(f.ptyId, 'a', null, {
+        ...f.owner.surface,
+        incarnationId: 'incarnation-a'
+      })
+      f.runtime.onPtySpawned(f.ptyId, 'incarnation-a')
+      const result = await f.adopt(workspace)
+      expect(result).toMatchObject({
+        ptyId: f.ptyId,
+        worktreeId: 'a',
+        title: 'incumbent'
+      })
+      expect(f.reveals.at(-1)).toMatchObject({
+        title: 'incumbent',
+        cwd: f.cwd,
+        viewMode: 'chat',
+        launchConfig: f.launchConfig,
+        launchToken: 'synthetic-predecessor-token',
+        launchAgent: 'claude'
+      })
+      expect(f.spawns()).toBe(1)
+    }
+  )
+
+  it.each(['a', 'b'])(
+    'replaces all predecessor metadata before adoption from workspace %s',
+    async (workspace) => {
+      const f = await fixture()
+      f.replace('incarnation-b')
+      f.runtime.registerPty(f.ptyId, 'a', null, {
+        ...f.owner.surface,
+        incarnationId: 'incarnation-b'
+      })
+      const result = await f.adopt(workspace)
+      expect(result).toMatchObject({
+        ptyId: f.ptyId,
+        worktreeId: 'a',
+        title: null
+      })
+      expect(f.reveals.at(-1)).toMatchObject({
+        title: null,
+        cwd: undefined,
+        viewMode: undefined,
+        launchConfig: undefined,
+        launchToken: undefined,
+        launchAgent: undefined
+      })
+      const published = f.internals.mobileSessionTabsByWorktree.get('a')!.tabs[0]
+      expect(published).toMatchObject({
+        incarnationId: 'incarnation-b',
+        title: 'Terminal'
+      })
+      for (const key of ['startupCwd', 'viewMode', 'launchAgent']) {
+        expect(published).not.toHaveProperty(key)
+      }
+      expect(f.record).toMatchObject({
+        launchConfig: null,
+        launchToken: null,
+        launchAgent: null,
+        title: null,
+        launchSurface: undefined
+      })
+      expect(f.spawns()).toBe(1)
+      expect(f.internals.mobileSessionTabsByWorktree.has('b')).toBe(false)
+    }
+  )
+
+  it.each([
+    'spawn',
+    'record',
+    'exit-identity',
+    'unknown-registration',
+    'unknown-spawn',
+    'unknown-record'
+  ])('retires predecessor metadata through %s before any adoption', async (path) => {
+    const f = await fixture()
+    f.record.lastOscTitle = 'old OSC title'
+    f.record.controllerTitle = 'old controller title'
+    const next = path.startsWith('unknown') ? undefined : 'incarnation-b'
+    if (path.endsWith('spawn')) {
+      f.runtime.onPtySpawned(f.ptyId, next)
+    } else if (path.endsWith('record')) {
+      f.internals.recordPtyWorktree(f.ptyId, 'a', {
+        incarnationId: next ?? null
+      })
+    } else if (path === 'exit-identity') {
+      f.runtime.acceptPtyIncarnationForExit(f.ptyId, next!)
+    } else {
+      f.runtime.registerPty(f.ptyId, 'a', null, f.owner.surface)
+    }
+    expect(f.record).toMatchObject({
+      incarnationId: next ?? null,
+      launchConfig: null,
+      launchToken: null,
+      launchIncarnationId: null,
+      launchAgent: null,
+      title: null,
+      lastOscTitle: null,
+      controllerTitle: null,
+      managementTitle: null,
+      launchSurface: undefined
+    })
+  })
+
+  it('does not equate absent identities or reclaim metadata when identity becomes known', async () => {
+    const f = await fixture()
+    f.replace(undefined)
+    f.runtime.registerPty(f.ptyId, 'a', null, f.owner.surface)
+    const oldSurface = f.internals.mobileSessionTabsByWorktree.get('a')!.tabs[0]
+    if (oldSurface.type !== 'terminal') {
+      throw new Error('missing surface')
+    }
+    oldSurface.incarnationId = null
+    await f.adopt('b')
+    expect(f.reveals.at(-1)).toMatchObject({
+      cwd: undefined,
+      viewMode: undefined,
+      launchToken: undefined,
+      title: null
+    })
+    f.replace('incarnation-b')
+    await f.adopt('b')
+    expect(f.reveals.at(-1)).toMatchObject({
+      cwd: undefined,
+      viewMode: undefined,
+      launchToken: undefined,
+      title: null
+    })
+  })
+
+  it('restores replacement agent identity without predecessor launch authority and ignores stale exit', async () => {
+    const f = await fixture()
+    f.replace('incarnation-b')
+    f.runtime.registerPty(f.ptyId, 'a', null, {
+      ...f.owner.surface,
+      incarnationId: 'incarnation-b',
+      providerReattachLaunchIdentity: {
+        incarnationId: 'incarnation-b',
+        launchAgent: 'codex'
+      }
+    })
+    f.runtime.onPtyExit(f.ptyId, 0, 'incarnation-a')
+    await f.adopt('b')
+    expect(f.reveals.at(-1)).toMatchObject({
+      launchAgent: 'codex',
+      launchToken: undefined,
+      launchConfig: undefined
+    })
+    expect(f.record.connected).toBe(true)
+  })
+
+  it('accepts replacement launch authority and retains non-identity observations within its lifetime', async () => {
+    const f = await fixture()
+    f.runtime.registerPty(f.ptyId, 'a', null, {
+      ...f.owner.surface,
+      incarnationId: 'incarnation-b',
+      agentLaunchAuthority: {
+        launchToken: 'synthetic-replacement-token',
+        launchAgent: 'codex'
+      }
+    })
+    f.internals.recordPtyWorktree(f.ptyId, 'a', {})
+    expect(f.record).toMatchObject({
+      launchToken: 'synthetic-replacement-token',
+      launchIncarnationId: 'incarnation-b',
+      launchAgent: 'codex',
+      launchConfig: null
+    })
+  })
+})

--- a/src/main/runtime/runtime-terminal-orphan-adoption.ts
+++ b/src/main/runtime/runtime-terminal-orphan-adoption.ts
@@ -16,6 +16,7 @@ import { runtimeWorktreeIdsEqual } from './runtime-worktree-path-identity'
 import { rollbackWorkspaceSessionAfterFailedAsyncWrite } from './workspace-session-failed-write-rollback'
 
 type RuntimeTerminalOrphanAdoptionPorts = {
+  bindPtySurface: (ptyId: string, tabId: string, paneKey: string) => void
   getPty: (handle: string) => RuntimePtyWorktreeRecord | null
   getLeaves: (ptyId: string) => readonly RuntimeLeafRecord[]
   getLeaf: (tabId: string, leafId: string) => RuntimeLeafRecord | undefined
@@ -134,8 +135,7 @@ export async function adoptRuntimeTerminalOrphansFromInventory(args: {
   })
   if (isExactPersisted && sessionWorktreeId === workspace.id) {
     for (const { claim, pty, paneKey } of validated) {
-      pty.tabId = claim.tabId
-      pty.paneKey = paneKey
+      ports.bindPtySurface(pty.ptyId, claim.tabId, paneKey)
     }
     return {
       adopted: false,
@@ -235,8 +235,7 @@ export async function adoptRuntimeTerminalOrphansFromInventory(args: {
     throw error
   }
   for (const { claim, pty, paneKey } of validated) {
-    pty.tabId = claim.tabId
-    pty.paneKey = paneKey
+    ports.bindPtySurface(pty.ptyId, claim.tabId, paneKey)
   }
   ports.hydrateSession(workspace.id)
   ports.notifySessionChanged(workspace.id)

--- a/src/main/runtime/runtime-terminal-state-records.ts
+++ b/src/main/runtime/runtime-terminal-state-records.ts
@@ -53,6 +53,11 @@ export type RuntimePtyWorktreeRecord = RuntimeTerminalTailState & {
   wslDistro: string | null
   tabId: string | null
   paneKey: string | null
+  launchSurface?: {
+    incarnationId: PtyIncarnationId | null
+    startupCwd?: string
+    viewMode?: 'terminal' | 'chat'
+  }
   launchConfig: SleepingAgentLaunchConfig | null
   launchToken: string | null
   launchIncarnationId: PtyIncarnationId | null

--- a/src/main/runtime/runtime-terminal-state-records.ts
+++ b/src/main/runtime/runtime-terminal-state-records.ts
@@ -53,8 +53,8 @@ export type RuntimePtyWorktreeRecord = RuntimeTerminalTailState & {
   wslDistro: string | null
   tabId: string | null
   paneKey: string | null
+  // Process metadata is retired together by transitionPtyIncarnation before changing owners.
   launchSurface?: {
-    incarnationId: PtyIncarnationId | null
     startupCwd?: string
     viewMode?: 'terminal' | 'chat'
   }

--- a/src/main/runtime/runtime-worktree-binding-index.ts
+++ b/src/main/runtime/runtime-worktree-binding-index.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import { makePaneKey } from '../../shared/stable-pane-id'
 
 export function indexPersistedPtyWorktreeBindings(
@@ -86,4 +87,27 @@ export function setsEqual<T>(a: ReadonlySet<T>, b: ReadonlySet<T>): boolean {
     }
   }
   return true
+}
+
+export function createPersistedPtyBindingLookup(
+  readSession: (hostId: ExecutionHostId) => WorkspaceSessionState | null | undefined
+) {
+  type Indexes = {
+    worktreeIdByPtyId: ReturnType<typeof indexPersistedPtyWorktreeBindings>
+    surfaceByPtyId: ReturnType<typeof indexPersistedPtySurfaceBindings>
+  }
+  const indexesByHostId = new Map<ExecutionHostId, Indexes>()
+  return (hostId: ExecutionHostId): Indexes => {
+    const existing = indexesByHostId.get(hostId)
+    if (existing) {
+      return existing
+    }
+    const session = readSession(hostId)
+    const indexes = {
+      worktreeIdByPtyId: indexPersistedPtyWorktreeBindings(session),
+      surfaceByPtyId: indexPersistedPtySurfaceBindings(session)
+    }
+    indexesByHostId.set(hostId, indexes)
+    return indexes
+  }
 }

--- a/src/shared/claimed-agent-pty-owner-placement.test.ts
+++ b/src/shared/claimed-agent-pty-owner-placement.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentSessionOwnerBinding } from './agent-session-host-authority'
+import { ClaimedAgentPtyOwnerRegistry } from './claimed-agent-pty-owner'
+
+const claim = {
+  digestVersion: 1 as const,
+  keyId: 'synthetic-key',
+  agent: 'claude' as const,
+  identityDigest: 'writer',
+  worktreeScopeDigest: 'workspace-a'
+}
+const surface = {
+  worktreeId: 'workspace-a',
+  tabId: 'tab-a',
+  leafId: 'leaf-a',
+  terminalHandle: 'term_a'
+}
+const otherClaim = { ...claim, worktreeScopeDigest: 'workspace-b' }
+const otherSurface = { ...surface, worktreeId: 'workspace-b', tabId: 'tab-b' }
+
+describe('provider writer ownership independent of requested placement', () => {
+  it('joins a cross-workspace reservation without changing the incumbent binding', async () => {
+    const registry = new ClaimedAgentPtyOwnerRegistry()
+    let finish!: (result: { ptyId: string }) => void
+    const spawn = vi.fn(() => new Promise<{ ptyId: string }>((resolve) => (finish = resolve)))
+    const first = registry.ensure({ claim, surface, spawn })
+    const second = registry.ensure({ claim: otherClaim, surface: otherSurface, spawn })
+    finish({ ptyId: 'pty-a' })
+    const created = await first
+    expect(await second).toEqual({ disposition: 'adopted', owner: created.owner })
+    expect(spawn).toHaveBeenCalledOnce()
+    expect(registry.find(otherClaim)).toEqual(created.owner)
+  })
+
+  it('promotes a daemon adoption and recovers serialized evidence into a new controller', async () => {
+    const daemon = new ClaimedAgentPtyOwnerRegistry()
+    const incumbent = await daemon.ensure({
+      claim,
+      surface,
+      spawn: async () => ({ ptyId: 'pty-a' })
+    })
+    const controller = new ClaimedAgentPtyOwnerRegistry()
+    const physicalSpawn = vi.fn(async () => ({ ptyId: 'duplicate' }))
+    const result = await controller.ensure({
+      claim: otherClaim,
+      surface: otherSurface,
+      spawn: async () => {
+        const adopted = await daemon.ensure({
+          claim: otherClaim,
+          surface: otherSurface,
+          spawn: physicalSpawn
+        })
+        return { ...adopted, ptyId: adopted.owner.ptyId }
+      }
+    })
+    expect(result).toEqual({ disposition: 'adopted', owner: incumbent.owner })
+    const restartedController = new ClaimedAgentPtyOwnerRegistry()
+    restartedController.reconcileAuthoritative(JSON.parse(JSON.stringify(daemon.list())))
+    expect(
+      await restartedController.ensure({
+        claim: otherClaim,
+        surface: otherSurface,
+        spawn: physicalSpawn
+      })
+    ).toEqual(result)
+    expect(physicalSpawn).not.toHaveBeenCalled()
+  })
+
+  it.each(['scope', 'surface'] as const)('refuses forged fresh owner %s', async (field) => {
+    const registry = new ClaimedAgentPtyOwnerRegistry()
+    await expect(
+      registry.ensure({
+        claim,
+        surface,
+        spawn: async ({ generation }) => ({
+          ptyId: 'pty-a',
+          owner: {
+            claim: field === 'scope' ? otherClaim : claim,
+            surface: field === 'surface' ? otherSurface : surface,
+            generation,
+            ptyId: 'pty-a',
+            phase: 'live'
+          }
+        })
+      })
+    ).rejects.toThrow('agent_session_ownership_unknown')
+    expect(registry.list()).toEqual([])
+  })
+
+  it('refuses rewritten incumbent placement in a recovered snapshot', async () => {
+    const registry = new ClaimedAgentPtyOwnerRegistry()
+    const created = await registry.ensure({
+      claim,
+      surface,
+      spawn: async () => ({ ptyId: 'pty-a' })
+    })
+    const rewritten: AgentSessionOwnerBinding = {
+      ...created.owner,
+      claim: otherClaim,
+      surface: otherSurface
+    }
+    expect(() => registry.reconcileAuthoritative([created.owner, rewritten])).toThrow(
+      'agent_session_ownership_unknown'
+    )
+    expect(registry.find(otherClaim)).toEqual(created.owner)
+  })
+})

--- a/src/shared/claimed-agent-pty-owner.test.ts
+++ b/src/shared/claimed-agent-pty-owner.test.ts
@@ -48,7 +48,7 @@ describe('ClaimedAgentPtyOwnerRegistry', () => {
     expect(spawn).toHaveBeenCalledTimes(1)
   })
 
-  it('conflicts when the same identity is claimed by another worktree', async () => {
+  it('adopts the incumbent placement when another worktree requests the same writer', async () => {
     const registry = new ClaimedAgentPtyOwnerRegistry()
     await registry.ensure({
       claim: claim(),
@@ -65,10 +65,10 @@ describe('ClaimedAgentPtyOwnerRegistry', () => {
         surface: { ...surface, worktreeId: 'other' },
         spawn: async () => ({ ptyId: 'pty-2' })
       })
-    ).rejects.toThrow('agent_session_conflict')
+    ).resolves.toMatchObject({ disposition: 'adopted', owner: { ptyId: 'pty-1', surface } })
   })
 
-  it('does not find an owner through another worktree scope', async () => {
+  it('finds the incumbent through another worktree scope', async () => {
     const registry = new ClaimedAgentPtyOwnerRegistry()
     await registry.ensure({
       claim: claim(),
@@ -83,7 +83,7 @@ describe('ClaimedAgentPtyOwnerRegistry', () => {
           'ccccccccccccccccccccccccccccccccccccccccccc'
         )
       )
-    ).toBeNull()
+    ).toMatchObject({ ptyId: 'pty-1', surface, claim: claim() })
   })
 
   it('generation-guards release across a replacement owner', async () => {

--- a/src/shared/claimed-agent-pty-owner.ts
+++ b/src/shared/claimed-agent-pty-owner.ts
@@ -25,7 +25,6 @@ export const MAX_CLAIMED_AGENT_PTY_OWNER_ENTRIES = 1024
 
 type ReservedOwner = {
   claim: AgentSessionExecutionClaim
-  worktreeScopeDigest: string
   generation: string
   phase: 'reserved'
   promise: Promise<AgentSessionClaimedSpawnResult>
@@ -74,9 +73,6 @@ export class ClaimedAgentPtyOwnerRegistry {
       if (!agentSessionClaimsEqual(live.claim, requestedClaim)) {
         throw new Error('agent_session_ownership_unknown')
       }
-      if (live.claim.worktreeScopeDigest !== requestedClaim.worktreeScopeDigest) {
-        throw new Error('agent_session_conflict')
-      }
       if (!args.isLive || (await args.isLive(cloneOwner(live)))) {
         const current = this.live.get(key)
         if (current?.ptyId === live.ptyId && current.generation === live.generation) {
@@ -89,9 +85,6 @@ export class ClaimedAgentPtyOwnerRegistry {
 
     const reserved = this.reserved.get(key)
     if (reserved) {
-      if (reserved.worktreeScopeDigest !== requestedClaim.worktreeScopeDigest) {
-        throw new Error('agent_session_conflict')
-      }
       const result = await reserved.promise
       return { disposition: 'adopted', owner: cloneOwner(result.owner as LiveOwner) }
     }
@@ -109,7 +102,6 @@ export class ClaimedAgentPtyOwnerRegistry {
     void promise.catch(() => {})
     this.reserved.set(key, {
       claim: requestedClaim,
-      worktreeScopeDigest: requestedClaim.worktreeScopeDigest,
       generation,
       phase: 'reserved',
       promise
@@ -133,15 +125,13 @@ export class ClaimedAgentPtyOwnerRegistry {
             ptyId: spawned.ptyId,
             surface: requestedSurface
           }
-      if (
-        owner.ptyId !== spawned.ptyId ||
-        !scopedAgentSessionClaimsEqual(owner.claim, requestedClaim)
-      ) {
+      if (owner.ptyId !== spawned.ptyId || !agentSessionClaimsEqual(owner.claim, requestedClaim)) {
         throw new Error('agent_session_ownership_unknown')
       }
       if (
         spawned.disposition !== 'adopted' &&
-        !agentSessionSurfacesEqual(owner.surface, requestedSurface)
+        (!scopedAgentSessionClaimsEqual(owner.claim, requestedClaim) ||
+          !agentSessionSurfacesEqual(owner.surface, requestedSurface))
       ) {
         // Why: only an already-reconciled owner may override placement; a fresh
         // owner returning another surface would let a lower layer forge authority.
@@ -283,7 +273,7 @@ export class ClaimedAgentPtyOwnerRegistry {
 
   find(claim: AgentSessionExecutionClaim): AgentSessionOwnerBinding | null {
     const owner = this.live.get(agentSessionClaimKey(claim))
-    return owner && scopedAgentSessionClaimsEqual(owner.claim, claim) ? cloneOwner(owner) : null
+    return owner && agentSessionClaimsEqual(owner.claim, claim) ? cloneOwner(owner) : null
   }
 
   private rebuildPtyIndex(): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1248 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1222 |
| Prod | 22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​548 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​310 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​238 |

<!-- /orca-pr-loc -->

## What changed

Two workspace requests for one claimed provider writer now return its existing pane and placement. Previously, identity lookup could reject that owner solely because the requester used another workspace, and adoption could register or publish the incumbent using requester metadata. The claim registry now returns incumbents across live and reserved requests while preserving strict binding checks for registration/recovery and strict scope/surface checks for fresh spawns.

Runtime metadata now belongs to one process incarnation. Reusing a PTY ID retires predecessor launch configuration/token/agent, cwd/view metadata and process titles before registering the replacement. Positive matching identities preserve incumbent metadata; unavailable identities do not establish a match. All retained-record identity changes use one transition, which reuses existing authority and title-state retirement. Pending foreground reads retire with it, so a delayed predecessor response cannot restore the old agent identity. Provider reattach may restore the replacement agent identity independently of launch token/configuration authority.

Inventory operations now retain observation custody through reading, admission and synchronous application, released by one finally on success, rejection, timeout, retry and exceptions. Registration in the promise-resolution gap remains tracked, and a released observation cannot authorize a later application. They share an ownership revision boundary with registration, spawn, accepted lifecycle events, authority/handle invalidation, controller/graph clearing, cancellation, execution-context changes and surface rebinding. A response that overlaps a newer owner cannot retire launch authority or overwrite identity, handles, bindings, titles or liveness before admission. Positive evidence matching a newly confirmed incarnation and workspace can refresh that owner without retiring its metadata; stale identity, absence and cleared ownership reject the census. A request begun after the latest ownership change can still discover a genuine replacement. Orphan and recovery bindings use the central record transition.

Publication, reveal and returned titles use incumbent metadata. Recovered surfaces require matching PTY, pane and positive incarnation evidence. A stale replaced leaf cannot reintroduce its old chat mode; persistent parent layout and a different sibling's tab view preference remain presentation state. Fresh unknown-identity launches retain their immediate metadata, but later unknown-owner adoption cannot inherit it. Metadata is in-memory and is not durable when both the runtime record and matching surface are lost.

This is supporting ownership/placement work toward STA-6297 and STA-3499, not closure of either issue. Cold restore and AI Vault entrypoints, shared account-root/profile authority, execution-owner attestation, recovery authorization, durable reservations across daemon/key loss and fail-closed direct-SSH/old-peer routing remain separate foundation work. Existing signer and namespace trust assumptions remain.

## Validation at b49cf6c916fd854bb7444057870a77b769b3340d

- Canonical-config Vitest: **141 passed, zero failed**, nine focused ownership, observation-custody, placement, incarnation, handle, liveness and census-race files. This includes 31 existing ownership cases and 31 new custody cases; overlapping initial/restored runs are not added together.
- Node, web and CLI TypeScript checks passed sequentially using the three configured `npx tsc --noEmit -p` commands. Changed-source lint, formatting and commit hooks passed.
- Committed before two shipping-code ablations. Restoring the previous read-only observation lifetime reproduced **two failures** among 22 schedules in both Vitest and the finite runtime replay: offset-seven stale presence reverted A and cleared B authority; stale absence disconnected B. Suppressing release caused **30 custody-test failures** and failed all **eight cleanup runtime controls**. Both production files were restored from backups with byte comparisons and nonzero custody/release checks; all 141 tests passed afterward.
- Fresh final shipping-runtime bundles: **22/22 original bounded schedules** and **8/8 cleanup controls** pass, each invocation using a fresh isolated home. Cleanup controls cover success, stale rejection, synchronous read throw, asynchronous read rejection, timeout with late response, application exception, cancellation invalidation and targeted retry; each verifies zero retained observations and subsequent valid census admission. Synthetic transport and folder bindings; no real provider execution is claimed.

## Remaining review and validation

Pending fresh independent architecture and implementation review at **b49cf6c916fd854bb7444057870a77b769b3340d**. The prior custody-gap finding has an operation-scope correction and regression evidence, but has not received fresh reviewer signoff. No CLEAN, READY or merge endorsement.

The writer registry, incumbent placement and incarnation retirement mechanisms remain the same. The operation scope removes the read-to-application lifetime gap; it does not turn census application into a rollback transaction or grant general resource/recovery authority. The application has no await; later foreground/attach work uses its existing lifecycle handling.

Conflicting observations still reject the whole census using the existing unavailable-inventory path. One conflicting same-host owner can defer unrelated rows; a regression proves a later conflict-free census resumes, but continuous churn has no eventual-admission bound. Scope lasts through application and a bounded targeted retry, so tracking remains O(outstanding observations) per writer. No fleet/starvation benchmark or performance signoff.

No rendered Electron proof, actual daemon/controller-process restart, surviving descendants, native PTY, real provider/profile convergence, cold restore/AI Vault interaction, direct SSH, old-peer integration, or manual Windows/Linux/WSL validation. Workspace resolution is synthetic. No new RPC field/opcode, Git command, subprocess path or provider-specific branch. Earlier finite-child evidence remains historical, not rerun evidence at this head. Full STA-6297/STA-3499 resource authority remains unsolved.

## Linked issues

Supporting work toward [STA-6297](https://linear.app/stably/issue/STA-6297) and [STA-3499](https://linear.app/stably/issue/STA-3499); neither is closed by this PR.

## Visual proof

Not collected. Backing runtime and finite-child evidence only; rendered validation remains open.

## Agent skill upstream boundary

- [x] Not applicable; no skill-installer changes.
