### PR TITLE
perf(native-chat): avoid full journal snapshots for status updates

### DIFF
--- a/src/main/native-chat/agent-session-journal/journal-reducer.ts
+++ b/src/main/native-chat/agent-session-journal/journal-reducer.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../shared/agent-session-journal-item-key'
 import { structuredAgentSessionPayloadFingerprint } from '../../../shared/structured-agent-session-mutation'
 import type { JournalRow } from './journal-row-schema'
+import { JournalStatusProjection } from './journal-status-projection'
 
 export const MAX_JOURNAL_APPLIED_SETTLEMENT_IDS = 4_096
 
@@ -30,6 +31,7 @@ export type JournalReducerState = {
   /** Lowest sequence still individually replayable; rows below it were compacted. */
   oldestSequence: number
   highestFence: number
+  statusProjection: JournalStatusProjection
   items: Map<string, AgentJournalRenderItem>
   /** Revision of a removed item, so a late lower revision cannot resurrect it. */
   tombstones: Map<string, number>
@@ -49,6 +51,7 @@ export function createJournalReducerState(sessionId: string, epoch: string): Jou
     lastActivityAt: 0,
     oldestSequence: 1,
     highestFence: 0,
+    statusProjection: new JournalStatusProjection(),
     items: new Map(),
     tombstones: new Map(),
     submissions: new Map(),
@@ -185,6 +188,7 @@ function upsertItem(
   }
   if (!existing) {
     state.items.set(itemId, next)
+    state.statusProjection.changed(next, itemId)
     state.tombstones.delete(itemId)
     return
   }
@@ -204,6 +208,7 @@ function upsertItem(
     sequence: existing.sequence,
     observedAt: existing.observedAt
   })
+  state.statusProjection.changed(state.items.get(itemId), itemId)
   state.tombstones.delete(itemId)
 }
 
@@ -218,6 +223,7 @@ function removeItem(state: JournalReducerState, itemId: string, revision: number
   }
   state.tombstones.set(itemId, revision)
   state.items.delete(itemId)
+  state.statusProjection.changed(undefined, itemId)
 }
 
 function applySubmission(

--- a/src/main/native-chat/agent-session-journal/journal-status-projection.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-status-projection.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentJournalRenderItem } from '../../../shared/agent-session-journal-types'
+import { projectStructuredAgentSessionStatusSummary } from '../../../shared/structured-agent-session-projection'
+import { JournalStatusProjection } from './journal-status-projection'
+
+type Item = AgentJournalRenderItem
+const message = (text: string, role: 'user' | 'assistant' = 'assistant'): Item['body'] => ({
+  kind: 'message',
+  role,
+  blocks: [{ type: 'text', text }]
+})
+
+function setup() {
+  const items = new Map<string, Item>()
+  const projection = new JournalStatusProjection()
+  const set = (id: string, sequence: number, body: Item['body']) => {
+    const item = { itemId: id, sequence, revision: 1, observedAt: sequence, body }
+    items.set(id, item)
+    projection.changed(item, id)
+  }
+  const check = () =>
+    expect(projection.read(items)).toEqual(
+      projectStructuredAgentSessionStatusSummary(
+        [...items.values()].sort((a, b) => a.sequence - b.sequence)
+      )
+    )
+  return { items, projection, set, check }
+}
+
+describe('journal status projection', () => {
+  it('matches full replay through revisions, tombstones, ties, and late historical updates', () => {
+    const { items, projection, set, check } = setup()
+    const bodies: Item['body'][] = [
+      message('prompt', 'user'),
+      message('reply'),
+      message(''),
+      {
+        kind: 'approval',
+        title: 'Allow?',
+        detail: null,
+        options: [],
+        resolution: { state: 'pending' }
+      },
+      { kind: 'question', question: 'Which?', options: [], resolution: { state: 'pending' } },
+      { kind: 'status', text: '', turnLifecycle: { state: 'running', turnId: 'turn' } },
+      { kind: 'status', text: '', turnLifecycle: { state: 'completed', turnId: 'turn' } },
+      { kind: 'tool-call', name: 'Read', input: { path: '/file' }, state: 'running' },
+      { kind: 'tool-call', name: 'Read', input: { path: '/file' }, state: 'completed' }
+    ]
+    let seed = 42
+    const random = () => {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+      return seed
+    }
+    for (let i = 0; i < 3000; i++) {
+      const id = String(random() % 50)
+      if (random() % 5 === 0) {
+        items.delete(id)
+        projection.changed(undefined, id)
+      } else {
+        set(id, items.get(id)?.sequence ?? random() % 100, bodies[random() % bodies.length])
+      }
+      check()
+    }
+  })
+
+  it('does not traverse retained history during streaming revisions or repeated reads', () => {
+    const { items, projection, set, check } = setup()
+    for (let index = 0; index < 10_000; index++) {
+      set(String(index), index, message('historical'))
+    }
+    set('prompt', 10_000, message('current', 'user'))
+    set('reply', 10_001, message('current reply'))
+    check()
+    const values = vi.spyOn(items, 'values')
+    for (let index = 0; index < 1000; index++) {
+      set('reply', 10_001, message(`reply ${index}`))
+      expect(projection.read(items).lastAssistantMessage).toBe(`reply ${index}`)
+      projection.read(items)
+    }
+    expect(values).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/native-chat/agent-session-journal/journal-status-projection.test.ts
+++ b/src/main/native-chat/agent-session-journal/journal-status-projection.test.ts
@@ -39,9 +39,14 @@ describe('journal status projection', () => {
         title: 'Allow?',
         detail: null,
         options: [],
-        resolution: { state: 'pending' }
+        resolution: { state: 'pending', selectedOptionId: null, resolvedBy: null, resolvedAt: null }
       },
-      { kind: 'question', question: 'Which?', options: [], resolution: { state: 'pending' } },
+      {
+        kind: 'question',
+        question: 'Which?',
+        options: [],
+        resolution: { state: 'pending', selectedOptionId: null, resolvedBy: null, resolvedAt: null }
+      },
       { kind: 'status', text: '', turnLifecycle: { state: 'running', turnId: 'turn' } },
       { kind: 'status', text: '', turnLifecycle: { state: 'completed', turnId: 'turn' } },
       { kind: 'tool-call', name: 'Read', input: { path: '/file' }, state: 'running' },

--- a/src/main/native-chat/agent-session-journal/journal-status-projection.ts
+++ b/src/main/native-chat/agent-session-journal/journal-status-projection.ts
@@ -1,0 +1,83 @@
+import type { AgentJournalRenderItem } from '../../../shared/agent-session-journal-types'
+import { projectStructuredAgentSessionStatusSummary } from '../../../shared/structured-agent-session-projection'
+
+type Item = AgentJournalRenderItem
+const selectors = [
+  (item: Item) => item.body.kind === 'message' && item.body.role === 'user',
+  (item: Item) => item.body.kind === 'message' && item.body.role === 'assistant',
+  (item: Item) =>
+    item.body.kind === 'message' &&
+    item.body.role === 'assistant' &&
+    item.body.blocks.some((block) => block.type === 'text' && block.text.trim().length > 0),
+  (item: Item) => item.body.kind === 'status' && !!item.body.turnLifecycle,
+  (item: Item) => item.body.kind === 'tool-call' && item.body.state === 'running',
+  (item: Item) =>
+    (item.body.kind === 'approval' || item.body.kind === 'question') &&
+    item.body.resolution.state === 'pending'
+]
+
+/** Retains only the witnesses needed by the shared status projection. */
+export class JournalStatusProjection {
+  private candidates: (Item | undefined)[] = selectors.map(() => undefined)
+  private dirty = true
+  private cached: ReturnType<typeof projectStructuredAgentSessionStatusSummary> | undefined
+
+  changed(item: Item | undefined, itemId: string): void {
+    this.cached = undefined
+    if (this.dirty) {
+      return
+    }
+    for (let index = 0; index < selectors.length; index++) {
+      const previous = this.candidates[index]
+      if (previous?.itemId === itemId) {
+        if (!item || !selectors[index](item)) {
+          this.dirty = true
+          return
+        }
+        this.candidates[index] = item
+      } else if (item && selectors[index](item)) {
+        if (previous && item.sequence === previous.sequence) {
+          // Batch members share a sequence; recover their stable map order on the next read.
+          this.dirty = true
+          return
+        }
+        if (!previous || item.sequence > previous.sequence) {
+          this.candidates[index] = item
+        }
+      }
+    }
+  }
+
+  read(
+    items: ReadonlyMap<string, Item>
+  ): ReturnType<typeof projectStructuredAgentSessionStatusSummary> {
+    if (this.cached) {
+      return this.cached
+    }
+    if (this.dirty) {
+      this.candidates = selectors.map(() => undefined)
+      for (const item of items.values()) {
+        for (let index = 0; index < selectors.length; index++) {
+          const previous = this.candidates[index]
+          if (selectors[index](item) && (!previous || item.sequence >= previous.sequence)) {
+            this.candidates[index] = item
+          }
+        }
+      }
+      this.dirty = false
+    }
+    let selected = [...new Set(this.candidates.filter((item): item is Item => !!item))]
+    if (new Set(selected.map((item) => item.sequence)).size !== selected.length) {
+      const ids = new Set(selected.map((item) => item.itemId))
+      selected = []
+      for (const item of items.values()) {
+        if (ids.has(item.itemId)) {
+          selected.push(item)
+        }
+      }
+    }
+    selected.sort((a, b) => a.sequence - b.sequence)
+    this.cached = projectStructuredAgentSessionStatusSummary(selected)
+    return this.cached
+  }
+}

--- a/src/main/native-chat/agent-session-journal/journal-store.ts
+++ b/src/main/native-chat/agent-session-journal/journal-store.ts
@@ -162,6 +162,8 @@ export class AgentSessionJournal {
 
   snapshot = (): AgentJournalSnapshot => renderJournalState(this.state)
 
+  statusSummary = () => this.state.statusProjection.read(this.state.items)
+
   /** Includes revisions and completion tombstones, whose timestamps disappear from render items. */
   lastActivityAt = (): number => this.state.lastActivityAt
 

--- a/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
+++ b/src/main/native-chat/agent-session-wire/structured-agent-session-status-feed.ts
@@ -116,7 +116,9 @@ export class StructuredAgentSessionStatusFeed {
     journal: AgentSessionJournal
   ): AgentSessionStatusSummary {
     // An unreadable journal projects as "no turn": the chat itself shows the reset.
-    const items = journal.isReadOnly ? [] : journal.snapshot().items
+    const projection = journal.isReadOnly
+      ? projectStructuredAgentSessionStatusSummary([])
+      : journal.statusSummary()
     const record = this.deps.getRecord(sessionId)
     const providerSession = structuredAgentSessionProviderSessionMetadata(record)
     // The journal has no model: the record's acknowledged options are where an owner
@@ -126,7 +128,7 @@ export class StructuredAgentSessionStatusFeed {
       sessionId,
       workspaceId: session.params.location.workspaceId,
       agent: session.params.provider,
-      ...projectStructuredAgentSessionStatusSummary(items),
+      ...projection,
       ...(record?.rewind?.phase === 'prepared' || record?.rewind?.phase === 'provider-succeeded'
         ? { rewindBlockedReason: 'outcome-unknown' as const }
         : {}),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 |

<!-- /orca-pr-loc -->

## ELI5

Streaming a chat reply no longer rebuilds the whole journal just to update its sidebar status.

## What Changed

The journal reducer maintains at most six status witnesses and caches their shared status projection. Revisions update witnesses directly; removal, classification changes, and ambiguous batch ordering rebuild them from the reducer. Status publication calls this projection without constructing a transcript/submission snapshot.

## Why

The old feed called `journal.snapshot()` before deduplication on every publication, sorting and copying retained history. The new path reuses the existing shared status semantics while ordinary streaming costs stay independent of transcript item count. Fallback rebuilds scan history after witness removal or same-sequence ambiguity; this does not claim every mutation is constant time.

## Linked Issue

[STA-6933](https://linear.app/stably/issue/STA-6933). Status catalog retention (STA-6838 / STA-6929), payload durability, and disk quota are separate changes.

## Visual Proof

N/A — equivalent host status projection; no layout or interaction change.

## Testing

- 19 journal/status regression files, 204 tests passed with `ORCA_BACKGROUND_LAUNCH=1`, Vitest, and `--maxWorkers=1`.
- 3,000 deterministic mutations compare the bounded projection against full replay, including revision, deletion, and sequence ties.
- 10,000 retained items plus 1,000 streaming revisions assert zero history traversals after initialization.
- Node TypeScript and focused oxlint checks passed on macOS. No app build/launch, real session changes, rendered UI checks, or live SSH/WSL validation.
- No wire fields/opcodes or ownership semantics changed; the execution host continues to compute the same status fields for existing clients.

## Review

Draft; review candidate completeness and invalidation against the shared projection. Merging is not authorized.

## Agent skill upstream boundary

- [x] Not applicable.
