### PR TITLE
perf(renderer): avoid per-second spinner animation events

### DIFF
--- a/config/scripts/idle-cpu-renderer-scale-fixture.mjs
+++ b/config/scripts/idle-cpu-renderer-scale-fixture.mjs
@@ -1,6 +1,6 @@
 export async function configureRendererScaleFixture(page, options, repoPath) {
   return page.evaluate(
-    ({ agentsPerWorktree, lineageDepth, repoPath }) => {
+    ({ agentsPerWorktree, subagentsPerAgent, lineageDepth, repoPath }) => {
       const store = window.__store
       if (!store) {
         throw new Error('window.__store is not available')
@@ -98,7 +98,18 @@ export async function configureRendererScaleFixture(page, options, repoPath) {
               {
                 state: 'working',
                 prompt: `Idle CPU agent ${worktreeIndex + 1}.${agentIndex + 1}`,
-                agentType
+                agentType,
+                ...(subagentsPerAgent > 0
+                  ? {
+                      subagents: Array.from({ length: subagentsPerAgent }, (_, index) => ({
+                        id: `child-${index}`,
+                        state: 'working',
+                        startedAt: fixtureNow,
+                        agentType,
+                        description: `Subagent ${worktreeIndex + 1}.${agentIndex + 1}.${index + 1}`
+                      }))
+                    }
+                  : {})
               },
               agentType,
               { updatedAt: fixtureNow, stateStartedAt: fixtureNow },
@@ -116,10 +127,16 @@ export async function configureRendererScaleFixture(page, options, repoPath) {
         expandedLineageGroups: lineageParentIds.size,
         agentsPerWorktree,
         seededAgentRows,
+        seededSubagentRows: seededAgentRows * subagentsPerAgent,
         orderedWorktreeIds: worktrees.map((worktree) => worktree.id)
       }
     },
-    { agentsPerWorktree: options.agentsPerWorktree, lineageDepth: options.lineageDepth, repoPath }
+    {
+      agentsPerWorktree: options.agentsPerWorktree,
+      subagentsPerAgent: options.subagentsPerAgent ?? 0,
+      lineageDepth: options.lineageDepth,
+      repoPath
+    }
   )
 }
 

--- a/docs/reference/renderer-agent-status-performance.md
+++ b/docs/reference/renderer-agent-status-performance.md
@@ -87,13 +87,25 @@ bundled prototype, the fixture without seeded agents fell from 8,518 listeners
 to 1,218; with 100 visible agent rows the candidate mounted 1,618. Compare
 against the census in "Baseline on `main`", which the harness reports directly.
 
-### Share working-spinner phase without per-element animation queries
+### Share working-spinner phase without synchronous mount queries
 
 Working rows keep the existing compositor-driven CSS animation and shared
-visual phase. Each mount derives one negative animation delay from the document
-timeline instead of querying `getAnimations()` and mutating the animation start
-time. This removes per-row Web Animations setup from dense status transitions
-without adding a JavaScript animation clock.
+visual phase. `animationstart` anchors each animation to document time zero.
+Deferring the animation query until that event avoids a synchronous style flush
+at each mount and restores the shared phase after `display:none` or a motion
+preference change. A negative mount-time delay cannot preserve that phase after
+an animation restarts.
+
+### Bound spinner animation overhead
+
+Working rings keep compositor-driven CSS animation, but repeat the animation
+once per day rather than once per second. The same 12 steps per second now
+avoid recurring React animation-iteration dispatch. The existing stationary
+wrapper and ring rendering stay unchanged. Offscreen containment was evaluated
+and rejected after a pixel regression at low zoom on 1x displays.
+
+The history, isolated measurements, full-app workspace/agent/subagent benchmark,
+and limitations are documented in [Spinner rendering performance](./spinner-rendering-performance.md).
 
 ### Fold a burst in event order
 

--- a/docs/reference/spinner-rendering-performance.md
+++ b/docs/reference/spinner-rendering-performance.md
@@ -1,0 +1,198 @@
+# Spinner rendering performance
+
+## ELI5
+
+Imagine a wheel that tells the front desk every time it completes a lap. The
+front desk is also handling your typing. CSS already turns the wheel for us,
+but React still receives its once-per-second lap notifications.
+
+We put a day's worth of laps into one animation. The wheel moves at the same
+speed, while sending one lap notification a day. Drawing visible wheels still
+costs something. This removes recurring bookkeeping from the input thread; it
+does not make rendering or the rest of Orca free.
+
+## How this builds on earlier changes
+
+| Change                                                                               | What it achieved                                                                      | Remaining cost                                                                        |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [#9380](https://github.com/stablyai/orca/pull/9380): shared JavaScript clock         | Reduced frame-pipeline CPU in the original one-agent measurement                      | Wrote each spinner's style 12 times per second on the input thread                    |
+| [#12359](https://github.com/stablyai/orca/pull/12359): compositor CSS rotation       | Removed those recurring JavaScript style writes; fixed the reported typing regression | React still receives CSS iteration events                                             |
+| [#13987](https://github.com/stablyai/orca/pull/13987): synchronize on animationstart | Avoided a synchronous style query at every mount                                      | Steady-state animation overhead stayed the same                                       |
+| This change                                                                          | Preserves both later fixes and removes almost all iteration boundaries                | Compositing, other app work, mount/reveal work, and a daily iteration boundary remain |
+
+The historical measurements in #12359 reported 41 rings causing about 490 style
+writes per second, with typing input-delay p90 of 363 ms versus 19 ms when those
+writes stopped. Those are historical production measurements, not numbers from
+this benchmark or a direct comparison with today's app.
+
+## Implementation
+
+The production change is entirely in CSS. `AgentWorkingSpinner`, its callers,
+markup, border, animation-start handler, and reduced-motion behavior stay the
+same. No DOM node, pseudo-element, containment boundary, timer, observer, or
+JavaScript animation loop is added.
+
+The transform travels 86,400 turns in 86,400 seconds with 1,036,800 steps: exactly
+one revolution and 12 steps per second. `animationstart` sets `startTime = 0` as
+before, preserving shared phase after mount and animation restart. The step
+count is a timing-function parameter, not a million-entry keyframe list.
+
+React installs delegated `animationiteration` listeners even when the component
+has no iteration handler. A native 2.2-second trace of 200 isolated rings counted
+400 iteration events and 800 JavaScript calls before the change, versus zero of
+either with the long cycle. That trace installed no animation-event listener.
+These are event dispatches, not component rerenders or 400 separate OS wakeups.
+
+## Full-app benchmark
+
+The opt-in Playwright benchmark launches a fresh, hidden Orca app for each
+scenario. It creates real Git workspaces and seeds working statuses through the
+existing renderer fixture, including in-process subagent data. It renders the
+normal sidebar, virtualizer, lineage, agent rows, tabs, and terminal.
+
+| Scenario      | Git workspaces | Root agents | Subagents | Mounted / visible rings | Layout                                       |
+| ------------- | -------------: | ----------: | --------: | ----------------------: | -------------------------------------------- |
+| `one-agent`   |              1 |           1 |         0 |                   3 / 3 | One working agent                            |
+| `one-family`  |              1 |           2 |         4 |                   8 / 8 | All family rows expanded                     |
+| `200-flat`    |            200 |         400 |       800 |                162 / 15 | Normal virtualization; 23 workspaces mounted |
+| `200-lineage` |            200 |         400 |       800 |              1,401 / 15 | Expanded lineage; all 200 workspaces mounted |
+
+Measurement-only styles switch between the original one-second cycle and the
+new long cycle on the same elements. The real React root, callers, status data,
+and app stay the same. The reported run alternates A/B and B/A, with four
+ten-second CPU samples per variant after warmup. CPU samples use cumulative
+Electron process CPU and CDP main-thread task/script/style/layout metrics. No
+renderer polling, screenshots, or benchmark iteration listeners run during
+those CPU windows. No samples are discarded.
+
+Typing is measured separately using the existing paced terminal-typing probe:
+64 keys at 113 ms cadence, twice per variant, after two seconds of warmup with
+status traffic. Status updates arrive in groups of up to eight every 200 ms.
+Keys pass through the DOM, real PTY, and xterm. A sidecar timestamps arrival at
+the PTY, and a bounded terminal-buffer scan observes each echo. Missing input
+or echoes fail the benchmark. Echo measurements include the 10 ms scan interval;
+they do not measure native display presentation. Native animation traces also
+run separately from CPU and typing samples.
+
+The statuses are deterministic test data, not hundreds of paid model sessions.
+The test exercises UI cost under agent-status traffic, not the compute or network
+cost of model inference, SSH traffic, or hundreds of streaming PTYs.
+
+## Results
+
+CPU values are medians of four samples. "CPU ms/s" means milliseconds of
+processor time used in one wall-clock second: 100 ms/s is about 10% of one CPU
+core. Renderer + GPU-process CPU includes their other app work and CPU used by
+the graphics process; it is not GPU hardware utilization or whole-machine CPU.
+The main thread handles input and is included in renderer CPU, not extra work.
+Echo p90 means 90% of sampled keys were observed within that time; ranges show
+the two runs, not confidence intervals. No keys or echoes were missing.
+
+| Scenario      | Renderer + GPU CPU ms/s, old → new | Main-thread ms/s, old → new | Echo p90 ms, old → new |
+| ------------- | ---------------------------------: | --------------------------: | ---------------------- |
+| `one-agent`   |                        37.0 → 38.2 |                   5.4 → 3.5 | 19 → 18–19             |
+| `one-family`  |                        46.2 → 44.6 |                   7.8 → 4.4 | 17–19 → 18–19          |
+| `200-flat`    |                      141.6 → 122.8 |                 28.2 → 16.3 | 26–28 → 26–28          |
+| `200-lineage` |                      324.6 → 295.6 |                140.8 → 70.0 | 159–239 → 93–160       |
+
+The consistent gain is less main-thread work: about 35%, 43%, 42%, and 50%
+less in these four scenarios. Native 2.2-second traces counted 6, 16, 324, and
+2,802 iteration events before, and zero in each new variant, without adding an
+iteration listener. That avoided work also exists in Orca itself, independently
+of the isolated fixture and CPU noise.
+
+Total CPU was roughly unchanged in the one-worktree cases. In this run it fell
+13% with normal virtualization and 9% with expanded lineage; seven of eight
+paired large-case CPU samples favored the change. These percentages are not
+universal: a shorter three-variant ablation measured flat-list CPU at 89.0 ms/s before and
+108.0 ms/s with the long cycle, while main-thread time still fell from 26.3 to
+17.4 ms/s. The repeatable main-thread reduction is stronger evidence than a
+single total-CPU percentage.
+
+Typing was similar in the small and flat-list cases. Expanded-lineage echo p90
+improved in the final run, but a shorter ablation had similar before/after
+latencies. No general typing speedup or statistical non-regression guarantee
+is established by these short experiments.
+
+### All CPU samples
+
+Values are rounded to one decimal and listed by round, with no outliers removed.
+The first new small-case samples were higher than their paired baselines; they
+remain included. CPU and typing were sampled separately.
+
+| Scenario      | Version | Renderer + GPU CPU ms/s    | Main-thread ms/s           |
+| ------------- | ------- | -------------------------- | -------------------------- |
+| `one-agent`   | Old     | 37.8, 36.2, 26.2, 39.6     | 6.5, 5.2, 4.8, 5.7         |
+| `one-agent`   | New     | 53.3, 35.8, 37.5, 39.0     | 6.7, 2.8, 3.0, 4.1         |
+| `one-family`  | Old     | 46.3, 46.1, 47.9, 44.6     | 7.8, 7.6, 9.8, 7.7         |
+| `one-family`  | New     | 53.8, 45.4, 42.5, 43.8     | 6.8, 4.5, 3.1, 4.3         |
+| `200-flat`    | Old     | 142.4, 140.8, 147.0, 136.5 | 28.3, 28.1, 32.2, 27.0     |
+| `200-flat`    | New     | 122.9, 97.2, 122.7, 126.7  | 19.2, 10.7, 16.6, 16.0     |
+| `200-lineage` | Old     | 317.9, 385.2, 315.9, 331.2 | 134.4, 159.6, 133.9, 147.3 |
+| `200-lineage` | New     | 318.6, 256.9, 296.5, 294.7 | 89.2, 60.8, 71.6, 68.3     |
+
+## Reproduce
+
+```sh
+ORCA_BACKGROUND_LAUNCH=1 pnpm bench:spinners --sample-ms=5000
+ORCA_BACKGROUND_LAUNCH=1 pnpm bench:spinners --verify-only --scale-factor=1
+ORCA_BACKGROUND_LAUNCH=1 pnpm bench:spinners --verify-only --scale-factor=2
+ORCA_BACKGROUND_LAUNCH=1 ORCA_SPINNER_BENCH=1 ORCA_SPINNER_KEYS=64 \
+  pnpm test:e2e spinner-workspace-perf.spec.ts --workers=1
+```
+
+The full-app command rebuilds in `e2e` mode. For a fresh build already made with
+`pnpm exec electron-vite build --mode e2e`, `SKIP_BUILD=1` reuses it. Do not reuse
+an old launch-policy build. `ORCA_SPINNER_SAMPLE_MS`, `ORCA_SPINNER_ROUNDS`,
+`ORCA_SPINNER_KEYS`, `ORCA_SPINNER_KEY_CADENCE_MS`, `ORCA_SPINNER_VARIANTS`, and
+`ORCA_SPINNER_OUTPUT` control the experiment. `ORCA_SPINNER_CPU=0` repeats only
+typing; `--grep one-agent` selects one scenario. Reports, native traces, typing
+sidecars, and CDP screenshots are written under `.bench-fixtures/`. Run one
+benchmark at a time, without concurrent builds or tests.
+
+The optional `contained` variant retains the rejected offscreen experiment for
+ablation. It adds `content-visibility:auto` to the existing wrapper through
+measurement-only styles. It is not enabled in production or the default
+benchmark comparison.
+
+## Visual and behavioral checks
+
+Both 1x and 2x display-density checks passed 720 ring comparisons each: 6/8 px
+rings, light/dark themes, supported zoom extremes, all 12 phases, long elapsed
+times, and the daily wrap. Pixel tolerance is one channel level for floating-point
+antialias rounding. Checks also cover shared phase, reduced motion, initial
+offscreen reveal, repeated scroll-away/reveal, and `display:none` restoration.
+
+## Limits and rejected approaches
+
+Adding `content-visibility:auto` to the existing stationary wrapper saved more
+CPU at large mounted counts, but a 1x display check found a one-pixel shift at
+the minimum UI zoom. That containment change is excluded. A previous
+pseudo-element version also regressed typing latency in the virtualized list.
+Neither prototype's CPU or typing numbers describe the final patch.
+
+An initial typing run used a 100 ms key cadence, which can repeatedly align with
+200 ms status bursts. Follow-up runs use 113 ms, more keys, and two seconds of
+warmup under status traffic. This reduces timing bias; it does not excuse a
+regression. CPU measurements run separately and do not depend on key cadence.
+
+An early isolated test suggested a 31% process-CPU reduction that a longer audit
+did not reproduce. The longer isolated audit measured original 104.04 versus
+long-cycle 92.32 CPU ms/s, and main-thread 10.08 versus 0.24 ms/s. A fixture with
+every ring far offscreen and containment enabled could also approach idle; that
+is not representative of Orca with visible animations. Neither result justifies
+claiming "free spinners" or a universal CPU percentage. Virtualized, unmounted
+rows already cost nothing, and this patch does not add offscreen culling.
+
+All local measurements use an Apple M4 (10 cores), macOS, Electron 43.4.1 /
+Chromium 150.0.7871.224. Native windows stay hidden and unfocused;
+benchmark-only settings disable background throttling to exercise the frame
+pipeline. These are not visible-window power measurements. No battery benefit
+is established. Linux/Windows need their own runtime measurements. The
+renderer-only change does not alter SSH execution, wire data, status semantics,
+Git operations, or folder-workspace ownership.
+
+Animated PNGs, masks, layer promotion, CSS sprites, individual `rotate`, and
+containment on the rotating element were also explored. Shared images added
+raster work and regressed the single-ring case; sprites reintroduced per-frame
+style work. They did not meet the appearance and responsiveness requirements.

--- a/docs/reference/spinner-rendering-performance.md
+++ b/docs/reference/spinner-rendering-performance.md
@@ -159,9 +159,14 @@ benchmark comparison.
 
 Both 1x and 2x display-density checks passed 720 ring comparisons each: 6/8 px
 rings, light/dark themes, supported zoom extremes, all 12 phases, long elapsed
-times, and the daily wrap. Pixel tolerance is one channel level for floating-point
-antialias rounding. Checks also cover shared phase, reduced motion, initial
-offscreen reveal, repeated scroll-away/reveal, and `display:none` restoration.
+times, and the daily wrap. The comparison pauses each animation and sets its
+`currentTime`, so the long-elapsed and daily-wrap cases exercise the deterministic
+style path rather than a running compositor animation. Against that path the
+tolerance is one channel level for floating-point antialias rounding. A running
+animation at multi-hour ages can differ by a few channels on the ring edge — a
+fraction-of-a-pixel antialias difference at large accumulated angles, not a phase
+or shape change. Checks also cover shared phase, reduced motion, initial offscreen
+reveal, repeated scroll-away/reveal, and `display:none` restoration.
 
 ## Limits and rejected approaches
 

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "test:e2e:terminal-ime-native": "node config/scripts/run-terminal-ibus-hangul-e2e.mjs",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts",
     "bench:idle-cpu": "pnpm run ensure:electron-runtime && node config/scripts/run-idle-cpu-benchmark.mjs",
+    "bench:spinners": "node tests/tools/benchmarks/spinner-rendering/run.mjs",
     "bench:macos-computer-helper-owner-loss": "node config/scripts/macos-computer-helper-owner-loss-benchmark.mjs",
     "bench:startup": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/startup-time-bench.mjs",
     "bench:daemon-coldstart": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/daemon-coldstart-bench.mjs",

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "test:e2e:terminal-ime-native": "node config/scripts/run-terminal-ibus-hangul-e2e.mjs",
     "test:e2e:computer": "vitest run --config tests/e2e/vitest.config.ts",
     "bench:idle-cpu": "pnpm run ensure:electron-runtime && node config/scripts/run-idle-cpu-benchmark.mjs",
-    "bench:spinners": "node tests/tools/benchmarks/spinner-rendering/run.mjs",
+    "bench:spinners": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/spinner-rendering/run.mjs",
     "bench:macos-computer-helper-owner-loss": "node config/scripts/macos-computer-helper-owner-loss-benchmark.mjs",
     "bench:startup": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/startup-time-bench.mjs",
     "bench:daemon-coldstart": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/daemon-coldstart-bench.mjs",

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1514,18 +1514,16 @@ html.native-shell .app-layout {
   grid-template-rows: 1fr;
 }
 
-/* Why: must stay a compositor-driven CSS animation — a JS clock writing
-   per-element transforms blocks the renderer input thread (STA-3328: 41
-   spinners ⇒ ~490 style writes/s, keystroke p90 363ms). The component anchors
-   each animation's startTime once; steps(12) preserves the retired cadence. */
+/* Keep rotation on the compositor: JS style writes caused typing stalls (#12359). */
+/* One day per iteration avoids per-second React animation events; still 12 steps/second. */
 @keyframes agent-spinner-rotate {
   to {
-    transform: rotate(360deg);
+    transform: rotate(86400turn);
   }
 }
 
 .agent-working-spinner {
-  animation: agent-spinner-rotate 1s steps(12, end) infinite;
+  animation: agent-spinner-rotate 86400s steps(1036800, end) infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/renderer/src/components/AgentWorkingSpinner.test.tsx
+++ b/src/renderer/src/components/AgentWorkingSpinner.test.tsx
@@ -183,15 +183,13 @@ describe('AgentWorkingSpinner', () => {
     }
   })
 
-  // Why: the class only spins if main.css defines it — pin the wiring across
-  // both files so neither side can be renamed or dropped alone (STA-3328
-  // regressed typing latency when rotation moved onto the input thread).
-  it('is backed by a steps(12) keyframe animation in main.css', () => {
+  it('preserves 12 steps per second without frequent iteration events', () => {
     const css = readFileSync(join(__dirname, '../assets/main.css'), 'utf8')
 
     const rule = css.match(/\.agent-working-spinner\s*\{[^}]*\}/)?.[0]
     expect(rule).toBeDefined()
-    expect(rule).toContain('animation: agent-spinner-rotate 1s steps(12, end) infinite')
+    expect(rule).toContain('animation: agent-spinner-rotate 86400s steps(1036800, end) infinite')
+    expect(css).toContain('transform: rotate(86400turn)')
     expect(css).toContain('@keyframes agent-spinner-rotate')
 
     const reducedMotionBlock = css.match(

--- a/tests/e2e/paced-terminal-typing.ts
+++ b/tests/e2e/paced-terminal-typing.ts
@@ -1,0 +1,217 @@
+import type { Page } from '@stablyai/playwright-test'
+import { readFileSync } from 'node:fs'
+import { focusActiveTerminalInput } from './helpers/terminal'
+import { typingKeyMarkerPrefix } from './sustained-agent-typing-load-scripts'
+
+const KEY_CHARS = 'abcdefghijklmnopqrstuvwxyz'
+const TIMER_SAMPLE_MS = 16
+const MARKER_SCAN_TRAILING_ROWS = 160
+const ECHO_STRAGGLER_TIMEOUT_MS = 30_000
+
+export type LatencyStats = {
+  count: number
+  p50: number
+  p90: number
+  p99: number
+  max: number
+}
+
+type KeySample = {
+  seq: number
+  sentAt: number
+  ptyArrivedAt: number | null
+  echoSeenAt: number | null
+}
+
+export type PacedTypingMeasurement = {
+  keyCount: number
+  missingPtyArrivalCount: number
+  missingEchoCount: number
+  totalMs: LatencyStats | null
+  inputHalfMs: LatencyStats | null
+  echoHalfMs: LatencyStats | null
+  maxTimerDriftMs: number
+  samples: KeySample[]
+}
+
+function latencyStats(samples: number[]): LatencyStats | null {
+  if (samples.length === 0) {
+    return null
+  }
+  const sorted = [...samples].sort((a, b) => a - b)
+  const at = (q: number): number =>
+    sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
+  return {
+    count: sorted.length,
+    p50: at(0.5),
+    p90: at(0.9),
+    p99: at(0.99),
+    max: sorted.at(-1) ?? 0
+  }
+}
+
+async function scanRecentKeyMarkerSeqs(
+  page: Page,
+  markerPrefix: string
+): Promise<{ seqs: number[]; atMs: number }> {
+  return page.evaluate(
+    ({ markerPrefix, trailingRows }) => {
+      const state = window.__store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      const tabId =
+        state?.activeTabType === 'terminal'
+          ? state.activeTabId
+          : worktreeId
+            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+            : null
+      const manager = tabId ? window.__paneManagers?.get(tabId) : null
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+      const seqs: number[] = []
+      if (!pane) {
+        return { seqs, atMs: Date.now() }
+      }
+      // Why trailing rows, not serialize: full-buffer serialization on every
+      // poll runs on the renderer main thread and would perturb the very
+      // latency being measured (same rationale as the history-size spec).
+      const re = new RegExp(`${markerPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)`, 'g')
+      const buffer = pane.terminal.buffer.active
+      const start = Math.max(0, buffer.length - trailingRows)
+      for (let row = start; row < buffer.length; row += 1) {
+        const line = buffer.getLine(row)?.translateToString(true) ?? ''
+        let match: RegExpExecArray | null
+        while ((match = re.exec(line)) !== null) {
+          seqs.push(Number(match[1]))
+        }
+      }
+      return { seqs, atMs: Date.now() }
+    },
+    { markerPrefix, trailingRows: MARKER_SCAN_TRAILING_ROWS }
+  )
+}
+
+function readKeyArrivalSidecar(sidecarPath: string): Map<number, number> {
+  const arrivals = new Map<number, number>()
+  let raw = ''
+  try {
+    raw = readFileSync(sidecarPath, 'utf8')
+  } catch {
+    return arrivals
+  }
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) {
+      continue
+    }
+    try {
+      const entry = JSON.parse(line) as { seq: number; atMs: number }
+      arrivals.set(entry.seq, entry.atMs)
+    } catch {
+      /* torn tail write; final retry pass re-reads */
+    }
+  }
+  return arrivals
+}
+
+export async function measurePacedTyping(
+  page: Page,
+  runId: string,
+  sidecarPath: string,
+  options: { keyCount: number; keyCadenceMs: number }
+): Promise<PacedTypingMeasurement> {
+  const markerPrefix = typingKeyMarkerPrefix(runId)
+  await focusActiveTerminalInput(page)
+
+  const timerDrift = await page.evaluateHandle((sampleMs) => {
+    let maxTimerDriftMs = 0
+    let lastTick = performance.now()
+    const timer = window.setInterval(() => {
+      const now = performance.now()
+      maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
+      lastTick = now
+    }, sampleMs)
+    return {
+      stop: () => {
+        window.clearInterval(timer)
+        return maxTimerDriftMs
+      }
+    }
+  }, TIMER_SAMPLE_MS)
+
+  // Concurrent echo watcher: records the first time each key's marker is
+  // visible in the buffer, while typing continues at its own cadence.
+  const echoSeenAt = new Map<number, number>()
+  let watching = true
+  const echoWatcher = (async () => {
+    while (watching) {
+      const { seqs, atMs } = await scanRecentKeyMarkerSeqs(page, markerPrefix)
+      for (const seq of seqs) {
+        if (!echoSeenAt.has(seq)) {
+          echoSeenAt.set(seq, atMs)
+        }
+      }
+      await page.waitForTimeout(10)
+    }
+  })()
+
+  const sentAtBySeq = new Map<number, number>()
+  try {
+    for (let index = 0; index < options.keyCount; index++) {
+      const seq = index + 1
+      const tickStart = Date.now()
+      sentAtBySeq.set(seq, tickStart)
+      await page.keyboard.type(KEY_CHARS[index % KEY_CHARS.length])
+      const elapsed = Date.now() - tickStart
+      if (elapsed < options.keyCadenceMs) {
+        await page.waitForTimeout(options.keyCadenceMs - elapsed)
+      }
+    }
+    // Wait out stragglers so a slow echo is measured, not dropped.
+    const stragglerDeadline = Date.now() + ECHO_STRAGGLER_TIMEOUT_MS
+    while (echoSeenAt.size < options.keyCount && Date.now() < stragglerDeadline) {
+      await page.waitForTimeout(25)
+    }
+  } finally {
+    watching = false
+    await echoWatcher
+  }
+  const maxTimerDriftMs = await timerDrift.evaluate((watcher) => watcher.stop())
+  await timerDrift.dispose()
+
+  // The probe appends arrivals asynchronously; re-read until complete or 5s.
+  let arrivals = readKeyArrivalSidecar(sidecarPath)
+  const sidecarDeadline = Date.now() + 5_000
+  while (arrivals.size < options.keyCount && Date.now() < sidecarDeadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    arrivals = readKeyArrivalSidecar(sidecarPath)
+  }
+
+  const samples: KeySample[] = []
+  const totalMs: number[] = []
+  const inputHalfMs: number[] = []
+  const echoHalfMs: number[] = []
+  for (let seq = 1; seq <= options.keyCount; seq++) {
+    const sentAt = sentAtBySeq.get(seq) ?? 0
+    const ptyArrivedAt = arrivals.get(seq) ?? null
+    const seenAt = echoSeenAt.get(seq) ?? null
+    samples.push({ seq, sentAt, ptyArrivedAt, echoSeenAt: seenAt })
+    if (ptyArrivedAt !== null) {
+      inputHalfMs.push(ptyArrivedAt - sentAt)
+    }
+    if (seenAt !== null) {
+      totalMs.push(seenAt - sentAt)
+      if (ptyArrivedAt !== null) {
+        echoHalfMs.push(seenAt - ptyArrivedAt)
+      }
+    }
+  }
+
+  return {
+    keyCount: options.keyCount,
+    missingPtyArrivalCount: options.keyCount - arrivals.size,
+    missingEchoCount: options.keyCount - echoSeenAt.size,
+    totalMs: latencyStats(totalMs),
+    inputHalfMs: latencyStats(inputHalfMs),
+    echoHalfMs: latencyStats(echoHalfMs),
+    maxTimerDriftMs,
+    samples
+  }
+}

--- a/tests/e2e/spinner-workspace-fixture.ts
+++ b/tests/e2e/spinner-workspace-fixture.ts
@@ -1,0 +1,134 @@
+import type { Page } from '@stablyai/playwright-test'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { runProcess } from '../../src/shared/child-process/run-process'
+import { attachRepoAndOpenTerminal } from './helpers/orca-restart'
+import { configureRendererScaleFixture } from '../../config/scripts/idle-cpu-renderer-scale-fixture.mjs'
+
+export async function createSpinnerRepository(worktrees: number) {
+  const parent = path.resolve('.bench-fixtures')
+  mkdirSync(parent, { recursive: true })
+  const directory = mkdtempSync(path.join(parent, 'spinner-workspaces-'))
+  const repoPath = path.join(directory, 'primary')
+  mkdirSync(repoPath)
+  const git = async (args: string[]) => {
+    const result = await runProcess({ program: 'git', args, cwd: repoPath })
+    if (result.code !== 0) {
+      throw new Error(result.stderr)
+    }
+  }
+  await git(['init'])
+  await git(['config', 'user.email', 'spinner-benchmark@test.local'])
+  await git(['config', 'user.name', 'Spinner benchmark'])
+  await git(['config', 'commit.gpgsign', 'false'])
+  writeFileSync(path.join(repoPath, 'README.md'), '# Spinner benchmark\n')
+  await git(['add', 'README.md'])
+  await git(['commit', '-m', 'Spinner fixture'])
+  for (let index = 1; index < worktrees; index++) {
+    await git([
+      'worktree',
+      'add',
+      '-b',
+      `spinner-${index}`,
+      path.join(directory, `workspace-${index}`)
+    ])
+  }
+  return { directory, repoPath }
+}
+
+export async function seedSpinnerWorkspaces(
+  page: Page,
+  repoPath: string,
+  options: {
+    worktrees: number
+    lineageDepth: number
+    agentsPerWorktree: number
+    subagentsPerAgent: number
+  }
+) {
+  await attachRepoAndOpenTerminal(page, repoPath)
+  await page.evaluate(async () => {
+    const store = window.__store!
+    const repo = store.getState().repos[0]
+    await store.getState().fetchWorktrees(repo.id, { requireAuthoritative: true })
+    const paths = (store.getState().detectedWorktreesByRepo[repo.id]?.worktrees ?? [])
+      .filter((worktree) => !worktree.selectedCheckout)
+      .map((worktree) => worktree.path)
+    await store.getState().updateRepo(repo.id, {
+      externalWorktreeVisibility: 'show',
+      importedExternalWorktreePaths: paths,
+      externalWorktreeInboxBaselinePaths: paths
+    })
+    await store.getState().fetchWorktrees(repo.id, { requireAuthoritative: true })
+  })
+  await page.waitForFunction(
+    (count) => Object.values(window.__store!.getState().worktreesByRepo).flat().length === count,
+    options.worktrees
+  )
+  return configureRendererScaleFixture(page, options, repoPath)
+}
+
+export async function refreshSpinnerAgents(page: Page) {
+  return page.evaluate(() => {
+    const store = window.__store!
+    const agents = Object.values(store.getState().agentStatusByPaneKey).filter((entry) =>
+      entry.prompt?.startsWith('Idle CPU agent ')
+    )
+    for (const entry of agents) {
+      store.getState().setAgentStatus(
+        entry.paneKey,
+        {
+          state: 'working',
+          prompt: entry.prompt,
+          agentType: entry.agentType,
+          subagents: entry.subagents
+        },
+        entry.agentType,
+        { updatedAt: Date.now(), stateStartedAt: entry.stateStartedAt },
+        {
+          tabId: entry.tabId,
+          worktreeId: entry.worktreeId
+        }
+      )
+    }
+    return agents.length
+  })
+}
+
+export async function startSpinnerStatusTraffic(page: Page) {
+  return page.evaluateHandle(() => {
+    const store = window.__store!
+    const keys = Object.values(store.getState().agentStatusByPaneKey)
+      .filter((entry) => entry.prompt?.startsWith('Idle CPU agent '))
+      .map((entry) => entry.paneKey)
+    let cursor = 0
+    let updates = 0
+    const timer = setInterval(() => {
+      for (let index = 0; index < Math.min(8, keys.length); index++) {
+        const entry = store.getState().agentStatusByPaneKey[keys[cursor++ % keys.length]]
+        store.getState().setAgentStatus(
+          entry.paneKey,
+          {
+            state: 'working',
+            prompt: entry.prompt,
+            agentType: entry.agentType,
+            subagents: entry.subagents
+          },
+          entry.agentType,
+          { updatedAt: Date.now(), stateStartedAt: entry.stateStartedAt },
+          {
+            tabId: entry.tabId,
+            worktreeId: entry.worktreeId
+          }
+        )
+        updates++
+      }
+    }, 200)
+    return {
+      stop() {
+        clearInterval(timer)
+        return updates
+      }
+    }
+  })
+}

--- a/tests/e2e/spinner-workspace-perf.spec.ts
+++ b/tests/e2e/spinner-workspace-perf.spec.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from 'node:crypto'
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForSessionReady } from './helpers/store'
+import { sendToTerminal, waitForActivePanePtyId, waitForTerminalOutput } from './helpers/terminal'
+import { measurePacedTyping } from './paced-terminal-typing'
+import {
+  typingProbeReadyMarker,
+  writeTypingEchoProbeScript
+} from './sustained-agent-typing-load-scripts'
+import {
+  createSpinnerRepository,
+  refreshSpinnerAgents,
+  seedSpinnerWorkspaces,
+  startSpinnerStatusTraffic
+} from './spinner-workspace-fixture'
+import { collectRendererCensus } from '../../config/scripts/idle-cpu-renderer-scale-fixture.mjs'
+import {
+  setSpinnerVariant,
+  spinnerCensus
+} from '../tools/benchmarks/spinner-rendering/app-variants.mjs'
+import { sampleCpu } from '../tools/benchmarks/spinner-rendering/sample-cpu.mjs'
+import { traceIterations } from '../tools/benchmarks/spinner-rendering/trace-iterations.mjs'
+
+const enabled = process.env.ORCA_SPINNER_BENCH === '1'
+const sampleMs = Number(process.env.ORCA_SPINNER_SAMPLE_MS ?? 10000)
+const rounds = Number(process.env.ORCA_SPINNER_ROUNDS ?? 4)
+const keyCount = Number(process.env.ORCA_SPINNER_KEYS ?? 48)
+// Avoid phase-locking keystrokes to the 200 ms status burst or 60 Hz frames.
+const keyCadenceMs = Number(process.env.ORCA_SPINNER_KEY_CADENCE_MS ?? 113)
+const variants = (process.env.ORCA_SPINNER_VARIANTS ?? 'original,long').split(',')
+if (enabled) {
+  for (const [name, value, minimum] of [
+    ['sample duration', sampleMs, 1000],
+    ['rounds', rounds, 1],
+    ['keys', keyCount, 0],
+    ['key cadence', keyCadenceMs, 1]
+  ] as const) {
+    if (!Number.isInteger(value) || value < minimum) {
+      throw new Error(`Invalid spinner benchmark ${name}: ${value}`)
+    }
+  }
+}
+const scenarios = [
+  { name: 'one-agent', worktrees: 1, lineageDepth: 0, agentsPerWorktree: 1, subagentsPerAgent: 0 },
+  { name: 'one-family', worktrees: 1, lineageDepth: 0, agentsPerWorktree: 2, subagentsPerAgent: 2 },
+  { name: '200-flat', worktrees: 200, lineageDepth: 0, agentsPerWorktree: 2, subagentsPerAgent: 2 },
+  {
+    name: '200-lineage',
+    worktrees: 200,
+    lineageDepth: 2,
+    agentsPerWorktree: 2,
+    subagentsPerAgent: 2
+  }
+]
+
+test.use({
+  seedTestRepo: false,
+  orcaAppExtraEnv: { ORCA_BACKGROUND_LAUNCH: '1' },
+  orcaAppExtraArgs: [
+    '--disable-backgrounding-occluded-windows',
+    '--disable-renderer-backgrounding'
+  ],
+  trace: 'off',
+  screenshot: 'off'
+})
+test.skip(!enabled, 'Opt-in performance benchmark')
+
+for (const scenario of scenarios) {
+  test(`spinner performance ${scenario.name}`, async ({
+    electronApp,
+    orcaPage: page,
+    registerPostElectronShutdownCleanup
+  }, testInfo) => {
+    test.setTimeout(900_000)
+    const output = path.resolve(process.env.ORCA_SPINNER_OUTPUT ?? '.bench-fixtures/spinner-app')
+    mkdirSync(output, { recursive: true })
+    const fixture = await createSpinnerRepository(scenario.worktrees)
+    registerPostElectronShutdownCleanup(async () =>
+      rmSync(fixture.directory, { recursive: true, force: true })
+    )
+    await waitForSessionReady(page)
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const window = BrowserWindow.getAllWindows()[0]
+      window.webContents.setBackgroundThrottling(false)
+      window.setSize(1280, 900)
+    })
+    await page.emulateMedia({ reducedMotion: 'no-preference' })
+    const seeded = await seedSpinnerWorkspaces(page, fixture.repoPath, scenario)
+    await ensureTerminalVisible(page)
+    await page.waitForTimeout(10000)
+    await expect(page.locator('[data-worktree-sidebar] [data-agent-spinner]').first()).toBeVisible()
+    const census = await collectRendererCensus(page, scenario.lineageDepth)
+    const rings = await spinnerCensus(page)
+    expect(census.worktrees.store).toBe(scenario.worktrees)
+    expect(census.agentRows.storeLive).toBeGreaterThanOrEqual(
+      scenario.worktrees * scenario.agentsPerWorktree
+    )
+    if (scenario.subagentsPerAgent) {
+      expect(rings.workingSubagentRows).toBeGreaterThan(0)
+    }
+    if (scenario.lineageDepth) {
+      expect(census.worktrees.mountedUnique).toBe(scenario.worktrees)
+    }
+    const report = {
+      benchmark: 'working-spinner-workspaces',
+      createdAt: new Date().toISOString(),
+      scenario,
+      options: { sampleMs, rounds, keyCount, keyCadenceMs, variants },
+      seeded,
+      census,
+      rings,
+      versions: await electronApp.evaluate(() => process.versions),
+      traces: [] as unknown[],
+      samples: [] as unknown[],
+      typing: [] as unknown[]
+    }
+    const save = () =>
+      writeFileSync(
+        path.join(output, `${scenario.name}.json`),
+        `${JSON.stringify(report, null, 2)}\n`
+      )
+    save()
+    console.log(
+      JSON.stringify({
+        scenario: scenario.name,
+        rings,
+        mountedWorkspaces: census.worktrees.mountedUnique
+      })
+    )
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Performance.enable')
+    for (let round = 0; round < (process.env.ORCA_SPINNER_CPU === '0' ? 0 : rounds); round++) {
+      const order = round % 2 ? variants.toReversed() : variants
+      for (const variant of order) {
+        await setSpinnerVariant(page, variant)
+        await refreshSpinnerAgents(page)
+        await page.waitForTimeout(1500)
+        const before = await spinnerCensus(page)
+        const sample = { variant, round, before, ...(await sampleCpu(electronApp, cdp, sampleMs)) }
+        const after = await spinnerCensus(page)
+        expect(after.mounted).toBe(before.mounted)
+        report.samples.push(sample)
+        save()
+        console.log(JSON.stringify({ scenario: scenario.name, ...sample }))
+        if (round === rounds - 1) {
+          const trace = await traceIterations(
+            cdp,
+            path.join(output, `${scenario.name}-${variant}-trace.json`)
+          )
+          report.traces.push({ variant, ...trace })
+          save()
+        }
+      }
+    }
+    const ptyId = await waitForActivePanePtyId(page)
+    for (let round = 0; round < Math.min(rounds, 2); round++) {
+      for (const variant of round % 2 ? variants.toReversed() : variants) {
+        if (keyCount === 0) {
+          continue
+        }
+        await setSpinnerVariant(page, variant)
+        await refreshSpinnerAgents(page)
+        const runId = randomUUID()
+        const scriptPath = path.join(fixture.repoPath, `spinner-typing-${runId}.mjs`)
+        const sidecarPath = path.join(output, `typing-${runId}.jsonl`)
+        writeTypingEchoProbeScript(scriptPath, runId, sidecarPath)
+        await sendToTerminal(page, ptyId, `node ${path.basename(scriptPath)}\r`)
+        await waitForTerminalOutput(page, typingProbeReadyMarker(runId), 15000)
+        const traffic = await startSpinnerStatusTraffic(page)
+        try {
+          await page.waitForTimeout(2000)
+          const measurement = await measurePacedTyping(page, runId, sidecarPath, {
+            keyCount,
+            keyCadenceMs
+          })
+          expect(measurement.missingEchoCount).toBe(0)
+          expect(measurement.missingPtyArrivalCount).toBe(0)
+          report.typing.push({ variant, round, measurement })
+          save()
+          console.log(
+            JSON.stringify({
+              scenario: scenario.name,
+              variant,
+              typing: measurement.totalMs,
+              input: measurement.inputHalfMs
+            })
+          )
+        } finally {
+          await traffic.evaluate((probe) => probe.stop())
+          await traffic.dispose()
+          await sendToTerminal(page, ptyId, '\x03')
+        }
+      }
+    }
+    await setSpinnerVariant(page, 'long')
+    await page.screenshot({ path: path.join(output, `${scenario.name}.png`) })
+    expect(
+      await electronApp.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().every((window) => !window.isVisible() && !window.isFocused())
+      )
+    ).toBe(true)
+    await testInfo.attach('spinner-benchmark', {
+      path: path.join(output, `${scenario.name}.json`),
+      contentType: 'application/json'
+    })
+  })
+}

--- a/tests/e2e/terminal-multi-workspace-typing-latency.spec.ts
+++ b/tests/e2e/terminal-multi-workspace-typing-latency.spec.ts
@@ -20,9 +20,14 @@
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { type ChildProcess, spawn } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
+import {
+  measurePacedTyping,
+  type LatencyStats,
+  type PacedTypingMeasurement
+} from './paced-terminal-typing'
 import {
   ensureTerminalVisible,
   getActiveWorktreeId,
@@ -38,14 +43,12 @@ import {
 } from './helpers/terminal'
 import {
   ensureActiveWorktreePaneLoad,
-  focusActiveTerminalInput,
   focusPane,
   waitForTerminalOutputForPtyId,
   type TerminalLoadPane
 } from './artificial-opencode-pane-interactions'
 import {
   sustainedLoadReadyFilePath,
-  typingKeyMarkerPrefix,
   typingProbeReadyMarker,
   writeSustainedAgentLoadScript,
   writeTypingEchoProbeScript
@@ -65,41 +68,11 @@ const KEY_CADENCE_MS = readPositiveInt('ORCA_TYPING_BENCH_KEY_CADENCE_MS', 250)
 const CPU_WORKERS = readPositiveInt('ORCA_TYPING_BENCH_CPU_WORKERS', 0)
 const BENCH_LABEL = process.env.ORCA_TYPING_BENCH_LABEL ?? 'dev'
 
-const KEY_CHARS = 'abcdefghijklmnopqrstuvwxyz'
-const TIMER_SAMPLE_MS = 16
-const MARKER_SCAN_TRAILING_ROWS = 160
-const ECHO_STRAGGLER_TIMEOUT_MS = 30_000
 // Load must outlive setup (pane splits, worktree switches) plus the typing
 // window; generously padded because setup time varies with pane count.
 const LOAD_DURATION_S = Math.ceil((KEY_COUNT * KEY_CADENCE_MS) / 1000) + 90
 
 const RESULTS_DIR = path.resolve(__dirname, '..', '..', 'tools', 'benchmarks', 'results')
-
-type LatencyStats = {
-  count: number
-  p50: number
-  p90: number
-  p99: number
-  max: number
-}
-
-type KeySample = {
-  seq: number
-  sentAt: number
-  ptyArrivedAt: number | null
-  echoSeenAt: number | null
-}
-
-type PacedTypingMeasurement = {
-  keyCount: number
-  missingPtyArrivalCount: number
-  missingEchoCount: number
-  totalMs: LatencyStats | null
-  inputHalfMs: LatencyStats | null
-  echoHalfMs: LatencyStats | null
-  maxTimerDriftMs: number
-  samples: KeySample[]
-}
 
 type SchedulerDebugSnapshot = {
   queuedChars: number
@@ -120,187 +93,6 @@ type TypingBenchWindow = Window & {
   __terminalOutputSchedulerDebug?: {
     reset: () => void
     snapshot: () => SchedulerDebugSnapshot
-  }
-}
-
-function latencyStats(samples: number[]): LatencyStats | null {
-  if (samples.length === 0) {
-    return null
-  }
-  const sorted = [...samples].sort((a, b) => a - b)
-  const at = (q: number): number =>
-    sorted[Math.min(sorted.length - 1, Math.floor(q * sorted.length))]
-  return {
-    count: sorted.length,
-    p50: at(0.5),
-    p90: at(0.9),
-    p99: at(0.99),
-    max: sorted.at(-1) ?? 0
-  }
-}
-
-async function scanRecentKeyMarkerSeqs(
-  page: Page,
-  markerPrefix: string
-): Promise<{ seqs: number[]; atMs: number }> {
-  return page.evaluate(
-    ({ markerPrefix, trailingRows }) => {
-      const state = window.__store?.getState()
-      const worktreeId = state?.activeWorktreeId
-      const tabId =
-        state?.activeTabType === 'terminal'
-          ? state.activeTabId
-          : worktreeId
-            ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
-            : null
-      const manager = tabId ? window.__paneManagers?.get(tabId) : null
-      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
-      const seqs: number[] = []
-      if (!pane) {
-        return { seqs, atMs: Date.now() }
-      }
-      // Why trailing rows, not serialize: full-buffer serialization on every
-      // poll runs on the renderer main thread and would perturb the very
-      // latency being measured (same rationale as the history-size spec).
-      const re = new RegExp(`${markerPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(\\d+)`, 'g')
-      const buffer = pane.terminal.buffer.active
-      const start = Math.max(0, buffer.length - trailingRows)
-      for (let row = start; row < buffer.length; row += 1) {
-        const line = buffer.getLine(row)?.translateToString(true) ?? ''
-        let match: RegExpExecArray | null
-        while ((match = re.exec(line)) !== null) {
-          seqs.push(Number(match[1]))
-        }
-      }
-      return { seqs, atMs: Date.now() }
-    },
-    { markerPrefix, trailingRows: MARKER_SCAN_TRAILING_ROWS }
-  )
-}
-
-function readKeyArrivalSidecar(sidecarPath: string): Map<number, number> {
-  const arrivals = new Map<number, number>()
-  let raw = ''
-  try {
-    raw = readFileSync(sidecarPath, 'utf8')
-  } catch {
-    return arrivals
-  }
-  for (const line of raw.split('\n')) {
-    if (!line.trim()) {
-      continue
-    }
-    try {
-      const entry = JSON.parse(line) as { seq: number; atMs: number }
-      arrivals.set(entry.seq, entry.atMs)
-    } catch {
-      /* torn tail write; final retry pass re-reads */
-    }
-  }
-  return arrivals
-}
-
-async function measurePacedTyping(
-  page: Page,
-  runId: string,
-  sidecarPath: string
-): Promise<PacedTypingMeasurement> {
-  const markerPrefix = typingKeyMarkerPrefix(runId)
-  await focusActiveTerminalInput(page)
-
-  const timerDrift = await page.evaluateHandle((sampleMs) => {
-    let maxTimerDriftMs = 0
-    let lastTick = performance.now()
-    const timer = window.setInterval(() => {
-      const now = performance.now()
-      maxTimerDriftMs = Math.max(maxTimerDriftMs, now - lastTick - sampleMs)
-      lastTick = now
-    }, sampleMs)
-    return {
-      stop: () => {
-        window.clearInterval(timer)
-        return maxTimerDriftMs
-      }
-    }
-  }, TIMER_SAMPLE_MS)
-
-  // Concurrent echo watcher: records the first time each key's marker is
-  // visible in the buffer, while typing continues at its own cadence.
-  const echoSeenAt = new Map<number, number>()
-  let watching = true
-  const echoWatcher = (async () => {
-    while (watching) {
-      const { seqs, atMs } = await scanRecentKeyMarkerSeqs(page, markerPrefix)
-      for (const seq of seqs) {
-        if (!echoSeenAt.has(seq)) {
-          echoSeenAt.set(seq, atMs)
-        }
-      }
-      await page.waitForTimeout(10)
-    }
-  })()
-
-  const sentAtBySeq = new Map<number, number>()
-  try {
-    for (let index = 0; index < KEY_COUNT; index++) {
-      const seq = index + 1
-      const tickStart = Date.now()
-      sentAtBySeq.set(seq, tickStart)
-      await page.keyboard.type(KEY_CHARS[index % KEY_CHARS.length])
-      const elapsed = Date.now() - tickStart
-      if (elapsed < KEY_CADENCE_MS) {
-        await page.waitForTimeout(KEY_CADENCE_MS - elapsed)
-      }
-    }
-    // Wait out stragglers so a slow echo is measured, not dropped.
-    const stragglerDeadline = Date.now() + ECHO_STRAGGLER_TIMEOUT_MS
-    while (echoSeenAt.size < KEY_COUNT && Date.now() < stragglerDeadline) {
-      await page.waitForTimeout(25)
-    }
-  } finally {
-    watching = false
-    await echoWatcher
-  }
-  const maxTimerDriftMs = await timerDrift.evaluate((watcher) => watcher.stop())
-  await timerDrift.dispose()
-
-  // The probe appends arrivals asynchronously; re-read until complete or 5s.
-  let arrivals = readKeyArrivalSidecar(sidecarPath)
-  const sidecarDeadline = Date.now() + 5_000
-  while (arrivals.size < KEY_COUNT && Date.now() < sidecarDeadline) {
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    arrivals = readKeyArrivalSidecar(sidecarPath)
-  }
-
-  const samples: KeySample[] = []
-  const totalMs: number[] = []
-  const inputHalfMs: number[] = []
-  const echoHalfMs: number[] = []
-  for (let seq = 1; seq <= KEY_COUNT; seq++) {
-    const sentAt = sentAtBySeq.get(seq) ?? 0
-    const ptyArrivedAt = arrivals.get(seq) ?? null
-    const seenAt = echoSeenAt.get(seq) ?? null
-    samples.push({ seq, sentAt, ptyArrivedAt, echoSeenAt: seenAt })
-    if (ptyArrivedAt !== null) {
-      inputHalfMs.push(ptyArrivedAt - sentAt)
-    }
-    if (seenAt !== null) {
-      totalMs.push(seenAt - sentAt)
-      if (ptyArrivedAt !== null) {
-        echoHalfMs.push(seenAt - ptyArrivedAt)
-      }
-    }
-  }
-
-  return {
-    keyCount: KEY_COUNT,
-    missingPtyArrivalCount: KEY_COUNT - arrivals.size,
-    missingEchoCount: KEY_COUNT - echoSeenAt.size,
-    totalMs: latencyStats(totalMs),
-    inputHalfMs: latencyStats(inputHalfMs),
-    echoHalfMs: latencyStats(echoHalfMs),
-    maxTimerDriftMs,
-    samples
   }
 }
 
@@ -454,7 +246,10 @@ test.describe('Multi-workspace sustained typing latency bench', () => {
     try {
       await resetDeliveryDebug(orcaPage)
       await startTypingProbe(orcaPage, typingPtyId, probePath, runId)
-      const measurement = await measurePacedTyping(orcaPage, runId, sidecarPath)
+      const measurement = await measurePacedTyping(orcaPage, runId, sidecarPath, {
+        keyCount: KEY_COUNT,
+        keyCadenceMs: KEY_CADENCE_MS
+      })
       writeBenchReport(
         testInfo,
         'baseline',
@@ -517,7 +312,10 @@ test.describe('Multi-workspace sustained typing latency bench', () => {
         .toBeGreaterThan(0)
 
       await startTypingProbe(orcaPage, typingPtyId, probePath, runId)
-      const measurement = await measurePacedTyping(orcaPage, runId, sidecarPath)
+      const measurement = await measurePacedTyping(orcaPage, runId, sidecarPath, {
+        keyCount: KEY_COUNT,
+        keyCadenceMs: KEY_CADENCE_MS
+      })
       writeBenchReport(
         testInfo,
         `hidden-load-${LOAD_PANES}x${LOAD_RATE_KBPS}kbps-cpu${CPU_WORKERS}`,
@@ -576,7 +374,10 @@ test.describe('Multi-workspace sustained typing latency bench', () => {
 
       await resetDeliveryDebug(orcaPage)
       await startTypingProbe(orcaPage, typingPane.ptyId, probePath, runId)
-      const measurement = await measurePacedTyping(orcaPage, runId, sidecarPath)
+      const measurement = await measurePacedTyping(orcaPage, runId, sidecarPath, {
+        keyCount: KEY_COUNT,
+        keyCadenceMs: KEY_CADENCE_MS
+      })
       writeBenchReport(
         testInfo,
         `visible-split-${LOAD_RATE_KBPS}kbps-cpu${CPU_WORKERS}`,

--- a/tests/tools/benchmarks/spinner-rendering/app-variants.mjs
+++ b/tests/tools/benchmarks/spinner-rendering/app-variants.mjs
@@ -1,0 +1,59 @@
+export const spinnerVariants = {
+  original: `
+    @keyframes agent-spinner-rotate { to { transform: rotate(360deg); } }
+    .agent-working-spinner { animation-duration: 1s; animation-timing-function: steps(12, end); }
+  `,
+  long: '',
+  // Retain the rejected containment experiment for reproducible ablation.
+  contained:
+    '.spinner-benchmark-container { content-visibility: auto; overflow-clip-margin: var(--spacing); }'
+}
+
+export async function setSpinnerVariant(page, variant) {
+  if (!(variant in spinnerVariants)) {
+    throw new Error(`Unknown spinner variant: ${variant}`)
+  }
+  await page.evaluate((css) => {
+    for (const ring of document.querySelectorAll('[data-agent-spinner]')) {
+      ring.parentElement.classList.add('spinner-benchmark-container')
+    }
+    let style = document.getElementById('spinner-variant')
+    if (!style) {
+      style = document.createElement('style')
+      style.id = 'spinner-variant'
+      document.head.appendChild(style)
+    }
+    style.textContent = css
+  }, spinnerVariants[variant])
+}
+
+export async function spinnerCensus(page) {
+  return page.evaluate(() => {
+    const rings = [...document.querySelectorAll('[data-agent-spinner]')]
+    const inViewport = (ring) => {
+      // Querying the skipped child would force the rendering this census measures.
+      const rect = ring.parentElement.getBoundingClientRect()
+      if (rect.width === 0 || rect.height === 0) {
+        return false
+      }
+      let top = 0
+      let bottom = innerHeight
+      for (let parent = ring.parentElement; parent; parent = parent.parentElement) {
+        if (/(auto|scroll|hidden|clip)/.test(getComputedStyle(parent).overflowY)) {
+          const bounds = parent.getBoundingClientRect()
+          top = Math.max(top, bounds.top)
+          bottom = Math.min(bottom, bounds.bottom)
+        }
+      }
+      return rect.bottom > top && rect.top < bottom
+    }
+    return {
+      mounted: rings.length,
+      visible: rings.filter(inViewport).length,
+      workingSubagentRows: document.querySelectorAll(
+        '.worktree-agent-lineage-child-row [data-agent-spinner]'
+      ).length,
+      documentVisibility: document.visibilityState
+    }
+  })
+}

--- a/tests/tools/benchmarks/spinner-rendering/fixture.css
+++ b/tests/tools/benchmarks/spinner-rendering/fixture.css
@@ -1,0 +1,4 @@
+@import '../../../../src/renderer/src/assets/main.css';
+@source './fixture.tsx';
+@source '../../../../src/renderer/src/components/AgentWorkingSpinner.tsx';
+@source '../../../../src/renderer/src/components/AgentStateDot.tsx';

--- a/tests/tools/benchmarks/spinner-rendering/fixture.tsx
+++ b/tests/tools/benchmarks/spinner-rendering/fixture.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { AgentStateDot } from '../../../../src/renderer/src/components/AgentStateDot'
+import { UI_ZOOM_MIN, UI_ZOOM_MAX } from '../../../../src/shared/ui-zoom-level'
+import './fixture.css'
+
+type FixtureOptions = { count: number; baseline?: boolean; offset?: number; paired?: boolean }
+
+function anchorBaseline(event: React.AnimationEvent<HTMLSpanElement>): void {
+  const animation = event.currentTarget.getAnimations()[0]
+  if (animation) {
+    animation.startTime = 0
+  }
+}
+
+function Fixture({ count, baseline = false, offset = 0, paired = false }: FixtureOptions) {
+  return (
+    <div id="scroller" style={{ height: 700, overflow: 'auto', overflowAnchor: 'none' }}>
+      <div style={{ height: offset }} />
+      <div id="grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(20, 32px)' }}>
+        {Array.from({ length: count }, (_, index) => {
+          const size = index % 4 < 2 ? 'size-2' : 'size-1.5'
+          return (
+            <div
+              className="spinner-cell"
+              key={index}
+              style={{
+                width: 32,
+                height: 32,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center'
+              }}
+            >
+              {baseline || (paired && index % 2 === 0) ? (
+                <span
+                  className={`inline-flex shrink-0 items-center justify-center ${size === 'size-2' ? 'h-3 w-3' : 'h-2.5 w-2.5'}`}
+                >
+                  <span
+                    data-baseline=""
+                    onAnimationStart={anchorBaseline}
+                    className={`spinner-benchmark-baseline block rounded-full border-2 border-yellow-500 border-t-transparent ${size}`}
+                  />
+                </span>
+              ) : (
+                <AgentStateDot
+                  state="working"
+                  size={size === 'size-2' ? 'md' : 'sm'}
+                  title={null}
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+      <div style={{ height: 1000 }} />
+    </div>
+  )
+}
+
+const root = createRoot(document.getElementById('root')!)
+let generation = 0
+Object.assign(window, {
+  spinnerBenchmark: {
+    zoomExtremes: [1.2 ** UI_ZOOM_MIN, 1.2 ** UI_ZOOM_MAX],
+    render(options: FixtureOptions) {
+      flushSync(() => root.render(<Fixture key={++generation} {...options} />))
+    }
+  }
+})

--- a/tests/tools/benchmarks/spinner-rendering/index.html
+++ b/tests/tools/benchmarks/spinner-rendering/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 32px;
+      }
+      @keyframes spinner-benchmark-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .spinner-benchmark-baseline {
+        animation: spinner-benchmark-spin 1s steps(12, end) infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .spinner-benchmark-baseline {
+          animation: none;
+          border-top-color: var(--color-yellow-500);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./fixture.tsx"></script>
+  </body>
+</html>

--- a/tests/tools/benchmarks/spinner-rendering/main.ts
+++ b/tests/tools/benchmarks/spinner-rendering/main.ts
@@ -1,0 +1,22 @@
+import { app, BrowserWindow } from 'electron'
+import path from 'node:path'
+import { applyBackgroundActivationPolicy } from '../../../../src/main/window/foreground-activation-policy'
+
+if (process.env.ORCA_BACKGROUND_LAUNCH !== '1') {
+  throw new Error('Spinner measurements require ORCA_BACKGROUND_LAUNCH=1')
+}
+app.setPath('userData', path.join(__dirname, 'profile'))
+applyBackgroundActivationPolicy()
+// Exercise the frame pipeline while keeping the native window hidden.
+app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
+app.commandLine.appendSwitch('disable-renderer-backgrounding')
+
+void app.whenReady().then(async () => {
+  const window = new BrowserWindow({
+    show: false,
+    width: 1100,
+    height: 850,
+    webPreferences: { backgroundThrottling: false }
+  })
+  await window.loadURL('about:blank')
+})

--- a/tests/tools/benchmarks/spinner-rendering/run.mjs
+++ b/tests/tools/benchmarks/spinner-rendering/run.mjs
@@ -1,0 +1,93 @@
+import { _electron as electron } from '@stablyai/playwright-test'
+import { build as buildMain } from 'esbuild'
+import { build as buildRenderer } from 'vite'
+import tailwindcss from '@tailwindcss/vite'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { parseArgs } from 'node:util'
+import { verifyRendering } from './verify-rendering.mjs'
+import { sampleCpu } from './sample-cpu.mjs'
+
+const { values } = parseArgs({
+  options: {
+    count: { type: 'string', default: '200' },
+    'sample-ms': { type: 'string', default: '5000' },
+    'scale-factor': { type: 'string' },
+    'verify-only': { type: 'boolean', default: false }
+  }
+})
+const count = Number(values.count)
+const sampleMs = Number(values['sample-ms'])
+if (!Number.isInteger(count) || count < 1 || !Number.isFinite(sampleMs) || sampleMs < 1000) {
+  throw new Error('Use a positive integer --count and --sample-ms >= 1000')
+}
+const root = fileURLToPath(new URL('../../../../', import.meta.url))
+const outputParent = path.join(root, '.bench-fixtures')
+mkdirSync(outputParent, { recursive: true })
+const outputDir = mkdtempSync(path.join(outputParent, 'spinner-rendering-'))
+const main = path.join(outputDir, 'main.cjs')
+await buildMain({
+  entryPoints: [path.join(import.meta.dirname, 'main.ts')],
+  outfile: main,
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  external: ['electron']
+})
+await buildRenderer({
+  configFile: false,
+  root: import.meta.dirname,
+  base: './',
+  logLevel: 'silent',
+  plugins: [tailwindcss()],
+  resolve: { alias: { '@': path.join(root, 'src', 'renderer', 'src') } },
+  build: { outDir: path.join(outputDir, 'renderer'), emptyOutDir: true }
+})
+const { ELECTRON_RUN_AS_NODE: _runAsNode, ...env } = process.env
+const scaleArgs = values['scale-factor']
+  ? [`--force-device-scale-factor=${values['scale-factor']}`]
+  : []
+const app = await electron.launch({
+  args: [...scaleArgs, main],
+  env: { ...env, ORCA_BACKGROUND_LAUNCH: '1' }
+})
+const report = { samples: [] }
+const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+try {
+  const page = await app.firstWindow()
+  await page.goto(pathToFileURL(path.join(outputDir, 'renderer', 'index.html')).href)
+  await page.waitForFunction(() => Boolean(window.spinnerBenchmark))
+  report.versions = await app.evaluate(() => process.versions)
+  report.rendering = await verifyRendering(app, page, outputDir)
+  console.log(`Rendering checks passed: ${JSON.stringify(report.rendering)}`)
+  if (!values['verify-only']) {
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Performance.enable')
+    for (const total of [0, ...new Set([1, count])]) {
+      for (const offset of total === 0 ? [0] : [0, 5000]) {
+        // Interleave A/B/B/A to reduce temperature and background-load bias.
+        for (const baseline of total === 0 ? [true] : [true, false, false, true]) {
+          await page.evaluate((options) => window.spinnerBenchmark.render(options), {
+            count: total,
+            offset,
+            baseline
+          })
+          await pause(1000)
+          const sample = {
+            count: total,
+            offset,
+            baseline,
+            ...(await sampleCpu(app, cdp, sampleMs))
+          }
+          report.samples.push(sample)
+          console.log(JSON.stringify(sample))
+        }
+      }
+    }
+  }
+} finally {
+  writeFileSync(path.join(outputDir, 'report.json'), `${JSON.stringify(report, null, 2)}\n`)
+  console.log(`Spinner evidence: ${outputDir}`)
+  await app.close()
+}

--- a/tests/tools/benchmarks/spinner-rendering/sample-cpu.mjs
+++ b/tests/tools/benchmarks/spinner-rendering/sample-cpu.mjs
@@ -1,0 +1,45 @@
+export async function sampleCpu(app, cdp, sampleMs) {
+  const rendererMetrics = async () =>
+    Object.fromEntries(
+      (await cdp.send('Performance.getMetrics')).metrics.map(({ name, value }) => [name, value])
+    )
+  const processMetrics = () =>
+    app.evaluate(({ app }) =>
+      app
+        .getAppMetrics()
+        .map(({ pid, type, cpu }) => ({ pid, type, seconds: cpu.cumulativeCPUUsage }))
+    )
+  const beforeRenderer = await rendererMetrics()
+  const before = await processMetrics()
+  const started = performance.now()
+  await new Promise((resolve) => setTimeout(resolve, sampleMs))
+  const after = await processMetrics()
+  const elapsedMs = performance.now() - started
+  const afterRenderer = await rendererMetrics()
+  return {
+    elapsedMs,
+    cpuMsPerSecond: after.map((process) => {
+      const previous = before.find((row) => row.pid === process.pid)?.seconds
+      return {
+        pid: process.pid,
+        type: process.type,
+        value:
+          typeof previous === 'number' && typeof process.seconds === 'number'
+            ? ((process.seconds - previous) * 1e6) / elapsedMs
+            : null
+      }
+    }),
+    rendererMsPerSecond: Object.fromEntries(
+      ['TaskDuration', 'ScriptDuration', 'RecalcStyleDuration', 'LayoutDuration'].map((name) => [
+        name,
+        ((afterRenderer[name] - beforeRenderer[name]) * 1e6) / elapsedMs
+      ])
+    ),
+    rendererCountsPerSecond: Object.fromEntries(
+      ['RecalcStyleCount', 'LayoutCount'].map((name) => [
+        name,
+        ((afterRenderer[name] - beforeRenderer[name]) * 1000) / elapsedMs
+      ])
+    )
+  }
+}

--- a/tests/tools/benchmarks/spinner-rendering/trace-iterations.mjs
+++ b/tests/tools/benchmarks/spinner-rendering/trace-iterations.mjs
@@ -1,0 +1,33 @@
+import { writeFileSync } from 'node:fs'
+
+export async function traceIterations(cdp, outputPath, durationMs = 2200) {
+  await cdp.send('Tracing.start', {
+    categories: 'devtools.timeline',
+    transferMode: 'ReturnAsStream'
+  })
+  await new Promise((resolve) => setTimeout(resolve, durationMs))
+  const completion = new Promise((resolve) => cdp.once('Tracing.tracingComplete', resolve))
+  await cdp.send('Tracing.end')
+  const { stream } = await completion
+  let json = ''
+  try {
+    while (true) {
+      const part = await cdp.send('IO.read', { handle: stream })
+      json += part.data
+      if (part.eof) {
+        break
+      }
+    }
+  } finally {
+    await cdp.send('IO.close', { handle: stream })
+  }
+  writeFileSync(outputPath, json)
+  const events = JSON.parse(json).traceEvents
+  return {
+    durationMs,
+    iterationEvents: events.filter(
+      (event) => event.name === 'EventDispatch' && event.args?.data?.type === 'animationiteration'
+    ).length,
+    styleUpdates: events.filter((event) => event.name === 'UpdateLayoutTree').length
+  }
+}

--- a/tests/tools/benchmarks/spinner-rendering/verify-pixels.mjs
+++ b/tests/tools/benchmarks/spinner-rendering/verify-pixels.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict'
+import { writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { PNG } from 'pngjs'
+
+const TIMES = [
+  ...Array.from({ length: 12 }, (_, step) => (step * 1000) / 12 + 1),
+  3_600_251,
+  43_200_251,
+  86_399_751,
+  86_399_999,
+  86_400_001,
+  86_400_251
+]
+
+async function captureRingPixels(page, time) {
+  await page.evaluate(async (value) => {
+    const animations = document.getAnimations()
+    for (const animation of animations) {
+      animation.pause()
+    }
+    await Promise.all(animations.map((animation) => animation.ready))
+    for (const animation of animations) {
+      animation.currentTime = value
+    }
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+  }, time)
+  const screenshot = await page.screenshot()
+  const full = PNG.sync.read(screenshot)
+  const rect = await page.evaluate(() => {
+    const cells = [...document.querySelectorAll('.spinner-cell')].map((element) =>
+      element.getBoundingClientRect()
+    )
+    const scale = window.devicePixelRatio
+    const x = Math.floor(cells[0].x * scale)
+    const y = Math.floor(cells[0].y * scale)
+    return {
+      x,
+      y,
+      width: Math.ceil(cells.at(-1).right * scale) - x,
+      height: Math.ceil(cells[0].bottom * scale) - y
+    }
+  })
+  const rings = new PNG({ width: rect.width, height: rect.height })
+  PNG.bitblt(full, rings, rect.x, rect.y, rect.width, rect.height, 0, 0)
+  return { rings, screenshot }
+}
+
+export async function verifyPixels(app, page, outputDir, waitForPhase) {
+  let comparisons = 0
+  const [minimumZoom, maximumZoom] = await page.evaluate(() => window.spinnerBenchmark.zoomExtremes)
+  for (const zoom of [minimumZoom, 1, 1.25, 2, maximumZoom]) {
+    await app.evaluate(
+      ({ BrowserWindow }, value) =>
+        BrowserWindow.getAllWindows()[0].webContents.setZoomFactor(value),
+      zoom
+    )
+    for (const theme of ['light', 'dark']) {
+      await page.evaluate(
+        (value) => document.documentElement.classList.toggle('dark', value === 'dark'),
+        theme
+      )
+      await page.evaluate(() => window.spinnerBenchmark.render({ count: 4, baseline: true }))
+      await page.waitForFunction(() =>
+        [...document.querySelectorAll('[data-baseline]')].every(
+          (element) => element.getAnimations()[0]?.startTime === 0
+        )
+      )
+      const baseline = []
+      for (const time of TIMES) {
+        baseline.push((await captureRingPixels(page, time)).rings)
+      }
+      await page.evaluate(() => window.spinnerBenchmark.render({ count: 4 }))
+      await waitForPhase(page)
+      for (const [index, time] of TIMES.entries()) {
+        const { rings, screenshot } = await captureRingPixels(page, time)
+        const before = baseline[index]
+        assert.equal(rings.width, before.width)
+        assert.equal(rings.height, before.height)
+        let maxDifference = 0
+        for (let channel = 0; channel < rings.data.length; channel++) {
+          maxDifference = Math.max(
+            maxDifference,
+            Math.abs(rings.data[channel] - before.data[channel])
+          )
+        }
+        if (maxDifference > 1) {
+          writeFileSync(path.join(outputDir, 'pixel-before.png'), PNG.sync.write(before))
+          writeFileSync(path.join(outputDir, 'pixel-after.png'), PNG.sync.write(rings))
+        }
+        // Equivalent accumulated angles can round an antialias channel by one level.
+        assert.ok(
+          maxDifference <= 1,
+          `Pixel difference ${maxDifference} at zoom ${zoom}, ${theme}, time ${time}`
+        )
+        comparisons += 4
+        if (time === TIMES[1] && zoom === 1) {
+          writeFileSync(path.join(outputDir, `${theme}.png`), screenshot)
+        }
+      }
+    }
+  }
+  return comparisons
+}

--- a/tests/tools/benchmarks/spinner-rendering/verify-rendering.mjs
+++ b/tests/tools/benchmarks/spinner-rendering/verify-rendering.mjs
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict'
+import { verifyPixels } from './verify-pixels.mjs'
+
+async function waitForPhase(page) {
+  await page
+    .waitForFunction(() =>
+      [...document.querySelectorAll('[data-agent-spinner]')].every((element) => {
+        const animations = element.getAnimations({ subtree: true })
+        return (
+          animations.length === 1 &&
+          animations[0].startTime === 0 &&
+          animations[0].playState === 'running'
+        )
+      })
+    )
+    .catch(async (error) => {
+      console.log(
+        await page.evaluate(() =>
+          [...document.querySelectorAll('[data-agent-spinner]')].slice(0, 3).map((element) => ({
+            html: element.outerHTML,
+            width: getComputedStyle(element).width,
+            state: document.visibilityState,
+            animations: element.getAnimations({ subtree: true }).map((animation) => ({
+              name: animation.animationName,
+              start: animation.startTime,
+              time: animation.currentTime
+            }))
+          }))
+        )
+      )
+      throw error
+    })
+}
+
+export async function verifyRendering(app, page, outputDir) {
+  await page.emulateMedia({ reducedMotion: 'no-preference' })
+  await page.evaluate(() => window.spinnerBenchmark.render({ count: 4, paired: true }))
+  await waitForPhase(page)
+  const pixelComparisons = await verifyPixels(app, page, outputDir, waitForPhase)
+  await app.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows()[0].webContents.setZoomFactor(1)
+  )
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.waitForFunction(() =>
+    [...document.querySelectorAll('[data-agent-spinner]')].every((element) => {
+      const ring = getComputedStyle(element)
+      return (
+        element.getAnimations({ subtree: true }).length === 0 &&
+        ring.borderTopColor === ring.borderLeftColor
+      )
+    })
+  )
+  await page.emulateMedia({ reducedMotion: 'no-preference' })
+  await waitForPhase(page)
+  await page.evaluate(() => window.spinnerBenchmark.render({ count: 200, offset: 5000 }))
+  await waitForPhase(page)
+  await page.evaluate(() => {
+    document.querySelector('#scroller').scrollTop = 5000
+  })
+  await waitForPhase(page)
+  await page.evaluate(() => {
+    document.querySelector('#scroller').scrollTop = 0
+  })
+  await waitForPhase(page)
+  await page.evaluate(() => {
+    document.querySelector('#scroller').scrollTop = 5000
+  })
+  await waitForPhase(page)
+  await page.evaluate(() => {
+    document.querySelector('#grid').style.display = 'none'
+  })
+  await page.waitForFunction(
+    () => document.querySelector('#grid').getBoundingClientRect().height === 0
+  )
+  await page.evaluate(() => {
+    document.querySelector('#grid').style.display = 'grid'
+  })
+  await waitForPhase(page)
+  const iterationEvents = await page.evaluate(async () => {
+    window.spinnerBenchmark.render({ count: 4, paired: true })
+    const events = { baseline: 0, candidate: 0 }
+    const count = (event) => {
+      if (event.animationName === 'spinner-benchmark-spin') {
+        events.baseline++
+      }
+      if (event.animationName === 'agent-spinner-rotate') {
+        events.candidate++
+      }
+    }
+    document.addEventListener('animationiteration', count, true)
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 1250))
+    } finally {
+      document.removeEventListener('animationiteration', count, true)
+    }
+    return events
+  })
+  assert.ok(iterationEvents.baseline >= 2)
+  assert.equal(iterationEvents.candidate, 0)
+  assert.ok(
+    await app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().every((window) => !window.isVisible() && !window.isFocused())
+    )
+  )
+  return {
+    pixelComparisons,
+    iterationEvents,
+    phases: true,
+    reducedMotion: true,
+    scrollReveal: true,
+    displayReveal: true,
+    hiddenWindow: true
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1155 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​222 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​933 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​245 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​231 |

<!-- /orca-pr-loc -->

## ELI5

A spinner already turns without JavaScript driving every frame. But it still tells React "I finished a lap" every second, and those notifications interrupt the thread that handles typing.

This makes one animation contain a day's worth of laps. It looks and moves the same, but sends that notification once a day. Visible drawing still costs something; this removes avoidable bookkeeping.

## What Changed

- Change only the production CSS animation: 86,400 turns over 86,400 seconds, with 1,036,800 steps. That preserves one revolution and 12 steps per second.
- Add repeatable hidden-Electron benchmarks for 1 and 200 real Git workspaces, including working root-agent and subagent rows, normal virtualization, expanded lineage, and real PTY typing under status traffic.
- Reuse the existing scale fixture and extract the existing paced terminal-typing probe. Add pixel, phase, reduced-motion, and reveal checks.

## Why

This preserves the two later historical fixes:

- [#9380](https://github.com/stablyai/orca/pull/9380) used a shared JavaScript clock to reduce frame-pipeline CPU. Its per-spinner style writes later caused typing stalls at scale.
- [#12359](https://github.com/stablyai/orca/pull/12359) moved rotation back to compositor CSS. The historical production report measured about 490 style writes/sec with 41 rings and input p90 of 363 ms versus 19 ms with the writes stopped.
- [#13987](https://github.com/stablyai/orca/pull/13987) moved phase synchronization to `animationstart`, avoiding a synchronous style query at every mount.

The new change removes almost all CSS iteration boundaries. React delegates animation-iteration listeners even without a component handler. It adds no DOM nodes, JS clocks, observers, or per-frame style writes, and keeps the existing phase synchronization. Historical benchmark totals are not directly comparable with this run.

## Benchmarks

| Scenario | Renderer + GPU CPU ms/s, old → new | Main-thread ms/s, old → new | Echo p90 ms, old → new |
| --- | ---: | ---: | --- |
| `one-agent` | 37.0 → 38.2 | 5.4 → 3.5 | 19 → 18–19 |
| `one-family` | 46.2 → 44.6 | 7.8 → 4.4 | 17–19 → 18–19 |
| `200-flat` | 141.6 → 122.8 | 28.2 → 16.3 | 26–28 → 26–28 |
| `200-lineage` | 324.6 → 295.6 | 140.8 → 70.0 | 159–239 → 93–160 |

"CPU ms/sec" is processor time spent during one second: 100 ms/sec is about 10% of one CPU core. Renderer + GPU-process CPU includes their other Orca work; it is not GPU hardware usage or total system CPU. Main-thread time is included in renderer time. Echo p90 means 90% of sampled keys were observed within that time.

Main-thread median time fell about **35–50% across all four cases**, and separate 2.2-second native traces counted **6 / 16 / 324 / 2,802 iteration events before versus zero after**. This verifies avoided work in the real app without installing a benchmark iteration listener.

Total CPU was roughly unchanged for one worktree, and fell 13% / 9% in the final 200-worktree runs. A shorter ablation had mixed total-CPU results (flat list: 89 → 108 CPU ms/sec) while still reducing main-thread time. The reliable claim is reduced event and main-thread work; the CPU percentages are local measurements, not guarantees. Typing stayed similar in small/flat cases and improved in the final lineage run; a shorter run showed similar lineage typing, so no general typing speedup is claimed.

The 200-workspace cases seed 400 working root agents and 800 subagents. Normal virtualization mounts 23 workspaces / 162 rings; expanded lineage mounts all 200 / 1,401 rings. Both have 15 visible rings. The one-workspace cases have 1 agent / 3 rings and 2 root agents + 4 subagents / 8 rings.

Four interleaved 10-second CPU samples per variant; two 64-key typing runs at 113 ms cadence, with up to 40 status updates/sec. CPU, typing, and native traces are measured separately. No samples are discarded. The detailed report includes every CPU sample and reproduction commands: [full report](https://github.com/stablyai/orca/blob/e9ece2594844f5ae67192b1bff704642bf47490e/docs/reference/spinner-rendering-performance.md).

These are macOS / Apple M4 measurements in hidden, unthrottled Electron 43.4.1 renderers. Worktrees and the typing PTY are real; working agent statuses are deterministic fixture data, not hundreds of live model sessions or streaming PTYs. Linux, Windows, SSH transport, native display latency, and battery use were not benchmarked.

A containment prototype saved more CPU but shifted a small ring by one pixel at minimum zoom on a 1× display; a pseudo-element prototype also hurt typing latency. Both are excluded. Their results are not the numbers for this patch. The optional benchmark variant retains containment for reproducible comparison.

## Linked Issue

Related historical issue: STA-3328, addressed by [#12359](https://github.com/stablyai/orca/pull/12359). This is follow-up performance work requested by the maintainer.

## Visual Proof

N/A — no intended visual or interaction change. Automated CDP comparisons passed for 6/8 px rings at 1× and 2× display density, light/dark themes, supported zoom extremes, every phase, long elapsed times, and the daily wrap: 1,440 ring comparisons, allowing one antialias channel level of rounding.

## Testing

- [x] 47 focused component tests.
- [x] Renderer typecheck (`pnpm tc:web`).
- [x] Fresh E2E build and both display-density rendering/behavior checks.
- [x] Four full-app performance scenarios and changed-code quality gate (including type-aware checks and React Doctor).
- [x] Automated tests added/updated.

The wider E2E TypeScript project has existing errors in unrelated specs; none were reported in the changed spinner benchmark or extracted typing files. Full-repository lint and tests were not run. All launched apps remained hidden and unfocused with `ORCA_BACKGROUND_LAUNCH=1`; no native-focus tests were run on the desktop.

## Review

- [x] Production change is small and focused; supporting code makes the performance claim reproducible.
- [x] ELI5, historical comparison, raw measurements, and limitations documented.
- [x] Visual equivalence checked; rejected prototypes excluded.
- [x] Cross-platform, SSH/remote, and folder-workspace impact considered. No execution or wire-format changes.
- [x] Agent skill upstream boundary is not applicable; no upstream skill implementation is copied.
