### PR TITLE
fix(session): guard scoped resumes and host partition ownership

### DIFF
--- a/notes/linear-fix-report.md
+++ b/notes/linear-fix-report.md
@@ -4,7 +4,7 @@ Base: `588240043e8` (newer than the triage base). Refreshed all 19 named Linear 
 
 ## Delivered
 
-Three focused commits in one draft PR (URL recorded below):
+Draft PR: https://github.com/stablyai/orca/pull/19414 (base `main`). Three focused repair commits:
 
 - `e486911e2be`: sleeping resume checks live status, pending startup, and automatic claims across workspaces when provider identity, exact transcript path, execution host, and paired transport environment agree. Reuses the existing provider equality and route resolver. Folder owners are included; different account paths and hosts are isolated. Consecutive sweeps share the existing queued claim. This is renderer suppression, **not atomic host claiming**; legacy ID-only records retain existing behavior.
 - `f93fb796898`: offline/error/conflicting direct-SSH syncs remain `unverifiable`, including after a prior hydration. Repeated sweeps preserve the record; successful hydration/retry permits one launch. No inventory failure proves process exit.

--- a/notes/linear-fix-report.md
+++ b/notes/linear-fix-report.md
@@ -1,0 +1,52 @@
+# Session identity repair report
+
+Base: `588240043e8` (newer than the triage base). Refreshed all 19 named Linear issues with full comments and attachments through `orca linear issue ... --full --json`; no Linear writes were made. Searched open PRs by mechanism and issue IDs, and inspected #19405 and merged #17909.
+
+## Delivered
+
+Three focused commits in one draft PR (URL recorded below):
+
+- `e486911e2be`: sleeping resume checks live status, pending startup, and automatic claims across workspaces when provider identity, exact transcript path, execution host, and paired transport environment agree. Reuses the existing provider equality and route resolver. Folder owners are included; different account paths and hosts are isolated. Consecutive sweeps share the existing queued claim. This is renderer suppression, **not atomic host claiming**; legacy ID-only records retain existing behavior.
+- `f93fb796898`: offline/error/conflicting direct-SSH syncs remain `unverifiable`, including after a prior hydration. Repeated sweeps preserve the record; successful hydration/retry permits one launch. No inventory failure proves process exit.
+- `4465097095c`: runtime partition access and hydration reuse the ambiguity-aware repository host resolver. An empty runtime partition no longer adopts a foreign same-ID workspace; conflicting repo owners block reads/writes and are skipped during hydration. Ambiguity throws before legacy callers can default null to local. Foreign records are preserved, including folder state.
+
+## Validation
+
+All test/typecheck commands used `ORCA_BACKGROUND_LAUNCH=1`.
+
+- Renderer regression suite: 7 files / 66 tests passed, including existing remote compatibility and replay suites. The subsequently extended cross-workspace file passed all 8 tests (one extra consecutive-sweep regression).
+- Runtime partition suite: 2 files / 14 tests passed, including close/retirement integration tests that now preserve unproven foreign state.
+- `pnpm tc:web` and `pnpm tc:node` passed; node rechecked after the final ambiguity fence.
+- Changed-file quality gate passed with zero native, type-aware, or React Doctor findings across 8 source files; formatting/commit hooks and `git diff --check` passed.
+- Existing SSH reattach discrimination tests: 2 files / 7 tests passed, supporting the STA-3375 source-seam disposition.
+- No rendered Electron/real SSH/WSL/Windows validation, host restart, account migration, or multi-client process-ownership experiment was performed. No user session was cleaned up or machine configuration changed.
+
+## Issue disposition
+
+No issue is claimed fully resolved by this draft. The broad one-writer closure criteria remain open.
+
+| Issue | Disposition and exact coverage |
+|---|---|
+| STA-3513 | Open: traced renderer `local-partition` versus runtime SSH host persistence; shared helper explicitly documents the divergence. Durable read-both migration is not implemented. Existing #12722 covers read-side adoption separately. |
+| STA-6807 | Open: required `executionHostId` at all unified-tab normalization boundaries remains unimplemented. |
+| STA-6535 | Partial: runtime controller no longer uses first/last repo row or foreign nonempty partitions. Ambiguous IDs fail closed; explicit per-operation host selection and renderer/runtime durable partition convergence remain. Merged #17909 supplied the shared resolver reused here. |
+| STA-6297 | Partial: renderer cross-worktree claims covered when exact transcript and host scope are known. ID-only records, absent projections, multiple clients, and atomic execution-host claims remain. Open #19405 supports incumbent writer placement but explicitly does not close this ticket. |
+| STA-3498 | Partial: failed SSH hydration no longer permits sweep resume. Stale record worktree ownership, all pane reattach paths, and atomic remote claiming remain. |
+| STA-3500 | Partial: initial hydration guard already exists in base; this draft closes its offline/error/conflict escape. Full remote reconnect and all wake replay paths are not demonstrated. |
+| STA-3375 | Already addressed at the cited source seam: existing restoreRequired discrimination and live-source regression tests distinguish it from expiry. This draft does not change reattach or establish all historical secondary triggers resolved. |
+| STA-3499 | Open: AI Vault Resume entrypoint remains unchanged; #19405 is supporting runtime placement work, not closure. |
+| STA-6719 | Partial support only: scoped sleeping sweep claims improve one activation branch. Paired OMP reselect and initial-terminal seeding symptom not reproduced or claimed fixed. |
+| STA-6741 | Open: unattended same-worktree headless launch trigger remains unestablished; renderer cross-worktree coverage does not prove its fix. |
+| STA-5907 | Open: Windows reboot/update duplication and title/PTy binding not reproduced. Existing #18223 covers default-tab ledger persistence separately. |
+| STA-6240 | Open: rapid AI Vault resume clicks are not tested or serialized by this change. Consecutive sleeping sweeps are a different covered path. |
+| STA-2856 | Open: existing session-tabs publisher runtime-ID fences are present, but stale CLI handle reconciliation across host restart is not changed or proven. |
+| STA-3110 | Existing open PR #17798 owns authoritative null-PTY ghost pruning; not duplicated or modified here. |
+| STA-2210 | Open: historical Windows/WSL ghost inventories and daemon memory retention are not addressed by these changes. |
+| STA-6224 | Partial ownership split: viewer ghost work exists in #17798; server CLI close repair belongs to worker 2. No closure claim from this draft. |
+| STA-6830 | Open: traced global event handling and visibility fences but did not establish a failing new-workspace snapshot path; no speculative subscription change. |
+| STA-6721 | Open: independent sidebar row/status join and missing-tab projection remain unmodified. |
+| STA-5904 | Existing open PR #17139 covers visible terminal identity; no incarnation-proof feature duplicated here. |
+
+## Limits and follow-up
+
+No new RPC fields, opcodes, or published snapshot shapes are introduced. Existing remote-compatibility tests cover the sleeping sweep, not a real mixed-version host/client matrix. Partition adoption by unique matching ID was intentional historical behavior; removing it can leave old relocated state inaccessible until a migration supplies host identity evidence, and that is deliberately safer than copying or retiring another host's state. SSH folder snapshot scope remains unchanged because the direct-SSH snapshot does not publish folder rows. A full execution-host account-scoped reservation and inventory-generation authority must be coordinated with #19405 and applied to all launch paths; these three safeguards do not substitute for it.

--- a/src/main/runtime/orca-runtime-terminal-retirement-host-partition.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-retirement-host-partition.test.ts
@@ -175,7 +175,7 @@ function syncSshSplit(runtime: OrcaRuntimeService, snapshot: RuntimeMobileSessio
 }
 
 describe('OrcaRuntimeService terminal retirement host partitioning (STA-3463)', () => {
-  it('routes a stale catalog owner to the unique persisted session owner', async () => {
+  it('does not treat a unique foreign partition as proof of catalog host rotation', async () => {
     const staleHostId: ExecutionHostId = 'runtime:stale-host'
     const persistedTab = {
       id: 'tab',
@@ -233,12 +233,11 @@ describe('OrcaRuntimeService terminal retirement host partitioning (STA-3463)', 
       leafId: 'leaf'
     })
 
-    await expect(
-      runtime.closeMobileSessionTab(`id:${SSH_WORKTREE_ID}`, 'tab')
-    ).resolves.toMatchObject({
-      closed: true
-    })
-    expect(sessions.get(LOCAL_EXECUTION_HOST_ID)?.tabsByWorktree[SSH_WORKTREE_ID]).toEqual([])
+    const localBefore = sessions.get(LOCAL_EXECUTION_HOST_ID)
+    await expect(runtime.closeMobileSessionTab(`id:${SSH_WORKTREE_ID}`, 'tab')).rejects.toThrow(
+      'tab_not_found'
+    )
+    expect(sessions.get(LOCAL_EXECUTION_HOST_ID)).toBe(localBefore)
     expect(sessions.get(staleHostId)?.tabsByWorktree[SSH_WORKTREE_ID]).toEqual([])
   })
 
@@ -322,7 +321,7 @@ describe('OrcaRuntimeService terminal retirement host partitioning (STA-3463)', 
     expect(Object.keys(local.sleepingAgentSessionsByPaneKey ?? {})).toEqual(['local-tab:leaf'])
   })
 
-  it('clears resume records from the partition that owned the tabs when the catalog owner rotated', async () => {
+  it('preserves foreign resume records when catalog host rotation is unproven', async () => {
     const staleHostId: ExecutionHostId = 'runtime:stale-host'
     const sessions = new Map<ExecutionHostId, WorkspaceSessionState>([
       [
@@ -359,14 +358,15 @@ describe('OrcaRuntimeService terminal retirement host partitioning (STA-3463)', 
     runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
     runtime.registerPty(SSH_PTY_LEFT, SSH_WORKTREE_ID, null, { tabId: 'tab', leafId: 'left' })
 
+    const localBefore = sessions.get(LOCAL_EXECUTION_HOST_ID)
     await expect(runtime.closeTerminalsForWorktree(`id:${SSH_WORKTREE_ID}`)).resolves.toMatchObject(
-      { closed: 1 }
+      { closed: 0, stopped: 0 }
     )
-    expect(sessions.get(LOCAL_EXECUTION_HOST_ID)?.tabsByWorktree[SSH_WORKTREE_ID]).toEqual([])
-    expect(sessions.get(LOCAL_EXECUTION_HOST_ID)?.terminalPtyIncarnationsByPaneKey).toEqual({})
+    expect(sessions.get(LOCAL_EXECUTION_HOST_ID)).toBe(localBefore)
+    expect(localBefore?.terminalPtyIncarnationsByPaneKey).toEqual({ 'tab:left': 'incarnation-1' })
   })
 
-  it('hydrates the persisted owner when a folder host is absent from the host index', () => {
+  it('does not hydrate local folder tabs into an absent runtime host partition', () => {
     const folderWorktreeId = 'folder:folder-1'
     const localSession = {
       ...getDefaultWorkspaceSession(),
@@ -405,7 +405,7 @@ describe('OrcaRuntimeService terminal retirement host partitioning (STA-3463)', 
 
     const targets = controller.getHydrationTargets(true)
 
-    expect(targets.get(folderWorktreeId)).toBe(localSession)
+    expect(targets.has(folderWorktreeId)).toBe(false)
   })
 
   it('waits for provider retirement on a direct worktree stop', async () => {

--- a/src/main/runtime/runtime-workspace-session-controller.test.ts
+++ b/src/main/runtime/runtime-workspace-session-controller.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../shared/constants'
+import type { ExecutionHostId } from '../../shared/execution-host'
+import type { RuntimeStore } from './runtime-store-contract'
+import { RuntimeWorkspaceSessionController } from './runtime-workspace-session-controller'
+
+function harness(hosts: ExecutionHostId[], folder = false) {
+  const worktreeId = folder ? 'folder:one' : 'repo::/project'
+  const foreign = {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: { [worktreeId]: [{ id: 'foreign', worktreeId }] }
+  }
+  const empty = getDefaultWorkspaceSession()
+  const setWorkspaceSession = vi.fn()
+  const store = {
+    getRepos: () =>
+      folder ? [] : hosts.map((executionHostId) => ({ id: 'repo', executionHostId })),
+    getFolderWorkspaces: () => (folder ? [{ id: 'one', executionHostId: hosts[0] }] : []),
+    getWorkspaceSessionHostIds: () => ['local', 'runtime:other', ...hosts],
+    getWorkspaceSession: (hostId: string) => (hostId === 'runtime:other' ? foreign : empty),
+    setWorkspaceSession
+  } as unknown as RuntimeStore
+  const controller = new RuntimeWorkspaceSessionController({
+    getStore: () => store,
+    resolveFolderConnectionId: () => null,
+    hasRuntimeOwnedPtyCandidate: () => true
+  })
+  return { controller, worktreeId, foreign, empty, setWorkspaceSession }
+}
+
+describe('workspace session partition authority', () => {
+  it.each([false, true])(
+    'does not adopt a foreign partition when the owner is empty (folder=%s)',
+    (folder) => {
+      const h = harness(['runtime:owner'], folder)
+      expect(h.controller.tryGetHostId(h.worktreeId)).toBe('runtime:owner')
+      expect(h.controller.get(h.worktreeId)).toBe(h.empty)
+      expect(h.controller.getHydrationTargets(true).has(h.worktreeId)).toBe(false)
+      h.controller.set(h.worktreeId, h.empty)
+      expect(h.setWorkspaceSession).toHaveBeenCalledWith(h.empty, 'runtime:owner')
+    }
+  )
+
+  it.each([
+    ['local', 'runtime:owner'],
+    ['ssh:first', 'ssh:second'],
+    ['runtime:first', 'runtime:second']
+  ] as ExecutionHostId[][])('refuses colliding repository owners %s and %s', (first, second) => {
+    const h = harness([first!, second!])
+    expect(() => h.controller.tryGetHostId(h.worktreeId)).toThrow(
+      'worktree_execution_host_unresolved'
+    )
+    expect(() => h.controller.get(h.worktreeId)).toThrow('worktree_execution_host_unresolved')
+    expect(h.controller.getHydrationTargets(true).size).toBe(0)
+    expect(() => h.controller.set(h.worktreeId, h.empty)).toThrow(
+      'worktree_execution_host_unresolved'
+    )
+    expect(h.setWorkspaceSession).not.toHaveBeenCalled()
+  })
+
+  it('accepts duplicate repository rows that agree on their host', () => {
+    const h = harness(['ssh:owner', 'ssh:owner'])
+    expect(h.controller.tryGetHostId(h.worktreeId)).toBe('ssh:owner')
+  })
+})

--- a/src/main/runtime/runtime-workspace-session-controller.ts
+++ b/src/main/runtime/runtime-workspace-session-controller.ts
@@ -8,7 +8,7 @@ import {
 import type { FolderWorkspace } from '../../shared/folder-workspace-types'
 import type { WorkspaceSessionState } from '../../shared/workspace-session-state-types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
-import { workspaceSessionPartitionHostId } from '../../shared/workspace-session-partition-owner'
+import { resolveWorktreeHostRouting } from './worktree-launch-host-repo'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import type { RuntimeStore } from './runtime-store-contract'
 
@@ -47,59 +47,34 @@ export class RuntimeWorkspaceSessionController {
       return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
     }
     const resolvedWorktreeId = scope?.type === 'worktree' ? scope.worktreeId : worktreeId
-    const repo = store?.getRepo?.(getRepoIdFromWorktreeId(resolvedWorktreeId))
-    // Why: SSH worktrees keep their own `ssh:<targetId>` partition here while the renderer writes
-    // them to 'local'; the shared owner map records that divergence (#12723).
-    return repo
-      ? workspaceSessionPartitionHostId(getRepoExecutionHostId(repo), 'host-partition')
-      : LOCAL_EXECUTION_HOST_ID
-  }
-
-  private resolveHostId(
-    worktreeId: string,
-    preferredHostId: ExecutionHostId,
-    persistedHostIds: readonly ExecutionHostId[],
-    getWorkspaceSession: (hostId: ExecutionHostId) => WorkspaceSessionState
-  ): ExecutionHostId {
-    const hasPersistedTabs = (hostId: ExecutionHostId): boolean =>
-      (getWorkspaceSession(hostId).tabsByWorktree[worktreeId]?.length ?? 0) > 0
-    // Why: only runtime environment ids rotate across relay restarts. An empty SSH or
-    // local partition is the truth, and `repoId::path` repeats across hosts, so a
-    // same-id workspace elsewhere must never be adopted as this one's owner.
-    if (
-      parseExecutionHostId(preferredHostId)?.kind !== 'runtime' ||
-      hasPersistedTabs(preferredHostId)
-    ) {
-      return preferredHostId
+    const repoId = getRepoIdFromWorktreeId(resolvedWorktreeId)
+    const repos = store.getRepos?.() ?? []
+    const routing = resolveWorktreeHostRouting(repos, { repoId })
+    if (routing.kind === 'ambiguous') {
+      return null
     }
-    const persistedOwners = persistedHostIds.filter(
-      (hostId) => hostId !== preferredHostId && hasPersistedTabs(hostId)
-    )
-    return persistedOwners.length === 1 ? persistedOwners[0]! : preferredHostId
+    return routing.kind === 'resolved' ? routing.hostId : LOCAL_EXECUTION_HOST_ID
   }
 
   tryGetHostId(worktreeId: string): ExecutionHostId | null {
     const store = this.deps.getStore()
-    if (!store) {
-      return null
+    // Partition contents cannot prove that two execution hosts are the same host.
+    const hostId = store ? this.getPreferredHostId(worktreeId, store) : null
+    // Existing callers default a missing partition to local; ambiguity must not take that path.
+    if (store && !hostId && parseWorkspaceKey(worktreeId)?.type !== 'folder') {
+      throw new Error('worktree_execution_host_unresolved')
     }
-    const preferredHostId = this.getPreferredHostId(worktreeId, store)
-    if (!preferredHostId) {
-      return null
-    }
-    const persistedHostIds = store?.getWorkspaceSessionHostIds?.()
-    if (!store.getWorkspaceSession || !persistedHostIds) {
-      return preferredHostId
-    }
-    return this.resolveHostId(worktreeId, preferredHostId, persistedHostIds, (hostId) =>
-      store.getWorkspaceSession!(hostId)
-    )
+    return hostId
   }
 
   getHostId(worktreeId: string): ExecutionHostId {
     const hostId = this.tryGetHostId(worktreeId)
     if (!hostId) {
-      throw new Error('folder_workspace_not_found')
+      throw new Error(
+        parseWorkspaceKey(worktreeId)?.type === 'folder'
+          ? 'folder_workspace_not_found'
+          : 'worktree_execution_host_unresolved'
+      )
     }
     return hostId
   }
@@ -139,23 +114,6 @@ export class RuntimeWorkspaceSessionController {
       return new Map()
     }
     const repos = store?.getRepos?.() ?? []
-    const repoHostIdByRepoId = new Map(
-      repos.map((repo) => [repo.id, getRepoExecutionHostId(repo)] as const)
-    )
-    const folderHostIdByWorkspaceId = new Map(
-      (store?.getFolderWorkspaces?.() ?? []).map((workspace) => {
-        const explicitHostId =
-          workspace.executionHostId != null
-            ? (parseExecutionHostId(workspace.executionHostId)?.id ?? null)
-            : null
-        const connectionId = explicitHostId ? null : this.deps.resolveFolderConnectionId(workspace)
-        return [
-          workspace.id,
-          explicitHostId ??
-            (connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID)
-        ] as const
-      })
-    )
     const hostIds = new Set<ExecutionHostId>(['local'])
     for (const repo of repos) {
       hostIds.add(getRepoExecutionHostId(repo))
@@ -175,20 +133,7 @@ export class RuntimeWorkspaceSessionController {
     }
     for (const [hostId, session] of sessionsByHostId) {
       for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
-        const scope = parseWorkspaceKey(worktreeId)
-        const catalogOwnerHostId =
-          scope?.type === 'folder'
-            ? (folderHostIdByWorkspaceId.get(scope.folderWorkspaceId) ?? null)
-            : (repoHostIdByRepoId.get(
-                getRepoIdFromWorktreeId(scope?.type === 'worktree' ? scope.worktreeId : worktreeId)
-              ) ?? LOCAL_EXECUTION_HOST_ID)
-        const ownerHostId = this.resolveHostId(
-          worktreeId,
-          catalogOwnerHostId ?? LOCAL_EXECUTION_HOST_ID,
-          [...sessionsByHostId.keys()],
-          (candidateHostId) =>
-            sessionsByHostId.get(candidateHostId) ?? store.getWorkspaceSession!(candidateHostId)
-        )
+        const ownerHostId = this.getPreferredHostId(worktreeId, store)
         if (
           ownerHostId === hostId &&
           (includeAllPersistedWorktrees ||

--- a/src/renderer/src/lib/resume-sleeping-agent-cross-workspace.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-cross-workspace.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initial = useAppStore.getState()
+afterEach(() => useAppStore.setState(initial, true))
+
+function seed(
+  claim: 'status' | 'startup' | 'automatic',
+  options: { foreignHost?: boolean; foreignAccount?: boolean; folder?: boolean } = {}
+) {
+  const worktreeId = 'repo::/one'
+  const otherId = options.folder ? 'folder:two' : 'repo::/two'
+  const record: SleepingAgentSessionRecord = {
+    paneKey: 'old:leaf',
+    tabId: 'old',
+    worktreeId,
+    agent: 'claude',
+    providerSession: {
+      key: 'session_id',
+      id: 'session',
+      transcriptPath: '/account-a/session.jsonl'
+    },
+    prompt: '',
+    state: 'working',
+    origin: 'quit',
+    capturedAt: 1,
+    updatedAt: 1
+  }
+  const providerSession = {
+    ...record.providerSession,
+    ...(options.foreignAccount ? { transcriptPath: '/account-b/session.jsonl' } : {})
+  }
+  const otherHost = options.foreignHost ? 'ssh:other' : 'local'
+  useAppStore.setState({
+    repos: [{ id: 'repo', executionHostId: 'local' }],
+    worktreesByRepo: {
+      repo: [
+        { id: worktreeId, repoId: 'repo', hostId: 'local', path: '/one' },
+        { id: otherId, repoId: 'repo', hostId: otherHost, path: '/two' }
+      ]
+    },
+    folderWorkspaces: options.folder
+      ? [{ id: 'two', projectGroupId: 'group', executionHostId: otherHost }]
+      : [],
+    projectGroups: options.folder ? [{ id: 'group', executionHostId: otherHost }] : [],
+    tabsByWorktree: { [otherId]: [{ id: 'owner', worktreeId: otherId, ptyId: 'live' }] },
+    sleepingAgentSessionsByPaneKey: { [record.paneKey]: record },
+    agentStatusByPaneKey:
+      claim === 'status'
+        ? {
+            'owner:leaf': {
+              paneKey: 'owner:leaf',
+              tabId: 'owner',
+              worktreeId: otherId,
+              agentType: 'claude',
+              providerSession,
+              state: 'working'
+            }
+          }
+        : {},
+    pendingStartupByTabId:
+      claim === 'startup'
+        ? { owner: { launchAgent: 'claude', resumeProviderSession: providerSession } }
+        : {},
+    automaticAgentResumeClaimsByTabId:
+      claim === 'automatic'
+        ? { owner: { worktreeId: otherId, launchAgent: 'claude', providerSession } }
+        : {}
+  } as never)
+  return { record, worktreeId }
+}
+
+describe('sleeping resume claims across workspaces', () => {
+  it.each(['status', 'startup', 'automatic'] as const)(
+    'honors a same-host same-transcript %s claim',
+    (claim) => {
+      const { record, worktreeId } = seed(claim)
+      expect(resumeSleepingAgentSessionsForWorktree(worktreeId)).toBe(0)
+      expect(useAppStore.getState().tabsByWorktree[worktreeId]).toBeUndefined()
+      expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBeUndefined()
+    }
+  )
+  it.each([{ foreignHost: true }, { foreignAccount: true }])(
+    'does not claim another host or account: %j',
+    (options) => {
+      const { worktreeId } = seed('status', options)
+      expect(resumeSleepingAgentSessionsForWorktree(worktreeId)).toBe(1)
+    }
+  )
+  it('coalesces consecutive worktree sweeps before a queued resume spawns', () => {
+    const { record, worktreeId } = seed('status')
+    const second = { ...record, paneKey: 'second:leaf', tabId: 'second', worktreeId: 'repo::/two' }
+    useAppStore.setState({
+      tabsByWorktree: {},
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record, [second.paneKey]: second }
+    })
+    expect(resumeSleepingAgentSessionsForWorktree(worktreeId)).toBe(1)
+    expect(resumeSleepingAgentSessionsForWorktree(second.worktreeId)).toBe(0)
+    expect(Object.values(useAppStore.getState().tabsByWorktree).flat()).toHaveLength(1)
+  })
+
+  it('honors a folder workspace owner', () => {
+    const { worktreeId } = seed('status', { folder: true })
+    expect(resumeSleepingAgentSessionsForWorktree(worktreeId)).toBe(0)
+  })
+  it('does not infer an account match from a legacy ID-only record', () => {
+    const { record, worktreeId } = seed('status')
+    useAppStore.setState({
+      sleepingAgentSessionsByPaneKey: {
+        [record.paneKey]: { ...record, providerSession: { key: 'session_id', id: 'session' } }
+      }
+    })
+    expect(resumeSleepingAgentSessionsForWorktree(worktreeId)).toBe(1)
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session-direct-ssh-hydration-gap.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-direct-ssh-hydration-gap.test.ts
@@ -104,6 +104,25 @@ describe('sleeping-agent resume across the direct-SSH hydration gap', () => {
     expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
   })
 
+  it.each(['offline', 'error', 'conflict'] as const)(
+    'preserves the record through %s and resumes once after a successful retry',
+    (phase) => {
+      const record = seedColdDirectSshStart()
+      useAppStore.getState().setRemoteWorkspaceSyncStatus(TARGET_ID, { phase, direction: 'pull' })
+      for (let attempt = 0; attempt < 3; attempt++) {
+        expect(resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)).toBe(0)
+      }
+      expect(resumedTabCount(WORKTREE_ID)).toBe(0)
+      expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+
+      useAppStore.getState().markRemoteWorkspaceHydrated(TARGET_ID)
+      useAppStore.getState().setRemoteWorkspaceSyncStatus(TARGET_ID, { phase: 'synced' })
+      expect(resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)).toBe(1)
+      expect(resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)).toBe(0)
+      expect(resumedTabCount(WORKTREE_ID)).toBe(1)
+    }
+  )
+
   it('wakes the same session once the host answers and holds no pane for it', () => {
     const record = seedColdDirectSshStart()
     resumeSleepingAgentSessionsForWorktree(WORKTREE_ID)

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -1,4 +1,5 @@
 import { useAppStore } from '@/store'
+import { resolveWorktreeOperationRouteResult } from './worktree-operation-route'
 import {
   agentProviderSessionsEqual,
   type SleepingAgentSessionRecord
@@ -88,17 +89,47 @@ function activeOrQueuedResumeClaimsProviderSession(
   state: ReturnType<typeof useAppStore.getState>,
   samePaneOwnsRecovery: boolean
 ): boolean {
-  const worktreeTabIds = new Set(
-    (state.tabsByWorktree[record.worktreeId] ?? []).map((tab) => tab.id)
+  const tabWorktrees = new Map(
+    Object.entries(state.tabsByWorktree).flatMap(([worktreeId, tabs]) =>
+      tabs.map((tab) => [tab.id, worktreeId] as const)
+    )
   )
+  const recordRoute = resolveWorktreeOperationRouteResult(state, record.worktreeId)
+  const matchesScope = (
+    tabId: string,
+    providerSession: SleepingAgentSessionRecord['providerSession'] | undefined
+  ): boolean => {
+    const worktreeId = tabWorktrees.get(tabId)
+    if (!worktreeId) {
+      return false
+    }
+    if (worktreeId === record.worktreeId) {
+      return true
+    }
+    // Across workspaces, the exact transcript supplies the account namespace missing from the ID.
+    if (
+      !record.providerSession.transcriptPath ||
+      providerSession?.transcriptPath !== record.providerSession.transcriptPath
+    ) {
+      return false
+    }
+    const route = resolveWorktreeOperationRouteResult(state, worktreeId)
+    return (
+      recordRoute.kind === 'resolved' &&
+      route.kind === 'resolved' &&
+      recordRoute.route.executionHostId !== null &&
+      recordRoute.route.executionHostId === route.route.executionHostId &&
+      recordRoute.route.runtimeEnvironmentId === route.route.runtimeEnvironmentId
+    )
+  }
   for (const entry of Object.values(state.agentStatusByPaneKey)) {
     // Why: only an owned pane needs its record; hidden/live panes still dedupe by status.
     if (samePaneOwnsRecovery && entry.paneKey === record.paneKey) {
       continue
     }
     if (
-      worktreeTabIds.has(getAgentStatusTabId(entry) ?? '') &&
-      entry.worktreeId === record.worktreeId &&
+      matchesScope(getAgentStatusTabId(entry) ?? '', entry.providerSession) &&
+      entry.worktreeId === tabWorktrees.get(getAgentStatusTabId(entry) ?? '') &&
       entry.agentType === record.agent &&
       entry.state !== 'done' &&
       agentProviderSessionsEqual(record.agent, entry.providerSession, record.providerSession)
@@ -109,7 +140,7 @@ function activeOrQueuedResumeClaimsProviderSession(
 
   for (const [tabId, startup] of Object.entries(state.pendingStartupByTabId)) {
     if (
-      worktreeTabIds.has(tabId) &&
+      matchesScope(tabId, startup.resumeProviderSession) &&
       startup.launchAgent === record.agent &&
       agentProviderSessionsEqual(
         record.agent,
@@ -123,8 +154,8 @@ function activeOrQueuedResumeClaimsProviderSession(
 
   for (const [tabId, claim] of Object.entries(state.automaticAgentResumeClaimsByTabId)) {
     if (
-      worktreeTabIds.has(tabId) &&
-      claim.worktreeId === record.worktreeId &&
+      matchesScope(tabId, claim.providerSession) &&
+      claim.worktreeId === tabWorktrees.get(tabId) &&
       claim.launchAgent === record.agent &&
       agentProviderSessionsEqual(record.agent, claim.providerSession, record.providerSession)
     ) {

--- a/src/renderer/src/lib/workspace-terminal-host-authority.test.ts
+++ b/src/renderer/src/lib/workspace-terminal-host-authority.test.ts
@@ -104,20 +104,17 @@ describe('workspace terminal seeding authority', () => {
   })
 
   it.each(['offline', 'error'] as const)(
-    'falls back to none when a sync terminates in %s without ever hydrating',
+    'keeps a sync that terminates in %s unverifiable',
     (phase) => {
-      // The regression this guards: remoteWorkspaceHydratedTargetIds is add-only in practice
-      // (clearRemoteWorkspaceHydrated has no production caller), so without a floor one failed sync
-      // leaves every git worktree on this target terminal-less and its sleeping agents unresumable
-      // for the rest of the app session — strictly worse than the pre-gate behaviour, and escapable
-      // only by creating a tab by hand.
       const store = createTestStore()
       seedDirectSsh(store)
       store.getState().setRemoteWorkspaceSyncStatus(TARGET_ID, { phase, direction: 'pull' })
 
-      expect(resolveWorkspaceTerminalHostAuthority(store.getState(), SSH_WORKTREE_ID)).toBe('none')
-      expect(ensureWorktreeHasInitialTerminal(store.getState(), SSH_WORKTREE_ID)).toBeTruthy()
-      expect(terminalTabCount(store, SSH_WORKTREE_ID)).toBe(1)
+      expect(resolveWorkspaceTerminalHostAuthority(store.getState(), SSH_WORKTREE_ID)).toBe(
+        'unverifiable'
+      )
+      expect(ensureWorktreeHasInitialTerminal(store.getState(), SSH_WORKTREE_ID)).toBeNull()
+      expect(terminalTabCount(store, SSH_WORKTREE_ID)).toBe(0)
     }
   )
 
@@ -136,15 +133,15 @@ describe('workspace terminal seeding authority', () => {
     expect(ensureWorktreeHasInitialTerminal(store.getState(), SSH_WORKTREE_ID)).toBeNull()
   })
 
-  it('keeps a hydrated target on none even if a later sync errors', () => {
-    // Once the host has answered, a subsequent transport error is not evidence it holds nothing new
-    // — but it is also not a reason to start refusing. The hydrated branch wins.
+  it('revokes automatic launch authority when a later sync errors', () => {
     const store = createTestStore()
     seedDirectSsh(store)
     store.getState().markRemoteWorkspaceHydrated(TARGET_ID)
     store.getState().setRemoteWorkspaceSyncStatus(TARGET_ID, { phase: 'error', direction: 'pull' })
 
-    expect(resolveWorkspaceTerminalHostAuthority(store.getState(), SSH_WORKTREE_ID)).toBe('none')
+    expect(resolveWorkspaceTerminalHostAuthority(store.getState(), SSH_WORKTREE_ID)).toBe(
+      'unverifiable'
+    )
   })
 
   it('treats a conflicting host snapshot as unanswered', () => {

--- a/src/renderer/src/lib/workspace-terminal-host-authority.ts
+++ b/src/renderer/src/lib/workspace-terminal-host-authority.ts
@@ -17,8 +17,7 @@ import {
  *
  * - `live` — a remote execution host owns terminal creation here. It supplies the surface itself.
  * - `unverifiable` — the workspace has a remote execution host with a sync still in flight or not
- *   yet attempted. It is bounded: a sync that terminates without an answer resolves `none` rather
- *   than refusing forever (see resolveDirectSshAuthority).
+ *   yet attempted, or a failed sync. Only a successful hydration can lift that uncertainty.
  * - `none` — no remote host holds terminals here: either the workspace is local (this client *is*
  *   the execution host, and its own tab rows are the whole truth) or the host answered and holds
  *   nothing.
@@ -40,39 +39,19 @@ export type WorkspaceTerminalHostAuthorityState = WorktreeRuntimeOwnerState & {
   remoteWorkspaceSyncStatusByTargetId?: Record<string, RemoteWorkspaceSyncStatus>
 }
 
-/** A sync attempt that has stopped without an answer. `unverifiable` is the honest verdict about the
- *  host, but holding it forever is not a verdict — it is a refusal to act, so nothing would ever
- *  lift it. Four paths reach here: local-hydration timeout, a null `remoteWorkspace.get`, a falsy
- *  apply token, and never connecting at all.
- *
- *  Known gap: this floor was reasoned about when hydration was add-only, so "un-hydrated" implied
- *  "the host never answered". A snapshot whose rows could not be placed now revokes hydration
- *  (remote-workspace-snapshot-apply.ts), so a target that later lands on `offline`/`error` reaches
- *  this floor having *demonstrably* answered with tabs. Seeding is then authorised over live host
- *  terminals. That is not a regression — before the revocation existed the same target was marked
- *  hydrated and `synced`, which reached `none` sooner — but the floor should learn to tell a
- *  revoked target from one that never answered. Tracked for the SSH-v3 consolidation, where a
- *  single authoritative liveness source replaces this pair. */
-const TERMINATED_WITHOUT_ANSWER_PHASES = new Set(['offline', 'error'])
-
 function resolveDirectSshAuthority(
   state: WorkspaceTerminalHostAuthorityState,
   targetId: string
 ): WorkspaceTerminalHostAuthority {
   const phase = state.remoteWorkspaceSyncStatusByTargetId?.[targetId]?.phase
-  if (state.remoteWorkspaceHydratedTargetIds?.has(targetId)) {
-    // Why: the same pair use-app-session-persistence.ts gates uploads on. A conflicting snapshot
-    // means the client's picture is not the host's, so it is no basis for deciding the host holds
-    // nothing.
-    return phase === 'conflict' ? 'unverifiable' : 'none'
+  // A failed or conflicting pull cannot establish the host's current inventory.
+  if (phase === 'offline' || phase === 'error' || phase === 'conflict') {
+    return 'unverifiable'
   }
-  if (phase !== undefined && TERMINATED_WITHOUT_ANSWER_PHASES.has(phase)) {
-    // The bounded floor. Without it a single failed sync leaves every git worktree on this target
-    // terminal-less and its sleeping agents unresumable for the rest of the app session — strictly
-    // worse than the pre-gate behaviour, and only escapable by creating a tab by hand. Declining to
-    // seed is meant to be a wait, not a permanent refusal.
+  if (state.remoteWorkspaceHydratedTargetIds?.has(targetId)) {
     return 'none'
   }
+
   // Not connected, still pulling, or not yet attempted — "we could not ask", never "nothing there".
   return 'unverifiable'
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​108 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## ELI5

A failed SSH inventory or a matching workspace ID on another host should not authorize a replacement session. A known transcript already queued in another workspace should not receive a second resume tab.

## What Changed

Three independently reviewable commits add scoped cross-workspace sleeping-resume checks, preserve `unverifiable` after failed SSH hydration, and remove unproven foreign-partition adoption from the runtime session controller. Existing provider equality, workspace route resolution, and repository host resolution are reused.

Cross-workspace suppression requires the same provider identity, exact transcript path, execution host, and paired transport environment. ID-only legacy records keep their existing behavior. Conflicting repository owners block partition reads/writes before legacy null-to-local fallbacks can run; hydration skips ambiguous owners. Foreign state is preserved.

## Why

The renderer's three resume checks only saw the current worktree. SSH offline/error phases were converted to `none` even without an inventory answer. Runtime partition lookup treated the only nonempty same-ID partition as evidence of host migration and selected colliding repository rows by order.

This is a bounded set of safeguards, **not global exactly-once resume**. Atomic execution-host claims, account-root canonicalization, absent client projections, AI Vault resume, and generation-aware inventory foundations remain separate work. Existing draft [#19405](https://github.com/stablyai/orca/pull/19405) covers incumbent writer placement and is neither modified nor duplicated; these safeguards stand independently of it.

## Linked Issue

Partial coverage for [STA-6297](https://linear.app/stably/issue/STA-6297), [STA-3498](https://linear.app/stably/issue/STA-3498), [STA-3500](https://linear.app/stably/issue/STA-3500), and [STA-6535](https://linear.app/stably/issue/STA-6535). Supporting coverage only for [STA-6719](https://linear.app/stably/issue/STA-6719). No ticket closure is claimed. Exact disposition of all 19 triaged issues is in `notes/linear-fix-report.md`.

## Visual Proof

Pending rendered Electron validation. Tests exercise store actions and runtime partition/close behavior without launching an app or touching user sessions; no before/after UI evidence is claimed. Keep this PR draft.

## Testing

All tests/typechecks used `ORCA_BACKGROUND_LAUNCH=1` on macOS.

- Renderer suite: 7 files / 66 tests passed; the subsequently extended cross-workspace file passed 8 tests, including consecutive sweeps, folder ownership, host/account isolation, and legacy ID-only compatibility.
- Runtime partition/retirement suite: 2 files / 14 tests passed.
- Existing SSH restoreRequired discrimination suite: 2 files / 7 tests passed.
- Node and web typechecks passed; node rechecked after the final ambiguity fence.
- Changed-code quality: zero native, type-aware, and React Doctor findings across 8 source files; formatting and diff checks passed.

No real SSH/WSL/Windows, rendered Electron, host-restart, or multi-client process test was performed. Existing renderer remote-compatibility regressions pass; no RPC fields, stream opcodes, or snapshot shapes change. A full mixed-version integration run remains pending.

## Review

Self-reviewed; independent review pending. The old unique-partition migration heuristic is deliberately removed: relocated records can remain inaccessible until an explicit owner migration proves identity. The SSH renderer/local versus runtime/SSH durable persistence divergence remains open. Folder SSH snapshot scope is unchanged.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer material copied.

<!-- rebase-record -->
## Rebase record (2026-09-11)

Rebased onto `main` at `5fa62feda7c264c6eda99ba4788ffebab9aae26c`. No conflicts; all 5 commit(s) replayed as-is.

| | SHA |
| --- | --- |
| old head | `840e678f50d2c89202ca20e963367414c7b17558` |
| new head | `e533eaefe734df0f4f3ed5bff58d00bf4b010703` |
<!-- /rebase-record -->
