### PR TITLE
fix(codex): bound provider records with explicit capacity failure

### DIFF
--- a/src/main/codex/codex-app-server-record-reader.test.ts
+++ b/src/main/codex/codex-app-server-record-reader.test.ts
@@ -1,0 +1,65 @@
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CODEX_APP_SERVER_MAX_RECORD_BYTES,
+  createCodexAppServerRecordReader
+} from './codex-app-server-record-reader'
+
+function setup() {
+  const stdout = new PassThrough()
+  const onRecord = vi.fn()
+  const onRejected = vi.fn()
+  const onFatal = vi.fn()
+  const reader = createCodexAppServerRecordReader({ stdout, onRecord, onRejected, onFatal })
+  return { stdout, reader, onRecord, onRejected, onFatal }
+}
+
+describe('Codex record admission', () => {
+  it('fails once before an unterminated record can retain unbounded input', () => {
+    const { stdout, reader, onRecord, onRejected, onFatal } = setup()
+    const chunk = 'x'.repeat(1024 * 1024)
+    for (let index = 0; index <= CODEX_APP_SERVER_MAX_RECORD_BYTES / chunk.length; index++) {
+      stdout.emit('data', chunk)
+    }
+    expect(onFatal).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        name: 'NdjsonLineTooLongError',
+        maxLineBytes: CODEX_APP_SERVER_MAX_RECORD_BYTES
+      })
+    )
+    expect(stdout.isPaused()).toBe(true)
+    reader.resume()
+    stdout.emit('data', '\n{"id":1}\n')
+    expect(onRecord).not.toHaveBeenCalled()
+    expect(onRejected).not.toHaveBeenCalled()
+    expect(onFatal).toHaveBeenCalledTimes(1)
+    expect(stdout.isPaused()).toBe(true)
+    stdout.destroy()
+  })
+
+  it('delivers a multibyte record at the exact byte limit without clipping', () => {
+    const { stdout, onRecord, onFatal } = setup()
+    const body = 'é'.repeat((CODEX_APP_SERVER_MAX_RECORD_BYTES - 2) / 2)
+    stdout.emit('data', '"')
+    for (let offset = 0; offset < body.length; offset += 65536) {
+      stdout.emit('data', body.slice(offset, offset + 65536))
+    }
+    stdout.emit('data', '"\n')
+    expect(onRecord).toHaveBeenCalledExactlyOnceWith(body, `"${body}"`)
+    expect(onFatal).not.toHaveBeenCalled()
+    stdout.destroy()
+  })
+
+  it('fails safely when resumed queued input exceeds the record cap', () => {
+    const { stdout, reader, onFatal, onRecord } = setup()
+    onRecord.mockImplementationOnce(() => reader.pause())
+    const oversized = 'x'.repeat(CODEX_APP_SERVER_MAX_RECORD_BYTES + 1)
+    stdout.emit('data', `{}\n${oversized}\n`)
+    expect(onFatal).not.toHaveBeenCalled()
+    reader.resume()
+    expect(onFatal).toHaveBeenCalledTimes(1)
+    expect(onRecord).toHaveBeenCalledTimes(1)
+    expect(stdout.isPaused()).toBe(true)
+    stdout.destroy()
+  })
+})

--- a/src/main/codex/codex-app-server-record-reader.ts
+++ b/src/main/codex/codex-app-server-record-reader.ts
@@ -1,8 +1,11 @@
 import type { Readable } from 'node:stream'
 import {
   createIncrementalNdjsonFramer,
+  NdjsonLineTooLongError,
   type NdjsonRejectedRecord
 } from '../../shared/main-process-ndjson-framer'
+
+export const CODEX_APP_SERVER_MAX_RECORD_BYTES = 32 * 1024 * 1024
 
 type RecordReaderStream = Pick<Readable, 'on' | 'pause' | 'resume' | 'setEncoding'>
 
@@ -18,17 +21,40 @@ export function createCodexAppServerRecordReader(input: {
   onFatal: (error: Error) => void
 }): CodexAppServerRecordReader {
   let paused = false
-  const framer = createIncrementalNdjsonFramer(input.onRecord, input.onRejected, {
-    // The provider owns this local stdio stream, so valid agent payloads keep full fidelity.
-    maxLineBytes: Number.POSITIVE_INFINITY,
-    shouldPause: () => paused
-  })
+  let failed = false
+  const fail = (error: unknown): void => {
+    if (failed) {
+      return
+    }
+    failed = true
+    paused = true
+    input.stdout.pause()
+    framer.reset()
+    input.onFatal(error instanceof Error ? error : new Error(String(error)))
+  }
+  const framer = createIncrementalNdjsonFramer(
+    input.onRecord,
+    (rejected) => {
+      // A missing provider record invalidates the connection; never continue with clipped history.
+      if (rejected.kind === 'line-too-long') {
+        throw new NdjsonLineTooLongError(rejected.observedBytes, rejected.maxLineBytes)
+      }
+      input.onRejected(rejected)
+    },
+    {
+      maxLineBytes: CODEX_APP_SERVER_MAX_RECORD_BYTES,
+      shouldPause: () => paused
+    }
+  )
 
   input.stdout.setEncoding('utf8').on('data', (chunk: string) => {
+    if (failed) {
+      return
+    }
     try {
       framer.feed(chunk)
     } catch (error) {
-      input.onFatal(error instanceof Error ? error : new Error(String(error)))
+      fail(error)
     }
   })
 
@@ -38,11 +64,16 @@ export function createCodexAppServerRecordReader(input: {
       input.stdout.pause()
     },
     resume: () => {
-      if (!paused) {
+      if (failed || !paused) {
         return
       }
       paused = false
-      framer.resume()
+      try {
+        framer.resume()
+      } catch (error) {
+        fail(error)
+        return
+      }
       if (!paused) {
         input.stdout.resume()
       }

--- a/src/main/codex/codex-app-server-session.ts
+++ b/src/main/codex/codex-app-server-session.ts
@@ -166,7 +166,10 @@ export async function runCodexAppServerSession<T>(
       }
     },
     onRejected: () => undefined,
-    onFatal: failPending
+    onFatal: (error) => {
+      spawnError = error
+      failPending(error)
+    }
   })
 
   function failPending(error: Error): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |

<!-- /orca-pr-loc -->

## ELI5

A Codex response without a newline can no longer grow Orca's record buffer indefinitely. Records up to 32 MiB arrive intact; larger records fail the connection explicitly instead of silently losing provider output.

## What Changed

Use the existing bounded NDJSON framer with a 32 MiB record limit. Capacity failures stop and clear the reader exactly once, including failures encountered when resuming paused input. The short-lived app-server session remembers fatal errors so later requests fail immediately.

## Why

The former infinite limit also disabled effective paused-queue bounds. An oversized record now uses the existing fatal connection/recovery path, preserving the full-fidelity contract for admitted records. The cap exceeds the existing regression for responses larger than 16 MiB. This is explicit capacity refusal, not spooling: a provider response above the limit must be reduced before retrying.

## Linked Issue

[STA-6926](https://linear.app/stably/issue/STA-6926). No claim about historical Vitest crashes in STA-6765 or renderer allocation STA-3567.

## Visual Proof

N/A — host stream admission only; no rendered UI change.

## Testing

- `ORCA_BACKGROUND_LAUNCH=1 pnpm exec vitest run --config config/vitest.config.ts src/main/codex/codex-app-server-record-reader.test.ts src/main/codex/codex-app-server-connection.test.ts src/main/codex/codex-app-server-session.test.ts --maxWorkers=1`: 33 tests passed.
- Exact-boundary multibyte fidelity, newline-free overflow, one fatal notification, no post-failure resume, and overflow during paused-queue drain.
- Node TypeScript check and focused oxlint passed on macOS. No app launch, real provider session, machine configuration change, or rendered validation. Local, WSL, and SSH use the same execution-host reader; no RPC fields or opcodes changed.

## Review

Draft; please review the explicit 32 MiB admission policy and recovery behavior. Merging is not authorized.

## Agent skill upstream boundary

- [x] Not applicable.
