### PR TITLE
fix(agent-hooks): guard every Windows missing-target fallback before it reads stdin

### DIFF
--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -74,20 +74,37 @@ export const WINDOWS_HOOK_STDIN_DRAIN_LABEL = 'orca_agent_hook_drain_stdin'
 export const WINDOWS_HOOK_STDIN_READER = '"%SystemRoot%\\System32\\more.com"'
 export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = `${WINDOWS_HOOK_STDIN_READER} >nul 2>nul`
 
+// The Orca context a hook needs before it may own stdin; see the rule below.
+const WINDOWS_HOOK_ENVIRONMENT_VARS = [
+  'ORCA_AGENT_HOOK_PORT',
+  'ORCA_AGENT_HOOK_TOKEN',
+  'ORCA_PANE_KEY'
+] as const
+
 // Why (#11549): missing Orca context means the hook ran outside an Orca pane, where the caller
 // may abandon stdin rather than close it — a read-to-EOF then blocks forever and strands a
 // visible window per hook event. The Windows rule: a hook must check the Orca env before it
 // owns stdin, and exit without reading when the env is missing — the payload is discarded on
-// that path anyway. This applies to .cmd, the copilot .ps1, and the Git Bash kimi .sh alike.
+// that path anyway. This applies to .cmd, the copilot .ps1, and the Git Bash kimi .sh alike,
+// and to the launchers that own stdin themselves when the managed script is missing.
 // POSIX hooks keep capture-first: their callers close stdin, and exiting mid-write there
 // surfaces as EPIPE the agent can see (#8110).
 export function buildWindowsHookEnvironmentGuardLines(): string[] {
-  return [
-    'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',
-    'if "%ORCA_AGENT_HOOK_TOKEN%"=="" exit /b 0',
-    'if "%ORCA_PANE_KEY%"=="" exit /b 0'
-  ]
+  return WINDOWS_HOOK_ENVIRONMENT_VARS.map((name) => `if "%${name}%"=="" exit /b 0`)
 }
+
+/** The same guard in sh, for the Git Bash hooks and launchers that run on Windows.
+ *  Default-formed because a static hook precheck (Grok) rejects a bare reference it
+ *  cannot resolve. POSIX hosts keep capture-first — this is the Windows rule only. */
+export const WINDOWS_GIT_BASH_HOOK_ENVIRONMENT_GUARD = `if ${WINDOWS_HOOK_ENVIRONMENT_VARS.map(
+  (name) => `[ -z "\${${name}-}" ]`
+).join(' || ')}; then exit 0; fi`
+
+/** The same guard for a PowerShell hook or launcher. Anything that reaches
+ *  `[Console]::In.ReadToEnd()` must run this first, or it inherits #11549. */
+export const WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD = `if (${WINDOWS_HOOK_ENVIRONMENT_VARS.map(
+  (name) => `-not $env:${name}`
+).join(' -or ')}) { exit 0 }`
 
 export function buildWindowsHookStdinDrainEpilogue(): string[] {
   return [`:${WINDOWS_HOOK_STDIN_DRAIN_LABEL}`, WINDOWS_HOOK_STDIN_DRAIN_COMMAND, 'exit /b 0']

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -31,7 +31,10 @@ import {
   type HooksConfig
 } from './installer-utils'
 import { buildPosixAgentHookPostCommand } from './hook-post-command'
-import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
+import {
+  POSIX_HOOK_STDIN_DRAIN_COMMAND,
+  WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD
+} from './hook-stdin-contract'
 import { wrapRuntimeHomeHookCommand } from './runtime-home-hook-command'
 
 let tmpDir: string
@@ -618,7 +621,10 @@ function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   // Why: the execution-policy bypass rides in the payload, not on the command
   // line, so the launcher cannot spell the AV-blocked flag triple (#16003).
   // Why: PowerShell progress CLIXML corrupts consumers that merge stderr into JSON stdout.
-  return `$ProgressPreference='SilentlyContinue'; try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  // Why the guard is spelled by import: the launcher owns stdin on the missing-script path,
+  // so it obeys the shared Windows rule (#11549), and re-typing it here would let the two
+  // drift back apart.
+  return `$ProgressPreference='SilentlyContinue'; try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; ${WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD}; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
 describe('wrapWindowsHookCommand', () => {
@@ -640,15 +646,23 @@ describe('wrapWindowsHookCommand', () => {
     )
   })
 
-  it('emits fallback stdout when the managed script is missing', () => {
-    const command = wrapWindowsHookCommand(
-      'C:\\hooks\\cursor-hook.cmd',
-      {},
-      { fallbackStdout: '{"permission":"allow"}' }
+  // Why the ordering matters: a gate event reads silence as deny (#2426), and outside an
+  // Orca pane the guard exits before the read — so an answer placed after the drain never
+  // reaches the agent at all when the caller abandons the pipe (#11549).
+  it('answers before it guards, and guards before it owns stdin', () => {
+    const decoded = decodeWindowsHookCommand(
+      wrapWindowsHookCommand(
+        'C:\\hooks\\cursor-hook.cmd',
+        {},
+        { fallbackStdout: '{"permission":"allow"}' }
+      )
     )
-    expect(decodeWindowsHookCommand(command)).toContain(
-      'Write-Output \'{"permission":"allow"}\'; exit 0'
-    )
+    const answer = decoded.indexOf('Write-Output \'{"permission":"allow"}\'')
+    const guard = decoded.indexOf(WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD)
+    const ownsStdin = decoded.indexOf('[Console]::In.ReadToEnd()')
+    expect(answer).toBeGreaterThan(-1)
+    expect(guard).toBeGreaterThan(answer)
+    expect(ownsStdin).toBeGreaterThan(guard)
   })
 
   // Why: a user profile path like `C:\Users\Jane Doe` is the regression from

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -16,6 +16,7 @@ import { grantDirAcl, isPermissionError } from '../win32-utils'
 import { resolveHooksJsonWritePath } from './hook-config-write-path'
 import { writeRollingFileBackup } from '../rolling-file-backup'
 import { wrapWindowsPowerShellEncodedCommand } from './windows-powershell-hook-launcher'
+import { WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD } from './hook-stdin-contract'
 
 export type HookCommandConfig = {
   type: 'command'
@@ -131,7 +132,10 @@ export function wrapWindowsHookCommand(
     options.fallbackStdout === undefined
       ? ''
       : `Write-Output ${quotePowerShellString(options.fallbackStdout)}; `
-  const command = `${envPrefix}if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; ${fallback}exit 0`
+  // Why the order: answer first (a gate event reads silence as deny), then the shared
+  // env guard, and only then own stdin — outside an Orca pane the caller may abandon the
+  // pipe, and ReadToEnd would strand the launcher there forever (#11549).
+  const command = `${envPrefix}if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; ${fallback}${WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD}; [Console]::In.ReadToEnd() | Out-Null; exit 0`
   return wrapWindowsPowerShellEncodedCommand(command)
 }
 

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -63,12 +63,26 @@ import { KimiHookService } from '../kimi/hook-service'
 
 import { openClaudeHookService } from '../openclaude/hook-service'
 import { wrapPosixHookCommand, wrapWindowsHookCommand } from './installer-utils'
-import { POSIX_HOOK_STDIN_READER } from './hook-stdin-contract'
+import {
+  POSIX_HOOK_STDIN_READER,
+  WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD
+} from './hook-stdin-contract'
 import { wrapRuntimeHomeHookCommand } from './runtime-home-hook-command'
 import { createAgentHookMemorySftp } from './agent-hook-memory-sftp.test-fixture'
 import { findGitBash } from './windows-git-bash-path.test-fixture'
 
+/** The launchers ship their command base64'd; assert the shape they actually run. */
+function decodeEncodedPowerShellCommand(command: string): string {
+  const encoded = command.match(/-EncodedCommand\s+(\S+)/)
+  expect(encoded, 'launcher carries an encoded command').not.toBeNull()
+  return Buffer.from(encoded![1], 'base64').toString('utf16le')
+}
+
 const REMOTE_HOME = '/home/dev'
+// Why all three: Windows reports a write to a pipe whose reader is gone as any of these,
+// depending on whether the read handle, the pipe, or the process went first. Enumerating
+// them keeps the guard-exit legs from failing on which race the host happened to run.
+const WRITER_BROKEN_BY_EARLY_EXIT = ['EPIPE', 'ECONNRESET', 'EOF']
 const LARGE_PAYLOAD = Buffer.alloc(1_000_000, 'x')
 
 // Why: a developer box may set HKCU\...\Command Processor\AutoRun, which cmd.exe runs before any
@@ -156,7 +170,10 @@ type HookRun = {
 function runHookProcess(
   executable: string,
   args: string[],
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  // Why: `abandon` leaves the pipe open and unwritten — the shape a caller outside an Orca
+  // pane produces, and the only one that can catch a read-to-EOF that never returns (#11549).
+  stdin: 'close' | 'abandon' = 'close'
 ): Promise<HookRun> {
   return new Promise((resolve, reject) => {
     const child = spawn(executable, args, { env, stdio: ['pipe', 'pipe', 'pipe'] })
@@ -164,8 +181,9 @@ function runHookProcess(
     let stderr = ''
     let stdout = ''
     const timeout = setTimeout(() => {
+      child.stdin.destroy()
       child.kill('SIGKILL')
-      reject(new Error('hook did not finish after stdin closed'))
+      reject(new Error(`hook did not finish with stdin ${stdin}d`))
     }, 10_000)
     child.on('error', (error) => {
       clearTimeout(timeout)
@@ -182,7 +200,9 @@ function runHookProcess(
       clearTimeout(timeout)
       resolve({ exitCode, stdinErrors, stderr, stdout })
     })
-    child.stdin.end(LARGE_PAYLOAD)
+    if (stdin === 'close') {
+      child.stdin.end(LARGE_PAYLOAD)
+    }
   })
 }
 
@@ -303,6 +323,31 @@ describe('Windows managed hook stdin structure', () => {
       expect(copilot.indexOf('if (-not $env:ORCA_AGENT_HOOK_PORT')).toBeLessThan(
         copilot.indexOf('[Console]::In.ReadToEnd()')
       )
+      // Why: the two encoded-PowerShell launchers own stdin themselves when the managed
+      // script is missing, so the same guard has to precede their ReadToEnd — and the
+      // fallback answer has to precede the guard, or a gate event outside a pane is
+      // answered with silence, which reads as deny (#2426/#15462).
+      for (const [name, command] of [
+        [
+          'wrapWindowsHookCommand',
+          wrapWindowsHookCommand('C:\\missing\\orca-hook.cmd', {}, { fallbackStdout: '{}' })
+        ],
+        [
+          'wrapRuntimeHomeHookCommand',
+          wrapRuntimeHomeHookCommand('missing-orca-hook', { neutralJsonWhenMissing: true })
+        ]
+      ] as const) {
+        const decoded = decodeEncodedPowerShellCommand(command)
+        expect(decoded, `${name} decoded`).toContain(WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD)
+        expect(decoded.indexOf("Write-Output '{}'"), `${name} answers first`).toBeLessThan(
+          decoded.indexOf(WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD)
+        )
+        expect(
+          decoded.indexOf(WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD),
+          `${name} guards before owning stdin`
+        ).toBeLessThan(decoded.indexOf('[Console]::In.ReadToEnd()'))
+      }
+
       const kimi = readFileSync(join(hooksDir, 'kimi-hook.sh'), 'utf8')
       expect(kimi.indexOf('if [ -z "$ORCA_AGENT_HOOK_PORT" ]')).toBeGreaterThan(-1)
       expect(kimi.indexOf('if [ -z "$ORCA_AGENT_HOOK_PORT" ]')).toBeLessThan(
@@ -365,12 +410,11 @@ describe('Windows managed hook stdin structure', () => {
           const result = await runHookProcess(executable, args, hookEnvironment())
           expect(result.exitCode, `${fileName} exit code`).toBe(0)
           // Why (#11549 class): every Windows-local hook exits before owning stdin when the
-          // Orca env is missing, so the writer may break — EPIPE, or ECONNRESET when Windows
-          // tears the pipe down first. hookEnvironment() strips every ORCA_* var, so this
-          // relaxation only ever covers the missing-env path — a happy-path case added to
-          // this loop must not reuse it.
+          // Orca env is missing, so the writer may break. hookEnvironment() strips every
+          // ORCA_* var, so this relaxation only ever covers the missing-env path — a
+          // happy-path case added to this loop must not reuse it.
           for (const error of result.stdinErrors) {
-            expect(['EPIPE', 'ECONNRESET'], `${fileName} stdin error`).toContain(error.code)
+            expect(WRITER_BROKEN_BY_EARLY_EXIT, `${fileName} stdin error`).toContain(error.code)
           }
         }
 
@@ -395,9 +439,42 @@ describe('Windows managed hook stdin structure', () => {
           }
         ]
         for (const launcher of launcherCases) {
-          const result = await runHookProcess(launcher.executable, launcher.args, hookEnvironment())
-          expect(result.exitCode, `${launcher.name} exit code`).toBe(0)
-          expect(result.stdinErrors, `${launcher.name} stdin errors`).toHaveLength(0)
+          // Why (#11549 class): a launcher that reaches an interpreter owns stdin for a
+          // missing script exactly like a managed script does, so it obeys the same rule —
+          // drain inside a pane, exit before reading outside one. Its writer may therefore
+          // break on the missing-env leg, and must not on the in-pane leg.
+          const outside = await runHookProcess(
+            launcher.executable,
+            launcher.args,
+            hookEnvironment()
+          )
+          expect(outside.exitCode, `${launcher.name} exit code`).toBe(0)
+          for (const error of outside.stdinErrors) {
+            expect(WRITER_BROKEN_BY_EARLY_EXIT, `${launcher.name} stdin error`).toContain(
+              error.code
+            )
+          }
+          const insideAPane = await runHookProcess(
+            launcher.executable,
+            launcher.args,
+            hookEnvironment({
+              ORCA_AGENT_HOOK_PORT: '59999',
+              ORCA_AGENT_HOOK_TOKEN: 'token',
+              ORCA_PANE_KEY: 'tab:leaf'
+            })
+          )
+          expect(insideAPane.exitCode, `${launcher.name} in-pane exit code`).toBe(0)
+          expect(insideAPane.stdinErrors, `${launcher.name} in-pane stdin errors`).toHaveLength(0)
+          // Why this leg and not a shape assertion: an unguarded ReadToEnd exits fine when
+          // the writer closes the pipe. Only a caller that abandons it strands the launcher,
+          // which is what left a console per hook event on the reporting hosts.
+          const abandoned = await runHookProcess(
+            launcher.executable,
+            launcher.args,
+            hookEnvironment(),
+            'abandon'
+          )
+          expect(abandoned.exitCode, `${launcher.name} abandoned-stdin exit code`).toBe(0)
         }
       } finally {
         homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -1,4 +1,8 @@
-import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
+import {
+  POSIX_HOOK_STDIN_DRAIN_COMMAND,
+  WINDOWS_GIT_BASH_HOOK_ENVIRONMENT_GUARD,
+  WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD
+} from './hook-stdin-contract'
 import {
   encodeWindowsPowerShellHookCommand,
   WINDOWS_POWERSHELL_HOOK_SWITCHES
@@ -19,16 +23,30 @@ export function wrapRuntimeHomeHookCommand(
   const windowsScript = `"\${HOME-}/.orca/agent-hooks/${scriptBaseName}.cmd"`
   const posixScript = `"\${HOME-}/.orca/agent-hooks/${scriptBaseName}.sh"`
   const drain = POSIX_HOOK_STDIN_DRAIN_COMMAND
-  const missingScriptFallback = options.neutralJsonWhenMissing ? `${drain}; printf '{}\\n'` : drain
+  const neutralJson = options.neutralJsonWhenMissing ? `printf '{}\\n'` : ''
+  // Why two forms: the missing-script fallback owns stdin, so it follows the rule of the host
+  // it lands on. POSIX callers close the pipe, so capture-first is safe there and a mid-write
+  // exit stays visible as EPIPE (#8110). A Windows caller may abandon the pipe, so there the
+  // answer comes first and the drain only runs with an Orca env behind it (#11549).
+  const posixMissingScriptFallback = neutralJson ? `${drain}; ${neutralJson}` : drain
+  const windowsMissingScriptFallback = [
+    ...(neutralJson ? [neutralJson] : []),
+    WINDOWS_GIT_BASH_HOOK_ENVIRONMENT_GUARD,
+    drain
+  ].join('; ')
+  // Why platform-selected even when HOME is unset: which stdin rule applies follows the
+  // caller, not the reason the script could not be found.
+  const missingScriptFallback = `case "\${OSTYPE-}" in msys*|cygwin*|win32*) ${windowsMissingScriptFallback} ;; *) ${posixMissingScriptFallback} ;; esac`
   const powershell = '"${SYSTEMROOT-}/System32/WindowsPowerShell/v1.0/powershell.exe"'
   const powershellFallback = options.neutralJsonWhenMissing ? "; Write-Output '{}'" : ''
-  const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null${powershellFallback}; exit 0`
+  // Why the order: answer first, then the shared env guard, then own stdin — see wrapWindowsHookCommand.
+  const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }${powershellFallback}; ${WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD}; [Console]::In.ReadToEnd() | Out-Null; exit 0`
   const encodedCommand = encodeWindowsPowerShellHookCommand(powershellCommand)
   // Why: the Git Bash and native Windows launchers must spell the same switches — window suppression (#14815) and an AV verdict on the shape (#16003) both hit either path.
   const powershellInvocation = `${powershell} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodedCommand}`
-  const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${missingScriptFallback}; fi`
-  const windowsBranch = `if [ -f ${windowsScript} ]; then case "\${HOME-}" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${missingScriptFallback}; fi`
-  const posixBranch = `if [ -f ${posixScript} ] && [ -r ${posixScript} ] && [ -x ${posixScript} ]; then /bin/sh ${posixScript}; else ${missingScriptFallback}; fi`
+  const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${windowsMissingScriptFallback}; fi`
+  const windowsBranch = `if [ -f ${windowsScript} ]; then case "\${HOME-}" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${windowsMissingScriptFallback}; fi`
+  const posixBranch = `if [ -f ${posixScript} ] && [ -r ${posixScript} ] && [ -x ${posixScript} ]; then /bin/sh ${posixScript}; else ${posixMissingScriptFallback}; fi`
   // Why: OSTYPE is shell-owned, so platform selection adds no process to every hook invocation.
   return `if [ -z "\${HOME-}" ]; then ${missingScriptFallback}; else case "\${OSTYPE-}" in msys*|cygwin*|win32*) ${windowsBranch} ;; *) ${posixBranch} ;; esac; fi`
 }

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -102,8 +102,8 @@ export function getWindowsWrapperScript(eventName: string): string {
     ') else (',
     '  echo {}',
     ')',
-    // Why: when the shared core script is missing, this wrapper becomes the
-    // stdin owner and must finish the agent's payload write before returning.
+    // Missing-core fallbacks obey the same outside-Orca stdin guard as the core.
+    ...buildWindowsHookEnvironmentGuardLines(),
     WINDOWS_HOOK_STDIN_DRAIN_COMMAND,
     'exit /b 0',
     ''

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -88,7 +88,10 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 export function getWindowsWrapperScript(eventName: string): string {
   return [
     '@echo off',
-    'setlocal',
+    // Why (#9358/#9941): `!` is legal in the hooks path, and inherited delayed expansion
+    // eats it out of the percent-expanded `%~dp0` — the wrapper then misses the core and
+    // silently falls back on every event. Same reason the core disables it.
+    'setlocal DisableDelayedExpansion',
     `set "ORCA_ANTIGRAVITY_EVENT=${eventName}"`,
     'set "ORCA_ANTIGRAVITY_CORE=%~dp0antigravity-hook.cmd"',
     'if exist "%ORCA_ANTIGRAVITY_CORE%" (',

--- a/src/main/antigravity/windows-hook-payload-delivery.test.ts
+++ b/src/main/antigravity/windows-hook-payload-delivery.test.ts
@@ -1,7 +1,7 @@
 // Why (#15117): shape assertions cannot catch a curl line that posts nothing, so this suite
 // pipes a real payload through the installed wrappers and follows it to a live listener.
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { spawn } from 'node:child_process'
+import { spawnProcess } from '../../shared/child-process/run-process'
 import { createServer, type Server } from 'node:http'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -28,7 +28,8 @@ vi.mock('os', async (importOriginal) => {
 
 import { AntigravityHookService } from './hook-service'
 import { ANTIGRAVITY_EVENTS, ANTIGRAVITY_PRE_TOOL_USE_DECISION } from './hook-events'
-import { getManagedScript } from './hook-script'
+import { getManagedScript, getWindowsWrapperScript } from './hook-script'
+import { WINDOWS_HOOK_STDIN_DRAIN_COMMAND } from '../agent-hooks/hook-stdin-contract'
 
 // Why (#9358/#9941): `!` is legal in a Windows path and in a pane key. Under inherited
 // delayed expansion cmd eats it out of a percent-expanded curl argument, so bake one into
@@ -99,11 +100,10 @@ function runWrapper(
   stdinPayload: string | null = PAYLOAD
 ): Promise<HookRun> {
   return new Promise((resolve, reject) => {
-    // Why: mirror how Antigravity spawns the hook — `cmd /c <bare .cmd path>`, the exact
-    // chain in the bug report's process trace.
-    const child = spawn('cmd.exe', ['/d', '/c', wrapperPath], {
+    // Use the shared cmd encoder so spaces survive cmd's non-MSVCRT quoting.
+    const child = spawnProcess({
+      program: wrapperPath,
       stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true,
       env
     })
     let stdout = ''
@@ -111,6 +111,7 @@ function runWrapper(
     let timedOut = false
     const timer = setTimeout(() => {
       timedOut = true
+      child.stdin.destroy()
       child.kill('SIGKILL')
     }, 15_000)
     child.on('error', (error) => {
@@ -139,7 +140,9 @@ function runWrapper(
 
 function hookEnvironment(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const base = Object.fromEntries(
-    Object.entries(process.env).filter(([key]) => !key.startsWith('ORCA_'))
+    Object.entries(process.env).filter(
+      ([key]) => !key.startsWith('ORCA_') || key === 'ORCA_BACKGROUND_LAUNCH'
+    )
   )
   return { ...base, ...extra }
 }
@@ -154,6 +157,18 @@ function expectedStdout(eventName: string): string {
 // Why: runs on every platform — the live delivery suite below is Windows-only, so this
 // keeps a POSIX-only CI leg from letting the interpreter back into the hot path.
 describe('Antigravity Windows hook post command', () => {
+  it.each(ANTIGRAVITY_EVENTS)('guards missing-core stdin for $eventName', ({ eventName }) => {
+    const script = getWindowsWrapperScript(eventName)
+    const drain = script.indexOf(WINDOWS_HOOK_STDIN_DRAIN_COMMAND)
+    const answer = script.lastIndexOf('echo {}')
+    expect(drain).toBeGreaterThan(answer)
+    for (const key of ['ORCA_AGENT_HOOK_PORT', 'ORCA_AGENT_HOOK_TOKEN', 'ORCA_PANE_KEY']) {
+      const guard = script.indexOf(`if "%${key}%"=="" exit /b 0`)
+      expect(guard, key).toBeGreaterThan(answer)
+      expect(guard, key).toBeLessThan(drain)
+    }
+  })
+
   it('posts through curl.exe rather than a PowerShell interpreter', () => {
     vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
     const script = getManagedScript('local')
@@ -263,6 +278,36 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
     expect(listener.posts[0].payload).toBeNull()
     expect(listener.posts[0].hookEventName).toBe('PreInvocation')
   }, 30_000)
+
+  it.each(['ORCA_AGENT_HOOK_PORT', 'ORCA_AGENT_HOOK_TOKEN', 'ORCA_PANE_KEY'])(
+    'answers every missing-core event with abandoned stdin and no %s',
+    async (missingKey) => {
+      home = mkdtempSync(join(tmpdir(), 'orca antigravity fallback-'))
+      homedirMock.mockReturnValue(home)
+      expect(new AntigravityHookService().install().state).toBe('installed')
+      const hooksDir = join(home, '.orca', 'agent-hooks')
+      rmSync(join(hooksDir, 'antigravity-hook.cmd'))
+      const listener = await startHookListener()
+      server = listener.server
+      const env = hookEnvironment({
+        USERPROFILE: home,
+        HOME: home,
+        ORCA_AGENT_HOOK_PORT: String(listener.port),
+        ORCA_AGENT_HOOK_TOKEN: HOOK_TOKEN,
+        ORCA_PANE_KEY: PANE_KEY,
+        [missingKey]: ''
+      })
+      for (const event of ANTIGRAVITY_EVENTS) {
+        const result = await runWrapper(join(hooksDir, event.windowsWrapperFileName), env, null)
+        expect(result.timedOut, event.eventName).toBe(false)
+        expect(result.exitCode, event.eventName).toBe(0)
+        expect(result.stdout.trim(), event.eventName).toBe(expectedStdout(event.eventName))
+        expect(result.stderr, event.eventName).toBe('')
+      }
+      expect(listener.posts).toHaveLength(0)
+    },
+    90_000
+  )
 
   it('exits without reading stdin when the pane env is missing', async () => {
     home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))

--- a/src/main/antigravity/windows-hook-payload-delivery.test.ts
+++ b/src/main/antigravity/windows-hook-payload-delivery.test.ts
@@ -1,7 +1,7 @@
 // Why (#15117): shape assertions cannot catch a curl line that posts nothing, so this suite
 // pipes a real payload through the installed wrappers and follows it to a live listener.
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { spawnProcess } from '../../shared/child-process/run-process'
+import { spawn } from 'node:child_process'
 import { createServer, type Server } from 'node:http'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -92,18 +92,25 @@ async function startHookListener(): Promise<{
 
 type HookRun = { exitCode: number | null; stdout: string; stderr: string; timedOut: boolean }
 
+// Why spell `/v`: `cmd /d /c <bare .cmd path>` is the chain in the bug report's process trace,
+// and it inherits HKCU\...\Command Processor\DelayedExpansion. Naming the state makes the
+// hostile half reachable on any host — under `/v:on` cmd eats `!` out of every percent
+// expansion (#9358/#9941), and a harness pinned to `/v:off` could never fail on it.
+type DelayedExpansion = 'on' | 'off'
+const DELAYED_EXPANSION_STATES = ['off', 'on'] as const satisfies readonly DelayedExpansion[]
+
 function runWrapper(
   wrapperPath: string,
   env: NodeJS.ProcessEnv,
   // Why: `null` abandons stdin instead of closing it — the shape a caller outside an Orca
   // pane produces, and the only way to prove the env guard exits before reading (#11549).
-  stdinPayload: string | null = PAYLOAD
+  stdinPayload: string | null = PAYLOAD,
+  delayedExpansion: DelayedExpansion = 'off'
 ): Promise<HookRun> {
   return new Promise((resolve, reject) => {
-    // Use the shared cmd encoder so spaces survive cmd's non-MSVCRT quoting.
-    const child = spawnProcess({
-      program: wrapperPath,
+    const child = spawn('cmd.exe', [`/v:${delayedExpansion}`, '/d', '/c', wrapperPath], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       env
     })
     let stdout = ''
@@ -140,9 +147,7 @@ function runWrapper(
 
 function hookEnvironment(extra: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const base = Object.fromEntries(
-    Object.entries(process.env).filter(
-      ([key]) => !key.startsWith('ORCA_') || key === 'ORCA_BACKGROUND_LAUNCH'
-    )
+    Object.entries(process.env).filter(([key]) => !key.startsWith('ORCA_'))
   )
   return { ...base, ...extra }
 }
@@ -167,6 +172,12 @@ describe('Antigravity Windows hook post command', () => {
       expect(guard, key).toBeGreaterThan(answer)
       expect(guard, key).toBeLessThan(drain)
     }
+  })
+
+  // Why (#9358/#9941): `%~dp0` carries the hooks path, so an inherited delayed expansion eats
+  // a `!` out of it and the wrapper silently misses the core on every event.
+  it.each(ANTIGRAVITY_EVENTS)('disables delayed expansion for $eventName', ({ eventName }) => {
+    expect(getWindowsWrapperScript(eventName)).toContain('setlocal DisableDelayedExpansion')
   })
 
   it('posts through curl.exe rather than a PowerShell interpreter', () => {
@@ -200,7 +211,10 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
   })
 
   it('delivers every event wrapper payload to the listener without spawning PowerShell', async () => {
-    home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))
+    // Why the `!` in the directory: it lands in the wrapper's `%~dp0`, which is what an
+    // inherited delayed expansion eats (#9358/#9941). Without it the `/v:on` leg below
+    // proves nothing about the core lookup.
+    home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook!bang-'))
     homedirMock.mockReturnValue(home)
     expect(new AntigravityHookService().install().state).toBe('installed')
 
@@ -219,34 +233,42 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
       ORCA_WORKTREE_ID: WORKTREE_ID
     })
 
-    for (const event of ANTIGRAVITY_EVENTS) {
-      const label = event.eventName
-      const before = listener.posts.length
-      const result = await runWrapper(join(hooksDir, event.windowsWrapperFileName), env)
+    for (const delayedExpansion of DELAYED_EXPANSION_STATES) {
+      for (const event of ANTIGRAVITY_EVENTS) {
+        const label = `${event.eventName} (/v:${delayedExpansion})`
+        const before = listener.posts.length
+        const result = await runWrapper(
+          join(hooksDir, event.windowsWrapperFileName),
+          env,
+          PAYLOAD,
+          delayedExpansion
+        )
 
-      expect(result.timedOut, `${label} timed out`).toBe(false)
-      expect(result.exitCode, `${label} exit code`).toBe(0)
-      expect(result.stderr, `${label} stderr`).toBe('')
-      // Why: Antigravity reads silence on PreToolUse as deny (#2426), so the gate answer
-      // must survive the transport change.
-      expect(result.stdout.trim(), `${label} stdout`).toBe(expectedStdout(label))
+        expect(result.timedOut, `${label} timed out`).toBe(false)
+        expect(result.exitCode, `${label} exit code`).toBe(0)
+        expect(result.stderr, `${label} stderr`).toBe('')
+        // Why: Antigravity reads silence on PreToolUse as deny (#2426), so the gate answer
+        // must survive the transport change.
+        expect(result.stdout.trim(), `${label} stdout`).toBe(expectedStdout(event.eventName))
 
-      const posts = listener.posts.slice(before)
-      expect(posts, `${label} posted exactly one hook`).toHaveLength(1)
-      // Why: byte-exact, not "non-empty" — PowerShell recoded this body through the console
-      // code page, and a silently corrupted payload still looks posted.
-      expect(posts[0].payload, `${label} payload`).toBe(PAYLOAD)
-      expect(posts[0].hookEventName, `${label} hook_event_name`).toBe(label)
-      // Why: the `!` in both values is the delayed-expansion regression guard.
-      expect(posts[0].paneKey, `${label} paneKey`).toBe(PANE_KEY)
-      expect(posts[0].worktreeId, `${label} worktreeId`).toBe(WORKTREE_ID)
-      expect(posts[0].token, `${label} token`).toBe(HOOK_TOKEN)
-      expect(posts[0].contentType, `${label} content-type`).toContain(
-        'application/x-www-form-urlencoded'
-      )
+        const posts = listener.posts.slice(before)
+        expect(posts, `${label} posted exactly one hook`).toHaveLength(1)
+        // Why: byte-exact, not "non-empty" — PowerShell recoded this body through the console
+        // code page, and a silently corrupted payload still looks posted.
+        expect(posts[0].payload, `${label} payload`).toBe(PAYLOAD)
+        expect(posts[0].hookEventName, `${label} hook_event_name`).toBe(event.eventName)
+        // Why: the `!` in both values is the delayed-expansion regression guard — it is the
+        // `/v:on` leg that can actually fail on it.
+        expect(posts[0].paneKey, `${label} paneKey`).toBe(PANE_KEY)
+        expect(posts[0].worktreeId, `${label} worktreeId`).toBe(WORKTREE_ID)
+        expect(posts[0].token, `${label} token`).toBe(HOOK_TOKEN)
+        expect(posts[0].contentType, `${label} content-type`).toContain(
+          'application/x-www-form-urlencoded'
+        )
+      }
     }
-    // Why: five wrapper launches plus a real install can overrun the default under load.
-  }, 60_000)
+    // Why: ten wrapper launches plus a real install can overrun the default under load.
+  }, 90_000)
 
   // Why (#15117): Antigravity fires some events with no stdin at all. PowerShell substituted
   // `{}` before posting; curl forwards the empty body, so prove the post still happens — the
@@ -279,14 +301,21 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
     expect(listener.posts[0].hookEventName).toBe('PreInvocation')
   }, 30_000)
 
+  // Why a helper: the missing-core cases all need a real install with the core removed, which
+  // is the shape an AV quarantine or a half-finished uninstall leaves behind.
+  async function installWithoutCore(): Promise<string> {
+    home = mkdtempSync(join(tmpdir(), 'orca-antigravity-fallback-'))
+    homedirMock.mockReturnValue(home)
+    expect(new AntigravityHookService().install().state).toBe('installed')
+    const hooksDir = join(home, '.orca', 'agent-hooks')
+    rmSync(join(hooksDir, 'antigravity-hook.cmd'))
+    return hooksDir
+  }
+
   it.each(['ORCA_AGENT_HOOK_PORT', 'ORCA_AGENT_HOOK_TOKEN', 'ORCA_PANE_KEY'])(
     'answers every missing-core event with abandoned stdin and no %s',
     async (missingKey) => {
-      home = mkdtempSync(join(tmpdir(), 'orca antigravity fallback-'))
-      homedirMock.mockReturnValue(home)
-      expect(new AntigravityHookService().install().state).toBe('installed')
-      const hooksDir = join(home, '.orca', 'agent-hooks')
-      rmSync(join(hooksDir, 'antigravity-hook.cmd'))
+      const hooksDir = await installWithoutCore()
       const listener = await startHookListener()
       server = listener.server
       const env = hookEnvironment({
@@ -308,6 +337,30 @@ describe.skipIf(process.platform !== 'win32')('Antigravity Windows hook payload 
     },
     90_000
   )
+
+  // Why: the guard must not cost the valid path its drain — with the Orca env present the
+  // fallback still owns stdin, so the agent's payload write completes instead of breaking.
+  it('still drains a closed payload for every missing-core event inside a pane', async () => {
+    const hooksDir = await installWithoutCore()
+    const listener = await startHookListener()
+    server = listener.server
+    const env = hookEnvironment({
+      USERPROFILE: home,
+      HOME: home,
+      ORCA_AGENT_HOOK_PORT: String(listener.port),
+      ORCA_AGENT_HOOK_TOKEN: HOOK_TOKEN,
+      ORCA_PANE_KEY: PANE_KEY
+    })
+    for (const event of ANTIGRAVITY_EVENTS) {
+      const result = await runWrapper(join(hooksDir, event.windowsWrapperFileName), env)
+      expect(result.timedOut, event.eventName).toBe(false)
+      expect(result.exitCode, event.eventName).toBe(0)
+      expect(result.stdout.trim(), event.eventName).toBe(expectedStdout(event.eventName))
+      expect(result.stderr, event.eventName).toBe('')
+    }
+    // Why: the fallback answers the agent but has no core to post through.
+    expect(listener.posts).toHaveLength(0)
+  }, 60_000)
 
   it('exits without reading stdin when the pane env is missing', async () => {
     home = mkdtempSync(join(tmpdir(), 'orca-antigravity-hook-'))

--- a/src/main/copilot/copilot-managed-script.ts
+++ b/src/main/copilot/copilot-managed-script.ts
@@ -1,7 +1,8 @@
 import { getSharedManagedScriptPath } from '../agent-hooks/installer-utils'
 import {
   buildPosixHookPayloadCapture,
-  buildPosixHookSpoolLines
+  buildPosixHookSpoolLines,
+  WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD
 } from '../agent-hooks/hook-stdin-contract'
 
 export function getManagedScriptFileName(): string {
@@ -30,7 +31,7 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       // Why (#11549 class): missing Orca context means a user-wide hook fired outside an
       // Orca pane. ReadToEnd blocks forever if that caller abandons the pipe, so the guard
       // must run before the hook owns stdin; the payload would be discarded anyway.
-      'if (-not $env:ORCA_AGENT_HOOK_PORT -or -not $env:ORCA_AGENT_HOOK_TOKEN -or -not $env:ORCA_PANE_KEY) { exit 0 }',
+      WINDOWS_POWERSHELL_HOOK_ENVIRONMENT_GUARD,
       '$inputData = [Console]::In.ReadToEnd()',
       'if ([string]::IsNullOrWhiteSpace($inputData)) { exit 0 }',
       'try {',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​54 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​189 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## The bug

On Windows, a hook script sometimes can't find the file it's supposed to run — antivirus quarantined it, or an uninstall left half of it behind.

When that happens the hook falls back to a small "do nothing useful" path. That path ends with: **read whatever the agent is sending us, and throw it away.**

That read never finishes if nobody ever closes the pipe. And nobody closes the pipe when the hook runs *outside* Orca — from a plain terminal, say. So the hook just sits there. Forever. One stuck process, and often one visible black console window, for every single hook event.

This is the same bug we already fixed once (#11549). We fixed it in the hook *scripts*. We missed the *launchers*.

## Why we missed it

The rule is "check for Orca's environment variables **before** you read stdin."

That rule was written down once, in `.cmd` syntax. Everywhere else it was retyped by hand — once in PowerShell for Copilot, once in shell for Kimi. The two launchers never got a copy at all.

So this PR writes the variable names down **once** and generates all three versions from them. Now they can't drift apart again.

## What's fixed

**1. The PowerShell launcher** (`wrapWindowsHookCommand`) — used by Copilot, Cursor, Droid, Gemini, Command Code on every event, and by Antigravity/Codex/Devin/Grok when the file path has a space in it. It now checks the environment before reading.

It also had a second problem: it printed its fallback answer *after* the read. So for a "should I allow this tool?" event, the answer came out only once the read finished — which is never. Antigravity treats no answer as "deny". The answer now comes first.

**2. The Git Bash launcher** — same bug, found by the new test. Its fallback now picks the right rule for the machine it's on: Linux/Mac keep the old behaviour (their callers *do* close the pipe — see #8110), Windows gets the guard.

**3. The Antigravity wrapper had a separate, worse bug.** If your hooks folder path contains a `!` and Windows has "delayed expansion" turned on, cmd eats the `!` and the wrapper can't find the real hook script. It silently falls into the do-nothing path **on every event** — so Orca shows no agent status at all. The core script already protected against this; the wrapper didn't. One word fixes it.

Proof, same script both ways:

```
without the fix, delayed expansion on  ->  "core not found"   <- broken
with the fix,    delayed expansion on  ->  "core ran"         <- correct
```

## Tests

The old test spawned the hook in a way that **silently disabled** delayed expansion. That's the exact thing this file's `!`-in-the-pane-key checks exist to catch — so they couldn't fail, on any machine, ever.

Tests now use the real launch shape from the bug report and run every event **twice**, once with delayed expansion off and once on, with a `!` in the folder path so there's something to actually break.

The cross-agent stdin test previously *required* the buggy behaviour. It now checks the correct rule, and it holds the pipe open instead of closing it — which is the only way to catch a read that never returns.

Every fix was checked by undoing it and confirming a test goes red:

| undo this | tests that fail |
| --- | --- |
| wrapper environment check | 5 shape + 1 live (hangs 15s) |
| wrapper delayed-expansion fix | 5 shape + live run posts nothing |
| PowerShell launcher check | 1 shape + 1 live (hangs) |
| Git Bash launcher check | 1 live (hangs) |

## Verification

Run on real Windows 11, Node 24.

- Before the fix the launcher hung until killed at 6s. After, it exits in ~17ms.
- Typecheck, lint, and the changed-code quality gate all pass.
- Ran 3,347 tests across every agent's hook code, before and after, and diffed the failure lists: **no new failures**, one pre-existing failure fixed.
- 8 failures remain on my machine and are identical on `main`: 5 tests that call `/bin/sh` (can't work from Windows) and 3 that create symlinks (needs Developer Mode). Untouched — unrelated to this PR.

## Note for the reviewer

This started as a 2-line Antigravity fix. Reviewing it turned up the same bug in two launchers plus the separate `!` bug, so it grew to 8 files. The extra changes are all the same root cause and are covered by the table above — but if you'd rather have the launcher work split into its own PR, say so and I'll pull it out.

Out of scope, unchanged: STA-5074's env-present core hang is still there. The core still waits past 3s for EOF; `curl --max-time` does not bound its read of stdin.
