### PR TITLE
fix(ci): read the changed-path list past the first pipe buffer

### DIFF
--- a/config/scripts/pr-code-change-scope.mjs
+++ b/config/scripts/pr-code-change-scope.mjs
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs'
 import process from 'node:process'
 import { pathToFileURL } from 'node:url'
 
@@ -369,7 +368,14 @@ function matchesPrefix(file, prefixes) {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const files = readFileSync(0, 'utf8').split('\n').filter(Boolean)
+  // Why streamed, not readFileSync(0): a single read of fd 0 throws EAGAIN once the writer
+  // outgrows the 64 KB pipe buffer, which a stale PR base.sha reaches easily.
+  let input = ''
+  process.stdin.setEncoding('utf8')
+  for await (const chunk of process.stdin) {
+    input += chunk
+  }
+  const files = input.split(/\r?\n/).filter(Boolean)
   const classification = classifyPrJobs(files)
   for (const [name, value] of Object.entries(classification)) {
     process.stdout.write(`${name}=${value ? 'true' : 'false'}\n`)

--- a/config/scripts/pr-code-change-scope.test.mjs
+++ b/config/scripts/pr-code-change-scope.test.mjs
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -352,6 +352,54 @@ describe('per-job path classification', () => {
     expect(result.stdout).toContain('git_compatibility=false\n')
     expect(result.stdout).toContain('package=false\n')
     expect(result.stdout).toContain('test=true\n')
+  })
+
+  // A long-lived PR whose base.sha has gone stale diffs thousands of files, so the writer
+  // outruns one pipe buffer. A single fd-0 read then returns early, breaks the writer's pipe,
+  // and still exits 0 -- emitting no pairs at all, which silently skips every lane.
+  it('classifies a path that arrives after the first pipe buffer', async () => {
+    const filler = Array.from(
+      { length: 12_000 },
+      (_, index) => `docs/reference/generated-placeholder-${index}.md`
+    )
+    const input = `${[...filler, 'config/patches/xterm-upstream.json'].join('\n')}\n`
+    expect(input.length).toBeGreaterThan(64 * 1024)
+
+    const child = spawn(process.execPath, ['config/scripts/pr-code-change-scope.mjs'], {
+      cwd: projectDir,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let stdout = ''
+    let stderr = ''
+    let brokePipe = false
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => (stdout += chunk))
+    child.stderr.on('data', (chunk) => (stderr += chunk))
+    child.stdin.on('error', (error) => {
+      brokePipe ||= error.code === 'EPIPE'
+    })
+
+    const exitCode = await new Promise((resolvePromise) => {
+      child.on('close', resolvePromise)
+      let offset = 0
+      const step = () => {
+        if (offset >= input.length) {
+          child.stdin.end()
+          return
+        }
+        child.stdin.write(input.slice(offset, offset + 64 * 1024))
+        offset += 64 * 1024
+        setTimeout(step, 20)
+      }
+      step()
+    })
+
+    expect(stderr).not.toContain('EAGAIN')
+    expect(brokePipe).toBe(false)
+    expect(exitCode, stderr).toBe(0)
+    expect(stdout).toContain('should_run=true\n')
+    expect(stdout).toContain('xterm_patch_sync=true\n')
   })
 })
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

The PR Checks gate reads its list of changed files from stdin with one `readFileSync(0)`. When that list is bigger than a pipe buffer, the read returns early, the script exits **0 having printed nothing**, and every lane it gates gets silently skipped instead of failing. Stream stdin instead.

## Why now

PR #13178 hit this. GitHub gave it a `pull_request.base.sha` of `bb09dc17` — **1,592 commits behind current main**, because the PR was opened long ago and later refreshed onto main. The gate's merge-base diff therefore produced **13,294 files / 773,461 bytes** instead of that PR's actual 4 files, and blew past the 64 KB pipe buffer.

Result on #13178: `detect code-relevant changes` failed on all 3 attempts (never a flake), `verify` cascaded (`CODE_PATHS: failure`), and these 16 lanes were **skipped, not run**:

> typecheck, test, static analysis, xterm patch sync, package, package (windows), e2e, shell contracts, Git compatibility, cross-version wire compatibility, real IME, real WSL terminal, orcad browser provider, Codex index-heal contract, managed hooks on Node 18, prepare test native cache

The remaining green checks came from unrelated workflows, so the PR read as "mostly green" while none of its own validation had executed. That silent-skip is the part worth fixing: the failure mode is invisible rather than loud.

## What changed

`config/scripts/pr-code-change-scope.mjs` now streams `process.stdin` — the exact pattern its sibling `config/scripts/pr-e2e-source-routing.mjs` already uses for the same list in the same workflow step. No classification logic changed; no workflow YAML changed.

## Evidence

Threshold bisected on the real failing input — a clean pipe-buffer boundary:

| stdin | before |
| --- | --- |
| 58,822 bytes | OK |
| 70,116 bytes | `EAGAIN: resource temporarily unavailable, read` |
| 773,461 bytes (#13178's actual gate input) | `EAGAIN` |

After the fix, the 773 KB input classifies correctly. The real 4-file #13178 diff and the docs-only short-circuit (`README.md` → `should_run=false`) classify byte-identically to before.

## Testing

- [x] New regression test `classifies a path that arrives after the first pipe buffer`: feeds >64 KB through a real pipe with a slow writer, with the only code-relevant path placed **last**. Verified red against the old script (`expected 'node:fs:441...' not to contain 'EAGAIN'`) and green after.
- [x] Test is portable — uses `spawn`, not a shell pipeline, so it runs on the Windows lane too. Note `spawnSync({input})` does **not** reproduce the bug (it hands the child a blocking fd 0); the slow-writer pipe does.
- [x] `config/scripts/pr-code-change-scope.test.mjs` 31/31; `pr-e2e-source-routing`, `pr-workflow-lint-parity`, `pr-e2e-gate-contract`, `pr-workflow-parallelism` pass.
- [x] oxlint, oxfmt, changed-code quality gate clean.

## Follow-up not in this PR

This makes the gate robust to a large list; it does not make the list *correct*. A stale `base.sha` still over-triggers lanes (safe direction — it runs more, not fewer). Narrowing the diff to the true merge base against the base branch tip is a separate change.